### PR TITLE
Add integration search command

### DIFF
--- a/.agents/skills/aspire/SKILL.md
+++ b/.agents/skills/aspire/SKILL.md
@@ -14,7 +14,7 @@ Resources are typically defined in an AppHost such as, `AppHost.cs`, `apphost.ts
 - Starting, restarting, and stopping AppHosts with `aspire start` and `aspire stop`
 - Initializing Aspire in an existing app with `aspire init` (drops skeleton files; use the `aspireify` skill to complete wiring)
 - Inspecting resources, logs, traces, and docs
-- Discovering integrations with `aspire integration search` and adding them with `aspire add`
+- Discovering integrations with `aspire integration list` or `aspire integration search`, and adding them with `aspire add`
 - Recovering missing TypeScript AppHost support files with `aspire restore`
 - Discovering the correct frontend URL before a Playwright handoff
 - Understanding unfamiliar Aspire AppHost APIs before editing C# or TypeScript AppHosts
@@ -61,7 +61,7 @@ When the AppHost is `apphost.ts`, the `.modules/` folder at the project root con
 - Re-running `aspire start` is the restart path. In git worktrees, `aspire start --isolated` is both the start and restart command. Do not combine `aspire stop` and `aspire run`.
 - Use `--apphost <path>` when the workspace has multiple AppHosts or discovery is ambiguous.
 - Use `--format Json` when another tool or script needs machine-readable output.
-- Use `aspire integration search [query] --format Json` for read-only, scriptable integration discovery. Use `aspire add <package>` only when you are ready to mutate the AppHost.
+- Use `aspire integration list --format Json` for read-only, scriptable integration listing. Use `aspire integration search <query> --format Json` for read-only, scriptable integration filtering. Use `aspire add <package>` only when you are ready to mutate the AppHost.
 - Do not guess the integration or command shape for unfamiliar AppHost changes. Use `aspire docs search` and `aspire docs get` for the documented pattern, then use `aspire docs api search` and `aspire docs api get` when you need the specific reference entry.
 - For unfamiliar C# AppHost APIs, use Aspire API docs as the primary reference and, if available, use `dotnet-inspect` only to inspect local symbols, overloads, and builder chains.
 - Never install the obsolete Aspire workload.
@@ -71,7 +71,7 @@ When the AppHost is `apphost.ts`, the `.modules/` folder at the project root con
 ## Common capabilities
 
 - Use `aspire ps` when you need to discover running AppHosts before targeting one.
-- Use `aspire integration search [query]` when you need to discover available hosting integrations or filter by a friendly name before adding one.
+- Use `aspire integration list` when you need to discover available hosting integrations, or `aspire integration search <query>` to filter by a friendly name before adding one.
 - Use `aspire update` when the task is to refresh AppHost package references through the supported CLI workflow.
 - Use `aspire doctor` as an early diagnostics step when the local Aspire environment looks unhealthy.
 - Use `aspire resource`, `aspire secret`, `aspire config`, `aspire publish`, `aspire deploy`, and `aspire do` when the objective is resource operations, secrets/config management, or deployment.

--- a/.agents/skills/aspire/SKILL.md
+++ b/.agents/skills/aspire/SKILL.md
@@ -14,7 +14,7 @@ Resources are typically defined in an AppHost such as, `AppHost.cs`, `apphost.ts
 - Starting, restarting, and stopping AppHosts with `aspire start` and `aspire stop`
 - Initializing Aspire in an existing app with `aspire init` (drops skeleton files; use the `aspireify` skill to complete wiring)
 - Inspecting resources, logs, traces, and docs
-- Adding integrations with `aspire add`
+- Discovering integrations with `aspire integration search` and adding them with `aspire add`
 - Recovering missing TypeScript AppHost support files with `aspire restore`
 - Discovering the correct frontend URL before a Playwright handoff
 - Understanding unfamiliar Aspire AppHost APIs before editing C# or TypeScript AppHosts
@@ -34,7 +34,7 @@ Resources are typically defined in an AppHost such as, `AppHost.cs`, `apphost.ts
 2. Start the app with `aspire start`. Use `--isolated` in git worktrees or whenever shared local state would be risky.
 3. Use `aspire wait <resource>` before interacting with a resource that needs to be healthy.
 4. Inspect state with `aspire describe`, then use `aspire otel logs`, `aspire logs`, `aspire otel traces`, and `aspire export` before making code changes. Display returned data using the formatting rules in [references/monitoring.md](references/monitoring.md).
-5. Before adding an integration, introducing a custom dashboard/resource command, or using an unfamiliar AppHost API, use `aspire docs search <topic>` and `aspire docs get <slug>` for workflow guidance, then use `aspire docs api search <query> --language csharp|typescript` and `aspire docs api get <id>` when you need the API reference entry itself.
+5. Before adding an integration, use `aspire integration search <query>` when the package is unknown, then use `aspire docs search <topic>` and `aspire docs get <slug>` for workflow guidance. Before introducing a custom dashboard/resource command or using an unfamiliar AppHost API, use docs search/get and then `aspire docs api search <query> --language csharp|typescript` and `aspire docs api get <id>` when you need the API reference entry itself.
 6. Re-run `aspire start` after AppHost changes. In git worktrees, re-run `aspire start --isolated` instead of switching to `aspire run`.
 
 ## C# AppHosts
@@ -51,7 +51,7 @@ When the AppHost is implemented in C# such as `AppHost.cs`, `apphost.cs`, or a `
 When the AppHost is `apphost.ts`, the `.modules/` folder at the project root contains generated TypeScript modules that expose the Aspire APIs available to the AppHost. Common files include `.modules/aspire.ts`, `base.ts`, and `transport.ts`.
 
 - Do not edit `.modules/` directly.
-- Use `aspire add <package>` to add integrations and regenerate the available APIs.
+- Use `aspire integration search <query>` to find the integration package, then use `aspire add <package>` to add integrations and regenerate the available APIs.
 - Inspect `.modules/aspire.ts` after `aspire add` to see the refreshed API surface.
 - The local `tsconfig.json` often includes `.modules/**/*.ts` in its compilation scope.
 
@@ -61,6 +61,7 @@ When the AppHost is `apphost.ts`, the `.modules/` folder at the project root con
 - Re-running `aspire start` is the restart path. In git worktrees, `aspire start --isolated` is both the start and restart command. Do not combine `aspire stop` and `aspire run`.
 - Use `--apphost <path>` when the workspace has multiple AppHosts or discovery is ambiguous.
 - Use `--format Json` when another tool or script needs machine-readable output.
+- Use `aspire integration search [query] --format Json` for read-only, scriptable integration discovery. Use `aspire add <package>` only when you are ready to mutate the AppHost.
 - Do not guess the integration or command shape for unfamiliar AppHost changes. Use `aspire docs search` and `aspire docs get` for the documented pattern, then use `aspire docs api search` and `aspire docs api get` when you need the specific reference entry.
 - For unfamiliar C# AppHost APIs, use Aspire API docs as the primary reference and, if available, use `dotnet-inspect` only to inspect local symbols, overloads, and builder chains.
 - Never install the obsolete Aspire workload.
@@ -70,6 +71,7 @@ When the AppHost is `apphost.ts`, the `.modules/` folder at the project root con
 ## Common capabilities
 
 - Use `aspire ps` when you need to discover running AppHosts before targeting one.
+- Use `aspire integration search [query]` when you need to discover available hosting integrations or filter by a friendly name before adding one.
 - Use `aspire update` when the task is to refresh AppHost package references through the supported CLI workflow.
 - Use `aspire doctor` as an early diagnostics step when the local Aspire environment looks unhealthy.
 - Use `aspire resource`, `aspire secret`, `aspire config`, `aspire publish`, `aspire deploy`, and `aspire do` when the objective is resource operations, secrets/config management, or deployment.

--- a/.agents/skills/aspire/references/agent-workflows.md
+++ b/.agents/skills/aspire/references/agent-workflows.md
@@ -35,9 +35,10 @@ Inspect the live app before editing code:
 
 ## Scenario: I Need To Add An Integration, Understand An API, Or Add A Custom Command Safely
 
-Use the docs commands first for the workflow, then use the API reference commands if you need the concrete API entry:
+Use integration search to find the package when needed, then use the docs commands for the workflow and the API reference commands if you need the concrete API entry:
 
 ```bash
+aspire integration search postgres
 aspire docs search postgres
 aspire docs get <slug>
 aspire docs api search postgres --language csharp
@@ -56,6 +57,7 @@ aspire docs api search WithCommand --language csharp
 Keep these points in mind:
 
 - Read the docs before editing the AppHost so the implementation follows a documented Aspire pattern instead of guessing the workflow.
+- Use `aspire integration search <query>` when the package ID is unknown or the user asks to discover available integrations before changing the AppHost.
 - Use `aspire docs api` when you need the C# or TypeScript reference entry for the exact API you are about to call.
 - If the AppHost is C# and you need to understand local overloads or builder chains, use the `dotnet-inspect` skill if it is available after checking the Aspire API reference.
 - After adding an integration, restart with `aspire start` so the updated AppHost takes effect.

--- a/.agents/skills/aspire/references/agent-workflows.md
+++ b/.agents/skills/aspire/references/agent-workflows.md
@@ -57,7 +57,7 @@ aspire docs api search WithCommand --language csharp
 Keep these points in mind:
 
 - Read the docs before editing the AppHost so the implementation follows a documented Aspire pattern instead of guessing the workflow.
-- Use `aspire integration search <query>` when the package ID is unknown or the user asks to discover available integrations before changing the AppHost.
+- Use `aspire integration list` when the user asks to discover available integrations before changing the AppHost, or `aspire integration search <query>` when the package ID is unknown.
 - Use `aspire docs api` when you need the C# or TypeScript reference entry for the exact API you are about to call.
 - If the AppHost is C# and you need to understand local overloads or builder chains, use the `dotnet-inspect` skill if it is available after checking the Aspire API reference.
 - After adding an integration, restart with `aspire start` so the updated AppHost takes effect.

--- a/.agents/skills/aspire/references/app-commands.md
+++ b/.agents/skills/aspire/references/app-commands.md
@@ -44,6 +44,8 @@ Use these commands when multiple AppHosts may be running locally, when the AppHo
 
 ```bash
 aspire ps
+aspire integration search [query]
+aspire integration search [query] --format Json
 aspire add <package>
 aspire update
 aspire restore
@@ -53,6 +55,8 @@ Keep these points in mind:
 
 - Use `aspire ps` first when you need to discover which AppHost is already running.
 - If command arguments may differ across CLI versions, verify the current shape with `aspire <command> --help` before execution.
+- Use `aspire integration search [query]` for read-only discovery when the user asks what integrations are available or when you need to find the right package name before mutating the AppHost.
+- Use `aspire integration search [query] --format Json` when another tool needs structured integration discovery results.
 - Use `aspire add <package>` when the task is to add a supported integration or regenerate AppHost APIs.
 - Use `aspire update` when the ask is specifically to refresh AppHost package references through the supported CLI workflow.
 - Use `aspire restore` after pulls, cleans, or missing generated files when the AppHost needs its local support restored before running again.

--- a/.agents/skills/aspire/references/app-commands.md
+++ b/.agents/skills/aspire/references/app-commands.md
@@ -44,8 +44,10 @@ Use these commands when multiple AppHosts may be running locally, when the AppHo
 
 ```bash
 aspire ps
-aspire integration search [query]
-aspire integration search [query] --format Json
+aspire integration list
+aspire integration list --format Json
+aspire integration search <query>
+aspire integration search <query> --format Json
 aspire add <package>
 aspire update
 aspire restore
@@ -55,8 +57,9 @@ Keep these points in mind:
 
 - Use `aspire ps` first when you need to discover which AppHost is already running.
 - If command arguments may differ across CLI versions, verify the current shape with `aspire <command> --help` before execution.
-- Use `aspire integration search [query]` for read-only discovery when the user asks what integrations are available or when you need to find the right package name before mutating the AppHost.
-- Use `aspire integration search [query] --format Json` when another tool needs structured integration discovery results.
+- Use `aspire integration list` for read-only discovery when the user asks what integrations are available.
+- Use `aspire integration search <query>` when you need to find the right package name before mutating the AppHost.
+- Use `--format Json` with `integration list` or `integration search` when another tool needs structured integration discovery results.
 - Use `aspire add <package>` when the task is to add a supported integration or regenerate AppHost APIs.
 - Use `aspire update` when the ask is specifically to refresh AppHost package references through the supported CLI workflow.
 - Use `aspire restore` after pulls, cleans, or missing generated files when the AppHost needs its local support restored before running again.

--- a/.github/skills/cli-e2e-testing/SKILL.md
+++ b/.github/skills/cli-e2e-testing/SKILL.md
@@ -145,6 +145,26 @@ ASPIRE_E2E_ARCHIVE=/tmp/aspire-e2e.tar.gz \
 # 5. Fix and repeat from step 1 or 2
 ```
 
+### Manual Command Smoke Checks
+
+For command-surface changes, run a manual smoke check against the built CLI before deciding whether a full Hex1b E2E test is needed. This is useful for validating command routing, exit codes, output formats, and help text with the real executable.
+
+PowerShell:
+
+```powershell
+dotnet build src\Aspire.Cli\Aspire.Cli.csproj /p:SkipNativeBuild=true
+
+$dotnet = Join-Path (Get-Location) ".dotnet\dotnet.exe"
+$aspire = Join-Path (Get-Location) "artifacts\bin\Aspire.Cli\Debug\net10.0\aspire.dll"
+
+& $dotnet $aspire --version --nologo
+& $dotnet $aspire integration search redis --format json --nologo
+& $dotnet $aspire integration search redis --nologo
+& $dotnet $aspire integration add --help --nologo
+```
+
+Use assertions around the command results when validating a PR: check that structured output parses as JSON, human-readable output contains the expected table/help text, and intentionally invalid command shapes return a non-zero exit code. Prefer a full Hex1b E2E test when the scenario depends on terminal interaction, Docker/Linux-only behavior, `aspire new`, `aspire run`, generated project state, or prompts that cannot be covered by command tests plus manual smoke checks.
+
 ### Install Modes
 
 The `CliInstallStrategy` class auto-detects how to install the CLI in the test container. You can override via environment variables:

--- a/.github/skills/cli-e2e-testing/SKILL.md
+++ b/.github/skills/cli-e2e-testing/SKILL.md
@@ -145,26 +145,6 @@ ASPIRE_E2E_ARCHIVE=/tmp/aspire-e2e.tar.gz \
 # 5. Fix and repeat from step 1 or 2
 ```
 
-### Manual Command Smoke Checks
-
-For command-surface changes, run a manual smoke check against the built CLI before deciding whether a full Hex1b E2E test is needed. This is useful for validating command routing, exit codes, output formats, and help text with the real executable.
-
-PowerShell:
-
-```powershell
-dotnet build src\Aspire.Cli\Aspire.Cli.csproj /p:SkipNativeBuild=true
-
-$dotnet = Join-Path (Get-Location) ".dotnet\dotnet.exe"
-$aspire = Join-Path (Get-Location) "artifacts\bin\Aspire.Cli\Debug\net10.0\aspire.dll"
-
-& $dotnet $aspire --version --nologo
-& $dotnet $aspire integration search redis --format json --nologo
-& $dotnet $aspire integration search redis --nologo
-& $dotnet $aspire integration add --help --nologo
-```
-
-Use assertions around the command results when validating a PR: check that structured output parses as JSON, human-readable output contains the expected table/help text, and intentionally invalid command shapes return a non-zero exit code. Prefer a full Hex1b E2E test when the scenario depends on terminal interaction, Docker/Linux-only behavior, `aspire new`, `aspire run`, generated project state, or prompts that cannot be covered by command tests plus manual smoke checks.
-
 ### Install Modes
 
 The `CliInstallStrategy` class auto-detects how to install the CLI in the test container. You can override via environment variables:

--- a/src/Aspire.Cli/Commands/AddCommand.cs
+++ b/src/Aspire.Cli/Commands/AddCommand.cs
@@ -22,6 +22,8 @@ internal sealed class AddCommand : BaseCommand
 {
     internal override HelpGroup HelpGroup => HelpGroup.AppCommands;
 
+    private const double FuzzyMatchThreshold = 0.3;
+
     private readonly IPackagingService _packagingService;
     private readonly IProjectLocator _projectLocator;
     private readonly IAddCommandPrompter _prompter;
@@ -43,6 +45,18 @@ internal sealed class AddCommand : BaseCommand
     {
         Description = AddCommandStrings.SourceArgumentDescription
     };
+    private static readonly Option<bool> s_listOption = new("--list")
+    {
+        Description = AddCommandStrings.ListOptionDescription
+    };
+    private static readonly Option<string?> s_searchOption = new("--search")
+    {
+        Description = AddCommandStrings.SearchOptionDescription
+    };
+    private static readonly Option<OutputFormat> s_formatOption = new("--format")
+    {
+        Description = AddCommandStrings.FormatOptionDescription
+    };
 
     public AddCommand(IPackagingService packagingService, IInteractionService interactionService, IProjectLocator projectLocator, IAddCommandPrompter prompter, AspireCliTelemetry telemetry, IDotNetSdkInstaller sdkInstaller, IFeatures features, ICliUpdateNotifier updateNotifier, CliExecutionContext executionContext, ICliHostEnvironment hostEnvironment, IAppHostProjectFactory projectFactory)
         : base("add", AddCommandStrings.Description, features, updateNotifier, executionContext, interactionService, telemetry)
@@ -58,6 +72,9 @@ internal sealed class AddCommand : BaseCommand
         Options.Add(s_appHostOption);
         Options.Add(s_versionOption);
         Options.Add(s_sourceOption);
+        Options.Add(s_listOption);
+        Options.Add(s_searchOption);
+        Options.Add(s_formatOption);
     }
 
     protected override async Task<int> ExecuteAsync(ParseResult parseResult, CancellationToken cancellationToken)
@@ -69,8 +86,53 @@ internal sealed class AddCommand : BaseCommand
         try
         {
             var integrationName = parseResult.GetValue(s_integrationArgument);
-
             var passedAppHostProjectFile = parseResult.GetValue(s_appHostOption);
+            var version = parseResult.GetValue(s_versionOption);
+            var source = parseResult.GetValue(s_sourceOption);
+            var listRequested = parseResult.GetValue(s_listOption);
+            var searchTerm = parseResult.GetValue(s_searchOption);
+            var format = parseResult.GetValue(s_formatOption);
+            var jsonRequested = format == OutputFormat.Json;
+            var discoveryRequested = listRequested || searchTerm is not null;
+
+            if (jsonRequested && !discoveryRequested)
+            {
+                InteractionService.DisplayError(AddCommandStrings.JsonRequiresListOrSearch);
+                return ExitCodeConstants.MissingRequiredArgument;
+            }
+
+            if (discoveryRequested)
+            {
+                if (integrationName is not null || version is not null || source is not null)
+                {
+                    InteractionService.DisplayError(AddCommandStrings.DiscoveryOptionsCannotBeCombinedWithAddOptions);
+                    return ExitCodeConstants.MissingRequiredArgument;
+                }
+
+                var workingDirectory = passedAppHostProjectFile?.Directory ?? ExecutionContext.WorkingDirectory;
+                var discoveryPackagesWithChannels = await InteractionService.ShowStatusAsync(
+                    AddCommandStrings.SearchingForAspirePackages,
+                    async () => await GetIntegrationPackagesWithChannelsAsync(workingDirectory, configuredChannel: null, cancellationToken));
+
+                if (!discoveryPackagesWithChannels.Any())
+                {
+                    throw new EmptyChoicesException(AddCommandStrings.NoIntegrationPackagesFound);
+                }
+
+                var discoveryPackagesWithShortName = discoveryPackagesWithChannels
+                    .Select(GenerateFriendlyName)
+                    .OrderBy(p => p.FriendlyName, new CommunityToolkitFirstComparer())
+                    .ToArray();
+
+                if (discoveryPackagesWithShortName.Length == 0)
+                {
+                    InteractionService.DisplayError(AddCommandStrings.NoPackagesFound);
+                    return ExitCodeConstants.FailedToAddPackage;
+                }
+
+                return DisplayIntegrationDiscoveryResults(discoveryPackagesWithShortName, searchTerm, jsonRequested);
+            }
+
             var searchResult = await _projectLocator.UseOrFindAppHostProjectFileAsync(passedAppHostProjectFile, MultipleAppHostProjectsFoundBehavior.Prompt, createSettingsFile: true, cancellationToken);
             var effectiveAppHostProjectFile = searchResult.SelectedProjectFile;
 
@@ -90,8 +152,6 @@ internal sealed class AddCommand : BaseCommand
                     return ExitCodeConstants.SdkNotInstalled;
                 }
             }
-
-            var source = parseResult.GetValue(s_sourceOption);
 
             // For non-.NET projects, read the channel from the local Aspire configuration if available.
             // Unlike .NET projects which have a nuget.config, polyglot apphosts persist the channel
@@ -120,42 +180,7 @@ internal sealed class AddCommand : BaseCommand
 
             var packagesWithChannels = await InteractionService.ShowStatusAsync(
                 AddCommandStrings.SearchingForAspirePackages,
-                async () =>
-                {
-                    // Get channels and find the implicit channel, similar to how templates are handled
-                    var allChannels = await _packagingService.GetChannelsAsync(cancellationToken);
-
-                    // If a channel is configured in settings.json, use that specific channel
-                    if (!string.IsNullOrEmpty(configuredChannel))
-                    {
-                        allChannels = allChannels.Where(c => string.Equals(c.Name, configuredChannel, StringComparison.OrdinalIgnoreCase));
-                    }
-
-                    // If there are hives (PR build directories), include all channels.
-                    // If a channel is configured in settings.json, use that (already filtered above).
-                    // Otherwise, only use the implicit/default channel to avoid prompting.
-                    var hasHives = ExecutionContext.GetPrHiveCount() > 0;
-                    var channels = hasHives || !string.IsNullOrEmpty(configuredChannel)
-                        ? allChannels
-                        : allChannels.Where(c => c.Type is PackageChannelType.Implicit);
-
-                    var packages = new List<(NuGetPackage Package, PackageChannel Channel)>();
-                    var packagesLock = new object();
-
-                    await Parallel.ForEachAsync(channels, cancellationToken, async (channel, ct) =>
-                    {
-                        var integrationPackages = await channel.GetIntegrationPackagesAsync(
-                            workingDirectory: effectiveAppHostProjectFile.Directory!,
-                            cancellationToken: ct);
-                        lock (packagesLock)
-                        {
-                            packages.AddRange(integrationPackages.Select(p => (p, channel)));
-                        }
-                    });
-
-                    return packages;
-
-                });
+                async () => await GetIntegrationPackagesWithChannelsAsync(effectiveAppHostProjectFile.Directory!, configuredChannel, cancellationToken));
 
             if (!packagesWithChannels.Any())
             {
@@ -173,8 +198,6 @@ internal sealed class AddCommand : BaseCommand
             var filteredPackagesWithShortName = packagesWithShortName
                 .Where(p => p.FriendlyName == integrationName || p.Package.Id == integrationName);
 
-            var version = parseResult.GetValue(s_versionOption);
-
             if (!filteredPackagesWithShortName.Any() && integrationName is not null && version is not null && !_hostEnvironment.SupportsInteractiveInput)
             {
                 throw new EmptyChoicesException(string.Format(CultureInfo.CurrentCulture, AddCommandStrings.SpecifiedVersionRequiresExactPackageMatch, integrationName));
@@ -190,11 +213,10 @@ internal sealed class AddCommand : BaseCommand
                         .Select(p => new
                         {
                             Package = p,
-                            FriendlyNameScore = StringUtils.CalculateFuzzyScore(integrationName, p.FriendlyName),
-                            PackageIdScore = StringUtils.CalculateFuzzyScore(integrationName, p.Package.Id)
+                            Score = GetIntegrationSearchScore(integrationName, p)
                         })
-                        .Where(x => x.FriendlyNameScore > 0.3 || x.PackageIdScore > 0.3)
-                        .OrderByDescending(x => Math.Max(x.FriendlyNameScore, x.PackageIdScore))
+                        .Where(x => x.Score > FuzzyMatchThreshold)
+                        .OrderByDescending(x => x.Score)
                         .ThenByDescending(x => x.Package.FriendlyName, new CommunityToolkitFirstComparer())
                         .Select(x => x.Package)
                         .ToList();
@@ -317,6 +339,113 @@ internal sealed class AddCommand : BaseCommand
         }
     }
 
+    private async Task<IEnumerable<(NuGetPackage Package, PackageChannel Channel)>> GetIntegrationPackagesWithChannelsAsync(DirectoryInfo workingDirectory, string? configuredChannel, CancellationToken cancellationToken)
+    {
+        var allChannels = await _packagingService.GetChannelsAsync(cancellationToken);
+
+        if (!string.IsNullOrEmpty(configuredChannel))
+        {
+            allChannels = allChannels.Where(c => string.Equals(c.Name, configuredChannel, StringComparison.OrdinalIgnoreCase));
+        }
+
+        var hasHives = ExecutionContext.GetPrHiveCount() > 0;
+        var channels = hasHives || !string.IsNullOrEmpty(configuredChannel)
+            ? allChannels
+            : allChannels.Where(c => c.Type is PackageChannelType.Implicit);
+
+        var packages = new List<(NuGetPackage Package, PackageChannel Channel)>();
+        var packagesLock = new object();
+
+        await Parallel.ForEachAsync(channels, cancellationToken, async (channel, ct) =>
+        {
+            var integrationPackages = await channel.GetIntegrationPackagesAsync(
+                workingDirectory: workingDirectory,
+                cancellationToken: ct);
+            lock (packagesLock)
+            {
+                packages.AddRange(integrationPackages.Select(p => (p, channel)));
+            }
+        });
+
+        return packages;
+    }
+
+    private int DisplayIntegrationDiscoveryResults(IEnumerable<(string FriendlyName, NuGetPackage Package, PackageChannel Channel)> packages, string? searchTerm, bool jsonRequested)
+    {
+        var matches = packages
+            .Select(p => (Package: p, SearchScore: searchTerm is null ? 0 : GetIntegrationSearchScore(searchTerm, p)))
+            .Where(p => searchTerm is null || p.SearchScore > FuzzyMatchThreshold)
+            .GroupBy(p => p.Package.Package.Id)
+            .Select(g => g.OrderByDescending(p => SemVersion.Parse(p.Package.Package.Version), SemVersion.PrecedenceComparer).First());
+
+        var orderedMatches = searchTerm is null
+            ? matches.OrderBy(p => p.Package.FriendlyName, new CommunityToolkitFirstComparer()).ThenBy(p => p.Package.Package.Id, StringComparer.OrdinalIgnoreCase)
+            : matches.OrderByDescending(p => p.SearchScore).ThenBy(p => p.Package.FriendlyName, new CommunityToolkitFirstComparer())
+                .ThenBy(p => p.Package.Package.Id, StringComparer.OrdinalIgnoreCase);
+
+        var results = orderedMatches
+            .Select(p => new AddCommandIntegrationResult
+            {
+                Name = p.Package.FriendlyName,
+                Package = p.Package.Package.Id,
+                Version = p.Package.Package.Version
+            })
+            .ToArray();
+
+        if (jsonRequested)
+        {
+            var json = JsonSerializer.Serialize(results, JsonSourceGenerationContext.RelaxedEscaping.AddCommandIntegrationResultArray);
+            InteractionService.DisplayRawText(json, ConsoleOutput.Standard);
+            return ExitCodeConstants.Success;
+        }
+
+        if (results.Length == 0)
+        {
+            if (searchTerm is not null)
+            {
+                InteractionService.DisplayError(string.Format(CultureInfo.CurrentCulture, AddCommandStrings.NoIntegrationPackagesMatchedSearchTerm, searchTerm));
+            }
+            else
+            {
+                InteractionService.DisplayError(AddCommandStrings.NoPackagesFound);
+            }
+
+            return ExitCodeConstants.Success;
+        }
+
+        if (searchTerm is not null)
+        {
+            InteractionService.DisplaySuccess(string.Format(CultureInfo.CurrentCulture, AddCommandStrings.FoundIntegrationPackagesMatchingSearchTerm, results.Length, searchTerm));
+        }
+        else
+        {
+            InteractionService.DisplaySuccess(string.Format(CultureInfo.CurrentCulture, AddCommandStrings.FoundIntegrationPackages, results.Length));
+        }
+
+        var table = new Table();
+        table.AddBoldColumn(AddCommandStrings.HeaderName);
+        table.AddBoldColumn(AddCommandStrings.HeaderPackage);
+        table.AddBoldColumn(AddCommandStrings.HeaderVersion);
+
+        foreach (var result in results)
+        {
+            table.AddRow(
+                Markup.Escape(result.Name),
+                Markup.Escape(result.Package),
+                Markup.Escape(result.Version));
+        }
+
+        InteractionService.DisplayRenderable(table);
+        return ExitCodeConstants.Success;
+    }
+
+    private static double GetIntegrationSearchScore(string searchTerm, (string FriendlyName, NuGetPackage Package, PackageChannel Channel) package)
+    {
+        return Math.Max(
+            StringUtils.CalculateFuzzyScore(searchTerm, package.FriendlyName),
+            StringUtils.CalculateFuzzyScore(searchTerm, package.Package.Id));
+    }
+
     private static async Task<IEnumerable<(string FriendlyName, NuGetPackage Package, PackageChannel Channel)>> GetAllPackageVersions(DirectoryInfo workingDirectory, IEnumerable<(string FriendlyName, NuGetPackage Package, PackageChannel Channel)> possiblePackages, CancellationToken cancellationToken)
     {
         var distinctPackageIds = possiblePackages.DistinctBy(package => package.Package.Id);
@@ -423,6 +552,15 @@ internal sealed class AddCommand : BaseCommand
 
         return (friendlyName, packageWithChannel.Package, packageWithChannel.Channel);
     }
+}
+
+internal sealed class AddCommandIntegrationResult
+{
+    public required string Name { get; init; }
+
+    public required string Package { get; init; }
+
+    public required string Version { get; init; }
 }
 
 internal interface IAddCommandPrompter

--- a/src/Aspire.Cli/Commands/AddCommand.cs
+++ b/src/Aspire.Cli/Commands/AddCommand.cs
@@ -3,7 +3,6 @@
 
 using System.CommandLine;
 using System.Globalization;
-using System.Text.Json;
 using Aspire.Cli.Configuration;
 using Aspire.Cli.DotNet;
 using Aspire.Cli.Interaction;
@@ -18,14 +17,12 @@ using NuGetPackage = Aspire.Shared.NuGetPackageCli;
 
 namespace Aspire.Cli.Commands;
 
-internal sealed class AddCommand : BaseCommand
+internal class AddCommand : BaseCommand
 {
     internal override HelpGroup HelpGroup => HelpGroup.AppCommands;
 
-    private const double FuzzyMatchThreshold = 0.3;
-
-    private readonly IPackagingService _packagingService;
     private readonly IProjectLocator _projectLocator;
+    private readonly IntegrationPackageSearchService _integrationPackageSearchService;
     private readonly IAddCommandPrompter _prompter;
     private readonly IDotNetSdkInstaller _sdkInstaller;
     private readonly ICliHostEnvironment _hostEnvironment;
@@ -45,24 +42,17 @@ internal sealed class AddCommand : BaseCommand
     {
         Description = AddCommandStrings.SourceArgumentDescription
     };
-    private static readonly Option<bool> s_listOption = new("--list")
-    {
-        Description = AddCommandStrings.ListOptionDescription
-    };
-    private static readonly Option<string?> s_searchOption = new("--search")
-    {
-        Description = AddCommandStrings.SearchOptionDescription
-    };
-    private static readonly Option<OutputFormat> s_formatOption = new("--format")
-    {
-        Description = AddCommandStrings.FormatOptionDescription
-    };
 
-    public AddCommand(IPackagingService packagingService, IInteractionService interactionService, IProjectLocator projectLocator, IAddCommandPrompter prompter, AspireCliTelemetry telemetry, IDotNetSdkInstaller sdkInstaller, IFeatures features, ICliUpdateNotifier updateNotifier, CliExecutionContext executionContext, ICliHostEnvironment hostEnvironment, IAppHostProjectFactory projectFactory)
-        : base("add", AddCommandStrings.Description, features, updateNotifier, executionContext, interactionService, telemetry)
+    public AddCommand(IInteractionService interactionService, IProjectLocator projectLocator, IntegrationPackageSearchService integrationPackageSearchService, IAddCommandPrompter prompter, AspireCliTelemetry telemetry, IDotNetSdkInstaller sdkInstaller, IFeatures features, ICliUpdateNotifier updateNotifier, CliExecutionContext executionContext, ICliHostEnvironment hostEnvironment, IAppHostProjectFactory projectFactory)
+        : this("add", AddCommandStrings.Description, interactionService, projectLocator, integrationPackageSearchService, prompter, telemetry, sdkInstaller, features, updateNotifier, executionContext, hostEnvironment, projectFactory)
     {
-        _packagingService = packagingService;
+    }
+
+    protected AddCommand(string name, string description, IInteractionService interactionService, IProjectLocator projectLocator, IntegrationPackageSearchService integrationPackageSearchService, IAddCommandPrompter prompter, AspireCliTelemetry telemetry, IDotNetSdkInstaller sdkInstaller, IFeatures features, ICliUpdateNotifier updateNotifier, CliExecutionContext executionContext, ICliHostEnvironment hostEnvironment, IAppHostProjectFactory projectFactory)
+        : base(name, description, features, updateNotifier, executionContext, interactionService, telemetry)
+    {
         _projectLocator = projectLocator;
+        _integrationPackageSearchService = integrationPackageSearchService;
         _prompter = prompter;
         _sdkInstaller = sdkInstaller;
         _hostEnvironment = hostEnvironment;
@@ -72,9 +62,6 @@ internal sealed class AddCommand : BaseCommand
         Options.Add(s_appHostOption);
         Options.Add(s_versionOption);
         Options.Add(s_sourceOption);
-        Options.Add(s_listOption);
-        Options.Add(s_searchOption);
-        Options.Add(s_formatOption);
     }
 
     protected override async Task<int> ExecuteAsync(ParseResult parseResult, CancellationToken cancellationToken)
@@ -89,54 +76,6 @@ internal sealed class AddCommand : BaseCommand
             var passedAppHostProjectFile = parseResult.GetValue(s_appHostOption);
             var version = parseResult.GetValue(s_versionOption);
             var source = parseResult.GetValue(s_sourceOption);
-            var listRequested = parseResult.GetValue(s_listOption);
-            var searchTerm = parseResult.GetValue(s_searchOption);
-            var format = parseResult.GetValue(s_formatOption);
-            var jsonRequested = format == OutputFormat.Json;
-            var discoveryRequested = listRequested || searchTerm is not null;
-
-            if (jsonRequested && !discoveryRequested)
-            {
-                InteractionService.DisplayError(AddCommandStrings.JsonRequiresListOrSearch);
-                return ExitCodeConstants.MissingRequiredArgument;
-            }
-
-            if (discoveryRequested)
-            {
-                if (integrationName is not null || version is not null || source is not null)
-                {
-                    InteractionService.DisplayError(AddCommandStrings.DiscoveryOptionsCannotBeCombinedWithAddOptions);
-                    return ExitCodeConstants.MissingRequiredArgument;
-                }
-
-                var (workingDirectory, discoveryConfiguredChannel, discoveryContextExitCode) = await GetDiscoveryPackageSearchContextAsync(passedAppHostProjectFile, cancellationToken);
-                if (discoveryContextExitCode is { } discoveryExitCode)
-                {
-                    return discoveryExitCode;
-                }
-
-                var discoveryPackagesWithChannels = await InteractionService.ShowStatusAsync(
-                    AddCommandStrings.SearchingForAspirePackages,
-                    async () => await GetIntegrationPackagesWithChannelsAsync(workingDirectory, discoveryConfiguredChannel, cancellationToken));
-
-                if (!discoveryPackagesWithChannels.Any())
-                {
-                    throw new EmptyChoicesException(AddCommandStrings.NoIntegrationPackagesFound);
-                }
-
-                var discoveryPackagesWithShortName = discoveryPackagesWithChannels
-                    .Select(GenerateFriendlyName)
-                    .OrderBy(p => p.FriendlyName, new CommunityToolkitFirstComparer())
-                    .ToArray();
-
-                if (discoveryPackagesWithShortName.Length == 0)
-                {
-                    InteractionService.DisplayError(AddCommandStrings.NoPackagesFound);
-                    return ExitCodeConstants.FailedToAddPackage;
-                }
-
-                return DisplayIntegrationDiscoveryResults(discoveryPackagesWithShortName, searchTerm, jsonRequested);
-            }
 
             var searchResult = await _projectLocator.UseOrFindAppHostProjectFileAsync(passedAppHostProjectFile, MultipleAppHostProjectsFoundBehavior.Prompt, createSettingsFile: true, cancellationToken);
             var effectiveAppHostProjectFile = searchResult.SelectedProjectFile;
@@ -158,7 +97,7 @@ internal sealed class AddCommand : BaseCommand
                 }
             }
 
-            var (configuredChannel, configuredChannelExitCode) = GetConfiguredChannel(effectiveAppHostProjectFile, project);
+            var (configuredChannel, configuredChannelExitCode) = _integrationPackageSearchService.GetConfiguredChannel(effectiveAppHostProjectFile, project);
             if (configuredChannelExitCode is { } exitCode)
             {
                 return exitCode;
@@ -166,14 +105,14 @@ internal sealed class AddCommand : BaseCommand
 
             var packagesWithChannels = await InteractionService.ShowStatusAsync(
                 AddCommandStrings.SearchingForAspirePackages,
-                async () => await GetIntegrationPackagesWithChannelsAsync(effectiveAppHostProjectFile.Directory!, configuredChannel, cancellationToken));
+                async () => await _integrationPackageSearchService.GetIntegrationPackagesWithChannelsAsync(effectiveAppHostProjectFile.Directory!, configuredChannel, cancellationToken));
 
             if (!packagesWithChannels.Any())
             {
                 throw new EmptyChoicesException(AddCommandStrings.NoIntegrationPackagesFound);
             }
 
-            var packagesWithShortName = packagesWithChannels.Select(GenerateFriendlyName).OrderBy(p => p.FriendlyName, new CommunityToolkitFirstComparer());
+            var packagesWithShortName = packagesWithChannels.Select(IntegrationPackageSearchService.GenerateFriendlyName).OrderBy(p => p.FriendlyName, new CommunityToolkitFirstComparer());
 
             if (!packagesWithShortName.Any())
             {
@@ -195,7 +134,7 @@ internal sealed class AddCommand : BaseCommand
                 // then try a fuzzy search to create a broader filtered list.
                 // Materialize the query with ToList() to avoid multiple enumerations
                 // (which would recalculate fuzzy scores on each Count()/First() call).
-                filteredPackagesWithShortName = GetIntegrationSearchMatches(packagesWithShortName, integrationName)
+                filteredPackagesWithShortName = IntegrationPackageSearchService.GetIntegrationSearchMatches(packagesWithShortName, integrationName)
                     .Select(x => (x.FriendlyName, x.Package, x.Channel))
                     .ToList();
             }
@@ -317,188 +256,6 @@ internal sealed class AddCommand : BaseCommand
         }
     }
 
-    private async Task<IEnumerable<(NuGetPackage Package, PackageChannel Channel)>> GetIntegrationPackagesWithChannelsAsync(DirectoryInfo workingDirectory, string? configuredChannel, CancellationToken cancellationToken)
-    {
-        var allChannels = await _packagingService.GetChannelsAsync(cancellationToken);
-
-        if (!string.IsNullOrEmpty(configuredChannel))
-        {
-            allChannels = allChannels.Where(c => string.Equals(c.Name, configuredChannel, StringComparison.OrdinalIgnoreCase));
-        }
-
-        var hasHives = ExecutionContext.GetPrHiveCount() > 0;
-        var channels = hasHives || !string.IsNullOrEmpty(configuredChannel)
-            ? allChannels
-            : allChannels.Where(c => c.Type is PackageChannelType.Implicit);
-
-        var packages = new List<(NuGetPackage Package, PackageChannel Channel)>();
-        var packagesLock = new object();
-
-        await Parallel.ForEachAsync(channels, cancellationToken, async (channel, ct) =>
-        {
-            var integrationPackages = await channel.GetIntegrationPackagesAsync(
-                workingDirectory: workingDirectory,
-                cancellationToken: ct);
-            lock (packagesLock)
-            {
-                packages.AddRange(integrationPackages.Select(p => (p, channel)));
-            }
-        });
-
-        return packages;
-    }
-
-    private async Task<(DirectoryInfo WorkingDirectory, string? ConfiguredChannel, int? ExitCode)> GetDiscoveryPackageSearchContextAsync(FileInfo? passedAppHostProjectFile, CancellationToken cancellationToken)
-    {
-        FileInfo? appHostProjectFile;
-        if (passedAppHostProjectFile is not null)
-        {
-            var searchResult = await _projectLocator.UseOrFindAppHostProjectFileAsync(
-                passedAppHostProjectFile,
-                MultipleAppHostProjectsFoundBehavior.Throw,
-                createSettingsFile: false,
-                cancellationToken);
-
-            appHostProjectFile = searchResult.SelectedProjectFile;
-        }
-        else
-        {
-            appHostProjectFile = await _projectLocator.GetAppHostFromSettingsAsync(cancellationToken);
-        }
-
-        if (appHostProjectFile is null)
-        {
-            return (ExecutionContext.WorkingDirectory, ConfiguredChannel: null, ExitCode: null);
-        }
-
-        var project = _projectFactory.GetProject(appHostProjectFile);
-        var (configuredChannel, exitCode) = GetConfiguredChannel(appHostProjectFile, project);
-        return (appHostProjectFile.Directory!, configuredChannel, exitCode);
-    }
-
-    private (string? ConfiguredChannel, int? ExitCode) GetConfiguredChannel(FileInfo appHostProjectFile, IAppHostProject project)
-    {
-        // For non-.NET projects, read the channel from the local Aspire configuration if available.
-        // Unlike .NET projects which have a nuget.config, polyglot apphosts persist the channel
-        // in aspire.config.json (or the legacy settings.json during migration).
-        if (project.LanguageId == KnownLanguageId.CSharp)
-        {
-            return (ConfiguredChannel: null, ExitCode: null);
-        }
-
-        var appHostDirectory = appHostProjectFile.Directory!.FullName;
-        var isProjectReferenceMode = project.IsUsingProjectReferences(appHostProjectFile);
-        if (isProjectReferenceMode)
-        {
-            return (ConfiguredChannel: null, ExitCode: null);
-        }
-
-        // TODO: Remove legacy AspireJsonConfiguration fallback once confident most users
-        // have migrated. Tracked by https://github.com/microsoft/aspire/issues/15239
-        try
-        {
-            return (AspireConfigFile.Load(appHostDirectory)?.Channel
-                ?? AspireJsonConfiguration.Load(appHostDirectory)?.Channel, ExitCode: null);
-        }
-        catch (JsonException ex)
-        {
-            InteractionService.DisplayError(ex.Message);
-            return (ConfiguredChannel: null, ExitCode: ExitCodeConstants.FailedToLoadConfiguration);
-        }
-    }
-
-    private int DisplayIntegrationDiscoveryResults(IEnumerable<(string FriendlyName, NuGetPackage Package, PackageChannel Channel)> packages, string? searchTerm, bool jsonRequested)
-    {
-        var matches = (searchTerm is null
-            ? packages.Select(p => (p.FriendlyName, p.Package, p.Channel, SearchScore: 0.0))
-            : GetIntegrationSearchMatches(packages, searchTerm))
-            .GroupBy(p => p.Package.Id)
-            .Select(SelectPreferredIntegrationPackage);
-
-        var orderedMatches = searchTerm is null
-            ? matches.OrderBy(p => p.FriendlyName, new CommunityToolkitFirstComparer()).ThenBy(p => p.Package.Id, StringComparer.OrdinalIgnoreCase)
-            : matches;
-
-        var results = orderedMatches
-            .Select(p => new AddCommandIntegrationResult
-            {
-                Name = p.FriendlyName,
-                Package = p.Package.Id,
-                Version = p.Package.Version
-            })
-            .ToArray();
-
-        if (jsonRequested)
-        {
-            var json = JsonSerializer.Serialize(results, JsonSourceGenerationContext.RelaxedEscaping.AddCommandIntegrationResultArray);
-            InteractionService.DisplayRawText(json, ConsoleOutput.Standard);
-            return ExitCodeConstants.Success;
-        }
-
-        if (results.Length == 0)
-        {
-            if (searchTerm is not null)
-            {
-                InteractionService.DisplayError(string.Format(CultureInfo.CurrentCulture, AddCommandStrings.NoIntegrationPackagesMatchedSearchTerm, searchTerm));
-            }
-            else
-            {
-                InteractionService.DisplayError(AddCommandStrings.NoPackagesFound);
-            }
-
-            return ExitCodeConstants.Success;
-        }
-
-        if (searchTerm is not null)
-        {
-            InteractionService.DisplaySuccess(string.Format(CultureInfo.CurrentCulture, AddCommandStrings.FoundIntegrationPackagesMatchingSearchTerm, results.Length, searchTerm));
-        }
-        else
-        {
-            InteractionService.DisplaySuccess(string.Format(CultureInfo.CurrentCulture, AddCommandStrings.FoundIntegrationPackages, results.Length));
-        }
-
-        var table = new Table();
-        table.AddBoldColumn(AddCommandStrings.HeaderName);
-        table.AddBoldColumn(AddCommandStrings.HeaderPackage);
-        table.AddBoldColumn(AddCommandStrings.HeaderVersion);
-
-        foreach (var result in results)
-        {
-            table.AddRow(
-                Markup.Escape(result.Name),
-                Markup.Escape(result.Package),
-                Markup.Escape(result.Version));
-        }
-
-        InteractionService.DisplayRenderable(table);
-        return ExitCodeConstants.Success;
-    }
-
-    private static IEnumerable<(string FriendlyName, NuGetPackage Package, PackageChannel Channel, double SearchScore)> GetIntegrationSearchMatches(IEnumerable<(string FriendlyName, NuGetPackage Package, PackageChannel Channel)> packages, string searchTerm)
-    {
-        return packages
-            .Select(p => (p.FriendlyName, p.Package, p.Channel, SearchScore: GetIntegrationSearchScore(searchTerm, p)))
-            .Where(p => p.SearchScore > FuzzyMatchThreshold)
-            .OrderByDescending(p => p.SearchScore)
-            .ThenByDescending(p => p.FriendlyName, new CommunityToolkitFirstComparer());
-    }
-
-    private static (string FriendlyName, NuGetPackage Package, PackageChannel Channel, double SearchScore) SelectPreferredIntegrationPackage(IEnumerable<(string FriendlyName, NuGetPackage Package, PackageChannel Channel, double SearchScore)> packages)
-    {
-        return packages
-            .OrderByDescending(p => p.Channel.Type is PackageChannelType.Implicit)
-            .ThenByDescending(p => SemVersion.Parse(p.Package.Version), SemVersion.PrecedenceComparer)
-            .First();
-    }
-
-    private static double GetIntegrationSearchScore(string searchTerm, (string FriendlyName, NuGetPackage Package, PackageChannel Channel) package)
-    {
-        return Math.Max(
-            StringUtils.CalculateFuzzyScore(searchTerm, package.FriendlyName),
-            StringUtils.CalculateFuzzyScore(searchTerm, package.Package.Id));
-    }
-
     private static async Task<IEnumerable<(string FriendlyName, NuGetPackage Package, PackageChannel Channel)>> GetAllPackageVersions(DirectoryInfo workingDirectory, IEnumerable<(string FriendlyName, NuGetPackage Package, PackageChannel Channel)> possiblePackages, CancellationToken cancellationToken)
     {
         var distinctPackageIds = possiblePackages.DistinctBy(package => package.Package.Id);
@@ -597,23 +354,14 @@ internal sealed class AddCommand : BaseCommand
         return await GetPackageByInteractiveFlow(workingDirectory, possiblePackages, preferredVersion, cancellationToken);
     }
 
-    internal static (string FriendlyName, NuGetPackage Package, PackageChannel Channel) GenerateFriendlyName((NuGetPackage Package, PackageChannel Channel) packageWithChannel)
-    {
-        // Remove 'Aspire.Hosting' segment from anywhere in the package name
-        var packageId = packageWithChannel.Package.Id.Replace("Aspire.Hosting.", "", StringComparison.OrdinalIgnoreCase);
-        var friendlyName = packageId.Replace('.', '-').ToLowerInvariant();
-
-        return (friendlyName, packageWithChannel.Package, packageWithChannel.Channel);
-    }
 }
 
-internal sealed class AddCommandIntegrationResult
+internal sealed class IntegrationAddCommand : AddCommand
 {
-    public required string Name { get; init; }
-
-    public required string Package { get; init; }
-
-    public required string Version { get; init; }
+    public IntegrationAddCommand(IInteractionService interactionService, IProjectLocator projectLocator, IntegrationPackageSearchService integrationPackageSearchService, IAddCommandPrompter prompter, AspireCliTelemetry telemetry, IDotNetSdkInstaller sdkInstaller, IFeatures features, ICliUpdateNotifier updateNotifier, CliExecutionContext executionContext, ICliHostEnvironment hostEnvironment, IAppHostProjectFactory projectFactory)
+        : base("add", AddCommandStrings.Description, interactionService, projectLocator, integrationPackageSearchService, prompter, telemetry, sdkInstaller, features, updateNotifier, executionContext, hostEnvironment, projectFactory)
+    {
+    }
 }
 
 internal interface IAddCommandPrompter

--- a/src/Aspire.Cli/Commands/AddCommand.cs
+++ b/src/Aspire.Cli/Commands/AddCommand.cs
@@ -209,17 +209,9 @@ internal sealed class AddCommand : BaseCommand
                 // then try a fuzzy search to create a broader filtered list.
                 // Materialize the query with ToList() to avoid multiple enumerations
                 // (which would recalculate fuzzy scores on each Count()/First() call).
-                filteredPackagesWithShortName = packagesWithShortName
-                        .Select(p => new
-                        {
-                            Package = p,
-                            Score = GetIntegrationSearchScore(integrationName, p)
-                        })
-                        .Where(x => x.Score > FuzzyMatchThreshold)
-                        .OrderByDescending(x => x.Score)
-                        .ThenByDescending(x => x.Package.FriendlyName, new CommunityToolkitFirstComparer())
-                        .Select(x => x.Package)
-                        .ToList();
+                filteredPackagesWithShortName = GetIntegrationSearchMatches(packagesWithShortName, integrationName)
+                    .Select(x => (x.FriendlyName, x.Package, x.Channel))
+                    .ToList();
             }
 
             // If we didn't match any, show a complete list. If we matched one, and its
@@ -372,23 +364,22 @@ internal sealed class AddCommand : BaseCommand
 
     private int DisplayIntegrationDiscoveryResults(IEnumerable<(string FriendlyName, NuGetPackage Package, PackageChannel Channel)> packages, string? searchTerm, bool jsonRequested)
     {
-        var matches = packages
-            .Select(p => (Package: p, SearchScore: searchTerm is null ? 0 : GetIntegrationSearchScore(searchTerm, p)))
-            .Where(p => searchTerm is null || p.SearchScore > FuzzyMatchThreshold)
-            .GroupBy(p => p.Package.Package.Id)
-            .Select(g => g.OrderByDescending(p => SemVersion.Parse(p.Package.Package.Version), SemVersion.PrecedenceComparer).First());
+        var matches = (searchTerm is null
+            ? packages.Select(p => (p.FriendlyName, p.Package, p.Channel, SearchScore: 0.0))
+            : GetIntegrationSearchMatches(packages, searchTerm))
+            .GroupBy(p => p.Package.Id)
+            .Select(g => g.OrderByDescending(p => SemVersion.Parse(p.Package.Version), SemVersion.PrecedenceComparer).First());
 
         var orderedMatches = searchTerm is null
-            ? matches.OrderBy(p => p.Package.FriendlyName, new CommunityToolkitFirstComparer()).ThenBy(p => p.Package.Package.Id, StringComparer.OrdinalIgnoreCase)
-            : matches.OrderByDescending(p => p.SearchScore).ThenBy(p => p.Package.FriendlyName, new CommunityToolkitFirstComparer())
-                .ThenBy(p => p.Package.Package.Id, StringComparer.OrdinalIgnoreCase);
+            ? matches.OrderBy(p => p.FriendlyName, new CommunityToolkitFirstComparer()).ThenBy(p => p.Package.Id, StringComparer.OrdinalIgnoreCase)
+            : matches;
 
         var results = orderedMatches
             .Select(p => new AddCommandIntegrationResult
             {
-                Name = p.Package.FriendlyName,
-                Package = p.Package.Package.Id,
-                Version = p.Package.Package.Version
+                Name = p.FriendlyName,
+                Package = p.Package.Id,
+                Version = p.Package.Version
             })
             .ToArray();
 
@@ -437,6 +428,15 @@ internal sealed class AddCommand : BaseCommand
 
         InteractionService.DisplayRenderable(table);
         return ExitCodeConstants.Success;
+    }
+
+    private static IEnumerable<(string FriendlyName, NuGetPackage Package, PackageChannel Channel, double SearchScore)> GetIntegrationSearchMatches(IEnumerable<(string FriendlyName, NuGetPackage Package, PackageChannel Channel)> packages, string searchTerm)
+    {
+        return packages
+            .Select(p => (p.FriendlyName, p.Package, p.Channel, SearchScore: GetIntegrationSearchScore(searchTerm, p)))
+            .Where(p => p.SearchScore > FuzzyMatchThreshold)
+            .OrderByDescending(p => p.SearchScore)
+            .ThenByDescending(p => p.FriendlyName, new CommunityToolkitFirstComparer());
     }
 
     private static double GetIntegrationSearchScore(string searchTerm, (string FriendlyName, NuGetPackage Package, PackageChannel Channel) package)

--- a/src/Aspire.Cli/Commands/AddCommand.cs
+++ b/src/Aspire.Cli/Commands/AddCommand.cs
@@ -17,7 +17,7 @@ using NuGetPackage = Aspire.Shared.NuGetPackageCli;
 
 namespace Aspire.Cli.Commands;
 
-internal class AddCommand : BaseCommand
+internal sealed class AddCommand : BaseCommand
 {
     internal override HelpGroup HelpGroup => HelpGroup.AppCommands;
 
@@ -44,12 +44,7 @@ internal class AddCommand : BaseCommand
     };
 
     public AddCommand(IInteractionService interactionService, IProjectLocator projectLocator, IntegrationPackageSearchService integrationPackageSearchService, IAddCommandPrompter prompter, AspireCliTelemetry telemetry, IDotNetSdkInstaller sdkInstaller, IFeatures features, ICliUpdateNotifier updateNotifier, CliExecutionContext executionContext, ICliHostEnvironment hostEnvironment, IAppHostProjectFactory projectFactory)
-        : this("add", AddCommandStrings.Description, interactionService, projectLocator, integrationPackageSearchService, prompter, telemetry, sdkInstaller, features, updateNotifier, executionContext, hostEnvironment, projectFactory)
-    {
-    }
-
-    protected AddCommand(string name, string description, IInteractionService interactionService, IProjectLocator projectLocator, IntegrationPackageSearchService integrationPackageSearchService, IAddCommandPrompter prompter, AspireCliTelemetry telemetry, IDotNetSdkInstaller sdkInstaller, IFeatures features, ICliUpdateNotifier updateNotifier, CliExecutionContext executionContext, ICliHostEnvironment hostEnvironment, IAppHostProjectFactory projectFactory)
-        : base(name, description, features, updateNotifier, executionContext, interactionService, telemetry)
+        : base("add", AddCommandStrings.Description, features, updateNotifier, executionContext, interactionService, telemetry)
     {
         _projectLocator = projectLocator;
         _integrationPackageSearchService = integrationPackageSearchService;
@@ -354,14 +349,6 @@ internal class AddCommand : BaseCommand
         return await GetPackageByInteractiveFlow(workingDirectory, possiblePackages, preferredVersion, cancellationToken);
     }
 
-}
-
-internal sealed class IntegrationAddCommand : AddCommand
-{
-    public IntegrationAddCommand(IInteractionService interactionService, IProjectLocator projectLocator, IntegrationPackageSearchService integrationPackageSearchService, IAddCommandPrompter prompter, AspireCliTelemetry telemetry, IDotNetSdkInstaller sdkInstaller, IFeatures features, ICliUpdateNotifier updateNotifier, CliExecutionContext executionContext, ICliHostEnvironment hostEnvironment, IAppHostProjectFactory projectFactory)
-        : base("add", AddCommandStrings.Description, interactionService, projectLocator, integrationPackageSearchService, prompter, telemetry, sdkInstaller, features, updateNotifier, executionContext, hostEnvironment, projectFactory)
-    {
-    }
 }
 
 internal interface IAddCommandPrompter

--- a/src/Aspire.Cli/Commands/AddCommand.cs
+++ b/src/Aspire.Cli/Commands/AddCommand.cs
@@ -109,10 +109,15 @@ internal sealed class AddCommand : BaseCommand
                     return ExitCodeConstants.MissingRequiredArgument;
                 }
 
-                var workingDirectory = passedAppHostProjectFile?.Directory ?? ExecutionContext.WorkingDirectory;
+                var (workingDirectory, discoveryConfiguredChannel, discoveryContextExitCode) = await GetDiscoveryPackageSearchContextAsync(passedAppHostProjectFile, cancellationToken);
+                if (discoveryContextExitCode is { } discoveryExitCode)
+                {
+                    return discoveryExitCode;
+                }
+
                 var discoveryPackagesWithChannels = await InteractionService.ShowStatusAsync(
                     AddCommandStrings.SearchingForAspirePackages,
-                    async () => await GetIntegrationPackagesWithChannelsAsync(workingDirectory, configuredChannel: null, cancellationToken));
+                    async () => await GetIntegrationPackagesWithChannelsAsync(workingDirectory, discoveryConfiguredChannel, cancellationToken));
 
                 if (!discoveryPackagesWithChannels.Any())
                 {
@@ -153,29 +158,10 @@ internal sealed class AddCommand : BaseCommand
                 }
             }
 
-            // For non-.NET projects, read the channel from the local Aspire configuration if available.
-            // Unlike .NET projects which have a nuget.config, polyglot apphosts persist the channel
-            // in aspire.config.json (or the legacy settings.json during migration).
-            string? configuredChannel = null;
-            if (project.LanguageId != KnownLanguageId.CSharp)
+            var (configuredChannel, configuredChannelExitCode) = GetConfiguredChannel(effectiveAppHostProjectFile, project);
+            if (configuredChannelExitCode is { } exitCode)
             {
-                var appHostDirectory = effectiveAppHostProjectFile.Directory!.FullName;
-                var isProjectReferenceMode = AspireRepositoryDetector.DetectRepositoryRoot(appHostDirectory) is not null;
-                if (!isProjectReferenceMode)
-                {
-                    // TODO: Remove legacy AspireJsonConfiguration fallback once confident most users
-                    // have migrated. Tracked by https://github.com/microsoft/aspire/issues/15239
-                    try
-                    {
-                        configuredChannel = AspireConfigFile.Load(appHostDirectory)?.Channel
-                            ?? AspireJsonConfiguration.Load(appHostDirectory)?.Channel;
-                    }
-                    catch (JsonException ex)
-                    {
-                        InteractionService.DisplayError(ex.Message);
-                        return ExitCodeConstants.FailedToLoadConfiguration;
-                    }
-                }
+                return exitCode;
             }
 
             var packagesWithChannels = await InteractionService.ShowStatusAsync(
@@ -362,13 +348,72 @@ internal sealed class AddCommand : BaseCommand
         return packages;
     }
 
+    private async Task<(DirectoryInfo WorkingDirectory, string? ConfiguredChannel, int? ExitCode)> GetDiscoveryPackageSearchContextAsync(FileInfo? passedAppHostProjectFile, CancellationToken cancellationToken)
+    {
+        FileInfo? appHostProjectFile;
+        if (passedAppHostProjectFile is not null)
+        {
+            var searchResult = await _projectLocator.UseOrFindAppHostProjectFileAsync(
+                passedAppHostProjectFile,
+                MultipleAppHostProjectsFoundBehavior.Throw,
+                createSettingsFile: false,
+                cancellationToken);
+
+            appHostProjectFile = searchResult.SelectedProjectFile;
+        }
+        else
+        {
+            appHostProjectFile = await _projectLocator.GetAppHostFromSettingsAsync(cancellationToken);
+        }
+
+        if (appHostProjectFile is null)
+        {
+            return (ExecutionContext.WorkingDirectory, ConfiguredChannel: null, ExitCode: null);
+        }
+
+        var project = _projectFactory.GetProject(appHostProjectFile);
+        var (configuredChannel, exitCode) = GetConfiguredChannel(appHostProjectFile, project);
+        return (appHostProjectFile.Directory!, configuredChannel, exitCode);
+    }
+
+    private (string? ConfiguredChannel, int? ExitCode) GetConfiguredChannel(FileInfo appHostProjectFile, IAppHostProject project)
+    {
+        // For non-.NET projects, read the channel from the local Aspire configuration if available.
+        // Unlike .NET projects which have a nuget.config, polyglot apphosts persist the channel
+        // in aspire.config.json (or the legacy settings.json during migration).
+        if (project.LanguageId == KnownLanguageId.CSharp)
+        {
+            return (ConfiguredChannel: null, ExitCode: null);
+        }
+
+        var appHostDirectory = appHostProjectFile.Directory!.FullName;
+        var isProjectReferenceMode = project.IsUsingProjectReferences(appHostProjectFile);
+        if (isProjectReferenceMode)
+        {
+            return (ConfiguredChannel: null, ExitCode: null);
+        }
+
+        // TODO: Remove legacy AspireJsonConfiguration fallback once confident most users
+        // have migrated. Tracked by https://github.com/microsoft/aspire/issues/15239
+        try
+        {
+            return (AspireConfigFile.Load(appHostDirectory)?.Channel
+                ?? AspireJsonConfiguration.Load(appHostDirectory)?.Channel, ExitCode: null);
+        }
+        catch (JsonException ex)
+        {
+            InteractionService.DisplayError(ex.Message);
+            return (ConfiguredChannel: null, ExitCode: ExitCodeConstants.FailedToLoadConfiguration);
+        }
+    }
+
     private int DisplayIntegrationDiscoveryResults(IEnumerable<(string FriendlyName, NuGetPackage Package, PackageChannel Channel)> packages, string? searchTerm, bool jsonRequested)
     {
         var matches = (searchTerm is null
             ? packages.Select(p => (p.FriendlyName, p.Package, p.Channel, SearchScore: 0.0))
             : GetIntegrationSearchMatches(packages, searchTerm))
             .GroupBy(p => p.Package.Id)
-            .Select(g => g.OrderByDescending(p => SemVersion.Parse(p.Package.Version), SemVersion.PrecedenceComparer).First());
+            .Select(SelectPreferredIntegrationPackage);
 
         var orderedMatches = searchTerm is null
             ? matches.OrderBy(p => p.FriendlyName, new CommunityToolkitFirstComparer()).ThenBy(p => p.Package.Id, StringComparer.OrdinalIgnoreCase)
@@ -437,6 +482,14 @@ internal sealed class AddCommand : BaseCommand
             .Where(p => p.SearchScore > FuzzyMatchThreshold)
             .OrderByDescending(p => p.SearchScore)
             .ThenByDescending(p => p.FriendlyName, new CommunityToolkitFirstComparer());
+    }
+
+    private static (string FriendlyName, NuGetPackage Package, PackageChannel Channel, double SearchScore) SelectPreferredIntegrationPackage(IEnumerable<(string FriendlyName, NuGetPackage Package, PackageChannel Channel, double SearchScore)> packages)
+    {
+        return packages
+            .OrderByDescending(p => p.Channel.Type is PackageChannelType.Implicit)
+            .ThenByDescending(p => SemVersion.Parse(p.Package.Version), SemVersion.PrecedenceComparer)
+            .First();
     }
 
     private static double GetIntegrationSearchScore(string searchTerm, (string FriendlyName, NuGetPackage Package, PackageChannel Channel) package)

--- a/src/Aspire.Cli/Commands/BaseCommand.cs
+++ b/src/Aspire.Cli/Commands/BaseCommand.cs
@@ -85,7 +85,10 @@ internal abstract class BaseCommand : Command
         {
             if (option.Name == "--format" && option is Option<OutputFormat> formatOption)
             {
-                return parseResult.GetValue(formatOption) == OutputFormat.Json;
+                if (parseResult.GetValue(formatOption) == OutputFormat.Json)
+                {
+                    return true;
+                }
             }
         }
 

--- a/src/Aspire.Cli/Commands/BaseCommand.cs
+++ b/src/Aspire.Cli/Commands/BaseCommand.cs
@@ -85,10 +85,7 @@ internal abstract class BaseCommand : Command
         {
             if (option.Name == "--format" && option is Option<OutputFormat> formatOption)
             {
-                if (parseResult.GetValue(formatOption) == OutputFormat.Json)
-                {
-                    return true;
-                }
+                return parseResult.GetValue(formatOption) == OutputFormat.Json;
             }
         }
 

--- a/src/Aspire.Cli/Commands/IntegrationCommand.cs
+++ b/src/Aspire.Cli/Commands/IntegrationCommand.cs
@@ -16,7 +16,7 @@ internal sealed class IntegrationCommand : BaseCommand
     internal override HelpGroup HelpGroup => HelpGroup.AppCommands;
 
     public IntegrationCommand(
-        IntegrationAddCommand addCommand,
+        AddCommand addCommand,
         IntegrationListCommand listCommand,
         IntegrationSearchCommand searchCommand,
         IInteractionService interactionService,

--- a/src/Aspire.Cli/Commands/IntegrationCommand.cs
+++ b/src/Aspire.Cli/Commands/IntegrationCommand.cs
@@ -1,0 +1,39 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.CommandLine;
+using System.CommandLine.Help;
+using Aspire.Cli.Configuration;
+using Aspire.Cli.Interaction;
+using Aspire.Cli.Resources;
+using Aspire.Cli.Telemetry;
+using Aspire.Cli.Utils;
+
+namespace Aspire.Cli.Commands;
+
+internal sealed class IntegrationCommand : BaseCommand
+{
+    internal override HelpGroup HelpGroup => HelpGroup.AppCommands;
+
+    public IntegrationCommand(
+        IntegrationAddCommand addCommand,
+        IntegrationSearchCommand searchCommand,
+        IInteractionService interactionService,
+        IFeatures features,
+        ICliUpdateNotifier updateNotifier,
+        CliExecutionContext executionContext,
+        AspireCliTelemetry telemetry)
+        : base("integration", AddCommandStrings.IntegrationCommandDescription, features, updateNotifier, executionContext, interactionService, telemetry)
+    {
+        Subcommands.Add(addCommand);
+        Subcommands.Add(searchCommand);
+    }
+
+    protected override bool UpdateNotificationsEnabled => false;
+
+    protected override Task<int> ExecuteAsync(ParseResult parseResult, CancellationToken cancellationToken)
+    {
+        new HelpAction().Invoke(parseResult);
+        return Task.FromResult(ExitCodeConstants.InvalidCommand);
+    }
+}

--- a/src/Aspire.Cli/Commands/IntegrationCommand.cs
+++ b/src/Aspire.Cli/Commands/IntegrationCommand.cs
@@ -17,6 +17,7 @@ internal sealed class IntegrationCommand : BaseCommand
 
     public IntegrationCommand(
         IntegrationAddCommand addCommand,
+        IntegrationListCommand listCommand,
         IntegrationSearchCommand searchCommand,
         IInteractionService interactionService,
         IFeatures features,
@@ -26,6 +27,7 @@ internal sealed class IntegrationCommand : BaseCommand
         : base("integration", AddCommandStrings.IntegrationCommandDescription, features, updateNotifier, executionContext, interactionService, telemetry)
     {
         Subcommands.Add(addCommand);
+        Subcommands.Add(listCommand);
         Subcommands.Add(searchCommand);
     }
 

--- a/src/Aspire.Cli/Commands/IntegrationPackageSearchService.cs
+++ b/src/Aspire.Cli/Commands/IntegrationPackageSearchService.cs
@@ -1,0 +1,145 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Text.Json;
+using Aspire.Cli.Configuration;
+using Aspire.Cli.Interaction;
+using Aspire.Cli.Packaging;
+using Aspire.Cli.Projects;
+using Aspire.Cli.Utils;
+using Semver;
+using NuGetPackage = Aspire.Shared.NuGetPackageCli;
+
+namespace Aspire.Cli.Commands;
+
+internal sealed class IntegrationPackageSearchService(
+    IPackagingService packagingService,
+    IProjectLocator projectLocator,
+    IInteractionService interactionService,
+    CliExecutionContext executionContext,
+    IAppHostProjectFactory projectFactory)
+{
+    private const double FuzzyMatchThreshold = 0.3;
+
+    public async Task<IEnumerable<(NuGetPackage Package, PackageChannel Channel)>> GetIntegrationPackagesWithChannelsAsync(DirectoryInfo workingDirectory, string? configuredChannel, CancellationToken cancellationToken)
+    {
+        var allChannels = await packagingService.GetChannelsAsync(cancellationToken);
+
+        if (!string.IsNullOrEmpty(configuredChannel))
+        {
+            allChannels = allChannels.Where(c => string.Equals(c.Name, configuredChannel, StringComparison.OrdinalIgnoreCase));
+        }
+
+        var hasHives = executionContext.GetPrHiveCount() > 0;
+        var channels = hasHives || !string.IsNullOrEmpty(configuredChannel)
+            ? allChannels
+            : allChannels.Where(c => c.Type is PackageChannelType.Implicit);
+
+        var packages = new List<(NuGetPackage Package, PackageChannel Channel)>();
+        var packagesLock = new object();
+
+        await Parallel.ForEachAsync(channels, cancellationToken, async (channel, ct) =>
+        {
+            var integrationPackages = await channel.GetIntegrationPackagesAsync(
+                workingDirectory: workingDirectory,
+                cancellationToken: ct);
+            lock (packagesLock)
+            {
+                packages.AddRange(integrationPackages.Select(p => (p, channel)));
+            }
+        });
+
+        return packages;
+    }
+
+    public async Task<(DirectoryInfo WorkingDirectory, string? ConfiguredChannel, int? ExitCode)> GetPackageSearchContextAsync(FileInfo? passedAppHostProjectFile, CancellationToken cancellationToken)
+    {
+        FileInfo? appHostProjectFile;
+        if (passedAppHostProjectFile is not null)
+        {
+            var searchResult = await projectLocator.UseOrFindAppHostProjectFileAsync(
+                passedAppHostProjectFile,
+                MultipleAppHostProjectsFoundBehavior.Throw,
+                createSettingsFile: false,
+                cancellationToken);
+
+            appHostProjectFile = searchResult.SelectedProjectFile;
+        }
+        else
+        {
+            appHostProjectFile = await projectLocator.GetAppHostFromSettingsAsync(cancellationToken);
+        }
+
+        if (appHostProjectFile is null)
+        {
+            return (executionContext.WorkingDirectory, ConfiguredChannel: null, ExitCode: null);
+        }
+
+        var project = projectFactory.GetProject(appHostProjectFile);
+        var (configuredChannel, exitCode) = GetConfiguredChannel(appHostProjectFile, project);
+        return (appHostProjectFile.Directory!, configuredChannel, exitCode);
+    }
+
+    public (string? ConfiguredChannel, int? ExitCode) GetConfiguredChannel(FileInfo appHostProjectFile, IAppHostProject project)
+    {
+        // For non-.NET projects, read the channel from the local Aspire configuration if available.
+        // Unlike .NET projects which have a nuget.config, polyglot apphosts persist the channel
+        // in aspire.config.json (or the legacy settings.json during migration).
+        if (project.LanguageId == KnownLanguageId.CSharp)
+        {
+            return (ConfiguredChannel: null, ExitCode: null);
+        }
+
+        var appHostDirectory = appHostProjectFile.Directory!.FullName;
+        var isProjectReferenceMode = project.IsUsingProjectReferences(appHostProjectFile);
+        if (isProjectReferenceMode)
+        {
+            return (ConfiguredChannel: null, ExitCode: null);
+        }
+
+        // TODO: Remove legacy AspireJsonConfiguration fallback once confident most users
+        // have migrated. Tracked by https://github.com/microsoft/aspire/issues/15239
+        try
+        {
+            return (AspireConfigFile.Load(appHostDirectory)?.Channel
+                ?? AspireJsonConfiguration.Load(appHostDirectory)?.Channel, ExitCode: null);
+        }
+        catch (JsonException ex)
+        {
+            interactionService.DisplayError(ex.Message);
+            return (ConfiguredChannel: null, ExitCode: ExitCodeConstants.FailedToLoadConfiguration);
+        }
+    }
+
+    public static (string FriendlyName, NuGetPackage Package, PackageChannel Channel) GenerateFriendlyName((NuGetPackage Package, PackageChannel Channel) packageWithChannel)
+    {
+        var packageId = packageWithChannel.Package.Id.Replace("Aspire.Hosting.", "", StringComparison.OrdinalIgnoreCase);
+        var friendlyName = packageId.Replace('.', '-').ToLowerInvariant();
+
+        return (friendlyName, packageWithChannel.Package, packageWithChannel.Channel);
+    }
+
+    public static IEnumerable<(string FriendlyName, NuGetPackage Package, PackageChannel Channel, double SearchScore)> GetIntegrationSearchMatches(IEnumerable<(string FriendlyName, NuGetPackage Package, PackageChannel Channel)> packages, string searchTerm)
+    {
+        return packages
+            .Select(p => (p.FriendlyName, p.Package, p.Channel, SearchScore: GetIntegrationSearchScore(searchTerm, p)))
+            .Where(p => p.SearchScore > FuzzyMatchThreshold)
+            .OrderByDescending(p => p.SearchScore)
+            .ThenByDescending(p => p.FriendlyName, new CommunityToolkitFirstComparer());
+    }
+
+    public static (string FriendlyName, NuGetPackage Package, PackageChannel Channel, double SearchScore) SelectPreferredIntegrationPackage(IEnumerable<(string FriendlyName, NuGetPackage Package, PackageChannel Channel, double SearchScore)> packages)
+    {
+        return packages
+            .OrderByDescending(p => p.Channel.Type is PackageChannelType.Implicit)
+            .ThenByDescending(p => SemVersion.Parse(p.Package.Version), SemVersion.PrecedenceComparer)
+            .First();
+    }
+
+    private static double GetIntegrationSearchScore(string searchTerm, (string FriendlyName, NuGetPackage Package, PackageChannel Channel) package)
+    {
+        return Math.Max(
+            StringUtils.CalculateFuzzyScore(searchTerm, package.FriendlyName),
+            StringUtils.CalculateFuzzyScore(searchTerm, package.Package.Id));
+    }
+}

--- a/src/Aspire.Cli/Commands/IntegrationSearchCommand.cs
+++ b/src/Aspire.Cli/Commands/IntegrationSearchCommand.cs
@@ -67,21 +67,10 @@ internal abstract class IntegrationDiscoveryCommand : BaseCommand
                 async () => await _integrationPackageSearchService.GetIntegrationPackagesWithChannelsAsync(workingDirectory, configuredChannel, cancellationToken)))
                 .ToArray();
 
-            if (packagesWithChannels.Length == 0)
-            {
-                throw new EmptyChoicesException(AddCommandStrings.NoIntegrationPackagesFound);
-            }
-
             var packagesWithShortName = packagesWithChannels
                 .Select(IntegrationPackageSearchService.GenerateFriendlyName)
                 .OrderBy(p => p.FriendlyName, new CommunityToolkitFirstComparer())
                 .ToArray();
-
-            if (packagesWithShortName.Length == 0)
-            {
-                InteractionService.DisplayError(AddCommandStrings.NoPackagesFound);
-                return ExitCodeConstants.FailedToAddPackage;
-            }
 
             return DisplayIntegrationResults(packagesWithShortName, searchTerm, format);
         }
@@ -92,20 +81,14 @@ internal abstract class IntegrationDiscoveryCommand : BaseCommand
         catch (OperationCanceledException)
         {
             InteractionService.DisplayCancellationMessage();
-            return ExitCodeConstants.FailedToAddPackage;
-        }
-        catch (EmptyChoicesException ex)
-        {
-            Telemetry.RecordError(ex.Message, ex);
-            InteractionService.DisplayError(ex.Message);
-            return ExitCodeConstants.FailedToAddPackage;
+            return ExitCodeConstants.FailedToSearchIntegrations;
         }
         catch (Exception ex)
         {
             var errorMessage = string.Format(CultureInfo.CurrentCulture, AddCommandStrings.ErrorOccurredWhileSearchingIntegrations, ex.Message);
             Telemetry.RecordError(errorMessage, ex);
             InteractionService.DisplayError(errorMessage);
-            return ExitCodeConstants.FailedToAddPackage;
+            return ExitCodeConstants.FailedToSearchIntegrations;
         }
     }
 

--- a/src/Aspire.Cli/Commands/IntegrationSearchCommand.cs
+++ b/src/Aspire.Cli/Commands/IntegrationSearchCommand.cs
@@ -1,0 +1,193 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.CommandLine;
+using System.Globalization;
+using System.Text.Json;
+using Aspire.Cli.Configuration;
+using Aspire.Cli.Interaction;
+using Aspire.Cli.Packaging;
+using Aspire.Cli.Projects;
+using Aspire.Cli.Resources;
+using Aspire.Cli.Telemetry;
+using Aspire.Cli.Utils;
+using Spectre.Console;
+using NuGetPackage = Aspire.Shared.NuGetPackageCli;
+
+namespace Aspire.Cli.Commands;
+
+internal sealed class IntegrationSearchCommand : BaseCommand
+{
+    private readonly IntegrationPackageSearchService _integrationPackageSearchService;
+
+    private static readonly Argument<string?> s_queryArgument = new("query")
+    {
+        Description = AddCommandStrings.IntegrationSearchQueryArgumentDescription,
+        Arity = ArgumentArity.ZeroOrOne
+    };
+
+    private static readonly OptionWithLegacy<FileInfo?> s_appHostOption = new("--apphost", "--project", AddCommandStrings.IntegrationSearchAppHostOptionDescription);
+
+    private static readonly Option<OutputFormat> s_formatOption = new("--format")
+    {
+        Description = AddCommandStrings.FormatOptionDescription
+    };
+
+    public IntegrationSearchCommand(
+        IntegrationPackageSearchService integrationPackageSearchService,
+        IInteractionService interactionService,
+        IFeatures features,
+        ICliUpdateNotifier updateNotifier,
+        CliExecutionContext executionContext,
+        AspireCliTelemetry telemetry)
+        : base("search", AddCommandStrings.IntegrationSearchDescription, features, updateNotifier, executionContext, interactionService, telemetry)
+    {
+        _integrationPackageSearchService = integrationPackageSearchService;
+
+        Arguments.Add(s_queryArgument);
+        Options.Add(s_appHostOption);
+        Options.Add(s_formatOption);
+    }
+
+    protected override bool UpdateNotificationsEnabled => false;
+
+    protected override async Task<int> ExecuteAsync(ParseResult parseResult, CancellationToken cancellationToken)
+    {
+        using var activity = Telemetry.StartDiagnosticActivity(Name);
+
+        try
+        {
+            var searchTerm = parseResult.GetValue(s_queryArgument);
+            var passedAppHostProjectFile = parseResult.GetValue(s_appHostOption);
+            var format = parseResult.GetValue(s_formatOption);
+
+            var (workingDirectory, configuredChannel, contextExitCode) = await _integrationPackageSearchService.GetPackageSearchContextAsync(passedAppHostProjectFile, cancellationToken);
+            if (contextExitCode is { } exitCode)
+            {
+                return exitCode;
+            }
+
+            var packagesWithChannels = (await InteractionService.ShowStatusAsync(
+                AddCommandStrings.SearchingForAspirePackages,
+                async () => await _integrationPackageSearchService.GetIntegrationPackagesWithChannelsAsync(workingDirectory, configuredChannel, cancellationToken)))
+                .ToArray();
+
+            if (packagesWithChannels.Length == 0)
+            {
+                throw new EmptyChoicesException(AddCommandStrings.NoIntegrationPackagesFound);
+            }
+
+            var packagesWithShortName = packagesWithChannels
+                .Select(IntegrationPackageSearchService.GenerateFriendlyName)
+                .OrderBy(p => p.FriendlyName, new CommunityToolkitFirstComparer())
+                .ToArray();
+
+            if (packagesWithShortName.Length == 0)
+            {
+                InteractionService.DisplayError(AddCommandStrings.NoPackagesFound);
+                return ExitCodeConstants.FailedToAddPackage;
+            }
+
+            return DisplayIntegrationSearchResults(packagesWithShortName, searchTerm, format);
+        }
+        catch (ProjectLocatorException ex)
+        {
+            return HandleProjectLocatorException(ex, InteractionService, Telemetry);
+        }
+        catch (OperationCanceledException)
+        {
+            InteractionService.DisplayCancellationMessage();
+            return ExitCodeConstants.FailedToAddPackage;
+        }
+        catch (EmptyChoicesException ex)
+        {
+            Telemetry.RecordError(ex.Message, ex);
+            InteractionService.DisplayError(ex.Message);
+            return ExitCodeConstants.FailedToAddPackage;
+        }
+        catch (Exception ex)
+        {
+            var errorMessage = string.Format(CultureInfo.CurrentCulture, AddCommandStrings.ErrorOccurredWhileSearchingIntegrations, ex.Message);
+            Telemetry.RecordError(errorMessage, ex);
+            InteractionService.DisplayError(errorMessage);
+            return ExitCodeConstants.FailedToAddPackage;
+        }
+    }
+
+    private int DisplayIntegrationSearchResults(IEnumerable<(string FriendlyName, NuGetPackage Package, PackageChannel Channel)> packages, string? searchTerm, OutputFormat format)
+    {
+        var matches = (searchTerm is null
+            ? packages.Select(p => (p.FriendlyName, p.Package, p.Channel, SearchScore: 0.0))
+            : IntegrationPackageSearchService.GetIntegrationSearchMatches(packages, searchTerm))
+            .GroupBy(p => p.Package.Id)
+            .Select(IntegrationPackageSearchService.SelectPreferredIntegrationPackage);
+
+        var orderedMatches = searchTerm is null
+            ? matches.OrderBy(p => p.FriendlyName, new CommunityToolkitFirstComparer()).ThenBy(p => p.Package.Id, StringComparer.OrdinalIgnoreCase)
+            : matches;
+
+        var results = orderedMatches
+            .Select(p => new IntegrationSearchResult
+            {
+                Name = p.FriendlyName,
+                Package = p.Package.Id,
+                Version = p.Package.Version
+            })
+            .ToArray();
+
+        if (format is OutputFormat.Json)
+        {
+            var json = JsonSerializer.Serialize(results, JsonSourceGenerationContext.RelaxedEscaping.IntegrationSearchResultArray);
+            InteractionService.DisplayRawText(json, ConsoleOutput.Standard);
+            return ExitCodeConstants.Success;
+        }
+
+        if (results.Length == 0)
+        {
+            if (searchTerm is not null)
+            {
+                InteractionService.DisplayError(string.Format(CultureInfo.CurrentCulture, AddCommandStrings.NoIntegrationPackagesMatchedSearchTerm, searchTerm));
+            }
+            else
+            {
+                InteractionService.DisplayError(AddCommandStrings.NoPackagesFound);
+            }
+
+            return ExitCodeConstants.Success;
+        }
+
+        if (searchTerm is not null)
+        {
+            InteractionService.DisplaySuccess(string.Format(CultureInfo.CurrentCulture, AddCommandStrings.FoundIntegrationPackagesMatchingSearchTerm, results.Length, searchTerm));
+        }
+        else
+        {
+            InteractionService.DisplaySuccess(string.Format(CultureInfo.CurrentCulture, AddCommandStrings.FoundIntegrationPackages, results.Length));
+        }
+
+        var table = new Table();
+        table.AddBoldColumn(AddCommandStrings.HeaderName);
+        table.AddBoldColumn(AddCommandStrings.HeaderPackage);
+        table.AddBoldColumn(AddCommandStrings.HeaderVersion);
+
+        foreach (var result in results)
+        {
+            table.AddRow(
+                Markup.Escape(result.Name),
+                Markup.Escape(result.Package),
+                Markup.Escape(result.Version));
+        }
+
+        InteractionService.DisplayRenderable(table);
+        return ExitCodeConstants.Success;
+    }
+}
+
+internal sealed class IntegrationSearchResult
+{
+    public required string Name { get; init; }
+
+    public required string Package { get; init; }
+
+    public required string Version { get; init; }
+}

--- a/src/Aspire.Cli/Commands/IntegrationSearchCommand.cs
+++ b/src/Aspire.Cli/Commands/IntegrationSearchCommand.cs
@@ -16,40 +16,35 @@ using NuGetPackage = Aspire.Shared.NuGetPackageCli;
 
 namespace Aspire.Cli.Commands;
 
-internal sealed class IntegrationSearchCommand : BaseCommand
+internal abstract class IntegrationDiscoveryCommand : BaseCommand
 {
     private readonly IntegrationPackageSearchService _integrationPackageSearchService;
-
-    private static readonly Argument<string?> s_queryArgument = new("query")
-    {
-        Description = AddCommandStrings.IntegrationSearchQueryArgumentDescription,
-        Arity = ArgumentArity.ZeroOrOne
-    };
-
-    private static readonly OptionWithLegacy<FileInfo?> s_appHostOption = new("--apphost", "--project", AddCommandStrings.IntegrationSearchAppHostOptionDescription);
-
-    private static readonly Option<OutputFormat> s_formatOption = new("--format")
+    private readonly OptionWithLegacy<FileInfo?> _appHostOption = new("--apphost", "--project", AddCommandStrings.IntegrationSearchAppHostOptionDescription);
+    private readonly Option<OutputFormat> _formatOption = new("--format")
     {
         Description = AddCommandStrings.FormatOptionDescription
     };
 
-    public IntegrationSearchCommand(
+    protected IntegrationDiscoveryCommand(
+        string name,
+        string description,
         IntegrationPackageSearchService integrationPackageSearchService,
         IInteractionService interactionService,
         IFeatures features,
         ICliUpdateNotifier updateNotifier,
         CliExecutionContext executionContext,
         AspireCliTelemetry telemetry)
-        : base("search", AddCommandStrings.IntegrationSearchDescription, features, updateNotifier, executionContext, interactionService, telemetry)
+        : base(name, description, features, updateNotifier, executionContext, interactionService, telemetry)
     {
         _integrationPackageSearchService = integrationPackageSearchService;
 
-        Arguments.Add(s_queryArgument);
-        Options.Add(s_appHostOption);
-        Options.Add(s_formatOption);
+        Options.Add(_appHostOption);
+        Options.Add(_formatOption);
     }
 
     protected override bool UpdateNotificationsEnabled => false;
+
+    protected abstract string? GetSearchTerm(ParseResult parseResult);
 
     protected override async Task<int> ExecuteAsync(ParseResult parseResult, CancellationToken cancellationToken)
     {
@@ -57,9 +52,9 @@ internal sealed class IntegrationSearchCommand : BaseCommand
 
         try
         {
-            var searchTerm = parseResult.GetValue(s_queryArgument);
-            var passedAppHostProjectFile = parseResult.GetValue(s_appHostOption);
-            var format = parseResult.GetValue(s_formatOption);
+            var searchTerm = GetSearchTerm(parseResult);
+            var passedAppHostProjectFile = parseResult.GetValue(_appHostOption);
+            var format = parseResult.GetValue(_formatOption);
 
             var (workingDirectory, configuredChannel, contextExitCode) = await _integrationPackageSearchService.GetPackageSearchContextAsync(passedAppHostProjectFile, cancellationToken);
             if (contextExitCode is { } exitCode)
@@ -88,7 +83,7 @@ internal sealed class IntegrationSearchCommand : BaseCommand
                 return ExitCodeConstants.FailedToAddPackage;
             }
 
-            return DisplayIntegrationSearchResults(packagesWithShortName, searchTerm, format);
+            return DisplayIntegrationResults(packagesWithShortName, searchTerm, format);
         }
         catch (ProjectLocatorException ex)
         {
@@ -114,7 +109,7 @@ internal sealed class IntegrationSearchCommand : BaseCommand
         }
     }
 
-    private int DisplayIntegrationSearchResults(IEnumerable<(string FriendlyName, NuGetPackage Package, PackageChannel Channel)> packages, string? searchTerm, OutputFormat format)
+    private int DisplayIntegrationResults(IEnumerable<(string FriendlyName, NuGetPackage Package, PackageChannel Channel)> packages, string? searchTerm, OutputFormat format)
     {
         var matches = (searchTerm is null
             ? packages.Select(p => (p.FriendlyName, p.Package, p.Channel, SearchScore: 0.0))
@@ -181,6 +176,45 @@ internal sealed class IntegrationSearchCommand : BaseCommand
         InteractionService.DisplayRenderable(table);
         return ExitCodeConstants.Success;
     }
+}
+
+internal sealed class IntegrationListCommand : IntegrationDiscoveryCommand
+{
+    public IntegrationListCommand(
+        IntegrationPackageSearchService integrationPackageSearchService,
+        IInteractionService interactionService,
+        IFeatures features,
+        ICliUpdateNotifier updateNotifier,
+        CliExecutionContext executionContext,
+        AspireCliTelemetry telemetry)
+        : base("list", AddCommandStrings.IntegrationListDescription, integrationPackageSearchService, interactionService, features, updateNotifier, executionContext, telemetry)
+    {
+    }
+
+    protected override string? GetSearchTerm(ParseResult parseResult) => null;
+}
+
+internal sealed class IntegrationSearchCommand : IntegrationDiscoveryCommand
+{
+    private readonly Argument<string> _queryArgument = new("query")
+    {
+        Description = AddCommandStrings.IntegrationSearchQueryArgumentDescription,
+        Arity = ArgumentArity.ExactlyOne
+    };
+
+    public IntegrationSearchCommand(
+        IntegrationPackageSearchService integrationPackageSearchService,
+        IInteractionService interactionService,
+        IFeatures features,
+        ICliUpdateNotifier updateNotifier,
+        CliExecutionContext executionContext,
+        AspireCliTelemetry telemetry)
+        : base("search", AddCommandStrings.IntegrationSearchDescription, integrationPackageSearchService, interactionService, features, updateNotifier, executionContext, telemetry)
+    {
+        Arguments.Add(_queryArgument);
+    }
+
+    protected override string? GetSearchTerm(ParseResult parseResult) => parseResult.GetValue(_queryArgument);
 }
 
 internal sealed class IntegrationSearchResult

--- a/src/Aspire.Cli/Commands/RootCommand.cs
+++ b/src/Aspire.Cli/Commands/RootCommand.cs
@@ -117,6 +117,7 @@ internal sealed class RootCommand : BaseRootCommand
         PsCommand psCommand,
         DescribeCommand describeCommand,
         LogsCommand logsCommand,
+        IntegrationCommand integrationCommand,
         AddCommand addCommand,
         PublishCommand publishCommand,
         DeployCommand deployCommand,
@@ -209,6 +210,7 @@ internal sealed class RootCommand : BaseRootCommand
         Subcommands.Add(psCommand);
         Subcommands.Add(describeCommand);
         Subcommands.Add(logsCommand);
+        Subcommands.Add(integrationCommand);
         Subcommands.Add(addCommand);
         Subcommands.Add(publishCommand);
         Subcommands.Add(configCommand);

--- a/src/Aspire.Cli/ExitCodeConstants.cs
+++ b/src/Aspire.Cli/ExitCodeConstants.cs
@@ -27,4 +27,5 @@ internal static class ExitCodeConstants
     public const int FailedToLoadConfiguration = 19;
     public const int FailedToStartCli = 20;
     public const int MissingRequiredArgument = 21;
+    public const int FailedToSearchIntegrations = 22;
 }

--- a/src/Aspire.Cli/JsonSourceGenerationContext.cs
+++ b/src/Aspire.Cli/JsonSourceGenerationContext.cs
@@ -46,6 +46,7 @@ namespace Aspire.Cli;
 [JsonSerializable(typeof(ApiListItem[]))]
 [JsonSerializable(typeof(ApiSearchResult[]))]
 [JsonSerializable(typeof(ApiContent))]
+[JsonSerializable(typeof(AddCommandIntegrationResult[]))]
 internal partial class JsonSourceGenerationContext : JsonSerializerContext
 {
     private static JsonSourceGenerationContext? s_relaxedEscaping;

--- a/src/Aspire.Cli/JsonSourceGenerationContext.cs
+++ b/src/Aspire.Cli/JsonSourceGenerationContext.cs
@@ -46,7 +46,7 @@ namespace Aspire.Cli;
 [JsonSerializable(typeof(ApiListItem[]))]
 [JsonSerializable(typeof(ApiSearchResult[]))]
 [JsonSerializable(typeof(ApiContent))]
-[JsonSerializable(typeof(AddCommandIntegrationResult[]))]
+[JsonSerializable(typeof(IntegrationSearchResult[]))]
 internal partial class JsonSourceGenerationContext : JsonSerializerContext
 {
     private static JsonSourceGenerationContext? s_relaxedEscaping;

--- a/src/Aspire.Cli/Program.cs
+++ b/src/Aspire.Cli/Program.cs
@@ -483,7 +483,6 @@ public class Program
         builder.Services.AddTransient<LogsCommand>();
         builder.Services.AddTransient<IntegrationPackageSearchService>();
         builder.Services.AddTransient<IntegrationCommand>();
-        builder.Services.AddTransient<IntegrationAddCommand>();
         builder.Services.AddTransient<IntegrationListCommand>();
         builder.Services.AddTransient<IntegrationSearchCommand>();
         builder.Services.AddTransient<AddCommand>();

--- a/src/Aspire.Cli/Program.cs
+++ b/src/Aspire.Cli/Program.cs
@@ -484,6 +484,7 @@ public class Program
         builder.Services.AddTransient<IntegrationPackageSearchService>();
         builder.Services.AddTransient<IntegrationCommand>();
         builder.Services.AddTransient<IntegrationAddCommand>();
+        builder.Services.AddTransient<IntegrationListCommand>();
         builder.Services.AddTransient<IntegrationSearchCommand>();
         builder.Services.AddTransient<AddCommand>();
         builder.Services.AddTransient<PublishCommand>();

--- a/src/Aspire.Cli/Program.cs
+++ b/src/Aspire.Cli/Program.cs
@@ -481,6 +481,10 @@ public class Program
         builder.Services.AddTransient<PsCommand>();
         builder.Services.AddTransient<DescribeCommand>();
         builder.Services.AddTransient<LogsCommand>();
+        builder.Services.AddTransient<IntegrationPackageSearchService>();
+        builder.Services.AddTransient<IntegrationCommand>();
+        builder.Services.AddTransient<IntegrationAddCommand>();
+        builder.Services.AddTransient<IntegrationSearchCommand>();
         builder.Services.AddTransient<AddCommand>();
         builder.Services.AddTransient<PublishCommand>();
         builder.Services.AddTransient<ConfigCommand>();

--- a/src/Aspire.Cli/Resources/AddCommandStrings.Designer.cs
+++ b/src/Aspire.Cli/Resources/AddCommandStrings.Designer.cs
@@ -93,6 +93,30 @@ namespace Aspire.Cli.Resources {
             }
         }
 
+        public static string ListOptionDescription
+        {
+            get
+            {
+                return ResourceManager.GetString("ListOptionDescription", resourceCulture);
+            }
+        }
+
+        public static string SearchOptionDescription
+        {
+            get
+            {
+                return ResourceManager.GetString("SearchOptionDescription", resourceCulture);
+            }
+        }
+
+        public static string FormatOptionDescription
+        {
+            get
+            {
+                return ResourceManager.GetString("FormatOptionDescription", resourceCulture);
+            }
+        }
+
         public static string SearchingForAspirePackages
         {
             get
@@ -186,6 +210,70 @@ namespace Aspire.Cli.Resources {
             get
             {
                 return ResourceManager.GetString("NoPackagesMatchedSearchTerm", resourceCulture);
+            }
+        }
+
+        public static string NoIntegrationPackagesMatchedSearchTerm
+        {
+            get
+            {
+                return ResourceManager.GetString("NoIntegrationPackagesMatchedSearchTerm", resourceCulture);
+            }
+        }
+
+        public static string FoundIntegrationPackages
+        {
+            get
+            {
+                return ResourceManager.GetString("FoundIntegrationPackages", resourceCulture);
+            }
+        }
+
+        public static string FoundIntegrationPackagesMatchingSearchTerm
+        {
+            get
+            {
+                return ResourceManager.GetString("FoundIntegrationPackagesMatchingSearchTerm", resourceCulture);
+            }
+        }
+
+        public static string HeaderName
+        {
+            get
+            {
+                return ResourceManager.GetString("HeaderName", resourceCulture);
+            }
+        }
+
+        public static string HeaderPackage
+        {
+            get
+            {
+                return ResourceManager.GetString("HeaderPackage", resourceCulture);
+            }
+        }
+
+        public static string HeaderVersion
+        {
+            get
+            {
+                return ResourceManager.GetString("HeaderVersion", resourceCulture);
+            }
+        }
+
+        public static string JsonRequiresListOrSearch
+        {
+            get
+            {
+                return ResourceManager.GetString("JsonRequiresListOrSearch", resourceCulture);
+            }
+        }
+
+        public static string DiscoveryOptionsCannotBeCombinedWithAddOptions
+        {
+            get
+            {
+                return ResourceManager.GetString("DiscoveryOptionsCannotBeCombinedWithAddOptions", resourceCulture);
             }
         }
 

--- a/src/Aspire.Cli/Resources/AddCommandStrings.Designer.cs
+++ b/src/Aspire.Cli/Resources/AddCommandStrings.Designer.cs
@@ -61,6 +61,30 @@ namespace Aspire.Cli.Resources {
             }
         }
 
+        public static string IntegrationCommandDescription
+        {
+            get
+            {
+                return ResourceManager.GetString("IntegrationCommandDescription", resourceCulture);
+            }
+        }
+
+        public static string IntegrationSearchDescription
+        {
+            get
+            {
+                return ResourceManager.GetString("IntegrationSearchDescription", resourceCulture);
+            }
+        }
+
+        public static string IntegrationSearchQueryArgumentDescription
+        {
+            get
+            {
+                return ResourceManager.GetString("IntegrationSearchQueryArgumentDescription", resourceCulture);
+            }
+        }
+
         public static string IntegrationArgumentDescription
         {
             get
@@ -77,6 +101,14 @@ namespace Aspire.Cli.Resources {
             }
         }
 
+        public static string IntegrationSearchAppHostOptionDescription
+        {
+            get
+            {
+                return ResourceManager.GetString("IntegrationSearchAppHostOptionDescription", resourceCulture);
+            }
+        }
+
         public static string VersionArgumentDescription
         {
             get
@@ -90,22 +122,6 @@ namespace Aspire.Cli.Resources {
             get
             {
                 return ResourceManager.GetString("SourceArgumentDescription", resourceCulture);
-            }
-        }
-
-        public static string ListOptionDescription
-        {
-            get
-            {
-                return ResourceManager.GetString("ListOptionDescription", resourceCulture);
-            }
-        }
-
-        public static string SearchOptionDescription
-        {
-            get
-            {
-                return ResourceManager.GetString("SearchOptionDescription", resourceCulture);
             }
         }
 
@@ -189,6 +205,14 @@ namespace Aspire.Cli.Resources {
             }
         }
 
+        public static string ErrorOccurredWhileSearchingIntegrations
+        {
+            get
+            {
+                return ResourceManager.GetString("ErrorOccurredWhileSearchingIntegrations", resourceCulture);
+            }
+        }
+
         public static string SelectAVersionOfPackage
         {
             get
@@ -258,22 +282,6 @@ namespace Aspire.Cli.Resources {
             get
             {
                 return ResourceManager.GetString("HeaderVersion", resourceCulture);
-            }
-        }
-
-        public static string JsonRequiresListOrSearch
-        {
-            get
-            {
-                return ResourceManager.GetString("JsonRequiresListOrSearch", resourceCulture);
-            }
-        }
-
-        public static string DiscoveryOptionsCannotBeCombinedWithAddOptions
-        {
-            get
-            {
-                return ResourceManager.GetString("DiscoveryOptionsCannotBeCombinedWithAddOptions", resourceCulture);
             }
         }
 

--- a/src/Aspire.Cli/Resources/AddCommandStrings.Designer.cs
+++ b/src/Aspire.Cli/Resources/AddCommandStrings.Designer.cs
@@ -69,6 +69,14 @@ namespace Aspire.Cli.Resources {
             }
         }
 
+        public static string IntegrationListDescription
+        {
+            get
+            {
+                return ResourceManager.GetString("IntegrationListDescription", resourceCulture);
+            }
+        }
+
         public static string IntegrationSearchDescription
         {
             get

--- a/src/Aspire.Cli/Resources/AddCommandStrings.resx
+++ b/src/Aspire.Cli/Resources/AddCommandStrings.resx
@@ -132,6 +132,15 @@
   <data name="SourceArgumentDescription" xml:space="preserve">
     <value>The NuGet source to use for the integration</value>
   </data>
+  <data name="ListOptionDescription" xml:space="preserve">
+    <value>List available integrations without adding one</value>
+  </data>
+  <data name="SearchOptionDescription" xml:space="preserve">
+    <value>Search available integrations without adding one</value>
+  </data>
+  <data name="FormatOptionDescription" xml:space="preserve">
+    <value>Output format (Table or Json)</value>
+  </data>
   <data name="SearchingForAspirePackages" xml:space="preserve">
     <value>Searching for Aspire integrations...</value>
   </data>
@@ -172,6 +181,33 @@
   <data name="NoPackagesMatchedSearchTerm" xml:space="preserve">
     <value>No packages matched your search term '{0}'. Showing all available packages.</value>
     <comment>{0} is the search term provided by the user.</comment>
+  </data>
+  <data name="NoIntegrationPackagesMatchedSearchTerm" xml:space="preserve">
+    <value>No integration packages matched '{0}'.</value>
+    <comment>{0} is the search term provided by the user.</comment>
+  </data>
+  <data name="FoundIntegrationPackages" xml:space="preserve">
+    <value>Found {0} integration package(s).</value>
+    <comment>{0} is the number of integration packages found.</comment>
+  </data>
+  <data name="FoundIntegrationPackagesMatchingSearchTerm" xml:space="preserve">
+    <value>Found {0} integration package(s) matching '{1}'.</value>
+    <comment>{0} is the number of integration packages found, {1} is the search term provided by the user.</comment>
+  </data>
+  <data name="HeaderName" xml:space="preserve">
+    <value>Name</value>
+  </data>
+  <data name="HeaderPackage" xml:space="preserve">
+    <value>Package</value>
+  </data>
+  <data name="HeaderVersion" xml:space="preserve">
+    <value>Version</value>
+  </data>
+  <data name="JsonRequiresListOrSearch" xml:space="preserve">
+    <value>JSON output must be used with --list or --search.</value>
+  </data>
+  <data name="DiscoveryOptionsCannotBeCombinedWithAddOptions" xml:space="preserve">
+    <value>The --list and --search options cannot be combined with an integration name, --version, or --source.</value>
   </data>
   <data name="SpecifiedVersionNotFoundForPackage" xml:space="preserve">
     <value>The requested version '{1}' was not found for package '{0}'.</value>

--- a/src/Aspire.Cli/Resources/AddCommandStrings.resx
+++ b/src/Aspire.Cli/Resources/AddCommandStrings.resx
@@ -123,11 +123,14 @@
   <data name="IntegrationCommandDescription" xml:space="preserve">
     <value>Manage Aspire hosting integrations</value>
   </data>
+  <data name="IntegrationListDescription" xml:space="preserve">
+    <value>List available Aspire hosting integrations</value>
+  </data>
   <data name="IntegrationSearchDescription" xml:space="preserve">
     <value>Search available Aspire hosting integrations</value>
   </data>
   <data name="IntegrationSearchQueryArgumentDescription" xml:space="preserve">
-    <value>The integration search query. Omit to list all integrations.</value>
+    <value>The integration search query.</value>
   </data>
   <data name="IntegrationArgumentDescription" xml:space="preserve">
     <value>The name of the integration to add (e.g. redis, postgres)</value>

--- a/src/Aspire.Cli/Resources/AddCommandStrings.resx
+++ b/src/Aspire.Cli/Resources/AddCommandStrings.resx
@@ -120,23 +120,29 @@
   <data name="Description" xml:space="preserve">
     <value>Add a hosting integration to the AppHost</value>
   </data>
+  <data name="IntegrationCommandDescription" xml:space="preserve">
+    <value>Manage Aspire hosting integrations</value>
+  </data>
+  <data name="IntegrationSearchDescription" xml:space="preserve">
+    <value>Search available Aspire hosting integrations</value>
+  </data>
+  <data name="IntegrationSearchQueryArgumentDescription" xml:space="preserve">
+    <value>The integration search query. Omit to list all integrations.</value>
+  </data>
   <data name="IntegrationArgumentDescription" xml:space="preserve">
     <value>The name of the integration to add (e.g. redis, postgres)</value>
   </data>
   <data name="ProjectArgumentDescription" xml:space="preserve">
     <value>The Aspire AppHost project file, or a directory to search, to add the integration to</value>
   </data>
+  <data name="IntegrationSearchAppHostOptionDescription" xml:space="preserve">
+    <value>The Aspire AppHost project file, or a directory to search, for channel-aware integration discovery</value>
+  </data>
   <data name="VersionArgumentDescription" xml:space="preserve">
     <value>The version of the integration to add</value>
   </data>
   <data name="SourceArgumentDescription" xml:space="preserve">
     <value>The NuGet source to use for the integration</value>
-  </data>
-  <data name="ListOptionDescription" xml:space="preserve">
-    <value>List available integrations without adding one</value>
-  </data>
-  <data name="SearchOptionDescription" xml:space="preserve">
-    <value>Search available integrations without adding one</value>
   </data>
   <data name="FormatOptionDescription" xml:space="preserve">
     <value>Output format (Table or Json)</value>
@@ -171,6 +177,9 @@
   <data name="ErrorOccurredWhileAddingPackage" xml:space="preserve">
     <value>An error occurred while adding the package: {0}</value>
   </data>
+  <data name="ErrorOccurredWhileSearchingIntegrations" xml:space="preserve">
+    <value>An error occurred while searching integrations: {0}</value>
+  </data>
   <data name="SelectAVersionOfPackage" xml:space="preserve">
     <value>Select a version of {0}:</value>
     <comment>{0} is the package name.</comment>
@@ -202,12 +211,6 @@
   </data>
   <data name="HeaderVersion" xml:space="preserve">
     <value>Version</value>
-  </data>
-  <data name="JsonRequiresListOrSearch" xml:space="preserve">
-    <value>JSON output must be used with --list or --search.</value>
-  </data>
-  <data name="DiscoveryOptionsCannotBeCombinedWithAddOptions" xml:space="preserve">
-    <value>The --list and --search options cannot be combined with an integration name, --version, or --source.</value>
   </data>
   <data name="SpecifiedVersionNotFoundForPackage" xml:space="preserve">
     <value>The requested version '{1}' was not found for package '{0}'.</value>

--- a/src/Aspire.Cli/Resources/xlf/AddCommandStrings.cs.xlf
+++ b/src/Aspire.Cli/Resources/xlf/AddCommandStrings.cs.xlf
@@ -12,9 +12,44 @@
         <target state="needs-review-translation">Přidejte do hostitele aplikací Aspire integraci hostování.</target>
         <note />
       </trans-unit>
+      <trans-unit id="DiscoveryOptionsCannotBeCombinedWithAddOptions">
+        <source>The --list and --search options cannot be combined with an integration name, --version, or --source.</source>
+        <target state="new">The --list and --search options cannot be combined with an integration name, --version, or --source.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ErrorOccurredWhileAddingPackage">
         <source>An error occurred while adding the package: {0}</source>
         <target state="translated">Při přidávání balíčku došlo k chybě: {0}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FormatOptionDescription">
+        <source>Output format (Table or Json)</source>
+        <target state="new">Output format (Table or Json)</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FoundIntegrationPackages">
+        <source>Found {0} integration package(s).</source>
+        <target state="new">Found {0} integration package(s).</target>
+        <note>{0} is the number of integration packages found.</note>
+      </trans-unit>
+      <trans-unit id="FoundIntegrationPackagesMatchingSearchTerm">
+        <source>Found {0} integration package(s) matching '{1}'.</source>
+        <target state="new">Found {0} integration package(s) matching '{1}'.</target>
+        <note>{0} is the number of integration packages found, {1} is the search term provided by the user.</note>
+      </trans-unit>
+      <trans-unit id="HeaderName">
+        <source>Name</source>
+        <target state="new">Name</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HeaderPackage">
+        <source>Package</source>
+        <target state="new">Package</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HeaderVersion">
+        <source>Version</source>
+        <target state="new">Version</target>
         <note />
       </trans-unit>
       <trans-unit id="IntegrationArgumentDescription">
@@ -22,10 +57,25 @@
         <target state="needs-review-translation">Název integrace, která se má přidat (např. redis, postgres).</target>
         <note />
       </trans-unit>
+      <trans-unit id="JsonRequiresListOrSearch">
+        <source>JSON output must be used with --list or --search.</source>
+        <target state="new">JSON output must be used with --list or --search.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ListOptionDescription">
+        <source>List available integrations without adding one</source>
+        <target state="new">List available integrations without adding one</target>
+        <note />
+      </trans-unit>
       <trans-unit id="NoIntegrationPackagesFound">
         <source>No integration packages were found. Please check your internet connection or NuGet source configuration.</source>
         <target state="translated">Nenašly se žádné integrační balíčky. Zkontrolujte prosím připojení k internetu nebo zdrojovou konfiguraci NuGet.</target>
         <note />
+      </trans-unit>
+      <trans-unit id="NoIntegrationPackagesMatchedSearchTerm">
+        <source>No integration packages matched '{0}'.</source>
+        <target state="new">No integration packages matched '{0}'.</target>
+        <note>{0} is the search term provided by the user.</note>
       </trans-unit>
       <trans-unit id="NoPackagesFound">
         <source>No packages found.</source>
@@ -50,6 +100,11 @@
       <trans-unit id="ProjectArgumentDescription">
         <source>The Aspire AppHost project file, or a directory to search, to add the integration to</source>
         <target state="needs-review-translation">Cesta k souboru projektu, do které se má integrace přidat</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SearchOptionDescription">
+        <source>Search available integrations without adding one</source>
+        <target state="new">Search available integrations without adding one</target>
         <note />
       </trans-unit>
       <trans-unit id="SearchingForAspirePackages">

--- a/src/Aspire.Cli/Resources/xlf/AddCommandStrings.cs.xlf
+++ b/src/Aspire.Cli/Resources/xlf/AddCommandStrings.cs.xlf
@@ -12,14 +12,14 @@
         <target state="needs-review-translation">Přidejte do hostitele aplikací Aspire integraci hostování.</target>
         <note />
       </trans-unit>
-      <trans-unit id="DiscoveryOptionsCannotBeCombinedWithAddOptions">
-        <source>The --list and --search options cannot be combined with an integration name, --version, or --source.</source>
-        <target state="new">The --list and --search options cannot be combined with an integration name, --version, or --source.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ErrorOccurredWhileAddingPackage">
         <source>An error occurred while adding the package: {0}</source>
         <target state="translated">Při přidávání balíčku došlo k chybě: {0}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ErrorOccurredWhileSearchingIntegrations">
+        <source>An error occurred while searching integrations: {0}</source>
+        <target state="new">An error occurred while searching integrations: {0}</target>
         <note />
       </trans-unit>
       <trans-unit id="FormatOptionDescription">
@@ -57,14 +57,24 @@
         <target state="needs-review-translation">Název integrace, která se má přidat (např. redis, postgres).</target>
         <note />
       </trans-unit>
-      <trans-unit id="JsonRequiresListOrSearch">
-        <source>JSON output must be used with --list or --search.</source>
-        <target state="new">JSON output must be used with --list or --search.</target>
+      <trans-unit id="IntegrationCommandDescription">
+        <source>Manage Aspire hosting integrations</source>
+        <target state="new">Manage Aspire hosting integrations</target>
         <note />
       </trans-unit>
-      <trans-unit id="ListOptionDescription">
-        <source>List available integrations without adding one</source>
-        <target state="new">List available integrations without adding one</target>
+      <trans-unit id="IntegrationSearchAppHostOptionDescription">
+        <source>The Aspire AppHost project file, or a directory to search, for channel-aware integration discovery</source>
+        <target state="new">The Aspire AppHost project file, or a directory to search, for channel-aware integration discovery</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="IntegrationSearchDescription">
+        <source>Search available Aspire hosting integrations</source>
+        <target state="new">Search available Aspire hosting integrations</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="IntegrationSearchQueryArgumentDescription">
+        <source>The integration search query. Omit to list all integrations.</source>
+        <target state="new">The integration search query. Omit to list all integrations.</target>
         <note />
       </trans-unit>
       <trans-unit id="NoIntegrationPackagesFound">
@@ -100,11 +110,6 @@
       <trans-unit id="ProjectArgumentDescription">
         <source>The Aspire AppHost project file, or a directory to search, to add the integration to</source>
         <target state="needs-review-translation">Cesta k souboru projektu, do které se má integrace přidat</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="SearchOptionDescription">
-        <source>Search available integrations without adding one</source>
-        <target state="new">Search available integrations without adding one</target>
         <note />
       </trans-unit>
       <trans-unit id="SearchingForAspirePackages">

--- a/src/Aspire.Cli/Resources/xlf/AddCommandStrings.cs.xlf
+++ b/src/Aspire.Cli/Resources/xlf/AddCommandStrings.cs.xlf
@@ -62,6 +62,11 @@
         <target state="new">Manage Aspire hosting integrations</target>
         <note />
       </trans-unit>
+      <trans-unit id="IntegrationListDescription">
+        <source>List available Aspire hosting integrations</source>
+        <target state="new">List available Aspire hosting integrations</target>
+        <note />
+      </trans-unit>
       <trans-unit id="IntegrationSearchAppHostOptionDescription">
         <source>The Aspire AppHost project file, or a directory to search, for channel-aware integration discovery</source>
         <target state="new">The Aspire AppHost project file, or a directory to search, for channel-aware integration discovery</target>
@@ -73,8 +78,8 @@
         <note />
       </trans-unit>
       <trans-unit id="IntegrationSearchQueryArgumentDescription">
-        <source>The integration search query. Omit to list all integrations.</source>
-        <target state="new">The integration search query. Omit to list all integrations.</target>
+        <source>The integration search query.</source>
+        <target state="new">The integration search query.</target>
         <note />
       </trans-unit>
       <trans-unit id="NoIntegrationPackagesFound">

--- a/src/Aspire.Cli/Resources/xlf/AddCommandStrings.de.xlf
+++ b/src/Aspire.Cli/Resources/xlf/AddCommandStrings.de.xlf
@@ -12,9 +12,44 @@
         <target state="needs-review-translation">Fügen Sie dem Aspire AppHost eine Hosting-Integration hinzu.</target>
         <note />
       </trans-unit>
+      <trans-unit id="DiscoveryOptionsCannotBeCombinedWithAddOptions">
+        <source>The --list and --search options cannot be combined with an integration name, --version, or --source.</source>
+        <target state="new">The --list and --search options cannot be combined with an integration name, --version, or --source.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ErrorOccurredWhileAddingPackage">
         <source>An error occurred while adding the package: {0}</source>
         <target state="translated">Fehler beim Hinzufügen des Pakets: {0}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FormatOptionDescription">
+        <source>Output format (Table or Json)</source>
+        <target state="new">Output format (Table or Json)</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FoundIntegrationPackages">
+        <source>Found {0} integration package(s).</source>
+        <target state="new">Found {0} integration package(s).</target>
+        <note>{0} is the number of integration packages found.</note>
+      </trans-unit>
+      <trans-unit id="FoundIntegrationPackagesMatchingSearchTerm">
+        <source>Found {0} integration package(s) matching '{1}'.</source>
+        <target state="new">Found {0} integration package(s) matching '{1}'.</target>
+        <note>{0} is the number of integration packages found, {1} is the search term provided by the user.</note>
+      </trans-unit>
+      <trans-unit id="HeaderName">
+        <source>Name</source>
+        <target state="new">Name</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HeaderPackage">
+        <source>Package</source>
+        <target state="new">Package</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HeaderVersion">
+        <source>Version</source>
+        <target state="new">Version</target>
         <note />
       </trans-unit>
       <trans-unit id="IntegrationArgumentDescription">
@@ -22,10 +57,25 @@
         <target state="needs-review-translation">Der Name der Integration, die Sie hinzufügen möchten (z. B. redis, postgres).</target>
         <note />
       </trans-unit>
+      <trans-unit id="JsonRequiresListOrSearch">
+        <source>JSON output must be used with --list or --search.</source>
+        <target state="new">JSON output must be used with --list or --search.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ListOptionDescription">
+        <source>List available integrations without adding one</source>
+        <target state="new">List available integrations without adding one</target>
+        <note />
+      </trans-unit>
       <trans-unit id="NoIntegrationPackagesFound">
         <source>No integration packages were found. Please check your internet connection or NuGet source configuration.</source>
         <target state="translated">Es wurden keine Integrationspakete gefunden. Überprüfen Sie Ihre Internetverbindung oder NuGet-Quellkonfiguration.</target>
         <note />
+      </trans-unit>
+      <trans-unit id="NoIntegrationPackagesMatchedSearchTerm">
+        <source>No integration packages matched '{0}'.</source>
+        <target state="new">No integration packages matched '{0}'.</target>
+        <note>{0} is the search term provided by the user.</note>
       </trans-unit>
       <trans-unit id="NoPackagesFound">
         <source>No packages found.</source>
@@ -50,6 +100,11 @@
       <trans-unit id="ProjectArgumentDescription">
         <source>The Aspire AppHost project file, or a directory to search, to add the integration to</source>
         <target state="needs-review-translation">Der Pfad zur Projektdatei, der die Integration hinzugefügt werden soll.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SearchOptionDescription">
+        <source>Search available integrations without adding one</source>
+        <target state="new">Search available integrations without adding one</target>
         <note />
       </trans-unit>
       <trans-unit id="SearchingForAspirePackages">

--- a/src/Aspire.Cli/Resources/xlf/AddCommandStrings.de.xlf
+++ b/src/Aspire.Cli/Resources/xlf/AddCommandStrings.de.xlf
@@ -12,14 +12,14 @@
         <target state="needs-review-translation">Fügen Sie dem Aspire AppHost eine Hosting-Integration hinzu.</target>
         <note />
       </trans-unit>
-      <trans-unit id="DiscoveryOptionsCannotBeCombinedWithAddOptions">
-        <source>The --list and --search options cannot be combined with an integration name, --version, or --source.</source>
-        <target state="new">The --list and --search options cannot be combined with an integration name, --version, or --source.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ErrorOccurredWhileAddingPackage">
         <source>An error occurred while adding the package: {0}</source>
         <target state="translated">Fehler beim Hinzufügen des Pakets: {0}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ErrorOccurredWhileSearchingIntegrations">
+        <source>An error occurred while searching integrations: {0}</source>
+        <target state="new">An error occurred while searching integrations: {0}</target>
         <note />
       </trans-unit>
       <trans-unit id="FormatOptionDescription">
@@ -57,14 +57,24 @@
         <target state="needs-review-translation">Der Name der Integration, die Sie hinzufügen möchten (z. B. redis, postgres).</target>
         <note />
       </trans-unit>
-      <trans-unit id="JsonRequiresListOrSearch">
-        <source>JSON output must be used with --list or --search.</source>
-        <target state="new">JSON output must be used with --list or --search.</target>
+      <trans-unit id="IntegrationCommandDescription">
+        <source>Manage Aspire hosting integrations</source>
+        <target state="new">Manage Aspire hosting integrations</target>
         <note />
       </trans-unit>
-      <trans-unit id="ListOptionDescription">
-        <source>List available integrations without adding one</source>
-        <target state="new">List available integrations without adding one</target>
+      <trans-unit id="IntegrationSearchAppHostOptionDescription">
+        <source>The Aspire AppHost project file, or a directory to search, for channel-aware integration discovery</source>
+        <target state="new">The Aspire AppHost project file, or a directory to search, for channel-aware integration discovery</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="IntegrationSearchDescription">
+        <source>Search available Aspire hosting integrations</source>
+        <target state="new">Search available Aspire hosting integrations</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="IntegrationSearchQueryArgumentDescription">
+        <source>The integration search query. Omit to list all integrations.</source>
+        <target state="new">The integration search query. Omit to list all integrations.</target>
         <note />
       </trans-unit>
       <trans-unit id="NoIntegrationPackagesFound">
@@ -100,11 +110,6 @@
       <trans-unit id="ProjectArgumentDescription">
         <source>The Aspire AppHost project file, or a directory to search, to add the integration to</source>
         <target state="needs-review-translation">Der Pfad zur Projektdatei, der die Integration hinzugefügt werden soll.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="SearchOptionDescription">
-        <source>Search available integrations without adding one</source>
-        <target state="new">Search available integrations without adding one</target>
         <note />
       </trans-unit>
       <trans-unit id="SearchingForAspirePackages">

--- a/src/Aspire.Cli/Resources/xlf/AddCommandStrings.de.xlf
+++ b/src/Aspire.Cli/Resources/xlf/AddCommandStrings.de.xlf
@@ -62,6 +62,11 @@
         <target state="new">Manage Aspire hosting integrations</target>
         <note />
       </trans-unit>
+      <trans-unit id="IntegrationListDescription">
+        <source>List available Aspire hosting integrations</source>
+        <target state="new">List available Aspire hosting integrations</target>
+        <note />
+      </trans-unit>
       <trans-unit id="IntegrationSearchAppHostOptionDescription">
         <source>The Aspire AppHost project file, or a directory to search, for channel-aware integration discovery</source>
         <target state="new">The Aspire AppHost project file, or a directory to search, for channel-aware integration discovery</target>
@@ -73,8 +78,8 @@
         <note />
       </trans-unit>
       <trans-unit id="IntegrationSearchQueryArgumentDescription">
-        <source>The integration search query. Omit to list all integrations.</source>
-        <target state="new">The integration search query. Omit to list all integrations.</target>
+        <source>The integration search query.</source>
+        <target state="new">The integration search query.</target>
         <note />
       </trans-unit>
       <trans-unit id="NoIntegrationPackagesFound">

--- a/src/Aspire.Cli/Resources/xlf/AddCommandStrings.es.xlf
+++ b/src/Aspire.Cli/Resources/xlf/AddCommandStrings.es.xlf
@@ -12,9 +12,44 @@
         <target state="needs-review-translation">Agregue una integración de hospedaje a Aspire AppHost.</target>
         <note />
       </trans-unit>
+      <trans-unit id="DiscoveryOptionsCannotBeCombinedWithAddOptions">
+        <source>The --list and --search options cannot be combined with an integration name, --version, or --source.</source>
+        <target state="new">The --list and --search options cannot be combined with an integration name, --version, or --source.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ErrorOccurredWhileAddingPackage">
         <source>An error occurred while adding the package: {0}</source>
         <target state="translated">Se produjo un error al agregar el paquete: {0}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FormatOptionDescription">
+        <source>Output format (Table or Json)</source>
+        <target state="new">Output format (Table or Json)</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FoundIntegrationPackages">
+        <source>Found {0} integration package(s).</source>
+        <target state="new">Found {0} integration package(s).</target>
+        <note>{0} is the number of integration packages found.</note>
+      </trans-unit>
+      <trans-unit id="FoundIntegrationPackagesMatchingSearchTerm">
+        <source>Found {0} integration package(s) matching '{1}'.</source>
+        <target state="new">Found {0} integration package(s) matching '{1}'.</target>
+        <note>{0} is the number of integration packages found, {1} is the search term provided by the user.</note>
+      </trans-unit>
+      <trans-unit id="HeaderName">
+        <source>Name</source>
+        <target state="new">Name</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HeaderPackage">
+        <source>Package</source>
+        <target state="new">Package</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HeaderVersion">
+        <source>Version</source>
+        <target state="new">Version</target>
         <note />
       </trans-unit>
       <trans-unit id="IntegrationArgumentDescription">
@@ -22,10 +57,25 @@
         <target state="needs-review-translation">El nombre de la integración que se va a agregar (por ejemplo, redis, postgres).</target>
         <note />
       </trans-unit>
+      <trans-unit id="JsonRequiresListOrSearch">
+        <source>JSON output must be used with --list or --search.</source>
+        <target state="new">JSON output must be used with --list or --search.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ListOptionDescription">
+        <source>List available integrations without adding one</source>
+        <target state="new">List available integrations without adding one</target>
+        <note />
+      </trans-unit>
       <trans-unit id="NoIntegrationPackagesFound">
         <source>No integration packages were found. Please check your internet connection or NuGet source configuration.</source>
         <target state="translated">No se encontraron paquetes de integración. Compruebe la conexión a Internet o la configuración de origen de NuGet.</target>
         <note />
+      </trans-unit>
+      <trans-unit id="NoIntegrationPackagesMatchedSearchTerm">
+        <source>No integration packages matched '{0}'.</source>
+        <target state="new">No integration packages matched '{0}'.</target>
+        <note>{0} is the search term provided by the user.</note>
       </trans-unit>
       <trans-unit id="NoPackagesFound">
         <source>No packages found.</source>
@@ -50,6 +100,11 @@
       <trans-unit id="ProjectArgumentDescription">
         <source>The Aspire AppHost project file, or a directory to search, to add the integration to</source>
         <target state="needs-review-translation">La ruta al archivo del proyecto al que se agregará la integración.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SearchOptionDescription">
+        <source>Search available integrations without adding one</source>
+        <target state="new">Search available integrations without adding one</target>
         <note />
       </trans-unit>
       <trans-unit id="SearchingForAspirePackages">

--- a/src/Aspire.Cli/Resources/xlf/AddCommandStrings.es.xlf
+++ b/src/Aspire.Cli/Resources/xlf/AddCommandStrings.es.xlf
@@ -12,14 +12,14 @@
         <target state="needs-review-translation">Agregue una integración de hospedaje a Aspire AppHost.</target>
         <note />
       </trans-unit>
-      <trans-unit id="DiscoveryOptionsCannotBeCombinedWithAddOptions">
-        <source>The --list and --search options cannot be combined with an integration name, --version, or --source.</source>
-        <target state="new">The --list and --search options cannot be combined with an integration name, --version, or --source.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ErrorOccurredWhileAddingPackage">
         <source>An error occurred while adding the package: {0}</source>
         <target state="translated">Se produjo un error al agregar el paquete: {0}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ErrorOccurredWhileSearchingIntegrations">
+        <source>An error occurred while searching integrations: {0}</source>
+        <target state="new">An error occurred while searching integrations: {0}</target>
         <note />
       </trans-unit>
       <trans-unit id="FormatOptionDescription">
@@ -57,14 +57,24 @@
         <target state="needs-review-translation">El nombre de la integración que se va a agregar (por ejemplo, redis, postgres).</target>
         <note />
       </trans-unit>
-      <trans-unit id="JsonRequiresListOrSearch">
-        <source>JSON output must be used with --list or --search.</source>
-        <target state="new">JSON output must be used with --list or --search.</target>
+      <trans-unit id="IntegrationCommandDescription">
+        <source>Manage Aspire hosting integrations</source>
+        <target state="new">Manage Aspire hosting integrations</target>
         <note />
       </trans-unit>
-      <trans-unit id="ListOptionDescription">
-        <source>List available integrations without adding one</source>
-        <target state="new">List available integrations without adding one</target>
+      <trans-unit id="IntegrationSearchAppHostOptionDescription">
+        <source>The Aspire AppHost project file, or a directory to search, for channel-aware integration discovery</source>
+        <target state="new">The Aspire AppHost project file, or a directory to search, for channel-aware integration discovery</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="IntegrationSearchDescription">
+        <source>Search available Aspire hosting integrations</source>
+        <target state="new">Search available Aspire hosting integrations</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="IntegrationSearchQueryArgumentDescription">
+        <source>The integration search query. Omit to list all integrations.</source>
+        <target state="new">The integration search query. Omit to list all integrations.</target>
         <note />
       </trans-unit>
       <trans-unit id="NoIntegrationPackagesFound">
@@ -100,11 +110,6 @@
       <trans-unit id="ProjectArgumentDescription">
         <source>The Aspire AppHost project file, or a directory to search, to add the integration to</source>
         <target state="needs-review-translation">La ruta al archivo del proyecto al que se agregará la integración.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="SearchOptionDescription">
-        <source>Search available integrations without adding one</source>
-        <target state="new">Search available integrations without adding one</target>
         <note />
       </trans-unit>
       <trans-unit id="SearchingForAspirePackages">

--- a/src/Aspire.Cli/Resources/xlf/AddCommandStrings.es.xlf
+++ b/src/Aspire.Cli/Resources/xlf/AddCommandStrings.es.xlf
@@ -62,6 +62,11 @@
         <target state="new">Manage Aspire hosting integrations</target>
         <note />
       </trans-unit>
+      <trans-unit id="IntegrationListDescription">
+        <source>List available Aspire hosting integrations</source>
+        <target state="new">List available Aspire hosting integrations</target>
+        <note />
+      </trans-unit>
       <trans-unit id="IntegrationSearchAppHostOptionDescription">
         <source>The Aspire AppHost project file, or a directory to search, for channel-aware integration discovery</source>
         <target state="new">The Aspire AppHost project file, or a directory to search, for channel-aware integration discovery</target>
@@ -73,8 +78,8 @@
         <note />
       </trans-unit>
       <trans-unit id="IntegrationSearchQueryArgumentDescription">
-        <source>The integration search query. Omit to list all integrations.</source>
-        <target state="new">The integration search query. Omit to list all integrations.</target>
+        <source>The integration search query.</source>
+        <target state="new">The integration search query.</target>
         <note />
       </trans-unit>
       <trans-unit id="NoIntegrationPackagesFound">

--- a/src/Aspire.Cli/Resources/xlf/AddCommandStrings.fr.xlf
+++ b/src/Aspire.Cli/Resources/xlf/AddCommandStrings.fr.xlf
@@ -12,9 +12,44 @@
         <target state="needs-review-translation">Ajoutez une intégration d’hébergement à l’Aspire AppHost.</target>
         <note />
       </trans-unit>
+      <trans-unit id="DiscoveryOptionsCannotBeCombinedWithAddOptions">
+        <source>The --list and --search options cannot be combined with an integration name, --version, or --source.</source>
+        <target state="new">The --list and --search options cannot be combined with an integration name, --version, or --source.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ErrorOccurredWhileAddingPackage">
         <source>An error occurred while adding the package: {0}</source>
         <target state="translated">Une erreur s’est produite durant l’ajout du package : {0}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FormatOptionDescription">
+        <source>Output format (Table or Json)</source>
+        <target state="new">Output format (Table or Json)</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FoundIntegrationPackages">
+        <source>Found {0} integration package(s).</source>
+        <target state="new">Found {0} integration package(s).</target>
+        <note>{0} is the number of integration packages found.</note>
+      </trans-unit>
+      <trans-unit id="FoundIntegrationPackagesMatchingSearchTerm">
+        <source>Found {0} integration package(s) matching '{1}'.</source>
+        <target state="new">Found {0} integration package(s) matching '{1}'.</target>
+        <note>{0} is the number of integration packages found, {1} is the search term provided by the user.</note>
+      </trans-unit>
+      <trans-unit id="HeaderName">
+        <source>Name</source>
+        <target state="new">Name</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HeaderPackage">
+        <source>Package</source>
+        <target state="new">Package</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HeaderVersion">
+        <source>Version</source>
+        <target state="new">Version</target>
         <note />
       </trans-unit>
       <trans-unit id="IntegrationArgumentDescription">
@@ -22,10 +57,25 @@
         <target state="needs-review-translation">Nom de l’intégration à ajouter (par exemple, redis, postgres).</target>
         <note />
       </trans-unit>
+      <trans-unit id="JsonRequiresListOrSearch">
+        <source>JSON output must be used with --list or --search.</source>
+        <target state="new">JSON output must be used with --list or --search.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ListOptionDescription">
+        <source>List available integrations without adding one</source>
+        <target state="new">List available integrations without adding one</target>
+        <note />
+      </trans-unit>
       <trans-unit id="NoIntegrationPackagesFound">
         <source>No integration packages were found. Please check your internet connection or NuGet source configuration.</source>
         <target state="translated">Aucun package d’intégration n’a été trouvé. Veuillez vérifier votre connexion Internet ou la configuration de la source NuGet.</target>
         <note />
+      </trans-unit>
+      <trans-unit id="NoIntegrationPackagesMatchedSearchTerm">
+        <source>No integration packages matched '{0}'.</source>
+        <target state="new">No integration packages matched '{0}'.</target>
+        <note>{0} is the search term provided by the user.</note>
       </trans-unit>
       <trans-unit id="NoPackagesFound">
         <source>No packages found.</source>
@@ -50,6 +100,11 @@
       <trans-unit id="ProjectArgumentDescription">
         <source>The Aspire AppHost project file, or a directory to search, to add the integration to</source>
         <target state="needs-review-translation">Chemin du fichier projet auquel ajouter l’intégration.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SearchOptionDescription">
+        <source>Search available integrations without adding one</source>
+        <target state="new">Search available integrations without adding one</target>
         <note />
       </trans-unit>
       <trans-unit id="SearchingForAspirePackages">

--- a/src/Aspire.Cli/Resources/xlf/AddCommandStrings.fr.xlf
+++ b/src/Aspire.Cli/Resources/xlf/AddCommandStrings.fr.xlf
@@ -62,6 +62,11 @@
         <target state="new">Manage Aspire hosting integrations</target>
         <note />
       </trans-unit>
+      <trans-unit id="IntegrationListDescription">
+        <source>List available Aspire hosting integrations</source>
+        <target state="new">List available Aspire hosting integrations</target>
+        <note />
+      </trans-unit>
       <trans-unit id="IntegrationSearchAppHostOptionDescription">
         <source>The Aspire AppHost project file, or a directory to search, for channel-aware integration discovery</source>
         <target state="new">The Aspire AppHost project file, or a directory to search, for channel-aware integration discovery</target>
@@ -73,8 +78,8 @@
         <note />
       </trans-unit>
       <trans-unit id="IntegrationSearchQueryArgumentDescription">
-        <source>The integration search query. Omit to list all integrations.</source>
-        <target state="new">The integration search query. Omit to list all integrations.</target>
+        <source>The integration search query.</source>
+        <target state="new">The integration search query.</target>
         <note />
       </trans-unit>
       <trans-unit id="NoIntegrationPackagesFound">

--- a/src/Aspire.Cli/Resources/xlf/AddCommandStrings.fr.xlf
+++ b/src/Aspire.Cli/Resources/xlf/AddCommandStrings.fr.xlf
@@ -12,14 +12,14 @@
         <target state="needs-review-translation">Ajoutez une intégration d’hébergement à l’Aspire AppHost.</target>
         <note />
       </trans-unit>
-      <trans-unit id="DiscoveryOptionsCannotBeCombinedWithAddOptions">
-        <source>The --list and --search options cannot be combined with an integration name, --version, or --source.</source>
-        <target state="new">The --list and --search options cannot be combined with an integration name, --version, or --source.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ErrorOccurredWhileAddingPackage">
         <source>An error occurred while adding the package: {0}</source>
         <target state="translated">Une erreur s’est produite durant l’ajout du package : {0}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ErrorOccurredWhileSearchingIntegrations">
+        <source>An error occurred while searching integrations: {0}</source>
+        <target state="new">An error occurred while searching integrations: {0}</target>
         <note />
       </trans-unit>
       <trans-unit id="FormatOptionDescription">
@@ -57,14 +57,24 @@
         <target state="needs-review-translation">Nom de l’intégration à ajouter (par exemple, redis, postgres).</target>
         <note />
       </trans-unit>
-      <trans-unit id="JsonRequiresListOrSearch">
-        <source>JSON output must be used with --list or --search.</source>
-        <target state="new">JSON output must be used with --list or --search.</target>
+      <trans-unit id="IntegrationCommandDescription">
+        <source>Manage Aspire hosting integrations</source>
+        <target state="new">Manage Aspire hosting integrations</target>
         <note />
       </trans-unit>
-      <trans-unit id="ListOptionDescription">
-        <source>List available integrations without adding one</source>
-        <target state="new">List available integrations without adding one</target>
+      <trans-unit id="IntegrationSearchAppHostOptionDescription">
+        <source>The Aspire AppHost project file, or a directory to search, for channel-aware integration discovery</source>
+        <target state="new">The Aspire AppHost project file, or a directory to search, for channel-aware integration discovery</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="IntegrationSearchDescription">
+        <source>Search available Aspire hosting integrations</source>
+        <target state="new">Search available Aspire hosting integrations</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="IntegrationSearchQueryArgumentDescription">
+        <source>The integration search query. Omit to list all integrations.</source>
+        <target state="new">The integration search query. Omit to list all integrations.</target>
         <note />
       </trans-unit>
       <trans-unit id="NoIntegrationPackagesFound">
@@ -100,11 +110,6 @@
       <trans-unit id="ProjectArgumentDescription">
         <source>The Aspire AppHost project file, or a directory to search, to add the integration to</source>
         <target state="needs-review-translation">Chemin du fichier projet auquel ajouter l’intégration.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="SearchOptionDescription">
-        <source>Search available integrations without adding one</source>
-        <target state="new">Search available integrations without adding one</target>
         <note />
       </trans-unit>
       <trans-unit id="SearchingForAspirePackages">

--- a/src/Aspire.Cli/Resources/xlf/AddCommandStrings.it.xlf
+++ b/src/Aspire.Cli/Resources/xlf/AddCommandStrings.it.xlf
@@ -12,9 +12,44 @@
         <target state="needs-review-translation">Aggiungere un'integrazione di hosting all'AppHost Aspire.</target>
         <note />
       </trans-unit>
+      <trans-unit id="DiscoveryOptionsCannotBeCombinedWithAddOptions">
+        <source>The --list and --search options cannot be combined with an integration name, --version, or --source.</source>
+        <target state="new">The --list and --search options cannot be combined with an integration name, --version, or --source.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ErrorOccurredWhileAddingPackage">
         <source>An error occurred while adding the package: {0}</source>
         <target state="translated">Errore durante l'aggiunta del pacchetto: {0}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FormatOptionDescription">
+        <source>Output format (Table or Json)</source>
+        <target state="new">Output format (Table or Json)</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FoundIntegrationPackages">
+        <source>Found {0} integration package(s).</source>
+        <target state="new">Found {0} integration package(s).</target>
+        <note>{0} is the number of integration packages found.</note>
+      </trans-unit>
+      <trans-unit id="FoundIntegrationPackagesMatchingSearchTerm">
+        <source>Found {0} integration package(s) matching '{1}'.</source>
+        <target state="new">Found {0} integration package(s) matching '{1}'.</target>
+        <note>{0} is the number of integration packages found, {1} is the search term provided by the user.</note>
+      </trans-unit>
+      <trans-unit id="HeaderName">
+        <source>Name</source>
+        <target state="new">Name</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HeaderPackage">
+        <source>Package</source>
+        <target state="new">Package</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HeaderVersion">
+        <source>Version</source>
+        <target state="new">Version</target>
         <note />
       </trans-unit>
       <trans-unit id="IntegrationArgumentDescription">
@@ -22,10 +57,25 @@
         <target state="needs-review-translation">Nome dell'integrazione da aggiungere, (ad esempio redis, postgres).</target>
         <note />
       </trans-unit>
+      <trans-unit id="JsonRequiresListOrSearch">
+        <source>JSON output must be used with --list or --search.</source>
+        <target state="new">JSON output must be used with --list or --search.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ListOptionDescription">
+        <source>List available integrations without adding one</source>
+        <target state="new">List available integrations without adding one</target>
+        <note />
+      </trans-unit>
       <trans-unit id="NoIntegrationPackagesFound">
         <source>No integration packages were found. Please check your internet connection or NuGet source configuration.</source>
         <target state="translated">Non sono stati trovati pacchetti di integrazione. Controlla la connessione Internet o la configurazione dell'origine NuGet.</target>
         <note />
+      </trans-unit>
+      <trans-unit id="NoIntegrationPackagesMatchedSearchTerm">
+        <source>No integration packages matched '{0}'.</source>
+        <target state="new">No integration packages matched '{0}'.</target>
+        <note>{0} is the search term provided by the user.</note>
       </trans-unit>
       <trans-unit id="NoPackagesFound">
         <source>No packages found.</source>
@@ -50,6 +100,11 @@
       <trans-unit id="ProjectArgumentDescription">
         <source>The Aspire AppHost project file, or a directory to search, to add the integration to</source>
         <target state="needs-review-translation">Percorso del file di progetto a cui aggiungere l'integrazione.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SearchOptionDescription">
+        <source>Search available integrations without adding one</source>
+        <target state="new">Search available integrations without adding one</target>
         <note />
       </trans-unit>
       <trans-unit id="SearchingForAspirePackages">

--- a/src/Aspire.Cli/Resources/xlf/AddCommandStrings.it.xlf
+++ b/src/Aspire.Cli/Resources/xlf/AddCommandStrings.it.xlf
@@ -12,14 +12,14 @@
         <target state="needs-review-translation">Aggiungere un'integrazione di hosting all'AppHost Aspire.</target>
         <note />
       </trans-unit>
-      <trans-unit id="DiscoveryOptionsCannotBeCombinedWithAddOptions">
-        <source>The --list and --search options cannot be combined with an integration name, --version, or --source.</source>
-        <target state="new">The --list and --search options cannot be combined with an integration name, --version, or --source.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ErrorOccurredWhileAddingPackage">
         <source>An error occurred while adding the package: {0}</source>
         <target state="translated">Errore durante l'aggiunta del pacchetto: {0}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ErrorOccurredWhileSearchingIntegrations">
+        <source>An error occurred while searching integrations: {0}</source>
+        <target state="new">An error occurred while searching integrations: {0}</target>
         <note />
       </trans-unit>
       <trans-unit id="FormatOptionDescription">
@@ -57,14 +57,24 @@
         <target state="needs-review-translation">Nome dell'integrazione da aggiungere, (ad esempio redis, postgres).</target>
         <note />
       </trans-unit>
-      <trans-unit id="JsonRequiresListOrSearch">
-        <source>JSON output must be used with --list or --search.</source>
-        <target state="new">JSON output must be used with --list or --search.</target>
+      <trans-unit id="IntegrationCommandDescription">
+        <source>Manage Aspire hosting integrations</source>
+        <target state="new">Manage Aspire hosting integrations</target>
         <note />
       </trans-unit>
-      <trans-unit id="ListOptionDescription">
-        <source>List available integrations without adding one</source>
-        <target state="new">List available integrations without adding one</target>
+      <trans-unit id="IntegrationSearchAppHostOptionDescription">
+        <source>The Aspire AppHost project file, or a directory to search, for channel-aware integration discovery</source>
+        <target state="new">The Aspire AppHost project file, or a directory to search, for channel-aware integration discovery</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="IntegrationSearchDescription">
+        <source>Search available Aspire hosting integrations</source>
+        <target state="new">Search available Aspire hosting integrations</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="IntegrationSearchQueryArgumentDescription">
+        <source>The integration search query. Omit to list all integrations.</source>
+        <target state="new">The integration search query. Omit to list all integrations.</target>
         <note />
       </trans-unit>
       <trans-unit id="NoIntegrationPackagesFound">
@@ -100,11 +110,6 @@
       <trans-unit id="ProjectArgumentDescription">
         <source>The Aspire AppHost project file, or a directory to search, to add the integration to</source>
         <target state="needs-review-translation">Percorso del file di progetto a cui aggiungere l'integrazione.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="SearchOptionDescription">
-        <source>Search available integrations without adding one</source>
-        <target state="new">Search available integrations without adding one</target>
         <note />
       </trans-unit>
       <trans-unit id="SearchingForAspirePackages">

--- a/src/Aspire.Cli/Resources/xlf/AddCommandStrings.it.xlf
+++ b/src/Aspire.Cli/Resources/xlf/AddCommandStrings.it.xlf
@@ -62,6 +62,11 @@
         <target state="new">Manage Aspire hosting integrations</target>
         <note />
       </trans-unit>
+      <trans-unit id="IntegrationListDescription">
+        <source>List available Aspire hosting integrations</source>
+        <target state="new">List available Aspire hosting integrations</target>
+        <note />
+      </trans-unit>
       <trans-unit id="IntegrationSearchAppHostOptionDescription">
         <source>The Aspire AppHost project file, or a directory to search, for channel-aware integration discovery</source>
         <target state="new">The Aspire AppHost project file, or a directory to search, for channel-aware integration discovery</target>
@@ -73,8 +78,8 @@
         <note />
       </trans-unit>
       <trans-unit id="IntegrationSearchQueryArgumentDescription">
-        <source>The integration search query. Omit to list all integrations.</source>
-        <target state="new">The integration search query. Omit to list all integrations.</target>
+        <source>The integration search query.</source>
+        <target state="new">The integration search query.</target>
         <note />
       </trans-unit>
       <trans-unit id="NoIntegrationPackagesFound">

--- a/src/Aspire.Cli/Resources/xlf/AddCommandStrings.ja.xlf
+++ b/src/Aspire.Cli/Resources/xlf/AddCommandStrings.ja.xlf
@@ -12,9 +12,44 @@
         <target state="needs-review-translation">Aspire AppHost にホスティング統合を追加します。</target>
         <note />
       </trans-unit>
+      <trans-unit id="DiscoveryOptionsCannotBeCombinedWithAddOptions">
+        <source>The --list and --search options cannot be combined with an integration name, --version, or --source.</source>
+        <target state="new">The --list and --search options cannot be combined with an integration name, --version, or --source.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ErrorOccurredWhileAddingPackage">
         <source>An error occurred while adding the package: {0}</source>
         <target state="translated">パッケージの追加中にエラーが発生しました: {0}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FormatOptionDescription">
+        <source>Output format (Table or Json)</source>
+        <target state="new">Output format (Table or Json)</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FoundIntegrationPackages">
+        <source>Found {0} integration package(s).</source>
+        <target state="new">Found {0} integration package(s).</target>
+        <note>{0} is the number of integration packages found.</note>
+      </trans-unit>
+      <trans-unit id="FoundIntegrationPackagesMatchingSearchTerm">
+        <source>Found {0} integration package(s) matching '{1}'.</source>
+        <target state="new">Found {0} integration package(s) matching '{1}'.</target>
+        <note>{0} is the number of integration packages found, {1} is the search term provided by the user.</note>
+      </trans-unit>
+      <trans-unit id="HeaderName">
+        <source>Name</source>
+        <target state="new">Name</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HeaderPackage">
+        <source>Package</source>
+        <target state="new">Package</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HeaderVersion">
+        <source>Version</source>
+        <target state="new">Version</target>
         <note />
       </trans-unit>
       <trans-unit id="IntegrationArgumentDescription">
@@ -22,10 +57,25 @@
         <target state="needs-review-translation">追加する統合の名前 (例: redis、postgres)。</target>
         <note />
       </trans-unit>
+      <trans-unit id="JsonRequiresListOrSearch">
+        <source>JSON output must be used with --list or --search.</source>
+        <target state="new">JSON output must be used with --list or --search.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ListOptionDescription">
+        <source>List available integrations without adding one</source>
+        <target state="new">List available integrations without adding one</target>
+        <note />
+      </trans-unit>
       <trans-unit id="NoIntegrationPackagesFound">
         <source>No integration packages were found. Please check your internet connection or NuGet source configuration.</source>
         <target state="translated">統合パッケージが見つかりませんでした。インターネット接続または NuGet ソース構成を確認してください。</target>
         <note />
+      </trans-unit>
+      <trans-unit id="NoIntegrationPackagesMatchedSearchTerm">
+        <source>No integration packages matched '{0}'.</source>
+        <target state="new">No integration packages matched '{0}'.</target>
+        <note>{0} is the search term provided by the user.</note>
       </trans-unit>
       <trans-unit id="NoPackagesFound">
         <source>No packages found.</source>
@@ -50,6 +100,11 @@
       <trans-unit id="ProjectArgumentDescription">
         <source>The Aspire AppHost project file, or a directory to search, to add the integration to</source>
         <target state="needs-review-translation">統合を追加するプロジェクト ファイルへのパス。</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SearchOptionDescription">
+        <source>Search available integrations without adding one</source>
+        <target state="new">Search available integrations without adding one</target>
         <note />
       </trans-unit>
       <trans-unit id="SearchingForAspirePackages">

--- a/src/Aspire.Cli/Resources/xlf/AddCommandStrings.ja.xlf
+++ b/src/Aspire.Cli/Resources/xlf/AddCommandStrings.ja.xlf
@@ -62,6 +62,11 @@
         <target state="new">Manage Aspire hosting integrations</target>
         <note />
       </trans-unit>
+      <trans-unit id="IntegrationListDescription">
+        <source>List available Aspire hosting integrations</source>
+        <target state="new">List available Aspire hosting integrations</target>
+        <note />
+      </trans-unit>
       <trans-unit id="IntegrationSearchAppHostOptionDescription">
         <source>The Aspire AppHost project file, or a directory to search, for channel-aware integration discovery</source>
         <target state="new">The Aspire AppHost project file, or a directory to search, for channel-aware integration discovery</target>
@@ -73,8 +78,8 @@
         <note />
       </trans-unit>
       <trans-unit id="IntegrationSearchQueryArgumentDescription">
-        <source>The integration search query. Omit to list all integrations.</source>
-        <target state="new">The integration search query. Omit to list all integrations.</target>
+        <source>The integration search query.</source>
+        <target state="new">The integration search query.</target>
         <note />
       </trans-unit>
       <trans-unit id="NoIntegrationPackagesFound">

--- a/src/Aspire.Cli/Resources/xlf/AddCommandStrings.ja.xlf
+++ b/src/Aspire.Cli/Resources/xlf/AddCommandStrings.ja.xlf
@@ -12,14 +12,14 @@
         <target state="needs-review-translation">Aspire AppHost にホスティング統合を追加します。</target>
         <note />
       </trans-unit>
-      <trans-unit id="DiscoveryOptionsCannotBeCombinedWithAddOptions">
-        <source>The --list and --search options cannot be combined with an integration name, --version, or --source.</source>
-        <target state="new">The --list and --search options cannot be combined with an integration name, --version, or --source.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ErrorOccurredWhileAddingPackage">
         <source>An error occurred while adding the package: {0}</source>
         <target state="translated">パッケージの追加中にエラーが発生しました: {0}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ErrorOccurredWhileSearchingIntegrations">
+        <source>An error occurred while searching integrations: {0}</source>
+        <target state="new">An error occurred while searching integrations: {0}</target>
         <note />
       </trans-unit>
       <trans-unit id="FormatOptionDescription">
@@ -57,14 +57,24 @@
         <target state="needs-review-translation">追加する統合の名前 (例: redis、postgres)。</target>
         <note />
       </trans-unit>
-      <trans-unit id="JsonRequiresListOrSearch">
-        <source>JSON output must be used with --list or --search.</source>
-        <target state="new">JSON output must be used with --list or --search.</target>
+      <trans-unit id="IntegrationCommandDescription">
+        <source>Manage Aspire hosting integrations</source>
+        <target state="new">Manage Aspire hosting integrations</target>
         <note />
       </trans-unit>
-      <trans-unit id="ListOptionDescription">
-        <source>List available integrations without adding one</source>
-        <target state="new">List available integrations without adding one</target>
+      <trans-unit id="IntegrationSearchAppHostOptionDescription">
+        <source>The Aspire AppHost project file, or a directory to search, for channel-aware integration discovery</source>
+        <target state="new">The Aspire AppHost project file, or a directory to search, for channel-aware integration discovery</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="IntegrationSearchDescription">
+        <source>Search available Aspire hosting integrations</source>
+        <target state="new">Search available Aspire hosting integrations</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="IntegrationSearchQueryArgumentDescription">
+        <source>The integration search query. Omit to list all integrations.</source>
+        <target state="new">The integration search query. Omit to list all integrations.</target>
         <note />
       </trans-unit>
       <trans-unit id="NoIntegrationPackagesFound">
@@ -100,11 +110,6 @@
       <trans-unit id="ProjectArgumentDescription">
         <source>The Aspire AppHost project file, or a directory to search, to add the integration to</source>
         <target state="needs-review-translation">統合を追加するプロジェクト ファイルへのパス。</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="SearchOptionDescription">
-        <source>Search available integrations without adding one</source>
-        <target state="new">Search available integrations without adding one</target>
         <note />
       </trans-unit>
       <trans-unit id="SearchingForAspirePackages">

--- a/src/Aspire.Cli/Resources/xlf/AddCommandStrings.ko.xlf
+++ b/src/Aspire.Cli/Resources/xlf/AddCommandStrings.ko.xlf
@@ -12,9 +12,44 @@
         <target state="needs-review-translation">Aspire AppHost에 호스팅 통합을 추가하세요.</target>
         <note />
       </trans-unit>
+      <trans-unit id="DiscoveryOptionsCannotBeCombinedWithAddOptions">
+        <source>The --list and --search options cannot be combined with an integration name, --version, or --source.</source>
+        <target state="new">The --list and --search options cannot be combined with an integration name, --version, or --source.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ErrorOccurredWhileAddingPackage">
         <source>An error occurred while adding the package: {0}</source>
         <target state="translated">패키지를 추가하는 동안 오류가 발생했습니다({0}).</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FormatOptionDescription">
+        <source>Output format (Table or Json)</source>
+        <target state="new">Output format (Table or Json)</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FoundIntegrationPackages">
+        <source>Found {0} integration package(s).</source>
+        <target state="new">Found {0} integration package(s).</target>
+        <note>{0} is the number of integration packages found.</note>
+      </trans-unit>
+      <trans-unit id="FoundIntegrationPackagesMatchingSearchTerm">
+        <source>Found {0} integration package(s) matching '{1}'.</source>
+        <target state="new">Found {0} integration package(s) matching '{1}'.</target>
+        <note>{0} is the number of integration packages found, {1} is the search term provided by the user.</note>
+      </trans-unit>
+      <trans-unit id="HeaderName">
+        <source>Name</source>
+        <target state="new">Name</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HeaderPackage">
+        <source>Package</source>
+        <target state="new">Package</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HeaderVersion">
+        <source>Version</source>
+        <target state="new">Version</target>
         <note />
       </trans-unit>
       <trans-unit id="IntegrationArgumentDescription">
@@ -22,10 +57,25 @@
         <target state="needs-review-translation">추가할 통합의 이름(예: redis, postgres)입니다.</target>
         <note />
       </trans-unit>
+      <trans-unit id="JsonRequiresListOrSearch">
+        <source>JSON output must be used with --list or --search.</source>
+        <target state="new">JSON output must be used with --list or --search.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ListOptionDescription">
+        <source>List available integrations without adding one</source>
+        <target state="new">List available integrations without adding one</target>
+        <note />
+      </trans-unit>
       <trans-unit id="NoIntegrationPackagesFound">
         <source>No integration packages were found. Please check your internet connection or NuGet source configuration.</source>
         <target state="translated">통합 패키지를 찾을 수 없습니다. 인터넷 연결 또는 NuGet 원본 구성을 확인하세요.</target>
         <note />
+      </trans-unit>
+      <trans-unit id="NoIntegrationPackagesMatchedSearchTerm">
+        <source>No integration packages matched '{0}'.</source>
+        <target state="new">No integration packages matched '{0}'.</target>
+        <note>{0} is the search term provided by the user.</note>
       </trans-unit>
       <trans-unit id="NoPackagesFound">
         <source>No packages found.</source>
@@ -50,6 +100,11 @@
       <trans-unit id="ProjectArgumentDescription">
         <source>The Aspire AppHost project file, or a directory to search, to add the integration to</source>
         <target state="needs-review-translation">통합을 추가할 프로젝트 파일의 경로입니다.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SearchOptionDescription">
+        <source>Search available integrations without adding one</source>
+        <target state="new">Search available integrations without adding one</target>
         <note />
       </trans-unit>
       <trans-unit id="SearchingForAspirePackages">

--- a/src/Aspire.Cli/Resources/xlf/AddCommandStrings.ko.xlf
+++ b/src/Aspire.Cli/Resources/xlf/AddCommandStrings.ko.xlf
@@ -62,6 +62,11 @@
         <target state="new">Manage Aspire hosting integrations</target>
         <note />
       </trans-unit>
+      <trans-unit id="IntegrationListDescription">
+        <source>List available Aspire hosting integrations</source>
+        <target state="new">List available Aspire hosting integrations</target>
+        <note />
+      </trans-unit>
       <trans-unit id="IntegrationSearchAppHostOptionDescription">
         <source>The Aspire AppHost project file, or a directory to search, for channel-aware integration discovery</source>
         <target state="new">The Aspire AppHost project file, or a directory to search, for channel-aware integration discovery</target>
@@ -73,8 +78,8 @@
         <note />
       </trans-unit>
       <trans-unit id="IntegrationSearchQueryArgumentDescription">
-        <source>The integration search query. Omit to list all integrations.</source>
-        <target state="new">The integration search query. Omit to list all integrations.</target>
+        <source>The integration search query.</source>
+        <target state="new">The integration search query.</target>
         <note />
       </trans-unit>
       <trans-unit id="NoIntegrationPackagesFound">

--- a/src/Aspire.Cli/Resources/xlf/AddCommandStrings.ko.xlf
+++ b/src/Aspire.Cli/Resources/xlf/AddCommandStrings.ko.xlf
@@ -12,14 +12,14 @@
         <target state="needs-review-translation">Aspire AppHost에 호스팅 통합을 추가하세요.</target>
         <note />
       </trans-unit>
-      <trans-unit id="DiscoveryOptionsCannotBeCombinedWithAddOptions">
-        <source>The --list and --search options cannot be combined with an integration name, --version, or --source.</source>
-        <target state="new">The --list and --search options cannot be combined with an integration name, --version, or --source.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ErrorOccurredWhileAddingPackage">
         <source>An error occurred while adding the package: {0}</source>
         <target state="translated">패키지를 추가하는 동안 오류가 발생했습니다({0}).</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ErrorOccurredWhileSearchingIntegrations">
+        <source>An error occurred while searching integrations: {0}</source>
+        <target state="new">An error occurred while searching integrations: {0}</target>
         <note />
       </trans-unit>
       <trans-unit id="FormatOptionDescription">
@@ -57,14 +57,24 @@
         <target state="needs-review-translation">추가할 통합의 이름(예: redis, postgres)입니다.</target>
         <note />
       </trans-unit>
-      <trans-unit id="JsonRequiresListOrSearch">
-        <source>JSON output must be used with --list or --search.</source>
-        <target state="new">JSON output must be used with --list or --search.</target>
+      <trans-unit id="IntegrationCommandDescription">
+        <source>Manage Aspire hosting integrations</source>
+        <target state="new">Manage Aspire hosting integrations</target>
         <note />
       </trans-unit>
-      <trans-unit id="ListOptionDescription">
-        <source>List available integrations without adding one</source>
-        <target state="new">List available integrations without adding one</target>
+      <trans-unit id="IntegrationSearchAppHostOptionDescription">
+        <source>The Aspire AppHost project file, or a directory to search, for channel-aware integration discovery</source>
+        <target state="new">The Aspire AppHost project file, or a directory to search, for channel-aware integration discovery</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="IntegrationSearchDescription">
+        <source>Search available Aspire hosting integrations</source>
+        <target state="new">Search available Aspire hosting integrations</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="IntegrationSearchQueryArgumentDescription">
+        <source>The integration search query. Omit to list all integrations.</source>
+        <target state="new">The integration search query. Omit to list all integrations.</target>
         <note />
       </trans-unit>
       <trans-unit id="NoIntegrationPackagesFound">
@@ -100,11 +110,6 @@
       <trans-unit id="ProjectArgumentDescription">
         <source>The Aspire AppHost project file, or a directory to search, to add the integration to</source>
         <target state="needs-review-translation">통합을 추가할 프로젝트 파일의 경로입니다.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="SearchOptionDescription">
-        <source>Search available integrations without adding one</source>
-        <target state="new">Search available integrations without adding one</target>
         <note />
       </trans-unit>
       <trans-unit id="SearchingForAspirePackages">

--- a/src/Aspire.Cli/Resources/xlf/AddCommandStrings.pl.xlf
+++ b/src/Aspire.Cli/Resources/xlf/AddCommandStrings.pl.xlf
@@ -12,9 +12,44 @@
         <target state="needs-review-translation">Dodaj integrację hostingu do hosta AppHost platformy Aspire.</target>
         <note />
       </trans-unit>
+      <trans-unit id="DiscoveryOptionsCannotBeCombinedWithAddOptions">
+        <source>The --list and --search options cannot be combined with an integration name, --version, or --source.</source>
+        <target state="new">The --list and --search options cannot be combined with an integration name, --version, or --source.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ErrorOccurredWhileAddingPackage">
         <source>An error occurred while adding the package: {0}</source>
         <target state="translated">Wystąpił błąd podczas dodawania pakietu: {0}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FormatOptionDescription">
+        <source>Output format (Table or Json)</source>
+        <target state="new">Output format (Table or Json)</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FoundIntegrationPackages">
+        <source>Found {0} integration package(s).</source>
+        <target state="new">Found {0} integration package(s).</target>
+        <note>{0} is the number of integration packages found.</note>
+      </trans-unit>
+      <trans-unit id="FoundIntegrationPackagesMatchingSearchTerm">
+        <source>Found {0} integration package(s) matching '{1}'.</source>
+        <target state="new">Found {0} integration package(s) matching '{1}'.</target>
+        <note>{0} is the number of integration packages found, {1} is the search term provided by the user.</note>
+      </trans-unit>
+      <trans-unit id="HeaderName">
+        <source>Name</source>
+        <target state="new">Name</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HeaderPackage">
+        <source>Package</source>
+        <target state="new">Package</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HeaderVersion">
+        <source>Version</source>
+        <target state="new">Version</target>
         <note />
       </trans-unit>
       <trans-unit id="IntegrationArgumentDescription">
@@ -22,10 +57,25 @@
         <target state="needs-review-translation">Nazwa integracji do dodania (np. redis, postgres).</target>
         <note />
       </trans-unit>
+      <trans-unit id="JsonRequiresListOrSearch">
+        <source>JSON output must be used with --list or --search.</source>
+        <target state="new">JSON output must be used with --list or --search.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ListOptionDescription">
+        <source>List available integrations without adding one</source>
+        <target state="new">List available integrations without adding one</target>
+        <note />
+      </trans-unit>
       <trans-unit id="NoIntegrationPackagesFound">
         <source>No integration packages were found. Please check your internet connection or NuGet source configuration.</source>
         <target state="translated">Nie znaleziono pakietów integracji. Sprawdź połączenie internetowe lub konfigurację źródła NuGet.</target>
         <note />
+      </trans-unit>
+      <trans-unit id="NoIntegrationPackagesMatchedSearchTerm">
+        <source>No integration packages matched '{0}'.</source>
+        <target state="new">No integration packages matched '{0}'.</target>
+        <note>{0} is the search term provided by the user.</note>
       </trans-unit>
       <trans-unit id="NoPackagesFound">
         <source>No packages found.</source>
@@ -50,6 +100,11 @@
       <trans-unit id="ProjectArgumentDescription">
         <source>The Aspire AppHost project file, or a directory to search, to add the integration to</source>
         <target state="needs-review-translation">Ścieżka do pliku projektu, do którego ma zostać dodana integracja.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SearchOptionDescription">
+        <source>Search available integrations without adding one</source>
+        <target state="new">Search available integrations without adding one</target>
         <note />
       </trans-unit>
       <trans-unit id="SearchingForAspirePackages">

--- a/src/Aspire.Cli/Resources/xlf/AddCommandStrings.pl.xlf
+++ b/src/Aspire.Cli/Resources/xlf/AddCommandStrings.pl.xlf
@@ -62,6 +62,11 @@
         <target state="new">Manage Aspire hosting integrations</target>
         <note />
       </trans-unit>
+      <trans-unit id="IntegrationListDescription">
+        <source>List available Aspire hosting integrations</source>
+        <target state="new">List available Aspire hosting integrations</target>
+        <note />
+      </trans-unit>
       <trans-unit id="IntegrationSearchAppHostOptionDescription">
         <source>The Aspire AppHost project file, or a directory to search, for channel-aware integration discovery</source>
         <target state="new">The Aspire AppHost project file, or a directory to search, for channel-aware integration discovery</target>
@@ -73,8 +78,8 @@
         <note />
       </trans-unit>
       <trans-unit id="IntegrationSearchQueryArgumentDescription">
-        <source>The integration search query. Omit to list all integrations.</source>
-        <target state="new">The integration search query. Omit to list all integrations.</target>
+        <source>The integration search query.</source>
+        <target state="new">The integration search query.</target>
         <note />
       </trans-unit>
       <trans-unit id="NoIntegrationPackagesFound">

--- a/src/Aspire.Cli/Resources/xlf/AddCommandStrings.pl.xlf
+++ b/src/Aspire.Cli/Resources/xlf/AddCommandStrings.pl.xlf
@@ -12,14 +12,14 @@
         <target state="needs-review-translation">Dodaj integrację hostingu do hosta AppHost platformy Aspire.</target>
         <note />
       </trans-unit>
-      <trans-unit id="DiscoveryOptionsCannotBeCombinedWithAddOptions">
-        <source>The --list and --search options cannot be combined with an integration name, --version, or --source.</source>
-        <target state="new">The --list and --search options cannot be combined with an integration name, --version, or --source.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ErrorOccurredWhileAddingPackage">
         <source>An error occurred while adding the package: {0}</source>
         <target state="translated">Wystąpił błąd podczas dodawania pakietu: {0}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ErrorOccurredWhileSearchingIntegrations">
+        <source>An error occurred while searching integrations: {0}</source>
+        <target state="new">An error occurred while searching integrations: {0}</target>
         <note />
       </trans-unit>
       <trans-unit id="FormatOptionDescription">
@@ -57,14 +57,24 @@
         <target state="needs-review-translation">Nazwa integracji do dodania (np. redis, postgres).</target>
         <note />
       </trans-unit>
-      <trans-unit id="JsonRequiresListOrSearch">
-        <source>JSON output must be used with --list or --search.</source>
-        <target state="new">JSON output must be used with --list or --search.</target>
+      <trans-unit id="IntegrationCommandDescription">
+        <source>Manage Aspire hosting integrations</source>
+        <target state="new">Manage Aspire hosting integrations</target>
         <note />
       </trans-unit>
-      <trans-unit id="ListOptionDescription">
-        <source>List available integrations without adding one</source>
-        <target state="new">List available integrations without adding one</target>
+      <trans-unit id="IntegrationSearchAppHostOptionDescription">
+        <source>The Aspire AppHost project file, or a directory to search, for channel-aware integration discovery</source>
+        <target state="new">The Aspire AppHost project file, or a directory to search, for channel-aware integration discovery</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="IntegrationSearchDescription">
+        <source>Search available Aspire hosting integrations</source>
+        <target state="new">Search available Aspire hosting integrations</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="IntegrationSearchQueryArgumentDescription">
+        <source>The integration search query. Omit to list all integrations.</source>
+        <target state="new">The integration search query. Omit to list all integrations.</target>
         <note />
       </trans-unit>
       <trans-unit id="NoIntegrationPackagesFound">
@@ -100,11 +110,6 @@
       <trans-unit id="ProjectArgumentDescription">
         <source>The Aspire AppHost project file, or a directory to search, to add the integration to</source>
         <target state="needs-review-translation">Ścieżka do pliku projektu, do którego ma zostać dodana integracja.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="SearchOptionDescription">
-        <source>Search available integrations without adding one</source>
-        <target state="new">Search available integrations without adding one</target>
         <note />
       </trans-unit>
       <trans-unit id="SearchingForAspirePackages">

--- a/src/Aspire.Cli/Resources/xlf/AddCommandStrings.pt-BR.xlf
+++ b/src/Aspire.Cli/Resources/xlf/AddCommandStrings.pt-BR.xlf
@@ -12,9 +12,44 @@
         <target state="needs-review-translation">Adicione uma integração de hosting ao Aspire AppHost.</target>
         <note />
       </trans-unit>
+      <trans-unit id="DiscoveryOptionsCannotBeCombinedWithAddOptions">
+        <source>The --list and --search options cannot be combined with an integration name, --version, or --source.</source>
+        <target state="new">The --list and --search options cannot be combined with an integration name, --version, or --source.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ErrorOccurredWhileAddingPackage">
         <source>An error occurred while adding the package: {0}</source>
         <target state="translated">Ocorreu um erro ao adicionar o pacote: {0}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FormatOptionDescription">
+        <source>Output format (Table or Json)</source>
+        <target state="new">Output format (Table or Json)</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FoundIntegrationPackages">
+        <source>Found {0} integration package(s).</source>
+        <target state="new">Found {0} integration package(s).</target>
+        <note>{0} is the number of integration packages found.</note>
+      </trans-unit>
+      <trans-unit id="FoundIntegrationPackagesMatchingSearchTerm">
+        <source>Found {0} integration package(s) matching '{1}'.</source>
+        <target state="new">Found {0} integration package(s) matching '{1}'.</target>
+        <note>{0} is the number of integration packages found, {1} is the search term provided by the user.</note>
+      </trans-unit>
+      <trans-unit id="HeaderName">
+        <source>Name</source>
+        <target state="new">Name</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HeaderPackage">
+        <source>Package</source>
+        <target state="new">Package</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HeaderVersion">
+        <source>Version</source>
+        <target state="new">Version</target>
         <note />
       </trans-unit>
       <trans-unit id="IntegrationArgumentDescription">
@@ -22,10 +57,25 @@
         <target state="needs-review-translation">O nome da integração a ser adicionada (por exemplo, redis, postgres).</target>
         <note />
       </trans-unit>
+      <trans-unit id="JsonRequiresListOrSearch">
+        <source>JSON output must be used with --list or --search.</source>
+        <target state="new">JSON output must be used with --list or --search.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ListOptionDescription">
+        <source>List available integrations without adding one</source>
+        <target state="new">List available integrations without adding one</target>
+        <note />
+      </trans-unit>
       <trans-unit id="NoIntegrationPackagesFound">
         <source>No integration packages were found. Please check your internet connection or NuGet source configuration.</source>
         <target state="translated">Nenhum pacote de integração foi encontrado. Verifique sua conexão com a internet ou a configuração da fonte NuGet.</target>
         <note />
+      </trans-unit>
+      <trans-unit id="NoIntegrationPackagesMatchedSearchTerm">
+        <source>No integration packages matched '{0}'.</source>
+        <target state="new">No integration packages matched '{0}'.</target>
+        <note>{0} is the search term provided by the user.</note>
       </trans-unit>
       <trans-unit id="NoPackagesFound">
         <source>No packages found.</source>
@@ -50,6 +100,11 @@
       <trans-unit id="ProjectArgumentDescription">
         <source>The Aspire AppHost project file, or a directory to search, to add the integration to</source>
         <target state="needs-review-translation">O caminho para o arquivo de projeto ao qual adicionar a integração.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SearchOptionDescription">
+        <source>Search available integrations without adding one</source>
+        <target state="new">Search available integrations without adding one</target>
         <note />
       </trans-unit>
       <trans-unit id="SearchingForAspirePackages">

--- a/src/Aspire.Cli/Resources/xlf/AddCommandStrings.pt-BR.xlf
+++ b/src/Aspire.Cli/Resources/xlf/AddCommandStrings.pt-BR.xlf
@@ -62,6 +62,11 @@
         <target state="new">Manage Aspire hosting integrations</target>
         <note />
       </trans-unit>
+      <trans-unit id="IntegrationListDescription">
+        <source>List available Aspire hosting integrations</source>
+        <target state="new">List available Aspire hosting integrations</target>
+        <note />
+      </trans-unit>
       <trans-unit id="IntegrationSearchAppHostOptionDescription">
         <source>The Aspire AppHost project file, or a directory to search, for channel-aware integration discovery</source>
         <target state="new">The Aspire AppHost project file, or a directory to search, for channel-aware integration discovery</target>
@@ -73,8 +78,8 @@
         <note />
       </trans-unit>
       <trans-unit id="IntegrationSearchQueryArgumentDescription">
-        <source>The integration search query. Omit to list all integrations.</source>
-        <target state="new">The integration search query. Omit to list all integrations.</target>
+        <source>The integration search query.</source>
+        <target state="new">The integration search query.</target>
         <note />
       </trans-unit>
       <trans-unit id="NoIntegrationPackagesFound">

--- a/src/Aspire.Cli/Resources/xlf/AddCommandStrings.pt-BR.xlf
+++ b/src/Aspire.Cli/Resources/xlf/AddCommandStrings.pt-BR.xlf
@@ -12,14 +12,14 @@
         <target state="needs-review-translation">Adicione uma integração de hosting ao Aspire AppHost.</target>
         <note />
       </trans-unit>
-      <trans-unit id="DiscoveryOptionsCannotBeCombinedWithAddOptions">
-        <source>The --list and --search options cannot be combined with an integration name, --version, or --source.</source>
-        <target state="new">The --list and --search options cannot be combined with an integration name, --version, or --source.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ErrorOccurredWhileAddingPackage">
         <source>An error occurred while adding the package: {0}</source>
         <target state="translated">Ocorreu um erro ao adicionar o pacote: {0}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ErrorOccurredWhileSearchingIntegrations">
+        <source>An error occurred while searching integrations: {0}</source>
+        <target state="new">An error occurred while searching integrations: {0}</target>
         <note />
       </trans-unit>
       <trans-unit id="FormatOptionDescription">
@@ -57,14 +57,24 @@
         <target state="needs-review-translation">O nome da integração a ser adicionada (por exemplo, redis, postgres).</target>
         <note />
       </trans-unit>
-      <trans-unit id="JsonRequiresListOrSearch">
-        <source>JSON output must be used with --list or --search.</source>
-        <target state="new">JSON output must be used with --list or --search.</target>
+      <trans-unit id="IntegrationCommandDescription">
+        <source>Manage Aspire hosting integrations</source>
+        <target state="new">Manage Aspire hosting integrations</target>
         <note />
       </trans-unit>
-      <trans-unit id="ListOptionDescription">
-        <source>List available integrations without adding one</source>
-        <target state="new">List available integrations without adding one</target>
+      <trans-unit id="IntegrationSearchAppHostOptionDescription">
+        <source>The Aspire AppHost project file, or a directory to search, for channel-aware integration discovery</source>
+        <target state="new">The Aspire AppHost project file, or a directory to search, for channel-aware integration discovery</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="IntegrationSearchDescription">
+        <source>Search available Aspire hosting integrations</source>
+        <target state="new">Search available Aspire hosting integrations</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="IntegrationSearchQueryArgumentDescription">
+        <source>The integration search query. Omit to list all integrations.</source>
+        <target state="new">The integration search query. Omit to list all integrations.</target>
         <note />
       </trans-unit>
       <trans-unit id="NoIntegrationPackagesFound">
@@ -100,11 +110,6 @@
       <trans-unit id="ProjectArgumentDescription">
         <source>The Aspire AppHost project file, or a directory to search, to add the integration to</source>
         <target state="needs-review-translation">O caminho para o arquivo de projeto ao qual adicionar a integração.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="SearchOptionDescription">
-        <source>Search available integrations without adding one</source>
-        <target state="new">Search available integrations without adding one</target>
         <note />
       </trans-unit>
       <trans-unit id="SearchingForAspirePackages">

--- a/src/Aspire.Cli/Resources/xlf/AddCommandStrings.ru.xlf
+++ b/src/Aspire.Cli/Resources/xlf/AddCommandStrings.ru.xlf
@@ -12,9 +12,44 @@
         <target state="needs-review-translation">Добавьте интеграцию размещения в Aspire AppHost.</target>
         <note />
       </trans-unit>
+      <trans-unit id="DiscoveryOptionsCannotBeCombinedWithAddOptions">
+        <source>The --list and --search options cannot be combined with an integration name, --version, or --source.</source>
+        <target state="new">The --list and --search options cannot be combined with an integration name, --version, or --source.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ErrorOccurredWhileAddingPackage">
         <source>An error occurred while adding the package: {0}</source>
         <target state="translated">Произошла ошибка при добавлении пакета: {0}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FormatOptionDescription">
+        <source>Output format (Table or Json)</source>
+        <target state="new">Output format (Table or Json)</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FoundIntegrationPackages">
+        <source>Found {0} integration package(s).</source>
+        <target state="new">Found {0} integration package(s).</target>
+        <note>{0} is the number of integration packages found.</note>
+      </trans-unit>
+      <trans-unit id="FoundIntegrationPackagesMatchingSearchTerm">
+        <source>Found {0} integration package(s) matching '{1}'.</source>
+        <target state="new">Found {0} integration package(s) matching '{1}'.</target>
+        <note>{0} is the number of integration packages found, {1} is the search term provided by the user.</note>
+      </trans-unit>
+      <trans-unit id="HeaderName">
+        <source>Name</source>
+        <target state="new">Name</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HeaderPackage">
+        <source>Package</source>
+        <target state="new">Package</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HeaderVersion">
+        <source>Version</source>
+        <target state="new">Version</target>
         <note />
       </trans-unit>
       <trans-unit id="IntegrationArgumentDescription">
@@ -22,10 +57,25 @@
         <target state="needs-review-translation">Имя интеграции для добавления (например, redis, postgres).</target>
         <note />
       </trans-unit>
+      <trans-unit id="JsonRequiresListOrSearch">
+        <source>JSON output must be used with --list or --search.</source>
+        <target state="new">JSON output must be used with --list or --search.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ListOptionDescription">
+        <source>List available integrations without adding one</source>
+        <target state="new">List available integrations without adding one</target>
+        <note />
+      </trans-unit>
       <trans-unit id="NoIntegrationPackagesFound">
         <source>No integration packages were found. Please check your internet connection or NuGet source configuration.</source>
         <target state="translated">Ни одного пакета интеграции не найдено. Проверьте подключение к Интернету и конфигурацию источника NuGet.</target>
         <note />
+      </trans-unit>
+      <trans-unit id="NoIntegrationPackagesMatchedSearchTerm">
+        <source>No integration packages matched '{0}'.</source>
+        <target state="new">No integration packages matched '{0}'.</target>
+        <note>{0} is the search term provided by the user.</note>
       </trans-unit>
       <trans-unit id="NoPackagesFound">
         <source>No packages found.</source>
@@ -50,6 +100,11 @@
       <trans-unit id="ProjectArgumentDescription">
         <source>The Aspire AppHost project file, or a directory to search, to add the integration to</source>
         <target state="needs-review-translation">Путь к файлу проекта, в который необходимо добавить интеграцию.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SearchOptionDescription">
+        <source>Search available integrations without adding one</source>
+        <target state="new">Search available integrations without adding one</target>
         <note />
       </trans-unit>
       <trans-unit id="SearchingForAspirePackages">

--- a/src/Aspire.Cli/Resources/xlf/AddCommandStrings.ru.xlf
+++ b/src/Aspire.Cli/Resources/xlf/AddCommandStrings.ru.xlf
@@ -62,6 +62,11 @@
         <target state="new">Manage Aspire hosting integrations</target>
         <note />
       </trans-unit>
+      <trans-unit id="IntegrationListDescription">
+        <source>List available Aspire hosting integrations</source>
+        <target state="new">List available Aspire hosting integrations</target>
+        <note />
+      </trans-unit>
       <trans-unit id="IntegrationSearchAppHostOptionDescription">
         <source>The Aspire AppHost project file, or a directory to search, for channel-aware integration discovery</source>
         <target state="new">The Aspire AppHost project file, or a directory to search, for channel-aware integration discovery</target>
@@ -73,8 +78,8 @@
         <note />
       </trans-unit>
       <trans-unit id="IntegrationSearchQueryArgumentDescription">
-        <source>The integration search query. Omit to list all integrations.</source>
-        <target state="new">The integration search query. Omit to list all integrations.</target>
+        <source>The integration search query.</source>
+        <target state="new">The integration search query.</target>
         <note />
       </trans-unit>
       <trans-unit id="NoIntegrationPackagesFound">

--- a/src/Aspire.Cli/Resources/xlf/AddCommandStrings.ru.xlf
+++ b/src/Aspire.Cli/Resources/xlf/AddCommandStrings.ru.xlf
@@ -12,14 +12,14 @@
         <target state="needs-review-translation">Добавьте интеграцию размещения в Aspire AppHost.</target>
         <note />
       </trans-unit>
-      <trans-unit id="DiscoveryOptionsCannotBeCombinedWithAddOptions">
-        <source>The --list and --search options cannot be combined with an integration name, --version, or --source.</source>
-        <target state="new">The --list and --search options cannot be combined with an integration name, --version, or --source.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ErrorOccurredWhileAddingPackage">
         <source>An error occurred while adding the package: {0}</source>
         <target state="translated">Произошла ошибка при добавлении пакета: {0}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ErrorOccurredWhileSearchingIntegrations">
+        <source>An error occurred while searching integrations: {0}</source>
+        <target state="new">An error occurred while searching integrations: {0}</target>
         <note />
       </trans-unit>
       <trans-unit id="FormatOptionDescription">
@@ -57,14 +57,24 @@
         <target state="needs-review-translation">Имя интеграции для добавления (например, redis, postgres).</target>
         <note />
       </trans-unit>
-      <trans-unit id="JsonRequiresListOrSearch">
-        <source>JSON output must be used with --list or --search.</source>
-        <target state="new">JSON output must be used with --list or --search.</target>
+      <trans-unit id="IntegrationCommandDescription">
+        <source>Manage Aspire hosting integrations</source>
+        <target state="new">Manage Aspire hosting integrations</target>
         <note />
       </trans-unit>
-      <trans-unit id="ListOptionDescription">
-        <source>List available integrations without adding one</source>
-        <target state="new">List available integrations without adding one</target>
+      <trans-unit id="IntegrationSearchAppHostOptionDescription">
+        <source>The Aspire AppHost project file, or a directory to search, for channel-aware integration discovery</source>
+        <target state="new">The Aspire AppHost project file, or a directory to search, for channel-aware integration discovery</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="IntegrationSearchDescription">
+        <source>Search available Aspire hosting integrations</source>
+        <target state="new">Search available Aspire hosting integrations</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="IntegrationSearchQueryArgumentDescription">
+        <source>The integration search query. Omit to list all integrations.</source>
+        <target state="new">The integration search query. Omit to list all integrations.</target>
         <note />
       </trans-unit>
       <trans-unit id="NoIntegrationPackagesFound">
@@ -100,11 +110,6 @@
       <trans-unit id="ProjectArgumentDescription">
         <source>The Aspire AppHost project file, or a directory to search, to add the integration to</source>
         <target state="needs-review-translation">Путь к файлу проекта, в который необходимо добавить интеграцию.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="SearchOptionDescription">
-        <source>Search available integrations without adding one</source>
-        <target state="new">Search available integrations without adding one</target>
         <note />
       </trans-unit>
       <trans-unit id="SearchingForAspirePackages">

--- a/src/Aspire.Cli/Resources/xlf/AddCommandStrings.tr.xlf
+++ b/src/Aspire.Cli/Resources/xlf/AddCommandStrings.tr.xlf
@@ -12,9 +12,44 @@
         <target state="needs-review-translation">Aspire AppHost'a bir barındırma tümleştirmesi ekleyin.</target>
         <note />
       </trans-unit>
+      <trans-unit id="DiscoveryOptionsCannotBeCombinedWithAddOptions">
+        <source>The --list and --search options cannot be combined with an integration name, --version, or --source.</source>
+        <target state="new">The --list and --search options cannot be combined with an integration name, --version, or --source.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ErrorOccurredWhileAddingPackage">
         <source>An error occurred while adding the package: {0}</source>
         <target state="translated">{0} paketi eklenirken bir hata oluştu</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FormatOptionDescription">
+        <source>Output format (Table or Json)</source>
+        <target state="new">Output format (Table or Json)</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FoundIntegrationPackages">
+        <source>Found {0} integration package(s).</source>
+        <target state="new">Found {0} integration package(s).</target>
+        <note>{0} is the number of integration packages found.</note>
+      </trans-unit>
+      <trans-unit id="FoundIntegrationPackagesMatchingSearchTerm">
+        <source>Found {0} integration package(s) matching '{1}'.</source>
+        <target state="new">Found {0} integration package(s) matching '{1}'.</target>
+        <note>{0} is the number of integration packages found, {1} is the search term provided by the user.</note>
+      </trans-unit>
+      <trans-unit id="HeaderName">
+        <source>Name</source>
+        <target state="new">Name</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HeaderPackage">
+        <source>Package</source>
+        <target state="new">Package</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HeaderVersion">
+        <source>Version</source>
+        <target state="new">Version</target>
         <note />
       </trans-unit>
       <trans-unit id="IntegrationArgumentDescription">
@@ -22,10 +57,25 @@
         <target state="needs-review-translation">Eklenecek tümleştirmenin adı (ör. redis, postgres).</target>
         <note />
       </trans-unit>
+      <trans-unit id="JsonRequiresListOrSearch">
+        <source>JSON output must be used with --list or --search.</source>
+        <target state="new">JSON output must be used with --list or --search.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ListOptionDescription">
+        <source>List available integrations without adding one</source>
+        <target state="new">List available integrations without adding one</target>
+        <note />
+      </trans-unit>
       <trans-unit id="NoIntegrationPackagesFound">
         <source>No integration packages were found. Please check your internet connection or NuGet source configuration.</source>
         <target state="translated">Hiçbir tümleştirme paketi bulunamadı. Lütfen internet bağlantınızı veya NuGet kaynak yapılandırmanızı kontrol edin.</target>
         <note />
+      </trans-unit>
+      <trans-unit id="NoIntegrationPackagesMatchedSearchTerm">
+        <source>No integration packages matched '{0}'.</source>
+        <target state="new">No integration packages matched '{0}'.</target>
+        <note>{0} is the search term provided by the user.</note>
       </trans-unit>
       <trans-unit id="NoPackagesFound">
         <source>No packages found.</source>
@@ -50,6 +100,11 @@
       <trans-unit id="ProjectArgumentDescription">
         <source>The Aspire AppHost project file, or a directory to search, to add the integration to</source>
         <target state="needs-review-translation">Tümleştirmenin ekleneceği proje dosyasının yolu.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SearchOptionDescription">
+        <source>Search available integrations without adding one</source>
+        <target state="new">Search available integrations without adding one</target>
         <note />
       </trans-unit>
       <trans-unit id="SearchingForAspirePackages">

--- a/src/Aspire.Cli/Resources/xlf/AddCommandStrings.tr.xlf
+++ b/src/Aspire.Cli/Resources/xlf/AddCommandStrings.tr.xlf
@@ -62,6 +62,11 @@
         <target state="new">Manage Aspire hosting integrations</target>
         <note />
       </trans-unit>
+      <trans-unit id="IntegrationListDescription">
+        <source>List available Aspire hosting integrations</source>
+        <target state="new">List available Aspire hosting integrations</target>
+        <note />
+      </trans-unit>
       <trans-unit id="IntegrationSearchAppHostOptionDescription">
         <source>The Aspire AppHost project file, or a directory to search, for channel-aware integration discovery</source>
         <target state="new">The Aspire AppHost project file, or a directory to search, for channel-aware integration discovery</target>
@@ -73,8 +78,8 @@
         <note />
       </trans-unit>
       <trans-unit id="IntegrationSearchQueryArgumentDescription">
-        <source>The integration search query. Omit to list all integrations.</source>
-        <target state="new">The integration search query. Omit to list all integrations.</target>
+        <source>The integration search query.</source>
+        <target state="new">The integration search query.</target>
         <note />
       </trans-unit>
       <trans-unit id="NoIntegrationPackagesFound">

--- a/src/Aspire.Cli/Resources/xlf/AddCommandStrings.tr.xlf
+++ b/src/Aspire.Cli/Resources/xlf/AddCommandStrings.tr.xlf
@@ -12,14 +12,14 @@
         <target state="needs-review-translation">Aspire AppHost'a bir barındırma tümleştirmesi ekleyin.</target>
         <note />
       </trans-unit>
-      <trans-unit id="DiscoveryOptionsCannotBeCombinedWithAddOptions">
-        <source>The --list and --search options cannot be combined with an integration name, --version, or --source.</source>
-        <target state="new">The --list and --search options cannot be combined with an integration name, --version, or --source.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ErrorOccurredWhileAddingPackage">
         <source>An error occurred while adding the package: {0}</source>
         <target state="translated">{0} paketi eklenirken bir hata oluştu</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ErrorOccurredWhileSearchingIntegrations">
+        <source>An error occurred while searching integrations: {0}</source>
+        <target state="new">An error occurred while searching integrations: {0}</target>
         <note />
       </trans-unit>
       <trans-unit id="FormatOptionDescription">
@@ -57,14 +57,24 @@
         <target state="needs-review-translation">Eklenecek tümleştirmenin adı (ör. redis, postgres).</target>
         <note />
       </trans-unit>
-      <trans-unit id="JsonRequiresListOrSearch">
-        <source>JSON output must be used with --list or --search.</source>
-        <target state="new">JSON output must be used with --list or --search.</target>
+      <trans-unit id="IntegrationCommandDescription">
+        <source>Manage Aspire hosting integrations</source>
+        <target state="new">Manage Aspire hosting integrations</target>
         <note />
       </trans-unit>
-      <trans-unit id="ListOptionDescription">
-        <source>List available integrations without adding one</source>
-        <target state="new">List available integrations without adding one</target>
+      <trans-unit id="IntegrationSearchAppHostOptionDescription">
+        <source>The Aspire AppHost project file, or a directory to search, for channel-aware integration discovery</source>
+        <target state="new">The Aspire AppHost project file, or a directory to search, for channel-aware integration discovery</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="IntegrationSearchDescription">
+        <source>Search available Aspire hosting integrations</source>
+        <target state="new">Search available Aspire hosting integrations</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="IntegrationSearchQueryArgumentDescription">
+        <source>The integration search query. Omit to list all integrations.</source>
+        <target state="new">The integration search query. Omit to list all integrations.</target>
         <note />
       </trans-unit>
       <trans-unit id="NoIntegrationPackagesFound">
@@ -100,11 +110,6 @@
       <trans-unit id="ProjectArgumentDescription">
         <source>The Aspire AppHost project file, or a directory to search, to add the integration to</source>
         <target state="needs-review-translation">Tümleştirmenin ekleneceği proje dosyasının yolu.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="SearchOptionDescription">
-        <source>Search available integrations without adding one</source>
-        <target state="new">Search available integrations without adding one</target>
         <note />
       </trans-unit>
       <trans-unit id="SearchingForAspirePackages">

--- a/src/Aspire.Cli/Resources/xlf/AddCommandStrings.zh-Hans.xlf
+++ b/src/Aspire.Cli/Resources/xlf/AddCommandStrings.zh-Hans.xlf
@@ -12,9 +12,44 @@
         <target state="needs-review-translation">将托管集成添加到 Aspire AppHost。</target>
         <note />
       </trans-unit>
+      <trans-unit id="DiscoveryOptionsCannotBeCombinedWithAddOptions">
+        <source>The --list and --search options cannot be combined with an integration name, --version, or --source.</source>
+        <target state="new">The --list and --search options cannot be combined with an integration name, --version, or --source.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ErrorOccurredWhileAddingPackage">
         <source>An error occurred while adding the package: {0}</source>
         <target state="translated">添加包时出错: {0}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FormatOptionDescription">
+        <source>Output format (Table or Json)</source>
+        <target state="new">Output format (Table or Json)</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FoundIntegrationPackages">
+        <source>Found {0} integration package(s).</source>
+        <target state="new">Found {0} integration package(s).</target>
+        <note>{0} is the number of integration packages found.</note>
+      </trans-unit>
+      <trans-unit id="FoundIntegrationPackagesMatchingSearchTerm">
+        <source>Found {0} integration package(s) matching '{1}'.</source>
+        <target state="new">Found {0} integration package(s) matching '{1}'.</target>
+        <note>{0} is the number of integration packages found, {1} is the search term provided by the user.</note>
+      </trans-unit>
+      <trans-unit id="HeaderName">
+        <source>Name</source>
+        <target state="new">Name</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HeaderPackage">
+        <source>Package</source>
+        <target state="new">Package</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HeaderVersion">
+        <source>Version</source>
+        <target state="new">Version</target>
         <note />
       </trans-unit>
       <trans-unit id="IntegrationArgumentDescription">
@@ -22,10 +57,25 @@
         <target state="needs-review-translation">要添加的集成的名称(例如 redis、postgres)。</target>
         <note />
       </trans-unit>
+      <trans-unit id="JsonRequiresListOrSearch">
+        <source>JSON output must be used with --list or --search.</source>
+        <target state="new">JSON output must be used with --list or --search.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ListOptionDescription">
+        <source>List available integrations without adding one</source>
+        <target state="new">List available integrations without adding one</target>
+        <note />
+      </trans-unit>
       <trans-unit id="NoIntegrationPackagesFound">
         <source>No integration packages were found. Please check your internet connection or NuGet source configuration.</source>
         <target state="translated">找不到集成包。请检查 Internet 连接或 NuGet 源配置。</target>
         <note />
+      </trans-unit>
+      <trans-unit id="NoIntegrationPackagesMatchedSearchTerm">
+        <source>No integration packages matched '{0}'.</source>
+        <target state="new">No integration packages matched '{0}'.</target>
+        <note>{0} is the search term provided by the user.</note>
       </trans-unit>
       <trans-unit id="NoPackagesFound">
         <source>No packages found.</source>
@@ -50,6 +100,11 @@
       <trans-unit id="ProjectArgumentDescription">
         <source>The Aspire AppHost project file, or a directory to search, to add the integration to</source>
         <target state="needs-review-translation">要将集成添加到的项目文件的路径。</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SearchOptionDescription">
+        <source>Search available integrations without adding one</source>
+        <target state="new">Search available integrations without adding one</target>
         <note />
       </trans-unit>
       <trans-unit id="SearchingForAspirePackages">

--- a/src/Aspire.Cli/Resources/xlf/AddCommandStrings.zh-Hans.xlf
+++ b/src/Aspire.Cli/Resources/xlf/AddCommandStrings.zh-Hans.xlf
@@ -62,6 +62,11 @@
         <target state="new">Manage Aspire hosting integrations</target>
         <note />
       </trans-unit>
+      <trans-unit id="IntegrationListDescription">
+        <source>List available Aspire hosting integrations</source>
+        <target state="new">List available Aspire hosting integrations</target>
+        <note />
+      </trans-unit>
       <trans-unit id="IntegrationSearchAppHostOptionDescription">
         <source>The Aspire AppHost project file, or a directory to search, for channel-aware integration discovery</source>
         <target state="new">The Aspire AppHost project file, or a directory to search, for channel-aware integration discovery</target>
@@ -73,8 +78,8 @@
         <note />
       </trans-unit>
       <trans-unit id="IntegrationSearchQueryArgumentDescription">
-        <source>The integration search query. Omit to list all integrations.</source>
-        <target state="new">The integration search query. Omit to list all integrations.</target>
+        <source>The integration search query.</source>
+        <target state="new">The integration search query.</target>
         <note />
       </trans-unit>
       <trans-unit id="NoIntegrationPackagesFound">

--- a/src/Aspire.Cli/Resources/xlf/AddCommandStrings.zh-Hans.xlf
+++ b/src/Aspire.Cli/Resources/xlf/AddCommandStrings.zh-Hans.xlf
@@ -12,14 +12,14 @@
         <target state="needs-review-translation">将托管集成添加到 Aspire AppHost。</target>
         <note />
       </trans-unit>
-      <trans-unit id="DiscoveryOptionsCannotBeCombinedWithAddOptions">
-        <source>The --list and --search options cannot be combined with an integration name, --version, or --source.</source>
-        <target state="new">The --list and --search options cannot be combined with an integration name, --version, or --source.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ErrorOccurredWhileAddingPackage">
         <source>An error occurred while adding the package: {0}</source>
         <target state="translated">添加包时出错: {0}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ErrorOccurredWhileSearchingIntegrations">
+        <source>An error occurred while searching integrations: {0}</source>
+        <target state="new">An error occurred while searching integrations: {0}</target>
         <note />
       </trans-unit>
       <trans-unit id="FormatOptionDescription">
@@ -57,14 +57,24 @@
         <target state="needs-review-translation">要添加的集成的名称(例如 redis、postgres)。</target>
         <note />
       </trans-unit>
-      <trans-unit id="JsonRequiresListOrSearch">
-        <source>JSON output must be used with --list or --search.</source>
-        <target state="new">JSON output must be used with --list or --search.</target>
+      <trans-unit id="IntegrationCommandDescription">
+        <source>Manage Aspire hosting integrations</source>
+        <target state="new">Manage Aspire hosting integrations</target>
         <note />
       </trans-unit>
-      <trans-unit id="ListOptionDescription">
-        <source>List available integrations without adding one</source>
-        <target state="new">List available integrations without adding one</target>
+      <trans-unit id="IntegrationSearchAppHostOptionDescription">
+        <source>The Aspire AppHost project file, or a directory to search, for channel-aware integration discovery</source>
+        <target state="new">The Aspire AppHost project file, or a directory to search, for channel-aware integration discovery</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="IntegrationSearchDescription">
+        <source>Search available Aspire hosting integrations</source>
+        <target state="new">Search available Aspire hosting integrations</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="IntegrationSearchQueryArgumentDescription">
+        <source>The integration search query. Omit to list all integrations.</source>
+        <target state="new">The integration search query. Omit to list all integrations.</target>
         <note />
       </trans-unit>
       <trans-unit id="NoIntegrationPackagesFound">
@@ -100,11 +110,6 @@
       <trans-unit id="ProjectArgumentDescription">
         <source>The Aspire AppHost project file, or a directory to search, to add the integration to</source>
         <target state="needs-review-translation">要将集成添加到的项目文件的路径。</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="SearchOptionDescription">
-        <source>Search available integrations without adding one</source>
-        <target state="new">Search available integrations without adding one</target>
         <note />
       </trans-unit>
       <trans-unit id="SearchingForAspirePackages">

--- a/src/Aspire.Cli/Resources/xlf/AddCommandStrings.zh-Hant.xlf
+++ b/src/Aspire.Cli/Resources/xlf/AddCommandStrings.zh-Hant.xlf
@@ -12,9 +12,44 @@
         <target state="needs-review-translation">將主機整合新增到 Aspire AppHost。</target>
         <note />
       </trans-unit>
+      <trans-unit id="DiscoveryOptionsCannotBeCombinedWithAddOptions">
+        <source>The --list and --search options cannot be combined with an integration name, --version, or --source.</source>
+        <target state="new">The --list and --search options cannot be combined with an integration name, --version, or --source.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ErrorOccurredWhileAddingPackage">
         <source>An error occurred while adding the package: {0}</source>
         <target state="translated">新增套件時發生錯誤: {0}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FormatOptionDescription">
+        <source>Output format (Table or Json)</source>
+        <target state="new">Output format (Table or Json)</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FoundIntegrationPackages">
+        <source>Found {0} integration package(s).</source>
+        <target state="new">Found {0} integration package(s).</target>
+        <note>{0} is the number of integration packages found.</note>
+      </trans-unit>
+      <trans-unit id="FoundIntegrationPackagesMatchingSearchTerm">
+        <source>Found {0} integration package(s) matching '{1}'.</source>
+        <target state="new">Found {0} integration package(s) matching '{1}'.</target>
+        <note>{0} is the number of integration packages found, {1} is the search term provided by the user.</note>
+      </trans-unit>
+      <trans-unit id="HeaderName">
+        <source>Name</source>
+        <target state="new">Name</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HeaderPackage">
+        <source>Package</source>
+        <target state="new">Package</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HeaderVersion">
+        <source>Version</source>
+        <target state="new">Version</target>
         <note />
       </trans-unit>
       <trans-unit id="IntegrationArgumentDescription">
@@ -22,10 +57,25 @@
         <target state="needs-review-translation">要新增的整合名稱 (例如 redis、postgres)。</target>
         <note />
       </trans-unit>
+      <trans-unit id="JsonRequiresListOrSearch">
+        <source>JSON output must be used with --list or --search.</source>
+        <target state="new">JSON output must be used with --list or --search.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ListOptionDescription">
+        <source>List available integrations without adding one</source>
+        <target state="new">List available integrations without adding one</target>
+        <note />
+      </trans-unit>
       <trans-unit id="NoIntegrationPackagesFound">
         <source>No integration packages were found. Please check your internet connection or NuGet source configuration.</source>
         <target state="translated">找不到整合套件。請檢查您的網際網路連線或 NuGet 來源設定。</target>
         <note />
+      </trans-unit>
+      <trans-unit id="NoIntegrationPackagesMatchedSearchTerm">
+        <source>No integration packages matched '{0}'.</source>
+        <target state="new">No integration packages matched '{0}'.</target>
+        <note>{0} is the search term provided by the user.</note>
       </trans-unit>
       <trans-unit id="NoPackagesFound">
         <source>No packages found.</source>
@@ -50,6 +100,11 @@
       <trans-unit id="ProjectArgumentDescription">
         <source>The Aspire AppHost project file, or a directory to search, to add the integration to</source>
         <target state="needs-review-translation">要新增整合的專案檔路徑。</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SearchOptionDescription">
+        <source>Search available integrations without adding one</source>
+        <target state="new">Search available integrations without adding one</target>
         <note />
       </trans-unit>
       <trans-unit id="SearchingForAspirePackages">

--- a/src/Aspire.Cli/Resources/xlf/AddCommandStrings.zh-Hant.xlf
+++ b/src/Aspire.Cli/Resources/xlf/AddCommandStrings.zh-Hant.xlf
@@ -62,6 +62,11 @@
         <target state="new">Manage Aspire hosting integrations</target>
         <note />
       </trans-unit>
+      <trans-unit id="IntegrationListDescription">
+        <source>List available Aspire hosting integrations</source>
+        <target state="new">List available Aspire hosting integrations</target>
+        <note />
+      </trans-unit>
       <trans-unit id="IntegrationSearchAppHostOptionDescription">
         <source>The Aspire AppHost project file, or a directory to search, for channel-aware integration discovery</source>
         <target state="new">The Aspire AppHost project file, or a directory to search, for channel-aware integration discovery</target>
@@ -73,8 +78,8 @@
         <note />
       </trans-unit>
       <trans-unit id="IntegrationSearchQueryArgumentDescription">
-        <source>The integration search query. Omit to list all integrations.</source>
-        <target state="new">The integration search query. Omit to list all integrations.</target>
+        <source>The integration search query.</source>
+        <target state="new">The integration search query.</target>
         <note />
       </trans-unit>
       <trans-unit id="NoIntegrationPackagesFound">

--- a/src/Aspire.Cli/Resources/xlf/AddCommandStrings.zh-Hant.xlf
+++ b/src/Aspire.Cli/Resources/xlf/AddCommandStrings.zh-Hant.xlf
@@ -12,14 +12,14 @@
         <target state="needs-review-translation">將主機整合新增到 Aspire AppHost。</target>
         <note />
       </trans-unit>
-      <trans-unit id="DiscoveryOptionsCannotBeCombinedWithAddOptions">
-        <source>The --list and --search options cannot be combined with an integration name, --version, or --source.</source>
-        <target state="new">The --list and --search options cannot be combined with an integration name, --version, or --source.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ErrorOccurredWhileAddingPackage">
         <source>An error occurred while adding the package: {0}</source>
         <target state="translated">新增套件時發生錯誤: {0}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ErrorOccurredWhileSearchingIntegrations">
+        <source>An error occurred while searching integrations: {0}</source>
+        <target state="new">An error occurred while searching integrations: {0}</target>
         <note />
       </trans-unit>
       <trans-unit id="FormatOptionDescription">
@@ -57,14 +57,24 @@
         <target state="needs-review-translation">要新增的整合名稱 (例如 redis、postgres)。</target>
         <note />
       </trans-unit>
-      <trans-unit id="JsonRequiresListOrSearch">
-        <source>JSON output must be used with --list or --search.</source>
-        <target state="new">JSON output must be used with --list or --search.</target>
+      <trans-unit id="IntegrationCommandDescription">
+        <source>Manage Aspire hosting integrations</source>
+        <target state="new">Manage Aspire hosting integrations</target>
         <note />
       </trans-unit>
-      <trans-unit id="ListOptionDescription">
-        <source>List available integrations without adding one</source>
-        <target state="new">List available integrations without adding one</target>
+      <trans-unit id="IntegrationSearchAppHostOptionDescription">
+        <source>The Aspire AppHost project file, or a directory to search, for channel-aware integration discovery</source>
+        <target state="new">The Aspire AppHost project file, or a directory to search, for channel-aware integration discovery</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="IntegrationSearchDescription">
+        <source>Search available Aspire hosting integrations</source>
+        <target state="new">Search available Aspire hosting integrations</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="IntegrationSearchQueryArgumentDescription">
+        <source>The integration search query. Omit to list all integrations.</source>
+        <target state="new">The integration search query. Omit to list all integrations.</target>
         <note />
       </trans-unit>
       <trans-unit id="NoIntegrationPackagesFound">
@@ -100,11 +110,6 @@
       <trans-unit id="ProjectArgumentDescription">
         <source>The Aspire AppHost project file, or a directory to search, to add the integration to</source>
         <target state="needs-review-translation">要新增整合的專案檔路徑。</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="SearchOptionDescription">
-        <source>Search available integrations without adding one</source>
-        <target state="new">Search available integrations without adding one</target>
         <note />
       </trans-unit>
       <trans-unit id="SearchingForAspirePackages">

--- a/tests/Aspire.Cli.Tests/Commands/AddCommandTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/AddCommandTests.cs
@@ -1,9 +1,11 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Text.Json;
 using Aspire.Cli.Commands;
 using Aspire.Cli.Interaction;
 using Aspire.Cli.Packaging;
+using Aspire.Cli.Projects;
 using Aspire.Cli.Resources;
 using Aspire.Cli.Tests.TestServices;
 using Aspire.Cli.Tests.Utils;
@@ -28,6 +30,277 @@ public class AddCommandTests(ITestOutputHelper outputHelper)
 
         var exitCode = await result.InvokeAsync().DefaultTimeout();
         Assert.Equal(0, exitCode);
+    }
+
+    [Fact]
+    public async Task AddCommandWithJsonOptionDoesNotEmitDiscoveryJson()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        var rawJson = string.Empty;
+        var testInteractionService = new TestInteractionService
+        {
+            DisplayRawTextCallback = text => rawJson = text
+        };
+
+        var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper, options =>
+        {
+            options.InteractionServiceFactory = _ => testInteractionService;
+            options.DotNetCliRunnerFactory = _ =>
+            {
+                var runner = new TestDotNetCliRunner();
+                runner.SearchPackagesAsyncCallback = (_, _, _, _, _, _, _, _, _, _) => throw new InvalidOperationException("Should not search packages for the removed --json alias.");
+                return runner;
+            };
+        });
+        using var provider = services.BuildServiceProvider();
+
+        var command = provider.GetRequiredService<AddCommand>();
+        var result = command.Parse("add --list --json");
+
+        var exitCode = await result.InvokeAsync().DefaultTimeout();
+
+        Assert.Equal(ExitCodeConstants.MissingRequiredArgument, exitCode);
+        Assert.Empty(rawJson);
+        Assert.Contains(AddCommandStrings.DiscoveryOptionsCannotBeCombinedWithAddOptions, testInteractionService.DisplayedErrors);
+    }
+
+    [Fact]
+    public async Task AddCommandListFormatJsonReturnsAvailableIntegrationsWithoutPromptingOrAddingPackage()
+    {
+        var addPackageWasCalled = false;
+        var projectLocatorWasCalled = false;
+        var promptedForIntegration = false;
+        var promptedForVersion = false;
+        var rawJson = string.Empty;
+        var testInteractionService = new TestInteractionService
+        {
+            DisplayRawTextCallback = text => rawJson = text
+        };
+
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper, options =>
+        {
+            options.CliHostEnvironmentFactory = _ => TestHelpers.CreateNonInteractiveHostEnvironment();
+            options.InteractionServiceFactory = _ => testInteractionService;
+            options.ProjectLocatorFactory = _ => new TestProjectLocator
+            {
+                UseOrFindAppHostProjectFileWithBehaviorAsyncCallback = (_, _, _, _) =>
+                {
+                    projectLocatorWasCalled = true;
+                    return Task.FromResult(new AppHostProjectSearchResult(null, []));
+                }
+            };
+
+            options.AddCommandPrompterFactory = (sp) =>
+            {
+                var interactionService = sp.GetRequiredService<IInteractionService>();
+                var prompter = new TestAddCommandPrompter(interactionService);
+                prompter.PromptForIntegrationCallback = (_) =>
+                {
+                    promptedForIntegration = true;
+                    throw new InvalidOperationException("Should not prompt for integration when listing integrations.");
+                };
+                prompter.PromptForIntegrationVersionCallback = (_) =>
+                {
+                    promptedForVersion = true;
+                    throw new InvalidOperationException("Should not prompt for version when listing integrations.");
+                };
+                return prompter;
+            };
+
+            options.DotNetCliRunnerFactory = (sp) =>
+            {
+                var runner = new TestDotNetCliRunner();
+                runner.SearchPackagesAsyncCallback = (_, _, _, _, _, _, _, _, _, _) =>
+                {
+                    return (0, new[]
+                    {
+                        CreatePackage("Aspire.Hosting.Docker", "9.2.0"),
+                        CreatePackage("Aspire.Hosting.Redis", "9.2.0"),
+                        CreatePackage("Aspire.Hosting.Redis", "9.3.0"),
+                        CreatePackage("Aspire.Hosting.Azure.Redis", "9.2.0")
+                    });
+                };
+                runner.AddPackageAsyncCallback = (_, _, _, _, _, _, _) =>
+                {
+                    addPackageWasCalled = true;
+                    return 0;
+                };
+                return runner;
+            };
+        });
+        using var provider = services.BuildServiceProvider();
+
+        var command = provider.GetRequiredService<AddCommand>();
+        var result = command.Parse("add --list --format json");
+
+        var exitCode = await result.InvokeAsync().DefaultTimeout();
+
+        Assert.Equal(ExitCodeConstants.Success, exitCode);
+        Assert.False(projectLocatorWasCalled);
+        Assert.False(promptedForIntegration);
+        Assert.False(promptedForVersion);
+        Assert.False(addPackageWasCalled);
+
+        var integrations = ReadIntegrationResults(rawJson);
+        Assert.Equal(3, integrations.Length);
+        Assert.Contains(integrations, i => i.Name == "azure-redis" && i.Package == "Aspire.Hosting.Azure.Redis" && i.Version == "9.2.0");
+        Assert.Contains(integrations, i => i.Name == "docker" && i.Package == "Aspire.Hosting.Docker" && i.Version == "9.2.0");
+        Assert.Contains(integrations, i => i.Name == "redis" && i.Package == "Aspire.Hosting.Redis" && i.Version == "9.3.0");
+    }
+
+    [Fact]
+    public async Task AddCommandSearchFormatJsonFiltersAvailableIntegrationsWithoutAddingPackage()
+    {
+        var addPackageWasCalled = false;
+        var rawJson = string.Empty;
+        var testInteractionService = new TestInteractionService
+        {
+            DisplayRawTextCallback = text => rawJson = text
+        };
+
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper, options =>
+        {
+            options.CliHostEnvironmentFactory = _ => TestHelpers.CreateNonInteractiveHostEnvironment();
+            options.InteractionServiceFactory = _ => testInteractionService;
+            options.ProjectLocatorFactory = _ => new TestProjectLocator
+            {
+                UseOrFindAppHostProjectFileWithBehaviorAsyncCallback = (_, _, _, _) => throw new InvalidOperationException("Should not locate an AppHost when searching integrations.")
+            };
+
+            options.DotNetCliRunnerFactory = (sp) =>
+            {
+                var runner = new TestDotNetCliRunner();
+                runner.SearchPackagesAsyncCallback = (_, _, _, _, _, _, _, _, _, _) =>
+                {
+                    return (0, new[]
+                    {
+                        CreatePackage("Aspire.Hosting.Docker", "9.2.0"),
+                        CreatePackage("Aspire.Hosting.Redis", "9.2.0"),
+                        CreatePackage("Aspire.Hosting.Azure.Redis", "9.2.0")
+                    });
+                };
+                runner.AddPackageAsyncCallback = (_, _, _, _, _, _, _) =>
+                {
+                    addPackageWasCalled = true;
+                    return 0;
+                };
+                return runner;
+            };
+        });
+        using var provider = services.BuildServiceProvider();
+
+        var command = provider.GetRequiredService<AddCommand>();
+        var result = command.Parse("add --search redis --format json");
+
+        var exitCode = await result.InvokeAsync().DefaultTimeout();
+
+        Assert.Equal(ExitCodeConstants.Success, exitCode);
+        Assert.False(addPackageWasCalled);
+
+        var integrations = ReadIntegrationResults(rawJson);
+        Assert.Equal(2, integrations.Length);
+        Assert.Contains(integrations, i => i.Package == "Aspire.Hosting.Redis");
+        Assert.Contains(integrations, i => i.Package == "Aspire.Hosting.Azure.Redis");
+        Assert.DoesNotContain(integrations, i => i.Package == "Aspire.Hosting.Docker");
+    }
+
+    [Fact]
+    public async Task AddCommandSearchFormatJsonUsesFuzzyIntegrationMatching()
+    {
+        var rawJson = string.Empty;
+        var testInteractionService = new TestInteractionService
+        {
+            DisplayRawTextCallback = text => rawJson = text
+        };
+
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper, options =>
+        {
+            options.CliHostEnvironmentFactory = _ => TestHelpers.CreateNonInteractiveHostEnvironment();
+            options.InteractionServiceFactory = _ => testInteractionService;
+            options.DotNetCliRunnerFactory = (sp) =>
+            {
+                var runner = new TestDotNetCliRunner();
+                runner.SearchPackagesAsyncCallback = (_, _, _, _, _, _, _, _, _, _) =>
+                {
+                    return (0, new[]
+                    {
+                        CreatePackage("Aspire.Hosting.Docker", "9.2.0"),
+                        CreatePackage("Aspire.Hosting.Redis", "9.2.0"),
+                        CreatePackage("Aspire.Hosting.RabbitMQ", "9.2.0")
+                    });
+                };
+                return runner;
+            };
+        });
+        using var provider = services.BuildServiceProvider();
+
+        var command = provider.GetRequiredService<AddCommand>();
+        var result = command.Parse("add --search rdis --format json");
+
+        var exitCode = await result.InvokeAsync().DefaultTimeout();
+
+        Assert.Equal(ExitCodeConstants.Success, exitCode);
+
+        var integrations = ReadIntegrationResults(rawJson);
+        var integration = Assert.Single(integrations);
+        Assert.Equal("redis", integration.Name);
+        Assert.Equal("Aspire.Hosting.Redis", integration.Package);
+    }
+
+    [Fact]
+    public async Task AddCommandSearchFormatJsonReturnsEmptyArrayWhenNoIntegrationsMatch()
+    {
+        var addPackageWasCalled = false;
+        var rawJson = string.Empty;
+        var testInteractionService = new TestInteractionService
+        {
+            DisplayRawTextCallback = text => rawJson = text
+        };
+
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper, options =>
+        {
+            options.CliHostEnvironmentFactory = _ => TestHelpers.CreateNonInteractiveHostEnvironment();
+            options.InteractionServiceFactory = _ => testInteractionService;
+            options.ProjectLocatorFactory = _ => new TestProjectLocator
+            {
+                UseOrFindAppHostProjectFileWithBehaviorAsyncCallback = (_, _, _, _) => throw new InvalidOperationException("Should not locate an AppHost when searching integrations.")
+            };
+
+            options.DotNetCliRunnerFactory = (sp) =>
+            {
+                var runner = new TestDotNetCliRunner();
+                runner.SearchPackagesAsyncCallback = (_, _, _, _, _, _, _, _, _, _) =>
+                {
+                    return (0, new[]
+                    {
+                        CreatePackage("Aspire.Hosting.Docker", "9.2.0"),
+                        CreatePackage("Aspire.Hosting.Redis", "9.2.0")
+                    });
+                };
+                runner.AddPackageAsyncCallback = (_, _, _, _, _, _, _) =>
+                {
+                    addPackageWasCalled = true;
+                    return 0;
+                };
+                return runner;
+            };
+        });
+        using var provider = services.BuildServiceProvider();
+
+        var command = provider.GetRequiredService<AddCommand>();
+        var result = command.Parse("add --search azure --format json");
+
+        var exitCode = await result.InvokeAsync().DefaultTimeout();
+
+        Assert.Equal(ExitCodeConstants.Success, exitCode);
+        Assert.False(addPackageWasCalled);
+
+        var integrations = ReadIntegrationResults(rawJson);
+        Assert.Empty(integrations);
     }
 
     [Fact]
@@ -1493,6 +1766,27 @@ public class AddCommandTests(ITestOutputHelper outputHelper)
         Assert.Equal(0, exitCode);
         Assert.False(promptedForVersion);
         Assert.Equal(cliVersion, selectedPackageVersion);
+    }
+
+    private static NuGetPackage CreatePackage(string id, string version)
+    {
+        return new NuGetPackage
+        {
+            Id = id,
+            Source = "nuget",
+            Version = version
+        };
+    }
+
+    private static (string? Name, string? Package, string? Version)[] ReadIntegrationResults(string json)
+    {
+        using var document = JsonDocument.Parse(json);
+        return document.RootElement.EnumerateArray()
+            .Select(element => (
+                Name: element.GetProperty("name").GetString(),
+                Package: element.GetProperty("package").GetString(),
+                Version: element.GetProperty("version").GetString()))
+            .ToArray();
     }
 }
 

--- a/tests/Aspire.Cli.Tests/Commands/AddCommandTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/AddCommandTests.cs
@@ -194,6 +194,64 @@ public class AddCommandTests(ITestOutputHelper outputHelper)
         Assert.Contains(integrations, i => i.Name == "redis" && i.Package == "Aspire.Hosting.Redis" && i.Version == "9.3.0");
     }
 
+    [Theory]
+    [InlineData("integration list --format json")]
+    [InlineData("integration search redis --format json")]
+    public async Task IntegrationDiscoveryCommandFormatJsonReturnsEmptyArrayWhenNoIntegrationsAreAvailable(string commandLine)
+    {
+        var rawJson = string.Empty;
+        var testInteractionService = new TestInteractionService
+        {
+            DisplayRawTextCallback = text => rawJson = text
+        };
+
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper, options =>
+        {
+            options.CliHostEnvironmentFactory = _ => TestHelpers.CreateNonInteractiveHostEnvironment();
+            options.InteractionServiceFactory = _ => testInteractionService;
+            options.DotNetCliRunnerFactory = _ =>
+            {
+                var runner = new TestDotNetCliRunner();
+                runner.SearchPackagesAsyncCallback = (_, _, _, _, _, _, _, _, _, _) => (0, []);
+                return runner;
+            };
+        });
+        using var provider = services.BuildServiceProvider();
+
+        var command = provider.GetRequiredService<RootCommand>();
+        var result = command.Parse(commandLine);
+
+        var exitCode = await result.InvokeAsync().DefaultTimeout();
+
+        Assert.Equal(ExitCodeConstants.Success, exitCode);
+        Assert.Empty(ReadIntegrationResults(rawJson));
+    }
+
+    [Fact]
+    public async Task IntegrationDiscoveryCommandReturnsSearchFailureExitCodeWhenPackageDiscoveryFails()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper, options =>
+        {
+            options.CliHostEnvironmentFactory = _ => TestHelpers.CreateNonInteractiveHostEnvironment();
+            options.DotNetCliRunnerFactory = _ =>
+            {
+                var runner = new TestDotNetCliRunner();
+                runner.SearchPackagesAsyncCallback = (_, _, _, _, _, _, _, _, _, _) => throw new InvalidOperationException("Search failed.");
+                return runner;
+            };
+        });
+        using var provider = services.BuildServiceProvider();
+
+        var command = provider.GetRequiredService<RootCommand>();
+        var result = command.Parse("integration list");
+
+        var exitCode = await result.InvokeAsync().DefaultTimeout();
+
+        Assert.Equal(ExitCodeConstants.FailedToSearchIntegrations, exitCode);
+    }
+
     [Fact]
     public async Task IntegrationSearchCommandFormatJsonFiltersAvailableIntegrationsWithoutAddingPackage()
     {

--- a/tests/Aspire.Cli.Tests/Commands/AddCommandTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/AddCommandTests.cs
@@ -79,7 +79,38 @@ public class AddCommandTests(ITestOutputHelper outputHelper)
     }
 
     [Fact]
-    public async Task IntegrationSearchCommandFormatJsonReturnsAvailableIntegrationsWithoutPromptingOrAddingPackage()
+    public async Task IntegrationSearchCommandRequiresQuery()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        var rawJson = string.Empty;
+        var testInteractionService = new TestInteractionService
+        {
+            DisplayRawTextCallback = text => rawJson = text
+        };
+
+        var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper, options =>
+        {
+            options.InteractionServiceFactory = _ => testInteractionService;
+            options.DotNetCliRunnerFactory = _ =>
+            {
+                var runner = new TestDotNetCliRunner();
+                runner.SearchPackagesAsyncCallback = (_, _, _, _, _, _, _, _, _, _) => throw new InvalidOperationException("Should not search packages when the required search query is missing.");
+                return runner;
+            };
+        });
+        using var provider = services.BuildServiceProvider();
+
+        var command = provider.GetRequiredService<RootCommand>();
+        var result = command.Parse("integration search --format json");
+
+        var exitCode = await result.InvokeAsync().DefaultTimeout();
+
+        Assert.Equal(ExitCodeConstants.InvalidCommand, exitCode);
+        Assert.Empty(rawJson);
+    }
+
+    [Fact]
+    public async Task IntegrationListCommandFormatJsonReturnsAvailableIntegrationsWithoutPromptingOrAddingPackage()
     {
         var addPackageWasCalled = false;
         var projectLocatorWasCalled = false;
@@ -146,7 +177,7 @@ public class AddCommandTests(ITestOutputHelper outputHelper)
         using var provider = services.BuildServiceProvider();
 
         var command = provider.GetRequiredService<RootCommand>();
-        var result = command.Parse("integration search --format json");
+        var result = command.Parse("integration list --format json");
 
         var exitCode = await result.InvokeAsync().DefaultTimeout();
 
@@ -318,7 +349,7 @@ public class AddCommandTests(ITestOutputHelper outputHelper)
     }
 
     [Fact]
-    public async Task IntegrationSearchCommandFormatJsonPrefersImplicitChannelWhenMultipleChannelsContainSameIntegration()
+    public async Task IntegrationListCommandFormatJsonPrefersImplicitChannelWhenMultipleChannelsContainSameIntegration()
     {
         var rawJson = string.Empty;
         var testInteractionService = new TestInteractionService
@@ -353,7 +384,7 @@ public class AddCommandTests(ITestOutputHelper outputHelper)
         using var provider = services.BuildServiceProvider();
 
         var command = provider.GetRequiredService<RootCommand>();
-        var result = command.Parse("integration search --format json");
+        var result = command.Parse("integration list --format json");
 
         var exitCode = await result.InvokeAsync().DefaultTimeout();
 

--- a/tests/Aspire.Cli.Tests/Commands/AddCommandTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/AddCommandTests.cs
@@ -34,7 +34,21 @@ public class AddCommandTests(ITestOutputHelper outputHelper)
     }
 
     [Fact]
-    public async Task AddCommandWithJsonOptionDoesNotEmitDiscoveryJson()
+    public async Task IntegrationAddCommandWithHelpArgumentReturnsZero()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper);
+        using var provider = services.BuildServiceProvider();
+
+        var command = provider.GetRequiredService<RootCommand>();
+        var result = command.Parse("integration add --help");
+
+        var exitCode = await result.InvokeAsync().DefaultTimeout();
+        Assert.Equal(0, exitCode);
+    }
+
+    [Fact]
+    public async Task IntegrationSearchCommandWithJsonOptionDoesNotEmitDiscoveryJson()
     {
         using var workspace = TemporaryWorkspace.Create(outputHelper);
         var rawJson = string.Empty;
@@ -55,18 +69,17 @@ public class AddCommandTests(ITestOutputHelper outputHelper)
         });
         using var provider = services.BuildServiceProvider();
 
-        var command = provider.GetRequiredService<AddCommand>();
-        var result = command.Parse("add --list --json");
+        var command = provider.GetRequiredService<RootCommand>();
+        var result = command.Parse("integration search redis --json");
 
         var exitCode = await result.InvokeAsync().DefaultTimeout();
 
-        Assert.Equal(ExitCodeConstants.MissingRequiredArgument, exitCode);
+        Assert.Equal(ExitCodeConstants.InvalidCommand, exitCode);
         Assert.Empty(rawJson);
-        Assert.Contains(AddCommandStrings.DiscoveryOptionsCannotBeCombinedWithAddOptions, testInteractionService.DisplayedErrors);
     }
 
     [Fact]
-    public async Task AddCommandListFormatJsonReturnsAvailableIntegrationsWithoutPromptingOrAddingPackage()
+    public async Task IntegrationSearchCommandFormatJsonReturnsAvailableIntegrationsWithoutPromptingOrAddingPackage()
     {
         var addPackageWasCalled = false;
         var projectLocatorWasCalled = false;
@@ -132,8 +145,8 @@ public class AddCommandTests(ITestOutputHelper outputHelper)
         });
         using var provider = services.BuildServiceProvider();
 
-        var command = provider.GetRequiredService<AddCommand>();
-        var result = command.Parse("add --list --format json");
+        var command = provider.GetRequiredService<RootCommand>();
+        var result = command.Parse("integration search --format json");
 
         var exitCode = await result.InvokeAsync().DefaultTimeout();
 
@@ -151,7 +164,7 @@ public class AddCommandTests(ITestOutputHelper outputHelper)
     }
 
     [Fact]
-    public async Task AddCommandSearchFormatJsonFiltersAvailableIntegrationsWithoutAddingPackage()
+    public async Task IntegrationSearchCommandFormatJsonFiltersAvailableIntegrationsWithoutAddingPackage()
     {
         var addPackageWasCalled = false;
         var rawJson = string.Empty;
@@ -192,8 +205,8 @@ public class AddCommandTests(ITestOutputHelper outputHelper)
         });
         using var provider = services.BuildServiceProvider();
 
-        var command = provider.GetRequiredService<AddCommand>();
-        var result = command.Parse("add --search redis --format json");
+        var command = provider.GetRequiredService<RootCommand>();
+        var result = command.Parse("integration search redis --format json");
 
         var exitCode = await result.InvokeAsync().DefaultTimeout();
 
@@ -208,7 +221,7 @@ public class AddCommandTests(ITestOutputHelper outputHelper)
     }
 
     [Fact]
-    public async Task AddCommandSearchFormatJsonUsesFuzzyIntegrationMatching()
+    public async Task IntegrationSearchCommandFormatJsonUsesFuzzyIntegrationMatching()
     {
         var rawJson = string.Empty;
         var testInteractionService = new TestInteractionService
@@ -238,8 +251,8 @@ public class AddCommandTests(ITestOutputHelper outputHelper)
         });
         using var provider = services.BuildServiceProvider();
 
-        var command = provider.GetRequiredService<AddCommand>();
-        var result = command.Parse("add --search rdis --format json");
+        var command = provider.GetRequiredService<RootCommand>();
+        var result = command.Parse("integration search rdis --format json");
 
         var exitCode = await result.InvokeAsync().DefaultTimeout();
 
@@ -252,7 +265,7 @@ public class AddCommandTests(ITestOutputHelper outputHelper)
     }
 
     [Fact]
-    public async Task AddCommandSearchFormatJsonWithAppHostUsesConfiguredChannel()
+    public async Task IntegrationSearchCommandFormatJsonWithAppHostUsesConfiguredChannel()
     {
         var rawJson = string.Empty;
         var testInteractionService = new TestInteractionService
@@ -292,8 +305,8 @@ public class AddCommandTests(ITestOutputHelper outputHelper)
         services.AddSingleton<IAppHostProjectFactory>(new TestTypeScriptStarterProjectFactory((_, _) => Task.FromResult(true)));
         using var provider = services.BuildServiceProvider();
 
-        var command = provider.GetRequiredService<AddCommand>();
-        var result = command.Parse($"add --apphost \"{appHostFile.FullName}\" --search redis --format json");
+        var command = provider.GetRequiredService<RootCommand>();
+        var result = command.Parse($"integration search redis --apphost \"{appHostFile.FullName}\" --format json");
 
         var exitCode = await result.InvokeAsync().DefaultTimeout();
 
@@ -305,7 +318,7 @@ public class AddCommandTests(ITestOutputHelper outputHelper)
     }
 
     [Fact]
-    public async Task AddCommandListFormatJsonPrefersImplicitChannelWhenMultipleChannelsContainSameIntegration()
+    public async Task IntegrationSearchCommandFormatJsonPrefersImplicitChannelWhenMultipleChannelsContainSameIntegration()
     {
         var rawJson = string.Empty;
         var testInteractionService = new TestInteractionService
@@ -339,8 +352,8 @@ public class AddCommandTests(ITestOutputHelper outputHelper)
         });
         using var provider = services.BuildServiceProvider();
 
-        var command = provider.GetRequiredService<AddCommand>();
-        var result = command.Parse("add --list --format json");
+        var command = provider.GetRequiredService<RootCommand>();
+        var result = command.Parse("integration search --format json");
 
         var exitCode = await result.InvokeAsync().DefaultTimeout();
 
@@ -352,7 +365,7 @@ public class AddCommandTests(ITestOutputHelper outputHelper)
     }
 
     [Fact]
-    public async Task AddCommandSearchFormatJsonReturnsEmptyArrayWhenNoIntegrationsMatch()
+    public async Task IntegrationSearchCommandFormatJsonReturnsEmptyArrayWhenNoIntegrationsMatch()
     {
         var addPackageWasCalled = false;
         var rawJson = string.Empty;
@@ -392,8 +405,8 @@ public class AddCommandTests(ITestOutputHelper outputHelper)
         });
         using var provider = services.BuildServiceProvider();
 
-        var command = provider.GetRequiredService<AddCommand>();
-        var result = command.Parse("add --search azure --format json");
+        var command = provider.GetRequiredService<RootCommand>();
+        var result = command.Parse("integration search azure --format json");
 
         var exitCode = await result.InvokeAsync().DefaultTimeout();
 
@@ -1514,7 +1527,7 @@ public class AddCommandTests(ITestOutputHelper outputHelper)
         var package = new NuGetPackage { Id = packageId, Version = "1.0.0", Source = "test" };
 
         // Act
-        var result = AddCommand.GenerateFriendlyName((package, null!)); // Null is OK for this test.
+        var result = IntegrationPackageSearchService.GenerateFriendlyName((package, null!)); // Null is OK for this test.
 
         // Assert
         Assert.Equal(expectedFriendlyName, result.FriendlyName);

--- a/tests/Aspire.Cli.Tests/Commands/AddCommandTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/AddCommandTests.cs
@@ -3,6 +3,7 @@
 
 using System.Text.Json;
 using Aspire.Cli.Commands;
+using Aspire.Cli.Configuration;
 using Aspire.Cli.Interaction;
 using Aspire.Cli.Packaging;
 using Aspire.Cli.Projects;
@@ -248,6 +249,106 @@ public class AddCommandTests(ITestOutputHelper outputHelper)
         var integration = Assert.Single(integrations);
         Assert.Equal("redis", integration.Name);
         Assert.Equal("Aspire.Hosting.Redis", integration.Package);
+    }
+
+    [Fact]
+    public async Task AddCommandSearchFormatJsonWithAppHostUsesConfiguredChannel()
+    {
+        var rawJson = string.Empty;
+        var testInteractionService = new TestInteractionService
+        {
+            DisplayRawTextCallback = text => rawJson = text
+        };
+
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        var appHostFile = new FileInfo(Path.Combine(workspace.WorkspaceRoot.FullName, "apphost.ts"));
+        File.WriteAllText(appHostFile.FullName, string.Empty);
+        File.WriteAllText(Path.Combine(workspace.WorkspaceRoot.FullName, AspireConfigFile.FileName), """
+            {
+              "channel": "daily"
+            }
+            """);
+
+        var implicitCache = new FakeNuGetPackageCache
+        {
+            GetIntegrationPackagesAsyncCallback = (_, _, _, _) => Task.FromResult<IEnumerable<NuGetPackage>>([CreatePackage("Aspire.Hosting.Redis", "1.0.0")])
+        };
+        var dailyCache = new FakeNuGetPackageCache
+        {
+            GetIntegrationPackagesAsyncCallback = (_, _, _, _) => Task.FromResult<IEnumerable<NuGetPackage>>([CreatePackage("Aspire.Hosting.Redis", "2.0.0")])
+        };
+
+        var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper, options =>
+        {
+            options.InteractionServiceFactory = _ => testInteractionService;
+            options.PackagingServiceFactory = _ => new TestPackagingService
+            {
+                GetChannelsAsyncCallback = _ => Task.FromResult<IEnumerable<PackageChannel>>([
+                    PackageChannel.CreateImplicitChannel(implicitCache),
+                    PackageChannel.CreateExplicitChannel("daily", PackageChannelQuality.Both, [new PackageMapping("Aspire*", "daily")], dailyCache)
+                ])
+            };
+        });
+        services.AddSingleton<IAppHostProjectFactory>(new TestTypeScriptStarterProjectFactory((_, _) => Task.FromResult(true)));
+        using var provider = services.BuildServiceProvider();
+
+        var command = provider.GetRequiredService<AddCommand>();
+        var result = command.Parse($"add --apphost \"{appHostFile.FullName}\" --search redis --format json");
+
+        var exitCode = await result.InvokeAsync().DefaultTimeout();
+
+        Assert.Equal(ExitCodeConstants.Success, exitCode);
+
+        var integration = Assert.Single(ReadIntegrationResults(rawJson));
+        Assert.Equal("Aspire.Hosting.Redis", integration.Package);
+        Assert.Equal("2.0.0", integration.Version);
+    }
+
+    [Fact]
+    public async Task AddCommandListFormatJsonPrefersImplicitChannelWhenMultipleChannelsContainSameIntegration()
+    {
+        var rawJson = string.Empty;
+        var testInteractionService = new TestInteractionService
+        {
+            DisplayRawTextCallback = text => rawJson = text
+        };
+
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        Directory.CreateDirectory(Path.Combine(workspace.WorkspaceRoot.FullName, ".aspire", "hives", "test-hive"));
+
+        var implicitCache = new FakeNuGetPackageCache
+        {
+            GetIntegrationPackagesAsyncCallback = (_, _, _, _) => Task.FromResult<IEnumerable<NuGetPackage>>([CreatePackage("Aspire.Hosting.Redis", "1.0.0")])
+        };
+        var explicitCache = new FakeNuGetPackageCache
+        {
+            GetIntegrationPackagesAsyncCallback = (_, _, _, _) => Task.FromResult<IEnumerable<NuGetPackage>>([CreatePackage("Aspire.Hosting.Redis", "2.0.0")])
+        };
+
+        var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper, options =>
+        {
+            options.InteractionServiceFactory = _ => testInteractionService;
+            options.ProjectLocatorFactory = _ => new TestProjectLocator();
+            options.PackagingServiceFactory = _ => new TestPackagingService
+            {
+                GetChannelsAsyncCallback = _ => Task.FromResult<IEnumerable<PackageChannel>>([
+                    PackageChannel.CreateImplicitChannel(implicitCache),
+                    PackageChannel.CreateExplicitChannel("test-hive", PackageChannelQuality.Both, [new PackageMapping("Aspire*", "test-hive")], explicitCache)
+                ])
+            };
+        });
+        using var provider = services.BuildServiceProvider();
+
+        var command = provider.GetRequiredService<AddCommand>();
+        var result = command.Parse("add --list --format json");
+
+        var exitCode = await result.InvokeAsync().DefaultTimeout();
+
+        Assert.Equal(ExitCodeConstants.Success, exitCode);
+
+        var integration = Assert.Single(ReadIntegrationResults(rawJson));
+        Assert.Equal("Aspire.Hosting.Redis", integration.Package);
+        Assert.Equal("1.0.0", integration.Version);
     }
 
     [Fact]

--- a/tests/Aspire.Cli.Tests/Commands/BaseCommandTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/BaseCommandTests.cs
@@ -38,6 +38,31 @@ public class BaseCommandTests(ITestOutputHelper outputHelper)
     }
 
     [Fact]
+    public async Task BaseCommand_AddDiscoveryFormatJson_SetsConsoleOutputCorrectly()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        var testInteractionService = new TestInteractionService();
+        var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper, options =>
+        {
+            options.InteractionServiceFactory = _ => testInteractionService;
+            options.DotNetCliRunnerFactory = _ =>
+            {
+                var runner = new TestDotNetCliRunner();
+                runner.SearchPackagesAsyncCallback = (_, _, _, _, _, _, _, _, _, _) => (0, []);
+                return runner;
+            };
+        });
+        using var provider = services.BuildServiceProvider();
+
+        var command = provider.GetRequiredService<RootCommand>();
+        var result = command.Parse("add --list --format json");
+
+        await result.InvokeAsync().DefaultTimeout();
+
+        Assert.Equal(ConsoleOutput.Error, testInteractionService.Console);
+    }
+
+    [Fact]
     public async Task BaseCommand_WithNoUpdateNotification_DoesNotDisplayTrailingBlankLine()
     {
         using var workspace = TemporaryWorkspace.Create(outputHelper);

--- a/tests/Aspire.Cli.Tests/Commands/BaseCommandTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/BaseCommandTests.cs
@@ -38,7 +38,7 @@ public class BaseCommandTests(ITestOutputHelper outputHelper)
     }
 
     [Fact]
-    public async Task BaseCommand_IntegrationSearchFormatJson_SetsConsoleOutputCorrectly()
+    public async Task BaseCommand_IntegrationListFormatJson_SetsConsoleOutputCorrectly()
     {
         using var workspace = TemporaryWorkspace.Create(outputHelper);
         var testInteractionService = new TestInteractionService();
@@ -55,7 +55,7 @@ public class BaseCommandTests(ITestOutputHelper outputHelper)
         using var provider = services.BuildServiceProvider();
 
         var command = provider.GetRequiredService<RootCommand>();
-        var result = command.Parse("integration search --format json");
+        var result = command.Parse("integration list --format json");
 
         await result.InvokeAsync().DefaultTimeout();
 

--- a/tests/Aspire.Cli.Tests/Commands/BaseCommandTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/BaseCommandTests.cs
@@ -38,7 +38,7 @@ public class BaseCommandTests(ITestOutputHelper outputHelper)
     }
 
     [Fact]
-    public async Task BaseCommand_AddDiscoveryFormatJson_SetsConsoleOutputCorrectly()
+    public async Task BaseCommand_IntegrationSearchFormatJson_SetsConsoleOutputCorrectly()
     {
         using var workspace = TemporaryWorkspace.Create(outputHelper);
         var testInteractionService = new TestInteractionService();
@@ -55,7 +55,7 @@ public class BaseCommandTests(ITestOutputHelper outputHelper)
         using var provider = services.BuildServiceProvider();
 
         var command = provider.GetRequiredService<RootCommand>();
-        var result = command.Parse("add --list --format json");
+        var result = command.Parse("integration search --format json");
 
         await result.InvokeAsync().DefaultTimeout();
 

--- a/tests/Aspire.Cli.Tests/Utils/CliTestHelper.cs
+++ b/tests/Aspire.Cli.Tests/Utils/CliTestHelper.cs
@@ -199,6 +199,7 @@ internal static class CliTestHelper
         services.AddTransient<IntegrationPackageSearchService>();
         services.AddTransient<IntegrationCommand>();
         services.AddTransient<IntegrationAddCommand>();
+        services.AddTransient<IntegrationListCommand>();
         services.AddTransient<IntegrationSearchCommand>();
         services.AddTransient<AddCommand>();
         services.AddTransient<DeployCommand>();

--- a/tests/Aspire.Cli.Tests/Utils/CliTestHelper.cs
+++ b/tests/Aspire.Cli.Tests/Utils/CliTestHelper.cs
@@ -198,7 +198,6 @@ internal static class CliTestHelper
         services.AddTransient<ExecCommand>();
         services.AddTransient<IntegrationPackageSearchService>();
         services.AddTransient<IntegrationCommand>();
-        services.AddTransient<IntegrationAddCommand>();
         services.AddTransient<IntegrationListCommand>();
         services.AddTransient<IntegrationSearchCommand>();
         services.AddTransient<AddCommand>();

--- a/tests/Aspire.Cli.Tests/Utils/CliTestHelper.cs
+++ b/tests/Aspire.Cli.Tests/Utils/CliTestHelper.cs
@@ -196,6 +196,10 @@ internal static class CliTestHelper
         services.AddTransient<DescribeCommand>();
         services.AddTransient<LogsCommand>();
         services.AddTransient<ExecCommand>();
+        services.AddTransient<IntegrationPackageSearchService>();
+        services.AddTransient<IntegrationCommand>();
+        services.AddTransient<IntegrationAddCommand>();
+        services.AddTransient<IntegrationSearchCommand>();
         services.AddTransient<AddCommand>();
         services.AddTransient<DeployCommand>();
         services.AddTransient<DestroyCommand>();


### PR DESCRIPTION
## Description

Adds non-interactive discovery for Aspire hosting integrations through the new `aspire integration` command group.

Summary:
- Adds `aspire integration list` to list available hosting integrations without modifying an AppHost.
- Adds `aspire integration search <query>` to filter available hosting integrations with the same fuzzy matching score and threshold used by `aspire add <integration>`.
- Adds `aspire integration add` as a grouped equivalent to the existing `aspire add` command, leaving the top-level `aspire add <integration>` flow intact.
- Supports machine-readable output with the existing CLI convention: `--format json`.
- Keeps the default/human-friendly table output for terminal usage.
- Shares package/channel discovery logic between `add`, `integration list`, and `integration search`, including configured-channel handling for non-C# AppHosts and implicit-channel preference.

Sample commands and output:

```powershell
aspire integration search rdis --format json --nologo
```

```json
[
  {
    "name": "redis",
    "package": "Aspire.Hosting.Redis",
    "version": "13.4.0-preview.1.26256.8"
  }
]
```

```powershell
aspire integration search rdis --nologo
```

```text
Searching for Aspire integrations...
Found 1 integration package(s) matching 'rdis'.
Name   Package               Version
redis  Aspire.Hosting.Redis  13.4.0-preview.1.26256.8
```

```powershell
aspire integration list --format json --nologo
```

```text
Total: 115
```

First results from the JSON list output:

```json
[
  {
    "name": "agentframework-devui",
    "package": "Aspire.Hosting.AgentFramework.DevUI",
    "version": "13.3.0-pr.16310.gbea945d6"
  },
  {
    "name": "aws",
    "package": "Aspire.Hosting.AWS",
    "version": "13.0.2"
  },
  {
    "name": "azure",
    "package": "Aspire.Hosting.Azure",
    "version": "13.4.0-preview.1.26256.8"
  }
]
```

```powershell
aspire integration search --format json --nologo
```

```text
Required argument missing for command: 'search'.

Usage:
  aspire integration search <query> [options]

ExitCode: 1
```

Validation:
- `dotnet build src\Aspire.Cli\Aspire.Cli.csproj /p:SkipNativeBuild=true`
- `dotnet test --project tests\Aspire.Cli.Tests\Aspire.Cli.Tests.csproj --no-launch-profile -- --filter-class "*.AddCommandTests" --filter-class "*.BaseCommandTests" --filter-class "*.RootCommandTests" --filter-class "*.AddCommandFuzzySearchTests" --filter-not-trait "quarantined=true" --filter-not-trait "outerloop=true" --hangdump --hangdump-timeout 3m`
- Manual built CLI checks:
  - `aspire integration list --format json` returns 115 integrations and includes `Aspire.Hosting.Redis`.
  - `aspire integration list` returns the human-friendly table output.
  - `aspire integration search rdis --format json` returns `redis` / `Aspire.Hosting.Redis`.
  - `aspire integration search rdis` returns the human-friendly table output.
  - `aspire integration search --format json` is rejected because search now requires `<query>`.
  - `aspire integration add --help` and `aspire add --help` both continue to work.

Resolves microsoft/aspire#15880

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to `aspire.dev` issue:
      - [New issue](https://github.com/microsoft/aspire.dev/issues/new)
  - [x] No
