### PR TITLE
Use MarkupHelpers.SafeLink for graceful link degradation in CLI

### DIFF
--- a/src/Aspire.Cli/Commands/DashboardRunCommand.cs
+++ b/src/Aspire.Cli/Commands/DashboardRunCommand.cs
@@ -324,10 +324,9 @@ internal sealed class DashboardRunCommand : BaseCommand
         grid.Columns[0].Width = longestLabelLength;
 
         // Dashboard row
-        var escapedDashboardUrl = Markup.Escape(info.DashboardUrl);
         grid.AddRow(
             new Align(new Markup($"[bold green]{dashboardLabel}[/]:"), HorizontalAlignment.Right),
-            new Markup($"[link={escapedDashboardUrl}]{escapedDashboardUrl}[/]"));
+            new Markup(MarkupHelpers.SafeLink(_interactionService, info.DashboardUrl)));
         grid.AddRow(Text.Empty, Text.Empty);
 
         // OTLP gRPC row

--- a/src/Aspire.Cli/Commands/DescribeCommand.cs
+++ b/src/Aspire.Cli/Commands/DescribeCommand.cs
@@ -318,7 +318,7 @@ internal sealed class DescribeCommand : BaseCommand
             if (!string.IsNullOrEmpty(dashboardBaseUrl))
             {
                 var resourceUrl = DashboardUrls.CombineUrl(dashboardBaseUrl, DashboardUrls.ResourcesUrl(resource: snapshot.Name));
-                nameMarkup = $"[link={resourceUrl}]{nameMarkup}[/]";
+                nameMarkup = MarkupHelpers.SafeLink(_interactionService, resourceUrl, nameMarkup);
             }
 
             table.AddRow(nameMarkup, type, stateText, healthText, endpoints);
@@ -375,13 +375,12 @@ internal sealed class DescribeCommand : BaseCommand
             .ThenByDescending(e => e.Url.StartsWith("https", StringComparison.OrdinalIgnoreCase))
             .ThenBy(e => e.Name, StringComparer.OrdinalIgnoreCase);
 
-    private static string FormatEndpointUrl(string url, string? displayName = null)
+    private string FormatEndpointUrl(string url, string? displayName = null)
     {
-        var escaped = url.EscapeMarkup();
-        var text = !string.IsNullOrEmpty(displayName) ? displayName.EscapeMarkup() : escaped;
+        var text = !string.IsNullOrEmpty(displayName) ? displayName : url;
         return KnownUnsupportedUrlSchemes.IsLinkableUrl(url)
-            ? $"[link={escaped}]{text}[/]"
-            : text;
+            ? MarkupHelpers.SafeLink(_interactionService, url, text)
+            : text.EscapeMarkup();
     }
 
     private static string ColorHealth(string health) => health.ToUpperInvariant() switch

--- a/src/Aspire.Cli/Commands/DescribeCommand.cs
+++ b/src/Aspire.Cli/Commands/DescribeCommand.cs
@@ -314,14 +314,18 @@ internal sealed class DescribeCommand : BaseCommand
             var stateText = ColorState(snapshot.State);
             var healthText = ColorHealth(snapshot.HealthStatus?.EscapeMarkup() ?? "-");
 
-            var nameMarkup = ColorResourceName(displayName, displayName.EscapeMarkup());
+            string nameMarkup;
             if (!string.IsNullOrEmpty(dashboardBaseUrl))
             {
                 var resourceUrl = DashboardUrls.CombineUrl(dashboardBaseUrl, DashboardUrls.ResourcesUrl(resource: snapshot.Name));
-                nameMarkup = MarkupHelpers.SafeLink(_interactionService, resourceUrl, nameMarkup);
+                nameMarkup = MarkupHelpers.SafeLink(_interactionService, resourceUrl, displayName);
+            }
+            else
+            {
+                nameMarkup = displayName.EscapeMarkup();
             }
 
-            table.AddRow(nameMarkup, type, stateText, healthText, endpoints);
+            table.AddRow(ColorResourceName(displayName, nameMarkup), type, stateText, healthText, endpoints);
         }
 
         _interactionService.DisplayRenderable(table);

--- a/src/Aspire.Cli/Commands/DoctorCommand.cs
+++ b/src/Aspire.Cli/Commands/DoctorCommand.cs
@@ -122,7 +122,7 @@ internal sealed class DoctorCommand : BaseCommand
         if (warnings > 0 || failed > 0)
         {
             const string prerequisitesUrl = "https://aka.ms/aspire-prerequisites";
-            _ansiConsole.MarkupLine(string.Format(CultureInfo.CurrentCulture, DoctorCommandStrings.DetailedPrerequisitesLink, $"[link]{prerequisitesUrl}[/]"));
+            _ansiConsole.MarkupLine(string.Format(CultureInfo.CurrentCulture, DoctorCommandStrings.DetailedPrerequisitesLink, MarkupHelpers.SafeLink(InteractionService, prerequisitesUrl)));
         }
     }
 
@@ -160,7 +160,7 @@ internal sealed class DoctorCommand : BaseCommand
 
             if (hasLink)
             {
-                detailGrid.AddRow(new Markup($"See: [link={result.Link!.EscapeMarkup()}]{result.Link!.EscapeMarkup()}[/]"));
+                detailGrid.AddRow(new Markup($"See: {MarkupHelpers.SafeLink(InteractionService, result.Link!)}"));
             }
 
             if (hasDetails)

--- a/src/Aspire.Cli/Commands/PsCommand.cs
+++ b/src/Aspire.Cli/Commands/PsCommand.cs
@@ -263,7 +263,7 @@ internal sealed class PsCommand : BaseCommand
             {
                 if (Uri.TryCreate(appHost.DashboardUrl, UriKind.Absolute, out _))
                 {
-                    dashboard = $"[link={Markup.Escape(appHost.DashboardUrl)}]{Markup.Escape(appHost.DashboardUrl)}[/]";
+                    dashboard = MarkupHelpers.SafeLink(_interactionService, appHost.DashboardUrl);
                 }
                 else
                 {

--- a/src/Aspire.Cli/Commands/RunCommand.cs
+++ b/src/Aspire.Cli/Commands/RunCommand.cs
@@ -345,7 +345,7 @@ internal sealed class RunCommand : BaseCommand
                                 i == 0
                                     ? new Align(new Markup($"[bold green]{endpointsLocalizedString}[/]:"), HorizontalAlignment.Right)
                                     : Text.Empty,
-                                new Markup($"[bold]{resource.EscapeMarkup()}[/] [grey]has endpoint[/] [link={endpoint.EscapeMarkup()}]{endpoint.EscapeMarkup()}[/]")
+                                new Markup($"[bold]{resource.EscapeMarkup()}[/] [grey]has endpoint[/] {MarkupHelpers.SafeLink(_interactionService, endpoint)}")
                             );
                         }
 
@@ -541,12 +541,12 @@ internal sealed class RunCommand : BaseCommand
             {
                 grid.AddRow(
                     LabelMarkup(dashboardLabel),
-                    new Markup($"[link={dashboardUrl}]{dashboardUrl}[/]"));
+                    new Markup(MarkupHelpers.SafeLink(console, dashboardUrl)));
 
                 // Codespaces URL (if available)
                 if (!string.IsNullOrEmpty(codespacesUrl))
                 {
-                    grid.AddRow(Text.Empty, new Markup($"[link={codespacesUrl}]{codespacesUrl}[/]"));
+                    grid.AddRow(Text.Empty, new Markup(MarkupHelpers.SafeLink(console, codespacesUrl)));
                 }
             }
             else

--- a/src/Aspire.Cli/Commands/TelemetryCommandHelpers.cs
+++ b/src/Aspire.Cli/Commands/TelemetryCommandHelpers.cs
@@ -538,7 +538,10 @@ internal static class TelemetryCommandHelpers
     /// <param name="traceId">The trace ID.</param>
     /// <param name="displayText">The text to display (defaults to shortened trace ID).</param>
     /// <param name="spanId">Optional span ID to highlight in the trace detail view.</param>
-    /// <returns>A Spectre markup string with hyperlink, or plain text if dashboardUrl is null.</returns>
+    /// <returns>
+    /// A Spectre markup string with hyperlink when the console supports links and dashboardUrl is non-null;
+    /// or just the display text if links are unsupported, dashboardUrl is null, or traceId is empty.
+    /// </returns>
     public static string FormatTraceLink(IInteractionService interactionService, string? dashboardUrl, string traceId, string? displayText = null, string? spanId = null)
     {
         var text = displayText ?? OtlpHelpers.ToShortenedId(traceId);

--- a/src/Aspire.Cli/Commands/TelemetryCommandHelpers.cs
+++ b/src/Aspire.Cli/Commands/TelemetryCommandHelpers.cs
@@ -533,12 +533,13 @@ internal static class TelemetryCommandHelpers
     /// <summary>
     /// Creates a Spectre Console hyperlink markup for a trace detail in the Dashboard.
     /// </summary>
+    /// <param name="interactionService">The interaction service to determine link support.</param>
     /// <param name="dashboardUrl">The base dashboard URL.</param>
     /// <param name="traceId">The trace ID.</param>
     /// <param name="displayText">The text to display (defaults to shortened trace ID).</param>
     /// <param name="spanId">Optional span ID to highlight in the trace detail view.</param>
     /// <returns>A Spectre markup string with hyperlink, or plain text if dashboardUrl is null.</returns>
-    public static string FormatTraceLink(string? dashboardUrl, string traceId, string? displayText = null, string? spanId = null)
+    public static string FormatTraceLink(IInteractionService interactionService, string? dashboardUrl, string traceId, string? displayText = null, string? spanId = null)
     {
         var text = displayText ?? OtlpHelpers.ToShortenedId(traceId);
         if (string.IsNullOrEmpty(dashboardUrl) || string.IsNullOrEmpty(traceId))
@@ -548,7 +549,7 @@ internal static class TelemetryCommandHelpers
 
         // Dashboard trace detail URL: /traces/detail/{traceId}
         var url = DashboardUrls.CombineUrl(dashboardUrl, DashboardUrls.TraceDetailUrl(traceId, spanId));
-        return $"[link={url}]{text}[/]";
+        return MarkupHelpers.SafeLink(interactionService, url, text);
     }
 
     /// <summary>

--- a/src/Aspire.Cli/Commands/TelemetryCommandHelpers.cs
+++ b/src/Aspire.Cli/Commands/TelemetryCommandHelpers.cs
@@ -547,7 +547,7 @@ internal static class TelemetryCommandHelpers
         var text = displayText ?? OtlpHelpers.ToShortenedId(traceId);
         if (string.IsNullOrEmpty(dashboardUrl) || string.IsNullOrEmpty(traceId))
         {
-            return text;
+            return text.EscapeMarkup();
         }
 
         // Dashboard trace detail URL: /traces/detail/{traceId}

--- a/src/Aspire.Cli/Commands/TelemetrySpansCommand.cs
+++ b/src/Aspire.Cli/Commands/TelemetrySpansCommand.cs
@@ -270,7 +270,7 @@ internal sealed class TelemetrySpansCommand : BaseCommand
             ? FormatHelpers.FormatConsoleTime(_timeProvider, OtlpHelpers.UnixNanoSecondsToDateTime(span.StartTimeUnixNano.Value))
             : "";
         var shortSpanId = OtlpHelpers.ToShortenedId(spanId);
-        var spanIdLink = TelemetryCommandHelpers.FormatTraceLink(dashboardUrl, traceId, $"[grey]{shortSpanId}[/]", spanId: spanId);
+        var spanIdLink = TelemetryCommandHelpers.FormatTraceLink(_interactionService, dashboardUrl, traceId, $"[grey]{shortSpanId}[/]", spanId: spanId);
         var durationStr = TelemetryCommandHelpers.FormatDuration(duration);
         var resourceColor = _resourceColorMap.GetColor(resourceName);
 

--- a/src/Aspire.Cli/Commands/TelemetrySpansCommand.cs
+++ b/src/Aspire.Cli/Commands/TelemetrySpansCommand.cs
@@ -270,11 +270,11 @@ internal sealed class TelemetrySpansCommand : BaseCommand
             ? FormatHelpers.FormatConsoleTime(_timeProvider, OtlpHelpers.UnixNanoSecondsToDateTime(span.StartTimeUnixNano.Value))
             : "";
         var shortSpanId = OtlpHelpers.ToShortenedId(spanId);
-        var spanIdLink = TelemetryCommandHelpers.FormatTraceLink(_interactionService, dashboardUrl, traceId, $"[grey]{shortSpanId}[/]", spanId: spanId);
+        var spanIdLink = TelemetryCommandHelpers.FormatTraceLink(_interactionService, dashboardUrl, traceId, shortSpanId, spanId: spanId);
         var durationStr = TelemetryCommandHelpers.FormatDuration(duration);
         var resourceColor = _resourceColorMap.GetColor(resourceName);
 
         var escapedName = name.EscapeMarkup();
-        _interactionService.DisplayMarkupLine($"[grey]{timestamp}[/] [{statusColor}]{statusText}[/] [white]{durationStr,8}[/] [{resourceColor}]{resourceName.EscapeMarkup()}[/]: {escapedName} {spanIdLink}");
+        _interactionService.DisplayMarkupLine($"[grey]{timestamp}[/] [{statusColor}]{statusText}[/] [white]{durationStr,8}[/] [{resourceColor}]{resourceName.EscapeMarkup()}[/]: {escapedName} [grey]{spanIdLink}[/]");
     }
 }

--- a/src/Aspire.Cli/Commands/TelemetryTracesCommand.cs
+++ b/src/Aspire.Cli/Commands/TelemetryTracesCommand.cs
@@ -295,7 +295,7 @@ internal sealed class TelemetryTracesCommand : BaseCommand
                 ? FormatHelpers.FormatConsoleTime(_timeProvider, OtlpHelpers.UnixNanoSecondsToDateTime(info.StartTimeNano.Value))
                 : "";
             var shortTraceId = OtlpHelpers.ToShortenedId(info.TraceId);
-            var traceLink = TelemetryCommandHelpers.FormatTraceLink(dashboardUrl, info.TraceId, $"[grey]{shortTraceId}[/]");
+            var traceLink = TelemetryCommandHelpers.FormatTraceLink(_interactionService, dashboardUrl, info.TraceId, $"[grey]{shortTraceId}[/]");
             var nameColumn = $"[{resourceColor}]{info.Resource.EscapeMarkup()}[/]: {info.FirstSpanName.EscapeMarkup()} {traceLink}";
             table.AddRow(timestamp, nameColumn, info.SpanCount.ToString(CultureInfo.InvariantCulture), durationStr, statusText);
         }
@@ -333,7 +333,7 @@ internal sealed class TelemetryTracesCommand : BaseCommand
         }
 
         var shortTraceId = OtlpHelpers.ToShortenedId(traceId);
-        var traceLink = TelemetryCommandHelpers.FormatTraceLink(dashboardUrl, traceId, shortTraceId);
+        var traceLink = TelemetryCommandHelpers.FormatTraceLink(_interactionService, dashboardUrl, traceId, shortTraceId);
 
         if (spans.Count == 0)
         {
@@ -409,7 +409,7 @@ internal sealed class TelemetryTracesCommand : BaseCommand
         var statusText = span.HasError ? "ERR" : "OK";
         var durationStr = TelemetryCommandHelpers.FormatDuration(span.Duration).PadLeft(8);
         var shortenedSpanId = OtlpHelpers.ToShortenedId(span.SpanId);
-        var spanIdLink = TelemetryCommandHelpers.FormatTraceLink(dashboardUrl, traceId, $"[dim]{shortenedSpanId}[/]", spanId: span.SpanId);
+        var spanIdLink = TelemetryCommandHelpers.FormatTraceLink(_interactionService, dashboardUrl, traceId, $"[dim]{shortenedSpanId}[/]", spanId: span.SpanId);
         var escapedName = span.Name.EscapeMarkup();
 
         // Truncate long names

--- a/src/Aspire.Cli/Commands/TelemetryTracesCommand.cs
+++ b/src/Aspire.Cli/Commands/TelemetryTracesCommand.cs
@@ -295,8 +295,8 @@ internal sealed class TelemetryTracesCommand : BaseCommand
                 ? FormatHelpers.FormatConsoleTime(_timeProvider, OtlpHelpers.UnixNanoSecondsToDateTime(info.StartTimeNano.Value))
                 : "";
             var shortTraceId = OtlpHelpers.ToShortenedId(info.TraceId);
-            var traceLink = TelemetryCommandHelpers.FormatTraceLink(_interactionService, dashboardUrl, info.TraceId, $"[grey]{shortTraceId}[/]");
-            var nameColumn = $"[{resourceColor}]{info.Resource.EscapeMarkup()}[/]: {info.FirstSpanName.EscapeMarkup()} {traceLink}";
+            var traceLink = TelemetryCommandHelpers.FormatTraceLink(_interactionService, dashboardUrl, info.TraceId, shortTraceId);
+            var nameColumn = $"[{resourceColor}]{info.Resource.EscapeMarkup()}[/]: {info.FirstSpanName.EscapeMarkup()} [grey]{traceLink}[/]";
             table.AddRow(timestamp, nameColumn, info.SpanCount.ToString(CultureInfo.InvariantCulture), durationStr, statusText);
         }
 
@@ -409,7 +409,7 @@ internal sealed class TelemetryTracesCommand : BaseCommand
         var statusText = span.HasError ? "ERR" : "OK";
         var durationStr = TelemetryCommandHelpers.FormatDuration(span.Duration).PadLeft(8);
         var shortenedSpanId = OtlpHelpers.ToShortenedId(span.SpanId);
-        var spanIdLink = TelemetryCommandHelpers.FormatTraceLink(_interactionService, dashboardUrl, traceId, $"[dim]{shortenedSpanId}[/]", spanId: span.SpanId);
+        var spanIdLink = TelemetryCommandHelpers.FormatTraceLink(_interactionService, dashboardUrl, traceId, shortenedSpanId, spanId: span.SpanId);
         var escapedName = span.Name.EscapeMarkup();
 
         // Truncate long names
@@ -418,7 +418,7 @@ internal sealed class TelemetryTracesCommand : BaseCommand
             ? escapedName[..(maxNameLength - 3)] + "..."
             : escapedName;
 
-        _interactionService.DisplayMarkupLine($"{indent}{connector} {spanIdLink} {displayName} [{statusColor}]{statusText}[/] [dim]{durationStr}[/]");
+        _interactionService.DisplayMarkupLine($"{indent}{connector} [dim]{spanIdLink}[/] {displayName} [{statusColor}]{statusText}[/] [dim]{durationStr}[/]");
 
         // Render children
         if (childrenByParent.TryGetValue(span.SpanId, out var children))

--- a/src/Aspire.Cli/Interaction/ConsoleInteractionService.cs
+++ b/src/Aspire.Cli/Interaction/ConsoleInteractionService.cs
@@ -592,7 +592,7 @@ internal class ConsoleInteractionService : IInteractionService
             _errorConsole.MarkupLine(string.Format(CultureInfo.CurrentCulture, InteractionServiceStrings.ToUpdateRunCommand, updateCommand.EscapeMarkup()));
         }
 
-        _errorConsole.MarkupLine(string.Format(CultureInfo.CurrentCulture, InteractionServiceStrings.MoreInfoNewCliVersion, UpdateUrl));
+        _errorConsole.MarkupLine(string.Format(CultureInfo.CurrentCulture, InteractionServiceStrings.MoreInfoNewCliVersion, MarkupHelpers.SafeLink(this, UpdateUrl)));
     }
 
     internal static T? MatchChoice<T>(string value, IEnumerable<T> choices, Func<T, string> choiceFormatter) where T : notnull

--- a/src/Aspire.Cli/Interaction/ConsoleInteractionService.cs
+++ b/src/Aspire.Cli/Interaction/ConsoleInteractionService.cs
@@ -42,6 +42,8 @@ internal class ConsoleInteractionService : IInteractionService
 
     public ConsoleOutput Console { get; set; }
 
+    public bool SupportsLinks => MessageConsole.Profile.Capabilities.Links;
+
     public ConsoleInteractionService(ConsoleEnvironment consoleEnvironment, CliExecutionContext executionContext, ICliHostEnvironment hostEnvironment, ILoggerFactory loggerFactory)
     {
         ArgumentNullException.ThrowIfNull(consoleEnvironment);

--- a/src/Aspire.Cli/Interaction/ExtensionInteractionService.cs
+++ b/src/Aspire.Cli/Interaction/ExtensionInteractionService.cs
@@ -438,6 +438,8 @@ internal class ExtensionInteractionService : IExtensionInteractionService
         set => _consoleInteractionService.Console = value;
     }
 
+    public bool SupportsLinks => _consoleInteractionService.SupportsLinks;
+
     public void DisplayRawText(string text, ConsoleOutput? consoleOverride = null)
     {
         var result = _extensionTaskChannel.Writer.TryWrite(() => Backchannel.DisplayPlainTextAsync(text, _cancellationToken));

--- a/src/Aspire.Cli/Interaction/IInteractionService.cs
+++ b/src/Aspire.Cli/Interaction/IInteractionService.cs
@@ -39,6 +39,11 @@ internal interface IInteractionService
     /// </summary>
     ConsoleOutput Console { get; set; }
 
+    /// <summary>
+    /// Gets a value indicating whether the current console supports clickable hyperlinks.
+    /// </summary>
+    bool SupportsLinks { get; }
+
     void DisplayVersionUpdateNotification(string newerVersion, string? updateCommand = null);
     // The semantic type is stringly-typed because some values originate from backchannel payloads.
     // Use ConsoleLogTypes for CLI-defined values.

--- a/src/Aspire.Cli/Program.cs
+++ b/src/Aspire.Cli/Program.cs
@@ -642,11 +642,12 @@ public class Program
             {
                 // Write to stderr to avoid interfering with tools that parse stdout
                 var consoleEnvironment = serviceProvider.GetRequiredService<ConsoleEnvironment>();
+                var interactionService = serviceProvider.GetRequiredService<IInteractionService>();
 
                 const string telemetryUrl = "https://aka.ms/aspire/cli-telemetry";
 
                 consoleEnvironment.Error.WriteLine();
-                consoleEnvironment.Error.MarkupLine(string.Format(CultureInfo.CurrentCulture, RootCommandStrings.FirstTimeUseTelemetryNotice, $"[link]{telemetryUrl}[/]"));
+                consoleEnvironment.Error.MarkupLine(string.Format(CultureInfo.CurrentCulture, RootCommandStrings.FirstTimeUseTelemetryNotice, MarkupHelpers.SafeLink(interactionService, telemetryUrl)));
                 consoleEnvironment.Error.WriteLine();
             }
 

--- a/src/Aspire.Cli/Resources/InteractionServiceStrings.Designer.cs
+++ b/src/Aspire.Cli/Resources/InteractionServiceStrings.Designer.cs
@@ -223,7 +223,7 @@ namespace Aspire.Cli.Resources {
         }
 
         /// <summary>
-        ///   Looks up a localized string similar to [dim]For more information, see: [link]{0}[/][/].
+        ///   Looks up a localized string similar to [dim]For more information, see: {0}[/].
         /// </summary>
         public static string MoreInfoNewCliVersion {
             get {

--- a/src/Aspire.Cli/Resources/InteractionServiceStrings.resx
+++ b/src/Aspire.Cli/Resources/InteractionServiceStrings.resx
@@ -234,8 +234,8 @@
     <comment>Do not translate [yellow] and also leave [/] as-is. {0} is the version number</comment>
   </data>
   <data name="MoreInfoNewCliVersion" xml:space="preserve">
-    <value>[dim]For more information, see: [link]{0}[/][/]</value>
-    <comment>Do not translate [dim] and [link]. Also leave [/] as-is. {0} is a URL</comment>
+    <value>[dim]For more information, see: {0}[/]</value>
+    <comment>Do not translate [dim]. Also leave [/] as-is. {0} is a pre-formatted link</comment>
   </data>
   <data name="ToUpdateRunCommand" xml:space="preserve">
     <value>[dim]To update, run: {0}[/]</value>

--- a/src/Aspire.Cli/Resources/xlf/InteractionServiceStrings.cs.xlf
+++ b/src/Aspire.Cli/Resources/xlf/InteractionServiceStrings.cs.xlf
@@ -88,9 +88,9 @@
         <note />
       </trans-unit>
       <trans-unit id="MoreInfoNewCliVersion">
-        <source>[dim]For more information, see: [link]{0}[/][/]</source>
-        <target state="translated">[dim]Další informace najdete tady: [link]{0}[/][/]</target>
-        <note>Do not translate [dim] and [link]. Also leave [/] as-is. {0} is a URL</note>
+        <source>[dim]For more information, see: {0}[/]</source>
+        <target state="needs-review-translation">[dim]Další informace najdete tady: [link]{0}[/][/]</target>
+        <note>Do not translate [dim]. Also leave [/] as-is. {0} is a pre-formatted link</note>
       </trans-unit>
       <trans-unit id="NewCliVersionAvailable">
         <source>[yellow]A new version of Aspire is available: {0}[/]</source>

--- a/src/Aspire.Cli/Resources/xlf/InteractionServiceStrings.de.xlf
+++ b/src/Aspire.Cli/Resources/xlf/InteractionServiceStrings.de.xlf
@@ -88,9 +88,9 @@
         <note />
       </trans-unit>
       <trans-unit id="MoreInfoNewCliVersion">
-        <source>[dim]For more information, see: [link]{0}[/][/]</source>
-        <target state="translated">[dim]Weitere Informationen finden Sie unter: [Link]{0}[/][/]</target>
-        <note>Do not translate [dim] and [link]. Also leave [/] as-is. {0} is a URL</note>
+        <source>[dim]For more information, see: {0}[/]</source>
+        <target state="needs-review-translation">[dim]Weitere Informationen finden Sie unter: [Link]{0}[/][/]</target>
+        <note>Do not translate [dim]. Also leave [/] as-is. {0} is a pre-formatted link</note>
       </trans-unit>
       <trans-unit id="NewCliVersionAvailable">
         <source>[yellow]A new version of Aspire is available: {0}[/]</source>

--- a/src/Aspire.Cli/Resources/xlf/InteractionServiceStrings.es.xlf
+++ b/src/Aspire.Cli/Resources/xlf/InteractionServiceStrings.es.xlf
@@ -88,9 +88,9 @@
         <note />
       </trans-unit>
       <trans-unit id="MoreInfoNewCliVersion">
-        <source>[dim]For more information, see: [link]{0}[/][/]</source>
-        <target state="translated">[dim]Para obtener más información, consulte: [link]{0}[/][/]</target>
-        <note>Do not translate [dim] and [link]. Also leave [/] as-is. {0} is a URL</note>
+        <source>[dim]For more information, see: {0}[/]</source>
+        <target state="needs-review-translation">[dim]Para obtener más información, consulte: [link]{0}[/][/]</target>
+        <note>Do not translate [dim]. Also leave [/] as-is. {0} is a pre-formatted link</note>
       </trans-unit>
       <trans-unit id="NewCliVersionAvailable">
         <source>[yellow]A new version of Aspire is available: {0}[/]</source>

--- a/src/Aspire.Cli/Resources/xlf/InteractionServiceStrings.fr.xlf
+++ b/src/Aspire.Cli/Resources/xlf/InteractionServiceStrings.fr.xlf
@@ -88,9 +88,9 @@
         <note />
       </trans-unit>
       <trans-unit id="MoreInfoNewCliVersion">
-        <source>[dim]For more information, see: [link]{0}[/][/]</source>
-        <target state="translated">Pour découvrir plus d’informations, consultez : [lien]{0}[/][/]</target>
-        <note>Do not translate [dim] and [link]. Also leave [/] as-is. {0} is a URL</note>
+        <source>[dim]For more information, see: {0}[/]</source>
+        <target state="needs-review-translation">Pour découvrir plus d’informations, consultez : [lien]{0}[/][/]</target>
+        <note>Do not translate [dim]. Also leave [/] as-is. {0} is a pre-formatted link</note>
       </trans-unit>
       <trans-unit id="NewCliVersionAvailable">
         <source>[yellow]A new version of Aspire is available: {0}[/]</source>

--- a/src/Aspire.Cli/Resources/xlf/InteractionServiceStrings.it.xlf
+++ b/src/Aspire.Cli/Resources/xlf/InteractionServiceStrings.it.xlf
@@ -88,9 +88,9 @@
         <note />
       </trans-unit>
       <trans-unit id="MoreInfoNewCliVersion">
-        <source>[dim]For more information, see: [link]{0}[/][/]</source>
-        <target state="translated">[dim]Per altre informazioni, vedere: [link]{0}[/][/]</target>
-        <note>Do not translate [dim] and [link]. Also leave [/] as-is. {0} is a URL</note>
+        <source>[dim]For more information, see: {0}[/]</source>
+        <target state="needs-review-translation">[dim]Per altre informazioni, vedere: [link]{0}[/][/]</target>
+        <note>Do not translate [dim]. Also leave [/] as-is. {0} is a pre-formatted link</note>
       </trans-unit>
       <trans-unit id="NewCliVersionAvailable">
         <source>[yellow]A new version of Aspire is available: {0}[/]</source>

--- a/src/Aspire.Cli/Resources/xlf/InteractionServiceStrings.ja.xlf
+++ b/src/Aspire.Cli/Resources/xlf/InteractionServiceStrings.ja.xlf
@@ -88,9 +88,9 @@
         <note />
       </trans-unit>
       <trans-unit id="MoreInfoNewCliVersion">
-        <source>[dim]For more information, see: [link]{0}[/][/]</source>
-        <target state="translated">[暗い]詳細については、次を参照してください: [link]{0}[/][/]</target>
-        <note>Do not translate [dim] and [link]. Also leave [/] as-is. {0} is a URL</note>
+        <source>[dim]For more information, see: {0}[/]</source>
+        <target state="needs-review-translation">[暗い]詳細については、次を参照してください: [link]{0}[/][/]</target>
+        <note>Do not translate [dim]. Also leave [/] as-is. {0} is a pre-formatted link</note>
       </trans-unit>
       <trans-unit id="NewCliVersionAvailable">
         <source>[yellow]A new version of Aspire is available: {0}[/]</source>

--- a/src/Aspire.Cli/Resources/xlf/InteractionServiceStrings.ko.xlf
+++ b/src/Aspire.Cli/Resources/xlf/InteractionServiceStrings.ko.xlf
@@ -88,9 +88,9 @@
         <note />
       </trans-unit>
       <trans-unit id="MoreInfoNewCliVersion">
-        <source>[dim]For more information, see: [link]{0}[/][/]</source>
-        <target state="translated">[dim]자세한 내용은 [link]{0}[/][/]을(를) 참조하세요.</target>
-        <note>Do not translate [dim] and [link]. Also leave [/] as-is. {0} is a URL</note>
+        <source>[dim]For more information, see: {0}[/]</source>
+        <target state="needs-review-translation">[dim]자세한 내용은 [link]{0}[/][/]을(를) 참조하세요.</target>
+        <note>Do not translate [dim]. Also leave [/] as-is. {0} is a pre-formatted link</note>
       </trans-unit>
       <trans-unit id="NewCliVersionAvailable">
         <source>[yellow]A new version of Aspire is available: {0}[/]</source>

--- a/src/Aspire.Cli/Resources/xlf/InteractionServiceStrings.pl.xlf
+++ b/src/Aspire.Cli/Resources/xlf/InteractionServiceStrings.pl.xlf
@@ -88,9 +88,9 @@
         <note />
       </trans-unit>
       <trans-unit id="MoreInfoNewCliVersion">
-        <source>[dim]For more information, see: [link]{0}[/][/]</source>
-        <target state="translated">[dim]Aby uzyskać więcej informacji, zobacz: [link]{0}[/][/]</target>
-        <note>Do not translate [dim] and [link]. Also leave [/] as-is. {0} is a URL</note>
+        <source>[dim]For more information, see: {0}[/]</source>
+        <target state="needs-review-translation">[dim]Aby uzyskać więcej informacji, zobacz: [link]{0}[/][/]</target>
+        <note>Do not translate [dim]. Also leave [/] as-is. {0} is a pre-formatted link</note>
       </trans-unit>
       <trans-unit id="NewCliVersionAvailable">
         <source>[yellow]A new version of Aspire is available: {0}[/]</source>

--- a/src/Aspire.Cli/Resources/xlf/InteractionServiceStrings.pt-BR.xlf
+++ b/src/Aspire.Cli/Resources/xlf/InteractionServiceStrings.pt-BR.xlf
@@ -88,9 +88,9 @@
         <note />
       </trans-unit>
       <trans-unit id="MoreInfoNewCliVersion">
-        <source>[dim]For more information, see: [link]{0}[/][/]</source>
-        <target state="translated">[dim]Para obter mais informações, consulte: [link]{0}[/][/]</target>
-        <note>Do not translate [dim] and [link]. Also leave [/] as-is. {0} is a URL</note>
+        <source>[dim]For more information, see: {0}[/]</source>
+        <target state="needs-review-translation">[dim]Para obter mais informações, consulte: [link]{0}[/][/]</target>
+        <note>Do not translate [dim]. Also leave [/] as-is. {0} is a pre-formatted link</note>
       </trans-unit>
       <trans-unit id="NewCliVersionAvailable">
         <source>[yellow]A new version of Aspire is available: {0}[/]</source>

--- a/src/Aspire.Cli/Resources/xlf/InteractionServiceStrings.ru.xlf
+++ b/src/Aspire.Cli/Resources/xlf/InteractionServiceStrings.ru.xlf
@@ -88,9 +88,9 @@
         <note />
       </trans-unit>
       <trans-unit id="MoreInfoNewCliVersion">
-        <source>[dim]For more information, see: [link]{0}[/][/]</source>
-        <target state="translated">[dim]Дополнительные сведения: [link]{0}[/][/]</target>
-        <note>Do not translate [dim] and [link]. Also leave [/] as-is. {0} is a URL</note>
+        <source>[dim]For more information, see: {0}[/]</source>
+        <target state="needs-review-translation">[dim]Дополнительные сведения: [link]{0}[/][/]</target>
+        <note>Do not translate [dim]. Also leave [/] as-is. {0} is a pre-formatted link</note>
       </trans-unit>
       <trans-unit id="NewCliVersionAvailable">
         <source>[yellow]A new version of Aspire is available: {0}[/]</source>

--- a/src/Aspire.Cli/Resources/xlf/InteractionServiceStrings.tr.xlf
+++ b/src/Aspire.Cli/Resources/xlf/InteractionServiceStrings.tr.xlf
@@ -88,9 +88,9 @@
         <note />
       </trans-unit>
       <trans-unit id="MoreInfoNewCliVersion">
-        <source>[dim]For more information, see: [link]{0}[/][/]</source>
-        <target state="translated">[dim]Daha fazla bilgi için bkz.: [link]{0}[/][/]</target>
-        <note>Do not translate [dim] and [link]. Also leave [/] as-is. {0} is a URL</note>
+        <source>[dim]For more information, see: {0}[/]</source>
+        <target state="needs-review-translation">[dim]Daha fazla bilgi için bkz.: [link]{0}[/][/]</target>
+        <note>Do not translate [dim]. Also leave [/] as-is. {0} is a pre-formatted link</note>
       </trans-unit>
       <trans-unit id="NewCliVersionAvailable">
         <source>[yellow]A new version of Aspire is available: {0}[/]</source>

--- a/src/Aspire.Cli/Resources/xlf/InteractionServiceStrings.zh-Hans.xlf
+++ b/src/Aspire.Cli/Resources/xlf/InteractionServiceStrings.zh-Hans.xlf
@@ -88,9 +88,9 @@
         <note />
       </trans-unit>
       <trans-unit id="MoreInfoNewCliVersion">
-        <source>[dim]For more information, see: [link]{0}[/][/]</source>
-        <target state="translated">[dim]有关详细信息，请参阅: [link]{0}[/][/]</target>
-        <note>Do not translate [dim] and [link]. Also leave [/] as-is. {0} is a URL</note>
+        <source>[dim]For more information, see: {0}[/]</source>
+        <target state="needs-review-translation">[dim]有关详细信息，请参阅: [link]{0}[/][/]</target>
+        <note>Do not translate [dim]. Also leave [/] as-is. {0} is a pre-formatted link</note>
       </trans-unit>
       <trans-unit id="NewCliVersionAvailable">
         <source>[yellow]A new version of Aspire is available: {0}[/]</source>

--- a/src/Aspire.Cli/Resources/xlf/InteractionServiceStrings.zh-Hant.xlf
+++ b/src/Aspire.Cli/Resources/xlf/InteractionServiceStrings.zh-Hant.xlf
@@ -88,9 +88,9 @@
         <note />
       </trans-unit>
       <trans-unit id="MoreInfoNewCliVersion">
-        <source>[dim]For more information, see: [link]{0}[/][/]</source>
-        <target state="translated">[dim]如需詳細資訊，請參閱: [link]{0}[/][/]</target>
-        <note>Do not translate [dim] and [link]. Also leave [/] as-is. {0} is a URL</note>
+        <source>[dim]For more information, see: {0}[/]</source>
+        <target state="needs-review-translation">[dim]如需詳細資訊，請參閱: [link]{0}[/][/]</target>
+        <note>Do not translate [dim]. Also leave [/] as-is. {0} is a pre-formatted link</note>
       </trans-unit>
       <trans-unit id="NewCliVersionAvailable">
         <source>[yellow]A new version of Aspire is available: {0}[/]</source>

--- a/src/Aspire.Cli/Utils/MarkupHelpers.cs
+++ b/src/Aspire.Cli/Utils/MarkupHelpers.cs
@@ -17,11 +17,24 @@ internal static class MarkupHelpers
     /// </summary>
     public static string SafeLink(IInteractionService interactionService, string link, string? title = null)
     {
-        if (interactionService.SupportsLinks)
+        return SafeLink(interactionService.SupportsLinks, link, title);
+    }
+
+    /// <summary>
+    /// Builds a clickable link markup string when the console supports links,
+    /// otherwise returns a plain-text fallback.
+    /// </summary>
+    public static string SafeLink(bool supportsLinks, string link, string? title = null)
+    {
+        var noTitle = title is null || title == link;
+        link = link.EscapeMarkup();
+        title = title?.EscapeMarkup();
+
+        if (supportsLinks)
         {
-            return $"[link={link}]{(title ?? link).EscapeMarkup()}[/]";
+            return noTitle ? $"[link]{link}[/]" : $"[link={link}]{title}[/]";
         }
 
-        return title is null ? link : $"{title} ({link})";
+        return noTitle ? link : $"{title} ({link})";
     }
 }

--- a/src/Aspire.Cli/Utils/MarkupHelpers.cs
+++ b/src/Aspire.Cli/Utils/MarkupHelpers.cs
@@ -1,0 +1,27 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Aspire.Cli.Interaction;
+using Spectre.Console;
+
+namespace Aspire.Cli.Utils;
+
+/// <summary>
+/// Provides helpers for building Spectre.Console markup strings.
+/// </summary>
+internal static class MarkupHelpers
+{
+    /// <summary>
+    /// Builds a clickable link markup string when the console supports links,
+    /// otherwise returns a plain-text fallback.
+    /// </summary>
+    public static string SafeLink(IInteractionService interactionService, string link, string? title = null)
+    {
+        if (interactionService.SupportsLinks)
+        {
+            return $"[link={link}]{(title ?? link).EscapeMarkup()}[/]";
+        }
+
+        return title is null ? link : $"{title} ({link})";
+    }
+}

--- a/tests/Aspire.Cli.Tests/Commands/PublishCommandPromptingIntegrationTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/PublishCommandPromptingIntegrationTests.cs
@@ -855,6 +855,7 @@ internal sealed class TestConsoleInteractionServiceWithPromptTracking : IInterac
     private bool _shouldCancel;
 
     public ConsoleOutput Console { get; set; }
+    public bool SupportsLinks { get; set; }
     public List<StringPromptCall> StringPromptCalls { get; } = [];
     public List<object> SelectionPromptCalls { get; } = []; // Using object to handle generic types
     public List<BooleanPromptCall> BooleanPromptCalls { get; } = [];

--- a/tests/Aspire.Cli.Tests/Commands/TelemetryCommandTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/TelemetryCommandTests.cs
@@ -127,7 +127,8 @@ public class TelemetryCommandTests(ITestOutputHelper outputHelper)
     [Fact]
     public void FormatTraceLink_WithDashboardUrl_ReturnsHyperlink()
     {
-        var result = TelemetryCommandHelpers.FormatTraceLink("http://localhost:18888", "abc123456789");
+        var interactionService = new TestInteractionService { SupportsLinks = true };
+        var result = TelemetryCommandHelpers.FormatTraceLink(interactionService, "http://localhost:18888", "abc123456789");
 
         Assert.Contains("[link=", result);
         Assert.Contains("/traces/detail/abc123456789", result);
@@ -137,7 +138,8 @@ public class TelemetryCommandTests(ITestOutputHelper outputHelper)
     [Fact]
     public void FormatTraceLink_WithNullDashboardUrl_ReturnsPlainText()
     {
-        var result = TelemetryCommandHelpers.FormatTraceLink(null, "abc123456789");
+        var interactionService = new TestInteractionService();
+        var result = TelemetryCommandHelpers.FormatTraceLink(interactionService, null, "abc123456789");
 
         Assert.DoesNotContain("[link=", result);
         Assert.Equal("abc1234", result); // Just the shortened ID

--- a/tests/Aspire.Cli.Tests/Commands/TelemetryCommandTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/TelemetryCommandTests.cs
@@ -130,9 +130,7 @@ public class TelemetryCommandTests(ITestOutputHelper outputHelper)
         var interactionService = new TestInteractionService { SupportsLinks = true };
         var result = TelemetryCommandHelpers.FormatTraceLink(interactionService, "http://localhost:18888", "abc123456789");
 
-        Assert.Contains("[link=", result);
-        Assert.Contains("/traces/detail/abc123456789", result);
-        Assert.Contains("abc1234", result); // Shortened ID
+        Assert.Equal("[link=http://localhost:18888/traces/detail/abc123456789]abc1234[/]", result);
     }
 
     [Fact]
@@ -141,7 +139,6 @@ public class TelemetryCommandTests(ITestOutputHelper outputHelper)
         var interactionService = new TestInteractionService();
         var result = TelemetryCommandHelpers.FormatTraceLink(interactionService, null, "abc123456789");
 
-        Assert.DoesNotContain("[link=", result);
         Assert.Equal("abc1234", result); // Just the shortened ID
     }
 
@@ -151,9 +148,7 @@ public class TelemetryCommandTests(ITestOutputHelper outputHelper)
         var interactionService = new TestInteractionService { SupportsLinks = false };
         var result = TelemetryCommandHelpers.FormatTraceLink(interactionService, "http://localhost:18888", "abc123456789");
 
-        Assert.DoesNotContain("[link=", result);
-        Assert.Contains("abc1234", result); // Shortened ID still present
-        Assert.Contains("http://localhost:18888/traces/detail/abc123456789", result); // URL visible in fallback
+        Assert.Equal("abc1234 (http://localhost:18888/traces/detail/abc123456789)", result);
     }
 
     [Fact]

--- a/tests/Aspire.Cli.Tests/Commands/TelemetryCommandTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/TelemetryCommandTests.cs
@@ -146,6 +146,17 @@ public class TelemetryCommandTests(ITestOutputHelper outputHelper)
     }
 
     [Fact]
+    public void FormatTraceLink_WithDashboardUrlAndNoLinkSupport_ReturnsFallbackWithUrl()
+    {
+        var interactionService = new TestInteractionService { SupportsLinks = false };
+        var result = TelemetryCommandHelpers.FormatTraceLink(interactionService, "http://localhost:18888", "abc123456789");
+
+        Assert.DoesNotContain("[link=", result);
+        Assert.Contains("abc1234", result); // Shortened ID still present
+        Assert.Contains("http://localhost:18888/traces/detail/abc123456789", result); // URL visible in fallback
+    }
+
+    [Fact]
     public void ToOtlpResources_ConvertsResourceInfoToOtlpResources()
     {
         var resources = new ResourceInfoJson[]

--- a/tests/Aspire.Cli.Tests/Commands/TelemetrySpansCommandTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/TelemetrySpansCommandTests.cs
@@ -79,8 +79,8 @@ public class TelemetrySpansCommandTests(ITestOutputHelper outputHelper)
         // Span output format: "timestamp STATUS shortSpanId resourceName     duration spanName"
         var spanLines = outputWriter.Logs.Where(l => l.Contains("frontend") || l.Contains("backend")).ToList();
         Assert.Equal(2, spanLines.Count);
-        Assert.Equal($"{FormatHelpers.FormatConsoleTime(TimeProvider.System, s_testTime)} OK      50ms frontend: GET /index span001", spanLines[0]);
-        Assert.Equal($"{FormatHelpers.FormatConsoleTime(TimeProvider.System, s_testTime.AddMilliseconds(10))} ERR     20ms backend: SELECT * FROM users span002", spanLines[1]);
+        Assert.Equal($"{FormatHelpers.FormatConsoleTime(TimeProvider.System, s_testTime)} OK      50ms frontend: GET /index span001 (http://localhost:18888/traces/detail/trace001?spanId=span001)", spanLines[0]);
+        Assert.Equal($"{FormatHelpers.FormatConsoleTime(TimeProvider.System, s_testTime.AddMilliseconds(10))} ERR     20ms backend: SELECT * FROM users span002 (http://localhost:18888/traces/detail/trace001?spanId=span002)", spanLines[1]);
     }
 
     [Fact]
@@ -114,8 +114,8 @@ public class TelemetrySpansCommandTests(ITestOutputHelper outputHelper)
         // Replicas get shortened GUID appended
         var spanLines = outputWriter.Logs.Where(l => l.Contains("apiservice")).ToList();
         Assert.Equal(2, spanLines.Count);
-        Assert.Equal($"{FormatHelpers.FormatConsoleTime(TimeProvider.System, s_testTime)} OK      75ms apiservice-11111111: GET /api/products span001", spanLines[0]);
-        Assert.Equal($"{FormatHelpers.FormatConsoleTime(TimeProvider.System, s_testTime.AddMilliseconds(10))} ERR     50ms apiservice-aaaaaaaa: POST /api/orders span002", spanLines[1]);
+        Assert.Equal($"{FormatHelpers.FormatConsoleTime(TimeProvider.System, s_testTime)} OK      75ms apiservice-11111111: GET /api/products span001 (http://localhost:18888/traces/detail/trace001?spanId=span001)", spanLines[0]);
+        Assert.Equal($"{FormatHelpers.FormatConsoleTime(TimeProvider.System, s_testTime.AddMilliseconds(10))} ERR     50ms apiservice-aaaaaaaa: POST /api/orders span002 (http://localhost:18888/traces/detail/trace001?spanId=span002)", spanLines[1]);
     }
 
     private static string BuildSpansJson(params (string serviceName, string? instanceId, string spanId, string name, DateTime startTime, DateTime endTime, bool hasError)[] entries)

--- a/tests/Aspire.Cli.Tests/Commands/TelemetryTracesCommandTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/TelemetryTracesCommandTests.cs
@@ -83,13 +83,13 @@ public class TelemetryTracesCommandTests(ITestOutputHelper outputHelper)
         Assert.Equal(2, dataRows.Length);
 
         Assert.Equal(FormatHelpers.FormatConsoleTime(TimeProvider.System, s_testTime), dataRows[0][0]);
-        Assert.Equal("frontend: GET /frontend abc1234", dataRows[0][1]);
+        Assert.Equal("frontend: GET /frontend abc1234 (http://localhost:18888/traces/detail/abc1234567890def)", dataRows[0][1]);
         Assert.Equal("1", dataRows[0][2]);
         Assert.Equal("50ms", dataRows[0][3]);
         Assert.Equal("OK", dataRows[0][4]);
 
         Assert.Equal(FormatHelpers.FormatConsoleTime(TimeProvider.System, s_testTime.AddMilliseconds(10)), dataRows[1][0]);
-        Assert.Equal("backend: GET /backend def9876", dataRows[1][1]);
+        Assert.Equal("backend: GET /backend def9876 (http://localhost:18888/traces/detail/def9876543210abc)", dataRows[1][1]);
         Assert.Equal("1", dataRows[1][2]);
         Assert.Equal("20ms", dataRows[1][3]);
         Assert.Equal("OK", dataRows[1][4]);
@@ -134,13 +134,13 @@ public class TelemetryTracesCommandTests(ITestOutputHelper outputHelper)
         Assert.Equal(2, dataRows.Length);
 
         Assert.Equal(FormatHelpers.FormatConsoleTime(TimeProvider.System, s_testTime), dataRows[0][0]);
-        Assert.Equal("apiservice-11111111: GET /apiservice abc1234", dataRows[0][1]);
+        Assert.Equal("apiservice-11111111: GET /apiservice abc1234 (http://localhost:18888/traces/detail/abc1234567890def)", dataRows[0][1]);
         Assert.Equal("1", dataRows[0][2]);
         Assert.Equal("75ms", dataRows[0][3]);
         Assert.Equal("OK", dataRows[0][4]);
 
         Assert.Equal(FormatHelpers.FormatConsoleTime(TimeProvider.System, s_testTime.AddMilliseconds(10)), dataRows[1][0]);
-        Assert.Equal("apiservice-aaaaaaaa: GET /apiservice def9876", dataRows[1][1]);
+        Assert.Equal("apiservice-aaaaaaaa: GET /apiservice def9876 (http://localhost:18888/traces/detail/def9876543210abc)", dataRows[1][1]);
         Assert.Equal("1", dataRows[1][2]);
         Assert.Equal("50ms", dataRows[1][3]);
         Assert.Equal("ERR", dataRows[1][4]);

--- a/tests/Aspire.Cli.Tests/Commands/UpdateCommandTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/UpdateCommandTests.cs
@@ -1731,6 +1731,8 @@ internal sealed class CancellationTrackingInteractionService : IInteractionServi
         set => _innerService.Console = value;
     }
 
+    public bool SupportsLinks => _innerService.SupportsLinks;
+
     public Action? OnCancellationMessageDisplayed { get; set; }
 
     public CancellationTrackingInteractionService(IInteractionService innerService)

--- a/tests/Aspire.Cli.Tests/Projects/ExtensionGuestLauncherTests.cs
+++ b/tests/Aspire.Cli.Tests/Projects/ExtensionGuestLauncherTests.cs
@@ -156,6 +156,7 @@ public class ExtensionGuestLauncherTests
         public void ConsoleDisplaySubtleMessage(string message, bool allowMarkup = false) => throw new NotImplementedException();
         public void WriteConsoleLog(string message, int? lineNumber = null, string? type = null, bool isErrorMessage = false) => throw new NotImplementedException();
         public ConsoleOutput Console { get; set; }
+        public bool SupportsLinks { get; set; }
         public Task<T> ShowStatusAsync<T>(string statusText, Func<Task<T>> action, KnownEmoji? emoji = null, bool allowMarkup = false) => throw new NotImplementedException();
         public void ShowStatus(string statusText, Action action, KnownEmoji? emoji = null, bool allowMarkup = false) => throw new NotImplementedException();
         public Task<string> PromptForStringAsync(string promptText, Func<string, Spectre.Console.ValidationResult>? validator = null, bool isSecret = false, bool required = false, PromptBinding<string?>? binding = null, CancellationToken cancellationToken = default) => throw new NotImplementedException();

--- a/tests/Aspire.Cli.Tests/Templating/DotNetTemplateFactoryTests.cs
+++ b/tests/Aspire.Cli.Tests/Templating/DotNetTemplateFactoryTests.cs
@@ -416,6 +416,7 @@ public class DotNetTemplateFactoryTests
     private sealed class TestInteractionService : IInteractionService
     {
         public ConsoleOutput Console { get; set; }
+        public bool SupportsLinks { get; set; }
 
         public Task<T> PromptForSelectionAsync<T>(string prompt, IEnumerable<T> choices, Func<T, string> displaySelector, PromptBinding<string?>? binding = null, CancellationToken cancellationToken = default) where T : notnull
             => throw new NotImplementedException();

--- a/tests/Aspire.Cli.Tests/TestServices/TestExtensionInteractionService.cs
+++ b/tests/Aspire.Cli.Tests/TestServices/TestExtensionInteractionService.cs
@@ -14,6 +14,7 @@ namespace Aspire.Cli.Tests.TestServices;
 internal sealed class TestExtensionInteractionService(IServiceProvider serviceProvider) : IExtensionInteractionService
 {
     public ConsoleOutput Console { get; set; }
+    public bool SupportsLinks { get; set; }
     public Action<string>? DisplayErrorCallback { get; set; }
     public Action<string>? DisplaySubtleMessageCallback { get; set; }
     public Action<string>? DisplayConsoleWriteLineMessage { get; set; }

--- a/tests/Aspire.Cli.Tests/TestServices/TestInteractionService.cs
+++ b/tests/Aspire.Cli.Tests/TestServices/TestInteractionService.cs
@@ -17,6 +17,8 @@ internal sealed class TestInteractionService : IInteractionService
 
     public ConsoleOutput Console { get; set; }
 
+    public bool SupportsLinks { get; set; }
+
     // Callback hooks
     public Action<string>? DisplaySubtleMessageCallback { get; set; }
     public Action<string>? DisplayConsoleWriteLineMessage { get; set; }

--- a/tests/Aspire.Cli.Tests/Utils/MarkupHelpersTests.cs
+++ b/tests/Aspire.Cli.Tests/Utils/MarkupHelpersTests.cs
@@ -1,0 +1,104 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Text;
+using System.Text.RegularExpressions;
+using Aspire.Cli.Utils;
+using Spectre.Console;
+
+namespace Aspire.Cli.Tests.Utils;
+
+public class MarkupHelpersTests
+{
+    [Theory]
+    [InlineData("https://example.com", null, "[link]https://example.com[/]")]
+    [InlineData("https://example.com", "Example", "[link=https://example.com]Example[/]")]
+    [InlineData("https://example.com", "https://example.com", "[link]https://example.com[/]")] // title == link treated as no-title
+    [InlineData("http://[::1]:8080/dashboard", null, "[link]http://[[::1]]:8080/dashboard[/]")]
+    [InlineData("http://[::1]:8080/dashboard", "Dashboard", "[link=http://[[::1]]:8080/dashboard]Dashboard[/]")]
+    [InlineData("http://[fe80::1%25eth0]:5000", null, "[link]http://[[fe80::1%25eth0]]:5000[/]")]
+    [InlineData("http://[2001:db8::1]:18888/traces", "Traces", "[link=http://[[2001:db8::1]]:18888/traces]Traces[/]")]
+    [InlineData("https://example.com/path?a=1&b=2", null, "[link]https://example.com/path?a=1&b=2[/]")]
+    [InlineData("https://example.com/path?a=1&b=2", "Query Link", "[link=https://example.com/path?a=1&b=2]Query Link[/]")]
+    public void SafeLink_WhenSupportsLinks_ReturnsLinkMarkup(string link, string? title, string expected)
+    {
+        var result = MarkupHelpers.SafeLink(supportsLinks: true, link, title);
+
+        Assert.Equal(expected, result);
+    }
+
+    [Theory]
+    [InlineData("https://example.com", null, "https://example.com")]
+    [InlineData("https://example.com", "Example", "Example (https://example.com)")]
+    [InlineData("https://example.com", "https://example.com", "https://example.com")] // title == link treated as no-title
+    [InlineData("http://[::1]:8080/dashboard", null, "http://[[::1]]:8080/dashboard")]
+    [InlineData("http://[::1]:8080/dashboard", "Dashboard", "Dashboard (http://[[::1]]:8080/dashboard)")]
+    [InlineData("http://[fe80::1%25eth0]:5000", null, "http://[[fe80::1%25eth0]]:5000")]
+    [InlineData("http://[2001:db8::1]:18888/traces", "Traces", "Traces (http://[[2001:db8::1]]:18888/traces)")]
+    [InlineData("https://example.com/path?a=1&b=2", null, "https://example.com/path?a=1&b=2")]
+    [InlineData("https://example.com/path?a=1&b=2", "Query Link", "Query Link (https://example.com/path?a=1&b=2)")]
+    public void SafeLink_WhenNoLinkSupport_ReturnsPlainText(string link, string? title, string expected)
+    {
+        var result = MarkupHelpers.SafeLink(supportsLinks: false, link, title);
+
+        Assert.Equal(expected, result);
+    }
+
+    [Theory]
+    [InlineData("https://example.com/path?a=1&b=2", null, "https://example.com/path?a=1&b=2")]
+    [InlineData("http://[::1]:8080/dashboard", null, "http://[::1]:8080/dashboard")]
+    [InlineData("http://[2001:db8::1]:18888/traces", "Traces", "Traces")]
+    [InlineData("http://[fe80::1%25eth0]:5000/resource", "My [Resource]", "My [Resource]")]
+    [InlineData("https://example.com", "Title with [brackets]", "Title with [brackets]")]
+    public void SafeLink_WhenSupportsLinks_ProducesValidMarkup(string link, string? title, string expectedText)
+    {
+        var result = MarkupHelpers.SafeLink(supportsLinks: true, link, title);
+
+        var output = new StringBuilder();
+        var console = CreateAnsiConsole(output, ansi: true);
+        console.MarkupLine(result);
+
+        var rendered = output.ToString().Trim();
+        // OSC 8 format: ESC]8;id=N;url ESC\ text ESC]8;; ESC\
+        var escapedLink = Regex.Escape(link);
+        var escapedText = Regex.Escape(expectedText);
+        var pattern = $"\\x1b]8;id=\\d+;{escapedLink}\\x1b\\\\{escapedText}\\x1b]8;;\\x1b\\\\";
+        Assert.Matches(pattern, rendered);
+    }
+
+    [Theory]
+    [InlineData("https://example.com/path?a=1&b=2", null, "https://example.com/path?a=1&b=2")]
+    [InlineData("http://[::1]:8080/dashboard", null, "http://[::1]:8080/dashboard")]
+    [InlineData("http://[2001:db8::1]:18888/traces", "Traces", "Traces (http://[2001:db8::1]:18888/traces)")]
+    [InlineData("http://[fe80::1%25eth0]:5000/resource", "My [Resource]", "My [Resource] (http://[fe80::1%25eth0]:5000/resource)")]
+    [InlineData("https://example.com", "Title with [brackets]", "Title with [brackets] (https://example.com)")]
+    public void SafeLink_WhenNoLinkSupport_ProducesValidMarkup(string link, string? title, string expectedText)
+    {
+        var result = MarkupHelpers.SafeLink(supportsLinks: false, link, title);
+
+        var output = new StringBuilder();
+        var console = CreateAnsiConsole(output, ansi: false);
+        console.MarkupLine(result);
+
+        var rendered = output.ToString().Trim();
+        Assert.Equal(expectedText, rendered);
+    }
+
+    private static IAnsiConsole CreateAnsiConsole(StringBuilder output, bool ansi)
+    {
+        var settings = new AnsiConsoleSettings
+        {
+            Ansi = ansi ? AnsiSupport.Yes : AnsiSupport.No,
+            ColorSystem = ansi ? ColorSystemSupport.Standard : ColorSystemSupport.NoColors,
+            Out = new AnsiConsoleOutput(new StringWriter(output)),
+            Enrichment = new ProfileEnrichment { UseDefaultEnrichers = false }
+        };
+        var console = AnsiConsole.Create(settings);
+        console.Profile.Width = int.MaxValue;
+        if (ansi)
+        {
+            console.Profile.Capabilities.Links = true;
+        }
+        return console;
+    }
+}


### PR DESCRIPTION
## Description

Add `MarkupHelpers.SafeLink` helper and `IInteractionService.SupportsLinks` property so that CLI link markup gracefully degrades when the terminal doesn't support clickable hyperlinks.

Previously, the CLI used raw Spectre.Console `[link=...]` markup everywhere. When ANSI link support is unavailable, these render as plain text that can't be clicked and loses the URL when a title is provided.

Now all link construction goes through `MarkupHelpers.SafeLink`, which:
- Emits `[link=url]title[/]` when the console supports links
- Falls back to `title (url)` plain text otherwise

### Changes
- Added `bool SupportsLinks` to `IInteractionService` (reads from `MessageConsole.Profile.Capabilities.Links`)
- Created `MarkupHelpers.SafeLink` with overloads for `IInteractionService` and raw `bool`
- Converted all direct `[link=...]` markup in CLI commands to use `SafeLink`
- Updated resource string `MoreInfoNewCliVersion` to remove embedded `[link]` markup
- Updated test doubles and test assertions

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
  - [x] No
