### PR TITLE
Clarify AppHost output from stop all

### DIFF
--- a/src/Aspire.Cli/Commands/StopCommand.cs
+++ b/src/Aspire.Cli/Commands/StopCommand.cs
@@ -112,7 +112,7 @@ internal sealed class StopCommand : BaseCommand
         if (inScopeConnections.Length == 1)
         {
             var connection = inScopeConnections[0].Connection!;
-            return await StopAppHostAsync(connection, cancellationToken);
+            return await StopAppHostAsync(connection, GetAppHostDisplayPath(connection), cancellationToken);
         }
 
         // Multiple in-scope AppHosts or none in scope: error with guidance
@@ -137,7 +137,7 @@ internal sealed class StopCommand : BaseCommand
             return AppHostConnectionResultHandler.DisplayFailureAsInformation(result, _interactionService);
         }
 
-        return await StopAppHostAsync(result.Connection!, cancellationToken);
+        return await StopAppHostAsync(result.Connection!, GetAppHostDisplayPath(result.Connection!), cancellationToken);
     }
 
     /// <summary>
@@ -157,13 +157,19 @@ internal sealed class StopCommand : BaseCommand
 
         _logger.LogDebug("Found {Count} running AppHost(s) to stop", allConnections.Length);
 
+        var connections = allConnections.Select(connectionResult => connectionResult.Connection!).ToArray();
+        var displayPathCounts = connections
+            .GroupBy(GetAppHostDisplayPath, StringComparer.OrdinalIgnoreCase)
+            .ToDictionary(group => group.Key, group => group.Count(), StringComparer.OrdinalIgnoreCase);
+
         // Stop all AppHosts in parallel
-        var stopTasks = allConnections.Select(connectionResult =>
+        var stopTasks = connections.Select(connection =>
         {
-            var connection = connectionResult.Connection!;
             var appHostPath = connection.AppHostInfo?.AppHostPath ?? "Unknown";
+            var displayPath = GetAppHostDisplayPath(connection);
+            var appHostIdentifier = GetAppHostIdentifier(connection, displayPath, displayPathCounts[displayPath] > 1);
             _logger.LogDebug("Queuing stop for AppHost: {AppHostPath}", appHostPath);
-            return StopAppHostAsync(connection, cancellationToken);
+            return StopAppHostAsync(connection, appHostIdentifier, cancellationToken);
         }).ToArray();
 
         var results = await Task.WhenAll(stopTasks);
@@ -177,20 +183,16 @@ internal sealed class StopCommand : BaseCommand
     /// <summary>
     /// Stops a single AppHost by sending a stop signal to its CLI process or falling back to RPC.
     /// </summary>
-    private async Task<int> StopAppHostAsync(IAppHostAuxiliaryBackchannel connection, CancellationToken cancellationToken)
+    private async Task<int> StopAppHostAsync(IAppHostAuxiliaryBackchannel connection, string appHostIdentifier, CancellationToken cancellationToken)
     {
         // Stop the selected AppHost
         var appHostPath = connection.AppHostInfo?.AppHostPath ?? "Unknown";
-        // Use relative path for in-scope, full path for out-of-scope
-        var displayPath = connection.IsInScope
-            ? Path.GetRelativePath(ExecutionContext.WorkingDirectory.FullName, appHostPath)
-            : appHostPath;
-        _interactionService.DisplayMessage(KnownEmojis.Package, $"Found running AppHost: {displayPath}");
+        _interactionService.DisplayMessage(KnownEmojis.Package, string.Format(CultureInfo.CurrentCulture, StopCommandStrings.FoundRunningAppHost, appHostIdentifier));
         _logger.LogDebug("Stopping AppHost: {AppHostPath}", appHostPath);
 
         var appHostInfo = connection.AppHostInfo;
 
-        _interactionService.DisplayMessage(KnownEmojis.StopSign, "Sending stop signal...");
+        _interactionService.DisplayMessage(KnownEmojis.StopSign, string.Format(CultureInfo.CurrentCulture, StopCommandStrings.SendingStopSignal, appHostIdentifier));
 
         if (appHostInfo?.CliProcessId is int cliPid)
         {
@@ -202,7 +204,7 @@ internal sealed class StopCommand : BaseCommand
             catch (Exception ex)
             {
                 _logger.LogWarning(ex, "Failed to send stop signal to CLI process {Pid}", cliPid);
-                _interactionService.DisplayError(StopCommandStrings.FailedToStopAppHost);
+                _interactionService.DisplayError(string.Format(CultureInfo.CurrentCulture, StopCommandStrings.FailedToStopAppHost, appHostIdentifier));
                 return ExitCodeConstants.FailedToDotnetRunAppHost;
             }
         }
@@ -231,20 +233,20 @@ internal sealed class StopCommand : BaseCommand
                 catch (Exception ex)
                 {
                     _logger.LogWarning(ex, "Failed to send stop signal to process {Pid}", appHostPid);
-                    _interactionService.DisplayError(StopCommandStrings.FailedToStopAppHost);
+                    _interactionService.DisplayError(string.Format(CultureInfo.CurrentCulture, StopCommandStrings.FailedToStopAppHost, appHostIdentifier));
                     return ExitCodeConstants.FailedToDotnetRunAppHost;
                 }
             }
             else if (!rpcSucceeded)
             {
-                _interactionService.DisplayError(StopCommandStrings.FailedToStopAppHost);
+                _interactionService.DisplayError(string.Format(CultureInfo.CurrentCulture, StopCommandStrings.FailedToStopAppHost, appHostIdentifier));
                 return ExitCodeConstants.FailedToDotnetRunAppHost;
             }
         }
 
         var manager = new RunningInstanceManager(_logger, _interactionService, _timeProvider);
         var stopped = await _interactionService.ShowStatusAsync(
-            StopCommandStrings.StoppingAppHost,
+            string.Format(CultureInfo.CurrentCulture, StopCommandStrings.StoppingAppHost, appHostIdentifier),
             async () =>
             {
                 try
@@ -286,14 +288,34 @@ internal sealed class StopCommand : BaseCommand
 
         if (stopped)
         {
-            _interactionService.DisplaySuccess(StopCommandStrings.AppHostStoppedSuccessfully);
+            _interactionService.DisplaySuccess(string.Format(CultureInfo.CurrentCulture, StopCommandStrings.AppHostStoppedSuccessfully, appHostIdentifier));
             return ExitCodeConstants.Success;
         }
         else
         {
-            _interactionService.DisplayError(StopCommandStrings.FailedToStopAppHost);
+            _interactionService.DisplayError(string.Format(CultureInfo.CurrentCulture, StopCommandStrings.FailedToStopAppHost, appHostIdentifier));
             return ExitCodeConstants.FailedToDotnetRunAppHost;
         }
+    }
+
+    private string GetAppHostDisplayPath(IAppHostAuxiliaryBackchannel connection)
+    {
+        var appHostPath = connection.AppHostInfo?.AppHostPath;
+        if (string.IsNullOrEmpty(appHostPath))
+        {
+            return "Unknown";
+        }
+
+        return connection.IsInScope
+            ? Path.GetRelativePath(ExecutionContext.WorkingDirectory.FullName, appHostPath)
+            : appHostPath;
+    }
+
+    private static string GetAppHostIdentifier(IAppHostAuxiliaryBackchannel connection, string displayPath, bool includeProcessId)
+    {
+        return includeProcessId && connection.AppHostInfo is { } appHostInfo
+            ? string.Format(CultureInfo.CurrentCulture, StopCommandStrings.AppHostIdentifierWithProcessId, displayPath, appHostInfo.ProcessId)
+            : displayPath;
     }
 
     /// <summary>

--- a/src/Aspire.Cli/Commands/StopCommand.cs
+++ b/src/Aspire.Cli/Commands/StopCommand.cs
@@ -22,6 +22,7 @@ internal sealed class StopCommand : BaseCommand
     private readonly AppHostConnectionResolver _connectionResolver;
     private readonly ILogger<StopCommand> _logger;
     private readonly ICliHostEnvironment _hostEnvironment;
+    private readonly ProfilingTelemetry _profilingTelemetry;
     private readonly TimeProvider _timeProvider;
 
     private static readonly OptionWithLegacy<FileInfo?> s_appHostOption = new("--apphost", "--project", StopCommandStrings.ProjectArgumentDescription);
@@ -41,13 +42,15 @@ internal sealed class StopCommand : BaseCommand
         ICliHostEnvironment hostEnvironment,
         ILogger<StopCommand> logger,
         AspireCliTelemetry telemetry,
+        ProfilingTelemetry profilingTelemetry,
         TimeProvider? timeProvider = null)
         : base("stop", StopCommandStrings.Description, features, updateNotifier, executionContext, interactionService, telemetry)
     {
         _interactionService = interactionService;
-        _connectionResolver = new AppHostConnectionResolver(backchannelMonitor, interactionService, projectLocator, executionContext, logger);
+        _connectionResolver = new AppHostConnectionResolver(backchannelMonitor, interactionService, projectLocator, executionContext, logger, profilingTelemetry);
         _hostEnvironment = hostEnvironment;
         _logger = logger;
+        _profilingTelemetry = profilingTelemetry;
         _timeProvider = timeProvider ?? TimeProvider.System;
 
         Options.Add(s_appHostOption);
@@ -58,27 +61,28 @@ internal sealed class StopCommand : BaseCommand
     {
         var passedAppHostProjectFile = parseResult.GetValue(s_appHostOption);
         var stopAll = parseResult.GetValue(s_allOption);
+        using var activity = _profilingTelemetry.StartStopCommand(stopAll, passedAppHostProjectFile is not null);
 
         // Validate mutual exclusivity of --all and --project
         if (stopAll && passedAppHostProjectFile is not null)
         {
             _interactionService.DisplayError(string.Format(CultureInfo.InvariantCulture, StopCommandStrings.AllAndProjectMutuallyExclusive, s_allOption.Name, s_appHostOption.Name));
-            return ExitCodeConstants.FailedToFindProject;
+            return CompleteStopActivity(activity, ExitCodeConstants.FailedToFindProject);
         }
 
         // Handle --all: stop all running AppHosts
         if (stopAll)
         {
-            return await StopAllAppHostsAsync(cancellationToken);
+            return CompleteStopActivity(activity, await StopAllAppHostsAsync(cancellationToken));
         }
 
         // In non-interactive mode, try to auto-resolve without prompting
         if (!_hostEnvironment.SupportsInteractiveInput)
         {
-            return await ExecuteNonInteractiveAsync(passedAppHostProjectFile, cancellationToken);
+            return CompleteStopActivity(activity, await ExecuteNonInteractiveAsync(passedAppHostProjectFile, cancellationToken));
         }
 
-        return await ExecuteInteractiveAsync(passedAppHostProjectFile, cancellationToken);
+        return CompleteStopActivity(activity, await ExecuteInteractiveAsync(passedAppHostProjectFile, cancellationToken));
     }
 
     /// <summary>
@@ -112,6 +116,7 @@ internal sealed class StopCommand : BaseCommand
         if (inScopeConnections.Length == 1)
         {
             var connection = inScopeConnections[0].Connection!;
+            _profilingTelemetry.CurrentActivity.SetAppHostStopCount(1);
             return await StopAppHostAsync(connection, GetAppHostDisplayPath(connection), cancellationToken);
         }
 
@@ -137,6 +142,7 @@ internal sealed class StopCommand : BaseCommand
             return AppHostConnectionResultHandler.DisplayFailureAsInformation(result, _interactionService);
         }
 
+        _profilingTelemetry.CurrentActivity.SetAppHostStopCount(1);
         return await StopAppHostAsync(result.Connection!, GetAppHostDisplayPath(result.Connection!), cancellationToken);
     }
 
@@ -148,6 +154,7 @@ internal sealed class StopCommand : BaseCommand
         var allConnections = await _connectionResolver.ResolveAllConnectionsAsync(
             SharedCommandStrings.ScanningForRunningAppHosts,
             cancellationToken);
+        _profilingTelemetry.CurrentActivity.SetAppHostStopCount(allConnections.Length);
 
         if (allConnections.Length == 0)
         {
@@ -190,10 +197,10 @@ internal sealed class StopCommand : BaseCommand
     {
         // Stop the selected AppHost
         var appHostPath = connection.AppHostInfo?.AppHostPath ?? "Unknown";
+        var appHostInfo = connection.AppHostInfo;
+        using var activity = _profilingTelemetry.StartStopAppHost(appHostInfo);
         _interactionService.DisplayMessage(KnownEmojis.Package, string.Format(CultureInfo.CurrentCulture, StopCommandStrings.FoundRunningAppHost, appHostIdentifier));
         _logger.LogDebug("Stopping AppHost: {AppHostPath}", appHostPath);
-
-        var appHostInfo = connection.AppHostInfo;
 
         _interactionService.DisplayMessage(KnownEmojis.StopSign, string.Format(CultureInfo.CurrentCulture, StopCommandStrings.SendingStopSignal, appHostIdentifier));
 
@@ -208,7 +215,7 @@ internal sealed class StopCommand : BaseCommand
             {
                 _logger.LogWarning(ex, "Failed to send stop signal to CLI process {Pid}", cliPid);
                 _interactionService.DisplayError(string.Format(CultureInfo.CurrentCulture, StopCommandStrings.FailedToStopAppHost, appHostIdentifier));
-                return ExitCodeConstants.FailedToDotnetRunAppHost;
+                return CompleteStopActivity(activity, ExitCodeConstants.FailedToDotnetRunAppHost);
             }
         }
         else
@@ -237,13 +244,13 @@ internal sealed class StopCommand : BaseCommand
                 {
                     _logger.LogWarning(ex, "Failed to send stop signal to process {Pid}", appHostPid);
                     _interactionService.DisplayError(string.Format(CultureInfo.CurrentCulture, StopCommandStrings.FailedToStopAppHost, appHostIdentifier));
-                    return ExitCodeConstants.FailedToDotnetRunAppHost;
+                    return CompleteStopActivity(activity, ExitCodeConstants.FailedToDotnetRunAppHost);
                 }
             }
             else if (!rpcSucceeded)
             {
                 _interactionService.DisplayError(string.Format(CultureInfo.CurrentCulture, StopCommandStrings.FailedToStopAppHost, appHostIdentifier));
-                return ExitCodeConstants.FailedToDotnetRunAppHost;
+                return CompleteStopActivity(activity, ExitCodeConstants.FailedToDotnetRunAppHost);
             }
         }
 
@@ -292,13 +299,24 @@ internal sealed class StopCommand : BaseCommand
         if (stopped)
         {
             _interactionService.DisplaySuccess(string.Format(CultureInfo.CurrentCulture, StopCommandStrings.AppHostStoppedSuccessfully, appHostIdentifier));
-            return ExitCodeConstants.Success;
+            return CompleteStopActivity(activity, ExitCodeConstants.Success);
         }
         else
         {
             _interactionService.DisplayError(string.Format(CultureInfo.CurrentCulture, StopCommandStrings.FailedToStopAppHost, appHostIdentifier));
-            return ExitCodeConstants.FailedToDotnetRunAppHost;
+            return CompleteStopActivity(activity, ExitCodeConstants.FailedToDotnetRunAppHost);
         }
+    }
+
+    private static int CompleteStopActivity(ProfilingTelemetry.ActivityScope activity, int exitCode)
+    {
+        activity.SetProcessExitCode(exitCode);
+        if (exitCode != ExitCodeConstants.Success)
+        {
+            activity.SetError($"Stop exited with code {exitCode}.");
+        }
+
+        return exitCode;
     }
 
     private static string GetAppHostDisplayPath(IAppHostAuxiliaryBackchannel connection)

--- a/src/Aspire.Cli/Commands/StopCommand.cs
+++ b/src/Aspire.Cli/Commands/StopCommand.cs
@@ -158,16 +158,19 @@ internal sealed class StopCommand : BaseCommand
         _logger.LogDebug("Found {Count} running AppHost(s) to stop", allConnections.Length);
 
         var connections = allConnections.Select(connectionResult => connectionResult.Connection!).ToArray();
-        var displayPathCounts = connections
-            .GroupBy(GetAppHostDisplayPath, StringComparer.OrdinalIgnoreCase)
-            .ToDictionary(group => group.Key, group => group.Count(), StringComparer.OrdinalIgnoreCase);
+        var appHostPaths = connections.Select(GetAppHostPath).ToArray();
+        var appHostPathComparer = GetAppHostPathComparer();
+        var displayPaths = FileSystemHelper.ShortenPaths(appHostPaths);
+        var appHostPathCounts = appHostPaths
+            .GroupBy(path => path, appHostPathComparer)
+            .ToDictionary(group => group.Key, group => group.Count(), appHostPathComparer);
 
         // Stop all AppHosts in parallel
         var stopTasks = connections.Select(connection =>
         {
-            var appHostPath = connection.AppHostInfo?.AppHostPath ?? "Unknown";
-            var displayPath = GetAppHostDisplayPath(connection);
-            var appHostIdentifier = GetAppHostIdentifier(connection, displayPath, displayPathCounts[displayPath] > 1);
+            var appHostPath = GetAppHostPath(connection);
+            var displayPath = displayPaths[appHostPath];
+            var appHostIdentifier = GetAppHostIdentifier(connection, displayPath, appHostPathCounts[appHostPath] > 1);
             _logger.LogDebug("Queuing stop for AppHost: {AppHostPath}", appHostPath);
             return StopAppHostAsync(connection, appHostIdentifier, cancellationToken);
         }).ToArray();
@@ -298,17 +301,24 @@ internal sealed class StopCommand : BaseCommand
         }
     }
 
-    private string GetAppHostDisplayPath(IAppHostAuxiliaryBackchannel connection)
+    private static string GetAppHostDisplayPath(IAppHostAuxiliaryBackchannel connection)
     {
-        var appHostPath = connection.AppHostInfo?.AppHostPath;
-        if (string.IsNullOrEmpty(appHostPath))
-        {
-            return "Unknown";
-        }
+        var appHostPath = GetAppHostPath(connection);
+        return FileSystemHelper.ShortenPaths([appHostPath])[appHostPath];
+    }
 
-        return connection.IsInScope
-            ? Path.GetRelativePath(ExecutionContext.WorkingDirectory.FullName, appHostPath)
-            : appHostPath;
+    private static string GetAppHostPath(IAppHostAuxiliaryBackchannel connection)
+    {
+        return string.IsNullOrEmpty(connection.AppHostInfo?.AppHostPath)
+            ? "Unknown"
+            : connection.AppHostInfo.AppHostPath;
+    }
+
+    private static StringComparer GetAppHostPathComparer()
+    {
+        return OperatingSystem.IsWindows()
+            ? StringComparer.OrdinalIgnoreCase
+            : StringComparer.Ordinal;
     }
 
     private static string GetAppHostIdentifier(IAppHostAuxiliaryBackchannel connection, string displayPath, bool includeProcessId)

--- a/src/Aspire.Cli/Commands/StopCommand.cs
+++ b/src/Aspire.Cli/Commands/StopCommand.cs
@@ -304,7 +304,8 @@ internal sealed class StopCommand : BaseCommand
     private static string GetAppHostDisplayPath(IAppHostAuxiliaryBackchannel connection)
     {
         var appHostPath = GetAppHostPath(connection);
-        return FileSystemHelper.ShortenPaths([appHostPath])[appHostPath];
+        var displayPaths = FileSystemHelper.ShortenPaths([appHostPath]);
+        return displayPaths.TryGetValue(appHostPath, out var displayPath) ? displayPath : appHostPath;
     }
 
     private static string GetAppHostPath(IAppHostAuxiliaryBackchannel connection)

--- a/src/Aspire.Cli/Commands/StopCommand.cs
+++ b/src/Aspire.Cli/Commands/StopCommand.cs
@@ -117,7 +117,7 @@ internal sealed class StopCommand : BaseCommand
         {
             var connection = inScopeConnections[0].Connection!;
             _profilingTelemetry.CurrentActivity.SetAppHostStopCount(1);
-            return await StopAppHostAsync(connection, GetAppHostDisplayPath(connection), cancellationToken);
+            return await StopAppHostAsync(connection, GetSingleAppHostDisplayPath(connection), cancellationToken);
         }
 
         // Multiple in-scope AppHosts or none in scope: error with guidance
@@ -143,7 +143,7 @@ internal sealed class StopCommand : BaseCommand
         }
 
         _profilingTelemetry.CurrentActivity.SetAppHostStopCount(1);
-        return await StopAppHostAsync(result.Connection!, GetAppHostDisplayPath(result.Connection!), cancellationToken);
+        return await StopAppHostAsync(result.Connection!, GetSingleAppHostDisplayPath(result.Connection!), cancellationToken);
     }
 
     /// <summary>
@@ -232,7 +232,7 @@ internal sealed class StopCommand : BaseCommand
                 _logger.LogWarning(ex, "Failed to send stop signal via RPC");
             }
 
-            // If RPC didn't work, try sending SIGINT to AppHost process directly
+            // If RPC didn't work, try sending a stop signal to the AppHost process directly.
             if (!rpcSucceeded && appHostInfo?.ProcessId is int appHostPid)
             {
                 _logger.LogDebug("RPC stop not available, sending SIGTERM to AppHost PID {Pid}", appHostPid);
@@ -319,11 +319,17 @@ internal sealed class StopCommand : BaseCommand
         return exitCode;
     }
 
-    private static string GetAppHostDisplayPath(IAppHostAuxiliaryBackchannel connection)
+    private string GetSingleAppHostDisplayPath(IAppHostAuxiliaryBackchannel connection)
     {
-        var appHostPath = GetAppHostPath(connection);
-        var displayPaths = FileSystemHelper.ShortenPaths([appHostPath]);
-        return displayPaths.TryGetValue(appHostPath, out var displayPath) ? displayPath : appHostPath;
+        if (string.IsNullOrEmpty(connection.AppHostInfo?.AppHostPath))
+        {
+            return "Unknown";
+        }
+
+        var appHostPath = connection.AppHostInfo.AppHostPath;
+        return connection.IsInScope
+            ? Path.GetRelativePath(ExecutionContext.WorkingDirectory.FullName, appHostPath)
+            : appHostPath;
     }
 
     private static string GetAppHostPath(IAppHostAuxiliaryBackchannel connection)

--- a/src/Aspire.Cli/Resources/StopCommandStrings.Designer.cs
+++ b/src/Aspire.Cli/Resources/StopCommandStrings.Designer.cs
@@ -69,6 +69,12 @@ namespace Aspire.Cli.Resources {
             }
         }
 
+        public static string AppHostIdentifierWithProcessId {
+            get {
+                return ResourceManager.GetString("AppHostIdentifierWithProcessId", resourceCulture);
+            }
+        }
+
         public static string MultipleAppHostsRunning {
             get {
                 return ResourceManager.GetString("MultipleAppHostsRunning", resourceCulture);
@@ -78,6 +84,18 @@ namespace Aspire.Cli.Resources {
         public static string FailedToStopAppHost {
             get {
                 return ResourceManager.GetString("FailedToStopAppHost", resourceCulture);
+            }
+        }
+
+        public static string FoundRunningAppHost {
+            get {
+                return ResourceManager.GetString("FoundRunningAppHost", resourceCulture);
+            }
+        }
+
+        public static string SendingStopSignal {
+            get {
+                return ResourceManager.GetString("SendingStopSignal", resourceCulture);
             }
         }
 

--- a/src/Aspire.Cli/Resources/StopCommandStrings.resx
+++ b/src/Aspire.Cli/Resources/StopCommandStrings.resx
@@ -124,16 +124,25 @@
     <value>The path to the Aspire AppHost project file or a directory to search</value>
   </data>
   <data name="StoppingAppHost" xml:space="preserve">
-    <value>Stopping Aspire AppHost...</value>
+    <value>Stopping {0}...</value>
   </data>
   <data name="AppHostStoppedSuccessfully" xml:space="preserve">
-    <value>AppHost stopped successfully.</value>
+    <value>{0} stopped successfully.</value>
+  </data>
+  <data name="AppHostIdentifierWithProcessId" xml:space="preserve">
+    <value>{0} (PID {1})</value>
   </data>
   <data name="MultipleAppHostsRunning" xml:space="preserve">
     <value>Multiple AppHosts are running. Use --apphost to specify which one to stop, or select one:</value>
   </data>
   <data name="FailedToStopAppHost" xml:space="preserve">
-    <value>Failed to stop the AppHost.</value>
+    <value>Failed to stop {0}.</value>
+  </data>
+  <data name="FoundRunningAppHost" xml:space="preserve">
+    <value>Found running AppHost: {0}</value>
+  </data>
+  <data name="SendingStopSignal" xml:space="preserve">
+    <value>Sending stop signal to {0}...</value>
   </data>
   <data name="SelectAppHostAction" xml:space="preserve">
     <value>stop</value>

--- a/src/Aspire.Cli/Resources/xlf/StopCommandStrings.cs.xlf
+++ b/src/Aspire.Cli/Resources/xlf/StopCommandStrings.cs.xlf
@@ -7,9 +7,14 @@
         <target state="new">Stop all running AppHosts</target>
         <note />
       </trans-unit>
+      <trans-unit id="AppHostIdentifierWithProcessId">
+        <source>{0} (PID {1})</source>
+        <target state="new">{0} (PID {1})</target>
+        <note />
+      </trans-unit>
       <trans-unit id="AppHostStoppedSuccessfully">
-        <source>AppHost stopped successfully.</source>
-        <target state="needs-review-translation">Hostitel aplikací se úspěšně zastavil.</target>
+        <source>{0} stopped successfully.</source>
+        <target state="new">{0} stopped successfully.</target>
         <note />
       </trans-unit>
       <trans-unit id="Description">
@@ -18,8 +23,13 @@
         <note />
       </trans-unit>
       <trans-unit id="FailedToStopAppHost">
-        <source>Failed to stop the AppHost.</source>
-        <target state="needs-review-translation">Nepovedlo se zastavit hostitele aplikací.</target>
+        <source>Failed to stop {0}.</source>
+        <target state="new">Failed to stop {0}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FoundRunningAppHost">
+        <source>Found running AppHost: {0}</source>
+        <target state="new">Found running AppHost: {0}</target>
         <note />
       </trans-unit>
       <trans-unit id="MultipleAppHostsNonInteractive">
@@ -42,9 +52,14 @@
         <target state="translated">zastavit</target>
         <note />
       </trans-unit>
+      <trans-unit id="SendingStopSignal">
+        <source>Sending stop signal to {0}...</source>
+        <target state="new">Sending stop signal to {0}...</target>
+        <note />
+      </trans-unit>
       <trans-unit id="StoppingAppHost">
-        <source>Stopping Aspire AppHost...</source>
-        <target state="needs-review-translation">Spouští se hostitel aplikací Aspire...</target>
+        <source>Stopping {0}...</source>
+        <target state="new">Stopping {0}...</target>
         <note />
       </trans-unit>
       <trans-unit id="AllAndProjectMutuallyExclusive">

--- a/src/Aspire.Cli/Resources/xlf/StopCommandStrings.de.xlf
+++ b/src/Aspire.Cli/Resources/xlf/StopCommandStrings.de.xlf
@@ -7,9 +7,14 @@
         <target state="new">Stop all running AppHosts</target>
         <note />
       </trans-unit>
+      <trans-unit id="AppHostIdentifierWithProcessId">
+        <source>{0} (PID {1})</source>
+        <target state="new">{0} (PID {1})</target>
+        <note />
+      </trans-unit>
       <trans-unit id="AppHostStoppedSuccessfully">
-        <source>AppHost stopped successfully.</source>
-        <target state="needs-review-translation">AppHost wurde erfolgreich beendet.</target>
+        <source>{0} stopped successfully.</source>
+        <target state="new">{0} stopped successfully.</target>
         <note />
       </trans-unit>
       <trans-unit id="Description">
@@ -18,8 +23,13 @@
         <note />
       </trans-unit>
       <trans-unit id="FailedToStopAppHost">
-        <source>Failed to stop the AppHost.</source>
-        <target state="needs-review-translation">Beim Beenden des AppHost ist ein Fehler aufgetreten.</target>
+        <source>Failed to stop {0}.</source>
+        <target state="new">Failed to stop {0}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FoundRunningAppHost">
+        <source>Found running AppHost: {0}</source>
+        <target state="new">Found running AppHost: {0}</target>
         <note />
       </trans-unit>
       <trans-unit id="MultipleAppHostsNonInteractive">
@@ -42,9 +52,14 @@
         <target state="translated">Beenden</target>
         <note />
       </trans-unit>
+      <trans-unit id="SendingStopSignal">
+        <source>Sending stop signal to {0}...</source>
+        <target state="new">Sending stop signal to {0}...</target>
+        <note />
+      </trans-unit>
       <trans-unit id="StoppingAppHost">
-        <source>Stopping Aspire AppHost...</source>
-        <target state="needs-review-translation">Aspire-AppHost wird beendet …</target>
+        <source>Stopping {0}...</source>
+        <target state="new">Stopping {0}...</target>
         <note />
       </trans-unit>
       <trans-unit id="AllAndProjectMutuallyExclusive">

--- a/src/Aspire.Cli/Resources/xlf/StopCommandStrings.es.xlf
+++ b/src/Aspire.Cli/Resources/xlf/StopCommandStrings.es.xlf
@@ -7,9 +7,14 @@
         <target state="new">Stop all running AppHosts</target>
         <note />
       </trans-unit>
+      <trans-unit id="AppHostIdentifierWithProcessId">
+        <source>{0} (PID {1})</source>
+        <target state="new">{0} (PID {1})</target>
+        <note />
+      </trans-unit>
       <trans-unit id="AppHostStoppedSuccessfully">
-        <source>AppHost stopped successfully.</source>
-        <target state="needs-review-translation">AppHost se detuvo correctamente.</target>
+        <source>{0} stopped successfully.</source>
+        <target state="new">{0} stopped successfully.</target>
         <note />
       </trans-unit>
       <trans-unit id="Description">
@@ -18,8 +23,13 @@
         <note />
       </trans-unit>
       <trans-unit id="FailedToStopAppHost">
-        <source>Failed to stop the AppHost.</source>
-        <target state="needs-review-translation">No se pudo detener AppHost.</target>
+        <source>Failed to stop {0}.</source>
+        <target state="new">Failed to stop {0}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FoundRunningAppHost">
+        <source>Found running AppHost: {0}</source>
+        <target state="new">Found running AppHost: {0}</target>
         <note />
       </trans-unit>
       <trans-unit id="MultipleAppHostsNonInteractive">
@@ -42,9 +52,14 @@
         <target state="translated">detener</target>
         <note />
       </trans-unit>
+      <trans-unit id="SendingStopSignal">
+        <source>Sending stop signal to {0}...</source>
+        <target state="new">Sending stop signal to {0}...</target>
+        <note />
+      </trans-unit>
       <trans-unit id="StoppingAppHost">
-        <source>Stopping Aspire AppHost...</source>
-        <target state="needs-review-translation">Deteniendo apphost de Aspire...</target>
+        <source>Stopping {0}...</source>
+        <target state="new">Stopping {0}...</target>
         <note />
       </trans-unit>
       <trans-unit id="AllAndProjectMutuallyExclusive">

--- a/src/Aspire.Cli/Resources/xlf/StopCommandStrings.fr.xlf
+++ b/src/Aspire.Cli/Resources/xlf/StopCommandStrings.fr.xlf
@@ -7,9 +7,14 @@
         <target state="new">Stop all running AppHosts</target>
         <note />
       </trans-unit>
+      <trans-unit id="AppHostIdentifierWithProcessId">
+        <source>{0} (PID {1})</source>
+        <target state="new">{0} (PID {1})</target>
+        <note />
+      </trans-unit>
       <trans-unit id="AppHostStoppedSuccessfully">
-        <source>AppHost stopped successfully.</source>
-        <target state="needs-review-translation">AppHost s’est arrêtée avec succès.</target>
+        <source>{0} stopped successfully.</source>
+        <target state="new">{0} stopped successfully.</target>
         <note />
       </trans-unit>
       <trans-unit id="Description">
@@ -18,8 +23,13 @@
         <note />
       </trans-unit>
       <trans-unit id="FailedToStopAppHost">
-        <source>Failed to stop the AppHost.</source>
-        <target state="needs-review-translation">Échec de l'arrêt d’AppHost.</target>
+        <source>Failed to stop {0}.</source>
+        <target state="new">Failed to stop {0}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FoundRunningAppHost">
+        <source>Found running AppHost: {0}</source>
+        <target state="new">Found running AppHost: {0}</target>
         <note />
       </trans-unit>
       <trans-unit id="MultipleAppHostsNonInteractive">
@@ -42,9 +52,14 @@
         <target state="translated">arrêter</target>
         <note />
       </trans-unit>
+      <trans-unit id="SendingStopSignal">
+        <source>Sending stop signal to {0}...</source>
+        <target state="new">Sending stop signal to {0}...</target>
+        <note />
+      </trans-unit>
       <trans-unit id="StoppingAppHost">
-        <source>Stopping Aspire AppHost...</source>
-        <target state="needs-review-translation">Arrêt d'Aspire apphost...</target>
+        <source>Stopping {0}...</source>
+        <target state="new">Stopping {0}...</target>
         <note />
       </trans-unit>
       <trans-unit id="AllAndProjectMutuallyExclusive">

--- a/src/Aspire.Cli/Resources/xlf/StopCommandStrings.it.xlf
+++ b/src/Aspire.Cli/Resources/xlf/StopCommandStrings.it.xlf
@@ -7,9 +7,14 @@
         <target state="new">Stop all running AppHosts</target>
         <note />
       </trans-unit>
+      <trans-unit id="AppHostIdentifierWithProcessId">
+        <source>{0} (PID {1})</source>
+        <target state="new">{0} (PID {1})</target>
+        <note />
+      </trans-unit>
       <trans-unit id="AppHostStoppedSuccessfully">
-        <source>AppHost stopped successfully.</source>
-        <target state="needs-review-translation">AppHost è stato interrotto.</target>
+        <source>{0} stopped successfully.</source>
+        <target state="new">{0} stopped successfully.</target>
         <note />
       </trans-unit>
       <trans-unit id="Description">
@@ -18,8 +23,13 @@
         <note />
       </trans-unit>
       <trans-unit id="FailedToStopAppHost">
-        <source>Failed to stop the AppHost.</source>
-        <target state="needs-review-translation">Non è possibile arrestare AppHost.</target>
+        <source>Failed to stop {0}.</source>
+        <target state="new">Failed to stop {0}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FoundRunningAppHost">
+        <source>Found running AppHost: {0}</source>
+        <target state="new">Found running AppHost: {0}</target>
         <note />
       </trans-unit>
       <trans-unit id="MultipleAppHostsNonInteractive">
@@ -42,9 +52,14 @@
         <target state="translated">arresta</target>
         <note />
       </trans-unit>
+      <trans-unit id="SendingStopSignal">
+        <source>Sending stop signal to {0}...</source>
+        <target state="new">Sending stop signal to {0}...</target>
+        <note />
+      </trans-unit>
       <trans-unit id="StoppingAppHost">
-        <source>Stopping Aspire AppHost...</source>
-        <target state="needs-review-translation">Arresto dell'apphost Aspire in corso...</target>
+        <source>Stopping {0}...</source>
+        <target state="new">Stopping {0}...</target>
         <note />
       </trans-unit>
       <trans-unit id="AllAndProjectMutuallyExclusive">

--- a/src/Aspire.Cli/Resources/xlf/StopCommandStrings.ja.xlf
+++ b/src/Aspire.Cli/Resources/xlf/StopCommandStrings.ja.xlf
@@ -7,9 +7,14 @@
         <target state="new">Stop all running AppHosts</target>
         <note />
       </trans-unit>
+      <trans-unit id="AppHostIdentifierWithProcessId">
+        <source>{0} (PID {1})</source>
+        <target state="new">{0} (PID {1})</target>
+        <note />
+      </trans-unit>
       <trans-unit id="AppHostStoppedSuccessfully">
-        <source>AppHost stopped successfully.</source>
-        <target state="needs-review-translation">AppHost が正常に停止しました。</target>
+        <source>{0} stopped successfully.</source>
+        <target state="new">{0} stopped successfully.</target>
         <note />
       </trans-unit>
       <trans-unit id="Description">
@@ -18,8 +23,13 @@
         <note />
       </trans-unit>
       <trans-unit id="FailedToStopAppHost">
-        <source>Failed to stop the AppHost.</source>
-        <target state="needs-review-translation">AppHost を停止できませんでした。</target>
+        <source>Failed to stop {0}.</source>
+        <target state="new">Failed to stop {0}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FoundRunningAppHost">
+        <source>Found running AppHost: {0}</source>
+        <target state="new">Found running AppHost: {0}</target>
         <note />
       </trans-unit>
       <trans-unit id="MultipleAppHostsNonInteractive">
@@ -42,9 +52,14 @@
         <target state="translated">停止</target>
         <note />
       </trans-unit>
+      <trans-unit id="SendingStopSignal">
+        <source>Sending stop signal to {0}...</source>
+        <target state="new">Sending stop signal to {0}...</target>
+        <note />
+      </trans-unit>
       <trans-unit id="StoppingAppHost">
-        <source>Stopping Aspire AppHost...</source>
-        <target state="needs-review-translation">Aspire apphost を停止しています...</target>
+        <source>Stopping {0}...</source>
+        <target state="new">Stopping {0}...</target>
         <note />
       </trans-unit>
       <trans-unit id="AllAndProjectMutuallyExclusive">

--- a/src/Aspire.Cli/Resources/xlf/StopCommandStrings.ko.xlf
+++ b/src/Aspire.Cli/Resources/xlf/StopCommandStrings.ko.xlf
@@ -7,9 +7,14 @@
         <target state="new">Stop all running AppHosts</target>
         <note />
       </trans-unit>
+      <trans-unit id="AppHostIdentifierWithProcessId">
+        <source>{0} (PID {1})</source>
+        <target state="new">{0} (PID {1})</target>
+        <note />
+      </trans-unit>
       <trans-unit id="AppHostStoppedSuccessfully">
-        <source>AppHost stopped successfully.</source>
-        <target state="needs-review-translation">AppHost가 중지되었습니다.</target>
+        <source>{0} stopped successfully.</source>
+        <target state="new">{0} stopped successfully.</target>
         <note />
       </trans-unit>
       <trans-unit id="Description">
@@ -18,8 +23,13 @@
         <note />
       </trans-unit>
       <trans-unit id="FailedToStopAppHost">
-        <source>Failed to stop the AppHost.</source>
-        <target state="needs-review-translation">AppHost를 중지하지 못했습니다.</target>
+        <source>Failed to stop {0}.</source>
+        <target state="new">Failed to stop {0}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FoundRunningAppHost">
+        <source>Found running AppHost: {0}</source>
+        <target state="new">Found running AppHost: {0}</target>
         <note />
       </trans-unit>
       <trans-unit id="MultipleAppHostsNonInteractive">
@@ -42,9 +52,14 @@
         <target state="translated">중지</target>
         <note />
       </trans-unit>
+      <trans-unit id="SendingStopSignal">
+        <source>Sending stop signal to {0}...</source>
+        <target state="new">Sending stop signal to {0}...</target>
+        <note />
+      </trans-unit>
       <trans-unit id="StoppingAppHost">
-        <source>Stopping Aspire AppHost...</source>
-        <target state="needs-review-translation">Aspire AppHost를 중지하는 중...</target>
+        <source>Stopping {0}...</source>
+        <target state="new">Stopping {0}...</target>
         <note />
       </trans-unit>
       <trans-unit id="AllAndProjectMutuallyExclusive">

--- a/src/Aspire.Cli/Resources/xlf/StopCommandStrings.pl.xlf
+++ b/src/Aspire.Cli/Resources/xlf/StopCommandStrings.pl.xlf
@@ -7,9 +7,14 @@
         <target state="new">Stop all running AppHosts</target>
         <note />
       </trans-unit>
+      <trans-unit id="AppHostIdentifierWithProcessId">
+        <source>{0} (PID {1})</source>
+        <target state="new">{0} (PID {1})</target>
+        <note />
+      </trans-unit>
       <trans-unit id="AppHostStoppedSuccessfully">
-        <source>AppHost stopped successfully.</source>
-        <target state="needs-review-translation">Host aplikacji został pomyślnie zatrzymany.</target>
+        <source>{0} stopped successfully.</source>
+        <target state="new">{0} stopped successfully.</target>
         <note />
       </trans-unit>
       <trans-unit id="Description">
@@ -18,8 +23,13 @@
         <note />
       </trans-unit>
       <trans-unit id="FailedToStopAppHost">
-        <source>Failed to stop the AppHost.</source>
-        <target state="needs-review-translation">Nie można zatrzymać hosta aplikacji.</target>
+        <source>Failed to stop {0}.</source>
+        <target state="new">Failed to stop {0}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FoundRunningAppHost">
+        <source>Found running AppHost: {0}</source>
+        <target state="new">Found running AppHost: {0}</target>
         <note />
       </trans-unit>
       <trans-unit id="MultipleAppHostsNonInteractive">
@@ -42,9 +52,14 @@
         <target state="translated">zatrzymaj</target>
         <note />
       </trans-unit>
+      <trans-unit id="SendingStopSignal">
+        <source>Sending stop signal to {0}...</source>
+        <target state="new">Sending stop signal to {0}...</target>
+        <note />
+      </trans-unit>
       <trans-unit id="StoppingAppHost">
-        <source>Stopping Aspire AppHost...</source>
-        <target state="needs-review-translation">Trwa zatrzymywanie hosta Aspire...</target>
+        <source>Stopping {0}...</source>
+        <target state="new">Stopping {0}...</target>
         <note />
       </trans-unit>
       <trans-unit id="AllAndProjectMutuallyExclusive">

--- a/src/Aspire.Cli/Resources/xlf/StopCommandStrings.pt-BR.xlf
+++ b/src/Aspire.Cli/Resources/xlf/StopCommandStrings.pt-BR.xlf
@@ -7,9 +7,14 @@
         <target state="new">Stop all running AppHosts</target>
         <note />
       </trans-unit>
+      <trans-unit id="AppHostIdentifierWithProcessId">
+        <source>{0} (PID {1})</source>
+        <target state="new">{0} (PID {1})</target>
+        <note />
+      </trans-unit>
       <trans-unit id="AppHostStoppedSuccessfully">
-        <source>AppHost stopped successfully.</source>
-        <target state="needs-review-translation">AppHost interrompido com sucesso.</target>
+        <source>{0} stopped successfully.</source>
+        <target state="new">{0} stopped successfully.</target>
         <note />
       </trans-unit>
       <trans-unit id="Description">
@@ -18,8 +23,13 @@
         <note />
       </trans-unit>
       <trans-unit id="FailedToStopAppHost">
-        <source>Failed to stop the AppHost.</source>
-        <target state="needs-review-translation">Falha ao parar o AppHost.</target>
+        <source>Failed to stop {0}.</source>
+        <target state="new">Failed to stop {0}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FoundRunningAppHost">
+        <source>Found running AppHost: {0}</source>
+        <target state="new">Found running AppHost: {0}</target>
         <note />
       </trans-unit>
       <trans-unit id="MultipleAppHostsNonInteractive">
@@ -42,9 +52,14 @@
         <target state="translated">pare</target>
         <note />
       </trans-unit>
+      <trans-unit id="SendingStopSignal">
+        <source>Sending stop signal to {0}...</source>
+        <target state="new">Sending stop signal to {0}...</target>
+        <note />
+      </trans-unit>
       <trans-unit id="StoppingAppHost">
-        <source>Stopping Aspire AppHost...</source>
-        <target state="needs-review-translation">Parando o apphost Aspire...</target>
+        <source>Stopping {0}...</source>
+        <target state="new">Stopping {0}...</target>
         <note />
       </trans-unit>
       <trans-unit id="AllAndProjectMutuallyExclusive">

--- a/src/Aspire.Cli/Resources/xlf/StopCommandStrings.ru.xlf
+++ b/src/Aspire.Cli/Resources/xlf/StopCommandStrings.ru.xlf
@@ -7,9 +7,14 @@
         <target state="new">Stop all running AppHosts</target>
         <note />
       </trans-unit>
+      <trans-unit id="AppHostIdentifierWithProcessId">
+        <source>{0} (PID {1})</source>
+        <target state="new">{0} (PID {1})</target>
+        <note />
+      </trans-unit>
       <trans-unit id="AppHostStoppedSuccessfully">
-        <source>AppHost stopped successfully.</source>
-        <target state="needs-review-translation">Хост приложений остановлен.</target>
+        <source>{0} stopped successfully.</source>
+        <target state="new">{0} stopped successfully.</target>
         <note />
       </trans-unit>
       <trans-unit id="Description">
@@ -18,8 +23,13 @@
         <note />
       </trans-unit>
       <trans-unit id="FailedToStopAppHost">
-        <source>Failed to stop the AppHost.</source>
-        <target state="needs-review-translation">Не удалось остановить хост приложений.</target>
+        <source>Failed to stop {0}.</source>
+        <target state="new">Failed to stop {0}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FoundRunningAppHost">
+        <source>Found running AppHost: {0}</source>
+        <target state="new">Found running AppHost: {0}</target>
         <note />
       </trans-unit>
       <trans-unit id="MultipleAppHostsNonInteractive">
@@ -42,9 +52,14 @@
         <target state="translated">остановить</target>
         <note />
       </trans-unit>
+      <trans-unit id="SendingStopSignal">
+        <source>Sending stop signal to {0}...</source>
+        <target state="new">Sending stop signal to {0}...</target>
+        <note />
+      </trans-unit>
       <trans-unit id="StoppingAppHost">
-        <source>Stopping Aspire AppHost...</source>
-        <target state="needs-review-translation">Остановка хоста приложений Aspire...</target>
+        <source>Stopping {0}...</source>
+        <target state="new">Stopping {0}...</target>
         <note />
       </trans-unit>
       <trans-unit id="AllAndProjectMutuallyExclusive">

--- a/src/Aspire.Cli/Resources/xlf/StopCommandStrings.tr.xlf
+++ b/src/Aspire.Cli/Resources/xlf/StopCommandStrings.tr.xlf
@@ -7,9 +7,14 @@
         <target state="new">Stop all running AppHosts</target>
         <note />
       </trans-unit>
+      <trans-unit id="AppHostIdentifierWithProcessId">
+        <source>{0} (PID {1})</source>
+        <target state="new">{0} (PID {1})</target>
+        <note />
+      </trans-unit>
       <trans-unit id="AppHostStoppedSuccessfully">
-        <source>AppHost stopped successfully.</source>
-        <target state="needs-review-translation">AppHost başarıyla durduruldu.</target>
+        <source>{0} stopped successfully.</source>
+        <target state="new">{0} stopped successfully.</target>
         <note />
       </trans-unit>
       <trans-unit id="Description">
@@ -18,8 +23,13 @@
         <note />
       </trans-unit>
       <trans-unit id="FailedToStopAppHost">
-        <source>Failed to stop the AppHost.</source>
-        <target state="needs-review-translation">AppHost durdurulamadı.</target>
+        <source>Failed to stop {0}.</source>
+        <target state="new">Failed to stop {0}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FoundRunningAppHost">
+        <source>Found running AppHost: {0}</source>
+        <target state="new">Found running AppHost: {0}</target>
         <note />
       </trans-unit>
       <trans-unit id="MultipleAppHostsNonInteractive">
@@ -42,9 +52,14 @@
         <target state="translated">durdur</target>
         <note />
       </trans-unit>
+      <trans-unit id="SendingStopSignal">
+        <source>Sending stop signal to {0}...</source>
+        <target state="new">Sending stop signal to {0}...</target>
+        <note />
+      </trans-unit>
       <trans-unit id="StoppingAppHost">
-        <source>Stopping Aspire AppHost...</source>
-        <target state="needs-review-translation">Aspire apphost durduruluyor...</target>
+        <source>Stopping {0}...</source>
+        <target state="new">Stopping {0}...</target>
         <note />
       </trans-unit>
       <trans-unit id="AllAndProjectMutuallyExclusive">

--- a/src/Aspire.Cli/Resources/xlf/StopCommandStrings.zh-Hans.xlf
+++ b/src/Aspire.Cli/Resources/xlf/StopCommandStrings.zh-Hans.xlf
@@ -7,9 +7,14 @@
         <target state="new">Stop all running AppHosts</target>
         <note />
       </trans-unit>
+      <trans-unit id="AppHostIdentifierWithProcessId">
+        <source>{0} (PID {1})</source>
+        <target state="new">{0} (PID {1})</target>
+        <note />
+      </trans-unit>
       <trans-unit id="AppHostStoppedSuccessfully">
-        <source>AppHost stopped successfully.</source>
-        <target state="needs-review-translation">已成功停止 AppHost。</target>
+        <source>{0} stopped successfully.</source>
+        <target state="new">{0} stopped successfully.</target>
         <note />
       </trans-unit>
       <trans-unit id="Description">
@@ -18,8 +23,13 @@
         <note />
       </trans-unit>
       <trans-unit id="FailedToStopAppHost">
-        <source>Failed to stop the AppHost.</source>
-        <target state="needs-review-translation">停止 AppHost 失败。</target>
+        <source>Failed to stop {0}.</source>
+        <target state="new">Failed to stop {0}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FoundRunningAppHost">
+        <source>Found running AppHost: {0}</source>
+        <target state="new">Found running AppHost: {0}</target>
         <note />
       </trans-unit>
       <trans-unit id="MultipleAppHostsNonInteractive">
@@ -42,9 +52,14 @@
         <target state="translated">停止</target>
         <note />
       </trans-unit>
+      <trans-unit id="SendingStopSignal">
+        <source>Sending stop signal to {0}...</source>
+        <target state="new">Sending stop signal to {0}...</target>
+        <note />
+      </trans-unit>
       <trans-unit id="StoppingAppHost">
-        <source>Stopping Aspire AppHost...</source>
-        <target state="needs-review-translation">正在停止 Aspire AppHost...</target>
+        <source>Stopping {0}...</source>
+        <target state="new">Stopping {0}...</target>
         <note />
       </trans-unit>
       <trans-unit id="AllAndProjectMutuallyExclusive">

--- a/src/Aspire.Cli/Resources/xlf/StopCommandStrings.zh-Hant.xlf
+++ b/src/Aspire.Cli/Resources/xlf/StopCommandStrings.zh-Hant.xlf
@@ -7,9 +7,14 @@
         <target state="new">Stop all running AppHosts</target>
         <note />
       </trans-unit>
+      <trans-unit id="AppHostIdentifierWithProcessId">
+        <source>{0} (PID {1})</source>
+        <target state="new">{0} (PID {1})</target>
+        <note />
+      </trans-unit>
       <trans-unit id="AppHostStoppedSuccessfully">
-        <source>AppHost stopped successfully.</source>
-        <target state="needs-review-translation">已成功停止 AppHost。</target>
+        <source>{0} stopped successfully.</source>
+        <target state="new">{0} stopped successfully.</target>
         <note />
       </trans-unit>
       <trans-unit id="Description">
@@ -18,8 +23,13 @@
         <note />
       </trans-unit>
       <trans-unit id="FailedToStopAppHost">
-        <source>Failed to stop the AppHost.</source>
-        <target state="needs-review-translation">無法停止 AppHost。</target>
+        <source>Failed to stop {0}.</source>
+        <target state="new">Failed to stop {0}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FoundRunningAppHost">
+        <source>Found running AppHost: {0}</source>
+        <target state="new">Found running AppHost: {0}</target>
         <note />
       </trans-unit>
       <trans-unit id="MultipleAppHostsNonInteractive">
@@ -42,9 +52,14 @@
         <target state="translated">停止</target>
         <note />
       </trans-unit>
+      <trans-unit id="SendingStopSignal">
+        <source>Sending stop signal to {0}...</source>
+        <target state="new">Sending stop signal to {0}...</target>
+        <note />
+      </trans-unit>
       <trans-unit id="StoppingAppHost">
-        <source>Stopping Aspire AppHost...</source>
-        <target state="needs-review-translation">正在停止 Aspire AppHost...</target>
+        <source>Stopping {0}...</source>
+        <target state="new">Stopping {0}...</target>
         <note />
       </trans-unit>
       <trans-unit id="AllAndProjectMutuallyExclusive">

--- a/src/Aspire.Cli/Telemetry/ProfilingTelemetry.cs
+++ b/src/Aspire.Cli/Telemetry/ProfilingTelemetry.cs
@@ -63,6 +63,8 @@ internal sealed class ProfilingTelemetry(IConfiguration configuration) : IDispos
         public const string GuestExecuteCommand = "aspire/cli/guest.execute_command";
         public const string GitCommand = "aspire/cli/git.command";
         public const string NpmCommand = "aspire/cli/npm.command";
+        public const string StopCommand = "aspire/cli/stop";
+        public const string StopAppHost = "aspire/cli/stop_apphost";
 
         public static string DotNetCommand(string command) => $"aspire/cli/dotnet.{command}";
     }
@@ -118,6 +120,8 @@ internal sealed class ProfilingTelemetry(IConfiguration configuration) : IDispos
         public const string AppHostSupportsBackchannel = "aspire.cli.apphost.supports_backchannel";
         public const string AppHostAspireHostingVersion = "aspire.cli.apphost.aspire_hosting_version";
         public const string AppHostWatch = "aspire.cli.apphost.watch";
+        public const string AppHostStopAll = "aspire.cli.apphost.stop_all";
+        public const string AppHostStopCount = "aspire.cli.apphost.stop_count";
         public const string DevCertificateEnvironmentVariableCount = "aspire.cli.dev_cert.env_var_count";
         public const string BackchannelSocketFile = "aspire.cli.backchannel.socket_file";
         public const string BackchannelAutoReconnect = "aspire.cli.backchannel.auto_reconnect";
@@ -461,6 +465,25 @@ internal sealed class ProfilingTelemetry(IConfiguration configuration) : IDispos
         return StartActivity(Activities.RunCommand, startWithRemoteParent: true);
     }
 
+    internal ActivityScope StartStopCommand(bool stopAll, bool passedAppHostProjectFile)
+    {
+        var activity = StartActivity(Activities.StopCommand, startWithRemoteParent: true);
+        activity.SetAppHostStopAll(stopAll);
+        activity.SetAppHostProjectFileSpecified(passedAppHostProjectFile);
+        return activity;
+    }
+
+    internal ActivityScope StartStopAppHost(AppHostInformation? appHostInfo)
+    {
+        var activity = StartActivity(Activities.StopAppHost);
+        if (appHostInfo is not null)
+        {
+            activity.SetProcessId(appHostInfo.ProcessId);
+        }
+
+        return activity;
+    }
+
     private ActivityScope StartActivity(
         string name,
         ActivityKind kind = ActivityKind.Internal,
@@ -718,6 +741,10 @@ internal sealed class ProfilingTelemetry(IConfiguration configuration) : IDispos
         public void SetAppHostProjectFileSpecified(bool specified) => SetTag(Tags.AppHostProjectFileSpecified, specified);
 
         public void SetAppHostRunningInstanceResult(object? result) => SetTag(Tags.AppHostRunningInstanceResult, result?.ToString());
+
+        public void SetAppHostStopAll(bool stopAll) => SetTag(Tags.AppHostStopAll, stopAll);
+
+        public void SetAppHostStopCount(int count) => SetTag(Tags.AppHostStopCount, count);
 
         public void SetAppHostWatch(bool watch) => SetTag(Tags.AppHostWatch, watch);
 

--- a/tests/Aspire.Cli.EndToEnd.Tests/DescribeCommandTests.cs
+++ b/tests/Aspire.Cli.EndToEnd.Tests/DescribeCommandTests.cs
@@ -75,7 +75,7 @@ public sealed class DescribeCommandTests(ITestOutputHelper output)
         // Stop the AppHost using aspire stop
         await auto.TypeAsync("aspire stop");
         await auto.EnterAsync();
-        await auto.WaitUntilTextAsync(StopCommandStrings.AppHostStoppedSuccessfully, timeout: TimeSpan.FromMinutes(1));
+        await auto.WaitUntilTextAsync("stopped successfully.", timeout: TimeSpan.FromMinutes(1));
         await auto.WaitForSuccessPromptAsync(counter);
 
         // Exit the shell
@@ -200,7 +200,7 @@ public sealed class DescribeCommandTests(ITestOutputHelper output)
         // Stop the AppHost using aspire stop
         await auto.TypeAsync("aspire stop");
         await auto.EnterAsync();
-        await auto.WaitUntilTextAsync(StopCommandStrings.AppHostStoppedSuccessfully, timeout: TimeSpan.FromMinutes(1));
+        await auto.WaitUntilTextAsync("stopped successfully.", timeout: TimeSpan.FromMinutes(1));
         await auto.WaitForSuccessPromptAsync(counter);
 
         // Exit the shell

--- a/tests/Aspire.Cli.EndToEnd.Tests/DescribeCommandTests.cs
+++ b/tests/Aspire.Cli.EndToEnd.Tests/DescribeCommandTests.cs
@@ -75,7 +75,7 @@ public sealed class DescribeCommandTests(ITestOutputHelper output)
         // Stop the AppHost using aspire stop
         await auto.TypeAsync("aspire stop");
         await auto.EnterAsync();
-        await auto.WaitUntilTextAsync("stopped successfully.", timeout: TimeSpan.FromMinutes(1));
+        await auto.WaitUntilAppHostStoppedSuccessfullyAsync(timeout: TimeSpan.FromMinutes(1));
         await auto.WaitForSuccessPromptAsync(counter);
 
         // Exit the shell
@@ -200,7 +200,7 @@ public sealed class DescribeCommandTests(ITestOutputHelper output)
         // Stop the AppHost using aspire stop
         await auto.TypeAsync("aspire stop");
         await auto.EnterAsync();
-        await auto.WaitUntilTextAsync("stopped successfully.", timeout: TimeSpan.FromMinutes(1));
+        await auto.WaitUntilAppHostStoppedSuccessfullyAsync(timeout: TimeSpan.FromMinutes(1));
         await auto.WaitForSuccessPromptAsync(counter);
 
         // Exit the shell

--- a/tests/Aspire.Cli.EndToEnd.Tests/Helpers/CliE2EAutomatorHelpers.cs
+++ b/tests/Aspire.Cli.EndToEnd.Tests/Helpers/CliE2EAutomatorHelpers.cs
@@ -1,7 +1,9 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Globalization;
 using System.Xml.Linq;
+using Aspire.Cli.Resources;
 using Aspire.Cli.Tests.Utils;
 using Hex1b.Automation;
 using Xunit;
@@ -77,6 +79,11 @@ internal static class CliE2EAutomatorHelpers
         }
     }
 
+    internal static Task WaitUntilAppHostStoppedSuccessfullyAsync(this Hex1bTerminalAutomator auto, TimeSpan timeout)
+    {
+        return auto.WaitUntilTextAsync(GetAppHostStoppedSuccessfullySuffix(), timeout: timeout);
+    }
+
     /// <summary>
     /// Installs the Aspire CLI inside a Docker container using the given install strategy.
     /// Handles all modes: LocalHive, PullRequest, and InstallScript.
@@ -135,6 +142,21 @@ internal static class CliE2EAutomatorHelpers
         }
 
         await auto.VerifyAspireCliVersionAsync(strategy, counter);
+    }
+
+    private static string GetAppHostStoppedSuccessfullySuffix()
+    {
+        const string appHostMarker = "__AspireAppHost__";
+
+        var formattedMessage = string.Format(CultureInfo.CurrentCulture, StopCommandStrings.AppHostStoppedSuccessfully, appHostMarker);
+        var markerIndex = formattedMessage.IndexOf(appHostMarker, StringComparison.Ordinal);
+        var suffixStart = markerIndex + appHostMarker.Length;
+        if (markerIndex < 0 || suffixStart == formattedMessage.Length)
+        {
+            throw new InvalidOperationException($"Unable to derive a waitable suffix from {nameof(StopCommandStrings.AppHostStoppedSuccessfully)}.");
+        }
+
+        return formattedMessage[suffixStart..];
     }
 
     /// <summary>

--- a/tests/Aspire.Cli.EndToEnd.Tests/LogsCommandTests.cs
+++ b/tests/Aspire.Cli.EndToEnd.Tests/LogsCommandTests.cs
@@ -83,7 +83,7 @@ public sealed class LogsCommandTests(ITestOutputHelper output)
         // Stop the AppHost using aspire stop
         await auto.TypeAsync("aspire stop");
         await auto.EnterAsync();
-        await auto.WaitUntilTextAsync(StopCommandStrings.AppHostStoppedSuccessfully, timeout: TimeSpan.FromMinutes(1));
+        await auto.WaitUntilTextAsync("stopped successfully.", timeout: TimeSpan.FromMinutes(1));
         await auto.WaitForSuccessPromptAsync(counter);
 
         // Exit the shell

--- a/tests/Aspire.Cli.EndToEnd.Tests/LogsCommandTests.cs
+++ b/tests/Aspire.Cli.EndToEnd.Tests/LogsCommandTests.cs
@@ -83,7 +83,7 @@ public sealed class LogsCommandTests(ITestOutputHelper output)
         // Stop the AppHost using aspire stop
         await auto.TypeAsync("aspire stop");
         await auto.EnterAsync();
-        await auto.WaitUntilTextAsync("stopped successfully.", timeout: TimeSpan.FromMinutes(1));
+        await auto.WaitUntilAppHostStoppedSuccessfullyAsync(timeout: TimeSpan.FromMinutes(1));
         await auto.WaitForSuccessPromptAsync(counter);
 
         // Exit the shell

--- a/tests/Aspire.Cli.EndToEnd.Tests/PsCommandTests.cs
+++ b/tests/Aspire.Cli.EndToEnd.Tests/PsCommandTests.cs
@@ -69,7 +69,7 @@ public sealed class PsCommandTests(ITestOutputHelper output)
         // Stop the AppHost using aspire stop
         await auto.TypeAsync("aspire stop");
         await auto.EnterAsync();
-        await auto.WaitUntilTextAsync(StopCommandStrings.AppHostStoppedSuccessfully, timeout: TimeSpan.FromMinutes(1));
+        await auto.WaitUntilTextAsync("stopped successfully.", timeout: TimeSpan.FromMinutes(1));
         await auto.WaitForSuccessPromptAsync(counter);
 
         // Verify aspire ps shows no running AppHosts again after stop

--- a/tests/Aspire.Cli.EndToEnd.Tests/PsCommandTests.cs
+++ b/tests/Aspire.Cli.EndToEnd.Tests/PsCommandTests.cs
@@ -69,7 +69,7 @@ public sealed class PsCommandTests(ITestOutputHelper output)
         // Stop the AppHost using aspire stop
         await auto.TypeAsync("aspire stop");
         await auto.EnterAsync();
-        await auto.WaitUntilTextAsync("stopped successfully.", timeout: TimeSpan.FromMinutes(1));
+        await auto.WaitUntilAppHostStoppedSuccessfullyAsync(timeout: TimeSpan.FromMinutes(1));
         await auto.WaitForSuccessPromptAsync(counter);
 
         // Verify aspire ps shows no running AppHosts again after stop

--- a/tests/Aspire.Cli.EndToEnd.Tests/StartStopTests.cs
+++ b/tests/Aspire.Cli.EndToEnd.Tests/StartStopTests.cs
@@ -60,7 +60,7 @@ public sealed class StartStopTests(ITestOutputHelper output)
             // Stop the AppHost using aspire stop
             await auto.TypeAsync("aspire stop");
             await auto.EnterAsync();
-            await auto.WaitUntilTextAsync("stopped successfully.", timeout: TimeSpan.FromMinutes(1));
+            await auto.WaitUntilAppHostStoppedSuccessfullyAsync(timeout: TimeSpan.FromMinutes(1));
             await auto.WaitForSuccessPromptAsync(counter);
 
             await auto.ClearScreenAsync(counter);

--- a/tests/Aspire.Cli.EndToEnd.Tests/StartStopTests.cs
+++ b/tests/Aspire.Cli.EndToEnd.Tests/StartStopTests.cs
@@ -60,7 +60,7 @@ public sealed class StartStopTests(ITestOutputHelper output)
             // Stop the AppHost using aspire stop
             await auto.TypeAsync("aspire stop");
             await auto.EnterAsync();
-            await auto.WaitUntilTextAsync(StopCommandStrings.AppHostStoppedSuccessfully, timeout: TimeSpan.FromMinutes(1));
+            await auto.WaitUntilTextAsync("stopped successfully.", timeout: TimeSpan.FromMinutes(1));
             await auto.WaitForSuccessPromptAsync(counter);
 
             await auto.ClearScreenAsync(counter);

--- a/tests/Aspire.Cli.EndToEnd.Tests/StopNonInteractiveTests.cs
+++ b/tests/Aspire.Cli.EndToEnd.Tests/StopNonInteractiveTests.cs
@@ -61,7 +61,7 @@ public sealed class StopNonInteractiveTests(ITestOutputHelper output)
         // Stop the AppHost using aspire stop --non-interactive --apphost with a directory path.
         await auto.TypeAsync("aspire stop --non-interactive --apphost TestStopApp");
         await auto.EnterAsync();
-        await auto.WaitUntilTextAsync("stopped successfully.", timeout: TimeSpan.FromMinutes(1));
+        await auto.WaitUntilAppHostStoppedSuccessfullyAsync(timeout: TimeSpan.FromMinutes(1));
         await auto.WaitForSuccessPromptAsync(counter);
 
         // Clear screen
@@ -128,7 +128,7 @@ public sealed class StopNonInteractiveTests(ITestOutputHelper output)
         // Stop all AppHosts from within an AppHost directory using --non-interactive --all
         await auto.TypeAsync("aspire stop --non-interactive --all");
         await auto.EnterAsync();
-        await auto.WaitUntilTextAsync("stopped successfully.", timeout: TimeSpan.FromMinutes(1));
+        await auto.WaitUntilAppHostStoppedSuccessfullyAsync(timeout: TimeSpan.FromMinutes(1));
         await auto.WaitForSuccessPromptAsync(counter);
 
         // Clear screen
@@ -201,7 +201,7 @@ public sealed class StopNonInteractiveTests(ITestOutputHelper output)
         // Stop all AppHosts from an unrelated directory using --non-interactive --all
         await auto.TypeAsync("aspire stop --non-interactive --all");
         await auto.EnterAsync();
-        await auto.WaitUntilTextAsync("stopped successfully.", timeout: TimeSpan.FromMinutes(1));
+        await auto.WaitUntilAppHostStoppedSuccessfullyAsync(timeout: TimeSpan.FromMinutes(1));
         await auto.WaitForSuccessPromptAsync(counter);
 
         // Clear screen
@@ -285,7 +285,7 @@ public sealed class StopNonInteractiveTests(ITestOutputHelper output)
         // Now use --all to stop all AppHosts
         await auto.TypeAsync("aspire stop --all");
         await auto.EnterAsync();
-        await auto.WaitUntilTextAsync("stopped successfully.", timeout: TimeSpan.FromMinutes(1));
+        await auto.WaitUntilAppHostStoppedSuccessfullyAsync(timeout: TimeSpan.FromMinutes(1));
         await auto.WaitForSuccessPromptAsync(counter);
 
         // Exit the shell

--- a/tests/Aspire.Cli.EndToEnd.Tests/StopNonInteractiveTests.cs
+++ b/tests/Aspire.Cli.EndToEnd.Tests/StopNonInteractiveTests.cs
@@ -61,7 +61,7 @@ public sealed class StopNonInteractiveTests(ITestOutputHelper output)
         // Stop the AppHost using aspire stop --non-interactive --apphost with a directory path.
         await auto.TypeAsync("aspire stop --non-interactive --apphost TestStopApp");
         await auto.EnterAsync();
-        await auto.WaitUntilTextAsync(StopCommandStrings.AppHostStoppedSuccessfully, timeout: TimeSpan.FromMinutes(1));
+        await auto.WaitUntilTextAsync("stopped successfully.", timeout: TimeSpan.FromMinutes(1));
         await auto.WaitForSuccessPromptAsync(counter);
 
         // Clear screen
@@ -128,7 +128,7 @@ public sealed class StopNonInteractiveTests(ITestOutputHelper output)
         // Stop all AppHosts from within an AppHost directory using --non-interactive --all
         await auto.TypeAsync("aspire stop --non-interactive --all");
         await auto.EnterAsync();
-        await auto.WaitUntilTextAsync(StopCommandStrings.AppHostStoppedSuccessfully, timeout: TimeSpan.FromMinutes(1));
+        await auto.WaitUntilTextAsync("stopped successfully.", timeout: TimeSpan.FromMinutes(1));
         await auto.WaitForSuccessPromptAsync(counter);
 
         // Clear screen
@@ -201,7 +201,7 @@ public sealed class StopNonInteractiveTests(ITestOutputHelper output)
         // Stop all AppHosts from an unrelated directory using --non-interactive --all
         await auto.TypeAsync("aspire stop --non-interactive --all");
         await auto.EnterAsync();
-        await auto.WaitUntilTextAsync(StopCommandStrings.AppHostStoppedSuccessfully, timeout: TimeSpan.FromMinutes(1));
+        await auto.WaitUntilTextAsync("stopped successfully.", timeout: TimeSpan.FromMinutes(1));
         await auto.WaitForSuccessPromptAsync(counter);
 
         // Clear screen
@@ -285,7 +285,7 @@ public sealed class StopNonInteractiveTests(ITestOutputHelper output)
         // Now use --all to stop all AppHosts
         await auto.TypeAsync("aspire stop --all");
         await auto.EnterAsync();
-        await auto.WaitUntilTextAsync(StopCommandStrings.AppHostStoppedSuccessfully, timeout: TimeSpan.FromMinutes(1));
+        await auto.WaitUntilTextAsync("stopped successfully.", timeout: TimeSpan.FromMinutes(1));
         await auto.WaitForSuccessPromptAsync(counter);
 
         // Exit the shell

--- a/tests/Aspire.Cli.EndToEnd.Tests/WaitCommandTests.cs
+++ b/tests/Aspire.Cli.EndToEnd.Tests/WaitCommandTests.cs
@@ -61,7 +61,7 @@ public sealed class WaitCommandTests(ITestOutputHelper output)
         // Stop the AppHost using aspire stop
         await auto.TypeAsync("aspire stop");
         await auto.EnterAsync();
-        await auto.WaitUntilTextAsync(StopCommandStrings.AppHostStoppedSuccessfully, timeout: TimeSpan.FromMinutes(1));
+        await auto.WaitUntilTextAsync("stopped successfully.", timeout: TimeSpan.FromMinutes(1));
         await auto.WaitForSuccessPromptAsync(counter);
 
         // Exit the shell

--- a/tests/Aspire.Cli.EndToEnd.Tests/WaitCommandTests.cs
+++ b/tests/Aspire.Cli.EndToEnd.Tests/WaitCommandTests.cs
@@ -61,7 +61,7 @@ public sealed class WaitCommandTests(ITestOutputHelper output)
         // Stop the AppHost using aspire stop
         await auto.TypeAsync("aspire stop");
         await auto.EnterAsync();
-        await auto.WaitUntilTextAsync("stopped successfully.", timeout: TimeSpan.FromMinutes(1));
+        await auto.WaitUntilAppHostStoppedSuccessfullyAsync(timeout: TimeSpan.FromMinutes(1));
         await auto.WaitForSuccessPromptAsync(counter);
 
         // Exit the shell

--- a/tests/Aspire.Cli.Tests/Commands/StopCommandTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/StopCommandTests.cs
@@ -204,9 +204,41 @@ public class StopCommandTests(ITestOutputHelper outputHelper)
 
         Assert.Equal(ExitCodeConstants.Success, exitCode);
 
-        var expectedPath = "App1.AppHost.csproj";
+        var expectedPath = Path.Combine("App1", "App1.AppHost", "App1.AppHost.csproj");
         Assert.Contains(statusMessages, message => message == string.Format(CultureInfo.CurrentCulture, StopCommandStrings.StoppingAppHost, expectedPath));
         Assert.Contains(interactionService.DisplayedSuccess, message => message == string.Format(CultureInfo.CurrentCulture, StopCommandStrings.AppHostStoppedSuccessfully, expectedPath));
+    }
+
+    [Fact]
+    public async Task StopCommand_SingleOutOfScopeAppHostUsesFullPathInMessages()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        using var outOfScopeWorkspace = TemporaryWorkspace.Create(outputHelper);
+        var interactionService = new TestInteractionService();
+        var statusMessages = new ConcurrentQueue<string>();
+        interactionService.ShowStatusCallback = statusMessages.Enqueue;
+
+        var monitor = new TestAuxiliaryBackchannelMonitor();
+        var appHostPath = Path.Combine(outOfScopeWorkspace.WorkspaceRoot.FullName, "App1", "App1.AppHost", "App1.AppHost.csproj");
+        monitor.AddConnection("hash1", "socket.hash1", CreateConnection(appHostPath, int.MaxValue - 6, isInScope: false));
+
+        var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper, options =>
+        {
+            options.InteractionServiceFactory = _ => interactionService;
+            options.AuxiliaryBackchannelMonitorFactory = _ => monitor;
+            options.CliHostEnvironmentFactory = _ => TestHelpers.CreateInteractiveHostEnvironment();
+        });
+        using var provider = services.BuildServiceProvider();
+
+        var command = provider.GetRequiredService<RootCommand>();
+        var result = command.Parse("stop");
+
+        var exitCode = await result.InvokeAsync().DefaultTimeout();
+
+        Assert.Equal(ExitCodeConstants.Success, exitCode);
+
+        Assert.Contains(statusMessages, message => message == string.Format(CultureInfo.CurrentCulture, StopCommandStrings.StoppingAppHost, appHostPath));
+        Assert.Contains(interactionService.DisplayedSuccess, message => message == string.Format(CultureInfo.CurrentCulture, StopCommandStrings.AppHostStoppedSuccessfully, appHostPath));
     }
 
     [Fact]
@@ -219,8 +251,8 @@ public class StopCommandTests(ITestOutputHelper outputHelper)
         var monitor = new TestAuxiliaryBackchannelMonitor();
         var appHostPath1 = Path.Combine(workspace.WorkspaceRoot.FullName, "App1", "App1.AppHost.csproj");
         var appHostPath2 = Path.Combine(workspace.WorkspaceRoot.FullName, "App2", "App2.AppHost.csproj");
-        var processId1 = int.MaxValue - 6;
-        var processId2 = int.MaxValue - 7;
+        var processId1 = int.MaxValue - 7;
+        var processId2 = int.MaxValue - 8;
         monitor.AddConnection("hash1", "socket.hash1", CreateConnection(appHostPath1, processId1));
         monitor.AddConnection("hash2", "socket.hash2", CreateConnection(appHostPath2, processId2));
 
@@ -258,13 +290,13 @@ public class StopCommandTests(ITestOutputHelper outputHelper)
         Assert.All(stopAppHostActivities, activity => Assert.Equal(ExitCodeConstants.Success, activity.GetTagItem(TelemetryConstants.Tags.ProcessExitCode)));
     }
 
-    private static TestAppHostAuxiliaryBackchannel CreateConnection(string appHostPath, int processId)
+    private static TestAppHostAuxiliaryBackchannel CreateConnection(string appHostPath, int processId, bool isInScope = true)
     {
         return new TestAppHostAuxiliaryBackchannel
         {
             Hash = $"hash-{processId.ToString(CultureInfo.InvariantCulture)}",
             SocketPath = $"socket.{processId.ToString(CultureInfo.InvariantCulture)}",
-            IsInScope = true,
+            IsInScope = isInScope,
             AppHostInfo = new AppHostInformation
             {
                 AppHostPath = appHostPath,

--- a/tests/Aspire.Cli.Tests/Commands/StopCommandTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/StopCommandTests.cs
@@ -112,8 +112,8 @@ public class StopCommandTests(ITestOutputHelper outputHelper)
         interactionService.ShowStatusCallback = statusMessages.Enqueue;
 
         var monitor = new TestAuxiliaryBackchannelMonitor();
-        var appHostPath1 = Path.Combine(workspace.WorkspaceRoot.FullName, "App1", "App1.AppHost", "App1.AppHost.csproj");
-        var appHostPath2 = Path.Combine(workspace.WorkspaceRoot.FullName, "App2", "App2.AppHost", "App2.AppHost.csproj");
+        var appHostPath1 = Path.Combine(workspace.WorkspaceRoot.FullName, "App1", "AppHost.cs");
+        var appHostPath2 = Path.Combine(workspace.WorkspaceRoot.FullName, "App2", "AppHost.cs");
         monitor.AddConnection("hash1", "socket.hash1", CreateConnection(appHostPath1, int.MaxValue - 1));
         monitor.AddConnection("hash2", "socket.hash2", CreateConnection(appHostPath2, int.MaxValue - 2));
 
@@ -131,8 +131,8 @@ public class StopCommandTests(ITestOutputHelper outputHelper)
 
         Assert.Equal(ExitCodeConstants.Success, exitCode);
 
-        var expectedPath1 = Path.GetRelativePath(workspace.WorkspaceRoot.FullName, appHostPath1);
-        var expectedPath2 = Path.GetRelativePath(workspace.WorkspaceRoot.FullName, appHostPath2);
+        var expectedPath1 = Path.Combine("App1", "AppHost.cs");
+        var expectedPath2 = Path.Combine("App2", "AppHost.cs");
         var displayedText = GetDisplayedText(interactionService, statusMessages);
         Assert.Contains(displayedText, message => message.Contains(expectedPath1, StringComparison.Ordinal));
         Assert.Contains(displayedText, message => message.Contains(expectedPath2, StringComparison.Ordinal));
@@ -167,7 +167,7 @@ public class StopCommandTests(ITestOutputHelper outputHelper)
 
         Assert.Equal(ExitCodeConstants.Success, exitCode);
 
-        var expectedPath = Path.GetRelativePath(workspace.WorkspaceRoot.FullName, appHostPath);
+        var expectedPath = "App1.AppHost.csproj";
         var expectedIdentifier1 = string.Format(CultureInfo.CurrentCulture, StopCommandStrings.AppHostIdentifierWithProcessId, expectedPath, processId1);
         var expectedIdentifier2 = string.Format(CultureInfo.CurrentCulture, StopCommandStrings.AppHostIdentifierWithProcessId, expectedPath, processId2);
         var displayedText = GetDisplayedText(interactionService, statusMessages);
@@ -201,7 +201,7 @@ public class StopCommandTests(ITestOutputHelper outputHelper)
 
         Assert.Equal(ExitCodeConstants.Success, exitCode);
 
-        var expectedPath = Path.GetRelativePath(workspace.WorkspaceRoot.FullName, appHostPath);
+        var expectedPath = "App1.AppHost.csproj";
         Assert.Contains(statusMessages, message => message == string.Format(CultureInfo.CurrentCulture, StopCommandStrings.StoppingAppHost, expectedPath));
         Assert.Contains(interactionService.DisplayedSuccess, message => message == string.Format(CultureInfo.CurrentCulture, StopCommandStrings.AppHostStoppedSuccessfully, expectedPath));
     }

--- a/tests/Aspire.Cli.Tests/Commands/StopCommandTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/StopCommandTests.cs
@@ -2,13 +2,16 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Collections.Concurrent;
+using System.Diagnostics;
 using System.Globalization;
 using Aspire.Cli.Backchannel;
 using Aspire.Cli.Commands;
 using Aspire.Cli.Projects;
 using Aspire.Cli.Resources;
+using Aspire.Cli.Telemetry;
 using Aspire.Cli.Tests.TestServices;
 using Aspire.Cli.Tests.Utils;
+using Aspire.Hosting;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.AspNetCore.InternalTesting;
 
@@ -206,6 +209,55 @@ public class StopCommandTests(ITestOutputHelper outputHelper)
         Assert.Contains(interactionService.DisplayedSuccess, message => message == string.Format(CultureInfo.CurrentCulture, StopCommandStrings.AppHostStoppedSuccessfully, expectedPath));
     }
 
+    [Fact]
+    public async Task StopCommand_AllEmitsProfilingActivities()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        var stoppedActivities = new ConcurrentQueue<Activity>();
+        using var listener = CreateProfilingActivityListener(stoppedActivities.Enqueue);
+
+        var monitor = new TestAuxiliaryBackchannelMonitor();
+        var appHostPath1 = Path.Combine(workspace.WorkspaceRoot.FullName, "App1", "App1.AppHost.csproj");
+        var appHostPath2 = Path.Combine(workspace.WorkspaceRoot.FullName, "App2", "App2.AppHost.csproj");
+        var processId1 = int.MaxValue - 6;
+        var processId2 = int.MaxValue - 7;
+        monitor.AddConnection("hash1", "socket.hash1", CreateConnection(appHostPath1, processId1));
+        monitor.AddConnection("hash2", "socket.hash2", CreateConnection(appHostPath2, processId2));
+
+        var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper, options =>
+        {
+            options.AuxiliaryBackchannelMonitorFactory = _ => monitor;
+            options.ConfigurationCallback += config =>
+            {
+                config[KnownConfigNames.ProfilingEnabled] = "true";
+            };
+        });
+        using var provider = services.BuildServiceProvider();
+
+        var command = provider.GetRequiredService<RootCommand>();
+        var result = command.Parse("stop --all");
+
+        var exitCode = await result.InvokeAsync().DefaultTimeout();
+
+        Assert.Equal(ExitCodeConstants.Success, exitCode);
+
+        var stopCommandActivity = Assert.Single(stoppedActivities, activity => activity.OperationName == ProfilingTelemetry.Activities.StopCommand);
+        Assert.Equal(true, stopCommandActivity.GetTagItem(ProfilingTelemetry.Tags.AppHostStopAll));
+        Assert.Equal(2, stopCommandActivity.GetTagItem(ProfilingTelemetry.Tags.AppHostStopCount));
+        Assert.Equal(ExitCodeConstants.Success, stopCommandActivity.GetTagItem(TelemetryConstants.Tags.ProcessExitCode));
+
+        var stopAppHostActivities = stoppedActivities.Where(activity => activity.OperationName == ProfilingTelemetry.Activities.StopAppHost).ToArray();
+        Assert.Equal(2, stopAppHostActivities.Length);
+        var expectedProcessIds = new[] { processId1, processId2 }.Order().ToArray();
+        Assert.Equal(
+            expectedProcessIds,
+            stopAppHostActivities
+                .Select(activity => Assert.IsType<int>(activity.GetTagItem(TelemetryConstants.Tags.ProcessPid)))
+                .Order()
+                .ToArray());
+        Assert.All(stopAppHostActivities, activity => Assert.Equal(ExitCodeConstants.Success, activity.GetTagItem(TelemetryConstants.Tags.ProcessExitCode)));
+    }
+
     private static TestAppHostAuxiliaryBackchannel CreateConnection(string appHostPath, int processId)
     {
         return new TestAppHostAuxiliaryBackchannel
@@ -228,5 +280,17 @@ public class StopCommandTests(ITestOutputHelper outputHelper)
             .Concat(interactionService.DisplayedErrors)
             .Concat(statusMessages)
             .ToArray();
+    }
+
+    private static ActivityListener CreateProfilingActivityListener(Action<Activity> activityStopped)
+    {
+        var listener = new ActivityListener
+        {
+            ShouldListenTo = source => source.Name == ProfilingTelemetry.ActivitySourceName,
+            Sample = (ref ActivityCreationOptions<ActivityContext> _) => ActivitySamplingResult.AllDataAndRecorded,
+            ActivityStopped = activityStopped
+        };
+        ActivitySource.AddActivityListener(listener);
+        return listener;
     }
 }

--- a/tests/Aspire.Cli.Tests/Commands/StopCommandTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/StopCommandTests.cs
@@ -1,6 +1,9 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Collections.Concurrent;
+using System.Globalization;
+using Aspire.Cli.Backchannel;
 using Aspire.Cli.Commands;
 using Aspire.Cli.Projects;
 using Aspire.Cli.Resources;
@@ -98,5 +101,132 @@ public class StopCommandTests(ITestOutputHelper outputHelper)
         Assert.Equal(
             string.Format(SharedCommandStrings.AppHostNotRunningAtPath, Path.Combine("Resolved.AppHost", "Resolved.AppHost.csproj")),
             displayedMessage.Message);
+    }
+
+    [Fact]
+    public async Task StopCommand_AllIncludesEachAppHostPathInMessages()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        var interactionService = new TestInteractionService();
+        var statusMessages = new ConcurrentQueue<string>();
+        interactionService.ShowStatusCallback = statusMessages.Enqueue;
+
+        var monitor = new TestAuxiliaryBackchannelMonitor();
+        var appHostPath1 = Path.Combine(workspace.WorkspaceRoot.FullName, "App1", "App1.AppHost", "App1.AppHost.csproj");
+        var appHostPath2 = Path.Combine(workspace.WorkspaceRoot.FullName, "App2", "App2.AppHost", "App2.AppHost.csproj");
+        monitor.AddConnection("hash1", "socket.hash1", CreateConnection(appHostPath1, int.MaxValue - 1));
+        monitor.AddConnection("hash2", "socket.hash2", CreateConnection(appHostPath2, int.MaxValue - 2));
+
+        var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper, options =>
+        {
+            options.InteractionServiceFactory = _ => interactionService;
+            options.AuxiliaryBackchannelMonitorFactory = _ => monitor;
+        });
+        using var provider = services.BuildServiceProvider();
+
+        var command = provider.GetRequiredService<RootCommand>();
+        var result = command.Parse("stop --all");
+
+        var exitCode = await result.InvokeAsync().DefaultTimeout();
+
+        Assert.Equal(ExitCodeConstants.Success, exitCode);
+
+        var expectedPath1 = Path.GetRelativePath(workspace.WorkspaceRoot.FullName, appHostPath1);
+        var expectedPath2 = Path.GetRelativePath(workspace.WorkspaceRoot.FullName, appHostPath2);
+        var displayedText = GetDisplayedText(interactionService, statusMessages);
+        Assert.Contains(displayedText, message => message.Contains(expectedPath1, StringComparison.Ordinal));
+        Assert.Contains(displayedText, message => message.Contains(expectedPath2, StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public async Task StopCommand_AllIncludesProcessIdWhenAppHostPathsCollide()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        var interactionService = new TestInteractionService();
+        var statusMessages = new ConcurrentQueue<string>();
+        interactionService.ShowStatusCallback = statusMessages.Enqueue;
+
+        var monitor = new TestAuxiliaryBackchannelMonitor();
+        var appHostPath = Path.Combine(workspace.WorkspaceRoot.FullName, "App1", "App1.AppHost", "App1.AppHost.csproj");
+        var processId1 = int.MaxValue - 3;
+        var processId2 = int.MaxValue - 4;
+        monitor.AddConnection("hash1", "socket.hash1", CreateConnection(appHostPath, processId1));
+        monitor.AddConnection("hash2", "socket.hash2", CreateConnection(appHostPath, processId2));
+
+        var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper, options =>
+        {
+            options.InteractionServiceFactory = _ => interactionService;
+            options.AuxiliaryBackchannelMonitorFactory = _ => monitor;
+        });
+        using var provider = services.BuildServiceProvider();
+
+        var command = provider.GetRequiredService<RootCommand>();
+        var result = command.Parse("stop --all");
+
+        var exitCode = await result.InvokeAsync().DefaultTimeout();
+
+        Assert.Equal(ExitCodeConstants.Success, exitCode);
+
+        var expectedPath = Path.GetRelativePath(workspace.WorkspaceRoot.FullName, appHostPath);
+        var expectedIdentifier1 = string.Format(CultureInfo.CurrentCulture, StopCommandStrings.AppHostIdentifierWithProcessId, expectedPath, processId1);
+        var expectedIdentifier2 = string.Format(CultureInfo.CurrentCulture, StopCommandStrings.AppHostIdentifierWithProcessId, expectedPath, processId2);
+        var displayedText = GetDisplayedText(interactionService, statusMessages);
+        Assert.Contains(displayedText, message => message.Contains(expectedIdentifier1, StringComparison.Ordinal));
+        Assert.Contains(displayedText, message => message.Contains(expectedIdentifier2, StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public async Task StopCommand_SingleAppHostIncludesIdentifierInStatusAndSuccessMessages()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        var interactionService = new TestInteractionService();
+        var statusMessages = new ConcurrentQueue<string>();
+        interactionService.ShowStatusCallback = statusMessages.Enqueue;
+
+        var monitor = new TestAuxiliaryBackchannelMonitor();
+        var appHostPath = Path.Combine(workspace.WorkspaceRoot.FullName, "App1", "App1.AppHost", "App1.AppHost.csproj");
+        monitor.AddConnection("hash1", "socket.hash1", CreateConnection(appHostPath, int.MaxValue - 5));
+
+        var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper, options =>
+        {
+            options.InteractionServiceFactory = _ => interactionService;
+            options.AuxiliaryBackchannelMonitorFactory = _ => monitor;
+        });
+        using var provider = services.BuildServiceProvider();
+
+        var command = provider.GetRequiredService<RootCommand>();
+        var result = command.Parse("stop");
+
+        var exitCode = await result.InvokeAsync().DefaultTimeout();
+
+        Assert.Equal(ExitCodeConstants.Success, exitCode);
+
+        var expectedPath = Path.GetRelativePath(workspace.WorkspaceRoot.FullName, appHostPath);
+        Assert.Contains(statusMessages, message => message == string.Format(CultureInfo.CurrentCulture, StopCommandStrings.StoppingAppHost, expectedPath));
+        Assert.Contains(interactionService.DisplayedSuccess, message => message == string.Format(CultureInfo.CurrentCulture, StopCommandStrings.AppHostStoppedSuccessfully, expectedPath));
+    }
+
+    private static TestAppHostAuxiliaryBackchannel CreateConnection(string appHostPath, int processId)
+    {
+        return new TestAppHostAuxiliaryBackchannel
+        {
+            Hash = $"hash-{processId.ToString(CultureInfo.InvariantCulture)}",
+            SocketPath = $"socket.{processId.ToString(CultureInfo.InvariantCulture)}",
+            IsInScope = true,
+            AppHostInfo = new AppHostInformation
+            {
+                AppHostPath = appHostPath,
+                ProcessId = processId
+            }
+        };
+    }
+
+    private static string[] GetDisplayedText(TestInteractionService interactionService, ConcurrentQueue<string> statusMessages)
+    {
+        return interactionService.DisplayedMessages.Select(message => message.Message)
+            .Concat(interactionService.DisplayedSuccess)
+            .Concat(interactionService.DisplayedErrors)
+            .Concat(statusMessages)
+            .ToArray();
     }
 }

--- a/tests/Aspire.Cli.Tests/TestServices/TestInteractionService.cs
+++ b/tests/Aspire.Cli.Tests/TestServices/TestInteractionService.cs
@@ -12,6 +12,7 @@ namespace Aspire.Cli.Tests.TestServices;
 
 internal sealed class TestInteractionService : IInteractionService
 {
+    private readonly object _displayLock = new();
     private readonly Queue<(string Response, ResponseType Type)> _responses = new();
     private bool _shouldCancel;
 
@@ -46,6 +47,7 @@ internal sealed class TestInteractionService : IInteractionService
     public List<(KnownEmoji Emoji, string Message)> DisplayedMessages { get; } = [];
     public List<string> DisplayedPlainText { get; } = [];
     public List<(string Text, ConsoleOutput? ConsoleOverride)> DisplayedRawText { get; } = [];
+    public List<string> DisplayedSuccess { get; } = [];
     public int DisplayEmptyLineCount { get; private set; }
 
     // Response queue setup methods
@@ -178,16 +180,26 @@ internal sealed class TestInteractionService : IInteractionService
 
     public void DisplayError(string errorMessage)
     {
-        DisplayedErrors.Add(errorMessage);
+        lock (_displayLock)
+        {
+            DisplayedErrors.Add(errorMessage);
+        }
     }
 
     public void DisplayMessage(KnownEmoji emoji, string message, bool allowMarkup = false)
     {
-        DisplayedMessages.Add((emoji, message));
+        lock (_displayLock)
+        {
+            DisplayedMessages.Add((emoji, message));
+        }
     }
 
     public void DisplaySuccess(string message, bool allowMarkup = false)
     {
+        lock (_displayLock)
+        {
+            DisplayedSuccess.Add(message);
+        }
     }
 
     public void DisplayLines(IEnumerable<(OutputLineStream Stream, string Line)> lines)
@@ -234,19 +246,29 @@ internal sealed class TestInteractionService : IInteractionService
 
     public void DisplayEmptyLine()
     {
-        DisplayEmptyLineCount++;
+        lock (_displayLock)
+        {
+            DisplayEmptyLineCount++;
+        }
     }
 
     public void DisplayPlainText(string text)
     {
-        DisplayedPlainText.Add(text);
+        lock (_displayLock)
+        {
+            DisplayedPlainText.Add(text);
+        }
     }
 
     public Action<string>? DisplayRawTextCallback { get; set; }
 
     public void DisplayRawText(string text, ConsoleOutput? consoleOverride = null)
     {
-        DisplayedRawText.Add((text, consoleOverride));
+        lock (_displayLock)
+        {
+            DisplayedRawText.Add((text, consoleOverride));
+        }
+
         DisplayRawTextCallback?.Invoke(text);
     }
 


### PR DESCRIPTION
## Description

Clarifies `aspire stop --all` output by tagging each stop-related message with the AppHost it applies to. When multiple running AppHost instances share the same project path, the output appends the AppHost PID so same-path instances can still be distinguished.

This also adds stop-command profiling spans through `ProfilingTelemetry`, localizes previously hardcoded stop messages, updates generated xlf resources, and adjusts E2E waits for the now-formatted success message.

Example output before this change:

```text
Stopping Aspire AppHost...
AppHost stopped successfully.
Stopping Aspire AppHost...
AppHost stopped successfully.
```

Example output after this change with different AppHosts:

```text
Found running AppHost: App1.AppHost.csproj
Sending stop signal to App1.AppHost.csproj...
Stopping App1.AppHost.csproj...
App1.AppHost.csproj stopped successfully.

Found running AppHost: App2.AppHost.csproj
Sending stop signal to App2.AppHost.csproj...
Stopping App2.AppHost.csproj...
App2.AppHost.csproj stopped successfully.
```

Example output after this change when multiple running instances share the same AppHost path:

```text
Found running AppHost: App1.AppHost.csproj (PID 12345)
Sending stop signal to App1.AppHost.csproj (PID 12345)...
Stopping App1.AppHost.csproj (PID 12345)...
App1.AppHost.csproj (PID 12345) stopped successfully.

Found running AppHost: App1.AppHost.csproj (PID 67890)
Sending stop signal to App1.AppHost.csproj (PID 67890)...
Stopping App1.AppHost.csproj (PID 67890)...
App1.AppHost.csproj (PID 67890) stopped successfully.
```

Path display matches `aspire ps` table output by using `FileSystemHelper.ShortenPaths`, so AppHost paths are shortened while still remaining distinguishable.

Validation:

- `./restore.sh`
- `./dotnet.sh build /t:UpdateXlf src/Aspire.Cli/Aspire.Cli.csproj`
- `./dotnet.sh test --project tests/Aspire.Cli.Tests/Aspire.Cli.Tests.csproj --no-launch-profile -- --filter-class "*.StopCommandTests" --filter-not-trait "quarantined=true" --filter-not-trait "outerloop=true"`
- `./dotnet.sh test --project tests/Aspire.Cli.Tests/Aspire.Cli.Tests.csproj --no-launch-profile -- --filter-namespace "*.Telemetry" --filter-not-trait "quarantined=true" --filter-not-trait "outerloop=true"`
- `./dotnet.sh build tests/Aspire.Cli.EndToEnd.Tests/Aspire.Cli.EndToEnd.Tests.csproj`
- `git diff --check`

Fixes #16731

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to `aspire.dev` issue:
      - [New issue](https://github.com/microsoft/aspire.dev/issues/new)
  - [x] No
