### PR TITLE
Update documentation link in release notes

### DIFF
--- a/.github/workflows/release-github-tasks.yml
+++ b/.github/workflows/release-github-tasks.yml
@@ -238,7 +238,7 @@ jobs:
           ## What's New in Aspire $VERSION
 
           See the full changelog and documentation at:
-          - 📖 [Documentation](https://aspire.dev/docs/)
+          - 📖 [Documentation](https://aspire.dev/docs)
           - 🐛 [Known Issues](https://github.com/microsoft/aspire/issues?q=is%3Aissue+is%3Aopen+label%3A%22known-issue%22)
 
           ### Installation

--- a/.github/workflows/release-github-tasks.yml
+++ b/.github/workflows/release-github-tasks.yml
@@ -238,7 +238,7 @@ jobs:
           ## What's New in Aspire $VERSION
 
           See the full changelog and documentation at:
-          - 📖 [Documentation](https://learn.microsoft.com/microsoft/aspire/)
+          - 📖 [Documentation](https://aspire.dev/docs/)
           - 🐛 [Known Issues](https://github.com/microsoft/aspire/issues?q=is%3Aissue+is%3Aopen+label%3A%22known-issue%22)
 
           ### Installation


### PR DESCRIPTION
## Description

The link was outdated, official documentation URL is https://aspire.dev/docs/ (Aspire) instead of https://learn.microsoft.com/microsoft/aspire/ (Microsoft Learn).
I noticed this issue from an Email sent from github-actions[bot] <notifications@github.com>.

Fixes # (issue)

Replace link to the documentation with the valid one.

## Checklist

- Is this feature complete?
  - [X] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [X] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [X] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [X] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to `aspire.dev` issue:
      - [New issue](https://github.com/microsoft/aspire.dev/issues/new)
  - [X] No
