### PR TITLE
Skip log publish for WinGet/Homebrew installer jobs

### DIFF
--- a/eng/pipelines/azure-pipelines-unofficial.yml
+++ b/eng/pipelines/azure-pipelines-unofficial.yml
@@ -318,7 +318,11 @@ extends:
           enableMicrobuild: false
           enablePublishUsingPipelines: false
           enablePublishBuildAssets: false
-          enablePublishBuildArtifacts: true
+          # WinGet and Homebrew jobs only consume previously-built CLI archives;
+          # they don't run the repo build, so artifacts/log/$(_BuildConfig) is
+          # never created. Leaving this 'true' makes the 1ES Publish Logs output
+          # fail because its targetPath doesn't exist.
+          enablePublishBuildArtifacts: false
           enableTelemetry: true
           workspace:
             clean: all

--- a/eng/pipelines/azure-pipelines.yml
+++ b/eng/pipelines/azure-pipelines.yml
@@ -433,7 +433,11 @@ extends:
           enableMicrobuild: false
           enablePublishUsingPipelines: false
           enablePublishBuildAssets: false
-          enablePublishBuildArtifacts: true
+          # WinGet and Homebrew jobs only consume previously-built CLI archives;
+          # they don't run the repo build, so artifacts/log/$(_BuildConfig) is
+          # never created. Leaving this 'true' makes the 1ES Publish Logs output
+          # fail because its targetPath doesn't exist.
+          enablePublishBuildArtifacts: false
           enableTelemetry: true
           workspace:
             clean: all


### PR DESCRIPTION
## Summary

Fixes the **Prepare Installers** stage failure in the internal pipeline (e.g. [dnceng/internal build 2969660](https://dev.azure.com/dnceng/internal/_build/results?buildId=2969660)) where the WinGet and Homebrew jobs fail at log-publish time.

## Why it fails today

The `WinGet` and `Homebrew` jobs in `azure-pipelines.yml` and `azure-pipelines-unofficial.yml` go through Arcade's `eng/common/templates-official/jobs/jobs.yml` with `enablePublishBuildArtifacts: true`.

That setting (in `eng/common/templates-official/job/job.yml`) injects a 1ES `pipelineArtifact` output:

```yaml
- output: pipelineArtifact
  displayName: Publish Logs
  targetPath: '$(Build.ArtifactStagingDirectory)/artifacts/log/$(_BuildConfig)'
```

But these jobs never run `./build.sh` — they only `checkout` + `DownloadPipelineArtifact` + run the WinGet manifest / Homebrew cask packaging template against previously-built CLI archives. So `artifacts/log/Release/` is never created, and 1ES path validation on the publish output fails the job. `continueOnError` on the upstream `CopyFiles` step doesn't save us because the failing step is the 1ES `pipelineArtifact` output itself.

## Fix

Set `enablePublishBuildArtifacts: false` on the installer-stage `jobs.yml` invocation in both pipelines. There are no build logs to publish from these jobs. `enableTelemetry: true` is preserved (that flag controls dotnet CLI telemetry env vars, not log publishing).

## Verification

- `./restore.sh` and `./build.sh` are not affected — this only changes pipeline YAML for the WinGet/Homebrew packaging stage.
- The change applies to both the internal (`azure-pipelines.yml`) and unofficial (`azure-pipelines-unofficial.yml`) pipelines, since both define identical WinGet/Homebrew jobs that hit the same template path.
- The native build/sign jobs in `build_sign_native.yml` keep `enablePublishBuildArtifacts: true` because they do run a build and produce logs.