### PR TITLE
Add npm packages for Aspire CLI

### DIFF
--- a/.github/workflows/build-cli-native-archives.yml
+++ b/.github/workflows/build-cli-native-archives.yml
@@ -104,8 +104,25 @@ jobs:
             -Rid $rid `
             -ArchivePath $archive[0].FullName
 
-      # Upload DCP, Dashboard, and CLI tool NuGets so test/polyglot jobs can download them
-      - name: Upload RID-specific NuGets
+      - name: Verify CLI npm package
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = 'Stop'
+
+          $rid = '${{ matrix.targets.rids }}'
+          $archiveExtension = if ($rid.StartsWith('win-')) { 'zip' } else { 'tar.gz' }
+          $archive = @(Get-ChildItem -Path 'artifacts/packages/${{ inputs.configuration }}' -Filter "aspire-cli-$rid-*.$archiveExtension" -Recurse -File -ErrorAction SilentlyContinue)
+          if ($archive.Count -ne 1) {
+            throw "Expected exactly one CLI archive for $rid, but found $($archive.Count): $($archive.FullName -join ', ')"
+          }
+
+          eng/scripts/verify-cli-npm-package.ps1 `
+            -PackagesDir artifacts/packages/${{ inputs.configuration }} `
+            -Rid $rid `
+            -ArchivePath $archive[0].FullName
+
+      # Upload DCP, Dashboard, and CLI tool packages so test/polyglot jobs can download them
+      - name: Upload RID-specific packages
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
         with:
           name: built-nugets-for-${{ matrix.targets.rids }}
@@ -113,6 +130,7 @@ jobs:
             artifacts/packages/${{ inputs.configuration }}/Shipping/Aspire.Hosting.Orchestration.${{ matrix.targets.rids }}.*.nupkg
             artifacts/packages/${{ inputs.configuration }}/Shipping/Aspire.Dashboard.Sdk.${{ matrix.targets.rids }}.*.nupkg
             artifacts/packages/${{ inputs.configuration }}/Shipping/Aspire.Cli.*.nupkg
+            artifacts/packages/${{ inputs.configuration }}/Shipping/microsoft-aspire-cli*.tgz
           if-no-files-found: error
           retention-days: 15
 

--- a/docs/specs/npm-cli-package.md
+++ b/docs/specs/npm-cli-package.md
@@ -1,0 +1,161 @@
+# Aspire CLI npm package POC
+
+## Summary
+
+The Aspire CLI npm package POC distributes the native Aspire CLI through npm using the same native binary archives that feed the dotnet tool packages. The npm package shape follows the native-package convention used by tools such as esbuild and @vscode/ripgrep: a small top-level package exposes the command, while platform-specific packages carry the native payload.
+
+The POC package name is `@microsoft/aspire-cli`. It is intentionally a POC and does not yet include npm publishing, provenance, registry authentication, or CLI-side npm self-update behavior.
+
+## Goals
+
+- Produce npm tarballs as part of the same native CLI package build that produces the dotnet tool packages.
+- Keep the signed native CLI archive as the canonical payload for both dotnet tool and npm package outputs.
+- Use a top-level npm package with a JavaScript `bin` launcher and RID-specific optional native packages.
+- Avoid running the self-extracting native binary directly from `node_modules` or package-manager stores.
+- Verify generated npm packages against the native archive before staging them.
+
+## Non-goals
+
+- Publishing packages to npm or configuring registry authentication.
+- Defining final public package ownership, scope, provenance, or release policy.
+- Implementing `aspire update --self` for npm installs.
+- Replacing the dotnet tool package flow.
+
+## Package layout
+
+The top-level package is:
+
+```text
+@microsoft/aspire-cli
+```
+
+It contains:
+
+```text
+package.json
+README.md
+bin/aspire.js
+bin/aspire-package-map.json
+```
+
+The top-level `package.json` declares:
+
+- `bin.aspire = "bin/aspire.js"`
+- `optionalDependencies` for every supported RID package at the same version
+- `files = ["bin", "README.md"]`
+
+RID-specific packages are named by appending the RID:
+
+```text
+@microsoft/aspire-cli-win-x64
+@microsoft/aspire-cli-win-arm64
+@microsoft/aspire-cli-linux-x64
+@microsoft/aspire-cli-linux-arm64
+@microsoft/aspire-cli-linux-musl-x64
+@microsoft/aspire-cli-osx-x64
+@microsoft/aspire-cli-osx-arm64
+```
+
+Each RID package contains:
+
+```text
+package.json
+README.md
+bin/aspire
+```
+
+or on Windows:
+
+```text
+package.json
+README.md
+bin/aspire.exe
+```
+
+RID package metadata uses npm's platform selectors:
+
+- Windows packages set `os = ["win32"]` and the matching `cpu`.
+- macOS packages set `os = ["darwin"]` and the matching `cpu`.
+- Linux glibc packages set `os = ["linux"]`, matching `cpu`, and `libc = ["glibc"]`.
+- Linux musl packages set `os = ["linux"]`, matching `cpu`, and `libc = ["musl"]`.
+
+## Launcher behavior
+
+The top-level `aspire` command runs `bin/aspire.js`.
+
+The launcher:
+
+1. Loads `bin/aspire-package-map.json`.
+2. Detects the current RID from `process.platform`, `process.arch`, and libc detection for Linux.
+3. Resolves the matching RID package with `require.resolve("<rid-package>/package.json")`.
+4. Finds `bin/aspire` or `bin/aspire.exe` inside that package.
+5. Copies the native binary to an Aspire-owned writable cache.
+6. Spawns the cached binary with inherited stdio and forwards all command-line arguments.
+
+The default cache path is:
+
+```text
+~/.aspire/npm/<version>/<rid>/bin/aspire
+```
+
+or on Windows:
+
+```text
+%USERPROFILE%\.aspire\npm\<version>\<rid>\bin\aspire.exe
+```
+
+The cache root can be overridden with `ASPIRE_NPM_CACHE_DIR` for tests and diagnostics.
+
+The copy step is required because the native Aspire CLI self-extracts its embedded bundle relative to the process path on first run. Running the binary directly from `node_modules` could make the extraction target a package directory, pnpm store, Yarn unplugged location, global npm cache, or other read-only package-manager path. Copying to the Aspire cache makes first-run extraction land under an Aspire-owned writable layout.
+
+The launcher sets these environment variables for future CLI-side npm install detection:
+
+```text
+ASPIRE_NPM_PACKAGE
+ASPIRE_NPM_PACKAGE_VERSION
+ASPIRE_NPM_PACKAGE_RID
+```
+
+## Build integration
+
+`eng\clipack\Common.projitems` wires npm packing into the existing native CLI package flow.
+
+`PackDotnetTool` depends on `PackNpmPackage`, so the native package build produces:
+
+- the existing dotnet tool pointer package
+- the existing dotnet tool RID-specific package
+- the npm pointer tarball
+- the npm RID-specific tarball
+
+`PackNpmPackage` depends on `_ExtractNativeBinaryFromArchive`, which extracts `aspire` or `aspire.exe` from the native CLI archive. The npm pack script receives that extracted binary and repackages it without rebuilding or substituting another payload.
+
+`eng\scripts\pack-cli-npm-package.ps1` generates temporary npm package directories and invokes `npm pack` for the RID package and pointer package.
+
+## Verification and staging
+
+`eng\scripts\verify-cli-npm-package.ps1` verifies each RID build output by:
+
+1. Finding exactly one RID-specific npm tarball.
+2. Finding exactly one npm pointer tarball.
+3. Extracting both tarballs.
+4. Extracting the native CLI archive.
+5. Comparing the RID tarball binary byte-for-byte with the archive binary.
+6. Verifying pointer package metadata, `bin/aspire.js`, `aspire-package-map.json`, and optional dependency version alignment.
+
+`eng\scripts\stage-native-cli-tool-packages.ps1` stages npm `.tgz` artifacts alongside existing native CLI nupkgs. Npm packages are additive: if no npm packages are present, staging warns and continues so older nupkg-only flows remain valid.
+
+Only one pointer package is staged. The default canonical pointer source is `native_archives_win_x64`, matching the existing native CLI package staging convention. All RID-specific packages are staged.
+
+## Pipeline integration
+
+The native archive workflows verify npm tarballs after the existing nupkg verification.
+
+GitHub Actions uploads `microsoft-aspire-cli*.tgz` with the RID-specific package artifacts. Azure Pipelines installs Node.js before native package build because `npm pack` runs during packaging, verifies the npm packages, downloads `microsoft-aspire-cli*.tgz` in the staging job, and stages them with the native CLI packages.
+
+## Open follow-ups
+
+- Decide the final npm scope and package names.
+- Add npm publishing, provenance, and registry authentication.
+- Decide whether the launcher should use stronger cache freshness than file-size comparison.
+- Implement CLI-side npm install detection and self-update guidance.
+- Add end-to-end installation tests against a real npm install layout.

--- a/docs/specs/npm-cli-package.md
+++ b/docs/specs/npm-cli-package.md
@@ -6,6 +6,18 @@ The Aspire CLI npm package POC distributes the native Aspire CLI through npm usi
 
 The POC package name is `@microsoft/aspire-cli`. It is intentionally a POC and does not yet include npm publishing, provenance, registry authentication, or CLI-side npm self-update behavior.
 
+## Research and prior art
+
+This design follows the native npm package pattern used by established packages rather than introducing a custom installer.
+
+- npm's package metadata defines the primitives this POC uses: `bin` exposes a command on PATH, `optionalDependencies` allow platform-specific packages to be skipped when they do not apply, `files` limits packed content, and `os`/`cpu` select packages by `process.platform` and `process.arch`. See the npm package.json documentation for [`bin`](https://docs.npmjs.com/cli/v10/configuring-npm/package-json#bin), [`optionalDependencies`](https://docs.npmjs.com/cli/v10/configuring-npm/package-json#optionaldependencies), [`files`](https://docs.npmjs.com/cli/v10/configuring-npm/package-json#files), [`os`](https://docs.npmjs.com/cli/v10/configuring-npm/package-json#os), and [`cpu`](https://docs.npmjs.com/cli/v10/configuring-npm/package-json#cpu).
+- [esbuild](https://github.com/evanw/esbuild/blob/main/npm/esbuild/package.json) uses a top-level package with a `bin` entry and platform-specific packages such as [`@esbuild/linux-x64`](https://github.com/evanw/esbuild/blob/main/npm/@esbuild/linux-x64/package.json) listed as optional dependencies. Its platform resolver maps the current Node platform to an optional package and resolves the binary through Node package resolution rather than hardcoded `node_modules` paths.
+- [@vscode/ripgrep](https://github.com/microsoft/vscode-ripgrep/blob/main/packages/ripgrep/package.json) uses the same top-level package plus optional platform package shape for an external CLI binary. A platform package such as [`@vscode/ripgrep-linux-x64`](https://github.com/microsoft/vscode-ripgrep/blob/main/packages/ripgrep-linux-x64/package.json) contains a `bin/` payload and declares `os`/`cpu` metadata.
+- Rollup, SWC, and sharp show the modern `libc` split for Linux native packages. Examples include [`@rollup/rollup-linux-x64-gnu`](https://github.com/rollup/rollup/blob/master/npm/linux-x64-gnu/package.json), [`@swc/core-linux-x64-gnu`](https://github.com/swc-project/swc/blob/main/packages/core/scripts/npm/linux-x64-gnu/package.json), and [`@img/sharp-linux-x64`](https://github.com/lovell/sharp/blob/main/npm/linux-x64/package.json). Their runtime loaders also distinguish glibc from musl before selecting a native package.
+- Yarn's package portability guidance says packages should not write inside their own package directory outside postinstall because package directories may be read-only or backed by package-manager stores. See ["Packages should never write inside their own folder outside of postinstall"](https://yarnpkg.com/advanced/rulebook#packages-should-never-write-inside-their-own-folder-outside-of-postinstall).
+
+The Aspire-specific adaptation is the writable cache. Unlike most native npm CLIs, the Aspire CLI self-extracts an embedded bundle relative to its process path on first run. That means running the binary directly from the RID package would make the extraction root depend on the package-manager layout. Copying to `~/.aspire/npm/<version>/<rid>/bin` keeps npm installation mechanics separate from Aspire's first-run extraction layout.
+
 ## Goals
 
 - Produce npm tarballs as part of the same native CLI package build that produces the dotnet tool packages.

--- a/eng/clipack/Common.projitems
+++ b/eng/clipack/Common.projitems
@@ -141,7 +141,7 @@
   -->
 
   <Target Name="PackDotnetTool"
-          DependsOnTargets="_InitializeDotnetToolPackProperties;_ExtractNativeBinaryFromArchive;_PackRidSpecificDotnetTool;_PackPointerDotnetTool" />
+          DependsOnTargets="_InitializeDotnetToolPackProperties;_ExtractNativeBinaryFromArchive;_PackRidSpecificDotnetTool;_PackPointerDotnetTool;PackNpmPackage" />
 
   <Target Name="_InitializeDotnetToolPackProperties">
     <Error Condition="'$(CliRuntime)' == ''"
@@ -159,6 +159,10 @@
       <_CliToolPublishBaseDir>$([MSBuild]::NormalizeDirectory($(IntermediateOutputPath), 'tool-publish'))</_CliToolPublishBaseDir>
       <_CliToolPublishDir>$([MSBuild]::NormalizeDirectory($(_CliToolPublishBaseDir), '$(CliRuntime)'))</_CliToolPublishDir>
       <_CliToolPointerPublishDir>$([MSBuild]::NormalizeDirectory($(_CliToolPublishBaseDir), 'pointer'))</_CliToolPointerPublishDir>
+      <_CliNpmPackageStagingDir>$([MSBuild]::NormalizeDirectory($(IntermediateOutputPath), 'npm-packages', '$(CliRuntime)'))</_CliNpmPackageStagingDir>
+      <_CliNpmPackageStagingDirArg>$(_CliNpmPackageStagingDir.TrimEnd('\').TrimEnd('/'))</_CliNpmPackageStagingDirArg>
+      <_PackageOutputPathArg>$(PackageOutputPath.TrimEnd('\').TrimEnd('/'))</_PackageOutputPathArg>
+      <NpmCliPackageName Condition="'$(NpmCliPackageName)' == ''">@microsoft/aspire-cli</NpmCliPackageName>
     </PropertyGroup>
 
     <ItemGroup>
@@ -232,6 +236,14 @@
              Targets="Pack"
              Properties="@(_PackPointerProperties)"
              RemoveProperties="OutputPath;TargetFramework" />
+  </Target>
+
+  <Target Name="PackNpmPackage"
+          DependsOnTargets="_InitializeDotnetToolPackProperties;_ExtractNativeBinaryFromArchive">
+    <Message Importance="High"
+             Text="Packing CLI npm packages for $(CliRuntime) from '$(_ExtractedNativeBinaryPath)' extracted from '$(_CliArchivePath)'." />
+
+    <Exec Command="pwsh -NoProfile -NonInteractive -File &quot;$(RepoRoot)eng\scripts\pack-cli-npm-package.ps1&quot; -Rid &quot;$(CliRuntime)&quot; -Version &quot;$(Version)&quot; -NativeBinaryPath &quot;$(_ExtractedNativeBinaryPath)&quot; -OutputPath &quot;$(_PackageOutputPathArg)&quot; -StagingRoot &quot;$(_CliNpmPackageStagingDirArg)&quot; -PackageName &quot;$(NpmCliPackageName)&quot;" />
   </Target>
 
 </Project>

--- a/eng/clipack/npm/aspire.js
+++ b/eng/clipack/npm/aspire.js
@@ -6,6 +6,8 @@ const fs = require('fs');
 const os = require('os');
 const path = require('path');
 
+// Package names are generated at pack time so changing the npm package name in
+// MSBuild does not require editing this launcher.
 const ridPackageNames = loadRidPackageNames();
 
 function loadRidPackageNames() {
@@ -39,6 +41,8 @@ function detectRid() {
 }
 
 function isMusl() {
+  // npm supports libc-specific packages. Prefer Node's runtime report because
+  // it avoids spawning a process on glibc systems, then fall back to ldd.
   if (process.report && typeof process.report.getReport === 'function') {
     const report = process.report.getReport();
     if (report && report.header && report.header.glibcVersionRuntime) {
@@ -82,12 +86,17 @@ function ensureCachedBinary(sourcePath, binaryName, version, rid) {
   const targetDirectory = path.join(cacheRoot, version, rid, 'bin');
   const targetPath = path.join(targetDirectory, binaryName);
 
+  // The Aspire CLI self-extracts relative to its process path on first run.
+  // Running directly from node_modules could write into read-only package
+  // stores, so copy the native binary to an Aspire-owned writable layout.
   fs.mkdirSync(targetDirectory, { recursive: true });
 
   if (!needsCopy(sourcePath, targetPath)) {
     return targetPath;
   }
 
+  // Copy through a temp file so concurrent first runs never observe a partial
+  // executable at the final path.
   const tempPath = path.join(targetDirectory, `${binaryName}.${process.pid}.${Date.now()}.tmp`);
   fs.copyFileSync(sourcePath, tempPath);
 
@@ -125,6 +134,8 @@ function main() {
     stdio: 'inherit',
     env: {
       ...process.env,
+      // Future CLI-side update detection can use these values to distinguish
+      // npm installs from dotnet tool installs.
       ASPIRE_NPM_PACKAGE: packageJson.name,
       ASPIRE_NPM_PACKAGE_VERSION: packageJson.version,
       ASPIRE_NPM_PACKAGE_RID: rid

--- a/eng/clipack/npm/aspire.js
+++ b/eng/clipack/npm/aspire.js
@@ -1,0 +1,154 @@
+#!/usr/bin/env node
+'use strict';
+
+const childProcess = require('child_process');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+const ridPackageNames = loadRidPackageNames();
+
+function loadRidPackageNames() {
+  const packageMapPath = path.join(__dirname, 'aspire-package-map.json');
+  return new Map(Object.entries(JSON.parse(fs.readFileSync(packageMapPath, 'utf8'))));
+}
+
+function detectRid() {
+  const platform = process.platform;
+  const arch = process.arch;
+
+  if (platform === 'win32' && (arch === 'x64' || arch === 'arm64')) {
+    return `win-${arch}`;
+  }
+
+  if (platform === 'darwin' && (arch === 'x64' || arch === 'arm64')) {
+    return `osx-${arch}`;
+  }
+
+  if (platform === 'linux') {
+    if (arch === 'x64' && isMusl()) {
+      return 'linux-musl-x64';
+    }
+
+    if (arch === 'x64' || arch === 'arm64') {
+      return `linux-${arch}`;
+    }
+  }
+
+  throw new Error(`Unsupported platform: ${platform} ${arch}`);
+}
+
+function isMusl() {
+  if (process.report && typeof process.report.getReport === 'function') {
+    const report = process.report.getReport();
+    if (report && report.header && report.header.glibcVersionRuntime) {
+      return false;
+    }
+  }
+
+  const lddResult = childProcess.spawnSync('ldd', ['--version'], { encoding: 'utf8' });
+  const lddOutput = `${lddResult.stdout || ''}${lddResult.stderr || ''}`.toLowerCase();
+  return lddOutput.includes('musl');
+}
+
+function resolveNativeBinary(rid) {
+  const packageName = ridPackageNames.get(rid);
+  if (!packageName) {
+    throw new Error(`No Aspire CLI npm package is available for RID '${rid}'.`);
+  }
+
+  let packageJsonPath;
+  try {
+    packageJsonPath = require.resolve(`${packageName}/package.json`);
+  } catch (error) {
+    throw new Error(
+      `The Aspire CLI native package '${packageName}' was not installed. ` +
+      'Reinstall @microsoft/aspire-cli with optional dependencies enabled.',
+      { cause: error });
+  }
+
+  const binaryName = process.platform === 'win32' ? 'aspire.exe' : 'aspire';
+  const binaryPath = path.join(path.dirname(packageJsonPath), 'bin', binaryName);
+  if (!fs.existsSync(binaryPath)) {
+    throw new Error(`The Aspire CLI native package '${packageName}' is missing '${binaryName}'.`);
+  }
+
+  return { binaryPath, packageName, binaryName };
+}
+
+function ensureCachedBinary(sourcePath, binaryName, version, rid) {
+  const home = os.homedir() || os.tmpdir();
+  const cacheRoot = process.env.ASPIRE_NPM_CACHE_DIR || path.join(home, '.aspire', 'npm');
+  const targetDirectory = path.join(cacheRoot, version, rid, 'bin');
+  const targetPath = path.join(targetDirectory, binaryName);
+
+  fs.mkdirSync(targetDirectory, { recursive: true });
+
+  if (!needsCopy(sourcePath, targetPath)) {
+    return targetPath;
+  }
+
+  const tempPath = path.join(targetDirectory, `${binaryName}.${process.pid}.${Date.now()}.tmp`);
+  fs.copyFileSync(sourcePath, tempPath);
+
+  if (process.platform !== 'win32') {
+    fs.chmodSync(tempPath, 0o755);
+  }
+
+  try {
+    fs.rmSync(targetPath, { force: true });
+    fs.renameSync(tempPath, targetPath);
+  } catch (error) {
+    fs.rmSync(tempPath, { force: true });
+    throw error;
+  }
+
+  return targetPath;
+}
+
+function needsCopy(sourcePath, targetPath) {
+  try {
+    const source = fs.statSync(sourcePath);
+    const target = fs.statSync(targetPath);
+    return source.size !== target.size;
+  } catch {
+    return true;
+  }
+}
+
+function main() {
+  const packageJson = require(path.join(__dirname, '..', 'package.json'));
+  const rid = detectRid();
+  const nativeBinary = resolveNativeBinary(rid);
+  const executablePath = ensureCachedBinary(nativeBinary.binaryPath, nativeBinary.binaryName, packageJson.version, rid);
+  const child = childProcess.spawn(executablePath, process.argv.slice(2), {
+    stdio: 'inherit',
+    env: {
+      ...process.env,
+      ASPIRE_NPM_PACKAGE: packageJson.name,
+      ASPIRE_NPM_PACKAGE_VERSION: packageJson.version,
+      ASPIRE_NPM_PACKAGE_RID: rid
+    }
+  });
+
+  child.on('error', error => {
+    console.error(error.message);
+    process.exit(1);
+  });
+
+  child.on('exit', (code, signal) => {
+    if (signal) {
+      process.kill(process.pid, signal);
+      return;
+    }
+
+    process.exit(code === null ? 1 : code);
+  });
+}
+
+try {
+  main();
+} catch (error) {
+  console.error(error.message);
+  process.exit(1);
+}

--- a/eng/pipelines/azure-pipelines-unofficial.yml
+++ b/eng/pipelines/azure-pipelines-unofficial.yml
@@ -173,10 +173,11 @@ extends:
                   targetPath: '$(Build.SourcesDirectory)/artifacts/signed-archives/$(_BuildConfig)'
 
               - task: DownloadPipelineArtifact@2
-                displayName: 🟣Download Native CLI Tool Packages
+                displayName: 🟣Download Native CLI Packages
                 inputs:
                   itemPattern: |
                     **/Aspire.Cli*.nupkg
+                    **/microsoft-aspire-cli*.tgz
                   targetPath: '$(Build.SourcesDirectory)/artifacts/native-cli-packages/$(_BuildConfig)'
 
               - pwsh: |
@@ -184,7 +185,7 @@ extends:
                   & "$(Build.SourcesDirectory)/eng/scripts/stage-native-cli-tool-packages.ps1" `
                     -DownloadRoot "$(Build.SourcesDirectory)/artifacts/native-cli-packages/$(_BuildConfig)" `
                     -ShippingDir "$(Build.SourcesDirectory)/artifacts/packages/$(_BuildConfig)/Shipping"
-                displayName: 🟣Stage Native CLI Tool Packages
+                displayName: 🟣Stage Native CLI Packages
 
               - task: PowerShell@2
                 displayName: 🟣List artifacts packages contents

--- a/eng/pipelines/azure-pipelines.yml
+++ b/eng/pipelines/azure-pipelines.yml
@@ -261,10 +261,11 @@ extends:
                   targetPath: '$(Build.SourcesDirectory)/artifacts/signed-archives/$(_BuildConfig)'
 
               - task: DownloadPipelineArtifact@2
-                displayName: 🟣Download Native CLI Tool Packages
+                displayName: 🟣Download Native CLI Packages
                 inputs:
                   itemPattern: |
                     **/Aspire.Cli*.nupkg
+                    **/microsoft-aspire-cli*.tgz
                   targetPath: '$(Build.SourcesDirectory)/artifacts/native-cli-packages/$(_BuildConfig)'
 
               - pwsh: |
@@ -272,7 +273,7 @@ extends:
                   & "$(Build.SourcesDirectory)/eng/scripts/stage-native-cli-tool-packages.ps1" `
                     -DownloadRoot "$(Build.SourcesDirectory)/artifacts/native-cli-packages/$(_BuildConfig)" `
                     -ShippingDir "$(Build.SourcesDirectory)/artifacts/packages/$(_BuildConfig)/Shipping"
-                displayName: 🟣Stage Native CLI Tool Packages
+                displayName: 🟣Stage Native CLI Packages
 
               - task: PowerShell@2
                 displayName: 🟣List artifacts packages contents

--- a/eng/pipelines/templates/build_sign_native.yml
+++ b/eng/pipelines/templates/build_sign_native.yml
@@ -122,6 +122,11 @@ jobs:
                 chmod +x $(Build.SourcesDirectory)/artifacts/bin/Aspire.Managed/Release/net10.0/${{ targetRid }}/publish/aspire-managed
               displayName: 🟣Restore execute permission on aspire-managed
 
+          - task: NodeTool@0
+            displayName: 🟣Install node.js
+            inputs:
+              versionSpec: '20.x'
+
           - script: >-
               $(Build.SourcesDirectory)/$(dotnetScript)
               msbuild
@@ -164,6 +169,21 @@ jobs:
               $verifyParams.ArchivePath = $archive[0].FullName
               & "$(Build.SourcesDirectory)/eng/scripts/verify-cli-tool-nupkg.ps1" @verifyParams
             displayName: 🟣Verify CLI tool nupkg (${{ targetRid }})
+
+          - pwsh: |
+              $ErrorActionPreference = 'Stop'
+              $verifyParams = @{
+                PackagesDir = "$(Build.SourcesDirectory)/artifacts/packages/$(_BuildConfig)"
+                Rid = "${{ targetRid }}"
+              }
+              $archiveFilter = if ("${{ targetRid }}".StartsWith('win-')) { "aspire-cli-${{ targetRid }}-*.zip" } else { "aspire-cli-${{ targetRid }}-*.tar.gz" }
+              $archive = @(Get-ChildItem -Path $verifyParams.PackagesDir -Filter $archiveFilter -Recurse -File -ErrorAction SilentlyContinue)
+              if ($archive.Count -ne 1) {
+                throw "Expected exactly one CLI archive for ${{ targetRid }}, but found $($archive.Count): $($archive.FullName -join ', ')"
+              }
+              $verifyParams.ArchivePath = $archive[0].FullName
+              & "$(Build.SourcesDirectory)/eng/scripts/verify-cli-npm-package.ps1" @verifyParams
+            displayName: 🟣Verify CLI npm package (${{ targetRid }})
 
           # Verify the signed CLI archive can execute and create a project.
           # Only runs when the target RID architecture matches the build agent

--- a/eng/scripts/pack-cli-npm-package.ps1
+++ b/eng/scripts/pack-cli-npm-package.ps1
@@ -20,6 +20,8 @@ param(
 $ErrorActionPreference = 'Stop'
 
 function New-StringList([string[]]$Values) {
+  # PowerShell enumerates single-item arrays when returning from functions.
+  # Returning a List keeps os/cpu/libc/files as JSON arrays for npm metadata.
   $list = [System.Collections.Generic.List[string]]::new()
   foreach ($value in $Values) {
     $list.Add($value)
@@ -28,6 +30,8 @@ function New-StringList([string[]]$Values) {
 }
 
 function Get-RidPackageInfo([string]$PackageRid) {
+  # Keep npm platform metadata aligned with the RIDs produced by the native
+  # archive build. npm uses os/cpu/libc to install only the matching package.
   switch ($PackageRid) {
     'win-x64' {
       return [ordered]@{
@@ -106,6 +110,8 @@ function Invoke-NpmPack([string]$PackageDirectory, [string]$DestinationDirectory
   }
 }
 
+# MSBuild extracts this from the signed native CLI archive. This script only
+# repackages that payload; it must not rebuild or substitute another binary.
 if (-not (Test-Path -LiteralPath $NativeBinaryPath)) {
   throw "Native binary path does not exist: $NativeBinaryPath"
 }
@@ -173,6 +179,8 @@ foreach ($supportedRid in $supportedRids) {
   $optionalDependencies["$PackageName-$supportedRid"] = $Version
 }
 
+# The launcher reads this map instead of hardcoding package names so package
+# scope/name changes remain an MSBuild property.
 $ridPackageMap = [ordered]@{}
 foreach ($supportedRid in $supportedRids) {
   $ridPackageMap[$supportedRid] = "$PackageName-$supportedRid"

--- a/eng/scripts/pack-cli-npm-package.ps1
+++ b/eng/scripts/pack-cli-npm-package.ps1
@@ -1,0 +1,214 @@
+param(
+  [Parameter(Mandatory = $true)]
+  [string]$Rid,
+
+  [Parameter(Mandatory = $true)]
+  [string]$Version,
+
+  [Parameter(Mandatory = $true)]
+  [string]$NativeBinaryPath,
+
+  [Parameter(Mandatory = $true)]
+  [string]$OutputPath,
+
+  [Parameter(Mandatory = $true)]
+  [string]$StagingRoot,
+
+  [string]$PackageName = '@microsoft/aspire-cli'
+)
+
+$ErrorActionPreference = 'Stop'
+
+function New-StringList([string[]]$Values) {
+  $list = [System.Collections.Generic.List[string]]::new()
+  foreach ($value in $Values) {
+    $list.Add($value)
+  }
+  return ,$list
+}
+
+function Get-RidPackageInfo([string]$PackageRid) {
+  switch ($PackageRid) {
+    'win-x64' {
+      return [ordered]@{
+        BinaryName = 'aspire.exe'
+        Os = New-StringList 'win32'
+        Cpu = New-StringList 'x64'
+      }
+    }
+    'win-arm64' {
+      return [ordered]@{
+        BinaryName = 'aspire.exe'
+        Os = New-StringList 'win32'
+        Cpu = New-StringList 'arm64'
+      }
+    }
+    'linux-x64' {
+      return [ordered]@{
+        BinaryName = 'aspire'
+        Os = New-StringList 'linux'
+        Cpu = New-StringList 'x64'
+        Libc = New-StringList 'glibc'
+      }
+    }
+    'linux-arm64' {
+      return [ordered]@{
+        BinaryName = 'aspire'
+        Os = New-StringList 'linux'
+        Cpu = New-StringList 'arm64'
+        Libc = New-StringList 'glibc'
+      }
+    }
+    'linux-musl-x64' {
+      return [ordered]@{
+        BinaryName = 'aspire'
+        Os = New-StringList 'linux'
+        Cpu = New-StringList 'x64'
+        Libc = New-StringList 'musl'
+      }
+    }
+    'osx-x64' {
+      return [ordered]@{
+        BinaryName = 'aspire'
+        Os = New-StringList 'darwin'
+        Cpu = New-StringList 'x64'
+      }
+    }
+    'osx-arm64' {
+      return [ordered]@{
+        BinaryName = 'aspire'
+        Os = New-StringList 'darwin'
+        Cpu = New-StringList 'arm64'
+      }
+    }
+    default {
+      throw "Unsupported Aspire CLI RID for npm packaging: $PackageRid"
+    }
+  }
+}
+
+function Write-JsonFile([string]$Path, [object]$Value) {
+  $json = $Value | ConvertTo-Json -Depth 20
+  $utf8NoBom = [System.Text.UTF8Encoding]::new($false)
+  [System.IO.File]::WriteAllText($Path, "$json`n", $utf8NoBom)
+}
+
+function Write-TextFile([string]$Path, [string]$Value) {
+  $utf8NoBom = [System.Text.UTF8Encoding]::new($false)
+  [System.IO.File]::WriteAllText($Path, $Value, $utf8NoBom)
+}
+
+function Invoke-NpmPack([string]$PackageDirectory, [string]$DestinationDirectory) {
+  Write-Host "Packing npm package from $PackageDirectory"
+  & npm pack $PackageDirectory --pack-destination $DestinationDirectory
+  if ($LASTEXITCODE -ne 0) {
+    throw "npm pack failed for $PackageDirectory with exit code $LASTEXITCODE."
+  }
+}
+
+if (-not (Test-Path -LiteralPath $NativeBinaryPath)) {
+  throw "Native binary path does not exist: $NativeBinaryPath"
+}
+
+$repoRoot = (Resolve-Path (Join-Path $PSScriptRoot '..\..')).Path
+$launcherPath = Join-Path $repoRoot 'eng\clipack\npm\aspire.js'
+if (-not (Test-Path -LiteralPath $launcherPath)) {
+  throw "Npm launcher path does not exist: $launcherPath"
+}
+
+$ridInfo = Get-RidPackageInfo $Rid
+$ridPackageName = "$PackageName-$Rid"
+$supportedRids = @('win-x64', 'win-arm64', 'linux-x64', 'linux-arm64', 'linux-musl-x64', 'osx-x64', 'osx-arm64')
+
+Remove-Item -LiteralPath $StagingRoot -Recurse -Force -ErrorAction SilentlyContinue
+New-Item -ItemType Directory -Path $StagingRoot -Force | Out-Null
+New-Item -ItemType Directory -Path $OutputPath -Force | Out-Null
+
+$ridPackageRoot = Join-Path $StagingRoot 'rid'
+$ridPackageBin = Join-Path $ridPackageRoot 'bin'
+New-Item -ItemType Directory -Path $ridPackageBin -Force | Out-Null
+Copy-Item -LiteralPath $NativeBinaryPath -Destination (Join-Path $ridPackageBin $ridInfo.BinaryName) -Force
+
+$ridPackageJson = [ordered]@{
+  name = $ridPackageName
+  version = $Version
+  description = "Native Aspire CLI binary for $Rid."
+  license = 'MIT'
+  repository = [ordered]@{
+    type = 'git'
+    url = 'git+https://github.com/microsoft/aspire.git'
+  }
+  bugs = [ordered]@{
+    url = 'https://github.com/microsoft/aspire/issues'
+  }
+  os = $ridInfo.Os
+  cpu = $ridInfo.Cpu
+  files = New-StringList @('bin', 'README.md')
+}
+
+if ($ridInfo.Contains('Libc')) {
+  $ridPackageJson.libc = $ridInfo.Libc
+}
+
+Write-JsonFile (Join-Path $ridPackageRoot 'package.json') $ridPackageJson
+Write-TextFile (Join-Path $ridPackageRoot 'README.md') @"
+# $ridPackageName
+
+Native Aspire CLI binary for `$Rid`.
+
+This package is installed as an optional dependency of `$PackageName`.
+"@
+
+$pointerPackageRoot = Join-Path $StagingRoot 'pointer'
+$pointerPackageBin = Join-Path $pointerPackageRoot 'bin'
+New-Item -ItemType Directory -Path $pointerPackageBin -Force | Out-Null
+Copy-Item -LiteralPath $launcherPath -Destination (Join-Path $pointerPackageBin 'aspire.js') -Force
+
+if (-not [System.Runtime.InteropServices.RuntimeInformation]::IsOSPlatform([System.Runtime.InteropServices.OSPlatform]::Windows)) {
+  chmod +x (Join-Path $pointerPackageBin 'aspire.js')
+}
+
+$optionalDependencies = [ordered]@{}
+foreach ($supportedRid in $supportedRids) {
+  $optionalDependencies["$PackageName-$supportedRid"] = $Version
+}
+
+$ridPackageMap = [ordered]@{}
+foreach ($supportedRid in $supportedRids) {
+  $ridPackageMap[$supportedRid] = "$PackageName-$supportedRid"
+}
+
+$pointerPackageJson = [ordered]@{
+  name = $PackageName
+  version = $Version
+  description = 'Command line tool for Aspire developers.'
+  license = 'MIT'
+  repository = [ordered]@{
+    type = 'git'
+    url = 'git+https://github.com/microsoft/aspire.git'
+  }
+  bugs = [ordered]@{
+    url = 'https://github.com/microsoft/aspire/issues'
+  }
+  bin = [ordered]@{
+    aspire = 'bin/aspire.js'
+  }
+  engines = [ordered]@{
+    node = '>=16'
+  }
+  optionalDependencies = $optionalDependencies
+  files = New-StringList @('bin', 'README.md')
+}
+
+Write-JsonFile (Join-Path $pointerPackageRoot 'package.json') $pointerPackageJson
+Write-JsonFile (Join-Path $pointerPackageBin 'aspire-package-map.json') $ridPackageMap
+Write-TextFile (Join-Path $pointerPackageRoot 'README.md') @"
+# $PackageName
+
+Npm package for the Aspire CLI.
+
+This package installs a small JavaScript launcher and resolves the matching native Aspire CLI package for the current platform.
+"@
+
+Invoke-NpmPack $ridPackageRoot $OutputPath
+Invoke-NpmPack $pointerPackageRoot $OutputPath

--- a/eng/scripts/stage-native-cli-tool-packages.ps1
+++ b/eng/scripts/stage-native-cli-tool-packages.ps1
@@ -5,36 +5,69 @@ param(
   [Parameter(Mandatory = $true)]
   [string]$ShippingDir,
 
-  [string]$CanonicalPointerArtifactName = 'native_archives_win_x64'
+  [string]$CanonicalPointerArtifactName = 'native_archives_win_x64',
+
+  [string]$NpmPackageFilePrefix = 'microsoft-aspire-cli'
 )
 
 $ErrorActionPreference = 'Stop'
 
 New-Item -ItemType Directory -Path $ShippingDir -Force | Out-Null
 
-$packages = @(Get-ChildItem -Path $DownloadRoot -Filter "Aspire.Cli*.nupkg" -File -Recurse |
-  Where-Object { $_.Name -notmatch '\.symbols\.' } |
-  Sort-Object FullName)
-if ($packages.Count -eq 0) {
-  throw "No native CLI tool packages were downloaded to $DownloadRoot."
+$packageVersionPattern = '(?<Version>\d+(?:\.\d+){1,3}(?:-[0-9A-Za-z][0-9A-Za-z.-]*)?)'
+
+function Get-NativeArchiveArtifact {
+  param([System.IO.FileInfo]$Package)
+
+  $pathParts = $Package.FullName.Split([char[]]@('\', '/'), [System.StringSplitOptions]::RemoveEmptyEntries)
+  $nativeArchiveRoot = @($pathParts | Where-Object { $_ -like 'native_archives_*' } | Select-Object -First 1)
+
+  if ($nativeArchiveRoot.Count -eq 0) {
+    return $null
+  }
+
+  $artifactName = $nativeArchiveRoot[0]
+  return [pscustomobject]@{
+    Name = $artifactName
+    Rid = $artifactName.Substring('native_archives_'.Length).Replace('_', '-')
+  }
 }
 
-$packageVersionPattern = '(?<Version>\d+(?:\.\d+){1,3}(?:-[0-9A-Za-z][0-9A-Za-z.-]*)?)'
-$pointerPackagePattern = "^Aspire\.Cli\.$packageVersionPattern\.nupkg$"
+function New-ClassifiedPackage {
+  param(
+    [System.IO.FileInfo]$Package,
+    [string]$PackageKind,
+    [string]$ArtifactName,
+    [string]$ArtifactRid,
+    [string]$PackageVersion,
+    [bool]$IsPointerPackage
+  )
 
-$classifiedPackages = @(
+  [pscustomobject]@{
+    File = $Package
+    PackageKind = $PackageKind
+    PackageName = $Package.Name
+    PackageVersion = $PackageVersion
+    ArtifactName = $ArtifactName
+    ArtifactRid = $ArtifactRid
+    IsPointerPackage = $IsPointerPackage
+  }
+}
+
+function Get-ClassifiedNuGetPackages {
+  $packages = @(Get-ChildItem -Path $DownloadRoot -Filter "Aspire.Cli*.nupkg" -File -Recurse |
+    Where-Object { $_.Name -notmatch '\.symbols\.' } |
+    Sort-Object FullName)
+
   foreach ($package in $packages) {
-    $pathParts = $package.FullName.Split([char[]]@('\', '/'), [System.StringSplitOptions]::RemoveEmptyEntries)
-    $nativeArchiveRoot = @($pathParts | Where-Object { $_ -like 'native_archives_*' } | Select-Object -First 1)
-
-    if ($nativeArchiveRoot.Count -eq 0) {
+    $artifact = Get-NativeArchiveArtifact $package
+    if ($null -eq $artifact) {
       Write-Warning "Skipping Aspire.Cli package outside native archive artifacts: $($package.FullName)"
       continue
     }
 
-    $artifactName = $nativeArchiveRoot[0]
-    $artifactRid = $artifactName.Substring('native_archives_'.Length).Replace('_', '-')
-    $artifactRidPattern = [System.Text.RegularExpressions.Regex]::Escape($artifactRid)
+    $artifactRidPattern = [System.Text.RegularExpressions.Regex]::Escape($artifact.Rid)
+    $pointerPackagePattern = "^Aspire\.Cli\.$packageVersionPattern\.nupkg$"
     $ridPackagePattern = "^Aspire\.Cli\.$artifactRidPattern\.$packageVersionPattern\.nupkg$"
 
     $isPointerPackage = $false
@@ -48,49 +81,96 @@ $classifiedPackages = @(
     }
 
     if ($null -eq $packageVersion) {
-      throw "Unexpected Aspire.Cli package '$($package.FullName)' in artifact '$artifactName'. Expected either an Aspire.Cli pointer package or an Aspire.Cli.$artifactRid RID-specific package."
+      throw "Unexpected Aspire.Cli package '$($package.FullName)' in artifact '$($artifact.Name)'. Expected either an Aspire.Cli pointer package or an Aspire.Cli.$($artifact.Rid) RID-specific package."
     }
 
-    [pscustomobject]@{
-      File = $package
-      PackageName = $package.Name
-      PackageVersion = $packageVersion
-      ArtifactName = $artifactName
-      ArtifactRid = $artifactRid
-      IsPointerPackage = $isPointerPackage
-    }
+    New-ClassifiedPackage $package 'NuGet' $artifact.Name $artifact.Rid $packageVersion $isPointerPackage
   }
-)
-
-if ($classifiedPackages.Count -eq 0) {
-  throw "No native CLI tool packages were found under native_archives_<rid> artifacts in $DownloadRoot."
 }
 
-$canonicalPointerPackages = @($classifiedPackages | Where-Object { $_.IsPointerPackage -and $_.ArtifactName -eq $CanonicalPointerArtifactName })
-if ($canonicalPointerPackages.Count -ne 1) {
-  throw "Expected exactly one canonical Aspire.Cli pointer package from $CanonicalPointerArtifactName, but found $($canonicalPointerPackages.Count): $($canonicalPointerPackages.File.FullName -join ', ')"
+function Get-ClassifiedNpmPackages {
+  $packages = @(Get-ChildItem -Path $DownloadRoot -Filter "$NpmPackageFilePrefix*.tgz" -File -Recurse |
+    Sort-Object FullName)
+  $escapedPrefix = [System.Text.RegularExpressions.Regex]::Escape($NpmPackageFilePrefix)
+
+  foreach ($package in $packages) {
+    $artifact = Get-NativeArchiveArtifact $package
+    if ($null -eq $artifact) {
+      Write-Warning "Skipping Aspire CLI npm package outside native archive artifacts: $($package.FullName)"
+      continue
+    }
+
+    $artifactRidPattern = [System.Text.RegularExpressions.Regex]::Escape($artifact.Rid)
+    $pointerPackagePattern = "^$escapedPrefix-$packageVersionPattern\.tgz$"
+    $ridPackagePattern = "^$escapedPrefix-$artifactRidPattern-$packageVersionPattern\.tgz$"
+
+    $isPointerPackage = $false
+    $packageVersion = $null
+
+    if ($package.Name -match $pointerPackagePattern) {
+      $isPointerPackage = $true
+      $packageVersion = $Matches.Version
+    } elseif ($package.Name -match $ridPackagePattern) {
+      $packageVersion = $Matches.Version
+    }
+
+    if ($null -eq $packageVersion) {
+      throw "Unexpected Aspire CLI npm package '$($package.FullName)' in artifact '$($artifact.Name)'. Expected either a $NpmPackageFilePrefix pointer package or a $NpmPackageFilePrefix-$($artifact.Rid) RID-specific package."
+    }
+
+    New-ClassifiedPackage $package 'npm' $artifact.Name $artifact.Rid $packageVersion $isPointerPackage
+  }
 }
 
-$skippedPointerPackages = @($classifiedPackages | Where-Object { $_.IsPointerPackage -and $_.ArtifactName -ne $CanonicalPointerArtifactName })
-foreach ($package in $skippedPointerPackages) {
-  Write-Host "Skipping non-canonical Aspire.Cli pointer package from $($package.ArtifactName): $($package.File.FullName)"
+function Get-PackagesToStage {
+  param(
+    [object[]]$ClassifiedPackages,
+    [string]$PointerPackageDescription,
+    [string]$RidPackageDescription,
+    [string]$NoPackagesDescription
+  )
+
+  if ($ClassifiedPackages.Count -eq 0) {
+    throw "No $NoPackagesDescription packages were found under native_archives_<rid> artifacts in $DownloadRoot."
+  }
+
+  $canonicalPointerPackages = @($ClassifiedPackages | Where-Object { $_.IsPointerPackage -and $_.ArtifactName -eq $CanonicalPointerArtifactName })
+  if ($canonicalPointerPackages.Count -ne 1) {
+    throw "Expected exactly one canonical $PointerPackageDescription pointer package from $CanonicalPointerArtifactName, but found $($canonicalPointerPackages.Count): $($canonicalPointerPackages.File.FullName -join ', ')"
+  }
+
+  $skippedPointerPackages = @($ClassifiedPackages | Where-Object { $_.IsPointerPackage -and $_.ArtifactName -ne $CanonicalPointerArtifactName })
+  foreach ($package in $skippedPointerPackages) {
+    Write-Host "Skipping non-canonical $PointerPackageDescription pointer package from $($package.ArtifactName): $($package.File.FullName)"
+  }
+
+  $canonicalPointerVersion = $canonicalPointerPackages[0].PackageVersion
+  $ridPackages = @($ClassifiedPackages | Where-Object { -not $_.IsPointerPackage })
+  $duplicateRidPackageGroups = @($ridPackages | Group-Object ArtifactRid | Where-Object { $_.Count -gt 1 })
+  if ($duplicateRidPackageGroups.Count -gt 0) {
+    $details = @($duplicateRidPackageGroups | ForEach-Object { "$($_.Name): $($_.Group.File.FullName -join ', ')" })
+    throw "Expected exactly one $RidPackageDescription RID-specific package per RID, but found duplicates: $($details -join '; ')"
+  }
+
+  $ridPackageVersionMismatches = @($ridPackages | Where-Object { $_.PackageVersion -ne $canonicalPointerVersion })
+  if ($ridPackageVersionMismatches.Count -gt 0) {
+    $details = @($ridPackageVersionMismatches | ForEach-Object { "$($_.PackageName) has version $($_.PackageVersion)" })
+    throw "All $RidPackageDescription RID-specific packages must match canonical pointer package version $canonicalPointerVersion from $CanonicalPointerArtifactName, but found mismatches: $($details -join '; ')"
+  }
+
+  return @($canonicalPointerPackages[0]) + $ridPackages
 }
 
-$canonicalPointerVersion = $canonicalPointerPackages[0].PackageVersion
-$ridPackages = @($classifiedPackages | Where-Object { -not $_.IsPointerPackage })
-$duplicateRidPackageGroups = @($ridPackages | Group-Object ArtifactRid | Where-Object { $_.Count -gt 1 })
-if ($duplicateRidPackageGroups.Count -gt 0) {
-  $details = @($duplicateRidPackageGroups | ForEach-Object { "$($_.Name): $($_.Group.File.FullName -join ', ')" })
-  throw "Expected exactly one Aspire.Cli RID-specific package per RID, but found duplicates: $($details -join '; ')"
+$nugetPackagesToStage = Get-PackagesToStage (Get-ClassifiedNuGetPackages) 'Aspire.Cli' 'Aspire.Cli' 'native CLI tool'
+$classifiedNpmPackages = @(Get-ClassifiedNpmPackages)
+$npmPackagesToStage = if ($classifiedNpmPackages.Count -eq 0) {
+  Write-Warning "No Aspire CLI npm packages were found under native_archives_<rid> artifacts in $DownloadRoot."
+  @()
+} else {
+  Get-PackagesToStage $classifiedNpmPackages 'Aspire CLI npm' 'Aspire CLI npm' 'Aspire CLI npm'
 }
+$packagesToStage = @($nugetPackagesToStage) + @($npmPackagesToStage)
 
-$ridPackageVersionMismatches = @($ridPackages | Where-Object { $_.PackageVersion -ne $canonicalPointerVersion })
-if ($ridPackageVersionMismatches.Count -gt 0) {
-  $details = @($ridPackageVersionMismatches | ForEach-Object { "$($_.PackageName) has version $($_.PackageVersion)" })
-  throw "All Aspire.Cli RID-specific packages must match canonical pointer package version $canonicalPointerVersion from $CanonicalPointerArtifactName, but found mismatches: $($details -join '; ')"
-}
-
-$packagesToStage = @($canonicalPointerPackages[0]) + $ridPackages
 foreach ($packageToStage in $packagesToStage) {
   $package = $packageToStage.File
   Copy-Item -LiteralPath $package.FullName -Destination (Join-Path $ShippingDir $package.Name) -Force

--- a/eng/scripts/stage-native-cli-tool-packages.ps1
+++ b/eng/scripts/stage-native-cli-tool-packages.ps1
@@ -89,6 +89,8 @@ function Get-ClassifiedNuGetPackages {
 }
 
 function Get-ClassifiedNpmPackages {
+  # Npm packages are additive to the native CLI nupkgs. If older builds only
+  # downloaded nupkgs, staging should continue and emit a warning below.
   $packages = @(Get-ChildItem -Path $DownloadRoot -Filter "$NpmPackageFilePrefix*.tgz" -File -Recurse |
     Sort-Object FullName)
   $escapedPrefix = [System.Text.RegularExpressions.Regex]::Escape($NpmPackageFilePrefix)
@@ -139,6 +141,8 @@ function Get-PackagesToStage {
     throw "Expected exactly one canonical $PointerPackageDescription pointer package from $CanonicalPointerArtifactName, but found $($canonicalPointerPackages.Count): $($canonicalPointerPackages.File.FullName -join ', ')"
   }
 
+  # Pointer packages are produced for every RID build. Stage exactly one
+  # canonical pointer package and all RID-specific packages.
   $skippedPointerPackages = @($ClassifiedPackages | Where-Object { $_.IsPointerPackage -and $_.ArtifactName -ne $CanonicalPointerArtifactName })
   foreach ($package in $skippedPointerPackages) {
     Write-Host "Skipping non-canonical $PointerPackageDescription pointer package from $($package.ArtifactName): $($package.File.FullName)"

--- a/eng/scripts/verify-cli-npm-package.ps1
+++ b/eng/scripts/verify-cli-npm-package.ps1
@@ -1,0 +1,216 @@
+param(
+  [Parameter(Mandatory = $true)]
+  [string]$PackagesDir,
+
+  [Parameter(Mandatory = $true)]
+  [string]$Rid,
+
+  [string]$ArchivePath,
+
+  [string]$PackageName = '@microsoft/aspire-cli'
+)
+
+$ErrorActionPreference = 'Stop'
+
+function Write-Step([string]$Message) {
+  Write-Host "[verify-cli-npm-package] $Message"
+}
+
+function Assert-SinglePackage([object[]]$Packages, [string]$Description) {
+  if (-not $Packages -or $Packages.Count -eq 0) {
+    throw "Could not find $Description."
+  }
+
+  if ($Packages.Count -gt 1) {
+    throw "Found multiple packages for ${Description}: $($Packages.Name -join ', ')"
+  }
+
+  return $Packages[0]
+}
+
+function Expand-Tgz([string]$PackagePath, [string]$Destination) {
+  New-Item -ItemType Directory -Path $Destination -Force | Out-Null
+  tar -xzf $PackagePath -C $Destination
+  if ($LASTEXITCODE -ne 0) {
+    throw "Failed to extract $PackagePath."
+  }
+}
+
+function Expand-CliArchive([string]$Archive, [string]$Destination) {
+  New-Item -ItemType Directory -Path $Destination -Force | Out-Null
+
+  if ($Archive.EndsWith('.zip', [System.StringComparison]::OrdinalIgnoreCase)) {
+    Add-Type -AssemblyName System.IO.Compression.FileSystem
+    [System.IO.Compression.ZipFile]::ExtractToDirectory($Archive, $Destination)
+    return
+  }
+
+  if ($Archive.EndsWith('.tar.gz', [System.StringComparison]::OrdinalIgnoreCase)) {
+    tar -xzf $Archive -C $Destination
+    if ($LASTEXITCODE -ne 0) {
+      throw "Failed to extract CLI archive $Archive."
+    }
+    return
+  }
+
+  throw "Unsupported archive format: $Archive (expected .zip or .tar.gz)."
+}
+
+function Test-FileContentEqual([string]$ExpectedPath, [string]$ActualPath) {
+  $expected = Get-Item -LiteralPath $ExpectedPath
+  $actual = Get-Item -LiteralPath $ActualPath
+  if ($expected.Length -ne $actual.Length) {
+    return $false
+  }
+
+  $expectedStream = [System.IO.File]::OpenRead($expected.FullName)
+  $actualStream = [System.IO.File]::OpenRead($actual.FullName)
+  try {
+    $expectedBuffer = [byte[]]::new(1024 * 1024)
+    $actualBuffer = [byte[]]::new(1024 * 1024)
+
+    while ($true) {
+      $expectedRead = $expectedStream.Read($expectedBuffer, 0, $expectedBuffer.Length)
+      $actualRead = $actualStream.Read($actualBuffer, 0, $actualBuffer.Length)
+
+      if ($expectedRead -ne $actualRead) {
+        return $false
+      }
+
+      if ($expectedRead -eq 0) {
+        return $true
+      }
+
+      for ($i = 0; $i -lt $expectedRead; $i++) {
+        if ($expectedBuffer[$i] -ne $actualBuffer[$i]) {
+          return $false
+        }
+      }
+    }
+  }
+  finally {
+    $expectedStream.Dispose()
+    $actualStream.Dispose()
+  }
+}
+
+function Get-NpmPackageFilePrefix([string]$NpmPackageName) {
+  return $NpmPackageName.TrimStart('@').Replace('/', '-')
+}
+
+$effectiveDir = if (Test-Path (Join-Path $PackagesDir 'Shipping')) {
+  Join-Path $PackagesDir 'Shipping'
+} else {
+  $PackagesDir
+}
+
+Write-Step "PackagesDir: $effectiveDir"
+Write-Step "RID: $Rid"
+
+if ($ArchivePath) {
+  if (-not (Test-Path -LiteralPath $ArchivePath)) {
+    throw "ArchivePath does not exist: $ArchivePath"
+  }
+
+  $ArchivePath = (Resolve-Path -LiteralPath $ArchivePath).Path
+  Write-Step "Archive: $ArchivePath"
+}
+
+$packageFilePrefix = Get-NpmPackageFilePrefix $PackageName
+$ridPackage = Assert-SinglePackage `
+  (Get-ChildItem -Path $effectiveDir -Filter "$packageFilePrefix-$Rid-*.tgz" -ErrorAction SilentlyContinue) `
+  "RID-specific npm package for $Rid"
+$pointerPackage = Assert-SinglePackage `
+  (Get-ChildItem -Path $effectiveDir -Filter "$packageFilePrefix-*.tgz" -ErrorAction SilentlyContinue |
+    Where-Object { $_.Name -notmatch "^$([System.Text.RegularExpressions.Regex]::Escape($packageFilePrefix))-(win|linux|linux-musl|osx)-(x64|arm64)-" }) `
+  'Aspire CLI npm pointer package'
+
+Write-Step "RID package: $($ridPackage.Name)"
+Write-Step "Pointer package: $($pointerPackage.Name)"
+
+$root = Join-Path ([System.IO.Path]::GetTempPath()) "aspire-cli-npm-package-$([System.IO.Path]::GetRandomFileName())"
+$ridExtract = Join-Path $root 'rid'
+$pointerExtract = Join-Path $root 'pointer'
+$archiveExtract = Join-Path $root 'archive'
+
+try {
+  Expand-Tgz $ridPackage.FullName $ridExtract
+  Expand-Tgz $pointerPackage.FullName $pointerExtract
+
+  $binaryName = if ($Rid -like 'win-*') { 'aspire.exe' } else { 'aspire' }
+  $binaryPath = Join-Path $ridExtract "package/bin/$binaryName"
+  if (-not (Test-Path -LiteralPath $binaryPath)) {
+    throw "Could not find expected native binary at package/bin/$binaryName in $($ridPackage.Name)."
+  }
+
+  if ($ArchivePath) {
+    Expand-CliArchive $ArchivePath $archiveExtract
+    $archiveBinaryPath = Join-Path $archiveExtract $binaryName
+    if (-not (Test-Path -LiteralPath $archiveBinaryPath)) {
+      throw "Could not find $binaryName in CLI archive $ArchivePath."
+    }
+
+    if (-not (Test-FileContentEqual $archiveBinaryPath $binaryPath)) {
+      $archiveBinary = Get-Item -LiteralPath $archiveBinaryPath
+      $npmBinary = Get-Item -LiteralPath $binaryPath
+      throw "RID npm package binary does not match archive binary '$($archiveBinary.Name)'. Archive size: $($archiveBinary.Length) bytes; npm package size: $($npmBinary.Length) bytes."
+    }
+
+    Write-Step "RID package binary matches CLI archive binary."
+  }
+
+  $pointerPackageJsonPath = Join-Path $pointerExtract 'package/package.json'
+  if (-not (Test-Path -LiteralPath $pointerPackageJsonPath)) {
+    throw "Pointer package $($pointerPackage.Name) is missing package.json."
+  }
+
+  $pointerPackageJson = Get-Content -Path $pointerPackageJsonPath -Raw | ConvertFrom-Json
+  $expectedRidPackageName = "$PackageName-$Rid"
+  if ($pointerPackageJson.name -ne $PackageName) {
+    throw "Pointer package name mismatch. Expected '$PackageName', got '$($pointerPackageJson.name)'."
+  }
+
+  if (-not $pointerPackageJson.bin -or $pointerPackageJson.bin.aspire -ne 'bin/aspire.js') {
+    throw "Pointer package must expose the aspire bin at bin/aspire.js."
+  }
+
+  if (-not (Test-Path -LiteralPath (Join-Path $pointerExtract 'package/bin/aspire.js'))) {
+    throw "Pointer package is missing bin/aspire.js."
+  }
+
+  $packageMapPath = Join-Path $pointerExtract 'package/bin/aspire-package-map.json'
+  if (-not (Test-Path -LiteralPath $packageMapPath)) {
+    throw "Pointer package is missing bin/aspire-package-map.json."
+  }
+
+  $packageMap = Get-Content -Path $packageMapPath -Raw | ConvertFrom-Json
+  if ($packageMap.$Rid -ne $expectedRidPackageName) {
+    throw "Pointer package map does not reference $expectedRidPackageName for $Rid."
+  }
+
+  $optionalDependencyVersion = $pointerPackageJson.optionalDependencies.$expectedRidPackageName
+  if ($optionalDependencyVersion -ne $pointerPackageJson.version) {
+    throw "Pointer package optionalDependencies does not reference $expectedRidPackageName at version $($pointerPackageJson.version)."
+  }
+
+  $ridPackageJsonPath = Join-Path $ridExtract 'package/package.json'
+  if (-not (Test-Path -LiteralPath $ridPackageJsonPath)) {
+    throw "RID package $($ridPackage.Name) is missing package.json."
+  }
+
+  $ridPackageJson = Get-Content -Path $ridPackageJsonPath -Raw | ConvertFrom-Json
+  if ($ridPackageJson.name -ne $expectedRidPackageName) {
+    throw "RID package name mismatch. Expected '$expectedRidPackageName', got '$($ridPackageJson.name)'."
+  }
+
+  if ($ridPackageJson.version -ne $pointerPackageJson.version) {
+    throw "RID package version '$($ridPackageJson.version)' does not match pointer package version '$($pointerPackageJson.version)'."
+  }
+
+  Write-Step "CLI npm package verification passed."
+}
+finally {
+  if (Test-Path $root) {
+    Remove-Item -Path $root -Recurse -Force
+  }
+}

--- a/eng/scripts/verify-cli-npm-package.ps1
+++ b/eng/scripts/verify-cli-npm-package.ps1
@@ -116,6 +116,8 @@ if ($ArchivePath) {
   Write-Step "Archive: $ArchivePath"
 }
 
+# npm pack flattens scoped package names into tarball file names, e.g.
+# @microsoft/aspire-cli -> microsoft-aspire-cli-1.0.0.tgz.
 $packageFilePrefix = Get-NpmPackageFilePrefix $PackageName
 $ridPackage = Assert-SinglePackage `
   (Get-ChildItem -Path $effectiveDir -Filter "$packageFilePrefix-$Rid-*.tgz" -ErrorAction SilentlyContinue) `
@@ -150,6 +152,8 @@ try {
       throw "Could not find $binaryName in CLI archive $ArchivePath."
     }
 
+    # The signed native archive remains the canonical payload. The npm RID
+    # tarball must contain the exact same executable bytes.
     if (-not (Test-FileContentEqual $archiveBinaryPath $binaryPath)) {
       $archiveBinary = Get-Item -LiteralPath $archiveBinaryPath
       $npmBinary = Get-Item -LiteralPath $binaryPath
@@ -183,6 +187,8 @@ try {
     throw "Pointer package is missing bin/aspire-package-map.json."
   }
 
+  # The launcher depends on this generated map to resolve the selected RID
+  # package without hardcoding the package scope/name.
   $packageMap = Get-Content -Path $packageMapPath -Raw | ConvertFrom-Json
   if ($packageMap.$Rid -ne $expectedRidPackageName) {
     throw "Pointer package map does not reference $expectedRidPackageName for $Rid."

--- a/tests/Infrastructure.Tests/PowerShellScripts/StageNativeCliToolPackagesTests.cs
+++ b/tests/Infrastructure.Tests/PowerShellScripts/StageNativeCliToolPackagesTests.cs
@@ -70,6 +70,36 @@ public sealed class StageNativeCliToolPackagesTests : IDisposable
 
     [Fact]
     [RequiresTools(["pwsh"])]
+    public async Task StagesNpmPackagesWhenPresent()
+    {
+        var downloadRoot = CreateDownloadRoot();
+        var shippingDir = CreateShippingDir();
+
+        CreateNativeArchivePackages(downloadRoot, "win-x64");
+        CreateNativeArchivePackage(downloadRoot, "linux-x64", $"Aspire.Cli.linux-x64.{PackageVersion}.nupkg");
+        CreateNativeArchiveNpmPackages(downloadRoot, "win-x64");
+        CreateNativeArchiveNpmPackages(downloadRoot, "linux-x64");
+
+        var result = await RunScript(downloadRoot, shippingDir);
+
+        result.EnsureSuccessful();
+
+        var stagedPackageNames = GetStagedPackageNames(shippingDir);
+        Assert.Equal(
+            [
+                $"Aspire.Cli.{PackageVersion}.nupkg",
+                $"Aspire.Cli.linux-x64.{PackageVersion}.nupkg",
+                $"Aspire.Cli.win-x64.{PackageVersion}.nupkg",
+                $"microsoft-aspire-cli-{PackageVersion}.tgz",
+                $"microsoft-aspire-cli-linux-x64-{PackageVersion}.tgz",
+                $"microsoft-aspire-cli-win-x64-{PackageVersion}.tgz"
+            ],
+            stagedPackageNames);
+        Assert.Contains("Skipping non-canonical Aspire CLI npm pointer package", result.Output);
+    }
+
+    [Fact]
+    [RequiresTools(["pwsh"])]
     public async Task FailsWhenCanonicalPointerPackageIsMissing()
     {
         var downloadRoot = CreateDownloadRoot();
@@ -268,6 +298,12 @@ public sealed class StageNativeCliToolPackagesTests : IDisposable
         CreateNativeArchivePackage(downloadRoot, rid, $"Aspire.Cli.{rid}.{PackageVersion}.nupkg");
     }
 
+    private static void CreateNativeArchiveNpmPackages(string downloadRoot, string rid)
+    {
+        CreateNativeArchivePackage(downloadRoot, rid, $"microsoft-aspire-cli-{PackageVersion}.tgz");
+        CreateNativeArchivePackage(downloadRoot, rid, $"microsoft-aspire-cli-{rid}-{PackageVersion}.tgz");
+    }
+
     private static void CreateNativeArchivePackage(string downloadRoot, string rid, string packageName)
     {
         CreatePackage(downloadRoot, $"native_archives_{rid.Replace('-', '_')}", "Release", "Shipping", packageName);
@@ -282,7 +318,7 @@ public sealed class StageNativeCliToolPackagesTests : IDisposable
 
     private static string[] GetStagedPackageNames(string shippingDir)
     {
-        return Directory.GetFiles(shippingDir, "Aspire.Cli*.nupkg")
+        return Directory.GetFiles(shippingDir)
             .Select(Path.GetFileName)
             .Order(StringComparer.Ordinal)
             .ToArray()!;


### PR DESCRIPTION
## Description

This PR prototypes npm distribution for the Aspire CLI so the native CLI can be installed through common npm workflows while reusing the existing signed native archive pipeline.

It adds a top-level `@microsoft/aspire-cli` package with a JavaScript launcher plus RID-specific optional native packages. The launcher resolves the matching RID package, copies the native binary to a writable `~/.aspire/npm/<version>/<rid>/bin` cache, and runs it from there so the CLI's first-run self-extraction avoids `node_modules`, package stores, and other read-only install locations.

The native package build now packs npm tarballs beside the dotnet tool packages, verifies that the RID tarball payload matches the native archive, and stages/uploads the `.tgz` artifacts through the native CLI package flows. Npm publication and CLI-side npm self-update integration are intentionally left for follow-up.

Fixes # (issue)

## Checklist

- Is this feature complete?
  - [ ] Yes. Ready to ship.
  - [x] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to `aspire.dev` issue:
      - [New issue](https://github.com/microsoft/aspire.dev/issues/new)
  - [x] No