### PR TITLE
Add AI Agents dialog to dashboard header

### DIFF
--- a/src/Aspire.Dashboard/Components/Dialogs/AIAgentsDialog.razor
+++ b/src/Aspire.Dashboard/Components/Dialogs/AIAgentsDialog.razor
@@ -1,0 +1,16 @@
+﻿@using Aspire.Dashboard.Resources
+
+<FluentDialogHeader ShowDismiss="true">
+    <div class="dialog-title-grid">
+        <FluentIcon Value="@(new Icons.Regular.Size24.BotSparkle())" Style="grid-area: dialog-icon; align-self: center;" />
+        <FluentLabel Typo="Typography.PaneHeader" Class="col-long-content" Style="grid-area: dialog-title;">
+            @Loc[nameof(Dialogs.AIAgentsDialogTitle)]
+        </FluentLabel>
+    </div>
+</FluentDialogHeader>
+
+<FluentDialogBody Style="overflow-x: hidden">
+    <div class="markdown-content">
+        <MarkdownRenderer Markdown="@Description" MarkdownProcessor="@GetMarkdownProcessor()" SuppressParagraphOnNewLines="false" />
+    </div>
+</FluentDialogBody>

--- a/src/Aspire.Dashboard/Components/Dialogs/AIAgentsDialog.razor.cs
+++ b/src/Aspire.Dashboard/Components/Dialogs/AIAgentsDialog.razor.cs
@@ -1,0 +1,68 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Globalization;
+using Aspire.Dashboard.Configuration;
+using Aspire.Dashboard.Model.Markdown;
+using Microsoft.AspNetCore.Components;
+using Microsoft.Extensions.Localization;
+using Microsoft.Extensions.Options;
+using Microsoft.FluentUI.AspNetCore.Components;
+
+using DialogsLoc = Aspire.Dashboard.Resources.Dialogs;
+
+namespace Aspire.Dashboard.Components.Dialogs;
+
+public partial class AIAgentsDialog : IDialogContentComponent
+{
+    private MarkdownProcessor? _markdownProcessor;
+
+    [Inject]
+    public required IStringLocalizer<DialogsLoc> Loc { get; init; }
+
+    [Inject]
+    public required IStringLocalizer<Resources.ControlsStrings> ControlsStringsLoc { get; init; }
+
+    [Inject]
+    public required IDashboardClient DashboardClient { get; init; }
+
+    [Inject]
+    public required IOptionsMonitor<DashboardOptions> Options { get; init; }
+
+    private const string AppHostLearnMoreUrl = "https://aspire.dev/get-started/ai-coding-agents/";
+    private const string StandaloneLearnMoreUrl = "https://aspire.dev/dashboard/ai-coding-agents/";
+
+    private string Description => DashboardClient.IsEnabled
+        ? string.Format(CultureInfo.CurrentCulture, Loc[nameof(DialogsLoc.AIAgentsDialogAppHostDescription)], AppHostLearnMoreUrl)
+        : string.Format(CultureInfo.CurrentCulture, Loc[nameof(DialogsLoc.AIAgentsDialogStandaloneDescription)], GetDashboardUrl(), StandaloneLearnMoreUrl);
+
+    private string GetDashboardUrl()
+    {
+        var options = Options.CurrentValue;
+        var endpointAddresses = options.Frontend.GetEndpointAddresses();
+        var baseUrl = options.Frontend.PublicUrl
+            ?? (endpointAddresses.Count > 0 ? endpointAddresses[0].ToString() : null);
+
+        if (baseUrl is null)
+        {
+            return "http://localhost:18888";
+        }
+
+        // Trim trailing slash for consistent URL building.
+        baseUrl = baseUrl.TrimEnd('/');
+
+        if (options.Api.AuthMode is ApiAuthMode.ApiKey &&
+            options.Frontend.AuthMode is FrontendAuthMode.BrowserToken &&
+            options.Frontend.BrowserToken is { } token)
+        {
+            return $"{baseUrl}/login?t={token}";
+        }
+
+        return baseUrl;
+    }
+
+    private MarkdownProcessor GetMarkdownProcessor()
+    {
+        return _markdownProcessor ??= new MarkdownProcessor(ControlsStringsLoc, safeUrlSchemes: MarkdownHelpers.SafeUrlSchemes, extensions: []);
+    }
+}

--- a/src/Aspire.Dashboard/Components/Dialogs/AIAgentsDialog.razor.cs
+++ b/src/Aspire.Dashboard/Components/Dialogs/AIAgentsDialog.razor.cs
@@ -30,8 +30,8 @@ public partial class AIAgentsDialog : IDialogContentComponent
     [Inject]
     public required IOptionsMonitor<DashboardOptions> Options { get; init; }
 
-    private const string AppHostLearnMoreUrl = "https://aspire.dev/get-started/ai-coding-agents/";
-    private const string StandaloneLearnMoreUrl = "https://aspire.dev/dashboard/ai-coding-agents/";
+    private const string AppHostLearnMoreUrl = "https://aka.ms/aspire/ai-agents-apphost";
+    private const string StandaloneLearnMoreUrl = "https://aka.ms/aspire/dashboard-ai-standalone";
 
     private string Description => DashboardClient.IsEnabled
         ? string.Format(CultureInfo.CurrentCulture, Loc[nameof(DialogsLoc.AIAgentsDialogAppHostDescription)], AppHostLearnMoreUrl)

--- a/src/Aspire.Dashboard/Components/Dialogs/AIAgentsDialog.razor.cs
+++ b/src/Aspire.Dashboard/Components/Dialogs/AIAgentsDialog.razor.cs
@@ -3,6 +3,7 @@
 
 using System.Globalization;
 using Aspire.Dashboard.Configuration;
+using Aspire.Dashboard.Model.Assistant;
 using Aspire.Dashboard.Model.Markdown;
 using Microsoft.AspNetCore.Components;
 using Microsoft.Extensions.Localization;
@@ -39,9 +40,7 @@ public partial class AIAgentsDialog : IDialogContentComponent
     private string GetDashboardUrl()
     {
         var options = Options.CurrentValue;
-        var endpointAddresses = options.Frontend.GetEndpointAddresses();
-        var baseUrl = options.Frontend.PublicUrl
-            ?? (endpointAddresses.Count > 0 ? endpointAddresses[0].ToString() : null);
+        var baseUrl = AIHelpers.GetDashboardUrl(options);
 
         if (baseUrl is null)
         {

--- a/src/Aspire.Dashboard/Components/Layout/MainLayout.razor
+++ b/src/Aspire.Dashboard/Components/Layout/MainLayout.razor
@@ -33,6 +33,14 @@
                           Title="@Loc[nameof(Layout.MainLayoutAspireDashboardHelpLink)]" aria-label="@Loc[nameof(Layout.MainLayoutAspireDashboardHelpLink)]">
                 <FluentIcon Value="@(new Icons.Regular.Size24.QuestionCircle())" Color="Color.Neutral"/>
             </FluentButton>
+            @if (Options.CurrentValue.UI.DisableAgentHelp != true)
+            {
+                <FluentButton Class="header-button"
+                              Appearance="Appearance.Stealth" OnClick="@LaunchAIAgentsAsync"
+                              Title="@Loc[nameof(Layout.MainLayoutLaunchAIAgents)]" aria-label="@Loc[nameof(Layout.MainLayoutLaunchAIAgents)]">
+                    <FluentIcon Value="@(new Icons.Regular.Size24.BotSparkle())" Color="Color.Neutral"/>
+                </FluentButton>
+            }
             @if (AIContextProvider.Enabled)
             {
                 <FluentButton Class="@("header-button" + ((AIContextProvider.AssistantChatViewModel is {} vm && AIContextProvider.ShowAssistantSidebarDialog) ? " header-button-selected" : ""))"
@@ -79,6 +87,8 @@
             IsAIEnabled="@AIContextProvider.Enabled"
             CloseNavMenu="@CloseMobileNavMenu"
             LaunchHelpAsync="@LaunchHelpAsync"
+            LaunchAIAgentsAsync="@LaunchAIAgentsAsync"
+            IsAgentHelpEnabled="@(Options.CurrentValue.UI.DisableAgentHelp != true)"
             LaunchAIAssistantAsync="@LaunchAssistantAsync"
             LaunchNotificationsAsync="@LaunchNotificationsAsync"
             LaunchSettingsAsync="@LaunchSettingsAsync" />

--- a/src/Aspire.Dashboard/Components/Layout/MainLayout.razor.cs
+++ b/src/Aspire.Dashboard/Components/Layout/MainLayout.razor.cs
@@ -31,6 +31,7 @@ public partial class MainLayout : IGlobalKeydownListener, IAsyncDisposable
     private const string SettingsDialogId = "SettingsDialog";
     private const string HelpDialogId = "HelpDialog";
     private const string NotificationsDialogId = "NotificationsDialog";
+    private const string AIAgentsDialogId = "AIAgentsDialog";
 
     [Inject]
     public required ThemeManager ThemeManager { get; init; }
@@ -245,6 +246,36 @@ public partial class MainLayout : IGlobalKeydownListener, IAsyncDisposable
     private void HandleDialogClose(DialogInstance dialogResult)
     {
         _openPageDialog = null;
+    }
+
+    public async Task LaunchAIAgentsAsync()
+    {
+        DialogParameters parameters = new()
+        {
+            Title = Loc[nameof(Resources.Layout.MainLayoutLaunchAIAgents)],
+            PrimaryAction = Loc[nameof(Resources.Layout.MainLayoutSettingsDialogClose)],
+            PrimaryActionEnabled = true,
+            SecondaryAction = null,
+            TrapFocus = true,
+            Modal = true,
+            Alignment = HorizontalAlignment.Center,
+            Width = "700px",
+            Height = "auto",
+            Id = AIAgentsDialogId,
+            OnDialogClosing = EventCallback.Factory.Create<DialogInstance>(this, HandleDialogClose)
+        };
+
+        if (_openPageDialog is not null)
+        {
+            if (Equals(_openPageDialog.Id, AIAgentsDialogId) && !_openPageDialog.Result.IsCompleted)
+            {
+                return;
+            }
+
+            await _openPageDialog.CloseAsync();
+        }
+
+        _openPageDialog = await DialogService.ShowDialogAsync<AIAgentsDialog>(parameters).ConfigureAwait(true);
     }
 
     public async Task LaunchSettingsAsync()

--- a/src/Aspire.Dashboard/Components/Layout/MobileNavMenu.razor
+++ b/src/Aspire.Dashboard/Components/Layout/MobileNavMenu.razor
@@ -39,6 +39,12 @@
     public required Func<Task> LaunchHelpAsync { get; set; }
 
     [Parameter, EditorRequired]
+    public required Func<Task> LaunchAIAgentsAsync { get; set; }
+
+    [Parameter, EditorRequired]
+    public required bool IsAgentHelpEnabled { get; set; }
+
+    [Parameter, EditorRequired]
     public required Func<Task> LaunchAIAssistantAsync { get; set; }
 
     [Parameter, EditorRequired]

--- a/src/Aspire.Dashboard/Components/Layout/MobileNavMenu.razor.cs
+++ b/src/Aspire.Dashboard/Components/Layout/MobileNavMenu.razor.cs
@@ -89,6 +89,15 @@ public partial class MobileNavMenu : ComponentBase
             new Icons.Regular.Size24.QuestionCircle()
         );
 
+        if (IsAgentHelpEnabled)
+        {
+            yield return new MobileNavMenuEntry(
+                Loc[nameof(Resources.Layout.MainLayoutLaunchAIAgents)],
+                LaunchAIAgentsAsync,
+                new Icons.Regular.Size24.BotSparkle()
+            );
+        }
+
         if (IsAIEnabled)
         {
             yield return new MobileNavMenuEntry(

--- a/src/Aspire.Dashboard/Configuration/DashboardOptions.cs
+++ b/src/Aspire.Dashboard/Configuration/DashboardOptions.cs
@@ -309,6 +309,7 @@ public sealed class UIOptions
 {
     public bool? DisableResourceGraph { get; set; }
     public bool? DisableImport { get; set; }
+    public bool? DisableAgentHelp { get; set; }
 }
 
 // Don't set values after validating/parsing options.

--- a/src/Aspire.Dashboard/Resources/Dialogs.Designer.cs
+++ b/src/Aspire.Dashboard/Resources/Dialogs.Designer.cs
@@ -1193,5 +1193,32 @@ namespace Aspire.Dashboard.Resources {
                 return ResourceManager.GetString("NotificationEntryDismiss", resourceCulture);
             }
         }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to AI Agents.
+        /// </summary>
+        public static string AIAgentsDialogTitle {
+            get {
+                return ResourceManager.GetString("AIAgentsDialogTitle", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Build, debug, and profile apps using AI agents and Aspire....
+        /// </summary>
+        public static string AIAgentsDialogStandaloneDescription {
+            get {
+                return ResourceManager.GetString("AIAgentsDialogStandaloneDescription", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Build, debug, and profile apps using AI agents and Aspire....
+        /// </summary>
+        public static string AIAgentsDialogAppHostDescription {
+            get {
+                return ResourceManager.GetString("AIAgentsDialogAppHostDescription", resourceCulture);
+            }
+        }
     }
 }

--- a/src/Aspire.Dashboard/Resources/Dialogs.resx
+++ b/src/Aspire.Dashboard/Resources/Dialogs.resx
@@ -510,18 +510,12 @@
   <data name="AIAgentsDialogStandaloneDescription" xml:space="preserve">
     <value>Build, debug, and profile apps using AI agents and Aspire 🚀
 
-The structured logs and distributed traces in the dashboard are available to AI agents via the Aspire CLI and MCP server. This gives agents deep observability into your app, to help them diagnose issues and verify fixes.
+The structured logs and distributed traces in the dashboard are available to AI agents via the Aspire CLI. This gives agents deep observability into your app, to help them diagnose issues and verify fixes.
 
 Use Aspire CLI commands to get telemetry data in your terminal:
 
 ```bash
 aspire otel logs --dashboard-url {0}
-```
-
-Or start the Aspire MCP server:
-
-```bash
-aspire agent mcp --dashboard-url {0}
 ```
 
 For more information about using AI agents with the dashboard, such as setting up skills, see [Standalone dashboard and AI coding agents]({1}).</value>
@@ -530,7 +524,7 @@ For more information about using AI agents with the dashboard, such as setting u
   <data name="AIAgentsDialogAppHostDescription" xml:space="preserve">
     <value>Build, debug, and profile apps using AI agents and Aspire 🚀
 
-The structured logs, distributed traces, and resource status in this dashboard are available to AI agents via the Aspire CLI and MCP server. This gives agents deep observability into your app, to help them diagnose issues and verify fixes.
+The structured logs, distributed traces, and resource status in this dashboard are available to AI agents via the Aspire CLI. This gives agents deep observability into your app, to help them diagnose issues and verify fixes.
 
 Get started by running this command in your project:
 
@@ -538,7 +532,7 @@ Get started by running this command in your project:
 aspire agent init
 ```
 
-This configures skill files for your AI assistant. The skill files tell the agent how to use Aspire CLI commands such as `aspire otel logs`, `aspire otel traces`, and `aspire agent mcp`.
+This configures skill files for your AI assistant. The skill files tell the agent how to use Aspire CLI commands such as `aspire otel logs` and `aspire otel traces`.
 
 Once connected, agents can start your app, check resource health, fetch logs and traces, and more.
 

--- a/src/Aspire.Dashboard/Resources/Dialogs.resx
+++ b/src/Aspire.Dashboard/Resources/Dialogs.resx
@@ -504,4 +504,44 @@
   <data name="NotificationEntryDismiss" xml:space="preserve">
     <value>Dismiss notification</value>
   </data>
+  <data name="AIAgentsDialogTitle" xml:space="preserve">
+    <value>AI agents</value>
+  </data>
+  <data name="AIAgentsDialogStandaloneDescription" xml:space="preserve">
+    <value>Build, debug, and profile apps using AI agents and Aspire 🚀
+
+The structured logs and distributed traces in the dashboard are available to AI agents via the Aspire CLI and MCP server. This gives agents deep observability into your app, to help them diagnose issues and verify fixes.
+
+Use Aspire CLI commands to get telemetry data in your terminal:
+
+```bash
+aspire otel logs --dashboard-url {0}
+```
+
+Or start the Aspire MCP server:
+
+```bash
+aspire agent mcp --dashboard-url {0}
+```
+
+For more information about using AI agents with the dashboard, such as setting up skills, see [Standalone dashboard and AI coding agents]({1}).</value>
+    <comment>{0} is the dashboard URL, {1} is the learn more URL</comment>
+  </data>
+  <data name="AIAgentsDialogAppHostDescription" xml:space="preserve">
+    <value>Build, debug, and profile apps using AI agents and Aspire 🚀
+
+The structured logs, distributed traces, and resource status in this dashboard are available to AI agents via the Aspire CLI and MCP server. This gives agents deep observability into your app, to help them diagnose issues and verify fixes.
+
+Get started by running this command in your project:
+
+```bash
+aspire agent init
+```
+
+This configures skill files for your AI assistant. The skill files tell the agent how to use Aspire CLI commands such as `aspire otel logs`, `aspire otel traces`, and `aspire agent mcp`.
+
+Once connected, agents can start your app, check resource health, fetch logs and traces, and more.
+
+For more information about using AI agents with Aspire, such as setting up skills, see [AI coding agents]({0}).</value>
+  </data>
 </root>

--- a/src/Aspire.Dashboard/Resources/Dialogs.resx
+++ b/src/Aspire.Dashboard/Resources/Dialogs.resx
@@ -518,6 +518,11 @@ Use Aspire CLI commands to get telemetry data in your terminal:
 aspire otel logs --dashboard-url {0}
 ```
 
+- [`aspire otel logs`](https://aspire.dev/reference/cli/commands/aspire-otel/) — View structured logs
+- [`aspire otel traces`](https://aspire.dev/reference/cli/commands/aspire-otel/) — View distributed traces
+- [`aspire otel spans`](https://aspire.dev/reference/cli/commands/aspire-otel/) — View trace spans
+- [`aspire export`](https://aspire.dev/reference/cli/commands/aspire-export/) — Export telemetry and resource data to a zip file
+
 For more information about using AI agents with the dashboard, such as setting up skills, see [Standalone dashboard and AI coding agents]({1}).</value>
     <comment>{0} is the dashboard URL, {1} is the learn more URL</comment>
   </data>
@@ -532,7 +537,7 @@ Get started by running this command in your project:
 aspire agent init
 ```
 
-This configures skill files for your AI assistant. The skill files tell the agent how to use Aspire CLI commands such as `aspire otel logs` and `aspire otel traces`.
+This configures skill files for your AI assistant. The skill files tell the agent how to use Aspire CLI commands such as [`aspire otel logs`](https://aspire.dev/reference/cli/commands/aspire-otel/) and [`aspire otel traces`](https://aspire.dev/reference/cli/commands/aspire-otel/).
 
 Once connected, agents can start your app, check resource health, fetch logs and traces, and more.
 

--- a/src/Aspire.Dashboard/Resources/Dialogs.resx
+++ b/src/Aspire.Dashboard/Resources/Dialogs.resx
@@ -518,9 +518,9 @@ Use Aspire CLI commands to get telemetry data in your terminal:
 aspire otel logs --dashboard-url {0}
 ```
 
-- [`aspire otel logs`](https://aspire.dev/reference/cli/commands/aspire-otel/) — View structured logs
-- [`aspire otel traces`](https://aspire.dev/reference/cli/commands/aspire-otel/) — View distributed traces
-- [`aspire otel spans`](https://aspire.dev/reference/cli/commands/aspire-otel/) — View trace spans
+- [`aspire otel logs`](https://aspire.dev/reference/cli/commands/aspire-otel-logs/) — View structured logs
+- [`aspire otel traces`](https://aspire.dev/reference/cli/commands/aspire-otel-traces/) — View distributed traces
+- [`aspire otel spans`](https://aspire.dev/reference/cli/commands/aspire-otel-spans/) — View trace spans
 - [`aspire export`](https://aspire.dev/reference/cli/commands/aspire-export/) — Export telemetry and resource data to a zip file
 
 For more information about using AI agents with the dashboard, such as setting up skills, see [Standalone dashboard and AI coding agents]({1}).</value>
@@ -537,7 +537,7 @@ Get started by running this command in your project:
 aspire agent init
 ```
 
-This configures skill files for your AI assistant. The skill files tell the agent how to use Aspire CLI commands such as [`aspire otel logs`](https://aspire.dev/reference/cli/commands/aspire-otel/) and [`aspire otel traces`](https://aspire.dev/reference/cli/commands/aspire-otel/).
+This configures skill files for your AI assistant. The skill files tell the agent how to use Aspire CLI commands such as [`aspire logs`](https://aspire.dev/reference/cli/commands/aspire-logs/) and [`aspire otel traces`](https://aspire.dev/reference/cli/commands/aspire-otel-traces/).
 
 Once connected, agents can start your app, check resource health, fetch logs and traces, and more.
 

--- a/src/Aspire.Dashboard/Resources/Layout.Designer.cs
+++ b/src/Aspire.Dashboard/Resources/Layout.Designer.cs
@@ -275,5 +275,14 @@ namespace Aspire.Dashboard.Resources {
                 return ResourceManager.GetString("ReconnectRetryButtonText", resourceCulture);
             }
         }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to AI Agents.
+        /// </summary>
+        public static string MainLayoutLaunchAIAgents {
+            get {
+                return ResourceManager.GetString("MainLayoutLaunchAIAgents", resourceCulture);
+            }
+        }
     }
 }

--- a/src/Aspire.Dashboard/Resources/Layout.Designer.cs
+++ b/src/Aspire.Dashboard/Resources/Layout.Designer.cs
@@ -277,7 +277,7 @@ namespace Aspire.Dashboard.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to AI Agents.
+        ///   Looks up a localized string similar to AI agents.
         /// </summary>
         public static string MainLayoutLaunchAIAgents {
             get {

--- a/src/Aspire.Dashboard/Resources/Layout.resx
+++ b/src/Aspire.Dashboard/Resources/Layout.resx
@@ -189,4 +189,7 @@
   <data name="MessageUnsecuredEndpointApiBody" xml:space="preserve">
     <value>Untrusted apps can access telemetry data via the API.</value>
   </data>
+  <data name="MainLayoutLaunchAIAgents" xml:space="preserve">
+    <value>AI Agents</value>
+  </data>
 </root>

--- a/src/Aspire.Dashboard/Resources/Layout.resx
+++ b/src/Aspire.Dashboard/Resources/Layout.resx
@@ -190,6 +190,6 @@
     <value>Untrusted apps can access telemetry data via the API.</value>
   </data>
   <data name="MainLayoutLaunchAIAgents" xml:space="preserve">
-    <value>AI Agents</value>
+    <value>AI agents</value>
   </data>
 </root>

--- a/src/Aspire.Dashboard/Resources/xlf/Dialogs.cs.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Dialogs.cs.xlf
@@ -13,7 +13,7 @@ Get started by running this command in your project:
 aspire agent init
 ```
 
-This configures skill files for your AI assistant. The skill files tell the agent how to use Aspire CLI commands such as [`aspire otel logs`](https://aspire.dev/reference/cli/commands/aspire-otel/) and [`aspire otel traces`](https://aspire.dev/reference/cli/commands/aspire-otel/).
+This configures skill files for your AI assistant. The skill files tell the agent how to use Aspire CLI commands such as [`aspire logs`](https://aspire.dev/reference/cli/commands/aspire-logs/) and [`aspire otel traces`](https://aspire.dev/reference/cli/commands/aspire-otel-traces/).
 
 Once connected, agents can start your app, check resource health, fetch logs and traces, and more.
 
@@ -28,7 +28,7 @@ Get started by running this command in your project:
 aspire agent init
 ```
 
-This configures skill files for your AI assistant. The skill files tell the agent how to use Aspire CLI commands such as [`aspire otel logs`](https://aspire.dev/reference/cli/commands/aspire-otel/) and [`aspire otel traces`](https://aspire.dev/reference/cli/commands/aspire-otel/).
+This configures skill files for your AI assistant. The skill files tell the agent how to use Aspire CLI commands such as [`aspire logs`](https://aspire.dev/reference/cli/commands/aspire-logs/) and [`aspire otel traces`](https://aspire.dev/reference/cli/commands/aspire-otel-traces/).
 
 Once connected, agents can start your app, check resource health, fetch logs and traces, and more.
 
@@ -46,9 +46,9 @@ Use Aspire CLI commands to get telemetry data in your terminal:
 aspire otel logs --dashboard-url {0}
 ```
 
-- [`aspire otel logs`](https://aspire.dev/reference/cli/commands/aspire-otel/) — View structured logs
-- [`aspire otel traces`](https://aspire.dev/reference/cli/commands/aspire-otel/) — View distributed traces
-- [`aspire otel spans`](https://aspire.dev/reference/cli/commands/aspire-otel/) — View trace spans
+- [`aspire otel logs`](https://aspire.dev/reference/cli/commands/aspire-otel-logs/) — View structured logs
+- [`aspire otel traces`](https://aspire.dev/reference/cli/commands/aspire-otel-traces/) — View distributed traces
+- [`aspire otel spans`](https://aspire.dev/reference/cli/commands/aspire-otel-spans/) — View trace spans
 - [`aspire export`](https://aspire.dev/reference/cli/commands/aspire-export/) — Export telemetry and resource data to a zip file
 
 For more information about using AI agents with the dashboard, such as setting up skills, see [Standalone dashboard and AI coding agents]({1}).</source>
@@ -62,9 +62,9 @@ Use Aspire CLI commands to get telemetry data in your terminal:
 aspire otel logs --dashboard-url {0}
 ```
 
-- [`aspire otel logs`](https://aspire.dev/reference/cli/commands/aspire-otel/) — View structured logs
-- [`aspire otel traces`](https://aspire.dev/reference/cli/commands/aspire-otel/) — View distributed traces
-- [`aspire otel spans`](https://aspire.dev/reference/cli/commands/aspire-otel/) — View trace spans
+- [`aspire otel logs`](https://aspire.dev/reference/cli/commands/aspire-otel-logs/) — View structured logs
+- [`aspire otel traces`](https://aspire.dev/reference/cli/commands/aspire-otel-traces/) — View distributed traces
+- [`aspire otel spans`](https://aspire.dev/reference/cli/commands/aspire-otel-spans/) — View trace spans
 - [`aspire export`](https://aspire.dev/reference/cli/commands/aspire-export/) — Export telemetry and resource data to a zip file
 
 For more information about using AI agents with the dashboard, such as setting up skills, see [Standalone dashboard and AI coding agents]({1}).</target>

--- a/src/Aspire.Dashboard/Resources/xlf/Dialogs.cs.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Dialogs.cs.xlf
@@ -13,7 +13,7 @@ Get started by running this command in your project:
 aspire agent init
 ```
 
-This configures skill files for your AI assistant. The skill files tell the agent how to use Aspire CLI commands such as `aspire otel logs` and `aspire otel traces`.
+This configures skill files for your AI assistant. The skill files tell the agent how to use Aspire CLI commands such as [`aspire otel logs`](https://aspire.dev/reference/cli/commands/aspire-otel/) and [`aspire otel traces`](https://aspire.dev/reference/cli/commands/aspire-otel/).
 
 Once connected, agents can start your app, check resource health, fetch logs and traces, and more.
 
@@ -28,7 +28,7 @@ Get started by running this command in your project:
 aspire agent init
 ```
 
-This configures skill files for your AI assistant. The skill files tell the agent how to use Aspire CLI commands such as `aspire otel logs` and `aspire otel traces`.
+This configures skill files for your AI assistant. The skill files tell the agent how to use Aspire CLI commands such as [`aspire otel logs`](https://aspire.dev/reference/cli/commands/aspire-otel/) and [`aspire otel traces`](https://aspire.dev/reference/cli/commands/aspire-otel/).
 
 Once connected, agents can start your app, check resource health, fetch logs and traces, and more.
 
@@ -46,6 +46,11 @@ Use Aspire CLI commands to get telemetry data in your terminal:
 aspire otel logs --dashboard-url {0}
 ```
 
+- [`aspire otel logs`](https://aspire.dev/reference/cli/commands/aspire-otel/) — View structured logs
+- [`aspire otel traces`](https://aspire.dev/reference/cli/commands/aspire-otel/) — View distributed traces
+- [`aspire otel spans`](https://aspire.dev/reference/cli/commands/aspire-otel/) — View trace spans
+- [`aspire export`](https://aspire.dev/reference/cli/commands/aspire-export/) — Export telemetry and resource data to a zip file
+
 For more information about using AI agents with the dashboard, such as setting up skills, see [Standalone dashboard and AI coding agents]({1}).</source>
         <target state="new">Build, debug, and profile apps using AI agents and Aspire 🚀
 
@@ -56,6 +61,11 @@ Use Aspire CLI commands to get telemetry data in your terminal:
 ```bash
 aspire otel logs --dashboard-url {0}
 ```
+
+- [`aspire otel logs`](https://aspire.dev/reference/cli/commands/aspire-otel/) — View structured logs
+- [`aspire otel traces`](https://aspire.dev/reference/cli/commands/aspire-otel/) — View distributed traces
+- [`aspire otel spans`](https://aspire.dev/reference/cli/commands/aspire-otel/) — View trace spans
+- [`aspire export`](https://aspire.dev/reference/cli/commands/aspire-export/) — Export telemetry and resource data to a zip file
 
 For more information about using AI agents with the dashboard, such as setting up skills, see [Standalone dashboard and AI coding agents]({1}).</target>
         <note>{0} is the dashboard URL, {1} is the learn more URL</note>

--- a/src/Aspire.Dashboard/Resources/xlf/Dialogs.cs.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Dialogs.cs.xlf
@@ -5,7 +5,7 @@
       <trans-unit id="AIAgentsDialogAppHostDescription">
         <source>Build, debug, and profile apps using AI agents and Aspire 🚀
 
-The structured logs, distributed traces, and resource status in this dashboard are available to AI agents via the Aspire CLI and MCP server. This gives agents deep observability into your app, to help them diagnose issues and verify fixes.
+The structured logs, distributed traces, and resource status in this dashboard are available to AI agents via the Aspire CLI. This gives agents deep observability into your app, to help them diagnose issues and verify fixes.
 
 Get started by running this command in your project:
 
@@ -13,14 +13,14 @@ Get started by running this command in your project:
 aspire agent init
 ```
 
-This configures skill files for your AI assistant. The skill files tell the agent how to use Aspire CLI commands such as `aspire otel logs`, `aspire otel traces`, and `aspire agent mcp`.
+This configures skill files for your AI assistant. The skill files tell the agent how to use Aspire CLI commands such as `aspire otel logs` and `aspire otel traces`.
 
 Once connected, agents can start your app, check resource health, fetch logs and traces, and more.
 
 For more information about using AI agents with Aspire, such as setting up skills, see [AI coding agents]({0}).</source>
         <target state="new">Build, debug, and profile apps using AI agents and Aspire 🚀
 
-The structured logs, distributed traces, and resource status in this dashboard are available to AI agents via the Aspire CLI and MCP server. This gives agents deep observability into your app, to help them diagnose issues and verify fixes.
+The structured logs, distributed traces, and resource status in this dashboard are available to AI agents via the Aspire CLI. This gives agents deep observability into your app, to help them diagnose issues and verify fixes.
 
 Get started by running this command in your project:
 
@@ -28,7 +28,7 @@ Get started by running this command in your project:
 aspire agent init
 ```
 
-This configures skill files for your AI assistant. The skill files tell the agent how to use Aspire CLI commands such as `aspire otel logs`, `aspire otel traces`, and `aspire agent mcp`.
+This configures skill files for your AI assistant. The skill files tell the agent how to use Aspire CLI commands such as `aspire otel logs` and `aspire otel traces`.
 
 Once connected, agents can start your app, check resource health, fetch logs and traces, and more.
 
@@ -38,35 +38,23 @@ For more information about using AI agents with Aspire, such as setting up skill
       <trans-unit id="AIAgentsDialogStandaloneDescription">
         <source>Build, debug, and profile apps using AI agents and Aspire 🚀
 
-The structured logs and distributed traces in the dashboard are available to AI agents via the Aspire CLI and MCP server. This gives agents deep observability into your app, to help them diagnose issues and verify fixes.
+The structured logs and distributed traces in the dashboard are available to AI agents via the Aspire CLI. This gives agents deep observability into your app, to help them diagnose issues and verify fixes.
 
 Use Aspire CLI commands to get telemetry data in your terminal:
 
 ```bash
 aspire otel logs --dashboard-url {0}
-```
-
-Or start the Aspire MCP server:
-
-```bash
-aspire agent mcp --dashboard-url {0}
 ```
 
 For more information about using AI agents with the dashboard, such as setting up skills, see [Standalone dashboard and AI coding agents]({1}).</source>
         <target state="new">Build, debug, and profile apps using AI agents and Aspire 🚀
 
-The structured logs and distributed traces in the dashboard are available to AI agents via the Aspire CLI and MCP server. This gives agents deep observability into your app, to help them diagnose issues and verify fixes.
+The structured logs and distributed traces in the dashboard are available to AI agents via the Aspire CLI. This gives agents deep observability into your app, to help them diagnose issues and verify fixes.
 
 Use Aspire CLI commands to get telemetry data in your terminal:
 
 ```bash
 aspire otel logs --dashboard-url {0}
-```
-
-Or start the Aspire MCP server:
-
-```bash
-aspire agent mcp --dashboard-url {0}
 ```
 
 For more information about using AI agents with the dashboard, such as setting up skills, see [Standalone dashboard and AI coding agents]({1}).</target>

--- a/src/Aspire.Dashboard/Resources/xlf/Dialogs.cs.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Dialogs.cs.xlf
@@ -2,6 +2,81 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="cs" original="../Dialogs.resx">
     <body>
+      <trans-unit id="AIAgentsDialogAppHostDescription">
+        <source>Build, debug, and profile apps using AI agents and Aspire 🚀
+
+The structured logs, distributed traces, and resource status in this dashboard are available to AI agents via the Aspire CLI and MCP server. This gives agents deep observability into your app, to help them diagnose issues and verify fixes.
+
+Get started by running this command in your project:
+
+```bash
+aspire agent init
+```
+
+This configures skill files for your AI assistant. The skill files tell the agent how to use Aspire CLI commands such as `aspire otel logs`, `aspire otel traces`, and `aspire agent mcp`.
+
+Once connected, agents can start your app, check resource health, fetch logs and traces, and more.
+
+For more information about using AI agents with Aspire, such as setting up skills, see [AI coding agents]({0}).</source>
+        <target state="new">Build, debug, and profile apps using AI agents and Aspire 🚀
+
+The structured logs, distributed traces, and resource status in this dashboard are available to AI agents via the Aspire CLI and MCP server. This gives agents deep observability into your app, to help them diagnose issues and verify fixes.
+
+Get started by running this command in your project:
+
+```bash
+aspire agent init
+```
+
+This configures skill files for your AI assistant. The skill files tell the agent how to use Aspire CLI commands such as `aspire otel logs`, `aspire otel traces`, and `aspire agent mcp`.
+
+Once connected, agents can start your app, check resource health, fetch logs and traces, and more.
+
+For more information about using AI agents with Aspire, such as setting up skills, see [AI coding agents]({0}).</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AIAgentsDialogStandaloneDescription">
+        <source>Build, debug, and profile apps using AI agents and Aspire 🚀
+
+The structured logs and distributed traces in the dashboard are available to AI agents via the Aspire CLI and MCP server. This gives agents deep observability into your app, to help them diagnose issues and verify fixes.
+
+Use Aspire CLI commands to get telemetry data in your terminal:
+
+```bash
+aspire otel logs --dashboard-url {0}
+```
+
+Or start the Aspire MCP server:
+
+```bash
+aspire agent mcp --dashboard-url {0}
+```
+
+For more information about using AI agents with the dashboard, such as setting up skills, see [Standalone dashboard and AI coding agents]({1}).</source>
+        <target state="new">Build, debug, and profile apps using AI agents and Aspire 🚀
+
+The structured logs and distributed traces in the dashboard are available to AI agents via the Aspire CLI and MCP server. This gives agents deep observability into your app, to help them diagnose issues and verify fixes.
+
+Use Aspire CLI commands to get telemetry data in your terminal:
+
+```bash
+aspire otel logs --dashboard-url {0}
+```
+
+Or start the Aspire MCP server:
+
+```bash
+aspire agent mcp --dashboard-url {0}
+```
+
+For more information about using AI agents with the dashboard, such as setting up skills, see [Standalone dashboard and AI coding agents]({1}).</target>
+        <note>{0} is the dashboard URL, {1} is the learn more URL</note>
+      </trans-unit>
+      <trans-unit id="AIAgentsDialogTitle">
+        <source>AI agents</source>
+        <target state="new">AI agents</target>
+        <note />
+      </trans-unit>
       <trans-unit id="DialogCloseButtonText">
         <source>Close</source>
         <target state="translated">Zavřít</target>

--- a/src/Aspire.Dashboard/Resources/xlf/Dialogs.de.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Dialogs.de.xlf
@@ -13,7 +13,7 @@ Get started by running this command in your project:
 aspire agent init
 ```
 
-This configures skill files for your AI assistant. The skill files tell the agent how to use Aspire CLI commands such as [`aspire otel logs`](https://aspire.dev/reference/cli/commands/aspire-otel/) and [`aspire otel traces`](https://aspire.dev/reference/cli/commands/aspire-otel/).
+This configures skill files for your AI assistant. The skill files tell the agent how to use Aspire CLI commands such as [`aspire logs`](https://aspire.dev/reference/cli/commands/aspire-logs/) and [`aspire otel traces`](https://aspire.dev/reference/cli/commands/aspire-otel-traces/).
 
 Once connected, agents can start your app, check resource health, fetch logs and traces, and more.
 
@@ -28,7 +28,7 @@ Get started by running this command in your project:
 aspire agent init
 ```
 
-This configures skill files for your AI assistant. The skill files tell the agent how to use Aspire CLI commands such as [`aspire otel logs`](https://aspire.dev/reference/cli/commands/aspire-otel/) and [`aspire otel traces`](https://aspire.dev/reference/cli/commands/aspire-otel/).
+This configures skill files for your AI assistant. The skill files tell the agent how to use Aspire CLI commands such as [`aspire logs`](https://aspire.dev/reference/cli/commands/aspire-logs/) and [`aspire otel traces`](https://aspire.dev/reference/cli/commands/aspire-otel-traces/).
 
 Once connected, agents can start your app, check resource health, fetch logs and traces, and more.
 
@@ -46,9 +46,9 @@ Use Aspire CLI commands to get telemetry data in your terminal:
 aspire otel logs --dashboard-url {0}
 ```
 
-- [`aspire otel logs`](https://aspire.dev/reference/cli/commands/aspire-otel/) — View structured logs
-- [`aspire otel traces`](https://aspire.dev/reference/cli/commands/aspire-otel/) — View distributed traces
-- [`aspire otel spans`](https://aspire.dev/reference/cli/commands/aspire-otel/) — View trace spans
+- [`aspire otel logs`](https://aspire.dev/reference/cli/commands/aspire-otel-logs/) — View structured logs
+- [`aspire otel traces`](https://aspire.dev/reference/cli/commands/aspire-otel-traces/) — View distributed traces
+- [`aspire otel spans`](https://aspire.dev/reference/cli/commands/aspire-otel-spans/) — View trace spans
 - [`aspire export`](https://aspire.dev/reference/cli/commands/aspire-export/) — Export telemetry and resource data to a zip file
 
 For more information about using AI agents with the dashboard, such as setting up skills, see [Standalone dashboard and AI coding agents]({1}).</source>
@@ -62,9 +62,9 @@ Use Aspire CLI commands to get telemetry data in your terminal:
 aspire otel logs --dashboard-url {0}
 ```
 
-- [`aspire otel logs`](https://aspire.dev/reference/cli/commands/aspire-otel/) — View structured logs
-- [`aspire otel traces`](https://aspire.dev/reference/cli/commands/aspire-otel/) — View distributed traces
-- [`aspire otel spans`](https://aspire.dev/reference/cli/commands/aspire-otel/) — View trace spans
+- [`aspire otel logs`](https://aspire.dev/reference/cli/commands/aspire-otel-logs/) — View structured logs
+- [`aspire otel traces`](https://aspire.dev/reference/cli/commands/aspire-otel-traces/) — View distributed traces
+- [`aspire otel spans`](https://aspire.dev/reference/cli/commands/aspire-otel-spans/) — View trace spans
 - [`aspire export`](https://aspire.dev/reference/cli/commands/aspire-export/) — Export telemetry and resource data to a zip file
 
 For more information about using AI agents with the dashboard, such as setting up skills, see [Standalone dashboard and AI coding agents]({1}).</target>

--- a/src/Aspire.Dashboard/Resources/xlf/Dialogs.de.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Dialogs.de.xlf
@@ -13,7 +13,7 @@ Get started by running this command in your project:
 aspire agent init
 ```
 
-This configures skill files for your AI assistant. The skill files tell the agent how to use Aspire CLI commands such as `aspire otel logs` and `aspire otel traces`.
+This configures skill files for your AI assistant. The skill files tell the agent how to use Aspire CLI commands such as [`aspire otel logs`](https://aspire.dev/reference/cli/commands/aspire-otel/) and [`aspire otel traces`](https://aspire.dev/reference/cli/commands/aspire-otel/).
 
 Once connected, agents can start your app, check resource health, fetch logs and traces, and more.
 
@@ -28,7 +28,7 @@ Get started by running this command in your project:
 aspire agent init
 ```
 
-This configures skill files for your AI assistant. The skill files tell the agent how to use Aspire CLI commands such as `aspire otel logs` and `aspire otel traces`.
+This configures skill files for your AI assistant. The skill files tell the agent how to use Aspire CLI commands such as [`aspire otel logs`](https://aspire.dev/reference/cli/commands/aspire-otel/) and [`aspire otel traces`](https://aspire.dev/reference/cli/commands/aspire-otel/).
 
 Once connected, agents can start your app, check resource health, fetch logs and traces, and more.
 
@@ -46,6 +46,11 @@ Use Aspire CLI commands to get telemetry data in your terminal:
 aspire otel logs --dashboard-url {0}
 ```
 
+- [`aspire otel logs`](https://aspire.dev/reference/cli/commands/aspire-otel/) — View structured logs
+- [`aspire otel traces`](https://aspire.dev/reference/cli/commands/aspire-otel/) — View distributed traces
+- [`aspire otel spans`](https://aspire.dev/reference/cli/commands/aspire-otel/) — View trace spans
+- [`aspire export`](https://aspire.dev/reference/cli/commands/aspire-export/) — Export telemetry and resource data to a zip file
+
 For more information about using AI agents with the dashboard, such as setting up skills, see [Standalone dashboard and AI coding agents]({1}).</source>
         <target state="new">Build, debug, and profile apps using AI agents and Aspire 🚀
 
@@ -56,6 +61,11 @@ Use Aspire CLI commands to get telemetry data in your terminal:
 ```bash
 aspire otel logs --dashboard-url {0}
 ```
+
+- [`aspire otel logs`](https://aspire.dev/reference/cli/commands/aspire-otel/) — View structured logs
+- [`aspire otel traces`](https://aspire.dev/reference/cli/commands/aspire-otel/) — View distributed traces
+- [`aspire otel spans`](https://aspire.dev/reference/cli/commands/aspire-otel/) — View trace spans
+- [`aspire export`](https://aspire.dev/reference/cli/commands/aspire-export/) — Export telemetry and resource data to a zip file
 
 For more information about using AI agents with the dashboard, such as setting up skills, see [Standalone dashboard and AI coding agents]({1}).</target>
         <note>{0} is the dashboard URL, {1} is the learn more URL</note>

--- a/src/Aspire.Dashboard/Resources/xlf/Dialogs.de.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Dialogs.de.xlf
@@ -5,7 +5,7 @@
       <trans-unit id="AIAgentsDialogAppHostDescription">
         <source>Build, debug, and profile apps using AI agents and Aspire 🚀
 
-The structured logs, distributed traces, and resource status in this dashboard are available to AI agents via the Aspire CLI and MCP server. This gives agents deep observability into your app, to help them diagnose issues and verify fixes.
+The structured logs, distributed traces, and resource status in this dashboard are available to AI agents via the Aspire CLI. This gives agents deep observability into your app, to help them diagnose issues and verify fixes.
 
 Get started by running this command in your project:
 
@@ -13,14 +13,14 @@ Get started by running this command in your project:
 aspire agent init
 ```
 
-This configures skill files for your AI assistant. The skill files tell the agent how to use Aspire CLI commands such as `aspire otel logs`, `aspire otel traces`, and `aspire agent mcp`.
+This configures skill files for your AI assistant. The skill files tell the agent how to use Aspire CLI commands such as `aspire otel logs` and `aspire otel traces`.
 
 Once connected, agents can start your app, check resource health, fetch logs and traces, and more.
 
 For more information about using AI agents with Aspire, such as setting up skills, see [AI coding agents]({0}).</source>
         <target state="new">Build, debug, and profile apps using AI agents and Aspire 🚀
 
-The structured logs, distributed traces, and resource status in this dashboard are available to AI agents via the Aspire CLI and MCP server. This gives agents deep observability into your app, to help them diagnose issues and verify fixes.
+The structured logs, distributed traces, and resource status in this dashboard are available to AI agents via the Aspire CLI. This gives agents deep observability into your app, to help them diagnose issues and verify fixes.
 
 Get started by running this command in your project:
 
@@ -28,7 +28,7 @@ Get started by running this command in your project:
 aspire agent init
 ```
 
-This configures skill files for your AI assistant. The skill files tell the agent how to use Aspire CLI commands such as `aspire otel logs`, `aspire otel traces`, and `aspire agent mcp`.
+This configures skill files for your AI assistant. The skill files tell the agent how to use Aspire CLI commands such as `aspire otel logs` and `aspire otel traces`.
 
 Once connected, agents can start your app, check resource health, fetch logs and traces, and more.
 
@@ -38,35 +38,23 @@ For more information about using AI agents with Aspire, such as setting up skill
       <trans-unit id="AIAgentsDialogStandaloneDescription">
         <source>Build, debug, and profile apps using AI agents and Aspire 🚀
 
-The structured logs and distributed traces in the dashboard are available to AI agents via the Aspire CLI and MCP server. This gives agents deep observability into your app, to help them diagnose issues and verify fixes.
+The structured logs and distributed traces in the dashboard are available to AI agents via the Aspire CLI. This gives agents deep observability into your app, to help them diagnose issues and verify fixes.
 
 Use Aspire CLI commands to get telemetry data in your terminal:
 
 ```bash
 aspire otel logs --dashboard-url {0}
-```
-
-Or start the Aspire MCP server:
-
-```bash
-aspire agent mcp --dashboard-url {0}
 ```
 
 For more information about using AI agents with the dashboard, such as setting up skills, see [Standalone dashboard and AI coding agents]({1}).</source>
         <target state="new">Build, debug, and profile apps using AI agents and Aspire 🚀
 
-The structured logs and distributed traces in the dashboard are available to AI agents via the Aspire CLI and MCP server. This gives agents deep observability into your app, to help them diagnose issues and verify fixes.
+The structured logs and distributed traces in the dashboard are available to AI agents via the Aspire CLI. This gives agents deep observability into your app, to help them diagnose issues and verify fixes.
 
 Use Aspire CLI commands to get telemetry data in your terminal:
 
 ```bash
 aspire otel logs --dashboard-url {0}
-```
-
-Or start the Aspire MCP server:
-
-```bash
-aspire agent mcp --dashboard-url {0}
 ```
 
 For more information about using AI agents with the dashboard, such as setting up skills, see [Standalone dashboard and AI coding agents]({1}).</target>

--- a/src/Aspire.Dashboard/Resources/xlf/Dialogs.de.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Dialogs.de.xlf
@@ -2,6 +2,81 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="de" original="../Dialogs.resx">
     <body>
+      <trans-unit id="AIAgentsDialogAppHostDescription">
+        <source>Build, debug, and profile apps using AI agents and Aspire 🚀
+
+The structured logs, distributed traces, and resource status in this dashboard are available to AI agents via the Aspire CLI and MCP server. This gives agents deep observability into your app, to help them diagnose issues and verify fixes.
+
+Get started by running this command in your project:
+
+```bash
+aspire agent init
+```
+
+This configures skill files for your AI assistant. The skill files tell the agent how to use Aspire CLI commands such as `aspire otel logs`, `aspire otel traces`, and `aspire agent mcp`.
+
+Once connected, agents can start your app, check resource health, fetch logs and traces, and more.
+
+For more information about using AI agents with Aspire, such as setting up skills, see [AI coding agents]({0}).</source>
+        <target state="new">Build, debug, and profile apps using AI agents and Aspire 🚀
+
+The structured logs, distributed traces, and resource status in this dashboard are available to AI agents via the Aspire CLI and MCP server. This gives agents deep observability into your app, to help them diagnose issues and verify fixes.
+
+Get started by running this command in your project:
+
+```bash
+aspire agent init
+```
+
+This configures skill files for your AI assistant. The skill files tell the agent how to use Aspire CLI commands such as `aspire otel logs`, `aspire otel traces`, and `aspire agent mcp`.
+
+Once connected, agents can start your app, check resource health, fetch logs and traces, and more.
+
+For more information about using AI agents with Aspire, such as setting up skills, see [AI coding agents]({0}).</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AIAgentsDialogStandaloneDescription">
+        <source>Build, debug, and profile apps using AI agents and Aspire 🚀
+
+The structured logs and distributed traces in the dashboard are available to AI agents via the Aspire CLI and MCP server. This gives agents deep observability into your app, to help them diagnose issues and verify fixes.
+
+Use Aspire CLI commands to get telemetry data in your terminal:
+
+```bash
+aspire otel logs --dashboard-url {0}
+```
+
+Or start the Aspire MCP server:
+
+```bash
+aspire agent mcp --dashboard-url {0}
+```
+
+For more information about using AI agents with the dashboard, such as setting up skills, see [Standalone dashboard and AI coding agents]({1}).</source>
+        <target state="new">Build, debug, and profile apps using AI agents and Aspire 🚀
+
+The structured logs and distributed traces in the dashboard are available to AI agents via the Aspire CLI and MCP server. This gives agents deep observability into your app, to help them diagnose issues and verify fixes.
+
+Use Aspire CLI commands to get telemetry data in your terminal:
+
+```bash
+aspire otel logs --dashboard-url {0}
+```
+
+Or start the Aspire MCP server:
+
+```bash
+aspire agent mcp --dashboard-url {0}
+```
+
+For more information about using AI agents with the dashboard, such as setting up skills, see [Standalone dashboard and AI coding agents]({1}).</target>
+        <note>{0} is the dashboard URL, {1} is the learn more URL</note>
+      </trans-unit>
+      <trans-unit id="AIAgentsDialogTitle">
+        <source>AI agents</source>
+        <target state="new">AI agents</target>
+        <note />
+      </trans-unit>
       <trans-unit id="DialogCloseButtonText">
         <source>Close</source>
         <target state="translated">Schließen</target>

--- a/src/Aspire.Dashboard/Resources/xlf/Dialogs.es.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Dialogs.es.xlf
@@ -13,7 +13,7 @@ Get started by running this command in your project:
 aspire agent init
 ```
 
-This configures skill files for your AI assistant. The skill files tell the agent how to use Aspire CLI commands such as [`aspire otel logs`](https://aspire.dev/reference/cli/commands/aspire-otel/) and [`aspire otel traces`](https://aspire.dev/reference/cli/commands/aspire-otel/).
+This configures skill files for your AI assistant. The skill files tell the agent how to use Aspire CLI commands such as [`aspire logs`](https://aspire.dev/reference/cli/commands/aspire-logs/) and [`aspire otel traces`](https://aspire.dev/reference/cli/commands/aspire-otel-traces/).
 
 Once connected, agents can start your app, check resource health, fetch logs and traces, and more.
 
@@ -28,7 +28,7 @@ Get started by running this command in your project:
 aspire agent init
 ```
 
-This configures skill files for your AI assistant. The skill files tell the agent how to use Aspire CLI commands such as [`aspire otel logs`](https://aspire.dev/reference/cli/commands/aspire-otel/) and [`aspire otel traces`](https://aspire.dev/reference/cli/commands/aspire-otel/).
+This configures skill files for your AI assistant. The skill files tell the agent how to use Aspire CLI commands such as [`aspire logs`](https://aspire.dev/reference/cli/commands/aspire-logs/) and [`aspire otel traces`](https://aspire.dev/reference/cli/commands/aspire-otel-traces/).
 
 Once connected, agents can start your app, check resource health, fetch logs and traces, and more.
 
@@ -46,9 +46,9 @@ Use Aspire CLI commands to get telemetry data in your terminal:
 aspire otel logs --dashboard-url {0}
 ```
 
-- [`aspire otel logs`](https://aspire.dev/reference/cli/commands/aspire-otel/) — View structured logs
-- [`aspire otel traces`](https://aspire.dev/reference/cli/commands/aspire-otel/) — View distributed traces
-- [`aspire otel spans`](https://aspire.dev/reference/cli/commands/aspire-otel/) — View trace spans
+- [`aspire otel logs`](https://aspire.dev/reference/cli/commands/aspire-otel-logs/) — View structured logs
+- [`aspire otel traces`](https://aspire.dev/reference/cli/commands/aspire-otel-traces/) — View distributed traces
+- [`aspire otel spans`](https://aspire.dev/reference/cli/commands/aspire-otel-spans/) — View trace spans
 - [`aspire export`](https://aspire.dev/reference/cli/commands/aspire-export/) — Export telemetry and resource data to a zip file
 
 For more information about using AI agents with the dashboard, such as setting up skills, see [Standalone dashboard and AI coding agents]({1}).</source>
@@ -62,9 +62,9 @@ Use Aspire CLI commands to get telemetry data in your terminal:
 aspire otel logs --dashboard-url {0}
 ```
 
-- [`aspire otel logs`](https://aspire.dev/reference/cli/commands/aspire-otel/) — View structured logs
-- [`aspire otel traces`](https://aspire.dev/reference/cli/commands/aspire-otel/) — View distributed traces
-- [`aspire otel spans`](https://aspire.dev/reference/cli/commands/aspire-otel/) — View trace spans
+- [`aspire otel logs`](https://aspire.dev/reference/cli/commands/aspire-otel-logs/) — View structured logs
+- [`aspire otel traces`](https://aspire.dev/reference/cli/commands/aspire-otel-traces/) — View distributed traces
+- [`aspire otel spans`](https://aspire.dev/reference/cli/commands/aspire-otel-spans/) — View trace spans
 - [`aspire export`](https://aspire.dev/reference/cli/commands/aspire-export/) — Export telemetry and resource data to a zip file
 
 For more information about using AI agents with the dashboard, such as setting up skills, see [Standalone dashboard and AI coding agents]({1}).</target>

--- a/src/Aspire.Dashboard/Resources/xlf/Dialogs.es.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Dialogs.es.xlf
@@ -13,7 +13,7 @@ Get started by running this command in your project:
 aspire agent init
 ```
 
-This configures skill files for your AI assistant. The skill files tell the agent how to use Aspire CLI commands such as `aspire otel logs` and `aspire otel traces`.
+This configures skill files for your AI assistant. The skill files tell the agent how to use Aspire CLI commands such as [`aspire otel logs`](https://aspire.dev/reference/cli/commands/aspire-otel/) and [`aspire otel traces`](https://aspire.dev/reference/cli/commands/aspire-otel/).
 
 Once connected, agents can start your app, check resource health, fetch logs and traces, and more.
 
@@ -28,7 +28,7 @@ Get started by running this command in your project:
 aspire agent init
 ```
 
-This configures skill files for your AI assistant. The skill files tell the agent how to use Aspire CLI commands such as `aspire otel logs` and `aspire otel traces`.
+This configures skill files for your AI assistant. The skill files tell the agent how to use Aspire CLI commands such as [`aspire otel logs`](https://aspire.dev/reference/cli/commands/aspire-otel/) and [`aspire otel traces`](https://aspire.dev/reference/cli/commands/aspire-otel/).
 
 Once connected, agents can start your app, check resource health, fetch logs and traces, and more.
 
@@ -46,6 +46,11 @@ Use Aspire CLI commands to get telemetry data in your terminal:
 aspire otel logs --dashboard-url {0}
 ```
 
+- [`aspire otel logs`](https://aspire.dev/reference/cli/commands/aspire-otel/) — View structured logs
+- [`aspire otel traces`](https://aspire.dev/reference/cli/commands/aspire-otel/) — View distributed traces
+- [`aspire otel spans`](https://aspire.dev/reference/cli/commands/aspire-otel/) — View trace spans
+- [`aspire export`](https://aspire.dev/reference/cli/commands/aspire-export/) — Export telemetry and resource data to a zip file
+
 For more information about using AI agents with the dashboard, such as setting up skills, see [Standalone dashboard and AI coding agents]({1}).</source>
         <target state="new">Build, debug, and profile apps using AI agents and Aspire 🚀
 
@@ -56,6 +61,11 @@ Use Aspire CLI commands to get telemetry data in your terminal:
 ```bash
 aspire otel logs --dashboard-url {0}
 ```
+
+- [`aspire otel logs`](https://aspire.dev/reference/cli/commands/aspire-otel/) — View structured logs
+- [`aspire otel traces`](https://aspire.dev/reference/cli/commands/aspire-otel/) — View distributed traces
+- [`aspire otel spans`](https://aspire.dev/reference/cli/commands/aspire-otel/) — View trace spans
+- [`aspire export`](https://aspire.dev/reference/cli/commands/aspire-export/) — Export telemetry and resource data to a zip file
 
 For more information about using AI agents with the dashboard, such as setting up skills, see [Standalone dashboard and AI coding agents]({1}).</target>
         <note>{0} is the dashboard URL, {1} is the learn more URL</note>

--- a/src/Aspire.Dashboard/Resources/xlf/Dialogs.es.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Dialogs.es.xlf
@@ -5,7 +5,7 @@
       <trans-unit id="AIAgentsDialogAppHostDescription">
         <source>Build, debug, and profile apps using AI agents and Aspire 🚀
 
-The structured logs, distributed traces, and resource status in this dashboard are available to AI agents via the Aspire CLI and MCP server. This gives agents deep observability into your app, to help them diagnose issues and verify fixes.
+The structured logs, distributed traces, and resource status in this dashboard are available to AI agents via the Aspire CLI. This gives agents deep observability into your app, to help them diagnose issues and verify fixes.
 
 Get started by running this command in your project:
 
@@ -13,14 +13,14 @@ Get started by running this command in your project:
 aspire agent init
 ```
 
-This configures skill files for your AI assistant. The skill files tell the agent how to use Aspire CLI commands such as `aspire otel logs`, `aspire otel traces`, and `aspire agent mcp`.
+This configures skill files for your AI assistant. The skill files tell the agent how to use Aspire CLI commands such as `aspire otel logs` and `aspire otel traces`.
 
 Once connected, agents can start your app, check resource health, fetch logs and traces, and more.
 
 For more information about using AI agents with Aspire, such as setting up skills, see [AI coding agents]({0}).</source>
         <target state="new">Build, debug, and profile apps using AI agents and Aspire 🚀
 
-The structured logs, distributed traces, and resource status in this dashboard are available to AI agents via the Aspire CLI and MCP server. This gives agents deep observability into your app, to help them diagnose issues and verify fixes.
+The structured logs, distributed traces, and resource status in this dashboard are available to AI agents via the Aspire CLI. This gives agents deep observability into your app, to help them diagnose issues and verify fixes.
 
 Get started by running this command in your project:
 
@@ -28,7 +28,7 @@ Get started by running this command in your project:
 aspire agent init
 ```
 
-This configures skill files for your AI assistant. The skill files tell the agent how to use Aspire CLI commands such as `aspire otel logs`, `aspire otel traces`, and `aspire agent mcp`.
+This configures skill files for your AI assistant. The skill files tell the agent how to use Aspire CLI commands such as `aspire otel logs` and `aspire otel traces`.
 
 Once connected, agents can start your app, check resource health, fetch logs and traces, and more.
 
@@ -38,35 +38,23 @@ For more information about using AI agents with Aspire, such as setting up skill
       <trans-unit id="AIAgentsDialogStandaloneDescription">
         <source>Build, debug, and profile apps using AI agents and Aspire 🚀
 
-The structured logs and distributed traces in the dashboard are available to AI agents via the Aspire CLI and MCP server. This gives agents deep observability into your app, to help them diagnose issues and verify fixes.
+The structured logs and distributed traces in the dashboard are available to AI agents via the Aspire CLI. This gives agents deep observability into your app, to help them diagnose issues and verify fixes.
 
 Use Aspire CLI commands to get telemetry data in your terminal:
 
 ```bash
 aspire otel logs --dashboard-url {0}
-```
-
-Or start the Aspire MCP server:
-
-```bash
-aspire agent mcp --dashboard-url {0}
 ```
 
 For more information about using AI agents with the dashboard, such as setting up skills, see [Standalone dashboard and AI coding agents]({1}).</source>
         <target state="new">Build, debug, and profile apps using AI agents and Aspire 🚀
 
-The structured logs and distributed traces in the dashboard are available to AI agents via the Aspire CLI and MCP server. This gives agents deep observability into your app, to help them diagnose issues and verify fixes.
+The structured logs and distributed traces in the dashboard are available to AI agents via the Aspire CLI. This gives agents deep observability into your app, to help them diagnose issues and verify fixes.
 
 Use Aspire CLI commands to get telemetry data in your terminal:
 
 ```bash
 aspire otel logs --dashboard-url {0}
-```
-
-Or start the Aspire MCP server:
-
-```bash
-aspire agent mcp --dashboard-url {0}
 ```
 
 For more information about using AI agents with the dashboard, such as setting up skills, see [Standalone dashboard and AI coding agents]({1}).</target>

--- a/src/Aspire.Dashboard/Resources/xlf/Dialogs.es.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Dialogs.es.xlf
@@ -2,6 +2,81 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="es" original="../Dialogs.resx">
     <body>
+      <trans-unit id="AIAgentsDialogAppHostDescription">
+        <source>Build, debug, and profile apps using AI agents and Aspire 🚀
+
+The structured logs, distributed traces, and resource status in this dashboard are available to AI agents via the Aspire CLI and MCP server. This gives agents deep observability into your app, to help them diagnose issues and verify fixes.
+
+Get started by running this command in your project:
+
+```bash
+aspire agent init
+```
+
+This configures skill files for your AI assistant. The skill files tell the agent how to use Aspire CLI commands such as `aspire otel logs`, `aspire otel traces`, and `aspire agent mcp`.
+
+Once connected, agents can start your app, check resource health, fetch logs and traces, and more.
+
+For more information about using AI agents with Aspire, such as setting up skills, see [AI coding agents]({0}).</source>
+        <target state="new">Build, debug, and profile apps using AI agents and Aspire 🚀
+
+The structured logs, distributed traces, and resource status in this dashboard are available to AI agents via the Aspire CLI and MCP server. This gives agents deep observability into your app, to help them diagnose issues and verify fixes.
+
+Get started by running this command in your project:
+
+```bash
+aspire agent init
+```
+
+This configures skill files for your AI assistant. The skill files tell the agent how to use Aspire CLI commands such as `aspire otel logs`, `aspire otel traces`, and `aspire agent mcp`.
+
+Once connected, agents can start your app, check resource health, fetch logs and traces, and more.
+
+For more information about using AI agents with Aspire, such as setting up skills, see [AI coding agents]({0}).</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AIAgentsDialogStandaloneDescription">
+        <source>Build, debug, and profile apps using AI agents and Aspire 🚀
+
+The structured logs and distributed traces in the dashboard are available to AI agents via the Aspire CLI and MCP server. This gives agents deep observability into your app, to help them diagnose issues and verify fixes.
+
+Use Aspire CLI commands to get telemetry data in your terminal:
+
+```bash
+aspire otel logs --dashboard-url {0}
+```
+
+Or start the Aspire MCP server:
+
+```bash
+aspire agent mcp --dashboard-url {0}
+```
+
+For more information about using AI agents with the dashboard, such as setting up skills, see [Standalone dashboard and AI coding agents]({1}).</source>
+        <target state="new">Build, debug, and profile apps using AI agents and Aspire 🚀
+
+The structured logs and distributed traces in the dashboard are available to AI agents via the Aspire CLI and MCP server. This gives agents deep observability into your app, to help them diagnose issues and verify fixes.
+
+Use Aspire CLI commands to get telemetry data in your terminal:
+
+```bash
+aspire otel logs --dashboard-url {0}
+```
+
+Or start the Aspire MCP server:
+
+```bash
+aspire agent mcp --dashboard-url {0}
+```
+
+For more information about using AI agents with the dashboard, such as setting up skills, see [Standalone dashboard and AI coding agents]({1}).</target>
+        <note>{0} is the dashboard URL, {1} is the learn more URL</note>
+      </trans-unit>
+      <trans-unit id="AIAgentsDialogTitle">
+        <source>AI agents</source>
+        <target state="new">AI agents</target>
+        <note />
+      </trans-unit>
       <trans-unit id="DialogCloseButtonText">
         <source>Close</source>
         <target state="translated">Cerrar</target>

--- a/src/Aspire.Dashboard/Resources/xlf/Dialogs.fr.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Dialogs.fr.xlf
@@ -13,7 +13,7 @@ Get started by running this command in your project:
 aspire agent init
 ```
 
-This configures skill files for your AI assistant. The skill files tell the agent how to use Aspire CLI commands such as [`aspire otel logs`](https://aspire.dev/reference/cli/commands/aspire-otel/) and [`aspire otel traces`](https://aspire.dev/reference/cli/commands/aspire-otel/).
+This configures skill files for your AI assistant. The skill files tell the agent how to use Aspire CLI commands such as [`aspire logs`](https://aspire.dev/reference/cli/commands/aspire-logs/) and [`aspire otel traces`](https://aspire.dev/reference/cli/commands/aspire-otel-traces/).
 
 Once connected, agents can start your app, check resource health, fetch logs and traces, and more.
 
@@ -28,7 +28,7 @@ Get started by running this command in your project:
 aspire agent init
 ```
 
-This configures skill files for your AI assistant. The skill files tell the agent how to use Aspire CLI commands such as [`aspire otel logs`](https://aspire.dev/reference/cli/commands/aspire-otel/) and [`aspire otel traces`](https://aspire.dev/reference/cli/commands/aspire-otel/).
+This configures skill files for your AI assistant. The skill files tell the agent how to use Aspire CLI commands such as [`aspire logs`](https://aspire.dev/reference/cli/commands/aspire-logs/) and [`aspire otel traces`](https://aspire.dev/reference/cli/commands/aspire-otel-traces/).
 
 Once connected, agents can start your app, check resource health, fetch logs and traces, and more.
 
@@ -46,9 +46,9 @@ Use Aspire CLI commands to get telemetry data in your terminal:
 aspire otel logs --dashboard-url {0}
 ```
 
-- [`aspire otel logs`](https://aspire.dev/reference/cli/commands/aspire-otel/) — View structured logs
-- [`aspire otel traces`](https://aspire.dev/reference/cli/commands/aspire-otel/) — View distributed traces
-- [`aspire otel spans`](https://aspire.dev/reference/cli/commands/aspire-otel/) — View trace spans
+- [`aspire otel logs`](https://aspire.dev/reference/cli/commands/aspire-otel-logs/) — View structured logs
+- [`aspire otel traces`](https://aspire.dev/reference/cli/commands/aspire-otel-traces/) — View distributed traces
+- [`aspire otel spans`](https://aspire.dev/reference/cli/commands/aspire-otel-spans/) — View trace spans
 - [`aspire export`](https://aspire.dev/reference/cli/commands/aspire-export/) — Export telemetry and resource data to a zip file
 
 For more information about using AI agents with the dashboard, such as setting up skills, see [Standalone dashboard and AI coding agents]({1}).</source>
@@ -62,9 +62,9 @@ Use Aspire CLI commands to get telemetry data in your terminal:
 aspire otel logs --dashboard-url {0}
 ```
 
-- [`aspire otel logs`](https://aspire.dev/reference/cli/commands/aspire-otel/) — View structured logs
-- [`aspire otel traces`](https://aspire.dev/reference/cli/commands/aspire-otel/) — View distributed traces
-- [`aspire otel spans`](https://aspire.dev/reference/cli/commands/aspire-otel/) — View trace spans
+- [`aspire otel logs`](https://aspire.dev/reference/cli/commands/aspire-otel-logs/) — View structured logs
+- [`aspire otel traces`](https://aspire.dev/reference/cli/commands/aspire-otel-traces/) — View distributed traces
+- [`aspire otel spans`](https://aspire.dev/reference/cli/commands/aspire-otel-spans/) — View trace spans
 - [`aspire export`](https://aspire.dev/reference/cli/commands/aspire-export/) — Export telemetry and resource data to a zip file
 
 For more information about using AI agents with the dashboard, such as setting up skills, see [Standalone dashboard and AI coding agents]({1}).</target>

--- a/src/Aspire.Dashboard/Resources/xlf/Dialogs.fr.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Dialogs.fr.xlf
@@ -2,6 +2,81 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="fr" original="../Dialogs.resx">
     <body>
+      <trans-unit id="AIAgentsDialogAppHostDescription">
+        <source>Build, debug, and profile apps using AI agents and Aspire 🚀
+
+The structured logs, distributed traces, and resource status in this dashboard are available to AI agents via the Aspire CLI and MCP server. This gives agents deep observability into your app, to help them diagnose issues and verify fixes.
+
+Get started by running this command in your project:
+
+```bash
+aspire agent init
+```
+
+This configures skill files for your AI assistant. The skill files tell the agent how to use Aspire CLI commands such as `aspire otel logs`, `aspire otel traces`, and `aspire agent mcp`.
+
+Once connected, agents can start your app, check resource health, fetch logs and traces, and more.
+
+For more information about using AI agents with Aspire, such as setting up skills, see [AI coding agents]({0}).</source>
+        <target state="new">Build, debug, and profile apps using AI agents and Aspire 🚀
+
+The structured logs, distributed traces, and resource status in this dashboard are available to AI agents via the Aspire CLI and MCP server. This gives agents deep observability into your app, to help them diagnose issues and verify fixes.
+
+Get started by running this command in your project:
+
+```bash
+aspire agent init
+```
+
+This configures skill files for your AI assistant. The skill files tell the agent how to use Aspire CLI commands such as `aspire otel logs`, `aspire otel traces`, and `aspire agent mcp`.
+
+Once connected, agents can start your app, check resource health, fetch logs and traces, and more.
+
+For more information about using AI agents with Aspire, such as setting up skills, see [AI coding agents]({0}).</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AIAgentsDialogStandaloneDescription">
+        <source>Build, debug, and profile apps using AI agents and Aspire 🚀
+
+The structured logs and distributed traces in the dashboard are available to AI agents via the Aspire CLI and MCP server. This gives agents deep observability into your app, to help them diagnose issues and verify fixes.
+
+Use Aspire CLI commands to get telemetry data in your terminal:
+
+```bash
+aspire otel logs --dashboard-url {0}
+```
+
+Or start the Aspire MCP server:
+
+```bash
+aspire agent mcp --dashboard-url {0}
+```
+
+For more information about using AI agents with the dashboard, such as setting up skills, see [Standalone dashboard and AI coding agents]({1}).</source>
+        <target state="new">Build, debug, and profile apps using AI agents and Aspire 🚀
+
+The structured logs and distributed traces in the dashboard are available to AI agents via the Aspire CLI and MCP server. This gives agents deep observability into your app, to help them diagnose issues and verify fixes.
+
+Use Aspire CLI commands to get telemetry data in your terminal:
+
+```bash
+aspire otel logs --dashboard-url {0}
+```
+
+Or start the Aspire MCP server:
+
+```bash
+aspire agent mcp --dashboard-url {0}
+```
+
+For more information about using AI agents with the dashboard, such as setting up skills, see [Standalone dashboard and AI coding agents]({1}).</target>
+        <note>{0} is the dashboard URL, {1} is the learn more URL</note>
+      </trans-unit>
+      <trans-unit id="AIAgentsDialogTitle">
+        <source>AI agents</source>
+        <target state="new">AI agents</target>
+        <note />
+      </trans-unit>
       <trans-unit id="DialogCloseButtonText">
         <source>Close</source>
         <target state="translated">Fermer</target>

--- a/src/Aspire.Dashboard/Resources/xlf/Dialogs.fr.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Dialogs.fr.xlf
@@ -13,7 +13,7 @@ Get started by running this command in your project:
 aspire agent init
 ```
 
-This configures skill files for your AI assistant. The skill files tell the agent how to use Aspire CLI commands such as `aspire otel logs` and `aspire otel traces`.
+This configures skill files for your AI assistant. The skill files tell the agent how to use Aspire CLI commands such as [`aspire otel logs`](https://aspire.dev/reference/cli/commands/aspire-otel/) and [`aspire otel traces`](https://aspire.dev/reference/cli/commands/aspire-otel/).
 
 Once connected, agents can start your app, check resource health, fetch logs and traces, and more.
 
@@ -28,7 +28,7 @@ Get started by running this command in your project:
 aspire agent init
 ```
 
-This configures skill files for your AI assistant. The skill files tell the agent how to use Aspire CLI commands such as `aspire otel logs` and `aspire otel traces`.
+This configures skill files for your AI assistant. The skill files tell the agent how to use Aspire CLI commands such as [`aspire otel logs`](https://aspire.dev/reference/cli/commands/aspire-otel/) and [`aspire otel traces`](https://aspire.dev/reference/cli/commands/aspire-otel/).
 
 Once connected, agents can start your app, check resource health, fetch logs and traces, and more.
 
@@ -46,6 +46,11 @@ Use Aspire CLI commands to get telemetry data in your terminal:
 aspire otel logs --dashboard-url {0}
 ```
 
+- [`aspire otel logs`](https://aspire.dev/reference/cli/commands/aspire-otel/) — View structured logs
+- [`aspire otel traces`](https://aspire.dev/reference/cli/commands/aspire-otel/) — View distributed traces
+- [`aspire otel spans`](https://aspire.dev/reference/cli/commands/aspire-otel/) — View trace spans
+- [`aspire export`](https://aspire.dev/reference/cli/commands/aspire-export/) — Export telemetry and resource data to a zip file
+
 For more information about using AI agents with the dashboard, such as setting up skills, see [Standalone dashboard and AI coding agents]({1}).</source>
         <target state="new">Build, debug, and profile apps using AI agents and Aspire 🚀
 
@@ -56,6 +61,11 @@ Use Aspire CLI commands to get telemetry data in your terminal:
 ```bash
 aspire otel logs --dashboard-url {0}
 ```
+
+- [`aspire otel logs`](https://aspire.dev/reference/cli/commands/aspire-otel/) — View structured logs
+- [`aspire otel traces`](https://aspire.dev/reference/cli/commands/aspire-otel/) — View distributed traces
+- [`aspire otel spans`](https://aspire.dev/reference/cli/commands/aspire-otel/) — View trace spans
+- [`aspire export`](https://aspire.dev/reference/cli/commands/aspire-export/) — Export telemetry and resource data to a zip file
 
 For more information about using AI agents with the dashboard, such as setting up skills, see [Standalone dashboard and AI coding agents]({1}).</target>
         <note>{0} is the dashboard URL, {1} is the learn more URL</note>

--- a/src/Aspire.Dashboard/Resources/xlf/Dialogs.fr.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Dialogs.fr.xlf
@@ -5,7 +5,7 @@
       <trans-unit id="AIAgentsDialogAppHostDescription">
         <source>Build, debug, and profile apps using AI agents and Aspire 🚀
 
-The structured logs, distributed traces, and resource status in this dashboard are available to AI agents via the Aspire CLI and MCP server. This gives agents deep observability into your app, to help them diagnose issues and verify fixes.
+The structured logs, distributed traces, and resource status in this dashboard are available to AI agents via the Aspire CLI. This gives agents deep observability into your app, to help them diagnose issues and verify fixes.
 
 Get started by running this command in your project:
 
@@ -13,14 +13,14 @@ Get started by running this command in your project:
 aspire agent init
 ```
 
-This configures skill files for your AI assistant. The skill files tell the agent how to use Aspire CLI commands such as `aspire otel logs`, `aspire otel traces`, and `aspire agent mcp`.
+This configures skill files for your AI assistant. The skill files tell the agent how to use Aspire CLI commands such as `aspire otel logs` and `aspire otel traces`.
 
 Once connected, agents can start your app, check resource health, fetch logs and traces, and more.
 
 For more information about using AI agents with Aspire, such as setting up skills, see [AI coding agents]({0}).</source>
         <target state="new">Build, debug, and profile apps using AI agents and Aspire 🚀
 
-The structured logs, distributed traces, and resource status in this dashboard are available to AI agents via the Aspire CLI and MCP server. This gives agents deep observability into your app, to help them diagnose issues and verify fixes.
+The structured logs, distributed traces, and resource status in this dashboard are available to AI agents via the Aspire CLI. This gives agents deep observability into your app, to help them diagnose issues and verify fixes.
 
 Get started by running this command in your project:
 
@@ -28,7 +28,7 @@ Get started by running this command in your project:
 aspire agent init
 ```
 
-This configures skill files for your AI assistant. The skill files tell the agent how to use Aspire CLI commands such as `aspire otel logs`, `aspire otel traces`, and `aspire agent mcp`.
+This configures skill files for your AI assistant. The skill files tell the agent how to use Aspire CLI commands such as `aspire otel logs` and `aspire otel traces`.
 
 Once connected, agents can start your app, check resource health, fetch logs and traces, and more.
 
@@ -38,35 +38,23 @@ For more information about using AI agents with Aspire, such as setting up skill
       <trans-unit id="AIAgentsDialogStandaloneDescription">
         <source>Build, debug, and profile apps using AI agents and Aspire 🚀
 
-The structured logs and distributed traces in the dashboard are available to AI agents via the Aspire CLI and MCP server. This gives agents deep observability into your app, to help them diagnose issues and verify fixes.
+The structured logs and distributed traces in the dashboard are available to AI agents via the Aspire CLI. This gives agents deep observability into your app, to help them diagnose issues and verify fixes.
 
 Use Aspire CLI commands to get telemetry data in your terminal:
 
 ```bash
 aspire otel logs --dashboard-url {0}
-```
-
-Or start the Aspire MCP server:
-
-```bash
-aspire agent mcp --dashboard-url {0}
 ```
 
 For more information about using AI agents with the dashboard, such as setting up skills, see [Standalone dashboard and AI coding agents]({1}).</source>
         <target state="new">Build, debug, and profile apps using AI agents and Aspire 🚀
 
-The structured logs and distributed traces in the dashboard are available to AI agents via the Aspire CLI and MCP server. This gives agents deep observability into your app, to help them diagnose issues and verify fixes.
+The structured logs and distributed traces in the dashboard are available to AI agents via the Aspire CLI. This gives agents deep observability into your app, to help them diagnose issues and verify fixes.
 
 Use Aspire CLI commands to get telemetry data in your terminal:
 
 ```bash
 aspire otel logs --dashboard-url {0}
-```
-
-Or start the Aspire MCP server:
-
-```bash
-aspire agent mcp --dashboard-url {0}
 ```
 
 For more information about using AI agents with the dashboard, such as setting up skills, see [Standalone dashboard and AI coding agents]({1}).</target>

--- a/src/Aspire.Dashboard/Resources/xlf/Dialogs.it.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Dialogs.it.xlf
@@ -13,7 +13,7 @@ Get started by running this command in your project:
 aspire agent init
 ```
 
-This configures skill files for your AI assistant. The skill files tell the agent how to use Aspire CLI commands such as [`aspire otel logs`](https://aspire.dev/reference/cli/commands/aspire-otel/) and [`aspire otel traces`](https://aspire.dev/reference/cli/commands/aspire-otel/).
+This configures skill files for your AI assistant. The skill files tell the agent how to use Aspire CLI commands such as [`aspire logs`](https://aspire.dev/reference/cli/commands/aspire-logs/) and [`aspire otel traces`](https://aspire.dev/reference/cli/commands/aspire-otel-traces/).
 
 Once connected, agents can start your app, check resource health, fetch logs and traces, and more.
 
@@ -28,7 +28,7 @@ Get started by running this command in your project:
 aspire agent init
 ```
 
-This configures skill files for your AI assistant. The skill files tell the agent how to use Aspire CLI commands such as [`aspire otel logs`](https://aspire.dev/reference/cli/commands/aspire-otel/) and [`aspire otel traces`](https://aspire.dev/reference/cli/commands/aspire-otel/).
+This configures skill files for your AI assistant. The skill files tell the agent how to use Aspire CLI commands such as [`aspire logs`](https://aspire.dev/reference/cli/commands/aspire-logs/) and [`aspire otel traces`](https://aspire.dev/reference/cli/commands/aspire-otel-traces/).
 
 Once connected, agents can start your app, check resource health, fetch logs and traces, and more.
 
@@ -46,9 +46,9 @@ Use Aspire CLI commands to get telemetry data in your terminal:
 aspire otel logs --dashboard-url {0}
 ```
 
-- [`aspire otel logs`](https://aspire.dev/reference/cli/commands/aspire-otel/) — View structured logs
-- [`aspire otel traces`](https://aspire.dev/reference/cli/commands/aspire-otel/) — View distributed traces
-- [`aspire otel spans`](https://aspire.dev/reference/cli/commands/aspire-otel/) — View trace spans
+- [`aspire otel logs`](https://aspire.dev/reference/cli/commands/aspire-otel-logs/) — View structured logs
+- [`aspire otel traces`](https://aspire.dev/reference/cli/commands/aspire-otel-traces/) — View distributed traces
+- [`aspire otel spans`](https://aspire.dev/reference/cli/commands/aspire-otel-spans/) — View trace spans
 - [`aspire export`](https://aspire.dev/reference/cli/commands/aspire-export/) — Export telemetry and resource data to a zip file
 
 For more information about using AI agents with the dashboard, such as setting up skills, see [Standalone dashboard and AI coding agents]({1}).</source>
@@ -62,9 +62,9 @@ Use Aspire CLI commands to get telemetry data in your terminal:
 aspire otel logs --dashboard-url {0}
 ```
 
-- [`aspire otel logs`](https://aspire.dev/reference/cli/commands/aspire-otel/) — View structured logs
-- [`aspire otel traces`](https://aspire.dev/reference/cli/commands/aspire-otel/) — View distributed traces
-- [`aspire otel spans`](https://aspire.dev/reference/cli/commands/aspire-otel/) — View trace spans
+- [`aspire otel logs`](https://aspire.dev/reference/cli/commands/aspire-otel-logs/) — View structured logs
+- [`aspire otel traces`](https://aspire.dev/reference/cli/commands/aspire-otel-traces/) — View distributed traces
+- [`aspire otel spans`](https://aspire.dev/reference/cli/commands/aspire-otel-spans/) — View trace spans
 - [`aspire export`](https://aspire.dev/reference/cli/commands/aspire-export/) — Export telemetry and resource data to a zip file
 
 For more information about using AI agents with the dashboard, such as setting up skills, see [Standalone dashboard and AI coding agents]({1}).</target>

--- a/src/Aspire.Dashboard/Resources/xlf/Dialogs.it.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Dialogs.it.xlf
@@ -13,7 +13,7 @@ Get started by running this command in your project:
 aspire agent init
 ```
 
-This configures skill files for your AI assistant. The skill files tell the agent how to use Aspire CLI commands such as `aspire otel logs` and `aspire otel traces`.
+This configures skill files for your AI assistant. The skill files tell the agent how to use Aspire CLI commands such as [`aspire otel logs`](https://aspire.dev/reference/cli/commands/aspire-otel/) and [`aspire otel traces`](https://aspire.dev/reference/cli/commands/aspire-otel/).
 
 Once connected, agents can start your app, check resource health, fetch logs and traces, and more.
 
@@ -28,7 +28,7 @@ Get started by running this command in your project:
 aspire agent init
 ```
 
-This configures skill files for your AI assistant. The skill files tell the agent how to use Aspire CLI commands such as `aspire otel logs` and `aspire otel traces`.
+This configures skill files for your AI assistant. The skill files tell the agent how to use Aspire CLI commands such as [`aspire otel logs`](https://aspire.dev/reference/cli/commands/aspire-otel/) and [`aspire otel traces`](https://aspire.dev/reference/cli/commands/aspire-otel/).
 
 Once connected, agents can start your app, check resource health, fetch logs and traces, and more.
 
@@ -46,6 +46,11 @@ Use Aspire CLI commands to get telemetry data in your terminal:
 aspire otel logs --dashboard-url {0}
 ```
 
+- [`aspire otel logs`](https://aspire.dev/reference/cli/commands/aspire-otel/) — View structured logs
+- [`aspire otel traces`](https://aspire.dev/reference/cli/commands/aspire-otel/) — View distributed traces
+- [`aspire otel spans`](https://aspire.dev/reference/cli/commands/aspire-otel/) — View trace spans
+- [`aspire export`](https://aspire.dev/reference/cli/commands/aspire-export/) — Export telemetry and resource data to a zip file
+
 For more information about using AI agents with the dashboard, such as setting up skills, see [Standalone dashboard and AI coding agents]({1}).</source>
         <target state="new">Build, debug, and profile apps using AI agents and Aspire 🚀
 
@@ -56,6 +61,11 @@ Use Aspire CLI commands to get telemetry data in your terminal:
 ```bash
 aspire otel logs --dashboard-url {0}
 ```
+
+- [`aspire otel logs`](https://aspire.dev/reference/cli/commands/aspire-otel/) — View structured logs
+- [`aspire otel traces`](https://aspire.dev/reference/cli/commands/aspire-otel/) — View distributed traces
+- [`aspire otel spans`](https://aspire.dev/reference/cli/commands/aspire-otel/) — View trace spans
+- [`aspire export`](https://aspire.dev/reference/cli/commands/aspire-export/) — Export telemetry and resource data to a zip file
 
 For more information about using AI agents with the dashboard, such as setting up skills, see [Standalone dashboard and AI coding agents]({1}).</target>
         <note>{0} is the dashboard URL, {1} is the learn more URL</note>

--- a/src/Aspire.Dashboard/Resources/xlf/Dialogs.it.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Dialogs.it.xlf
@@ -2,6 +2,81 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="it" original="../Dialogs.resx">
     <body>
+      <trans-unit id="AIAgentsDialogAppHostDescription">
+        <source>Build, debug, and profile apps using AI agents and Aspire 🚀
+
+The structured logs, distributed traces, and resource status in this dashboard are available to AI agents via the Aspire CLI and MCP server. This gives agents deep observability into your app, to help them diagnose issues and verify fixes.
+
+Get started by running this command in your project:
+
+```bash
+aspire agent init
+```
+
+This configures skill files for your AI assistant. The skill files tell the agent how to use Aspire CLI commands such as `aspire otel logs`, `aspire otel traces`, and `aspire agent mcp`.
+
+Once connected, agents can start your app, check resource health, fetch logs and traces, and more.
+
+For more information about using AI agents with Aspire, such as setting up skills, see [AI coding agents]({0}).</source>
+        <target state="new">Build, debug, and profile apps using AI agents and Aspire 🚀
+
+The structured logs, distributed traces, and resource status in this dashboard are available to AI agents via the Aspire CLI and MCP server. This gives agents deep observability into your app, to help them diagnose issues and verify fixes.
+
+Get started by running this command in your project:
+
+```bash
+aspire agent init
+```
+
+This configures skill files for your AI assistant. The skill files tell the agent how to use Aspire CLI commands such as `aspire otel logs`, `aspire otel traces`, and `aspire agent mcp`.
+
+Once connected, agents can start your app, check resource health, fetch logs and traces, and more.
+
+For more information about using AI agents with Aspire, such as setting up skills, see [AI coding agents]({0}).</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AIAgentsDialogStandaloneDescription">
+        <source>Build, debug, and profile apps using AI agents and Aspire 🚀
+
+The structured logs and distributed traces in the dashboard are available to AI agents via the Aspire CLI and MCP server. This gives agents deep observability into your app, to help them diagnose issues and verify fixes.
+
+Use Aspire CLI commands to get telemetry data in your terminal:
+
+```bash
+aspire otel logs --dashboard-url {0}
+```
+
+Or start the Aspire MCP server:
+
+```bash
+aspire agent mcp --dashboard-url {0}
+```
+
+For more information about using AI agents with the dashboard, such as setting up skills, see [Standalone dashboard and AI coding agents]({1}).</source>
+        <target state="new">Build, debug, and profile apps using AI agents and Aspire 🚀
+
+The structured logs and distributed traces in the dashboard are available to AI agents via the Aspire CLI and MCP server. This gives agents deep observability into your app, to help them diagnose issues and verify fixes.
+
+Use Aspire CLI commands to get telemetry data in your terminal:
+
+```bash
+aspire otel logs --dashboard-url {0}
+```
+
+Or start the Aspire MCP server:
+
+```bash
+aspire agent mcp --dashboard-url {0}
+```
+
+For more information about using AI agents with the dashboard, such as setting up skills, see [Standalone dashboard and AI coding agents]({1}).</target>
+        <note>{0} is the dashboard URL, {1} is the learn more URL</note>
+      </trans-unit>
+      <trans-unit id="AIAgentsDialogTitle">
+        <source>AI agents</source>
+        <target state="new">AI agents</target>
+        <note />
+      </trans-unit>
       <trans-unit id="DialogCloseButtonText">
         <source>Close</source>
         <target state="translated">Chiudi</target>

--- a/src/Aspire.Dashboard/Resources/xlf/Dialogs.it.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Dialogs.it.xlf
@@ -5,7 +5,7 @@
       <trans-unit id="AIAgentsDialogAppHostDescription">
         <source>Build, debug, and profile apps using AI agents and Aspire 🚀
 
-The structured logs, distributed traces, and resource status in this dashboard are available to AI agents via the Aspire CLI and MCP server. This gives agents deep observability into your app, to help them diagnose issues and verify fixes.
+The structured logs, distributed traces, and resource status in this dashboard are available to AI agents via the Aspire CLI. This gives agents deep observability into your app, to help them diagnose issues and verify fixes.
 
 Get started by running this command in your project:
 
@@ -13,14 +13,14 @@ Get started by running this command in your project:
 aspire agent init
 ```
 
-This configures skill files for your AI assistant. The skill files tell the agent how to use Aspire CLI commands such as `aspire otel logs`, `aspire otel traces`, and `aspire agent mcp`.
+This configures skill files for your AI assistant. The skill files tell the agent how to use Aspire CLI commands such as `aspire otel logs` and `aspire otel traces`.
 
 Once connected, agents can start your app, check resource health, fetch logs and traces, and more.
 
 For more information about using AI agents with Aspire, such as setting up skills, see [AI coding agents]({0}).</source>
         <target state="new">Build, debug, and profile apps using AI agents and Aspire 🚀
 
-The structured logs, distributed traces, and resource status in this dashboard are available to AI agents via the Aspire CLI and MCP server. This gives agents deep observability into your app, to help them diagnose issues and verify fixes.
+The structured logs, distributed traces, and resource status in this dashboard are available to AI agents via the Aspire CLI. This gives agents deep observability into your app, to help them diagnose issues and verify fixes.
 
 Get started by running this command in your project:
 
@@ -28,7 +28,7 @@ Get started by running this command in your project:
 aspire agent init
 ```
 
-This configures skill files for your AI assistant. The skill files tell the agent how to use Aspire CLI commands such as `aspire otel logs`, `aspire otel traces`, and `aspire agent mcp`.
+This configures skill files for your AI assistant. The skill files tell the agent how to use Aspire CLI commands such as `aspire otel logs` and `aspire otel traces`.
 
 Once connected, agents can start your app, check resource health, fetch logs and traces, and more.
 
@@ -38,35 +38,23 @@ For more information about using AI agents with Aspire, such as setting up skill
       <trans-unit id="AIAgentsDialogStandaloneDescription">
         <source>Build, debug, and profile apps using AI agents and Aspire 🚀
 
-The structured logs and distributed traces in the dashboard are available to AI agents via the Aspire CLI and MCP server. This gives agents deep observability into your app, to help them diagnose issues and verify fixes.
+The structured logs and distributed traces in the dashboard are available to AI agents via the Aspire CLI. This gives agents deep observability into your app, to help them diagnose issues and verify fixes.
 
 Use Aspire CLI commands to get telemetry data in your terminal:
 
 ```bash
 aspire otel logs --dashboard-url {0}
-```
-
-Or start the Aspire MCP server:
-
-```bash
-aspire agent mcp --dashboard-url {0}
 ```
 
 For more information about using AI agents with the dashboard, such as setting up skills, see [Standalone dashboard and AI coding agents]({1}).</source>
         <target state="new">Build, debug, and profile apps using AI agents and Aspire 🚀
 
-The structured logs and distributed traces in the dashboard are available to AI agents via the Aspire CLI and MCP server. This gives agents deep observability into your app, to help them diagnose issues and verify fixes.
+The structured logs and distributed traces in the dashboard are available to AI agents via the Aspire CLI. This gives agents deep observability into your app, to help them diagnose issues and verify fixes.
 
 Use Aspire CLI commands to get telemetry data in your terminal:
 
 ```bash
 aspire otel logs --dashboard-url {0}
-```
-
-Or start the Aspire MCP server:
-
-```bash
-aspire agent mcp --dashboard-url {0}
 ```
 
 For more information about using AI agents with the dashboard, such as setting up skills, see [Standalone dashboard and AI coding agents]({1}).</target>

--- a/src/Aspire.Dashboard/Resources/xlf/Dialogs.ja.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Dialogs.ja.xlf
@@ -13,7 +13,7 @@ Get started by running this command in your project:
 aspire agent init
 ```
 
-This configures skill files for your AI assistant. The skill files tell the agent how to use Aspire CLI commands such as [`aspire otel logs`](https://aspire.dev/reference/cli/commands/aspire-otel/) and [`aspire otel traces`](https://aspire.dev/reference/cli/commands/aspire-otel/).
+This configures skill files for your AI assistant. The skill files tell the agent how to use Aspire CLI commands such as [`aspire logs`](https://aspire.dev/reference/cli/commands/aspire-logs/) and [`aspire otel traces`](https://aspire.dev/reference/cli/commands/aspire-otel-traces/).
 
 Once connected, agents can start your app, check resource health, fetch logs and traces, and more.
 
@@ -28,7 +28,7 @@ Get started by running this command in your project:
 aspire agent init
 ```
 
-This configures skill files for your AI assistant. The skill files tell the agent how to use Aspire CLI commands such as [`aspire otel logs`](https://aspire.dev/reference/cli/commands/aspire-otel/) and [`aspire otel traces`](https://aspire.dev/reference/cli/commands/aspire-otel/).
+This configures skill files for your AI assistant. The skill files tell the agent how to use Aspire CLI commands such as [`aspire logs`](https://aspire.dev/reference/cli/commands/aspire-logs/) and [`aspire otel traces`](https://aspire.dev/reference/cli/commands/aspire-otel-traces/).
 
 Once connected, agents can start your app, check resource health, fetch logs and traces, and more.
 
@@ -46,9 +46,9 @@ Use Aspire CLI commands to get telemetry data in your terminal:
 aspire otel logs --dashboard-url {0}
 ```
 
-- [`aspire otel logs`](https://aspire.dev/reference/cli/commands/aspire-otel/) — View structured logs
-- [`aspire otel traces`](https://aspire.dev/reference/cli/commands/aspire-otel/) — View distributed traces
-- [`aspire otel spans`](https://aspire.dev/reference/cli/commands/aspire-otel/) — View trace spans
+- [`aspire otel logs`](https://aspire.dev/reference/cli/commands/aspire-otel-logs/) — View structured logs
+- [`aspire otel traces`](https://aspire.dev/reference/cli/commands/aspire-otel-traces/) — View distributed traces
+- [`aspire otel spans`](https://aspire.dev/reference/cli/commands/aspire-otel-spans/) — View trace spans
 - [`aspire export`](https://aspire.dev/reference/cli/commands/aspire-export/) — Export telemetry and resource data to a zip file
 
 For more information about using AI agents with the dashboard, such as setting up skills, see [Standalone dashboard and AI coding agents]({1}).</source>
@@ -62,9 +62,9 @@ Use Aspire CLI commands to get telemetry data in your terminal:
 aspire otel logs --dashboard-url {0}
 ```
 
-- [`aspire otel logs`](https://aspire.dev/reference/cli/commands/aspire-otel/) — View structured logs
-- [`aspire otel traces`](https://aspire.dev/reference/cli/commands/aspire-otel/) — View distributed traces
-- [`aspire otel spans`](https://aspire.dev/reference/cli/commands/aspire-otel/) — View trace spans
+- [`aspire otel logs`](https://aspire.dev/reference/cli/commands/aspire-otel-logs/) — View structured logs
+- [`aspire otel traces`](https://aspire.dev/reference/cli/commands/aspire-otel-traces/) — View distributed traces
+- [`aspire otel spans`](https://aspire.dev/reference/cli/commands/aspire-otel-spans/) — View trace spans
 - [`aspire export`](https://aspire.dev/reference/cli/commands/aspire-export/) — Export telemetry and resource data to a zip file
 
 For more information about using AI agents with the dashboard, such as setting up skills, see [Standalone dashboard and AI coding agents]({1}).</target>

--- a/src/Aspire.Dashboard/Resources/xlf/Dialogs.ja.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Dialogs.ja.xlf
@@ -13,7 +13,7 @@ Get started by running this command in your project:
 aspire agent init
 ```
 
-This configures skill files for your AI assistant. The skill files tell the agent how to use Aspire CLI commands such as `aspire otel logs` and `aspire otel traces`.
+This configures skill files for your AI assistant. The skill files tell the agent how to use Aspire CLI commands such as [`aspire otel logs`](https://aspire.dev/reference/cli/commands/aspire-otel/) and [`aspire otel traces`](https://aspire.dev/reference/cli/commands/aspire-otel/).
 
 Once connected, agents can start your app, check resource health, fetch logs and traces, and more.
 
@@ -28,7 +28,7 @@ Get started by running this command in your project:
 aspire agent init
 ```
 
-This configures skill files for your AI assistant. The skill files tell the agent how to use Aspire CLI commands such as `aspire otel logs` and `aspire otel traces`.
+This configures skill files for your AI assistant. The skill files tell the agent how to use Aspire CLI commands such as [`aspire otel logs`](https://aspire.dev/reference/cli/commands/aspire-otel/) and [`aspire otel traces`](https://aspire.dev/reference/cli/commands/aspire-otel/).
 
 Once connected, agents can start your app, check resource health, fetch logs and traces, and more.
 
@@ -46,6 +46,11 @@ Use Aspire CLI commands to get telemetry data in your terminal:
 aspire otel logs --dashboard-url {0}
 ```
 
+- [`aspire otel logs`](https://aspire.dev/reference/cli/commands/aspire-otel/) — View structured logs
+- [`aspire otel traces`](https://aspire.dev/reference/cli/commands/aspire-otel/) — View distributed traces
+- [`aspire otel spans`](https://aspire.dev/reference/cli/commands/aspire-otel/) — View trace spans
+- [`aspire export`](https://aspire.dev/reference/cli/commands/aspire-export/) — Export telemetry and resource data to a zip file
+
 For more information about using AI agents with the dashboard, such as setting up skills, see [Standalone dashboard and AI coding agents]({1}).</source>
         <target state="new">Build, debug, and profile apps using AI agents and Aspire 🚀
 
@@ -56,6 +61,11 @@ Use Aspire CLI commands to get telemetry data in your terminal:
 ```bash
 aspire otel logs --dashboard-url {0}
 ```
+
+- [`aspire otel logs`](https://aspire.dev/reference/cli/commands/aspire-otel/) — View structured logs
+- [`aspire otel traces`](https://aspire.dev/reference/cli/commands/aspire-otel/) — View distributed traces
+- [`aspire otel spans`](https://aspire.dev/reference/cli/commands/aspire-otel/) — View trace spans
+- [`aspire export`](https://aspire.dev/reference/cli/commands/aspire-export/) — Export telemetry and resource data to a zip file
 
 For more information about using AI agents with the dashboard, such as setting up skills, see [Standalone dashboard and AI coding agents]({1}).</target>
         <note>{0} is the dashboard URL, {1} is the learn more URL</note>

--- a/src/Aspire.Dashboard/Resources/xlf/Dialogs.ja.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Dialogs.ja.xlf
@@ -5,7 +5,7 @@
       <trans-unit id="AIAgentsDialogAppHostDescription">
         <source>Build, debug, and profile apps using AI agents and Aspire 🚀
 
-The structured logs, distributed traces, and resource status in this dashboard are available to AI agents via the Aspire CLI and MCP server. This gives agents deep observability into your app, to help them diagnose issues and verify fixes.
+The structured logs, distributed traces, and resource status in this dashboard are available to AI agents via the Aspire CLI. This gives agents deep observability into your app, to help them diagnose issues and verify fixes.
 
 Get started by running this command in your project:
 
@@ -13,14 +13,14 @@ Get started by running this command in your project:
 aspire agent init
 ```
 
-This configures skill files for your AI assistant. The skill files tell the agent how to use Aspire CLI commands such as `aspire otel logs`, `aspire otel traces`, and `aspire agent mcp`.
+This configures skill files for your AI assistant. The skill files tell the agent how to use Aspire CLI commands such as `aspire otel logs` and `aspire otel traces`.
 
 Once connected, agents can start your app, check resource health, fetch logs and traces, and more.
 
 For more information about using AI agents with Aspire, such as setting up skills, see [AI coding agents]({0}).</source>
         <target state="new">Build, debug, and profile apps using AI agents and Aspire 🚀
 
-The structured logs, distributed traces, and resource status in this dashboard are available to AI agents via the Aspire CLI and MCP server. This gives agents deep observability into your app, to help them diagnose issues and verify fixes.
+The structured logs, distributed traces, and resource status in this dashboard are available to AI agents via the Aspire CLI. This gives agents deep observability into your app, to help them diagnose issues and verify fixes.
 
 Get started by running this command in your project:
 
@@ -28,7 +28,7 @@ Get started by running this command in your project:
 aspire agent init
 ```
 
-This configures skill files for your AI assistant. The skill files tell the agent how to use Aspire CLI commands such as `aspire otel logs`, `aspire otel traces`, and `aspire agent mcp`.
+This configures skill files for your AI assistant. The skill files tell the agent how to use Aspire CLI commands such as `aspire otel logs` and `aspire otel traces`.
 
 Once connected, agents can start your app, check resource health, fetch logs and traces, and more.
 
@@ -38,35 +38,23 @@ For more information about using AI agents with Aspire, such as setting up skill
       <trans-unit id="AIAgentsDialogStandaloneDescription">
         <source>Build, debug, and profile apps using AI agents and Aspire 🚀
 
-The structured logs and distributed traces in the dashboard are available to AI agents via the Aspire CLI and MCP server. This gives agents deep observability into your app, to help them diagnose issues and verify fixes.
+The structured logs and distributed traces in the dashboard are available to AI agents via the Aspire CLI. This gives agents deep observability into your app, to help them diagnose issues and verify fixes.
 
 Use Aspire CLI commands to get telemetry data in your terminal:
 
 ```bash
 aspire otel logs --dashboard-url {0}
-```
-
-Or start the Aspire MCP server:
-
-```bash
-aspire agent mcp --dashboard-url {0}
 ```
 
 For more information about using AI agents with the dashboard, such as setting up skills, see [Standalone dashboard and AI coding agents]({1}).</source>
         <target state="new">Build, debug, and profile apps using AI agents and Aspire 🚀
 
-The structured logs and distributed traces in the dashboard are available to AI agents via the Aspire CLI and MCP server. This gives agents deep observability into your app, to help them diagnose issues and verify fixes.
+The structured logs and distributed traces in the dashboard are available to AI agents via the Aspire CLI. This gives agents deep observability into your app, to help them diagnose issues and verify fixes.
 
 Use Aspire CLI commands to get telemetry data in your terminal:
 
 ```bash
 aspire otel logs --dashboard-url {0}
-```
-
-Or start the Aspire MCP server:
-
-```bash
-aspire agent mcp --dashboard-url {0}
 ```
 
 For more information about using AI agents with the dashboard, such as setting up skills, see [Standalone dashboard and AI coding agents]({1}).</target>

--- a/src/Aspire.Dashboard/Resources/xlf/Dialogs.ja.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Dialogs.ja.xlf
@@ -2,6 +2,81 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="ja" original="../Dialogs.resx">
     <body>
+      <trans-unit id="AIAgentsDialogAppHostDescription">
+        <source>Build, debug, and profile apps using AI agents and Aspire 🚀
+
+The structured logs, distributed traces, and resource status in this dashboard are available to AI agents via the Aspire CLI and MCP server. This gives agents deep observability into your app, to help them diagnose issues and verify fixes.
+
+Get started by running this command in your project:
+
+```bash
+aspire agent init
+```
+
+This configures skill files for your AI assistant. The skill files tell the agent how to use Aspire CLI commands such as `aspire otel logs`, `aspire otel traces`, and `aspire agent mcp`.
+
+Once connected, agents can start your app, check resource health, fetch logs and traces, and more.
+
+For more information about using AI agents with Aspire, such as setting up skills, see [AI coding agents]({0}).</source>
+        <target state="new">Build, debug, and profile apps using AI agents and Aspire 🚀
+
+The structured logs, distributed traces, and resource status in this dashboard are available to AI agents via the Aspire CLI and MCP server. This gives agents deep observability into your app, to help them diagnose issues and verify fixes.
+
+Get started by running this command in your project:
+
+```bash
+aspire agent init
+```
+
+This configures skill files for your AI assistant. The skill files tell the agent how to use Aspire CLI commands such as `aspire otel logs`, `aspire otel traces`, and `aspire agent mcp`.
+
+Once connected, agents can start your app, check resource health, fetch logs and traces, and more.
+
+For more information about using AI agents with Aspire, such as setting up skills, see [AI coding agents]({0}).</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AIAgentsDialogStandaloneDescription">
+        <source>Build, debug, and profile apps using AI agents and Aspire 🚀
+
+The structured logs and distributed traces in the dashboard are available to AI agents via the Aspire CLI and MCP server. This gives agents deep observability into your app, to help them diagnose issues and verify fixes.
+
+Use Aspire CLI commands to get telemetry data in your terminal:
+
+```bash
+aspire otel logs --dashboard-url {0}
+```
+
+Or start the Aspire MCP server:
+
+```bash
+aspire agent mcp --dashboard-url {0}
+```
+
+For more information about using AI agents with the dashboard, such as setting up skills, see [Standalone dashboard and AI coding agents]({1}).</source>
+        <target state="new">Build, debug, and profile apps using AI agents and Aspire 🚀
+
+The structured logs and distributed traces in the dashboard are available to AI agents via the Aspire CLI and MCP server. This gives agents deep observability into your app, to help them diagnose issues and verify fixes.
+
+Use Aspire CLI commands to get telemetry data in your terminal:
+
+```bash
+aspire otel logs --dashboard-url {0}
+```
+
+Or start the Aspire MCP server:
+
+```bash
+aspire agent mcp --dashboard-url {0}
+```
+
+For more information about using AI agents with the dashboard, such as setting up skills, see [Standalone dashboard and AI coding agents]({1}).</target>
+        <note>{0} is the dashboard URL, {1} is the learn more URL</note>
+      </trans-unit>
+      <trans-unit id="AIAgentsDialogTitle">
+        <source>AI agents</source>
+        <target state="new">AI agents</target>
+        <note />
+      </trans-unit>
       <trans-unit id="DialogCloseButtonText">
         <source>Close</source>
         <target state="translated">閉じる</target>

--- a/src/Aspire.Dashboard/Resources/xlf/Dialogs.ko.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Dialogs.ko.xlf
@@ -13,7 +13,7 @@ Get started by running this command in your project:
 aspire agent init
 ```
 
-This configures skill files for your AI assistant. The skill files tell the agent how to use Aspire CLI commands such as [`aspire otel logs`](https://aspire.dev/reference/cli/commands/aspire-otel/) and [`aspire otel traces`](https://aspire.dev/reference/cli/commands/aspire-otel/).
+This configures skill files for your AI assistant. The skill files tell the agent how to use Aspire CLI commands such as [`aspire logs`](https://aspire.dev/reference/cli/commands/aspire-logs/) and [`aspire otel traces`](https://aspire.dev/reference/cli/commands/aspire-otel-traces/).
 
 Once connected, agents can start your app, check resource health, fetch logs and traces, and more.
 
@@ -28,7 +28,7 @@ Get started by running this command in your project:
 aspire agent init
 ```
 
-This configures skill files for your AI assistant. The skill files tell the agent how to use Aspire CLI commands such as [`aspire otel logs`](https://aspire.dev/reference/cli/commands/aspire-otel/) and [`aspire otel traces`](https://aspire.dev/reference/cli/commands/aspire-otel/).
+This configures skill files for your AI assistant. The skill files tell the agent how to use Aspire CLI commands such as [`aspire logs`](https://aspire.dev/reference/cli/commands/aspire-logs/) and [`aspire otel traces`](https://aspire.dev/reference/cli/commands/aspire-otel-traces/).
 
 Once connected, agents can start your app, check resource health, fetch logs and traces, and more.
 
@@ -46,9 +46,9 @@ Use Aspire CLI commands to get telemetry data in your terminal:
 aspire otel logs --dashboard-url {0}
 ```
 
-- [`aspire otel logs`](https://aspire.dev/reference/cli/commands/aspire-otel/) — View structured logs
-- [`aspire otel traces`](https://aspire.dev/reference/cli/commands/aspire-otel/) — View distributed traces
-- [`aspire otel spans`](https://aspire.dev/reference/cli/commands/aspire-otel/) — View trace spans
+- [`aspire otel logs`](https://aspire.dev/reference/cli/commands/aspire-otel-logs/) — View structured logs
+- [`aspire otel traces`](https://aspire.dev/reference/cli/commands/aspire-otel-traces/) — View distributed traces
+- [`aspire otel spans`](https://aspire.dev/reference/cli/commands/aspire-otel-spans/) — View trace spans
 - [`aspire export`](https://aspire.dev/reference/cli/commands/aspire-export/) — Export telemetry and resource data to a zip file
 
 For more information about using AI agents with the dashboard, such as setting up skills, see [Standalone dashboard and AI coding agents]({1}).</source>
@@ -62,9 +62,9 @@ Use Aspire CLI commands to get telemetry data in your terminal:
 aspire otel logs --dashboard-url {0}
 ```
 
-- [`aspire otel logs`](https://aspire.dev/reference/cli/commands/aspire-otel/) — View structured logs
-- [`aspire otel traces`](https://aspire.dev/reference/cli/commands/aspire-otel/) — View distributed traces
-- [`aspire otel spans`](https://aspire.dev/reference/cli/commands/aspire-otel/) — View trace spans
+- [`aspire otel logs`](https://aspire.dev/reference/cli/commands/aspire-otel-logs/) — View structured logs
+- [`aspire otel traces`](https://aspire.dev/reference/cli/commands/aspire-otel-traces/) — View distributed traces
+- [`aspire otel spans`](https://aspire.dev/reference/cli/commands/aspire-otel-spans/) — View trace spans
 - [`aspire export`](https://aspire.dev/reference/cli/commands/aspire-export/) — Export telemetry and resource data to a zip file
 
 For more information about using AI agents with the dashboard, such as setting up skills, see [Standalone dashboard and AI coding agents]({1}).</target>

--- a/src/Aspire.Dashboard/Resources/xlf/Dialogs.ko.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Dialogs.ko.xlf
@@ -13,7 +13,7 @@ Get started by running this command in your project:
 aspire agent init
 ```
 
-This configures skill files for your AI assistant. The skill files tell the agent how to use Aspire CLI commands such as `aspire otel logs` and `aspire otel traces`.
+This configures skill files for your AI assistant. The skill files tell the agent how to use Aspire CLI commands such as [`aspire otel logs`](https://aspire.dev/reference/cli/commands/aspire-otel/) and [`aspire otel traces`](https://aspire.dev/reference/cli/commands/aspire-otel/).
 
 Once connected, agents can start your app, check resource health, fetch logs and traces, and more.
 
@@ -28,7 +28,7 @@ Get started by running this command in your project:
 aspire agent init
 ```
 
-This configures skill files for your AI assistant. The skill files tell the agent how to use Aspire CLI commands such as `aspire otel logs` and `aspire otel traces`.
+This configures skill files for your AI assistant. The skill files tell the agent how to use Aspire CLI commands such as [`aspire otel logs`](https://aspire.dev/reference/cli/commands/aspire-otel/) and [`aspire otel traces`](https://aspire.dev/reference/cli/commands/aspire-otel/).
 
 Once connected, agents can start your app, check resource health, fetch logs and traces, and more.
 
@@ -46,6 +46,11 @@ Use Aspire CLI commands to get telemetry data in your terminal:
 aspire otel logs --dashboard-url {0}
 ```
 
+- [`aspire otel logs`](https://aspire.dev/reference/cli/commands/aspire-otel/) — View structured logs
+- [`aspire otel traces`](https://aspire.dev/reference/cli/commands/aspire-otel/) — View distributed traces
+- [`aspire otel spans`](https://aspire.dev/reference/cli/commands/aspire-otel/) — View trace spans
+- [`aspire export`](https://aspire.dev/reference/cli/commands/aspire-export/) — Export telemetry and resource data to a zip file
+
 For more information about using AI agents with the dashboard, such as setting up skills, see [Standalone dashboard and AI coding agents]({1}).</source>
         <target state="new">Build, debug, and profile apps using AI agents and Aspire 🚀
 
@@ -56,6 +61,11 @@ Use Aspire CLI commands to get telemetry data in your terminal:
 ```bash
 aspire otel logs --dashboard-url {0}
 ```
+
+- [`aspire otel logs`](https://aspire.dev/reference/cli/commands/aspire-otel/) — View structured logs
+- [`aspire otel traces`](https://aspire.dev/reference/cli/commands/aspire-otel/) — View distributed traces
+- [`aspire otel spans`](https://aspire.dev/reference/cli/commands/aspire-otel/) — View trace spans
+- [`aspire export`](https://aspire.dev/reference/cli/commands/aspire-export/) — Export telemetry and resource data to a zip file
 
 For more information about using AI agents with the dashboard, such as setting up skills, see [Standalone dashboard and AI coding agents]({1}).</target>
         <note>{0} is the dashboard URL, {1} is the learn more URL</note>

--- a/src/Aspire.Dashboard/Resources/xlf/Dialogs.ko.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Dialogs.ko.xlf
@@ -5,7 +5,7 @@
       <trans-unit id="AIAgentsDialogAppHostDescription">
         <source>Build, debug, and profile apps using AI agents and Aspire 🚀
 
-The structured logs, distributed traces, and resource status in this dashboard are available to AI agents via the Aspire CLI and MCP server. This gives agents deep observability into your app, to help them diagnose issues and verify fixes.
+The structured logs, distributed traces, and resource status in this dashboard are available to AI agents via the Aspire CLI. This gives agents deep observability into your app, to help them diagnose issues and verify fixes.
 
 Get started by running this command in your project:
 
@@ -13,14 +13,14 @@ Get started by running this command in your project:
 aspire agent init
 ```
 
-This configures skill files for your AI assistant. The skill files tell the agent how to use Aspire CLI commands such as `aspire otel logs`, `aspire otel traces`, and `aspire agent mcp`.
+This configures skill files for your AI assistant. The skill files tell the agent how to use Aspire CLI commands such as `aspire otel logs` and `aspire otel traces`.
 
 Once connected, agents can start your app, check resource health, fetch logs and traces, and more.
 
 For more information about using AI agents with Aspire, such as setting up skills, see [AI coding agents]({0}).</source>
         <target state="new">Build, debug, and profile apps using AI agents and Aspire 🚀
 
-The structured logs, distributed traces, and resource status in this dashboard are available to AI agents via the Aspire CLI and MCP server. This gives agents deep observability into your app, to help them diagnose issues and verify fixes.
+The structured logs, distributed traces, and resource status in this dashboard are available to AI agents via the Aspire CLI. This gives agents deep observability into your app, to help them diagnose issues and verify fixes.
 
 Get started by running this command in your project:
 
@@ -28,7 +28,7 @@ Get started by running this command in your project:
 aspire agent init
 ```
 
-This configures skill files for your AI assistant. The skill files tell the agent how to use Aspire CLI commands such as `aspire otel logs`, `aspire otel traces`, and `aspire agent mcp`.
+This configures skill files for your AI assistant. The skill files tell the agent how to use Aspire CLI commands such as `aspire otel logs` and `aspire otel traces`.
 
 Once connected, agents can start your app, check resource health, fetch logs and traces, and more.
 
@@ -38,35 +38,23 @@ For more information about using AI agents with Aspire, such as setting up skill
       <trans-unit id="AIAgentsDialogStandaloneDescription">
         <source>Build, debug, and profile apps using AI agents and Aspire 🚀
 
-The structured logs and distributed traces in the dashboard are available to AI agents via the Aspire CLI and MCP server. This gives agents deep observability into your app, to help them diagnose issues and verify fixes.
+The structured logs and distributed traces in the dashboard are available to AI agents via the Aspire CLI. This gives agents deep observability into your app, to help them diagnose issues and verify fixes.
 
 Use Aspire CLI commands to get telemetry data in your terminal:
 
 ```bash
 aspire otel logs --dashboard-url {0}
-```
-
-Or start the Aspire MCP server:
-
-```bash
-aspire agent mcp --dashboard-url {0}
 ```
 
 For more information about using AI agents with the dashboard, such as setting up skills, see [Standalone dashboard and AI coding agents]({1}).</source>
         <target state="new">Build, debug, and profile apps using AI agents and Aspire 🚀
 
-The structured logs and distributed traces in the dashboard are available to AI agents via the Aspire CLI and MCP server. This gives agents deep observability into your app, to help them diagnose issues and verify fixes.
+The structured logs and distributed traces in the dashboard are available to AI agents via the Aspire CLI. This gives agents deep observability into your app, to help them diagnose issues and verify fixes.
 
 Use Aspire CLI commands to get telemetry data in your terminal:
 
 ```bash
 aspire otel logs --dashboard-url {0}
-```
-
-Or start the Aspire MCP server:
-
-```bash
-aspire agent mcp --dashboard-url {0}
 ```
 
 For more information about using AI agents with the dashboard, such as setting up skills, see [Standalone dashboard and AI coding agents]({1}).</target>

--- a/src/Aspire.Dashboard/Resources/xlf/Dialogs.ko.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Dialogs.ko.xlf
@@ -2,6 +2,81 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="ko" original="../Dialogs.resx">
     <body>
+      <trans-unit id="AIAgentsDialogAppHostDescription">
+        <source>Build, debug, and profile apps using AI agents and Aspire 🚀
+
+The structured logs, distributed traces, and resource status in this dashboard are available to AI agents via the Aspire CLI and MCP server. This gives agents deep observability into your app, to help them diagnose issues and verify fixes.
+
+Get started by running this command in your project:
+
+```bash
+aspire agent init
+```
+
+This configures skill files for your AI assistant. The skill files tell the agent how to use Aspire CLI commands such as `aspire otel logs`, `aspire otel traces`, and `aspire agent mcp`.
+
+Once connected, agents can start your app, check resource health, fetch logs and traces, and more.
+
+For more information about using AI agents with Aspire, such as setting up skills, see [AI coding agents]({0}).</source>
+        <target state="new">Build, debug, and profile apps using AI agents and Aspire 🚀
+
+The structured logs, distributed traces, and resource status in this dashboard are available to AI agents via the Aspire CLI and MCP server. This gives agents deep observability into your app, to help them diagnose issues and verify fixes.
+
+Get started by running this command in your project:
+
+```bash
+aspire agent init
+```
+
+This configures skill files for your AI assistant. The skill files tell the agent how to use Aspire CLI commands such as `aspire otel logs`, `aspire otel traces`, and `aspire agent mcp`.
+
+Once connected, agents can start your app, check resource health, fetch logs and traces, and more.
+
+For more information about using AI agents with Aspire, such as setting up skills, see [AI coding agents]({0}).</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AIAgentsDialogStandaloneDescription">
+        <source>Build, debug, and profile apps using AI agents and Aspire 🚀
+
+The structured logs and distributed traces in the dashboard are available to AI agents via the Aspire CLI and MCP server. This gives agents deep observability into your app, to help them diagnose issues and verify fixes.
+
+Use Aspire CLI commands to get telemetry data in your terminal:
+
+```bash
+aspire otel logs --dashboard-url {0}
+```
+
+Or start the Aspire MCP server:
+
+```bash
+aspire agent mcp --dashboard-url {0}
+```
+
+For more information about using AI agents with the dashboard, such as setting up skills, see [Standalone dashboard and AI coding agents]({1}).</source>
+        <target state="new">Build, debug, and profile apps using AI agents and Aspire 🚀
+
+The structured logs and distributed traces in the dashboard are available to AI agents via the Aspire CLI and MCP server. This gives agents deep observability into your app, to help them diagnose issues and verify fixes.
+
+Use Aspire CLI commands to get telemetry data in your terminal:
+
+```bash
+aspire otel logs --dashboard-url {0}
+```
+
+Or start the Aspire MCP server:
+
+```bash
+aspire agent mcp --dashboard-url {0}
+```
+
+For more information about using AI agents with the dashboard, such as setting up skills, see [Standalone dashboard and AI coding agents]({1}).</target>
+        <note>{0} is the dashboard URL, {1} is the learn more URL</note>
+      </trans-unit>
+      <trans-unit id="AIAgentsDialogTitle">
+        <source>AI agents</source>
+        <target state="new">AI agents</target>
+        <note />
+      </trans-unit>
       <trans-unit id="DialogCloseButtonText">
         <source>Close</source>
         <target state="translated">닫기</target>

--- a/src/Aspire.Dashboard/Resources/xlf/Dialogs.pl.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Dialogs.pl.xlf
@@ -13,7 +13,7 @@ Get started by running this command in your project:
 aspire agent init
 ```
 
-This configures skill files for your AI assistant. The skill files tell the agent how to use Aspire CLI commands such as [`aspire otel logs`](https://aspire.dev/reference/cli/commands/aspire-otel/) and [`aspire otel traces`](https://aspire.dev/reference/cli/commands/aspire-otel/).
+This configures skill files for your AI assistant. The skill files tell the agent how to use Aspire CLI commands such as [`aspire logs`](https://aspire.dev/reference/cli/commands/aspire-logs/) and [`aspire otel traces`](https://aspire.dev/reference/cli/commands/aspire-otel-traces/).
 
 Once connected, agents can start your app, check resource health, fetch logs and traces, and more.
 
@@ -28,7 +28,7 @@ Get started by running this command in your project:
 aspire agent init
 ```
 
-This configures skill files for your AI assistant. The skill files tell the agent how to use Aspire CLI commands such as [`aspire otel logs`](https://aspire.dev/reference/cli/commands/aspire-otel/) and [`aspire otel traces`](https://aspire.dev/reference/cli/commands/aspire-otel/).
+This configures skill files for your AI assistant. The skill files tell the agent how to use Aspire CLI commands such as [`aspire logs`](https://aspire.dev/reference/cli/commands/aspire-logs/) and [`aspire otel traces`](https://aspire.dev/reference/cli/commands/aspire-otel-traces/).
 
 Once connected, agents can start your app, check resource health, fetch logs and traces, and more.
 
@@ -46,9 +46,9 @@ Use Aspire CLI commands to get telemetry data in your terminal:
 aspire otel logs --dashboard-url {0}
 ```
 
-- [`aspire otel logs`](https://aspire.dev/reference/cli/commands/aspire-otel/) — View structured logs
-- [`aspire otel traces`](https://aspire.dev/reference/cli/commands/aspire-otel/) — View distributed traces
-- [`aspire otel spans`](https://aspire.dev/reference/cli/commands/aspire-otel/) — View trace spans
+- [`aspire otel logs`](https://aspire.dev/reference/cli/commands/aspire-otel-logs/) — View structured logs
+- [`aspire otel traces`](https://aspire.dev/reference/cli/commands/aspire-otel-traces/) — View distributed traces
+- [`aspire otel spans`](https://aspire.dev/reference/cli/commands/aspire-otel-spans/) — View trace spans
 - [`aspire export`](https://aspire.dev/reference/cli/commands/aspire-export/) — Export telemetry and resource data to a zip file
 
 For more information about using AI agents with the dashboard, such as setting up skills, see [Standalone dashboard and AI coding agents]({1}).</source>
@@ -62,9 +62,9 @@ Use Aspire CLI commands to get telemetry data in your terminal:
 aspire otel logs --dashboard-url {0}
 ```
 
-- [`aspire otel logs`](https://aspire.dev/reference/cli/commands/aspire-otel/) — View structured logs
-- [`aspire otel traces`](https://aspire.dev/reference/cli/commands/aspire-otel/) — View distributed traces
-- [`aspire otel spans`](https://aspire.dev/reference/cli/commands/aspire-otel/) — View trace spans
+- [`aspire otel logs`](https://aspire.dev/reference/cli/commands/aspire-otel-logs/) — View structured logs
+- [`aspire otel traces`](https://aspire.dev/reference/cli/commands/aspire-otel-traces/) — View distributed traces
+- [`aspire otel spans`](https://aspire.dev/reference/cli/commands/aspire-otel-spans/) — View trace spans
 - [`aspire export`](https://aspire.dev/reference/cli/commands/aspire-export/) — Export telemetry and resource data to a zip file
 
 For more information about using AI agents with the dashboard, such as setting up skills, see [Standalone dashboard and AI coding agents]({1}).</target>

--- a/src/Aspire.Dashboard/Resources/xlf/Dialogs.pl.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Dialogs.pl.xlf
@@ -13,7 +13,7 @@ Get started by running this command in your project:
 aspire agent init
 ```
 
-This configures skill files for your AI assistant. The skill files tell the agent how to use Aspire CLI commands such as `aspire otel logs` and `aspire otel traces`.
+This configures skill files for your AI assistant. The skill files tell the agent how to use Aspire CLI commands such as [`aspire otel logs`](https://aspire.dev/reference/cli/commands/aspire-otel/) and [`aspire otel traces`](https://aspire.dev/reference/cli/commands/aspire-otel/).
 
 Once connected, agents can start your app, check resource health, fetch logs and traces, and more.
 
@@ -28,7 +28,7 @@ Get started by running this command in your project:
 aspire agent init
 ```
 
-This configures skill files for your AI assistant. The skill files tell the agent how to use Aspire CLI commands such as `aspire otel logs` and `aspire otel traces`.
+This configures skill files for your AI assistant. The skill files tell the agent how to use Aspire CLI commands such as [`aspire otel logs`](https://aspire.dev/reference/cli/commands/aspire-otel/) and [`aspire otel traces`](https://aspire.dev/reference/cli/commands/aspire-otel/).
 
 Once connected, agents can start your app, check resource health, fetch logs and traces, and more.
 
@@ -46,6 +46,11 @@ Use Aspire CLI commands to get telemetry data in your terminal:
 aspire otel logs --dashboard-url {0}
 ```
 
+- [`aspire otel logs`](https://aspire.dev/reference/cli/commands/aspire-otel/) — View structured logs
+- [`aspire otel traces`](https://aspire.dev/reference/cli/commands/aspire-otel/) — View distributed traces
+- [`aspire otel spans`](https://aspire.dev/reference/cli/commands/aspire-otel/) — View trace spans
+- [`aspire export`](https://aspire.dev/reference/cli/commands/aspire-export/) — Export telemetry and resource data to a zip file
+
 For more information about using AI agents with the dashboard, such as setting up skills, see [Standalone dashboard and AI coding agents]({1}).</source>
         <target state="new">Build, debug, and profile apps using AI agents and Aspire 🚀
 
@@ -56,6 +61,11 @@ Use Aspire CLI commands to get telemetry data in your terminal:
 ```bash
 aspire otel logs --dashboard-url {0}
 ```
+
+- [`aspire otel logs`](https://aspire.dev/reference/cli/commands/aspire-otel/) — View structured logs
+- [`aspire otel traces`](https://aspire.dev/reference/cli/commands/aspire-otel/) — View distributed traces
+- [`aspire otel spans`](https://aspire.dev/reference/cli/commands/aspire-otel/) — View trace spans
+- [`aspire export`](https://aspire.dev/reference/cli/commands/aspire-export/) — Export telemetry and resource data to a zip file
 
 For more information about using AI agents with the dashboard, such as setting up skills, see [Standalone dashboard and AI coding agents]({1}).</target>
         <note>{0} is the dashboard URL, {1} is the learn more URL</note>

--- a/src/Aspire.Dashboard/Resources/xlf/Dialogs.pl.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Dialogs.pl.xlf
@@ -5,7 +5,7 @@
       <trans-unit id="AIAgentsDialogAppHostDescription">
         <source>Build, debug, and profile apps using AI agents and Aspire 🚀
 
-The structured logs, distributed traces, and resource status in this dashboard are available to AI agents via the Aspire CLI and MCP server. This gives agents deep observability into your app, to help them diagnose issues and verify fixes.
+The structured logs, distributed traces, and resource status in this dashboard are available to AI agents via the Aspire CLI. This gives agents deep observability into your app, to help them diagnose issues and verify fixes.
 
 Get started by running this command in your project:
 
@@ -13,14 +13,14 @@ Get started by running this command in your project:
 aspire agent init
 ```
 
-This configures skill files for your AI assistant. The skill files tell the agent how to use Aspire CLI commands such as `aspire otel logs`, `aspire otel traces`, and `aspire agent mcp`.
+This configures skill files for your AI assistant. The skill files tell the agent how to use Aspire CLI commands such as `aspire otel logs` and `aspire otel traces`.
 
 Once connected, agents can start your app, check resource health, fetch logs and traces, and more.
 
 For more information about using AI agents with Aspire, such as setting up skills, see [AI coding agents]({0}).</source>
         <target state="new">Build, debug, and profile apps using AI agents and Aspire 🚀
 
-The structured logs, distributed traces, and resource status in this dashboard are available to AI agents via the Aspire CLI and MCP server. This gives agents deep observability into your app, to help them diagnose issues and verify fixes.
+The structured logs, distributed traces, and resource status in this dashboard are available to AI agents via the Aspire CLI. This gives agents deep observability into your app, to help them diagnose issues and verify fixes.
 
 Get started by running this command in your project:
 
@@ -28,7 +28,7 @@ Get started by running this command in your project:
 aspire agent init
 ```
 
-This configures skill files for your AI assistant. The skill files tell the agent how to use Aspire CLI commands such as `aspire otel logs`, `aspire otel traces`, and `aspire agent mcp`.
+This configures skill files for your AI assistant. The skill files tell the agent how to use Aspire CLI commands such as `aspire otel logs` and `aspire otel traces`.
 
 Once connected, agents can start your app, check resource health, fetch logs and traces, and more.
 
@@ -38,35 +38,23 @@ For more information about using AI agents with Aspire, such as setting up skill
       <trans-unit id="AIAgentsDialogStandaloneDescription">
         <source>Build, debug, and profile apps using AI agents and Aspire 🚀
 
-The structured logs and distributed traces in the dashboard are available to AI agents via the Aspire CLI and MCP server. This gives agents deep observability into your app, to help them diagnose issues and verify fixes.
+The structured logs and distributed traces in the dashboard are available to AI agents via the Aspire CLI. This gives agents deep observability into your app, to help them diagnose issues and verify fixes.
 
 Use Aspire CLI commands to get telemetry data in your terminal:
 
 ```bash
 aspire otel logs --dashboard-url {0}
-```
-
-Or start the Aspire MCP server:
-
-```bash
-aspire agent mcp --dashboard-url {0}
 ```
 
 For more information about using AI agents with the dashboard, such as setting up skills, see [Standalone dashboard and AI coding agents]({1}).</source>
         <target state="new">Build, debug, and profile apps using AI agents and Aspire 🚀
 
-The structured logs and distributed traces in the dashboard are available to AI agents via the Aspire CLI and MCP server. This gives agents deep observability into your app, to help them diagnose issues and verify fixes.
+The structured logs and distributed traces in the dashboard are available to AI agents via the Aspire CLI. This gives agents deep observability into your app, to help them diagnose issues and verify fixes.
 
 Use Aspire CLI commands to get telemetry data in your terminal:
 
 ```bash
 aspire otel logs --dashboard-url {0}
-```
-
-Or start the Aspire MCP server:
-
-```bash
-aspire agent mcp --dashboard-url {0}
 ```
 
 For more information about using AI agents with the dashboard, such as setting up skills, see [Standalone dashboard and AI coding agents]({1}).</target>

--- a/src/Aspire.Dashboard/Resources/xlf/Dialogs.pl.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Dialogs.pl.xlf
@@ -2,6 +2,81 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="pl" original="../Dialogs.resx">
     <body>
+      <trans-unit id="AIAgentsDialogAppHostDescription">
+        <source>Build, debug, and profile apps using AI agents and Aspire 🚀
+
+The structured logs, distributed traces, and resource status in this dashboard are available to AI agents via the Aspire CLI and MCP server. This gives agents deep observability into your app, to help them diagnose issues and verify fixes.
+
+Get started by running this command in your project:
+
+```bash
+aspire agent init
+```
+
+This configures skill files for your AI assistant. The skill files tell the agent how to use Aspire CLI commands such as `aspire otel logs`, `aspire otel traces`, and `aspire agent mcp`.
+
+Once connected, agents can start your app, check resource health, fetch logs and traces, and more.
+
+For more information about using AI agents with Aspire, such as setting up skills, see [AI coding agents]({0}).</source>
+        <target state="new">Build, debug, and profile apps using AI agents and Aspire 🚀
+
+The structured logs, distributed traces, and resource status in this dashboard are available to AI agents via the Aspire CLI and MCP server. This gives agents deep observability into your app, to help them diagnose issues and verify fixes.
+
+Get started by running this command in your project:
+
+```bash
+aspire agent init
+```
+
+This configures skill files for your AI assistant. The skill files tell the agent how to use Aspire CLI commands such as `aspire otel logs`, `aspire otel traces`, and `aspire agent mcp`.
+
+Once connected, agents can start your app, check resource health, fetch logs and traces, and more.
+
+For more information about using AI agents with Aspire, such as setting up skills, see [AI coding agents]({0}).</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AIAgentsDialogStandaloneDescription">
+        <source>Build, debug, and profile apps using AI agents and Aspire 🚀
+
+The structured logs and distributed traces in the dashboard are available to AI agents via the Aspire CLI and MCP server. This gives agents deep observability into your app, to help them diagnose issues and verify fixes.
+
+Use Aspire CLI commands to get telemetry data in your terminal:
+
+```bash
+aspire otel logs --dashboard-url {0}
+```
+
+Or start the Aspire MCP server:
+
+```bash
+aspire agent mcp --dashboard-url {0}
+```
+
+For more information about using AI agents with the dashboard, such as setting up skills, see [Standalone dashboard and AI coding agents]({1}).</source>
+        <target state="new">Build, debug, and profile apps using AI agents and Aspire 🚀
+
+The structured logs and distributed traces in the dashboard are available to AI agents via the Aspire CLI and MCP server. This gives agents deep observability into your app, to help them diagnose issues and verify fixes.
+
+Use Aspire CLI commands to get telemetry data in your terminal:
+
+```bash
+aspire otel logs --dashboard-url {0}
+```
+
+Or start the Aspire MCP server:
+
+```bash
+aspire agent mcp --dashboard-url {0}
+```
+
+For more information about using AI agents with the dashboard, such as setting up skills, see [Standalone dashboard and AI coding agents]({1}).</target>
+        <note>{0} is the dashboard URL, {1} is the learn more URL</note>
+      </trans-unit>
+      <trans-unit id="AIAgentsDialogTitle">
+        <source>AI agents</source>
+        <target state="new">AI agents</target>
+        <note />
+      </trans-unit>
       <trans-unit id="DialogCloseButtonText">
         <source>Close</source>
         <target state="translated">Zamknij</target>

--- a/src/Aspire.Dashboard/Resources/xlf/Dialogs.pt-BR.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Dialogs.pt-BR.xlf
@@ -13,7 +13,7 @@ Get started by running this command in your project:
 aspire agent init
 ```
 
-This configures skill files for your AI assistant. The skill files tell the agent how to use Aspire CLI commands such as [`aspire otel logs`](https://aspire.dev/reference/cli/commands/aspire-otel/) and [`aspire otel traces`](https://aspire.dev/reference/cli/commands/aspire-otel/).
+This configures skill files for your AI assistant. The skill files tell the agent how to use Aspire CLI commands such as [`aspire logs`](https://aspire.dev/reference/cli/commands/aspire-logs/) and [`aspire otel traces`](https://aspire.dev/reference/cli/commands/aspire-otel-traces/).
 
 Once connected, agents can start your app, check resource health, fetch logs and traces, and more.
 
@@ -28,7 +28,7 @@ Get started by running this command in your project:
 aspire agent init
 ```
 
-This configures skill files for your AI assistant. The skill files tell the agent how to use Aspire CLI commands such as [`aspire otel logs`](https://aspire.dev/reference/cli/commands/aspire-otel/) and [`aspire otel traces`](https://aspire.dev/reference/cli/commands/aspire-otel/).
+This configures skill files for your AI assistant. The skill files tell the agent how to use Aspire CLI commands such as [`aspire logs`](https://aspire.dev/reference/cli/commands/aspire-logs/) and [`aspire otel traces`](https://aspire.dev/reference/cli/commands/aspire-otel-traces/).
 
 Once connected, agents can start your app, check resource health, fetch logs and traces, and more.
 
@@ -46,9 +46,9 @@ Use Aspire CLI commands to get telemetry data in your terminal:
 aspire otel logs --dashboard-url {0}
 ```
 
-- [`aspire otel logs`](https://aspire.dev/reference/cli/commands/aspire-otel/) — View structured logs
-- [`aspire otel traces`](https://aspire.dev/reference/cli/commands/aspire-otel/) — View distributed traces
-- [`aspire otel spans`](https://aspire.dev/reference/cli/commands/aspire-otel/) — View trace spans
+- [`aspire otel logs`](https://aspire.dev/reference/cli/commands/aspire-otel-logs/) — View structured logs
+- [`aspire otel traces`](https://aspire.dev/reference/cli/commands/aspire-otel-traces/) — View distributed traces
+- [`aspire otel spans`](https://aspire.dev/reference/cli/commands/aspire-otel-spans/) — View trace spans
 - [`aspire export`](https://aspire.dev/reference/cli/commands/aspire-export/) — Export telemetry and resource data to a zip file
 
 For more information about using AI agents with the dashboard, such as setting up skills, see [Standalone dashboard and AI coding agents]({1}).</source>
@@ -62,9 +62,9 @@ Use Aspire CLI commands to get telemetry data in your terminal:
 aspire otel logs --dashboard-url {0}
 ```
 
-- [`aspire otel logs`](https://aspire.dev/reference/cli/commands/aspire-otel/) — View structured logs
-- [`aspire otel traces`](https://aspire.dev/reference/cli/commands/aspire-otel/) — View distributed traces
-- [`aspire otel spans`](https://aspire.dev/reference/cli/commands/aspire-otel/) — View trace spans
+- [`aspire otel logs`](https://aspire.dev/reference/cli/commands/aspire-otel-logs/) — View structured logs
+- [`aspire otel traces`](https://aspire.dev/reference/cli/commands/aspire-otel-traces/) — View distributed traces
+- [`aspire otel spans`](https://aspire.dev/reference/cli/commands/aspire-otel-spans/) — View trace spans
 - [`aspire export`](https://aspire.dev/reference/cli/commands/aspire-export/) — Export telemetry and resource data to a zip file
 
 For more information about using AI agents with the dashboard, such as setting up skills, see [Standalone dashboard and AI coding agents]({1}).</target>

--- a/src/Aspire.Dashboard/Resources/xlf/Dialogs.pt-BR.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Dialogs.pt-BR.xlf
@@ -13,7 +13,7 @@ Get started by running this command in your project:
 aspire agent init
 ```
 
-This configures skill files for your AI assistant. The skill files tell the agent how to use Aspire CLI commands such as `aspire otel logs` and `aspire otel traces`.
+This configures skill files for your AI assistant. The skill files tell the agent how to use Aspire CLI commands such as [`aspire otel logs`](https://aspire.dev/reference/cli/commands/aspire-otel/) and [`aspire otel traces`](https://aspire.dev/reference/cli/commands/aspire-otel/).
 
 Once connected, agents can start your app, check resource health, fetch logs and traces, and more.
 
@@ -28,7 +28,7 @@ Get started by running this command in your project:
 aspire agent init
 ```
 
-This configures skill files for your AI assistant. The skill files tell the agent how to use Aspire CLI commands such as `aspire otel logs` and `aspire otel traces`.
+This configures skill files for your AI assistant. The skill files tell the agent how to use Aspire CLI commands such as [`aspire otel logs`](https://aspire.dev/reference/cli/commands/aspire-otel/) and [`aspire otel traces`](https://aspire.dev/reference/cli/commands/aspire-otel/).
 
 Once connected, agents can start your app, check resource health, fetch logs and traces, and more.
 
@@ -46,6 +46,11 @@ Use Aspire CLI commands to get telemetry data in your terminal:
 aspire otel logs --dashboard-url {0}
 ```
 
+- [`aspire otel logs`](https://aspire.dev/reference/cli/commands/aspire-otel/) — View structured logs
+- [`aspire otel traces`](https://aspire.dev/reference/cli/commands/aspire-otel/) — View distributed traces
+- [`aspire otel spans`](https://aspire.dev/reference/cli/commands/aspire-otel/) — View trace spans
+- [`aspire export`](https://aspire.dev/reference/cli/commands/aspire-export/) — Export telemetry and resource data to a zip file
+
 For more information about using AI agents with the dashboard, such as setting up skills, see [Standalone dashboard and AI coding agents]({1}).</source>
         <target state="new">Build, debug, and profile apps using AI agents and Aspire 🚀
 
@@ -56,6 +61,11 @@ Use Aspire CLI commands to get telemetry data in your terminal:
 ```bash
 aspire otel logs --dashboard-url {0}
 ```
+
+- [`aspire otel logs`](https://aspire.dev/reference/cli/commands/aspire-otel/) — View structured logs
+- [`aspire otel traces`](https://aspire.dev/reference/cli/commands/aspire-otel/) — View distributed traces
+- [`aspire otel spans`](https://aspire.dev/reference/cli/commands/aspire-otel/) — View trace spans
+- [`aspire export`](https://aspire.dev/reference/cli/commands/aspire-export/) — Export telemetry and resource data to a zip file
 
 For more information about using AI agents with the dashboard, such as setting up skills, see [Standalone dashboard and AI coding agents]({1}).</target>
         <note>{0} is the dashboard URL, {1} is the learn more URL</note>

--- a/src/Aspire.Dashboard/Resources/xlf/Dialogs.pt-BR.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Dialogs.pt-BR.xlf
@@ -5,7 +5,7 @@
       <trans-unit id="AIAgentsDialogAppHostDescription">
         <source>Build, debug, and profile apps using AI agents and Aspire 🚀
 
-The structured logs, distributed traces, and resource status in this dashboard are available to AI agents via the Aspire CLI and MCP server. This gives agents deep observability into your app, to help them diagnose issues and verify fixes.
+The structured logs, distributed traces, and resource status in this dashboard are available to AI agents via the Aspire CLI. This gives agents deep observability into your app, to help them diagnose issues and verify fixes.
 
 Get started by running this command in your project:
 
@@ -13,14 +13,14 @@ Get started by running this command in your project:
 aspire agent init
 ```
 
-This configures skill files for your AI assistant. The skill files tell the agent how to use Aspire CLI commands such as `aspire otel logs`, `aspire otel traces`, and `aspire agent mcp`.
+This configures skill files for your AI assistant. The skill files tell the agent how to use Aspire CLI commands such as `aspire otel logs` and `aspire otel traces`.
 
 Once connected, agents can start your app, check resource health, fetch logs and traces, and more.
 
 For more information about using AI agents with Aspire, such as setting up skills, see [AI coding agents]({0}).</source>
         <target state="new">Build, debug, and profile apps using AI agents and Aspire 🚀
 
-The structured logs, distributed traces, and resource status in this dashboard are available to AI agents via the Aspire CLI and MCP server. This gives agents deep observability into your app, to help them diagnose issues and verify fixes.
+The structured logs, distributed traces, and resource status in this dashboard are available to AI agents via the Aspire CLI. This gives agents deep observability into your app, to help them diagnose issues and verify fixes.
 
 Get started by running this command in your project:
 
@@ -28,7 +28,7 @@ Get started by running this command in your project:
 aspire agent init
 ```
 
-This configures skill files for your AI assistant. The skill files tell the agent how to use Aspire CLI commands such as `aspire otel logs`, `aspire otel traces`, and `aspire agent mcp`.
+This configures skill files for your AI assistant. The skill files tell the agent how to use Aspire CLI commands such as `aspire otel logs` and `aspire otel traces`.
 
 Once connected, agents can start your app, check resource health, fetch logs and traces, and more.
 
@@ -38,35 +38,23 @@ For more information about using AI agents with Aspire, such as setting up skill
       <trans-unit id="AIAgentsDialogStandaloneDescription">
         <source>Build, debug, and profile apps using AI agents and Aspire 🚀
 
-The structured logs and distributed traces in the dashboard are available to AI agents via the Aspire CLI and MCP server. This gives agents deep observability into your app, to help them diagnose issues and verify fixes.
+The structured logs and distributed traces in the dashboard are available to AI agents via the Aspire CLI. This gives agents deep observability into your app, to help them diagnose issues and verify fixes.
 
 Use Aspire CLI commands to get telemetry data in your terminal:
 
 ```bash
 aspire otel logs --dashboard-url {0}
-```
-
-Or start the Aspire MCP server:
-
-```bash
-aspire agent mcp --dashboard-url {0}
 ```
 
 For more information about using AI agents with the dashboard, such as setting up skills, see [Standalone dashboard and AI coding agents]({1}).</source>
         <target state="new">Build, debug, and profile apps using AI agents and Aspire 🚀
 
-The structured logs and distributed traces in the dashboard are available to AI agents via the Aspire CLI and MCP server. This gives agents deep observability into your app, to help them diagnose issues and verify fixes.
+The structured logs and distributed traces in the dashboard are available to AI agents via the Aspire CLI. This gives agents deep observability into your app, to help them diagnose issues and verify fixes.
 
 Use Aspire CLI commands to get telemetry data in your terminal:
 
 ```bash
 aspire otel logs --dashboard-url {0}
-```
-
-Or start the Aspire MCP server:
-
-```bash
-aspire agent mcp --dashboard-url {0}
 ```
 
 For more information about using AI agents with the dashboard, such as setting up skills, see [Standalone dashboard and AI coding agents]({1}).</target>

--- a/src/Aspire.Dashboard/Resources/xlf/Dialogs.pt-BR.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Dialogs.pt-BR.xlf
@@ -2,6 +2,81 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="pt-BR" original="../Dialogs.resx">
     <body>
+      <trans-unit id="AIAgentsDialogAppHostDescription">
+        <source>Build, debug, and profile apps using AI agents and Aspire 🚀
+
+The structured logs, distributed traces, and resource status in this dashboard are available to AI agents via the Aspire CLI and MCP server. This gives agents deep observability into your app, to help them diagnose issues and verify fixes.
+
+Get started by running this command in your project:
+
+```bash
+aspire agent init
+```
+
+This configures skill files for your AI assistant. The skill files tell the agent how to use Aspire CLI commands such as `aspire otel logs`, `aspire otel traces`, and `aspire agent mcp`.
+
+Once connected, agents can start your app, check resource health, fetch logs and traces, and more.
+
+For more information about using AI agents with Aspire, such as setting up skills, see [AI coding agents]({0}).</source>
+        <target state="new">Build, debug, and profile apps using AI agents and Aspire 🚀
+
+The structured logs, distributed traces, and resource status in this dashboard are available to AI agents via the Aspire CLI and MCP server. This gives agents deep observability into your app, to help them diagnose issues and verify fixes.
+
+Get started by running this command in your project:
+
+```bash
+aspire agent init
+```
+
+This configures skill files for your AI assistant. The skill files tell the agent how to use Aspire CLI commands such as `aspire otel logs`, `aspire otel traces`, and `aspire agent mcp`.
+
+Once connected, agents can start your app, check resource health, fetch logs and traces, and more.
+
+For more information about using AI agents with Aspire, such as setting up skills, see [AI coding agents]({0}).</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AIAgentsDialogStandaloneDescription">
+        <source>Build, debug, and profile apps using AI agents and Aspire 🚀
+
+The structured logs and distributed traces in the dashboard are available to AI agents via the Aspire CLI and MCP server. This gives agents deep observability into your app, to help them diagnose issues and verify fixes.
+
+Use Aspire CLI commands to get telemetry data in your terminal:
+
+```bash
+aspire otel logs --dashboard-url {0}
+```
+
+Or start the Aspire MCP server:
+
+```bash
+aspire agent mcp --dashboard-url {0}
+```
+
+For more information about using AI agents with the dashboard, such as setting up skills, see [Standalone dashboard and AI coding agents]({1}).</source>
+        <target state="new">Build, debug, and profile apps using AI agents and Aspire 🚀
+
+The structured logs and distributed traces in the dashboard are available to AI agents via the Aspire CLI and MCP server. This gives agents deep observability into your app, to help them diagnose issues and verify fixes.
+
+Use Aspire CLI commands to get telemetry data in your terminal:
+
+```bash
+aspire otel logs --dashboard-url {0}
+```
+
+Or start the Aspire MCP server:
+
+```bash
+aspire agent mcp --dashboard-url {0}
+```
+
+For more information about using AI agents with the dashboard, such as setting up skills, see [Standalone dashboard and AI coding agents]({1}).</target>
+        <note>{0} is the dashboard URL, {1} is the learn more URL</note>
+      </trans-unit>
+      <trans-unit id="AIAgentsDialogTitle">
+        <source>AI agents</source>
+        <target state="new">AI agents</target>
+        <note />
+      </trans-unit>
       <trans-unit id="DialogCloseButtonText">
         <source>Close</source>
         <target state="translated">Fechar</target>

--- a/src/Aspire.Dashboard/Resources/xlf/Dialogs.ru.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Dialogs.ru.xlf
@@ -13,7 +13,7 @@ Get started by running this command in your project:
 aspire agent init
 ```
 
-This configures skill files for your AI assistant. The skill files tell the agent how to use Aspire CLI commands such as [`aspire otel logs`](https://aspire.dev/reference/cli/commands/aspire-otel/) and [`aspire otel traces`](https://aspire.dev/reference/cli/commands/aspire-otel/).
+This configures skill files for your AI assistant. The skill files tell the agent how to use Aspire CLI commands such as [`aspire logs`](https://aspire.dev/reference/cli/commands/aspire-logs/) and [`aspire otel traces`](https://aspire.dev/reference/cli/commands/aspire-otel-traces/).
 
 Once connected, agents can start your app, check resource health, fetch logs and traces, and more.
 
@@ -28,7 +28,7 @@ Get started by running this command in your project:
 aspire agent init
 ```
 
-This configures skill files for your AI assistant. The skill files tell the agent how to use Aspire CLI commands such as [`aspire otel logs`](https://aspire.dev/reference/cli/commands/aspire-otel/) and [`aspire otel traces`](https://aspire.dev/reference/cli/commands/aspire-otel/).
+This configures skill files for your AI assistant. The skill files tell the agent how to use Aspire CLI commands such as [`aspire logs`](https://aspire.dev/reference/cli/commands/aspire-logs/) and [`aspire otel traces`](https://aspire.dev/reference/cli/commands/aspire-otel-traces/).
 
 Once connected, agents can start your app, check resource health, fetch logs and traces, and more.
 
@@ -46,9 +46,9 @@ Use Aspire CLI commands to get telemetry data in your terminal:
 aspire otel logs --dashboard-url {0}
 ```
 
-- [`aspire otel logs`](https://aspire.dev/reference/cli/commands/aspire-otel/) — View structured logs
-- [`aspire otel traces`](https://aspire.dev/reference/cli/commands/aspire-otel/) — View distributed traces
-- [`aspire otel spans`](https://aspire.dev/reference/cli/commands/aspire-otel/) — View trace spans
+- [`aspire otel logs`](https://aspire.dev/reference/cli/commands/aspire-otel-logs/) — View structured logs
+- [`aspire otel traces`](https://aspire.dev/reference/cli/commands/aspire-otel-traces/) — View distributed traces
+- [`aspire otel spans`](https://aspire.dev/reference/cli/commands/aspire-otel-spans/) — View trace spans
 - [`aspire export`](https://aspire.dev/reference/cli/commands/aspire-export/) — Export telemetry and resource data to a zip file
 
 For more information about using AI agents with the dashboard, such as setting up skills, see [Standalone dashboard and AI coding agents]({1}).</source>
@@ -62,9 +62,9 @@ Use Aspire CLI commands to get telemetry data in your terminal:
 aspire otel logs --dashboard-url {0}
 ```
 
-- [`aspire otel logs`](https://aspire.dev/reference/cli/commands/aspire-otel/) — View structured logs
-- [`aspire otel traces`](https://aspire.dev/reference/cli/commands/aspire-otel/) — View distributed traces
-- [`aspire otel spans`](https://aspire.dev/reference/cli/commands/aspire-otel/) — View trace spans
+- [`aspire otel logs`](https://aspire.dev/reference/cli/commands/aspire-otel-logs/) — View structured logs
+- [`aspire otel traces`](https://aspire.dev/reference/cli/commands/aspire-otel-traces/) — View distributed traces
+- [`aspire otel spans`](https://aspire.dev/reference/cli/commands/aspire-otel-spans/) — View trace spans
 - [`aspire export`](https://aspire.dev/reference/cli/commands/aspire-export/) — Export telemetry and resource data to a zip file
 
 For more information about using AI agents with the dashboard, such as setting up skills, see [Standalone dashboard and AI coding agents]({1}).</target>

--- a/src/Aspire.Dashboard/Resources/xlf/Dialogs.ru.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Dialogs.ru.xlf
@@ -13,7 +13,7 @@ Get started by running this command in your project:
 aspire agent init
 ```
 
-This configures skill files for your AI assistant. The skill files tell the agent how to use Aspire CLI commands such as `aspire otel logs` and `aspire otel traces`.
+This configures skill files for your AI assistant. The skill files tell the agent how to use Aspire CLI commands such as [`aspire otel logs`](https://aspire.dev/reference/cli/commands/aspire-otel/) and [`aspire otel traces`](https://aspire.dev/reference/cli/commands/aspire-otel/).
 
 Once connected, agents can start your app, check resource health, fetch logs and traces, and more.
 
@@ -28,7 +28,7 @@ Get started by running this command in your project:
 aspire agent init
 ```
 
-This configures skill files for your AI assistant. The skill files tell the agent how to use Aspire CLI commands such as `aspire otel logs` and `aspire otel traces`.
+This configures skill files for your AI assistant. The skill files tell the agent how to use Aspire CLI commands such as [`aspire otel logs`](https://aspire.dev/reference/cli/commands/aspire-otel/) and [`aspire otel traces`](https://aspire.dev/reference/cli/commands/aspire-otel/).
 
 Once connected, agents can start your app, check resource health, fetch logs and traces, and more.
 
@@ -46,6 +46,11 @@ Use Aspire CLI commands to get telemetry data in your terminal:
 aspire otel logs --dashboard-url {0}
 ```
 
+- [`aspire otel logs`](https://aspire.dev/reference/cli/commands/aspire-otel/) — View structured logs
+- [`aspire otel traces`](https://aspire.dev/reference/cli/commands/aspire-otel/) — View distributed traces
+- [`aspire otel spans`](https://aspire.dev/reference/cli/commands/aspire-otel/) — View trace spans
+- [`aspire export`](https://aspire.dev/reference/cli/commands/aspire-export/) — Export telemetry and resource data to a zip file
+
 For more information about using AI agents with the dashboard, such as setting up skills, see [Standalone dashboard and AI coding agents]({1}).</source>
         <target state="new">Build, debug, and profile apps using AI agents and Aspire 🚀
 
@@ -56,6 +61,11 @@ Use Aspire CLI commands to get telemetry data in your terminal:
 ```bash
 aspire otel logs --dashboard-url {0}
 ```
+
+- [`aspire otel logs`](https://aspire.dev/reference/cli/commands/aspire-otel/) — View structured logs
+- [`aspire otel traces`](https://aspire.dev/reference/cli/commands/aspire-otel/) — View distributed traces
+- [`aspire otel spans`](https://aspire.dev/reference/cli/commands/aspire-otel/) — View trace spans
+- [`aspire export`](https://aspire.dev/reference/cli/commands/aspire-export/) — Export telemetry and resource data to a zip file
 
 For more information about using AI agents with the dashboard, such as setting up skills, see [Standalone dashboard and AI coding agents]({1}).</target>
         <note>{0} is the dashboard URL, {1} is the learn more URL</note>

--- a/src/Aspire.Dashboard/Resources/xlf/Dialogs.ru.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Dialogs.ru.xlf
@@ -2,6 +2,81 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="ru" original="../Dialogs.resx">
     <body>
+      <trans-unit id="AIAgentsDialogAppHostDescription">
+        <source>Build, debug, and profile apps using AI agents and Aspire 🚀
+
+The structured logs, distributed traces, and resource status in this dashboard are available to AI agents via the Aspire CLI and MCP server. This gives agents deep observability into your app, to help them diagnose issues and verify fixes.
+
+Get started by running this command in your project:
+
+```bash
+aspire agent init
+```
+
+This configures skill files for your AI assistant. The skill files tell the agent how to use Aspire CLI commands such as `aspire otel logs`, `aspire otel traces`, and `aspire agent mcp`.
+
+Once connected, agents can start your app, check resource health, fetch logs and traces, and more.
+
+For more information about using AI agents with Aspire, such as setting up skills, see [AI coding agents]({0}).</source>
+        <target state="new">Build, debug, and profile apps using AI agents and Aspire 🚀
+
+The structured logs, distributed traces, and resource status in this dashboard are available to AI agents via the Aspire CLI and MCP server. This gives agents deep observability into your app, to help them diagnose issues and verify fixes.
+
+Get started by running this command in your project:
+
+```bash
+aspire agent init
+```
+
+This configures skill files for your AI assistant. The skill files tell the agent how to use Aspire CLI commands such as `aspire otel logs`, `aspire otel traces`, and `aspire agent mcp`.
+
+Once connected, agents can start your app, check resource health, fetch logs and traces, and more.
+
+For more information about using AI agents with Aspire, such as setting up skills, see [AI coding agents]({0}).</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AIAgentsDialogStandaloneDescription">
+        <source>Build, debug, and profile apps using AI agents and Aspire 🚀
+
+The structured logs and distributed traces in the dashboard are available to AI agents via the Aspire CLI and MCP server. This gives agents deep observability into your app, to help them diagnose issues and verify fixes.
+
+Use Aspire CLI commands to get telemetry data in your terminal:
+
+```bash
+aspire otel logs --dashboard-url {0}
+```
+
+Or start the Aspire MCP server:
+
+```bash
+aspire agent mcp --dashboard-url {0}
+```
+
+For more information about using AI agents with the dashboard, such as setting up skills, see [Standalone dashboard and AI coding agents]({1}).</source>
+        <target state="new">Build, debug, and profile apps using AI agents and Aspire 🚀
+
+The structured logs and distributed traces in the dashboard are available to AI agents via the Aspire CLI and MCP server. This gives agents deep observability into your app, to help them diagnose issues and verify fixes.
+
+Use Aspire CLI commands to get telemetry data in your terminal:
+
+```bash
+aspire otel logs --dashboard-url {0}
+```
+
+Or start the Aspire MCP server:
+
+```bash
+aspire agent mcp --dashboard-url {0}
+```
+
+For more information about using AI agents with the dashboard, such as setting up skills, see [Standalone dashboard and AI coding agents]({1}).</target>
+        <note>{0} is the dashboard URL, {1} is the learn more URL</note>
+      </trans-unit>
+      <trans-unit id="AIAgentsDialogTitle">
+        <source>AI agents</source>
+        <target state="new">AI agents</target>
+        <note />
+      </trans-unit>
       <trans-unit id="DialogCloseButtonText">
         <source>Close</source>
         <target state="translated">Закрыть</target>

--- a/src/Aspire.Dashboard/Resources/xlf/Dialogs.ru.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Dialogs.ru.xlf
@@ -5,7 +5,7 @@
       <trans-unit id="AIAgentsDialogAppHostDescription">
         <source>Build, debug, and profile apps using AI agents and Aspire 🚀
 
-The structured logs, distributed traces, and resource status in this dashboard are available to AI agents via the Aspire CLI and MCP server. This gives agents deep observability into your app, to help them diagnose issues and verify fixes.
+The structured logs, distributed traces, and resource status in this dashboard are available to AI agents via the Aspire CLI. This gives agents deep observability into your app, to help them diagnose issues and verify fixes.
 
 Get started by running this command in your project:
 
@@ -13,14 +13,14 @@ Get started by running this command in your project:
 aspire agent init
 ```
 
-This configures skill files for your AI assistant. The skill files tell the agent how to use Aspire CLI commands such as `aspire otel logs`, `aspire otel traces`, and `aspire agent mcp`.
+This configures skill files for your AI assistant. The skill files tell the agent how to use Aspire CLI commands such as `aspire otel logs` and `aspire otel traces`.
 
 Once connected, agents can start your app, check resource health, fetch logs and traces, and more.
 
 For more information about using AI agents with Aspire, such as setting up skills, see [AI coding agents]({0}).</source>
         <target state="new">Build, debug, and profile apps using AI agents and Aspire 🚀
 
-The structured logs, distributed traces, and resource status in this dashboard are available to AI agents via the Aspire CLI and MCP server. This gives agents deep observability into your app, to help them diagnose issues and verify fixes.
+The structured logs, distributed traces, and resource status in this dashboard are available to AI agents via the Aspire CLI. This gives agents deep observability into your app, to help them diagnose issues and verify fixes.
 
 Get started by running this command in your project:
 
@@ -28,7 +28,7 @@ Get started by running this command in your project:
 aspire agent init
 ```
 
-This configures skill files for your AI assistant. The skill files tell the agent how to use Aspire CLI commands such as `aspire otel logs`, `aspire otel traces`, and `aspire agent mcp`.
+This configures skill files for your AI assistant. The skill files tell the agent how to use Aspire CLI commands such as `aspire otel logs` and `aspire otel traces`.
 
 Once connected, agents can start your app, check resource health, fetch logs and traces, and more.
 
@@ -38,35 +38,23 @@ For more information about using AI agents with Aspire, such as setting up skill
       <trans-unit id="AIAgentsDialogStandaloneDescription">
         <source>Build, debug, and profile apps using AI agents and Aspire 🚀
 
-The structured logs and distributed traces in the dashboard are available to AI agents via the Aspire CLI and MCP server. This gives agents deep observability into your app, to help them diagnose issues and verify fixes.
+The structured logs and distributed traces in the dashboard are available to AI agents via the Aspire CLI. This gives agents deep observability into your app, to help them diagnose issues and verify fixes.
 
 Use Aspire CLI commands to get telemetry data in your terminal:
 
 ```bash
 aspire otel logs --dashboard-url {0}
-```
-
-Or start the Aspire MCP server:
-
-```bash
-aspire agent mcp --dashboard-url {0}
 ```
 
 For more information about using AI agents with the dashboard, such as setting up skills, see [Standalone dashboard and AI coding agents]({1}).</source>
         <target state="new">Build, debug, and profile apps using AI agents and Aspire 🚀
 
-The structured logs and distributed traces in the dashboard are available to AI agents via the Aspire CLI and MCP server. This gives agents deep observability into your app, to help them diagnose issues and verify fixes.
+The structured logs and distributed traces in the dashboard are available to AI agents via the Aspire CLI. This gives agents deep observability into your app, to help them diagnose issues and verify fixes.
 
 Use Aspire CLI commands to get telemetry data in your terminal:
 
 ```bash
 aspire otel logs --dashboard-url {0}
-```
-
-Or start the Aspire MCP server:
-
-```bash
-aspire agent mcp --dashboard-url {0}
 ```
 
 For more information about using AI agents with the dashboard, such as setting up skills, see [Standalone dashboard and AI coding agents]({1}).</target>

--- a/src/Aspire.Dashboard/Resources/xlf/Dialogs.tr.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Dialogs.tr.xlf
@@ -2,6 +2,81 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="tr" original="../Dialogs.resx">
     <body>
+      <trans-unit id="AIAgentsDialogAppHostDescription">
+        <source>Build, debug, and profile apps using AI agents and Aspire 🚀
+
+The structured logs, distributed traces, and resource status in this dashboard are available to AI agents via the Aspire CLI and MCP server. This gives agents deep observability into your app, to help them diagnose issues and verify fixes.
+
+Get started by running this command in your project:
+
+```bash
+aspire agent init
+```
+
+This configures skill files for your AI assistant. The skill files tell the agent how to use Aspire CLI commands such as `aspire otel logs`, `aspire otel traces`, and `aspire agent mcp`.
+
+Once connected, agents can start your app, check resource health, fetch logs and traces, and more.
+
+For more information about using AI agents with Aspire, such as setting up skills, see [AI coding agents]({0}).</source>
+        <target state="new">Build, debug, and profile apps using AI agents and Aspire 🚀
+
+The structured logs, distributed traces, and resource status in this dashboard are available to AI agents via the Aspire CLI and MCP server. This gives agents deep observability into your app, to help them diagnose issues and verify fixes.
+
+Get started by running this command in your project:
+
+```bash
+aspire agent init
+```
+
+This configures skill files for your AI assistant. The skill files tell the agent how to use Aspire CLI commands such as `aspire otel logs`, `aspire otel traces`, and `aspire agent mcp`.
+
+Once connected, agents can start your app, check resource health, fetch logs and traces, and more.
+
+For more information about using AI agents with Aspire, such as setting up skills, see [AI coding agents]({0}).</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AIAgentsDialogStandaloneDescription">
+        <source>Build, debug, and profile apps using AI agents and Aspire 🚀
+
+The structured logs and distributed traces in the dashboard are available to AI agents via the Aspire CLI and MCP server. This gives agents deep observability into your app, to help them diagnose issues and verify fixes.
+
+Use Aspire CLI commands to get telemetry data in your terminal:
+
+```bash
+aspire otel logs --dashboard-url {0}
+```
+
+Or start the Aspire MCP server:
+
+```bash
+aspire agent mcp --dashboard-url {0}
+```
+
+For more information about using AI agents with the dashboard, such as setting up skills, see [Standalone dashboard and AI coding agents]({1}).</source>
+        <target state="new">Build, debug, and profile apps using AI agents and Aspire 🚀
+
+The structured logs and distributed traces in the dashboard are available to AI agents via the Aspire CLI and MCP server. This gives agents deep observability into your app, to help them diagnose issues and verify fixes.
+
+Use Aspire CLI commands to get telemetry data in your terminal:
+
+```bash
+aspire otel logs --dashboard-url {0}
+```
+
+Or start the Aspire MCP server:
+
+```bash
+aspire agent mcp --dashboard-url {0}
+```
+
+For more information about using AI agents with the dashboard, such as setting up skills, see [Standalone dashboard and AI coding agents]({1}).</target>
+        <note>{0} is the dashboard URL, {1} is the learn more URL</note>
+      </trans-unit>
+      <trans-unit id="AIAgentsDialogTitle">
+        <source>AI agents</source>
+        <target state="new">AI agents</target>
+        <note />
+      </trans-unit>
       <trans-unit id="DialogCloseButtonText">
         <source>Close</source>
         <target state="translated">Kapat</target>

--- a/src/Aspire.Dashboard/Resources/xlf/Dialogs.tr.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Dialogs.tr.xlf
@@ -13,7 +13,7 @@ Get started by running this command in your project:
 aspire agent init
 ```
 
-This configures skill files for your AI assistant. The skill files tell the agent how to use Aspire CLI commands such as [`aspire otel logs`](https://aspire.dev/reference/cli/commands/aspire-otel/) and [`aspire otel traces`](https://aspire.dev/reference/cli/commands/aspire-otel/).
+This configures skill files for your AI assistant. The skill files tell the agent how to use Aspire CLI commands such as [`aspire logs`](https://aspire.dev/reference/cli/commands/aspire-logs/) and [`aspire otel traces`](https://aspire.dev/reference/cli/commands/aspire-otel-traces/).
 
 Once connected, agents can start your app, check resource health, fetch logs and traces, and more.
 
@@ -28,7 +28,7 @@ Get started by running this command in your project:
 aspire agent init
 ```
 
-This configures skill files for your AI assistant. The skill files tell the agent how to use Aspire CLI commands such as [`aspire otel logs`](https://aspire.dev/reference/cli/commands/aspire-otel/) and [`aspire otel traces`](https://aspire.dev/reference/cli/commands/aspire-otel/).
+This configures skill files for your AI assistant. The skill files tell the agent how to use Aspire CLI commands such as [`aspire logs`](https://aspire.dev/reference/cli/commands/aspire-logs/) and [`aspire otel traces`](https://aspire.dev/reference/cli/commands/aspire-otel-traces/).
 
 Once connected, agents can start your app, check resource health, fetch logs and traces, and more.
 
@@ -46,9 +46,9 @@ Use Aspire CLI commands to get telemetry data in your terminal:
 aspire otel logs --dashboard-url {0}
 ```
 
-- [`aspire otel logs`](https://aspire.dev/reference/cli/commands/aspire-otel/) — View structured logs
-- [`aspire otel traces`](https://aspire.dev/reference/cli/commands/aspire-otel/) — View distributed traces
-- [`aspire otel spans`](https://aspire.dev/reference/cli/commands/aspire-otel/) — View trace spans
+- [`aspire otel logs`](https://aspire.dev/reference/cli/commands/aspire-otel-logs/) — View structured logs
+- [`aspire otel traces`](https://aspire.dev/reference/cli/commands/aspire-otel-traces/) — View distributed traces
+- [`aspire otel spans`](https://aspire.dev/reference/cli/commands/aspire-otel-spans/) — View trace spans
 - [`aspire export`](https://aspire.dev/reference/cli/commands/aspire-export/) — Export telemetry and resource data to a zip file
 
 For more information about using AI agents with the dashboard, such as setting up skills, see [Standalone dashboard and AI coding agents]({1}).</source>
@@ -62,9 +62,9 @@ Use Aspire CLI commands to get telemetry data in your terminal:
 aspire otel logs --dashboard-url {0}
 ```
 
-- [`aspire otel logs`](https://aspire.dev/reference/cli/commands/aspire-otel/) — View structured logs
-- [`aspire otel traces`](https://aspire.dev/reference/cli/commands/aspire-otel/) — View distributed traces
-- [`aspire otel spans`](https://aspire.dev/reference/cli/commands/aspire-otel/) — View trace spans
+- [`aspire otel logs`](https://aspire.dev/reference/cli/commands/aspire-otel-logs/) — View structured logs
+- [`aspire otel traces`](https://aspire.dev/reference/cli/commands/aspire-otel-traces/) — View distributed traces
+- [`aspire otel spans`](https://aspire.dev/reference/cli/commands/aspire-otel-spans/) — View trace spans
 - [`aspire export`](https://aspire.dev/reference/cli/commands/aspire-export/) — Export telemetry and resource data to a zip file
 
 For more information about using AI agents with the dashboard, such as setting up skills, see [Standalone dashboard and AI coding agents]({1}).</target>

--- a/src/Aspire.Dashboard/Resources/xlf/Dialogs.tr.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Dialogs.tr.xlf
@@ -13,7 +13,7 @@ Get started by running this command in your project:
 aspire agent init
 ```
 
-This configures skill files for your AI assistant. The skill files tell the agent how to use Aspire CLI commands such as `aspire otel logs` and `aspire otel traces`.
+This configures skill files for your AI assistant. The skill files tell the agent how to use Aspire CLI commands such as [`aspire otel logs`](https://aspire.dev/reference/cli/commands/aspire-otel/) and [`aspire otel traces`](https://aspire.dev/reference/cli/commands/aspire-otel/).
 
 Once connected, agents can start your app, check resource health, fetch logs and traces, and more.
 
@@ -28,7 +28,7 @@ Get started by running this command in your project:
 aspire agent init
 ```
 
-This configures skill files for your AI assistant. The skill files tell the agent how to use Aspire CLI commands such as `aspire otel logs` and `aspire otel traces`.
+This configures skill files for your AI assistant. The skill files tell the agent how to use Aspire CLI commands such as [`aspire otel logs`](https://aspire.dev/reference/cli/commands/aspire-otel/) and [`aspire otel traces`](https://aspire.dev/reference/cli/commands/aspire-otel/).
 
 Once connected, agents can start your app, check resource health, fetch logs and traces, and more.
 
@@ -46,6 +46,11 @@ Use Aspire CLI commands to get telemetry data in your terminal:
 aspire otel logs --dashboard-url {0}
 ```
 
+- [`aspire otel logs`](https://aspire.dev/reference/cli/commands/aspire-otel/) — View structured logs
+- [`aspire otel traces`](https://aspire.dev/reference/cli/commands/aspire-otel/) — View distributed traces
+- [`aspire otel spans`](https://aspire.dev/reference/cli/commands/aspire-otel/) — View trace spans
+- [`aspire export`](https://aspire.dev/reference/cli/commands/aspire-export/) — Export telemetry and resource data to a zip file
+
 For more information about using AI agents with the dashboard, such as setting up skills, see [Standalone dashboard and AI coding agents]({1}).</source>
         <target state="new">Build, debug, and profile apps using AI agents and Aspire 🚀
 
@@ -56,6 +61,11 @@ Use Aspire CLI commands to get telemetry data in your terminal:
 ```bash
 aspire otel logs --dashboard-url {0}
 ```
+
+- [`aspire otel logs`](https://aspire.dev/reference/cli/commands/aspire-otel/) — View structured logs
+- [`aspire otel traces`](https://aspire.dev/reference/cli/commands/aspire-otel/) — View distributed traces
+- [`aspire otel spans`](https://aspire.dev/reference/cli/commands/aspire-otel/) — View trace spans
+- [`aspire export`](https://aspire.dev/reference/cli/commands/aspire-export/) — Export telemetry and resource data to a zip file
 
 For more information about using AI agents with the dashboard, such as setting up skills, see [Standalone dashboard and AI coding agents]({1}).</target>
         <note>{0} is the dashboard URL, {1} is the learn more URL</note>

--- a/src/Aspire.Dashboard/Resources/xlf/Dialogs.tr.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Dialogs.tr.xlf
@@ -5,7 +5,7 @@
       <trans-unit id="AIAgentsDialogAppHostDescription">
         <source>Build, debug, and profile apps using AI agents and Aspire 🚀
 
-The structured logs, distributed traces, and resource status in this dashboard are available to AI agents via the Aspire CLI and MCP server. This gives agents deep observability into your app, to help them diagnose issues and verify fixes.
+The structured logs, distributed traces, and resource status in this dashboard are available to AI agents via the Aspire CLI. This gives agents deep observability into your app, to help them diagnose issues and verify fixes.
 
 Get started by running this command in your project:
 
@@ -13,14 +13,14 @@ Get started by running this command in your project:
 aspire agent init
 ```
 
-This configures skill files for your AI assistant. The skill files tell the agent how to use Aspire CLI commands such as `aspire otel logs`, `aspire otel traces`, and `aspire agent mcp`.
+This configures skill files for your AI assistant. The skill files tell the agent how to use Aspire CLI commands such as `aspire otel logs` and `aspire otel traces`.
 
 Once connected, agents can start your app, check resource health, fetch logs and traces, and more.
 
 For more information about using AI agents with Aspire, such as setting up skills, see [AI coding agents]({0}).</source>
         <target state="new">Build, debug, and profile apps using AI agents and Aspire 🚀
 
-The structured logs, distributed traces, and resource status in this dashboard are available to AI agents via the Aspire CLI and MCP server. This gives agents deep observability into your app, to help them diagnose issues and verify fixes.
+The structured logs, distributed traces, and resource status in this dashboard are available to AI agents via the Aspire CLI. This gives agents deep observability into your app, to help them diagnose issues and verify fixes.
 
 Get started by running this command in your project:
 
@@ -28,7 +28,7 @@ Get started by running this command in your project:
 aspire agent init
 ```
 
-This configures skill files for your AI assistant. The skill files tell the agent how to use Aspire CLI commands such as `aspire otel logs`, `aspire otel traces`, and `aspire agent mcp`.
+This configures skill files for your AI assistant. The skill files tell the agent how to use Aspire CLI commands such as `aspire otel logs` and `aspire otel traces`.
 
 Once connected, agents can start your app, check resource health, fetch logs and traces, and more.
 
@@ -38,35 +38,23 @@ For more information about using AI agents with Aspire, such as setting up skill
       <trans-unit id="AIAgentsDialogStandaloneDescription">
         <source>Build, debug, and profile apps using AI agents and Aspire 🚀
 
-The structured logs and distributed traces in the dashboard are available to AI agents via the Aspire CLI and MCP server. This gives agents deep observability into your app, to help them diagnose issues and verify fixes.
+The structured logs and distributed traces in the dashboard are available to AI agents via the Aspire CLI. This gives agents deep observability into your app, to help them diagnose issues and verify fixes.
 
 Use Aspire CLI commands to get telemetry data in your terminal:
 
 ```bash
 aspire otel logs --dashboard-url {0}
-```
-
-Or start the Aspire MCP server:
-
-```bash
-aspire agent mcp --dashboard-url {0}
 ```
 
 For more information about using AI agents with the dashboard, such as setting up skills, see [Standalone dashboard and AI coding agents]({1}).</source>
         <target state="new">Build, debug, and profile apps using AI agents and Aspire 🚀
 
-The structured logs and distributed traces in the dashboard are available to AI agents via the Aspire CLI and MCP server. This gives agents deep observability into your app, to help them diagnose issues and verify fixes.
+The structured logs and distributed traces in the dashboard are available to AI agents via the Aspire CLI. This gives agents deep observability into your app, to help them diagnose issues and verify fixes.
 
 Use Aspire CLI commands to get telemetry data in your terminal:
 
 ```bash
 aspire otel logs --dashboard-url {0}
-```
-
-Or start the Aspire MCP server:
-
-```bash
-aspire agent mcp --dashboard-url {0}
 ```
 
 For more information about using AI agents with the dashboard, such as setting up skills, see [Standalone dashboard and AI coding agents]({1}).</target>

--- a/src/Aspire.Dashboard/Resources/xlf/Dialogs.zh-Hans.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Dialogs.zh-Hans.xlf
@@ -13,7 +13,7 @@ Get started by running this command in your project:
 aspire agent init
 ```
 
-This configures skill files for your AI assistant. The skill files tell the agent how to use Aspire CLI commands such as [`aspire otel logs`](https://aspire.dev/reference/cli/commands/aspire-otel/) and [`aspire otel traces`](https://aspire.dev/reference/cli/commands/aspire-otel/).
+This configures skill files for your AI assistant. The skill files tell the agent how to use Aspire CLI commands such as [`aspire logs`](https://aspire.dev/reference/cli/commands/aspire-logs/) and [`aspire otel traces`](https://aspire.dev/reference/cli/commands/aspire-otel-traces/).
 
 Once connected, agents can start your app, check resource health, fetch logs and traces, and more.
 
@@ -28,7 +28,7 @@ Get started by running this command in your project:
 aspire agent init
 ```
 
-This configures skill files for your AI assistant. The skill files tell the agent how to use Aspire CLI commands such as [`aspire otel logs`](https://aspire.dev/reference/cli/commands/aspire-otel/) and [`aspire otel traces`](https://aspire.dev/reference/cli/commands/aspire-otel/).
+This configures skill files for your AI assistant. The skill files tell the agent how to use Aspire CLI commands such as [`aspire logs`](https://aspire.dev/reference/cli/commands/aspire-logs/) and [`aspire otel traces`](https://aspire.dev/reference/cli/commands/aspire-otel-traces/).
 
 Once connected, agents can start your app, check resource health, fetch logs and traces, and more.
 
@@ -46,9 +46,9 @@ Use Aspire CLI commands to get telemetry data in your terminal:
 aspire otel logs --dashboard-url {0}
 ```
 
-- [`aspire otel logs`](https://aspire.dev/reference/cli/commands/aspire-otel/) — View structured logs
-- [`aspire otel traces`](https://aspire.dev/reference/cli/commands/aspire-otel/) — View distributed traces
-- [`aspire otel spans`](https://aspire.dev/reference/cli/commands/aspire-otel/) — View trace spans
+- [`aspire otel logs`](https://aspire.dev/reference/cli/commands/aspire-otel-logs/) — View structured logs
+- [`aspire otel traces`](https://aspire.dev/reference/cli/commands/aspire-otel-traces/) — View distributed traces
+- [`aspire otel spans`](https://aspire.dev/reference/cli/commands/aspire-otel-spans/) — View trace spans
 - [`aspire export`](https://aspire.dev/reference/cli/commands/aspire-export/) — Export telemetry and resource data to a zip file
 
 For more information about using AI agents with the dashboard, such as setting up skills, see [Standalone dashboard and AI coding agents]({1}).</source>
@@ -62,9 +62,9 @@ Use Aspire CLI commands to get telemetry data in your terminal:
 aspire otel logs --dashboard-url {0}
 ```
 
-- [`aspire otel logs`](https://aspire.dev/reference/cli/commands/aspire-otel/) — View structured logs
-- [`aspire otel traces`](https://aspire.dev/reference/cli/commands/aspire-otel/) — View distributed traces
-- [`aspire otel spans`](https://aspire.dev/reference/cli/commands/aspire-otel/) — View trace spans
+- [`aspire otel logs`](https://aspire.dev/reference/cli/commands/aspire-otel-logs/) — View structured logs
+- [`aspire otel traces`](https://aspire.dev/reference/cli/commands/aspire-otel-traces/) — View distributed traces
+- [`aspire otel spans`](https://aspire.dev/reference/cli/commands/aspire-otel-spans/) — View trace spans
 - [`aspire export`](https://aspire.dev/reference/cli/commands/aspire-export/) — Export telemetry and resource data to a zip file
 
 For more information about using AI agents with the dashboard, such as setting up skills, see [Standalone dashboard and AI coding agents]({1}).</target>

--- a/src/Aspire.Dashboard/Resources/xlf/Dialogs.zh-Hans.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Dialogs.zh-Hans.xlf
@@ -13,7 +13,7 @@ Get started by running this command in your project:
 aspire agent init
 ```
 
-This configures skill files for your AI assistant. The skill files tell the agent how to use Aspire CLI commands such as `aspire otel logs` and `aspire otel traces`.
+This configures skill files for your AI assistant. The skill files tell the agent how to use Aspire CLI commands such as [`aspire otel logs`](https://aspire.dev/reference/cli/commands/aspire-otel/) and [`aspire otel traces`](https://aspire.dev/reference/cli/commands/aspire-otel/).
 
 Once connected, agents can start your app, check resource health, fetch logs and traces, and more.
 
@@ -28,7 +28,7 @@ Get started by running this command in your project:
 aspire agent init
 ```
 
-This configures skill files for your AI assistant. The skill files tell the agent how to use Aspire CLI commands such as `aspire otel logs` and `aspire otel traces`.
+This configures skill files for your AI assistant. The skill files tell the agent how to use Aspire CLI commands such as [`aspire otel logs`](https://aspire.dev/reference/cli/commands/aspire-otel/) and [`aspire otel traces`](https://aspire.dev/reference/cli/commands/aspire-otel/).
 
 Once connected, agents can start your app, check resource health, fetch logs and traces, and more.
 
@@ -46,6 +46,11 @@ Use Aspire CLI commands to get telemetry data in your terminal:
 aspire otel logs --dashboard-url {0}
 ```
 
+- [`aspire otel logs`](https://aspire.dev/reference/cli/commands/aspire-otel/) — View structured logs
+- [`aspire otel traces`](https://aspire.dev/reference/cli/commands/aspire-otel/) — View distributed traces
+- [`aspire otel spans`](https://aspire.dev/reference/cli/commands/aspire-otel/) — View trace spans
+- [`aspire export`](https://aspire.dev/reference/cli/commands/aspire-export/) — Export telemetry and resource data to a zip file
+
 For more information about using AI agents with the dashboard, such as setting up skills, see [Standalone dashboard and AI coding agents]({1}).</source>
         <target state="new">Build, debug, and profile apps using AI agents and Aspire 🚀
 
@@ -56,6 +61,11 @@ Use Aspire CLI commands to get telemetry data in your terminal:
 ```bash
 aspire otel logs --dashboard-url {0}
 ```
+
+- [`aspire otel logs`](https://aspire.dev/reference/cli/commands/aspire-otel/) — View structured logs
+- [`aspire otel traces`](https://aspire.dev/reference/cli/commands/aspire-otel/) — View distributed traces
+- [`aspire otel spans`](https://aspire.dev/reference/cli/commands/aspire-otel/) — View trace spans
+- [`aspire export`](https://aspire.dev/reference/cli/commands/aspire-export/) — Export telemetry and resource data to a zip file
 
 For more information about using AI agents with the dashboard, such as setting up skills, see [Standalone dashboard and AI coding agents]({1}).</target>
         <note>{0} is the dashboard URL, {1} is the learn more URL</note>

--- a/src/Aspire.Dashboard/Resources/xlf/Dialogs.zh-Hans.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Dialogs.zh-Hans.xlf
@@ -5,7 +5,7 @@
       <trans-unit id="AIAgentsDialogAppHostDescription">
         <source>Build, debug, and profile apps using AI agents and Aspire 🚀
 
-The structured logs, distributed traces, and resource status in this dashboard are available to AI agents via the Aspire CLI and MCP server. This gives agents deep observability into your app, to help them diagnose issues and verify fixes.
+The structured logs, distributed traces, and resource status in this dashboard are available to AI agents via the Aspire CLI. This gives agents deep observability into your app, to help them diagnose issues and verify fixes.
 
 Get started by running this command in your project:
 
@@ -13,14 +13,14 @@ Get started by running this command in your project:
 aspire agent init
 ```
 
-This configures skill files for your AI assistant. The skill files tell the agent how to use Aspire CLI commands such as `aspire otel logs`, `aspire otel traces`, and `aspire agent mcp`.
+This configures skill files for your AI assistant. The skill files tell the agent how to use Aspire CLI commands such as `aspire otel logs` and `aspire otel traces`.
 
 Once connected, agents can start your app, check resource health, fetch logs and traces, and more.
 
 For more information about using AI agents with Aspire, such as setting up skills, see [AI coding agents]({0}).</source>
         <target state="new">Build, debug, and profile apps using AI agents and Aspire 🚀
 
-The structured logs, distributed traces, and resource status in this dashboard are available to AI agents via the Aspire CLI and MCP server. This gives agents deep observability into your app, to help them diagnose issues and verify fixes.
+The structured logs, distributed traces, and resource status in this dashboard are available to AI agents via the Aspire CLI. This gives agents deep observability into your app, to help them diagnose issues and verify fixes.
 
 Get started by running this command in your project:
 
@@ -28,7 +28,7 @@ Get started by running this command in your project:
 aspire agent init
 ```
 
-This configures skill files for your AI assistant. The skill files tell the agent how to use Aspire CLI commands such as `aspire otel logs`, `aspire otel traces`, and `aspire agent mcp`.
+This configures skill files for your AI assistant. The skill files tell the agent how to use Aspire CLI commands such as `aspire otel logs` and `aspire otel traces`.
 
 Once connected, agents can start your app, check resource health, fetch logs and traces, and more.
 
@@ -38,35 +38,23 @@ For more information about using AI agents with Aspire, such as setting up skill
       <trans-unit id="AIAgentsDialogStandaloneDescription">
         <source>Build, debug, and profile apps using AI agents and Aspire 🚀
 
-The structured logs and distributed traces in the dashboard are available to AI agents via the Aspire CLI and MCP server. This gives agents deep observability into your app, to help them diagnose issues and verify fixes.
+The structured logs and distributed traces in the dashboard are available to AI agents via the Aspire CLI. This gives agents deep observability into your app, to help them diagnose issues and verify fixes.
 
 Use Aspire CLI commands to get telemetry data in your terminal:
 
 ```bash
 aspire otel logs --dashboard-url {0}
-```
-
-Or start the Aspire MCP server:
-
-```bash
-aspire agent mcp --dashboard-url {0}
 ```
 
 For more information about using AI agents with the dashboard, such as setting up skills, see [Standalone dashboard and AI coding agents]({1}).</source>
         <target state="new">Build, debug, and profile apps using AI agents and Aspire 🚀
 
-The structured logs and distributed traces in the dashboard are available to AI agents via the Aspire CLI and MCP server. This gives agents deep observability into your app, to help them diagnose issues and verify fixes.
+The structured logs and distributed traces in the dashboard are available to AI agents via the Aspire CLI. This gives agents deep observability into your app, to help them diagnose issues and verify fixes.
 
 Use Aspire CLI commands to get telemetry data in your terminal:
 
 ```bash
 aspire otel logs --dashboard-url {0}
-```
-
-Or start the Aspire MCP server:
-
-```bash
-aspire agent mcp --dashboard-url {0}
 ```
 
 For more information about using AI agents with the dashboard, such as setting up skills, see [Standalone dashboard and AI coding agents]({1}).</target>

--- a/src/Aspire.Dashboard/Resources/xlf/Dialogs.zh-Hans.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Dialogs.zh-Hans.xlf
@@ -2,6 +2,81 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="zh-Hans" original="../Dialogs.resx">
     <body>
+      <trans-unit id="AIAgentsDialogAppHostDescription">
+        <source>Build, debug, and profile apps using AI agents and Aspire 🚀
+
+The structured logs, distributed traces, and resource status in this dashboard are available to AI agents via the Aspire CLI and MCP server. This gives agents deep observability into your app, to help them diagnose issues and verify fixes.
+
+Get started by running this command in your project:
+
+```bash
+aspire agent init
+```
+
+This configures skill files for your AI assistant. The skill files tell the agent how to use Aspire CLI commands such as `aspire otel logs`, `aspire otel traces`, and `aspire agent mcp`.
+
+Once connected, agents can start your app, check resource health, fetch logs and traces, and more.
+
+For more information about using AI agents with Aspire, such as setting up skills, see [AI coding agents]({0}).</source>
+        <target state="new">Build, debug, and profile apps using AI agents and Aspire 🚀
+
+The structured logs, distributed traces, and resource status in this dashboard are available to AI agents via the Aspire CLI and MCP server. This gives agents deep observability into your app, to help them diagnose issues and verify fixes.
+
+Get started by running this command in your project:
+
+```bash
+aspire agent init
+```
+
+This configures skill files for your AI assistant. The skill files tell the agent how to use Aspire CLI commands such as `aspire otel logs`, `aspire otel traces`, and `aspire agent mcp`.
+
+Once connected, agents can start your app, check resource health, fetch logs and traces, and more.
+
+For more information about using AI agents with Aspire, such as setting up skills, see [AI coding agents]({0}).</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AIAgentsDialogStandaloneDescription">
+        <source>Build, debug, and profile apps using AI agents and Aspire 🚀
+
+The structured logs and distributed traces in the dashboard are available to AI agents via the Aspire CLI and MCP server. This gives agents deep observability into your app, to help them diagnose issues and verify fixes.
+
+Use Aspire CLI commands to get telemetry data in your terminal:
+
+```bash
+aspire otel logs --dashboard-url {0}
+```
+
+Or start the Aspire MCP server:
+
+```bash
+aspire agent mcp --dashboard-url {0}
+```
+
+For more information about using AI agents with the dashboard, such as setting up skills, see [Standalone dashboard and AI coding agents]({1}).</source>
+        <target state="new">Build, debug, and profile apps using AI agents and Aspire 🚀
+
+The structured logs and distributed traces in the dashboard are available to AI agents via the Aspire CLI and MCP server. This gives agents deep observability into your app, to help them diagnose issues and verify fixes.
+
+Use Aspire CLI commands to get telemetry data in your terminal:
+
+```bash
+aspire otel logs --dashboard-url {0}
+```
+
+Or start the Aspire MCP server:
+
+```bash
+aspire agent mcp --dashboard-url {0}
+```
+
+For more information about using AI agents with the dashboard, such as setting up skills, see [Standalone dashboard and AI coding agents]({1}).</target>
+        <note>{0} is the dashboard URL, {1} is the learn more URL</note>
+      </trans-unit>
+      <trans-unit id="AIAgentsDialogTitle">
+        <source>AI agents</source>
+        <target state="new">AI agents</target>
+        <note />
+      </trans-unit>
       <trans-unit id="DialogCloseButtonText">
         <source>Close</source>
         <target state="translated">关闭</target>

--- a/src/Aspire.Dashboard/Resources/xlf/Dialogs.zh-Hant.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Dialogs.zh-Hant.xlf
@@ -2,6 +2,81 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="zh-Hant" original="../Dialogs.resx">
     <body>
+      <trans-unit id="AIAgentsDialogAppHostDescription">
+        <source>Build, debug, and profile apps using AI agents and Aspire 🚀
+
+The structured logs, distributed traces, and resource status in this dashboard are available to AI agents via the Aspire CLI and MCP server. This gives agents deep observability into your app, to help them diagnose issues and verify fixes.
+
+Get started by running this command in your project:
+
+```bash
+aspire agent init
+```
+
+This configures skill files for your AI assistant. The skill files tell the agent how to use Aspire CLI commands such as `aspire otel logs`, `aspire otel traces`, and `aspire agent mcp`.
+
+Once connected, agents can start your app, check resource health, fetch logs and traces, and more.
+
+For more information about using AI agents with Aspire, such as setting up skills, see [AI coding agents]({0}).</source>
+        <target state="new">Build, debug, and profile apps using AI agents and Aspire 🚀
+
+The structured logs, distributed traces, and resource status in this dashboard are available to AI agents via the Aspire CLI and MCP server. This gives agents deep observability into your app, to help them diagnose issues and verify fixes.
+
+Get started by running this command in your project:
+
+```bash
+aspire agent init
+```
+
+This configures skill files for your AI assistant. The skill files tell the agent how to use Aspire CLI commands such as `aspire otel logs`, `aspire otel traces`, and `aspire agent mcp`.
+
+Once connected, agents can start your app, check resource health, fetch logs and traces, and more.
+
+For more information about using AI agents with Aspire, such as setting up skills, see [AI coding agents]({0}).</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AIAgentsDialogStandaloneDescription">
+        <source>Build, debug, and profile apps using AI agents and Aspire 🚀
+
+The structured logs and distributed traces in the dashboard are available to AI agents via the Aspire CLI and MCP server. This gives agents deep observability into your app, to help them diagnose issues and verify fixes.
+
+Use Aspire CLI commands to get telemetry data in your terminal:
+
+```bash
+aspire otel logs --dashboard-url {0}
+```
+
+Or start the Aspire MCP server:
+
+```bash
+aspire agent mcp --dashboard-url {0}
+```
+
+For more information about using AI agents with the dashboard, such as setting up skills, see [Standalone dashboard and AI coding agents]({1}).</source>
+        <target state="new">Build, debug, and profile apps using AI agents and Aspire 🚀
+
+The structured logs and distributed traces in the dashboard are available to AI agents via the Aspire CLI and MCP server. This gives agents deep observability into your app, to help them diagnose issues and verify fixes.
+
+Use Aspire CLI commands to get telemetry data in your terminal:
+
+```bash
+aspire otel logs --dashboard-url {0}
+```
+
+Or start the Aspire MCP server:
+
+```bash
+aspire agent mcp --dashboard-url {0}
+```
+
+For more information about using AI agents with the dashboard, such as setting up skills, see [Standalone dashboard and AI coding agents]({1}).</target>
+        <note>{0} is the dashboard URL, {1} is the learn more URL</note>
+      </trans-unit>
+      <trans-unit id="AIAgentsDialogTitle">
+        <source>AI agents</source>
+        <target state="new">AI agents</target>
+        <note />
+      </trans-unit>
       <trans-unit id="DialogCloseButtonText">
         <source>Close</source>
         <target state="translated">關閉</target>

--- a/src/Aspire.Dashboard/Resources/xlf/Dialogs.zh-Hant.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Dialogs.zh-Hant.xlf
@@ -13,7 +13,7 @@ Get started by running this command in your project:
 aspire agent init
 ```
 
-This configures skill files for your AI assistant. The skill files tell the agent how to use Aspire CLI commands such as [`aspire otel logs`](https://aspire.dev/reference/cli/commands/aspire-otel/) and [`aspire otel traces`](https://aspire.dev/reference/cli/commands/aspire-otel/).
+This configures skill files for your AI assistant. The skill files tell the agent how to use Aspire CLI commands such as [`aspire logs`](https://aspire.dev/reference/cli/commands/aspire-logs/) and [`aspire otel traces`](https://aspire.dev/reference/cli/commands/aspire-otel-traces/).
 
 Once connected, agents can start your app, check resource health, fetch logs and traces, and more.
 
@@ -28,7 +28,7 @@ Get started by running this command in your project:
 aspire agent init
 ```
 
-This configures skill files for your AI assistant. The skill files tell the agent how to use Aspire CLI commands such as [`aspire otel logs`](https://aspire.dev/reference/cli/commands/aspire-otel/) and [`aspire otel traces`](https://aspire.dev/reference/cli/commands/aspire-otel/).
+This configures skill files for your AI assistant. The skill files tell the agent how to use Aspire CLI commands such as [`aspire logs`](https://aspire.dev/reference/cli/commands/aspire-logs/) and [`aspire otel traces`](https://aspire.dev/reference/cli/commands/aspire-otel-traces/).
 
 Once connected, agents can start your app, check resource health, fetch logs and traces, and more.
 
@@ -46,9 +46,9 @@ Use Aspire CLI commands to get telemetry data in your terminal:
 aspire otel logs --dashboard-url {0}
 ```
 
-- [`aspire otel logs`](https://aspire.dev/reference/cli/commands/aspire-otel/) — View structured logs
-- [`aspire otel traces`](https://aspire.dev/reference/cli/commands/aspire-otel/) — View distributed traces
-- [`aspire otel spans`](https://aspire.dev/reference/cli/commands/aspire-otel/) — View trace spans
+- [`aspire otel logs`](https://aspire.dev/reference/cli/commands/aspire-otel-logs/) — View structured logs
+- [`aspire otel traces`](https://aspire.dev/reference/cli/commands/aspire-otel-traces/) — View distributed traces
+- [`aspire otel spans`](https://aspire.dev/reference/cli/commands/aspire-otel-spans/) — View trace spans
 - [`aspire export`](https://aspire.dev/reference/cli/commands/aspire-export/) — Export telemetry and resource data to a zip file
 
 For more information about using AI agents with the dashboard, such as setting up skills, see [Standalone dashboard and AI coding agents]({1}).</source>
@@ -62,9 +62,9 @@ Use Aspire CLI commands to get telemetry data in your terminal:
 aspire otel logs --dashboard-url {0}
 ```
 
-- [`aspire otel logs`](https://aspire.dev/reference/cli/commands/aspire-otel/) — View structured logs
-- [`aspire otel traces`](https://aspire.dev/reference/cli/commands/aspire-otel/) — View distributed traces
-- [`aspire otel spans`](https://aspire.dev/reference/cli/commands/aspire-otel/) — View trace spans
+- [`aspire otel logs`](https://aspire.dev/reference/cli/commands/aspire-otel-logs/) — View structured logs
+- [`aspire otel traces`](https://aspire.dev/reference/cli/commands/aspire-otel-traces/) — View distributed traces
+- [`aspire otel spans`](https://aspire.dev/reference/cli/commands/aspire-otel-spans/) — View trace spans
 - [`aspire export`](https://aspire.dev/reference/cli/commands/aspire-export/) — Export telemetry and resource data to a zip file
 
 For more information about using AI agents with the dashboard, such as setting up skills, see [Standalone dashboard and AI coding agents]({1}).</target>

--- a/src/Aspire.Dashboard/Resources/xlf/Dialogs.zh-Hant.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Dialogs.zh-Hant.xlf
@@ -13,7 +13,7 @@ Get started by running this command in your project:
 aspire agent init
 ```
 
-This configures skill files for your AI assistant. The skill files tell the agent how to use Aspire CLI commands such as `aspire otel logs` and `aspire otel traces`.
+This configures skill files for your AI assistant. The skill files tell the agent how to use Aspire CLI commands such as [`aspire otel logs`](https://aspire.dev/reference/cli/commands/aspire-otel/) and [`aspire otel traces`](https://aspire.dev/reference/cli/commands/aspire-otel/).
 
 Once connected, agents can start your app, check resource health, fetch logs and traces, and more.
 
@@ -28,7 +28,7 @@ Get started by running this command in your project:
 aspire agent init
 ```
 
-This configures skill files for your AI assistant. The skill files tell the agent how to use Aspire CLI commands such as `aspire otel logs` and `aspire otel traces`.
+This configures skill files for your AI assistant. The skill files tell the agent how to use Aspire CLI commands such as [`aspire otel logs`](https://aspire.dev/reference/cli/commands/aspire-otel/) and [`aspire otel traces`](https://aspire.dev/reference/cli/commands/aspire-otel/).
 
 Once connected, agents can start your app, check resource health, fetch logs and traces, and more.
 
@@ -46,6 +46,11 @@ Use Aspire CLI commands to get telemetry data in your terminal:
 aspire otel logs --dashboard-url {0}
 ```
 
+- [`aspire otel logs`](https://aspire.dev/reference/cli/commands/aspire-otel/) — View structured logs
+- [`aspire otel traces`](https://aspire.dev/reference/cli/commands/aspire-otel/) — View distributed traces
+- [`aspire otel spans`](https://aspire.dev/reference/cli/commands/aspire-otel/) — View trace spans
+- [`aspire export`](https://aspire.dev/reference/cli/commands/aspire-export/) — Export telemetry and resource data to a zip file
+
 For more information about using AI agents with the dashboard, such as setting up skills, see [Standalone dashboard and AI coding agents]({1}).</source>
         <target state="new">Build, debug, and profile apps using AI agents and Aspire 🚀
 
@@ -56,6 +61,11 @@ Use Aspire CLI commands to get telemetry data in your terminal:
 ```bash
 aspire otel logs --dashboard-url {0}
 ```
+
+- [`aspire otel logs`](https://aspire.dev/reference/cli/commands/aspire-otel/) — View structured logs
+- [`aspire otel traces`](https://aspire.dev/reference/cli/commands/aspire-otel/) — View distributed traces
+- [`aspire otel spans`](https://aspire.dev/reference/cli/commands/aspire-otel/) — View trace spans
+- [`aspire export`](https://aspire.dev/reference/cli/commands/aspire-export/) — Export telemetry and resource data to a zip file
 
 For more information about using AI agents with the dashboard, such as setting up skills, see [Standalone dashboard and AI coding agents]({1}).</target>
         <note>{0} is the dashboard URL, {1} is the learn more URL</note>

--- a/src/Aspire.Dashboard/Resources/xlf/Dialogs.zh-Hant.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Dialogs.zh-Hant.xlf
@@ -5,7 +5,7 @@
       <trans-unit id="AIAgentsDialogAppHostDescription">
         <source>Build, debug, and profile apps using AI agents and Aspire 🚀
 
-The structured logs, distributed traces, and resource status in this dashboard are available to AI agents via the Aspire CLI and MCP server. This gives agents deep observability into your app, to help them diagnose issues and verify fixes.
+The structured logs, distributed traces, and resource status in this dashboard are available to AI agents via the Aspire CLI. This gives agents deep observability into your app, to help them diagnose issues and verify fixes.
 
 Get started by running this command in your project:
 
@@ -13,14 +13,14 @@ Get started by running this command in your project:
 aspire agent init
 ```
 
-This configures skill files for your AI assistant. The skill files tell the agent how to use Aspire CLI commands such as `aspire otel logs`, `aspire otel traces`, and `aspire agent mcp`.
+This configures skill files for your AI assistant. The skill files tell the agent how to use Aspire CLI commands such as `aspire otel logs` and `aspire otel traces`.
 
 Once connected, agents can start your app, check resource health, fetch logs and traces, and more.
 
 For more information about using AI agents with Aspire, such as setting up skills, see [AI coding agents]({0}).</source>
         <target state="new">Build, debug, and profile apps using AI agents and Aspire 🚀
 
-The structured logs, distributed traces, and resource status in this dashboard are available to AI agents via the Aspire CLI and MCP server. This gives agents deep observability into your app, to help them diagnose issues and verify fixes.
+The structured logs, distributed traces, and resource status in this dashboard are available to AI agents via the Aspire CLI. This gives agents deep observability into your app, to help them diagnose issues and verify fixes.
 
 Get started by running this command in your project:
 
@@ -28,7 +28,7 @@ Get started by running this command in your project:
 aspire agent init
 ```
 
-This configures skill files for your AI assistant. The skill files tell the agent how to use Aspire CLI commands such as `aspire otel logs`, `aspire otel traces`, and `aspire agent mcp`.
+This configures skill files for your AI assistant. The skill files tell the agent how to use Aspire CLI commands such as `aspire otel logs` and `aspire otel traces`.
 
 Once connected, agents can start your app, check resource health, fetch logs and traces, and more.
 
@@ -38,35 +38,23 @@ For more information about using AI agents with Aspire, such as setting up skill
       <trans-unit id="AIAgentsDialogStandaloneDescription">
         <source>Build, debug, and profile apps using AI agents and Aspire 🚀
 
-The structured logs and distributed traces in the dashboard are available to AI agents via the Aspire CLI and MCP server. This gives agents deep observability into your app, to help them diagnose issues and verify fixes.
+The structured logs and distributed traces in the dashboard are available to AI agents via the Aspire CLI. This gives agents deep observability into your app, to help them diagnose issues and verify fixes.
 
 Use Aspire CLI commands to get telemetry data in your terminal:
 
 ```bash
 aspire otel logs --dashboard-url {0}
-```
-
-Or start the Aspire MCP server:
-
-```bash
-aspire agent mcp --dashboard-url {0}
 ```
 
 For more information about using AI agents with the dashboard, such as setting up skills, see [Standalone dashboard and AI coding agents]({1}).</source>
         <target state="new">Build, debug, and profile apps using AI agents and Aspire 🚀
 
-The structured logs and distributed traces in the dashboard are available to AI agents via the Aspire CLI and MCP server. This gives agents deep observability into your app, to help them diagnose issues and verify fixes.
+The structured logs and distributed traces in the dashboard are available to AI agents via the Aspire CLI. This gives agents deep observability into your app, to help them diagnose issues and verify fixes.
 
 Use Aspire CLI commands to get telemetry data in your terminal:
 
 ```bash
 aspire otel logs --dashboard-url {0}
-```
-
-Or start the Aspire MCP server:
-
-```bash
-aspire agent mcp --dashboard-url {0}
 ```
 
 For more information about using AI agents with the dashboard, such as setting up skills, see [Standalone dashboard and AI coding agents]({1}).</target>

--- a/src/Aspire.Dashboard/Resources/xlf/Layout.cs.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Layout.cs.xlf
@@ -17,6 +17,11 @@
         <target state="translated">Úložiště Aspire</target>
         <note />
       </trans-unit>
+      <trans-unit id="MainLayoutLaunchAIAgents">
+        <source>AI Agents</source>
+        <target state="new">AI Agents</target>
+        <note />
+      </trans-unit>
       <trans-unit id="MainLayoutLaunchNotifications">
         <source>Notifications</source>
         <target state="new">Notifications</target>

--- a/src/Aspire.Dashboard/Resources/xlf/Layout.cs.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Layout.cs.xlf
@@ -18,8 +18,8 @@
         <note />
       </trans-unit>
       <trans-unit id="MainLayoutLaunchAIAgents">
-        <source>AI Agents</source>
-        <target state="new">AI Agents</target>
+        <source>AI agents</source>
+        <target state="new">AI agents</target>
         <note />
       </trans-unit>
       <trans-unit id="MainLayoutLaunchNotifications">

--- a/src/Aspire.Dashboard/Resources/xlf/Layout.de.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Layout.de.xlf
@@ -17,6 +17,11 @@
         <target state="translated">Aspire-Repository</target>
         <note />
       </trans-unit>
+      <trans-unit id="MainLayoutLaunchAIAgents">
+        <source>AI Agents</source>
+        <target state="new">AI Agents</target>
+        <note />
+      </trans-unit>
       <trans-unit id="MainLayoutLaunchNotifications">
         <source>Notifications</source>
         <target state="new">Notifications</target>

--- a/src/Aspire.Dashboard/Resources/xlf/Layout.de.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Layout.de.xlf
@@ -18,8 +18,8 @@
         <note />
       </trans-unit>
       <trans-unit id="MainLayoutLaunchAIAgents">
-        <source>AI Agents</source>
-        <target state="new">AI Agents</target>
+        <source>AI agents</source>
+        <target state="new">AI agents</target>
         <note />
       </trans-unit>
       <trans-unit id="MainLayoutLaunchNotifications">

--- a/src/Aspire.Dashboard/Resources/xlf/Layout.es.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Layout.es.xlf
@@ -17,6 +17,11 @@
         <target state="translated">Repositorio de Aspire</target>
         <note />
       </trans-unit>
+      <trans-unit id="MainLayoutLaunchAIAgents">
+        <source>AI Agents</source>
+        <target state="new">AI Agents</target>
+        <note />
+      </trans-unit>
       <trans-unit id="MainLayoutLaunchNotifications">
         <source>Notifications</source>
         <target state="new">Notifications</target>

--- a/src/Aspire.Dashboard/Resources/xlf/Layout.es.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Layout.es.xlf
@@ -18,8 +18,8 @@
         <note />
       </trans-unit>
       <trans-unit id="MainLayoutLaunchAIAgents">
-        <source>AI Agents</source>
-        <target state="new">AI Agents</target>
+        <source>AI agents</source>
+        <target state="new">AI agents</target>
         <note />
       </trans-unit>
       <trans-unit id="MainLayoutLaunchNotifications">

--- a/src/Aspire.Dashboard/Resources/xlf/Layout.fr.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Layout.fr.xlf
@@ -17,6 +17,11 @@
         <target state="translated">Référentiel Aspire</target>
         <note />
       </trans-unit>
+      <trans-unit id="MainLayoutLaunchAIAgents">
+        <source>AI Agents</source>
+        <target state="new">AI Agents</target>
+        <note />
+      </trans-unit>
       <trans-unit id="MainLayoutLaunchNotifications">
         <source>Notifications</source>
         <target state="new">Notifications</target>

--- a/src/Aspire.Dashboard/Resources/xlf/Layout.fr.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Layout.fr.xlf
@@ -18,8 +18,8 @@
         <note />
       </trans-unit>
       <trans-unit id="MainLayoutLaunchAIAgents">
-        <source>AI Agents</source>
-        <target state="new">AI Agents</target>
+        <source>AI agents</source>
+        <target state="new">AI agents</target>
         <note />
       </trans-unit>
       <trans-unit id="MainLayoutLaunchNotifications">

--- a/src/Aspire.Dashboard/Resources/xlf/Layout.it.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Layout.it.xlf
@@ -17,6 +17,11 @@
         <target state="translated">Repository Aspire</target>
         <note />
       </trans-unit>
+      <trans-unit id="MainLayoutLaunchAIAgents">
+        <source>AI Agents</source>
+        <target state="new">AI Agents</target>
+        <note />
+      </trans-unit>
       <trans-unit id="MainLayoutLaunchNotifications">
         <source>Notifications</source>
         <target state="new">Notifications</target>

--- a/src/Aspire.Dashboard/Resources/xlf/Layout.it.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Layout.it.xlf
@@ -18,8 +18,8 @@
         <note />
       </trans-unit>
       <trans-unit id="MainLayoutLaunchAIAgents">
-        <source>AI Agents</source>
-        <target state="new">AI Agents</target>
+        <source>AI agents</source>
+        <target state="new">AI agents</target>
         <note />
       </trans-unit>
       <trans-unit id="MainLayoutLaunchNotifications">

--- a/src/Aspire.Dashboard/Resources/xlf/Layout.ja.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Layout.ja.xlf
@@ -17,6 +17,11 @@
         <target state="translated">Aspire リポジトリ</target>
         <note />
       </trans-unit>
+      <trans-unit id="MainLayoutLaunchAIAgents">
+        <source>AI Agents</source>
+        <target state="new">AI Agents</target>
+        <note />
+      </trans-unit>
       <trans-unit id="MainLayoutLaunchNotifications">
         <source>Notifications</source>
         <target state="new">Notifications</target>

--- a/src/Aspire.Dashboard/Resources/xlf/Layout.ja.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Layout.ja.xlf
@@ -18,8 +18,8 @@
         <note />
       </trans-unit>
       <trans-unit id="MainLayoutLaunchAIAgents">
-        <source>AI Agents</source>
-        <target state="new">AI Agents</target>
+        <source>AI agents</source>
+        <target state="new">AI agents</target>
         <note />
       </trans-unit>
       <trans-unit id="MainLayoutLaunchNotifications">

--- a/src/Aspire.Dashboard/Resources/xlf/Layout.ko.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Layout.ko.xlf
@@ -17,6 +17,11 @@
         <target state="translated">Aspire 리포지토리</target>
         <note />
       </trans-unit>
+      <trans-unit id="MainLayoutLaunchAIAgents">
+        <source>AI Agents</source>
+        <target state="new">AI Agents</target>
+        <note />
+      </trans-unit>
       <trans-unit id="MainLayoutLaunchNotifications">
         <source>Notifications</source>
         <target state="new">Notifications</target>

--- a/src/Aspire.Dashboard/Resources/xlf/Layout.ko.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Layout.ko.xlf
@@ -18,8 +18,8 @@
         <note />
       </trans-unit>
       <trans-unit id="MainLayoutLaunchAIAgents">
-        <source>AI Agents</source>
-        <target state="new">AI Agents</target>
+        <source>AI agents</source>
+        <target state="new">AI agents</target>
         <note />
       </trans-unit>
       <trans-unit id="MainLayoutLaunchNotifications">

--- a/src/Aspire.Dashboard/Resources/xlf/Layout.pl.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Layout.pl.xlf
@@ -17,6 +17,11 @@
         <target state="translated">Repozytorium Aspire</target>
         <note />
       </trans-unit>
+      <trans-unit id="MainLayoutLaunchAIAgents">
+        <source>AI Agents</source>
+        <target state="new">AI Agents</target>
+        <note />
+      </trans-unit>
       <trans-unit id="MainLayoutLaunchNotifications">
         <source>Notifications</source>
         <target state="new">Notifications</target>

--- a/src/Aspire.Dashboard/Resources/xlf/Layout.pl.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Layout.pl.xlf
@@ -18,8 +18,8 @@
         <note />
       </trans-unit>
       <trans-unit id="MainLayoutLaunchAIAgents">
-        <source>AI Agents</source>
-        <target state="new">AI Agents</target>
+        <source>AI agents</source>
+        <target state="new">AI agents</target>
         <note />
       </trans-unit>
       <trans-unit id="MainLayoutLaunchNotifications">

--- a/src/Aspire.Dashboard/Resources/xlf/Layout.pt-BR.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Layout.pt-BR.xlf
@@ -17,6 +17,11 @@
         <target state="translated">Repositório do Aspire</target>
         <note />
       </trans-unit>
+      <trans-unit id="MainLayoutLaunchAIAgents">
+        <source>AI Agents</source>
+        <target state="new">AI Agents</target>
+        <note />
+      </trans-unit>
       <trans-unit id="MainLayoutLaunchNotifications">
         <source>Notifications</source>
         <target state="new">Notifications</target>

--- a/src/Aspire.Dashboard/Resources/xlf/Layout.pt-BR.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Layout.pt-BR.xlf
@@ -18,8 +18,8 @@
         <note />
       </trans-unit>
       <trans-unit id="MainLayoutLaunchAIAgents">
-        <source>AI Agents</source>
-        <target state="new">AI Agents</target>
+        <source>AI agents</source>
+        <target state="new">AI agents</target>
         <note />
       </trans-unit>
       <trans-unit id="MainLayoutLaunchNotifications">

--- a/src/Aspire.Dashboard/Resources/xlf/Layout.ru.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Layout.ru.xlf
@@ -17,6 +17,11 @@
         <target state="translated">Репозиторий Aspire</target>
         <note />
       </trans-unit>
+      <trans-unit id="MainLayoutLaunchAIAgents">
+        <source>AI Agents</source>
+        <target state="new">AI Agents</target>
+        <note />
+      </trans-unit>
       <trans-unit id="MainLayoutLaunchNotifications">
         <source>Notifications</source>
         <target state="new">Notifications</target>

--- a/src/Aspire.Dashboard/Resources/xlf/Layout.ru.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Layout.ru.xlf
@@ -18,8 +18,8 @@
         <note />
       </trans-unit>
       <trans-unit id="MainLayoutLaunchAIAgents">
-        <source>AI Agents</source>
-        <target state="new">AI Agents</target>
+        <source>AI agents</source>
+        <target state="new">AI agents</target>
         <note />
       </trans-unit>
       <trans-unit id="MainLayoutLaunchNotifications">

--- a/src/Aspire.Dashboard/Resources/xlf/Layout.tr.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Layout.tr.xlf
@@ -17,6 +17,11 @@
         <target state="translated">Aspire deposu</target>
         <note />
       </trans-unit>
+      <trans-unit id="MainLayoutLaunchAIAgents">
+        <source>AI Agents</source>
+        <target state="new">AI Agents</target>
+        <note />
+      </trans-unit>
       <trans-unit id="MainLayoutLaunchNotifications">
         <source>Notifications</source>
         <target state="new">Notifications</target>

--- a/src/Aspire.Dashboard/Resources/xlf/Layout.tr.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Layout.tr.xlf
@@ -18,8 +18,8 @@
         <note />
       </trans-unit>
       <trans-unit id="MainLayoutLaunchAIAgents">
-        <source>AI Agents</source>
-        <target state="new">AI Agents</target>
+        <source>AI agents</source>
+        <target state="new">AI agents</target>
         <note />
       </trans-unit>
       <trans-unit id="MainLayoutLaunchNotifications">

--- a/src/Aspire.Dashboard/Resources/xlf/Layout.zh-Hans.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Layout.zh-Hans.xlf
@@ -17,6 +17,11 @@
         <target state="translated">Aspire 存储库</target>
         <note />
       </trans-unit>
+      <trans-unit id="MainLayoutLaunchAIAgents">
+        <source>AI Agents</source>
+        <target state="new">AI Agents</target>
+        <note />
+      </trans-unit>
       <trans-unit id="MainLayoutLaunchNotifications">
         <source>Notifications</source>
         <target state="new">Notifications</target>

--- a/src/Aspire.Dashboard/Resources/xlf/Layout.zh-Hans.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Layout.zh-Hans.xlf
@@ -18,8 +18,8 @@
         <note />
       </trans-unit>
       <trans-unit id="MainLayoutLaunchAIAgents">
-        <source>AI Agents</source>
-        <target state="new">AI Agents</target>
+        <source>AI agents</source>
+        <target state="new">AI agents</target>
         <note />
       </trans-unit>
       <trans-unit id="MainLayoutLaunchNotifications">

--- a/src/Aspire.Dashboard/Resources/xlf/Layout.zh-Hant.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Layout.zh-Hant.xlf
@@ -17,6 +17,11 @@
         <target state="translated">Aspire 存放庫</target>
         <note />
       </trans-unit>
+      <trans-unit id="MainLayoutLaunchAIAgents">
+        <source>AI Agents</source>
+        <target state="new">AI Agents</target>
+        <note />
+      </trans-unit>
       <trans-unit id="MainLayoutLaunchNotifications">
         <source>Notifications</source>
         <target state="new">Notifications</target>

--- a/src/Aspire.Dashboard/Resources/xlf/Layout.zh-Hant.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Layout.zh-Hant.xlf
@@ -18,8 +18,8 @@
         <note />
       </trans-unit>
       <trans-unit id="MainLayoutLaunchAIAgents">
-        <source>AI Agents</source>
-        <target state="new">AI Agents</target>
+        <source>AI agents</source>
+        <target state="new">AI agents</target>
         <note />
       </trans-unit>
       <trans-unit id="MainLayoutLaunchNotifications">

--- a/src/Aspire.Dashboard/wwwroot/css/markdown.css
+++ b/src/Aspire.Dashboard/wwwroot/css/markdown.css
@@ -86,6 +86,9 @@
 .markdown-container pre code {
     font-size: 13px;
     line-height: 20px;
+}
+
+.markdown-container pre code, .markdown-container a code {
     background-color: unset;
     padding: unset;
     border-radius: unset;

--- a/src/Aspire.Dashboard/wwwroot/css/markdown.css
+++ b/src/Aspire.Dashboard/wwwroot/css/markdown.css
@@ -86,9 +86,6 @@
 .markdown-container pre code {
     font-size: 13px;
     line-height: 20px;
-}
-
-.markdown-container pre code, .markdown-container a code {
     background-color: unset;
     padding: unset;
     border-radius: unset;

--- a/src/Shared/DashboardConfigNames.cs
+++ b/src/Shared/DashboardConfigNames.cs
@@ -48,6 +48,7 @@ internal static class DashboardConfigNames
     public static readonly ConfigName DebugSessionTelemetryOptOutName = new("Dashboard:DebugSession:TelemetryOptOut", "DASHBOARD__DEBUGSESSION__TELEMETRYOPTOUT");
     public static readonly ConfigName UIDisableResourceGraphName = new("Dashboard:UI:DisableResourceGraph", "DASHBOARD__UI__DISABLERESOURCEGRAPH");
     public static readonly ConfigName UIDisableImportName = new("Dashboard:UI:DisableImport", "DASHBOARD__UI__DISABLEIMPORT");
+    public static readonly ConfigName UIDisableAgentHelpName = new("Dashboard:UI:DisableAgentHelp", "DASHBOARD__UI__DISABLEAGENTHELP");
 
     public static class Legacy
     {

--- a/src/Shared/TokenGenerator.cs
+++ b/src/Shared/TokenGenerator.cs
@@ -14,7 +14,7 @@ internal static class TokenGenerator
 
         string tokenHex;
 #if NET9_0_OR_GREATER
-        tokenHex = Convert.ToHexStringLower(tokenBytes); 
+        tokenHex = Convert.ToHexStringLower(tokenBytes);
 #else
         tokenHex = Convert.ToHexString(tokenBytes).ToLowerInvariant();
 #endif


### PR DESCRIPTION
## Description

Add an AI Agents info dialog to the Aspire Dashboard header. When clicked, the dialog provides users with instructions on how to use AI coding agents with the dashboard, including CLI commands and links to documentation.

### Changes

- **AIAgentsDialog**: New dialog component with `BotSparkle` icon in the header and markdown-rendered content showing setup instructions
- **Dynamic dashboard URL**: Builds the dashboard URL from `Frontend.PublicUrl` configuration, appending `/login?t={token}` when API key + browser token auth is active
- **DisableAgentHelp setting**: New `Dashboard:UI:DisableAgentHelp` configuration option to hide the button
- **Desktop + mobile**: Button added to both desktop header (between Help and Settings) and mobile navigation menu
- **Adaptive content**: Dialog content adapts between standalone dashboard mode and AppHost-connected mode

Header icon:
<img width="452" height="160" alt="image" src="https://github.com/user-attachments/assets/a10a89d6-85d9-44f2-8c07-83e39bb7aac8" />

AppHost dialog:
<img width="981" height="753" alt="image" src="https://github.com/user-attachments/assets/4d92ac0e-00fe-4791-a2b3-b9309f69d70e" />

Standalone dialog:
<img width="987" height="807" alt="image" src="https://github.com/user-attachments/assets/be6ecb2d-068a-4fc9-a63c-0a8d7aebe488" />

## Checklist

- Is this feature complete?
  - [ ] Yes. Ready to ship.
  - [x] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [x] No
- Did you add public API?
  - [ ] Yes
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
  - [x] No
