### PR TITLE
Use Aspire container runtime for project image builds

### DIFF
--- a/src/Aspire.Cli/Aspire.Cli.csproj
+++ b/src/Aspire.Cli/Aspire.Cli.csproj
@@ -98,6 +98,7 @@
     <Compile Include="$(SharedDir)EnumerableExtensions.cs" Link="Utils\EnumerableExtensions.cs" />
     <Compile Include="$(SharedDir)KnownConfigNames.cs" Link="Utils\KnownConfigNames.cs" />
     <Compile Include="$(SharedDir)DashboardConfigNames.cs" Link="Utils\DashboardConfigNames.cs" />
+    <Compile Include="$(SharedDir)KnownContainerRuntimes.cs" Link="Utils\KnownContainerRuntimes.cs" />
     <Compile Include="$(SharedDir)ContainerRuntimeDetector.cs" Link="Utils\ContainerRuntimeDetector.cs" />
     <Compile Include="$(SharedDir)DashboardExitCodes.cs" Link="Utils\DashboardExitCodes.cs" />
     <Compile Include="$(SharedDir)KnownOtelConfigNames.cs" Link="Utils\KnownOtelConfigNames.cs" />

--- a/src/Aspire.Cli/Utils/EnvironmentChecker/ContainerRuntimeCheck.cs
+++ b/src/Aspire.Cli/Utils/EnvironmentChecker/ContainerRuntimeCheck.cs
@@ -29,8 +29,8 @@ internal sealed class ContainerRuntimeCheck(ILogger<ContainerRuntimeCheck> logge
         try
         {
             // Probe all runtimes in parallel
-            var dockerTask = ContainerRuntimeDetector.CheckRuntimeAsync("docker", "Docker", isDefault: true, logger, cancellationToken);
-            var podmanTask = ContainerRuntimeDetector.CheckRuntimeAsync("podman", "Podman", isDefault: false, logger, cancellationToken);
+            var dockerTask = ContainerRuntimeDetector.CheckRuntimeAsync(KnownContainerRuntimes.Docker, "Docker", isDefault: true, logger, cancellationToken);
+            var podmanTask = ContainerRuntimeDetector.CheckRuntimeAsync(KnownContainerRuntimes.Podman, "Podman", isDefault: false, logger, cancellationToken);
             var runtimes = await Task.WhenAll(dockerTask, podmanTask);
 
             var configuredRuntime = Environment.GetEnvironmentVariable("ASPIRE_CONTAINER_RUNTIME")

--- a/src/Aspire.Hosting/Aspire.Hosting.csproj
+++ b/src/Aspire.Hosting/Aspire.Hosting.csproj
@@ -29,6 +29,7 @@
     <Compile Include="$(SharedDir)KnownEndpointNames.cs" Link="Utils\KnownEndpointNames.cs" />
     <Compile Include="$(SharedDir)EnvironmentVariableNameEncoder.cs" Link="ApplicationModel\EnvironmentVariableNameEncoder.cs" />
     <Compile Include="$(SharedDir)KnownConfigNames.cs" Link="Utils\KnownConfigNames.cs" />
+    <Compile Include="$(SharedDir)KnownContainerRuntimes.cs" Link="Utils\KnownContainerRuntimes.cs" />
     <Compile Include="$(SharedDir)ContainerRuntimeDetector.cs" Link="Publishing\ContainerRuntimeDetector.cs" />
     <Compile Include="$(SharedDir)KnownOtelConfigNames.cs" Link="Utils\KnownOtelConfigNames.cs" />
     <Compile Include="$(SharedDir)OtlpEndpointResolver.cs" Link="Utils\OtlpEndpointResolver.cs" />

--- a/src/Aspire.Hosting/Dcp/DcpDependencyCheck.cs
+++ b/src/Aspire.Hosting/Dcp/DcpDependencyCheck.cs
@@ -8,6 +8,7 @@ using System.Text.Json;
 using System.Text.RegularExpressions;
 using Aspire.Hosting.Dcp.Process;
 using Aspire.Hosting.Resources;
+using Aspire.Shared;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 
@@ -214,12 +215,12 @@ internal sealed partial class DcpDependencyCheck : IDcpDependencyCheckService
         messageBuilder.AppendFormat(CultureInfo.InvariantCulture, InteractionStrings.ContainerRuntimeUnhealthyMessage, containerRuntime);
         string? linkUrl = null;
 
-        if (string.Equals(containerRuntime, "docker", StringComparison.OrdinalIgnoreCase))
+        if (string.Equals(containerRuntime, KnownContainerRuntimes.Docker, StringComparison.OrdinalIgnoreCase))
         {
             messageBuilder.Append(InteractionStrings.ContainerRuntimeDockerAdvice);
             linkUrl = "https://docs.docker.com/desktop/use-desktop/resource-saver/";
         }
-        else if (string.Equals(containerRuntime, "podman", StringComparison.OrdinalIgnoreCase))
+        else if (string.Equals(containerRuntime, KnownContainerRuntimes.Podman, StringComparison.OrdinalIgnoreCase))
         {
             messageBuilder.Append(InteractionStrings.ContainerRuntimePodmanAdvice);
         }
@@ -237,7 +238,7 @@ internal sealed partial class DcpDependencyCheck : IDcpDependencyCheckService
         if (string.IsNullOrEmpty(containerRuntime))
         {
             // Default runtime is Docker
-            containerRuntime = "docker";
+            containerRuntime = KnownContainerRuntimes.Docker;
         }
         var installed = dcpInfo.Containers?.Installed ?? false;
         var running = dcpInfo.Containers?.Running ?? false;

--- a/src/Aspire.Hosting/Dcp/DcpHost.cs
+++ b/src/Aspire.Hosting/Dcp/DcpHost.cs
@@ -11,6 +11,7 @@ using Aspire.Dashboard.Utils;
 using Aspire.Hosting.ApplicationModel;
 using Aspire.Hosting.Dcp.Process;
 using Aspire.Hosting.Resources;
+using Aspire.Shared;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
@@ -490,7 +491,7 @@ internal sealed class DcpHost
         if (string.IsNullOrEmpty(containerRuntime))
         {
             // Default runtime is Docker
-            containerRuntime = "docker";
+            containerRuntime = KnownContainerRuntimes.Docker;
         }
 
         var installed = dcpInfo.Containers?.Installed ?? false;

--- a/src/Aspire.Hosting/Dcp/IDcpDependencyCheckService.cs
+++ b/src/Aspire.Hosting/Dcp/IDcpDependencyCheckService.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Text.Json.Serialization;
+using Aspire.Shared;
 
 namespace Aspire.Hosting.Dcp;
 
@@ -42,7 +43,7 @@ internal sealed class DcpContainersInfo
     internal string ContainerHostName =>
         HostName ?? Runtime switch
         {
-            "podman" => "host.containers.internal",
+            KnownContainerRuntimes.Podman => "host.containers.internal",
             _ => "host.docker.internal",
         };
 }

--- a/src/Aspire.Hosting/DistributedApplicationBuilder.cs
+++ b/src/Aspire.Hosting/DistributedApplicationBuilder.cs
@@ -29,6 +29,7 @@ using Aspire.Hosting.Pipelines;
 using Aspire.Hosting.Pipelines.Internal;
 using Aspire.Hosting.Publishing;
 using Aspire.Hosting.UserSecrets;
+using Aspire.Shared;
 using Aspire.Shared.UserSecrets;
 using Microsoft.Extensions.Configuration.UserSecrets;
 using Aspire.Hosting.VersionChecking;
@@ -516,8 +517,8 @@ public class DistributedApplicationBuilder : IDistributedApplicationBuilder
 
         // Publishing support
         Eventing.Subscribe<BeforeStartEvent>(BuiltInDistributedApplicationEventSubscriptionHandlers.MutateHttp2TransportAsync);
-        _innerBuilder.Services.AddKeyedSingleton<IContainerRuntime, DockerContainerRuntime>("docker");
-        _innerBuilder.Services.AddKeyedSingleton<IContainerRuntime, PodmanContainerRuntime>("podman");
+        _innerBuilder.Services.AddKeyedSingleton<IContainerRuntime, DockerContainerRuntime>(KnownContainerRuntimes.Docker);
+        _innerBuilder.Services.AddKeyedSingleton<IContainerRuntime, PodmanContainerRuntime>(KnownContainerRuntimes.Podman);
         _innerBuilder.Services.AddSingleton<IContainerRuntimeResolver, ContainerRuntimeResolver>();
         _innerBuilder.Services.AddSingleton<IResourceContainerImageManager, ResourceContainerImageManager>();
         _innerBuilder.Services.AddSingleton<PipelineActivityReporter>();

--- a/src/Aspire.Hosting/Publishing/ContainerRuntimeResolver.cs
+++ b/src/Aspire.Hosting/Publishing/ContainerRuntimeResolver.cs
@@ -76,7 +76,7 @@ internal sealed class ContainerRuntimeResolver : IContainerRuntimeResolver
         // Auto-detect: probe available runtimes asynchronously.
         // See https://github.com/microsoft/dcp/blob/main/internal/containers/runtimes/runtime.go
         var detected = await ContainerRuntimeDetector.FindAvailableRuntimeAsync(logger: _logger, cancellationToken: cancellationToken).ConfigureAwait(false);
-        var runtimeKey = detected?.Executable ?? "docker";
+        var runtimeKey = detected?.Executable ?? KnownContainerRuntimes.Docker;
 
         if (detected is { IsHealthy: true })
         {
@@ -88,7 +88,7 @@ internal sealed class ContainerRuntimeResolver : IContainerRuntimeResolver
         }
         else
         {
-            _logger.LogWarning("No container runtime detected, defaulting to 'docker'. Install Docker or Podman to use container features.");
+            _logger.LogWarning("No container runtime detected, defaulting to '{DefaultRuntime}'. Install Docker or Podman to use container features.", KnownContainerRuntimes.Docker);
         }
 
         return _serviceProvider.GetRequiredKeyedService<IContainerRuntime>(runtimeKey);

--- a/src/Aspire.Hosting/Publishing/DockerContainerRuntime.cs
+++ b/src/Aspire.Hosting/Publishing/DockerContainerRuntime.cs
@@ -5,6 +5,7 @@
 #pragma warning disable ASPIRECONTAINERRUNTIME001
 
 using Aspire.Hosting.ApplicationModel;
+using Aspire.Shared;
 using Microsoft.Extensions.Logging;
 
 namespace Aspire.Hosting.Publishing;
@@ -15,7 +16,7 @@ internal sealed class DockerContainerRuntime : ContainerRuntimeBase<DockerContai
     {
     }
 
-    protected override string RuntimeExecutable => "docker";
+    protected override string RuntimeExecutable => KnownContainerRuntimes.Docker;
     public override string Name => "Docker";
     private async Task RunDockerBuildAsync(string contextPath, string dockerfilePath, ContainerImageBuildOptions? options, Dictionary<string, string?> buildArguments, Dictionary<string, BuildImageSecretValue> buildSecrets, string? stage, CancellationToken cancellationToken)
     {

--- a/src/Aspire.Hosting/Publishing/PodmanContainerRuntime.cs
+++ b/src/Aspire.Hosting/Publishing/PodmanContainerRuntime.cs
@@ -7,6 +7,7 @@
 using System.Text.Json;
 using System.Text.Json.Serialization;
 using Aspire.Hosting.Dcp.Process;
+using Aspire.Shared;
 using Microsoft.Extensions.Logging;
 
 namespace Aspire.Hosting.Publishing;
@@ -17,7 +18,7 @@ internal sealed class PodmanContainerRuntime : ContainerRuntimeBase<PodmanContai
     {
     }
 
-    protected override string RuntimeExecutable => "podman";
+    protected override string RuntimeExecutable => KnownContainerRuntimes.Podman;
     public override string Name => "Podman";
 
     /// <summary>

--- a/src/Aspire.Hosting/Publishing/ResourceContainerImageManager.cs
+++ b/src/Aspire.Hosting/Publishing/ResourceContainerImageManager.cs
@@ -432,6 +432,8 @@ internal sealed class ResourceContainerImageManager(
 
     private static string? GetLocalRegistryName(IContainerRuntime containerRuntime)
     {
+        // The .NET SDK container targets require these exact LocalRegistry values;
+        // lower-case executable names fail with CONTAINER2002.
         if (string.Equals(containerRuntime.Name, KnownContainerRuntimes.Docker, StringComparison.OrdinalIgnoreCase))
         {
             return "Docker";

--- a/src/Aspire.Hosting/Publishing/ResourceContainerImageManager.cs
+++ b/src/Aspire.Hosting/Publishing/ResourceContainerImageManager.cs
@@ -434,12 +434,12 @@ internal sealed class ResourceContainerImageManager(
     {
         if (string.Equals(containerRuntime.Name, KnownContainerRuntimes.Docker, StringComparison.OrdinalIgnoreCase))
         {
-            return KnownContainerRuntimes.Docker;
+            return "Docker";
         }
 
         if (string.Equals(containerRuntime.Name, KnownContainerRuntimes.Podman, StringComparison.OrdinalIgnoreCase))
         {
-            return KnownContainerRuntimes.Podman;
+            return "Podman";
         }
 
         return null;

--- a/src/Aspire.Hosting/Publishing/ResourceContainerImageManager.cs
+++ b/src/Aspire.Hosting/Publishing/ResourceContainerImageManager.cs
@@ -9,6 +9,7 @@ using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using Aspire.Hosting.ApplicationModel;
 using Aspire.Hosting.Dcp.Process;
+using Aspire.Shared;
 using Microsoft.Extensions.Logging;
 
 namespace Aspire.Hosting.Publishing;
@@ -330,7 +331,13 @@ internal sealed class ResourceContainerImageManager(
             throw new DistributedApplicationException($"The resource '{resource.Name}' does not have a project metadata annotation.");
         }
 
+        var containerRuntime = await GetContainerRuntimeAsync(cancellationToken).ConfigureAwait(false);
         var arguments = $"publish \"{projectMetadata.ProjectPath}\" --configuration Release /t:PublishContainer /p:ContainerRepository=\"{options.LocalImageName}\" /p:ContainerImageTag=\"{options.LocalImageTag}\"";
+
+        if (GetLocalRegistryName(containerRuntime) is string localRegistry)
+        {
+            arguments += $" /p:LocalRegistry=\"{localRegistry}\"";
+        }
 
         // Add additional arguments based on options
         if (!string.IsNullOrEmpty(options.OutputPath))
@@ -421,6 +428,21 @@ internal sealed class ResourceContainerImageManager(
                     processResult.ExitCode);
             }
         }
+    }
+
+    private static string? GetLocalRegistryName(IContainerRuntime containerRuntime)
+    {
+        if (string.Equals(containerRuntime.Name, KnownContainerRuntimes.Docker, StringComparison.OrdinalIgnoreCase))
+        {
+            return KnownContainerRuntimes.Docker;
+        }
+
+        if (string.Equals(containerRuntime.Name, KnownContainerRuntimes.Podman, StringComparison.OrdinalIgnoreCase))
+        {
+            return KnownContainerRuntimes.Podman;
+        }
+
+        return null;
     }
 
     private async Task BuildContainerImageFromDockerfileAsync(IResource resource, DockerfileBuildAnnotation dockerfileBuildAnnotation, string imageName, ResolvedContainerBuildOptions options, CancellationToken cancellationToken)

--- a/src/Shared/ContainerRuntimeDetector.cs
+++ b/src/Shared/ContainerRuntimeDetector.cs
@@ -90,8 +90,8 @@ internal static class ContainerRuntimeDetector
 
     private static readonly (string Executable, string Name, bool IsDefault)[] s_knownRuntimes =
     [
-        ("docker", "Docker", true),
-        ("podman", "Podman", false)
+        (KnownContainerRuntimes.Docker, "Docker", true),
+        (KnownContainerRuntimes.Podman, "Podman", false)
     ];
 
     /// <summary>

--- a/src/Shared/KnownContainerRuntimes.cs
+++ b/src/Shared/KnownContainerRuntimes.cs
@@ -1,0 +1,10 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Aspire.Shared;
+
+internal static class KnownContainerRuntimes
+{
+    public const string Docker = "docker";
+    public const string Podman = "podman";
+}

--- a/tests/Aspire.Hosting.Tests/Publishing/FakeContainerRuntime.cs
+++ b/tests/Aspire.Hosting.Tests/Publishing/FakeContainerRuntime.cs
@@ -11,9 +11,9 @@ namespace Aspire.Hosting.Tests.Publishing;
 
 using Aspire.Hosting.ApplicationModel;
 
-public sealed class FakeContainerRuntime(bool shouldFail = false, bool isRunning = true) : IContainerRuntime, IContainerRuntimeResolver
+public sealed class FakeContainerRuntime(bool shouldFail = false, bool isRunning = true, string name = "fake-runtime") : IContainerRuntime, IContainerRuntimeResolver
 {
-    public string Name => "fake-runtime";
+    public string Name => name;
     public bool WasHealthCheckCalled { get; private set; }
     public int CheckIfRunningCallCount { get; private set; }
     public bool WasTagImageCalled { get; private set; }

--- a/tests/Aspire.Hosting.Tests/Publishing/ResourceContainerImageManagerTests.cs
+++ b/tests/Aspire.Hosting.Tests/Publishing/ResourceContainerImageManagerTests.cs
@@ -704,7 +704,7 @@ public class ResourceContainerImageBuilderTests(ITestOutputHelper output)
         var collector = app.Services.GetFakeLogCollector();
         var logs = collector.GetSnapshot();
 
-        Assert.Contains(logs, log => log.Message.Contains("/p:LocalRegistry=\"podman\""));
+        Assert.Contains(logs, log => log.Message.Contains("/p:LocalRegistry=\"Podman\""));
     }
 
     [Fact]

--- a/tests/Aspire.Hosting.Tests/Publishing/ResourceContainerImageManagerTests.cs
+++ b/tests/Aspire.Hosting.Tests/Publishing/ResourceContainerImageManagerTests.cs
@@ -669,6 +669,45 @@ public class ResourceContainerImageBuilderTests(ITestOutputHelper output)
     }
 
     [Fact]
+    public async Task BuildImageAsync_ProjectBuildPassesResolvedContainerRuntimeAsLocalRegistry()
+    {
+        using var builder = TestDistributedApplicationBuilder.Create(output);
+
+        builder.Services.AddLogging(logging =>
+        {
+            logging.AddFakeLogging();
+            logging.AddXunit(output);
+        });
+
+        var fakeContainerRuntime = new FakeContainerRuntime(name: "PODMAN");
+        builder.Services.AddSingleton<IContainerRuntimeResolver>(fakeContainerRuntime);
+
+        using var tempDir = new TestTempDirectory();
+
+        var project = builder.AddResource(new ProjectResource("broken-project"))
+            .WithAnnotation(new TestProjectMetadata(Path.Combine(tempDir.Path, "missing.csproj")))
+            .WithContainerBuildOptions(ctx =>
+            {
+                ctx.Destination = ContainerImageDestination.Archive;
+                ctx.ImageFormat = ContainerImageFormat.Oci;
+                ctx.OutputPath = tempDir.Path;
+            });
+
+        using var app = builder.Build();
+
+        using var cts = new CancellationTokenSource(TestConstants.DefaultTimeoutTimeSpan);
+        var imageBuilder = app.Services.GetRequiredService<IResourceContainerImageManager>();
+
+        await Assert.ThrowsAsync<ProcessFailedException>(() =>
+            imageBuilder.BuildImageAsync(project.Resource, cts.Token));
+
+        var collector = app.Services.GetFakeLogCollector();
+        var logs = collector.GetSnapshot();
+
+        Assert.Contains(logs, log => log.Message.Contains("/p:LocalRegistry=\"podman\""));
+    }
+
+    [Fact]
     [RequiresFeature(TestFeature.Docker | TestFeature.DockerPluginBuildx)]
     public async Task CanBuildImageFromDockerfileWithBuildArgsSecretsAndStage()
     {


### PR DESCRIPTION
## Description

Aspire deployment can resolve Podman as the active container runtime, but .NET project resources were still letting the .NET SDK choose its own local registry tool for `PublishContainer`. On machines with both Docker and Podman installed, that could build project images into Docker while Aspire later tried to tag and push them through Podman.

This change passes the resolved Aspire container runtime to SDK container publish using `LocalRegistry`, so project resource images are built into the same local engine used by Dockerfile builds and image push steps. It also adds shared known container runtime constants and uses them across hosting, CLI runtime checks, and DCP runtime messaging to keep the runtime identifiers aligned.

Fixes #16600

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to `aspire.dev` issue:
      - [New issue](https://github.com/microsoft/aspire.dev/issues/new)
  - [x] No