### PR TITLE
Add Kubernetes manifest ATS API

### DIFF
--- a/src/Aspire.Hosting.Kubernetes/KubernetesManifestResource.cs
+++ b/src/Aspire.Hosting.Kubernetes/KubernetesManifestResource.cs
@@ -138,13 +138,68 @@ public sealed class KubernetesManifestResource : BaseKubernetesResource
             null => null,
             string => value,
             bool => value,
-            byte or sbyte or short or ushort or int or uint or long or ulong or float or double or decimal => value,
+            byte or sbyte or short or ushort or int or uint or long or ulong => value,
+            float floatValue => NormalizeFloatingPointValue(floatValue),
+            double doubleValue => NormalizeFloatingPointValue(doubleValue),
+            decimal decimalValue => NormalizeDecimalValue(decimalValue),
             JsonElement element => NormalizeJsonElement(element),
             JsonNode node => NormalizeJsonNode(node),
             IDictionary dictionary => NormalizeDictionary(dictionary),
             IEnumerable enumerable when value is not string => NormalizeEnumerable(enumerable),
             _ => throw new ArgumentException($"Manifest field values must be JSON-compatible primitives, dictionaries, or arrays. Type '{value.GetType()}' is not supported.", nameof(value))
         };
+    }
+
+    private const double MaxLongExclusiveAsDouble = 9_223_372_036_854_775_808d;
+
+    private static object NormalizeFloatingPointValue(float value)
+    {
+        if (!float.IsFinite(value))
+        {
+            throw new ArgumentException("Manifest field numeric values must be finite.", nameof(value));
+        }
+
+        if (MathF.Truncate(value) == value)
+        {
+            return ConvertWholeNumberToLong(value);
+        }
+
+        return value;
+    }
+
+    private static object NormalizeFloatingPointValue(double value)
+    {
+        if (!double.IsFinite(value))
+        {
+            throw new ArgumentException("Manifest field numeric values must be finite.", nameof(value));
+        }
+
+        if (Math.Truncate(value) == value)
+        {
+            return ConvertWholeNumberToLong(value);
+        }
+
+        return value;
+    }
+
+    private static object NormalizeDecimalValue(decimal value)
+    {
+        if (decimal.Truncate(value) == value && value >= long.MinValue && value <= long.MaxValue)
+        {
+            return decimal.ToInt64(value);
+        }
+
+        return value;
+    }
+
+    private static long ConvertWholeNumberToLong(double value)
+    {
+        if (value < long.MinValue || value >= MaxLongExclusiveAsDouble)
+        {
+            throw new ArgumentException($"Whole-number manifest field values must be between {long.MinValue} and {long.MaxValue}.", nameof(value));
+        }
+
+        return (long)value;
     }
 
     private static object? NormalizeJsonNode(JsonNode node)

--- a/src/Aspire.Hosting.Kubernetes/KubernetesManifestResource.cs
+++ b/src/Aspire.Hosting.Kubernetes/KubernetesManifestResource.cs
@@ -1,0 +1,201 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Collections;
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using Aspire.Hosting.Kubernetes.Resources;
+
+namespace Aspire.Hosting.Kubernetes;
+
+/// <summary>
+/// Represents an arbitrary Kubernetes manifest that is emitted with a Kubernetes service.
+/// </summary>
+/// <remarks>
+/// This type provides a polyglot-friendly server-side handle for custom manifests. C# callers that need
+/// strongly typed Kubernetes objects can continue to add <see cref="BaseKubernetesResource"/> instances
+/// directly to <see cref="KubernetesResource.AdditionalResources"/>.
+/// </remarks>
+[AspireExport]
+public sealed class KubernetesManifestResource : BaseKubernetesResource
+{
+    internal KubernetesManifestResource(string apiVersion, string kind, string name)
+        : base(apiVersion, kind)
+    {
+        Metadata.Name = name;
+    }
+
+    internal Dictionary<string, object?> Fields { get; } = [];
+
+    /// <summary>
+    /// Sets the namespace for this manifest.
+    /// </summary>
+    /// <param name="namespace">The Kubernetes namespace.</param>
+    /// <returns>This manifest resource.</returns>
+    [AspireExport(Description = "Sets the Kubernetes namespace for this manifest")]
+    public KubernetesManifestResource WithNamespace(string @namespace)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(@namespace);
+
+        Metadata.Namespace = @namespace;
+
+        return this;
+    }
+
+    /// <summary>
+    /// Adds or updates a Kubernetes label on this manifest.
+    /// </summary>
+    /// <param name="key">The label key.</param>
+    /// <param name="value">The label value.</param>
+    /// <returns>This manifest resource.</returns>
+    [AspireExport(Description = "Adds or updates a Kubernetes label on this manifest")]
+    public KubernetesManifestResource WithLabel(string key, string value)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(key);
+        ArgumentNullException.ThrowIfNull(value);
+
+        Metadata.Labels[key] = value;
+
+        return this;
+    }
+
+    /// <summary>
+    /// Adds or updates a Kubernetes annotation on this manifest.
+    /// </summary>
+    /// <param name="key">The annotation key.</param>
+    /// <param name="value">The annotation value.</param>
+    /// <returns>This manifest resource.</returns>
+    [AspireExport(Description = "Adds or updates a Kubernetes annotation on this manifest")]
+    public KubernetesManifestResource WithAnnotation(string key, string value)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(key);
+        ArgumentNullException.ThrowIfNull(value);
+
+        Metadata.Annotations[key] = value;
+
+        return this;
+    }
+
+    /// <summary>
+    /// Adds or updates a manifest field using a dot-separated path.
+    /// </summary>
+    /// <param name="path">The dot-separated manifest field path, for example <c>spec.replicas</c> or <c>data.username</c>.</param>
+    /// <param name="value">The field value.</param>
+    /// <returns>This manifest resource.</returns>
+    [AspireExport(Description = "Adds or updates a manifest field using a dot-separated path")]
+    public KubernetesManifestResource WithField(
+        string path,
+        [AspireUnion(typeof(string), typeof(double), typeof(bool))] object value)
+    {
+        var segments = ParseFieldPath(path);
+
+        SetField(Fields, segments, NormalizeManifestValue(value));
+
+        return this;
+    }
+
+    private static string[] ParseFieldPath(string path)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(path);
+
+        var segments = path.Split('.', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+        if (segments.Length == 0)
+        {
+            throw new ArgumentException("Manifest field path must contain at least one segment.", nameof(path));
+        }
+
+        if (segments[0] is "apiVersion" or "kind" or "metadata")
+        {
+            throw new ArgumentException("Use the dedicated manifest API to configure apiVersion, kind, and metadata fields.", nameof(path));
+        }
+
+        return segments;
+    }
+
+    private static void SetField(Dictionary<string, object?> fields, ReadOnlySpan<string> path, object? value)
+    {
+        var current = fields;
+
+        for (var i = 0; i < path.Length - 1; i++)
+        {
+            var segment = path[i];
+            if (!current.TryGetValue(segment, out var child) || child is not Dictionary<string, object?> childFields)
+            {
+                childFields = [];
+                current[segment] = childFields;
+            }
+
+            current = childFields;
+        }
+
+        current[path[^1]] = value;
+    }
+
+    internal static object? NormalizeManifestValue(object? value)
+    {
+        return value switch
+        {
+            null => null,
+            string => value,
+            bool => value,
+            byte or sbyte or short or ushort or int or uint or long or ulong or float or double or decimal => value,
+            JsonElement element => NormalizeJsonElement(element),
+            JsonNode node => NormalizeJsonNode(node),
+            IDictionary dictionary => NormalizeDictionary(dictionary),
+            IEnumerable enumerable when value is not string => NormalizeEnumerable(enumerable),
+            _ => throw new ArgumentException($"Manifest field values must be JSON-compatible primitives, dictionaries, or arrays. Type '{value.GetType()}' is not supported.", nameof(value))
+        };
+    }
+
+    private static object? NormalizeJsonNode(JsonNode node)
+    {
+        using var document = JsonDocument.Parse(node.ToJsonString());
+
+        return NormalizeJsonElement(document.RootElement);
+    }
+
+    private static object? NormalizeJsonElement(JsonElement element)
+    {
+        return element.ValueKind switch
+        {
+            JsonValueKind.Null => null,
+            JsonValueKind.String => element.GetString(),
+            JsonValueKind.True => true,
+            JsonValueKind.False => false,
+            JsonValueKind.Number when element.TryGetInt64(out var longValue) => longValue,
+            JsonValueKind.Number => element.GetDouble(),
+            JsonValueKind.Array => element.EnumerateArray().Select(NormalizeJsonElement).ToList(),
+            JsonValueKind.Object => element.EnumerateObject().ToDictionary(prop => prop.Name, prop => NormalizeJsonElement(prop.Value), StringComparer.Ordinal),
+            _ => throw new ArgumentException($"Unsupported JSON value kind '{element.ValueKind}'.", nameof(element))
+        };
+    }
+
+    private static Dictionary<string, object?> NormalizeDictionary(IDictionary dictionary)
+    {
+        var result = new Dictionary<string, object?>(StringComparer.Ordinal);
+
+        foreach (DictionaryEntry entry in dictionary)
+        {
+            if (entry.Key is not string key)
+            {
+                throw new ArgumentException("Manifest field dictionaries must use string keys.");
+            }
+
+            result[key] = NormalizeManifestValue(entry.Value);
+        }
+
+        return result;
+    }
+
+    private static List<object?> NormalizeEnumerable(IEnumerable enumerable)
+    {
+        var result = new List<object?>();
+
+        foreach (var item in enumerable)
+        {
+            result.Add(NormalizeManifestValue(item));
+        }
+
+        return result;
+    }
+}

--- a/src/Aspire.Hosting.Kubernetes/KubernetesManifestResource.cs
+++ b/src/Aspire.Hosting.Kubernetes/KubernetesManifestResource.cs
@@ -74,6 +74,10 @@ internal sealed class KubernetesManifestResource : BaseKubernetesResource
     /// <summary>
     /// Adds or updates a manifest field using a dot-separated path.
     /// </summary>
+    /// <remarks>
+    /// Polyglot SDKs currently support scalar field values only. Use dot-separated paths to build nested objects with
+    /// scalar leaf values; array values are not supported by this method.
+    /// </remarks>
     /// <param name="path">The dot-separated manifest field path, for example <c>spec.replicas</c> or <c>data.username</c>.</param>
     /// <param name="value">The field value.</param>
     /// <returns>This manifest resource.</returns>
@@ -84,7 +88,7 @@ internal sealed class KubernetesManifestResource : BaseKubernetesResource
     {
         var segments = ParseFieldPath(path);
 
-        SetField(Fields, segments, NormalizeManifestValue(value));
+        SetField(Fields, segments, path, NormalizeManifestValue(value));
 
         return this;
     }
@@ -107,23 +111,31 @@ internal sealed class KubernetesManifestResource : BaseKubernetesResource
         return segments;
     }
 
-    private static void SetField(Dictionary<string, object?> fields, ReadOnlySpan<string> path, object? value)
+    private static void SetField(Dictionary<string, object?> fields, ReadOnlySpan<string> segments, string path, object? value)
     {
         var current = fields;
 
-        for (var i = 0; i < path.Length - 1; i++)
+        for (var i = 0; i < segments.Length - 1; i++)
         {
-            var segment = path[i];
-            if (!current.TryGetValue(segment, out var child) || child is not Dictionary<string, object?> childFields)
+            var segment = segments[i];
+            if (current.TryGetValue(segment, out var child))
             {
-                childFields = [];
-                current[segment] = childFields;
-            }
+                if (child is not Dictionary<string, object?> childFields)
+                {
+                    throw new ArgumentException($"Cannot set nested manifest field '{path}' because '{segment}' already has a scalar value.", nameof(path));
+                }
 
-            current = childFields;
+                current = childFields;
+            }
+            else
+            {
+                var childFields = new Dictionary<string, object?>(StringComparer.Ordinal);
+                current[segment] = childFields;
+                current = childFields;
+            }
         }
 
-        current[path[^1]] = value;
+        current[segments[^1]] = value;
     }
 
     internal static object? NormalizeManifestValue(object? value)

--- a/src/Aspire.Hosting.Kubernetes/KubernetesManifestResource.cs
+++ b/src/Aspire.Hosting.Kubernetes/KubernetesManifestResource.cs
@@ -11,13 +11,8 @@ namespace Aspire.Hosting.Kubernetes;
 /// <summary>
 /// Represents an arbitrary Kubernetes manifest that is emitted with a Kubernetes service.
 /// </summary>
-/// <remarks>
-/// This type provides a polyglot-friendly server-side handle for custom manifests. C# callers that need
-/// strongly typed Kubernetes objects can continue to add <see cref="BaseKubernetesResource"/> instances
-/// directly to <see cref="KubernetesResource.AdditionalResources"/>.
-/// </remarks>
 [AspireExport]
-public sealed class KubernetesManifestResource : BaseKubernetesResource
+internal sealed class KubernetesManifestResource : BaseKubernetesResource
 {
     internal KubernetesManifestResource(string apiVersion, string kind, string name)
         : base(apiVersion, kind)

--- a/src/Aspire.Hosting.Kubernetes/KubernetesPublishingContext.cs
+++ b/src/Aspire.Hosting.Kubernetes/KubernetesPublishingContext.cs
@@ -34,6 +34,7 @@ internal sealed class KubernetesPublishingContext(
         .WithNamingConvention(CamelCaseNamingConvention.Instance)
         .WithTypeConverter(new ByteArrayStringYamlConverter())
         .WithTypeConverter(new IntOrStringYamlConverter())
+        .WithTypeConverter(new KubernetesManifestResourceYamlConverter())
         .WithEventEmitter(nextEmitter => new ForceQuotedStringsEventEmitter(nextEmitter, HelmExtensions.ShouldDoubleQuoteString))
         .WithEventEmitter(e => new FloatEmitter(e))
         .WithEmissionPhaseObjectGraphVisitor(args => new YamlIEnumerableSkipEmptyObjectGraphVisitor(args.InnerVisitor))

--- a/src/Aspire.Hosting.Kubernetes/KubernetesResource.cs
+++ b/src/Aspire.Hosting.Kubernetes/KubernetesResource.cs
@@ -79,7 +79,7 @@ public partial class KubernetesResource(string name, IResource resource, Kuberne
     public List<BaseKubernetesResource> AdditionalResources { get; } = [];
 
     /// <summary>
-    /// Adds an arbitrary Kubernetes manifest to this service's generated Helm chart.
+    /// Adds an arbitrary Kubernetes manifest to this service's generated Helm chart for polyglot callers.
     /// </summary>
     /// <param name="apiVersion">The Kubernetes API version for the manifest.</param>
     /// <param name="kind">The Kubernetes resource kind for the manifest.</param>
@@ -87,7 +87,7 @@ public partial class KubernetesResource(string name, IResource resource, Kuberne
     /// <param name="configure">A callback that configures the manifest fields.</param>
     /// <returns>The added Kubernetes manifest resource.</returns>
     [AspireExport(Description = "Adds an arbitrary Kubernetes manifest to this service's generated Helm chart", RunSyncOnBackgroundThread = true)]
-    public KubernetesManifestResource AddManifest(string apiVersion, string kind, string name, Action<KubernetesManifestResource>? configure = null)
+    internal KubernetesManifestResource AddManifest(string apiVersion, string kind, string name, Action<KubernetesManifestResource>? configure = null)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(apiVersion);
         ArgumentException.ThrowIfNullOrWhiteSpace(kind);

--- a/src/Aspire.Hosting.Kubernetes/KubernetesResource.cs
+++ b/src/Aspire.Hosting.Kubernetes/KubernetesResource.cs
@@ -75,7 +75,30 @@ public partial class KubernetesResource(string name, IResource resource, Kuberne
     /// <summary>
     /// Additional resources that are part of this Kubernetes service.
     /// </summary>
+    [AspireExportIgnore(Reason = "Kubernetes manifest resource types are C#-only customization objects and are not part of the polyglot SDK surface.")]
     public List<BaseKubernetesResource> AdditionalResources { get; } = [];
+
+    /// <summary>
+    /// Adds an arbitrary Kubernetes manifest to this service's generated Helm chart.
+    /// </summary>
+    /// <param name="apiVersion">The Kubernetes API version for the manifest.</param>
+    /// <param name="kind">The Kubernetes resource kind for the manifest.</param>
+    /// <param name="name">The Kubernetes metadata name for the manifest.</param>
+    /// <param name="configure">A callback that configures the manifest fields.</param>
+    /// <returns>The added Kubernetes manifest resource.</returns>
+    [AspireExport(Description = "Adds an arbitrary Kubernetes manifest to this service's generated Helm chart", RunSyncOnBackgroundThread = true)]
+    public KubernetesManifestResource AddManifest(string apiVersion, string kind, string name, Action<KubernetesManifestResource>? configure = null)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(apiVersion);
+        ArgumentException.ThrowIfNullOrWhiteSpace(kind);
+        ArgumentException.ThrowIfNullOrWhiteSpace(name);
+
+        var manifest = new KubernetesManifestResource(apiVersion, kind, name);
+        configure?.Invoke(manifest);
+        AdditionalResources.Add(manifest);
+
+        return manifest;
+    }
 
     /// <summary>
     /// Gets the resource that is the target of this Kubernetes service.

--- a/src/Aspire.Hosting.Kubernetes/Yaml/KubernetesManifestResourceYamlConverter.cs
+++ b/src/Aspire.Hosting.Kubernetes/Yaml/KubernetesManifestResourceYamlConverter.cs
@@ -1,0 +1,48 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using YamlDotNet.Core;
+using YamlDotNet.Core.Events;
+using YamlDotNet.Serialization;
+
+namespace Aspire.Hosting.Kubernetes.Yaml;
+
+internal sealed class KubernetesManifestResourceYamlConverter : IYamlTypeConverter
+{
+    public bool Accepts(Type type)
+    {
+        return type == typeof(KubernetesManifestResource);
+    }
+
+    public object? ReadYaml(IParser parser, Type type, ObjectDeserializer rootDeserializer)
+    {
+        throw new NotSupportedException($"{nameof(KubernetesManifestResource)} only supports YAML serialization.");
+    }
+
+    public void WriteYaml(IEmitter emitter, object? value, Type type, ObjectSerializer serializer)
+    {
+        if (value is not KubernetesManifestResource manifest)
+        {
+            throw new InvalidOperationException($"Expected {nameof(KubernetesManifestResource)} but got {value?.GetType()}.");
+        }
+
+        emitter.Emit(new MappingStart());
+
+        WriteProperty("apiVersion", manifest.ApiVersion, serializer);
+        WriteProperty("kind", manifest.Kind, serializer);
+        WriteProperty("metadata", manifest.Metadata, serializer);
+
+        foreach (var (key, fieldValue) in manifest.Fields)
+        {
+            WriteProperty(key, fieldValue, serializer);
+        }
+
+        emitter.Emit(new MappingEnd());
+    }
+
+    private static void WriteProperty(string name, object? value, ObjectSerializer serializer)
+    {
+        serializer(name);
+        serializer(value);
+    }
+}

--- a/src/Aspire.Hosting.Kubernetes/Yaml/KubernetesManifestResourceYamlConverter.cs
+++ b/src/Aspire.Hosting.Kubernetes/Yaml/KubernetesManifestResourceYamlConverter.cs
@@ -16,7 +16,7 @@ internal sealed class KubernetesManifestResourceYamlConverter : IYamlTypeConvert
 
     public object? ReadYaml(IParser parser, Type type, ObjectDeserializer rootDeserializer)
     {
-        throw new NotSupportedException($"{nameof(KubernetesManifestResource)} only supports YAML serialization.");
+        throw new NotSupportedException($"{nameof(KubernetesManifestResource)} does not support YAML deserialization.");
     }
 
     public void WriteYaml(IEmitter emitter, object? value, Type type, ObjectSerializer serializer)

--- a/tests/Aspire.Hosting.Kubernetes.Tests/KubernetesPublisherTests.cs
+++ b/tests/Aspire.Hosting.Kubernetes.Tests/KubernetesPublisherTests.cs
@@ -232,6 +232,17 @@ public class KubernetesPublisherTests()
     }
 
     [Fact]
+    public void KubernetesManifestResourceWithFieldThrowsWhenIntermediatePathIsScalar()
+    {
+        var manifest = new KubernetesManifestResource("example.com/v1", "Example", "example");
+        manifest.WithField("spec", "scalar");
+
+        var exception = Assert.Throws<ArgumentException>(() => manifest.WithField("spec.replicas", 3));
+
+        Assert.Contains("Cannot set nested manifest field 'spec.replicas' because 'spec' already has a scalar value.", exception.Message);
+    }
+
+    [Fact]
     public async Task PublishAsync_HandlesSpecialResourceName()
     {
         using var tempDir = new TestTempDirectory();

--- a/tests/Aspire.Hosting.Kubernetes.Tests/KubernetesPublisherTests.cs
+++ b/tests/Aspire.Hosting.Kubernetes.Tests/KubernetesPublisherTests.cs
@@ -4,6 +4,7 @@
 using Aspire.Hosting.ApplicationModel;
 using Aspire.Hosting.Kubernetes.Resources;
 using Aspire.Hosting.Utils;
+using YamlDotNet.RepresentationModel;
 using YamlDotNet.Serialization;
 
 namespace Aspire.Hosting.Kubernetes.Tests;
@@ -194,7 +195,7 @@ public class KubernetesPublisherTests()
                         .WithField("spec.scaleTargetRef.kind", "Deployment")
                         .WithField("spec.scaleTargetRef.name", "myapp")
                         .WithField("spec.minReplicaCount", 1)
-                        .WithField("spec.maxReplicaCount", 3)
+                        .WithField("spec.maxReplicaCount", (double)3)
                         .WithField("data.enabled", true);
                 });
             });
@@ -219,7 +220,14 @@ public class KubernetesPublisherTests()
         Assert.Contains("kind: \"Deployment\"", content);
         Assert.Contains("name: \"myapp\"", content);
         Assert.Contains("minReplicaCount: 1", content);
-        Assert.Contains("maxReplicaCount: 3", content);
+
+        var yaml = new YamlStream();
+        yaml.Load(new StringReader(content));
+        var root = Assert.IsType<YamlMappingNode>(yaml.Documents[0].RootNode);
+        var spec = Assert.IsType<YamlMappingNode>(root.Children.Single(static entry => entry.Key is YamlScalarNode { Value: "spec" }).Value);
+        var maxReplicaCount = Assert.IsType<YamlScalarNode>(spec.Children.Single(static entry => entry.Key is YamlScalarNode { Value: "maxReplicaCount" }).Value);
+        Assert.Equal("3", maxReplicaCount.Value);
+        Assert.DoesNotContain("maxReplicaCount: 3.0", content);
         Assert.Contains("enabled: true", content);
     }
 

--- a/tests/Aspire.Hosting.Kubernetes.Tests/KubernetesPublisherTests.cs
+++ b/tests/Aspire.Hosting.Kubernetes.Tests/KubernetesPublisherTests.cs
@@ -176,6 +176,54 @@ public class KubernetesPublisherTests()
     }
 
     [Fact]
+    public async Task PublishAsync_CustomManifestResource()
+    {
+        using var tempDir = new TestTempDirectory();
+        var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish, tempDir.Path);
+
+        builder.AddKubernetesEnvironment("env");
+
+        builder.AddContainer("myapp", "mcr.microsoft.com/dotnet/aspnet:8.0")
+            .PublishAsKubernetesService(serviceResource =>
+            {
+                serviceResource.AddManifest("keda.sh/v1alpha1", "ScaledObject", "myapp-scaler", manifest =>
+                {
+                    manifest.WithNamespace("autoscaling")
+                        .WithLabel("example.com/custom", "true")
+                        .WithAnnotation("example.com/source", "polyglot")
+                        .WithField("spec.scaleTargetRef.kind", "Deployment")
+                        .WithField("spec.scaleTargetRef.name", "myapp")
+                        .WithField("spec.minReplicaCount", 1)
+                        .WithField("spec.maxReplicaCount", 3)
+                        .WithField("data.enabled", true);
+                });
+            });
+
+        var app = builder.Build();
+
+        app.Run();
+
+        var manifestPath = Path.Combine(tempDir.Path, "templates/myapp/scaler.yaml");
+        Assert.True(File.Exists(manifestPath), $"Manifest should exist at {manifestPath}");
+
+        var content = await File.ReadAllTextAsync(manifestPath);
+
+        Assert.Contains("apiVersion: keda.sh/v1alpha1", content);
+        Assert.Contains("kind: ScaledObject", content);
+        Assert.Contains("myapp-scaler", content);
+        Assert.Contains("namespace: \"autoscaling\"", content);
+        Assert.Contains("example.com/custom: \"true\"", content);
+        Assert.Contains("app.kubernetes.io/name:", content);
+        Assert.Contains("example.com/source: \"polyglot\"", content);
+        Assert.Contains("scaleTargetRef:", content);
+        Assert.Contains("kind: \"Deployment\"", content);
+        Assert.Contains("name: \"myapp\"", content);
+        Assert.Contains("minReplicaCount: 1", content);
+        Assert.Contains("maxReplicaCount: 3", content);
+        Assert.Contains("enabled: true", content);
+    }
+
+    [Fact]
     public async Task PublishAsync_HandlesSpecialResourceName()
     {
         using var tempDir = new TestTempDirectory();

--- a/tests/PolyglotAppHosts/Aspire.Hosting.Kubernetes/Go/apphost.go
+++ b/tests/PolyglotAppHosts/Aspire.Hosting.Kubernetes/Go/apphost.go
@@ -65,6 +65,15 @@ func main() {
 	_ = serviceContainer.PublishAsKubernetesService(func(service aspire.KubernetesResource) {
 		_, _ = service.Name()
 		_ = service.Parent()
+		_ = service.AddManifest("keda.sh/v1alpha1", "ScaledObject", "kube-service-scaler", &aspire.AddManifestOptions{
+			Configure: func(manifest aspire.KubernetesManifestResource) {
+				manifest.WithLabel("example.com/custom", "true")
+				manifest.WithAnnotation("example.com/source", "go")
+				manifest.WithField("spec.scaleTargetRef.kind", "Deployment")
+				manifest.WithField("spec.scaleTargetRef.name", "kube-service")
+				manifest.WithField("spec.maxReplicaCount", 3)
+			},
+		})
 	})
 	if err = serviceContainer.Err(); err != nil {
 		log.Fatalf(aspire.FormatError(err))

--- a/tests/PolyglotAppHosts/Aspire.Hosting.Kubernetes/Java/AppHost.java
+++ b/tests/PolyglotAppHosts/Aspire.Hosting.Kubernetes/Java/AppHost.java
@@ -46,6 +46,13 @@ void main() throws Exception {
         serviceContainer.publishAsKubernetesService((service) -> {
             var _serviceName = service.name();
             var _serviceParent = service.parent();
+            service.addManifest("keda.sh/v1alpha1", "ScaledObject", "kube-service-scaler", (manifest) -> {
+                manifest.withLabel("example.com/custom", "true");
+                manifest.withAnnotation("example.com/source", "java");
+                manifest.withField("spec.scaleTargetRef.kind", "Deployment");
+                manifest.withField("spec.scaleTargetRef.name", "kube-service");
+                manifest.withField("spec.maxReplicaCount", 3);
+            });
         });
         builder.build().run();
     }

--- a/tests/PolyglotAppHosts/Aspire.Hosting.Kubernetes/Python/apphost.py
+++ b/tests/PolyglotAppHosts/Aspire.Hosting.Kubernetes/Python/apphost.py
@@ -35,5 +35,16 @@ with create_builder() as builder:
     ingress.with_hostname("ingress.example.com")
     ingress.with_tls("ingress-tls")
     service_container = builder.add_container("resource", "image")
-    service_container.publish_as_kubernetes_service()
+
+    def configure_service(service):
+        def configure_manifest(manifest):
+            manifest.with_label("example.com/custom", "true")
+            manifest.with_annotation("example.com/source", "python")
+            manifest.with_field("spec.scaleTargetRef.kind", "Deployment")
+            manifest.with_field("spec.scaleTargetRef.name", "resource")
+            manifest.with_field("spec.maxReplicaCount", 3)
+
+        service.add_manifest("keda.sh/v1alpha1", "ScaledObject", "resource-scaler", configure_manifest)
+
+    service_container.publish_as_kubernetes_service(configure_service)
     builder.run()

--- a/tests/PolyglotAppHosts/Aspire.Hosting.Kubernetes/TypeScript/apphost.ts
+++ b/tests/PolyglotAppHosts/Aspire.Hosting.Kubernetes/TypeScript/apphost.ts
@@ -60,6 +60,16 @@ const serviceContainer = await builder.addContainer('kube-service', 'redis:alpin
 await serviceContainer.publishAsKubernetesService(async (service) => {
     const _serviceName: string = await service.name();
     const _serviceParent = await service.parent();
+
+    await service.addManifest('keda.sh/v1alpha1', 'ScaledObject', 'kube-service-scaler', {
+        configure: async (manifest) => {
+            await manifest.withLabel('example.com/custom', 'true');
+            await manifest.withAnnotation('example.com/source', 'typescript');
+            await manifest.withField('spec.scaleTargetRef.kind', 'Deployment');
+            await manifest.withField('spec.scaleTargetRef.name', 'kube-service');
+            await manifest.withField('spec.maxReplicaCount', 3);
+        },
+    });
 });
 
 await builder.build().run();


### PR DESCRIPTION
## Description

The Kubernetes ATS SDK dump warned because `KubernetesResource.AdditionalResources` exposed `List<BaseKubernetesResource>`, a C#-oriented customization model that is not an ATS-compatible polyglot contract. This change keeps `AdditionalResources` available as the C# escape hatch, but excludes it from ATS and adds a polyglot-friendly server-side manifest helper instead.

`KubernetesResource.AddManifest(...)` now creates a `KubernetesManifestResource` server-side and returns an opaque handle that can be configured with `WithNamespace`, `WithLabel`, `WithAnnotation`, and scalar `WithField(path, value)` calls. This avoids serializing locally instantiated DTO/object graphs across ATS, where opaque resource references would not preserve handle semantics.

We could also add well-known helper methods for specific Kubernetes resources that we decide are mandatory first-class scenarios, such as selected ConfigMap, Secret, or KEDA-oriented helpers. This PR does not add those yet because exporting every Kubernetes resource or sub-resource would effectively expose the Kubernetes serialization object model as public polyglot API. The generic manifest handle fixes the warning and unblocks custom-resource scenarios while preserving space to add curated, scenario-specific helpers later.

Updated the Kubernetes polyglot apphost samples for TypeScript, Python, Java, and Go, and added publisher coverage for emitting a custom KEDA-style manifest.

Fixes # (issue): N/A

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [x] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [x] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [x] No
  - [ ] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No