### PR TITLE
Validate environment variable names for Foundry hosted agents

### DIFF
--- a/src/Aspire.Hosting.Foundry/HostedAgent/AzureHostedAgentResource.cs
+++ b/src/Aspire.Hosting.Foundry/HostedAgent/AzureHostedAgentResource.cs
@@ -143,7 +143,7 @@ public class AzureHostedAgentResource : Resource, IResourceWithEnvironment
         var projectClient = new AIProjectClient(new Uri(projectEndpoint), new DefaultAzureCredential());
         var result = await projectClient.AgentAdministrationClient.CreateAgentVersionAsync(
             Name,
-            def.ToProjectsAgentVersionCreationOptions(),
+            def.ToProjectsAgentVersionCreationOptions(Target.Name),
             cancellationToken: context.CancellationToken
         ).ConfigureAwait(false);
         return result.Value;

--- a/src/Aspire.Hosting.Foundry/HostedAgent/HostedAgentConfiguration.cs
+++ b/src/Aspire.Hosting.Foundry/HostedAgent/HostedAgentConfiguration.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Globalization;
+using System.Text.RegularExpressions;
 using Azure.AI.Projects.Agents;
 
 namespace Aspire.Hosting.Foundry;
@@ -15,7 +16,7 @@ namespace Aspire.Hosting.Foundry;
 /// ATS-compatible properties are exported; Azure SDK-specific members remain .NET-only.
 /// </remarks>
 [AspireExport(ExposeProperties = true)]
-public class HostedAgentConfiguration(string image)
+public partial class HostedAgentConfiguration(string image)
 {
     /// <summary>
     /// The description of the hosted agent.
@@ -112,8 +113,10 @@ public class HostedAgentConfiguration(string image)
     /// <summary>
     /// Converts this configuration to an <see cref="ProjectsAgentVersionCreationOptions"/> instance.
     /// </summary>
-    public ProjectsAgentVersionCreationOptions ToProjectsAgentVersionCreationOptions()
+    internal ProjectsAgentVersionCreationOptions ToProjectsAgentVersionCreationOptions(string targetResourceName)
     {
+        ValidateEnvironmentVariableNames(EnvironmentVariables.Keys, targetResourceName);
+
         var def = new HostedAgentDefinition(
             ContainerProtocolVersions,
             cpu: CpuString,
@@ -143,4 +146,26 @@ public class HostedAgentConfiguration(string image)
         }
         return options;
     }
+
+    private static void ValidateEnvironmentVariableNames(IEnumerable<string> environmentVariableNames, string? targetResourceName)
+    {
+        var invalidNames = environmentVariableNames
+            .Where(static name => !EnvironmentVariableNameRegex().IsMatch(name))
+            .Order(StringComparer.Ordinal)
+            .ToArray();
+
+        if (invalidNames.Length == 0)
+        {
+            return;
+        }
+
+        throw new DistributedApplicationException(
+            $"Foundry hosted agent for target resource '{targetResourceName}' contains environment variable names that are not supported by Foundry Hosted Agents. " +
+            $"Environment variable names must contain only ASCII letters, digits, or underscores. " +
+            $"Invalid name(s): '{string.Join("', '", invalidNames)}'");
+    }
+
+    // hosted agent environment variables must contain only letters, digits, or underscores.
+    [GeneratedRegex("^[A-Za-z0-9_]+$")]
+    private static partial Regex EnvironmentVariableNameRegex();
 }

--- a/tests/Aspire.Hosting.Azure.Tests/FoundryExtensionsTests.cs
+++ b/tests/Aspire.Hosting.Azure.Tests/FoundryExtensionsTests.cs
@@ -274,11 +274,11 @@ public class FoundryExtensionsTests
         var project = builder.AddFoundry("account")
             .AddProject("my-project");
 
-        var weatherAgent = builder.AddProject<Project>("weather-agent", launchProfileName: null)
+        var weatherAgent = builder.AddProject<Project>("weatheragent", launchProfileName: null)
             .WithEndpoint(targetPort: 9000, scheme: "http", name: "http", isExternal: true)
             .WithComputeEnvironment(env);
 
-        var advisorAgent = builder.AddProject<Project>("advisor-agent", launchProfileName: null)
+        var advisorAgent = builder.AddProject<Project>("advisoragent", launchProfileName: null)
             .WithReference(weatherAgent)
             .WaitFor(weatherAgent)
             .PublishAsHostedAgent(project);
@@ -300,7 +300,7 @@ public class FoundryExtensionsTests
             NullLogger<FoundryExtensionsTests>.Instance,
             cts.Token);
 
-        Assert.Equal("https://weather-agent.example.azurecontainerapps.io", environmentVariables["services__weather-agent__http__0"]);
+        Assert.Equal("https://weatheragent.example.azurecontainerapps.io", environmentVariables["services__weatheragent__http__0"]);
     }
 
     [Fact]
@@ -427,3 +427,4 @@ public class FoundryExtensionsTests
     }
 
 }
+

--- a/tests/Aspire.Hosting.Foundry.Tests/HostedAgentConfigurationTests.cs
+++ b/tests/Aspire.Hosting.Foundry.Tests/HostedAgentConfigurationTests.cs
@@ -67,7 +67,7 @@ public class HostedAgentConfigurationTests
             Cpu = 1.0m,
         };
 
-        var options = config.ToProjectsAgentVersionCreationOptions();
+        var options = config.ToProjectsAgentVersionCreationOptions("target");
 
         Assert.NotNull(options);
         Assert.Equal("Test agent", options.Description);
@@ -81,6 +81,23 @@ public class HostedAgentConfigurationTests
 
         Assert.Single(config.EnvironmentVariables);
         Assert.Equal("VALUE", config.EnvironmentVariables["KEY"]);
+    }
+
+    [Fact]
+    public void ToProjectsAgentVersionCreationOptions_ThrowsForInvalidEnvironmentVariableNames()
+    {
+        var config = new HostedAgentConfiguration("myimage:latest");
+        config.EnvironmentVariables["VALID_NAME_1"] = "value";
+        config.EnvironmentVariables["INVALID-NAME"] = "value";
+        config.EnvironmentVariables["invalid.name"] = "value";
+
+        var ex = Assert.Throws<DistributedApplicationException>(() => config.ToProjectsAgentVersionCreationOptions("target"));
+
+        Assert.Contains("Foundry hosted agent for target resource 'target'", ex.Message);
+        Assert.Contains("Environment variable names must contain only ASCII letters, digits, or underscores.", ex.Message);
+        Assert.Contains("'INVALID-NAME'", ex.Message);
+        Assert.Contains("'invalid.name'", ex.Message);
+        Assert.DoesNotContain("VALID_NAME_1", ex.Message);
     }
 
     [Fact]

--- a/tests/Aspire.Hosting.Foundry.Tests/HostedAgentConfigurationTests.cs
+++ b/tests/Aspire.Hosting.Foundry.Tests/HostedAgentConfigurationTests.cs
@@ -93,11 +93,9 @@ public class HostedAgentConfigurationTests
 
         var ex = Assert.Throws<DistributedApplicationException>(() => config.ToProjectsAgentVersionCreationOptions("target"));
 
-        Assert.Contains("Foundry hosted agent for target resource 'target'", ex.Message);
-        Assert.Contains("Environment variable names must contain only ASCII letters, digits, or underscores.", ex.Message);
-        Assert.Contains("'INVALID-NAME'", ex.Message);
-        Assert.Contains("'invalid.name'", ex.Message);
-        Assert.DoesNotContain("VALID_NAME_1", ex.Message);
+        Assert.Equal(
+            "Foundry hosted agent for target resource 'target' contains environment variable names that are not supported by Foundry Hosted Agents. Environment variable names must contain only ASCII letters, digits, or underscores. Invalid name(s): 'INVALID-NAME', 'invalid.name'",
+            ex.Message);
     }
 
     [Fact]


### PR DESCRIPTION
## Description

Foundry Hosted Agents only accept environment variable names containing ASCII letters, digits, and underscores. Other characters (dashes, dots, etc.) are silently rejected at deploy time, producing a confusing failure. This change validates names up-front.

## Changes

- `HostedAgentConfiguration.ToProjectsAgentVersionCreationOptions` now takes the target resource name and validates each environment variable name against a source-generated regex (`^[A-Za-z0-9_]+$`).
- Invalid names cause a `DistributedApplicationException` listing the offending names and the target resource.
- Method visibility tightened to `internal` (only the resource-side deploy path needs it).
- Renamed the target resources in `PublishAsHostedAgent_ResolvesExternalContainerAppReference` to non-dashed names so the existing happy-path test continues to pass.
- Added a unit test covering the new validation.

## Fixes

Fixes #16858

## Checklist

- [x] Tests added/updated and passing locally (`Aspire.Hosting.Foundry.Tests` 84/84, `FoundryExtensionsTests` 19/19)
- [x] Build clean