### PR TITLE
Use specific role assignment export names

### DIFF
--- a/src/Aspire.Hosting.Azure.AppConfiguration/AzureAppConfigurationExtensions.cs
+++ b/src/Aspire.Hosting.Azure.AppConfiguration/AzureAppConfigurationExtensions.cs
@@ -208,7 +208,7 @@ public static class AzureAppConfigurationExtensions
     /// <param name="roles">The App Configuration roles to be assigned.</param>
     /// <returns>The updated <see cref="IResourceBuilder{T}"/> with the applied role assignments.</returns>
     /// <exception cref="ArgumentException">Thrown when a role value is not a valid <see cref="AzureAppConfigurationRole"/> value.</exception>
-    [AspireExport("withAppConfigurationRoleAssignments", MethodName = "withRoleAssignments", Description = "Assigns App Configuration roles to a resource")]
+    [AspireExport("withAppConfigurationRoleAssignments", Description = "Assigns App Configuration roles to a resource")]
     internal static IResourceBuilder<T> WithRoleAssignments<T>(
         this IResourceBuilder<T> builder,
         IResourceBuilder<AzureAppConfigurationResource> target,

--- a/src/Aspire.Hosting.Azure.CognitiveServices/AzureOpenAIExtensions.cs
+++ b/src/Aspire.Hosting.Azure.CognitiveServices/AzureOpenAIExtensions.cs
@@ -255,7 +255,7 @@ public static class AzureOpenAIExtensions
     /// <param name="roles">The Azure OpenAI roles to be assigned (for example, <see cref="AzureOpenAIRole.CognitiveServicesOpenAIUser"/>).</param>
     /// <returns>The updated <see cref="IResourceBuilder{T}"/> with the applied role assignments.</returns>
     /// <exception cref="ArgumentException">Thrown when a role value is not a valid <see cref="AzureOpenAIRole"/> value.</exception>
-    [AspireExport("withCognitiveServicesRoleAssignments", MethodName = "withRoleAssignments", Description = "Assigns Cognitive Services roles to a resource")]
+    [AspireExport("withCognitiveServicesRoleAssignments", Description = "Assigns Cognitive Services roles to a resource")]
     internal static IResourceBuilder<T> WithRoleAssignments<T>(
         this IResourceBuilder<T> builder,
         IResourceBuilder<AzureOpenAIResource> target,

--- a/src/Aspire.Hosting.Azure.ContainerRegistry/AzureContainerRegistryExtensions.cs
+++ b/src/Aspire.Hosting.Azure.ContainerRegistry/AzureContainerRegistryExtensions.cs
@@ -265,7 +265,7 @@ public static class AzureContainerRegistryExtensions
     /// <param name="roles">The Azure Container Registry roles to assign to the resource.</param>
     /// <returns>A reference to the <see cref="IResourceBuilder{T}"/>.</returns>
     /// <exception cref="ArgumentException">Thrown when a role value is not a valid <see cref="AzureContainerRegistryRole"/> value.</exception>
-    [AspireExport("withContainerRegistryRoleAssignments", MethodName = "withRoleAssignments", Description = "Assigns Azure Container Registry roles to a resource.")]
+    [AspireExport("withContainerRegistryRoleAssignments", Description = "Assigns Azure Container Registry roles to a resource.")]
     internal static IResourceBuilder<T> WithRoleAssignments<T>(
         this IResourceBuilder<T> builder,
         IResourceBuilder<AzureContainerRegistryResource> target,

--- a/src/Aspire.Hosting.Azure.EventHubs/AzureEventHubsExtensions.cs
+++ b/src/Aspire.Hosting.Azure.EventHubs/AzureEventHubsExtensions.cs
@@ -530,7 +530,7 @@ public static class AzureEventHubsExtensions
     /// <param name="roles">The Event Hubs roles to be assigned.</param>
     /// <returns>The updated <see cref="IResourceBuilder{T}"/> with the applied role assignments.</returns>
     /// <exception cref="ArgumentException">Thrown when a role value is not a valid <see cref="AzureEventHubsRole"/> value.</exception>
-    [AspireExport("withEventHubsRoleAssignments", MethodName = "withRoleAssignments", Description = "Assigns Event Hubs roles to a resource")]
+    [AspireExport("withEventHubsRoleAssignments", Description = "Assigns Event Hubs roles to a resource")]
     internal static IResourceBuilder<T> WithRoleAssignments<T>(
         this IResourceBuilder<T> builder,
         IResourceBuilder<AzureEventHubsResource> target,

--- a/src/Aspire.Hosting.Azure.KeyVault/AzureKeyVaultResourceExtensions.cs
+++ b/src/Aspire.Hosting.Azure.KeyVault/AzureKeyVaultResourceExtensions.cs
@@ -186,7 +186,7 @@ public static partial class AzureKeyVaultResourceExtensions
     /// <param name="roles">The Key Vault roles to be assigned.</param>
     /// <returns>The updated <see cref="IResourceBuilder{T}"/> with the applied role assignments.</returns>
     /// <exception cref="ArgumentException">Thrown when a role value is not a valid <see cref="AzureKeyVaultRole"/> value.</exception>
-    [AspireExport("withKeyVaultRoleAssignments", MethodName = "withRoleAssignments", Description = "Assigns Key Vault roles to a resource")]
+    [AspireExport("withKeyVaultRoleAssignments", Description = "Assigns Key Vault roles to a resource")]
     internal static IResourceBuilder<T> WithRoleAssignments<T>(
         this IResourceBuilder<T> builder,
         IResourceBuilder<AzureKeyVaultResource> target,

--- a/src/Aspire.Hosting.Azure.Search/AzureSearchExtensions.cs
+++ b/src/Aspire.Hosting.Azure.Search/AzureSearchExtensions.cs
@@ -146,7 +146,7 @@ public static class AzureSearchExtensions
     /// <param name="roles">The Azure AI Search roles to be assigned.</param>
     /// <returns>The updated <see cref="IResourceBuilder{T}"/> with the applied role assignments.</returns>
     /// <exception cref="ArgumentException">Thrown when a role value is not a valid <see cref="AzureSearchRole"/> value.</exception>
-    [AspireExport("withSearchRoleAssignments", MethodName = "withRoleAssignments", Description = "Assigns Azure AI Search roles to a resource")]
+    [AspireExport("withSearchRoleAssignments", Description = "Assigns Azure AI Search roles to a resource")]
     internal static IResourceBuilder<T> WithRoleAssignments<T>(
         this IResourceBuilder<T> builder,
         IResourceBuilder<AzureSearchResource> target,

--- a/src/Aspire.Hosting.Azure.ServiceBus/AzureServiceBusExtensions.cs
+++ b/src/Aspire.Hosting.Azure.ServiceBus/AzureServiceBusExtensions.cs
@@ -683,7 +683,7 @@ public static class AzureServiceBusExtensions
     /// <param name="roles">The Service Bus roles to be assigned.</param>
     /// <returns>The updated <see cref="IResourceBuilder{T}"/> with the applied role assignments.</returns>
     /// <exception cref="ArgumentException">Thrown when a role value is not a valid <see cref="AzureServiceBusRole"/> value.</exception>
-    [AspireExport("withServiceBusRoleAssignments", MethodName = "withRoleAssignments", Description = "Assigns Service Bus roles to a resource")]
+    [AspireExport("withServiceBusRoleAssignments", Description = "Assigns Service Bus roles to a resource")]
     internal static IResourceBuilder<T> WithRoleAssignments<T>(
         this IResourceBuilder<T> builder,
         IResourceBuilder<AzureServiceBusResource> target,

--- a/src/Aspire.Hosting.Azure.SignalR/AzureSignalRExtensions.cs
+++ b/src/Aspire.Hosting.Azure.SignalR/AzureSignalRExtensions.cs
@@ -211,7 +211,7 @@ public static class AzureSignalRExtensions
     /// <param name="roles">The Azure SignalR roles to be assigned (for example, <see cref="AzureSignalRRole.SignalRContributor"/>).</param>
     /// <returns>The updated <see cref="IResourceBuilder{T}"/> with the applied role assignments.</returns>
     /// <exception cref="ArgumentException">Thrown when a role value is not a valid <see cref="AzureSignalRRole"/> value.</exception>
-    [AspireExport("withSignalRRoleAssignments", MethodName = "withRoleAssignments", Description = "Assigns Azure SignalR roles to a resource")]
+    [AspireExport("withSignalRRoleAssignments", Description = "Assigns Azure SignalR roles to a resource")]
     internal static IResourceBuilder<T> WithRoleAssignments<T>(
         this IResourceBuilder<T> builder,
         IResourceBuilder<AzureSignalRResource> target,

--- a/src/Aspire.Hosting.Azure.Storage/AzureStorageExtensions.cs
+++ b/src/Aspire.Hosting.Azure.Storage/AzureStorageExtensions.cs
@@ -710,7 +710,7 @@ public static class AzureStorageExtensions
     /// <param name="roles">The storage roles to be assigned.</param>
     /// <returns>The updated <see cref="IResourceBuilder{T}"/> with the applied role assignments.</returns>
     /// <exception cref="ArgumentException">Thrown when a role value is not a valid <see cref="AzureStorageRole"/> value.</exception>
-    [AspireExport("withStorageRoleAssignments", MethodName = "withRoleAssignments", Description = "Assigns Azure Storage roles to a resource")]
+    [AspireExport("withStorageRoleAssignments", Description = "Assigns Azure Storage roles to a resource")]
     internal static IResourceBuilder<T> WithRoleAssignments<T>(
         this IResourceBuilder<T> builder,
         IResourceBuilder<AzureStorageResource> target,

--- a/src/Aspire.Hosting.Azure.WebPubSub/AzureWebPubSubExtensions.cs
+++ b/src/Aspire.Hosting.Azure.WebPubSub/AzureWebPubSubExtensions.cs
@@ -329,7 +329,7 @@ public static class AzureWebPubSubExtensions
     /// <param name="roles">The Web PubSub roles to be assigned.</param>
     /// <returns>The updated <see cref="IResourceBuilder{T}"/> with the applied role assignments.</returns>
     /// <exception cref="ArgumentException">Thrown when a role value is not a valid <see cref="AzureWebPubSubRole"/> value.</exception>
-    [AspireExport("withWebPubSubRoleAssignments", MethodName = "withRoleAssignments", Description = "Assigns Azure Web PubSub roles to a resource")]
+    [AspireExport("withWebPubSubRoleAssignments", Description = "Assigns Azure Web PubSub roles to a resource")]
     internal static IResourceBuilder<T> WithRoleAssignments<T>(
         this IResourceBuilder<T> builder,
         IResourceBuilder<AzureWebPubSubResource> target,

--- a/src/Aspire.Hosting.Foundry/FoundryExtensions.cs
+++ b/src/Aspire.Hosting.Foundry/FoundryExtensions.cs
@@ -246,7 +246,7 @@ public static class FoundryExtensions
     /// <param name="roles">The Microsoft Foundry roles to be assigned (for example, <see cref="FoundryRole.CognitiveServicesOpenAIUser"/>).</param>
     /// <returns>The updated <see cref="IResourceBuilder{T}"/> with the applied role assignments.</returns>
     /// <exception cref="ArgumentException">Thrown when a role value is not a valid <see cref="FoundryRole"/> value.</exception>
-    [AspireExport("withFoundryRoleAssignments", MethodName = "withRoleAssignments", Description = "Assigns Microsoft Foundry roles to a resource")]
+    [AspireExport("withFoundryRoleAssignments", Description = "Assigns Microsoft Foundry roles to a resource")]
     internal static IResourceBuilder<T> WithRoleAssignments<T>(
         this IResourceBuilder<T> builder,
         IResourceBuilder<FoundryResource> target,

--- a/tests/PolyglotAppHosts/Aspire.Hosting.Azure.AppConfiguration/Go/apphost.go
+++ b/tests/PolyglotAppHosts/Aspire.Hosting.Azure.AppConfiguration/Go/apphost.go
@@ -17,7 +17,7 @@ func main() {
 		log.Fatalf(aspire.FormatError(err))
 	}
 
-	appConfig.WithRoleAssignments(appConfig, []aspire.AzureAppConfigurationRole{
+	appConfig.WithAppConfigurationRoleAssignments(appConfig, []aspire.AzureAppConfigurationRole{
 		aspire.AzureAppConfigurationRoleAppConfigurationDataOwner,
 		aspire.AzureAppConfigurationRoleAppConfigurationDataReader,
 	})

--- a/tests/PolyglotAppHosts/Aspire.Hosting.Azure.AppConfiguration/Java/AppHost.java
+++ b/tests/PolyglotAppHosts/Aspire.Hosting.Azure.AppConfiguration/Java/AppHost.java
@@ -3,7 +3,7 @@ import aspire.*;
 void main() throws Exception {
         var builder = DistributedApplication.CreateBuilder();
         var appConfig = builder.addAzureAppConfiguration("appconfig");
-        appConfig.withRoleAssignments(appConfig, new AzureAppConfigurationRole[] { AzureAppConfigurationRole.APP_CONFIGURATION_DATA_OWNER, AzureAppConfigurationRole.APP_CONFIGURATION_DATA_READER });
+        appConfig.withAppConfigurationRoleAssignments(appConfig, new AzureAppConfigurationRole[] { AzureAppConfigurationRole.APP_CONFIGURATION_DATA_OWNER, AzureAppConfigurationRole.APP_CONFIGURATION_DATA_READER });
         appConfig.runAsEmulator((emulator) -> {
                 emulator.withDataBindMount(".aace/appconfig");
                 emulator.withDataVolume("appconfig-data");

--- a/tests/PolyglotAppHosts/Aspire.Hosting.Azure.AppConfiguration/TypeScript/apphost.ts
+++ b/tests/PolyglotAppHosts/Aspire.Hosting.Azure.AppConfiguration/TypeScript/apphost.ts
@@ -3,7 +3,7 @@ import { AzureAppConfigurationRole, createBuilder } from './.modules/aspire.js';
 const builder = await createBuilder();
 
 const appConfig = await builder.addAzureAppConfiguration("appconfig");
-await appConfig.withRoleAssignments(appConfig, [AzureAppConfigurationRole.AppConfigurationDataOwner, AzureAppConfigurationRole.AppConfigurationDataReader]);
+await appConfig.withAppConfigurationRoleAssignments(appConfig, [AzureAppConfigurationRole.AppConfigurationDataOwner, AzureAppConfigurationRole.AppConfigurationDataReader]);
 await appConfig.runAsEmulator({
     configureEmulator: async (emulator) => {
         await emulator.withDataBindMount({ path: ".aace/appconfig" });

--- a/tests/PolyglotAppHosts/Aspire.Hosting.Azure.CognitiveServices/Go/apphost.go
+++ b/tests/PolyglotAppHosts/Aspire.Hosting.Azure.CognitiveServices/Go/apphost.go
@@ -23,7 +23,7 @@ func main() {
 	}
 
 	api := builder.AddContainer("api", "redis:latest").
-		WithRoleAssignments(openai, []aspire.AzureOpenAIRole{aspire.AzureOpenAIRoleCognitiveServicesOpenAIUser})
+		WithCognitiveServicesRoleAssignments(openai, []aspire.AzureOpenAIRole{aspire.AzureOpenAIRoleCognitiveServicesOpenAIUser})
 	if api.Err() != nil {
 		log.Fatalf(aspire.FormatError(api.Err()))
 	}

--- a/tests/PolyglotAppHosts/Aspire.Hosting.Azure.CognitiveServices/Java/AppHost.java
+++ b/tests/PolyglotAppHosts/Aspire.Hosting.Azure.CognitiveServices/Java/AppHost.java
@@ -7,6 +7,6 @@ void main() throws Exception {
         var openai = builder.addAzureOpenAI("openai");
         openai.addDeployment("chat", "gpt-4o-mini", "2024-07-18");
         var api = builder.addContainer("api", "redis:latest");
-        api.withRoleAssignments(openai, new AzureOpenAIRole[] { AzureOpenAIRole.COGNITIVE_SERVICES_OPEN_AIUSER });
+        api.withCognitiveServicesRoleAssignments(openai, new AzureOpenAIRole[] { AzureOpenAIRole.COGNITIVE_SERVICES_OPEN_AIUSER });
         builder.build().run();
     }

--- a/tests/PolyglotAppHosts/Aspire.Hosting.Azure.CognitiveServices/TypeScript/apphost.ts
+++ b/tests/PolyglotAppHosts/Aspire.Hosting.Azure.CognitiveServices/TypeScript/apphost.ts
@@ -9,7 +9,7 @@ const openai = await builder.addAzureOpenAI('openai');
 const chat = await openai.addDeployment('chat', 'gpt-4o-mini', '2024-07-18');
 
 const api = await builder.addContainer('api', 'redis:latest');
-await api.withRoleAssignments(openai, [AzureOpenAIRole.CognitiveServicesOpenAIUser]);
+await api.withCognitiveServicesRoleAssignments(openai, [AzureOpenAIRole.CognitiveServicesOpenAIUser]);
 
 const _deploymentParent = await chat.parent();
 const _deploymentConnectionString = await chat.connectionStringExpression();

--- a/tests/PolyglotAppHosts/Aspire.Hosting.Azure.ContainerRegistry/Go/apphost.go
+++ b/tests/PolyglotAppHosts/Aspire.Hosting.Azure.ContainerRegistry/Go/apphost.go
@@ -25,7 +25,7 @@ func main() {
 
 	environment := builder.AddAzureContainerAppEnvironment("environment")
 	environment.WithAzureContainerRegistry(registry)
-	environment.WithRoleAssignments(registry, []aspire.AzureContainerRegistryRole{
+	environment.WithContainerRegistryRoleAssignments(registry, []aspire.AzureContainerRegistryRole{
 		aspire.AzureContainerRegistryRoleAcrPull,
 		aspire.AzureContainerRegistryRoleAcrPush,
 	})

--- a/tests/PolyglotAppHosts/Aspire.Hosting.Azure.ContainerRegistry/Java/AppHost.java
+++ b/tests/PolyglotAppHosts/Aspire.Hosting.Azure.ContainerRegistry/Java/AppHost.java
@@ -6,7 +6,7 @@ void main() throws Exception {
             .withPurgeTask("0 1 * * *", new WithPurgeTaskOptions().filter("samples:*").ago(7.0).keep(5.0).taskName("purge-samples"));
         var environment = builder.addAzureContainerAppEnvironment("environment");
         environment.withAzureContainerRegistry(registry);
-        environment.withRoleAssignments(registry, new AzureContainerRegistryRole[] { AzureContainerRegistryRole.ACR_PULL, AzureContainerRegistryRole.ACR_PUSH });
+        environment.withContainerRegistryRoleAssignments(registry, new AzureContainerRegistryRole[] { AzureContainerRegistryRole.ACR_PULL, AzureContainerRegistryRole.ACR_PUSH });
         var registryFromEnvironment = environment.getAzureContainerRegistry();
         registryFromEnvironment.withPurgeTask("0 2 * * *", new WithPurgeTaskOptions().filter("environment:*").ago(14.0).keep(2.0));
         builder.build().run();

--- a/tests/PolyglotAppHosts/Aspire.Hosting.Azure.ContainerRegistry/TypeScript/apphost.ts
+++ b/tests/PolyglotAppHosts/Aspire.Hosting.Azure.ContainerRegistry/TypeScript/apphost.ts
@@ -12,7 +12,7 @@ const registry = await builder.addAzureContainerRegistry("containerregistry")
 
 const environment = await builder.addAzureContainerAppEnvironment("environment");
 await environment.withAzureContainerRegistry(registry);
-await environment.withRoleAssignments(registry, [
+await environment.withContainerRegistryRoleAssignments(registry, [
     AzureContainerRegistryRole.AcrPull,
     AzureContainerRegistryRole.AcrPush
 ]);

--- a/tests/PolyglotAppHosts/Aspire.Hosting.Azure.EventHubs/Go/apphost.go
+++ b/tests/PolyglotAppHosts/Aspire.Hosting.Azure.EventHubs/Go/apphost.go
@@ -17,7 +17,7 @@ func main() {
 		log.Fatalf(aspire.FormatError(eventHubs.Err()))
 	}
 
-	eventHubs.WithRoleAssignments(eventHubs, []aspire.AzureEventHubsRole{
+	eventHubs.WithEventHubsRoleAssignments(eventHubs, []aspire.AzureEventHubsRole{
 		aspire.AzureEventHubsRoleAzureEventHubsDataOwner,
 	})
 
@@ -38,7 +38,7 @@ func main() {
 
 	consumerGroup := hub.AddConsumerGroup("processors", &aspire.AddConsumerGroupOptions{
 		GroupName: aspire.StringPtr("processor-group"),
-	}).WithRoleAssignments(eventHubs, []aspire.AzureEventHubsRole{
+	}).WithEventHubsRoleAssignments(eventHubs, []aspire.AzureEventHubsRole{
 		aspire.AzureEventHubsRoleAzureEventHubsDataReceiver,
 	})
 	if consumerGroup.Err() != nil {
@@ -50,7 +50,7 @@ func main() {
 			emulator.
 				WithHostPort(5673).
 				WithConfigurationFile("./eventhubs.config.json").
-				WithRoleAssignments(eventHubs, []aspire.AzureEventHubsRole{
+				WithEventHubsRoleAssignments(eventHubs, []aspire.AzureEventHubsRole{
 					aspire.AzureEventHubsRoleAzureEventHubsDataSender,
 				})
 		},

--- a/tests/PolyglotAppHosts/Aspire.Hosting.Azure.EventHubs/Java/AppHost.java
+++ b/tests/PolyglotAppHosts/Aspire.Hosting.Azure.EventHubs/Java/AppHost.java
@@ -3,7 +3,7 @@ import aspire.*;
 void main() throws Exception {
         var builder = DistributedApplication.CreateBuilder();
         var eventHubs = builder.addAzureEventHubs("eventhubs");
-        eventHubs.withRoleAssignments(eventHubs, new AzureEventHubsRole[] { AzureEventHubsRole.AZURE_EVENT_HUBS_DATA_OWNER });
+        eventHubs.withEventHubsRoleAssignments(eventHubs, new AzureEventHubsRole[] { AzureEventHubsRole.AZURE_EVENT_HUBS_DATA_OWNER });
         var hub = eventHubs.addHub("orders", "orders-hub");
         hub.withProperties((configuredHub) -> {
             configuredHub.setHubName("orders-hub");
@@ -12,12 +12,12 @@ void main() throws Exception {
             var _partitionCount = configuredHub.partitionCount();
         });
         var consumerGroup = hub.addConsumerGroup("processors", "processor-group");
-        consumerGroup.withRoleAssignments(eventHubs, new AzureEventHubsRole[] { AzureEventHubsRole.AZURE_EVENT_HUBS_DATA_RECEIVER });
+        consumerGroup.withEventHubsRoleAssignments(eventHubs, new AzureEventHubsRole[] { AzureEventHubsRole.AZURE_EVENT_HUBS_DATA_RECEIVER });
         eventHubs.runAsEmulator((emulator) -> {
                 emulator
                     .withHostPort(5673.0)
                     .withConfigurationFile("./eventhubs.config.json")
-                    .withRoleAssignments(eventHubs, new AzureEventHubsRole[] { AzureEventHubsRole.AZURE_EVENT_HUBS_DATA_SENDER });
+                    .withEventHubsRoleAssignments(eventHubs, new AzureEventHubsRole[] { AzureEventHubsRole.AZURE_EVENT_HUBS_DATA_SENDER });
             });
         builder.build().run();
     }

--- a/tests/PolyglotAppHosts/Aspire.Hosting.Azure.EventHubs/TypeScript/apphost.ts
+++ b/tests/PolyglotAppHosts/Aspire.Hosting.Azure.EventHubs/TypeScript/apphost.ts
@@ -3,7 +3,7 @@ import { AzureEventHubsRole, createBuilder } from './.modules/aspire.js';
 const builder = await createBuilder();
 const eventHubs = await builder.addAzureEventHubs('eventhubs');
 
-await eventHubs.withRoleAssignments(eventHubs, [AzureEventHubsRole.AzureEventHubsDataOwner]);
+await eventHubs.withEventHubsRoleAssignments(eventHubs, [AzureEventHubsRole.AzureEventHubsDataOwner]);
 
 const hub = await eventHubs.addHub('orders', { hubName: 'orders-hub' });
 await hub.withProperties(async (configuredHub) => {
@@ -18,14 +18,14 @@ const _hubParent = await hub.parent();
 const _hubConnectionString = await hub.connectionStringExpression();
 
 const consumerGroup = await hub.addConsumerGroup('processors', { groupName: 'processor-group' });
-await consumerGroup.withRoleAssignments(eventHubs, [AzureEventHubsRole.AzureEventHubsDataReceiver]);
+await consumerGroup.withEventHubsRoleAssignments(eventHubs, [AzureEventHubsRole.AzureEventHubsDataReceiver]);
 
 await eventHubs.runAsEmulator({
     configureContainer: async (emulator) => {
         await emulator
             .withHostPort({ port: 5673 })
             .withConfigurationFile('./eventhubs.config.json')
-            .withRoleAssignments(eventHubs, [AzureEventHubsRole.AzureEventHubsDataSender]);
+            .withEventHubsRoleAssignments(eventHubs, [AzureEventHubsRole.AzureEventHubsDataSender]);
     }
 });
 

--- a/tests/PolyglotAppHosts/Aspire.Hosting.Azure.KeyVault/Go/apphost.go
+++ b/tests/PolyglotAppHosts/Aspire.Hosting.Azure.KeyVault/Go/apphost.go
@@ -25,8 +25,8 @@ func main() {
 	exprSecretValue := aspire.RefExpr("secret-value-%v", secretParam)
 	namedExprSecretValue := aspire.RefExpr("named-secret-value-%v", namedSecretParam)
 
-	// ── 2. WithRoleAssignments ────────────────────────────────────────────────
-	vault.WithRoleAssignments(vault, []aspire.AzureKeyVaultRole{
+	// ── 2. WithKeyVaultRoleAssignments ────────────────────────────────────────
+	vault.WithKeyVaultRoleAssignments(vault, []aspire.AzureKeyVaultRole{
 		aspire.AzureKeyVaultRoleKeyVaultReader,
 		aspire.AzureKeyVaultRoleKeyVaultSecretsUser,
 	})
@@ -49,13 +49,13 @@ func main() {
 	_ = vault.GetSecret("param-secret")
 
 	// Apply role assignments to created secret resources to validate generic coverage.
-	secretFromParameter.WithRoleAssignments(vault,
+	secretFromParameter.WithKeyVaultRoleAssignments(vault,
 		[]aspire.AzureKeyVaultRole{aspire.AzureKeyVaultRoleKeyVaultSecretsUser})
-	secretFromExpression.WithRoleAssignments(vault,
+	secretFromExpression.WithKeyVaultRoleAssignments(vault,
 		[]aspire.AzureKeyVaultRole{aspire.AzureKeyVaultRoleKeyVaultReader})
-	namedSecretFromParameter.WithRoleAssignments(vault,
+	namedSecretFromParameter.WithKeyVaultRoleAssignments(vault,
 		[]aspire.AzureKeyVaultRole{aspire.AzureKeyVaultRoleKeyVaultSecretsOfficer})
-	namedSecretFromExpression.WithRoleAssignments(vault,
+	namedSecretFromExpression.WithKeyVaultRoleAssignments(vault,
 		[]aspire.AzureKeyVaultRole{aspire.AzureKeyVaultRoleKeyVaultReader})
 
 	app, err := builder.Build()

--- a/tests/PolyglotAppHosts/Aspire.Hosting.Azure.KeyVault/Java/AppHost.java
+++ b/tests/PolyglotAppHosts/Aspire.Hosting.Azure.KeyVault/Java/AppHost.java
@@ -12,8 +12,8 @@ void main() throws Exception {
         // Reference expressions for expression-based APIs
         var exprSecretValue = ReferenceExpression.refExpr("secret-value-%s", secretParam);
         var namedExprSecretValue = ReferenceExpression.refExpr("named-secret-value-%s", namedSecretParam);
-        // ── 2. withRoleAssignments ───────────────────────────────────────────────────
-        vault.withRoleAssignments(vault, new AzureKeyVaultRole[] { AzureKeyVaultRole.KEY_VAULT_READER, AzureKeyVaultRole.KEY_VAULT_SECRETS_USER });
+        // ── 2. withKeyVaultRoleAssignments ───────────────────────────────────────────
+        vault.withKeyVaultRoleAssignments(vault, new AzureKeyVaultRole[] { AzureKeyVaultRole.KEY_VAULT_READER, AzureKeyVaultRole.KEY_VAULT_SECRETS_USER });
         // ── 3. addSecret ─────────────────────────────────────────────────────────────
         var secretFromParameter = vault.addSecret("param-secret", secretParam, null);
         // ── 4. addSecretFromExpression ───────────────────────────────────────────────
@@ -25,9 +25,9 @@ void main() throws Exception {
         // ── 7. getSecret ─────────────────────────────────────────────────────────────
         var _existingSecretRef = vault.getSecret("param-secret");
         // Apply role assignments to created secret resources to validate generic coverage.
-        secretFromParameter.withRoleAssignments(vault, new AzureKeyVaultRole[] { AzureKeyVaultRole.KEY_VAULT_SECRETS_USER });
-        secretFromExpression.withRoleAssignments(vault, new AzureKeyVaultRole[] { AzureKeyVaultRole.KEY_VAULT_READER });
-        namedSecretFromParameter.withRoleAssignments(vault, new AzureKeyVaultRole[] { AzureKeyVaultRole.KEY_VAULT_SECRETS_OFFICER });
-        namedSecretFromExpression.withRoleAssignments(vault, new AzureKeyVaultRole[] { AzureKeyVaultRole.KEY_VAULT_READER });
+        secretFromParameter.withKeyVaultRoleAssignments(vault, new AzureKeyVaultRole[] { AzureKeyVaultRole.KEY_VAULT_SECRETS_USER });
+        secretFromExpression.withKeyVaultRoleAssignments(vault, new AzureKeyVaultRole[] { AzureKeyVaultRole.KEY_VAULT_READER });
+        namedSecretFromParameter.withKeyVaultRoleAssignments(vault, new AzureKeyVaultRole[] { AzureKeyVaultRole.KEY_VAULT_SECRETS_OFFICER });
+        namedSecretFromExpression.withKeyVaultRoleAssignments(vault, new AzureKeyVaultRole[] { AzureKeyVaultRole.KEY_VAULT_READER });
         builder.build().run();
     }

--- a/tests/PolyglotAppHosts/Aspire.Hosting.Azure.KeyVault/Python/apphost.py
+++ b/tests/PolyglotAppHosts/Aspire.Hosting.Azure.KeyVault/Python/apphost.py
@@ -13,7 +13,7 @@ with create_builder() as builder:
     # Reference expressions for expression-based APIs
     expr_secret_value = "expression"
     named_expr_secret_value = "expression"
-    # ── 2. withRoleAssignments ───────────────────────────────────────────────────
+    # ── 2. with_key_vault_role_assignments ───────────────────────────────────────
     vault.with_key_vault_role_assignments()
     # ── 3. addSecret ─────────────────────────────────────────────────────────────
     secret_from_parameter = vault.add_secret("resource")

--- a/tests/PolyglotAppHosts/Aspire.Hosting.Azure.KeyVault/TypeScript/apphost.ts
+++ b/tests/PolyglotAppHosts/Aspire.Hosting.Azure.KeyVault/TypeScript/apphost.ts
@@ -15,8 +15,8 @@ const namedSecretParam = await builder.addParameter("named-secret-param", { secr
 const exprSecretValue = refExpr`secret-value-${secretParam}`;
 const namedExprSecretValue = refExpr`named-secret-value-${namedSecretParam}`;
 
-// ── 2. withRoleAssignments ───────────────────────────────────────────────────
-await vault.withRoleAssignments(vault, [
+// ── 2. withKeyVaultRoleAssignments ───────────────────────────────────────────
+await vault.withKeyVaultRoleAssignments(vault, [
     AzureKeyVaultRole.KeyVaultReader,
     AzureKeyVaultRole.KeyVaultSecretsUser,
 ]);
@@ -37,9 +37,9 @@ const namedSecretFromExpression = await vault.addSecret("secret-resource-expr", 
 const _existingSecretRef = await vault.getSecret("param-secret");
 
 // Apply role assignments to created secret resources to validate generic coverage.
-await secretFromParameter.withRoleAssignments(vault, [AzureKeyVaultRole.KeyVaultSecretsUser]);
-await secretFromExpression.withRoleAssignments(vault, [AzureKeyVaultRole.KeyVaultReader]);
-await namedSecretFromParameter.withRoleAssignments(vault, [AzureKeyVaultRole.KeyVaultSecretsOfficer]);
-await namedSecretFromExpression.withRoleAssignments(vault, [AzureKeyVaultRole.KeyVaultReader]);
+await secretFromParameter.withKeyVaultRoleAssignments(vault, [AzureKeyVaultRole.KeyVaultSecretsUser]);
+await secretFromExpression.withKeyVaultRoleAssignments(vault, [AzureKeyVaultRole.KeyVaultReader]);
+await namedSecretFromParameter.withKeyVaultRoleAssignments(vault, [AzureKeyVaultRole.KeyVaultSecretsOfficer]);
+await namedSecretFromExpression.withKeyVaultRoleAssignments(vault, [AzureKeyVaultRole.KeyVaultReader]);
 
 await builder.build().run();

--- a/tests/PolyglotAppHosts/Aspire.Hosting.Azure.Search/Go/apphost.go
+++ b/tests/PolyglotAppHosts/Aspire.Hosting.Azure.Search/Go/apphost.go
@@ -13,7 +13,7 @@ func main() {
 	}
 
 	search := builder.AddAzureSearch("resource")
-	search.WithRoleAssignments(search, []aspire.AzureSearchRole{
+	search.WithSearchRoleAssignments(search, []aspire.AzureSearchRole{
 		aspire.AzureSearchRoleSearchServiceContributor,
 		aspire.AzureSearchRoleSearchIndexDataReader})
 	if search.Err() != nil {

--- a/tests/PolyglotAppHosts/Aspire.Hosting.Azure.Search/Java/AppHost.java
+++ b/tests/PolyglotAppHosts/Aspire.Hosting.Azure.Search/Java/AppHost.java
@@ -3,6 +3,6 @@ import aspire.*;
 void main() throws Exception {
         var builder = DistributedApplication.CreateBuilder();
         var search = builder.addAzureSearch("search");
-        search.withRoleAssignments(search, new AzureSearchRole[] { AzureSearchRole.SEARCH_SERVICE_CONTRIBUTOR, AzureSearchRole.SEARCH_INDEX_DATA_READER });
+        search.withSearchRoleAssignments(search, new AzureSearchRole[] { AzureSearchRole.SEARCH_SERVICE_CONTRIBUTOR, AzureSearchRole.SEARCH_INDEX_DATA_READER });
         builder.build().run();
     }

--- a/tests/PolyglotAppHosts/Aspire.Hosting.Azure.Search/TypeScript/apphost.ts
+++ b/tests/PolyglotAppHosts/Aspire.Hosting.Azure.Search/TypeScript/apphost.ts
@@ -3,7 +3,7 @@ import { AzureSearchRole, createBuilder } from './.modules/aspire.js';
 const builder = await createBuilder();
 const search = await builder.addAzureSearch('search');
 
-await search.withRoleAssignments(search, [
+await search.withSearchRoleAssignments(search, [
     AzureSearchRole.SearchServiceContributor,
     AzureSearchRole.SearchIndexDataReader
 ]);

--- a/tests/PolyglotAppHosts/Aspire.Hosting.Azure.ServiceBus/Go/apphost.go
+++ b/tests/PolyglotAppHosts/Aspire.Hosting.Azure.ServiceBus/Go/apphost.go
@@ -132,22 +132,22 @@ func main() {
 	_ = aspire.AzureServiceBusFilterTypeSqlFilter
 	_ = aspire.AzureServiceBusFilterTypeCorrelationFilter
 
-	// ── 7. WithRoleAssignments — enum-based role assignment shim ───────────────
+	// ── 7. WithServiceBusRoleAssignments — enum-based role assignment shim ────
 	// On the parent ServiceBus resource (all 3 roles)
-	serviceBus.WithRoleAssignments(serviceBus, []aspire.AzureServiceBusRole{
+	serviceBus.WithServiceBusRoleAssignments(serviceBus, []aspire.AzureServiceBusRole{
 		aspire.AzureServiceBusRoleAzureServiceBusDataOwner,
 		aspire.AzureServiceBusRoleAzureServiceBusDataSender,
 		aspire.AzureServiceBusRoleAzureServiceBusDataReceiver,
 	})
 
 	// On child resources
-	queue.WithRoleAssignments(serviceBus, []aspire.AzureServiceBusRole{
+	queue.WithServiceBusRoleAssignments(serviceBus, []aspire.AzureServiceBusRole{
 		aspire.AzureServiceBusRoleAzureServiceBusDataReceiver,
 	})
-	topic.WithRoleAssignments(serviceBus, []aspire.AzureServiceBusRole{
+	topic.WithServiceBusRoleAssignments(serviceBus, []aspire.AzureServiceBusRole{
 		aspire.AzureServiceBusRoleAzureServiceBusDataSender,
 	})
-	subscription.WithRoleAssignments(serviceBus, []aspire.AzureServiceBusRole{
+	subscription.WithServiceBusRoleAssignments(serviceBus, []aspire.AzureServiceBusRole{
 		aspire.AzureServiceBusRoleAzureServiceBusDataReceiver,
 	})
 

--- a/tests/PolyglotAppHosts/Aspire.Hosting.Azure.ServiceBus/Java/AppHost.java
+++ b/tests/PolyglotAppHosts/Aspire.Hosting.Azure.ServiceBus/Java/AppHost.java
@@ -25,10 +25,10 @@ void main() throws Exception {
         queue.withProperties((q) -> { q.setDeadLetteringOnMessageExpiration(true); q.setDefaultMessageTimeToLive(36000000000.0); q.setDuplicateDetectionHistoryTimeWindow(6000000000.0); q.setForwardDeadLetteredMessagesTo("dead-letter-queue"); q.setForwardTo("forwarding-queue"); q.setLockDuration(300000000.0); q.setMaxDeliveryCount(10); q.setRequiresDuplicateDetection(true); q.setRequiresSession(false); var _dlq = q.deadLetteringOnMessageExpiration(); var _ttl = q.defaultMessageTimeToLive(); var _fwd = q.forwardTo(); var _maxDel = q.maxDeliveryCount(); });
         topic.withProperties((t) -> { t.setDefaultMessageTimeToLive(6048000000000.0); t.setDuplicateDetectionHistoryTimeWindow(3000000000.0); t.setRequiresDuplicateDetection(false); var _dupDetect = t.requiresDuplicateDetection(); });
         subscription.withProperties((s) -> { s.setDeadLetteringOnMessageExpiration(true); s.setDefaultMessageTimeToLive(72000000000.0); s.setForwardDeadLetteredMessagesTo("sub-dlq"); s.setForwardTo("sub-forward"); s.setLockDuration(600000000.0); s.setMaxDeliveryCount(5); s.setRequiresSession(false); var _lock = s.lockDuration(); var _rules = s.rules(); });
-        serviceBus.withRoleAssignments(serviceBus, new AzureServiceBusRole[] { AzureServiceBusRole.AZURE_SERVICE_BUS_DATA_OWNER, AzureServiceBusRole.AZURE_SERVICE_BUS_DATA_SENDER, AzureServiceBusRole.AZURE_SERVICE_BUS_DATA_RECEIVER });
-        queue.withRoleAssignments(serviceBus, new AzureServiceBusRole[] { AzureServiceBusRole.AZURE_SERVICE_BUS_DATA_RECEIVER });
-        topic.withRoleAssignments(serviceBus, new AzureServiceBusRole[] { AzureServiceBusRole.AZURE_SERVICE_BUS_DATA_SENDER });
-        subscription.withRoleAssignments(serviceBus, new AzureServiceBusRole[] { AzureServiceBusRole.AZURE_SERVICE_BUS_DATA_RECEIVER });
+        serviceBus.withServiceBusRoleAssignments(serviceBus, new AzureServiceBusRole[] { AzureServiceBusRole.AZURE_SERVICE_BUS_DATA_OWNER, AzureServiceBusRole.AZURE_SERVICE_BUS_DATA_SENDER, AzureServiceBusRole.AZURE_SERVICE_BUS_DATA_RECEIVER });
+        queue.withServiceBusRoleAssignments(serviceBus, new AzureServiceBusRole[] { AzureServiceBusRole.AZURE_SERVICE_BUS_DATA_RECEIVER });
+        topic.withServiceBusRoleAssignments(serviceBus, new AzureServiceBusRole[] { AzureServiceBusRole.AZURE_SERVICE_BUS_DATA_SENDER });
+        subscription.withServiceBusRoleAssignments(serviceBus, new AzureServiceBusRole[] { AzureServiceBusRole.AZURE_SERVICE_BUS_DATA_RECEIVER });
         var _sqlFilter = AzureServiceBusFilterType.SQL_FILTER;
         var _correlationFilter = AzureServiceBusFilterType.CORRELATION_FILTER;
         serviceBus

--- a/tests/PolyglotAppHosts/Aspire.Hosting.Azure.ServiceBus/TypeScript/apphost.ts
+++ b/tests/PolyglotAppHosts/Aspire.Hosting.Azure.ServiceBus/TypeScript/apphost.ts
@@ -118,18 +118,18 @@ await subscription.withProperties(async (s) => {
     });
 });
 
-// ── 7. withRoleAssignments — enum-based role assignment shim ───────────────
+// ── 7. withServiceBusRoleAssignments — enum-based role assignment shim ─────
 // On the parent ServiceBus resource (all 3 roles)
-await serviceBus.withRoleAssignments(serviceBus, [
+await serviceBus.withServiceBusRoleAssignments(serviceBus, [
     AzureServiceBusRole.AzureServiceBusDataOwner,
     AzureServiceBusRole.AzureServiceBusDataSender,
     AzureServiceBusRole.AzureServiceBusDataReceiver,
 ]);
 
 // On child resources
-await queue.withRoleAssignments(serviceBus, [AzureServiceBusRole.AzureServiceBusDataReceiver]);
-await topic.withRoleAssignments(serviceBus, [AzureServiceBusRole.AzureServiceBusDataSender]);
-await subscription.withRoleAssignments(serviceBus, [AzureServiceBusRole.AzureServiceBusDataReceiver]);
+await queue.withServiceBusRoleAssignments(serviceBus, [AzureServiceBusRole.AzureServiceBusDataReceiver]);
+await topic.withServiceBusRoleAssignments(serviceBus, [AzureServiceBusRole.AzureServiceBusDataSender]);
+await subscription.withServiceBusRoleAssignments(serviceBus, [AzureServiceBusRole.AzureServiceBusDataReceiver]);
 
 // ── 8. Verify enum values are accessible ────────────────────────────────────
 const _sqlFilter = AzureServiceBusFilterType.SqlFilter;

--- a/tests/PolyglotAppHosts/Aspire.Hosting.Azure.Storage/Go/apphost.go
+++ b/tests/PolyglotAppHosts/Aspire.Hosting.Azure.Storage/Go/apphost.go
@@ -22,7 +22,7 @@ func main() {
 		log.Fatalf(aspire.FormatError(storage.Err()))
 	}
 
-	storage.WithRoleAssignments(storage, []aspire.AzureStorageRole{
+	storage.WithStorageRoleAssignments(storage, []aspire.AzureStorageRole{
 		aspire.AzureStorageRoleStorageBlobDataContributor,
 		aspire.AzureStorageRoleStorageQueueDataContributor,
 	})

--- a/tests/PolyglotAppHosts/Aspire.Hosting.Azure.Storage/Java/AppHost.java
+++ b/tests/PolyglotAppHosts/Aspire.Hosting.Azure.Storage/Java/AppHost.java
@@ -4,7 +4,7 @@ void main() throws Exception {
         var builder = DistributedApplication.CreateBuilder();
         var storage = builder.addAzureStorage("storage");
         storage.runAsEmulator();
-        storage.withRoleAssignments(storage, new AzureStorageRole[] { AzureStorageRole.STORAGE_BLOB_DATA_CONTRIBUTOR, AzureStorageRole.STORAGE_QUEUE_DATA_CONTRIBUTOR });
+        storage.withStorageRoleAssignments(storage, new AzureStorageRole[] { AzureStorageRole.STORAGE_BLOB_DATA_CONTRIBUTOR, AzureStorageRole.STORAGE_QUEUE_DATA_CONTRIBUTOR });
         // Callbacks are currently not working
         // storage.runAsEmulator({
         //     configureContainer: (emulator) -> {

--- a/tests/PolyglotAppHosts/Aspire.Hosting.Azure.Storage/TypeScript/apphost.ts
+++ b/tests/PolyglotAppHosts/Aspire.Hosting.Azure.Storage/TypeScript/apphost.ts
@@ -4,7 +4,7 @@ const builder = await createBuilder();
 
 const storage = await builder.addAzureStorage("storage");
 await storage.runAsEmulator();
-await storage.withRoleAssignments(storage, [AzureStorageRole.StorageBlobDataContributor, AzureStorageRole.StorageQueueDataContributor]);
+await storage.withStorageRoleAssignments(storage, [AzureStorageRole.StorageBlobDataContributor, AzureStorageRole.StorageQueueDataContributor]);
 
 // Callbacks are currently not working
 // await storage.runAsEmulator({

--- a/tests/PolyglotAppHosts/Aspire.Hosting.Azure.WebPubSub/Go/apphost.go
+++ b/tests/PolyglotAppHosts/Aspire.Hosting.Azure.WebPubSub/Go/apphost.go
@@ -38,13 +38,13 @@ func main() {
 		log.Fatalf(aspire.FormatError(container.Err()))
 	}
 
-	container.WithRoleAssignments(webpubsub, []aspire.AzureWebPubSubRole{
+	container.WithWebPubSubRoleAssignments(webpubsub, []aspire.AzureWebPubSubRole{
 		aspire.AzureWebPubSubRoleWebPubSubServiceOwner,
 		aspire.AzureWebPubSubRoleWebPubSubServiceReader,
 		aspire.AzureWebPubSubRoleWebPubSubContributor,
 	})
 
-	webpubsub.WithRoleAssignments(webpubsub, []aspire.AzureWebPubSubRole{
+	webpubsub.WithWebPubSubRoleAssignments(webpubsub, []aspire.AzureWebPubSubRole{
 		aspire.AzureWebPubSubRoleWebPubSubServiceReader,
 	})
 

--- a/tests/PolyglotAppHosts/Aspire.Hosting.Azure.WebPubSub/Java/AppHost.java
+++ b/tests/PolyglotAppHosts/Aspire.Hosting.Azure.WebPubSub/Java/AppHost.java
@@ -10,11 +10,11 @@ void main() throws Exception {
         // addEventHandler - adds an event handler to a hub
         hub.addEventHandler(ReferenceExpression.refExpr("https://example.com/handler"));
         hub.addEventHandler(ReferenceExpression.refExpr("https://example.com/handler2"), new AddEventHandlerOptions().userEventPattern("event1").systemEvents(new String[] { "connect", "connected" }));
-        // withRoleAssignments - assigns roles on a container resource
+        // withWebPubSubRoleAssignments - assigns roles on a container resource
         var container = builder.addContainer("mycontainer", "mcr.microsoft.com/dotnet/samples:aspnetapp");
-        container.withRoleAssignments(webpubsub, new AzureWebPubSubRole[] { AzureWebPubSubRole.WEB_PUB_SUB_SERVICE_OWNER, AzureWebPubSubRole.WEB_PUB_SUB_SERVICE_READER, AzureWebPubSubRole.WEB_PUB_SUB_CONTRIBUTOR });
-        // withRoleAssignments - also available directly on AzureWebPubSubResource builder
-        webpubsub.withRoleAssignments(webpubsub, new AzureWebPubSubRole[] { AzureWebPubSubRole.WEB_PUB_SUB_SERVICE_READER });
+        container.withWebPubSubRoleAssignments(webpubsub, new AzureWebPubSubRole[] { AzureWebPubSubRole.WEB_PUB_SUB_SERVICE_OWNER, AzureWebPubSubRole.WEB_PUB_SUB_SERVICE_READER, AzureWebPubSubRole.WEB_PUB_SUB_CONTRIBUTOR });
+        // withWebPubSubRoleAssignments - also available directly on AzureWebPubSubResource builder
+        webpubsub.withWebPubSubRoleAssignments(webpubsub, new AzureWebPubSubRole[] { AzureWebPubSubRole.WEB_PUB_SUB_SERVICE_READER });
         // withReference - generic, works via IResourceWithConnectionString
         container.withReference(webpubsub, new WithReferenceOptions());
         container.withReference(hub, new WithReferenceOptions());

--- a/tests/PolyglotAppHosts/Aspire.Hosting.Azure.WebPubSub/Python/apphost.py
+++ b/tests/PolyglotAppHosts/Aspire.Hosting.Azure.WebPubSub/Python/apphost.py
@@ -13,10 +13,10 @@ with create_builder() as builder:
     # addEventHandler — adds an event handler to a hub
     hub.add_event_handler("resource")
     hub.add_event_handler("resource")
-    # withRoleAssignments — assigns roles on a container resource
+    # with_web_pub_sub_role_assignments — assigns roles on a container resource
     container = builder.add_container("resource", "image")
     container.with_web_pub_sub_role_assignments()
-    # withRoleAssignments — also available directly on AzureWebPubSubResource builder
+    # with_web_pub_sub_role_assignments — also available directly on AzureWebPubSubResource builder
     webpubsub.with_web_pub_sub_role_assignments()
     # withReference — generic, works via IResourceWithConnectionString
     container.with_reference()

--- a/tests/PolyglotAppHosts/Aspire.Hosting.Azure.WebPubSub/TypeScript/apphost.ts
+++ b/tests/PolyglotAppHosts/Aspire.Hosting.Azure.WebPubSub/TypeScript/apphost.ts
@@ -17,16 +17,16 @@ await hub.addEventHandler(refExpr`https://example.com/handler2`, {
     systemEvents: ["connect", "connected"],
 });
 
-// withRoleAssignments — assigns roles on a container resource
+// withWebPubSubRoleAssignments — assigns roles on a container resource
 const container = await builder.addContainer("mycontainer", "mcr.microsoft.com/dotnet/samples:aspnetapp");
-await container.withRoleAssignments(webpubsub, [
+await container.withWebPubSubRoleAssignments(webpubsub, [
     AzureWebPubSubRole.WebPubSubServiceOwner,
     AzureWebPubSubRole.WebPubSubServiceReader,
     AzureWebPubSubRole.WebPubSubContributor,
 ]);
 
-// withRoleAssignments — also available directly on AzureWebPubSubResource builder
-await webpubsub.withRoleAssignments(webpubsub, [AzureWebPubSubRole.WebPubSubServiceReader]);
+// withWebPubSubRoleAssignments — also available directly on AzureWebPubSubResource builder
+await webpubsub.withWebPubSubRoleAssignments(webpubsub, [AzureWebPubSubRole.WebPubSubServiceReader]);
 
 // withReference — generic, works via IResourceWithConnectionString
 await container.withReference(webpubsub);

--- a/tests/PolyglotAppHosts/Aspire.Hosting.Foundry/Java/AppHost.java
+++ b/tests/PolyglotAppHosts/Aspire.Hosting.Foundry/Java/AppHost.java
@@ -117,7 +117,7 @@ server.listen(port, '127.0.0.1');
             }));
 
         var api = builder.addContainer("api", "nginx");
-        foundry.withRoleAssignments(registry, new AzureContainerRegistryRole[] {
+        foundry.withContainerRegistryRoleAssignments(registry, new AzureContainerRegistryRole[] {
             AzureContainerRegistryRole.ACR_PULL
         });
 

--- a/tests/PolyglotAppHosts/Aspire.Hosting.Foundry/Python/apphost.py
+++ b/tests/PolyglotAppHosts/Aspire.Hosting.Foundry/Python/apphost.py
@@ -126,7 +126,7 @@ server.listen(port, '127.0.0.1');
     hosted_agent.publish_as_hosted_agent(project=project)
 
     api = builder.add_container("api", "nginx")
-    foundry.with_role_assignments(registry)
+    foundry.with_container_registry_role_assignments(registry)
 
     _deployment_name = chat.deployment_name
     _model_name = chat.model_name

--- a/tests/PolyglotAppHosts/Aspire.Hosting.Foundry/TypeScript/apphost.ts
+++ b/tests/PolyglotAppHosts/Aspire.Hosting.Foundry/TypeScript/apphost.ts
@@ -122,7 +122,7 @@ await hostedAgent.publishAsHostedAgent({
 });
 
 const api = await builder.addContainer('api', 'nginx');
-await foundry.withRoleAssignments(registry, [AzureContainerRegistryRole.AcrPull]);
+await foundry.withContainerRegistryRoleAssignments(registry, [AzureContainerRegistryRole.AcrPull]);
 
 const _deploymentName = await chat.deploymentName.get();
 const _modelName = await chat.modelName.get();


### PR DESCRIPTION
## Description

The shared polyglot `withRoleAssignments` method name caused ATS SDK dump collisions when multiple Azure integrations were referenced together. This change removes the shared method-name override from the role-assignment shims so each integration exports its existing specific capability name, such as `withStorageRoleAssignments`, `withEventHubsRoleAssignments`, and `withKeyVaultRoleAssignments`.

The PolyglotAppHosts samples were updated across TypeScript, Java, Go, and affected Python hosts to call the specific role-assignment methods. The built-in Azure.Provisioning role overloads remain ignored because they are not ATS-compatible; the exported Aspire-owned enum shims are the polyglot-safe surface.

Fixes # N/A

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No