### PR TITLE
Add public AzureRoleAssignmentResource type

### DIFF
--- a/src/Aspire.Hosting.Azure/AzureResourcePreparer.cs
+++ b/src/Aspire.Hosting.Azure/AzureResourcePreparer.cs
@@ -260,7 +260,7 @@ internal sealed class AzureResourcePreparer(
         return result;
     }
 
-    private (AzureUserAssignedIdentityResource IdentityResource, List<AzureBicepResource> RoleAssignmentResources) CreateIdentityAndRoleAssignmentResources(
+    private (AzureUserAssignedIdentityResource IdentityResource, List<AzureRoleAssignmentResource> RoleAssignmentResources) CreateIdentityAndRoleAssignmentResources(
         IResource resource,
         Dictionary<AzureProvisioningResource, IEnumerable<RoleDefinition>> roleAssignments)
     {
@@ -290,16 +290,19 @@ internal sealed class AzureResourcePreparer(
         return (identityResource, roleAssignmentResources);
     }
 
-    private List<AzureBicepResource> CreateRoleAssignmentsResources(
+    private List<AzureRoleAssignmentResource> CreateRoleAssignmentsResources(
         IResource resource,
         Dictionary<AzureProvisioningResource, IEnumerable<RoleDefinition>> roleAssignments,
         AzureUserAssignedIdentityResource appIdentityResource)
     {
-        var roleAssignmentResources = new List<AzureBicepResource>();
+        var roleAssignmentResources = new List<AzureRoleAssignmentResource>();
         foreach (var (targetResource, roles) in roleAssignments)
         {
-            var roleAssignmentResource = new AzureProvisioningResource(
+            var roleAssignmentResource = new AzureRoleAssignmentResource(
                 $"{resource.Name}-roles-{targetResource.Name}",
+                targetResource,
+                resource,
+                appIdentityResource,
                 infra => AddRoleAssignmentsInfrastructure(infra, targetResource, roles, appIdentityResource))
             {
                 ProvisioningBuildOptions = options.Value.ProvisioningBuildOptions,
@@ -398,12 +401,15 @@ internal sealed class AzureResourcePreparer(
         }
     }
 
-    private AzureProvisioningResource CreateGlobalRoleAssignmentsResource(
+    private AzureRoleAssignmentResource CreateGlobalRoleAssignmentsResource(
         AzureProvisioningResource targetResource,
         IEnumerable<RoleDefinition> roles)
     {
-        var roleAssignmentResource = new AzureProvisioningResource(
+        var roleAssignmentResource = new AzureRoleAssignmentResource(
             $"{targetResource.Name}-roles",
+            targetResource,
+            ownerResource: null,
+            identityResource: null,
             infra => AddGlobalRoleAssignmentsInfrastructure(infra, targetResource, roles))
         {
             ProvisioningBuildOptions = options.Value.ProvisioningBuildOptions,

--- a/src/Aspire.Hosting.Azure/AzureRoleAssignmentResource.cs
+++ b/src/Aspire.Hosting.Azure/AzureRoleAssignmentResource.cs
@@ -42,11 +42,23 @@ public sealed class AzureRoleAssignmentResource(
     /// When <c>WithRoleAssignments</c> is called using an <see cref="AzureUserAssignedIdentityResource"/>,
     /// OwnerResource and IdentityResource are the same.
     /// </remarks>
-    public IResource? OwnerResource { get; } = ownerResource;
+    public IResource? OwnerResource { get; } = ValidateOwnerAndIdentity(ownerResource, identityResource);
 
     /// <summary>
     /// Gets the user-assigned managed identity whose principal receives the role assignments,
     /// or <see langword="null"/> for global role assignments that are granted to the deployment principal.
     /// </summary>
     public AzureUserAssignedIdentityResource? IdentityResource { get; } = identityResource;
+
+    private static IResource? ValidateOwnerAndIdentity(IResource? ownerResource, AzureUserAssignedIdentityResource? identityResource)
+    {
+        if ((ownerResource is null) != (identityResource is null))
+        {
+            throw new ArgumentException(
+                $"'{nameof(ownerResource)}' and '{nameof(identityResource)}' must both be null (for global role assignments) or both be non-null (for targeted role assignments).",
+                ownerResource is null ? nameof(ownerResource) : nameof(identityResource));
+        }
+
+        return ownerResource;
+    }
 }

--- a/src/Aspire.Hosting.Azure/AzureRoleAssignmentResource.cs
+++ b/src/Aspire.Hosting.Azure/AzureRoleAssignmentResource.cs
@@ -1,0 +1,52 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Aspire.Hosting.ApplicationModel;
+
+namespace Aspire.Hosting.Azure;
+
+/// <summary>
+/// Represents a set of Azure role assignments granted on a target Azure resource.
+/// </summary>
+/// <remarks>
+/// When <see cref="OwnerResource"/> is non-<see langword="null"/>, the role assignments are granted to
+/// the managed identity (<see cref="IdentityResource"/>) owned by that Aspire resource. When
+/// <see cref="OwnerResource"/> is <see langword="null"/>, the role assignments are global and are
+/// granted to the deployment principal.
+/// </remarks>
+/// <param name="name">The name of the resource in the distributed application model.</param>
+/// <param name="targetAzureResource">The Azure resource that the roles are assigned on.</param>
+/// <param name="ownerResource">The Aspire resource that owns this set of role assignments, or <see langword="null"/> for global role assignments granted to the deployment principal.</param>
+/// <param name="identityResource">The user-assigned managed identity whose principal receives the role assignments, or <see langword="null"/> for global role assignments granted to the deployment principal.</param>
+/// <param name="configureInfrastructure">Callback to configure the Azure role assignment resources.</param>
+public sealed class AzureRoleAssignmentResource(
+    string name,
+    AzureProvisioningResource targetAzureResource,
+    IResource? ownerResource,
+    AzureUserAssignedIdentityResource? identityResource,
+    Action<AzureResourceInfrastructure> configureInfrastructure)
+    : AzureProvisioningResource(name, configureInfrastructure)
+{
+    /// <summary>
+    /// Gets the Azure resource that the roles are assigned on.
+    /// </summary>
+    public AzureProvisioningResource TargetAzureResource { get; } = targetAzureResource ?? throw new ArgumentNullException(nameof(targetAzureResource));
+
+    /// <summary>
+    /// Gets the Aspire resource that owns this set of role assignments,
+    /// or <see langword="null"/> for global role assignments that are granted to the deployment principal.
+    /// </summary>
+    /// <remarks>
+    /// This is the resource on which <c>WithRoleAssignments</c> was called. Its managed identity
+    /// is exposed via <see cref="IdentityResource"/>.
+    /// When <c>WithRoleAssignments</c> is called using an <see cref="AzureUserAssignedIdentityResource"/>,
+    /// OwnerResource and IdentityResource are the same.
+    /// </remarks>
+    public IResource? OwnerResource { get; } = ownerResource;
+
+    /// <summary>
+    /// Gets the user-assigned managed identity whose principal receives the role assignments,
+    /// or <see langword="null"/> for global role assignments that are granted to the deployment principal.
+    /// </summary>
+    public AzureUserAssignedIdentityResource? IdentityResource { get; } = identityResource;
+}

--- a/src/Aspire.Hosting.Azure/RoleAssignmentResourceAnnotation.cs
+++ b/src/Aspire.Hosting.Azure/RoleAssignmentResourceAnnotation.cs
@@ -6,12 +6,12 @@ using Aspire.Hosting.ApplicationModel;
 namespace Aspire.Hosting.Azure;
 
 /// <summary>
-/// An annotation that points to the AzureProvisioningResource that contains the role assignments for an Azure resource.
+/// An annotation that points to the resource that contains the role assignments for an Azure resource.
 /// </summary>
-internal sealed class RoleAssignmentResourceAnnotation(AzureProvisioningResource rolesResource) : IResourceAnnotation
+internal sealed class RoleAssignmentResourceAnnotation(AzureRoleAssignmentResource rolesResource) : IResourceAnnotation
 {
     /// <summary>
-    /// The AzureProvisioningResource that contains the role assignments for the Azure resource.
+    /// The resource that contains the role assignments for the Azure resource.
     /// </summary>
-    public AzureProvisioningResource RolesResource { get; } = rolesResource;
+    public AzureRoleAssignmentResource RolesResource { get; } = rolesResource;
 }

--- a/tests/Aspire.Hosting.Azure.Tests/AzureResourcePreparerTests.cs
+++ b/tests/Aspire.Hosting.Azure.Tests/AzureResourcePreparerTests.cs
@@ -2,12 +2,16 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 #pragma warning disable ASPIREAZURE003 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
+#pragma warning disable ASPIREPIPELINES001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
 
 using Aspire.Hosting.ApplicationModel;
+using Aspire.Hosting.Pipelines;
 using Aspire.Hosting.Utils;
+using Azure.Provisioning.KeyVault;
 using Azure.Provisioning.Storage;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
 using static Aspire.Hosting.Utils.AzureManifestUtils;
 
 namespace Aspire.Hosting.Azure.Tests;
@@ -69,7 +73,9 @@ public class AzureResourcePreparerTests
         {
             // when AzureContainerAppsInfrastructure is not added, we always apply the default role assignments to a new 'storage-roles' resource.
             // The same applies when in RunMode and we are provisioning Azure resources for F5 local development.
-            var storageRoles = Assert.Single(model.Resources.OfType<AzureProvisioningResource>(), r => r.Name == "storage-roles");
+            var storageRoles = Assert.Single(model.Resources.OfType<AzureRoleAssignmentResource>(), r => r.Name == "storage-roles");
+            Assert.Same(storage.Resource, storageRoles.TargetAzureResource);
+            Assert.Null(storageRoles.OwnerResource);
 
             var storageRolesManifest = await GetManifestWithBicep(storageRoles, skipPreparer: true);
             await Verify(storageRolesManifest.BicepText, extension: "bicep");
@@ -113,7 +119,9 @@ public class AzureResourcePreparerTests
         {
             // in RunMode, we apply the role assignments to a new 'storage-roles' resource, so the provisioned resource
             // adds these role assignments for F5 local development.
-            var storageRoles = Assert.Single(model.Resources.OfType<AzureProvisioningResource>(), r => r.Name == "storage-roles");
+            var storageRoles = Assert.Single(model.Resources.OfType<AzureRoleAssignmentResource>(), r => r.Name == "storage-roles");
+            Assert.Same(storage.Resource, storageRoles.TargetAzureResource);
+            Assert.Null(storageRoles.OwnerResource);
 
             var storageRolesManifest = await GetManifestWithBicep(storageRoles, skipPreparer: true);
             await Verify(storageRolesManifest.BicepText, extension: "bicep");
@@ -208,12 +216,71 @@ public class AzureResourcePreparerTests
         var model = app.Services.GetRequiredService<DistributedApplicationModel>();
         await ExecuteBeforeStartHooksAsync(app, default);
 
-        var roleAssignmentResource = Assert.Single(model.Resources.OfType<AzureBicepResource>(), r => r.Name == "api-roles-storage");
+        var roleAssignmentResource = Assert.Single(model.Resources.OfType<AzureRoleAssignmentResource>(), r => r.Name == "api-roles-storage");
         var deploymentTarget = Assert.IsAssignableFrom<AzureBicepResource>(api.Resource.GetDeploymentTargetAnnotation()?.DeploymentTarget);
 
+        Assert.Same(storage.Resource, roleAssignmentResource.TargetAzureResource);
+        Assert.Same(api.Resource, roleAssignmentResource.OwnerResource);
         Assert.Contains(roleAssignmentResource, deploymentTarget.References);
         Assert.Contains(blobPE.Resource, deploymentTarget.References);
         Assert.Contains(queuesPE.Resource, deploymentTarget.References);
+    }
+
+    [Fact]
+    public async Task PipelineStepAfterBeforeStartCanInspectRoleAssignmentsForTargetAzureResource()
+    {
+        const string inspectRoleAssignmentsStepName = "inspect-keyvault-role-assignments";
+
+        using var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish, step: inspectRoleAssignmentsStepName);
+        builder.AddAzureContainerAppEnvironment("env");
+
+        var keyVault = builder.AddAzureKeyVault("keyvault");
+        var storage = builder.AddAzureStorage("storage");
+
+        var api = builder.AddProject<Project>("api", launchProfileName: null)
+            .WithRoleAssignments(keyVault, KeyVaultBuiltInRole.KeyVaultSecretsUser)
+            .WithRoleAssignments(storage, StorageBuiltInRole.StorageBlobDataReader);
+
+        var worker = builder.AddProject<Project>("worker", launchProfileName: null)
+            .WithRoleAssignments(keyVault, KeyVaultBuiltInRole.KeyVaultSecretsUser);
+
+        List<AzureRoleAssignmentResource>? keyVaultRoleAssignments = null;
+        builder.Pipeline.AddStep(
+            inspectRoleAssignmentsStepName,
+            context =>
+            {
+                keyVaultRoleAssignments =
+                    [.. context.Model.Resources
+                        .OfType<AzureRoleAssignmentResource>()
+                        .Where(resource => resource.TargetAzureResource == keyVault.Resource)
+                        .OrderBy(resource => resource.Name, StringComparer.Ordinal)];
+
+                return Task.CompletedTask;
+            },
+            dependsOn: WellKnownPipelineSteps.BeforeStart);
+
+        using var app = builder.Build();
+        await ExecutePipelineAsync(app);
+
+        Assert.NotNull(keyVaultRoleAssignments);
+        Assert.Collection(keyVaultRoleAssignments,
+            resource =>
+            {
+                Assert.Equal("api-roles-keyvault", resource.Name);
+                Assert.Same(keyVault.Resource, resource.TargetAzureResource);
+                Assert.Same(api.Resource, resource.OwnerResource);
+            },
+            resource =>
+            {
+                Assert.Equal("worker-roles-keyvault", resource.Name);
+                Assert.Same(keyVault.Resource, resource.TargetAzureResource);
+                Assert.Same(worker.Resource, resource.OwnerResource);
+            });
+
+        var storageRoleAssignment = Assert.Single(
+            app.Services.GetRequiredService<DistributedApplicationModel>().Resources.OfType<AzureRoleAssignmentResource>(),
+            resource => resource.TargetAzureResource == storage.Resource);
+        Assert.Same(api.Resource, storageRoleAssignment.OwnerResource);
     }
 
     [Fact]
@@ -373,5 +440,18 @@ public class AzureResourcePreparerTests
     private sealed class Project : IProjectMetadata
     {
         public string ProjectPath => "project";
+    }
+
+    private static Task ExecutePipelineAsync(DistributedApplication app)
+    {
+        var pipeline = app.Services.GetRequiredService<IDistributedApplicationPipeline>();
+        var context = new PipelineContext(
+            app.Services.GetRequiredService<DistributedApplicationModel>(),
+            app.Services.GetRequiredService<DistributedApplicationExecutionContext>(),
+            app.Services,
+            app.Services.GetRequiredService<ILogger<AzureResourcePreparerTests>>(),
+            CancellationToken.None);
+
+        return pipeline.ExecuteAsync(context);
     }
 }

--- a/tests/Aspire.Hosting.Azure.Tests/AzureResourcePreparerTests.cs
+++ b/tests/Aspire.Hosting.Azure.Tests/AzureResourcePreparerTests.cs
@@ -18,6 +18,22 @@ namespace Aspire.Hosting.Azure.Tests;
 
 public class AzureResourcePreparerTests
 {
+    [Fact]
+    public void AzureRoleAssignmentResourceThrowsWhenOwnerAndIdentityAreInconsistent()
+    {
+        var target = new TestProvisioningResource("target");
+        var identity = new AzureUserAssignedIdentityResource("identity");
+        var owner = new TestProvisioningResource("owner");
+
+        Assert.Throws<ArgumentException>("identityResource", () =>
+            new AzureRoleAssignmentResource("roles", target, owner, identityResource: null, _ => { }));
+
+        Assert.Throws<ArgumentException>("ownerResource", () =>
+            new AzureRoleAssignmentResource("roles", target, ownerResource: null, identity, _ => { }));
+    }
+
+    private sealed class TestProvisioningResource(string name) : AzureProvisioningResource(name, _ => { });
+
     [Theory]
     [InlineData(DistributedApplicationOperation.Publish)]
     [InlineData(DistributedApplicationOperation.Run)]

--- a/tests/Aspire.Hosting.Azure.Tests/AzureUserAssignedIdentityTests.cs
+++ b/tests/Aspire.Hosting.Azure.Tests/AzureUserAssignedIdentityTests.cs
@@ -77,7 +77,7 @@ public class AzureUserAssignedIdentityTests
             r => Assert.IsType<AzureUserAssignedIdentityResource>(r),
             r =>
             {
-                Assert.IsType<AzureProvisioningResource>(r);
+                Assert.IsType<AzureRoleAssignmentResource>(r);
                 Assert.Equal("myidentity-roles-myregistry", r.Name);
             });
 
@@ -87,7 +87,9 @@ public class AzureUserAssignedIdentityTests
         var registryResource = Assert.Single(model.Resources.OfType<AzureContainerRegistryResource>(), r => r.Name == "myregistry");
         var (_, registryBicep) = await GetManifestWithBicep(registryResource, skipPreparer: true);
 
-        var identityRoleAssignments = Assert.Single(model.Resources.OfType<AzureProvisioningResource>(), r => r.Name == "myidentity-roles-myregistry");
+        var identityRoleAssignments = Assert.Single(model.Resources.OfType<AzureRoleAssignmentResource>(), r => r.Name == "myidentity-roles-myregistry");
+        Assert.Same(registryResource, identityRoleAssignments.TargetAzureResource);
+        Assert.Same(identityResource, identityRoleAssignments.OwnerResource);
         var (_, identityRoleAssignmentsBicep) = await GetManifestWithBicep(identityRoleAssignments, skipPreparer: true);
 
         await Verify(identityBicep, "bicep")
@@ -159,7 +161,7 @@ public class AzureUserAssignedIdentityTests
             r => Assert.IsType<AzureStorageResource>(r),
             r => Assert.IsType<AzureUserAssignedIdentityResource>(r),
             r => Assert.IsType<ProjectResource>(r),
-            r => Assert.IsType<AzureProvisioningResource>(r));
+            r => Assert.IsType<AzureRoleAssignmentResource>(r));
 
         // Verify the identity resource is the only one that exists
         var identityResource = Assert.Single(model.Resources.OfType<AzureUserAssignedIdentityResource>());
@@ -171,8 +173,10 @@ public class AzureUserAssignedIdentityTests
         Assert.Same(identity.Resource, identityAnnotation.IdentityResource);
 
         // Verify the role assignment resource for the project
-        var roleAssignmentResource = Assert.Single(model.Resources.OfType<AzureProvisioningResource>(),
+        var roleAssignmentResource = Assert.Single(model.Resources.OfType<AzureRoleAssignmentResource>(),
             r => r.Name == "myapp-roles-mystorage");
+        Assert.Same(storage.Resource, roleAssignmentResource.TargetAzureResource);
+        Assert.Same(computeResource, roleAssignmentResource.OwnerResource);
 
         // Get the Bicep for all resources
         var deploymentTarget = Assert.Single(computeResource.Annotations.OfType<DeploymentTargetAnnotation>());
@@ -215,7 +219,7 @@ public class AzureUserAssignedIdentityTests
             r => Assert.IsType<AzureStorageResource>(r),
             r => Assert.IsType<AzureUserAssignedIdentityResource>(r),
             r => Assert.IsType<ProjectResource>(r),
-            r => Assert.IsType<AzureProvisioningResource>(r));
+            r => Assert.IsType<AzureRoleAssignmentResource>(r));
 
         // Verify the identity resource is the only one that exists
         var identityResource = Assert.Single(model.Resources.OfType<AzureUserAssignedIdentityResource>());
@@ -227,8 +231,10 @@ public class AzureUserAssignedIdentityTests
         Assert.Same(identity.Resource, identityAnnotation.IdentityResource);
 
         // Verify the role assignment resource for the project
-        var roleAssignmentResource = Assert.Single(model.Resources.OfType<AzureProvisioningResource>(),
+        var roleAssignmentResource = Assert.Single(model.Resources.OfType<AzureRoleAssignmentResource>(),
             r => r.Name == "myapp-roles-mystorage");
+        Assert.Same(storage.Resource, roleAssignmentResource.TargetAzureResource);
+        Assert.Same(computeResource, roleAssignmentResource.OwnerResource);
 
         // Get the Bicep for all resources
         var deploymentTarget = Assert.Single(computeResource.Annotations.OfType<DeploymentTargetAnnotation>());
@@ -293,8 +299,8 @@ public class AzureUserAssignedIdentityTests
             r => Assert.IsType<AzureUserAssignedIdentityResource>(r),
             r => Assert.IsType<ProjectResource>(r),
             r => Assert.IsType<ProjectResource>(r),
-            r => Assert.True(r is AzureProvisioningResource { Name: "myapp-roles-mystorage" }),
-            r => Assert.True(r is AzureProvisioningResource { Name: "myapp2-roles-mystorage" }));
+            r => Assert.True(r is AzureRoleAssignmentResource { Name: "myapp-roles-mystorage" }),
+            r => Assert.True(r is AzureRoleAssignmentResource { Name: "myapp2-roles-mystorage" }));
 
         // Verify the identity resource is the only one that exists
         var identityResource = Assert.Single(model.Resources.OfType<AzureUserAssignedIdentityResource>());
@@ -309,10 +315,14 @@ public class AzureUserAssignedIdentityTests
         Assert.Same(identity.Resource, identityAnnotation2.IdentityResource);
 
         // Verify the role assignment resource for the project
-        var roleAssignmentResource = Assert.Single(model.Resources.OfType<AzureProvisioningResource>(),
+        var roleAssignmentResource = Assert.Single(model.Resources.OfType<AzureRoleAssignmentResource>(),
             r => r.Name == "myapp-roles-mystorage");
-        var roleAssignmentResource2 = Assert.Single(model.Resources.OfType<AzureProvisioningResource>(),
+        var roleAssignmentResource2 = Assert.Single(model.Resources.OfType<AzureRoleAssignmentResource>(),
             r => r.Name == "myapp2-roles-mystorage");
+        Assert.Same(storage.Resource, roleAssignmentResource.TargetAzureResource);
+        Assert.Same(computeResource, roleAssignmentResource.OwnerResource);
+        Assert.Same(storage.Resource, roleAssignmentResource2.TargetAzureResource);
+        Assert.Same(computeResource2, roleAssignmentResource2.OwnerResource);
         // Each project uses the same identity, but assigns different roles
         Assert.NotSame(roleAssignmentResource, roleAssignmentResource2);
 

--- a/tests/Aspire.Hosting.Azure.Tests/RoleAssignmentTests.cs
+++ b/tests/Aspire.Hosting.Azure.Tests/RoleAssignmentTests.cs
@@ -297,7 +297,7 @@ public class RoleAssignmentTests()
         await ExecuteBeforeStartHooksAsync(app, default);
 
         // Verify that explicit role assignments still work even after ClearDefaultRoleAssignments
-        var projRoles = Assert.Single(model.Resources.OfType<AzureProvisioningResource>(), r => r.Name == "api-roles-keyvault");
+        var projRoles = Assert.Single(model.Resources.OfType<AzureRoleAssignmentResource>(), r => r.Name == "api-roles-keyvault");
         Assert.NotNull(projRoles);
     }
 
@@ -325,7 +325,7 @@ public class RoleAssignmentTests()
         await ExecuteBeforeStartHooksAsync(app, default);
 
         // The server should have a role assignment to the cache since it directly references it
-        Assert.Single(model.Resources.OfType<AzureProvisioningResource>(), r => r.Name == "server-roles-cache");
+        Assert.Single(model.Resources.OfType<AzureRoleAssignmentResource>(), r => r.Name == "server-roles-cache");
 
         // The webfrontend should NOT have a role assignment to the cache since it only references the server
         Assert.DoesNotContain(model.Resources, r => r.Name == "webfrontend-roles-cache");
@@ -348,7 +348,12 @@ public class RoleAssignmentTests()
 
         await ExecuteBeforeStartHooksAsync(app, default);
 
-        var projRoles = Assert.Single(model.Resources.OfType<AzureProvisioningResource>(), r => r.Name == $"api-roles-{azureResourceName}");
+        var project = Assert.Single(model.Resources.OfType<ProjectResource>(), r => r.Name == "api");
+        var targetAzureResource = Assert.Single(model.Resources.OfType<AzureProvisioningResource>(), r => r.Name == azureResourceName);
+        var projRoles = Assert.Single(model.Resources.OfType<AzureRoleAssignmentResource>(), r => r.Name == $"api-roles-{azureResourceName}");
+
+        Assert.Same(targetAzureResource, projRoles.TargetAzureResource);
+        Assert.Same(project, projRoles.OwnerResource);
 
         var (rolesManifest, rolesBicep) = await GetManifestWithBicep(projRoles);
 

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureDeployerTests.DeployAsync_WithAzureResourceDependencies_DoesNotHang_step=diagnostics.verified.txt
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureDeployerTests.DeployAsync_WithAzureResourceDependencies_DoesNotHang_step=diagnostics.verified.txt
@@ -156,7 +156,7 @@ Step: provision-api-identity
 Step: provision-api-roles-kv
     Description: Provisions the Azure Bicep resource api-roles-kv using Azure infrastructure.
     Dependencies: ✓ create-provisioning-context, ✓ provision-api-identity, ✓ provision-kv
-    Resource: api-roles-kv (AzureProvisioningResource)
+    Resource: api-roles-kv (AzureRoleAssignmentResource)
     Tags: provision-infra
 
 Step: provision-api-website

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureDeployerTests.DeployAsync_WithPrivateEndpoints_CreatesCorrectDependencies.verified.txt
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureDeployerTests.DeployAsync_WithPrivateEndpoints_CreatesCorrectDependencies.verified.txt
@@ -174,13 +174,13 @@ Step: provision-api-identity
 Step: provision-api-roles-cosmos
     Description: Provisions the Azure Bicep resource api-roles-cosmos using Azure infrastructure.
     Dependencies: ✓ create-provisioning-context, ✓ provision-api-identity, ✓ provision-cosmos
-    Resource: api-roles-cosmos (AzureProvisioningResource)
+    Resource: api-roles-cosmos (AzureRoleAssignmentResource)
     Tags: provision-infra
 
 Step: provision-api-roles-sql
     Description: Provisions the Azure Bicep resource api-roles-sql using Azure infrastructure.
     Dependencies: ✓ create-provisioning-context, ✓ provision-api-identity, ✓ provision-pe-subnet-files-pe, ✓ provision-pe-subnet-sql-pe, ✓ provision-sql, ✓ provision-sql-store, ✓ provision-vnet
-    Resource: api-roles-sql (AzureProvisioningResource)
+    Resource: api-roles-sql (AzureRoleAssignmentResource)
     Tags: provision-infra
 
 Step: provision-azure-bicep-resources
@@ -258,7 +258,7 @@ Step: provision-sql-admin-identity
 Step: provision-sql-admin-identity-roles-sql-store
     Description: Provisions the Azure Bicep resource sql-admin-identity-roles-sql-store using Azure infrastructure.
     Dependencies: ✓ create-provisioning-context, ✓ provision-sql-admin-identity, ✓ provision-sql-store
-    Resource: sql-admin-identity-roles-sql-store (AzureProvisioningResource)
+    Resource: sql-admin-identity-roles-sql-store (AzureRoleAssignmentResource)
     Tags: provision-infra
 
 Step: provision-sql-nsg

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureDeployerTests.DeployAsync_WithRedisAccessKeyAuthentication_CreatesCorrectDependencies.verified.txt
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureDeployerTests.DeployAsync_WithRedisAccessKeyAuthentication_CreatesCorrectDependencies.verified.txt
@@ -163,19 +163,19 @@ Step: provision-api-identity
 Step: provision-api-roles-cache-kv
     Description: Provisions the Azure Bicep resource api-roles-cache-kv using Azure infrastructure.
     Dependencies: ✓ create-provisioning-context, ✓ provision-api-identity, ✓ provision-cache-kv
-    Resource: api-roles-cache-kv (AzureProvisioningResource)
+    Resource: api-roles-cache-kv (AzureRoleAssignmentResource)
     Tags: provision-infra
 
 Step: provision-api-roles-cosmos-kv
     Description: Provisions the Azure Bicep resource api-roles-cosmos-kv using Azure infrastructure.
     Dependencies: ✓ create-provisioning-context, ✓ provision-api-identity, ✓ provision-cosmos-kv
-    Resource: api-roles-cosmos-kv (AzureProvisioningResource)
+    Resource: api-roles-cosmos-kv (AzureRoleAssignmentResource)
     Tags: provision-infra
 
 Step: provision-api-roles-pg-kv
     Description: Provisions the Azure Bicep resource api-roles-pg-kv using Azure infrastructure.
     Dependencies: ✓ create-provisioning-context, ✓ provision-api-identity, ✓ provision-pg-kv
-    Resource: api-roles-pg-kv (AzureProvisioningResource)
+    Resource: api-roles-pg-kv (AzureRoleAssignmentResource)
     Tags: provision-infra
 
 Step: provision-api-website


### PR DESCRIPTION
## Description

Introduces a new public `AzureRoleAssignmentResource` type so callers can inspect role-assignment resources in the application model (e.g. from a pipeline step) and reason about what role assignments target which Azure resource.

Previously, role-assignment resources added by `AzureResourcePreparer` were plain `AzureProvisioningResource` instances, which made it impossible to identify them as role assignments or discover their target/owner without inspecting internal annotations.

The new type exposes:

- **`TargetAzureResource`** — the Azure resource that the roles are assigned on (the scope, e.g. a `KeyVault`, `Storage`, etc.).
- **`OwnerResource`** — the Aspire resource that owns this set of role assignments (the resource on which `WithRoleAssignments(...)` was called). `null` for global role assignments granted to the deployment principal.
- **`IdentityResource`** — the user-assigned managed identity (`AzureUserAssignedIdentityResource`) whose principal receives the role assignments. `null` for global role assignments granted to the deployment principal.

`RoleAssignmentResourceAnnotation` is also tightened to hold the new typed resource. A regression test is added that uses a pipeline step running after `WellKnownPipelineSteps.BeforeStart` to enumerate all `AzureRoleAssignmentResource`s targeting a single Azure resource (a Key Vault).

Fixes # (issue)

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [x] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [x] Yes
      - [ ] No
  - [ ] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
