### PR TITLE
Fix GitHub Models health check export

### DIFF
--- a/src/Aspire.Hosting.GitHub.Models/GitHubModelsExtensions.cs
+++ b/src/Aspire.Hosting.GitHub.Models/GitHubModelsExtensions.cs
@@ -164,6 +164,7 @@ public static class GitHubModelsExtensions
         return builder;
     }
 
+    // The default export id would be "withHealthCheck", which collides with the core Aspire.Hosting IResource health check export.
     /// <summary>
     /// Adds a health check to the GitHub Model resource.
     /// </summary>
@@ -185,7 +186,6 @@ public static class GitHubModelsExtensions
     /// the model is not working as expected. Furthermore, the health check will run a single time per application instance.
     /// </para>
     /// </remarks>
-    // The default export id would be "withHealthCheck", which collides with the core Aspire.Hosting IResource health check export.
     [AspireExport("enableHealthCheck", Description = "Adds a health check for the GitHub Model resource.")]
     public static IResourceBuilder<GitHubModelResource> WithHealthCheck(this IResourceBuilder<GitHubModelResource> builder)
     {

--- a/src/Aspire.Hosting.GitHub.Models/GitHubModelsExtensions.cs
+++ b/src/Aspire.Hosting.GitHub.Models/GitHubModelsExtensions.cs
@@ -185,7 +185,8 @@ public static class GitHubModelsExtensions
     /// the model is not working as expected. Furthermore, the health check will run a single time per application instance.
     /// </para>
     /// </remarks>
-    [AspireExport("enableHealthCheck", MethodName = "withHealthCheck", Description = "Adds a health check for the GitHub Model resource.")]
+    // The default export id would be "withHealthCheck", which collides with the core Aspire.Hosting IResource health check export.
+    [AspireExport("enableHealthCheck", Description = "Adds a health check for the GitHub Model resource.")]
     public static IResourceBuilder<GitHubModelResource> WithHealthCheck(this IResourceBuilder<GitHubModelResource> builder)
     {
         ArgumentNullException.ThrowIfNull(builder);

--- a/tests/PolyglotAppHosts/Aspire.Hosting.GitHub.Models/Go/apphost.go
+++ b/tests/PolyglotAppHosts/Aspire.Hosting.GitHub.Models/Go/apphost.go
@@ -39,7 +39,7 @@ func main() {
 	}
 	githubModel.WithApiKey(apiKey)
 
-	githubModel.WithHealthCheck()
+	githubModel.EnableHealthCheck()
 
 	container := builder.AddContainer("my-service", "mcr.microsoft.com/dotnet/samples:latest")
 	container.WithReference(githubModel)

--- a/tests/PolyglotAppHosts/Aspire.Hosting.GitHub.Models/Java/AppHost.java
+++ b/tests/PolyglotAppHosts/Aspire.Hosting.GitHub.Models/Java/AppHost.java
@@ -13,7 +13,7 @@ void main() throws Exception {
         var apiKey = builder.addParameter("gh-api-key", new AddParameterOptions().secret(true));
         githubModel.withApiKey(apiKey);
         // 4) enableHealthCheck - integration-specific no-args health check
-        githubModel.withHealthCheck();
+        githubModel.enableHealthCheck();
         // 5) withReference - pass GitHubModelResource as a connection string source to a container
         var container = builder.addContainer("my-service", "mcr.microsoft.com/dotnet/samples:latest");
         container.withReference(githubModel, new WithReferenceOptions());

--- a/tests/PolyglotAppHosts/Aspire.Hosting.GitHub.Models/TypeScript/apphost.ts
+++ b/tests/PolyglotAppHosts/Aspire.Hosting.GitHub.Models/TypeScript/apphost.ts
@@ -17,7 +17,7 @@ const apiKey = await builder.addParameter("gh-api-key", { secret: true });
 await githubModel.withApiKey(apiKey);
 
 // 4) enableHealthCheck — integration-specific no-args health check
-await githubModel.withHealthCheck();
+await githubModel.enableHealthCheck();
 
 // 5) withReference — pass GitHubModelResource as a connection string source to a container
 const container = await builder.addContainer("my-service", "mcr.microsoft.com/dotnet/samples:latest");


### PR DESCRIPTION
## Description

GitHub Models' ATS health check export was generating `withHealthCheck`, which collides with the core `Aspire.Hosting/withHealthCheck` resource export during `aspire sdk dump`. This keeps the integration-specific export id as `enableHealthCheck`, removes the custom generated method name that caused the collision, and documents why the explicit id is required.

The GitHub Models polyglot validation AppHosts now call the generated `enableHealthCheck` name in TypeScript, Go, and Java. Python already used `enable_health_check`.

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No