### PR TITLE
Avoid duplicate inherited ATS properties

### DIFF
--- a/src/Aspire.Hosting.RemoteHost/AtsCapabilityScanner.cs
+++ b/src/Aspire.Hosting.RemoteHost/AtsCapabilityScanner.cs
@@ -1409,6 +1409,11 @@ public static class AtsCapabilityScanner
                 continue;
             }
 
+            if (IsInheritedPropertyExportedByBaseType(contextType, property))
+            {
+                continue;
+            }
+
             // Check for [AspireExportIgnore]
             if (HasExportIgnoreAttribute(property))
             {
@@ -1762,6 +1767,38 @@ public static class AtsCapabilityScanner
             Methods = methods,
             Properties = properties
         };
+    }
+
+    private static bool IsInheritedPropertyExportedByBaseType(Type contextType, PropertyInfo property)
+    {
+        var declaringType = property.DeclaringType;
+        if (declaringType is null || declaringType == contextType)
+        {
+            return false;
+        }
+
+        var memberExportAttr = GetAspireExportAttribute(property);
+        var isPublic = property.GetMethod?.IsPublic == true;
+
+        for (var baseType = contextType.BaseType; baseType is not null; baseType = baseType.BaseType)
+        {
+            if (!declaringType.IsAssignableFrom(baseType))
+            {
+                continue;
+            }
+
+            var exposeAllProperties = HasExposePropertiesAttribute(baseType);
+            var baseTypeScansMembers =
+                exposeAllProperties ||
+                HasExposeMethodsAttribute(baseType) ||
+                GetAspireExportAttribute(baseType) is not null;
+            if (baseTypeScansMembers && ShouldExportMember(isPublic, exposeAllProperties, memberExportAttr))
+            {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     private static AtsCapabilityInfo? CreateCapabilityInfo(

--- a/tests/Aspire.Hosting.RemoteHost.Tests/AtsCapabilityScannerTests.cs
+++ b/tests/Aspire.Hosting.RemoteHost.Tests/AtsCapabilityScannerTests.cs
@@ -348,6 +348,25 @@ public class AtsCapabilityScannerTests
         Assert.DoesNotContain(dto.Properties, p => p.Name == nameof(HttpCommandOptions.GetCommandResult));
     }
 
+    [Fact]
+    public void ScanAssembly_DerivedExportedType_DoesNotRegenerateInheritedProperties()
+    {
+        var result = AtsCapabilityScanner.ScanAssembly(typeof(AtsCapabilityScannerTests).Assembly);
+
+        var baseNameCapability = Assert.Single(result.Capabilities,
+            c => c.CapabilityId.EndsWith("/BaseExportedProperties.name", StringComparison.Ordinal));
+
+        Assert.Contains(baseNameCapability.ExpandedTargetTypes,
+            t => t.TypeId == AtsTypeMapping.DeriveTypeId(typeof(DerivedExportedProperties)));
+        Assert.Contains(result.Capabilities,
+            c => c.CapabilityId.EndsWith("/DerivedExportedProperties.framework", StringComparison.Ordinal));
+        Assert.DoesNotContain(result.Capabilities,
+            c => c.CapabilityId.EndsWith("/DerivedExportedProperties.name", StringComparison.Ordinal));
+        Assert.DoesNotContain(result.Diagnostics,
+            d => d.Message.Contains(nameof(DerivedExportedProperties), StringComparison.Ordinal)
+                && d.Message.Contains("has collisions", StringComparison.Ordinal));
+    }
+
     #endregion
 
     #region Callback Parameter Type Resolution Tests
@@ -531,6 +550,18 @@ public class AtsCapabilityScannerTests
         public TestResource(string name) : base(name)
         {
         }
+    }
+
+    [AspireExport(ExposeProperties = true)]
+    private class BaseExportedProperties
+    {
+        public string Name { get; } = "";
+    }
+
+    [AspireExport(ExposeProperties = true)]
+    private sealed class DerivedExportedProperties : BaseExportedProperties
+    {
+        public string Framework { get; } = "";
     }
 
     public sealed class AssemblyLevelExportedTestType


### PR DESCRIPTION
## Description

The ATS scanner was regenerating inherited property getter capabilities for exported derived types even when an exported base type already exposed those properties. After target expansion this produced duplicate SDK method names like `JavaScriptAppResource.command` and `NextJsAppResource.command` on `NextJsAppResource`, causing `sdk dump` collision warnings.

This change skips inherited properties that will already be emitted by an exported base type, while preserving inherited property exposure from unexported bases such as `Resource.Name`. It also adds a regression test for exported base and derived property scanning.

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
