### PR TITLE
Support named resource command options

### DIFF
--- a/src/Aspire.Cli/Commands/GroupedHelpWriter.cs
+++ b/src/Aspire.Cli/Commands/GroupedHelpWriter.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.CommandLine;
+using System.CommandLine.Help;
 using Aspire.Cli.Resources;
 
 namespace Aspire.Cli.Commands;
@@ -42,9 +43,7 @@ internal static class GroupedHelpWriter
         }
 
         // Usage
-        writer.WriteLine(HelpGroupStrings.Usage);
-        writer.WriteLine(GetIndent() + HelpGroupStrings.UsageSyntax);
-        writer.WriteLine();
+        WriteUsage(writer, HelpGroupStrings.UsageSyntax);
 
         // Collect visible subcommands and organize by group.
         var grouped = new Dictionary<HelpGroup, List<BaseCommand>>();
@@ -143,32 +142,48 @@ internal static class GroupedHelpWriter
         var visibleOptions = command.Options.Where(o => !o.Hidden).ToList();
         if (visibleOptions.Count > 0)
         {
-            writer.WriteLine(HelpGroupStrings.Options);
-
-            var optionColumnWidth = 0;
-            foreach (var opt in visibleOptions)
-            {
-                var label = FormatOptionLabel(opt);
-                if (label.Length > optionColumnWidth)
-                {
-                    optionColumnWidth = label.Length;
-                }
-            }
-
-            optionColumnWidth += 4;
-
-            foreach (var opt in visibleOptions)
-            {
-                var label = FormatOptionLabel(opt);
-                var desc = opt.Description ?? string.Empty;
-                WriteTwoColumnRow(writer, label, desc, optionColumnWidth, width);
-            }
-
-            writer.WriteLine();
+            WriteTwoColumnSection(
+                writer,
+                HelpGroupStrings.Options,
+                visibleOptions.Select(static opt => (FormatOptionLabel(opt), opt.Description ?? string.Empty)),
+                width);
         }
 
         // Help hint
         writer.WriteLine(HelpGroupStrings.HelpHint);
+    }
+
+    internal static void WriteUsage(TextWriter writer, params string[] usages)
+    {
+        writer.WriteLine(HelpGroupStrings.Usage);
+        foreach (var usage in usages)
+        {
+            writer.WriteLine(GetIndent() + usage);
+        }
+
+        writer.WriteLine();
+    }
+
+    internal static void WriteTwoColumnSection(TextWriter writer, string heading, IEnumerable<(string Label, string Description)> rows, int maxWidth, bool trailingBlankLine = true)
+    {
+        var rowArray = rows.ToArray();
+        if (rowArray.Length == 0)
+        {
+            return;
+        }
+
+        writer.WriteLine(heading);
+
+        var columnWidth = rowArray.Max(static row => row.Label.Length) + 4;
+        foreach (var (label, description) in rowArray)
+        {
+            WriteTwoColumnRow(writer, label, description, columnWidth, maxWidth);
+        }
+
+        if (trailingBlankLine)
+        {
+            writer.WriteLine();
+        }
     }
 
     private static void WriteGroup(TextWriter writer, string heading, List<BaseCommand> commands, int columnWidth, int width)
@@ -287,7 +302,7 @@ internal static class GroupedHelpWriter
         return string.Join(" ", parts);
     }
 
-    private static string FormatOptionLabel(Option option)
+    internal static string FormatOptionLabel(Option option, bool includeValueName = false)
     {
         // Collect all identifiers: Name may not be in Aliases in System.CommandLine 2.0.
         var allNames = new HashSet<string>(option.Aliases, StringComparer.Ordinal);
@@ -296,9 +311,23 @@ internal static class GroupedHelpWriter
             allNames.Add(option.Name);
         }
 
-        var sorted = allNames.OrderBy(a => a.Length).ToList();
-        return sorted.Count > 1
-            ? $"{sorted[0]}, {sorted[1]}"
-            : sorted.Count > 0 ? sorted[0] : option.Name;
+        var label = string.Join(", ", allNames.OrderBy(a => a.Length).ThenBy(a => a, StringComparer.Ordinal));
+        return includeValueName && !IsBooleanOption(option)
+            ? $"{label} <{GetOptionValueName(option)}>"
+            : label;
+    }
+
+    private static bool IsBooleanOption(Option option)
+    {
+        return option is Option<bool> or HelpOption;
+    }
+
+    private static string GetOptionValueName(Option option)
+    {
+        var longName = option.Name.StartsWith("--", StringComparison.Ordinal)
+            ? option.Name
+            : option.Aliases.FirstOrDefault(static alias => alias.StartsWith("--", StringComparison.Ordinal)) ?? option.Name;
+
+        return longName.TrimStart('-');
     }
 }

--- a/src/Aspire.Cli/Commands/ResourceCommand.cs
+++ b/src/Aspire.Cli/Commands/ResourceCommand.cs
@@ -140,6 +140,8 @@ internal sealed class ResourceCommand : BaseCommand
 
     private static (JsonNode? Arguments, string? ErrorMessage) CreateCommandArguments(ResourceSnapshotCommand? command, string[] capturedArguments)
     {
+        capturedArguments = RemoveDelimiter(capturedArguments);
+
         if (capturedArguments.Length == 0)
         {
             if (command?.ArgumentInputs is { Length: > 0 } inputs)
@@ -176,25 +178,30 @@ internal sealed class ResourceCommand : BaseCommand
             parserCommand.Options.Add(option);
         }
 
+        parserCommand.Validators.Add(result =>
+        {
+            var missingRequiredOptions = argumentInputs
+                .Where(argument => argument.Required && string.IsNullOrEmpty(argument.Value) && result.GetResult(options[argument]) is not { Implicit: false })
+                .Select(argument => $"--{ToKebabCase(argument.Name)}")
+                .ToArray();
+
+            if (missingRequiredOptions.Length == 1)
+            {
+                result.AddError($"Required option '{missingRequiredOptions[0]}' was not provided.");
+            }
+            else if (missingRequiredOptions.Length > 1)
+            {
+                result.AddError($"Required options were not provided: {string.Join(", ", missingRequiredOptions.Select(static optionName => $"'{optionName}'"))}.");
+            }
+        });
+
         // Parse the resource command tail with System.CommandLine as a second pass. The first pass parses Aspire CLI
         // options and leaves resource command tokens in ParseResult.UnmatchedTokens; this pass parses those remaining
         // tokens against options generated from ResourceSnapshotCommand.ArgumentInputs.
-        var parseResult = parserCommand.Parse(RemoveDelimiter(capturedArguments));
+        var parseResult = parserCommand.Parse(capturedArguments);
         if (parseResult.Errors.Count > 0)
         {
             return (arguments, string.Join(Environment.NewLine, parseResult.Errors.Select(static error => error.Message)));
-        }
-
-        var missingRequiredOptions = argumentInputs
-            .Where(argument => argument.Required && string.IsNullOrEmpty(argument.Value) && parseResult.GetResult(options[argument]) is not { Implicit: false })
-            .Select(argument => $"--{ToKebabCase(argument.Name)}")
-            .ToArray();
-        if (missingRequiredOptions.Length > 0)
-        {
-            var message = missingRequiredOptions.Length == 1
-                ? $"Required option '{missingRequiredOptions[0]}' was not provided."
-                : $"Required options were not provided: {string.Join(", ", missingRequiredOptions.Select(static optionName => $"'{optionName}'"))}.";
-            return (arguments, message);
         }
 
         foreach (var argument in argumentInputs)
@@ -233,9 +240,12 @@ internal sealed class ResourceCommand : BaseCommand
 
     private static string[] RemoveDelimiter(string[] capturedArguments)
     {
-        return capturedArguments.Contains("--", StringComparer.Ordinal)
-            ? capturedArguments.Where(static argument => argument is not "--").ToArray()
-            : capturedArguments;
+        if (capturedArguments.Length == 0 || capturedArguments[0] is not "--")
+        {
+            return capturedArguments;
+        }
+
+        return capturedArguments[1..];
     }
 
     private static JsonObject CreateUnknownArguments(string[] capturedArguments)
@@ -243,11 +253,6 @@ internal sealed class ResourceCommand : BaseCommand
         var arguments = new JsonObject();
         foreach (var token in capturedArguments)
         {
-            if (token is "--")
-            {
-                continue;
-            }
-
             arguments[token] = null;
         }
 

--- a/src/Aspire.Cli/Commands/ResourceCommand.cs
+++ b/src/Aspire.Cli/Commands/ResourceCommand.cs
@@ -2,7 +2,11 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.CommandLine;
+using System.CommandLine.Help;
+using System.CommandLine.Invocation;
+using System.CommandLine.Parsing;
 using System.Globalization;
+using System.Text;
 using System.Text.Json.Nodes;
 using Aspire.Cli.Backchannel;
 using Aspire.Cli.Configuration;
@@ -64,6 +68,7 @@ internal sealed class ResourceCommand : BaseCommand
         Arguments.Add(s_resourceArgument);
         Arguments.Add(s_commandArgument);
         Options.Add(s_appHostOption);
+        Options.Add(new HelpOption { Action = new ResourceCommandHelpAction(this) });
         TreatUnmatchedTokensAsErrors = false;
     }
 
@@ -87,9 +92,15 @@ internal sealed class ResourceCommand : BaseCommand
         }
 
         var connection = result.Connection!;
-        var commandArguments = capturedArguments.Length > 0
-            ? new JsonArray(capturedArguments.Select(static argument => (JsonNode?)JsonValue.Create(argument)).ToArray())
-            : null;
+        var command = await GetCommandMetadataAsync(connection, resourceName, commandName, includeHidden: false, cancellationToken).ConfigureAwait(false);
+        var commandArgumentsResult = CreateCommandArguments(command, capturedArguments);
+        if (commandArgumentsResult.ErrorMessage is { } errorMessage)
+        {
+            _interactionService.DisplayError(errorMessage);
+            return ExitCodeConstants.InvalidCommand;
+        }
+
+        var commandArguments = commandArgumentsResult.Arguments;
 
         // Map well-known friendly names (start/stop/restart) to their display metadata
         if (s_wellKnownCommands.TryGetValue(commandName, out var knownCommand))
@@ -117,4 +128,381 @@ internal sealed class ResourceCommand : BaseCommand
             cancellationToken);
     }
 
+    private static async Task<ResourceSnapshotCommand?> GetCommandMetadataAsync(IAppHostAuxiliaryBackchannel connection, string resourceName, string commandName, bool includeHidden, CancellationToken cancellationToken)
+    {
+        var snapshots = await connection.GetResourceSnapshotsAsync(includeHidden, cancellationToken).ConfigureAwait(false);
+        var resources = ResourceSnapshotMapper.ResolveResources(resourceName, snapshots);
+
+        return resources
+            .SelectMany(static resource => resource.Commands)
+            .FirstOrDefault(command => string.Equals(command.Name, commandName, StringComparison.OrdinalIgnoreCase));
+    }
+
+    private static (JsonNode? Arguments, string? ErrorMessage) CreateCommandArguments(ResourceSnapshotCommand? command, string[] capturedArguments)
+    {
+        if (capturedArguments.Length == 0)
+        {
+            if (command?.ArgumentInputs is { Length: > 0 } inputs)
+            {
+                return CreateCommandArguments(inputs, capturedArguments);
+            }
+
+            return (null, null);
+        }
+
+        if (command?.ArgumentInputs is not { Length: > 0 } argumentInputs)
+        {
+            // Without command metadata there are no options to give System.CommandLine, so do not infer any values.
+            // Forward tokens as unknown names and let hosting-side validation reject them.
+            return (CreateUnknownArguments(capturedArguments), null);
+        }
+
+        return CreateCommandArguments(argumentInputs, capturedArguments);
+    }
+
+    private static (JsonObject Arguments, string? ErrorMessage) CreateCommandArguments(ResourceSnapshotCommandArgument[] argumentInputs, string[] capturedArguments)
+    {
+        var arguments = new JsonObject();
+        var options = new Dictionary<ResourceSnapshotCommandArgument, Option>();
+        var parserCommand = new Command("resource-command")
+        {
+            TreatUnmatchedTokensAsErrors = true
+        };
+
+        foreach (var argument in argumentInputs)
+        {
+            var option = CreateCommandArgumentOption(argument);
+            options.Add(argument, option);
+            parserCommand.Options.Add(option);
+        }
+
+        // Parse the resource command tail with System.CommandLine as a second pass. The first pass parses Aspire CLI
+        // options and leaves resource command tokens in ParseResult.UnmatchedTokens; this pass parses those remaining
+        // tokens against options generated from ResourceSnapshotCommand.ArgumentInputs.
+        var parseResult = parserCommand.Parse(capturedArguments);
+        if (parseResult.Errors.Count > 0)
+        {
+            return (arguments, string.Join(Environment.NewLine, parseResult.Errors.Select(static error => error.Message)));
+        }
+
+        var missingRequiredOptions = argumentInputs
+            .Where(argument => argument.Required && argument.Value is null && parseResult.GetResult(options[argument]) is not { Implicit: false })
+            .Select(argument => $"--{ToKebabCase(argument.Name)}")
+            .ToArray();
+        if (missingRequiredOptions.Length > 0)
+        {
+            var message = missingRequiredOptions.Length == 1
+                ? $"Required option '{missingRequiredOptions[0]}' was not provided."
+                : $"Required options were not provided: {string.Join(", ", missingRequiredOptions.Select(static optionName => $"'{optionName}'"))}.";
+            return (arguments, message);
+        }
+
+        foreach (var argument in argumentInputs)
+        {
+            var option = options[argument];
+            if (parseResult.GetResult(option) is not { Implicit: false })
+            {
+                continue;
+            }
+
+            if (option is Option<bool> boolOption)
+            {
+                arguments[argument.Name] = parseResult.GetValue(boolOption).ToString().ToLowerInvariant();
+            }
+            else if (option is Option<double?> numberOption)
+            {
+                var value = parseResult.GetValue(numberOption);
+                arguments[argument.Name] = value?.ToString(CultureInfo.InvariantCulture);
+            }
+            else if (option is Option<string?> stringOption)
+            {
+                arguments[argument.Name] = parseResult.GetValue(stringOption);
+            }
+        }
+
+        foreach (var unmatchedToken in parseResult.UnmatchedTokens)
+        {
+            // Metadata-backed command inputs are options only. Any leftover token is forwarded as an unknown argument
+            // name so hosting-side validation reports it instead of binding it positionally.
+            // Example: `#name` becomes `{ "#name": null }`, which is not a declared command input.
+            arguments[unmatchedToken] = null;
+        }
+
+        return (arguments, null);
+    }
+
+    private static JsonObject CreateUnknownArguments(string[] capturedArguments)
+    {
+        var arguments = new JsonObject();
+        foreach (var token in capturedArguments)
+        {
+            if (token is "--")
+            {
+                continue;
+            }
+
+            arguments[token] = null;
+        }
+
+        return arguments;
+    }
+
+    private static Option CreateCommandArgumentOption(ResourceSnapshotCommandArgument argument)
+    {
+        // Resource command input names are exposed as both exact-name and kebab-case System.CommandLine options:
+        // - "timeoutMilliseconds" accepts "--timeoutMilliseconds" and "--timeout-milliseconds"
+        // - "LogLevel" accepts "--LogLevel" and "--log-level"
+        // - "url" accepts "--url"
+        var optionName = ToKebabCase(argument.Name);
+        Option option = (IsBooleanInput(argument), IsNumberInput(argument)) switch
+        {
+            (true, _) => new Option<bool>($"--{optionName}")
+            {
+                DefaultValueFactory = _ => bool.TryParse(argument.Value, out var value) && value
+            },
+            (_, true) => new Option<double?>($"--{optionName}")
+            {
+                Arity = ArgumentArity.ExactlyOne,
+                AllowMultipleArgumentsPerToken = false,
+                DefaultValueFactory = _ => double.TryParse(argument.Value, CultureInfo.InvariantCulture, out var value) ? value : null
+            },
+            _ => new Option<string?>($"--{optionName}")
+            {
+                Arity = ArgumentArity.ExactlyOne,
+                AllowMultipleArgumentsPerToken = false,
+                DefaultValueFactory = _ => argument.Value
+            }
+        };
+
+        if (option is Option<bool> boolOption)
+        {
+            boolOption.Arity = ArgumentArity.ZeroOrOne;
+            boolOption.AllowMultipleArgumentsPerToken = false;
+        }
+
+        option.Description = argument.Description ?? argument.Label;
+        option.Required = argument.Required && argument.Value is null;
+
+        if (!argument.AllowCustomChoice && argument.Options is { Count: > 0 } options)
+        {
+            option.Validators.Add(result =>
+            {
+                var value = result.GetValueOrDefault<string?>();
+                if (value is not null && !options.ContainsKey(value))
+                {
+                    result.AddError($"Option '--{optionName}' only accepts the following values: {string.Join(", ", options.Keys)}.");
+                }
+            });
+        }
+
+        var exactName = $"--{argument.Name}";
+        if (!string.Equals(exactName, $"--{optionName}", StringComparison.Ordinal))
+        {
+            option.Aliases.Add(exactName);
+        }
+
+        return option;
+    }
+
+    private static bool IsBooleanInput(ResourceSnapshotCommandArgument argument)
+    {
+        return string.Equals(argument.InputType, "Boolean", StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static bool IsNumberInput(ResourceSnapshotCommandArgument argument)
+    {
+        return string.Equals(argument.InputType, "Number", StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static string ToKebabCase(string value)
+    {
+        if (string.IsNullOrEmpty(value))
+        {
+            return value;
+        }
+
+        var builder = new StringBuilder(value.Length + 4);
+        for (var i = 0; i < value.Length; i++)
+        {
+            var ch = value[i];
+            if (char.IsUpper(ch))
+            {
+                if (i > 0 && builder[^1] != '-')
+                {
+                    builder.Append('-');
+                }
+
+                builder.Append(char.ToLowerInvariant(ch));
+            }
+            else
+            {
+                builder.Append(ch);
+            }
+        }
+
+        return builder.ToString();
+    }
+
+    private sealed class ResourceCommandHelpAction(ResourceCommand command) : AsynchronousCommandLineAction
+    {
+        private readonly HelpAction _defaultHelpAction = new();
+
+        public override async Task<int> InvokeAsync(ParseResult parseResult, CancellationToken cancellationToken)
+        {
+            var request = ResourceCommandHelpParser.Parse(parseResult, s_resourceArgument, s_commandArgument, s_appHostOption);
+            if (request is null)
+            {
+                return _defaultHelpAction.Invoke(parseResult);
+            }
+
+            var result = await command._connectionResolver.ResolveConnectionAsync(
+                request.AppHostProjectFile,
+                SharedCommandStrings.ScanningForRunningAppHosts,
+                string.Format(CultureInfo.CurrentCulture, SharedCommandStrings.SelectAppHost, ResourceCommandStrings.SelectAppHostAction),
+                SharedCommandStrings.AppHostNotRunning,
+                cancellationToken).ConfigureAwait(false);
+
+            if (!result.Success)
+            {
+                return _defaultHelpAction.Invoke(parseResult);
+            }
+
+            var resourceCommand = await GetCommandMetadataAsync(result.Connection!, request.ResourceName, request.CommandName, includeHidden: false, cancellationToken).ConfigureAwait(false);
+            if (resourceCommand is null)
+            {
+                return _defaultHelpAction.Invoke(parseResult);
+            }
+
+            WriteResourceCommandHelp(parseResult.InvocationConfiguration.Output, parseResult.CommandResult, request.ResourceName, resourceCommand);
+            return ExitCodeConstants.Success;
+        }
+
+        private static void WriteResourceCommandHelp(TextWriter writer, CommandResult commandResult, string resourceName, ResourceSnapshotCommand command)
+        {
+            var cliOptionNames = GetCliOptionNames(commandResult);
+
+            writer.WriteLine(command.Description is { Length: > 0 } ? command.Description : command.DisplayName ?? command.Name);
+            writer.WriteLine();
+            writer.WriteLine("Usage:");
+            writer.WriteLine($"  aspire resource {resourceName} {command.Name} [command-options] [options]");
+            writer.WriteLine($"  aspire resource {resourceName} {command.Name} -- [command-options]");
+
+            if (command.ArgumentInputs.Length > 0)
+            {
+                writer.WriteLine();
+                writer.WriteLine("Command options:");
+                foreach (var argument in command.ArgumentInputs)
+                {
+                    var optionName = ToKebabCase(argument.Name);
+                    writer.Write("  --");
+                    writer.Write(optionName);
+                    if (!IsBooleanInput(argument))
+                    {
+                        writer.Write(" <value>");
+                    }
+
+                    var description = GetArgumentDescription(argument);
+                    if (description.Length > 0)
+                    {
+                        writer.Write("  ");
+                        writer.Write(description);
+                    }
+
+                    if (cliOptionNames.Contains(optionName))
+                    {
+                        writer.Write(" Use `-- --");
+                        writer.Write(optionName);
+                        if (!IsBooleanInput(argument))
+                        {
+                            writer.Write(" <value>");
+                        }
+
+                        writer.Write("` to pass this command option.");
+                    }
+
+                    writer.WriteLine();
+                }
+            }
+
+            writer.WriteLine();
+            writer.WriteLine("Options:");
+            writer.WriteLine($"  {s_appHostOption.Name} <apphost>  {s_appHostOption.InnerOption.Description}");
+            writer.WriteLine("  -?, -h, --help       Show help and usage information");
+        }
+
+        private static HashSet<string> GetCliOptionNames(CommandResult commandResult)
+        {
+            var names = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
+            AddOptionNames(commandResult.Command.Options, includeOnlyRecursive: false, names);
+
+            var current = commandResult.Parent;
+            while (current is CommandResult parentCommandResult)
+            {
+                AddOptionNames(parentCommandResult.Command.Options, includeOnlyRecursive: true, names);
+                current = parentCommandResult.Parent;
+            }
+
+            return names;
+        }
+
+        private static void AddOptionNames(IEnumerable<Option> options, bool includeOnlyRecursive, HashSet<string> names)
+        {
+            foreach (var option in options)
+            {
+                if (includeOnlyRecursive && !option.Recursive)
+                {
+                    continue;
+                }
+
+                AddLongOptionName(option.Name, names);
+                foreach (var alias in option.Aliases)
+                {
+                    AddLongOptionName(alias, names);
+                }
+            }
+        }
+
+        private static void AddLongOptionName(string optionName, HashSet<string> names)
+        {
+            if (optionName.StartsWith("--", StringComparison.Ordinal))
+            {
+                names.Add(optionName[2..]);
+            }
+            else if (!optionName.StartsWith("-", StringComparison.Ordinal))
+            {
+                names.Add(optionName);
+            }
+        }
+
+        private static string GetArgumentDescription(ResourceSnapshotCommandArgument argument)
+        {
+            var parts = new List<string>();
+            if (argument.Description is { Length: > 0 })
+            {
+                parts.Add(argument.Description);
+            }
+            else if (argument.Label is { Length: > 0 })
+            {
+                parts.Add(argument.Label);
+            }
+
+            if (argument.Required)
+            {
+                parts.Add("Required.");
+            }
+
+            if (argument.Options is { Count: > 0 } options)
+            {
+                parts.Add($"Allowed values: {string.Join(", ", options.Keys)}.");
+            }
+
+            if (argument.Value is { Length: > 0 } value)
+            {
+                parts.Add($"Default: {value}.");
+            }
+
+            return string.Join(" ", parts);
+        }
+    }
 }

--- a/src/Aspire.Cli/Commands/ResourceCommand.cs
+++ b/src/Aspire.Cli/Commands/ResourceCommand.cs
@@ -179,14 +179,14 @@ internal sealed class ResourceCommand : BaseCommand
         // Parse the resource command tail with System.CommandLine as a second pass. The first pass parses Aspire CLI
         // options and leaves resource command tokens in ParseResult.UnmatchedTokens; this pass parses those remaining
         // tokens against options generated from ResourceSnapshotCommand.ArgumentInputs.
-        var parseResult = parserCommand.Parse(capturedArguments);
+        var parseResult = parserCommand.Parse(RemoveDelimiter(capturedArguments));
         if (parseResult.Errors.Count > 0)
         {
             return (arguments, string.Join(Environment.NewLine, parseResult.Errors.Select(static error => error.Message)));
         }
 
         var missingRequiredOptions = argumentInputs
-            .Where(argument => argument.Required && argument.Value is null && parseResult.GetResult(options[argument]) is not { Implicit: false })
+            .Where(argument => argument.Required && string.IsNullOrEmpty(argument.Value) && parseResult.GetResult(options[argument]) is not { Implicit: false })
             .Select(argument => $"--{ToKebabCase(argument.Name)}")
             .ToArray();
         if (missingRequiredOptions.Length > 0)
@@ -229,6 +229,13 @@ internal sealed class ResourceCommand : BaseCommand
         }
 
         return (arguments, null);
+    }
+
+    private static string[] RemoveDelimiter(string[] capturedArguments)
+    {
+        return capturedArguments.Contains("--", StringComparer.Ordinal)
+            ? capturedArguments.Where(static argument => argument is not "--").ToArray()
+            : capturedArguments;
     }
 
     private static JsonObject CreateUnknownArguments(string[] capturedArguments)
@@ -281,7 +288,7 @@ internal sealed class ResourceCommand : BaseCommand
         }
 
         option.Description = argument.Description ?? argument.Label;
-        option.Required = argument.Required && argument.Value is null;
+        option.Required = argument.Required && string.IsNullOrEmpty(argument.Value);
 
         if (!argument.AllowCustomChoice && argument.Options is { Count: > 0 } options)
         {
@@ -426,8 +433,76 @@ internal sealed class ResourceCommand : BaseCommand
 
             writer.WriteLine();
             writer.WriteLine("Options:");
-            writer.WriteLine($"  {s_appHostOption.Name} <apphost>  {s_appHostOption.InnerOption.Description}");
-            writer.WriteLine("  -?, -h, --help       Show help and usage information");
+            foreach (var option in GetVisibleCliOptions(commandResult))
+            {
+                var description = option.Description ?? string.Empty;
+                writer.Write("  ");
+                writer.Write(GetOptionUsage(option));
+                if (description.Length > 0)
+                {
+                    writer.Write("  ");
+                    writer.Write(description);
+                }
+
+                writer.WriteLine();
+            }
+        }
+
+        private static IEnumerable<Option> GetVisibleCliOptions(CommandResult commandResult)
+        {
+            var seenOptionNames = new HashSet<string>(StringComparer.Ordinal);
+
+            foreach (var option in commandResult.Command.Options)
+            {
+                if (!option.Hidden && seenOptionNames.Add(option.Name))
+                {
+                    yield return option;
+                }
+            }
+
+            var current = commandResult.Parent;
+            while (current is CommandResult parentCommandResult)
+            {
+                foreach (var option in parentCommandResult.Command.Options)
+                {
+                    if (option.Recursive && !option.Hidden && seenOptionNames.Add(option.Name))
+                    {
+                        yield return option;
+                    }
+                }
+
+                current = parentCommandResult.Parent;
+            }
+        }
+
+        private static string GetOptionUsage(Option option)
+        {
+            var names = GetDisplayOptionNames(option);
+            var suffix = IsBooleanOption(option) ? string.Empty : $" <{GetOptionValueName(option)}>";
+
+            return $"{string.Join(", ", names)}{suffix}";
+        }
+
+        private static string[] GetDisplayOptionNames(Option option)
+        {
+            return option.Aliases
+                .Prepend(option.Name)
+                .Where(static name => name.StartsWith("-", StringComparison.Ordinal))
+                .Distinct(StringComparer.Ordinal)
+                .OrderBy(static name => name.StartsWith("--", StringComparison.Ordinal) ? 1 : 0)
+                .ThenBy(static name => name, StringComparer.Ordinal)
+                .ToArray();
+        }
+
+        private static bool IsBooleanOption(Option option)
+        {
+            return option is Option<bool> or HelpOption;
+        }
+
+        private static string GetOptionValueName(Option option)
+        {
+            var name = GetDisplayOptionNames(option).Last(static name => name.StartsWith("--", StringComparison.Ordinal));
+            return name[2..];
         }
 
         private static HashSet<string> GetCliOptionNames(CommandResult commandResult)
@@ -487,7 +562,7 @@ internal sealed class ResourceCommand : BaseCommand
                 parts.Add(argument.Label);
             }
 
-            if (argument.Required)
+            if (argument.Required && string.IsNullOrEmpty(argument.Value))
             {
                 parts.Add("Required.");
             }

--- a/src/Aspire.Cli/Commands/ResourceCommand.cs
+++ b/src/Aspire.Cli/Commands/ResourceCommand.cs
@@ -29,12 +29,16 @@ internal sealed class ResourceCommand : BaseCommand
 
     private static readonly Argument<string> s_resourceArgument = new("resource")
     {
-        Description = ResourceCommandStrings.CommandResourceArgumentDescription
+        Description = ResourceCommandStrings.CommandResourceArgumentDescription,
+        Arity = ArgumentArity.ExactlyOne,
+        DefaultValueFactory = _ => string.Empty
     };
 
     private static readonly Argument<string> s_commandArgument = new("command")
     {
-        Description = ResourceCommandStrings.CommandNameArgumentDescription
+        Description = ResourceCommandStrings.CommandNameArgumentDescription,
+        Arity = ArgumentArity.ExactlyOne,
+        DefaultValueFactory = _ => string.Empty
     };
 
     private static readonly OptionWithLegacy<FileInfo?> s_appHostOption = new("--apphost", "--project", SharedCommandStrings.AppHostOptionDescription);
@@ -43,7 +47,7 @@ internal sealed class ResourceCommand : BaseCommand
     /// Well-known commands with their display metadata.
     /// The command name is used directly (no mapping needed since the user-facing names match the actual command names).
     /// </summary>
-    private static readonly Dictionary<string, (string ProgressVerb, string BaseVerb, string PastTenseVerb)> s_wellKnownCommands = new(StringComparer.OrdinalIgnoreCase)
+    private static readonly Dictionary<string, (string ProgressVerb, string BaseVerb, string PastTenseVerb)> s_wellKnownCommands = new(StringComparers.CommandName)
     {
         ["start"] = ("Starting", "start", "started"),
         ["stop"] = ("Stopping", "stop", "stopped"),
@@ -70,6 +74,22 @@ internal sealed class ResourceCommand : BaseCommand
         Options.Add(s_appHostOption);
         Options.Add(new HelpOption { Action = new ResourceCommandHelpAction(this) });
         TreatUnmatchedTokensAsErrors = false;
+
+        Validators.Add(result =>
+        {
+            var resourceName = result.GetValue(s_resourceArgument);
+            if (string.IsNullOrEmpty(resourceName))
+            {
+                result.AddError("The 'resource' argument is required.");
+                return;
+            }
+
+            var commandName = result.GetValue(s_commandArgument);
+            if (string.IsNullOrEmpty(commandName))
+            {
+                result.AddError("The 'command' argument is required.");
+            }
+        });
     }
 
     protected override async Task<int> ExecuteAsync(ParseResult parseResult, CancellationToken cancellationToken)
@@ -135,7 +155,7 @@ internal sealed class ResourceCommand : BaseCommand
 
         return resources
             .SelectMany(static resource => resource.Commands)
-            .FirstOrDefault(command => string.Equals(command.Name, commandName, StringComparison.OrdinalIgnoreCase));
+            .FirstOrDefault(command => string.Equals(command.Name, commandName, StringComparisons.CommandName));
     }
 
     private static (JsonNode? Arguments, string? ErrorMessage) CreateCommandArguments(ResourceSnapshotCommand? command, string[] capturedArguments)

--- a/src/Aspire.Cli/Commands/ResourceCommand.cs
+++ b/src/Aspire.Cli/Commands/ResourceCommand.cs
@@ -78,14 +78,14 @@ internal sealed class ResourceCommand : BaseCommand
         Validators.Add(result =>
         {
             var resourceName = result.GetValue(s_resourceArgument);
-            if (string.IsNullOrEmpty(resourceName))
+            if (string.IsNullOrEmpty(resourceName) || IsOptionLikeToken(resourceName))
             {
                 result.AddError("The 'resource' argument is required.");
                 return;
             }
 
             var commandName = result.GetValue(s_commandArgument);
-            if (string.IsNullOrEmpty(commandName))
+            if (string.IsNullOrEmpty(commandName) || IsOptionLikeToken(commandName))
             {
                 result.AddError("The 'command' argument is required.");
             }
@@ -344,6 +344,11 @@ internal sealed class ResourceCommand : BaseCommand
     private static bool IsNumberInput(ResourceSnapshotCommandArgument argument)
     {
         return string.Equals(argument.InputType, "Number", StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static bool IsOptionLikeToken(string value)
+    {
+        return value.StartsWith("-", StringComparison.Ordinal);
     }
 
     private static string ToKebabCase(string value)

--- a/src/Aspire.Cli/Commands/ResourceCommand.cs
+++ b/src/Aspire.Cli/Commands/ResourceCommand.cs
@@ -80,14 +80,14 @@ internal sealed class ResourceCommand : BaseCommand
             var resourceName = result.GetValue(s_resourceArgument);
             if (string.IsNullOrEmpty(resourceName) || IsOptionLikeToken(resourceName))
             {
-                result.AddError("The 'resource' argument is required.");
+                result.AddError(string.Format(CultureInfo.CurrentCulture, ResourceCommandStrings.ArgumentRequired, s_resourceArgument.Name));
                 return;
             }
 
             var commandName = result.GetValue(s_commandArgument);
             if (string.IsNullOrEmpty(commandName) || IsOptionLikeToken(commandName))
             {
-                result.AddError("The 'command' argument is required.");
+                result.AddError(string.Format(CultureInfo.CurrentCulture, ResourceCommandStrings.ArgumentRequired, s_commandArgument.Name));
             }
         });
     }

--- a/src/Aspire.Cli/Commands/ResourceCommand.cs
+++ b/src/Aspire.Cli/Commands/ResourceCommand.cs
@@ -221,6 +221,12 @@ internal sealed class ResourceCommand : BaseCommand
         var parseResult = parserCommand.Parse(capturedArguments);
         if (parseResult.Errors.Count > 0)
         {
+            var unrecognizedCommandOptions = GroupUnrecognizedCommandOptions(parseResult.UnmatchedTokens);
+            if (unrecognizedCommandOptions.Length > 0)
+            {
+                return (arguments, FormatUnrecognizedCommandOptions(unrecognizedCommandOptions));
+            }
+
             return (arguments, string.Join(Environment.NewLine, parseResult.Errors.Select(static error => error.Message)));
         }
 
@@ -271,7 +277,7 @@ internal sealed class ResourceCommand : BaseCommand
     private static JsonObject CreateUnknownArguments(string[] capturedArguments)
     {
         var arguments = new JsonObject();
-        foreach (var token in capturedArguments)
+        foreach (var token in GroupOptionLikeArguments(capturedArguments))
         {
             arguments[token] = null;
         }
@@ -348,7 +354,64 @@ internal sealed class ResourceCommand : BaseCommand
 
     private static bool IsOptionLikeToken(string value)
     {
-        return value.StartsWith("-", StringComparison.Ordinal);
+        return value is not "--" && value.StartsWith("-", StringComparison.Ordinal);
+    }
+
+    private static string[] GroupOptionLikeArguments(IReadOnlyList<string> arguments)
+    {
+        var groupedArguments = new List<string>();
+        for (var i = 0; i < arguments.Count; i++)
+        {
+            var argument = arguments[i];
+            if (IsOptionLikeToken(argument) &&
+                !argument.Contains('=') &&
+                i + 1 < arguments.Count &&
+                !IsOptionLikeToken(arguments[i + 1]))
+            {
+                groupedArguments.Add($"{argument} {arguments[i + 1]}");
+                i++;
+            }
+            else
+            {
+                groupedArguments.Add(argument);
+            }
+        }
+
+        return [.. groupedArguments];
+    }
+
+    private static string[] GroupUnrecognizedCommandOptions(IReadOnlyList<string> arguments)
+    {
+        var groupedArguments = new List<string>();
+        for (var i = 0; i < arguments.Count; i++)
+        {
+            var argument = arguments[i];
+            if (!IsOptionLikeToken(argument))
+            {
+                continue;
+            }
+
+            if (!argument.Contains('=') &&
+                i + 1 < arguments.Count &&
+                !IsOptionLikeToken(arguments[i + 1]))
+            {
+                groupedArguments.Add($"{argument} {arguments[i + 1]}");
+                i++;
+            }
+            else
+            {
+                groupedArguments.Add(argument);
+            }
+        }
+
+        return [.. groupedArguments];
+    }
+
+    private static string FormatUnrecognizedCommandOptions(string[] optionNames)
+    {
+        return optionNames.Length == 1
+            ? $"Unrecognized command option '{optionNames[0]}'."
+            : $"Unrecognized command options: {string.Join(", ", optionNames.Select(static optionName => $"'{optionName}'"))}.";
     }
 
     private static string ToKebabCase(string value)

--- a/src/Aspire.Cli/Commands/ResourceCommand.cs
+++ b/src/Aspire.Cli/Commands/ResourceCommand.cs
@@ -483,62 +483,25 @@ internal sealed class ResourceCommand : BaseCommand
 
             writer.WriteLine(command.Description is { Length: > 0 } ? command.Description : command.DisplayName ?? command.Name);
             writer.WriteLine();
-            writer.WriteLine("Usage:");
-            writer.WriteLine($"  aspire resource {resourceName} {command.Name} [command-options] [options]");
-            writer.WriteLine($"  aspire resource {resourceName} {command.Name} -- [command-options]");
+            GroupedHelpWriter.WriteUsage(
+                writer,
+                string.Format(CultureInfo.CurrentCulture, ResourceCommandStrings.CommandSpecificHelpUsageSyntax, resourceName, command.Name));
 
             if (command.ArgumentInputs.Length > 0)
             {
-                writer.WriteLine();
-                writer.WriteLine("Command options:");
-                foreach (var argument in command.ArgumentInputs)
-                {
-                    var optionName = ToKebabCase(argument.Name);
-                    writer.Write("  --");
-                    writer.Write(optionName);
-                    if (!IsBooleanInput(argument))
-                    {
-                        writer.Write(" <value>");
-                    }
-
-                    var description = GetArgumentDescription(argument);
-                    if (description.Length > 0)
-                    {
-                        writer.Write("  ");
-                        writer.Write(description);
-                    }
-
-                    if (cliOptionNames.Contains(optionName))
-                    {
-                        writer.Write(" Use `-- --");
-                        writer.Write(optionName);
-                        if (!IsBooleanInput(argument))
-                        {
-                            writer.Write(" <value>");
-                        }
-
-                        writer.Write("` to pass this command option.");
-                    }
-
-                    writer.WriteLine();
-                }
+                GroupedHelpWriter.WriteTwoColumnSection(
+                    writer,
+                    ResourceCommandStrings.CommandSpecificHelpCommandOptions,
+                    command.ArgumentInputs.Select(argument => (GetCommandOptionLabel(argument), GetArgumentDescription(argument, cliOptionNames))),
+                    maxWidth: 120);
             }
 
-            writer.WriteLine();
-            writer.WriteLine("Options:");
-            foreach (var option in GetVisibleCliOptions(commandResult))
-            {
-                var description = option.Description ?? string.Empty;
-                writer.Write("  ");
-                writer.Write(GetOptionUsage(option));
-                if (description.Length > 0)
-                {
-                    writer.Write("  ");
-                    writer.Write(description);
-                }
-
-                writer.WriteLine();
-            }
+            GroupedHelpWriter.WriteTwoColumnSection(
+                writer,
+                HelpGroupStrings.Options,
+                GetVisibleCliOptions(commandResult).Select(static option => (GroupedHelpWriter.FormatOptionLabel(option, includeValueName: true), option.Description ?? string.Empty)),
+                maxWidth: 120,
+                trailingBlankLine: false);
         }
 
         private static IEnumerable<Option> GetVisibleCliOptions(CommandResult commandResult)
@@ -566,36 +529,6 @@ internal sealed class ResourceCommand : BaseCommand
 
                 current = parentCommandResult.Parent;
             }
-        }
-
-        private static string GetOptionUsage(Option option)
-        {
-            var names = GetDisplayOptionNames(option);
-            var suffix = IsBooleanOption(option) ? string.Empty : $" <{GetOptionValueName(option)}>";
-
-            return $"{string.Join(", ", names)}{suffix}";
-        }
-
-        private static string[] GetDisplayOptionNames(Option option)
-        {
-            return option.Aliases
-                .Prepend(option.Name)
-                .Where(static name => name.StartsWith("-", StringComparison.Ordinal))
-                .Distinct(StringComparer.Ordinal)
-                .OrderBy(static name => name.StartsWith("--", StringComparison.Ordinal) ? 1 : 0)
-                .ThenBy(static name => name, StringComparer.Ordinal)
-                .ToArray();
-        }
-
-        private static bool IsBooleanOption(Option option)
-        {
-            return option is Option<bool> or HelpOption;
-        }
-
-        private static string GetOptionValueName(Option option)
-        {
-            var name = GetDisplayOptionNames(option).Last(static name => name.StartsWith("--", StringComparison.Ordinal));
-            return name[2..];
         }
 
         private static HashSet<string> GetCliOptionNames(CommandResult commandResult)
@@ -643,7 +576,15 @@ internal sealed class ResourceCommand : BaseCommand
             }
         }
 
-        private static string GetArgumentDescription(ResourceSnapshotCommandArgument argument)
+        private static string GetCommandOptionLabel(ResourceSnapshotCommandArgument argument)
+        {
+            var optionName = ToKebabCase(argument.Name);
+            return IsBooleanInput(argument)
+                ? $"--{optionName}"
+                : $"--{optionName} <{ResourceCommandStrings.CommandSpecificHelpValuePlaceholder}>";
+        }
+
+        private static string GetArgumentDescription(ResourceSnapshotCommandArgument argument, HashSet<string> cliOptionNames)
         {
             var parts = new List<string>();
             if (argument.Description is { Length: > 0 })
@@ -657,17 +598,26 @@ internal sealed class ResourceCommand : BaseCommand
 
             if (argument.Required && string.IsNullOrEmpty(argument.Value))
             {
-                parts.Add("Required.");
+                parts.Add(ResourceCommandStrings.CommandSpecificHelpRequired);
             }
 
             if (argument.Options is { Count: > 0 } options)
             {
-                parts.Add($"Allowed values: {string.Join(", ", options.Keys)}.");
+                parts.Add(string.Format(CultureInfo.CurrentCulture, ResourceCommandStrings.CommandSpecificHelpAllowedValues, string.Join(", ", options.Keys)));
             }
 
             if (argument.Value is { Length: > 0 } value)
             {
-                parts.Add($"Default: {value}.");
+                parts.Add(string.Format(CultureInfo.CurrentCulture, ResourceCommandStrings.CommandSpecificHelpDefaultValue, value));
+            }
+
+            var optionName = ToKebabCase(argument.Name);
+            if (cliOptionNames.Contains(optionName))
+            {
+                var valuePlaceholder = IsBooleanInput(argument)
+                    ? string.Empty
+                    : $" <{ResourceCommandStrings.CommandSpecificHelpValuePlaceholder}>";
+                parts.Add(string.Format(CultureInfo.CurrentCulture, ResourceCommandStrings.CommandSpecificHelpDelimiterHint, optionName, valuePlaceholder));
             }
 
             return string.Join(" ", parts);

--- a/src/Aspire.Cli/Commands/ResourceCommandHelpParser.cs
+++ b/src/Aspire.Cli/Commands/ResourceCommandHelpParser.cs
@@ -1,0 +1,50 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.CommandLine;
+
+namespace Aspire.Cli.Commands;
+
+internal sealed record ResourceCommandHelpRequest(string ResourceName, string CommandName, FileInfo? AppHostProjectFile);
+
+internal static class ResourceCommandHelpParser
+{
+    public static ResourceCommandHelpRequest? Parse(
+        ParseResult parseResult,
+        Argument<string> resourceArgument,
+        Argument<string> commandArgument,
+        OptionWithLegacy<FileInfo?> appHostOption)
+    {
+        // Command-specific help is only available when both the resource and command were parsed:
+        //   aspire resource web wait-for-browser --help
+        //   aspire resource web wait-for-browser --apphost ./AppHost.csproj --help
+        //   aspire resource web wait-for-browser --project ./AppHost.csproj --help
+        //
+        // Generic help is intentionally ignored here and falls back to System.CommandLine:
+        //   aspire resource --help
+        //   aspire resource web --help
+        var resourceName = GetArgumentValue(parseResult, resourceArgument);
+        var commandName = GetArgumentValue(parseResult, commandArgument);
+        if (string.IsNullOrEmpty(resourceName) || string.IsNullOrEmpty(commandName))
+        {
+            return null;
+        }
+
+        return new ResourceCommandHelpRequest(
+            resourceName,
+            commandName,
+            GetOptionValue(parseResult, appHostOption.InnerOption) ?? GetOptionValue(parseResult, appHostOption.LegacyOption));
+    }
+
+    private static string? GetArgumentValue(ParseResult parseResult, Argument<string> argument)
+    {
+        var result = parseResult.GetResult(argument);
+        return result?.Tokens.Count > 0 ? result.Tokens[0].Value : null;
+    }
+
+    private static FileInfo? GetOptionValue(ParseResult parseResult, Option<FileInfo?> option)
+    {
+        var result = parseResult.GetResult(option);
+        return result?.Tokens.Count > 0 ? new FileInfo(result.Tokens[0].Value) : null;
+    }
+}

--- a/src/Aspire.Cli/Commands/ResourceCommandHelpParser.cs
+++ b/src/Aspire.Cli/Commands/ResourceCommandHelpParser.cs
@@ -25,7 +25,10 @@ internal static class ResourceCommandHelpParser
         //   aspire resource web --help
         var resourceName = GetArgumentValue(parseResult, resourceArgument);
         var commandName = GetArgumentValue(parseResult, commandArgument);
-        if (string.IsNullOrEmpty(resourceName) || string.IsNullOrEmpty(commandName))
+        if (string.IsNullOrEmpty(resourceName) ||
+            IsOptionLikeToken(resourceName) ||
+            string.IsNullOrEmpty(commandName) ||
+            IsOptionLikeToken(commandName))
         {
             return null;
         }
@@ -46,5 +49,10 @@ internal static class ResourceCommandHelpParser
     {
         var result = parseResult.GetResult(option);
         return result?.Tokens.Count > 0 ? new FileInfo(result.Tokens[0].Value) : null;
+    }
+
+    private static bool IsOptionLikeToken(string value)
+    {
+        return value.StartsWith("-", StringComparison.Ordinal);
     }
 }

--- a/src/Aspire.Cli/Commands/ResourceCommandHelper.cs
+++ b/src/Aspire.Cli/Commands/ResourceCommandHelper.cs
@@ -170,7 +170,41 @@ internal static class ResourceCommandHelper
             return errorMessage;
         }
 
-        var errors = validationErrors.Select(error => $"{error.ArgumentName}: {error.ErrorMessage}");
+        var errors = validationErrors.Select(error => $"{FormatArgumentNameForDisplay(error.ArgumentName)}: {error.ErrorMessage}");
         return $"{errorMessage}{Environment.NewLine}{string.Join(Environment.NewLine, errors)}";
+    }
+
+    internal static string FormatArgumentNameForDisplay(string argumentName)
+    {
+        return argumentName.StartsWith("-", StringComparison.Ordinal) ? argumentName : $"--{ToKebabCase(argumentName)}";
+    }
+
+    private static string ToKebabCase(string value)
+    {
+        if (string.IsNullOrEmpty(value))
+        {
+            return value;
+        }
+
+        var builder = new System.Text.StringBuilder(value.Length + 4);
+        for (var i = 0; i < value.Length; i++)
+        {
+            var ch = value[i];
+            if (char.IsUpper(ch))
+            {
+                if (i > 0 && builder[^1] != '-')
+                {
+                    builder.Append('-');
+                }
+
+                builder.Append(char.ToLowerInvariant(ch));
+            }
+            else
+            {
+                builder.Append(ch);
+            }
+        }
+
+        return builder.ToString();
     }
 }

--- a/src/Aspire.Cli/Commands/ResourceCommandHelper.cs
+++ b/src/Aspire.Cli/Commands/ResourceCommandHelper.cs
@@ -163,9 +163,9 @@ internal static class ResourceCommandHelper
         return string.IsNullOrEmpty(errorMessage) ? "Unknown error occurred." : errorMessage;
     }
 
-    private static string AppendValidationErrors(string errorMessage, ResourceCommandArgumentValidationError[] validationErrors)
+    private static string AppendValidationErrors(string errorMessage, ResourceCommandArgumentValidationError[]? validationErrors)
     {
-        if (validationErrors.Length == 0)
+        if (validationErrors is not { Length: > 0 })
         {
             return errorMessage;
         }

--- a/src/Aspire.Cli/Mcp/Tools/ExecuteResourceCommandTool.cs
+++ b/src/Aspire.Cli/Mcp/Tools/ExecuteResourceCommandTool.cs
@@ -4,6 +4,7 @@
 using System.Text.Json;
 using System.Text.Json.Nodes;
 using Aspire.Cli.Backchannel;
+using Aspire.Cli.Commands;
 using Microsoft.Extensions.Logging;
 using ModelContextProtocol;
 using ModelContextProtocol.Protocol;
@@ -131,7 +132,7 @@ internal sealed class ExecuteResourceCommandTool(
 #pragma warning restore CS0618 // Type or member is obsolete
                 if (response.ValidationErrors is { Length: > 0 })
                 {
-                    message = $"{message}{Environment.NewLine}{string.Join(Environment.NewLine, response.ValidationErrors.Select(error => $"{error.ArgumentName}: {error.ErrorMessage}"))}";
+                    message = $"{message}{Environment.NewLine}{string.Join(Environment.NewLine, response.ValidationErrors.Select(error => $"{ResourceCommandHelper.FormatArgumentNameForDisplay(error.ArgumentName)}: {error.ErrorMessage}"))}";
                 }
 
                 var content = new List<TextContentBlock>

--- a/src/Aspire.Cli/Mcp/Tools/ExecuteResourceCommandTool.cs
+++ b/src/Aspire.Cli/Mcp/Tools/ExecuteResourceCommandTool.cs
@@ -129,7 +129,7 @@ internal sealed class ExecuteResourceCommandTool(
 #pragma warning disable CS0618 // Type or member is obsolete
                 var message = (response.Message ?? response.ErrorMessage) is { Length: > 0 } errorMsg ? errorMsg : "Unknown error. See logs for details.";
 #pragma warning restore CS0618 // Type or member is obsolete
-                if (response.ValidationErrors.Length > 0)
+                if (response.ValidationErrors is { Length: > 0 })
                 {
                     message = $"{message}{Environment.NewLine}{string.Join(Environment.NewLine, response.ValidationErrors.Select(error => $"{error.ArgumentName}: {error.ErrorMessage}"))}";
                 }

--- a/src/Aspire.Cli/Resources/ResourceCommandStrings.Designer.cs
+++ b/src/Aspire.Cli/Resources/ResourceCommandStrings.Designer.cs
@@ -69,6 +69,12 @@ namespace Aspire.Cli.Resources {
             }
         }
 
+        internal static string ArgumentRequired {
+            get {
+                return ResourceManager.GetString("ArgumentRequired", resourceCulture);
+            }
+        }
+
         internal static string CommandSpecificHelpAllowedValues {
             get {
                 return ResourceManager.GetString("CommandSpecificHelpAllowedValues", resourceCulture);

--- a/src/Aspire.Cli/Resources/ResourceCommandStrings.Designer.cs
+++ b/src/Aspire.Cli/Resources/ResourceCommandStrings.Designer.cs
@@ -69,5 +69,47 @@ namespace Aspire.Cli.Resources {
             }
         }
 
+        internal static string CommandSpecificHelpAllowedValues {
+            get {
+                return ResourceManager.GetString("CommandSpecificHelpAllowedValues", resourceCulture);
+            }
+        }
+
+        internal static string CommandSpecificHelpCommandOptions {
+            get {
+                return ResourceManager.GetString("CommandSpecificHelpCommandOptions", resourceCulture);
+            }
+        }
+
+        internal static string CommandSpecificHelpDefaultValue {
+            get {
+                return ResourceManager.GetString("CommandSpecificHelpDefaultValue", resourceCulture);
+            }
+        }
+
+        internal static string CommandSpecificHelpDelimiterHint {
+            get {
+                return ResourceManager.GetString("CommandSpecificHelpDelimiterHint", resourceCulture);
+            }
+        }
+
+        internal static string CommandSpecificHelpRequired {
+            get {
+                return ResourceManager.GetString("CommandSpecificHelpRequired", resourceCulture);
+            }
+        }
+
+        internal static string CommandSpecificHelpUsageSyntax {
+            get {
+                return ResourceManager.GetString("CommandSpecificHelpUsageSyntax", resourceCulture);
+            }
+        }
+
+        internal static string CommandSpecificHelpValuePlaceholder {
+            get {
+                return ResourceManager.GetString("CommandSpecificHelpValuePlaceholder", resourceCulture);
+            }
+        }
+
     }
 }

--- a/src/Aspire.Cli/Resources/ResourceCommandStrings.resx
+++ b/src/Aspire.Cli/Resources/ResourceCommandStrings.resx
@@ -70,6 +70,9 @@
   <data name="CommandNameArgumentDescription" xml:space="preserve">
     <value>The name of the command to execute (e.g. start, stop, restart)</value>
   </data>
+  <data name="ArgumentRequired" xml:space="preserve">
+    <value>The '{0}' argument is required.</value>
+  </data>
   <data name="CommandSpecificHelpUsageSyntax" xml:space="preserve">
     <value>aspire resource {0} {1} [options] [[--] &lt;command-options&gt;...]</value>
   </data>

--- a/src/Aspire.Cli/Resources/ResourceCommandStrings.resx
+++ b/src/Aspire.Cli/Resources/ResourceCommandStrings.resx
@@ -70,4 +70,25 @@
   <data name="CommandNameArgumentDescription" xml:space="preserve">
     <value>The name of the command to execute (e.g. start, stop, restart)</value>
   </data>
+  <data name="CommandSpecificHelpUsageSyntax" xml:space="preserve">
+    <value>aspire resource {0} {1} [options] [[--] &lt;command-options&gt;...]</value>
+  </data>
+  <data name="CommandSpecificHelpCommandOptions" xml:space="preserve">
+    <value>Command options:</value>
+  </data>
+  <data name="CommandSpecificHelpValuePlaceholder" xml:space="preserve">
+    <value>value</value>
+  </data>
+  <data name="CommandSpecificHelpDelimiterHint" xml:space="preserve">
+    <value>Use `-- --{0}{1}` to pass this command option.</value>
+  </data>
+  <data name="CommandSpecificHelpRequired" xml:space="preserve">
+    <value>Required.</value>
+  </data>
+  <data name="CommandSpecificHelpAllowedValues" xml:space="preserve">
+    <value>Allowed values: {0}.</value>
+  </data>
+  <data name="CommandSpecificHelpDefaultValue" xml:space="preserve">
+    <value>Default: {0}.</value>
+  </data>
 </root>

--- a/src/Aspire.Cli/Resources/xlf/ResourceCommandStrings.cs.xlf
+++ b/src/Aspire.Cli/Resources/xlf/ResourceCommandStrings.cs.xlf
@@ -2,6 +2,11 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="cs" original="../ResourceCommandStrings.resx">
     <body>
+      <trans-unit id="ArgumentRequired">
+        <source>The '{0}' argument is required.</source>
+        <target state="new">The '{0}' argument is required.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CommandDescription">
         <source>Execute a command on a resource (e.g. start, stop, restart)</source>
         <target state="needs-review-translation">Spusťte příkaz pro prostředek.</target>

--- a/src/Aspire.Cli/Resources/xlf/ResourceCommandStrings.cs.xlf
+++ b/src/Aspire.Cli/Resources/xlf/ResourceCommandStrings.cs.xlf
@@ -17,6 +17,41 @@
         <target state="needs-review-translation">Název prostředku, na kterém se má příkaz provést</target>
         <note />
       </trans-unit>
+      <trans-unit id="CommandSpecificHelpAllowedValues">
+        <source>Allowed values: {0}.</source>
+        <target state="new">Allowed values: {0}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CommandSpecificHelpCommandOptions">
+        <source>Command options:</source>
+        <target state="new">Command options:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CommandSpecificHelpDefaultValue">
+        <source>Default: {0}.</source>
+        <target state="new">Default: {0}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CommandSpecificHelpDelimiterHint">
+        <source>Use `-- --{0}{1}` to pass this command option.</source>
+        <target state="new">Use `-- --{0}{1}` to pass this command option.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CommandSpecificHelpRequired">
+        <source>Required.</source>
+        <target state="new">Required.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CommandSpecificHelpUsageSyntax">
+        <source>aspire resource {0} {1} [options] [[--] &lt;command-options&gt;...]</source>
+        <target state="new">aspire resource {0} {1} [options] [[--] &lt;command-options&gt;...]</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CommandSpecificHelpValuePlaceholder">
+        <source>value</source>
+        <target state="new">value</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SelectAppHostAction">
         <source>connect to</source>
         <target state="translated">připojit k</target>

--- a/src/Aspire.Cli/Resources/xlf/ResourceCommandStrings.de.xlf
+++ b/src/Aspire.Cli/Resources/xlf/ResourceCommandStrings.de.xlf
@@ -2,6 +2,11 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="de" original="../ResourceCommandStrings.resx">
     <body>
+      <trans-unit id="ArgumentRequired">
+        <source>The '{0}' argument is required.</source>
+        <target state="new">The '{0}' argument is required.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CommandDescription">
         <source>Execute a command on a resource (e.g. start, stop, restart)</source>
         <target state="needs-review-translation">Führen Sie einen Befehl auf einer Ressource aus.</target>

--- a/src/Aspire.Cli/Resources/xlf/ResourceCommandStrings.de.xlf
+++ b/src/Aspire.Cli/Resources/xlf/ResourceCommandStrings.de.xlf
@@ -17,6 +17,41 @@
         <target state="needs-review-translation">Der Name der Ressource, für die der Befehl ausgeführt werden soll.</target>
         <note />
       </trans-unit>
+      <trans-unit id="CommandSpecificHelpAllowedValues">
+        <source>Allowed values: {0}.</source>
+        <target state="new">Allowed values: {0}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CommandSpecificHelpCommandOptions">
+        <source>Command options:</source>
+        <target state="new">Command options:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CommandSpecificHelpDefaultValue">
+        <source>Default: {0}.</source>
+        <target state="new">Default: {0}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CommandSpecificHelpDelimiterHint">
+        <source>Use `-- --{0}{1}` to pass this command option.</source>
+        <target state="new">Use `-- --{0}{1}` to pass this command option.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CommandSpecificHelpRequired">
+        <source>Required.</source>
+        <target state="new">Required.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CommandSpecificHelpUsageSyntax">
+        <source>aspire resource {0} {1} [options] [[--] &lt;command-options&gt;...]</source>
+        <target state="new">aspire resource {0} {1} [options] [[--] &lt;command-options&gt;...]</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CommandSpecificHelpValuePlaceholder">
+        <source>value</source>
+        <target state="new">value</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SelectAppHostAction">
         <source>connect to</source>
         <target state="translated">stellen Sie eine Verbindung her mit</target>

--- a/src/Aspire.Cli/Resources/xlf/ResourceCommandStrings.es.xlf
+++ b/src/Aspire.Cli/Resources/xlf/ResourceCommandStrings.es.xlf
@@ -2,6 +2,11 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="es" original="../ResourceCommandStrings.resx">
     <body>
+      <trans-unit id="ArgumentRequired">
+        <source>The '{0}' argument is required.</source>
+        <target state="new">The '{0}' argument is required.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CommandDescription">
         <source>Execute a command on a resource (e.g. start, stop, restart)</source>
         <target state="needs-review-translation">Ejecute un comando en un recurso.</target>

--- a/src/Aspire.Cli/Resources/xlf/ResourceCommandStrings.es.xlf
+++ b/src/Aspire.Cli/Resources/xlf/ResourceCommandStrings.es.xlf
@@ -17,6 +17,41 @@
         <target state="needs-review-translation">El nombre del recurso de destino en el que se ejecutará el comando.</target>
         <note />
       </trans-unit>
+      <trans-unit id="CommandSpecificHelpAllowedValues">
+        <source>Allowed values: {0}.</source>
+        <target state="new">Allowed values: {0}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CommandSpecificHelpCommandOptions">
+        <source>Command options:</source>
+        <target state="new">Command options:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CommandSpecificHelpDefaultValue">
+        <source>Default: {0}.</source>
+        <target state="new">Default: {0}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CommandSpecificHelpDelimiterHint">
+        <source>Use `-- --{0}{1}` to pass this command option.</source>
+        <target state="new">Use `-- --{0}{1}` to pass this command option.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CommandSpecificHelpRequired">
+        <source>Required.</source>
+        <target state="new">Required.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CommandSpecificHelpUsageSyntax">
+        <source>aspire resource {0} {1} [options] [[--] &lt;command-options&gt;...]</source>
+        <target state="new">aspire resource {0} {1} [options] [[--] &lt;command-options&gt;...]</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CommandSpecificHelpValuePlaceholder">
+        <source>value</source>
+        <target state="new">value</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SelectAppHostAction">
         <source>connect to</source>
         <target state="translated">conectarse a</target>

--- a/src/Aspire.Cli/Resources/xlf/ResourceCommandStrings.fr.xlf
+++ b/src/Aspire.Cli/Resources/xlf/ResourceCommandStrings.fr.xlf
@@ -2,6 +2,11 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="fr" original="../ResourceCommandStrings.resx">
     <body>
+      <trans-unit id="ArgumentRequired">
+        <source>The '{0}' argument is required.</source>
+        <target state="new">The '{0}' argument is required.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CommandDescription">
         <source>Execute a command on a resource (e.g. start, stop, restart)</source>
         <target state="needs-review-translation">Exécuter une commande sur une ressource.</target>

--- a/src/Aspire.Cli/Resources/xlf/ResourceCommandStrings.fr.xlf
+++ b/src/Aspire.Cli/Resources/xlf/ResourceCommandStrings.fr.xlf
@@ -17,6 +17,41 @@
         <target state="needs-review-translation">Nom de la ressource sur laquelle exécuter la commande.</target>
         <note />
       </trans-unit>
+      <trans-unit id="CommandSpecificHelpAllowedValues">
+        <source>Allowed values: {0}.</source>
+        <target state="new">Allowed values: {0}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CommandSpecificHelpCommandOptions">
+        <source>Command options:</source>
+        <target state="new">Command options:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CommandSpecificHelpDefaultValue">
+        <source>Default: {0}.</source>
+        <target state="new">Default: {0}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CommandSpecificHelpDelimiterHint">
+        <source>Use `-- --{0}{1}` to pass this command option.</source>
+        <target state="new">Use `-- --{0}{1}` to pass this command option.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CommandSpecificHelpRequired">
+        <source>Required.</source>
+        <target state="new">Required.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CommandSpecificHelpUsageSyntax">
+        <source>aspire resource {0} {1} [options] [[--] &lt;command-options&gt;...]</source>
+        <target state="new">aspire resource {0} {1} [options] [[--] &lt;command-options&gt;...]</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CommandSpecificHelpValuePlaceholder">
+        <source>value</source>
+        <target state="new">value</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SelectAppHostAction">
         <source>connect to</source>
         <target state="translated">se connecter à</target>

--- a/src/Aspire.Cli/Resources/xlf/ResourceCommandStrings.it.xlf
+++ b/src/Aspire.Cli/Resources/xlf/ResourceCommandStrings.it.xlf
@@ -2,6 +2,11 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="it" original="../ResourceCommandStrings.resx">
     <body>
+      <trans-unit id="ArgumentRequired">
+        <source>The '{0}' argument is required.</source>
+        <target state="new">The '{0}' argument is required.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CommandDescription">
         <source>Execute a command on a resource (e.g. start, stop, restart)</source>
         <target state="needs-review-translation">Eseguire un comando su una risorsa.</target>

--- a/src/Aspire.Cli/Resources/xlf/ResourceCommandStrings.it.xlf
+++ b/src/Aspire.Cli/Resources/xlf/ResourceCommandStrings.it.xlf
@@ -17,6 +17,41 @@
         <target state="needs-review-translation">Nome della risorsa di destinazione rispetto al quale eseguire il comando.</target>
         <note />
       </trans-unit>
+      <trans-unit id="CommandSpecificHelpAllowedValues">
+        <source>Allowed values: {0}.</source>
+        <target state="new">Allowed values: {0}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CommandSpecificHelpCommandOptions">
+        <source>Command options:</source>
+        <target state="new">Command options:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CommandSpecificHelpDefaultValue">
+        <source>Default: {0}.</source>
+        <target state="new">Default: {0}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CommandSpecificHelpDelimiterHint">
+        <source>Use `-- --{0}{1}` to pass this command option.</source>
+        <target state="new">Use `-- --{0}{1}` to pass this command option.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CommandSpecificHelpRequired">
+        <source>Required.</source>
+        <target state="new">Required.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CommandSpecificHelpUsageSyntax">
+        <source>aspire resource {0} {1} [options] [[--] &lt;command-options&gt;...]</source>
+        <target state="new">aspire resource {0} {1} [options] [[--] &lt;command-options&gt;...]</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CommandSpecificHelpValuePlaceholder">
+        <source>value</source>
+        <target state="new">value</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SelectAppHostAction">
         <source>connect to</source>
         <target state="translated">connettersi a</target>

--- a/src/Aspire.Cli/Resources/xlf/ResourceCommandStrings.ja.xlf
+++ b/src/Aspire.Cli/Resources/xlf/ResourceCommandStrings.ja.xlf
@@ -2,6 +2,11 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="ja" original="../ResourceCommandStrings.resx">
     <body>
+      <trans-unit id="ArgumentRequired">
+        <source>The '{0}' argument is required.</source>
+        <target state="new">The '{0}' argument is required.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CommandDescription">
         <source>Execute a command on a resource (e.g. start, stop, restart)</source>
         <target state="needs-review-translation">リソースでコマンドを実行します。</target>

--- a/src/Aspire.Cli/Resources/xlf/ResourceCommandStrings.ja.xlf
+++ b/src/Aspire.Cli/Resources/xlf/ResourceCommandStrings.ja.xlf
@@ -17,6 +17,41 @@
         <target state="needs-review-translation">コマンドを実行する対象のリソースの名前。</target>
         <note />
       </trans-unit>
+      <trans-unit id="CommandSpecificHelpAllowedValues">
+        <source>Allowed values: {0}.</source>
+        <target state="new">Allowed values: {0}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CommandSpecificHelpCommandOptions">
+        <source>Command options:</source>
+        <target state="new">Command options:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CommandSpecificHelpDefaultValue">
+        <source>Default: {0}.</source>
+        <target state="new">Default: {0}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CommandSpecificHelpDelimiterHint">
+        <source>Use `-- --{0}{1}` to pass this command option.</source>
+        <target state="new">Use `-- --{0}{1}` to pass this command option.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CommandSpecificHelpRequired">
+        <source>Required.</source>
+        <target state="new">Required.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CommandSpecificHelpUsageSyntax">
+        <source>aspire resource {0} {1} [options] [[--] &lt;command-options&gt;...]</source>
+        <target state="new">aspire resource {0} {1} [options] [[--] &lt;command-options&gt;...]</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CommandSpecificHelpValuePlaceholder">
+        <source>value</source>
+        <target state="new">value</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SelectAppHostAction">
         <source>connect to</source>
         <target state="translated">接続先</target>

--- a/src/Aspire.Cli/Resources/xlf/ResourceCommandStrings.ko.xlf
+++ b/src/Aspire.Cli/Resources/xlf/ResourceCommandStrings.ko.xlf
@@ -2,6 +2,11 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="ko" original="../ResourceCommandStrings.resx">
     <body>
+      <trans-unit id="ArgumentRequired">
+        <source>The '{0}' argument is required.</source>
+        <target state="new">The '{0}' argument is required.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CommandDescription">
         <source>Execute a command on a resource (e.g. start, stop, restart)</source>
         <target state="needs-review-translation">리소스에서 명령을 실행합니다.</target>

--- a/src/Aspire.Cli/Resources/xlf/ResourceCommandStrings.ko.xlf
+++ b/src/Aspire.Cli/Resources/xlf/ResourceCommandStrings.ko.xlf
@@ -17,6 +17,41 @@
         <target state="needs-review-translation">명령을 실행할 대상 리소스의 이름입니다.</target>
         <note />
       </trans-unit>
+      <trans-unit id="CommandSpecificHelpAllowedValues">
+        <source>Allowed values: {0}.</source>
+        <target state="new">Allowed values: {0}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CommandSpecificHelpCommandOptions">
+        <source>Command options:</source>
+        <target state="new">Command options:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CommandSpecificHelpDefaultValue">
+        <source>Default: {0}.</source>
+        <target state="new">Default: {0}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CommandSpecificHelpDelimiterHint">
+        <source>Use `-- --{0}{1}` to pass this command option.</source>
+        <target state="new">Use `-- --{0}{1}` to pass this command option.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CommandSpecificHelpRequired">
+        <source>Required.</source>
+        <target state="new">Required.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CommandSpecificHelpUsageSyntax">
+        <source>aspire resource {0} {1} [options] [[--] &lt;command-options&gt;...]</source>
+        <target state="new">aspire resource {0} {1} [options] [[--] &lt;command-options&gt;...]</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CommandSpecificHelpValuePlaceholder">
+        <source>value</source>
+        <target state="new">value</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SelectAppHostAction">
         <source>connect to</source>
         <target state="translated">연결 대상</target>

--- a/src/Aspire.Cli/Resources/xlf/ResourceCommandStrings.pl.xlf
+++ b/src/Aspire.Cli/Resources/xlf/ResourceCommandStrings.pl.xlf
@@ -2,6 +2,11 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="pl" original="../ResourceCommandStrings.resx">
     <body>
+      <trans-unit id="ArgumentRequired">
+        <source>The '{0}' argument is required.</source>
+        <target state="new">The '{0}' argument is required.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CommandDescription">
         <source>Execute a command on a resource (e.g. start, stop, restart)</source>
         <target state="needs-review-translation">Wykonaj polecenie dla zasobu.</target>

--- a/src/Aspire.Cli/Resources/xlf/ResourceCommandStrings.pl.xlf
+++ b/src/Aspire.Cli/Resources/xlf/ResourceCommandStrings.pl.xlf
@@ -17,6 +17,41 @@
         <target state="needs-review-translation">Nazwa zasobu, na którym ma zostać wykonane polecenie.</target>
         <note />
       </trans-unit>
+      <trans-unit id="CommandSpecificHelpAllowedValues">
+        <source>Allowed values: {0}.</source>
+        <target state="new">Allowed values: {0}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CommandSpecificHelpCommandOptions">
+        <source>Command options:</source>
+        <target state="new">Command options:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CommandSpecificHelpDefaultValue">
+        <source>Default: {0}.</source>
+        <target state="new">Default: {0}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CommandSpecificHelpDelimiterHint">
+        <source>Use `-- --{0}{1}` to pass this command option.</source>
+        <target state="new">Use `-- --{0}{1}` to pass this command option.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CommandSpecificHelpRequired">
+        <source>Required.</source>
+        <target state="new">Required.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CommandSpecificHelpUsageSyntax">
+        <source>aspire resource {0} {1} [options] [[--] &lt;command-options&gt;...]</source>
+        <target state="new">aspire resource {0} {1} [options] [[--] &lt;command-options&gt;...]</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CommandSpecificHelpValuePlaceholder">
+        <source>value</source>
+        <target state="new">value</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SelectAppHostAction">
         <source>connect to</source>
         <target state="translated">połącz z</target>

--- a/src/Aspire.Cli/Resources/xlf/ResourceCommandStrings.pt-BR.xlf
+++ b/src/Aspire.Cli/Resources/xlf/ResourceCommandStrings.pt-BR.xlf
@@ -2,6 +2,11 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="pt-BR" original="../ResourceCommandStrings.resx">
     <body>
+      <trans-unit id="ArgumentRequired">
+        <source>The '{0}' argument is required.</source>
+        <target state="new">The '{0}' argument is required.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CommandDescription">
         <source>Execute a command on a resource (e.g. start, stop, restart)</source>
         <target state="needs-review-translation">Execute um comando em um recurso.</target>

--- a/src/Aspire.Cli/Resources/xlf/ResourceCommandStrings.pt-BR.xlf
+++ b/src/Aspire.Cli/Resources/xlf/ResourceCommandStrings.pt-BR.xlf
@@ -17,6 +17,41 @@
         <target state="needs-review-translation">O nome do recurso no qual executar o comando.</target>
         <note />
       </trans-unit>
+      <trans-unit id="CommandSpecificHelpAllowedValues">
+        <source>Allowed values: {0}.</source>
+        <target state="new">Allowed values: {0}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CommandSpecificHelpCommandOptions">
+        <source>Command options:</source>
+        <target state="new">Command options:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CommandSpecificHelpDefaultValue">
+        <source>Default: {0}.</source>
+        <target state="new">Default: {0}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CommandSpecificHelpDelimiterHint">
+        <source>Use `-- --{0}{1}` to pass this command option.</source>
+        <target state="new">Use `-- --{0}{1}` to pass this command option.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CommandSpecificHelpRequired">
+        <source>Required.</source>
+        <target state="new">Required.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CommandSpecificHelpUsageSyntax">
+        <source>aspire resource {0} {1} [options] [[--] &lt;command-options&gt;...]</source>
+        <target state="new">aspire resource {0} {1} [options] [[--] &lt;command-options&gt;...]</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CommandSpecificHelpValuePlaceholder">
+        <source>value</source>
+        <target state="new">value</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SelectAppHostAction">
         <source>connect to</source>
         <target state="translated">conectar-se a</target>

--- a/src/Aspire.Cli/Resources/xlf/ResourceCommandStrings.ru.xlf
+++ b/src/Aspire.Cli/Resources/xlf/ResourceCommandStrings.ru.xlf
@@ -2,6 +2,11 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="ru" original="../ResourceCommandStrings.resx">
     <body>
+      <trans-unit id="ArgumentRequired">
+        <source>The '{0}' argument is required.</source>
+        <target state="new">The '{0}' argument is required.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CommandDescription">
         <source>Execute a command on a resource (e.g. start, stop, restart)</source>
         <target state="needs-review-translation">Выполнить команду на ресурсе.</target>

--- a/src/Aspire.Cli/Resources/xlf/ResourceCommandStrings.ru.xlf
+++ b/src/Aspire.Cli/Resources/xlf/ResourceCommandStrings.ru.xlf
@@ -17,6 +17,41 @@
         <target state="needs-review-translation">Имя целевого ресурса, на котором будет выполняться команда.</target>
         <note />
       </trans-unit>
+      <trans-unit id="CommandSpecificHelpAllowedValues">
+        <source>Allowed values: {0}.</source>
+        <target state="new">Allowed values: {0}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CommandSpecificHelpCommandOptions">
+        <source>Command options:</source>
+        <target state="new">Command options:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CommandSpecificHelpDefaultValue">
+        <source>Default: {0}.</source>
+        <target state="new">Default: {0}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CommandSpecificHelpDelimiterHint">
+        <source>Use `-- --{0}{1}` to pass this command option.</source>
+        <target state="new">Use `-- --{0}{1}` to pass this command option.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CommandSpecificHelpRequired">
+        <source>Required.</source>
+        <target state="new">Required.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CommandSpecificHelpUsageSyntax">
+        <source>aspire resource {0} {1} [options] [[--] &lt;command-options&gt;...]</source>
+        <target state="new">aspire resource {0} {1} [options] [[--] &lt;command-options&gt;...]</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CommandSpecificHelpValuePlaceholder">
+        <source>value</source>
+        <target state="new">value</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SelectAppHostAction">
         <source>connect to</source>
         <target state="translated">подключить к</target>

--- a/src/Aspire.Cli/Resources/xlf/ResourceCommandStrings.tr.xlf
+++ b/src/Aspire.Cli/Resources/xlf/ResourceCommandStrings.tr.xlf
@@ -2,6 +2,11 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="tr" original="../ResourceCommandStrings.resx">
     <body>
+      <trans-unit id="ArgumentRequired">
+        <source>The '{0}' argument is required.</source>
+        <target state="new">The '{0}' argument is required.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CommandDescription">
         <source>Execute a command on a resource (e.g. start, stop, restart)</source>
         <target state="needs-review-translation">Bir kaynak üzerinde bir komut çalıştırın.</target>

--- a/src/Aspire.Cli/Resources/xlf/ResourceCommandStrings.tr.xlf
+++ b/src/Aspire.Cli/Resources/xlf/ResourceCommandStrings.tr.xlf
@@ -17,6 +17,41 @@
         <target state="needs-review-translation">Komutu yürütecek kaynağın adı.</target>
         <note />
       </trans-unit>
+      <trans-unit id="CommandSpecificHelpAllowedValues">
+        <source>Allowed values: {0}.</source>
+        <target state="new">Allowed values: {0}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CommandSpecificHelpCommandOptions">
+        <source>Command options:</source>
+        <target state="new">Command options:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CommandSpecificHelpDefaultValue">
+        <source>Default: {0}.</source>
+        <target state="new">Default: {0}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CommandSpecificHelpDelimiterHint">
+        <source>Use `-- --{0}{1}` to pass this command option.</source>
+        <target state="new">Use `-- --{0}{1}` to pass this command option.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CommandSpecificHelpRequired">
+        <source>Required.</source>
+        <target state="new">Required.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CommandSpecificHelpUsageSyntax">
+        <source>aspire resource {0} {1} [options] [[--] &lt;command-options&gt;...]</source>
+        <target state="new">aspire resource {0} {1} [options] [[--] &lt;command-options&gt;...]</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CommandSpecificHelpValuePlaceholder">
+        <source>value</source>
+        <target state="new">value</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SelectAppHostAction">
         <source>connect to</source>
         <target state="translated">şuna bağlanın:</target>

--- a/src/Aspire.Cli/Resources/xlf/ResourceCommandStrings.zh-Hans.xlf
+++ b/src/Aspire.Cli/Resources/xlf/ResourceCommandStrings.zh-Hans.xlf
@@ -2,6 +2,11 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="zh-Hans" original="../ResourceCommandStrings.resx">
     <body>
+      <trans-unit id="ArgumentRequired">
+        <source>The '{0}' argument is required.</source>
+        <target state="new">The '{0}' argument is required.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CommandDescription">
         <source>Execute a command on a resource (e.g. start, stop, restart)</source>
         <target state="needs-review-translation">在资源上执行命令。</target>

--- a/src/Aspire.Cli/Resources/xlf/ResourceCommandStrings.zh-Hans.xlf
+++ b/src/Aspire.Cli/Resources/xlf/ResourceCommandStrings.zh-Hans.xlf
@@ -17,6 +17,41 @@
         <target state="needs-review-translation">要在其上执行命令的资源的名称。</target>
         <note />
       </trans-unit>
+      <trans-unit id="CommandSpecificHelpAllowedValues">
+        <source>Allowed values: {0}.</source>
+        <target state="new">Allowed values: {0}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CommandSpecificHelpCommandOptions">
+        <source>Command options:</source>
+        <target state="new">Command options:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CommandSpecificHelpDefaultValue">
+        <source>Default: {0}.</source>
+        <target state="new">Default: {0}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CommandSpecificHelpDelimiterHint">
+        <source>Use `-- --{0}{1}` to pass this command option.</source>
+        <target state="new">Use `-- --{0}{1}` to pass this command option.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CommandSpecificHelpRequired">
+        <source>Required.</source>
+        <target state="new">Required.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CommandSpecificHelpUsageSyntax">
+        <source>aspire resource {0} {1} [options] [[--] &lt;command-options&gt;...]</source>
+        <target state="new">aspire resource {0} {1} [options] [[--] &lt;command-options&gt;...]</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CommandSpecificHelpValuePlaceholder">
+        <source>value</source>
+        <target state="new">value</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SelectAppHostAction">
         <source>connect to</source>
         <target state="translated">连接到</target>

--- a/src/Aspire.Cli/Resources/xlf/ResourceCommandStrings.zh-Hant.xlf
+++ b/src/Aspire.Cli/Resources/xlf/ResourceCommandStrings.zh-Hant.xlf
@@ -2,6 +2,11 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="zh-Hant" original="../ResourceCommandStrings.resx">
     <body>
+      <trans-unit id="ArgumentRequired">
+        <source>The '{0}' argument is required.</source>
+        <target state="new">The '{0}' argument is required.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CommandDescription">
         <source>Execute a command on a resource (e.g. start, stop, restart)</source>
         <target state="needs-review-translation">在資源上執行命令。</target>

--- a/src/Aspire.Cli/Resources/xlf/ResourceCommandStrings.zh-Hant.xlf
+++ b/src/Aspire.Cli/Resources/xlf/ResourceCommandStrings.zh-Hant.xlf
@@ -17,6 +17,41 @@
         <target state="needs-review-translation">要執行命令的資源名稱。</target>
         <note />
       </trans-unit>
+      <trans-unit id="CommandSpecificHelpAllowedValues">
+        <source>Allowed values: {0}.</source>
+        <target state="new">Allowed values: {0}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CommandSpecificHelpCommandOptions">
+        <source>Command options:</source>
+        <target state="new">Command options:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CommandSpecificHelpDefaultValue">
+        <source>Default: {0}.</source>
+        <target state="new">Default: {0}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CommandSpecificHelpDelimiterHint">
+        <source>Use `-- --{0}{1}` to pass this command option.</source>
+        <target state="new">Use `-- --{0}{1}` to pass this command option.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CommandSpecificHelpRequired">
+        <source>Required.</source>
+        <target state="new">Required.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CommandSpecificHelpUsageSyntax">
+        <source>aspire resource {0} {1} [options] [[--] &lt;command-options&gt;...]</source>
+        <target state="new">aspire resource {0} {1} [options] [[--] &lt;command-options&gt;...]</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CommandSpecificHelpValuePlaceholder">
+        <source>value</source>
+        <target state="new">value</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SelectAppHostAction">
         <source>connect to</source>
         <target state="translated">連線至</target>

--- a/src/Aspire.Hosting/ApplicationModel/ResourceCommandService.cs
+++ b/src/Aspire.Hosting/ApplicationModel/ResourceCommandService.cs
@@ -288,6 +288,10 @@ public class ResourceCommandService
 
                     arguments = promptedArguments!;
                 }
+                else
+                {
+                    await LoadDynamicCommandArgumentsAsync(arguments, cancellationToken).ConfigureAwait(false);
+                }
 
                 if (!await ValidateArgumentsAsync(annotation, arguments, cancellationToken).ConfigureAwait(false))
                 {
@@ -359,6 +363,8 @@ public class ResourceCommandService
         }
 
         var normalizedArguments = NormalizeCommandArguments(annotation, arguments);
+        await LoadDynamicCommandArgumentsAsync(normalizedArguments, cancellationToken).ConfigureAwait(false);
+
         return await ValidateArgumentsAsync(annotation, normalizedArguments, cancellationToken).ConfigureAwait(false)
             ? CommandResults.Success()
             : new ExecuteCommandResult
@@ -495,6 +501,41 @@ public class ResourceCommandService
         }
 
         return !context.HasErrors;
+    }
+
+    private async Task LoadDynamicCommandArgumentsAsync(InteractionInputCollection arguments, CancellationToken cancellationToken)
+    {
+        foreach (var argument in arguments)
+        {
+            if (argument.DynamicLoading is { } dynamicLoading && ShouldLoadDynamicCommandArgument(dynamicLoading, arguments))
+            {
+                await dynamicLoading.LoadCallback(new LoadInputContext
+                {
+                    AllInputs = arguments,
+                    Input = argument,
+                    Services = _serviceProvider,
+                    CancellationToken = cancellationToken
+                }).ConfigureAwait(false);
+            }
+        }
+    }
+
+    private static bool ShouldLoadDynamicCommandArgument(InputLoadOptions dynamicLoading, InteractionInputCollection arguments)
+    {
+        if (dynamicLoading.AlwaysLoadOnStart || dynamicLoading.DependsOnInputs is not { Count: > 0 } dependencies)
+        {
+            return true;
+        }
+
+        foreach (var dependency in dependencies)
+        {
+            if (!arguments.TryGetByName(dependency, out var input) || string.IsNullOrEmpty(input.Value))
+            {
+                return false;
+            }
+        }
+
+        return true;
     }
 
     private async Task<(InteractionInputCollection? Arguments, ExecuteCommandResult? Result)> PromptForCommandArgumentsAsync(ResourceCommandAnnotation annotation, InteractionInputCollection arguments, CancellationToken cancellationToken)

--- a/tests/Aspire.Cli.Tests/Commands/ResourceCommandHelpParserTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/ResourceCommandHelpParserTests.cs
@@ -1,0 +1,96 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.CommandLine;
+using Aspire.Cli.Commands;
+using CommandLineRootCommand = System.CommandLine.RootCommand;
+
+namespace Aspire.Cli.Tests.Commands;
+
+public class ResourceCommandHelpParserTests
+{
+    [Fact]
+    public void Parse_WithResourceAndCommand_ReturnsCommandSpecificHelpRequest()
+    {
+        var (command, resourceArgument, commandArgument, appHostOption) = CreateCommand();
+
+        var request = ResourceCommandHelpParser.Parse(
+            command.Parse("resource web wait-for-browser --help"),
+            resourceArgument,
+            commandArgument,
+            appHostOption);
+
+        Assert.NotNull(request);
+        Assert.Equal("web", request.ResourceName);
+        Assert.Equal("wait-for-browser", request.CommandName);
+        Assert.Null(request.AppHostProjectFile);
+    }
+
+    [Fact]
+    public void Parse_WithAppHostOption_ReturnsAppHostProjectFile()
+    {
+        var (command, resourceArgument, commandArgument, appHostOption) = CreateCommand();
+
+        var request = ResourceCommandHelpParser.Parse(
+            command.Parse("resource web wait-for-browser --apphost ./AppHost/AppHost.csproj --help"),
+            resourceArgument,
+            commandArgument,
+            appHostOption);
+
+        Assert.NotNull(request);
+        Assert.Equal("web", request.ResourceName);
+        Assert.Equal("wait-for-browser", request.CommandName);
+        var appHostProjectFile = Assert.IsType<FileInfo>(request.AppHostProjectFile);
+        Assert.EndsWith(Path.Combine("AppHost", "AppHost.csproj"), appHostProjectFile.FullName);
+    }
+
+    [Fact]
+    public void Parse_WithLegacyProjectOption_ReturnsAppHostProjectFile()
+    {
+        var (command, resourceArgument, commandArgument, appHostOption) = CreateCommand();
+
+        var request = ResourceCommandHelpParser.Parse(
+            command.Parse("resource web wait-for-browser --project ./AppHost/AppHost.csproj --help"),
+            resourceArgument,
+            commandArgument,
+            appHostOption);
+
+        Assert.NotNull(request);
+        Assert.Equal("web", request.ResourceName);
+        Assert.Equal("wait-for-browser", request.CommandName);
+        var appHostProjectFile = Assert.IsType<FileInfo>(request.AppHostProjectFile);
+        Assert.EndsWith(Path.Combine("AppHost", "AppHost.csproj"), appHostProjectFile.FullName);
+    }
+
+    [Theory]
+    [InlineData("resource --help")]
+    [InlineData("resource web --help")]
+    public void Parse_WithGenericResourceHelp_ReturnsNull(string commandLine)
+    {
+        var (command, resourceArgument, commandArgument, appHostOption) = CreateCommand();
+
+        var request = ResourceCommandHelpParser.Parse(
+            command.Parse(commandLine),
+            resourceArgument,
+            commandArgument,
+            appHostOption);
+
+        Assert.Null(request);
+    }
+
+    private static (CommandLineRootCommand Command, Argument<string> ResourceArgument, Argument<string> CommandArgument, OptionWithLegacy<FileInfo?> AppHostOption) CreateCommand()
+    {
+        var resourceArgument = new Argument<string>("resource");
+        var commandArgument = new Argument<string>("command");
+        var appHostOption = new OptionWithLegacy<FileInfo?>("--apphost", "--project", "AppHost path");
+        var resourceCommand = new Command("resource")
+        {
+            Arguments = { resourceArgument, commandArgument }
+        };
+        resourceCommand.Options.Add(appHostOption);
+
+        var rootCommand = new CommandLineRootCommand { resourceCommand };
+
+        return (rootCommand, resourceArgument, commandArgument, appHostOption);
+    }
+}

--- a/tests/Aspire.Cli.Tests/Commands/ResourceCommandHelpParserTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/ResourceCommandHelpParserTests.cs
@@ -65,6 +65,9 @@ public class ResourceCommandHelpParserTests
     [Theory]
     [InlineData("resource --help")]
     [InlineData("resource web --help")]
+    [InlineData("resource web --message --help")]
+    [InlineData("resource web --message=hi --help")]
+    [InlineData("resource web -- --message hi --help")]
     public void Parse_WithGenericResourceHelp_ReturnsNull(string commandLine)
     {
         var (command, resourceArgument, commandArgument, appHostOption) = CreateCommand();

--- a/tests/Aspire.Cli.Tests/Commands/ResourceCommandHelperTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/ResourceCommandHelperTests.cs
@@ -214,7 +214,7 @@ public class ResourceCommandHelperTests
         Assert.Equal(ExitCodeConstants.FailedToExecuteResourceCommand, exitCode);
         var error = Assert.Single(interactionService.DisplayedErrors);
         Assert.Contains("Command argument validation failed.", error);
-        Assert.Contains("target: Target must not be prod.", error);
+        Assert.Contains("--target: Target must not be prod.", error);
     }
 
     [Fact]

--- a/tests/Aspire.Cli.Tests/Commands/ResourceCommandHelperTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/ResourceCommandHelperTests.cs
@@ -216,4 +216,34 @@ public class ResourceCommandHelperTests
         Assert.Contains("Command argument validation failed.", error);
         Assert.Contains("target: Target must not be prod.", error);
     }
+
+    [Fact]
+    public async Task ExecuteGenericCommandAsync_WhenValidationErrorsIsNull_DisplaysCommandError()
+    {
+        var connection = new TestAppHostAuxiliaryBackchannel
+        {
+            ExecuteResourceCommandResult = new ExecuteResourceCommandResponse
+            {
+                Success = false,
+                Message = "Command 'ss' not available for resource 'test-resource'.",
+                ValidationErrors = null!
+            }
+        };
+
+        var interactionService = new TestInteractionService();
+
+        var exitCode = await ResourceCommandHelper.ExecuteGenericCommandAsync(
+            connection,
+            interactionService,
+            NullLogger.Instance,
+            "test-resource",
+            "ss",
+            arguments: null,
+            cancellationToken: CancellationToken.None).DefaultTimeout();
+
+        Assert.Equal(ExitCodeConstants.FailedToExecuteResourceCommand, exitCode);
+        var error = Assert.Single(interactionService.DisplayedErrors);
+        Assert.Contains("Failed to execute command 'ss' on resource 'test-resource'", error);
+        Assert.Contains("Command 'ss' not available for resource 'test-resource'.", error);
+    }
 }

--- a/tests/Aspire.Cli.Tests/Commands/ResourceCommandTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/ResourceCommandTests.cs
@@ -814,6 +814,35 @@ public class ResourceCommandTests(ITestOutputHelper outputHelper)
     }
 
     [Fact]
+    public async Task ResourceCommand_ForwardsCommandOptionsAfterDelimiter()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+
+        var backchannel = new TestAppHostAuxiliaryBackchannel
+        {
+            ExecuteResourceCommandResult = new ExecuteResourceCommandResponse { Success = true },
+            ResourceSnapshots =
+            [
+                CreateResourceSnapshot(
+                    "web-browser-automation",
+                    CreateCommand(
+                        "configure",
+                        CreateArgument("message"),
+                        CreateArgument("timeoutMilliseconds", inputType: "Number")))
+            ]
+        };
+        await using var provider = CreateServiceProvider(workspace, outputHelper, backchannel);
+
+        var command = provider.GetRequiredService<RootCommand>();
+        var result = command.Parse("""resource web-browser-automation configure -- --message "from delimiter" --timeout-milliseconds 10""");
+
+        var exitCode = await result.InvokeAsync().DefaultTimeout();
+
+        Assert.Equal(ExitCodeConstants.Success, exitCode);
+        AssertJsonObject(backchannel.ExecuteResourceCommandArguments, ("message", "from delimiter"), ("timeoutMilliseconds", "10"));
+    }
+
+    [Fact]
     public async Task ResourceCommand_DoesNotForwardCommandOptionWithoutDelimiterWhenNameCollidesWithCliOption()
     {
         using var workspace = TemporaryWorkspace.Create(outputHelper);
@@ -987,6 +1016,71 @@ public class ResourceCommandTests(ITestOutputHelper outputHelper)
         Assert.Equal(ExitCodeConstants.Success, exitCode);
         Assert.Contains("aspire resource web-browser-automation configure -- [command-options]", helpOutput);
         Assert.Contains("--log-level <value>  Log level for the resource command. Use `-- --log-level <value>` to pass this command option.", helpOutput);
+    }
+
+    [Fact]
+    public async Task ResourceCommand_CommandSpecificHelpShowsVisibleCliOptions()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        var helpWriter = new StringWriter();
+
+        var backchannel = new TestAppHostAuxiliaryBackchannel
+        {
+            ResourceSnapshots =
+            [
+                CreateResourceSnapshot(
+                    "web-browser-automation",
+                    CreateCommand("configure", "Configures the browser.", CreateArgument("selector")))
+            ]
+        };
+        await using var provider = CreateServiceProvider(workspace, outputHelper, backchannel);
+
+        var command = provider.GetRequiredService<RootCommand>();
+        var result = command.Parse("""resource web-browser-automation configure --help""");
+
+        var exitCode = await result.InvokeAsync(new InvocationConfiguration { Output = helpWriter }).DefaultTimeout();
+        var helpOutput = helpWriter.ToString();
+
+        Assert.Equal(ExitCodeConstants.Success, exitCode);
+        Assert.Contains("--apphost <apphost>", helpOutput);
+        Assert.Contains("-?, -h, --help", helpOutput);
+        Assert.Contains("-l, --log-level <log-level>", helpOutput);
+        Assert.Contains("--non-interactive", helpOutput);
+        Assert.Contains("--nologo", helpOutput);
+        Assert.Contains("--banner", helpOutput);
+        Assert.Contains("--wait-for-debugger", helpOutput);
+        Assert.DoesNotContain("--debug", helpOutput);
+    }
+
+    [Fact]
+    public async Task ResourceCommand_CommandSpecificHelpDoesNotMarkDefaultedRequiredArgumentsAsRequired()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        var helpWriter = new StringWriter();
+
+        var backchannel = new TestAppHostAuxiliaryBackchannel
+        {
+            ResourceSnapshots =
+            [
+                CreateResourceSnapshot(
+                    "web-browser-automation",
+                    CreateCommand(
+                        "configure",
+                        "Configures the browser.",
+                        CreateArgument("count", description: "Count value.", inputType: "Number", required: true, value: "5")))
+            ]
+        };
+        await using var provider = CreateServiceProvider(workspace, outputHelper, backchannel);
+
+        var command = provider.GetRequiredService<RootCommand>();
+        var result = command.Parse("""resource web-browser-automation configure --help""");
+
+        var exitCode = await result.InvokeAsync(new InvocationConfiguration { Output = helpWriter }).DefaultTimeout();
+        var helpOutput = helpWriter.ToString();
+
+        Assert.Equal(ExitCodeConstants.Success, exitCode);
+        Assert.Contains("--count <value>  Count value. Default: 5.", helpOutput);
+        Assert.DoesNotContain("--count <value>  Count value. Required.", helpOutput);
     }
 
     [Fact]

--- a/tests/Aspire.Cli.Tests/Commands/ResourceCommandTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/ResourceCommandTests.cs
@@ -9,6 +9,7 @@ using Aspire.Cli.Tests.TestServices;
 using Aspire.Cli.Tests.Utils;
 using Microsoft.AspNetCore.InternalTesting;
 using Microsoft.Extensions.DependencyInjection;
+using InvocationConfiguration = System.CommandLine.InvocationConfiguration;
 
 namespace Aspire.Cli.Tests.Commands;
 
@@ -127,13 +128,22 @@ public class ResourceCommandTests(ITestOutputHelper outputHelper)
     }
 
     [Fact]
-    public async Task ResourceCommand_ForwardsOrderedArguments()
+    public async Task ResourceCommand_DoesNotBindPositionalArgumentsByName()
     {
         using var workspace = TemporaryWorkspace.Create(outputHelper);
 
         var backchannel = new TestAppHostAuxiliaryBackchannel
         {
-            ExecuteResourceCommandResult = new ExecuteResourceCommandResponse { Success = true }
+            ExecuteResourceCommandResult = new ExecuteResourceCommandResponse { Success = true },
+            ResourceSnapshots =
+            [
+                CreateResourceSnapshot(
+                    "web-browser-automation",
+                    CreateCommand(
+                        "fill-browser",
+                        CreateArgument("selector"),
+                        CreateArgument("value")))
+            ]
         };
         var monitor = new TestAuxiliaryBackchannelMonitor();
         monitor.AddConnection("hash", "/tmp/test.sock", backchannel);
@@ -149,9 +159,8 @@ public class ResourceCommandTests(ITestOutputHelper outputHelper)
 
         var exitCode = await result.InvokeAsync().DefaultTimeout();
 
-        Assert.Equal(ExitCodeConstants.Success, exitCode);
-        AssertJsonStringArray(backchannel.ExecuteResourceCommandArguments, "#name", "Aspire");
-        Assert.True(backchannel.ExecuteResourceCommandOptions?.NonInteractive == true);
+        Assert.Equal(ExitCodeConstants.InvalidCommand, exitCode);
+        Assert.Equal(0, backchannel.ExecuteResourceCommandCallCount);
     }
 
     [Fact]
@@ -183,13 +192,22 @@ public class ResourceCommandTests(ITestOutputHelper outputHelper)
     }
 
     [Fact]
-    public async Task ResourceCommand_ForwardsEqualsArgumentsByOrder()
+    public async Task ResourceCommand_ForwardsOptionEqualsArgumentsByName()
     {
         using var workspace = TemporaryWorkspace.Create(outputHelper);
 
         var backchannel = new TestAppHostAuxiliaryBackchannel
         {
-            ExecuteResourceCommandResult = new ExecuteResourceCommandResponse { Success = true }
+            ExecuteResourceCommandResult = new ExecuteResourceCommandResponse { Success = true },
+            ResourceSnapshots =
+            [
+                CreateResourceSnapshot(
+                    "web-browser-automation",
+                    CreateCommand(
+                        "wait-for-browser",
+                        CreateArgument("text"),
+                        CreateArgument("timeoutMilliseconds", inputType: "Number")))
+            ]
         };
         var monitor = new TestAuxiliaryBackchannelMonitor();
         monitor.AddConnection("hash", "/tmp/test.sock", backchannel);
@@ -201,22 +219,28 @@ public class ResourceCommandTests(ITestOutputHelper outputHelper)
         using var provider = services.BuildServiceProvider();
 
         var command = provider.GetRequiredService<RootCommand>();
-        var result = command.Parse("""resource web-browser-automation wait-for-browser "text=Submitted Aspire!" timeoutMilliseconds=500""");
+        var result = command.Parse("""resource web-browser-automation wait-for-browser "--text=Submitted Aspire!" --timeoutMilliseconds=500""");
 
         var exitCode = await result.InvokeAsync().DefaultTimeout();
 
         Assert.Equal(ExitCodeConstants.Success, exitCode);
-        AssertJsonStringArray(backchannel.ExecuteResourceCommandArguments, "text=Submitted Aspire!", "timeoutMilliseconds=500");
+        AssertJsonObject(backchannel.ExecuteResourceCommandArguments, ("text", "Submitted Aspire!"), ("timeoutMilliseconds", "500"));
     }
 
     [Fact]
-    public async Task ResourceCommand_ForwardsJsonLookingArgumentByOrder()
+    public async Task ResourceCommand_DoesNotBindJsonLookingPositionalArgumentByName()
     {
         using var workspace = TemporaryWorkspace.Create(outputHelper);
 
         var backchannel = new TestAppHostAuxiliaryBackchannel
         {
-            ExecuteResourceCommandResult = new ExecuteResourceCommandResponse { Success = true }
+            ExecuteResourceCommandResult = new ExecuteResourceCommandResponse { Success = true },
+            ResourceSnapshots =
+            [
+                CreateResourceSnapshot(
+                    "web-browser-automation",
+                    CreateCommand("click-browser", CreateArgument("selector")))
+            ]
         };
         var monitor = new TestAuxiliaryBackchannelMonitor();
         monitor.AddConnection("hash", "/tmp/test.sock", backchannel);
@@ -232,12 +256,12 @@ public class ResourceCommandTests(ITestOutputHelper outputHelper)
 
         var exitCode = await result.InvokeAsync().DefaultTimeout();
 
-        Assert.Equal(ExitCodeConstants.Success, exitCode);
-        AssertJsonStringArray(backchannel.ExecuteResourceCommandArguments, "{\"selector\":\"#submit\"}");
+        Assert.Equal(ExitCodeConstants.InvalidCommand, exitCode);
+        Assert.Equal(0, backchannel.ExecuteResourceCommandCallCount);
     }
 
     [Fact]
-    public async Task ResourceCommand_ForwardsPositionalArgumentContainingEquals()
+    public async Task ResourceCommand_DoesNotForwardPositionalArgumentContainingEqualsAsArray()
     {
         using var workspace = TemporaryWorkspace.Create(outputHelper);
 
@@ -260,11 +284,11 @@ public class ResourceCommandTests(ITestOutputHelper outputHelper)
         var exitCode = await result.InvokeAsync().DefaultTimeout();
 
         Assert.Equal(ExitCodeConstants.Success, exitCode);
-        AssertJsonStringArray(backchannel.ExecuteResourceCommandArguments, "https://example.com/?q=aspire");
+        AssertJsonObject(backchannel.ExecuteResourceCommandArguments, ("https://example.com/?q=aspire", null));
     }
 
     [Fact]
-    public async Task ResourceCommand_ForwardsExtraArguments()
+    public async Task ResourceCommand_DoesNotForwardExtraArgumentsAsArray()
     {
         using var workspace = TemporaryWorkspace.Create(outputHelper);
 
@@ -287,11 +311,11 @@ public class ResourceCommandTests(ITestOutputHelper outputHelper)
         var exitCode = await result.InvokeAsync().DefaultTimeout();
 
         Assert.Equal(ExitCodeConstants.Success, exitCode);
-        AssertJsonStringArray(backchannel.ExecuteResourceCommandArguments, "#submit", "extra");
+        AssertJsonObject(backchannel.ExecuteResourceCommandArguments, ("#submit", null), ("extra", null));
     }
 
     [Fact]
-    public async Task ResourceCommand_ForwardsOptionLookingArgumentsByOrder()
+    public async Task ResourceCommand_DoesNotInferOptionLookingArgumentsWithoutMetadata()
     {
         using var workspace = TemporaryWorkspace.Create(outputHelper);
 
@@ -314,21 +338,840 @@ public class ResourceCommandTests(ITestOutputHelper outputHelper)
         var exitCode = await result.InvokeAsync().DefaultTimeout();
 
         Assert.Equal(ExitCodeConstants.Success, exitCode);
-        AssertJsonStringArray(backchannel.ExecuteResourceCommandArguments, "--selector", "#submit", "--count", "2");
+        AssertJsonObject(backchannel.ExecuteResourceCommandArguments, ("--selector", null), ("#submit", null), ("--count", null), ("2", null));
     }
 
-    private static void AssertJsonStringArray(JsonNode? actual, params string[] expected)
+    [Fact]
+    public async Task ResourceCommand_DoesNotInferBareOptionWithoutMetadata()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+
+        var backchannel = new TestAppHostAuxiliaryBackchannel
+        {
+            ExecuteResourceCommandResult = new ExecuteResourceCommandResponse { Success = true }
+        };
+        var monitor = new TestAuxiliaryBackchannelMonitor();
+        monitor.AddConnection("hash", "/tmp/test.sock", backchannel);
+
+        var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper, options =>
+        {
+            options.AuxiliaryBackchannelMonitorFactory = _ => monitor;
+        });
+        using var provider = services.BuildServiceProvider();
+
+        var command = provider.GetRequiredService<RootCommand>();
+        var result = command.Parse("""resource web-browser-automation configure --verbose""");
+
+        var exitCode = await result.InvokeAsync().DefaultTimeout();
+
+        Assert.Equal(ExitCodeConstants.Success, exitCode);
+        AssertJsonObject(backchannel.ExecuteResourceCommandArguments, ("--verbose", null));
+    }
+
+    [Fact]
+    public async Task ResourceCommand_ForwardsOptionalArgumentsByName()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+
+        var backchannel = new TestAppHostAuxiliaryBackchannel
+        {
+            ExecuteResourceCommandResult = new ExecuteResourceCommandResponse { Success = true },
+            ResourceSnapshots =
+            [
+                CreateResourceSnapshot(
+                    "web-browser-automation",
+                    CreateCommand(
+                        "wait-for-browser",
+                        CreateArgument("selector"),
+                        CreateArgument("timeoutMilliseconds", inputType: "Number")))
+            ]
+        };
+        var monitor = new TestAuxiliaryBackchannelMonitor();
+        monitor.AddConnection("hash", "/tmp/test.sock", backchannel);
+
+        var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper, options =>
+        {
+            options.AuxiliaryBackchannelMonitorFactory = _ => monitor;
+        });
+        using var provider = services.BuildServiceProvider();
+
+        var command = provider.GetRequiredService<RootCommand>();
+        var result = command.Parse("""resource web-browser-automation wait-for-browser --timeout-milliseconds 500""");
+
+        var exitCode = await result.InvokeAsync().DefaultTimeout();
+
+        Assert.Equal(ExitCodeConstants.Success, exitCode);
+        AssertJsonObject(backchannel.ExecuteResourceCommandArguments, ("timeoutMilliseconds", "500"));
+    }
+
+    [Fact]
+    public async Task ResourceCommand_ForwardsKebabCaseEqualsAndBareBooleanArgumentsByName()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+
+        var backchannel = new TestAppHostAuxiliaryBackchannel
+        {
+            ExecuteResourceCommandResult = new ExecuteResourceCommandResponse { Success = true },
+            ResourceSnapshots =
+            [
+                CreateResourceSnapshot(
+                    "web-browser-automation",
+                    CreateCommand(
+                        "configure",
+                        CreateArgument("timeoutMilliseconds", inputType: "Number"),
+                        CreateArgument("proxy", inputType: "Boolean")))
+            ]
+        };
+        var monitor = new TestAuxiliaryBackchannelMonitor();
+        monitor.AddConnection("hash", "/tmp/test.sock", backchannel);
+
+        var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper, options =>
+        {
+            options.AuxiliaryBackchannelMonitorFactory = _ => monitor;
+        });
+        using var provider = services.BuildServiceProvider();
+
+        var command = provider.GetRequiredService<RootCommand>();
+        var result = command.Parse("""resource web-browser-automation configure --timeout-milliseconds=500 --proxy""");
+
+        var exitCode = await result.InvokeAsync().DefaultTimeout();
+
+        Assert.Equal(ExitCodeConstants.Success, exitCode);
+        AssertJsonObject(backchannel.ExecuteResourceCommandArguments, ("timeoutMilliseconds", "500"), ("proxy", "true"));
+    }
+
+    [Theory]
+    [InlineData("--proxy true", "true")]
+    [InlineData("--proxy false", "false")]
+    [InlineData("--proxy=false", "false")]
+    public async Task ResourceCommand_ForwardsExplicitBooleanCommandOptionValues(string arguments, string expectedValue)
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+
+        var backchannel = new TestAppHostAuxiliaryBackchannel
+        {
+            ExecuteResourceCommandResult = new ExecuteResourceCommandResponse { Success = true },
+            ResourceSnapshots =
+            [
+                CreateResourceSnapshot(
+                    "web-browser-automation",
+                    CreateCommand(
+                        "configure",
+                        CreateArgument("proxy", inputType: "Boolean")))
+            ]
+        };
+        await using var provider = CreateServiceProvider(workspace, outputHelper, backchannel);
+
+        var command = provider.GetRequiredService<RootCommand>();
+        var result = command.Parse($"""resource web-browser-automation configure {arguments}""");
+
+        var exitCode = await result.InvokeAsync().DefaultTimeout();
+
+        Assert.Equal(ExitCodeConstants.Success, exitCode);
+        AssertJsonObject(backchannel.ExecuteResourceCommandArguments, ("proxy", expectedValue));
+    }
+
+    [Fact]
+    public async Task ResourceCommand_ForwardsValidChoiceCommandOption()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+
+        var backchannel = new TestAppHostAuxiliaryBackchannel
+        {
+            ExecuteResourceCommandResult = new ExecuteResourceCommandResponse { Success = true },
+            ResourceSnapshots =
+            [
+                CreateResourceSnapshot(
+                    "web-browser-automation",
+                    CreateCommand(
+                        "configure",
+                        CreateArgument(
+                            "flavor",
+                            inputType: "Choice",
+                            options: new Dictionary<string, string?>
+                            {
+                                ["vanilla"] = "Vanilla",
+                                ["chocolate"] = "Chocolate"
+                            })))
+            ]
+        };
+        await using var provider = CreateServiceProvider(workspace, outputHelper, backchannel);
+
+        var command = provider.GetRequiredService<RootCommand>();
+        var result = command.Parse("""resource web-browser-automation configure --flavor chocolate""");
+
+        var exitCode = await result.InvokeAsync().DefaultTimeout();
+
+        Assert.Equal(ExitCodeConstants.Success, exitCode);
+        AssertJsonObject(backchannel.ExecuteResourceCommandArguments, ("flavor", "chocolate"));
+    }
+
+    [Fact]
+    public async Task ResourceCommand_ReturnsInvalidCommandForInvalidChoiceCommandOption()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        var interactionService = new TestInteractionService();
+
+        var backchannel = new TestAppHostAuxiliaryBackchannel
+        {
+            ExecuteResourceCommandResult = new ExecuteResourceCommandResponse { Success = true },
+            ResourceSnapshots =
+            [
+                CreateResourceSnapshot(
+                    "web-browser-automation",
+                    CreateCommand(
+                        "configure",
+                        CreateArgument(
+                            "flavor",
+                            inputType: "Choice",
+                            options: new Dictionary<string, string?>
+                            {
+                                ["vanilla"] = "Vanilla",
+                                ["chocolate"] = "Chocolate"
+                            })))
+            ]
+        };
+        await using var provider = CreateServiceProvider(workspace, outputHelper, backchannel, interactionService);
+
+        var command = provider.GetRequiredService<RootCommand>();
+        var result = command.Parse("""resource web-browser-automation configure --flavor strawberry""");
+
+        var exitCode = await result.InvokeAsync().DefaultTimeout();
+
+        Assert.Equal(ExitCodeConstants.InvalidCommand, exitCode);
+        Assert.Equal(0, backchannel.ExecuteResourceCommandCallCount);
+        var error = Assert.Single(interactionService.DisplayedErrors);
+        Assert.Contains("--flavor", error);
+        Assert.Contains("vanilla, chocolate", error);
+    }
+
+    [Fact]
+    public async Task ResourceCommand_ForwardsCustomChoiceCommandOptionWhenAllowed()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+
+        var backchannel = new TestAppHostAuxiliaryBackchannel
+        {
+            ExecuteResourceCommandResult = new ExecuteResourceCommandResponse { Success = true },
+            ResourceSnapshots =
+            [
+                CreateResourceSnapshot(
+                    "web-browser-automation",
+                    CreateCommand(
+                        "configure",
+                        CreateArgument(
+                            "flavor",
+                            inputType: "Choice",
+                            options: new Dictionary<string, string?>
+                            {
+                                ["vanilla"] = "Vanilla",
+                                ["chocolate"] = "Chocolate"
+                            },
+                            allowCustomChoice: true)))
+            ]
+        };
+        await using var provider = CreateServiceProvider(workspace, outputHelper, backchannel);
+
+        var command = provider.GetRequiredService<RootCommand>();
+        var result = command.Parse("""resource web-browser-automation configure --flavor strawberry""");
+
+        var exitCode = await result.InvokeAsync().DefaultTimeout();
+
+        Assert.Equal(ExitCodeConstants.Success, exitCode);
+        AssertJsonObject(backchannel.ExecuteResourceCommandArguments, ("flavor", "strawberry"));
+    }
+
+    [Fact]
+    public async Task ResourceCommand_DoesNotSerializeOmittedCommandOptionDefaults()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+
+        var backchannel = new TestAppHostAuxiliaryBackchannel
+        {
+            ExecuteResourceCommandResult = new ExecuteResourceCommandResponse { Success = true },
+            ResourceSnapshots =
+            [
+                CreateResourceSnapshot(
+                    "web-browser-automation",
+                    CreateCommand(
+                        "configure",
+                        CreateArgument("message", value: "hello"),
+                        CreateArgument("count", inputType: "Number", required: true, value: "5"),
+                        CreateArgument("enabled", inputType: "Boolean", value: "true")))
+            ]
+        };
+        await using var provider = CreateServiceProvider(workspace, outputHelper, backchannel);
+
+        var command = provider.GetRequiredService<RootCommand>();
+        var result = command.Parse("""resource web-browser-automation configure""");
+
+        var exitCode = await result.InvokeAsync().DefaultTimeout();
+
+        Assert.Equal(ExitCodeConstants.Success, exitCode);
+        AssertJsonObject(backchannel.ExecuteResourceCommandArguments);
+    }
+
+    [Theory]
+    [InlineData("--message", "--message")]
+    [InlineData("--count", "--count")]
+    public async Task ResourceCommand_ReturnsInvalidCommandForMissingCommandOptionValue(string arguments, string expectedOptionName)
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        var interactionService = new TestInteractionService();
+
+        var backchannel = new TestAppHostAuxiliaryBackchannel
+        {
+            ExecuteResourceCommandResult = new ExecuteResourceCommandResponse { Success = true },
+            ResourceSnapshots =
+            [
+                CreateResourceSnapshot(
+                    "web-browser-automation",
+                    CreateCommand(
+                        "configure",
+                        CreateArgument("message"),
+                        CreateArgument("count", inputType: "Number")))
+            ]
+        };
+        await using var provider = CreateServiceProvider(workspace, outputHelper, backchannel, interactionService);
+
+        var command = provider.GetRequiredService<RootCommand>();
+        var result = command.Parse($"""resource web-browser-automation configure {arguments}""");
+
+        var exitCode = await result.InvokeAsync().DefaultTimeout();
+
+        Assert.Equal(ExitCodeConstants.InvalidCommand, exitCode);
+        Assert.Equal(0, backchannel.ExecuteResourceCommandCallCount);
+        var error = Assert.Single(interactionService.DisplayedErrors);
+        Assert.Contains(expectedOptionName, error);
+    }
+
+    [Fact]
+    public async Task ResourceCommand_ReturnsInvalidCommandForDuplicateCommandOption()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+
+        var backchannel = new TestAppHostAuxiliaryBackchannel
+        {
+            ExecuteResourceCommandResult = new ExecuteResourceCommandResponse { Success = true },
+            ResourceSnapshots =
+            [
+                CreateResourceSnapshot(
+                    "web-browser-automation",
+                    CreateCommand("configure", CreateArgument("message")))
+            ]
+        };
+        await using var provider = CreateServiceProvider(workspace, outputHelper, backchannel);
+
+        var command = provider.GetRequiredService<RootCommand>();
+        var result = command.Parse("""resource web-browser-automation configure --message first --message second""");
+
+        var exitCode = await result.InvokeAsync().DefaultTimeout();
+
+        Assert.Equal(ExitCodeConstants.InvalidCommand, exitCode);
+        Assert.Equal(0, backchannel.ExecuteResourceCommandCallCount);
+    }
+
+    [Fact]
+    public async Task ResourceCommand_ReturnsInvalidCommandForMissingRequiredCommandOption()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+
+        var backchannel = new TestAppHostAuxiliaryBackchannel
+        {
+            ExecuteResourceCommandResult = new ExecuteResourceCommandResponse { Success = true },
+            ResourceSnapshots =
+            [
+                CreateResourceSnapshot(
+                    "web-browser-automation",
+                    CreateCommand(
+                        "wait-for-browser",
+                        CreateArgument("selector", required: true),
+                        CreateArgument("timeoutMilliseconds", inputType: "Number")))
+            ]
+        };
+        var monitor = new TestAuxiliaryBackchannelMonitor();
+        monitor.AddConnection("hash", "/tmp/test.sock", backchannel);
+
+        var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper, options =>
+        {
+            options.AuxiliaryBackchannelMonitorFactory = _ => monitor;
+        });
+        using var provider = services.BuildServiceProvider();
+
+        var command = provider.GetRequiredService<RootCommand>();
+        var result = command.Parse("""resource web-browser-automation wait-for-browser --timeout-milliseconds 500""");
+
+        var exitCode = await result.InvokeAsync().DefaultTimeout();
+
+        Assert.Equal(ExitCodeConstants.InvalidCommand, exitCode);
+        Assert.Equal(0, backchannel.ExecuteResourceCommandCallCount);
+    }
+
+    [Fact]
+    public async Task ResourceCommand_ReturnsInvalidCommandForInvalidNumberCommandOption()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+
+        var backchannel = new TestAppHostAuxiliaryBackchannel
+        {
+            ExecuteResourceCommandResult = new ExecuteResourceCommandResponse { Success = true },
+            ResourceSnapshots =
+            [
+                CreateResourceSnapshot(
+                    "web-browser-automation",
+                    CreateCommand(
+                        "wait-for-browser",
+                        CreateArgument("timeoutMilliseconds", inputType: "Number")))
+            ]
+        };
+        var monitor = new TestAuxiliaryBackchannelMonitor();
+        monitor.AddConnection("hash", "/tmp/test.sock", backchannel);
+
+        var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper, options =>
+        {
+            options.AuxiliaryBackchannelMonitorFactory = _ => monitor;
+        });
+        using var provider = services.BuildServiceProvider();
+
+        var command = provider.GetRequiredService<RootCommand>();
+        var result = command.Parse("""resource web-browser-automation wait-for-browser --timeout-milliseconds not-a-number""");
+
+        var exitCode = await result.InvokeAsync().DefaultTimeout();
+
+        Assert.Equal(ExitCodeConstants.InvalidCommand, exitCode);
+        Assert.Equal(0, backchannel.ExecuteResourceCommandCallCount);
+    }
+
+    [Fact]
+    public async Task ResourceCommand_DoesNotBindMixedNamedAndPositionalArgumentsByName()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+
+        var backchannel = new TestAppHostAuxiliaryBackchannel
+        {
+            ExecuteResourceCommandResult = new ExecuteResourceCommandResponse { Success = true },
+            ResourceSnapshots =
+            [
+                CreateResourceSnapshot(
+                    "web-browser-automation",
+                    CreateCommand(
+                        "fill-browser",
+                        CreateArgument("selector"),
+                        CreateArgument("value")))
+            ]
+        };
+        var monitor = new TestAuxiliaryBackchannelMonitor();
+        monitor.AddConnection("hash", "/tmp/test.sock", backchannel);
+
+        var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper, options =>
+        {
+            options.AuxiliaryBackchannelMonitorFactory = _ => monitor;
+        });
+        using var provider = services.BuildServiceProvider();
+
+        var command = provider.GetRequiredService<RootCommand>();
+        var result = command.Parse("""resource web-browser-automation fill-browser --selector "#name" Aspire""");
+
+        var exitCode = await result.InvokeAsync().DefaultTimeout();
+
+        Assert.Equal(ExitCodeConstants.InvalidCommand, exitCode);
+        Assert.Equal(0, backchannel.ExecuteResourceCommandCallCount);
+    }
+
+    [Fact]
+    public async Task ResourceCommand_ForwardsCommandOptionAfterDelimiterWhenNameCollidesWithCliOption()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+
+        var backchannel = new TestAppHostAuxiliaryBackchannel
+        {
+            ExecuteResourceCommandResult = new ExecuteResourceCommandResponse { Success = true },
+            ResourceSnapshots =
+            [
+                CreateResourceSnapshot(
+                    "web-browser-automation",
+                    CreateCommand(
+                        "configure",
+                        CreateArgument("logLevel")))
+            ]
+        };
+        var monitor = new TestAuxiliaryBackchannelMonitor();
+        monitor.AddConnection("hash", "/tmp/test.sock", backchannel);
+
+        var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper, options =>
+        {
+            options.AuxiliaryBackchannelMonitorFactory = _ => monitor;
+        });
+        using var provider = services.BuildServiceProvider();
+
+        var command = provider.GetRequiredService<RootCommand>();
+        var result = command.Parse("""resource web-browser-automation configure -- --log-level Debug""");
+
+        var exitCode = await result.InvokeAsync().DefaultTimeout();
+
+        Assert.Equal(ExitCodeConstants.Success, exitCode);
+        AssertJsonObject(backchannel.ExecuteResourceCommandArguments, ("logLevel", "Debug"));
+    }
+
+    [Fact]
+    public async Task ResourceCommand_DoesNotForwardCommandOptionWithoutDelimiterWhenNameCollidesWithCliOption()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+
+        var backchannel = new TestAppHostAuxiliaryBackchannel
+        {
+            ExecuteResourceCommandResult = new ExecuteResourceCommandResponse { Success = true },
+            ResourceSnapshots =
+            [
+                CreateResourceSnapshot(
+                    "web-browser-automation",
+                    CreateCommand(
+                        "configure",
+                        CreateArgument("logLevel")))
+            ]
+        };
+        await using var provider = CreateServiceProvider(workspace, outputHelper, backchannel);
+
+        var command = provider.GetRequiredService<RootCommand>();
+        var result = command.Parse("""resource web-browser-automation configure --log-level Debug""");
+
+        var exitCode = await result.InvokeAsync().DefaultTimeout();
+
+        Assert.Equal(ExitCodeConstants.Success, exitCode);
+        AssertJsonObject(backchannel.ExecuteResourceCommandArguments);
+    }
+
+    [Fact]
+    public async Task ResourceCommand_ForwardsExactArgumentNameThatStartsWithNo()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+
+        var backchannel = new TestAppHostAuxiliaryBackchannel
+        {
+            ExecuteResourceCommandResult = new ExecuteResourceCommandResponse { Success = true },
+            ResourceSnapshots =
+            [
+                CreateResourceSnapshot(
+                    "web-browser-automation",
+                    CreateCommand(
+                        "configure",
+                        CreateArgument("noProxy")))
+            ]
+        };
+        var monitor = new TestAuxiliaryBackchannelMonitor();
+        monitor.AddConnection("hash", "/tmp/test.sock", backchannel);
+
+        var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper, options =>
+        {
+            options.AuxiliaryBackchannelMonitorFactory = _ => monitor;
+        });
+        using var provider = services.BuildServiceProvider();
+
+        var command = provider.GetRequiredService<RootCommand>();
+        var result = command.Parse("""resource web-browser-automation configure --no-proxy localhost""");
+
+        var exitCode = await result.InvokeAsync().DefaultTimeout();
+
+        Assert.Equal(ExitCodeConstants.Success, exitCode);
+        AssertJsonObject(backchannel.ExecuteResourceCommandArguments, ("noProxy", "localhost"));
+    }
+
+    [Fact]
+    public async Task ResourceCommand_DoesNotSynthesizeNegatedBooleanArgument()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+
+        var backchannel = new TestAppHostAuxiliaryBackchannel
+        {
+            ExecuteResourceCommandResult = new ExecuteResourceCommandResponse { Success = true },
+            ResourceSnapshots =
+            [
+                CreateResourceSnapshot(
+                    "web-browser-automation",
+                    CreateCommand(
+                        "configure",
+                        CreateArgument("proxy", inputType: "Boolean")))
+            ]
+        };
+        var monitor = new TestAuxiliaryBackchannelMonitor();
+        monitor.AddConnection("hash", "/tmp/test.sock", backchannel);
+
+        var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper, options =>
+        {
+            options.AuxiliaryBackchannelMonitorFactory = _ => monitor;
+        });
+        using var provider = services.BuildServiceProvider();
+
+        var command = provider.GetRequiredService<RootCommand>();
+        var result = command.Parse("""resource web-browser-automation configure --no-proxy""");
+
+        var exitCode = await result.InvokeAsync().DefaultTimeout();
+
+        Assert.Equal(ExitCodeConstants.InvalidCommand, exitCode);
+        Assert.Equal(0, backchannel.ExecuteResourceCommandCallCount);
+    }
+
+    [Fact]
+    public async Task ResourceCommand_CommandSpecificHelpShowsArgumentInputs()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        var helpWriter = new StringWriter();
+
+        var backchannel = new TestAppHostAuxiliaryBackchannel
+        {
+            ResourceSnapshots =
+            [
+                CreateResourceSnapshot(
+                    "web-browser-automation",
+                    CreateCommand(
+                        "wait-for-browser",
+                        "Waits for text in the browser.",
+                        CreateArgument("selector", description: "Selector to wait for.", required: true),
+                        CreateArgument("timeoutMilliseconds", description: "Timeout in milliseconds.", inputType: "Number")))
+            ]
+        };
+        var monitor = new TestAuxiliaryBackchannelMonitor();
+        monitor.AddConnection("hash", "/tmp/test.sock", backchannel);
+
+        var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper, options =>
+        {
+            options.AuxiliaryBackchannelMonitorFactory = _ => monitor;
+        });
+        using var provider = services.BuildServiceProvider();
+
+        var command = provider.GetRequiredService<RootCommand>();
+        var result = command.Parse("""resource web-browser-automation wait-for-browser --help""");
+
+        var exitCode = await result.InvokeAsync(new InvocationConfiguration { Output = helpWriter }).DefaultTimeout();
+        var helpOutput = helpWriter.ToString();
+
+        Assert.Equal(ExitCodeConstants.Success, exitCode);
+        Assert.Contains("Waits for text in the browser.", helpOutput);
+        Assert.Contains("--selector <value>  Selector to wait for. Required.", helpOutput);
+        Assert.Contains("--timeout-milliseconds <value>  Timeout in milliseconds.", helpOutput);
+    }
+
+    [Fact]
+    public async Task ResourceCommand_CommandSpecificHelpShowsDelimiterForArgumentNamesThatCollideWithCliOptions()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        var helpWriter = new StringWriter();
+
+        var backchannel = new TestAppHostAuxiliaryBackchannel
+        {
+            ResourceSnapshots =
+            [
+                CreateResourceSnapshot(
+                    "web-browser-automation",
+                    CreateCommand(
+                        "configure",
+                        "Configures the browser.",
+                        CreateArgument("logLevel", description: "Log level for the resource command.")))
+            ]
+        };
+        var monitor = new TestAuxiliaryBackchannelMonitor();
+        monitor.AddConnection("hash", "/tmp/test.sock", backchannel);
+
+        var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper, options =>
+        {
+            options.AuxiliaryBackchannelMonitorFactory = _ => monitor;
+        });
+        using var provider = services.BuildServiceProvider();
+
+        var command = provider.GetRequiredService<RootCommand>();
+        var result = command.Parse("""resource web-browser-automation configure --help""");
+
+        var exitCode = await result.InvokeAsync(new InvocationConfiguration { Output = helpWriter }).DefaultTimeout();
+        var helpOutput = helpWriter.ToString();
+
+        Assert.Equal(ExitCodeConstants.Success, exitCode);
+        Assert.Contains("aspire resource web-browser-automation configure -- [command-options]", helpOutput);
+        Assert.Contains("--log-level <value>  Log level for the resource command. Use `-- --log-level <value>` to pass this command option.", helpOutput);
+    }
+
+    [Fact]
+    public async Task ResourceCommand_CommandSpecificHelpFallsBackToDefaultHelpWhenAppHostIsNotRunning()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        var helpWriter = new StringWriter();
+
+        var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper);
+        using var provider = services.BuildServiceProvider();
+
+        var command = provider.GetRequiredService<RootCommand>();
+        var result = command.Parse("""resource web-browser-automation configure --help""");
+
+        var exitCode = await result.InvokeAsync(new InvocationConfiguration { Output = helpWriter }).DefaultTimeout();
+        var helpOutput = helpWriter.ToString();
+
+        Assert.Equal(ExitCodeConstants.Success, exitCode);
+        Assert.Contains("Usage:", helpOutput);
+        Assert.DoesNotContain("Command options:", helpOutput);
+    }
+
+    [Fact]
+    public async Task ResourceCommand_CommandSpecificHelpFallsBackToDefaultHelpWhenCommandMetadataIsMissing()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        var helpWriter = new StringWriter();
+
+        var backchannel = new TestAppHostAuxiliaryBackchannel
+        {
+            ResourceSnapshots =
+            [
+                CreateResourceSnapshot("web-browser-automation")
+            ]
+        };
+        await using var provider = CreateServiceProvider(workspace, outputHelper, backchannel);
+
+        var command = provider.GetRequiredService<RootCommand>();
+        var result = command.Parse("""resource web-browser-automation configure --help""");
+
+        var exitCode = await result.InvokeAsync(new InvocationConfiguration { Output = helpWriter }).DefaultTimeout();
+        var helpOutput = helpWriter.ToString();
+
+        Assert.Equal(ExitCodeConstants.Success, exitCode);
+        Assert.Contains("Usage:", helpOutput);
+        Assert.DoesNotContain("Command options:", helpOutput);
+    }
+
+    [Fact]
+    public async Task ResourceCommand_CommandSpecificHelpForAllArgumentTypesMatchesSnapshot()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        var helpWriter = new StringWriter();
+
+        var backchannel = new TestAppHostAuxiliaryBackchannel
+        {
+            ResourceSnapshots =
+            [
+                CreateResourceSnapshot(
+                    "argument-commands",
+                    CreateCommand(
+                        "all-argument-types",
+                        "Exercises command help for every supported resource command argument shape.",
+                        CreateArgument("message", description: "Text input shown as a value option.", required: true),
+                        CreateArgument("secret", description: "Secret text input shown as a value option.", inputType: "SecretText"),
+                        CreateArgument("count", description: "Number input with a default.", inputType: "Number", required: true, value: "5"),
+                        CreateArgument("enabled", description: "Boolean input shown as a flag.", inputType: "Boolean", value: "true"),
+                        CreateArgument(
+                            "flavor",
+                            description: "Choice input with fixed allowed values.",
+                            inputType: "Choice",
+                            options: new Dictionary<string, string?>
+                            {
+                                ["vanilla"] = "Vanilla",
+                                ["chocolate"] = "Chocolate"
+                            }),
+                        CreateArgument("logLevel", description: "Command option colliding with a CLI option.")))
+            ]
+        };
+        var monitor = new TestAuxiliaryBackchannelMonitor();
+        monitor.AddConnection("hash", "/tmp/test.sock", backchannel);
+
+        var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper, options =>
+        {
+            options.AuxiliaryBackchannelMonitorFactory = _ => monitor;
+        });
+        using var provider = services.BuildServiceProvider();
+
+        var command = provider.GetRequiredService<RootCommand>();
+        var result = command.Parse("""resource argument-commands all-argument-types --help""");
+
+        var exitCode = await result.InvokeAsync(new InvocationConfiguration { Output = helpWriter }).DefaultTimeout();
+
+        Assert.Equal(ExitCodeConstants.Success, exitCode);
+        await Verify(helpWriter.ToString(), extension: "txt");
+    }
+
+    private static void AssertJsonObject(JsonNode? actual, params (string Name, string? Value)[] expected)
     {
         Assert.NotNull(actual);
-        var actualArray = Assert.IsType<JsonArray>(actual);
-        var actualElements = actualArray.ToArray();
-        Assert.Equal(expected.Length, actualElements.Length);
+        var actualObject = Assert.IsType<JsonObject>(actual);
+        Assert.Equal(expected.Length, actualObject.Count);
 
-        for (var i = 0; i < expected.Length; i++)
+        foreach (var (name, value) in expected)
         {
-            var actualElement = Assert.IsAssignableFrom<JsonValue>(actualElements[i]);
-            Assert.Equal(JsonValueKind.String, actualElement.GetValueKind());
-            Assert.Equal(expected[i], actualElement.GetValue<string>());
+            Assert.True(actualObject.TryGetPropertyValue(name, out var actualValue), $"Expected argument '{name}' to exist.");
+            if (value is null)
+            {
+                Assert.Null(actualValue);
+            }
+            else
+            {
+                var actualElement = Assert.IsAssignableFrom<JsonValue>(actualValue);
+                Assert.Equal(JsonValueKind.String, actualElement.GetValueKind());
+                Assert.Equal(value, actualElement.GetValue<string>());
+            }
         }
+    }
+
+    private static ResourceSnapshot CreateResourceSnapshot(string name, params ResourceSnapshotCommand[] commands)
+    {
+        return new ResourceSnapshot
+        {
+            Name = name,
+            DisplayName = name,
+            State = "Running",
+            Commands = commands
+        };
+    }
+
+    private static ServiceProvider CreateServiceProvider(
+        TemporaryWorkspace workspace,
+        ITestOutputHelper outputHelper,
+        TestAppHostAuxiliaryBackchannel backchannel,
+        TestInteractionService? interactionService = null)
+    {
+        var monitor = new TestAuxiliaryBackchannelMonitor();
+        monitor.AddConnection("hash", "/tmp/test.sock", backchannel);
+
+        var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper, options =>
+        {
+            options.AuxiliaryBackchannelMonitorFactory = _ => monitor;
+            if (interactionService is not null)
+            {
+                options.InteractionServiceFactory = _ => interactionService;
+            }
+        });
+
+        return services.BuildServiceProvider();
+    }
+
+    private static ResourceSnapshotCommand CreateCommand(string name, params ResourceSnapshotCommandArgument[] argumentInputs)
+    {
+        return CreateCommand(name, description: null, argumentInputs);
+    }
+
+    private static ResourceSnapshotCommand CreateCommand(string name, string? description, params ResourceSnapshotCommandArgument[] argumentInputs)
+    {
+        return new ResourceSnapshotCommand
+        {
+            Name = name,
+            Description = description,
+            State = "Enabled",
+            ArgumentInputs = argumentInputs
+        };
+    }
+
+    private static ResourceSnapshotCommandArgument CreateArgument(
+        string name,
+        string? description = null,
+        string inputType = "Text",
+        bool required = false,
+        string? value = null,
+        Dictionary<string, string?>? options = null,
+        bool allowCustomChoice = false)
+    {
+        return new ResourceSnapshotCommandArgument
+        {
+            Name = name,
+            Description = description,
+            InputType = inputType,
+            Required = required,
+            Value = value,
+            Options = options,
+            AllowCustomChoice = allowCustomChoice
+        };
     }
 }

--- a/tests/Aspire.Cli.Tests/Commands/ResourceCommandTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/ResourceCommandTests.cs
@@ -675,6 +675,7 @@ public class ResourceCommandTests(ITestOutputHelper outputHelper)
     public async Task ResourceCommand_ReturnsInvalidCommandForMissingRequiredCommandOption()
     {
         using var workspace = TemporaryWorkspace.Create(outputHelper);
+        var interactionService = new TestInteractionService();
 
         var backchannel = new TestAppHostAuxiliaryBackchannel
         {
@@ -689,14 +690,7 @@ public class ResourceCommandTests(ITestOutputHelper outputHelper)
                         CreateArgument("timeoutMilliseconds", inputType: "Number")))
             ]
         };
-        var monitor = new TestAuxiliaryBackchannelMonitor();
-        monitor.AddConnection("hash", "/tmp/test.sock", backchannel);
-
-        var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper, options =>
-        {
-            options.AuxiliaryBackchannelMonitorFactory = _ => monitor;
-        });
-        using var provider = services.BuildServiceProvider();
+        await using var provider = CreateServiceProvider(workspace, outputHelper, backchannel, interactionService);
 
         var command = provider.GetRequiredService<RootCommand>();
         var result = command.Parse("""resource web-browser-automation wait-for-browser --timeout-milliseconds 500""");
@@ -705,6 +699,8 @@ public class ResourceCommandTests(ITestOutputHelper outputHelper)
 
         Assert.Equal(ExitCodeConstants.InvalidCommand, exitCode);
         Assert.Equal(0, backchannel.ExecuteResourceCommandCallCount);
+        var error = Assert.Single(interactionService.DisplayedErrors);
+        Assert.Contains("--selector", error);
     }
 
     [Fact]

--- a/tests/Aspire.Cli.Tests/Commands/ResourceCommandTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/ResourceCommandTests.cs
@@ -40,7 +40,9 @@ public class ResourceCommandTests(ITestOutputHelper outputHelper)
         var command = provider.GetRequiredService<RootCommand>();
         var result = command.Parse("resource");
 
-        // Missing required argument should fail
+        var error = Assert.Single(result.Errors);
+        Assert.Equal("The 'resource' argument is required.", error.Message);
+
         var exitCode = await result.InvokeAsync().DefaultTimeout();
         Assert.NotEqual(ExitCodeConstants.Success, exitCode);
     }
@@ -55,7 +57,9 @@ public class ResourceCommandTests(ITestOutputHelper outputHelper)
         var command = provider.GetRequiredService<RootCommand>();
         var result = command.Parse("resource myresource");
 
-        // Missing required command argument should fail
+        var error = Assert.Single(result.Errors);
+        Assert.Equal("The 'command' argument is required.", error.Message);
+
         var exitCode = await result.InvokeAsync().DefaultTimeout();
         Assert.NotEqual(ExitCodeConstants.Success, exitCode);
     }
@@ -402,6 +406,34 @@ public class ResourceCommandTests(ITestOutputHelper outputHelper)
 
         Assert.Equal(ExitCodeConstants.Success, exitCode);
         AssertJsonObject(backchannel.ExecuteResourceCommandArguments, ("timeoutMilliseconds", "500"));
+    }
+
+    [Fact]
+    public async Task ResourceCommand_DoesNotMatchCommandMetadataUsingDifferentCase()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+
+        var backchannel = new TestAppHostAuxiliaryBackchannel
+        {
+            ExecuteResourceCommandResult = new ExecuteResourceCommandResponse { Success = true },
+            ResourceSnapshots =
+            [
+                CreateResourceSnapshot(
+                    "web-browser-automation",
+                    CreateCommand(
+                        "configure",
+                        CreateArgument("message")))
+            ]
+        };
+        await using var provider = CreateServiceProvider(workspace, outputHelper, backchannel);
+
+        var command = provider.GetRequiredService<RootCommand>();
+        var result = command.Parse("""resource web-browser-automation Configure --message hello""");
+
+        var exitCode = await result.InvokeAsync().DefaultTimeout();
+
+        Assert.Equal(ExitCodeConstants.Success, exitCode);
+        AssertJsonObject(backchannel.ExecuteResourceCommandArguments, ("--message", null), ("hello", null));
     }
 
     [Fact]

--- a/tests/Aspire.Cli.Tests/Commands/ResourceCommandTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/ResourceCommandTests.cs
@@ -407,7 +407,7 @@ public class ResourceCommandTests(ITestOutputHelper outputHelper)
         var exitCode = await result.InvokeAsync().DefaultTimeout();
 
         Assert.Equal(ExitCodeConstants.Success, exitCode);
-        AssertJsonObject(backchannel.ExecuteResourceCommandArguments, ("--selector", null), ("#submit", null), ("--count", null), ("2", null));
+        AssertJsonObject(backchannel.ExecuteResourceCommandArguments, ("--selector #submit", null), ("--count 2", null));
     }
 
     [Fact]
@@ -454,7 +454,7 @@ public class ResourceCommandTests(ITestOutputHelper outputHelper)
         var exitCode = await result.InvokeAsync().DefaultTimeout();
 
         Assert.Equal(ExitCodeConstants.Success, exitCode);
-        AssertJsonObject(backchannel.ExecuteResourceCommandArguments, ("--selector", null), ("#submit", null));
+        AssertJsonObject(backchannel.ExecuteResourceCommandArguments, ("--selector #submit", null));
     }
 
     [Fact]
@@ -518,7 +518,7 @@ public class ResourceCommandTests(ITestOutputHelper outputHelper)
         var exitCode = await result.InvokeAsync().DefaultTimeout();
 
         Assert.Equal(ExitCodeConstants.Success, exitCode);
-        AssertJsonObject(backchannel.ExecuteResourceCommandArguments, ("--message", null), ("hello", null));
+        AssertJsonObject(backchannel.ExecuteResourceCommandArguments, ("--message hello", null));
     }
 
     [Fact]
@@ -688,8 +688,31 @@ public class ResourceCommandTests(ITestOutputHelper outputHelper)
         Assert.Equal(ExitCodeConstants.InvalidCommand, exitCode);
         Assert.Equal(0, backchannel.ExecuteResourceCommandCallCount);
         var error = Assert.Single(interactionService.DisplayedErrors);
-        Assert.Contains("--unknown", error);
-        Assert.Contains("value", error);
+        Assert.Equal("Unrecognized command option '--unknown value'.", error);
+    }
+
+    [Fact]
+    public async Task ResourceCommand_GroupsUnknownCommandOptionValueWhenCommandMetadataIsMissing()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+
+        var backchannel = new TestAppHostAuxiliaryBackchannel
+        {
+            ExecuteResourceCommandResult = new ExecuteResourceCommandResponse { Success = true },
+            ResourceSnapshots =
+            [
+                CreateResourceSnapshot("web-browser-automation")
+            ]
+        };
+        await using var provider = CreateServiceProvider(workspace, outputHelper, backchannel);
+
+        var command = provider.GetRequiredService<RootCommand>();
+        var result = command.Parse("""resource web-browser-automation configure --mm ss""");
+
+        var exitCode = await result.InvokeAsync().DefaultTimeout();
+
+        Assert.Equal(ExitCodeConstants.Success, exitCode);
+        AssertJsonObject(backchannel.ExecuteResourceCommandArguments, ("--mm ss", null));
     }
 
     [Fact]
@@ -719,6 +742,47 @@ public class ResourceCommandTests(ITestOutputHelper outputHelper)
         Assert.Equal(0, backchannel.ExecuteResourceCommandCallCount);
         var error = Assert.Single(interactionService.DisplayedErrors);
         Assert.Contains("maybe", error);
+    }
+
+    [Fact]
+    public async Task ResourceCommand_DisplaysValidationErrorArgumentNamesAsCliOptions()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        var interactionService = new TestInteractionService();
+
+        var backchannel = new TestAppHostAuxiliaryBackchannel
+        {
+            ExecuteResourceCommandResult = new ExecuteResourceCommandResponse
+            {
+                Success = false,
+                Message = "Command argument validation failed.",
+                ValidationErrors =
+                [
+                    new ResourceCommandArgumentValidationError
+                    {
+                        ArgumentName = "timeoutSeconds",
+                        ErrorMessage = "Value must be greater than 0."
+                    }
+                ]
+            },
+            ResourceSnapshots =
+            [
+                CreateResourceSnapshot(
+                    "web-browser-automation",
+                    CreateCommand("configure", CreateArgument("timeoutSeconds", inputType: "Number")))
+            ]
+        };
+        await using var provider = CreateServiceProvider(workspace, outputHelper, backchannel, interactionService);
+
+        var command = provider.GetRequiredService<RootCommand>();
+        var result = command.Parse("""resource web-browser-automation configure --timeout-seconds 0""");
+
+        var exitCode = await result.InvokeAsync().DefaultTimeout();
+
+        Assert.Equal(ExitCodeConstants.FailedToExecuteResourceCommand, exitCode);
+        var error = Assert.Single(interactionService.DisplayedErrors);
+        Assert.Contains("--timeout-seconds: Value must be greater than 0.", error);
+        Assert.DoesNotContain("timeoutSeconds:", error);
     }
 
     [Fact]

--- a/tests/Aspire.Cli.Tests/Commands/ResourceCommandTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/ResourceCommandTests.cs
@@ -47,6 +47,25 @@ public class ResourceCommandTests(ITestOutputHelper outputHelper)
         Assert.NotEqual(ExitCodeConstants.Success, exitCode);
     }
 
+    [Theory]
+    [InlineData("--message hi")]
+    [InlineData("--message=hi")]
+    public async Task ResourceCommand_RequiresResourceArgumentWhenCommandOptionsAreProvidedWithoutResource(string arguments)
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper);
+        using var provider = services.BuildServiceProvider();
+
+        var command = provider.GetRequiredService<RootCommand>();
+        var result = command.Parse($"""resource {arguments}""");
+
+        var error = Assert.Single(result.Errors);
+        Assert.Equal("The 'resource' argument is required.", error.Message);
+
+        var exitCode = await result.InvokeAsync().DefaultTimeout();
+        Assert.NotEqual(ExitCodeConstants.Success, exitCode);
+    }
+
     [Fact]
     public async Task ResourceCommand_RequiresCommandArgument()
     {
@@ -56,6 +75,26 @@ public class ResourceCommandTests(ITestOutputHelper outputHelper)
 
         var command = provider.GetRequiredService<RootCommand>();
         var result = command.Parse("resource myresource");
+
+        var error = Assert.Single(result.Errors);
+        Assert.Equal("The 'command' argument is required.", error.Message);
+
+        var exitCode = await result.InvokeAsync().DefaultTimeout();
+        Assert.NotEqual(ExitCodeConstants.Success, exitCode);
+    }
+
+    [Theory]
+    [InlineData("--message hi")]
+    [InlineData("--message=hi")]
+    [InlineData("-- --message hi")]
+    public async Task ResourceCommand_RequiresCommandArgumentWhenCommandOptionsAreProvidedWithoutCommand(string arguments)
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper);
+        using var provider = services.BuildServiceProvider();
+
+        var command = provider.GetRequiredService<RootCommand>();
+        var result = command.Parse($"""resource myresource {arguments}""");
 
         var error = Assert.Single(result.Errors);
         Assert.Equal("The 'command' argument is required.", error.Message);

--- a/tests/Aspire.Cli.Tests/Commands/ResourceCommandTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/ResourceCommandTests.cs
@@ -1295,8 +1295,10 @@ public class ResourceCommandTests(ITestOutputHelper outputHelper)
 
         Assert.Equal(ExitCodeConstants.Success, exitCode);
         Assert.Contains("Waits for text in the browser.", helpOutput);
-        Assert.Contains("--selector <value>  Selector to wait for. Required.", helpOutput);
-        Assert.Contains("--timeout-milliseconds <value>  Timeout in milliseconds.", helpOutput);
+        Assert.Contains("--selector <value>", helpOutput);
+        Assert.Contains("Selector to wait for. Required.", helpOutput);
+        Assert.Contains("--timeout-milliseconds <value>", helpOutput);
+        Assert.Contains("Timeout in milliseconds.", helpOutput);
     }
 
     [Fact]
@@ -1333,8 +1335,10 @@ public class ResourceCommandTests(ITestOutputHelper outputHelper)
         var helpOutput = helpWriter.ToString();
 
         Assert.Equal(ExitCodeConstants.Success, exitCode);
-        Assert.Contains("aspire resource web-browser-automation configure -- [command-options]", helpOutput);
-        Assert.Contains("--log-level <value>  Log level for the resource command. Use `-- --log-level <value>` to pass this command option.", helpOutput);
+        Assert.Contains("aspire resource web-browser-automation configure [options] [[--] <command-options>...]", helpOutput);
+        Assert.Contains("--log-level <value>", helpOutput);
+        Assert.Contains("Log level for the resource command.", helpOutput);
+        Assert.Contains("Use `-- --log-level <value>` to pass this command", helpOutput);
     }
 
     [Fact]
@@ -1362,7 +1366,7 @@ public class ResourceCommandTests(ITestOutputHelper outputHelper)
 
         Assert.Equal(ExitCodeConstants.Success, exitCode);
         Assert.Contains("--apphost <apphost>", helpOutput);
-        Assert.Contains("-?, -h, --help", helpOutput);
+        Assert.Contains("-?, -h, /?, /h, --help", helpOutput);
         Assert.Contains("-l, --log-level <log-level>", helpOutput);
         Assert.Contains("--non-interactive", helpOutput);
         Assert.Contains("--nologo", helpOutput);
@@ -1398,8 +1402,9 @@ public class ResourceCommandTests(ITestOutputHelper outputHelper)
         var helpOutput = helpWriter.ToString();
 
         Assert.Equal(ExitCodeConstants.Success, exitCode);
-        Assert.Contains("--count <value>  Count value. Default: 5.", helpOutput);
-        Assert.DoesNotContain("--count <value>  Count value. Required.", helpOutput);
+        Assert.Contains("--count <value>", helpOutput);
+        Assert.Contains("Count value. Default: 5.", helpOutput);
+        Assert.DoesNotContain("Count value. Required.", helpOutput);
     }
 
     [Fact]

--- a/tests/Aspire.Cli.Tests/Commands/ResourceCommandTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/ResourceCommandTests.cs
@@ -132,6 +132,32 @@ public class ResourceCommandTests(ITestOutputHelper outputHelper)
     }
 
     [Fact]
+    public async Task ResourceCommand_DoesNotUseWellKnownCommandMatchingWithDifferentCase()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        var statuses = new List<string>();
+        var interactionService = new TestInteractionService
+        {
+            ShowStatusCallback = statuses.Add
+        };
+
+        var backchannel = new TestAppHostAuxiliaryBackchannel
+        {
+            ExecuteResourceCommandResult = new ExecuteResourceCommandResponse { Success = true }
+        };
+        await using var provider = CreateServiceProvider(workspace, outputHelper, backchannel, interactionService);
+
+        var command = provider.GetRequiredService<RootCommand>();
+        var result = command.Parse("resource myresource Start");
+
+        var exitCode = await result.InvokeAsync().DefaultTimeout();
+
+        Assert.Equal(ExitCodeConstants.Success, exitCode);
+        Assert.Equal(1, backchannel.ExecuteResourceCommandCallCount);
+        Assert.Contains("Executing command 'Start' on resource 'myresource'...", statuses);
+    }
+
+    [Fact]
     public async Task ResourceCommand_DoesNotBindPositionalArgumentsByName()
     {
         using var workspace = TemporaryWorkspace.Create(outputHelper);
@@ -373,6 +399,26 @@ public class ResourceCommandTests(ITestOutputHelper outputHelper)
     }
 
     [Fact]
+    public async Task ResourceCommand_RemovesDelimiterWithoutMetadata()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+
+        var backchannel = new TestAppHostAuxiliaryBackchannel
+        {
+            ExecuteResourceCommandResult = new ExecuteResourceCommandResponse { Success = true }
+        };
+        await using var provider = CreateServiceProvider(workspace, outputHelper, backchannel);
+
+        var command = provider.GetRequiredService<RootCommand>();
+        var result = command.Parse("""resource web-browser-automation configure -- --selector "#submit" """);
+
+        var exitCode = await result.InvokeAsync().DefaultTimeout();
+
+        Assert.Equal(ExitCodeConstants.Success, exitCode);
+        AssertJsonObject(backchannel.ExecuteResourceCommandArguments, ("--selector", null), ("#submit", null));
+    }
+
+    [Fact]
     public async Task ResourceCommand_ForwardsOptionalArgumentsByName()
     {
         using var workspace = TemporaryWorkspace.Create(outputHelper);
@@ -578,6 +624,65 @@ public class ResourceCommandTests(ITestOutputHelper outputHelper)
     }
 
     [Fact]
+    public async Task ResourceCommand_ReturnsInvalidCommandForUnknownCommandOption()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        var interactionService = new TestInteractionService();
+
+        var backchannel = new TestAppHostAuxiliaryBackchannel
+        {
+            ExecuteResourceCommandResult = new ExecuteResourceCommandResponse { Success = true },
+            ResourceSnapshots =
+            [
+                CreateResourceSnapshot(
+                    "web-browser-automation",
+                    CreateCommand("configure", CreateArgument("message")))
+            ]
+        };
+        await using var provider = CreateServiceProvider(workspace, outputHelper, backchannel, interactionService);
+
+        var command = provider.GetRequiredService<RootCommand>();
+        var result = command.Parse("""resource web-browser-automation configure --unknown value""");
+
+        var exitCode = await result.InvokeAsync().DefaultTimeout();
+
+        Assert.Equal(ExitCodeConstants.InvalidCommand, exitCode);
+        Assert.Equal(0, backchannel.ExecuteResourceCommandCallCount);
+        var error = Assert.Single(interactionService.DisplayedErrors);
+        Assert.Contains("--unknown", error);
+        Assert.Contains("value", error);
+    }
+
+    [Fact]
+    public async Task ResourceCommand_ReturnsInvalidCommandForInvalidBooleanCommandOptionValue()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        var interactionService = new TestInteractionService();
+
+        var backchannel = new TestAppHostAuxiliaryBackchannel
+        {
+            ExecuteResourceCommandResult = new ExecuteResourceCommandResponse { Success = true },
+            ResourceSnapshots =
+            [
+                CreateResourceSnapshot(
+                    "web-browser-automation",
+                    CreateCommand("configure", CreateArgument("proxy", inputType: "Boolean")))
+            ]
+        };
+        await using var provider = CreateServiceProvider(workspace, outputHelper, backchannel, interactionService);
+
+        var command = provider.GetRequiredService<RootCommand>();
+        var result = command.Parse("""resource web-browser-automation configure --proxy maybe""");
+
+        var exitCode = await result.InvokeAsync().DefaultTimeout();
+
+        Assert.Equal(ExitCodeConstants.InvalidCommand, exitCode);
+        Assert.Equal(0, backchannel.ExecuteResourceCommandCallCount);
+        var error = Assert.Single(interactionService.DisplayedErrors);
+        Assert.Contains("maybe", error);
+    }
+
+    [Fact]
     public async Task ResourceCommand_ForwardsCustomChoiceCommandOptionWhenAllowed()
     {
         using var workspace = TemporaryWorkspace.Create(outputHelper);
@@ -646,6 +751,7 @@ public class ResourceCommandTests(ITestOutputHelper outputHelper)
     [Theory]
     [InlineData("--message", "--message")]
     [InlineData("--count", "--count")]
+    [InlineData("-- --message", "--message")]
     public async Task ResourceCommand_ReturnsInvalidCommandForMissingCommandOptionValue(string arguments, string expectedOptionName)
     {
         using var workspace = TemporaryWorkspace.Create(outputHelper);
@@ -675,6 +781,36 @@ public class ResourceCommandTests(ITestOutputHelper outputHelper)
         Assert.Equal(0, backchannel.ExecuteResourceCommandCallCount);
         var error = Assert.Single(interactionService.DisplayedErrors);
         Assert.Contains(expectedOptionName, error);
+    }
+
+    [Fact]
+    public async Task ResourceCommand_ReturnsInvalidCommandForDuplicateCommandOptionUsingExactAndKebabAliases()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        var interactionService = new TestInteractionService();
+
+        var backchannel = new TestAppHostAuxiliaryBackchannel
+        {
+            ExecuteResourceCommandResult = new ExecuteResourceCommandResponse { Success = true },
+            ResourceSnapshots =
+            [
+                CreateResourceSnapshot(
+                    "web-browser-automation",
+                    CreateCommand("configure", CreateArgument("timeoutMilliseconds", inputType: "Number")))
+            ]
+        };
+        await using var provider = CreateServiceProvider(workspace, outputHelper, backchannel, interactionService);
+
+        var command = provider.GetRequiredService<RootCommand>();
+        var result = command.Parse("""resource web-browser-automation configure --timeoutMilliseconds 1 --timeout-milliseconds 2""");
+
+        var exitCode = await result.InvokeAsync().DefaultTimeout();
+
+        Assert.Equal(ExitCodeConstants.InvalidCommand, exitCode);
+        Assert.Equal(0, backchannel.ExecuteResourceCommandCallCount);
+        var error = Assert.Single(interactionService.DisplayedErrors);
+        Assert.Contains("--timeoutMilliseconds", error);
+        Assert.Contains("2 were provided", error);
     }
 
     [Fact]
@@ -733,6 +869,39 @@ public class ResourceCommandTests(ITestOutputHelper outputHelper)
         Assert.Equal(0, backchannel.ExecuteResourceCommandCallCount);
         var error = Assert.Single(interactionService.DisplayedErrors);
         Assert.Contains("--selector", error);
+    }
+
+    [Fact]
+    public async Task ResourceCommand_ReturnsInvalidCommandForMultipleMissingRequiredCommandOptions()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        var interactionService = new TestInteractionService();
+
+        var backchannel = new TestAppHostAuxiliaryBackchannel
+        {
+            ExecuteResourceCommandResult = new ExecuteResourceCommandResponse { Success = true },
+            ResourceSnapshots =
+            [
+                CreateResourceSnapshot(
+                    "web-browser-automation",
+                    CreateCommand(
+                        "wait-for-browser",
+                        CreateArgument("selector", required: true),
+                        CreateArgument("text", required: true)))
+            ]
+        };
+        await using var provider = CreateServiceProvider(workspace, outputHelper, backchannel, interactionService);
+
+        var command = provider.GetRequiredService<RootCommand>();
+        var result = command.Parse("""resource web-browser-automation wait-for-browser""");
+
+        var exitCode = await result.InvokeAsync().DefaultTimeout();
+
+        Assert.Equal(ExitCodeConstants.InvalidCommand, exitCode);
+        Assert.Equal(0, backchannel.ExecuteResourceCommandCallCount);
+        var error = Assert.Single(interactionService.DisplayedErrors);
+        Assert.Contains("--selector", error);
+        Assert.Contains("--text", error);
     }
 
     [Fact]
@@ -966,6 +1135,25 @@ public class ResourceCommandTests(ITestOutputHelper outputHelper)
 
         Assert.Equal(ExitCodeConstants.InvalidCommand, exitCode);
         Assert.Equal(0, backchannel.ExecuteResourceCommandCallCount);
+    }
+
+    [Fact]
+    public async Task ResourceCommand_ResourceOnlyHelpUsesDefaultHelp()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        var helpWriter = new StringWriter();
+        var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper);
+        using var provider = services.BuildServiceProvider();
+
+        var command = provider.GetRequiredService<RootCommand>();
+        var result = command.Parse("""resource myresource --help""");
+
+        var exitCode = await result.InvokeAsync(new InvocationConfiguration { Output = helpWriter }).DefaultTimeout();
+        var helpOutput = helpWriter.ToString();
+
+        Assert.Equal(ExitCodeConstants.Success, exitCode);
+        Assert.Contains("Execute a command on a resource", helpOutput);
+        Assert.Contains("resource <resource> <command>", helpOutput);
     }
 
     [Fact]

--- a/tests/Aspire.Cli.Tests/Mcp/ExecuteResourceCommandToolTests.cs
+++ b/tests/Aspire.Cli.Tests/Mcp/ExecuteResourceCommandToolTests.cs
@@ -226,7 +226,7 @@ public class ExecuteResourceCommandToolTests
         Assert.True(result.IsError);
         Assert.Contains(result.Content, c => c is ModelContextProtocol.Protocol.TextContentBlock t &&
             t.Text.Contains("Command argument validation failed.") &&
-            t.Text.Contains("target: Target must not be prod."));
+            t.Text.Contains("--target: Target must not be prod."));
     }
 
     [Fact]

--- a/tests/Aspire.Cli.Tests/Mcp/ExecuteResourceCommandToolTests.cs
+++ b/tests/Aspire.Cli.Tests/Mcp/ExecuteResourceCommandToolTests.cs
@@ -175,6 +175,29 @@ public class ExecuteResourceCommandToolTests
     }
 
     [Fact]
+    public async Task ExecuteResourceCommandTool_ReturnsError_WhenCommandFailsWithNullValidationErrors()
+    {
+        var monitor = new TestAuxiliaryBackchannelMonitor();
+        var connection = new TestAppHostAuxiliaryBackchannel
+        {
+            ExecuteResourceCommandResult = new ExecuteResourceCommandResponse
+            {
+                Success = false,
+                Message = "Resource not found",
+                ValidationErrors = null!
+            }
+        };
+        monitor.AddConnection("hash1", "socket.hash1", connection);
+
+        var tool = new ExecuteResourceCommandTool(monitor, NullLogger<ExecuteResourceCommandTool>.Instance);
+
+        var result = await tool.CallToolAsync(CallToolContextTestHelper.Create(CreateArguments("nonexistent", "start")), CancellationToken.None).DefaultTimeout();
+
+        Assert.True(result.IsError);
+        Assert.Contains(result.Content, c => c is ModelContextProtocol.Protocol.TextContentBlock t && t.Text.Contains("Resource not found"));
+    }
+
+    [Fact]
     public async Task ExecuteResourceCommandTool_ReturnsValidationErrors_WhenCommandArgumentsAreInvalid()
     {
         var monitor = new TestAuxiliaryBackchannelMonitor();

--- a/tests/Aspire.Cli.Tests/Snapshots/ResourceCommandTests.ResourceCommand_CommandSpecificHelpForAllArgumentTypesMatchesSnapshot.verified.txt
+++ b/tests/Aspire.Cli.Tests/Snapshots/ResourceCommandTests.ResourceCommand_CommandSpecificHelpForAllArgumentTypesMatchesSnapshot.verified.txt
@@ -7,11 +7,16 @@ Usage:
 Command options:
   --message <value>  Text input shown as a value option. Required.
   --secret <value>  Secret text input shown as a value option.
-  --count <value>  Number input with a default. Required. Default: 5.
+  --count <value>  Number input with a default. Default: 5.
   --enabled  Boolean input shown as a flag. Default: true.
   --flavor <value>  Choice input with fixed allowed values. Allowed values: vanilla, chocolate.
   --log-level <value>  Command option colliding with a CLI option. Use `-- --log-level <value>` to pass this command option.
 
 Options:
   --apphost <apphost>  The path to the Aspire AppHost project file or a directory to search
-  -?, -h, --help       Show help and usage information
+  -?, -h, --help  Show help and usage information
+  -l, --log-level <log-level>  Set the minimum log level for console output (Trace, Debug, Information, Warning, Error, Critical)
+  --non-interactive  Run the command in non-interactive mode, disabling all interactive prompts and spinners
+  --nologo  Suppress the startup banner and telemetry notice
+  --banner  Display the animated Aspire CLI welcome banner
+  --wait-for-debugger  Wait for a debugger to attach before executing the command

--- a/tests/Aspire.Cli.Tests/Snapshots/ResourceCommandTests.ResourceCommand_CommandSpecificHelpForAllArgumentTypesMatchesSnapshot.verified.txt
+++ b/tests/Aspire.Cli.Tests/Snapshots/ResourceCommandTests.ResourceCommand_CommandSpecificHelpForAllArgumentTypesMatchesSnapshot.verified.txt
@@ -1,0 +1,17 @@
+﻿Exercises command help for every supported resource command argument shape.
+
+Usage:
+  aspire resource argument-commands all-argument-types [command-options] [options]
+  aspire resource argument-commands all-argument-types -- [command-options]
+
+Command options:
+  --message <value>  Text input shown as a value option. Required.
+  --secret <value>  Secret text input shown as a value option.
+  --count <value>  Number input with a default. Required. Default: 5.
+  --enabled  Boolean input shown as a flag. Default: true.
+  --flavor <value>  Choice input with fixed allowed values. Allowed values: vanilla, chocolate.
+  --log-level <value>  Command option colliding with a CLI option. Use `-- --log-level <value>` to pass this command option.
+
+Options:
+  --apphost <apphost>  The path to the Aspire AppHost project file or a directory to search
+  -?, -h, --help       Show help and usage information

--- a/tests/Aspire.Cli.Tests/Snapshots/ResourceCommandTests.ResourceCommand_CommandSpecificHelpForAllArgumentTypesMatchesSnapshot.verified.txt
+++ b/tests/Aspire.Cli.Tests/Snapshots/ResourceCommandTests.ResourceCommand_CommandSpecificHelpForAllArgumentTypesMatchesSnapshot.verified.txt
@@ -1,22 +1,23 @@
 ﻿Exercises command help for every supported resource command argument shape.
 
 Usage:
-  aspire resource argument-commands all-argument-types [command-options] [options]
-  aspire resource argument-commands all-argument-types -- [command-options]
+  aspire resource argument-commands all-argument-types [options] [[--] <command-options>...]
 
 Command options:
-  --message <value>  Text input shown as a value option. Required.
-  --secret <value>  Secret text input shown as a value option.
-  --count <value>  Number input with a default. Default: 5.
-  --enabled  Boolean input shown as a flag. Default: true.
-  --flavor <value>  Choice input with fixed allowed values. Allowed values: vanilla, chocolate.
-  --log-level <value>  Command option colliding with a CLI option. Use `-- --log-level <value>` to pass this command option.
+  --message <value>      Text input shown as a value option. Required.
+  --secret <value>       Secret text input shown as a value option.
+  --count <value>        Number input with a default. Default: 5.
+  --enabled              Boolean input shown as a flag. Default: true.
+  --flavor <value>       Choice input with fixed allowed values. Allowed values: vanilla, chocolate.
+  --log-level <value>    Command option colliding with a CLI option. Use `-- --log-level <value>` to pass this command
+                         option.
 
 Options:
-  --apphost <apphost>  The path to the Aspire AppHost project file or a directory to search
-  -?, -h, --help  Show help and usage information
-  -l, --log-level <log-level>  Set the minimum log level for console output (Trace, Debug, Information, Warning, Error, Critical)
-  --non-interactive  Run the command in non-interactive mode, disabling all interactive prompts and spinners
-  --nologo  Suppress the startup banner and telemetry notice
-  --banner  Display the animated Aspire CLI welcome banner
-  --wait-for-debugger  Wait for a debugger to attach before executing the command
+  --apphost <apphost>            The path to the Aspire AppHost project file or a directory to search
+  -?, -h, /?, /h, --help         Show help and usage information
+  -l, --log-level <log-level>    Set the minimum log level for console output (Trace, Debug, Information, Warning,
+                                 Error, Critical)
+  --non-interactive              Run the command in non-interactive mode, disabling all interactive prompts and spinners
+  --nologo                       Suppress the startup banner and telemetry notice
+  --banner                       Display the animated Aspire CLI welcome banner
+  --wait-for-debugger            Wait for a debugger to attach before executing the command

--- a/tests/Aspire.Hosting.Tests/ResourceCommandServiceTests.cs
+++ b/tests/Aspire.Hosting.Tests/ResourceCommandServiceTests.cs
@@ -732,6 +732,80 @@ public class ResourceCommandServiceTests(ITestOutputHelper testOutputHelper)
     }
 
     [Fact]
+    public async Task ExecuteCommandAsync_LoadsDependentChoiceOptionsBeforeBuiltInValidation()
+    {
+        using var builder = TestDistributedApplicationBuilder.Create(testOutputHelper);
+
+        var executed = false;
+        var loadCount = 0;
+        var custom = builder.AddResource(new CustomResource("myResource"));
+        custom.WithCommand(name: "mycommand",
+                displayName: "My command",
+                executeCommand: _ =>
+                {
+                    executed = true;
+                    return Task.FromResult(CommandResults.Success());
+                },
+                commandOptions: new CommandOptions
+                {
+                    Arguments =
+                    [
+                        new InteractionInput
+                        {
+                            Name = "subscription",
+                            InputType = InputType.Choice,
+                            Required = true,
+                            Options = [KeyValuePair.Create("sub-a", "Subscription A")]
+                        },
+                        new InteractionInput
+                        {
+                            Name = "location",
+                            InputType = InputType.Choice,
+                            Required = true,
+                            DynamicLoading = new InputLoadOptions
+                            {
+                                DependsOnInputs = ["subscription"],
+                                LoadCallback = context =>
+                                {
+                                    loadCount++;
+                                    Assert.Equal("sub-a", context.AllInputs.GetString("subscription"));
+                                    context.Input.Options = [KeyValuePair.Create("westus", "West US")];
+
+                                    return Task.CompletedTask;
+                                }
+                            }
+                        }
+                    ]
+                });
+
+        var app = builder.Build();
+        await app.StartAsync();
+
+        var result = await app.ResourceCommands.ExecuteCommandAsync(
+            "myResource",
+            "mycommand",
+            new ResourceCommandExecutionOptions
+            {
+                ArgumentValues = new Dictionary<string, string?>
+                {
+                    ["subscription"] = "sub-a",
+                    ["location"] = "centralus"
+                },
+                ArgumentsProvided = true,
+                NonInteractive = true
+            },
+            CancellationToken.None).DefaultTimeout();
+
+        Assert.False(result.Success);
+        Assert.False(executed);
+        Assert.Equal(1, loadCount);
+        Assert.NotNull(result.InvalidArguments);
+        var invalidArgument = Assert.Single(result.InvalidArguments, argument => argument.ValidationErrors.Count > 0);
+        Assert.Equal("location", invalidArgument.Name);
+        Assert.Equal("Value must be one of the provided options.", Assert.Single(invalidArgument.ValidationErrors));
+    }
+
+    [Fact]
     public async Task ExecuteCommandAsync_UnknownNamedArgumentValues_DoesNotExecuteCommand()
     {
         using var builder = TestDistributedApplicationBuilder.Create(testOutputHelper);


### PR DESCRIPTION
## Description

Resource command inputs were previously forwarded as ordered positional values, which made optional inputs difficult to use without providing every earlier value. This change makes resource command inputs feel like normal CLI options: command metadata is used to parse the command tail as named options with System.CommandLine, and the CLI sends the existing named JSON object payload over the backchannel.

This also adds command-specific `--help` for resource commands. The help output shows each command input, whether it is required, default values, choice values, and how to use `--` when a resource command option name collides with an Aspire CLI option.

### User-facing usage

The Stress playground now exposes resource command inputs as named options. For example, a command with text, number, boolean, choice, and secret inputs shows command-specific help:

```console
$ aspire resource argument-commands echo-arguments --help
Common dashboard/API command with text, number, boolean, choice, and secret argument inputs.

Usage:
  aspire resource argument-commands echo-arguments [command-options] [options]
  aspire resource argument-commands echo-arguments -- [command-options]

Command options:
  --message <value>  Text value to echo. Required.
  --repeat <value>  How many times to echo the message. Default: 1.
  --shout  Uppercase the echoed message. Default: false.
  --flavor <value>  Choice argument used to verify select input rendering. Allowed values: vanilla, chocolate, strawberry. Default: vanilla.
  --secret <value>  Secret text input. The command only returns its length.

Options:
  --apphost <apphost>  The path to the Aspire AppHost project file or a directory to search
  -?, -h, --help       Show help and usage information
```

Those options can be invoked by name instead of position:

```console
$ aspire resource argument-commands echo-arguments --message "hello named options" --repeat 2 --shout false --flavor chocolate --secret s3cr3t
Executing command 'echo-arguments' on resource 'argument-commands'...
✅ Command 'echo-arguments' executed successfully on resource 'argument-commands'.
{
  "Message": "hello named options",
  "Repeat": 2,
  "Shout": false,
  "Flavor": "chocolate",
  "SecretLength": 6,
  "Echoed": [
    "hello named options",
    "hello named options"
  ]
}
```

Named options also allow later optional inputs to be supplied without filling every earlier optional input. This Stress command provides required values plus `--item20`, while omitting `--item04` through `--item19`:

```console
$ aspire resource argument-commands argument-stress-test --run-id pr-description --iterations 1 --enabled true --item01 one --item02 two --item03 three --item20 twenty
Executing command 'argument-stress-test' on resource 'argument-commands'...
✅ Command 'argument-stress-test' executed successfully on resource 'argument-commands'.
{
  "PropertyCount": 7,
  "StringCharacters": 31,
  "NumberCount": 1,
  "BooleanCount": 1,
  "PropertyNames": [
    "runId",
    "iterations",
    "enabled",
    "item01",
    "item02",
    "item03",
    "item20"
  ]
}
```

Validation:
- `./dotnet.sh test --project tests/Aspire.Cli.Tests/Aspire.Cli.Tests.csproj --no-launch-profile -- --filter-class "*.ResourceCommandTests" --filter-class "*.ResourceCommandHelpParserTests" --filter-not-trait "quarantined=true" --filter-not-trait "outerloop=true"`
- Stress playground smoke-tested command-specific help, named required inputs, omitted optional inputs, late optional inputs, positional rejection, and invalid number rejection.

Dependencies: N/A

Fixes # (issue)

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
