### PR TITLE
Add displayImmediately command result overload

### DIFF
--- a/src/Aspire.Hosting/ApplicationModel/ResourceCommandAnnotation.cs
+++ b/src/Aspire.Hosting/ApplicationModel/ResourceCommandAnnotation.cs
@@ -232,6 +232,11 @@ public static class CommandResults
     /// <param name="result">The result data.</param>
     /// <param name="resultFormat">The format of the result data.</param>
     /// <param name="displayImmediately">A value indicating whether the result data should be displayed immediately in the dashboard.</param>
+    /// <remarks>
+    /// When <paramref name="displayImmediately"/> is <see langword="true"/>, the dashboard opens the result dialog
+    /// automatically when the command completes. Other clients can still read the result data from
+    /// <see cref="ExecuteCommandResult.Data"/>.
+    /// </remarks>
     public static ExecuteCommandResult Success(string message, string result, CommandResultFormat resultFormat, bool displayImmediately) => new() { Success = true, Message = message, Data = new CommandResultData { Value = result, Format = resultFormat, DisplayImmediately = displayImmediately } };
 
     /// <summary>

--- a/src/Aspire.Hosting/ApplicationModel/ResourceCommandAnnotation.cs
+++ b/src/Aspire.Hosting/ApplicationModel/ResourceCommandAnnotation.cs
@@ -226,6 +226,15 @@ public static class CommandResults
     public static ExecuteCommandResult Success(string message, string result, CommandResultFormat resultFormat = CommandResultFormat.Text) => new() { Success = true, Message = message, Data = new CommandResultData { Value = result, Format = resultFormat } };
 
     /// <summary>
+    /// Produces a success result with a message and result data.
+    /// </summary>
+    /// <param name="message">The message associated with the result.</param>
+    /// <param name="result">The result data.</param>
+    /// <param name="resultFormat">The format of the result data.</param>
+    /// <param name="displayImmediately">A value indicating whether the result data should be displayed immediately in the dashboard.</param>
+    public static ExecuteCommandResult Success(string message, string result, CommandResultFormat resultFormat, bool displayImmediately) => new() { Success = true, Message = message, Data = new CommandResultData { Value = result, Format = resultFormat, DisplayImmediately = displayImmediately } };
+
+    /// <summary>
     /// Produces a success result with a message and a value.
     /// </summary>
     /// <param name="message">The message associated with the result.</param>

--- a/tests/Aspire.Hosting.Tests/ResourceCommandServiceTests.cs
+++ b/tests/Aspire.Hosting.Tests/ResourceCommandServiceTests.cs
@@ -1056,6 +1056,18 @@ public class ResourceCommandServiceTests(ITestOutputHelper testOutputHelper)
     }
 
     [Fact]
+    public void CommandResults_SuccessWithResultAndDisplayImmediately_ProducesCorrectResult()
+    {
+        var result = CommandResults.Success("Success.", "{\"key\": \"value\"}", CommandResultFormat.Json, displayImmediately: true);
+
+        Assert.True(result.Success);
+        Assert.NotNull(result.Data);
+        Assert.Equal("{\"key\": \"value\"}", result.Data.Value);
+        Assert.Equal(CommandResultFormat.Json, result.Data.Format);
+        Assert.True(result.Data.DisplayImmediately);
+    }
+
+    [Fact]
     public void CommandResults_SuccessWithTextResult_DefaultsToText()
     {
         var result = CommandResults.Success("Success.", "hello world");


### PR DESCRIPTION
## Description

Fixes #16893

Adds a `CommandResults.Success` overload that lets resource commands mark returned result data to display immediately in the dashboard. The overload keeps `CommandResultFormat` explicit so the API avoids ambiguity with the existing optional format overload while still making the existing `DisplayImmediately` behavior discoverable from the factory.

Focused unit coverage verifies the overload sets the result value, format, and `DisplayImmediately` flag.

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [x] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [x] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [x] No
  - [ ] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No