### PR TITLE
Add dashboard density options

### DIFF
--- a/src/Aspire.Dashboard/Components/Controls/Chart/ChartBase.cs
+++ b/src/Aspire.Dashboard/Components/Controls/Chart/ChartBase.cs
@@ -46,6 +46,9 @@ public abstract class ChartBase : ComponentBase, IAsyncDisposable
     [Inject]
     public required PauseManager PauseManager { get; init; }
 
+    [CascadingParameter]
+    public DashboardDensity DashboardDensity { get; init; } = DashboardDensity.Comfortable;
+
     [Parameter, EditorRequired]
     public required InstrumentViewModel InstrumentViewModel { get; set; }
 

--- a/src/Aspire.Dashboard/Components/Controls/Chart/MetricTable.razor
+++ b/src/Aspire.Dashboard/Components/Controls/Chart/MetricTable.razor
@@ -20,7 +20,7 @@
     <FluentDataGrid
         @ref="_dataGrid"
         Items="@_metricsView"
-        ItemSize="46"
+        ItemSize="@DashboardDensity.MainGridItemSize()"
         Virtualize="true"
         GridTemplateColumns="@string.Join(" ", Enumerable.Repeat("1fr", columnCount))"
         ItemKey="@(item => item.DateTime)">

--- a/src/Aspire.Dashboard/Components/Dialogs/ManageDataDialog.razor
+++ b/src/Aspire.Dashboard/Components/Dialogs/ManageDataDialog.razor
@@ -10,7 +10,7 @@
 <div style="height: 44vh; overflow-y: auto;">
     <FluentDataGrid @ref="_dataGrid"
                     Items="@GetGridItems()"
-                    ItemSize="46"
+                    ItemSize="@DashboardDensity.MainGridItemSize()"
                     Virtualize="true"
                     GenerateHeader="GenerateHeaderOption.Sticky"
                     GridTemplateColumns="2fr 1fr"

--- a/src/Aspire.Dashboard/Components/Dialogs/ManageDataDialog.razor.cs
+++ b/src/Aspire.Dashboard/Components/Dialogs/ManageDataDialog.razor.cs
@@ -56,6 +56,9 @@ public partial class ManageDataDialog : IDialogContentComponent, IAsyncDisposabl
     [Inject]
     public required ITelemetryErrorRecorder ErrorRecorder { get; init; }
 
+    [CascadingParameter]
+    public DashboardDensity DashboardDensity { get; init; } = DashboardDensity.Comfortable;
+
     private readonly ConcurrentDictionary<string, ResourceViewModel> _resourceByName = new(StringComparers.ResourceName);
     private readonly Dictionary<string, ResourceDataRow> _resourceDataRows = new(StringComparers.ResourceName);
     private readonly HashSet<string> _expandedResourceNames = new(StringComparers.ResourceName);

--- a/src/Aspire.Dashboard/Components/Dialogs/SettingsDialog.razor
+++ b/src/Aspire.Dashboard/Components/Dialogs/SettingsDialog.razor
@@ -46,6 +46,18 @@
             </FluentRadioGroup>
         </div>
 
+        <div class="input-container">
+            <FluentRadioGroup TValue="DashboardDensity"
+                              Label="@Loc[nameof(Dialogs.SettingsDialogDensity)]"
+                              @bind-Value="@_dashboardDensity"
+                              @bind-Value:after="OnDensityChanged"
+                              Orientation="Orientation.Vertical">
+                <FluentRadio Value="@DashboardDensity.Comfortable">@Loc[nameof(Dialogs.SettingsDialogDensityComfortable)]</FluentRadio>
+                <FluentRadio Value="@DashboardDensity.Compact">@Loc[nameof(Dialogs.SettingsDialogDensityCompact)]</FluentRadio>
+            </FluentRadioGroup>
+            <p class="setting-subtext">@Loc[nameof(Dialogs.SettingsDialogDensityDescription)]</p>
+        </div>
+
         <div>
             <span class="setting-title">@Loc[nameof(Dialogs.SettingsDialogDashboardLogsAndTelemetry)]</span>
             <div>

--- a/src/Aspire.Dashboard/Components/Dialogs/SettingsDialog.razor.cs
+++ b/src/Aspire.Dashboard/Components/Dialogs/SettingsDialog.razor.cs
@@ -16,6 +16,7 @@ public partial class SettingsDialog : IDialogContentComponent, IDisposable
     private List<CultureInfo> _languageOptions = null!;
     private CultureInfo? _selectedUiCulture;
     private TimeFormat _timeFormat;
+    private DashboardDensity _dashboardDensity = DashboardDensity.Comfortable;
 
     private IDisposable? _themeChangedSubscription;
 
@@ -40,7 +41,7 @@ public partial class SettingsDialog : IDialogContentComponent, IDisposable
     [Inject]
     public required ILocalStorage LocalStorage { get; init; }
 
-    protected override void OnInitialized()
+    protected override async Task OnInitializedAsync()
     {
         _languageOptions = GlobalizationHelpers.OrderedLocalizedCultures;
 
@@ -50,6 +51,11 @@ public partial class SettingsDialog : IDialogContentComponent, IDisposable
             CultureInfo.CurrentUICulture;
 
         _timeFormat = TimeProvider.ConfiguredTimeFormat;
+        var dashboardDensityResult = await LocalStorage.GetAsync<DashboardDensity>(BrowserStorageKeys.DashboardDensity);
+        if (dashboardDensityResult.Success)
+        {
+            _dashboardDensity = dashboardDensityResult.Value;
+        }
 
         _currentSetting = ThemeManager.SelectedTheme ?? ThemeManager.ThemeSettingSystem;
 
@@ -121,6 +127,16 @@ public partial class SettingsDialog : IDialogContentComponent, IDisposable
         await LocalStorage.SetAsync(BrowserStorageKeys.TimeFormat, _timeFormat);
 
         // Reload the page to ensure all components pick up the new format
+        var uri = new Uri(NavigationManager.Uri)
+            .GetComponents(UriComponents.PathAndQuery, UriFormat.Unescaped);
+
+        NavigationManager.NavigateTo(uri, forceLoad: true);
+    }
+
+    private async Task OnDensityChanged()
+    {
+        await LocalStorage.SetAsync(BrowserStorageKeys.DashboardDensity, _dashboardDensity);
+
         var uri = new Uri(NavigationManager.Uri)
             .GetComponents(UriComponents.PathAndQuery, UriFormat.Unescaped);
 

--- a/src/Aspire.Dashboard/Components/Layout/MainLayout.razor
+++ b/src/Aspire.Dashboard/Components/Layout/MainLayout.razor
@@ -6,7 +6,7 @@
 @inject IStringLocalizer<Dialogs> DialogsLoc
 @inherits LayoutComponentBase
 
-<div class="layout" style="@(_isNavMenuOpen ? "overflow: hidden;" : string.Empty)">
+<div class="layout" data-density="@_dashboardDensity.ToAttributeValue()" style="@(_isNavMenuOpen ? "overflow: hidden;" : string.Empty)">
     <div class="aspire-icon">
         <FluentAnchor Appearance="Appearance.Stealth" Href="/" Class="logo"
                       title="@Loc[nameof(Layout.MainLayoutAspire)]"
@@ -94,28 +94,30 @@
             LaunchSettingsAsync="@LaunchSettingsAsync" />
     }
 
-    <div class="messagebar-container">
-        <FluentMessageBarProvider Section="@DashboardUIHelpers.MessageBarSection" Class="top-messagebar" MaxMessageCount="null" NewestOnTop="true" />
-        @if (AIContextProvider.AssistantChatViewModel is not null && AIContextProvider.ShowAssistantSidebarDialog)
-        {
-            <div class="layout-sidebar-spacer"></div>
-        }
-    </div>
-    <div class="layout-body-container">
-        <FluentBodyContent Class="custom-body-content body-content">
-            <FluentToastProvider MaxToastCount="3" Timeout="5000" />
-            @Body
-        </FluentBodyContent>
-        @if (AIContextProvider.AssistantChatViewModel is not null && AIContextProvider.ShowAssistantSidebarDialog)
-        {
-            <div class="layout-sidebar-spacer"></div>
-        }
-    </div>
+    <CascadingValue Value="_dashboardDensity">
+        <div class="messagebar-container">
+            <FluentMessageBarProvider Section="@DashboardUIHelpers.MessageBarSection" Class="top-messagebar" MaxMessageCount="null" NewestOnTop="true" />
+            @if (AIContextProvider.AssistantChatViewModel is not null && AIContextProvider.ShowAssistantSidebarDialog)
+            {
+                <div class="layout-sidebar-spacer"></div>
+            }
+        </div>
+        <div class="layout-body-container">
+            <FluentBodyContent Class="custom-body-content body-content">
+                <FluentToastProvider MaxToastCount="3" Timeout="5000" />
+                @Body
+            </FluentBodyContent>
+            @if (AIContextProvider.AssistantChatViewModel is not null && AIContextProvider.ShowAssistantSidebarDialog)
+            {
+                <div class="layout-sidebar-spacer"></div>
+            }
+        </div>
 
-    <FluentDialogProvider/>
-    <FluentTooltipProvider />
-    <FluentMenuProvider />
-    <InteractionsProvider />
+        <FluentDialogProvider/>
+        <FluentTooltipProvider />
+        <FluentMenuProvider />
+        <InteractionsProvider />
+    </CascadingValue>
     <div id="blazor-error-ui">
         @Loc[nameof(Layout.MainLayoutUnhandledErrorMessage)]
         <a href="" class="reload">@Loc[nameof(Layout.MainLayoutUnhandledErrorReload)]</a>

--- a/src/Aspire.Dashboard/Components/Layout/MainLayout.razor.cs
+++ b/src/Aspire.Dashboard/Components/Layout/MainLayout.razor.cs
@@ -28,6 +28,7 @@ public partial class MainLayout : IGlobalKeydownListener, IAsyncDisposable
     private DotNetObjectReference<MainLayout>? _layoutReference;
     private IDialogReference? _openPageDialog;
     private IDisposable? _aiDisplayChangedSubscription;
+    private DashboardDensity _dashboardDensity = DashboardDensity.Comfortable;
     private const string SettingsDialogId = "SettingsDialog";
     private const string HelpDialogId = "HelpDialog";
     private const string NotificationsDialogId = "NotificationsDialog";
@@ -120,6 +121,12 @@ public partial class MainLayout : IGlobalKeydownListener, IAsyncDisposable
         if (timeFormatResult.Success)
         {
             TimeProvider.SetConfiguredTimeFormat(timeFormatResult.Value);
+        }
+
+        var dashboardDensityResult = await LocalStorage.GetAsync<DashboardDensity>(BrowserStorageKeys.DashboardDensity);
+        if (dashboardDensityResult.Success)
+        {
+            _dashboardDensity = dashboardDensityResult.Value;
         }
 
         await DisplayUnsecuredEndpointsMessageAsync();

--- a/src/Aspire.Dashboard/Components/Pages/Metrics.razor.cs
+++ b/src/Aspire.Dashboard/Components/Pages/Metrics.razor.cs
@@ -77,6 +77,9 @@ public partial class Metrics : IDisposable, IComponentWithTelemetry, IPageWithSe
     [CascadingParameter]
     public required ViewportInformation ViewportInformation { get; init; }
 
+    [CascadingParameter]
+    public DashboardDensity DashboardDensity { get; init; } = DashboardDensity.Comfortable;
+
     protected override void OnInitialized()
     {
         TelemetryContextProvider.Initialize(TelemetryContext);

--- a/src/Aspire.Dashboard/Components/Pages/Resources.razor
+++ b/src/Aspire.Dashboard/Components/Pages/Resources.razor
@@ -128,7 +128,7 @@
                                                     ResizeType="DataGridResizeType.Discrete"
                                                     Virtualize="true"
                                                     GenerateHeader="GenerateHeaderOption.Sticky"
-                                                    ItemSize="46"
+                                                    ItemSize="@DashboardDensity.MainGridItemSize()"
                                                     OverscanCount="100"
                                                     ItemsProvider="@GetData"
                                                     ResizableColumns="true"

--- a/src/Aspire.Dashboard/Components/Pages/Resources.razor.cs
+++ b/src/Aspire.Dashboard/Components/Pages/Resources.razor.cs
@@ -77,6 +77,9 @@ public partial class Resources : ComponentBase, IComponentWithTelemetry, IAsyncD
     public required DashboardDialogService DialogService { get; init; }
     [Inject]
     public required IconResolver IconResolver { get; init; }
+
+    [CascadingParameter]
+    public DashboardDensity DashboardDensity { get; init; } = DashboardDensity.Comfortable;
     [Inject]
     public required ResourceMenuBuilder ResourceMenuBuilder { get; init; }
 

--- a/src/Aspire.Dashboard/Components/Pages/StructuredLogs.razor
+++ b/src/Aspire.Dashboard/Components/Pages/StructuredLogs.razor
@@ -120,7 +120,7 @@
                                                 Virtualize="true"
                                                 RowClass="@GetRowClass"
                                                 GenerateHeader="GenerateHeaderOption.Sticky"
-                                                ItemSize="46"
+                                                ItemSize="@DashboardDensity.MainGridItemSize()"
                                                 OverscanCount="100"
                                                 ResizableColumns="true"
                                                 ResizeColumnOnAllRows="false"

--- a/src/Aspire.Dashboard/Components/Pages/StructuredLogs.razor.cs
+++ b/src/Aspire.Dashboard/Components/Pages/StructuredLogs.razor.cs
@@ -78,6 +78,9 @@ public partial class StructuredLogs : IComponentWithTelemetry, IPageWithSessionA
     [Inject]
     public required BrowserTimeProvider TimeProvider { get; init; }
 
+    [CascadingParameter]
+    public DashboardDensity DashboardDensity { get; init; } = DashboardDensity.Comfortable;
+
     [Inject]
     public required ILogger<StructuredLogs> Logger { get; init; }
 

--- a/src/Aspire.Dashboard/Components/Pages/TraceDetail.razor
+++ b/src/Aspire.Dashboard/Components/Pages/TraceDetail.razor
@@ -135,7 +135,7 @@
                                             RowClass="@GetRowClass"
                                             GridTemplateColumns="@_manager.GetGridTemplateColumns()"
                                             RowSize="DataGridRowSize.Medium"
-                                            ItemSize="44"
+                                            ItemSize="@DashboardDensity.TraceDetailGridItemSize()"
                                             OverscanCount="100"
                                             ShowHover="true"
                                             ItemKey="@(r => r.Span.SpanId)"

--- a/src/Aspire.Dashboard/Components/Pages/TraceDetail.razor.cs
+++ b/src/Aspire.Dashboard/Components/Pages/TraceDetail.razor.cs
@@ -58,6 +58,9 @@ public partial class TraceDetail : ComponentBase, IComponentWithTelemetry, IDisp
     [SupplyParameterFromQuery]
     public string? SpanId { get; set; }
 
+    [CascadingParameter]
+    public DashboardDensity DashboardDensity { get; init; } = DashboardDensity.Comfortable;
+
     [Inject]
     public required ILogger<TraceDetail> Logger { get; init; }
 

--- a/src/Aspire.Dashboard/Components/Pages/Traces.razor
+++ b/src/Aspire.Dashboard/Components/Pages/Traces.razor
@@ -97,7 +97,7 @@
                                     Virtualize="true"
                                     RowClass="@GetRowClass"
                                     GenerateHeader="GenerateHeaderOption.Sticky"
-                                    ItemSize="46"
+                                    ItemSize="@DashboardDensity.MainGridItemSize()"
                                     OverscanCount="100"
                                     ResizableColumns="true"
                                     ResizeColumnOnAllRows="false"

--- a/src/Aspire.Dashboard/Components/Pages/Traces.razor.cs
+++ b/src/Aspire.Dashboard/Components/Pages/Traces.razor.cs
@@ -71,6 +71,9 @@ public partial class Traces : IComponentWithTelemetry, IPageWithSessionAndUrlSta
     [Inject]
     public required BrowserTimeProvider TimeProvider { get; init; }
 
+    [CascadingParameter]
+    public DashboardDensity DashboardDensity { get; init; } = DashboardDensity.Comfortable;
+
     [Inject]
     public required IOptions<DashboardOptions> DashboardOptions { get; init; }
 

--- a/src/Aspire.Dashboard/Model/DashboardDensity.cs
+++ b/src/Aspire.Dashboard/Model/DashboardDensity.cs
@@ -1,0 +1,41 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Aspire.Dashboard.Model;
+
+/// <summary>
+/// Defines the dashboard's visual density.
+/// </summary>
+public enum DashboardDensity
+{
+    /// <summary>
+    /// The default dashboard spacing.
+    /// </summary>
+    Comfortable,
+
+    /// <summary>
+    /// Reduced spacing for denser dashboard views.
+    /// </summary>
+    Compact
+}
+
+internal static class DashboardDensityExtensions
+{
+    public static string ToAttributeValue(this DashboardDensity density) => density switch
+    {
+        DashboardDensity.Compact => "compact",
+        _ => "comfortable"
+    };
+
+    public static int MainGridItemSize(this DashboardDensity density) => density switch
+    {
+        DashboardDensity.Compact => 36,
+        _ => 46
+    };
+
+    public static int TraceDetailGridItemSize(this DashboardDensity density) => density switch
+    {
+        DashboardDensity.Compact => 36,
+        _ => 44
+    };
+}

--- a/src/Aspire.Dashboard/Resources/Dialogs.Designer.cs
+++ b/src/Aspire.Dashboard/Resources/Dialogs.Designer.cs
@@ -10,8 +10,8 @@
 
 namespace Aspire.Dashboard.Resources {
     using System;
-    
-    
+
+
     /// <summary>
     ///   A strongly-typed resource class, for looking up localized strings, etc.
     /// </summary>
@@ -23,7 +23,7 @@ namespace Aspire.Dashboard.Resources {
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     public class Dialogs {
-        
+
         private static global::System.Resources.ResourceManager resourceMan;
         
         private static global::System.Globalization.CultureInfo resourceCulture;
@@ -1014,6 +1014,42 @@ namespace Aspire.Dashboard.Resources {
             }
         }
         
+        /// <summary>
+        ///   Looks up a localized string similar to Density.
+        /// </summary>
+        public static string SettingsDialogDensity {
+            get {
+                return ResourceManager.GetString("SettingsDialogDensity", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Comfortable.
+        /// </summary>
+        public static string SettingsDialogDensityComfortable {
+            get {
+                return ResourceManager.GetString("SettingsDialogDensityComfortable", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Compact.
+        /// </summary>
+        public static string SettingsDialogDensityCompact {
+            get {
+                return ResourceManager.GetString("SettingsDialogDensityCompact", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Compact reduces spacing in tables, details, and page chrome..
+        /// </summary>
+        public static string SettingsDialogDensityDescription {
+            get {
+                return ResourceManager.GetString("SettingsDialogDensityDescription", resourceCulture);
+            }
+        }
+
         /// <summary>
         ///   Looks up a localized string similar to Theme.
         /// </summary>

--- a/src/Aspire.Dashboard/Resources/Dialogs.resx
+++ b/src/Aspire.Dashboard/Resources/Dialogs.resx
@@ -147,6 +147,18 @@
   <data name="SettingsDialogTheme" xml:space="preserve">
     <value>Theme</value>
   </data>
+  <data name="SettingsDialogDensity" xml:space="preserve">
+    <value>Density</value>
+  </data>
+  <data name="SettingsDialogDensityComfortable" xml:space="preserve">
+    <value>Comfortable</value>
+  </data>
+  <data name="SettingsDialogDensityCompact" xml:space="preserve">
+    <value>Compact</value>
+  </data>
+  <data name="SettingsDialogDensityDescription" xml:space="preserve">
+    <value>Compact reduces spacing in tables, details, and page chrome.</value>
+  </data>
   <data name="SettingsDialogVersion" xml:space="preserve">
     <value>Version: {0}</value>
     <comment>{0} is the dashboard version string</comment>

--- a/src/Aspire.Dashboard/Resources/xlf/Dialogs.cs.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Dialogs.cs.xlf
@@ -570,6 +570,26 @@ For more information about using AI agents with the dashboard, such as setting u
         <target state="translated">Protokoly prostředků a telemetrie</target>
         <note />
       </trans-unit>
+      <trans-unit id="SettingsDialogDensity">
+        <source>Density</source>
+        <target state="new">Density</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SettingsDialogDensityComfortable">
+        <source>Comfortable</source>
+        <target state="new">Comfortable</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SettingsDialogDensityCompact">
+        <source>Compact</source>
+        <target state="new">Compact</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SettingsDialogDensityDescription">
+        <source>Compact reduces spacing in tables, details, and page chrome.</source>
+        <target state="new">Compact reduces spacing in tables, details, and page chrome.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SettingsDialogDotNetRuntimeVersion">
         <source>Runtime: {0}</source>
         <target state="translated">Modul runtime: {0}</target>

--- a/src/Aspire.Dashboard/Resources/xlf/Dialogs.de.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Dialogs.de.xlf
@@ -570,6 +570,26 @@ For more information about using AI agents with the dashboard, such as setting u
         <target state="translated">Ressourcenprotokolle und Telemetrie</target>
         <note />
       </trans-unit>
+      <trans-unit id="SettingsDialogDensity">
+        <source>Density</source>
+        <target state="new">Density</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SettingsDialogDensityComfortable">
+        <source>Comfortable</source>
+        <target state="new">Comfortable</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SettingsDialogDensityCompact">
+        <source>Compact</source>
+        <target state="new">Compact</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SettingsDialogDensityDescription">
+        <source>Compact reduces spacing in tables, details, and page chrome.</source>
+        <target state="new">Compact reduces spacing in tables, details, and page chrome.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SettingsDialogDotNetRuntimeVersion">
         <source>Runtime: {0}</source>
         <target state="translated">Laufzeit: {0}</target>

--- a/src/Aspire.Dashboard/Resources/xlf/Dialogs.es.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Dialogs.es.xlf
@@ -570,6 +570,26 @@ For more information about using AI agents with the dashboard, such as setting u
         <target state="translated">Registros de recursos y telemetría</target>
         <note />
       </trans-unit>
+      <trans-unit id="SettingsDialogDensity">
+        <source>Density</source>
+        <target state="new">Density</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SettingsDialogDensityComfortable">
+        <source>Comfortable</source>
+        <target state="new">Comfortable</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SettingsDialogDensityCompact">
+        <source>Compact</source>
+        <target state="new">Compact</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SettingsDialogDensityDescription">
+        <source>Compact reduces spacing in tables, details, and page chrome.</source>
+        <target state="new">Compact reduces spacing in tables, details, and page chrome.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SettingsDialogDotNetRuntimeVersion">
         <source>Runtime: {0}</source>
         <target state="translated">Runtime: {0}</target>

--- a/src/Aspire.Dashboard/Resources/xlf/Dialogs.fr.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Dialogs.fr.xlf
@@ -570,6 +570,26 @@ For more information about using AI agents with the dashboard, such as setting u
         <target state="translated">Journaux d’activité de ressources et télémétrie</target>
         <note />
       </trans-unit>
+      <trans-unit id="SettingsDialogDensity">
+        <source>Density</source>
+        <target state="new">Density</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SettingsDialogDensityComfortable">
+        <source>Comfortable</source>
+        <target state="new">Comfortable</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SettingsDialogDensityCompact">
+        <source>Compact</source>
+        <target state="new">Compact</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SettingsDialogDensityDescription">
+        <source>Compact reduces spacing in tables, details, and page chrome.</source>
+        <target state="new">Compact reduces spacing in tables, details, and page chrome.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SettingsDialogDotNetRuntimeVersion">
         <source>Runtime: {0}</source>
         <target state="translated">Runtime : {0}</target>

--- a/src/Aspire.Dashboard/Resources/xlf/Dialogs.it.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Dialogs.it.xlf
@@ -570,6 +570,26 @@ For more information about using AI agents with the dashboard, such as setting u
         <target state="translated">Log delle risorse e telemetria</target>
         <note />
       </trans-unit>
+      <trans-unit id="SettingsDialogDensity">
+        <source>Density</source>
+        <target state="new">Density</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SettingsDialogDensityComfortable">
+        <source>Comfortable</source>
+        <target state="new">Comfortable</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SettingsDialogDensityCompact">
+        <source>Compact</source>
+        <target state="new">Compact</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SettingsDialogDensityDescription">
+        <source>Compact reduces spacing in tables, details, and page chrome.</source>
+        <target state="new">Compact reduces spacing in tables, details, and page chrome.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SettingsDialogDotNetRuntimeVersion">
         <source>Runtime: {0}</source>
         <target state="translated">Runtime: {0}</target>

--- a/src/Aspire.Dashboard/Resources/xlf/Dialogs.ja.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Dialogs.ja.xlf
@@ -570,6 +570,26 @@ For more information about using AI agents with the dashboard, such as setting u
         <target state="translated">リソース ログとテレメトリ</target>
         <note />
       </trans-unit>
+      <trans-unit id="SettingsDialogDensity">
+        <source>Density</source>
+        <target state="new">Density</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SettingsDialogDensityComfortable">
+        <source>Comfortable</source>
+        <target state="new">Comfortable</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SettingsDialogDensityCompact">
+        <source>Compact</source>
+        <target state="new">Compact</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SettingsDialogDensityDescription">
+        <source>Compact reduces spacing in tables, details, and page chrome.</source>
+        <target state="new">Compact reduces spacing in tables, details, and page chrome.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SettingsDialogDotNetRuntimeVersion">
         <source>Runtime: {0}</source>
         <target state="translated">ランタイム: {0}</target>

--- a/src/Aspire.Dashboard/Resources/xlf/Dialogs.ko.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Dialogs.ko.xlf
@@ -570,6 +570,26 @@ For more information about using AI agents with the dashboard, such as setting u
         <target state="translated">리소스 로그 및 원격 분석</target>
         <note />
       </trans-unit>
+      <trans-unit id="SettingsDialogDensity">
+        <source>Density</source>
+        <target state="new">Density</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SettingsDialogDensityComfortable">
+        <source>Comfortable</source>
+        <target state="new">Comfortable</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SettingsDialogDensityCompact">
+        <source>Compact</source>
+        <target state="new">Compact</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SettingsDialogDensityDescription">
+        <source>Compact reduces spacing in tables, details, and page chrome.</source>
+        <target state="new">Compact reduces spacing in tables, details, and page chrome.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SettingsDialogDotNetRuntimeVersion">
         <source>Runtime: {0}</source>
         <target state="translated">런타임: {0}</target>

--- a/src/Aspire.Dashboard/Resources/xlf/Dialogs.pl.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Dialogs.pl.xlf
@@ -570,6 +570,26 @@ For more information about using AI agents with the dashboard, such as setting u
         <target state="translated">Dzienniki zasobów i dane telemetryczne</target>
         <note />
       </trans-unit>
+      <trans-unit id="SettingsDialogDensity">
+        <source>Density</source>
+        <target state="new">Density</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SettingsDialogDensityComfortable">
+        <source>Comfortable</source>
+        <target state="new">Comfortable</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SettingsDialogDensityCompact">
+        <source>Compact</source>
+        <target state="new">Compact</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SettingsDialogDensityDescription">
+        <source>Compact reduces spacing in tables, details, and page chrome.</source>
+        <target state="new">Compact reduces spacing in tables, details, and page chrome.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SettingsDialogDotNetRuntimeVersion">
         <source>Runtime: {0}</source>
         <target state="translated">Środowisko uruchomieniowe: {0}</target>

--- a/src/Aspire.Dashboard/Resources/xlf/Dialogs.pt-BR.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Dialogs.pt-BR.xlf
@@ -570,6 +570,26 @@ For more information about using AI agents with the dashboard, such as setting u
         <target state="translated">Logs e telemetria do recurso</target>
         <note />
       </trans-unit>
+      <trans-unit id="SettingsDialogDensity">
+        <source>Density</source>
+        <target state="new">Density</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SettingsDialogDensityComfortable">
+        <source>Comfortable</source>
+        <target state="new">Comfortable</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SettingsDialogDensityCompact">
+        <source>Compact</source>
+        <target state="new">Compact</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SettingsDialogDensityDescription">
+        <source>Compact reduces spacing in tables, details, and page chrome.</source>
+        <target state="new">Compact reduces spacing in tables, details, and page chrome.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SettingsDialogDotNetRuntimeVersion">
         <source>Runtime: {0}</source>
         <target state="translated">Tempo de execução: {0}</target>

--- a/src/Aspire.Dashboard/Resources/xlf/Dialogs.ru.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Dialogs.ru.xlf
@@ -570,6 +570,26 @@ For more information about using AI agents with the dashboard, such as setting u
         <target state="translated">Журналы ресурсов и телеметрия</target>
         <note />
       </trans-unit>
+      <trans-unit id="SettingsDialogDensity">
+        <source>Density</source>
+        <target state="new">Density</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SettingsDialogDensityComfortable">
+        <source>Comfortable</source>
+        <target state="new">Comfortable</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SettingsDialogDensityCompact">
+        <source>Compact</source>
+        <target state="new">Compact</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SettingsDialogDensityDescription">
+        <source>Compact reduces spacing in tables, details, and page chrome.</source>
+        <target state="new">Compact reduces spacing in tables, details, and page chrome.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SettingsDialogDotNetRuntimeVersion">
         <source>Runtime: {0}</source>
         <target state="translated">Среда выполнения: {0}</target>

--- a/src/Aspire.Dashboard/Resources/xlf/Dialogs.tr.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Dialogs.tr.xlf
@@ -570,6 +570,26 @@ For more information about using AI agents with the dashboard, such as setting u
         <target state="translated">Kaynak günlükleri ve telemetri</target>
         <note />
       </trans-unit>
+      <trans-unit id="SettingsDialogDensity">
+        <source>Density</source>
+        <target state="new">Density</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SettingsDialogDensityComfortable">
+        <source>Comfortable</source>
+        <target state="new">Comfortable</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SettingsDialogDensityCompact">
+        <source>Compact</source>
+        <target state="new">Compact</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SettingsDialogDensityDescription">
+        <source>Compact reduces spacing in tables, details, and page chrome.</source>
+        <target state="new">Compact reduces spacing in tables, details, and page chrome.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SettingsDialogDotNetRuntimeVersion">
         <source>Runtime: {0}</source>
         <target state="translated">Çalışma Zamanı: {0}</target>

--- a/src/Aspire.Dashboard/Resources/xlf/Dialogs.zh-Hans.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Dialogs.zh-Hans.xlf
@@ -570,6 +570,26 @@ For more information about using AI agents with the dashboard, such as setting u
         <target state="translated">资源日志和遥测</target>
         <note />
       </trans-unit>
+      <trans-unit id="SettingsDialogDensity">
+        <source>Density</source>
+        <target state="new">Density</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SettingsDialogDensityComfortable">
+        <source>Comfortable</source>
+        <target state="new">Comfortable</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SettingsDialogDensityCompact">
+        <source>Compact</source>
+        <target state="new">Compact</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SettingsDialogDensityDescription">
+        <source>Compact reduces spacing in tables, details, and page chrome.</source>
+        <target state="new">Compact reduces spacing in tables, details, and page chrome.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SettingsDialogDotNetRuntimeVersion">
         <source>Runtime: {0}</source>
         <target state="translated">运行时: {0}</target>

--- a/src/Aspire.Dashboard/Resources/xlf/Dialogs.zh-Hant.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Dialogs.zh-Hant.xlf
@@ -570,6 +570,26 @@ For more information about using AI agents with the dashboard, such as setting u
         <target state="translated">資源記錄與遙測</target>
         <note />
       </trans-unit>
+      <trans-unit id="SettingsDialogDensity">
+        <source>Density</source>
+        <target state="new">Density</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SettingsDialogDensityComfortable">
+        <source>Comfortable</source>
+        <target state="new">Comfortable</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SettingsDialogDensityCompact">
+        <source>Compact</source>
+        <target state="new">Compact</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SettingsDialogDensityDescription">
+        <source>Compact reduces spacing in tables, details, and page chrome.</source>
+        <target state="new">Compact reduces spacing in tables, details, and page chrome.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SettingsDialogDotNetRuntimeVersion">
         <source>Runtime: {0}</source>
         <target state="translated">執行階段: {0}</target>

--- a/src/Aspire.Dashboard/Utils/BrowserStorageKeys.cs
+++ b/src/Aspire.Dashboard/Utils/BrowserStorageKeys.cs
@@ -11,6 +11,7 @@ internal static class BrowserStorageKeys
     public const string UnsecuredTelemetryMessageDismissedKey = "Aspire_Telemetry_UnsecuredMessageDismissed";
     public const string UnsecuredEndpointMessageDismissedKey = "Aspire_Security_UnsecuredEndpointMessageDismissed";
     public const string TimeFormat = "Aspire_TimeFormat";
+    public const string DashboardDensity = "Aspire_DashboardDensity";
 
     public const string TracesPageState = "Aspire_PageState_Traces";
     public const string StructuredLogsPageState = "Aspire_PageState_StructuredLogs";

--- a/src/Aspire.Dashboard/wwwroot/css/app.css
+++ b/src/Aspire.Dashboard/wwwroot/css/app.css
@@ -2172,3 +2172,189 @@ fluent-button::part(control) {
     font-size: 10px;
     padding: 2px 8px;
 }
+
+/* --- Density: Compact --- */
+.layout[data-density="compact"] {
+    --aspire-radius-card: 10px;
+    --aspire-radius-panel: 12px;
+    --aspire-radius-section: 7px;
+}
+
+.layout[data-density="compact"] .content-layout {
+    border-radius: 12px;
+    height: calc(100% - 20px);
+    margin: 10px 14px;
+    width: calc(100% - 28px);
+}
+
+.layout[data-density="compact"] h1 {
+    font-size: var(--type-ramp-plus-3-font-size);
+    line-height: var(--type-ramp-plus-3-line-height);
+    margin-top: 0;
+    margin-bottom: 0.25rem;
+}
+
+.layout[data-density="compact"] .content-header {
+    padding: 14px 16px 8px;
+}
+
+.layout[data-density="compact"] .content-header .title-toolbar-inline {
+    min-height: 34px;
+}
+
+.layout[data-density="compact"] fluent-toolbar[orientation=horizontal] {
+    gap: 4px;
+    min-height: 36px;
+    padding: 4px 8px;
+}
+
+.layout[data-density="compact"] fluent-tabs::part(tablist) {
+    gap: 3px;
+    padding: 3px 5px;
+}
+
+.layout[data-density="compact"] fluent-tab {
+    font-size: 12px;
+    padding: 3px 10px;
+}
+
+.layout[data-density="compact"] fluent-tab::part(content) {
+    padding: 2px 7px;
+}
+
+.layout[data-density="compact"] fluent-tab[aria-selected="true"]::after {
+    bottom: 2px;
+    left: 12px;
+    right: 12px;
+}
+
+.layout[data-density="compact"] .fluent-data-grid-row[row-type='header'] td,
+.layout[data-density="compact"] .fluent-data-grid-row[row-type='sticky-header'] td,
+.layout[data-density="compact"] .fluent-data-grid-row[row-type='header'] th,
+.layout[data-density="compact"] .fluent-data-grid-row[row-type='sticky-header'] th {
+    font-size: 12px;
+    padding: 7px 10px !important;
+}
+
+.layout[data-density="compact"] .fluent-data-grid-row:not([row-type='header'],[row-type='sticky-header']) td {
+    font-size: 12.5px;
+    line-height: 18px;
+    padding: 6px 10px !important;
+}
+
+.layout[data-density="compact"] .property-grid-container .fluent-data-grid-row[row-type='header'] td,
+.layout[data-density="compact"] .property-grid-container .fluent-data-grid-row[row-type='sticky-header'] td,
+.layout[data-density="compact"] .property-grid-container .fluent-data-grid-row[row-type='header'] th,
+.layout[data-density="compact"] .property-grid-container .fluent-data-grid-row[row-type='sticky-header'] th,
+.layout[data-density="compact"] .property-grid-container .fluent-data-grid-row:not([row-type='header'],[row-type='sticky-header']) td {
+    height: 36px !important;
+}
+
+.layout[data-density="compact"] .fluent-data-grid-row[row-type='header'] .column-header:not(:first-of-type) .col-sort-button,
+.layout[data-density="compact"] .fluent-data-grid-row[row-type='sticky-header'] .column-header:not(:first-of-type) .col-sort-button {
+    margin-inline-start: -8px;
+}
+
+.layout[data-density="compact"] .fluent-data-grid-row[row-type='header'] .column-header:first-of-type .col-sort-button,
+.layout[data-density="compact"] .fluent-data-grid-row[row-type='sticky-header'] .column-header:first-of-type .col-sort-button {
+    margin-inline-start: 18px;
+}
+
+.layout[data-density="compact"] .main-grid .fluent-data-grid-row:not([row-type='sticky-header'], .empty-content-row) td:first-child:not(.expand-col) {
+    padding-left: calc(((var(--design-unit) * 2) + var(--focus-stroke-width) - var(--stroke-width) + 5) * 1px);
+}
+
+.layout[data-density="compact"] .main-grid .column-header:not(.select-all):first-of-type {
+    padding-inline-start: calc(var(--design-unit) * 1px) !important;
+}
+
+.layout[data-density="compact"] .grid-action-container {
+    column-gap: 3px;
+    min-height: 22px;
+}
+
+.layout[data-density="compact"] .grid-action-container fluent-button[appearance=lightweight],
+.layout[data-density="compact"] .grid-action-container fluent-button[appearance=stealth],
+.layout[data-density="compact"] .aspire-menu-button-icon-only[appearance=lightweight],
+.layout[data-density="compact"] .aspire-menu-button-icon-only[appearance=stealth],
+.layout[data-density="compact"] .grid-action-spacer {
+    height: 22px;
+    min-width: 22px;
+    width: 22px;
+}
+
+.layout[data-density="compact"] .grid-action-container fluent-button[appearance=lightweight]::part(control),
+.layout[data-density="compact"] .grid-action-container fluent-button[appearance=stealth]::part(control),
+.layout[data-density="compact"] .aspire-menu-button-icon-only[appearance=lightweight]::part(control),
+.layout[data-density="compact"] .aspire-menu-button-icon-only[appearance=stealth]::part(control) {
+    height: 22px;
+    min-width: 22px;
+    width: 22px;
+}
+
+.layout[data-density="compact"] .main-grid-expand-container,
+.layout[data-density="compact"] .main-grid-expand-button {
+    width: 16px;
+    min-width: 16px;
+}
+
+.layout[data-density="compact"] .main-grid-expand-button::part(control) {
+    height: 16px;
+    min-width: 16px;
+    width: 16px;
+}
+
+.layout[data-density="compact"] .details-container > header {
+    padding: calc(var(--design-unit) * 1.25px) calc(var(--design-unit) * 2px);
+}
+
+.layout[data-density="compact"] .details-container > header > .details-header-title {
+    font-size: var(--type-ramp-minus-1-font-size) !important;
+    line-height: 18px;
+}
+
+.layout[data-density="compact"] .resource-details-layout,
+.layout[data-density="compact"] .structured-log-details-layout {
+    gap: 0;
+}
+
+.layout[data-density="compact"] .property-grid-container {
+    padding: 0;
+}
+
+.layout[data-density="compact"] .property-grid-container fluent-accordion {
+    gap: 0;
+    margin-bottom: 0;
+}
+
+.layout[data-density="compact"] .property-grid-container > fluent-accordion > fluent-accordion-item::part(heading) {
+    padding-left: calc(var(--design-unit) * 1px);
+}
+
+.layout[data-density="compact"] .property-grid-container fluent-accordion-item::part(heading) {
+    min-height: 34px;
+    padding-bottom: 4px;
+    padding-top: 4px;
+}
+
+.layout[data-density="compact"] .property-grid-container fluent-accordion-item::part(heading-content) {
+    font-size: var(--type-ramp-minus-1-font-size);
+}
+
+.layout[data-density="compact"] .property-grid-container fluent-accordion-item:is([expanded], [aria-expanded="true"])::part(heading),
+.layout[data-density="compact"] .property-grid-container fluent-accordion-item:is([expanded], [aria-expanded="true"])::part(heading):hover {
+    background-size: 100% 1px, auto;
+}
+
+.layout[data-density="compact"] fluent-input::part(control),
+.layout[data-density="compact"] fluent-search::part(control),
+.layout[data-density="compact"] fluent-select::part(control),
+.layout[data-density="compact"] fluent-combobox::part(control) {
+    min-height: 30px;
+}
+
+.layout[data-density="compact"] .severity-cell .fluent-badge,
+.layout[data-density="compact"] .severity-cell fluent-badge {
+    font-size: 10px;
+    padding: 1px 6px;
+}


### PR DESCRIPTION
## Description

Adds a persisted dashboard density setting with Comfortable and Compact modes. NOTE this is based off the redesign branch!

Compact mode reduces visual density across the dashboard without changing the default comfortable experience:
- Adds Settings > Density with localized strings and persisted browser storage.
- Applies a layout-level `data-density` attribute for density-specific styling.
- Tightens compact page headers, toolbars, tabs, table rows, action buttons, and detail panes.
- Keeps virtualized grid `ItemSize` values aligned with compact row heights.

Base branch: `dashboard-brand-refresh`.

Fixes # (issue)

## Validation

- Built `src\Aspire.Dashboard\Aspire.Dashboard.csproj` with `SkipNativeBuild=true`.
- Verified in TestShop that Comfortable and Compact persist from Settings.
- Verified compact main table rows and detail pane rows both measure 36px.

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [x] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
