### PR TITLE
Clean up ResourceCommandRequest/Response proto: use map for arguments, remove response argument_inputs

### DIFF
--- a/src/Aspire.Dashboard/Model/ResourceCommandResponseViewModel.cs
+++ b/src/Aspire.Dashboard/Model/ResourceCommandResponseViewModel.cs
@@ -1,9 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.Collections.Immutable;
-using Aspire.DashboardService.Proto.V1;
-
 namespace Aspire.Dashboard.Model;
 
 public class ResourceCommandResponseViewModel
@@ -12,7 +9,6 @@ public class ResourceCommandResponseViewModel
     public string? ErrorMessage { get; init; }
     public string? Message { get; init; }
     public ResourceCommandResultViewModel? Result { get; init; }
-    public ImmutableArray<InteractionInput> ArgumentInputs { get; init; } = [];
 }
 
 /// <summary>

--- a/src/Aspire.Dashboard/ServiceClient/DashboardClient.cs
+++ b/src/Aspire.Dashboard/ServiceClient/DashboardClient.cs
@@ -767,7 +767,10 @@ internal sealed class DashboardClient : IDashboardClient
 
         if (options.Arguments is { } arguments)
         {
-            request.Arguments.Add(arguments);
+            foreach (var (key, value) in arguments)
+            {
+                request.Arguments.Add(key, value);
+            }
         }
 
         try

--- a/src/Aspire.Dashboard/ServiceClient/DashboardClient.cs
+++ b/src/Aspire.Dashboard/ServiceClient/DashboardClient.cs
@@ -760,11 +760,15 @@ internal sealed class DashboardClient : IDashboardClient
         var request = new ResourceCommandRequest()
         {
             CommandName = command.Name,
-            Arguments = options.Arguments,
             ResourceName = resourceName,
             ResourceType = resourceType,
             NonInteractive = options.NonInteractive
         };
+
+        if (options.Arguments is { } arguments)
+        {
+            request.Arguments.Add(arguments);
+        }
 
         try
         {

--- a/src/Aspire.Dashboard/ServiceClient/IDashboardClient.cs
+++ b/src/Aspire.Dashboard/ServiceClient/IDashboardClient.cs
@@ -80,9 +80,9 @@ public interface IDashboardClient : IAsyncDisposable
 public sealed class ExecuteResourceCommandOptions
 {
     /// <summary>
-    /// Gets the invocation arguments supplied to the command.
+    /// Gets the invocation arguments supplied to the command, keyed by argument name.
     /// </summary>
-    public Value? Arguments { get; init; }
+    public IReadOnlyDictionary<string, Value>? Arguments { get; init; }
 
     /// <summary>
     /// Gets a value indicating whether command execution should fail instead of prompting for missing input.

--- a/src/Aspire.Dashboard/ServiceClient/Partials.cs
+++ b/src/Aspire.Dashboard/ServiceClient/Partials.cs
@@ -206,7 +206,6 @@ partial class ResourceCommandResponse
             ErrorMessage = resolvedMessage,
             Message = resolvedMessage,
             Kind = (Dashboard.Model.ResourceCommandResponseKind)Kind,
-            ArgumentInputs = ArgumentInputs.ToImmutableArray(),
             Result = Result is not null ? new ResourceCommandResultViewModel
             {
                 Value = Result.Value,

--- a/src/Aspire.Hosting/Dashboard/DashboardService.cs
+++ b/src/Aspire.Hosting/Dashboard/DashboardService.cs
@@ -4,6 +4,7 @@
 using System.Text.RegularExpressions;
 using System.Globalization;
 using Aspire.DashboardService.Proto.V1;
+using Google.Protobuf.Collections;
 using Google.Protobuf.WellKnownTypes;
 using Grpc.Core;
 using Microsoft.AspNetCore.Authorization;
@@ -410,34 +411,18 @@ internal sealed partial class DashboardService(DashboardServiceData serviceData,
             };
         }
 
-        if (invalidArguments is not null)
-        {
-            response.ArgumentInputs.AddRange(invalidArguments.Select(argument => CreateInteractionInputDto(argument)));
-        }
-
         return response;
     }
 
-    private static IReadOnlyDictionary<string, string?>? ConvertArgumentValues(Value? value)
+    private static IReadOnlyDictionary<string, string?>? ConvertArgumentValues(MapField<string, Value> arguments)
     {
-        if (value is null)
+        if (arguments.Count == 0)
         {
             return null;
         }
 
-        // ResourceCommandRequest arguments are encoded as an object-valued google.protobuf.Value in the dashboard gRPC protocol:
-        // {
-        //   "command_name": "click",
-        //   "resource_name": "web-browser-logs",
-        //   "arguments": { "selector": "#submit" }
-        // }
-        if (value.KindCase != Value.KindOneofCase.StructValue)
-        {
-            throw new RpcException(new Status(StatusCode.InvalidArgument, "Resource command arguments must be an object."));
-        }
-
         var values = new Dictionary<string, string?>(StringComparers.InteractionInputName);
-        foreach (var field in value.StructValue.Fields)
+        foreach (var field in arguments)
         {
             values[field.Key] = ConvertArgumentValue(field.Key, field.Value);
         }

--- a/src/Aspire.Hosting/Dashboard/proto/dashboard_service.proto
+++ b/src/Aspire.Hosting/Dashboard/proto/dashboard_service.proto
@@ -52,7 +52,7 @@ message ResourceCommand {
     // or hidden in the UI.
     ResourceCommandState state = 9;
     // Static, ordered input metadata that describes the invocation arguments accepted by the command.
-    // Dashboard clients can render these inputs and send object-shaped values in ResourceCommandRequest.arguments.
+    // Dashboard clients can render these inputs and send a map of Values in ResourceCommandRequest.arguments keyed by InteractionInput.name.
     repeated InteractionInput argument_inputs = 10;
 }
 

--- a/src/Aspire.Hosting/Dashboard/proto/dashboard_service.proto
+++ b/src/Aspire.Hosting/Dashboard/proto/dashboard_service.proto
@@ -104,7 +104,6 @@ message ResourceCommandResponse {
     optional string error_message = 2 [deprecated = true];
     optional string message = 3;
     optional ResourceCommandResult result = 4;
-    reserved 5;
 }
 
 message ResourceCommandResult {

--- a/src/Aspire.Hosting/Dashboard/proto/dashboard_service.proto
+++ b/src/Aspire.Hosting/Dashboard/proto/dashboard_service.proto
@@ -77,10 +77,10 @@ message ResourceCommandRequest {
     // Deprecated. An optional parameter to accompany the command.
     // Copied from the ResourceCommand that this request object is initialized from.
     optional google.protobuf.Value parameter = 4 [deprecated = true];
-    // Optional invocation arguments to pass to the command.
+    // Invocation arguments to pass to the command.
     // Unlike parameter, this value is supplied by the client for this execution.
-    // Dashboard requests encode arguments as an object-valued google.protobuf.Value keyed by InteractionInput.name.
-    optional google.protobuf.Value arguments = 5;
+    // Keys are InteractionInput.name values; each value is a google.protobuf.Value (string, number, bool, or null).
+    map<string, google.protobuf.Value> arguments = 5;
     // When true, command execution should fail instead of prompting for missing input.
     bool non_interactive = 6;
 }
@@ -104,7 +104,7 @@ message ResourceCommandResponse {
     optional string error_message = 2 [deprecated = true];
     optional string message = 3;
     optional ResourceCommandResult result = 4;
-    repeated InteractionInput argument_inputs = 5;
+    reserved 5;
 }
 
 message ResourceCommandResult {

--- a/tests/Aspire.Hosting.Tests/Dashboard/DashboardServiceTests.cs
+++ b/tests/Aspire.Hosting.Tests/Dashboard/DashboardServiceTests.cs
@@ -423,6 +423,7 @@ public class DashboardServiceTests(ITestOutputHelper testOutputHelper)
             context);
 
         Assert.Equal(ResourceCommandResponseKind.InvalidArguments, response.Kind);
+        Assert.Equal("Command argument validation failed.", response.Message);
         Assert.False(executed);
     }
 

--- a/tests/Aspire.Hosting.Tests/Dashboard/DashboardServiceTests.cs
+++ b/tests/Aspire.Hosting.Tests/Dashboard/DashboardServiceTests.cs
@@ -293,14 +293,11 @@ public class DashboardServiceTests(ITestOutputHelper testOutputHelper)
             {
                 ResourceName = testResource.Name,
                 CommandName = "click",
-                Arguments = Value.ForStruct(new Struct
+                Arguments =
                 {
-                    Fields =
-                    {
-                        ["selector"] = Value.ForString("#submit"),
-                        ["clickCount"] = Value.ForNumber(2)
-                    }
-                })
+                    ["selector"] = Value.ForString("#submit"),
+                    ["clickCount"] = Value.ForNumber(2)
+                }
             },
             context);
 
@@ -355,13 +352,10 @@ public class DashboardServiceTests(ITestOutputHelper testOutputHelper)
             {
                 ResourceName = testResource.Name,
                 CommandName = "click",
-                Arguments = Value.ForStruct(new Struct
+                Arguments =
                 {
-                    Fields =
-                    {
-                        ["selecter"] = Value.ForString("#submit")
-                    }
-                })
+                    ["selecter"] = Value.ForString("#submit")
+                }
             },
             context);
 
@@ -421,21 +415,15 @@ public class DashboardServiceTests(ITestOutputHelper testOutputHelper)
             {
                 ResourceName = testResource.Name,
                 CommandName = "validate",
-                Arguments = Value.ForStruct(new Struct
+                Arguments =
                 {
-                    Fields =
-                    {
-                        ["target"] = Value.ForString("prod")
-                    }
-                })
+                    ["target"] = Value.ForString("prod")
+                }
             },
             context);
 
         Assert.Equal(ResourceCommandResponseKind.InvalidArguments, response.Kind);
         Assert.False(executed);
-        var invalidArgument = Assert.Single(response.ArgumentInputs);
-        Assert.Equal("target", invalidArgument.Name);
-        Assert.Equal("Target must not be prod.", Assert.Single(invalidArgument.ValidationErrors));
     }
 
     [Theory]


### PR DESCRIPTION
## Description

Cleans up the `ResourceCommandRequest` and `ResourceCommandResponse` proto messages in the dashboard gRPC protocol. These proto changes haven't shipped in a release yet, so this is not a breaking change.

1. **`ResourceCommandRequest.arguments`**: Changed from `optional google.protobuf.Value` (which required encoding as a `Struct`) to `map<string, google.protobuf.Value>`. This makes the wire format strongly typed — keys are argument names (matching `InteractionInput.name`) and values are typed proto `Value`s. The server-side `ConvertArgumentValues` method is simplified since it no longer needs to unwrap a `Struct` or validate that the `Value` is object-shaped.

2. **`ResourceCommandResponse.argument_inputs`**: Removed. This field carried `InteractionInput` items with validation errors back to the client, but was unused by the dashboard (the `DashboardCommandExecutor` never reads it). The `ResourceCommandResponseViewModel.ArgumentInputs` property and its mapping in `Partials.cs` are also removed.

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
  - [x] No
