### PR TITLE
Show resource-scoped command help

### DIFF
--- a/src/Aspire.Cli/Backchannel/ResourceSnapshotMapper.cs
+++ b/src/Aspire.Cli/Backchannel/ResourceSnapshotMapper.cs
@@ -151,14 +151,14 @@ internal static class ResourceSnapshotMapper
             Commands = commands
         };
 
-        static bool IsDefaultCommandVisibility(string visibility)
+        static bool IsDefaultCommandVisibility(string? visibility)
         {
             return string.Equals(visibility, KnownCommandVisibility.Default, StringComparison.OrdinalIgnoreCase);
         }
 
-        static bool IsCommandVisibleToApi(string visibility)
+        static bool IsCommandVisibleToApi(string? visibility)
         {
-            return visibility.Split(',').Any(static value => string.Equals(value.Trim(), KnownCommandVisibility.Api, StringComparison.OrdinalIgnoreCase));
+            return visibility?.Split(',').Any(static value => string.Equals(value.Trim(), KnownCommandVisibility.Api, StringComparison.OrdinalIgnoreCase)) is true;
         }
     }
 

--- a/src/Aspire.Cli/Backchannel/ResourceSnapshotMapper.cs
+++ b/src/Aspire.Cli/Backchannel/ResourceSnapshotMapper.cs
@@ -104,10 +104,10 @@ internal static class ResourceSnapshotMapper
 
         // Only include enabled commands
         var commands = snapshot.Commands
-            .Where(c => string.Equals(c.State, "Enabled", StringComparison.OrdinalIgnoreCase) && IsCommandVisibleToApi(c.Visibility))
+            .Where(IsCommandAvailableToApi)
             .OrderBy(c => c.Name)
             .ToDistinctDictionary(
-                 c => c.Name,
+                  c => c.Name,
                   c => new ResourceCommandJson
                   {
                       Description = c.Description,
@@ -150,16 +150,22 @@ internal static class ResourceSnapshotMapper
             Relationships = relationships.ToArray(),
             Commands = commands
         };
+    }
 
-        static bool IsDefaultCommandVisibility(string? visibility)
-        {
-            return string.Equals(visibility, KnownCommandVisibility.Default, StringComparison.OrdinalIgnoreCase);
-        }
+    internal static bool IsCommandAvailableToApi(ResourceSnapshotCommand command)
+    {
+        return string.Equals(command.State, "Enabled", StringComparison.OrdinalIgnoreCase) &&
+            IsCommandVisibleToApi(command.Visibility);
+    }
 
-        static bool IsCommandVisibleToApi(string? visibility)
-        {
-            return visibility?.Split(',').Any(static value => string.Equals(value.Trim(), KnownCommandVisibility.Api, StringComparison.OrdinalIgnoreCase)) is true;
-        }
+    private static bool IsDefaultCommandVisibility(string? visibility)
+    {
+        return string.Equals(visibility, KnownCommandVisibility.Default, StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static bool IsCommandVisibleToApi(string? visibility)
+    {
+        return visibility?.Split(',').Any(static value => string.Equals(value.Trim(), KnownCommandVisibility.Api, StringComparison.OrdinalIgnoreCase)) is true;
     }
 
     private static ResourceCommandArgumentJson MapCommandArgumentInput(ResourceSnapshotCommandArgument input)

--- a/src/Aspire.Cli/Commands/ResourceCommand.cs
+++ b/src/Aspire.Cli/Commands/ResourceCommand.cs
@@ -5,6 +5,7 @@ using System.CommandLine;
 using System.CommandLine.Help;
 using System.CommandLine.Invocation;
 using System.CommandLine.Parsing;
+using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.Text;
 using System.Text.Json.Nodes;
@@ -24,6 +25,7 @@ internal sealed class ResourceCommand : BaseCommand
     internal override HelpGroup HelpGroup => HelpGroup.ResourceManagement;
 
     private readonly IInteractionService _interactionService;
+    private readonly IAuxiliaryBackchannelMonitor _backchannelMonitor;
     private readonly AppHostConnectionResolver _connectionResolver;
     private readonly ILogger<ResourceCommand> _logger;
 
@@ -42,6 +44,10 @@ internal sealed class ResourceCommand : BaseCommand
     };
 
     private static readonly OptionWithLegacy<FileInfo?> s_appHostOption = new("--apphost", "--project", SharedCommandStrings.AppHostOptionDescription);
+    private static readonly Option<bool> s_includeHiddenOption = new("--include-hidden")
+    {
+        Description = ResourceCommandStrings.IncludeHiddenOptionDescription
+    };
 
     /// <summary>
     /// Well-known commands with their display metadata.
@@ -66,12 +72,14 @@ internal sealed class ResourceCommand : BaseCommand
         : base("resource", ResourceCommandStrings.CommandDescription, features, updateNotifier, executionContext, interactionService, telemetry)
     {
         _interactionService = interactionService;
+        _backchannelMonitor = backchannelMonitor;
         _connectionResolver = new AppHostConnectionResolver(backchannelMonitor, interactionService, projectLocator, executionContext, logger);
         _logger = logger;
 
         Arguments.Add(s_resourceArgument);
         Arguments.Add(s_commandArgument);
         Options.Add(s_appHostOption);
+        Options.Add(s_includeHiddenOption);
         Options.Add(new HelpOption { Action = new ResourceCommandHelpAction(this) });
         TreatUnmatchedTokensAsErrors = false;
 
@@ -97,6 +105,7 @@ internal sealed class ResourceCommand : BaseCommand
         var resourceName = parseResult.GetValue(s_resourceArgument)!;
         var commandName = parseResult.GetValue(s_commandArgument)!;
         var passedAppHostProjectFile = parseResult.GetValue(s_appHostOption);
+        var includeHidden = parseResult.GetValue(s_includeHiddenOption);
         var capturedArguments = parseResult.UnmatchedTokens.ToArray();
 
         var result = await _connectionResolver.ResolveConnectionAsync(
@@ -112,7 +121,7 @@ internal sealed class ResourceCommand : BaseCommand
         }
 
         var connection = result.Connection!;
-        var command = await GetCommandMetadataAsync(connection, resourceName, commandName, includeHidden: false, cancellationToken).ConfigureAwait(false);
+        var command = await GetCommandMetadataAsync(connection, resourceName, commandName, includeHidden, cancellationToken).ConfigureAwait(false);
         var commandArgumentsResult = CreateCommandArguments(command, capturedArguments);
         if (commandArgumentsResult.ErrorMessage is { } errorMessage)
         {
@@ -156,6 +165,38 @@ internal sealed class ResourceCommand : BaseCommand
         return resources
             .SelectMany(static resource => resource.Commands)
             .FirstOrDefault(command => string.Equals(command.Name, commandName, StringComparisons.CommandName));
+    }
+
+    private static async Task<(string Name, string Description)[]> GetAvailableCommandMetadataAsync(IAppHostAuxiliaryBackchannel connection, string resourceName, bool includeHidden, CancellationToken cancellationToken)
+    {
+        var snapshots = await connection.GetResourceSnapshotsAsync(includeHidden, cancellationToken).ConfigureAwait(false);
+        var resources = ResourceSnapshotMapper.ResolveResources(resourceName, snapshots);
+
+        return resources
+            .SelectMany(static resource => resource.Commands)
+            .Where(IsAvailableToCli)
+            .GroupBy(static command => command.Name, StringComparers.CommandName)
+            .OrderBy(static group => group.Key, StringComparers.CommandName)
+            .Select(static group =>
+            {
+                var description = group
+                    .Select(static command => command.Description ?? command.DisplayName)
+                    .FirstOrDefault(static description => !string.IsNullOrEmpty(description));
+
+                return (group.Key, description ?? string.Empty);
+            })
+            .ToArray();
+    }
+
+    private static bool IsAvailableToCli(ResourceSnapshotCommand command)
+    {
+        return string.Equals(command.State, "Enabled", StringComparison.OrdinalIgnoreCase) &&
+            IsVisibleToCli(command.Visibility);
+    }
+
+    private static bool IsVisibleToCli(string? visibility)
+    {
+        return visibility?.Split(',').Any(static value => string.Equals(value.Trim(), KnownCommandVisibility.Api, StringComparison.OrdinalIgnoreCase)) is true;
     }
 
     private static (JsonNode? Arguments, string? ErrorMessage) CreateCommandArguments(ResourceSnapshotCommand? command, string[] capturedArguments)
@@ -452,7 +493,13 @@ internal sealed class ResourceCommand : BaseCommand
             var request = ResourceCommandHelpParser.Parse(parseResult, s_resourceArgument, s_commandArgument, s_appHostOption);
             if (request is null)
             {
-                return _defaultHelpAction.Invoke(parseResult);
+                var exitCode = _defaultHelpAction.Invoke(parseResult);
+                if (TryGetResourceOnlyHelp(parseResult, out var resourceName))
+                {
+                    await WriteAvailableCommandsAsync(parseResult, resourceName, cancellationToken).ConfigureAwait(false);
+                }
+
+                return exitCode;
             }
 
             var result = await command._connectionResolver.ResolveConnectionAsync(
@@ -467,7 +514,8 @@ internal sealed class ResourceCommand : BaseCommand
                 return _defaultHelpAction.Invoke(parseResult);
             }
 
-            var resourceCommand = await GetCommandMetadataAsync(result.Connection!, request.ResourceName, request.CommandName, includeHidden: false, cancellationToken).ConfigureAwait(false);
+            var includeHidden = parseResult.GetValue(s_includeHiddenOption);
+            var resourceCommand = await GetCommandMetadataAsync(result.Connection!, request.ResourceName, request.CommandName, includeHidden, cancellationToken).ConfigureAwait(false);
             if (resourceCommand is null)
             {
                 return _defaultHelpAction.Invoke(parseResult);
@@ -475,6 +523,83 @@ internal sealed class ResourceCommand : BaseCommand
 
             WriteResourceCommandHelp(parseResult.InvocationConfiguration.Output, parseResult.CommandResult, request.ResourceName, resourceCommand);
             return ExitCodeConstants.Success;
+        }
+
+        private async Task WriteAvailableCommandsAsync(ParseResult parseResult, string resourceName, CancellationToken cancellationToken)
+        {
+            var connection = await ResolveConnectionForAvailableCommandsAsync(parseResult, cancellationToken).ConfigureAwait(false);
+            if (connection is null)
+            {
+                return;
+            }
+
+            var includeHidden = parseResult.GetValue(s_includeHiddenOption);
+            var commands = await GetAvailableCommandMetadataAsync(connection, resourceName, includeHidden, cancellationToken).ConfigureAwait(false);
+            if (commands.Length == 0)
+            {
+                return;
+            }
+
+            GroupedHelpWriter.WriteTwoColumnSection(
+                parseResult.InvocationConfiguration.Output,
+                ResourceCommandStrings.AvailableResourceCommands,
+                commands,
+                maxWidth: 120,
+                trailingBlankLine: false);
+        }
+
+        private async Task<IAppHostAuxiliaryBackchannel?> ResolveConnectionForAvailableCommandsAsync(ParseResult parseResult, CancellationToken cancellationToken)
+        {
+            var appHostProjectFile = parseResult.GetValue(s_appHostOption);
+            if (appHostProjectFile is not null)
+            {
+                var result = await command._connectionResolver.ResolveConnectionAsync(
+                    appHostProjectFile,
+                    SharedCommandStrings.ScanningForRunningAppHosts,
+                    string.Format(CultureInfo.CurrentCulture, SharedCommandStrings.SelectAppHost, ResourceCommandStrings.SelectAppHostAction),
+                    SharedCommandStrings.AppHostNotRunning,
+                    cancellationToken).ConfigureAwait(false);
+
+                return result.Connection;
+            }
+
+            var inScopeConnections = await command._interactionService.ShowStatusAsync(
+                SharedCommandStrings.ScanningForRunningAppHosts,
+                async () =>
+                {
+                    await command._backchannelMonitor.ScanAsync(cancellationToken).ConfigureAwait(false);
+                    return command._backchannelMonitor.Connections.Where(static connection => connection.IsInScope).ToList();
+                });
+
+            return inScopeConnections.Count == 1 ? inScopeConnections[0] : null;
+        }
+
+        private static bool TryGetResourceOnlyHelp(ParseResult parseResult, [NotNullWhen(true)] out string? resourceName)
+        {
+            // Resource-only help is `aspire resource <resource> --help`. Because the command argument has a default,
+            // System.CommandLine can bind the next option token (or an option value like --apphost's path) as the
+            // command. Treat those as "no command" so resource-scoped help can still show the resource's commands.
+            var resourceArgumentResult = parseResult.GetResult(s_resourceArgument);
+            resourceName = resourceArgumentResult?.Tokens.Count > 0 ? resourceArgumentResult.Tokens[0].Value : null;
+            var commandArgumentResult = parseResult.GetResult(s_commandArgument);
+            var commandName = commandArgumentResult?.Tokens.Count > 0 ? commandArgumentResult.Tokens[0].Value : null;
+            var appHostOptionValue = GetOptionTokenValue(parseResult, s_appHostOption.InnerOption) ?? GetOptionTokenValue(parseResult, s_appHostOption.LegacyOption);
+
+            var hasResourceName = !string.IsNullOrEmpty(resourceName) && !IsOptionLikeToken(resourceName);
+
+            // The command slot is considered empty when it has no token, when it captured an option like --help,
+            // or when it captured the value for --apphost/--project instead of an actual resource command name.
+            var hasNoCommandName = string.IsNullOrEmpty(commandName) ||
+                IsOptionLikeToken(commandName) ||
+                string.Equals(commandName, appHostOptionValue, StringComparison.Ordinal);
+
+            return hasResourceName && hasNoCommandName;
+        }
+
+        private static string? GetOptionTokenValue(ParseResult parseResult, Option<FileInfo?> option)
+        {
+            var result = parseResult.GetResult(option);
+            return result?.Tokens.Count > 0 ? result.Tokens[0].Value : null;
         }
 
         private static void WriteResourceCommandHelp(TextWriter writer, CommandResult commandResult, string resourceName, ResourceSnapshotCommand command)

--- a/src/Aspire.Cli/Commands/ResourceCommand.cs
+++ b/src/Aspire.Cli/Commands/ResourceCommand.cs
@@ -26,6 +26,7 @@ internal sealed class ResourceCommand : BaseCommand
 
     private readonly IInteractionService _interactionService;
     private readonly IAuxiliaryBackchannelMonitor _backchannelMonitor;
+    private readonly IProjectLocator _projectLocator;
     private readonly AppHostConnectionResolver _connectionResolver;
     private readonly ILogger<ResourceCommand> _logger;
 
@@ -46,7 +47,7 @@ internal sealed class ResourceCommand : BaseCommand
     private static readonly OptionWithLegacy<FileInfo?> s_appHostOption = new("--apphost", "--project", SharedCommandStrings.AppHostOptionDescription);
     private static readonly Option<bool> s_includeHiddenOption = new("--include-hidden")
     {
-        Description = ResourceCommandStrings.IncludeHiddenOptionDescription
+        Description = SharedCommandStrings.IncludeHiddenOptionDescription
     };
 
     /// <summary>
@@ -73,6 +74,7 @@ internal sealed class ResourceCommand : BaseCommand
     {
         _interactionService = interactionService;
         _backchannelMonitor = backchannelMonitor;
+        _projectLocator = projectLocator;
         _connectionResolver = new AppHostConnectionResolver(backchannelMonitor, interactionService, projectLocator, executionContext, logger);
         _logger = logger;
 
@@ -174,7 +176,7 @@ internal sealed class ResourceCommand : BaseCommand
 
         return resources
             .SelectMany(static resource => resource.Commands)
-            .Where(IsAvailableToCli)
+            .Where(ResourceSnapshotMapper.IsCommandAvailableToApi)
             .GroupBy(static command => command.Name, StringComparers.CommandName)
             .OrderBy(static group => group.Key, StringComparers.CommandName)
             .Select(static group =>
@@ -186,17 +188,6 @@ internal sealed class ResourceCommand : BaseCommand
                 return (group.Key, description ?? string.Empty);
             })
             .ToArray();
-    }
-
-    private static bool IsAvailableToCli(ResourceSnapshotCommand command)
-    {
-        return string.Equals(command.State, "Enabled", StringComparison.OrdinalIgnoreCase) &&
-            IsVisibleToCli(command.Visibility);
-    }
-
-    private static bool IsVisibleToCli(string? visibility)
-    {
-        return visibility?.Split(',').Any(static value => string.Equals(value.Trim(), KnownCommandVisibility.Api, StringComparison.OrdinalIgnoreCase)) is true;
     }
 
     private static (JsonNode? Arguments, string? ErrorMessage) CreateCommandArguments(ResourceSnapshotCommand? command, string[] capturedArguments)
@@ -496,7 +487,14 @@ internal sealed class ResourceCommand : BaseCommand
                 var exitCode = _defaultHelpAction.Invoke(parseResult);
                 if (TryGetResourceOnlyHelp(parseResult, out var resourceName))
                 {
-                    await WriteAvailableCommandsAsync(parseResult, resourceName, cancellationToken).ConfigureAwait(false);
+                    try
+                    {
+                        await WriteAvailableCommandsAsync(parseResult, resourceName, cancellationToken).ConfigureAwait(false);
+                    }
+                    catch (Exception ex) when (ex is not OperationCanceledException)
+                    {
+                        command._logger.LogDebug(ex, "Failed to augment resource help with available resource commands.");
+                    }
                 }
 
                 return exitCode;
@@ -553,14 +551,7 @@ internal sealed class ResourceCommand : BaseCommand
             var appHostProjectFile = parseResult.GetValue(s_appHostOption);
             if (appHostProjectFile is not null)
             {
-                var result = await command._connectionResolver.ResolveConnectionAsync(
-                    appHostProjectFile,
-                    SharedCommandStrings.ScanningForRunningAppHosts,
-                    string.Format(CultureInfo.CurrentCulture, SharedCommandStrings.SelectAppHost, ResourceCommandStrings.SelectAppHostAction),
-                    SharedCommandStrings.AppHostNotRunning,
-                    cancellationToken).ConfigureAwait(false);
-
-                return result.Connection;
+                return await ResolveExplicitConnectionForAvailableCommandsAsync(appHostProjectFile, cancellationToken).ConfigureAwait(false);
             }
 
             var inScopeConnections = await command._interactionService.ShowStatusAsync(
@@ -572,6 +563,50 @@ internal sealed class ResourceCommand : BaseCommand
                 });
 
             return inScopeConnections.Count == 1 ? inScopeConnections[0] : null;
+        }
+
+        private async Task<IAppHostAuxiliaryBackchannel?> ResolveExplicitConnectionForAvailableCommandsAsync(FileInfo appHostProjectFile, CancellationToken cancellationToken)
+        {
+            FileInfo? selectedAppHostProjectFile = appHostProjectFile;
+
+            if (Directory.Exists(appHostProjectFile.FullName))
+            {
+                var searchResult = await command._projectLocator.UseOrFindAppHostProjectFileAsync(
+                    appHostProjectFile,
+                    MultipleAppHostProjectsFoundBehavior.Throw,
+                    createSettingsFile: false,
+                    cancellationToken).ConfigureAwait(false);
+
+                selectedAppHostProjectFile = searchResult.SelectedProjectFile;
+            }
+            else if (!appHostProjectFile.Exists)
+            {
+                return null;
+            }
+
+            if (selectedAppHostProjectFile is null)
+            {
+                return null;
+            }
+
+            var targetPath = Path.GetFullPath(selectedAppHostProjectFile.FullName);
+            var matchingConnections = await command._interactionService.ShowStatusAsync(
+                SharedCommandStrings.ScanningForRunningAppHosts,
+                async () =>
+                {
+                    await command._backchannelMonitor.ScanAsync(cancellationToken).ConfigureAwait(false);
+                    return command._backchannelMonitor.Connections
+                        .Where(connection => IsMatchingAppHostPath(connection.AppHostInfo?.AppHostPath, targetPath))
+                        .ToList();
+                });
+
+            return matchingConnections.Count == 1 ? matchingConnections[0] : null;
+        }
+
+        private static bool IsMatchingAppHostPath(string? appHostPath, string targetPath)
+        {
+            return !string.IsNullOrEmpty(appHostPath) &&
+                string.Equals(Path.GetFullPath(appHostPath), targetPath, StringComparison.OrdinalIgnoreCase);
         }
 
         private static bool TryGetResourceOnlyHelp(ParseResult parseResult, [NotNullWhen(true)] out string? resourceName)

--- a/src/Aspire.Cli/Commands/ResourceCommandHelpParser.cs
+++ b/src/Aspire.Cli/Commands/ResourceCommandHelpParser.cs
@@ -25,10 +25,20 @@ internal static class ResourceCommandHelpParser
         //   aspire resource web --help
         var resourceName = GetArgumentValue(parseResult, resourceArgument);
         var commandName = GetArgumentValue(parseResult, commandArgument);
+        var appHostOptionValue = GetOptionTokenValue(parseResult, appHostOption.InnerOption) ?? GetOptionTokenValue(parseResult, appHostOption.LegacyOption);
+
+        // Only intercept help when the resource and command tokens are real positional arguments. Resource-only help,
+        // option tokens, and option values that System.CommandLine bound into the command argument should fall back to
+        // the default/resource-scoped help paths instead of being treated as command-specific help.
+        // Examples:
+        //   aspire resource web --help
+        //   aspire resource web --apphost ./AppHost.csproj --help
+        //   aspire resource web -- --message hi --help
         if (string.IsNullOrEmpty(resourceName) ||
             IsOptionLikeToken(resourceName) ||
             string.IsNullOrEmpty(commandName) ||
-            IsOptionLikeToken(commandName))
+            IsOptionLikeToken(commandName) ||
+            string.Equals(commandName, appHostOptionValue, StringComparison.Ordinal))
         {
             return null;
         }
@@ -36,7 +46,7 @@ internal static class ResourceCommandHelpParser
         return new ResourceCommandHelpRequest(
             resourceName,
             commandName,
-            GetOptionValue(parseResult, appHostOption.InnerOption) ?? GetOptionValue(parseResult, appHostOption.LegacyOption));
+            appHostOptionValue is null ? null : new FileInfo(appHostOptionValue));
     }
 
     private static string? GetArgumentValue(ParseResult parseResult, Argument<string> argument)
@@ -45,10 +55,10 @@ internal static class ResourceCommandHelpParser
         return result?.Tokens.Count > 0 ? result.Tokens[0].Value : null;
     }
 
-    private static FileInfo? GetOptionValue(ParseResult parseResult, Option<FileInfo?> option)
+    private static string? GetOptionTokenValue(ParseResult parseResult, Option<FileInfo?> option)
     {
         var result = parseResult.GetResult(option);
-        return result?.Tokens.Count > 0 ? new FileInfo(result.Tokens[0].Value) : null;
+        return result?.Tokens.Count > 0 ? result.Tokens[0].Value : null;
     }
 
     private static bool IsOptionLikeToken(string value)

--- a/src/Aspire.Cli/Resources/ResourceCommandStrings.Designer.cs
+++ b/src/Aspire.Cli/Resources/ResourceCommandStrings.Designer.cs
@@ -75,6 +75,18 @@ namespace Aspire.Cli.Resources {
             }
         }
 
+        internal static string AvailableResourceCommands {
+            get {
+                return ResourceManager.GetString("AvailableResourceCommands", resourceCulture);
+            }
+        }
+
+        internal static string IncludeHiddenOptionDescription {
+            get {
+                return ResourceManager.GetString("IncludeHiddenOptionDescription", resourceCulture);
+            }
+        }
+
         internal static string CommandSpecificHelpAllowedValues {
             get {
                 return ResourceManager.GetString("CommandSpecificHelpAllowedValues", resourceCulture);

--- a/src/Aspire.Cli/Resources/ResourceCommandStrings.Designer.cs
+++ b/src/Aspire.Cli/Resources/ResourceCommandStrings.Designer.cs
@@ -81,12 +81,6 @@ namespace Aspire.Cli.Resources {
             }
         }
 
-        internal static string IncludeHiddenOptionDescription {
-            get {
-                return ResourceManager.GetString("IncludeHiddenOptionDescription", resourceCulture);
-            }
-        }
-
         internal static string CommandSpecificHelpAllowedValues {
             get {
                 return ResourceManager.GetString("CommandSpecificHelpAllowedValues", resourceCulture);

--- a/src/Aspire.Cli/Resources/ResourceCommandStrings.resx
+++ b/src/Aspire.Cli/Resources/ResourceCommandStrings.resx
@@ -73,6 +73,12 @@
   <data name="ArgumentRequired" xml:space="preserve">
     <value>The '{0}' argument is required.</value>
   </data>
+  <data name="AvailableResourceCommands" xml:space="preserve">
+    <value>Available resource commands:</value>
+  </data>
+  <data name="IncludeHiddenOptionDescription" xml:space="preserve">
+    <value>Include hidden resources in the output</value>
+  </data>
   <data name="CommandSpecificHelpUsageSyntax" xml:space="preserve">
     <value>aspire resource {0} {1} [options] [[--] &lt;command-options&gt;...]</value>
   </data>

--- a/src/Aspire.Cli/Resources/ResourceCommandStrings.resx
+++ b/src/Aspire.Cli/Resources/ResourceCommandStrings.resx
@@ -76,9 +76,6 @@
   <data name="AvailableResourceCommands" xml:space="preserve">
     <value>Available resource commands:</value>
   </data>
-  <data name="IncludeHiddenOptionDescription" xml:space="preserve">
-    <value>Include hidden resources in the output</value>
-  </data>
   <data name="CommandSpecificHelpUsageSyntax" xml:space="preserve">
     <value>aspire resource {0} {1} [options] [[--] &lt;command-options&gt;...]</value>
   </data>

--- a/src/Aspire.Cli/Resources/SharedCommandStrings.Designer.cs
+++ b/src/Aspire.Cli/Resources/SharedCommandStrings.Designer.cs
@@ -81,6 +81,12 @@ namespace Aspire.Cli.Resources {
             }
         }
 
+        internal static string IncludeHiddenOptionDescription {
+            get {
+                return ResourceManager.GetString("IncludeHiddenOptionDescription", resourceCulture);
+            }
+        }
+
         internal static string FormatOptionDescription {
             get {
                 return ResourceManager.GetString("FormatOptionDescription", resourceCulture);

--- a/src/Aspire.Cli/Resources/SharedCommandStrings.resx
+++ b/src/Aspire.Cli/Resources/SharedCommandStrings.resx
@@ -136,6 +136,9 @@
   <data name="AppHostOptionDescription" xml:space="preserve">
     <value>The path to the Aspire AppHost project file or a directory to search</value>
   </data>
+  <data name="IncludeHiddenOptionDescription" xml:space="preserve">
+    <value>Include hidden resources in the output</value>
+  </data>
   <data name="FormatOptionDescription" xml:space="preserve">
     <value>Output format for detached AppHost results</value>
   </data>

--- a/src/Aspire.Cli/Resources/xlf/ResourceCommandStrings.cs.xlf
+++ b/src/Aspire.Cli/Resources/xlf/ResourceCommandStrings.cs.xlf
@@ -7,6 +7,11 @@
         <target state="new">The '{0}' argument is required.</target>
         <note />
       </trans-unit>
+      <trans-unit id="AvailableResourceCommands">
+        <source>Available resource commands:</source>
+        <target state="new">Available resource commands:</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CommandDescription">
         <source>Execute a command on a resource (e.g. start, stop, restart)</source>
         <target state="needs-review-translation">Spusťte příkaz pro prostředek.</target>
@@ -55,6 +60,11 @@
       <trans-unit id="CommandSpecificHelpValuePlaceholder">
         <source>value</source>
         <target state="new">value</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="IncludeHiddenOptionDescription">
+        <source>Include hidden resources in the output</source>
+        <target state="new">Include hidden resources in the output</target>
         <note />
       </trans-unit>
       <trans-unit id="SelectAppHostAction">

--- a/src/Aspire.Cli/Resources/xlf/ResourceCommandStrings.cs.xlf
+++ b/src/Aspire.Cli/Resources/xlf/ResourceCommandStrings.cs.xlf
@@ -62,11 +62,6 @@
         <target state="new">value</target>
         <note />
       </trans-unit>
-      <trans-unit id="IncludeHiddenOptionDescription">
-        <source>Include hidden resources in the output</source>
-        <target state="new">Include hidden resources in the output</target>
-        <note />
-      </trans-unit>
       <trans-unit id="SelectAppHostAction">
         <source>connect to</source>
         <target state="translated">připojit k</target>

--- a/src/Aspire.Cli/Resources/xlf/ResourceCommandStrings.de.xlf
+++ b/src/Aspire.Cli/Resources/xlf/ResourceCommandStrings.de.xlf
@@ -7,6 +7,11 @@
         <target state="new">The '{0}' argument is required.</target>
         <note />
       </trans-unit>
+      <trans-unit id="AvailableResourceCommands">
+        <source>Available resource commands:</source>
+        <target state="new">Available resource commands:</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CommandDescription">
         <source>Execute a command on a resource (e.g. start, stop, restart)</source>
         <target state="needs-review-translation">Führen Sie einen Befehl auf einer Ressource aus.</target>
@@ -55,6 +60,11 @@
       <trans-unit id="CommandSpecificHelpValuePlaceholder">
         <source>value</source>
         <target state="new">value</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="IncludeHiddenOptionDescription">
+        <source>Include hidden resources in the output</source>
+        <target state="new">Include hidden resources in the output</target>
         <note />
       </trans-unit>
       <trans-unit id="SelectAppHostAction">

--- a/src/Aspire.Cli/Resources/xlf/ResourceCommandStrings.de.xlf
+++ b/src/Aspire.Cli/Resources/xlf/ResourceCommandStrings.de.xlf
@@ -62,11 +62,6 @@
         <target state="new">value</target>
         <note />
       </trans-unit>
-      <trans-unit id="IncludeHiddenOptionDescription">
-        <source>Include hidden resources in the output</source>
-        <target state="new">Include hidden resources in the output</target>
-        <note />
-      </trans-unit>
       <trans-unit id="SelectAppHostAction">
         <source>connect to</source>
         <target state="translated">stellen Sie eine Verbindung her mit</target>

--- a/src/Aspire.Cli/Resources/xlf/ResourceCommandStrings.es.xlf
+++ b/src/Aspire.Cli/Resources/xlf/ResourceCommandStrings.es.xlf
@@ -7,6 +7,11 @@
         <target state="new">The '{0}' argument is required.</target>
         <note />
       </trans-unit>
+      <trans-unit id="AvailableResourceCommands">
+        <source>Available resource commands:</source>
+        <target state="new">Available resource commands:</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CommandDescription">
         <source>Execute a command on a resource (e.g. start, stop, restart)</source>
         <target state="needs-review-translation">Ejecute un comando en un recurso.</target>
@@ -55,6 +60,11 @@
       <trans-unit id="CommandSpecificHelpValuePlaceholder">
         <source>value</source>
         <target state="new">value</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="IncludeHiddenOptionDescription">
+        <source>Include hidden resources in the output</source>
+        <target state="new">Include hidden resources in the output</target>
         <note />
       </trans-unit>
       <trans-unit id="SelectAppHostAction">

--- a/src/Aspire.Cli/Resources/xlf/ResourceCommandStrings.es.xlf
+++ b/src/Aspire.Cli/Resources/xlf/ResourceCommandStrings.es.xlf
@@ -62,11 +62,6 @@
         <target state="new">value</target>
         <note />
       </trans-unit>
-      <trans-unit id="IncludeHiddenOptionDescription">
-        <source>Include hidden resources in the output</source>
-        <target state="new">Include hidden resources in the output</target>
-        <note />
-      </trans-unit>
       <trans-unit id="SelectAppHostAction">
         <source>connect to</source>
         <target state="translated">conectarse a</target>

--- a/src/Aspire.Cli/Resources/xlf/ResourceCommandStrings.fr.xlf
+++ b/src/Aspire.Cli/Resources/xlf/ResourceCommandStrings.fr.xlf
@@ -7,6 +7,11 @@
         <target state="new">The '{0}' argument is required.</target>
         <note />
       </trans-unit>
+      <trans-unit id="AvailableResourceCommands">
+        <source>Available resource commands:</source>
+        <target state="new">Available resource commands:</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CommandDescription">
         <source>Execute a command on a resource (e.g. start, stop, restart)</source>
         <target state="needs-review-translation">Exécuter une commande sur une ressource.</target>
@@ -55,6 +60,11 @@
       <trans-unit id="CommandSpecificHelpValuePlaceholder">
         <source>value</source>
         <target state="new">value</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="IncludeHiddenOptionDescription">
+        <source>Include hidden resources in the output</source>
+        <target state="new">Include hidden resources in the output</target>
         <note />
       </trans-unit>
       <trans-unit id="SelectAppHostAction">

--- a/src/Aspire.Cli/Resources/xlf/ResourceCommandStrings.fr.xlf
+++ b/src/Aspire.Cli/Resources/xlf/ResourceCommandStrings.fr.xlf
@@ -62,11 +62,6 @@
         <target state="new">value</target>
         <note />
       </trans-unit>
-      <trans-unit id="IncludeHiddenOptionDescription">
-        <source>Include hidden resources in the output</source>
-        <target state="new">Include hidden resources in the output</target>
-        <note />
-      </trans-unit>
       <trans-unit id="SelectAppHostAction">
         <source>connect to</source>
         <target state="translated">se connecter à</target>

--- a/src/Aspire.Cli/Resources/xlf/ResourceCommandStrings.it.xlf
+++ b/src/Aspire.Cli/Resources/xlf/ResourceCommandStrings.it.xlf
@@ -7,6 +7,11 @@
         <target state="new">The '{0}' argument is required.</target>
         <note />
       </trans-unit>
+      <trans-unit id="AvailableResourceCommands">
+        <source>Available resource commands:</source>
+        <target state="new">Available resource commands:</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CommandDescription">
         <source>Execute a command on a resource (e.g. start, stop, restart)</source>
         <target state="needs-review-translation">Eseguire un comando su una risorsa.</target>
@@ -55,6 +60,11 @@
       <trans-unit id="CommandSpecificHelpValuePlaceholder">
         <source>value</source>
         <target state="new">value</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="IncludeHiddenOptionDescription">
+        <source>Include hidden resources in the output</source>
+        <target state="new">Include hidden resources in the output</target>
         <note />
       </trans-unit>
       <trans-unit id="SelectAppHostAction">

--- a/src/Aspire.Cli/Resources/xlf/ResourceCommandStrings.it.xlf
+++ b/src/Aspire.Cli/Resources/xlf/ResourceCommandStrings.it.xlf
@@ -62,11 +62,6 @@
         <target state="new">value</target>
         <note />
       </trans-unit>
-      <trans-unit id="IncludeHiddenOptionDescription">
-        <source>Include hidden resources in the output</source>
-        <target state="new">Include hidden resources in the output</target>
-        <note />
-      </trans-unit>
       <trans-unit id="SelectAppHostAction">
         <source>connect to</source>
         <target state="translated">connettersi a</target>

--- a/src/Aspire.Cli/Resources/xlf/ResourceCommandStrings.ja.xlf
+++ b/src/Aspire.Cli/Resources/xlf/ResourceCommandStrings.ja.xlf
@@ -7,6 +7,11 @@
         <target state="new">The '{0}' argument is required.</target>
         <note />
       </trans-unit>
+      <trans-unit id="AvailableResourceCommands">
+        <source>Available resource commands:</source>
+        <target state="new">Available resource commands:</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CommandDescription">
         <source>Execute a command on a resource (e.g. start, stop, restart)</source>
         <target state="needs-review-translation">リソースでコマンドを実行します。</target>
@@ -55,6 +60,11 @@
       <trans-unit id="CommandSpecificHelpValuePlaceholder">
         <source>value</source>
         <target state="new">value</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="IncludeHiddenOptionDescription">
+        <source>Include hidden resources in the output</source>
+        <target state="new">Include hidden resources in the output</target>
         <note />
       </trans-unit>
       <trans-unit id="SelectAppHostAction">

--- a/src/Aspire.Cli/Resources/xlf/ResourceCommandStrings.ja.xlf
+++ b/src/Aspire.Cli/Resources/xlf/ResourceCommandStrings.ja.xlf
@@ -62,11 +62,6 @@
         <target state="new">value</target>
         <note />
       </trans-unit>
-      <trans-unit id="IncludeHiddenOptionDescription">
-        <source>Include hidden resources in the output</source>
-        <target state="new">Include hidden resources in the output</target>
-        <note />
-      </trans-unit>
       <trans-unit id="SelectAppHostAction">
         <source>connect to</source>
         <target state="translated">接続先</target>

--- a/src/Aspire.Cli/Resources/xlf/ResourceCommandStrings.ko.xlf
+++ b/src/Aspire.Cli/Resources/xlf/ResourceCommandStrings.ko.xlf
@@ -7,6 +7,11 @@
         <target state="new">The '{0}' argument is required.</target>
         <note />
       </trans-unit>
+      <trans-unit id="AvailableResourceCommands">
+        <source>Available resource commands:</source>
+        <target state="new">Available resource commands:</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CommandDescription">
         <source>Execute a command on a resource (e.g. start, stop, restart)</source>
         <target state="needs-review-translation">리소스에서 명령을 실행합니다.</target>
@@ -55,6 +60,11 @@
       <trans-unit id="CommandSpecificHelpValuePlaceholder">
         <source>value</source>
         <target state="new">value</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="IncludeHiddenOptionDescription">
+        <source>Include hidden resources in the output</source>
+        <target state="new">Include hidden resources in the output</target>
         <note />
       </trans-unit>
       <trans-unit id="SelectAppHostAction">

--- a/src/Aspire.Cli/Resources/xlf/ResourceCommandStrings.ko.xlf
+++ b/src/Aspire.Cli/Resources/xlf/ResourceCommandStrings.ko.xlf
@@ -62,11 +62,6 @@
         <target state="new">value</target>
         <note />
       </trans-unit>
-      <trans-unit id="IncludeHiddenOptionDescription">
-        <source>Include hidden resources in the output</source>
-        <target state="new">Include hidden resources in the output</target>
-        <note />
-      </trans-unit>
       <trans-unit id="SelectAppHostAction">
         <source>connect to</source>
         <target state="translated">연결 대상</target>

--- a/src/Aspire.Cli/Resources/xlf/ResourceCommandStrings.pl.xlf
+++ b/src/Aspire.Cli/Resources/xlf/ResourceCommandStrings.pl.xlf
@@ -7,6 +7,11 @@
         <target state="new">The '{0}' argument is required.</target>
         <note />
       </trans-unit>
+      <trans-unit id="AvailableResourceCommands">
+        <source>Available resource commands:</source>
+        <target state="new">Available resource commands:</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CommandDescription">
         <source>Execute a command on a resource (e.g. start, stop, restart)</source>
         <target state="needs-review-translation">Wykonaj polecenie dla zasobu.</target>
@@ -55,6 +60,11 @@
       <trans-unit id="CommandSpecificHelpValuePlaceholder">
         <source>value</source>
         <target state="new">value</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="IncludeHiddenOptionDescription">
+        <source>Include hidden resources in the output</source>
+        <target state="new">Include hidden resources in the output</target>
         <note />
       </trans-unit>
       <trans-unit id="SelectAppHostAction">

--- a/src/Aspire.Cli/Resources/xlf/ResourceCommandStrings.pl.xlf
+++ b/src/Aspire.Cli/Resources/xlf/ResourceCommandStrings.pl.xlf
@@ -62,11 +62,6 @@
         <target state="new">value</target>
         <note />
       </trans-unit>
-      <trans-unit id="IncludeHiddenOptionDescription">
-        <source>Include hidden resources in the output</source>
-        <target state="new">Include hidden resources in the output</target>
-        <note />
-      </trans-unit>
       <trans-unit id="SelectAppHostAction">
         <source>connect to</source>
         <target state="translated">połącz z</target>

--- a/src/Aspire.Cli/Resources/xlf/ResourceCommandStrings.pt-BR.xlf
+++ b/src/Aspire.Cli/Resources/xlf/ResourceCommandStrings.pt-BR.xlf
@@ -7,6 +7,11 @@
         <target state="new">The '{0}' argument is required.</target>
         <note />
       </trans-unit>
+      <trans-unit id="AvailableResourceCommands">
+        <source>Available resource commands:</source>
+        <target state="new">Available resource commands:</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CommandDescription">
         <source>Execute a command on a resource (e.g. start, stop, restart)</source>
         <target state="needs-review-translation">Execute um comando em um recurso.</target>
@@ -55,6 +60,11 @@
       <trans-unit id="CommandSpecificHelpValuePlaceholder">
         <source>value</source>
         <target state="new">value</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="IncludeHiddenOptionDescription">
+        <source>Include hidden resources in the output</source>
+        <target state="new">Include hidden resources in the output</target>
         <note />
       </trans-unit>
       <trans-unit id="SelectAppHostAction">

--- a/src/Aspire.Cli/Resources/xlf/ResourceCommandStrings.pt-BR.xlf
+++ b/src/Aspire.Cli/Resources/xlf/ResourceCommandStrings.pt-BR.xlf
@@ -62,11 +62,6 @@
         <target state="new">value</target>
         <note />
       </trans-unit>
-      <trans-unit id="IncludeHiddenOptionDescription">
-        <source>Include hidden resources in the output</source>
-        <target state="new">Include hidden resources in the output</target>
-        <note />
-      </trans-unit>
       <trans-unit id="SelectAppHostAction">
         <source>connect to</source>
         <target state="translated">conectar-se a</target>

--- a/src/Aspire.Cli/Resources/xlf/ResourceCommandStrings.ru.xlf
+++ b/src/Aspire.Cli/Resources/xlf/ResourceCommandStrings.ru.xlf
@@ -7,6 +7,11 @@
         <target state="new">The '{0}' argument is required.</target>
         <note />
       </trans-unit>
+      <trans-unit id="AvailableResourceCommands">
+        <source>Available resource commands:</source>
+        <target state="new">Available resource commands:</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CommandDescription">
         <source>Execute a command on a resource (e.g. start, stop, restart)</source>
         <target state="needs-review-translation">Выполнить команду на ресурсе.</target>
@@ -55,6 +60,11 @@
       <trans-unit id="CommandSpecificHelpValuePlaceholder">
         <source>value</source>
         <target state="new">value</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="IncludeHiddenOptionDescription">
+        <source>Include hidden resources in the output</source>
+        <target state="new">Include hidden resources in the output</target>
         <note />
       </trans-unit>
       <trans-unit id="SelectAppHostAction">

--- a/src/Aspire.Cli/Resources/xlf/ResourceCommandStrings.ru.xlf
+++ b/src/Aspire.Cli/Resources/xlf/ResourceCommandStrings.ru.xlf
@@ -62,11 +62,6 @@
         <target state="new">value</target>
         <note />
       </trans-unit>
-      <trans-unit id="IncludeHiddenOptionDescription">
-        <source>Include hidden resources in the output</source>
-        <target state="new">Include hidden resources in the output</target>
-        <note />
-      </trans-unit>
       <trans-unit id="SelectAppHostAction">
         <source>connect to</source>
         <target state="translated">подключить к</target>

--- a/src/Aspire.Cli/Resources/xlf/ResourceCommandStrings.tr.xlf
+++ b/src/Aspire.Cli/Resources/xlf/ResourceCommandStrings.tr.xlf
@@ -7,6 +7,11 @@
         <target state="new">The '{0}' argument is required.</target>
         <note />
       </trans-unit>
+      <trans-unit id="AvailableResourceCommands">
+        <source>Available resource commands:</source>
+        <target state="new">Available resource commands:</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CommandDescription">
         <source>Execute a command on a resource (e.g. start, stop, restart)</source>
         <target state="needs-review-translation">Bir kaynak üzerinde bir komut çalıştırın.</target>
@@ -55,6 +60,11 @@
       <trans-unit id="CommandSpecificHelpValuePlaceholder">
         <source>value</source>
         <target state="new">value</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="IncludeHiddenOptionDescription">
+        <source>Include hidden resources in the output</source>
+        <target state="new">Include hidden resources in the output</target>
         <note />
       </trans-unit>
       <trans-unit id="SelectAppHostAction">

--- a/src/Aspire.Cli/Resources/xlf/ResourceCommandStrings.tr.xlf
+++ b/src/Aspire.Cli/Resources/xlf/ResourceCommandStrings.tr.xlf
@@ -62,11 +62,6 @@
         <target state="new">value</target>
         <note />
       </trans-unit>
-      <trans-unit id="IncludeHiddenOptionDescription">
-        <source>Include hidden resources in the output</source>
-        <target state="new">Include hidden resources in the output</target>
-        <note />
-      </trans-unit>
       <trans-unit id="SelectAppHostAction">
         <source>connect to</source>
         <target state="translated">şuna bağlanın:</target>

--- a/src/Aspire.Cli/Resources/xlf/ResourceCommandStrings.zh-Hans.xlf
+++ b/src/Aspire.Cli/Resources/xlf/ResourceCommandStrings.zh-Hans.xlf
@@ -7,6 +7,11 @@
         <target state="new">The '{0}' argument is required.</target>
         <note />
       </trans-unit>
+      <trans-unit id="AvailableResourceCommands">
+        <source>Available resource commands:</source>
+        <target state="new">Available resource commands:</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CommandDescription">
         <source>Execute a command on a resource (e.g. start, stop, restart)</source>
         <target state="needs-review-translation">在资源上执行命令。</target>
@@ -55,6 +60,11 @@
       <trans-unit id="CommandSpecificHelpValuePlaceholder">
         <source>value</source>
         <target state="new">value</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="IncludeHiddenOptionDescription">
+        <source>Include hidden resources in the output</source>
+        <target state="new">Include hidden resources in the output</target>
         <note />
       </trans-unit>
       <trans-unit id="SelectAppHostAction">

--- a/src/Aspire.Cli/Resources/xlf/ResourceCommandStrings.zh-Hans.xlf
+++ b/src/Aspire.Cli/Resources/xlf/ResourceCommandStrings.zh-Hans.xlf
@@ -62,11 +62,6 @@
         <target state="new">value</target>
         <note />
       </trans-unit>
-      <trans-unit id="IncludeHiddenOptionDescription">
-        <source>Include hidden resources in the output</source>
-        <target state="new">Include hidden resources in the output</target>
-        <note />
-      </trans-unit>
       <trans-unit id="SelectAppHostAction">
         <source>connect to</source>
         <target state="translated">连接到</target>

--- a/src/Aspire.Cli/Resources/xlf/ResourceCommandStrings.zh-Hant.xlf
+++ b/src/Aspire.Cli/Resources/xlf/ResourceCommandStrings.zh-Hant.xlf
@@ -7,6 +7,11 @@
         <target state="new">The '{0}' argument is required.</target>
         <note />
       </trans-unit>
+      <trans-unit id="AvailableResourceCommands">
+        <source>Available resource commands:</source>
+        <target state="new">Available resource commands:</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CommandDescription">
         <source>Execute a command on a resource (e.g. start, stop, restart)</source>
         <target state="needs-review-translation">在資源上執行命令。</target>
@@ -55,6 +60,11 @@
       <trans-unit id="CommandSpecificHelpValuePlaceholder">
         <source>value</source>
         <target state="new">value</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="IncludeHiddenOptionDescription">
+        <source>Include hidden resources in the output</source>
+        <target state="new">Include hidden resources in the output</target>
         <note />
       </trans-unit>
       <trans-unit id="SelectAppHostAction">

--- a/src/Aspire.Cli/Resources/xlf/ResourceCommandStrings.zh-Hant.xlf
+++ b/src/Aspire.Cli/Resources/xlf/ResourceCommandStrings.zh-Hant.xlf
@@ -62,11 +62,6 @@
         <target state="new">value</target>
         <note />
       </trans-unit>
-      <trans-unit id="IncludeHiddenOptionDescription">
-        <source>Include hidden resources in the output</source>
-        <target state="new">Include hidden resources in the output</target>
-        <note />
-      </trans-unit>
       <trans-unit id="SelectAppHostAction">
         <source>connect to</source>
         <target state="translated">連線至</target>

--- a/src/Aspire.Cli/Resources/xlf/SharedCommandStrings.cs.xlf
+++ b/src/Aspire.Cli/Resources/xlf/SharedCommandStrings.cs.xlf
@@ -42,6 +42,11 @@
         <target state="new">Status</target>
         <note />
       </trans-unit>
+      <trans-unit id="IncludeHiddenOptionDescription">
+        <source>Include hidden resources in the output</source>
+        <target state="new">Include hidden resources in the output</target>
+        <note />
+      </trans-unit>
       <trans-unit id="IsolatedOptionDescription">
         <source>Run in isolated mode with randomized ports and isolated user secrets, allowing multiple instances to run simultaneously</source>
         <target state="new">Run in isolated mode with randomized ports and isolated user secrets, allowing multiple instances to run simultaneously</target>

--- a/src/Aspire.Cli/Resources/xlf/SharedCommandStrings.de.xlf
+++ b/src/Aspire.Cli/Resources/xlf/SharedCommandStrings.de.xlf
@@ -42,6 +42,11 @@
         <target state="new">Status</target>
         <note />
       </trans-unit>
+      <trans-unit id="IncludeHiddenOptionDescription">
+        <source>Include hidden resources in the output</source>
+        <target state="new">Include hidden resources in the output</target>
+        <note />
+      </trans-unit>
       <trans-unit id="IsolatedOptionDescription">
         <source>Run in isolated mode with randomized ports and isolated user secrets, allowing multiple instances to run simultaneously</source>
         <target state="new">Run in isolated mode with randomized ports and isolated user secrets, allowing multiple instances to run simultaneously</target>

--- a/src/Aspire.Cli/Resources/xlf/SharedCommandStrings.es.xlf
+++ b/src/Aspire.Cli/Resources/xlf/SharedCommandStrings.es.xlf
@@ -42,6 +42,11 @@
         <target state="new">Status</target>
         <note />
       </trans-unit>
+      <trans-unit id="IncludeHiddenOptionDescription">
+        <source>Include hidden resources in the output</source>
+        <target state="new">Include hidden resources in the output</target>
+        <note />
+      </trans-unit>
       <trans-unit id="IsolatedOptionDescription">
         <source>Run in isolated mode with randomized ports and isolated user secrets, allowing multiple instances to run simultaneously</source>
         <target state="new">Run in isolated mode with randomized ports and isolated user secrets, allowing multiple instances to run simultaneously</target>

--- a/src/Aspire.Cli/Resources/xlf/SharedCommandStrings.fr.xlf
+++ b/src/Aspire.Cli/Resources/xlf/SharedCommandStrings.fr.xlf
@@ -42,6 +42,11 @@
         <target state="new">Status</target>
         <note />
       </trans-unit>
+      <trans-unit id="IncludeHiddenOptionDescription">
+        <source>Include hidden resources in the output</source>
+        <target state="new">Include hidden resources in the output</target>
+        <note />
+      </trans-unit>
       <trans-unit id="IsolatedOptionDescription">
         <source>Run in isolated mode with randomized ports and isolated user secrets, allowing multiple instances to run simultaneously</source>
         <target state="new">Run in isolated mode with randomized ports and isolated user secrets, allowing multiple instances to run simultaneously</target>

--- a/src/Aspire.Cli/Resources/xlf/SharedCommandStrings.it.xlf
+++ b/src/Aspire.Cli/Resources/xlf/SharedCommandStrings.it.xlf
@@ -42,6 +42,11 @@
         <target state="new">Status</target>
         <note />
       </trans-unit>
+      <trans-unit id="IncludeHiddenOptionDescription">
+        <source>Include hidden resources in the output</source>
+        <target state="new">Include hidden resources in the output</target>
+        <note />
+      </trans-unit>
       <trans-unit id="IsolatedOptionDescription">
         <source>Run in isolated mode with randomized ports and isolated user secrets, allowing multiple instances to run simultaneously</source>
         <target state="new">Run in isolated mode with randomized ports and isolated user secrets, allowing multiple instances to run simultaneously</target>

--- a/src/Aspire.Cli/Resources/xlf/SharedCommandStrings.ja.xlf
+++ b/src/Aspire.Cli/Resources/xlf/SharedCommandStrings.ja.xlf
@@ -42,6 +42,11 @@
         <target state="new">Status</target>
         <note />
       </trans-unit>
+      <trans-unit id="IncludeHiddenOptionDescription">
+        <source>Include hidden resources in the output</source>
+        <target state="new">Include hidden resources in the output</target>
+        <note />
+      </trans-unit>
       <trans-unit id="IsolatedOptionDescription">
         <source>Run in isolated mode with randomized ports and isolated user secrets, allowing multiple instances to run simultaneously</source>
         <target state="new">Run in isolated mode with randomized ports and isolated user secrets, allowing multiple instances to run simultaneously</target>

--- a/src/Aspire.Cli/Resources/xlf/SharedCommandStrings.ko.xlf
+++ b/src/Aspire.Cli/Resources/xlf/SharedCommandStrings.ko.xlf
@@ -42,6 +42,11 @@
         <target state="new">Status</target>
         <note />
       </trans-unit>
+      <trans-unit id="IncludeHiddenOptionDescription">
+        <source>Include hidden resources in the output</source>
+        <target state="new">Include hidden resources in the output</target>
+        <note />
+      </trans-unit>
       <trans-unit id="IsolatedOptionDescription">
         <source>Run in isolated mode with randomized ports and isolated user secrets, allowing multiple instances to run simultaneously</source>
         <target state="new">Run in isolated mode with randomized ports and isolated user secrets, allowing multiple instances to run simultaneously</target>

--- a/src/Aspire.Cli/Resources/xlf/SharedCommandStrings.pl.xlf
+++ b/src/Aspire.Cli/Resources/xlf/SharedCommandStrings.pl.xlf
@@ -42,6 +42,11 @@
         <target state="new">Status</target>
         <note />
       </trans-unit>
+      <trans-unit id="IncludeHiddenOptionDescription">
+        <source>Include hidden resources in the output</source>
+        <target state="new">Include hidden resources in the output</target>
+        <note />
+      </trans-unit>
       <trans-unit id="IsolatedOptionDescription">
         <source>Run in isolated mode with randomized ports and isolated user secrets, allowing multiple instances to run simultaneously</source>
         <target state="new">Run in isolated mode with randomized ports and isolated user secrets, allowing multiple instances to run simultaneously</target>

--- a/src/Aspire.Cli/Resources/xlf/SharedCommandStrings.pt-BR.xlf
+++ b/src/Aspire.Cli/Resources/xlf/SharedCommandStrings.pt-BR.xlf
@@ -42,6 +42,11 @@
         <target state="new">Status</target>
         <note />
       </trans-unit>
+      <trans-unit id="IncludeHiddenOptionDescription">
+        <source>Include hidden resources in the output</source>
+        <target state="new">Include hidden resources in the output</target>
+        <note />
+      </trans-unit>
       <trans-unit id="IsolatedOptionDescription">
         <source>Run in isolated mode with randomized ports and isolated user secrets, allowing multiple instances to run simultaneously</source>
         <target state="new">Run in isolated mode with randomized ports and isolated user secrets, allowing multiple instances to run simultaneously</target>

--- a/src/Aspire.Cli/Resources/xlf/SharedCommandStrings.ru.xlf
+++ b/src/Aspire.Cli/Resources/xlf/SharedCommandStrings.ru.xlf
@@ -42,6 +42,11 @@
         <target state="new">Status</target>
         <note />
       </trans-unit>
+      <trans-unit id="IncludeHiddenOptionDescription">
+        <source>Include hidden resources in the output</source>
+        <target state="new">Include hidden resources in the output</target>
+        <note />
+      </trans-unit>
       <trans-unit id="IsolatedOptionDescription">
         <source>Run in isolated mode with randomized ports and isolated user secrets, allowing multiple instances to run simultaneously</source>
         <target state="new">Run in isolated mode with randomized ports and isolated user secrets, allowing multiple instances to run simultaneously</target>

--- a/src/Aspire.Cli/Resources/xlf/SharedCommandStrings.tr.xlf
+++ b/src/Aspire.Cli/Resources/xlf/SharedCommandStrings.tr.xlf
@@ -42,6 +42,11 @@
         <target state="new">Status</target>
         <note />
       </trans-unit>
+      <trans-unit id="IncludeHiddenOptionDescription">
+        <source>Include hidden resources in the output</source>
+        <target state="new">Include hidden resources in the output</target>
+        <note />
+      </trans-unit>
       <trans-unit id="IsolatedOptionDescription">
         <source>Run in isolated mode with randomized ports and isolated user secrets, allowing multiple instances to run simultaneously</source>
         <target state="new">Run in isolated mode with randomized ports and isolated user secrets, allowing multiple instances to run simultaneously</target>

--- a/src/Aspire.Cli/Resources/xlf/SharedCommandStrings.zh-Hans.xlf
+++ b/src/Aspire.Cli/Resources/xlf/SharedCommandStrings.zh-Hans.xlf
@@ -42,6 +42,11 @@
         <target state="new">Status</target>
         <note />
       </trans-unit>
+      <trans-unit id="IncludeHiddenOptionDescription">
+        <source>Include hidden resources in the output</source>
+        <target state="new">Include hidden resources in the output</target>
+        <note />
+      </trans-unit>
       <trans-unit id="IsolatedOptionDescription">
         <source>Run in isolated mode with randomized ports and isolated user secrets, allowing multiple instances to run simultaneously</source>
         <target state="new">Run in isolated mode with randomized ports and isolated user secrets, allowing multiple instances to run simultaneously</target>

--- a/src/Aspire.Cli/Resources/xlf/SharedCommandStrings.zh-Hant.xlf
+++ b/src/Aspire.Cli/Resources/xlf/SharedCommandStrings.zh-Hant.xlf
@@ -42,6 +42,11 @@
         <target state="new">Status</target>
         <note />
       </trans-unit>
+      <trans-unit id="IncludeHiddenOptionDescription">
+        <source>Include hidden resources in the output</source>
+        <target state="new">Include hidden resources in the output</target>
+        <note />
+      </trans-unit>
       <trans-unit id="IsolatedOptionDescription">
         <source>Run in isolated mode with randomized ports and isolated user secrets, allowing multiple instances to run simultaneously</source>
         <target state="new">Run in isolated mode with randomized ports and isolated user secrets, allowing multiple instances to run simultaneously</target>

--- a/tests/Aspire.Cli.Tests/Backchannel/ResourceSnapshotMapperTests.cs
+++ b/tests/Aspire.Cli.Tests/Backchannel/ResourceSnapshotMapperTests.cs
@@ -48,7 +48,8 @@ public class ResourceSnapshotMapperTests
                     ]
                 },
                 new ResourceSnapshotCommand { Name = "start", State = "Disabled", Description = "Start" },
-                new ResourceSnapshotCommand { Name = "dashboard-only", State = "Enabled", Description = "UI only", Visibility = KnownCommandVisibility.UI }
+                new ResourceSnapshotCommand { Name = "dashboard-only", State = "Enabled", Description = "UI only", Visibility = KnownCommandVisibility.UI },
+                new ResourceSnapshotCommand { Name = "missing-visibility", State = "Enabled", Description = "Missing visibility", Visibility = null! }
             ],
             EnvironmentVariables =
             [

--- a/tests/Aspire.Cli.Tests/Commands/ResourceCommandHelpParserTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/ResourceCommandHelpParserTests.cs
@@ -65,8 +65,11 @@ public class ResourceCommandHelpParserTests
     [Theory]
     [InlineData("resource --help")]
     [InlineData("resource web --help")]
+    [InlineData("resource web --apphost ./AppHost/AppHost.csproj --help")]
+    [InlineData("resource web --project ./AppHost/AppHost.csproj --help")]
     [InlineData("resource web --message --help")]
     [InlineData("resource web --message=hi --help")]
+    [InlineData("resource web --help -- --message help")]
     [InlineData("resource web -- --message hi --help")]
     public void Parse_WithGenericResourceHelp_ReturnsNull(string commandLine)
     {

--- a/tests/Aspire.Cli.Tests/Commands/ResourceCommandTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/ResourceCommandTests.cs
@@ -31,6 +31,97 @@ public class ResourceCommandTests(ITestOutputHelper outputHelper)
     }
 
     [Fact]
+    public async Task ResourceCommand_HelpShowsAvailableResourceCommandsMatchesSnapshot()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        var helpWriter = new StringWriter();
+
+        var backchannel = new TestAppHostAuxiliaryBackchannel
+        {
+            ResourceSnapshots =
+            [
+                CreateResourceSnapshot(
+                    "web",
+                    CreateCommand("wait-for-browser", "Waits for text in the browser."),
+                    CreateCommand("configure", "Configures the browser."),
+                    CreateCommand("dashboard-only", "Dashboard-only command.", state: "Enabled", visibility: KnownCommandVisibility.UI),
+                    CreateCommand("missing-visibility", "Missing visibility command.", state: "Enabled", visibility: null!)),
+                CreateResourceSnapshot(
+                    "api",
+                    CreateCommand("wait-for-browser", "Waits for text in the browser."),
+                    CreateCommand("disabled-command", "Disabled command.", state: "Disabled", visibility: KnownCommandVisibility.Api))
+            ]
+        };
+        await using var provider = CreateServiceProvider(workspace, outputHelper, backchannel);
+
+        var command = provider.GetRequiredService<RootCommand>();
+        var result = command.Parse("resource web --non-interactive --help");
+
+        var exitCode = await result.InvokeAsync(new InvocationConfiguration { Output = helpWriter }).DefaultTimeout();
+
+        Assert.Equal(ExitCodeConstants.Success, exitCode);
+        await Verify(helpWriter.ToString(), extension: "txt");
+    }
+
+    [Fact]
+    public async Task ResourceCommand_HelpDoesNotPromptForOutOfScopeAppHostsMatchesSnapshot()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        var helpWriter = new StringWriter();
+
+        var backchannel = new TestAppHostAuxiliaryBackchannel
+        {
+            IsInScope = false,
+            ResourceSnapshots =
+            [
+                CreateResourceSnapshot(
+                    "web",
+                    CreateCommand("wait-for-browser", "Waits for text in the browser."))
+            ]
+        };
+        var interactionService = new TestInteractionService
+        {
+            PromptForSelectionCallback = (_, _, _, _) => throw new InvalidOperationException("Help should not prompt for an AppHost.")
+        };
+        await using var provider = CreateServiceProvider(workspace, outputHelper, backchannel, interactionService);
+
+        var command = provider.GetRequiredService<RootCommand>();
+        var result = command.Parse("resource web --help");
+
+        var exitCode = await result.InvokeAsync(new InvocationConfiguration { Output = helpWriter }).DefaultTimeout();
+
+        Assert.Equal(ExitCodeConstants.Success, exitCode);
+        await Verify(helpWriter.ToString(), extension: "txt");
+    }
+
+    [Fact]
+    public async Task ResourceCommand_HelpIncludesHiddenResourceCommandsWhenRequestedMatchesSnapshot()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        var helpWriter = new StringWriter();
+
+        var backchannel = new TestAppHostAuxiliaryBackchannel
+        {
+            ResourceSnapshots =
+            [
+                CreateResourceSnapshot(
+                    "hidden-worker",
+                    "Hidden",
+                    CreateCommand("inspect-hidden-worker", "Inspects the hidden worker."))
+            ]
+        };
+        await using var provider = CreateServiceProvider(workspace, outputHelper, backchannel);
+
+        var command = provider.GetRequiredService<RootCommand>();
+        var result = command.Parse("resource hidden-worker --include-hidden --help");
+
+        var exitCode = await result.InvokeAsync(new InvocationConfiguration { Output = helpWriter }).DefaultTimeout();
+
+        Assert.Equal(ExitCodeConstants.Success, exitCode);
+        await Verify(helpWriter.ToString(), extension: "txt");
+    }
+
+    [Fact]
     public async Task ResourceCommand_RequiresResourceArgument()
     {
         using var workspace = TemporaryWorkspace.Create(outputHelper);
@@ -1143,6 +1234,36 @@ public class ResourceCommandTests(ITestOutputHelper outputHelper)
     }
 
     [Fact]
+    public async Task ResourceCommand_IncludeHiddenExecutesHiddenResourceCommandWithMetadata()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+
+        var backchannel = new TestAppHostAuxiliaryBackchannel
+        {
+            ExecuteResourceCommandResult = new ExecuteResourceCommandResponse { Success = true },
+            ResourceSnapshots =
+            [
+                CreateResourceSnapshot(
+                    "hidden-worker",
+                    "Hidden",
+                    CreateCommand(
+                        "configure",
+                        CreateArgument("message")))
+            ]
+        };
+        await using var provider = CreateServiceProvider(workspace, outputHelper, backchannel);
+
+        var command = provider.GetRequiredService<RootCommand>();
+        var result = command.Parse("resource hidden-worker configure --include-hidden -- --message \"from hidden resource\"");
+
+        var exitCode = await result.InvokeAsync().DefaultTimeout();
+
+        Assert.Equal(ExitCodeConstants.Success, exitCode);
+        Assert.Equal(1, backchannel.ExecuteResourceCommandCallCount);
+        AssertJsonObject(backchannel.ExecuteResourceCommandArguments, ("message", "from hidden resource"));
+    }
+
+    [Fact]
     public async Task ResourceCommand_DoesNotForwardCommandOptionWithoutDelimiterWhenNameCollidesWithCliOption()
     {
         using var workspace = TemporaryWorkspace.Create(outputHelper);
@@ -1299,6 +1420,67 @@ public class ResourceCommandTests(ITestOutputHelper outputHelper)
         Assert.Contains("Selector to wait for. Required.", helpOutput);
         Assert.Contains("--timeout-milliseconds <value>", helpOutput);
         Assert.Contains("Timeout in milliseconds.", helpOutput);
+    }
+
+    [Fact]
+    public async Task ResourceCommand_CommandSpecificHelpBeforeDelimiterShowsHelp()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        var helpWriter = new StringWriter();
+
+        var backchannel = new TestAppHostAuxiliaryBackchannel
+        {
+            ResourceSnapshots =
+            [
+                CreateResourceSnapshot(
+                    "web-browser-automation",
+                    CreateCommand(
+                        "wait-for-browser",
+                        "Waits for text in the browser.",
+                        CreateArgument("selector", description: "Selector to wait for.", required: true)))
+            ]
+        };
+        await using var provider = CreateServiceProvider(workspace, outputHelper, backchannel);
+
+        var command = provider.GetRequiredService<RootCommand>();
+        var result = command.Parse("""resource web-browser-automation wait-for-browser --help -- --selector #main""");
+
+        var exitCode = await result.InvokeAsync(new InvocationConfiguration { Output = helpWriter }).DefaultTimeout();
+        var helpOutput = helpWriter.ToString();
+
+        Assert.Equal(ExitCodeConstants.Success, exitCode);
+        Assert.Equal(0, backchannel.ExecuteResourceCommandCallCount);
+        Assert.Contains("Waits for text in the browser.", helpOutput);
+        Assert.Contains("--selector <value>", helpOutput);
+    }
+
+    [Fact]
+    public async Task ResourceCommand_HelpAfterDelimiterIsForwardedToResourceCommand()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        var helpWriter = new StringWriter();
+
+        var backchannel = new TestAppHostAuxiliaryBackchannel
+        {
+            ExecuteResourceCommandResult = new ExecuteResourceCommandResponse { Success = true },
+            ResourceSnapshots =
+            [
+                CreateResourceSnapshot(
+                    "web-browser-automation",
+                    CreateCommand("custom-command"))
+            ]
+        };
+        await using var provider = CreateServiceProvider(workspace, outputHelper, backchannel);
+
+        var command = provider.GetRequiredService<RootCommand>();
+        var result = command.Parse("""resource web-browser-automation custom-command -- --help""");
+
+        var exitCode = await result.InvokeAsync(new InvocationConfiguration { Output = helpWriter }).DefaultTimeout();
+
+        Assert.Equal(ExitCodeConstants.Success, exitCode);
+        Assert.Equal(1, backchannel.ExecuteResourceCommandCallCount);
+        Assert.DoesNotContain("Usage:", helpWriter.ToString());
+        AssertJsonObject(backchannel.ExecuteResourceCommandArguments, ("--help", null));
     }
 
     [Fact]
@@ -1526,11 +1708,16 @@ public class ResourceCommandTests(ITestOutputHelper outputHelper)
 
     private static ResourceSnapshot CreateResourceSnapshot(string name, params ResourceSnapshotCommand[] commands)
     {
+        return CreateResourceSnapshot(name, state: "Running", commands);
+    }
+
+    private static ResourceSnapshot CreateResourceSnapshot(string name, string state, params ResourceSnapshotCommand[] commands)
+    {
         return new ResourceSnapshot
         {
             Name = name,
             DisplayName = name,
-            State = "Running",
+            State = state,
             Commands = commands
         };
     }
@@ -1563,11 +1750,17 @@ public class ResourceCommandTests(ITestOutputHelper outputHelper)
 
     private static ResourceSnapshotCommand CreateCommand(string name, string? description, params ResourceSnapshotCommandArgument[] argumentInputs)
     {
+        return CreateCommand(name, description, state: "Enabled", visibility: KnownCommandVisibility.Default, argumentInputs);
+    }
+
+    private static ResourceSnapshotCommand CreateCommand(string name, string? description, string state, string? visibility, params ResourceSnapshotCommandArgument[] argumentInputs)
+    {
         return new ResourceSnapshotCommand
         {
             Name = name,
             Description = description,
-            State = "Enabled",
+            State = state,
+            Visibility = visibility!,
             ArgumentInputs = argumentInputs
         };
     }

--- a/tests/Aspire.Cli.Tests/Commands/ResourceCommandTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/ResourceCommandTests.cs
@@ -5,6 +5,7 @@ using System.Text.Json;
 using System.Text.Json.Nodes;
 using Aspire.Cli.Backchannel;
 using Aspire.Cli.Commands;
+using Aspire.Cli.Projects;
 using Aspire.Cli.Tests.TestServices;
 using Aspire.Cli.Tests.Utils;
 using Microsoft.AspNetCore.InternalTesting;
@@ -92,6 +93,147 @@ public class ResourceCommandTests(ITestOutputHelper outputHelper)
 
         Assert.Equal(ExitCodeConstants.Success, exitCode);
         await Verify(helpWriter.ToString(), extension: "txt");
+    }
+
+    [Fact]
+    public async Task ResourceCommand_HelpFallsBackToDefaultHelpWhenAvailableCommandsScanFails()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        var helpWriter = new StringWriter();
+
+        var monitor = new TestAuxiliaryBackchannelMonitor
+        {
+            ScanAsyncCallback = _ => throw new InvalidOperationException("Scan failed.")
+        };
+        var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper, options =>
+        {
+            options.AuxiliaryBackchannelMonitorFactory = _ => monitor;
+        });
+        using var provider = services.BuildServiceProvider();
+
+        var command = provider.GetRequiredService<RootCommand>();
+        var result = command.Parse("resource web --help");
+
+        var exitCode = await result.InvokeAsync(new InvocationConfiguration { Output = helpWriter }).DefaultTimeout();
+        var helpOutput = helpWriter.ToString();
+
+        Assert.Equal(ExitCodeConstants.Success, exitCode);
+        Assert.Contains("Execute a command on a resource", helpOutput);
+        Assert.DoesNotContain("Available resource commands:", helpOutput);
+    }
+
+    [Fact]
+    public async Task ResourceCommand_HelpFallsBackToDefaultHelpWhenAvailableCommandsSnapshotFails()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        var helpWriter = new StringWriter();
+
+        var backchannel = new TestAppHostAuxiliaryBackchannel
+        {
+            GetResourceSnapshotsHandler = _ => throw new InvalidOperationException("Snapshot failed.")
+        };
+        await using var provider = CreateServiceProvider(workspace, outputHelper, backchannel);
+
+        var command = provider.GetRequiredService<RootCommand>();
+        var result = command.Parse("resource web --help");
+
+        var exitCode = await result.InvokeAsync(new InvocationConfiguration { Output = helpWriter }).DefaultTimeout();
+        var helpOutput = helpWriter.ToString();
+
+        Assert.Equal(ExitCodeConstants.Success, exitCode);
+        Assert.Contains("Execute a command on a resource", helpOutput);
+        Assert.DoesNotContain("Available resource commands:", helpOutput);
+    }
+
+    [Fact]
+    public async Task ResourceCommand_HelpWithAppHostDirectoryDoesNotPromptWhenMultipleAppHostsFound()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        var helpWriter = new StringWriter();
+        var appHostDirectory = workspace.WorkspaceRoot.CreateSubdirectory("Apps");
+        var prompted = false;
+        var interactionService = new TestInteractionService
+        {
+            PromptForSelectionCallback = (_, _, _, _) =>
+            {
+                prompted = true;
+                throw new InvalidOperationException("Help should not prompt for an AppHost.");
+            }
+        };
+        var projectLocator = new TestProjectLocator
+        {
+            UseOrFindAppHostProjectFileWithBehaviorAsyncCallback = (_, behavior, _, _) =>
+            {
+                Assert.Equal(MultipleAppHostProjectsFoundBehavior.Throw, behavior);
+                throw new ProjectLocatorException("multiple", ProjectLocatorFailureReason.MultipleProjectFilesFound);
+            }
+        };
+        var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper, options =>
+        {
+            options.InteractionServiceFactory = _ => interactionService;
+            options.ProjectLocatorFactory = _ => projectLocator;
+        });
+        using var provider = services.BuildServiceProvider();
+
+        var command = provider.GetRequiredService<RootCommand>();
+        var result = command.Parse($"""resource web --apphost "{appHostDirectory.FullName}" --help""");
+
+        var exitCode = await result.InvokeAsync(new InvocationConfiguration { Output = helpWriter }).DefaultTimeout();
+        var helpOutput = helpWriter.ToString();
+
+        Assert.Equal(ExitCodeConstants.Success, exitCode);
+        Assert.False(prompted);
+        Assert.Contains("Execute a command on a resource", helpOutput);
+        Assert.DoesNotContain("Available resource commands:", helpOutput);
+    }
+
+    [Fact]
+    public async Task ResourceCommand_HelpWithAppHostDoesNotPromptWhenMultipleRunningAppHostsMatch()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        var helpWriter = new StringWriter();
+        var appHostProjectFile = new FileInfo(Path.Combine(workspace.WorkspaceRoot.FullName, "AppHost.csproj"));
+        File.WriteAllText(appHostProjectFile.FullName, "<Project />");
+        var prompted = false;
+        var interactionService = new TestInteractionService
+        {
+            PromptForSelectionCallback = (_, _, _, _) =>
+            {
+                prompted = true;
+                throw new InvalidOperationException("Help should not prompt for an AppHost.");
+            }
+        };
+        var appHostInfo = new AppHostInformation
+        {
+            AppHostPath = appHostProjectFile.FullName,
+            ProcessId = 1
+        };
+        var monitor = new TestAuxiliaryBackchannelMonitor();
+        monitor.AddConnection(
+            "hash1",
+            Path.Combine(workspace.WorkspaceRoot.FullName, "socket1"),
+            new TestAppHostAuxiliaryBackchannel { AppHostInfo = appHostInfo });
+        monitor.AddConnection(
+            "hash2",
+            Path.Combine(workspace.WorkspaceRoot.FullName, "socket2"),
+            new TestAppHostAuxiliaryBackchannel { AppHostInfo = appHostInfo });
+        var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper, options =>
+        {
+            options.AuxiliaryBackchannelMonitorFactory = _ => monitor;
+            options.InteractionServiceFactory = _ => interactionService;
+        });
+        using var provider = services.BuildServiceProvider();
+
+        var command = provider.GetRequiredService<RootCommand>();
+        var result = command.Parse($"""resource web --apphost "{appHostProjectFile.FullName}" --help""");
+
+        var exitCode = await result.InvokeAsync(new InvocationConfiguration { Output = helpWriter }).DefaultTimeout();
+        var helpOutput = helpWriter.ToString();
+
+        Assert.Equal(ExitCodeConstants.Success, exitCode);
+        Assert.False(prompted);
+        Assert.Contains("Execute a command on a resource", helpOutput);
+        Assert.DoesNotContain("Available resource commands:", helpOutput);
     }
 
     [Fact]

--- a/tests/Aspire.Cli.Tests/Snapshots/ResourceCommandTests.ResourceCommand_CommandSpecificHelpForAllArgumentTypesMatchesSnapshot.verified.txt
+++ b/tests/Aspire.Cli.Tests/Snapshots/ResourceCommandTests.ResourceCommand_CommandSpecificHelpForAllArgumentTypesMatchesSnapshot.verified.txt
@@ -14,6 +14,7 @@ Command options:
 
 Options:
   --apphost <apphost>            The path to the Aspire AppHost project file or a directory to search
+  --include-hidden               Include hidden resources in the output
   -?, -h, /?, /h, --help         Show help and usage information
   -l, --log-level <log-level>    Set the minimum log level for console output (Trace, Debug, Information, Warning,
                                  Error, Critical)

--- a/tests/Aspire.Cli.Tests/Snapshots/ResourceCommandTests.ResourceCommand_HelpDoesNotPromptForOutOfScopeAppHostsMatchesSnapshot.verified.txt
+++ b/tests/Aspire.Cli.Tests/Snapshots/ResourceCommandTests.ResourceCommand_HelpDoesNotPromptForOutOfScopeAppHostsMatchesSnapshot.verified.txt
@@ -1,0 +1,23 @@
+﻿Description:
+  Execute a command on a resource (e.g. start, stop, restart)
+
+Usage:
+  Aspire.Cli.Tests resource <resource> <command> [options] [[--] <additional arguments>...]]
+
+Arguments:
+  <resource>  The name of the resource to execute the command on
+  <command>   The name of the command to execute (e.g. start, stop, restart)
+
+Options:
+  --apphost <apphost>                                                    The path to the Aspire AppHost project file or a directory to search
+  --include-hidden                                                       Include hidden resources in the output
+  -?, -h, --help                                                         Show help and usage information
+  -l, --log-level <Critical|Debug|Error|Information|None|Trace|Warning>  Set the minimum log level for console output (Trace, Debug, Information, Warning, Error, Critical)
+  --non-interactive                                                      Run the command in non-interactive mode, disabling all interactive prompts and spinners
+  --nologo                                                               Suppress the startup banner and telemetry notice
+  --banner                                                               Display the animated Aspire CLI welcome banner
+  --wait-for-debugger                                                    Wait for a debugger to attach before executing the command
+
+Additional Arguments:
+  Arguments passed to the application that is being run.
+

--- a/tests/Aspire.Cli.Tests/Snapshots/ResourceCommandTests.ResourceCommand_HelpIncludesHiddenResourceCommandsWhenRequestedMatchesSnapshot.verified.txt
+++ b/tests/Aspire.Cli.Tests/Snapshots/ResourceCommandTests.ResourceCommand_HelpIncludesHiddenResourceCommandsWhenRequestedMatchesSnapshot.verified.txt
@@ -1,0 +1,25 @@
+﻿Description:
+  Execute a command on a resource (e.g. start, stop, restart)
+
+Usage:
+  Aspire.Cli.Tests resource <resource> <command> [options] [[--] <additional arguments>...]]
+
+Arguments:
+  <resource>  The name of the resource to execute the command on
+  <command>   The name of the command to execute (e.g. start, stop, restart)
+
+Options:
+  --apphost <apphost>                                                    The path to the Aspire AppHost project file or a directory to search
+  --include-hidden                                                       Include hidden resources in the output
+  -?, -h, --help                                                         Show help and usage information
+  -l, --log-level <Critical|Debug|Error|Information|None|Trace|Warning>  Set the minimum log level for console output (Trace, Debug, Information, Warning, Error, Critical)
+  --non-interactive                                                      Run the command in non-interactive mode, disabling all interactive prompts and spinners
+  --nologo                                                               Suppress the startup banner and telemetry notice
+  --banner                                                               Display the animated Aspire CLI welcome banner
+  --wait-for-debugger                                                    Wait for a debugger to attach before executing the command
+
+Additional Arguments:
+  Arguments passed to the application that is being run.
+
+Available resource commands:
+  inspect-hidden-worker    Inspects the hidden worker.

--- a/tests/Aspire.Cli.Tests/Snapshots/ResourceCommandTests.ResourceCommand_HelpShowsAvailableResourceCommandsMatchesSnapshot.verified.txt
+++ b/tests/Aspire.Cli.Tests/Snapshots/ResourceCommandTests.ResourceCommand_HelpShowsAvailableResourceCommandsMatchesSnapshot.verified.txt
@@ -1,0 +1,26 @@
+﻿Description:
+  Execute a command on a resource (e.g. start, stop, restart)
+
+Usage:
+  Aspire.Cli.Tests resource <resource> <command> [options] [[--] <additional arguments>...]]
+
+Arguments:
+  <resource>  The name of the resource to execute the command on
+  <command>   The name of the command to execute (e.g. start, stop, restart)
+
+Options:
+  --apphost <apphost>                                                    The path to the Aspire AppHost project file or a directory to search
+  --include-hidden                                                       Include hidden resources in the output
+  -?, -h, --help                                                         Show help and usage information
+  -l, --log-level <Critical|Debug|Error|Information|None|Trace|Warning>  Set the minimum log level for console output (Trace, Debug, Information, Warning, Error, Critical)
+  --non-interactive                                                      Run the command in non-interactive mode, disabling all interactive prompts and spinners
+  --nologo                                                               Suppress the startup banner and telemetry notice
+  --banner                                                               Display the animated Aspire CLI welcome banner
+  --wait-for-debugger                                                    Wait for a debugger to attach before executing the command
+
+Additional Arguments:
+  Arguments passed to the application that is being run.
+
+Available resource commands:
+  configure           Configures the browser.
+  wait-for-browser    Waits for text in the browser.

--- a/tests/Aspire.Cli.Tests/TestServices/TestAuxiliaryBackchannelMonitor.cs
+++ b/tests/Aspire.Cli.Tests/TestServices/TestAuxiliaryBackchannelMonitor.cs
@@ -24,13 +24,15 @@ internal sealed class TestAuxiliaryBackchannelMonitor : IAuxiliaryBackchannelMon
     /// </summary>
     public int ScanCallCount { get; private set; }
 
+    public Func<CancellationToken, Task>? ScanAsyncCallback { get; set; }
+
     /// <summary>
     /// Triggers an immediate scan. In the test implementation, this just increments ScanCallCount.
     /// </summary>
     public Task ScanAsync(CancellationToken cancellationToken = default)
     {
         ScanCallCount++;
-        return Task.CompletedTask;
+        return ScanAsyncCallback?.Invoke(cancellationToken) ?? Task.CompletedTask;
     }
 
     public IAppHostAuxiliaryBackchannel? SelectedConnection


### PR DESCRIPTION
## Description

Resource commands are discovered from the running AppHost, but `aspire resource <resource> --help` only showed the static CLI shape. This change augments resource-scoped help with the commands available for that specific resource, while keeping top-level `aspire resource --help` generic because commands are resource-specific.

The resource command now:

- Shows an `Available resource commands:` section for `aspire resource <resource> --help`.
- Keeps command-specific argument help for `aspire resource <resource> <command> --help`.
- Treats `--help` after `--` as a resource-command argument instead of CLI help.
- Supports `--include-hidden` for resource command execution and help metadata lookup.
- Avoids prompting for AppHost selection when resource-scoped help cannot identify a single in-scope AppHost without an explicit `--apphost`.
- Handles null command visibility values safely in both resource help and resource snapshot mapping.

### User-facing usage

```bash
aspire resource argument-commands --apphost playground/Stress/Stress.AppHost/Stress.AppHost.csproj --help
```

Stress playground output includes resource-specific commands:

```text
Available resource commands:
  argument-stress-test      Minor dashboard/API stress command with many dynamically generated inputs to exercise
                            argument metadata and payload handling.
  dependent-arguments       Command with dependent inputs that dynamically load options based on other input values.
  echo-arguments            Common dashboard/API command with text, number, boolean, choice, and secret argument inputs.
  echo-command-arguments    Common API-only command that accepts required text and number arguments plus an optional
                            boolean.
  validate-arguments        Less common validation command with failure results, required inputs, defaults, and choice
                            validation.
```

Validation:

```bash
./dotnet.sh build /t:UpdateXlf src/Aspire.Cli/Aspire.Cli.csproj --nologo
./dotnet.sh test --project tests/Aspire.Cli.Tests/Aspire.Cli.Tests.csproj --no-launch-profile -- --filter-class "*.ResourceSnapshotMapperTests" --filter-class "*.ResourceCommandTests" --filter-class "*.ResourceCommandHelpParserTests" --filter-not-trait "quarantined=true" --filter-not-trait "outerloop=true"
```

Fixes # (issue)

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No