### PR TITLE
Add process-backed resource commands

### DIFF
--- a/playground/Stress/Stress.AppHost/CommandResources.cs
+++ b/playground/Stress/Stress.AppHost/CommandResources.cs
@@ -5,9 +5,13 @@ using System.Text.Json;
 using Microsoft.Extensions.DependencyInjection;
 
 #pragma warning disable ASPIREINTERACTION001 // InteractionInput is used to exercise resource command arguments.
+#pragma warning disable ASPIREPROCESSCOMMAND001 // Process command APIs are experimental.
 
 internal static class CommandResources
 {
+    private static string NodeExecutablePath { get; } = Environment.GetEnvironmentVariable("NODE") ?? "node";
+    private static string DotnetExecutablePath { get; } = Environment.GetEnvironmentVariable("DOTNET_HOST_PATH") ?? "dotnet";
+
     public static void AddCommandResources(
         this IDistributedApplicationBuilder builder,
         IResourceBuilder<ProjectResource> serviceBuilder,
@@ -425,6 +429,411 @@ internal static class CommandResources
                 ]
             });
 
+        // These commands exercise local process-backed resource commands, including issue-inspired command shapes.
+        var processCommands = builder.AddCommandGroup("process-commands", serviceBuilder.Resource);
+        var processCommandScriptsDirectory = Path.Combine(builder.AppHostDirectory, "process-command-scripts");
+        var processCommandStdinScriptPath = Path.Combine(processCommandScriptsDirectory, "stdin.js");
+        var processCommandEnvironmentScriptPath = Path.Combine(processCommandScriptsDirectory, "environment.js");
+        var processCommandWorkingDirectoryScriptPath = Path.Combine(processCommandScriptsDirectory, "working-directory.js");
+        var processCommandStderrFailureScriptPath = Path.Combine(processCommandScriptsDirectory, "stderr-failure.js");
+        var processCommandOutputLimitScriptPath = Path.Combine(processCommandScriptsDirectory, "output-limit.js");
+        var processCommandBackupRestoreScriptPath = Path.Combine(processCommandScriptsDirectory, "backup-restore.js");
+        var processCommandContainerExecScriptPath = Path.Combine(processCommandScriptsDirectory, "container-exec.js");
+        var processCommandSampleBackupPath = Path.Combine(processCommandScriptsDirectory, "sample-backup.dump");
+        var processCommandFileAppsDirectory = Path.GetFullPath(Path.Combine(builder.AppHostDirectory, "..", "process-command-file-apps"));
+        var processCommandCSharpArgumentsAndStdinAppPath = Path.Combine(processCommandFileAppsDirectory, "arguments-and-stdin.cs");
+        var processCommandCSharpWorkingDirectoryFailureAppPath = Path.Combine(processCommandFileAppsDirectory, "working-directory-failure.cs");
+        var processCommandIssueToolAppPath = Path.Combine(processCommandFileAppsDirectory, "issue-tool.cs");
+
+        processCommands.WithProcessCommand(
+            commandName: "dotnet-version",
+            displayName: "Show .NET version",
+            executablePath: "dotnet",
+            arguments: ["--version"],
+            commandOptions: new ProcessCommandOptions
+            {
+                Description = "Runs 'dotnet --version' from the AppHost and returns the process output.",
+                IconName = "WindowConsole",
+                MaxOutputLineCount = 10
+            });
+        processCommands.WithProcessCommand(
+            commandName: "dotnet-command",
+            displayName: "Run dotnet command",
+            processSpecFactory: context =>
+            {
+                var command = context.Arguments.GetString("command") switch
+                {
+                    "info" => "--info",
+                    _ => "--version"
+                };
+
+                return new ProcessCommandSpec("dotnet")
+                {
+                    Arguments = [command]
+                };
+            },
+            commandOptions: new ProcessCommandOptions
+            {
+                Description = "Runs a selected dotnet command from the AppHost to exercise process command arguments.",
+                IconName = "WindowConsole",
+                MaxOutputLineCount = 25,
+                Arguments =
+                [
+                    new InteractionInput
+                    {
+                        Name = "command",
+                        Label = "Command",
+                        Description = "Select which dotnet command to run.",
+                        InputType = InputType.Choice,
+                        Value = "version",
+                        Options =
+                        [
+                            KeyValuePair.Create("version", "dotnet --version"),
+                            KeyValuePair.Create("info", "dotnet --info")
+                        ]
+                    }
+                ]
+            });
+        processCommands.WithProcessCommand(
+            commandName: "process-stdin",
+            displayName: "Process stdin",
+            processSpecFactory: context => CreateNodeProcessSpec(
+                processCommandStdinScriptPath,
+                standardInputContent: context.Arguments.GetString("input") ?? "Hello from stdin"),
+            commandOptions: new ProcessCommandOptions
+            {
+                Description = "Runs a process that reads one line from standard input.",
+                IconName = "WindowConsole",
+                MaxOutputLineCount = 10,
+                Arguments =
+                [
+                    new InteractionInput
+                    {
+                        Name = "input",
+                        Label = "Input",
+                        Description = "Text written to the process standard input.",
+                        InputType = InputType.Text,
+                        Value = "Hello from stdin",
+                        MaxLength = 100
+                    }
+                ]
+            });
+        processCommands.WithProcessCommand(
+            commandName: "process-environment",
+            displayName: "Process environment",
+            processSpecFactory: _ => CreateNodeProcessSpec(
+                processCommandEnvironmentScriptPath,
+                environmentVariables: new Dictionary<string, string>
+                {
+                    ["PROCESS_COMMAND_SAMPLE"] = "from-process-command"
+                },
+                inheritEnvironmentVariables: false),
+            commandOptions: new ProcessCommandOptions
+            {
+                Description = "Runs a process with a custom environment and environment inheritance disabled.",
+                IconName = "WindowConsole",
+                MaxOutputLineCount = 10
+            });
+        processCommands.WithProcessCommand(
+            commandName: "process-working-directory",
+            displayName: "Process working directory",
+            processSpecFactory: _ => CreateNodeProcessSpec(
+                processCommandWorkingDirectoryScriptPath,
+                workingDirectory: builder.AppHostDirectory),
+            commandOptions: new ProcessCommandOptions
+            {
+                Description = "Runs a process from the AppHost working directory and lists project files.",
+                IconName = "Folder",
+                MaxOutputLineCount = 10
+            });
+        processCommands.WithProcessCommand(
+            commandName: "process-stderr-failure",
+            displayName: "Process stderr failure",
+            processSpecFactory: _ => CreateNodeProcessSpec(processCommandStderrFailureScriptPath),
+            commandOptions: new ProcessCommandOptions
+            {
+                Description = "Runs a process that writes stdout/stderr and returns a non-zero exit code.",
+                IconName = "Warning",
+                MaxOutputLineCount = 10
+            });
+        processCommands.WithProcessCommand(
+            commandName: "process-output-limit",
+            displayName: "Process output limit",
+            processSpecFactory: _ => CreateNodeProcessSpec(processCommandOutputLimitScriptPath),
+            commandOptions: new ProcessCommandOptions
+            {
+                Description = "Runs a process that emits more lines than the command returns.",
+                IconName = "TableLightning",
+                MaxOutputLineCount = 5,
+                DisplayImmediately = false
+            });
+        processCommands.WithProcessCommand(
+            commandName: "process-csharp-file-app",
+            displayName: "Process C# file app",
+            processSpecFactory: context => CreateDotnetFileAppProcessSpec(
+                processCommandCSharpArgumentsAndStdinAppPath,
+                arguments: [context.Arguments.GetString("name") ?? "Aspire"],
+                standardInputContent: context.Arguments.GetString("input") ?? "Hello from C#"),
+            commandOptions: new ProcessCommandOptions
+            {
+                Description = "Runs a C# file-based app that reads command arguments and standard input.",
+                IconName = "WindowConsole",
+                MaxOutputLineCount = 10,
+                Arguments =
+                [
+                    new InteractionInput
+                    {
+                        Name = "name",
+                        Label = "Name",
+                        Description = "Text passed as a C# file app command-line argument.",
+                        InputType = InputType.Text,
+                        Value = "Aspire",
+                        MaxLength = 100
+                    },
+                    new InteractionInput
+                    {
+                        Name = "input",
+                        Label = "Input",
+                        Description = "Text written to the C# file app standard input.",
+                        InputType = InputType.Text,
+                        Value = "Hello from C#",
+                        MaxLength = 100
+                    }
+                ]
+            });
+        processCommands.WithProcessCommand(
+            commandName: "process-csharp-file-app-failure",
+            displayName: "Process C# file app failure",
+            processSpecFactory: _ => CreateDotnetFileAppProcessSpec(
+                processCommandCSharpWorkingDirectoryFailureAppPath,
+                workingDirectory: builder.AppHostDirectory),
+            commandOptions: new ProcessCommandOptions
+            {
+                Description = "Runs a C# file-based app from the AppHost working directory that writes stdout/stderr and returns a non-zero exit code.",
+                IconName = "Warning",
+                MaxOutputLineCount = 10
+            });
+        processCommands.WithProcessCommand(
+            commandName: "issue-seed-data",
+            displayName: "Issue: Seed data",
+            processSpecFactory: context => CreateDotnetFileAppProcessSpec(
+                processCommandIssueToolAppPath,
+                arguments:
+                [
+                    "seed",
+                    context.Arguments.GetString("dataset") ?? "small",
+                    context.Arguments.GetString("customers") ?? "25"
+                ],
+                environmentVariables: new Dictionary<string, string>
+                {
+                    ["ConnectionStrings__mainDb"] = "Host=localhost;Port=15432;Database=mainDb;Username=postgres",
+                    ["ASPIRE_COMMAND_SCENARIO"] = "#8502 seed-data"
+                }),
+            commandOptions: new ProcessCommandOptions
+            {
+                Description = "Exercises a data seeding command with dashboard/CLI arguments.",
+                IconName = "DatabasePlugConnected",
+                MaxOutputLineCount = 20,
+                Arguments =
+                [
+                    new InteractionInput
+                    {
+                        Name = "dataset",
+                        Label = "Dataset",
+                        Description = "Seed data size.",
+                        InputType = InputType.Choice,
+                        Value = "small",
+                        Options =
+                        [
+                            KeyValuePair.Create("small", "Small"),
+                            KeyValuePair.Create("medium", "Medium"),
+                            KeyValuePair.Create("large", "Large")
+                        ]
+                    },
+                    new InteractionInput
+                    {
+                        Name = "customers",
+                        Label = "Customers",
+                        Description = "Number of customers to create.",
+                        InputType = InputType.Number,
+                        Value = "25"
+                    }
+                ]
+            });
+        processCommands.WithProcessCommand(
+            commandName: "issue-e2e-tests",
+            displayName: "Issue: E2E test filter",
+            processSpecFactory: context => CreateDotnetFileAppProcessSpec(
+                processCommandIssueToolAppPath,
+                arguments:
+                [
+                    "test",
+                    context.Arguments.GetString("filter") ?? "smoke"
+                ],
+                environmentVariables: new Dictionary<string, string>
+                {
+                    ["ASPIRE_TEST_CONFIGURATION"] = "Debug",
+                    ["ASPIRE_COMMAND_SCENARIO"] = "#8502 e2e-tests"
+                }),
+            commandOptions: new ProcessCommandOptions
+            {
+                Description = "Exercises running different test filters from a resource command.",
+                IconName = "Beaker",
+                MaxOutputLineCount = 20,
+                Arguments =
+                [
+                    new InteractionInput
+                    {
+                        Name = "filter",
+                        Label = "Filter",
+                        Description = "The test filter to run.",
+                        InputType = InputType.Choice,
+                        Value = "smoke",
+                        Options =
+                        [
+                            KeyValuePair.Create("smoke", "Smoke tests"),
+                            KeyValuePair.Create("db", "Database tests"),
+                            KeyValuePair.Create("ui", "UI tests")
+                        ]
+                    }
+                ]
+            });
+        processCommands.WithProcessCommand(
+            commandName: "issue-start-job",
+            displayName: "Issue: Start job-like process",
+            processSpecFactory: context => CreateDotnetFileAppProcessSpec(
+                processCommandIssueToolAppPath,
+                arguments:
+                [
+                    "job",
+                    context.Arguments.GetString("job") ?? "daily-import"
+                ],
+                standardInputContent: context.Arguments.GetString("payload") ?? "local-trigger"),
+            commandOptions: new ProcessCommandOptions
+            {
+                Description = "Exercises the on-demand job trigger shape by starting a local process with a payload.",
+                IconName = "Play",
+                MaxOutputLineCount = 20,
+                Arguments =
+                [
+                    new InteractionInput
+                    {
+                        Name = "job",
+                        Label = "Job",
+                        Description = "Job name to run.",
+                        InputType = InputType.Text,
+                        Value = "daily-import",
+                        MaxLength = 100
+                    },
+                    new InteractionInput
+                    {
+                        Name = "payload",
+                        Label = "Payload",
+                        Description = "Payload written to the job process standard input.",
+                        InputType = InputType.Text,
+                        Value = "local-trigger",
+                        MaxLength = 200
+                    }
+                ]
+            });
+        processCommands.WithProcessCommand(
+            commandName: "issue-restore-backup",
+            displayName: "Issue: Restore backup",
+            processSpecFactory: context => CreateNodeProcessSpec(
+                processCommandBackupRestoreScriptPath,
+                arguments:
+                [
+                    context.Arguments.GetString("backupPath") ?? processCommandSampleBackupPath,
+                    context.Arguments.GetString("container") ?? "db-server",
+                    context.Arguments.GetString("database") ?? "mainDb"
+                ]),
+            commandOptions: new ProcessCommandOptions
+            {
+                Description = "Exercises backup restore command composition similar to docker cp and docker exec pg_restore.",
+                IconName = "DatabaseArrowRight",
+                MaxOutputLineCount = 20,
+                Arguments =
+                [
+                    new InteractionInput
+                    {
+                        Name = "backupPath",
+                        Label = "Backup path",
+                        Description = "Backup file path on the AppHost machine.",
+                        InputType = InputType.Text,
+                        Value = processCommandSampleBackupPath,
+                        MaxLength = 500
+                    },
+                    new InteractionInput
+                    {
+                        Name = "container",
+                        Label = "Container",
+                        Description = "Container name or ID.",
+                        InputType = InputType.Text,
+                        Value = "db-server",
+                        MaxLength = 100
+                    },
+                    new InteractionInput
+                    {
+                        Name = "database",
+                        Label = "Database",
+                        Description = "Database name to restore.",
+                        InputType = InputType.Text,
+                        Value = "mainDb",
+                        MaxLength = 100
+                    }
+                ]
+            });
+        processCommands.WithProcessCommand(
+            commandName: "issue-container-exec-shape",
+            displayName: "Issue: Container exec shape",
+            processSpecFactory: context => CreateNodeProcessSpec(
+                processCommandContainerExecScriptPath,
+                arguments:
+                [
+                    GetRequiredCommandArgument(context.Arguments, "container"),
+                    GetRequiredCommandArgument(context.Arguments, "execCommand"),
+                    GetRequiredCommandArgument(context.Arguments, "workingDirectory")
+                ]),
+            commandOptions: new ProcessCommandOptions
+            {
+                Description = "Exercises the local process shape for a docker exec-style command.",
+                IconName = "WindowConsole",
+                MaxOutputLineCount = 20,
+                Arguments =
+                [
+                    new InteractionInput
+                    {
+                        Name = "container",
+                        Label = "Container",
+                        Description = "Container name or ID.",
+                        InputType = InputType.Text,
+                        Required = true,
+                        Placeholder = "db-server",
+                        MaxLength = 100
+                    },
+                    new InteractionInput
+                    {
+                        Name = "execCommand",
+                        Label = "Command",
+                        Description = "Command to execute in the container.",
+                        InputType = InputType.Text,
+                        Required = true,
+                        Placeholder = "pg_isready -U postgres",
+                        MaxLength = 200
+                    },
+                    new InteractionInput
+                    {
+                        Name = "workingDirectory",
+                        Label = "Working directory",
+                        Description = "Working directory inside the container.",
+                        InputType = InputType.Text,
+                        Required = true,
+                        Placeholder = "/",
+                        MaxLength = 200
+                    }
+                ]
+            });
+
         serviceBuilder.WithHttpCommand("/write-console", "Write to console", commandOptions: new() { Method = HttpMethod.Get, IconName = "ContentViewGalleryLightning" });
         serviceBuilder.WithHttpCommand("/write-console-large", "Write to console large", commandOptions: new() { Method = HttpMethod.Get, IconName = "ContentViewGalleryLightning" });
         serviceBuilder.WithHttpCommand("/increment-counter", "Increment counter", commandOptions: new() { Method = HttpMethod.Get, IconName = "ContentViewGalleryLightning" });
@@ -604,6 +1013,11 @@ internal static class CommandResources
         };
     }
 
+    private static string GetRequiredCommandArgument(InteractionInputCollection arguments, string name)
+    {
+        return arguments.GetString(name) ?? throw new InvalidOperationException($"The '{name}' argument is required.");
+    }
+
     private static ValidateCommandArguments ReadValidateCommandArguments(InteractionInputCollection arguments)
     {
         return new ValidateCommandArguments
@@ -666,6 +1080,55 @@ internal static class CommandResources
         return inputs;
     }
 
+    private static ProcessCommandSpec CreateNodeProcessSpec(
+        string scriptPath,
+        IReadOnlyList<string>? arguments = null,
+        string? workingDirectory = null,
+        IDictionary<string, string>? environmentVariables = null,
+        bool inheritEnvironmentVariables = true,
+        string? standardInputContent = null)
+    {
+        var processArguments = new List<string> { scriptPath };
+        if (arguments is not null)
+        {
+            processArguments.AddRange(arguments);
+        }
+
+        return new ProcessCommandSpec(NodeExecutablePath)
+        {
+            Arguments = processArguments,
+            WorkingDirectory = workingDirectory,
+            EnvironmentVariables = environmentVariables ?? new Dictionary<string, string>(),
+            InheritEnvironmentVariables = inheritEnvironmentVariables,
+            StandardInputContent = standardInputContent
+        };
+    }
+
+    private static ProcessCommandSpec CreateDotnetFileAppProcessSpec(
+        string appPath,
+        IReadOnlyList<string>? arguments = null,
+        string? workingDirectory = null,
+        IDictionary<string, string>? environmentVariables = null,
+        bool inheritEnvironmentVariables = true,
+        string? standardInputContent = null)
+    {
+        var processArguments = new List<string> { "run", "--file", appPath };
+        if (arguments is { Count: > 0 })
+        {
+            processArguments.Add("--");
+            processArguments.AddRange(arguments);
+        }
+
+        return new ProcessCommandSpec(DotnetExecutablePath)
+        {
+            Arguments = processArguments,
+            WorkingDirectory = workingDirectory,
+            EnvironmentVariables = environmentVariables ?? new Dictionary<string, string>(),
+            InheritEnvironmentVariables = inheritEnvironmentVariables,
+            StandardInputContent = standardInputContent
+        };
+    }
+
     private static async Task ExecuteCommandForAllResourcesAsync(IServiceProvider serviceProvider, string commandName, CancellationToken cancellationToken)
     {
         var commandService = serviceProvider.GetRequiredService<ResourceCommandService>();
@@ -708,3 +1171,6 @@ internal static class CommandResources
         public bool RequireHealthy { get; set; } = true;
     }
 }
+
+#pragma warning restore ASPIREPROCESSCOMMAND001
+#pragma warning restore ASPIREINTERACTION001

--- a/playground/Stress/Stress.AppHost/process-command-scripts/backup-restore.js
+++ b/playground/Stress/Stress.AppHost/process-command-scripts/backup-restore.js
@@ -1,0 +1,18 @@
+const fs = require("node:fs");
+
+const [backupPath = "sample-backup.dump", containerName = "db-server", databaseName = "mainDb"] = process.argv.slice(2);
+
+console.log("scenario=#12906/#7786 backup-restore");
+console.log(`backup-path=${backupPath}`);
+console.log(`container=${containerName}`);
+console.log(`database=${databaseName}`);
+
+if (!fs.existsSync(backupPath)) {
+    console.error(`backup-missing=${backupPath}`);
+    process.exit(2);
+}
+
+const backupSize = fs.statSync(backupPath).size;
+console.log(`backup-size-bytes=${backupSize}`);
+console.log(`docker-cp-shape=docker cp "${backupPath}" "${containerName}:/tmp/restore.dump"`);
+console.log(`docker-exec-shape=docker exec "${containerName}" pg_restore -U postgres -d "${databaseName}" /tmp/restore.dump`);

--- a/playground/Stress/Stress.AppHost/process-command-scripts/container-exec.js
+++ b/playground/Stress/Stress.AppHost/process-command-scripts/container-exec.js
@@ -1,0 +1,12 @@
+const [containerName = "db-server", command = "pg_isready -U postgres", workingDirectory = "/"] = process.argv.slice(2);
+
+console.log("scenario=#10301 container-exec");
+console.log(`container=${containerName}`);
+console.log(`working-directory=${workingDirectory}`);
+console.log(`command=${command}`);
+console.log(`docker-exec-shape=docker exec -w "${workingDirectory}" "${containerName}" ${command}`);
+
+if (command.includes("fail")) {
+    console.error("simulated-container-exec-failure");
+    process.exit(3);
+}

--- a/playground/Stress/Stress.AppHost/process-command-scripts/environment.js
+++ b/playground/Stress/Stress.AppHost/process-command-scripts/environment.js
@@ -1,0 +1,1 @@
+console.log(`env=${process.env.PROCESS_COMMAND_SAMPLE ?? ""}`);

--- a/playground/Stress/Stress.AppHost/process-command-scripts/output-limit.js
+++ b/playground/Stress/Stress.AppHost/process-command-scripts/output-limit.js
@@ -1,0 +1,3 @@
+for (let i = 1; i <= 20; i++) {
+    console.log(`line-${i}`);
+}

--- a/playground/Stress/Stress.AppHost/process-command-scripts/sample-backup.dump
+++ b/playground/Stress/Stress.AppHost/process-command-scripts/sample-backup.dump
@@ -1,0 +1,1 @@
+sample backup content for process command restore scenario

--- a/playground/Stress/Stress.AppHost/process-command-scripts/stderr-failure.js
+++ b/playground/Stress/Stress.AppHost/process-command-scripts/stderr-failure.js
@@ -1,0 +1,3 @@
+console.log("stdout-line");
+console.error("stderr-line");
+process.exit(3);

--- a/playground/Stress/Stress.AppHost/process-command-scripts/stdin.js
+++ b/playground/Stress/Stress.AppHost/process-command-scripts/stdin.js
@@ -1,0 +1,7 @@
+let input = "";
+
+process.stdin.setEncoding("utf8");
+process.stdin.on("data", chunk => input += chunk);
+process.stdin.on("end", () => {
+    console.log(`stdin-${input.trim()}`);
+});

--- a/playground/Stress/Stress.AppHost/process-command-scripts/working-directory.js
+++ b/playground/Stress/Stress.AppHost/process-command-scripts/working-directory.js
@@ -1,0 +1,9 @@
+const fs = require("node:fs");
+
+const projectFiles = fs.readdirSync(process.cwd())
+    .filter(entry => entry.endsWith(".csproj"))
+    .sort();
+
+for (const projectFile of projectFiles) {
+    console.log(projectFile);
+}

--- a/playground/Stress/process-command-file-apps/arguments-and-stdin.cs
+++ b/playground/Stress/process-command-file-apps/arguments-and-stdin.cs
@@ -1,0 +1,6 @@
+#:sdk Microsoft.NET.Sdk
+var input = await Console.In.ReadToEndAsync();
+var name = args.Length > 0 ? args[0] : "unknown";
+
+Console.WriteLine($"csharp-argument-{name}");
+Console.WriteLine($"csharp-stdin-{input.Trim()}");

--- a/playground/Stress/process-command-file-apps/issue-tool.cs
+++ b/playground/Stress/process-command-file-apps/issue-tool.cs
@@ -1,0 +1,36 @@
+#:sdk Microsoft.NET.Sdk
+
+var mode = args.Length > 0 ? args[0] : "unknown";
+
+Console.WriteLine($"scenario={Environment.GetEnvironmentVariable("ASPIRE_COMMAND_SCENARIO") ?? "manual"}");
+Console.WriteLine($"mode={mode}");
+
+if (mode == "seed")
+{
+    var dataset = args.Length > 1 ? args[1] : "small";
+    var customers = args.Length > 2 ? args[2] : "25";
+
+    Console.WriteLine($"seed-dataset={dataset}");
+    Console.WriteLine($"seed-customers={customers}");
+    Console.WriteLine($"connection-set={!string.IsNullOrEmpty(Environment.GetEnvironmentVariable("ConnectionStrings__mainDb"))}");
+}
+else if (mode == "test")
+{
+    var filter = args.Length > 1 ? args[1] : "smoke";
+
+    Console.WriteLine($"test-filter={filter}");
+    Console.WriteLine($"configuration={Environment.GetEnvironmentVariable("ASPIRE_TEST_CONFIGURATION") ?? "unknown"}");
+}
+else if (mode == "job")
+{
+    var jobName = args.Length > 1 ? args[1] : "daily-import";
+    var stdin = await Console.In.ReadToEndAsync();
+
+    Console.WriteLine($"job-name={jobName}");
+    Console.WriteLine($"job-payload={stdin.Trim()}");
+}
+else
+{
+    Console.Error.WriteLine($"unknown-mode={mode}");
+    Environment.Exit(2);
+}

--- a/playground/Stress/process-command-file-apps/working-directory-failure.cs
+++ b/playground/Stress/process-command-file-apps/working-directory-failure.cs
@@ -1,0 +1,13 @@
+#:sdk Microsoft.NET.Sdk
+
+var projectFiles = Directory.EnumerateFiles(Directory.GetCurrentDirectory(), "*.csproj")
+    .Select(Path.GetFileName)
+    .OrderBy(static fileName => fileName);
+
+foreach (var projectFile in projectFiles)
+{
+    Console.WriteLine(projectFile);
+}
+
+Console.Error.WriteLine("csharp-stderr-line");
+Environment.Exit(4);

--- a/playground/TypeScriptAppHost/apphost.ts
+++ b/playground/TypeScriptAppHost/apphost.ts
@@ -108,12 +108,9 @@ await cache.withProcessCommand(
             processCommandScriptPath,
             "from-typescript-apphost"
         ],
-        environmentVariables: [
-            {
-                name: "TS_PROCESS_COMMAND_SAMPLE",
-                value: "from-process-command"
-            }
-        ],
+        environmentVariables: {
+            TS_PROCESS_COMMAND_SAMPLE: "from-process-command"
+        },
         standardInputContent: "hello from TypeScript AppHost",
         maxOutputLineCount: 10,
         commandOptions: {

--- a/playground/TypeScriptAppHost/apphost.ts
+++ b/playground/TypeScriptAppHost/apphost.ts
@@ -3,6 +3,7 @@
 // Run with: aspire run
 // Publish with: aspire publish
 
+import { join } from 'node:path';
 import {
     createBuilder,
     refExpr,
@@ -29,6 +30,7 @@ await builder.addDockerComposeEnvironment("compose");
 
 const dir = await builder.appHostDirectory();
 console.log(`AppHost directory: ${dir}`);
+const processCommandScriptPath = join(dir, "process-command-scripts", "node-process-check.js");
 
 // Add PostgreSQL server and database
 const postgres = await builder.addPostgres("postgres");
@@ -95,6 +97,28 @@ await cache.withCommand(
                     await context.addValidationError("count", "Count must be greater than or equal to 1.");
                 }
             }
+        }
+    });
+await cache.withProcessCommand(
+    "node-process-check",
+    "Node process check",
+    {
+        executablePath: "node",
+        arguments: [
+            processCommandScriptPath,
+            "from-typescript-apphost"
+        ],
+        environmentVariables: [
+            {
+                name: "TS_PROCESS_COMMAND_SAMPLE",
+                value: "from-process-command"
+            }
+        ],
+        standardInputContent: "hello from TypeScript AppHost",
+        maxOutputLineCount: 10,
+        commandOptions: {
+            description: "Runs a Node process command from the TypeScript AppHost.",
+            iconName: "WindowConsole"
         }
     });
 

--- a/playground/TypeScriptAppHost/process-command-scripts/node-process-check.js
+++ b/playground/TypeScriptAppHost/process-command-scripts/node-process-check.js
@@ -1,0 +1,9 @@
+let input = "";
+
+process.stdin.setEncoding("utf8");
+process.stdin.on("data", chunk => input += chunk);
+process.stdin.on("end", () => {
+    console.log(`ts-process-command-arg=${process.argv[2]}`);
+    console.log(`ts-process-command-env=${process.env.TS_PROCESS_COMMAND_SAMPLE}`);
+    console.log(`ts-process-command-stdin=${input.trim()}`);
+});

--- a/src/Aspire.Hosting.Docker/Aspire.Hosting.Docker.csproj
+++ b/src/Aspire.Hosting.Docker/Aspire.Hosting.Docker.csproj
@@ -13,6 +13,7 @@
     <Compile Include="..\Aspire.Hosting\Dcp\Process\ProcessSpec.cs" Link="Shared\ProcessSpec.cs" />
     <Compile Include="..\Aspire.Hosting\Dcp\Process\ProcessOutputCapture.cs" Link="Shared\ProcessOutputCapture.cs" />
     <Compile Include="..\Aspire.Hosting\Dcp\Process\ProcessUtil.cs" Link="Shared\ProcessUtil.cs" />
+    <Compile Include="$(SharedDir)PathLookupHelper.cs" LinkBase="Shared" />
     <Compile Include="$(SharedDir)ResourceNameComparer.cs" LinkBase="Shared" />
     <Compile Include="$(SharedDir)KnownOtelConfigNames.cs" LinkBase="Shared" />
     <Compile Include="$(SharedDir)PublishingContextUtils.cs" LinkBase="Shared" />

--- a/src/Aspire.Hosting.RemoteHost/AtsCapabilityScanner.cs
+++ b/src/Aspire.Hosting.RemoteHost/AtsCapabilityScanner.cs
@@ -1039,6 +1039,7 @@ public static class AtsCapabilityScanner
             }
 
             var propDescription = GetXmlDocSummary(xmlDoc, $"P:{type.FullName}.{prop.Name}");
+            var isOptional = !prop.CanWrite || Nullable.GetUnderlyingType(prop.PropertyType) is not null;
 
             properties.Add(new AtsDtoPropertyInfo
             {
@@ -1047,7 +1048,7 @@ public static class AtsCapabilityScanner
                 IsCallback = isCallback,
                 CallbackParameters = callbackParameters,
                 CallbackReturnType = callbackReturnType,
-                IsOptional = !prop.CanWrite, // If no setter, it's likely init-only and required
+                IsOptional = isOptional,
                 Description = propDescription
             });
         }

--- a/src/Aspire.Hosting/ApplicationModel/ProcessCommandOptions.cs
+++ b/src/Aspire.Hosting/ApplicationModel/ProcessCommandOptions.cs
@@ -67,7 +67,7 @@ internal sealed class ProcessCommandExportOptions
     /// <summary>
     /// The environment variables to set for the process.
     /// </summary>
-    public IReadOnlyList<ProcessCommandEnvironmentVariable>? EnvironmentVariables { get; set; }
+    public IReadOnlyDictionary<string, string>? EnvironmentVariables { get; set; }
 
     /// <summary>
     /// A value indicating whether the process should inherit the current environment variables.
@@ -98,21 +98,4 @@ internal sealed class ProcessCommandExportOptions
     /// A value indicating whether returned command output should be displayed immediately in the dashboard.
     /// </summary>
     public bool? DisplayImmediately { get; set; }
-}
-
-/// <summary>
-/// Represents an environment variable to set for a resource process command.
-/// </summary>
-[AspireDto]
-internal sealed class ProcessCommandEnvironmentVariable
-{
-    /// <summary>
-    /// The environment variable name.
-    /// </summary>
-    public string? Name { get; set; }
-
-    /// <summary>
-    /// The environment variable value.
-    /// </summary>
-    public string? Value { get; set; }
 }

--- a/src/Aspire.Hosting/ApplicationModel/ProcessCommandOptions.cs
+++ b/src/Aspire.Hosting/ApplicationModel/ProcessCommandOptions.cs
@@ -1,0 +1,118 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Diagnostics.CodeAnalysis;
+
+namespace Aspire.Hosting.ApplicationModel;
+
+/// <summary>
+/// Optional configuration for resource process commands added with <see cref="ResourceBuilderExtensions.WithProcessCommand{TResource}(IResourceBuilder{TResource}, string, string, Func{ExecuteCommandContext, ValueTask{ProcessCommandSpec}}, ProcessCommandOptions?)"/>.
+/// </summary>
+[Experimental("ASPIREPROCESSCOMMAND001", UrlFormat = "https://aka.ms/aspire/diagnostics/{0}")]
+public class ProcessCommandOptions : CommandOptions
+{
+    private int _maxOutputLineCount = 50;
+
+    internal static new ProcessCommandOptions Default { get; } = new();
+
+    /// <summary>
+    /// Gets or sets the maximum number of stdout and stderr output lines returned as command result data.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Standard output and standard error are captured together in the order observed by the process runner. The returned
+    /// command result contains the retained tail of the combined output as plain text.
+    /// </para>
+    /// </remarks>
+    public int MaxOutputLineCount
+    {
+        get => _maxOutputLineCount;
+        set
+        {
+            ArgumentOutOfRangeException.ThrowIfNegativeOrZero(value);
+            _maxOutputLineCount = value;
+        }
+    }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether returned command output should be displayed immediately in the dashboard.
+    /// </summary>
+    /// <remarks>
+    /// The default value is <see langword="true"/>.
+    /// </remarks>
+    public bool DisplayImmediately { get; set; } = true;
+}
+
+/// <summary>
+/// ATS-friendly configuration for resource process commands.
+/// </summary>
+[AspireDto]
+internal sealed class ProcessCommandExportOptions
+{
+    /// <summary>
+    /// The executable path or command name to start.
+    /// </summary>
+    public string? ExecutablePath { get; set; }
+
+    /// <summary>
+    /// The command-line arguments for the process.
+    /// </summary>
+    public IReadOnlyList<string>? Arguments { get; set; }
+
+    /// <summary>
+    /// The working directory for the process.
+    /// </summary>
+    public string? WorkingDirectory { get; set; }
+
+    /// <summary>
+    /// The environment variables to set for the process.
+    /// </summary>
+    public IReadOnlyList<ProcessCommandEnvironmentVariable>? EnvironmentVariables { get; set; }
+
+    /// <summary>
+    /// A value indicating whether the process should inherit the current environment variables.
+    /// </summary>
+    public bool InheritEnvironmentVariables { get; set; } = true;
+
+    /// <summary>
+    /// Standard input content to write to the process after it starts.
+    /// </summary>
+    public string? StandardInputContent { get; set; }
+
+    /// <summary>
+    /// A value indicating whether the entire process tree should be killed when the process is disposed.
+    /// </summary>
+    public bool KillEntireProcessTree { get; set; } = true;
+
+    /// <summary>
+    /// Optional command configuration.
+    /// </summary>
+    public CommandOptions? CommandOptions { get; set; }
+
+    /// <summary>
+    /// The maximum number of stdout and stderr output lines returned as command result data.
+    /// </summary>
+    public int? MaxOutputLineCount { get; set; }
+
+    /// <summary>
+    /// A value indicating whether returned command output should be displayed immediately in the dashboard.
+    /// </summary>
+    public bool? DisplayImmediately { get; set; }
+}
+
+/// <summary>
+/// Represents an environment variable to set for a resource process command.
+/// </summary>
+[AspireDto]
+internal sealed class ProcessCommandEnvironmentVariable
+{
+    /// <summary>
+    /// The environment variable name.
+    /// </summary>
+    public string? Name { get; set; }
+
+    /// <summary>
+    /// The environment variable value.
+    /// </summary>
+    public string? Value { get; set; }
+}

--- a/src/Aspire.Hosting/ApplicationModel/ProcessCommandOptions.cs
+++ b/src/Aspire.Hosting/ApplicationModel/ProcessCommandOptions.cs
@@ -72,7 +72,7 @@ internal sealed class ProcessCommandExportOptions
     /// <summary>
     /// A value indicating whether the process should inherit the current environment variables.
     /// </summary>
-    public bool InheritEnvironmentVariables { get; set; } = true;
+    public bool? InheritEnvironmentVariables { get; set; }
 
     /// <summary>
     /// Standard input content to write to the process after it starts.
@@ -82,7 +82,7 @@ internal sealed class ProcessCommandExportOptions
     /// <summary>
     /// A value indicating whether the entire process tree should be killed when the process is disposed.
     /// </summary>
-    public bool KillEntireProcessTree { get; set; } = true;
+    public bool? KillEntireProcessTree { get; set; }
 
     /// <summary>
     /// Optional command configuration.

--- a/src/Aspire.Hosting/ApplicationModel/ProcessCommandOptions.cs
+++ b/src/Aspire.Hosting/ApplicationModel/ProcessCommandOptions.cs
@@ -12,6 +12,7 @@ namespace Aspire.Hosting.ApplicationModel;
 public class ProcessCommandOptions : CommandOptions
 {
     private int _maxOutputLineCount = 50;
+    private IReadOnlyList<int> _successExitCodes = [0];
 
     internal static new ProcessCommandOptions Default { get; } = new();
 
@@ -22,6 +23,9 @@ public class ProcessCommandOptions : CommandOptions
     /// <para>
     /// Standard output and standard error are captured together in the order observed by the process runner. The returned
     /// command result contains the retained tail of the combined output as plain text.
+    /// </para>
+    /// <para>
+    /// This option is not applied by default result handling when <see cref="GetCommandResult"/> is specified.
     /// </para>
     /// </remarks>
     public int MaxOutputLineCount
@@ -38,9 +42,46 @@ public class ProcessCommandOptions : CommandOptions
     /// Gets or sets a value indicating whether returned command output should be displayed immediately in the dashboard.
     /// </summary>
     /// <remarks>
+    /// <para>
     /// The default value is <see langword="true"/>.
+    /// </para>
+    /// <para>
+    /// This option is not applied by default result handling when <see cref="GetCommandResult"/> is specified.
+    /// </para>
     /// </remarks>
     public bool DisplayImmediately { get; set; } = true;
+
+    /// <summary>
+    /// Gets or sets the exit codes that are treated as a successful command invocation when <see cref="GetCommandResult"/> is not specified.
+    /// </summary>
+    /// <remarks>
+    /// The default value is <c>[0]</c>.
+    /// </remarks>
+    public IReadOnlyList<int> SuccessExitCodes
+    {
+        get => _successExitCodes;
+        set
+        {
+            ArgumentNullException.ThrowIfNull(value);
+
+            if (value.Count == 0)
+            {
+                throw new ArgumentException("At least one process command success exit code must be specified.", nameof(value));
+            }
+
+            _successExitCodes = value.ToArray();
+        }
+    }
+
+    /// <summary>
+    /// Gets or sets a callback to be invoked after the process exits to determine the result of the command invocation.
+    /// </summary>
+    /// <remarks>
+    /// When specified, <see cref="SuccessExitCodes"/>, <see cref="MaxOutputLineCount"/>, and <see cref="DisplayImmediately"/>
+    /// are not applied by the default result handling. The callback can use <see cref="ProcessCommandResultContext.GetFormattedOutput"/>
+    /// to format retained process output.
+    /// </remarks>
+    public Func<ProcessCommandResultContext, Task<ExecuteCommandResult>>? GetCommandResult { get; set; }
 }
 
 /// <summary>
@@ -98,4 +139,9 @@ internal sealed class ProcessCommandExportOptions
     /// A value indicating whether returned command output should be displayed immediately in the dashboard.
     /// </summary>
     public bool? DisplayImmediately { get; set; }
+
+    /// <summary>
+    /// The exit codes that are treated as a successful command invocation.
+    /// </summary>
+    public IReadOnlyList<int>? SuccessExitCodes { get; set; }
 }

--- a/src/Aspire.Hosting/ApplicationModel/ProcessCommandOptions.cs
+++ b/src/Aspire.Hosting/ApplicationModel/ProcessCommandOptions.cs
@@ -14,7 +14,7 @@ public class ProcessCommandOptions : CommandOptions
     private int _maxOutputLineCount = 50;
     private IReadOnlyList<int> _successExitCodes = [0];
 
-    internal static new ProcessCommandOptions Default { get; } = new();
+    internal static new ProcessCommandOptions Default => new();
 
     /// <summary>
     /// Gets or sets the maximum number of stdout and stderr output lines returned as command result data.

--- a/src/Aspire.Hosting/ApplicationModel/ProcessCommandResultContext.cs
+++ b/src/Aspire.Hosting/ApplicationModel/ProcessCommandResultContext.cs
@@ -1,0 +1,67 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Diagnostics.CodeAnalysis;
+using Aspire.Hosting.Utils;
+using Microsoft.Extensions.Logging;
+
+namespace Aspire.Hosting.ApplicationModel;
+
+/// <summary>
+/// Context passed to callback to configure <see cref="ExecuteCommandResult"/> when using
+/// <see cref="ResourceBuilderExtensions.WithProcessCommand{TResource}(IResourceBuilder{TResource}, string, string, Func{ExecuteCommandContext, ValueTask{ProcessCommandSpec}}, ProcessCommandOptions?)"/>.
+/// </summary>
+[Experimental("ASPIREPROCESSCOMMAND001", UrlFormat = "https://aka.ms/aspire/diagnostics/{0}")]
+public sealed class ProcessCommandResultContext
+{
+    /// <summary>
+    /// Gets the service provider.
+    /// </summary>
+    public required IServiceProvider ServiceProvider { get; init; }
+
+    /// <summary>
+    /// Gets the name of the resource the command was configured on.
+    /// </summary>
+    public required string ResourceName { get; init; }
+
+    /// <summary>
+    /// Gets the logger for the command invocation.
+    /// </summary>
+    public required ILogger Logger { get; init; }
+
+    /// <summary>
+    /// Gets the cancellation token.
+    /// </summary>
+    public required CancellationToken CancellationToken { get; init; }
+
+    /// <summary>
+    /// Gets the process command specification used for the command invocation.
+    /// </summary>
+    public required ProcessCommandSpec ProcessCommandSpec { get; init; }
+
+    /// <summary>
+    /// Gets the process exit code.
+    /// </summary>
+    public required int ExitCode { get; init; }
+
+    /// <summary>
+    /// Gets the retained stdout and stderr output lines in the order observed by the process runner.
+    /// </summary>
+    public required IReadOnlyList<string> Output { get; init; }
+
+    /// <summary>
+    /// Gets the total number of stdout and stderr lines observed by the process runner.
+    /// </summary>
+    public required int TotalOutputLineCount { get; init; }
+
+    /// <summary>
+    /// Returns the last <paramref name="maxLines"/> process output lines formatted for display.
+    /// </summary>
+    /// <param name="maxLines">The maximum number of lines to include.</param>
+    /// <param name="outputDescription">The label used when the output is truncated.</param>
+    /// <returns>The formatted output.</returns>
+    public string GetFormattedOutput(int maxLines = 50, string outputDescription = "Command output")
+    {
+        return ProcessOutputCapture.FormatOutput(Output, TotalOutputLineCount, maxLines, outputDescription);
+    }
+}

--- a/src/Aspire.Hosting/ApplicationModel/ProcessCommandSpec.cs
+++ b/src/Aspire.Hosting/ApplicationModel/ProcessCommandSpec.cs
@@ -1,0 +1,64 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Diagnostics.CodeAnalysis;
+
+namespace Aspire.Hosting.ApplicationModel;
+
+/// <summary>
+/// Describes a local process that is started when a process-backed resource command executes.
+/// </summary>
+/// <param name="executablePath">
+/// The executable path or command name to start. Command names are resolved from the AppHost process PATH.
+/// </param>
+[Experimental("ASPIREPROCESSCOMMAND001", UrlFormat = "https://aka.ms/aspire/diagnostics/{0}")]
+public sealed class ProcessCommandSpec(string executablePath)
+{
+    /// <summary>
+    /// Gets the executable path or command name to start.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Command names without directory separators are resolved from the AppHost process PATH before starting the process.
+    /// </para>
+    /// </remarks>
+    public string ExecutablePath { get; } = !string.IsNullOrWhiteSpace(executablePath)
+        ? executablePath
+        : throw new ArgumentException("The executable path cannot be null, empty, or whitespace.", nameof(executablePath));
+
+    /// <summary>
+    /// Gets or sets the working directory for the process.
+    /// </summary>
+    public string? WorkingDirectory { get; init; }
+
+    /// <summary>
+    /// Gets or sets the command-line arguments for the process.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Arguments are passed using <see cref="System.Diagnostics.ProcessStartInfo.ArgumentList"/> so that each item is
+    /// escaped according to the current platform's process-start rules.
+    /// </para>
+    /// </remarks>
+    public IReadOnlyList<string> Arguments { get; init; } = [];
+
+    /// <summary>
+    /// Gets or sets the environment variables to set for the process.
+    /// </summary>
+    public IDictionary<string, string> EnvironmentVariables { get; init; } = new Dictionary<string, string>();
+
+    /// <summary>
+    /// Gets or sets a value indicating whether the process should inherit the current environment variables.
+    /// </summary>
+    public bool InheritEnvironmentVariables { get; init; } = true;
+
+    /// <summary>
+    /// Gets or sets standard input content to write to the process after it starts.
+    /// </summary>
+    public string? StandardInputContent { get; init; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether the entire process tree should be killed when the process is disposed.
+    /// </summary>
+    public bool KillEntireProcessTree { get; init; } = true;
+}

--- a/src/Aspire.Hosting/Dcp/Process/IProcessRunner.cs
+++ b/src/Aspire.Hosting/Dcp/Process/IProcessRunner.cs
@@ -1,0 +1,24 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Aspire.Hosting.Dcp.Process;
+
+/// <summary>
+/// Runs external processes.
+/// </summary>
+internal interface IProcessRunner
+{
+    /// <summary>
+    /// Runs a process with the specified configuration.
+    /// </summary>
+    (Task<ProcessResult>, IAsyncDisposable) Run(ProcessSpec processSpec);
+}
+
+/// <summary>
+/// Runs external processes by delegating to <see cref="ProcessUtil"/>.
+/// </summary>
+internal sealed class DefaultProcessRunner : IProcessRunner
+{
+    public (Task<ProcessResult>, IAsyncDisposable) Run(ProcessSpec processSpec)
+        => ProcessUtil.Run(processSpec);
+}

--- a/src/Aspire.Hosting/Dcp/Process/ProcessSpec.cs
+++ b/src/Aspire.Hosting/Dcp/Process/ProcessSpec.cs
@@ -12,12 +12,14 @@ internal sealed class ProcessSpec
     public IDictionary<string, string> EnvironmentVariables { get; init; } = new Dictionary<string, string>();
     public bool InheritEnv { get; init; } = true;
     public string? Arguments { get; init; }
+    public IReadOnlyList<string>? ArgumentList { get; init; }
     public Action<string>? OnOutputData { get; init; }
     public Action<string>? OnErrorData { get; init; }
     public Action<int>? OnStart { get; init; }
     public Action<int>? OnStop { get; init; }
     public bool KillEntireProcessTree { get; init; } = true;
     public bool ThrowOnNonZeroReturnCode { get; init; } = true;
+    public bool ResolveExecutablePath { get; init; }
     public int? RetainedOutputLineCount { get; init; }
     public string? StandardInputContent { get; init; }
 

--- a/src/Aspire.Hosting/Dcp/Process/ProcessUtil.cs
+++ b/src/Aspire.Hosting/Dcp/Process/ProcessUtil.cs
@@ -20,6 +20,11 @@ internal static partial class ProcessUtil
 
     public static (Task<ProcessResult>, IAsyncDisposable) Run(ProcessSpec processSpec)
     {
+        if (processSpec.Arguments is not null && processSpec.ArgumentList is not null)
+        {
+            throw new InvalidOperationException($"Specify either {nameof(ProcessSpec.Arguments)} or {nameof(ProcessSpec.ArgumentList)}, not both.");
+        }
+
         var retainedOutputLineCount = processSpec.RetainedOutputLineCount ?? (processSpec.ThrowOnNonZeroReturnCode ? ProcessSpec.DefaultRetainedOutputLineCount : 0);
         ArgumentOutOfRangeException.ThrowIfNegative(retainedOutputLineCount);
 
@@ -27,13 +32,17 @@ internal static partial class ProcessUtil
             ? new(retainedOutputLineCount)
             : null;
 
+        var resolvedExecutablePath = processSpec.ResolveExecutablePath
+            ? PathLookupHelper.ResolveExecutablePath(processSpec.ExecutablePath, processSpec.EnvironmentVariables)
+            : processSpec.ExecutablePath;
+
         var process = new System.Diagnostics.Process()
         {
             StartInfo =
             {
-                FileName = processSpec.ExecutablePath,
+                FileName = resolvedExecutablePath,
                 WorkingDirectory = processSpec.WorkingDirectory ?? string.Empty,
-                Arguments = processSpec.Arguments,
+                Arguments = processSpec.Arguments ?? string.Empty,
                 RedirectStandardOutput = true,
                 RedirectStandardError = true,
                 RedirectStandardInput = processSpec.StandardInputContent != null,
@@ -43,6 +52,14 @@ internal static partial class ProcessUtil
             },
             EnableRaisingEvents = true
         };
+
+        if (processSpec.ArgumentList is not null)
+        {
+            foreach (var argument in processSpec.ArgumentList)
+            {
+                process.StartInfo.ArgumentList.Add(argument);
+            }
+        }
 
         if (!processSpec.InheritEnv)
         {
@@ -112,8 +129,12 @@ internal static partial class ProcessUtil
 #endif
 
             process.Start();
-            
-            // Write standard input if provided and ensure it's flushed before closing
+            processSpec.OnStart?.Invoke(process.Id);
+            startupComplete.Set();
+            process.BeginOutputReadLine();
+            process.BeginErrorReadLine();
+
+            // Write standard input after output reads are active so processes can write before reading input.
             if (processSpec.StandardInputContent != null)
             {
                 var writer = process.StandardInput;
@@ -121,10 +142,6 @@ internal static partial class ProcessUtil
                 writer.Flush();
                 writer.Close();
             }
-            
-            process.BeginOutputReadLine();
-            process.BeginErrorReadLine();
-            processSpec.OnStart?.Invoke(process.Id);
 
             _ = Task.Run(async () =>
             {
@@ -212,7 +229,16 @@ internal static partial class ProcessUtil
                 sys_kill(_process.Id, sig: 2); // SIGINT
             }
 
-            await _processLifetimeTask.WaitAsync(s_processExitTimeout).ConfigureAwait(false);
+            try
+            {
+                await _processLifetimeTask.WaitAsync(s_processExitTimeout).ConfigureAwait(false);
+            }
+            catch (TimeoutException) when (!_process.HasExited)
+            {
+                _process.Kill(entireProcessTree: true);
+                await _processLifetimeTask.WaitAsync(s_processExitTimeout).ConfigureAwait(false);
+            }
+
             if (!_process.HasExited)
             {
                 // Always try to kill the entire process tree here if all of the above has failed.

--- a/src/Aspire.Hosting/Dcp/Process/ProcessUtil.cs
+++ b/src/Aspire.Hosting/Dcp/Process/ProcessUtil.cs
@@ -226,7 +226,7 @@ internal static partial class ProcessUtil
             {
                 if (!_process.CloseMainWindow())
                 {
-                    _process.Kill(_entireProcessTree);
+                    Kill(_process, _entireProcessTree);
                 }
             }
             else
@@ -238,16 +238,39 @@ internal static partial class ProcessUtil
             {
                 await _processLifetimeTask.WaitAsync(s_processExitTimeout).ConfigureAwait(false);
             }
-            catch (TimeoutException) when (!_process.HasExited)
+            catch (TimeoutException)
             {
-                _process.Kill(entireProcessTree: true);
-                await _processLifetimeTask.WaitAsync(s_processExitTimeout).ConfigureAwait(false);
+                if (!_process.HasExited)
+                {
+                    Kill(_process, entireProcessTree: true);
+                }
+
+                try
+                {
+                    await _processLifetimeTask.WaitAsync(s_processExitTimeout).ConfigureAwait(false);
+                }
+                catch (TimeoutException)
+                {
+                    // The process may have exited while inherited stdout/stderr pipes are still held open by descendants.
+                    // Do not let cleanup throw and skip the final kill attempt below.
+                }
             }
 
             if (!_process.HasExited)
             {
                 // Always try to kill the entire process tree here if all of the above has failed.
-                _process.Kill(entireProcessTree: true);
+                Kill(_process, entireProcessTree: true);
+            }
+        }
+
+        private static void Kill(System.Diagnostics.Process process, bool entireProcessTree)
+        {
+            try
+            {
+                process.Kill(entireProcessTree);
+            }
+            catch (InvalidOperationException) when (process.HasExited)
+            {
             }
         }
     }

--- a/src/Aspire.Hosting/Dcp/Process/ProcessUtil.cs
+++ b/src/Aspire.Hosting/Dcp/Process/ProcessUtil.cs
@@ -125,7 +125,7 @@ internal static partial class ProcessUtil
         try
         {
 #if ASPIRE_EVENTSOURCE
-            AspireEventSource.Instance.ProcessLaunchStart(processSpec.ExecutablePath, processSpec.Arguments ?? "");
+            AspireEventSource.Instance.ProcessLaunchStart(processSpec.ExecutablePath, FormatProcessArguments(processSpec));
 #endif
 
             process.Start();
@@ -156,7 +156,7 @@ internal static partial class ProcessUtil
 
                     if (processSpec.ThrowOnNonZeroReturnCode && process.ExitCode != 0)
                     {
-                        var message = $"Command {processSpec.ExecutablePath} {processSpec.Arguments} returned non-zero exit code {process.ExitCode}";
+                        var message = $"Command {processSpec.ExecutablePath} {FormatProcessArguments(processSpec)} returned non-zero exit code {process.ExitCode}";
 
                         if (outputCapture?.TotalLineCount > 0)
                         {
@@ -180,11 +180,16 @@ internal static partial class ProcessUtil
         {
             startupComplete.Set(); // Allow output/error/exit handlers to start processing data.
 #if ASPIRE_EVENTSOURCE
-            AspireEventSource.Instance.ProcessLaunchStop(processSpec.ExecutablePath, processSpec.Arguments ?? "");
+            AspireEventSource.Instance.ProcessLaunchStop(processSpec.ExecutablePath, FormatProcessArguments(processSpec));
 #endif
         }
 
         return (processLifetimeTcs.Task, new ProcessDisposable(process, processLifetimeTcs.Task, processSpec.KillEntireProcessTree));
+    }
+
+    private static string FormatProcessArguments(ProcessSpec processSpec)
+    {
+        return processSpec.Arguments ?? string.Join(" ", processSpec.ArgumentList ?? []);
     }
 
     private static ProcessResult CreateProcessResult(int exitCode, ProcessOutputCapture? outputCapture)

--- a/src/Aspire.Hosting/Dcp/Process/ProcessUtil.cs
+++ b/src/Aspire.Hosting/Dcp/Process/ProcessUtil.cs
@@ -3,6 +3,7 @@
 
 using System.Diagnostics;
 using System.Runtime.InteropServices;
+using System.Text;
 using Aspire.Hosting.Utils;
 
 namespace Aspire.Hosting.Dcp.Process;
@@ -22,7 +23,7 @@ internal static partial class ProcessUtil
     {
         if (processSpec.Arguments is not null && processSpec.ArgumentList is not null)
         {
-            throw new InvalidOperationException($"Specify either {nameof(ProcessSpec.Arguments)} or {nameof(ProcessSpec.ArgumentList)}, not both.");
+            throw new ArgumentException($"Specify either {nameof(ProcessSpec.Arguments)} or {nameof(ProcessSpec.ArgumentList)}, not both.", nameof(processSpec));
         }
 
         var retainedOutputLineCount = processSpec.RetainedOutputLineCount ?? (processSpec.ThrowOnNonZeroReturnCode ? ProcessSpec.DefaultRetainedOutputLineCount : 0);
@@ -125,7 +126,7 @@ internal static partial class ProcessUtil
         try
         {
 #if ASPIRE_EVENTSOURCE
-            AspireEventSource.Instance.ProcessLaunchStart(processSpec.ExecutablePath, FormatProcessArguments(processSpec));
+            AspireEventSource.Instance.ProcessLaunchStart(processSpec.ExecutablePath, FormatProcessArgumentsForDisplay(processSpec));
 #endif
 
             process.Start();
@@ -156,7 +157,7 @@ internal static partial class ProcessUtil
 
                     if (processSpec.ThrowOnNonZeroReturnCode && process.ExitCode != 0)
                     {
-                        var message = $"Command {processSpec.ExecutablePath} {FormatProcessArguments(processSpec)} returned non-zero exit code {process.ExitCode}";
+                        var message = $"Command {processSpec.ExecutablePath} {FormatProcessArgumentsForDisplay(processSpec)} returned non-zero exit code {process.ExitCode}";
 
                         if (outputCapture?.TotalLineCount > 0)
                         {
@@ -180,16 +181,59 @@ internal static partial class ProcessUtil
         {
             startupComplete.Set(); // Allow output/error/exit handlers to start processing data.
 #if ASPIRE_EVENTSOURCE
-            AspireEventSource.Instance.ProcessLaunchStop(processSpec.ExecutablePath, FormatProcessArguments(processSpec));
+            AspireEventSource.Instance.ProcessLaunchStop(processSpec.ExecutablePath, FormatProcessArgumentsForDisplay(processSpec));
 #endif
         }
 
         return (processLifetimeTcs.Task, new ProcessDisposable(process, processLifetimeTcs.Task, processSpec.KillEntireProcessTree));
     }
 
-    private static string FormatProcessArguments(ProcessSpec processSpec)
+    private static string FormatProcessArgumentsForDisplay(ProcessSpec processSpec)
     {
-        return processSpec.Arguments ?? string.Join(" ", processSpec.ArgumentList ?? []);
+        return processSpec.Arguments ?? string.Join(" ", processSpec.ArgumentList?.Select(FormatProcessArgumentForDisplay) ?? []);
+    }
+
+    private static string FormatProcessArgumentForDisplay(string argument)
+    {
+        // This string is only for diagnostics and EventSource payloads; ProcessStartInfo.ArgumentList is still what
+        // supplies argv to the child process. Quote values using the same escaping shape expected by Windows command
+        // lines so spaces, quotes, and empty strings are readable instead of ambiguous.
+        // See https://learn.microsoft.com/cpp/c-language/parsing-c-command-line-arguments
+        if (argument.Length > 0 && !argument.Any(static c => char.IsWhiteSpace(c) || c == '"'))
+        {
+            return argument;
+        }
+
+        var builder = new StringBuilder(argument.Length + 2);
+        builder.Append('"');
+
+        var backslashCount = 0;
+        foreach (var c in argument)
+        {
+            if (c == '\\')
+            {
+                backslashCount++;
+                continue;
+            }
+
+            if (c == '"')
+            {
+                builder.Append('\\', backslashCount * 2 + 1);
+                builder.Append('"');
+            }
+            else
+            {
+                builder.Append('\\', backslashCount);
+                builder.Append(c);
+            }
+
+            backslashCount = 0;
+        }
+
+        builder.Append('\\', backslashCount * 2);
+        builder.Append('"');
+
+        return builder.ToString();
     }
 
     private static ProcessResult CreateProcessResult(int exitCode, ProcessOutputCapture? outputCapture)

--- a/src/Aspire.Hosting/DistributedApplicationBuilder.cs
+++ b/src/Aspire.Hosting/DistributedApplicationBuilder.cs
@@ -18,6 +18,7 @@ using Aspire.Hosting.Backchannel;
 using Aspire.Hosting.Cli;
 using Aspire.Hosting.Dashboard;
 using Aspire.Hosting.Dcp;
+using Aspire.Hosting.Dcp.Process;
 using Aspire.Hosting.Devcontainers;
 using Aspire.Hosting.Devcontainers.Codespaces;
 using Aspire.Hosting.Diagnostics;
@@ -355,6 +356,7 @@ public class DistributedApplicationBuilder : IDistributedApplicationBuilder
         _innerBuilder.Services.AddSingleton<ResourceNotificationService>();
         _innerBuilder.Services.AddSingleton<ResourceLoggerService>();
         _innerBuilder.Services.AddSingleton<ResourceCommandService>(s => new ResourceCommandService(s.GetRequiredService<ResourceNotificationService>(), s.GetRequiredService<ResourceLoggerService>(), s));
+        _innerBuilder.Services.TryAddSingleton<IProcessRunner, DefaultProcessRunner>();
 #pragma warning disable ASPIREINTERACTION001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
         _innerBuilder.Services.AddSingleton<InteractionService>();
         _innerBuilder.Services.AddSingleton<IInteractionService>(sp => sp.GetRequiredService<InteractionService>());

--- a/src/Aspire.Hosting/ResourceBuilderExtensions.cs
+++ b/src/Aspire.Hosting/ResourceBuilderExtensions.cs
@@ -2680,6 +2680,12 @@ public static class ResourceBuilderExtensions
     /// </para>
     /// <para>This C# overload is not exported to polyglot app hosts. Use the language-specific static process command API instead.</para>
     /// </remarks>
+    /// <example>
+    /// <code>
+    /// var redis = builder.AddRedis("cache")
+    ///     .WithProcessCommand("dotnet-version", "Show .NET version", "dotnet", ["--version"]);
+    /// </code>
+    /// </example>
     [Experimental("ASPIREPROCESSCOMMAND001", UrlFormat = "https://aka.ms/aspire/diagnostics/{0}")]
     [AspireExportIgnore(Reason = "Process commands start local processes from AppHost callbacks and cannot be represented in polyglot app hosts.")]
     public static IResourceBuilder<TResource> WithProcessCommand<TResource>(
@@ -2728,6 +2734,20 @@ public static class ResourceBuilderExtensions
     /// </para>
     /// <para>This C# callback overload is not available in polyglot app hosts.</para>
     /// </remarks>
+    /// <example>
+    /// <code>
+    /// var redis = builder.AddRedis("cache")
+    ///     .WithProcessCommand(
+    ///         "seed-data",
+    ///         "Seed data",
+    ///         context => new ProcessCommandSpec("dotnet")
+    ///         {
+    ///             Arguments = ["run", "--project", "tools/SeedData", "--", context.Arguments.GetString("dataset") ?? "small"],
+    ///             EnvironmentVariables = { ["ConnectionStrings__db"] = "Host=localhost;Database=db" }
+    ///         },
+    ///         new ProcessCommandOptions { MaxOutputLineCount = 20 });
+    /// </code>
+    /// </example>
     [Experimental("ASPIREPROCESSCOMMAND001", UrlFormat = "https://aka.ms/aspire/diagnostics/{0}")]
     [AspireExportIgnore(Reason = "Process command factories are C# callbacks and cannot be represented in polyglot app hosts.")]
     public static IResourceBuilder<TResource> WithProcessCommand<TResource>(
@@ -2771,6 +2791,19 @@ public static class ResourceBuilderExtensions
     /// </para>
     /// <para>This C# callback overload is not available in polyglot app hosts.</para>
     /// </remarks>
+    /// <example>
+    /// <code>
+    /// var redis = builder.AddRedis("cache")
+    ///     .WithProcessCommand(
+    ///         "seed-data",
+    ///         "Seed data",
+    ///         context => new ValueTask&lt;ProcessCommandSpec&gt;(new ProcessCommandSpec("dotnet")
+    ///         {
+    ///             Arguments = ["run", "--project", "tools/SeedData", "--", context.Arguments.GetString("dataset") ?? "small"],
+    ///             StandardInputContent = "seed"
+    ///         }));
+    /// </code>
+    /// </example>
     [Experimental("ASPIREPROCESSCOMMAND001", UrlFormat = "https://aka.ms/aspire/diagnostics/{0}")]
     [AspireExportIgnore(Reason = "Process command factories are C# callbacks and cannot be represented in polyglot app hosts.")]
     public static IResourceBuilder<TResource> WithProcessCommand<TResource>(

--- a/src/Aspire.Hosting/ResourceBuilderExtensions.cs
+++ b/src/Aspire.Hosting/ResourceBuilderExtensions.cs
@@ -10,6 +10,7 @@ using System.Security.Cryptography.X509Certificates;
 using Aspire.Dashboard.Model;
 using Aspire.Hosting.ApplicationModel;
 using Aspire.Hosting.Ats;
+using Aspire.Hosting.Dcp.Process;
 using Aspire.Hosting.Publishing;
 using Aspire.Hosting.Utils;
 using Microsoft.Extensions.DependencyInjection;
@@ -2657,6 +2658,371 @@ public static class ResourceBuilderExtensions
         _ = new InteractionInputCollection(arguments);
     }
 #pragma warning restore ASPIREINTERACTION001
+
+    #pragma warning disable ASPIREPROCESSCOMMAND001 // Process command APIs are experimental.
+
+    /// <summary>
+    /// Adds a command to the resource that starts a local process when invoked.
+    /// </summary>
+    /// <typeparam name="TResource">The type of the resource.</typeparam>
+    /// <param name="builder">The resource builder.</param>
+    /// <param name="commandName">The name of command. The name uniquely identifies the command.</param>
+    /// <param name="displayName">The display name visible in UI.</param>
+    /// <param name="executablePath">The executable path or command name to start.</param>
+    /// <param name="arguments">The command-line arguments for the process.</param>
+    /// <param name="commandOptions">Optional configuration for the command.</param>
+    /// <returns>The <see cref="IResourceBuilder{T}"/>.</returns>
+    /// <remarks>
+    /// <para>
+    /// The command will be added to the resource represented by <paramref name="builder"/>. When the command executes,
+    /// the process is started inside the AppHost process. Standard output and standard error are streamed to the
+    /// command logger and a bounded tail of the combined output is returned as command result data.
+    /// </para>
+    /// <para>This C# overload is not exported to polyglot app hosts. Use the language-specific static process command API instead.</para>
+    /// </remarks>
+    [Experimental("ASPIREPROCESSCOMMAND001", UrlFormat = "https://aka.ms/aspire/diagnostics/{0}")]
+    [AspireExportIgnore(Reason = "Process commands start local processes from AppHost callbacks and cannot be represented in polyglot app hosts.")]
+    public static IResourceBuilder<TResource> WithProcessCommand<TResource>(
+        this IResourceBuilder<TResource> builder,
+        string commandName,
+        string displayName,
+        string executablePath,
+        IReadOnlyList<string>? arguments = null,
+        ProcessCommandOptions? commandOptions = null)
+        where TResource : IResource
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(executablePath);
+        var processArguments = arguments?.ToArray() ?? [];
+
+        return builder.WithProcessCommand(
+            commandName,
+            displayName,
+            _ => new ProcessCommandSpec(executablePath)
+            {
+                Arguments = processArguments
+            },
+            commandOptions);
+    }
+
+    /// <summary>
+    /// Adds a command to the resource that starts a local process when invoked.
+    /// </summary>
+    /// <typeparam name="TResource">The type of the resource.</typeparam>
+    /// <param name="builder">The resource builder.</param>
+    /// <param name="commandName">The name of command. The name uniquely identifies the command.</param>
+    /// <param name="displayName">The display name visible in UI.</param>
+    /// <param name="processSpecFactory">A callback that creates the local process specification when the command is invoked.</param>
+    /// <param name="commandOptions">Optional configuration for the command.</param>
+    /// <returns>The <see cref="IResourceBuilder{T}"/>.</returns>
+    /// <remarks>
+    /// <para>
+    /// The command will be added to the resource represented by <paramref name="builder"/>. When the command executes,
+    /// <paramref name="processSpecFactory"/> is called inside the AppHost process with the command execution context.
+    /// Use <see cref="ExecuteCommandContext.Arguments"/> to read values supplied by the command caller.
+    /// </para>
+    /// <para>
+    /// Standard output and standard error are streamed to the command logger and a bounded tail of the combined output is
+    /// returned as command result data. Configure <see cref="ProcessCommandOptions.MaxOutputLineCount"/> to control the
+    /// number of returned output lines. Configure <see cref="ProcessCommandOptions.DisplayImmediately"/> to control
+    /// whether returned output opens automatically in the dashboard.
+    /// </para>
+    /// <para>This C# callback overload is not available in polyglot app hosts.</para>
+    /// </remarks>
+    [Experimental("ASPIREPROCESSCOMMAND001", UrlFormat = "https://aka.ms/aspire/diagnostics/{0}")]
+    [AspireExportIgnore(Reason = "Process command factories are C# callbacks and cannot be represented in polyglot app hosts.")]
+    public static IResourceBuilder<TResource> WithProcessCommand<TResource>(
+        this IResourceBuilder<TResource> builder,
+        string commandName,
+        string displayName,
+        Func<ExecuteCommandContext, ProcessCommandSpec> processSpecFactory,
+        ProcessCommandOptions? commandOptions = null)
+        where TResource : IResource
+    {
+        ArgumentNullException.ThrowIfNull(processSpecFactory);
+
+        return builder.WithProcessCommand(
+            commandName,
+            displayName,
+            context => new ValueTask<ProcessCommandSpec>(processSpecFactory(context)),
+            commandOptions);
+    }
+
+    /// <summary>
+    /// Adds a command to the resource that starts a local process when invoked.
+    /// </summary>
+    /// <typeparam name="TResource">The type of the resource.</typeparam>
+    /// <param name="builder">The resource builder.</param>
+    /// <param name="commandName">The name of command. The name uniquely identifies the command.</param>
+    /// <param name="displayName">The display name visible in UI.</param>
+    /// <param name="processSpecFactory">A callback that creates the local process specification when the command is invoked.</param>
+    /// <param name="commandOptions">Optional configuration for the command.</param>
+    /// <returns>The <see cref="IResourceBuilder{T}"/>.</returns>
+    /// <remarks>
+    /// <para>
+    /// The command will be added to the resource represented by <paramref name="builder"/>. When the command executes,
+    /// <paramref name="processSpecFactory"/> is called inside the AppHost process with the command execution context.
+    /// Use <see cref="ExecuteCommandContext.Arguments"/> to read values supplied by the command caller.
+    /// </para>
+    /// <para>
+    /// Standard output and standard error are streamed to the command logger and a bounded tail of the combined output is
+    /// returned as command result data. Configure <see cref="ProcessCommandOptions.MaxOutputLineCount"/> to control the
+    /// number of returned output lines. Configure <see cref="ProcessCommandOptions.DisplayImmediately"/> to control
+    /// whether returned output opens automatically in the dashboard.
+    /// </para>
+    /// <para>This C# callback overload is not available in polyglot app hosts.</para>
+    /// </remarks>
+    [Experimental("ASPIREPROCESSCOMMAND001", UrlFormat = "https://aka.ms/aspire/diagnostics/{0}")]
+    [AspireExportIgnore(Reason = "Process command factories are C# callbacks and cannot be represented in polyglot app hosts.")]
+    public static IResourceBuilder<TResource> WithProcessCommand<TResource>(
+        this IResourceBuilder<TResource> builder,
+        string commandName,
+        string displayName,
+        Func<ExecuteCommandContext, ValueTask<ProcessCommandSpec>> processSpecFactory,
+        ProcessCommandOptions? commandOptions = null)
+        where TResource : IResource
+    {
+        ArgumentNullException.ThrowIfNull(builder);
+        ArgumentNullException.ThrowIfNull(commandName);
+        ArgumentNullException.ThrowIfNull(displayName);
+        ArgumentNullException.ThrowIfNull(processSpecFactory);
+
+        commandOptions ??= ProcessCommandOptions.Default;
+
+        builder.WithCommand(
+            commandName,
+            displayName,
+            async context =>
+            {
+                try
+                {
+                    var processCommandSpec = await processSpecFactory(context).ConfigureAwait(false)
+                        ?? throw new InvalidOperationException("The process command specification factory returned null.");
+
+                    return await ExecuteProcessCommandAsync(context, processCommandSpec, commandOptions).ConfigureAwait(false);
+                }
+                catch (OperationCanceledException)
+                {
+                    return CommandResults.Canceled();
+                }
+                catch (Exception ex)
+                {
+                    return CommandResults.Failure(ex);
+                }
+            },
+            commandOptions);
+
+        return builder;
+    }
+
+    /// <summary>
+    /// Adds a command to the resource that starts a local process when invoked.
+    /// </summary>
+    [Experimental("ASPIREPROCESSCOMMAND001", UrlFormat = "https://aka.ms/aspire/diagnostics/{0}")]
+    [AspireExport("withProcessCommand", Description = "Adds a process resource command")]
+    internal static IResourceBuilder<TResource> WithProcessCommandExport<TResource>(
+        this IResourceBuilder<TResource> builder,
+        string commandName,
+        string displayName,
+        ProcessCommandExportOptions options)
+        where TResource : IResource
+    {
+        ArgumentNullException.ThrowIfNull(options);
+
+        return builder.WithProcessCommand(
+            commandName,
+            displayName,
+            _ => CreateProcessCommandSpec(options),
+            CreateProcessCommandOptions(options));
+    }
+
+    internal static async Task<ExecuteCommandResult> ExecuteProcessCommandAsync(ExecuteCommandContext context, ProcessCommandSpec processCommandSpec, ProcessCommandOptions commandOptions)
+    {
+        var processSpec = CreateProcessSpec(context, processCommandSpec, commandOptions);
+        var processRunner = context.ServiceProvider.GetRequiredService<IProcessRunner>();
+        var (pendingProcessResult, processDisposable) = processRunner.Run(processSpec);
+
+        await using (processDisposable.ConfigureAwait(false))
+        {
+            try
+            {
+                var processResult = await pendingProcessResult.WaitAsync(context.CancellationToken).ConfigureAwait(false);
+                return GetProcessCommandResult(processCommandSpec.ExecutablePath, processResult, commandOptions);
+            }
+            catch (OperationCanceledException) when (context.CancellationToken.IsCancellationRequested)
+            {
+                await processDisposable.DisposeAsync().ConfigureAwait(false);
+                return CommandResults.Canceled();
+            }
+        }
+    }
+
+    private static ProcessCommandOptions CreateProcessCommandOptions(ProcessCommandExportOptions exportOptions)
+    {
+        var commandOptions = new ProcessCommandOptions();
+
+        if (exportOptions.CommandOptions is { } commonOptions)
+        {
+#pragma warning disable ASPIREINTERACTION001 // Process command exports reuse command argument metadata.
+#pragma warning disable CS0618 // Parameter is obsolete but still flowed for command option compatibility.
+            commandOptions.Description = commonOptions.Description;
+            commandOptions.Parameter = commonOptions.Parameter;
+            commandOptions.Arguments = commonOptions.Arguments;
+            commandOptions.ValidateArguments = commonOptions.ValidateArguments;
+            commandOptions.Visibility = commonOptions.Visibility;
+            commandOptions.ConfirmationMessage = commonOptions.ConfirmationMessage;
+            commandOptions.IconName = commonOptions.IconName;
+            commandOptions.IconVariant = commonOptions.IconVariant;
+            commandOptions.IsHighlighted = commonOptions.IsHighlighted;
+            commandOptions.UpdateState = commonOptions.UpdateState;
+#pragma warning restore CS0618
+#pragma warning restore ASPIREINTERACTION001
+        }
+
+        if (exportOptions.MaxOutputLineCount is { } maxOutputLineCount)
+        {
+            if (maxOutputLineCount <= 0)
+            {
+                throw new DistributedApplicationException("Process command output line count must be greater than zero.");
+            }
+
+            commandOptions.MaxOutputLineCount = maxOutputLineCount;
+        }
+
+        if (exportOptions.DisplayImmediately is { } displayImmediately)
+        {
+            commandOptions.DisplayImmediately = displayImmediately;
+        }
+
+        return commandOptions;
+    }
+
+    private static ProcessCommandSpec CreateProcessCommandSpec(ProcessCommandExportOptions exportOptions)
+    {
+        var executablePath = exportOptions.ExecutablePath;
+        if (string.IsNullOrWhiteSpace(executablePath))
+        {
+            throw new DistributedApplicationException("Process command requires a non-empty executable path.");
+        }
+
+        var arguments = exportOptions.Arguments ?? [];
+        foreach (var argument in arguments)
+        {
+            if (argument is null)
+            {
+                throw new DistributedApplicationException("Process command arguments cannot contain null values.");
+            }
+        }
+
+        return new ProcessCommandSpec(executablePath)
+        {
+            WorkingDirectory = exportOptions.WorkingDirectory,
+            Arguments = arguments.ToArray(),
+            EnvironmentVariables = CreateEnvironmentVariables(exportOptions.EnvironmentVariables),
+            InheritEnvironmentVariables = exportOptions.InheritEnvironmentVariables,
+            StandardInputContent = exportOptions.StandardInputContent,
+            KillEntireProcessTree = exportOptions.KillEntireProcessTree
+        };
+    }
+
+    private static Dictionary<string, string> CreateEnvironmentVariables(IReadOnlyList<ProcessCommandEnvironmentVariable>? environmentVariables)
+    {
+        var result = new Dictionary<string, string>(StringComparer.Ordinal);
+        if (environmentVariables is null)
+        {
+            return result;
+        }
+
+        foreach (var environmentVariable in environmentVariables)
+        {
+            if (environmentVariable is null)
+            {
+                throw new DistributedApplicationException("Process command environment variables cannot contain null entries.");
+            }
+
+            if (string.IsNullOrWhiteSpace(environmentVariable.Name))
+            {
+                throw new DistributedApplicationException("Process command environment variables require non-empty names.");
+            }
+
+            if (environmentVariable.Value is null)
+            {
+                throw new DistributedApplicationException($"Process command environment variable '{environmentVariable.Name}' requires a value.");
+            }
+
+            result.Add(environmentVariable.Name, environmentVariable.Value);
+        }
+
+        return result;
+    }
+
+    private static ProcessSpec CreateProcessSpec(ExecuteCommandContext context, ProcessCommandSpec processCommandSpec, ProcessCommandOptions commandOptions)
+    {
+        var arguments = processCommandSpec.Arguments ?? [];
+        foreach (var argument in arguments)
+        {
+            if (argument is null)
+            {
+                throw new DistributedApplicationException($"Process command '{processCommandSpec.ExecutablePath}' arguments cannot contain null values.");
+            }
+        }
+
+        var environmentVariables = processCommandSpec.EnvironmentVariables ?? new Dictionary<string, string>();
+        foreach (var (name, value) in environmentVariables)
+        {
+            if (string.IsNullOrWhiteSpace(name))
+            {
+                throw new DistributedApplicationException($"Process command '{processCommandSpec.ExecutablePath}' environment variables require non-empty names.");
+            }
+
+            if (value is null)
+            {
+                throw new DistributedApplicationException($"Process command '{processCommandSpec.ExecutablePath}' environment variable '{name}' requires a value.");
+            }
+        }
+
+        return new ProcessSpec(processCommandSpec.ExecutablePath)
+        {
+            WorkingDirectory = processCommandSpec.WorkingDirectory,
+            ArgumentList = arguments,
+            EnvironmentVariables = environmentVariables,
+            InheritEnv = processCommandSpec.InheritEnvironmentVariables,
+            StandardInputContent = processCommandSpec.StandardInputContent,
+            KillEntireProcessTree = processCommandSpec.KillEntireProcessTree,
+            ThrowOnNonZeroReturnCode = false,
+            ResolveExecutablePath = true,
+            RetainedOutputLineCount = commandOptions.MaxOutputLineCount,
+            OnOutputData = output => context.Logger.LogInformation("{ExecutablePath} (stdout): {Output}", processCommandSpec.ExecutablePath, output),
+            OnErrorData = error => context.Logger.LogInformation("{ExecutablePath} (stderr): {Error}", processCommandSpec.ExecutablePath, error)
+        };
+    }
+
+    internal static ExecuteCommandResult GetProcessCommandResult(string executablePath, ProcessResult processResult, ProcessCommandOptions commandOptions)
+    {
+        var formattedOutput = processResult.GetFormattedOutput(commandOptions.MaxOutputLineCount);
+        var resultData = string.IsNullOrEmpty(formattedOutput)
+            ? null
+            : new CommandResultData
+            {
+                Value = formattedOutput,
+                Format = CommandResultFormat.Text,
+                DisplayImmediately = commandOptions.DisplayImmediately
+            };
+
+        if (processResult.ExitCode == 0)
+        {
+            return resultData is null
+                ? CommandResults.Success()
+                : new ExecuteCommandResult { Success = true, Data = resultData };
+        }
+
+        var message = $"Command '{executablePath}' returned non-zero exit code {processResult.ExitCode}.";
+
+        return resultData is null
+            ? CommandResults.Failure(message)
+            : CommandResults.Failure(message, resultData);
+    }
+
+    #pragma warning restore ASPIREPROCESSCOMMAND001
 
     /// <summary>
     /// Adds a command to the resource that when invoked sends an HTTP request to the specified endpoint and path.

--- a/src/Aspire.Hosting/ResourceBuilderExtensions.cs
+++ b/src/Aspire.Hosting/ResourceBuilderExtensions.cs
@@ -2956,7 +2956,7 @@ public static class ResourceBuilderExtensions
         };
     }
 
-    private static Dictionary<string, string> CreateEnvironmentVariables(IReadOnlyList<ProcessCommandEnvironmentVariable>? environmentVariables)
+    private static Dictionary<string, string> CreateEnvironmentVariables(IReadOnlyDictionary<string, string>? environmentVariables)
     {
         var result = new Dictionary<string, string>(StringComparer.Ordinal);
         if (environmentVariables is null)
@@ -2964,24 +2964,19 @@ public static class ResourceBuilderExtensions
             return result;
         }
 
-        foreach (var environmentVariable in environmentVariables)
+        foreach (var (name, value) in environmentVariables)
         {
-            if (environmentVariable is null)
-            {
-                throw new DistributedApplicationException("Process command environment variables cannot contain null entries.");
-            }
-
-            if (string.IsNullOrWhiteSpace(environmentVariable.Name))
+            if (string.IsNullOrWhiteSpace(name))
             {
                 throw new DistributedApplicationException("Process command environment variables require non-empty names.");
             }
 
-            if (environmentVariable.Value is null)
+            if (value is null)
             {
-                throw new DistributedApplicationException($"Process command environment variable '{environmentVariable.Name}' requires a value.");
+                throw new DistributedApplicationException($"Process command environment variable '{name}' requires a value.");
             }
 
-            result.Add(environmentVariable.Name, environmentVariable.Value);
+            result.Add(name, value);
         }
 
         return result;

--- a/src/Aspire.Hosting/ResourceBuilderExtensions.cs
+++ b/src/Aspire.Hosting/ResourceBuilderExtensions.cs
@@ -2883,7 +2883,6 @@ public static class ResourceBuilderExtensions
             }
             catch (OperationCanceledException) when (context.CancellationToken.IsCancellationRequested)
             {
-                await processDisposable.DisposeAsync().ConfigureAwait(false);
                 return CommandResults.Canceled();
             }
         }
@@ -2951,9 +2950,9 @@ public static class ResourceBuilderExtensions
             WorkingDirectory = exportOptions.WorkingDirectory,
             Arguments = arguments.ToArray(),
             EnvironmentVariables = CreateEnvironmentVariables(exportOptions.EnvironmentVariables),
-            InheritEnvironmentVariables = exportOptions.InheritEnvironmentVariables,
+            InheritEnvironmentVariables = exportOptions.InheritEnvironmentVariables ?? true,
             StandardInputContent = exportOptions.StandardInputContent,
-            KillEntireProcessTree = exportOptions.KillEntireProcessTree
+            KillEntireProcessTree = exportOptions.KillEntireProcessTree ?? true
         };
     }
 

--- a/src/Aspire.Hosting/ResourceBuilderExtensions.cs
+++ b/src/Aspire.Hosting/ResourceBuilderExtensions.cs
@@ -2727,10 +2727,12 @@ public static class ResourceBuilderExtensions
     /// Use <see cref="ExecuteCommandContext.Arguments"/> to read values supplied by the command caller.
     /// </para>
     /// <para>
-    /// Standard output and standard error are streamed to the command logger and a bounded tail of the combined output is
-    /// returned as command result data. Configure <see cref="ProcessCommandOptions.MaxOutputLineCount"/> to control the
-    /// number of returned output lines. Configure <see cref="ProcessCommandOptions.DisplayImmediately"/> to control
-    /// whether returned output opens automatically in the dashboard.
+    /// Standard output and standard error are streamed to the command logger at <see cref="LogLevel.Debug"/> and a bounded tail
+    /// of the combined output is returned as command result data. Configure <see cref="ProcessCommandOptions.SuccessExitCodes"/>
+    /// to control which exit codes are treated as success. Configure <see cref="ProcessCommandOptions.MaxOutputLineCount"/>
+    /// to control the number of returned output lines. Configure <see cref="ProcessCommandOptions.DisplayImmediately"/> to
+    /// control whether returned output opens automatically in the dashboard. Configure <see cref="ProcessCommandOptions.GetCommandResult"/>
+    /// to create a custom command result from the process exit code and output.
     /// </para>
     /// <para>This C# callback overload is not available in polyglot app hosts.</para>
     /// </remarks>
@@ -2784,10 +2786,12 @@ public static class ResourceBuilderExtensions
     /// Use <see cref="ExecuteCommandContext.Arguments"/> to read values supplied by the command caller.
     /// </para>
     /// <para>
-    /// Standard output and standard error are streamed to the command logger and a bounded tail of the combined output is
-    /// returned as command result data. Configure <see cref="ProcessCommandOptions.MaxOutputLineCount"/> to control the
-    /// number of returned output lines. Configure <see cref="ProcessCommandOptions.DisplayImmediately"/> to control
-    /// whether returned output opens automatically in the dashboard.
+    /// Standard output and standard error are streamed to the command logger at <see cref="LogLevel.Debug"/> and a bounded tail
+    /// of the combined output is returned as command result data. Configure <see cref="ProcessCommandOptions.SuccessExitCodes"/>
+    /// to control which exit codes are treated as success. Configure <see cref="ProcessCommandOptions.MaxOutputLineCount"/>
+    /// to control the number of returned output lines. Configure <see cref="ProcessCommandOptions.DisplayImmediately"/> to
+    /// control whether returned output opens automatically in the dashboard. Configure <see cref="ProcessCommandOptions.GetCommandResult"/>
+    /// to create a custom command result from the process exit code and output.
     /// </para>
     /// <para>This C# callback overload is not available in polyglot app hosts.</para>
     /// </remarks>
@@ -2879,7 +2883,7 @@ public static class ResourceBuilderExtensions
             try
             {
                 var processResult = await pendingProcessResult.WaitAsync(context.CancellationToken).ConfigureAwait(false);
-                return GetProcessCommandResult(processCommandSpec.ExecutablePath, processResult, commandOptions);
+                return await GetProcessCommandResultAsync(context, processCommandSpec, processResult, commandOptions).ConfigureAwait(false);
             }
             catch (OperationCanceledException) when (context.CancellationToken.IsCancellationRequested)
             {
@@ -2923,6 +2927,13 @@ public static class ResourceBuilderExtensions
         if (exportOptions.DisplayImmediately is { } displayImmediately)
         {
             commandOptions.DisplayImmediately = displayImmediately;
+        }
+
+        // Some generated clients serialize default collection values as empty arrays. Treat an empty exported list as
+        // omitted so those clients preserve the default [0] success code.
+        if (exportOptions.SuccessExitCodes is { Count: > 0 } successExitCodes)
+        {
+            commandOptions.SuccessExitCodes = successExitCodes.ToArray();
         }
 
         return commandOptions;
@@ -3018,12 +3029,34 @@ public static class ResourceBuilderExtensions
             ThrowOnNonZeroReturnCode = false,
             ResolveExecutablePath = true,
             RetainedOutputLineCount = commandOptions.MaxOutputLineCount,
-            OnOutputData = output => context.Logger.LogInformation("{ExecutablePath} (stdout): {Output}", processCommandSpec.ExecutablePath, output),
-            OnErrorData = error => context.Logger.LogInformation("{ExecutablePath} (stderr): {Error}", processCommandSpec.ExecutablePath, error)
+            OnOutputData = output => context.Logger.LogDebug("{ExecutablePath} (stdout): {Output}", processCommandSpec.ExecutablePath, output),
+            OnErrorData = error => context.Logger.LogDebug("{ExecutablePath} (stderr): {Error}", processCommandSpec.ExecutablePath, error)
         };
     }
 
-    internal static ExecuteCommandResult GetProcessCommandResult(string executablePath, ProcessResult processResult, ProcessCommandOptions commandOptions)
+    private static async Task<ExecuteCommandResult> GetProcessCommandResultAsync(ExecuteCommandContext context, ProcessCommandSpec processCommandSpec, ProcessResult processResult, ProcessCommandOptions commandOptions)
+    {
+        if (commandOptions.GetCommandResult is { } getCommandResult)
+        {
+            var resultContext = new ProcessCommandResultContext
+            {
+                ServiceProvider = context.ServiceProvider,
+                ResourceName = context.ResourceName,
+                Logger = context.Logger,
+                CancellationToken = context.CancellationToken,
+                ProcessCommandSpec = processCommandSpec,
+                ExitCode = processResult.ExitCode,
+                Output = processResult.ProcessOutput,
+                TotalOutputLineCount = processResult.TotalProcessOutputLineCount
+            };
+
+            return await getCommandResult(resultContext).ConfigureAwait(false);
+        }
+
+        return GetDefaultProcessCommandResult(processCommandSpec.ExecutablePath, processResult, commandOptions);
+    }
+
+    internal static ExecuteCommandResult GetDefaultProcessCommandResult(string executablePath, ProcessResult processResult, ProcessCommandOptions commandOptions)
     {
         var formattedOutput = processResult.GetFormattedOutput(commandOptions.MaxOutputLineCount);
         var resultData = string.IsNullOrEmpty(formattedOutput)
@@ -3035,14 +3068,20 @@ public static class ResourceBuilderExtensions
                 DisplayImmediately = commandOptions.DisplayImmediately
             };
 
-        if (processResult.ExitCode == 0)
+        var successExitCodes = commandOptions.SuccessExitCodes;
+        if (successExitCodes is null || successExitCodes.Count == 0)
+        {
+            throw new InvalidOperationException("Process command success exit codes must contain at least one value.");
+        }
+
+        if (successExitCodes.Contains(processResult.ExitCode))
         {
             return resultData is null
                 ? CommandResults.Success()
                 : new ExecuteCommandResult { Success = true, Data = resultData };
         }
 
-        var message = $"Command '{executablePath}' returned non-zero exit code {processResult.ExitCode}.";
+        var message = $"Command '{executablePath}' exited with code {processResult.ExitCode}, which is not in the configured success exit codes [{string.Join(", ", successExitCodes)}].";
 
         return resultData is null
             ? CommandResults.Failure(message)

--- a/src/Shared/PathLookupHelper.cs
+++ b/src/Shared/PathLookupHelper.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Collections.Generic;
 using System.Diagnostics;
 
 /// <summary>
@@ -8,6 +9,36 @@ using System.Diagnostics;
 /// </summary>
 internal static class PathLookupHelper
 {
+    /// <summary>
+    /// Resolves an executable path or command name to a full path by searching the system PATH.
+    /// </summary>
+    /// <param name="executablePath">The executable path or command name to resolve.</param>
+    /// <param name="environmentVariables">Optional environment variable overrides to use for lookup.</param>
+    /// <returns>The resolved executable path if found; otherwise, <paramref name="executablePath"/>.</returns>
+    public static string ResolveExecutablePath(string executablePath, IDictionary<string, string>? environmentVariables = null)
+    {
+        Debug.Assert(!string.IsNullOrWhiteSpace(executablePath));
+
+        // Values with a directory/root component are explicit paths (relative, absolute, UNC, drive-relative, etc.).
+        // Do not PATH-search or append PATHEXT here; let Process.Start handle missing files or platform-specific path rules.
+        if (IsExplicitExecutablePath(executablePath))
+        {
+            return executablePath;
+        }
+
+        // The actual PATH walk is shared by FindFullPathFromPath below. This wrapper first computes the
+        // effective PATH/PATHEXT from command-specific environment overrides so lookup matches the child process.
+        var (pathOverride, pathExtensionsOverride) = GetPathLookupEnvironmentVariables(environmentVariables);
+
+        var path = pathOverride ?? Environment.GetEnvironmentVariable("PATH");
+        var pathExtensions = OperatingSystem.IsWindows()
+            ? (pathExtensionsOverride ?? Environment.GetEnvironmentVariable("PATHEXT"))?.Split(';', StringSplitOptions.RemoveEmptyEntries) ?? []
+            : null;
+
+        return FindFullPathFromPath(executablePath, path, Path.PathSeparator, File.Exists, pathExtensions)
+            ?? executablePath;
+    }
+
     /// <summary>
     /// Finds the full path of a command by searching the system PATH.
     /// On Windows, this also searches for executables with common extensions (.exe, .cmd, .bat, etc.).
@@ -72,5 +103,49 @@ internal static class PathLookupHelper
         }
 
         return null;
+    }
+
+    private static bool IsExplicitExecutablePath(string executablePath)
+    {
+        return !string.Equals(Path.GetFileName(executablePath), executablePath, StringComparison.Ordinal)
+            || Path.IsPathRooted(executablePath);
+    }
+
+    private static (string? Path, string? PathExtensions) GetPathLookupEnvironmentVariables(IDictionary<string, string>? environmentVariables)
+    {
+        if (environmentVariables is null)
+        {
+            return default;
+        }
+
+        var hasPath = environmentVariables.TryGetValue("PATH", out var path);
+        string? pathExtensions = null;
+        var hasPathExtensions = OperatingSystem.IsWindows() && environmentVariables.TryGetValue("PATHEXT", out pathExtensions);
+
+        // Environment variables are case-insensitive on Windows and case-sensitive on Unix-like systems.
+        // Scan once for both PATH and PATHEXT casing variants instead of scanning once per variable.
+        if (OperatingSystem.IsWindows() && (!hasPath || !hasPathExtensions))
+        {
+            foreach (var (key, environmentValue) in environmentVariables)
+            {
+                if (!hasPath && string.Equals(key, "PATH", StringComparison.OrdinalIgnoreCase))
+                {
+                    path = environmentValue;
+                    hasPath = true;
+                }
+                else if (!hasPathExtensions && string.Equals(key, "PATHEXT", StringComparison.OrdinalIgnoreCase))
+                {
+                    pathExtensions = environmentValue;
+                    hasPathExtensions = true;
+                }
+
+                if (hasPath && hasPathExtensions)
+                {
+                    break;
+                }
+            }
+        }
+
+        return (path, pathExtensions);
     }
 }

--- a/src/Shared/PathLookupHelper.cs
+++ b/src/Shared/PathLookupHelper.cs
@@ -14,7 +14,8 @@ internal static class PathLookupHelper
     /// </summary>
     /// <param name="executablePath">The executable path or command name to resolve.</param>
     /// <param name="environmentVariables">Optional environment variable overrides to use for lookup.</param>
-    /// <returns>The resolved executable path if found; otherwise, <paramref name="executablePath"/>.</returns>
+    /// <returns>The resolved executable path if found; otherwise, <paramref name="executablePath"/> when it is an explicit path.</returns>
+    /// <exception cref="FileNotFoundException">Thrown when <paramref name="executablePath"/> is a command name that is not found on PATH.</exception>
     public static string ResolveExecutablePath(string executablePath, IDictionary<string, string>? environmentVariables = null)
     {
         Debug.Assert(!string.IsNullOrWhiteSpace(executablePath));
@@ -35,8 +36,12 @@ internal static class PathLookupHelper
             ? (pathExtensionsOverride ?? Environment.GetEnvironmentVariable("PATHEXT"))?.Split(';', StringSplitOptions.RemoveEmptyEntries) ?? []
             : null;
 
-        return FindFullPathFromPath(executablePath, path, Path.PathSeparator, File.Exists, pathExtensions)
-            ?? executablePath;
+        // Non-explicit command names must resolve through the effective PATH before Process.Start sees them. On Windows,
+        // CreateProcessW also searches the AppHost executable directory and current directory for bare names, which would
+        // bypass the intended PATH-only lookup if we returned the original name on miss.
+        // See https://learn.microsoft.com/windows/win32/api/processthreadsapi/nf-processthreadsapi-createprocessw
+        return FindFullPathFromPath(executablePath, path, Path.PathSeparator, FileExistsAndIsExecutable, pathExtensions)
+            ?? throw new FileNotFoundException($"Executable '{executablePath}' was not found on PATH.", executablePath);
     }
 
     /// <summary>
@@ -51,7 +56,7 @@ internal static class PathLookupHelper
             ? Environment.GetEnvironmentVariable("PATHEXT")?.Split(';', StringSplitOptions.RemoveEmptyEntries) ?? []
             : null;
 
-        return FindFullPathFromPath(command, Environment.GetEnvironmentVariable("PATH"), Path.PathSeparator, File.Exists, pathExtensions);
+        return FindFullPathFromPath(command, Environment.GetEnvironmentVariable("PATH"), Path.PathSeparator, FileExistsAndIsExecutable, pathExtensions);
     }
 
     /// <summary>
@@ -109,6 +114,35 @@ internal static class PathLookupHelper
     {
         return !string.Equals(Path.GetFileName(executablePath), executablePath, StringComparison.Ordinal)
             || Path.IsPathRooted(executablePath);
+    }
+
+    private static bool FileExistsAndIsExecutable(string path)
+    {
+        if (!File.Exists(path))
+        {
+            return false;
+        }
+
+        if (OperatingSystem.IsWindows())
+        {
+            return true;
+        }
+
+        try
+        {
+            // Match Unix command lookup behavior by skipping PATH entries that exist but have no execute bit set.
+            const UnixFileMode ExecuteBits = UnixFileMode.UserExecute | UnixFileMode.GroupExecute | UnixFileMode.OtherExecute;
+
+            return (File.GetUnixFileMode(path) & ExecuteBits) != 0;
+        }
+        catch (IOException)
+        {
+            return false;
+        }
+        catch (UnauthorizedAccessException)
+        {
+            return false;
+        }
     }
 
     private static (string? Path, string? PathExtensions) GetPathLookupEnvironmentVariables(IDictionary<string, string>? environmentVariables)

--- a/tests/Aspire.Hosting.CodeGeneration.Go.Tests/Snapshots/TwoPassScanningGeneratedAspire.verified.go
+++ b/tests/Aspire.Hosting.CodeGeneration.Go.Tests/Snapshots/TwoPassScanningGeneratedAspire.verified.go
@@ -509,6 +509,50 @@ func (d *GenerateParameterDefault) ToMap() map[string]any {
 	return m
 }
 
+// ProcessCommandExportOptions represents ProcessCommandExportOptions.
+type ProcessCommandExportOptions struct {
+	ExecutablePath string `json:"ExecutablePath,omitempty"`
+	Arguments []string `json:"Arguments,omitempty"`
+	WorkingDirectory string `json:"WorkingDirectory,omitempty"`
+	EnvironmentVariables []*ProcessCommandEnvironmentVariable `json:"EnvironmentVariables,omitempty"`
+	InheritEnvironmentVariables bool `json:"InheritEnvironmentVariables,omitempty"`
+	StandardInputContent string `json:"StandardInputContent,omitempty"`
+	KillEntireProcessTree bool `json:"KillEntireProcessTree,omitempty"`
+	CommandOptions *CommandOptions `json:"CommandOptions,omitempty"`
+	MaxOutputLineCount float64 `json:"MaxOutputLineCount,omitempty"`
+	DisplayImmediately bool `json:"DisplayImmediately,omitempty"`
+}
+
+// ToMap converts the DTO to a map for JSON serialization.
+func (d *ProcessCommandExportOptions) ToMap() map[string]any {
+	m := map[string]any{}
+	m["ExecutablePath"] = serializeValue(d.ExecutablePath)
+	if d.Arguments != nil { m["Arguments"] = serializeValue(d.Arguments) }
+	m["WorkingDirectory"] = serializeValue(d.WorkingDirectory)
+	if d.EnvironmentVariables != nil { m["EnvironmentVariables"] = serializeValue(d.EnvironmentVariables) }
+	m["InheritEnvironmentVariables"] = serializeValue(d.InheritEnvironmentVariables)
+	m["StandardInputContent"] = serializeValue(d.StandardInputContent)
+	m["KillEntireProcessTree"] = serializeValue(d.KillEntireProcessTree)
+	if d.CommandOptions != nil { m["CommandOptions"] = serializeValue(d.CommandOptions) }
+	m["MaxOutputLineCount"] = serializeValue(d.MaxOutputLineCount)
+	m["DisplayImmediately"] = serializeValue(d.DisplayImmediately)
+	return m
+}
+
+// ProcessCommandEnvironmentVariable represents ProcessCommandEnvironmentVariable.
+type ProcessCommandEnvironmentVariable struct {
+	Name string `json:"Name,omitempty"`
+	Value string `json:"Value,omitempty"`
+}
+
+// ToMap converts the DTO to a map for JSON serialization.
+func (d *ProcessCommandEnvironmentVariable) ToMap() map[string]any {
+	m := map[string]any{}
+	m["Name"] = serializeValue(d.Name)
+	m["Value"] = serializeValue(d.Value)
+	return m
+}
+
 // ExecuteCommandResult represents ExecuteCommandResult.
 type ExecuteCommandResult struct {
 	Success bool `json:"Success,omitempty"`
@@ -938,6 +982,7 @@ type Aspire_Hosting_CodeGeneration_Go_TestsTestVaultResource interface {
 	WithParentRelationship(parent Resource) Aspire_Hosting_CodeGeneration_Go_TestsTestVaultResource
 	WithPipelineConfiguration(callback func(obj PipelineConfigurationContext)) Aspire_Hosting_CodeGeneration_Go_TestsTestVaultResource
 	WithPipelineStepFactory(stepName string, callback func(arg PipelineStepContext), options ...*WithPipelineStepFactoryOptions) Aspire_Hosting_CodeGeneration_Go_TestsTestVaultResource
+	WithProcessCommand(commandName string, displayName string, options *ProcessCommandExportOptions) Aspire_Hosting_CodeGeneration_Go_TestsTestVaultResource
 	WithReference(source any, options ...*WithReferenceOptions) Aspire_Hosting_CodeGeneration_Go_TestsTestVaultResource
 	WithReferenceEnvironment(options *ReferenceEnvironmentInjectionOptions) Aspire_Hosting_CodeGeneration_Go_TestsTestVaultResource
 	WithRelationship(resourceBuilder Resource, type_ string) Aspire_Hosting_CodeGeneration_Go_TestsTestVaultResource
@@ -2341,6 +2386,20 @@ func (s *aspire_Hosting_CodeGeneration_Go_TestsTestVaultResource) WithPipelineSt
 	return s
 }
 
+// WithProcessCommand adds a process resource command
+func (s *aspire_Hosting_CodeGeneration_Go_TestsTestVaultResource) WithProcessCommand(commandName string, displayName string, options *ProcessCommandExportOptions) Aspire_Hosting_CodeGeneration_Go_TestsTestVaultResource {
+	if s.err != nil { return s }
+	ctx := context.Background()
+	reqArgs := map[string]any{
+		"builder": s.handle.ToJSON(),
+	}
+	reqArgs["commandName"] = serializeValue(commandName)
+	reqArgs["displayName"] = serializeValue(displayName)
+	if options != nil { reqArgs["options"] = serializeValue(options) }
+	if _, err := s.client.invokeCapability(ctx, "Aspire.Hosting/withProcessCommand", reqArgs); err != nil { s.setErr(err) }
+	return s
+}
+
 // WithReference adds a reference to another resource
 // Allowed types for parameter source: Resource, EndpointReference, string.
 func (s *aspire_Hosting_CodeGeneration_Go_TestsTestVaultResource) WithReference(source any, options ...*WithReferenceOptions) Aspire_Hosting_CodeGeneration_Go_TestsTestVaultResource {
@@ -2776,6 +2835,7 @@ type CSharpAppResource interface {
 	WithParentRelationship(parent Resource) CSharpAppResource
 	WithPipelineConfiguration(callback func(obj PipelineConfigurationContext)) CSharpAppResource
 	WithPipelineStepFactory(stepName string, callback func(arg PipelineStepContext), options ...*WithPipelineStepFactoryOptions) CSharpAppResource
+	WithProcessCommand(commandName string, displayName string, options *ProcessCommandExportOptions) CSharpAppResource
 	WithReference(source any, options ...*WithReferenceOptions) CSharpAppResource
 	WithReferenceEnvironment(options *ReferenceEnvironmentInjectionOptions) CSharpAppResource
 	WithRelationship(resourceBuilder Resource, type_ string) CSharpAppResource
@@ -3950,6 +4010,20 @@ func (s *cSharpAppResource) WithPipelineStepFactory(stepName string, callback fu
 	return s
 }
 
+// WithProcessCommand adds a process resource command
+func (s *cSharpAppResource) WithProcessCommand(commandName string, displayName string, options *ProcessCommandExportOptions) CSharpAppResource {
+	if s.err != nil { return s }
+	ctx := context.Background()
+	reqArgs := map[string]any{
+		"builder": s.handle.ToJSON(),
+	}
+	reqArgs["commandName"] = serializeValue(commandName)
+	reqArgs["displayName"] = serializeValue(displayName)
+	if options != nil { reqArgs["options"] = serializeValue(options) }
+	if _, err := s.client.invokeCapability(ctx, "Aspire.Hosting/withProcessCommand", reqArgs); err != nil { s.setErr(err) }
+	return s
+}
+
 // WithReference adds a reference to another resource
 // Allowed types for parameter source: Resource, EndpointReference, string.
 func (s *cSharpAppResource) WithReference(source any, options ...*WithReferenceOptions) CSharpAppResource {
@@ -4703,6 +4777,7 @@ type ContainerRegistryResource interface {
 	WithParentRelationship(parent Resource) ContainerRegistryResource
 	WithPipelineConfiguration(callback func(obj PipelineConfigurationContext)) ContainerRegistryResource
 	WithPipelineStepFactory(stepName string, callback func(arg PipelineStepContext), options ...*WithPipelineStepFactoryOptions) ContainerRegistryResource
+	WithProcessCommand(commandName string, displayName string, options *ProcessCommandExportOptions) ContainerRegistryResource
 	WithRelationship(resourceBuilder Resource, type_ string) ContainerRegistryResource
 	WithRequiredCommand(command string, options ...*WithRequiredCommandOptions) ContainerRegistryResource
 	WithStatus(status TestResourceStatus) ContainerRegistryResource
@@ -5311,6 +5386,20 @@ func (s *containerRegistryResource) WithPipelineStepFactory(stepName string, cal
 	return s
 }
 
+// WithProcessCommand adds a process resource command
+func (s *containerRegistryResource) WithProcessCommand(commandName string, displayName string, options *ProcessCommandExportOptions) ContainerRegistryResource {
+	if s.err != nil { return s }
+	ctx := context.Background()
+	reqArgs := map[string]any{
+		"builder": s.handle.ToJSON(),
+	}
+	reqArgs["commandName"] = serializeValue(commandName)
+	reqArgs["displayName"] = serializeValue(displayName)
+	if options != nil { reqArgs["options"] = serializeValue(options) }
+	if _, err := s.client.invokeCapability(ctx, "Aspire.Hosting/withProcessCommand", reqArgs); err != nil { s.setErr(err) }
+	return s
+}
+
 // WithRelationship adds a relationship to another resource
 func (s *containerRegistryResource) WithRelationship(resourceBuilder Resource, type_ string) ContainerRegistryResource {
 	if s.err != nil { return s }
@@ -5548,6 +5637,7 @@ type ContainerResource interface {
 	WithParentRelationship(parent Resource) ContainerResource
 	WithPipelineConfiguration(callback func(obj PipelineConfigurationContext)) ContainerResource
 	WithPipelineStepFactory(stepName string, callback func(arg PipelineStepContext), options ...*WithPipelineStepFactoryOptions) ContainerResource
+	WithProcessCommand(commandName string, displayName string, options *ProcessCommandExportOptions) ContainerResource
 	WithReference(source any, options ...*WithReferenceOptions) ContainerResource
 	WithReferenceEnvironment(options *ReferenceEnvironmentInjectionOptions) ContainerResource
 	WithRelationship(resourceBuilder Resource, type_ string) ContainerResource
@@ -6947,6 +7037,20 @@ func (s *containerResource) WithPipelineStepFactory(stepName string, callback fu
 		for k, v := range merged.ToMap() { reqArgs[k] = v }
 	}
 	if _, err := s.client.invokeCapability(ctx, "Aspire.Hosting/withPipelineStepFactory", reqArgs); err != nil { s.setErr(err) }
+	return s
+}
+
+// WithProcessCommand adds a process resource command
+func (s *containerResource) WithProcessCommand(commandName string, displayName string, options *ProcessCommandExportOptions) ContainerResource {
+	if s.err != nil { return s }
+	ctx := context.Background()
+	reqArgs := map[string]any{
+		"builder": s.handle.ToJSON(),
+	}
+	reqArgs["commandName"] = serializeValue(commandName)
+	reqArgs["displayName"] = serializeValue(displayName)
+	if options != nil { reqArgs["options"] = serializeValue(options) }
+	if _, err := s.client.invokeCapability(ctx, "Aspire.Hosting/withProcessCommand", reqArgs); err != nil { s.setErr(err) }
 	return s
 }
 
@@ -8702,6 +8806,7 @@ type DotnetToolResource interface {
 	WithParentRelationship(parent Resource) DotnetToolResource
 	WithPipelineConfiguration(callback func(obj PipelineConfigurationContext)) DotnetToolResource
 	WithPipelineStepFactory(stepName string, callback func(arg PipelineStepContext), options ...*WithPipelineStepFactoryOptions) DotnetToolResource
+	WithProcessCommand(commandName string, displayName string, options *ProcessCommandExportOptions) DotnetToolResource
 	WithReference(source any, options ...*WithReferenceOptions) DotnetToolResource
 	WithReferenceEnvironment(options *ReferenceEnvironmentInjectionOptions) DotnetToolResource
 	WithRelationship(resourceBuilder Resource, type_ string) DotnetToolResource
@@ -9859,6 +9964,20 @@ func (s *dotnetToolResource) WithPipelineStepFactory(stepName string, callback f
 		for k, v := range merged.ToMap() { reqArgs[k] = v }
 	}
 	if _, err := s.client.invokeCapability(ctx, "Aspire.Hosting/withPipelineStepFactory", reqArgs); err != nil { s.setErr(err) }
+	return s
+}
+
+// WithProcessCommand adds a process resource command
+func (s *dotnetToolResource) WithProcessCommand(commandName string, displayName string, options *ProcessCommandExportOptions) DotnetToolResource {
+	if s.err != nil { return s }
+	ctx := context.Background()
+	reqArgs := map[string]any{
+		"builder": s.handle.ToJSON(),
+	}
+	reqArgs["commandName"] = serializeValue(commandName)
+	reqArgs["displayName"] = serializeValue(displayName)
+	if options != nil { reqArgs["options"] = serializeValue(options) }
+	if _, err := s.client.invokeCapability(ctx, "Aspire.Hosting/withProcessCommand", reqArgs); err != nil { s.setErr(err) }
 	return s
 }
 
@@ -11195,6 +11314,7 @@ type ExecutableResource interface {
 	WithParentRelationship(parent Resource) ExecutableResource
 	WithPipelineConfiguration(callback func(obj PipelineConfigurationContext)) ExecutableResource
 	WithPipelineStepFactory(stepName string, callback func(arg PipelineStepContext), options ...*WithPipelineStepFactoryOptions) ExecutableResource
+	WithProcessCommand(commandName string, displayName string, options *ProcessCommandExportOptions) ExecutableResource
 	WithReference(source any, options ...*WithReferenceOptions) ExecutableResource
 	WithReferenceEnvironment(options *ReferenceEnvironmentInjectionOptions) ExecutableResource
 	WithRelationship(resourceBuilder Resource, type_ string) ExecutableResource
@@ -12349,6 +12469,20 @@ func (s *executableResource) WithPipelineStepFactory(stepName string, callback f
 	return s
 }
 
+// WithProcessCommand adds a process resource command
+func (s *executableResource) WithProcessCommand(commandName string, displayName string, options *ProcessCommandExportOptions) ExecutableResource {
+	if s.err != nil { return s }
+	ctx := context.Background()
+	reqArgs := map[string]any{
+		"builder": s.handle.ToJSON(),
+	}
+	reqArgs["commandName"] = serializeValue(commandName)
+	reqArgs["displayName"] = serializeValue(displayName)
+	if options != nil { reqArgs["options"] = serializeValue(options) }
+	if _, err := s.client.invokeCapability(ctx, "Aspire.Hosting/withProcessCommand", reqArgs); err != nil { s.setErr(err) }
+	return s
+}
+
 // WithReference adds a reference to another resource
 // Allowed types for parameter source: Resource, EndpointReference, string.
 func (s *executableResource) WithReference(source any, options ...*WithReferenceOptions) ExecutableResource {
@@ -12894,6 +13028,7 @@ type ExternalServiceResource interface {
 	WithParentRelationship(parent Resource) ExternalServiceResource
 	WithPipelineConfiguration(callback func(obj PipelineConfigurationContext)) ExternalServiceResource
 	WithPipelineStepFactory(stepName string, callback func(arg PipelineStepContext), options ...*WithPipelineStepFactoryOptions) ExternalServiceResource
+	WithProcessCommand(commandName string, displayName string, options *ProcessCommandExportOptions) ExternalServiceResource
 	WithRelationship(resourceBuilder Resource, type_ string) ExternalServiceResource
 	WithRequiredCommand(command string, options ...*WithRequiredCommandOptions) ExternalServiceResource
 	WithStatus(status TestResourceStatus) ExternalServiceResource
@@ -13517,6 +13652,20 @@ func (s *externalServiceResource) WithPipelineStepFactory(stepName string, callb
 		for k, v := range merged.ToMap() { reqArgs[k] = v }
 	}
 	if _, err := s.client.invokeCapability(ctx, "Aspire.Hosting/withPipelineStepFactory", reqArgs); err != nil { s.setErr(err) }
+	return s
+}
+
+// WithProcessCommand adds a process resource command
+func (s *externalServiceResource) WithProcessCommand(commandName string, displayName string, options *ProcessCommandExportOptions) ExternalServiceResource {
+	if s.err != nil { return s }
+	ctx := context.Background()
+	reqArgs := map[string]any{
+		"builder": s.handle.ToJSON(),
+	}
+	reqArgs["commandName"] = serializeValue(commandName)
+	reqArgs["displayName"] = serializeValue(displayName)
+	if options != nil { reqArgs["options"] = serializeValue(options) }
+	if _, err := s.client.invokeCapability(ctx, "Aspire.Hosting/withProcessCommand", reqArgs); err != nil { s.setErr(err) }
 	return s
 }
 
@@ -14223,6 +14372,7 @@ type ParameterResource interface {
 	WithParentRelationship(parent Resource) ParameterResource
 	WithPipelineConfiguration(callback func(obj PipelineConfigurationContext)) ParameterResource
 	WithPipelineStepFactory(stepName string, callback func(arg PipelineStepContext), options ...*WithPipelineStepFactoryOptions) ParameterResource
+	WithProcessCommand(commandName string, displayName string, options *ProcessCommandExportOptions) ParameterResource
 	WithRelationship(resourceBuilder Resource, type_ string) ParameterResource
 	WithRequiredCommand(command string, options ...*WithRequiredCommandOptions) ParameterResource
 	WithStatus(status TestResourceStatus) ParameterResource
@@ -14847,6 +14997,20 @@ func (s *parameterResource) WithPipelineStepFactory(stepName string, callback fu
 		for k, v := range merged.ToMap() { reqArgs[k] = v }
 	}
 	if _, err := s.client.invokeCapability(ctx, "Aspire.Hosting/withPipelineStepFactory", reqArgs); err != nil { s.setErr(err) }
+	return s
+}
+
+// WithProcessCommand adds a process resource command
+func (s *parameterResource) WithProcessCommand(commandName string, displayName string, options *ProcessCommandExportOptions) ParameterResource {
+	if s.err != nil { return s }
+	ctx := context.Background()
+	reqArgs := map[string]any{
+		"builder": s.handle.ToJSON(),
+	}
+	reqArgs["commandName"] = serializeValue(commandName)
+	reqArgs["displayName"] = serializeValue(displayName)
+	if options != nil { reqArgs["options"] = serializeValue(options) }
+	if _, err := s.client.invokeCapability(ctx, "Aspire.Hosting/withProcessCommand", reqArgs); err != nil { s.setErr(err) }
 	return s
 }
 
@@ -15707,6 +15871,7 @@ type ProjectResource interface {
 	WithParentRelationship(parent Resource) ProjectResource
 	WithPipelineConfiguration(callback func(obj PipelineConfigurationContext)) ProjectResource
 	WithPipelineStepFactory(stepName string, callback func(arg PipelineStepContext), options ...*WithPipelineStepFactoryOptions) ProjectResource
+	WithProcessCommand(commandName string, displayName string, options *ProcessCommandExportOptions) ProjectResource
 	WithReference(source any, options ...*WithReferenceOptions) ProjectResource
 	WithReferenceEnvironment(options *ReferenceEnvironmentInjectionOptions) ProjectResource
 	WithRelationship(resourceBuilder Resource, type_ string) ProjectResource
@@ -16878,6 +17043,20 @@ func (s *projectResource) WithPipelineStepFactory(stepName string, callback func
 		for k, v := range merged.ToMap() { reqArgs[k] = v }
 	}
 	if _, err := s.client.invokeCapability(ctx, "Aspire.Hosting/withPipelineStepFactory", reqArgs); err != nil { s.setErr(err) }
+	return s
+}
+
+// WithProcessCommand adds a process resource command
+func (s *projectResource) WithProcessCommand(commandName string, displayName string, options *ProcessCommandExportOptions) ProjectResource {
+	if s.err != nil { return s }
+	ctx := context.Background()
+	reqArgs := map[string]any{
+		"builder": s.handle.ToJSON(),
+	}
+	reqArgs["commandName"] = serializeValue(commandName)
+	reqArgs["displayName"] = serializeValue(displayName)
+	if options != nil { reqArgs["options"] = serializeValue(options) }
+	if _, err := s.client.invokeCapability(ctx, "Aspire.Hosting/withProcessCommand", reqArgs); err != nil { s.setErr(err) }
 	return s
 }
 
@@ -18575,6 +18754,7 @@ type TestDatabaseResource interface {
 	WithParentRelationship(parent Resource) TestDatabaseResource
 	WithPipelineConfiguration(callback func(obj PipelineConfigurationContext)) TestDatabaseResource
 	WithPipelineStepFactory(stepName string, callback func(arg PipelineStepContext), options ...*WithPipelineStepFactoryOptions) TestDatabaseResource
+	WithProcessCommand(commandName string, displayName string, options *ProcessCommandExportOptions) TestDatabaseResource
 	WithReference(source any, options ...*WithReferenceOptions) TestDatabaseResource
 	WithReferenceEnvironment(options *ReferenceEnvironmentInjectionOptions) TestDatabaseResource
 	WithRelationship(resourceBuilder Resource, type_ string) TestDatabaseResource
@@ -19977,6 +20157,20 @@ func (s *testDatabaseResource) WithPipelineStepFactory(stepName string, callback
 	return s
 }
 
+// WithProcessCommand adds a process resource command
+func (s *testDatabaseResource) WithProcessCommand(commandName string, displayName string, options *ProcessCommandExportOptions) TestDatabaseResource {
+	if s.err != nil { return s }
+	ctx := context.Background()
+	reqArgs := map[string]any{
+		"builder": s.handle.ToJSON(),
+	}
+	reqArgs["commandName"] = serializeValue(commandName)
+	reqArgs["displayName"] = serializeValue(displayName)
+	if options != nil { reqArgs["options"] = serializeValue(options) }
+	if _, err := s.client.invokeCapability(ctx, "Aspire.Hosting/withProcessCommand", reqArgs); err != nil { s.setErr(err) }
+	return s
+}
+
 // WithReference adds a reference to another resource
 // Allowed types for parameter source: Resource, EndpointReference, string.
 func (s *testDatabaseResource) WithReference(source any, options ...*WithReferenceOptions) TestDatabaseResource {
@@ -20483,6 +20677,7 @@ type TestRedisResource interface {
 	WithPersistence(options ...*WithPersistenceOptions) TestRedisResource
 	WithPipelineConfiguration(callback func(obj PipelineConfigurationContext)) TestRedisResource
 	WithPipelineStepFactory(stepName string, callback func(arg PipelineStepContext), options ...*WithPipelineStepFactoryOptions) TestRedisResource
+	WithProcessCommand(commandName string, displayName string, options *ProcessCommandExportOptions) TestRedisResource
 	WithRedisSpecific(option string) TestRedisResource
 	WithReference(source any, options ...*WithReferenceOptions) TestRedisResource
 	WithReferenceEnvironment(options *ReferenceEnvironmentInjectionOptions) TestRedisResource
@@ -22139,6 +22334,20 @@ func (s *testRedisResource) WithPipelineStepFactory(stepName string, callback fu
 		for k, v := range merged.ToMap() { reqArgs[k] = v }
 	}
 	if _, err := s.client.invokeCapability(ctx, "Aspire.Hosting/withPipelineStepFactory", reqArgs); err != nil { s.setErr(err) }
+	return s
+}
+
+// WithProcessCommand adds a process resource command
+func (s *testRedisResource) WithProcessCommand(commandName string, displayName string, options *ProcessCommandExportOptions) TestRedisResource {
+	if s.err != nil { return s }
+	ctx := context.Background()
+	reqArgs := map[string]any{
+		"builder": s.handle.ToJSON(),
+	}
+	reqArgs["commandName"] = serializeValue(commandName)
+	reqArgs["displayName"] = serializeValue(displayName)
+	if options != nil { reqArgs["options"] = serializeValue(options) }
+	if _, err := s.client.invokeCapability(ctx, "Aspire.Hosting/withProcessCommand", reqArgs); err != nil { s.setErr(err) }
 	return s
 }
 

--- a/tests/Aspire.Hosting.CodeGeneration.Go.Tests/Snapshots/TwoPassScanningGeneratedAspire.verified.go
+++ b/tests/Aspire.Hosting.CodeGeneration.Go.Tests/Snapshots/TwoPassScanningGeneratedAspire.verified.go
@@ -514,7 +514,7 @@ type ProcessCommandExportOptions struct {
 	ExecutablePath string `json:"ExecutablePath,omitempty"`
 	Arguments []string `json:"Arguments,omitempty"`
 	WorkingDirectory string `json:"WorkingDirectory,omitempty"`
-	EnvironmentVariables []*ProcessCommandEnvironmentVariable `json:"EnvironmentVariables,omitempty"`
+	EnvironmentVariables map[string]string `json:"EnvironmentVariables,omitempty"`
 	InheritEnvironmentVariables *bool `json:"InheritEnvironmentVariables,omitempty"`
 	StandardInputContent string `json:"StandardInputContent,omitempty"`
 	KillEntireProcessTree *bool `json:"KillEntireProcessTree,omitempty"`
@@ -536,20 +536,6 @@ func (d *ProcessCommandExportOptions) ToMap() map[string]any {
 	if d.CommandOptions != nil { m["CommandOptions"] = serializeValue(d.CommandOptions) }
 	if d.MaxOutputLineCount != nil { m["MaxOutputLineCount"] = serializeValue(d.MaxOutputLineCount) }
 	if d.DisplayImmediately != nil { m["DisplayImmediately"] = serializeValue(d.DisplayImmediately) }
-	return m
-}
-
-// ProcessCommandEnvironmentVariable represents ProcessCommandEnvironmentVariable.
-type ProcessCommandEnvironmentVariable struct {
-	Name string `json:"Name,omitempty"`
-	Value string `json:"Value,omitempty"`
-}
-
-// ToMap converts the DTO to a map for JSON serialization.
-func (d *ProcessCommandEnvironmentVariable) ToMap() map[string]any {
-	m := map[string]any{}
-	m["Name"] = serializeValue(d.Name)
-	m["Value"] = serializeValue(d.Value)
 	return m
 }
 

--- a/tests/Aspire.Hosting.CodeGeneration.Go.Tests/Snapshots/TwoPassScanningGeneratedAspire.verified.go
+++ b/tests/Aspire.Hosting.CodeGeneration.Go.Tests/Snapshots/TwoPassScanningGeneratedAspire.verified.go
@@ -231,7 +231,7 @@ type InteractionInput struct {
 	Placeholder string `json:"Placeholder,omitempty"`
 	AllowCustomChoice bool `json:"AllowCustomChoice,omitempty"`
 	Disabled bool `json:"Disabled,omitempty"`
-	MaxLength float64 `json:"MaxLength,omitempty"`
+	MaxLength *float64 `json:"MaxLength,omitempty"`
 }
 
 // ToMap converts the DTO to a map for JSON serialization.
@@ -249,7 +249,7 @@ func (d *InteractionInput) ToMap() map[string]any {
 	m["Placeholder"] = serializeValue(d.Placeholder)
 	m["AllowCustomChoice"] = serializeValue(d.AllowCustomChoice)
 	m["Disabled"] = serializeValue(d.Disabled)
-	m["MaxLength"] = serializeValue(d.MaxLength)
+	if d.MaxLength != nil { m["MaxLength"] = serializeValue(d.MaxLength) }
 	return m
 }
 
@@ -356,7 +356,7 @@ type ResourceEventDto struct {
 	State string `json:"State,omitempty"`
 	StateStyle string `json:"StateStyle,omitempty"`
 	HealthStatus string `json:"HealthStatus,omitempty"`
-	ExitCode float64 `json:"ExitCode,omitempty"`
+	ExitCode *float64 `json:"ExitCode,omitempty"`
 }
 
 // ToMap converts the DTO to a map for JSON serialization.
@@ -367,7 +367,7 @@ func (d *ResourceEventDto) ToMap() map[string]any {
 	m["State"] = serializeValue(d.State)
 	m["StateStyle"] = serializeValue(d.StateStyle)
 	m["HealthStatus"] = serializeValue(d.HealthStatus)
-	m["ExitCode"] = serializeValue(d.ExitCode)
+	if d.ExitCode != nil { m["ExitCode"] = serializeValue(d.ExitCode) }
 	return m
 }
 
@@ -416,7 +416,7 @@ type CommandOptions struct {
 	Visibility ResourceCommandVisibility `json:"Visibility,omitempty"`
 	ConfirmationMessage string `json:"ConfirmationMessage,omitempty"`
 	IconName string `json:"IconName,omitempty"`
-	IconVariant IconVariant `json:"IconVariant,omitempty"`
+	IconVariant *IconVariant `json:"IconVariant,omitempty"`
 	IsHighlighted bool `json:"IsHighlighted,omitempty"`
 	UpdateState func(...any) any `json:"UpdateState,omitempty"`
 }
@@ -431,7 +431,7 @@ func (d *CommandOptions) ToMap() map[string]any {
 	m["Visibility"] = serializeValue(d.Visibility)
 	m["ConfirmationMessage"] = serializeValue(d.ConfirmationMessage)
 	m["IconName"] = serializeValue(d.IconName)
-	m["IconVariant"] = serializeValue(d.IconVariant)
+	if d.IconVariant != nil { m["IconVariant"] = serializeValue(d.IconVariant) }
 	m["IsHighlighted"] = serializeValue(d.IsHighlighted)
 	if d.UpdateState != nil { m["UpdateState"] = serializeValue(d.UpdateState) }
 	return m
@@ -442,7 +442,7 @@ type HttpCommandExportOptions struct {
 	Description string `json:"Description,omitempty"`
 	ConfirmationMessage string `json:"ConfirmationMessage,omitempty"`
 	IconName string `json:"IconName,omitempty"`
-	IconVariant IconVariant `json:"IconVariant,omitempty"`
+	IconVariant *IconVariant `json:"IconVariant,omitempty"`
 	IsHighlighted bool `json:"IsHighlighted,omitempty"`
 	CommandName string `json:"CommandName,omitempty"`
 	EndpointName string `json:"EndpointName,omitempty"`
@@ -456,7 +456,7 @@ func (d *HttpCommandExportOptions) ToMap() map[string]any {
 	m["Description"] = serializeValue(d.Description)
 	m["ConfirmationMessage"] = serializeValue(d.ConfirmationMessage)
 	m["IconName"] = serializeValue(d.IconName)
-	m["IconVariant"] = serializeValue(d.IconVariant)
+	if d.IconVariant != nil { m["IconVariant"] = serializeValue(d.IconVariant) }
 	m["IsHighlighted"] = serializeValue(d.IsHighlighted)
 	m["CommandName"] = serializeValue(d.CommandName)
 	m["EndpointName"] = serializeValue(d.EndpointName)
@@ -515,12 +515,12 @@ type ProcessCommandExportOptions struct {
 	Arguments []string `json:"Arguments,omitempty"`
 	WorkingDirectory string `json:"WorkingDirectory,omitempty"`
 	EnvironmentVariables []*ProcessCommandEnvironmentVariable `json:"EnvironmentVariables,omitempty"`
-	InheritEnvironmentVariables bool `json:"InheritEnvironmentVariables,omitempty"`
+	InheritEnvironmentVariables *bool `json:"InheritEnvironmentVariables,omitempty"`
 	StandardInputContent string `json:"StandardInputContent,omitempty"`
-	KillEntireProcessTree bool `json:"KillEntireProcessTree,omitempty"`
+	KillEntireProcessTree *bool `json:"KillEntireProcessTree,omitempty"`
 	CommandOptions *CommandOptions `json:"CommandOptions,omitempty"`
-	MaxOutputLineCount float64 `json:"MaxOutputLineCount,omitempty"`
-	DisplayImmediately bool `json:"DisplayImmediately,omitempty"`
+	MaxOutputLineCount *float64 `json:"MaxOutputLineCount,omitempty"`
+	DisplayImmediately *bool `json:"DisplayImmediately,omitempty"`
 }
 
 // ToMap converts the DTO to a map for JSON serialization.
@@ -530,12 +530,12 @@ func (d *ProcessCommandExportOptions) ToMap() map[string]any {
 	if d.Arguments != nil { m["Arguments"] = serializeValue(d.Arguments) }
 	m["WorkingDirectory"] = serializeValue(d.WorkingDirectory)
 	if d.EnvironmentVariables != nil { m["EnvironmentVariables"] = serializeValue(d.EnvironmentVariables) }
-	m["InheritEnvironmentVariables"] = serializeValue(d.InheritEnvironmentVariables)
+	if d.InheritEnvironmentVariables != nil { m["InheritEnvironmentVariables"] = serializeValue(d.InheritEnvironmentVariables) }
 	m["StandardInputContent"] = serializeValue(d.StandardInputContent)
-	m["KillEntireProcessTree"] = serializeValue(d.KillEntireProcessTree)
+	if d.KillEntireProcessTree != nil { m["KillEntireProcessTree"] = serializeValue(d.KillEntireProcessTree) }
 	if d.CommandOptions != nil { m["CommandOptions"] = serializeValue(d.CommandOptions) }
-	m["MaxOutputLineCount"] = serializeValue(d.MaxOutputLineCount)
-	m["DisplayImmediately"] = serializeValue(d.DisplayImmediately)
+	if d.MaxOutputLineCount != nil { m["MaxOutputLineCount"] = serializeValue(d.MaxOutputLineCount) }
+	if d.DisplayImmediately != nil { m["DisplayImmediately"] = serializeValue(d.DisplayImmediately) }
 	return m
 }
 

--- a/tests/Aspire.Hosting.CodeGeneration.Go.Tests/Snapshots/TwoPassScanningGeneratedAspire.verified.go
+++ b/tests/Aspire.Hosting.CodeGeneration.Go.Tests/Snapshots/TwoPassScanningGeneratedAspire.verified.go
@@ -521,6 +521,7 @@ type ProcessCommandExportOptions struct {
 	CommandOptions *CommandOptions `json:"CommandOptions,omitempty"`
 	MaxOutputLineCount *float64 `json:"MaxOutputLineCount,omitempty"`
 	DisplayImmediately *bool `json:"DisplayImmediately,omitempty"`
+	SuccessExitCodes []float64 `json:"SuccessExitCodes,omitempty"`
 }
 
 // ToMap converts the DTO to a map for JSON serialization.
@@ -536,6 +537,7 @@ func (d *ProcessCommandExportOptions) ToMap() map[string]any {
 	if d.CommandOptions != nil { m["CommandOptions"] = serializeValue(d.CommandOptions) }
 	if d.MaxOutputLineCount != nil { m["MaxOutputLineCount"] = serializeValue(d.MaxOutputLineCount) }
 	if d.DisplayImmediately != nil { m["DisplayImmediately"] = serializeValue(d.DisplayImmediately) }
+	if d.SuccessExitCodes != nil { m["SuccessExitCodes"] = serializeValue(d.SuccessExitCodes) }
 	return m
 }
 

--- a/tests/Aspire.Hosting.CodeGeneration.Java.Tests/Snapshots/TwoPassScanningGeneratedAspire.verified.java
+++ b/tests/Aspire.Hosting.CodeGeneration.Java.Tests/Snapshots/TwoPassScanningGeneratedAspire.verified.java
@@ -1,4 +1,4 @@
-// ===== AddContainerOptions.java =====
+﻿// ===== AddContainerOptions.java =====
 // AddContainerOptions.java - GENERATED CODE - DO NOT EDIT
 
 package aspire;
@@ -2247,6 +2247,17 @@ public class CSharpAppResource extends ProjectResource {
         return this;
     }
 
+    /** Adds a process resource command */
+    public CSharpAppResource withProcessCommand(String commandName, String displayName, ProcessCommandExportOptions options) {
+        Map<String, Object> reqArgs = new HashMap<>();
+        reqArgs.put("builder", AspireClient.serializeValue(getHandle()));
+        reqArgs.put("commandName", AspireClient.serializeValue(commandName));
+        reqArgs.put("displayName", AspireClient.serializeValue(displayName));
+        reqArgs.put("options", AspireClient.serializeValue(options));
+        getClient().invokeCapability("Aspire.Hosting/withProcessCommand", reqArgs);
+        return this;
+    }
+
     public CSharpAppResource withHttpCommand(String path, String displayName) {
         return withHttpCommand(path, displayName, null);
     }
@@ -3791,6 +3802,17 @@ public class ContainerRegistryResource extends ResourceBuilderBase {
         return this;
     }
 
+    /** Adds a process resource command */
+    public ContainerRegistryResource withProcessCommand(String commandName, String displayName, ProcessCommandExportOptions options) {
+        Map<String, Object> reqArgs = new HashMap<>();
+        reqArgs.put("builder", AspireClient.serializeValue(getHandle()));
+        reqArgs.put("commandName", AspireClient.serializeValue(commandName));
+        reqArgs.put("displayName", AspireClient.serializeValue(displayName));
+        reqArgs.put("options", AspireClient.serializeValue(options));
+        getClient().invokeCapability("Aspire.Hosting/withProcessCommand", reqArgs);
+        return this;
+    }
+
     /** Adds a relationship to another resource */
     public ContainerRegistryResource withRelationship(IResource resourceBuilder, String type) {
         Map<String, Object> reqArgs = new HashMap<>();
@@ -5242,6 +5264,17 @@ public class ContainerResource extends ResourceBuilderBase {
             reqArgs.put("commandOptions", AspireClient.serializeValue(commandOptions));
         }
         getClient().invokeCapability("Aspire.Hosting/withCommand", reqArgs);
+        return this;
+    }
+
+    /** Adds a process resource command */
+    public ContainerResource withProcessCommand(String commandName, String displayName, ProcessCommandExportOptions options) {
+        Map<String, Object> reqArgs = new HashMap<>();
+        reqArgs.put("builder", AspireClient.serializeValue(getHandle()));
+        reqArgs.put("commandName", AspireClient.serializeValue(commandName));
+        reqArgs.put("displayName", AspireClient.serializeValue(displayName));
+        reqArgs.put("options", AspireClient.serializeValue(options));
+        getClient().invokeCapability("Aspire.Hosting/withProcessCommand", reqArgs);
         return this;
     }
 
@@ -7307,6 +7340,17 @@ public class DotnetToolResource extends ExecutableResource {
         return this;
     }
 
+    /** Adds a process resource command */
+    public DotnetToolResource withProcessCommand(String commandName, String displayName, ProcessCommandExportOptions options) {
+        Map<String, Object> reqArgs = new HashMap<>();
+        reqArgs.put("builder", AspireClient.serializeValue(getHandle()));
+        reqArgs.put("commandName", AspireClient.serializeValue(commandName));
+        reqArgs.put("displayName", AspireClient.serializeValue(displayName));
+        reqArgs.put("options", AspireClient.serializeValue(options));
+        getClient().invokeCapability("Aspire.Hosting/withProcessCommand", reqArgs);
+        return this;
+    }
+
     public DotnetToolResource withHttpCommand(String path, String displayName) {
         return withHttpCommand(path, displayName, null);
     }
@@ -9286,6 +9330,17 @@ public class ExecutableResource extends ResourceBuilderBase {
         return this;
     }
 
+    /** Adds a process resource command */
+    public ExecutableResource withProcessCommand(String commandName, String displayName, ProcessCommandExportOptions options) {
+        Map<String, Object> reqArgs = new HashMap<>();
+        reqArgs.put("builder", AspireClient.serializeValue(getHandle()));
+        reqArgs.put("commandName", AspireClient.serializeValue(commandName));
+        reqArgs.put("displayName", AspireClient.serializeValue(displayName));
+        reqArgs.put("options", AspireClient.serializeValue(options));
+        getClient().invokeCapability("Aspire.Hosting/withProcessCommand", reqArgs);
+        return this;
+    }
+
     public ExecutableResource withHttpCommand(String path, String displayName) {
         return withHttpCommand(path, displayName, null);
     }
@@ -10260,6 +10315,17 @@ public class ExternalServiceResource extends ResourceBuilderBase {
             reqArgs.put("commandOptions", AspireClient.serializeValue(commandOptions));
         }
         getClient().invokeCapability("Aspire.Hosting/withCommand", reqArgs);
+        return this;
+    }
+
+    /** Adds a process resource command */
+    public ExternalServiceResource withProcessCommand(String commandName, String displayName, ProcessCommandExportOptions options) {
+        Map<String, Object> reqArgs = new HashMap<>();
+        reqArgs.put("builder", AspireClient.serializeValue(getHandle()));
+        reqArgs.put("commandName", AspireClient.serializeValue(commandName));
+        reqArgs.put("displayName", AspireClient.serializeValue(displayName));
+        reqArgs.put("options", AspireClient.serializeValue(options));
+        getClient().invokeCapability("Aspire.Hosting/withProcessCommand", reqArgs);
         return this;
     }
 
@@ -13093,6 +13159,17 @@ public class ParameterResource extends ResourceBuilderBase {
         return this;
     }
 
+    /** Adds a process resource command */
+    public ParameterResource withProcessCommand(String commandName, String displayName, ProcessCommandExportOptions options) {
+        Map<String, Object> reqArgs = new HashMap<>();
+        reqArgs.put("builder", AspireClient.serializeValue(getHandle()));
+        reqArgs.put("commandName", AspireClient.serializeValue(commandName));
+        reqArgs.put("displayName", AspireClient.serializeValue(displayName));
+        reqArgs.put("options", AspireClient.serializeValue(options));
+        getClient().invokeCapability("Aspire.Hosting/withProcessCommand", reqArgs);
+        return this;
+    }
+
     /** Adds a relationship to another resource */
     public ParameterResource withRelationship(IResource resourceBuilder, String type) {
         Map<String, Object> reqArgs = new HashMap<>();
@@ -13956,6 +14033,90 @@ public enum ProbeType implements WireValueEnum {
     }
 }
 
+// ===== ProcessCommandEnvironmentVariable.java =====
+// ProcessCommandEnvironmentVariable.java - GENERATED CODE - DO NOT EDIT
+
+package aspire;
+
+import java.util.*;
+import java.util.function.*;
+
+/** ProcessCommandEnvironmentVariable DTO. */
+public class ProcessCommandEnvironmentVariable implements JsonSerializable {
+    private String name;
+    private String value;
+
+    public String getName() { return name; }
+    public void setName(String value) { this.name = value; }
+    public String getValue() { return value; }
+    public void setValue(String value) { this.value = value; }
+
+    public Map<String, Object> toMap() {
+        Map<String, Object> map = new HashMap<>();
+        map.put("Name", AspireClient.serializeValue(name));
+        map.put("Value", AspireClient.serializeValue(value));
+        return map;
+    }
+}
+
+// ===== ProcessCommandExportOptions.java =====
+// ProcessCommandExportOptions.java - GENERATED CODE - DO NOT EDIT
+
+package aspire;
+
+import java.util.*;
+import java.util.function.*;
+
+/** ProcessCommandExportOptions DTO. */
+public class ProcessCommandExportOptions implements JsonSerializable {
+    private String executablePath;
+    private String[] arguments;
+    private String workingDirectory;
+    private ProcessCommandEnvironmentVariable[] environmentVariables;
+    private boolean inheritEnvironmentVariables;
+    private String standardInputContent;
+    private boolean killEntireProcessTree;
+    private CommandOptions commandOptions;
+    private double maxOutputLineCount;
+    private boolean displayImmediately;
+
+    public String getExecutablePath() { return executablePath; }
+    public void setExecutablePath(String value) { this.executablePath = value; }
+    public String[] getArguments() { return arguments; }
+    public void setArguments(String[] value) { this.arguments = value; }
+    public String getWorkingDirectory() { return workingDirectory; }
+    public void setWorkingDirectory(String value) { this.workingDirectory = value; }
+    public ProcessCommandEnvironmentVariable[] getEnvironmentVariables() { return environmentVariables; }
+    public void setEnvironmentVariables(ProcessCommandEnvironmentVariable[] value) { this.environmentVariables = value; }
+    public boolean getInheritEnvironmentVariables() { return inheritEnvironmentVariables; }
+    public void setInheritEnvironmentVariables(boolean value) { this.inheritEnvironmentVariables = value; }
+    public String getStandardInputContent() { return standardInputContent; }
+    public void setStandardInputContent(String value) { this.standardInputContent = value; }
+    public boolean getKillEntireProcessTree() { return killEntireProcessTree; }
+    public void setKillEntireProcessTree(boolean value) { this.killEntireProcessTree = value; }
+    public CommandOptions getCommandOptions() { return commandOptions; }
+    public void setCommandOptions(CommandOptions value) { this.commandOptions = value; }
+    public double getMaxOutputLineCount() { return maxOutputLineCount; }
+    public void setMaxOutputLineCount(double value) { this.maxOutputLineCount = value; }
+    public boolean getDisplayImmediately() { return displayImmediately; }
+    public void setDisplayImmediately(boolean value) { this.displayImmediately = value; }
+
+    public Map<String, Object> toMap() {
+        Map<String, Object> map = new HashMap<>();
+        map.put("ExecutablePath", AspireClient.serializeValue(executablePath));
+        map.put("Arguments", AspireClient.serializeValue(arguments));
+        map.put("WorkingDirectory", AspireClient.serializeValue(workingDirectory));
+        map.put("EnvironmentVariables", AspireClient.serializeValue(environmentVariables));
+        map.put("InheritEnvironmentVariables", AspireClient.serializeValue(inheritEnvironmentVariables));
+        map.put("StandardInputContent", AspireClient.serializeValue(standardInputContent));
+        map.put("KillEntireProcessTree", AspireClient.serializeValue(killEntireProcessTree));
+        map.put("CommandOptions", AspireClient.serializeValue(commandOptions));
+        map.put("MaxOutputLineCount", AspireClient.serializeValue(maxOutputLineCount));
+        map.put("DisplayImmediately", AspireClient.serializeValue(displayImmediately));
+        return map;
+    }
+}
+
 // ===== ProjectResource.java =====
 // ProjectResource.java - GENERATED CODE - DO NOT EDIT
 
@@ -14706,6 +14867,17 @@ public class ProjectResource extends ResourceBuilderBase {
             reqArgs.put("commandOptions", AspireClient.serializeValue(commandOptions));
         }
         getClient().invokeCapability("Aspire.Hosting/withCommand", reqArgs);
+        return this;
+    }
+
+    /** Adds a process resource command */
+    public ProjectResource withProcessCommand(String commandName, String displayName, ProcessCommandExportOptions options) {
+        Map<String, Object> reqArgs = new HashMap<>();
+        reqArgs.put("builder", AspireClient.serializeValue(getHandle()));
+        reqArgs.put("commandName", AspireClient.serializeValue(commandName));
+        reqArgs.put("displayName", AspireClient.serializeValue(displayName));
+        reqArgs.put("options", AspireClient.serializeValue(options));
+        getClient().invokeCapability("Aspire.Hosting/withProcessCommand", reqArgs);
         return this;
     }
 
@@ -17370,6 +17542,17 @@ public class TestDatabaseResource extends ContainerResource {
         return this;
     }
 
+    /** Adds a process resource command */
+    public TestDatabaseResource withProcessCommand(String commandName, String displayName, ProcessCommandExportOptions options) {
+        Map<String, Object> reqArgs = new HashMap<>();
+        reqArgs.put("builder", AspireClient.serializeValue(getHandle()));
+        reqArgs.put("commandName", AspireClient.serializeValue(commandName));
+        reqArgs.put("displayName", AspireClient.serializeValue(displayName));
+        reqArgs.put("options", AspireClient.serializeValue(options));
+        getClient().invokeCapability("Aspire.Hosting/withProcessCommand", reqArgs);
+        return this;
+    }
+
     public TestDatabaseResource withHttpCommand(String path, String displayName) {
         return withHttpCommand(path, displayName, null);
     }
@@ -19253,6 +19436,17 @@ public class TestRedisResource extends ContainerResource {
             reqArgs.put("commandOptions", AspireClient.serializeValue(commandOptions));
         }
         getClient().invokeCapability("Aspire.Hosting/withCommand", reqArgs);
+        return this;
+    }
+
+    /** Adds a process resource command */
+    public TestRedisResource withProcessCommand(String commandName, String displayName, ProcessCommandExportOptions options) {
+        Map<String, Object> reqArgs = new HashMap<>();
+        reqArgs.put("builder", AspireClient.serializeValue(getHandle()));
+        reqArgs.put("commandName", AspireClient.serializeValue(commandName));
+        reqArgs.put("displayName", AspireClient.serializeValue(displayName));
+        reqArgs.put("options", AspireClient.serializeValue(options));
+        getClient().invokeCapability("Aspire.Hosting/withProcessCommand", reqArgs);
         return this;
     }
 
@@ -21183,6 +21377,17 @@ public class TestVaultResource extends ContainerResource {
         return this;
     }
 
+    /** Adds a process resource command */
+    public TestVaultResource withProcessCommand(String commandName, String displayName, ProcessCommandExportOptions options) {
+        Map<String, Object> reqArgs = new HashMap<>();
+        reqArgs.put("builder", AspireClient.serializeValue(getHandle()));
+        reqArgs.put("commandName", AspireClient.serializeValue(commandName));
+        reqArgs.put("displayName", AspireClient.serializeValue(displayName));
+        reqArgs.put("options", AspireClient.serializeValue(options));
+        getClient().invokeCapability("Aspire.Hosting/withProcessCommand", reqArgs);
+        return this;
+    }
+
     public TestVaultResource withHttpCommand(String path, String displayName) {
         return withHttpCommand(path, displayName, null);
     }
@@ -22851,6 +23056,8 @@ public final class WithVolumeOptions {
 .modules/PipelineStepFactoryContext.java
 .modules/PipelineSummary.java
 .modules/ProbeType.java
+.modules/ProcessCommandEnvironmentVariable.java
+.modules/ProcessCommandExportOptions.java
 .modules/ProjectResource.java
 .modules/ProjectResourceOptions.java
 .modules/ProtocolType.java
@@ -22908,4 +23115,3 @@ public final class WithVolumeOptions {
 .modules/WithPipelineStepFactoryOptions.java
 .modules/WithReferenceOptions.java
 .modules/WithVolumeOptions.java
-

--- a/tests/Aspire.Hosting.CodeGeneration.Java.Tests/Snapshots/TwoPassScanningGeneratedAspire.verified.java
+++ b/tests/Aspire.Hosting.CodeGeneration.Java.Tests/Snapshots/TwoPassScanningGeneratedAspire.verified.java
@@ -14033,32 +14033,6 @@ public enum ProbeType implements WireValueEnum {
     }
 }
 
-// ===== ProcessCommandEnvironmentVariable.java =====
-// ProcessCommandEnvironmentVariable.java - GENERATED CODE - DO NOT EDIT
-
-package aspire;
-
-import java.util.*;
-import java.util.function.*;
-
-/** ProcessCommandEnvironmentVariable DTO. */
-public class ProcessCommandEnvironmentVariable implements JsonSerializable {
-    private String name;
-    private String value;
-
-    public String getName() { return name; }
-    public void setName(String value) { this.name = value; }
-    public String getValue() { return value; }
-    public void setValue(String value) { this.value = value; }
-
-    public Map<String, Object> toMap() {
-        Map<String, Object> map = new HashMap<>();
-        map.put("Name", AspireClient.serializeValue(name));
-        map.put("Value", AspireClient.serializeValue(value));
-        return map;
-    }
-}
-
 // ===== ProcessCommandExportOptions.java =====
 // ProcessCommandExportOptions.java - GENERATED CODE - DO NOT EDIT
 
@@ -14072,7 +14046,7 @@ public class ProcessCommandExportOptions implements JsonSerializable {
     private String executablePath;
     private String[] arguments;
     private String workingDirectory;
-    private ProcessCommandEnvironmentVariable[] environmentVariables;
+    private Map<String, String> environmentVariables;
     private Boolean inheritEnvironmentVariables;
     private String standardInputContent;
     private Boolean killEntireProcessTree;
@@ -14086,8 +14060,8 @@ public class ProcessCommandExportOptions implements JsonSerializable {
     public void setArguments(String[] value) { this.arguments = value; }
     public String getWorkingDirectory() { return workingDirectory; }
     public void setWorkingDirectory(String value) { this.workingDirectory = value; }
-    public ProcessCommandEnvironmentVariable[] getEnvironmentVariables() { return environmentVariables; }
-    public void setEnvironmentVariables(ProcessCommandEnvironmentVariable[] value) { this.environmentVariables = value; }
+    public Map<String, String> getEnvironmentVariables() { return environmentVariables; }
+    public void setEnvironmentVariables(Map<String, String> value) { this.environmentVariables = value; }
     public Boolean getInheritEnvironmentVariables() { return inheritEnvironmentVariables; }
     public void setInheritEnvironmentVariables(Boolean value) { this.inheritEnvironmentVariables = value; }
     public String getStandardInputContent() { return standardInputContent; }
@@ -23056,7 +23030,6 @@ public final class WithVolumeOptions {
 .modules/PipelineStepFactoryContext.java
 .modules/PipelineSummary.java
 .modules/ProbeType.java
-.modules/ProcessCommandEnvironmentVariable.java
 .modules/ProcessCommandExportOptions.java
 .modules/ProjectResource.java
 .modules/ProjectResourceOptions.java

--- a/tests/Aspire.Hosting.CodeGeneration.Java.Tests/Snapshots/TwoPassScanningGeneratedAspire.verified.java
+++ b/tests/Aspire.Hosting.CodeGeneration.Java.Tests/Snapshots/TwoPassScanningGeneratedAspire.verified.java
@@ -12803,7 +12803,7 @@ public class InteractionInput implements JsonSerializable {
     private String placeholder;
     private boolean allowCustomChoice;
     private boolean disabled;
-    private double maxLength;
+    private Double maxLength;
 
     public String getName() { return name; }
     public void setName(String value) { this.name = value; }
@@ -12829,8 +12829,8 @@ public class InteractionInput implements JsonSerializable {
     public void setAllowCustomChoice(boolean value) { this.allowCustomChoice = value; }
     public boolean getDisabled() { return disabled; }
     public void setDisabled(boolean value) { this.disabled = value; }
-    public double getMaxLength() { return maxLength; }
-    public void setMaxLength(double value) { this.maxLength = value; }
+    public Double getMaxLength() { return maxLength; }
+    public void setMaxLength(Double value) { this.maxLength = value; }
 
     public Map<String, Object> toMap() {
         Map<String, Object> map = new HashMap<>();
@@ -14073,12 +14073,12 @@ public class ProcessCommandExportOptions implements JsonSerializable {
     private String[] arguments;
     private String workingDirectory;
     private ProcessCommandEnvironmentVariable[] environmentVariables;
-    private boolean inheritEnvironmentVariables;
+    private Boolean inheritEnvironmentVariables;
     private String standardInputContent;
-    private boolean killEntireProcessTree;
+    private Boolean killEntireProcessTree;
     private CommandOptions commandOptions;
-    private double maxOutputLineCount;
-    private boolean displayImmediately;
+    private Double maxOutputLineCount;
+    private Boolean displayImmediately;
 
     public String getExecutablePath() { return executablePath; }
     public void setExecutablePath(String value) { this.executablePath = value; }
@@ -14088,18 +14088,18 @@ public class ProcessCommandExportOptions implements JsonSerializable {
     public void setWorkingDirectory(String value) { this.workingDirectory = value; }
     public ProcessCommandEnvironmentVariable[] getEnvironmentVariables() { return environmentVariables; }
     public void setEnvironmentVariables(ProcessCommandEnvironmentVariable[] value) { this.environmentVariables = value; }
-    public boolean getInheritEnvironmentVariables() { return inheritEnvironmentVariables; }
-    public void setInheritEnvironmentVariables(boolean value) { this.inheritEnvironmentVariables = value; }
+    public Boolean getInheritEnvironmentVariables() { return inheritEnvironmentVariables; }
+    public void setInheritEnvironmentVariables(Boolean value) { this.inheritEnvironmentVariables = value; }
     public String getStandardInputContent() { return standardInputContent; }
     public void setStandardInputContent(String value) { this.standardInputContent = value; }
-    public boolean getKillEntireProcessTree() { return killEntireProcessTree; }
-    public void setKillEntireProcessTree(boolean value) { this.killEntireProcessTree = value; }
+    public Boolean getKillEntireProcessTree() { return killEntireProcessTree; }
+    public void setKillEntireProcessTree(Boolean value) { this.killEntireProcessTree = value; }
     public CommandOptions getCommandOptions() { return commandOptions; }
     public void setCommandOptions(CommandOptions value) { this.commandOptions = value; }
-    public double getMaxOutputLineCount() { return maxOutputLineCount; }
-    public void setMaxOutputLineCount(double value) { this.maxOutputLineCount = value; }
-    public boolean getDisplayImmediately() { return displayImmediately; }
-    public void setDisplayImmediately(boolean value) { this.displayImmediately = value; }
+    public Double getMaxOutputLineCount() { return maxOutputLineCount; }
+    public void setMaxOutputLineCount(Double value) { this.maxOutputLineCount = value; }
+    public Boolean getDisplayImmediately() { return displayImmediately; }
+    public void setDisplayImmediately(Boolean value) { this.displayImmediately = value; }
 
     public Map<String, Object> toMap() {
         Map<String, Object> map = new HashMap<>();
@@ -16057,7 +16057,7 @@ public class ResourceEventDto implements JsonSerializable {
     private String state;
     private String stateStyle;
     private String healthStatus;
-    private double exitCode;
+    private Double exitCode;
 
     public String getResourceName() { return resourceName; }
     public void setResourceName(String value) { this.resourceName = value; }
@@ -16069,8 +16069,8 @@ public class ResourceEventDto implements JsonSerializable {
     public void setStateStyle(String value) { this.stateStyle = value; }
     public String getHealthStatus() { return healthStatus; }
     public void setHealthStatus(String value) { this.healthStatus = value; }
-    public double getExitCode() { return exitCode; }
-    public void setExitCode(double value) { this.exitCode = value; }
+    public Double getExitCode() { return exitCode; }
+    public void setExitCode(Double value) { this.exitCode = value; }
 
     public Map<String, Object> toMap() {
         Map<String, Object> map = new HashMap<>();

--- a/tests/Aspire.Hosting.CodeGeneration.Java.Tests/Snapshots/TwoPassScanningGeneratedAspire.verified.java
+++ b/tests/Aspire.Hosting.CodeGeneration.Java.Tests/Snapshots/TwoPassScanningGeneratedAspire.verified.java
@@ -14053,6 +14053,7 @@ public class ProcessCommandExportOptions implements JsonSerializable {
     private CommandOptions commandOptions;
     private Double maxOutputLineCount;
     private Boolean displayImmediately;
+    private double[] successExitCodes;
 
     public String getExecutablePath() { return executablePath; }
     public void setExecutablePath(String value) { this.executablePath = value; }
@@ -14074,6 +14075,8 @@ public class ProcessCommandExportOptions implements JsonSerializable {
     public void setMaxOutputLineCount(Double value) { this.maxOutputLineCount = value; }
     public Boolean getDisplayImmediately() { return displayImmediately; }
     public void setDisplayImmediately(Boolean value) { this.displayImmediately = value; }
+    public double[] getSuccessExitCodes() { return successExitCodes; }
+    public void setSuccessExitCodes(double[] value) { this.successExitCodes = value; }
 
     public Map<String, Object> toMap() {
         Map<String, Object> map = new HashMap<>();
@@ -14087,6 +14090,7 @@ public class ProcessCommandExportOptions implements JsonSerializable {
         map.put("CommandOptions", AspireClient.serializeValue(commandOptions));
         map.put("MaxOutputLineCount", AspireClient.serializeValue(maxOutputLineCount));
         map.put("DisplayImmediately", AspireClient.serializeValue(displayImmediately));
+        map.put("SuccessExitCodes", AspireClient.serializeValue(successExitCodes));
         return map;
     }
 }

--- a/tests/Aspire.Hosting.CodeGeneration.Python.Tests/Snapshots/TwoPassScanningGeneratedAspire.verified.py
+++ b/tests/Aspire.Hosting.CodeGeneration.Python.Tests/Snapshots/TwoPassScanningGeneratedAspire.verified.py
@@ -1807,15 +1807,11 @@ class InteractionInput(typing.TypedDict, total=False):
     Disabled: bool
     MaxLength: int
 
-class ProcessCommandEnvironmentVariable(typing.TypedDict, total=False):
-    Name: str
-    Value: str
-
 class ProcessCommandExportOptions(typing.TypedDict, total=False):
     ExecutablePath: str
     Arguments: typing.Iterable[str]
     WorkingDirectory: str
-    EnvironmentVariables: typing.Iterable[ProcessCommandEnvironmentVariable]
+    EnvironmentVariables: typing.Mapping[str, str]
     InheritEnvironmentVariables: bool
     StandardInputContent: str
     KillEntireProcessTree: bool

--- a/tests/Aspire.Hosting.CodeGeneration.Python.Tests/Snapshots/TwoPassScanningGeneratedAspire.verified.py
+++ b/tests/Aspire.Hosting.CodeGeneration.Python.Tests/Snapshots/TwoPassScanningGeneratedAspire.verified.py
@@ -1807,6 +1807,22 @@ class InteractionInput(typing.TypedDict, total=False):
     Disabled: bool
     MaxLength: int
 
+class ProcessCommandEnvironmentVariable(typing.TypedDict, total=False):
+    Name: str
+    Value: str
+
+class ProcessCommandExportOptions(typing.TypedDict, total=False):
+    ExecutablePath: str
+    Arguments: typing.Iterable[str]
+    WorkingDirectory: str
+    EnvironmentVariables: typing.Iterable[ProcessCommandEnvironmentVariable]
+    InheritEnvironmentVariables: bool
+    StandardInputContent: str
+    KillEntireProcessTree: bool
+    CommandOptions: CommandOptions
+    MaxOutputLineCount: int
+    DisplayImmediately: bool
+
 class ReferenceEnvironmentInjectionOptions(typing.TypedDict, total=False):
     ConnectionString: bool
     ConnectionProperties: bool
@@ -5699,6 +5715,10 @@ class AbstractResource(abc.ABC):
         """Adds a resource command"""
 
     @abc.abstractmethod
+    def with_process_command(self, command_name: str, display_name: str, options: ProcessCommandExportOptions) -> typing.Self:
+        """Adds a process resource command"""
+
+    @abc.abstractmethod
     def with_relationship(self, resource_builder: AbstractResource, type: str) -> typing.Self:
         """Adds a relationship to another resource"""
 
@@ -6052,6 +6072,7 @@ class _BaseResourceKwargs(typing.TypedDict, total=False):
     explicit_start: typing.Literal[True]
     health_check: str
     command: tuple[str, str, typing.Callable[[ExecuteCommandContext], ExecuteCommandResult]] | CommandParameters
+    process_command: tuple[str, str, ProcessCommandExportOptions]
     relationship: tuple[AbstractResource, str]
     parent_relationship: AbstractResource
     child_relationship: AbstractResource
@@ -6210,6 +6231,19 @@ class _BaseResource(AbstractResource):
             rpc_args['commandOptions'] = command_options
         result = self._client.invoke_capability(
             'Aspire.Hosting/withCommand',
+            rpc_args,
+        )
+        self._handle = self._wrap_builder(result)
+        return self
+
+    def with_process_command(self, command_name: str, display_name: str, options: ProcessCommandExportOptions) -> typing.Self:
+        """Adds a process resource command"""
+        rpc_args: dict[str, typing.Any] = {'builder': self._handle}
+        rpc_args['commandName'] = command_name
+        rpc_args['displayName'] = display_name
+        rpc_args['options'] = options
+        result = self._client.invoke_capability(
+            'Aspire.Hosting/withProcessCommand',
             rpc_args,
         )
         self._handle = self._wrap_builder(result)
@@ -6680,6 +6714,15 @@ class _BaseResource(AbstractResource):
                 handle = self._wrap_builder(client.invoke_capability('Aspire.Hosting/withCommand', rpc_args))
             else:
                 raise TypeError("Invalid type for option 'command'. Expected: (str, str, Callable[[ExecuteCommandContext], ExecuteCommandResult]) or CommandParameters")
+        if _process_command := kwargs.pop("process_command", None):
+            if _validate_tuple_types(_process_command, (str, str, ProcessCommandExportOptions)):
+                rpc_args: dict[str, typing.Any] = {"builder": handle}
+                rpc_args["commandName"] = typing.cast(tuple[str, str, ProcessCommandExportOptions], _process_command)[0]
+                rpc_args["displayName"] = typing.cast(tuple[str, str, ProcessCommandExportOptions], _process_command)[1]
+                rpc_args["options"] = typing.cast(tuple[str, str, ProcessCommandExportOptions], _process_command)[2]
+                handle = self._wrap_builder(client.invoke_capability('Aspire.Hosting/withProcessCommand', rpc_args))
+            else:
+                raise TypeError("Invalid type for option 'process_command'. Expected: (str, str, ProcessCommandExportOptions)")
         if _relationship := kwargs.pop("relationship", None):
             if _validate_tuple_types(_relationship, (AbstractResource, str)):
                 rpc_args: dict[str, typing.Any] = {"builder": handle}

--- a/tests/Aspire.Hosting.CodeGeneration.Python.Tests/Snapshots/TwoPassScanningGeneratedAspire.verified.py
+++ b/tests/Aspire.Hosting.CodeGeneration.Python.Tests/Snapshots/TwoPassScanningGeneratedAspire.verified.py
@@ -1818,6 +1818,7 @@ class ProcessCommandExportOptions(typing.TypedDict, total=False):
     CommandOptions: CommandOptions
     MaxOutputLineCount: int
     DisplayImmediately: bool
+    SuccessExitCodes: typing.Iterable[int]
 
 class ReferenceEnvironmentInjectionOptions(typing.TypedDict, total=False):
     ConnectionString: bool

--- a/tests/Aspire.Hosting.CodeGeneration.Rust.Tests/Snapshots/TwoPassScanningGeneratedAspire.verified.rs
+++ b/tests/Aspire.Hosting.CodeGeneration.Rust.Tests/Snapshots/TwoPassScanningGeneratedAspire.verified.rs
@@ -903,6 +903,66 @@ impl GenerateParameterDefault {
     }
 }
 
+/// ProcessCommandExportOptions
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct ProcessCommandExportOptions {
+    #[serde(rename = "ExecutablePath")]
+    pub executable_path: String,
+    #[serde(rename = "Arguments")]
+    pub arguments: Vec<String>,
+    #[serde(rename = "WorkingDirectory")]
+    pub working_directory: String,
+    #[serde(rename = "EnvironmentVariables")]
+    pub environment_variables: Vec<ProcessCommandEnvironmentVariable>,
+    #[serde(rename = "InheritEnvironmentVariables")]
+    pub inherit_environment_variables: bool,
+    #[serde(rename = "StandardInputContent")]
+    pub standard_input_content: String,
+    #[serde(rename = "KillEntireProcessTree")]
+    pub kill_entire_process_tree: bool,
+    #[serde(rename = "CommandOptions")]
+    pub command_options: CommandOptions,
+    #[serde(rename = "MaxOutputLineCount")]
+    pub max_output_line_count: f64,
+    #[serde(rename = "DisplayImmediately")]
+    pub display_immediately: bool,
+}
+
+impl ProcessCommandExportOptions {
+    pub fn to_map(&self) -> HashMap<String, Value> {
+        let mut map = HashMap::new();
+        map.insert("ExecutablePath".to_string(), serde_json::to_value(&self.executable_path).unwrap_or(Value::Null));
+        map.insert("Arguments".to_string(), serde_json::to_value(&self.arguments).unwrap_or(Value::Null));
+        map.insert("WorkingDirectory".to_string(), serde_json::to_value(&self.working_directory).unwrap_or(Value::Null));
+        map.insert("EnvironmentVariables".to_string(), serde_json::to_value(&self.environment_variables).unwrap_or(Value::Null));
+        map.insert("InheritEnvironmentVariables".to_string(), serde_json::to_value(&self.inherit_environment_variables).unwrap_or(Value::Null));
+        map.insert("StandardInputContent".to_string(), serde_json::to_value(&self.standard_input_content).unwrap_or(Value::Null));
+        map.insert("KillEntireProcessTree".to_string(), serde_json::to_value(&self.kill_entire_process_tree).unwrap_or(Value::Null));
+        map.insert("CommandOptions".to_string(), serde_json::to_value(&self.command_options).unwrap_or(Value::Null));
+        map.insert("MaxOutputLineCount".to_string(), serde_json::to_value(&self.max_output_line_count).unwrap_or(Value::Null));
+        map.insert("DisplayImmediately".to_string(), serde_json::to_value(&self.display_immediately).unwrap_or(Value::Null));
+        map
+    }
+}
+
+/// ProcessCommandEnvironmentVariable
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct ProcessCommandEnvironmentVariable {
+    #[serde(rename = "Name")]
+    pub name: String,
+    #[serde(rename = "Value")]
+    pub value: String,
+}
+
+impl ProcessCommandEnvironmentVariable {
+    pub fn to_map(&self) -> HashMap<String, Value> {
+        let mut map = HashMap::new();
+        map.insert("Name".to_string(), serde_json::to_value(&self.name).unwrap_or(Value::Null));
+        map.insert("Value".to_string(), serde_json::to_value(&self.value).unwrap_or(Value::Null));
+        map
+    }
+}
+
 /// ExecuteCommandResult
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct ExecuteCommandResult {
@@ -1805,6 +1865,18 @@ impl CSharpAppResource {
             args.insert("commandOptions".to_string(), serde_json::to_value(v).unwrap_or(Value::Null));
         }
         let result = self.client.invoke_capability("Aspire.Hosting/withCommand", args)?;
+        let handle: Handle = serde_json::from_value(result)?;
+        Ok(IResource::new(handle, self.client.clone()))
+    }
+
+    /// Adds a process resource command
+    pub fn with_process_command(&self, command_name: &str, display_name: &str, options: ProcessCommandExportOptions) -> Result<IResource, Box<dyn std::error::Error>> {
+        let mut args: HashMap<String, Value> = HashMap::new();
+        args.insert("builder".to_string(), self.handle.to_json());
+        args.insert("commandName".to_string(), serde_json::to_value(&command_name).unwrap_or(Value::Null));
+        args.insert("displayName".to_string(), serde_json::to_value(&display_name).unwrap_or(Value::Null));
+        args.insert("options".to_string(), serde_json::to_value(&options).unwrap_or(Value::Null));
+        let result = self.client.invoke_capability("Aspire.Hosting/withProcessCommand", args)?;
         let handle: Handle = serde_json::from_value(result)?;
         Ok(IResource::new(handle, self.client.clone()))
     }
@@ -2833,6 +2905,18 @@ impl ContainerRegistryResource {
             args.insert("commandOptions".to_string(), serde_json::to_value(v).unwrap_or(Value::Null));
         }
         let result = self.client.invoke_capability("Aspire.Hosting/withCommand", args)?;
+        let handle: Handle = serde_json::from_value(result)?;
+        Ok(IResource::new(handle, self.client.clone()))
+    }
+
+    /// Adds a process resource command
+    pub fn with_process_command(&self, command_name: &str, display_name: &str, options: ProcessCommandExportOptions) -> Result<IResource, Box<dyn std::error::Error>> {
+        let mut args: HashMap<String, Value> = HashMap::new();
+        args.insert("builder".to_string(), self.handle.to_json());
+        args.insert("commandName".to_string(), serde_json::to_value(&command_name).unwrap_or(Value::Null));
+        args.insert("displayName".to_string(), serde_json::to_value(&display_name).unwrap_or(Value::Null));
+        args.insert("options".to_string(), serde_json::to_value(&options).unwrap_or(Value::Null));
+        let result = self.client.invoke_capability("Aspire.Hosting/withProcessCommand", args)?;
         let handle: Handle = serde_json::from_value(result)?;
         Ok(IResource::new(handle, self.client.clone()))
     }
@@ -3908,6 +3992,18 @@ impl ContainerResource {
             args.insert("commandOptions".to_string(), serde_json::to_value(v).unwrap_or(Value::Null));
         }
         let result = self.client.invoke_capability("Aspire.Hosting/withCommand", args)?;
+        let handle: Handle = serde_json::from_value(result)?;
+        Ok(IResource::new(handle, self.client.clone()))
+    }
+
+    /// Adds a process resource command
+    pub fn with_process_command(&self, command_name: &str, display_name: &str, options: ProcessCommandExportOptions) -> Result<IResource, Box<dyn std::error::Error>> {
+        let mut args: HashMap<String, Value> = HashMap::new();
+        args.insert("builder".to_string(), self.handle.to_json());
+        args.insert("commandName".to_string(), serde_json::to_value(&command_name).unwrap_or(Value::Null));
+        args.insert("displayName".to_string(), serde_json::to_value(&display_name).unwrap_or(Value::Null));
+        args.insert("options".to_string(), serde_json::to_value(&options).unwrap_or(Value::Null));
+        let result = self.client.invoke_capability("Aspire.Hosting/withProcessCommand", args)?;
         let handle: Handle = serde_json::from_value(result)?;
         Ok(IResource::new(handle, self.client.clone()))
     }
@@ -5572,6 +5668,18 @@ impl DotnetToolResource {
         Ok(IResource::new(handle, self.client.clone()))
     }
 
+    /// Adds a process resource command
+    pub fn with_process_command(&self, command_name: &str, display_name: &str, options: ProcessCommandExportOptions) -> Result<IResource, Box<dyn std::error::Error>> {
+        let mut args: HashMap<String, Value> = HashMap::new();
+        args.insert("builder".to_string(), self.handle.to_json());
+        args.insert("commandName".to_string(), serde_json::to_value(&command_name).unwrap_or(Value::Null));
+        args.insert("displayName".to_string(), serde_json::to_value(&display_name).unwrap_or(Value::Null));
+        args.insert("options".to_string(), serde_json::to_value(&options).unwrap_or(Value::Null));
+        let result = self.client.invoke_capability("Aspire.Hosting/withProcessCommand", args)?;
+        let handle: Handle = serde_json::from_value(result)?;
+        Ok(IResource::new(handle, self.client.clone()))
+    }
+
     /// Adds an HTTP resource command
     pub fn with_http_command(&self, path: &str, display_name: &str, options: Option<HttpCommandExportOptions>) -> Result<IResourceWithEndpoints, Box<dyn std::error::Error>> {
         let mut args: HashMap<String, Value> = HashMap::new();
@@ -7219,6 +7327,18 @@ impl ExecutableResource {
         Ok(IResource::new(handle, self.client.clone()))
     }
 
+    /// Adds a process resource command
+    pub fn with_process_command(&self, command_name: &str, display_name: &str, options: ProcessCommandExportOptions) -> Result<IResource, Box<dyn std::error::Error>> {
+        let mut args: HashMap<String, Value> = HashMap::new();
+        args.insert("builder".to_string(), self.handle.to_json());
+        args.insert("commandName".to_string(), serde_json::to_value(&command_name).unwrap_or(Value::Null));
+        args.insert("displayName".to_string(), serde_json::to_value(&display_name).unwrap_or(Value::Null));
+        args.insert("options".to_string(), serde_json::to_value(&options).unwrap_or(Value::Null));
+        let result = self.client.invoke_capability("Aspire.Hosting/withProcessCommand", args)?;
+        let handle: Handle = serde_json::from_value(result)?;
+        Ok(IResource::new(handle, self.client.clone()))
+    }
+
     /// Adds an HTTP resource command
     pub fn with_http_command(&self, path: &str, display_name: &str, options: Option<HttpCommandExportOptions>) -> Result<IResourceWithEndpoints, Box<dyn std::error::Error>> {
         let mut args: HashMap<String, Value> = HashMap::new();
@@ -7997,6 +8117,18 @@ impl ExternalServiceResource {
             args.insert("commandOptions".to_string(), serde_json::to_value(v).unwrap_or(Value::Null));
         }
         let result = self.client.invoke_capability("Aspire.Hosting/withCommand", args)?;
+        let handle: Handle = serde_json::from_value(result)?;
+        Ok(IResource::new(handle, self.client.clone()))
+    }
+
+    /// Adds a process resource command
+    pub fn with_process_command(&self, command_name: &str, display_name: &str, options: ProcessCommandExportOptions) -> Result<IResource, Box<dyn std::error::Error>> {
+        let mut args: HashMap<String, Value> = HashMap::new();
+        args.insert("builder".to_string(), self.handle.to_json());
+        args.insert("commandName".to_string(), serde_json::to_value(&command_name).unwrap_or(Value::Null));
+        args.insert("displayName".to_string(), serde_json::to_value(&display_name).unwrap_or(Value::Null));
+        args.insert("options".to_string(), serde_json::to_value(&options).unwrap_or(Value::Null));
+        let result = self.client.invoke_capability("Aspire.Hosting/withProcessCommand", args)?;
         let handle: Handle = serde_json::from_value(result)?;
         Ok(IResource::new(handle, self.client.clone()))
     }
@@ -10398,6 +10530,18 @@ impl ParameterResource {
         Ok(IResource::new(handle, self.client.clone()))
     }
 
+    /// Adds a process resource command
+    pub fn with_process_command(&self, command_name: &str, display_name: &str, options: ProcessCommandExportOptions) -> Result<IResource, Box<dyn std::error::Error>> {
+        let mut args: HashMap<String, Value> = HashMap::new();
+        args.insert("builder".to_string(), self.handle.to_json());
+        args.insert("commandName".to_string(), serde_json::to_value(&command_name).unwrap_or(Value::Null));
+        args.insert("displayName".to_string(), serde_json::to_value(&display_name).unwrap_or(Value::Null));
+        args.insert("options".to_string(), serde_json::to_value(&options).unwrap_or(Value::Null));
+        let result = self.client.invoke_capability("Aspire.Hosting/withProcessCommand", args)?;
+        let handle: Handle = serde_json::from_value(result)?;
+        Ok(IResource::new(handle, self.client.clone()))
+    }
+
     /// Adds a relationship to another resource
     pub fn with_relationship(&self, resource_builder: &IResource, r#type: &str) -> Result<IResource, Box<dyn std::error::Error>> {
         let mut args: HashMap<String, Value> = HashMap::new();
@@ -11743,6 +11887,18 @@ impl ProjectResource {
             args.insert("commandOptions".to_string(), serde_json::to_value(v).unwrap_or(Value::Null));
         }
         let result = self.client.invoke_capability("Aspire.Hosting/withCommand", args)?;
+        let handle: Handle = serde_json::from_value(result)?;
+        Ok(IResource::new(handle, self.client.clone()))
+    }
+
+    /// Adds a process resource command
+    pub fn with_process_command(&self, command_name: &str, display_name: &str, options: ProcessCommandExportOptions) -> Result<IResource, Box<dyn std::error::Error>> {
+        let mut args: HashMap<String, Value> = HashMap::new();
+        args.insert("builder".to_string(), self.handle.to_json());
+        args.insert("commandName".to_string(), serde_json::to_value(&command_name).unwrap_or(Value::Null));
+        args.insert("displayName".to_string(), serde_json::to_value(&display_name).unwrap_or(Value::Null));
+        args.insert("options".to_string(), serde_json::to_value(&options).unwrap_or(Value::Null));
+        let result = self.client.invoke_capability("Aspire.Hosting/withProcessCommand", args)?;
         let handle: Handle = serde_json::from_value(result)?;
         Ok(IResource::new(handle, self.client.clone()))
     }
@@ -13644,6 +13800,18 @@ impl TestDatabaseResource {
         Ok(IResource::new(handle, self.client.clone()))
     }
 
+    /// Adds a process resource command
+    pub fn with_process_command(&self, command_name: &str, display_name: &str, options: ProcessCommandExportOptions) -> Result<IResource, Box<dyn std::error::Error>> {
+        let mut args: HashMap<String, Value> = HashMap::new();
+        args.insert("builder".to_string(), self.handle.to_json());
+        args.insert("commandName".to_string(), serde_json::to_value(&command_name).unwrap_or(Value::Null));
+        args.insert("displayName".to_string(), serde_json::to_value(&display_name).unwrap_or(Value::Null));
+        args.insert("options".to_string(), serde_json::to_value(&options).unwrap_or(Value::Null));
+        let result = self.client.invoke_capability("Aspire.Hosting/withProcessCommand", args)?;
+        let handle: Handle = serde_json::from_value(result)?;
+        Ok(IResource::new(handle, self.client.clone()))
+    }
+
     /// Adds an HTTP resource command
     pub fn with_http_command(&self, path: &str, display_name: &str, options: Option<HttpCommandExportOptions>) -> Result<IResourceWithEndpoints, Box<dyn std::error::Error>> {
         let mut args: HashMap<String, Value> = HashMap::new();
@@ -15036,6 +15204,18 @@ impl TestRedisResource {
             args.insert("commandOptions".to_string(), serde_json::to_value(v).unwrap_or(Value::Null));
         }
         let result = self.client.invoke_capability("Aspire.Hosting/withCommand", args)?;
+        let handle: Handle = serde_json::from_value(result)?;
+        Ok(IResource::new(handle, self.client.clone()))
+    }
+
+    /// Adds a process resource command
+    pub fn with_process_command(&self, command_name: &str, display_name: &str, options: ProcessCommandExportOptions) -> Result<IResource, Box<dyn std::error::Error>> {
+        let mut args: HashMap<String, Value> = HashMap::new();
+        args.insert("builder".to_string(), self.handle.to_json());
+        args.insert("commandName".to_string(), serde_json::to_value(&command_name).unwrap_or(Value::Null));
+        args.insert("displayName".to_string(), serde_json::to_value(&display_name).unwrap_or(Value::Null));
+        args.insert("options".to_string(), serde_json::to_value(&options).unwrap_or(Value::Null));
+        let result = self.client.invoke_capability("Aspire.Hosting/withProcessCommand", args)?;
         let handle: Handle = serde_json::from_value(result)?;
         Ok(IResource::new(handle, self.client.clone()))
     }
@@ -16498,6 +16678,18 @@ impl TestVaultResource {
             args.insert("commandOptions".to_string(), serde_json::to_value(v).unwrap_or(Value::Null));
         }
         let result = self.client.invoke_capability("Aspire.Hosting/withCommand", args)?;
+        let handle: Handle = serde_json::from_value(result)?;
+        Ok(IResource::new(handle, self.client.clone()))
+    }
+
+    /// Adds a process resource command
+    pub fn with_process_command(&self, command_name: &str, display_name: &str, options: ProcessCommandExportOptions) -> Result<IResource, Box<dyn std::error::Error>> {
+        let mut args: HashMap<String, Value> = HashMap::new();
+        args.insert("builder".to_string(), self.handle.to_json());
+        args.insert("commandName".to_string(), serde_json::to_value(&command_name).unwrap_or(Value::Null));
+        args.insert("displayName".to_string(), serde_json::to_value(&display_name).unwrap_or(Value::Null));
+        args.insert("options".to_string(), serde_json::to_value(&options).unwrap_or(Value::Null));
+        let result = self.client.invoke_capability("Aspire.Hosting/withProcessCommand", args)?;
         let handle: Handle = serde_json::from_value(result)?;
         Ok(IResource::new(handle, self.client.clone()))
     }

--- a/tests/Aspire.Hosting.CodeGeneration.Rust.Tests/Snapshots/TwoPassScanningGeneratedAspire.verified.rs
+++ b/tests/Aspire.Hosting.CodeGeneration.Rust.Tests/Snapshots/TwoPassScanningGeneratedAspire.verified.rs
@@ -921,7 +921,7 @@ pub struct ProcessCommandExportOptions {
     #[serde(rename = "WorkingDirectory")]
     pub working_directory: String,
     #[serde(rename = "EnvironmentVariables")]
-    pub environment_variables: Vec<ProcessCommandEnvironmentVariable>,
+    pub environment_variables: HashMap<String, String>,
     #[serde(rename = "InheritEnvironmentVariables", skip_serializing_if = "Option::is_none")]
     pub inherit_environment_variables: Option<bool>,
     #[serde(rename = "StandardInputContent")]
@@ -957,24 +957,6 @@ impl ProcessCommandExportOptions {
         if let Some(ref v) = self.display_immediately {
             map.insert("DisplayImmediately".to_string(), serde_json::to_value(v).unwrap_or(Value::Null));
         }
-        map
-    }
-}
-
-/// ProcessCommandEnvironmentVariable
-#[derive(Debug, Clone, Default, Serialize, Deserialize)]
-pub struct ProcessCommandEnvironmentVariable {
-    #[serde(rename = "Name")]
-    pub name: String,
-    #[serde(rename = "Value")]
-    pub value: String,
-}
-
-impl ProcessCommandEnvironmentVariable {
-    pub fn to_map(&self) -> HashMap<String, Value> {
-        let mut map = HashMap::new();
-        map.insert("Name".to_string(), serde_json::to_value(&self.name).unwrap_or(Value::Null));
-        map.insert("Value".to_string(), serde_json::to_value(&self.value).unwrap_or(Value::Null));
         map
     }
 }

--- a/tests/Aspire.Hosting.CodeGeneration.Rust.Tests/Snapshots/TwoPassScanningGeneratedAspire.verified.rs
+++ b/tests/Aspire.Hosting.CodeGeneration.Rust.Tests/Snapshots/TwoPassScanningGeneratedAspire.verified.rs
@@ -531,8 +531,8 @@ pub struct InteractionInput {
     pub allow_custom_choice: bool,
     #[serde(rename = "Disabled")]
     pub disabled: bool,
-    #[serde(rename = "MaxLength")]
-    pub max_length: f64,
+    #[serde(rename = "MaxLength", skip_serializing_if = "Option::is_none")]
+    pub max_length: Option<f64>,
 }
 
 impl InteractionInput {
@@ -550,7 +550,9 @@ impl InteractionInput {
         map.insert("Placeholder".to_string(), serde_json::to_value(&self.placeholder).unwrap_or(Value::Null));
         map.insert("AllowCustomChoice".to_string(), serde_json::to_value(&self.allow_custom_choice).unwrap_or(Value::Null));
         map.insert("Disabled".to_string(), serde_json::to_value(&self.disabled).unwrap_or(Value::Null));
-        map.insert("MaxLength".to_string(), serde_json::to_value(&self.max_length).unwrap_or(Value::Null));
+        if let Some(ref v) = self.max_length {
+            map.insert("MaxLength".to_string(), serde_json::to_value(v).unwrap_or(Value::Null));
+        }
         map
     }
 }
@@ -697,8 +699,8 @@ pub struct ResourceEventDto {
     pub state_style: String,
     #[serde(rename = "HealthStatus")]
     pub health_status: String,
-    #[serde(rename = "ExitCode")]
-    pub exit_code: f64,
+    #[serde(rename = "ExitCode", skip_serializing_if = "Option::is_none")]
+    pub exit_code: Option<f64>,
 }
 
 impl ResourceEventDto {
@@ -709,7 +711,9 @@ impl ResourceEventDto {
         map.insert("State".to_string(), serde_json::to_value(&self.state).unwrap_or(Value::Null));
         map.insert("StateStyle".to_string(), serde_json::to_value(&self.state_style).unwrap_or(Value::Null));
         map.insert("HealthStatus".to_string(), serde_json::to_value(&self.health_status).unwrap_or(Value::Null));
-        map.insert("ExitCode".to_string(), serde_json::to_value(&self.exit_code).unwrap_or(Value::Null));
+        if let Some(ref v) = self.exit_code {
+            map.insert("ExitCode".to_string(), serde_json::to_value(v).unwrap_or(Value::Null));
+        }
         map
     }
 }
@@ -779,8 +783,8 @@ pub struct CommandOptions {
     pub confirmation_message: String,
     #[serde(rename = "IconName")]
     pub icon_name: String,
-    #[serde(rename = "IconVariant")]
-    pub icon_variant: IconVariant,
+    #[serde(rename = "IconVariant", skip_serializing_if = "Option::is_none")]
+    pub icon_variant: Option<IconVariant>,
     #[serde(rename = "IsHighlighted")]
     pub is_highlighted: bool,
     #[serde(rename = "UpdateState")]
@@ -797,7 +801,9 @@ impl CommandOptions {
         map.insert("Visibility".to_string(), serde_json::to_value(&self.visibility).unwrap_or(Value::Null));
         map.insert("ConfirmationMessage".to_string(), serde_json::to_value(&self.confirmation_message).unwrap_or(Value::Null));
         map.insert("IconName".to_string(), serde_json::to_value(&self.icon_name).unwrap_or(Value::Null));
-        map.insert("IconVariant".to_string(), serde_json::to_value(&self.icon_variant).unwrap_or(Value::Null));
+        if let Some(ref v) = self.icon_variant {
+            map.insert("IconVariant".to_string(), serde_json::to_value(v).unwrap_or(Value::Null));
+        }
         map.insert("IsHighlighted".to_string(), serde_json::to_value(&self.is_highlighted).unwrap_or(Value::Null));
         map.insert("UpdateState".to_string(), serde_json::to_value(&self.update_state).unwrap_or(Value::Null));
         map
@@ -813,8 +819,8 @@ pub struct HttpCommandExportOptions {
     pub confirmation_message: String,
     #[serde(rename = "IconName")]
     pub icon_name: String,
-    #[serde(rename = "IconVariant")]
-    pub icon_variant: IconVariant,
+    #[serde(rename = "IconVariant", skip_serializing_if = "Option::is_none")]
+    pub icon_variant: Option<IconVariant>,
     #[serde(rename = "IsHighlighted")]
     pub is_highlighted: bool,
     #[serde(rename = "CommandName")]
@@ -833,7 +839,9 @@ impl HttpCommandExportOptions {
         map.insert("Description".to_string(), serde_json::to_value(&self.description).unwrap_or(Value::Null));
         map.insert("ConfirmationMessage".to_string(), serde_json::to_value(&self.confirmation_message).unwrap_or(Value::Null));
         map.insert("IconName".to_string(), serde_json::to_value(&self.icon_name).unwrap_or(Value::Null));
-        map.insert("IconVariant".to_string(), serde_json::to_value(&self.icon_variant).unwrap_or(Value::Null));
+        if let Some(ref v) = self.icon_variant {
+            map.insert("IconVariant".to_string(), serde_json::to_value(v).unwrap_or(Value::Null));
+        }
         map.insert("IsHighlighted".to_string(), serde_json::to_value(&self.is_highlighted).unwrap_or(Value::Null));
         map.insert("CommandName".to_string(), serde_json::to_value(&self.command_name).unwrap_or(Value::Null));
         map.insert("EndpointName".to_string(), serde_json::to_value(&self.endpoint_name).unwrap_or(Value::Null));
@@ -914,18 +922,18 @@ pub struct ProcessCommandExportOptions {
     pub working_directory: String,
     #[serde(rename = "EnvironmentVariables")]
     pub environment_variables: Vec<ProcessCommandEnvironmentVariable>,
-    #[serde(rename = "InheritEnvironmentVariables")]
-    pub inherit_environment_variables: bool,
+    #[serde(rename = "InheritEnvironmentVariables", skip_serializing_if = "Option::is_none")]
+    pub inherit_environment_variables: Option<bool>,
     #[serde(rename = "StandardInputContent")]
     pub standard_input_content: String,
-    #[serde(rename = "KillEntireProcessTree")]
-    pub kill_entire_process_tree: bool,
+    #[serde(rename = "KillEntireProcessTree", skip_serializing_if = "Option::is_none")]
+    pub kill_entire_process_tree: Option<bool>,
     #[serde(rename = "CommandOptions")]
     pub command_options: CommandOptions,
-    #[serde(rename = "MaxOutputLineCount")]
-    pub max_output_line_count: f64,
-    #[serde(rename = "DisplayImmediately")]
-    pub display_immediately: bool,
+    #[serde(rename = "MaxOutputLineCount", skip_serializing_if = "Option::is_none")]
+    pub max_output_line_count: Option<f64>,
+    #[serde(rename = "DisplayImmediately", skip_serializing_if = "Option::is_none")]
+    pub display_immediately: Option<bool>,
 }
 
 impl ProcessCommandExportOptions {
@@ -935,12 +943,20 @@ impl ProcessCommandExportOptions {
         map.insert("Arguments".to_string(), serde_json::to_value(&self.arguments).unwrap_or(Value::Null));
         map.insert("WorkingDirectory".to_string(), serde_json::to_value(&self.working_directory).unwrap_or(Value::Null));
         map.insert("EnvironmentVariables".to_string(), serde_json::to_value(&self.environment_variables).unwrap_or(Value::Null));
-        map.insert("InheritEnvironmentVariables".to_string(), serde_json::to_value(&self.inherit_environment_variables).unwrap_or(Value::Null));
+        if let Some(ref v) = self.inherit_environment_variables {
+            map.insert("InheritEnvironmentVariables".to_string(), serde_json::to_value(v).unwrap_or(Value::Null));
+        }
         map.insert("StandardInputContent".to_string(), serde_json::to_value(&self.standard_input_content).unwrap_or(Value::Null));
-        map.insert("KillEntireProcessTree".to_string(), serde_json::to_value(&self.kill_entire_process_tree).unwrap_or(Value::Null));
+        if let Some(ref v) = self.kill_entire_process_tree {
+            map.insert("KillEntireProcessTree".to_string(), serde_json::to_value(v).unwrap_or(Value::Null));
+        }
         map.insert("CommandOptions".to_string(), serde_json::to_value(&self.command_options).unwrap_or(Value::Null));
-        map.insert("MaxOutputLineCount".to_string(), serde_json::to_value(&self.max_output_line_count).unwrap_or(Value::Null));
-        map.insert("DisplayImmediately".to_string(), serde_json::to_value(&self.display_immediately).unwrap_or(Value::Null));
+        if let Some(ref v) = self.max_output_line_count {
+            map.insert("MaxOutputLineCount".to_string(), serde_json::to_value(v).unwrap_or(Value::Null));
+        }
+        if let Some(ref v) = self.display_immediately {
+            map.insert("DisplayImmediately".to_string(), serde_json::to_value(v).unwrap_or(Value::Null));
+        }
         map
     }
 }

--- a/tests/Aspire.Hosting.CodeGeneration.Rust.Tests/Snapshots/TwoPassScanningGeneratedAspire.verified.rs
+++ b/tests/Aspire.Hosting.CodeGeneration.Rust.Tests/Snapshots/TwoPassScanningGeneratedAspire.verified.rs
@@ -1,4 +1,4 @@
-﻿//! aspire.rs - Capability-based Aspire SDK
+//! aspire.rs - Capability-based Aspire SDK
 //! GENERATED CODE - DO NOT EDIT
 
 use std::collections::HashMap;
@@ -934,6 +934,8 @@ pub struct ProcessCommandExportOptions {
     pub max_output_line_count: Option<f64>,
     #[serde(rename = "DisplayImmediately", skip_serializing_if = "Option::is_none")]
     pub display_immediately: Option<bool>,
+    #[serde(rename = "SuccessExitCodes")]
+    pub success_exit_codes: Vec<f64>,
 }
 
 impl ProcessCommandExportOptions {
@@ -957,6 +959,7 @@ impl ProcessCommandExportOptions {
         if let Some(ref v) = self.display_immediately {
             map.insert("DisplayImmediately".to_string(), serde_json::to_value(v).unwrap_or(Value::Null));
         }
+        map.insert("SuccessExitCodes".to_string(), serde_json::to_value(&self.success_exit_codes).unwrap_or(Value::Null));
         map
     }
 }

--- a/tests/Aspire.Hosting.CodeGeneration.TypeScript.Tests/Snapshots/HostingContainerResourceCapabilities.verified.txt
+++ b/tests/Aspire.Hosting.CodeGeneration.TypeScript.Tests/Snapshots/HostingContainerResourceCapabilities.verified.txt
@@ -910,6 +910,20 @@
     ]
   },
   {
+    CapabilityId: Aspire.Hosting/withProcessCommand,
+    MethodName: withProcessCommand,
+    TargetType: {
+      TypeId: Aspire.Hosting/Aspire.Hosting.ApplicationModel.IResource,
+      IsInterface: true
+    },
+    ExpandedTargetTypes: [
+      {
+        TypeId: Aspire.Hosting/Aspire.Hosting.ApplicationModel.ContainerResource,
+        IsInterface: false
+      }
+    ]
+  },
+  {
     CapabilityId: Aspire.Hosting/withReference,
     MethodName: withReference,
     TargetType: {

--- a/tests/Aspire.Hosting.CodeGeneration.TypeScript.Tests/Snapshots/TwoPassScanningGeneratedAspire.verified.ts
+++ b/tests/Aspire.Hosting.CodeGeneration.TypeScript.Tests/Snapshots/TwoPassScanningGeneratedAspire.verified.ts
@@ -576,18 +576,12 @@ export interface HttpsCertificateInfo {
     thumbprint?: string;
 }
 
-/** DTO interface for ProcessCommandEnvironmentVariable */
-export interface ProcessCommandEnvironmentVariable {
-    name?: string;
-    value?: string;
-}
-
 /** DTO interface for ProcessCommandExportOptions */
 export interface ProcessCommandExportOptions {
     executablePath?: string;
     arguments?: string[];
     workingDirectory?: string;
-    environmentVariables?: ProcessCommandEnvironmentVariable[];
+    environmentVariables?: Record<string, string>;
     inheritEnvironmentVariables?: boolean;
     standardInputContent?: string;
     killEntireProcessTree?: boolean;

--- a/tests/Aspire.Hosting.CodeGeneration.TypeScript.Tests/Snapshots/TwoPassScanningGeneratedAspire.verified.ts
+++ b/tests/Aspire.Hosting.CodeGeneration.TypeScript.Tests/Snapshots/TwoPassScanningGeneratedAspire.verified.ts
@@ -576,6 +576,26 @@ export interface HttpsCertificateInfo {
     thumbprint?: string;
 }
 
+/** DTO interface for ProcessCommandEnvironmentVariable */
+export interface ProcessCommandEnvironmentVariable {
+    name?: string;
+    value?: string;
+}
+
+/** DTO interface for ProcessCommandExportOptions */
+export interface ProcessCommandExportOptions {
+    executablePath?: string;
+    arguments?: string[];
+    workingDirectory?: string;
+    environmentVariables?: ProcessCommandEnvironmentVariable[];
+    inheritEnvironmentVariables?: boolean;
+    standardInputContent?: string;
+    killEntireProcessTree?: boolean;
+    commandOptions?: CommandOptions;
+    maxOutputLineCount?: number;
+    displayImmediately?: boolean;
+}
+
 /** DTO interface for ReferenceEnvironmentInjectionOptions */
 export interface ReferenceEnvironmentInjectionOptions {
     connectionString?: boolean;
@@ -7833,6 +7853,8 @@ export interface ContainerRegistryResource {
     withHealthCheck(key: string): ContainerRegistryResourcePromise;
     /** Adds a resource command */
     withCommand(name: string, displayName: string, executeCommand: (arg: ExecuteCommandContext) => Promise<ExecuteCommandResult>, options?: WithCommandOptions): ContainerRegistryResourcePromise;
+    /** Adds a process resource command */
+    withProcessCommand(commandName: string, displayName: string, options: ProcessCommandExportOptions): ContainerRegistryResourcePromise;
     /** Adds a relationship to another resource */
     withRelationship(resourceBuilder: Awaitable<CSharpAppResource | ComputeResource | ContainerFilesDestinationResource | ContainerRegistryResource | ContainerResource | DotnetToolResource | ExecutableResource | ExternalServiceResource | ParameterResource | ProjectResource | Resource | ResourceWithArgs | ResourceWithConnectionString | ResourceWithContainerFiles | ResourceWithEndpoints | ResourceWithEnvironment | ResourceWithWaitSupport | TestDatabaseResource | TestRedisResource | TestVaultResource>, type: string): ContainerRegistryResourcePromise;
     /** Sets the parent relationship */
@@ -7926,6 +7948,8 @@ export interface ContainerRegistryResourcePromise extends PromiseLike<ContainerR
     withHealthCheck(key: string): ContainerRegistryResourcePromise;
     /** Adds a resource command */
     withCommand(name: string, displayName: string, executeCommand: (arg: ExecuteCommandContext) => Promise<ExecuteCommandResult>, options?: WithCommandOptions): ContainerRegistryResourcePromise;
+    /** Adds a process resource command */
+    withProcessCommand(commandName: string, displayName: string, options: ProcessCommandExportOptions): ContainerRegistryResourcePromise;
     /** Adds a relationship to another resource */
     withRelationship(resourceBuilder: Awaitable<CSharpAppResource | ComputeResource | ContainerFilesDestinationResource | ContainerRegistryResource | ContainerResource | DotnetToolResource | ExecutableResource | ExternalServiceResource | ParameterResource | ProjectResource | Resource | ResourceWithArgs | ResourceWithConnectionString | ResourceWithContainerFiles | ResourceWithEndpoints | ResourceWithEnvironment | ResourceWithWaitSupport | TestDatabaseResource | TestRedisResource | TestVaultResource>, type: string): ContainerRegistryResourcePromise;
     /** Sets the parent relationship */
@@ -8170,6 +8194,20 @@ class ContainerRegistryResourceImpl extends ResourceBuilderBase<ContainerRegistr
     withCommand(name: string, displayName: string, executeCommand: (arg: ExecuteCommandContext) => Promise<ExecuteCommandResult>, options?: WithCommandOptions): ContainerRegistryResourcePromise {
         const commandOptions = options?.commandOptions;
         return new ContainerRegistryResourcePromiseImpl(this._withCommandInternal(name, displayName, executeCommand, commandOptions), this._client);
+    }
+
+    /** @internal */
+    private async _withProcessCommandInternal(commandName: string, displayName: string, options: ProcessCommandExportOptions): Promise<ContainerRegistryResource> {
+        const rpcArgs: Record<string, unknown> = { builder: this._handle, commandName, displayName, options };
+        const result = await this._client.invokeCapability<ContainerRegistryResourceHandle>(
+            'Aspire.Hosting/withProcessCommand',
+            rpcArgs
+        );
+        return new ContainerRegistryResourceImpl(result, this._client);
+    }
+
+    withProcessCommand(commandName: string, displayName: string, options: ProcessCommandExportOptions): ContainerRegistryResourcePromise {
+        return new ContainerRegistryResourcePromiseImpl(this._withProcessCommandInternal(commandName, displayName, options), this._client);
     }
 
     /** @internal */
@@ -8783,6 +8821,10 @@ class ContainerRegistryResourcePromiseImpl implements ContainerRegistryResourceP
         return new ContainerRegistryResourcePromiseImpl(this._promise.then(obj => obj.withCommand(name, displayName, executeCommand, options)), this._client);
     }
 
+    withProcessCommand(commandName: string, displayName: string, options: ProcessCommandExportOptions): ContainerRegistryResourcePromise {
+        return new ContainerRegistryResourcePromiseImpl(this._promise.then(obj => obj.withProcessCommand(commandName, displayName, options)), this._client);
+    }
+
     withRelationship(resourceBuilder: Awaitable<CSharpAppResource | ComputeResource | ContainerFilesDestinationResource | ContainerRegistryResource | ContainerResource | DotnetToolResource | ExecutableResource | ExternalServiceResource | ParameterResource | ProjectResource | Resource | ResourceWithArgs | ResourceWithConnectionString | ResourceWithContainerFiles | ResourceWithEndpoints | ResourceWithEnvironment | ResourceWithWaitSupport | TestDatabaseResource | TestRedisResource | TestVaultResource>, type: string): ContainerRegistryResourcePromise {
         return new ContainerRegistryResourcePromiseImpl(this._promise.then(obj => obj.withRelationship(resourceBuilder, type)), this._client);
     }
@@ -9031,6 +9073,8 @@ export interface ContainerResource {
     withHttpHealthCheck(options?: WithHttpHealthCheckOptions): ContainerResourcePromise;
     /** Adds a resource command */
     withCommand(name: string, displayName: string, executeCommand: (arg: ExecuteCommandContext) => Promise<ExecuteCommandResult>, options?: WithCommandOptions): ContainerResourcePromise;
+    /** Adds a process resource command */
+    withProcessCommand(commandName: string, displayName: string, options: ProcessCommandExportOptions): ContainerResourcePromise;
     /** Adds an HTTP resource command */
     withHttpCommand(path: string, displayName: string, options?: HttpCommandExportOptions): ContainerResourcePromise;
     /** Configures developer certificate trust */
@@ -9230,6 +9274,8 @@ export interface ContainerResourcePromise extends PromiseLike<ContainerResource>
     withHttpHealthCheck(options?: WithHttpHealthCheckOptions): ContainerResourcePromise;
     /** Adds a resource command */
     withCommand(name: string, displayName: string, executeCommand: (arg: ExecuteCommandContext) => Promise<ExecuteCommandResult>, options?: WithCommandOptions): ContainerResourcePromise;
+    /** Adds a process resource command */
+    withProcessCommand(commandName: string, displayName: string, options: ProcessCommandExportOptions): ContainerResourcePromise;
     /** Adds an HTTP resource command */
     withHttpCommand(path: string, displayName: string, options?: HttpCommandExportOptions): ContainerResourcePromise;
     /** Configures developer certificate trust */
@@ -10177,6 +10223,20 @@ class ContainerResourceImpl extends ResourceBuilderBase<ContainerResourceHandle>
     withCommand(name: string, displayName: string, executeCommand: (arg: ExecuteCommandContext) => Promise<ExecuteCommandResult>, options?: WithCommandOptions): ContainerResourcePromise {
         const commandOptions = options?.commandOptions;
         return new ContainerResourcePromiseImpl(this._withCommandInternal(name, displayName, executeCommand, commandOptions), this._client);
+    }
+
+    /** @internal */
+    private async _withProcessCommandInternal(commandName: string, displayName: string, options: ProcessCommandExportOptions): Promise<ContainerResource> {
+        const rpcArgs: Record<string, unknown> = { builder: this._handle, commandName, displayName, options };
+        const result = await this._client.invokeCapability<ContainerResourceHandle>(
+            'Aspire.Hosting/withProcessCommand',
+            rpcArgs
+        );
+        return new ContainerResourceImpl(result, this._client);
+    }
+
+    withProcessCommand(commandName: string, displayName: string, options: ProcessCommandExportOptions): ContainerResourcePromise {
+        return new ContainerResourcePromiseImpl(this._withProcessCommandInternal(commandName, displayName, options), this._client);
     }
 
     /** @internal */
@@ -11169,6 +11229,10 @@ class ContainerResourcePromiseImpl implements ContainerResourcePromise {
         return new ContainerResourcePromiseImpl(this._promise.then(obj => obj.withCommand(name, displayName, executeCommand, options)), this._client);
     }
 
+    withProcessCommand(commandName: string, displayName: string, options: ProcessCommandExportOptions): ContainerResourcePromise {
+        return new ContainerResourcePromiseImpl(this._promise.then(obj => obj.withProcessCommand(commandName, displayName, options)), this._client);
+    }
+
     withHttpCommand(path: string, displayName: string, options?: HttpCommandExportOptions): ContainerResourcePromise {
         return new ContainerResourcePromiseImpl(this._promise.then(obj => obj.withHttpCommand(path, displayName, options)), this._client);
     }
@@ -11439,6 +11503,8 @@ export interface CSharpAppResource {
     withHttpHealthCheck(options?: WithHttpHealthCheckOptions): CSharpAppResourcePromise;
     /** Adds a resource command */
     withCommand(name: string, displayName: string, executeCommand: (arg: ExecuteCommandContext) => Promise<ExecuteCommandResult>, options?: WithCommandOptions): CSharpAppResourcePromise;
+    /** Adds a process resource command */
+    withProcessCommand(commandName: string, displayName: string, options: ProcessCommandExportOptions): CSharpAppResourcePromise;
     /** Adds an HTTP resource command */
     withHttpCommand(path: string, displayName: string, options?: HttpCommandExportOptions): CSharpAppResourcePromise;
     /** Configures developer certificate trust */
@@ -11606,6 +11672,8 @@ export interface CSharpAppResourcePromise extends PromiseLike<CSharpAppResource>
     withHttpHealthCheck(options?: WithHttpHealthCheckOptions): CSharpAppResourcePromise;
     /** Adds a resource command */
     withCommand(name: string, displayName: string, executeCommand: (arg: ExecuteCommandContext) => Promise<ExecuteCommandResult>, options?: WithCommandOptions): CSharpAppResourcePromise;
+    /** Adds a process resource command */
+    withProcessCommand(commandName: string, displayName: string, options: ProcessCommandExportOptions): CSharpAppResourcePromise;
     /** Adds an HTTP resource command */
     withHttpCommand(path: string, displayName: string, options?: HttpCommandExportOptions): CSharpAppResourcePromise;
     /** Configures developer certificate trust */
@@ -12326,6 +12394,20 @@ class CSharpAppResourceImpl extends ResourceBuilderBase<CSharpAppResourceHandle>
     withCommand(name: string, displayName: string, executeCommand: (arg: ExecuteCommandContext) => Promise<ExecuteCommandResult>, options?: WithCommandOptions): CSharpAppResourcePromise {
         const commandOptions = options?.commandOptions;
         return new CSharpAppResourcePromiseImpl(this._withCommandInternal(name, displayName, executeCommand, commandOptions), this._client);
+    }
+
+    /** @internal */
+    private async _withProcessCommandInternal(commandName: string, displayName: string, options: ProcessCommandExportOptions): Promise<CSharpAppResource> {
+        const rpcArgs: Record<string, unknown> = { builder: this._handle, commandName, displayName, options };
+        const result = await this._client.invokeCapability<CSharpAppResourceHandle>(
+            'Aspire.Hosting/withProcessCommand',
+            rpcArgs
+        );
+        return new CSharpAppResourceImpl(result, this._client);
+    }
+
+    withProcessCommand(commandName: string, displayName: string, options: ProcessCommandExportOptions): CSharpAppResourcePromise {
+        return new CSharpAppResourcePromiseImpl(this._withProcessCommandInternal(commandName, displayName, options), this._client);
     }
 
     /** @internal */
@@ -13240,6 +13322,10 @@ class CSharpAppResourcePromiseImpl implements CSharpAppResourcePromise {
         return new CSharpAppResourcePromiseImpl(this._promise.then(obj => obj.withCommand(name, displayName, executeCommand, options)), this._client);
     }
 
+    withProcessCommand(commandName: string, displayName: string, options: ProcessCommandExportOptions): CSharpAppResourcePromise {
+        return new CSharpAppResourcePromiseImpl(this._promise.then(obj => obj.withProcessCommand(commandName, displayName, options)), this._client);
+    }
+
     withHttpCommand(path: string, displayName: string, options?: HttpCommandExportOptions): CSharpAppResourcePromise {
         return new CSharpAppResourcePromiseImpl(this._promise.then(obj => obj.withHttpCommand(path, displayName, options)), this._client);
     }
@@ -13516,6 +13602,8 @@ export interface DotnetToolResource {
     withHttpHealthCheck(options?: WithHttpHealthCheckOptions): DotnetToolResourcePromise;
     /** Adds a resource command */
     withCommand(name: string, displayName: string, executeCommand: (arg: ExecuteCommandContext) => Promise<ExecuteCommandResult>, options?: WithCommandOptions): DotnetToolResourcePromise;
+    /** Adds a process resource command */
+    withProcessCommand(commandName: string, displayName: string, options: ProcessCommandExportOptions): DotnetToolResourcePromise;
     /** Adds an HTTP resource command */
     withHttpCommand(path: string, displayName: string, options?: HttpCommandExportOptions): DotnetToolResourcePromise;
     /** Configures developer certificate trust */
@@ -13693,6 +13781,8 @@ export interface DotnetToolResourcePromise extends PromiseLike<DotnetToolResourc
     withHttpHealthCheck(options?: WithHttpHealthCheckOptions): DotnetToolResourcePromise;
     /** Adds a resource command */
     withCommand(name: string, displayName: string, executeCommand: (arg: ExecuteCommandContext) => Promise<ExecuteCommandResult>, options?: WithCommandOptions): DotnetToolResourcePromise;
+    /** Adds a process resource command */
+    withProcessCommand(commandName: string, displayName: string, options: ProcessCommandExportOptions): DotnetToolResourcePromise;
     /** Adds an HTTP resource command */
     withHttpCommand(path: string, displayName: string, options?: HttpCommandExportOptions): DotnetToolResourcePromise;
     /** Configures developer certificate trust */
@@ -14480,6 +14570,20 @@ class DotnetToolResourceImpl extends ResourceBuilderBase<DotnetToolResourceHandl
     withCommand(name: string, displayName: string, executeCommand: (arg: ExecuteCommandContext) => Promise<ExecuteCommandResult>, options?: WithCommandOptions): DotnetToolResourcePromise {
         const commandOptions = options?.commandOptions;
         return new DotnetToolResourcePromiseImpl(this._withCommandInternal(name, displayName, executeCommand, commandOptions), this._client);
+    }
+
+    /** @internal */
+    private async _withProcessCommandInternal(commandName: string, displayName: string, options: ProcessCommandExportOptions): Promise<DotnetToolResource> {
+        const rpcArgs: Record<string, unknown> = { builder: this._handle, commandName, displayName, options };
+        const result = await this._client.invokeCapability<DotnetToolResourceHandle>(
+            'Aspire.Hosting/withProcessCommand',
+            rpcArgs
+        );
+        return new DotnetToolResourceImpl(result, this._client);
+    }
+
+    withProcessCommand(commandName: string, displayName: string, options: ProcessCommandExportOptions): DotnetToolResourcePromise {
+        return new DotnetToolResourcePromiseImpl(this._withProcessCommandInternal(commandName, displayName, options), this._client);
     }
 
     /** @internal */
@@ -15414,6 +15518,10 @@ class DotnetToolResourcePromiseImpl implements DotnetToolResourcePromise {
         return new DotnetToolResourcePromiseImpl(this._promise.then(obj => obj.withCommand(name, displayName, executeCommand, options)), this._client);
     }
 
+    withProcessCommand(commandName: string, displayName: string, options: ProcessCommandExportOptions): DotnetToolResourcePromise {
+        return new DotnetToolResourcePromiseImpl(this._promise.then(obj => obj.withProcessCommand(commandName, displayName, options)), this._client);
+    }
+
     withHttpCommand(path: string, displayName: string, options?: HttpCommandExportOptions): DotnetToolResourcePromise {
         return new DotnetToolResourcePromiseImpl(this._promise.then(obj => obj.withHttpCommand(path, displayName, options)), this._client);
     }
@@ -15678,6 +15786,8 @@ export interface ExecutableResource {
     withHttpHealthCheck(options?: WithHttpHealthCheckOptions): ExecutableResourcePromise;
     /** Adds a resource command */
     withCommand(name: string, displayName: string, executeCommand: (arg: ExecuteCommandContext) => Promise<ExecuteCommandResult>, options?: WithCommandOptions): ExecutableResourcePromise;
+    /** Adds a process resource command */
+    withProcessCommand(commandName: string, displayName: string, options: ProcessCommandExportOptions): ExecutableResourcePromise;
     /** Adds an HTTP resource command */
     withHttpCommand(path: string, displayName: string, options?: HttpCommandExportOptions): ExecutableResourcePromise;
     /** Configures developer certificate trust */
@@ -15843,6 +15953,8 @@ export interface ExecutableResourcePromise extends PromiseLike<ExecutableResourc
     withHttpHealthCheck(options?: WithHttpHealthCheckOptions): ExecutableResourcePromise;
     /** Adds a resource command */
     withCommand(name: string, displayName: string, executeCommand: (arg: ExecuteCommandContext) => Promise<ExecuteCommandResult>, options?: WithCommandOptions): ExecutableResourcePromise;
+    /** Adds a process resource command */
+    withProcessCommand(commandName: string, displayName: string, options: ProcessCommandExportOptions): ExecutableResourcePromise;
     /** Adds an HTTP resource command */
     withHttpCommand(path: string, displayName: string, options?: HttpCommandExportOptions): ExecutableResourcePromise;
     /** Configures developer certificate trust */
@@ -16546,6 +16658,20 @@ class ExecutableResourceImpl extends ResourceBuilderBase<ExecutableResourceHandl
     withCommand(name: string, displayName: string, executeCommand: (arg: ExecuteCommandContext) => Promise<ExecuteCommandResult>, options?: WithCommandOptions): ExecutableResourcePromise {
         const commandOptions = options?.commandOptions;
         return new ExecutableResourcePromiseImpl(this._withCommandInternal(name, displayName, executeCommand, commandOptions), this._client);
+    }
+
+    /** @internal */
+    private async _withProcessCommandInternal(commandName: string, displayName: string, options: ProcessCommandExportOptions): Promise<ExecutableResource> {
+        const rpcArgs: Record<string, unknown> = { builder: this._handle, commandName, displayName, options };
+        const result = await this._client.invokeCapability<ExecutableResourceHandle>(
+            'Aspire.Hosting/withProcessCommand',
+            rpcArgs
+        );
+        return new ExecutableResourceImpl(result, this._client);
+    }
+
+    withProcessCommand(commandName: string, displayName: string, options: ProcessCommandExportOptions): ExecutableResourcePromise {
+        return new ExecutableResourcePromiseImpl(this._withProcessCommandInternal(commandName, displayName, options), this._client);
     }
 
     /** @internal */
@@ -17456,6 +17582,10 @@ class ExecutableResourcePromiseImpl implements ExecutableResourcePromise {
         return new ExecutableResourcePromiseImpl(this._promise.then(obj => obj.withCommand(name, displayName, executeCommand, options)), this._client);
     }
 
+    withProcessCommand(commandName: string, displayName: string, options: ProcessCommandExportOptions): ExecutableResourcePromise {
+        return new ExecutableResourcePromiseImpl(this._promise.then(obj => obj.withProcessCommand(commandName, displayName, options)), this._client);
+    }
+
     withHttpCommand(path: string, displayName: string, options?: HttpCommandExportOptions): ExecutableResourcePromise {
         return new ExecutableResourcePromiseImpl(this._promise.then(obj => obj.withHttpCommand(path, displayName, options)), this._client);
     }
@@ -17674,6 +17804,8 @@ export interface ExternalServiceResource {
     withHealthCheck(key: string): ExternalServiceResourcePromise;
     /** Adds a resource command */
     withCommand(name: string, displayName: string, executeCommand: (arg: ExecuteCommandContext) => Promise<ExecuteCommandResult>, options?: WithCommandOptions): ExternalServiceResourcePromise;
+    /** Adds a process resource command */
+    withProcessCommand(commandName: string, displayName: string, options: ProcessCommandExportOptions): ExternalServiceResourcePromise;
     /** Adds a relationship to another resource */
     withRelationship(resourceBuilder: Awaitable<CSharpAppResource | ComputeResource | ContainerFilesDestinationResource | ContainerRegistryResource | ContainerResource | DotnetToolResource | ExecutableResource | ExternalServiceResource | ParameterResource | ProjectResource | Resource | ResourceWithArgs | ResourceWithConnectionString | ResourceWithContainerFiles | ResourceWithEndpoints | ResourceWithEnvironment | ResourceWithWaitSupport | TestDatabaseResource | TestRedisResource | TestVaultResource>, type: string): ExternalServiceResourcePromise;
     /** Sets the parent relationship */
@@ -17769,6 +17901,8 @@ export interface ExternalServiceResourcePromise extends PromiseLike<ExternalServ
     withHealthCheck(key: string): ExternalServiceResourcePromise;
     /** Adds a resource command */
     withCommand(name: string, displayName: string, executeCommand: (arg: ExecuteCommandContext) => Promise<ExecuteCommandResult>, options?: WithCommandOptions): ExternalServiceResourcePromise;
+    /** Adds a process resource command */
+    withProcessCommand(commandName: string, displayName: string, options: ProcessCommandExportOptions): ExternalServiceResourcePromise;
     /** Adds a relationship to another resource */
     withRelationship(resourceBuilder: Awaitable<CSharpAppResource | ComputeResource | ContainerFilesDestinationResource | ContainerRegistryResource | ContainerResource | DotnetToolResource | ExecutableResource | ExternalServiceResource | ParameterResource | ProjectResource | Resource | ResourceWithArgs | ResourceWithConnectionString | ResourceWithContainerFiles | ResourceWithEndpoints | ResourceWithEnvironment | ResourceWithWaitSupport | TestDatabaseResource | TestRedisResource | TestVaultResource>, type: string): ExternalServiceResourcePromise;
     /** Sets the parent relationship */
@@ -18033,6 +18167,20 @@ class ExternalServiceResourceImpl extends ResourceBuilderBase<ExternalServiceRes
     withCommand(name: string, displayName: string, executeCommand: (arg: ExecuteCommandContext) => Promise<ExecuteCommandResult>, options?: WithCommandOptions): ExternalServiceResourcePromise {
         const commandOptions = options?.commandOptions;
         return new ExternalServiceResourcePromiseImpl(this._withCommandInternal(name, displayName, executeCommand, commandOptions), this._client);
+    }
+
+    /** @internal */
+    private async _withProcessCommandInternal(commandName: string, displayName: string, options: ProcessCommandExportOptions): Promise<ExternalServiceResource> {
+        const rpcArgs: Record<string, unknown> = { builder: this._handle, commandName, displayName, options };
+        const result = await this._client.invokeCapability<ExternalServiceResourceHandle>(
+            'Aspire.Hosting/withProcessCommand',
+            rpcArgs
+        );
+        return new ExternalServiceResourceImpl(result, this._client);
+    }
+
+    withProcessCommand(commandName: string, displayName: string, options: ProcessCommandExportOptions): ExternalServiceResourcePromise {
+        return new ExternalServiceResourcePromiseImpl(this._withProcessCommandInternal(commandName, displayName, options), this._client);
     }
 
     /** @internal */
@@ -18650,6 +18798,10 @@ class ExternalServiceResourcePromiseImpl implements ExternalServiceResourcePromi
         return new ExternalServiceResourcePromiseImpl(this._promise.then(obj => obj.withCommand(name, displayName, executeCommand, options)), this._client);
     }
 
+    withProcessCommand(commandName: string, displayName: string, options: ProcessCommandExportOptions): ExternalServiceResourcePromise {
+        return new ExternalServiceResourcePromiseImpl(this._promise.then(obj => obj.withProcessCommand(commandName, displayName, options)), this._client);
+    }
+
     withRelationship(resourceBuilder: Awaitable<CSharpAppResource | ComputeResource | ContainerFilesDestinationResource | ContainerRegistryResource | ContainerResource | DotnetToolResource | ExecutableResource | ExternalServiceResource | ParameterResource | ProjectResource | Resource | ResourceWithArgs | ResourceWithConnectionString | ResourceWithContainerFiles | ResourceWithEndpoints | ResourceWithEnvironment | ResourceWithWaitSupport | TestDatabaseResource | TestRedisResource | TestVaultResource>, type: string): ExternalServiceResourcePromise {
         return new ExternalServiceResourcePromiseImpl(this._promise.then(obj => obj.withRelationship(resourceBuilder, type)), this._client);
     }
@@ -18820,6 +18972,8 @@ export interface ParameterResource {
     withHealthCheck(key: string): ParameterResourcePromise;
     /** Adds a resource command */
     withCommand(name: string, displayName: string, executeCommand: (arg: ExecuteCommandContext) => Promise<ExecuteCommandResult>, options?: WithCommandOptions): ParameterResourcePromise;
+    /** Adds a process resource command */
+    withProcessCommand(commandName: string, displayName: string, options: ProcessCommandExportOptions): ParameterResourcePromise;
     /** Adds a relationship to another resource */
     withRelationship(resourceBuilder: Awaitable<CSharpAppResource | ComputeResource | ContainerFilesDestinationResource | ContainerRegistryResource | ContainerResource | DotnetToolResource | ExecutableResource | ExternalServiceResource | ParameterResource | ProjectResource | Resource | ResourceWithArgs | ResourceWithConnectionString | ResourceWithContainerFiles | ResourceWithEndpoints | ResourceWithEnvironment | ResourceWithWaitSupport | TestDatabaseResource | TestRedisResource | TestVaultResource>, type: string): ParameterResourcePromise;
     /** Sets the parent relationship */
@@ -18915,6 +19069,8 @@ export interface ParameterResourcePromise extends PromiseLike<ParameterResource>
     withHealthCheck(key: string): ParameterResourcePromise;
     /** Adds a resource command */
     withCommand(name: string, displayName: string, executeCommand: (arg: ExecuteCommandContext) => Promise<ExecuteCommandResult>, options?: WithCommandOptions): ParameterResourcePromise;
+    /** Adds a process resource command */
+    withProcessCommand(commandName: string, displayName: string, options: ProcessCommandExportOptions): ParameterResourcePromise;
     /** Adds a relationship to another resource */
     withRelationship(resourceBuilder: Awaitable<CSharpAppResource | ComputeResource | ContainerFilesDestinationResource | ContainerRegistryResource | ContainerResource | DotnetToolResource | ExecutableResource | ExternalServiceResource | ParameterResource | ProjectResource | Resource | ResourceWithArgs | ResourceWithConnectionString | ResourceWithContainerFiles | ResourceWithEndpoints | ResourceWithEnvironment | ResourceWithWaitSupport | TestDatabaseResource | TestRedisResource | TestVaultResource>, type: string): ParameterResourcePromise;
     /** Sets the parent relationship */
@@ -19175,6 +19331,20 @@ class ParameterResourceImpl extends ResourceBuilderBase<ParameterResourceHandle>
     withCommand(name: string, displayName: string, executeCommand: (arg: ExecuteCommandContext) => Promise<ExecuteCommandResult>, options?: WithCommandOptions): ParameterResourcePromise {
         const commandOptions = options?.commandOptions;
         return new ParameterResourcePromiseImpl(this._withCommandInternal(name, displayName, executeCommand, commandOptions), this._client);
+    }
+
+    /** @internal */
+    private async _withProcessCommandInternal(commandName: string, displayName: string, options: ProcessCommandExportOptions): Promise<ParameterResource> {
+        const rpcArgs: Record<string, unknown> = { builder: this._handle, commandName, displayName, options };
+        const result = await this._client.invokeCapability<ParameterResourceHandle>(
+            'Aspire.Hosting/withProcessCommand',
+            rpcArgs
+        );
+        return new ParameterResourceImpl(result, this._client);
+    }
+
+    withProcessCommand(commandName: string, displayName: string, options: ProcessCommandExportOptions): ParameterResourcePromise {
+        return new ParameterResourcePromiseImpl(this._withProcessCommandInternal(commandName, displayName, options), this._client);
     }
 
     /** @internal */
@@ -19792,6 +19962,10 @@ class ParameterResourcePromiseImpl implements ParameterResourcePromise {
         return new ParameterResourcePromiseImpl(this._promise.then(obj => obj.withCommand(name, displayName, executeCommand, options)), this._client);
     }
 
+    withProcessCommand(commandName: string, displayName: string, options: ProcessCommandExportOptions): ParameterResourcePromise {
+        return new ParameterResourcePromiseImpl(this._promise.then(obj => obj.withProcessCommand(commandName, displayName, options)), this._client);
+    }
+
     withRelationship(resourceBuilder: Awaitable<CSharpAppResource | ComputeResource | ContainerFilesDestinationResource | ContainerRegistryResource | ContainerResource | DotnetToolResource | ExecutableResource | ExternalServiceResource | ParameterResource | ProjectResource | Resource | ResourceWithArgs | ResourceWithConnectionString | ResourceWithContainerFiles | ResourceWithEndpoints | ResourceWithEnvironment | ResourceWithWaitSupport | TestDatabaseResource | TestRedisResource | TestVaultResource>, type: string): ParameterResourcePromise {
         return new ParameterResourcePromiseImpl(this._promise.then(obj => obj.withRelationship(resourceBuilder, type)), this._client);
     }
@@ -20010,6 +20184,8 @@ export interface ProjectResource {
     withHttpHealthCheck(options?: WithHttpHealthCheckOptions): ProjectResourcePromise;
     /** Adds a resource command */
     withCommand(name: string, displayName: string, executeCommand: (arg: ExecuteCommandContext) => Promise<ExecuteCommandResult>, options?: WithCommandOptions): ProjectResourcePromise;
+    /** Adds a process resource command */
+    withProcessCommand(commandName: string, displayName: string, options: ProcessCommandExportOptions): ProjectResourcePromise;
     /** Adds an HTTP resource command */
     withHttpCommand(path: string, displayName: string, options?: HttpCommandExportOptions): ProjectResourcePromise;
     /** Configures developer certificate trust */
@@ -20177,6 +20353,8 @@ export interface ProjectResourcePromise extends PromiseLike<ProjectResource> {
     withHttpHealthCheck(options?: WithHttpHealthCheckOptions): ProjectResourcePromise;
     /** Adds a resource command */
     withCommand(name: string, displayName: string, executeCommand: (arg: ExecuteCommandContext) => Promise<ExecuteCommandResult>, options?: WithCommandOptions): ProjectResourcePromise;
+    /** Adds a process resource command */
+    withProcessCommand(commandName: string, displayName: string, options: ProcessCommandExportOptions): ProjectResourcePromise;
     /** Adds an HTTP resource command */
     withHttpCommand(path: string, displayName: string, options?: HttpCommandExportOptions): ProjectResourcePromise;
     /** Configures developer certificate trust */
@@ -20897,6 +21075,20 @@ class ProjectResourceImpl extends ResourceBuilderBase<ProjectResourceHandle> imp
     withCommand(name: string, displayName: string, executeCommand: (arg: ExecuteCommandContext) => Promise<ExecuteCommandResult>, options?: WithCommandOptions): ProjectResourcePromise {
         const commandOptions = options?.commandOptions;
         return new ProjectResourcePromiseImpl(this._withCommandInternal(name, displayName, executeCommand, commandOptions), this._client);
+    }
+
+    /** @internal */
+    private async _withProcessCommandInternal(commandName: string, displayName: string, options: ProcessCommandExportOptions): Promise<ProjectResource> {
+        const rpcArgs: Record<string, unknown> = { builder: this._handle, commandName, displayName, options };
+        const result = await this._client.invokeCapability<ProjectResourceHandle>(
+            'Aspire.Hosting/withProcessCommand',
+            rpcArgs
+        );
+        return new ProjectResourceImpl(result, this._client);
+    }
+
+    withProcessCommand(commandName: string, displayName: string, options: ProcessCommandExportOptions): ProjectResourcePromise {
+        return new ProjectResourcePromiseImpl(this._withProcessCommandInternal(commandName, displayName, options), this._client);
     }
 
     /** @internal */
@@ -21811,6 +22003,10 @@ class ProjectResourcePromiseImpl implements ProjectResourcePromise {
         return new ProjectResourcePromiseImpl(this._promise.then(obj => obj.withCommand(name, displayName, executeCommand, options)), this._client);
     }
 
+    withProcessCommand(commandName: string, displayName: string, options: ProcessCommandExportOptions): ProjectResourcePromise {
+        return new ProjectResourcePromiseImpl(this._promise.then(obj => obj.withProcessCommand(commandName, displayName, options)), this._client);
+    }
+
     withHttpCommand(path: string, displayName: string, options?: HttpCommandExportOptions): ProjectResourcePromise {
         return new ProjectResourcePromiseImpl(this._promise.then(obj => obj.withHttpCommand(path, displayName, options)), this._client);
     }
@@ -22107,6 +22303,8 @@ export interface TestDatabaseResource {
     withHttpHealthCheck(options?: WithHttpHealthCheckOptions): TestDatabaseResourcePromise;
     /** Adds a resource command */
     withCommand(name: string, displayName: string, executeCommand: (arg: ExecuteCommandContext) => Promise<ExecuteCommandResult>, options?: WithCommandOptions): TestDatabaseResourcePromise;
+    /** Adds a process resource command */
+    withProcessCommand(commandName: string, displayName: string, options: ProcessCommandExportOptions): TestDatabaseResourcePromise;
     /** Adds an HTTP resource command */
     withHttpCommand(path: string, displayName: string, options?: HttpCommandExportOptions): TestDatabaseResourcePromise;
     /** Configures developer certificate trust */
@@ -22306,6 +22504,8 @@ export interface TestDatabaseResourcePromise extends PromiseLike<TestDatabaseRes
     withHttpHealthCheck(options?: WithHttpHealthCheckOptions): TestDatabaseResourcePromise;
     /** Adds a resource command */
     withCommand(name: string, displayName: string, executeCommand: (arg: ExecuteCommandContext) => Promise<ExecuteCommandResult>, options?: WithCommandOptions): TestDatabaseResourcePromise;
+    /** Adds a process resource command */
+    withProcessCommand(commandName: string, displayName: string, options: ProcessCommandExportOptions): TestDatabaseResourcePromise;
     /** Adds an HTTP resource command */
     withHttpCommand(path: string, displayName: string, options?: HttpCommandExportOptions): TestDatabaseResourcePromise;
     /** Configures developer certificate trust */
@@ -23253,6 +23453,20 @@ class TestDatabaseResourceImpl extends ResourceBuilderBase<TestDatabaseResourceH
     withCommand(name: string, displayName: string, executeCommand: (arg: ExecuteCommandContext) => Promise<ExecuteCommandResult>, options?: WithCommandOptions): TestDatabaseResourcePromise {
         const commandOptions = options?.commandOptions;
         return new TestDatabaseResourcePromiseImpl(this._withCommandInternal(name, displayName, executeCommand, commandOptions), this._client);
+    }
+
+    /** @internal */
+    private async _withProcessCommandInternal(commandName: string, displayName: string, options: ProcessCommandExportOptions): Promise<TestDatabaseResource> {
+        const rpcArgs: Record<string, unknown> = { builder: this._handle, commandName, displayName, options };
+        const result = await this._client.invokeCapability<TestDatabaseResourceHandle>(
+            'Aspire.Hosting/withProcessCommand',
+            rpcArgs
+        );
+        return new TestDatabaseResourceImpl(result, this._client);
+    }
+
+    withProcessCommand(commandName: string, displayName: string, options: ProcessCommandExportOptions): TestDatabaseResourcePromise {
+        return new TestDatabaseResourcePromiseImpl(this._withProcessCommandInternal(commandName, displayName, options), this._client);
     }
 
     /** @internal */
@@ -24245,6 +24459,10 @@ class TestDatabaseResourcePromiseImpl implements TestDatabaseResourcePromise {
         return new TestDatabaseResourcePromiseImpl(this._promise.then(obj => obj.withCommand(name, displayName, executeCommand, options)), this._client);
     }
 
+    withProcessCommand(commandName: string, displayName: string, options: ProcessCommandExportOptions): TestDatabaseResourcePromise {
+        return new TestDatabaseResourcePromiseImpl(this._promise.then(obj => obj.withProcessCommand(commandName, displayName, options)), this._client);
+    }
+
     withHttpCommand(path: string, displayName: string, options?: HttpCommandExportOptions): TestDatabaseResourcePromise {
         return new TestDatabaseResourcePromiseImpl(this._promise.then(obj => obj.withHttpCommand(path, displayName, options)), this._client);
     }
@@ -24549,6 +24767,8 @@ export interface TestRedisResource {
     withHttpHealthCheck(options?: WithHttpHealthCheckOptions): TestRedisResourcePromise;
     /** Adds a resource command */
     withCommand(name: string, displayName: string, executeCommand: (arg: ExecuteCommandContext) => Promise<ExecuteCommandResult>, options?: WithCommandOptions): TestRedisResourcePromise;
+    /** Adds a process resource command */
+    withProcessCommand(commandName: string, displayName: string, options: ProcessCommandExportOptions): TestRedisResourcePromise;
     /** Adds an HTTP resource command */
     withHttpCommand(path: string, displayName: string, options?: HttpCommandExportOptions): TestRedisResourcePromise;
     /** Configures developer certificate trust */
@@ -24778,6 +24998,8 @@ export interface TestRedisResourcePromise extends PromiseLike<TestRedisResource>
     withHttpHealthCheck(options?: WithHttpHealthCheckOptions): TestRedisResourcePromise;
     /** Adds a resource command */
     withCommand(name: string, displayName: string, executeCommand: (arg: ExecuteCommandContext) => Promise<ExecuteCommandResult>, options?: WithCommandOptions): TestRedisResourcePromise;
+    /** Adds a process resource command */
+    withProcessCommand(commandName: string, displayName: string, options: ProcessCommandExportOptions): TestRedisResourcePromise;
     /** Adds an HTTP resource command */
     withHttpCommand(path: string, displayName: string, options?: HttpCommandExportOptions): TestRedisResourcePromise;
     /** Configures developer certificate trust */
@@ -25773,6 +25995,20 @@ class TestRedisResourceImpl extends ResourceBuilderBase<TestRedisResourceHandle>
     withCommand(name: string, displayName: string, executeCommand: (arg: ExecuteCommandContext) => Promise<ExecuteCommandResult>, options?: WithCommandOptions): TestRedisResourcePromise {
         const commandOptions = options?.commandOptions;
         return new TestRedisResourcePromiseImpl(this._withCommandInternal(name, displayName, executeCommand, commandOptions), this._client);
+    }
+
+    /** @internal */
+    private async _withProcessCommandInternal(commandName: string, displayName: string, options: ProcessCommandExportOptions): Promise<TestRedisResource> {
+        const rpcArgs: Record<string, unknown> = { builder: this._handle, commandName, displayName, options };
+        const result = await this._client.invokeCapability<TestRedisResourceHandle>(
+            'Aspire.Hosting/withProcessCommand',
+            rpcArgs
+        );
+        return new TestRedisResourceImpl(result, this._client);
+    }
+
+    withProcessCommand(commandName: string, displayName: string, options: ProcessCommandExportOptions): TestRedisResourcePromise {
+        return new TestRedisResourcePromiseImpl(this._withProcessCommandInternal(commandName, displayName, options), this._client);
     }
 
     /** @internal */
@@ -26949,6 +27185,10 @@ class TestRedisResourcePromiseImpl implements TestRedisResourcePromise {
         return new TestRedisResourcePromiseImpl(this._promise.then(obj => obj.withCommand(name, displayName, executeCommand, options)), this._client);
     }
 
+    withProcessCommand(commandName: string, displayName: string, options: ProcessCommandExportOptions): TestRedisResourcePromise {
+        return new TestRedisResourcePromiseImpl(this._promise.then(obj => obj.withProcessCommand(commandName, displayName, options)), this._client);
+    }
+
     withHttpCommand(path: string, displayName: string, options?: HttpCommandExportOptions): TestRedisResourcePromise {
         return new TestRedisResourcePromiseImpl(this._promise.then(obj => obj.withHttpCommand(path, displayName, options)), this._client);
     }
@@ -27301,6 +27541,8 @@ export interface TestVaultResource {
     withHttpHealthCheck(options?: WithHttpHealthCheckOptions): TestVaultResourcePromise;
     /** Adds a resource command */
     withCommand(name: string, displayName: string, executeCommand: (arg: ExecuteCommandContext) => Promise<ExecuteCommandResult>, options?: WithCommandOptions): TestVaultResourcePromise;
+    /** Adds a process resource command */
+    withProcessCommand(commandName: string, displayName: string, options: ProcessCommandExportOptions): TestVaultResourcePromise;
     /** Adds an HTTP resource command */
     withHttpCommand(path: string, displayName: string, options?: HttpCommandExportOptions): TestVaultResourcePromise;
     /** Configures developer certificate trust */
@@ -27502,6 +27744,8 @@ export interface TestVaultResourcePromise extends PromiseLike<TestVaultResource>
     withHttpHealthCheck(options?: WithHttpHealthCheckOptions): TestVaultResourcePromise;
     /** Adds a resource command */
     withCommand(name: string, displayName: string, executeCommand: (arg: ExecuteCommandContext) => Promise<ExecuteCommandResult>, options?: WithCommandOptions): TestVaultResourcePromise;
+    /** Adds a process resource command */
+    withProcessCommand(commandName: string, displayName: string, options: ProcessCommandExportOptions): TestVaultResourcePromise;
     /** Adds an HTTP resource command */
     withHttpCommand(path: string, displayName: string, options?: HttpCommandExportOptions): TestVaultResourcePromise;
     /** Configures developer certificate trust */
@@ -28451,6 +28695,20 @@ class TestVaultResourceImpl extends ResourceBuilderBase<TestVaultResourceHandle>
     withCommand(name: string, displayName: string, executeCommand: (arg: ExecuteCommandContext) => Promise<ExecuteCommandResult>, options?: WithCommandOptions): TestVaultResourcePromise {
         const commandOptions = options?.commandOptions;
         return new TestVaultResourcePromiseImpl(this._withCommandInternal(name, displayName, executeCommand, commandOptions), this._client);
+    }
+
+    /** @internal */
+    private async _withProcessCommandInternal(commandName: string, displayName: string, options: ProcessCommandExportOptions): Promise<TestVaultResource> {
+        const rpcArgs: Record<string, unknown> = { builder: this._handle, commandName, displayName, options };
+        const result = await this._client.invokeCapability<TestVaultResourceHandle>(
+            'Aspire.Hosting/withProcessCommand',
+            rpcArgs
+        );
+        return new TestVaultResourceImpl(result, this._client);
+    }
+
+    withProcessCommand(commandName: string, displayName: string, options: ProcessCommandExportOptions): TestVaultResourcePromise {
+        return new TestVaultResourcePromiseImpl(this._withProcessCommandInternal(commandName, displayName, options), this._client);
     }
 
     /** @internal */
@@ -29457,6 +29715,10 @@ class TestVaultResourcePromiseImpl implements TestVaultResourcePromise {
         return new TestVaultResourcePromiseImpl(this._promise.then(obj => obj.withCommand(name, displayName, executeCommand, options)), this._client);
     }
 
+    withProcessCommand(commandName: string, displayName: string, options: ProcessCommandExportOptions): TestVaultResourcePromise {
+        return new TestVaultResourcePromiseImpl(this._promise.then(obj => obj.withProcessCommand(commandName, displayName, options)), this._client);
+    }
+
     withHttpCommand(path: string, displayName: string, options?: HttpCommandExportOptions): TestVaultResourcePromise {
         return new TestVaultResourcePromiseImpl(this._promise.then(obj => obj.withHttpCommand(path, displayName, options)), this._client);
     }
@@ -29857,6 +30119,8 @@ export interface Resource {
     withHealthCheck(key: string): ResourcePromise;
     /** Adds a resource command */
     withCommand(name: string, displayName: string, executeCommand: (arg: ExecuteCommandContext) => Promise<ExecuteCommandResult>, options?: WithCommandOptions): ResourcePromise;
+    /** Adds a process resource command */
+    withProcessCommand(commandName: string, displayName: string, options: ProcessCommandExportOptions): ResourcePromise;
     /** Adds a relationship to another resource */
     withRelationship(resourceBuilder: Awaitable<CSharpAppResource | ComputeResource | ContainerFilesDestinationResource | ContainerRegistryResource | ContainerResource | DotnetToolResource | ExecutableResource | ExternalServiceResource | ParameterResource | ProjectResource | Resource | ResourceWithArgs | ResourceWithConnectionString | ResourceWithContainerFiles | ResourceWithEndpoints | ResourceWithEnvironment | ResourceWithWaitSupport | TestDatabaseResource | TestRedisResource | TestVaultResource>, type: string): ResourcePromise;
     /** Sets the parent relationship */
@@ -29950,6 +30214,8 @@ export interface ResourcePromise extends PromiseLike<Resource> {
     withHealthCheck(key: string): ResourcePromise;
     /** Adds a resource command */
     withCommand(name: string, displayName: string, executeCommand: (arg: ExecuteCommandContext) => Promise<ExecuteCommandResult>, options?: WithCommandOptions): ResourcePromise;
+    /** Adds a process resource command */
+    withProcessCommand(commandName: string, displayName: string, options: ProcessCommandExportOptions): ResourcePromise;
     /** Adds a relationship to another resource */
     withRelationship(resourceBuilder: Awaitable<CSharpAppResource | ComputeResource | ContainerFilesDestinationResource | ContainerRegistryResource | ContainerResource | DotnetToolResource | ExecutableResource | ExternalServiceResource | ParameterResource | ProjectResource | Resource | ResourceWithArgs | ResourceWithConnectionString | ResourceWithContainerFiles | ResourceWithEndpoints | ResourceWithEnvironment | ResourceWithWaitSupport | TestDatabaseResource | TestRedisResource | TestVaultResource>, type: string): ResourcePromise;
     /** Sets the parent relationship */
@@ -30194,6 +30460,20 @@ class ResourceImpl extends ResourceBuilderBase<IResourceHandle> implements Resou
     withCommand(name: string, displayName: string, executeCommand: (arg: ExecuteCommandContext) => Promise<ExecuteCommandResult>, options?: WithCommandOptions): ResourcePromise {
         const commandOptions = options?.commandOptions;
         return new ResourcePromiseImpl(this._withCommandInternal(name, displayName, executeCommand, commandOptions), this._client);
+    }
+
+    /** @internal */
+    private async _withProcessCommandInternal(commandName: string, displayName: string, options: ProcessCommandExportOptions): Promise<Resource> {
+        const rpcArgs: Record<string, unknown> = { builder: this._handle, commandName, displayName, options };
+        const result = await this._client.invokeCapability<IResourceHandle>(
+            'Aspire.Hosting/withProcessCommand',
+            rpcArgs
+        );
+        return new ResourceImpl(result, this._client);
+    }
+
+    withProcessCommand(commandName: string, displayName: string, options: ProcessCommandExportOptions): ResourcePromise {
+        return new ResourcePromiseImpl(this._withProcessCommandInternal(commandName, displayName, options), this._client);
     }
 
     /** @internal */
@@ -30805,6 +31085,10 @@ class ResourcePromiseImpl implements ResourcePromise {
 
     withCommand(name: string, displayName: string, executeCommand: (arg: ExecuteCommandContext) => Promise<ExecuteCommandResult>, options?: WithCommandOptions): ResourcePromise {
         return new ResourcePromiseImpl(this._promise.then(obj => obj.withCommand(name, displayName, executeCommand, options)), this._client);
+    }
+
+    withProcessCommand(commandName: string, displayName: string, options: ProcessCommandExportOptions): ResourcePromise {
+        return new ResourcePromiseImpl(this._promise.then(obj => obj.withProcessCommand(commandName, displayName, options)), this._client);
     }
 
     withRelationship(resourceBuilder: Awaitable<CSharpAppResource | ComputeResource | ContainerFilesDestinationResource | ContainerRegistryResource | ContainerResource | DotnetToolResource | ExecutableResource | ExternalServiceResource | ParameterResource | ProjectResource | Resource | ResourceWithArgs | ResourceWithConnectionString | ResourceWithContainerFiles | ResourceWithEndpoints | ResourceWithEnvironment | ResourceWithWaitSupport | TestDatabaseResource | TestRedisResource | TestVaultResource>, type: string): ResourcePromise {

--- a/tests/Aspire.Hosting.CodeGeneration.TypeScript.Tests/Snapshots/TwoPassScanningGeneratedAspire.verified.ts
+++ b/tests/Aspire.Hosting.CodeGeneration.TypeScript.Tests/Snapshots/TwoPassScanningGeneratedAspire.verified.ts
@@ -588,6 +588,7 @@ export interface ProcessCommandExportOptions {
     commandOptions?: CommandOptions;
     maxOutputLineCount?: number;
     displayImmediately?: boolean;
+    successExitCodes?: number[];
 }
 
 /** DTO interface for ReferenceEnvironmentInjectionOptions */

--- a/tests/Aspire.Hosting.Tests/Dcp/ProcessUtilTests.cs
+++ b/tests/Aspire.Hosting.Tests/Dcp/ProcessUtilTests.cs
@@ -1,7 +1,9 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Text.Json;
 using Aspire.Hosting.Dcp.Process;
+using Aspire.Hosting.Tests.Utils;
 
 namespace Aspire.Hosting.Tests.Dcp;
 
@@ -11,10 +13,11 @@ public class ProcessUtilTests
     [Fact]
     public async Task Run_WaitsForOutputCallbacksToFinishBeforeCompleting()
     {
+        using var scripts = new TestTempDirectory();
         var callbackStarted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
         var releaseCallback = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
 
-        var spec = CreateSingleLineOutputProcessSpec(output =>
+        var spec = CreateSingleLineOutputProcessSpec(scripts, output =>
         {
             Assert.Equal("final-line", output);
             callbackStarted.TrySetResult();
@@ -25,14 +28,14 @@ public class ProcessUtilTests
 
         await using (processDisposable)
         {
-            await callbackStarted.Task.WaitAsync(TimeSpan.FromSeconds(10));
+            await callbackStarted.Task.WaitAsync(TimeSpan.FromSeconds(30));
             await Task.Delay(200);
 
             Assert.False(pendingProcessResult.IsCompleted);
 
             releaseCallback.TrySetResult();
 
-            var result = await pendingProcessResult.WaitAsync(TimeSpan.FromSeconds(10));
+            var result = await pendingProcessResult.WaitAsync(TimeSpan.FromSeconds(30));
             Assert.Equal(0, result.ExitCode);
         }
     }
@@ -40,11 +43,12 @@ public class ProcessUtilTests
     [Fact]
     public async Task Run_IncludesCapturedOutputInNonZeroExitException()
     {
-        var (pendingProcessResult, processDisposable) = ProcessUtil.Run(CreateFailingProcessSpec(["stdout-final-line", "stderr-final-line"], emitSecondLineToStderr: true));
+        using var scripts = new TestTempDirectory();
+        var (pendingProcessResult, processDisposable) = ProcessUtil.Run(CreateFailingProcessSpec(scripts, ["stdout-final-line", "stderr-final-line"], emitSecondLineToStderr: true));
 
         await using (processDisposable)
         {
-            var exception = await Assert.ThrowsAsync<InvalidOperationException>(() => pendingProcessResult).WaitAsync(TimeSpan.FromSeconds(10));
+            var exception = await Assert.ThrowsAsync<InvalidOperationException>(() => pendingProcessResult).WaitAsync(TimeSpan.FromSeconds(30));
 
             Assert.Contains("returned non-zero exit code 1", exception.Message);
             Assert.Contains("stdout-final-line", exception.Message);
@@ -55,7 +59,9 @@ public class ProcessUtilTests
     [Fact]
     public async Task Run_ReturnsCapturedOutputInProcessResult_WhenRetentionEnabled()
     {
+        using var scripts = new TestTempDirectory();
         var spec = CreateFailingProcessSpec(
+            scripts,
             ["stdout-final-line", "stderr-final-line"],
             emitSecondLineToStderr: true,
             throwOnNonZeroReturnCode: false,
@@ -65,7 +71,7 @@ public class ProcessUtilTests
 
         await using (processDisposable)
         {
-            var processResult = await pendingProcessResult.WaitAsync(TimeSpan.FromSeconds(10));
+            var processResult = await pendingProcessResult.WaitAsync(TimeSpan.FromSeconds(30));
             var normalizedOutput = processResult.ProcessOutput.Select(static line => line.TrimEnd()).ToArray();
 
             Assert.Equal(1, processResult.ExitCode);
@@ -77,14 +83,87 @@ public class ProcessUtilTests
     }
 
     [Fact]
-    public async Task Run_TruncatesCapturedOutputToLast50LinesInNonZeroExitException()
+    public async Task Run_PassesArgumentListToProcess()
     {
-        var lines = Enumerable.Range(1, 52).Select(i => $"line-{i}").ToArray();
-        var (pendingProcessResult, processDisposable) = ProcessUtil.Run(CreateFailingProcessSpec(lines));
+        using var scripts = new TestTempDirectory();
+        var appPath = DotnetFileAppProcess.WriteApp(scripts, "argument-list.cs", """
+            #:sdk Microsoft.NET.Sdk
+            Console.WriteLine(args[0]);
+            """);
+        var outputLines = new List<string>();
+        var spec = DotnetFileAppProcess.CreateDcpProcessSpec(appPath, ["argument-list-value"], onOutputData: outputLines.Add);
+
+        var (pendingProcessResult, processDisposable) = ProcessUtil.Run(spec);
 
         await using (processDisposable)
         {
-            var exception = await Assert.ThrowsAsync<InvalidOperationException>(() => pendingProcessResult).WaitAsync(TimeSpan.FromSeconds(10));
+            var result = await pendingProcessResult.WaitAsync(TimeSpan.FromSeconds(30));
+
+            Assert.Equal(0, result.ExitCode);
+            Assert.Contains("argument-list-value", outputLines);
+        }
+    }
+
+    [Fact]
+    public async Task Run_ResolvesExecutableNameFromPathBeforeStartingProcess()
+    {
+        using var scripts = new TestTempDirectory();
+        var appPath = DotnetFileAppProcess.WriteApp(scripts, "path-executable.cs", """
+            #:sdk Microsoft.NET.Sdk
+            Console.WriteLine("path-executable-output");
+            """);
+        var dotnetPath = DotnetFileAppProcess.ResolvedExecutablePath;
+        var dotnetDirectory = Path.GetDirectoryName(dotnetPath);
+        var dotnetExecutableName = Path.GetFileName(dotnetPath);
+        var outputLines = new List<string>();
+        var spec = new ProcessSpec(dotnetExecutableName)
+        {
+            ArgumentList = DotnetFileAppProcess.CreateArguments(appPath),
+            EnvironmentVariables = new Dictionary<string, string>
+            {
+                ["PATH"] = dotnetDirectory ?? string.Empty
+            },
+            OnOutputData = outputLines.Add,
+            ThrowOnNonZeroReturnCode = false,
+            ResolveExecutablePath = true
+        };
+
+        var (pendingProcessResult, processDisposable) = ProcessUtil.Run(spec);
+
+        await using (processDisposable)
+        {
+            var result = await pendingProcessResult.WaitAsync(TimeSpan.FromSeconds(30));
+
+            Assert.Equal(0, result.ExitCode);
+            Assert.Contains("path-executable-output", outputLines);
+        }
+    }
+
+    [Fact]
+    public void Run_Throws_WhenArgumentsAndArgumentListAreSpecified()
+    {
+        var spec = new ProcessSpec("dotnet")
+        {
+            Arguments = "--version",
+            ArgumentList = ["--info"],
+            ThrowOnNonZeroReturnCode = false
+        };
+
+        var exception = Assert.Throws<InvalidOperationException>(() => ProcessUtil.Run(spec));
+
+        Assert.Equal("Specify either Arguments or ArgumentList, not both.", exception.Message);
+    }
+
+    [Fact]
+    public async Task Run_TruncatesCapturedOutputToLast50LinesInNonZeroExitException()
+    {
+        using var scripts = new TestTempDirectory();
+        var lines = Enumerable.Range(1, 52).Select(i => $"line-{i}").ToArray();
+        var (pendingProcessResult, processDisposable) = ProcessUtil.Run(CreateFailingProcessSpec(scripts, lines));
+
+        await using (processDisposable)
+        {
+            var exception = await Assert.ThrowsAsync<InvalidOperationException>(() => pendingProcessResult).WaitAsync(TimeSpan.FromSeconds(30));
             var outputLines = exception.Message.Split(Environment.NewLine, StringSplitOptions.RemoveEmptyEntries);
             var normalizedOutputLines = outputLines.Select(static line => line.TrimEnd()).ToArray();
 
@@ -96,77 +175,46 @@ public class ProcessUtilTests
         }
     }
 
-    private static ProcessSpec CreateSingleLineOutputProcessSpec(Action<string> onOutputData)
+    private static ProcessSpec CreateSingleLineOutputProcessSpec(TestTempDirectory scripts, Action<string> onOutputData)
     {
-        if (OperatingSystem.IsWindows())
-        {
-            return new ProcessSpec("cmd")
-            {
-                Arguments = "/c echo final-line",
-                OnOutputData = onOutputData,
-                ThrowOnNonZeroReturnCode = false
-            };
-        }
+        var appPath = DotnetFileAppProcess.WriteApp(scripts, "single-line.cs", """
+            #:sdk Microsoft.NET.Sdk
+            Console.WriteLine("final-line");
+            """);
 
-        return new ProcessSpec("sh")
-        {
-            Arguments = "-c \"echo final-line\"",
-            OnOutputData = onOutputData,
-            ThrowOnNonZeroReturnCode = false
-        };
+        return DotnetFileAppProcess.CreateDcpProcessSpec(appPath, onOutputData: onOutputData);
     }
 
     private static ProcessSpec CreateFailingProcessSpec(
+        TestTempDirectory scripts,
         string[] lines,
         bool emitSecondLineToStderr = false,
         bool throwOnNonZeroReturnCode = true,
         int? retainedOutputLineCount = null)
     {
-        if (OperatingSystem.IsWindows())
-        {
-            var commandParts = new List<string>();
+        var appPath = DotnetFileAppProcess.WriteApp(scripts, "failing.cs", $$"""
+            #:sdk Microsoft.NET.Sdk
+            var lines = new[] { {{string.Join(", ", lines.Select(static line => JsonSerializer.Serialize(line)))}} };
+            var emitSecondLineToStderr = {{JsonSerializer.Serialize(emitSecondLineToStderr)}};
+
             for (var i = 0; i < lines.Length; i++)
             {
                 if (emitSecondLineToStderr && i == 1)
                 {
-                    commandParts.Add($"echo {lines[i]} 1>&2");
+                    Console.Error.WriteLine(lines[i]);
                 }
                 else
                 {
-                    commandParts.Add($"echo {lines[i]}");
+                    Console.WriteLine(lines[i]);
                 }
             }
 
-            commandParts.Add("exit /b 1");
+            Environment.Exit(1);
+            """);
 
-            return new ProcessSpec("cmd")
-            {
-                Arguments = $"/c \"{string.Join(" & ", commandParts)}\"",
-                ThrowOnNonZeroReturnCode = throwOnNonZeroReturnCode,
-                RetainedOutputLineCount = retainedOutputLineCount
-            };
-        }
-
-        var unixCommandParts = new List<string>();
-        for (var i = 0; i < lines.Length; i++)
-        {
-            if (emitSecondLineToStderr && i == 1)
-            {
-                unixCommandParts.Add($"echo {lines[i]} 1>&2");
-            }
-            else
-            {
-                unixCommandParts.Add($"echo {lines[i]}");
-            }
-        }
-
-        unixCommandParts.Add("exit 1");
-
-        return new ProcessSpec("sh")
-        {
-            Arguments = $"-c \"{string.Join("; ", unixCommandParts)}\"",
-            ThrowOnNonZeroReturnCode = throwOnNonZeroReturnCode,
-            RetainedOutputLineCount = retainedOutputLineCount
-        };
+        return DotnetFileAppProcess.CreateDcpProcessSpec(
+            appPath,
+            throwOnNonZeroReturnCode: throwOnNonZeroReturnCode,
+            retainedOutputLineCount: retainedOutputLineCount);
     }
 }

--- a/tests/Aspire.Hosting.Tests/Dcp/ProcessUtilTests.cs
+++ b/tests/Aspire.Hosting.Tests/Dcp/ProcessUtilTests.cs
@@ -105,6 +105,30 @@ public class ProcessUtilTests
     }
 
     [Fact]
+    public async Task Run_IncludesArgumentListInNonZeroExitException()
+    {
+        using var scripts = new TestTempDirectory();
+        var appPath = DotnetFileAppProcess.WriteApp(scripts, "argument-list-failure.cs", """
+            #:sdk Microsoft.NET.Sdk
+            Environment.Exit(7);
+            """);
+        var spec = DotnetFileAppProcess.CreateDcpProcessSpec(
+            appPath,
+            ["failure-argument"],
+            throwOnNonZeroReturnCode: true);
+
+        var (pendingProcessResult, processDisposable) = ProcessUtil.Run(spec);
+
+        await using (processDisposable)
+        {
+            var exception = await Assert.ThrowsAsync<InvalidOperationException>(() => pendingProcessResult).WaitAsync(TimeSpan.FromSeconds(30));
+
+            Assert.Contains("returned non-zero exit code 7", exception.Message);
+            Assert.Contains("failure-argument", exception.Message);
+        }
+    }
+
+    [Fact]
     public async Task Run_ResolvesExecutableNameFromPathBeforeStartingProcess()
     {
         using var scripts = new TestTempDirectory();

--- a/tests/Aspire.Hosting.Tests/Dcp/ProcessUtilTests.cs
+++ b/tests/Aspire.Hosting.Tests/Dcp/ProcessUtilTests.cs
@@ -114,7 +114,7 @@ public class ProcessUtilTests
             """);
         var spec = DotnetFileAppProcess.CreateDcpProcessSpec(
             appPath,
-            ["failure-argument"],
+            ["failure-argument", "failure argument", "quote\"argument", ""],
             throwOnNonZeroReturnCode: true);
 
         var (pendingProcessResult, processDisposable) = ProcessUtil.Run(spec);
@@ -125,6 +125,7 @@ public class ProcessUtilTests
 
             Assert.Contains("returned non-zero exit code 7", exception.Message);
             Assert.Contains("failure-argument", exception.Message);
+            Assert.Contains("-- failure-argument \"failure argument\" \"quote\\\"argument\" \"\"", exception.Message);
         }
     }
 
@@ -173,9 +174,10 @@ public class ProcessUtilTests
             ThrowOnNonZeroReturnCode = false
         };
 
-        var exception = Assert.Throws<InvalidOperationException>(() => ProcessUtil.Run(spec));
+        var exception = Assert.Throws<ArgumentException>(() => ProcessUtil.Run(spec));
 
-        Assert.Equal("Specify either Arguments or ArgumentList, not both.", exception.Message);
+        Assert.StartsWith("Specify either Arguments or ArgumentList, not both.", exception.Message);
+        Assert.Equal("processSpec", exception.ParamName);
     }
 
     [Fact]

--- a/tests/Aspire.Hosting.Tests/PathLookupHelperTests.cs
+++ b/tests/Aspire.Hosting.Tests/PathLookupHelperTests.cs
@@ -7,6 +7,62 @@ namespace Aspire.Cli.Tests.Utils;
 public class PathLookupHelperTests
 {
     [Fact]
+    public void ResolveExecutablePath_SearchesPath_WhenExecutableIsCommandName()
+    {
+        using var tempDirectory = new TestTempDirectory();
+        var binPath = Path.Combine(tempDirectory.Path, "bin");
+        Directory.CreateDirectory(binPath);
+
+        var executableName = OperatingSystem.IsWindows() ? "mycommand.exe" : "mycommand";
+        var executablePath = Path.Combine(binPath, executableName);
+        File.WriteAllText(executablePath, string.Empty);
+
+        var result = PathLookupHelper.ResolveExecutablePath(
+            executableName,
+            new Dictionary<string, string> { ["PATH"] = binPath });
+
+        Assert.Equal(executablePath, result);
+    }
+
+    [Theory]
+    [InlineData("relative/mycommand")]
+    [InlineData("./mycommand")]
+    [InlineData("../mycommand")]
+    public void ResolveExecutablePath_DoesNotSearchPath_WhenExecutablePathIsExplicit(string executablePath)
+    {
+        using var tempDirectory = new TestTempDirectory();
+        var binPath = Path.Combine(tempDirectory.Path, "bin");
+        Directory.CreateDirectory(binPath);
+        File.WriteAllText(Path.Combine(binPath, "mycommand"), string.Empty);
+
+        var result = PathLookupHelper.ResolveExecutablePath(
+            executablePath,
+            new Dictionary<string, string> { ["PATH"] = binPath });
+
+        Assert.Equal(executablePath, result);
+    }
+
+    [Fact]
+    public void ResolveExecutablePath_DoesNotSearchPath_WhenWindowsExecutablePathIsDriveRelative()
+    {
+        if (!OperatingSystem.IsWindows())
+        {
+            return;
+        }
+
+        using var tempDirectory = new TestTempDirectory();
+        var binPath = Path.Combine(tempDirectory.Path, "bin");
+        Directory.CreateDirectory(binPath);
+        File.WriteAllText(Path.Combine(binPath, "mycommand.exe"), string.Empty);
+
+        var result = PathLookupHelper.ResolveExecutablePath(
+            "C:mycommand.exe",
+            new Dictionary<string, string> { ["PATH"] = binPath });
+
+        Assert.Equal("C:mycommand.exe", result);
+    }
+
+    [Fact]
     public void FindFullPathFromPath_WhenCommandExistsOnPath_ReturnsFullPath()
     {
         // Arrange

--- a/tests/Aspire.Hosting.Tests/PathLookupHelperTests.cs
+++ b/tests/Aspire.Hosting.Tests/PathLookupHelperTests.cs
@@ -16,10 +16,50 @@ public class PathLookupHelperTests
         var executableName = OperatingSystem.IsWindows() ? "mycommand.exe" : "mycommand";
         var executablePath = Path.Combine(binPath, executableName);
         File.WriteAllText(executablePath, string.Empty);
+        MakeExecutableOnUnix(executablePath);
 
         var result = PathLookupHelper.ResolveExecutablePath(
             executableName,
             new Dictionary<string, string> { ["PATH"] = binPath });
+
+        Assert.Equal(executablePath, result);
+    }
+
+    [Fact]
+    public void ResolveExecutablePath_Throws_WhenExecutableIsCommandNameAndNotFoundOnPath()
+    {
+        var exception = Assert.Throws<FileNotFoundException>(() => PathLookupHelper.ResolveExecutablePath(
+            "missing-command",
+            new Dictionary<string, string> { ["PATH"] = string.Empty }));
+
+        Assert.Equal("missing-command", exception.FileName);
+    }
+
+    [Fact]
+    public void ResolveExecutablePath_SkipsNonExecutableFilesOnUnix()
+    {
+        if (OperatingSystem.IsWindows())
+        {
+            return;
+        }
+
+        using var tempDirectory = new TestTempDirectory();
+        var firstBinPath = Path.Combine(tempDirectory.Path, "first-bin");
+        var secondBinPath = Path.Combine(tempDirectory.Path, "second-bin");
+        Directory.CreateDirectory(firstBinPath);
+        Directory.CreateDirectory(secondBinPath);
+
+        var nonExecutablePath = Path.Combine(firstBinPath, "mycommand");
+        File.WriteAllText(nonExecutablePath, string.Empty);
+        File.SetUnixFileMode(nonExecutablePath, UnixFileMode.UserRead | UnixFileMode.UserWrite);
+
+        var executablePath = Path.Combine(secondBinPath, "mycommand");
+        File.WriteAllText(executablePath, string.Empty);
+        File.SetUnixFileMode(executablePath, UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.UserExecute);
+
+        var result = PathLookupHelper.ResolveExecutablePath(
+            "mycommand",
+            new Dictionary<string, string> { ["PATH"] = string.Join(Path.PathSeparator, firstBinPath, secondBinPath) });
 
         Assert.Equal(executablePath, result);
     }
@@ -370,5 +410,13 @@ public class PathLookupHelperTests
 
         // Assert - dir1 exact match is found because no extension match exists in dir1
         Assert.Equal(dir1ExactPath, result);
+    }
+
+    private static void MakeExecutableOnUnix(string path)
+    {
+        if (!OperatingSystem.IsWindows())
+        {
+            File.SetUnixFileMode(path, File.GetUnixFileMode(path) | UnixFileMode.UserExecute);
+        }
     }
 }

--- a/tests/Aspire.Hosting.Tests/Utils/DotnetFileAppProcess.cs
+++ b/tests/Aspire.Hosting.Tests/Utils/DotnetFileAppProcess.cs
@@ -1,0 +1,87 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Aspire.Hosting.Dcp.Process;
+
+namespace Aspire.Hosting.Tests.Utils;
+
+#pragma warning disable ASPIREPROCESSCOMMAND001 // Process command APIs are experimental.
+
+internal static class DotnetFileAppProcess
+{
+    public static string ExecutablePath { get; } = Environment.GetEnvironmentVariable("DOTNET_HOST_PATH") ?? "dotnet";
+    public static string ResolvedExecutablePath { get; } = PathLookupHelper.FindFullPathFromPath(ExecutablePath) ?? ExecutablePath;
+
+    public static string WriteApp(TestTempDirectory directory, string fileName, string content)
+    {
+        var appPath = Path.Combine(directory.Path, fileName);
+        File.WriteAllText(appPath, content);
+
+        return appPath;
+    }
+
+    public static ProcessCommandSpec CreateProcessCommandSpec(
+        string appPath,
+        IReadOnlyList<string>? arguments = null,
+        string? workingDirectory = null,
+        IDictionary<string, string>? environmentVariables = null,
+        bool inheritEnvironmentVariables = true,
+        string? standardInputContent = null)
+    {
+        return new ProcessCommandSpec(ExecutablePath)
+        {
+            Arguments = CreateArguments(appPath, arguments),
+            WorkingDirectory = workingDirectory,
+            EnvironmentVariables = environmentVariables ?? new Dictionary<string, string>(),
+            InheritEnvironmentVariables = inheritEnvironmentVariables,
+            StandardInputContent = standardInputContent
+        };
+    }
+
+    public static ProcessCommandExportOptions CreateProcessCommandExportOptions(string appPath, Action<ProcessCommandExportOptions>? configure = null)
+        => CreateProcessCommandExportOptions(appPath, arguments: null, configure);
+
+    public static ProcessCommandExportOptions CreateProcessCommandExportOptions(
+        string appPath,
+        IReadOnlyList<string>? arguments,
+        Action<ProcessCommandExportOptions>? configure = null)
+    {
+        var options = new ProcessCommandExportOptions
+        {
+            ExecutablePath = ExecutablePath,
+            Arguments = CreateArguments(appPath, arguments)
+        };
+
+        configure?.Invoke(options);
+
+        return options;
+    }
+
+    public static ProcessSpec CreateDcpProcessSpec(
+        string appPath,
+        IReadOnlyList<string>? arguments = null,
+        Action<string>? onOutputData = null,
+        Action<string>? onErrorData = null,
+        bool throwOnNonZeroReturnCode = false,
+        int? retainedOutputLineCount = null)
+    {
+        return new ProcessSpec(ExecutablePath)
+        {
+            ArgumentList = CreateArguments(appPath, arguments),
+            OnOutputData = onOutputData,
+            OnErrorData = onErrorData,
+            ThrowOnNonZeroReturnCode = throwOnNonZeroReturnCode,
+            ResolveExecutablePath = true,
+            RetainedOutputLineCount = retainedOutputLineCount
+        };
+    }
+
+    public static string[] CreateArguments(string appPath, IReadOnlyList<string>? arguments = null)
+    {
+        return arguments is null or { Count: 0 }
+            ? ["run", "--file", appPath]
+            : ["run", "--file", appPath, "--", .. arguments];
+    }
+}
+
+#pragma warning restore ASPIREPROCESSCOMMAND001

--- a/tests/Aspire.Hosting.Tests/WithProcessCommandTests.cs
+++ b/tests/Aspire.Hosting.Tests/WithProcessCommandTests.cs
@@ -676,14 +676,10 @@ public class WithProcessCommandTests(ITestOutputHelper testOutputHelper)
                     ExecutablePath = "export-executable",
                     Arguments = ["--from-export"],
                     WorkingDirectory = "/test/export-working-directory",
-                    EnvironmentVariables =
-                    [
-                        new ProcessCommandEnvironmentVariable
-                        {
-                            Name = "PROCESS_COMMAND_EXPORT_VALUE",
-                            Value = "from-export-environment"
-                        }
-                    ],
+                    EnvironmentVariables = new Dictionary<string, string>
+                    {
+                        ["PROCESS_COMMAND_EXPORT_VALUE"] = "from-export-environment"
+                    },
                     InheritEnvironmentVariables = false,
                     StandardInputContent = "from-export-stdin",
                     KillEntireProcessTree = false,
@@ -762,35 +758,20 @@ public class WithProcessCommandTests(ITestOutputHelper testOutputHelper)
                 new ProcessCommandExportOptions
                 {
                     ExecutablePath = "test-command",
-                    EnvironmentVariables = [null!]
-                },
-                "environment variables cannot contain null entries"),
-            (
-                new ProcessCommandExportOptions
-                {
-                    ExecutablePath = "test-command",
-                    EnvironmentVariables =
-                    [
-                        new ProcessCommandEnvironmentVariable
-                        {
-                            Name = " ",
-                            Value = "value"
-                        }
-                    ]
+                    EnvironmentVariables = new Dictionary<string, string>
+                    {
+                        [" "] = "value"
+                    }
                 },
                 "environment variables require non-empty names"),
             (
                 new ProcessCommandExportOptions
                 {
                     ExecutablePath = "test-command",
-                    EnvironmentVariables =
-                    [
-                        new ProcessCommandEnvironmentVariable
-                        {
-                            Name = "PROCESS_COMMAND_EXPORT_VALUE",
-                            Value = null
-                        }
-                    ]
+                    EnvironmentVariables = new Dictionary<string, string>
+                    {
+                        ["PROCESS_COMMAND_EXPORT_VALUE"] = null!
+                    }
                 },
                 "environment variable 'PROCESS_COMMAND_EXPORT_VALUE' requires a value")
         };

--- a/tests/Aspire.Hosting.Tests/WithProcessCommandTests.cs
+++ b/tests/Aspire.Hosting.Tests/WithProcessCommandTests.cs
@@ -1,0 +1,1184 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Aspire.Hosting.Dcp.Process;
+using Aspire.Hosting.Tests.Utils;
+using Aspire.Hosting.Testing;
+using Aspire.Hosting.Utils;
+using Microsoft.AspNetCore.InternalTesting;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Aspire.Hosting.Tests;
+
+#pragma warning disable ASPIREINTERACTION001 // InteractionInput is used to describe resource command arguments.
+#pragma warning disable ASPIREPROCESSCOMMAND001 // Process command APIs are experimental.
+
+[Trait("Partition", "6")]
+public class WithProcessCommandTests(ITestOutputHelper testOutputHelper)
+{
+    [Fact]
+    public void WithProcessCommand_AddsResourceCommandAnnotation_WithCustomValues()
+    {
+        using var builder = CreateTestDistributedApplicationBuilder();
+
+        var resourceBuilder = builder.AddResource(new CustomResource("resource"))
+            .WithProcessCommand(
+                "my-command",
+                "Run command",
+                "dotnet",
+                ["--version"],
+                new ProcessCommandOptions
+                {
+                    Description = "Command description",
+                    ConfirmationMessage = "Are you sure?",
+                    IconName = "Command",
+                    IconVariant = IconVariant.Filled,
+                    IsHighlighted = true,
+                    Arguments =
+                    [
+                        new InteractionInput
+                        {
+                            Name = "target",
+                            InputType = InputType.Text
+                        }
+                    ]
+                });
+
+        var command = resourceBuilder.Resource.Annotations.OfType<ResourceCommandAnnotation>().Single();
+
+        Assert.Equal("my-command", command.Name);
+        Assert.Equal("Run command", command.DisplayName);
+        Assert.Equal("Command description", command.DisplayDescription);
+        Assert.Equal("Are you sure?", command.ConfirmationMessage);
+        Assert.Equal("Command", command.IconName);
+        Assert.Equal(IconVariant.Filled, command.IconVariant);
+        Assert.True(command.IsHighlighted);
+        var argument = Assert.Single(command.Arguments);
+        Assert.Equal("target", argument.Name);
+    }
+
+    [Fact]
+    public async Task WithProcessCommandExport_AddsResourceCommandAnnotationAndRunsProcess()
+    {
+        var processRunner = new TestProcessRunner();
+        processRunner.EnqueueResult(output: ["export-line"]);
+        using var builder = CreateTestDistributedApplicationBuilder(processRunner);
+
+        var resource = builder.AddResource(new CustomResource("resource"))
+            .WithProcessCommandExport(
+                "export-command",
+                "Run export command",
+                new ProcessCommandExportOptions
+                {
+                    ExecutablePath = "export-command-executable",
+                    Arguments = ["--export"],
+                    CommandOptions = new CommandOptions
+                    {
+                        Description = "Export command description",
+                        ConfirmationMessage = "Run export command?",
+                        IconName = "Command",
+                        IconVariant = IconVariant.Filled,
+                        IsHighlighted = true
+                    },
+                    MaxOutputLineCount = 5,
+                    DisplayImmediately = false
+                });
+
+        var command = resource.Resource.Annotations.OfType<ResourceCommandAnnotation>().Single();
+
+        Assert.Equal("export-command", command.Name);
+        Assert.Equal("Run export command", command.DisplayName);
+        Assert.Equal("Export command description", command.DisplayDescription);
+        Assert.Equal("Run export command?", command.ConfirmationMessage);
+        Assert.Equal("Command", command.IconName);
+        Assert.Equal(IconVariant.Filled, command.IconVariant);
+        Assert.True(command.IsHighlighted);
+
+        using var app = builder.Build();
+        await app.StartAsync().DefaultTimeout();
+
+        var result = await app.ResourceCommands.ExecuteCommandAsync(resource.Resource, "export-command").DefaultTimeout();
+
+        Assert.True(result.Success);
+        Assert.Equal(CommandResultFormat.Text, result.Data?.Format);
+        Assert.False(result.Data?.DisplayImmediately);
+        Assert.Contains("export-line", result.Data?.Value);
+
+        var processSpec = Assert.Single(processRunner.ProcessSpecs);
+        Assert.Equal("export-command-executable", processSpec.ExecutablePath);
+        Assert.Equal(["--export"], processSpec.ArgumentList);
+        Assert.Equal(5, processSpec.RetainedOutputLineCount);
+        Assert.True(processSpec.ResolveExecutablePath);
+        Assert.False(processSpec.ThrowOnNonZeroReturnCode);
+    }
+
+    [Fact]
+    public async Task WithProcessCommand_ProcessFactoryReceivesExecutionContextAndArguments()
+    {
+        var processRunner = new TestProcessRunner();
+        processRunner.EnqueueResult(output: ["hello-from-argument"]);
+        using var builder = CreateTestDistributedApplicationBuilder(processRunner);
+
+        ExecuteCommandContext? capturedContext = null;
+        var resource = builder.AddResource(new CustomResource("resource"))
+            .WithProcessCommand(
+                "echo-argument",
+                "Echo argument",
+                context =>
+                {
+                    capturedContext = context;
+                    var message = context.Arguments.GetString("message");
+                    return CreateProcessCommandSpec(arguments: [message ?? string.Empty]);
+                },
+                new ProcessCommandOptions
+                {
+                    Arguments =
+                    [
+                        new InteractionInput
+                        {
+                            Name = "message",
+                            InputType = InputType.Text
+                        }
+                    ]
+                });
+
+        using var app = builder.Build();
+        await app.StartAsync().DefaultTimeout();
+
+        var arguments = new InteractionInputCollection(
+        [
+            new InteractionInput
+            {
+                Name = "message",
+                InputType = InputType.Text,
+                Value = "hello-from-argument"
+            }
+        ]);
+
+        var result = await app.ResourceCommands.ExecuteCommandAsync(resource.Resource, "echo-argument", arguments).DefaultTimeout();
+
+        Assert.True(result.Success);
+        Assert.Equal(CommandResultFormat.Text, result.Data?.Format);
+        Assert.Contains("hello-from-argument", result.Data?.Value);
+        Assert.NotNull(capturedContext);
+        Assert.Equal(resource.Resource.Name, capturedContext.ResourceName);
+        Assert.NotNull(capturedContext.ServiceProvider);
+        Assert.Equal("hello-from-argument", capturedContext.Arguments.GetString("message"));
+        Assert.NotNull(capturedContext.Logger);
+
+        var processSpec = Assert.Single(processRunner.ProcessSpecs);
+        Assert.Equal(["hello-from-argument"], processSpec.ArgumentList);
+    }
+
+    [Fact]
+    public async Task WithProcessCommand_AwaitsAsyncProcessFactory()
+    {
+        var processRunner = new TestProcessRunner();
+        processRunner.EnqueueResult(output: ["async-factory-output"]);
+        using var builder = CreateTestDistributedApplicationBuilder(processRunner);
+        var factoryAwaited = false;
+
+        async ValueTask<ProcessCommandSpec> CreateSpecAsync(ExecuteCommandContext _)
+        {
+            await Task.Yield();
+            factoryAwaited = true;
+
+            return CreateProcessCommandSpec(arguments: ["from-async-factory"]);
+        }
+
+        var resource = builder.AddResource(new CustomResource("resource"))
+            .WithProcessCommand(
+                "async-factory",
+                "Async factory",
+                CreateSpecAsync);
+
+        using var app = builder.Build();
+        await app.StartAsync().DefaultTimeout();
+
+        var result = await app.ResourceCommands.ExecuteCommandAsync(resource.Resource, "async-factory").DefaultTimeout();
+
+        Assert.True(result.Success);
+        Assert.True(factoryAwaited);
+        Assert.Contains("async-factory-output", result.Data?.Value);
+        var processSpec = Assert.Single(processRunner.ProcessSpecs);
+        Assert.Equal(["from-async-factory"], processSpec.ArgumentList);
+    }
+
+    [Fact]
+    public async Task WithProcessCommand_ExecutesFreshProcessForEachInvocation()
+    {
+        var processRunner = new TestProcessRunner();
+        processRunner.EnqueueResult(output: ["first-output"]);
+        processRunner.EnqueueResult(exitCode: 3, output: ["second-output"]);
+        using var builder = CreateTestDistributedApplicationBuilder(processRunner);
+        var invocationCount = 0;
+
+        var resource = builder.AddResource(new CustomResource("resource"))
+            .WithProcessCommand(
+                "repeat",
+                "Repeat",
+                _ =>
+                {
+                    invocationCount++;
+
+                    return CreateProcessCommandSpec(
+                        executablePath: $"test-command-{invocationCount}",
+                        arguments: [$"arg-{invocationCount}"]);
+                });
+
+        using var app = builder.Build();
+        await app.StartAsync().DefaultTimeout();
+
+        var firstResult = await app.ResourceCommands.ExecuteCommandAsync(resource.Resource, "repeat").DefaultTimeout();
+        var secondResult = await app.ResourceCommands.ExecuteCommandAsync(resource.Resource, "repeat").DefaultTimeout();
+
+        Assert.True(firstResult.Success);
+        Assert.Contains("first-output", firstResult.Data?.Value);
+        Assert.False(secondResult.Success);
+        Assert.Contains("returned non-zero exit code 3", secondResult.Message);
+        Assert.Contains("second-output", secondResult.Data?.Value);
+
+        Assert.Collection(
+            processRunner.ProcessSpecs,
+            processSpec =>
+            {
+                Assert.Equal("test-command-1", processSpec.ExecutablePath);
+                Assert.Equal(["arg-1"], processSpec.ArgumentList);
+            },
+            processSpec =>
+            {
+                Assert.Equal("test-command-2", processSpec.ExecutablePath);
+                Assert.Equal(["arg-2"], processSpec.ArgumentList);
+            });
+    }
+
+    [Fact]
+    public async Task WithProcessCommand_ReturnsBoundedOutput()
+    {
+        var processRunner = new TestProcessRunner();
+        processRunner.EnqueueResult(output: ["line-3", "line-4", "line-5"], totalOutputLineCount: 5);
+        using var builder = CreateTestDistributedApplicationBuilder(processRunner);
+
+        var resource = builder.AddResource(new CustomResource("resource"))
+            .WithProcessCommand(
+                "many-lines",
+                "Many lines",
+                _ => CreateProcessCommandSpec(),
+                new ProcessCommandOptions
+                {
+                    MaxOutputLineCount = 3
+                });
+
+        using var app = builder.Build();
+        await app.StartAsync().DefaultTimeout();
+
+        var result = await app.ResourceCommands.ExecuteCommandAsync(resource.Resource, "many-lines").DefaultTimeout();
+
+        Assert.True(result.Success);
+        Assert.NotNull(result.Data);
+        Assert.Equal(CommandResultFormat.Text, result.Data.Format);
+        Assert.True(result.Data.DisplayImmediately);
+        Assert.Contains("Command output truncated: showing last 3 of 5 lines.", result.Data.Value);
+        Assert.DoesNotContain("line-1", result.Data.Value);
+        Assert.DoesNotContain("line-2", result.Data.Value);
+        Assert.Contains("line-3", result.Data.Value);
+        Assert.Contains("line-5", result.Data.Value);
+    }
+
+    [Fact]
+    public async Task WithProcessCommand_DisplayImmediately_CanBeDisabled()
+    {
+        var processRunner = new TestProcessRunner();
+        processRunner.EnqueueResult(output: ["display-immediately-output"]);
+        using var builder = CreateTestDistributedApplicationBuilder(processRunner);
+
+        var resource = builder.AddResource(new CustomResource("resource"))
+            .WithProcessCommand(
+                "display-immediately",
+                "Display immediately",
+                _ => CreateProcessCommandSpec(),
+                new ProcessCommandOptions
+                {
+                    DisplayImmediately = false
+                });
+
+        using var app = builder.Build();
+        await app.StartAsync().DefaultTimeout();
+
+        var result = await app.ResourceCommands.ExecuteCommandAsync(resource.Resource, "display-immediately").DefaultTimeout();
+
+        Assert.True(result.Success);
+        Assert.NotNull(result.Data);
+        Assert.False(result.Data.DisplayImmediately);
+        Assert.Contains("display-immediately-output", result.Data.Value);
+    }
+
+    [Fact]
+    public async Task WithProcessCommand_SuccessWithoutOutput_ReturnsNoResultData()
+    {
+        var processRunner = new TestProcessRunner();
+        processRunner.EnqueueResult();
+        using var builder = CreateTestDistributedApplicationBuilder(processRunner);
+
+        var resource = builder.AddResource(new CustomResource("resource"))
+            .WithProcessCommand(
+                "no-output",
+                "No output",
+                _ => CreateProcessCommandSpec());
+
+        using var app = builder.Build();
+        await app.StartAsync().DefaultTimeout();
+
+        var result = await app.ResourceCommands.ExecuteCommandAsync(resource.Resource, "no-output").DefaultTimeout();
+
+        Assert.True(result.Success);
+        Assert.Null(result.Data);
+    }
+
+    [Fact]
+    public async Task WithProcessCommand_NonZeroExitWithoutOutput_ReturnsFailureWithoutResultData()
+    {
+        var processRunner = new TestProcessRunner();
+        processRunner.EnqueueResult(exitCode: 9);
+        using var builder = CreateTestDistributedApplicationBuilder(processRunner);
+
+        var resource = builder.AddResource(new CustomResource("resource"))
+            .WithProcessCommand(
+                "fail-no-output",
+                "Fail without output",
+                _ => CreateProcessCommandSpec());
+
+        using var app = builder.Build();
+        await app.StartAsync().DefaultTimeout();
+
+        var result = await app.ResourceCommands.ExecuteCommandAsync(resource.Resource, "fail-no-output").DefaultTimeout();
+
+        Assert.False(result.Success);
+        Assert.Contains("returned non-zero exit code 9", result.Message);
+        Assert.Null(result.Data);
+    }
+
+    [Fact]
+    public async Task WithProcessCommand_NonZeroExitWithOutput_HonorsDisplayImmediatelyOption()
+    {
+        var processRunner = new TestProcessRunner();
+        processRunner.EnqueueResult(exitCode: 2, output: ["failure-output"]);
+        using var builder = CreateTestDistributedApplicationBuilder(processRunner);
+
+        var resource = builder.AddResource(new CustomResource("resource"))
+            .WithProcessCommand(
+                "failure-display-immediately",
+                "Failure display immediately",
+                _ => CreateProcessCommandSpec(),
+                new ProcessCommandOptions
+                {
+                    DisplayImmediately = false
+                });
+
+        using var app = builder.Build();
+        await app.StartAsync().DefaultTimeout();
+
+        var result = await app.ResourceCommands.ExecuteCommandAsync(resource.Resource, "failure-display-immediately").DefaultTimeout();
+
+        Assert.False(result.Success);
+        Assert.NotNull(result.Data);
+        Assert.False(result.Data.DisplayImmediately);
+        Assert.Contains("failure-output", result.Data.Value);
+    }
+
+    [Fact]
+    public async Task WithProcessCommand_StreamsStdoutAndStderrToResourceLoggerAndResult()
+    {
+        var processRunner = new TestProcessRunner();
+        processRunner.EnqueueResult(output: ["stdout-line"], error: ["stderr-line"]);
+        using var builder = CreateTestDistributedApplicationBuilder(processRunner);
+
+        var resource = builder.AddResource(new CustomResource("resource"))
+            .WithProcessCommand(
+                "log-output",
+                "Log output",
+                _ => CreateProcessCommandSpec());
+
+        using var app = builder.Build();
+        await app.StartAsync().DefaultTimeout();
+
+        var result = await app.ResourceCommands.ExecuteCommandAsync(resource.Resource, "log-output").DefaultTimeout();
+
+        Assert.True(result.Success);
+        Assert.Contains("stdout-line", result.Data?.Value);
+        Assert.Contains("stderr-line", result.Data?.Value);
+
+        var loggerService = app.Services.GetRequiredService<ResourceLoggerService>();
+        var logs = await ConsoleLoggingTestHelpers.WatchForLogsAsync(loggerService, 4, resource.Resource).DefaultTimeout();
+        var logContents = logs.Select(log => log.Content).ToArray();
+
+        Assert.Contains(logContents, log => log.Contains("(stdout): stdout-line", StringComparison.Ordinal));
+        Assert.Contains(logContents, log => log.Contains("(stderr): stderr-line", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public async Task WithProcessCommand_ReturnsOutputInRunnerObservedOrder()
+    {
+        var processRunner = new TestProcessRunner();
+        processRunner.EnqueueResult(
+            outputEvents:
+            [
+                Output("stdout-1"),
+                Error("stderr-1"),
+                Output("stdout-2")
+            ]);
+        using var builder = CreateTestDistributedApplicationBuilder(processRunner);
+
+        var resource = builder.AddResource(new CustomResource("resource"))
+            .WithProcessCommand(
+                "ordered-output",
+                "Ordered output",
+                _ => CreateProcessCommandSpec());
+
+        using var app = builder.Build();
+        await app.StartAsync().DefaultTimeout();
+
+        var result = await app.ResourceCommands.ExecuteCommandAsync(resource.Resource, "ordered-output").DefaultTimeout();
+
+        Assert.True(result.Success);
+        Assert.NotNull(result.Data);
+        Assert.Equal(
+            ["stdout-1", "stderr-1", "stdout-2"],
+            result.Data.Value.Split(Environment.NewLine, StringSplitOptions.None));
+    }
+
+    [Fact]
+    public async Task WithProcessCommand_NonZeroExit_ReturnsFailureWithBoundedOutput()
+    {
+        var processRunner = new TestProcessRunner();
+        processRunner.EnqueueResult(exitCode: 7, output: ["failed-line"]);
+        using var builder = CreateTestDistributedApplicationBuilder(processRunner);
+
+        var resource = builder.AddResource(new CustomResource("resource"))
+            .WithProcessCommand(
+                "fail",
+                "Fail",
+                _ => CreateProcessCommandSpec(),
+                new ProcessCommandOptions
+                {
+                    MaxOutputLineCount = 5
+                });
+
+        using var app = builder.Build();
+        await app.StartAsync().DefaultTimeout();
+
+        var result = await app.ResourceCommands.ExecuteCommandAsync(resource.Resource, "fail").DefaultTimeout();
+
+        Assert.False(result.Success);
+        Assert.False(result.Canceled);
+        Assert.NotEqual("Unhandled exception thrown.", result.Message);
+        Assert.Contains("returned non-zero exit code 7", result.Message);
+        Assert.Equal(CommandResultFormat.Text, result.Data?.Format);
+        Assert.True(result.Data?.DisplayImmediately);
+        Assert.Contains("failed-line", result.Data?.Value);
+    }
+
+    [Fact]
+    public async Task WithProcessCommand_PreservesArgumentValues()
+    {
+        var processRunner = new TestProcessRunner();
+        processRunner.EnqueueResult();
+        using var builder = CreateTestDistributedApplicationBuilder(processRunner);
+        string[] expectedArguments =
+        [
+            "value with spaces",
+            "quote\"value",
+            "",
+            "$HOME && rm -rf /",
+            "semi;colon"
+        ];
+
+        var resource = builder.AddResource(new CustomResource("resource"))
+            .WithProcessCommand(
+                "argument-fidelity",
+                "Argument fidelity",
+                _ => CreateProcessCommandSpec(arguments: expectedArguments));
+
+        using var app = builder.Build();
+        await app.StartAsync().DefaultTimeout();
+
+        var result = await app.ResourceCommands.ExecuteCommandAsync(resource.Resource, "argument-fidelity").DefaultTimeout();
+
+        Assert.True(result.Success);
+        var processSpec = Assert.Single(processRunner.ProcessSpecs);
+        Assert.Equal(expectedArguments, processSpec.ArgumentList);
+        Assert.Null(processSpec.Arguments);
+    }
+
+    [Fact]
+    public async Task WithProcessCommand_StandardInputContent_FlowsToProcessSpec()
+    {
+        var processRunner = new TestProcessRunner();
+        processRunner.EnqueueResult();
+        using var builder = CreateTestDistributedApplicationBuilder(processRunner);
+
+        var resource = builder.AddResource(new CustomResource("resource"))
+            .WithProcessCommand(
+                "stdin",
+                "Standard input",
+                _ => CreateProcessCommandSpec(standardInputContent: "from-standard-input"));
+
+        using var app = builder.Build();
+        await app.StartAsync().DefaultTimeout();
+
+        var result = await app.ResourceCommands.ExecuteCommandAsync(resource.Resource, "stdin").DefaultTimeout();
+
+        Assert.True(result.Success);
+        var processSpec = Assert.Single(processRunner.ProcessSpecs);
+        Assert.Equal("from-standard-input", processSpec.StandardInputContent);
+    }
+
+    [Fact]
+    public async Task WithProcessCommand_EnablesExecutablePathResolution()
+    {
+        var processRunner = new TestProcessRunner();
+        processRunner.EnqueueResult();
+        using var builder = CreateTestDistributedApplicationBuilder(processRunner);
+
+        var resource = builder.AddResource(new CustomResource("resource"))
+            .WithProcessCommand(
+                "path-executable",
+                "Path executable",
+                _ => CreateProcessCommandSpec("test-command-name"));
+
+        using var app = builder.Build();
+        await app.StartAsync().DefaultTimeout();
+
+        var result = await app.ResourceCommands.ExecuteCommandAsync(resource.Resource, "path-executable").DefaultTimeout();
+
+        Assert.True(result.Success);
+        var processSpec = Assert.Single(processRunner.ProcessSpecs);
+        Assert.Equal("test-command-name", processSpec.ExecutablePath);
+        Assert.True(processSpec.ResolveExecutablePath);
+    }
+
+    [Fact]
+    public async Task WithProcessCommand_WorkingDirectory_FlowsToProcessSpec()
+    {
+        var processRunner = new TestProcessRunner();
+        processRunner.EnqueueResult();
+        using var builder = CreateTestDistributedApplicationBuilder(processRunner);
+
+        var resource = builder.AddResource(new CustomResource("resource"))
+            .WithProcessCommand(
+                "working-directory",
+                "Working directory",
+                _ => CreateProcessCommandSpec(workingDirectory: "/test/working-directory"));
+
+        using var app = builder.Build();
+        await app.StartAsync().DefaultTimeout();
+
+        var result = await app.ResourceCommands.ExecuteCommandAsync(resource.Resource, "working-directory").DefaultTimeout();
+
+        Assert.True(result.Success);
+        var processSpec = Assert.Single(processRunner.ProcessSpecs);
+        Assert.Equal("/test/working-directory", processSpec.WorkingDirectory);
+    }
+
+    [Fact]
+    public async Task WithProcessCommand_EnvironmentVariables_FlowToProcessSpec()
+    {
+        var processRunner = new TestProcessRunner();
+        processRunner.EnqueueResult();
+        using var builder = CreateTestDistributedApplicationBuilder(processRunner);
+
+        var environmentVariables = new Dictionary<string, string>
+        {
+            ["PROCESS_COMMAND_TEST_VALUE"] = "from-environment"
+        };
+
+        var resource = builder.AddResource(new CustomResource("resource"))
+            .WithProcessCommand(
+                "environment",
+                "Environment",
+                _ => CreateProcessCommandSpec(environmentVariables: environmentVariables));
+
+        using var app = builder.Build();
+        await app.StartAsync().DefaultTimeout();
+
+        var result = await app.ResourceCommands.ExecuteCommandAsync(resource.Resource, "environment").DefaultTimeout();
+
+        Assert.True(result.Success);
+        var processSpec = Assert.Single(processRunner.ProcessSpecs);
+        Assert.Equal("from-environment", processSpec.EnvironmentVariables["PROCESS_COMMAND_TEST_VALUE"]);
+    }
+
+    [Fact]
+    public async Task WithProcessCommand_InvalidEnvironmentVariableName_ReturnsFailureWithoutCreatingProcess()
+    {
+        var processRunner = new TestProcessRunner();
+        using var builder = CreateTestDistributedApplicationBuilder(processRunner);
+
+        var resource = builder.AddResource(new CustomResource("resource"))
+            .WithProcessCommand(
+                "invalid-environment-name",
+                "Invalid environment name",
+                _ => CreateProcessCommandSpec(
+                    environmentVariables: new Dictionary<string, string>
+                    {
+                        [""] = "value"
+                    }));
+
+        using var app = builder.Build();
+        await app.StartAsync().DefaultTimeout();
+
+        var result = await app.ResourceCommands.ExecuteCommandAsync(resource.Resource, "invalid-environment-name").DefaultTimeout();
+
+        Assert.False(result.Success);
+        Assert.Contains("environment variables require non-empty names", result.Message);
+        Assert.Empty(processRunner.ProcessSpecs);
+    }
+
+    [Fact]
+    public async Task WithProcessCommand_NullEnvironmentVariableValue_ReturnsFailureWithoutCreatingProcess()
+    {
+        var processRunner = new TestProcessRunner();
+        using var builder = CreateTestDistributedApplicationBuilder(processRunner);
+
+        var resource = builder.AddResource(new CustomResource("resource"))
+            .WithProcessCommand(
+                "null-environment-value",
+                "Null environment value",
+                _ => CreateProcessCommandSpec(
+                    environmentVariables: new Dictionary<string, string>
+                    {
+                        ["PROCESS_COMMAND_TEST_VALUE"] = null!
+                    }));
+
+        using var app = builder.Build();
+        await app.StartAsync().DefaultTimeout();
+
+        var result = await app.ResourceCommands.ExecuteCommandAsync(resource.Resource, "null-environment-value").DefaultTimeout();
+
+        Assert.False(result.Success);
+        Assert.Contains("environment variable 'PROCESS_COMMAND_TEST_VALUE' requires a value", result.Message);
+        Assert.Empty(processRunner.ProcessSpecs);
+    }
+
+    [Fact]
+    public async Task WithProcessCommandExport_ProcessOptionsFlowToProcessSpec()
+    {
+        var processRunner = new TestProcessRunner();
+        processRunner.EnqueueResult(output: ["export-options-output"]);
+        using var builder = CreateTestDistributedApplicationBuilder(processRunner);
+
+        var resource = builder.AddResource(new CustomResource("resource"))
+            .WithProcessCommandExport(
+                "export-options",
+                "Export options",
+                new ProcessCommandExportOptions
+                {
+                    ExecutablePath = "export-executable",
+                    Arguments = ["--from-export"],
+                    WorkingDirectory = "/test/export-working-directory",
+                    EnvironmentVariables =
+                    [
+                        new ProcessCommandEnvironmentVariable
+                        {
+                            Name = "PROCESS_COMMAND_EXPORT_VALUE",
+                            Value = "from-export-environment"
+                        }
+                    ],
+                    InheritEnvironmentVariables = false,
+                    StandardInputContent = "from-export-stdin",
+                    KillEntireProcessTree = false,
+                    MaxOutputLineCount = 10,
+                    DisplayImmediately = false
+                });
+
+        using var app = builder.Build();
+        await app.StartAsync().DefaultTimeout();
+
+        var result = await app.ResourceCommands.ExecuteCommandAsync(resource.Resource, "export-options").DefaultTimeout();
+
+        Assert.True(result.Success);
+        Assert.NotNull(result.Data);
+        Assert.False(result.Data.DisplayImmediately);
+        Assert.Contains("export-options-output", result.Data.Value);
+
+        var processSpec = Assert.Single(processRunner.ProcessSpecs);
+        Assert.Equal("export-executable", processSpec.ExecutablePath);
+        Assert.Equal(["--from-export"], processSpec.ArgumentList);
+        Assert.Equal("/test/export-working-directory", processSpec.WorkingDirectory);
+        Assert.Equal("from-export-environment", processSpec.EnvironmentVariables["PROCESS_COMMAND_EXPORT_VALUE"]);
+        Assert.False(processSpec.InheritEnv);
+        Assert.Equal("from-export-stdin", processSpec.StandardInputContent);
+        Assert.False(processSpec.KillEntireProcessTree);
+        Assert.Equal(10, processSpec.RetainedOutputLineCount);
+    }
+
+    [Fact]
+    public async Task WithProcessCommandExport_InvalidProcessOptions_ReturnsFailureWithoutCreatingProcess()
+    {
+        var invalidOptions = new (ProcessCommandExportOptions Options, string ExpectedMessage)[]
+        {
+            (
+                new ProcessCommandExportOptions
+                {
+                    ExecutablePath = ""
+                },
+                "requires a non-empty executable path"),
+            (
+                new ProcessCommandExportOptions
+                {
+                    ExecutablePath = "test-command",
+                    Arguments = ["valid", null!]
+                },
+                "arguments cannot contain null values"),
+            (
+                new ProcessCommandExportOptions
+                {
+                    ExecutablePath = "test-command",
+                    EnvironmentVariables = [null!]
+                },
+                "environment variables cannot contain null entries"),
+            (
+                new ProcessCommandExportOptions
+                {
+                    ExecutablePath = "test-command",
+                    EnvironmentVariables =
+                    [
+                        new ProcessCommandEnvironmentVariable
+                        {
+                            Name = " ",
+                            Value = "value"
+                        }
+                    ]
+                },
+                "environment variables require non-empty names"),
+            (
+                new ProcessCommandExportOptions
+                {
+                    ExecutablePath = "test-command",
+                    EnvironmentVariables =
+                    [
+                        new ProcessCommandEnvironmentVariable
+                        {
+                            Name = "PROCESS_COMMAND_EXPORT_VALUE",
+                            Value = null
+                        }
+                    ]
+                },
+                "environment variable 'PROCESS_COMMAND_EXPORT_VALUE' requires a value")
+        };
+
+        for (var i = 0; i < invalidOptions.Length; i++)
+        {
+            var (options, expectedMessage) = invalidOptions[i];
+            var processRunner = new TestProcessRunner();
+            using var builder = CreateTestDistributedApplicationBuilder(processRunner);
+            var resource = builder.AddResource(new CustomResource($"resource-{i}"))
+                .WithProcessCommandExport(
+                    $"invalid-export-{i}",
+                    "Invalid export",
+                    options);
+
+            using var app = builder.Build();
+            await app.StartAsync().DefaultTimeout();
+
+            var result = await app.ResourceCommands.ExecuteCommandAsync(resource.Resource, $"invalid-export-{i}").DefaultTimeout();
+
+            Assert.False(result.Success);
+            Assert.Contains(expectedMessage, result.Message);
+            Assert.Empty(processRunner.ProcessSpecs);
+        }
+    }
+
+    [Fact]
+    public void WithProcessCommandExport_InvalidMaxOutputLineCount_ThrowsWhenAddingCommand()
+    {
+        using var builder = CreateTestDistributedApplicationBuilder();
+
+        var exception = Assert.Throws<DistributedApplicationException>(() =>
+            builder.AddResource(new CustomResource("resource"))
+                .WithProcessCommandExport(
+                    "invalid-output-line-count",
+                    "Invalid output line count",
+                    new ProcessCommandExportOptions
+                    {
+                        ExecutablePath = "test-command",
+                        MaxOutputLineCount = 0
+                    }));
+
+        Assert.Contains("output line count must be greater than zero", exception.Message);
+    }
+
+    [Fact]
+    public async Task WithProcessCommand_CanDisableEnvironmentInheritance()
+    {
+        var processRunner = new TestProcessRunner();
+        processRunner.EnqueueResult();
+        using var builder = CreateTestDistributedApplicationBuilder(processRunner);
+
+        var resource = builder.AddResource(new CustomResource("resource"))
+            .WithProcessCommand(
+                "environment-inheritance",
+                "Environment inheritance",
+                _ => CreateProcessCommandSpec(
+                    arguments: ["inherited-variable"],
+                    inheritEnvironmentVariables: false));
+
+        using var app = builder.Build();
+        await app.StartAsync().DefaultTimeout();
+
+        var result = await app.ResourceCommands.ExecuteCommandAsync(resource.Resource, "environment-inheritance").DefaultTimeout();
+
+        Assert.True(result.Success);
+        var processSpec = Assert.Single(processRunner.ProcessSpecs);
+        Assert.False(processSpec.InheritEnv);
+    }
+
+    [Fact]
+    public async Task WithProcessCommand_ProcessStartFailure_ReturnsFailure()
+    {
+        var processRunner = new TestProcessRunner();
+        processRunner.EnqueueException(new InvalidOperationException("process start failed"));
+        using var builder = CreateTestDistributedApplicationBuilder(processRunner);
+
+        var resource = builder.AddResource(new CustomResource("resource"))
+            .WithProcessCommand(
+                "missing",
+                "Missing",
+                "aspire-process-command-missing-executable");
+
+        using var app = builder.Build();
+        await app.StartAsync().DefaultTimeout();
+
+        var result = await app.ResourceCommands.ExecuteCommandAsync(resource.Resource, "missing").DefaultTimeout();
+
+        Assert.False(result.Success);
+        Assert.False(result.Canceled);
+        Assert.Equal("process start failed", result.Message);
+        Assert.NotEqual("Unhandled exception thrown.", result.Message);
+    }
+
+    [Fact]
+    public async Task WithProcessCommand_ProcessTaskFailure_ReturnsFailureAndDisposesProcess()
+    {
+        var processRunner = new TestProcessRunner();
+        processRunner.EnqueuePending(Task.FromException<ProcessResult>(new InvalidOperationException("process failed after start")));
+        using var builder = CreateTestDistributedApplicationBuilder(processRunner);
+
+        var resource = builder.AddResource(new CustomResource("resource"))
+            .WithProcessCommand(
+                "process-task-failure",
+                "Process task failure",
+                "test-command");
+
+        using var app = builder.Build();
+        await app.StartAsync().DefaultTimeout();
+
+        var result = await app.ResourceCommands.ExecuteCommandAsync(resource.Resource, "process-task-failure").DefaultTimeout();
+
+        Assert.False(result.Success);
+        Assert.False(result.Canceled);
+        Assert.Equal("process failed after start", result.Message);
+        Assert.Contains(processRunner.Disposables, disposable => disposable.DisposeCallCount > 0);
+    }
+
+    [Fact]
+    public async Task WithProcessCommand_NullProcessSpecFactoryResult_ReturnsFailure()
+    {
+        using var builder = CreateTestDistributedApplicationBuilder();
+        Func<ExecuteCommandContext, ValueTask<ProcessCommandSpec>> processSpecFactory = _ => new ValueTask<ProcessCommandSpec>((ProcessCommandSpec)null!);
+
+        var resource = builder.AddResource(new CustomResource("resource"))
+            .WithProcessCommand(
+                "null-process-spec",
+                "Null process spec",
+                processSpecFactory);
+
+        using var app = builder.Build();
+        await app.StartAsync().DefaultTimeout();
+
+        var result = await app.ResourceCommands.ExecuteCommandAsync(resource.Resource, "null-process-spec").DefaultTimeout();
+
+        Assert.False(result.Success);
+        Assert.Contains("factory returned null", result.Message);
+    }
+
+    [Fact]
+    public async Task WithProcessCommand_ProcessSpecFactoryException_ReturnsFailureWithoutCreatingProcess()
+    {
+        var processRunner = new TestProcessRunner();
+        using var builder = CreateTestDistributedApplicationBuilder(processRunner);
+
+        static ProcessCommandSpec CreateSpec(ExecuteCommandContext _)
+        {
+            throw new InvalidOperationException("factory failed");
+        }
+
+        var resource = builder.AddResource(new CustomResource("resource"))
+            .WithProcessCommand(
+                "factory-exception",
+                "Factory exception",
+                CreateSpec);
+
+        using var app = builder.Build();
+        await app.StartAsync().DefaultTimeout();
+
+        var result = await app.ResourceCommands.ExecuteCommandAsync(resource.Resource, "factory-exception").DefaultTimeout();
+
+        Assert.False(result.Success);
+        Assert.Equal("factory failed", result.Message);
+        Assert.Empty(processRunner.ProcessSpecs);
+    }
+
+    [Fact]
+    public async Task WithProcessCommand_NullArgument_ReturnsFailure()
+    {
+        using var builder = CreateTestDistributedApplicationBuilder();
+
+        var resource = builder.AddResource(new CustomResource("resource"))
+            .WithProcessCommand(
+                "null-argument",
+                "Null argument",
+                _ => new ProcessCommandSpec("test-command")
+                {
+                    Arguments = [null!]
+                });
+
+        using var app = builder.Build();
+        await app.StartAsync().DefaultTimeout();
+
+        var result = await app.ResourceCommands.ExecuteCommandAsync(resource.Resource, "null-argument").DefaultTimeout();
+
+        Assert.False(result.Success);
+        Assert.Contains("arguments cannot contain null values", result.Message);
+    }
+
+    [Fact]
+    public async Task WithProcessCommand_ValidationFailure_DoesNotCreateProcess()
+    {
+        var processRunner = new TestProcessRunner();
+        using var builder = CreateTestDistributedApplicationBuilder(processRunner);
+        var processSpecFactoryCalled = false;
+
+        var resource = builder.AddResource(new CustomResource("resource"))
+            .WithProcessCommand(
+                "validation-failure",
+                "Validation failure",
+                _ =>
+                {
+                    processSpecFactoryCalled = true;
+                    return CreateProcessCommandSpec();
+                },
+                new ProcessCommandOptions
+                {
+                    Arguments =
+                    [
+                        new InteractionInput
+                        {
+                            Name = "required",
+                            InputType = InputType.Text,
+                            Required = true
+                        }
+                    ]
+                });
+
+        using var app = builder.Build();
+        await app.StartAsync().DefaultTimeout();
+
+        var result = await app.ResourceCommands.ExecuteCommandAsync(resource.Resource, "validation-failure").DefaultTimeout();
+
+        Assert.False(result.Success);
+        Assert.False(processSpecFactoryCalled);
+        Assert.Empty(processRunner.ProcessSpecs);
+        Assert.Equal("Command argument validation failed.", result.Message);
+        Assert.NotNull(result.InvalidArguments);
+        var invalidArgument = Assert.Single(result.InvalidArguments);
+        Assert.Equal("required", invalidArgument.Name);
+        Assert.Equal("Value is required.", Assert.Single(invalidArgument.ValidationErrors));
+    }
+
+    [Fact]
+    public async Task WithProcessCommand_Cancellation_ReturnsCanceledResultAndDisposesProcess()
+    {
+        var processRunner = new TestProcessRunner();
+        var pendingProcessResult = new TaskCompletionSource<ProcessResult>(TaskCreationOptions.RunContinuationsAsynchronously);
+        processRunner.EnqueuePending(pendingProcessResult.Task);
+        using var builder = CreateTestDistributedApplicationBuilder(processRunner);
+
+        var resource = builder.AddResource(new CustomResource("resource"))
+            .WithProcessCommand(
+                "wait",
+                "Wait",
+                _ => CreateProcessCommandSpec());
+
+        using var app = builder.Build();
+        await app.StartAsync().DefaultTimeout();
+
+        using var cts = new CancellationTokenSource();
+        var commandTask = app.ResourceCommands.ExecuteCommandAsync(resource.Resource, "wait", cts.Token);
+
+        await processRunner.RunStarted.Task.DefaultTimeout();
+        await cts.CancelAsync();
+
+        var result = await commandTask.DefaultTimeout();
+
+        Assert.False(result.Success);
+        Assert.True(result.Canceled);
+        Assert.Contains(processRunner.Disposables, disposable => disposable.DisposeCallCount > 0);
+    }
+
+    private IDistributedApplicationTestingBuilder CreateTestDistributedApplicationBuilder(TestProcessRunner? processRunner = null)
+    {
+        var builder = TestDistributedApplicationBuilder.Create(testOutputHelper);
+        builder.Services.AddSingleton<IProcessRunner>(processRunner ?? new TestProcessRunner());
+
+        return builder;
+    }
+
+    private static ProcessCommandSpec CreateProcessCommandSpec(
+        string executablePath = "test-command",
+        IReadOnlyList<string>? arguments = null,
+        string? workingDirectory = null,
+        IDictionary<string, string>? environmentVariables = null,
+        bool inheritEnvironmentVariables = true,
+        string? standardInputContent = null,
+        bool killEntireProcessTree = true)
+    {
+        return new ProcessCommandSpec(executablePath)
+        {
+            Arguments = arguments ?? [],
+            WorkingDirectory = workingDirectory,
+            EnvironmentVariables = environmentVariables ?? new Dictionary<string, string>(),
+            InheritEnvironmentVariables = inheritEnvironmentVariables,
+            StandardInputContent = standardInputContent,
+            KillEntireProcessTree = killEntireProcessTree
+        };
+    }
+
+    private sealed class TestProcessRunner : IProcessRunner
+    {
+        private readonly Queue<TestProcessRun> _runs = [];
+        private readonly List<TestProcessDisposable> _disposables = [];
+
+        public List<ProcessSpec> ProcessSpecs { get; } = [];
+
+        public IReadOnlyList<TestProcessDisposable> Disposables => _disposables;
+
+        public TaskCompletionSource<ProcessSpec> RunStarted { get; } = new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        public void EnqueueResult(
+            int exitCode = 0,
+            IReadOnlyList<string>? output = null,
+            IReadOnlyList<string>? error = null,
+            int? totalOutputLineCount = null,
+            IReadOnlyList<TestProcessOutput>? outputEvents = null)
+        {
+            _runs.Enqueue(TestProcessRun.Result(exitCode, output, error, totalOutputLineCount, outputEvents));
+        }
+
+        public void EnqueueException(Exception exception)
+        {
+            _runs.Enqueue(TestProcessRun.Failed(exception));
+        }
+
+        public void EnqueuePending(Task<ProcessResult> processResult)
+        {
+            _runs.Enqueue(TestProcessRun.Pending(processResult));
+        }
+
+        public (Task<ProcessResult>, IAsyncDisposable) Run(ProcessSpec processSpec)
+        {
+            ProcessSpecs.Add(processSpec);
+            RunStarted.TrySetResult(processSpec);
+
+            var disposable = new TestProcessDisposable();
+            _disposables.Add(disposable);
+
+            var run = _runs.Count > 0 ? _runs.Dequeue() : TestProcessRun.Result();
+            if (run.FailureException is { } exception)
+            {
+                throw exception;
+            }
+
+            if (run.PendingResult is { } pendingResult)
+            {
+                return (pendingResult, disposable);
+            }
+
+            foreach (var output in run.OutputEvents)
+            {
+                if (output.IsError)
+                {
+                    processSpec.OnErrorData?.Invoke(output.Value);
+                }
+                else
+                {
+                    processSpec.OnOutputData?.Invoke(output.Value);
+                }
+            }
+
+            var processOutput = run.OutputEvents.Select(static output => output.Value).ToArray();
+            var processResult = new ProcessResult(run.ExitCode, processOutput, run.TotalOutputLineCount);
+
+            return (Task.FromResult(processResult), disposable);
+        }
+    }
+
+    private sealed record TestProcessRun(
+        int ExitCode,
+        IReadOnlyList<TestProcessOutput> OutputEvents,
+        int? TotalOutputLineCount,
+        Exception? FailureException,
+        Task<ProcessResult>? PendingResult)
+    {
+        public static TestProcessRun Result(
+            int exitCode = 0,
+            IReadOnlyList<string>? output = null,
+            IReadOnlyList<string>? error = null,
+            int? totalOutputLineCount = null,
+            IReadOnlyList<TestProcessOutput>? outputEvents = null)
+        {
+            outputEvents ??=
+            [
+                .. (output ?? Array.Empty<string>()).Select(Output),
+                .. (error ?? Array.Empty<string>()).Select(Error)
+            ];
+
+            return new TestProcessRun(exitCode, outputEvents, totalOutputLineCount, null, null);
+        }
+
+        public static TestProcessRun Failed(Exception exception)
+        {
+            return new TestProcessRun(0, [], null, exception, null);
+        }
+
+        public static TestProcessRun Pending(Task<ProcessResult> pendingResult)
+        {
+            return new TestProcessRun(0, [], null, null, pendingResult);
+        }
+    }
+
+    private static TestProcessOutput Output(string value) => new(false, value);
+
+    private static TestProcessOutput Error(string value) => new(true, value);
+
+    private sealed record TestProcessOutput(bool IsError, string Value);
+
+    private sealed class TestProcessDisposable : IAsyncDisposable
+    {
+        public int DisposeCallCount { get; private set; }
+
+        public ValueTask DisposeAsync()
+        {
+            DisposeCallCount++;
+
+            return ValueTask.CompletedTask;
+        }
+    }
+
+    private sealed class CustomResource(string name) : Resource(name)
+    {
+    }
+}
+
+#pragma warning restore ASPIREPROCESSCOMMAND001
+#pragma warning restore ASPIREINTERACTION001

--- a/tests/Aspire.Hosting.Tests/WithProcessCommandTests.cs
+++ b/tests/Aspire.Hosting.Tests/WithProcessCommandTests.cs
@@ -235,7 +235,8 @@ public class WithProcessCommandTests(ITestOutputHelper testOutputHelper)
         Assert.True(firstResult.Success);
         Assert.Contains("first-output", firstResult.Data?.Value);
         Assert.False(secondResult.Success);
-        Assert.Contains("returned non-zero exit code 3", secondResult.Message);
+        Assert.Contains("exited with code 3", secondResult.Message);
+        Assert.Contains("configured success exit codes [0]", secondResult.Message);
         Assert.Contains("second-output", secondResult.Data?.Value);
 
         Assert.Collection(
@@ -354,8 +355,47 @@ public class WithProcessCommandTests(ITestOutputHelper testOutputHelper)
         var result = await app.ResourceCommands.ExecuteCommandAsync(resource.Resource, "fail-no-output").DefaultTimeout();
 
         Assert.False(result.Success);
-        Assert.Contains("returned non-zero exit code 9", result.Message);
+        Assert.Contains("exited with code 9", result.Message);
+        Assert.Contains("configured success exit codes [0]", result.Message);
         Assert.Null(result.Data);
+    }
+
+    [Fact]
+    public async Task WithProcessCommand_SuccessExitCodes_TreatsConfiguredExitCodeAsSuccess()
+    {
+        var processRunner = new TestProcessRunner();
+        processRunner.EnqueueResult(exitCode: 5, output: ["accepted-output"]);
+        using var builder = CreateTestDistributedApplicationBuilder(processRunner);
+
+        var resource = builder.AddResource(new CustomResource("resource"))
+            .WithProcessCommand(
+                "accepted-exit-code",
+                "Accepted exit code",
+                _ => CreateProcessCommandSpec(),
+                new ProcessCommandOptions
+                {
+                    SuccessExitCodes = [0, 5]
+                });
+
+        using var app = builder.Build();
+        await app.StartAsync().DefaultTimeout();
+
+        var result = await app.ResourceCommands.ExecuteCommandAsync(resource.Resource, "accepted-exit-code").DefaultTimeout();
+
+        Assert.True(result.Success);
+        Assert.Contains("accepted-output", result.Data?.Value);
+    }
+
+    [Fact]
+    public void WithProcessCommand_EmptySuccessExitCodes_ThrowsWhenConfiguringOptions()
+    {
+        var exception = Assert.Throws<ArgumentException>(() =>
+            new ProcessCommandOptions
+            {
+                SuccessExitCodes = []
+            });
+
+        Assert.Contains("At least one process command success exit code must be specified.", exception.Message);
     }
 
     [Fact]
@@ -417,6 +457,68 @@ public class WithProcessCommandTests(ITestOutputHelper testOutputHelper)
     }
 
     [Fact]
+    public async Task WithProcessCommand_GetCommandResult_CanCustomizeResultFromProcessOutput()
+    {
+        var processRunner = new TestProcessRunner();
+        processRunner.EnqueueResult(
+            exitCode: 42,
+            outputEvents:
+            [
+                Output("""{"status":"custom"}"""),
+                Error("diagnostic-line")
+            ]);
+        using var builder = CreateTestDistributedApplicationBuilder(processRunner);
+
+        ProcessCommandResultContext? capturedContext = null;
+        var resource = builder.AddResource(new CustomResource("resource"))
+            .WithProcessCommand(
+                "custom-result",
+                "Custom result",
+                _ => CreateProcessCommandSpec(arguments: ["custom-argument"]),
+                new ProcessCommandOptions
+                {
+                    SuccessExitCodes = [0],
+                    GetCommandResult = context =>
+                    {
+                        capturedContext = context;
+
+                        return Task.FromResult(new ExecuteCommandResult
+                        {
+                            Success = true,
+                            Data = new CommandResultData
+                            {
+                                Value = context.Output[0],
+                                Format = CommandResultFormat.Json,
+                                DisplayImmediately = false
+                            }
+                        });
+                    }
+                });
+
+        using var app = builder.Build();
+        await app.StartAsync().DefaultTimeout();
+
+        var result = await app.ResourceCommands.ExecuteCommandAsync(resource.Resource, "custom-result").DefaultTimeout();
+
+        Assert.True(result.Success);
+        Assert.Equal(CommandResultFormat.Json, result.Data?.Format);
+        Assert.False(result.Data?.DisplayImmediately);
+        Assert.Equal("""{"status":"custom"}""", result.Data?.Value);
+
+        Assert.NotNull(capturedContext);
+        Assert.Equal(42, capturedContext.ExitCode);
+        Assert.Equal(resource.Resource.Name, capturedContext.ResourceName);
+        Assert.NotNull(capturedContext.ServiceProvider);
+        Assert.NotNull(capturedContext.Logger);
+        Assert.Equal(["custom-argument"], capturedContext.ProcessCommandSpec.Arguments);
+        Assert.Equal(["{\"status\":\"custom\"}", "diagnostic-line"], capturedContext.Output);
+        Assert.Equal(2, capturedContext.TotalOutputLineCount);
+        var formattedOutput = capturedContext.GetFormattedOutput(maxLines: 1);
+        Assert.Contains("Command output truncated: showing last 1 of 2 lines.", formattedOutput);
+        Assert.Contains("diagnostic-line", formattedOutput);
+    }
+
+    [Fact]
     public async Task WithProcessCommand_ReturnsOutputInRunnerObservedOrder()
     {
         var processRunner = new TestProcessRunner();
@@ -472,7 +574,8 @@ public class WithProcessCommandTests(ITestOutputHelper testOutputHelper)
         Assert.False(result.Success);
         Assert.False(result.Canceled);
         Assert.NotEqual("Unhandled exception thrown.", result.Message);
-        Assert.Contains("returned non-zero exit code 7", result.Message);
+        Assert.Contains("exited with code 7", result.Message);
+        Assert.Contains("configured success exit codes [0]", result.Message);
         Assert.Equal(CommandResultFormat.Text, result.Data?.Format);
         Assert.True(result.Data?.DisplayImmediately);
         Assert.Contains("failed-line", result.Data?.Value);
@@ -684,7 +787,8 @@ public class WithProcessCommandTests(ITestOutputHelper testOutputHelper)
                     StandardInputContent = "from-export-stdin",
                     KillEntireProcessTree = false,
                     MaxOutputLineCount = 10,
-                    DisplayImmediately = false
+                    DisplayImmediately = false,
+                    SuccessExitCodes = [0, 17]
                 });
 
         using var app = builder.Build();
@@ -706,6 +810,32 @@ public class WithProcessCommandTests(ITestOutputHelper testOutputHelper)
         Assert.Equal("from-export-stdin", processSpec.StandardInputContent);
         Assert.False(processSpec.KillEntireProcessTree);
         Assert.Equal(10, processSpec.RetainedOutputLineCount);
+    }
+
+    [Fact]
+    public async Task WithProcessCommandExport_SuccessExitCodes_TreatsConfiguredExitCodeAsSuccess()
+    {
+        var processRunner = new TestProcessRunner();
+        processRunner.EnqueueResult(exitCode: 17, output: ["export-accepted-output"]);
+        using var builder = CreateTestDistributedApplicationBuilder(processRunner);
+
+        var resource = builder.AddResource(new CustomResource("resource"))
+            .WithProcessCommandExport(
+                "export-accepted-exit-code",
+                "Export accepted exit code",
+                new ProcessCommandExportOptions
+                {
+                    ExecutablePath = "export-executable",
+                    SuccessExitCodes = [0, 17]
+                });
+
+        using var app = builder.Build();
+        await app.StartAsync().DefaultTimeout();
+
+        var result = await app.ResourceCommands.ExecuteCommandAsync(resource.Resource, "export-accepted-exit-code").DefaultTimeout();
+
+        Assert.True(result.Success);
+        Assert.Contains("export-accepted-output", result.Data?.Value);
     }
 
     [Fact]
@@ -815,6 +945,32 @@ public class WithProcessCommandTests(ITestOutputHelper testOutputHelper)
                     }));
 
         Assert.Contains("output line count must be greater than zero", exception.Message);
+    }
+
+    [Fact]
+    public async Task WithProcessCommandExport_EmptySuccessExitCodesUseDefault()
+    {
+        var processRunner = new TestProcessRunner();
+        processRunner.EnqueueResult(exitCode: 1);
+        using var builder = CreateTestDistributedApplicationBuilder(processRunner);
+
+        var resource = builder.AddResource(new CustomResource("resource"))
+            .WithProcessCommandExport(
+                "default-success-exit-codes",
+                "Default success exit codes",
+                new ProcessCommandExportOptions
+                {
+                    ExecutablePath = "test-command",
+                    SuccessExitCodes = []
+                });
+
+        using var app = builder.Build();
+        await app.StartAsync().DefaultTimeout();
+
+        var result = await app.ResourceCommands.ExecuteCommandAsync(resource.Resource, "default-success-exit-codes").DefaultTimeout();
+
+        Assert.False(result.Success);
+        Assert.Contains("configured success exit codes [0]", result.Message);
     }
 
     [Fact]

--- a/tests/Aspire.Hosting.Tests/WithProcessCommandTests.cs
+++ b/tests/Aspire.Hosting.Tests/WithProcessCommandTests.cs
@@ -713,6 +713,34 @@ public class WithProcessCommandTests(ITestOutputHelper testOutputHelper)
     }
 
     [Fact]
+    public async Task WithProcessCommandExport_UnspecifiedBooleanOptionsUseProcessCommandSpecDefaults()
+    {
+        var processRunner = new TestProcessRunner();
+        processRunner.EnqueueResult();
+        using var builder = CreateTestDistributedApplicationBuilder(processRunner);
+
+        var resource = builder.AddResource(new CustomResource("resource"))
+            .WithProcessCommandExport(
+                "export-default-options",
+                "Export default options",
+                new ProcessCommandExportOptions
+                {
+                    ExecutablePath = "export-executable"
+                });
+
+        using var app = builder.Build();
+        await app.StartAsync().DefaultTimeout();
+
+        var result = await app.ResourceCommands.ExecuteCommandAsync(resource.Resource, "export-default-options").DefaultTimeout();
+
+        Assert.True(result.Success);
+
+        var processSpec = Assert.Single(processRunner.ProcessSpecs);
+        Assert.True(processSpec.InheritEnv);
+        Assert.True(processSpec.KillEntireProcessTree);
+    }
+
+    [Fact]
     public async Task WithProcessCommandExport_InvalidProcessOptions_ReturnsFailureWithoutCreatingProcess()
     {
         var invalidOptions = new (ProcessCommandExportOptions Options, string ExpectedMessage)[]
@@ -1023,7 +1051,8 @@ public class WithProcessCommandTests(ITestOutputHelper testOutputHelper)
 
         Assert.False(result.Success);
         Assert.True(result.Canceled);
-        Assert.Contains(processRunner.Disposables, disposable => disposable.DisposeCallCount > 0);
+        var disposable = Assert.Single(processRunner.Disposables);
+        Assert.Equal(1, disposable.DisposeCallCount);
     }
 
     private IDistributedApplicationTestingBuilder CreateTestDistributedApplicationBuilder(TestProcessRunner? processRunner = null)

--- a/tests/Aspire.Hosting.Tests/WithProcessCommandTests.cs
+++ b/tests/Aspire.Hosting.Tests/WithProcessCommandTests.cs
@@ -17,6 +17,24 @@ namespace Aspire.Hosting.Tests;
 public class WithProcessCommandTests(ITestOutputHelper testOutputHelper)
 {
     [Fact]
+    public void ProcessCommandOptions_Default_ReturnsIndependentInstances()
+    {
+        var options = ProcessCommandOptions.Default;
+
+        options.Description = "Mutated description";
+        options.MaxOutputLineCount = 1;
+        options.DisplayImmediately = false;
+        options.SuccessExitCodes = [0, 5];
+
+        var defaultOptions = ProcessCommandOptions.Default;
+
+        Assert.Null(defaultOptions.Description);
+        Assert.Equal(50, defaultOptions.MaxOutputLineCount);
+        Assert.True(defaultOptions.DisplayImmediately);
+        Assert.Equal([0], defaultOptions.SuccessExitCodes);
+    }
+
+    [Fact]
     public void WithProcessCommand_AddsResourceCommandAnnotation_WithCustomValues()
     {
         using var builder = CreateTestDistributedApplicationBuilder();

--- a/tests/PolyglotAppHosts/Aspire.Hosting.Yarp/Go/apphost.go
+++ b/tests/PolyglotAppHosts/Aspire.Hosting.Yarp/Go/apphost.go
@@ -44,43 +44,43 @@ func main() {
 
 		endpointCluster := config.AddClusterFromEndpoint(endpoint).
 			WithForwarderRequestConfig(&aspire.YarpForwarderRequestConfig{
-				ActivityTimeout:        30_000_000,
-				AllowResponseBuffering: true,
+				ActivityTimeout:        aspire.Float64Ptr(30_000_000),
+				AllowResponseBuffering: aspire.BoolPtr(true),
 				Version:                "2.0",
 			}).
 			WithHttpClientConfig(&aspire.YarpHttpClientConfig{
-				DangerousAcceptAnyServerCertificate: true,
-				EnableMultipleHttp2Connections:      true,
-				MaxConnectionsPerServer:             10,
+				DangerousAcceptAnyServerCertificate: aspire.BoolPtr(true),
+				EnableMultipleHttp2Connections:      aspire.BoolPtr(true),
+				MaxConnectionsPerServer:             aspire.Float64Ptr(10),
 				RequestHeaderEncoding:               "utf-8",
 				ResponseHeaderEncoding:              "utf-8",
 			}).
 			WithSessionAffinityConfig(&aspire.YarpSessionAffinityConfig{
 				AffinityKeyName: ".Aspire.Affinity",
-				Enabled:         true,
+				Enabled:         aspire.BoolPtr(true),
 				FailurePolicy:   "Redistribute",
 				Policy:          "Cookie",
 				Cookie: &aspire.YarpSessionAffinityCookieConfig{
 					Domain:      "example.com",
-					HttpOnly:    true,
-					IsEssential: true,
+					HttpOnly:    aspire.BoolPtr(true),
+					IsEssential: aspire.BoolPtr(true),
 					Path:        "/",
 				},
 			}).
 			WithHealthCheckConfig(&aspire.YarpHealthCheckConfig{
 				AvailableDestinationsPolicy: "HealthyOrPanic",
 				Active: &aspire.YarpActiveHealthCheckConfig{
-					Enabled:  true,
-					Interval: 50_000_000,
+					Enabled:  aspire.BoolPtr(true),
+					Interval: aspire.Float64Ptr(50_000_000),
 					Path:     "/health",
 					Policy:   "ConsecutiveFailures",
 					Query:    "probe=1",
-					Timeout:  20_000_000,
+					Timeout:  aspire.Float64Ptr(20_000_000),
 				},
 				Passive: &aspire.YarpPassiveHealthCheckConfig{
-					Enabled:            true,
+					Enabled:            aspire.BoolPtr(true),
 					Policy:             "TransportFailureRateHealthPolicy",
-					ReactivationPeriod: 100_000_000,
+					ReactivationPeriod: aspire.Float64Ptr(100_000_000),
 				},
 			})
 

--- a/tests/PolyglotAppHosts/Aspire.Hosting.Yarp/Java/AppHost.java
+++ b/tests/PolyglotAppHosts/Aspire.Hosting.Yarp/Java/AppHost.java
@@ -49,7 +49,7 @@ void main() throws Exception {
             var httpClientConfig = new YarpHttpClientConfig();
             httpClientConfig.setDangerousAcceptAnyServerCertificate(true);
             httpClientConfig.setEnableMultipleHttp2Connections(true);
-            httpClientConfig.setMaxConnectionsPerServer(10);
+            httpClientConfig.setMaxConnectionsPerServer(10.0);
             httpClientConfig.setRequestHeaderEncoding("utf-8");
             httpClientConfig.setResponseHeaderEncoding("utf-8");
             endpointCluster.withHttpClientConfig(httpClientConfig);

--- a/tests/PolyglotAppHosts/Aspire.Hosting/TypeScript/apphost.ts
+++ b/tests/PolyglotAppHosts/Aspire.Hosting/TypeScript/apphost.ts
@@ -11,8 +11,10 @@ import {
     refExpr,
 } from './.modules/aspire.js';
 import type { DockerfileBuilderCallbackContext } from './.modules/aspire.js';
+import { fileURLToPath } from 'node:url';
 
 const builder = await createBuilder();
+const processCommandStdinScriptPath = fileURLToPath(new URL("./process-command-scripts/stdin.js", import.meta.url));
 
 // ===================================================================
 // Factory methods on builder
@@ -635,6 +637,28 @@ await container.withHealthCheck("http");
 // withCommand
 await container.withCommand("restart", "Restart", async (_ctx) => {
     return { success: true };
+});
+
+// withProcessCommand
+await container.withProcessCommand("dotnet-version", "Show .NET version", {
+    executablePath: "dotnet",
+    arguments: ["--version"],
+    commandOptions: {
+        description: "Runs dotnet --version from a TypeScript AppHost.",
+        iconName: "WindowConsole",
+    },
+    maxOutputLineCount: 10,
+    displayImmediately: false,
+});
+await container.withProcessCommand("node-stdin", "Node stdin", {
+    executablePath: "node",
+    arguments: [processCommandStdinScriptPath],
+    standardInputContent: "hello-from-typescript",
+    commandOptions: {
+        description: "Runs node and writes command input to stdin.",
+        iconName: "WindowConsole",
+    },
+    maxOutputLineCount: 10,
 });
 
 // withHttpCommand

--- a/tests/PolyglotAppHosts/Aspire.Hosting/TypeScript/process-command-scripts/stdin.js
+++ b/tests/PolyglotAppHosts/Aspire.Hosting/TypeScript/process-command-scripts/stdin.js
@@ -1,0 +1,7 @@
+let input = "";
+
+process.stdin.setEncoding("utf8");
+process.stdin.on("data", chunk => input += chunk);
+process.stdin.on("end", () => {
+    console.log(`stdin-${input.trim()}`);
+});


### PR DESCRIPTION
## Description

Resource commands can already call back into AppHost code, but there was no reusable helper for the common "run this local tool and return its output" pattern. This adds an experimental `WithProcessCommand` API so AppHost authors can expose process-backed resource commands without each integration sharing or duplicating the internal DCP process utility types.

The helper starts local processes from the AppHost, passes arguments through `ProcessStartInfo.ArgumentList`, supports dynamic process creation from `ExecuteCommandContext`, streams stdout and stderr to the command logger, returns bounded text output, and maps cancellation and non-zero exits into resource command results. The implementation also adds a core `IProcessRunner` abstraction so command tests can run deterministically without depending on installed tools.

### Related discussions and issues

This PR is intended to unblock or improve several resource-command scenarios that have come up in discussions/issues:

- https://github.com/microsoft/aspire/discussions/8502 - dynamic command-line arguments for custom resource commands, such as seed-data or E2E-test command shapes.
- https://github.com/microsoft/aspire/discussions/12906 and https://github.com/microsoft/aspire/discussions/7786 - backup/restore and container-ID workflows where an AppHost command needs to compose local tooling around containers.
- https://github.com/microsoft/aspire/issues/10301 - executing command shapes against container resources.

### User-facing usage

C# AppHost:

```csharp
builder.AddRedis("cache")
    .WithProcessCommand(
        "dotnet-version",
        "Show .NET version",
        "dotnet",
        ["--version"]);
```

Dynamic C# process command:

```csharp
builder.AddRedis("cache")
    .WithProcessCommand(
        "seed-data",
        "Seed data",
        context => new ProcessCommandSpec("dotnet")
        {
            Arguments = ["run", "--project", "tools/SeedData", "--", context.Arguments.GetString("dataset") ?? "small"],
            EnvironmentVariables = { ["ConnectionStrings__db"] = "Host=localhost;Database=db" }
        },
        new ProcessCommandOptions { MaxOutputLineCount = 20 });
```

TypeScript AppHost static process command:

```typescript
await cache.withProcessCommand(
    "node-process-check",
    "Node process check",
    {
        executablePath: "node",
        arguments: [processCommandScriptPath, "from-typescript-apphost"],
        environmentVariables: [
            {
                name: "TS_PROCESS_COMMAND_SAMPLE",
                value: "from-process-command"
            }
        ],
        standardInputContent: "hello from TypeScript AppHost",
        maxOutputLineCount: 10
    });
```

### Security considerations

This API executes local processes from the AppHost machine. The command is configured by the AppHost author, arguments are passed as an argument list rather than through a shell, command names are resolved from the AppHost process PATH only for non-explicit executable names, and returned output is bounded. Since this introduces a public process-spawning surface, security review should confirm the command execution and PATH-resolution assumptions.

### Validation

- `dotnet test` for `WithProcessCommandTests`, `ProcessUtilTests`, and `PathLookupHelperTests` in `Aspire.Hosting.Tests` (60 passed)
- `git diff --check`
- `./restore.sh && ./build.sh --build`
- `./dotnet.sh build src/Aspire.Hosting/Aspire.Hosting.csproj --no-restore /p:SkipNativeBuild=true`
- Stress playground CLI E2E for process commands, including arguments, stdin, env vars, bounded output, and expected failures
- Stress dashboard E2E for process commands, including argument dialogs, output display, and failure output
- TypeScript AppHost build and CLI E2E:

```text
ts-process-command-arg=from-typescript-apphost
ts-process-command-env=from-process-command
ts-process-command-stdin=hello from TypeScript AppHost
```

Fixes # (issue)

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [x] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [x] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [x] Yes
      - [ ] No
  - [ ] No
- Does the change make any security assumptions or guarantees?
  - [x] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [x] No
  - [ ] No
