### PR TITLE
Add code comment guidance

### DIFF
--- a/.github/skills/code-review/SKILL.md
+++ b/.github/skills/code-review/SKILL.md
@@ -120,7 +120,8 @@ Only flag **actual problems**. Every comment must identify a concrete issue. Cat
     - Changes to `NuGet.config` adding unapproved feeds
     - Changes to `global.json`
     - Using `== null` instead of `is null`
-13. **Test problems** — flaky patterns per the test review guidelines: thread-unsafe test fakes, log-based readiness checks instead of `WaitForHealthyAsync()`, shared timeout budgets, hardcoded ports, `Directory.SetCurrentDirectory` usage, commented-out tests.
+13. **Code comment guidance** — apply the `AGENTS.md` Code comments guidance when reviewing changed code. Flag only concrete problems, such as comments that contradict the code, workaround comments without a tracking link, parser/protocol/log parsing that omits the raw shape needed to understand edge cases, or comments around privacy/security-sensitive behavior that fail to explain the opt-in, scope, or WHY. Do not flag subjective missing comments or ask for comments on obvious code.
+14. **Test problems** — flaky patterns per the test review guidelines: thread-unsafe test fakes, log-based readiness checks instead of `WaitForHealthyAsync()`, shared timeout budgets, hardcoded ports, `Directory.SetCurrentDirectory` usage, commented-out tests.
 
 ### What NOT to Flag
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -76,6 +76,119 @@ When reviewing pull requests:
 * Use `nameof` instead of string literals when referring to member names.
 * Place private class declarations at the bottom of the file.
 
+### Code comments
+
+* Err on the side of over-commenting code when the reasoning is not obvious. Comments should explain **WHY** code is written a particular way; the **WHY** is the most important part.
+* Do comment non-obvious implementation details: concurrency hazards, lifecycle constraints, compatibility requirements, platform quirks, upstream workarounds, and intentional deviations from the obvious helper or API.
+* When parsing strings, logs, command output, protocol payloads, or other loosely structured data, include a comment with an example of the raw format being parsed. Show edge cases, escaping rules, delimiters, optional fields, or malformed-but-observed inputs when they affect the parser.
+* When code follows an external standard, protocol, or ecosystem convention, include valid links to the relevant source material so future readers can verify the rule and understand why the code follows it.
+* Do not add comments that simply narrate clear code, such as "set the timeout" immediately before assigning a timeout.
+* Keep workaround comments close to the workaround. Include an issue link when the workaround is tied to an upstream bug, and describe the condition for removing it when that is known.
+
+Good comments explain the constraint or tradeoff:
+
+```csharp
+// Read both streams concurrently to avoid deadlock when a pipe buffer fills.
+var stdoutTask = process.StandardOutput.ReadToEndAsync();
+var stderrTask = process.StandardError.ReadToEndAsync();
+```
+
+```csharp
+// Endpoint adoption runs on the command path, so fail quickly when stale metadata
+// points at a dead or reused port.
+var timeout = TimeSpan.FromSeconds(2);
+```
+
+```csharp
+// The temporary config is disposed when this method returns. That is intentional:
+// only `dotnet new install` consumes the config; later template creation uses the
+// already-installed template hive and ambient NuGet configuration.
+using var temporaryConfig = await TemporaryNuGetConfig.CreateAsync(mappings);
+```
+
+```csharp
+// Workaround for an upstream library bug on Windows where URI SANs are formatted
+// differently than the verifier expects. Cryptographic verification still runs;
+// only the identity checks are performed manually from the certificate extensions.
+var result = await VerifyWithManualIdentityFallbackAsync(bundle, cancellationToken);
+```
+
+```csharp
+public required IReadOnlyList<PipelineStep> Steps
+{
+    get;
+    init
+    {
+        field = value;
+        // IMPORTANT: The ResourceNameComparer must be used here to ensure correct lookup behavior
+        // based on resource names, NOT the default reference equality. This is because resources
+        // may be swapped out (referred to as bait-and-switch) during model transformations.
+        StepToResourceMap = field.ToLookup(s => s.Resource, s => s, new ResourceNameComparer());
+    }
+}
+```
+
+```csharp
+// Output sensitive message content for GenAI.
+// A convention for libraries that output GenAI telemetry is to use
+// `OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT`.
+// See:
+// - https://opentelemetry.io/blog/2024/otel-generative-ai/
+// - https://github.com/search?q=org%3Aopen-telemetry+OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT&type=code
+context.EnvironmentVariables[KnownOtelConfigNames.InstrumentationGenAiCaptureMessageContent] = "true";
+```
+
+```csharp
+// If we have multiple endpoints for the same scheme, differentiate them by appending a number.
+// Start numbering with the second endpoint so the first stays just http/https, which preserves
+// the same behavior as "dotnet run". Only do this in Run mode because, in Publish mode, those
+// extra endpoints with generic names would not be easily usable.
+var endpointName = bindingAddress.Scheme;
+if (endpointCountByScheme[bindingAddress.Scheme] > 1)
+{
+    endpointName += endpointCountByScheme[bindingAddress.Scheme];
+}
+```
+
+```csharp
+// The implementation here is less than ideal, but we don't have a clean way of building resource
+// types that change their behavior based on context. In this case, publish mode needs the resource
+// to behave like a ContainerResource instead of a ProjectResource, so we remove the ProjectResource
+// from the application model and add a new ContainerResource in its place.
+//
+// There are still dangling references to the original ProjectResource in the application model, but
+// in publish mode it won't be used. This is a limitation of the current design.
+builder.ApplicationBuilder.Resources.Remove(builder.Resource);
+```
+
+Parsing comments should show the raw shape and important edge cases:
+
+```csharp
+// Parse resource log lines emitted as:
+//   [2026-05-10T18:34:22.123Z] frontend stdout: Now listening on: http://localhost:5221
+// The message can contain additional ':' characters, so split only on the first
+// " stdout: " or " stderr: " delimiter after the resource name.
+var match = s_logLineRegex.Match(line);
+```
+
+```csharp
+// The endpoint metadata sidecar uses the DevTools /json/version shape:
+//   { "webSocketDebuggerUrl": "ws://127.0.0.1:50981/devtools/browser/<id>" }
+// Older Chromium builds can omit the property while the browser is still starting;
+// treat that as a retryable probe failure rather than invalid metadata.
+var endpoint = payload.WebSocketDebuggerUrl;
+```
+
+Avoid comments that restate the code:
+
+```csharp
+// Set the timeout to two seconds.
+var timeout = TimeSpan.FromSeconds(2);
+
+// Create a list.
+var resources = new List<Resource>();
+```
+
 ### Nullable Reference Types
 
 * Declare variables non-nullable, and check for `null` at entry points.


### PR DESCRIPTION
## Description

Agents need clearer guidance on when comments should explain non-obvious implementation details, especially **WHY** choices were made. This updates `AGENTS.md` with a Code comments section that tells agents to err on the side of over-commenting when reasoning is not obvious and to emphasize **WHY** as the most important part.

The guidance covers comments for parser inputs, external standards and ecosystem conventions with valid links, compatibility-preserving behavior, mode-specific behavior, identity and equality semantics, workarounds, and known design limitations. It includes concrete C# examples and counterexamples of comments that merely restate obvious code.

Docs-only guidance change; no runtime behavior changes.

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [x] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No