### PR TITLE
Trim whitespace in markdown link text and extract MarkdownLinkConverter

### DIFF
--- a/src/Aspire.Cli/Utils/ConsoleActivityLogger.cs
+++ b/src/Aspire.Cli/Utils/ConsoleActivityLogger.cs
@@ -314,7 +314,7 @@ internal sealed class ConsoleActivityLogger
         {
             var plainKey = item.Key.EscapeMarkup();
             var plainValue = item.EnableMarkdown
-                ? MarkdownToSpectreConverter.ConvertLinksToPlainText(item.Value).EscapeMarkup()
+                ? MarkdownLinkConverter.ConvertLinksToPlainText(item.Value).EscapeMarkup()
                 : item.Value.EscapeMarkup();
             return $"  {plainKey}: {plainValue}";
         }

--- a/src/Aspire.Cli/Utils/Markdown/MarkdownLinkConverter.cs
+++ b/src/Aspire.Cli/Utils/Markdown/MarkdownLinkConverter.cs
@@ -1,0 +1,30 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Text.RegularExpressions;
+
+namespace Aspire.Cli.Utils.Markdown;
+
+/// <summary>
+/// Converts markdown links to plain text.
+/// </summary>
+internal static partial class MarkdownLinkConverter
+{
+    /// <summary>
+    /// Converts markdown links to plain text.
+    /// </summary>
+    /// <param name="markdown">The markdown text to convert.</param>
+    /// <returns>The text with markdown links converted to the plain text format <c>text (url)</c>.</returns>
+    public static string ConvertLinksToPlainText(string markdown)
+    {
+        return LinkRegex().Replace(markdown, match =>
+        {
+            var text = match.Groups[1].Value.Trim();
+            var url = match.Groups[2].Value;
+            return $"{text} ({url})";
+        });
+    }
+
+    [GeneratedRegex(@"\[((?:[^\[\]]|\[[^\[\]]*\])+)\]\(([^)]+)\)")]
+    private static partial Regex LinkRegex();
+}

--- a/src/Aspire.Cli/Utils/Markdown/MarkdownToSpectreConverter.Markup.cs
+++ b/src/Aspire.Cli/Utils/Markdown/MarkdownToSpectreConverter.Markup.cs
@@ -552,6 +552,7 @@ internal partial class MarkdownToSpectreConverter
         {
             var contentStart = builder.Length;
             AppendInlinesToMarkup(builder, link, markdown);
+            TrimAppendedWhitespace(builder, contentStart);
 
             var appendedLength = builder.Length - contentStart;
             if (appendedLength == 0 || appendedLength == link.Url.Length && AppendedTextEquals(builder, contentStart, link.Url))
@@ -576,6 +577,7 @@ internal partial class MarkdownToSpectreConverter
 
         var linkContentStart = builder.Length;
         AppendInlinesToMarkup(builder, link, markdown);
+        TrimAppendedWhitespace(builder, linkContentStart);
         if (builder.Length == linkContentStart)
         {
             AppendEscapedMarkup(builder, link.Url.AsSpan());

--- a/src/Aspire.Cli/Utils/Markdown/MarkdownToSpectreConverter.PlainText.cs
+++ b/src/Aspire.Cli/Utils/Markdown/MarkdownToSpectreConverter.PlainText.cs
@@ -8,16 +8,6 @@ namespace Aspire.Cli.Utils.Markdown;
 internal partial class MarkdownToSpectreConverter
 {
     /// <summary>
-    /// Converts markdown links to plain text.
-    /// </summary>
-    /// <param name="markdown">The markdown text to convert.</param>
-    /// <returns>The text with markdown links converted to the plain text format <c>text (url)</c>.</returns>
-    public static string ConvertLinksToPlainText(string markdown)
-    {
-        return LinkRegex().Replace(markdown, "$1 ($2)");
-    }
-
-    /// <summary>
     /// Converts markdown to a lossy plain-text representation suitable for redirected or non-interactive output.
     /// </summary>
     /// <param name="markdown">The markdown text to convert.</param>

--- a/src/Aspire.Cli/Utils/Markdown/MarkdownToSpectreConverter.cs
+++ b/src/Aspire.Cli/Utils/Markdown/MarkdownToSpectreConverter.cs
@@ -354,9 +354,6 @@ internal partial class MarkdownToSpectreConverter
         }
     }
 
-    [GeneratedRegex(@"\[((?:[^\[\]]|\[[^\[\]]*\])+)\]\(([^)]+)\)")]
-    private static partial Regex LinkRegex();
-
     [GeneratedRegex(@"</?[^>]+>", RegexOptions.Singleline)]
     private static partial Regex HtmlTagRegex();
 }

--- a/src/Aspire.Cli/Utils/Markdown/MarkdownToSpectreConverter.cs
+++ b/src/Aspire.Cli/Utils/Markdown/MarkdownToSpectreConverter.cs
@@ -80,6 +80,21 @@ internal partial class MarkdownToSpectreConverter
         }
     }
 
+    private static void TrimAppendedWhitespace(StringBuilder builder, int contentStart)
+    {
+        // Trim trailing whitespace
+        while (builder.Length > contentStart && char.IsWhiteSpace(builder[builder.Length - 1]))
+        {
+            builder.Length--;
+        }
+
+        // Trim leading whitespace
+        while (builder.Length > contentStart && char.IsWhiteSpace(builder[contentStart]))
+        {
+            builder.Remove(contentStart, 1);
+        }
+    }
+
     private static void WrapAppendedLines(StringBuilder builder, int contentStart, string linePrefix, string lineSuffix)
     {
         if (contentStart >= builder.Length)

--- a/tests/Aspire.Cli.Tests/Utils/MarkdownLinkConverterTests.cs
+++ b/tests/Aspire.Cli.Tests/Utils/MarkdownLinkConverterTests.cs
@@ -1,0 +1,41 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Aspire.Cli.Utils.Markdown;
+
+namespace Aspire.Cli.Tests.Utils;
+
+public class MarkdownLinkConverterTests
+{
+    [Fact]
+    public void ConvertLinksToPlainText_WithBracketedLinkText_ConvertsCorrectly()
+    {
+        var result = MarkdownLinkConverter.ConvertLinksToPlainText(
+            "[CreateBuilder(string[])](https://aspire.dev/reference/api/csharp/aspire.hosting/distributedapplication/methods.md#createbuilder-string)");
+
+        Assert.Equal(
+            "CreateBuilder(string[]) (https://aspire.dev/reference/api/csharp/aspire.hosting/distributedapplication/methods.md#createbuilder-string)",
+            result);
+    }
+
+    [Theory]
+    [InlineData("[ Discord](https://aka.ms/aspire-discord)", "Discord (https://aka.ms/aspire-discord)")]
+    [InlineData("[Discord ](https://aka.ms/aspire-discord)", "Discord (https://aka.ms/aspire-discord)")]
+    [InlineData("[ GitHub ](https://github.com)", "GitHub (https://github.com)")]
+    [InlineData("[no-trim](https://example.com)", "no-trim (https://example.com)")]
+    public void ConvertLinksToPlainText_TrimsWhitespaceFromLinkText(string markdown, string expected)
+    {
+        var result = MarkdownLinkConverter.ConvertLinksToPlainText(markdown);
+
+        Assert.Equal(expected, result);
+    }
+
+    [Fact]
+    public void ConvertLinksToPlainText_WithSurroundingText_TrimsWhitespaceFromLinkText()
+    {
+        var result = MarkdownLinkConverter.ConvertLinksToPlainText(
+            "Drop by [ Discord](https://aka.ms/aspire-discord) to chat.");
+
+        Assert.Equal("Drop by Discord (https://aka.ms/aspire-discord) to chat.", result);
+    }
+}

--- a/tests/Aspire.Cli.Tests/Utils/MarkdownToSpectreConverterTests.cs
+++ b/tests/Aspire.Cli.Tests/Utils/MarkdownToSpectreConverterTests.cs
@@ -120,17 +120,6 @@ public partial class MarkdownToSpectreConverterTests
     }
 
     [Fact]
-    public void ConvertLinksToPlainText_WithBracketedLinkText_ConvertsCorrectly()
-    {
-        var result = MarkdownToSpectreConverter.ConvertLinksToPlainText(
-            "[CreateBuilder(string[])](https://aspire.dev/reference/api/csharp/aspire.hosting/distributedapplication/methods.md#createbuilder-string)");
-
-        Assert.Equal(
-            "CreateBuilder(string[]) (https://aspire.dev/reference/api/csharp/aspire.hosting/distributedapplication/methods.md#createbuilder-string)",
-            result);
-    }
-
-    [Fact]
     public void ConvertToPlainText_WithLinksAndImages_ConvertsCorrectly()
     {
         var markdown = "Visit [GitHub](https://github.com) and remove ![diagram](https://example.com/diagram.png).";

--- a/tests/Aspire.Cli.Tests/Utils/MarkdownToSpectreConverterTests.cs
+++ b/tests/Aspire.Cli.Tests/Utils/MarkdownToSpectreConverterTests.cs
@@ -107,6 +107,9 @@ public partial class MarkdownToSpectreConverterTests
     [InlineData("[link text](https://example.com)", "[cyan][link=https://example.com]link text[/][/]")]
     [InlineData("Visit [GitHub](https://github.com) for more info.", "Visit [cyan][link=https://github.com]GitHub[/][/] for more info.")]
     [InlineData("[CreateBuilder(string[])](https://aspire.dev/reference/api/csharp/aspire.hosting/distributedapplication/methods.md#createbuilder-string)", "[cyan][link=https://aspire.dev/reference/api/csharp/aspire.hosting/distributedapplication/methods.md#createbuilder-string]CreateBuilder(string[[]])[/][/]")]
+    [InlineData("[ Discord](https://aka.ms/aspire-discord)", "[cyan][link=https://aka.ms/aspire-discord]Discord[/][/]")]
+    [InlineData("[Discord ](https://aka.ms/aspire-discord)", "[cyan][link=https://aka.ms/aspire-discord]Discord[/][/]")]
+    [InlineData("[ GitHub ](https://github.com)", "[cyan][link=https://github.com]GitHub[/][/]")]
     public void ConvertToSpectre_WithLinks_ConvertsCorrectly(string markdown, string expected)
     {
         // Act
@@ -135,6 +138,16 @@ public partial class MarkdownToSpectreConverterTests
         var result = MarkdownToSpectreConverter.ConvertToPlainText(markdown);
 
         Assert.Equal("Visit GitHub (https://github.com) and remove .", result);
+    }
+
+    [Fact]
+    public void ConvertToPlainText_TrimsWhitespaceFromLinkText()
+    {
+        var markdown = "Drop by [ Discord](https://aka.ms/aspire-discord) to chat.";
+
+        var result = MarkdownToSpectreConverter.ConvertToPlainText(markdown);
+
+        Assert.Equal("Drop by Discord (https://aka.ms/aspire-discord) to chat.", result);
     }
 
     [Fact]


### PR DESCRIPTION
## Summary

Trims leading and trailing whitespace from link text in both the Markdig-based and regex-based markdown conversion paths. Also extracts the regex-based `ConvertLinksToPlainText` into a dedicated `MarkdownLinkConverter` type since it has no dependency on Spectre.Console.

<img width="1289" height="582" alt="image" src="https://github.com/user-attachments/assets/6f219e1f-7290-4188-ba5a-de9cc29ac3a4"/>

## Changes

- **`MarkdownToSpectreConverter.Markup.cs`**: Added `TrimAppendedWhitespace` calls in both the plain-text and rich hyperlink rendering paths of `AppendLinkToMarkup`
- **`MarkdownToSpectreConverter.cs`**: Added `TrimAppendedWhitespace` helper that trims whitespace from a `StringBuilder` range; removed unused `LinkRegex`
- **`MarkdownToSpectreConverter.PlainText.cs`**: Removed `ConvertLinksToPlainText` (moved to `MarkdownLinkConverter`)
- **`MarkdownLinkConverter.cs`** (new): Extracted `ConvertLinksToPlainText` and its `LinkRegex` into a standalone type with no Spectre.Console dependency; fixed whitespace trimming via `match.Groups[1].Value.Trim()`
- **`ConsoleActivityLogger.cs`**: Updated caller to use `MarkdownLinkConverter.ConvertLinksToPlainText`
- **`MarkdownLinkConverterTests.cs`** (new): Tests for `ConvertLinksToPlainText` covering bracketed link text, leading/trailing/both-sides whitespace, and surrounding text
- **`MarkdownToSpectreConverterTests.cs`**: Added test cases for whitespace in Spectre markup links and plain text output