### PR TITLE
Display Unknown state in resource details when state is null

### DIFF
--- a/playground/Stress/Stress.AppHost/AppHost.cs
+++ b/playground/Stress/Stress.AppHost/AppHost.cs
@@ -121,4 +121,6 @@ builder.AddProject<Projects.Stress_Empty>("empty-profile-2", launchProfileName: 
     .WithEnvironment("ENV_TO_OVERRIDE", "this value came from the apphost")
     .WithArgs("arg_from_apphost");
 
+builder.AddNoStatusResource("no-status-resource");
+
 builder.Build().Run();

--- a/playground/Stress/Stress.AppHost/TestResource.cs
+++ b/playground/Stress/Stress.AppHost/TestResource.cs
@@ -64,6 +64,22 @@ static class TestResourceExtensions
 
         return rb;
     }
+
+    [AspireExportIgnore(Reason = "Stress playground helper; not part of the supported ATS surface.")]
+    public static IResourceBuilder<NoStatusResource> AddNoStatusResource(this IDistributedApplicationBuilder builder, string name)
+    {
+        var rb = builder.AddResource(new NoStatusResource(name))
+                      .WithInitialState(new()
+                      {
+                          ResourceType = "No Status Resource",
+                          Properties = [
+                              new(CustomResourceKnownProperties.Source, "Custom")
+                          ]
+                      })
+                      .ExcludeFromManifest();
+
+        return rb;
+    }
 }
 
 internal sealed class TestResourceLifecycle(
@@ -138,4 +154,8 @@ sealed class TestNestedResource(string name, IResource parent) : Resource(name),
 sealed class CommandGroupResource(string name, IResource parent) : Resource(name), IResourceWithParent
 {
     public IResource Parent { get; } = parent;
+}
+
+sealed class NoStatusResource(string name) : Resource(name)
+{
 }

--- a/src/Aspire.Dashboard/Components/Controls/PropertyValues/ResourceStateValue.razor
+++ b/src/Aspire.Dashboard/Components/Controls/PropertyValues/ResourceStateValue.razor
@@ -6,4 +6,4 @@
                 Color="@_stateViewModel.Color"
                 Class="severity-icon" />
 }
-<FluentHighlighter HighlightedText="@HighlightText" Text="@Value" />
+<FluentHighlighter HighlightedText="@HighlightText" Text="@_stateViewModel.Text" />

--- a/src/Aspire.Dashboard/Components/Controls/ResourceDetails.razor.cs
+++ b/src/Aspire.Dashboard/Components/Controls/ResourceDetails.razor.cs
@@ -396,7 +396,10 @@ public partial class ResourceDetails : IComponentWithTelemetry, IDisposable
     private IEnumerable<DisplayedResourcePropertyViewModel> GetResourceProperties(bool ordered)
     {
         var vms = _displayedResourcePropertyViewModels
-            .Where(vm => vm.Value is { HasNullValue: false } and not { KindCase: Value.KindOneofCase.ListValue, ListValue.Values.Count: 0 });
+            .Where(vm => vm.Value is { HasNullValue: false } and not { KindCase: Value.KindOneofCase.ListValue, ListValue.Values.Count: 0 }
+                // State has a custom component (ResourceStateValue) that renders "Unknown" when the value is null,
+                // so always include it in the property list.
+                || string.Equals(vm.KnownProperty?.Key, KnownProperties.Resource.State, StringComparisons.ResourcePropertyName));
 
         return ordered
             ? vms.OrderBy(vm => vm.Priority).ThenBy(vm => vm.DisplayName)

--- a/tests/Aspire.Dashboard.Components.Tests/Controls/ResourceDetailsTests.cs
+++ b/tests/Aspire.Dashboard.Components.Tests/Controls/ResourceDetailsTests.cs
@@ -7,11 +7,13 @@ using Aspire.Dashboard.Components.Controls;
 using Aspire.Dashboard.Resources;
 using Aspire.Dashboard.Components.Tests.Shared;
 using Aspire.Dashboard.Model;
+using Aspire.Dashboard.Tests.Shared;
 using Aspire.Tests.Shared.DashboardModel;
 using Bunit;
 using Google.Protobuf.WellKnownTypes;
 using Microsoft.AspNetCore.Components;
 using Microsoft.AspNetCore.Components.Web;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Diagnostics.HealthChecks;
 using Microsoft.FluentUI.AspNetCore.Components;
 using Xunit;
@@ -390,6 +392,37 @@ public class ResourceDetailsTests : DashboardTestContext
         var resourcePropertyGrid = cut.FindAll(".property-grid")[0];
         Assert.Contains(ControlsStrings.ResourceDetailsStateDescriptionHeader, resourcePropertyGrid.TextContent);
         Assert.Contains(Columns.StateColumnResourceWaiting, resourcePropertyGrid.TextContent);
+    }
+
+    [Fact]
+    public void Render_NullState_ShowsUnknownStateInResourceDetails()
+    {
+        ResourceSetupHelpers.SetupResourceDetails(this);
+        Services.AddSingleton<IDashboardClient>(new TestDashboardClient(isEnabled: true));
+
+        var properties = new Dictionary<string, ResourcePropertyViewModel>
+        {
+            [KnownProperties.Resource.State] = new ResourcePropertyViewModel(
+                KnownProperties.Resource.State,
+                Value.ForNull(),
+                isValueSensitive: false,
+                knownProperty: new KnownProperty(KnownProperties.Resource.State, _ => Aspire.Dashboard.Resources.Resources.ResourcesDetailsStateProperty),
+                priority: 0)
+        };
+
+        var resource = ModelTestHelpers.CreateResource(
+            resourceName: "app1",
+            properties: properties);
+
+        var cut = RenderComponent<ResourceDetails>(builder =>
+        {
+            builder.Add(p => p.Resource, resource);
+            builder.Add(p => p.ResourceByName, new ConcurrentDictionary<string, ResourceViewModel>([new KeyValuePair<string, ResourceViewModel>(resource.Name, resource)]));
+        });
+
+        var resourcePropertyGrid = cut.FindAll(".property-grid")[0];
+        Assert.Contains(Aspire.Dashboard.Resources.Resources.ResourcesDetailsStateProperty, resourcePropertyGrid.TextContent);
+        Assert.Contains(Columns.UnknownStateLabel, resourcePropertyGrid.TextContent);
     }
 
     [Fact]


### PR DESCRIPTION
## Description

When a resource has no state, the resource detail panel did not show a state row at all. Meanwhile, the resource grid's state column correctly displays "Unknown" in this scenario. This change makes the resource detail view consistent with the grid by always showing the State property row, rendering "Unknown" when the state is null.

Three changes were needed:
- **`ResourceDetails.razor.cs`**: Updated `GetResourceProperties()` to always include the State property even when its protobuf value is null, since the `ResourceStateValue` component handles null state rendering.
- **`ResourceStateValue.razor`**: Changed the `FluentHighlighter` to use `_stateViewModel.Text` (from `ResourceStateViewModel`) instead of the raw property `Value` parameter. This matches how `StateColumnDisplay.razor` renders state text in the grid and ensures "Unknown" is displayed for null state.
- **`ResourceDetailsTests.cs`**: Added a test verifying that a resource with null state shows the "Unknown" label in the detail property grid.

Fixes https://github.com/microsoft/aspire/issues/6217

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
