### PR TITLE
Update milestone changelog workflow to target 13.4

### DIFF
--- a/.github/workflows/milestone-changelog.lock.yml
+++ b/.github/workflows/milestone-changelog.lock.yml
@@ -1,4 +1,4 @@
-# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"05e62e2df2ae4f9fd49315c5842196374553a891771e402789b3f58dc4a28426","compiler_version":"v0.72.0","strict":true,"agent_id":"copilot"}
+# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"a1ca3cf7fa48b8704a44327107718a79ba253d021e6e9eebac62e36419dcadb4","compiler_version":"v0.72.0","strict":true,"agent_id":"copilot"}
 # gh-aw-manifest: {"version":1,"secrets":["COPILOT_GITHUB_TOKEN","GH_AW_GITHUB_MCP_SERVER_TOKEN","GH_AW_GITHUB_TOKEN","GITHUB_TOKEN"],"actions":[{"repo":"actions/checkout","sha":"de0fac2e4500dabe0009e67214ff5f5447ce83dd","version":"v6.0.2"},{"repo":"actions/download-artifact","sha":"3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c","version":"v8.0.1"},{"repo":"actions/download-artifact","sha":"d3f86a106a0bac45b974a628896c90dbdf5c8093","version":"v4"},{"repo":"actions/github-script","sha":"3a2844b7e9c422d3c10d287c895573f7108da1b3","version":"v9.0.0"},{"repo":"actions/setup-node","sha":"48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e","version":"v6.4.0"},{"repo":"actions/upload-artifact","sha":"043fb46d1a93c77aae656e7c1c64a875d1fc6a0a","version":"v7.0.1"},{"repo":"actions/upload-artifact","sha":"ea165f8d65b6e75b540449e92b4886f43607fa02","version":"v4"},{"repo":"github/gh-aw-actions/setup","sha":"ff0525b685481744f490a0d362753d8001e4b39d","version":"v0.72.0"}],"containers":[{"image":"ghcr.io/github/gh-aw-firewall/agent:0.25.41"},{"image":"ghcr.io/github/gh-aw-firewall/api-proxy:0.25.41"},{"image":"ghcr.io/github/gh-aw-firewall/squid:0.25.41"},{"image":"ghcr.io/github/gh-aw-mcpg:v0.3.6","digest":"sha256:2bb8eef86006a4c5963c55616a9c51c32f27bfdecb023b8aa6f91f6718d9171c","pinned_image":"ghcr.io/github/gh-aw-mcpg:v0.3.6@sha256:2bb8eef86006a4c5963c55616a9c51c32f27bfdecb023b8aa6f91f6718d9171c"},{"image":"ghcr.io/github/github-mcp-server:v1.0.3","digest":"sha256:2ac27ef03461ef2b877031b838a7d1fd7f12b12d4ace7796d8cad91446d55959","pinned_image":"ghcr.io/github/github-mcp-server:v1.0.3@sha256:2ac27ef03461ef2b877031b838a7d1fd7f12b12d4ace7796d8cad91446d55959"},{"image":"node:lts-alpine","digest":"sha256:d1b3b4da11eefd5941e7f0b9cf17783fc99d9c6fc34884a665f40a06dbdfc94f","pinned_image":"node:lts-alpine@sha256:d1b3b4da11eefd5941e7f0b9cf17783fc99d9c6fc34884a665f40a06dbdfc94f"}]}
 #    ___                   _   _      
 #   / _ \                 | | (_)     
@@ -82,8 +82,8 @@ run-name: "Milestone Changelog Generator"
 env:
   BATCH_SIZE: "20"
   DOCS_REPO: microsoft/aspire.dev
-  MILESTONE: "13.3"
-  MILESTONE_START: "2026-03-01"
+  MILESTONE: "13.4"
+  MILESTONE_START: "2026-05-08"
   PRODUCT: Aspire
   REPO: microsoft/aspire
 
@@ -203,20 +203,20 @@ jobs:
         run: |
           bash "${RUNNER_TEMP}/gh-aw/actions/create_prompt_first.sh"
           {
-          cat << 'GH_AW_PROMPT_4de97aeafbd5171b_EOF'
+          cat << 'GH_AW_PROMPT_471a002a97b1b9b4_EOF'
           <system>
-          GH_AW_PROMPT_4de97aeafbd5171b_EOF
+          GH_AW_PROMPT_471a002a97b1b9b4_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/xpia.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/temp_folder_prompt.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/markdown.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/safe_outputs_prompt.md"
-          cat << 'GH_AW_PROMPT_4de97aeafbd5171b_EOF'
+          cat << 'GH_AW_PROMPT_471a002a97b1b9b4_EOF'
           <safe-output-tools>
           Tools: missing_tool, missing_data, noop, publish
           </safe-output-tools>
-          GH_AW_PROMPT_4de97aeafbd5171b_EOF
+          GH_AW_PROMPT_471a002a97b1b9b4_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/mcp_cli_tools_prompt.md"
-          cat << 'GH_AW_PROMPT_4de97aeafbd5171b_EOF'
+          cat << 'GH_AW_PROMPT_471a002a97b1b9b4_EOF'
           <github-context>
           The following GitHub context information is available for this workflow:
           {{#if __GH_AW_GITHUB_ACTOR__ }}
@@ -245,12 +245,12 @@ jobs:
           {{/if}}
           </github-context>
           
-          GH_AW_PROMPT_4de97aeafbd5171b_EOF
+          GH_AW_PROMPT_471a002a97b1b9b4_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/github_mcp_tools_with_safeoutputs_prompt.md"
-          cat << 'GH_AW_PROMPT_4de97aeafbd5171b_EOF'
+          cat << 'GH_AW_PROMPT_471a002a97b1b9b4_EOF'
           </system>
           {{#runtime-import .github/workflows/milestone-changelog.md}}
-          GH_AW_PROMPT_4de97aeafbd5171b_EOF
+          GH_AW_PROMPT_471a002a97b1b9b4_EOF
           } > "$GH_AW_PROMPT"
       - name: Interpolate variables and render templates
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
@@ -454,9 +454,9 @@ jobs:
           mkdir -p "${RUNNER_TEMP}/gh-aw/safeoutputs"
           mkdir -p /tmp/gh-aw/safeoutputs
           mkdir -p /tmp/gh-aw/mcp-logs/safeoutputs
-          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << 'GH_AW_SAFE_OUTPUTS_CONFIG_a6a28e7f728f79f0_EOF'
+          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << 'GH_AW_SAFE_OUTPUTS_CONFIG_4ce43cd50014d684_EOF'
           {"create_report_incomplete_issue":{},"missing_data":{},"missing_tool":{},"noop":{"max":1,"report-as-issue":"true"},"publish":{"description":"Publish the wiki page, push state to the memory branch, and ensure the feedback issue exists","output":"Wiki page published and memory branch updated!"},"report_incomplete":{}}
-          GH_AW_SAFE_OUTPUTS_CONFIG_a6a28e7f728f79f0_EOF
+          GH_AW_SAFE_OUTPUTS_CONFIG_4ce43cd50014d684_EOF
       - name: Generate Safe Outputs Tools
         env:
           GH_AW_TOOLS_META_JSON: |
@@ -629,7 +629,7 @@ jobs:
           
           mkdir -p /home/runner/.copilot
           GH_AW_NODE=$(which node 2>/dev/null || command -v node 2>/dev/null || echo node)
-          cat << GH_AW_MCP_CONFIG_0ce6f33cd1b55eda_EOF | "$GH_AW_NODE" "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.cjs"
+          cat << GH_AW_MCP_CONFIG_1389b9ae0d4da8fd_EOF | "$GH_AW_NODE" "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.cjs"
           {
             "mcpServers": {
               "github": {
@@ -673,7 +673,7 @@ jobs:
               "payloadDir": "${MCP_GATEWAY_PAYLOAD_DIR}"
             }
           }
-          GH_AW_MCP_CONFIG_0ce6f33cd1b55eda_EOF
+          GH_AW_MCP_CONFIG_1389b9ae0d4da8fd_EOF
       - name: Mount MCP servers as CLIs
         id: mount-mcp-clis
         continue-on-error: true

--- a/.github/workflows/milestone-changelog.md
+++ b/.github/workflows/milestone-changelog.md
@@ -39,8 +39,8 @@ env:
   PRODUCT: "Aspire"
   REPO: "microsoft/aspire"
   DOCS_REPO: "microsoft/aspire.dev"
-  MILESTONE_START: "2026-03-01"
-  MILESTONE: "13.3"
+  MILESTONE_START: "2026-05-08"
+  MILESTONE: "13.4"
   BATCH_SIZE: "20"
 
 on:
@@ -423,7 +423,7 @@ Each run appends newly merged changes to the existing content while preserving
 previous entries. A companion feedback issue collects editorial comments.
 
 > **Note:** `${PRODUCT}`, `${REPO}`, `${DOCS_REPO}`, `${MILESTONE_START}`, `${MILESTONE}`, and `${BATCH_SIZE}` refer to values set in the workflow's
-> `env` block (currently **`Aspire`**, **`microsoft/aspire`**, **`microsoft/aspire.dev`**, **`2026-03-01`**, **`13.3`**, and **`20`**). All file names,
+> `env` block (currently **`Aspire`**, **`microsoft/aspire`**, **`microsoft/aspire.dev`**, **`2026-05-08`**, **`13.4`**, and **`20`**). All file names,
 > titles, and references below derive from those values.
 
 ## Important: available tools


### PR DESCRIPTION
## Summary

13.3 [shipped on 2026-05-07](https://github.com/microsoft/aspire/releases/tag/v13.3.0), so the [milestone changelog generator workflow](https://github.com/microsoft/aspire/blob/main/.github/workflows/milestone-changelog.md) should now target 13.4.

This PR updates the workflow's `env` block:

| Setting | Before | After |
|---|---|---|
| `MILESTONE` | `13.3` | `13.4` |
| `MILESTONE_START` | `2026-03-01` | `2026-05-08` |

`MILESTONE_START` is set to the day after 13.3.0 was published so that docs PRs from `microsoft/aspire.dev` are filtered to those merged after the 13.3 release.

The companion documentation note further down the file (the parenthetical that lists the current env values) is updated to match.

## Lock file

`.github/workflows/milestone-changelog.lock.yml` is regenerated using `gh aw v0.72.0` (the same compiler version that produced the existing lock file) so the diff is minimal — only:

- the frontmatter hash (line 1)
- `MILESTONE` and `MILESTONE_START` env values
- a few content-derived heredoc delimiter hashes

No action SHAs, container image versions, or other infra references change.

## What happens next

After merge, the next scheduled run will start producing a `13.4-Change-log` wiki page (the existing `13.3-Change-log` page is left untouched). The memory branch state for 13.3 (`memory/milestone-changelog/13.3/`) is also preserved; new state files will accumulate under `13.4/`.