### PR TITLE
Enable static web assets in all environments for dashboard

### DIFF
--- a/src/Aspire.Dashboard/DashboardWebApplication.cs
+++ b/src/Aspire.Dashboard/DashboardWebApplication.cs
@@ -133,6 +133,12 @@ public sealed class DashboardWebApplication : IAsyncDisposable
 
         var builder = options is not null ? WebApplication.CreateBuilder(options) : WebApplication.CreateBuilder();
 
+        // WebApplication.CreateBuilder only enables static web assets in the Development environment.
+        // The dashboard needs them in all environments when running from source (e.g. to serve
+        // _content/ files from NuGet packages like FluentUI). The call is a no-op when published
+        // because the static web assets manifest doesn't exist.
+        builder.WebHost.UseStaticWebAssets();
+
         preConfigureBuilder?.Invoke(builder);
 
 #if !DEBUG

--- a/src/Aspire.Dashboard/DashboardWebApplication.cs
+++ b/src/Aspire.Dashboard/DashboardWebApplication.cs
@@ -133,11 +133,14 @@ public sealed class DashboardWebApplication : IAsyncDisposable
 
         var builder = options is not null ? WebApplication.CreateBuilder(options) : WebApplication.CreateBuilder();
 
-        // WebApplication.CreateBuilder only enables static web assets in the Development environment.
-        // The dashboard needs them in all environments when running from source (e.g. to serve
+        // WebApplication.CreateBuilder already enables static web assets in the Development environment.
+        // The dashboard also needs them in other environments when running from source (e.g. to serve
         // _content/ files from NuGet packages like FluentUI). The call is a no-op when published
         // because the static web assets manifest doesn't exist.
-        builder.WebHost.UseStaticWebAssets();
+        if (!builder.Environment.IsDevelopment())
+        {
+            builder.WebHost.UseStaticWebAssets();
+        }
 
         preConfigureBuilder?.Invoke(builder);
 


### PR DESCRIPTION
## Description

When running the Aspire Dashboard from source with a non-Development `ASPNETCORE_ENVIRONMENT`, static web assets from Razor Class Libraries (e.g. FluentUI's JS/CSS files served under `_content/`) are not found. This causes the dashboard UI to fail to load with repeated `TypeError: Failed to fetch dynamically imported module` errors for FluentUI components.

The root cause is that `WebApplication.CreateBuilder()` only calls `UseStaticWebAssets()` automatically in the Development environment. This change explicitly calls `builder.WebHost.UseStaticWebAssets()` so RCL static assets are served regardless of environment. The call is a no-op when published because the static web assets manifest doesn't exist in the published output.

Fixes https://github.com/microsoft/aspire/issues/16069

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [x] No
- Did you add public API?
  - [ ] Yes
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
  - [x] No
