### PR TITLE
Fix traces != (not equals) filter returning empty results

### DIFF
--- a/src/Aspire.Dashboard/Model/Otlp/TelemetryFilter.cs
+++ b/src/Aspire.Dashboard/Model/Otlp/TelemetryFilter.cs
@@ -160,10 +160,11 @@ public class FieldTelemetryFilter : TelemetryFilter
         }
         else
         {
-            // And
+            // And — both values must satisfy the not-equal/not-contains condition.
+            // When Value2 is null (most fields only have one value), Value1 alone is sufficient.
             if (fieldValue.Value1 != null && IsMatch(fieldValue.Value1, Value, Condition))
             {
-                if (fieldValue.Value2 != null && IsMatch(fieldValue.Value2, Value, Condition))
+                if (fieldValue.Value2 is null || IsMatch(fieldValue.Value2, Value, Condition))
                 {
                     return true;
                 }

--- a/tests/Aspire.Dashboard.Tests/TelemetryRepositoryTests/TraceTests.cs
+++ b/tests/Aspire.Dashboard.Tests/TelemetryRepositoryTests/TraceTests.cs
@@ -1302,6 +1302,51 @@ public class TraceTests
     }
 
     [Fact]
+    public void GetTraces_NotEqualFilter_NonMatchingValue_ReturnsTrace()
+    {
+        // Arrange
+        var repository = CreateRepository();
+
+        var addContext = new AddContext();
+        repository.AddTraces(addContext, new RepeatedField<ResourceSpans>()
+        {
+            new ResourceSpans
+            {
+                Resource = CreateResource(name: "resource1", instanceId: "123"),
+                ScopeSpans =
+                {
+                    new ScopeSpans
+                    {
+                        Scope = CreateScope(),
+                        Spans = { CreateSpan(traceId: "1", spanId: "1-1", startTime: s_testTime.AddMinutes(1), endTime: s_testTime.AddMinutes(10), attributes: [KeyValuePair.Create("key1", "value1")]) }
+                    }
+                }
+            }
+        });
+
+        Assert.Equal(0, addContext.FailureCount);
+
+        // Act - filter for key1 != "other_value" should return the trace since key1 is "value1"
+        var traces = repository.GetTraces(new GetTracesRequest
+        {
+            ResourceKey = new ResourceKey("resource1", InstanceId: null),
+            FilterText = string.Empty,
+            StartIndex = 0,
+            Count = 10,
+            Filters = [
+                new FieldTelemetryFilter { Field = "key1", Condition = FilterCondition.NotEqual, Value = "other_value" }
+            ]
+        });
+
+        // Assert
+        Assert.Collection(traces.PagedResult.Items,
+            trace =>
+            {
+                AssertId("1", trace.TraceId);
+            });
+    }
+
+    [Fact]
     public void AddTraces_OutOfOrder_FullName()
     {
         // Arrange


### PR DESCRIPTION
## Description

On the Dashboard Traces page, applying a `!=` (not equals) or `not contains` filter condition causes all traces to be filtered out, regardless of the value provided. The `=` (equals) operator works correctly on the same field/value.

The root cause is in `FieldTelemetryFilter.Apply(OtlpSpan)`. The not-equal/not-contains branch requires both `Value1` and `Value2` of `OtlpSpan.GetFieldValue()` to be non-null and satisfy the condition. Since most span fields only populate `Value1` (only `ServiceName` provides a `Value2` for the uninstrumented peer), the inner `fieldValue.Value2 != null` check always fails, causing every span to return `false` and be excluded.

The fix changes the condition so that a null `Value2` does not block the match — when only one field value exists, the `Value1` result alone is sufficient. When both values are present, both must still satisfy the not-equal condition (AND semantics).

Fixes #16554

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
  - [x] No