### PR TITLE
Improve milestone changelog: backport filtering, docs enrichment, cleanup

### DIFF
--- a/.github/workflows/milestone-changelog.lock.yml
+++ b/.github/workflows/milestone-changelog.lock.yml
@@ -1,4 +1,4 @@
-# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"12269a714d4ba9aab4f300b9b32ae27b4585613992e732e1d435379159a0a393","compiler_version":"v0.72.0","strict":true,"agent_id":"copilot"}
+# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"96790172bb4e6ecc13e741862822be188d5b7eb92605c3f44ed996e5cad62907","compiler_version":"v0.72.0","strict":true,"agent_id":"copilot"}
 # gh-aw-manifest: {"version":1,"secrets":["COPILOT_GITHUB_TOKEN","GH_AW_GITHUB_MCP_SERVER_TOKEN","GH_AW_GITHUB_TOKEN","GITHUB_TOKEN"],"actions":[{"repo":"actions/checkout","sha":"de0fac2e4500dabe0009e67214ff5f5447ce83dd","version":"v6.0.2"},{"repo":"actions/download-artifact","sha":"3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c","version":"v8.0.1"},{"repo":"actions/download-artifact","sha":"d3f86a106a0bac45b974a628896c90dbdf5c8093","version":"v4"},{"repo":"actions/github-script","sha":"3a2844b7e9c422d3c10d287c895573f7108da1b3","version":"v9.0.0"},{"repo":"actions/setup-node","sha":"48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e","version":"v6.4.0"},{"repo":"actions/upload-artifact","sha":"043fb46d1a93c77aae656e7c1c64a875d1fc6a0a","version":"v7.0.1"},{"repo":"actions/upload-artifact","sha":"ea165f8d65b6e75b540449e92b4886f43607fa02","version":"v4"},{"repo":"github/gh-aw-actions/setup","sha":"ff0525b685481744f490a0d362753d8001e4b39d","version":"v0.72.0"}],"containers":[{"image":"ghcr.io/github/gh-aw-firewall/agent:0.25.41"},{"image":"ghcr.io/github/gh-aw-firewall/api-proxy:0.25.41"},{"image":"ghcr.io/github/gh-aw-firewall/squid:0.25.41"},{"image":"ghcr.io/github/gh-aw-mcpg:v0.3.6","digest":"sha256:2bb8eef86006a4c5963c55616a9c51c32f27bfdecb023b8aa6f91f6718d9171c","pinned_image":"ghcr.io/github/gh-aw-mcpg:v0.3.6@sha256:2bb8eef86006a4c5963c55616a9c51c32f27bfdecb023b8aa6f91f6718d9171c"},{"image":"ghcr.io/github/github-mcp-server:v1.0.3","digest":"sha256:2ac27ef03461ef2b877031b838a7d1fd7f12b12d4ace7796d8cad91446d55959","pinned_image":"ghcr.io/github/github-mcp-server:v1.0.3@sha256:2ac27ef03461ef2b877031b838a7d1fd7f12b12d4ace7796d8cad91446d55959"},{"image":"node:lts-alpine","digest":"sha256:d1b3b4da11eefd5941e7f0b9cf17783fc99d9c6fc34884a665f40a06dbdfc94f","pinned_image":"node:lts-alpine@sha256:d1b3b4da11eefd5941e7f0b9cf17783fc99d9c6fc34884a665f40a06dbdfc94f"}]}
 #    ___                   _   _      
 #   / _ \                 | | (_)     
@@ -205,20 +205,20 @@ jobs:
         run: |
           bash "${RUNNER_TEMP}/gh-aw/actions/create_prompt_first.sh"
           {
-          cat << 'GH_AW_PROMPT_61d7b3841e95f8f0_EOF'
+          cat << 'GH_AW_PROMPT_7f44e8735b1d1f9e_EOF'
           <system>
-          GH_AW_PROMPT_61d7b3841e95f8f0_EOF
+          GH_AW_PROMPT_7f44e8735b1d1f9e_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/xpia.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/temp_folder_prompt.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/markdown.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/safe_outputs_prompt.md"
-          cat << 'GH_AW_PROMPT_61d7b3841e95f8f0_EOF'
+          cat << 'GH_AW_PROMPT_7f44e8735b1d1f9e_EOF'
           <safe-output-tools>
           Tools: missing_tool, missing_data, noop, publish
           </safe-output-tools>
-          GH_AW_PROMPT_61d7b3841e95f8f0_EOF
+          GH_AW_PROMPT_7f44e8735b1d1f9e_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/mcp_cli_tools_prompt.md"
-          cat << 'GH_AW_PROMPT_61d7b3841e95f8f0_EOF'
+          cat << 'GH_AW_PROMPT_7f44e8735b1d1f9e_EOF'
           <github-context>
           The following GitHub context information is available for this workflow:
           {{#if __GH_AW_GITHUB_ACTOR__ }}
@@ -247,12 +247,12 @@ jobs:
           {{/if}}
           </github-context>
           
-          GH_AW_PROMPT_61d7b3841e95f8f0_EOF
+          GH_AW_PROMPT_7f44e8735b1d1f9e_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/github_mcp_tools_with_safeoutputs_prompt.md"
-          cat << 'GH_AW_PROMPT_61d7b3841e95f8f0_EOF'
+          cat << 'GH_AW_PROMPT_7f44e8735b1d1f9e_EOF'
           </system>
           {{#runtime-import .github/workflows/milestone-changelog.md}}
-          GH_AW_PROMPT_61d7b3841e95f8f0_EOF
+          GH_AW_PROMPT_7f44e8735b1d1f9e_EOF
           } > "$GH_AW_PROMPT"
       - name: Interpolate variables and render templates
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
@@ -456,9 +456,9 @@ jobs:
           mkdir -p "${RUNNER_TEMP}/gh-aw/safeoutputs"
           mkdir -p /tmp/gh-aw/safeoutputs
           mkdir -p /tmp/gh-aw/mcp-logs/safeoutputs
-          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << 'GH_AW_SAFE_OUTPUTS_CONFIG_07fde4245b9273e1_EOF'
+          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << 'GH_AW_SAFE_OUTPUTS_CONFIG_50fd6b43fcd38ead_EOF'
           {"create_report_incomplete_issue":{},"missing_data":{},"missing_tool":{},"noop":{"max":1,"report-as-issue":"true"},"publish":{"description":"Publish the wiki page, push state to the memory branch, and ensure the feedback issue exists","output":"Wiki page published and memory branch updated!"},"report_incomplete":{}}
-          GH_AW_SAFE_OUTPUTS_CONFIG_07fde4245b9273e1_EOF
+          GH_AW_SAFE_OUTPUTS_CONFIG_50fd6b43fcd38ead_EOF
       - name: Generate Safe Outputs Tools
         env:
           GH_AW_TOOLS_META_JSON: |
@@ -631,7 +631,7 @@ jobs:
           
           mkdir -p /home/runner/.copilot
           GH_AW_NODE=$(which node 2>/dev/null || command -v node 2>/dev/null || echo node)
-          cat << GH_AW_MCP_CONFIG_6486e537a99d2555_EOF | "$GH_AW_NODE" "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.cjs"
+          cat << GH_AW_MCP_CONFIG_ae76031087a8ae57_EOF | "$GH_AW_NODE" "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.cjs"
           {
             "mcpServers": {
               "github": {
@@ -675,7 +675,7 @@ jobs:
               "payloadDir": "${MCP_GATEWAY_PAYLOAD_DIR}"
             }
           }
-          GH_AW_MCP_CONFIG_6486e537a99d2555_EOF
+          GH_AW_MCP_CONFIG_ae76031087a8ae57_EOF
       - name: Mount MCP servers as CLIs
         id: mount-mcp-clis
         continue-on-error: true
@@ -1356,7 +1356,7 @@ jobs:
           # 1. Fetch ALL merged PRs in milestone, sorted by merge date ascending
           gh pr list --repo "$REPO" --state merged --limit 5000 \
             --search "milestone:$MILESTONE" \
-            --json number,title,body,author,mergedAt,labels,additions,deletions,changedFiles \
+            --json number,title,body,author,mergedBy,mergedAt,labels,additions,deletions,changedFiles \
             | jq 'sort_by(.mergedAt)' \
             > "$DATA_DIR/all-milestone-prs.json"
 

--- a/.github/workflows/milestone-changelog.lock.yml
+++ b/.github/workflows/milestone-changelog.lock.yml
@@ -1,4 +1,4 @@
-# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"2a1b2ee321dbf97bab0617af42d236178ca087965d76a764da893b23c7128a7a","compiler_version":"v0.72.0","strict":true,"agent_id":"copilot"}
+# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"1ecda83e6c871a67bd204d77ca45e2eba54d457f52d51520ef47a733ac732b0b","compiler_version":"v0.72.0","strict":true,"agent_id":"copilot"}
 # gh-aw-manifest: {"version":1,"secrets":["COPILOT_GITHUB_TOKEN","GH_AW_GITHUB_MCP_SERVER_TOKEN","GH_AW_GITHUB_TOKEN","GITHUB_TOKEN"],"actions":[{"repo":"actions/checkout","sha":"de0fac2e4500dabe0009e67214ff5f5447ce83dd","version":"v6.0.2"},{"repo":"actions/download-artifact","sha":"3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c","version":"v8.0.1"},{"repo":"actions/download-artifact","sha":"d3f86a106a0bac45b974a628896c90dbdf5c8093","version":"v4"},{"repo":"actions/github-script","sha":"3a2844b7e9c422d3c10d287c895573f7108da1b3","version":"v9.0.0"},{"repo":"actions/setup-node","sha":"48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e","version":"v6.4.0"},{"repo":"actions/upload-artifact","sha":"043fb46d1a93c77aae656e7c1c64a875d1fc6a0a","version":"v7.0.1"},{"repo":"actions/upload-artifact","sha":"ea165f8d65b6e75b540449e92b4886f43607fa02","version":"v4"},{"repo":"github/gh-aw-actions/setup","sha":"ff0525b685481744f490a0d362753d8001e4b39d","version":"v0.72.0"}],"containers":[{"image":"ghcr.io/github/gh-aw-firewall/agent:0.25.41"},{"image":"ghcr.io/github/gh-aw-firewall/api-proxy:0.25.41"},{"image":"ghcr.io/github/gh-aw-firewall/squid:0.25.41"},{"image":"ghcr.io/github/gh-aw-mcpg:v0.3.6","digest":"sha256:2bb8eef86006a4c5963c55616a9c51c32f27bfdecb023b8aa6f91f6718d9171c","pinned_image":"ghcr.io/github/gh-aw-mcpg:v0.3.6@sha256:2bb8eef86006a4c5963c55616a9c51c32f27bfdecb023b8aa6f91f6718d9171c"},{"image":"ghcr.io/github/github-mcp-server:v1.0.3","digest":"sha256:2ac27ef03461ef2b877031b838a7d1fd7f12b12d4ace7796d8cad91446d55959","pinned_image":"ghcr.io/github/github-mcp-server:v1.0.3@sha256:2ac27ef03461ef2b877031b838a7d1fd7f12b12d4ace7796d8cad91446d55959"},{"image":"node:lts-alpine","digest":"sha256:d1b3b4da11eefd5941e7f0b9cf17783fc99d9c6fc34884a665f40a06dbdfc94f","pinned_image":"node:lts-alpine@sha256:d1b3b4da11eefd5941e7f0b9cf17783fc99d9c6fc34884a665f40a06dbdfc94f"}]}
 #    ___                   _   _      
 #   / _ \                 | | (_)     
@@ -205,20 +205,20 @@ jobs:
         run: |
           bash "${RUNNER_TEMP}/gh-aw/actions/create_prompt_first.sh"
           {
-          cat << 'GH_AW_PROMPT_2d587c3b9af54fa5_EOF'
+          cat << 'GH_AW_PROMPT_1a03ff56ec563ebf_EOF'
           <system>
-          GH_AW_PROMPT_2d587c3b9af54fa5_EOF
+          GH_AW_PROMPT_1a03ff56ec563ebf_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/xpia.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/temp_folder_prompt.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/markdown.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/safe_outputs_prompt.md"
-          cat << 'GH_AW_PROMPT_2d587c3b9af54fa5_EOF'
+          cat << 'GH_AW_PROMPT_1a03ff56ec563ebf_EOF'
           <safe-output-tools>
           Tools: missing_tool, missing_data, noop, publish
           </safe-output-tools>
-          GH_AW_PROMPT_2d587c3b9af54fa5_EOF
+          GH_AW_PROMPT_1a03ff56ec563ebf_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/mcp_cli_tools_prompt.md"
-          cat << 'GH_AW_PROMPT_2d587c3b9af54fa5_EOF'
+          cat << 'GH_AW_PROMPT_1a03ff56ec563ebf_EOF'
           <github-context>
           The following GitHub context information is available for this workflow:
           {{#if __GH_AW_GITHUB_ACTOR__ }}
@@ -247,12 +247,12 @@ jobs:
           {{/if}}
           </github-context>
           
-          GH_AW_PROMPT_2d587c3b9af54fa5_EOF
+          GH_AW_PROMPT_1a03ff56ec563ebf_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/github_mcp_tools_with_safeoutputs_prompt.md"
-          cat << 'GH_AW_PROMPT_2d587c3b9af54fa5_EOF'
+          cat << 'GH_AW_PROMPT_1a03ff56ec563ebf_EOF'
           </system>
           {{#runtime-import .github/workflows/milestone-changelog.md}}
-          GH_AW_PROMPT_2d587c3b9af54fa5_EOF
+          GH_AW_PROMPT_1a03ff56ec563ebf_EOF
           } > "$GH_AW_PROMPT"
       - name: Interpolate variables and render templates
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
@@ -456,9 +456,9 @@ jobs:
           mkdir -p "${RUNNER_TEMP}/gh-aw/safeoutputs"
           mkdir -p /tmp/gh-aw/safeoutputs
           mkdir -p /tmp/gh-aw/mcp-logs/safeoutputs
-          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << 'GH_AW_SAFE_OUTPUTS_CONFIG_c68c4ff5806eb8a9_EOF'
+          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << 'GH_AW_SAFE_OUTPUTS_CONFIG_69562d2b48b4bec5_EOF'
           {"create_report_incomplete_issue":{},"missing_data":{},"missing_tool":{},"noop":{"max":1,"report-as-issue":"true"},"publish":{"description":"Publish the wiki page, push state to the memory branch, and ensure the feedback issue exists","output":"Wiki page published and memory branch updated!"},"report_incomplete":{}}
-          GH_AW_SAFE_OUTPUTS_CONFIG_c68c4ff5806eb8a9_EOF
+          GH_AW_SAFE_OUTPUTS_CONFIG_69562d2b48b4bec5_EOF
       - name: Generate Safe Outputs Tools
         env:
           GH_AW_TOOLS_META_JSON: |
@@ -631,7 +631,7 @@ jobs:
           
           mkdir -p /home/runner/.copilot
           GH_AW_NODE=$(which node 2>/dev/null || command -v node 2>/dev/null || echo node)
-          cat << GH_AW_MCP_CONFIG_49d1414112665bb5_EOF | "$GH_AW_NODE" "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.cjs"
+          cat << GH_AW_MCP_CONFIG_4cfe1468ab3af66d_EOF | "$GH_AW_NODE" "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.cjs"
           {
             "mcpServers": {
               "github": {
@@ -675,7 +675,7 @@ jobs:
               "payloadDir": "${MCP_GATEWAY_PAYLOAD_DIR}"
             }
           }
-          GH_AW_MCP_CONFIG_49d1414112665bb5_EOF
+          GH_AW_MCP_CONFIG_4cfe1468ab3af66d_EOF
       - name: Mount MCP servers as CLIs
         id: mount-mcp-clis
         continue-on-error: true
@@ -1378,39 +1378,30 @@ jobs:
           echo "Already processed: $PROCESSED_COUNT"
           echo "Batch PRs (oldest $BATCH_SIZE unprocessed): $BATCH_COUNT"
 
-          # Extract backport entries from previous milestone, filtered to the
-          # batch window. Reads directly from the memory branch clone (still
-          # alive in $MEMORY_TMP) so both backport==true and date filtering
-          # happen in a single jq pass.
-          PREVIOUS_MILESTONE="${{ env.PREVIOUS_MILESTONE }}"
-          if [ "$BATCH_COUNT" -gt 0 ] && [ -n "$PREVIOUS_MILESTONE" ]; then
-            PREV_CHANGES="$MEMORY_TMP/repo/$PREVIOUS_MILESTONE/changes"
-            if [ -d "$PREV_CHANGES" ] && ls "$PREV_CHANGES"/*.json >/dev/null 2>&1; then
-              OLDEST_MERGED=$(jq -r '.[0].mergedAt' "$DATA_DIR/batch-prs.json")
-              cat "$PREV_CHANGES"/*.json \
-                | jq -s --arg cutoff "$OLDEST_MERGED" \
-                  '[.[] | select(.backport == true and .firstMergedAt >= $cutoff)]' \
-                > "$DATA_DIR/backport-prs.json" 2>/dev/null \
-                || echo '[]' > "$DATA_DIR/backport-prs.json"
-              echo "Backport entries from $PREVIOUS_MILESTONE (filtered to batch window): $(jq length "$DATA_DIR/backport-prs.json")"
-            fi
-          fi
           rm -rf "$MEMORY_TMP"
-          if [ ! -f "$DATA_DIR/backport-prs.json" ]; then
-            echo '[]' > "$DATA_DIR/backport-prs.json"
-          fi
 
-          # 2a. Enrich batch PRs with author_association, comments, and files.
-          #     Two API calls per PR:
-          #       1. gh pr view --json files,comments  (files + comments in one call)
-          #       2. gh api .../pulls/$NUM              (author_association, not in gh pr view)
+          # 2a. Enrich batch PRs with comments, files, and authorAssociation.
+          #     The per-PR author_association from the REST API is unreliable
+          #     with GITHUB_TOKEN: org members show as CONTRIBUTOR because the
+          #     token lacks org-level read scope. Instead, we check each author
+          #     via the per-user collaborator/permission endpoint (only needs
+          #     metadata-read scope). Authors with write/maintain/admin are
+          #     MEMBER; others are CONTRIBUTOR.
           if [ "$BATCH_COUNT" -gt 0 ]; then
-            echo "Enriching batch PRs with author_association, comments, and files..."
+            echo "Enriching batch PRs with authorAssociation, comments, and files..."
             : > "$DATA_DIR/enrichment.jsonl"
             for NUM in $(jq -r '.[].number' "$DATA_DIR/batch-prs.json"); do
               VIEW=$(gh pr view "$NUM" --repo "$REPO" --json files,comments 2>/dev/null) \
                 || VIEW='{"files":[],"comments":[]}'
-              ASSOC=$(gh api "repos/$REPO/pulls/$NUM" --jq '.author_association' 2>/dev/null || echo "UNKNOWN")
+              # Determine authorAssociation via per-user permission endpoint.
+              # This endpoint only requires metadata-read scope, unlike the
+              # bulk collaborators list which requires push/admin access.
+              AUTHOR=$(jq -r --argjson n "$NUM" '.[] | select(.number == $n) | .author.login' "$DATA_DIR/batch-prs.json")
+              PERM=$(gh api "repos/$REPO/collaborators/$AUTHOR/permission" --jq '.permission' 2>/dev/null) || PERM=""
+              case "$PERM" in
+                write|maintain|admin) ASSOC="MEMBER" ;;
+                *) ASSOC="CONTRIBUTOR" ;;
+              esac
               echo "$VIEW" | jq --arg n "$NUM" --arg a "$ASSOC" '{($n): {
                 authorAssociation: $a,
                 comments: [(.comments // [])[] | {author: .author.login, body: .body, createdAt: .createdAt}],
@@ -1425,7 +1416,7 @@ jobs:
                 )' > "$DATA_DIR/batch-prs-tmp.json" \
               && mv "$DATA_DIR/batch-prs-tmp.json" "$DATA_DIR/batch-prs.json"
             rm -f "$DATA_DIR/enrichment.jsonl"
-            echo "Enriched $BATCH_COUNT batch PRs with author_association, comments, and files"
+            echo "Enriched $BATCH_COUNT batch PRs with authorAssociation, comments, and files"
           fi
 
           # 2b. Fetch docs PRs from DOCS_REPO merged after milestone start date

--- a/.github/workflows/milestone-changelog.lock.yml
+++ b/.github/workflows/milestone-changelog.lock.yml
@@ -1,4 +1,4 @@
-# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"f3a61e56db19ac0e172afc1468a2a6de85f92f2fe842c16cabb89698bddfd3e7","compiler_version":"v0.72.0","strict":true,"agent_id":"copilot"}
+# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"286e54423f0982c17c81f002409d4fc26effa10df1da8c4f755f974f556b1771","compiler_version":"v0.72.0","strict":true,"agent_id":"copilot"}
 # gh-aw-manifest: {"version":1,"secrets":["COPILOT_GITHUB_TOKEN","GH_AW_GITHUB_MCP_SERVER_TOKEN","GH_AW_GITHUB_TOKEN","GITHUB_TOKEN"],"actions":[{"repo":"actions/checkout","sha":"de0fac2e4500dabe0009e67214ff5f5447ce83dd","version":"v6.0.2"},{"repo":"actions/download-artifact","sha":"3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c","version":"v8.0.1"},{"repo":"actions/download-artifact","sha":"d3f86a106a0bac45b974a628896c90dbdf5c8093","version":"v4"},{"repo":"actions/github-script","sha":"3a2844b7e9c422d3c10d287c895573f7108da1b3","version":"v9.0.0"},{"repo":"actions/setup-node","sha":"48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e","version":"v6.4.0"},{"repo":"actions/upload-artifact","sha":"043fb46d1a93c77aae656e7c1c64a875d1fc6a0a","version":"v7.0.1"},{"repo":"actions/upload-artifact","sha":"ea165f8d65b6e75b540449e92b4886f43607fa02","version":"v4"},{"repo":"github/gh-aw-actions/setup","sha":"ff0525b685481744f490a0d362753d8001e4b39d","version":"v0.72.0"}],"containers":[{"image":"ghcr.io/github/gh-aw-firewall/agent:0.25.41"},{"image":"ghcr.io/github/gh-aw-firewall/api-proxy:0.25.41"},{"image":"ghcr.io/github/gh-aw-firewall/squid:0.25.41"},{"image":"ghcr.io/github/gh-aw-mcpg:v0.3.6","digest":"sha256:2bb8eef86006a4c5963c55616a9c51c32f27bfdecb023b8aa6f91f6718d9171c","pinned_image":"ghcr.io/github/gh-aw-mcpg:v0.3.6@sha256:2bb8eef86006a4c5963c55616a9c51c32f27bfdecb023b8aa6f91f6718d9171c"},{"image":"ghcr.io/github/github-mcp-server:v1.0.3","digest":"sha256:2ac27ef03461ef2b877031b838a7d1fd7f12b12d4ace7796d8cad91446d55959","pinned_image":"ghcr.io/github/github-mcp-server:v1.0.3@sha256:2ac27ef03461ef2b877031b838a7d1fd7f12b12d4ace7796d8cad91446d55959"},{"image":"node:lts-alpine","digest":"sha256:d1b3b4da11eefd5941e7f0b9cf17783fc99d9c6fc34884a665f40a06dbdfc94f","pinned_image":"node:lts-alpine@sha256:d1b3b4da11eefd5941e7f0b9cf17783fc99d9c6fc34884a665f40a06dbdfc94f"}]}
 #    ___                   _   _      
 #   / _ \                 | | (_)     
@@ -88,7 +88,7 @@ env:
   MILESTONE_START: "2026-05-08"
   PREVIOUS_MILESTONE: "13.3"
   PRODUCT: Aspire
-  RELEASE_NOTES_URL: https://aspire.dev/whats-new/upgrade-aspire/
+  RELEASE_NOTES_URL: https://aka.ms/aspire/update-latest
   REPO: microsoft/aspire
 
 jobs:
@@ -207,20 +207,20 @@ jobs:
         run: |
           bash "${RUNNER_TEMP}/gh-aw/actions/create_prompt_first.sh"
           {
-          cat << 'GH_AW_PROMPT_37ee35f01c335b2e_EOF'
+          cat << 'GH_AW_PROMPT_24f2e632b0fdf561_EOF'
           <system>
-          GH_AW_PROMPT_37ee35f01c335b2e_EOF
+          GH_AW_PROMPT_24f2e632b0fdf561_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/xpia.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/temp_folder_prompt.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/markdown.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/safe_outputs_prompt.md"
-          cat << 'GH_AW_PROMPT_37ee35f01c335b2e_EOF'
+          cat << 'GH_AW_PROMPT_24f2e632b0fdf561_EOF'
           <safe-output-tools>
           Tools: missing_tool, missing_data, noop, publish
           </safe-output-tools>
-          GH_AW_PROMPT_37ee35f01c335b2e_EOF
+          GH_AW_PROMPT_24f2e632b0fdf561_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/mcp_cli_tools_prompt.md"
-          cat << 'GH_AW_PROMPT_37ee35f01c335b2e_EOF'
+          cat << 'GH_AW_PROMPT_24f2e632b0fdf561_EOF'
           <github-context>
           The following GitHub context information is available for this workflow:
           {{#if __GH_AW_GITHUB_ACTOR__ }}
@@ -249,12 +249,12 @@ jobs:
           {{/if}}
           </github-context>
           
-          GH_AW_PROMPT_37ee35f01c335b2e_EOF
+          GH_AW_PROMPT_24f2e632b0fdf561_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/github_mcp_tools_with_safeoutputs_prompt.md"
-          cat << 'GH_AW_PROMPT_37ee35f01c335b2e_EOF'
+          cat << 'GH_AW_PROMPT_24f2e632b0fdf561_EOF'
           </system>
           {{#runtime-import .github/workflows/milestone-changelog.md}}
-          GH_AW_PROMPT_37ee35f01c335b2e_EOF
+          GH_AW_PROMPT_24f2e632b0fdf561_EOF
           } > "$GH_AW_PROMPT"
       - name: Interpolate variables and render templates
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
@@ -458,9 +458,9 @@ jobs:
           mkdir -p "${RUNNER_TEMP}/gh-aw/safeoutputs"
           mkdir -p /tmp/gh-aw/safeoutputs
           mkdir -p /tmp/gh-aw/mcp-logs/safeoutputs
-          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << 'GH_AW_SAFE_OUTPUTS_CONFIG_d4ffc4d9a429285f_EOF'
+          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << 'GH_AW_SAFE_OUTPUTS_CONFIG_3f229eaaf58f4f7d_EOF'
           {"create_report_incomplete_issue":{},"missing_data":{},"missing_tool":{},"noop":{"max":1,"report-as-issue":"true"},"publish":{"description":"Publish the wiki page, push state to the memory branch, and ensure the feedback issue exists","output":"Wiki page published and memory branch updated!"},"report_incomplete":{}}
-          GH_AW_SAFE_OUTPUTS_CONFIG_d4ffc4d9a429285f_EOF
+          GH_AW_SAFE_OUTPUTS_CONFIG_3f229eaaf58f4f7d_EOF
       - name: Generate Safe Outputs Tools
         env:
           GH_AW_TOOLS_META_JSON: |
@@ -633,7 +633,7 @@ jobs:
           
           mkdir -p /home/runner/.copilot
           GH_AW_NODE=$(which node 2>/dev/null || command -v node 2>/dev/null || echo node)
-          cat << GH_AW_MCP_CONFIG_7f035f1c769faeaf_EOF | "$GH_AW_NODE" "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.cjs"
+          cat << GH_AW_MCP_CONFIG_14c9051a7fabec3c_EOF | "$GH_AW_NODE" "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.cjs"
           {
             "mcpServers": {
               "github": {
@@ -677,7 +677,7 @@ jobs:
               "payloadDir": "${MCP_GATEWAY_PAYLOAD_DIR}"
             }
           }
-          GH_AW_MCP_CONFIG_7f035f1c769faeaf_EOF
+          GH_AW_MCP_CONFIG_14c9051a7fabec3c_EOF
       - name: Mount MCP servers as CLIs
         id: mount-mcp-clis
         continue-on-error: true

--- a/.github/workflows/milestone-changelog.lock.yml
+++ b/.github/workflows/milestone-changelog.lock.yml
@@ -1,4 +1,4 @@
-# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"fd65eb78b9d8aeed677130f1310746fbc85cf71522d3e78f345173f89e822705","compiler_version":"v0.72.0","strict":true,"agent_id":"copilot"}
+# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"f3a61e56db19ac0e172afc1468a2a6de85f92f2fe842c16cabb89698bddfd3e7","compiler_version":"v0.72.0","strict":true,"agent_id":"copilot"}
 # gh-aw-manifest: {"version":1,"secrets":["COPILOT_GITHUB_TOKEN","GH_AW_GITHUB_MCP_SERVER_TOKEN","GH_AW_GITHUB_TOKEN","GITHUB_TOKEN"],"actions":[{"repo":"actions/checkout","sha":"de0fac2e4500dabe0009e67214ff5f5447ce83dd","version":"v6.0.2"},{"repo":"actions/download-artifact","sha":"3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c","version":"v8.0.1"},{"repo":"actions/download-artifact","sha":"d3f86a106a0bac45b974a628896c90dbdf5c8093","version":"v4"},{"repo":"actions/github-script","sha":"3a2844b7e9c422d3c10d287c895573f7108da1b3","version":"v9.0.0"},{"repo":"actions/setup-node","sha":"48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e","version":"v6.4.0"},{"repo":"actions/upload-artifact","sha":"043fb46d1a93c77aae656e7c1c64a875d1fc6a0a","version":"v7.0.1"},{"repo":"actions/upload-artifact","sha":"ea165f8d65b6e75b540449e92b4886f43607fa02","version":"v4"},{"repo":"github/gh-aw-actions/setup","sha":"ff0525b685481744f490a0d362753d8001e4b39d","version":"v0.72.0"}],"containers":[{"image":"ghcr.io/github/gh-aw-firewall/agent:0.25.41"},{"image":"ghcr.io/github/gh-aw-firewall/api-proxy:0.25.41"},{"image":"ghcr.io/github/gh-aw-firewall/squid:0.25.41"},{"image":"ghcr.io/github/gh-aw-mcpg:v0.3.6","digest":"sha256:2bb8eef86006a4c5963c55616a9c51c32f27bfdecb023b8aa6f91f6718d9171c","pinned_image":"ghcr.io/github/gh-aw-mcpg:v0.3.6@sha256:2bb8eef86006a4c5963c55616a9c51c32f27bfdecb023b8aa6f91f6718d9171c"},{"image":"ghcr.io/github/github-mcp-server:v1.0.3","digest":"sha256:2ac27ef03461ef2b877031b838a7d1fd7f12b12d4ace7796d8cad91446d55959","pinned_image":"ghcr.io/github/github-mcp-server:v1.0.3@sha256:2ac27ef03461ef2b877031b838a7d1fd7f12b12d4ace7796d8cad91446d55959"},{"image":"node:lts-alpine","digest":"sha256:d1b3b4da11eefd5941e7f0b9cf17783fc99d9c6fc34884a665f40a06dbdfc94f","pinned_image":"node:lts-alpine@sha256:d1b3b4da11eefd5941e7f0b9cf17783fc99d9c6fc34884a665f40a06dbdfc94f"}]}
 #    ___                   _   _      
 #   / _ \                 | | (_)     
@@ -35,6 +35,7 @@
 #   - MILESTONE_START: (main workflow)
 #   - PREVIOUS_MILESTONE: (main workflow)
 #   - PRODUCT: (main workflow)
+#   - RELEASE_NOTES_URL: (main workflow)
 #   - REPO: (main workflow)
 #
 # Secrets used:
@@ -87,6 +88,7 @@ env:
   MILESTONE_START: "2026-05-08"
   PREVIOUS_MILESTONE: "13.3"
   PRODUCT: Aspire
+  RELEASE_NOTES_URL: https://aspire.dev/whats-new/upgrade-aspire/
   REPO: microsoft/aspire
 
 jobs:
@@ -205,20 +207,20 @@ jobs:
         run: |
           bash "${RUNNER_TEMP}/gh-aw/actions/create_prompt_first.sh"
           {
-          cat << 'GH_AW_PROMPT_36abf6104e5d43a1_EOF'
+          cat << 'GH_AW_PROMPT_37ee35f01c335b2e_EOF'
           <system>
-          GH_AW_PROMPT_36abf6104e5d43a1_EOF
+          GH_AW_PROMPT_37ee35f01c335b2e_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/xpia.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/temp_folder_prompt.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/markdown.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/safe_outputs_prompt.md"
-          cat << 'GH_AW_PROMPT_36abf6104e5d43a1_EOF'
+          cat << 'GH_AW_PROMPT_37ee35f01c335b2e_EOF'
           <safe-output-tools>
           Tools: missing_tool, missing_data, noop, publish
           </safe-output-tools>
-          GH_AW_PROMPT_36abf6104e5d43a1_EOF
+          GH_AW_PROMPT_37ee35f01c335b2e_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/mcp_cli_tools_prompt.md"
-          cat << 'GH_AW_PROMPT_36abf6104e5d43a1_EOF'
+          cat << 'GH_AW_PROMPT_37ee35f01c335b2e_EOF'
           <github-context>
           The following GitHub context information is available for this workflow:
           {{#if __GH_AW_GITHUB_ACTOR__ }}
@@ -247,12 +249,12 @@ jobs:
           {{/if}}
           </github-context>
           
-          GH_AW_PROMPT_36abf6104e5d43a1_EOF
+          GH_AW_PROMPT_37ee35f01c335b2e_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/github_mcp_tools_with_safeoutputs_prompt.md"
-          cat << 'GH_AW_PROMPT_36abf6104e5d43a1_EOF'
+          cat << 'GH_AW_PROMPT_37ee35f01c335b2e_EOF'
           </system>
           {{#runtime-import .github/workflows/milestone-changelog.md}}
-          GH_AW_PROMPT_36abf6104e5d43a1_EOF
+          GH_AW_PROMPT_37ee35f01c335b2e_EOF
           } > "$GH_AW_PROMPT"
       - name: Interpolate variables and render templates
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
@@ -456,9 +458,9 @@ jobs:
           mkdir -p "${RUNNER_TEMP}/gh-aw/safeoutputs"
           mkdir -p /tmp/gh-aw/safeoutputs
           mkdir -p /tmp/gh-aw/mcp-logs/safeoutputs
-          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << 'GH_AW_SAFE_OUTPUTS_CONFIG_279c658139a5e567_EOF'
+          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << 'GH_AW_SAFE_OUTPUTS_CONFIG_d4ffc4d9a429285f_EOF'
           {"create_report_incomplete_issue":{},"missing_data":{},"missing_tool":{},"noop":{"max":1,"report-as-issue":"true"},"publish":{"description":"Publish the wiki page, push state to the memory branch, and ensure the feedback issue exists","output":"Wiki page published and memory branch updated!"},"report_incomplete":{}}
-          GH_AW_SAFE_OUTPUTS_CONFIG_279c658139a5e567_EOF
+          GH_AW_SAFE_OUTPUTS_CONFIG_d4ffc4d9a429285f_EOF
       - name: Generate Safe Outputs Tools
         env:
           GH_AW_TOOLS_META_JSON: |
@@ -631,7 +633,7 @@ jobs:
           
           mkdir -p /home/runner/.copilot
           GH_AW_NODE=$(which node 2>/dev/null || command -v node 2>/dev/null || echo node)
-          cat << GH_AW_MCP_CONFIG_e0fc72630c2b6ebd_EOF | "$GH_AW_NODE" "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.cjs"
+          cat << GH_AW_MCP_CONFIG_7f035f1c769faeaf_EOF | "$GH_AW_NODE" "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.cjs"
           {
             "mcpServers": {
               "github": {
@@ -675,7 +677,7 @@ jobs:
               "payloadDir": "${MCP_GATEWAY_PAYLOAD_DIR}"
             }
           }
-          GH_AW_MCP_CONFIG_e0fc72630c2b6ebd_EOF
+          GH_AW_MCP_CONFIG_7f035f1c769faeaf_EOF
       - name: Mount MCP servers as CLIs
         id: mount-mcp-clis
         continue-on-error: true

--- a/.github/workflows/milestone-changelog.lock.yml
+++ b/.github/workflows/milestone-changelog.lock.yml
@@ -1,4 +1,4 @@
-# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"1ecda83e6c871a67bd204d77ca45e2eba54d457f52d51520ef47a733ac732b0b","compiler_version":"v0.72.0","strict":true,"agent_id":"copilot"}
+# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"12269a714d4ba9aab4f300b9b32ae27b4585613992e732e1d435379159a0a393","compiler_version":"v0.72.0","strict":true,"agent_id":"copilot"}
 # gh-aw-manifest: {"version":1,"secrets":["COPILOT_GITHUB_TOKEN","GH_AW_GITHUB_MCP_SERVER_TOKEN","GH_AW_GITHUB_TOKEN","GITHUB_TOKEN"],"actions":[{"repo":"actions/checkout","sha":"de0fac2e4500dabe0009e67214ff5f5447ce83dd","version":"v6.0.2"},{"repo":"actions/download-artifact","sha":"3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c","version":"v8.0.1"},{"repo":"actions/download-artifact","sha":"d3f86a106a0bac45b974a628896c90dbdf5c8093","version":"v4"},{"repo":"actions/github-script","sha":"3a2844b7e9c422d3c10d287c895573f7108da1b3","version":"v9.0.0"},{"repo":"actions/setup-node","sha":"48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e","version":"v6.4.0"},{"repo":"actions/upload-artifact","sha":"043fb46d1a93c77aae656e7c1c64a875d1fc6a0a","version":"v7.0.1"},{"repo":"actions/upload-artifact","sha":"ea165f8d65b6e75b540449e92b4886f43607fa02","version":"v4"},{"repo":"github/gh-aw-actions/setup","sha":"ff0525b685481744f490a0d362753d8001e4b39d","version":"v0.72.0"}],"containers":[{"image":"ghcr.io/github/gh-aw-firewall/agent:0.25.41"},{"image":"ghcr.io/github/gh-aw-firewall/api-proxy:0.25.41"},{"image":"ghcr.io/github/gh-aw-firewall/squid:0.25.41"},{"image":"ghcr.io/github/gh-aw-mcpg:v0.3.6","digest":"sha256:2bb8eef86006a4c5963c55616a9c51c32f27bfdecb023b8aa6f91f6718d9171c","pinned_image":"ghcr.io/github/gh-aw-mcpg:v0.3.6@sha256:2bb8eef86006a4c5963c55616a9c51c32f27bfdecb023b8aa6f91f6718d9171c"},{"image":"ghcr.io/github/github-mcp-server:v1.0.3","digest":"sha256:2ac27ef03461ef2b877031b838a7d1fd7f12b12d4ace7796d8cad91446d55959","pinned_image":"ghcr.io/github/github-mcp-server:v1.0.3@sha256:2ac27ef03461ef2b877031b838a7d1fd7f12b12d4ace7796d8cad91446d55959"},{"image":"node:lts-alpine","digest":"sha256:d1b3b4da11eefd5941e7f0b9cf17783fc99d9c6fc34884a665f40a06dbdfc94f","pinned_image":"node:lts-alpine@sha256:d1b3b4da11eefd5941e7f0b9cf17783fc99d9c6fc34884a665f40a06dbdfc94f"}]}
 #    ___                   _   _      
 #   / _ \                 | | (_)     
@@ -205,20 +205,20 @@ jobs:
         run: |
           bash "${RUNNER_TEMP}/gh-aw/actions/create_prompt_first.sh"
           {
-          cat << 'GH_AW_PROMPT_1a03ff56ec563ebf_EOF'
+          cat << 'GH_AW_PROMPT_61d7b3841e95f8f0_EOF'
           <system>
-          GH_AW_PROMPT_1a03ff56ec563ebf_EOF
+          GH_AW_PROMPT_61d7b3841e95f8f0_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/xpia.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/temp_folder_prompt.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/markdown.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/safe_outputs_prompt.md"
-          cat << 'GH_AW_PROMPT_1a03ff56ec563ebf_EOF'
+          cat << 'GH_AW_PROMPT_61d7b3841e95f8f0_EOF'
           <safe-output-tools>
           Tools: missing_tool, missing_data, noop, publish
           </safe-output-tools>
-          GH_AW_PROMPT_1a03ff56ec563ebf_EOF
+          GH_AW_PROMPT_61d7b3841e95f8f0_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/mcp_cli_tools_prompt.md"
-          cat << 'GH_AW_PROMPT_1a03ff56ec563ebf_EOF'
+          cat << 'GH_AW_PROMPT_61d7b3841e95f8f0_EOF'
           <github-context>
           The following GitHub context information is available for this workflow:
           {{#if __GH_AW_GITHUB_ACTOR__ }}
@@ -247,12 +247,12 @@ jobs:
           {{/if}}
           </github-context>
           
-          GH_AW_PROMPT_1a03ff56ec563ebf_EOF
+          GH_AW_PROMPT_61d7b3841e95f8f0_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/github_mcp_tools_with_safeoutputs_prompt.md"
-          cat << 'GH_AW_PROMPT_1a03ff56ec563ebf_EOF'
+          cat << 'GH_AW_PROMPT_61d7b3841e95f8f0_EOF'
           </system>
           {{#runtime-import .github/workflows/milestone-changelog.md}}
-          GH_AW_PROMPT_1a03ff56ec563ebf_EOF
+          GH_AW_PROMPT_61d7b3841e95f8f0_EOF
           } > "$GH_AW_PROMPT"
       - name: Interpolate variables and render templates
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
@@ -456,9 +456,9 @@ jobs:
           mkdir -p "${RUNNER_TEMP}/gh-aw/safeoutputs"
           mkdir -p /tmp/gh-aw/safeoutputs
           mkdir -p /tmp/gh-aw/mcp-logs/safeoutputs
-          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << 'GH_AW_SAFE_OUTPUTS_CONFIG_69562d2b48b4bec5_EOF'
+          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << 'GH_AW_SAFE_OUTPUTS_CONFIG_07fde4245b9273e1_EOF'
           {"create_report_incomplete_issue":{},"missing_data":{},"missing_tool":{},"noop":{"max":1,"report-as-issue":"true"},"publish":{"description":"Publish the wiki page, push state to the memory branch, and ensure the feedback issue exists","output":"Wiki page published and memory branch updated!"},"report_incomplete":{}}
-          GH_AW_SAFE_OUTPUTS_CONFIG_69562d2b48b4bec5_EOF
+          GH_AW_SAFE_OUTPUTS_CONFIG_07fde4245b9273e1_EOF
       - name: Generate Safe Outputs Tools
         env:
           GH_AW_TOOLS_META_JSON: |
@@ -631,7 +631,7 @@ jobs:
           
           mkdir -p /home/runner/.copilot
           GH_AW_NODE=$(which node 2>/dev/null || command -v node 2>/dev/null || echo node)
-          cat << GH_AW_MCP_CONFIG_4cfe1468ab3af66d_EOF | "$GH_AW_NODE" "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.cjs"
+          cat << GH_AW_MCP_CONFIG_6486e537a99d2555_EOF | "$GH_AW_NODE" "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.cjs"
           {
             "mcpServers": {
               "github": {
@@ -675,7 +675,7 @@ jobs:
               "payloadDir": "${MCP_GATEWAY_PAYLOAD_DIR}"
             }
           }
-          GH_AW_MCP_CONFIG_4cfe1468ab3af66d_EOF
+          GH_AW_MCP_CONFIG_6486e537a99d2555_EOF
       - name: Mount MCP servers as CLIs
         id: mount-mcp-clis
         continue-on-error: true
@@ -1397,11 +1397,15 @@ jobs:
               # This endpoint only requires metadata-read scope, unlike the
               # bulk collaborators list which requires push/admin access.
               AUTHOR=$(jq -r --argjson n "$NUM" '.[] | select(.number == $n) | .author.login' "$DATA_DIR/batch-prs.json")
-              PERM=$(gh api "repos/$REPO/collaborators/$AUTHOR/permission" --jq '.permission' 2>/dev/null) || PERM=""
-              case "$PERM" in
-                write|maintain|admin) ASSOC="MEMBER" ;;
-                *) ASSOC="CONTRIBUTOR" ;;
-              esac
+              if [ -z "$AUTHOR" ] || [ "$AUTHOR" = "null" ]; then
+                ASSOC="UNKNOWN"
+              else
+                PERM=$(gh api "repos/$REPO/collaborators/$AUTHOR/permission" --jq '.permission' 2>/dev/null) || PERM=""
+                case "$PERM" in
+                  write|maintain|admin) ASSOC="MEMBER" ;;
+                  *) ASSOC="CONTRIBUTOR" ;;
+                esac
+              fi
               echo "$VIEW" | jq --arg n "$NUM" --arg a "$ASSOC" '{($n): {
                 authorAssociation: $a,
                 comments: [(.comments // [])[] | {author: .author.login, body: .body, createdAt: .createdAt}],

--- a/.github/workflows/milestone-changelog.lock.yml
+++ b/.github/workflows/milestone-changelog.lock.yml
@@ -1,4 +1,4 @@
-# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"05e62e2df2ae4f9fd49315c5842196374553a891771e402789b3f58dc4a28426","compiler_version":"v0.72.0","strict":true,"agent_id":"copilot"}
+# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"2a1b2ee321dbf97bab0617af42d236178ca087965d76a764da893b23c7128a7a","compiler_version":"v0.72.0","strict":true,"agent_id":"copilot"}
 # gh-aw-manifest: {"version":1,"secrets":["COPILOT_GITHUB_TOKEN","GH_AW_GITHUB_MCP_SERVER_TOKEN","GH_AW_GITHUB_TOKEN","GITHUB_TOKEN"],"actions":[{"repo":"actions/checkout","sha":"de0fac2e4500dabe0009e67214ff5f5447ce83dd","version":"v6.0.2"},{"repo":"actions/download-artifact","sha":"3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c","version":"v8.0.1"},{"repo":"actions/download-artifact","sha":"d3f86a106a0bac45b974a628896c90dbdf5c8093","version":"v4"},{"repo":"actions/github-script","sha":"3a2844b7e9c422d3c10d287c895573f7108da1b3","version":"v9.0.0"},{"repo":"actions/setup-node","sha":"48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e","version":"v6.4.0"},{"repo":"actions/upload-artifact","sha":"043fb46d1a93c77aae656e7c1c64a875d1fc6a0a","version":"v7.0.1"},{"repo":"actions/upload-artifact","sha":"ea165f8d65b6e75b540449e92b4886f43607fa02","version":"v4"},{"repo":"github/gh-aw-actions/setup","sha":"ff0525b685481744f490a0d362753d8001e4b39d","version":"v0.72.0"}],"containers":[{"image":"ghcr.io/github/gh-aw-firewall/agent:0.25.41"},{"image":"ghcr.io/github/gh-aw-firewall/api-proxy:0.25.41"},{"image":"ghcr.io/github/gh-aw-firewall/squid:0.25.41"},{"image":"ghcr.io/github/gh-aw-mcpg:v0.3.6","digest":"sha256:2bb8eef86006a4c5963c55616a9c51c32f27bfdecb023b8aa6f91f6718d9171c","pinned_image":"ghcr.io/github/gh-aw-mcpg:v0.3.6@sha256:2bb8eef86006a4c5963c55616a9c51c32f27bfdecb023b8aa6f91f6718d9171c"},{"image":"ghcr.io/github/github-mcp-server:v1.0.3","digest":"sha256:2ac27ef03461ef2b877031b838a7d1fd7f12b12d4ace7796d8cad91446d55959","pinned_image":"ghcr.io/github/github-mcp-server:v1.0.3@sha256:2ac27ef03461ef2b877031b838a7d1fd7f12b12d4ace7796d8cad91446d55959"},{"image":"node:lts-alpine","digest":"sha256:d1b3b4da11eefd5941e7f0b9cf17783fc99d9c6fc34884a665f40a06dbdfc94f","pinned_image":"node:lts-alpine@sha256:d1b3b4da11eefd5941e7f0b9cf17783fc99d9c6fc34884a665f40a06dbdfc94f"}]}
 #    ___                   _   _      
 #   / _ \                 | | (_)     
@@ -33,6 +33,7 @@
 #   - DOCS_REPO: (main workflow)
 #   - MILESTONE: (main workflow)
 #   - MILESTONE_START: (main workflow)
+#   - PREVIOUS_MILESTONE: (main workflow)
 #   - PRODUCT: (main workflow)
 #   - REPO: (main workflow)
 #
@@ -82,8 +83,9 @@ run-name: "Milestone Changelog Generator"
 env:
   BATCH_SIZE: "20"
   DOCS_REPO: microsoft/aspire.dev
-  MILESTONE: "13.3"
-  MILESTONE_START: "2026-03-01"
+  MILESTONE: "13.4"
+  MILESTONE_START: "2026-05-08"
+  PREVIOUS_MILESTONE: "13.3"
   PRODUCT: Aspire
   REPO: microsoft/aspire
 
@@ -203,20 +205,20 @@ jobs:
         run: |
           bash "${RUNNER_TEMP}/gh-aw/actions/create_prompt_first.sh"
           {
-          cat << 'GH_AW_PROMPT_4de97aeafbd5171b_EOF'
+          cat << 'GH_AW_PROMPT_2d587c3b9af54fa5_EOF'
           <system>
-          GH_AW_PROMPT_4de97aeafbd5171b_EOF
+          GH_AW_PROMPT_2d587c3b9af54fa5_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/xpia.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/temp_folder_prompt.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/markdown.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/safe_outputs_prompt.md"
-          cat << 'GH_AW_PROMPT_4de97aeafbd5171b_EOF'
+          cat << 'GH_AW_PROMPT_2d587c3b9af54fa5_EOF'
           <safe-output-tools>
           Tools: missing_tool, missing_data, noop, publish
           </safe-output-tools>
-          GH_AW_PROMPT_4de97aeafbd5171b_EOF
+          GH_AW_PROMPT_2d587c3b9af54fa5_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/mcp_cli_tools_prompt.md"
-          cat << 'GH_AW_PROMPT_4de97aeafbd5171b_EOF'
+          cat << 'GH_AW_PROMPT_2d587c3b9af54fa5_EOF'
           <github-context>
           The following GitHub context information is available for this workflow:
           {{#if __GH_AW_GITHUB_ACTOR__ }}
@@ -245,12 +247,12 @@ jobs:
           {{/if}}
           </github-context>
           
-          GH_AW_PROMPT_4de97aeafbd5171b_EOF
+          GH_AW_PROMPT_2d587c3b9af54fa5_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/github_mcp_tools_with_safeoutputs_prompt.md"
-          cat << 'GH_AW_PROMPT_4de97aeafbd5171b_EOF'
+          cat << 'GH_AW_PROMPT_2d587c3b9af54fa5_EOF'
           </system>
           {{#runtime-import .github/workflows/milestone-changelog.md}}
-          GH_AW_PROMPT_4de97aeafbd5171b_EOF
+          GH_AW_PROMPT_2d587c3b9af54fa5_EOF
           } > "$GH_AW_PROMPT"
       - name: Interpolate variables and render templates
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
@@ -454,9 +456,9 @@ jobs:
           mkdir -p "${RUNNER_TEMP}/gh-aw/safeoutputs"
           mkdir -p /tmp/gh-aw/safeoutputs
           mkdir -p /tmp/gh-aw/mcp-logs/safeoutputs
-          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << 'GH_AW_SAFE_OUTPUTS_CONFIG_a6a28e7f728f79f0_EOF'
+          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << 'GH_AW_SAFE_OUTPUTS_CONFIG_c68c4ff5806eb8a9_EOF'
           {"create_report_incomplete_issue":{},"missing_data":{},"missing_tool":{},"noop":{"max":1,"report-as-issue":"true"},"publish":{"description":"Publish the wiki page, push state to the memory branch, and ensure the feedback issue exists","output":"Wiki page published and memory branch updated!"},"report_incomplete":{}}
-          GH_AW_SAFE_OUTPUTS_CONFIG_a6a28e7f728f79f0_EOF
+          GH_AW_SAFE_OUTPUTS_CONFIG_c68c4ff5806eb8a9_EOF
       - name: Generate Safe Outputs Tools
         env:
           GH_AW_TOOLS_META_JSON: |
@@ -629,7 +631,7 @@ jobs:
           
           mkdir -p /home/runner/.copilot
           GH_AW_NODE=$(which node 2>/dev/null || command -v node 2>/dev/null || echo node)
-          cat << GH_AW_MCP_CONFIG_0ce6f33cd1b55eda_EOF | "$GH_AW_NODE" "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.cjs"
+          cat << GH_AW_MCP_CONFIG_49d1414112665bb5_EOF | "$GH_AW_NODE" "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.cjs"
           {
             "mcpServers": {
               "github": {
@@ -673,7 +675,7 @@ jobs:
               "payloadDir": "${MCP_GATEWAY_PAYLOAD_DIR}"
             }
           }
-          GH_AW_MCP_CONFIG_0ce6f33cd1b55eda_EOF
+          GH_AW_MCP_CONFIG_49d1414112665bb5_EOF
       - name: Mount MCP servers as CLIs
         id: mount-mcp-clis
         continue-on-error: true
@@ -1349,12 +1351,12 @@ jobs:
               echo "::warning::Memory branch clone failed: $(cat "$CLONE_ERR")"
             fi
           fi
-          rm -rf "$MEMORY_TMP" "$CLONE_ERR"
+          rm -f "$CLONE_ERR"
 
           # 1. Fetch ALL merged PRs in milestone, sorted by merge date ascending
           gh pr list --repo "$REPO" --state merged --limit 5000 \
             --search "milestone:$MILESTONE" \
-            --json number,title,body,author,mergedAt,labels,additions,deletions,changedFiles,files \
+            --json number,title,body,author,mergedAt,labels,additions,deletions,changedFiles \
             | jq 'sort_by(.mergedAt)' \
             > "$DATA_DIR/all-milestone-prs.json"
 
@@ -1376,21 +1378,54 @@ jobs:
           echo "Already processed: $PROCESSED_COUNT"
           echo "Batch PRs (oldest $BATCH_SIZE unprocessed): $BATCH_COUNT"
 
-          # 2a. Enrich batch PRs with author_association (not available via gh pr list)
+          # Extract backport entries from previous milestone, filtered to the
+          # batch window. Reads directly from the memory branch clone (still
+          # alive in $MEMORY_TMP) so both backport==true and date filtering
+          # happen in a single jq pass.
+          PREVIOUS_MILESTONE="${{ env.PREVIOUS_MILESTONE }}"
+          if [ "$BATCH_COUNT" -gt 0 ] && [ -n "$PREVIOUS_MILESTONE" ]; then
+            PREV_CHANGES="$MEMORY_TMP/repo/$PREVIOUS_MILESTONE/changes"
+            if [ -d "$PREV_CHANGES" ] && ls "$PREV_CHANGES"/*.json >/dev/null 2>&1; then
+              OLDEST_MERGED=$(jq -r '.[0].mergedAt' "$DATA_DIR/batch-prs.json")
+              cat "$PREV_CHANGES"/*.json \
+                | jq -s --arg cutoff "$OLDEST_MERGED" \
+                  '[.[] | select(.backport == true and .firstMergedAt >= $cutoff)]' \
+                > "$DATA_DIR/backport-prs.json" 2>/dev/null \
+                || echo '[]' > "$DATA_DIR/backport-prs.json"
+              echo "Backport entries from $PREVIOUS_MILESTONE (filtered to batch window): $(jq length "$DATA_DIR/backport-prs.json")"
+            fi
+          fi
+          rm -rf "$MEMORY_TMP"
+          if [ ! -f "$DATA_DIR/backport-prs.json" ]; then
+            echo '[]' > "$DATA_DIR/backport-prs.json"
+          fi
+
+          # 2a. Enrich batch PRs with author_association, comments, and files.
+          #     Two API calls per PR:
+          #       1. gh pr view --json files,comments  (files + comments in one call)
+          #       2. gh api .../pulls/$NUM              (author_association, not in gh pr view)
           if [ "$BATCH_COUNT" -gt 0 ]; then
-            echo "Enriching batch PRs with author_association..."
-            # Build a JSON lookup object {"number": "association", ...} in one pass
-            ASSOC_JSON="{}"
+            echo "Enriching batch PRs with author_association, comments, and files..."
+            : > "$DATA_DIR/enrichment.jsonl"
             for NUM in $(jq -r '.[].number' "$DATA_DIR/batch-prs.json"); do
+              VIEW=$(gh pr view "$NUM" --repo "$REPO" --json files,comments 2>/dev/null) \
+                || VIEW='{"files":[],"comments":[]}'
               ASSOC=$(gh api "repos/$REPO/pulls/$NUM" --jq '.author_association' 2>/dev/null || echo "UNKNOWN")
-              ASSOC_JSON=$(echo "$ASSOC_JSON" | jq --arg n "$NUM" --arg a "$ASSOC" '. + {($n): $a}')
+              echo "$VIEW" | jq --arg n "$NUM" --arg a "$ASSOC" '{($n): {
+                authorAssociation: $a,
+                comments: [(.comments // [])[] | {author: .author.login, body: .body, createdAt: .createdAt}],
+                files: [(.files // [])[] | {path: .path, additions: .additions, deletions: .deletions, changeType: .changeType}]
+              }}' >> "$DATA_DIR/enrichment.jsonl"
             done
-            # Merge all associations into batch-prs.json in a single rewrite
-            echo "$ASSOC_JSON" | jq --slurpfile prs "$DATA_DIR/batch-prs.json" \
-              '. as $lookup | $prs[0] | map(. + {authorAssociation: ($lookup[(.number | tostring)] // "UNKNOWN")})' \
-              > "$DATA_DIR/batch-prs-tmp.json" \
+            # Merge enrichment lookup into batch-prs.json
+            jq -s 'add // {}' "$DATA_DIR/enrichment.jsonl" \
+              | jq --slurpfile prs "$DATA_DIR/batch-prs.json" '. as $lookup | $prs[0] | map(
+                  ($lookup[(.number | tostring)] // {}) as $e |
+                  . + {authorAssociation: ($e.authorAssociation // "UNKNOWN"), comments: ($e.comments // []), files: ($e.files // [])}
+                )' > "$DATA_DIR/batch-prs-tmp.json" \
               && mv "$DATA_DIR/batch-prs-tmp.json" "$DATA_DIR/batch-prs.json"
-            echo "Enriched $BATCH_COUNT batch PRs with author_association"
+            rm -f "$DATA_DIR/enrichment.jsonl"
+            echo "Enriched $BATCH_COUNT batch PRs with author_association, comments, and files"
           fi
 
           # 2b. Fetch docs PRs from DOCS_REPO merged after milestone start date

--- a/.github/workflows/milestone-changelog.lock.yml
+++ b/.github/workflows/milestone-changelog.lock.yml
@@ -1,4 +1,4 @@
-# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"96790172bb4e6ecc13e741862822be188d5b7eb92605c3f44ed996e5cad62907","compiler_version":"v0.72.0","strict":true,"agent_id":"copilot"}
+# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"fd65eb78b9d8aeed677130f1310746fbc85cf71522d3e78f345173f89e822705","compiler_version":"v0.72.0","strict":true,"agent_id":"copilot"}
 # gh-aw-manifest: {"version":1,"secrets":["COPILOT_GITHUB_TOKEN","GH_AW_GITHUB_MCP_SERVER_TOKEN","GH_AW_GITHUB_TOKEN","GITHUB_TOKEN"],"actions":[{"repo":"actions/checkout","sha":"de0fac2e4500dabe0009e67214ff5f5447ce83dd","version":"v6.0.2"},{"repo":"actions/download-artifact","sha":"3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c","version":"v8.0.1"},{"repo":"actions/download-artifact","sha":"d3f86a106a0bac45b974a628896c90dbdf5c8093","version":"v4"},{"repo":"actions/github-script","sha":"3a2844b7e9c422d3c10d287c895573f7108da1b3","version":"v9.0.0"},{"repo":"actions/setup-node","sha":"48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e","version":"v6.4.0"},{"repo":"actions/upload-artifact","sha":"043fb46d1a93c77aae656e7c1c64a875d1fc6a0a","version":"v7.0.1"},{"repo":"actions/upload-artifact","sha":"ea165f8d65b6e75b540449e92b4886f43607fa02","version":"v4"},{"repo":"github/gh-aw-actions/setup","sha":"ff0525b685481744f490a0d362753d8001e4b39d","version":"v0.72.0"}],"containers":[{"image":"ghcr.io/github/gh-aw-firewall/agent:0.25.41"},{"image":"ghcr.io/github/gh-aw-firewall/api-proxy:0.25.41"},{"image":"ghcr.io/github/gh-aw-firewall/squid:0.25.41"},{"image":"ghcr.io/github/gh-aw-mcpg:v0.3.6","digest":"sha256:2bb8eef86006a4c5963c55616a9c51c32f27bfdecb023b8aa6f91f6718d9171c","pinned_image":"ghcr.io/github/gh-aw-mcpg:v0.3.6@sha256:2bb8eef86006a4c5963c55616a9c51c32f27bfdecb023b8aa6f91f6718d9171c"},{"image":"ghcr.io/github/github-mcp-server:v1.0.3","digest":"sha256:2ac27ef03461ef2b877031b838a7d1fd7f12b12d4ace7796d8cad91446d55959","pinned_image":"ghcr.io/github/github-mcp-server:v1.0.3@sha256:2ac27ef03461ef2b877031b838a7d1fd7f12b12d4ace7796d8cad91446d55959"},{"image":"node:lts-alpine","digest":"sha256:d1b3b4da11eefd5941e7f0b9cf17783fc99d9c6fc34884a665f40a06dbdfc94f","pinned_image":"node:lts-alpine@sha256:d1b3b4da11eefd5941e7f0b9cf17783fc99d9c6fc34884a665f40a06dbdfc94f"}]}
 #    ___                   _   _      
 #   / _ \                 | | (_)     
@@ -205,20 +205,20 @@ jobs:
         run: |
           bash "${RUNNER_TEMP}/gh-aw/actions/create_prompt_first.sh"
           {
-          cat << 'GH_AW_PROMPT_7f44e8735b1d1f9e_EOF'
+          cat << 'GH_AW_PROMPT_36abf6104e5d43a1_EOF'
           <system>
-          GH_AW_PROMPT_7f44e8735b1d1f9e_EOF
+          GH_AW_PROMPT_36abf6104e5d43a1_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/xpia.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/temp_folder_prompt.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/markdown.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/safe_outputs_prompt.md"
-          cat << 'GH_AW_PROMPT_7f44e8735b1d1f9e_EOF'
+          cat << 'GH_AW_PROMPT_36abf6104e5d43a1_EOF'
           <safe-output-tools>
           Tools: missing_tool, missing_data, noop, publish
           </safe-output-tools>
-          GH_AW_PROMPT_7f44e8735b1d1f9e_EOF
+          GH_AW_PROMPT_36abf6104e5d43a1_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/mcp_cli_tools_prompt.md"
-          cat << 'GH_AW_PROMPT_7f44e8735b1d1f9e_EOF'
+          cat << 'GH_AW_PROMPT_36abf6104e5d43a1_EOF'
           <github-context>
           The following GitHub context information is available for this workflow:
           {{#if __GH_AW_GITHUB_ACTOR__ }}
@@ -247,12 +247,12 @@ jobs:
           {{/if}}
           </github-context>
           
-          GH_AW_PROMPT_7f44e8735b1d1f9e_EOF
+          GH_AW_PROMPT_36abf6104e5d43a1_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/github_mcp_tools_with_safeoutputs_prompt.md"
-          cat << 'GH_AW_PROMPT_7f44e8735b1d1f9e_EOF'
+          cat << 'GH_AW_PROMPT_36abf6104e5d43a1_EOF'
           </system>
           {{#runtime-import .github/workflows/milestone-changelog.md}}
-          GH_AW_PROMPT_7f44e8735b1d1f9e_EOF
+          GH_AW_PROMPT_36abf6104e5d43a1_EOF
           } > "$GH_AW_PROMPT"
       - name: Interpolate variables and render templates
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
@@ -456,9 +456,9 @@ jobs:
           mkdir -p "${RUNNER_TEMP}/gh-aw/safeoutputs"
           mkdir -p /tmp/gh-aw/safeoutputs
           mkdir -p /tmp/gh-aw/mcp-logs/safeoutputs
-          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << 'GH_AW_SAFE_OUTPUTS_CONFIG_50fd6b43fcd38ead_EOF'
+          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << 'GH_AW_SAFE_OUTPUTS_CONFIG_279c658139a5e567_EOF'
           {"create_report_incomplete_issue":{},"missing_data":{},"missing_tool":{},"noop":{"max":1,"report-as-issue":"true"},"publish":{"description":"Publish the wiki page, push state to the memory branch, and ensure the feedback issue exists","output":"Wiki page published and memory branch updated!"},"report_incomplete":{}}
-          GH_AW_SAFE_OUTPUTS_CONFIG_50fd6b43fcd38ead_EOF
+          GH_AW_SAFE_OUTPUTS_CONFIG_279c658139a5e567_EOF
       - name: Generate Safe Outputs Tools
         env:
           GH_AW_TOOLS_META_JSON: |
@@ -631,7 +631,7 @@ jobs:
           
           mkdir -p /home/runner/.copilot
           GH_AW_NODE=$(which node 2>/dev/null || command -v node 2>/dev/null || echo node)
-          cat << GH_AW_MCP_CONFIG_ae76031087a8ae57_EOF | "$GH_AW_NODE" "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.cjs"
+          cat << GH_AW_MCP_CONFIG_e0fc72630c2b6ebd_EOF | "$GH_AW_NODE" "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.cjs"
           {
             "mcpServers": {
               "github": {
@@ -675,7 +675,7 @@ jobs:
               "payloadDir": "${MCP_GATEWAY_PAYLOAD_DIR}"
             }
           }
-          GH_AW_MCP_CONFIG_ae76031087a8ae57_EOF
+          GH_AW_MCP_CONFIG_e0fc72630c2b6ebd_EOF
       - name: Mount MCP servers as CLIs
         id: mount-mcp-clis
         continue-on-error: true
@@ -1428,7 +1428,7 @@ jobs:
           MILESTONE_START="${{ env.MILESTONE_START }}"
           gh pr list --repo "$DOCS_REPO" --state merged --limit 5000 \
             --search "merged:>=${MILESTONE_START}" \
-            --json number,title,body,author,mergedAt,labels,additions,deletions,changedFiles,files \
+            --json number,title,body,author,mergedBy,mergedAt,labels,additions,deletions,changedFiles,files \
             | jq 'sort_by(.mergedAt)' \
             > "$DATA_DIR/all-docs-prs.json"
 

--- a/.github/workflows/milestone-changelog.md
+++ b/.github/workflows/milestone-changelog.md
@@ -542,15 +542,15 @@ with `jq` to see their exact shape.
 | File | Contents |
 |------|----------|
 | `all-milestone-prs.json` | All merged PRs in the `${MILESTONE}` milestone, sorted by `mergedAt` ascending |
-| `batch-prs.json` | Oldest ${BATCH_SIZE} unprocessed product PRs, enriched with `authorAssociation`, `mergedBy`, `files`, and `comments` (not available from `gh pr list`) |
+| `batch-prs.json` | Oldest ${BATCH_SIZE} unprocessed product PRs. Includes `mergedBy` from the initial fetch, plus `authorAssociation`, `files`, and `comments` added by the enrichment step (not available from `gh pr list`) |
 | `all-docs-prs.json` | All merged PRs in `${DOCS_REPO}` since `${MILESTONE_START}`, sorted by `mergedAt` ascending |
 | `batch-docs-prs.json` | Oldest ${BATCH_SIZE} unprocessed docs PRs (same base fields as product PRs plus `files`, but **without** `authorAssociation` or `comments`) |
 
 ## Step 3: Process the batch PRs
 
 Read `/tmp/gh-aw/pr-data/batch-prs.json`. This is a JSON array of up to ${BATCH_SIZE}
-unprocessed PRs, sorted by `mergedAt` ascending (oldest first). See Step 2 for the
-full schema of each entry.
+unprocessed PRs, sorted by `mergedAt` ascending (oldest first). Inspect the JSON
+with `jq` to see the exact field names available in each entry.
 
 1. **Exclude bot-authored PRs** — remove any PR whose `author.is_bot` is `true`,
    **except** these cases which should be processed normally:
@@ -722,23 +722,6 @@ Then determine whether either of these optional flags applies:
 | **Docs required** | 📝 | Change needs documentation (new feature, changed behavior, new config options) |
 | **Community contribution** | 🌍 | PR's `authorAssociation` (from the batch data) is not `MEMBER` or `OWNER`, **and** the PR's `author.is_bot` (from the batch data) is not `true` — i.e., the author is a human external community contributor. For **backport PRs** (Step 3a), use the original PR author's `authorAssociation` and ignore the backport bot's `is_bot` flag. |
 
-### 5c. Determine owner
-
-Every changelog entry has an **owner** — the team member accountable for the
-change. Determine the owner as follows:
-
-1. **Default:** The PR author (`author.login` from the batch data).
-2. **Community contribution:** If the PR author is a community contributor
-   (i.e., `authorAssociation` is not `MEMBER` or `OWNER`), the owner is the
-   person who merged the PR (`mergedBy.login` from the batch data).
-3. **Backport PRs:** Use the original PR's author (per Step 3a item 5). If
-   that author is a community contributor, use the backport PR's `mergedBy`.
-4. **Grouped entries (Step 5e):** When multiple PRs are grouped into one
-   entry, the owner is determined by the **first** (oldest) PR in the group.
-
-Set the `owner` field in the change file (Step 6a) to the owner's GitHub
-username (without `@` prefix).
-
 The `authorAssociation` field is pre-populated in the batch data by the fetch-data
 job. Use it directly — no additional API calls are needed. For **backport PRs**,
 the original PR's author is not in the batch; query:
@@ -778,6 +761,25 @@ non-empty after Step 5g), add a `Docs:` line linking to the docs PRs:
 When multiple docs PRs are linked, separate them with commas. The line order
 within each entry is: `Owner:`, `Changes:`, `Docs:` (if any), then flag lines.
 Keep the `📝 **Documentation required**` flag line as well.
+
+### 5c. Determine owner
+
+Every changelog entry has an **owner** — the team member accountable for the
+change. Determine the owner as follows:
+
+1. **Default:** The PR author (`author.login` from the batch data).
+2. **Community contribution:** If the PR author is a community contributor
+   (i.e., `authorAssociation` is not `MEMBER` or `OWNER`), the owner is the
+   person who merged the PR (`mergedBy.login` from the batch data). If
+   `mergedBy` is null or missing, fall back to the PR author as owner.
+3. **Backport PRs:** Use the original PR's author (per Step 3a item 5). If
+   that author is a community contributor, use the backport PR's `mergedBy`
+   (or the PR author if `mergedBy` is null).
+4. **Grouped entries (Step 5e):** When multiple PRs are grouped into one
+   entry, the owner is determined by the **first** (oldest) PR in the group.
+
+Set the `owner` field in the change file (Step 6a) to the owner's GitHub
+username (without `@` prefix).
 
 ### 5d. Write name and description
 

--- a/.github/workflows/milestone-changelog.md
+++ b/.github/workflows/milestone-changelog.md
@@ -542,15 +542,36 @@ with `jq` to see their exact shape.
 | File | Contents |
 |------|----------|
 | `all-milestone-prs.json` | All merged PRs in the `${MILESTONE}` milestone, sorted by `mergedAt` ascending |
-| `batch-prs.json` | Oldest ${BATCH_SIZE} unprocessed product PRs. Includes `mergedBy` from the initial fetch, plus `authorAssociation`, `files`, and `comments` added by the enrichment step (not available from `gh pr list`) |
+| `batch-prs.json` | Oldest ${BATCH_SIZE} unprocessed product PRs. Includes `authorAssociation`, `files`, and `comments` added by the enrichment step (not available from `gh pr list`) |
 | `all-docs-prs.json` | All merged PRs in `${DOCS_REPO}` since `${MILESTONE_START}`, sorted by `mergedAt` ascending |
 | `batch-docs-prs.json` | Oldest ${BATCH_SIZE} unprocessed docs PRs (same base fields as product PRs plus `files`, but **without** `authorAssociation` or `comments`) |
+
+Each entry in `batch-prs.json` contains:
+
+| Field | Type | Source | Description |
+|-------|------|--------|-------------|
+| `number` | number | `gh pr list` | PR number |
+| `title` | string | `gh pr list` | PR title |
+| `body` | string | `gh pr list` | PR description/body text |
+| `author` | object | `gh pr list` | `{login, is_bot}` — PR author |
+| `mergedBy` | object \| null | `gh pr list` | `{login, is_bot}` — user who merged the PR (null if unavailable) |
+| `mergedAt` | string | `gh pr list` | ISO 8601 UTC merge timestamp |
+| `labels` | array | `gh pr list` | Array of `{name}` objects |
+| `additions` | number | `gh pr list` | Total lines added |
+| `deletions` | number | `gh pr list` | Total lines deleted |
+| `changedFiles` | number | `gh pr list` | Number of files changed |
+| `authorAssociation` | string | enrichment | `"MEMBER"`, `"CONTRIBUTOR"`, or `"UNKNOWN"` |
+| `files` | array | enrichment | Array of `{path, additions, deletions, changeType}` objects |
+| `comments` | array | enrichment | Array of `{author, body, createdAt}` objects |
+
+Entries in `batch-docs-prs.json` have the same base fields (from `gh pr list`)
+plus `files`, but **without** `authorAssociation` or `comments`.
 
 ## Step 3: Process the batch PRs
 
 Read `/tmp/gh-aw/pr-data/batch-prs.json`. This is a JSON array of up to ${BATCH_SIZE}
-unprocessed PRs, sorted by `mergedAt` ascending (oldest first). Inspect the JSON
-with `jq` to see the exact field names available in each entry.
+unprocessed PRs, sorted by `mergedAt` ascending (oldest first). See Step 2 for the
+full schema of each entry.
 
 1. **Exclude bot-authored PRs** — remove any PR whose `author.is_bot` is `true`,
    **except** these cases which should be processed normally:

--- a/.github/workflows/milestone-changelog.md
+++ b/.github/workflows/milestone-changelog.md
@@ -164,27 +164,7 @@ jobs:
           echo "Already processed: $PROCESSED_COUNT"
           echo "Batch PRs (oldest $BATCH_SIZE unprocessed): $BATCH_COUNT"
 
-          # Extract backport entries from previous milestone, filtered to the
-          # batch window. Reads directly from the memory branch clone (still
-          # alive in $MEMORY_TMP) so both backport==true and date filtering
-          # happen in a single jq pass.
-          PREVIOUS_MILESTONE="${{ env.PREVIOUS_MILESTONE }}"
-          if [ "$BATCH_COUNT" -gt 0 ] && [ -n "$PREVIOUS_MILESTONE" ]; then
-            PREV_CHANGES="$MEMORY_TMP/repo/$PREVIOUS_MILESTONE/changes"
-            if [ -d "$PREV_CHANGES" ] && ls "$PREV_CHANGES"/*.json >/dev/null 2>&1; then
-              OLDEST_MERGED=$(jq -r '.[0].mergedAt' "$DATA_DIR/batch-prs.json")
-              cat "$PREV_CHANGES"/*.json \
-                | jq -s --arg cutoff "$OLDEST_MERGED" \
-                  '[.[] | select(.backport == true and .firstMergedAt >= $cutoff)]' \
-                > "$DATA_DIR/backport-prs.json" 2>/dev/null \
-                || echo '[]' > "$DATA_DIR/backport-prs.json"
-              echo "Backport entries from $PREVIOUS_MILESTONE (filtered to batch window): $(jq length "$DATA_DIR/backport-prs.json")"
-            fi
-          fi
           rm -rf "$MEMORY_TMP"
-          if [ ! -f "$DATA_DIR/backport-prs.json" ]; then
-            echo '[]' > "$DATA_DIR/backport-prs.json"
-          fi
 
           # 2a. Enrich batch PRs with comments, files, and authorAssociation.
           #     The per-PR author_association from the REST API is unreliable
@@ -507,8 +487,7 @@ use one of these patterns:
 | Docs milestone start | `${MILESTONE_START}` (fetch docs PRs merged on or after this date) |
 | Docs batch file | `/tmp/gh-aw/pr-data/batch-docs-prs.json` (unprocessed docs PRs) |
 | Docs PR tracker directory | `prs-docs/` (under memory directories; one JSON file per docs PR) |
-| Previous milestone | `${PREVIOUS_MILESTONE}` (optional; used to filter PRs already shipped via backport) |
-| Backport entries file | `/tmp/gh-aw/pr-data/backport-prs.json` (change entries with `backport: true` from previous milestone) |
+| Previous milestone | `${PREVIOUS_MILESTONE}` (optional; used to identify the release branch for backport detection) |
 
 ## Step 1: Load existing changelog and feedback
 
@@ -560,7 +539,6 @@ with `jq` to see their exact shape.
 | `batch-prs.json` | Oldest ${BATCH_SIZE} unprocessed product PRs, enriched with `authorAssociation`, `files`, and `comments` (not available from `gh pr list`) |
 | `all-docs-prs.json` | All merged PRs in `${DOCS_REPO}` since `${MILESTONE_START}`, sorted by `mergedAt` ascending |
 | `batch-docs-prs.json` | Oldest ${BATCH_SIZE} unprocessed docs PRs (same base fields as product PRs plus `files`, but **without** `authorAssociation` or `comments`) |
-| `backport-prs.json` | Change entries with `backport: true` from the `${PREVIOUS_MILESTONE}` milestone (same schema as Step 6a), filtered to entries whose `firstMergedAt` is on or after the oldest batch PR's `mergedAt`. Empty array if none. Used in Step 3 item 2 to exclude PRs already shipped via backport. |
 
 ## Step 3: Process the batch PRs
 
@@ -578,16 +556,20 @@ full schema of each entry.
      targeting a release branch.
    Record each excluded bot PR as an individual tracker file in `prs/` with
    `status: "excluded"` in Step 6b so they are not re-processed on future runs.
-2. **Exclude PRs already shipped via backport** — if
-   `/tmp/gh-aw/pr-data/backport-prs.json` is non-empty, check each batch PR
-   against the backport entries from the previous milestone. A batch PR should
-   be excluded if it is the **original source** of a backport entry — i.e., its
-   title or body closely matches a backport entry's `name` or `description`,
-   or a backport entry's `description`/`name` explicitly references the PR
-   number. When excluding, set `status: "excluded"` in the PR tracker with a
-   comment like `"Already shipped via backport in milestone <previous>"`. Do
-   **not** exclude PRs that merely touch the same area — the match must be
-   specific to the same logical change.
+2. **Exclude PRs already shipped via backport** — for each batch PR whose
+   `mergedAt` is **before** `${MILESTONE_START}` (i.e., the PR was merged in
+   the previous milestone window and carried over), check the PR's `body` and
+   `comments` (both available in the batch data) for evidence that a backport
+   to the previous milestone's release branch was triggered. Look for:
+   - A `/backport to release/${PREVIOUS_MILESTONE}` command in comments.
+   - A bot comment (e.g., from `github-actions[bot]` or `mergifyio`) confirming
+     a backport PR was created targeting `release/${PREVIOUS_MILESTONE}`.
+   - Body text stating the PR was backported to `release/${PREVIOUS_MILESTONE}`.
+   If a backport was triggered, exclude the PR — its changes already shipped
+   in the previous milestone. Set `status: "excluded"` in the PR tracker with
+   a comment like `"Backported to release/${PREVIOUS_MILESTONE}"`.
+   PRs merged **on or after** `${MILESTONE_START}` should **not** be checked
+   for backports — they are new to this milestone by definition.
 3. If the batch has fewer than ${BATCH_SIZE} PRs, this is the last batch — after
    processing it, the backlog will be fully caught up.
 

--- a/.github/workflows/milestone-changelog.md
+++ b/.github/workflows/milestone-changelog.md
@@ -536,8 +536,7 @@ to determine what work is available.
 
 ## Step 2: Review the pre-computed data
 
-All paths are under `/tmp/gh-aw/pr-data/`. Inspect the JSON files directly
-with `jq` to see their exact shape.
+All paths are under `/tmp/gh-aw/pr-data/`.
 
 | File | Contents |
 |------|----------|
@@ -548,21 +547,21 @@ with `jq` to see their exact shape.
 
 Each entry in `batch-prs.json` contains:
 
-| Field | Type | Source | Description |
-|-------|------|--------|-------------|
-| `number` | number | `gh pr list` | PR number |
-| `title` | string | `gh pr list` | PR title |
-| `body` | string | `gh pr list` | PR description/body text |
-| `author` | object | `gh pr list` | `{login, is_bot}` — PR author |
-| `mergedBy` | object \| null | `gh pr list` | `{login, is_bot}` — user who merged the PR (null if unavailable) |
-| `mergedAt` | string | `gh pr list` | ISO 8601 UTC merge timestamp |
-| `labels` | array | `gh pr list` | Array of `{name}` objects |
-| `additions` | number | `gh pr list` | Total lines added |
-| `deletions` | number | `gh pr list` | Total lines deleted |
-| `changedFiles` | number | `gh pr list` | Number of files changed |
-| `authorAssociation` | string | enrichment | `"MEMBER"`, `"CONTRIBUTOR"`, or `"UNKNOWN"` |
-| `files` | array | enrichment | Array of `{path, additions, deletions, changeType}` objects |
-| `comments` | array | enrichment | Array of `{author, body, createdAt}` objects |
+| Field | Type | Description |
+|-------|------|-------------|
+| `number` | number | PR number |
+| `title` | string | PR title |
+| `body` | string | PR description/body text |
+| `author` | object | `{login, is_bot}` — PR author |
+| `mergedBy` | object | null | `{login, is_bot}` — user who merged the PR (null if unavailable) |
+| `mergedAt` | string | ISO 8601 UTC merge timestamp |
+| `labels` | array | Array of `{name}` objects |
+| `additions` | number | Total lines added |
+| `deletions` | number | Total lines deleted |
+| `changedFiles` | number | Number of files changed |
+| `authorAssociation` | string | `"MEMBER"`, `"CONTRIBUTOR"`, or `"UNKNOWN"` |
+| `files` | array | Array of `{path, additions, deletions, changeType}` objects |
+| `comments` | array | Array of `{author, body, createdAt}` objects |
 
 Entries in `batch-docs-prs.json` have the same base fields (from `gh pr list`)
 but **without** `authorAssociation` or `comments`.

--- a/.github/workflows/milestone-changelog.md
+++ b/.github/workflows/milestone-changelog.md
@@ -565,7 +565,7 @@ Each entry in `batch-prs.json` contains:
 | `comments` | array | enrichment | Array of `{author, body, createdAt}` objects |
 
 Entries in `batch-docs-prs.json` have the same base fields (from `gh pr list`)
-plus `files`, but **without** `authorAssociation` or `comments`.
+but **without** `authorAssociation` or `comments`.
 
 ## Step 3: Process the batch PRs
 

--- a/.github/workflows/milestone-changelog.md
+++ b/.github/workflows/milestone-changelog.md
@@ -1154,15 +1154,15 @@ Use this exact format:
 - [💻 CLI](#-cli)
 - [📊 Dashboard](#-dashboard)
 
+> ℹ️ This changelog is automatically generated from merged pull requests and may
+> contain inaccuracies. For official release notes, see
+> [${RELEASE_NOTES_URL}](${RELEASE_NOTES_URL}).
+
 ## What's New
 
 - [2026-04-22 22:48 — 🧭 Feature name](#-apphost)
 - [2026-04-21 07:30 — 🆕 New CLI command](#-cli)
 - [2026-04-20 23:05 — 🚀 Another feature](#-apphost)
-
-> ℹ️ This changelog is automatically generated from merged pull requests and may
-> contain inaccuracies. For official release notes, see
-> [${RELEASE_NOTES_URL}](${RELEASE_NOTES_URL}).
 
 ## 🏠 AppHost
 

--- a/.github/workflows/milestone-changelog.md
+++ b/.github/workflows/milestone-changelog.md
@@ -42,7 +42,7 @@ env:
   MILESTONE_START: "2026-05-08"
   MILESTONE: "13.4"
   PREVIOUS_MILESTONE: "13.3"
-  RELEASE_NOTES_URL: "https://aspire.dev/whats-new/upgrade-aspire/"
+  RELEASE_NOTES_URL: "https://aka.ms/aspire/update-latest"
   BATCH_SIZE: "20"
 
 on:
@@ -1201,7 +1201,7 @@ Use this exact format:
 
 ---
 
-*This changelog is automatically generated. To provide feedback, comment on the
+*To provide feedback, comment on the
 [Changelog feedback](<link to the "[${MILESTONE}] Changelog feedback" issue in this repo>) issue
 (e.g., "Exclude PR #1234", "Rename: X → Y", "Merge PRs #1234 and #5678").*
 

--- a/.github/workflows/milestone-changelog.md
+++ b/.github/workflows/milestone-changelog.md
@@ -142,7 +142,7 @@ jobs:
           # 1. Fetch ALL merged PRs in milestone, sorted by merge date ascending
           gh pr list --repo "$REPO" --state merged --limit 5000 \
             --search "milestone:$MILESTONE" \
-            --json number,title,body,author,mergedAt,labels,additions,deletions,changedFiles \
+            --json number,title,body,author,mergedBy,mergedAt,labels,additions,deletions,changedFiles \
             | jq 'sort_by(.mergedAt)' \
             > "$DATA_DIR/all-milestone-prs.json"
 
@@ -540,7 +540,7 @@ with `jq` to see their exact shape.
 | File | Contents |
 |------|----------|
 | `all-milestone-prs.json` | All merged PRs in the `${MILESTONE}` milestone, sorted by `mergedAt` ascending |
-| `batch-prs.json` | Oldest ${BATCH_SIZE} unprocessed product PRs, enriched with `authorAssociation`, `files`, and `comments` (not available from `gh pr list`) |
+| `batch-prs.json` | Oldest ${BATCH_SIZE} unprocessed product PRs, enriched with `authorAssociation`, `mergedBy`, `files`, and `comments` (not available from `gh pr list`) |
 | `all-docs-prs.json` | All merged PRs in `${DOCS_REPO}` since `${MILESTONE_START}`, sorted by `mergedAt` ascending |
 | `batch-docs-prs.json` | Oldest ${BATCH_SIZE} unprocessed docs PRs (same base fields as product PRs plus `files`, but **without** `authorAssociation` or `comments`) |
 
@@ -579,9 +579,9 @@ full schema of each entry.
    processing it, the backlog will be fully caught up.
 
 For each remaining (non-bot) PR, collect all data from the batch: number, title,
-author, `authorAssociation`, body, labels, changed file paths (`files` array), and
-total changed lines (additions + deletions). No additional API calls are needed —
-the batch data contains everything required.
+author, `mergedBy`, `authorAssociation`, body, labels, changed file paths (`files`
+array), and total changed lines (additions + deletions). No additional API calls
+are needed — the batch data contains everything required.
 
 ### 3a. Processing backport PRs
 
@@ -720,6 +720,23 @@ Then determine whether either of these optional flags applies:
 | **Docs required** | 📝 | Change needs documentation (new feature, changed behavior, new config options) |
 | **Community contribution** | 🌍 | PR's `authorAssociation` (from the batch data) is not `MEMBER` or `OWNER`, **and** the PR's `author.is_bot` (from the batch data) is not `true` — i.e., the author is a human external community contributor. For **backport PRs** (Step 3a), use the original PR author's `authorAssociation` and ignore the backport bot's `is_bot` flag. |
 
+### Owner
+
+Every changelog entry has an **owner** — the team member accountable for the
+change. Determine the owner as follows:
+
+1. **Default:** The PR author (`author.login` from the batch data).
+2. **Community contribution:** If the PR author is a community contributor
+   (i.e., `authorAssociation` is not `MEMBER` or `OWNER`), the owner is the
+   person who merged the PR (`mergedBy.login` from the batch data).
+3. **Backport PRs:** Use the original PR's author (per Step 3a item 5). If
+   that author is a community contributor, use the backport PR's `mergedBy`.
+4. **Grouped entries (Step 5d):** When multiple PRs are grouped into one
+   entry, the owner is determined by the **first** (oldest) PR in the group.
+
+Set the `owner` field in the change file (Step 6a) to the owner's GitHub
+username (without `@` prefix).
+
 The `authorAssociation` field is pre-populated in the batch data by the fetch-data
 job. Use it directly — no additional API calls are needed. For **backport PRs**,
 the original PR's author is not in the batch; query:
@@ -738,6 +755,7 @@ indented line below the Changes line:
 
 ```
   Changes: [#1234](https://github.com/${REPO}/pull/1234)  
+  Owner: [@jamesnk](https://github.com/jamesnk)  
   ⚠️ **Breaking change**  
   📝 **Documentation required**  
   🌍 **Community contribution** by [@username](https://github.com/username)  
@@ -755,9 +773,9 @@ non-empty after Step 5f), add a `Docs:` line linking to the docs PRs:
 ```
   Docs: [${DOCS_REPO}#456](https://github.com/${DOCS_REPO}/pull/456)  
 ```
-When multiple docs PRs are linked, separate them with commas. The `Docs:` line
-appears immediately after the `Changes:` line. Keep the
-`📝 **Documentation required**` flag line as well.
+When multiple docs PRs are linked, separate them with commas. The line order
+within each entry is: `Changes:`, `Owner:`, `Docs:` (if any), then flag lines.
+Keep the `📝 **Documentation required**` flag line as well.
 
 ### 5c. Write name and description
 
@@ -888,6 +906,7 @@ Schema:
   "firstMergedAt": "2026-04-20T14:15:00Z",
   "lastMergedAt": "2026-04-22T18:30:00Z",
   "name": "New CLI command",
+  "owner": "jamesnk",
   "prs": [1240]
 }
 ```
@@ -907,6 +926,7 @@ Field definitions:
 - **firstMergedAt**: ISO 8601 UTC timestamp of the earliest PR's merge date
 - **lastMergedAt**: ISO 8601 UTC timestamp of the most recent PR's merge date
 - **name**: Short, user-friendly name for the change
+- **owner**: GitHub username (without `@`) of the team member accountable for this change (see Step 5b Owner section)
 - **prs**: Array of PR numbers associated with this entry
 
 After writing each file, **normalize formatting** by running:
@@ -1080,12 +1100,12 @@ Under each area heading, add a one-line **summary** counting the entries per cha
 type, e.g. `2 new features, 1 improvement` or `3 bug fixes`. Use singular form
 for counts of 1 (`1 new feature`, `1 bug fix`, `1 improvement`).
 
-**Every line** within a changelog entry (name, description, Changes, Docs, and each flag
-line) must end with **two trailing spaces** (`  `) to produce a markdown line break.
-This includes the last line of each entry, even when there are no flags.
+**Every line** within a changelog entry (name, description, Changes, Owner, Docs, and
+each flag line) must end with **two trailing spaces** (`  `) to produce a markdown
+line break. This includes the last line of each entry, even when there are no flags.
 
-When a changelog entry has a non-empty `docsPrs` array, add a **Docs:** line immediately
-after the `Changes:` line. Each docs PR is linked using the format
+When a changelog entry has a non-empty `docsPrs` array, add a **Docs:** line after
+the `Owner:` line. Each docs PR is linked using the format
 `[${DOCS_REPO}#456](https://github.com/${DOCS_REPO}/pull/456)`. Separate multiple
 docs PRs with commas. The `📝 **Documentation required**` flag line is kept
 regardless of whether docs PRs are linked.
@@ -1116,12 +1136,14 @@ Use this exact format:
 1. **🧭 Feature name**  
   Brief user-facing description  
   Changes: [#1234](https://github.com/${REPO}/pull/1234), [#1235](https://github.com/${REPO}/pull/1235)  
+  Owner: [@jamesnk](https://github.com/jamesnk)  
   ⚠️ **Breaking change**  
   📝 **Documentation required**  
 
 1. **🚀 Another feature**  
   What this means for users  
   Changes: [#1236](https://github.com/${REPO}/pull/1236)  
+  Owner: [@davidfowl](https://github.com/davidfowl)  
   Docs: [${DOCS_REPO}#456](https://github.com/${DOCS_REPO}/pull/456)  
   📝 **Documentation required**  
 
@@ -1130,6 +1152,7 @@ Use this exact format:
 1. **⚡ Performance boost**  
   Faster startup for container resources  
   Changes: [#1238](https://github.com/${REPO}/pull/1238)  
+  Owner: [@eerhardt](https://github.com/eerhardt)  
 
 ## 💻 CLI
 
@@ -1140,12 +1163,14 @@ Use this exact format:
 1. **🆕 New CLI command**  
   Added a new command for scaffolding resources  
   Changes: [#1240](https://github.com/${REPO}/pull/1240)  
+  Owner: [@jamesnk](https://github.com/jamesnk)  
 
 #### Bug fixes
 
 1. **🐛 Fix crash on init**  
   Resolved a crash when running init in an empty directory  
   Changes: [#1239](https://github.com/${REPO}/pull/1239)  
+  Owner: [@maddymontaquila](https://github.com/maddymontaquila)  
   ⚠️ **Breaking change**  
   🌍 **Community contribution** by [@contributor](https://github.com/contributor)  
 
@@ -1158,6 +1183,7 @@ Use this exact format:
 1. **🎨 Dashboard improvement**  
   Description of the change  
   Changes: [#1237](https://github.com/${REPO}/pull/1237)  
+  Owner: [@AdrianJSClique](https://github.com/AdrianJSClique)  
 
 ---
 

--- a/.github/workflows/milestone-changelog.md
+++ b/.github/workflows/milestone-changelog.md
@@ -503,11 +503,11 @@ to determine what work is available.
 
 - If `batch-prs.json` is **non-empty**, proceed through all steps (1–8).
 - If `batch-prs.json` is **empty** but `batch-docs-prs.json` is non-empty,
-  **skip Steps 3 and 5a–5e** (no product PRs to process) but continue through
-  Steps 1, 2, 4, 5f, 6, 7, and 8 to process docs PRs, apply editorial
+  **skip Steps 3 and 5a–5f** (no product PRs to process) but continue through
+  Steps 1, 2, 4, 5g, 6, 7, and 8 to process docs PRs, apply editorial
   feedback, and update the wiki.
 - If **both** batches are empty, the `fetch-data` job detected updated feedback.
-  **Skip Steps 3, 5a–5e, and 5f** but continue through Steps 1, 2, 4, 6, 7,
+  **Skip Steps 3, 5a–5f, and 5g** but continue through Steps 1, 2, 4, 6, 7,
   and 8 to apply editorial feedback, refresh the “What’s New” section, and
   update the footer counts.
 
@@ -650,7 +650,7 @@ body, labels, and file paths only.
 
 Use the diff to write a more accurate changelog name and description. If the diff
 reveals the change is not notable (e.g., pure refactoring despite a misleading title),
-apply the filtering rules from Step 5e.
+apply the filtering rules from Step 5f.
 
 ## Step 4: Process editorial feedback from comments
 
@@ -722,7 +722,7 @@ Then determine whether either of these optional flags applies:
 | **Docs required** | 📝 | Change needs documentation (new feature, changed behavior, new config options) |
 | **Community contribution** | 🌍 | PR's `authorAssociation` (from the batch data) is not `MEMBER` or `OWNER`, **and** the PR's `author.is_bot` (from the batch data) is not `true` — i.e., the author is a human external community contributor. For **backport PRs** (Step 3a), use the original PR author's `authorAssociation` and ignore the backport bot's `is_bot` flag. |
 
-### Owner
+### 5c. Determine owner
 
 Every changelog entry has an **owner** — the team member accountable for the
 change. Determine the owner as follows:
@@ -733,7 +733,7 @@ change. Determine the owner as follows:
    person who merged the PR (`mergedBy.login` from the batch data).
 3. **Backport PRs:** Use the original PR's author (per Step 3a item 5). If
    that author is a community contributor, use the backport PR's `mergedBy`.
-4. **Grouped entries (Step 5d):** When multiple PRs are grouped into one
+4. **Grouped entries (Step 5e):** When multiple PRs are grouped into one
    entry, the owner is determined by the **first** (oldest) PR in the group.
 
 Set the `owner` field in the change file (Step 6a) to the owner's GitHub
@@ -771,7 +771,7 @@ This gives visibility and recognition to external contributors.
 Omit flag lines entirely when a flag does not apply.
 
 When documentation PRs have been matched to an entry (the `docsPrs` array is
-non-empty after Step 5f), add a `Docs:` line linking to the docs PRs:
+non-empty after Step 5g), add a `Docs:` line linking to the docs PRs:
 ```
   Docs: [${DOCS_REPO}#456](https://github.com/${DOCS_REPO}/pull/456)  
 ```
@@ -779,7 +779,7 @@ When multiple docs PRs are linked, separate them with commas. The line order
 within each entry is: `Owner:`, `Changes:`, `Docs:` (if any), then flag lines.
 Keep the `📝 **Documentation required**` flag line as well.
 
-### 5c. Write name and description
+### 5d. Write name and description
 
 - **Emoji**: Choose a single emoji that represents the change. Pick something specific
   and evocative — avoid reusing the area emoji. Examples: 🧭 for navigation, 🚀 for
@@ -789,7 +789,7 @@ Keep the `📝 **Documentation required**` flag line as well.
 - **Description**: One to two sentences describing the change from an end-user
   perspective. Focus on *what* changed and *why* it matters.
 
-### 5d. Group related PRs
+### 5e. Group related PRs
 
 If multiple PRs **within the current batch** represent the same logical change
 (e.g., a feature spread across several PRs), combine them into **one** changelog
@@ -804,7 +804,7 @@ rather than creating a new one:
   (e.g., new capabilities, platform support, configuration options).
 - Keep the description concise — add detail, don't repeat what's already there.
 
-### 5e. Filtering rules
+### 5f. Filtering rules
 
 - **Include**: new features, notable bug fixes, breaking changes, performance
   improvements, new integrations, new resource types, and notable engineering or
@@ -816,7 +816,7 @@ rather than creating a new one:
 - When in doubt about whether a change is notable, include it — it can always be
   removed via a comment later.
 
-### 5f. Match documentation PRs
+### 5g. Match documentation PRs
 
 Read `/tmp/gh-aw/pr-data/batch-docs-prs.json`. This is a JSON array of up to
 ${BATCH_SIZE} unprocessed docs PRs from `${DOCS_REPO}`, sorted by `mergedAt`
@@ -889,7 +889,7 @@ Where:
 Create the `changes/` directory (via `mkdir -p`) if it does not exist.
 
 If a changelog entry was updated (e.g., a new PR was grouped with an existing entry
-per Step 5d), overwrite the existing change file with the updated content.
+per Step 5e), overwrite the existing change file with the updated content.
 
 Schema:
 
@@ -1252,7 +1252,7 @@ if it exists) and check that:
    body must still be present in the new body (unless editorial feedback explicitly
    requested removal).
 2. **No existing entries were modified** unless the modification adds a PR number from
-   the current batch to that entry's Changes line (per Step 5d grouping rules), or
+   the current batch to that entry's Changes line (per Step 5e grouping rules), or
    editorial feedback from Step 4 explicitly requested the change (e.g., rename,
    merge, area override).
 3. **All new entries reference only PR numbers from the current batch** — any PR number

--- a/.github/workflows/milestone-changelog.md
+++ b/.github/workflows/milestone-changelog.md
@@ -453,7 +453,7 @@ Each run appends newly merged changes to the existing content while preserving
 previous entries. A companion feedback issue collects editorial comments.
 
 > **Note:** `${PRODUCT}`, `${REPO}`, `${DOCS_REPO}`, `${MILESTONE_START}`, `${MILESTONE}`, `${PREVIOUS_MILESTONE}`, `${RELEASE_NOTES_URL}`, and `${BATCH_SIZE}` refer to values set in the workflow's
-> `env` block (currently **`Aspire`**, **`microsoft/aspire`**, **`microsoft/aspire.dev`**, **`2026-05-08`**, **`13.4`**, **`13.3`**, **`https://aspire.dev/whats-new/upgrade-aspire/`**, and **`20`**). All file names,
+> `env` block (currently **`Aspire`**, **`microsoft/aspire`**, **`microsoft/aspire.dev`**, **`2026-05-08`**, **`13.4`**, **`13.3`**, **`https://aka.ms/aspire/update-latest`**, and **`20`**). All file names,
 > titles, and references below derive from those values.
 
 ## Important: available tools
@@ -542,7 +542,7 @@ with `jq` to see their exact shape.
 | File | Contents |
 |------|----------|
 | `all-milestone-prs.json` | All merged PRs in the `${MILESTONE}` milestone, sorted by `mergedAt` ascending |
-| `batch-prs.json` | Oldest ${BATCH_SIZE} unprocessed product PRs, enriched with `authorAssociation`, `files`, and `comments` (not available from `gh pr list`) |
+| `batch-prs.json` | Oldest ${BATCH_SIZE} unprocessed product PRs, enriched with `authorAssociation`, `mergedBy`, `files`, and `comments` (not available from `gh pr list`) |
 | `all-docs-prs.json` | All merged PRs in `${DOCS_REPO}` since `${MILESTONE_START}`, sorted by `mergedAt` ascending |
 | `batch-docs-prs.json` | Oldest ${BATCH_SIZE} unprocessed docs PRs (same base fields as product PRs plus `files`, but **without** `authorAssociation` or `comments`) |
 
@@ -581,9 +581,9 @@ full schema of each entry.
    processing it, the backlog will be fully caught up.
 
 For each remaining (non-bot) PR, collect all data from the batch: number, title,
-author, `authorAssociation`, body, labels, changed file paths (`files` array), and
-total changed lines (additions + deletions). No additional API calls are needed —
-the batch data contains everything required.
+author, `mergedBy`, `authorAssociation`, body, labels, changed file paths (`files`
+array), and total changed lines (additions + deletions). No additional API calls
+are needed — the batch data contains everything required.
 
 ### 3a. Processing backport PRs
 

--- a/.github/workflows/milestone-changelog.md
+++ b/.github/workflows/milestone-changelog.md
@@ -39,8 +39,9 @@ env:
   PRODUCT: "Aspire"
   REPO: "microsoft/aspire"
   DOCS_REPO: "microsoft/aspire.dev"
-  MILESTONE_START: "2026-03-01"
-  MILESTONE: "13.3"
+  MILESTONE_START: "2026-05-08"
+  MILESTONE: "13.4"
+  PREVIOUS_MILESTONE: "13.3"
   BATCH_SIZE: "20"
 
 on:
@@ -136,7 +137,7 @@ jobs:
               echo "::warning::Memory branch clone failed: $(cat "$CLONE_ERR")"
             fi
           fi
-          rm -rf "$MEMORY_TMP" "$CLONE_ERR"
+          rm -f "$CLONE_ERR"
 
           # 1. Fetch ALL merged PRs in milestone, sorted by merge date ascending
           gh pr list --repo "$REPO" --state merged --limit 5000 \
@@ -162,6 +163,28 @@ jobs:
           PROCESSED_COUNT=$(echo "$PROCESSED_NUMBERS" | jq length)
           echo "Already processed: $PROCESSED_COUNT"
           echo "Batch PRs (oldest $BATCH_SIZE unprocessed): $BATCH_COUNT"
+
+          # Extract backport entries from previous milestone, filtered to the
+          # batch window. Reads directly from the memory branch clone (still
+          # alive in $MEMORY_TMP) so both backport==true and date filtering
+          # happen in a single jq pass.
+          PREVIOUS_MILESTONE="${{ env.PREVIOUS_MILESTONE }}"
+          if [ "$BATCH_COUNT" -gt 0 ] && [ -n "$PREVIOUS_MILESTONE" ]; then
+            PREV_CHANGES="$MEMORY_TMP/repo/$PREVIOUS_MILESTONE/changes"
+            if [ -d "$PREV_CHANGES" ] && ls "$PREV_CHANGES"/*.json >/dev/null 2>&1; then
+              OLDEST_MERGED=$(jq -r '.[0].mergedAt' "$DATA_DIR/batch-prs.json")
+              cat "$PREV_CHANGES"/*.json \
+                | jq -s --arg cutoff "$OLDEST_MERGED" \
+                  '[.[] | select(.backport == true and .firstMergedAt >= $cutoff)]' \
+                > "$DATA_DIR/backport-prs.json" 2>/dev/null \
+                || echo '[]' > "$DATA_DIR/backport-prs.json"
+              echo "Backport entries from $PREVIOUS_MILESTONE (filtered to batch window): $(jq length "$DATA_DIR/backport-prs.json")"
+            fi
+          fi
+          rm -rf "$MEMORY_TMP"
+          if [ ! -f "$DATA_DIR/backport-prs.json" ]; then
+            echo '[]' > "$DATA_DIR/backport-prs.json"
+          fi
 
           # 2a. Enrich batch PRs with author_association, comments, and files.
           #     Two API calls per PR:
@@ -196,7 +219,7 @@ jobs:
           MILESTONE_START="${{ env.MILESTONE_START }}"
           gh pr list --repo "$DOCS_REPO" --state merged --limit 5000 \
             --search "merged:>=${MILESTONE_START}" \
-            --json number,title,body,author,mergedAt,labels,additions,deletions,changedFiles \
+            --json number,title,body,author,mergedAt,labels,additions,deletions,changedFiles,files \
             | jq 'sort_by(.mergedAt)' \
             > "$DATA_DIR/all-docs-prs.json"
 
@@ -433,8 +456,8 @@ Generate and maintain a changelog for the **${PRODUCT} ${MILESTONE} milestone** 
 Each run appends newly merged changes to the existing content while preserving
 previous entries. A companion feedback issue collects editorial comments.
 
-> **Note:** `${PRODUCT}`, `${REPO}`, `${DOCS_REPO}`, `${MILESTONE_START}`, `${MILESTONE}`, and `${BATCH_SIZE}` refer to values set in the workflow's
-> `env` block (currently **`Aspire`**, **`microsoft/aspire`**, **`microsoft/aspire.dev`**, **`2026-03-01`**, **`13.3`**, and **`20`**). All file names,
+> **Note:** `${PRODUCT}`, `${REPO}`, `${DOCS_REPO}`, `${MILESTONE_START}`, `${MILESTONE}`, `${PREVIOUS_MILESTONE}`, and `${BATCH_SIZE}` refer to values set in the workflow's
+> `env` block (currently **`Aspire`**, **`microsoft/aspire`**, **`microsoft/aspire.dev`**, **`2026-05-08`**, **`13.4`**, **`13.3`**, and **`20`**). All file names,
 > titles, and references below derive from those values.
 
 ## Important: available tools
@@ -473,6 +496,8 @@ use one of these patterns:
 | Docs milestone start | `${MILESTONE_START}` (fetch docs PRs merged on or after this date) |
 | Docs batch file | `/tmp/gh-aw/pr-data/batch-docs-prs.json` (unprocessed docs PRs) |
 | Docs PR tracker directory | `prs-docs/` (under memory directories; one JSON file per docs PR) |
+| Previous milestone | `${PREVIOUS_MILESTONE}` (optional; used to filter PRs already shipped via backport) |
+| Backport entries file | `/tmp/gh-aw/pr-data/backport-prs.json` (change entries with `backport: true` from previous milestone) |
 
 ## Step 1: Load existing changelog and feedback
 
@@ -513,45 +538,24 @@ to determine what work is available.
    on this issue will be read in Step 4 when processing editorial feedback. If the file does not exist, there is no
    feedback to process.
 
-## Step 2: Review the pre-computed batch
+## Step 2: Review the pre-computed data
 
-The pre-computation step (in the frontmatter) has already:
-- Fetched **all** merged PRs in the ${MILESTONE} milestone, sorted by merge date
-  ascending (oldest first) → `/tmp/gh-aw/pr-data/all-milestone-prs.json`
-- Compared each PR against the individual PR tracker files in `prs/` on the
-  memory branch to identify which PRs have not yet been processed (no tracker
-  file present)
-- Written the oldest ${BATCH_SIZE} unprocessed PRs to `/tmp/gh-aw/pr-data/batch-prs.json`
+All paths are under `/tmp/gh-aw/pr-data/`. Inspect the JSON files directly
+with `jq` to see their exact shape.
 
-Each entry in `batch-prs.json` contains: `number`, `title`, `body`, `author` (object
-with `login` and `is_bot`), `authorAssociation` (string, e.g. `"MEMBER"`, `"OWNER"`,
-`"CONTRIBUTOR"`, `"NONE"`), `mergedAt`, `labels` (array of objects with `name`),
-`additions`, `deletions`, `changedFiles`, `files` (array of objects with
-`path`, `additions`, `deletions`, `changeType`) listing the changed file paths,
-and `comments` (array of objects with `author`, `body`, `createdAt`) containing
-the PR's issue comments. The `files` and `comments` fields are enriched from
-the REST API during the pre-computation step (not from `gh pr list`).
-
-The pre-computation step has also fetched merged PRs from `${DOCS_REPO}` that
-were merged on or after `${MILESTONE_START}`:
-- All matching docs PRs → `/tmp/gh-aw/pr-data/all-docs-prs.json`
-- Oldest ${BATCH_SIZE} unprocessed docs PRs → `/tmp/gh-aw/pr-data/batch-docs-prs.json`
-
-Each entry in `batch-docs-prs.json` has the same schema as `batch-prs.json`,
-except without the `authorAssociation`, `comments`, or `files` fields (which
-are only enriched for product PRs).
+| File | Contents |
+|------|----------|
+| `all-milestone-prs.json` | All merged PRs in the `${MILESTONE}` milestone, sorted by `mergedAt` ascending |
+| `batch-prs.json` | Oldest ${BATCH_SIZE} unprocessed product PRs, enriched with `authorAssociation`, `files`, and `comments` (not available from `gh pr list`) |
+| `all-docs-prs.json` | All merged PRs in `${DOCS_REPO}` since `${MILESTONE_START}`, sorted by `mergedAt` ascending |
+| `batch-docs-prs.json` | Oldest ${BATCH_SIZE} unprocessed docs PRs (same base fields as product PRs plus `files`, but **without** `authorAssociation` or `comments`) |
+| `backport-prs.json` | Change entries with `backport: true` from the `${PREVIOUS_MILESTONE}` milestone (same schema as Step 6a), filtered to entries whose `firstMergedAt` is on or after the oldest batch PR's `mergedAt`. Empty array if none. Used in Step 3 item 2 to exclude PRs already shipped via backport. |
 
 ## Step 3: Process the batch PRs
 
 Read `/tmp/gh-aw/pr-data/batch-prs.json`. This is a JSON array of up to ${BATCH_SIZE}
-unprocessed PRs, sorted by `mergedAt` ascending (oldest first). Each entry contains:
-`number`, `title`, `body`, `author` (object with `login` and `is_bot`), `mergedAt`,
-`labels` (array of objects with `name`), `additions`, `deletions`, `changedFiles`,
-`files` (array of objects with `path`, `additions`, `deletions`, `changeType`),
-and `comments` (array of objects with `author`, `body`, `createdAt`).
-The batch is also enriched with `authorAssociation` (fetched via REST API in the
-pre-computation step). The `files`, `comments`, and `authorAssociation` fields
-are all fetched per-PR during enrichment, not from `gh pr list`.
+unprocessed PRs, sorted by `mergedAt` ascending (oldest first). See Step 2 for the
+full schema of each entry.
 
 1. **Exclude bot-authored PRs** — remove any PR whose `author.is_bot` is `true`,
    **except** these cases which should be processed normally:
@@ -563,7 +567,17 @@ are all fetched per-PR during enrichment, not from `gh pr list`.
      targeting a release branch.
    Record each excluded bot PR as an individual tracker file in `prs/` with
    `status: "excluded"` in Step 6b so they are not re-processed on future runs.
-2. If the batch has fewer than ${BATCH_SIZE} PRs, this is the last batch — after
+2. **Exclude PRs already shipped via backport** — if
+   `/tmp/gh-aw/pr-data/backport-prs.json` is non-empty, check each batch PR
+   against the backport entries from the previous milestone. A batch PR should
+   be excluded if it is the **original source** of a backport entry — i.e., its
+   title or body closely matches a backport entry's `name` or `description`,
+   or a backport entry's `description`/`name` explicitly references the PR
+   number. When excluding, set `status: "excluded"` in the PR tracker with a
+   comment like `"Already shipped via backport in milestone <previous>"`. Do
+   **not** exclude PRs that merely touch the same area — the match must be
+   specific to the same logical change.
+3. If the batch has fewer than ${BATCH_SIZE} PRs, this is the last batch — after
    processing it, the backlog will be fully caught up.
 
 For each remaining (non-bot) PR, collect all data from the batch: number, title,
@@ -784,7 +798,8 @@ rather than creating a new one:
 
 Read `/tmp/gh-aw/pr-data/batch-docs-prs.json`. This is a JSON array of up to
 ${BATCH_SIZE} unprocessed docs PRs from `${DOCS_REPO}`, sorted by `mergedAt`
-ascending. Each entry has the same schema as the product PR batch.
+ascending. Each entry has the same fields as product PRs except
+`authorAssociation` and `comments` (which are only enriched for product PRs).
 
 Unlike product PRs (Step 3), **do not exclude bot-authored docs PRs** —
 automated docs PRs from bots often contain meaningful documentation updates.
@@ -795,8 +810,8 @@ filter but documents an unrelated product or version), record it as
 `"excluded"` in the docs PR tracker (Step 6d) with a comment explaining why.
 
 For each remaining docs PR, determine whether it documents a changelog entry.
-The batch data already contains each docs PR's `title`, `body`, and `files`
-(changed file paths) — no additional API calls are needed. Match by:
+The batch data already contains each docs PR's `title`, `body`, `files`
+(changed file paths), and `labels` — no additional API calls are needed. Match by:
 
 1. **Explicit product PR reference** — the docs PR body or title mentions a
    product PR number (e.g., "Documents #1234", links to

--- a/.github/workflows/milestone-changelog.md
+++ b/.github/workflows/milestone-changelog.md
@@ -141,7 +141,7 @@ jobs:
           # 1. Fetch ALL merged PRs in milestone, sorted by merge date ascending
           gh pr list --repo "$REPO" --state merged --limit 5000 \
             --search "milestone:$MILESTONE" \
-            --json number,title,body,author,mergedAt,labels,additions,deletions,changedFiles,files \
+            --json number,title,body,author,mergedAt,labels,additions,deletions,changedFiles \
             | jq 'sort_by(.mergedAt)' \
             > "$DATA_DIR/all-milestone-prs.json"
 
@@ -163,21 +163,32 @@ jobs:
           echo "Already processed: $PROCESSED_COUNT"
           echo "Batch PRs (oldest $BATCH_SIZE unprocessed): $BATCH_COUNT"
 
-          # 2a. Enrich batch PRs with author_association (not available via gh pr list)
+          # 2a. Enrich batch PRs with author_association, comments, and files.
+          #     Two API calls per PR:
+          #       1. gh pr view --json files,comments  (files + comments in one call)
+          #       2. gh api .../pulls/$NUM              (author_association, not in gh pr view)
           if [ "$BATCH_COUNT" -gt 0 ]; then
-            echo "Enriching batch PRs with author_association..."
-            # Build a JSON lookup object {"number": "association", ...} in one pass
-            ASSOC_JSON="{}"
+            echo "Enriching batch PRs with author_association, comments, and files..."
+            : > "$DATA_DIR/enrichment.jsonl"
             for NUM in $(jq -r '.[].number' "$DATA_DIR/batch-prs.json"); do
+              VIEW=$(gh pr view "$NUM" --repo "$REPO" --json files,comments 2>/dev/null) \
+                || VIEW='{"files":[],"comments":[]}'
               ASSOC=$(gh api "repos/$REPO/pulls/$NUM" --jq '.author_association' 2>/dev/null || echo "UNKNOWN")
-              ASSOC_JSON=$(echo "$ASSOC_JSON" | jq --arg n "$NUM" --arg a "$ASSOC" '. + {($n): $a}')
+              echo "$VIEW" | jq --arg n "$NUM" --arg a "$ASSOC" '{($n): {
+                authorAssociation: $a,
+                comments: [(.comments // [])[] | {author: .author.login, body: .body, createdAt: .createdAt}],
+                files: [(.files // [])[] | {path: .path, additions: .additions, deletions: .deletions, changeType: .changeType}]
+              }}' >> "$DATA_DIR/enrichment.jsonl"
             done
-            # Merge all associations into batch-prs.json in a single rewrite
-            echo "$ASSOC_JSON" | jq --slurpfile prs "$DATA_DIR/batch-prs.json" \
-              '. as $lookup | $prs[0] | map(. + {authorAssociation: ($lookup[(.number | tostring)] // "UNKNOWN")})' \
-              > "$DATA_DIR/batch-prs-tmp.json" \
+            # Merge enrichment lookup into batch-prs.json
+            jq -s 'add // {}' "$DATA_DIR/enrichment.jsonl" \
+              | jq --slurpfile prs "$DATA_DIR/batch-prs.json" '. as $lookup | $prs[0] | map(
+                  ($lookup[(.number | tostring)] // {}) as $e |
+                  . + {authorAssociation: ($e.authorAssociation // "UNKNOWN"), comments: ($e.comments // []), files: ($e.files // [])}
+                )' > "$DATA_DIR/batch-prs-tmp.json" \
               && mv "$DATA_DIR/batch-prs-tmp.json" "$DATA_DIR/batch-prs.json"
-            echo "Enriched $BATCH_COUNT batch PRs with author_association"
+            rm -f "$DATA_DIR/enrichment.jsonl"
+            echo "Enriched $BATCH_COUNT batch PRs with author_association, comments, and files"
           fi
 
           # 2b. Fetch docs PRs from DOCS_REPO merged after milestone start date
@@ -185,7 +196,7 @@ jobs:
           MILESTONE_START="${{ env.MILESTONE_START }}"
           gh pr list --repo "$DOCS_REPO" --state merged --limit 5000 \
             --search "merged:>=${MILESTONE_START}" \
-            --json number,title,body,author,mergedAt,labels,additions,deletions,changedFiles,files \
+            --json number,title,body,author,mergedAt,labels,additions,deletions,changedFiles \
             | jq 'sort_by(.mergedAt)' \
             > "$DATA_DIR/all-docs-prs.json"
 
@@ -515,8 +526,11 @@ The pre-computation step (in the frontmatter) has already:
 Each entry in `batch-prs.json` contains: `number`, `title`, `body`, `author` (object
 with `login` and `is_bot`), `authorAssociation` (string, e.g. `"MEMBER"`, `"OWNER"`,
 `"CONTRIBUTOR"`, `"NONE"`), `mergedAt`, `labels` (array of objects with `name`),
-`additions`, `deletions`, `changedFiles`, and `files` (array of objects with
-`path`, `additions`, `deletions`, `changeType`) listing the changed file paths.
+`additions`, `deletions`, `changedFiles`, `files` (array of objects with
+`path`, `additions`, `deletions`, `changeType`) listing the changed file paths,
+and `comments` (array of objects with `author`, `body`, `createdAt`) containing
+the PR's issue comments. The `files` and `comments` fields are enriched from
+the REST API during the pre-computation step (not from `gh pr list`).
 
 The pre-computation step has also fetched merged PRs from `${DOCS_REPO}` that
 were merged on or after `${MILESTONE_START}`:
@@ -524,8 +538,8 @@ were merged on or after `${MILESTONE_START}`:
 - Oldest ${BATCH_SIZE} unprocessed docs PRs → `/tmp/gh-aw/pr-data/batch-docs-prs.json`
 
 Each entry in `batch-docs-prs.json` has the same schema as `batch-prs.json`,
-except without the `authorAssociation` field (which is only enriched for
-product PRs).
+except without the `authorAssociation`, `comments`, or `files` fields (which
+are only enriched for product PRs).
 
 ## Step 3: Process the batch PRs
 
@@ -533,9 +547,11 @@ Read `/tmp/gh-aw/pr-data/batch-prs.json`. This is a JSON array of up to ${BATCH_
 unprocessed PRs, sorted by `mergedAt` ascending (oldest first). Each entry contains:
 `number`, `title`, `body`, `author` (object with `login` and `is_bot`), `mergedAt`,
 `labels` (array of objects with `name`), `additions`, `deletions`, `changedFiles`,
-and `files` (array of objects with `path`, `additions`, `deletions`, `changeType`).
+`files` (array of objects with `path`, `additions`, `deletions`, `changeType`),
+and `comments` (array of objects with `author`, `body`, `createdAt`).
 The batch is also enriched with `authorAssociation` (fetched via REST API in the
-pre-computation step).
+pre-computation step). The `files`, `comments`, and `authorAssociation` fields
+are all fetched per-PR during enrichment, not from `gh pr list`.
 
 1. **Exclude bot-authored PRs** — remove any PR whose `author.is_bot` is `true`,
    **except** these cases which should be processed normally:

--- a/.github/workflows/milestone-changelog.md
+++ b/.github/workflows/milestone-changelog.md
@@ -183,11 +183,15 @@ jobs:
               # This endpoint only requires metadata-read scope, unlike the
               # bulk collaborators list which requires push/admin access.
               AUTHOR=$(jq -r --argjson n "$NUM" '.[] | select(.number == $n) | .author.login' "$DATA_DIR/batch-prs.json")
-              PERM=$(gh api "repos/$REPO/collaborators/$AUTHOR/permission" --jq '.permission' 2>/dev/null) || PERM=""
-              case "$PERM" in
-                write|maintain|admin) ASSOC="MEMBER" ;;
-                *) ASSOC="CONTRIBUTOR" ;;
-              esac
+              if [ -z "$AUTHOR" ] || [ "$AUTHOR" = "null" ]; then
+                ASSOC="UNKNOWN"
+              else
+                PERM=$(gh api "repos/$REPO/collaborators/$AUTHOR/permission" --jq '.permission' 2>/dev/null) || PERM=""
+                case "$PERM" in
+                  write|maintain|admin) ASSOC="MEMBER" ;;
+                  *) ASSOC="CONTRIBUTOR" ;;
+                esac
+              fi
               echo "$VIEW" | jq --arg n "$NUM" --arg a "$ASSOC" '{($n): {
                 authorAssociation: $a,
                 comments: [(.comments // [])[] | {author: .author.login, body: .body, createdAt: .createdAt}],
@@ -556,9 +560,10 @@ full schema of each entry.
      targeting a release branch.
    Record each excluded bot PR as an individual tracker file in `prs/` with
    `status: "excluded"` in Step 6b so they are not re-processed on future runs.
-2. **Exclude PRs already shipped via backport** — for each batch PR whose
-   `mergedAt` is **before** `${MILESTONE_START}` (i.e., the PR was merged in
-   the previous milestone window and carried over), check the PR's `body` and
+2. **Exclude PRs already shipped via backport** — if `${PREVIOUS_MILESTONE}`
+   is empty or not set, skip this check entirely. Otherwise, for each batch PR
+   whose `mergedAt` is **before** `${MILESTONE_START}` (i.e., the PR was merged
+   in the previous milestone window and carried over), check the PR's `body` and
    `comments` (both available in the batch data) for evidence that a backport
    to the previous milestone's release branch was triggered. Look for:
    - A `/backport to release/${PREVIOUS_MILESTONE}` command in comments.

--- a/.github/workflows/milestone-changelog.md
+++ b/.github/workflows/milestone-changelog.md
@@ -214,7 +214,7 @@ jobs:
           MILESTONE_START="${{ env.MILESTONE_START }}"
           gh pr list --repo "$DOCS_REPO" --state merged --limit 5000 \
             --search "merged:>=${MILESTONE_START}" \
-            --json number,title,body,author,mergedAt,labels,additions,deletions,changedFiles,files \
+            --json number,title,body,author,mergedBy,mergedAt,labels,additions,deletions,changedFiles,files \
             | jq 'sort_by(.mergedAt)' \
             > "$DATA_DIR/all-docs-prs.json"
 
@@ -540,7 +540,7 @@ with `jq` to see their exact shape.
 | File | Contents |
 |------|----------|
 | `all-milestone-prs.json` | All merged PRs in the `${MILESTONE}` milestone, sorted by `mergedAt` ascending |
-| `batch-prs.json` | Oldest ${BATCH_SIZE} unprocessed product PRs, enriched with `authorAssociation`, `mergedBy`, `files`, and `comments` (not available from `gh pr list`) |
+| `batch-prs.json` | Oldest ${BATCH_SIZE} unprocessed product PRs, enriched with `authorAssociation`, `files`, and `comments` (not available from `gh pr list`) |
 | `all-docs-prs.json` | All merged PRs in `${DOCS_REPO}` since `${MILESTONE_START}`, sorted by `mergedAt` ascending |
 | `batch-docs-prs.json` | Oldest ${BATCH_SIZE} unprocessed docs PRs (same base fields as product PRs plus `files`, but **without** `authorAssociation` or `comments`) |
 
@@ -579,9 +579,9 @@ full schema of each entry.
    processing it, the backlog will be fully caught up.
 
 For each remaining (non-bot) PR, collect all data from the batch: number, title,
-author, `mergedBy`, `authorAssociation`, body, labels, changed file paths (`files`
-array), and total changed lines (additions + deletions). No additional API calls
-are needed — the batch data contains everything required.
+author, `authorAssociation`, body, labels, changed file paths (`files` array), and
+total changed lines (additions + deletions). No additional API calls are needed —
+the batch data contains everything required.
 
 ### 3a. Processing backport PRs
 
@@ -754,8 +754,8 @@ A change can have zero or more flags. When present, show each flag on its own
 indented line below the Changes line:
 
 ```
-  Changes: [#1234](https://github.com/${REPO}/pull/1234)  
   Owner: [@jamesnk](https://github.com/jamesnk)  
+  Changes: [#1234](https://github.com/${REPO}/pull/1234)  
   ⚠️ **Breaking change**  
   📝 **Documentation required**  
   🌍 **Community contribution** by [@username](https://github.com/username)  
@@ -774,7 +774,7 @@ non-empty after Step 5f), add a `Docs:` line linking to the docs PRs:
   Docs: [${DOCS_REPO}#456](https://github.com/${DOCS_REPO}/pull/456)  
 ```
 When multiple docs PRs are linked, separate them with commas. The line order
-within each entry is: `Changes:`, `Owner:`, `Docs:` (if any), then flag lines.
+within each entry is: `Owner:`, `Changes:`, `Docs:` (if any), then flag lines.
 Keep the `📝 **Documentation required**` flag line as well.
 
 ### 5c. Write name and description
@@ -926,7 +926,7 @@ Field definitions:
 - **firstMergedAt**: ISO 8601 UTC timestamp of the earliest PR's merge date
 - **lastMergedAt**: ISO 8601 UTC timestamp of the most recent PR's merge date
 - **name**: Short, user-friendly name for the change
-- **owner**: GitHub username (without `@`) of the team member accountable for this change (see Step 5b Owner section)
+- **owner**: GitHub username (without `@`) of the team member accountable for this change
 - **prs**: Array of PR numbers associated with this entry
 
 After writing each file, **normalize formatting** by running:
@@ -1105,7 +1105,7 @@ each flag line) must end with **two trailing spaces** (`  `) to produce a markdo
 line break. This includes the last line of each entry, even when there are no flags.
 
 When a changelog entry has a non-empty `docsPrs` array, add a **Docs:** line after
-the `Owner:` line. Each docs PR is linked using the format
+the `Changes:` line. Each docs PR is linked using the format
 `[${DOCS_REPO}#456](https://github.com/${DOCS_REPO}/pull/456)`. Separate multiple
 docs PRs with commas. The `📝 **Documentation required**` flag line is kept
 regardless of whether docs PRs are linked.
@@ -1135,15 +1135,15 @@ Use this exact format:
 
 1. **🧭 Feature name**  
   Brief user-facing description  
-  Changes: [#1234](https://github.com/${REPO}/pull/1234), [#1235](https://github.com/${REPO}/pull/1235)  
   Owner: [@jamesnk](https://github.com/jamesnk)  
+  Changes: [#1234](https://github.com/${REPO}/pull/1234), [#1235](https://github.com/${REPO}/pull/1235)  
   ⚠️ **Breaking change**  
   📝 **Documentation required**  
 
 1. **🚀 Another feature**  
   What this means for users  
-  Changes: [#1236](https://github.com/${REPO}/pull/1236)  
   Owner: [@davidfowl](https://github.com/davidfowl)  
+  Changes: [#1236](https://github.com/${REPO}/pull/1236)  
   Docs: [${DOCS_REPO}#456](https://github.com/${DOCS_REPO}/pull/456)  
   📝 **Documentation required**  
 
@@ -1151,8 +1151,8 @@ Use this exact format:
 
 1. **⚡ Performance boost**  
   Faster startup for container resources  
-  Changes: [#1238](https://github.com/${REPO}/pull/1238)  
   Owner: [@eerhardt](https://github.com/eerhardt)  
+  Changes: [#1238](https://github.com/${REPO}/pull/1238)  
 
 ## 💻 CLI
 
@@ -1162,15 +1162,15 @@ Use this exact format:
 
 1. **🆕 New CLI command**  
   Added a new command for scaffolding resources  
-  Changes: [#1240](https://github.com/${REPO}/pull/1240)  
   Owner: [@jamesnk](https://github.com/jamesnk)  
+  Changes: [#1240](https://github.com/${REPO}/pull/1240)  
 
 #### Bug fixes
 
 1. **🐛 Fix crash on init**  
   Resolved a crash when running init in an empty directory  
-  Changes: [#1239](https://github.com/${REPO}/pull/1239)  
   Owner: [@maddymontaquila](https://github.com/maddymontaquila)  
+  Changes: [#1239](https://github.com/${REPO}/pull/1239)  
   ⚠️ **Breaking change**  
   🌍 **Community contribution** by [@contributor](https://github.com/contributor)  
 
@@ -1182,8 +1182,8 @@ Use this exact format:
 
 1. **🎨 Dashboard improvement**  
   Description of the change  
-  Changes: [#1237](https://github.com/${REPO}/pull/1237)  
   Owner: [@AdrianJSClique](https://github.com/AdrianJSClique)  
+  Changes: [#1237](https://github.com/${REPO}/pull/1237)  
 
 ---
 

--- a/.github/workflows/milestone-changelog.md
+++ b/.github/workflows/milestone-changelog.md
@@ -42,6 +42,7 @@ env:
   MILESTONE_START: "2026-05-08"
   MILESTONE: "13.4"
   PREVIOUS_MILESTONE: "13.3"
+  RELEASE_NOTES_URL: "https://aspire.dev/whats-new/upgrade-aspire/"
   BATCH_SIZE: "20"
 
 on:
@@ -451,8 +452,8 @@ Generate and maintain a changelog for the **${PRODUCT} ${MILESTONE} milestone** 
 Each run appends newly merged changes to the existing content while preserving
 previous entries. A companion feedback issue collects editorial comments.
 
-> **Note:** `${PRODUCT}`, `${REPO}`, `${DOCS_REPO}`, `${MILESTONE_START}`, `${MILESTONE}`, `${PREVIOUS_MILESTONE}`, and `${BATCH_SIZE}` refer to values set in the workflow's
-> `env` block (currently **`Aspire`**, **`microsoft/aspire`**, **`microsoft/aspire.dev`**, **`2026-05-08`**, **`13.4`**, **`13.3`**, and **`20`**). All file names,
+> **Note:** `${PRODUCT}`, `${REPO}`, `${DOCS_REPO}`, `${MILESTONE_START}`, `${MILESTONE}`, `${PREVIOUS_MILESTONE}`, `${RELEASE_NOTES_URL}`, and `${BATCH_SIZE}` refer to values set in the workflow's
+> `env` block (currently **`Aspire`**, **`microsoft/aspire`**, **`microsoft/aspire.dev`**, **`2026-05-08`**, **`13.4`**, **`13.3`**, **`https://aspire.dev/whats-new/upgrade-aspire/`**, and **`20`**). All file names,
 > titles, and references below derive from those values.
 
 ## Important: available tools
@@ -492,6 +493,7 @@ use one of these patterns:
 | Docs batch file | `/tmp/gh-aw/pr-data/batch-docs-prs.json` (unprocessed docs PRs) |
 | Docs PR tracker directory | `prs-docs/` (under memory directories; one JSON file per docs PR) |
 | Previous milestone | `${PREVIOUS_MILESTONE}` (optional; used to identify the release branch for backport detection) |
+| Release notes URL | `${RELEASE_NOTES_URL}` (official release notes page) |
 
 ## Step 1: Load existing changelog and feedback
 
@@ -1096,6 +1098,14 @@ entry's individual emoji, `<Name>` is the changelog entry name, and
 (e.g., `-apphost`, `-cli`, `-dashboard`). The `#` before the slug is mandatory
 markdown anchor syntax — always write `(#-apphost)`, never `(-apphost)`.
 
+After the What's New list, add a blockquote disclaimer:
+
+```markdown
+> ℹ️ This changelog is automatically generated from merged pull requests and may
+> contain inaccuracies. For official release notes, see
+> [${RELEASE_NOTES_URL}](${RELEASE_NOTES_URL}).
+```
+
 Under each area heading, add a one-line **summary** counting the entries per change
 type, e.g. `2 new features, 1 improvement` or `3 bug fixes`. Use singular form
 for counts of 1 (`1 new feature`, `1 bug fix`, `1 improvement`).
@@ -1126,6 +1136,10 @@ Use this exact format:
 - [2026-04-22 22:48 — 🧭 Feature name](#-apphost)
 - [2026-04-21 07:30 — 🆕 New CLI command](#-cli)
 - [2026-04-20 23:05 — 🚀 Another feature](#-apphost)
+
+> ℹ️ This changelog is automatically generated from merged pull requests and may
+> contain inaccuracies. For official release notes, see
+> [${RELEASE_NOTES_URL}](${RELEASE_NOTES_URL}).
 
 ## 🏠 AppHost
 

--- a/.github/workflows/milestone-changelog.md
+++ b/.github/workflows/milestone-changelog.md
@@ -186,17 +186,28 @@ jobs:
             echo '[]' > "$DATA_DIR/backport-prs.json"
           fi
 
-          # 2a. Enrich batch PRs with author_association, comments, and files.
-          #     Two API calls per PR:
-          #       1. gh pr view --json files,comments  (files + comments in one call)
-          #       2. gh api .../pulls/$NUM              (author_association, not in gh pr view)
+          # 2a. Enrich batch PRs with comments, files, and authorAssociation.
+          #     The per-PR author_association from the REST API is unreliable
+          #     with GITHUB_TOKEN: org members show as CONTRIBUTOR because the
+          #     token lacks org-level read scope. Instead, we check each author
+          #     via the per-user collaborator/permission endpoint (only needs
+          #     metadata-read scope). Authors with write/maintain/admin are
+          #     MEMBER; others are CONTRIBUTOR.
           if [ "$BATCH_COUNT" -gt 0 ]; then
-            echo "Enriching batch PRs with author_association, comments, and files..."
+            echo "Enriching batch PRs with authorAssociation, comments, and files..."
             : > "$DATA_DIR/enrichment.jsonl"
             for NUM in $(jq -r '.[].number' "$DATA_DIR/batch-prs.json"); do
               VIEW=$(gh pr view "$NUM" --repo "$REPO" --json files,comments 2>/dev/null) \
                 || VIEW='{"files":[],"comments":[]}'
-              ASSOC=$(gh api "repos/$REPO/pulls/$NUM" --jq '.author_association' 2>/dev/null || echo "UNKNOWN")
+              # Determine authorAssociation via per-user permission endpoint.
+              # This endpoint only requires metadata-read scope, unlike the
+              # bulk collaborators list which requires push/admin access.
+              AUTHOR=$(jq -r --argjson n "$NUM" '.[] | select(.number == $n) | .author.login' "$DATA_DIR/batch-prs.json")
+              PERM=$(gh api "repos/$REPO/collaborators/$AUTHOR/permission" --jq '.permission' 2>/dev/null) || PERM=""
+              case "$PERM" in
+                write|maintain|admin) ASSOC="MEMBER" ;;
+                *) ASSOC="CONTRIBUTOR" ;;
+              esac
               echo "$VIEW" | jq --arg n "$NUM" --arg a "$ASSOC" '{($n): {
                 authorAssociation: $a,
                 comments: [(.comments // [])[] | {author: .author.login, body: .body, createdAt: .createdAt}],
@@ -211,7 +222,7 @@ jobs:
                 )' > "$DATA_DIR/batch-prs-tmp.json" \
               && mv "$DATA_DIR/batch-prs-tmp.json" "$DATA_DIR/batch-prs.json"
             rm -f "$DATA_DIR/enrichment.jsonl"
-            echo "Enriched $BATCH_COUNT batch PRs with author_association, comments, and files"
+            echo "Enriched $BATCH_COUNT batch PRs with authorAssociation, comments, and files"
           fi
 
           # 2b. Fetch docs PRs from DOCS_REPO merged after milestone start date
@@ -609,13 +620,16 @@ or partially filled. To process them:
 4. **Use the backport PR's number** (not the original) in the `Changes:` line
    and in `prs` arrays, since the backport is the PR that was merged into the
    milestone.
-5. **Use the original PR author's `author_association`** for the community
-   contribution flag (Step 5b), since the backport bot is not a meaningful author.
-   Set the `author` field in the PR tracker to the original PR's author, not the
-   bot. When evaluating Step 5b's "Community contribution" flag for a backport PR,
-   use the **original author's** `author_association` and treat `author.is_bot` as
-   `false` (since the original author — not the backport bot — is the meaningful
-   contributor).
+5. **Use the original PR author** for the community contribution flag
+   (Step 5b), since the backport bot is not a meaningful author. Set the
+   `author` field in the PR tracker to the original PR's author, not the bot.
+   To determine whether the original author is a team member, query:
+   ```bash
+   gh api "repos/${REPO}/collaborators/<AUTHOR>/permission" --jq '.permission'
+   ```
+   If the result is `write`, `maintain`, or `admin`, they are `MEMBER`;
+   otherwise `CONTRIBUTOR`. Treat `author.is_bot` as `false` (since the
+   original author — not the backport bot — is the meaningful contributor).
 6. **Set `backport: true`** in the change file for this entry (see Step 6a schema).
    If the backport PR is grouped with an existing entry that was not a backport,
    keep `backport: false` (the entry is not purely backport-derived).
@@ -721,15 +735,16 @@ Then determine whether either of these optional flags applies:
 
 The `authorAssociation` field is pre-populated in the batch data by the fetch-data
 job. Use it directly — no additional API calls are needed. For **backport PRs**,
-the original PR's `author_association` is not in the batch; fetch it via:
+the original PR's author is not in the batch; query:
 ```bash
-gh api "repos/${REPO}/pulls/<ORIGINAL_NUMBER>" --jq '.author_association'
+gh api "repos/${REPO}/collaborators/<AUTHOR>/permission" --jq '.permission'
 ```
+If the result is `write`, `maintain`, or `admin`, they are `MEMBER`; otherwise
+`CONTRIBUTOR`.
 
 > **Never infer community-contributor status from fork origin, username, or any
-> other heuristic.** Only the `author_association` / `authorAssociation` field
-> from the GitHub API is authoritative. Team members frequently submit PRs from
-> personal forks.
+> other heuristic.** Only the collaborator list and `authorAssociation` field are
+> authoritative. Team members frequently submit PRs from personal forks.
 
 A change can have zero or more flags. When present, show each flag on its own
 indented line below the Changes line:


### PR DESCRIPTION
## Description

Improves the `milestone-changelog` gh-aw workflow with backport filtering, docs PR enrichment, and cleanup:

- **Add `files` to docs `gh pr list`** — Step 5f needs changed file paths to match docs PRs to changelog entries. Previously `files` was missing from the docs query, causing the agent to fall through to diff reading on every docs PR. Since `gh pr list` supports `files` natively, this adds it with zero extra API calls.
- **Combine backport extraction and date filtering** — Moved backport entry extraction to after the batch is computed so `backport == true` and `firstMergedAt >= oldest batch date` happen in a single `jq` pass. This eliminates the intermediate file, the second `jq` pass, and the temp-file-then-mv pattern. The `$MEMORY_TMP` clone directory lifetime is extended slightly to support reading directly from it.
- **Fix `jq -s` glob expansion** — Pipes change files through `cat` before `jq -s` to avoid shell argument length limits when the previous milestone has many change files.
- **Simplify Step 2** — Replaced the verbose field-by-field schema table with a concise file-level table. The agent can inspect JSON directly with `jq`.
- **Fix Step 5f field claims** — Updated to accurately state that docs PRs have `files` but lack `authorAssociation` and `comments`.
- **Remove Step 3 schema duplication** — Now references Step 2 instead of repeating the full schema.

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [x] No
- Did you add public API?
  - [ ] Yes
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
  - [x] No
