### PR TITLE
Cap docs PR date range to batch cutoff to prevent premature exclusion

### DIFF
--- a/.github/workflows/milestone-changelog.lock.yml
+++ b/.github/workflows/milestone-changelog.lock.yml
@@ -1,4 +1,4 @@
-# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"286e54423f0982c17c81f002409d4fc26effa10df1da8c4f755f974f556b1771","compiler_version":"v0.72.0","strict":true,"agent_id":"copilot"}
+# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"68a1d86961e5995ca058a39d0cba9b4bf742775330ca302fcb962afbff47536a","compiler_version":"v0.72.0","strict":true,"agent_id":"copilot"}
 # gh-aw-manifest: {"version":1,"secrets":["COPILOT_GITHUB_TOKEN","GH_AW_GITHUB_MCP_SERVER_TOKEN","GH_AW_GITHUB_TOKEN","GITHUB_TOKEN"],"actions":[{"repo":"actions/checkout","sha":"de0fac2e4500dabe0009e67214ff5f5447ce83dd","version":"v6.0.2"},{"repo":"actions/download-artifact","sha":"3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c","version":"v8.0.1"},{"repo":"actions/download-artifact","sha":"d3f86a106a0bac45b974a628896c90dbdf5c8093","version":"v4"},{"repo":"actions/github-script","sha":"3a2844b7e9c422d3c10d287c895573f7108da1b3","version":"v9.0.0"},{"repo":"actions/setup-node","sha":"48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e","version":"v6.4.0"},{"repo":"actions/upload-artifact","sha":"043fb46d1a93c77aae656e7c1c64a875d1fc6a0a","version":"v7.0.1"},{"repo":"actions/upload-artifact","sha":"ea165f8d65b6e75b540449e92b4886f43607fa02","version":"v4"},{"repo":"github/gh-aw-actions/setup","sha":"ff0525b685481744f490a0d362753d8001e4b39d","version":"v0.72.0"}],"containers":[{"image":"ghcr.io/github/gh-aw-firewall/agent:0.25.41"},{"image":"ghcr.io/github/gh-aw-firewall/api-proxy:0.25.41"},{"image":"ghcr.io/github/gh-aw-firewall/squid:0.25.41"},{"image":"ghcr.io/github/gh-aw-mcpg:v0.3.6","digest":"sha256:2bb8eef86006a4c5963c55616a9c51c32f27bfdecb023b8aa6f91f6718d9171c","pinned_image":"ghcr.io/github/gh-aw-mcpg:v0.3.6@sha256:2bb8eef86006a4c5963c55616a9c51c32f27bfdecb023b8aa6f91f6718d9171c"},{"image":"ghcr.io/github/github-mcp-server:v1.0.3","digest":"sha256:2ac27ef03461ef2b877031b838a7d1fd7f12b12d4ace7796d8cad91446d55959","pinned_image":"ghcr.io/github/github-mcp-server:v1.0.3@sha256:2ac27ef03461ef2b877031b838a7d1fd7f12b12d4ace7796d8cad91446d55959"},{"image":"node:lts-alpine","digest":"sha256:d1b3b4da11eefd5941e7f0b9cf17783fc99d9c6fc34884a665f40a06dbdfc94f","pinned_image":"node:lts-alpine@sha256:d1b3b4da11eefd5941e7f0b9cf17783fc99d9c6fc34884a665f40a06dbdfc94f"}]}
 #    ___                   _   _      
 #   / _ \                 | | (_)     
@@ -207,20 +207,20 @@ jobs:
         run: |
           bash "${RUNNER_TEMP}/gh-aw/actions/create_prompt_first.sh"
           {
-          cat << 'GH_AW_PROMPT_24f2e632b0fdf561_EOF'
+          cat << 'GH_AW_PROMPT_c3827fe844ae66d5_EOF'
           <system>
-          GH_AW_PROMPT_24f2e632b0fdf561_EOF
+          GH_AW_PROMPT_c3827fe844ae66d5_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/xpia.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/temp_folder_prompt.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/markdown.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/safe_outputs_prompt.md"
-          cat << 'GH_AW_PROMPT_24f2e632b0fdf561_EOF'
+          cat << 'GH_AW_PROMPT_c3827fe844ae66d5_EOF'
           <safe-output-tools>
           Tools: missing_tool, missing_data, noop, publish
           </safe-output-tools>
-          GH_AW_PROMPT_24f2e632b0fdf561_EOF
+          GH_AW_PROMPT_c3827fe844ae66d5_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/mcp_cli_tools_prompt.md"
-          cat << 'GH_AW_PROMPT_24f2e632b0fdf561_EOF'
+          cat << 'GH_AW_PROMPT_c3827fe844ae66d5_EOF'
           <github-context>
           The following GitHub context information is available for this workflow:
           {{#if __GH_AW_GITHUB_ACTOR__ }}
@@ -249,12 +249,12 @@ jobs:
           {{/if}}
           </github-context>
           
-          GH_AW_PROMPT_24f2e632b0fdf561_EOF
+          GH_AW_PROMPT_c3827fe844ae66d5_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/github_mcp_tools_with_safeoutputs_prompt.md"
-          cat << 'GH_AW_PROMPT_24f2e632b0fdf561_EOF'
+          cat << 'GH_AW_PROMPT_c3827fe844ae66d5_EOF'
           </system>
           {{#runtime-import .github/workflows/milestone-changelog.md}}
-          GH_AW_PROMPT_24f2e632b0fdf561_EOF
+          GH_AW_PROMPT_c3827fe844ae66d5_EOF
           } > "$GH_AW_PROMPT"
       - name: Interpolate variables and render templates
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
@@ -458,9 +458,9 @@ jobs:
           mkdir -p "${RUNNER_TEMP}/gh-aw/safeoutputs"
           mkdir -p /tmp/gh-aw/safeoutputs
           mkdir -p /tmp/gh-aw/mcp-logs/safeoutputs
-          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << 'GH_AW_SAFE_OUTPUTS_CONFIG_3f229eaaf58f4f7d_EOF'
+          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << 'GH_AW_SAFE_OUTPUTS_CONFIG_755f2c48793d69e7_EOF'
           {"create_report_incomplete_issue":{},"missing_data":{},"missing_tool":{},"noop":{"max":1,"report-as-issue":"true"},"publish":{"description":"Publish the wiki page, push state to the memory branch, and ensure the feedback issue exists","output":"Wiki page published and memory branch updated!"},"report_incomplete":{}}
-          GH_AW_SAFE_OUTPUTS_CONFIG_3f229eaaf58f4f7d_EOF
+          GH_AW_SAFE_OUTPUTS_CONFIG_755f2c48793d69e7_EOF
       - name: Generate Safe Outputs Tools
         env:
           GH_AW_TOOLS_META_JSON: |
@@ -633,7 +633,7 @@ jobs:
           
           mkdir -p /home/runner/.copilot
           GH_AW_NODE=$(which node 2>/dev/null || command -v node 2>/dev/null || echo node)
-          cat << GH_AW_MCP_CONFIG_14c9051a7fabec3c_EOF | "$GH_AW_NODE" "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.cjs"
+          cat << GH_AW_MCP_CONFIG_e863f97f403870c9_EOF | "$GH_AW_NODE" "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.cjs"
           {
             "mcpServers": {
               "github": {
@@ -677,7 +677,7 @@ jobs:
               "payloadDir": "${MCP_GATEWAY_PAYLOAD_DIR}"
             }
           }
-          GH_AW_MCP_CONFIG_14c9051a7fabec3c_EOF
+          GH_AW_MCP_CONFIG_e863f97f403870c9_EOF
       - name: Mount MCP servers as CLIs
         id: mount-mcp-clis
         continue-on-error: true
@@ -1425,11 +1425,21 @@ jobs:
             echo "Enriched $BATCH_COUNT batch PRs with authorAssociation, comments, and files"
           fi
 
-          # 2b. Fetch docs PRs from DOCS_REPO merged after milestone start date
+          # 2b. Fetch docs PRs from DOCS_REPO merged after milestone start date.
+          #     Cap the date range to the most recently merged PR in the current
+          #     batch so that docs PRs are only evaluated once their corresponding
+          #     product PRs have been processed. When the batch is smaller than
+          #     BATCH_SIZE, all product PRs are caught up and no cap is needed.
           DOCS_REPO="${{ env.DOCS_REPO }}"
           MILESTONE_START="${{ env.MILESTONE_START }}"
+          DOCS_MERGED_RANGE="merged:>=${MILESTONE_START}"
+          if [ "$BATCH_COUNT" -ge "$BATCH_SIZE" ]; then
+            BATCH_CUTOFF=$(jq -r '.[-1].mergedAt' "$DATA_DIR/batch-prs.json")
+            DOCS_MERGED_RANGE="merged:${MILESTONE_START}..${BATCH_CUTOFF}"
+            echo "Capping docs PRs to merged on or before $BATCH_CUTOFF (batch is full)"
+          fi
           gh pr list --repo "$DOCS_REPO" --state merged --limit 5000 \
-            --search "merged:>=${MILESTONE_START}" \
+            --search "$DOCS_MERGED_RANGE" \
             --json number,title,body,author,mergedBy,mergedAt,labels,additions,deletions,changedFiles,files \
             | jq 'sort_by(.mergedAt)' \
             > "$DATA_DIR/all-docs-prs.json"

--- a/.github/workflows/milestone-changelog.md
+++ b/.github/workflows/milestone-changelog.md
@@ -210,11 +210,21 @@ jobs:
             echo "Enriched $BATCH_COUNT batch PRs with authorAssociation, comments, and files"
           fi
 
-          # 2b. Fetch docs PRs from DOCS_REPO merged after milestone start date
+          # 2b. Fetch docs PRs from DOCS_REPO merged after milestone start date.
+          #     Cap the date range to the most recently merged PR in the current
+          #     batch so that docs PRs are only evaluated once their corresponding
+          #     product PRs have been processed. When the batch is smaller than
+          #     BATCH_SIZE, all product PRs are caught up and no cap is needed.
           DOCS_REPO="${{ env.DOCS_REPO }}"
           MILESTONE_START="${{ env.MILESTONE_START }}"
+          DOCS_MERGED_RANGE="merged:>=${MILESTONE_START}"
+          if [ "$BATCH_COUNT" -ge "$BATCH_SIZE" ]; then
+            BATCH_CUTOFF=$(jq -r '.[-1].mergedAt' "$DATA_DIR/batch-prs.json")
+            DOCS_MERGED_RANGE="merged:${MILESTONE_START}..${BATCH_CUTOFF}"
+            echo "Capping docs PRs to merged on or before $BATCH_CUTOFF (batch is full)"
+          fi
           gh pr list --repo "$DOCS_REPO" --state merged --limit 5000 \
-            --search "merged:>=${MILESTONE_START}" \
+            --search "$DOCS_MERGED_RANGE" \
             --json number,title,body,author,mergedBy,mergedAt,labels,additions,deletions,changedFiles,files \
             | jq 'sort_by(.mergedAt)' \
             > "$DATA_DIR/all-docs-prs.json"


### PR DESCRIPTION
When the product PR batch is full (BATCH_SIZE), docs PRs merged after the last product PR in the batch haven't had their matching changelog entries created yet. This causes them to be marked as excluded with 'No matching changelog entry found' and they're never re-evaluated.

Fix: cap the docs PR date range to the most recently merged product PR in the current batch. When the batch is smaller than BATCH_SIZE (all product PRs caught up), no cap is applied.