### PR TITLE
Add --search option to aspire logs and aspire otel commands

### DIFF
--- a/.agents/skills/aspire/references/agent-workflows.md
+++ b/.agents/skills/aspire/references/agent-workflows.md
@@ -28,9 +28,9 @@ Keep these points in mind:
 Inspect the live app before editing code:
 
 1. `aspire describe` to check resource state.
-2. `aspire otel logs <resource>` to inspect structured logs.
-3. `aspire logs <resource>` to inspect console output.
-4. `aspire otel traces <resource>` to follow cross-service activity.
+2. `aspire otel logs <resource>` to inspect structured logs. Add `--search "<term>"` to filter by keyword.
+3. `aspire logs <resource>` to inspect console output. Add `--search "<term>"` to filter by keyword.
+4. `aspire otel traces <resource>` to follow cross-service activity. Add `--search "<term>"` to narrow results.
 5. `aspire export` when you need a zipped telemetry snapshot for deeper analysis or handoff.
 
 ## Scenario: I Need To Add An Integration, Understand An API, Or Add A Custom Command Safely

--- a/.agents/skills/aspire/references/monitoring.md
+++ b/.agents/skills/aspire/references/monitoring.md
@@ -28,7 +28,10 @@ aspire otel logs [resource] --format Json
 aspire otel traces [resource] --format Json
 aspire otel spans [resource] --format Json
 aspire otel logs --trace-id <id> --format Json
+aspire otel logs [resource] --search "connection timeout"
+aspire otel spans [resource] --search "/api/products"
 aspire logs [resource]
+aspire logs [resource] --search "error"
 ```
 
 Keep these points in mind:
@@ -36,8 +39,10 @@ Keep these points in mind:
 - Prefer structured telemetry before raw console logs when possible.
 - Use `aspire logs` as a secondary console-output view after checking structured telemetry.
 - Use the trace-filtered log command when you already have a trace id and want the related log slice.
+- Use `--search` to filter results by a case-insensitive text match across all fields (messages, attribute keys/values, trace/span IDs, resource names, severity, scope names). This is the fastest way to narrow output when you know what you're looking for.
 - Prefer `--format Json` when another tool or script needs to consume the result, such as a Playwright handoff or endpoint extraction.
 - `[resource]` is optional. Include it to filter results to a single resource; omit it to see all resources.
+- `--search` can be combined with other options like `--format Json`, `--trace-id`, `--limit`, and resource filtering.
 
 ## Scenario: I Need A Sharable Diagnostics Bundle
 

--- a/src/Aspire.Cli/Commands/LogsCommand.cs
+++ b/src/Aspire.Cli/Commands/LogsCommand.cs
@@ -309,6 +309,12 @@ internal sealed class LogsCommand : BaseCommand
                 LogsCommandStrings.GettingLogs,
                 async () => await CollectLogsAsync(connection, resourceWatcher, resourceName, cancellationToken).ConfigureAwait(false));
 
+            // Apply full-text search filter before tail so tail count reflects matching entries
+            if (!string.IsNullOrEmpty(search))
+            {
+                entries = entries.Where(e => MatchesSearch(e, search)).ToList();
+            }
+
             // Output last N lines
             var tailedEntries = entries.Count > tail.Value
                 ? entries.Skip(entries.Count - tail.Value)

--- a/src/Aspire.Cli/Commands/LogsCommand.cs
+++ b/src/Aspire.Cli/Commands/LogsCommand.cs
@@ -106,6 +106,10 @@ internal sealed class LogsCommand : BaseCommand
     {
         Description = LogsCommandStrings.IncludeHiddenOptionDescription
     };
+    private static readonly Option<string?> s_searchOption = new("--search")
+    {
+        Description = LogsCommandStrings.SearchOptionDescription
+    };
 
     private readonly ResourceColorMap _resourceColorMap;
 
@@ -135,6 +139,7 @@ internal sealed class LogsCommand : BaseCommand
         Options.Add(s_tailOption);
         Options.Add(s_timestampsOption);
         Options.Add(s_includeHiddenOption);
+        Options.Add(s_searchOption);
     }
 
     protected override async Task<int> ExecuteAsync(ParseResult parseResult, CancellationToken cancellationToken)
@@ -148,6 +153,7 @@ internal sealed class LogsCommand : BaseCommand
         var tail = parseResult.GetValue(s_tailOption);
         var timestamps = parseResult.GetValue(s_timestampsOption);
         var includeHidden = parseResult.GetValue(s_includeHiddenOption);
+        var search = parseResult.GetValue(s_searchOption);
 
         // Validate --tail value
         if (tail.HasValue && tail.Value < 1)
@@ -200,7 +206,7 @@ internal sealed class LogsCommand : BaseCommand
         {
             try
             {
-                return await ExecuteWatchAsync(connection, resourceWatcher, resourceName, format, tail, timestamps, cancellationToken);
+                return await ExecuteWatchAsync(connection, resourceWatcher, resourceName, format, tail, timestamps, search, cancellationToken);
             }
             catch (OperationCanceledException ex) when (ex.CancellationToken == cancellationToken || cancellationToken.IsCancellationRequested)
             {
@@ -224,7 +230,7 @@ internal sealed class LogsCommand : BaseCommand
         }
         else
         {
-            return await ExecuteGetAsync(connection, resourceWatcher, resourceName, format, tail, timestamps, cancellationToken);
+            return await ExecuteGetAsync(connection, resourceWatcher, resourceName, format, tail, timestamps, search, cancellationToken);
         }
     }
 
@@ -235,12 +241,19 @@ internal sealed class LogsCommand : BaseCommand
         OutputFormat format,
         int? tail,
         bool timestamps,
+        string? search,
         CancellationToken cancellationToken)
     {
         // Collect all logs, parsing into LogEntry with resolved resource names sorted by timestamp
         var entries = await _interactionService.ShowStatusAsync(
             LogsCommandStrings.GettingLogs,
             async () => await CollectLogsAsync(connection, resourceWatcher, resourceName, cancellationToken).ConfigureAwait(false));
+
+        // Apply full-text search filter on log content
+        if (!string.IsNullOrEmpty(search))
+        {
+            entries = entries.Where(e => MatchesSearch(e, search)).ToList();
+        }
 
         // Apply tail filter (tail.Value is guaranteed >= 1 by earlier validation)
         if (tail.HasValue && entries.Count > tail.Value)
@@ -284,6 +297,7 @@ internal sealed class LogsCommand : BaseCommand
         OutputFormat format,
         int? tail,
         bool timestamps,
+        string? search,
         CancellationToken cancellationToken)
     {
         var logParser = new LogParser(ConsoleColor.Black);
@@ -322,6 +336,13 @@ internal sealed class LogsCommand : BaseCommand
             }
 
             var entry = ParseLogLine(logLine, logParser, resourceWatcher.GetAllResources());
+
+            // Apply full-text search filter on streamed log content
+            if (!string.IsNullOrEmpty(search) && !MatchesSearch(entry, search))
+            {
+                continue;
+            }
+
             OutputLogLine(entry, format, timestamps);
         }
 
@@ -403,6 +424,14 @@ internal sealed class LogsCommand : BaseCommand
     private static string FormatTimestamp(DateTime timestamp)
     {
         return timestamp.ToString("yyyy-MM-ddTHH:mm:ss.fffK", CultureInfo.InvariantCulture);
+    }
+
+    private static bool MatchesSearch(LogEntry entry, string search)
+    {
+        var content = entry.RawContent ?? entry.Content ?? string.Empty;
+        var prefix = entry.ResourcePrefix ?? string.Empty;
+        return content.Contains(search, StringComparisons.FullTextSearch) ||
+               prefix.Contains(search, StringComparisons.FullTextSearch);
     }
 
     private static string ResolveResourceName(string resourceName, IEnumerable<ResourceSnapshot> snapshots)

--- a/src/Aspire.Cli/Commands/TelemetryCommandHelpers.cs
+++ b/src/Aspire.Cli/Commands/TelemetryCommandHelpers.cs
@@ -94,6 +94,14 @@ internal static class TelemetryCommandHelpers
     };
 
     /// <summary>
+    /// Full-text search option for filtering across all telemetry fields.
+    /// </summary>
+    internal static Option<string?> CreateSearchOption() => new("--search")
+    {
+        Description = TelemetryCommandStrings.SearchOptionDescription
+    };
+
+    /// <summary>
     /// Dashboard URL option for connecting directly to a standalone dashboard.
     /// </summary>
     internal static Option<string?> CreateDashboardUrlOption() => new("--dashboard-url")

--- a/src/Aspire.Cli/Commands/TelemetryLogsCommand.cs
+++ b/src/Aspire.Cli/Commands/TelemetryLogsCommand.cs
@@ -41,6 +41,7 @@ internal sealed class TelemetryLogsCommand : BaseCommand
     private static readonly Option<string?> s_traceIdOption = TelemetryCommandHelpers.CreateTraceIdOption("--trace-id");
     private static readonly Option<string?> s_dashboardUrlOption = TelemetryCommandHelpers.CreateDashboardUrlOption();
     private static readonly Option<string?> s_apiKeyOption = TelemetryCommandHelpers.CreateApiKeyOption();
+    private static readonly Option<string?> s_searchOption = TelemetryCommandHelpers.CreateSearchOption();
     // Logs-specific option
     private static readonly Option<string?> s_severityOption = new("--severity")
     {
@@ -79,6 +80,7 @@ internal sealed class TelemetryLogsCommand : BaseCommand
         Options.Add(s_dashboardUrlOption);
         Options.Add(s_apiKeyOption);
         Options.Add(s_severityOption);
+        Options.Add(s_searchOption);
     }
 
     protected override async Task<int> ExecuteAsync(ParseResult parseResult, CancellationToken cancellationToken)
@@ -94,6 +96,7 @@ internal sealed class TelemetryLogsCommand : BaseCommand
         var severity = parseResult.GetValue(s_severityOption);
         var dashboardUrl = parseResult.GetValue(s_dashboardUrlOption);
         var apiKey = parseResult.GetValue(s_apiKeyOption);
+        var search = parseResult.GetValue(s_searchOption);
 
         // Validate --limit value
         if (limit.HasValue && limit.Value < 1)
@@ -110,7 +113,7 @@ internal sealed class TelemetryLogsCommand : BaseCommand
             return dashboardApi.ExitCode;
         }
 
-        return await FetchLogsAsync(dashboardApi.BaseUrl!, dashboardApi.ApiToken!, resourceName, traceId, severity, limit, follow, format, dashboardOnly: dashboardUrl is not null, dashboardApi.DashboardUrl!, cancellationToken);
+        return await FetchLogsAsync(dashboardApi.BaseUrl!, dashboardApi.ApiToken!, resourceName, traceId, severity, limit, follow, format, dashboardOnly: dashboardUrl is not null, dashboardApi.DashboardUrl!, search, cancellationToken);
     }
 
     private async Task<int> FetchLogsAsync(
@@ -124,6 +127,7 @@ internal sealed class TelemetryLogsCommand : BaseCommand
         OutputFormat format,
         bool dashboardOnly,
         string dashboardUrl,
+        string? search,
         CancellationToken cancellationToken)
     {
         try
@@ -147,7 +151,7 @@ internal sealed class TelemetryLogsCommand : BaseCommand
             // Build URL with query parameters
             int? effectiveLimit = (limit.HasValue && !follow) ? limit.Value : null;
 
-            var url = DashboardUrls.TelemetryLogsApiUrl(baseUrl, resolvedResources, traceId: traceId, severity: severity, limit: effectiveLimit, follow: follow ? true : null);
+            var url = DashboardUrls.TelemetryLogsApiUrl(baseUrl, resolvedResources, traceId: traceId, severity: severity, limit: effectiveLimit, follow: follow ? true : null, search: search);
 
             if (follow)
             {

--- a/src/Aspire.Cli/Commands/TelemetrySpansCommand.cs
+++ b/src/Aspire.Cli/Commands/TelemetrySpansCommand.cs
@@ -41,6 +41,7 @@ internal sealed class TelemetrySpansCommand : BaseCommand
     private static readonly Option<bool?> s_hasErrorOption = TelemetryCommandHelpers.CreateHasErrorOption();
     private static readonly Option<string?> s_dashboardUrlOption = TelemetryCommandHelpers.CreateDashboardUrlOption();
     private static readonly Option<string?> s_apiKeyOption = TelemetryCommandHelpers.CreateApiKeyOption();
+    private static readonly Option<string?> s_searchOption = TelemetryCommandHelpers.CreateSearchOption();
 
     public TelemetrySpansCommand(
         IInteractionService interactionService,
@@ -72,6 +73,7 @@ internal sealed class TelemetrySpansCommand : BaseCommand
         Options.Add(s_hasErrorOption);
         Options.Add(s_dashboardUrlOption);
         Options.Add(s_apiKeyOption);
+        Options.Add(s_searchOption);
     }
 
     protected override async Task<int> ExecuteAsync(ParseResult parseResult, CancellationToken cancellationToken)
@@ -87,6 +89,7 @@ internal sealed class TelemetrySpansCommand : BaseCommand
         var hasError = parseResult.GetValue(s_hasErrorOption);
         var dashboardUrl = parseResult.GetValue(s_dashboardUrlOption);
         var apiKey = parseResult.GetValue(s_apiKeyOption);
+        var search = parseResult.GetValue(s_searchOption);
 
         // Validate --limit value
         if (limit.HasValue && limit.Value < 1)
@@ -103,7 +106,7 @@ internal sealed class TelemetrySpansCommand : BaseCommand
             return dashboardApi.ExitCode;
         }
 
-        return await FetchSpansAsync(dashboardApi.BaseUrl!, dashboardApi.ApiToken!, resourceName, traceId, hasError, limit, follow, format, dashboardOnly: dashboardUrl is not null, dashboardApi.DashboardUrl!, cancellationToken);
+        return await FetchSpansAsync(dashboardApi.BaseUrl!, dashboardApi.ApiToken!, resourceName, traceId, hasError, limit, follow, format, dashboardOnly: dashboardUrl is not null, dashboardApi.DashboardUrl!, search, cancellationToken);
     }
 
     private async Task<int> FetchSpansAsync(
@@ -117,6 +120,7 @@ internal sealed class TelemetrySpansCommand : BaseCommand
         OutputFormat format,
         bool dashboardOnly,
         string dashboardUrl,
+        string? search,
         CancellationToken cancellationToken)
     {
         try
@@ -140,7 +144,7 @@ internal sealed class TelemetrySpansCommand : BaseCommand
             // Build URL with query parameters
             int? effectiveLimit = (limit.HasValue && !follow) ? limit.Value : null;
 
-            var url = DashboardUrls.TelemetrySpansApiUrl(baseUrl, resolvedResources, traceId: traceId, hasError: hasError, limit: effectiveLimit, follow: follow ? true : null);
+            var url = DashboardUrls.TelemetrySpansApiUrl(baseUrl, resolvedResources, traceId: traceId, hasError: hasError, limit: effectiveLimit, follow: follow ? true : null, search: search);
 
             _logger.LogDebug("Fetching spans from {Url}", url);
 

--- a/src/Aspire.Cli/Commands/TelemetryTracesCommand.cs
+++ b/src/Aspire.Cli/Commands/TelemetryTracesCommand.cs
@@ -41,6 +41,7 @@ internal sealed class TelemetryTracesCommand : BaseCommand
     private static readonly Option<bool?> s_hasErrorOption = TelemetryCommandHelpers.CreateHasErrorOption();
     private static readonly Option<string?> s_dashboardUrlOption = TelemetryCommandHelpers.CreateDashboardUrlOption();
     private static readonly Option<string?> s_apiKeyOption = TelemetryCommandHelpers.CreateApiKeyOption();
+    private static readonly Option<string?> s_searchOption = TelemetryCommandHelpers.CreateSearchOption();
 
     public TelemetryTracesCommand(
         IInteractionService interactionService,
@@ -71,6 +72,7 @@ internal sealed class TelemetryTracesCommand : BaseCommand
         Options.Add(s_hasErrorOption);
         Options.Add(s_dashboardUrlOption);
         Options.Add(s_apiKeyOption);
+        Options.Add(s_searchOption);
     }
 
     protected override async Task<int> ExecuteAsync(ParseResult parseResult, CancellationToken cancellationToken)
@@ -85,6 +87,7 @@ internal sealed class TelemetryTracesCommand : BaseCommand
         var hasError = parseResult.GetValue(s_hasErrorOption);
         var dashboardUrl = parseResult.GetValue(s_dashboardUrlOption);
         var apiKey = parseResult.GetValue(s_apiKeyOption);
+        var search = parseResult.GetValue(s_searchOption);
 
         // Validate --limit value
         if (limit.HasValue && limit.Value < 1)
@@ -109,7 +112,7 @@ internal sealed class TelemetryTracesCommand : BaseCommand
             }
             else
             {
-                return await FetchTracesAsync(dashboardApi.BaseUrl!, dashboardApi.ApiToken!, resourceName, hasError, limit, format, dashboardApi.DashboardUrl!, cancellationToken);
+                return await FetchTracesAsync(dashboardApi.BaseUrl!, dashboardApi.ApiToken!, resourceName, hasError, limit, format, dashboardApi.DashboardUrl!, search, cancellationToken);
             }
         }
         catch (HttpRequestException ex)
@@ -187,6 +190,7 @@ internal sealed class TelemetryTracesCommand : BaseCommand
         int? limit,
         OutputFormat format,
         string dashboardUrl,
+        string? search,
         CancellationToken cancellationToken)
     {
         using var client = TelemetryCommandHelpers.CreateApiClient(_httpClientFactory, apiToken);
@@ -206,7 +210,7 @@ internal sealed class TelemetryTracesCommand : BaseCommand
         // Pre-resolve colors so assignment is deterministic regardless of data order
         TelemetryCommandHelpers.ResolveResourceColors(_resourceColorMap, allOtlpResources);
 
-        var url = DashboardUrls.TelemetryTracesApiUrl(baseUrl, resolvedResources, hasError: hasError, limit: limit);
+        var url = DashboardUrls.TelemetryTracesApiUrl(baseUrl, resolvedResources, hasError: hasError, limit: limit, search: search);
 
         _logger.LogDebug("Fetching traces from {Url}", url);
 

--- a/src/Aspire.Cli/Mcp/Tools/ListConsoleLogsTool.cs
+++ b/src/Aspire.Cli/Mcp/Tools/ListConsoleLogsTool.cs
@@ -29,6 +29,10 @@ internal sealed class ListConsoleLogsTool(IAuxiliaryBackchannelMonitor auxiliary
                 "resourceName": {
                   "type": "string",
                   "description": "The resource name."
+                },
+                "search": {
+                  "type": "string",
+                  "description": "Full-text search to filter log content."
                 }
               },
               "required": ["resourceName"]
@@ -52,6 +56,12 @@ internal sealed class ListConsoleLogsTool(IAuxiliaryBackchannelMonitor auxiliary
             throw new McpProtocolException("The resourceName parameter is required.", McpErrorCode.InvalidParams);
         }
 
+        string? search = null;
+        if (arguments is not null && arguments.TryGetValue("search", out var searchElement))
+        {
+            search = searchElement.GetString();
+        }
+
         var connection = await AppHostConnectionHelper.GetSelectedConnectionAsync(auxiliaryBackchannelMonitor, logger, cancellationToken).ConfigureAwait(false);
         if (connection is null)
         {
@@ -71,6 +81,16 @@ internal sealed class ListConsoleLogsTool(IAuxiliaryBackchannelMonitor auxiliary
             }
 
             var entries = logEntries.GetEntries().ToList();
+
+            // Apply full-text search filter on log content
+            if (!string.IsNullOrEmpty(search))
+            {
+                entries = entries.Where(e =>
+                    (e.Content is not null && e.Content.Contains(search, StringComparisons.FullTextSearch)) ||
+                    (e.RawContent is not null && e.RawContent.Contains(search, StringComparisons.FullTextSearch)))
+                    .ToList();
+            }
+
             var totalLogsCount = entries.Count == 0 ? 0 : entries.Last().LineNumber;
             var (trimmedItems, limitMessage) = SharedAIHelpers.GetLimitFromEndWithSummary(
                 entries,

--- a/src/Aspire.Cli/Mcp/Tools/ListConsoleLogsTool.cs
+++ b/src/Aspire.Cli/Mcp/Tools/ListConsoleLogsTool.cs
@@ -46,7 +46,8 @@ internal sealed class ListConsoleLogsTool(IAuxiliaryBackchannelMonitor auxiliary
 
         // Get the resource name from arguments
         string? resourceName = null;
-        if (arguments is not null && arguments.TryGetValue("resourceName", out var resourceNameElement))
+        if (arguments is not null && arguments.TryGetValue("resourceName", out var resourceNameElement) &&
+            resourceNameElement.ValueKind == JsonValueKind.String)
         {
             resourceName = resourceNameElement.GetString();
         }
@@ -57,7 +58,8 @@ internal sealed class ListConsoleLogsTool(IAuxiliaryBackchannelMonitor auxiliary
         }
 
         string? search = null;
-        if (arguments is not null && arguments.TryGetValue("search", out var searchElement))
+        if (arguments is not null && arguments.TryGetValue("search", out var searchElement) &&
+            searchElement.ValueKind == JsonValueKind.String)
         {
             search = searchElement.GetString();
         }
@@ -91,7 +93,12 @@ internal sealed class ListConsoleLogsTool(IAuxiliaryBackchannelMonitor auxiliary
                     .ToList();
             }
 
-            var totalLogsCount = entries.Count == 0 ? 0 : entries.Last().LineNumber;
+            // When search is applied, total reflects matching entries. Otherwise, use the
+            // last line number which represents the total lines collected by the LogEntries buffer.
+            var totalLogsCount = string.IsNullOrEmpty(search)
+                ? (entries.Count == 0 ? 0 : entries.Last().LineNumber)
+                : entries.Count;
+
             var (trimmedItems, limitMessage) = SharedAIHelpers.GetLimitFromEndWithSummary(
                 entries,
                 totalLogsCount,

--- a/src/Aspire.Cli/Mcp/Tools/ListStructuredLogsTool.cs
+++ b/src/Aspire.Cli/Mcp/Tools/ListStructuredLogsTool.cs
@@ -33,6 +33,10 @@ internal sealed class ListStructuredLogsTool(IDashboardInfoProvider dashboardInf
                 "resourceName": {
                   "type": "string",
                   "description": "The resource name. This limits logs returned to the specified resource. If no resource name is specified then structured logs for all resources are returned."
+                },
+                "search": {
+                  "type": "string",
+                  "description": "Full-text search to filter logs. Searches across log text, attribute values, names, source, IDs, and other fields."
                 }
               }
             }
@@ -50,6 +54,13 @@ internal sealed class ListStructuredLogsTool(IDashboardInfoProvider dashboardInf
             resourceNameElement.ValueKind == JsonValueKind.String)
         {
             resourceName = resourceNameElement.GetString();
+        }
+
+        string? search = null;
+        if (arguments?.TryGetValue("search", out var searchElement) == true &&
+            searchElement.ValueKind == JsonValueKind.String)
+        {
+            search = searchElement.GetString();
         }
 
         try
@@ -70,7 +81,7 @@ internal sealed class ListStructuredLogsTool(IDashboardInfoProvider dashboardInf
             }
 
             // Fetch all logs from the API. Limiting of returned telemetry to the MCP caller happens later.
-            var url = DashboardUrls.TelemetryLogsApiUrl(apiBaseUrl, resolvedResources, limit: TelemetryCommandHelpers.MaxTelemetryLimit);
+            var url = DashboardUrls.TelemetryLogsApiUrl(apiBaseUrl, resolvedResources, limit: TelemetryCommandHelpers.MaxTelemetryLimit, search: search);
 
             logger.LogDebug("Fetching structured logs from {Url}", url);
 

--- a/src/Aspire.Cli/Mcp/Tools/ListTraceStructuredLogsTool.cs
+++ b/src/Aspire.Cli/Mcp/Tools/ListTraceStructuredLogsTool.cs
@@ -33,6 +33,10 @@ internal sealed class ListTraceStructuredLogsTool(IDashboardInfoProvider dashboa
                 "traceId": {
                   "type": "string",
                   "description": "The trace id of the distributed trace."
+                },
+                "search": {
+                  "type": "string",
+                  "description": "Full-text search to filter logs. Searches across log text, attribute values, names, source, IDs, and other fields."
                 }
               },
               "required": ["traceId"]
@@ -62,6 +66,13 @@ internal sealed class ListTraceStructuredLogsTool(IDashboardInfoProvider dashboa
             };
         }
 
+        string? search = null;
+        if (arguments?.TryGetValue("search", out var searchElement) == true &&
+            searchElement.ValueKind == JsonValueKind.String)
+        {
+            search = searchElement.GetString();
+        }
+
         try
         {
             using var client = TelemetryCommandHelpers.CreateApiClient(httpClientFactory, apiToken);
@@ -70,7 +81,7 @@ internal sealed class ListTraceStructuredLogsTool(IDashboardInfoProvider dashboa
 
             // Build the logs API URL with traceId filter
             // Fetch all logs for the trace from the API. Limiting of returned telemetry to the MCP caller happens later.
-            var url = DashboardUrls.TelemetryLogsApiUrl(apiBaseUrl, traceId: traceId, limit: TelemetryCommandHelpers.MaxTelemetryLimit);
+            var url = DashboardUrls.TelemetryLogsApiUrl(apiBaseUrl, traceId: traceId, limit: TelemetryCommandHelpers.MaxTelemetryLimit, search: search);
 
             logger.LogDebug("Fetching structured logs from {Url}", url);
 

--- a/src/Aspire.Cli/Mcp/Tools/ListTracesTool.cs
+++ b/src/Aspire.Cli/Mcp/Tools/ListTracesTool.cs
@@ -33,6 +33,10 @@ internal sealed class ListTracesTool(IDashboardInfoProvider dashboardInfoProvide
                 "resourceName": {
                   "type": "string",
                   "description": "The resource name. This limits traces returned to the specified resource. If no resource name is specified then distributed traces for all resources are returned."
+                },
+                "search": {
+                  "type": "string",
+                  "description": "Full-text search to filter traces. Searches across span names, attribute values, IDs, and other fields."
                 }
               }
             }
@@ -50,6 +54,13 @@ internal sealed class ListTracesTool(IDashboardInfoProvider dashboardInfoProvide
             resourceNameElement.ValueKind == JsonValueKind.String)
         {
             resourceName = resourceNameElement.GetString();
+        }
+
+        string? search = null;
+        if (arguments?.TryGetValue("search", out var searchElement) == true &&
+            searchElement.ValueKind == JsonValueKind.String)
+        {
+            search = searchElement.GetString();
         }
 
         try
@@ -70,7 +81,7 @@ internal sealed class ListTracesTool(IDashboardInfoProvider dashboardInfoProvide
             }
 
             // Fetch all traces from the API. Limiting of returned telemetry to the MCP caller happens later.
-            var url = DashboardUrls.TelemetryTracesApiUrl(apiBaseUrl, resolvedResources, limit: TelemetryCommandHelpers.MaxTelemetryLimit);
+            var url = DashboardUrls.TelemetryTracesApiUrl(apiBaseUrl, resolvedResources, limit: TelemetryCommandHelpers.MaxTelemetryLimit, search: search);
 
             logger.LogDebug("Fetching traces from {Url}", url);
 

--- a/src/Aspire.Cli/Resources/LogsCommandStrings.Designer.cs
+++ b/src/Aspire.Cli/Resources/LogsCommandStrings.Designer.cs
@@ -122,5 +122,11 @@ namespace Aspire.Cli.Resources {
                 return ResourceManager.GetString("GettingLogs", resourceCulture);
             }
         }
+
+        public static string SearchOptionDescription {
+            get {
+                return ResourceManager.GetString("SearchOptionDescription", resourceCulture);
+            }
+        }
     }
 }

--- a/src/Aspire.Cli/Resources/LogsCommandStrings.resx
+++ b/src/Aspire.Cli/Resources/LogsCommandStrings.resx
@@ -159,4 +159,7 @@
   <data name="GettingLogs" xml:space="preserve">
     <value>Getting logs...</value>
   </data>
+  <data name="SearchOptionDescription" xml:space="preserve">
+    <value>Full-text search to filter log content</value>
+  </data>
 </root>

--- a/src/Aspire.Cli/Resources/TelemetryCommandStrings.Designer.cs
+++ b/src/Aspire.Cli/Resources/TelemetryCommandStrings.Designer.cs
@@ -169,6 +169,15 @@ namespace Aspire.Cli.Resources {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Full-text search across log text, attribute values, names, source, IDs, and other fields.
+        /// </summary>
+        internal static string SearchOptionDescription {
+            get {
+                return ResourceManager.GetString("SearchOptionDescription", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to The --limit value must be a positive number..
         /// </summary>
         internal static string LimitMustBePositive {

--- a/src/Aspire.Cli/Resources/TelemetryCommandStrings.Designer.cs
+++ b/src/Aspire.Cli/Resources/TelemetryCommandStrings.Designer.cs
@@ -169,7 +169,7 @@ namespace Aspire.Cli.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Full-text search across log text, attribute values, names, source, IDs, and other fields.
+        ///   Looks up a localized string similar to Full-text search across telemetry text fields, such as log messages, attribute values, names, source, and IDs.
         /// </summary>
         internal static string SearchOptionDescription {
             get {

--- a/src/Aspire.Cli/Resources/TelemetryCommandStrings.resx
+++ b/src/Aspire.Cli/Resources/TelemetryCommandStrings.resx
@@ -153,6 +153,9 @@
   <data name="HasErrorOptionDescription" xml:space="preserve">
     <value>Filter by error status (true to show only errors, false to exclude errors)</value>
   </data>
+  <data name="SearchOptionDescription" xml:space="preserve">
+    <value>Full-text search across telemetry text fields, such as log messages, attribute values, names, source, and IDs</value>
+  </data>
   <data name="LimitMustBePositive" xml:space="preserve">
     <value>The --limit value must be a positive number.</value>
   </data>

--- a/src/Aspire.Cli/Resources/xlf/LogsCommandStrings.cs.xlf
+++ b/src/Aspire.Cli/Resources/xlf/LogsCommandStrings.cs.xlf
@@ -42,6 +42,11 @@
         <target state="translated">Pokud nepoužíváte --follow, vyžaduje se název prostředku. Pokud chcete streamovat protokoly ze všech prostředků, použijte --follow.</target>
         <note />
       </trans-unit>
+      <trans-unit id="SearchOptionDescription">
+        <source>Full-text search to filter log content</source>
+        <target state="new">Full-text search to filter log content</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SelectAppHostAction">
         <source>stream logs from</source>
         <target state="translated">streamovat protokoly z</target>

--- a/src/Aspire.Cli/Resources/xlf/LogsCommandStrings.de.xlf
+++ b/src/Aspire.Cli/Resources/xlf/LogsCommandStrings.de.xlf
@@ -42,6 +42,11 @@
         <target state="translated">Ein Ressourcenname ist erforderlich, wenn --follow nicht verwendet wird. Verwenden Sie --follow, um Protokolle aller Ressourcen zu streamen.</target>
         <note />
       </trans-unit>
+      <trans-unit id="SearchOptionDescription">
+        <source>Full-text search to filter log content</source>
+        <target state="new">Full-text search to filter log content</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SelectAppHostAction">
         <source>stream logs from</source>
         <target state="translated">Protokolle streamen von</target>

--- a/src/Aspire.Cli/Resources/xlf/LogsCommandStrings.es.xlf
+++ b/src/Aspire.Cli/Resources/xlf/LogsCommandStrings.es.xlf
@@ -42,6 +42,11 @@
         <target state="translated">Se requiere un nombre de recurso cuando no se usa --follow. Use --follow para transmitir registros de todos los recursos.</target>
         <note />
       </trans-unit>
+      <trans-unit id="SearchOptionDescription">
+        <source>Full-text search to filter log content</source>
+        <target state="new">Full-text search to filter log content</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SelectAppHostAction">
         <source>stream logs from</source>
         <target state="translated">transmitir registros desde</target>

--- a/src/Aspire.Cli/Resources/xlf/LogsCommandStrings.fr.xlf
+++ b/src/Aspire.Cli/Resources/xlf/LogsCommandStrings.fr.xlf
@@ -42,6 +42,11 @@
         <target state="translated">Un nom de ressource est requis si vous n’utilisez pas --follow. Utilisez --follow pour diffuser en continu les journaux de toutes les ressources.</target>
         <note />
       </trans-unit>
+      <trans-unit id="SearchOptionDescription">
+        <source>Full-text search to filter log content</source>
+        <target state="new">Full-text search to filter log content</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SelectAppHostAction">
         <source>stream logs from</source>
         <target state="translated">transmettre les journaux de</target>

--- a/src/Aspire.Cli/Resources/xlf/LogsCommandStrings.it.xlf
+++ b/src/Aspire.Cli/Resources/xlf/LogsCommandStrings.it.xlf
@@ -42,6 +42,11 @@
         <target state="translated">Quando non si usa --follow, è necessario specificare un nome di risorsa. Usare --follow per trasmettere i log da tutte le risorse.</target>
         <note />
       </trans-unit>
+      <trans-unit id="SearchOptionDescription">
+        <source>Full-text search to filter log content</source>
+        <target state="new">Full-text search to filter log content</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SelectAppHostAction">
         <source>stream logs from</source>
         <target state="translated">trasmettere log da</target>

--- a/src/Aspire.Cli/Resources/xlf/LogsCommandStrings.ja.xlf
+++ b/src/Aspire.Cli/Resources/xlf/LogsCommandStrings.ja.xlf
@@ -42,6 +42,11 @@
         <target state="translated">--follow を使わない場合はリソース名の指定が必須です。--follow を使う場合、すべてのリソースのログがストリーミングされます。</target>
         <note />
       </trans-unit>
+      <trans-unit id="SearchOptionDescription">
+        <source>Full-text search to filter log content</source>
+        <target state="new">Full-text search to filter log content</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SelectAppHostAction">
         <source>stream logs from</source>
         <target state="translated">次からログをストリーミングする</target>

--- a/src/Aspire.Cli/Resources/xlf/LogsCommandStrings.ko.xlf
+++ b/src/Aspire.Cli/Resources/xlf/LogsCommandStrings.ko.xlf
@@ -42,6 +42,11 @@
         <target state="translated">--follow를 사용하지 않을 경우 리소스 이름은 필수 항목입니다. --follow를 사용하여 모든 리소스의 로그를 스트리밍합니다.</target>
         <note />
       </trans-unit>
+      <trans-unit id="SearchOptionDescription">
+        <source>Full-text search to filter log content</source>
+        <target state="new">Full-text search to filter log content</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SelectAppHostAction">
         <source>stream logs from</source>
         <target state="translated">에서 로그 스트리밍</target>

--- a/src/Aspire.Cli/Resources/xlf/LogsCommandStrings.pl.xlf
+++ b/src/Aspire.Cli/Resources/xlf/LogsCommandStrings.pl.xlf
@@ -42,6 +42,11 @@
         <target state="translated">Nazwa zasobu jest wymagana, jeśli nie używasz opcji --follow. Użyj opcji --follow, aby przesyłać strumieniowo dzienniki ze wszystkich zasobów.</target>
         <note />
       </trans-unit>
+      <trans-unit id="SearchOptionDescription">
+        <source>Full-text search to filter log content</source>
+        <target state="new">Full-text search to filter log content</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SelectAppHostAction">
         <source>stream logs from</source>
         <target state="translated">prześlij strumieniowo dzienniki z</target>

--- a/src/Aspire.Cli/Resources/xlf/LogsCommandStrings.pt-BR.xlf
+++ b/src/Aspire.Cli/Resources/xlf/LogsCommandStrings.pt-BR.xlf
@@ -42,6 +42,11 @@
         <target state="translated">Um nome de recurso é necessário ao não usar --follow. Use --follow para transmitir logs de todos os recursos.</target>
         <note />
       </trans-unit>
+      <trans-unit id="SearchOptionDescription">
+        <source>Full-text search to filter log content</source>
+        <target state="new">Full-text search to filter log content</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SelectAppHostAction">
         <source>stream logs from</source>
         <target state="translated">fazer streaming de logs de</target>

--- a/src/Aspire.Cli/Resources/xlf/LogsCommandStrings.ru.xlf
+++ b/src/Aspire.Cli/Resources/xlf/LogsCommandStrings.ru.xlf
@@ -42,6 +42,11 @@
         <target state="translated">При отсутствии параметра --follow необходимо указать имя ресурса. Используйте --follow для потоковой передачи журналов из всех ресурсов.</target>
         <note />
       </trans-unit>
+      <trans-unit id="SearchOptionDescription">
+        <source>Full-text search to filter log content</source>
+        <target state="new">Full-text search to filter log content</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SelectAppHostAction">
         <source>stream logs from</source>
         <target state="translated">потоковая передача журналов из</target>

--- a/src/Aspire.Cli/Resources/xlf/LogsCommandStrings.tr.xlf
+++ b/src/Aspire.Cli/Resources/xlf/LogsCommandStrings.tr.xlf
@@ -42,6 +42,11 @@
         <target state="translated">--follow kullanılmadığında kaynak adı gereklidir. Tüm kaynaklardan günlük akışı yapmak için --follow kullanın.</target>
         <note />
       </trans-unit>
+      <trans-unit id="SearchOptionDescription">
+        <source>Full-text search to filter log content</source>
+        <target state="new">Full-text search to filter log content</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SelectAppHostAction">
         <source>stream logs from</source>
         <target state="translated">akış günlüklerinin kaynağı</target>

--- a/src/Aspire.Cli/Resources/xlf/LogsCommandStrings.zh-Hans.xlf
+++ b/src/Aspire.Cli/Resources/xlf/LogsCommandStrings.zh-Hans.xlf
@@ -42,6 +42,11 @@
         <target state="translated">不使用 --follow 时必须指定资源名称。使用 --follow 流式传输所有资源的日志。</target>
         <note />
       </trans-unit>
+      <trans-unit id="SearchOptionDescription">
+        <source>Full-text search to filter log content</source>
+        <target state="new">Full-text search to filter log content</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SelectAppHostAction">
         <source>stream logs from</source>
         <target state="translated">从以下位置流式传输日志</target>

--- a/src/Aspire.Cli/Resources/xlf/LogsCommandStrings.zh-Hant.xlf
+++ b/src/Aspire.Cli/Resources/xlf/LogsCommandStrings.zh-Hant.xlf
@@ -42,6 +42,11 @@
         <target state="translated">當未使用 --follow 時，必須指定資源名稱。使用 --follow 從所有資源串流記錄。</target>
         <note />
       </trans-unit>
+      <trans-unit id="SearchOptionDescription">
+        <source>Full-text search to filter log content</source>
+        <target state="new">Full-text search to filter log content</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SelectAppHostAction">
         <source>stream logs from</source>
         <target state="translated">串流來自以下位置的記錄</target>

--- a/src/Aspire.Cli/Resources/xlf/TelemetryCommandStrings.cs.xlf
+++ b/src/Aspire.Cli/Resources/xlf/TelemetryCommandStrings.cs.xlf
@@ -167,6 +167,11 @@
         <target state="needs-review-translation">Filtrovat podle názvu prostředku.</target>
         <note />
       </trans-unit>
+      <trans-unit id="SearchOptionDescription">
+        <source>Full-text search across attribute values, names, source, IDs, and other text fields</source>
+        <target state="new">Full-text search across attribute values, names, source, IDs, and other text fields</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SelectAppHostAction">
         <source>view telemetry for</source>
         <target state="translated">zobrazit telemetrii pro</target>

--- a/src/Aspire.Cli/Resources/xlf/TelemetryCommandStrings.cs.xlf
+++ b/src/Aspire.Cli/Resources/xlf/TelemetryCommandStrings.cs.xlf
@@ -168,8 +168,8 @@
         <note />
       </trans-unit>
       <trans-unit id="SearchOptionDescription">
-        <source>Full-text search across attribute values, names, source, IDs, and other text fields</source>
-        <target state="new">Full-text search across attribute values, names, source, IDs, and other text fields</target>
+        <source>Full-text search across telemetry text fields, such as log messages, attribute values, names, source, and IDs</source>
+        <target state="new">Full-text search across telemetry text fields, such as log messages, attribute values, names, source, and IDs</target>
         <note />
       </trans-unit>
       <trans-unit id="SelectAppHostAction">

--- a/src/Aspire.Cli/Resources/xlf/TelemetryCommandStrings.de.xlf
+++ b/src/Aspire.Cli/Resources/xlf/TelemetryCommandStrings.de.xlf
@@ -167,6 +167,11 @@
         <target state="needs-review-translation">Filtern Sie nach Ressourcennamen.</target>
         <note />
       </trans-unit>
+      <trans-unit id="SearchOptionDescription">
+        <source>Full-text search across attribute values, names, source, IDs, and other text fields</source>
+        <target state="new">Full-text search across attribute values, names, source, IDs, and other text fields</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SelectAppHostAction">
         <source>view telemetry for</source>
         <target state="translated">Telemetrie anzeigen für</target>

--- a/src/Aspire.Cli/Resources/xlf/TelemetryCommandStrings.de.xlf
+++ b/src/Aspire.Cli/Resources/xlf/TelemetryCommandStrings.de.xlf
@@ -168,8 +168,8 @@
         <note />
       </trans-unit>
       <trans-unit id="SearchOptionDescription">
-        <source>Full-text search across attribute values, names, source, IDs, and other text fields</source>
-        <target state="new">Full-text search across attribute values, names, source, IDs, and other text fields</target>
+        <source>Full-text search across telemetry text fields, such as log messages, attribute values, names, source, and IDs</source>
+        <target state="new">Full-text search across telemetry text fields, such as log messages, attribute values, names, source, and IDs</target>
         <note />
       </trans-unit>
       <trans-unit id="SelectAppHostAction">

--- a/src/Aspire.Cli/Resources/xlf/TelemetryCommandStrings.es.xlf
+++ b/src/Aspire.Cli/Resources/xlf/TelemetryCommandStrings.es.xlf
@@ -168,8 +168,8 @@
         <note />
       </trans-unit>
       <trans-unit id="SearchOptionDescription">
-        <source>Full-text search across attribute values, names, source, IDs, and other text fields</source>
-        <target state="new">Full-text search across attribute values, names, source, IDs, and other text fields</target>
+        <source>Full-text search across telemetry text fields, such as log messages, attribute values, names, source, and IDs</source>
+        <target state="new">Full-text search across telemetry text fields, such as log messages, attribute values, names, source, and IDs</target>
         <note />
       </trans-unit>
       <trans-unit id="SelectAppHostAction">

--- a/src/Aspire.Cli/Resources/xlf/TelemetryCommandStrings.es.xlf
+++ b/src/Aspire.Cli/Resources/xlf/TelemetryCommandStrings.es.xlf
@@ -167,6 +167,11 @@
         <target state="needs-review-translation">Filtrar por nombre de recurso.</target>
         <note />
       </trans-unit>
+      <trans-unit id="SearchOptionDescription">
+        <source>Full-text search across attribute values, names, source, IDs, and other text fields</source>
+        <target state="new">Full-text search across attribute values, names, source, IDs, and other text fields</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SelectAppHostAction">
         <source>view telemetry for</source>
         <target state="translated">ver telemetría para</target>

--- a/src/Aspire.Cli/Resources/xlf/TelemetryCommandStrings.fr.xlf
+++ b/src/Aspire.Cli/Resources/xlf/TelemetryCommandStrings.fr.xlf
@@ -168,8 +168,8 @@
         <note />
       </trans-unit>
       <trans-unit id="SearchOptionDescription">
-        <source>Full-text search across attribute values, names, source, IDs, and other text fields</source>
-        <target state="new">Full-text search across attribute values, names, source, IDs, and other text fields</target>
+        <source>Full-text search across telemetry text fields, such as log messages, attribute values, names, source, and IDs</source>
+        <target state="new">Full-text search across telemetry text fields, such as log messages, attribute values, names, source, and IDs</target>
         <note />
       </trans-unit>
       <trans-unit id="SelectAppHostAction">

--- a/src/Aspire.Cli/Resources/xlf/TelemetryCommandStrings.fr.xlf
+++ b/src/Aspire.Cli/Resources/xlf/TelemetryCommandStrings.fr.xlf
@@ -167,6 +167,11 @@
         <target state="needs-review-translation">Filtrer par nom de ressource.</target>
         <note />
       </trans-unit>
+      <trans-unit id="SearchOptionDescription">
+        <source>Full-text search across attribute values, names, source, IDs, and other text fields</source>
+        <target state="new">Full-text search across attribute values, names, source, IDs, and other text fields</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SelectAppHostAction">
         <source>view telemetry for</source>
         <target state="translated">Voir la télémétrie</target>

--- a/src/Aspire.Cli/Resources/xlf/TelemetryCommandStrings.it.xlf
+++ b/src/Aspire.Cli/Resources/xlf/TelemetryCommandStrings.it.xlf
@@ -167,6 +167,11 @@
         <target state="needs-review-translation">Filtrare per nome della risorsa.</target>
         <note />
       </trans-unit>
+      <trans-unit id="SearchOptionDescription">
+        <source>Full-text search across attribute values, names, source, IDs, and other text fields</source>
+        <target state="new">Full-text search across attribute values, names, source, IDs, and other text fields</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SelectAppHostAction">
         <source>view telemetry for</source>
         <target state="translated">visualizzare dati di telemetria per</target>

--- a/src/Aspire.Cli/Resources/xlf/TelemetryCommandStrings.it.xlf
+++ b/src/Aspire.Cli/Resources/xlf/TelemetryCommandStrings.it.xlf
@@ -168,8 +168,8 @@
         <note />
       </trans-unit>
       <trans-unit id="SearchOptionDescription">
-        <source>Full-text search across attribute values, names, source, IDs, and other text fields</source>
-        <target state="new">Full-text search across attribute values, names, source, IDs, and other text fields</target>
+        <source>Full-text search across telemetry text fields, such as log messages, attribute values, names, source, and IDs</source>
+        <target state="new">Full-text search across telemetry text fields, such as log messages, attribute values, names, source, and IDs</target>
         <note />
       </trans-unit>
       <trans-unit id="SelectAppHostAction">

--- a/src/Aspire.Cli/Resources/xlf/TelemetryCommandStrings.ja.xlf
+++ b/src/Aspire.Cli/Resources/xlf/TelemetryCommandStrings.ja.xlf
@@ -168,8 +168,8 @@
         <note />
       </trans-unit>
       <trans-unit id="SearchOptionDescription">
-        <source>Full-text search across attribute values, names, source, IDs, and other text fields</source>
-        <target state="new">Full-text search across attribute values, names, source, IDs, and other text fields</target>
+        <source>Full-text search across telemetry text fields, such as log messages, attribute values, names, source, and IDs</source>
+        <target state="new">Full-text search across telemetry text fields, such as log messages, attribute values, names, source, and IDs</target>
         <note />
       </trans-unit>
       <trans-unit id="SelectAppHostAction">

--- a/src/Aspire.Cli/Resources/xlf/TelemetryCommandStrings.ja.xlf
+++ b/src/Aspire.Cli/Resources/xlf/TelemetryCommandStrings.ja.xlf
@@ -167,6 +167,11 @@
         <target state="needs-review-translation">リソース名でフィルター処理します。</target>
         <note />
       </trans-unit>
+      <trans-unit id="SearchOptionDescription">
+        <source>Full-text search across attribute values, names, source, IDs, and other text fields</source>
+        <target state="new">Full-text search across attribute values, names, source, IDs, and other text fields</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SelectAppHostAction">
         <source>view telemetry for</source>
         <target state="translated">次のテレメトリを表示する:</target>

--- a/src/Aspire.Cli/Resources/xlf/TelemetryCommandStrings.ko.xlf
+++ b/src/Aspire.Cli/Resources/xlf/TelemetryCommandStrings.ko.xlf
@@ -167,6 +167,11 @@
         <target state="needs-review-translation">리소스 이름으로 필터링</target>
         <note />
       </trans-unit>
+      <trans-unit id="SearchOptionDescription">
+        <source>Full-text search across attribute values, names, source, IDs, and other text fields</source>
+        <target state="new">Full-text search across attribute values, names, source, IDs, and other text fields</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SelectAppHostAction">
         <source>view telemetry for</source>
         <target state="translated">원격 분석 데이터 보기</target>

--- a/src/Aspire.Cli/Resources/xlf/TelemetryCommandStrings.ko.xlf
+++ b/src/Aspire.Cli/Resources/xlf/TelemetryCommandStrings.ko.xlf
@@ -168,8 +168,8 @@
         <note />
       </trans-unit>
       <trans-unit id="SearchOptionDescription">
-        <source>Full-text search across attribute values, names, source, IDs, and other text fields</source>
-        <target state="new">Full-text search across attribute values, names, source, IDs, and other text fields</target>
+        <source>Full-text search across telemetry text fields, such as log messages, attribute values, names, source, and IDs</source>
+        <target state="new">Full-text search across telemetry text fields, such as log messages, attribute values, names, source, and IDs</target>
         <note />
       </trans-unit>
       <trans-unit id="SelectAppHostAction">

--- a/src/Aspire.Cli/Resources/xlf/TelemetryCommandStrings.pl.xlf
+++ b/src/Aspire.Cli/Resources/xlf/TelemetryCommandStrings.pl.xlf
@@ -168,8 +168,8 @@
         <note />
       </trans-unit>
       <trans-unit id="SearchOptionDescription">
-        <source>Full-text search across attribute values, names, source, IDs, and other text fields</source>
-        <target state="new">Full-text search across attribute values, names, source, IDs, and other text fields</target>
+        <source>Full-text search across telemetry text fields, such as log messages, attribute values, names, source, and IDs</source>
+        <target state="new">Full-text search across telemetry text fields, such as log messages, attribute values, names, source, and IDs</target>
         <note />
       </trans-unit>
       <trans-unit id="SelectAppHostAction">

--- a/src/Aspire.Cli/Resources/xlf/TelemetryCommandStrings.pl.xlf
+++ b/src/Aspire.Cli/Resources/xlf/TelemetryCommandStrings.pl.xlf
@@ -167,6 +167,11 @@
         <target state="needs-review-translation">Filtruj według nazwy zasobu.</target>
         <note />
       </trans-unit>
+      <trans-unit id="SearchOptionDescription">
+        <source>Full-text search across attribute values, names, source, IDs, and other text fields</source>
+        <target state="new">Full-text search across attribute values, names, source, IDs, and other text fields</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SelectAppHostAction">
         <source>view telemetry for</source>
         <target state="translated">wyświetl dane telemetryczne dla</target>

--- a/src/Aspire.Cli/Resources/xlf/TelemetryCommandStrings.pt-BR.xlf
+++ b/src/Aspire.Cli/Resources/xlf/TelemetryCommandStrings.pt-BR.xlf
@@ -167,6 +167,11 @@
         <target state="needs-review-translation">Filtre por nome de recurso.</target>
         <note />
       </trans-unit>
+      <trans-unit id="SearchOptionDescription">
+        <source>Full-text search across attribute values, names, source, IDs, and other text fields</source>
+        <target state="new">Full-text search across attribute values, names, source, IDs, and other text fields</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SelectAppHostAction">
         <source>view telemetry for</source>
         <target state="translated">exibir telemetria para</target>

--- a/src/Aspire.Cli/Resources/xlf/TelemetryCommandStrings.pt-BR.xlf
+++ b/src/Aspire.Cli/Resources/xlf/TelemetryCommandStrings.pt-BR.xlf
@@ -168,8 +168,8 @@
         <note />
       </trans-unit>
       <trans-unit id="SearchOptionDescription">
-        <source>Full-text search across attribute values, names, source, IDs, and other text fields</source>
-        <target state="new">Full-text search across attribute values, names, source, IDs, and other text fields</target>
+        <source>Full-text search across telemetry text fields, such as log messages, attribute values, names, source, and IDs</source>
+        <target state="new">Full-text search across telemetry text fields, such as log messages, attribute values, names, source, and IDs</target>
         <note />
       </trans-unit>
       <trans-unit id="SelectAppHostAction">

--- a/src/Aspire.Cli/Resources/xlf/TelemetryCommandStrings.ru.xlf
+++ b/src/Aspire.Cli/Resources/xlf/TelemetryCommandStrings.ru.xlf
@@ -167,6 +167,11 @@
         <target state="needs-review-translation">Фильтровать по имени ресурса.</target>
         <note />
       </trans-unit>
+      <trans-unit id="SearchOptionDescription">
+        <source>Full-text search across attribute values, names, source, IDs, and other text fields</source>
+        <target state="new">Full-text search across attribute values, names, source, IDs, and other text fields</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SelectAppHostAction">
         <source>view telemetry for</source>
         <target state="translated">просмотреть телеметрию для</target>

--- a/src/Aspire.Cli/Resources/xlf/TelemetryCommandStrings.ru.xlf
+++ b/src/Aspire.Cli/Resources/xlf/TelemetryCommandStrings.ru.xlf
@@ -168,8 +168,8 @@
         <note />
       </trans-unit>
       <trans-unit id="SearchOptionDescription">
-        <source>Full-text search across attribute values, names, source, IDs, and other text fields</source>
-        <target state="new">Full-text search across attribute values, names, source, IDs, and other text fields</target>
+        <source>Full-text search across telemetry text fields, such as log messages, attribute values, names, source, and IDs</source>
+        <target state="new">Full-text search across telemetry text fields, such as log messages, attribute values, names, source, and IDs</target>
         <note />
       </trans-unit>
       <trans-unit id="SelectAppHostAction">

--- a/src/Aspire.Cli/Resources/xlf/TelemetryCommandStrings.tr.xlf
+++ b/src/Aspire.Cli/Resources/xlf/TelemetryCommandStrings.tr.xlf
@@ -167,6 +167,11 @@
         <target state="needs-review-translation">Kaynak adına göre filtreleyin.</target>
         <note />
       </trans-unit>
+      <trans-unit id="SearchOptionDescription">
+        <source>Full-text search across attribute values, names, source, IDs, and other text fields</source>
+        <target state="new">Full-text search across attribute values, names, source, IDs, and other text fields</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SelectAppHostAction">
         <source>view telemetry for</source>
         <target state="translated">telemetrisini görüntüle:</target>

--- a/src/Aspire.Cli/Resources/xlf/TelemetryCommandStrings.tr.xlf
+++ b/src/Aspire.Cli/Resources/xlf/TelemetryCommandStrings.tr.xlf
@@ -168,8 +168,8 @@
         <note />
       </trans-unit>
       <trans-unit id="SearchOptionDescription">
-        <source>Full-text search across attribute values, names, source, IDs, and other text fields</source>
-        <target state="new">Full-text search across attribute values, names, source, IDs, and other text fields</target>
+        <source>Full-text search across telemetry text fields, such as log messages, attribute values, names, source, and IDs</source>
+        <target state="new">Full-text search across telemetry text fields, such as log messages, attribute values, names, source, and IDs</target>
         <note />
       </trans-unit>
       <trans-unit id="SelectAppHostAction">

--- a/src/Aspire.Cli/Resources/xlf/TelemetryCommandStrings.zh-Hans.xlf
+++ b/src/Aspire.Cli/Resources/xlf/TelemetryCommandStrings.zh-Hans.xlf
@@ -168,8 +168,8 @@
         <note />
       </trans-unit>
       <trans-unit id="SearchOptionDescription">
-        <source>Full-text search across attribute values, names, source, IDs, and other text fields</source>
-        <target state="new">Full-text search across attribute values, names, source, IDs, and other text fields</target>
+        <source>Full-text search across telemetry text fields, such as log messages, attribute values, names, source, and IDs</source>
+        <target state="new">Full-text search across telemetry text fields, such as log messages, attribute values, names, source, and IDs</target>
         <note />
       </trans-unit>
       <trans-unit id="SelectAppHostAction">

--- a/src/Aspire.Cli/Resources/xlf/TelemetryCommandStrings.zh-Hans.xlf
+++ b/src/Aspire.Cli/Resources/xlf/TelemetryCommandStrings.zh-Hans.xlf
@@ -167,6 +167,11 @@
         <target state="needs-review-translation">按资源名称筛选。</target>
         <note />
       </trans-unit>
+      <trans-unit id="SearchOptionDescription">
+        <source>Full-text search across attribute values, names, source, IDs, and other text fields</source>
+        <target state="new">Full-text search across attribute values, names, source, IDs, and other text fields</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SelectAppHostAction">
         <source>view telemetry for</source>
         <target state="translated">查看以下项的遥测:</target>

--- a/src/Aspire.Cli/Resources/xlf/TelemetryCommandStrings.zh-Hant.xlf
+++ b/src/Aspire.Cli/Resources/xlf/TelemetryCommandStrings.zh-Hant.xlf
@@ -168,8 +168,8 @@
         <note />
       </trans-unit>
       <trans-unit id="SearchOptionDescription">
-        <source>Full-text search across attribute values, names, source, IDs, and other text fields</source>
-        <target state="new">Full-text search across attribute values, names, source, IDs, and other text fields</target>
+        <source>Full-text search across telemetry text fields, such as log messages, attribute values, names, source, and IDs</source>
+        <target state="new">Full-text search across telemetry text fields, such as log messages, attribute values, names, source, and IDs</target>
         <note />
       </trans-unit>
       <trans-unit id="SelectAppHostAction">

--- a/src/Aspire.Cli/Resources/xlf/TelemetryCommandStrings.zh-Hant.xlf
+++ b/src/Aspire.Cli/Resources/xlf/TelemetryCommandStrings.zh-Hant.xlf
@@ -167,6 +167,11 @@
         <target state="needs-review-translation">依資源名稱篩選。</target>
         <note />
       </trans-unit>
+      <trans-unit id="SearchOptionDescription">
+        <source>Full-text search across attribute values, names, source, IDs, and other text fields</source>
+        <target state="new">Full-text search across attribute values, names, source, IDs, and other text fields</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SelectAppHostAction">
         <source>view telemetry for</source>
         <target state="translated">檢視遙測資料</target>

--- a/src/Aspire.Dashboard/Api/TelemetryApiService.cs
+++ b/src/Aspire.Dashboard/Api/TelemetryApiService.cs
@@ -29,7 +29,7 @@ internal sealed class TelemetryApiService(
     /// Returns null if resource filter is specified but not found.
     /// Supports multiple resource names.
     /// </summary>
-    public TelemetryApiResponse? GetSpans(string[]? resourceNames, string? traceId, bool? hasError, int? limit)
+    public TelemetryApiResponse? GetSpans(string[]? resourceNames, string? traceId, bool? hasError, int? limit, string? search = null)
     {
         // Resolve resource keys for all specified resources
         var resources = telemetryRepository.GetResources();
@@ -77,6 +77,12 @@ internal sealed class TelemetryApiService(
             spans = spans.Where(s => s.Status != OtlpSpanStatusCode.Error).ToList();
         }
 
+        // Apply full-text search across all span fields
+        if (!string.IsNullOrEmpty(search))
+        {
+            spans = spans.Where(s => MatchesSearch(s, search)).ToList();
+        }
+
         var totalCount = spans.Count;
 
         // Apply limit (take from end for most recent)
@@ -100,7 +106,7 @@ internal sealed class TelemetryApiService(
     /// Returns null if resource filter is specified but not found.
     /// Supports multiple resource names.
     /// </summary>
-    public TelemetryApiResponse? GetTraces(string[]? resourceNames, bool? hasError, int? limit)
+    public TelemetryApiResponse? GetTraces(string[]? resourceNames, bool? hasError, int? limit, string? search = null)
     {
         // Resolve resource keys for all specified resources
         var resources = telemetryRepository.GetResources();
@@ -137,6 +143,14 @@ internal sealed class TelemetryApiService(
         else if (hasError == false)
         {
             traces = traces.Where(t => !t.Spans.Any(s => s.Status == OtlpSpanStatusCode.Error)).ToList();
+        }
+
+        // Apply full-text search: a trace matches if its name matches or any span within it matches
+        if (!string.IsNullOrEmpty(search))
+        {
+            traces = traces.Where(t =>
+                t.FullName.Contains(search, StringComparisons.FullTextSearch) ||
+                t.Spans.Any(s => MatchesSearch(s, search))).ToList();
         }
 
         var totalCount = traces.Count;
@@ -189,7 +203,7 @@ internal sealed class TelemetryApiService(
     /// Returns null if resource filter is specified but not found.
     /// Supports multiple resource names.
     /// </summary>
-    public TelemetryApiResponse? GetLogs(string[]? resourceNames, string? traceId, string? severity, int? limit)
+    public TelemetryApiResponse? GetLogs(string[]? resourceNames, string? traceId, string? severity, int? limit, string? search = null)
     {
         // Resolve resource keys for all specified resources
         var resources = telemetryRepository.GetResources();
@@ -243,6 +257,13 @@ internal sealed class TelemetryApiService(
         }
 
         var logs = allLogs;
+
+        // Apply full-text search across all log fields
+        if (!string.IsNullOrEmpty(search))
+        {
+            logs = logs.Where(l => MatchesSearch(l, search)).ToList();
+        }
+
         var totalCount = logs.Count;
 
         // Apply limit (take from end for most recent)
@@ -269,6 +290,7 @@ internal sealed class TelemetryApiService(
         string[]? resourceNames,
         string? traceId,
         bool? hasError,
+        string? search,
         [EnumeratorCancellation] CancellationToken cancellationToken)
     {
         // Resolve resource keys
@@ -307,6 +329,12 @@ internal sealed class TelemetryApiService(
                 continue;
             }
 
+            // Apply full-text search filter
+            if (!string.IsNullOrEmpty(search) && !MatchesSearch(span, search))
+            {
+                continue;
+            }
+
             // Use compact JSON for NDJSON streaming (no indentation)
             yield return TelemetryExportService.ConvertSpanToJson(span, _outgoingPeerResolvers, logs: null, indent: false);
         }
@@ -320,6 +348,7 @@ internal sealed class TelemetryApiService(
         string[]? resourceNames,
         string? traceId,
         string? severity,
+        string? search,
         [EnumeratorCancellation] CancellationToken cancellationToken)
     {
         // Resolve resource keys
@@ -373,6 +402,12 @@ internal sealed class TelemetryApiService(
                 continue;
             }
 
+            // Apply full-text search filter
+            if (!string.IsNullOrEmpty(search) && !MatchesSearch(log, search))
+            {
+                continue;
+            }
+
             var otlpData = TelemetryExportService.ConvertLogsToOtlpJson([log]);
             yield return JsonSerializer.Serialize(otlpData, OtlpJsonSerializerContext.DefaultOptions);
         }
@@ -396,6 +431,127 @@ internal sealed class TelemetryApiService(
                 HasMetrics = r.HasMetrics
             })
             .ToArray();
+    }
+
+    /// <summary>
+    /// Checks whether a log entry matches a full-text search string.
+    /// Searches across message, attribute values, scope name, event name, trace ID, span ID,
+    /// severity, and resource name using case-insensitive contains matching.
+    /// </summary>
+    private static bool MatchesSearch(OtlpLogEntry log, string search)
+    {
+        if (log.Message.Contains(search, StringComparisons.FullTextSearch))
+        {
+            return true;
+        }
+
+        if (log.Scope.Name.Contains(search, StringComparisons.FullTextSearch))
+        {
+            return true;
+        }
+
+        if (log.EventName is not null && log.EventName.Contains(search, StringComparisons.FullTextSearch))
+        {
+            return true;
+        }
+
+        if (log.TraceId.Contains(search, StringComparisons.FullTextSearch))
+        {
+            return true;
+        }
+
+        if (log.SpanId.Contains(search, StringComparisons.FullTextSearch))
+        {
+            return true;
+        }
+
+        if (log.Severity.ToString().Contains(search, StringComparisons.FullTextSearch))
+        {
+            return true;
+        }
+
+        if (log.ResourceView.Resource.ResourceName.Contains(search, StringComparisons.FullTextSearch))
+        {
+            return true;
+        }
+
+        foreach (var attribute in log.Attributes)
+        {
+            if (attribute.Key.Contains(search, StringComparisons.FullTextSearch) ||
+                attribute.Value.Contains(search, StringComparisons.FullTextSearch))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /// <summary>
+    /// Checks whether a span matches a full-text search string.
+    /// Searches across name, attribute values, span ID, trace ID, status message,
+    /// scope name, event names, and resource name using case-insensitive contains matching.
+    /// </summary>
+    private static bool MatchesSearch(OtlpSpan span, string search)
+    {
+        if (span.Name.Contains(search, StringComparisons.FullTextSearch))
+        {
+            return true;
+        }
+
+        if (span.SpanId.Contains(search, StringComparisons.FullTextSearch))
+        {
+            return true;
+        }
+
+        if (span.TraceId.Contains(search, StringComparisons.FullTextSearch))
+        {
+            return true;
+        }
+
+        if (span.StatusMessage is not null && span.StatusMessage.Contains(search, StringComparisons.FullTextSearch))
+        {
+            return true;
+        }
+
+        if (span.Scope.Name.Contains(search, StringComparisons.FullTextSearch))
+        {
+            return true;
+        }
+
+        if (span.Source.Resource.ResourceName.Contains(search, StringComparisons.FullTextSearch))
+        {
+            return true;
+        }
+
+        if (span.Status.ToString().Contains(search, StringComparisons.FullTextSearch))
+        {
+            return true;
+        }
+
+        if (span.Kind.ToString().Contains(search, StringComparisons.FullTextSearch))
+        {
+            return true;
+        }
+
+        foreach (var attribute in span.Attributes)
+        {
+            if (attribute.Key.Contains(search, StringComparisons.FullTextSearch) ||
+                attribute.Value.Contains(search, StringComparisons.FullTextSearch))
+            {
+                return true;
+            }
+        }
+
+        foreach (var evt in span.Events)
+        {
+            if (evt.Name.Contains(search, StringComparisons.FullTextSearch))
+            {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     /// <summary>

--- a/src/Aspire.Dashboard/DashboardEndpointsBuilder.cs
+++ b/src/Aspire.Dashboard/DashboardEndpointsBuilder.cs
@@ -150,15 +150,16 @@ public static class DashboardEndpointsBuilder
             [FromQuery] bool? hasError,
             [FromQuery] int? limit,
             [FromQuery] bool? follow,
+            [FromQuery] string? search,
             CancellationToken cancellationToken) =>
         {
             if (follow == true)
             {
-                await StreamNdjsonAsync(httpContext, service.FollowSpansAsync(resource, traceId, hasError, cancellationToken), cancellationToken).ConfigureAwait(false);
+                await StreamNdjsonAsync(httpContext, service.FollowSpansAsync(resource, traceId, hasError, search, cancellationToken), cancellationToken).ConfigureAwait(false);
                 return Results.Empty;
             }
 
-            var response = service.GetSpans(resource, traceId, hasError, limit);
+            var response = service.GetSpans(resource, traceId, hasError, limit, search);
             if (response is null)
             {
                 return Results.NotFound(new ProblemDetails
@@ -181,15 +182,16 @@ public static class DashboardEndpointsBuilder
             [FromQuery] string? severity,
             [FromQuery] int? limit,
             [FromQuery] bool? follow,
+            [FromQuery] string? search,
             CancellationToken cancellationToken) =>
         {
             if (follow == true)
             {
-                await StreamNdjsonAsync(httpContext, service.FollowLogsAsync(resource, traceId, severity, cancellationToken), cancellationToken).ConfigureAwait(false);
+                await StreamNdjsonAsync(httpContext, service.FollowLogsAsync(resource, traceId, severity, search, cancellationToken), cancellationToken).ConfigureAwait(false);
                 return Results.Empty;
             }
 
-            var response = service.GetLogs(resource, traceId, severity, limit);
+            var response = service.GetLogs(resource, traceId, severity, limit, search);
             if (response is null)
             {
                 return Results.NotFound(new ProblemDetails
@@ -208,9 +210,10 @@ public static class DashboardEndpointsBuilder
             TelemetryApiService service,
             [FromQuery] string[]? resource,
             [FromQuery] bool? hasError,
-            [FromQuery] int? limit) =>
+            [FromQuery] int? limit,
+            [FromQuery] string? search) =>
         {
-            var response = service.GetTraces(resource, hasError, limit);
+            var response = service.GetTraces(resource, hasError, limit, search);
             if (response is null)
             {
                 return Results.NotFound(new ProblemDetails

--- a/src/Shared/DashboardUrls.cs
+++ b/src/Shared/DashboardUrls.cs
@@ -201,8 +201,9 @@ internal static class DashboardUrls
     /// <param name="severity">Optional minimum severity level filter.</param>
     /// <param name="limit">Optional maximum number of results to return.</param>
     /// <param name="follow">Optional flag to enable streaming mode.</param>
+    /// <param name="search">Optional full-text search string to filter results.</param>
     /// <returns>The full API URL.</returns>
-    public static string TelemetryLogsApiUrl(string baseUrl, List<string>? resources = null, string? traceId = null, string? severity = null, int? limit = null, bool? follow = null)
+    public static string TelemetryLogsApiUrl(string baseUrl, List<string>? resources = null, string? traceId = null, string? severity = null, int? limit = null, bool? follow = null, string? search = null)
     {
         var url = $"/{TelemetryApiBasePath}/logs";
         url = AddResourceParams(url, resources);
@@ -222,6 +223,10 @@ internal static class DashboardUrls
         {
             url = AddQueryString(url, "follow", "true");
         }
+        if (search is not null)
+        {
+            url = AddQueryString(url, "search", search);
+        }
         return CombineUrl(baseUrl, url);
     }
 
@@ -234,8 +239,9 @@ internal static class DashboardUrls
     /// <param name="hasError">Optional filter for error status.</param>
     /// <param name="limit">Optional maximum number of results to return.</param>
     /// <param name="follow">Optional flag to enable streaming mode.</param>
+    /// <param name="search">Optional full-text search string to filter results.</param>
     /// <returns>The full API URL.</returns>
-    public static string TelemetrySpansApiUrl(string baseUrl, List<string>? resources = null, string? traceId = null, bool? hasError = null, int? limit = null, bool? follow = null)
+    public static string TelemetrySpansApiUrl(string baseUrl, List<string>? resources = null, string? traceId = null, bool? hasError = null, int? limit = null, bool? follow = null, string? search = null)
     {
         var url = $"/{TelemetryApiBasePath}/spans";
         url = AddResourceParams(url, resources);
@@ -255,6 +261,10 @@ internal static class DashboardUrls
         {
             url = AddQueryString(url, "follow", "true");
         }
+        if (search is not null)
+        {
+            url = AddQueryString(url, "search", search);
+        }
         return CombineUrl(baseUrl, url);
     }
 
@@ -265,8 +275,9 @@ internal static class DashboardUrls
     /// <param name="resources">Optional list of resource names to filter by.</param>
     /// <param name="hasError">Optional filter for error status.</param>
     /// <param name="limit">Optional maximum number of results to return.</param>
+    /// <param name="search">Optional full-text search string to filter results.</param>
     /// <returns>The full API URL.</returns>
-    public static string TelemetryTracesApiUrl(string baseUrl, List<string>? resources = null, bool? hasError = null, int? limit = null)
+    public static string TelemetryTracesApiUrl(string baseUrl, List<string>? resources = null, bool? hasError = null, int? limit = null, string? search = null)
     {
         var url = $"/{TelemetryApiBasePath}/traces";
         url = AddResourceParams(url, resources);
@@ -277,6 +288,10 @@ internal static class DashboardUrls
         if (limit is not null)
         {
             url = AddQueryString(url, "limit", limit.Value.ToString(CultureInfo.InvariantCulture));
+        }
+        if (search is not null)
+        {
+            url = AddQueryString(url, "search", search);
         }
         return CombineUrl(baseUrl, url);
     }

--- a/src/Shared/StringComparers.cs
+++ b/src/Shared/StringComparers.cs
@@ -34,6 +34,7 @@ internal static class StringComparers
     public static StringComparer InteractionInputName => StringComparer.OrdinalIgnoreCase;
     public static StringComparer NetworkID => StringComparer.Ordinal;
     public static StringComparer NuGetPackageId => StringComparer.OrdinalIgnoreCase;
+    public static StringComparer FullTextSearch => StringComparer.OrdinalIgnoreCase;
 }
 
 internal static class StringComparisons
@@ -65,4 +66,5 @@ internal static class StringComparisons
     public static StringComparison InteractionInputName => StringComparison.OrdinalIgnoreCase;
     public static StringComparison NetworkID => StringComparison.Ordinal;
     public static StringComparison NuGetPackageId => StringComparison.OrdinalIgnoreCase;
+    public static StringComparison FullTextSearch => StringComparison.OrdinalIgnoreCase;
 }

--- a/tests/Aspire.Cli.Tests/Commands/LogsCommandTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/LogsCommandTests.cs
@@ -1031,6 +1031,65 @@ public class LogsCommandTests(ITestOutputHelper outputHelper)
         return services.BuildServiceProvider();
     }
 
+    [Fact]
+    public async Task LogsCommand_WithSearchOption_FiltersLogsByContent()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        var outputWriter = new TestOutputTextWriter(outputHelper);
+
+        using var provider = CreateLogsTestServices(workspace, outputWriter, disableAnsi: true,
+            logLines:
+            [
+                new ResourceLogLine { ResourceName = "redis", LineNumber = 1, Content = "Ready to accept connections", IsError = false },
+                new ResourceLogLine { ResourceName = "redis", LineNumber = 2, Content = "Connection timeout error", IsError = true },
+                new ResourceLogLine { ResourceName = "redis", LineNumber = 3, Content = "Client connected from 127.0.0.1", IsError = false }
+            ]);
+
+        var command = provider.GetRequiredService<RootCommand>();
+        var result = command.Parse("logs redis --search timeout --format json");
+
+        var exitCode = await result.InvokeAsync().DefaultTimeout();
+
+        Assert.Equal(ExitCodeConstants.Success, exitCode);
+
+        var jsonOutput = outputWriter.Logs.FirstOrDefault(l => l.Contains("\"logs\""));
+        Assert.NotNull(jsonOutput);
+
+        var logsOutput = JsonSerializer.Deserialize(jsonOutput, LogsCommandJsonContext.Snapshot.LogsOutput);
+        Assert.NotNull(logsOutput);
+
+        // Only the log containing "timeout" should be returned
+        Assert.Single(logsOutput.Logs);
+        Assert.Contains("timeout", logsOutput.Logs[0].Content, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public async Task LogsCommand_WithSearchOption_NoMatch_ReturnsEmptyLogs()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        var outputWriter = new TestOutputTextWriter(outputHelper);
+
+        using var provider = CreateLogsTestServices(workspace, outputWriter, disableAnsi: true,
+            logLines:
+            [
+                new ResourceLogLine { ResourceName = "redis", LineNumber = 1, Content = "Ready to accept connections", IsError = false }
+            ]);
+
+        var command = provider.GetRequiredService<RootCommand>();
+        var result = command.Parse("logs redis --search nonexistent --format json");
+
+        var exitCode = await result.InvokeAsync().DefaultTimeout();
+
+        Assert.Equal(ExitCodeConstants.Success, exitCode);
+
+        var jsonOutput = outputWriter.Logs.FirstOrDefault(l => l.Contains("\"logs\""));
+        Assert.NotNull(jsonOutput);
+
+        var logsOutput = JsonSerializer.Deserialize(jsonOutput, LogsCommandJsonContext.Snapshot.LogsOutput);
+        Assert.NotNull(logsOutput);
+        Assert.Empty(logsOutput.Logs);
+    }
+
     private ServiceProvider CreateLogsTestServices(
         TemporaryWorkspace workspace,
         TestOutputTextWriter outputWriter,

--- a/tests/Aspire.Cli.Tests/Commands/LogsCommandTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/LogsCommandTests.cs
@@ -1090,6 +1090,52 @@ public class LogsCommandTests(ITestOutputHelper outputHelper)
         Assert.Empty(logsOutput.Logs);
     }
 
+    [Fact]
+    public async Task LogsCommand_FollowWithTailAndSearch_FiltersTailOutput()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        var outputWriter = new TestOutputTextWriter(outputHelper);
+
+        using var provider = CreateLogsTestServices(workspace, outputWriter, disableAnsi: true,
+            configureConnection: connection =>
+            {
+                connection.AppHostInfo = CreateAppHostInfo(workspace, Environment.ProcessId);
+                connection.GetResourceLogsHandler = (resourceName, follow, cancellationToken) =>
+                    FollowTailSearchLogsAsync(follow, cancellationToken);
+            });
+
+        var command = provider.GetRequiredService<RootCommand>();
+        var result = command.Parse("logs redis --follow --tail 10 --search timeout");
+
+        var exitCode = await result.InvokeAsync().DefaultTimeout();
+
+        Assert.Equal(ExitCodeConstants.Success, exitCode);
+
+        // The tail output should only contain lines matching the search
+        Assert.DoesNotContain(outputWriter.Logs, l => l.Contains("Ready to accept connections", StringComparison.Ordinal));
+        Assert.Contains(outputWriter.Logs, l => l.Contains("Connection timeout error", StringComparison.Ordinal));
+        Assert.DoesNotContain(outputWriter.Logs, l => l.Contains("Client connected", StringComparison.Ordinal));
+    }
+
+    private static async IAsyncEnumerable<ResourceLogLine> FollowTailSearchLogsAsync(
+        bool follow,
+        [EnumeratorCancellation] CancellationToken cancellationToken = default)
+    {
+        if (!follow)
+        {
+            // Non-follow: return the initial set of logs (used for --tail)
+            yield return new ResourceLogLine { ResourceName = "redis", LineNumber = 1, Content = "Ready to accept connections", IsError = false };
+            yield return new ResourceLogLine { ResourceName = "redis", LineNumber = 2, Content = "Connection timeout error", IsError = true };
+            yield return new ResourceLogLine { ResourceName = "redis", LineNumber = 3, Content = "Client connected from 127.0.0.1", IsError = false };
+            yield break;
+        }
+
+        // Follow: simulate the stream ending via disposal (no new logs)
+        await Task.Yield();
+        cancellationToken.ThrowIfCancellationRequested();
+        throw new ObjectDisposedException("StreamJsonRpc.JsonRpc");
+    }
+
     private ServiceProvider CreateLogsTestServices(
         TemporaryWorkspace workspace,
         TestOutputTextWriter outputWriter,

--- a/tests/Aspire.Cli.Tests/Commands/TelemetryLogsCommandTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/TelemetryLogsCommandTests.cs
@@ -667,4 +667,52 @@ public class TelemetryLogsCommandTests(ITestOutputHelper outputHelper)
 
         Assert.Equal(expected, formattedJson, ignoreLineEndingDifferences: true);
     }
+
+    [Fact]
+    public async Task TelemetryLogsCommand_WithSearchOption_PassesSearchToUrl()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        var outputWriter = new TestOutputTextWriter(outputHelper);
+        string? capturedUrl = null;
+
+        var handler = new MockHttpMessageHandler(request =>
+        {
+            var url = request.RequestUri!.ToString();
+            if (url.Contains("/api/telemetry/resources"))
+            {
+                return new HttpResponseMessage(HttpStatusCode.OK)
+                {
+                    Content = new StringContent("[]", System.Text.Encoding.UTF8, "application/json")
+                };
+            }
+            if (url.Contains("/api/telemetry/logs"))
+            {
+                capturedUrl = url;
+                var json = BuildLogsJson(("redis", null, 9, "Information", "Connection timeout", s_testTime));
+                return new HttpResponseMessage(HttpStatusCode.OK)
+                {
+                    Content = new StringContent(json, System.Text.Encoding.UTF8, "application/json")
+                };
+            }
+            return new HttpResponseMessage(HttpStatusCode.NotFound);
+        });
+
+        var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper, options =>
+        {
+            options.OutputTextWriter = outputWriter;
+            options.DisableAnsi = true;
+        });
+        services.AddSingleton(handler);
+        services.Replace(ServiceDescriptor.Singleton<IHttpClientFactory>(new MockHttpClientFactory(handler)));
+
+        using var provider = services.BuildServiceProvider();
+        var command = provider.GetRequiredService<RootCommand>();
+        var result = command.Parse("otel logs --dashboard-url http://localhost:18888 --search timeout");
+
+        var exitCode = await result.InvokeAsync().DefaultTimeout();
+
+        Assert.Equal(ExitCodeConstants.Success, exitCode);
+        Assert.NotNull(capturedUrl);
+        Assert.Contains("search=timeout", capturedUrl);
+    }
 }

--- a/tests/Aspire.Cli.Tests/Commands/TelemetrySpansCommandTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/TelemetrySpansCommandTests.cs
@@ -406,4 +406,52 @@ public class TelemetrySpansCommandTests(ITestOutputHelper outputHelper)
 
         Assert.Equal(expected, formattedJson, ignoreLineEndingDifferences: true);
     }
+
+    [Fact]
+    public async Task TelemetrySpansCommand_WithSearchOption_PassesSearchToUrl()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        var outputWriter = new TestOutputTextWriter(outputHelper);
+        string? capturedUrl = null;
+
+        var handler = new MockHttpMessageHandler(request =>
+        {
+            var url = request.RequestUri!.ToString();
+            if (url.Contains("/api/telemetry/resources"))
+            {
+                return new HttpResponseMessage(HttpStatusCode.OK)
+                {
+                    Content = new StringContent("[]", System.Text.Encoding.UTF8, "application/json")
+                };
+            }
+            if (url.Contains("/api/telemetry/spans"))
+            {
+                capturedUrl = url;
+                var json = BuildSpansJson(("frontend", null, "span001", "GET /index", s_testTime, s_testTime.AddMilliseconds(50), false));
+                return new HttpResponseMessage(HttpStatusCode.OK)
+                {
+                    Content = new StringContent(json, System.Text.Encoding.UTF8, "application/json")
+                };
+            }
+            return new HttpResponseMessage(HttpStatusCode.NotFound);
+        });
+
+        var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper, options =>
+        {
+            options.OutputTextWriter = outputWriter;
+            options.DisableAnsi = true;
+        });
+        services.AddSingleton(handler);
+        services.Replace(ServiceDescriptor.Singleton<IHttpClientFactory>(new MockHttpClientFactory(handler)));
+
+        using var provider = services.BuildServiceProvider();
+        var command = provider.GetRequiredService<RootCommand>();
+        var result = command.Parse("otel spans --dashboard-url http://localhost:18888 --search \"GET /index\"");
+
+        var exitCode = await result.InvokeAsync().DefaultTimeout();
+
+        Assert.Equal(ExitCodeConstants.Success, exitCode);
+        Assert.NotNull(capturedUrl);
+        Assert.Contains("search=", capturedUrl);
+    }
 }

--- a/tests/Aspire.Cli.Tests/Commands/TelemetryTracesCommandTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/TelemetryTracesCommandTests.cs
@@ -475,4 +475,52 @@ public class TelemetryTracesCommandTests(ITestOutputHelper outputHelper)
         var jsonLine = outputWriter.Logs.Single(l => l.TrimStart().StartsWith('['));
         Assert.Equal("[]", jsonLine);
     }
+
+    [Fact]
+    public async Task TelemetryTracesCommand_WithSearchOption_PassesSearchToUrl()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        var outputWriter = new TestOutputTextWriter(outputHelper);
+        string? capturedUrl = null;
+
+        var handler = new MockHttpMessageHandler(request =>
+        {
+            var url = request.RequestUri!.ToString();
+            if (url.Contains("/api/telemetry/resources"))
+            {
+                return new HttpResponseMessage(HttpStatusCode.OK)
+                {
+                    Content = new StringContent("[]", System.Text.Encoding.UTF8, "application/json")
+                };
+            }
+            if (url.Contains("/api/telemetry/traces"))
+            {
+                capturedUrl = url;
+                var json = BuildTracesJson(("abc1234567890def", "frontend", null, "span001", s_testTime, s_testTime.AddMilliseconds(50), false));
+                return new HttpResponseMessage(HttpStatusCode.OK)
+                {
+                    Content = new StringContent(json, System.Text.Encoding.UTF8, "application/json")
+                };
+            }
+            return new HttpResponseMessage(HttpStatusCode.NotFound);
+        });
+
+        var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper, options =>
+        {
+            options.OutputTextWriter = outputWriter;
+            options.DisableAnsi = true;
+        });
+        services.AddSingleton(handler);
+        services.Replace(ServiceDescriptor.Singleton<IHttpClientFactory>(new MockHttpClientFactory(handler)));
+
+        using var provider = services.BuildServiceProvider();
+        var command = provider.GetRequiredService<RootCommand>();
+        var result = command.Parse("otel traces --dashboard-url http://localhost:18888 --search frontend");
+
+        var exitCode = await result.InvokeAsync().DefaultTimeout();
+
+        Assert.Equal(ExitCodeConstants.Success, exitCode);
+        Assert.NotNull(capturedUrl);
+        Assert.Contains("search=frontend", capturedUrl);
+    }
 }

--- a/tests/Aspire.Cli.Tests/Mcp/ListConsoleLogsToolTests.cs
+++ b/tests/Aspire.Cli.Tests/Mcp/ListConsoleLogsToolTests.cs
@@ -299,6 +299,78 @@ public class ListConsoleLogsToolTests
         Assert.Equal("", codeBlockContent);
     }
 
+    [Fact]
+    public async Task ListConsoleLogsTool_WithSearch_TotalLogsCountReflectsUnfilteredCount()
+    {
+        var monitor = new TestAuxiliaryBackchannelMonitor();
+        var connection = new TestAppHostAuxiliaryBackchannel
+        {
+            LogLines =
+            [
+                new ResourceLogLine { ResourceName = "api-service", LineNumber = 1, Content = "Starting application...", IsError = false },
+                new ResourceLogLine { ResourceName = "api-service", LineNumber = 2, Content = "Connection established", IsError = false },
+                new ResourceLogLine { ResourceName = "api-service", LineNumber = 3, Content = "Request received", IsError = false },
+                new ResourceLogLine { ResourceName = "api-service", LineNumber = 4, Content = "Connection closed", IsError = false }
+            ]
+        };
+        monitor.AddConnection("hash1", "socket.hash1", connection);
+
+        var tool = new ListConsoleLogsTool(monitor, NullLogger<ListConsoleLogsTool>.Instance);
+
+        var arguments = new Dictionary<string, JsonElement>
+        {
+            ["resourceName"] = JsonDocument.Parse("\"api-service\"").RootElement,
+            ["search"] = JsonDocument.Parse("\"Connection\"").RootElement
+        };
+
+        var result = await tool.CallToolAsync(CallToolContextTestHelper.Create(arguments), CancellationToken.None).DefaultTimeout();
+
+        Assert.True(result.IsError is null or false);
+        var textContent = result.Content![0] as ModelContextProtocol.Protocol.TextContentBlock;
+        Assert.NotNull(textContent);
+
+        // With search applied, totalLogsCount reflects matching entries (2), not the
+        // last LineNumber (4). Since all matching entries fit within the limit, the summary
+        // should say "Returned 2 console logs."
+        Assert.Contains("Returned 2 console logs.", textContent.Text);
+    }
+
+    [Fact]
+    public async Task ListConsoleLogsTool_WithNonStringSearchValue_IgnoresSearch()
+    {
+        var monitor = new TestAuxiliaryBackchannelMonitor();
+        var connection = new TestAppHostAuxiliaryBackchannel
+        {
+            LogLines =
+            [
+                new ResourceLogLine { ResourceName = "api-service", LineNumber = 1, Content = "Hello world", IsError = false },
+                new ResourceLogLine { ResourceName = "api-service", LineNumber = 2, Content = "Goodbye world", IsError = false }
+            ]
+        };
+        monitor.AddConnection("hash1", "socket.hash1", connection);
+
+        var tool = new ListConsoleLogsTool(monitor, NullLogger<ListConsoleLogsTool>.Instance);
+
+        // Pass a numeric value for search instead of a string
+        var arguments = new Dictionary<string, JsonElement>
+        {
+            ["resourceName"] = JsonDocument.Parse("\"api-service\"").RootElement,
+            ["search"] = JsonDocument.Parse("42").RootElement
+        };
+
+        var result = await tool.CallToolAsync(CallToolContextTestHelper.Create(arguments), CancellationToken.None).DefaultTimeout();
+
+        // Should not throw - search is ignored when ValueKind is not String
+        Assert.True(result.IsError is null or false);
+        var textContent = result.Content![0] as ModelContextProtocol.Protocol.TextContentBlock;
+        Assert.NotNull(textContent);
+
+        // All logs should be returned since search was not applied
+        var codeBlockContent = ExtractCodeBlockContent(textContent.Text);
+        Assert.Contains("Hello world", codeBlockContent);
+        Assert.Contains("Goodbye world", codeBlockContent);
+    }
+
     private static string ExtractCodeBlockContent(string text)
     {
         var match = Regex.Match(text, @"```plaintext\s*(.*?)\s*```", RegexOptions.Singleline);

--- a/tests/Aspire.Cli.Tests/Mcp/ListConsoleLogsToolTests.cs
+++ b/tests/Aspire.Cli.Tests/Mcp/ListConsoleLogsToolTests.cs
@@ -200,6 +200,105 @@ public class ListConsoleLogsToolTests
         Assert.Equal("Green text normal text", codeBlockContent);
     }
 
+    [Fact]
+    public async Task ListConsoleLogsTool_WithSearch_FiltersLogsByContent()
+    {
+        var monitor = new TestAuxiliaryBackchannelMonitor();
+        var connection = new TestAppHostAuxiliaryBackchannel
+        {
+            LogLines =
+            [
+                new ResourceLogLine { ResourceName = "api-service", LineNumber = 1, Content = "Starting application...", IsError = false },
+                new ResourceLogLine { ResourceName = "api-service", LineNumber = 2, Content = "Connection established", IsError = false },
+                new ResourceLogLine { ResourceName = "api-service", LineNumber = 3, Content = "Request received", IsError = false }
+            ]
+        };
+        monitor.AddConnection("hash1", "socket.hash1", connection);
+
+        var tool = new ListConsoleLogsTool(monitor, NullLogger<ListConsoleLogsTool>.Instance);
+
+        var arguments = new Dictionary<string, JsonElement>
+        {
+            ["resourceName"] = JsonDocument.Parse("\"api-service\"").RootElement,
+            ["search"] = JsonDocument.Parse("\"Connection\"").RootElement
+        };
+
+        var result = await tool.CallToolAsync(CallToolContextTestHelper.Create(arguments), CancellationToken.None).DefaultTimeout();
+
+        Assert.True(result.IsError is null or false);
+        var textContent = result.Content![0] as ModelContextProtocol.Protocol.TextContentBlock;
+        Assert.NotNull(textContent);
+
+        var codeBlockContent = ExtractCodeBlockContent(textContent.Text);
+        Assert.Contains("Connection established", codeBlockContent);
+        Assert.DoesNotContain("Starting application", codeBlockContent);
+        Assert.DoesNotContain("Request received", codeBlockContent);
+    }
+
+    [Fact]
+    public async Task ListConsoleLogsTool_WithSearch_IsCaseInsensitive()
+    {
+        var monitor = new TestAuxiliaryBackchannelMonitor();
+        var connection = new TestAppHostAuxiliaryBackchannel
+        {
+            LogLines =
+            [
+                new ResourceLogLine { ResourceName = "api-service", LineNumber = 1, Content = "ERROR: Something failed", IsError = true },
+                new ResourceLogLine { ResourceName = "api-service", LineNumber = 2, Content = "Normal operation", IsError = false }
+            ]
+        };
+        monitor.AddConnection("hash1", "socket.hash1", connection);
+
+        var tool = new ListConsoleLogsTool(monitor, NullLogger<ListConsoleLogsTool>.Instance);
+
+        var arguments = new Dictionary<string, JsonElement>
+        {
+            ["resourceName"] = JsonDocument.Parse("\"api-service\"").RootElement,
+            ["search"] = JsonDocument.Parse("\"error\"").RootElement
+        };
+
+        var result = await tool.CallToolAsync(CallToolContextTestHelper.Create(arguments), CancellationToken.None).DefaultTimeout();
+
+        Assert.True(result.IsError is null or false);
+        var textContent = result.Content![0] as ModelContextProtocol.Protocol.TextContentBlock;
+        Assert.NotNull(textContent);
+
+        var codeBlockContent = ExtractCodeBlockContent(textContent.Text);
+        Assert.Contains("Something failed", codeBlockContent);
+        Assert.DoesNotContain("Normal operation", codeBlockContent);
+    }
+
+    [Fact]
+    public async Task ListConsoleLogsTool_WithSearch_NoMatch_ReturnsEmpty()
+    {
+        var monitor = new TestAuxiliaryBackchannelMonitor();
+        var connection = new TestAppHostAuxiliaryBackchannel
+        {
+            LogLines =
+            [
+                new ResourceLogLine { ResourceName = "api-service", LineNumber = 1, Content = "Hello world", IsError = false }
+            ]
+        };
+        monitor.AddConnection("hash1", "socket.hash1", connection);
+
+        var tool = new ListConsoleLogsTool(monitor, NullLogger<ListConsoleLogsTool>.Instance);
+
+        var arguments = new Dictionary<string, JsonElement>
+        {
+            ["resourceName"] = JsonDocument.Parse("\"api-service\"").RootElement,
+            ["search"] = JsonDocument.Parse("\"nonexistent\"").RootElement
+        };
+
+        var result = await tool.CallToolAsync(CallToolContextTestHelper.Create(arguments), CancellationToken.None).DefaultTimeout();
+
+        Assert.True(result.IsError is null or false);
+        var textContent = result.Content![0] as ModelContextProtocol.Protocol.TextContentBlock;
+        Assert.NotNull(textContent);
+
+        var codeBlockContent = ExtractCodeBlockContent(textContent.Text);
+        Assert.Equal("", codeBlockContent);
+    }
+
     private static string ExtractCodeBlockContent(string text)
     {
         var match = Regex.Match(text, @"```plaintext\s*(.*?)\s*```", RegexOptions.Singleline);

--- a/tests/Aspire.Cli.Tests/Mcp/ListConsoleLogsToolTests.cs
+++ b/tests/Aspire.Cli.Tests/Mcp/ListConsoleLogsToolTests.cs
@@ -300,7 +300,7 @@ public class ListConsoleLogsToolTests
     }
 
     [Fact]
-    public async Task ListConsoleLogsTool_WithSearch_TotalLogsCountReflectsUnfilteredCount()
+    public async Task ListConsoleLogsTool_WithSearch_ReturnsSummaryWithFilteredCount()
     {
         var monitor = new TestAuxiliaryBackchannelMonitor();
         var connection = new TestAppHostAuxiliaryBackchannel

--- a/tests/Aspire.Cli.Tests/Mcp/ListStructuredLogsToolTests.cs
+++ b/tests/Aspire.Cli.Tests/Mcp/ListStructuredLogsToolTests.cs
@@ -418,4 +418,70 @@ public class ListStructuredLogsToolTests
         monitor.AddConnection("hash1", "socket.hash1", connection);
         return monitor;
     }
+
+    [Fact]
+    public async Task ListStructuredLogsTool_WithSearch_PassesSearchToUrl()
+    {
+        var resources = new ResourceInfoJson[]
+        {
+            new() { Name = "api-service", InstanceId = null, HasLogs = true, HasTraces = true, HasMetrics = true }
+        };
+        var resourcesResponse = JsonSerializer.Serialize(resources, OtlpJsonSerializerContext.Default.ResourceInfoJsonArray);
+
+        var apiResponseObj = new TelemetryApiResponse
+        {
+            Data = new OtlpTelemetryDataJson { ResourceLogs = [] },
+            TotalCount = 0,
+            ReturnedCount = 0
+        };
+        var apiResponse = JsonSerializer.Serialize(apiResponseObj, OtlpJsonSerializerContext.Default.TelemetryApiResponse);
+
+        string? capturedUrl = null;
+        using var mockHandler = new MockHttpMessageHandler(request =>
+        {
+            var url = request.RequestUri!.ToString();
+            if (request.RequestUri?.AbsolutePath.Contains("/resources") == true)
+            {
+                return new HttpResponseMessage(HttpStatusCode.OK)
+                {
+                    Content = new StringContent(resourcesResponse, System.Text.Encoding.UTF8, "application/json")
+                };
+            }
+
+            capturedUrl = url;
+            return new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent(apiResponse, System.Text.Encoding.UTF8, "application/json")
+            };
+        });
+        var mockHttpClientFactory = new MockHttpClientFactory(mockHandler);
+
+        var monitor = CreateMonitorWithDashboard();
+        var tool = CreateTool(monitor, mockHttpClientFactory);
+
+        var arguments = new Dictionary<string, JsonElement>
+        {
+            ["search"] = JsonDocument.Parse("\"timeout error\"").RootElement
+        };
+
+        var result = await tool.CallToolAsync(CallToolContextTestHelper.Create(arguments), CancellationToken.None).DefaultTimeout();
+
+        Assert.True(result.IsError is null or false);
+        Assert.NotNull(capturedUrl);
+        Assert.Contains("search=timeout", capturedUrl);
+    }
+
+    [Fact]
+    public void ListStructuredLogsTool_InputSchema_HasSearchProperty()
+    {
+        var tool = CreateTool();
+
+        var schema = tool.GetInputSchema();
+
+        Assert.Equal(JsonValueKind.Object, schema.ValueKind);
+        Assert.True(schema.TryGetProperty("properties", out var properties));
+        Assert.True(properties.TryGetProperty("search", out var search));
+        Assert.True(search.TryGetProperty("type", out var type));
+        Assert.Equal("string", type.GetString());
+    }
 }

--- a/tests/Aspire.Cli.Tests/Mcp/ListTracesToolTests.cs
+++ b/tests/Aspire.Cli.Tests/Mcp/ListTracesToolTests.cs
@@ -460,4 +460,70 @@ public class ListTracesToolTests
         monitor.AddConnection("hash1", "socket.hash1", connection);
         return monitor;
     }
+
+    [Fact]
+    public async Task ListTracesTool_WithSearch_PassesSearchToUrl()
+    {
+        var resources = new ResourceInfoJson[]
+        {
+            new() { Name = "api-service", InstanceId = null, HasLogs = true, HasTraces = true, HasMetrics = true }
+        };
+        var resourcesResponse = JsonSerializer.Serialize(resources, OtlpJsonSerializerContext.Default.ResourceInfoJsonArray);
+
+        var apiResponseObj = new TelemetryApiResponse
+        {
+            Data = new OtlpTelemetryDataJson { ResourceSpans = [] },
+            TotalCount = 0,
+            ReturnedCount = 0
+        };
+        var apiResponse = JsonSerializer.Serialize(apiResponseObj, OtlpJsonSerializerContext.Default.TelemetryApiResponse);
+
+        string? capturedUrl = null;
+        using var mockHandler = new MockHttpMessageHandler(request =>
+        {
+            var url = request.RequestUri!.ToString();
+            if (request.RequestUri?.AbsolutePath.Contains("/resources") == true)
+            {
+                return new HttpResponseMessage(HttpStatusCode.OK)
+                {
+                    Content = new StringContent(resourcesResponse, System.Text.Encoding.UTF8, "application/json")
+                };
+            }
+
+            capturedUrl = url;
+            return new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent(apiResponse, System.Text.Encoding.UTF8, "application/json")
+            };
+        });
+        var mockHttpClientFactory = new MockHttpClientFactory(mockHandler);
+
+        var monitor = CreateMonitorWithDashboard();
+        var tool = CreateTool(monitor, mockHttpClientFactory);
+
+        var arguments = new Dictionary<string, JsonElement>
+        {
+            ["search"] = JsonDocument.Parse("\"GET /api\"").RootElement
+        };
+
+        var result = await tool.CallToolAsync(CallToolContextTestHelper.Create(arguments), CancellationToken.None).DefaultTimeout();
+
+        Assert.True(result.IsError is null or false);
+        Assert.NotNull(capturedUrl);
+        Assert.Contains("search=", capturedUrl);
+    }
+
+    [Fact]
+    public void ListTracesTool_InputSchema_HasSearchProperty()
+    {
+        var tool = CreateTool();
+
+        var schema = tool.GetInputSchema();
+
+        Assert.Equal(JsonValueKind.Object, schema.ValueKind);
+        Assert.True(schema.TryGetProperty("properties", out var properties));
+        Assert.True(properties.TryGetProperty("search", out var search));
+        Assert.True(search.TryGetProperty("type", out var type));
+        Assert.Equal("string", type.GetString());
+    }
 }

--- a/tests/Aspire.Dashboard.Tests/DashboardUrlsTests.cs
+++ b/tests/Aspire.Dashboard.Tests/DashboardUrlsTests.cs
@@ -82,4 +82,46 @@ public class DashboardUrlsTests
     {
         Assert.Equal("/api/set-language?language=fr-FR&redirectUrl=%2Fhi", DashboardUrls.SetLanguageUrl("fr-FR", "/hi"));
     }
+
+    [Fact]
+    public void TelemetryLogsApiUrl_WithSearch_AppendsSearchQueryParameter()
+    {
+        var url = DashboardUrls.TelemetryLogsApiUrl("http://localhost:18888", search: "connection error");
+
+        Assert.Contains("search=connection%20error", url);
+    }
+
+    [Fact]
+    public void TelemetryLogsApiUrl_WithoutSearch_DoesNotAppendSearchParameter()
+    {
+        var url = DashboardUrls.TelemetryLogsApiUrl("http://localhost:18888");
+
+        Assert.DoesNotContain("search", url);
+    }
+
+    [Fact]
+    public void TelemetrySpansApiUrl_WithSearch_AppendsSearchQueryParameter()
+    {
+        var url = DashboardUrls.TelemetrySpansApiUrl("http://localhost:18888", search: "GET /api");
+
+        Assert.Contains("search=GET%20%2Fapi", url);
+    }
+
+    [Fact]
+    public void TelemetryTracesApiUrl_WithSearch_AppendsSearchQueryParameter()
+    {
+        var url = DashboardUrls.TelemetryTracesApiUrl("http://localhost:18888", search: "timeout");
+
+        Assert.Contains("search=timeout", url);
+    }
+
+    [Fact]
+    public void TelemetryLogsApiUrl_WithSearchAndOtherParams_AppendsAllParameters()
+    {
+        var url = DashboardUrls.TelemetryLogsApiUrl("http://localhost:18888", resources: ["service1"], severity: "error", search: "failed");
+
+        Assert.Contains("resource=service1", url);
+        Assert.Contains("severity=error", url);
+        Assert.Contains("search=failed", url);
+    }
 }

--- a/tests/Aspire.Dashboard.Tests/TelemetryApiServiceTests.cs
+++ b/tests/Aspire.Dashboard.Tests/TelemetryApiServiceTests.cs
@@ -286,16 +286,15 @@ public class TelemetryApiServiceTests
     public void GetLogs_WithSearch_IsCaseInsensitive()
     {
         var repository = CreateRepository();
-        AddLogs(repository, ["ERROR occurred"], severity: SeverityNumber.Error);
+        AddLogs(repository, ["UPPERCASE warning detected"]);
         AddLogs(repository, ["Normal log"]);
 
         var service = CreateService(repository);
 
-        var result = service.GetLogs(resourceNames: null, traceId: null, severity: null, limit: null, search: "error");
+        var result = service.GetLogs(resourceNames: null, traceId: null, severity: null, limit: null, search: "uppercase warning");
 
         Assert.NotNull(result);
-        // Matches "ERROR occurred" message (case-insensitive) and potentially the severity field
-        Assert.True(result.ReturnedCount >= 1);
+        Assert.Equal(1, result.ReturnedCount);
     }
 
     [Fact]

--- a/tests/Aspire.Dashboard.Tests/TelemetryApiServiceTests.cs
+++ b/tests/Aspire.Dashboard.Tests/TelemetryApiServiceTests.cs
@@ -21,38 +21,14 @@ public class TelemetryApiServiceTests
     [Fact]
     public async Task FollowSpansAsync_StreamsAllSpans()
     {
-        // Arrange
         var repository = CreateRepository();
-
-        // Add 5 spans
-        for (var i = 1; i <= 5; i++)
-        {
-            repository.AddTraces(new AddContext(), new RepeatedField<ResourceSpans>
-            {
-                new ResourceSpans
-                {
-                    Resource = CreateResource(name: "service1", instanceId: "inst1"),
-                    ScopeSpans =
-                    {
-                        new ScopeSpans
-                        {
-                            Scope = CreateScope(),
-                            Spans =
-                            {
-                                CreateSpan(traceId: $"trace{i}", spanId: $"span{i}", startTime: s_testTime.AddMinutes(i), endTime: s_testTime.AddMinutes(i + 1))
-                            }
-                        }
-                    }
-                }
-            });
-        }
+        AddSpans(repository, count: 5);
 
         var service = CreateService(repository);
         using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
 
-        // Act - stream spans
         var receivedItems = new List<string>();
-        await foreach (var item in service.FollowSpansAsync(null, null, null, cts.Token))
+        await foreach (var item in service.FollowSpansAsync(null, null, null, null, cts.Token))
         {
             receivedItems.Add(item);
             if (receivedItems.Count >= 5)
@@ -61,45 +37,20 @@ public class TelemetryApiServiceTests
             }
         }
 
-        // Assert - should receive all 5 items
         Assert.Equal(5, receivedItems.Count);
     }
 
     [Fact]
     public async Task FollowLogsAsync_StreamsAllLogs()
     {
-        // Arrange
         var repository = CreateRepository();
-
-        // Add 5 logs
-        for (var i = 1; i <= 5; i++)
-        {
-            repository.AddLogs(new AddContext(), new RepeatedField<ResourceLogs>
-            {
-                new ResourceLogs
-                {
-                    Resource = CreateResource(name: "service1", instanceId: "inst1"),
-                    ScopeLogs =
-                    {
-                        new ScopeLogs
-                        {
-                            Scope = CreateScope("TestLogger"),
-                            LogRecords =
-                            {
-                                CreateLogRecord(time: s_testTime.AddMinutes(i), message: $"log{i}", severity: SeverityNumber.Info)
-                            }
-                        }
-                    }
-                }
-            });
-        }
+        AddLogs(repository, ["log1", "log2", "log3", "log4", "log5"]);
 
         var service = CreateService(repository);
         using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
 
-        // Act - stream logs
         var receivedItems = new List<string>();
-        await foreach (var item in service.FollowLogsAsync(null, null, null, cts.Token))
+        await foreach (var item in service.FollowLogsAsync(null, null, null, null, cts.Token))
         {
             receivedItems.Add(item);
             if (receivedItems.Count >= 5)
@@ -108,208 +59,44 @@ public class TelemetryApiServiceTests
             }
         }
 
-        // Assert - should receive all 5 items
         Assert.Equal(5, receivedItems.Count);
     }
 
-    [Fact]
-    public void GetSpans_HasErrorFalse_ExcludesErrorSpans()
+    [Theory]
+    [InlineData(false, "ok-span", "error-span")]
+    [InlineData(true, "error-span", "ok-span")]
+    public void GetSpans_HasErrorFilter_ReturnsExpectedSpans(bool hasError, string expectedSpan, string excludedSpan)
     {
-        // Arrange
         var repository = CreateRepository();
-
-        // Add spans - one with error, one without
-        repository.AddTraces(new AddContext(), new RepeatedField<ResourceSpans>
-        {
-            new ResourceSpans
-            {
-                Resource = CreateResource(name: "service1", instanceId: "inst1"),
-                ScopeSpans =
-                {
-                    new ScopeSpans
-                    {
-                        Scope = CreateScope(),
-                        Spans =
-                        {
-                            CreateSpan(traceId: "trace1", spanId: "ok-span", startTime: s_testTime, endTime: s_testTime.AddMinutes(1), status: new Status { Code = Status.Types.StatusCode.Ok }),
-                            CreateSpan(traceId: "trace2", spanId: "error-span", startTime: s_testTime.AddMinutes(2), endTime: s_testTime.AddMinutes(3), status: new Status { Code = Status.Types.StatusCode.Error })
-                        }
-                    }
-                }
-            }
-        });
+        AddSpansWithStatus(repository);
 
         var service = CreateService(repository);
 
-        // Act - get spans with hasError=false
-        var result = service.GetSpans(resourceNames: null, traceId: null, hasError: false, limit: null);
+        var result = service.GetSpans(resourceNames: null, traceId: null, hasError: hasError, limit: null);
 
-        // Assert - should only return the non-error span
         Assert.NotNull(result);
         Assert.Equal(1, result.ReturnedCount);
-        
-        // Serialize to check content
+
         var json = System.Text.Json.JsonSerializer.Serialize(result.Data);
-        Assert.DoesNotContain("error-span", json);
-        Assert.Contains("ok-span", json);
+        Assert.Contains(expectedSpan, json);
+        Assert.DoesNotContain(excludedSpan, json);
     }
 
-    [Fact]
-    public void GetSpans_HasErrorTrue_OnlyReturnsErrorSpans()
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public void GetTraces_HasErrorFilter_ReturnsExpectedTraces(bool hasError)
     {
-        // Arrange
         var repository = CreateRepository();
-
-        // Add spans - one with error, one without
-        repository.AddTraces(new AddContext(), new RepeatedField<ResourceSpans>
-        {
-            new ResourceSpans
-            {
-                Resource = CreateResource(name: "service1", instanceId: "inst1"),
-                ScopeSpans =
-                {
-                    new ScopeSpans
-                    {
-                        Scope = CreateScope(),
-                        Spans =
-                        {
-                            CreateSpan(traceId: "trace1", spanId: "ok-span", startTime: s_testTime, endTime: s_testTime.AddMinutes(1), status: new Status { Code = Status.Types.StatusCode.Ok }),
-                            CreateSpan(traceId: "trace2", spanId: "error-span", startTime: s_testTime.AddMinutes(2), endTime: s_testTime.AddMinutes(3), status: new Status { Code = Status.Types.StatusCode.Error })
-                        }
-                    }
-                }
-            }
-        });
+        AddTracesWithStatus(repository);
 
         var service = CreateService(repository);
 
-        // Act - get spans with hasError=true
-        var result = service.GetSpans(resourceNames: null, traceId: null, hasError: true, limit: null);
+        var result = service.GetTraces(resourceNames: null, hasError: hasError, limit: null);
 
-        // Assert - should only return the error span
         Assert.NotNull(result);
         Assert.Equal(1, result.ReturnedCount);
-        
-        var json = System.Text.Json.JsonSerializer.Serialize(result.Data);
-        Assert.Contains("error-span", json);
-        Assert.DoesNotContain("ok-span", json);
-    }
 
-    [Fact]
-    public void GetTraces_HasErrorFalse_ExcludesTracesWithErrors()
-    {
-        // Arrange
-        var repository = CreateRepository();
-
-        // Add two traces - one with error span, one without
-        repository.AddTraces(new AddContext(), new RepeatedField<ResourceSpans>
-        {
-            new ResourceSpans
-            {
-                Resource = CreateResource(name: "service1", instanceId: "inst1"),
-                ScopeSpans =
-                {
-                    new ScopeSpans
-                    {
-                        Scope = CreateScope(),
-                        Spans =
-                        {
-                            CreateSpan(traceId: "ok-trace", spanId: "span1", startTime: s_testTime, endTime: s_testTime.AddMinutes(1), status: new Status { Code = Status.Types.StatusCode.Ok })
-                        }
-                    }
-                }
-            }
-        });
-
-        repository.AddTraces(new AddContext(), new RepeatedField<ResourceSpans>
-        {
-            new ResourceSpans
-            {
-                Resource = CreateResource(name: "service1", instanceId: "inst1"),
-                ScopeSpans =
-                {
-                    new ScopeSpans
-                    {
-                        Scope = CreateScope(),
-                        Spans =
-                        {
-                            CreateSpan(traceId: "error-trace", spanId: "span2", startTime: s_testTime.AddMinutes(2), endTime: s_testTime.AddMinutes(3), status: new Status { Code = Status.Types.StatusCode.Error })
-                        }
-                    }
-                }
-            }
-        });
-
-        var service = CreateService(repository);
-
-        // Act - get traces with hasError=false (no error, should exclude the error trace)
-        var result = service.GetTraces(resourceNames: null, hasError: false, limit: null);
-
-        // Assert - should only return 1 trace (the one without errors)
-        Assert.NotNull(result);
-        Assert.Equal(1, result.ReturnedCount);
-        
-        // Verify with null filter returns both
-        var allResult = service.GetTraces(resourceNames: null, hasError: null, limit: null);
-        Assert.NotNull(allResult);
-        Assert.Equal(2, allResult.ReturnedCount);
-    }
-
-    [Fact]
-    public void GetTraces_HasErrorTrue_OnlyReturnsTracesWithErrors()
-    {
-        // Arrange
-        var repository = CreateRepository();
-
-        // Add two traces - one with error span, one without
-        repository.AddTraces(new AddContext(), new RepeatedField<ResourceSpans>
-        {
-            new ResourceSpans
-            {
-                Resource = CreateResource(name: "service1", instanceId: "inst1"),
-                ScopeSpans =
-                {
-                    new ScopeSpans
-                    {
-                        Scope = CreateScope(),
-                        Spans =
-                        {
-                            CreateSpan(traceId: "ok-trace", spanId: "span1", startTime: s_testTime, endTime: s_testTime.AddMinutes(1), status: new Status { Code = Status.Types.StatusCode.Ok })
-                        }
-                    }
-                }
-            }
-        });
-
-        repository.AddTraces(new AddContext(), new RepeatedField<ResourceSpans>
-        {
-            new ResourceSpans
-            {
-                Resource = CreateResource(name: "service1", instanceId: "inst1"),
-                ScopeSpans =
-                {
-                    new ScopeSpans
-                    {
-                        Scope = CreateScope(),
-                        Spans =
-                        {
-                            CreateSpan(traceId: "error-trace", spanId: "span2", startTime: s_testTime.AddMinutes(2), endTime: s_testTime.AddMinutes(3), status: new Status { Code = Status.Types.StatusCode.Error })
-                        }
-                    }
-                }
-            }
-        });
-
-        var service = CreateService(repository);
-
-        // Act - get traces with hasError=true (error only)
-        var result = service.GetTraces(resourceNames: null, hasError: true, limit: null);
-
-        // Assert - should only return 1 trace (the one with errors)
-        Assert.NotNull(result);
-        Assert.Equal(1, result.ReturnedCount);
-        
-        // Verify with null filter returns both
         var allResult = service.GetTraces(resourceNames: null, hasError: null, limit: null);
         Assert.NotNull(allResult);
         Assert.Equal(2, allResult.ReturnedCount);
@@ -318,94 +105,48 @@ public class TelemetryApiServiceTests
     [Fact]
     public async Task FollowSpansAsync_WithInvalidResourceName_ReturnsNoSpans()
     {
-        // Arrange
         var repository = CreateRepository();
-
-        // Add spans for service1
-        repository.AddTraces(new AddContext(), new RepeatedField<ResourceSpans>
-        {
-            new ResourceSpans
-            {
-                Resource = CreateResource(name: "service1", instanceId: "inst1"),
-                ScopeSpans =
-                {
-                    new ScopeSpans
-                    {
-                        Scope = CreateScope(),
-                        Spans =
-                        {
-                            CreateSpan(traceId: "trace1", spanId: "span1", startTime: s_testTime, endTime: s_testTime.AddMinutes(1))
-                        }
-                    }
-                }
-            }
-        });
+        AddSpans(repository, count: 1);
 
         var service = CreateService(repository);
         using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(2));
 
-        // Act - stream spans for a non-existent resource
         var receivedItems = new List<string>();
         try
         {
-            await foreach (var item in service.FollowSpansAsync(["nonexistent-service"], null, null, cts.Token))
+            await foreach (var item in service.FollowSpansAsync(["nonexistent-service"], null, null, null, cts.Token))
             {
                 receivedItems.Add(item);
             }
         }
         catch (OperationCanceledException)
         {
-            // Expected - timeout
         }
 
-        // Assert - should receive NO items because the resource doesn't exist
         Assert.Empty(receivedItems);
     }
 
     [Fact]
     public async Task FollowLogsAsync_WithInvalidResourceName_ReturnsNoLogs()
     {
-        // Arrange
         var repository = CreateRepository();
-
-        // Add logs for service1
-        repository.AddLogs(new AddContext(), new RepeatedField<ResourceLogs>
-        {
-            new ResourceLogs
-            {
-                Resource = CreateResource(name: "service1", instanceId: "inst1"),
-                ScopeLogs =
-                {
-                    new ScopeLogs
-                    {
-                        Scope = CreateScope("TestLogger"),
-                        LogRecords =
-                        {
-                            CreateLogRecord(time: s_testTime, message: "log1", severity: SeverityNumber.Info)
-                        }
-                    }
-                }
-            }
-        });
+        AddLogs(repository, ["log1"]);
 
         var service = CreateService(repository);
         using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(2));
 
-        // Act - stream logs for a non-existent resource
         var receivedItems = new List<string>();
         try
         {
-            await foreach (var item in service.FollowLogsAsync(["nonexistent-service"], null, null, cts.Token))
+            await foreach (var item in service.FollowLogsAsync(["nonexistent-service"], null, null, null, cts.Token))
             {
                 receivedItems.Add(item);
             }
         }
         catch (OperationCanceledException)
         {
-            // Expected - timeout
         }
 
-        // Assert - should receive NO items because the resource doesn't exist
         Assert.Empty(receivedItems);
     }
 
@@ -419,24 +160,9 @@ public class TelemetryApiServiceTests
         var repository = CreateRepository();
         var traceId = Encoding.UTF8.GetString(Convert.FromHexString("747261636531"));
 
-        repository.AddTraces(new AddContext(), new RepeatedField<ResourceSpans>
-        {
-            new ResourceSpans
-            {
-                Resource = CreateResource(name: "service1", instanceId: "inst1"),
-                ScopeSpans =
-                {
-                    new ScopeSpans
-                    {
-                        Scope = CreateScope(),
-                        Spans =
-                        {
-                            CreateSpan(traceId: traceId, spanId: "span1", startTime: s_testTime, endTime: s_testTime.AddMinutes(1))
-                        }
-                    }
-                }
-            }
-        });
+        AddSpansToRepository(repository, [
+            CreateSpan(traceId: traceId, spanId: "span1", startTime: s_testTime, endTime: s_testTime.AddMinutes(1))
+        ]);
 
         var service = CreateService(repository);
 
@@ -457,27 +183,11 @@ public class TelemetryApiServiceTests
     public void GetSpans_WithLimit_ReturnsMostRecentSpans()
     {
         var repository = CreateRepository();
-
-        repository.AddTraces(new AddContext(), new RepeatedField<ResourceSpans>
-        {
-            new ResourceSpans
-            {
-                Resource = CreateResource(name: "service1", instanceId: "inst1"),
-                ScopeSpans =
-                {
-                    new ScopeSpans
-                    {
-                        Scope = CreateScope(),
-                        Spans =
-                        {
-                            CreateSpan(traceId: "trace1", spanId: "old-span", startTime: s_testTime, endTime: s_testTime.AddMinutes(1)),
-                            CreateSpan(traceId: "trace2", spanId: "mid-span", startTime: s_testTime.AddMinutes(2), endTime: s_testTime.AddMinutes(3)),
-                            CreateSpan(traceId: "trace3", spanId: "new-span", startTime: s_testTime.AddMinutes(4), endTime: s_testTime.AddMinutes(5))
-                        }
-                    }
-                }
-            }
-        });
+        AddSpansToRepository(repository, [
+            CreateSpan(traceId: "trace1", spanId: "old-span", startTime: s_testTime, endTime: s_testTime.AddMinutes(1)),
+            CreateSpan(traceId: "trace2", spanId: "mid-span", startTime: s_testTime.AddMinutes(2), endTime: s_testTime.AddMinutes(3)),
+            CreateSpan(traceId: "trace3", spanId: "new-span", startTime: s_testTime.AddMinutes(4), endTime: s_testTime.AddMinutes(5))
+        ]);
 
         var service = CreateService(repository);
 
@@ -497,28 +207,7 @@ public class TelemetryApiServiceTests
     public void GetTraces_WithLimit_ReturnsMostRecentTraces()
     {
         var repository = CreateRepository();
-
-        for (var i = 1; i <= 3; i++)
-        {
-            repository.AddTraces(new AddContext(), new RepeatedField<ResourceSpans>
-            {
-                new ResourceSpans
-                {
-                    Resource = CreateResource(name: "service1", instanceId: "inst1"),
-                    ScopeSpans =
-                    {
-                        new ScopeSpans
-                        {
-                            Scope = CreateScope(),
-                            Spans =
-                            {
-                                CreateSpan(traceId: $"trace{i}", spanId: $"span{i}", startTime: s_testTime.AddMinutes(i * 10), endTime: s_testTime.AddMinutes(i * 10 + 1))
-                            }
-                        }
-                    }
-                }
-            });
-        }
+        AddSpans(repository, count: 3, startMinuteSpacing: 10);
 
         var service = CreateService(repository);
 
@@ -538,27 +227,7 @@ public class TelemetryApiServiceTests
     public void GetLogs_WithLimit_ReturnsMostRecentLogs()
     {
         var repository = CreateRepository();
-
-        repository.AddLogs(new AddContext(), new RepeatedField<ResourceLogs>
-        {
-            new ResourceLogs
-            {
-                Resource = CreateResource(name: "service1", instanceId: "inst1"),
-                ScopeLogs =
-                {
-                    new ScopeLogs
-                    {
-                        Scope = CreateScope("TestLogger"),
-                        LogRecords =
-                        {
-                            CreateLogRecord(time: s_testTime, message: "old-log", severity: SeverityNumber.Info),
-                            CreateLogRecord(time: s_testTime.AddMinutes(1), message: "mid-log", severity: SeverityNumber.Info),
-                            CreateLogRecord(time: s_testTime.AddMinutes(2), message: "new-log", severity: SeverityNumber.Info)
-                        }
-                    }
-                }
-            }
-        });
+        AddLogs(repository, ["old-log", "mid-log", "new-log"]);
 
         var service = CreateService(repository);
 
@@ -586,6 +255,198 @@ public class TelemetryApiServiceTests
             logRecords.Add(CreateLogRecord(time: s_testTime.AddMilliseconds(i), message: $"log{i}", severity: SeverityNumber.Info));
         }
 
+        AddLogsToRepository(repository, logRecords);
+
+        var service = CreateService(repository);
+
+        var result = service.GetLogs(resourceNames: null, traceId: null, severity: null, limit: 100_000);
+
+        Assert.NotNull(result);
+        Assert.Equal(totalLogs, result.TotalCount);
+        Assert.Equal(totalLogs, result.ReturnedCount);
+    }
+
+    [Theory]
+    [InlineData("Connection", 2)]
+    [InlineData("nonexistent", 0)]
+    public void GetLogs_WithSearch_FiltersLogsByMessage(string search, int expectedCount)
+    {
+        var repository = CreateRepository();
+        AddLogs(repository, ["Connection established", "Request received", "Connection closed"]);
+
+        var service = CreateService(repository);
+
+        var result = service.GetLogs(resourceNames: null, traceId: null, severity: null, limit: null, search: search);
+
+        Assert.NotNull(result);
+        Assert.Equal(expectedCount, result.ReturnedCount);
+    }
+
+    [Fact]
+    public void GetLogs_WithSearch_IsCaseInsensitive()
+    {
+        var repository = CreateRepository();
+        AddLogs(repository, ["ERROR occurred"], severity: SeverityNumber.Error);
+        AddLogs(repository, ["Normal log"]);
+
+        var service = CreateService(repository);
+
+        var result = service.GetLogs(resourceNames: null, traceId: null, severity: null, limit: null, search: "error");
+
+        Assert.NotNull(result);
+        // Matches "ERROR occurred" message (case-insensitive) and potentially the severity field
+        Assert.True(result.ReturnedCount >= 1);
+    }
+
+    [Fact]
+    public void GetLogs_WithSearch_MatchesAttributes()
+    {
+        var repository = CreateRepository();
+        AddLogsToRepository(repository, [
+            CreateLogRecord(time: s_testTime, message: "log1", severity: SeverityNumber.Info,
+                attributes: [new KeyValuePair<string, string>("http.url", "/api/products")]),
+            CreateLogRecord(time: s_testTime.AddMinutes(1), message: "log2", severity: SeverityNumber.Info,
+                attributes: [new KeyValuePair<string, string>("http.url", "/api/orders")])
+        ]);
+
+        var service = CreateService(repository);
+
+        var result = service.GetLogs(resourceNames: null, traceId: null, severity: null, limit: null, search: "products");
+
+        Assert.NotNull(result);
+        Assert.Equal(1, result.ReturnedCount);
+    }
+
+    [Theory]
+    [InlineData("span1", 1)]
+    [InlineData("products", 1)]
+    public void GetSpans_WithSearch_FiltersSpans(string search, int expectedCount)
+    {
+        var repository = CreateRepository();
+        AddSpansToRepository(repository, [
+            CreateSpan(traceId: "trace1", spanId: "span1", startTime: s_testTime, endTime: s_testTime.AddMinutes(1),
+                attributes: [new KeyValuePair<string, string>("http.url", "/api/products")]),
+            CreateSpan(traceId: "trace2", spanId: "span2", startTime: s_testTime.AddMinutes(2), endTime: s_testTime.AddMinutes(3),
+                attributes: [new KeyValuePair<string, string>("http.url", "/api/orders")])
+        ]);
+
+        var service = CreateService(repository);
+
+        var result = service.GetSpans(resourceNames: null, traceId: null, hasError: null, limit: null, search: search);
+
+        Assert.NotNull(result);
+        Assert.Equal(expectedCount, result.ReturnedCount);
+    }
+
+    [Theory]
+    [InlineData("span1", 1)]
+    [InlineData("nonexistent-xyz", 0)]
+    public void GetTraces_WithSearch_FiltersTraces(string search, int expectedCount)
+    {
+        var repository = CreateRepository();
+
+        // Each trace needs a separate AddTraces call to get distinct trace IDs in the repository
+        AddSpansToRepository(repository, [
+            CreateSpan(traceId: "trace1", spanId: "span1", startTime: s_testTime, endTime: s_testTime.AddMinutes(1))
+        ]);
+        AddSpansToRepository(repository, [
+            CreateSpan(traceId: "trace2", spanId: "span2", startTime: s_testTime.AddMinutes(10), endTime: s_testTime.AddMinutes(11))
+        ]);
+
+        var service = CreateService(repository);
+
+        var result = service.GetTraces(resourceNames: null, hasError: null, limit: null, search: search);
+
+        Assert.NotNull(result);
+        Assert.Equal(expectedCount, result.ReturnedCount);
+
+        if (expectedCount > 0)
+        {
+            var allResult = service.GetTraces(resourceNames: null, hasError: null, limit: null);
+            Assert.NotNull(allResult);
+            Assert.Equal(2, allResult.ReturnedCount);
+        }
+    }
+
+    /// <summary>
+    /// Adds spans with sequential trace/span IDs to the repository. Each span is added in a separate
+    /// AddTraces call so that it gets its own trace entry.
+    /// </summary>
+    private static void AddSpans(TelemetryRepository repository, int count, int startMinuteSpacing = 1)
+    {
+        for (var i = 1; i <= count; i++)
+        {
+            AddSpansToRepository(repository, [
+                CreateSpan(traceId: $"trace{i}", spanId: $"span{i}", startTime: s_testTime.AddMinutes(i * startMinuteSpacing), endTime: s_testTime.AddMinutes(i * startMinuteSpacing + 1))
+            ]);
+        }
+    }
+
+    /// <summary>
+    /// Adds a batch of spans (as raw Span objects) to the repository under a single resource.
+    /// </summary>
+    private static void AddSpansToRepository(TelemetryRepository repository, IEnumerable<Span> spans)
+    {
+        repository.AddTraces(new AddContext(), new RepeatedField<ResourceSpans>
+        {
+            new ResourceSpans
+            {
+                Resource = CreateResource(name: "service1", instanceId: "inst1"),
+                ScopeSpans =
+                {
+                    new ScopeSpans
+                    {
+                        Scope = CreateScope(),
+                        Spans = { spans }
+                    }
+                }
+            }
+        });
+    }
+
+    /// <summary>
+    /// Adds one OK span and one Error span to the repository for hasError filter tests.
+    /// </summary>
+    private static void AddSpansWithStatus(TelemetryRepository repository)
+    {
+        AddSpansToRepository(repository, [
+            CreateSpan(traceId: "trace1", spanId: "ok-span", startTime: s_testTime, endTime: s_testTime.AddMinutes(1), status: new Status { Code = Status.Types.StatusCode.Ok }),
+            CreateSpan(traceId: "trace2", spanId: "error-span", startTime: s_testTime.AddMinutes(2), endTime: s_testTime.AddMinutes(3), status: new Status { Code = Status.Types.StatusCode.Error })
+        ]);
+    }
+
+    /// <summary>
+    /// Adds two traces (separate trace IDs) with OK and Error status for hasError filter tests.
+    /// </summary>
+    private static void AddTracesWithStatus(TelemetryRepository repository)
+    {
+        AddSpansToRepository(repository, [
+            CreateSpan(traceId: "ok-trace", spanId: "span1", startTime: s_testTime, endTime: s_testTime.AddMinutes(1), status: new Status { Code = Status.Types.StatusCode.Ok })
+        ]);
+        AddSpansToRepository(repository, [
+            CreateSpan(traceId: "error-trace", spanId: "span2", startTime: s_testTime.AddMinutes(2), endTime: s_testTime.AddMinutes(3), status: new Status { Code = Status.Types.StatusCode.Error })
+        ]);
+    }
+
+    /// <summary>
+    /// Adds log entries with the specified messages to the repository.
+    /// </summary>
+    private static void AddLogs(TelemetryRepository repository, string[] messages, SeverityNumber severity = SeverityNumber.Info)
+    {
+        var logRecords = new RepeatedField<LogRecord>();
+        for (var i = 0; i < messages.Length; i++)
+        {
+            logRecords.Add(CreateLogRecord(time: s_testTime.AddMinutes(i), message: messages[i], severity: severity));
+        }
+
+        AddLogsToRepository(repository, logRecords);
+    }
+
+    /// <summary>
+    /// Adds a batch of raw LogRecord objects to the repository under a single resource.
+    /// </summary>
+    private static void AddLogsToRepository(TelemetryRepository repository, RepeatedField<LogRecord> logRecords)
+    {
         repository.AddLogs(new AddContext(), new RepeatedField<ResourceLogs>
         {
             new ResourceLogs
@@ -601,19 +462,8 @@ public class TelemetryApiServiceTests
                 }
             }
         });
-
-        var service = CreateService(repository);
-
-        var result = service.GetLogs(resourceNames: null, traceId: null, severity: null, limit: 100_000);
-
-        Assert.NotNull(result);
-        Assert.Equal(totalLogs, result.TotalCount);
-        Assert.Equal(totalLogs, result.ReturnedCount);
     }
 
-    /// <summary>
-    /// Creates a TelemetryApiService instance for testing with optional custom dependencies.
-    /// </summary>
     private static TelemetryApiService CreateService(
         TelemetryRepository? repository = null,
         IOutgoingPeerResolver[]? peerResolvers = null)

--- a/tests/Aspire.Dashboard.Tests/TelemetryApiServiceTests.cs
+++ b/tests/Aspire.Dashboard.Tests/TelemetryApiServiceTests.cs
@@ -83,9 +83,10 @@ public class TelemetryApiServiceTests
     }
 
     [Theory]
-    [InlineData(false)]
-    [InlineData(true)]
-    public void GetTraces_HasErrorFilter_ReturnsExpectedTraces(bool hasError)
+    [InlineData(false, 1)]
+    [InlineData(true, 1)]
+    [InlineData(null, 2)]
+    public void GetTraces_HasErrorFilter_ReturnsExpectedTraces(bool? hasError, int expectedCount)
     {
         var repository = CreateRepository();
         AddTracesWithStatus(repository);
@@ -95,11 +96,7 @@ public class TelemetryApiServiceTests
         var result = service.GetTraces(resourceNames: null, hasError: hasError, limit: null);
 
         Assert.NotNull(result);
-        Assert.Equal(1, result.ReturnedCount);
-
-        var allResult = service.GetTraces(resourceNames: null, hasError: null, limit: null);
-        Assert.NotNull(allResult);
-        Assert.Equal(2, allResult.ReturnedCount);
+        Assert.Equal(expectedCount, result.ReturnedCount);
     }
 
     [Fact]


### PR DESCRIPTION
## Description

Adds a `--search` option to `aspire logs` and `aspire otel logs/spans/traces` commands, as well as the corresponding MCP tools, enabling full-text search filtering across all telemetry and log data.

Users can now quickly filter logs and telemetry output to find relevant entries without piping through external tools. The search is case-insensitive and matches across all text fields including messages, attribute keys/values, trace/span IDs, resource names, severity, scope names, and event names.

### Implementation details
- Dashboard `TelemetryApiService` accepts a `search` query parameter and applies server-side filtering via `MatchesSearch` methods for both logs and spans
- CLI commands pass the search term through to the dashboard API and also apply client-side filtering for console logs
- Added `StringComparisons.FullTextSearch` / `StringComparers.FullTextSearch` to centralize the comparison strategy
- MCP tools (`ListConsoleLogs`, `ListStructuredLogs`, `ListTraceStructuredLogs`, `ListTraces`) all support the new `search` input parameter

### User-facing usage

```bash
# Filter console logs by content
aspire logs --search "connection timeout"

# Filter structured logs from a specific resource
aspire otel logs myservice --search "error"

# Filter spans by attribute values
aspire otel spans myservice --search "/api/products"

# Filter traces
aspire otel traces myservice --search "trace-id-prefix"
```

Command help (`aspire logs --help` excerpt):
```
Options:
  --search <search>  Filter log output by searching across all text fields (case-insensitive)
```

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
  - [x] No
