### PR TITLE
Skip compute env validation in run mode (#16940)

### DIFF
--- a/src/Aspire.Hosting.Azure.AppContainers/AzureContainerAppExtensions.cs
+++ b/src/Aspire.Hosting.Azure.AppContainers/AzureContainerAppExtensions.cs
@@ -62,6 +62,11 @@ public static class AzureContainerAppExtensions
                 name: ContainerAppsPipelineStepMarker.StepName,
                 action: ctx =>
                 {
+                    if (!ctx.ExecutionContext.IsPublishMode)
+                    {
+                        return Task.CompletedTask;
+                    }
+
                     if (!ctx.Model.Resources.OfType<AzureContainerAppEnvironmentResource>().Any())
                     {
                         foreach (var r in ctx.Model.GetComputeResources())

--- a/src/Aspire.Hosting.Azure.AppService/AzureAppServiceEnvironmentExtensions.cs
+++ b/src/Aspire.Hosting.Azure.AppService/AzureAppServiceEnvironmentExtensions.cs
@@ -46,6 +46,11 @@ public static partial class AzureAppServiceEnvironmentExtensions
                 name: AppServicePipelineStepMarker.StepName,
                 action: ctx =>
                 {
+                    if (!ctx.ExecutionContext.IsPublishMode)
+                    {
+                        return Task.CompletedTask;
+                    }
+
                     if (!ctx.Model.Resources.OfType<AzureAppServiceEnvironmentResource>().Any())
                     {
                         foreach (var r in ctx.Model.GetComputeResources())

--- a/src/Aspire.Hosting.Docker/DockerComposeEnvironmentExtensions.cs
+++ b/src/Aspire.Hosting.Docker/DockerComposeEnvironmentExtensions.cs
@@ -34,6 +34,11 @@ public static class DockerComposeEnvironmentExtensions
                 name: DockerComposePipelineStepMarker.StepName,
                 action: ctx =>
                 {
+                    if (!ctx.ExecutionContext.IsPublishMode)
+                    {
+                        return Task.CompletedTask;
+                    }
+
                     if (!ctx.Model.Resources.OfType<DockerComposeEnvironmentResource>().Any())
                     {
                         foreach (var r in ctx.Model.GetComputeResources())

--- a/src/Aspire.Hosting.Kubernetes/KubernetesEnvironmentExtensions.cs
+++ b/src/Aspire.Hosting.Kubernetes/KubernetesEnvironmentExtensions.cs
@@ -38,6 +38,11 @@ public static class KubernetesEnvironmentExtensions
                 name: KubernetesPipelineStepMarker.StepName,
                 action: ctx =>
                 {
+                    if (!ctx.ExecutionContext.IsPublishMode)
+                    {
+                        return Task.CompletedTask;
+                    }
+
                     var hasKubernetesEnvironment = ctx.Model.Resources.OfType<KubernetesEnvironmentResource>().Any() ||
                         ctx.Model.Resources.OfType<IComputeEnvironmentResource>()
                             .Any(r => r.HasAnnotationOfType<KubernetesEnvironmentAnnotation>());

--- a/tests/Aspire.Hosting.Azure.Tests/AzureAppServiceTests.cs
+++ b/tests/Aspire.Hosting.Azure.Tests/AzureAppServiceTests.cs
@@ -411,6 +411,26 @@ public class AzureAppServiceTests(ITestOutputHelper testOutputHelper)
     }
 
     [Fact]
+    public async Task ValidateAzureAppService_DoesNotThrowInRunMode()
+    {
+        // Regression test for https://github.com/microsoft/aspire/issues/16940.
+        // In run mode, AddAzureAppServiceEnvironment does not add the env resource to the model.
+        // If a compute resource still ends up with an AzureAppServiceWebsiteCustomizationAnnotation
+        // (e.g. via WithAnnotation), the validation step should not throw at 'aspire run' time —
+        // PublishAs* customizations are only meaningful at publish/deploy time.
+        var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Run);
+
+        builder.AddAzureAppServiceEnvironment("env");
+
+        builder.AddContainer("api", "myimage")
+            .WithAnnotation(new AzureAppServiceWebsiteCustomizationAnnotation((_, _) => { }));
+
+        using var app = builder.Build();
+
+        await ExecuteBeforeStartHooksAsync(app, default);
+    }
+
+    [Fact]
     [ActiveIssue("https://github.com/microsoft/aspire/issues/11818", typeof(PlatformDetection), nameof(PlatformDetection.IsRunningFromAzdo))]
     public async Task MultipleAzureAppServiceEnvironmentsSupported()
     {

--- a/tests/Aspire.Hosting.Azure.Tests/AzureContainerAppsTests.cs
+++ b/tests/Aspire.Hosting.Azure.Tests/AzureContainerAppsTests.cs
@@ -1782,6 +1782,29 @@ public class AzureContainerAppsTests
     }
 
     [Fact]
+    public async Task ValidateAzureContainerApps_DoesNotThrowInRunMode()
+    {
+        // Regression test for https://github.com/microsoft/aspire/issues/16940.
+        // In run mode, AddAzureContainerAppEnvironment does not add the env resource to the
+        // model. If a compute resource still ends up with an AzureContainerAppCustomizationAnnotation
+        // (e.g. via WithAnnotation), the validation step should not throw at 'aspire run' time —
+        // PublishAs* customizations are only meaningful at publish/deploy time.
+        var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Run);
+
+        builder.AddAzureContainerAppEnvironment("env");
+
+        builder.AddContainer("api", "myimage")
+            .WithAnnotation(new AzureContainerAppCustomizationAnnotation((_, _) => { }));
+
+        builder.AddContainer("worker", "myimage")
+            .WithAnnotation(new AzureContainerAppJobCustomizationAnnotation((_, _) => { }));
+
+        using var app = builder.Build();
+
+        await ExecuteBeforeStartHooksAsync(app, default);
+    }
+
+    [Fact]
     public async Task MultipleAzureContainerAppEnvironmentsSupported()
     {
         using var tempDir = new TestTempDirectory();

--- a/tests/Aspire.Hosting.Docker.Tests/DockerComposeTests.cs
+++ b/tests/Aspire.Hosting.Docker.Tests/DockerComposeTests.cs
@@ -128,6 +128,26 @@ public class DockerComposeTests(ITestOutputHelper output)
     }
 
     [Fact]
+    public async Task ValidateDockerCompose_DoesNotThrowInRunMode()
+    {
+        // Regression test for https://github.com/microsoft/aspire/issues/16940.
+        // In run mode, AddDockerComposeEnvironment does not add the env resource to the model.
+        // If a compute resource still ends up with a DockerComposeServiceCustomizationAnnotation
+        // (e.g. via WithAnnotation), the validation step should not throw at 'aspire run' time —
+        // PublishAs* customizations are only meaningful at publish/deploy time.
+        using var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Run);
+
+        builder.AddDockerComposeEnvironment("docker-compose");
+
+        builder.AddContainer("api", "myimage")
+            .WithAnnotation(new DockerComposeServiceCustomizationAnnotation((_, _) => { }));
+
+        using var app = builder.Build();
+
+        await ExecuteBeforeStartHooksAsync(app, default);
+    }
+
+    [Fact]
     public async Task MultipleDockerComposeEnvironmentsSupported()
     {
         using var tempDir = new TestTempDirectory();

--- a/tests/Aspire.Hosting.Kubernetes.Tests/KubernetesEnvironmentResourceTests.cs
+++ b/tests/Aspire.Hosting.Kubernetes.Tests/KubernetesEnvironmentResourceTests.cs
@@ -5,6 +5,7 @@
 using System.Runtime.CompilerServices;
 using Aspire.Hosting;
 using Aspire.Hosting.ApplicationModel;
+using Aspire.Hosting.Kubernetes;
 using Aspire.Hosting.Utils;
 using Aspire.TestUtilities;
 using Microsoft.Extensions.DependencyInjection;
@@ -67,6 +68,26 @@ public class KubernetesEnvironmentResourceTests(ITestOutputHelper output)
             builder.AddExecutable("exe", "path/to/executable", ".")
                 .PublishAsDockerFile()
                 .PublishAsKubernetesService((_) => { }));
+    }
+
+    [Fact]
+    public async Task ValidateKubernetes_DoesNotThrowInRunMode()
+    {
+        // Regression test for https://github.com/microsoft/aspire/issues/16940.
+        // In run mode, AddKubernetesEnvironment does not add the env resource to the model.
+        // If a compute resource still ends up with a KubernetesServiceCustomizationAnnotation
+        // (e.g. via WithAnnotation), the validation step should not throw at 'aspire run' time —
+        // PublishAs* customizations are only meaningful at publish/deploy time.
+        using var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Run);
+
+        builder.AddKubernetesEnvironment("env");
+
+        builder.AddContainer("api", "myimage")
+            .WithAnnotation(new KubernetesServiceCustomizationAnnotation((_) => { }));
+
+        using var app = builder.Build();
+
+        await ExecuteBeforeStartHooksAsync(app, default);
     }
 
     [Fact]


### PR DESCRIPTION
## Description

Fixes #16940.

After upgrading to 13.3.0, `aspire run` started failing with:

> Step 'validate-azure-container-apps' failed: Resource '...' is configured to publish as an Azure Container App, but there are no 'AzureContainerAppEnvironmentResource' resources. Ensure you have added one by calling 'AddAzureContainerAppEnvironment'.

even when the user *had* called `AddAzureContainerAppEnvironment`.

### Root cause

The `validate-azure-container-apps` step (introduced in #13780) is wired into the `before-start` pipeline phase, which runs for both `aspire run` and publish/deploy. The step checks for `AzureContainerAppEnvironmentResource` instances in the model — but `AddAzureContainerAppEnvironment` only adds the environment resource to the model in publish mode (in run mode it returns a builder without `AddResource`). So in run mode the "no environment resources" branch is always taken, and any compute resource that ends up with `AzureContainerAppCustomizationAnnotation` / `AzureContainerAppJobCustomizationAnnotation` (e.g. attached via `WithAnnotation`) trips the throw.

`validate-azure-app-service` has the identical shape.

### Fix

`PublishAs*` annotations only affect publish/deploy output, so the validation has no purpose in run mode. Both validation steps now short-circuit when `ctx.ExecutionContext.IsPublishMode` is false.

Added regression tests for both validations that build a run-mode app with a compute resource carrying the customization annotation and assert that `ExecuteBeforeStartHooksAsync` does not throw.

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
  - [x] No