### PR TITLE
Export Docker service reference node types

### DIFF
--- a/src/Aspire.Hosting.Docker/Resources/ServiceNodes/ConfigReference.cs
+++ b/src/Aspire.Hosting.Docker/Resources/ServiceNodes/ConfigReference.cs
@@ -13,6 +13,7 @@ namespace Aspire.Hosting.Docker.Resources.ServiceNodes;
 /// service in a containerized environment. It includes information about
 /// the configuration source, target, ownership, and permissions.
 /// </remarks>
+[AspireExport(ExposeProperties = true)]
 [YamlSerializable]
 public sealed class ConfigReference
 {

--- a/src/Aspire.Hosting.Docker/Resources/ServiceNodes/SecretReference.cs
+++ b/src/Aspire.Hosting.Docker/Resources/ServiceNodes/SecretReference.cs
@@ -8,6 +8,7 @@ namespace Aspire.Hosting.Docker.Resources.ServiceNodes;
 /// <summary>
 /// Represents a reference to a secret within a Docker service configuration.
 /// </summary>
+[AspireExport(ExposeProperties = true)]
 [YamlSerializable]
 public sealed class SecretReference
 {

--- a/src/Aspire.Hosting.Docker/Resources/ServiceNodes/Ulimit.cs
+++ b/src/Aspire.Hosting.Docker/Resources/ServiceNodes/Ulimit.cs
@@ -12,6 +12,7 @@ namespace Aspire.Hosting.Docker.Resources.ServiceNodes;
 /// This class is typically used to specify soft and hard limits for resources
 /// such as file descriptors or process count for Docker containers.
 /// </remarks>
+[AspireExport(ExposeProperties = true)]
 [YamlSerializable]
 public sealed class Ulimit
 {

--- a/tests/PolyglotAppHosts/Aspire.Hosting.Docker/Go/apphost.go
+++ b/tests/PolyglotAppHosts/Aspire.Hosting.Docker/Go/apphost.go
@@ -54,6 +54,9 @@ func main() {
 		_, _ = service.ContainerName()
 		_, _ = service.PullPolicy()
 		_, _ = service.Restart()
+		_, _ = service.Configs().Count()
+		_, _ = service.Secrets().Count()
+		_, _ = service.Ulimits().Count()
 	})
 
 	_, _ = compose.DefaultNetworkName()

--- a/tests/PolyglotAppHosts/Aspire.Hosting.Docker/Java/AppHost.java
+++ b/tests/PolyglotAppHosts/Aspire.Hosting.Docker/Java/AppHost.java
@@ -53,6 +53,9 @@ void main() throws Exception {
             var _composeEnvironmentName = composeEnvironment.name();
             var _serviceContainerName = service.containerName();
             var _serviceRestart = service.restart();
+            var _serviceConfigs = service.configs();
+            var _serviceSecrets = service.secrets();
+            var _serviceUlimitsCount = service.ulimits().size();
         });
         var _resolvedDefaultNetworkName = compose.defaultNetworkName();
         var _resolvedDashboardEnabled = compose.dashboardEnabled();

--- a/tests/PolyglotAppHosts/Aspire.Hosting.Docker/Python/apphost.py
+++ b/tests/PolyglotAppHosts/Aspire.Hosting.Docker/Python/apphost.py
@@ -48,6 +48,9 @@ with create_builder() as builder:
         compose_service.parent().name()
         service.container_name()
         service.restart()
+        _service_configs_count = len(service.configs)
+        _service_secrets_count = len(service.secrets)
+        _service_ulimits_count = len(service.ulimits)
 
     compose.configure_compose_file(configure_compose_file)
     compose.with_dashboard()

--- a/tests/PolyglotAppHosts/Aspire.Hosting.Docker/TypeScript/apphost.ts
+++ b/tests/PolyglotAppHosts/Aspire.Hosting.Docker/TypeScript/apphost.ts
@@ -68,6 +68,9 @@ await api.publishAsDockerComposeService(async (composeService, service) => {
 
     const _serviceContainerName: string = await service.containerName.get();
     const _serviceRestart: string = await service.restart.get();
+    const _serviceConfigsCount: number = await service.configs.count();
+    const _serviceSecretsCount: number = await service.secrets.count();
+    const _serviceUlimitsCount: number = await service.ulimits.count();
 });
 
 const _resolvedDefaultNetworkName: string = await compose.defaultNetworkName.get();


### PR DESCRIPTION
## Description

`aspire sdk dump` skipped several Docker service capabilities because the service config, secret, and ulimit reference node types were not exported as ATS types. This exports those existing Docker service-node types using the same pattern as the other Docker nodes so the generated SDK surface can include `configs`, `secrets`, and `ulimits` without diagnostics.

The Docker polyglot apphosts now touch the newly exported collection surfaces for TypeScript, Python, Go, and Java, matching the repository guidance for ATS export coverage changes.

Fixes # (issue)

N/A

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
