### PR TITLE
Fix Foundry search connection export

### DIFF
--- a/src/Aspire.Hosting.Foundry/Project/ConnectionBuilderExtensions.cs
+++ b/src/Aspire.Hosting.Foundry/Project/ConnectionBuilderExtensions.cs
@@ -199,7 +199,7 @@ public static class AzureCognitiveServicesProjectConnectionsBuilderExtensions
     /// <summary>
     /// Adds an Azure AI Search connection to a Microsoft Foundry project.
     /// </summary>
-    [AspireExport("addSearchConnectionFromResource", Description = "Adds an Azure AI Search connection to a Microsoft Foundry project.")]
+    [AspireExportIgnore(Reason = "Raw AzureSearchResource parameters are not ATS-compatible. Use the resource-builder overload instead.")]
     public static IResourceBuilder<AzureCognitiveServicesProjectConnectionResource> AddConnection(
         this IResourceBuilder<AzureCognitiveServicesProjectResource> builder,
         AzureSearchResource search)


### PR DESCRIPTION
## Description

`aspire sdk dump` for `Aspire.Hosting.Foundry` emitted a warning because the raw `AzureSearchResource` connection helper was exported even though raw resource parameters are not ATS-compatible. This marks that lower-level overload as ignored, matching the other raw Foundry connection helpers, while keeping the builder-based `addSearchConnection` export available for polyglot apphosts so role assignments still flow through the intended API.

Fixes: N/A

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No