### PR TITLE
Fix ATS export shadowing for target-specific methods

### DIFF
--- a/src/Aspire.Hosting.RemoteHost/AtsCapabilityScanner.cs
+++ b/src/Aspire.Hosting.RemoteHost/AtsCapabilityScanner.cs
@@ -903,10 +903,10 @@ public static class AtsCapabilityScanner
     }
 
     /// <summary>
-    /// Detects method name collisions after capability expansion and removes colliding methods,
-    /// keeping only the first one (sorted by CapabilityId). A warning is emitted for each
-    /// removed capability. Since ATS doesn't support method overloading, each (TargetTypeId, MethodName)
-    /// pair must be unique. Use [AspireExport(MethodName = "uniqueName")] to resolve collisions.
+    /// Detects method name collisions after capability expansion. Since ATS doesn't support method
+    /// overloading, each (TargetTypeId, MethodName) pair must be unique. When a concrete target has
+    /// a target-specific export, it shadows matching generic exports only for that target. Ambiguous
+    /// collisions still remove later capabilities and emit warnings.
     /// </summary>
     private static void FilterMethodNameCollisions(List<AtsCapabilityInfo> capabilities, List<AtsDiagnostic> diagnostics)
     {
@@ -926,12 +926,44 @@ public static class AtsCapabilityScanner
         }
 
         var capabilitiesToRemove = new HashSet<string>();
+        var expandedTargetsToRemove = new Dictionary<string, HashSet<string>>(StringComparer.Ordinal);
 
         foreach (var collisionGroup in collisionGroups)
         {
             var methodName = collisionGroup.Key.MethodName;
             var targetTypeId = collisionGroup.Key.Target;
-            var capIds = collisionGroup.Select(x => x.Capability.CapabilityId).Distinct().ToList();
+            var collidingCapabilities = collisionGroup
+                .Select(x => x.Capability)
+                .GroupBy(c => c.CapabilityId, StringComparer.Ordinal)
+                .Select(g => g.First())
+                .ToList();
+            var exactTargetCapabilities = collidingCapabilities
+                .Where(c => string.Equals(c.TargetTypeId, targetTypeId, StringComparison.Ordinal))
+                .ToList();
+
+            if (exactTargetCapabilities.Count == 1)
+            {
+                var exactTargetCapability = exactTargetCapabilities[0];
+                foreach (var collidingCapability in collidingCapabilities)
+                {
+                    if (string.Equals(collidingCapability.CapabilityId, exactTargetCapability.CapabilityId, StringComparison.Ordinal))
+                    {
+                        continue;
+                    }
+
+                    if (!expandedTargetsToRemove.TryGetValue(collidingCapability.CapabilityId, out var targetIds))
+                    {
+                        targetIds = new(StringComparer.Ordinal);
+                        expandedTargetsToRemove[collidingCapability.CapabilityId] = targetIds;
+                    }
+
+                    targetIds.Add(targetTypeId);
+                }
+
+                continue;
+            }
+
+            var capIds = collidingCapabilities.Select(c => c.CapabilityId).ToList();
             capIds.Sort(StringComparer.Ordinal);
 
             var conflictingIdsStr = string.Join(", ", capIds);
@@ -947,7 +979,19 @@ public static class AtsCapabilityScanner
             }
         }
 
-        capabilities.RemoveAll(c => capabilitiesToRemove.Contains(c.CapabilityId));
+        foreach (var capability in capabilities)
+        {
+            if (expandedTargetsToRemove.TryGetValue(capability.CapabilityId, out var targetIds))
+            {
+                capability.ExpandedTargetTypes = capability.ExpandedTargetTypes
+                    .Where(t => !targetIds.Contains(t.TypeId))
+                    .ToList();
+            }
+        }
+
+        capabilities.RemoveAll(c =>
+            capabilitiesToRemove.Contains(c.CapabilityId) ||
+            (c.TargetTypeId is not null && c.ExpandedTargetTypes.Count == 0));
     }
 
     /// <summary>

--- a/tests/Aspire.Hosting.RemoteHost.Tests/AtsCapabilityScannerTests.cs
+++ b/tests/Aspire.Hosting.RemoteHost.Tests/AtsCapabilityScannerTests.cs
@@ -367,6 +367,28 @@ public class AtsCapabilityScannerTests
                 && d.Message.Contains("has collisions", StringComparison.Ordinal));
     }
 
+    [Fact]
+    public void ScanAssembly_TargetSpecificMethodShadowsGenericExpandedMethodOnlyForThatTarget()
+    {
+        var result = AtsCapabilityScanner.ScanAssembly(typeof(AtsCapabilityScannerTests).Assembly);
+        var shadowedTypeId = AtsTypeMapping.DeriveTypeId(typeof(ShadowedEnvironmentResource));
+        var otherTypeId = AtsTypeMapping.DeriveTypeId(typeof(OtherEnvironmentResource));
+
+        var genericCapability = Assert.Single(result.Capabilities,
+            c => c.CapabilityId.EndsWith("/shadowedExporter", StringComparison.Ordinal));
+        var specificCapability = Assert.Single(result.Capabilities,
+            c => c.CapabilityId.EndsWith("/specificShadowedExporter", StringComparison.Ordinal));
+
+        Assert.Equal("shadowedExporter", genericCapability.MethodName);
+        Assert.Equal("shadowedExporter", specificCapability.MethodName);
+        Assert.DoesNotContain(genericCapability.ExpandedTargetTypes, t => t.TypeId == shadowedTypeId);
+        Assert.Contains(genericCapability.ExpandedTargetTypes, t => t.TypeId == otherTypeId);
+        Assert.Contains(specificCapability.ExpandedTargetTypes, t => t.TypeId == shadowedTypeId);
+        Assert.DoesNotContain(result.Diagnostics,
+            d => d.Message.Contains("shadowedExporter", StringComparison.Ordinal)
+                && d.Message.Contains("has collisions", StringComparison.Ordinal));
+    }
+
     #endregion
 
     #region Callback Parameter Type Resolution Tests
@@ -552,6 +574,10 @@ public class AtsCapabilityScannerTests
         }
     }
 
+    private sealed class ShadowedEnvironmentResource(string name) : Resource(name), IResourceWithEnvironment;
+
+    private sealed class OtherEnvironmentResource(string name) : Resource(name), IResourceWithEnvironment;
+
     [AspireExport(ExposeProperties = true)]
     private class BaseExportedProperties
     {
@@ -590,6 +616,25 @@ public class AtsCapabilityScannerTests
             Func<ContainerResource, ProjectResource, Task> callback)
         {
             _ = callback;
+            return builder;
+        }
+
+        [AspireExport("shadowedExporter")]
+        public static IResourceBuilder<T> ShadowedExporter<T>(IResourceBuilder<T> builder)
+            where T : IResourceWithEnvironment
+        {
+            return builder;
+        }
+
+        [AspireExport("specificShadowedExporter", MethodName = "shadowedExporter")]
+        public static IResourceBuilder<ShadowedEnvironmentResource> SpecificShadowedExporter(IResourceBuilder<ShadowedEnvironmentResource> builder)
+        {
+            return builder;
+        }
+
+        [AspireExport("otherEnvironmentProbe")]
+        public static IResourceBuilder<OtherEnvironmentResource> OtherEnvironmentProbe(IResourceBuilder<OtherEnvironmentResource> builder)
+        {
             return builder;
         }
     }

--- a/tests/PolyglotAppHosts/Aspire.Hosting.Keycloak/Go/apphost.go
+++ b/tests/PolyglotAppHosts/Aspire.Hosting.Keycloak/Go/apphost.go
@@ -36,7 +36,9 @@ func main() {
 		WithDisabledFeatures([]string{"scripts"}).
 		WithOtlpExporter(&aspire.WithOtlpExporterOptions{Protocol: &protocol})
 
+	genericProtocol := aspire.OtlpProtocolHttpJson
 	builder.AddContainer("consumer", "nginx").
+		WithOtlpExporter(&aspire.WithOtlpExporterOptions{Protocol: &genericProtocol}).
 		WithReference(keycloak).
 		WithReference(keycloak2)
 

--- a/tests/PolyglotAppHosts/Aspire.Hosting.Keycloak/Java/AppHost.java
+++ b/tests/PolyglotAppHosts/Aspire.Hosting.Keycloak/Java/AppHost.java
@@ -18,6 +18,7 @@ void main() throws Exception {
             .withDisabledFeatures(new String[] { "scripts" })
             .withOtlpExporter(OtlpProtocol.HTTP_PROTOBUF);
         var consumer = builder.addContainer("consumer", "nginx");
+        consumer.withOtlpExporter(OtlpProtocol.HTTP_JSON);
         consumer.withReference(keycloak, new WithReferenceOptions());
         consumer.withReference(keycloak2, new WithReferenceOptions());
         var _keycloakName = keycloak.name();

--- a/tests/PolyglotAppHosts/Aspire.Hosting.Keycloak/Python/apphost.py
+++ b/tests/PolyglotAppHosts/Aspire.Hosting.Keycloak/Python/apphost.py
@@ -8,8 +8,11 @@ with create_builder() as builder:
     admin_username = builder.add_parameter("parameter")
     admin_password = builder.add_parameter("parameter")
     keycloak = builder.add_keycloak("resource")
+    keycloak.with_otlp_exporter()
     keycloak2 = builder.add_keycloak("resource")
-    builder.add_container("resource", "image")
+    keycloak2.with_otlp_exporter(protocol="HttpProtobuf")
+    consumer = builder.add_container("resource", "image")
+    consumer.with_otlp_exporter(protocol="HttpJson")
     _keycloak_name = keycloak.name
     _keycloak_entrypoint = keycloak.entrypoint
     _keycloak_shell_execution = keycloak.shell_execution

--- a/tests/PolyglotAppHosts/Aspire.Hosting.Keycloak/TypeScript/apphost.ts
+++ b/tests/PolyglotAppHosts/Aspire.Hosting.Keycloak/TypeScript/apphost.ts
@@ -26,6 +26,7 @@ const keycloak2 = await builder.addKeycloak("keycloak2")
     .withOtlpExporter({ protocol: OtlpProtocol.HttpProtobuf });
 
 await builder.addContainer("consumer", "nginx")
+    .withOtlpExporter({ protocol: OtlpProtocol.HttpJson })
     .withReference(keycloak)
     .withReference(keycloak2);
 

--- a/tests/PolyglotAppHosts/Aspire.Hosting/Go/apphost.go
+++ b/tests/PolyglotAppHosts/Aspire.Hosting/Go/apphost.go
@@ -21,6 +21,8 @@ func main() {
 	if err = container.Err(); err != nil {
 		log.Fatalf(aspire.FormatError(err))
 	}
+	genericOtlpProtocol := aspire.OtlpProtocolHttpJson
+	container.WithOtlpExporter(&aspire.WithOtlpExporterOptions{Protocol: &genericOtlpProtocol})
 	taggedContainer := builder.AddContainer("mytaggedcontainer", &aspire.AddContainerOptions{
 		Image: "nginx",
 		Tag:   "stable-alpine",

--- a/tests/PolyglotAppHosts/Aspire.Hosting/Java/AppHost.java
+++ b/tests/PolyglotAppHosts/Aspire.Hosting/Java/AppHost.java
@@ -3,6 +3,7 @@ import aspire.*;
 void main() throws Exception {
         var builder = DistributedApplication.CreateBuilder();
         var container = builder.addContainer("mycontainer", "nginx");
+        container.withOtlpExporter(OtlpProtocol.HTTP_JSON);
         var dockerContainer = builder.addDockerfile("dockerapp", "./app");
         var configureDockerfileBuilder = (AspireAction1<DockerfileBuilderCallbackContext>) (dockerfileContext) -> {
             var _dockerfileResource = dockerfileContext.resource();

--- a/tests/PolyglotAppHosts/Aspire.Hosting/Python/apphost.py
+++ b/tests/PolyglotAppHosts/Aspire.Hosting/Python/apphost.py
@@ -93,6 +93,7 @@ with create_builder() as builder:
 
     # addContainer (pre-existing)
     container = builder.add_container("resource", "image")
+    container.with_otlp_exporter(protocol="HttpJson")
     # addDockerfile
     docker_container = builder.add_dockerfile("resource", ".")
     docker_builder_container = builder.add_dockerfile_builder("builder-resource", ".", configure_dockerfile_builder, stage="runtime")

--- a/tests/PolyglotAppHosts/Aspire.Hosting/TypeScript/apphost.ts
+++ b/tests/PolyglotAppHosts/Aspire.Hosting/TypeScript/apphost.ts
@@ -7,6 +7,7 @@ import {
     CertificateTrustScope,
     EndpointProperty,
     IconVariant,
+    OtlpProtocol,
     ProbeType,
     refExpr,
 } from './.modules/aspire.js';
@@ -20,6 +21,7 @@ const builder = await createBuilder();
 
 // addContainer (pre-existing)
 const container = await builder.addContainer("mycontainer", "nginx");
+await container.withOtlpExporter({ protocol: OtlpProtocol.HttpJson });
 const taggedContainer = await builder.addContainer("mytaggedcontainer", {
     image: "nginx",
     tag: "stable-alpine",


### PR DESCRIPTION
## Description

Generic ATS exports can expand onto concrete resource targets, which caused Keycloak's target-specific `withOtlpExporter` export to collide with the generic `IResourceWithEnvironment` OTLP export. This change makes the scanner treat a single exact-target export as the winner for that concrete target only, while preserving the generic export for all other compatible resources.

This removes the Keycloak SDK dump collision without removing `Aspire.Hosting/withOtlpExporter` globally. The regression test covers the shadowing behavior and verifies no collision diagnostic is emitted for the intentional exact-target override.

Fixes: N/A

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No