### PR TITLE
feat: Aspire.Hosting.Kubernetes.K3s

### DIFF
--- a/Aspire.slnx
+++ b/Aspire.slnx
@@ -59,6 +59,7 @@
     <Project Path="src/Aspire.Hosting.Kafka/Aspire.Hosting.Kafka.csproj" />
     <Project Path="src/Aspire.Hosting.Keycloak/Aspire.Hosting.Keycloak.csproj" />
     <Project Path="src/Aspire.Hosting.Kubernetes/Aspire.Hosting.Kubernetes.csproj" />
+    <Project Path="src/Aspire.Hosting.Kubernetes.K3s/Aspire.Hosting.Kubernetes.K3s.csproj" />
     <Project Path="src/Aspire.Hosting.Maui/Aspire.Hosting.Maui.csproj" />
     <Project Path="src/Aspire.Hosting.Milvus/Aspire.Hosting.Milvus.csproj" />
     <Project Path="src/Aspire.Hosting.MongoDB/Aspire.Hosting.MongoDB.csproj" />

--- a/src/Aspire.Hosting.Kubernetes.K3s/Annotations/HelmReleaseAnnotation.cs
+++ b/src/Aspire.Hosting.Kubernetes.K3s/Annotations/HelmReleaseAnnotation.cs
@@ -1,0 +1,59 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Aspire.Hosting.ApplicationModel;
+
+namespace Aspire.Hosting.Kubernetes.Annotations;
+
+/// <summary>
+/// Declares a Helm chart release to be installed into the k3s cluster before
+/// the <see cref="K3sClusterResource"/> transitions to the running state.
+/// </summary>
+public sealed class HelmReleaseAnnotation : IResourceAnnotation
+{
+    /// <summary>
+    /// Initializes a new instance of <see cref="HelmReleaseAnnotation"/>.
+    /// </summary>
+    /// <param name="releaseName">The Helm release name.</param>
+    /// <param name="chart">The chart name or OCI reference (e.g. <c>cert-manager</c> or <c>oci://ghcr.io/org/chart</c>).</param>
+    /// <param name="repo">Optional Helm repository URL. Required when <paramref name="chart"/> is a short name.</param>
+    /// <param name="version">Optional chart version. If omitted, the latest version is used.</param>
+    /// <param name="namespace">Kubernetes namespace for the release. Defaults to <c>default</c>.</param>
+    /// <param name="valuesFile">Optional path to a values YAML file on the host.</param>
+    public HelmReleaseAnnotation(
+        string releaseName,
+        string chart,
+        string? repo = null,
+        string? version = null,
+        string? @namespace = null,
+        string? valuesFile = null)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(releaseName);
+        ArgumentException.ThrowIfNullOrWhiteSpace(chart);
+
+        ReleaseName = releaseName;
+        Chart = chart;
+        Repo = repo;
+        Version = version;
+        Namespace = @namespace ?? "default";
+        ValuesFile = valuesFile;
+    }
+
+    /// <summary>Gets the Helm release name.</summary>
+    public string ReleaseName { get; }
+
+    /// <summary>Gets the chart name or OCI reference.</summary>
+    public string Chart { get; }
+
+    /// <summary>Gets the optional Helm repository URL.</summary>
+    public string? Repo { get; }
+
+    /// <summary>Gets the optional chart version.</summary>
+    public string? Version { get; }
+
+    /// <summary>Gets the Kubernetes namespace for the release.</summary>
+    public string Namespace { get; }
+
+    /// <summary>Gets the optional path to a values YAML file.</summary>
+    public string? ValuesFile { get; }
+}

--- a/src/Aspire.Hosting.Kubernetes.K3s/Annotations/KubernetesDashboardAnnotation.cs
+++ b/src/Aspire.Hosting.Kubernetes.K3s/Annotations/KubernetesDashboardAnnotation.cs
@@ -1,0 +1,20 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Aspire.Hosting.ApplicationModel;
+
+namespace Aspire.Hosting.Kubernetes.Annotations;
+
+/// <summary>
+/// Marker annotation that signals the Kubernetes Dashboard should be installed and
+/// configured in the k3s cluster after startup.
+/// </summary>
+internal sealed class KubernetesDashboardAnnotation : IResourceAnnotation
+{
+    internal KubernetesDashboardAnnotation(string version)
+    {
+        Version = version;
+    }
+
+    internal string Version { get; }
+}

--- a/src/Aspire.Hosting.Kubernetes.K3s/Annotations/KustomizeAnnotation.cs
+++ b/src/Aspire.Hosting.Kubernetes.K3s/Annotations/KustomizeAnnotation.cs
@@ -1,0 +1,29 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Aspire.Hosting.ApplicationModel;
+
+namespace Aspire.Hosting.Kubernetes.Annotations;
+
+/// <summary>
+/// Declares a Kustomize overlay to be applied into the k3s cluster before
+/// the <see cref="K3sClusterResource"/> transitions to the running state.
+/// </summary>
+public sealed class KustomizeAnnotation : IResourceAnnotation
+{
+    /// <summary>
+    /// Initializes a new instance of <see cref="KustomizeAnnotation"/>.
+    /// </summary>
+    /// <param name="path">
+    /// Path to the Kustomize directory or URL (e.g. <c>./k8s/overlays/local</c> or a GitHub URL).
+    /// Relative paths are resolved against the AppHost project directory.
+    /// </param>
+    public KustomizeAnnotation(string path)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(path);
+        Path = path;
+    }
+
+    /// <summary>Gets the path or URL passed to <c>kubectl apply -k</c>.</summary>
+    public string Path { get; }
+}

--- a/src/Aspire.Hosting.Kubernetes.K3s/Aspire.Hosting.Kubernetes.K3s.csproj
+++ b/src/Aspire.Hosting.Kubernetes.K3s/Aspire.Hosting.Kubernetes.K3s.csproj
@@ -1,0 +1,19 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>$(DefaultTargetFramework)</TargetFramework>
+    <IsPackable>true</IsPackable>
+    <SuppressFinalPackageVersion>true</SuppressFinalPackageVersion>
+    <PackageTags>aspire hosting kubernetes k3s emulator</PackageTags>
+    <Description>K3s (Kubernetes-in-Docker) emulator resource for Aspire local development.</Description>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Aspire.Hosting\Aspire.Hosting.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <InternalsVisibleTo Include="Aspire.Hosting.Kubernetes.K3s.Tests" />
+  </ItemGroup>
+
+</Project>

--- a/src/Aspire.Hosting.Kubernetes.K3s/K3sBuilderExtensions.cs
+++ b/src/Aspire.Hosting.Kubernetes.K3s/K3sBuilderExtensions.cs
@@ -1,0 +1,537 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Diagnostics;
+using System.Runtime.InteropServices;
+using System.Text.RegularExpressions;
+using Aspire.Hosting.ApplicationModel;
+using Aspire.Hosting.Kubernetes.Annotations;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+using Microsoft.Extensions.Logging;
+
+namespace Aspire.Hosting.Kubernetes;
+
+/// <summary>
+/// Provides extension methods for adding a k3s Kubernetes cluster to the Aspire application model.
+/// </summary>
+public static partial class K3sBuilderExtensions
+{
+    /// <summary>
+    /// Adds a k3s Kubernetes cluster resource to the application model.
+    /// </summary>
+    /// <param name="builder">The distributed application builder.</param>
+    /// <param name="name">The resource name. Used as the connection string name when referenced by dependents.</param>
+    /// <param name="apiServerPort">
+    /// The host port to expose the Kubernetes API server on.
+    /// When <see langword="null"/> (default), DCP allocates a free port automatically.
+    /// </param>
+    /// <param name="configure">Optional callback to configure cluster options.</param>
+    /// <returns>A builder for the <see cref="K3sClusterResource"/>.</returns>
+    /// <remarks>
+    /// <para>
+    /// This resource includes a built-in health check that polls the k3s <c>/readyz</c> endpoint.
+    /// Use <see cref="ResourceBuilderExtensions.WaitFor{T}(IResourceBuilder{T}, IResourceBuilder{IResource})"/>
+    /// on dependent resources to ensure the cluster is fully ready before they start.
+    /// </para>
+    /// <para>
+    /// The cluster requires Docker with privileged container support. The kubeconfig is written
+    /// to a host temp directory and automatically rewritten to reference <c>localhost:{port}</c>.
+    /// </para>
+    /// </remarks>
+    [AspireExportIgnore(Reason = "Polyglot app hosts use the canonical addK3sCluster export without options callback.")]
+    public static IResourceBuilder<K3sClusterResource> AddK3sCluster(
+        this IDistributedApplicationBuilder builder,
+        [ResourceName] string name,
+        int? apiServerPort = null,
+        Action<K3sClusterOptions>? configure = null)
+    {
+        ArgumentNullException.ThrowIfNull(builder);
+        ArgumentNullException.ThrowIfNull(name);
+
+        var options = new K3sClusterOptions();
+        configure?.Invoke(options);
+
+        var kubeconfigDir = Path.Combine(Path.GetTempPath(), $"aspire-k3s-{name}");
+        Directory.CreateDirectory(kubeconfigDir);
+
+        var resource = new K3sClusterResource(name, kubeconfigDir)
+        {
+            KubectlBootstrapTag = TryParseK8sVersionFromK3sTag(options.ImageTag, out var k8sVersion)
+                ? k8sVersion
+                : "latest"
+        };
+
+        var healthCheckKey = $"{name}_k3s_check";
+        builder.Services.AddHealthChecks().Add(new HealthCheckRegistration(
+            healthCheckKey,
+            _ => new K3sReadinessHealthCheck(resource),
+            failureStatus: null,
+            tags: null,
+            timeout: TimeSpan.FromSeconds(10)));
+
+        var resourceBuilder = builder.AddResource(resource)
+            .WithImage(K3sContainerImageTags.Image, options.ImageTag)
+            .WithImageRegistry(K3sContainerImageTags.Registry)
+            .WithEndpoint(port: apiServerPort, targetPort: 6443, name: K3sClusterResource.ApiEndpointName, scheme: "https")
+            .WithEnvironment("K3S_KUBECONFIG_OUTPUT", "/kubeconfig/admin.yaml")
+            .WithBindMount(kubeconfigDir, "/kubeconfig")
+            .WithArgs(ctx =>
+            {
+                ctx.Args.Add("server");
+
+                foreach (var component in options.DisabledComponents)
+                {
+                    ctx.Args.Add($"--disable={component}");
+                }
+
+                foreach (var san in options.TlsSans)
+                {
+                    ctx.Args.Add($"--tls-san={san}");
+                }
+
+                if (options.PodSubnet is not null)
+                {
+                    ctx.Args.Add($"--cluster-cidr={options.PodSubnet}");
+                }
+
+                if (options.ServiceSubnet is not null)
+                {
+                    ctx.Args.Add($"--service-cidr={options.ServiceSubnet}");
+                }
+
+                foreach (var arg in options.ExtraArgs)
+                {
+                    ctx.Args.Add(arg);
+                }
+
+                return Task.CompletedTask;
+            })
+            .WithContainerRuntimeArgs("--privileged")
+            .WithContainerRuntimeArgs("--tmpfs", "/run", "--tmpfs", "/var/run")
+            .WithHealthCheck(healthCheckKey);
+
+        builder.Eventing.Subscribe<ConnectionStringAvailableEvent>(resource, async (@event, ct) =>
+        {
+            var logger = @event.Services.GetRequiredService<ILogger<K3sClusterResource>>();
+            await RunWorkloadsAsync(resource, logger, ct).ConfigureAwait(false);
+        });
+
+        return resourceBuilder;
+    }
+
+    /// <summary>
+    /// Deploys a Helm chart release into the k3s cluster before it transitions to the running state.
+    /// </summary>
+    /// <param name="builder">The k3s cluster resource builder.</param>
+    /// <param name="releaseName">The Helm release name.</param>
+    /// <param name="chart">The chart name or OCI reference (e.g. <c>oci://ghcr.io/org/chart</c>).</param>
+    /// <param name="repo">Optional Helm repository URL. Required when <paramref name="chart"/> is a short name.</param>
+    /// <param name="version">Optional chart version. Defaults to latest.</param>
+    /// <param name="namespace">Kubernetes namespace for the release. Defaults to <c>default</c>.</param>
+    /// <param name="valuesFile">Optional path to a values YAML file on the host.</param>
+    [AspireExport(Description = "Installs a Helm chart release into the k3s cluster before startup")]
+    public static IResourceBuilder<K3sClusterResource> WithHelmRelease(
+        this IResourceBuilder<K3sClusterResource> builder,
+        string releaseName,
+        string chart,
+        string? repo = null,
+        string? version = null,
+        string? @namespace = null,
+        string? valuesFile = null)
+    {
+        ArgumentNullException.ThrowIfNull(builder);
+        return builder.WithAnnotation(new HelmReleaseAnnotation(releaseName, chart, repo, version, @namespace, valuesFile));
+    }
+
+    /// <summary>
+    /// Applies a Kustomize overlay into the k3s cluster before it transitions to the running state.
+    /// </summary>
+    /// <param name="builder">The k3s cluster resource builder.</param>
+    /// <param name="path">
+    /// Path to the Kustomize directory or URL (e.g. <c>./k8s/overlays/local</c>).
+    /// Relative paths are resolved against the current working directory.
+    /// </param>
+    [AspireExport(Description = "Applies a Kustomize overlay into the k3s cluster before startup")]
+    public static IResourceBuilder<K3sClusterResource> WithKustomize(
+        this IResourceBuilder<K3sClusterResource> builder,
+        string path)
+    {
+        ArgumentNullException.ThrowIfNull(builder);
+        return builder.WithAnnotation(new KustomizeAnnotation(path));
+    }
+
+    /// <summary>
+    /// Installs the Kubernetes Dashboard into the cluster and logs the access token
+    /// and port-forward command to the resource output.
+    /// </summary>
+    /// <param name="builder">The k3s cluster resource builder.</param>
+    /// <param name="version">Dashboard Helm chart version. Defaults to <c>7.10.0</c>.</param>
+    /// <remarks>
+    /// Requires <c>helm</c> and <c>kubectl</c> on the host PATH.
+    /// If either is absent, a warning is logged and the dashboard is skipped.
+    /// </remarks>
+    [AspireExport(Description = "Installs the Kubernetes Dashboard into the k3s cluster")]
+    public static IResourceBuilder<K3sClusterResource> WithKubernetesDashboard(
+        this IResourceBuilder<K3sClusterResource> builder,
+        string version = "7.10.0")
+    {
+        ArgumentNullException.ThrowIfNull(builder);
+        return builder
+            .WithHelmRelease(
+                releaseName: "kubernetes-dashboard",
+                chart: "kubernetes-dashboard",
+                repo: "https://kubernetes.github.io/dashboard/",
+                version: version,
+                @namespace: "kubernetes-dashboard")
+            .WithAnnotation(new KubernetesDashboardAnnotation(version));
+    }
+
+    /// <summary>
+    /// Mounts a named Docker volume at <c>/var/lib/rancher/k3s</c> to preserve cluster state
+    /// across Aspire session restarts.
+    /// </summary>
+    /// <param name="builder">The k3s cluster resource builder.</param>
+    /// <param name="volumeName">
+    /// Named Docker volume to use. When <see langword="null"/> (default),
+    /// a name is derived from the cluster resource name.
+    /// </param>
+    [AspireExport(Description = "Mounts a named Docker volume to persist k3s cluster state across restarts")]
+    public static IResourceBuilder<K3sClusterResource> WithPersistentState(
+        this IResourceBuilder<K3sClusterResource> builder,
+        string? volumeName = null)
+    {
+        ArgumentNullException.ThrowIfNull(builder);
+        var name = volumeName ?? $"aspire-k3s-{builder.Resource.Name}-data";
+        return builder.WithVolume(name, "/var/lib/rancher/k3s");
+    }
+
+    /// <summary>
+    /// Injects the kubeconfig from the k3s cluster into the dependent resource's environment.
+    /// </summary>
+    /// <typeparam name="TDestination">The dependent resource type.</typeparam>
+    /// <param name="builder">The dependent resource builder.</param>
+    /// <param name="source">The k3s cluster resource builder.</param>
+    /// <param name="strategy">
+    /// How to inject the kubeconfig. <see cref="KubeconfigInjectionStrategy.Auto"/> (default)
+    /// uses <see cref="KubeconfigInjectionStrategy.FilePath"/> for local processes and
+    /// <see cref="KubeconfigInjectionStrategy.EnvVar"/> for containers.
+    /// </param>
+    /// <param name="envPrefix">
+    /// Optional prefix for injected environment variable names. Useful when referencing
+    /// multiple clusters from a single resource (e.g. <c>"HUB_"</c> → <c>HUB_KUBECONFIG_DATA</c>).
+    /// </param>
+    [AspireExportIgnore(Reason = "Custom WithReference overload for K3sClusterResource is not ATS-compatible due to enum strategy parameter.")]
+    public static IResourceBuilder<TDestination> WithReference<TDestination>(
+        this IResourceBuilder<TDestination> builder,
+        IResourceBuilder<K3sClusterResource> source,
+        KubeconfigInjectionStrategy strategy = KubeconfigInjectionStrategy.Auto,
+        string envPrefix = "")
+        where TDestination : IResourceWithEnvironment
+    {
+        ArgumentNullException.ThrowIfNull(builder);
+        ArgumentNullException.ThrowIfNull(source);
+
+        var cluster = source.Resource;
+
+        return builder.WithEnvironment(context =>
+        {
+            var effectiveStrategy = strategy == KubeconfigInjectionStrategy.Auto
+                ? (builder.Resource is ContainerResource
+                    ? KubeconfigInjectionStrategy.EnvVar
+                    : KubeconfigInjectionStrategy.FilePath)
+                : strategy;
+
+            switch (effectiveStrategy)
+            {
+                case KubeconfigInjectionStrategy.FilePath:
+                    context.EnvironmentVariables[$"{envPrefix}KUBECONFIG"] = cluster.KubeconfigFilePath;
+                    break;
+
+                case KubeconfigInjectionStrategy.EnvVar:
+                    if (cluster.KubeconfigData is { } data)
+                    {
+                        context.EnvironmentVariables[$"{envPrefix}KUBECONFIG_DATA"] = data;
+                    }
+                    break;
+            }
+        });
+    }
+
+    // Well-known Alpine images used as ephemeral bootstrap containers when the host
+    // binary is not found on PATH. Each image carries only the tool it needs.
+    // Helm is version-agnostic across Kubernetes versions; kubectl is pinned per-resource
+    // to match the embedded Kubernetes version and respect the ±1 minor skew policy.
+    private const string HelmBootstrapImage = "alpine/helm:latest";
+    private const string KubectlBootstrapImageBase = "alpine/kubectl";
+
+    private static async Task RunWorkloadsAsync(K3sClusterResource resource, ILogger logger, CancellationToken ct)
+    {
+        foreach (var helm in resource.Annotations.OfType<HelmReleaseAnnotation>())
+        {
+            await RunHelmReleaseAsync(helm, resource, logger, ct).ConfigureAwait(false);
+        }
+
+        foreach (var kustomize in resource.Annotations.OfType<KustomizeAnnotation>())
+        {
+            await RunKustomizeAsync(kustomize, resource, logger, ct).ConfigureAwait(false);
+        }
+
+        if (resource.TryGetLastAnnotation<KubernetesDashboardAnnotation>(out _))
+        {
+            await SetupDashboardAccessAsync(resource, logger, ct).ConfigureAwait(false);
+        }
+    }
+
+    private static async Task RunHelmReleaseAsync(HelmReleaseAnnotation helm, K3sClusterResource resource, ILogger logger, CancellationToken ct)
+    {
+        var parts = new List<string> { "helm", "install", helm.ReleaseName, helm.Chart };
+
+        if (helm.Repo is not null)
+        {
+            parts.Add("--repo");
+            parts.Add(helm.Repo);
+        }
+
+        if (helm.Version is not null)
+        {
+            parts.Add("--version");
+            parts.Add(helm.Version);
+        }
+
+        parts.Add("--namespace");
+        parts.Add(helm.Namespace);
+        parts.Add("--create-namespace");
+        parts.Add("--wait");
+
+        if (helm.ValuesFile is not null)
+        {
+            parts.Add("--values");
+            parts.Add(helm.ValuesFile);
+        }
+
+        var arguments = string.Join(' ', parts.Skip(1).Select(p => p.Contains(' ', StringComparison.Ordinal) ? $"\"{p}\"" : p));
+
+        logger.LogInformation("Installing Helm release '{ReleaseName}' (chart: {Chart})...", helm.ReleaseName, helm.Chart);
+
+        if (TryFindExecutable("helm", out var helmPath))
+        {
+            await RunHostProcessAsync(helmPath!, arguments, resource.KubeconfigFilePath, logger, ct).ConfigureAwait(false);
+        }
+        else
+        {
+            logger.LogInformation("'helm' not found on PATH — using bootstrap container ({Image}).", HelmBootstrapImage);
+            await RunBootstrapContainerAsync($"helm {arguments}", HelmBootstrapImage, resource, logger, ct).ConfigureAwait(false);
+        }
+    }
+
+    private static async Task RunKustomizeAsync(KustomizeAnnotation kustomize, K3sClusterResource resource, ILogger logger, CancellationToken ct)
+    {
+        var arguments = $"apply -k \"{kustomize.Path}\"";
+
+        logger.LogInformation("Applying Kustomize overlay '{Path}'...", kustomize.Path);
+
+        if (TryFindExecutable("kubectl", out var kubectlPath))
+        {
+            await RunHostProcessAsync(kubectlPath!, arguments, resource.KubeconfigFilePath, logger, ct).ConfigureAwait(false);
+        }
+        else
+        {
+            logger.LogInformation("'kubectl' not found on PATH — using bootstrap container ({Image}).", $"{KubectlBootstrapImageBase}:{resource.KubectlBootstrapTag}");
+            await RunBootstrapContainerAsync($"kubectl {arguments}", $"{KubectlBootstrapImageBase}:{resource.KubectlBootstrapTag}", resource, logger, ct).ConfigureAwait(false);
+        }
+    }
+
+    private static async Task SetupDashboardAccessAsync(K3sClusterResource resource, ILogger logger, CancellationToken ct)
+    {
+        const string serviceAccountYaml = """
+            apiVersion: v1
+            kind: ServiceAccount
+            metadata:
+              name: aspire-admin
+              namespace: kubernetes-dashboard
+            ---
+            apiVersion: rbac.authorization.k8s.io/v1
+            kind: ClusterRoleBinding
+            metadata:
+              name: aspire-admin
+            roleRef:
+              apiGroup: rbac.authorization.k8s.io
+              kind: ClusterRole
+              name: cluster-admin
+            subjects:
+            - kind: ServiceAccount
+              name: aspire-admin
+              namespace: kubernetes-dashboard
+            """;
+
+        // Write the YAML to the kubeconfig dir so the bootstrap container can reach it via the mounted volume.
+        var rbacYamlPath = Path.Combine(resource.KubeconfigHostPath, "dashboard-rbac.yaml");
+        await File.WriteAllTextAsync(rbacYamlPath, serviceAccountYaml, ct).ConfigureAwait(false);
+
+        logger.LogInformation("Creating Kubernetes Dashboard service account...");
+
+        const string applyArgs = "kubectl apply -f /kubeconfig/dashboard-rbac.yaml";
+        const string tokenArgs = "kubectl create token aspire-admin --namespace kubernetes-dashboard --duration=87600h";
+
+        if (TryFindExecutable("kubectl", out var kubectlPath))
+        {
+            await RunHostProcessAsync(kubectlPath!, $"apply -f \"{rbacYamlPath}\"", resource.KubeconfigFilePath, logger, ct).ConfigureAwait(false);
+            var token = (await RunHostProcessCaptureAsync(kubectlPath!, "create token aspire-admin --namespace kubernetes-dashboard --duration=87600h", resource.KubeconfigFilePath, ct).ConfigureAwait(false)).Trim();
+            LogDashboardInfo(logger, token);
+        }
+        else
+        {
+            logger.LogInformation("'kubectl' not found on PATH — using bootstrap container ({Image}).", $"{KubectlBootstrapImageBase}:{resource.KubectlBootstrapTag}");
+            await RunBootstrapContainerAsync(applyArgs, $"{KubectlBootstrapImageBase}:{resource.KubectlBootstrapTag}", resource, logger, ct).ConfigureAwait(false);
+            var token = (await RunBootstrapContainerCaptureAsync(tokenArgs, $"{KubectlBootstrapImageBase}:{resource.KubectlBootstrapTag}", resource, ct).ConfigureAwait(false)).Trim();
+            LogDashboardInfo(logger, token);
+        }
+
+        static void LogDashboardInfo(ILogger logger, string token) =>
+            logger.LogInformation(
+                "Kubernetes Dashboard ready.{NewLine}" +
+                "  Port-forward: kubectl port-forward -n kubernetes-dashboard svc/kubernetes-dashboard-kong-proxy 8443:443{NewLine}" +
+                "  Token:        {Token}",
+                Environment.NewLine, Environment.NewLine, token);
+    }
+
+    private static async Task RunBootstrapContainerAsync(string command, string image, K3sClusterResource resource, ILogger logger, CancellationToken ct)
+    {
+        if (!TryFindExecutable("docker", out var dockerPath))
+        {
+            logger.LogWarning("'docker' not found on PATH. Cannot run bootstrap container. Skipping.");
+            return;
+        }
+
+        var dockerArgs = BuildBootstrapDockerArgs(command, image, resource.KubeconfigHostPath);
+        await RunHostProcessAsync(dockerPath!, dockerArgs, kubeconfig: null, logger, ct).ConfigureAwait(false);
+    }
+
+    private static async Task<string> RunBootstrapContainerCaptureAsync(string command, string image, K3sClusterResource resource, CancellationToken ct)
+    {
+        if (!TryFindExecutable("docker", out var dockerPath))
+        {
+            return string.Empty;
+        }
+
+        var dockerArgs = BuildBootstrapDockerArgs(command, image, resource.KubeconfigHostPath);
+        return await RunHostProcessCaptureAsync(dockerPath!, dockerArgs, kubeconfig: null, ct).ConfigureAwait(false);
+    }
+
+    private static string BuildBootstrapDockerArgs(string command, string image, string kubeconfigHostPath)
+    {
+        var parts = new List<string>
+        {
+            "run", "--rm",
+            "-v", $"{kubeconfigHostPath}:/kubeconfig:ro",
+            "-e", "KUBECONFIG=/kubeconfig/admin-container.yaml",
+        };
+
+        // On Linux, host.docker.internal is not automatically resolvable — add it via host-gateway.
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+        {
+            parts.Add("--add-host=host.docker.internal:host-gateway");
+        }
+
+        parts.Add(image);
+
+        // Append the actual command (e.g. "helm install ..." or "kubectl apply -k ...")
+        parts.AddRange(command.Split(' ', StringSplitOptions.RemoveEmptyEntries));
+
+        return string.Join(' ', parts);
+    }
+
+    private static async Task RunHostProcessAsync(string executable, string arguments, string? kubeconfig, ILogger logger, CancellationToken ct)
+    {
+        var psi = new ProcessStartInfo(executable, arguments)
+        {
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+        };
+
+        if (kubeconfig is not null)
+        {
+            psi.Environment["KUBECONFIG"] = kubeconfig;
+        }
+
+        using var process = Process.Start(psi) ?? throw new InvalidOperationException($"Failed to start '{executable}'.");
+        var output = await process.StandardOutput.ReadToEndAsync(ct).ConfigureAwait(false);
+        var error = await process.StandardError.ReadToEndAsync(ct).ConfigureAwait(false);
+        await process.WaitForExitAsync(ct).ConfigureAwait(false);
+
+        if (process.ExitCode != 0)
+        {
+            logger.LogWarning("'{Executable} {Arguments}' exited with code {ExitCode}.{NewLine}{Error}",
+                executable, arguments, process.ExitCode, Environment.NewLine, error);
+        }
+        else if (!string.IsNullOrWhiteSpace(output))
+        {
+            logger.LogDebug("{Output}", output);
+        }
+    }
+
+    private static async Task<string> RunHostProcessCaptureAsync(string executable, string arguments, string? kubeconfig, CancellationToken ct)
+    {
+        var psi = new ProcessStartInfo(executable, arguments)
+        {
+            RedirectStandardOutput = true,
+            UseShellExecute = false,
+        };
+
+        if (kubeconfig is not null)
+        {
+            psi.Environment["KUBECONFIG"] = kubeconfig;
+        }
+
+        using var process = Process.Start(psi) ?? throw new InvalidOperationException($"Failed to start '{executable}'.");
+        var output = await process.StandardOutput.ReadToEndAsync(ct).ConfigureAwait(false);
+        await process.WaitForExitAsync(ct).ConfigureAwait(false);
+        return output;
+    }
+
+    private static bool TryFindExecutable(string name, out string? fullPath)
+    {
+        var pathEnv = Environment.GetEnvironmentVariable("PATH") ?? string.Empty;
+        var separator = Path.PathSeparator;
+        var extensions = OperatingSystem.IsWindows()
+            ? (Environment.GetEnvironmentVariable("PATHEXT") ?? ".COM;.EXE;.BAT").Split(';')
+            : [""];
+
+        foreach (var dir in pathEnv.Split(separator, StringSplitOptions.RemoveEmptyEntries))
+        {
+            foreach (var ext in extensions)
+            {
+                var candidate = Path.Combine(dir, name + ext);
+                if (File.Exists(candidate))
+                {
+                    fullPath = candidate;
+                    return true;
+                }
+            }
+        }
+
+        fullPath = null;
+        return false;
+    }
+
+    // k3s image tags embed the Kubernetes version: v1.32.3-k3s1, v1.31.0-k3s2, etc.
+    // We extract the semver part so alpine/kubectl can be pinned to the same version,
+    // staying within Kubernetes' ±1 minor version skew policy.
+    private static bool TryParseK8sVersionFromK3sTag(string k3sTag, out string k8sVersion)
+    {
+        var match = K3sVersionPattern().Match(k3sTag);
+        if (match.Success)
+        {
+            k8sVersion = match.Groups[1].Value; // e.g. "1.32.3"
+            return true;
+        }
+
+        k8sVersion = "latest";
+        return false;
+    }
+
+    [GeneratedRegex(@"^v?(\d+\.\d+\.\d+)-k3s\d+$")]
+    private static partial Regex K3sVersionPattern();
+}

--- a/src/Aspire.Hosting.Kubernetes.K3s/K3sClusterOptions.cs
+++ b/src/Aspire.Hosting.Kubernetes.K3s/K3sClusterOptions.cs
@@ -1,0 +1,52 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Aspire.Hosting.Kubernetes;
+
+/// <summary>
+/// Configuration options for a <see cref="K3sClusterResource"/>.
+/// </summary>
+/// <remarks>
+/// Mirrors the structure of a Kind cluster config YAML and YARP-style options builders.
+/// Each property translates to one or more <c>k3s server</c> command-line arguments.
+/// </remarks>
+public sealed class K3sClusterOptions
+{
+    /// <summary>
+    /// Additional Subject Alternative Names added to the k3s TLS certificate.
+    /// Defaults to <c>host.docker.internal</c>, <c>localhost</c>, and <c>0.0.0.0</c>
+    /// so the kubeconfig is valid from both the host and other containers.
+    /// Maps to <c>--tls-san</c>.
+    /// </summary>
+    public List<string> TlsSans { get; } = ["host.docker.internal", "localhost", "0.0.0.0"];
+
+    /// <summary>
+    /// k3s built-in components to disable at startup.
+    /// Defaults to <c>traefik</c> and <c>servicelb</c> to keep the cluster lightweight.
+    /// Maps to one <c>--disable=X</c> argument per entry.
+    /// </summary>
+    public List<string> DisabledComponents { get; } = ["traefik", "servicelb"];
+
+    /// <summary>
+    /// Raw additional arguments appended to the <c>k3s server</c> command after all derived arguments.
+    /// </summary>
+    public List<string> ExtraArgs { get; } = [];
+
+    /// <summary>
+    /// CIDR range for pod networking. Maps to <c>--cluster-cidr</c>.
+    /// Equivalent to Kind's <c>networking.podSubnet</c>.
+    /// </summary>
+    public string? PodSubnet { get; set; }
+
+    /// <summary>
+    /// CIDR range for service IPs. Maps to <c>--service-cidr</c>.
+    /// Equivalent to Kind's <c>networking.serviceSubnet</c>.
+    /// </summary>
+    public string? ServiceSubnet { get; set; }
+
+    /// <summary>
+    /// The <c>rancher/k3s</c> image tag to use.
+    /// Defaults to <c>latest</c>; pin to a specific version for reproducible environments.
+    /// </summary>
+    public string ImageTag { get; set; } = K3sContainerImageTags.Tag;
+}

--- a/src/Aspire.Hosting.Kubernetes.K3s/K3sClusterResource.cs
+++ b/src/Aspire.Hosting.Kubernetes.K3s/K3sClusterResource.cs
@@ -1,0 +1,71 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Aspire.Hosting.ApplicationModel;
+
+namespace Aspire.Hosting.Kubernetes;
+
+/// <summary>
+/// Represents a local Kubernetes cluster running via k3s inside a Docker container.
+/// </summary>
+/// <remarks>
+/// The cluster is started automatically when the Aspire application runs and torn down
+/// when the session ends. The kubeconfig is written to a host temp directory and exposed
+/// to dependent resources via <c>KUBECONFIG</c> (for local processes) or
+/// <c>KUBECONFIG_DATA</c> (for containers).
+/// </remarks>
+public sealed class K3sClusterResource : ContainerResource, IResourceWithConnectionString
+{
+    internal const string ApiEndpointName = "api";
+
+    internal K3sClusterResource(string name, string kubeconfigHostPath) : base(name)
+    {
+        KubeconfigHostPath = kubeconfigHostPath;
+    }
+
+    private EndpointReference? _apiEndpoint;
+
+    /// <summary>
+    /// Gets the endpoint reference for the Kubernetes API server.
+    /// </summary>
+    public EndpointReference ApiEndpoint => _apiEndpoint ??= new(this, ApiEndpointName);
+
+    /// <summary>
+    /// Gets the directory on the host where the kubeconfig file is written.
+    /// The kubeconfig file is located at <c>{KubeconfigHostPath}/admin.yaml</c>.
+    /// </summary>
+    public string KubeconfigHostPath { get; }
+
+    /// <summary>
+    /// Gets the full path to the kubeconfig file on the host.
+    /// Server URL is set to <c>https://localhost:{port}</c> for use by local processes and host CLIs.
+    /// </summary>
+    public string KubeconfigFilePath => Path.Combine(KubeconfigHostPath, "admin.yaml");
+
+    /// <summary>
+    /// Gets the full path to the container-variant kubeconfig file on the host.
+    /// Server URL is set to <c>https://host.docker.internal:{port}</c> so ephemeral bootstrap
+    /// containers can reach the host-mapped API server port.
+    /// </summary>
+    public string ContainerKubeconfigFilePath => Path.Combine(KubeconfigHostPath, "admin-container.yaml");
+
+    /// <summary>
+    /// Gets or sets the base64-encoded kubeconfig YAML with the server URL rewritten
+    /// to point at <c>localhost:{allocated-port}</c>. Set by the health check on first
+    /// successful readiness probe; <see langword="null"/> until then.
+    /// </summary>
+    public string? KubeconfigData { get; internal set; }
+
+    /// <summary>
+    /// Gets the <c>alpine/kubectl</c> image tag to use for the bootstrap container,
+    /// derived from the k3s image tag so kubectl stays within Kubernetes' ±1 minor version skew policy.
+    /// Falls back to <c>latest</c> when the tag cannot be parsed (e.g. <c>latest</c> or a digest).
+    /// </summary>
+    internal string KubectlBootstrapTag { get; init; } = "latest";
+
+    /// <summary>
+    /// Gets the connection string expression, which resolves to the kubeconfig file path on the host.
+    /// </summary>
+    public ReferenceExpression ConnectionStringExpression =>
+        ReferenceExpression.Create($"{KubeconfigFilePath}");
+}

--- a/src/Aspire.Hosting.Kubernetes.K3s/K3sContainerImageTags.cs
+++ b/src/Aspire.Hosting.Kubernetes.K3s/K3sContainerImageTags.cs
@@ -1,0 +1,11 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Aspire.Hosting.Kubernetes;
+
+internal static class K3sContainerImageTags
+{
+    internal const string Registry = "docker.io";
+    internal const string Image = "rancher/k3s";
+    internal const string Tag = "latest";
+}

--- a/src/Aspire.Hosting.Kubernetes.K3s/K3sReadinessHealthCheck.cs
+++ b/src/Aspire.Hosting.Kubernetes.K3s/K3sReadinessHealthCheck.cs
@@ -1,0 +1,79 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Text;
+using System.Text.RegularExpressions;
+using Aspire.Hosting.ApplicationModel;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+
+namespace Aspire.Hosting.Kubernetes;
+
+internal sealed partial class K3sReadinessHealthCheck(K3sClusterResource resource) : IHealthCheck
+{
+    public async Task<HealthCheckResult> CheckHealthAsync(HealthCheckContext context, CancellationToken cancellationToken = default)
+    {
+        if (!File.Exists(resource.KubeconfigFilePath))
+        {
+            return HealthCheckResult.Unhealthy("Kubeconfig not yet written by k3s.");
+        }
+
+        var endpoint = resource.Annotations
+            .OfType<EndpointAnnotation>()
+            .FirstOrDefault(a => a.Name == K3sClusterResource.ApiEndpointName);
+
+        var port = endpoint?.AllocatedEndpoint?.Port;
+        if (port is null)
+        {
+            return HealthCheckResult.Unhealthy("API server port not yet allocated.");
+        }
+
+        if (resource.KubeconfigData is null)
+        {
+            try
+            {
+                var yaml = await File.ReadAllTextAsync(resource.KubeconfigFilePath, cancellationToken).ConfigureAwait(false);
+
+                // Host variant: server URL uses localhost so local processes and host CLIs can reach the API server.
+                var hostKubeconfig = RewriteServerUrl(yaml, $"https://localhost:{port}");
+                await File.WriteAllTextAsync(resource.KubeconfigFilePath, hostKubeconfig, cancellationToken).ConfigureAwait(false);
+                resource.KubeconfigData = Convert.ToBase64String(Encoding.UTF8.GetBytes(hostKubeconfig));
+
+                // Container variant: server URL uses host.docker.internal so ephemeral bootstrap containers
+                // (helm-kubectl, alpine/k8s, etc.) can reach the host-mapped API server port.
+                // On Linux, docker run adds --add-host=host.docker.internal:host-gateway automatically.
+                var containerKubeconfig = RewriteServerUrl(yaml, $"https://host.docker.internal:{port}");
+                await File.WriteAllTextAsync(resource.ContainerKubeconfigFilePath, containerKubeconfig, cancellationToken).ConfigureAwait(false);
+            }
+            catch (Exception ex)
+            {
+                return HealthCheckResult.Unhealthy($"Failed to process kubeconfig: {ex.Message}");
+            }
+        }
+
+        try
+        {
+            using var handler = new HttpClientHandler
+            {
+                ServerCertificateCustomValidationCallback = HttpClientHandler.DangerousAcceptAnyServerCertificateValidator
+            };
+            using var client = new HttpClient(handler) { Timeout = TimeSpan.FromSeconds(5) };
+            var response = await client.GetAsync(
+                new Uri($"https://localhost:{port}/readyz"),
+                cancellationToken).ConfigureAwait(false);
+
+            return response.IsSuccessStatusCode
+                ? HealthCheckResult.Healthy()
+                : HealthCheckResult.Unhealthy($"k3s API server returned {(int)response.StatusCode} {response.ReasonPhrase}.");
+        }
+        catch (Exception ex)
+        {
+            return HealthCheckResult.Unhealthy($"Cannot reach k3s API server: {ex.Message}");
+        }
+    }
+
+    private static string RewriteServerUrl(string kubeconfig, string serverUrl) =>
+        ServerUrlPattern().Replace(kubeconfig, $"server: {serverUrl}");
+
+    [GeneratedRegex(@"server: https://[\w.\-]+:\d+")]
+    private static partial Regex ServerUrlPattern();
+}

--- a/src/Aspire.Hosting.Kubernetes.K3s/KubeconfigInjectionStrategy.cs
+++ b/src/Aspire.Hosting.Kubernetes.K3s/KubeconfigInjectionStrategy.cs
@@ -1,0 +1,30 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Aspire.Hosting.Kubernetes;
+
+/// <summary>
+/// Controls how kubeconfig credentials are injected into resources that reference a <see cref="K3sClusterResource"/>.
+/// </summary>
+public enum KubeconfigInjectionStrategy
+{
+    /// <summary>
+    /// Automatically selects the strategy based on the consumer type.
+    /// Uses <see cref="FilePath"/> for <c>ProjectResource</c> and <c>ExecutableResource</c>,
+    /// and <see cref="EnvVar"/> for <c>ContainerResource</c>.
+    /// </summary>
+    Auto,
+
+    /// <summary>
+    /// Injects the kubeconfig file path via the <c>KUBECONFIG</c> environment variable.
+    /// Suitable for local processes that can access the host filesystem.
+    /// </summary>
+    FilePath,
+
+    /// <summary>
+    /// Injects the full kubeconfig YAML as a base64-encoded string via the
+    /// <c>KUBECONFIG_DATA</c> environment variable (or <c>{prefix}KUBECONFIG_DATA</c> when a prefix is specified).
+    /// Suitable for containers where the host filesystem is not accessible.
+    /// </summary>
+    EnvVar,
+}


### PR DESCRIPTION
## Description

Adds `Aspire.Hosting.Kubernetes.K3s`, a new hosting integration that runs a lightweight Kubernetes cluster (k3s) as a standard Aspire `ContainerResource` using the official `rancher/k3s` Docker image. This lets developers declare a local Kubernetes cluster in `Program.cs` the same way they add Redis or PostgreSQL — no external tooling required beyond Docker.

Fixes #16956

### What's included

**New project: `src/Aspire.Hosting.Kubernetes.K3s/`**

| Type | Name | Purpose |
|---|---|---|
| Resource | `K3sClusterResource` | `ContainerResource` + `IResourceWithConnectionString` — kubeconfig file path as connection string |
| Options | `K3sClusterOptions` | Kind-style config object (pod subnet, disabled components, TLS SANs, image tag, extra args) |
| Extensions | `K3sBuilderExtensions` | `AddK3sCluster`, `WithHelmRelease`, `WithKustomize`, `WithKubernetesDashboard`, `WithPersistentState`, `WithReference` |
| Health check | `K3sReadinessHealthCheck` | Polls `/readyz`, rewrites kubeconfig server URL on first healthy probe |
| Annotations | `HelmReleaseAnnotation`, `KustomizeAnnotation`, `KubernetesDashboardAnnotation` | Declare workloads to deploy before the cluster is marked running |
| Enum | `KubeconfigInjectionStrategy` | Controls how kubeconfig is injected: `FilePath`, `EnvVar`, `Auto` |

### Usage

```csharp
var cluster = builder.AddK3sCluster("k8s", configure: options =>
{
    options.PodSubnet = "10.244.0.0/16";
    options.ImageTag = "v1.32.3-k3s1";
})
.WithHelmRelease("cert-manager", "cert-manager",
    repo: "https://charts.jetstack.io", version: "v1.17.0")
.WithKustomize("./k8s/overlays/local")
.WithKubernetesDashboard()
.WithPersistentState();

// Local process: injects KUBECONFIG=/tmp/aspire-k3s-k8s/admin.yaml
builder.AddProject<Projects.MyOperator>("operator")
    .WaitFor(cluster)
    .WithReference(cluster);

// Container: injects KUBECONFIG_DATA=<base64-encoded yaml>
builder.AddContainer("operator", "myorg/operator")
    .WaitFor(cluster)
    .WithReference(cluster);
```

### Key design decisions

**k3s as `ContainerResource`, not a CLI wrapper.** Analysis of the k3d source showed it is a thin Go wrapper over `docker create`. All essential flags (`--privileged`, port mapping, volume mounts, env vars) map directly to existing Aspire container APIs — no Docker SDK dependency needed.

**Two kubeconfig variants written on first healthy probe.** `admin.yaml` uses `localhost:{port}` for host processes; `admin-container.yaml` uses `host.docker.internal:{port}` for bootstrap containers. On Linux, `--add-host=host.docker.internal:host-gateway` is appended to `docker run` automatically.

**Helm and Kustomize use purpose-built Alpine images as fallback.** When `helm` or `kubectl` are not on the host PATH, ephemeral containers are used instead — `alpine/helm:latest` for Helm operations and `alpine/kubectl:{k8s-version}` for kubectl operations. The kubectl image tag is derived from the k3s image tag (e.g. `v1.32.3-k3s1` → `alpine/kubectl:1.32.3`) to respect Kubernetes' ±1 minor version skew policy. If the tag cannot be parsed (e.g. `latest`), both fall back to `latest`.

**Kind-style options builder.** `K3sClusterOptions` mirrors Kind's YAML config structure in C#, following the same pattern as YARP's config objects. This keeps cluster configuration structured and discoverable without scattering settings across many extension method chains.

**`KubeconfigInjectionStrategy.Auto`** selects `FilePath` for `ProjectResource`/`ExecutableResource` (standard `KUBECONFIG` env var) and `EnvVar` for `ContainerResource` (`KUBECONFIG_DATA` base64 payload). Both can be overridden explicitly, and an `envPrefix` parameter supports multi-cluster scenarios.

## Checklist

- Is this feature complete?
  - [ ] Yes. Ready to ship.
  - [x] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [x] No
- Did you add public API?
  - [x] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [x] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [x] No
  - [ ] No
- Does the change make any security assumptions or guarantees?
  - [x] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [x] No
    - Notes: The k3s container runs in privileged mode (required by k3s/containerd). `HttpClientHandler.DangerousAcceptAnyServerCertificateValidator` is used in the health check to reach the self-signed API server — this is scoped to local development only. The kubeconfig is written to a host temp directory; no credentials are transmitted over the network.
  - [ ] No
