### PR TITLE
Add INatsClient and JSON default to NATS integration

### DIFF
--- a/playground/nats/Nats.ApiService/Program.cs
+++ b/playground/nats/Nats.ApiService/Program.cs
@@ -32,7 +32,7 @@ app.MapPost("/publish/", async (AppEvent @event, INatsJSContext js) =>
 {
     var ack = await js.PublishAsync(@event.Subject, @event);
     ack.EnsureSuccess();
-    return Results.Created();
+    return Results.Ok(new { ack.Stream, ack.Seq, ack.Duplicate });
 });
 
 app.MapGet("/consume", async (INatsJSContext js, HttpContext ctx, CancellationToken ct) =>

--- a/playground/nats/Nats.ApiService/Program.cs
+++ b/playground/nats/Nats.ApiService/Program.cs
@@ -1,3 +1,4 @@
+using System.Text.Json;
 using NATS.Client.Core;
 using NATS.Client.JetStream;
 using NATS.Client.JetStream.Models;
@@ -8,69 +9,71 @@ var builder = WebApplication.CreateBuilder(args);
 // Add services to the container.
 builder.AddServiceDefaults();
 
-builder.AddNatsClient("nats", configureOptions: opts =>
-{
-    var jsonRegistry = new NatsJsonContextSerializerRegistry(AppJsonContext.Default);
-    return opts with { SerializerRegistry = jsonRegistry };
-});
+builder.AddNatsClient("nats");
 
 builder.AddNatsJetStream();
 
 var app = builder.Build();
 
+var jetStream = app.Services.GetRequiredService<INatsJSContext>();
+await jetStream.CreateOrUpdateStreamAsync(new StreamConfig("events", ["events.>"]));
+
+app.UseFileServer();
+
 // Configure the HTTP request pipeline.
 app.MapDefaultEndpoints();
-app.MapGet("/ping", async (INatsConnection nats) =>
+app.MapGet("/ping", async (INatsClient nats) =>
 {
     var rtt = await nats.PingAsync();
-    return Results.Json(new { rtt, nats.ServerInfo });
+    return Results.Json(new { rtt, nats.Connection.ServerInfo });
 });
 
-app.MapPost("/stream", async (StreamConfig config, INatsJSContext jetStream) =>
+app.MapPost("/publish/", async (AppEvent @event, INatsJSContext js) =>
 {
-    var stream = await jetStream.CreateStreamAsync(config);
-    var name = stream.Info.Config.Name;
-    return Results.Created($"/stream/{name}", name);
-});
-
-app.MapGet("/stream/{name}", async (string name, INatsJSContext jetStream) =>
-{
-    var stream = await jetStream.GetStreamAsync(name);
-    return Results.Ok(stream.Info);
-});
-
-app.MapPost("/publish/", async (AppEvent @event, INatsJSContext jetStream) =>
-{
-    try
-    {
-        var ack = await jetStream.PublishAsync(@event.Subject, @event);
-        ack.EnsureSuccess();
-    }
-    catch (NatsJSPublishNoResponseException)
-    {
-        return Results.Problem("Make sure the stream is created before publishing.");
-    }
-
+    var ack = await js.PublishAsync(@event.Subject, @event);
+    ack.EnsureSuccess();
     return Results.Created();
 });
 
-app.MapGet("/consume/{name}", async (string name, INatsJSContext jetStream) =>
+app.MapGet("/consume", async (INatsJSContext js, HttpContext ctx, CancellationToken ct) =>
 {
-    var stream = await jetStream.GetStreamAsync(name);
-    var consumer = await stream.CreateOrderedConsumerAsync();
+    ctx.Response.Headers.ContentType = "text/event-stream";
+    ctx.Response.Headers.CacheControl = "no-cache";
 
-    var events = new List<AppEvent>();
-    await foreach(var msg in consumer.ConsumeAsync<AppEvent>())
+    var stream = await js.GetStreamAsync("events", cancellationToken: ct);
+    var consumer = await stream.CreateOrderedConsumerAsync(cancellationToken: ct);
+
+    await foreach (var msg in consumer.ConsumeAsync<AppEvent>(cancellationToken: ct))
     {
-        events.Add(msg.Data!);
-
-        if (msg.Metadata?.NumPending == 0)
+        if (msg.Data is null)
         {
-            break;
+            continue;
         }
-    }
 
-    return Results.Ok(events);
+        await ctx.Response.WriteAsync($"data: {JsonSerializer.Serialize(msg.Data)}\n\n", ct);
+        await ctx.Response.Body.FlushAsync(ct);
+    }
+});
+
+app.MapGet("/consume/{name}", async (string name, INatsJSContext js, HttpContext ctx, CancellationToken ct) =>
+{
+    ctx.Response.Headers.ContentType = "text/event-stream";
+    ctx.Response.Headers.CacheControl = "no-cache";
+
+    var stream = await js.GetStreamAsync("events", cancellationToken: ct);
+    var consumer = await stream.CreateOrUpdateConsumerAsync(new ConsumerConfig(name), ct);
+
+    await foreach (var msg in consumer.ConsumeAsync<AppEvent>(cancellationToken: ct))
+    {
+        if (msg.Data is null)
+        {
+            continue;
+        }
+
+        await ctx.Response.WriteAsync($"data: {JsonSerializer.Serialize(msg.Data)}\n\n", ct);
+        await ctx.Response.Body.FlushAsync(ct);
+        await msg.AckAsync(cancellationToken: ct);
+    }
 });
 
 app.Run();

--- a/playground/nats/Nats.ApiService/wwwroot/index.html
+++ b/playground/nats/Nats.ApiService/wwwroot/index.html
@@ -33,8 +33,8 @@
     </p>
     <p>
         Docs:
-        <a href="https://docs.nats.io/" target="_blank" rel="noreferrer">NATS</a>,
-        <a href="https://nats-io.github.io/nats.net/" target="_blank" rel="noreferrer">NATS .NET client</a>.
+        <a href="https://docs.nats.io/" target="_blank" rel="noopener noreferrer">NATS</a>,
+        <a href="https://nats-io.github.io/nats.net/" target="_blank" rel="noopener noreferrer">NATS .NET client</a>.
     </p>
 
     <section>

--- a/playground/nats/Nats.ApiService/wwwroot/index.html
+++ b/playground/nats/Nats.ApiService/wwwroot/index.html
@@ -1,0 +1,188 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="utf-8" />
+    <title>NATS Aspire Playground</title>
+    <style>
+        body { font-family: system-ui, sans-serif; max-width: 720px; margin: 2rem auto; padding: 0 1rem; }
+        h1 { margin-bottom: 0.5rem; }
+        section { border: 1px solid #ccc; border-radius: 4px; padding: 1rem; margin: 1rem 0; }
+        .consumer-box { border: 1px solid #ddd; border-radius: 4px; padding: 0.75rem; margin: 0.5rem 0; background: #fafafa; }
+        .consumer-box header { display: flex; justify-content: space-between; align-items: center; margin-bottom: 0.5rem; }
+        .consumer-box h3 { margin: 0; font-size: 1rem; }
+        label { display: block; margin: 0.25rem 0; }
+        input { width: 100%; box-sizing: border-box; padding: 0.25rem; }
+        .row { display: flex; gap: 0.5rem; align-items: end; }
+        .row > * { flex: 1; }
+        .row > button { flex: 0; }
+        button { padding: 0.4rem 0.8rem; margin-top: 0.5rem; }
+        pre { background: #f4f4f4; padding: 0.5rem; overflow: auto; max-height: 15rem; margin: 0.5rem 0 0; }
+    </style>
+</head>
+<body>
+    <h1>NATS Aspire Playground</h1>
+    <p>
+        This <code>api</code> service exposes HTTP endpoints that drive a NATS server (with JetStream) running in a container.
+        The <code>events</code> stream (subject <code>events.&gt;</code>) is created at startup.
+        A separate <code>backend</code> service subscribes directly to <code>events.&gt;</code> and logs each message.
+    </p>
+    <p>
+        Try it: start a consumer below, then publish events and watch them arrive over Server-Sent Events.
+        You can also open the <code>backend</code> resource in the Aspire dashboard's <strong>Console</strong> tab
+        to see the same events being processed there.
+    </p>
+    <p>
+        Docs:
+        <a href="https://docs.nats.io/" target="_blank" rel="noreferrer">NATS</a>,
+        <a href="https://nats-io.github.io/nats.net/" target="_blank" rel="noreferrer">NATS .NET client</a>.
+    </p>
+
+    <section>
+        <h2>Ping</h2>
+        <form id="pingForm">
+            <button type="submit">GET /ping</button>
+        </form>
+        <pre id="pingOut"></pre>
+    </section>
+
+    <section>
+        <h2>Publish event</h2>
+        <form id="publishForm">
+            <label>Subject <input name="subject" value="events.example" required /></label>
+            <label>Name <input name="name" value="hello" required /></label>
+            <label>Description <input name="description" value="from the form" /></label>
+            <label>Priority <input name="priority" type="number" step="0.1" value="1.0" required /></label>
+            <button type="submit">POST /publish/</button>
+        </form>
+        <pre id="publishOut"></pre>
+    </section>
+
+    <section>
+        <h2>Ordered consumer</h2>
+        <p>Ephemeral. Replays all messages from the start every time you reconnect.</p>
+        <div id="orderedBox"></div>
+    </section>
+
+    <section>
+        <h2>Named (durable) consumers</h2>
+        <p>
+            Server tracks position per name. Add multiple boxes:
+            different names each get every message; same name shares messages (queue-style).
+            Try adding, removing and adding again using the same name,
+            where it should pick up after the last message it read before.
+        </p>
+        <div class="row">
+            <label>Consumer name <input id="newConsumerName" value="worker-1" /></label>
+            <button id="addConsumerBtn" type="button">Add</button>
+        </div>
+        <div id="namedConsumers"></div>
+    </section>
+
+    <script>
+        function formData(form) {
+            const out = {};
+            new FormData(form).forEach((v, k) => out[k] = v);
+            return out;
+        }
+
+        async function show(el, res) {
+            const text = await res.text();
+            try { el.textContent = JSON.stringify(JSON.parse(text), null, 2); }
+            catch { el.textContent = `${res.status} ${res.statusText}\n${text}`; }
+        }
+
+        document.getElementById('pingForm').addEventListener('submit', async e => {
+            e.preventDefault();
+            await show(document.getElementById('pingOut'), await fetch('/ping'));
+        });
+
+        document.getElementById('publishForm').addEventListener('submit', async e => {
+            e.preventDefault();
+            const d = formData(e.target);
+            const body = {
+                subject: d.subject,
+                name: d.name,
+                description: d.description,
+                priority: Number(d.priority),
+            };
+            const res = await fetch('/publish/', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify(body),
+            });
+            await show(document.getElementById('publishOut'), res);
+        });
+
+        function createConsumerBox({ title, url, removable }) {
+            const box = document.createElement('div');
+            box.className = 'consumer-box';
+
+            const header = document.createElement('header');
+            const h3 = document.createElement('h3');
+            h3.textContent = title;
+            header.appendChild(h3);
+
+            const controls = document.createElement('div');
+            const startBtn = document.createElement('button');
+            startBtn.textContent = 'Start';
+            const stopBtn = document.createElement('button');
+            stopBtn.textContent = 'Stop';
+            stopBtn.disabled = true;
+            controls.append(startBtn, stopBtn);
+            if (removable) {
+                const removeBtn = document.createElement('button');
+                removeBtn.textContent = 'Remove';
+                removeBtn.addEventListener('click', () => {
+                    if (stream) { stream.close(); stream = null; }
+                    box.remove();
+                });
+                controls.append(removeBtn);
+            }
+            header.appendChild(controls);
+            box.appendChild(header);
+
+            const out = document.createElement('pre');
+            box.appendChild(out);
+
+            let stream = null;
+            startBtn.addEventListener('click', () => {
+                if (stream) return;
+                out.textContent = '';
+                stream = new EventSource(url);
+                stream.onmessage = e => {
+                    out.textContent += e.data + '\n';
+                    out.scrollTop = out.scrollHeight;
+                };
+                stream.onerror = () => {
+                    out.textContent += '[stream closed]\n';
+                };
+                startBtn.disabled = true;
+                stopBtn.disabled = false;
+            });
+            stopBtn.addEventListener('click', () => {
+                if (stream) { stream.close(); stream = null; }
+                startBtn.disabled = false;
+                stopBtn.disabled = true;
+            });
+
+            return box;
+        }
+
+        document.getElementById('orderedBox').appendChild(
+            createConsumerBox({ title: 'ordered', url: '/consume', removable: false })
+        );
+
+        document.getElementById('addConsumerBtn').addEventListener('click', () => {
+            const name = document.getElementById('newConsumerName').value.trim();
+            if (!name) return;
+            document.getElementById('namedConsumers').appendChild(
+                createConsumerBox({
+                    title: name,
+                    url: `/consume/${encodeURIComponent(name)}`,
+                    removable: true,
+                })
+            );
+        });
+    </script>
+</body>
+</html>

--- a/playground/nats/Nats.Backend/Program.cs
+++ b/playground/nats/Nats.Backend/Program.cs
@@ -5,11 +5,7 @@ var builder = WebApplication.CreateBuilder(args);
 
 builder.AddServiceDefaults();
 
-builder.AddNatsClient("nats", configureOptions: opts =>
-{
-    var jsonRegistry = new NatsJsonContextSerializerRegistry(AppJsonContext.Default);
-    return opts with { SerializerRegistry = jsonRegistry };
-});
+builder.AddNatsClient("nats");
 
 builder.Services.AddHostedService<AppEventsBackendService>();
 
@@ -17,7 +13,7 @@ var app = builder.Build();
 app.MapDefaultEndpoints();
 app.Run();
 
-public class AppEventsBackendService(INatsConnection nats,  ILogger<AppEventsBackendService> logger) : IHostedService
+public class AppEventsBackendService(INatsClient nats,  ILogger<AppEventsBackendService> logger) : IHostedService
 {
     private readonly CancellationTokenSource _cts = new();
     private Task? _subscription;

--- a/playground/nats/Nats.Common/AppEvent.cs
+++ b/playground/nats/Nats.Common/AppEvent.cs
@@ -1,14 +1,6 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.Text.Json.Serialization;
-
 namespace Nats.Common;
 
 public record AppEvent(string Subject, string Name, string Description, decimal Priority);
-
-[JsonSerializable(typeof(AppEvent))]
-[JsonSourceGenerationOptions(PropertyNameCaseInsensitive = true)]
-public partial class AppJsonContext : JsonSerializerContext
-{
-}

--- a/src/Components/Aspire.NATS.Net/AspireNatsClientExtensions.cs
+++ b/src/Components/Aspire.NATS.Net/AspireNatsClientExtensions.cs
@@ -10,6 +10,7 @@ using Microsoft.Extensions.Diagnostics.HealthChecks;
 using Microsoft.Extensions.Logging;
 using NATS.Client.Core;
 using NATS.Client.JetStream;
+using NATS.Net;
 
 namespace Microsoft.Extensions.Hosting;
 
@@ -137,6 +138,7 @@ public static class AspireNatsClientExtensions
             var options = NatsOpts.Default with
             {
                 LoggerFactory = provider.GetRequiredService<ILoggerFactory>(),
+                SerializerRegistry = NatsClientDefaultSerializerRegistry.Default,
             };
 
             if (configureOptions != null)
@@ -158,11 +160,13 @@ public static class AspireNatsClientExtensions
         {
             builder.Services.TryAddSingleton(Factory);
             builder.Services.TryAddSingleton<INatsConnection>(static provider => provider.GetRequiredService<NatsConnection>());
+            builder.Services.TryAddSingleton<INatsClient>(static provider => provider.GetRequiredService<NatsConnection>());
         }
         else
         {
             builder.Services.TryAddKeyedSingleton<NatsConnection>(serviceKey, (provider, _) => Factory(provider));
             builder.Services.TryAddKeyedSingleton<INatsConnection>(serviceKey, static (provider, key) => provider.GetRequiredKeyedService<NatsConnection>(key));
+            builder.Services.TryAddKeyedSingleton<INatsClient>(serviceKey, static (provider, key) => provider.GetRequiredKeyedService<NatsConnection>(key));
         }
 
         if (!settings.DisableHealthChecks)

--- a/src/Components/Aspire.NATS.Net/README.md
+++ b/src/Components/Aspire.NATS.Net/README.md
@@ -1,6 +1,6 @@
 # Aspire.NATS.Net library
 
-Registers [INatsConnection](https://nats-io.github.io/nats.net.v2/api/NATS.Client.Core.INatsConnection.html) in the DI container for connecting NATS server. Enables corresponding health check and logging.
+Registers [INatsClient](https://nats-io.github.io/nats.net/api/NATS.Client.Core.INatsClient.html) and [INatsConnection](https://nats-io.github.io/nats.net/api/NATS.Client.Core.INatsConnection.html) in the DI container for connecting to a NATS server. Enables corresponding health check, logging and telemetry.
 
 ## Getting started
 
@@ -18,21 +18,28 @@ dotnet add package Aspire.NATS.Net
 
 ## Usage example
 
-In the _AppHost.cs_ file of your project, call the `AddNatsClient` extension method to register a `INatsConnection` for use via the dependency injection container. The method takes a connection name parameter.
+In the _Program.cs_ file of your project, call the `AddNatsClient` extension method to register an `INatsClient` (and `INatsConnection`) for use via the dependency injection container. The method takes a connection name parameter.
 
 ```csharp
 builder.AddNatsClient("nats");
 ```
 
-You can then retrieve a `INatsConnection` instance using dependency injection. For example, to retrieve a connection from a Web API controller:
+You can then retrieve an `INatsClient` instance using dependency injection. For example, to retrieve the client from a Web API controller:
 
 ```csharp
-private readonly INatsConnection _connection;
+private readonly INatsClient _client;
 
-public ProductsController(INatsConnection connection)
+public ProductsController(INatsClient client)
 {
-    _connection = connection;
+    _client = client;
 }
+```
+
+By default, the registered client uses `NatsClientDefaultSerializerRegistry` which serializes typed payloads as JSON (with raw and UTF-8 primitive support). To use a custom serializer, such as a source-generated `NatsJsonContextSerializerRegistry` for AOT, pass a `configureOptions` delegate:
+
+```csharp
+builder.AddNatsClient("nats", configureOptions: opts =>
+    opts with { SerializerRegistry = new NatsJsonContextSerializerRegistry(MyJsonContext.Default) });
 ```
 
 ## Configuration
@@ -108,7 +115,7 @@ builder.AddNatsClient("nats");
 
 ## Additional documentation
 
-* https://nats-io.github.io/nats.net.v2/documentation/intro.html
+* https://nats-io.github.io/nats.net/documentation/intro.html
 * https://github.com/microsoft/aspire/tree/main/src/Components/README.md
 
 ## Feedback & contributing

--- a/tests/Aspire.NATS.Net.Tests/AspireNatsClientExtensionsTests.cs
+++ b/tests/Aspire.NATS.Net.Tests/AspireNatsClientExtensionsTests.cs
@@ -233,6 +233,36 @@ public class AspireNatsClientExtensionsTests : IClassFixture<NatsContainerFixtur
         }, _connectionString).Dispose();
     }
 
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public void RegistersINatsClient(bool useKeyed)
+    {
+        var builder = Host.CreateEmptyApplicationBuilder(null);
+        builder.Configuration.AddInMemoryCollection([
+            new KeyValuePair<string, string?>("ConnectionStrings:nats", _connectionString)
+        ]);
+
+        if (useKeyed)
+        {
+            builder.AddKeyedNatsClient("nats");
+        }
+        else
+        {
+            builder.AddNatsClient("nats");
+        }
+
+        using var host = builder.Build();
+        var client = useKeyed ?
+            host.Services.GetRequiredKeyedService<INatsClient>("nats") :
+            host.Services.GetRequiredService<INatsClient>();
+        var connection = useKeyed ?
+            host.Services.GetRequiredKeyedService<INatsConnection>("nats") :
+            host.Services.GetRequiredService<INatsConnection>();
+
+        Assert.Same(connection, client);
+    }
+
     [Fact]
     public void CanAddMultipleKeyedServices()
     {


### PR DESCRIPTION
`AddNatsClient` now also registers `INatsClient` and defaults the `SerializerRegistry` to `NatsClientDefaultSerializerRegistry`, so typed publish/subscribe works without an explicit `configureOptions` override.

User-provided NATS serialization registries still win. Users publishing only primitives or raw bytes are unaffected; users publishing POCOs without setting a registry previously hit a runtime exception and will now receive JSON output.

Playground sample is reworked around `INatsClient`: drops the duplicated source-gen JSON wiring, auto-creates the events stream at startup, and adds a static HTML page demonstrating SSE consume with both ordered and durable consumers.

- [x] Same-name durable consumer resumes from last ack after restart
- [x] Two same-name durable consumers split work (queue-style)
- [x] Two different-name durable consumers each get all events
- [x] Backend logs show events in the dashboard Console tab