### PR TITLE
Update Azure.Provisioning.Cdn to 1.0.0-beta.2

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -44,7 +44,7 @@
     <PackageVersion Include="Azure.Provisioning.AppContainers" Version="1.2.0" />
     <PackageVersion Include="Azure.Provisioning.AppService" Version="1.3.1" />
     <PackageVersion Include="Azure.Provisioning.ApplicationInsights" Version="1.1.0" />
-    <PackageVersion Include="Azure.Provisioning.Cdn" Version="1.0.0-beta.1" />
+    <PackageVersion Include="Azure.Provisioning.Cdn" Version="1.0.0-beta.2" />
     <PackageVersion Include="Azure.Provisioning.ContainerRegistry" Version="1.1.0" />
     <PackageVersion Include="Azure.Provisioning.ContainerService" Version="1.0.0-beta.6" />
     <PackageVersion Include="Azure.Provisioning.CognitiveServices" Version="1.2.0" />
@@ -185,7 +185,7 @@
     <!-- playground apps dependencies for javascript -->
     <PackageVersion Include="Swashbuckle.AspNetCore" Version="9.0.6" />
     <!-- Pinned versions for Component Governance - Remove when root dependencies are updated -->
-    <PackageVersion Include="Azure.Core" Version="1.53.0" />
+    <PackageVersion Include="Azure.Core" Version="1.54.0" />
     <PackageVersion Include="Azure.Identity" Version="1.21.0" />
     <!-- https://github.com/Azure/azure-cosmos-dotnet-v3/pull/3313 -->
     <PackageVersion Include="Newtonsoft.Json" Version="13.0.4" />

--- a/src/Aspire.Hosting.Azure.FrontDoor/AzureFrontDoorExtensions.cs
+++ b/src/Aspire.Hosting.Azure.FrontDoor/AzureFrontDoorExtensions.cs
@@ -20,13 +20,6 @@ namespace Aspire.Hosting;
 /// </summary>
 public static class AzureFrontDoorExtensions
 {
-    // Azure resource name length limits (from Azure portal).
-    private const int ProfileNameMaxLength = 90;
-    private const int EndpointNameMaxLength = 46;
-    private const int OriginGroupNameMaxLength = 90;
-    private const int OriginNameMaxLength = 90;
-    private const int RouteNameMaxLength = 90;
-
     /// <summary>
     /// Adds an Azure Front Door resource to the application model.
     /// </summary>
@@ -76,7 +69,6 @@ public static class AzureFrontDoorExtensions
             var profile = new CdnProfile(infrastructure.AspireResource.GetBicepIdentifier())
             {
                 SkuName = CdnSkuName.StandardAzureFrontDoor,
-                Name = BicepFunction.Take(BicepFunction.Interpolate($"{infrastructure.AspireResource.Name}-{BicepFunction.GetUniqueString(BicepFunction.GetResourceGroup().Id)}"), ProfileNameMaxLength),
                 Location = new AzureLocation("Global"),
                 Tags = { { "aspire-resource-name", infrastructure.AspireResource.Name } }
             };
@@ -89,7 +81,6 @@ public static class AzureFrontDoorExtensions
             {
                 var originResource = originAnnotation.Resource;
                 var originBicepId = Infrastructure.NormalizeBicepIdentifier(originResource.Name);
-                var originName = originResource.Name.ToLowerInvariant();
 
                 var endpointReference = GetOriginEndpoint(originResource);
 
@@ -105,7 +96,6 @@ public static class AzureFrontDoorExtensions
                 var endpoint = new FrontDoorEndpoint($"{originBicepId}Endpoint")
                 {
                     Parent = profile,
-                    Name = BicepFunction.Take(BicepFunction.Interpolate($"{originName}-{BicepFunction.GetUniqueString(BicepFunction.GetResourceGroup().Id)}"), EndpointNameMaxLength),
                     Location = new AzureLocation("Global")
                 };
                 infrastructure.Add(endpoint);
@@ -114,7 +104,6 @@ public static class AzureFrontDoorExtensions
                 var originGroup = new FrontDoorOriginGroup($"{originBicepId}OriginGroup")
                 {
                     Parent = profile,
-                    Name = BicepFunction.Take(BicepFunction.Interpolate($"{originName}-og-{BicepFunction.GetUniqueString(BicepFunction.GetResourceGroup().Id)}"), OriginGroupNameMaxLength),
                     HealthProbeSettings = new HealthProbeSettings
                     {
                         ProbeProtocol = probeProtocol,
@@ -133,7 +122,6 @@ public static class AzureFrontDoorExtensions
                 var origin = new FrontDoorOrigin($"{originBicepId}Origin")
                 {
                     Parent = originGroup,
-                    Name = BicepFunction.Take(BicepFunction.Interpolate($"{originName}-origin-{BicepFunction.GetUniqueString(BicepFunction.GetResourceGroup().Id)}"), OriginNameMaxLength),
                     HostName = hostParam,
                     OriginHostHeader = hostParam
                 };
@@ -143,7 +131,6 @@ public static class AzureFrontDoorExtensions
                 var route = new FrontDoorRoute($"{originBicepId}Route")
                 {
                     Parent = endpoint,
-                    Name = BicepFunction.Take(BicepFunction.Interpolate($"{originName}-route-{BicepFunction.GetUniqueString(BicepFunction.GetResourceGroup().Id)}"), RouteNameMaxLength),
                     OriginGroupId = originGroup.Id,
                     PatternsToMatch = ["/*"],
                     ForwardingProtocol = ForwardingProtocol.HttpsOnly,

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureFrontDoorTests.AddAzureFrontDoorWithMultipleOriginsGeneratesBicep.verified.bicep
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureFrontDoorTests.AddAzureFrontDoorWithMultipleOriginsGeneratesBicep.verified.bicep
@@ -6,7 +6,7 @@ param api_host string
 param web_host string
 
 resource frontdoor 'Microsoft.Cdn/profiles@2025-06-01' = {
-  name: take('frontdoor-${uniqueString(resourceGroup().id)}', 90)
+  name: take('frontdoor-${uniqueString(resourceGroup().id)}', 260)
   location: 'Global'
   sku: {
     name: 'Standard_AzureFrontDoor'
@@ -17,13 +17,13 @@ resource frontdoor 'Microsoft.Cdn/profiles@2025-06-01' = {
 }
 
 resource apiEndpoint 'Microsoft.Cdn/profiles/afdEndpoints@2025-06-01' = {
-  name: take('api-${uniqueString(resourceGroup().id)}', 46)
+  name: take('apiEndpoint-${uniqueString(resourceGroup().id)}', 46)
   location: 'Global'
   parent: frontdoor
 }
 
 resource apiOriginGroup 'Microsoft.Cdn/profiles/originGroups@2025-06-01' = {
-  name: take('api-og-${uniqueString(resourceGroup().id)}', 90)
+  name: take('apiOriginGroup-${uniqueString(resourceGroup().id)}', 90)
   properties: {
     healthProbeSettings: {
       probePath: '/'
@@ -39,7 +39,7 @@ resource apiOriginGroup 'Microsoft.Cdn/profiles/originGroups@2025-06-01' = {
 }
 
 resource apiOrigin 'Microsoft.Cdn/profiles/originGroups/origins@2025-06-01' = {
-  name: take('api-origin-${uniqueString(resourceGroup().id)}', 90)
+  name: take('apiOrigin-${uniqueString(resourceGroup().id)}', 90)
   properties: {
     hostName: api_host
     originHostHeader: api_host
@@ -48,7 +48,7 @@ resource apiOrigin 'Microsoft.Cdn/profiles/originGroups/origins@2025-06-01' = {
 }
 
 resource apiRoute 'Microsoft.Cdn/profiles/afdEndpoints/routes@2025-06-01' = {
-  name: take('api-route-${uniqueString(resourceGroup().id)}', 90)
+  name: take('apiRoute-${uniqueString(resourceGroup().id)}', 90)
   properties: {
     forwardingProtocol: 'HttpsOnly'
     httpsRedirect: 'Enabled'
@@ -67,13 +67,13 @@ resource apiRoute 'Microsoft.Cdn/profiles/afdEndpoints/routes@2025-06-01' = {
 }
 
 resource webEndpoint 'Microsoft.Cdn/profiles/afdEndpoints@2025-06-01' = {
-  name: take('web-${uniqueString(resourceGroup().id)}', 46)
+  name: take('webEndpoint-${uniqueString(resourceGroup().id)}', 46)
   location: 'Global'
   parent: frontdoor
 }
 
 resource webOriginGroup 'Microsoft.Cdn/profiles/originGroups@2025-06-01' = {
-  name: take('web-og-${uniqueString(resourceGroup().id)}', 90)
+  name: take('webOriginGroup-${uniqueString(resourceGroup().id)}', 90)
   properties: {
     healthProbeSettings: {
       probePath: '/'
@@ -89,7 +89,7 @@ resource webOriginGroup 'Microsoft.Cdn/profiles/originGroups@2025-06-01' = {
 }
 
 resource webOrigin 'Microsoft.Cdn/profiles/originGroups/origins@2025-06-01' = {
-  name: take('web-origin-${uniqueString(resourceGroup().id)}', 90)
+  name: take('webOrigin-${uniqueString(resourceGroup().id)}', 90)
   properties: {
     hostName: web_host
     originHostHeader: web_host
@@ -98,7 +98,7 @@ resource webOrigin 'Microsoft.Cdn/profiles/originGroups/origins@2025-06-01' = {
 }
 
 resource webRoute 'Microsoft.Cdn/profiles/afdEndpoints/routes@2025-06-01' = {
-  name: take('web-route-${uniqueString(resourceGroup().id)}', 90)
+  name: take('webRoute-${uniqueString(resourceGroup().id)}', 90)
   properties: {
     forwardingProtocol: 'HttpsOnly'
     httpsRedirect: 'Enabled'

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureFrontDoorTests.AddAzureFrontDoorWithSingleOriginGeneratesBicep.verified.bicep
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureFrontDoorTests.AddAzureFrontDoorWithSingleOriginGeneratesBicep.verified.bicep
@@ -4,7 +4,7 @@ param location string = resourceGroup().location
 param my_api_host string
 
 resource frontdoor 'Microsoft.Cdn/profiles@2025-06-01' = {
-  name: take('frontdoor-${uniqueString(resourceGroup().id)}', 90)
+  name: take('frontdoor-${uniqueString(resourceGroup().id)}', 260)
   location: 'Global'
   sku: {
     name: 'Standard_AzureFrontDoor'
@@ -15,13 +15,13 @@ resource frontdoor 'Microsoft.Cdn/profiles@2025-06-01' = {
 }
 
 resource my_apiEndpoint 'Microsoft.Cdn/profiles/afdEndpoints@2025-06-01' = {
-  name: take('my-api-${uniqueString(resourceGroup().id)}', 46)
+  name: take('myapiEndpoint-${uniqueString(resourceGroup().id)}', 46)
   location: 'Global'
   parent: frontdoor
 }
 
 resource my_apiOriginGroup 'Microsoft.Cdn/profiles/originGroups@2025-06-01' = {
-  name: take('my-api-og-${uniqueString(resourceGroup().id)}', 90)
+  name: take('myapiOriginGroup-${uniqueString(resourceGroup().id)}', 90)
   properties: {
     healthProbeSettings: {
       probePath: '/'
@@ -37,7 +37,7 @@ resource my_apiOriginGroup 'Microsoft.Cdn/profiles/originGroups@2025-06-01' = {
 }
 
 resource my_apiOrigin 'Microsoft.Cdn/profiles/originGroups/origins@2025-06-01' = {
-  name: take('my-api-origin-${uniqueString(resourceGroup().id)}', 90)
+  name: take('myapiOrigin-${uniqueString(resourceGroup().id)}', 90)
   properties: {
     hostName: my_api_host
     originHostHeader: my_api_host
@@ -46,7 +46,7 @@ resource my_apiOrigin 'Microsoft.Cdn/profiles/originGroups/origins@2025-06-01' =
 }
 
 resource my_apiRoute 'Microsoft.Cdn/profiles/afdEndpoints/routes@2025-06-01' = {
-  name: take('my-api-route-${uniqueString(resourceGroup().id)}', 90)
+  name: take('myapiRoute-${uniqueString(resourceGroup().id)}', 90)
   properties: {
     forwardingProtocol: 'HttpsOnly'
     httpsRedirect: 'Enabled'


### PR DESCRIPTION
## Description

With the latest version we can remove our own name generation and length limit and instead rely on the base Azure.Provisioning algorithm to generate names.

NOTE: This is a change from the 13.3.0-preview version and can result in duplicate endpoints, origin groups, routes. etc. Remove the existing resource, or set the Name explicitly in ConfigureInfrastructure, to avoid it during the upgrade.

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
- Did you add public API?
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [x] No
