### PR TITLE
Fix tunnel-dependent containers that wait on other resources

### DIFF
--- a/src/Aspire.Hosting/Dcp/ContainerCreationContext.cs
+++ b/src/Aspire.Hosting/Dcp/ContainerCreationContext.cs
@@ -1,7 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.Threading.Channels;
 using Aspire.Hosting.Dcp.Model;
 
 namespace Aspire.Hosting.Dcp;
@@ -18,38 +17,12 @@ internal record class ContainerNetworkService
 /// <summary>
 /// Helps coordinate container creation tasks and container tunnel creation and configuration task.
 /// </summary>
-internal sealed class ContainerCreationContext : IDisposable
+internal sealed class ContainerCreationContext(Task containerPrerequisitesReady, Task containerTunnelPrerequisitesReady)
 {
-    public readonly CountdownEvent ContainerServicesSpecReady;
-    public readonly Channel<ContainerNetworkService> ContainerServicesChan;
-    private readonly Lazy<Task> _createTunnelLazy;
+    // The task that completes when the container prerequisites are ready.
+    public Task ContainerPrerequisitesReady { get; } = containerPrerequisitesReady;
 
-    public Task CreateTunnel => _createTunnelLazy.Value;
-
-    public ContainerCreationContext(int containerCount, Func<ContainerCreationContext, Task> createTunnelFunc)
-    {
-        ContainerServicesSpecReady = new CountdownEvent(containerCount);
-        ContainerServicesChan = Channel.CreateUnbounded<ContainerNetworkService>();
-        _createTunnelLazy = new Lazy<Task>(() => createTunnelFunc(this), LazyThreadSafetyMode.ExecutionAndPublication);
-    }
-
-    /// <summary>
-    /// Creates a new ContainerCreationContext for creating additional containers (beyond the initial set created during application startup).
-    /// </summary>
-    /// <remarks>
-    /// The new context will share the same tunnel creation task as the original context, ensuring that the tunnel is only created once
-    /// and that all containers will properly synchronize with the tunnel creation task.
-    /// </remarks>
-    public ContainerCreationContext ForAdditionalContainers(int additionalContainerCount)
-    {
-        return new ContainerCreationContext(additionalContainerCount, _ => CreateTunnel);
-    }
-
-    /// <summary>
-    /// Disposes resources owned by the container creation context.
-    /// </summary>
-    public void Dispose()
-    {
-        ContainerServicesSpecReady.Dispose();
-    }
+    // The task that completes when the container tunnel prerequisites are ready.
+    // For container tunnel to start, both the container prerequisites and the container tunnel prerequisites must be ready.
+    public Task ContainerTunnelPrerequisitesReady { get; } = containerTunnelPrerequisitesReady;
 }

--- a/src/Aspire.Hosting/Dcp/ContainerCreationContext.cs
+++ b/src/Aspire.Hosting/Dcp/ContainerCreationContext.cs
@@ -17,7 +17,10 @@ internal record class ContainerNetworkService
 /// <summary>
 /// Helps coordinate container creation tasks and container tunnel creation and configuration task.
 /// </summary>
-internal sealed class ContainerCreationContext(Task containerPrerequisitesReady, Task containerTunnelPrerequisitesReady)
+internal sealed class ContainerCreationContext(
+    Task containerPrerequisitesReady, 
+    Task containerTunnelPrerequisitesReady,
+    CancellationToken applicationRunCancellationToken)
 {
     // The task that completes when the container prerequisites are ready.
     public Task ContainerPrerequisitesReady { get; } = containerPrerequisitesReady;
@@ -25,4 +28,8 @@ internal sealed class ContainerCreationContext(Task containerPrerequisitesReady,
     // The task that completes when the container tunnel prerequisites are ready.
     // For container tunnel to start, both the container prerequisites and the container tunnel prerequisites must be ready.
     public Task ContainerTunnelPrerequisitesReady { get; } = containerTunnelPrerequisitesReady;
+
+    // The cancellation token for the application run that this context belongs to. 
+    // This is used to cancel the container tunnel creation task if the application run is cancelled.
+    public CancellationToken ApplicationRunCancellationToken { get; } = applicationRunCancellationToken;
 }

--- a/src/Aspire.Hosting/Dcp/ContainerCreator.cs
+++ b/src/Aspire.Hosting/Dcp/ContainerCreator.cs
@@ -43,7 +43,7 @@ internal record struct HostResourceWithEndpoints(
 /// Handles preparation and creation of Container, ContainerExec, ContainerNetwork,
 /// and ContainerNetworkTunnelProxy DCP resources.
 /// </summary>
-internal sealed class ContainerCreator : IObjectCreator<Container, ContainerCreationContext>, IObjectCreator<ContainerExec, EmptyCreationContext>
+internal sealed class ContainerCreator : IObjectCreator<Container, ContainerCreationContext>, IObjectCreator<ContainerExec, EmptyCreationContext>, IDisposable
 {
     private const string ContainerTunnelContainerName = "aspire";
 
@@ -83,6 +83,11 @@ internal sealed class ContainerCreator : IObjectCreator<Container, ContainerCrea
         _logger = logger;
         _normalizedApplicationName = DcpExecutor.NormalizeApplicationName(hostEnvironment.ApplicationName);
         _appResources = appResources;
+    }
+
+    public void Dispose()
+    {
+        _tunnelSemaphore.Dispose();
     }
 
     private async Task<string> GetContainerHostNameAsync(CancellationToken cancellationToken = default)
@@ -431,8 +436,8 @@ internal sealed class ContainerCreator : IObjectCreator<Container, ContainerCrea
     private async Task<AppResource<ContainerNetworkTunnelProxy>> CreateTunnelProxyResourceAsync(
         IDcpObjectFactory factory,
         List<TunnelConfiguration>? tunnels,
-        CancellationToken cancellationToken = default
-) {
+        CancellationToken cancellationToken = default)
+    {
         Debug.Assert(_options.Value.EnableAspireContainerTunnel, "This method should only be called if the container tunnel feature is enabled.");
         Debug.Assert(!_appResources.Get().OfType<AppResource<ContainerNetworkTunnelProxy>>().Any(), "This method should only be called if a tunnel proxy resource hasn't already been created.");
 
@@ -485,7 +490,6 @@ internal sealed class ContainerCreator : IObjectCreator<Container, ContainerCrea
 
         await Task.WhenAll([cctx.ContainerPrerequisitesReady, cctx.ContainerTunnelPrerequisitesReady]).WaitAsync(cancellationToken).ConfigureAwait(false);
 
-        _appResources.AddRange(containerNetworkServices.Select(cns => cns.ServiceResource));
         var serviceObjects = containerNetworkServices.Select(cns => cns.ServiceResource.DcpResource).ToArray();
         await factory.CreateDcpObjectsAsync(serviceObjects, cancellationToken).ConfigureAwait(false);
 
@@ -527,11 +531,10 @@ internal sealed class ContainerCreator : IObjectCreator<Container, ContainerCrea
         }
 
         await factory.UpdateWithEffectiveAddressInfo(serviceObjects, cancellationToken, TimeSpan.FromMinutes(1)).ConfigureAwait(false);
-        DcpModelUtilities.AddAllocatedEndpointInfo(
-            _appResources.Get().OfType<RenderedModelResource<Executable>>(),
-            AllocatedEndpointsMode.ContainerTunnel,
-            _appResources.Get(),
-            _options.Value.EnableAspireContainerTunnel,
+        _appResources.AddRange(containerNetworkServices.Select(cns => cns.ServiceResource));
+        DcpModelUtilities.AddContainerTunnelAllocatedEndpoints(
+            hostDependencies.Select(hd => hd.Resource),
+            _appResources,
             await GetContainerHostNameAsync(cancellationToken).ConfigureAwait(false));
     }
 

--- a/src/Aspire.Hosting/Dcp/ContainerCreator.cs
+++ b/src/Aspire.Hosting/Dcp/ContainerCreator.cs
@@ -57,6 +57,9 @@ internal sealed class ContainerCreator : IObjectCreator<Container, ContainerCrea
     private readonly ILogger<ContainerCreator> _logger;
     private readonly string _normalizedApplicationName;
     private readonly DcpAppResourceStore _appResources;
+    private readonly SemaphoreSlim _tunnelSemaphore = new(1, 1);
+    private readonly List<TunnelConfiguration> _tunnelConfigurations = [];
+    private Task<AppResource<ContainerNetworkTunnelProxy>>? _tunnelCreationTask;
 
     public ContainerCreator(
         IConfiguration configuration,
@@ -240,25 +243,15 @@ internal sealed class ContainerCreator : IObjectCreator<Container, ContainerCrea
 
     public async Task CreateObjectAsync(RenderedModelResource<Container> cr, ContainerCreationContext cctx, ILogger logger, IDcpObjectFactory factory, CancellationToken cancellationToken)
     {
-        var signalServicesSpecReadyOnce = ConcurrencyUtils.Once(() => cctx.ContainerServicesSpecReady.Signal());
+        var hostDependencies = (await GetHostDependenciesAsync(cr.ModelResource, cancellationToken).ConfigureAwait(false)).ToImmutableArray();
 
-        try
+        if (hostDependencies.Any())
         {
-            var hostDependencies = (await GetHostDependenciesAsync(cr.ModelResource, cancellationToken).ConfigureAwait(false)).ToImmutableArray();
-
-            if (hostDependencies.Any())
-            {
-                await CreateTunnelDependentContainerAsync(cr, hostDependencies, cctx, signalServicesSpecReadyOnce, factory, cancellationToken).ConfigureAwait(false);
-            }
-            else
-            {
-                signalServicesSpecReadyOnce();
-                await BuildAndCreateContainerAsync(cr, logger, factory, cancellationToken).ConfigureAwait(false);
-            }
+            await CreateHostDependentContainerAsync(cr, hostDependencies, cctx, factory, cancellationToken).ConfigureAwait(false);
         }
-        finally
+        else
         {
-            signalServicesSpecReadyOnce();
+            await BuildAndCreateContainerAsync(cr, logger, factory, cancellationToken).ConfigureAwait(false);
         }
     }
 
@@ -435,8 +428,11 @@ internal sealed class ContainerCreator : IObjectCreator<Container, ContainerCrea
         return services;
     }
 
-    internal async Task<AppResource<ContainerNetworkTunnelProxy>> CreateTunnelProxyResourceAsync(List<TunnelConfiguration>? tunnels, CancellationToken cancellationToken = default)
-    {
+    private async Task<AppResource<ContainerNetworkTunnelProxy>> CreateTunnelProxyResourceAsync(
+        IDcpObjectFactory factory,
+        List<TunnelConfiguration>? tunnels,
+        CancellationToken cancellationToken = default
+) {
         Debug.Assert(_options.Value.EnableAspireContainerTunnel, "This method should only be called if the container tunnel feature is enabled.");
         Debug.Assert(!_appResources.Get().OfType<AppResource<ContainerNetworkTunnelProxy>>().Any(), "This method should only be called if a tunnel proxy resource hasn't already been created.");
 
@@ -446,72 +442,152 @@ internal sealed class ContainerCreator : IObjectCreator<Container, ContainerCrea
         tunnelProxy.Spec.Tunnels = tunnels;
         var tunnelAppResource = new AppResource<ContainerNetworkTunnelProxy>(tunnelProxy);
         _appResources.Add(tunnelAppResource);
+
+        await factory.CreateDcpObjectsAsync([tunnelProxy], cancellationToken).ConfigureAwait(false);
+        await WaitForTunnelProxyAsync(tunnelProxy, factory, cancellationToken).ConfigureAwait(false);
+
         return tunnelAppResource;
     }
 
     /// <summary>
-    /// Creates the container tunnel: reads tunnel service specs from the container creation context,
-    /// creates the corresponding DCP service and tunnel proxy objects, and waits for their addresses.
+    /// Ensures that host resources referenced by a container are reachable.
     /// </summary>
-    internal async Task CreateTunnelAsync(ContainerCreationContext cctx, IDcpObjectFactory factory, CancellationToken cancellationToken)
+    internal async Task EnsureHostConnectivityAsync(ImmutableArray<HostResourceWithEndpoints> hostDependencies, ContainerCreationContext cctx, IDcpObjectFactory factory, CancellationToken cancellationToken)
     {
-        // Container creation tasks need to figure out dependencies of each container
-        // and then create Service and TunnelConfiguration definitions for each of them.
-        cctx.ContainerServicesSpecReady.Wait(cancellationToken);
-        cctx.ContainerServicesChan.Writer.Complete();
+        if (!_options.Value.EnableAspireContainerTunnel)
+        {
+            // If we are not tunneling, regular container creation prerequisites are all we need.
+            await cctx.ContainerPrerequisitesReady.WaitAsync(cancellationToken).ConfigureAwait(false);
+            return;
+        }
 
-        // Now create the container network services for the host resources, update the tunnel, and advertise AllocatedEndpoints.
-        var containerNetworkServices = cctx.ContainerServicesChan.Reader.ReadAllAsync(cancellationToken).ToBlockingEnumerable(cancellationToken).ToArray();
+        ContainerNetworkService[] containerNetworkServices;
+
+        // While not strictly necessary from correctness perspective, it is better for performance if tunnel creation
+        // is as "chunky" as possible. That is why we serialize the discovery of host dependencies, 
+        // so concurrently-created containers that share host dependencies do not "split" these dependencies 
+        // (and associated tunnels) between themselves.
+        await _tunnelSemaphore.WaitAsync(cancellationToken).ConfigureAwait(false);
+        try
+        {
+            containerNetworkServices = hostDependencies.SelectMany(CreateContainerNetworkServicesForHostResource).ToArray();
+        }
+        finally
+        {
+            _tunnelSemaphore.Release();
+        }
+
+        if (containerNetworkServices.Length == 0)
+        {
+            // We have already set up tunnels for all currently-needed host dependencies.
+            return;
+        }
+
+        await Task.WhenAll([cctx.ContainerPrerequisitesReady, cctx.ContainerTunnelPrerequisitesReady]).WaitAsync(cancellationToken).ConfigureAwait(false);
+
         _appResources.AddRange(containerNetworkServices.Select(cns => cns.ServiceResource));
         var serviceObjects = containerNetworkServices.Select(cns => cns.ServiceResource.DcpResource).ToArray();
         await factory.CreateDcpObjectsAsync(serviceObjects, cancellationToken).ConfigureAwait(false);
 
-        var tunnels = containerNetworkServices.Where(s => s.TunnelConfig is not null).Select(s => s.TunnelConfig!).ToList();
-        Debug.Assert(tunnels.Count == containerNetworkServices.Length, "Each tunneled service should have a tunnel config");
-        await CreateTunnelProxyResourceAsync(tunnels, cancellationToken).ConfigureAwait(false);
+        var newTunnels = containerNetworkServices.Where(s => s.TunnelConfig is not null).Select(s => s.TunnelConfig!).ToArray();
+        Debug.Assert(newTunnels.Length == containerNetworkServices.Length, "Each tunneled service should have a tunnel config");
+        bool tunnelConfigIsValid = false;
 
-        // Create all ContainerNetworkTunnelProxy objects that have been prepared.
-        var tunnelProxies = _appResources.Get().OfType<AppResource<ContainerNetworkTunnelProxy>>().Select(r => r.DcpResource).ToArray();
-        await factory.CreateDcpObjectsAsync(tunnelProxies, cancellationToken).ConfigureAwait(false);
+        await _tunnelSemaphore.WaitAsync(cancellationToken).ConfigureAwait(false);
+        try
+        {
+            _tunnelConfigurations.AddRange(newTunnels);
+            if (_tunnelCreationTask is null)
+            {
+                _tunnelCreationTask = CreateTunnelProxyResourceAsync(factory, _tunnelConfigurations.ToList(), cancellationToken);
+                tunnelConfigIsValid = true; // .. because the tunnel proxy will be created with "our" current tunnel configuration.
+            }
+        }
+        finally
+        {
+            _tunnelSemaphore.Release();
+        }
 
-        // Wait for each tunnel proxy to reach a stable state (Running or Failed).
+        var tunnelProxyResource = await _tunnelCreationTask.WaitAsync(cancellationToken).ConfigureAwait(false);
+
+        if (!tunnelConfigIsValid)
+        {
+            // Nothing good will come from patching the tunnel proxy concurrently, and with different tunnel configurations.
+            await _tunnelSemaphore.WaitAsync(cancellationToken).ConfigureAwait(false);
+            try
+            {
+                await factory.PatchDcpObjectAsync(tunnelProxyResource.DcpResource,
+                    p => p.Spec.Tunnels = _tunnelConfigurations.ToList(),
+                    cancellationToken).ConfigureAwait(false);
+            }
+            finally
+            {
+                _tunnelSemaphore.Release();
+            };
+        }
+
+        await factory.UpdateWithEffectiveAddressInfo(serviceObjects, cancellationToken, TimeSpan.FromMinutes(1)).ConfigureAwait(false);
+        DcpModelUtilities.AddAllocatedEndpointInfo(
+            _appResources.Get().OfType<RenderedModelResource<Executable>>(),
+            AllocatedEndpointsMode.ContainerTunnel,
+            _appResources.Get(),
+            _options.Value.EnableAspireContainerTunnel,
+            await GetContainerHostNameAsync(cancellationToken).ConfigureAwait(false));
+    }
+
+    private async Task WaitForTunnelProxyAsync(
+        ContainerNetworkTunnelProxy tunnelProxy,
+        IDcpObjectFactory factory,
+        CancellationToken cancellationToken)
+    {
         // Container tunnel initialization can take a while if the container tunnel image needs to be built,
         // especially if the required image pull is slow, hence 10 minute timeout here.
         var observedProxies = await factory.WaitForStateAsync(
-            tunnelProxies,
-            p => p.Status?.State,
+            [tunnelProxy],
+            p =>
+            {
+                var status = p.Status;
+                if (string.Equals(status?.State, ContainerNetworkTunnelProxyState.Failed, StringComparison.Ordinal))
+                {
+                    return ContainerNetworkTunnelProxyState.Failed;
+                }
+
+                if (status is not null && string.Equals(status.State, ContainerNetworkTunnelProxyState.Running, StringComparison.Ordinal))
+                {
+                    return ContainerNetworkTunnelProxyState.Running;
+                }
+
+                return null;
+            },
             [ContainerNetworkTunnelProxyState.Running, ContainerNetworkTunnelProxyState.Failed],
             TimeSpan.FromMinutes(10),
             cancellationToken).ConfigureAwait(false);
 
-        var failedProxies = observedProxies
-            .Where(p => string.Equals(p.Status?.State, ContainerNetworkTunnelProxyState.Failed, StringComparison.Ordinal))
-            .ToArray();
-        var pendingProxies = observedProxies
-            .Where(p => !string.Equals(p.Status?.State, ContainerNetworkTunnelProxyState.Running, StringComparison.Ordinal)
-                     && !string.Equals(p.Status?.State, ContainerNetworkTunnelProxyState.Failed, StringComparison.Ordinal))
-            .ToArray();
+        var observedProxy = observedProxies.Single();
+        tunnelProxy.Status = observedProxy.Status;
+
+        var failed = string.Equals(observedProxy.Status?.State, ContainerNetworkTunnelProxyState.Failed, StringComparison.Ordinal);
+        var observedStatus = observedProxy.Status;
+        var running = observedStatus is not null &&
+            string.Equals(observedStatus.State, ContainerNetworkTunnelProxyState.Running, StringComparison.Ordinal);
 
         const string noDetailsAvailable = "(no additional error details available)";
-        foreach (var proxy in failedProxies)
+        if (failed)
         {
             _logger.LogError(
                 "Container network tunnel proxy '{Name}' failed: {Details}",
-                proxy.Metadata.Name,
-                proxy.Status?.Message ?? noDetailsAvailable);
+                observedProxy.Metadata.Name,
+                observedProxy.Status?.Message ?? noDetailsAvailable);
         }
 
-        if (failedProxies.Length > 0 || pendingProxies.Length > 0)
+        if (failed || !running)
         {
-            var failedDetails = failedProxies.Select(p => $"'{p.Metadata.Name}': {p.Status?.Message ?? noDetailsAvailable}");
-            var unstableDetails = pendingProxies.Select(p => $"'{p.Metadata.Name}': did not reach a stable state (current state: '{p.Status?.State ?? "(unknown)"}')");
-            var allDetails = string.Join("; ", failedDetails.Concat(unstableDetails));
+            var details = failed
+                ? $"'{observedProxy.Metadata.Name}': {observedProxy.Status?.Message ?? noDetailsAvailable}"
+                : $"'{observedProxy.Metadata.Name}': did not reach a stable state (current state: '{observedProxy.Status?.State ?? "(unknown)"}')";
             throw new DistributedApplicationException(
-                $"One or more container network tunnel proxies did not start successfully: {allDetails}");
+                $"One or more container network tunnel proxies did not start successfully: {details}");
         }
-
-        // All tunnel proxies are running, so service address allocation should be quick.
-        await factory.UpdateWithEffectiveAddressInfo(serviceObjects, cancellationToken, TimeSpan.FromMinutes(1)).ConfigureAwait(false);
     }
 
     internal async Task<IEnumerable<HostResourceWithEndpoints>> GetHostDependenciesAsync(IResource resource, CancellationToken cancellationToken)
@@ -541,26 +617,18 @@ internal sealed class ContainerCreator : IObjectCreator<Container, ContainerCrea
         return hostDependencies;
     }
 
-    internal async Task CreateTunnelDependentContainerAsync(RenderedModelResource<Container> cr, ImmutableArray<HostResourceWithEndpoints> hostDependencies, ContainerCreationContext cctx, Action signalServicesSpecReadyOnce, IDcpObjectFactory factory, CancellationToken cToken)
+    internal async Task CreateHostDependentContainerAsync(RenderedModelResource<Container> cr, ImmutableArray<HostResourceWithEndpoints> hostDependencies, ContainerCreationContext cctx, IDcpObjectFactory factory, CancellationToken cToken)
     {
         cToken.ThrowIfCancellationRequested();
 
-        List<ContainerNetworkService> newServices = [];
-        foreach (var dep in hostDependencies)
-        {
-            var cnetServices = CreateContainerNetworkServicesForHostResource(dep);
-            newServices.AddRange(cnetServices);
-        }
-        if (newServices.Count > 0)
-        {
-            foreach (var s in newServices)
-            {
-                await cctx.ContainerServicesChan.Writer.WriteAsync(s, cToken).ConfigureAwait(false);
-            }
-        }
+        await EnsureHostConnectivityAsync(hostDependencies, cctx, factory, cToken).ConfigureAwait(false);
 
-        signalServicesSpecReadyOnce();
-        await cctx.CreateTunnel.ConfigureAwait(false);
+        var hostEndpointAllocatedTasks = hostDependencies
+            .SelectMany(h => h.Endpoints)
+            .Where(e => e.Protocol == ProtocolType.Tcp)
+            .Select(e => e.AllAllocatedEndpoints.GetAllocatedEndpointAsync(KnownNetworkIdentifiers.DefaultAspireContainerNetwork, cToken))
+            .ToArray();
+        await Task.WhenAll(hostEndpointAllocatedTasks).ConfigureAwait(false);
 
         await BuildAndCreateContainerAsync(cr, _loggerService.GetLogger(cr.ModelResource), factory, cToken).ConfigureAwait(false);
     }

--- a/src/Aspire.Hosting/Dcp/ContainerCreator.cs
+++ b/src/Aspire.Hosting/Dcp/ContainerCreator.cs
@@ -503,7 +503,7 @@ internal sealed class ContainerCreator : IObjectCreator<Container, ContainerCrea
             _tunnelConfigurations.AddRange(newTunnels);
             if (_tunnelCreationTask is null)
             {
-                _tunnelCreationTask = CreateTunnelProxyResourceAsync(factory, _tunnelConfigurations.ToList(), cancellationToken);
+                _tunnelCreationTask = CreateTunnelProxyResourceAsync(factory, _tunnelConfigurations.ToList(), cctx.ApplicationRunCancellationToken);
                 tunnelConfigIsValid = true; // .. because the tunnel proxy will be created with "our" current tunnel configuration.
             }
         }

--- a/src/Aspire.Hosting/Dcp/DcpExecutor.cs
+++ b/src/Aspire.Hosting/Dcp/DcpExecutor.cs
@@ -206,10 +206,8 @@ internal sealed partial class DcpExecutor : IDcpExecutor, IDcpObjectFactory, IAs
             {
                 await getProxyAddresses.ConfigureAwait(false);
 
-                DcpModelUtilities.AddAllocatedEndpointInfo(
+                DcpModelUtilities.AddWorkloadAllocatedEndpoints(
                     executables,
-                    AllocatedEndpointsMode.Workload,
-                    _appResources.Get(),
                     _options.Value.EnableAspireContainerTunnel,
                     ContainerHostName);
                 await PublishEndpointsAllocatedEventAsync(executables, ct).ConfigureAwait(false);
@@ -231,10 +229,8 @@ internal sealed partial class DcpExecutor : IDcpExecutor, IDcpObjectFactory, IAs
                 await Task.WhenAll([getProxyAddresses, createContainerNetworks]).WaitAsync(ct).ConfigureAwait(false);
 
                 // Allocate container workload endpoints, then publish endpoint-allocated events.
-                DcpModelUtilities.AddAllocatedEndpointInfo(
+                DcpModelUtilities.AddWorkloadAllocatedEndpoints(
                     containers,
-                    AllocatedEndpointsMode.Workload,
-                    _appResources.Get(),
                     _options.Value.EnableAspireContainerTunnel,
                     ContainerHostName);
                 await PublishEndpointsAllocatedEventAsync(containers, ct).ConfigureAwait(false);
@@ -324,6 +320,7 @@ internal sealed partial class DcpExecutor : IDcpExecutor, IDcpObjectFactory, IAs
         {
             ar.Dispose();
         }
+        _containerCreator.Dispose();
     }
 
     /// <summary>

--- a/src/Aspire.Hosting/Dcp/DcpExecutor.cs
+++ b/src/Aspire.Hosting/Dcp/DcpExecutor.cs
@@ -221,7 +221,7 @@ internal sealed partial class DcpExecutor : IDcpExecutor, IDcpObjectFactory, IAs
             }, ct);
 
             // Configuring containers that use the tunnel require these host network-side endpoints for Executables to be ready.
-            var cctx = new ContainerCreationContext(createContainerNetworks, createExecutableEndpoints);
+            var cctx = new ContainerCreationContext(createContainerNetworks, createExecutableEndpoints, ct);
             _containerContextSource.SetResult(cctx);
 
             var createContainers = Task.Run(async () =>

--- a/src/Aspire.Hosting/Dcp/DcpExecutor.cs
+++ b/src/Aspire.Hosting/Dcp/DcpExecutor.cs
@@ -6,7 +6,6 @@
 
 using System.Collections.Immutable;
 using System.Diagnostics;
-using System.Diagnostics.CodeAnalysis;
 using System.Text;
 using System.Text.Json;
 using System.Text.RegularExpressions;
@@ -73,7 +72,7 @@ internal sealed partial class DcpExecutor : IDcpExecutor, IDcpObjectFactory, IAs
     private readonly ExecutableCreator _executableCreator;
     private readonly ContainerCreator _containerCreator;
 
-    // We need to preserve the container creation context from the application startup phase 
+    // We need to preserve the container creation context from the application startup phase
     // so that container explicit start does not suffer from timing issues.
     private readonly TaskCompletionSource<ContainerCreationContext> _containerContextSource;
 
@@ -207,7 +206,12 @@ internal sealed partial class DcpExecutor : IDcpExecutor, IDcpObjectFactory, IAs
             {
                 await getProxyAddresses.ConfigureAwait(false);
 
-                AddAllocatedEndpointInfo(executables, AllocatedEndpointsMode.Workload);
+                DcpModelUtilities.AddAllocatedEndpointInfo(
+                    executables,
+                    AllocatedEndpointsMode.Workload,
+                    _appResources.Get(),
+                    _options.Value.EnableAspireContainerTunnel,
+                    ContainerHostName);
                 await PublishEndpointsAllocatedEventAsync(executables, ct).ConfigureAwait(false);
             }, ct);
 
@@ -218,22 +222,8 @@ internal sealed partial class DcpExecutor : IDcpExecutor, IDcpObjectFactory, IAs
                 await CreateRenderedResourcesAsync(_executableCreator, executables, EmptyCreationContext.s_instance, ct).ConfigureAwait(false);
             }, ct);
 
-            Task createTunnelFunc(ContainerCreationContext cctx) => Task.Run(async () =>
-            {
-                await Task.WhenAll([getProxyAddresses, createContainerNetworks]).WaitAsync(ct).ConfigureAwait(false);
-
-                await _containerCreator.CreateTunnelAsync(cctx, this, ct).ConfigureAwait(false);
-
-                AddAllocatedEndpointInfo(executables, AllocatedEndpointsMode.ContainerTunnel);
-
-                // createExecutableEndpoints() is not really part of container tunnel initialization,
-                // but configuring containers that use the tunnel require these host network-side endpoints to be ready,
-                // so instead of having container creation tasks wait on two separate tasks (current one + createExecutableEndpoints),
-                // we just wait for createExecutableEndpoints here, and container creation tasks can then wait on this one.
-                await createExecutableEndpoints.ConfigureAwait(false);
-            }, ct);
-
-            var cctx = new ContainerCreationContext(containers.Length, createTunnelFunc);
+            // Configuring containers that use the tunnel require these host network-side endpoints for Executables to be ready.
+            var cctx = new ContainerCreationContext(createContainerNetworks, createExecutableEndpoints);
             _containerContextSource.SetResult(cctx);
 
             var createContainers = Task.Run(async () =>
@@ -241,7 +231,12 @@ internal sealed partial class DcpExecutor : IDcpExecutor, IDcpObjectFactory, IAs
                 await Task.WhenAll([getProxyAddresses, createContainerNetworks]).WaitAsync(ct).ConfigureAwait(false);
 
                 // Allocate container workload endpoints, then publish endpoint-allocated events.
-                AddAllocatedEndpointInfo(containers, AllocatedEndpointsMode.Workload);
+                DcpModelUtilities.AddAllocatedEndpointInfo(
+                    containers,
+                    AllocatedEndpointsMode.Workload,
+                    _appResources.Get(),
+                    _options.Value.EnableAspireContainerTunnel,
+                    ContainerHostName);
                 await PublishEndpointsAllocatedEventAsync(containers, ct).ConfigureAwait(false);
 
                 await CreateRenderedResourcesAsync(_containerCreator, containers, cctx, ct).ConfigureAwait(false);
@@ -325,10 +320,6 @@ internal sealed partial class DcpExecutor : IDcpExecutor, IDcpObjectFactory, IAs
         var disposeCts = new CancellationTokenSource();
         disposeCts.CancelAfter(s_disposeTimeout);
         await StopAsync(disposeCts.Token).ConfigureAwait(false);
-        if (_containerContextSource.Task.IsCompletedSuccessfully)
-        {
-            _containerContextSource.Task.Result.Dispose();
-        }
         foreach (var ar in _appResources.Get())
         {
             ar.Dispose();
@@ -609,6 +600,15 @@ internal sealed partial class DcpExecutor : IDcpExecutor, IDcpObjectFactory, IAs
     Task IDcpObjectFactory.CreateDcpObjectsAsync<T>(IEnumerable<T> objects, CancellationToken cancellationToken)
         => CreateDcpObjectsAsync(objects, cancellationToken);
 
+    async Task<T> IDcpObjectFactory.PatchDcpObjectAsync<T>(T obj, Action<T> change, CancellationToken cancellationToken)
+    {
+        var patch = CreatePatch(obj, change);
+        var result = await _kubernetesService.PatchAsync(obj, patch, cancellationToken).ConfigureAwait(false);
+        change(obj);
+
+        return result;
+    }
+
     private async Task CreateDcpObjectsAsync<RT>(IEnumerable<RT> objects, CancellationToken cancellationToken) where RT : CustomResource, IKubernetesStaticMetadata
     {
         var toCreate = objects.ToImmutableArray();
@@ -667,140 +667,6 @@ internal sealed partial class DcpExecutor : IDcpExecutor, IDcpObjectFactory, IAs
         {
             AspireEventSource.Instance.DcpObjectSetCreationStop(RT.ObjectKind, toCreate.Length);
         }
-    }
-
-    // Adds allocated endpoints for all relevant resources in the model
-    private void AddAllocatedEndpointInfo<TDcpResource>(IEnumerable<RenderedModelResource<TDcpResource>> resources, AllocatedEndpointsMode mode)
-            where TDcpResource : CustomResource, IKubernetesStaticMetadata
-    {
-        foreach (var appResource in resources)
-        {
-            if ((mode & AllocatedEndpointsMode.Workload) != 0)
-            {
-                foreach (var sp in appResource.ServicesProduced)
-                {
-                    var svc = (Service)sp.DcpResource;
-
-                    if (!svc.HasCompleteAddress && sp.EndpointAnnotation.IsProxied)
-                    {
-                        // This should never happen; if it does, we have a bug without a workaround for the user.
-                        // We should have waited for the service to have a complete address before getting here.
-                        throw new InvalidDataException($"Service {svc.Metadata.Name} should have valid address at this point");
-                    }
-
-                    if (!sp.EndpointAnnotation.IsProxied && svc.AllocatedPort is null)
-                    {
-                        throw new InvalidOperationException($"Service '{svc.Metadata.Name}' needs to specify a port for endpoint '{sp.EndpointAnnotation.Name}' since it isn't using a proxy.");
-                    }
-
-                    var (targetHost, bindingMode) = DcpModelUtilities.NormalizeTargetHost(sp.EndpointAnnotation.TargetHost);
-
-                    sp.EndpointAnnotation.AllocatedEndpoint = new AllocatedEndpoint(
-                        sp.EndpointAnnotation,
-                        targetHost,
-                        (int)svc.AllocatedPort!,
-                        bindingMode,
-                        targetPortExpression: $$$"""{{- portForServing "{{{svc.Metadata.Name}}}" -}}""",
-                        KnownNetworkIdentifiers.LocalhostNetwork);
-
-                    if (appResource.DcpResource is Container ctr && ctr.Spec.Networks is not null)
-                    {
-                        // Once container networks are fully supported, this should allocate endpoints on those networks
-                        var containerNetwork = ctr.Spec.Networks.FirstOrDefault(n => n.Name == KnownNetworkIdentifiers.DefaultAspireContainerNetwork.Value);
-
-                        if (containerNetwork is not null)
-                        {
-                            var port = sp.EndpointAnnotation.TargetPort!;
-
-                            var allocatedEndpoint = new AllocatedEndpoint(
-                                sp.EndpointAnnotation,
-                                $"{sp.ModelResource.Name}.dev.internal",
-                                (int)port,
-                                EndpointBindingMode.SingleAddress,
-                                targetPortExpression: $$$"""{{- portForServing "{{{svc.Metadata.Name}}}" -}}""",
-                                KnownNetworkIdentifiers.DefaultAspireContainerNetwork
-                            );
-                            sp.EndpointAnnotation.AllAllocatedEndpoints.AddOrUpdateAllocatedEndpoint(allocatedEndpoint.NetworkID, allocatedEndpoint);
-                        }
-                    }
-
-                    // If we are not using the tunnel, we can project Executable endpoints into container networks via ContainerHostName.
-                    // This really only works for Docker Desktop, but it is useful for testing too.
-                    if (appResource.DcpResource is Executable && !_options.Value.EnableAspireContainerTunnel)
-                    {
-                        var port = sp.EndpointAnnotation.TargetPort!;
-                        var allocatedEndpoint = new AllocatedEndpoint(
-                            sp.EndpointAnnotation,
-                            ContainerHostName,
-                            (int)svc.AllocatedPort!,
-                            EndpointBindingMode.SingleAddress,
-                            targetPortExpression: $$$"""{{- portForServing "{{{svc.Metadata.Name}}}" -}}""",
-                            KnownNetworkIdentifiers.DefaultAspireContainerNetwork
-                        );
-                        sp.EndpointAnnotation.AllAllocatedEndpoints.AddOrUpdateAllocatedEndpoint(KnownNetworkIdentifiers.DefaultAspireContainerNetwork, allocatedEndpoint);
-                    }
-                }
-            }
-
-            if ((mode & AllocatedEndpointsMode.ContainerTunnel) != 0 && _options.Value.EnableAspireContainerTunnel)
-            {
-                // If there are any additional services that are not directly produced by this resource,
-                // but leverage its endpoints via container tunnel, we want to add allocated endpoint info for them as well.
-
-                var tunnelServices = _appResources.Get().OfType<AppResource<Service>>().Select(r => (
-                    Service: r.DcpResource,
-                    ResourceName: r.DcpResource.Metadata.Annotations?.TryGetValue(CustomResource.ResourceNameAnnotation, out var resourceName) == true ? resourceName : null,
-                    EndpointName: r.DcpResource.Metadata.Annotations?.TryGetValue(CustomResource.EndpointNameAnnotation, out var endpointName) == true ? endpointName : null,
-                    TunnelInstanceName: r.DcpResource.Metadata.Annotations?.TryGetValue(CustomResource.ContainerTunnelInstanceName, out var tunnelInstanceName) == true ? tunnelInstanceName : null,
-                    ContainerNetworkName: r.DcpResource.Metadata.Annotations?.TryGetValue(CustomResource.ContainerNetworkAnnotation, out var containerNetworkName) == true ? containerNetworkName : null
-                ))
-                .Where(ts =>
-                    ts.Service is not null &&
-                    string.Equals(ts.ResourceName, appResource.ModelResource.Name, StringComparisons.ResourceName) &&
-                    !string.IsNullOrEmpty(ts.EndpointName) &&
-                    !string.IsNullOrEmpty(ts.ContainerNetworkName)
-                );
-
-                foreach (var ts in tunnelServices)
-                {
-                    if (!TryGetEndpoint(appResource.ModelResource, ts.EndpointName, out var endpoint))
-                    {
-                        throw new InvalidDataException($"Service '{ts.Service!.Metadata.Name}' refers to endpoint '{ts.EndpointName}' that does not exist");
-                    }
-
-                    if (ts.Service?.HasCompleteAddress is not true)
-                    {
-                        // This should never happen; if it does, we have a bug without a workaround for the user.
-                        throw new InvalidDataException($"Container tunnel service {ts.Service?.Metadata.Name} should have valid address at this point");
-                    }
-
-                    var serverSvc = _appResources.Get().OfType<ServiceWithModelResource>().FirstOrDefault(swr =>
-                        string.Equals(swr.ModelResource.Name, ts.ResourceName, StringComparisons.ResourceName) &&
-                        string.Equals(swr.EndpointAnnotation.Name, endpoint.Name, StringComparisons.EndpointAnnotationName)
-                    );
-                    if (serverSvc is null)
-                    {
-                        // Should never happen -- we should have created a Service for every endpoint exposed from a resource.
-                        throw new InvalidDataException($"The '{endpoint.Name}' on resource '{ts.ResourceName}' should have an associated DCP Service resource already set up");
-                    }
-
-                    var networkID = new NetworkIdentifier(ts.ContainerNetworkName!);
-                    var address = string.IsNullOrEmpty(ts.TunnelInstanceName) ? ContainerHostName : KnownHostNames.DefaultContainerTunnelHostName;
-                    var port = _options.Value.EnableAspireContainerTunnel ? (int)ts.Service!.AllocatedPort! : serverSvc.EndpointAnnotation.AllocatedEndpoint!.Port;
-
-                    var tunnelAllocatedEndpoint = new AllocatedEndpoint(
-                        endpoint,
-                        address,
-                        port,
-                        EndpointBindingMode.SingleAddress,
-                        targetPortExpression: $$$"""{{- portForServing "{{{ts.Service.Name}}}" -}}""",
-                        networkID
-                    );
-                    endpoint.AllAllocatedEndpoints.AddOrUpdateAllocatedEndpoint(networkID, tunnelAllocatedEndpoint);
-                }
-            }
-        }
-
     }
 
     /// <summary>
@@ -1231,11 +1097,8 @@ internal sealed partial class DcpExecutor : IDcpExecutor, IDcpObjectFactory, IAs
 
                     await _executorEvents.PublishAsync(new OnConnectionStringAvailableContext(cancellationToken, resourceReference.ModelResource)).ConfigureAwait(false);
                     await _executorEvents.PublishAsync(new OnResourceStartingContext(cancellationToken, resourceType, resourceReference.ModelResource, resourceReference.DcpResourceName)).ConfigureAwait(false);
-                    var startupCctx = await _containerContextSource.Task.ConfigureAwait(false);
-                    using (var cctx = startupCctx.ForAdditionalContainers(1))
-                    {
-                        await _containerCreator.CreateObjectAsync(cr, cctx, resourceLogger, this, cancellationToken).ConfigureAwait(false);
-                    }
+                    var cctx = await _containerContextSource.Task.ConfigureAwait(false);
+                    await _containerCreator.CreateObjectAsync(cr, cctx, resourceLogger, this, cancellationToken).ConfigureAwait(false);
                     break;
                 case RenderedModelResource<Executable> er:
                     await EnsureResourceDeletedAsync<Executable>(resourceReference.DcpResourceName, cancellationToken).ConfigureAwait(false);
@@ -1321,16 +1184,6 @@ internal sealed partial class DcpExecutor : IDcpExecutor, IDcpObjectFactory, IAs
         {
             throw new DistributedApplicationException($"Failed to delete '{resourceName}' successfully before restart.");
         }
-    }
-
-    private static bool TryGetEndpoint(IResource resource, string? endpointName, [NotNullWhen(true)] out EndpointAnnotation? endpoint)
-    {
-        endpoint = null;
-        if (resource.TryGetAnnotationsOfType<EndpointAnnotation>(out var endpoints))
-        {
-            endpoint = endpoints.FirstOrDefault(e => string.Equals(e.Name, endpointName, StringComparisons.EndpointAnnotationName));
-        }
-        return endpoint is not null;
     }
 
     /// <summary>

--- a/src/Aspire.Hosting/Dcp/DcpExecutor.cs
+++ b/src/Aspire.Hosting/Dcp/DcpExecutor.cs
@@ -320,7 +320,6 @@ internal sealed partial class DcpExecutor : IDcpExecutor, IDcpObjectFactory, IAs
         {
             ar.Dispose();
         }
-        _containerCreator.Dispose();
     }
 
     /// <summary>

--- a/src/Aspire.Hosting/Dcp/DcpModelUtilities.cs
+++ b/src/Aspire.Hosting/Dcp/DcpModelUtilities.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.Net;
 using Aspire.Hosting.ApplicationModel;
@@ -81,6 +82,156 @@ internal static class DcpModelUtilities
             }
             return false;
         }
+    }
+
+    internal static void AddAllocatedEndpointInfo<TDcpResource>(
+        IEnumerable<RenderedModelResource<TDcpResource>> resources,
+        AllocatedEndpointsMode mode,
+        IEnumerable<IAppResource> appResources,
+        bool enableAspireContainerTunnel,
+        string containerHostName)
+        where TDcpResource : CustomResource, IKubernetesStaticMetadata
+    {
+        var allAppResources = appResources.ToArray();
+
+        foreach (var appResource in resources)
+        {
+            if ((mode & AllocatedEndpointsMode.Workload) != 0)
+            {
+                foreach (var sp in appResource.ServicesProduced)
+                {
+                    var svc = (Service)sp.DcpResource;
+
+                    if (!svc.HasCompleteAddress && sp.EndpointAnnotation.IsProxied)
+                    {
+                        // This should never happen; if it does, we have a bug without a workaround for the user.
+                        // We should have waited for the service to have a complete address before getting here.
+                        throw new InvalidDataException($"Service {svc.Metadata.Name} should have valid address at this point");
+                    }
+
+                    if (!sp.EndpointAnnotation.IsProxied && svc.AllocatedPort is null)
+                    {
+                        throw new InvalidOperationException($"Service '{svc.Metadata.Name}' needs to specify a port for endpoint '{sp.EndpointAnnotation.Name}' since it isn't using a proxy.");
+                    }
+
+                    var (targetHost, bindingMode) = NormalizeTargetHost(sp.EndpointAnnotation.TargetHost);
+
+                    sp.EndpointAnnotation.AllocatedEndpoint = new AllocatedEndpoint(
+                        sp.EndpointAnnotation,
+                        targetHost,
+                        (int)svc.AllocatedPort!,
+                        bindingMode,
+                        targetPortExpression: $$$"""{{- portForServing "{{{svc.Metadata.Name}}}" -}}""",
+                        KnownNetworkIdentifiers.LocalhostNetwork);
+
+                    if (appResource.DcpResource is Container ctr && ctr.Spec.Networks is not null)
+                    {
+                        // Once container networks are fully supported, this should allocate endpoints on those networks
+                        var containerNetwork = ctr.Spec.Networks.FirstOrDefault(n => n.Name == KnownNetworkIdentifiers.DefaultAspireContainerNetwork.Value);
+
+                        if (containerNetwork is not null)
+                        {
+                            var port = sp.EndpointAnnotation.TargetPort!;
+
+                            var allocatedEndpoint = new AllocatedEndpoint(
+                                sp.EndpointAnnotation,
+                                $"{sp.ModelResource.Name}.dev.internal",
+                                (int)port,
+                                EndpointBindingMode.SingleAddress,
+                                targetPortExpression: $$$"""{{- portForServing "{{{svc.Metadata.Name}}}" -}}""",
+                                KnownNetworkIdentifiers.DefaultAspireContainerNetwork
+                            );
+                            sp.EndpointAnnotation.AllAllocatedEndpoints.AddOrUpdateAllocatedEndpoint(allocatedEndpoint.NetworkID, allocatedEndpoint);
+                        }
+                    }
+
+                    // If we are not using the tunnel, we can project Executable endpoints into container networks via ContainerHostName.
+                    // This really only works for Docker Desktop, but it is useful for testing too.
+                    if (appResource.DcpResource is Executable && !enableAspireContainerTunnel)
+                    {
+                        var port = sp.EndpointAnnotation.TargetPort!;
+                        var allocatedEndpoint = new AllocatedEndpoint(
+                            sp.EndpointAnnotation,
+                            containerHostName,
+                            (int)svc.AllocatedPort!,
+                            EndpointBindingMode.SingleAddress,
+                            targetPortExpression: $$$"""{{- portForServing "{{{svc.Metadata.Name}}}" -}}""",
+                            KnownNetworkIdentifiers.DefaultAspireContainerNetwork
+                        );
+                        sp.EndpointAnnotation.AllAllocatedEndpoints.AddOrUpdateAllocatedEndpoint(KnownNetworkIdentifiers.DefaultAspireContainerNetwork, allocatedEndpoint);
+                    }
+                }
+            }
+
+            if ((mode & AllocatedEndpointsMode.ContainerTunnel) != 0 && enableAspireContainerTunnel)
+            {
+                // If there are any additional services that are not directly produced by this resource,
+                // but leverage its endpoints via container tunnel, we want to add allocated endpoint info for them as well.
+
+                var tunnelServices = allAppResources.OfType<AppResource<Service>>().Select(r => (
+                    Service: r.DcpResource,
+                    ResourceName: r.DcpResource.Metadata.Annotations?.TryGetValue(CustomResource.ResourceNameAnnotation, out var resourceName) == true ? resourceName : null,
+                    EndpointName: r.DcpResource.Metadata.Annotations?.TryGetValue(CustomResource.EndpointNameAnnotation, out var endpointName) == true ? endpointName : null,
+                    TunnelInstanceName: r.DcpResource.Metadata.Annotations?.TryGetValue(CustomResource.ContainerTunnelInstanceName, out var tunnelInstanceName) == true ? tunnelInstanceName : null,
+                    ContainerNetworkName: r.DcpResource.Metadata.Annotations?.TryGetValue(CustomResource.ContainerNetworkAnnotation, out var containerNetworkName) == true ? containerNetworkName : null
+                ))
+                .Where(ts =>
+                    ts.Service is not null &&
+                    string.Equals(ts.ResourceName, appResource.ModelResource.Name, StringComparisons.ResourceName) &&
+                    !string.IsNullOrEmpty(ts.EndpointName) &&
+                    !string.IsNullOrEmpty(ts.ContainerNetworkName)
+                );
+
+                foreach (var ts in tunnelServices)
+                {
+                    if (!TryGetEndpoint(appResource.ModelResource, ts.EndpointName, out var endpoint))
+                    {
+                        throw new InvalidDataException($"Service '{ts.Service!.Metadata.Name}' refers to endpoint '{ts.EndpointName}' that does not exist");
+                    }
+
+                    if (ts.Service?.HasCompleteAddress is not true)
+                    {
+                        // This should never happen; if it does, we have a bug without a workaround for the user.
+                        throw new InvalidDataException($"Container tunnel service {ts.Service?.Metadata.Name} should have valid address at this point");
+                    }
+
+                    var serverSvc = allAppResources.OfType<ServiceWithModelResource>().FirstOrDefault(swr =>
+                        string.Equals(swr.ModelResource.Name, ts.ResourceName, StringComparisons.ResourceName) &&
+                        string.Equals(swr.EndpointAnnotation.Name, endpoint.Name, StringComparisons.EndpointAnnotationName)
+                    );
+                    if (serverSvc is null)
+                    {
+                        // Should never happen -- we should have created a Service for every endpoint exposed from a resource.
+                        throw new InvalidDataException($"The '{endpoint.Name}' on resource '{ts.ResourceName}' should have an associated DCP Service resource already set up");
+                    }
+
+                    var networkID = new NetworkIdentifier(ts.ContainerNetworkName!);
+                    var address = string.IsNullOrEmpty(ts.TunnelInstanceName) ? containerHostName : KnownHostNames.DefaultContainerTunnelHostName;
+                    var port = enableAspireContainerTunnel ? (int)ts.Service!.AllocatedPort! : serverSvc.EndpointAnnotation.AllocatedEndpoint!.Port;
+
+                    var tunnelAllocatedEndpoint = new AllocatedEndpoint(
+                        endpoint,
+                        address,
+                        port,
+                        EndpointBindingMode.SingleAddress,
+                        targetPortExpression: $$$"""{{- portForServing "{{{ts.Service.Metadata.Name}}}" -}}""",
+                        networkID
+                    );
+                    endpoint.AllAllocatedEndpoints.AddOrUpdateAllocatedEndpoint(networkID, tunnelAllocatedEndpoint);
+                }
+            }
+        }
+    }
+
+    private static bool TryGetEndpoint(IResource resource, string? endpointName, [NotNullWhen(true)] out EndpointAnnotation? endpoint)
+    {
+        endpoint = null;
+        if (resource.TryGetAnnotationsOfType<EndpointAnnotation>(out var endpoints))
+        {
+            endpoint = endpoints.FirstOrDefault(e => string.Equals(e.Name, endpointName, StringComparisons.EndpointAnnotationName));
+        }
+
+        return endpoint is not null;
     }
 
     /// <summary>

--- a/src/Aspire.Hosting/Dcp/DcpModelUtilities.cs
+++ b/src/Aspire.Hosting/Dcp/DcpModelUtilities.cs
@@ -84,141 +84,140 @@ internal static class DcpModelUtilities
         }
     }
 
-    internal static void AddAllocatedEndpointInfo<TDcpResource>(
+    internal static void AddWorkloadAllocatedEndpoints<TDcpResource>(
         IEnumerable<RenderedModelResource<TDcpResource>> resources,
-        AllocatedEndpointsMode mode,
-        IEnumerable<IAppResource> appResources,
         bool enableAspireContainerTunnel,
         string containerHostName)
         where TDcpResource : CustomResource, IKubernetesStaticMetadata
     {
-        var allAppResources = appResources.ToArray();
-
-        foreach (var appResource in resources)
+        foreach (var res in resources)
         {
-            if ((mode & AllocatedEndpointsMode.Workload) != 0)
+            foreach (var sp in res.ServicesProduced)
             {
-                foreach (var sp in appResource.ServicesProduced)
+                var svc = sp.DcpResource;
+
+                if (!svc.HasCompleteAddress && sp.EndpointAnnotation.IsProxied)
                 {
-                    var svc = (Service)sp.DcpResource;
+                    // This should never happen; if it does, we have a bug without a workaround for the user.
+                    // We should have waited for the service to have a complete address before getting here.
+                    throw new InvalidDataException($"Service {svc.Metadata.Name} should have valid address at this point");
+                }
 
-                    if (!svc.HasCompleteAddress && sp.EndpointAnnotation.IsProxied)
-                    {
-                        // This should never happen; if it does, we have a bug without a workaround for the user.
-                        // We should have waited for the service to have a complete address before getting here.
-                        throw new InvalidDataException($"Service {svc.Metadata.Name} should have valid address at this point");
-                    }
+                if (!sp.EndpointAnnotation.IsProxied && svc.AllocatedPort is null)
+                {
+                    throw new InvalidOperationException($"Service '{svc.Metadata.Name}' needs to specify a port for endpoint '{sp.EndpointAnnotation.Name}' since it isn't using a proxy.");
+                }
 
-                    if (!sp.EndpointAnnotation.IsProxied && svc.AllocatedPort is null)
-                    {
-                        throw new InvalidOperationException($"Service '{svc.Metadata.Name}' needs to specify a port for endpoint '{sp.EndpointAnnotation.Name}' since it isn't using a proxy.");
-                    }
+                var (targetHost, bindingMode) = NormalizeTargetHost(sp.EndpointAnnotation.TargetHost);
 
-                    var (targetHost, bindingMode) = NormalizeTargetHost(sp.EndpointAnnotation.TargetHost);
+                sp.EndpointAnnotation.AllocatedEndpoint = new AllocatedEndpoint(
+                    sp.EndpointAnnotation,
+                    targetHost,
+                    (int)svc.AllocatedPort!,
+                    bindingMode,
+                    targetPortExpression: $$$"""{{- portForServing "{{{svc.Metadata.Name}}}" -}}""",
+                    KnownNetworkIdentifiers.LocalhostNetwork);
 
-                    sp.EndpointAnnotation.AllocatedEndpoint = new AllocatedEndpoint(
-                        sp.EndpointAnnotation,
-                        targetHost,
-                        (int)svc.AllocatedPort!,
-                        bindingMode,
-                        targetPortExpression: $$$"""{{- portForServing "{{{svc.Metadata.Name}}}" -}}""",
-                        KnownNetworkIdentifiers.LocalhostNetwork);
+                if (res.DcpResource is Container ctr && ctr.Spec.Networks is not null)
+                {
+                    // Once container networks are fully supported, this should allocate endpoints on those networks
+                    var containerNetwork = ctr.Spec.Networks.FirstOrDefault(n => n.Name == KnownNetworkIdentifiers.DefaultAspireContainerNetwork.Value);
 
-                    if (appResource.DcpResource is Container ctr && ctr.Spec.Networks is not null)
-                    {
-                        // Once container networks are fully supported, this should allocate endpoints on those networks
-                        var containerNetwork = ctr.Spec.Networks.FirstOrDefault(n => n.Name == KnownNetworkIdentifiers.DefaultAspireContainerNetwork.Value);
-
-                        if (containerNetwork is not null)
-                        {
-                            var port = sp.EndpointAnnotation.TargetPort!;
-
-                            var allocatedEndpoint = new AllocatedEndpoint(
-                                sp.EndpointAnnotation,
-                                $"{sp.ModelResource.Name}.dev.internal",
-                                (int)port,
-                                EndpointBindingMode.SingleAddress,
-                                targetPortExpression: $$$"""{{- portForServing "{{{svc.Metadata.Name}}}" -}}""",
-                                KnownNetworkIdentifiers.DefaultAspireContainerNetwork
-                            );
-                            sp.EndpointAnnotation.AllAllocatedEndpoints.AddOrUpdateAllocatedEndpoint(allocatedEndpoint.NetworkID, allocatedEndpoint);
-                        }
-                    }
-
-                    // If we are not using the tunnel, we can project Executable endpoints into container networks via ContainerHostName.
-                    // This really only works for Docker Desktop, but it is useful for testing too.
-                    if (appResource.DcpResource is Executable && !enableAspireContainerTunnel)
+                    if (containerNetwork is not null)
                     {
                         var port = sp.EndpointAnnotation.TargetPort!;
+
                         var allocatedEndpoint = new AllocatedEndpoint(
                             sp.EndpointAnnotation,
-                            containerHostName,
-                            (int)svc.AllocatedPort!,
+                            $"{sp.ModelResource.Name}.dev.internal",
+                            (int)port,
                             EndpointBindingMode.SingleAddress,
                             targetPortExpression: $$$"""{{- portForServing "{{{svc.Metadata.Name}}}" -}}""",
                             KnownNetworkIdentifiers.DefaultAspireContainerNetwork
                         );
-                        sp.EndpointAnnotation.AllAllocatedEndpoints.AddOrUpdateAllocatedEndpoint(KnownNetworkIdentifiers.DefaultAspireContainerNetwork, allocatedEndpoint);
+                        sp.EndpointAnnotation.AllAllocatedEndpoints.AddOrUpdateAllocatedEndpoint(allocatedEndpoint.NetworkID, allocatedEndpoint);
                     }
+                }
+
+                // If we are not using the tunnel, we can project Executable endpoints into container networks via ContainerHostName.
+                // This really only works for Docker Desktop, but it is useful for testing too.
+                if (res.DcpResource is Executable && !enableAspireContainerTunnel)
+                {
+                    var port = sp.EndpointAnnotation.TargetPort!;
+                    var allocatedEndpoint = new AllocatedEndpoint(
+                        sp.EndpointAnnotation,
+                        containerHostName,
+                        (int)svc.AllocatedPort!,
+                        EndpointBindingMode.SingleAddress,
+                        targetPortExpression: $$$"""{{- portForServing "{{{svc.Metadata.Name}}}" -}}""",
+                        KnownNetworkIdentifiers.DefaultAspireContainerNetwork
+                    );
+                    sp.EndpointAnnotation.AllAllocatedEndpoints.AddOrUpdateAllocatedEndpoint(KnownNetworkIdentifiers.DefaultAspireContainerNetwork, allocatedEndpoint);
                 }
             }
+        }
+    }
 
-            if ((mode & AllocatedEndpointsMode.ContainerTunnel) != 0 && enableAspireContainerTunnel)
+    internal static void AddContainerTunnelAllocatedEndpoints(
+        IEnumerable<IResource> affectedResources,
+        DcpAppResourceStore allAppResources,
+        string containerHostName)
+    {
+        foreach (var res in affectedResources)
+        {
+            // If there are any additional services that are not directly produced by this resource,
+            // but leverage its endpoints via container tunnel, we want to add allocated endpoint info for them as well.
+
+            var tunnelServices = allAppResources.Get().OfType<AppResource<Service>>().Select(r => (
+                Service: r.DcpResource,
+                ResourceName: r.DcpResource.Metadata.Annotations?.TryGetValue(CustomResource.ResourceNameAnnotation, out var resourceName) == true ? resourceName : null,
+                EndpointName: r.DcpResource.Metadata.Annotations?.TryGetValue(CustomResource.EndpointNameAnnotation, out var endpointName) == true ? endpointName : null,
+                TunnelInstanceName: r.DcpResource.Metadata.Annotations?.TryGetValue(CustomResource.ContainerTunnelInstanceName, out var tunnelInstanceName) == true ? tunnelInstanceName : null,
+                ContainerNetworkName: r.DcpResource.Metadata.Annotations?.TryGetValue(CustomResource.ContainerNetworkAnnotation, out var containerNetworkName) == true ? containerNetworkName : null
+            ))
+            .Where(ts =>
+                ts.Service is not null &&
+                string.Equals(ts.ResourceName, res.Name, StringComparisons.ResourceName) &&
+                !string.IsNullOrEmpty(ts.EndpointName) &&
+                !string.IsNullOrEmpty(ts.ContainerNetworkName)
+            );
+
+            foreach (var ts in tunnelServices)
             {
-                // If there are any additional services that are not directly produced by this resource,
-                // but leverage its endpoints via container tunnel, we want to add allocated endpoint info for them as well.
-
-                var tunnelServices = allAppResources.OfType<AppResource<Service>>().Select(r => (
-                    Service: r.DcpResource,
-                    ResourceName: r.DcpResource.Metadata.Annotations?.TryGetValue(CustomResource.ResourceNameAnnotation, out var resourceName) == true ? resourceName : null,
-                    EndpointName: r.DcpResource.Metadata.Annotations?.TryGetValue(CustomResource.EndpointNameAnnotation, out var endpointName) == true ? endpointName : null,
-                    TunnelInstanceName: r.DcpResource.Metadata.Annotations?.TryGetValue(CustomResource.ContainerTunnelInstanceName, out var tunnelInstanceName) == true ? tunnelInstanceName : null,
-                    ContainerNetworkName: r.DcpResource.Metadata.Annotations?.TryGetValue(CustomResource.ContainerNetworkAnnotation, out var containerNetworkName) == true ? containerNetworkName : null
-                ))
-                .Where(ts =>
-                    ts.Service is not null &&
-                    string.Equals(ts.ResourceName, appResource.ModelResource.Name, StringComparisons.ResourceName) &&
-                    !string.IsNullOrEmpty(ts.EndpointName) &&
-                    !string.IsNullOrEmpty(ts.ContainerNetworkName)
-                );
-
-                foreach (var ts in tunnelServices)
+                if (!TryGetEndpoint(res, ts.EndpointName, out var endpoint))
                 {
-                    if (!TryGetEndpoint(appResource.ModelResource, ts.EndpointName, out var endpoint))
-                    {
-                        throw new InvalidDataException($"Service '{ts.Service!.Metadata.Name}' refers to endpoint '{ts.EndpointName}' that does not exist");
-                    }
-
-                    if (ts.Service?.HasCompleteAddress is not true)
-                    {
-                        // This should never happen; if it does, we have a bug without a workaround for the user.
-                        throw new InvalidDataException($"Container tunnel service {ts.Service?.Metadata.Name} should have valid address at this point");
-                    }
-
-                    var serverSvc = allAppResources.OfType<ServiceWithModelResource>().FirstOrDefault(swr =>
-                        string.Equals(swr.ModelResource.Name, ts.ResourceName, StringComparisons.ResourceName) &&
-                        string.Equals(swr.EndpointAnnotation.Name, endpoint.Name, StringComparisons.EndpointAnnotationName)
-                    );
-                    if (serverSvc is null)
-                    {
-                        // Should never happen -- we should have created a Service for every endpoint exposed from a resource.
-                        throw new InvalidDataException($"The '{endpoint.Name}' on resource '{ts.ResourceName}' should have an associated DCP Service resource already set up");
-                    }
-
-                    var networkID = new NetworkIdentifier(ts.ContainerNetworkName!);
-                    var address = string.IsNullOrEmpty(ts.TunnelInstanceName) ? containerHostName : KnownHostNames.DefaultContainerTunnelHostName;
-                    var port = enableAspireContainerTunnel ? (int)ts.Service!.AllocatedPort! : serverSvc.EndpointAnnotation.AllocatedEndpoint!.Port;
-
-                    var tunnelAllocatedEndpoint = new AllocatedEndpoint(
-                        endpoint,
-                        address,
-                        port,
-                        EndpointBindingMode.SingleAddress,
-                        targetPortExpression: $$$"""{{- portForServing "{{{ts.Service.Metadata.Name}}}" -}}""",
-                        networkID
-                    );
-                    endpoint.AllAllocatedEndpoints.AddOrUpdateAllocatedEndpoint(networkID, tunnelAllocatedEndpoint);
+                    throw new InvalidDataException($"Service '{ts.Service!.Metadata.Name}' refers to endpoint '{ts.EndpointName}' that does not exist");
                 }
+
+                if (ts.Service?.HasCompleteAddress is not true)
+                {
+                    // This should never happen; if it does, we have a bug without a workaround for the user.
+                    throw new InvalidDataException($"Container tunnel service {ts.Service?.Metadata.Name} should have valid address at this point");
+                }
+
+                var serverSvc = allAppResources.Get().OfType<ServiceWithModelResource>().FirstOrDefault(swr =>
+                    string.Equals(swr.ModelResource.Name, ts.ResourceName, StringComparisons.ResourceName) &&
+                    string.Equals(swr.EndpointAnnotation.Name, endpoint.Name, StringComparisons.EndpointAnnotationName)
+                );
+                if (serverSvc is null)
+                {
+                    // Should never happen -- we should have created a Service for every endpoint exposed from a resource.
+                    throw new InvalidDataException($"The '{endpoint.Name}' on resource '{ts.ResourceName}' should have an associated DCP Service resource already set up");
+                }
+
+                var networkID = new NetworkIdentifier(ts.ContainerNetworkName!);
+                var address = string.IsNullOrEmpty(ts.TunnelInstanceName) ? containerHostName : KnownHostNames.DefaultContainerTunnelHostName;
+                var port = (int)ts.Service!.AllocatedPort!;
+
+                var tunnelAllocatedEndpoint = new AllocatedEndpoint(
+                    endpoint,
+                    address,
+                    port,
+                    EndpointBindingMode.SingleAddress,
+                    targetPortExpression: $$$"""{{- portForServing "{{{ts.Service.Metadata.Name}}}" -}}""",
+                    networkID
+                );
+                endpoint.AllAllocatedEndpoints.AddOrUpdateAllocatedEndpoint(networkID, tunnelAllocatedEndpoint);
             }
         }
     }

--- a/src/Aspire.Hosting/Dcp/IDcpExecutor.cs
+++ b/src/Aspire.Hosting/Dcp/IDcpExecutor.cs
@@ -3,17 +3,6 @@
 
 namespace Aspire.Hosting.Dcp;
 
-/// <summary>
-/// Specifies which endpoints to process when creating AllocatedEndpoint info.
-/// </summary>
-[Flags]
-internal enum AllocatedEndpointsMode
-{
-    Workload = 0x1,
-    ContainerTunnel = 0x2,
-    All = 0xFF
-}
-
 internal interface IDcpExecutor
 {
     Task RunApplicationAsync(CancellationToken cancellationToken);

--- a/src/Aspire.Hosting/Dcp/IDcpObjectFactory.cs
+++ b/src/Aspire.Hosting/Dcp/IDcpObjectFactory.cs
@@ -30,6 +30,12 @@ internal interface IDcpObjectFactory
         where TDcpResource : CustomResource, IKubernetesStaticMetadata;
 
     /// <summary>
+    /// Patches a DCP custom resource object via the Kubernetes API.
+    /// </summary>
+    Task<TDcpResource> PatchDcpObjectAsync<TDcpResource>(TDcpResource obj, Action<TDcpResource> change, CancellationToken cancellationToken)
+        where TDcpResource : CustomResource, IKubernetesStaticMetadata;
+
+    /// <summary>
     /// Waits until the provided set of Services have their addresses allocated by the orchestrator
     /// and updates them with the allocated address information.
     /// </summary>

--- a/tests/Aspire.Hosting.Tests/ContainerTunnelTests.cs
+++ b/tests/Aspire.Hosting.Tests/ContainerTunnelTests.cs
@@ -82,4 +82,74 @@ public class ContainerTunnelTests(ITestOutputHelper testOutputHelper)
         await app.StopAsync().DefaultTimeout(TestConstants.DefaultOrchestratorTestLongTimeout);
     }
 
+    [Fact]
+    [RequiresFeature(TestFeature.Docker | TestFeature.DockerPluginBuildx)]
+    public async Task WaitingContainersCanUseTunnel()
+    {
+        const string testName = "waiting-containers-can-use-tunnel";
+        using var builder = TestDistributedApplicationBuilder.Create(testOutputHelper);
+        builder.Configuration[KnownConfigNames.EnableContainerTunnel] = "true";
+
+        var servicea = builder.AddProject<Projects.ServiceA>($"{testName}-servicea", launchProfileName: null)
+            .WithHttpEndpoint();
+
+        var container = builder.AddContainer($"{testName}-container", "mcr.microsoft.com/cbl-mariner/base/nginx", "1.22")
+            .WithEnvironment("SERVICEA_URL", servicea.GetEndpoint("http"));
+
+        var waitingContainer = builder.AddContainer($"{testName}-waiting", "mcr.microsoft.com/cbl-mariner/base/nginx", "1.22")
+            .WaitFor(container);
+
+        var waitingContainerConsumingEndpoint = builder.AddContainer($"{testName}-waiting-consuming", "mcr.microsoft.com/cbl-mariner/base/nginx", "1.22")
+            .WithEnvironment("SERVICEA_URL", servicea.GetEndpoint("http"))
+            .WaitFor(container);
+
+        await using var app = builder.Build();
+
+        // Use extra long timeout because if this is first time the tunnel is being used,
+        // getting the base images and building the tunnel (client) proxy image may take a while.
+        await app.StartAsync().DefaultTimeout(TestConstants.ExtraLongTimeoutDuration);
+
+        foreach (var c in new[] { container, waitingContainer, waitingContainerConsumingEndpoint })
+        {
+            await app.ResourceNotifications.WaitForResourceAsync(c.Resource.Name, KnownResourceStates.Running)
+            .DefaultTimeout(TestConstants.DefaultOrchestratorTestLongTimeout);
+        }
+
+        await app.StopAsync().DefaultTimeout(TestConstants.DefaultOrchestratorTestLongTimeout);
+    }
+
+    [Fact]
+    [RequiresFeature(TestFeature.Docker | TestFeature.DockerPluginBuildx)]
+    public async Task HostResourceCanWaitForTunnelDependentContainers()
+    {
+        const string testName = "host-resource-waits-for-tunnel-container";
+        using var builder = TestDistributedApplicationBuilder.Create(testOutputHelper);
+        builder.Configuration[KnownConfigNames.EnableContainerTunnel] = "true";
+
+        var upstreamService = builder.AddProject<Projects.ServiceA>($"{testName}-upstream", launchProfileName: null)
+            .WithHttpEndpoint();
+
+        var tunnelDependentContainer = builder.AddContainer($"{testName}-container", "mcr.microsoft.com/cbl-mariner/base/nginx", "1.22")
+            .WithEnvironment("UPSTREAM_SERVICE_URL", upstreamService.GetEndpoint("http"))
+            .WaitFor(upstreamService);
+
+        var downstreamService = builder.AddProject<Projects.ServiceB>($"{testName}-downstream", launchProfileName: null)
+            .WithHttpEndpoint()
+            .WaitFor(tunnelDependentContainer);
+
+        await using var app = builder.Build();
+
+        // Use extra long timeout because if this is first time the tunnel is being used,
+        // getting the base images and building the tunnel (client) proxy image may take a while.
+        await app.StartAsync().DefaultTimeout(TestConstants.ExtraLongTimeoutDuration);
+
+        foreach (var resourceName in new[] { upstreamService.Resource.Name, tunnelDependentContainer.Resource.Name, downstreamService.Resource.Name })
+        {
+            await app.ResourceNotifications.WaitForResourceAsync(resourceName, KnownResourceStates.Running)
+                .DefaultTimeout(TestConstants.DefaultOrchestratorTestLongTimeout);
+        }
+
+        await app.StopAsync().DefaultTimeout(TestConstants.DefaultOrchestratorTestLongTimeout);
+    }
+
 }

--- a/tests/Aspire.Hosting.Tests/Dcp/DcpExecutorTests.cs
+++ b/tests/Aspire.Hosting.Tests/Dcp/DcpExecutorTests.cs
@@ -3315,6 +3315,145 @@ public class DcpExecutorTests
     }
 
     [Fact]
+    public async Task WaitingTunnelDependentContainersDoNotBlockTunnelCreation()
+    {
+        var builder = DistributedApplication.CreateBuilder();
+
+        var executableA = builder.AddExecutable("executableA", "command", "")
+            .WithEndpoint(name: "http", targetPort: 1234, port: 5678, isProxied: true);
+
+        var executableB = builder.AddExecutable("executableB", "command", "")
+            .WithEndpoint(name: "http", targetPort: 1235, port: 5679, isProxied: true);
+
+        var container = builder.AddContainer("container", "image")
+            .WithEnvironment("EXEC_A_PORT", executableA.GetEndpoint("http").Property(EndpointProperty.Port));
+
+        var waiting = builder.AddContainer("waiting", "image")
+            .WaitFor(container);
+
+        var waitingConsumingEndpoint = builder.AddContainer("waitingConsumingEndpoint", "image")
+            .WithEnvironment("EXEC_B_PORT", executableB.GetEndpoint("http").Property(EndpointProperty.Port))
+            .WaitFor(container);
+
+        var kubernetesService = new TestKubernetesService();
+        using var app = builder.Build();
+        var distributedAppModel = app.Services.GetRequiredService<DistributedApplicationModel>();
+
+        var events = new DcpExecutorEvents();
+        events.Subscribe<OnResourceStartingContext>(async context =>
+        {
+            if (context.Resource == waiting.Resource || context.Resource == waitingConsumingEndpoint.Resource)
+            {
+                while (!kubernetesService.CreatedResources.OfType<Container>().Any(c => c.AppModelResourceName == container.Resource.Name))
+                {
+                    await Task.Delay(10, context.CancellationToken).ConfigureAwait(false);
+                }
+            }
+        });
+
+        var dcpOptions = new DcpOptions
+        {
+            EnableAspireContainerTunnel = true,
+        };
+
+        var appExecutor = CreateAppExecutor(distributedAppModel, kubernetesService: kubernetesService, dcpOptions: dcpOptions, events: events);
+        await appExecutor.RunApplicationAsync().DefaultTimeout();
+
+        var createdContainers = kubernetesService.CreatedResources.OfType<Container>().ToList();
+        Assert.Single(createdContainers, c => c.AppModelResourceName == container.Resource.Name);
+        Assert.Single(createdContainers, c => c.AppModelResourceName == waiting.Resource.Name);
+        var waitingConsumingContainer = Assert.Single(createdContainers, c => c.AppModelResourceName == waitingConsumingEndpoint.Resource.Name);
+
+        var tunnelServices = kubernetesService.CreatedResources
+            .OfType<Service>()
+            .Where(s => s.Metadata.Annotations.ContainsKey(CustomResource.ContainerTunnelInstanceName))
+            .ToList();
+
+        Assert.Single(tunnelServices, s => s.AppModelResourceName == executableA.Resource.Name);
+        var executableBTunnelService = Assert.Single(tunnelServices, s => s.AppModelResourceName == executableB.Resource.Name);
+
+        Assert.NotNull(waitingConsumingContainer.Spec.Env);
+        var executableBPort = Assert.Single(waitingConsumingContainer.Spec.Env, e => e.Name == "EXEC_B_PORT").Value;
+        Assert.Equal(executableBTunnelService.AllocatedPort.ToString(), executableBPort);
+
+        var tunnelProxy = Assert.Single(kubernetesService.CreatedResources.OfType<ContainerNetworkTunnelProxy>());
+        Assert.Equal(2, tunnelProxy.Spec.Tunnels?.Count);
+    }
+
+    [Fact]
+    public async Task HostResourceCanWaitForTunnelDependentContainer()
+    {
+        var builder = DistributedApplication.CreateBuilder();
+
+        var upstreamExecutable = builder.AddExecutable("upstreamExecutable", "command", "")
+            .WithEndpoint(name: "http", targetPort: 1234, port: 5678, isProxied: true);
+
+        var tunnelDependentContainer = builder.AddContainer("tunnelDependentContainer", "image")
+            .WithEnvironment("UPSTREAM_PORT", upstreamExecutable.GetEndpoint("http").Property(EndpointProperty.Port))
+            .WaitFor(upstreamExecutable);
+
+        var downstreamExecutable = builder.AddExecutable("downstreamExecutable", "command", "")
+            .WithEndpoint(name: "http", targetPort: 1235, port: 5679, isProxied: true)
+            .WaitFor(tunnelDependentContainer);
+
+        var kubernetesService = new TestKubernetesService();
+        using var app = builder.Build();
+        var distributedAppModel = app.Services.GetRequiredService<DistributedApplicationModel>();
+
+        var events = new DcpExecutorEvents();
+        events.Subscribe<OnResourceStartingContext>(async context =>
+        {
+            if (context.Resource == tunnelDependentContainer.Resource)
+            {
+                while (!kubernetesService.CreatedResources.OfType<Executable>().Any(e => e.AppModelResourceName == upstreamExecutable.Resource.Name))
+                {
+                    await Task.Delay(10, context.CancellationToken).ConfigureAwait(false);
+                }
+            }
+
+            if (context.Resource == downstreamExecutable.Resource)
+            {
+                while (!kubernetesService.CreatedResources.OfType<Container>().Any(c => c.AppModelResourceName == tunnelDependentContainer.Resource.Name))
+                {
+                    await Task.Delay(10, context.CancellationToken).ConfigureAwait(false);
+                }
+            }
+        });
+
+        var dcpOptions = new DcpOptions
+        {
+            EnableAspireContainerTunnel = true,
+        };
+
+        var appExecutor = CreateAppExecutor(distributedAppModel, kubernetesService: kubernetesService, dcpOptions: dcpOptions, events: events);
+        await appExecutor.RunApplicationAsync().DefaultTimeout();
+
+        var createdResources = kubernetesService.CreatedResources.ToList();
+        var upstreamExecutableResource = Assert.Single(createdResources.OfType<Executable>(), e => e.AppModelResourceName == upstreamExecutable.Resource.Name);
+        var downstreamExecutableResource = Assert.Single(createdResources.OfType<Executable>(), e => e.AppModelResourceName == downstreamExecutable.Resource.Name);
+        var tunnelDependentDcpContainer = Assert.Single(createdResources.OfType<Container>(), c => c.AppModelResourceName == tunnelDependentContainer.Resource.Name);
+
+        Assert.True(
+            createdResources.IndexOf(tunnelDependentDcpContainer) < createdResources.IndexOf(downstreamExecutableResource),
+            "The downstream host resource should not be created until the tunnel-dependent container it waits for has been created.");
+
+        var tunnelServices = createdResources
+            .OfType<Service>()
+            .Where(s => s.Metadata.Annotations.ContainsKey(CustomResource.ContainerTunnelInstanceName))
+            .ToList();
+
+        var upstreamTunnelService = Assert.Single(tunnelServices, s => s.AppModelResourceName == upstreamExecutable.Resource.Name);
+
+        Assert.NotNull(tunnelDependentDcpContainer.Spec.Env);
+        var upstreamPort = Assert.Single(tunnelDependentDcpContainer.Spec.Env, e => e.Name == "UPSTREAM_PORT").Value;
+        Assert.Equal(upstreamTunnelService.AllocatedPort.ToString(), upstreamPort);
+
+        var tunnelProxy = Assert.Single(createdResources.OfType<ContainerNetworkTunnelProxy>());
+        Assert.Equal(1, tunnelProxy.Spec.Tunnels?.Count);
+        Assert.NotNull(upstreamExecutableResource);
+    }
+
+    [Fact]
     public async Task EnvironmentCallbackThrows_OtherResourcesStillStart()
     {
         var builder = DistributedApplication.CreateBuilder();

--- a/tests/Aspire.Hosting.Tests/Dcp/TestKubernetesService.cs
+++ b/tests/Aspire.Hosting.Tests/Dcp/TestKubernetesService.cs
@@ -86,6 +86,8 @@ internal sealed class TestKubernetesService : IKubernetesService
                 proxy.Status = new ContainerNetworkTunnelProxyStatus();
             }
             proxy.Status.State = ContainerNetworkTunnelProxyState.Running;
+            proxy.Status.TunnelConfigurationVersion = 1;
+            proxy.Status.TunnelStatuses = CreateReadyTunnelStatuses(proxy.Spec.Tunnels);
         }
 
         lock (CreatedResources)
@@ -189,8 +191,8 @@ internal sealed class TestKubernetesService : IKubernetesService
 
     public Task<T> PatchAsync<T>(T obj, V1Patch patch, CancellationToken cancellationToken = default) where T : CustomResource, IKubernetesStaticMetadata
     {
-        // Not a complete implementation, but Aspire is using patching only to stop resources,
-        // so this is good enough.
+        // Not a complete implementation; tests currently use patching to stop resources
+        // and to update container tunnel proxy configuration.
 
         if (patch.Type == V1Patch.PatchType.JsonPatch)
         {
@@ -233,6 +235,16 @@ internal sealed class TestKubernetesService : IKubernetesService
                 }
             }
 
+            if (res is ContainerNetworkTunnelProxy proxy && result is ContainerNetworkTunnelProxy updatedProxy)
+            {
+                proxy.Spec = updatedProxy.Spec;
+                proxy.Status ??= new ContainerNetworkTunnelProxyStatus();
+                proxy.Status.State = ContainerNetworkTunnelProxyState.Running;
+                proxy.Status.TunnelConfigurationVersion++;
+                proxy.Status.TunnelStatuses = CreateReadyTunnelStatuses(proxy.Spec.Tunnels);
+                PushResourceModified(proxy);
+            }
+
             return Task.FromResult(res);
         }
 
@@ -258,5 +270,15 @@ internal sealed class TestKubernetesService : IKubernetesService
     public Task CleanupResourcesAsync(CancellationToken cancellationToken = default)
     {
         return StopServerAsync("Full", cancellationToken);
+    }
+
+    private static List<TunnelStatus>? CreateReadyTunnelStatuses(List<TunnelConfiguration>? tunnels)
+    {
+        return tunnels?.Select(t => new TunnelStatus
+        {
+            Name = t.Name,
+            State = TunnelState.Ready,
+            Timestamp = DateTime.UtcNow
+        }).ToList();
     }
 }


### PR DESCRIPTION
## Description

The implementation of container tunnel that shipped in Aspire 13.3 does not work if the tunnel-using containers wait on other resources. The reason is Aspire implements resource wait as a blocking `ResourceStarting` event handler. That blocking occurred before the crucial part of container startup sequence, which the tunnel initialization depended on. Effectively we had a startup deadlock.

The change refactors how container startup and tunnel startup cooperate. Crucially, the tunnel no longer requires all tunnel-dependent containers to reach a certain startup phase; additional tunnel-dependent containers can be started at any point during application lifecycle.

Fixes # (issue)
- https://github.com/microsoft/aspire/issues/16897 (verified manually)
- https://github.com/microsoft/aspire/issues/16976 (most likely--don't have a full repro yet)

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
