### PR TITLE
Fix CLI 'output directory not empty' message for interactive mode

### DIFF
--- a/src/Aspire.Cli/Resources/NewCommandStrings.Designer.cs
+++ b/src/Aspire.Cli/Resources/NewCommandStrings.Designer.cs
@@ -151,9 +151,15 @@ namespace Aspire.Cli.Resources {
             }
         }
 
-        public static string OutputDirectoryNotEmpty {
+        public static string OutputDirectoryNotEmptyNonInteractive {
             get {
-                return ResourceManager.GetString("OutputDirectoryNotEmpty", resourceCulture);
+                return ResourceManager.GetString("OutputDirectoryNotEmptyNonInteractive", resourceCulture);
+            }
+        }
+
+        public static string OutputDirectoryNotEmptyInteractive {
+            get {
+                return ResourceManager.GetString("OutputDirectoryNotEmptyInteractive", resourceCulture);
             }
         }
 

--- a/src/Aspire.Cli/Resources/NewCommandStrings.resx
+++ b/src/Aspire.Cli/Resources/NewCommandStrings.resx
@@ -154,8 +154,11 @@
   <data name="NonInteractiveTemplateRequired" xml:space="preserve">
     <value>A template must be specified when running in non-interactive mode. Use 'aspire new &lt;template&gt;'.</value>
   </data>
-  <data name="OutputDirectoryNotEmpty" xml:space="preserve">
+  <data name="OutputDirectoryNotEmptyNonInteractive" xml:space="preserve">
     <value>The output directory '{0}' already exists and is not empty. Specify --output with a different location.</value>
+  </data>
+  <data name="OutputDirectoryNotEmptyInteractive" xml:space="preserve">
+    <value>The output directory '{0}' already exists and is not empty. Specify a different location.</value>
   </data>
   <data name="OutputPathContainsInvalidCharacters" xml:space="preserve">
     <value>The output path '{0}' contains invalid characters.</value>

--- a/src/Aspire.Cli/Resources/xlf/NewCommandStrings.cs.xlf
+++ b/src/Aspire.Cli/Resources/xlf/NewCommandStrings.cs.xlf
@@ -52,9 +52,14 @@
         <target state="needs-review-translation">Výstupní cesta pro projekt</target>
         <note />
       </trans-unit>
-      <trans-unit id="OutputDirectoryNotEmpty">
+      <trans-unit id="OutputDirectoryNotEmptyNonInteractive">
         <source>The output directory '{0}' already exists and is not empty. Specify --output with a different location.</source>
         <target state="new">The output directory '{0}' already exists and is not empty. Specify --output with a different location.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="OutputDirectoryNotEmptyInteractive">
+        <source>The output directory '{0}' already exists and is not empty. Specify a different location.</source>
+        <target state="new">The output directory '{0}' already exists and is not empty. Specify a different location.</target>
         <note />
       </trans-unit>
       <trans-unit id="OutputPathContainsInvalidCharacters">

--- a/src/Aspire.Cli/Resources/xlf/NewCommandStrings.de.xlf
+++ b/src/Aspire.Cli/Resources/xlf/NewCommandStrings.de.xlf
@@ -52,9 +52,14 @@
         <target state="needs-review-translation">Der Ausgabepfad für das Projekt.</target>
         <note />
       </trans-unit>
-      <trans-unit id="OutputDirectoryNotEmpty">
+      <trans-unit id="OutputDirectoryNotEmptyNonInteractive">
         <source>The output directory '{0}' already exists and is not empty. Specify --output with a different location.</source>
         <target state="new">The output directory '{0}' already exists and is not empty. Specify --output with a different location.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="OutputDirectoryNotEmptyInteractive">
+        <source>The output directory '{0}' already exists and is not empty. Specify a different location.</source>
+        <target state="new">The output directory '{0}' already exists and is not empty. Specify a different location.</target>
         <note />
       </trans-unit>
       <trans-unit id="OutputPathContainsInvalidCharacters">

--- a/src/Aspire.Cli/Resources/xlf/NewCommandStrings.es.xlf
+++ b/src/Aspire.Cli/Resources/xlf/NewCommandStrings.es.xlf
@@ -52,9 +52,14 @@
         <target state="needs-review-translation">La ruta de salida del proyecto.</target>
         <note />
       </trans-unit>
-      <trans-unit id="OutputDirectoryNotEmpty">
+      <trans-unit id="OutputDirectoryNotEmptyNonInteractive">
         <source>The output directory '{0}' already exists and is not empty. Specify --output with a different location.</source>
         <target state="new">The output directory '{0}' already exists and is not empty. Specify --output with a different location.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="OutputDirectoryNotEmptyInteractive">
+        <source>The output directory '{0}' already exists and is not empty. Specify a different location.</source>
+        <target state="new">The output directory '{0}' already exists and is not empty. Specify a different location.</target>
         <note />
       </trans-unit>
       <trans-unit id="OutputPathContainsInvalidCharacters">

--- a/src/Aspire.Cli/Resources/xlf/NewCommandStrings.fr.xlf
+++ b/src/Aspire.Cli/Resources/xlf/NewCommandStrings.fr.xlf
@@ -52,9 +52,14 @@
         <target state="needs-review-translation">Le chemin de sortie du projet.</target>
         <note />
       </trans-unit>
-      <trans-unit id="OutputDirectoryNotEmpty">
+      <trans-unit id="OutputDirectoryNotEmptyNonInteractive">
         <source>The output directory '{0}' already exists and is not empty. Specify --output with a different location.</source>
         <target state="new">The output directory '{0}' already exists and is not empty. Specify --output with a different location.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="OutputDirectoryNotEmptyInteractive">
+        <source>The output directory '{0}' already exists and is not empty. Specify a different location.</source>
+        <target state="new">The output directory '{0}' already exists and is not empty. Specify a different location.</target>
         <note />
       </trans-unit>
       <trans-unit id="OutputPathContainsInvalidCharacters">

--- a/src/Aspire.Cli/Resources/xlf/NewCommandStrings.it.xlf
+++ b/src/Aspire.Cli/Resources/xlf/NewCommandStrings.it.xlf
@@ -52,9 +52,14 @@
         <target state="needs-review-translation">Percorso di output per il progetto.</target>
         <note />
       </trans-unit>
-      <trans-unit id="OutputDirectoryNotEmpty">
+      <trans-unit id="OutputDirectoryNotEmptyNonInteractive">
         <source>The output directory '{0}' already exists and is not empty. Specify --output with a different location.</source>
         <target state="new">The output directory '{0}' already exists and is not empty. Specify --output with a different location.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="OutputDirectoryNotEmptyInteractive">
+        <source>The output directory '{0}' already exists and is not empty. Specify a different location.</source>
+        <target state="new">The output directory '{0}' already exists and is not empty. Specify a different location.</target>
         <note />
       </trans-unit>
       <trans-unit id="OutputPathContainsInvalidCharacters">

--- a/src/Aspire.Cli/Resources/xlf/NewCommandStrings.ja.xlf
+++ b/src/Aspire.Cli/Resources/xlf/NewCommandStrings.ja.xlf
@@ -52,9 +52,14 @@
         <target state="needs-review-translation">プロジェクトの出力パス。</target>
         <note />
       </trans-unit>
-      <trans-unit id="OutputDirectoryNotEmpty">
+      <trans-unit id="OutputDirectoryNotEmptyNonInteractive">
         <source>The output directory '{0}' already exists and is not empty. Specify --output with a different location.</source>
         <target state="new">The output directory '{0}' already exists and is not empty. Specify --output with a different location.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="OutputDirectoryNotEmptyInteractive">
+        <source>The output directory '{0}' already exists and is not empty. Specify a different location.</source>
+        <target state="new">The output directory '{0}' already exists and is not empty. Specify a different location.</target>
         <note />
       </trans-unit>
       <trans-unit id="OutputPathContainsInvalidCharacters">

--- a/src/Aspire.Cli/Resources/xlf/NewCommandStrings.ko.xlf
+++ b/src/Aspire.Cli/Resources/xlf/NewCommandStrings.ko.xlf
@@ -52,9 +52,14 @@
         <target state="needs-review-translation">프로젝트의 출력 경로입니다.</target>
         <note />
       </trans-unit>
-      <trans-unit id="OutputDirectoryNotEmpty">
+      <trans-unit id="OutputDirectoryNotEmptyNonInteractive">
         <source>The output directory '{0}' already exists and is not empty. Specify --output with a different location.</source>
         <target state="new">The output directory '{0}' already exists and is not empty. Specify --output with a different location.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="OutputDirectoryNotEmptyInteractive">
+        <source>The output directory '{0}' already exists and is not empty. Specify a different location.</source>
+        <target state="new">The output directory '{0}' already exists and is not empty. Specify a different location.</target>
         <note />
       </trans-unit>
       <trans-unit id="OutputPathContainsInvalidCharacters">

--- a/src/Aspire.Cli/Resources/xlf/NewCommandStrings.pl.xlf
+++ b/src/Aspire.Cli/Resources/xlf/NewCommandStrings.pl.xlf
@@ -52,9 +52,14 @@
         <target state="needs-review-translation">Ścieżka wyjściowa projektu.</target>
         <note />
       </trans-unit>
-      <trans-unit id="OutputDirectoryNotEmpty">
+      <trans-unit id="OutputDirectoryNotEmptyNonInteractive">
         <source>The output directory '{0}' already exists and is not empty. Specify --output with a different location.</source>
         <target state="new">The output directory '{0}' already exists and is not empty. Specify --output with a different location.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="OutputDirectoryNotEmptyInteractive">
+        <source>The output directory '{0}' already exists and is not empty. Specify a different location.</source>
+        <target state="new">The output directory '{0}' already exists and is not empty. Specify a different location.</target>
         <note />
       </trans-unit>
       <trans-unit id="OutputPathContainsInvalidCharacters">

--- a/src/Aspire.Cli/Resources/xlf/NewCommandStrings.pt-BR.xlf
+++ b/src/Aspire.Cli/Resources/xlf/NewCommandStrings.pt-BR.xlf
@@ -52,9 +52,14 @@
         <target state="needs-review-translation">O caminho de saída para o projeto.</target>
         <note />
       </trans-unit>
-      <trans-unit id="OutputDirectoryNotEmpty">
+      <trans-unit id="OutputDirectoryNotEmptyNonInteractive">
         <source>The output directory '{0}' already exists and is not empty. Specify --output with a different location.</source>
         <target state="new">The output directory '{0}' already exists and is not empty. Specify --output with a different location.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="OutputDirectoryNotEmptyInteractive">
+        <source>The output directory '{0}' already exists and is not empty. Specify a different location.</source>
+        <target state="new">The output directory '{0}' already exists and is not empty. Specify a different location.</target>
         <note />
       </trans-unit>
       <trans-unit id="OutputPathContainsInvalidCharacters">

--- a/src/Aspire.Cli/Resources/xlf/NewCommandStrings.ru.xlf
+++ b/src/Aspire.Cli/Resources/xlf/NewCommandStrings.ru.xlf
@@ -52,9 +52,14 @@
         <target state="needs-review-translation">Выходной путь для проекта.</target>
         <note />
       </trans-unit>
-      <trans-unit id="OutputDirectoryNotEmpty">
+      <trans-unit id="OutputDirectoryNotEmptyNonInteractive">
         <source>The output directory '{0}' already exists and is not empty. Specify --output with a different location.</source>
         <target state="new">The output directory '{0}' already exists and is not empty. Specify --output with a different location.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="OutputDirectoryNotEmptyInteractive">
+        <source>The output directory '{0}' already exists and is not empty. Specify a different location.</source>
+        <target state="new">The output directory '{0}' already exists and is not empty. Specify a different location.</target>
         <note />
       </trans-unit>
       <trans-unit id="OutputPathContainsInvalidCharacters">

--- a/src/Aspire.Cli/Resources/xlf/NewCommandStrings.tr.xlf
+++ b/src/Aspire.Cli/Resources/xlf/NewCommandStrings.tr.xlf
@@ -52,9 +52,14 @@
         <target state="needs-review-translation">Projenin çıkış yolu.</target>
         <note />
       </trans-unit>
-      <trans-unit id="OutputDirectoryNotEmpty">
+      <trans-unit id="OutputDirectoryNotEmptyNonInteractive">
         <source>The output directory '{0}' already exists and is not empty. Specify --output with a different location.</source>
         <target state="new">The output directory '{0}' already exists and is not empty. Specify --output with a different location.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="OutputDirectoryNotEmptyInteractive">
+        <source>The output directory '{0}' already exists and is not empty. Specify a different location.</source>
+        <target state="new">The output directory '{0}' already exists and is not empty. Specify a different location.</target>
         <note />
       </trans-unit>
       <trans-unit id="OutputPathContainsInvalidCharacters">

--- a/src/Aspire.Cli/Resources/xlf/NewCommandStrings.zh-Hans.xlf
+++ b/src/Aspire.Cli/Resources/xlf/NewCommandStrings.zh-Hans.xlf
@@ -52,9 +52,14 @@
         <target state="needs-review-translation">项目的输出路径。</target>
         <note />
       </trans-unit>
-      <trans-unit id="OutputDirectoryNotEmpty">
+      <trans-unit id="OutputDirectoryNotEmptyNonInteractive">
         <source>The output directory '{0}' already exists and is not empty. Specify --output with a different location.</source>
         <target state="new">The output directory '{0}' already exists and is not empty. Specify --output with a different location.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="OutputDirectoryNotEmptyInteractive">
+        <source>The output directory '{0}' already exists and is not empty. Specify a different location.</source>
+        <target state="new">The output directory '{0}' already exists and is not empty. Specify a different location.</target>
         <note />
       </trans-unit>
       <trans-unit id="OutputPathContainsInvalidCharacters">

--- a/src/Aspire.Cli/Resources/xlf/NewCommandStrings.zh-Hant.xlf
+++ b/src/Aspire.Cli/Resources/xlf/NewCommandStrings.zh-Hant.xlf
@@ -52,9 +52,14 @@
         <target state="needs-review-translation">專案的輸出路徑。</target>
         <note />
       </trans-unit>
-      <trans-unit id="OutputDirectoryNotEmpty">
+      <trans-unit id="OutputDirectoryNotEmptyNonInteractive">
         <source>The output directory '{0}' already exists and is not empty. Specify --output with a different location.</source>
         <target state="new">The output directory '{0}' already exists and is not empty. Specify --output with a different location.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="OutputDirectoryNotEmptyInteractive">
+        <source>The output directory '{0}' already exists and is not empty. Specify a different location.</source>
+        <target state="new">The output directory '{0}' already exists and is not empty. Specify a different location.</target>
         <note />
       </trans-unit>
       <trans-unit id="OutputPathContainsInvalidCharacters">

--- a/src/Aspire.Cli/Templating/DotNetTemplateFactory.cs
+++ b/src/Aspire.Cli/Templating/DotNetTemplateFactory.cs
@@ -605,7 +605,7 @@ internal class DotNetTemplateFactory(
 
             // Re-validate the adjusted path for non-empty directory since appending the
             // project name may target a different directory than the one already validated.
-            var validationError = OutputPathHelper.ValidateResolvedOutputPath(outputPath);
+            var validationError = OutputPathHelper.ValidateOutputPath(outputPath, isExplicitOutput: inputs.Output is not null);
             if (validationError is not null)
             {
                 interactionService.DisplayError(validationError);

--- a/src/Aspire.Cli/Templating/DotNetTemplateFactory.cs
+++ b/src/Aspire.Cli/Templating/DotNetTemplateFactory.cs
@@ -605,7 +605,7 @@ internal class DotNetTemplateFactory(
 
             // Re-validate the adjusted path for non-empty directory since appending the
             // project name may target a different directory than the one already validated.
-            var validationError = OutputPathHelper.ValidateOutputPath(outputPath, isExplicitOutput: inputs.Output is not null);
+            var validationError = OutputPathHelper.ValidateOutputPath(outputPath, executionContext.WorkingDirectory.FullName, isExplicitOutput: inputs.Output is not null);
             if (validationError is not null)
             {
                 interactionService.DisplayError(validationError);

--- a/src/Aspire.Cli/Templating/OutputPathHelper.cs
+++ b/src/Aspire.Cli/Templating/OutputPathHelper.cs
@@ -49,7 +49,7 @@ internal static class OutputPathHelper
         baseName = SanitizeBaseName(baseName);
 
         var baseCandidate = $"./{baseName}";
-        if (!IsNonEmptyDirectory(baseCandidate, workingDirectory))
+        if (!IsNonEmptyDirectory(Path.GetFullPath(baseCandidate, workingDirectory)))
         {
             return baseCandidate;
         }
@@ -57,7 +57,7 @@ internal static class OutputPathHelper
         for (var i = 2; i < 1000; i++)
         {
             var candidate = $"{baseCandidate}-{i}";
-            if (!IsNonEmptyDirectory(candidate, workingDirectory))
+            if (!IsNonEmptyDirectory(Path.GetFullPath(candidate, workingDirectory)))
             {
                 return candidate;
             }
@@ -75,15 +75,10 @@ internal static class OutputPathHelper
     {
         return path =>
         {
-            if (ContainsInvalidPathChars(path))
+            var validationResult = ValidateOutputPath(path, workingDirectory, isExplicitOutput: false);
+            if (validationResult is not null)
             {
-                return ValidationResult.Error(string.Format(CultureInfo.CurrentCulture, NewCommandStrings.OutputPathContainsInvalidCharacters, path));
-            }
-
-            if (IsNonEmptyDirectory(path, workingDirectory))
-            {
-                var fullPath = Path.GetFullPath(path, workingDirectory);
-                return ValidationResult.Error(string.Format(CultureInfo.CurrentCulture, NewCommandStrings.OutputDirectoryNotEmpty, fullPath));
+                return ValidationResult.Error(validationResult);
             }
 
             return ValidationResult.Success();
@@ -94,31 +89,23 @@ internal static class OutputPathHelper
     /// Validates a (possibly relative) output path before resolution. Returns an error message if the path
     /// contains invalid characters or targets a non-empty existing directory, or <see langword="null"/> if valid.
     /// </summary>
-    internal static string? ValidateOutputPath(string path, string workingDirectory)
+    internal static string? ValidateOutputPath(string path, string workingDirectory, bool isExplicitOutput = true)
     {
-        if (ContainsInvalidPathChars(path))
-        {
-            return string.Format(CultureInfo.CurrentCulture, NewCommandStrings.OutputPathContainsInvalidCharacters, path);
-        }
-
-        if (IsNonEmptyDirectory(path, workingDirectory))
-        {
-            var fullPath = Path.GetFullPath(path, workingDirectory);
-            return string.Format(CultureInfo.CurrentCulture, NewCommandStrings.OutputDirectoryNotEmpty, fullPath);
-        }
-
-        return null;
+        var fullPath = Path.GetFullPath(path, workingDirectory);
+        return ValidateOutputPath(fullPath, isExplicitOutput);
     }
 
-    /// <summary>
-    /// Validates the resolved (absolute) output path and returns an error message if it's
-    /// a non-empty existing directory, or <see langword="null"/> if valid.
-    /// </summary>
-    internal static string? ValidateResolvedOutputPath(string absolutePath)
+    internal static string? ValidateOutputPath(string fullPath, bool isExplicitOutput = true)
     {
-        if (Directory.Exists(absolutePath) && Directory.EnumerateFileSystemEntries(absolutePath).Any())
+        if (ContainsInvalidPathChars(fullPath))
         {
-            return string.Format(CultureInfo.CurrentCulture, NewCommandStrings.OutputDirectoryNotEmpty, absolutePath);
+            return string.Format(CultureInfo.CurrentCulture, NewCommandStrings.OutputPathContainsInvalidCharacters, fullPath);
+        }
+
+        if (IsNonEmptyDirectory(fullPath))
+        {
+            var format = isExplicitOutput ? NewCommandStrings.OutputDirectoryNotEmptyNonInteractive : NewCommandStrings.OutputDirectoryNotEmptyInteractive;
+            return string.Format(CultureInfo.CurrentCulture, format, fullPath);
         }
 
         return null;
@@ -136,9 +123,8 @@ internal static class OutputPathHelper
         return path.AsSpan().IndexOfAny(Path.GetInvalidPathChars()) >= 0;
     }
 
-    private static bool IsNonEmptyDirectory(string relativePath, string workingDirectory)
+    private static bool IsNonEmptyDirectory(string fullPath)
     {
-        var fullPath = Path.GetFullPath(relativePath, workingDirectory);
-        return Directory.Exists(fullPath) && Directory.EnumerateFileSystemEntries(fullPath).Any();
+        return Path.IsPathRooted(fullPath) && Directory.Exists(fullPath) && Directory.EnumerateFileSystemEntries(fullPath).Any();
     }
 }

--- a/src/Aspire.Cli/Templating/OutputPathHelper.cs
+++ b/src/Aspire.Cli/Templating/OutputPathHelper.cs
@@ -91,17 +91,13 @@ internal static class OutputPathHelper
     /// </summary>
     internal static string? ValidateOutputPath(string path, string workingDirectory, bool isExplicitOutput = true)
     {
-        var fullPath = Path.GetFullPath(path, workingDirectory);
-        return ValidateOutputPath(fullPath, isExplicitOutput);
-    }
-
-    internal static string? ValidateOutputPath(string fullPath, bool isExplicitOutput = true)
-    {
-        if (ContainsInvalidPathChars(fullPath))
+        // Validate the path before calling Path.GetFullPath to avoid exceptions from invalid characters.
+        if (ContainsInvalidPathChars(path))
         {
-            return string.Format(CultureInfo.CurrentCulture, NewCommandStrings.OutputPathContainsInvalidCharacters, fullPath);
+            return string.Format(CultureInfo.CurrentCulture, NewCommandStrings.OutputPathContainsInvalidCharacters, path);
         }
 
+        var fullPath = Path.GetFullPath(path, workingDirectory);
         if (IsNonEmptyDirectory(fullPath))
         {
             var format = isExplicitOutput ? NewCommandStrings.OutputDirectoryNotEmptyNonInteractive : NewCommandStrings.OutputDirectoryNotEmptyInteractive;

--- a/tests/Aspire.Cli.Tests/Commands/NewCommandTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/NewCommandTests.cs
@@ -2269,7 +2269,7 @@ public class NewCommandTests(ITestOutputHelper outputHelper)
         var exitCode = await result.InvokeAsync().DefaultTimeout();
         Assert.Equal(ExitCodeConstants.FailedToCreateNewProject, exitCode);
         Assert.NotNull(testInteractionService);
-        var expectedError = string.Format(CultureInfo.CurrentCulture, NewCommandStrings.OutputDirectoryNotEmpty, existingDir.FullName);
+        var expectedError = string.Format(CultureInfo.CurrentCulture, NewCommandStrings.OutputDirectoryNotEmptyNonInteractive, existingDir.FullName);
         var e = Assert.Single(testInteractionService.DisplayedErrors);
         Assert.Equal(expectedError, e);
     }


### PR DESCRIPTION
## Description

When the CLI detects a non-empty output directory during `aspire new`, it previously always showed:

> The output directory '...' already exists and is not empty. Specify --output with a different location.

This message is misleading in interactive mode where the user didn't use `--output` — they were prompted for the path. This change splits the message into two context-appropriate variants:

- **Non-interactive / explicit `--output`**: "...Specify --output with a different location."
- **Interactive prompt**: "...Specify a different location."

Also fixes two pre-existing build errors in `OutputPathHelper`:
- A variable name bug (`path` instead of `fullPath`) in the single-arg `ValidateOutputPath` overload.
- A missing method reference (`ValidateResolvedOutputPath` → `ValidateOutputPath`) in `DotNetTemplateFactory`.
- Adds a rooted-path guard to `IsNonEmptyDirectory` to avoid unexpected behavior with relative paths.

Fixes https://github.com/microsoft/aspire/issues/16646

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
  - [x] No
