### PR TITLE
Add doctor Aspire version checks

### DIFF
--- a/src/Aspire.Cli/Commands/DoctorCommand.cs
+++ b/src/Aspire.Cli/Commands/DoctorCommand.cs
@@ -189,6 +189,8 @@ internal sealed class DoctorCommand : BaseCommand
         return category switch
         {
             "sdk" => DoctorCommandStrings.SdkCategoryHeader,
+            "aspire" => DoctorCommandStrings.AspireCategoryHeader,
+            "apphost" => DoctorCommandStrings.AppHostCategoryHeader,
             "container" => DoctorCommandStrings.ContainerCategoryHeader,
             "environment" => DoctorCommandStrings.EnvironmentCategoryHeader,
             _ => category
@@ -199,9 +201,11 @@ internal sealed class DoctorCommand : BaseCommand
     {
         return category switch
         {
-            "sdk" => 1,
-            "container" => 2,
-            "environment" => 3,
+            "aspire" => 0,
+            "apphost" => 1,
+            "sdk" => 2,
+            "container" => 3,
+            "environment" => 4,
             _ => 99
         };
     }

--- a/src/Aspire.Cli/Program.cs
+++ b/src/Aspire.Cli/Program.cs
@@ -466,6 +466,7 @@ public class Program
         builder.Services.AddSingleton<IAppHostProjectFactory, AppHostProjectFactory>();
 
         // Environment checking services.
+        builder.Services.AddSingleton<IEnvironmentCheck, AspireVersionCheck>();
         builder.Services.AddSingleton<IEnvironmentCheck, WslEnvironmentCheck>();
         builder.Services.AddSingleton<IEnvironmentCheck, DotNetSdkCheck>();
         builder.Services.AddSingleton<IEnvironmentCheck, TypeScriptAppHostToolingCheck>();

--- a/src/Aspire.Cli/Projects/AppHostCandidateFinder.cs
+++ b/src/Aspire.Cli/Projects/AppHostCandidateFinder.cs
@@ -23,13 +23,15 @@ internal interface IAppHostCandidateFinder
     /// <param name="nugetCachePath">The NuGet package cache path to exclude, if known.</param>
     /// <param name="scope">Controls which files are considered. See <see cref="AppHostDiscoveryScope"/>.</param>
     /// <param name="cancellationToken">The cancellation token.</param>
+    /// <param name="maxDepth">The maximum subdirectory depth to search, where 0 only considers files in <paramref name="searchDirectory"/>.</param>
     /// <returns>A search result with matching files and one count entry for every requested pattern.</returns>
     Task<AppHostCandidateFileSearchResult> FindCandidateFilesAsync(
         DirectoryInfo searchDirectory,
         IReadOnlyList<string> patterns,
         string? nugetCachePath,
         AppHostDiscoveryScope scope,
-        CancellationToken cancellationToken);
+        CancellationToken cancellationToken,
+        int? maxDepth = null);
 }
 
 /// <summary>
@@ -79,7 +81,8 @@ internal sealed class AppHostCandidateFinder(
         IReadOnlyList<string> patterns,
         string? nugetCachePath,
         AppHostDiscoveryScope scope,
-        CancellationToken cancellationToken)
+        CancellationToken cancellationToken,
+        int? maxDepth = null)
     {
         using var discoveryActivity = profilingTelemetry.StartAppHostCandidateDiscovery(searchDirectory, scope, patterns.Count, nugetCachePath is not null);
         if (patterns.Count == 0)
@@ -100,7 +103,7 @@ internal sealed class AppHostCandidateFinder(
             {
                 logger.LogDebug("Using git-included file list ({Count} entries) as discovery source.", includedPaths.Count);
                 using var matchActivity = profilingTelemetry.StartAppHostCandidateGitMatch(includedPaths.Count, patterns.Count);
-                var result = MatchFromIncludedPaths(searchDirectory, patterns, includedPaths, nugetCachePath, cancellationToken);
+                var result = MatchFromIncludedPaths(searchDirectory, patterns, includedPaths, nugetCachePath, maxDepth, cancellationToken);
                 matchActivity.SetAppHostCandidateCount(result.Files.Length);
                 discoveryActivity.SetAppHostDiscoverySource(ProfilingTelemetry.Values.AppHostDiscoverySourceGit);
                 discoveryActivity.SetAppHostDiscoveryIncludedFileCount(includedPaths.Count);
@@ -121,7 +124,7 @@ internal sealed class AppHostCandidateFinder(
         };
 
         using var walkActivity = profilingTelemetry.StartAppHostCandidateFilesystemWalk(searchDirectory, patterns.Count, skipList is not null, nugetCachePath is not null);
-        var searchResult = FindMatchingFiles(searchDirectory, patterns, enumerationOptions, nugetCachePath, skipList, walkActivity, cancellationToken);
+        var searchResult = FindMatchingFiles(searchDirectory, patterns, enumerationOptions, nugetCachePath, skipList, maxDepth, walkActivity, cancellationToken);
         walkActivity.SetAppHostCandidateCount(searchResult.Files.Length);
         discoveryActivity.SetAppHostDiscoverySource(ProfilingTelemetry.Values.AppHostDiscoverySourceFilesystem);
         discoveryActivity.SetAppHostCandidateCount(searchResult.Files.Length);
@@ -133,6 +136,7 @@ internal sealed class AppHostCandidateFinder(
         IReadOnlyList<string> patterns,
         IReadOnlySet<string> includedPaths,
         string? nugetCachePath,
+        int? maxDepth,
         CancellationToken cancellationToken)
     {
         var pathComparison = GetPathComparison();
@@ -183,6 +187,10 @@ internal sealed class AppHostCandidateFinder(
             }
 
             var relativeNative = Path.GetRelativePath(rootFullName, absolutePath);
+            if (!IsWithinDepth(relativeNative, maxDepth))
+            {
+                continue;
+            }
 
             // Microsoft.Extensions.FileSystemGlobbing matchers operate on forward-slash
             // paths even on Windows. Convert "src\\AppHost\\AppHost.csproj" to
@@ -260,6 +268,7 @@ internal sealed class AppHostCandidateFinder(
         EnumerationOptions options,
         string? excludePath,
         FrozenSet<string>? excludedDirectoryNames,
+        int? maxDepth,
         ProfilingTelemetry.ActivityScope walkActivity,
         CancellationToken cancellationToken)
     {
@@ -278,7 +287,7 @@ internal sealed class AppHostCandidateFinder(
         // "**/*.csproj" and let the matcher walk once instead of enumerating once per
         // language detection pattern.
         var counters = new DiscoveryCounters();
-        var directory = new MatcherDirectoryInfo(searchDirectory, options, excludePath, excludedDirectoryNames, pathComparison, counters, cancellationToken);
+        var directory = new MatcherDirectoryInfo(searchDirectory, options, excludePath, excludedDirectoryNames, pathComparison, counters, depth: 0, maxDepth, cancellationToken);
         var matchedFilePaths = matcher.Execute(directory).Files.Select(match => match.Path).ToArray();
         walkActivity.SetAppHostDiscoveryWalkCounts(counters.FilesEnumerated, counters.DirectoriesEnumerated, counters.DirectoriesSkipped);
 
@@ -327,6 +336,23 @@ internal sealed class AppHostCandidateFinder(
             : $"**/{normalizedPattern}";
     }
 
+    private static bool IsWithinDepth(string relativePath, int? maxDepth)
+    {
+        if (maxDepth is null)
+        {
+            return true;
+        }
+
+        var relativeDirectory = Path.GetDirectoryName(relativePath);
+        if (string.IsNullOrEmpty(relativeDirectory))
+        {
+            return true;
+        }
+
+        var depth = relativeDirectory.Split([Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar], StringSplitOptions.RemoveEmptyEntries).Length;
+        return depth <= maxDepth;
+    }
+
     private static Matcher CreateMatcher(IEnumerable<string> patterns)
     {
         var matcher = new Matcher(StringComparison.OrdinalIgnoreCase);
@@ -367,7 +393,7 @@ internal sealed class AppHostCandidateFinder(
         public int DirectoriesSkipped { get; set; }
     }
 
-    private sealed class MatcherDirectoryInfo(DirectoryInfo directory, EnumerationOptions options, string? excludePath, FrozenSet<string>? excludedDirectoryNames, StringComparison pathComparison, DiscoveryCounters counters, CancellationToken cancellationToken) : DirectoryInfoBase
+    private sealed class MatcherDirectoryInfo(DirectoryInfo directory, EnumerationOptions options, string? excludePath, FrozenSet<string>? excludedDirectoryNames, StringComparison pathComparison, DiscoveryCounters counters, int depth, int? maxDepth, CancellationToken cancellationToken) : DirectoryInfoBase
     {
         private readonly DirectoryInfo _directory = directory;
         private readonly EnumerationOptions _options = options;
@@ -375,6 +401,8 @@ internal sealed class AppHostCandidateFinder(
         private readonly FrozenSet<string>? _excludedDirectoryNames = excludedDirectoryNames;
         private readonly StringComparison _pathComparison = pathComparison;
         private readonly DiscoveryCounters _counters = counters;
+        private readonly int _depth = depth;
+        private readonly int? _maxDepth = maxDepth;
         private readonly CancellationToken _cancellationToken = cancellationToken;
 
         public override string Name => _directory.Name;
@@ -382,7 +410,7 @@ internal sealed class AppHostCandidateFinder(
         public override string FullName => _directory.FullName;
 
         public override DirectoryInfoBase ParentDirectory => _directory.Parent is { } parent
-            ? new MatcherDirectoryInfo(parent, _options, _excludePath, _excludedDirectoryNames, _pathComparison, _counters, _cancellationToken)
+            ? new MatcherDirectoryInfo(parent, _options, _excludePath, _excludedDirectoryNames, _pathComparison, _counters, _depth - 1, _maxDepth, _cancellationToken)
             : null!;
 
         public override IEnumerable<FileSystemInfoBase> EnumerateFileSystemInfos()
@@ -394,9 +422,9 @@ internal sealed class AppHostCandidateFinder(
                 if (entry is DirectoryInfo childDirectory)
                 {
                     _counters.DirectoriesEnumerated++;
-                    if (!ShouldExcludeDirectory(childDirectory))
+                    if (CanRecurse && !ShouldExcludeDirectory(childDirectory))
                     {
-                        yield return new MatcherDirectoryInfo(childDirectory, _options, _excludePath, _excludedDirectoryNames, _pathComparison, _counters, _cancellationToken);
+                        yield return new MatcherDirectoryInfo(childDirectory, _options, _excludePath, _excludedDirectoryNames, _pathComparison, _counters, _depth + 1, _maxDepth, _cancellationToken);
                     }
                     else
                     {
@@ -406,19 +434,22 @@ internal sealed class AppHostCandidateFinder(
                 else if (entry is FileInfo childFile)
                 {
                     _counters.FilesEnumerated++;
-                    yield return new MatcherFileInfo(childFile, _options, _excludePath, _excludedDirectoryNames, _pathComparison, _counters, _cancellationToken);
+                    if (CanIncludeFiles)
+                    {
+                        yield return new MatcherFileInfo(childFile, _options, _excludePath, _excludedDirectoryNames, _pathComparison, _counters, _depth, _maxDepth, _cancellationToken);
+                    }
                 }
             }
         }
 
         public override DirectoryInfoBase GetDirectory(string path)
         {
-            return new MatcherDirectoryInfo(new DirectoryInfo(Path.Combine(_directory.FullName, path)), _options, _excludePath, _excludedDirectoryNames, _pathComparison, _counters, _cancellationToken);
+            return new MatcherDirectoryInfo(new DirectoryInfo(Path.Combine(_directory.FullName, path)), _options, _excludePath, _excludedDirectoryNames, _pathComparison, _counters, _depth + 1, _maxDepth, _cancellationToken);
         }
 
         public override FileInfoBase GetFile(string path)
         {
-            return new MatcherFileInfo(new FileInfo(Path.Combine(_directory.FullName, path)), _options, _excludePath, _excludedDirectoryNames, _pathComparison, _counters, _cancellationToken);
+            return new MatcherFileInfo(new FileInfo(Path.Combine(_directory.FullName, path)), _options, _excludePath, _excludedDirectoryNames, _pathComparison, _counters, _depth, _maxDepth, _cancellationToken);
         }
 
         private bool ShouldExcludeDirectory(DirectoryInfo directory)
@@ -437,9 +468,13 @@ internal sealed class AppHostCandidateFinder(
             return directoryPath.Equals(_excludePath, _pathComparison)
                 || directoryPath.StartsWith(_excludePath + Path.DirectorySeparatorChar, _pathComparison);
         }
+
+        private bool CanRecurse => _maxDepth is null || _depth < _maxDepth;
+
+        private bool CanIncludeFiles => _maxDepth is null || _depth <= _maxDepth;
     }
 
-    private sealed class MatcherFileInfo(FileInfo file, EnumerationOptions options, string? excludePath, FrozenSet<string>? excludedDirectoryNames, StringComparison pathComparison, DiscoveryCounters counters, CancellationToken cancellationToken) : FileInfoBase
+    private sealed class MatcherFileInfo(FileInfo file, EnumerationOptions options, string? excludePath, FrozenSet<string>? excludedDirectoryNames, StringComparison pathComparison, DiscoveryCounters counters, int depth, int? maxDepth, CancellationToken cancellationToken) : FileInfoBase
     {
         private readonly FileInfo _file = file;
         private readonly EnumerationOptions _options = options;
@@ -447,6 +482,8 @@ internal sealed class AppHostCandidateFinder(
         private readonly FrozenSet<string>? _excludedDirectoryNames = excludedDirectoryNames;
         private readonly StringComparison _pathComparison = pathComparison;
         private readonly DiscoveryCounters _counters = counters;
+        private readonly int _depth = depth;
+        private readonly int? _maxDepth = maxDepth;
         private readonly CancellationToken _cancellationToken = cancellationToken;
 
         public override string Name => _file.Name;
@@ -454,7 +491,7 @@ internal sealed class AppHostCandidateFinder(
         public override string FullName => _file.FullName;
 
         public override DirectoryInfoBase ParentDirectory => _file.Directory is { } parent
-            ? new MatcherDirectoryInfo(parent, _options, _excludePath, _excludedDirectoryNames, _pathComparison, _counters, _cancellationToken)
+            ? new MatcherDirectoryInfo(parent, _options, _excludePath, _excludedDirectoryNames, _pathComparison, _counters, _depth, _maxDepth, _cancellationToken)
             : null!;
     }
 

--- a/src/Aspire.Cli/Projects/DotNetAppHostProject.cs
+++ b/src/Aspire.Cli/Projects/DotNetAppHostProject.cs
@@ -188,7 +188,7 @@ internal sealed class DotNetAppHostProject : IAppHostProject
 
         if (information.ExitCode == 0 && information.IsAspireHost)
         {
-            return new AppHostValidationResult(IsValid: true);
+            return new AppHostValidationResult(IsValid: true, AspireHostingVersion: information.AspireHostingVersion);
         }
 
         // Check if it's possibly an unbuildable AppHost (has the right name pattern but couldn't be validated)
@@ -197,6 +197,18 @@ internal sealed class DotNetAppHostProject : IAppHostProject
         return new AppHostValidationResult(
             IsValid: false,
             IsPossiblyUnbuildable: isPossiblyUnbuildable);
+    }
+
+    /// <inheritdoc />
+    public async Task<string?> GetAspireHostingVersionAsync(FileInfo appHostFile, CancellationToken cancellationToken)
+    {
+        // Use the same MSBuild-based inspection as validation so version resolution
+        // follows the project model that run/publish already rely on, including
+        // SDK-style projects, package references, and Central Package Management.
+        var information = await _runner.GetAppHostInformationAsync(appHostFile, new ProcessInvocationOptions(), cancellationToken);
+        return information.ExitCode == 0 && information.IsAspireHost
+            ? information.AspireHostingVersion
+            : null;
     }
 
     private static bool IsPossiblyUnbuildableAppHost(FileInfo projectFile)

--- a/src/Aspire.Cli/Projects/GuestAppHostProject.cs
+++ b/src/Aspire.Cli/Projects/GuestAppHostProject.cs
@@ -202,6 +202,21 @@ internal sealed class GuestAppHostProject : IAppHostProject, IGuestAppHostSdkGen
         return config.GetEffectiveSdkVersion(GetEffectiveSdkVersion());
     }
 
+    /// <inheritdoc />
+    public Task<string?> GetAspireHostingVersionAsync(FileInfo appHostFile, CancellationToken cancellationToken)
+    {
+        var defaultSdkVersion = GetEffectiveSdkVersion();
+
+        // Version inspection is read-only. Load an existing config from the same
+        // inherited config root used by guest AppHost operations, but do not call
+        // LoadOrCreate because merely checking the version must not write config files.
+        var config = appHostFile.Directory is { } directory
+            ? AspireConfigFile.Load(GetConfigDirectory(directory).FullName)
+            : null;
+
+        return Task.FromResult<string?>(config?.GetEffectiveSdkVersion(defaultSdkVersion) ?? defaultSdkVersion);
+    }
+
     /// <summary>
     /// Prepares the AppHost server (creates files and builds for dev mode, restores packages for prebuilt mode).
     /// </summary>

--- a/src/Aspire.Cli/Projects/IAppHostProject.cs
+++ b/src/Aspire.Cli/Projects/IAppHostProject.cs
@@ -13,7 +13,8 @@ internal record AppHostValidationResult(
     bool IsValid,
     bool IsPossiblyUnbuildable = false,
     bool IsUnsupported = false,
-    string? Message = null);
+    string? Message = null,
+    string? AspireHostingVersion = null);
 
 /// <summary>
 /// Context for updating packages in an AppHost project.
@@ -220,6 +221,14 @@ internal interface IAppHostProject
     /// <param name="cancellationToken">A cancellation token.</param>
     /// <returns>A validation result indicating if the file is valid and any additional status.</returns>
     Task<AppHostValidationResult> ValidateAppHostAsync(FileInfo appHostFile, CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Gets the Aspire SDK version used by the specified AppHost.
+    /// </summary>
+    /// <param name="appHostFile">The AppHost file.</param>
+    /// <param name="cancellationToken">A cancellation token.</param>
+    /// <returns>The resolved version using this project type's AppHost model, or <see langword="null"/> when the version is unknown.</returns>
+    Task<string?> GetAspireHostingVersionAsync(FileInfo appHostFile, CancellationToken cancellationToken);
 
     /// <summary>
     /// Adds a package to the AppHost project.

--- a/src/Aspire.Cli/Projects/ProjectLocator.cs
+++ b/src/Aspire.Cli/Projects/ProjectLocator.cs
@@ -38,12 +38,18 @@ internal interface IProjectLocator
     Task<FileInfo?> UseOrFindAppHostProjectFileAsync(FileInfo? projectFile, bool createSettingsFile, CancellationToken cancellationToken);
 
     /// <summary>
-    /// Resolves the AppHost project file from <c>.aspire/settings.json</c> only, without any
-    /// user interaction or recursive filesystem scanning. Returns <c>null</c> when no settings
-    /// file or <c>appHostPath</c> entry is found, or when the configured path is no longer a
-    /// valid AppHost project.
+    /// Resolves the AppHost project file from Aspire settings, without any user interaction or
+    /// recursive filesystem scanning. Returns <c>null</c> when no settings file or AppHost path
+    /// entry is found, or when the configured path is no longer a valid AppHost project.
     /// </summary>
     Task<FileInfo?> GetAppHostFromSettingsAsync(CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Resolves the AppHost project file from Aspire settings starting in the specified directory,
+    /// without any user interaction or recursive filesystem scanning.
+    /// </summary>
+    Task<FileInfo?> GetAppHostFromSettingsAsync(DirectoryInfo searchDirectory, bool searchParentDirectories, CancellationToken cancellationToken = default)
+        => GetAppHostFromSettingsAsync(cancellationToken);
 }
 
 internal sealed record AppHostProjectCandidate(FileInfo AppHostFile, string Language, AppHostProjectCandidateStatus Status = AppHostProjectCandidateStatus.Buildable);
@@ -271,12 +277,18 @@ internal sealed class ProjectLocator(
     /// <inheritdoc />
     public async Task<FileInfo?> GetAppHostFromSettingsAsync(CancellationToken cancellationToken = default)
     {
-        return await GetValidatedAppHostProjectFileFromSettingsAsync(silent: true, cancellationToken);
+        return await GetAppHostFromSettingsAsync(executionContext.WorkingDirectory, searchParentDirectories: true, cancellationToken);
     }
 
-    private async Task<FileInfo?> GetValidatedAppHostProjectFileFromSettingsAsync(bool silent, CancellationToken cancellationToken)
+    /// <inheritdoc />
+    public async Task<FileInfo?> GetAppHostFromSettingsAsync(DirectoryInfo searchDirectory, bool searchParentDirectories, CancellationToken cancellationToken = default)
     {
-        var settingsAppHost = await GetAppHostProjectFileFromSettingsAsync(silent, cancellationToken);
+        return await GetValidatedAppHostProjectFileFromSettingsAsync(searchDirectory, searchParentDirectories, silent: true, cancellationToken);
+    }
+
+    private async Task<FileInfo?> GetValidatedAppHostProjectFileFromSettingsAsync(DirectoryInfo searchDirectory, bool searchParentDirectories, bool silent, CancellationToken cancellationToken)
+    {
+        var settingsAppHost = await GetAppHostProjectFileFromSettingsAsync(searchDirectory, searchParentDirectories, silent, cancellationToken);
         if (settingsAppHost is null)
         {
             return null;
@@ -312,10 +324,8 @@ internal sealed class ProjectLocator(
         return null;
     }
 
-    private async Task<FileInfo?> GetAppHostProjectFileFromSettingsAsync(bool silent, CancellationToken cancellationToken)
+    private async Task<FileInfo?> GetAppHostProjectFileFromSettingsAsync(DirectoryInfo searchDirectory, bool searchParentDirectories, bool silent, CancellationToken cancellationToken)
     {
-        var searchDirectory = executionContext.WorkingDirectory;
-
         while (true)
         {
             // Check aspire.config.json first
@@ -382,7 +392,7 @@ internal sealed class ProjectLocator(
                 }
             }
 
-            if (searchDirectory.Parent is not null)
+            if (searchParentDirectories && searchDirectory.Parent is not null)
             {
                 searchDirectory = searchDirectory.Parent;
             }
@@ -509,7 +519,7 @@ internal sealed class ProjectLocator(
             }
         }
 
-        var settingsAppHost = await GetValidatedAppHostProjectFileFromSettingsAsync(silent: true, cancellationToken);
+        var settingsAppHost = await GetValidatedAppHostProjectFileFromSettingsAsync(executionContext.WorkingDirectory, searchParentDirectories: true, silent: true, cancellationToken);
 
         if (settingsAppHost is not null && multipleAppHostProjectsFoundBehavior is not MultipleAppHostProjectsFoundBehavior.None)
         {

--- a/src/Aspire.Cli/Projects/ProjectLocator.cs
+++ b/src/Aspire.Cli/Projects/ProjectLocator.cs
@@ -27,6 +27,19 @@ internal interface IProjectLocator
     Task<List<AppHostProjectCandidate>> FindAppHostProjectsAsync(DirectoryInfo searchDirectory, AppHostDiscoveryScope scope, CancellationToken cancellationToken);
 
     /// <summary>
+    /// Finds all candidate AppHost projects in the specified search directory up to the specified depth.
+    /// </summary>
+    /// <param name="searchDirectory">The directory to search.</param>
+    /// <param name="scope">Controls which files are considered. See <see cref="AppHostDiscoveryScope"/>.</param>
+    /// <param name="maxDepth">The maximum subdirectory depth to search, where 0 only considers files in <paramref name="searchDirectory"/>.</param>
+    /// <param name="cancellationToken">The cancellation token.</param>
+    /// <returns>A list of candidate AppHost projects with language metadata sorted by full path.</returns>
+    Task<List<AppHostProjectCandidate>> FindAppHostProjectsAsync(DirectoryInfo searchDirectory, AppHostDiscoveryScope scope, int? maxDepth, CancellationToken cancellationToken)
+        => maxDepth is null
+            ? FindAppHostProjectsAsync(searchDirectory, scope, cancellationToken)
+            : throw new NotSupportedException();
+
+    /// <summary>
     /// Finds all candidate AppHost project files in the specified search directory, without language metadata.
     /// </summary>
     /// <param name="searchDirectory">The directory to search recursively.</param>
@@ -34,6 +47,19 @@ internal interface IProjectLocator
     /// <param name="cancellationToken">The cancellation token.</param>
     /// <returns>A list of candidate AppHost project files sorted by full path.</returns>
     Task<List<FileInfo>> FindAppHostProjectFilesAsync(DirectoryInfo searchDirectory, AppHostDiscoveryScope scope, CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Finds all candidate AppHost project files in the specified search directory up to the specified depth, without language metadata.
+    /// </summary>
+    /// <param name="searchDirectory">The directory to search.</param>
+    /// <param name="scope">Controls which files are considered. See <see cref="AppHostDiscoveryScope"/>.</param>
+    /// <param name="maxDepth">The maximum subdirectory depth to search, where 0 only considers files in <paramref name="searchDirectory"/>.</param>
+    /// <param name="cancellationToken">The cancellation token.</param>
+    /// <returns>A list of candidate AppHost project files sorted by full path.</returns>
+    Task<List<FileInfo>> FindAppHostProjectFilesAsync(DirectoryInfo searchDirectory, AppHostDiscoveryScope scope, int? maxDepth, CancellationToken cancellationToken)
+        => maxDepth is null
+            ? FindAppHostProjectFilesAsync(searchDirectory, scope, cancellationToken)
+            : throw new NotSupportedException();
     Task<AppHostProjectSearchResult> UseOrFindAppHostProjectFileAsync(FileInfo? projectFile, MultipleAppHostProjectsFoundBehavior multipleAppHostProjectsFoundBehavior, bool createSettingsFile, CancellationToken cancellationToken = default);
     Task<FileInfo?> UseOrFindAppHostProjectFileAsync(FileInfo? projectFile, bool createSettingsFile, CancellationToken cancellationToken);
 
@@ -80,7 +106,20 @@ internal sealed class ProjectLocator(
     /// <returns>A list of candidate AppHost projects with language metadata sorted by full path.</returns>
     public async Task<List<AppHostProjectCandidate>> FindAppHostProjectsAsync(DirectoryInfo searchDirectory, AppHostDiscoveryScope scope, CancellationToken cancellationToken)
     {
-        var allCandidates = await FindAppHostProjectFilesAsync(searchDirectory, stopAfterMultipleBuildableAppHosts: false, displayProgress: false, scope, cancellationToken);
+        return await FindAppHostProjectsAsync(searchDirectory, scope, maxDepth: null, cancellationToken);
+    }
+
+    /// <summary>
+    /// Finds all candidate AppHost projects in the specified search directory with language metadata.
+    /// </summary>
+    /// <param name="searchDirectory">The directory to search.</param>
+    /// <param name="scope">Controls which files are considered. See <see cref="AppHostDiscoveryScope"/>.</param>
+    /// <param name="maxDepth">The maximum subdirectory depth to search, where 0 only considers files in <paramref name="searchDirectory"/>.</param>
+    /// <param name="cancellationToken">The cancellation token.</param>
+    /// <returns>A list of candidate AppHost projects with language metadata sorted by full path.</returns>
+    public async Task<List<AppHostProjectCandidate>> FindAppHostProjectsAsync(DirectoryInfo searchDirectory, AppHostDiscoveryScope scope, int? maxDepth, CancellationToken cancellationToken)
+    {
+        var allCandidates = await FindAppHostProjectFilesAsync(searchDirectory, stopAfterMultipleBuildableAppHosts: false, displayProgress: false, scope, maxDepth, cancellationToken);
         var candidates = allCandidates.BuildableAppHost.Concat(allCandidates.UnbuildableSuspectedAppHostProjects).ToList();
         candidates.Sort((x, y) => x.AppHostFile.FullName.CompareTo(y.AppHostFile.FullName));
         return candidates;
@@ -95,7 +134,20 @@ internal sealed class ProjectLocator(
     /// <returns>A list of candidate AppHost project files sorted by full path.</returns>
     public async Task<List<FileInfo>> FindAppHostProjectFilesAsync(DirectoryInfo searchDirectory, AppHostDiscoveryScope scope, CancellationToken cancellationToken)
     {
-        var candidates = await FindAppHostProjectsAsync(searchDirectory, scope, cancellationToken);
+        return await FindAppHostProjectFilesAsync(searchDirectory, scope, maxDepth: null, cancellationToken);
+    }
+
+    /// <summary>
+    /// Finds all candidate AppHost project files in the specified search directory path.
+    /// </summary>
+    /// <param name="searchDirectory">The directory path to search.</param>
+    /// <param name="scope">Controls which files are considered. See <see cref="AppHostDiscoveryScope"/>.</param>
+    /// <param name="maxDepth">The maximum subdirectory depth to search, where 0 only considers files in <paramref name="searchDirectory"/>.</param>
+    /// <param name="cancellationToken">The cancellation token.</param>
+    /// <returns>A list of candidate AppHost project files sorted by full path.</returns>
+    public async Task<List<FileInfo>> FindAppHostProjectFilesAsync(DirectoryInfo searchDirectory, AppHostDiscoveryScope scope, int? maxDepth, CancellationToken cancellationToken)
+    {
+        var candidates = await FindAppHostProjectsAsync(searchDirectory, scope, maxDepth, cancellationToken);
         return candidates.Select(c => c.AppHostFile).ToList();
     }
 
@@ -116,10 +168,10 @@ internal sealed class ProjectLocator(
 
     private async Task<(List<AppHostProjectCandidate> BuildableAppHost, List<AppHostProjectCandidate> UnbuildableSuspectedAppHostProjects, bool HasUnsupportedProjects)> FindAppHostProjectFilesAsync(DirectoryInfo searchDirectory, bool stopAfterMultipleBuildableAppHosts, AppHostDiscoveryScope scope, CancellationToken cancellationToken)
     {
-        return await FindAppHostProjectFilesAsync(searchDirectory, stopAfterMultipleBuildableAppHosts, displayProgress: true, scope, cancellationToken);
+        return await FindAppHostProjectFilesAsync(searchDirectory, stopAfterMultipleBuildableAppHosts, displayProgress: true, scope, maxDepth: null, cancellationToken);
     }
 
-    private async Task<(List<AppHostProjectCandidate> BuildableAppHost, List<AppHostProjectCandidate> UnbuildableSuspectedAppHostProjects, bool HasUnsupportedProjects)> FindAppHostProjectFilesAsync(DirectoryInfo searchDirectory, bool stopAfterMultipleBuildableAppHosts, bool displayProgress, AppHostDiscoveryScope scope, CancellationToken cancellationToken)
+    private async Task<(List<AppHostProjectCandidate> BuildableAppHost, List<AppHostProjectCandidate> UnbuildableSuspectedAppHostProjects, bool HasUnsupportedProjects)> FindAppHostProjectFilesAsync(DirectoryInfo searchDirectory, bool stopAfterMultipleBuildableAppHosts, bool displayProgress, AppHostDiscoveryScope scope, int? maxDepth, CancellationToken cancellationToken)
     {
         using var activity = telemetry.StartDiagnosticActivity();
 
@@ -153,7 +205,7 @@ internal sealed class ProjectLocator(
 
             // Collect all candidates with their handlers across all patterns.
             var candidatesWithHandlers = new List<(FileInfo File, IAppHostProject Handler)>();
-            var candidateSearchResult = await appHostCandidateFinder.FindCandidateFilesAsync(searchDirectory, allPatterns, nugetCachePath, scope, cancellationToken);
+            var candidateSearchResult = await appHostCandidateFinder.FindCandidateFilesAsync(searchDirectory, allPatterns, nugetCachePath, scope, cancellationToken, maxDepth);
             var candidateFiles = candidateSearchResult.Files;
             var candidateCountsByPattern = candidateSearchResult.CountsByPattern;
 

--- a/src/Aspire.Cli/Resources/DoctorCommandStrings.Designer.cs
+++ b/src/Aspire.Cli/Resources/DoctorCommandStrings.Designer.cs
@@ -85,6 +85,24 @@ namespace Aspire.Cli.Resources {
                 return ResourceManager.GetString("EnvironmentCheckHeader", resourceCulture);
             }
         }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Aspire.
+        /// </summary>
+        public static string AspireCategoryHeader {
+            get {
+                return ResourceManager.GetString("AspireCategoryHeader", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to AppHost.
+        /// </summary>
+        public static string AppHostCategoryHeader {
+            get {
+                return ResourceManager.GetString("AppHostCategoryHeader", resourceCulture);
+            }
+        }
         
         /// <summary>
         ///   Looks up a localized string similar to .NET SDK.
@@ -139,7 +157,88 @@ namespace Aspire.Cli.Resources {
                 return ResourceManager.GetString("CheckingPrerequisites", resourceCulture);
             }
         }
-        
+
+        /// <summary>
+        ///   Looks up a localized string similar to unknown.
+        /// </summary>
+        public static string VersionUnknown {
+            get {
+                return ResourceManager.GetString("VersionUnknown", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Aspire CLI version {0}.
+        /// </summary>
+        public static string CliVersionMessageFormat {
+            get {
+                return ResourceManager.GetString("CliVersionMessageFormat", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Aspire CLI version {0} is out of date. Latest version is {1}.
+        /// </summary>
+        public static string CliVersionOutOfDateMessageFormat {
+            get {
+                return ResourceManager.GetString("CliVersionOutOfDateMessageFormat", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Run &apos;{0}&apos; to update Aspire CLI..
+        /// </summary>
+        public static string CliVersionOutOfDateFixFormat {
+            get {
+                return ResourceManager.GetString("CliVersionOutOfDateFixFormat", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Could not check for Aspire CLI updates.
+        /// </summary>
+        public static string CliVersionUpdateCheckFailedMessage {
+            get {
+                return ResourceManager.GetString("CliVersionUpdateCheckFailedMessage", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to AppHost version {0} ({1}).
+        /// </summary>
+        public static string AppHostVersionMessageFormat {
+            get {
+                return ResourceManager.GetString("AppHostVersionMessageFormat", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Could not determine AppHost version ({0}).
+        /// </summary>
+        public static string AppHostVersionUnknownMessageFormat {
+            get {
+                return ResourceManager.GetString("AppHostVersionUnknownMessageFormat", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Could not determine AppHost version.
+        /// </summary>
+        public static string AppHostVersionCheckFailedMessage {
+            get {
+                return ResourceManager.GetString("AppHostVersionCheckFailedMessage", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Could not determine AppHost version ({0}).
+        /// </summary>
+        public static string AppHostVersionCheckFailedForProjectMessageFormat {
+            get {
+                return ResourceManager.GetString("AppHostVersionCheckFailedForProjectMessageFormat", resourceCulture);
+            }
+        }
+
         /// <summary>
         ///   Looks up a localized string similar to No HTTPS development certificate found.
         /// </summary>

--- a/src/Aspire.Cli/Resources/DoctorCommandStrings.Designer.cs
+++ b/src/Aspire.Cli/Resources/DoctorCommandStrings.Designer.cs
@@ -231,15 +231,6 @@ namespace Aspire.Cli.Resources {
         }
 
         /// <summary>
-        ///   Looks up a localized string similar to Could not determine AppHost version ({0}).
-        /// </summary>
-        public static string AppHostVersionCheckFailedForProjectMessageFormat {
-            get {
-                return ResourceManager.GetString("AppHostVersionCheckFailedForProjectMessageFormat", resourceCulture);
-            }
-        }
-
-        /// <summary>
         ///   Looks up a localized string similar to No HTTPS development certificate found.
         /// </summary>
         public static string DevCertsNoCertificateMessage {

--- a/src/Aspire.Cli/Resources/DoctorCommandStrings.resx
+++ b/src/Aspire.Cli/Resources/DoctorCommandStrings.resx
@@ -67,6 +67,12 @@
   <data name="EnvironmentCheckHeader" xml:space="preserve">
     <value>Aspire Environment Check</value>
   </data>
+  <data name="AspireCategoryHeader" xml:space="preserve">
+    <value>Aspire</value>
+  </data>
+  <data name="AppHostCategoryHeader" xml:space="preserve">
+    <value>AppHost</value>
+  </data>
   <data name="SdkCategoryHeader" xml:space="preserve">
     <value>.NET SDK</value>
   </data>
@@ -85,6 +91,39 @@
   </data>
   <data name="CheckingPrerequisites" xml:space="preserve">
     <value>Checking Aspire environment...</value>
+  </data>
+  <data name="VersionUnknown" xml:space="preserve">
+    <value>unknown</value>
+  </data>
+  <data name="CliVersionMessageFormat" xml:space="preserve">
+    <value>Aspire CLI version {0}</value>
+    <comment>{0} is the current Aspire CLI version.</comment>
+  </data>
+  <data name="CliVersionOutOfDateMessageFormat" xml:space="preserve">
+    <value>Aspire CLI version {0} is out of date. Latest version is {1}</value>
+    <comment>{0} is the current Aspire CLI version. {1} is the latest available Aspire CLI version.</comment>
+  </data>
+  <data name="CliVersionOutOfDateFixFormat" xml:space="preserve">
+    <value>Run '{0}' to update Aspire CLI.</value>
+    <comment>{0} is the command to update Aspire CLI.</comment>
+  </data>
+  <data name="CliVersionUpdateCheckFailedMessage" xml:space="preserve">
+    <value>Could not check for Aspire CLI updates</value>
+  </data>
+  <data name="AppHostVersionMessageFormat" xml:space="preserve">
+    <value>AppHost version {0} ({1})</value>
+    <comment>{0} is the AppHost Aspire.Hosting version. {1} is the AppHost project path.</comment>
+  </data>
+  <data name="AppHostVersionUnknownMessageFormat" xml:space="preserve">
+    <value>Could not determine AppHost version ({0})</value>
+    <comment>{0} is the AppHost project path.</comment>
+  </data>
+  <data name="AppHostVersionCheckFailedMessage" xml:space="preserve">
+    <value>Could not determine AppHost version</value>
+  </data>
+  <data name="AppHostVersionCheckFailedForProjectMessageFormat" xml:space="preserve">
+    <value>Could not determine AppHost version ({0})</value>
+    <comment>{0} is the AppHost project path.</comment>
   </data>
   <data name="DevCertsNoCertificateMessage" xml:space="preserve">
     <value>No HTTPS development certificate found</value>

--- a/src/Aspire.Cli/Resources/DoctorCommandStrings.resx
+++ b/src/Aspire.Cli/Resources/DoctorCommandStrings.resx
@@ -121,10 +121,6 @@
   <data name="AppHostVersionCheckFailedMessage" xml:space="preserve">
     <value>Could not determine AppHost version</value>
   </data>
-  <data name="AppHostVersionCheckFailedForProjectMessageFormat" xml:space="preserve">
-    <value>Could not determine AppHost version ({0})</value>
-    <comment>{0} is the AppHost project path.</comment>
-  </data>
   <data name="DevCertsNoCertificateMessage" xml:space="preserve">
     <value>No HTTPS development certificate found</value>
   </data>

--- a/src/Aspire.Cli/Resources/xlf/DoctorCommandStrings.cs.xlf
+++ b/src/Aspire.Cli/Resources/xlf/DoctorCommandStrings.cs.xlf
@@ -7,11 +7,6 @@
         <target state="new">AppHost</target>
         <note />
       </trans-unit>
-      <trans-unit id="AppHostVersionCheckFailedForProjectMessageFormat">
-        <source>Could not determine AppHost version ({0})</source>
-        <target state="new">Could not determine AppHost version ({0})</target>
-        <note>{0} is the AppHost project path.</note>
-      </trans-unit>
       <trans-unit id="AppHostVersionCheckFailedMessage">
         <source>Could not determine AppHost version</source>
         <target state="new">Could not determine AppHost version</target>

--- a/src/Aspire.Cli/Resources/xlf/DoctorCommandStrings.cs.xlf
+++ b/src/Aspire.Cli/Resources/xlf/DoctorCommandStrings.cs.xlf
@@ -2,9 +2,59 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="cs" original="../DoctorCommandStrings.resx">
     <body>
+      <trans-unit id="AppHostCategoryHeader">
+        <source>AppHost</source>
+        <target state="new">AppHost</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AppHostVersionCheckFailedForProjectMessageFormat">
+        <source>Could not determine AppHost version ({0})</source>
+        <target state="new">Could not determine AppHost version ({0})</target>
+        <note>{0} is the AppHost project path.</note>
+      </trans-unit>
+      <trans-unit id="AppHostVersionCheckFailedMessage">
+        <source>Could not determine AppHost version</source>
+        <target state="new">Could not determine AppHost version</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AppHostVersionMessageFormat">
+        <source>AppHost version {0} ({1})</source>
+        <target state="new">AppHost version {0} ({1})</target>
+        <note>{0} is the AppHost Aspire.Hosting version. {1} is the AppHost project path.</note>
+      </trans-unit>
+      <trans-unit id="AppHostVersionUnknownMessageFormat">
+        <source>Could not determine AppHost version ({0})</source>
+        <target state="new">Could not determine AppHost version ({0})</target>
+        <note>{0} is the AppHost project path.</note>
+      </trans-unit>
+      <trans-unit id="AspireCategoryHeader">
+        <source>Aspire</source>
+        <target state="new">Aspire</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CheckingPrerequisites">
         <source>Checking Aspire environment...</source>
         <target state="translated">Kontroluje se prostředí Aspire...</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CliVersionMessageFormat">
+        <source>Aspire CLI version {0}</source>
+        <target state="new">Aspire CLI version {0}</target>
+        <note>{0} is the current Aspire CLI version.</note>
+      </trans-unit>
+      <trans-unit id="CliVersionOutOfDateFixFormat">
+        <source>Run '{0}' to update Aspire CLI.</source>
+        <target state="new">Run '{0}' to update Aspire CLI.</target>
+        <note>{0} is the command to update Aspire CLI.</note>
+      </trans-unit>
+      <trans-unit id="CliVersionOutOfDateMessageFormat">
+        <source>Aspire CLI version {0} is out of date. Latest version is {1}</source>
+        <target state="new">Aspire CLI version {0} is out of date. Latest version is {1}</target>
+        <note>{0} is the current Aspire CLI version. {1} is the latest available Aspire CLI version.</note>
+      </trans-unit>
+      <trans-unit id="CliVersionUpdateCheckFailedMessage">
+        <source>Could not check for Aspire CLI updates</source>
+        <target state="new">Could not check for Aspire CLI updates</target>
         <note />
       </trans-unit>
       <trans-unit id="ContainerCategoryHeader">
@@ -135,6 +185,11 @@
       <trans-unit id="SummaryFormat">
         <source>Summary: {0} passed, {1} warnings, {2} failed</source>
         <target state="translated">Shrnutí – úspěšné: {0}, upozornění: {1}, selhalo: {2}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="VersionUnknown">
+        <source>unknown</source>
+        <target state="new">unknown</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Aspire.Cli/Resources/xlf/DoctorCommandStrings.de.xlf
+++ b/src/Aspire.Cli/Resources/xlf/DoctorCommandStrings.de.xlf
@@ -7,11 +7,6 @@
         <target state="new">AppHost</target>
         <note />
       </trans-unit>
-      <trans-unit id="AppHostVersionCheckFailedForProjectMessageFormat">
-        <source>Could not determine AppHost version ({0})</source>
-        <target state="new">Could not determine AppHost version ({0})</target>
-        <note>{0} is the AppHost project path.</note>
-      </trans-unit>
       <trans-unit id="AppHostVersionCheckFailedMessage">
         <source>Could not determine AppHost version</source>
         <target state="new">Could not determine AppHost version</target>

--- a/src/Aspire.Cli/Resources/xlf/DoctorCommandStrings.de.xlf
+++ b/src/Aspire.Cli/Resources/xlf/DoctorCommandStrings.de.xlf
@@ -2,9 +2,59 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="de" original="../DoctorCommandStrings.resx">
     <body>
+      <trans-unit id="AppHostCategoryHeader">
+        <source>AppHost</source>
+        <target state="new">AppHost</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AppHostVersionCheckFailedForProjectMessageFormat">
+        <source>Could not determine AppHost version ({0})</source>
+        <target state="new">Could not determine AppHost version ({0})</target>
+        <note>{0} is the AppHost project path.</note>
+      </trans-unit>
+      <trans-unit id="AppHostVersionCheckFailedMessage">
+        <source>Could not determine AppHost version</source>
+        <target state="new">Could not determine AppHost version</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AppHostVersionMessageFormat">
+        <source>AppHost version {0} ({1})</source>
+        <target state="new">AppHost version {0} ({1})</target>
+        <note>{0} is the AppHost Aspire.Hosting version. {1} is the AppHost project path.</note>
+      </trans-unit>
+      <trans-unit id="AppHostVersionUnknownMessageFormat">
+        <source>Could not determine AppHost version ({0})</source>
+        <target state="new">Could not determine AppHost version ({0})</target>
+        <note>{0} is the AppHost project path.</note>
+      </trans-unit>
+      <trans-unit id="AspireCategoryHeader">
+        <source>Aspire</source>
+        <target state="new">Aspire</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CheckingPrerequisites">
         <source>Checking Aspire environment...</source>
         <target state="translated">Aspire-Umgebung wird überprüft …</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CliVersionMessageFormat">
+        <source>Aspire CLI version {0}</source>
+        <target state="new">Aspire CLI version {0}</target>
+        <note>{0} is the current Aspire CLI version.</note>
+      </trans-unit>
+      <trans-unit id="CliVersionOutOfDateFixFormat">
+        <source>Run '{0}' to update Aspire CLI.</source>
+        <target state="new">Run '{0}' to update Aspire CLI.</target>
+        <note>{0} is the command to update Aspire CLI.</note>
+      </trans-unit>
+      <trans-unit id="CliVersionOutOfDateMessageFormat">
+        <source>Aspire CLI version {0} is out of date. Latest version is {1}</source>
+        <target state="new">Aspire CLI version {0} is out of date. Latest version is {1}</target>
+        <note>{0} is the current Aspire CLI version. {1} is the latest available Aspire CLI version.</note>
+      </trans-unit>
+      <trans-unit id="CliVersionUpdateCheckFailedMessage">
+        <source>Could not check for Aspire CLI updates</source>
+        <target state="new">Could not check for Aspire CLI updates</target>
         <note />
       </trans-unit>
       <trans-unit id="ContainerCategoryHeader">
@@ -135,6 +185,11 @@
       <trans-unit id="SummaryFormat">
         <source>Summary: {0} passed, {1} warnings, {2} failed</source>
         <target state="translated">Zusammenfassung: {0} erfolgreich, {1} Warnungen, {2} fehlgeschlagen</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="VersionUnknown">
+        <source>unknown</source>
+        <target state="new">unknown</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Aspire.Cli/Resources/xlf/DoctorCommandStrings.es.xlf
+++ b/src/Aspire.Cli/Resources/xlf/DoctorCommandStrings.es.xlf
@@ -7,11 +7,6 @@
         <target state="new">AppHost</target>
         <note />
       </trans-unit>
-      <trans-unit id="AppHostVersionCheckFailedForProjectMessageFormat">
-        <source>Could not determine AppHost version ({0})</source>
-        <target state="new">Could not determine AppHost version ({0})</target>
-        <note>{0} is the AppHost project path.</note>
-      </trans-unit>
       <trans-unit id="AppHostVersionCheckFailedMessage">
         <source>Could not determine AppHost version</source>
         <target state="new">Could not determine AppHost version</target>

--- a/src/Aspire.Cli/Resources/xlf/DoctorCommandStrings.es.xlf
+++ b/src/Aspire.Cli/Resources/xlf/DoctorCommandStrings.es.xlf
@@ -2,9 +2,59 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="es" original="../DoctorCommandStrings.resx">
     <body>
+      <trans-unit id="AppHostCategoryHeader">
+        <source>AppHost</source>
+        <target state="new">AppHost</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AppHostVersionCheckFailedForProjectMessageFormat">
+        <source>Could not determine AppHost version ({0})</source>
+        <target state="new">Could not determine AppHost version ({0})</target>
+        <note>{0} is the AppHost project path.</note>
+      </trans-unit>
+      <trans-unit id="AppHostVersionCheckFailedMessage">
+        <source>Could not determine AppHost version</source>
+        <target state="new">Could not determine AppHost version</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AppHostVersionMessageFormat">
+        <source>AppHost version {0} ({1})</source>
+        <target state="new">AppHost version {0} ({1})</target>
+        <note>{0} is the AppHost Aspire.Hosting version. {1} is the AppHost project path.</note>
+      </trans-unit>
+      <trans-unit id="AppHostVersionUnknownMessageFormat">
+        <source>Could not determine AppHost version ({0})</source>
+        <target state="new">Could not determine AppHost version ({0})</target>
+        <note>{0} is the AppHost project path.</note>
+      </trans-unit>
+      <trans-unit id="AspireCategoryHeader">
+        <source>Aspire</source>
+        <target state="new">Aspire</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CheckingPrerequisites">
         <source>Checking Aspire environment...</source>
         <target state="translated">Comprobando el entorno de Aspire...</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CliVersionMessageFormat">
+        <source>Aspire CLI version {0}</source>
+        <target state="new">Aspire CLI version {0}</target>
+        <note>{0} is the current Aspire CLI version.</note>
+      </trans-unit>
+      <trans-unit id="CliVersionOutOfDateFixFormat">
+        <source>Run '{0}' to update Aspire CLI.</source>
+        <target state="new">Run '{0}' to update Aspire CLI.</target>
+        <note>{0} is the command to update Aspire CLI.</note>
+      </trans-unit>
+      <trans-unit id="CliVersionOutOfDateMessageFormat">
+        <source>Aspire CLI version {0} is out of date. Latest version is {1}</source>
+        <target state="new">Aspire CLI version {0} is out of date. Latest version is {1}</target>
+        <note>{0} is the current Aspire CLI version. {1} is the latest available Aspire CLI version.</note>
+      </trans-unit>
+      <trans-unit id="CliVersionUpdateCheckFailedMessage">
+        <source>Could not check for Aspire CLI updates</source>
+        <target state="new">Could not check for Aspire CLI updates</target>
         <note />
       </trans-unit>
       <trans-unit id="ContainerCategoryHeader">
@@ -135,6 +185,11 @@
       <trans-unit id="SummaryFormat">
         <source>Summary: {0} passed, {1} warnings, {2} failed</source>
         <target state="translated">Resumen: {0} correctos, {1} advertencias, {2} fallos</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="VersionUnknown">
+        <source>unknown</source>
+        <target state="new">unknown</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Aspire.Cli/Resources/xlf/DoctorCommandStrings.fr.xlf
+++ b/src/Aspire.Cli/Resources/xlf/DoctorCommandStrings.fr.xlf
@@ -2,9 +2,59 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="fr" original="../DoctorCommandStrings.resx">
     <body>
+      <trans-unit id="AppHostCategoryHeader">
+        <source>AppHost</source>
+        <target state="new">AppHost</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AppHostVersionCheckFailedForProjectMessageFormat">
+        <source>Could not determine AppHost version ({0})</source>
+        <target state="new">Could not determine AppHost version ({0})</target>
+        <note>{0} is the AppHost project path.</note>
+      </trans-unit>
+      <trans-unit id="AppHostVersionCheckFailedMessage">
+        <source>Could not determine AppHost version</source>
+        <target state="new">Could not determine AppHost version</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AppHostVersionMessageFormat">
+        <source>AppHost version {0} ({1})</source>
+        <target state="new">AppHost version {0} ({1})</target>
+        <note>{0} is the AppHost Aspire.Hosting version. {1} is the AppHost project path.</note>
+      </trans-unit>
+      <trans-unit id="AppHostVersionUnknownMessageFormat">
+        <source>Could not determine AppHost version ({0})</source>
+        <target state="new">Could not determine AppHost version ({0})</target>
+        <note>{0} is the AppHost project path.</note>
+      </trans-unit>
+      <trans-unit id="AspireCategoryHeader">
+        <source>Aspire</source>
+        <target state="new">Aspire</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CheckingPrerequisites">
         <source>Checking Aspire environment...</source>
         <target state="translated">Vérification de l’environnement Aspire...</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CliVersionMessageFormat">
+        <source>Aspire CLI version {0}</source>
+        <target state="new">Aspire CLI version {0}</target>
+        <note>{0} is the current Aspire CLI version.</note>
+      </trans-unit>
+      <trans-unit id="CliVersionOutOfDateFixFormat">
+        <source>Run '{0}' to update Aspire CLI.</source>
+        <target state="new">Run '{0}' to update Aspire CLI.</target>
+        <note>{0} is the command to update Aspire CLI.</note>
+      </trans-unit>
+      <trans-unit id="CliVersionOutOfDateMessageFormat">
+        <source>Aspire CLI version {0} is out of date. Latest version is {1}</source>
+        <target state="new">Aspire CLI version {0} is out of date. Latest version is {1}</target>
+        <note>{0} is the current Aspire CLI version. {1} is the latest available Aspire CLI version.</note>
+      </trans-unit>
+      <trans-unit id="CliVersionUpdateCheckFailedMessage">
+        <source>Could not check for Aspire CLI updates</source>
+        <target state="new">Could not check for Aspire CLI updates</target>
         <note />
       </trans-unit>
       <trans-unit id="ContainerCategoryHeader">
@@ -135,6 +185,11 @@
       <trans-unit id="SummaryFormat">
         <source>Summary: {0} passed, {1} warnings, {2} failed</source>
         <target state="translated">Résumé : {0} réussis, {1} avertissements, {2} échoués</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="VersionUnknown">
+        <source>unknown</source>
+        <target state="new">unknown</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Aspire.Cli/Resources/xlf/DoctorCommandStrings.fr.xlf
+++ b/src/Aspire.Cli/Resources/xlf/DoctorCommandStrings.fr.xlf
@@ -7,11 +7,6 @@
         <target state="new">AppHost</target>
         <note />
       </trans-unit>
-      <trans-unit id="AppHostVersionCheckFailedForProjectMessageFormat">
-        <source>Could not determine AppHost version ({0})</source>
-        <target state="new">Could not determine AppHost version ({0})</target>
-        <note>{0} is the AppHost project path.</note>
-      </trans-unit>
       <trans-unit id="AppHostVersionCheckFailedMessage">
         <source>Could not determine AppHost version</source>
         <target state="new">Could not determine AppHost version</target>

--- a/src/Aspire.Cli/Resources/xlf/DoctorCommandStrings.it.xlf
+++ b/src/Aspire.Cli/Resources/xlf/DoctorCommandStrings.it.xlf
@@ -7,11 +7,6 @@
         <target state="new">AppHost</target>
         <note />
       </trans-unit>
-      <trans-unit id="AppHostVersionCheckFailedForProjectMessageFormat">
-        <source>Could not determine AppHost version ({0})</source>
-        <target state="new">Could not determine AppHost version ({0})</target>
-        <note>{0} is the AppHost project path.</note>
-      </trans-unit>
       <trans-unit id="AppHostVersionCheckFailedMessage">
         <source>Could not determine AppHost version</source>
         <target state="new">Could not determine AppHost version</target>

--- a/src/Aspire.Cli/Resources/xlf/DoctorCommandStrings.it.xlf
+++ b/src/Aspire.Cli/Resources/xlf/DoctorCommandStrings.it.xlf
@@ -2,9 +2,59 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="it" original="../DoctorCommandStrings.resx">
     <body>
+      <trans-unit id="AppHostCategoryHeader">
+        <source>AppHost</source>
+        <target state="new">AppHost</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AppHostVersionCheckFailedForProjectMessageFormat">
+        <source>Could not determine AppHost version ({0})</source>
+        <target state="new">Could not determine AppHost version ({0})</target>
+        <note>{0} is the AppHost project path.</note>
+      </trans-unit>
+      <trans-unit id="AppHostVersionCheckFailedMessage">
+        <source>Could not determine AppHost version</source>
+        <target state="new">Could not determine AppHost version</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AppHostVersionMessageFormat">
+        <source>AppHost version {0} ({1})</source>
+        <target state="new">AppHost version {0} ({1})</target>
+        <note>{0} is the AppHost Aspire.Hosting version. {1} is the AppHost project path.</note>
+      </trans-unit>
+      <trans-unit id="AppHostVersionUnknownMessageFormat">
+        <source>Could not determine AppHost version ({0})</source>
+        <target state="new">Could not determine AppHost version ({0})</target>
+        <note>{0} is the AppHost project path.</note>
+      </trans-unit>
+      <trans-unit id="AspireCategoryHeader">
+        <source>Aspire</source>
+        <target state="new">Aspire</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CheckingPrerequisites">
         <source>Checking Aspire environment...</source>
         <target state="translated">Verifica dell'ambiente Aspire in corso...</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CliVersionMessageFormat">
+        <source>Aspire CLI version {0}</source>
+        <target state="new">Aspire CLI version {0}</target>
+        <note>{0} is the current Aspire CLI version.</note>
+      </trans-unit>
+      <trans-unit id="CliVersionOutOfDateFixFormat">
+        <source>Run '{0}' to update Aspire CLI.</source>
+        <target state="new">Run '{0}' to update Aspire CLI.</target>
+        <note>{0} is the command to update Aspire CLI.</note>
+      </trans-unit>
+      <trans-unit id="CliVersionOutOfDateMessageFormat">
+        <source>Aspire CLI version {0} is out of date. Latest version is {1}</source>
+        <target state="new">Aspire CLI version {0} is out of date. Latest version is {1}</target>
+        <note>{0} is the current Aspire CLI version. {1} is the latest available Aspire CLI version.</note>
+      </trans-unit>
+      <trans-unit id="CliVersionUpdateCheckFailedMessage">
+        <source>Could not check for Aspire CLI updates</source>
+        <target state="new">Could not check for Aspire CLI updates</target>
         <note />
       </trans-unit>
       <trans-unit id="ContainerCategoryHeader">
@@ -135,6 +185,11 @@
       <trans-unit id="SummaryFormat">
         <source>Summary: {0} passed, {1} warnings, {2} failed</source>
         <target state="translated">Riepilogo: {0} superati, {1} avvisi, {2} non superati</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="VersionUnknown">
+        <source>unknown</source>
+        <target state="new">unknown</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Aspire.Cli/Resources/xlf/DoctorCommandStrings.ja.xlf
+++ b/src/Aspire.Cli/Resources/xlf/DoctorCommandStrings.ja.xlf
@@ -7,11 +7,6 @@
         <target state="new">AppHost</target>
         <note />
       </trans-unit>
-      <trans-unit id="AppHostVersionCheckFailedForProjectMessageFormat">
-        <source>Could not determine AppHost version ({0})</source>
-        <target state="new">Could not determine AppHost version ({0})</target>
-        <note>{0} is the AppHost project path.</note>
-      </trans-unit>
       <trans-unit id="AppHostVersionCheckFailedMessage">
         <source>Could not determine AppHost version</source>
         <target state="new">Could not determine AppHost version</target>

--- a/src/Aspire.Cli/Resources/xlf/DoctorCommandStrings.ja.xlf
+++ b/src/Aspire.Cli/Resources/xlf/DoctorCommandStrings.ja.xlf
@@ -2,9 +2,59 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="ja" original="../DoctorCommandStrings.resx">
     <body>
+      <trans-unit id="AppHostCategoryHeader">
+        <source>AppHost</source>
+        <target state="new">AppHost</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AppHostVersionCheckFailedForProjectMessageFormat">
+        <source>Could not determine AppHost version ({0})</source>
+        <target state="new">Could not determine AppHost version ({0})</target>
+        <note>{0} is the AppHost project path.</note>
+      </trans-unit>
+      <trans-unit id="AppHostVersionCheckFailedMessage">
+        <source>Could not determine AppHost version</source>
+        <target state="new">Could not determine AppHost version</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AppHostVersionMessageFormat">
+        <source>AppHost version {0} ({1})</source>
+        <target state="new">AppHost version {0} ({1})</target>
+        <note>{0} is the AppHost Aspire.Hosting version. {1} is the AppHost project path.</note>
+      </trans-unit>
+      <trans-unit id="AppHostVersionUnknownMessageFormat">
+        <source>Could not determine AppHost version ({0})</source>
+        <target state="new">Could not determine AppHost version ({0})</target>
+        <note>{0} is the AppHost project path.</note>
+      </trans-unit>
+      <trans-unit id="AspireCategoryHeader">
+        <source>Aspire</source>
+        <target state="new">Aspire</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CheckingPrerequisites">
         <source>Checking Aspire environment...</source>
         <target state="translated">Aspire 環境を確認しています...</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CliVersionMessageFormat">
+        <source>Aspire CLI version {0}</source>
+        <target state="new">Aspire CLI version {0}</target>
+        <note>{0} is the current Aspire CLI version.</note>
+      </trans-unit>
+      <trans-unit id="CliVersionOutOfDateFixFormat">
+        <source>Run '{0}' to update Aspire CLI.</source>
+        <target state="new">Run '{0}' to update Aspire CLI.</target>
+        <note>{0} is the command to update Aspire CLI.</note>
+      </trans-unit>
+      <trans-unit id="CliVersionOutOfDateMessageFormat">
+        <source>Aspire CLI version {0} is out of date. Latest version is {1}</source>
+        <target state="new">Aspire CLI version {0} is out of date. Latest version is {1}</target>
+        <note>{0} is the current Aspire CLI version. {1} is the latest available Aspire CLI version.</note>
+      </trans-unit>
+      <trans-unit id="CliVersionUpdateCheckFailedMessage">
+        <source>Could not check for Aspire CLI updates</source>
+        <target state="new">Could not check for Aspire CLI updates</target>
         <note />
       </trans-unit>
       <trans-unit id="ContainerCategoryHeader">
@@ -135,6 +185,11 @@
       <trans-unit id="SummaryFormat">
         <source>Summary: {0} passed, {1} warnings, {2} failed</source>
         <target state="translated">概要: {0} 成功、{1} 警告、{2} 失敗</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="VersionUnknown">
+        <source>unknown</source>
+        <target state="new">unknown</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Aspire.Cli/Resources/xlf/DoctorCommandStrings.ko.xlf
+++ b/src/Aspire.Cli/Resources/xlf/DoctorCommandStrings.ko.xlf
@@ -2,9 +2,59 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="ko" original="../DoctorCommandStrings.resx">
     <body>
+      <trans-unit id="AppHostCategoryHeader">
+        <source>AppHost</source>
+        <target state="new">AppHost</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AppHostVersionCheckFailedForProjectMessageFormat">
+        <source>Could not determine AppHost version ({0})</source>
+        <target state="new">Could not determine AppHost version ({0})</target>
+        <note>{0} is the AppHost project path.</note>
+      </trans-unit>
+      <trans-unit id="AppHostVersionCheckFailedMessage">
+        <source>Could not determine AppHost version</source>
+        <target state="new">Could not determine AppHost version</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AppHostVersionMessageFormat">
+        <source>AppHost version {0} ({1})</source>
+        <target state="new">AppHost version {0} ({1})</target>
+        <note>{0} is the AppHost Aspire.Hosting version. {1} is the AppHost project path.</note>
+      </trans-unit>
+      <trans-unit id="AppHostVersionUnknownMessageFormat">
+        <source>Could not determine AppHost version ({0})</source>
+        <target state="new">Could not determine AppHost version ({0})</target>
+        <note>{0} is the AppHost project path.</note>
+      </trans-unit>
+      <trans-unit id="AspireCategoryHeader">
+        <source>Aspire</source>
+        <target state="new">Aspire</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CheckingPrerequisites">
         <source>Checking Aspire environment...</source>
         <target state="translated">Aspire 환경을 확인하는 중...</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CliVersionMessageFormat">
+        <source>Aspire CLI version {0}</source>
+        <target state="new">Aspire CLI version {0}</target>
+        <note>{0} is the current Aspire CLI version.</note>
+      </trans-unit>
+      <trans-unit id="CliVersionOutOfDateFixFormat">
+        <source>Run '{0}' to update Aspire CLI.</source>
+        <target state="new">Run '{0}' to update Aspire CLI.</target>
+        <note>{0} is the command to update Aspire CLI.</note>
+      </trans-unit>
+      <trans-unit id="CliVersionOutOfDateMessageFormat">
+        <source>Aspire CLI version {0} is out of date. Latest version is {1}</source>
+        <target state="new">Aspire CLI version {0} is out of date. Latest version is {1}</target>
+        <note>{0} is the current Aspire CLI version. {1} is the latest available Aspire CLI version.</note>
+      </trans-unit>
+      <trans-unit id="CliVersionUpdateCheckFailedMessage">
+        <source>Could not check for Aspire CLI updates</source>
+        <target state="new">Could not check for Aspire CLI updates</target>
         <note />
       </trans-unit>
       <trans-unit id="ContainerCategoryHeader">
@@ -135,6 +185,11 @@
       <trans-unit id="SummaryFormat">
         <source>Summary: {0} passed, {1} warnings, {2} failed</source>
         <target state="translated">요약: {0}개 통과, {1}개 경고, {2}개 실패</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="VersionUnknown">
+        <source>unknown</source>
+        <target state="new">unknown</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Aspire.Cli/Resources/xlf/DoctorCommandStrings.ko.xlf
+++ b/src/Aspire.Cli/Resources/xlf/DoctorCommandStrings.ko.xlf
@@ -7,11 +7,6 @@
         <target state="new">AppHost</target>
         <note />
       </trans-unit>
-      <trans-unit id="AppHostVersionCheckFailedForProjectMessageFormat">
-        <source>Could not determine AppHost version ({0})</source>
-        <target state="new">Could not determine AppHost version ({0})</target>
-        <note>{0} is the AppHost project path.</note>
-      </trans-unit>
       <trans-unit id="AppHostVersionCheckFailedMessage">
         <source>Could not determine AppHost version</source>
         <target state="new">Could not determine AppHost version</target>

--- a/src/Aspire.Cli/Resources/xlf/DoctorCommandStrings.pl.xlf
+++ b/src/Aspire.Cli/Resources/xlf/DoctorCommandStrings.pl.xlf
@@ -2,9 +2,59 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="pl" original="../DoctorCommandStrings.resx">
     <body>
+      <trans-unit id="AppHostCategoryHeader">
+        <source>AppHost</source>
+        <target state="new">AppHost</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AppHostVersionCheckFailedForProjectMessageFormat">
+        <source>Could not determine AppHost version ({0})</source>
+        <target state="new">Could not determine AppHost version ({0})</target>
+        <note>{0} is the AppHost project path.</note>
+      </trans-unit>
+      <trans-unit id="AppHostVersionCheckFailedMessage">
+        <source>Could not determine AppHost version</source>
+        <target state="new">Could not determine AppHost version</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AppHostVersionMessageFormat">
+        <source>AppHost version {0} ({1})</source>
+        <target state="new">AppHost version {0} ({1})</target>
+        <note>{0} is the AppHost Aspire.Hosting version. {1} is the AppHost project path.</note>
+      </trans-unit>
+      <trans-unit id="AppHostVersionUnknownMessageFormat">
+        <source>Could not determine AppHost version ({0})</source>
+        <target state="new">Could not determine AppHost version ({0})</target>
+        <note>{0} is the AppHost project path.</note>
+      </trans-unit>
+      <trans-unit id="AspireCategoryHeader">
+        <source>Aspire</source>
+        <target state="new">Aspire</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CheckingPrerequisites">
         <source>Checking Aspire environment...</source>
         <target state="translated">Sprawdzanie środowiska Aspire...</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CliVersionMessageFormat">
+        <source>Aspire CLI version {0}</source>
+        <target state="new">Aspire CLI version {0}</target>
+        <note>{0} is the current Aspire CLI version.</note>
+      </trans-unit>
+      <trans-unit id="CliVersionOutOfDateFixFormat">
+        <source>Run '{0}' to update Aspire CLI.</source>
+        <target state="new">Run '{0}' to update Aspire CLI.</target>
+        <note>{0} is the command to update Aspire CLI.</note>
+      </trans-unit>
+      <trans-unit id="CliVersionOutOfDateMessageFormat">
+        <source>Aspire CLI version {0} is out of date. Latest version is {1}</source>
+        <target state="new">Aspire CLI version {0} is out of date. Latest version is {1}</target>
+        <note>{0} is the current Aspire CLI version. {1} is the latest available Aspire CLI version.</note>
+      </trans-unit>
+      <trans-unit id="CliVersionUpdateCheckFailedMessage">
+        <source>Could not check for Aspire CLI updates</source>
+        <target state="new">Could not check for Aspire CLI updates</target>
         <note />
       </trans-unit>
       <trans-unit id="ContainerCategoryHeader">
@@ -135,6 +185,11 @@
       <trans-unit id="SummaryFormat">
         <source>Summary: {0} passed, {1} warnings, {2} failed</source>
         <target state="translated">Podsumowanie: zaliczone {0}, ostrzeżenia {1}, niezaliczone {2}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="VersionUnknown">
+        <source>unknown</source>
+        <target state="new">unknown</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Aspire.Cli/Resources/xlf/DoctorCommandStrings.pl.xlf
+++ b/src/Aspire.Cli/Resources/xlf/DoctorCommandStrings.pl.xlf
@@ -7,11 +7,6 @@
         <target state="new">AppHost</target>
         <note />
       </trans-unit>
-      <trans-unit id="AppHostVersionCheckFailedForProjectMessageFormat">
-        <source>Could not determine AppHost version ({0})</source>
-        <target state="new">Could not determine AppHost version ({0})</target>
-        <note>{0} is the AppHost project path.</note>
-      </trans-unit>
       <trans-unit id="AppHostVersionCheckFailedMessage">
         <source>Could not determine AppHost version</source>
         <target state="new">Could not determine AppHost version</target>

--- a/src/Aspire.Cli/Resources/xlf/DoctorCommandStrings.pt-BR.xlf
+++ b/src/Aspire.Cli/Resources/xlf/DoctorCommandStrings.pt-BR.xlf
@@ -2,9 +2,59 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="pt-BR" original="../DoctorCommandStrings.resx">
     <body>
+      <trans-unit id="AppHostCategoryHeader">
+        <source>AppHost</source>
+        <target state="new">AppHost</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AppHostVersionCheckFailedForProjectMessageFormat">
+        <source>Could not determine AppHost version ({0})</source>
+        <target state="new">Could not determine AppHost version ({0})</target>
+        <note>{0} is the AppHost project path.</note>
+      </trans-unit>
+      <trans-unit id="AppHostVersionCheckFailedMessage">
+        <source>Could not determine AppHost version</source>
+        <target state="new">Could not determine AppHost version</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AppHostVersionMessageFormat">
+        <source>AppHost version {0} ({1})</source>
+        <target state="new">AppHost version {0} ({1})</target>
+        <note>{0} is the AppHost Aspire.Hosting version. {1} is the AppHost project path.</note>
+      </trans-unit>
+      <trans-unit id="AppHostVersionUnknownMessageFormat">
+        <source>Could not determine AppHost version ({0})</source>
+        <target state="new">Could not determine AppHost version ({0})</target>
+        <note>{0} is the AppHost project path.</note>
+      </trans-unit>
+      <trans-unit id="AspireCategoryHeader">
+        <source>Aspire</source>
+        <target state="new">Aspire</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CheckingPrerequisites">
         <source>Checking Aspire environment...</source>
         <target state="translated">Verificando o ambiente do Aspire...</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CliVersionMessageFormat">
+        <source>Aspire CLI version {0}</source>
+        <target state="new">Aspire CLI version {0}</target>
+        <note>{0} is the current Aspire CLI version.</note>
+      </trans-unit>
+      <trans-unit id="CliVersionOutOfDateFixFormat">
+        <source>Run '{0}' to update Aspire CLI.</source>
+        <target state="new">Run '{0}' to update Aspire CLI.</target>
+        <note>{0} is the command to update Aspire CLI.</note>
+      </trans-unit>
+      <trans-unit id="CliVersionOutOfDateMessageFormat">
+        <source>Aspire CLI version {0} is out of date. Latest version is {1}</source>
+        <target state="new">Aspire CLI version {0} is out of date. Latest version is {1}</target>
+        <note>{0} is the current Aspire CLI version. {1} is the latest available Aspire CLI version.</note>
+      </trans-unit>
+      <trans-unit id="CliVersionUpdateCheckFailedMessage">
+        <source>Could not check for Aspire CLI updates</source>
+        <target state="new">Could not check for Aspire CLI updates</target>
         <note />
       </trans-unit>
       <trans-unit id="ContainerCategoryHeader">
@@ -135,6 +185,11 @@
       <trans-unit id="SummaryFormat">
         <source>Summary: {0} passed, {1} warnings, {2} failed</source>
         <target state="translated">Resumo: {0} aprovado, {1} avisos, {2} falha</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="VersionUnknown">
+        <source>unknown</source>
+        <target state="new">unknown</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Aspire.Cli/Resources/xlf/DoctorCommandStrings.pt-BR.xlf
+++ b/src/Aspire.Cli/Resources/xlf/DoctorCommandStrings.pt-BR.xlf
@@ -7,11 +7,6 @@
         <target state="new">AppHost</target>
         <note />
       </trans-unit>
-      <trans-unit id="AppHostVersionCheckFailedForProjectMessageFormat">
-        <source>Could not determine AppHost version ({0})</source>
-        <target state="new">Could not determine AppHost version ({0})</target>
-        <note>{0} is the AppHost project path.</note>
-      </trans-unit>
       <trans-unit id="AppHostVersionCheckFailedMessage">
         <source>Could not determine AppHost version</source>
         <target state="new">Could not determine AppHost version</target>

--- a/src/Aspire.Cli/Resources/xlf/DoctorCommandStrings.ru.xlf
+++ b/src/Aspire.Cli/Resources/xlf/DoctorCommandStrings.ru.xlf
@@ -7,11 +7,6 @@
         <target state="new">AppHost</target>
         <note />
       </trans-unit>
-      <trans-unit id="AppHostVersionCheckFailedForProjectMessageFormat">
-        <source>Could not determine AppHost version ({0})</source>
-        <target state="new">Could not determine AppHost version ({0})</target>
-        <note>{0} is the AppHost project path.</note>
-      </trans-unit>
       <trans-unit id="AppHostVersionCheckFailedMessage">
         <source>Could not determine AppHost version</source>
         <target state="new">Could not determine AppHost version</target>

--- a/src/Aspire.Cli/Resources/xlf/DoctorCommandStrings.ru.xlf
+++ b/src/Aspire.Cli/Resources/xlf/DoctorCommandStrings.ru.xlf
@@ -2,9 +2,59 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="ru" original="../DoctorCommandStrings.resx">
     <body>
+      <trans-unit id="AppHostCategoryHeader">
+        <source>AppHost</source>
+        <target state="new">AppHost</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AppHostVersionCheckFailedForProjectMessageFormat">
+        <source>Could not determine AppHost version ({0})</source>
+        <target state="new">Could not determine AppHost version ({0})</target>
+        <note>{0} is the AppHost project path.</note>
+      </trans-unit>
+      <trans-unit id="AppHostVersionCheckFailedMessage">
+        <source>Could not determine AppHost version</source>
+        <target state="new">Could not determine AppHost version</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AppHostVersionMessageFormat">
+        <source>AppHost version {0} ({1})</source>
+        <target state="new">AppHost version {0} ({1})</target>
+        <note>{0} is the AppHost Aspire.Hosting version. {1} is the AppHost project path.</note>
+      </trans-unit>
+      <trans-unit id="AppHostVersionUnknownMessageFormat">
+        <source>Could not determine AppHost version ({0})</source>
+        <target state="new">Could not determine AppHost version ({0})</target>
+        <note>{0} is the AppHost project path.</note>
+      </trans-unit>
+      <trans-unit id="AspireCategoryHeader">
+        <source>Aspire</source>
+        <target state="new">Aspire</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CheckingPrerequisites">
         <source>Checking Aspire environment...</source>
         <target state="translated">Проверка среды Aspire...</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CliVersionMessageFormat">
+        <source>Aspire CLI version {0}</source>
+        <target state="new">Aspire CLI version {0}</target>
+        <note>{0} is the current Aspire CLI version.</note>
+      </trans-unit>
+      <trans-unit id="CliVersionOutOfDateFixFormat">
+        <source>Run '{0}' to update Aspire CLI.</source>
+        <target state="new">Run '{0}' to update Aspire CLI.</target>
+        <note>{0} is the command to update Aspire CLI.</note>
+      </trans-unit>
+      <trans-unit id="CliVersionOutOfDateMessageFormat">
+        <source>Aspire CLI version {0} is out of date. Latest version is {1}</source>
+        <target state="new">Aspire CLI version {0} is out of date. Latest version is {1}</target>
+        <note>{0} is the current Aspire CLI version. {1} is the latest available Aspire CLI version.</note>
+      </trans-unit>
+      <trans-unit id="CliVersionUpdateCheckFailedMessage">
+        <source>Could not check for Aspire CLI updates</source>
+        <target state="new">Could not check for Aspire CLI updates</target>
         <note />
       </trans-unit>
       <trans-unit id="ContainerCategoryHeader">
@@ -135,6 +185,11 @@
       <trans-unit id="SummaryFormat">
         <source>Summary: {0} passed, {1} warnings, {2} failed</source>
         <target state="translated">Сводка: {0} успешно, предупреждений: {1}, {2} с ошибками</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="VersionUnknown">
+        <source>unknown</source>
+        <target state="new">unknown</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Aspire.Cli/Resources/xlf/DoctorCommandStrings.tr.xlf
+++ b/src/Aspire.Cli/Resources/xlf/DoctorCommandStrings.tr.xlf
@@ -7,11 +7,6 @@
         <target state="new">AppHost</target>
         <note />
       </trans-unit>
-      <trans-unit id="AppHostVersionCheckFailedForProjectMessageFormat">
-        <source>Could not determine AppHost version ({0})</source>
-        <target state="new">Could not determine AppHost version ({0})</target>
-        <note>{0} is the AppHost project path.</note>
-      </trans-unit>
       <trans-unit id="AppHostVersionCheckFailedMessage">
         <source>Could not determine AppHost version</source>
         <target state="new">Could not determine AppHost version</target>

--- a/src/Aspire.Cli/Resources/xlf/DoctorCommandStrings.tr.xlf
+++ b/src/Aspire.Cli/Resources/xlf/DoctorCommandStrings.tr.xlf
@@ -2,9 +2,59 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="tr" original="../DoctorCommandStrings.resx">
     <body>
+      <trans-unit id="AppHostCategoryHeader">
+        <source>AppHost</source>
+        <target state="new">AppHost</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AppHostVersionCheckFailedForProjectMessageFormat">
+        <source>Could not determine AppHost version ({0})</source>
+        <target state="new">Could not determine AppHost version ({0})</target>
+        <note>{0} is the AppHost project path.</note>
+      </trans-unit>
+      <trans-unit id="AppHostVersionCheckFailedMessage">
+        <source>Could not determine AppHost version</source>
+        <target state="new">Could not determine AppHost version</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AppHostVersionMessageFormat">
+        <source>AppHost version {0} ({1})</source>
+        <target state="new">AppHost version {0} ({1})</target>
+        <note>{0} is the AppHost Aspire.Hosting version. {1} is the AppHost project path.</note>
+      </trans-unit>
+      <trans-unit id="AppHostVersionUnknownMessageFormat">
+        <source>Could not determine AppHost version ({0})</source>
+        <target state="new">Could not determine AppHost version ({0})</target>
+        <note>{0} is the AppHost project path.</note>
+      </trans-unit>
+      <trans-unit id="AspireCategoryHeader">
+        <source>Aspire</source>
+        <target state="new">Aspire</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CheckingPrerequisites">
         <source>Checking Aspire environment...</source>
         <target state="translated">Aspire ortamı kontrol ediliyor...</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CliVersionMessageFormat">
+        <source>Aspire CLI version {0}</source>
+        <target state="new">Aspire CLI version {0}</target>
+        <note>{0} is the current Aspire CLI version.</note>
+      </trans-unit>
+      <trans-unit id="CliVersionOutOfDateFixFormat">
+        <source>Run '{0}' to update Aspire CLI.</source>
+        <target state="new">Run '{0}' to update Aspire CLI.</target>
+        <note>{0} is the command to update Aspire CLI.</note>
+      </trans-unit>
+      <trans-unit id="CliVersionOutOfDateMessageFormat">
+        <source>Aspire CLI version {0} is out of date. Latest version is {1}</source>
+        <target state="new">Aspire CLI version {0} is out of date. Latest version is {1}</target>
+        <note>{0} is the current Aspire CLI version. {1} is the latest available Aspire CLI version.</note>
+      </trans-unit>
+      <trans-unit id="CliVersionUpdateCheckFailedMessage">
+        <source>Could not check for Aspire CLI updates</source>
+        <target state="new">Could not check for Aspire CLI updates</target>
         <note />
       </trans-unit>
       <trans-unit id="ContainerCategoryHeader">
@@ -135,6 +185,11 @@
       <trans-unit id="SummaryFormat">
         <source>Summary: {0} passed, {1} warnings, {2} failed</source>
         <target state="translated">Özet: {0} başarılı, {1} uyarı, {2} başarısız</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="VersionUnknown">
+        <source>unknown</source>
+        <target state="new">unknown</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Aspire.Cli/Resources/xlf/DoctorCommandStrings.zh-Hans.xlf
+++ b/src/Aspire.Cli/Resources/xlf/DoctorCommandStrings.zh-Hans.xlf
@@ -7,11 +7,6 @@
         <target state="new">AppHost</target>
         <note />
       </trans-unit>
-      <trans-unit id="AppHostVersionCheckFailedForProjectMessageFormat">
-        <source>Could not determine AppHost version ({0})</source>
-        <target state="new">Could not determine AppHost version ({0})</target>
-        <note>{0} is the AppHost project path.</note>
-      </trans-unit>
       <trans-unit id="AppHostVersionCheckFailedMessage">
         <source>Could not determine AppHost version</source>
         <target state="new">Could not determine AppHost version</target>

--- a/src/Aspire.Cli/Resources/xlf/DoctorCommandStrings.zh-Hans.xlf
+++ b/src/Aspire.Cli/Resources/xlf/DoctorCommandStrings.zh-Hans.xlf
@@ -2,9 +2,59 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="zh-Hans" original="../DoctorCommandStrings.resx">
     <body>
+      <trans-unit id="AppHostCategoryHeader">
+        <source>AppHost</source>
+        <target state="new">AppHost</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AppHostVersionCheckFailedForProjectMessageFormat">
+        <source>Could not determine AppHost version ({0})</source>
+        <target state="new">Could not determine AppHost version ({0})</target>
+        <note>{0} is the AppHost project path.</note>
+      </trans-unit>
+      <trans-unit id="AppHostVersionCheckFailedMessage">
+        <source>Could not determine AppHost version</source>
+        <target state="new">Could not determine AppHost version</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AppHostVersionMessageFormat">
+        <source>AppHost version {0} ({1})</source>
+        <target state="new">AppHost version {0} ({1})</target>
+        <note>{0} is the AppHost Aspire.Hosting version. {1} is the AppHost project path.</note>
+      </trans-unit>
+      <trans-unit id="AppHostVersionUnknownMessageFormat">
+        <source>Could not determine AppHost version ({0})</source>
+        <target state="new">Could not determine AppHost version ({0})</target>
+        <note>{0} is the AppHost project path.</note>
+      </trans-unit>
+      <trans-unit id="AspireCategoryHeader">
+        <source>Aspire</source>
+        <target state="new">Aspire</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CheckingPrerequisites">
         <source>Checking Aspire environment...</source>
         <target state="translated">正在检查 Aspire 环境...</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CliVersionMessageFormat">
+        <source>Aspire CLI version {0}</source>
+        <target state="new">Aspire CLI version {0}</target>
+        <note>{0} is the current Aspire CLI version.</note>
+      </trans-unit>
+      <trans-unit id="CliVersionOutOfDateFixFormat">
+        <source>Run '{0}' to update Aspire CLI.</source>
+        <target state="new">Run '{0}' to update Aspire CLI.</target>
+        <note>{0} is the command to update Aspire CLI.</note>
+      </trans-unit>
+      <trans-unit id="CliVersionOutOfDateMessageFormat">
+        <source>Aspire CLI version {0} is out of date. Latest version is {1}</source>
+        <target state="new">Aspire CLI version {0} is out of date. Latest version is {1}</target>
+        <note>{0} is the current Aspire CLI version. {1} is the latest available Aspire CLI version.</note>
+      </trans-unit>
+      <trans-unit id="CliVersionUpdateCheckFailedMessage">
+        <source>Could not check for Aspire CLI updates</source>
+        <target state="new">Could not check for Aspire CLI updates</target>
         <note />
       </trans-unit>
       <trans-unit id="ContainerCategoryHeader">
@@ -135,6 +185,11 @@
       <trans-unit id="SummaryFormat">
         <source>Summary: {0} passed, {1} warnings, {2} failed</source>
         <target state="translated">摘要: {0} 通过,{1} 警告， {2} 失败</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="VersionUnknown">
+        <source>unknown</source>
+        <target state="new">unknown</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Aspire.Cli/Resources/xlf/DoctorCommandStrings.zh-Hant.xlf
+++ b/src/Aspire.Cli/Resources/xlf/DoctorCommandStrings.zh-Hant.xlf
@@ -7,11 +7,6 @@
         <target state="new">AppHost</target>
         <note />
       </trans-unit>
-      <trans-unit id="AppHostVersionCheckFailedForProjectMessageFormat">
-        <source>Could not determine AppHost version ({0})</source>
-        <target state="new">Could not determine AppHost version ({0})</target>
-        <note>{0} is the AppHost project path.</note>
-      </trans-unit>
       <trans-unit id="AppHostVersionCheckFailedMessage">
         <source>Could not determine AppHost version</source>
         <target state="new">Could not determine AppHost version</target>

--- a/src/Aspire.Cli/Resources/xlf/DoctorCommandStrings.zh-Hant.xlf
+++ b/src/Aspire.Cli/Resources/xlf/DoctorCommandStrings.zh-Hant.xlf
@@ -2,9 +2,59 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="zh-Hant" original="../DoctorCommandStrings.resx">
     <body>
+      <trans-unit id="AppHostCategoryHeader">
+        <source>AppHost</source>
+        <target state="new">AppHost</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AppHostVersionCheckFailedForProjectMessageFormat">
+        <source>Could not determine AppHost version ({0})</source>
+        <target state="new">Could not determine AppHost version ({0})</target>
+        <note>{0} is the AppHost project path.</note>
+      </trans-unit>
+      <trans-unit id="AppHostVersionCheckFailedMessage">
+        <source>Could not determine AppHost version</source>
+        <target state="new">Could not determine AppHost version</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AppHostVersionMessageFormat">
+        <source>AppHost version {0} ({1})</source>
+        <target state="new">AppHost version {0} ({1})</target>
+        <note>{0} is the AppHost Aspire.Hosting version. {1} is the AppHost project path.</note>
+      </trans-unit>
+      <trans-unit id="AppHostVersionUnknownMessageFormat">
+        <source>Could not determine AppHost version ({0})</source>
+        <target state="new">Could not determine AppHost version ({0})</target>
+        <note>{0} is the AppHost project path.</note>
+      </trans-unit>
+      <trans-unit id="AspireCategoryHeader">
+        <source>Aspire</source>
+        <target state="new">Aspire</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CheckingPrerequisites">
         <source>Checking Aspire environment...</source>
         <target state="translated">正在檢查 Aspire 環境...</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CliVersionMessageFormat">
+        <source>Aspire CLI version {0}</source>
+        <target state="new">Aspire CLI version {0}</target>
+        <note>{0} is the current Aspire CLI version.</note>
+      </trans-unit>
+      <trans-unit id="CliVersionOutOfDateFixFormat">
+        <source>Run '{0}' to update Aspire CLI.</source>
+        <target state="new">Run '{0}' to update Aspire CLI.</target>
+        <note>{0} is the command to update Aspire CLI.</note>
+      </trans-unit>
+      <trans-unit id="CliVersionOutOfDateMessageFormat">
+        <source>Aspire CLI version {0} is out of date. Latest version is {1}</source>
+        <target state="new">Aspire CLI version {0} is out of date. Latest version is {1}</target>
+        <note>{0} is the current Aspire CLI version. {1} is the latest available Aspire CLI version.</note>
+      </trans-unit>
+      <trans-unit id="CliVersionUpdateCheckFailedMessage">
+        <source>Could not check for Aspire CLI updates</source>
+        <target state="new">Could not check for Aspire CLI updates</target>
         <note />
       </trans-unit>
       <trans-unit id="ContainerCategoryHeader">
@@ -135,6 +185,11 @@
       <trans-unit id="SummaryFormat">
         <source>Summary: {0} passed, {1} warnings, {2} failed</source>
         <target state="translated">摘要: {0} 個通過、{1} 個警告、{2} 個已失敗</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="VersionUnknown">
+        <source>unknown</source>
+        <target state="new">unknown</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Aspire.Cli/Utils/CliUpdateNotifier.cs
+++ b/src/Aspire.Cli/Utils/CliUpdateNotifier.cs
@@ -12,9 +12,12 @@ namespace Aspire.Cli.Utils;
 internal interface ICliUpdateNotifier
 {
     Task CheckForCliUpdatesAsync(DirectoryInfo workingDirectory, CancellationToken cancellationToken);
+    Task<CliVersionStatus> GetVersionStatusAsync(DirectoryInfo workingDirectory, CancellationToken cancellationToken);
     void NotifyIfUpdateAvailable();
     bool IsUpdateAvailable();
 }
+
+internal sealed record CliVersionStatus(string? CurrentVersion, string? LatestVersion, string? UpdateCommand, string? UpdateCheckError = null);
 
 internal class CliUpdateNotifier(
     ILogger<CliUpdateNotifier> logger,
@@ -25,56 +28,83 @@ internal class CliUpdateNotifier(
 
     public async Task CheckForCliUpdatesAsync(DirectoryInfo workingDirectory, CancellationToken cancellationToken)
     {
-        _availablePackages = await nuGetPackageCache.GetCliPackagesAsync(
-            workingDirectory: workingDirectory,
-            prerelease: true,
-            nugetConfigFile: null,
-            cancellationToken: cancellationToken);
+        _availablePackages = await GetCliPackagesAsync(workingDirectory, cancellationToken);
     }
 
     public void NotifyIfUpdateAvailable()
     {
-        if (_availablePackages is null)
+        var status = GetCachedVersionStatus();
+        if (status.LatestVersion is not null)
         {
-            return;
+            interactionService.DisplayVersionUpdateNotification(status.LatestVersion, status.UpdateCommand);
+        }
+    }
+
+    public async Task<CliVersionStatus> GetVersionStatusAsync(DirectoryInfo workingDirectory, CancellationToken cancellationToken)
+    {
+        try
+        {
+            // Callers that need a synchronous answer cannot rely on the background
+            // prefetcher racing to populate the cache before command exit.
+            // Refresh through the same method used by background update notifications so
+            // NuGet source selection and cache mutation stay consistent.
+            await CheckForCliUpdatesAsync(workingDirectory, cancellationToken);
+        }
+        catch (OperationCanceledException)
+        {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            logger.LogDebug(ex, "Failed to check for Aspire CLI updates.");
+            return GetCachedVersionStatus(ex.Message);
         }
 
-        var currentVersion = GetCurrentVersion();
-        if (currentVersion is null)
-        {
-            logger.LogDebug("Unable to determine current CLI version for update check.");
-            return;
-        }
-
-        var newerVersion = PackageUpdateHelpers.GetNewerVersion(logger, currentVersion, _availablePackages);
-
-        if (newerVersion is not null)
-        {
-            var updateCommand = DotNetToolDetection.GetDotNetToolUpdateCommand() ?? "aspire update";
-
-            interactionService.DisplayVersionUpdateNotification(newerVersion.ToString(), updateCommand);
-        }
+        return GetCachedVersionStatus();
     }
 
     public bool IsUpdateAvailable()
-    {
-        if (_availablePackages is null)
-        {
-            return false;
-        }
-
-        var currentVersion = GetCurrentVersion();
-        if (currentVersion is null)
-        {
-            return false;
-        }
-
-        var newerVersion = PackageUpdateHelpers.GetNewerVersion(logger, currentVersion, _availablePackages);
-        return newerVersion is not null;
-    }
+        => GetCachedVersionStatus().LatestVersion is not null;
 
     protected virtual SemVersion? GetCurrentVersion()
     {
         return PackageUpdateHelpers.GetCurrentPackageVersion();
+    }
+
+    private CliVersionStatus GetCachedVersionStatus(string? updateCheckError = null)
+    {
+        // Keep all version comparison and update-command selection in one place so
+        // callers cannot disagree when package metadata has already been fetched.
+        var currentVersion = GetCurrentVersion();
+        var currentVersionString = currentVersion?.ToString() ?? PackageUpdateHelpers.GetCurrentAssemblyVersion();
+
+        if (updateCheckError is not null)
+        {
+            return new CliVersionStatus(currentVersionString, null, null, updateCheckError);
+        }
+
+        if (_availablePackages is null)
+        {
+            return new CliVersionStatus(currentVersionString, null, null);
+        }
+
+        if (currentVersion is null)
+        {
+            logger.LogDebug("Unable to determine current CLI version for update check.");
+            return new CliVersionStatus(currentVersionString, null, null);
+        }
+
+        var newerVersion = PackageUpdateHelpers.GetNewerVersion(logger, currentVersion, _availablePackages);
+        var updateCommand = newerVersion is null ? null : DotNetToolDetection.GetDotNetToolUpdateCommand() ?? "aspire update";
+        return new CliVersionStatus(currentVersionString, newerVersion?.ToString(), updateCommand);
+    }
+
+    private async Task<IEnumerable<Shared.NuGetPackageCli>> GetCliPackagesAsync(DirectoryInfo workingDirectory, CancellationToken cancellationToken)
+    {
+        return await nuGetPackageCache.GetCliPackagesAsync(
+            workingDirectory: workingDirectory,
+            prerelease: true,
+            nugetConfigFile: null,
+            cancellationToken: cancellationToken);
     }
 }

--- a/src/Aspire.Cli/Utils/EnvironmentChecker/AspireVersionCheck.cs
+++ b/src/Aspire.Cli/Utils/EnvironmentChecker/AspireVersionCheck.cs
@@ -21,8 +21,6 @@ internal sealed class AspireVersionCheck(
     CliExecutionContext executionContext,
     ILogger<AspireVersionCheck> logger) : IEnvironmentCheck
 {
-    private static readonly string[] s_dotNetAppHostFileNames = ["AppHost.csproj", "AppHost.fsproj", "AppHost.vbproj", "apphost.cs"];
-
     // Version checks should appear first so users immediately see which Aspire bits
     // produced the rest of the doctor output before reading environment diagnostics.
     public int Order => 0;
@@ -228,29 +226,36 @@ internal sealed class AspireVersionCheck(
 
     private async Task<IReadOnlyList<FileInfo>> ResolveAppHostFilesAsync(CancellationToken cancellationToken)
     {
-        var configuredAppHost = ResolveAppHostFromCurrentDirectoryConfig();
+        // AppHost version reporting is intentionally shallow: use an AppHost explicitly
+        // configured in the current directory, or exactly one AppHost-looking file in
+        // the current directory. Avoid recursive discovery so doctor does not choose
+        // between multiple AppHosts or pay the cost of project-wide AppHost search for
+        // an informational version check.
+        var configuredAppHost = await ResolveAppHostFromCurrentDirectoryConfigAsync(cancellationToken);
         if (configuredAppHost is not null)
         {
             return [configuredAppHost];
         }
 
-        var candidates = new List<FileInfo>();
-        var candidateFileNames = new HashSet<string>(s_dotNetAppHostFileNames, StringComparer.OrdinalIgnoreCase);
+        var candidates = new Dictionary<string, FileInfo>(OperatingSystem.IsWindows() ? StringComparer.OrdinalIgnoreCase : StringComparer.Ordinal);
         var languages = await languageDiscovery.GetAvailableLanguagesAsync(cancellationToken);
         foreach (var language in languages)
         {
-            if (!string.IsNullOrWhiteSpace(language.AppHostFileName))
-            {
-                candidateFileNames.Add(language.AppHostFileName);
-            }
-        }
+            var project = projectFactory.GetProject(language);
+            var detectionPatterns = await project.GetDetectionPatternsAsync(cancellationToken);
 
-        foreach (var candidateFileName in candidateFileNames)
-        {
-            var candidate = new FileInfo(Path.Combine(executionContext.WorkingDirectory.FullName, candidateFileName));
-            if (candidate.Exists)
+            foreach (var detectionPattern in detectionPatterns)
             {
-                candidates.Add(candidate);
+                cancellationToken.ThrowIfCancellationRequested();
+
+                foreach (var candidatePath in Directory.EnumerateFiles(executionContext.WorkingDirectory.FullName, detectionPattern, SearchOption.TopDirectoryOnly))
+                {
+                    var candidate = new FileInfo(candidatePath);
+                    if (project.CanHandle(candidate))
+                    {
+                        candidates.TryAdd(candidate.FullName, candidate);
+                    }
+                }
             }
         }
 
@@ -262,10 +267,10 @@ internal sealed class AspireVersionCheck(
             return [];
         }
 
-        return candidates;
+        return [.. candidates.Values];
     }
 
-    private FileInfo? ResolveAppHostFromCurrentDirectoryConfig()
+    private async Task<FileInfo?> ResolveAppHostFromCurrentDirectoryConfigAsync(CancellationToken cancellationToken)
     {
         var config = AspireConfigFile.Load(executionContext.WorkingDirectory.FullName);
         if (config?.AppHost?.Path is not { Length: > 0 } appHostPath)
@@ -283,7 +288,21 @@ internal sealed class AspireVersionCheck(
             throw new FileNotFoundException($"AppHost path '{appHostPath}' from {AspireConfigFile.FileName} does not exist.", appHostFile.FullName);
         }
 
-        return appHostFile;
+        var languages = await languageDiscovery.GetAvailableLanguagesAsync(cancellationToken);
+        foreach (var language in languages)
+        {
+            var project = projectFactory.GetProject(language);
+            if (project.CanHandle(appHostFile))
+            {
+                return appHostFile;
+            }
+        }
+
+        logger.LogDebug(
+            "Ignoring AppHost path '{AppHostPath}' from {ConfigFile} because no project handler can process it.",
+            appHostFile.FullName,
+            AspireConfigFile.FileName);
+        return null;
     }
 
     private async Task<(bool IsAppHost, string? Version)> ResolveAppHostVersionAsync(FileInfo appHostFile, CancellationToken cancellationToken)

--- a/src/Aspire.Cli/Utils/EnvironmentChecker/AspireVersionCheck.cs
+++ b/src/Aspire.Cli/Utils/EnvironmentChecker/AspireVersionCheck.cs
@@ -107,10 +107,10 @@ internal sealed class AspireVersionCheck(
 
     private async Task<EnvironmentCheckResult?> GetAppHostVersionCheckAsync(CancellationToken cancellationToken)
     {
-        FileInfo? appHostFile;
+        IReadOnlyList<FileInfo> appHostFiles;
         try
         {
-            appHostFile = await ResolveAppHostFileAsync(cancellationToken);
+            appHostFiles = await ResolveAppHostFilesAsync(cancellationToken);
         }
         catch (ProjectLocatorException ex) when (ex.FailureReason is ProjectLocatorFailureReason.NoProjectFileFound or ProjectLocatorFailureReason.ProjectFileDoesntExist)
         {
@@ -134,41 +134,62 @@ internal sealed class AspireVersionCheck(
             };
         }
 
-        if (appHostFile is null)
+        foreach (var appHostFile in appHostFiles)
         {
-            return null;
-        }
-
-        var relativePath = GetRelativePath(appHostFile);
-        var (isAppHost, version) = await ResolveAppHostVersionAsync(appHostFile, cancellationToken);
-        if (!isAppHost)
-        {
-            return null;
-        }
-
-        if (string.IsNullOrWhiteSpace(version))
-        {
-            return new EnvironmentCheckResult
+            var relativePath = GetRelativePath(appHostFile);
+            try
             {
-                Category = "apphost",
-                Name = "apphost-version",
-                Status = EnvironmentCheckStatus.Warning,
-                Message = string.Format(CultureInfo.CurrentCulture, DoctorCommandStrings.AppHostVersionUnknownMessageFormat, relativePath),
-                Metadata = BuildAppHostVersionMetadata(relativePath, version: null)
-            };
+                var (isAppHost, version) = await ResolveAppHostVersionAsync(appHostFile, cancellationToken);
+                if (!isAppHost)
+                {
+                    continue;
+                }
+
+                if (string.IsNullOrWhiteSpace(version))
+                {
+                    return new EnvironmentCheckResult
+                    {
+                        Category = "apphost",
+                        Name = "apphost-version",
+                        Status = EnvironmentCheckStatus.Warning,
+                        Message = string.Format(CultureInfo.CurrentCulture, DoctorCommandStrings.AppHostVersionUnknownMessageFormat, relativePath),
+                        Metadata = BuildAppHostVersionMetadata(relativePath, version: null)
+                    };
+                }
+
+                return new EnvironmentCheckResult
+                {
+                    Category = "apphost",
+                    Name = "apphost-version",
+                    Status = EnvironmentCheckStatus.Pass,
+                    Message = string.Format(CultureInfo.CurrentCulture, DoctorCommandStrings.AppHostVersionMessageFormat, version, relativePath),
+                    Metadata = BuildAppHostVersionMetadata(relativePath, version)
+                };
+            }
+            catch (OperationCanceledException)
+            {
+                throw;
+            }
+            catch (Exception ex)
+            {
+                logger.LogDebug(ex, "Failed to check Aspire AppHost version for {AppHostPath}.", appHostFile.FullName);
+
+                return new EnvironmentCheckResult
+                {
+                    Category = "apphost",
+                    Name = "apphost-version",
+                    Status = EnvironmentCheckStatus.Warning,
+                    Message = DoctorCommandStrings.AppHostVersionCheckFailedMessage,
+                    Details = ex.Message,
+                    Metadata = BuildAppHostVersionMetadata(relativePath, version: null)
+                };
+            }
         }
 
-        return new EnvironmentCheckResult
-        {
-            Category = "apphost",
-            Name = "apphost-version",
-            Status = EnvironmentCheckStatus.Pass,
-            Message = string.Format(CultureInfo.CurrentCulture, DoctorCommandStrings.AppHostVersionMessageFormat, version, relativePath),
-            Metadata = BuildAppHostVersionMetadata(relativePath, version)
-        };
+        return null;
     }
 
-    private async Task<FileInfo?> ResolveAppHostFileAsync(CancellationToken cancellationToken)
+    private async Task<IReadOnlyList<FileInfo>> ResolveAppHostFilesAsync(CancellationToken cancellationToken)
     {
         // Match the other doctor checks: honor a configured AppHost first without
         // scanning, then use bounded language detection. Avoid the full project locator
@@ -177,20 +198,80 @@ internal sealed class AspireVersionCheck(
         var configuredAppHost = await projectLocator.GetAppHostFromSettingsAsync(cancellationToken);
         if (configuredAppHost is not null)
         {
-            return configuredAppHost;
+            return [configuredAppHost];
         }
 
         // Detect only which AppHost language appears to be present within the bounded
-        // search depth, then ask that language to find its first matching AppHost file.
+        // search depth, then validate matching candidates until an AppHost is found.
         var detectedLanguageId = await languageDiscovery.DetectLanguageRecursiveAsync(executionContext.WorkingDirectory, cancellationToken);
         if (detectedLanguageId is null)
         {
-            return null;
+            return [];
         }
 
         var detectedLanguage = languageDiscovery.GetLanguageById(detectedLanguageId.Value);
-        var discoveredPath = detectedLanguage?.FindInDirectory(executionContext.WorkingDirectory.FullName);
-        return discoveredPath is not null ? new FileInfo(discoveredPath) : null;
+        return detectedLanguage is not null
+            ? FindAppHostCandidates(detectedLanguage, cancellationToken).ToArray()
+            : [];
+    }
+
+    private IEnumerable<FileInfo> FindAppHostCandidates(LanguageInfo language, CancellationToken cancellationToken)
+    {
+        var root = executionContext.WorkingDirectory.FullName;
+        if (!Directory.Exists(root))
+        {
+            yield break;
+        }
+
+        var dirs = new Stack<(string Path, int Depth)>();
+        dirs.Push((root, 0));
+
+        while (dirs.Count > 0)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            var (dir, depth) = dirs.Pop();
+
+            IEnumerable<string> files;
+            try
+            {
+                files = Directory.EnumerateFiles(dir).ToArray();
+            }
+            catch (Exception ex) when (ex is DirectoryNotFoundException or IOException or UnauthorizedAccessException)
+            {
+                logger.LogDebug(ex, "Skipping directory {Directory} while finding AppHost candidates.", dir);
+                continue;
+            }
+
+            foreach (var file in files)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                if (language.MatchesFile(Path.GetFileName(file)))
+                {
+                    yield return new FileInfo(file);
+                }
+            }
+
+            if (depth >= LanguageInfo.DetectionRecurseLimit)
+            {
+                continue;
+            }
+
+            IEnumerable<string> subdirectories;
+            try
+            {
+                subdirectories = Directory.EnumerateDirectories(dir).ToArray();
+            }
+            catch (Exception ex) when (ex is DirectoryNotFoundException or IOException or UnauthorizedAccessException)
+            {
+                logger.LogDebug(ex, "Skipping subdirectories of {Directory} while finding AppHost candidates.", dir);
+                continue;
+            }
+
+            foreach (var subdirectory in subdirectories)
+            {
+                dirs.Push((subdirectory, depth + 1));
+            }
+        }
     }
 
     private async Task<(bool IsAppHost, string? Version)> ResolveAppHostVersionAsync(FileInfo appHostFile, CancellationToken cancellationToken)

--- a/src/Aspire.Cli/Utils/EnvironmentChecker/AspireVersionCheck.cs
+++ b/src/Aspire.Cli/Utils/EnvironmentChecker/AspireVersionCheck.cs
@@ -3,7 +3,6 @@
 
 using System.Globalization;
 using System.Text.Json.Nodes;
-using Aspire.Cli.Configuration;
 using Aspire.Cli.Projects;
 using Aspire.Cli.Resources;
 using Microsoft.Extensions.Logging;
@@ -16,6 +15,7 @@ namespace Aspire.Cli.Utils.EnvironmentChecker;
 /// </summary>
 internal sealed class AspireVersionCheck(
     ICliUpdateNotifier updateNotifier,
+    IProjectLocator projectLocator,
     ILanguageDiscovery languageDiscovery,
     IAppHostProjectFactory projectFactory,
     CliExecutionContext executionContext,
@@ -231,7 +231,7 @@ internal sealed class AspireVersionCheck(
         // the current directory. Avoid recursive discovery so doctor does not choose
         // between multiple AppHosts or pay the cost of project-wide AppHost search for
         // an informational version check.
-        var configuredAppHost = await ResolveAppHostFromCurrentDirectoryConfigAsync(cancellationToken);
+        var configuredAppHost = await projectLocator.GetAppHostFromSettingsAsync(executionContext.WorkingDirectory, searchParentDirectories: false, cancellationToken);
         if (configuredAppHost is not null)
         {
             return [configuredAppHost];
@@ -268,41 +268,6 @@ internal sealed class AspireVersionCheck(
         }
 
         return [.. candidates.Values];
-    }
-
-    private async Task<FileInfo?> ResolveAppHostFromCurrentDirectoryConfigAsync(CancellationToken cancellationToken)
-    {
-        var config = AspireConfigFile.Load(executionContext.WorkingDirectory.FullName);
-        if (config?.AppHost?.Path is not { Length: > 0 } appHostPath)
-        {
-            return null;
-        }
-
-        var qualifiedPath = Path.IsPathRooted(appHostPath)
-            ? appHostPath
-            : Path.Combine(executionContext.WorkingDirectory.FullName, appHostPath);
-
-        var appHostFile = new FileInfo(Path.GetFullPath(qualifiedPath));
-        if (!appHostFile.Exists)
-        {
-            throw new FileNotFoundException($"AppHost path '{appHostPath}' from {AspireConfigFile.FileName} does not exist.", appHostFile.FullName);
-        }
-
-        var languages = await languageDiscovery.GetAvailableLanguagesAsync(cancellationToken);
-        foreach (var language in languages)
-        {
-            var project = projectFactory.GetProject(language);
-            if (project.CanHandle(appHostFile))
-            {
-                return appHostFile;
-            }
-        }
-
-        logger.LogDebug(
-            "Ignoring AppHost path '{AppHostPath}' from {ConfigFile} because no project handler can process it.",
-            appHostFile.FullName,
-            AspireConfigFile.FileName);
-        return null;
     }
 
     private async Task<(bool IsAppHost, string? Version)> ResolveAppHostVersionAsync(FileInfo appHostFile, CancellationToken cancellationToken)

--- a/src/Aspire.Cli/Utils/EnvironmentChecker/AspireVersionCheck.cs
+++ b/src/Aspire.Cli/Utils/EnvironmentChecker/AspireVersionCheck.cs
@@ -1,0 +1,260 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Globalization;
+using System.Text.Json.Nodes;
+using Aspire.Cli.Projects;
+using Aspire.Cli.Resources;
+using Microsoft.Extensions.Logging;
+
+namespace Aspire.Cli.Utils.EnvironmentChecker;
+
+/// <summary>
+/// Reports the installed Aspire CLI version, whether a newer CLI version is available, and
+/// the Aspire SDK version used by the selected AppHost when one can be discovered.
+/// </summary>
+internal sealed class AspireVersionCheck(
+    ICliUpdateNotifier updateNotifier,
+    IProjectLocator projectLocator,
+    ILanguageDiscovery languageDiscovery,
+    IAppHostProjectFactory projectFactory,
+    CliExecutionContext executionContext,
+    ILogger<AspireVersionCheck> logger) : IEnvironmentCheck
+{
+    // Version checks should appear first so users immediately see which Aspire bits
+    // produced the rest of the doctor output before reading environment diagnostics.
+    public int Order => 0;
+
+    public async Task<IReadOnlyList<EnvironmentCheckResult>> CheckAsync(CancellationToken cancellationToken = default)
+    {
+        var results = new List<EnvironmentCheckResult>
+        {
+            await GetCliVersionCheckAsync(cancellationToken)
+        };
+
+        var appHostVersionCheck = await GetAppHostVersionCheckAsync(cancellationToken);
+        if (appHostVersionCheck is not null)
+        {
+            results.Add(appHostVersionCheck);
+        }
+
+        return results;
+    }
+
+    private async Task<EnvironmentCheckResult> GetCliVersionCheckAsync(CancellationToken cancellationToken)
+    {
+        try
+        {
+            var status = await updateNotifier.GetVersionStatusAsync(executionContext.WorkingDirectory, cancellationToken);
+            var currentVersion = string.IsNullOrWhiteSpace(status.CurrentVersion) ? DoctorCommandStrings.VersionUnknown : status.CurrentVersion;
+
+            // Doctor should always report the installed CLI version. Treat update lookup
+            // failures as a warning on that same check rather than hiding the version or
+            // failing the command because offline/private-feed scenarios are common.
+            if (status.UpdateCheckError is { Length: > 0 } updateCheckError)
+            {
+                return new EnvironmentCheckResult
+                {
+                    Category = "aspire",
+                    Name = "cli-version",
+                    Status = EnvironmentCheckStatus.Warning,
+                    Message = string.Format(CultureInfo.CurrentCulture, DoctorCommandStrings.CliVersionMessageFormat, currentVersion),
+                    Details = $"{DoctorCommandStrings.CliVersionUpdateCheckFailedMessage}: {updateCheckError}",
+                    Metadata = BuildCliVersionMetadata(currentVersion, latestVersion: null, status.UpdateCommand, updateCheckError)
+                };
+            }
+
+            if (status.LatestVersion is { Length: > 0 } latestVersion)
+            {
+                return new EnvironmentCheckResult
+                {
+                    Category = "aspire",
+                    Name = "cli-version",
+                    Status = EnvironmentCheckStatus.Warning,
+                    Message = string.Format(CultureInfo.CurrentCulture, DoctorCommandStrings.CliVersionOutOfDateMessageFormat, currentVersion, latestVersion),
+                    Fix = string.Format(CultureInfo.CurrentCulture, DoctorCommandStrings.CliVersionOutOfDateFixFormat, status.UpdateCommand ?? "aspire update"),
+                    Metadata = BuildCliVersionMetadata(currentVersion, latestVersion, status.UpdateCommand, updateCheckError: null)
+                };
+            }
+
+            return new EnvironmentCheckResult
+            {
+                Category = "aspire",
+                Name = "cli-version",
+                Status = EnvironmentCheckStatus.Pass,
+                Message = string.Format(CultureInfo.CurrentCulture, DoctorCommandStrings.CliVersionMessageFormat, currentVersion),
+                Metadata = BuildCliVersionMetadata(currentVersion, latestVersion: null, status.UpdateCommand, updateCheckError: null)
+            };
+        }
+        catch (OperationCanceledException)
+        {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            logger.LogDebug(ex, "Failed to check Aspire CLI version.");
+
+            return new EnvironmentCheckResult
+            {
+                Category = "aspire",
+                Name = "cli-version",
+                Status = EnvironmentCheckStatus.Warning,
+                Message = DoctorCommandStrings.CliVersionUpdateCheckFailedMessage,
+                Details = ex.Message
+            };
+        }
+    }
+
+    private async Task<EnvironmentCheckResult?> GetAppHostVersionCheckAsync(CancellationToken cancellationToken)
+    {
+        FileInfo? appHostFile;
+        try
+        {
+            appHostFile = await ResolveAppHostFileAsync(cancellationToken);
+        }
+        catch (ProjectLocatorException ex) when (ex.FailureReason is ProjectLocatorFailureReason.NoProjectFileFound or ProjectLocatorFailureReason.ProjectFileDoesntExist)
+        {
+            // Doctor is useful outside an Aspire app too; no AppHost simply means there is
+            // no AppHost version check to include.
+            return null;
+        }
+        catch (OperationCanceledException)
+        {
+            throw;
+        }
+        catch (ProjectLocatorException ex)
+        {
+            return new EnvironmentCheckResult
+            {
+                Category = "apphost",
+                Name = "apphost-version",
+                Status = EnvironmentCheckStatus.Warning,
+                Message = DoctorCommandStrings.AppHostVersionCheckFailedMessage,
+                Details = ex.Message
+            };
+        }
+
+        if (appHostFile is null)
+        {
+            return null;
+        }
+
+        var relativePath = GetRelativePath(appHostFile);
+        var (isAppHost, version) = await ResolveAppHostVersionAsync(appHostFile, cancellationToken);
+        if (!isAppHost)
+        {
+            return null;
+        }
+
+        if (string.IsNullOrWhiteSpace(version))
+        {
+            return new EnvironmentCheckResult
+            {
+                Category = "apphost",
+                Name = "apphost-version",
+                Status = EnvironmentCheckStatus.Warning,
+                Message = string.Format(CultureInfo.CurrentCulture, DoctorCommandStrings.AppHostVersionUnknownMessageFormat, relativePath),
+                Metadata = BuildAppHostVersionMetadata(relativePath, version: null)
+            };
+        }
+
+        return new EnvironmentCheckResult
+        {
+            Category = "apphost",
+            Name = "apphost-version",
+            Status = EnvironmentCheckStatus.Pass,
+            Message = string.Format(CultureInfo.CurrentCulture, DoctorCommandStrings.AppHostVersionMessageFormat, version, relativePath),
+            Metadata = BuildAppHostVersionMetadata(relativePath, version)
+        };
+    }
+
+    private async Task<FileInfo?> ResolveAppHostFileAsync(CancellationToken cancellationToken)
+    {
+        // Match the other doctor checks: honor a configured AppHost first without
+        // scanning, then use bounded language detection. Avoid the full project locator
+        // walk here because the AppHost version is informational and doctor should stay
+        // fast in large repositories that do not contain an AppHost.
+        var configuredAppHost = await projectLocator.GetAppHostFromSettingsAsync(cancellationToken);
+        if (configuredAppHost is not null)
+        {
+            return configuredAppHost;
+        }
+
+        // Detect only which AppHost language appears to be present within the bounded
+        // search depth, then ask that language to find its first matching AppHost file.
+        var detectedLanguageId = await languageDiscovery.DetectLanguageRecursiveAsync(executionContext.WorkingDirectory, cancellationToken);
+        if (detectedLanguageId is null)
+        {
+            return null;
+        }
+
+        var detectedLanguage = languageDiscovery.GetLanguageById(detectedLanguageId.Value);
+        var discoveredPath = detectedLanguage?.FindInDirectory(executionContext.WorkingDirectory.FullName);
+        return discoveredPath is not null ? new FileInfo(discoveredPath) : null;
+    }
+
+    private async Task<(bool IsAppHost, string? Version)> ResolveAppHostVersionAsync(FileInfo appHostFile, CancellationToken cancellationToken)
+    {
+        var project = projectFactory.TryGetProject(appHostFile);
+        if (project is null)
+        {
+            return (false, null);
+        }
+
+        var validationResult = await project.ValidateAppHostAsync(appHostFile, cancellationToken);
+        if (validationResult.IsValid)
+        {
+            return (true, validationResult.AspireHostingVersion ?? await project.GetAspireHostingVersionAsync(appHostFile, cancellationToken));
+        }
+
+        // A project named like an AppHost may fail validation because it is not currently
+        // buildable. Keep reporting the candidate so doctor can explain that the version is unknown,
+        // but suppress ordinary projects that only matched the broad language detection patterns.
+        return (validationResult.IsPossiblyUnbuildable, null);
+    }
+
+    private string GetRelativePath(FileInfo file)
+    {
+        return Path.GetRelativePath(executionContext.WorkingDirectory.FullName, file.FullName);
+    }
+
+    private static JsonObject BuildCliVersionMetadata(string currentVersion, string? latestVersion, string? updateCommand, string? updateCheckError)
+    {
+        var metadata = new JsonObject
+        {
+            ["currentVersion"] = currentVersion
+        };
+
+        if (!string.IsNullOrWhiteSpace(latestVersion))
+        {
+            metadata["latestVersion"] = latestVersion;
+        }
+
+        if (!string.IsNullOrWhiteSpace(updateCommand))
+        {
+            metadata["updateCommand"] = updateCommand;
+        }
+
+        if (!string.IsNullOrWhiteSpace(updateCheckError))
+        {
+            metadata["updateCheckError"] = updateCheckError;
+        }
+
+        return metadata;
+    }
+
+    private static JsonObject BuildAppHostVersionMetadata(string relativePath, string? version)
+    {
+        var metadata = new JsonObject
+        {
+            ["appHostPath"] = relativePath
+        };
+
+        if (!string.IsNullOrWhiteSpace(version))
+        {
+            metadata["version"] = version;
+        }
+
+        return metadata;
+    }
+}

--- a/src/Aspire.Cli/Utils/EnvironmentChecker/AspireVersionCheck.cs
+++ b/src/Aspire.Cli/Utils/EnvironmentChecker/AspireVersionCheck.cs
@@ -16,7 +16,6 @@ namespace Aspire.Cli.Utils.EnvironmentChecker;
 internal sealed class AspireVersionCheck(
     ICliUpdateNotifier updateNotifier,
     IProjectLocator projectLocator,
-    ILanguageDiscovery languageDiscovery,
     IAppHostProjectFactory projectFactory,
     CliExecutionContext executionContext,
     ILogger<AspireVersionCheck> logger) : IEnvironmentCheck
@@ -237,27 +236,11 @@ internal sealed class AspireVersionCheck(
             return [configuredAppHost];
         }
 
-        var candidates = new Dictionary<string, FileInfo>(OperatingSystem.IsWindows() ? StringComparer.OrdinalIgnoreCase : StringComparer.Ordinal);
-        var languages = await languageDiscovery.GetAvailableLanguagesAsync(cancellationToken);
-        foreach (var language in languages)
-        {
-            var project = projectFactory.GetProject(language);
-            var detectionPatterns = await project.GetDetectionPatternsAsync(cancellationToken);
-
-            foreach (var detectionPattern in detectionPatterns)
-            {
-                cancellationToken.ThrowIfCancellationRequested();
-
-                foreach (var candidatePath in Directory.EnumerateFiles(executionContext.WorkingDirectory.FullName, detectionPattern, SearchOption.TopDirectoryOnly))
-                {
-                    var candidate = new FileInfo(candidatePath);
-                    if (project.CanHandle(candidate))
-                    {
-                        candidates.TryAdd(candidate.FullName, candidate);
-                    }
-                }
-            }
-        }
+        var candidates = await projectLocator.FindAppHostProjectFilesAsync(
+            executionContext.WorkingDirectory,
+            AppHostDiscoveryScope.ExplicitDirectory,
+            maxDepth: 0,
+            cancellationToken);
 
         if (candidates.Count > 1)
         {
@@ -267,7 +250,7 @@ internal sealed class AspireVersionCheck(
             return [];
         }
 
-        return [.. candidates.Values];
+        return candidates;
     }
 
     private async Task<(bool IsAppHost, string? Version)> ResolveAppHostVersionAsync(FileInfo appHostFile, CancellationToken cancellationToken)

--- a/src/Aspire.Cli/Utils/EnvironmentChecker/AspireVersionCheck.cs
+++ b/src/Aspire.Cli/Utils/EnvironmentChecker/AspireVersionCheck.cs
@@ -32,7 +32,29 @@ internal sealed class AspireVersionCheck(
             await GetCliVersionCheckAsync(cancellationToken)
         };
 
-        var appHostVersionCheck = await GetAppHostVersionCheckAsync(cancellationToken);
+        EnvironmentCheckResult? appHostVersionCheck;
+        try
+        {
+            appHostVersionCheck = await GetAppHostVersionCheckAsync(cancellationToken);
+        }
+        catch (OperationCanceledException)
+        {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            logger.LogDebug(ex, "Failed to resolve AppHost version.");
+
+            appHostVersionCheck = new EnvironmentCheckResult
+            {
+                Category = "apphost",
+                Name = "apphost-version",
+                Status = EnvironmentCheckStatus.Warning,
+                Message = DoctorCommandStrings.AppHostVersionCheckFailedMessage,
+                Details = ex.Message
+            };
+        }
+
         if (appHostVersionCheck is not null)
         {
             results.Add(appHostVersionCheck);
@@ -133,6 +155,19 @@ internal sealed class AspireVersionCheck(
                 Details = ex.Message
             };
         }
+        catch (Exception ex)
+        {
+            logger.LogDebug(ex, "Failed to find Aspire AppHost for version check.");
+
+            return new EnvironmentCheckResult
+            {
+                Category = "apphost",
+                Name = "apphost-version",
+                Status = EnvironmentCheckStatus.Warning,
+                Message = DoctorCommandStrings.AppHostVersionCheckFailedMessage,
+                Details = ex.Message
+            };
+        }
 
         foreach (var appHostFile in appHostFiles)
         {
@@ -192,17 +227,15 @@ internal sealed class AspireVersionCheck(
     private async Task<IReadOnlyList<FileInfo>> ResolveAppHostFilesAsync(CancellationToken cancellationToken)
     {
         // Match the other doctor checks: honor a configured AppHost first without
-        // scanning, then use bounded language detection. Avoid the full project locator
-        // walk here because the AppHost version is informational and doctor should stay
-        // fast in large repositories that do not contain an AppHost.
+        // scanning, then use bounded language detection. Avoid the full project
+        // locator walk here because the AppHost version is informational and doctor
+        // should stay fast in large repositories that do not contain an AppHost.
         var configuredAppHost = await projectLocator.GetAppHostFromSettingsAsync(cancellationToken);
         if (configuredAppHost is not null)
         {
             return [configuredAppHost];
         }
 
-        // Detect only which AppHost language appears to be present within the bounded
-        // search depth, then validate matching candidates until an AppHost is found.
         var detectedLanguageId = await languageDiscovery.DetectLanguageRecursiveAsync(executionContext.WorkingDirectory, cancellationToken);
         if (detectedLanguageId is null)
         {
@@ -210,68 +243,8 @@ internal sealed class AspireVersionCheck(
         }
 
         var detectedLanguage = languageDiscovery.GetLanguageById(detectedLanguageId.Value);
-        return detectedLanguage is not null
-            ? FindAppHostCandidates(detectedLanguage, cancellationToken).ToArray()
-            : [];
-    }
-
-    private IEnumerable<FileInfo> FindAppHostCandidates(LanguageInfo language, CancellationToken cancellationToken)
-    {
-        var root = executionContext.WorkingDirectory.FullName;
-        if (!Directory.Exists(root))
-        {
-            yield break;
-        }
-
-        var dirs = new Stack<(string Path, int Depth)>();
-        dirs.Push((root, 0));
-
-        while (dirs.Count > 0)
-        {
-            cancellationToken.ThrowIfCancellationRequested();
-            var (dir, depth) = dirs.Pop();
-
-            IEnumerable<string> files;
-            try
-            {
-                files = Directory.EnumerateFiles(dir).ToArray();
-            }
-            catch (Exception ex) when (ex is DirectoryNotFoundException or IOException or UnauthorizedAccessException)
-            {
-                logger.LogDebug(ex, "Skipping directory {Directory} while finding AppHost candidates.", dir);
-                continue;
-            }
-
-            foreach (var file in files)
-            {
-                cancellationToken.ThrowIfCancellationRequested();
-                if (language.MatchesFile(Path.GetFileName(file)))
-                {
-                    yield return new FileInfo(file);
-                }
-            }
-
-            if (depth >= LanguageInfo.DetectionRecurseLimit)
-            {
-                continue;
-            }
-
-            IEnumerable<string> subdirectories;
-            try
-            {
-                subdirectories = Directory.EnumerateDirectories(dir).ToArray();
-            }
-            catch (Exception ex) when (ex is DirectoryNotFoundException or IOException or UnauthorizedAccessException)
-            {
-                logger.LogDebug(ex, "Skipping subdirectories of {Directory} while finding AppHost candidates.", dir);
-                continue;
-            }
-
-            foreach (var subdirectory in subdirectories)
-            {
-                dirs.Push((subdirectory, depth + 1));
-            }
-        }
+        var discoveredPath = detectedLanguage?.FindInDirectory(executionContext.WorkingDirectory.FullName);
+        return discoveredPath is not null ? [new FileInfo(discoveredPath)] : [];
     }
 
     private async Task<(bool IsAppHost, string? Version)> ResolveAppHostVersionAsync(FileInfo appHostFile, CancellationToken cancellationToken)

--- a/src/Aspire.Cli/Utils/EnvironmentChecker/AspireVersionCheck.cs
+++ b/src/Aspire.Cli/Utils/EnvironmentChecker/AspireVersionCheck.cs
@@ -3,6 +3,7 @@
 
 using System.Globalization;
 using System.Text.Json.Nodes;
+using Aspire.Cli.Configuration;
 using Aspire.Cli.Projects;
 using Aspire.Cli.Resources;
 using Microsoft.Extensions.Logging;
@@ -15,12 +16,13 @@ namespace Aspire.Cli.Utils.EnvironmentChecker;
 /// </summary>
 internal sealed class AspireVersionCheck(
     ICliUpdateNotifier updateNotifier,
-    IProjectLocator projectLocator,
     ILanguageDiscovery languageDiscovery,
     IAppHostProjectFactory projectFactory,
     CliExecutionContext executionContext,
     ILogger<AspireVersionCheck> logger) : IEnvironmentCheck
 {
+    private static readonly string[] s_dotNetAppHostFileNames = ["AppHost.csproj", "AppHost.fsproj", "AppHost.vbproj", "apphost.cs"];
+
     // Version checks should appear first so users immediately see which Aspire bits
     // produced the rest of the doctor output before reading environment diagnostics.
     public int Order => 0;
@@ -226,25 +228,62 @@ internal sealed class AspireVersionCheck(
 
     private async Task<IReadOnlyList<FileInfo>> ResolveAppHostFilesAsync(CancellationToken cancellationToken)
     {
-        // Match the other doctor checks: honor a configured AppHost first without
-        // scanning, then use bounded language detection. Avoid the full project
-        // locator walk here because the AppHost version is informational and doctor
-        // should stay fast in large repositories that do not contain an AppHost.
-        var configuredAppHost = await projectLocator.GetAppHostFromSettingsAsync(cancellationToken);
+        var configuredAppHost = ResolveAppHostFromCurrentDirectoryConfig();
         if (configuredAppHost is not null)
         {
             return [configuredAppHost];
         }
 
-        var detectedLanguageId = await languageDiscovery.DetectLanguageRecursiveAsync(executionContext.WorkingDirectory, cancellationToken);
-        if (detectedLanguageId is null)
+        var candidates = new List<FileInfo>();
+        var candidateFileNames = new HashSet<string>(s_dotNetAppHostFileNames, StringComparer.OrdinalIgnoreCase);
+        var languages = await languageDiscovery.GetAvailableLanguagesAsync(cancellationToken);
+        foreach (var language in languages)
         {
+            if (!string.IsNullOrWhiteSpace(language.AppHostFileName))
+            {
+                candidateFileNames.Add(language.AppHostFileName);
+            }
+        }
+
+        foreach (var candidateFileName in candidateFileNames)
+        {
+            var candidate = new FileInfo(Path.Combine(executionContext.WorkingDirectory.FullName, candidateFileName));
+            if (candidate.Exists)
+            {
+                candidates.Add(candidate);
+            }
+        }
+
+        if (candidates.Count > 1)
+        {
+            logger.LogDebug(
+                "Found multiple AppHost candidates in {WorkingDirectory}; skipping AppHost version check because no AppHost is configured.",
+                executionContext.WorkingDirectory.FullName);
             return [];
         }
 
-        var detectedLanguage = languageDiscovery.GetLanguageById(detectedLanguageId.Value);
-        var discoveredPath = detectedLanguage?.FindInDirectory(executionContext.WorkingDirectory.FullName);
-        return discoveredPath is not null ? [new FileInfo(discoveredPath)] : [];
+        return candidates;
+    }
+
+    private FileInfo? ResolveAppHostFromCurrentDirectoryConfig()
+    {
+        var config = AspireConfigFile.Load(executionContext.WorkingDirectory.FullName);
+        if (config?.AppHost?.Path is not { Length: > 0 } appHostPath)
+        {
+            return null;
+        }
+
+        var qualifiedPath = Path.IsPathRooted(appHostPath)
+            ? appHostPath
+            : Path.Combine(executionContext.WorkingDirectory.FullName, appHostPath);
+
+        var appHostFile = new FileInfo(Path.GetFullPath(qualifiedPath));
+        if (!appHostFile.Exists)
+        {
+            throw new FileNotFoundException($"AppHost path '{appHostPath}' from {AspireConfigFile.FileName} does not exist.", appHostFile.FullName);
+        }
+
+        return appHostFile;
     }
 
     private async Task<(bool IsAppHost, string? Version)> ResolveAppHostVersionAsync(FileInfo appHostFile, CancellationToken cancellationToken)

--- a/tests/Aspire.Cli.Tests/Commands/DoctorCommandTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/DoctorCommandTests.cs
@@ -372,21 +372,16 @@ public class DoctorCommandTests(ITestOutputHelper outputHelper)
     public async Task DoctorCommand_Json_PreservesCliVersionWhenAppHostDiscoveryFails()
     {
         using var workspace = TemporaryWorkspace.Create(outputHelper);
-        await File.WriteAllTextAsync(
-            Path.Combine(workspace.WorkspaceRoot.FullName, "aspire.config.json"),
-            """
-            {
-              "appHost": {
-                "path": "missing/AppHost.csproj"
-              }
-            }
-            """);
 
         var interactionService = new TestInteractionService();
         var services = CreateDoctorVersionServiceCollection(workspace, outputHelper, options =>
         {
             options.InteractionServiceFactory = _ => interactionService;
             options.CliUpdateNotifierFactory = _ => new TestCliUpdateNotifier();
+            options.ProjectLocatorFactory = _ => new TestProjectLocator
+            {
+                GetAppHostFromSettingsAsyncCallback = _ => throw new IOException("settings lookup failed")
+            };
         });
         using var provider = services.BuildServiceProvider();
 
@@ -406,7 +401,7 @@ public class DoctorCommandTests(ITestOutputHelper outputHelper)
 
         Assert.Equal("pass", cliVersionCheck.GetProperty("status").GetString());
         Assert.Equal("warning", appHostVersionCheck.GetProperty("status").GetString());
-        Assert.Contains("missing/AppHost.csproj", appHostVersionCheck.GetProperty("details").GetString());
+        Assert.Equal("settings lookup failed", appHostVersionCheck.GetProperty("details").GetString());
     }
 
     [Fact]

--- a/tests/Aspire.Cli.Tests/Commands/DoctorCommandTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/DoctorCommandTests.cs
@@ -136,6 +136,7 @@ public class DoctorCommandTests(ITestOutputHelper outputHelper)
             options.AppHostProjectFactory = _ => new TestAppHostProjectFactory
             {
                 CanHandleCallback = file => file.Extension.Equals(".ts", StringComparison.OrdinalIgnoreCase),
+                DetectionPatterns = ["apphost.ts"],
                 GetAspireHostingVersionAsyncCallback = (_, _) => Task.FromResult<string?>("13.1.0")
             };
             options.DotNetCliRunnerFactory = _ => new TestDotNetCliRunner
@@ -338,6 +339,7 @@ public class DoctorCommandTests(ITestOutputHelper outputHelper)
             options.AppHostProjectFactory = _ => new TestAppHostProjectFactory
             {
                 CanHandleCallback = file => file.Extension.Equals(".ts", StringComparison.OrdinalIgnoreCase),
+                DetectionPatterns = ["apphost.ts"],
                 GetAspireHostingVersionAsyncCallback = (_, _) =>
                     throw new InvalidOperationException("invalid aspire.config.json")
             };

--- a/tests/Aspire.Cli.Tests/Commands/DoctorCommandTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/DoctorCommandTests.cs
@@ -249,6 +249,93 @@ public class DoctorCommandTests(ITestOutputHelper outputHelper)
     }
 
     [Fact]
+    public async Task DoctorCommand_Json_ContinuesSearchingAfterNonAppHostProject()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        var projectFile = new FileInfo(Path.Combine(workspace.WorkspaceRoot.FullName, "Normal.csproj"));
+        await File.WriteAllTextAsync(projectFile.FullName, "<Project />");
+        var appHostDirectory = workspace.WorkspaceRoot.CreateSubdirectory("app");
+        var appHostFile = new FileInfo(Path.Combine(appHostDirectory.FullName, "AppHost.csproj"));
+        await File.WriteAllTextAsync(appHostFile.FullName, "<Project />");
+
+        var interactionService = new TestInteractionService();
+        var services = CreateDoctorVersionServiceCollection(workspace, outputHelper, options =>
+        {
+            options.InteractionServiceFactory = _ => interactionService;
+            options.CliUpdateNotifierFactory = _ => new TestCliUpdateNotifier();
+            options.AppHostProjectFactory = _ => new TestAppHostProjectFactory
+            {
+                ValidateAppHostCallback = file => new AppHostValidationResult(
+                    IsValid: file.Name.Equals("AppHost.csproj", StringComparison.OrdinalIgnoreCase)),
+                GetAspireHostingVersionAsyncCallback = (_, _) => Task.FromResult<string?>("13.2.0")
+            };
+        });
+        using var provider = services.BuildServiceProvider();
+
+        var command = provider.GetRequiredService<Aspire.Cli.Commands.RootCommand>();
+        var result = command.Parse("doctor --format json");
+
+        var exitCode = await result.InvokeAsync().DefaultTimeout();
+
+        Assert.Equal(ExitCodeConstants.Success, exitCode);
+
+        var (json, _) = Assert.Single(interactionService.DisplayedRawText);
+        using var document = JsonDocument.Parse(json);
+        var appHostVersionCheck = document.RootElement.GetProperty("checks").EnumerateArray()
+            .Single(check => check.GetProperty("name").GetString() == "apphost-version");
+
+        Assert.Equal("pass", appHostVersionCheck.GetProperty("status").GetString());
+        var appHostVersionMetadata = appHostVersionCheck.GetProperty("metadata");
+        Assert.Equal("13.2.0", appHostVersionMetadata.GetProperty("version").GetString());
+        Assert.Equal(
+            Path.Combine("app", "AppHost.csproj"),
+            appHostVersionMetadata.GetProperty("appHostPath").GetString());
+    }
+
+    [Fact]
+    public async Task DoctorCommand_Json_PreservesCliVersionWhenAppHostVersionResolutionFails()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        var appHostFile = new FileInfo(Path.Combine(workspace.WorkspaceRoot.FullName, "apphost.ts"));
+        await File.WriteAllTextAsync(appHostFile.FullName, "export {};");
+
+        var interactionService = new TestInteractionService();
+        var services = CreateDoctorVersionServiceCollection(workspace, outputHelper, options =>
+        {
+            options.InteractionServiceFactory = _ => interactionService;
+            options.CliUpdateNotifierFactory = _ => new TestCliUpdateNotifier();
+            options.AppHostProjectFactory = _ => new TestAppHostProjectFactory
+            {
+                CanHandleCallback = file => file.Extension.Equals(".ts", StringComparison.OrdinalIgnoreCase),
+                GetAspireHostingVersionAsyncCallback = (_, _) =>
+                    throw new InvalidOperationException("invalid aspire.config.json")
+            };
+        });
+        using var provider = services.BuildServiceProvider();
+
+        var command = provider.GetRequiredService<Aspire.Cli.Commands.RootCommand>();
+        var result = command.Parse("doctor --format json");
+
+        var exitCode = await result.InvokeAsync().DefaultTimeout();
+
+        Assert.Equal(ExitCodeConstants.Success, exitCode);
+
+        var (json, _) = Assert.Single(interactionService.DisplayedRawText);
+        using var document = JsonDocument.Parse(json);
+        var cliVersionCheck = document.RootElement.GetProperty("checks").EnumerateArray()
+            .Single(check => check.GetProperty("name").GetString() == "cli-version");
+        var appHostVersionCheck = document.RootElement.GetProperty("checks").EnumerateArray()
+            .Single(check => check.GetProperty("name").GetString() == "apphost-version");
+
+        Assert.Equal("pass", cliVersionCheck.GetProperty("status").GetString());
+        Assert.Equal("warning", appHostVersionCheck.GetProperty("status").GetString());
+        Assert.Equal("invalid aspire.config.json", appHostVersionCheck.GetProperty("details").GetString());
+        Assert.Equal(
+            "apphost.ts",
+            appHostVersionCheck.GetProperty("metadata").GetProperty("appHostPath").GetString());
+    }
+
+    [Fact]
     public async Task DoctorCommand_Json_UsesConfiguredAppHostBeyondLanguageDetectionLimit()
     {
         using var workspace = TemporaryWorkspace.Create(outputHelper);
@@ -289,7 +376,9 @@ public class DoctorCommandTests(ITestOutputHelper outputHelper)
         Assert.Contains("AppHost.csproj", appHostVersionCheck.GetProperty("message").GetString()!);
         var appHostVersionMetadata = appHostVersionCheck.GetProperty("metadata");
         Assert.Equal("13.2.0", appHostVersionMetadata.GetProperty("version").GetString());
-        Assert.Equal("level0/level1/level2/level3/level4/level5/AppHost.csproj", appHostVersionMetadata.GetProperty("appHostPath").GetString());
+        Assert.Equal(
+            Path.Combine("level0", "level1", "level2", "level3", "level4", "level5", "AppHost.csproj"),
+            appHostVersionMetadata.GetProperty("appHostPath").GetString());
     }
 
     private static IServiceCollection CreateDoctorVersionServiceCollection(

--- a/tests/Aspire.Cli.Tests/Commands/DoctorCommandTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/DoctorCommandTests.cs
@@ -1,7 +1,12 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Text.Json;
+using Aspire.Cli.Interaction;
+using Aspire.Cli.Projects;
+using Aspire.Cli.Tests.TestServices;
 using Aspire.Cli.Tests.Utils;
+using Aspire.Cli.Utils;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.AspNetCore.InternalTesting;
 
@@ -23,5 +28,276 @@ public class DoctorCommandTests(ITestOutputHelper outputHelper)
         
         // Help should return success
         Assert.Equal(ExitCodeConstants.Success, exitCode);
+    }
+
+    [Fact]
+    public async Task DoctorCommand_Json_IncludesCliVersionStatus()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        var interactionService = new TestInteractionService();
+        var updateNotifier = new TestCliUpdateNotifier
+        {
+            GetVersionStatusAsyncCallback = (_, _) => Task.FromResult(new CliVersionStatus("13.0.0", "13.1.0", "aspire update"))
+        };
+        var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper, options =>
+        {
+            options.InteractionServiceFactory = _ => interactionService;
+            options.CliUpdateNotifierFactory = _ => updateNotifier;
+        });
+        using var provider = services.BuildServiceProvider();
+
+        var command = provider.GetRequiredService<Aspire.Cli.Commands.RootCommand>();
+        var result = command.Parse("doctor --format json");
+
+        var exitCode = await result.InvokeAsync().DefaultTimeout();
+
+        Assert.Equal(ExitCodeConstants.Success, exitCode);
+
+        var (json, console) = Assert.Single(interactionService.DisplayedRawText);
+        Assert.Equal(ConsoleOutput.Standard, console);
+        using var document = JsonDocument.Parse(json);
+        var cliVersionCheck = document.RootElement.GetProperty("checks").EnumerateArray()
+            .Single(check => check.GetProperty("name").GetString() == "cli-version");
+
+        Assert.Equal("aspire", cliVersionCheck.GetProperty("category").GetString());
+        Assert.Equal("warning", cliVersionCheck.GetProperty("status").GetString());
+        Assert.Contains("13.0.0", cliVersionCheck.GetProperty("message").GetString()!);
+        Assert.Contains("13.1.0", cliVersionCheck.GetProperty("message").GetString()!);
+        var cliVersionMetadata = cliVersionCheck.GetProperty("metadata");
+        Assert.Equal("13.0.0", cliVersionMetadata.GetProperty("currentVersion").GetString());
+        Assert.Equal("13.1.0", cliVersionMetadata.GetProperty("latestVersion").GetString());
+        Assert.Equal("aspire update", cliVersionMetadata.GetProperty("updateCommand").GetString());
+    }
+
+    [Fact]
+    public async Task DoctorCommand_Json_IncludesAppHostVersionWhenAppHostExists()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        var appHostFile = new FileInfo(Path.Combine(workspace.WorkspaceRoot.FullName, "AppHost.csproj"));
+        await File.WriteAllTextAsync(appHostFile.FullName, "<Project />");
+
+        var interactionService = new TestInteractionService();
+        var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper, options =>
+        {
+            options.InteractionServiceFactory = _ => interactionService;
+            options.CliUpdateNotifierFactory = _ => new TestCliUpdateNotifier();
+            options.AppHostProjectFactory = _ => new TestAppHostProjectFactory
+            {
+                GetAspireHostingVersionAsyncCallback = (_, _) => Task.FromResult<string?>("13.0.0")
+            };
+        });
+        using var provider = services.BuildServiceProvider();
+
+        var command = provider.GetRequiredService<Aspire.Cli.Commands.RootCommand>();
+        var result = command.Parse("doctor --format json");
+
+        var exitCode = await result.InvokeAsync().DefaultTimeout();
+
+        Assert.Equal(ExitCodeConstants.Success, exitCode);
+
+        var (json, _) = Assert.Single(interactionService.DisplayedRawText);
+        using var document = JsonDocument.Parse(json);
+        var appHostVersionCheck = document.RootElement.GetProperty("checks").EnumerateArray()
+            .Single(check => check.GetProperty("name").GetString() == "apphost-version");
+
+        Assert.Equal("apphost", appHostVersionCheck.GetProperty("category").GetString());
+        Assert.Equal("pass", appHostVersionCheck.GetProperty("status").GetString());
+        Assert.Contains("13.0.0", appHostVersionCheck.GetProperty("message").GetString()!);
+        Assert.Contains("AppHost.csproj", appHostVersionCheck.GetProperty("message").GetString()!);
+        var appHostVersionMetadata = appHostVersionCheck.GetProperty("metadata");
+        Assert.Equal("13.0.0", appHostVersionMetadata.GetProperty("version").GetString());
+        Assert.Equal("AppHost.csproj", appHostVersionMetadata.GetProperty("appHostPath").GetString());
+    }
+
+    [Fact]
+    public async Task DoctorCommand_Json_IncludesTypeScriptAppHostVersionFromAspireConfig()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        var appHostFile = new FileInfo(Path.Combine(workspace.WorkspaceRoot.FullName, "apphost.ts"));
+        await File.WriteAllTextAsync(appHostFile.FullName, "export {};");
+        await File.WriteAllTextAsync(
+            Path.Combine(workspace.WorkspaceRoot.FullName, "aspire.config.json"),
+            """
+            {
+              "sdk": {
+                "version": "13.1.0"
+              }
+            }
+            """);
+
+        var interactionService = new TestInteractionService();
+        var runnerCalled = false;
+        var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper, options =>
+        {
+            options.InteractionServiceFactory = _ => interactionService;
+            options.CliUpdateNotifierFactory = _ => new TestCliUpdateNotifier();
+            options.AppHostProjectFactory = _ => new TestAppHostProjectFactory
+            {
+                CanHandleCallback = file => file.Extension.Equals(".ts", StringComparison.OrdinalIgnoreCase),
+                GetAspireHostingVersionAsyncCallback = (_, _) => Task.FromResult<string?>("13.1.0")
+            };
+            options.DotNetCliRunnerFactory = _ => new TestDotNetCliRunner
+            {
+                GetAppHostInformationAsyncCallback = (_, _, _) =>
+                {
+                    runnerCalled = true;
+                    return (0, true, "unexpected");
+                }
+            };
+        });
+        using var provider = services.BuildServiceProvider();
+
+        var command = provider.GetRequiredService<Aspire.Cli.Commands.RootCommand>();
+        var result = command.Parse("doctor --format json");
+
+        var exitCode = await result.InvokeAsync().DefaultTimeout();
+
+        Assert.Equal(ExitCodeConstants.Success, exitCode);
+        Assert.False(runnerCalled);
+
+        var (json, _) = Assert.Single(interactionService.DisplayedRawText);
+        using var document = JsonDocument.Parse(json);
+        var appHostVersionCheck = document.RootElement.GetProperty("checks").EnumerateArray()
+            .Single(check => check.GetProperty("name").GetString() == "apphost-version");
+
+        Assert.Equal("apphost", appHostVersionCheck.GetProperty("category").GetString());
+        Assert.Equal("pass", appHostVersionCheck.GetProperty("status").GetString());
+        Assert.Contains("13.1.0", appHostVersionCheck.GetProperty("message").GetString()!);
+        Assert.Contains("apphost.ts", appHostVersionCheck.GetProperty("message").GetString()!);
+        var appHostVersionMetadata = appHostVersionCheck.GetProperty("metadata");
+        Assert.Equal("13.1.0", appHostVersionMetadata.GetProperty("version").GetString());
+        Assert.Equal("apphost.ts", appHostVersionMetadata.GetProperty("appHostPath").GetString());
+    }
+
+    [Fact]
+    public async Task DoctorCommand_Json_DoesNotScanBeyondLanguageDetectionLimitForAppHostVersion()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        var appHostFile = CreateDeepAppHostFile(workspace, depth: LanguageInfo.DetectionRecurseLimit + 1);
+        await File.WriteAllTextAsync(appHostFile.FullName, "<Project />");
+
+        var interactionService = new TestInteractionService();
+        var versionLookupCalled = false;
+        var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper, options =>
+        {
+            options.InteractionServiceFactory = _ => interactionService;
+            options.CliUpdateNotifierFactory = _ => new TestCliUpdateNotifier();
+            options.AppHostProjectFactory = _ => new TestAppHostProjectFactory
+            {
+                GetAspireHostingVersionAsyncCallback = (_, _) =>
+                {
+                    versionLookupCalled = true;
+                    return Task.FromResult<string?>("unexpected");
+                }
+            };
+        });
+        using var provider = services.BuildServiceProvider();
+
+        var command = provider.GetRequiredService<Aspire.Cli.Commands.RootCommand>();
+        var result = command.Parse("doctor --format json");
+
+        var exitCode = await result.InvokeAsync().DefaultTimeout();
+
+        Assert.Equal(ExitCodeConstants.Success, exitCode);
+        Assert.False(versionLookupCalled);
+
+        var (json, _) = Assert.Single(interactionService.DisplayedRawText);
+        using var document = JsonDocument.Parse(json);
+        Assert.DoesNotContain(document.RootElement.GetProperty("checks").EnumerateArray(),
+            check => check.GetProperty("name").GetString() == "apphost-version");
+    }
+
+    [Fact]
+    public async Task DoctorCommand_Json_DoesNotShowAppHostVersionForNonAppHostProject()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        var projectFile = new FileInfo(Path.Combine(workspace.WorkspaceRoot.FullName, "Normal.csproj"));
+        await File.WriteAllTextAsync(projectFile.FullName, "<Project />");
+
+        var interactionService = new TestInteractionService();
+        var versionLookupCalled = false;
+        var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper, options =>
+        {
+            options.InteractionServiceFactory = _ => interactionService;
+            options.CliUpdateNotifierFactory = _ => new TestCliUpdateNotifier();
+            options.AppHostProjectFactory = _ => new TestAppHostProjectFactory
+            {
+                ValidateAppHostCallback = _ => new AppHostValidationResult(IsValid: false),
+                GetAspireHostingVersionAsyncCallback = (_, _) =>
+                {
+                    versionLookupCalled = true;
+                    return Task.FromResult<string?>("unexpected");
+                }
+            };
+        });
+        using var provider = services.BuildServiceProvider();
+
+        var command = provider.GetRequiredService<Aspire.Cli.Commands.RootCommand>();
+        var result = command.Parse("doctor --format json");
+
+        var exitCode = await result.InvokeAsync().DefaultTimeout();
+
+        Assert.Equal(ExitCodeConstants.Success, exitCode);
+        Assert.False(versionLookupCalled);
+
+        var (json, _) = Assert.Single(interactionService.DisplayedRawText);
+        using var document = JsonDocument.Parse(json);
+        Assert.DoesNotContain(document.RootElement.GetProperty("checks").EnumerateArray(),
+            check => check.GetProperty("name").GetString() == "apphost-version");
+    }
+
+    [Fact]
+    public async Task DoctorCommand_Json_UsesConfiguredAppHostBeyondLanguageDetectionLimit()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        var appHostFile = CreateDeepAppHostFile(workspace, depth: LanguageInfo.DetectionRecurseLimit + 1);
+        await File.WriteAllTextAsync(appHostFile.FullName, "<Project />");
+
+        var interactionService = new TestInteractionService();
+        var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper, options =>
+        {
+            options.InteractionServiceFactory = _ => interactionService;
+            options.CliUpdateNotifierFactory = _ => new TestCliUpdateNotifier();
+            options.ProjectLocatorFactory = _ => new TestProjectLocator
+            {
+                GetAppHostFromSettingsAsyncCallback = _ => Task.FromResult<FileInfo?>(appHostFile)
+            };
+            options.AppHostProjectFactory = _ => new TestAppHostProjectFactory
+            {
+                GetAspireHostingVersionAsyncCallback = (_, _) => Task.FromResult<string?>("13.2.0")
+            };
+        });
+        using var provider = services.BuildServiceProvider();
+
+        var command = provider.GetRequiredService<Aspire.Cli.Commands.RootCommand>();
+        var result = command.Parse("doctor --format json");
+
+        var exitCode = await result.InvokeAsync().DefaultTimeout();
+
+        Assert.Equal(ExitCodeConstants.Success, exitCode);
+
+        var (json, _) = Assert.Single(interactionService.DisplayedRawText);
+        using var document = JsonDocument.Parse(json);
+        var appHostVersionCheck = document.RootElement.GetProperty("checks").EnumerateArray()
+            .Single(check => check.GetProperty("name").GetString() == "apphost-version");
+
+        Assert.Equal("apphost", appHostVersionCheck.GetProperty("category").GetString());
+        Assert.Equal("pass", appHostVersionCheck.GetProperty("status").GetString());
+        Assert.Contains("13.2.0", appHostVersionCheck.GetProperty("message").GetString()!);
+        Assert.Contains("AppHost.csproj", appHostVersionCheck.GetProperty("message").GetString()!);
+        var appHostVersionMetadata = appHostVersionCheck.GetProperty("metadata");
+        Assert.Equal("13.2.0", appHostVersionMetadata.GetProperty("version").GetString());
+        Assert.Equal("level0/level1/level2/level3/level4/level5/AppHost.csproj", appHostVersionMetadata.GetProperty("appHostPath").GetString());
+    }
+
+    private static FileInfo CreateDeepAppHostFile(TemporaryWorkspace workspace, int depth)
+    {
+        var directory = workspace.WorkspaceRoot;
+        for (var i = 0; i < depth; i++)
+        {
+            directory = directory.CreateSubdirectory($"level{i}");
+        }
+
+        return new FileInfo(Path.Combine(directory.FullName, "AppHost.csproj"));
     }
 }

--- a/tests/Aspire.Cli.Tests/Commands/DoctorCommandTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/DoctorCommandTests.cs
@@ -7,7 +7,9 @@ using Aspire.Cli.Projects;
 using Aspire.Cli.Tests.TestServices;
 using Aspire.Cli.Tests.Utils;
 using Aspire.Cli.Utils;
+using Aspire.Cli.Utils.EnvironmentChecker;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.AspNetCore.InternalTesting;
 
 namespace Aspire.Cli.Tests.Commands;
@@ -39,7 +41,7 @@ public class DoctorCommandTests(ITestOutputHelper outputHelper)
         {
             GetVersionStatusAsyncCallback = (_, _) => Task.FromResult(new CliVersionStatus("13.0.0", "13.1.0", "aspire update"))
         };
-        var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper, options =>
+        var services = CreateDoctorVersionServiceCollection(workspace, outputHelper, options =>
         {
             options.InteractionServiceFactory = _ => interactionService;
             options.CliUpdateNotifierFactory = _ => updateNotifier;
@@ -77,7 +79,7 @@ public class DoctorCommandTests(ITestOutputHelper outputHelper)
         await File.WriteAllTextAsync(appHostFile.FullName, "<Project />");
 
         var interactionService = new TestInteractionService();
-        var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper, options =>
+        var services = CreateDoctorVersionServiceCollection(workspace, outputHelper, options =>
         {
             options.InteractionServiceFactory = _ => interactionService;
             options.CliUpdateNotifierFactory = _ => new TestCliUpdateNotifier();
@@ -127,7 +129,7 @@ public class DoctorCommandTests(ITestOutputHelper outputHelper)
 
         var interactionService = new TestInteractionService();
         var runnerCalled = false;
-        var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper, options =>
+        var services = CreateDoctorVersionServiceCollection(workspace, outputHelper, options =>
         {
             options.InteractionServiceFactory = _ => interactionService;
             options.CliUpdateNotifierFactory = _ => new TestCliUpdateNotifier();
@@ -178,7 +180,7 @@ public class DoctorCommandTests(ITestOutputHelper outputHelper)
 
         var interactionService = new TestInteractionService();
         var versionLookupCalled = false;
-        var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper, options =>
+        var services = CreateDoctorVersionServiceCollection(workspace, outputHelper, options =>
         {
             options.InteractionServiceFactory = _ => interactionService;
             options.CliUpdateNotifierFactory = _ => new TestCliUpdateNotifier();
@@ -216,7 +218,7 @@ public class DoctorCommandTests(ITestOutputHelper outputHelper)
 
         var interactionService = new TestInteractionService();
         var versionLookupCalled = false;
-        var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper, options =>
+        var services = CreateDoctorVersionServiceCollection(workspace, outputHelper, options =>
         {
             options.InteractionServiceFactory = _ => interactionService;
             options.CliUpdateNotifierFactory = _ => new TestCliUpdateNotifier();
@@ -254,7 +256,7 @@ public class DoctorCommandTests(ITestOutputHelper outputHelper)
         await File.WriteAllTextAsync(appHostFile.FullName, "<Project />");
 
         var interactionService = new TestInteractionService();
-        var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper, options =>
+        var services = CreateDoctorVersionServiceCollection(workspace, outputHelper, options =>
         {
             options.InteractionServiceFactory = _ => interactionService;
             options.CliUpdateNotifierFactory = _ => new TestCliUpdateNotifier();
@@ -288,6 +290,17 @@ public class DoctorCommandTests(ITestOutputHelper outputHelper)
         var appHostVersionMetadata = appHostVersionCheck.GetProperty("metadata");
         Assert.Equal("13.2.0", appHostVersionMetadata.GetProperty("version").GetString());
         Assert.Equal("level0/level1/level2/level3/level4/level5/AppHost.csproj", appHostVersionMetadata.GetProperty("appHostPath").GetString());
+    }
+
+    private static IServiceCollection CreateDoctorVersionServiceCollection(
+        TemporaryWorkspace workspace,
+        ITestOutputHelper outputHelper,
+        Action<CliServiceCollectionTestOptions>? configure)
+    {
+        var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper, configure);
+        services.RemoveAll<IEnvironmentCheck>();
+        services.AddSingleton<IEnvironmentCheck, AspireVersionCheck>();
+        return services;
     }
 
     private static FileInfo CreateDeepAppHostFile(TemporaryWorkspace workspace, int depth)

--- a/tests/Aspire.Cli.Tests/Commands/DoctorCommandTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/DoctorCommandTests.cs
@@ -249,7 +249,7 @@ public class DoctorCommandTests(ITestOutputHelper outputHelper)
     }
 
     [Fact]
-    public async Task DoctorCommand_Json_ContinuesSearchingAfterNonAppHostProject()
+    public async Task DoctorCommand_Json_DoesNotContinueSearchingAfterFirstNonAppHostProject()
     {
         using var workspace = TemporaryWorkspace.Create(outputHelper);
         var projectFile = new FileInfo(Path.Combine(workspace.WorkspaceRoot.FullName, "Normal.csproj"));
@@ -281,15 +281,8 @@ public class DoctorCommandTests(ITestOutputHelper outputHelper)
 
         var (json, _) = Assert.Single(interactionService.DisplayedRawText);
         using var document = JsonDocument.Parse(json);
-        var appHostVersionCheck = document.RootElement.GetProperty("checks").EnumerateArray()
-            .Single(check => check.GetProperty("name").GetString() == "apphost-version");
-
-        Assert.Equal("pass", appHostVersionCheck.GetProperty("status").GetString());
-        var appHostVersionMetadata = appHostVersionCheck.GetProperty("metadata");
-        Assert.Equal("13.2.0", appHostVersionMetadata.GetProperty("version").GetString());
-        Assert.Equal(
-            Path.Combine("app", "AppHost.csproj"),
-            appHostVersionMetadata.GetProperty("appHostPath").GetString());
+        Assert.DoesNotContain(document.RootElement.GetProperty("checks").EnumerateArray(),
+            check => check.GetProperty("name").GetString() == "apphost-version");
     }
 
     [Fact]
@@ -333,6 +326,44 @@ public class DoctorCommandTests(ITestOutputHelper outputHelper)
         Assert.Equal(
             "apphost.ts",
             appHostVersionCheck.GetProperty("metadata").GetProperty("appHostPath").GetString());
+    }
+
+    [Fact]
+    public async Task DoctorCommand_Json_PreservesCliVersionWhenAppHostDiscoveryFails()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+
+        var interactionService = new TestInteractionService();
+        var services = CreateDoctorVersionServiceCollection(workspace, outputHelper, options =>
+        {
+            options.InteractionServiceFactory = _ => interactionService;
+            options.CliUpdateNotifierFactory = _ => new TestCliUpdateNotifier();
+        });
+        services.RemoveAll<ILanguageDiscovery>();
+        services.AddSingleton<ILanguageDiscovery>(new TestLanguageDiscovery
+        {
+            DetectLanguageRecursiveAsyncCallback = (_, _) =>
+                throw new IOException("language discovery failed")
+        });
+        using var provider = services.BuildServiceProvider();
+
+        var command = provider.GetRequiredService<Aspire.Cli.Commands.RootCommand>();
+        var result = command.Parse("doctor --format json");
+
+        var exitCode = await result.InvokeAsync().DefaultTimeout();
+
+        Assert.Equal(ExitCodeConstants.Success, exitCode);
+
+        var (json, _) = Assert.Single(interactionService.DisplayedRawText);
+        using var document = JsonDocument.Parse(json);
+        var cliVersionCheck = document.RootElement.GetProperty("checks").EnumerateArray()
+            .Single(check => check.GetProperty("name").GetString() == "cli-version");
+        var appHostVersionCheck = document.RootElement.GetProperty("checks").EnumerateArray()
+            .Single(check => check.GetProperty("name").GetString() == "apphost-version");
+
+        Assert.Equal("pass", cliVersionCheck.GetProperty("status").GetString());
+        Assert.Equal("warning", appHostVersionCheck.GetProperty("status").GetString());
+        Assert.Equal("language discovery failed", appHostVersionCheck.GetProperty("details").GetString());
     }
 
     [Fact]

--- a/tests/Aspire.Cli.Tests/Commands/DoctorCommandTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/DoctorCommandTests.cs
@@ -172,7 +172,7 @@ public class DoctorCommandTests(ITestOutputHelper outputHelper)
     }
 
     [Fact]
-    public async Task DoctorCommand_Json_DoesNotScanBeyondLanguageDetectionLimitForAppHostVersion()
+    public async Task DoctorCommand_Json_DoesNotDiscoverNestedAppHostWithoutConfig()
     {
         using var workspace = TemporaryWorkspace.Create(outputHelper);
         var appHostFile = CreateDeepAppHostFile(workspace, depth: LanguageInfo.DetectionRecurseLimit + 1);
@@ -249,7 +249,7 @@ public class DoctorCommandTests(ITestOutputHelper outputHelper)
     }
 
     [Fact]
-    public async Task DoctorCommand_Json_DoesNotContinueSearchingAfterFirstNonAppHostProject()
+    public async Task DoctorCommand_Json_DoesNotDiscoverNestedAppHostWhenAnotherProjectExists()
     {
         using var workspace = TemporaryWorkspace.Create(outputHelper);
         var projectFile = new FileInfo(Path.Combine(workspace.WorkspaceRoot.FullName, "Normal.csproj"));
@@ -278,6 +278,44 @@ public class DoctorCommandTests(ITestOutputHelper outputHelper)
         var exitCode = await result.InvokeAsync().DefaultTimeout();
 
         Assert.Equal(ExitCodeConstants.Success, exitCode);
+
+        var (json, _) = Assert.Single(interactionService.DisplayedRawText);
+        using var document = JsonDocument.Parse(json);
+        Assert.DoesNotContain(document.RootElement.GetProperty("checks").EnumerateArray(),
+            check => check.GetProperty("name").GetString() == "apphost-version");
+    }
+
+    [Fact]
+    public async Task DoctorCommand_Json_DoesNotChooseBetweenMultipleDirectAppHostsWithoutConfig()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        await File.WriteAllTextAsync(Path.Combine(workspace.WorkspaceRoot.FullName, "AppHost.csproj"), "<Project />");
+        await File.WriteAllTextAsync(Path.Combine(workspace.WorkspaceRoot.FullName, "AppHost.fsproj"), "<Project />");
+
+        var interactionService = new TestInteractionService();
+        var versionLookupCalled = false;
+        var services = CreateDoctorVersionServiceCollection(workspace, outputHelper, options =>
+        {
+            options.InteractionServiceFactory = _ => interactionService;
+            options.CliUpdateNotifierFactory = _ => new TestCliUpdateNotifier();
+            options.AppHostProjectFactory = _ => new TestAppHostProjectFactory
+            {
+                GetAspireHostingVersionAsyncCallback = (_, _) =>
+                {
+                    versionLookupCalled = true;
+                    return Task.FromResult<string?>("unexpected");
+                }
+            };
+        });
+        using var provider = services.BuildServiceProvider();
+
+        var command = provider.GetRequiredService<Aspire.Cli.Commands.RootCommand>();
+        var result = command.Parse("doctor --format json");
+
+        var exitCode = await result.InvokeAsync().DefaultTimeout();
+
+        Assert.Equal(ExitCodeConstants.Success, exitCode);
+        Assert.False(versionLookupCalled);
 
         var (json, _) = Assert.Single(interactionService.DisplayedRawText);
         using var document = JsonDocument.Parse(json);
@@ -332,18 +370,21 @@ public class DoctorCommandTests(ITestOutputHelper outputHelper)
     public async Task DoctorCommand_Json_PreservesCliVersionWhenAppHostDiscoveryFails()
     {
         using var workspace = TemporaryWorkspace.Create(outputHelper);
+        await File.WriteAllTextAsync(
+            Path.Combine(workspace.WorkspaceRoot.FullName, "aspire.config.json"),
+            """
+            {
+              "appHost": {
+                "path": "missing/AppHost.csproj"
+              }
+            }
+            """);
 
         var interactionService = new TestInteractionService();
         var services = CreateDoctorVersionServiceCollection(workspace, outputHelper, options =>
         {
             options.InteractionServiceFactory = _ => interactionService;
             options.CliUpdateNotifierFactory = _ => new TestCliUpdateNotifier();
-        });
-        services.RemoveAll<ILanguageDiscovery>();
-        services.AddSingleton<ILanguageDiscovery>(new TestLanguageDiscovery
-        {
-            DetectLanguageRecursiveAsyncCallback = (_, _) =>
-                throw new IOException("language discovery failed")
         });
         using var provider = services.BuildServiceProvider();
 
@@ -363,7 +404,7 @@ public class DoctorCommandTests(ITestOutputHelper outputHelper)
 
         Assert.Equal("pass", cliVersionCheck.GetProperty("status").GetString());
         Assert.Equal("warning", appHostVersionCheck.GetProperty("status").GetString());
-        Assert.Equal("language discovery failed", appHostVersionCheck.GetProperty("details").GetString());
+        Assert.Contains("missing/AppHost.csproj", appHostVersionCheck.GetProperty("details").GetString());
     }
 
     [Fact]
@@ -372,16 +413,21 @@ public class DoctorCommandTests(ITestOutputHelper outputHelper)
         using var workspace = TemporaryWorkspace.Create(outputHelper);
         var appHostFile = CreateDeepAppHostFile(workspace, depth: LanguageInfo.DetectionRecurseLimit + 1);
         await File.WriteAllTextAsync(appHostFile.FullName, "<Project />");
+        await File.WriteAllTextAsync(
+            Path.Combine(workspace.WorkspaceRoot.FullName, "aspire.config.json"),
+            $$"""
+            {
+              "appHost": {
+                "path": "{{Path.GetRelativePath(workspace.WorkspaceRoot.FullName, appHostFile.FullName).Replace('\\', '/')}}"
+              }
+            }
+            """);
 
         var interactionService = new TestInteractionService();
         var services = CreateDoctorVersionServiceCollection(workspace, outputHelper, options =>
         {
             options.InteractionServiceFactory = _ => interactionService;
             options.CliUpdateNotifierFactory = _ => new TestCliUpdateNotifier();
-            options.ProjectLocatorFactory = _ => new TestProjectLocator
-            {
-                GetAppHostFromSettingsAsyncCallback = _ => Task.FromResult<FileInfo?>(appHostFile)
-            };
             options.AppHostProjectFactory = _ => new TestAppHostProjectFactory
             {
                 GetAspireHostingVersionAsyncCallback = (_, _) => Task.FromResult<string?>("13.2.0")

--- a/tests/Aspire.Cli.Tests/Commands/SecretCommandTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/SecretCommandTests.cs
@@ -128,5 +128,6 @@ public class SecretCommandTests(ITestOutputHelper outputHelper)
         public Task<int> RunAsync(AppHostProjectContext context, CancellationToken cancellationToken) => throw new NotSupportedException();
         public Task<UpdatePackagesResult> UpdatePackagesAsync(UpdatePackagesContext context, CancellationToken cancellationToken) => throw new NotSupportedException();
         public Task<AppHostValidationResult> ValidateAppHostAsync(FileInfo appHostFile, CancellationToken cancellationToken) => throw new NotSupportedException();
+        public Task<string?> GetAspireHostingVersionAsync(FileInfo appHostFile, CancellationToken cancellationToken) => throw new NotSupportedException();
     }
 }

--- a/tests/Aspire.Cli.Tests/Projects/AppHostCandidateFinderTests.cs
+++ b/tests/Aspire.Cli.Tests/Projects/AppHostCandidateFinderTests.cs
@@ -339,6 +339,53 @@ public class AppHostCandidateFinderTests(ITestOutputHelper outputHelper)
     }
 
     [Fact]
+    public async Task FindCandidateFilesAsync_MaxDepthZero_MatchesOnlySearchDirectoryFiles()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        var directAppHost = await WriteFileAsync(workspace.WorkspaceRoot, "AppHost.csproj");
+        var nestedAppHost = await WriteFileAsync(workspace.WorkspaceRoot, "App/AppHost.csproj");
+        var finder = CreateFinder();
+
+        var result = await finder.FindCandidateFilesAsync(workspace.WorkspaceRoot, ["AppHost.csproj"], nugetCachePath: null, AppHostDiscoveryScope.ExplicitDirectory, CancellationToken.None, maxDepth: 0).DefaultTimeout();
+
+        var path = Assert.Single(result.Files).FullName;
+        Assert.Equal(directAppHost.FullName, path);
+        Assert.DoesNotContain(result.Files, file => file.FullName == nestedAppHost.FullName);
+        Assert.Equal(1, result.CountsByPattern["AppHost.csproj"]);
+    }
+
+    [Fact]
+    public async Task FindCandidateFilesAsync_MaxDepthZero_DoesNotMatchDirectoryAwarePatternsBelowSearchDirectory()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        var nestedAppHost = await WriteFileAsync(workspace.WorkspaceRoot, "App/AppHost.csproj");
+        var finder = CreateFinder();
+
+        var result = await finder.FindCandidateFilesAsync(workspace.WorkspaceRoot, ["App/AppHost.csproj"], nugetCachePath: null, AppHostDiscoveryScope.ExplicitDirectory, CancellationToken.None, maxDepth: 0).DefaultTimeout();
+
+        Assert.Empty(result.Files);
+        Assert.DoesNotContain(result.Files, file => file.FullName == nestedAppHost.FullName);
+        Assert.Equal(0, result.CountsByPattern["App/AppHost.csproj"]);
+    }
+
+    [Fact]
+    public async Task FindCandidateFilesAsync_DefaultFilteredGitMode_MaxDepthZero_MatchesOnlySearchDirectoryFiles()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        var directAppHost = await WriteFileAsync(workspace.WorkspaceRoot, "AppHost.csproj");
+        var nestedAppHost = await WriteFileAsync(workspace.WorkspaceRoot, "App/AppHost.csproj");
+        var gitRepository = CreateGitRepository(directAppHost.FullName, nestedAppHost.FullName);
+        var finder = CreateFinder(gitRepository);
+
+        var result = await finder.FindCandidateFilesAsync(workspace.WorkspaceRoot, ["AppHost.csproj"], nugetCachePath: null, AppHostDiscoveryScope.DefaultFiltered, CancellationToken.None, maxDepth: 0).DefaultTimeout();
+
+        var path = Assert.Single(result.Files).FullName;
+        Assert.Equal(directAppHost.FullName, path);
+        Assert.DoesNotContain(result.Files, file => file.FullName == nestedAppHost.FullName);
+        Assert.Equal(1, result.CountsByPattern["AppHost.csproj"]);
+    }
+
+    [Fact]
     public async Task FindCandidateFilesAsync_ReturnsUniqueFilesAndCountsEveryPattern()
     {
         using var workspace = TemporaryWorkspace.Create(outputHelper);

--- a/tests/Aspire.Cli.Tests/Projects/ProjectLocatorTests.cs
+++ b/tests/Aspire.Cli.Tests/Projects/ProjectLocatorTests.cs
@@ -8,6 +8,7 @@ using Aspire.Cli.DotNet;
 using Aspire.Cli.Git;
 using Aspire.Cli.Interaction;
 using Aspire.Cli.Projects;
+using Aspire.Cli.Utils;
 using Aspire.Cli.Resources;
 using Aspire.Cli.Telemetry;
 using Aspire.Cli.Tests.Telemetry;
@@ -1144,6 +1145,9 @@ builder.Build().Run();");
 
             public Task<AppHostValidationResult> ValidateAppHostAsync(FileInfo appHostFile, CancellationToken cancellationToken)
                 => Task.FromResult(new AppHostValidationResult(IsValid: appHostFile.Name.Equals(supportedFileName, StringComparison.OrdinalIgnoreCase)));
+
+            public Task<string?> GetAspireHostingVersionAsync(FileInfo appHostFile, CancellationToken cancellationToken)
+                => Task.FromResult<string?>(VersionHelper.GetDefaultTemplateVersion());
 
             public Task<bool> AddPackageAsync(AddPackageContext context, CancellationToken cancellationToken)
                 => throw new NotImplementedException();

--- a/tests/Aspire.Cli.Tests/TestServices/TestAppHostProjectFactory.cs
+++ b/tests/Aspire.Cli.Tests/TestServices/TestAppHostProjectFactory.cs
@@ -34,6 +34,11 @@ internal sealed class TestAppHostProjectFactory : IAppHostProjectFactory
     /// </summary>
     public Func<FileInfo, CancellationToken, Task<AppHostValidationResult>>? ValidateAppHostAsyncCallback { get; set; }
 
+    /// <summary>
+    /// Optional detection patterns to advertise from the test project.
+    /// </summary>
+    public string[]? DetectionPatterns { get; set; }
+
     public TestAppHostProjectFactory()
     {
         _testProject = new TestAppHostProject(this);
@@ -145,10 +150,15 @@ internal sealed class TestAppHostProjectFactory : IAppHostProjectFactory
         }
 
         public Task<string[]> GetDetectionPatternsAsync(CancellationToken cancellationToken)
-            => Task.FromResult(s_detectionPatterns);
+            => Task.FromResult(_factory.DetectionPatterns ?? s_detectionPatterns);
 
         public bool CanHandle(FileInfo appHostFile)
         {
+            if (_factory.CanHandleCallback?.Invoke(appHostFile) == true)
+            {
+                return true;
+            }
+
             var extension = appHostFile.Extension.ToLowerInvariant();
             if (extension is ".csproj" or ".fsproj" or ".vbproj")
             {

--- a/tests/Aspire.Cli.Tests/TestServices/TestAppHostProjectFactory.cs
+++ b/tests/Aspire.Cli.Tests/TestServices/TestAppHostProjectFactory.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using Aspire.Cli.Projects;
+using Aspire.Cli.Utils;
 
 namespace Aspire.Cli.Tests.TestServices;
 
@@ -17,6 +18,16 @@ internal sealed class TestAppHostProjectFactory : IAppHostProjectFactory
     /// Optional callback to control validation behavior. If not set, all valid project files are considered valid AppHosts.
     /// </summary>
     public Func<FileInfo, AppHostValidationResult>? ValidateAppHostCallback { get; set; }
+
+    /// <summary>
+    /// Optional callback for tests that need this factory to handle non-.NET AppHost file names.
+    /// </summary>
+    public Func<FileInfo, bool>? CanHandleCallback { get; set; }
+
+    /// <summary>
+    /// Optional callback to control AppHost version resolution behavior.
+    /// </summary>
+    public Func<FileInfo, CancellationToken, Task<string?>>? GetAspireHostingVersionAsyncCallback { get; set; }
 
     /// <summary>
     /// Optional async callback to control validation behavior.
@@ -41,6 +52,11 @@ internal sealed class TestAppHostProjectFactory : IAppHostProjectFactory
 
     public IAppHostProject? TryGetProject(FileInfo appHostFile)
     {
+        if (CanHandleCallback?.Invoke(appHostFile) == true)
+        {
+            return _testProject;
+        }
+
         // Handle .csproj, .fsproj, .vbproj files
         if (s_projectExtensions.Contains(appHostFile.Extension))
         {
@@ -181,6 +197,13 @@ internal sealed class TestAppHostProjectFactory : IAppHostProjectFactory
             }
 
             return Task.FromResult(new AppHostValidationResult(IsValid: true));
+        }
+
+        public Task<string?> GetAspireHostingVersionAsync(FileInfo appHostFile, CancellationToken cancellationToken)
+        {
+            return _factory.GetAspireHostingVersionAsyncCallback is not null
+                ? _factory.GetAspireHostingVersionAsyncCallback(appHostFile, cancellationToken)
+                : Task.FromResult<string?>(VersionHelper.GetDefaultTemplateVersion());
         }
 
         public Task<bool> AddPackageAsync(AddPackageContext context, CancellationToken cancellationToken)

--- a/tests/Aspire.Cli.Tests/TestServices/TestCliUpdateNotifier.cs
+++ b/tests/Aspire.Cli.Tests/TestServices/TestCliUpdateNotifier.cs
@@ -11,6 +11,8 @@ internal sealed class TestCliUpdateNotifier : ICliUpdateNotifier
 
     public Func<bool>? IsUpdateAvailableCallback { get; set; }
 
+    public Func<DirectoryInfo, CancellationToken, Task<CliVersionStatus>>? GetVersionStatusAsyncCallback { get; set; }
+
     public Func<DirectoryInfo, CancellationToken, Task>? CheckForCliUpdatesAsyncCallback { get; set; }
 
     public Action? NotifyIfUpdateAvailableCallback { get; set; }
@@ -23,6 +25,13 @@ internal sealed class TestCliUpdateNotifier : ICliUpdateNotifier
         }
 
         return Task.CompletedTask;
+    }
+
+    public Task<CliVersionStatus> GetVersionStatusAsync(DirectoryInfo workingDirectory, CancellationToken cancellationToken)
+    {
+        return GetVersionStatusAsyncCallback is not null
+            ? GetVersionStatusAsyncCallback(workingDirectory, cancellationToken)
+            : Task.FromResult(new CliVersionStatus("13.0.0", null, null));
     }
 
     public void NotifyIfUpdateAvailable()

--- a/tests/Aspire.Cli.Tests/TestServices/TestLanguageDiscovery.cs
+++ b/tests/Aspire.Cli.Tests/TestServices/TestLanguageDiscovery.cs
@@ -24,6 +24,8 @@ internal sealed class TestLanguageDiscovery : ILanguageDiscovery
 
     private readonly LanguageInfo[] _allLanguages;
 
+    public Func<DirectoryInfo, CancellationToken, Task<LanguageId?>>? DetectLanguageRecursiveAsyncCallback { get; set; }
+
     public TestLanguageDiscovery(params LanguageInfo[] additionalLanguages)
     {
         _allLanguages = [.. s_defaultLanguages, .. additionalLanguages];
@@ -60,6 +62,11 @@ internal sealed class TestLanguageDiscovery : ILanguageDiscovery
 
     public Task<LanguageId?> DetectLanguageRecursiveAsync(DirectoryInfo directory, CancellationToken cancellationToken = default)
     {
+        if (DetectLanguageRecursiveAsyncCallback is not null)
+        {
+            return DetectLanguageRecursiveAsyncCallback(directory, cancellationToken);
+        }
+
         foreach (var language in _allLanguages)
         {
             if (language.FindInDirectory(directory.FullName) is not null)

--- a/tests/Aspire.Cli.Tests/TestServices/TestLanguageDiscovery.cs
+++ b/tests/Aspire.Cli.Tests/TestServices/TestLanguageDiscovery.cs
@@ -24,8 +24,6 @@ internal sealed class TestLanguageDiscovery : ILanguageDiscovery
 
     private readonly LanguageInfo[] _allLanguages;
 
-    public Func<DirectoryInfo, CancellationToken, Task<LanguageId?>>? DetectLanguageRecursiveAsyncCallback { get; set; }
-
     public TestLanguageDiscovery(params LanguageInfo[] additionalLanguages)
     {
         _allLanguages = [.. s_defaultLanguages, .. additionalLanguages];
@@ -62,11 +60,6 @@ internal sealed class TestLanguageDiscovery : ILanguageDiscovery
 
     public Task<LanguageId?> DetectLanguageRecursiveAsync(DirectoryInfo directory, CancellationToken cancellationToken = default)
     {
-        if (DetectLanguageRecursiveAsyncCallback is not null)
-        {
-            return DetectLanguageRecursiveAsyncCallback(directory, cancellationToken);
-        }
-
         foreach (var language in _allLanguages)
         {
             if (language.FindInDirectory(directory.FullName) is not null)

--- a/tests/Aspire.Cli.Tests/TestServices/TestProjectLocator.cs
+++ b/tests/Aspire.Cli.Tests/TestServices/TestProjectLocator.cs
@@ -18,6 +18,8 @@ internal sealed class TestProjectLocator : IProjectLocator
 
     public Func<DirectoryInfo, AppHostDiscoveryScope, CancellationToken, Task<List<FileInfo>>>? FindAppHostProjectFilesAsyncCallback { get; set; }
 
+    public Func<DirectoryInfo, AppHostDiscoveryScope, int?, CancellationToken, Task<List<FileInfo>>>? FindAppHostProjectFilesWithDepthAsyncCallback { get; set; }
+
     public async Task<List<AppHostProjectCandidate>> FindAppHostProjectsAsync(DirectoryInfo searchDirectory, AppHostDiscoveryScope scope, CancellationToken cancellationToken)
     {
         if (FindAppHostProjectsAsyncCallback != null)
@@ -36,6 +38,16 @@ internal sealed class TestProjectLocator : IProjectLocator
         }
 
         return [];
+    }
+
+    public async Task<List<FileInfo>> FindAppHostProjectFilesAsync(DirectoryInfo searchDirectory, AppHostDiscoveryScope scope, int? maxDepth, CancellationToken cancellationToken)
+    {
+        if (FindAppHostProjectFilesWithDepthAsyncCallback != null)
+        {
+            return await FindAppHostProjectFilesWithDepthAsyncCallback(searchDirectory, scope, maxDepth, cancellationToken);
+        }
+
+        return await FindAppHostProjectFilesAsync(searchDirectory, scope, cancellationToken);
     }
 
     public async Task<FileInfo?> UseOrFindAppHostProjectFileAsync(FileInfo? projectFile, bool createSettingsFile, CancellationToken cancellationToken)
@@ -81,5 +93,10 @@ internal sealed class TestProjectLocator : IProjectLocator
 
         // Default: no settings file found
         return null;
+    }
+
+    public async Task<FileInfo?> GetAppHostFromSettingsAsync(DirectoryInfo searchDirectory, bool searchParentDirectories, CancellationToken cancellationToken = default)
+    {
+        return await GetAppHostFromSettingsAsync(cancellationToken);
     }
 }

--- a/tests/Aspire.Cli.Tests/TestServices/TestTypeScriptStarterProjectFactory.cs
+++ b/tests/Aspire.Cli.Tests/TestServices/TestTypeScriptStarterProjectFactory.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using Aspire.Cli.Projects;
+using Aspire.Cli.Utils;
 
 namespace Aspire.Cli.Tests.TestServices;
 
@@ -70,6 +71,11 @@ internal sealed class TestTypeScriptStarterProject(Func<DirectoryInfo, Cancellat
     public Task<AppHostValidationResult> ValidateAppHostAsync(FileInfo appHostFile, CancellationToken cancellationToken)
     {
         return Task.FromResult(new AppHostValidationResult(IsValid: CanHandle(appHostFile)));
+    }
+
+    public Task<string?> GetAspireHostingVersionAsync(FileInfo appHostFile, CancellationToken cancellationToken)
+    {
+        return Task.FromResult<string?>(VersionHelper.GetDefaultTemplateVersion());
     }
 
     public Task<bool> AddPackageAsync(AddPackageContext context, CancellationToken cancellationToken)

--- a/tests/Aspire.Cli.Tests/Utils/CliTestHelper.cs
+++ b/tests/Aspire.Cli.Tests/Utils/CliTestHelper.cs
@@ -161,8 +161,9 @@ internal static class CliTestHelper
         {
             return language => ActivatorUtilities.CreateInstance<GuestAppHostProject>(sp, language);
         });
-        services.AddSingleton<IAppHostProjectFactory, AppHostProjectFactory>();
+        services.AddSingleton(options.AppHostProjectFactory);
 
+        services.AddSingleton<IEnvironmentCheck, AspireVersionCheck>();
         services.AddSingleton<IEnvironmentCheck, WslEnvironmentCheck>();
         services.AddSingleton<IEnvironmentCheck, DotNetSdkCheck>();
         services.AddSingleton<IEnvironmentCheck, TypeScriptAppHostToolingCheck>();
@@ -375,6 +376,7 @@ internal sealed class CliServiceCollectionTestOptions
     public Func<IServiceProvider, IProjectLocator> ProjectLocatorFactory { get; set; }
     public Func<IServiceProvider, ISolutionLocator> SolutionLocatorFactory { get; set; }
     public Func<IServiceProvider, CliExecutionContext> CliExecutionContextFactory { get; set; }
+    public Func<IServiceProvider, IAppHostProjectFactory> AppHostProjectFactory { get; set; } = serviceProvider => ActivatorUtilities.CreateInstance<AppHostProjectFactory>(serviceProvider);
     public Func<IServiceProvider, IFirstTimeUseNoticeSentinel> FirstTimeUseNoticeSentinelFactory { get; set; } = _ => new TestFirstTimeUseNoticeSentinel();
     public Func<IServiceProvider, IBannerService> BannerServiceFactory { get; set; } = _ => new TestBannerService();
 

--- a/tests/Aspire.Cli.Tests/Utils/CliUpdateNotificationServiceTests.cs
+++ b/tests/Aspire.Cli.Tests/Utils/CliUpdateNotificationServiceTests.cs
@@ -175,6 +175,38 @@ public class CliUpdateNotificationServiceTests(ITestOutputHelper outputHelper)
     }
 
     [Fact]
+    public void NotifyIfUpdateAvailable_WithoutCachedPackages_DoesNotNotify()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper, configure =>
+        {
+            configure.InteractionServiceFactory = sp =>
+            {
+                var interactionService = new TestInteractionService();
+                interactionService.DisplayVersionUpdateNotificationCallback = _ =>
+                {
+                    Assert.Fail("Should not notify before package metadata has been cached.");
+                };
+
+                return interactionService;
+            };
+
+            configure.CliUpdateNotifierFactory = sp =>
+            {
+                var logger = sp.GetRequiredService<ILogger<CliUpdateNotifier>>();
+                var nuGetPackageCache = sp.GetRequiredService<INuGetPackageCache>();
+                var interactionService = sp.GetRequiredService<IInteractionService>();
+                return new CliUpdateNotifierWithPackageVersionOverride("9.4.0", logger, nuGetPackageCache, interactionService);
+            };
+        });
+
+        using var provider = services.BuildServiceProvider();
+        var notifier = provider.GetRequiredService<ICliUpdateNotifier>();
+
+        notifier.NotifyIfUpdateAvailable();
+    }
+
+    [Fact]
     public async Task NotifyIfUpdateAvailable_UsesDotnetToolCommandForNativeAotToolStorePath()
     {
         using var workspace = TemporaryWorkspace.Create(outputHelper);


### PR DESCRIPTION
## Description

`aspire doctor` should make version problems visible without requiring users or agents to infer them from other commands. This adds a dedicated Aspire version check that reports the current Aspire CLI version, whether a newer CLI version is available, and the AppHost Aspire SDK version when an AppHost is present.

The AppHost version lookup follows the same fast discovery shape as the other doctor checks: configured AppHosts are honored first, then bounded language detection is used so repositories without an AppHost are not scanned deeply. Version resolution is delegated through `IAppHostProject` so .NET and guest AppHost types each use their own project model. JSON output includes structured metadata for the CLI and AppHost version checks.

### User-facing usage

```bash
aspire doctor
aspire doctor --format json
```

Text output example from a .NET AppHost folder:

```text
Checking Aspire environment...

Aspire Environment Check
========================

Aspire
  ⚠️ Aspire CLI version 13.4.0-dev is out of date. Latest version is 13.4.0-preview.1.26262.10
       Run 'aspire update' to update Aspire CLI.

AppHost
  ✅ AppHost version 13.4.0 (TestProject.AppHost.csproj)

.NET SDK
  ✅ .NET 10.0.203 installed (arm64)

Container Runtime
  ✅ Docker v28.5.1: running (auto-detected (default)) ← active

Environment
  ✅ HTTPS development certificate is trusted

Summary: 4 passed, 1 warnings, 0 failed
For detailed prerequisites: https://aka.ms/aspire-prerequisites
```

JSON version check examples:

```json
{
  "category": "aspire",
  "name": "cli-version",
  "status": "pass",
  "message": "Aspire CLI version 13.4.0-dev",
  "metadata": {
    "currentVersion": "13.4.0-dev"
  }
}
```

When an AppHost is found, JSON output also includes:

```json
{
  "category": "apphost",
  "name": "apphost-version",
  "status": "pass",
  "message": "AppHost version 13.0.0 (AppHost.csproj)",
  "metadata": {
    "appHostPath": "AppHost.csproj",
    "version": "13.0.0"
  }
}
```

Validation:

```bash
dotnet test --project /Users/davidfowler/dev/git/copilot-worktrees/aspire/davidfowl-miniature-tribble/tests/Aspire.Cli.Tests/Aspire.Cli.Tests.csproj --no-launch-profile -- --filter-class "*.CliUpdateNotificationServiceTests" --filter-class "*.DoctorCommandTests" --filter-not-trait "quarantined=true" --filter-not-trait "outerloop=true"
```

Fixes #16066

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No