### PR TITLE
Refactor CLI commands to return CommandResult and centralize cancellation handling

### DIFF
--- a/src/Aspire.Cli/Commands/AddCommand.cs
+++ b/src/Aspire.Cli/Commands/AddCommand.cs
@@ -226,8 +226,7 @@ internal sealed class AddCommand : BaseCommand
         }
         catch (OperationCanceledException)
         {
-            InteractionService.DisplayCancellationMessage();
-            return CommandResult.Failure(ExitCodeConstants.FailedToAddPackage);
+            return CommandResult.Cancelled();
         }
         catch (EmptyChoicesException ex)
         {

--- a/src/Aspire.Cli/Commands/AddCommand.cs
+++ b/src/Aspire.Cli/Commands/AddCommand.cs
@@ -59,7 +59,7 @@ internal sealed class AddCommand : BaseCommand
         Options.Add(s_sourceOption);
     }
 
-    protected override async Task<int> ExecuteAsync(ParseResult parseResult, CancellationToken cancellationToken)
+    protected override async Task<CommandResult> ExecuteAsync(ParseResult parseResult, CancellationToken cancellationToken)
     {
         using var activity = Telemetry.StartDiagnosticActivity(this.Name);
 
@@ -77,7 +77,7 @@ internal sealed class AddCommand : BaseCommand
 
             if (effectiveAppHostProjectFile is null)
             {
-                return ExitCodeConstants.FailedToFindProject;
+                return CommandResult.Failure(ExitCodeConstants.FailedToFindProject);
             }
 
             // Get the appropriate project handler
@@ -88,14 +88,14 @@ internal sealed class AddCommand : BaseCommand
             {
                 if (!await SdkInstallHelper.EnsureSdkInstalledAsync(_sdkInstaller, InteractionService, Telemetry, cancellationToken: cancellationToken))
                 {
-                    return ExitCodeConstants.SdkNotInstalled;
+                    return CommandResult.Failure(ExitCodeConstants.SdkNotInstalled);
                 }
             }
 
             var (configuredChannel, configuredChannelExitCode) = _integrationPackageSearchService.GetConfiguredChannel(effectiveAppHostProjectFile, project);
             if (configuredChannelExitCode is { } exitCode)
             {
-                return exitCode;
+                return CommandResult.FromExitCode(exitCode);
             }
 
             var packagesWithChannels = await InteractionService.ShowStatusAsync(
@@ -111,8 +111,7 @@ internal sealed class AddCommand : BaseCommand
 
             if (!packagesWithShortName.Any())
             {
-                InteractionService.DisplayError(AddCommandStrings.NoPackagesFound);
-                return ExitCodeConstants.FailedToAddPackage;
+                return CommandResult.Failure(ExitCodeConstants.FailedToAddPackage, AddCommandStrings.NoPackagesFound);
             }
 
             var filteredPackagesWithShortName = packagesWithShortName
@@ -201,8 +200,7 @@ internal sealed class AddCommand : BaseCommand
             }
             else if (runningInstanceResult == RunningInstanceResult.StopFailed)
             {
-                InteractionService.DisplayError(AddCommandStrings.UnableToStopRunningInstances);
-                return ExitCodeConstants.FailedToAddPackage;
+                return CommandResult.Failure(ExitCodeConstants.FailedToAddPackage, AddCommandStrings.UnableToStopRunningInstances);
             }
 
             var success = await InteractionService.ShowStatusAsync(
@@ -216,12 +214,11 @@ internal sealed class AddCommand : BaseCommand
                 {
                     InteractionService.DisplayLines(outputCollector.GetLines());
                 }
-                InteractionService.DisplayError(string.Format(CultureInfo.CurrentCulture, AddCommandStrings.PackageInstallationFailed, ExitCodeConstants.FailedToAddPackage));
-                return ExitCodeConstants.FailedToAddPackage;
+                return CommandResult.Failure(ExitCodeConstants.FailedToAddPackage, string.Format(CultureInfo.CurrentCulture, AddCommandStrings.PackageInstallationFailed, ExitCodeConstants.FailedToAddPackage));
             }
 
             InteractionService.DisplaySuccess(string.Format(CultureInfo.CurrentCulture, AddCommandStrings.PackageAddedSuccessfully, selectedNuGetPackage.Package.Id, selectedNuGetPackage.Package.Version));
-            return ExitCodeConstants.Success;
+            return CommandResult.Success();
         }
         catch (ProjectLocatorException ex)
         {
@@ -230,13 +227,12 @@ internal sealed class AddCommand : BaseCommand
         catch (OperationCanceledException)
         {
             InteractionService.DisplayCancellationMessage();
-            return ExitCodeConstants.FailedToAddPackage;
+            return CommandResult.Failure(ExitCodeConstants.FailedToAddPackage);
         }
         catch (EmptyChoicesException ex)
         {
             Telemetry.RecordError(ex.Message, ex);
-            InteractionService.DisplayError(ex.Message);
-            return ExitCodeConstants.FailedToAddPackage;
+            return CommandResult.Failure(ExitCodeConstants.FailedToAddPackage, ex.Message);
         }
         catch (Exception ex)
         {
@@ -246,8 +242,7 @@ internal sealed class AddCommand : BaseCommand
             }
             var errorMessage = string.Format(CultureInfo.CurrentCulture, AddCommandStrings.ErrorOccurredWhileAddingPackage, ex.Message);
             Telemetry.RecordError(errorMessage, ex);
-            InteractionService.DisplayError(errorMessage);
-            return ExitCodeConstants.FailedToAddPackage;
+            return CommandResult.Failure(ExitCodeConstants.FailedToAddPackage, errorMessage);
         }
     }
 

--- a/src/Aspire.Cli/Commands/AddCommand.cs
+++ b/src/Aspire.Cli/Commands/AddCommand.cs
@@ -216,7 +216,7 @@ internal sealed class AddCommand : BaseCommand
                 {
                     InteractionService.DisplayLines(outputCollector.GetLines());
                 }
-                InteractionService.DisplayError(string.Format(CultureInfo.CurrentCulture, AddCommandStrings.PackageInstallationFailed, ExitCodeConstants.FailedToAddPackage, ExecutionContext.LogFilePath));
+                InteractionService.DisplayError(string.Format(CultureInfo.CurrentCulture, AddCommandStrings.PackageInstallationFailed, ExitCodeConstants.FailedToAddPackage));
                 return ExitCodeConstants.FailedToAddPackage;
             }
 

--- a/src/Aspire.Cli/Commands/AgentCommand.cs
+++ b/src/Aspire.Cli/Commands/AgentCommand.cs
@@ -1,8 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.CommandLine;
-using System.CommandLine.Help;
 using Aspire.Cli.Configuration;
 using Aspire.Cli.Interaction;
 using Aspire.Cli.Resources;
@@ -14,7 +12,7 @@ namespace Aspire.Cli.Commands;
 /// <summary>
 /// Parent command for AI agent integrations. Contains subcommands for MCP server and initialization.
 /// </summary>
-internal sealed class AgentCommand : BaseCommand
+internal sealed class AgentCommand : ParentCommand
 {
     internal override HelpGroup HelpGroup => HelpGroup.ToolsAndConfiguration;
 
@@ -30,13 +28,5 @@ internal sealed class AgentCommand : BaseCommand
     {
         Subcommands.Add(mcpCommand);
         Subcommands.Add(initCommand);
-    }
-
-    protected override bool UpdateNotificationsEnabled => false;
-
-    protected override Task<int> ExecuteAsync(ParseResult parseResult, CancellationToken cancellationToken)
-    {
-        new HelpAction().Invoke(parseResult);
-        return Task.FromResult(ExitCodeConstants.InvalidCommand);
     }
 }

--- a/src/Aspire.Cli/Commands/AgentInitCommand.cs
+++ b/src/Aspire.Cli/Commands/AgentInitCommand.cs
@@ -91,7 +91,7 @@ internal sealed class AgentInitCommand : BaseCommand, IPackageMetaPrefetchingCom
     /// Public entry point for executing the init command.
     /// This allows McpInitCommand to delegate to this implementation.
     /// </summary>
-    internal Task<int> ExecuteCommandAsync(ParseResult parseResult, CancellationToken cancellationToken)
+    internal Task<CommandResult> ExecuteCommandAsync(ParseResult parseResult, CancellationToken cancellationToken)
     {
         return ExecuteAsync(parseResult, cancellationToken);
     }
@@ -128,11 +128,11 @@ internal sealed class AgentInitCommand : BaseCommand, IPackageMetaPrefetchingCom
         return new(ExitCodeConstants.Success, [], []);
     }
 
-    protected override async Task<int> ExecuteAsync(ParseResult parseResult, CancellationToken cancellationToken)
+    protected override async Task<CommandResult> ExecuteAsync(ParseResult parseResult, CancellationToken cancellationToken)
     {
         var workspaceRoot = await PromptForWorkspaceRootAsync(parseResult, cancellationToken);
         var result = await ExecuteAgentInitAsync(workspaceRoot, parseResult, cancellationToken);
-        return result.ExitCode;
+        return CommandResult.FromExitCode(result.ExitCode);
     }
 
     private async Task<DirectoryInfo> PromptForWorkspaceRootAsync(ParseResult parseResult, CancellationToken cancellationToken)

--- a/src/Aspire.Cli/Commands/AgentInitCommand.cs
+++ b/src/Aspire.Cli/Commands/AgentInitCommand.cs
@@ -372,10 +372,6 @@ internal sealed class AgentInitCommand : BaseCommand, IPackageMetaPrefetchingCom
         if (hasErrors)
         {
             _interactionService.DisplayMessage(KnownEmojis.Warning, AgentCommandStrings.ConfigurationCompletedWithErrors);
-            _interactionService.DisplayMessage(
-                KnownEmojis.PageFacingUp,
-                string.Format(CultureInfo.CurrentCulture, InteractionServiceStrings.SeeLogsAt, MarkupHelpers.SafeFileLink(_interactionService, ExecutionContext.LogFilePath)),
-                allowMarkup: true);
         }
         else
         {

--- a/src/Aspire.Cli/Commands/AgentMcpCommand.cs
+++ b/src/Aspire.Cli/Commands/AgentMcpCommand.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.CommandLine;
+using System.Globalization;
 using System.Text.Json;
 using Aspire.Cli.Backchannel;
 using Aspire.Cli.Configuration;
@@ -105,7 +106,7 @@ internal sealed class AgentMcpCommand : BaseCommand
             if (!UrlHelper.IsHttpUrl(dashboardUrl))
             {
                 _logger.LogError("Invalid --dashboard-url: {DashboardUrl}", dashboardUrl);
-                return CommandResult.Failure(ExitCodeConstants.InvalidCommand);
+                return CommandResult.Failure(ExitCodeConstants.InvalidCommand, string.Format(CultureInfo.CurrentCulture, TelemetryCommandStrings.DashboardUrlInvalid, dashboardUrl));
             }
 
             _dashboardOnlyMode = true;

--- a/src/Aspire.Cli/Commands/AgentMcpCommand.cs
+++ b/src/Aspire.Cli/Commands/AgentMcpCommand.cs
@@ -90,12 +90,12 @@ internal sealed class AgentMcpCommand : BaseCommand
     /// Public entry point for executing the MCP server command.
     /// This allows McpStartCommand to delegate to this implementation.
     /// </summary>
-    internal Task<int> ExecuteCommandAsync(ParseResult parseResult, CancellationToken cancellationToken)
+    internal Task<CommandResult> ExecuteCommandAsync(ParseResult parseResult, CancellationToken cancellationToken)
     {
         return ExecuteAsync(parseResult, cancellationToken);
     }
 
-    protected override async Task<int> ExecuteAsync(ParseResult parseResult, CancellationToken cancellationToken)
+    protected override async Task<CommandResult> ExecuteAsync(ParseResult parseResult, CancellationToken cancellationToken)
     {
         var dashboardUrl = parseResult.GetValue(s_dashboardUrlOption);
         var apiKey = parseResult.GetValue(s_apiKeyOption);
@@ -105,7 +105,7 @@ internal sealed class AgentMcpCommand : BaseCommand
             if (!UrlHelper.IsHttpUrl(dashboardUrl))
             {
                 _logger.LogError("Invalid --dashboard-url: {DashboardUrl}", dashboardUrl);
-                return ExitCodeConstants.InvalidCommand;
+                return CommandResult.Failure(ExitCodeConstants.InvalidCommand);
             }
 
             _dashboardOnlyMode = true;
@@ -166,7 +166,7 @@ internal sealed class AgentMcpCommand : BaseCommand
         _resourceToolRefreshService.SetMcpServer(null);
         _server = null;
 
-        return ExitCodeConstants.Success;
+        return CommandResult.Success();
     }
 
     private async ValueTask<ListToolsResult> HandleListToolsAsync(RequestContext<ListToolsRequestParams> request, CancellationToken cancellationToken)

--- a/src/Aspire.Cli/Commands/ApiCommand.cs
+++ b/src/Aspire.Cli/Commands/ApiCommand.cs
@@ -1,8 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.CommandLine;
-using System.CommandLine.Help;
 using Aspire.Cli.Configuration;
 using Aspire.Cli.Interaction;
 using Aspire.Cli.Resources;
@@ -14,7 +12,7 @@ namespace Aspire.Cli.Commands;
 /// <summary>
 /// Parent command for API documentation operations under <c>docs</c>.
 /// </summary>
-internal sealed class ApiCommand : BaseCommand
+internal sealed class ApiCommand : ParentCommand
 {
     internal override HelpGroup HelpGroup => HelpGroup.ToolsAndConfiguration;
 
@@ -43,13 +41,5 @@ internal sealed class ApiCommand : BaseCommand
         Subcommands.Add(listCommand);
         Subcommands.Add(searchCommand);
         Subcommands.Add(getCommand);
-    }
-
-    protected override bool UpdateNotificationsEnabled => false;
-
-    protected override Task<int> ExecuteAsync(ParseResult parseResult, CancellationToken cancellationToken)
-    {
-        new HelpAction().Invoke(parseResult);
-        return Task.FromResult(ExitCodeConstants.InvalidCommand);
     }
 }

--- a/src/Aspire.Cli/Commands/ApiGetCommand.cs
+++ b/src/Aspire.Cli/Commands/ApiGetCommand.cs
@@ -56,7 +56,7 @@ internal sealed class ApiGetCommand : BaseCommand
 
     protected override bool UpdateNotificationsEnabled => false;
 
-    protected override async Task<int> ExecuteAsync(ParseResult parseResult, CancellationToken cancellationToken)
+    protected override async Task<CommandResult> ExecuteAsync(ParseResult parseResult, CancellationToken cancellationToken)
     {
         using var activity = Telemetry.StartDiagnosticActivity(Name);
 
@@ -69,18 +69,17 @@ internal sealed class ApiGetCommand : BaseCommand
 
         if (item is null)
         {
-            InteractionService.DisplayError(string.Format(CultureInfo.CurrentCulture, ApiCommandStrings.ApiNotFound, id));
-            return ExitCodeConstants.InvalidCommand;
+            return CommandResult.Failure(ExitCodeConstants.InvalidCommand, string.Format(CultureInfo.CurrentCulture, ApiCommandStrings.ApiNotFound, id));
         }
 
         if (format is OutputFormat.Json)
         {
             var json = JsonSerializer.Serialize(item, JsonSourceGenerationContext.RelaxedEscaping.ApiContent);
             InteractionService.DisplayRawText(json, ConsoleOutput.Standard);
-            return ExitCodeConstants.Success;
+            return CommandResult.Success();
         }
 
         InteractionService.DisplayMarkdown(item.Content);
-        return ExitCodeConstants.Success;
+        return CommandResult.Success();
     }
 }

--- a/src/Aspire.Cli/Commands/ApiListCommand.cs
+++ b/src/Aspire.Cli/Commands/ApiListCommand.cs
@@ -57,7 +57,7 @@ internal sealed class ApiListCommand : BaseCommand
 
     protected override bool UpdateNotificationsEnabled => false;
 
-    protected override async Task<int> ExecuteAsync(ParseResult parseResult, CancellationToken cancellationToken)
+    protected override async Task<CommandResult> ExecuteAsync(ParseResult parseResult, CancellationToken cancellationToken)
     {
         using var activity = Telemetry.StartDiagnosticActivity(Name);
 
@@ -71,14 +71,14 @@ internal sealed class ApiListCommand : BaseCommand
         if (items.Count is 0)
         {
             InteractionService.DisplayError(string.Format(CultureInfo.CurrentCulture, ApiCommandStrings.NoApiEntriesFound, scope));
-            return ExitCodeConstants.Success;
+            return CommandResult.Success();
         }
 
         if (format is OutputFormat.Json)
         {
             var json = JsonSerializer.Serialize(items.ToArray(), JsonSourceGenerationContext.RelaxedEscaping.ApiListItemArray);
             InteractionService.DisplayRawText(json, ConsoleOutput.Standard);
-            return ExitCodeConstants.Success;
+            return CommandResult.Success();
         }
 
         InteractionService.DisplaySuccess(string.Format(CultureInfo.CurrentCulture, ApiCommandStrings.FoundApiEntries, items.Count, scope));
@@ -99,6 +99,6 @@ internal sealed class ApiListCommand : BaseCommand
         }
 
         InteractionService.DisplayRenderable(table);
-        return ExitCodeConstants.Success;
+        return CommandResult.Success();
     }
 }

--- a/src/Aspire.Cli/Commands/ApiSearchCommand.cs
+++ b/src/Aspire.Cli/Commands/ApiSearchCommand.cs
@@ -69,7 +69,7 @@ internal sealed class ApiSearchCommand : BaseCommand
 
     protected override bool UpdateNotificationsEnabled => false;
 
-    protected override async Task<int> ExecuteAsync(ParseResult parseResult, CancellationToken cancellationToken)
+    protected override async Task<CommandResult> ExecuteAsync(ParseResult parseResult, CancellationToken cancellationToken)
     {
         using var activity = Telemetry.StartDiagnosticActivity(Name);
 
@@ -85,14 +85,14 @@ internal sealed class ApiSearchCommand : BaseCommand
         if (items.Count is 0)
         {
             InteractionService.DisplayError(string.Format(CultureInfo.CurrentCulture, ApiCommandStrings.NoResultsFound, query));
-            return ExitCodeConstants.Success;
+            return CommandResult.Success();
         }
 
         if (format is OutputFormat.Json)
         {
             var json = JsonSerializer.Serialize([.. items], JsonSourceGenerationContext.RelaxedEscaping.ApiSearchResultArray);
             InteractionService.DisplayRawText(json, ConsoleOutput.Standard);
-            return ExitCodeConstants.Success;
+            return CommandResult.Success();
         }
 
         InteractionService.DisplaySuccess(string.Format(CultureInfo.CurrentCulture, ApiCommandStrings.FoundSearchResults, items.Count, query));
@@ -115,6 +115,6 @@ internal sealed class ApiSearchCommand : BaseCommand
         }
 
         InteractionService.DisplayRenderable(table);
-        return ExitCodeConstants.Success;
+        return CommandResult.Success();
     }
 }

--- a/src/Aspire.Cli/Commands/AppHostLauncher.cs
+++ b/src/Aspire.Cli/Commands/AppHostLauncher.cs
@@ -105,7 +105,7 @@ internal sealed class AppHostLauncher(
         }
         catch (ProjectLocatorException ex)
         {
-            return BaseCommand.HandleProjectLocatorException(ex, interactionService, telemetry);
+            return BaseCommand.HandleProjectLocatorException(ex, interactionService, telemetry).ExitCode;
         }
 
         var effectiveAppHostFile = searchResult.SelectedProjectFile;

--- a/src/Aspire.Cli/Commands/AppHostLauncher.cs
+++ b/src/Aspire.Cli/Commands/AppHostLauncher.cs
@@ -77,8 +77,8 @@ internal sealed class AppHostLauncher(
     /// <param name="globalArgs">Global CLI args to forward to child process.</param>
     /// <param name="additionalArgs">Additional unmatched args to forward.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
-    /// <returns>Exit code indicating success or failure.</returns>
-    public async Task<int> LaunchDetachedAsync(
+    /// <returns>A <see cref="CommandResult"/> indicating success or failure.</returns>
+    public async Task<CommandResult> LaunchDetachedAsync(
         FileInfo? passedAppHostProjectFile,
         OutputFormat? format,
         bool isolated,
@@ -105,14 +105,14 @@ internal sealed class AppHostLauncher(
         }
         catch (ProjectLocatorException ex)
         {
-            return BaseCommand.HandleProjectLocatorException(ex, interactionService, telemetry).ExitCode;
+            return BaseCommand.HandleProjectLocatorException(ex, interactionService, telemetry);
         }
 
         var effectiveAppHostFile = searchResult.SelectedProjectFile;
 
         if (effectiveAppHostFile is null)
         {
-            return ExitCodeConstants.FailedToFindProject;
+            return CommandResult.Failure(ExitCodeConstants.FailedToFindProject);
         }
 
         logger.LogDebug("Starting AppHost in background: {AppHostPath}", effectiveAppHostFile.FullName);
@@ -155,13 +155,13 @@ internal sealed class AppHostLauncher(
         // Handle failure cases
         if (launchResult.Backchannel is null || launchResult.ChildProcess is null)
         {
-            return HandleLaunchFailure(launchResult, childLogFile);
+            return CommandResult.FromExitCode(HandleLaunchFailure(launchResult, childLogFile));
         }
 
         // Display results
         DisplayLaunchResult(launchResult, effectiveAppHostFile, childLogFile, format, isExtensionHost);
 
-        return ExitCodeConstants.Success;
+        return CommandResult.Success();
     }
 
     private async Task StopExistingInstancesAsync(FileInfo effectiveAppHostFile, CancellationToken cancellationToken)

--- a/src/Aspire.Cli/Commands/BaseCommand.cs
+++ b/src/Aspire.Cli/Commands/BaseCommand.cs
@@ -60,6 +60,17 @@ internal abstract class BaseCommand : Command
                 exitCode = ExitCodeConstants.MissingRequiredArgument;
             }
 
+            // Display the CLI log file path on non-zero exit codes so the user knows
+            // where to find diagnostic details. Suppress for user-input errors where
+            // the log wouldn't contain useful context (e.g., missing required arguments).
+            if (exitCode != ExitCodeConstants.Success && exitCode != ExitCodeConstants.MissingRequiredArgument)
+            {
+                interactionService.DisplayMessage(
+                    KnownEmojis.PageFacingUp,
+                    string.Format(CultureInfo.CurrentCulture, InteractionServiceStrings.SeeLogsAt, MarkupHelpers.SafeFileLink(interactionService, executionContext.LogFilePath)),
+                    allowMarkup: true);
+            }
+
             if (UpdateNotificationsEnabled && features.IsFeatureEnabled(KnownFeatures.UpdateNotificationsEnabled, true))
             {
                 try

--- a/src/Aspire.Cli/Commands/BaseCommand.cs
+++ b/src/Aspire.Cli/Commands/BaseCommand.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.CommandLine;
+using System.CommandLine.Help;
 using System.Globalization;
 using Aspire.Cli.Configuration;
 using Aspire.Cli.Interaction;
@@ -49,21 +50,32 @@ internal abstract class BaseCommand : Command
 
             // TODO: SDK install goes here in the future.
 
-            int exitCode;
+            CommandResult result;
             try
             {
-                exitCode = await ExecuteAsync(parseResult, cancellationToken);
+                result = await ExecuteAsync(parseResult, cancellationToken);
             }
             catch (NonInteractiveException)
             {
                 // Error messages have already been displayed by the interaction service.
-                exitCode = ExitCodeConstants.MissingRequiredArgument;
+                result = CommandResult.Failure(ExitCodeConstants.MissingRequiredArgument);
+            }
+
+            if (result.ErrorMessage is not null)
+            {
+                interactionService.DisplayError(result.ErrorMessage);
+            }
+
+            if (result.ShouldDisplayHelp)
+            {
+                new HelpAction().Invoke(parseResult);
+                return result.ExitCode;
             }
 
             // Display the CLI log file path on non-zero exit codes so the user knows
             // where to find diagnostic details. Suppress for user-input errors where
             // the log wouldn't contain useful context (e.g., missing required arguments).
-            if (exitCode != ExitCodeConstants.Success && exitCode != ExitCodeConstants.MissingRequiredArgument)
+            if (result.ExitCode != ExitCodeConstants.Success && result.ExitCode != ExitCodeConstants.MissingRequiredArgument)
             {
                 interactionService.DisplayMessage(
                     KnownEmojis.PageFacingUp,
@@ -83,11 +95,11 @@ internal abstract class BaseCommand : Command
                 }
             }
 
-            return exitCode;
+            return result.ExitCode;
         });
     }
 
-    protected abstract Task<int> ExecuteAsync(ParseResult parseResult, CancellationToken cancellationToken);
+    protected abstract Task<CommandResult> ExecuteAsync(ParseResult parseResult, CancellationToken cancellationToken);
 
     /// <summary>
     /// Checks whether this command has a --format option whose parsed value is <see cref="OutputFormat.Json"/>.
@@ -105,7 +117,7 @@ internal abstract class BaseCommand : Command
         return false;
     }
 
-    internal static int HandleProjectLocatorException(ProjectLocatorException ex, IInteractionService interactionService, AspireCliTelemetry telemetry)
+    internal static CommandResult HandleProjectLocatorException(ProjectLocatorException ex, IInteractionService interactionService, AspireCliTelemetry telemetry)
     {
         ArgumentNullException.ThrowIfNull(ex);
         ArgumentNullException.ThrowIfNull(interactionService);
@@ -113,8 +125,7 @@ internal abstract class BaseCommand : Command
         var (exitCode, errorMessage) = ProjectLocatorErrorHelper.GetExitCodeAndMessage(ex);
 
         telemetry.RecordError(errorMessage, ex);
-        interactionService.DisplayError(errorMessage);
-        return exitCode;
+        return CommandResult.Failure(exitCode, errorMessage);
     }
 
     internal static void AddNonInteractiveRequiresYesValidator(Command command, Option<bool> yesOption)

--- a/src/Aspire.Cli/Commands/BaseCommand.cs
+++ b/src/Aspire.Cli/Commands/BaseCommand.cs
@@ -72,10 +72,9 @@ internal abstract class BaseCommand : Command
                 return result.ExitCode;
             }
 
-            if (result.ExitCode == ExitCodeConstants.Cancelled)
+            if (result.ShouldDisplayCancellationMessage)
             {
                 interactionService.DisplayCancellationMessage();
-                return result.ExitCode;
             }
 
             // Display the CLI log file path on non-zero exit codes so the user knows

--- a/src/Aspire.Cli/Commands/BaseCommand.cs
+++ b/src/Aspire.Cli/Commands/BaseCommand.cs
@@ -72,6 +72,12 @@ internal abstract class BaseCommand : Command
                 return result.ExitCode;
             }
 
+            if (result.ExitCode == ExitCodeConstants.Cancelled)
+            {
+                interactionService.DisplayCancellationMessage();
+                return result.ExitCode;
+            }
+
             // Display the CLI log file path on non-zero exit codes so the user knows
             // where to find diagnostic details. Suppress for user-input errors where
             // the log wouldn't contain useful context (e.g., missing required arguments).

--- a/src/Aspire.Cli/Commands/CacheCommand.cs
+++ b/src/Aspire.Cli/Commands/CacheCommand.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.CommandLine;
-using System.CommandLine.Help;
 using System.Globalization;
 using Aspire.Cli.Configuration;
 using Aspire.Cli.Interaction;
@@ -12,7 +11,7 @@ using Aspire.Cli.Utils;
 
 namespace Aspire.Cli.Commands;
 
-internal sealed class CacheCommand : BaseCommand
+internal sealed class CacheCommand : ParentCommand
 {
     internal override HelpGroup HelpGroup => HelpGroup.ToolsAndConfiguration;
 
@@ -24,14 +23,6 @@ internal sealed class CacheCommand : BaseCommand
         Subcommands.Add(clearCommand);
     }
 
-    protected override bool UpdateNotificationsEnabled => false;
-
-    protected override Task<int> ExecuteAsync(ParseResult parseResult, CancellationToken cancellationToken)
-    {
-        new HelpAction().Invoke(parseResult);
-        return Task.FromResult(ExitCodeConstants.InvalidCommand);
-    }
-
     internal sealed class ClearCommand : BaseCommand
     {
         public ClearCommand(IInteractionService interactionService, IFeatures features, ICliUpdateNotifier updateNotifier, CliExecutionContext executionContext, AspireCliTelemetry telemetry)
@@ -41,7 +32,7 @@ internal sealed class CacheCommand : BaseCommand
 
         protected override bool UpdateNotificationsEnabled => false;
 
-        protected override Task<int> ExecuteAsync(ParseResult parseResult, CancellationToken cancellationToken)
+        protected override Task<CommandResult> ExecuteAsync(ParseResult parseResult, CancellationToken cancellationToken)
         {
             try
             {
@@ -64,14 +55,14 @@ internal sealed class CacheCommand : BaseCommand
                     InteractionService.DisplaySuccess(CacheCommandStrings.CacheCleared);
                 }
 
-                return Task.FromResult(ExitCodeConstants.Success);
+                return Task.FromResult(CommandResult.Success());
             }
             catch (Exception ex)
             {
                 var errorMessage = string.Format(CultureInfo.CurrentCulture, CacheCommandStrings.CacheClearFailed, ex.Message);
                 Telemetry.RecordError(errorMessage, ex);
                 InteractionService.DisplayError(errorMessage);
-                return Task.FromResult(ExitCodeConstants.InvalidCommand);
+                return Task.FromResult(CommandResult.Failure(ExitCodeConstants.InvalidCommand));
             }
         }
 

--- a/src/Aspire.Cli/Commands/CertificatesCleanCommand.cs
+++ b/src/Aspire.Cli/Commands/CertificatesCleanCommand.cs
@@ -27,7 +27,7 @@ internal sealed class CertificatesCleanCommand : BaseCommand
 
     protected override bool UpdateNotificationsEnabled => false;
 
-    protected override Task<int> ExecuteAsync(ParseResult parseResult, CancellationToken cancellationToken)
+    protected override Task<CommandResult> ExecuteAsync(ParseResult parseResult, CancellationToken cancellationToken)
     {
         InteractionService.DisplayMessage(KnownEmojis.Information, CertificatesCommandStrings.CleanProgress);
 
@@ -36,18 +36,18 @@ internal sealed class CertificatesCleanCommand : BaseCommand
         if (result.Success)
         {
             InteractionService.DisplaySuccess(CertificatesCommandStrings.CleanSuccess);
-            return Task.FromResult(ExitCodeConstants.Success);
+            return Task.FromResult(CommandResult.FromExitCode(ExitCodeConstants.Success));
         }
 
         if (result.WasCancelled)
         {
             InteractionService.DisplayMessage(KnownEmojis.Warning, CertificatesCommandStrings.CleanCancelled);
-            return Task.FromResult(ExitCodeConstants.FailedToTrustCertificates);
+            return Task.FromResult(CommandResult.FromExitCode(ExitCodeConstants.FailedToTrustCertificates));
         }
 
         var details = string.Format(CultureInfo.CurrentCulture, CertificatesCommandStrings.CleanFailureDetailsFormat, result.ErrorMessage);
         InteractionService.DisplayError(details);
         InteractionService.DisplayError(CertificatesCommandStrings.CleanFailure);
-        return Task.FromResult(ExitCodeConstants.FailedToTrustCertificates);
+        return Task.FromResult(CommandResult.FromExitCode(ExitCodeConstants.FailedToTrustCertificates));
     }
 }

--- a/src/Aspire.Cli/Commands/CertificatesCommand.cs
+++ b/src/Aspire.Cli/Commands/CertificatesCommand.cs
@@ -1,8 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.CommandLine;
-using System.CommandLine.Help;
 using Aspire.Cli.Configuration;
 using Aspire.Cli.Interaction;
 using Aspire.Cli.Resources;
@@ -11,7 +9,7 @@ using Aspire.Cli.Utils;
 
 namespace Aspire.Cli.Commands;
 
-internal sealed class CertificatesCommand : BaseCommand
+internal sealed class CertificatesCommand : ParentCommand
 {
     internal override HelpGroup HelpGroup => HelpGroup.ToolsAndConfiguration;
 
@@ -23,13 +21,5 @@ internal sealed class CertificatesCommand : BaseCommand
 
         Subcommands.Add(cleanCommand);
         Subcommands.Add(trustCommand);
-    }
-
-    protected override bool UpdateNotificationsEnabled => false;
-
-    protected override Task<int> ExecuteAsync(ParseResult parseResult, CancellationToken cancellationToken)
-    {
-        new HelpAction().Invoke(parseResult);
-        return Task.FromResult(ExitCodeConstants.InvalidCommand);
     }
 }

--- a/src/Aspire.Cli/Commands/CertificatesTrustCommand.cs
+++ b/src/Aspire.Cli/Commands/CertificatesTrustCommand.cs
@@ -27,7 +27,7 @@ internal sealed class CertificatesTrustCommand : BaseCommand
 
     protected override bool UpdateNotificationsEnabled => false;
 
-    protected override async Task<int> ExecuteAsync(ParseResult parseResult, CancellationToken cancellationToken)
+    protected override async Task<CommandResult> ExecuteAsync(ParseResult parseResult, CancellationToken cancellationToken)
     {
         InteractionService.DisplayMessage(KnownEmojis.Information, CertificatesCommandStrings.TrustProgress);
 
@@ -36,17 +36,15 @@ internal sealed class CertificatesTrustCommand : BaseCommand
         if (result.Success)
         {
             InteractionService.DisplaySuccess(CertificatesCommandStrings.TrustSuccess);
-            return ExitCodeConstants.Success;
+            return CommandResult.Success();
         }
 
         if (result.WasCancelled)
         {
-            return ExitCodeConstants.FailedToTrustCertificates;
+            return CommandResult.Failure(ExitCodeConstants.FailedToTrustCertificates);
         }
 
         var details = string.Format(CultureInfo.CurrentCulture, CertificatesCommandStrings.TrustFailureDetailsFormat, result.ResultCode);
-        InteractionService.DisplayError(details);
-        InteractionService.DisplayError(CertificatesCommandStrings.TrustFailure);
-        return ExitCodeConstants.FailedToTrustCertificates;
+        return CommandResult.Failure(ExitCodeConstants.FailedToTrustCertificates, $"{CertificatesCommandStrings.TrustFailure} {details}");
     }
 }

--- a/src/Aspire.Cli/Commands/CommandResult.cs
+++ b/src/Aspire.Cli/Commands/CommandResult.cs
@@ -1,0 +1,39 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Aspire.Cli.Commands;
+
+/// <summary>
+/// Represents the outcome of a CLI command execution.
+/// </summary>
+internal sealed class CommandResult
+{
+    public int ExitCode { get; }
+
+    public string? ErrorMessage { get; }
+
+    public bool ShouldDisplayHelp { get; }
+
+    private CommandResult(int exitCode, string? errorMessage = null, bool shouldDisplayHelp = false)
+    {
+        ExitCode = exitCode;
+        ErrorMessage = errorMessage;
+        ShouldDisplayHelp = shouldDisplayHelp;
+    }
+
+    public static CommandResult Success() => new(ExitCodeConstants.Success);
+
+    public static CommandResult Failure(int exitCode, string? errorMessage = null) => new(exitCode, errorMessage);
+
+    /// <summary>
+    /// Indicates the command should display help and return an invalid-command exit code.
+    /// </summary>
+    public static CommandResult DisplayHelp() => new(ExitCodeConstants.InvalidCommand, shouldDisplayHelp: true);
+
+    /// <summary>
+    /// Creates a result from a raw exit code with no error message.
+    /// Useful when wrapping calls that return plain exit codes.
+    /// </summary>
+    public static CommandResult FromExitCode(int exitCode) =>
+        exitCode == ExitCodeConstants.Success ? Success() : Failure(exitCode);
+}

--- a/src/Aspire.Cli/Commands/CommandResult.cs
+++ b/src/Aspire.Cli/Commands/CommandResult.cs
@@ -14,11 +14,14 @@ internal sealed class CommandResult
 
     public bool ShouldDisplayHelp { get; }
 
-    private CommandResult(int exitCode, string? errorMessage = null, bool shouldDisplayHelp = false)
+    public bool ShouldDisplayCancellationMessage { get; }
+
+    private CommandResult(int exitCode, string? errorMessage = null, bool shouldDisplayHelp = false, bool shouldDisplayCancellationMessage = false)
     {
         ExitCode = exitCode;
         ErrorMessage = errorMessage;
         ShouldDisplayHelp = shouldDisplayHelp;
+        ShouldDisplayCancellationMessage = shouldDisplayCancellationMessage;
     }
 
     public static CommandResult Success() => new(ExitCodeConstants.Success);
@@ -29,7 +32,7 @@ internal sealed class CommandResult
     /// Indicates the command was cancelled by the user (e.g. Ctrl+C).
     /// <see cref="BaseCommand"/> displays the cancellation message centrally.
     /// </summary>
-    public static CommandResult Cancelled() => new(ExitCodeConstants.Cancelled);
+    public static CommandResult Cancelled(int exitCode = ExitCodeConstants.Cancelled) => new(exitCode, shouldDisplayCancellationMessage: true);
 
     /// <summary>
     /// Indicates the command should display help and return an invalid-command exit code.

--- a/src/Aspire.Cli/Commands/CommandResult.cs
+++ b/src/Aspire.Cli/Commands/CommandResult.cs
@@ -26,6 +26,12 @@ internal sealed class CommandResult
     public static CommandResult Failure(int exitCode, string? errorMessage = null) => new(exitCode, errorMessage);
 
     /// <summary>
+    /// Indicates the command was cancelled by the user (e.g. Ctrl+C).
+    /// <see cref="BaseCommand"/> displays the cancellation message centrally.
+    /// </summary>
+    public static CommandResult Cancelled() => new(ExitCodeConstants.Cancelled);
+
+    /// <summary>
     /// Indicates the command should display help and return an invalid-command exit code.
     /// </summary>
     public static CommandResult DisplayHelp() => new(ExitCodeConstants.InvalidCommand, shouldDisplayHelp: true);

--- a/src/Aspire.Cli/Commands/ConfigCommand.cs
+++ b/src/Aspire.Cli/Commands/ConfigCommand.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.CommandLine;
-using System.CommandLine.Help;
 using System.Diagnostics;
 using System.Globalization;
 using Aspire.Cli.Configuration;
@@ -44,12 +43,11 @@ internal sealed class ConfigCommand : BaseCommand
 
     protected override bool UpdateNotificationsEnabled => false;
 
-    protected override async Task<int> ExecuteAsync(ParseResult parseResult, CancellationToken cancellationToken)
+    protected override async Task<CommandResult> ExecuteAsync(ParseResult parseResult, CancellationToken cancellationToken)
     {
         if (_configuration[KnownConfigNames.ExtensionPromptEnabled] is not "true")
         {
-            new HelpAction().Invoke(parseResult);
-            return ExitCodeConstants.InvalidCommand;
+            return CommandResult.DisplayHelp();
         }
 
         // Prompt for the action that the user wants to perform
@@ -63,7 +61,7 @@ internal sealed class ConfigCommand : BaseCommand
             },
             cancellationToken: cancellationToken);
 
-        return await subcommand.InteractiveExecuteAsync(cancellationToken);
+        return CommandResult.FromExitCode(await subcommand.InteractiveExecuteAsync(cancellationToken));
     }
 
     private sealed class GetCommand : BaseConfigSubCommand
@@ -81,16 +79,15 @@ internal sealed class ConfigCommand : BaseCommand
 
         protected override bool UpdateNotificationsEnabled => false;
 
-        protected override Task<int> ExecuteAsync(ParseResult parseResult, CancellationToken cancellationToken)
+        protected override async Task<CommandResult> ExecuteAsync(ParseResult parseResult, CancellationToken cancellationToken)
         {
             var key = parseResult.GetValue(s_keyArgument);
             if (key is null)
             {
-                InteractionService.DisplayError(ErrorStrings.ConfigurationKeyRequired);
-                return Task.FromResult(ExitCodeConstants.InvalidCommand);
+                return CommandResult.Failure(ExitCodeConstants.InvalidCommand, ErrorStrings.ConfigurationKeyRequired);
             }
 
-            return ExecuteAsync(key, cancellationToken);
+            return CommandResult.FromExitCode(await ExecuteAsync(key, cancellationToken));
         }
 
         public override async Task<int> InteractiveExecuteAsync(CancellationToken cancellationToken)
@@ -141,7 +138,7 @@ internal sealed class ConfigCommand : BaseCommand
 
         protected override bool UpdateNotificationsEnabled => false;
 
-        protected override Task<int> ExecuteAsync(ParseResult parseResult, CancellationToken cancellationToken)
+        protected override async Task<CommandResult> ExecuteAsync(ParseResult parseResult, CancellationToken cancellationToken)
         {
             var key = parseResult.GetValue(s_keyArgument);
             var value = parseResult.GetValue(s_valueArgument);
@@ -149,17 +146,15 @@ internal sealed class ConfigCommand : BaseCommand
 
             if (key is null)
             {
-                InteractionService.DisplayError(ErrorStrings.ConfigurationKeyRequired);
-                return Task.FromResult(ExitCodeConstants.InvalidCommand);
+                return CommandResult.Failure(ExitCodeConstants.InvalidCommand, ErrorStrings.ConfigurationKeyRequired);
             }
 
             if (value is null)
             {
-                InteractionService.DisplayError(ErrorStrings.ConfigurationValueRequired);
-                return Task.FromResult(ExitCodeConstants.InvalidCommand);
+                return CommandResult.Failure(ExitCodeConstants.InvalidCommand, ErrorStrings.ConfigurationValueRequired);
             }
 
-            return ExecuteAsync(key, value, isGlobal, cancellationToken);
+            return CommandResult.FromExitCode(await ExecuteAsync(key, value, isGlobal, cancellationToken));
         }
 
         public override async Task<int> InteractiveExecuteAsync(CancellationToken cancellationToken)
@@ -225,10 +220,10 @@ internal sealed class ConfigCommand : BaseCommand
 
         protected override bool UpdateNotificationsEnabled => false;
 
-        protected override Task<int> ExecuteAsync(ParseResult parseResult, CancellationToken cancellationToken)
+        protected override async Task<CommandResult> ExecuteAsync(ParseResult parseResult, CancellationToken cancellationToken)
         {
             var showAll = parseResult.GetValue(s_allOption);
-            return ExecuteAsync(showAll, cancellationToken);
+            return CommandResult.FromExitCode(await ExecuteAsync(showAll, cancellationToken));
         }
 
         public override Task<int> InteractiveExecuteAsync(CancellationToken cancellationToken)
@@ -383,18 +378,17 @@ internal sealed class ConfigCommand : BaseCommand
 
         protected override bool UpdateNotificationsEnabled => false;
 
-        protected override Task<int> ExecuteAsync(ParseResult parseResult, CancellationToken cancellationToken)
+        protected override async Task<CommandResult> ExecuteAsync(ParseResult parseResult, CancellationToken cancellationToken)
         {
             var key = parseResult.GetValue(s_keyArgument);
             var isGlobal = parseResult.GetValue(s_globalOption);
 
             if (key is null)
             {
-                InteractionService.DisplayError(ErrorStrings.ConfigurationKeyRequired);
-                return Task.FromResult(ExitCodeConstants.InvalidCommand);
+                return CommandResult.Failure(ExitCodeConstants.InvalidCommand, ErrorStrings.ConfigurationKeyRequired);
             }
 
-            return ExecuteAsync(key, isGlobal, cancellationToken);
+            return CommandResult.FromExitCode(await ExecuteAsync(key, isGlobal, cancellationToken));
         }
 
         public override async Task<int> InteractiveExecuteAsync(CancellationToken cancellationToken)
@@ -469,10 +463,10 @@ internal sealed class ConfigCommand : BaseCommand
 
         protected override bool UpdateNotificationsEnabled => false;
 
-        protected override Task<int> ExecuteAsync(ParseResult parseResult, CancellationToken cancellationToken)
+        protected override async Task<CommandResult> ExecuteAsync(ParseResult parseResult, CancellationToken cancellationToken)
         {
             var useJson = parseResult.GetValue<bool>("--json");
-            return ExecuteAsync(useJson);
+            return CommandResult.FromExitCode(await ExecuteAsync(useJson));
         }
 
         public override Task<int> InteractiveExecuteAsync(CancellationToken cancellationToken)

--- a/src/Aspire.Cli/Commands/DashboardCommand.cs
+++ b/src/Aspire.Cli/Commands/DashboardCommand.cs
@@ -1,8 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.CommandLine;
-using System.CommandLine.Help;
 using Aspire.Cli.Configuration;
 using Aspire.Cli.Interaction;
 using Aspire.Cli.Resources;
@@ -14,7 +12,7 @@ namespace Aspire.Cli.Commands;
 /// <summary>
 /// Parent command for dashboard operations. Contains subcommands for running the dashboard.
 /// </summary>
-internal sealed class DashboardCommand : BaseCommand
+internal sealed class DashboardCommand : ParentCommand
 {
     internal override HelpGroup HelpGroup => HelpGroup.Monitoring;
 
@@ -30,13 +28,5 @@ internal sealed class DashboardCommand : BaseCommand
         ArgumentNullException.ThrowIfNull(runCommand);
 
         Subcommands.Add(runCommand);
-    }
-
-    protected override bool UpdateNotificationsEnabled => false;
-
-    protected override Task<int> ExecuteAsync(ParseResult parseResult, CancellationToken cancellationToken)
-    {
-        new HelpAction().Invoke(parseResult);
-        return Task.FromResult(ExitCodeConstants.InvalidCommand);
     }
 }

--- a/src/Aspire.Cli/Commands/DashboardRunCommand.cs
+++ b/src/Aspire.Cli/Commands/DashboardRunCommand.cs
@@ -82,20 +82,18 @@ internal sealed class DashboardRunCommand : BaseCommand
         TreatUnmatchedTokensAsErrors = false;
     }
 
-    protected override async Task<int> ExecuteAsync(ParseResult parseResult, CancellationToken cancellationToken)
+    protected override async Task<CommandResult> ExecuteAsync(ParseResult parseResult, CancellationToken cancellationToken)
     {
         var layout = await _bundleService.EnsureExtractedAndGetLayoutAsync(cancellationToken).ConfigureAwait(false);
         if (layout is null)
         {
-            _interactionService.DisplayError(DashboardCommandStrings.BundleLayoutNotFound);
-            return ExitCodeConstants.DashboardFailure;
+            return CommandResult.Failure(ExitCodeConstants.DashboardFailure, DashboardCommandStrings.BundleLayoutNotFound);
         }
 
         var managedPath = layout.GetManagedPath();
         if (managedPath is null || !File.Exists(managedPath))
         {
-            _interactionService.DisplayError(DashboardCommandStrings.ManagedBinaryNotFound);
-            return ExitCodeConstants.DashboardFailure;
+            return CommandResult.Failure(ExitCodeConstants.DashboardFailure, DashboardCommandStrings.ManagedBinaryNotFound);
         }
 
         var dashboardArgs = new List<string> { "dashboard" };
@@ -138,7 +136,7 @@ internal sealed class DashboardRunCommand : BaseCommand
         // Resolve URLs for the summary display.
         var dashboardInfo = ResolveDashboardInfo(dashboardArgs, unmatchedTokens, ExecutionContext, browserToken);
 
-        return await ExecuteForegroundAsync(managedPath, dashboardArgs, dashboardInfo, environmentVariables, cancellationToken).ConfigureAwait(false);
+        return CommandResult.FromExitCode(await ExecuteForegroundAsync(managedPath, dashboardArgs, dashboardInfo, environmentVariables, cancellationToken).ConfigureAwait(false));
     }
 
     private static void AddOptionArgs(ParseResult parseResult, List<string> args, IReadOnlyList<string> unmatchedTokens, CliExecutionContext executionContext)

--- a/src/Aspire.Cli/Commands/DashboardRunCommand.cs
+++ b/src/Aspire.Cli/Commands/DashboardRunCommand.cs
@@ -446,10 +446,6 @@ internal sealed class DashboardRunCommand : BaseCommand
                 : DashboardCommandStrings.DashboardStartTimedOut;
 
             _interactionService.DisplayError(exitMessage);
-            _interactionService.DisplayMessage(
-                KnownEmojis.PageFacingUp,
-                string.Format(CultureInfo.CurrentCulture, InteractionServiceStrings.SeeLogsAt, MarkupHelpers.SafeFileLink(_interactionService, ExecutionContext.LogFilePath)),
-                allowMarkup: true);
 
             if (!process.HasExited)
             {

--- a/src/Aspire.Cli/Commands/DashboardRunCommand.cs
+++ b/src/Aspire.Cli/Commands/DashboardRunCommand.cs
@@ -136,7 +136,7 @@ internal sealed class DashboardRunCommand : BaseCommand
         // Resolve URLs for the summary display.
         var dashboardInfo = ResolveDashboardInfo(dashboardArgs, unmatchedTokens, ExecutionContext, browserToken);
 
-        return CommandResult.FromExitCode(await ExecuteForegroundAsync(managedPath, dashboardArgs, dashboardInfo, environmentVariables, cancellationToken).ConfigureAwait(false));
+        return await ExecuteForegroundAsync(managedPath, dashboardArgs, dashboardInfo, environmentVariables, cancellationToken).ConfigureAwait(false);
     }
 
     private static void AddOptionArgs(ParseResult parseResult, List<string> args, IReadOnlyList<string> unmatchedTokens, CliExecutionContext executionContext)
@@ -348,7 +348,7 @@ internal sealed class DashboardRunCommand : BaseCommand
         interactionService.DisplayRenderable(padder);
     }
 
-    private async Task<int> ExecuteForegroundAsync(string managedPath, List<string> dashboardArgs, DashboardInfo dashboardInfo, IDictionary<string, string>? environmentVariables, CancellationToken cancellationToken)
+    private async Task<CommandResult> ExecuteForegroundAsync(string managedPath, List<string> dashboardArgs, DashboardInfo dashboardInfo, IDictionary<string, string>? environmentVariables, CancellationToken cancellationToken)
     {
         _logger.LogDebug("Starting dashboard in foreground: {ManagedPath}", managedPath);
 
@@ -384,7 +384,7 @@ internal sealed class DashboardRunCommand : BaseCommand
         {
             _logger.LogError(ex, "Failed to start dashboard process: {ManagedPath}", managedPath);
             _interactionService.DisplayError(string.Format(CultureInfo.CurrentCulture, DashboardCommandStrings.DashboardFailedToStart, ex.Message));
-            return ExitCodeConstants.DashboardFailure;
+            return CommandResult.Failure(ExitCodeConstants.DashboardFailure);
         }
 
         using var _ = process;
@@ -420,7 +420,9 @@ internal sealed class DashboardRunCommand : BaseCommand
                 process.Kill(entireProcessTree: true);
             }
 
-            return ExitCodeConstants.Success;
+            // Command is designed to be cancellable by the user (e.g. Ctrl+C) at any time.
+            // Treat cancellation as a successful exit since the user intentionally stopped the dashboard.
+            return CommandResult.Cancelled(ExitCodeConstants.Success);
         }
 
         if (completedTask != readyTcs.Task)
@@ -450,7 +452,7 @@ internal sealed class DashboardRunCommand : BaseCommand
                 process.Kill(entireProcessTree: true);
             }
 
-            return ExitCodeConstants.DashboardFailure;
+            return CommandResult.Failure(ExitCodeConstants.DashboardFailure);
         }
 
         // Dashboard is ready.
@@ -470,7 +472,7 @@ internal sealed class DashboardRunCommand : BaseCommand
                 process.Kill(entireProcessTree: true);
             }
 
-            return ExitCodeConstants.Success;
+            return CommandResult.Cancelled(ExitCodeConstants.Success);
         }
 
         if (process.ExitCode != 0)
@@ -478,6 +480,6 @@ internal sealed class DashboardRunCommand : BaseCommand
             _interactionService.DisplayError(GetExitCodeMessage(process.ExitCode));
         }
 
-        return process.ExitCode == 0 ? ExitCodeConstants.Success : ExitCodeConstants.DashboardFailure;
+        return process.ExitCode == 0 ? CommandResult.Success() : CommandResult.Failure(ExitCodeConstants.DashboardFailure);
     }
 }

--- a/src/Aspire.Cli/Commands/DescribeCommand.cs
+++ b/src/Aspire.Cli/Commands/DescribeCommand.cs
@@ -120,7 +120,7 @@ internal sealed class DescribeCommand : BaseCommand
         Options.Add(s_includeHiddenOption);
     }
 
-    protected override async Task<int> ExecuteAsync(ParseResult parseResult, CancellationToken cancellationToken)
+    protected override async Task<CommandResult> ExecuteAsync(ParseResult parseResult, CancellationToken cancellationToken)
     {
         using var activity = Telemetry.StartDiagnosticActivity(Name);
 
@@ -139,7 +139,7 @@ internal sealed class DescribeCommand : BaseCommand
 
         if (!result.Success)
         {
-            return AppHostConnectionResultHandler.DisplayFailureAsInformation(result, _interactionService);
+            return CommandResult.FromExitCode(AppHostConnectionResultHandler.DisplayFailureAsInformation(result, _interactionService));
         }
 
         var connection = result.Connection!;
@@ -163,17 +163,17 @@ internal sealed class DescribeCommand : BaseCommand
         {
             try
             {
-                return await ExecuteWatchAsync(connection, resourceWatcher, dashboardBaseUrl, resourceName, format, cancellationToken);
+                return CommandResult.FromExitCode(await ExecuteWatchAsync(connection, resourceWatcher, dashboardBaseUrl, resourceName, format, cancellationToken));
             }
             catch (OperationCanceledException ex) when (ex.CancellationToken == cancellationToken || cancellationToken.IsCancellationRequested)
             {
-                return ExitCodeConstants.Success;
+                return CommandResult.Success();
             }
             catch (Exception ex) when (AppHostFollowDisconnectHelpers.IsExpectedDisconnect(ex))
             {
                 if (cancellationToken.IsCancellationRequested)
                 {
-                    return ExitCodeConstants.Success;
+                    return CommandResult.Success();
                 }
 
                 // Stopping or restarting the AppHost can tear down the JSON-RPC stream while
@@ -182,12 +182,12 @@ internal sealed class DescribeCommand : BaseCommand
                 // message on stderr so JSON output on stdout remains parseable.
                 AppHostFollowDisconnectHelpers.WriteStatusMessage(_interactionService, connection);
 
-                return ExitCodeConstants.Success;
+                return CommandResult.Success();
             }
         }
         else
         {
-            return ExecuteSnapshot(resourceWatcher.GetResources().ToList(), dashboardBaseUrl, resourceName, format);
+            return CommandResult.FromExitCode(ExecuteSnapshot(resourceWatcher.GetResources().ToList(), dashboardBaseUrl, resourceName, format));
         }
     }
 

--- a/src/Aspire.Cli/Commands/DocsCommand.cs
+++ b/src/Aspire.Cli/Commands/DocsCommand.cs
@@ -1,8 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.CommandLine;
-using System.CommandLine.Help;
 using Aspire.Cli.Configuration;
 using Aspire.Cli.Interaction;
 using Aspire.Cli.Resources;
@@ -14,7 +12,7 @@ namespace Aspire.Cli.Commands;
 /// <summary>
 /// Parent command for documentation operations. Contains subcommands for listing, searching, and getting docs, including API reference content.
 /// </summary>
-internal sealed class DocsCommand : BaseCommand
+internal sealed class DocsCommand : ParentCommand
 {
     internal override HelpGroup HelpGroup => HelpGroup.ToolsAndConfiguration;
 
@@ -34,13 +32,5 @@ internal sealed class DocsCommand : BaseCommand
         Subcommands.Add(searchCommand);
         Subcommands.Add(getCommand);
         Subcommands.Add(apiCommand);
-    }
-
-    protected override bool UpdateNotificationsEnabled => false;
-
-    protected override Task<int> ExecuteAsync(ParseResult parseResult, CancellationToken cancellationToken)
-    {
-        new HelpAction().Invoke(parseResult);
-        return Task.FromResult(ExitCodeConstants.InvalidCommand);
     }
 }

--- a/src/Aspire.Cli/Commands/DocsGetCommand.cs
+++ b/src/Aspire.Cli/Commands/DocsGetCommand.cs
@@ -57,7 +57,7 @@ internal sealed class DocsGetCommand : BaseCommand
 
     protected override bool UpdateNotificationsEnabled => false;
 
-    protected override async Task<int> ExecuteAsync(ParseResult parseResult, CancellationToken cancellationToken)
+    protected override async Task<CommandResult> ExecuteAsync(ParseResult parseResult, CancellationToken cancellationToken)
     {
         using var activity = Telemetry.StartDiagnosticActivity(Name);
 
@@ -74,8 +74,7 @@ internal sealed class DocsGetCommand : BaseCommand
 
         if (doc is null)
         {
-            InteractionService.DisplayError(string.Format(CultureInfo.CurrentCulture, DocsCommandStrings.DocumentNotFound, slug));
-            return ExitCodeConstants.InvalidCommand;
+            return CommandResult.Failure(ExitCodeConstants.InvalidCommand, string.Format(CultureInfo.CurrentCulture, DocsCommandStrings.DocumentNotFound, slug));
         }
 
         if (format is OutputFormat.Json)
@@ -89,6 +88,6 @@ internal sealed class DocsGetCommand : BaseCommand
             InteractionService.DisplayMarkdown(doc.Content, maxWidth: 100);
         }
 
-        return ExitCodeConstants.Success;
+        return CommandResult.Success();
     }
 }

--- a/src/Aspire.Cli/Commands/DocsListCommand.cs
+++ b/src/Aspire.Cli/Commands/DocsListCommand.cs
@@ -46,7 +46,7 @@ internal sealed class DocsListCommand : BaseCommand
 
     protected override bool UpdateNotificationsEnabled => false;
 
-    protected override async Task<int> ExecuteAsync(ParseResult parseResult, CancellationToken cancellationToken)
+    protected override async Task<CommandResult> ExecuteAsync(ParseResult parseResult, CancellationToken cancellationToken)
     {
         using var activity = Telemetry.StartDiagnosticActivity(Name);
 
@@ -61,8 +61,7 @@ internal sealed class DocsListCommand : BaseCommand
 
         if (docs.Count is 0)
         {
-            InteractionService.DisplayError(DocsCommandStrings.NoDocumentationAvailable);
-            return ExitCodeConstants.InvalidCommand;
+            return CommandResult.Failure(ExitCodeConstants.InvalidCommand, DocsCommandStrings.NoDocumentationAvailable);
         }
 
         if (format is OutputFormat.Json)
@@ -91,6 +90,6 @@ internal sealed class DocsListCommand : BaseCommand
             InteractionService.DisplayRenderable(table);
         }
 
-        return ExitCodeConstants.Success;
+        return CommandResult.Success();
     }
 }

--- a/src/Aspire.Cli/Commands/DocsSearchCommand.cs
+++ b/src/Aspire.Cli/Commands/DocsSearchCommand.cs
@@ -58,7 +58,7 @@ internal sealed class DocsSearchCommand : BaseCommand
 
     protected override bool UpdateNotificationsEnabled => false;
 
-    protected override async Task<int> ExecuteAsync(ParseResult parseResult, CancellationToken cancellationToken)
+    protected override async Task<CommandResult> ExecuteAsync(ParseResult parseResult, CancellationToken cancellationToken)
     {
         using var activity = Telemetry.StartDiagnosticActivity(Name);
 
@@ -76,7 +76,7 @@ internal sealed class DocsSearchCommand : BaseCommand
         if (response is null || response.Results.Count is 0)
         {
             InteractionService.DisplayError(string.Format(CultureInfo.CurrentCulture, DocsCommandStrings.NoResultsFound, query));
-            return ExitCodeConstants.Success; // Not an error, just no results
+            return CommandResult.Success(); // Not an error, just no results
         }
 
         if (format is OutputFormat.Json)
@@ -108,6 +108,6 @@ internal sealed class DocsSearchCommand : BaseCommand
             InteractionService.DisplayRenderable(table);
         }
 
-        return ExitCodeConstants.Success;
+        return CommandResult.Success();
     }
 }

--- a/src/Aspire.Cli/Commands/DoctorCommand.cs
+++ b/src/Aspire.Cli/Commands/DoctorCommand.cs
@@ -40,7 +40,7 @@ internal sealed class DoctorCommand : BaseCommand
         Options.Add(s_formatOption);
     }
 
-    protected override async Task<int> ExecuteAsync(ParseResult parseResult, CancellationToken cancellationToken)
+    protected override async Task<CommandResult> ExecuteAsync(ParseResult parseResult, CancellationToken cancellationToken)
     {
         var format = parseResult.GetValue(s_formatOption);
 
@@ -60,7 +60,7 @@ internal sealed class DoctorCommand : BaseCommand
 
         // Exit code: 0 if no failures (warnings are OK), 1 (InvalidCommand) if any failures
         var hasFailures = results.Any(r => r.Status == EnvironmentCheckStatus.Fail);
-        return hasFailures ? ExitCodeConstants.InvalidCommand : ExitCodeConstants.Success;
+        return CommandResult.FromExitCode(hasFailures ? ExitCodeConstants.InvalidCommand : ExitCodeConstants.Success);
     }
 
     private void OutputJson(IReadOnlyList<EnvironmentCheckResult> results)

--- a/src/Aspire.Cli/Commands/ExportCommand.cs
+++ b/src/Aspire.Cli/Commands/ExportCommand.cs
@@ -113,7 +113,7 @@ internal sealed class ExportCommand : BaseCommand
         }
 
         var dashboardApi = await TelemetryCommandHelpers.GetDashboardApiAsync(
-            _connectionResolver, _interactionService, _httpClientFactory, _logger, passedAppHostProjectFile, dashboardUrl, apiKey, requireDashboard: false, ExecutionContext.LogFilePath, cancellationToken);
+            _connectionResolver, _interactionService, _httpClientFactory, _logger, passedAppHostProjectFile, dashboardUrl, apiKey, requireDashboard: false, cancellationToken);
 
         if (!dashboardApi.Success)
         {
@@ -133,7 +133,7 @@ internal sealed class ExportCommand : BaseCommand
         {
             _logger.LogError(ex, "Failed to export telemetry data from dashboard");
             var errorInfo = await TelemetryCommandHelpers.FormatTelemetryErrorAsync(ex, dashboardApi.BaseUrl!, true, _httpClientFactory, _logger, cancellationToken);
-            TelemetryCommandHelpers.DisplayTelemetryError(_interactionService, errorInfo, ExecutionContext.LogFilePath);
+            TelemetryCommandHelpers.DisplayTelemetryError(_interactionService, errorInfo);
             return ExitCodeConstants.DashboardFailure;
         }
         catch (Exception ex)

--- a/src/Aspire.Cli/Commands/ExportCommand.cs
+++ b/src/Aspire.Cli/Commands/ExportCommand.cs
@@ -80,7 +80,7 @@ internal sealed class ExportCommand : BaseCommand
         Options.Add(s_includeHiddenOption);
     }
 
-    protected override async Task<int> ExecuteAsync(ParseResult parseResult, CancellationToken cancellationToken)
+    protected override async Task<CommandResult> ExecuteAsync(ParseResult parseResult, CancellationToken cancellationToken)
     {
         using var activity = Telemetry.StartDiagnosticActivity(Name);
 
@@ -94,8 +94,7 @@ internal sealed class ExportCommand : BaseCommand
         // Validate mutual exclusivity of --apphost and --dashboard-url
         if (passedAppHostProjectFile is not null && dashboardUrl is not null)
         {
-            _interactionService.DisplayError(TelemetryCommandStrings.DashboardUrlAndAppHostExclusive);
-            return ExitCodeConstants.InvalidCommand;
+            return CommandResult.Failure(ExitCodeConstants.InvalidCommand, TelemetryCommandStrings.DashboardUrlAndAppHostExclusive);
         }
 
         // Default file name if not specified
@@ -117,7 +116,7 @@ internal sealed class ExportCommand : BaseCommand
 
         if (!dashboardApi.Success)
         {
-            return dashboardApi.ExitCode;
+            return CommandResult.FromExitCode(dashboardApi.ExitCode);
         }
 
         if (dashboardApi.BaseUrl is null)
@@ -127,20 +126,19 @@ internal sealed class ExportCommand : BaseCommand
 
         try
         {
-            return await ExportDataAsync(resourceName, includeHidden, dashboardApi.Connection, dashboardApi.BaseUrl, dashboardApi.ApiToken, outputPath, cancellationToken);
+            return CommandResult.FromExitCode(await ExportDataAsync(resourceName, includeHidden, dashboardApi.Connection, dashboardApi.BaseUrl, dashboardApi.ApiToken, outputPath, cancellationToken));
         }
         catch (HttpRequestException ex) when (dashboardUrl is not null)
         {
             _logger.LogError(ex, "Failed to export telemetry data from dashboard");
             var errorInfo = await TelemetryCommandHelpers.FormatTelemetryErrorAsync(ex, dashboardApi.BaseUrl!, true, _httpClientFactory, _logger, cancellationToken);
             TelemetryCommandHelpers.DisplayTelemetryError(_interactionService, errorInfo);
-            return ExitCodeConstants.DashboardFailure;
+            return CommandResult.Failure(ExitCodeConstants.DashboardFailure);
         }
         catch (Exception ex)
         {
             _logger.LogError(ex, "Failed to export telemetry data");
-            _interactionService.DisplayError(string.Format(CultureInfo.CurrentCulture, ExportCommandStrings.FailedToExport, ex.Message));
-            return ExitCodeConstants.DashboardFailure;
+            return CommandResult.Failure(ExitCodeConstants.DashboardFailure, string.Format(CultureInfo.CurrentCulture, ExportCommandStrings.FailedToExport, ex.Message));
         }
     }
 

--- a/src/Aspire.Cli/Commands/ExtensionInternalCommand.cs
+++ b/src/Aspire.Cli/Commands/ExtensionInternalCommand.cs
@@ -21,9 +21,9 @@ internal sealed class ExtensionInternalCommand : BaseCommand
         this.Subcommands.Add(new GetAppHostCandidatesCommand(features, updateNotifier, projectLocator, executionContext, interactionService, telemetry));
     }
 
-    protected override Task<int> ExecuteAsync(ParseResult parseResult, CancellationToken cancellationToken)
+    protected override Task<CommandResult> ExecuteAsync(ParseResult parseResult, CancellationToken cancellationToken)
     {
-        return Task.FromResult(ExitCodeConstants.Success);
+        return Task.FromResult(CommandResult.FromExitCode(ExitCodeConstants.Success));
     }
 
     private sealed class GetAppHostCandidatesCommand : BaseCommand
@@ -37,7 +37,7 @@ internal sealed class ExtensionInternalCommand : BaseCommand
 
         protected override bool UpdateNotificationsEnabled => false;
 
-        protected override async Task<int> ExecuteAsync(ParseResult parseResult, CancellationToken cancellationToken)
+        protected override async Task<CommandResult> ExecuteAsync(ParseResult parseResult, CancellationToken cancellationToken)
         {
             try
             {
@@ -50,11 +50,11 @@ internal sealed class ExtensionInternalCommand : BaseCommand
                 }, BackchannelJsonSerializerContext.Default.AppHostProjectSearchResultPoco);
                 // Structured output always goes to stdout.
                 InteractionService.DisplayRawText(json, ConsoleOutput.Standard);
-                return ExitCodeConstants.Success;
+                return CommandResult.Success();
             }
             catch
             {
-                return ExitCodeConstants.FailedToFindProject;
+                return CommandResult.Failure(ExitCodeConstants.FailedToFindProject);
             }
         }
     }

--- a/src/Aspire.Cli/Commands/InitCommand.cs
+++ b/src/Aspire.Cli/Commands/InitCommand.cs
@@ -105,7 +105,7 @@ internal sealed class InitCommand : BaseCommand
         Options.Add(NewCommand.s_suppressAgentInitOption);
     }
 
-    protected override async Task<int> ExecuteAsync(ParseResult parseResult, CancellationToken cancellationToken)
+    protected override async Task<CommandResult> ExecuteAsync(ParseResult parseResult, CancellationToken cancellationToken)
     {
         using var activity = Telemetry.StartDiagnosticActivity(this.Name);
 
@@ -133,8 +133,7 @@ internal sealed class InitCommand : BaseCommand
 
         if (dropResult != ExitCodeConstants.Success)
         {
-            InteractionService.DisplayError(InteractionServiceStrings.ProjectCouldNotBeCreated);
-            return dropResult;
+            return CommandResult.Failure(dropResult, InteractionServiceStrings.ProjectCouldNotBeCreated);
         }
 
         // Persist the prompted language selection now that the skeleton drop succeeded.
@@ -187,7 +186,7 @@ internal sealed class InitCommand : BaseCommand
             }
         }
 
-        return agentInitResult.ExitCode;
+        return CommandResult.FromExitCode(agentInitResult.ExitCode);
     }
 
     private void DisplayDeprecatedOptionWarnings(ParseResult parseResult)

--- a/src/Aspire.Cli/Commands/InitCommand.cs
+++ b/src/Aspire.Cli/Commands/InitCommand.cs
@@ -134,10 +134,6 @@ internal sealed class InitCommand : BaseCommand
         if (dropResult != ExitCodeConstants.Success)
         {
             InteractionService.DisplayError(InteractionServiceStrings.ProjectCouldNotBeCreated);
-            InteractionService.DisplayMessage(
-                KnownEmojis.PageFacingUp,
-                string.Format(CultureInfo.CurrentCulture, InteractionServiceStrings.SeeLogsAt, MarkupHelpers.SafeFileLink(InteractionService, ExecutionContext.LogFilePath)),
-                allowMarkup: true);
             return dropResult;
         }
 
@@ -392,7 +388,7 @@ internal sealed class InitCommand : BaseCommand
         if (installOutcome.ExitCode != 0)
         {
             InteractionService.DisplayLines(installOutcome.OutputLines);
-            InteractionService.DisplayError(string.Format(CultureInfo.CurrentCulture, TemplatingStrings.TemplateInstallationFailed, installOutcome.ExitCode, _executionContext.LogFilePath));
+            InteractionService.DisplayError(string.Format(CultureInfo.CurrentCulture, TemplatingStrings.TemplateInstallationFailed, installOutcome.ExitCode));
             return ExitCodeConstants.FailedToInstallTemplates;
         }
 

--- a/src/Aspire.Cli/Commands/IntegrationCommand.cs
+++ b/src/Aspire.Cli/Commands/IntegrationCommand.cs
@@ -1,8 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.CommandLine;
-using System.CommandLine.Help;
 using Aspire.Cli.Configuration;
 using Aspire.Cli.Interaction;
 using Aspire.Cli.Resources;
@@ -11,7 +9,7 @@ using Aspire.Cli.Utils;
 
 namespace Aspire.Cli.Commands;
 
-internal sealed class IntegrationCommand : BaseCommand
+internal sealed class IntegrationCommand : ParentCommand
 {
     internal override HelpGroup HelpGroup => HelpGroup.AppCommands;
 
@@ -29,13 +27,5 @@ internal sealed class IntegrationCommand : BaseCommand
         Subcommands.Add(addCommand);
         Subcommands.Add(listCommand);
         Subcommands.Add(searchCommand);
-    }
-
-    protected override bool UpdateNotificationsEnabled => false;
-
-    protected override Task<int> ExecuteAsync(ParseResult parseResult, CancellationToken cancellationToken)
-    {
-        new HelpAction().Invoke(parseResult);
-        return Task.FromResult(ExitCodeConstants.InvalidCommand);
     }
 }

--- a/src/Aspire.Cli/Commands/IntegrationSearchCommand.cs
+++ b/src/Aspire.Cli/Commands/IntegrationSearchCommand.cs
@@ -46,7 +46,7 @@ internal abstract class IntegrationDiscoveryCommand : BaseCommand
 
     protected abstract string? GetSearchTerm(ParseResult parseResult);
 
-    protected override async Task<int> ExecuteAsync(ParseResult parseResult, CancellationToken cancellationToken)
+    protected override async Task<CommandResult> ExecuteAsync(ParseResult parseResult, CancellationToken cancellationToken)
     {
         using var activity = Telemetry.StartDiagnosticActivity(Name);
 
@@ -59,7 +59,7 @@ internal abstract class IntegrationDiscoveryCommand : BaseCommand
             var (workingDirectory, configuredChannel, contextExitCode) = await _integrationPackageSearchService.GetPackageSearchContextAsync(passedAppHostProjectFile, cancellationToken);
             if (contextExitCode is { } exitCode)
             {
-                return exitCode;
+                return CommandResult.FromExitCode(exitCode);
             }
 
             var packagesWithChannels = (await InteractionService.ShowStatusAsync(
@@ -72,7 +72,7 @@ internal abstract class IntegrationDiscoveryCommand : BaseCommand
                 .OrderBy(p => p.FriendlyName, new CommunityToolkitFirstComparer())
                 .ToArray();
 
-            return DisplayIntegrationResults(packagesWithShortName, searchTerm, format);
+            return CommandResult.FromExitCode(DisplayIntegrationResults(packagesWithShortName, searchTerm, format));
         }
         catch (ProjectLocatorException ex)
         {
@@ -81,14 +81,13 @@ internal abstract class IntegrationDiscoveryCommand : BaseCommand
         catch (OperationCanceledException)
         {
             InteractionService.DisplayCancellationMessage();
-            return ExitCodeConstants.FailedToSearchIntegrations;
+            return CommandResult.Failure(ExitCodeConstants.FailedToSearchIntegrations);
         }
         catch (Exception ex)
         {
             var errorMessage = string.Format(CultureInfo.CurrentCulture, AddCommandStrings.ErrorOccurredWhileSearchingIntegrations, ex.Message);
             Telemetry.RecordError(errorMessage, ex);
-            InteractionService.DisplayError(errorMessage);
-            return ExitCodeConstants.FailedToSearchIntegrations;
+            return CommandResult.Failure(ExitCodeConstants.FailedToSearchIntegrations, errorMessage);
         }
     }
 

--- a/src/Aspire.Cli/Commands/IntegrationSearchCommand.cs
+++ b/src/Aspire.Cli/Commands/IntegrationSearchCommand.cs
@@ -80,8 +80,7 @@ internal abstract class IntegrationDiscoveryCommand : BaseCommand
         }
         catch (OperationCanceledException)
         {
-            InteractionService.DisplayCancellationMessage();
-            return CommandResult.Failure(ExitCodeConstants.FailedToSearchIntegrations);
+            return CommandResult.Cancelled();
         }
         catch (Exception ex)
         {

--- a/src/Aspire.Cli/Commands/LogsCommand.cs
+++ b/src/Aspire.Cli/Commands/LogsCommand.cs
@@ -142,7 +142,7 @@ internal sealed class LogsCommand : BaseCommand
         Options.Add(s_searchOption);
     }
 
-    protected override async Task<int> ExecuteAsync(ParseResult parseResult, CancellationToken cancellationToken)
+    protected override async Task<CommandResult> ExecuteAsync(ParseResult parseResult, CancellationToken cancellationToken)
     {
         using var activity = Telemetry.StartDiagnosticActivity(Name);
 
@@ -158,8 +158,7 @@ internal sealed class LogsCommand : BaseCommand
         // Validate --tail value
         if (tail.HasValue && tail.Value < 1)
         {
-            _interactionService.DisplayError(LogsCommandStrings.TailMustBePositive);
-            return ExitCodeConstants.InvalidCommand;
+            return CommandResult.Failure(ExitCodeConstants.InvalidCommand, LogsCommandStrings.TailMustBePositive);
         }
 
         var result = await _connectionResolver.ResolveConnectionAsync(
@@ -171,7 +170,7 @@ internal sealed class LogsCommand : BaseCommand
 
         if (!result.Success)
         {
-            return AppHostConnectionResultHandler.DisplayFailureAsInformation(result, _interactionService);
+            return CommandResult.FromExitCode(AppHostConnectionResultHandler.DisplayFailureAsInformation(result, _interactionService));
         }
 
         var connection = result.Connection!;
@@ -189,8 +188,7 @@ internal sealed class LogsCommand : BaseCommand
         {
             if (!ResourceSnapshotMapper.WhereMatchesResourceName(resourceWatcher.GetAllResources(), resourceName).Any())
             {
-                _interactionService.DisplayError(string.Format(CultureInfo.CurrentCulture, LogsCommandStrings.ResourceNotFound, resourceName));
-                return ExitCodeConstants.InvalidCommand;
+                return CommandResult.Failure(ExitCodeConstants.InvalidCommand, string.Format(CultureInfo.CurrentCulture, LogsCommandStrings.ResourceNotFound, resourceName));
             }
         }
         else
@@ -198,7 +196,7 @@ internal sealed class LogsCommand : BaseCommand
             if (!resourceWatcher.GetResources().Any())
             {
                 _interactionService.DisplayMessage(KnownEmojis.Information, LogsCommandStrings.NoResourcesFound);
-                return ExitCodeConstants.Success;
+                return CommandResult.Success();
             }
         }
 
@@ -206,17 +204,17 @@ internal sealed class LogsCommand : BaseCommand
         {
             try
             {
-                return await ExecuteWatchAsync(connection, resourceWatcher, resourceName, format, tail, timestamps, search, cancellationToken);
+                return CommandResult.FromExitCode(await ExecuteWatchAsync(connection, resourceWatcher, resourceName, format, tail, timestamps, search, cancellationToken));
             }
             catch (OperationCanceledException ex) when (ex.CancellationToken == cancellationToken || cancellationToken.IsCancellationRequested)
             {
-                return ExitCodeConstants.Success;
+                return CommandResult.Success();
             }
             catch (Exception ex) when (AppHostFollowDisconnectHelpers.IsExpectedDisconnect(ex))
             {
                 if (cancellationToken.IsCancellationRequested)
                 {
-                    return ExitCodeConstants.Success;
+                    return CommandResult.Success();
                 }
 
                 // Stopping or restarting the AppHost can tear down the JSON-RPC stream while
@@ -225,12 +223,12 @@ internal sealed class LogsCommand : BaseCommand
                 // message on stderr so JSON output on stdout remains parseable.
                 AppHostFollowDisconnectHelpers.WriteStatusMessage(_interactionService, connection);
 
-                return ExitCodeConstants.Success;
+                return CommandResult.Success();
             }
         }
         else
         {
-            return await ExecuteGetAsync(connection, resourceWatcher, resourceName, format, tail, timestamps, search, cancellationToken);
+            return CommandResult.FromExitCode(await ExecuteGetAsync(connection, resourceWatcher, resourceName, format, tail, timestamps, search, cancellationToken));
         }
     }
 

--- a/src/Aspire.Cli/Commands/LsCommand.cs
+++ b/src/Aspire.Cli/Commands/LsCommand.cs
@@ -51,7 +51,7 @@ internal sealed class LsCommand : BaseCommand
         Options.Add(s_allOption);
     }
 
-    protected override async Task<int> ExecuteAsync(ParseResult parseResult, CancellationToken cancellationToken)
+    protected override async Task<CommandResult> ExecuteAsync(ParseResult parseResult, CancellationToken cancellationToken)
     {
         using var activity = Telemetry.StartDiagnosticActivity(Name);
 
@@ -96,7 +96,7 @@ internal sealed class LsCommand : BaseCommand
             DisplayTable(appHostInfos);
         }
 
-        return ExitCodeConstants.Success;
+        return CommandResult.Success();
     }
 
     private void DisplayTable(List<CandidateAppHostDisplayInfo> appHosts)

--- a/src/Aspire.Cli/Commands/McpCallCommand.cs
+++ b/src/Aspire.Cli/Commands/McpCallCommand.cs
@@ -63,7 +63,7 @@ internal sealed class McpCallCommand : BaseCommand
         Options.Add(s_appHostOption);
     }
 
-    protected override async Task<int> ExecuteAsync(ParseResult parseResult, CancellationToken cancellationToken)
+    protected override async Task<CommandResult> ExecuteAsync(ParseResult parseResult, CancellationToken cancellationToken)
     {
         var resourceName = parseResult.GetValue(s_resourceArgument)!;
         var toolName = parseResult.GetValue(s_toolArgument)!;
@@ -79,7 +79,7 @@ internal sealed class McpCallCommand : BaseCommand
 
         if (!result.Success)
         {
-            return AppHostConnectionResultHandler.DisplayFailureAsError(result, _interactionService, ExitCodeConstants.FailedToDotnetRunAppHost);
+            return CommandResult.FromExitCode(AppHostConnectionResultHandler.DisplayFailureAsError(result, _interactionService, ExitCodeConstants.FailedToDotnetRunAppHost));
         }
 
         var connection = result.Connection!;
@@ -93,8 +93,7 @@ internal sealed class McpCallCommand : BaseCommand
                 using var doc = JsonDocument.Parse(inputJson);
                 if (doc.RootElement.ValueKind != JsonValueKind.Object)
                 {
-                    _interactionService.DisplayError("Invalid JSON input: expected a JSON object.");
-                    return ExitCodeConstants.InvalidCommand;
+                    return CommandResult.Failure(ExitCodeConstants.InvalidCommand, "Invalid JSON input: expected a JSON object.");
                 }
                 var dict = new Dictionary<string, JsonElement>();
                 foreach (var prop in doc.RootElement.EnumerateObject())
@@ -105,8 +104,7 @@ internal sealed class McpCallCommand : BaseCommand
             }
             catch (JsonException ex)
             {
-                _interactionService.DisplayError($"Invalid JSON input: {ex.Message}");
-                return ExitCodeConstants.InvalidCommand;
+                return CommandResult.Failure(ExitCodeConstants.InvalidCommand, $"Invalid JSON input: {ex.Message}");
             }
         }
 
@@ -143,15 +141,14 @@ internal sealed class McpCallCommand : BaseCommand
 
             if (callResult.IsError == true)
             {
-                return ExitCodeConstants.InvalidCommand;
+                return CommandResult.Failure(ExitCodeConstants.InvalidCommand);
             }
 
-            return ExitCodeConstants.Success;
+            return CommandResult.Success();
         }
         catch (Exception ex)
         {
-            _interactionService.DisplayError($"Failed to call tool '{toolName}' on resource '{resourceName}': {ex.Message}");
-            return ExitCodeConstants.InvalidCommand;
+            return CommandResult.Failure(ExitCodeConstants.InvalidCommand, $"Failed to call tool '{toolName}' on resource '{resourceName}': {ex.Message}");
         }
     }
 }

--- a/src/Aspire.Cli/Commands/McpCommand.cs
+++ b/src/Aspire.Cli/Commands/McpCommand.cs
@@ -1,8 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.CommandLine;
-using System.CommandLine.Help;
 using Aspire.Cli.Configuration;
 using Aspire.Cli.Interaction;
 using Aspire.Cli.Resources;
@@ -15,7 +13,7 @@ namespace Aspire.Cli.Commands;
 /// MCP command for interacting with MCP tools exposed by running resources.
 /// Also provides legacy 'start' and 'init' subcommands for backward compatibility.
 /// </summary>
-internal sealed class McpCommand : BaseCommand
+internal sealed class McpCommand : ParentCommand
 {
     internal override HelpGroup HelpGroup => HelpGroup.ToolsAndConfiguration;
 
@@ -39,13 +37,5 @@ internal sealed class McpCommand : BaseCommand
         initCommand.Hidden = true;
         Subcommands.Add(startCommand);
         Subcommands.Add(initCommand);
-    }
-
-    protected override bool UpdateNotificationsEnabled => false;
-
-    protected override Task<int> ExecuteAsync(ParseResult parseResult, CancellationToken cancellationToken)
-    {
-        new HelpAction().Invoke(parseResult);
-        return Task.FromResult(ExitCodeConstants.InvalidCommand);
     }
 }

--- a/src/Aspire.Cli/Commands/McpInitCommand.cs
+++ b/src/Aspire.Cli/Commands/McpInitCommand.cs
@@ -60,13 +60,13 @@ internal sealed class McpInitCommand : BaseCommand, IPackageMetaPrefetchingComma
 
     protected override bool UpdateNotificationsEnabled => false;
 
-    protected override Task<int> ExecuteAsync(ParseResult parseResult, CancellationToken cancellationToken)
+    protected override async Task<CommandResult> ExecuteAsync(ParseResult parseResult, CancellationToken cancellationToken)
     {
         // Display deprecation warning
         InteractionService.DisplayMarkupLine($"[yellow]⚠ {McpCommandStrings.DeprecatedCommandWarning}[/]");
         InteractionService.DisplayEmptyLine();
         
         // Delegate to the new AgentInitCommand
-        return _agentInitCommand.ExecuteCommandAsync(parseResult, cancellationToken);
+        return await _agentInitCommand.ExecuteCommandAsync(parseResult, cancellationToken);
     }
 }

--- a/src/Aspire.Cli/Commands/McpStartCommand.cs
+++ b/src/Aspire.Cli/Commands/McpStartCommand.cs
@@ -33,12 +33,12 @@ internal sealed class McpStartCommand : BaseCommand
 
     protected override bool UpdateNotificationsEnabled => false;
 
-    protected override Task<int> ExecuteAsync(ParseResult parseResult, CancellationToken cancellationToken)
+    protected override async Task<CommandResult> ExecuteAsync(ParseResult parseResult, CancellationToken cancellationToken)
     {
         // Display deprecation warning to stderr (all MCP logging goes to stderr)
         InteractionService.DisplayMarkupLine($"[yellow]⚠ {McpCommandStrings.DeprecatedCommandWarning}[/]");
 
         // Delegate to the new AgentMcpCommand
-        return _agentMcpCommand.ExecuteCommandAsync(parseResult, cancellationToken);
+        return await _agentMcpCommand.ExecuteCommandAsync(parseResult, cancellationToken);
     }
 }

--- a/src/Aspire.Cli/Commands/McpToolsCommand.cs
+++ b/src/Aspire.Cli/Commands/McpToolsCommand.cs
@@ -50,7 +50,7 @@ internal sealed class McpToolsCommand : BaseCommand
         Options.Add(s_formatOption);
     }
 
-    protected override async Task<int> ExecuteAsync(ParseResult parseResult, CancellationToken cancellationToken)
+    protected override async Task<CommandResult> ExecuteAsync(ParseResult parseResult, CancellationToken cancellationToken)
     {
         var passedAppHostProjectFile = parseResult.GetValue(s_appHostOption);
         var format = parseResult.GetValue(s_formatOption);
@@ -64,7 +64,7 @@ internal sealed class McpToolsCommand : BaseCommand
 
         if (!result.Success)
         {
-            return AppHostConnectionResultHandler.DisplayFailureAsInformation(result, _interactionService);
+            return CommandResult.FromExitCode(AppHostConnectionResultHandler.DisplayFailureAsInformation(result, _interactionService));
         }
 
         var connection = result.Connection!;
@@ -74,7 +74,7 @@ internal sealed class McpToolsCommand : BaseCommand
         if (resourcesWithTools.Count == 0)
         {
             _interactionService.DisplayMessage(KnownEmojis.Information, "No resources with MCP tools found.");
-            return ExitCodeConstants.Success;
+            return CommandResult.Success();
         }
 
         if (format == OutputFormat.Json)
@@ -124,6 +124,6 @@ internal sealed class McpToolsCommand : BaseCommand
             _interactionService.DisplayRenderable(table);
         }
 
-        return ExitCodeConstants.Success;
+        return CommandResult.Success();
     }
 }

--- a/src/Aspire.Cli/Commands/NewCommand.cs
+++ b/src/Aspire.Cli/Commands/NewCommand.cs
@@ -385,7 +385,7 @@ internal sealed class NewCommand : BaseCommand, IPackageMetaPrefetchingCommand
             });
     }
 
-    protected override async Task<int> ExecuteAsync(ParseResult parseResult, CancellationToken cancellationToken)
+    protected override async Task<CommandResult> ExecuteAsync(ParseResult parseResult, CancellationToken cancellationToken)
     {
         using var activity = Telemetry.StartDiagnosticActivity(this.Name);
 
@@ -397,13 +397,13 @@ internal sealed class NewCommand : BaseCommand, IPackageMetaPrefetchingCommand
         var template = await GetProjectTemplateAsync(availableTemplates, parseResult, cancellationToken);
         if (template is null)
         {
-            return ExitCodeConstants.InvalidCommand;
+            return CommandResult.Failure(ExitCodeConstants.InvalidCommand);
         }
 
         var (languageResolutionSuccess, selectedLanguageId) = await ResolveSelectedLanguageAsync(template, parseResult, cancellationToken);
         if (!languageResolutionSuccess)
         {
-            return ExitCodeConstants.InvalidCommand;
+            return CommandResult.Failure(ExitCodeConstants.InvalidCommand);
         }
 
         var version = parseResult.GetValue(s_versionOption);
@@ -414,9 +414,7 @@ internal sealed class NewCommand : BaseCommand, IPackageMetaPrefetchingCommand
             var resolveResult = await ResolveCliTemplateVersionAsync(parseResult, cancellationToken);
             if (!resolveResult.Success)
             {
-                InteractionService.DisplayError(resolveResult.ErrorMessage);
-                InteractionService.DisplayError(InteractionServiceStrings.ProjectCouldNotBeCreated);
-                return ExitCodeConstants.InvalidCommand;
+                return CommandResult.Failure(ExitCodeConstants.InvalidCommand, resolveResult.ErrorMessage);
             }
 
             version = resolveResult.Version;
@@ -443,7 +441,7 @@ internal sealed class NewCommand : BaseCommand, IPackageMetaPrefetchingCommand
             extensionInteractionService.OpenEditor(templateResult.OutputPath);
         }
 
-        return agentInitResult.ExitCode;
+        return CommandResult.FromExitCode(agentInitResult.ExitCode);
     }
 
     private static bool ShouldResolveCliTemplateVersion(ITemplate template)

--- a/src/Aspire.Cli/Commands/NewCommand.cs
+++ b/src/Aspire.Cli/Commands/NewCommand.cs
@@ -416,10 +416,6 @@ internal sealed class NewCommand : BaseCommand, IPackageMetaPrefetchingCommand
             {
                 InteractionService.DisplayError(resolveResult.ErrorMessage);
                 InteractionService.DisplayError(InteractionServiceStrings.ProjectCouldNotBeCreated);
-                InteractionService.DisplayMessage(
-                    KnownEmojis.PageFacingUp,
-                    string.Format(CultureInfo.CurrentCulture, InteractionServiceStrings.SeeLogsAt, MarkupHelpers.SafeFileLink(InteractionService, ExecutionContext.LogFilePath)),
-                    allowMarkup: true);
                 return ExitCodeConstants.InvalidCommand;
             }
 

--- a/src/Aspire.Cli/Commands/ParentCommand.cs
+++ b/src/Aspire.Cli/Commands/ParentCommand.cs
@@ -1,0 +1,28 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.CommandLine;
+using Aspire.Cli.Configuration;
+using Aspire.Cli.Interaction;
+using Aspire.Cli.Telemetry;
+using Aspire.Cli.Utils;
+
+namespace Aspire.Cli.Commands;
+
+/// <summary>
+/// Base class for commands that only contain subcommands and display help when invoked directly.
+/// </summary>
+internal abstract class ParentCommand : BaseCommand
+{
+    protected ParentCommand(string name, string description, IFeatures features, ICliUpdateNotifier updateNotifier, CliExecutionContext executionContext, IInteractionService interactionService, AspireCliTelemetry telemetry)
+        : base(name, description, features, updateNotifier, executionContext, interactionService, telemetry)
+    {
+    }
+
+    protected override bool UpdateNotificationsEnabled => false;
+
+    protected sealed override Task<CommandResult> ExecuteAsync(ParseResult parseResult, CancellationToken cancellationToken)
+    {
+        return Task.FromResult(CommandResult.DisplayHelp());
+    }
+}

--- a/src/Aspire.Cli/Commands/PipelineCommandBase.cs
+++ b/src/Aspire.Cli/Commands/PipelineCommandBase.cs
@@ -136,7 +136,7 @@ internal abstract class PipelineCommandBase : BaseCommand
     /// </summary>
     protected virtual string[] GetCommandArgs(ParseResult parseResult) => [];
 
-    protected override async Task<int> ExecuteAsync(ParseResult parseResult, CancellationToken cancellationToken)
+    protected override async Task<CommandResult> ExecuteAsync(ParseResult parseResult, CancellationToken cancellationToken)
     {
         // If running in the extension context (Aspire terminal) without a debug session,
         // intercept and tell VS Code to start a proper debug session for this command.
@@ -153,7 +153,7 @@ internal abstract class PipelineCommandBase : BaseCommand
 
                 if (passedAppHostProjectFile is null)
                 {
-                    return ExitCodeConstants.FailedToFindProject;
+                    return CommandResult.Failure(ExitCodeConstants.FailedToFindProject);
                 }
             }
 
@@ -161,7 +161,7 @@ internal abstract class PipelineCommandBase : BaseCommand
 
             extensionInteractionService.DisplayConsolePlainText($"Detected aspire {Name} inside the Aspire extension, starting a debug session in VS Code...");
             await extensionInteractionService.StartDebugSessionAsync(ExecutionContext.WorkingDirectory.FullName, passedAppHostProjectFile?.FullName, debug: true, new DebugSessionOptions { Command = Name, Args = commandArgs.Length > 0 ? commandArgs : null });
-            return ExitCodeConstants.Success;
+            return CommandResult.Success();
         }
 
         var debugMode = parseResult.GetValue(RootCommand.DebugOption);
@@ -186,7 +186,7 @@ internal abstract class PipelineCommandBase : BaseCommand
             {
                 // Send terminal progress bar stop sequence
                 StopTerminalProgressBar();
-                return ExitCodeConstants.FailedToFindProject;
+                return CommandResult.Failure(ExitCodeConstants.FailedToFindProject);
             }
 
             var project = _projectFactory.GetProject(effectiveAppHostFile);
@@ -285,7 +285,7 @@ internal abstract class PipelineCommandBase : BaseCommand
 
                 await backchannel.RequestStopAsync(cancellationToken).ConfigureAwait(false);
                 await pendingRun;
-                return ExitCodeConstants.Success;
+                return CommandResult.Success();
             }
 
             var publishingActivities = backchannel.GetPublishingActivitiesAsync(cancellationToken);
@@ -315,18 +315,18 @@ internal abstract class PipelineCommandBase : BaseCommand
                 {
                     InteractionService.DisplayLines(outputCollector.GetLines());
                 }
-                return exitCode;
+                return CommandResult.FromExitCode(exitCode);
             }
 
             // If the apphost exited successfully (0) but reported failures via backchannel,
             // return a failure exit code.
             if (!noFailuresReported)
             {
-                return ExitCodeConstants.FailedToBuildArtifacts;
+                return CommandResult.Failure(ExitCodeConstants.FailedToBuildArtifacts);
             }
 
             // Both apphost exit code and backchannel indicate success
-            return ExitCodeConstants.Success;
+            return CommandResult.Success();
         }
         catch (OperationCanceledException ex)
         {
@@ -335,8 +335,7 @@ internal abstract class PipelineCommandBase : BaseCommand
             _logger.LogDebug(ex, "Operation was cancelled.");
             var canceledMessage = GetCanceledMessage();
             Telemetry.RecordError(canceledMessage, ex);
-            InteractionService.DisplayError(canceledMessage);
-            return ExitCodeConstants.FailedToBuildArtifacts;
+            return CommandResult.Failure(ExitCodeConstants.FailedToBuildArtifacts, canceledMessage);
         }
         catch (ProjectLocatorException ex)
         {
@@ -348,15 +347,14 @@ internal abstract class PipelineCommandBase : BaseCommand
         {
             // SDK not installed - message already displayed by EnsureSdkInstalledAsync
             StopTerminalProgressBar();
-            return ExitCodeConstants.SdkNotInstalled;
+            return CommandResult.Failure(ExitCodeConstants.SdkNotInstalled);
         }
         catch (AppHostIncompatibleException ex)
         {
             // Send terminal progress bar stop sequence on exception
             StopTerminalProgressBar();
             Telemetry.RecordError($"AppHost is incompatible. Required capability: {ex.RequiredCapability}", ex);
-            InteractionService.DisplayError(ex.Message);
-            return ExitCodeConstants.AppHostIncompatible;
+            return CommandResult.Failure(ExitCodeConstants.AppHostIncompatible, ex.Message);
         }
         catch (FailedToConnectBackchannelConnection ex)
         {
@@ -369,7 +367,7 @@ internal abstract class PipelineCommandBase : BaseCommand
             {
                 InteractionService.DisplayLines(outputCollector.GetLines());
             }
-            return ExitCodeConstants.FailedToBuildArtifacts;
+            return CommandResult.Failure(ExitCodeConstants.FailedToBuildArtifacts);
         }
         catch (ConnectionLostException ex)
         {
@@ -382,7 +380,7 @@ internal abstract class PipelineCommandBase : BaseCommand
             {
                 InteractionService.DisplayLines(outputCollector.GetLines());
             }
-            return pendingRun is { } && debugMode ? await pendingRun : ExitCodeConstants.FailedToBuildArtifacts;
+            return CommandResult.FromExitCode(pendingRun is { } && debugMode ? await pendingRun : ExitCodeConstants.FailedToBuildArtifacts);
         }
         catch (Exception ex)
         {
@@ -395,7 +393,7 @@ internal abstract class PipelineCommandBase : BaseCommand
             {
                 InteractionService.DisplayLines(outputCollector.GetLines());
             }
-            return ExitCodeConstants.FailedToBuildArtifacts;
+            return CommandResult.Failure(ExitCodeConstants.FailedToBuildArtifacts);
         }
     }
 

--- a/src/Aspire.Cli/Commands/PsCommand.cs
+++ b/src/Aspire.Cli/Commands/PsCommand.cs
@@ -95,7 +95,7 @@ internal sealed class PsCommand : BaseCommand
         Options.Add(s_resourcesOption);
     }
 
-    protected override async Task<int> ExecuteAsync(ParseResult parseResult, CancellationToken cancellationToken)
+    protected override async Task<CommandResult> ExecuteAsync(ParseResult parseResult, CancellationToken cancellationToken)
     {
         using var activity = Telemetry.StartDiagnosticActivity(Name);
 
@@ -123,7 +123,7 @@ internal sealed class PsCommand : BaseCommand
             {
                 _interactionService.DisplayMessage(KnownEmojis.Information, SharedCommandStrings.AppHostNotRunning);
             }
-            return ExitCodeConstants.Success;
+            return CommandResult.Success();
         }
 
         // Order: in-scope first, then out-of-scope
@@ -145,7 +145,7 @@ internal sealed class PsCommand : BaseCommand
             DisplayTable(appHostInfos);
         }
 
-        return ExitCodeConstants.Success;
+        return CommandResult.Success();
     }
 
     private async Task<List<AppHostDisplayInfo>> GatherAppHostInfosAsync(List<IAppHostAuxiliaryBackchannel> connections, bool includeResources, CancellationToken cancellationToken)

--- a/src/Aspire.Cli/Commands/RenderCommand.cs
+++ b/src/Aspire.Cli/Commands/RenderCommand.cs
@@ -110,18 +110,18 @@ internal sealed class RenderCommand : BaseCommand
 
     protected override bool UpdateNotificationsEnabled => false;
 
-    protected override async Task<int> ExecuteAsync(ParseResult parseResult, CancellationToken cancellationToken)
+    protected override async Task<CommandResult> ExecuteAsync(ParseResult parseResult, CancellationToken cancellationToken)
     {
         if (parseResult.GetValue(s_listScenariosOption))
         {
             ListScenarios();
-            return ExitCodeConstants.Success;
+            return CommandResult.Success();
         }
 
         var requestedScenario = parseResult.GetValue(s_scenarioOption);
         if (!string.IsNullOrEmpty(requestedScenario))
         {
-            return await ExecuteChoiceAsync(requestedScenario, parseResult.GetValue(s_consoleWidthOption), cancellationToken);
+            return CommandResult.FromExitCode(await ExecuteChoiceAsync(requestedScenario, parseResult.GetValue(s_consoleWidthOption), cancellationToken));
         }
 
         while (true)
@@ -135,7 +135,7 @@ internal sealed class RenderCommand : BaseCommand
             var exitCode = await ExecuteChoiceAsync(choice, parseResult.GetValue(s_consoleWidthOption), cancellationToken);
             if (choice == "exit" || exitCode != ExitCodeConstants.Success)
             {
-                return exitCode;
+                return CommandResult.FromExitCode(exitCode);
             }
         }
     }
@@ -244,7 +244,7 @@ internal sealed class RenderCommand : BaseCommand
                 async () =>
                 {
                     await Task.Delay(TimeSpan.FromSeconds(2), cancellationToken);
-                    return ExitCodeConstants.Success;
+                    return CommandResult.Success();
                 },
                 emoji: emoji);
         }
@@ -259,7 +259,7 @@ internal sealed class RenderCommand : BaseCommand
             async () =>
             {
                 await Task.Delay(TimeSpan.FromSeconds(2), cancellationToken);
-                return ExitCodeConstants.Success;
+                return CommandResult.Success();
             },
             emoji: KnownEmojis.Package,
             allowMarkup: true);
@@ -274,7 +274,7 @@ internal sealed class RenderCommand : BaseCommand
             async () =>
             {
                 await Task.Delay(TimeSpan.FromSeconds(2), cancellationToken);
-                return ExitCodeConstants.Success;
+                return CommandResult.Success();
             },
             emoji: KnownEmojis.Package);
 

--- a/src/Aspire.Cli/Commands/ResourceCommand.cs
+++ b/src/Aspire.Cli/Commands/ResourceCommand.cs
@@ -4,7 +4,6 @@
 using System.CommandLine;
 using System.CommandLine.Help;
 using System.CommandLine.Invocation;
-using System.CommandLine.Parsing;
 using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.Text;
@@ -102,7 +101,7 @@ internal sealed class ResourceCommand : BaseCommand
         });
     }
 
-    protected override async Task<int> ExecuteAsync(ParseResult parseResult, CancellationToken cancellationToken)
+    protected override async Task<CommandResult> ExecuteAsync(ParseResult parseResult, CancellationToken cancellationToken)
     {
         var resourceName = parseResult.GetValue(s_resourceArgument)!;
         var commandName = parseResult.GetValue(s_commandArgument)!;
@@ -119,7 +118,7 @@ internal sealed class ResourceCommand : BaseCommand
 
         if (!result.Success)
         {
-            return AppHostConnectionResultHandler.DisplayFailureAsError(result, _interactionService, ExitCodeConstants.FailedToFindProject);
+            return CommandResult.FromExitCode(AppHostConnectionResultHandler.DisplayFailureAsError(result, _interactionService, ExitCodeConstants.FailedToFindProject));
         }
 
         var connection = result.Connection!;
@@ -127,8 +126,7 @@ internal sealed class ResourceCommand : BaseCommand
         var commandArgumentsResult = CreateCommandArguments(command, capturedArguments);
         if (commandArgumentsResult.ErrorMessage is { } errorMessage)
         {
-            _interactionService.DisplayError(errorMessage);
-            return ExitCodeConstants.InvalidCommand;
+            return CommandResult.Failure(ExitCodeConstants.InvalidCommand, errorMessage);
         }
 
         var commandArguments = commandArgumentsResult.Arguments;
@@ -136,7 +134,7 @@ internal sealed class ResourceCommand : BaseCommand
         // Map well-known friendly names (start/stop/restart) to their display metadata
         if (s_wellKnownCommands.TryGetValue(commandName, out var knownCommand))
         {
-            return await ResourceCommandHelper.ExecuteResourceCommandAsync(
+            return CommandResult.FromExitCode(await ResourceCommandHelper.ExecuteResourceCommandAsync(
                 connection,
                 _interactionService,
                 _logger,
@@ -146,17 +144,17 @@ internal sealed class ResourceCommand : BaseCommand
                 knownCommand.BaseVerb,
                 knownCommand.PastTenseVerb,
                 commandArguments,
-                cancellationToken);
+                cancellationToken));
         }
 
-        return await ResourceCommandHelper.ExecuteGenericCommandAsync(
+        return CommandResult.FromExitCode(await ResourceCommandHelper.ExecuteGenericCommandAsync(
             connection,
             _interactionService,
             _logger,
             resourceName,
             commandName,
             commandArguments,
-            cancellationToken);
+            cancellationToken));
     }
 
     private static async Task<ResourceSnapshotCommand?> GetCommandMetadataAsync(IAppHostAuxiliaryBackchannel connection, string resourceName, string commandName, bool includeHidden, CancellationToken cancellationToken)
@@ -637,7 +635,7 @@ internal sealed class ResourceCommand : BaseCommand
             return result?.Tokens.Count > 0 ? result.Tokens[0].Value : null;
         }
 
-        private static void WriteResourceCommandHelp(TextWriter writer, CommandResult commandResult, string resourceName, ResourceSnapshotCommand command)
+        private static void WriteResourceCommandHelp(TextWriter writer, System.CommandLine.Parsing.CommandResult commandResult, string resourceName, ResourceSnapshotCommand command)
         {
             var cliOptionNames = GetCliOptionNames(commandResult);
 
@@ -664,7 +662,7 @@ internal sealed class ResourceCommand : BaseCommand
                 trailingBlankLine: false);
         }
 
-        private static IEnumerable<Option> GetVisibleCliOptions(CommandResult commandResult)
+        private static IEnumerable<Option> GetVisibleCliOptions(System.CommandLine.Parsing.CommandResult commandResult)
         {
             var seenOptionNames = new HashSet<string>(StringComparer.Ordinal);
 
@@ -677,7 +675,7 @@ internal sealed class ResourceCommand : BaseCommand
             }
 
             var current = commandResult.Parent;
-            while (current is CommandResult parentCommandResult)
+            while (current is System.CommandLine.Parsing.CommandResult parentCommandResult)
             {
                 foreach (var option in parentCommandResult.Command.Options)
                 {
@@ -691,14 +689,14 @@ internal sealed class ResourceCommand : BaseCommand
             }
         }
 
-        private static HashSet<string> GetCliOptionNames(CommandResult commandResult)
+        private static HashSet<string> GetCliOptionNames(System.CommandLine.Parsing.CommandResult commandResult)
         {
             var names = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
 
             AddOptionNames(commandResult.Command.Options, includeOnlyRecursive: false, names);
 
             var current = commandResult.Parent;
-            while (current is CommandResult parentCommandResult)
+            while (current is System.CommandLine.Parsing.CommandResult parentCommandResult)
             {
                 AddOptionNames(parentCommandResult.Command.Options, includeOnlyRecursive: true, names);
                 current = parentCommandResult.Parent;

--- a/src/Aspire.Cli/Commands/RestoreCommand.cs
+++ b/src/Aspire.Cli/Commands/RestoreCommand.cs
@@ -59,7 +59,7 @@ internal sealed class RestoreCommand : BaseCommand
         Options.Add(s_appHostOption);
     }
 
-    protected override async Task<int> ExecuteAsync(ParseResult parseResult, CancellationToken cancellationToken)
+    protected override async Task<CommandResult> ExecuteAsync(ParseResult parseResult, CancellationToken cancellationToken)
     {
         var passedAppHostProjectFile = parseResult.GetValue(s_appHostOption);
 
@@ -106,30 +106,29 @@ internal sealed class RestoreCommand : BaseCommand
                 {
                     _interactionService.DisplaySuccess(
                         string.Format(CultureInfo.CurrentCulture, RestoreCommandStrings.RestoreSucceeded, AspireConfigFile.FileName));
-                    return ExitCodeConstants.Success;
+                    return CommandResult.Success();
                 }
 
-                return ExitCodeConstants.FailedToBuildArtifacts;
+                return CommandResult.Failure(ExitCodeConstants.FailedToBuildArtifacts);
             }
 
             if (effectiveAppHostFile is null)
             {
-                return ExitCodeConstants.FailedToFindProject;
+                return CommandResult.Failure(ExitCodeConstants.FailedToFindProject);
             }
 
             var project = _projectFactory.TryGetProject(effectiveAppHostFile);
 
             if (project is null)
             {
-                InteractionService.DisplayError(RestoreCommandStrings.UnrecognizedAppHostType);
-                return ExitCodeConstants.FailedToFindProject;
+                return CommandResult.Failure(ExitCodeConstants.FailedToFindProject, RestoreCommandStrings.UnrecognizedAppHostType);
             }
 
             if (project is DotNetAppHostProject)
             {
                 if (!await SdkInstallHelper.EnsureSdkInstalledAsync(_sdkInstaller, InteractionService, Telemetry, cancellationToken: cancellationToken))
                 {
-                    return ExitCodeConstants.SdkNotInstalled;
+                    return CommandResult.Failure(ExitCodeConstants.SdkNotInstalled);
                 }
 
                 var appHostDirectory = effectiveAppHostFile.Directory!;
@@ -144,10 +143,10 @@ internal sealed class RestoreCommand : BaseCommand
                 {
                     _interactionService.DisplaySuccess(
                         string.Format(CultureInfo.CurrentCulture, RestoreCommandStrings.RestoreSucceeded, effectiveAppHostFile.Name));
-                    return ExitCodeConstants.Success;
+                    return CommandResult.Success();
                 }
 
-                return ExitCodeConstants.FailedToBuildArtifacts;
+                return CommandResult.Failure(ExitCodeConstants.FailedToBuildArtifacts);
             }
 
             if (project is GuestAppHostProject guestProject)
@@ -164,19 +163,18 @@ internal sealed class RestoreCommand : BaseCommand
                 {
                     _interactionService.DisplaySuccess(
                         string.Format(CultureInfo.CurrentCulture, RestoreCommandStrings.RestoreSucceeded, effectiveAppHostFile.Name));
-                    return ExitCodeConstants.Success;
+                    return CommandResult.Success();
                 }
 
-                return ExitCodeConstants.FailedToBuildArtifacts;
+                return CommandResult.Failure(ExitCodeConstants.FailedToBuildArtifacts);
             }
 
-            InteractionService.DisplayError(RestoreCommandStrings.UnrecognizedAppHostType);
-            return ExitCodeConstants.FailedToFindProject;
+            return CommandResult.Failure(ExitCodeConstants.FailedToFindProject, RestoreCommandStrings.UnrecognizedAppHostType);
         }
         catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
         {
             InteractionService.DisplayCancellationMessage();
-            return ExitCodeConstants.Success;
+            return CommandResult.Success();
         }
         catch (ProjectLocatorException ex)
         {
@@ -186,8 +184,7 @@ internal sealed class RestoreCommand : BaseCommand
         {
             var errorMessage = string.Format(CultureInfo.CurrentCulture, InteractionServiceStrings.UnexpectedErrorOccurred, ex.Message);
             Telemetry.RecordError(errorMessage, ex);
-            InteractionService.DisplayError(errorMessage);
-            return ExitCodeConstants.FailedToBuildArtifacts;
+            return CommandResult.Failure(ExitCodeConstants.FailedToBuildArtifacts, errorMessage);
         }
     }
 

--- a/src/Aspire.Cli/Commands/RestoreCommand.cs
+++ b/src/Aspire.Cli/Commands/RestoreCommand.cs
@@ -173,8 +173,7 @@ internal sealed class RestoreCommand : BaseCommand
         }
         catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
         {
-            InteractionService.DisplayCancellationMessage();
-            return CommandResult.Success();
+            return CommandResult.Cancelled();
         }
         catch (ProjectLocatorException ex)
         {

--- a/src/Aspire.Cli/Commands/RunCommand.cs
+++ b/src/Aspire.Cli/Commands/RunCommand.cs
@@ -431,7 +431,10 @@ internal sealed class RunCommand : BaseCommand
         catch (OperationCanceledException ex) when (ex.CancellationToken == cancellationToken || ex is ExtensionOperationCanceledException)
         {
             runActivity?.SetTag(TelemetryConstants.Tags.ErrorType, "canceled");
-            return CommandResult.Cancelled();
+
+            // Command is designed to be cancellable by the user (e.g. Ctrl+C) at any time.
+            // Treat cancellation as a successful exit since the user intentionally stopped the AppHost.
+            return CommandResult.Cancelled(ExitCodeConstants.Success);
         }
         catch (ProjectLocatorException ex)
         {

--- a/src/Aspire.Cli/Commands/RunCommand.cs
+++ b/src/Aspire.Cli/Commands/RunCommand.cs
@@ -425,7 +425,11 @@ internal sealed class RunCommand : BaseCommand
                 await pendingLogCapture;
                 var exitCode = await pendingRun;
                 lifetimeActivity.SetProcessExitCode(exitCode);
-                return CommandResult.FromExitCode(exitCode);
+
+                // Cancelled by user (e.g., Ctrl+C) - treat as successful exit since the user intentionally stopped the AppHost.
+                return exitCode == ExitCodeConstants.Cancelled
+                    ? CommandResult.Cancelled(ExitCodeConstants.Success)
+                    : CommandResult.FromExitCode(exitCode);
             }
         }
         catch (OperationCanceledException ex) when (ex.CancellationToken == cancellationToken || ex is ExtensionOperationCanceledException)

--- a/src/Aspire.Cli/Commands/RunCommand.cs
+++ b/src/Aspire.Cli/Commands/RunCommand.cs
@@ -165,7 +165,7 @@ internal sealed class RunCommand : BaseCommand
         // Handle detached mode - spawn child process and exit
         if (detach)
         {
-            return CommandResult.FromExitCode(await ExecuteDetachedAsync(parseResult, passedAppHostProjectFile, isExtensionHost, cancellationToken));
+            return await ExecuteDetachedAsync(parseResult, passedAppHostProjectFile, isExtensionHost, cancellationToken);
         }
 
         // A user may run `aspire run` in an Aspire terminal in VS Code. In this case, intercept and prompt
@@ -431,8 +431,7 @@ internal sealed class RunCommand : BaseCommand
         catch (OperationCanceledException ex) when (ex.CancellationToken == cancellationToken || ex is ExtensionOperationCanceledException)
         {
             runActivity?.SetTag(TelemetryConstants.Tags.ErrorType, "canceled");
-            InteractionService.DisplayCancellationMessage();
-            return CommandResult.Success();
+            return CommandResult.Cancelled();
         }
         catch (ProjectLocatorException ex)
         {
@@ -692,7 +691,7 @@ internal sealed class RunCommand : BaseCommand
     /// </list>
     /// <para>On any failure, the log file path is displayed so the user can investigate.</para>
     /// </remarks>
-    private Task<int> ExecuteDetachedAsync(ParseResult parseResult, FileInfo? passedAppHostProjectFile, bool isExtensionHost, CancellationToken cancellationToken)
+    private Task<CommandResult> ExecuteDetachedAsync(ParseResult parseResult, FileInfo? passedAppHostProjectFile, bool isExtensionHost, CancellationToken cancellationToken)
     {
         var format = parseResult.GetValue(AppHostLauncher.s_formatOption);
         var isolated = parseResult.GetValue(AppHostLauncher.s_isolatedOption);

--- a/src/Aspire.Cli/Commands/RunCommand.cs
+++ b/src/Aspire.Cli/Commands/RunCommand.cs
@@ -291,10 +291,6 @@ internal sealed class RunCommand : BaseCommand
                     InteractionService.DisplayLines(outputCollector.GetLines());
                 }
                 InteractionService.DisplayError(InteractionServiceStrings.ProjectCouldNotBeBuilt);
-                InteractionService.DisplayMessage(
-                    KnownEmojis.PageFacingUp,
-                    string.Format(CultureInfo.CurrentCulture, InteractionServiceStrings.SeeLogsAt, MarkupHelpers.SafeFileLink(InteractionService, ExecutionContext.LogFilePath)),
-                    allowMarkup: true);
                 return await pendingRun;
             }
 
@@ -467,11 +463,6 @@ internal sealed class RunCommand : BaseCommand
             var errorMessage = string.Format(CultureInfo.CurrentCulture, InteractionServiceStrings.ErrorConnectingToAppHost, ex.Message);
             Telemetry.RecordError(errorMessage, ex);
             InteractionService.DisplayError(errorMessage);
-            // Don't display raw output - it's already in the log file
-            InteractionService.DisplayMessage(
-                KnownEmojis.PageFacingUp,
-                string.Format(CultureInfo.CurrentCulture, InteractionServiceStrings.SeeLogsAt, MarkupHelpers.SafeFileLink(InteractionService, ExecutionContext.LogFilePath)),
-                allowMarkup: true);
             return ExitCodeConstants.FailedToDotnetRunAppHost;
         }
         catch (ConnectionLostException) when (isExtensionHost)
@@ -486,11 +477,6 @@ internal sealed class RunCommand : BaseCommand
             var errorMessage = string.Format(CultureInfo.CurrentCulture, InteractionServiceStrings.UnexpectedErrorOccurred, ex.Message);
             Telemetry.RecordError(errorMessage, ex);
             InteractionService.DisplayError(errorMessage);
-            // Don't display raw output - it's already in the log file
-            InteractionService.DisplayMessage(
-                KnownEmojis.PageFacingUp,
-                string.Format(CultureInfo.CurrentCulture, InteractionServiceStrings.SeeLogsAt, MarkupHelpers.SafeFileLink(InteractionService, ExecutionContext.LogFilePath)),
-                allowMarkup: true);
             return ExitCodeConstants.FailedToDotnetRunAppHost;
         }
         finally

--- a/src/Aspire.Cli/Commands/RunCommand.cs
+++ b/src/Aspire.Cli/Commands/RunCommand.cs
@@ -132,7 +132,7 @@ internal sealed class RunCommand : BaseCommand
         TreatUnmatchedTokensAsErrors = false;
     }
 
-    protected override async Task<int> ExecuteAsync(ParseResult parseResult, CancellationToken cancellationToken)
+    protected override async Task<CommandResult> ExecuteAsync(ParseResult parseResult, CancellationToken cancellationToken)
     {
         var passedAppHostProjectFile = parseResult.GetValue(AppHostLauncher.s_appHostOption);
         var detach = parseResult.GetValue(s_detachOption);
@@ -151,8 +151,7 @@ internal sealed class RunCommand : BaseCommand
         // Validate that --format is only used with --detach
         if (format == OutputFormat.Json && !detach)
         {
-            InteractionService.DisplayError(RunCommandStrings.FormatRequiresDetach);
-            return ExitCodeConstants.InvalidCommand;
+            return CommandResult.Failure(ExitCodeConstants.InvalidCommand, RunCommandStrings.FormatRequiresDetach);
         }
 
         // Validate that --no-build is not used when watch mode would be enabled
@@ -160,14 +159,13 @@ internal sealed class RunCommand : BaseCommand
         var watchModeEnabled = _features.IsFeatureEnabled(KnownFeatures.DefaultWatchEnabled, defaultValue: false) || (isExtensionHost && !startDebugSession);
         if (noBuild && watchModeEnabled)
         {
-            InteractionService.DisplayError(RunCommandStrings.NoBuildNotSupportedWithWatchMode);
-            return ExitCodeConstants.InvalidCommand;
+            return CommandResult.Failure(ExitCodeConstants.InvalidCommand, RunCommandStrings.NoBuildNotSupportedWithWatchMode);
         }
 
         // Handle detached mode - spawn child process and exit
         if (detach)
         {
-            return await ExecuteDetachedAsync(parseResult, passedAppHostProjectFile, isExtensionHost, cancellationToken);
+            return CommandResult.FromExitCode(await ExecuteDetachedAsync(parseResult, passedAppHostProjectFile, isExtensionHost, cancellationToken));
         }
 
         // A user may run `aspire run` in an Aspire terminal in VS Code. In this case, intercept and prompt
@@ -181,7 +179,7 @@ internal sealed class RunCommand : BaseCommand
         {
             extensionInteractionService.DisplayConsolePlainText(RunCommandStrings.StartingDebugSessionInExtension);
             await extensionInteractionService.StartDebugSessionAsync(ExecutionContext.WorkingDirectory.FullName, passedAppHostProjectFile?.FullName, startDebugSession, new DebugSessionOptions { Command = "run" });
-            return ExitCodeConstants.Success;
+            return CommandResult.Success();
         }
 
         AppHostProjectContext? context = null;
@@ -215,7 +213,7 @@ internal sealed class RunCommand : BaseCommand
             if (effectiveAppHostFile is null)
             {
                 runActivity?.SetTag(TelemetryConstants.Tags.ErrorType, "project_not_found");
-                return ExitCodeConstants.FailedToFindProject;
+                return CommandResult.Failure(ExitCodeConstants.FailedToFindProject);
             }
 
             // Resolve the language for this file and get the appropriate handler
@@ -223,8 +221,7 @@ internal sealed class RunCommand : BaseCommand
             if (project is null)
             {
                 runActivity?.SetTag(TelemetryConstants.Tags.ErrorType, "project_not_found");
-                InteractionService.DisplayError("Unrecognized app host type.");
-                return ExitCodeConstants.FailedToFindProject;
+                return CommandResult.Failure(ExitCodeConstants.FailedToFindProject, "Unrecognized app host type.");
             }
 
             runActivity?.SetTag(TelemetryConstants.Tags.AppHostLanguage, project.LanguageId);
@@ -290,8 +287,7 @@ internal sealed class RunCommand : BaseCommand
                 {
                     InteractionService.DisplayLines(outputCollector.GetLines());
                 }
-                InteractionService.DisplayError(InteractionServiceStrings.ProjectCouldNotBeBuilt);
-                return await pendingRun;
+                return CommandResult.Failure(await pendingRun, InteractionServiceStrings.ProjectCouldNotBeBuilt);
             }
 
             // If --wait-for-debugger, display a message so the user knows the AppHost is paused.
@@ -429,14 +425,14 @@ internal sealed class RunCommand : BaseCommand
                 await pendingLogCapture;
                 var exitCode = await pendingRun;
                 lifetimeActivity.SetProcessExitCode(exitCode);
-                return exitCode;
+                return CommandResult.FromExitCode(exitCode);
             }
         }
         catch (OperationCanceledException ex) when (ex.CancellationToken == cancellationToken || ex is ExtensionOperationCanceledException)
         {
             runActivity?.SetTag(TelemetryConstants.Tags.ErrorType, "canceled");
             InteractionService.DisplayCancellationMessage();
-            return ExitCodeConstants.Success;
+            return CommandResult.Success();
         }
         catch (ProjectLocatorException ex)
         {
@@ -447,37 +443,34 @@ internal sealed class RunCommand : BaseCommand
         {
             runActivity?.SetTag(TelemetryConstants.Tags.ErrorType, "incompatible_version");
             Telemetry.RecordError(ex.Message, ex);
-            return InteractionService.DisplayIncompatibleVersionError(ex, ex.AspireHostingVersion ?? ex.RequiredCapability);
+            return CommandResult.FromExitCode(InteractionService.DisplayIncompatibleVersionError(ex, ex.AspireHostingVersion ?? ex.RequiredCapability));
         }
         catch (CertificateServiceException ex)
         {
             runActivity?.SetTag(TelemetryConstants.Tags.ErrorType, "certificate_trust_failed");
             var errorMessage = string.Format(CultureInfo.CurrentCulture, TemplatingStrings.CertificateTrustError, ex.Message);
             Telemetry.RecordError(errorMessage, ex);
-            InteractionService.DisplayError(errorMessage);
-            return ExitCodeConstants.FailedToTrustCertificates;
+            return CommandResult.Failure(ExitCodeConstants.FailedToTrustCertificates, errorMessage);
         }
         catch (FailedToConnectBackchannelConnection ex)
         {
             runActivity?.SetTag(TelemetryConstants.Tags.ErrorType, "backchannel_connection_failed");
             var errorMessage = string.Format(CultureInfo.CurrentCulture, InteractionServiceStrings.ErrorConnectingToAppHost, ex.Message);
             Telemetry.RecordError(errorMessage, ex);
-            InteractionService.DisplayError(errorMessage);
-            return ExitCodeConstants.FailedToDotnetRunAppHost;
+            return CommandResult.Failure(ExitCodeConstants.FailedToDotnetRunAppHost, errorMessage);
         }
         catch (ConnectionLostException) when (isExtensionHost)
         {
             // When the extension manages the AppHost lifecycle (e.g., VS Code debug session),
             // it terminates the process on stop/restart, causing the backchannel to drop.
-            return ExitCodeConstants.Success;
+            return CommandResult.Success();
         }
         catch (Exception ex)
         {
             runActivity?.SetTag(TelemetryConstants.Tags.ErrorType, ex.GetType().FullName);
             var errorMessage = string.Format(CultureInfo.CurrentCulture, InteractionServiceStrings.UnexpectedErrorOccurred, ex.Message);
             Telemetry.RecordError(errorMessage, ex);
-            InteractionService.DisplayError(errorMessage);
-            return ExitCodeConstants.FailedToDotnetRunAppHost;
+            return CommandResult.Failure(ExitCodeConstants.FailedToDotnetRunAppHost, errorMessage);
         }
         finally
         {

--- a/src/Aspire.Cli/Commands/Sdk/SdkCommand.cs
+++ b/src/Aspire.Cli/Commands/Sdk/SdkCommand.cs
@@ -1,8 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.CommandLine;
-using System.CommandLine.Help;
 using Aspire.Cli.Configuration;
 using Aspire.Cli.Interaction;
 using Aspire.Cli.Telemetry;
@@ -14,7 +12,7 @@ namespace Aspire.Cli.Commands.Sdk;
 /// Parent command for SDK-related operations.
 /// Usage: aspire sdk [subcommand]
 /// </summary>
-internal sealed class SdkCommand : BaseCommand
+internal sealed class SdkCommand : ParentCommand
 {
     public SdkCommand(
         SdkGenerateCommand generateCommand,
@@ -29,14 +27,5 @@ internal sealed class SdkCommand : BaseCommand
         Hidden = true;
         Subcommands.Add(generateCommand);
         Subcommands.Add(dumpCommand);
-    }
-
-    protected override bool UpdateNotificationsEnabled => false;
-
-    protected override Task<int> ExecuteAsync(ParseResult parseResult, CancellationToken cancellationToken)
-    {
-        // When invoked without a subcommand, show help
-        new HelpAction().Invoke(parseResult);
-        return Task.FromResult(ExitCodeConstants.InvalidCommand);
     }
 }

--- a/src/Aspire.Cli/Commands/Sdk/SdkDumpCommand.cs
+++ b/src/Aspire.Cli/Commands/Sdk/SdkDumpCommand.cs
@@ -68,7 +68,7 @@ internal sealed class SdkDumpCommand : BaseCommand
         Options.Add(s_formatOption);
     }
 
-    protected override async Task<int> ExecuteAsync(ParseResult parseResult, CancellationToken cancellationToken)
+    protected override async Task<CommandResult> ExecuteAsync(ParseResult parseResult, CancellationToken cancellationToken)
     {
         var integrationArgs = parseResult.GetValue(s_integrationArgument) ?? [];
         var outputFile = parseResult.GetValue(s_outputOption);
@@ -84,8 +84,7 @@ internal sealed class SdkDumpCommand : BaseCommand
                 var projectFile = new FileInfo(arg);
                 if (!projectFile.Exists)
                 {
-                    InteractionService.DisplayError($"Integration project not found: {projectFile.FullName}");
-                    return ExitCodeConstants.FailedToFindProject;
+                    return CommandResult.Failure(ExitCodeConstants.FailedToFindProject, $"Integration project not found: {projectFile.FullName}");
                 }
 
                 integrations.Add(IntegrationReference.FromProject(
@@ -100,14 +99,12 @@ internal sealed class SdkDumpCommand : BaseCommand
 
                 if (string.IsNullOrWhiteSpace(packageName) || string.IsNullOrWhiteSpace(packageVersion) || packageName.Contains('@'))
                 {
-                    InteractionService.DisplayError($"Invalid package format '{arg}'. Expected PackageName@Version (e.g. Aspire.Hosting.Redis@9.2.0).");
-                    return ExitCodeConstants.InvalidCommand;
+                    return CommandResult.Failure(ExitCodeConstants.InvalidCommand, $"Invalid package format '{arg}'. Expected PackageName@Version (e.g. Aspire.Hosting.Redis@9.2.0).");
                 }
 
                 if (!SemVersion.TryParse(packageVersion, SemVersionStyles.Any, out _))
                 {
-                    InteractionService.DisplayError($"Invalid version '{packageVersion}' in '{arg}'. Expected a valid NuGet version (e.g. 9.2.0).");
-                    return ExitCodeConstants.InvalidCommand;
+                    return CommandResult.Failure(ExitCodeConstants.InvalidCommand, $"Invalid version '{packageVersion}' in '{arg}'. Expected a valid NuGet version (e.g. 9.2.0).");
                 }
 
                 _logger.LogDebug("Parsed package reference {PackageName} version {Version}", packageName, packageVersion);
@@ -115,21 +112,20 @@ internal sealed class SdkDumpCommand : BaseCommand
             }
             else
             {
-                InteractionService.DisplayError($"Invalid integration argument '{arg}'. Expected a .csproj path or PackageName@Version format.");
-                return ExitCodeConstants.InvalidCommand;
+                return CommandResult.Failure(ExitCodeConstants.InvalidCommand, $"Invalid integration argument '{arg}'. Expected a .csproj path or PackageName@Version format.");
             }
         }
 
         // For file output, skip the interactive spinner
         if (outputFile is not null)
         {
-            return await DumpCapabilitiesAsync(integrations, outputFile, format, cancellationToken);
+            return CommandResult.FromExitCode(await DumpCapabilitiesAsync(integrations, outputFile, format, cancellationToken));
         }
 
-        return await InteractionService.ShowStatusAsync(
+        return CommandResult.FromExitCode(await InteractionService.ShowStatusAsync(
             "Scanning capabilities...",
             async () => await DumpCapabilitiesAsync(integrations, outputFile, format, cancellationToken),
-            emoji: KnownEmojis.MagnifyingGlassTiltedLeft);
+            emoji: KnownEmojis.MagnifyingGlassTiltedLeft));
     }
 
     private async Task<int> DumpCapabilitiesAsync(

--- a/src/Aspire.Cli/Commands/Sdk/SdkGenerateCommand.cs
+++ b/src/Aspire.Cli/Commands/Sdk/SdkGenerateCommand.cs
@@ -59,7 +59,7 @@ internal sealed class SdkGenerateCommand : BaseCommand
         Options.Add(s_outputOption);
     }
 
-    protected override async Task<int> ExecuteAsync(ParseResult parseResult, CancellationToken cancellationToken)
+    protected override async Task<CommandResult> ExecuteAsync(ParseResult parseResult, CancellationToken cancellationToken)
     {
         var integrationProject = parseResult.GetValue(s_integrationArgument)!;
         var language = parseResult.GetValue(s_languageOption)!;
@@ -68,22 +68,19 @@ internal sealed class SdkGenerateCommand : BaseCommand
         // Validate the integration project exists
         if (!integrationProject.Exists)
         {
-            InteractionService.DisplayError($"Integration project not found: {integrationProject.FullName}");
-            return ExitCodeConstants.FailedToFindProject;
+            return CommandResult.Failure(ExitCodeConstants.FailedToFindProject, $"Integration project not found: {integrationProject.FullName}");
         }
 
         if (!integrationProject.Extension.Equals(".csproj", StringComparison.OrdinalIgnoreCase))
         {
-            InteractionService.DisplayError($"Expected a .csproj file, got: {integrationProject.Extension}");
-            return ExitCodeConstants.InvalidCommand;
+            return CommandResult.Failure(ExitCodeConstants.InvalidCommand, $"Expected a .csproj file, got: {integrationProject.Extension}");
         }
 
         // Resolve the language info
         var languageInfo = await GetLanguageInfoAsync(language, cancellationToken);
         if (languageInfo is null)
         {
-            InteractionService.DisplayError($"Unsupported language: {language}");
-            return ExitCodeConstants.InvalidCommand;
+            return CommandResult.Failure(ExitCodeConstants.InvalidCommand, $"Unsupported language: {language}");
         }
 
         // Create output directory if it doesn't exist
@@ -92,10 +89,10 @@ internal sealed class SdkGenerateCommand : BaseCommand
             outputDir.Create();
         }
 
-        return await InteractionService.ShowStatusAsync(
+        return CommandResult.FromExitCode(await InteractionService.ShowStatusAsync(
             $"Generating {languageInfo.DisplayName} SDK from {integrationProject.Name}...",
             async () => await GenerateSdkAsync(integrationProject, languageInfo, outputDir, cancellationToken),
-            emoji: KnownEmojis.Hammer);
+            emoji: KnownEmojis.Hammer));
     }
 
     private async Task<LanguageInfo?> GetLanguageInfoAsync(string language, CancellationToken cancellationToken)

--- a/src/Aspire.Cli/Commands/SecretCommand.cs
+++ b/src/Aspire.Cli/Commands/SecretCommand.cs
@@ -1,8 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.CommandLine;
-using System.CommandLine.Help;
 using Aspire.Cli.Configuration;
 using Aspire.Cli.Interaction;
 using Aspire.Cli.Resources;
@@ -14,7 +12,7 @@ namespace Aspire.Cli.Commands;
 /// <summary>
 /// Manages AppHost user secrets (set, get, list, delete).
 /// </summary>
-internal sealed class SecretCommand : BaseCommand
+internal sealed class SecretCommand : ParentCommand
 {
     internal static readonly OptionWithLegacy<FileInfo?> s_appHostOption = new("--apphost", "--project", SharedCommandStrings.AppHostOptionDescription);
 
@@ -38,11 +36,5 @@ internal sealed class SecretCommand : BaseCommand
         Subcommands.Add(listCommand);
         Subcommands.Add(pathCommand);
         Subcommands.Add(deleteCommand);
-    }
-
-    protected override Task<int> ExecuteAsync(ParseResult parseResult, CancellationToken cancellationToken)
-    {
-        new HelpAction().Invoke(parseResult);
-        return Task.FromResult(ExitCodeConstants.InvalidCommand);
     }
 }

--- a/src/Aspire.Cli/Commands/SecretDeleteCommand.cs
+++ b/src/Aspire.Cli/Commands/SecretDeleteCommand.cs
@@ -40,7 +40,7 @@ internal sealed class SecretDeleteCommand : BaseCommand
         Options.Add(SecretCommand.s_appHostOption);
     }
 
-    protected override async Task<int> ExecuteAsync(ParseResult parseResult, CancellationToken cancellationToken)
+    protected override async Task<CommandResult> ExecuteAsync(ParseResult parseResult, CancellationToken cancellationToken)
     {
         // Argument arity guarantees non-null
         var key = parseResult.GetValue(s_keyArgument)!;
@@ -49,18 +49,16 @@ internal sealed class SecretDeleteCommand : BaseCommand
         var result = await _secretStoreResolver.ResolveAsync(projectFile, autoInit: false, cancellationToken);
         if (result is null)
         {
-            InteractionService.DisplayError(SecretCommandStrings.CouldNotFindAppHost);
-            return ExitCodeConstants.FailedToFindProject;
+            return CommandResult.Failure(ExitCodeConstants.FailedToFindProject, SecretCommandStrings.CouldNotFindAppHost);
         }
 
         if (!result.Store.Remove(key))
         {
-            InteractionService.DisplayError(string.Format(CultureInfo.CurrentCulture, SecretCommandStrings.SecretNotFound, key.EscapeMarkup()));
-            return ExitCodeConstants.ConfigNotFound;
+            return CommandResult.Failure(ExitCodeConstants.ConfigNotFound, string.Format(CultureInfo.CurrentCulture, SecretCommandStrings.SecretNotFound, key.EscapeMarkup()));
         }
 
         result.Store.Save();
         InteractionService.DisplaySuccess(string.Format(CultureInfo.CurrentCulture, SecretCommandStrings.SecretDeleteSuccess, key));
-        return ExitCodeConstants.Success;
+        return CommandResult.Success();
     }
 }

--- a/src/Aspire.Cli/Commands/SecretGetCommand.cs
+++ b/src/Aspire.Cli/Commands/SecretGetCommand.cs
@@ -40,7 +40,7 @@ internal sealed class SecretGetCommand : BaseCommand
         Options.Add(SecretCommand.s_appHostOption);
     }
 
-    protected override async Task<int> ExecuteAsync(ParseResult parseResult, CancellationToken cancellationToken)
+    protected override async Task<CommandResult> ExecuteAsync(ParseResult parseResult, CancellationToken cancellationToken)
     {
         // Argument arity guarantees non-null
         var key = parseResult.GetValue(s_keyArgument)!;
@@ -49,19 +49,17 @@ internal sealed class SecretGetCommand : BaseCommand
         var result = await _secretStoreResolver.ResolveAsync(projectFile, autoInit: false, cancellationToken);
         if (result is null)
         {
-            InteractionService.DisplayError(SecretCommandStrings.CouldNotFindAppHost);
-            return ExitCodeConstants.FailedToFindProject;
+            return CommandResult.Failure(ExitCodeConstants.FailedToFindProject, SecretCommandStrings.CouldNotFindAppHost);
         }
 
         var value = result.Store.Get(key);
         if (value is null)
         {
-            InteractionService.DisplayError(string.Format(CultureInfo.CurrentCulture, SecretCommandStrings.SecretNotFound, key.EscapeMarkup()));
-            return ExitCodeConstants.ConfigNotFound;
+            return CommandResult.Failure(ExitCodeConstants.ConfigNotFound, string.Format(CultureInfo.CurrentCulture, SecretCommandStrings.SecretNotFound, key.EscapeMarkup()));
         }
 
         // Write value to stdout (machine-readable)
         InteractionService.DisplayRawText(value, consoleOverride: ConsoleOutput.Standard);
-        return ExitCodeConstants.Success;
+        return CommandResult.Success();
     }
 }

--- a/src/Aspire.Cli/Commands/SecretListCommand.cs
+++ b/src/Aspire.Cli/Commands/SecretListCommand.cs
@@ -41,7 +41,7 @@ internal sealed class SecretListCommand : BaseCommand
         Options.Add(s_formatOption);
     }
 
-    protected override async Task<int> ExecuteAsync(ParseResult parseResult, CancellationToken cancellationToken)
+    protected override async Task<CommandResult> ExecuteAsync(ParseResult parseResult, CancellationToken cancellationToken)
     {
         var projectFile = parseResult.GetValue(SecretCommand.s_appHostOption);
         var format = parseResult.GetValue(s_formatOption);
@@ -49,8 +49,7 @@ internal sealed class SecretListCommand : BaseCommand
         var result = await _secretStoreResolver.ResolveAsync(projectFile, autoInit: false, cancellationToken);
         if (result is null)
         {
-            InteractionService.DisplayError(SecretCommandStrings.CouldNotFindAppHost);
-            return ExitCodeConstants.FailedToFindProject;
+            return CommandResult.Failure(ExitCodeConstants.FailedToFindProject, SecretCommandStrings.CouldNotFindAppHost);
         }
 
         var secrets = result.Store.ToList();
@@ -89,6 +88,6 @@ internal sealed class SecretListCommand : BaseCommand
             }
         }
 
-        return ExitCodeConstants.Success;
+        return CommandResult.Success();
     }
 }

--- a/src/Aspire.Cli/Commands/SecretPathCommand.cs
+++ b/src/Aspire.Cli/Commands/SecretPathCommand.cs
@@ -32,18 +32,17 @@ internal sealed class SecretPathCommand : BaseCommand
         Options.Add(SecretCommand.s_appHostOption);
     }
 
-    protected override async Task<int> ExecuteAsync(ParseResult parseResult, CancellationToken cancellationToken)
+    protected override async Task<CommandResult> ExecuteAsync(ParseResult parseResult, CancellationToken cancellationToken)
     {
         var projectFile = parseResult.GetValue(SecretCommand.s_appHostOption);
 
         var result = await _secretStoreResolver.ResolveAsync(projectFile, autoInit: false, cancellationToken);
         if (result is null)
         {
-            InteractionService.DisplayError(SecretCommandStrings.CouldNotFindAppHost);
-            return ExitCodeConstants.FailedToFindProject;
+            return CommandResult.Failure(ExitCodeConstants.FailedToFindProject, SecretCommandStrings.CouldNotFindAppHost);
         }
 
         InteractionService.DisplayRawText(result.Store.FilePath, consoleOverride: ConsoleOutput.Standard);
-        return ExitCodeConstants.Success;
+        return CommandResult.Success();
     }
 }

--- a/src/Aspire.Cli/Commands/SecretSetCommand.cs
+++ b/src/Aspire.Cli/Commands/SecretSetCommand.cs
@@ -45,7 +45,7 @@ internal sealed class SecretSetCommand : BaseCommand
         Options.Add(SecretCommand.s_appHostOption);
     }
 
-    protected override async Task<int> ExecuteAsync(ParseResult parseResult, CancellationToken cancellationToken)
+    protected override async Task<CommandResult> ExecuteAsync(ParseResult parseResult, CancellationToken cancellationToken)
     {
         // Argument arity guarantees non-null
         var key = parseResult.GetValue(s_keyArgument)!;
@@ -57,14 +57,13 @@ internal sealed class SecretSetCommand : BaseCommand
         var result = await _secretStoreResolver.ResolveAsync(projectFile, autoInit: true, cancellationToken);
         if (result is null)
         {
-            InteractionService.DisplayError(SecretCommandStrings.CouldNotFindAppHost);
-            return ExitCodeConstants.FailedToFindProject;
+            return CommandResult.Failure(ExitCodeConstants.FailedToFindProject, SecretCommandStrings.CouldNotFindAppHost);
         }
 
         result.Store.Set(key, value);
         result.Store.Save();
 
         InteractionService.DisplaySuccess(string.Format(CultureInfo.CurrentCulture, SecretCommandStrings.SecretSetSuccess, key));
-        return ExitCodeConstants.Success;
+        return CommandResult.Success();
     }
 }

--- a/src/Aspire.Cli/Commands/SetupCommand.cs
+++ b/src/Aspire.Cli/Commands/SetupCommand.cs
@@ -44,7 +44,7 @@ internal sealed class SetupCommand : BaseCommand
         Options.Add(s_forceOption);
     }
 
-    protected override async Task<int> ExecuteAsync(ParseResult parseResult, CancellationToken cancellationToken)
+    protected override async Task<CommandResult> ExecuteAsync(ParseResult parseResult, CancellationToken cancellationToken)
     {
         var installPath = parseResult.GetValue(s_installPathOption);
         var force = parseResult.GetValue(s_forceOption);
@@ -52,8 +52,7 @@ internal sealed class SetupCommand : BaseCommand
         var processPath = Environment.ProcessPath;
         if (string.IsNullOrEmpty(processPath))
         {
-            InteractionService.DisplayError("Could not determine the CLI executable path.");
-            return ExitCodeConstants.FailedToBuildArtifacts;
+            return CommandResult.Failure(ExitCodeConstants.FailedToBuildArtifacts, "Could not determine the CLI executable path.");
         }
 
         // Determine extraction directory
@@ -64,8 +63,7 @@ internal sealed class SetupCommand : BaseCommand
 
         if (string.IsNullOrEmpty(installPath))
         {
-            InteractionService.DisplayError("Could not determine the installation path.");
-            return ExitCodeConstants.FailedToBuildArtifacts;
+            return CommandResult.Failure(ExitCodeConstants.FailedToBuildArtifacts, "Could not determine the installation path.");
         }
 
         // Extract with spinner
@@ -75,7 +73,7 @@ internal sealed class SetupCommand : BaseCommand
             async () =>
             {
                 result = await _bundleService.ExtractAsync(installPath, force, cancellationToken);
-                return ExitCodeConstants.Success;
+                return CommandResult.Success();
             }, emoji: KnownEmojis.Package);
 
         switch (result)
@@ -93,8 +91,7 @@ internal sealed class SetupCommand : BaseCommand
                 break;
 
             case BundleExtractResult.ExtractionFailed:
-                InteractionService.DisplayError($"Bundle was extracted to {installPath} but layout validation failed.");
-                return ExitCodeConstants.FailedToBuildArtifacts;
+                return CommandResult.Failure(ExitCodeConstants.FailedToBuildArtifacts, $"Bundle was extracted to {installPath} but layout validation failed.");
         }
 
         return exitCode;

--- a/src/Aspire.Cli/Commands/StartCommand.cs
+++ b/src/Aspire.Cli/Commands/StartCommand.cs
@@ -39,7 +39,7 @@ internal sealed class StartCommand : BaseCommand
         TreatUnmatchedTokensAsErrors = false;
     }
 
-    protected override async Task<int> ExecuteAsync(ParseResult parseResult, CancellationToken cancellationToken)
+    protected override async Task<CommandResult> ExecuteAsync(ParseResult parseResult, CancellationToken cancellationToken)
     {
         var passedAppHostProjectFile = parseResult.GetValue(AppHostLauncher.s_appHostOption);
         var format = parseResult.GetValue(AppHostLauncher.s_formatOption);
@@ -59,7 +59,7 @@ internal sealed class StartCommand : BaseCommand
             additionalArgs.Add("--no-build");
         }
 
-        return await _appHostLauncher.LaunchDetachedAsync(
+        return CommandResult.FromExitCode(await _appHostLauncher.LaunchDetachedAsync(
             passedAppHostProjectFile,
             format,
             isolated,
@@ -67,6 +67,6 @@ internal sealed class StartCommand : BaseCommand
             waitForDebugger,
             globalArgs,
             additionalArgs,
-            cancellationToken);
+            cancellationToken));
     }
 }

--- a/src/Aspire.Cli/Commands/StartCommand.cs
+++ b/src/Aspire.Cli/Commands/StartCommand.cs
@@ -59,7 +59,7 @@ internal sealed class StartCommand : BaseCommand
             additionalArgs.Add("--no-build");
         }
 
-        return CommandResult.FromExitCode(await _appHostLauncher.LaunchDetachedAsync(
+        return await _appHostLauncher.LaunchDetachedAsync(
             passedAppHostProjectFile,
             format,
             isolated,
@@ -67,6 +67,6 @@ internal sealed class StartCommand : BaseCommand
             waitForDebugger,
             globalArgs,
             additionalArgs,
-            cancellationToken));
+            cancellationToken);
     }
 }

--- a/src/Aspire.Cli/Commands/StopCommand.cs
+++ b/src/Aspire.Cli/Commands/StopCommand.cs
@@ -57,7 +57,7 @@ internal sealed class StopCommand : BaseCommand
         Options.Add(s_allOption);
     }
 
-    protected override async Task<int> ExecuteAsync(ParseResult parseResult, CancellationToken cancellationToken)
+    protected override async Task<CommandResult> ExecuteAsync(ParseResult parseResult, CancellationToken cancellationToken)
     {
         var passedAppHostProjectFile = parseResult.GetValue(s_appHostOption);
         var stopAll = parseResult.GetValue(s_allOption);
@@ -66,23 +66,22 @@ internal sealed class StopCommand : BaseCommand
         // Validate mutual exclusivity of --all and --project
         if (stopAll && passedAppHostProjectFile is not null)
         {
-            _interactionService.DisplayError(string.Format(CultureInfo.InvariantCulture, StopCommandStrings.AllAndProjectMutuallyExclusive, s_allOption.Name, s_appHostOption.Name));
-            return CompleteStopActivity(activity, ExitCodeConstants.FailedToFindProject);
+            return CommandResult.Failure(CompleteStopActivity(activity, ExitCodeConstants.FailedToFindProject), string.Format(CultureInfo.InvariantCulture, StopCommandStrings.AllAndProjectMutuallyExclusive, s_allOption.Name, s_appHostOption.Name));
         }
 
         // Handle --all: stop all running AppHosts
         if (stopAll)
         {
-            return CompleteStopActivity(activity, await StopAllAppHostsAsync(cancellationToken));
+            return CommandResult.FromExitCode(CompleteStopActivity(activity, await StopAllAppHostsAsync(cancellationToken)));
         }
 
         // In non-interactive mode, try to auto-resolve without prompting
         if (!_hostEnvironment.SupportsInteractiveInput)
         {
-            return CompleteStopActivity(activity, await ExecuteNonInteractiveAsync(passedAppHostProjectFile, cancellationToken));
+            return CommandResult.FromExitCode(CompleteStopActivity(activity, await ExecuteNonInteractiveAsync(passedAppHostProjectFile, cancellationToken)));
         }
 
-        return CompleteStopActivity(activity, await ExecuteInteractiveAsync(passedAppHostProjectFile, cancellationToken));
+        return CommandResult.FromExitCode(CompleteStopActivity(activity, await ExecuteInteractiveAsync(passedAppHostProjectFile, cancellationToken)));
     }
 
     /// <summary>

--- a/src/Aspire.Cli/Commands/TelemetryCommand.cs
+++ b/src/Aspire.Cli/Commands/TelemetryCommand.cs
@@ -1,8 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.CommandLine;
-using System.CommandLine.Help;
 using Aspire.Cli.Configuration;
 using Aspire.Cli.Interaction;
 using Aspire.Cli.Resources;
@@ -14,7 +12,7 @@ namespace Aspire.Cli.Commands;
 /// <summary>
 /// Parent command for telemetry operations. Contains subcommands for viewing logs, spans, and traces.
 /// </summary>
-internal sealed class TelemetryCommand : BaseCommand
+internal sealed class TelemetryCommand : ParentCommand
 {
     internal override HelpGroup HelpGroup => HelpGroup.Monitoring;
 
@@ -36,13 +34,5 @@ internal sealed class TelemetryCommand : BaseCommand
         Subcommands.Add(logsCommand);
         Subcommands.Add(spansCommand);
         Subcommands.Add(tracesCommand);
-    }
-
-    protected override bool UpdateNotificationsEnabled => false;
-
-    protected override Task<int> ExecuteAsync(ParseResult parseResult, CancellationToken cancellationToken)
-    {
-        new HelpAction().Invoke(parseResult);
-        return Task.FromResult(ExitCodeConstants.InvalidCommand);
     }
 }

--- a/src/Aspire.Cli/Commands/TelemetryCommandHelpers.cs
+++ b/src/Aspire.Cli/Commands/TelemetryCommandHelpers.cs
@@ -184,7 +184,6 @@ internal static class TelemetryCommandHelpers
     /// When <c>true</c>, a missing Dashboard API is a hard error.
     /// When <c>false</c>, a missing Dashboard API is non-fatal and the method returns success with <c>null</c> base URL and token.
     /// </param>
-    /// <param name="logFilePath">The path to the current session's log file, displayed alongside errors.</param>
     /// <param name="cancellationToken">The cancellation token.</param>
     /// <returns>A <see cref="DashboardApiResult"/> with the resolved connection and dashboard API info.</returns>
     public static async Task<DashboardApiResult> GetDashboardApiAsync(
@@ -196,7 +195,6 @@ internal static class TelemetryCommandHelpers
         string? dashboardUrl,
         string? apiKey,
         bool requireDashboard,
-        string logFilePath,
         CancellationToken cancellationToken)
     {
         // Validate mutual exclusivity of --apphost and --dashboard-url
@@ -221,8 +219,7 @@ internal static class TelemetryCommandHelpers
                     interactionService,
                     new TelemetryErrorInfo(
                         string.Format(CultureInfo.CurrentCulture, TelemetryCommandStrings.DashboardUrlInvalid, dashboardUrl),
-                        TelemetryCommandStrings.DashboardUrlInvalidHint),
-                    logFilePath);
+                        TelemetryCommandStrings.DashboardUrlInvalidHint));
                 return DashboardApiResult.Failure(ExitCodeConstants.InvalidCommand);
             }
 
@@ -247,7 +244,7 @@ internal static class TelemetryCommandHelpers
                             TelemetryCommandStrings.DashboardLoginTokenFailedHint,
                             TelemetryCommandStrings.DashboardLoginTokenFailedAnonymousHint),
                     };
-                    DisplayTelemetryError(interactionService, errorInfo, logFilePath);
+                    DisplayTelemetryError(interactionService, errorInfo);
                     return DashboardApiResult.Failure(ExitCodeConstants.DashboardFailure);
                 }
 
@@ -281,8 +278,7 @@ internal static class TelemetryCommandHelpers
                     interactionService,
                     new TelemetryErrorInfo(
                         TelemetryCommandStrings.DashboardNotAvailable,
-                        TelemetryCommandStrings.DashboardNotAvailableHint),
-                    logFilePath);
+                        TelemetryCommandStrings.DashboardNotAvailableHint));
                 return DashboardApiResult.Failure(ExitCodeConstants.DashboardFailure);
             }
 
@@ -318,12 +314,12 @@ internal static class TelemetryCommandHelpers
     }
 
     /// <summary>
-    /// Displays a telemetry error with a structured format: error message, optional hint, and log file path.
+    /// Displays a telemetry error with a structured format: error message and optional hints.
+    /// The CLI log file path is displayed centrally by BaseCommand on non-zero exit.
     /// </summary>
     public static void DisplayTelemetryError(
         IInteractionService interactionService,
-        TelemetryErrorInfo errorInfo,
-        string logFilePath)
+        TelemetryErrorInfo errorInfo)
     {
         interactionService.DisplayError(errorInfo.Error);
 
@@ -331,11 +327,6 @@ internal static class TelemetryCommandHelpers
         {
             interactionService.DisplayMessage(KnownEmojis.Information, hint);
         }
-
-        interactionService.DisplayMessage(
-            KnownEmojis.PageFacingUp,
-            string.Format(CultureInfo.CurrentCulture, InteractionServiceStrings.SeeLogsAt, MarkupHelpers.SafeFileLink(interactionService, logFilePath)),
-            allowMarkup: true);
     }
 
     /// <summary>

--- a/src/Aspire.Cli/Commands/TelemetryLogsCommand.cs
+++ b/src/Aspire.Cli/Commands/TelemetryLogsCommand.cs
@@ -106,7 +106,7 @@ internal sealed class TelemetryLogsCommand : BaseCommand
         }
 
         var dashboardApi = await TelemetryCommandHelpers.GetDashboardApiAsync(
-            _connectionResolver, _interactionService, _httpClientFactory, _logger, passedAppHostProjectFile, dashboardUrl, apiKey, requireDashboard: true, ExecutionContext.LogFilePath, cancellationToken);
+            _connectionResolver, _interactionService, _httpClientFactory, _logger, passedAppHostProjectFile, dashboardUrl, apiKey, requireDashboard: true, cancellationToken);
 
         if (!dashboardApi.Success)
         {
@@ -166,7 +166,7 @@ internal sealed class TelemetryLogsCommand : BaseCommand
         {
             _logger.LogError(ex, "Failed to fetch logs from Dashboard API");
             var errorInfo = await TelemetryCommandHelpers.FormatTelemetryErrorAsync(ex, baseUrl, dashboardOnly, _httpClientFactory, _logger, cancellationToken);
-            TelemetryCommandHelpers.DisplayTelemetryError(_interactionService, errorInfo, ExecutionContext.LogFilePath);
+            TelemetryCommandHelpers.DisplayTelemetryError(_interactionService, errorInfo);
             return ExitCodeConstants.DashboardFailure;
         }
     }

--- a/src/Aspire.Cli/Commands/TelemetryLogsCommand.cs
+++ b/src/Aspire.Cli/Commands/TelemetryLogsCommand.cs
@@ -83,7 +83,7 @@ internal sealed class TelemetryLogsCommand : BaseCommand
         Options.Add(s_searchOption);
     }
 
-    protected override async Task<int> ExecuteAsync(ParseResult parseResult, CancellationToken cancellationToken)
+    protected override async Task<CommandResult> ExecuteAsync(ParseResult parseResult, CancellationToken cancellationToken)
     {
         using var activity = Telemetry.StartDiagnosticActivity(Name);
 
@@ -101,8 +101,7 @@ internal sealed class TelemetryLogsCommand : BaseCommand
         // Validate --limit value
         if (limit.HasValue && limit.Value < 1)
         {
-            _interactionService.DisplayError(TelemetryCommandStrings.LimitMustBePositive);
-            return ExitCodeConstants.InvalidCommand;
+            return CommandResult.Failure(ExitCodeConstants.InvalidCommand, TelemetryCommandStrings.LimitMustBePositive);
         }
 
         var dashboardApi = await TelemetryCommandHelpers.GetDashboardApiAsync(
@@ -110,10 +109,10 @@ internal sealed class TelemetryLogsCommand : BaseCommand
 
         if (!dashboardApi.Success)
         {
-            return dashboardApi.ExitCode;
+            return CommandResult.FromExitCode(dashboardApi.ExitCode);
         }
 
-        return await FetchLogsAsync(dashboardApi.BaseUrl!, dashboardApi.ApiToken!, resourceName, traceId, severity, limit, follow, format, dashboardOnly: dashboardUrl is not null, dashboardApi.DashboardUrl!, search, cancellationToken);
+        return CommandResult.FromExitCode(await FetchLogsAsync(dashboardApi.BaseUrl!, dashboardApi.ApiToken!, resourceName, traceId, severity, limit, follow, format, dashboardOnly: dashboardUrl is not null, dashboardApi.DashboardUrl!, search, cancellationToken));
     }
 
     private async Task<int> FetchLogsAsync(

--- a/src/Aspire.Cli/Commands/TelemetrySpansCommand.cs
+++ b/src/Aspire.Cli/Commands/TelemetrySpansCommand.cs
@@ -99,7 +99,7 @@ internal sealed class TelemetrySpansCommand : BaseCommand
         }
 
         var dashboardApi = await TelemetryCommandHelpers.GetDashboardApiAsync(
-            _connectionResolver, _interactionService, _httpClientFactory, _logger, passedAppHostProjectFile, dashboardUrl, apiKey, requireDashboard: true, ExecutionContext.LogFilePath, cancellationToken);
+            _connectionResolver, _interactionService, _httpClientFactory, _logger, passedAppHostProjectFile, dashboardUrl, apiKey, requireDashboard: true, cancellationToken);
 
         if (!dashboardApi.Success)
         {
@@ -161,7 +161,7 @@ internal sealed class TelemetrySpansCommand : BaseCommand
         {
             _logger.LogError(ex, "Failed to fetch spans from Dashboard API");
             var errorInfo = await TelemetryCommandHelpers.FormatTelemetryErrorAsync(ex, baseUrl, dashboardOnly, _httpClientFactory, _logger, cancellationToken);
-            TelemetryCommandHelpers.DisplayTelemetryError(_interactionService, errorInfo, ExecutionContext.LogFilePath);
+            TelemetryCommandHelpers.DisplayTelemetryError(_interactionService, errorInfo);
             return ExitCodeConstants.DashboardFailure;
         }
     }

--- a/src/Aspire.Cli/Commands/TelemetrySpansCommand.cs
+++ b/src/Aspire.Cli/Commands/TelemetrySpansCommand.cs
@@ -76,7 +76,7 @@ internal sealed class TelemetrySpansCommand : BaseCommand
         Options.Add(s_searchOption);
     }
 
-    protected override async Task<int> ExecuteAsync(ParseResult parseResult, CancellationToken cancellationToken)
+    protected override async Task<CommandResult> ExecuteAsync(ParseResult parseResult, CancellationToken cancellationToken)
     {
         using var activity = Telemetry.StartDiagnosticActivity(Name);
 
@@ -94,8 +94,7 @@ internal sealed class TelemetrySpansCommand : BaseCommand
         // Validate --limit value
         if (limit.HasValue && limit.Value < 1)
         {
-            _interactionService.DisplayError(TelemetryCommandStrings.LimitMustBePositive);
-            return ExitCodeConstants.InvalidCommand;
+            return CommandResult.Failure(ExitCodeConstants.InvalidCommand, TelemetryCommandStrings.LimitMustBePositive);
         }
 
         var dashboardApi = await TelemetryCommandHelpers.GetDashboardApiAsync(
@@ -103,10 +102,10 @@ internal sealed class TelemetrySpansCommand : BaseCommand
 
         if (!dashboardApi.Success)
         {
-            return dashboardApi.ExitCode;
+            return CommandResult.FromExitCode(dashboardApi.ExitCode);
         }
 
-        return await FetchSpansAsync(dashboardApi.BaseUrl!, dashboardApi.ApiToken!, resourceName, traceId, hasError, limit, follow, format, dashboardOnly: dashboardUrl is not null, dashboardApi.DashboardUrl!, search, cancellationToken);
+        return CommandResult.FromExitCode(await FetchSpansAsync(dashboardApi.BaseUrl!, dashboardApi.ApiToken!, resourceName, traceId, hasError, limit, follow, format, dashboardOnly: dashboardUrl is not null, dashboardApi.DashboardUrl!, search, cancellationToken));
     }
 
     private async Task<int> FetchSpansAsync(

--- a/src/Aspire.Cli/Commands/TelemetryTracesCommand.cs
+++ b/src/Aspire.Cli/Commands/TelemetryTracesCommand.cs
@@ -75,7 +75,7 @@ internal sealed class TelemetryTracesCommand : BaseCommand
         Options.Add(s_searchOption);
     }
 
-    protected override async Task<int> ExecuteAsync(ParseResult parseResult, CancellationToken cancellationToken)
+    protected override async Task<CommandResult> ExecuteAsync(ParseResult parseResult, CancellationToken cancellationToken)
     {
         using var activity = Telemetry.StartDiagnosticActivity(Name);
 
@@ -92,8 +92,7 @@ internal sealed class TelemetryTracesCommand : BaseCommand
         // Validate --limit value
         if (limit.HasValue && limit.Value < 1)
         {
-            _interactionService.DisplayError(TelemetryCommandStrings.LimitMustBePositive);
-            return ExitCodeConstants.InvalidCommand;
+            return CommandResult.Failure(ExitCodeConstants.InvalidCommand, TelemetryCommandStrings.LimitMustBePositive);
         }
 
         var dashboardApi = await TelemetryCommandHelpers.GetDashboardApiAsync(
@@ -101,18 +100,18 @@ internal sealed class TelemetryTracesCommand : BaseCommand
 
         if (!dashboardApi.Success)
         {
-            return dashboardApi.ExitCode;
+            return CommandResult.FromExitCode(dashboardApi.ExitCode);
         }
 
         try
         {
             if (!string.IsNullOrEmpty(traceId))
             {
-                return await FetchSingleTraceAsync(dashboardApi.BaseUrl!, dashboardApi.ApiToken!, traceId, format, dashboardApi.DashboardUrl!, cancellationToken);
+                return CommandResult.FromExitCode(await FetchSingleTraceAsync(dashboardApi.BaseUrl!, dashboardApi.ApiToken!, traceId, format, dashboardApi.DashboardUrl!, cancellationToken));
             }
             else
             {
-                return await FetchTracesAsync(dashboardApi.BaseUrl!, dashboardApi.ApiToken!, resourceName, hasError, limit, format, dashboardApi.DashboardUrl!, search, cancellationToken);
+                return CommandResult.FromExitCode(await FetchTracesAsync(dashboardApi.BaseUrl!, dashboardApi.ApiToken!, resourceName, hasError, limit, format, dashboardApi.DashboardUrl!, search, cancellationToken));
             }
         }
         catch (HttpRequestException ex)
@@ -120,7 +119,7 @@ internal sealed class TelemetryTracesCommand : BaseCommand
             _logger.LogError(ex, "Failed to fetch traces from Dashboard API");
             var errorInfo = await TelemetryCommandHelpers.FormatTelemetryErrorAsync(ex, dashboardApi.BaseUrl!, dashboardUrl is not null, _httpClientFactory, _logger, cancellationToken);
             TelemetryCommandHelpers.DisplayTelemetryError(_interactionService, errorInfo);
-            return ExitCodeConstants.DashboardFailure;
+            return CommandResult.Failure(ExitCodeConstants.DashboardFailure);
         }
     }
 

--- a/src/Aspire.Cli/Commands/TelemetryTracesCommand.cs
+++ b/src/Aspire.Cli/Commands/TelemetryTracesCommand.cs
@@ -97,7 +97,7 @@ internal sealed class TelemetryTracesCommand : BaseCommand
         }
 
         var dashboardApi = await TelemetryCommandHelpers.GetDashboardApiAsync(
-            _connectionResolver, _interactionService, _httpClientFactory, _logger, passedAppHostProjectFile, dashboardUrl, apiKey, requireDashboard: true, ExecutionContext.LogFilePath, cancellationToken);
+            _connectionResolver, _interactionService, _httpClientFactory, _logger, passedAppHostProjectFile, dashboardUrl, apiKey, requireDashboard: true, cancellationToken);
 
         if (!dashboardApi.Success)
         {
@@ -119,7 +119,7 @@ internal sealed class TelemetryTracesCommand : BaseCommand
         {
             _logger.LogError(ex, "Failed to fetch traces from Dashboard API");
             var errorInfo = await TelemetryCommandHelpers.FormatTelemetryErrorAsync(ex, dashboardApi.BaseUrl!, dashboardUrl is not null, _httpClientFactory, _logger, cancellationToken);
-            TelemetryCommandHelpers.DisplayTelemetryError(_interactionService, errorInfo, ExecutionContext.LogFilePath);
+            TelemetryCommandHelpers.DisplayTelemetryError(_interactionService, errorInfo);
             return ExitCodeConstants.DashboardFailure;
         }
     }

--- a/src/Aspire.Cli/Commands/TemplateCommand.cs
+++ b/src/Aspire.Cli/Commands/TemplateCommand.cs
@@ -12,9 +12,9 @@ namespace Aspire.Cli.Commands;
 
 internal sealed class TemplateCommand : BaseCommand
 {
-    private readonly Func<ParseResult, CancellationToken, Task<int>> _executeCallback;
+    private readonly Func<ParseResult, CancellationToken, Task<CommandResult>> _executeCallback;
 
-    public TemplateCommand(ITemplate template, Func<ParseResult, CancellationToken, Task<int>> executeCallback, IFeatures features, ICliUpdateNotifier updateNotifier, CliExecutionContext executionContext, IInteractionService interactionService, AspireCliTelemetry telemetry)
+    public TemplateCommand(ITemplate template, Func<ParseResult, CancellationToken, Task<CommandResult>> executeCallback, IFeatures features, ICliUpdateNotifier updateNotifier, CliExecutionContext executionContext, IInteractionService interactionService, AspireCliTelemetry telemetry)
         : base(template.Name, template.Description, features, updateNotifier, executionContext, interactionService, telemetry)
     {
         ArgumentNullException.ThrowIfNull(template);
@@ -24,7 +24,7 @@ internal sealed class TemplateCommand : BaseCommand
         _executeCallback = executeCallback;
     }
 
-    protected override Task<int> ExecuteAsync(ParseResult parseResult, CancellationToken cancellationToken)
+    protected override Task<CommandResult> ExecuteAsync(ParseResult parseResult, CancellationToken cancellationToken)
     {
         return _executeCallback(parseResult, cancellationToken);
     }

--- a/src/Aspire.Cli/Commands/UpdateCommand.cs
+++ b/src/Aspire.Cli/Commands/UpdateCommand.cs
@@ -111,7 +111,7 @@ internal sealed class UpdateCommand : BaseCommand
         return DotNetToolDetection.GetDotNetToolUpdateCommand();
     }
 
-    protected override async Task<int> ExecuteAsync(ParseResult parseResult, CancellationToken cancellationToken)
+    protected override async Task<CommandResult> ExecuteAsync(ParseResult parseResult, CancellationToken cancellationToken)
     {
         var isSelfUpdate = parseResult.GetValue(s_selfOption);
 
@@ -124,23 +124,22 @@ internal sealed class UpdateCommand : BaseCommand
             {
                 InteractionService.DisplayMessage(KnownEmojis.Information, UpdateCommandStrings.DotNetToolSelfUpdateMessage);
                 InteractionService.DisplayPlainText($"  {dotNetToolUpdateCommand}");
-                return 0;
+                return CommandResult.FromExitCode(0);
             }
 
             if (_cliDownloader is null)
             {
-                InteractionService.DisplayError("CLI self-update is not available in this environment.");
-                return ExitCodeConstants.InvalidCommand;
+                return CommandResult.Failure(ExitCodeConstants.InvalidCommand, "CLI self-update is not available in this environment.");
             }
 
             try
             {
-                return await ExecuteSelfUpdateAsync(parseResult, cancellationToken);
+                return CommandResult.FromExitCode(await ExecuteSelfUpdateAsync(parseResult, cancellationToken));
             }
             catch (OperationCanceledException)
             {
                 InteractionService.DisplayCancellationMessage();
-                return ExitCodeConstants.InvalidCommand;
+                return CommandResult.Failure(ExitCodeConstants.InvalidCommand);
             }
         }
 
@@ -151,7 +150,7 @@ internal sealed class UpdateCommand : BaseCommand
             var projectFile = await _projectLocator.UseOrFindAppHostProjectFileAsync(passedAppHostProjectFile, createSettingsFile: true, cancellationToken);
             if (projectFile is null)
             {
-                return ExitCodeConstants.FailedToFindProject;
+                return CommandResult.Failure(ExitCodeConstants.FailedToFindProject);
             }
 
             var project = _projectFactory.GetProject(projectFile);
@@ -264,11 +263,11 @@ internal sealed class UpdateCommand : BaseCommand
                     {
                         InteractionService.DisplayMessage(KnownEmojis.Information, UpdateCommandStrings.DotNetToolSelfUpdateMessage);
                         InteractionService.DisplayPlainText($"  {dotNetToolUpdateCommand}");
-                        return ExitCodeConstants.Success;
+                        return CommandResult.Success();
                     }
 
                     // Use the same channel that was selected for the project update
-                    return await ExecuteSelfUpdateAsync(parseResult, cancellationToken, channel.Name);
+                    return CommandResult.FromExitCode(await ExecuteSelfUpdateAsync(parseResult, cancellationToken, channel.Name));
                 }
             }
         }
@@ -276,15 +275,13 @@ internal sealed class UpdateCommand : BaseCommand
         {
             var message = Markup.Escape(ex.Message);
             Telemetry.RecordError(message, ex);
-            InteractionService.DisplayError(message);
-            return ExitCodeConstants.FailedToUpgradeProject;
+            return CommandResult.Failure(ExitCodeConstants.FailedToUpgradeProject, message);
         }
         catch (ChannelNotFoundException ex)
         {
             var message = Markup.Escape(ex.Message);
             Telemetry.RecordError(message, ex);
-            InteractionService.DisplayError(message);
-            return ExitCodeConstants.FailedToUpgradeProject;
+            return CommandResult.Failure(ExitCodeConstants.FailedToUpgradeProject, message);
         }
         catch (ProjectLocatorException ex)
         {
@@ -301,7 +298,7 @@ internal sealed class UpdateCommand : BaseCommand
 
                     if (shouldUpdateCli)
                     {
-                        return await ExecuteSelfUpdateAsync(parseResult, cancellationToken);
+                        return CommandResult.FromExitCode(await ExecuteSelfUpdateAsync(parseResult, cancellationToken));
                     }
                 }
             }
@@ -311,10 +308,10 @@ internal sealed class UpdateCommand : BaseCommand
         catch (OperationCanceledException)
         {
             InteractionService.DisplayCancellationMessage();
-            return ExitCodeConstants.FailedToUpgradeProject;
+            return CommandResult.Failure(ExitCodeConstants.FailedToUpgradeProject);
         }
 
-        return 0;
+        return CommandResult.FromExitCode(0);
     }
 
     private async Task<int> ExecuteSelfUpdateAsync(ParseResult parseResult, CancellationToken cancellationToken, string? selectedChannel = null)

--- a/src/Aspire.Cli/Commands/UpdateCommand.cs
+++ b/src/Aspire.Cli/Commands/UpdateCommand.cs
@@ -134,12 +134,11 @@ internal sealed class UpdateCommand : BaseCommand
 
             try
             {
-                return CommandResult.FromExitCode(await ExecuteSelfUpdateAsync(parseResult, cancellationToken));
+                return await ExecuteSelfUpdateAsync(parseResult, cancellationToken);
             }
             catch (OperationCanceledException)
             {
-                InteractionService.DisplayCancellationMessage();
-                return CommandResult.Failure(ExitCodeConstants.InvalidCommand);
+                return CommandResult.Cancelled();
             }
         }
 
@@ -267,7 +266,7 @@ internal sealed class UpdateCommand : BaseCommand
                     }
 
                     // Use the same channel that was selected for the project update
-                    return CommandResult.FromExitCode(await ExecuteSelfUpdateAsync(parseResult, cancellationToken, channel.Name));
+                    return await ExecuteSelfUpdateAsync(parseResult, cancellationToken, channel.Name);
                 }
             }
         }
@@ -298,7 +297,7 @@ internal sealed class UpdateCommand : BaseCommand
 
                     if (shouldUpdateCli)
                     {
-                        return CommandResult.FromExitCode(await ExecuteSelfUpdateAsync(parseResult, cancellationToken));
+                        return await ExecuteSelfUpdateAsync(parseResult, cancellationToken);
                     }
                 }
             }
@@ -307,14 +306,13 @@ internal sealed class UpdateCommand : BaseCommand
         }
         catch (OperationCanceledException)
         {
-            InteractionService.DisplayCancellationMessage();
-            return CommandResult.Failure(ExitCodeConstants.FailedToUpgradeProject);
+            return CommandResult.Cancelled();
         }
 
         return CommandResult.FromExitCode(0);
     }
 
-    private async Task<int> ExecuteSelfUpdateAsync(ParseResult parseResult, CancellationToken cancellationToken, string? selectedChannel = null)
+    private async Task<CommandResult> ExecuteSelfUpdateAsync(ParseResult parseResult, CancellationToken cancellationToken, string? selectedChannel = null)
     {
         var channel = selectedChannel ?? parseResult.GetValue(_channelOption) ?? parseResult.GetValue(_qualityOption);
 
@@ -343,8 +341,7 @@ internal sealed class UpdateCommand : BaseCommand
             var currentExePath = Environment.ProcessPath;
             if (string.IsNullOrEmpty(currentExePath))
             {
-                InteractionService.DisplayError("Unable to determine the current executable path.");
-                return ExitCodeConstants.InvalidCommand;
+                return CommandResult.Failure(ExitCodeConstants.InvalidCommand, "Unable to determine the current executable path.");
             }
 
             InteractionService.DisplayMessage(KnownEmojis.Package, $"Current CLI location: {currentExePath}");
@@ -356,19 +353,17 @@ internal sealed class UpdateCommand : BaseCommand
             // Extract and update to $HOME/.aspire/bin
             await ExtractAndUpdateAsync(archivePath, cancellationToken);
 
-            return 0;
+            return CommandResult.Success();
         }
         catch (OperationCanceledException)
         {
-            InteractionService.DisplayCancellationMessage();
-            return ExitCodeConstants.InvalidCommand;
+            return CommandResult.Cancelled();
         }
         catch (Exception ex)
         {
             Telemetry.RecordError("Failed to update CLI", ex);
             var errorMessage = $"Failed to update CLI: {ex.Message}";
-            InteractionService.DisplayError(errorMessage);
-            return ExitCodeConstants.InvalidCommand;
+            return CommandResult.Failure(ExitCodeConstants.InvalidCommand, errorMessage);
         }
     }
 

--- a/src/Aspire.Cli/Commands/WaitCommand.cs
+++ b/src/Aspire.Cli/Commands/WaitCommand.cs
@@ -65,7 +65,7 @@ internal sealed class WaitCommand : BaseCommand
         Options.Add(s_appHostOption);
     }
 
-    protected override async Task<int> ExecuteAsync(ParseResult parseResult, CancellationToken cancellationToken)
+    protected override async Task<CommandResult> ExecuteAsync(ParseResult parseResult, CancellationToken cancellationToken)
     {
         using var activity = Telemetry.StartDiagnosticActivity(Name);
 
@@ -77,15 +77,13 @@ internal sealed class WaitCommand : BaseCommand
         // Validate status value
         if (!IsValidStatus(status))
         {
-            _interactionService.DisplayError(string.Format(CultureInfo.CurrentCulture, WaitCommandStrings.InvalidStatusValue, status));
-            return ExitCodeConstants.InvalidCommand;
+            return CommandResult.Failure(ExitCodeConstants.InvalidCommand, string.Format(CultureInfo.CurrentCulture, WaitCommandStrings.InvalidStatusValue, status));
         }
 
         // Validate timeout
         if (timeoutSeconds <= 0)
         {
-            _interactionService.DisplayError(WaitCommandStrings.TimeoutMustBePositive);
-            return ExitCodeConstants.InvalidCommand;
+            return CommandResult.Failure(ExitCodeConstants.InvalidCommand, WaitCommandStrings.TimeoutMustBePositive);
         }
 
         // Resolve connection to a running AppHost
@@ -98,12 +96,12 @@ internal sealed class WaitCommand : BaseCommand
 
         if (!result.Success)
         {
-            return AppHostConnectionResultHandler.DisplayFailureAsError(result, _interactionService, ExitCodeConstants.FailedToFindProject);
+            return CommandResult.FromExitCode(AppHostConnectionResultHandler.DisplayFailureAsError(result, _interactionService, ExitCodeConstants.FailedToFindProject));
         }
 
         var connection = result.Connection!;
 
-        return await WaitForResourceAsync(connection, resourceName, status, timeoutSeconds, cancellationToken);
+        return CommandResult.FromExitCode(await WaitForResourceAsync(connection, resourceName, status, timeoutSeconds, cancellationToken));
     }
 
     private async Task<int> WaitForResourceAsync(

--- a/src/Aspire.Cli/ExitCodeConstants.cs
+++ b/src/Aspire.Cli/ExitCodeConstants.cs
@@ -28,4 +28,9 @@ internal static class ExitCodeConstants
     public const int FailedToStartCli = 20;
     public const int MissingRequiredArgument = 21;
     public const int FailedToSearchIntegrations = 22;
+
+    // 130 is the conventional exit code for cancellation (128 + SIGINT signal 2).
+    // Used for all user-initiated cancellations, not just SIGINT, so callers can
+    // distinguish "user cancelled" from a real error.
+    public const int Cancelled = 130;
 }

--- a/src/Aspire.Cli/Program.cs
+++ b/src/Aspire.Cli/Program.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.CommandLine;
-using System.CommandLine.Parsing;
 using System.Diagnostics;
 using System.Globalization;
 using System.Runtime.InteropServices;
@@ -855,7 +854,7 @@ public class Program
         // Walk the parent command tree to find the top-level command name and get the full command name for this parseresult.
         var parentNames = new List<string> { r.CommandResult.Command.Name };
         var current = r.CommandResult.Parent;
-        while (current is CommandResult parentCommandResult)
+        while (current is System.CommandLine.Parsing.CommandResult parentCommandResult)
         {
             parentNames.Add(parentCommandResult.Command.Name);
             current = parentCommandResult.Parent;

--- a/src/Aspire.Cli/Projects/GuestAppHostProject.cs
+++ b/src/Aspire.Cli/Projects/GuestAppHostProject.cs
@@ -573,8 +573,7 @@ internal sealed class GuestAppHostProject : IAppHostProject, IGuestAppHostSdkGen
         {
             // Signal that build/preparation failed so RunCommand doesn't hang waiting
             context.BuildCompletionSource?.TrySetResult(false);
-            _interactionService.DisplayCancellationMessage();
-            return ExitCodeConstants.Success;
+            return ExitCodeConstants.Cancelled;
         }
         catch (Exception ex)
         {
@@ -1002,8 +1001,7 @@ internal sealed class GuestAppHostProject : IAppHostProject, IGuestAppHostSdkGen
         }
         catch (OperationCanceledException)
         {
-            _interactionService.DisplayCancellationMessage();
-            return ExitCodeConstants.Success;
+            return ExitCodeConstants.Cancelled;
         }
         catch (Exception ex)
         {

--- a/src/Aspire.Cli/Resources/AddCommandStrings.resx
+++ b/src/Aspire.Cli/Resources/AddCommandStrings.resx
@@ -170,8 +170,8 @@
     <value>Adding Aspire hosting integration...</value>
   </data>
   <data name="PackageInstallationFailed" xml:space="preserve">
-    <value>The package installation failed with exit code {0}. See logs at {1}</value>
-    <comment>{0} is a number, {1} is the log file path</comment>
+    <value>The package installation failed with exit code {0}.</value>
+    <comment>{0} is a number</comment>
   </data>
   <data name="PackageAddedSuccessfully" xml:space="preserve">
     <value>The package {0}::{1} was added successfully.</value>

--- a/src/Aspire.Cli/Resources/TemplatingStrings.Designer.cs
+++ b/src/Aspire.Cli/Resources/TemplatingStrings.Designer.cs
@@ -313,7 +313,7 @@ namespace Aspire.Cli.Resources {
         }
 
         /// <summary>
-        ///   Looks up a localized string similar to Project creation failed with exit code {0}. See logs at {1}.
+        ///   Looks up a localized string similar to Project creation failed with exit code {0}.
         /// </summary>
         public static string ProjectCreationFailed {
             get {
@@ -367,7 +367,7 @@ namespace Aspire.Cli.Resources {
         }
 
         /// <summary>
-        ///   Looks up a localized string similar to The template installation failed with exit code {0}. See logs at {1}.
+        ///   Looks up a localized string similar to The template installation failed with exit code {0}.
         /// </summary>
         public static string TemplateInstallationFailed {
             get {

--- a/src/Aspire.Cli/Resources/TemplatingStrings.resx
+++ b/src/Aspire.Cli/Resources/TemplatingStrings.resx
@@ -202,8 +202,8 @@
     <value>Getting templates...</value>
   </data>
   <data name="TemplateInstallationFailed" xml:space="preserve">
-    <value>The template installation failed with exit code {0}. See logs at {1}</value>
-    <comment>{0} is a number, {1} is the log file path</comment>
+    <value>The template installation failed with exit code {0}.</value>
+    <comment>{0} is a number</comment>
   </data>
   <data name="UsingProjectTemplatesVersion" xml:space="preserve">
     <value>Using project templates version: {0}</value>
@@ -212,8 +212,8 @@
     <value>Creating new Aspire project...</value>
   </data>
   <data name="ProjectCreationFailed" xml:space="preserve">
-    <value>Project creation failed with exit code {0}. See logs at {1}</value>
-    <comment>{0} is a number, {1} is the log file path</comment>
+    <value>Project creation failed with exit code {0}.</value>
+    <comment>{0} is a number</comment>
   </data>
   <data name="ProjectCreatedSuccessfully" xml:space="preserve">
     <value>Project created successfully in {0}.</value>

--- a/src/Aspire.Cli/Resources/xlf/AddCommandStrings.cs.xlf
+++ b/src/Aspire.Cli/Resources/xlf/AddCommandStrings.cs.xlf
@@ -108,9 +108,9 @@
         <note>{0} is the package name, {1} is the version.</note>
       </trans-unit>
       <trans-unit id="PackageInstallationFailed">
-        <source>The package installation failed with exit code {0}. See logs at {1}</source>
-        <target state="translated">Instalace balíčku se nezdařila s ukončovacím kódem {0}. Protokoly najdete na {1}</target>
-        <note>{0} is a number, {1} is the log file path</note>
+        <source>The package installation failed with exit code {0}.</source>
+        <target state="new">The package installation failed with exit code {0}.</target>
+        <note>{0} is a number</note>
       </trans-unit>
       <trans-unit id="ProjectArgumentDescription">
         <source>The Aspire AppHost project file, or a directory to search, to add the integration to</source>

--- a/src/Aspire.Cli/Resources/xlf/AddCommandStrings.de.xlf
+++ b/src/Aspire.Cli/Resources/xlf/AddCommandStrings.de.xlf
@@ -108,9 +108,9 @@
         <note>{0} is the package name, {1} is the version.</note>
       </trans-unit>
       <trans-unit id="PackageInstallationFailed">
-        <source>The package installation failed with exit code {0}. See logs at {1}</source>
-        <target state="translated">Die Paketinstallation ist mit dem Exitcode {0} fehlgeschlagen. Protokolle unter {1} anzeigen.</target>
-        <note>{0} is a number, {1} is the log file path</note>
+        <source>The package installation failed with exit code {0}.</source>
+        <target state="new">The package installation failed with exit code {0}.</target>
+        <note>{0} is a number</note>
       </trans-unit>
       <trans-unit id="ProjectArgumentDescription">
         <source>The Aspire AppHost project file, or a directory to search, to add the integration to</source>

--- a/src/Aspire.Cli/Resources/xlf/AddCommandStrings.es.xlf
+++ b/src/Aspire.Cli/Resources/xlf/AddCommandStrings.es.xlf
@@ -108,9 +108,9 @@
         <note>{0} is the package name, {1} is the version.</note>
       </trans-unit>
       <trans-unit id="PackageInstallationFailed">
-        <source>The package installation failed with exit code {0}. See logs at {1}</source>
-        <target state="translated">La instalación del paquete falló con el código de salida {0}. Consulte los registros en {1}</target>
-        <note>{0} is a number, {1} is the log file path</note>
+        <source>The package installation failed with exit code {0}.</source>
+        <target state="new">The package installation failed with exit code {0}.</target>
+        <note>{0} is a number</note>
       </trans-unit>
       <trans-unit id="ProjectArgumentDescription">
         <source>The Aspire AppHost project file, or a directory to search, to add the integration to</source>

--- a/src/Aspire.Cli/Resources/xlf/AddCommandStrings.fr.xlf
+++ b/src/Aspire.Cli/Resources/xlf/AddCommandStrings.fr.xlf
@@ -108,9 +108,9 @@
         <note>{0} is the package name, {1} is the version.</note>
       </trans-unit>
       <trans-unit id="PackageInstallationFailed">
-        <source>The package installation failed with exit code {0}. See logs at {1}</source>
-        <target state="translated">L’installation du package a échoué avec le code de sortie {0}. Consultez les journaux à l’emplacement {1}</target>
-        <note>{0} is a number, {1} is the log file path</note>
+        <source>The package installation failed with exit code {0}.</source>
+        <target state="new">The package installation failed with exit code {0}.</target>
+        <note>{0} is a number</note>
       </trans-unit>
       <trans-unit id="ProjectArgumentDescription">
         <source>The Aspire AppHost project file, or a directory to search, to add the integration to</source>

--- a/src/Aspire.Cli/Resources/xlf/AddCommandStrings.it.xlf
+++ b/src/Aspire.Cli/Resources/xlf/AddCommandStrings.it.xlf
@@ -108,9 +108,9 @@
         <note>{0} is the package name, {1} is the version.</note>
       </trans-unit>
       <trans-unit id="PackageInstallationFailed">
-        <source>The package installation failed with exit code {0}. See logs at {1}</source>
-        <target state="translated">L'installazione del pacchetto non è riuscita con codice di uscita {0}. Consultare i log in {1}</target>
-        <note>{0} is a number, {1} is the log file path</note>
+        <source>The package installation failed with exit code {0}.</source>
+        <target state="new">The package installation failed with exit code {0}.</target>
+        <note>{0} is a number</note>
       </trans-unit>
       <trans-unit id="ProjectArgumentDescription">
         <source>The Aspire AppHost project file, or a directory to search, to add the integration to</source>

--- a/src/Aspire.Cli/Resources/xlf/AddCommandStrings.ja.xlf
+++ b/src/Aspire.Cli/Resources/xlf/AddCommandStrings.ja.xlf
@@ -108,9 +108,9 @@
         <note>{0} is the package name, {1} is the version.</note>
       </trans-unit>
       <trans-unit id="PackageInstallationFailed">
-        <source>The package installation failed with exit code {0}. See logs at {1}</source>
-        <target state="translated">パッケージのインストールが終了コード {0} で失敗しました。{1} でログを表示する</target>
-        <note>{0} is a number, {1} is the log file path</note>
+        <source>The package installation failed with exit code {0}.</source>
+        <target state="new">The package installation failed with exit code {0}.</target>
+        <note>{0} is a number</note>
       </trans-unit>
       <trans-unit id="ProjectArgumentDescription">
         <source>The Aspire AppHost project file, or a directory to search, to add the integration to</source>

--- a/src/Aspire.Cli/Resources/xlf/AddCommandStrings.ko.xlf
+++ b/src/Aspire.Cli/Resources/xlf/AddCommandStrings.ko.xlf
@@ -108,9 +108,9 @@
         <note>{0} is the package name, {1} is the version.</note>
       </trans-unit>
       <trans-unit id="PackageInstallationFailed">
-        <source>The package installation failed with exit code {0}. See logs at {1}</source>
-        <target state="translated">패키지 설치에 실패했습니다(종료 코드: {0}). {1}에서 로그 보기</target>
-        <note>{0} is a number, {1} is the log file path</note>
+        <source>The package installation failed with exit code {0}.</source>
+        <target state="new">The package installation failed with exit code {0}.</target>
+        <note>{0} is a number</note>
       </trans-unit>
       <trans-unit id="ProjectArgumentDescription">
         <source>The Aspire AppHost project file, or a directory to search, to add the integration to</source>

--- a/src/Aspire.Cli/Resources/xlf/AddCommandStrings.pl.xlf
+++ b/src/Aspire.Cli/Resources/xlf/AddCommandStrings.pl.xlf
@@ -108,9 +108,9 @@
         <note>{0} is the package name, {1} is the version.</note>
       </trans-unit>
       <trans-unit id="PackageInstallationFailed">
-        <source>The package installation failed with exit code {0}. See logs at {1}</source>
-        <target state="translated">Instalacja pakietu nie powiodła się z kodem zakończenia {0}. Zobacz dzienniki pod adresem {1}</target>
-        <note>{0} is a number, {1} is the log file path</note>
+        <source>The package installation failed with exit code {0}.</source>
+        <target state="new">The package installation failed with exit code {0}.</target>
+        <note>{0} is a number</note>
       </trans-unit>
       <trans-unit id="ProjectArgumentDescription">
         <source>The Aspire AppHost project file, or a directory to search, to add the integration to</source>

--- a/src/Aspire.Cli/Resources/xlf/AddCommandStrings.pt-BR.xlf
+++ b/src/Aspire.Cli/Resources/xlf/AddCommandStrings.pt-BR.xlf
@@ -108,9 +108,9 @@
         <note>{0} is the package name, {1} is the version.</note>
       </trans-unit>
       <trans-unit id="PackageInstallationFailed">
-        <source>The package installation failed with exit code {0}. See logs at {1}</source>
-        <target state="translated">A instalação do pacote falhou com o código de saída {0}. Ver logs em {1}</target>
-        <note>{0} is a number, {1} is the log file path</note>
+        <source>The package installation failed with exit code {0}.</source>
+        <target state="new">The package installation failed with exit code {0}.</target>
+        <note>{0} is a number</note>
       </trans-unit>
       <trans-unit id="ProjectArgumentDescription">
         <source>The Aspire AppHost project file, or a directory to search, to add the integration to</source>

--- a/src/Aspire.Cli/Resources/xlf/AddCommandStrings.ru.xlf
+++ b/src/Aspire.Cli/Resources/xlf/AddCommandStrings.ru.xlf
@@ -108,9 +108,9 @@
         <note>{0} is the package name, {1} is the version.</note>
       </trans-unit>
       <trans-unit id="PackageInstallationFailed">
-        <source>The package installation failed with exit code {0}. See logs at {1}</source>
-        <target state="translated">Не удалось установить пакет. Код завершения: {0}. См. журналы по адресу {1}</target>
-        <note>{0} is a number, {1} is the log file path</note>
+        <source>The package installation failed with exit code {0}.</source>
+        <target state="new">The package installation failed with exit code {0}.</target>
+        <note>{0} is a number</note>
       </trans-unit>
       <trans-unit id="ProjectArgumentDescription">
         <source>The Aspire AppHost project file, or a directory to search, to add the integration to</source>

--- a/src/Aspire.Cli/Resources/xlf/AddCommandStrings.tr.xlf
+++ b/src/Aspire.Cli/Resources/xlf/AddCommandStrings.tr.xlf
@@ -108,9 +108,9 @@
         <note>{0} is the package name, {1} is the version.</note>
       </trans-unit>
       <trans-unit id="PackageInstallationFailed">
-        <source>The package installation failed with exit code {0}. See logs at {1}</source>
-        <target state="translated">Paket yüklemesi {0} çıkış koduyla başarısız oldu. {1} adresinde günlüklere bakın</target>
-        <note>{0} is a number, {1} is the log file path</note>
+        <source>The package installation failed with exit code {0}.</source>
+        <target state="new">The package installation failed with exit code {0}.</target>
+        <note>{0} is a number</note>
       </trans-unit>
       <trans-unit id="ProjectArgumentDescription">
         <source>The Aspire AppHost project file, or a directory to search, to add the integration to</source>

--- a/src/Aspire.Cli/Resources/xlf/AddCommandStrings.zh-Hans.xlf
+++ b/src/Aspire.Cli/Resources/xlf/AddCommandStrings.zh-Hans.xlf
@@ -108,9 +108,9 @@
         <note>{0} is the package name, {1} is the version.</note>
       </trans-unit>
       <trans-unit id="PackageInstallationFailed">
-        <source>The package installation failed with exit code {0}. See logs at {1}</source>
-        <target state="translated">包安装失败，退出代码为 {0}。请参阅 {1} 处的日志</target>
-        <note>{0} is a number, {1} is the log file path</note>
+        <source>The package installation failed with exit code {0}.</source>
+        <target state="new">The package installation failed with exit code {0}.</target>
+        <note>{0} is a number</note>
       </trans-unit>
       <trans-unit id="ProjectArgumentDescription">
         <source>The Aspire AppHost project file, or a directory to search, to add the integration to</source>

--- a/src/Aspire.Cli/Resources/xlf/AddCommandStrings.zh-Hant.xlf
+++ b/src/Aspire.Cli/Resources/xlf/AddCommandStrings.zh-Hant.xlf
@@ -108,9 +108,9 @@
         <note>{0} is the package name, {1} is the version.</note>
       </trans-unit>
       <trans-unit id="PackageInstallationFailed">
-        <source>The package installation failed with exit code {0}. See logs at {1}</source>
-        <target state="translated">套件安裝失敗，結束代碼為 {0}。請參閱 {1} 中的記錄</target>
-        <note>{0} is a number, {1} is the log file path</note>
+        <source>The package installation failed with exit code {0}.</source>
+        <target state="new">The package installation failed with exit code {0}.</target>
+        <note>{0} is a number</note>
       </trans-unit>
       <trans-unit id="ProjectArgumentDescription">
         <source>The Aspire AppHost project file, or a directory to search, to add the integration to</source>

--- a/src/Aspire.Cli/Resources/xlf/TemplatingStrings.cs.xlf
+++ b/src/Aspire.Cli/Resources/xlf/TemplatingStrings.cs.xlf
@@ -138,9 +138,9 @@
         <note>{0} is a path</note>
       </trans-unit>
       <trans-unit id="ProjectCreationFailed">
-        <source>Project creation failed with exit code {0}. See logs at {1}</source>
-        <target state="translated">Vytvoření projektu se nezdařilo s ukončovacím kódem {0}. Protokoly najdete na {1}</target>
-        <note>{0} is a number, {1} is the log file path</note>
+        <source>Project creation failed with exit code {0}.</source>
+        <target state="new">Project creation failed with exit code {0}.</target>
+        <note>{0} is a number</note>
       </trans-unit>
       <trans-unit id="PromptForTFMOptions_Description">
         <source>Configures whether to create a project for integration tests using MSTest, NUnit, or xUnit.net.</source>
@@ -168,9 +168,9 @@
         <note />
       </trans-unit>
       <trans-unit id="TemplateInstallationFailed">
-        <source>The template installation failed with exit code {0}. See logs at {1}</source>
-        <target state="translated">Instalace balíčku se nezdařila s ukončovacím kódem {0}. Protokoly najdete na {1}</target>
-        <note>{0} is a number, {1} is the log file path</note>
+        <source>The template installation failed with exit code {0}.</source>
+        <target state="new">The template installation failed with exit code {0}.</target>
+        <note>{0} is a number</note>
       </trans-unit>
       <trans-unit id="Unknown">
         <source>Unknown</source>

--- a/src/Aspire.Cli/Resources/xlf/TemplatingStrings.de.xlf
+++ b/src/Aspire.Cli/Resources/xlf/TemplatingStrings.de.xlf
@@ -138,9 +138,9 @@
         <note>{0} is a path</note>
       </trans-unit>
       <trans-unit id="ProjectCreationFailed">
-        <source>Project creation failed with exit code {0}. See logs at {1}</source>
-        <target state="translated">Die Projekterstellung ist mit dem Exitcode {0} fehlgeschlagen. Protokolle unter {1} anzeigen.</target>
-        <note>{0} is a number, {1} is the log file path</note>
+        <source>Project creation failed with exit code {0}.</source>
+        <target state="new">Project creation failed with exit code {0}.</target>
+        <note>{0} is a number</note>
       </trans-unit>
       <trans-unit id="PromptForTFMOptions_Description">
         <source>Configures whether to create a project for integration tests using MSTest, NUnit, or xUnit.net.</source>
@@ -168,9 +168,9 @@
         <note />
       </trans-unit>
       <trans-unit id="TemplateInstallationFailed">
-        <source>The template installation failed with exit code {0}. See logs at {1}</source>
-        <target state="translated">Die Vorlageninstallation ist mit dem Exitcode {0} fehlgeschlagen. Protokolle unter {1} anzeigen.</target>
-        <note>{0} is a number, {1} is the log file path</note>
+        <source>The template installation failed with exit code {0}.</source>
+        <target state="new">The template installation failed with exit code {0}.</target>
+        <note>{0} is a number</note>
       </trans-unit>
       <trans-unit id="Unknown">
         <source>Unknown</source>

--- a/src/Aspire.Cli/Resources/xlf/TemplatingStrings.es.xlf
+++ b/src/Aspire.Cli/Resources/xlf/TemplatingStrings.es.xlf
@@ -138,9 +138,9 @@
         <note>{0} is a path</note>
       </trans-unit>
       <trans-unit id="ProjectCreationFailed">
-        <source>Project creation failed with exit code {0}. See logs at {1}</source>
-        <target state="translated">Error al crear el proyecto con el código de salida {0}. Consulte los registros en {1}</target>
-        <note>{0} is a number, {1} is the log file path</note>
+        <source>Project creation failed with exit code {0}.</source>
+        <target state="new">Project creation failed with exit code {0}.</target>
+        <note>{0} is a number</note>
       </trans-unit>
       <trans-unit id="PromptForTFMOptions_Description">
         <source>Configures whether to create a project for integration tests using MSTest, NUnit, or xUnit.net.</source>
@@ -168,9 +168,9 @@
         <note />
       </trans-unit>
       <trans-unit id="TemplateInstallationFailed">
-        <source>The template installation failed with exit code {0}. See logs at {1}</source>
-        <target state="translated">La instalación de la plantilla falló con el código de salida {0}. Consulte los registros en {1}</target>
-        <note>{0} is a number, {1} is the log file path</note>
+        <source>The template installation failed with exit code {0}.</source>
+        <target state="new">The template installation failed with exit code {0}.</target>
+        <note>{0} is a number</note>
       </trans-unit>
       <trans-unit id="Unknown">
         <source>Unknown</source>

--- a/src/Aspire.Cli/Resources/xlf/TemplatingStrings.fr.xlf
+++ b/src/Aspire.Cli/Resources/xlf/TemplatingStrings.fr.xlf
@@ -138,9 +138,9 @@
         <note>{0} is a path</note>
       </trans-unit>
       <trans-unit id="ProjectCreationFailed">
-        <source>Project creation failed with exit code {0}. See logs at {1}</source>
-        <target state="translated">Désolé, échec de la création du projet avec le code de sortie {0}. Consultez les journaux à l’emplacement {1}</target>
-        <note>{0} is a number, {1} is the log file path</note>
+        <source>Project creation failed with exit code {0}.</source>
+        <target state="new">Project creation failed with exit code {0}.</target>
+        <note>{0} is a number</note>
       </trans-unit>
       <trans-unit id="PromptForTFMOptions_Description">
         <source>Configures whether to create a project for integration tests using MSTest, NUnit, or xUnit.net.</source>
@@ -168,9 +168,9 @@
         <note />
       </trans-unit>
       <trans-unit id="TemplateInstallationFailed">
-        <source>The template installation failed with exit code {0}. See logs at {1}</source>
-        <target state="translated">L’installation du modèle a échoué avec le code de sortie {0}. Consultez les journaux à l’emplacement {1}</target>
-        <note>{0} is a number, {1} is the log file path</note>
+        <source>The template installation failed with exit code {0}.</source>
+        <target state="new">The template installation failed with exit code {0}.</target>
+        <note>{0} is a number</note>
       </trans-unit>
       <trans-unit id="Unknown">
         <source>Unknown</source>

--- a/src/Aspire.Cli/Resources/xlf/TemplatingStrings.it.xlf
+++ b/src/Aspire.Cli/Resources/xlf/TemplatingStrings.it.xlf
@@ -138,9 +138,9 @@
         <note>{0} is a path</note>
       </trans-unit>
       <trans-unit id="ProjectCreationFailed">
-        <source>Project creation failed with exit code {0}. See logs at {1}</source>
-        <target state="translated">Creazione del progetto non riuscita con codice di uscita {0}. Consultare i log in {1}</target>
-        <note>{0} is a number, {1} is the log file path</note>
+        <source>Project creation failed with exit code {0}.</source>
+        <target state="new">Project creation failed with exit code {0}.</target>
+        <note>{0} is a number</note>
       </trans-unit>
       <trans-unit id="PromptForTFMOptions_Description">
         <source>Configures whether to create a project for integration tests using MSTest, NUnit, or xUnit.net.</source>
@@ -168,9 +168,9 @@
         <note />
       </trans-unit>
       <trans-unit id="TemplateInstallationFailed">
-        <source>The template installation failed with exit code {0}. See logs at {1}</source>
-        <target state="translated">L'installazione del modello non è riuscita con codice di uscita {0}. Consultare i log in {1}</target>
-        <note>{0} is a number, {1} is the log file path</note>
+        <source>The template installation failed with exit code {0}.</source>
+        <target state="new">The template installation failed with exit code {0}.</target>
+        <note>{0} is a number</note>
       </trans-unit>
       <trans-unit id="Unknown">
         <source>Unknown</source>

--- a/src/Aspire.Cli/Resources/xlf/TemplatingStrings.ja.xlf
+++ b/src/Aspire.Cli/Resources/xlf/TemplatingStrings.ja.xlf
@@ -138,9 +138,9 @@
         <note>{0} is a path</note>
       </trans-unit>
       <trans-unit id="ProjectCreationFailed">
-        <source>Project creation failed with exit code {0}. See logs at {1}</source>
-        <target state="translated">プロジェクトの作成が、終了コード {0} で失敗しました。{1} でログを表示する</target>
-        <note>{0} is a number, {1} is the log file path</note>
+        <source>Project creation failed with exit code {0}.</source>
+        <target state="new">Project creation failed with exit code {0}.</target>
+        <note>{0} is a number</note>
       </trans-unit>
       <trans-unit id="PromptForTFMOptions_Description">
         <source>Configures whether to create a project for integration tests using MSTest, NUnit, or xUnit.net.</source>
@@ -168,9 +168,9 @@
         <note />
       </trans-unit>
       <trans-unit id="TemplateInstallationFailed">
-        <source>The template installation failed with exit code {0}. See logs at {1}</source>
-        <target state="translated">テンプレートのインストールが、終了コード {0} で失敗しました。{1} でログを表示する</target>
-        <note>{0} is a number, {1} is the log file path</note>
+        <source>The template installation failed with exit code {0}.</source>
+        <target state="new">The template installation failed with exit code {0}.</target>
+        <note>{0} is a number</note>
       </trans-unit>
       <trans-unit id="Unknown">
         <source>Unknown</source>

--- a/src/Aspire.Cli/Resources/xlf/TemplatingStrings.ko.xlf
+++ b/src/Aspire.Cli/Resources/xlf/TemplatingStrings.ko.xlf
@@ -138,9 +138,9 @@
         <note>{0} is a path</note>
       </trans-unit>
       <trans-unit id="ProjectCreationFailed">
-        <source>Project creation failed with exit code {0}. See logs at {1}</source>
-        <target state="translated">{0} 종료 코드를 이용하여 프로젝트 만들기에 실패했습니다. {1}에서 로그 보기</target>
-        <note>{0} is a number, {1} is the log file path</note>
+        <source>Project creation failed with exit code {0}.</source>
+        <target state="new">Project creation failed with exit code {0}.</target>
+        <note>{0} is a number</note>
       </trans-unit>
       <trans-unit id="PromptForTFMOptions_Description">
         <source>Configures whether to create a project for integration tests using MSTest, NUnit, or xUnit.net.</source>
@@ -168,9 +168,9 @@
         <note />
       </trans-unit>
       <trans-unit id="TemplateInstallationFailed">
-        <source>The template installation failed with exit code {0}. See logs at {1}</source>
-        <target state="translated">{0} 종료 코드를 이용한 템플릿 설치에 실패했습니다. {1}에서 로그 보기</target>
-        <note>{0} is a number, {1} is the log file path</note>
+        <source>The template installation failed with exit code {0}.</source>
+        <target state="new">The template installation failed with exit code {0}.</target>
+        <note>{0} is a number</note>
       </trans-unit>
       <trans-unit id="Unknown">
         <source>Unknown</source>

--- a/src/Aspire.Cli/Resources/xlf/TemplatingStrings.pl.xlf
+++ b/src/Aspire.Cli/Resources/xlf/TemplatingStrings.pl.xlf
@@ -138,9 +138,9 @@
         <note>{0} is a path</note>
       </trans-unit>
       <trans-unit id="ProjectCreationFailed">
-        <source>Project creation failed with exit code {0}. See logs at {1}</source>
-        <target state="translated">Tworzenie projektu nie powiodło się z kodem zakończenia {0}. Zobacz dzienniki pod adresem {1}</target>
-        <note>{0} is a number, {1} is the log file path</note>
+        <source>Project creation failed with exit code {0}.</source>
+        <target state="new">Project creation failed with exit code {0}.</target>
+        <note>{0} is a number</note>
       </trans-unit>
       <trans-unit id="PromptForTFMOptions_Description">
         <source>Configures whether to create a project for integration tests using MSTest, NUnit, or xUnit.net.</source>
@@ -168,9 +168,9 @@
         <note />
       </trans-unit>
       <trans-unit id="TemplateInstallationFailed">
-        <source>The template installation failed with exit code {0}. See logs at {1}</source>
-        <target state="translated">Instalacja szablonu nie powiodła się z kodem zakończenia {0}. Zobacz dzienniki pod adresem {1}</target>
-        <note>{0} is a number, {1} is the log file path</note>
+        <source>The template installation failed with exit code {0}.</source>
+        <target state="new">The template installation failed with exit code {0}.</target>
+        <note>{0} is a number</note>
       </trans-unit>
       <trans-unit id="Unknown">
         <source>Unknown</source>

--- a/src/Aspire.Cli/Resources/xlf/TemplatingStrings.pt-BR.xlf
+++ b/src/Aspire.Cli/Resources/xlf/TemplatingStrings.pt-BR.xlf
@@ -138,9 +138,9 @@
         <note>{0} is a path</note>
       </trans-unit>
       <trans-unit id="ProjectCreationFailed">
-        <source>Project creation failed with exit code {0}. See logs at {1}</source>
-        <target state="translated">Falha na criação do projeto com código de saída {0}. Ver logs em {1}</target>
-        <note>{0} is a number, {1} is the log file path</note>
+        <source>Project creation failed with exit code {0}.</source>
+        <target state="new">Project creation failed with exit code {0}.</target>
+        <note>{0} is a number</note>
       </trans-unit>
       <trans-unit id="PromptForTFMOptions_Description">
         <source>Configures whether to create a project for integration tests using MSTest, NUnit, or xUnit.net.</source>
@@ -168,9 +168,9 @@
         <note />
       </trans-unit>
       <trans-unit id="TemplateInstallationFailed">
-        <source>The template installation failed with exit code {0}. See logs at {1}</source>
-        <target state="translated">A instalação do modelo falhou com o código de saída {0}. Ver logs em {1}</target>
-        <note>{0} is a number, {1} is the log file path</note>
+        <source>The template installation failed with exit code {0}.</source>
+        <target state="new">The template installation failed with exit code {0}.</target>
+        <note>{0} is a number</note>
       </trans-unit>
       <trans-unit id="Unknown">
         <source>Unknown</source>

--- a/src/Aspire.Cli/Resources/xlf/TemplatingStrings.ru.xlf
+++ b/src/Aspire.Cli/Resources/xlf/TemplatingStrings.ru.xlf
@@ -138,9 +138,9 @@
         <note>{0} is a path</note>
       </trans-unit>
       <trans-unit id="ProjectCreationFailed">
-        <source>Project creation failed with exit code {0}. See logs at {1}</source>
-        <target state="translated">Не удалось создать проект. Код завершения: {0}. См. журналы по адресу {1}</target>
-        <note>{0} is a number, {1} is the log file path</note>
+        <source>Project creation failed with exit code {0}.</source>
+        <target state="new">Project creation failed with exit code {0}.</target>
+        <note>{0} is a number</note>
       </trans-unit>
       <trans-unit id="PromptForTFMOptions_Description">
         <source>Configures whether to create a project for integration tests using MSTest, NUnit, or xUnit.net.</source>
@@ -168,9 +168,9 @@
         <note />
       </trans-unit>
       <trans-unit id="TemplateInstallationFailed">
-        <source>The template installation failed with exit code {0}. See logs at {1}</source>
-        <target state="translated">Не удалось установить шаблон. Код завершения: {0}. См. журналы по адресу {1}</target>
-        <note>{0} is a number, {1} is the log file path</note>
+        <source>The template installation failed with exit code {0}.</source>
+        <target state="new">The template installation failed with exit code {0}.</target>
+        <note>{0} is a number</note>
       </trans-unit>
       <trans-unit id="Unknown">
         <source>Unknown</source>

--- a/src/Aspire.Cli/Resources/xlf/TemplatingStrings.tr.xlf
+++ b/src/Aspire.Cli/Resources/xlf/TemplatingStrings.tr.xlf
@@ -138,9 +138,9 @@
         <note>{0} is a path</note>
       </trans-unit>
       <trans-unit id="ProjectCreationFailed">
-        <source>Project creation failed with exit code {0}. See logs at {1}</source>
-        <target state="translated">Proje oluşturma başarısız oldu, çıkış kodu {0}. {1} adresinde günlüklere bakın</target>
-        <note>{0} is a number, {1} is the log file path</note>
+        <source>Project creation failed with exit code {0}.</source>
+        <target state="new">Project creation failed with exit code {0}.</target>
+        <note>{0} is a number</note>
       </trans-unit>
       <trans-unit id="PromptForTFMOptions_Description">
         <source>Configures whether to create a project for integration tests using MSTest, NUnit, or xUnit.net.</source>
@@ -168,9 +168,9 @@
         <note />
       </trans-unit>
       <trans-unit id="TemplateInstallationFailed">
-        <source>The template installation failed with exit code {0}. See logs at {1}</source>
-        <target state="translated">Şablon yüklemesi {0} çıkış koduyla başarısız oldu. {1} adresinde günlüklere bakın</target>
-        <note>{0} is a number, {1} is the log file path</note>
+        <source>The template installation failed with exit code {0}.</source>
+        <target state="new">The template installation failed with exit code {0}.</target>
+        <note>{0} is a number</note>
       </trans-unit>
       <trans-unit id="Unknown">
         <source>Unknown</source>

--- a/src/Aspire.Cli/Resources/xlf/TemplatingStrings.zh-Hans.xlf
+++ b/src/Aspire.Cli/Resources/xlf/TemplatingStrings.zh-Hans.xlf
@@ -138,9 +138,9 @@
         <note>{0} is a path</note>
       </trans-unit>
       <trans-unit id="ProjectCreationFailed">
-        <source>Project creation failed with exit code {0}. See logs at {1}</source>
-        <target state="translated">项目创建失败，退出代码为 {0}。请参阅 {1} 处的日志</target>
-        <note>{0} is a number, {1} is the log file path</note>
+        <source>Project creation failed with exit code {0}.</source>
+        <target state="new">Project creation failed with exit code {0}.</target>
+        <note>{0} is a number</note>
       </trans-unit>
       <trans-unit id="PromptForTFMOptions_Description">
         <source>Configures whether to create a project for integration tests using MSTest, NUnit, or xUnit.net.</source>
@@ -168,9 +168,9 @@
         <note />
       </trans-unit>
       <trans-unit id="TemplateInstallationFailed">
-        <source>The template installation failed with exit code {0}. See logs at {1}</source>
-        <target state="translated">模板安装失败，退出代码为 {0}。请参阅 {1} 处的日志</target>
-        <note>{0} is a number, {1} is the log file path</note>
+        <source>The template installation failed with exit code {0}.</source>
+        <target state="new">The template installation failed with exit code {0}.</target>
+        <note>{0} is a number</note>
       </trans-unit>
       <trans-unit id="Unknown">
         <source>Unknown</source>

--- a/src/Aspire.Cli/Resources/xlf/TemplatingStrings.zh-Hant.xlf
+++ b/src/Aspire.Cli/Resources/xlf/TemplatingStrings.zh-Hant.xlf
@@ -138,9 +138,9 @@
         <note>{0} is a path</note>
       </trans-unit>
       <trans-unit id="ProjectCreationFailed">
-        <source>Project creation failed with exit code {0}. See logs at {1}</source>
-        <target state="translated">專案建立失敗，結束代碼為 {0}。請參閱 {1} 中的記錄</target>
-        <note>{0} is a number, {1} is the log file path</note>
+        <source>Project creation failed with exit code {0}.</source>
+        <target state="new">Project creation failed with exit code {0}.</target>
+        <note>{0} is a number</note>
       </trans-unit>
       <trans-unit id="PromptForTFMOptions_Description">
         <source>Configures whether to create a project for integration tests using MSTest, NUnit, or xUnit.net.</source>
@@ -168,9 +168,9 @@
         <note />
       </trans-unit>
       <trans-unit id="TemplateInstallationFailed">
-        <source>The template installation failed with exit code {0}. See logs at {1}</source>
-        <target state="translated">範本安裝失敗，結束代碼為 {0}。請參閱 {1} 中的記錄</target>
-        <note>{0} is a number, {1} is the log file path</note>
+        <source>The template installation failed with exit code {0}.</source>
+        <target state="new">The template installation failed with exit code {0}.</target>
+        <note>{0} is a number</note>
       </trans-unit>
       <trans-unit id="Unknown">
         <source>Unknown</source>

--- a/src/Aspire.Cli/Templating/DotNetTemplateFactory.cs
+++ b/src/Aspire.Cli/Templating/DotNetTemplateFactory.cs
@@ -536,8 +536,7 @@ internal class DotNetTemplateFactory(
         }
         catch (OperationCanceledException)
         {
-            interactionService.DisplayCancellationMessage();
-            return new TemplateResult(ExitCodeConstants.FailedToCreateNewProject);
+            return new TemplateResult(ExitCodeConstants.Cancelled);
         }
         catch (CertificateServiceException ex)
         {

--- a/src/Aspire.Cli/Templating/DotNetTemplateFactory.cs
+++ b/src/Aspire.Cli/Templating/DotNetTemplateFactory.cs
@@ -480,7 +480,7 @@ internal class DotNetTemplateFactory(
             if (installOutcome.ExitCode != 0)
             {
                 interactionService.DisplayLines(installOutcome.OutputLines);
-                interactionService.DisplayError(string.Format(CultureInfo.CurrentCulture, TemplatingStrings.TemplateInstallationFailed, installOutcome.ExitCode, executionContext.LogFilePath));
+                interactionService.DisplayError(string.Format(CultureInfo.CurrentCulture, TemplatingStrings.TemplateInstallationFailed, installOutcome.ExitCode));
                 return new TemplateResult(ExitCodeConstants.FailedToInstallTemplates);
             }
 
@@ -519,7 +519,7 @@ internal class DotNetTemplateFactory(
                 }
 
                 interactionService.DisplayLines(newProjectCollector.GetLines());
-                interactionService.DisplayError(string.Format(CultureInfo.CurrentCulture, TemplatingStrings.ProjectCreationFailed, newProjectExitCode, executionContext.LogFilePath));
+                interactionService.DisplayError(string.Format(CultureInfo.CurrentCulture, TemplatingStrings.ProjectCreationFailed, newProjectExitCode));
                 return new TemplateResult(ExitCodeConstants.FailedToCreateNewProject);
             }
 

--- a/tests/Aspire.Cli.Tests/Commands/AgentMcpCommandTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/AgentMcpCommandTests.cs
@@ -577,9 +577,9 @@ public class AgentMcpCommandTests(ITestOutputHelper outputHelper)
         var rootCommand = serviceProvider.GetRequiredService<RootCommand>();
         var parseResult = rootCommand.Parse("agent mcp --dashboard-url not-a-url");
 
-        var exitCode = await agentMcpCommand.ExecuteCommandAsync(parseResult, CancellationToken.None).DefaultTimeout();
+        var result = await agentMcpCommand.ExecuteCommandAsync(parseResult, CancellationToken.None).DefaultTimeout();
 
-        Assert.Equal(ExitCodeConstants.InvalidCommand, exitCode);
+        Assert.Equal(ExitCodeConstants.InvalidCommand, result.ExitCode);
     }
 
     private static string GetResultText(CallToolResult result)

--- a/tests/Aspire.Cli.Tests/Commands/DashboardRunCommandTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/DashboardRunCommandTests.cs
@@ -325,6 +325,42 @@ public class DashboardRunCommandTests(ITestOutputHelper outputHelper)
         Assert.Equal(expectedMessage, errorMessage);
     }
 
+    [Fact]
+    public async Task DashboardRunCommand_WhenCancelled_DisplaysCancellationMessageAndReturnsSuccess()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+
+        var testInteractionService = new TestInteractionService();
+        var readyTcs = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var (services, _, executionFactory) = CreateServicesWithLayout(workspace, interactionService: testInteractionService);
+        executionFactory.CreateExecutionCallback = (_, _, _, options) =>
+            new TestProcessExecution("fake", [], null, options, (_, _) => (0, null), () => 0)
+            {
+                WaitForExitAsyncCallback = async (processOptions, cancellationToken) =>
+                {
+                    processOptions.StandardOutputCallback?.Invoke("Now listening on: http://localhost:18888");
+                    readyTcs.TrySetResult();
+                    await Task.Delay(Timeout.InfiniteTimeSpan, cancellationToken).ConfigureAwait(false);
+                    return 0;
+                }
+            };
+
+        using var provider = services.BuildServiceProvider();
+        var command = provider.GetRequiredService<RootCommand>();
+        var result = command.Parse("dashboard run");
+
+        using var cts = new CancellationTokenSource();
+        var pendingRun = result.InvokeAsync(cancellationToken: cts.Token);
+
+        await readyTcs.Task.DefaultTimeout();
+        await cts.CancelAsync();
+
+        var exitCode = await pendingRun.DefaultTimeout();
+
+        Assert.Equal(ExitCodeConstants.Success, exitCode);
+        Assert.Equal(1, testInteractionService.DisplayCancellationMessageCount);
+    }
+
     [Theory]
     [InlineData("", "http://localhost:18888")]
     [InlineData(";;;", "http://localhost:18888")]

--- a/tests/Aspire.Cli.Tests/Commands/RunCommandTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/RunCommandTests.cs
@@ -401,7 +401,7 @@ public class RunCommandTests(ITestOutputHelper outputHelper)
         cts.Cancel();
 
         var exitCode = await pendingRun.DefaultTimeout();
-        Assert.Equal(ExitCodeConstants.Cancelled, exitCode);
+        Assert.Equal(ExitCodeConstants.Success, exitCode);
     }
 
     [Fact]
@@ -456,7 +456,7 @@ public class RunCommandTests(ITestOutputHelper outputHelper)
         cts.Cancel();
 
         var exitCode = await pendingRun.DefaultTimeout(TestConstants.LongTimeoutDuration);
-        Assert.Equal(ExitCodeConstants.Cancelled, exitCode);
+        Assert.Equal(ExitCodeConstants.Success, exitCode);
     }
 
     [Fact]
@@ -573,7 +573,8 @@ public class RunCommandTests(ITestOutputHelper outputHelper)
         var exitCode = await pendingRun.DefaultTimeout(TestConstants.LongTimeoutDuration);
 
         // The command should handle cancellation gracefully
-        Assert.Equal(ExitCodeConstants.Cancelled, exitCode);
+        Assert.Equal(ExitCodeConstants.Success, exitCode);
+        Assert.Equal(1, testInteractionService.DisplayCancellationMessageCount);
 
         // Verify a warning was displayed (not an error)
         var m = Assert.Single(testInteractionService.DisplayedMessages);
@@ -674,7 +675,7 @@ public class RunCommandTests(ITestOutputHelper outputHelper)
         cts.Cancel();
         var exitCode = await pendingRun.DefaultTimeout();
 
-        Assert.Equal(ExitCodeConstants.Cancelled, exitCode);
+        Assert.Equal(ExitCodeConstants.Success, exitCode);
         Assert.False(buildCalled, "Build should be skipped when extension DevKit capability is available.");
     }
 
@@ -744,7 +745,7 @@ public class RunCommandTests(ITestOutputHelper outputHelper)
         cts.Cancel();
         var exitCode = await pendingRun.DefaultTimeout();
 
-        Assert.Equal(ExitCodeConstants.Cancelled, exitCode);
+        Assert.Equal(ExitCodeConstants.Success, exitCode);
         Assert.False(buildCalled, "Build should be skipped when running in extension.");
     }
 
@@ -817,7 +818,7 @@ public class RunCommandTests(ITestOutputHelper outputHelper)
 
         var exitCode = await pendingRun.DefaultTimeout();
 
-        Assert.Equal(ExitCodeConstants.Cancelled, exitCode);
+        Assert.Equal(ExitCodeConstants.Success, exitCode);
         Assert.True(buildCalled, "Build should be called when extension has build-dotnet-using-cli capability.");
     }
 
@@ -1652,7 +1653,7 @@ public class RunCommandTests(ITestOutputHelper outputHelper)
             cts.Cancel();
 
             var exitCode = await pendingRun.DefaultTimeout();
-            Assert.Equal(ExitCodeConstants.Cancelled, exitCode);
+            Assert.Equal(ExitCodeConstants.Success, exitCode);
 
             // Verify DcpPublisher__RandomizePorts is set to true for isolated mode
             Assert.True(capturedEnv.ContainsKey("DcpPublisher__RandomizePorts"), "DcpPublisher__RandomizePorts should be set in isolated mode");
@@ -1859,7 +1860,7 @@ public class RunCommandTests(ITestOutputHelper outputHelper)
 
         var exitCode = await pendingRun.DefaultTimeout();
 
-        Assert.Equal(ExitCodeConstants.Cancelled, exitCode);
+        Assert.Equal(ExitCodeConstants.Success, exitCode);
         Assert.False(startDebugSessionCalled, "StartDebugSessionAsync should not be called in non-interactive mode.");
     }
 

--- a/tests/Aspire.Cli.Tests/Commands/RunCommandTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/RunCommandTests.cs
@@ -405,6 +405,49 @@ public class RunCommandTests(ITestOutputHelper outputHelper)
     }
 
     [Fact]
+    public async Task RunCommand_WhenAppHostReturnsCancelled_CompletesSuccessfully()
+    {
+        var runnerFactory = (IServiceProvider sp) =>
+        {
+            var runner = new TestDotNetCliRunner();
+            runner.BuildAsyncCallback = (projectFile, noRestore, options, ct) => 0;
+            runner.GetAppHostInformationAsyncCallback = (projectFile, options, ct) => (0, true, VersionHelper.GetDefaultTemplateVersion());
+            runner.RunAsyncCallback = (projectFile, watch, noBuild, noRestore, args, env, backchannelCompletionSource, options, ct) =>
+            {
+                var backchannel = sp.GetRequiredService<IAppHostCliBackchannel>();
+                backchannelCompletionSource!.SetResult(backchannel);
+
+                return Task.FromResult(ExitCodeConstants.Cancelled);
+            };
+
+            return runner;
+        };
+
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper, options =>
+        {
+            options.ProjectLocatorFactory = _ => new TestProjectLocator();
+            options.AppHostBackchannelFactory = _ => new TestAppHostBackchannel
+            {
+                GetDashboardUrlsAsyncCallback = _ => Task.FromResult(new DashboardUrlsState
+                {
+                    DashboardHealthy = true,
+                    BaseUrlWithLoginToken = "http://localhost:5000/login?t=abcd"
+                })
+            };
+            options.DotNetCliRunnerFactory = runnerFactory;
+        });
+
+        using var provider = services.BuildServiceProvider();
+        var command = provider.GetRequiredService<RootCommand>();
+        var result = command.Parse("run");
+
+        var exitCode = await result.InvokeAsync().DefaultTimeout(TestConstants.LongTimeoutDuration);
+
+        Assert.Equal(ExitCodeConstants.Success, exitCode);
+    }
+
+    [Fact]
     public async Task RunCommand_WithNoResources_CompletesSuccessfully()
     {
         var getResourceStatesAsyncCalled = new TaskCompletionSource();

--- a/tests/Aspire.Cli.Tests/Commands/RunCommandTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/RunCommandTests.cs
@@ -401,7 +401,7 @@ public class RunCommandTests(ITestOutputHelper outputHelper)
         cts.Cancel();
 
         var exitCode = await pendingRun.DefaultTimeout();
-        Assert.Equal(ExitCodeConstants.Success, exitCode);
+        Assert.Equal(ExitCodeConstants.Cancelled, exitCode);
     }
 
     [Fact]
@@ -456,7 +456,7 @@ public class RunCommandTests(ITestOutputHelper outputHelper)
         cts.Cancel();
 
         var exitCode = await pendingRun.DefaultTimeout(TestConstants.LongTimeoutDuration);
-        Assert.Equal(ExitCodeConstants.Success, exitCode);
+        Assert.Equal(ExitCodeConstants.Cancelled, exitCode);
     }
 
     [Fact]
@@ -572,8 +572,8 @@ public class RunCommandTests(ITestOutputHelper outputHelper)
 
         var exitCode = await pendingRun.DefaultTimeout(TestConstants.LongTimeoutDuration);
 
-        // The command should succeed even when the dashboard is unhealthy
-        Assert.Equal(ExitCodeConstants.Success, exitCode);
+        // The command should handle cancellation gracefully
+        Assert.Equal(ExitCodeConstants.Cancelled, exitCode);
 
         // Verify a warning was displayed (not an error)
         var m = Assert.Single(testInteractionService.DisplayedMessages);
@@ -674,7 +674,7 @@ public class RunCommandTests(ITestOutputHelper outputHelper)
         cts.Cancel();
         var exitCode = await pendingRun.DefaultTimeout();
 
-        Assert.Equal(ExitCodeConstants.Success, exitCode);
+        Assert.Equal(ExitCodeConstants.Cancelled, exitCode);
         Assert.False(buildCalled, "Build should be skipped when extension DevKit capability is available.");
     }
 
@@ -744,7 +744,7 @@ public class RunCommandTests(ITestOutputHelper outputHelper)
         cts.Cancel();
         var exitCode = await pendingRun.DefaultTimeout();
 
-        Assert.Equal(ExitCodeConstants.Success, exitCode);
+        Assert.Equal(ExitCodeConstants.Cancelled, exitCode);
         Assert.False(buildCalled, "Build should be skipped when running in extension.");
     }
 
@@ -817,7 +817,7 @@ public class RunCommandTests(ITestOutputHelper outputHelper)
 
         var exitCode = await pendingRun.DefaultTimeout();
 
-        Assert.Equal(ExitCodeConstants.Success, exitCode);
+        Assert.Equal(ExitCodeConstants.Cancelled, exitCode);
         Assert.True(buildCalled, "Build should be called when extension has build-dotnet-using-cli capability.");
     }
 
@@ -1652,7 +1652,7 @@ public class RunCommandTests(ITestOutputHelper outputHelper)
             cts.Cancel();
 
             var exitCode = await pendingRun.DefaultTimeout();
-            Assert.Equal(ExitCodeConstants.Success, exitCode);
+            Assert.Equal(ExitCodeConstants.Cancelled, exitCode);
 
             // Verify DcpPublisher__RandomizePorts is set to true for isolated mode
             Assert.True(capturedEnv.ContainsKey("DcpPublisher__RandomizePorts"), "DcpPublisher__RandomizePorts should be set in isolated mode");
@@ -1859,7 +1859,7 @@ public class RunCommandTests(ITestOutputHelper outputHelper)
 
         var exitCode = await pendingRun.DefaultTimeout();
 
-        Assert.Equal(ExitCodeConstants.Success, exitCode);
+        Assert.Equal(ExitCodeConstants.Cancelled, exitCode);
         Assert.False(startDebugSessionCalled, "StartDebugSessionAsync should not be called in non-interactive mode.");
     }
 

--- a/tests/Aspire.Cli.Tests/Commands/UpdateCommandTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/UpdateCommandTests.cs
@@ -1117,7 +1117,7 @@ public class UpdateCommandTests(ITestOutputHelper outputHelper)
 
         // Assert
         Assert.True(cancellationMessageDisplayed, "Cancellation message should have been displayed");
-        Assert.Equal(ExitCodeConstants.FailedToUpgradeProject, exitCode);
+        Assert.Equal(ExitCodeConstants.Cancelled, exitCode);
     }
 
     [Fact]
@@ -1654,7 +1654,7 @@ public class UpdateCommandTests(ITestOutputHelper outputHelper)
 
         // Assert
         Assert.True(cancellationMessageDisplayed, "Cancellation message should have been displayed");
-        Assert.Equal(ExitCodeConstants.InvalidCommand, exitCode);
+        Assert.Equal(ExitCodeConstants.Cancelled, exitCode);
     }
 
     [Fact]

--- a/tests/Aspire.Cli.Tests/NuGet/NuGetPackagePrefetcherTests.cs
+++ b/tests/Aspire.Cli.Tests/NuGet/NuGetPackagePrefetcherTests.cs
@@ -240,9 +240,9 @@ internal sealed class TestCommand : BaseCommand
     {
     }
 
-    protected override Task<int> ExecuteAsync(ParseResult parseResult, CancellationToken cancellationToken)
+    protected override Task<CommandResult> ExecuteAsync(ParseResult parseResult, CancellationToken cancellationToken)
     {
-        return Task.FromResult(0);
+        return Task.FromResult(CommandResult.Success());
     }
 }
 
@@ -255,8 +255,8 @@ internal sealed class TestCommandWithInterface : BaseCommand, IPackageMetaPrefet
     public bool PrefetchesTemplatePackageMetadata => true;
     public bool PrefetchesCliPackageMetadata => true;
 
-    protected override Task<int> ExecuteAsync(ParseResult parseResult, CancellationToken cancellationToken)
+    protected override Task<CommandResult> ExecuteAsync(ParseResult parseResult, CancellationToken cancellationToken)
     {
-        return Task.FromResult(0);
+        return Task.FromResult(CommandResult.Success());
     }
 }

--- a/tests/Aspire.Cli.Tests/TestServices/TestInteractionService.cs
+++ b/tests/Aspire.Cli.Tests/TestServices/TestInteractionService.cs
@@ -49,6 +49,7 @@ internal sealed class TestInteractionService : IInteractionService
     public List<(string Text, ConsoleOutput? ConsoleOverride)> DisplayedRawText { get; } = [];
     public List<string> DisplayedSuccess { get; } = [];
     public int DisplayEmptyLineCount { get; private set; }
+    public int DisplayCancellationMessageCount { get; private set; }
 
     // Response queue setup methods
     public void SetupStringPromptResponse(string response) => _responses.Enqueue((response, ResponseType.String));
@@ -208,6 +209,7 @@ internal sealed class TestInteractionService : IInteractionService
 
     public void DisplayCancellationMessage()
     {
+        DisplayCancellationMessageCount++;
     }
 
     public Task<bool> PromptConfirmAsync(string promptText, PromptBinding<bool>? binding = null, CancellationToken cancellationToken = default)

--- a/tests/Aspire.Cli.Tests/TestServices/TestProcessExecutionFactory.cs
+++ b/tests/Aspire.Cli.Tests/TestServices/TestProcessExecutionFactory.cs
@@ -108,6 +108,8 @@ internal sealed class TestProcessExecution : IProcessExecution
 
     public bool StartReturnValue { get; init; } = true;
 
+    public Func<ProcessInvocationOptions, CancellationToken, Task<int>>? WaitForExitAsyncCallback { get; init; }
+
     public bool Start()
     {
         if (!StartReturnValue)
@@ -124,6 +126,11 @@ internal sealed class TestProcessExecution : IProcessExecution
         if (!_started)
         {
             throw new InvalidOperationException("Process has not been started.");
+        }
+
+        if (WaitForExitAsyncCallback is not null)
+        {
+            return WaitForExitAsyncCallback(_options, cancellationToken);
         }
 
         var attempt = _attemptCounter();


### PR DESCRIPTION
## Description

Refactors CLI command error handling so that `ExecuteAsync` returns a structured `CommandResult` type instead of a raw `int` exit code. This enables commands to return error messages alongside exit codes, with `BaseCommand` displaying them centrally — eliminating scattered `DisplayError` + `return` patterns across 60+ command files.

Also centralizes cancellation handling: commands now return `CommandResult.Cancelled()` (exit code 130) instead of individually calling `DisplayCancellationMessage()`, with `BaseCommand` detecting the cancellation exit code and displaying the message in one place.

### Changes

- **`CommandResult` type** — New sealed class with `ExitCode` and optional `ErrorMessage` properties. Factory methods: `Success()`, `Failure(int exitCode, string? errorMessage)`, `DisplayHelp()`, `Cancelled()`, `FromExitCode(int exitCode)`.
- **`BaseCommand` updates** — `ExecuteAsync` now returns `Task<CommandResult>`. The `SetAction` handler displays `ErrorMessage` via `DisplayError()` before the log path. For `DisplayHelp()` results, it invokes `HelpAction` and skips the log path display. For `Cancelled` results, it calls `DisplayCancellationMessage()` and skips the log path and update notifications.
- **`ParentCommand` base class** — New abstract class for commands that only contain subcommands. Provides `UpdateNotificationsEnabled => false` and a sealed `ExecuteAsync` returning `CommandResult.DisplayHelp()`. 11 parent commands now inherit from it, removing boilerplate.
- **Error message consolidation** — Converted ~66 `DisplayError(msg); return exitCode;` patterns to `return CommandResult.Failure(exitCode, msg);`, centralizing error display in `BaseCommand`.
- **Centralized cancellation** — Replaced all per-command `DisplayCancellationMessage()` + return patterns with `CommandResult.Cancelled()`. The cancellation message is now displayed once in `BaseCommand`. Uses exit code 130 (the conventional 128 + SIGINT signal 2) for all user-initiated cancellations.
- **`AppHostLauncher.LaunchDetachedAsync`** — Changed return type from `Task<int>` to `Task<CommandResult>` so error messages from the launch process are preserved and displayed.
- **`AgentMcpCommand`** — Added error message for invalid dashboard URL that was previously silently failing.
- **`UpdateCommand.ExecuteSelfUpdateAsync`** — Changed return type from `Task<int>` to `Task<CommandResult>` for consistent error propagation.
- **`GuestAppHostProject` and `DotNetTemplateFactory`** — Updated cancellation paths to return `ExitCodeConstants.Cancelled` instead of calling `DisplayCancellationMessage()` directly.

### User-facing usage

No user-facing behavior changes. Error messages, cancellation messages, and help output appear in the same places as before, but are now routed through `CommandResult` for consistency. The log file path and update notifications are no longer shown when a command is cancelled or displays help.

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
  - [x] No
