### PR TITLE
ci: add contents: read to the top-level CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,9 @@ on:
       - main
       - 'release/**'
 
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}


### PR DESCRIPTION
`ci.yml` currently runs without a top-level `permissions:` block, so the `GITHUB_TOKEN` passed down to the `tests.yml` reusable workflow inherits whatever the repo default token scope happens to be. This adds an explicit `contents: read` at the top of `ci.yml`.

I traced the actual `github.token` uses in the called workflow before deciding on the scope:

- PR head checkout in the test jobs — read
- The `GenerateCITimeline` dotnet tool that reads workflow run timelines via `GH_TOKEN` — read-only API queries
- `actions/upload-artifact@v7` calls — artifact API, doesn't need `contents: write`

All read-side, so `contents: read` is the minimum needed and won't break anything.

I deliberately didn't touch the other 5 workflows my audit flagged (`labeler-cache-retention`, `reproduce-flaky-tests`, `tests-outerloop`, `tests-quarantine`, `warm-cli-e2e-image-cache`). Those either touch the GHA cache (need `actions: write` to refresh TTLs) or fan out to other reusable workflows that may need package/registry write scopes. Each of those deserves its own focused PR after a separate per-workflow check.

YAML validates with `python -c "import yaml; yaml.safe_load(...)"`.