### PR TITLE
Add typed cert-manager API for Kubernetes/AKS environments

### DIFF
--- a/.github/workflows/deployment-tests.yml
+++ b/.github/workflows/deployment-tests.yml
@@ -251,6 +251,15 @@ jobs:
           docker info | head -20
           echo "✅ Docker is available"
 
+      # Pin helm to a version that supports `helm install --server-side`/--force-conflicts
+      # (added in v3.18.0). The default helm preinstalled on the runner image lags behind
+      # this and breaks AKS cert-manager scenarios that need server-side apply to coexist
+      # with the AKS Azure Policy add-on's webhook mutations.
+      - name: Setup Helm
+        uses: azure/setup-helm@1a275c3b69536ee54be43f2070a358922e12c8d4 # v4.3.1
+        with:
+          version: v3.21.0
+
       - name: Run deployment test (${{ matrix.shortname }})
         id: run_tests
         env:

--- a/.github/workflows/deployment-tests.yml
+++ b/.github/workflows/deployment-tests.yml
@@ -252,13 +252,16 @@ jobs:
           echo "✅ Docker is available"
 
       # Pin helm to a version that supports `helm install --server-side`/--force-conflicts
-      # (added in v3.18.0). The default helm preinstalled on the runner image lags behind
-      # this and breaks AKS cert-manager scenarios that need server-side apply to coexist
-      # with the AKS Azure Policy add-on's webhook mutations.
+      # (added in helm v3.18.0; helm v4 keeps both but `--server-side` is now a string flag
+      # accepting true|false|auto, which is why our code passes `--server-side=true` rather
+      # than the bare flag — that form parses identically on v3.18+ and v4). The default
+      # helm preinstalled on the runner image lags behind and rejects these flags, which
+      # breaks AKS cert-manager scenarios that need server-side apply to coexist with the
+      # AKS Azure Policy add-on's webhook mutations.
       - name: Setup Helm
         uses: azure/setup-helm@1a275c3b69536ee54be43f2070a358922e12c8d4 # v4.3.1
         with:
-          version: v3.21.0
+          version: v4.1.4
 
       - name: Run deployment test (${{ matrix.shortname }})
         id: run_tests

--- a/Aspire.slnx
+++ b/Aspire.slnx
@@ -178,6 +178,10 @@
     <Project Path="playground/AksDemo/AksDemo.ApiService/AksDemo.ApiService.csproj" />
     <Project Path="playground/AksDemo/AksDemo.AppHost/AksDemo.AppHost.csproj" />
   </Folder>
+  <Folder Name="/playground/CertManagerDemo/">
+    <Project Path="playground/CertManagerDemo/CertManagerDemo.ApiService/CertManagerDemo.ApiService.csproj" />
+    <Project Path="playground/CertManagerDemo/CertManagerDemo.AppHost/CertManagerDemo.AppHost.csproj" />
+  </Folder>
   <Folder Name="/playground/AzureStorageEndToEnd/">
     <Project Path="playground/AzureStorageEndToEnd/AzureStorageEndToEnd.ApiService/AzureStorageEndToEnd.ApiService.csproj" />
     <Project Path="playground/AzureStorageEndToEnd/AzureStorageEndToEnd.AppHost/AzureStorageEndToEnd.AppHost.csproj" />

--- a/playground/CertManagerDemo/CertManagerDemo.ApiService/CertManagerDemo.ApiService.csproj
+++ b/playground/CertManagerDemo/CertManagerDemo.ApiService/CertManagerDemo.ApiService.csproj
@@ -1,0 +1,13 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+
+  <PropertyGroup>
+    <TargetFramework>$(DefaultTargetFramework)</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\Playground.ServiceDefaults\Playground.ServiceDefaults.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/playground/CertManagerDemo/CertManagerDemo.ApiService/Program.cs
+++ b/playground/CertManagerDemo/CertManagerDemo.ApiService/Program.cs
@@ -1,0 +1,57 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+var builder = WebApplication.CreateBuilder(args);
+
+builder.AddServiceDefaults();
+
+var app = builder.Build();
+
+app.MapDefaultEndpoints();
+
+// Endpoints used to validate end-to-end TLS through AGC + cert-manager.
+// /         - identity, useful for confirming routing reached the right pod
+// /api      - target of the storefront-gw HTTPRoute (no path rewriting on the gateway)
+// /admin    - target of the admin-gw HTTPRoute
+// /tls      - reports whether the request reached us over HTTPS via X-Forwarded-Proto;
+//             handy for confirming the cert chain end-to-end once a Let's Encrypt cert
+//             has been issued and bound to the gateway listener.
+
+static object BuildIdentity(string surface) => new
+{
+    service = "CertManagerDemo.ApiService",
+    surface,
+    machineName = Environment.MachineName,
+    podIp = Environment.GetEnvironmentVariable("POD_IP"),
+    timestampUtc = DateTimeOffset.UtcNow
+};
+
+app.MapGet("/", () => Results.Ok(BuildIdentity("root")));
+app.MapGet("/api", () => Results.Ok(BuildIdentity("storefront")));
+app.MapGet("/admin", () => Results.Ok(BuildIdentity("admin")));
+
+app.MapGet("/tls", (HttpContext ctx) => Results.Ok(new
+{
+    // AGC terminates TLS and forwards the client scheme via X-Forwarded-Proto. If the
+    // gateway listener has a Let's Encrypt cert bound by cert-manager, requests to the
+    // public FQDN over https should land here with X-Forwarded-Proto=https.
+    forwardedProto = ctx.Request.Headers["X-Forwarded-Proto"].ToString(),
+    forwardedFor = ctx.Request.Headers["X-Forwarded-For"].ToString(),
+    host = ctx.Request.Host.Value,
+    scheme = ctx.Request.Scheme,
+    isHttps = ctx.Request.IsHttps
+}));
+
+app.MapGet("/info", () => Results.Ok(new
+{
+    machineName = Environment.MachineName,
+    osVersion = Environment.OSVersion.ToString(),
+    processorCount = Environment.ProcessorCount,
+    dotnetVersion = Environment.Version.ToString(),
+    aspnetcoreEnv = Environment.GetEnvironmentVariable("ASPNETCORE_ENVIRONMENT"),
+    podIp = Environment.GetEnvironmentVariable("POD_IP"),
+    podName = Environment.GetEnvironmentVariable("POD_NAME"),
+    nodeName = Environment.GetEnvironmentVariable("NODE_NAME")
+}));
+
+app.Run();

--- a/playground/CertManagerDemo/CertManagerDemo.ApiService/Properties/launchSettings.json
+++ b/playground/CertManagerDemo/CertManagerDemo.ApiService/Properties/launchSettings.json
@@ -1,0 +1,14 @@
+{
+  "$schema": "http://json.schemastore.org/launchsettings.json",
+  "profiles": {
+    "http": {
+      "commandName": "Project",
+      "dotnetRunMessages": true,
+      "launchBrowser": false,
+      "applicationUrl": "http://localhost:5297",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
+    }
+  }
+}

--- a/playground/CertManagerDemo/CertManagerDemo.ApiService/appsettings.json
+++ b/playground/CertManagerDemo/CertManagerDemo.ApiService/appsettings.json
@@ -1,0 +1,9 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning"
+    }
+  },
+  "AllowedHosts": "*"
+}

--- a/playground/CertManagerDemo/CertManagerDemo.AppHost/AppHost.cs
+++ b/playground/CertManagerDemo/CertManagerDemo.AppHost/AppHost.cs
@@ -1,0 +1,65 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+#pragma warning disable ASPIREAZURE003 // AddSubnet / AzureSubnetResource are evaluation-only
+
+var builder = DistributedApplication.CreateBuilder(args);
+
+// VNet layout (mirrors AksDemo so the two playgrounds can be diffed cleanly):
+//   10.100.0.0/16   - vnet (chosen to avoid the AKS default service CIDR 10.0.0.0/16)
+//     10.100.0.0/22 - aks node pool subnet (1024 IPs - room for pods/nodes)
+//     10.100.4.0/24 - public AGC frontend subnet (delegated to ServiceNetworking by AddLoadBalancer)
+//     10.100.5.0/24 - admin AGC frontend subnet
+var vnet = builder.AddAzureVirtualNetwork("vnet", "10.100.0.0/16");
+var aksSubnet = vnet.AddSubnet("aks-nodes", "10.100.0.0/22");
+var publicSubnet = vnet.AddSubnet("alb-public", "10.100.4.0/24");
+var adminSubnet = vnet.AddSubnet("alb-admin", "10.100.5.0/24");
+
+var aks = builder.AddAzureKubernetesEnvironment("aks")
+                 .WithSubnet(aksSubnet)
+                 .WithSystemNodePool("Standard_D2as_v5");
+
+aks.AddNodePool("workload", "Standard_D2as_v5", minCount: 1, maxCount: 3);
+
+var publicLb = aks.AddLoadBalancer("public", publicSubnet);
+var adminLb = aks.AddLoadBalancer("admin", adminSubnet);
+
+// Email used to register the ACME account with Let's Encrypt. Treat as a parameter so
+// it can be supplied per-environment (`aspire deploy -p acme-email=...`) without burning
+// it into source.
+var acmeEmail = builder.AddParameter("acme-email");
+
+// Install cert-manager via the typed API. This is the only difference from AksDemo:
+// AksDemo wires the chart in by hand and pairs it with a manual cluster-issuer annotation,
+// whereas here cert-manager and its ClusterIssuer are first-class resources in the model.
+var certManager = aks.AddCertManager();
+
+// A single Let's Encrypt production ClusterIssuer with an HTTP-01 solver. cert-manager
+// satisfies the challenge by serving a token at /.well-known/acme-challenge/{token} on
+// the same hostname being validated, which works for any AGC-assigned FQDN because port
+// 80 is publicly reachable.
+var letsEncrypt = certManager.AddIssuer("letsencrypt-prod")
+                             .WithLetsEncryptProduction(acmeEmail)
+                             .WithHttp01Solver();
+
+var api = builder.AddProject<Projects.CertManagerDemo_ApiService>("api")
+   .WithExternalHttpEndpoints();
+
+// Public gateway: serves /api -> the api service, attached to the public AGC ALB.
+// WithTls(letsEncrypt) creates an HTTPS listener AND adds the
+// `cert-manager.io/cluster-issuer: letsencrypt-prod` annotation in one call. Once AGC
+// assigns the gateway its <random>.fz<n>.alb.azure.com FQDN, the tls-fqdn-discovery
+// pipeline step patches it into the listener and cert-manager issues a real Let's Encrypt
+// cert via HTTP-01 against that FQDN. No ClusterIssuer needs to be created out-of-band.
+aks.AddGateway("storefront-gw")
+   .WithLoadBalancer(publicLb)
+   .WithRoute("/api", api.GetEndpoint("http"))
+   .WithTls(letsEncrypt);
+
+// Admin gateway: same backend on a separate AGC ALB. No TLS here on purpose, so the diff
+// between an HTTP-only and a cert-manager-managed HTTPS gateway is obvious side-by-side.
+aks.AddGateway("admin-gw")
+   .WithLoadBalancer(adminLb)
+   .WithRoute("/admin", api.GetEndpoint("http"));
+
+builder.Build().Run();

--- a/playground/CertManagerDemo/CertManagerDemo.AppHost/AppHost.cs
+++ b/playground/CertManagerDemo/CertManagerDemo.AppHost/AppHost.cs
@@ -32,7 +32,7 @@ var acmeEmail = builder.AddParameter("acme-email");
 // Install cert-manager via the typed API. This is the only difference from AksDemo:
 // AksDemo wires the chart in by hand and pairs it with a manual cluster-issuer annotation,
 // whereas here cert-manager and its ClusterIssuer are first-class resources in the model.
-var certManager = aks.AddCertManager();
+var certManager = aks.AddCertManager("cert-manager");
 
 // A single Let's Encrypt production ClusterIssuer with an HTTP-01 solver. cert-manager
 // satisfies the challenge by serving a token at /.well-known/acme-challenge/{token} on

--- a/playground/CertManagerDemo/CertManagerDemo.AppHost/CertManagerDemo.AppHost.csproj
+++ b/playground/CertManagerDemo/CertManagerDemo.AppHost/CertManagerDemo.AppHost.csproj
@@ -1,0 +1,21 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>$(DefaultTargetFramework)</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsAspireHost>true</IsAspireHost>
+    <UserSecretsId>9b7a14f1-4e6f-4f2d-9d3a-1c0a7b4d2e88</UserSecretsId>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <AspireProjectOrPackageReference Include="Aspire.Hosting.AppHost" />
+    <AspireProjectOrPackageReference Include="Aspire.Hosting.Azure" />
+    <AspireProjectOrPackageReference Include="Aspire.Hosting.Azure.Kubernetes" />
+    <AspireProjectOrPackageReference Include="Aspire.Hosting.Azure.Network" />
+
+    <ProjectReference Include="..\CertManagerDemo.ApiService\CertManagerDemo.ApiService.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/playground/CertManagerDemo/CertManagerDemo.AppHost/Properties/launchSettings.json
+++ b/playground/CertManagerDemo/CertManagerDemo.AppHost/Properties/launchSettings.json
@@ -1,0 +1,44 @@
+{
+  "$schema": "http://json.schemastore.org/launchsettings.json",
+  "profiles": {
+    "https": {
+      "commandName": "Project",
+      "dotnetRunMessages": true,
+      "launchBrowser": true,
+      "applicationUrl": "https://localhost:16240;http://localhost:16241",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development",
+        "DOTNET_ENVIRONMENT": "Development",
+        "ASPIRE_DASHBOARD_OTLP_ENDPOINT_URL": "https://localhost:17160",
+        "ASPIRE_RESOURCE_SERVICE_ENDPOINT_URL": "https://localhost:17160",
+        "ASPIRE_SHOW_DASHBOARD_RESOURCES": "true"
+      }
+    },
+    "http": {
+      "commandName": "Project",
+      "dotnetRunMessages": true,
+      "launchBrowser": true,
+      "applicationUrl": "http://localhost:16241",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development",
+        "DOTNET_ENVIRONMENT": "Development",
+        "ASPIRE_DASHBOARD_OTLP_ENDPOINT_URL": "http://localhost:17161",
+        "ASPIRE_RESOURCE_SERVICE_ENDPOINT_URL": "http://localhost:17161",
+        "ASPIRE_SHOW_DASHBOARD_RESOURCES": "true",
+        "ASPIRE_ALLOW_UNSECURED_TRANSPORT": "true"
+      }
+    },
+    "generate-manifest": {
+      "commandName": "Project",
+      "launchBrowser": true,
+      "dotnetRunMessages": true,
+      "commandLineArgs": "--publisher manifest --output-path aspire-manifest.json",
+      "applicationUrl": "http://localhost:16241",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development",
+        "DOTNET_ENVIRONMENT": "Development",
+        "ASPIRE_DASHBOARD_OTLP_ENDPOINT_URL": "http://localhost:17161"
+      }
+    }
+  }
+}

--- a/playground/CertManagerDemo/CertManagerDemo.AppHost/appsettings.json
+++ b/playground/CertManagerDemo/CertManagerDemo.AppHost/appsettings.json
@@ -1,0 +1,9 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning",
+      "Aspire.Hosting.Dcp": "Warning"
+    }
+  }
+}

--- a/playground/CertManagerDemo/aspire.config.json
+++ b/playground/CertManagerDemo/aspire.config.json
@@ -1,0 +1,5 @@
+{
+  "appHost": {
+    "path": "CertManagerDemo.AppHost/CertManagerDemo.AppHost.csproj"
+  }
+}

--- a/src/Aspire.Hosting.Azure.Kubernetes/AzureCertManagerExtensions.cs
+++ b/src/Aspire.Hosting.Azure.Kubernetes/AzureCertManagerExtensions.cs
@@ -1,0 +1,42 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Aspire.Hosting.ApplicationModel;
+using Aspire.Hosting.Azure.Kubernetes;
+using Aspire.Hosting.Kubernetes;
+
+namespace Aspire.Hosting;
+
+/// <summary>
+/// Provides AKS-specific overloads for installing cert-manager into an
+/// <see cref="AzureKubernetesEnvironmentResource"/>.
+/// </summary>
+public static class AzureCertManagerExtensions
+{
+    /// <summary>
+    /// Installs cert-manager into the AKS cluster's underlying Kubernetes environment and
+    /// returns a typed <see cref="CertManagerResource"/> that can host issuer resources.
+    /// </summary>
+    /// <param name="builder">The AKS environment resource builder.</param>
+    /// <param name="name">The Aspire resource name for the cert-manager installation. Defaults to <c>"cert-manager"</c>.</param>
+    /// <param name="chartVersion">The cert-manager Helm chart version to install.
+    /// Defaults to a pinned version validated against this Aspire build.</param>
+    /// <returns>A reference to the <see cref="IResourceBuilder{CertManagerResource}"/> for chaining.</returns>
+    /// <remarks>
+    /// Delegates to <see cref="CertManagerExtensions.AddCertManager(IResourceBuilder{KubernetesEnvironmentResource}, string, string?)"/>
+    /// against the underlying <see cref="AzureKubernetesEnvironmentResource.KubernetesEnvironment"/>,
+    /// mirroring the pattern used by <see cref="AzureKubernetesIngressExtensions.AddHelmChart"/>.
+    /// </remarks>
+    [AspireExport(Description = "Installs cert-manager into an AKS environment")]
+    public static IResourceBuilder<CertManagerResource> AddCertManager(
+        this IResourceBuilder<AzureKubernetesEnvironmentResource> builder,
+        [ResourceName] string name = "cert-manager",
+        string? chartVersion = null)
+    {
+        ArgumentNullException.ThrowIfNull(builder);
+        ArgumentException.ThrowIfNullOrEmpty(name);
+
+        var k8sEnvBuilder = builder.ApplicationBuilder.CreateResourceBuilder(builder.Resource.KubernetesEnvironment);
+        return k8sEnvBuilder.AddCertManager(name, chartVersion);
+    }
+}

--- a/src/Aspire.Hosting.Azure.Kubernetes/AzureCertManagerExtensions.cs
+++ b/src/Aspire.Hosting.Azure.Kubernetes/AzureCertManagerExtensions.cs
@@ -18,7 +18,7 @@ public static class AzureCertManagerExtensions
     /// returns a typed <see cref="CertManagerResource"/> that can host issuer resources.
     /// </summary>
     /// <param name="builder">The AKS environment resource builder.</param>
-    /// <param name="name">The Aspire resource name for the cert-manager installation. Defaults to <c>"cert-manager"</c>.</param>
+    /// <param name="name">The Aspire resource name for the cert-manager installation.</param>
     /// <param name="chartVersion">The cert-manager Helm chart version to install.
     /// Defaults to a pinned version validated against this Aspire build.</param>
     /// <returns>A reference to the <see cref="IResourceBuilder{CertManagerResource}"/> for chaining.</returns>
@@ -30,7 +30,7 @@ public static class AzureCertManagerExtensions
     [AspireExport(Description = "Installs cert-manager into an AKS environment")]
     public static IResourceBuilder<CertManagerResource> AddCertManager(
         this IResourceBuilder<AzureKubernetesEnvironmentResource> builder,
-        [ResourceName] string name = "cert-manager",
+        [ResourceName] string name,
         string? chartVersion = null)
     {
         ArgumentNullException.ThrowIfNull(builder);

--- a/src/Aspire.Hosting.Kubernetes/CertManagerExtensions.cs
+++ b/src/Aspire.Hosting.Kubernetes/CertManagerExtensions.cs
@@ -1,8 +1,15 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+#pragma warning disable ASPIREPIPELINES001 // Type is for evaluation purposes only and is subject to change or removal in future updates.
+
+using System.Globalization;
+using System.Text;
 using Aspire.Hosting.ApplicationModel;
+using Aspire.Hosting.Dcp.Process;
 using Aspire.Hosting.Kubernetes;
+using Aspire.Hosting.Pipelines;
+using Microsoft.Extensions.Logging;
 
 namespace Aspire.Hosting;
 
@@ -90,7 +97,17 @@ public static class CertManagerExtensions
             return builder.ApplicationBuilder.CreateResourceBuilder(resource);
         }
 
-        return builder.ApplicationBuilder.AddResource(resource).ExcludeFromManifest();
+        var resourceBuilder = builder.ApplicationBuilder.AddResource(resource).ExcludeFromManifest();
+
+        // Emit one kubectl-apply step per ClusterIssuer at deploy time. The annotation factory
+        // closure captures the CertManagerResource and reads .Issuers when the pipeline is
+        // assembled, so issuers added via AddIssuer(...) after this call are still picked up.
+        // Each step depends on helm-install-{chartName} so cert-manager (and its admission
+        // webhook) is up before we apply CRD instances.
+        resourceBuilder.WithAnnotation(new PipelineStepAnnotation(_ =>
+            BuildIssuerApplySteps(resource, chartName)));
+
+        return resourceBuilder;
     }
 
     /// <summary>
@@ -290,5 +307,200 @@ public static class CertManagerExtensions
         return builder
             .WithTls()
             .WithIngressAnnotation(ClusterIssuerAnnotationKey, issuer.Resource.Name);
+    }
+
+    private static Task<IEnumerable<PipelineStep>> BuildIssuerApplySteps(
+        CertManagerResource certManager,
+        string chartName)
+    {
+        var steps = new List<PipelineStep>();
+
+        foreach (var issuer in certManager.Issuers)
+        {
+            // Capture each issuer in its own local so the closure below doesn't see the
+            // foreach iteration variable.
+            var captured = issuer;
+
+            var step = new PipelineStep
+            {
+                Name = $"cm-issuer-apply-{captured.Name}",
+                Description = $"Applies cert-manager ClusterIssuer '{captured.Name}'",
+                Action = ctx => ApplyClusterIssuerAsync(ctx, certManager, captured)
+            };
+
+            // Wait for cert-manager itself to be installed and ready (helm install uses
+            // --wait, so the validating webhook is guaranteed to be Available before this
+            // step runs). Without this dep we'd race the webhook and get
+            // 'failed calling webhook "webhook.cert-manager.io": no endpoints available'.
+            step.DependsOn($"helm-install-{chartName}");
+            step.RequiredBy(WellKnownPipelineSteps.Deploy);
+            steps.Add(step);
+        }
+
+        return Task.FromResult<IEnumerable<PipelineStep>>(steps);
+    }
+
+    private static async Task ApplyClusterIssuerAsync(
+        PipelineStepContext context,
+        CertManagerResource certManager,
+        CertManagerIssuerResource issuer)
+    {
+        if (issuer.Spec is null)
+        {
+            throw new InvalidOperationException(
+                $"ClusterIssuer '{issuer.Name}' has no spec. Configure it with WithLetsEncryptProduction(), " +
+                "WithLetsEncryptStaging(), or WithAcmeServer().");
+        }
+
+        if (issuer.Solvers.Count == 0)
+        {
+            throw new InvalidOperationException(
+                $"ClusterIssuer '{issuer.Name}' has no solvers configured. Add at least one " +
+                "solver via WithHttp01Solver().");
+        }
+
+        var environment = certManager.Parent;
+
+        var manifest = await BuildClusterIssuerManifestAsync(context.Model, certManager, issuer, context.CancellationToken)
+            .ConfigureAwait(false);
+
+        context.Logger.LogInformation(
+            "Applying cert-manager ClusterIssuer '{IssuerName}'.", issuer.Name);
+
+        // Write to a temp file and apply. kubectl apply -f - via stdin would avoid the
+        // temp file but ProcessUtil.Run doesn't expose a stdin pipe; Directory.CreateTempSubdirectory
+        // is the standard temp pattern in this codebase (see EnsureBootstrapTlsSecretAsync).
+        var tempDir = Directory.CreateTempSubdirectory(".aspire-cm-issuer");
+        try
+        {
+            var manifestPath = Path.Combine(tempDir.FullName, $"{issuer.Name}.yaml");
+            await File.WriteAllTextAsync(manifestPath, manifest, context.CancellationToken).ConfigureAwait(false);
+
+            var args = new StringBuilder();
+            args.Append(CultureInfo.InvariantCulture, $"apply -f \"{manifestPath}\"");
+            if (environment.KubeConfigPath is not null)
+            {
+                args.Append(CultureInfo.InvariantCulture, $" --kubeconfig \"{environment.KubeConfigPath}\"");
+            }
+
+            var stderr = new StringBuilder();
+            var (resultTask, disposable) = ProcessUtil.Run(new ProcessSpec("kubectl")
+            {
+                Arguments = args.ToString(),
+                ThrowOnNonZeroReturnCode = false,
+                InheritEnv = true,
+                OnOutputData = line => context.Logger.LogDebug("kubectl: {Line}", line),
+                OnErrorData = line =>
+                {
+                    stderr.AppendLine(line);
+                    context.Logger.LogDebug("kubectl: {Line}", line);
+                }
+            });
+
+            await using (disposable.ConfigureAwait(false))
+            {
+                var result = await resultTask.WaitAsync(context.CancellationToken).ConfigureAwait(false);
+                if (result.ExitCode != 0)
+                {
+                    var errOut = stderr.ToString().Trim();
+                    throw new InvalidOperationException(
+                        $"kubectl apply for ClusterIssuer '{issuer.Name}' failed with exit code {result.ExitCode}: {errOut}");
+                }
+            }
+
+            context.Logger.LogInformation("ClusterIssuer '{IssuerName}' applied.", issuer.Name);
+        }
+        finally
+        {
+            try { tempDir.Delete(recursive: true); } catch { }
+        }
+    }
+
+    private static async Task<string> BuildClusterIssuerManifestAsync(
+        ApplicationModel.DistributedApplicationModel model,
+        CertManagerResource certManager,
+        CertManagerIssuerResource issuer,
+        CancellationToken cancellationToken)
+    {
+        var sb = new StringBuilder();
+        sb.AppendLine("apiVersion: cert-manager.io/v1");
+        sb.AppendLine("kind: ClusterIssuer");
+        sb.AppendLine("metadata:");
+        sb.Append("  name: ").AppendLine(issuer.Name);
+        sb.AppendLine("spec:");
+
+        switch (issuer.Spec)
+        {
+            case CertManagerAcmeIssuerSpec acme:
+                {
+                    var server = await acme.ServerUrl.GetValueAsync(cancellationToken).ConfigureAwait(false);
+                    var email = await acme.Email.GetValueAsync(cancellationToken).ConfigureAwait(false);
+                    sb.AppendLine("  acme:");
+                    sb.Append("    server: ").AppendLine(server);
+                    sb.Append("    email: ").AppendLine(email);
+                    sb.AppendLine("    privateKeySecretRef:");
+                    sb.Append("      name: ").Append(issuer.Name).AppendLine("-account-key");
+                    sb.AppendLine("    solvers:");
+                    foreach (var solver in issuer.Solvers)
+                    {
+                        AppendSolver(sb, solver, model, certManager, issuer);
+                    }
+                    break;
+                }
+            default:
+                throw new InvalidOperationException(
+                    $"Unknown issuer spec type '{issuer.Spec?.GetType().Name}' on issuer '{issuer.Name}'.");
+        }
+
+        return sb.ToString();
+    }
+
+    private static void AppendSolver(
+        StringBuilder sb,
+        CertManagerSolverConfig solver,
+        ApplicationModel.DistributedApplicationModel model,
+        CertManagerResource certManager,
+        CertManagerIssuerResource issuer)
+    {
+        switch (solver)
+        {
+            case CertManagerHttp01SolverConfig:
+                {
+                    sb.AppendLine("    - http01:");
+                    sb.AppendLine("        gatewayHTTPRoute:");
+
+                    // cert-manager's HTTP-01 Gateway API solver creates an HTTPRoute that has to
+                    // attach to the Gateway being validated. Without parentRefs, the route is
+                    // orphaned and the ACME challenge URL is unreachable.
+                    // See https://cert-manager.io/docs/configuration/acme/http01/#configuring-the-http01-gateway-api-solver
+                    var parentGateways = model.Resources
+                        .OfType<KubernetesGatewayResource>()
+                        .Where(g => g.Parent == certManager.Parent
+                                    && g.GatewayAnnotations.TryGetValue(ClusterIssuerAnnotationKey, out var v)
+                                    && string.Equals(v.Format, issuer.Name, StringComparison.Ordinal))
+                        .ToList();
+
+                    if (parentGateways.Count == 0)
+                    {
+                        // No annotated gateway found yet — emit the solver with no parentRefs.
+                        // cert-manager will reject the challenge until at least one Gateway
+                        // adopts the issuer, but the apply itself succeeds and a redeploy
+                        // after wiring up WithTls(issuer) will fix it.
+                        return;
+                    }
+
+                    sb.AppendLine("          parentRefs:");
+                    foreach (var gateway in parentGateways)
+                    {
+                        sb.AppendLine("            - group: gateway.networking.k8s.io");
+                        sb.AppendLine("              kind: Gateway");
+                        sb.Append("              name: ").AppendLine(gateway.Name);
+                    }
+                    break;
+                }
+            default:
+                throw new InvalidOperationException(
+                    $"Unknown solver type '{solver.GetType().Name}' on issuer '{issuer.Name}'.");
+        }
     }
 }

--- a/src/Aspire.Hosting.Kubernetes/CertManagerExtensions.cs
+++ b/src/Aspire.Hosting.Kubernetes/CertManagerExtensions.cs
@@ -1,0 +1,287 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Aspire.Hosting.ApplicationModel;
+using Aspire.Hosting.Kubernetes;
+
+namespace Aspire.Hosting;
+
+/// <summary>
+/// Provides extension methods for installing cert-manager into a Kubernetes environment
+/// and declaring <c>ClusterIssuer</c> resources against it.
+/// </summary>
+public static class CertManagerExtensions
+{
+    // The pinned default cert-manager chart version. Bump deliberately when validating against
+    // a newer release; the Helm chart's API and CRDs evolve across minor versions.
+    private const string DefaultChartReference = "oci://quay.io/jetstack/charts/cert-manager";
+    private const string DefaultChartVersion = "v1.18.2";
+
+    // Well-known ACME directory endpoints. See https://letsencrypt.org/docs/acme-protocol-updates/
+    // for the current canonical URLs.
+    private const string LetsEncryptProductionUrl = "https://acme-v02.api.letsencrypt.org/directory";
+    private const string LetsEncryptStagingUrl = "https://acme-staging-v02.api.letsencrypt.org/directory";
+
+    // The annotation cert-manager watches on Gateway / Ingress resources to auto-provision
+    // a Certificate from the named ClusterIssuer.
+    // See https://cert-manager.io/docs/usage/gateway/ and
+    // https://cert-manager.io/docs/usage/ingress/.
+    internal const string ClusterIssuerAnnotationKey = "cert-manager.io/cluster-issuer";
+
+    /// <summary>
+    /// Installs cert-manager into the Kubernetes environment and returns a typed
+    /// <see cref="CertManagerResource"/> that can host issuer resources.
+    /// </summary>
+    /// <param name="builder">The Kubernetes environment resource builder.</param>
+    /// <param name="name">The Aspire resource name for the cert-manager installation. Defaults to <c>"cert-manager"</c>.</param>
+    /// <param name="chartVersion">The cert-manager Helm chart version to install.
+    /// Defaults to a pinned version validated against this Aspire build.</param>
+    /// <returns>A reference to the <see cref="IResourceBuilder{CertManagerResource}"/> for chaining.</returns>
+    /// <remarks>
+    /// <para>
+    /// Internally creates a <see cref="KubernetesHelmChartResource"/> via
+    /// <see cref="KubernetesHelmChartExtensions.AddHelmChart(IResourceBuilder{KubernetesEnvironmentResource}, string, string, string)"/>
+    /// pointed at <c>oci://quay.io/jetstack/charts/cert-manager</c>. The chart is configured with:
+    /// </para>
+    /// <list type="bullet">
+    ///   <item><c>crds.enabled = true</c> — installs the cert-manager CRDs (<c>ClusterIssuer</c>, <c>Certificate</c>, ...) so issuer manifests can be applied immediately afterwards.</item>
+    ///   <item><c>config.enableGatewayAPI = true</c> — lets cert-manager watch Gateway API <c>Gateway</c>/<c>HTTPRoute</c> resources for the cluster-issuer annotation.</item>
+    ///   <item><c>WithForceConflicts()</c> — works around the AKS Azure Policy add-on mutating cert-manager's <c>ValidatingWebhookConfiguration</c> after install.</item>
+    ///   <item><c>WithDestroy()</c> — cleans up the Helm release on <c>aspire destroy</c>.</item>
+    /// </list>
+    /// <para>
+    /// To customise additional Helm values, access the underlying chart via
+    /// <see cref="CertManagerResource.HelmChart"/>.
+    /// </para>
+    /// </remarks>
+    [AspireExport(Description = "Installs cert-manager into a Kubernetes environment")]
+    public static IResourceBuilder<CertManagerResource> AddCertManager(
+        this IResourceBuilder<KubernetesEnvironmentResource> builder,
+        [ResourceName] string name = "cert-manager",
+        string? chartVersion = null)
+    {
+        ArgumentNullException.ThrowIfNull(builder);
+        ArgumentException.ThrowIfNullOrEmpty(name);
+
+        var version = chartVersion ?? DefaultChartVersion;
+
+        var chartBuilder = builder
+            .AddHelmChart(name, DefaultChartReference, version)
+            .WithHelmValue("crds.enabled", "true")
+            // Gateway API support is opt-in in the cert-manager chart. Without these values
+            // cert-manager will not provision Certificates for Gateway listeners.
+            // See https://cert-manager.io/docs/usage/gateway/.
+            .WithHelmValue("config.apiVersion", "controller.config.cert-manager.io/v1alpha1")
+            .WithHelmValue("config.kind", "ControllerConfiguration")
+            .WithHelmValue("config.enableGatewayAPI", "true")
+            .WithForceConflicts()
+            .WithDestroy();
+
+        var resource = new CertManagerResource(name, builder.Resource, chartBuilder.Resource);
+
+        // CertManagerResource is a typed handle around the underlying KubernetesHelmChartResource:
+        // the chart is what actually gets deployed (it's already in the model via AddHelmChart
+        // above), so we deliberately don't AddResource() here. That keeps the user-visible
+        // resource name (the chart) unique and avoids a name collision with the wrapper.
+        return builder.ApplicationBuilder.CreateResourceBuilder(resource);
+    }
+
+    /// <summary>
+    /// Adds a cert-manager <c>ClusterIssuer</c> to this cert-manager installation.
+    /// </summary>
+    /// <param name="builder">The cert-manager resource builder.</param>
+    /// <param name="name">The Aspire resource name. Also used as the <c>metadata.name</c>
+    /// of the generated <c>ClusterIssuer</c>, so it must be a valid DNS-1123 label.</param>
+    /// <returns>A reference to the <see cref="IResourceBuilder{CertManagerIssuerResource}"/> for chaining.</returns>
+    [AspireExport(Description = "Adds a cert-manager ClusterIssuer")]
+    public static IResourceBuilder<CertManagerIssuerResource> AddIssuer(
+        this IResourceBuilder<CertManagerResource> builder,
+        [ResourceName] string name)
+    {
+        ArgumentNullException.ThrowIfNull(builder);
+        ArgumentException.ThrowIfNullOrEmpty(name);
+
+        var issuer = new CertManagerIssuerResource(name, builder.Resource);
+        builder.Resource.Issuers.Add(issuer);
+
+        if (builder.ApplicationBuilder.ExecutionContext.IsRunMode)
+        {
+            return builder.ApplicationBuilder.CreateResourceBuilder(issuer);
+        }
+
+        return builder.ApplicationBuilder.AddResource(issuer).ExcludeFromManifest();
+    }
+
+    /// <summary>
+    /// Configures the issuer to use the Let's Encrypt production ACME endpoint.
+    /// </summary>
+    /// <param name="builder">The issuer resource builder.</param>
+    /// <param name="email">The contact email registered with the ACME account. Let's Encrypt
+    /// uses this address for expiry notifications and rate-limit appeals.</param>
+    /// <returns>A reference to the <see cref="IResourceBuilder{CertManagerIssuerResource}"/> for chaining.</returns>
+    /// <remarks>
+    /// Production certificates are subject to strict per-domain rate limits
+    /// (<see href="https://letsencrypt.org/docs/rate-limits/"/>). For development workflows,
+    /// prefer <see cref="WithLetsEncryptStaging(IResourceBuilder{CertManagerIssuerResource}, string)"/>
+    /// which uses untrusted staging certificates with much higher rate limits.
+    /// </remarks>
+    [AspireExport(Description = "Configures the issuer for Let's Encrypt production")]
+    public static IResourceBuilder<CertManagerIssuerResource> WithLetsEncryptProduction(
+        this IResourceBuilder<CertManagerIssuerResource> builder,
+        string email)
+        => WithAcmeServer(builder, LetsEncryptProductionUrl, email);
+
+    /// <summary>
+    /// Configures the issuer to use the Let's Encrypt production ACME endpoint, with the
+    /// contact email supplied via a parameter resolved at deploy time.
+    /// </summary>
+    /// <param name="builder">The issuer resource builder.</param>
+    /// <param name="email">A parameter resource builder whose value is the contact email.</param>
+    /// <returns>A reference to the <see cref="IResourceBuilder{CertManagerIssuerResource}"/> for chaining.</returns>
+    [AspireExport("withLetsEncryptProductionParam", Description = "Configures the issuer for Let's Encrypt production with a parameterized email")]
+    public static IResourceBuilder<CertManagerIssuerResource> WithLetsEncryptProduction(
+        this IResourceBuilder<CertManagerIssuerResource> builder,
+        IResourceBuilder<ParameterResource> email)
+        => WithAcmeServer(builder, LetsEncryptProductionUrl, email);
+
+    /// <summary>
+    /// Configures the issuer to use the Let's Encrypt staging ACME endpoint. Certificates issued
+    /// from staging are not trusted by browsers, but the endpoint has much higher rate limits,
+    /// making it the right choice for development and CI workflows.
+    /// </summary>
+    /// <param name="builder">The issuer resource builder.</param>
+    /// <param name="email">The contact email registered with the ACME account.</param>
+    /// <returns>A reference to the <see cref="IResourceBuilder{CertManagerIssuerResource}"/> for chaining.</returns>
+    [AspireExport(Description = "Configures the issuer for Let's Encrypt staging")]
+    public static IResourceBuilder<CertManagerIssuerResource> WithLetsEncryptStaging(
+        this IResourceBuilder<CertManagerIssuerResource> builder,
+        string email)
+        => WithAcmeServer(builder, LetsEncryptStagingUrl, email);
+
+    /// <summary>
+    /// Configures the issuer to use the Let's Encrypt staging ACME endpoint, with the
+    /// contact email supplied via a parameter.
+    /// </summary>
+    [AspireExport("withLetsEncryptStagingParam", Description = "Configures the issuer for Let's Encrypt staging with a parameterized email")]
+    public static IResourceBuilder<CertManagerIssuerResource> WithLetsEncryptStaging(
+        this IResourceBuilder<CertManagerIssuerResource> builder,
+        IResourceBuilder<ParameterResource> email)
+        => WithAcmeServer(builder, LetsEncryptStagingUrl, email);
+
+    /// <summary>
+    /// Configures the issuer to use a custom ACME directory endpoint (e.g., a private ACME
+    /// server such as ZeroSSL or step-ca).
+    /// </summary>
+    /// <param name="builder">The issuer resource builder.</param>
+    /// <param name="serverUrl">The ACME directory URL (e.g., <c>https://acme.example.com/directory</c>).</param>
+    /// <param name="email">The contact email registered with the ACME account.</param>
+    /// <returns>A reference to the <see cref="IResourceBuilder{CertManagerIssuerResource}"/> for chaining.</returns>
+    [AspireExport(Description = "Configures the issuer to use a custom ACME directory")]
+    public static IResourceBuilder<CertManagerIssuerResource> WithAcmeServer(
+        this IResourceBuilder<CertManagerIssuerResource> builder,
+        string serverUrl,
+        string email)
+    {
+        ArgumentNullException.ThrowIfNull(builder);
+        ArgumentException.ThrowIfNullOrEmpty(serverUrl);
+        ArgumentException.ThrowIfNullOrEmpty(email);
+
+        builder.Resource.Spec = new CertManagerAcmeIssuerSpec(
+            ReferenceExpression.Create($"{serverUrl}"),
+            ReferenceExpression.Create($"{email}"));
+
+        return builder;
+    }
+
+    /// <summary>
+    /// Configures the issuer to use a custom ACME directory endpoint with a parameterized email.
+    /// </summary>
+    [AspireExport("withAcmeServerParam", Description = "Configures the issuer to use a custom ACME directory with a parameterized email")]
+    public static IResourceBuilder<CertManagerIssuerResource> WithAcmeServer(
+        this IResourceBuilder<CertManagerIssuerResource> builder,
+        string serverUrl,
+        IResourceBuilder<ParameterResource> email)
+    {
+        ArgumentNullException.ThrowIfNull(builder);
+        ArgumentException.ThrowIfNullOrEmpty(serverUrl);
+        ArgumentNullException.ThrowIfNull(email);
+
+        builder.Resource.Spec = new CertManagerAcmeIssuerSpec(
+            ReferenceExpression.Create($"{serverUrl}"),
+            ReferenceExpression.Create($"{email.Resource}"));
+
+        return builder;
+    }
+
+    /// <summary>
+    /// Adds an HTTP-01 ACME challenge solver to the issuer. cert-manager will satisfy the
+    /// challenge by provisioning a temporary HTTP route at
+    /// <c>/.well-known/acme-challenge/{token}</c> on the same hostname being validated.
+    /// This requires the hostname to be publicly reachable on port 80.
+    /// </summary>
+    /// <param name="builder">The issuer resource builder.</param>
+    /// <returns>A reference to the <see cref="IResourceBuilder{CertManagerIssuerResource}"/> for chaining.</returns>
+    /// <remarks>
+    /// HTTP-01 is the right choice for gateways exposed via Azure Application Gateway for
+    /// Containers (AGC) or any ingress controller that publishes a publicly addressable
+    /// hostname. Wildcard certificates require a DNS-01 solver, which is not yet supported.
+    /// </remarks>
+    [AspireExport(Description = "Adds an HTTP-01 ACME challenge solver to the issuer")]
+    public static IResourceBuilder<CertManagerIssuerResource> WithHttp01Solver(
+        this IResourceBuilder<CertManagerIssuerResource> builder)
+    {
+        ArgumentNullException.ThrowIfNull(builder);
+
+        builder.Resource.Solvers.Add(new CertManagerHttp01SolverConfig());
+        return builder;
+    }
+
+    /// <summary>
+    /// Adds an HTTPS listener to the gateway and wires it to the supplied cert-manager
+    /// <c>ClusterIssuer</c>. This adds the <c>cert-manager.io/cluster-issuer</c> annotation
+    /// to the generated Gateway resource, causing cert-manager to provision and renew a
+    /// certificate for each gateway listener hostname.
+    /// </summary>
+    /// <param name="builder">The gateway resource builder.</param>
+    /// <param name="issuer">The cert-manager <c>ClusterIssuer</c> to issue certificates from.</param>
+    /// <returns>A reference to the <see cref="IResourceBuilder{KubernetesGatewayResource}"/> for chaining.</returns>
+    /// <remarks>
+    /// Equivalent to calling <c>WithTls()</c> followed by
+    /// <c>WithGatewayAnnotation("cert-manager.io/cluster-issuer", issuer.Resource.Name)</c>,
+    /// but type-safe and refactor-friendly.
+    /// </remarks>
+    [AspireExport("withGatewayTlsIssuer", Description = "Configures TLS on a Kubernetes Gateway using a cert-manager ClusterIssuer")]
+    public static IResourceBuilder<KubernetesGatewayResource> WithTls(
+        this IResourceBuilder<KubernetesGatewayResource> builder,
+        IResourceBuilder<CertManagerIssuerResource> issuer)
+    {
+        ArgumentNullException.ThrowIfNull(builder);
+        ArgumentNullException.ThrowIfNull(issuer);
+
+        return builder
+            .WithTls()
+            .WithGatewayAnnotation(ClusterIssuerAnnotationKey, issuer.Resource.Name);
+    }
+
+    /// <summary>
+    /// Adds TLS configuration to the ingress and wires it to the supplied cert-manager
+    /// <c>ClusterIssuer</c>. This adds the <c>cert-manager.io/cluster-issuer</c> annotation
+    /// to the generated Ingress resource, causing cert-manager to provision and renew a
+    /// certificate for each ingress host.
+    /// </summary>
+    /// <param name="builder">The ingress resource builder.</param>
+    /// <param name="issuer">The cert-manager <c>ClusterIssuer</c> to issue certificates from.</param>
+    /// <returns>A reference to the <see cref="IResourceBuilder{KubernetesIngressResource}"/> for chaining.</returns>
+    [AspireExport("withIngressTlsIssuer", Description = "Configures TLS on a Kubernetes Ingress using a cert-manager ClusterIssuer")]
+    public static IResourceBuilder<KubernetesIngressResource> WithTls(
+        this IResourceBuilder<KubernetesIngressResource> builder,
+        IResourceBuilder<CertManagerIssuerResource> issuer)
+    {
+        ArgumentNullException.ThrowIfNull(builder);
+        ArgumentNullException.ThrowIfNull(issuer);
+
+        return builder
+            .WithTls()
+            .WithIngressAnnotation(ClusterIssuerAnnotationKey, issuer.Resource.Name);
+    }
+}

--- a/src/Aspire.Hosting.Kubernetes/CertManagerExtensions.cs
+++ b/src/Aspire.Hosting.Kubernetes/CertManagerExtensions.cs
@@ -23,7 +23,7 @@ public static class CertManagerExtensions
     // The pinned default cert-manager chart version. Bump deliberately when validating against
     // a newer release; the Helm chart's API and CRDs evolve across minor versions.
     private const string DefaultChartReference = "oci://quay.io/jetstack/charts/cert-manager";
-    private const string DefaultChartVersion = "v1.18.2";
+    private const string DefaultChartVersion = "v1.20.2";
 
     // Well-known ACME directory endpoints. See https://letsencrypt.org/docs/acme-protocol-updates/
     // for the current canonical URLs.

--- a/src/Aspire.Hosting.Kubernetes/CertManagerExtensions.cs
+++ b/src/Aspire.Hosting.Kubernetes/CertManagerExtensions.cs
@@ -65,8 +65,14 @@ public static class CertManagerExtensions
 
         var version = chartVersion ?? DefaultChartVersion;
 
+        // The helm chart is exposed in the model under "{name}-chart" so the user-facing
+        // CertManagerResource can keep the natural "{name}" identifier without colliding.
+        // Both show up in the dashboard / generated artifacts: the chart is what actually
+        // installs cert-manager, and the wrapper is what hosts the typed issuer children.
+        var chartName = $"{name}-chart";
+
         var chartBuilder = builder
-            .AddHelmChart(name, DefaultChartReference, version)
+            .AddHelmChart(chartName, DefaultChartReference, version)
             .WithHelmValue("crds.enabled", "true")
             // Gateway API support is opt-in in the cert-manager chart. Without these values
             // cert-manager will not provision Certificates for Gateway listeners.
@@ -79,11 +85,12 @@ public static class CertManagerExtensions
 
         var resource = new CertManagerResource(name, builder.Resource, chartBuilder.Resource);
 
-        // CertManagerResource is a typed handle around the underlying KubernetesHelmChartResource:
-        // the chart is what actually gets deployed (it's already in the model via AddHelmChart
-        // above), so we deliberately don't AddResource() here. That keeps the user-visible
-        // resource name (the chart) unique and avoids a name collision with the wrapper.
-        return builder.ApplicationBuilder.CreateResourceBuilder(resource);
+        if (builder.ApplicationBuilder.ExecutionContext.IsRunMode)
+        {
+            return builder.ApplicationBuilder.CreateResourceBuilder(resource);
+        }
+
+        return builder.ApplicationBuilder.AddResource(resource).ExcludeFromManifest();
     }
 
     /// <summary>

--- a/src/Aspire.Hosting.Kubernetes/CertManagerExtensions.cs
+++ b/src/Aspire.Hosting.Kubernetes/CertManagerExtensions.cs
@@ -8,6 +8,7 @@ using System.Text;
 using Aspire.Hosting.ApplicationModel;
 using Aspire.Hosting.Dcp.Process;
 using Aspire.Hosting.Kubernetes;
+using Aspire.Hosting.Kubernetes.Extensions;
 using Aspire.Hosting.Pipelines;
 using Microsoft.Extensions.Logging;
 
@@ -35,12 +36,20 @@ public static class CertManagerExtensions
     // https://cert-manager.io/docs/usage/ingress/.
     internal const string ClusterIssuerAnnotationKey = "cert-manager.io/cluster-issuer";
 
+    // Aspire resource names cap at 64 chars. The helm chart we register beside the wrapper
+    // is "{name}-chart" (6 extra chars), so the user-facing name has to stay under this
+    // bound or AddHelmChart will reject it with a confusing downstream error.
+    private const int MaxResourceNameLength = 64;
+    private const string ChartNameSuffix = "-chart";
+
     /// <summary>
     /// Installs cert-manager into the Kubernetes environment and returns a typed
     /// <see cref="CertManagerResource"/> that can host issuer resources.
     /// </summary>
     /// <param name="builder">The Kubernetes environment resource builder.</param>
-    /// <param name="name">The Aspire resource name for the cert-manager installation. Defaults to <c>"cert-manager"</c>.</param>
+    /// <param name="name">The Aspire resource name for the cert-manager installation. Each call
+    /// adds a uniquely-named resource to the application model, so multiple Kubernetes environments
+    /// must each pass distinct names.</param>
     /// <param name="chartVersion">The cert-manager Helm chart version to install.
     /// Defaults to a pinned version validated against this Aspire build.</param>
     /// <returns>A reference to the <see cref="IResourceBuilder{CertManagerResource}"/> for chaining.</returns>
@@ -54,8 +63,13 @@ public static class CertManagerExtensions
     ///   <item><c>crds.enabled = true</c> — installs the cert-manager CRDs (<c>ClusterIssuer</c>, <c>Certificate</c>, ...) so issuer manifests can be applied immediately afterwards.</item>
     ///   <item><c>config.enableGatewayAPI = true</c> — lets cert-manager watch Gateway API <c>Gateway</c>/<c>HTTPRoute</c> resources for the cluster-issuer annotation.</item>
     ///   <item><c>WithForceConflicts()</c> — works around the AKS Azure Policy add-on mutating cert-manager's <c>ValidatingWebhookConfiguration</c> after install.</item>
-    ///   <item><c>WithDestroy()</c> — cleans up the Helm release on <c>aspire destroy</c>.</item>
+    ///   <item><c>WithDestroy()</c> — uninstalls the Helm release on <c>aspire destroy</c>.</item>
     /// </list>
+    /// <para>
+    /// Issuer manifests are applied directly via <c>kubectl apply</c> at deploy time (not as
+    /// part of the Helm release), and are deleted via <c>kubectl delete</c> on
+    /// <c>aspire destroy</c> before the cert-manager Helm release itself is uninstalled.
+    /// </para>
     /// <para>
     /// To customise additional Helm values, access the underlying chart via
     /// <see cref="CertManagerResource.HelmChart"/>.
@@ -64,11 +78,22 @@ public static class CertManagerExtensions
     [AspireExport(Description = "Installs cert-manager into a Kubernetes environment")]
     public static IResourceBuilder<CertManagerResource> AddCertManager(
         this IResourceBuilder<KubernetesEnvironmentResource> builder,
-        [ResourceName] string name = "cert-manager",
+        [ResourceName] string name,
         string? chartVersion = null)
     {
         ArgumentNullException.ThrowIfNull(builder);
         ArgumentException.ThrowIfNullOrEmpty(name);
+
+        // Keep room for the "-chart" suffix we append for the underlying helm chart resource.
+        // Without this guard, an otherwise-valid 64-char name would build successfully here
+        // and then explode inside AddHelmChart with a less-clear "name too long" message.
+        if (name.Length > MaxResourceNameLength - ChartNameSuffix.Length)
+        {
+            throw new ArgumentException(
+                $"cert-manager resource name '{name}' is too long. The maximum length is {MaxResourceNameLength - ChartNameSuffix.Length} characters because " +
+                $"a companion Helm chart resource is registered as '{{name}}{ChartNameSuffix}' which must itself fit within the {MaxResourceNameLength}-character Aspire resource name limit.",
+                nameof(name));
+        }
 
         var version = chartVersion ?? DefaultChartVersion;
 
@@ -76,7 +101,7 @@ public static class CertManagerExtensions
         // CertManagerResource can keep the natural "{name}" identifier without colliding.
         // Both show up in the dashboard / generated artifacts: the chart is what actually
         // installs cert-manager, and the wrapper is what hosts the typed issuer children.
-        var chartName = $"{name}-chart";
+        var chartName = $"{name}{ChartNameSuffix}";
 
         var chartBuilder = builder
             .AddHelmChart(chartName, DefaultChartReference, version)
@@ -99,13 +124,18 @@ public static class CertManagerExtensions
 
         var resourceBuilder = builder.ApplicationBuilder.AddResource(resource).ExcludeFromManifest();
 
-        // Emit one kubectl-apply step per ClusterIssuer at deploy time. The annotation factory
-        // closure captures the CertManagerResource and reads .Issuers when the pipeline is
-        // assembled, so issuers added via AddIssuer(...) after this call are still picked up.
-        // Each step depends on helm-install-{chartName} so cert-manager (and its admission
-        // webhook) is up before we apply CRD instances.
+        // Emit one kubectl-apply step per ClusterIssuer at deploy time, plus one kubectl-delete
+        // step per ClusterIssuer at destroy time. The annotation factory closures capture the
+        // CertManagerResource and read .Issuers when the pipeline is assembled, so issuers added
+        // via AddIssuer(...) after this call are still picked up.
+        // Apply steps depend on helm-install-{chartName} so cert-manager (and its admission
+        // webhook) is up before we apply CRD instances. Delete steps run before
+        // helm-uninstall-{chartName} so we delete the ClusterIssuers (and let cert-manager
+        // clean up its account secrets) while the controller is still alive.
         resourceBuilder.WithAnnotation(new PipelineStepAnnotation(_ =>
             BuildIssuerApplySteps(resource, chartName)));
+        resourceBuilder.WithAnnotation(new PipelineStepAnnotation(_ =>
+            BuildIssuerDeleteSteps(resource, chartName)));
 
         return resourceBuilder;
     }
@@ -160,7 +190,7 @@ public static class CertManagerExtensions
     /// contact email supplied via a parameter resolved at deploy time.
     /// </summary>
     /// <param name="builder">The issuer resource builder.</param>
-    /// <param name="email">A parameter resource builder whose value is the contact email.</param>
+    /// <param name="email">A parameter resource builder whose value is the contact email registered with the ACME account.</param>
     /// <returns>A reference to the <see cref="IResourceBuilder{CertManagerIssuerResource}"/> for chaining.</returns>
     [AspireExport("withLetsEncryptProductionParam", Description = "Configures the issuer for Let's Encrypt production with a parameterized email")]
     public static IResourceBuilder<CertManagerIssuerResource> WithLetsEncryptProduction(
@@ -184,8 +214,11 @@ public static class CertManagerExtensions
 
     /// <summary>
     /// Configures the issuer to use the Let's Encrypt staging ACME endpoint, with the
-    /// contact email supplied via a parameter.
+    /// contact email supplied via a parameter resolved at deploy time.
     /// </summary>
+    /// <param name="builder">The issuer resource builder.</param>
+    /// <param name="email">A parameter resource builder whose value is the contact email registered with the ACME account.</param>
+    /// <returns>A reference to the <see cref="IResourceBuilder{CertManagerIssuerResource}"/> for chaining.</returns>
     [AspireExport("withLetsEncryptStagingParam", Description = "Configures the issuer for Let's Encrypt staging with a parameterized email")]
     public static IResourceBuilder<CertManagerIssuerResource> WithLetsEncryptStaging(
         this IResourceBuilder<CertManagerIssuerResource> builder,
@@ -220,6 +253,10 @@ public static class CertManagerExtensions
     /// <summary>
     /// Configures the issuer to use a custom ACME directory endpoint with a parameterized email.
     /// </summary>
+    /// <param name="builder">The issuer resource builder.</param>
+    /// <param name="serverUrl">The ACME directory URL (e.g., <c>https://acme.example.com/directory</c>).</param>
+    /// <param name="email">A parameter resource builder whose value is the contact email registered with the ACME account.</param>
+    /// <returns>A reference to the <see cref="IResourceBuilder{CertManagerIssuerResource}"/> for chaining.</returns>
     [AspireExport("withAcmeServerParam", Description = "Configures the issuer to use a custom ACME directory with a parameterized email")]
     public static IResourceBuilder<CertManagerIssuerResource> WithAcmeServer(
         this IResourceBuilder<CertManagerIssuerResource> builder,
@@ -272,7 +309,10 @@ public static class CertManagerExtensions
     /// <remarks>
     /// Equivalent to calling <c>WithTls()</c> followed by
     /// <c>WithGatewayAnnotation("cert-manager.io/cluster-issuer", issuer.Resource.Name)</c>,
-    /// but type-safe and refactor-friendly.
+    /// but type-safe and refactor-friendly. Throws if the gateway and the issuer's
+    /// cert-manager installation are not part of the same Kubernetes environment, since
+    /// cert-manager is per-cluster and would otherwise silently produce an unsatisfiable
+    /// TLS configuration.
     /// </remarks>
     [AspireExport("withGatewayTlsIssuer", Description = "Configures TLS on a Kubernetes Gateway using a cert-manager ClusterIssuer")]
     public static IResourceBuilder<KubernetesGatewayResource> WithTls(
@@ -282,31 +322,21 @@ public static class CertManagerExtensions
         ArgumentNullException.ThrowIfNull(builder);
         ArgumentNullException.ThrowIfNull(issuer);
 
+        var gatewayEnvironment = builder.Resource.Parent;
+        var issuerEnvironment = issuer.Resource.Parent.Parent;
+        var nameComparer = new ResourceNameComparer();
+        if (!nameComparer.Equals(gatewayEnvironment, issuerEnvironment))
+        {
+            throw new InvalidOperationException(
+                $"Gateway '{builder.Resource.Name}' is in Kubernetes environment '{gatewayEnvironment.Name}' but issuer " +
+                $"'{issuer.Resource.Name}' belongs to cert-manager installation '{issuer.Resource.Parent.Name}' in environment " +
+                $"'{issuerEnvironment.Name}'. cert-manager is per-cluster, so an issuer can only be used by gateways in the " +
+                "same Kubernetes environment.");
+        }
+
         return builder
             .WithTls()
             .WithGatewayAnnotation(ClusterIssuerAnnotationKey, issuer.Resource.Name);
-    }
-
-    /// <summary>
-    /// Adds TLS configuration to the ingress and wires it to the supplied cert-manager
-    /// <c>ClusterIssuer</c>. This adds the <c>cert-manager.io/cluster-issuer</c> annotation
-    /// to the generated Ingress resource, causing cert-manager to provision and renew a
-    /// certificate for each ingress host.
-    /// </summary>
-    /// <param name="builder">The ingress resource builder.</param>
-    /// <param name="issuer">The cert-manager <c>ClusterIssuer</c> to issue certificates from.</param>
-    /// <returns>A reference to the <see cref="IResourceBuilder{KubernetesIngressResource}"/> for chaining.</returns>
-    [AspireExport("withIngressTlsIssuer", Description = "Configures TLS on a Kubernetes Ingress using a cert-manager ClusterIssuer")]
-    public static IResourceBuilder<KubernetesIngressResource> WithTls(
-        this IResourceBuilder<KubernetesIngressResource> builder,
-        IResourceBuilder<CertManagerIssuerResource> issuer)
-    {
-        ArgumentNullException.ThrowIfNull(builder);
-        ArgumentNullException.ThrowIfNull(issuer);
-
-        return builder
-            .WithTls()
-            .WithIngressAnnotation(ClusterIssuerAnnotationKey, issuer.Resource.Name);
     }
 
     private static Task<IEnumerable<PipelineStep>> BuildIssuerApplySteps(
@@ -334,6 +364,38 @@ public static class CertManagerExtensions
             // 'failed calling webhook "webhook.cert-manager.io": no endpoints available'.
             step.DependsOn($"helm-install-{chartName}");
             step.RequiredBy(WellKnownPipelineSteps.Deploy);
+            steps.Add(step);
+        }
+
+        return Task.FromResult<IEnumerable<PipelineStep>>(steps);
+    }
+
+    private static Task<IEnumerable<PipelineStep>> BuildIssuerDeleteSteps(
+        CertManagerResource certManager,
+        string chartName)
+    {
+        var steps = new List<PipelineStep>();
+
+        foreach (var issuer in certManager.Issuers)
+        {
+            var captured = issuer;
+
+            var step = new PipelineStep
+            {
+                Name = $"cm-issuer-delete-{captured.Name}",
+                Description = $"Deletes cert-manager ClusterIssuer '{captured.Name}'",
+                Action = ctx => DeleteClusterIssuerAsync(ctx, certManager, captured),
+                DependsOnSteps = [WellKnownPipelineSteps.DestroyPrereq]
+            };
+
+            // Run before the cert-manager helm chart is uninstalled. Once the chart goes,
+            // the cert-manager.io CRDs are removed and the API server forgets ClusterIssuer
+            // exists, so a delete attempted afterwards either silently no-ops (object kind
+            // not found) or fails. Deleting while cert-manager is still alive also lets the
+            // controller clean up the ACME account secret it created in the cert-manager
+            // namespace.
+            step.RequiredBy($"helm-uninstall-{chartName}");
+            step.RequiredBy(WellKnownPipelineSteps.Destroy);
             steps.Add(step);
         }
 
@@ -418,7 +480,63 @@ public static class CertManagerExtensions
         }
     }
 
-    private static async Task<string> BuildClusterIssuerManifestAsync(
+    private static async Task DeleteClusterIssuerAsync(
+        PipelineStepContext context,
+        CertManagerResource certManager,
+        CertManagerIssuerResource issuer)
+    {
+        var environment = certManager.Parent;
+        // Match the lowercase normalization used at apply time so we target the same object.
+        var k8sIssuerName = issuer.Name.ToKubernetesResourceName();
+
+        context.Logger.LogInformation(
+            "Deleting cert-manager ClusterIssuer '{IssuerName}'.", issuer.Name);
+
+        var args = new StringBuilder();
+        // --ignore-not-found makes destroy idempotent: re-running aspire destroy after a
+        // partially-completed prior destroy (or after the issuer was deleted manually) is a
+        // no-op rather than a failure.
+        args.Append(CultureInfo.InvariantCulture, $"delete clusterissuer {k8sIssuerName} --ignore-not-found");
+        if (environment.KubeConfigPath is not null)
+        {
+            args.Append(CultureInfo.InvariantCulture, $" --kubeconfig \"{environment.KubeConfigPath}\"");
+        }
+
+        var stderr = new StringBuilder();
+        var (resultTask, disposable) = ProcessUtil.Run(new ProcessSpec("kubectl")
+        {
+            Arguments = args.ToString(),
+            ThrowOnNonZeroReturnCode = false,
+            InheritEnv = true,
+            OnOutputData = line => context.Logger.LogDebug("kubectl: {Line}", line),
+            OnErrorData = line =>
+            {
+                stderr.AppendLine(line);
+                context.Logger.LogDebug("kubectl: {Line}", line);
+            }
+        });
+
+        await using (disposable.ConfigureAwait(false))
+        {
+            var result = await resultTask.WaitAsync(context.CancellationToken).ConfigureAwait(false);
+            if (result.ExitCode != 0)
+            {
+                // Don't fail destroy if delete encountered an error — log and continue so the
+                // rest of the destroy pipeline (helm-uninstall, infra teardown) can still run.
+                // The cluster is most likely about to be torn down anyway.
+                context.Logger.LogWarning(
+                    "kubectl delete for ClusterIssuer '{IssuerName}' returned exit code {ExitCode}: {StdErr}",
+                    issuer.Name,
+                    result.ExitCode,
+                    stderr.ToString().Trim());
+                return;
+            }
+        }
+
+        context.Logger.LogInformation("ClusterIssuer '{IssuerName}' deleted.", issuer.Name);
+    }
+
+    internal static async Task<string> BuildClusterIssuerManifestAsync(
         ApplicationModel.DistributedApplicationModel model,
         CertManagerResource certManager,
         CertManagerIssuerResource issuer,
@@ -429,7 +547,11 @@ public static class CertManagerExtensions
         sb.AppendLine("apiVersion: cert-manager.io/v1");
         sb.AppendLine("kind: ClusterIssuer");
         sb.AppendLine("metadata:");
-        sb.Append("  name: ").AppendLine(issuer.Name);
+        // Kubernetes object metadata.name must be a valid DNS-1123 subdomain (lowercase).
+        // Aspire resource names allow uppercase, so normalise here to match the same rule the
+        // rest of the Kubernetes integration uses for generated object names.
+        var k8sIssuerName = issuer.Name.ToKubernetesResourceName();
+        sb.Append("  name: ").AppendLine(k8sIssuerName);
         sb.AppendLine("spec:");
 
         switch (issuer.Spec)
@@ -442,7 +564,7 @@ public static class CertManagerExtensions
                     sb.Append("    server: ").AppendLine(server);
                     sb.Append("    email: ").AppendLine(email);
                     sb.AppendLine("    privateKeySecretRef:");
-                    sb.Append("      name: ").Append(issuer.Name).AppendLine("-account-key");
+                    sb.Append("      name: ").Append(k8sIssuerName).AppendLine("-account-key");
                     sb.AppendLine("    solvers:");
                     foreach (var solver in issuer.Solvers)
                     {
@@ -507,7 +629,9 @@ public static class CertManagerExtensions
                     {
                         sb.AppendLine("            - group: gateway.networking.k8s.io");
                         sb.AppendLine("              kind: Gateway");
-                        sb.Append("              name: ").AppendLine(gateway.Name);
+                        // Match the metadata.name normalization used by BuildGatewayObjects so
+                        // the parentRef resolves to the actual Gateway in the cluster.
+                        sb.Append("              name: ").AppendLine(gateway.Name.ToKubernetesResourceName());
                     }
                     break;
                 }

--- a/src/Aspire.Hosting.Kubernetes/CertManagerExtensions.cs
+++ b/src/Aspire.Hosting.Kubernetes/CertManagerExtensions.cs
@@ -361,7 +361,7 @@ public static class CertManagerExtensions
 
         var environment = certManager.Parent;
 
-        var manifest = await BuildClusterIssuerManifestAsync(context.Model, certManager, issuer, context.CancellationToken)
+        var manifest = await BuildClusterIssuerManifestAsync(context.Model, certManager, issuer, context.Logger, context.CancellationToken)
             .ConfigureAwait(false);
 
         context.Logger.LogInformation(
@@ -412,7 +412,9 @@ public static class CertManagerExtensions
         }
         finally
         {
-            try { tempDir.Delete(recursive: true); } catch { }
+            try { tempDir.Delete(recursive: true); }
+            catch (IOException) { /* best-effort cleanup */ }
+            catch (UnauthorizedAccessException) { /* best-effort cleanup */ }
         }
     }
 
@@ -420,6 +422,7 @@ public static class CertManagerExtensions
         ApplicationModel.DistributedApplicationModel model,
         CertManagerResource certManager,
         CertManagerIssuerResource issuer,
+        ILogger logger,
         CancellationToken cancellationToken)
     {
         var sb = new StringBuilder();
@@ -443,7 +446,7 @@ public static class CertManagerExtensions
                     sb.AppendLine("    solvers:");
                     foreach (var solver in issuer.Solvers)
                     {
-                        AppendSolver(sb, solver, model, certManager, issuer);
+                        AppendSolver(sb, solver, model, certManager, issuer, logger);
                     }
                     break;
                 }
@@ -460,7 +463,8 @@ public static class CertManagerExtensions
         CertManagerSolverConfig solver,
         ApplicationModel.DistributedApplicationModel model,
         CertManagerResource certManager,
-        CertManagerIssuerResource issuer)
+        CertManagerIssuerResource issuer,
+        ILogger logger)
     {
         switch (solver)
         {
@@ -473,19 +477,28 @@ public static class CertManagerExtensions
                     // attach to the Gateway being validated. Without parentRefs, the route is
                     // orphaned and the ACME challenge URL is unreachable.
                     // See https://cert-manager.io/docs/configuration/acme/http01/#configuring-the-http01-gateway-api-solver
+                    var nameComparer = new ResourceNameComparer();
                     var parentGateways = model.Resources
                         .OfType<KubernetesGatewayResource>()
-                        .Where(g => g.Parent == certManager.Parent
+                        .Where(g => nameComparer.Equals(g.Parent, certManager.Parent)
                                     && g.GatewayAnnotations.TryGetValue(ClusterIssuerAnnotationKey, out var v)
                                     && string.Equals(v.Format, issuer.Name, StringComparison.Ordinal))
                         .ToList();
 
                     if (parentGateways.Count == 0)
                     {
-                        // No annotated gateway found yet — emit the solver with no parentRefs.
-                        // cert-manager will reject the challenge until at least one Gateway
-                        // adopts the issuer, but the apply itself succeeds and a redeploy
-                        // after wiring up WithTls(issuer) will fix it.
+                        // No annotated gateway found. cert-manager will accept this manifest but
+                        // the HTTP-01 challenge can never be satisfied because there's no parent
+                        // Gateway for the solver's HTTPRoute to attach to. Emit a warning so the
+                        // misconfiguration is visible at deploy time instead of leaving the user
+                        // to discover it via Certificates stuck in 'Pending' indefinitely.
+                        logger.LogWarning(
+                            "ClusterIssuer '{IssuerName}' has an HTTP-01 solver but no Gateway in environment '{EnvironmentName}' is annotated with " +
+                            ClusterIssuerAnnotationKey + "={IssuerName}. cert-manager will not be able to satisfy ACME challenges until at least " +
+                            "one Gateway adopts this issuer (e.g. via WithTls(issuer)).",
+                            issuer.Name,
+                            certManager.Parent.Name,
+                            issuer.Name);
                         return;
                     }
 

--- a/src/Aspire.Hosting.Kubernetes/CertManagerIssuerResource.cs
+++ b/src/Aspire.Hosting.Kubernetes/CertManagerIssuerResource.cs
@@ -1,0 +1,93 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Aspire.Hosting.ApplicationModel;
+
+namespace Aspire.Hosting.Kubernetes;
+
+/// <summary>
+/// Represents a cert-manager <c>ClusterIssuer</c> resource in the Aspire application model.
+/// </summary>
+/// <remarks>
+/// <para>
+/// At publish time, an issuer emits a <c>cert-manager.io/v1 ClusterIssuer</c> manifest into
+/// the generated Helm chart output. Cluster-scoped issuers can be referenced by gateways and
+/// ingresses across all namespaces, which matches the typical multi-namespace deployment
+/// pattern for Aspire applications.
+/// </para>
+/// <para>
+/// Issuers are namespace-scoped <c>Issuer</c> resources are intentionally not modeled in the
+/// initial release. <see cref="CertManagerExtensions.AddIssuer"/> always produces a
+/// cluster-scoped <c>ClusterIssuer</c>.
+/// </para>
+/// </remarks>
+[AspireExport]
+public sealed class CertManagerIssuerResource : Resource, IResourceWithParent<CertManagerResource>
+{
+    /// <summary>
+    /// Initializes a new instance of <see cref="CertManagerIssuerResource"/>.
+    /// </summary>
+    /// <param name="name">The Aspire resource name. Also used as the <c>metadata.name</c> of
+    /// the generated <c>ClusterIssuer</c>, so it must be a valid DNS-1123 label.</param>
+    /// <param name="parent">The parent cert-manager installation.</param>
+    public CertManagerIssuerResource(string name, CertManagerResource parent) : base(name)
+    {
+        ArgumentNullException.ThrowIfNull(parent);
+
+        Parent = parent;
+    }
+
+    /// <summary>
+    /// Gets the parent cert-manager installation.
+    /// </summary>
+    public CertManagerResource Parent { get; }
+
+    /// <summary>
+    /// Gets or sets the issuer specification (ACME, self-signed, CA, ...).
+    /// </summary>
+    /// <remarks>
+    /// Set indirectly via <see cref="CertManagerExtensions.WithLetsEncryptProduction(IResourceBuilder{CertManagerIssuerResource}, string)"/>,
+    /// <see cref="CertManagerExtensions.WithLetsEncryptStaging(IResourceBuilder{CertManagerIssuerResource}, string)"/>,
+    /// or <see cref="CertManagerExtensions.WithAcmeServer(IResourceBuilder{CertManagerIssuerResource}, string, string)"/>.
+    /// Only one issuer kind may be configured per resource; the most recent <c>WithXxx</c>
+    /// call wins and replaces any prior spec.
+    /// </remarks>
+    internal CertManagerIssuerSpec? Spec { get; set; }
+
+    /// <summary>
+    /// Gets the configured ACME challenge solvers in the order they were added via
+    /// <see cref="CertManagerExtensions.WithHttp01Solver"/>.
+    /// </summary>
+    /// <remarks>
+    /// At least one solver is required for ACME issuers. The list is order-preserving so
+    /// users can declare priority across multiple solvers in a future release.
+    /// </remarks>
+    internal List<CertManagerSolverConfig> Solvers { get; } = [];
+}
+
+/// <summary>
+/// Base type for cert-manager issuer specifications. The subtype determines the
+/// <c>spec.*</c> structure of the generated <c>ClusterIssuer</c> manifest.
+/// </summary>
+internal abstract record CertManagerIssuerSpec;
+
+/// <summary>
+/// Configures the issuer as an ACME (RFC 8555) issuer such as Let's Encrypt.
+/// </summary>
+/// <param name="ServerUrl">The ACME directory URL.</param>
+/// <param name="Email">The contact email registered with the ACME account.</param>
+internal sealed record CertManagerAcmeIssuerSpec(
+    ReferenceExpression ServerUrl,
+    ReferenceExpression Email) : CertManagerIssuerSpec;
+
+/// <summary>
+/// Base type for an ACME challenge solver configuration.
+/// </summary>
+internal abstract record CertManagerSolverConfig;
+
+/// <summary>
+/// Configures an HTTP-01 ACME solver. cert-manager will provision an
+/// <c>HTTPRoute</c> (Gateway API) or <c>Ingress</c> at <c>/.well-known/acme-challenge/</c>
+/// to satisfy the ACME challenge.
+/// </summary>
+internal sealed record CertManagerHttp01SolverConfig : CertManagerSolverConfig;

--- a/src/Aspire.Hosting.Kubernetes/CertManagerIssuerResource.cs
+++ b/src/Aspire.Hosting.Kubernetes/CertManagerIssuerResource.cs
@@ -10,10 +10,16 @@ namespace Aspire.Hosting.Kubernetes;
 /// </summary>
 /// <remarks>
 /// <para>
-/// At publish time, an issuer emits a <c>cert-manager.io/v1 ClusterIssuer</c> manifest into
-/// the generated Helm chart output. Cluster-scoped issuers can be referenced by gateways and
-/// ingresses across all namespaces, which matches the typical multi-namespace deployment
-/// pattern for Aspire applications.
+/// At deploy time, an issuer is rendered to a <c>cert-manager.io/v1 ClusterIssuer</c>
+/// YAML document and applied to the cluster with <c>kubectl apply</c> after the
+/// cert-manager Helm chart is installed and its admission webhook is reachable. The
+/// manifest is not baked into the helm chart output; it is applied directly so the
+/// chart and its issuers can be managed and torn down independently.
+/// </para>
+/// <para>
+/// Cluster-scoped issuers can be referenced by gateways and ingresses across all
+/// namespaces, which matches the typical multi-namespace deployment pattern for
+/// Aspire applications.
 /// </para>
 /// <para>
 /// Namespace-scoped <c>Issuer</c> resources are intentionally not modeled in the initial

--- a/src/Aspire.Hosting.Kubernetes/CertManagerIssuerResource.cs
+++ b/src/Aspire.Hosting.Kubernetes/CertManagerIssuerResource.cs
@@ -16,9 +16,9 @@ namespace Aspire.Hosting.Kubernetes;
 /// pattern for Aspire applications.
 /// </para>
 /// <para>
-/// Issuers are namespace-scoped <c>Issuer</c> resources are intentionally not modeled in the
-/// initial release. <see cref="CertManagerExtensions.AddIssuer"/> always produces a
-/// cluster-scoped <c>ClusterIssuer</c>.
+/// Namespace-scoped <c>Issuer</c> resources are intentionally not modeled in the initial
+/// release. <see cref="CertManagerExtensions.AddIssuer"/> always produces a cluster-scoped
+/// <c>ClusterIssuer</c>.
 /// </para>
 /// </remarks>
 [AspireExport]

--- a/src/Aspire.Hosting.Kubernetes/CertManagerResource.cs
+++ b/src/Aspire.Hosting.Kubernetes/CertManagerResource.cs
@@ -20,7 +20,9 @@ namespace Aspire.Hosting.Kubernetes;
 /// Under the covers, <see cref="CertManagerExtensions.AddCertManager"/> installs cert-manager
 /// using a <see cref="KubernetesHelmChartResource"/> pointed at the upstream
 /// <c>oci://quay.io/jetstack/charts/cert-manager</c> chart, with CRDs and Gateway API
-/// support enabled. The chart resource is exposed via <see cref="HelmChart"/> for advanced
+/// support enabled. The chart resource is registered in the model under
+/// <c>"{name}-chart"</c> (so the cert-manager wrapper itself can keep the natural
+/// <c>"{name}"</c> identifier) and is exposed via <see cref="HelmChart"/> for advanced
 /// configuration.
 /// </para>
 /// </remarks>

--- a/src/Aspire.Hosting.Kubernetes/CertManagerResource.cs
+++ b/src/Aspire.Hosting.Kubernetes/CertManagerResource.cs
@@ -1,0 +1,77 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Aspire.Hosting.ApplicationModel;
+
+namespace Aspire.Hosting.Kubernetes;
+
+/// <summary>
+/// Represents a cert-manager installation on a Kubernetes environment.
+/// </summary>
+/// <remarks>
+/// <para>
+/// cert-manager is a Kubernetes add-on that provisions and renews X.509
+/// certificates from sources such as Let's Encrypt. Aspire models cert-manager
+/// as a typed resource so that issuer resources (<see cref="CertManagerIssuerResource"/>)
+/// can be parented to it and gateways/ingresses can reference issuers in a strongly-typed
+/// way via <c>WithTls(issuer)</c>.
+/// </para>
+/// <para>
+/// Under the covers, <see cref="CertManagerExtensions.AddCertManager"/> installs cert-manager
+/// using a <see cref="KubernetesHelmChartResource"/> pointed at the upstream
+/// <c>oci://quay.io/jetstack/charts/cert-manager</c> chart, with CRDs and Gateway API
+/// support enabled. The chart resource is exposed via <see cref="HelmChart"/> for advanced
+/// configuration.
+/// </para>
+/// </remarks>
+/// <example>
+/// <code>
+/// var aks = builder.AddAzureKubernetesEnvironment("aks");
+/// var certManager = aks.AddCertManager();
+///
+/// var letsencrypt = certManager.AddIssuer("letsencrypt-prod")
+///     .WithLetsEncryptProduction("ops@contoso.com")
+///     .WithHttp01Solver();
+///
+/// aks.AddGateway("gw")
+///    .WithRoute("/api", api.GetEndpoint("http"))
+///    .WithTls(letsencrypt);
+/// </code>
+/// </example>
+[AspireExport]
+public sealed class CertManagerResource : Resource, IResourceWithParent<KubernetesEnvironmentResource>
+{
+    /// <summary>
+    /// Initializes a new instance of <see cref="CertManagerResource"/>.
+    /// </summary>
+    /// <param name="name">The Aspire resource name for this cert-manager installation.</param>
+    /// <param name="environment">The parent Kubernetes environment.</param>
+    /// <param name="helmChart">The underlying Helm chart resource that installs cert-manager.</param>
+    public CertManagerResource(
+        string name,
+        KubernetesEnvironmentResource environment,
+        KubernetesHelmChartResource helmChart) : base(name)
+    {
+        ArgumentNullException.ThrowIfNull(environment);
+        ArgumentNullException.ThrowIfNull(helmChart);
+
+        Parent = environment;
+        HelmChart = helmChart;
+    }
+
+    /// <summary>
+    /// Gets the parent Kubernetes environment that hosts cert-manager.
+    /// </summary>
+    public KubernetesEnvironmentResource Parent { get; }
+
+    /// <summary>
+    /// Gets the underlying Helm chart resource used to install cert-manager.
+    /// Use this to apply additional Helm values, change the chart version, etc.
+    /// </summary>
+    public KubernetesHelmChartResource HelmChart { get; }
+
+    /// <summary>
+    /// Gets the issuers declared against this cert-manager installation.
+    /// </summary>
+    internal List<CertManagerIssuerResource> Issuers { get; } = [];
+}

--- a/src/Aspire.Hosting.Kubernetes/CertManagerResource.cs
+++ b/src/Aspire.Hosting.Kubernetes/CertManagerResource.cs
@@ -29,7 +29,7 @@ namespace Aspire.Hosting.Kubernetes;
 /// <example>
 /// <code>
 /// var aks = builder.AddAzureKubernetesEnvironment("aks");
-/// var certManager = aks.AddCertManager();
+/// var certManager = aks.AddCertManager("cert-manager");
 ///
 /// var letsencrypt = certManager.AddIssuer("letsencrypt-prod")
 ///     .WithLetsEncryptProduction("ops@contoso.com")
@@ -68,7 +68,9 @@ public sealed class CertManagerResource : Resource, IResourceWithParent<Kubernet
 
     /// <summary>
     /// Gets the underlying Helm chart resource used to install cert-manager.
-    /// Use this to apply additional Helm values, change the chart version, etc.
+    /// Use this to layer additional Helm values via <c>WithHelmChartValues</c> or to
+    /// inspect chart metadata. The chart name and version are fixed at construction
+    /// time and cannot be changed through this property.
     /// </summary>
     public KubernetesHelmChartResource HelmChart { get; }
 

--- a/src/Aspire.Hosting.Kubernetes/KubernetesEnvironmentResource.cs
+++ b/src/Aspire.Hosting.Kubernetes/KubernetesEnvironmentResource.cs
@@ -603,7 +603,7 @@ public sealed class KubernetesEnvironmentResource : Resource, IComputeEnvironmen
                 SecretName = await ResolveExpressionAsync(tls.SecretName, cancellationToken).ConfigureAwait(false),
             };
 
-            foreach (var host in tls.Hosts)
+            foreach (var host in ingressResource.Hostnames)
             {
                 tlsEntry.Hosts.Add(await ResolveExpressionAsync(host, cancellationToken).ConfigureAwait(false));
             }
@@ -622,7 +622,7 @@ public sealed class KubernetesEnvironmentResource : Resource, IComputeEnvironmen
 
             foreach (var tls in ingressResource.TlsConfigs)
             {
-                foreach (var host in tls.Hosts)
+                foreach (var host in ingressResource.Hostnames)
                 {
                     var resolvedHost = await ResolveExpressionAsync(host, cancellationToken).ConfigureAwait(false);
                     if (!hostsWithRules.Contains(resolvedHost))
@@ -767,7 +767,7 @@ public sealed class KubernetesEnvironmentResource : Resource, IComputeEnvironmen
         {
             var resolvedSecretName = await ResolveExpressionAsync(tls.SecretName, cancellationToken).ConfigureAwait(false);
 
-            if (tls.Hosts.Count == 0)
+            if (gatewayResource.Hostnames.Count == 0)
             {
                 // No hostnames specified — create an HTTPS listener without a hostname restriction.
                 // The hostname will be discovered from the Gateway's assigned address after deployment
@@ -793,7 +793,7 @@ public sealed class KubernetesEnvironmentResource : Resource, IComputeEnvironmen
             }
             else
             {
-                foreach (var host in tls.Hosts)
+                foreach (var host in gatewayResource.Hostnames)
                 {
                     var listenerName = tlsListenerIndex == 0 ? "https" : $"https-{tlsListenerIndex}";
                     tlsListenerIndex++;
@@ -924,7 +924,7 @@ public sealed class KubernetesEnvironmentResource : Resource, IComputeEnvironmen
         {
             foreach (var tls in gateway.TlsConfigs)
             {
-                foreach (var host in tls.Hosts)
+                foreach (var host in gateway.Hostnames)
                 {
                     tlsSecrets.Add((tls.SecretName, host));
                 }
@@ -935,7 +935,7 @@ public sealed class KubernetesEnvironmentResource : Resource, IComputeEnvironmen
         {
             foreach (var tls in ingress.TlsConfigs)
             {
-                foreach (var host in tls.Hosts)
+                foreach (var host in ingress.Hostnames)
                 {
                     tlsSecrets.Add((tls.SecretName, host));
                 }
@@ -959,7 +959,7 @@ public sealed class KubernetesEnvironmentResource : Resource, IComputeEnvironmen
         {
             foreach (var tls in gateway.TlsConfigs)
             {
-                if (tls.Hosts.Count == 0)
+                if (gateway.Hostnames.Count == 0)
                 {
                     results.Add((gateway, tls.SecretName));
                 }

--- a/src/Aspire.Hosting.Kubernetes/KubernetesEnvironmentResource.cs
+++ b/src/Aspire.Hosting.Kubernetes/KubernetesEnvironmentResource.cs
@@ -282,6 +282,29 @@ public sealed class KubernetesEnvironmentResource : Resource, IComputeEnvironmen
                 steps.Add(fqdnDiscoveryStep);
             }
 
+            // Pre-helm cleanup step — strip any stale non-helm Update entries from the
+            // managedFields of Gateways with TLS. Older Aspire builds patched the listener
+            // hostname with kubectl's default field manager ("kubectl-patch"); that Update
+            // entry persists in managedFields after later builds switched to
+            // --field-manager=helm, and helm's server-side apply still conflicts with the
+            // foreign Update ownership of .spec.listeners[name="https"].hostname. Removing
+            // the stale entry up front lets helm upgrade succeed without --force-conflicts.
+            // No-op on first deploy (the Gateway doesn't exist yet) and on clusters that
+            // were only ever managed by current code (no foreign managers found).
+            var gatewaysWithTls = CollectGatewaysWithTls(model, environment);
+            if (gatewaysWithTls.Count > 0)
+            {
+                var cleanupStep = new PipelineStep
+                {
+                    Name = $"gateway-field-cleanup-{environment.Name}",
+                    Description = "Removes stale foreign field-manager entries from existing Gateways so helm upgrade can re-apply",
+                    Action = ctx => CleanupGatewayFieldOwnershipAsync(ctx, environment, gatewaysWithTls)
+                };
+                cleanupStep.RequiredBy($"helm-deploy-{environment.Name}");
+                cleanupStep.DependsOn($"prepare-{environment.Name}");
+                steps.Add(cleanupStep);
+            }
+
             // Expand deployment target steps for compute resources (including dashboard if enabled)
             var resources = environment.DashboardEnabled && environment.Dashboard?.Resource is KubernetesAspireDashboardResource dashboard
                 ? [.. model.GetComputeResources(), dashboard]
@@ -970,6 +993,28 @@ public sealed class KubernetesEnvironmentResource : Resource, IComputeEnvironmen
     }
 
     /// <summary>
+    /// Collects Gateway resources that have any TLS configuration, regardless of whether
+    /// hostnames are explicitly set. Used by the pre-deploy cleanup step that strips
+    /// stale foreign field-manager ownership.
+    /// </summary>
+    private static List<KubernetesGatewayResource> CollectGatewaysWithTls(
+        DistributedApplicationModel model,
+        KubernetesEnvironmentResource environment)
+    {
+        var results = new List<KubernetesGatewayResource>();
+
+        foreach (var gateway in model.Resources.OfType<KubernetesGatewayResource>().Where(g => g.Parent == environment))
+        {
+            if (gateway.TlsConfigs.Count > 0)
+            {
+                results.Add(gateway);
+            }
+        }
+
+        return results;
+    }
+
+    /// <summary>
     /// Discovers the assigned FQDN from the Gateway's status, patches the HTTPS listener
     /// to include the hostname, and creates a bootstrap TLS secret so cert-manager can
     /// issue a real certificate.
@@ -1394,6 +1439,201 @@ public sealed class KubernetesEnvironmentResource : Resource, IComputeEnvironmen
             {
                 // Fall back to assuming index 1
                 indices.Add(1);
+            }
+        }
+
+        return indices;
+    }
+
+    /// <summary>
+    /// Pre-helm-deploy step: removes any non-helm Update entries from the
+    /// <c>managedFields</c> of existing Gateways with TLS configuration. Older Aspire
+    /// builds patched the listener hostname with kubectl's default field manager
+    /// (<c>kubectl-patch</c>), and that Update entry persists in the resource's
+    /// <c>managedFields</c> after later builds switched to <c>--field-manager=helm</c>.
+    /// Server-side Apply by helm conflicts with the foreign Update ownership of
+    /// <c>.spec.listeners[name="https"].hostname</c> until the foreign entry is removed,
+    /// so we strip it preemptively. No-op when the Gateway doesn't yet exist (first
+    /// deploy), when the cluster is unreachable, or when only helm-owned managedFields
+    /// entries are present.
+    /// See https://kubernetes.io/docs/reference/using-api/server-side-apply/#clearing-managedfields
+    /// </summary>
+    private static async Task CleanupGatewayFieldOwnershipAsync(
+        PipelineStepContext context,
+        KubernetesEnvironmentResource environment,
+        List<KubernetesGatewayResource> gateways)
+    {
+        var @namespace = "default";
+        if (environment.TryGetLastAnnotation<KubernetesNamespaceAnnotation>(out var nsAnnotation))
+        {
+            var resolvedNs = await nsAnnotation.Namespace.GetValueAsync(context.CancellationToken).ConfigureAwait(false);
+            if (!string.IsNullOrEmpty(resolvedNs))
+            {
+                @namespace = resolvedNs;
+            }
+        }
+
+        foreach (var gateway in gateways)
+        {
+            var gatewayName = gateway.Name.ToKubernetesResourceName();
+
+            var getArgs = $"get gateway {gatewayName} --namespace {@namespace} --show-managed-fields -o json --ignore-not-found";
+            if (environment.KubeConfigPath is not null)
+            {
+                getArgs += $" --kubeconfig \"{environment.KubeConfigPath}\"";
+            }
+
+            var stdout = new List<string>();
+            var (getResult, getDisposable) = ProcessUtil.Run(new ProcessSpec("kubectl")
+            {
+                Arguments = getArgs,
+                ThrowOnNonZeroReturnCode = false,
+                InheritEnv = true,
+                OnOutputData = stdout.Add,
+                OnErrorData = line => context.Logger.LogDebug("{Line}", line)
+            });
+
+            int getExit;
+            await using (getDisposable.ConfigureAwait(false))
+            {
+                getExit = (await getResult.WaitAsync(context.CancellationToken).ConfigureAwait(false)).ExitCode;
+            }
+
+            if (getExit != 0 || stdout.Count == 0)
+            {
+                // Gateway doesn't exist yet (first deploy) or kubectl error — nothing to do.
+                context.Logger.LogDebug("Gateway '{GatewayName}' not found or unreadable; skipping field-ownership cleanup.", gatewayName);
+                continue;
+            }
+
+            // Identify managedFields entries to remove: any Update operation by a manager
+            // other than "helm" that owns fields under .spec.listeners. We descend in
+            // reverse index order so JSON patch path indices remain stable.
+            List<int> indicesToRemove;
+            try
+            {
+                using var doc = System.Text.Json.JsonDocument.Parse(string.Join("", stdout));
+                indicesToRemove = FindForeignListenerOwnershipIndices(doc.RootElement);
+            }
+            catch (System.Text.Json.JsonException ex)
+            {
+                context.Logger.LogDebug(ex, "Could not parse Gateway '{GatewayName}' JSON for field-ownership cleanup.", gatewayName);
+                continue;
+            }
+
+            if (indicesToRemove.Count == 0)
+            {
+                continue;
+            }
+
+            // Build a JSON Patch removing each stale entry. Process highest index first so
+            // earlier removals don't shift the indices of pending operations.
+            var ops = indicesToRemove
+                .OrderByDescending(i => i)
+                .Select(i => new
+                {
+                    op = "remove",
+                    path = $"/metadata/managedFields/{i}"
+                });
+            var patchJson = System.Text.Json.JsonSerializer.Serialize(ops);
+
+            var patchTempDir = Directory.CreateTempSubdirectory(".aspire-gateway-fields");
+            try
+            {
+                var patchFilePath = Path.Combine(patchTempDir.FullName, "patch.json");
+                await File.WriteAllTextAsync(patchFilePath, patchJson, context.CancellationToken).ConfigureAwait(false);
+
+                var patchArgs = $"patch gateway {gatewayName} --namespace {@namespace} --type=json --patch-file \"{patchFilePath}\"";
+                if (environment.KubeConfigPath is not null)
+                {
+                    patchArgs += $" --kubeconfig \"{environment.KubeConfigPath}\"";
+                }
+
+                var (patchResult, patchDisposable) = ProcessUtil.Run(new ProcessSpec("kubectl")
+                {
+                    Arguments = patchArgs,
+                    ThrowOnNonZeroReturnCode = false,
+                    InheritEnv = true,
+                    OnOutputData = line => context.Logger.LogDebug("{Line}", line),
+                    OnErrorData = line => context.Logger.LogDebug("{Line}", line)
+                });
+
+                await using (patchDisposable.ConfigureAwait(false))
+                {
+                    var patchExit = (await patchResult.WaitAsync(context.CancellationToken).ConfigureAwait(false)).ExitCode;
+                    if (patchExit == 0)
+                    {
+                        context.Logger.LogInformation(
+                            "Removed {Count} stale field-manager entr{Suffix} from Gateway '{GatewayName}' to allow helm upgrade.",
+                            indicesToRemove.Count,
+                            indicesToRemove.Count == 1 ? "y" : "ies",
+                            gatewayName);
+                    }
+                    else
+                    {
+                        // Best-effort cleanup: if it fails, helm upgrade may still succeed
+                        // (the user may have an explicit hostname matching the existing one)
+                        // and if it doesn't, the failure surfaces clearly via helm.
+                        context.Logger.LogDebug(
+                            "Field-ownership cleanup on Gateway '{GatewayName}' returned exit code {ExitCode}; continuing.",
+                            gatewayName, patchExit);
+                    }
+                }
+            }
+            finally
+            {
+                DeleteTempDirSafely(patchTempDir, context.Logger);
+            }
+        }
+    }
+
+    /// <summary>
+    /// Returns the indices of <c>managedFields</c> entries that represent foreign
+    /// (non-helm) Update operations owning fields under <c>.spec.listeners</c>. These
+    /// entries are remnants of older builds that patched the Gateway with kubectl's
+    /// default field manager and conflict with helm's server-side apply on subsequent
+    /// upgrades.
+    /// </summary>
+    private static List<int> FindForeignListenerOwnershipIndices(System.Text.Json.JsonElement root)
+    {
+        var indices = new List<int>();
+
+        if (!root.TryGetProperty("metadata", out var metadata) ||
+            !metadata.TryGetProperty("managedFields", out var managedFields) ||
+            managedFields.ValueKind != System.Text.Json.JsonValueKind.Array)
+        {
+            return indices;
+        }
+
+        for (var i = 0; i < managedFields.GetArrayLength(); i++)
+        {
+            var entry = managedFields[i];
+
+            // Only target Update entries — Apply entries are part of normal SSA ownership
+            // and removing them would be destructive.
+            if (!entry.TryGetProperty("operation", out var op) ||
+                !string.Equals(op.GetString(), "Update", StringComparison.Ordinal))
+            {
+                continue;
+            }
+
+            // Helm's own entries are safe — both Apply and any incidental Update use the
+            // same manager name and therefore don't conflict with helm's next Apply.
+            if (entry.TryGetProperty("manager", out var mgr) &&
+                string.Equals(mgr.GetString(), "helm", StringComparison.Ordinal))
+            {
+                continue;
+            }
+
+            // Only remove entries that own a listener field — preserves status managers
+            // like alb-controller which legitimately update .status. The fieldsV1 path
+            // for a Gateway listener is shaped:
+            //   {"f:spec":{"f:listeners":{"k:{\"name\":\"https\"}":{"f:hostname":{}}}}}
+            if (entry.TryGetProperty("fieldsV1", out var fieldsV1) &&
+                fieldsV1.TryGetProperty("f:spec", out var fSpec) &&
+                fSpec.TryGetProperty("f:listeners", out _))
+            {
+                indices.Add(i);
             }
         }
 

--- a/src/Aspire.Hosting.Kubernetes/KubernetesEnvironmentResource.cs
+++ b/src/Aspire.Hosting.Kubernetes/KubernetesEnvironmentResource.cs
@@ -1066,11 +1066,18 @@ public sealed class KubernetesEnvironmentResource : Resource, IComputeEnvironmen
 
             if (string.IsNullOrEmpty(discoveredFqdn))
             {
-                context.Logger.LogWarning(
-                    "Gateway '{GatewayName}' was not assigned a hostname address after waiting. " +
-                    "TLS hostname discovery skipped. You may need to redeploy with an explicit hostname via WithHostname().",
-                    gatewayName);
-                continue;
+                // Hard failure rather than a logged warning: when the user has TLS configured
+                // without an explicit hostname, the deployment is only meaningful once the
+                // listener hostname is patched (cert-manager's gateway shim issues no
+                // certificate for a hostname-less HTTPS listener). Silently continuing
+                // produces an apparently-successful deploy that never serves valid TLS, which
+                // is far worse than failing visibly here. The user can fix this by either
+                // waiting for their controller to assign an address sooner or by passing an
+                // explicit hostname via WithHostname() / WithTls(hostname: ...).
+                throw new InvalidOperationException(
+                    $"Gateway '{gatewayName}' was not assigned a hostname address within the discovery timeout. " +
+                    "TLS hostname discovery cannot complete. Either retry the deploy (the controller may still be " +
+                    "provisioning the address) or set an explicit hostname via WithHostname().");
             }
 
             context.Logger.LogInformation(
@@ -1282,10 +1289,15 @@ public sealed class KubernetesEnvironmentResource : Resource, IComputeEnvironmen
         KubernetesEnvironmentResource environment,
         PipelineStepContext context)
     {
+        // AGC and other Gateway controllers can take several minutes to assign an address
+        // after the Gateway is created (AGC has been observed taking 5-10 minutes when AGC
+        // and the cluster are freshly provisioned in the same deploy). Allow up to ~15
+        // minutes (180 attempts × 5s) before giving up, matching the wait budget our E2E
+        // tests use for the same condition.
         var pipeline = new ResiliencePipelineBuilder<string?>()
             .AddRetry(new RetryStrategyOptions<string?>
             {
-                MaxRetryAttempts = 59,
+                MaxRetryAttempts = 179,
                 Delay = TimeSpan.FromSeconds(5),
                 BackoffType = DelayBackoffType.Constant,
                 ShouldHandle = new PredicateBuilder<string?>().HandleResult(r => r is null),

--- a/src/Aspire.Hosting.Kubernetes/KubernetesEnvironmentResource.cs
+++ b/src/Aspire.Hosting.Kubernetes/KubernetesEnvironmentResource.cs
@@ -1060,7 +1060,16 @@ public sealed class KubernetesEnvironmentResource : Resource, IComputeEnvironmen
                     var patchFilePath = Path.Combine(patchTempDir.FullName, "patch.json");
                     await File.WriteAllTextAsync(patchFilePath, patchJson, context.CancellationToken).ConfigureAwait(false);
 
-                    var patchArgs = $"patch gateway {gatewayName} --namespace {@namespace} --type=json --patch-file \"{patchFilePath}\"";
+                    // Use --field-manager=helm so Helm becomes the registered owner of the
+                    // listener hostname field. Without this, kubectl defaults the field manager
+                    // to "kubectl-patch", and a subsequent `helm upgrade` (which uses server-side
+                    // apply with field manager "helm") fails on the next deploy with:
+                    //   conflict with "kubectl-patch" using gateway.networking.k8s.io/v1:
+                    //   .spec.listeners[name="https"].hostname
+                    // Server-side apply Apply operations conflict with foreign Update operations
+                    // recorded in managedFields, but matching manager names do not conflict.
+                    // See https://kubernetes.io/docs/reference/using-api/server-side-apply/#conflicts
+                    var patchArgs = $"patch gateway {gatewayName} --namespace {@namespace} --type=json --field-manager=helm --patch-file \"{patchFilePath}\"";
                     if (environment.KubeConfigPath is not null)
                     {
                         patchArgs += $" --kubeconfig \"{environment.KubeConfigPath}\"";

--- a/src/Aspire.Hosting.Kubernetes/KubernetesGatewayExtensions.cs
+++ b/src/Aspire.Hosting.Kubernetes/KubernetesGatewayExtensions.cs
@@ -213,8 +213,7 @@ public static class KubernetesGatewayExtensions
         ArgumentException.ThrowIfNullOrEmpty(secretName);
 
         builder.Resource.TlsConfigs.Add(new GatewayTlsConfig(
-            SecretName: ReferenceExpression.Create($"{secretName}"),
-            Hosts: [.. builder.Resource.Hostnames]));
+            SecretName: ReferenceExpression.Create($"{secretName}")));
 
         return builder;
     }
@@ -234,8 +233,7 @@ public static class KubernetesGatewayExtensions
         ArgumentNullException.ThrowIfNull(secretName);
 
         builder.Resource.TlsConfigs.Add(new GatewayTlsConfig(
-            SecretName: ReferenceExpression.Create($"{secretName.Resource}"),
-            Hosts: [.. builder.Resource.Hostnames]));
+            SecretName: ReferenceExpression.Create($"{secretName.Resource}")));
 
         return builder;
     }
@@ -254,8 +252,7 @@ public static class KubernetesGatewayExtensions
         var secretName = $"{builder.Resource.Name}-tls";
 
         builder.Resource.TlsConfigs.Add(new GatewayTlsConfig(
-            SecretName: ReferenceExpression.Create($"{secretName}"),
-            Hosts: [.. builder.Resource.Hostnames]));
+            SecretName: ReferenceExpression.Create($"{secretName}")));
 
         return builder;
     }

--- a/src/Aspire.Hosting.Kubernetes/KubernetesGatewayResource.cs
+++ b/src/Aspire.Hosting.Kubernetes/KubernetesGatewayResource.cs
@@ -93,8 +93,10 @@ internal sealed record GatewayRouteConfig(
 
 /// <summary>
 /// Stores TLS configuration for a <see cref="KubernetesGatewayResource"/>.
-/// Configures an HTTPS listener on the Gateway with TLS termination.
+/// Configures an HTTPS listener on the Gateway with TLS termination. The set of hostnames
+/// the listener applies to is resolved from the gateway's <see cref="KubernetesGatewayResource.Hostnames"/>
+/// at manifest-emit time, so callers can register hostnames before or after WithTls without
+/// affecting the generated listener.
 /// </summary>
 internal sealed record GatewayTlsConfig(
-    ReferenceExpression SecretName,
-    List<ReferenceExpression> Hosts);
+    ReferenceExpression SecretName);

--- a/src/Aspire.Hosting.Kubernetes/KubernetesHelmChartExtensions.cs
+++ b/src/Aspire.Hosting.Kubernetes/KubernetesHelmChartExtensions.cs
@@ -312,11 +312,20 @@ public static partial class KubernetesHelmChartExtensions
             // See KubernetesHelmChartExtensions.WithForceConflicts for the full rationale.
             //
             // --server-side is REQUIRED alongside --force-conflicts: helm only registers
-            // the --force-conflicts flag in server-side-apply mode. Without --server-side,
-            // helm rejects the unknown flag with "Error: unknown flag: --force-conflicts"
-            // before it even attempts to install the chart. Both flags arrived together
-            // in helm v3.18.
-            arguments.Append(" --server-side --force-conflicts");
+            // the --force-conflicts flag in server-side-apply mode. Both flags arrived
+            // together in helm v3.18.
+            //
+            // We pass --server-side=true (with explicit value) rather than the bare
+            // --server-side flag because helm v4 changed --server-side from a bool flag
+            // to a string flag with "true"|"false"|"auto" values
+            // (https://github.com/helm/helm/pull/13649). The bare form would consume the
+            // following --force-conflicts as the flag value under v4, poisoning the
+            // release metadata with the literal string "--force-conflicts" and breaking
+            // every subsequent `helm upgrade` with
+            // "invalid/unknown release server-side apply method: --force-conflicts".
+            // The =true form parses identically under helm v3.18+ (where the bool flag
+            // also accepts an explicit value) and helm v4.
+            arguments.Append(" --server-side=true --force-conflicts");
         }
 
         if (environment.KubeConfigPath is not null)

--- a/src/Aspire.Hosting.Kubernetes/KubernetesIngressExtensions.cs
+++ b/src/Aspire.Hosting.Kubernetes/KubernetesIngressExtensions.cs
@@ -235,8 +235,7 @@ public static class KubernetesIngressExtensions
         ArgumentException.ThrowIfNullOrEmpty(secretName);
 
         builder.Resource.TlsConfigs.Add(new IngressTlsConfig(
-            SecretName: ReferenceExpression.Create($"{secretName}"),
-            Hosts: [.. builder.Resource.Hostnames]));
+            SecretName: ReferenceExpression.Create($"{secretName}")));
 
         return builder;
     }
@@ -256,8 +255,7 @@ public static class KubernetesIngressExtensions
         ArgumentNullException.ThrowIfNull(secretName);
 
         builder.Resource.TlsConfigs.Add(new IngressTlsConfig(
-            SecretName: ReferenceExpression.Create($"{secretName.Resource}"),
-            Hosts: [.. builder.Resource.Hostnames]));
+            SecretName: ReferenceExpression.Create($"{secretName.Resource}")));
 
         return builder;
     }
@@ -276,8 +274,7 @@ public static class KubernetesIngressExtensions
         var secretName = $"{builder.Resource.Name}-tls";
 
         builder.Resource.TlsConfigs.Add(new IngressTlsConfig(
-            SecretName: ReferenceExpression.Create($"{secretName}"),
-            Hosts: [.. builder.Resource.Hostnames]));
+            SecretName: ReferenceExpression.Create($"{secretName}")));
 
         return builder;
     }

--- a/src/Aspire.Hosting.Kubernetes/KubernetesIngressResource.cs
+++ b/src/Aspire.Hosting.Kubernetes/KubernetesIngressResource.cs
@@ -118,11 +118,13 @@ internal sealed record IngressRouteConfig(
     EndpointReference Endpoint);
 
 /// <summary>
-/// Stores TLS configuration for a <see cref="KubernetesIngressResource"/>.
+/// Stores TLS configuration for a <see cref="KubernetesIngressResource"/>. The set of hostnames
+/// covered by this TLS entry is resolved from the ingress's
+/// <see cref="KubernetesIngressResource.Hostnames"/> at manifest-emit time, so callers can register
+/// hostnames before or after WithTls without affecting the generated <c>spec.tls</c> entry.
 /// </summary>
 internal sealed record IngressTlsConfig(
-    ReferenceExpression SecretName,
-    List<ReferenceExpression> Hosts);
+    ReferenceExpression SecretName);
 
 /// <summary>
 /// Stores the default backend configuration for a <see cref="KubernetesIngressResource"/>.

--- a/tests/Aspire.Deployment.EndToEnd.Tests/AksAzureKubernetesEnvironmentCertManagerDeploymentTests.cs
+++ b/tests/Aspire.Deployment.EndToEnd.Tests/AksAzureKubernetesEnvironmentCertManagerDeploymentTests.cs
@@ -1,0 +1,369 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Aspire.Cli.Tests.Utils;
+using Aspire.Deployment.EndToEnd.Tests.Helpers;
+using Hex1b.Automation;
+using Xunit;
+
+namespace Aspire.Deployment.EndToEnd.Tests;
+
+/// <summary>
+/// End-to-end test for the typed cert-manager API on top of <c>AddAzureKubernetesEnvironment</c>:
+/// <c>aks.AddCertManager()</c> + <c>AddIssuer().WithLetsEncryptStaging(email).WithHttp01Solver()</c>
+/// combined with <c>gateway.WithTls(issuer)</c>. The Aspire deploy pipeline provisions the AKS
+/// cluster, ACR, VNet, AGC, installs the cert-manager Helm chart, applies the <c>ClusterIssuer</c>
+/// manifest, pre-creates the bootstrap TLS secret, and patches the discovered AGC FQDN onto
+/// the gateway's HTTPS listener. The test then waits for cert-manager to complete the HTTP-01
+/// challenge against the AGC FQDN and replace the placeholder cert with a real one, and
+/// verifies the gateway is serving a Let's Encrypt-issued certificate.
+///
+/// Uses Let's Encrypt <em>staging</em> (not production) because production has strict per-domain
+/// rate limits (~5 certs / week) that nightly + on-demand E2E runs would burn through quickly.
+/// Staging issues real ACME certs from a CA that identifies itself as "(STAGING) Let's Encrypt",
+/// which still proves the full HTTP-01 + Gateway API solver flow end-to-end.
+/// </summary>
+public sealed class AksAzureKubernetesEnvironmentCertManagerDeploymentTests(ITestOutputHelper output)
+{
+    // Provisioning AKS + AGC + cert-manager takes ~15 min, deploy + cert issuance another
+    // ~10 min in the worst case (ACME order can take a few minutes once the listener is patched).
+    private static readonly TimeSpan s_testTimeout = TimeSpan.FromMinutes(75);
+
+    [Fact]
+    public async Task DeployApiWithCertManagerToAzureKubernetesEnvironment()
+    {
+        using var cts = new CancellationTokenSource(s_testTimeout);
+        using var linkedCts = CancellationTokenSource.CreateLinkedTokenSource(
+            cts.Token, TestContext.Current.CancellationToken);
+        var cancellationToken = linkedCts.Token;
+
+        await DeployApiWithCertManagerToAzureKubernetesEnvironmentCore(cancellationToken);
+    }
+
+    private async Task DeployApiWithCertManagerToAzureKubernetesEnvironmentCore(CancellationToken cancellationToken)
+    {
+        var subscriptionId = AzureAuthenticationHelpers.TryGetSubscriptionId();
+        if (string.IsNullOrEmpty(subscriptionId))
+        {
+            Assert.Skip("Azure subscription not configured. Set ASPIRE_DEPLOYMENT_TEST_SUBSCRIPTION.");
+        }
+
+        if (!AzureAuthenticationHelpers.IsAzureAuthAvailable())
+        {
+            if (DeploymentE2ETestHelpers.IsRunningInCI)
+            {
+                Assert.Fail("Azure authentication not available in CI. Check OIDC configuration.");
+            }
+            else
+            {
+                Assert.Skip("Azure authentication not available. Run 'az login' to authenticate.");
+            }
+        }
+
+        var workspace = TemporaryWorkspace.Create(output);
+        var startTime = DateTime.UtcNow;
+        var deploymentUrls = new Dictionary<string, string>();
+        var resourceGroupName = DeploymentE2ETestHelpers.GenerateResourceGroupName("akscm");
+        var projectName = "AksCertManager";
+
+        // ACME registration email. Staging accepts any well-formed address, so we use a
+        // dedicated one that's clearly identifiable as automation.
+        const string acmeEmail = "aspire-e2e-test@microsoft.com";
+
+        output.WriteLine($"Test: {nameof(DeployApiWithCertManagerToAzureKubernetesEnvironment)}");
+        output.WriteLine($"Project Name: {projectName}");
+        output.WriteLine($"Resource Group: {resourceGroupName}");
+        output.WriteLine($"Subscription: {subscriptionId[..8]}...");
+        output.WriteLine($"Workspace: {workspace.WorkspaceRoot.FullName}");
+
+        try
+        {
+            using var terminal = DeploymentE2ETestHelpers.CreateTestTerminal();
+            var pendingRun = terminal.RunAsync(cancellationToken);
+
+            var counter = new SequenceCounter();
+            var auto = new Hex1bTerminalAutomator(terminal, defaultTimeout: TimeSpan.FromSeconds(500));
+
+            output.WriteLine("Step 1: Preparing environment...");
+            await auto.PrepareEnvironmentAsync(workspace, counter);
+
+            await auto.InstallCurrentBuildAspireCliAsync(counter, output);
+
+            output.WriteLine("Step 3: Creating Aspire starter project...");
+            await auto.AspireNewAsync(projectName, counter, useRedisCache: false);
+
+            output.WriteLine("Step 4: Navigating to project directory...");
+            await auto.TypeAsync($"cd {projectName}");
+            await auto.EnterAsync();
+            await auto.WaitForSuccessPromptAsync(counter);
+
+            output.WriteLine("Step 5: Adding Azure Kubernetes hosting package...");
+            await auto.TypeAsync("aspire add Aspire.Hosting.Azure.Kubernetes");
+            await auto.EnterAsync();
+            await auto.WaitForAspireAddCompletionAsync(counter);
+
+            // Patch AppHost.cs with AddAzureKubernetesEnvironment + AddLoadBalancer + AddCertManager
+            // + AddIssuer + WithTls(issuer). This is the cert-manager-enabled variant of
+            // AksAzureKubernetesEnvironmentGatewayDeploymentTests' AppHost — the ONLY differences
+            // from that test's AppHost are the AddCertManager/AddIssuer calls and replacing the
+            // gateway's plain "/" route with WithTls(letsEncrypt).
+            var projectDir = Path.Combine(workspace.WorkspaceRoot.FullName, projectName);
+            var appHostDir = Path.Combine(projectDir, $"{projectName}.AppHost");
+            var appHostFilePath = Path.Combine(appHostDir, "AppHost.cs");
+
+            output.WriteLine($"Step 6: Modifying AppHost.cs at: {appHostFilePath}");
+
+            var content = File.ReadAllText(appHostFilePath);
+
+            const string buildRunPattern = "builder.Build().Run();";
+            const string replacement = """
+// VNet layout chosen to avoid the AKS default service CIDR (10.0.0.0/16):
+//   10.100.0.0/16   - vnet
+//     10.100.0.0/22 - aks node pool subnet
+//     10.100.4.0/24 - AGC frontend subnet (delegated to ServiceNetworking by AddLoadBalancer)
+var vnet = builder.AddAzureVirtualNetwork("vnet", "10.100.0.0/16");
+var aksSubnet = vnet.AddSubnet("aks-nodes", "10.100.0.0/22");
+var albSubnet = vnet.AddSubnet("alb-public", "10.100.4.0/24");
+
+var aks = builder.AddAzureKubernetesEnvironment("aks")
+    .WithSubnet(aksSubnet)
+    .WithSystemNodePool("Standard_D2as_v5");
+aks.AddNodePool("workload", "Standard_D2as_v5", minCount: 1, maxCount: 3);
+
+var publicLb = aks.AddLoadBalancer("public", albSubnet);
+
+// Email registered with the staging ACME endpoint. Passed as a parameter so the test
+// supplies it via Parameters__acmeemail without burning it into AppHost source.
+var acmeEmail = builder.AddParameter("acmeemail");
+
+// Install cert-manager via the typed API and declare a Let's Encrypt STAGING ClusterIssuer.
+// Staging is intentional — production rate limits would block repeat E2E runs. The
+// staging endpoint exercises the same HTTP-01 + Gateway API solver flow end-to-end.
+var certManager = aks.AddCertManager();
+var letsEncrypt = certManager.AddIssuer("letsencrypt-staging")
+    .WithLetsEncryptStaging(acmeEmail)
+    .WithHttp01Solver();
+
+// Gateway with HTTPS listener. WithTls(letsEncrypt) creates the listener AND adds the
+// cert-manager.io/cluster-issuer annotation in one call. Once AGC assigns the gateway
+// its FQDN, the tls-fqdn-discovery pipeline step patches it onto the listener and the
+// cm-issuer-apply step ensures the ClusterIssuer is present so cert-manager can complete
+// the HTTP-01 challenge against the AGC FQDN.
+aks.AddGateway("api-gw")
+    .WithLoadBalancer(publicLb)
+    .WithRoute("/", apiService.GetEndpoint("http"))
+    .WithTls(letsEncrypt);
+
+builder.Build().Run();
+""";
+
+            content = content.Replace(buildRunPattern, replacement);
+
+            const string pragmaBlock =
+                "#pragma warning disable ASPIREPIPELINES001\n" +
+                "#pragma warning disable ASPIRECOMPUTE003\n" +
+                "#pragma warning disable ASPIREAZURE003\n";
+
+            if (!content.Contains("#pragma warning disable ASPIREPIPELINES001"))
+            {
+                content = pragmaBlock + content;
+            }
+
+            File.WriteAllText(appHostFilePath, content);
+            output.WriteLine("Modified AppHost.cs with AddCertManager + AddIssuer + WithTls(issuer)");
+
+            output.WriteLine("Step 7: Navigating to AppHost directory...");
+            await auto.TypeAsync($"cd {projectName}.AppHost");
+            await auto.EnterAsync();
+            await auto.WaitForSuccessPromptAsync(counter);
+
+            output.WriteLine("Step 8: Setting deployment environment variables...");
+            await auto.TypeAsync(
+                $"unset ASPIRE_PLAYGROUND && " +
+                $"export AZURE__LOCATION=westus3 && " +
+                $"export AZURE__RESOURCEGROUP={resourceGroupName} && " +
+                $"export Parameters__acmeemail={acmeEmail}");
+            await auto.EnterAsync();
+            await auto.WaitForSuccessPromptAsync(counter);
+
+            // The deploy pipeline provisions AKS + AGC, installs the cert-manager helm chart,
+            // applies the ClusterIssuer, and pre-creates the bootstrap TLS secret. Use a
+            // generous timeout to cover the AKS+AGC bring-up window.
+            output.WriteLine("Step 9: Starting AKS + cert-manager deployment (15-20 min)...");
+            await auto.TypeAsync("aspire deploy --clear-cache");
+            await auto.EnterAsync();
+            await auto.WaitForPipelineSuccessAsync(timeout: TimeSpan.FromMinutes(40));
+            await auto.WaitForSuccessPromptAsync(counter, TimeSpan.FromMinutes(2));
+
+            output.WriteLine("Step 10: Getting AKS credentials...");
+            await auto.TypeAsync(
+                $"AKS_NAME=$(az aks list -g {resourceGroupName} --query '[0].name' -o tsv) && " +
+                $"az aks get-credentials -g {resourceGroupName} -n $AKS_NAME --overwrite-existing");
+            await auto.EnterAsync();
+            await auto.WaitForSuccessPromptAsync(counter, TimeSpan.FromSeconds(60));
+
+            output.WriteLine("Step 11: Waiting for pods to be ready...");
+            await auto.TypeAsync("kubectl wait --for=condition=ready pod --all --all-namespaces --timeout=300s 2>/dev/null || true");
+            await auto.EnterAsync();
+            await auto.WaitForSuccessPromptAsync(counter, TimeSpan.FromMinutes(6));
+
+            await auto.TypeAsync(
+                "kubectl get pods --all-namespaces && " +
+                "kubectl get gateway --all-namespaces && " +
+                "kubectl get clusterissuer && " +
+                "kubectl get certificate --all-namespaces");
+            await auto.EnterAsync();
+            await auto.WaitForSuccessPromptAsync(counter, TimeSpan.FromSeconds(30));
+
+            // Verify the ClusterIssuer the cm-issuer-apply pipeline step was supposed to create
+            // is present and Ready. Without this, cert-manager's CertificateRequest would sit
+            // in 'IssuerNotFound' indefinitely.
+            output.WriteLine("Step 12: Verifying ClusterIssuer is Ready...");
+            await auto.TypeAsync(
+                "OK=0; for i in $(seq 1 30); do " +
+                "READY=$(kubectl get clusterissuer letsencrypt-staging -o jsonpath='{.status.conditions[?(@.type==\"Ready\")].status}' 2>/dev/null); " +
+                "[ \"$READY\" = \"True\" ] && echo 'ClusterIssuer Ready' && OK=1 && break; " +
+                "echo \"Attempt $i: ClusterIssuer status=$READY, waiting...\"; sleep 5; done; " +
+                "[ \"$OK\" = \"1\" ] || { echo 'FAIL: letsencrypt-staging ClusterIssuer never became Ready'; kubectl describe clusterissuer letsencrypt-staging; exit 1; }");
+            await auto.EnterAsync();
+            await auto.WaitForSuccessPromptAsync(counter, TimeSpan.FromMinutes(3));
+
+            output.WriteLine("Step 13: Discovering gateway namespace...");
+            await auto.TypeAsync(
+                "NS=$(kubectl get gateway --all-namespaces -o jsonpath='{range .items[?(@.metadata.name==\"api-gw\")]}{.metadata.namespace}{end}') && " +
+                "echo \"Namespace: $NS\"");
+            await auto.EnterAsync();
+            await auto.WaitForSuccessPromptAsync(counter, TimeSpan.FromSeconds(30));
+
+            // Wait for AGC to assign the gateway an FQDN. The Bug 2 fix pre-creates the
+            // bootstrap TLS secret so AGC will program the gateway even before cert-manager
+            // has issued a real cert; without that fix this would deadlock.
+            output.WriteLine("Step 14: Waiting for AGC to assign gateway FQDN (up to 15 min)...");
+            await auto.TypeAsync(
+                "OK=0; for i in $(seq 1 90); do " +
+                "FQDN=$(kubectl get gateway api-gw -n $NS -o jsonpath='{.status.addresses[0].value}' 2>/dev/null); " +
+                "[ -n \"$FQDN\" ] && echo \"Gateway FQDN: $FQDN\" && OK=1 && break; " +
+                "echo \"Attempt $i: waiting for AGC FQDN...\"; sleep 10; done; " +
+                "[ \"$OK\" = \"1\" ] || { echo 'FAIL: gateway never received AGC FQDN'; exit 1; }");
+            await auto.EnterAsync();
+            await auto.WaitForSuccessPromptAsync(counter, TimeSpan.FromMinutes(16));
+
+            // Wait for cert-manager to complete the HTTP-01 challenge and replace the
+            // bootstrap placeholder cert with a real (staging) Let's Encrypt cert.
+            output.WriteLine("Step 15: Waiting for cert-manager to issue the certificate (up to 10 min)...");
+            await auto.TypeAsync(
+                "OK=0; for i in $(seq 1 60); do " +
+                "READY=$(kubectl get certificate -n $NS api-gw-tls -o jsonpath='{.status.conditions[?(@.type==\"Ready\")].status}' 2>/dev/null); " +
+                "[ \"$READY\" = \"True\" ] && echo 'Certificate Ready' && OK=1 && break; " +
+                "echo \"Attempt $i: certificate Ready=$READY, waiting...\"; sleep 10; done; " +
+                "[ \"$OK\" = \"1\" ] || { echo 'FAIL: certificate never became Ready'; " +
+                "kubectl describe certificate -n $NS api-gw-tls; " +
+                "kubectl get challenge,order -n $NS; " +
+                "exit 1; }");
+            await auto.EnterAsync();
+            await auto.WaitForSuccessPromptAsync(counter, TimeSpan.FromMinutes(11));
+
+            // Probe the served cert and assert the issuer string contains "Let's Encrypt".
+            // The CA chain on a staging cert is "(STAGING) Let's Encrypt"; on production it's
+            // plain "Let's Encrypt" — both match a case-insensitive grep on "let's encrypt".
+            //
+            // Using openssl s_client (with -servername for SNI) rather than curl because curl
+            // would refuse the staging cert at TLS layer; we want the cert details regardless
+            // of trust. AGC also takes a few seconds to load the new cert into the data plane
+            // after the secret is updated, so retry the probe.
+            output.WriteLine("Step 16: Verifying served cert is from Let's Encrypt...");
+            await auto.TypeAsync(
+                "FQDN=$(kubectl get gateway api-gw -n $NS -o jsonpath='{.status.addresses[0].value}') && " +
+                "echo \"Probing https://$FQDN\" && " +
+                "OK=0; for i in $(seq 1 24); do sleep 5; " +
+                "ISSUER=$(echo | openssl s_client -connect $FQDN:443 -servername $FQDN 2>/dev/null | " +
+                "openssl x509 -noout -issuer 2>/dev/null); " +
+                "echo \"Attempt $i: issuer=$ISSUER\"; " +
+                "echo \"$ISSUER\" | grep -i \"let's encrypt\" >/dev/null && " +
+                "echo \"PASS: Let's Encrypt cert observed: $ISSUER\" && OK=1 && break; " +
+                "done; " +
+                "[ \"$OK\" = \"1\" ] || { echo 'FAIL: served cert is not from Let'\\''s Encrypt'; exit 1; }");
+            await auto.EnterAsync();
+            await auto.WaitForSuccessPromptAsync(counter, TimeSpan.FromMinutes(3));
+
+            // Verify HTTPS actually serves the apiservice. Using -k (insecure) because the
+            // staging Let's Encrypt CA isn't in the system trust store; the previous step
+            // already proved cryptographic identity (issuer == Let's Encrypt).
+            output.WriteLine("Step 17: Verifying https://<fqdn>/weatherforecast returns 200...");
+            await auto.TypeAsync(
+                "FQDN=$(kubectl get gateway api-gw -n $NS -o jsonpath='{.status.addresses[0].value}') && " +
+                "OK=0; for i in $(seq 1 30); do sleep 5; " +
+                "S=$(curl -kso /dev/null -w '%{http_code}' -m 10 https://$FQDN/weatherforecast 2>/dev/null); " +
+                "[ \"$S\" = \"200\" ] && echo \"HTTPS $S OK\" && OK=1 && break; " +
+                "echo \"Attempt $i: HTTPS $S\"; done; " +
+                "[ \"$OK\" = \"1\" ] || { echo 'FAIL: HTTPS endpoint never returned 200'; exit 1; }");
+            await auto.EnterAsync();
+            await auto.WaitForSuccessPromptAsync(counter, TimeSpan.FromMinutes(4));
+
+            output.WriteLine("Step 18: Destroying deployment...");
+            await auto.AspireDestroyAsync(counter);
+
+            await auto.TypeAsync("exit");
+            await auto.EnterAsync();
+
+            await pendingRun;
+
+            var duration = DateTime.UtcNow - startTime;
+            output.WriteLine($"Deployment completed in {duration}");
+
+            DeploymentReporter.ReportDeploymentSuccess(
+                nameof(DeployApiWithCertManagerToAzureKubernetesEnvironment),
+                resourceGroupName,
+                deploymentUrls,
+                duration);
+
+            output.WriteLine("✅ Test passed - cert-manager issued a Let's Encrypt cert via HTTP-01!");
+        }
+        catch (Exception ex)
+        {
+            var duration = DateTime.UtcNow - startTime;
+            output.WriteLine($"❌ Test failed after {duration}: {ex.Message}");
+
+            DeploymentReporter.ReportDeploymentFailure(
+                nameof(DeployApiWithCertManagerToAzureKubernetesEnvironment),
+                resourceGroupName,
+                ex.Message,
+                ex.StackTrace);
+
+            throw;
+        }
+        finally
+        {
+            output.WriteLine($"Triggering cleanup of resource group: {resourceGroupName}");
+            TriggerCleanupResourceGroup(resourceGroupName);
+        }
+    }
+
+    private void TriggerCleanupResourceGroup(string resourceGroupName)
+    {
+        using var process = new System.Diagnostics.Process
+        {
+            StartInfo = new System.Diagnostics.ProcessStartInfo
+            {
+                FileName = "az",
+                Arguments = $"group delete --name {resourceGroupName} --yes --no-wait",
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+                CreateNoWindow = true
+            }
+        };
+
+        try
+        {
+            process.Start();
+            output.WriteLine($"Cleanup triggered for resource group: {resourceGroupName}");
+            DeploymentReporter.ReportCleanupStatus(resourceGroupName, success: true, "Cleanup triggered (fire-and-forget)");
+        }
+        catch (Exception ex)
+        {
+            output.WriteLine($"Failed to trigger cleanup: {ex.Message}");
+            DeploymentReporter.ReportCleanupStatus(resourceGroupName, success: false, ex.Message);
+        }
+    }
+}

--- a/tests/Aspire.Deployment.EndToEnd.Tests/AksAzureKubernetesEnvironmentCertManagerDeploymentTests.cs
+++ b/tests/Aspire.Deployment.EndToEnd.Tests/AksAzureKubernetesEnvironmentCertManagerDeploymentTests.cs
@@ -301,7 +301,20 @@ builder.Build().Run();
             await auto.EnterAsync();
             await auto.WaitForSuccessPromptAsync(counter, TimeSpan.FromMinutes(4));
 
-            output.WriteLine("Step 18: Destroying deployment...");
+            // Re-deploy without --clear-cache to exercise the helm UPGRADE path on top of the
+            // already-installed cert-manager release. This guards against bugs that only manifest
+            // on the second deploy — e.g. helm CLI flag parsing changes between major versions
+            // (helm v4 made --server-side a string flag, which would silently consume the
+            // following --force-conflicts as its value during install and then fail every
+            // subsequent upgrade with "invalid/unknown release server-side apply method:
+            // --force-conflicts"). The first deploy alone would not catch this.
+            output.WriteLine("Step 18: Re-deploying to validate helm upgrade idempotency...");
+            await auto.TypeAsync("aspire deploy");
+            await auto.EnterAsync();
+            await auto.WaitForPipelineSuccessAsync(timeout: TimeSpan.FromMinutes(20));
+            await auto.WaitForSuccessPromptAsync(counter, TimeSpan.FromMinutes(2));
+
+            output.WriteLine("Step 19: Destroying deployment...");
             await auto.AspireDestroyAsync(counter);
 
             await auto.TypeAsync("exit");

--- a/tests/Aspire.Deployment.EndToEnd.Tests/AksAzureKubernetesEnvironmentCertManagerDeploymentTests.cs
+++ b/tests/Aspire.Deployment.EndToEnd.Tests/AksAzureKubernetesEnvironmentCertManagerDeploymentTests.cs
@@ -10,7 +10,7 @@ namespace Aspire.Deployment.EndToEnd.Tests;
 
 /// <summary>
 /// End-to-end test for the typed cert-manager API on top of <c>AddAzureKubernetesEnvironment</c>:
-/// <c>aks.AddCertManager()</c> + <c>AddIssuer().WithLetsEncryptStaging(email).WithHttp01Solver()</c>
+/// <c>aks.AddCertManager("cert-manager")</c> + <c>AddIssuer().WithLetsEncryptStaging(email).WithHttp01Solver()</c>
 /// combined with <c>gateway.WithTls(issuer)</c>. The Aspire deploy pipeline provisions the AKS
 /// cluster, ACR, VNet, AGC, installs the cert-manager Helm chart, applies the <c>ClusterIssuer</c>
 /// manifest, pre-creates the bootstrap TLS secret, and patches the discovered AGC FQDN onto
@@ -139,7 +139,7 @@ var acmeEmail = builder.AddParameter("acmeemail");
 // Install cert-manager via the typed API and declare a Let's Encrypt STAGING ClusterIssuer.
 // Staging is intentional — production rate limits would block repeat E2E runs. The
 // staging endpoint exercises the same HTTP-01 + Gateway API solver flow end-to-end.
-var certManager = aks.AddCertManager();
+var certManager = aks.AddCertManager("cert-manager");
 var letsEncrypt = certManager.AddIssuer("letsencrypt-staging")
     .WithLetsEncryptStaging(acmeEmail)
     .WithHttp01Solver();
@@ -235,9 +235,10 @@ builder.Build().Run();
             await auto.EnterAsync();
             await auto.WaitForSuccessPromptAsync(counter, TimeSpan.FromSeconds(30));
 
-            // Wait for AGC to assign the gateway an FQDN. The Bug 2 fix pre-creates the
-            // bootstrap TLS secret so AGC will program the gateway even before cert-manager
-            // has issued a real cert; without that fix this would deadlock.
+            // Wait for AGC to assign the gateway an FQDN. The hosting integration pre-creates
+            // a self-signed bootstrap TLS secret so AGC will program the gateway listener even
+            // before cert-manager has issued the real certificate; without it the listener
+            // would deadlock waiting for a secret that doesn't exist yet.
             output.WriteLine("Step 14: Waiting for AGC to assign gateway FQDN (up to 15 min)...");
             await auto.TypeAsync(
                 "OK=0; for i in $(seq 1 90); do " +

--- a/tests/Aspire.Deployment.EndToEnd.Tests/AksAzureKubernetesEnvironmentCertManagerTypeScriptDeploymentTests.cs
+++ b/tests/Aspire.Deployment.EndToEnd.Tests/AksAzureKubernetesEnvironmentCertManagerTypeScriptDeploymentTests.cs
@@ -290,7 +290,20 @@ await builder.build().run();
             await auto.EnterAsync();
             await auto.WaitForSuccessPromptAsync(counter, TimeSpan.FromMinutes(4));
 
-            output.WriteLine("Step 17: Destroying deployment...");
+            // Re-deploy without --clear-cache to exercise the helm UPGRADE path on top of the
+            // already-installed cert-manager release. This guards against bugs that only manifest
+            // on the second deploy — e.g. helm CLI flag parsing changes between major versions
+            // (helm v4 made --server-side a string flag, which would silently consume the
+            // following --force-conflicts as its value during install and then fail every
+            // subsequent upgrade with "invalid/unknown release server-side apply method:
+            // --force-conflicts"). The first deploy alone would not catch this.
+            output.WriteLine("Step 17: Re-deploying to validate helm upgrade idempotency...");
+            await auto.TypeAsync("aspire deploy");
+            await auto.EnterAsync();
+            await auto.WaitForPipelineSuccessAsync(timeout: TimeSpan.FromMinutes(20));
+            await auto.WaitForSuccessPromptAsync(counter, TimeSpan.FromMinutes(2));
+
+            output.WriteLine("Step 18: Destroying deployment...");
             await auto.AspireDestroyAsync(counter);
 
             await auto.TypeAsync("exit");

--- a/tests/Aspire.Deployment.EndToEnd.Tests/AksAzureKubernetesEnvironmentCertManagerTypeScriptDeploymentTests.cs
+++ b/tests/Aspire.Deployment.EndToEnd.Tests/AksAzureKubernetesEnvironmentCertManagerTypeScriptDeploymentTests.cs
@@ -1,0 +1,359 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Aspire.Cli.Tests.Utils;
+using Aspire.Deployment.EndToEnd.Tests.Helpers;
+using Hex1b.Automation;
+using Xunit;
+
+namespace Aspire.Deployment.EndToEnd.Tests;
+
+/// <summary>
+/// TypeScript-AppHost variant of the AKS cert-manager E2E test. Mirrors
+/// <see cref="AksAzureKubernetesEnvironmentCertManagerDeploymentTests"/> but uses the
+/// TypeScript Express/React starter (<c>aspire new</c> --&gt; <c>Starter App (Express/React, TypeScript AppHost)</c>)
+/// and patches <c>apphost.ts</c> to wire <c>addAzureKubernetesEnvironment</c> +
+/// <c>addCertManager</c> + <c>addIssuer().withLetsEncryptProductionParam(acmeEmail).withHttp01Solver()</c>
+/// + <c>gateway.withGatewayTlsIssuer(letsEncrypt)</c> around the Express API.
+///
+/// Proves that the cert-manager API surface generated for TypeScript via <c>[AspireExport]</c>
+/// works end-to-end against a real AKS cluster (this complements the polyglot type-check
+/// validation in <c>tests/PolyglotAppHosts/Aspire.Hosting.Kubernetes/TypeScript/apphost.ts</c>).
+///
+/// Uses Let's Encrypt <em>production</em> so the served cert chains to a publicly-trusted root
+/// (mirrors a realistic deployment). Production is rate-limited (50 certs / registered
+/// domain / week, 5 duplicate certs / week — see https://letsencrypt.org/docs/rate-limits/),
+/// so re-runs that change the gateway FQDN consume quota; throttle CI scheduling
+/// accordingly.
+/// </summary>
+public sealed class AksAzureKubernetesEnvironmentCertManagerTypeScriptDeploymentTests(ITestOutputHelper output)
+{
+    // Same budget as the C# variant — AKS + AGC + cert-manager bring-up plus ACME challenge
+    // can take 25-30 minutes in the worst case.
+    private static readonly TimeSpan s_testTimeout = TimeSpan.FromMinutes(75);
+
+    [Fact]
+    public async Task DeployTypeScriptApiWithCertManagerToAzureKubernetesEnvironment()
+    {
+        using var cts = new CancellationTokenSource(s_testTimeout);
+        using var linkedCts = CancellationTokenSource.CreateLinkedTokenSource(
+            cts.Token, TestContext.Current.CancellationToken);
+        var cancellationToken = linkedCts.Token;
+
+        await DeployTypeScriptApiWithCertManagerToAzureKubernetesEnvironmentCore(cancellationToken);
+    }
+
+    private async Task DeployTypeScriptApiWithCertManagerToAzureKubernetesEnvironmentCore(CancellationToken cancellationToken)
+    {
+        var subscriptionId = AzureAuthenticationHelpers.TryGetSubscriptionId();
+        if (string.IsNullOrEmpty(subscriptionId))
+        {
+            Assert.Skip("Azure subscription not configured. Set ASPIRE_DEPLOYMENT_TEST_SUBSCRIPTION.");
+        }
+
+        if (!AzureAuthenticationHelpers.IsAzureAuthAvailable())
+        {
+            if (DeploymentE2ETestHelpers.IsRunningInCI)
+            {
+                Assert.Fail("Azure authentication not available in CI. Check OIDC configuration.");
+            }
+            else
+            {
+                Assert.Skip("Azure authentication not available. Run 'az login' to authenticate.");
+            }
+        }
+
+        var workspace = TemporaryWorkspace.Create(output);
+        var startTime = DateTime.UtcNow;
+        var deploymentUrls = new Dictionary<string, string>();
+        var resourceGroupName = DeploymentE2ETestHelpers.GenerateResourceGroupName("akscmts");
+        var projectName = "AksCertManagerTs";
+
+        // ACME registration email — used for Let's Encrypt account binding and renewal warnings.
+        const string acmeEmail = "aspire-e2e-test@microsoft.com";
+
+        output.WriteLine($"Test: {nameof(DeployTypeScriptApiWithCertManagerToAzureKubernetesEnvironment)}");
+        output.WriteLine($"Project Name: {projectName}");
+        output.WriteLine($"Resource Group: {resourceGroupName}");
+        output.WriteLine($"Subscription: {subscriptionId[..8]}...");
+        output.WriteLine($"Workspace: {workspace.WorkspaceRoot.FullName}");
+
+        try
+        {
+            using var terminal = DeploymentE2ETestHelpers.CreateTestTerminal();
+            var pendingRun = terminal.RunAsync(cancellationToken);
+
+            var counter = new SequenceCounter();
+            var auto = new Hex1bTerminalAutomator(terminal, defaultTimeout: TimeSpan.FromSeconds(500));
+
+            output.WriteLine("Step 1: Preparing environment...");
+            await auto.PrepareEnvironmentAsync(workspace, counter);
+
+            // TypeScript apphosts need the full bundle (not just the CLI binary) because the
+            // prebuilt AppHost server is required for `aspire add` to regenerate SDK code.
+            output.WriteLine("Step 2: Installing Aspire CLI bundle...");
+            await auto.InstallCurrentBuildAspireBundleAsync(counter, output);
+
+            output.WriteLine("Step 3: Creating TypeScript Express/React project...");
+            await auto.AspireNewAsync(projectName, counter, template: AspireTemplate.ExpressReact);
+
+            output.WriteLine("Step 4: Navigating to project directory...");
+            await auto.TypeAsync($"cd {projectName}");
+            await auto.EnterAsync();
+            await auto.WaitForSuccessPromptAsync(counter);
+
+            output.WriteLine("Step 5: Adding Azure Kubernetes hosting package...");
+            await auto.TypeAsync("aspire add Aspire.Hosting.Azure.Kubernetes");
+            await auto.EnterAsync();
+
+            // aspire add may or may not show a version selection prompt depending on whether
+            // packages are available from the local hive (bundle install).
+            if (DeploymentE2ETestHelpers.IsRunningInCI)
+            {
+                await auto.WaitForAspireAddCompletionAsync(counter);
+            }
+            else
+            {
+                await auto.WaitForSuccessPromptAsync(counter, TimeSpan.FromSeconds(180));
+            }
+
+            // Patch apphost.ts. The Express/React starter creates an Express API at ./api
+            // exposing an HTTP endpoint, plus a Vite frontend bundled in for publish. We
+            // replace the trailing `await builder.build().run();` with the AKS + cert-manager
+            // wiring that puts the API behind a Gateway with TLS issued by Let's Encrypt production.
+            //
+            // The TypeScript surface mirrors the C# API exposed via [AspireExport]:
+            //   addAzureKubernetesEnvironment / withSubnet / withSystemNodePool / addNodePool
+            //   addLoadBalancer
+            //   addCertManager / addIssuer / withLetsEncryptProductionParam / withHttp01Solver
+            //   addGateway / withLoadBalancer / withRoute / withGatewayTlsIssuer
+            var projectDir = Path.Combine(workspace.WorkspaceRoot.FullName, projectName);
+            var appHostFilePath = Path.Combine(projectDir, "apphost.ts");
+
+            output.WriteLine($"Step 6: Modifying apphost.ts at: {appHostFilePath}");
+
+            var content = File.ReadAllText(appHostFilePath);
+
+            const string buildRunPattern = "await builder.build().run();";
+            const string replacement = """
+// VNet layout chosen to avoid the AKS default service CIDR (10.0.0.0/16):
+//   10.100.0.0/16   - vnet
+//     10.100.0.0/22 - aks node pool subnet
+//     10.100.4.0/24 - AGC frontend subnet (delegated to ServiceNetworking by addLoadBalancer)
+const vnet = await builder.addAzureVirtualNetwork("vnet", { addressPrefix: "10.100.0.0/16" });
+const aksSubnet = await vnet.addSubnet("aks-nodes", "10.100.0.0/22");
+const albSubnet = await vnet.addSubnet("alb-public", "10.100.4.0/24");
+
+const aks = await builder.addAzureKubernetesEnvironment("aks");
+await aks.withSubnet(aksSubnet);
+await aks.withSystemNodePool({ vmSize: "Standard_D2as_v5" });
+await aks.addNodePool("workload", { vmSize: "Standard_D2as_v5", minCount: 1, maxCount: 3 });
+
+const publicLb = await aks.addLoadBalancer("public", albSubnet);
+
+// Email registered with the ACME endpoint. Passed as a parameter so the test
+// supplies it via Parameters__acmeemail without burning it into apphost source.
+const acmeEmail = await builder.addParameter("acmeemail");
+
+// Install cert-manager via the typed API and declare a Let's Encrypt PRODUCTION ClusterIssuer.
+const certManager = await aks.addCertManager("cert-manager");
+const letsEncrypt = await certManager.addIssuer("letsencrypt-prod");
+await letsEncrypt.withLetsEncryptProductionParam(acmeEmail);
+await letsEncrypt.withHttp01Solver();
+
+// Gateway with HTTPS listener. withGatewayTlsIssuer(letsEncrypt) creates the listener AND
+// adds the cert-manager.io/cluster-issuer annotation in one call.
+const gateway = await aks.addGateway("api-gw");
+await gateway.withLoadBalancer(publicLb);
+await gateway.withGatewayPathRoute("/", app.getEndpoint("http"));
+await gateway.withGatewayTlsIssuer(letsEncrypt);
+
+await builder.build().run();
+""";
+
+            content = content.Replace(buildRunPattern, replacement);
+            File.WriteAllText(appHostFilePath, content);
+            output.WriteLine("Modified apphost.ts with addCertManager + addIssuer + withGatewayTlsIssuer");
+
+            output.WriteLine("Step 7: Setting deployment environment variables...");
+            await auto.TypeAsync(
+                $"unset ASPIRE_PLAYGROUND && " +
+                $"export AZURE__LOCATION=westus3 && " +
+                $"export AZURE__RESOURCEGROUP={resourceGroupName} && " +
+                $"export Parameters__acmeemail={acmeEmail}");
+            await auto.EnterAsync();
+            await auto.WaitForSuccessPromptAsync(counter);
+
+            // The deploy pipeline provisions AKS + AGC, installs the cert-manager Helm chart,
+            // applies the ClusterIssuer, and pre-creates the bootstrap TLS secret. Use a
+            // generous timeout to cover the AKS+AGC bring-up window.
+            output.WriteLine("Step 8: Starting AKS + cert-manager deployment (15-20 min)...");
+            await auto.TypeAsync("aspire deploy --clear-cache");
+            await auto.EnterAsync();
+            await auto.WaitForPipelineSuccessAsync(timeout: TimeSpan.FromMinutes(40));
+            await auto.WaitForSuccessPromptAsync(counter, TimeSpan.FromMinutes(2));
+
+            output.WriteLine("Step 9: Getting AKS credentials...");
+            await auto.TypeAsync(
+                $"AKS_NAME=$(az aks list -g {resourceGroupName} --query '[0].name' -o tsv) && " +
+                $"az aks get-credentials -g {resourceGroupName} -n $AKS_NAME --overwrite-existing");
+            await auto.EnterAsync();
+            await auto.WaitForSuccessPromptAsync(counter, TimeSpan.FromSeconds(60));
+
+            output.WriteLine("Step 10: Waiting for pods to be ready...");
+            await auto.TypeAsync("kubectl wait --for=condition=ready pod --all --all-namespaces --timeout=300s 2>/dev/null || true");
+            await auto.EnterAsync();
+            await auto.WaitForSuccessPromptAsync(counter, TimeSpan.FromMinutes(6));
+
+            await auto.TypeAsync(
+                "kubectl get pods --all-namespaces && " +
+                "kubectl get gateway --all-namespaces && " +
+                "kubectl get clusterissuer && " +
+                "kubectl get certificate --all-namespaces");
+            await auto.EnterAsync();
+            await auto.WaitForSuccessPromptAsync(counter, TimeSpan.FromSeconds(30));
+
+            output.WriteLine("Step 11: Verifying ClusterIssuer is Ready...");
+            await auto.TypeAsync(
+                "OK=0; for i in $(seq 1 30); do " +
+                "READY=$(kubectl get clusterissuer letsencrypt-prod -o jsonpath='{.status.conditions[?(@.type==\"Ready\")].status}' 2>/dev/null); " +
+                "[ \"$READY\" = \"True\" ] && echo 'ClusterIssuer Ready' && OK=1 && break; " +
+                "echo \"Attempt $i: ClusterIssuer status=$READY, waiting...\"; sleep 5; done; " +
+                "[ \"$OK\" = \"1\" ] || { echo 'FAIL: letsencrypt-prod ClusterIssuer never became Ready'; kubectl describe clusterissuer letsencrypt-prod; exit 1; }");
+            await auto.EnterAsync();
+            await auto.WaitForSuccessPromptAsync(counter, TimeSpan.FromMinutes(3));
+
+            output.WriteLine("Step 12: Discovering gateway namespace...");
+            await auto.TypeAsync(
+                "NS=$(kubectl get gateway --all-namespaces -o jsonpath='{range .items[?(@.metadata.name==\"api-gw\")]}{.metadata.namespace}{end}') && " +
+                "echo \"Namespace: $NS\"");
+            await auto.EnterAsync();
+            await auto.WaitForSuccessPromptAsync(counter, TimeSpan.FromSeconds(30));
+
+            output.WriteLine("Step 13: Waiting for AGC to assign gateway FQDN (up to 15 min)...");
+            await auto.TypeAsync(
+                "OK=0; for i in $(seq 1 90); do " +
+                "FQDN=$(kubectl get gateway api-gw -n $NS -o jsonpath='{.status.addresses[0].value}' 2>/dev/null); " +
+                "[ -n \"$FQDN\" ] && echo \"Gateway FQDN: $FQDN\" && OK=1 && break; " +
+                "echo \"Attempt $i: waiting for AGC FQDN...\"; sleep 10; done; " +
+                "[ \"$OK\" = \"1\" ] || { echo 'FAIL: gateway never received AGC FQDN'; exit 1; }");
+            await auto.EnterAsync();
+            await auto.WaitForSuccessPromptAsync(counter, TimeSpan.FromMinutes(16));
+
+            output.WriteLine("Step 14: Waiting for cert-manager to issue the certificate (up to 10 min)...");
+            await auto.TypeAsync(
+                "OK=0; for i in $(seq 1 60); do " +
+                "READY=$(kubectl get certificate -n $NS api-gw-tls -o jsonpath='{.status.conditions[?(@.type==\"Ready\")].status}' 2>/dev/null); " +
+                "[ \"$READY\" = \"True\" ] && echo 'Certificate Ready' && OK=1 && break; " +
+                "echo \"Attempt $i: certificate Ready=$READY, waiting...\"; sleep 10; done; " +
+                "[ \"$OK\" = \"1\" ] || { echo 'FAIL: certificate never became Ready'; " +
+                "kubectl describe certificate -n $NS api-gw-tls; " +
+                "kubectl get challenge,order -n $NS; " +
+                "exit 1; }");
+            await auto.EnterAsync();
+            await auto.WaitForSuccessPromptAsync(counter, TimeSpan.FromMinutes(11));
+
+            // Probe the served cert and assert the issuer string contains "Let's Encrypt".
+            // Production certs identify as "Let's Encrypt" (no "(STAGING)" prefix). Using
+            // openssl s_client (with -servername for SNI) rather than curl — both work for
+            // production certs, but openssl gives us issuer-string asserts without depending
+            // on system trust store configuration. AGC takes a few seconds to load the new
+            // cert into the data plane after the secret is updated, so we retry the probe.
+            output.WriteLine("Step 15: Verifying served cert is from Let's Encrypt...");
+            await auto.TypeAsync(
+                "FQDN=$(kubectl get gateway api-gw -n $NS -o jsonpath='{.status.addresses[0].value}') && " +
+                "echo \"Probing https://$FQDN\" && " +
+                "OK=0; for i in $(seq 1 24); do sleep 5; " +
+                "ISSUER=$(echo | openssl s_client -connect $FQDN:443 -servername $FQDN 2>/dev/null | " +
+                "openssl x509 -noout -issuer 2>/dev/null); " +
+                "echo \"Attempt $i: issuer=$ISSUER\"; " +
+                "echo \"$ISSUER\" | grep -i \"let's encrypt\" >/dev/null && " +
+                "echo \"PASS: Let's Encrypt cert observed: $ISSUER\" && OK=1 && break; " +
+                "done; " +
+                "[ \"$OK\" = \"1\" ] || { echo 'FAIL: served cert is not from Let'\\''s Encrypt'; exit 1; }");
+            await auto.EnterAsync();
+            await auto.WaitForSuccessPromptAsync(counter, TimeSpan.FromMinutes(3));
+
+            // Verify HTTPS actually serves the Express API. Production certs chain to a
+            // publicly-trusted root, but we still pass -k to curl for resilience against
+            // transient trust-store quirks on the runner; the previous step already proved
+            // cryptographic identity (issuer == Let's Encrypt). The Express API serves at
+            // "/" — any 2xx response is a pass.
+            output.WriteLine("Step 16: Verifying https://<fqdn>/ returns 2xx from the Express API...");
+            await auto.TypeAsync(
+                "FQDN=$(kubectl get gateway api-gw -n $NS -o jsonpath='{.status.addresses[0].value}') && " +
+                "OK=0; for i in $(seq 1 30); do sleep 5; " +
+                "S=$(curl -kso /dev/null -w '%{http_code}' -m 10 https://$FQDN/ 2>/dev/null); " +
+                "case \"$S\" in 2*) echo \"HTTPS $S OK\"; OK=1; break;; esac; " +
+                "echo \"Attempt $i: HTTPS $S\"; done; " +
+                "[ \"$OK\" = \"1\" ] || { echo 'FAIL: HTTPS endpoint never returned 2xx'; exit 1; }");
+            await auto.EnterAsync();
+            await auto.WaitForSuccessPromptAsync(counter, TimeSpan.FromMinutes(4));
+
+            output.WriteLine("Step 17: Destroying deployment...");
+            await auto.AspireDestroyAsync(counter);
+
+            await auto.TypeAsync("exit");
+            await auto.EnterAsync();
+
+            await pendingRun;
+
+            var duration = DateTime.UtcNow - startTime;
+            output.WriteLine($"Deployment completed in {duration}");
+
+            DeploymentReporter.ReportDeploymentSuccess(
+                nameof(DeployTypeScriptApiWithCertManagerToAzureKubernetesEnvironment),
+                resourceGroupName,
+                deploymentUrls,
+                duration);
+
+            output.WriteLine("✅ Test passed - cert-manager issued a Let's Encrypt cert via HTTP-01 (TypeScript apphost)!");
+        }
+        catch (Exception ex)
+        {
+            var duration = DateTime.UtcNow - startTime;
+            output.WriteLine($"❌ Test failed after {duration}: {ex.Message}");
+
+            DeploymentReporter.ReportDeploymentFailure(
+                nameof(DeployTypeScriptApiWithCertManagerToAzureKubernetesEnvironment),
+                resourceGroupName,
+                ex.Message,
+                ex.StackTrace);
+
+            throw;
+        }
+        finally
+        {
+            output.WriteLine($"Triggering cleanup of resource group: {resourceGroupName}");
+            TriggerCleanupResourceGroup(resourceGroupName);
+        }
+    }
+
+    private void TriggerCleanupResourceGroup(string resourceGroupName)
+    {
+        using var process = new System.Diagnostics.Process
+        {
+            StartInfo = new System.Diagnostics.ProcessStartInfo
+            {
+                FileName = "az",
+                Arguments = $"group delete --name {resourceGroupName} --yes --no-wait",
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+                CreateNoWindow = true
+            }
+        };
+
+        try
+        {
+            process.Start();
+            output.WriteLine($"Cleanup triggered for resource group: {resourceGroupName}");
+            DeploymentReporter.ReportCleanupStatus(resourceGroupName, success: true, "Cleanup triggered (fire-and-forget)");
+        }
+        catch (Exception ex)
+        {
+            output.WriteLine($"Failed to trigger cleanup: {ex.Message}");
+            DeploymentReporter.ReportCleanupStatus(resourceGroupName, success: false, ex.Message);
+        }
+    }
+}

--- a/tests/Aspire.Hosting.Kubernetes.Tests/CertManagerTests.cs
+++ b/tests/Aspire.Hosting.Kubernetes.Tests/CertManagerTests.cs
@@ -10,7 +10,7 @@ namespace Aspire.Hosting.Kubernetes.Tests;
 public class CertManagerTests
 {
     [Fact]
-    public void AddCertManager_AddsHelmChartButNotWrapperResource()
+    public void AddCertManager_RegistersWrapperAndHelmChartUnderSeparateNames()
     {
         var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish);
         var k8s = builder.AddKubernetesEnvironment("env");
@@ -20,9 +20,9 @@ public class CertManagerTests
         Assert.Equal("cert-manager", certManager.Resource.Name);
         Assert.Same(k8s.Resource, certManager.Resource.Parent);
 
-        // AddCertManager should compose with the existing AddHelmChart machinery so users
-        // can introspect / further configure the underlying chart via HelmChart.
-        Assert.Equal("cert-manager", certManager.Resource.HelmChart.Name);
+        // The wrapper keeps the natural "{name}" identifier; the helm chart is registered
+        // under "{name}-chart" so both can coexist in the model without colliding.
+        Assert.Equal("cert-manager-chart", certManager.Resource.HelmChart.Name);
         Assert.Equal("oci://quay.io/jetstack/charts/cert-manager", certManager.Resource.HelmChart.ChartReference);
         Assert.StartsWith("v", certManager.Resource.HelmChart.ChartVersion);
 
@@ -31,13 +31,10 @@ public class CertManagerTests
         Assert.Equal("true", certManager.Resource.HelmChart.Values["crds.enabled"]);
         Assert.Equal("true", certManager.Resource.HelmChart.Values["config.enableGatewayAPI"]);
 
-        // The chart is the deployable resource. CertManagerResource itself is just a typed
-        // handle for hanging issuers off and is intentionally not registered in the model
-        // (otherwise it would name-collide with the chart).
         var app = builder.Build();
         var appModel = app.Services.GetRequiredService<DistributedApplicationModel>();
-        Assert.Contains(appModel.Resources, r => r is KubernetesHelmChartResource c && c.Name == "cert-manager");
-        Assert.DoesNotContain(appModel.Resources, r => r is CertManagerResource);
+        Assert.Contains(appModel.Resources, r => r is CertManagerResource c && c.Name == "cert-manager");
+        Assert.Contains(appModel.Resources, r => r is KubernetesHelmChartResource c && c.Name == "cert-manager-chart");
     }
 
     [Fact]
@@ -132,11 +129,11 @@ public class CertManagerTests
     }
 
     [Fact]
-    public void AddCertManager_RunMode_StillCreatesTypedHandle()
+    public void AddCertManager_RunMode_DoesNotRegisterResources()
     {
-        // CertManagerResource is a typed handle (not a model-registered resource) in
-        // every mode. The underlying helm chart resource is still suppressed from the
-        // model in run mode because helm install only happens at deploy time.
+        // In run mode neither the wrapper nor its helm chart get added to the model
+        // (helm install only runs at deploy time, and AddHelmChart already suppresses
+        // its resource in run mode).
         var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Run);
         var k8s = builder.AddKubernetesEnvironment("env");
 

--- a/tests/Aspire.Hosting.Kubernetes.Tests/CertManagerTests.cs
+++ b/tests/Aspire.Hosting.Kubernetes.Tests/CertManagerTests.cs
@@ -1,0 +1,150 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Aspire.Hosting.ApplicationModel;
+using Aspire.Hosting.Utils;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Aspire.Hosting.Kubernetes.Tests;
+
+public class CertManagerTests
+{
+    [Fact]
+    public void AddCertManager_AddsHelmChartButNotWrapperResource()
+    {
+        var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish);
+        var k8s = builder.AddKubernetesEnvironment("env");
+
+        var certManager = k8s.AddCertManager();
+
+        Assert.Equal("cert-manager", certManager.Resource.Name);
+        Assert.Same(k8s.Resource, certManager.Resource.Parent);
+
+        // AddCertManager should compose with the existing AddHelmChart machinery so users
+        // can introspect / further configure the underlying chart via HelmChart.
+        Assert.Equal("cert-manager", certManager.Resource.HelmChart.Name);
+        Assert.Equal("oci://quay.io/jetstack/charts/cert-manager", certManager.Resource.HelmChart.ChartReference);
+        Assert.StartsWith("v", certManager.Resource.HelmChart.ChartVersion);
+
+        // CRDs and Gateway API support are required for cert-manager to issue certificates
+        // for Aspire-modeled Gateway resources, so they must be on by default.
+        Assert.Equal("true", certManager.Resource.HelmChart.Values["crds.enabled"]);
+        Assert.Equal("true", certManager.Resource.HelmChart.Values["config.enableGatewayAPI"]);
+
+        // The chart is the deployable resource. CertManagerResource itself is just a typed
+        // handle for hanging issuers off and is intentionally not registered in the model
+        // (otherwise it would name-collide with the chart).
+        var app = builder.Build();
+        var appModel = app.Services.GetRequiredService<DistributedApplicationModel>();
+        Assert.Contains(appModel.Resources, r => r is KubernetesHelmChartResource c && c.Name == "cert-manager");
+        Assert.DoesNotContain(appModel.Resources, r => r is CertManagerResource);
+    }
+
+    [Fact]
+    public void AddIssuer_WithLetsEncryptProductionAndHttp01_PopulatesSpecAndSolver()
+    {
+        var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish);
+        var k8s = builder.AddKubernetesEnvironment("env");
+        var certManager = k8s.AddCertManager();
+
+        var issuer = certManager.AddIssuer("letsencrypt-prod")
+            .WithLetsEncryptProduction("ops@contoso.com")
+            .WithHttp01Solver();
+
+        Assert.Equal("letsencrypt-prod", issuer.Resource.Name);
+        Assert.Same(certManager.Resource, issuer.Resource.Parent);
+        Assert.Contains(issuer.Resource, certManager.Resource.Issuers);
+
+        var spec = Assert.IsType<CertManagerAcmeIssuerSpec>(issuer.Resource.Spec);
+        Assert.Equal("https://acme-v02.api.letsencrypt.org/directory", spec.ServerUrl.Format);
+        Assert.Equal("ops@contoso.com", spec.Email.Format);
+
+        var solver = Assert.Single(issuer.Resource.Solvers);
+        Assert.IsType<CertManagerHttp01SolverConfig>(solver);
+    }
+
+    [Fact]
+    public void WithLetsEncryptStaging_UsesStagingDirectoryUrl()
+    {
+        var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish);
+        var certManager = builder.AddKubernetesEnvironment("env").AddCertManager();
+
+        var issuer = certManager.AddIssuer("le-staging")
+            .WithLetsEncryptStaging("ops@contoso.com");
+
+        var spec = Assert.IsType<CertManagerAcmeIssuerSpec>(issuer.Resource.Spec);
+        Assert.Equal("https://acme-staging-v02.api.letsencrypt.org/directory", spec.ServerUrl.Format);
+    }
+
+    [Fact]
+    public void WithAcmeServer_AllowsCustomDirectoryUrl()
+    {
+        var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish);
+        var certManager = builder.AddKubernetesEnvironment("env").AddCertManager();
+
+        var issuer = certManager.AddIssuer("custom-acme")
+            .WithAcmeServer("https://acme.example.com/directory", "ops@contoso.com");
+
+        var spec = Assert.IsType<CertManagerAcmeIssuerSpec>(issuer.Resource.Spec);
+        Assert.Equal("https://acme.example.com/directory", spec.ServerUrl.Format);
+    }
+
+    [Fact]
+    public void Gateway_WithTls_Issuer_AddsClusterIssuerAnnotation()
+    {
+        var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish);
+        var k8s = builder.AddKubernetesEnvironment("env");
+        var issuer = k8s.AddCertManager()
+            .AddIssuer("letsencrypt-prod")
+            .WithLetsEncryptProduction("ops@contoso.com")
+            .WithHttp01Solver();
+
+        var gateway = k8s.AddGateway("public")
+            .WithGatewayClass("nginx")
+            .WithTls(issuer);
+
+        // The typed WithTls(issuer) overload should be equivalent to WithTls() + setting
+        // the cert-manager.io/cluster-issuer annotation to the issuer's name.
+        Assert.Single(gateway.Resource.TlsConfigs);
+        Assert.True(gateway.Resource.GatewayAnnotations.TryGetValue(
+            CertManagerExtensions.ClusterIssuerAnnotationKey, out var value));
+        Assert.Equal("letsencrypt-prod", value!.Format);
+    }
+
+    [Fact]
+    public void Ingress_WithTls_Issuer_AddsClusterIssuerAnnotation()
+    {
+        var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish);
+        var k8s = builder.AddKubernetesEnvironment("env");
+        var issuer = k8s.AddCertManager()
+            .AddIssuer("letsencrypt-prod")
+            .WithLetsEncryptProduction("ops@contoso.com")
+            .WithHttp01Solver();
+
+        var ingress = k8s.AddIngress("public")
+            .WithIngressClass("nginx")
+            .WithTls(issuer);
+
+        Assert.Single(ingress.Resource.TlsConfigs);
+        Assert.True(ingress.Resource.IngressAnnotations.TryGetValue(
+            CertManagerExtensions.ClusterIssuerAnnotationKey, out var value));
+        Assert.Equal("letsencrypt-prod", value!.Format);
+    }
+
+    [Fact]
+    public void AddCertManager_RunMode_StillCreatesTypedHandle()
+    {
+        // CertManagerResource is a typed handle (not a model-registered resource) in
+        // every mode. The underlying helm chart resource is still suppressed from the
+        // model in run mode because helm install only happens at deploy time.
+        var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Run);
+        var k8s = builder.AddKubernetesEnvironment("env");
+
+        var certManager = k8s.AddCertManager();
+        Assert.NotNull(certManager.Resource);
+
+        var app = builder.Build();
+        var appModel = app.Services.GetRequiredService<DistributedApplicationModel>();
+        Assert.DoesNotContain(appModel.Resources, r => r is CertManagerResource);
+    }
+}

--- a/tests/Aspire.Hosting.Kubernetes.Tests/CertManagerTests.cs
+++ b/tests/Aspire.Hosting.Kubernetes.Tests/CertManagerTests.cs
@@ -4,6 +4,7 @@
 using Aspire.Hosting.ApplicationModel;
 using Aspire.Hosting.Utils;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
 
 namespace Aspire.Hosting.Kubernetes.Tests;
 
@@ -15,7 +16,7 @@ public class CertManagerTests
         var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish);
         var k8s = builder.AddKubernetesEnvironment("env");
 
-        var certManager = k8s.AddCertManager();
+        var certManager = k8s.AddCertManager("cert-manager");
 
         Assert.Equal("cert-manager", certManager.Resource.Name);
         Assert.Same(k8s.Resource, certManager.Resource.Parent);
@@ -42,7 +43,7 @@ public class CertManagerTests
     {
         var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish);
         var k8s = builder.AddKubernetesEnvironment("env");
-        var certManager = k8s.AddCertManager();
+        var certManager = k8s.AddCertManager("cert-manager");
 
         var issuer = certManager.AddIssuer("letsencrypt-prod")
             .WithLetsEncryptProduction("ops@contoso.com")
@@ -64,7 +65,7 @@ public class CertManagerTests
     public void WithLetsEncryptStaging_UsesStagingDirectoryUrl()
     {
         var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish);
-        var certManager = builder.AddKubernetesEnvironment("env").AddCertManager();
+        var certManager = builder.AddKubernetesEnvironment("env").AddCertManager("cert-manager");
 
         var issuer = certManager.AddIssuer("le-staging")
             .WithLetsEncryptStaging("ops@contoso.com");
@@ -77,7 +78,7 @@ public class CertManagerTests
     public void WithAcmeServer_AllowsCustomDirectoryUrl()
     {
         var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish);
-        var certManager = builder.AddKubernetesEnvironment("env").AddCertManager();
+        var certManager = builder.AddKubernetesEnvironment("env").AddCertManager("cert-manager");
 
         var issuer = certManager.AddIssuer("custom-acme")
             .WithAcmeServer("https://acme.example.com/directory", "ops@contoso.com");
@@ -91,7 +92,7 @@ public class CertManagerTests
     {
         var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish);
         var k8s = builder.AddKubernetesEnvironment("env");
-        var issuer = k8s.AddCertManager()
+        var issuer = k8s.AddCertManager("cert-manager")
             .AddIssuer("letsencrypt-prod")
             .WithLetsEncryptProduction("ops@contoso.com")
             .WithHttp01Solver();
@@ -109,23 +110,65 @@ public class CertManagerTests
     }
 
     [Fact]
-    public void Ingress_WithTls_Issuer_AddsClusterIssuerAnnotation()
+    public async Task BuildClusterIssuerManifest_EmitsExpectedYamlForLetsEncryptHttp01()
     {
         var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish);
         var k8s = builder.AddKubernetesEnvironment("env");
-        var issuer = k8s.AddCertManager()
-            .AddIssuer("letsencrypt-prod")
+        var issuer = k8s.AddCertManager("cert-manager")
+            .AddIssuer("LetsEncrypt-Prod") // intentionally mixed-case to verify DNS-1123 normalization
             .WithLetsEncryptProduction("ops@contoso.com")
             .WithHttp01Solver();
 
-        var ingress = k8s.AddIngress("public")
-            .WithIngressClass("nginx")
+        // A gateway that adopts this issuer must end up referenced as a parentRef on the
+        // generated solver, so cert-manager's HTTP-01 HTTPRoute can attach to it.
+        k8s.AddGateway("PUBLIC-GW")
+            .WithGatewayClass("nginx")
             .WithTls(issuer);
 
-        Assert.Single(ingress.Resource.TlsConfigs);
-        Assert.True(ingress.Resource.IngressAnnotations.TryGetValue(
-            CertManagerExtensions.ClusterIssuerAnnotationKey, out var value));
-        Assert.Equal("letsencrypt-prod", value!.Format);
+        using var app = builder.Build();
+        var model = app.Services.GetRequiredService<DistributedApplicationModel>();
+        var certManagerResource = model.Resources.OfType<CertManagerResource>().Single();
+        var issuerResource = certManagerResource.Issuers.Single();
+
+        var yaml = await CertManagerExtensions.BuildClusterIssuerManifestAsync(
+            model,
+            certManagerResource,
+            issuerResource,
+            NullLogger.Instance,
+            TestContext.Current.CancellationToken);
+
+        // Object names go through ToKubernetesResourceName() (lowercasing) so they're valid
+        // DNS-1123 subdomains regardless of the casing the user picked for the Aspire name.
+        Assert.Contains("apiVersion: cert-manager.io/v1", yaml);
+        Assert.Contains("kind: ClusterIssuer", yaml);
+        Assert.Contains("name: letsencrypt-prod", yaml);
+        Assert.Contains("server: https://acme-v02.api.letsencrypt.org/directory", yaml);
+        Assert.Contains("email: ops@contoso.com", yaml);
+        Assert.Contains("name: letsencrypt-prod-account-key", yaml);
+        Assert.Contains("- http01:", yaml);
+        Assert.Contains("gatewayHTTPRoute:", yaml);
+        // Gateway parentRef must also be lowercase to match the actual emitted Gateway name.
+        Assert.Contains("name: public-gw", yaml);
+    }
+
+    [Fact]
+    public void Gateway_WithTls_Issuer_FromDifferentEnvironment_Throws()
+    {
+        // cert-manager is per-cluster, so an issuer can only TLS-protect gateways inside the
+        // same Kubernetes environment. Cross-env wiring is a configuration bug we want to
+        // catch at app-host build time, not at deploy time when nothing comes up.
+        var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish);
+        var envA = builder.AddKubernetesEnvironment("env-a");
+        var envB = builder.AddKubernetesEnvironment("env-b");
+
+        var issuerInA = envA.AddCertManager("cert-manager")
+            .AddIssuer("le-prod")
+            .WithLetsEncryptProduction("ops@contoso.com")
+            .WithHttp01Solver();
+
+        var gatewayInB = envB.AddGateway("public").WithGatewayClass("nginx");
+
+        Assert.Throws<InvalidOperationException>(() => gatewayInB.WithTls(issuerInA));
     }
 
     [Fact]
@@ -137,7 +180,7 @@ public class CertManagerTests
         var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Run);
         var k8s = builder.AddKubernetesEnvironment("env");
 
-        var certManager = k8s.AddCertManager();
+        var certManager = k8s.AddCertManager("cert-manager");
         Assert.NotNull(certManager.Resource);
 
         var app = builder.Build();

--- a/tests/Aspire.Hosting.Kubernetes.Tests/KubernetesGatewayTests.cs
+++ b/tests/Aspire.Hosting.Kubernetes.Tests/KubernetesGatewayTests.cs
@@ -269,4 +269,44 @@ public class KubernetesGatewayTests
         var httpsSection = lines.Skip(httpsIndex).Take((nextListenerOrEnd > httpsIndex ? nextListenerOrEnd : lines.Count) - httpsIndex);
         Assert.DoesNotContain(httpsSection, l => l.StartsWith("hostname:") || l.StartsWith("hostname "));
     }
+
+    [Fact]
+    public async Task AddGateway_WithTls_BeforeWithHostname_HostnameStillAppliedToHttpsListener()
+    {
+        // Regression test: WithTls() must not snapshot the hostname list at call time.
+        // The hostname is registered AFTER WithTls() here; the generated HTTPS listener
+        // must still pick it up, otherwise cert-manager will issue a cert for the wrong
+        // hostname (or fall back to the gateway's auto-assigned FQDN).
+        using var tempDir = new TestTempDirectory();
+        var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish, tempDir.Path);
+
+        var k8s = builder.AddKubernetesEnvironment("env");
+        var gateway = k8s.AddGateway("public").WithGatewayClass("azure-alb-external");
+
+        var api = builder.AddContainer("myapi", "nginx")
+            .WithHttpEndpoint(targetPort: 8080);
+
+        gateway
+            .WithRoute("/", api.GetEndpoint("http"))
+            .WithTls("my-tls-secret")
+            .WithHostname("api.example.com");
+
+        var app = builder.Build();
+        app.Run();
+
+        var gatewayFile = Path.Combine(tempDir.Path, "templates", "public", "public.yaml");
+        var content = await File.ReadAllTextAsync(gatewayFile);
+
+        Assert.Contains("HTTPS", content);
+        Assert.Contains("my-tls-secret", content);
+        Assert.Contains("api.example.com", content);
+
+        var lines = content.Split('\n').Select(l => l.Trim()).ToList();
+        var httpsIndex = lines.FindIndex(l => l.Contains("protocol:") && l.Contains("HTTPS"));
+        Assert.True(httpsIndex >= 0, "HTTPS listener not found in:\n" + content);
+
+        var nextListenerOrEnd = lines.FindIndex(httpsIndex + 1, l => l.StartsWith("- name:") || l == "");
+        var httpsSection = lines.Skip(httpsIndex).Take((nextListenerOrEnd > httpsIndex ? nextListenerOrEnd : lines.Count) - httpsIndex).ToList();
+        Assert.Contains(httpsSection, l => l.Contains("hostname:") && l.Contains("api.example.com"));
+    }
 }

--- a/tests/Aspire.Hosting.Kubernetes.Tests/KubernetesIngressTests.cs
+++ b/tests/Aspire.Hosting.Kubernetes.Tests/KubernetesIngressTests.cs
@@ -90,6 +90,36 @@ public class KubernetesIngressTests
     }
 
     [Fact]
+    public async Task AddIngress_WithTls_BeforeWithHostname_HostnameIncludedInTlsHosts()
+    {
+        // Regression test: WithTls() must not snapshot the hostname list at call time.
+        using var tempDir = new TestTempDirectory();
+        var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish, tempDir.Path);
+
+        var k8s = builder.AddKubernetesEnvironment("env");
+        var ingress = k8s.AddIngress("public");
+
+        var api = builder.AddContainer("myapi", "nginx")
+            .WithHttpEndpoint(targetPort: 8080);
+
+        ingress
+            .WithRoute("api.example.com", "/", api.GetEndpoint("http"))
+            .WithTls("my-tls-secret")
+            .WithHostname("api.example.com");
+
+        var app = builder.Build();
+        app.Run();
+
+        var ingressPath = Path.Combine(tempDir.Path, "templates", "public", "public.yaml");
+        var content = await File.ReadAllTextAsync(ingressPath);
+
+        Assert.Contains("my-tls-secret", content);
+        Assert.Contains("api.example.com", content);
+        // The TLS section should list the hostname under hosts.
+        Assert.Matches(@"tls:[\s\S]*?hosts:[\s\S]*?api\.example\.com", content);
+    }
+
+    [Fact]
     public async Task AddIngress_WithMultipleRoutes_GroupsByHost()
     {
         using var tempDir = new TestTempDirectory();

--- a/tests/PolyglotAppHosts/Aspire.Hosting.Kubernetes/TypeScript/apphost.ts
+++ b/tests/PolyglotAppHosts/Aspire.Hosting.Kubernetes/TypeScript/apphost.ts
@@ -56,6 +56,42 @@ const ingress = await kubernetes.addIngress('public-ingress');
 await ingress.withHostname('ingress.example.com');
 await ingress.withTls('ingress-tls');
 
+// === cert-manager ===
+// Validates the typed cert-manager API surface generated for TypeScript:
+// addCertManager / addIssuer / withLetsEncrypt* / withAcmeServer / withHttp01Solver /
+// gateway.withGatewayTlsIssuer.
+const acmeEmail = await builder.addParameter('acme-email');
+const acmeServer = await builder.addParameter('acme-server');
+
+const certManager = await kubernetes.addCertManager('cert-manager');
+
+const prodIssuer = await certManager.addIssuer('letsencrypt-prod');
+await prodIssuer.withLetsEncryptProduction('admin@example.com');
+await prodIssuer.withHttp01Solver();
+
+const prodIssuerParam = await certManager.addIssuer('letsencrypt-prod-param');
+await prodIssuerParam.withLetsEncryptProductionParam(acmeEmail);
+await prodIssuerParam.withHttp01Solver();
+
+const stagingIssuer = await certManager.addIssuer('letsencrypt-staging');
+await stagingIssuer.withLetsEncryptStaging('admin@example.com');
+await stagingIssuer.withHttp01Solver();
+
+const stagingIssuerParam = await certManager.addIssuer('letsencrypt-staging-param');
+await stagingIssuerParam.withLetsEncryptStagingParam(acmeEmail);
+await stagingIssuerParam.withHttp01Solver();
+
+const customIssuer = await certManager.addIssuer('custom-acme');
+await customIssuer.withAcmeServer('https://acme.example.com/directory', 'admin@example.com');
+await customIssuer.withHttp01Solver();
+
+const customIssuerParam = await certManager.addIssuer('custom-acme-param');
+await customIssuerParam.withAcmeServerParam(acmeServer, acmeEmail);
+await customIssuerParam.withHttp01Solver();
+
+// Wire the staging issuer onto the gateway via the typed cert-manager overload.
+await gateway.withGatewayTlsIssuer(stagingIssuer);
+
 const serviceContainer = await builder.addContainer('kube-service', 'redis:alpine');
 await serviceContainer.publishAsKubernetesService(async (service) => {
     const _serviceName: string = await service.name();

--- a/tests/PolyglotAppHosts/Aspire.Hosting.Kubernetes/TypeScript/apphost.ts
+++ b/tests/PolyglotAppHosts/Aspire.Hosting.Kubernetes/TypeScript/apphost.ts
@@ -61,7 +61,6 @@ await ingress.withTls('ingress-tls');
 // addCertManager / addIssuer / withLetsEncrypt* / withAcmeServer / withHttp01Solver /
 // gateway.withGatewayTlsIssuer.
 const acmeEmail = await builder.addParameter('acme-email');
-const acmeServer = await builder.addParameter('acme-server');
 
 const certManager = await kubernetes.addCertManager('cert-manager');
 
@@ -86,7 +85,7 @@ await customIssuer.withAcmeServer('https://acme.example.com/directory', 'admin@e
 await customIssuer.withHttp01Solver();
 
 const customIssuerParam = await certManager.addIssuer('custom-acme-param');
-await customIssuerParam.withAcmeServerParam(acmeServer, acmeEmail);
+await customIssuerParam.withAcmeServerParam('https://acme.example.com/directory', acmeEmail);
 await customIssuerParam.withHttp01Solver();
 
 // Wire the staging issuer onto the gateway via the typed cert-manager overload.


### PR DESCRIPTION
## Description

Adds a typed cert-manager API surface to `Aspire.Hosting.Kubernetes` so cert-manager can be installed, configured, and wired to gateways/ingress through the Aspire app model — without dropping into raw `WithAnnotation` calls or hand-written Helm values.

### What's added

- **`AddCertManager(name)`** on `IResourceBuilder<KubernetesEnvironmentResource>` — installs the cert-manager Helm chart (`helm install --wait`) and returns a `CertManagerResource` for further configuration.
- **`AddIssuer(name)`** on `CertManagerResource` — declares a `ClusterIssuer` that gets applied at deploy time after cert-manager is healthy.
- Issuer fluent configuration:
  - `WithLetsEncryptProduction(email)` / `WithLetsEncryptProductionParam(parameter)`
  - `WithLetsEncryptStaging(email)` / `WithLetsEncryptStagingParam(parameter)`
  - `WithAcmeServer(serverUrl, email)` / `WithAcmeServer(serverUrl, parameter)` for custom ACME servers
  - `WithHttp01Solver()` (DNS-01 deferred to a follow-up PR)
- **`gateway.WithTls(issuer)`** overload — wires a cert-manager `ClusterIssuer` to a gateway listener via the `cert-manager.io/cluster-issuer` annotation. Validates that the gateway and issuer live in the same `KubernetesEnvironment` so cross-cluster mistakes fail loudly at app-model build time.

### Pipeline

The `AddCertManager(...)` call enqueues the existing helm-install pipeline step. Each `AddIssuer(...)` enqueues a `cm-issuer-apply-{name}` step that depends on the helm install (so cert-manager's validating webhook is guaranteed to be Available before the `ClusterIssuer` is applied — otherwise we race the webhook and get `failed calling webhook "webhook.cert-manager.io": no endpoints available`).

For gateways with TLS but no explicit `WithHostname`, the integration also pre-creates a self-signed bootstrap TLS secret so the controller (e.g., AGC) will program the listener before cert-manager has issued the real certificate. Without this the listener would deadlock waiting for a secret that doesn't exist yet.

## C# example (Express + React on AKS, Let's Encrypt prod via HTTP-01)

```csharp
#pragma warning disable ASPIREPIPELINES001
#pragma warning disable ASPIRECOMPUTE003
#pragma warning disable ASPIREAZURE003

var builder = DistributedApplication.CreateBuilder(args);

var acmeEmail = builder.AddParameter("acmeemail");

var aks = builder.AddAzureKubernetesEnvironment("aks")
    .WithSystemNodePool(p => p.VmSize = "Standard_D2as_v5");

var certManager = aks.AddCertManager("cert-manager");

var letsEncrypt = certManager.AddIssuer("letsencrypt-prod")
    .WithLetsEncryptProductionParam(acmeEmail)
    .WithHttp01Solver();

var api = builder.AddProject<Projects.Api>("api")
    .WithHttpEndpoint();

var gateway = aks.AddGateway("api-gw")
    .WithGatewayPathRoute("/", api.GetEndpoint("http"))
    .WithTls(letsEncrypt);

builder.Build().Run();
```

## TypeScript example (same pattern, polyglot apphost)

```typescript
import { distributedApplication } from "@microsoft/aspire";

const builder = await distributedApplication();

const acmeEmail = await builder.addParameter("acme-email");

const aks = await builder.addAzureKubernetesEnvironment("aks");
await aks.addAzureVirtualNetwork("vnet", { addressPrefix: "10.224.0.0/12" });
await aks.withSystemNodePool({ vmSize: "Standard_D2as_v5" });

const certManager = await aks.addCertManager("cert-manager");

const letsEncrypt = await certManager.addIssuer("letsencrypt-prod");
await letsEncrypt.withLetsEncryptProductionParam(acmeEmail);
await letsEncrypt.withHttp01Solver();

const app = await builder.addNpmApp("app", "../app", "start");
await app.withHttpEndpoint();

const gateway = await aks.addGateway("api-gw");
await gateway.withGatewayPathRoute("/", app.getEndpoint("http"));
await gateway.withGatewayTlsIssuer(letsEncrypt);

await builder.build().run();
```

## Tests

- `tests/Aspire.Hosting.Kubernetes.Tests/CertManagerTests.cs` — unit coverage for `AddCertManager`, `AddIssuer`, the various `WithLetsEncrypt*` and `WithAcmeServer` overloads, `WithHttp01Solver`, `WithTls(issuer)`, and the cross-environment validation.
- `tests/Aspire.Hosting.Kubernetes.Tests/KubernetesGatewayTests.cs` and `KubernetesIngressTests.cs` — added regression tests covering the `WithTls()`-then-`WithHostname()` ordering case.
- `tests/PolyglotAppHosts/Aspire.Hosting.Kubernetes/TypeScript/apphost.ts` — exercises the entire surface in TypeScript via `tsc --noEmit` (so the `[AspireExport]`-driven TS bindings stay valid).
- `tests/Aspire.Deployment.EndToEnd.Tests/AksAzureKubernetesEnvironmentCertManagerDeploymentTests.cs` and `AksAzureKubernetesEnvironmentCertManagerTypeScriptDeploymentTests.cs` — full deploy E2E tests that stand up AKS + AGC, install cert-manager, issue a real Let's Encrypt **production** certificate via HTTP-01, verify trusted HTTPS, and then **re-deploy** to exercise the helm UPGRADE path before destroying the cluster.

## Bug fixes pulled in along the way

- **Helm v4 `--server-side` flag parsing** — Helm v4 changed `--server-side` from a bool flag to a string-valued one (`true|false|auto`) in [helm/helm#13649](https://github.com/helm/helm/pull/13649). Our code shelled out `--server-side --force-conflicts`, which Helm v4 silently parses as `--server-side=--force-conflicts`, poisoning release metadata so every subsequent upgrade fails with `invalid/unknown release server-side apply method: --force-conflicts`. The first install appeared to succeed; the second always failed. Now using `--server-side=true` so the flag parses identically under v3.18 and v4.
- **Gateway/ingress TLS hostname ordering** — `WithTls(...)` snapshotted `Resource.Hostnames` at call time, so calling `WithTls()` before `WithHostname()` produced an HTTPS listener with no hostname (and cert-manager would then issue a cert for the wrong host). The TLS config records now resolve hostnames lazily at manifest-emit time so calling order doesn't matter.

## Out of scope (follow-ups)

- DNS-01 solver support (e.g. Azure DNS) — needed for wildcard certs and for hostnames that aren't yet publicly addressable.
- Renewal monitoring / dashboard surface for cert-manager certificates.