### PR TITLE
Fix `aspire init` producing AppHost projects that fail to restore on non-stable channels

### DIFF
--- a/docs/dogfooding-pull-requests.md
+++ b/docs/dogfooding-pull-requests.md
@@ -163,6 +163,14 @@ The scripts auto-detect your OS and architecture and locate the latest `ci.yml` 
     ./eng/scripts/get-aspire-cli-pr.ps1 1234 -HiveOnly -Verbose
     ```
 
+## C# AppHost scaffolding
+
+When you run `aspire init` against a workspace using a `pr-<N>` CLI (such as one installed by the scripts above), the command writes a workspace-scoped `NuGet.config` to the solution root pinned to the matching `~/.aspire/hives/pr-<N>/packages/` feed. Package restore in the scaffolded C# AppHost resolves the PR build's `Aspire.Hosting.*` packages and `Aspire.AppHost.Sdk` from that hive.
+
+The same behavior applies to other non-stable CLI channels (`staging`, `daily`, locally-built `local`), with the workspace `NuGet.config` pinned to the matching channel feed — a remote Azure DevOps feed for `staging` / `daily`, a local hive for `local` / `run-*`.
+
+The file is scoped to the solution directory and only affects projects under it. It does not modify your user-level or machine-level NuGet configuration.
+
 ## Troubleshooting
 
 - "No workflow run found":

--- a/src/Aspire.Cli/Commands/InitCommand.cs
+++ b/src/Aspire.Cli/Commands/InitCommand.cs
@@ -235,6 +235,27 @@ internal sealed class InitCommand : BaseCommand
 
     private async Task<int> DropCSharpSingleFileSkeletonAsync(DirectoryInfo workingDirectory, CancellationToken cancellationToken)
     {
+        // Ensure the workspace has a NuGet.config that exposes the running CLI binary's
+        // identity-channel package sources (CliExecutionContext.IdentityChannel — stable,
+        // staging, daily, pr-<N>, or local). Run this BEFORE the apphost.cs-already-exists
+        // early return so re-running `aspire init` against a workspace produced by a
+        // previous broken CLI (which left apphost.cs without a workspace NuGet.config)
+        // recovers cleanly. The config is also required so MSBuild can resolve
+        // `#:sdk Aspire.AppHost.Sdk@<version>` from the SDK directive — both for
+        // `aspire add` (`dotnet package add --file apphost.cs`) and for
+        // `dotnet run --file apphost.cs`. Without it, any non-stable channel (PR/run
+        // hives, locally-built `local-*`/`dev-*` hives, the staging channel, etc.) is
+        // invisible and SDK resolution fails. `NuGetConfigMerger` underneath creates a
+        // new file or merges missing sources into an existing one.
+        var createdNuGetConfig = await _templateNuGetConfigService.CreateOrUpdateNuGetConfigWithoutPromptAsync(
+            channelName: _executionContext.IdentityChannel,
+            outputPath: workingDirectory.FullName,
+            cancellationToken).ConfigureAwait(false);
+        if (createdNuGetConfig)
+        {
+            InteractionService.DisplayMessage(KnownEmojis.Package, TemplatingStrings.NuGetConfigCreatedOrUpdatedConfirmationMessage);
+        }
+
         var appHostPath = Path.Combine(workingDirectory.FullName, "apphost.cs");
         if (File.Exists(appHostPath))
         {
@@ -257,29 +278,6 @@ internal sealed class InitCommand : BaseCommand
             """;
         File.WriteAllText(appHostPath, appHostContent);
         InteractionService.DisplayMessage(KnownEmojis.CheckMarkButton, "Created apphost.cs");
-
-        // Ensure the workspace has a NuGet.config that exposes the running CLI binary's
-        // identity-channel package sources (CliExecutionContext.IdentityChannel — stable,
-        // staging, daily, pr-<N>, or local). This is required so MSBuild can resolve
-        // `#:sdk Aspire.AppHost.Sdk@<version>` from the apphost.cs SDK directive — both
-        // for `aspire add` (`dotnet package add --file apphost.cs`) and for
-        // `dotnet run --file apphost.cs`. Without it, any non-stable channel (PR/run
-        // hives, locally-built `local-*`/`dev-*` hives, the staging channel, etc.)
-        // is invisible and SDK resolution fails. Mirrors how `aspire new` handles
-        // template output via the same shared service; `NuGetConfigMerger` underneath
-        // creates a new file or merges missing sources into an existing one, so adding
-        // hives later is handled the same way as for templates.
-        var createdNuGetConfig = await _templateNuGetConfigService.CreateOrUpdateNuGetConfigWithoutPromptAsync(
-            channelName: _executionContext.IdentityChannel,
-            outputPath: workingDirectory.FullName,
-            cancellationToken).ConfigureAwait(false);
-        if (createdNuGetConfig)
-        {
-            // Use a confirmation message that does NOT contain the literal substring
-            // "NuGet.config" — the AspireInitAsync E2E helper false-matches that
-            // substring as a Y/n prompt and gets out of sync with the real prompts.
-            InteractionService.DisplayMessage(KnownEmojis.CheckMarkButton, "Created package sources file");
-        }
 
         // Generate one set of ports so aspire.config.json (used by `aspire run`) and
         // apphost.run.json (used by `dotnet run apphost.cs`) agree on the dashboard /
@@ -313,6 +311,33 @@ internal sealed class InitCommand : BaseCommand
         var solutionName = Path.GetFileNameWithoutExtension(solutionFile.Name);
         var appHostDirName = $"{solutionName}.AppHost";
         var appHostDirPath = Path.Combine(solutionDir.FullName, appHostDirName);
+
+        // Drop the solution-directory NuGet.config BEFORE the AppHost-dir-already-exists
+        // early return so re-running `aspire init` against a workspace produced by a
+        // previous broken CLI (which left a `<sln>.AppHost/` without a workspace
+        // NuGet.config) recovers cleanly. Writing here is also required BEFORE
+        // `_runner.NewProjectAsync` so the aspire-apphost template's built-in `restore`
+        // post-action (template.json post-action id "restore", conditioned on
+        // !skipRestore which defaults to false) can resolve the
+        // `Aspire.AppHost.Sdk/<version>` reference from the channel-matched hive. The
+        // post-action currently runs with continueOnError=true so a missing nuget.config
+        // wouldn't fail init, but its restore would still emit confusing errors and waste
+        // work — and a future template change that drops continueOnError would break init
+        // outright.
+        //
+        // Source: CliExecutionContext.IdentityChannel (stable / staging / daily / pr-<N> /
+        // local). NuGetConfigMerger underneath creates a new file or merges missing
+        // sources into an existing one, so adding hives later is handled the same way as
+        // for templates. Mirrors what DropCSharpSingleFileSkeletonAsync already does for
+        // the apphost.cs path on every channel.
+        var createdNuGetConfig = await _templateNuGetConfigService.CreateOrUpdateNuGetConfigWithoutPromptAsync(
+            channelName: _executionContext.IdentityChannel,
+            outputPath: solutionDir.FullName,
+            cancellationToken).ConfigureAwait(false);
+        if (createdNuGetConfig)
+        {
+            InteractionService.DisplayMessage(KnownEmojis.Package, TemplatingStrings.NuGetConfigCreatedOrUpdatedConfirmationMessage);
+        }
 
         if (Directory.Exists(appHostDirPath))
         {

--- a/tests/Aspire.Cli.EndToEnd.Tests/CSharpProjectModeInitTests.cs
+++ b/tests/Aspire.Cli.EndToEnd.Tests/CSharpProjectModeInitTests.cs
@@ -1,0 +1,182 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Xml.Linq;
+using Aspire.Cli.EndToEnd.Tests.Helpers;
+using Aspire.Cli.Tests.Utils;
+using Hex1b.Automation;
+using Xunit;
+
+namespace Aspire.Cli.EndToEnd.Tests;
+
+/// <summary>
+/// E2E coverage for <c>aspire init</c>'s C# project-mode path (the workspace contains a
+/// <c>.sln</c> or <c>.slnx</c>, so <c>SolutionLocator</c> routes init to
+/// <c>DropCSharpProjectSkeletonAsync</c> instead of the single-file branch).
+/// </summary>
+/// <remarks>
+/// <para>
+/// The single-file path is exercised by <see cref="SingleFileAppHostInitDotnetRunTests"/>.
+/// Every other E2E that invokes <c>aspire init</c> starts in an empty workspace, so
+/// init deterministically takes the single-file branch — the project-mode skeleton drop
+/// (<c>dotnet new aspire-apphost</c> + workspace <c>nuget.config</c> write + template
+/// install) is otherwise only exercised by unit tests with a mocked
+/// <c>IDotNetCliRunner</c>. Regressions in <c>TemplateNuGetConfigService</c>,
+/// <c>NuGetConfigMerger</c> write semantics, the <c>aspire-apphost</c> template's
+/// <c>restore</c> post-action, or <c>SolutionLocator</c>'s <c>.sln</c>/<c>.slnx</c>
+/// discovery would slip through unit coverage but be caught here.
+/// </para>
+/// <para>
+/// On a non-stable CLI channel (<c>pr-&lt;N&gt;</c>, locally-built <c>local</c>,
+/// <c>staging</c>, <c>daily</c>), <c>Aspire.AppHost.Sdk/&lt;version&gt;</c> exists only
+/// in the channel feed and not on nuget.org. If the workspace <c>nuget.config</c> isn't
+/// written to the solution dir before <c>dotnet new aspire-apphost</c>'s built-in
+/// <c>restore</c> post-action runs (or before a follow-up <c>dotnet build</c>), SDK
+/// resolution fails with <c>error MSB4236: The SDK 'Aspire.AppHost.Sdk/...' could not
+/// be found</c>. That is the exact failure mode of the bug fixed by
+/// https://github.com/microsoft/aspire/issues/17104.
+/// </para>
+/// </remarks>
+public sealed class CSharpProjectModeInitTests(ITestOutputHelper output)
+{
+    /// <summary>
+    /// Runs <c>aspire init</c> in a workspace containing a stub solution file, then
+    /// verifies that the generated <c>Test.AppHost/Test.AppHost.csproj</c> can be
+    /// built against the channel-matched hive.
+    /// </summary>
+    /// <remarks>
+    /// The <c>dotnet build</c> step is the regression assertion: without the workspace
+    /// <c>nuget.config</c> written by <c>DropCSharpProjectSkeletonAsync</c>, MSBuild
+    /// cannot resolve <c>Aspire.AppHost.Sdk/&lt;version&gt;</c> from the local-archive
+    /// or PR hive and fails with MSB4236. On the stable channel the same write happens
+    /// (with <c>&lt;clear/&gt;</c> + nuget.org as the only source), so the assertion
+    /// still meaningfully exercises the new code path.
+    /// </remarks>
+    [CaptureWorkspaceOnFailure]
+    [Theory]
+    [InlineData("Test.sln")]
+    [InlineData("Test.slnx")]
+    public async Task AspireInitWithSolutionFileGeneratesAppHostThatBuildsAgainstChannelHive(string solutionFileName)
+    {
+        var repoRoot = CliE2ETestHelpers.GetRepoRoot();
+        var strategy = CliInstallStrategy.Detect(output.WriteLine);
+        var workspace = TemporaryWorkspace.Create(output);
+
+        // Pre-create a stub solution file so SolutionLocator routes init to project mode.
+        // The contents are not inspected — SolutionLocator only looks at the extension —
+        // and the follow-up `dotnet build` is invoked on the generated .csproj directly.
+        var solutionPath = Path.Combine(workspace.WorkspaceRoot.FullName, solutionFileName);
+        File.WriteAllText(solutionPath, "Fake solution file");
+
+        using var terminal = CliE2ETestHelpers.CreateDockerTestTerminal(repoRoot, strategy, output, mountDockerSocket: false, workspace: workspace);
+
+        var pendingRun = terminal.RunAsync(TestContext.Current.CancellationToken);
+
+        var counter = new SequenceCounter();
+        var auto = new Hex1bTerminalAutomator(terminal, defaultTimeout: TimeSpan.FromSeconds(500));
+
+        await auto.PrepareDockerEnvironmentAsync(counter, workspace);
+        await auto.InstallAspireCliAsync(strategy, counter);
+
+        // `AspireInitAsync` runs `aspire init --language csharp` and handles any NuGet.config /
+        // URLs / agent-init prompts that may appear. Routing to project-mode happens after
+        // language selection via SolutionLocator regardless of how the language was chosen,
+        // so the --language flag is equivalent to accepting the interactive '> C#' default
+        // for the purposes of this regression.
+        await auto.AspireInitAsync(counter);
+
+        var workspaceNuGetConfig = Path.Combine(workspace.WorkspaceRoot.FullName, "nuget.config");
+        var appHostCsproj = Path.Combine(workspace.WorkspaceRoot.FullName, "Test.AppHost", "Test.AppHost.csproj");
+
+        Assert.True(
+            File.Exists(workspaceNuGetConfig),
+            $"Expected workspace nuget.config next to the solution at: {workspaceNuGetConfig}. "
+            + "Without it, the channel-pinned Aspire.AppHost.Sdk/<version> cannot be resolved on non-stable CLI channels.");
+        Assert.True(File.Exists(appHostCsproj), $"Expected AppHost csproj at: {appHostCsproj}");
+
+        // Sanity that the workspace nuget.config actually carries package sources. Full
+        // structural assertions (<clear/>, packageSourceMapping shape, channel-feed name)
+        // live in InitCommand_ProjectMode_NoChannelOverride_* unit tests — this E2E only
+        // needs to confirm a real file was written before letting `dotnet build` exercise
+        // it for real.
+        var nuGetConfigDoc = XDocument.Load(workspaceNuGetConfig);
+        Assert.NotEmpty(nuGetConfigDoc.Root!.Elements("packageSources").Elements("add"));
+
+        // The regression assertion: without the channel-pinned workspace nuget.config,
+        // `dotnet build` fails with `error MSB4236: The SDK 'Aspire.AppHost.Sdk/...'
+        // could not be found.` 3 minutes is enough headroom for a cold restore + build on
+        // CI; the cache-hit case (the template's `restore` post-action already populated
+        // ~/.nuget/packages during init) finishes well under 30 seconds. Using the
+        // fail-fast helper so a build failure surfaces immediately via the shell's
+        // numbered ERR prompt instead of timing out.
+        await auto.RunCommandFailFastAsync(
+            "dotnet build Test.AppHost/Test.AppHost.csproj",
+            counter,
+            TimeSpan.FromMinutes(3));
+
+        await auto.TypeAsync("exit");
+        await auto.EnterAsync();
+        await pendingRun;
+    }
+
+    /// <summary>
+    /// Rerun-recovery: when a previous broken CLI run left the AppHost dir scaffolded
+    /// but no workspace <c>nuget.config</c>, re-running <c>aspire init</c> should write
+    /// the missing config and exit successfully without disturbing files left in the
+    /// AppHost dir.
+    /// </summary>
+    /// <remarks>
+    /// Guards the placement of the <c>CreateOrUpdateNuGetConfigWithoutPromptAsync</c>
+    /// call BEFORE the <c>Directory.Exists(appHostDirPath)</c> early return in
+    /// <c>DropCSharpProjectSkeletonAsync</c>. A refactor that moves the helper call back
+    /// below the early return would leave users on a broken workspace with no recovery
+    /// path short of deleting the half-scaffolded AppHost dir manually.
+    /// </remarks>
+    [CaptureWorkspaceOnFailure]
+    [Fact]
+    public async Task AspireInitWithExistingAppHostDirRecreatesMissingNuGetConfigAndPreservesFiles()
+    {
+        var repoRoot = CliE2ETestHelpers.GetRepoRoot();
+        var strategy = CliInstallStrategy.Detect(output.WriteLine);
+        var workspace = TemporaryWorkspace.Create(output);
+
+        // Simulate the broken state a previous CLI version could leave: a solution +
+        // half-scaffolded AppHost dir with a user-touched file, but no workspace
+        // nuget.config. The recovery path must (a) write the missing nuget.config, (b)
+        // leave the AppHost dir alone, and (c) exit successfully.
+        var solutionPath = Path.Combine(workspace.WorkspaceRoot.FullName, "Test.sln");
+        File.WriteAllText(solutionPath, "Fake solution file");
+        var appHostDir = Directory.CreateDirectory(Path.Combine(workspace.WorkspaceRoot.FullName, "Test.AppHost"));
+        var leftoverPath = Path.Combine(appHostDir.FullName, "leftover.txt");
+        const string LeftoverContent = "user file from a previous broken init";
+        File.WriteAllText(leftoverPath, LeftoverContent);
+
+        using var terminal = CliE2ETestHelpers.CreateDockerTestTerminal(repoRoot, strategy, output, mountDockerSocket: false, workspace: workspace);
+
+        var pendingRun = terminal.RunAsync(TestContext.Current.CancellationToken);
+
+        var counter = new SequenceCounter();
+        var auto = new Hex1bTerminalAutomator(terminal, defaultTimeout: TimeSpan.FromSeconds(500));
+
+        await auto.PrepareDockerEnvironmentAsync(counter, workspace);
+        await auto.InstallAspireCliAsync(strategy, counter);
+
+        // The early-return path still chains through the common agent-init prompt at the
+        // end of the init flow, so `AspireInitAsync` reaches its terminal state cleanly.
+        await auto.AspireInitAsync(counter);
+
+        var workspaceNuGetConfig = Path.Combine(workspace.WorkspaceRoot.FullName, "nuget.config");
+
+        Assert.True(
+            File.Exists(workspaceNuGetConfig),
+            $"Expected workspace nuget.config next to the solution at: {workspaceNuGetConfig}. "
+            + "The CreateOrUpdateNuGetConfigWithoutPromptAsync call must run BEFORE the "
+            + "Directory.Exists(appHostDirPath) early return so reruns recover the missing config.");
+        Assert.True(File.Exists(leftoverPath), $"Pre-existing AppHost file should be preserved: {leftoverPath}");
+        Assert.Equal(LeftoverContent, File.ReadAllText(leftoverPath));
+
+        await auto.TypeAsync("exit");
+        await auto.EnterAsync();
+        await pendingRun;
+    }
+}

--- a/tests/Aspire.Cli.Tests/Commands/InitCommandTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/InitCommandTests.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Text.Json.Nodes;
+using System.Xml.Linq;
 using Aspire.Cli.Agents;
 using Aspire.Cli.Commands;
 using Aspire.Cli.Configuration;
@@ -626,6 +627,14 @@ public class InitCommandTests(ITestOutputHelper outputHelper)
         // The implicit channel surfaces the package's Source field as the nugetSource even when no
         // temporary config is generated, so nugetSource may be non-null. The contract this test guards
         // is that nugetConfigFile stays null on the implicit channel.
+
+        // The fix must also leave the solution-directory NuGet.config alone on the implicit
+        // channel — TemplateNuGetConfigService.CreateOrUpdateNuGetConfigWithoutPromptAsync
+        // short-circuits when the matched channel is not Explicit. A regression that dropped
+        // the channel-type guard would silently create a workspace NuGet.config here.
+        Assert.False(
+            File.Exists(Path.Combine(workspace.WorkspaceRoot.FullName, "nuget.config")),
+            "implicit channel must not write a workspace nuget.config in the solution directory.");
     }
 
     [Fact]
@@ -897,8 +906,7 @@ public class InitCommandTests(ITestOutputHelper outputHelper)
         var nugetConfigPath = Path.Combine(workspace.WorkspaceRoot.FullName, "nuget.config");
         Assert.True(File.Exists(nugetConfigPath), $"nuget.config should be created in workspace for channel '{contextChannel}'.");
 
-        var nugetConfigContent = File.ReadAllText(nugetConfigPath);
-        Assert.Contains(SourceForChannel(contextChannel), nugetConfigContent);
+        AssertNuGetConfigHasChannelShape(nugetConfigPath, contextChannel);
     }
 
     /// <summary>
@@ -1055,6 +1063,437 @@ public class InitCommandTests(ITestOutputHelper outputHelper)
         Assert.Equal("13.3.0", capturedTemplateVersion);
     }
 
+    /// <summary>
+    /// Project-mode counterpart to
+    /// <see cref="InitCommand_SingleFileMode_NoChannelOverride_WiresNuGetConfigToCliExecutionContextChannel"/>.
+    /// When the user does not pass <c>--channel</c>, the project-mode init path must wire a
+    /// <c>NuGet.config</c> in the solution directory to the channel baked into the running CLI
+    /// binary (exposed as <see cref="CliExecutionContext.IdentityChannel"/>) BEFORE invoking
+    /// <c>dotnet new aspire-apphost</c>, so the aspire-apphost template's built-in
+    /// <c>restore</c> post-action (template.json, conditioned on <c>!skipRestore</c>) can
+    /// resolve <c>Aspire.AppHost.Sdk/&lt;version&gt;</c> from the channel-matched hive
+    /// instead of probing only the user-level feeds. Without the right ordering the
+    /// post-action restore silently fails (it runs with <c>continueOnError=true</c>),
+    /// wasting work and emitting confusing errors. The capture inside
+    /// <c>NewProjectAsyncCallback</c> guards both the ordering and the file content; the
+    /// final structural assertion guards <c>&lt;clear/&gt;</c> + <c>Aspire*</c> mapping
+    /// correctness.
+    /// </summary>
+    [Theory]
+    [InlineData("stable")]
+    [InlineData("staging")]
+    [InlineData("daily")]
+    [InlineData("pr-12345")]
+    public async Task InitCommand_ProjectMode_NoChannelOverride_WiresNuGetConfigInSolutionDirToCliExecutionContextChannel(string contextChannel)
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+
+        var solutionFile = new FileInfo(Path.Combine(workspace.WorkspaceRoot.FullName, "Test.sln"));
+        File.WriteAllText(solutionFile.FullName, "Fake solution file");
+
+        var nugetConfigPath = Path.Combine(workspace.WorkspaceRoot.FullName, "nuget.config");
+        string? nugetConfigContentAtNewProjectTime = null;
+
+        var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper, options =>
+        {
+            options.CliExecutionContextFactory = _ => CreateExecutionContextForChannel(workspace.WorkspaceRoot, contextChannel);
+            options.PackagingServiceFactory = _ => CreateNamedChannelPackagingService(contextChannel);
+
+            options.DotNetCliRunnerFactory = _ =>
+            {
+                var runner = new TestDotNetCliRunner();
+                runner.InstallTemplateAsyncCallback = (_, version, _, _, _, _, _) => (0, version);
+                runner.NewProjectAsyncCallback = (_, _, outputPath, _, _) =>
+                {
+                    // The aspire-apphost template's restore post-action depends on the
+                    // workspace nuget.config being on disk AND containing the channel
+                    // source before `dotnet new` runs; capture the actual file content
+                    // (not just existence) so a regression that writes a stale file first
+                    // and updates it afterward would still be caught.
+                    nugetConfigContentAtNewProjectTime = File.Exists(nugetConfigPath)
+                        ? File.ReadAllText(nugetConfigPath)
+                        : null;
+                    Directory.CreateDirectory(outputPath);
+                    return 0;
+                };
+                return runner;
+            };
+        });
+
+        var serviceProvider = services.BuildServiceProvider();
+        var initCommand = serviceProvider.GetRequiredService<InitCommand>();
+
+        var parseResult = initCommand.Parse("init");
+        var exitCode = await parseResult.InvokeAsync().DefaultTimeout();
+
+        Assert.Equal(ExitCodeConstants.Success, exitCode);
+
+        Assert.True(File.Exists(nugetConfigPath), $"nuget.config should be created in the solution directory for channel '{contextChannel}'.");
+        Assert.NotNull(nugetConfigContentAtNewProjectTime);
+        Assert.Contains(SourceForChannel(contextChannel), nugetConfigContentAtNewProjectTime!);
+
+        AssertNuGetConfigHasChannelShape(nugetConfigPath, contextChannel);
+    }
+
+    /// <summary>
+    /// Guards the recover-on-rerun contract: a user who ran a previously broken CLI (which
+    /// produced an AppHost project but did NOT write a workspace NuGet.config) reruns
+    /// <c>aspire init</c> against the fixed CLI and now has a working workspace. The fix
+    /// in <c>DropCSharpProjectSkeletonAsync</c> writes the workspace NuGet.config BEFORE the
+    /// AppHost-dir-already-exists early return — moving the write below the guard would
+    /// silently regress this scenario because the early return reports Success without
+    /// running channel-aware setup.
+    /// </summary>
+    [Fact]
+    public async Task InitCommand_ProjectMode_RerunWithExistingAppHostDirAndMissingNuGetConfig_CreatesNuGetConfig()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+
+        var solutionFile = new FileInfo(Path.Combine(workspace.WorkspaceRoot.FullName, "Test.sln"));
+        File.WriteAllText(solutionFile.FullName, "Fake solution file");
+
+        // Simulate the post-broken-init starting state: AppHost dir already exists, no workspace nuget.config.
+        var appHostDir = new DirectoryInfo(Path.Combine(workspace.WorkspaceRoot.FullName, "Test.AppHost"));
+        appHostDir.Create();
+        Assert.False(File.Exists(Path.Combine(workspace.WorkspaceRoot.FullName, "nuget.config")));
+
+        var contextChannel = "staging";
+
+        var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper, options =>
+        {
+            options.CliExecutionContextFactory = _ => CreateExecutionContextForChannel(workspace.WorkspaceRoot, contextChannel);
+            options.PackagingServiceFactory = _ => CreateNamedChannelPackagingService(contextChannel);
+            // No DotNetCliRunner override — InstallTemplate / NewProject must NOT be invoked
+            // because the AppHost dir already exists. The default TestDotNetCliRunner throws
+            // on any unhandled callback, so this also guards the contract that nothing
+            // template-related runs on the rerun-recovery path.
+        });
+
+        var serviceProvider = services.BuildServiceProvider();
+        var initCommand = serviceProvider.GetRequiredService<InitCommand>();
+
+        var parseResult = initCommand.Parse("init");
+        var exitCode = await parseResult.InvokeAsync().DefaultTimeout();
+
+        Assert.Equal(ExitCodeConstants.Success, exitCode);
+        var nugetConfigPath = Path.Combine(workspace.WorkspaceRoot.FullName, "nuget.config");
+        Assert.True(File.Exists(nugetConfigPath), "rerun must create the workspace nuget.config even though the AppHost dir already exists.");
+        AssertNuGetConfigHasChannelShape(nugetConfigPath, contextChannel);
+    }
+
+    /// <summary>
+    /// Single-file counterpart of
+    /// <see cref="InitCommand_ProjectMode_RerunWithExistingAppHostDirAndMissingNuGetConfig_CreatesNuGetConfig"/>.
+    /// When <c>apphost.cs</c> already exists from a previous broken CLI but no workspace
+    /// NuGet.config was written, the rerun must still drop the NuGet.config in the working
+    /// directory so the existing apphost can resolve the channel-pinned SDK.
+    /// </summary>
+    [Fact]
+    public async Task InitCommand_SingleFileMode_RerunWithExistingAppHostFileAndMissingNuGetConfig_CreatesNuGetConfig()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+
+        // Simulate the post-broken-init starting state: apphost.cs exists, no nuget.config.
+        var appHostPath = Path.Combine(workspace.WorkspaceRoot.FullName, "apphost.cs");
+        File.WriteAllText(appHostPath, "#:sdk Aspire.AppHost.Sdk@13.4.0-staging.x\nbuilder.Build().Run();");
+        Assert.False(File.Exists(Path.Combine(workspace.WorkspaceRoot.FullName, "nuget.config")));
+
+        var contextChannel = "staging";
+
+        var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper, options =>
+        {
+            options.CliExecutionContextFactory = _ => CreateExecutionContextForChannel(workspace.WorkspaceRoot, contextChannel);
+            options.PackagingServiceFactory = _ => CreateNamedChannelPackagingService(contextChannel);
+        });
+
+        var serviceProvider = services.BuildServiceProvider();
+        var initCommand = serviceProvider.GetRequiredService<InitCommand>();
+
+        var parseResult = initCommand.Parse("init");
+        var exitCode = await parseResult.InvokeAsync().DefaultTimeout();
+
+        Assert.Equal(ExitCodeConstants.Success, exitCode);
+        var nugetConfigPath = Path.Combine(workspace.WorkspaceRoot.FullName, "nuget.config");
+        Assert.True(File.Exists(nugetConfigPath), "rerun must create the workspace nuget.config even though apphost.cs already exists.");
+        AssertNuGetConfigHasChannelShape(nugetConfigPath, contextChannel);
+    }
+
+    /// <summary>
+    /// When the solution file lives in a subdirectory of the CLI's working directory,
+    /// <c>SolutionLocator</c> still finds it (it searches with <c>SearchOption.AllDirectories</c>),
+    /// and the workspace NuGet.config must be written next to the solution — not at the
+    /// working directory root. A mutation that passed <c>workingDirectory.FullName</c> instead
+    /// of <c>solutionDir.FullName</c> to <c>CreateOrUpdateNuGetConfigWithoutPromptAsync</c>
+    /// would put the file in the wrong place and the AppHost wouldn't resolve.
+    /// </summary>
+    [Fact]
+    public async Task InitCommand_ProjectMode_SolutionInSubdirectory_WritesNuGetConfigNextToSolutionNotInWorkingDirectory()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+
+        var solutionDir = workspace.WorkspaceRoot.CreateSubdirectory("nested");
+        var solutionFile = new FileInfo(Path.Combine(solutionDir.FullName, "Test.sln"));
+        File.WriteAllText(solutionFile.FullName, "Fake solution file");
+
+        var contextChannel = "staging";
+
+        var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper, options =>
+        {
+            options.CliExecutionContextFactory = _ => CreateExecutionContextForChannel(workspace.WorkspaceRoot, contextChannel);
+            options.PackagingServiceFactory = _ => CreateNamedChannelPackagingService(contextChannel);
+
+            options.DotNetCliRunnerFactory = _ =>
+            {
+                var runner = new TestDotNetCliRunner();
+                runner.InstallTemplateAsyncCallback = (_, version, _, _, _, _, _) => (0, version);
+                runner.NewProjectAsyncCallback = (_, _, outputPath, _, _) =>
+                {
+                    Directory.CreateDirectory(outputPath);
+                    return 0;
+                };
+                return runner;
+            };
+        });
+
+        var serviceProvider = services.BuildServiceProvider();
+        var initCommand = serviceProvider.GetRequiredService<InitCommand>();
+
+        var parseResult = initCommand.Parse("init");
+        var exitCode = await parseResult.InvokeAsync().DefaultTimeout();
+
+        Assert.Equal(ExitCodeConstants.Success, exitCode);
+        Assert.True(File.Exists(Path.Combine(solutionDir.FullName, "nuget.config")),
+            "nuget.config must be written in the solution directory, not the working directory.");
+        Assert.False(File.Exists(Path.Combine(workspace.WorkspaceRoot.FullName, "nuget.config")),
+            "nuget.config must NOT be written in the working directory when the solution lives in a subdirectory.");
+        AssertNuGetConfigHasChannelShape(Path.Combine(solutionDir.FullName, "nuget.config"), contextChannel);
+    }
+
+    /// <summary>
+    /// When a NuGet.config already exists in the solution directory with the user's own
+    /// package source, <c>aspire init</c> must merge the channel feed in (via
+    /// <c>NuGetConfigMerger.UpdateExistingNuGetConfigAsync</c>) instead of clobbering the
+    /// file. The merger has its own unit tests; this test guards the InitCommand-level
+    /// integration so a regression in how the helper is invoked from the command path
+    /// (wrong arg, missing call, accidental overwrite) doesn't slip through.
+    /// </summary>
+    [Fact]
+    public async Task InitCommand_ProjectMode_WithPreExistingNuGetConfig_PreservesUserSourcesAndAddsChannelSource()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+
+        var solutionFile = new FileInfo(Path.Combine(workspace.WorkspaceRoot.FullName, "Test.sln"));
+        File.WriteAllText(solutionFile.FullName, "Fake solution file");
+
+        const string userFeedUrl = "https://contoso.example.invalid/v3/index.json";
+        const string nugetConfigContent = $$"""
+            <?xml version="1.0" encoding="utf-8"?>
+            <configuration>
+              <packageSources>
+                <add key="contoso" value="{{userFeedUrl}}" />
+              </packageSources>
+            </configuration>
+            """;
+        var nugetConfigPath = Path.Combine(workspace.WorkspaceRoot.FullName, "nuget.config");
+        File.WriteAllText(nugetConfigPath, nugetConfigContent);
+
+        var contextChannel = "staging";
+
+        var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper, options =>
+        {
+            options.CliExecutionContextFactory = _ => CreateExecutionContextForChannel(workspace.WorkspaceRoot, contextChannel);
+            options.PackagingServiceFactory = _ => CreateNamedChannelPackagingService(contextChannel);
+
+            options.DotNetCliRunnerFactory = _ =>
+            {
+                var runner = new TestDotNetCliRunner();
+                runner.InstallTemplateAsyncCallback = (_, version, _, _, _, _, _) => (0, version);
+                runner.NewProjectAsyncCallback = (_, _, outputPath, _, _) =>
+                {
+                    Directory.CreateDirectory(outputPath);
+                    return 0;
+                };
+                return runner;
+            };
+        });
+
+        var serviceProvider = services.BuildServiceProvider();
+        var initCommand = serviceProvider.GetRequiredService<InitCommand>();
+
+        var parseResult = initCommand.Parse("init");
+        var exitCode = await parseResult.InvokeAsync().DefaultTimeout();
+
+        Assert.Equal(ExitCodeConstants.Success, exitCode);
+
+        var merged = File.ReadAllText(nugetConfigPath);
+        Assert.Contains(userFeedUrl, merged);
+        Assert.Contains(SourceForChannel(contextChannel), merged);
+    }
+
+    /// <summary>
+    /// When multiple explicit channels are registered (mirroring real
+    /// <c>PackagingService</c> which exposes stable + optional staging + daily + PR hives
+    /// simultaneously), the helper must select the channel whose name matches
+    /// <c>CliExecutionContext.IdentityChannel</c> — not just "the first explicit channel".
+    /// A mutation that took the first explicit channel would silently wire a daily-channel
+    /// CLI to stable sources.
+    /// </summary>
+    [Fact]
+    public async Task InitCommand_ProjectMode_MultipleExplicitChannels_PicksChannelMatchingIdentity()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+
+        var solutionFile = new FileInfo(Path.Combine(workspace.WorkspaceRoot.FullName, "Test.sln"));
+        File.WriteAllText(solutionFile.FullName, "Fake solution file");
+
+        var contextChannel = "daily";
+
+        var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper, options =>
+        {
+            options.CliExecutionContextFactory = _ => CreateExecutionContextForChannel(workspace.WorkspaceRoot, contextChannel);
+            // Register stable + staging + daily simultaneously. The matching channel ("daily")
+            // is not the first one in the list.
+            options.PackagingServiceFactory = _ => CreateMultiChannelPackagingService("stable", "staging", "daily");
+
+            options.DotNetCliRunnerFactory = _ =>
+            {
+                var runner = new TestDotNetCliRunner();
+                runner.InstallTemplateAsyncCallback = (_, version, _, _, _, _, _) => (0, version);
+                runner.NewProjectAsyncCallback = (_, _, outputPath, _, _) =>
+                {
+                    Directory.CreateDirectory(outputPath);
+                    return 0;
+                };
+                return runner;
+            };
+        });
+
+        var serviceProvider = services.BuildServiceProvider();
+        var initCommand = serviceProvider.GetRequiredService<InitCommand>();
+
+        var parseResult = initCommand.Parse("init");
+        var exitCode = await parseResult.InvokeAsync().DefaultTimeout();
+
+        Assert.Equal(ExitCodeConstants.Success, exitCode);
+        var nugetConfigPath = Path.Combine(workspace.WorkspaceRoot.FullName, "nuget.config");
+        var content = File.ReadAllText(nugetConfigPath);
+
+        Assert.Contains(SourceForChannel("daily"), content);
+        Assert.DoesNotContain(SourceForChannel("stable"), content);
+        Assert.DoesNotContain(SourceForChannel("staging"), content);
+        AssertNuGetConfigHasChannelShape(nugetConfigPath, "daily");
+    }
+
+    /// <summary>
+    /// Locally-built CLI (IdentityChannel == <c>local</c>) on a machine where no <c>local</c>
+    /// channel is registered (e.g. <c>~/.aspire/hives/local</c> isn't materialized). The fix
+    /// helper must short-circuit (return <see langword="false"/>) instead of throwing — a
+    /// regression that threw on the no-matching-channel branch would crash every locally-built
+    /// CLI run. <c>DropCSharpProjectSkeletonAsync</c> additionally falls back to the implicit
+    /// channel for template install via its <c>ChannelNotFoundException</c> handler, so init
+    /// must still complete successfully.
+    /// </summary>
+    [Fact]
+    public async Task InitCommand_ProjectMode_LocalIdentityChannelWithNoLocalChannelRegistered_DoesNotWriteNuGetConfig()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+
+        var solutionFile = new FileInfo(Path.Combine(workspace.WorkspaceRoot.FullName, "Test.sln"));
+        File.WriteAllText(solutionFile.FullName, "Fake solution file");
+
+        var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper, options =>
+        {
+            options.CliExecutionContextFactory = _ =>
+                BuildExecutionContext(workspace.WorkspaceRoot, channel: PackageChannelNames.Local);
+
+            // Packaging service exposes only the implicit channel — no "local" channel.
+            options.PackagingServiceFactory = _ =>
+            {
+                var fakeCache = new FakeNuGetPackageCache
+                {
+                    GetTemplatePackagesAsyncCallback = (_, _, _, _) =>
+                        Task.FromResult<IEnumerable<NuGetPackageCli>>(
+                            [new NuGetPackageCli { Id = "Aspire.ProjectTemplates", Source = "nuget.org", Version = "13.3.0" }])
+                };
+                var implicitChannel = PackageChannel.CreateImplicitChannel(fakeCache);
+                return new TestPackagingService
+                {
+                    GetChannelsAsyncCallback = _ => Task.FromResult<IEnumerable<PackageChannel>>([implicitChannel])
+                };
+            };
+
+            options.DotNetCliRunnerFactory = _ =>
+            {
+                var runner = new TestDotNetCliRunner();
+                runner.InstallTemplateAsyncCallback = (_, version, _, _, _, _, _) => (0, version);
+                runner.NewProjectAsyncCallback = (_, _, outputPath, _, _) =>
+                {
+                    Directory.CreateDirectory(outputPath);
+                    return 0;
+                };
+                return runner;
+            };
+        });
+
+        var serviceProvider = services.BuildServiceProvider();
+        var initCommand = serviceProvider.GetRequiredService<InitCommand>();
+
+        var parseResult = initCommand.Parse("init");
+        var exitCode = await parseResult.InvokeAsync().DefaultTimeout();
+
+        Assert.Equal(ExitCodeConstants.Success, exitCode);
+        Assert.False(
+            File.Exists(Path.Combine(workspace.WorkspaceRoot.FullName, "nuget.config")),
+            "no workspace nuget.config should be written when no matching channel exists for IdentityChannel='local'.");
+    }
+
+    /// <summary>
+    /// <c>SolutionLocator</c> handles both <c>.sln</c> and <c>.slnx</c> formats
+    /// (<c>SolutionLocator.GetSolutionFilesInDirectoryAndSubfoldersAsync</c>). The
+    /// project-mode theory above covers <c>.sln</c>; this guards that the <c>.slnx</c>
+    /// path produces an equivalently-wired workspace NuGet.config so a future divergence
+    /// (e.g. a switch on extension that skipped the nuget.config write) would be caught.
+    /// </summary>
+    [Fact]
+    public async Task InitCommand_ProjectMode_WithSlnxSolutionFile_WiresWorkspaceNuGetConfig()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+
+        var solutionFile = new FileInfo(Path.Combine(workspace.WorkspaceRoot.FullName, "Test.slnx"));
+        File.WriteAllText(solutionFile.FullName, """<Solution />""");
+
+        var contextChannel = "staging";
+
+        var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper, options =>
+        {
+            options.CliExecutionContextFactory = _ => CreateExecutionContextForChannel(workspace.WorkspaceRoot, contextChannel);
+            options.PackagingServiceFactory = _ => CreateNamedChannelPackagingService(contextChannel);
+
+            options.DotNetCliRunnerFactory = _ =>
+            {
+                var runner = new TestDotNetCliRunner();
+                runner.InstallTemplateAsyncCallback = (_, version, _, _, _, _, _) => (0, version);
+                runner.NewProjectAsyncCallback = (_, _, outputPath, _, _) =>
+                {
+                    Directory.CreateDirectory(outputPath);
+                    return 0;
+                };
+                return runner;
+            };
+        });
+
+        var serviceProvider = services.BuildServiceProvider();
+        var initCommand = serviceProvider.GetRequiredService<InitCommand>();
+
+        var parseResult = initCommand.Parse("init");
+        var exitCode = await parseResult.InvokeAsync().DefaultTimeout();
+
+        Assert.Equal(ExitCodeConstants.Success, exitCode);
+        var nugetConfigPath = Path.Combine(workspace.WorkspaceRoot.FullName, "nuget.config");
+        Assert.True(File.Exists(nugetConfigPath));
+        AssertNuGetConfigHasChannelShape(nugetConfigPath, contextChannel);
+    }
+
     private static CliExecutionContext CreateExecutionContextForChannel(DirectoryInfo workingDirectory, string contextChannel)
     {
         return BuildExecutionContext(workingDirectory, channel: contextChannel);
@@ -1079,31 +1518,78 @@ public class InitCommandTests(ITestOutputHelper outputHelper)
     }
 
     private static TestPackagingService CreateNamedChannelPackagingService(string channelName)
+        => CreateMultiChannelPackagingService(channelName);
+
+    /// <summary>
+    /// Returns a <see cref="TestPackagingService"/> exposing one named explicit channel per
+    /// entry in <paramref name="channelNames"/>, each with two mappings (<c>Aspire* → channelSource</c>
+    /// and <c>* → fallbackSource</c>) so consumers can assert <c>&lt;packageSourceMapping&gt;</c>
+    /// shape — not just that one URL appears in the file. The real <see cref="PackagingService"/>
+    /// exposes multiple explicit channels simultaneously (stable, optional staging, daily,
+    /// PR hives), so registering more than one here lets a test prove the resolver picks the
+    /// channel matching <see cref="CliExecutionContext.IdentityChannel"/> rather than just
+    /// taking the first explicit channel.
+    /// </summary>
+    private static TestPackagingService CreateMultiChannelPackagingService(params string[] channelNames)
     {
-        var source = SourceForChannel(channelName);
-        var version = "13.3.0";
-
-        var fakeCache = new FakeNuGetPackageCache
+        var channels = channelNames.Select(channelName =>
         {
-            GetTemplatePackagesAsyncCallback = (_, _, _, _) =>
-                Task.FromResult<IEnumerable<NuGetPackageCli>>(
-                    [new NuGetPackageCli { Id = "Aspire.ProjectTemplates", Source = source, Version = version }])
-        };
+            var channelSource = SourceForChannel(channelName);
+            var fallbackSource = FallbackSourceForChannel(channelName);
+            var version = "13.3.0";
 
-        var explicitChannel = PackageChannel.CreateExplicitChannel(
-            channelName,
-            PackageChannelQuality.Both,
-            [new PackageMapping("Aspire*", source)],
-            fakeCache);
+            var fakeCache = new FakeNuGetPackageCache
+            {
+                GetTemplatePackagesAsyncCallback = (_, _, _, _) =>
+                    Task.FromResult<IEnumerable<NuGetPackageCli>>(
+                        [new NuGetPackageCli { Id = "Aspire.ProjectTemplates", Source = channelSource, Version = version }])
+            };
+
+            return PackageChannel.CreateExplicitChannel(
+                channelName,
+                PackageChannelQuality.Both,
+                [new PackageMapping("Aspire*", channelSource), new PackageMapping(PackageMapping.AllPackages, fallbackSource)],
+                fakeCache);
+        }).ToArray();
 
         return new TestPackagingService
         {
-            GetChannelsAsyncCallback = _ => Task.FromResult<IEnumerable<PackageChannel>>([explicitChannel])
+            GetChannelsAsyncCallback = _ => Task.FromResult<IEnumerable<PackageChannel>>(channels)
         };
     }
 
     private static string SourceForChannel(string channelName)
         => $"https://feeds.test.invalid/{channelName}/v3/index.json";
+
+    private static string FallbackSourceForChannel(string channelName)
+        => $"https://feeds.test.invalid/{channelName}-fallback/v3/index.json";
+
+    /// <summary>
+    /// Asserts that the workspace NuGet.config written by
+    /// <c>TemplateNuGetConfigService.CreateOrUpdateNuGetConfigWithoutPromptAsync</c>
+    /// carries the structural elements the fix depends on: the channel feed URL is registered
+    /// as a package source, a <c>&lt;clear/&gt;</c> element neutralizes any inherited
+    /// parent-directory NuGet config (without which a user-level config disabling our hive
+    /// would shadow the mapping), and the <c>Aspire*</c> pattern routes to the channel
+    /// feed via <c>&lt;packageSourceMapping&gt;</c>.
+    /// </summary>
+    private static void AssertNuGetConfigHasChannelShape(string nugetConfigPath, string channelName)
+    {
+        var channelSource = SourceForChannel(channelName);
+        var root = XDocument.Load(nugetConfigPath).Root ?? throw new InvalidOperationException("Empty NuGet.config.");
+
+        var packageSources = root.Element("packageSources");
+        Assert.NotNull(packageSources);
+        Assert.NotNull(packageSources!.Element("clear"));
+        Assert.Contains(packageSources.Elements("add"), e => (string?)e.Attribute("value") == channelSource);
+
+        var packageSourceMapping = root.Element("packageSourceMapping");
+        Assert.NotNull(packageSourceMapping);
+        var aspirePatternSource = packageSourceMapping!.Elements("packageSource")
+            .FirstOrDefault(ps => ps.Elements("package").Any(p => (string?)p.Attribute("pattern") == "Aspire*"));
+        Assert.NotNull(aspirePatternSource);
+        Assert.Equal(channelSource, (string?)aspirePatternSource!.Attribute("key"));
+    }
 
     private sealed class TestScaffoldingService : IScaffoldingService
     {

--- a/tests/Aspire.Cli.Tests/Packaging/PackagingServiceTests.cs
+++ b/tests/Aspire.Cli.Tests/Packaging/PackagingServiceTests.cs
@@ -51,6 +51,41 @@ public class PackagingServiceTests(ITestOutputHelper outputHelper)
         Assert.False(dailyChannel.ConfigureGlobalPackagesFolder);
     }
 
+    /// <summary>
+    /// Locks in the structural invariant that <c>aspire init</c> and <c>aspire new</c> depend
+    /// on: the <c>stable</c> channel is always <see cref="PackageChannelType.Explicit"/> with a
+    /// non-empty <see cref="PackageChannel.Mappings"/> array containing a <see cref="PackageMapping.AllPackages"/>
+    /// pattern. <c>TemplateNuGetConfigService.CreateOrUpdateNuGetConfigWithoutPromptAsync</c>
+    /// short-circuits if the matching channel is not explicit or has no mappings, so a future
+    /// refactor that flipped stable to implicit / removed its mappings would silently turn the
+    /// workspace-NuGet.config write into a no-op for every stable-channel CLI user. The
+    /// InitCommand-level tests use a fake stable channel and cannot catch this regression at the
+    /// real <see cref="PackagingService"/> layer.
+    /// </summary>
+    [Fact]
+    public async Task GetChannelsAsync_StableChannel_IsExplicitWithAllPackagesMappingToNuGetOrg()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        var tempDir = workspace.WorkspaceRoot;
+        var hivesDir = new DirectoryInfo(Path.Combine(tempDir.FullName, ".aspire", "hives"));
+        var cacheDir = new DirectoryInfo(Path.Combine(tempDir.FullName, ".aspire", "cache"));
+        var executionContext = new CliExecutionContext(tempDir, hivesDir, cacheDir, new DirectoryInfo(Path.Combine(Path.GetTempPath(), "aspire-test-runtimes")), new DirectoryInfo(Path.Combine(Path.GetTempPath(), "aspire-test-logs")), "test.log");
+
+        var features = new TestFeatures();
+        var configuration = new ConfigurationBuilder().Build();
+        var packagingService = new PackagingService(executionContext, new FakeNuGetPackageCache(), features, configuration, NullLogger<PackagingService>.Instance);
+
+        var channels = await packagingService.GetChannelsAsync().DefaultTimeout();
+
+        var stableChannel = channels.First(c => c.Name == PackageChannelNames.Stable);
+        Assert.Equal(PackageChannelType.Explicit, stableChannel.Type);
+        Assert.NotNull(stableChannel.Mappings);
+        Assert.NotEmpty(stableChannel.Mappings!);
+        Assert.Contains(stableChannel.Mappings!, m =>
+            m.PackageFilter == PackageMapping.AllPackages &&
+            m.Source == "https://api.nuget.org/v3/index.json");
+    }
+
     [Fact]
     public async Task GetChannelsAsync_WhenStagingChannelEnabled_IncludesStagingChannelWithOverrideFeed()
     {

--- a/tests/Shared/Hex1bAutomatorTestHelpers.cs
+++ b/tests/Shared/Hex1bAutomatorTestHelpers.cs
@@ -664,8 +664,13 @@ internal static class Hex1bAutomatorTestHelpers
         this Hex1bTerminalAutomator auto,
         SequenceCounter counter)
     {
+        // Match the actual prompt text shape — the trailing '?' avoids false-matching
+        // informational confirmation messages like "Created NuGet.config..." which contain
+        // the same substring but are not Y/n prompts. The two real prompts are
+        // "Create NuGet.config for selected channels?" and "Update NuGet.config to add
+        // missing package sources for the selected channel?" — both end in '?'.
         var waitingForNuGetConfigPrompt = new CellPatternSearcher()
-            .Find("NuGet.config");
+            .Find("NuGet.config?");
 
         var waitingForUrlsPrompt = new CellPatternSearcher()
             .Find("Use *.dev.localhost URLs");


### PR DESCRIPTION
## Description

Fixes #17104.

### What we found

- The `aspire-apphost` template stamps the C# AppHost csproj with `<Project Sdk="Aspire.AppHost.Sdk/<channel-version>">` using whatever version the channel resolves to.
- On non-stable channels (PR / staging / daily / locally-built `local` / `run-*`), that exact prerelease version only exists in `~/.aspire/hives/<channel>/packages/`. It's never on nuget.org.
- Project-mode `aspire init` happily scaffolded the AppHost but never wrote a workspace `nuget.config` next to the solution, so NuGet had no way to discover the hive.
- The single-file `aspire init` path already wrote a workspace `nuget.config` via `TemplateNuGetConfigService.CreateOrUpdateNuGetConfigWithoutPromptAsync` — project-mode just wasn't calling that helper.

Reproduced verbatim against `origin/main` (`ba84b7e2b3`) with a freshly-built local CLI:

```console
$ aspire init --language csharp --suppress-agent-init
Searching for available project template versions...
Installing Aspire project templates...
Creating AppHost from template...
✅ Created Test.AppHost/

$ ls -a            # no nuget.config next to the .sln
.   ..   Test.AppHost   Test.slnx

$ cat Test.AppHost/Test.AppHost.csproj
<Project Sdk="Aspire.AppHost.Sdk/13.4.0-local.20260514.t205238">

  <PropertyGroup>
    <OutputType>Exe</OutputType>
    <TargetFramework>net10.0</TargetFramework>
    ...
  </PropertyGroup>

</Project>

$ cd Test.AppHost && dotnet restore
… : error : Could not resolve SDK "Aspire.AppHost.Sdk". …
… : error :   Unable to find package Aspire.AppHost.Sdk with version (= 13.4.0-local.20260514.t205238)
… : error :   - Found 28 version(s) in nuget.org [ Nearest version: 13.3.2 ]
… : error :   - Found 0 version(s) in staging
… : error :   - Found 0 version(s) in dotnet-eng
… : error MSB4236: The SDK 'Aspire.AppHost.Sdk/13.4.0-local.20260514.t205238' specified could not be found.
```

The package is sitting at `~/.aspire/hives/local/packages/Aspire.AppHost.Sdk.13.4.0-local.20260514.t205238.nupkg`. NuGet just never looks there.

### How it was fixed

- Project-mode `aspire init` now calls the same helper the single-file path already uses, pinned to `CliExecutionContext.IdentityChannel`.
- The call is hoisted to two specific positions:
  - **Before** `dotnet new aspire-apphost` — so the template's built-in `restore` post-action sees the workspace `nuget.config` and resolves the SDK against the hive cleanly during init.
  - **Before** the existing-AppHost early-return — so users who hit the original bug can recover by re-running `aspire init` instead of having to delete the half-broken AppHost first.
- Same hoist applied to the single-file path so its rerun-recovery story matches.

After the fix:

```console
$ aspire init --language csharp --suppress-agent-init
📦 Created or updated NuGet.config in the project directory with required package sources.
Searching for available project template versions...
Installing Aspire project templates...
Creating AppHost from template...
✅ Created Test.AppHost/

$ ls -a            # workspace nuget.config now sitting next to the .sln
.   ..   nuget.config   Test.AppHost   Test.slnx

$ cd Test.AppHost && dotnet restore
  Determining projects to restore...
  All projects are up-to-date for restore.
```

(`dotnet restore` is a cache hit because the template's own `restore` post-action — now seeing the workspace `nuget.config` — populated `~/.nuget/packages/aspire.apphost.sdk/...` during `aspire init`.)

### Side effect

While auditing, found that the `AspireInitAsync` E2E test helper (`tests/Shared/Hex1bAutomatorTestHelpers.cs`) was substring-matching `"NuGet.config"` to detect the create/update prompt, which would also false-match informational messages containing the same substring. Tightened to `"NuGet.config?"` (the actual prompts always end in `?`, the informational confirmation messages don't). This let `InitCommand` use the existing localized `TemplatingStrings.NuGetConfigCreatedOrUpdatedConfirmationMessage` (the same string `aspire add` uses) instead of a hardcoded English placeholder that was avoiding the substring.

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
- Did you add public API?
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [x] No
