### PR TITLE
Use aspnetapp-9.0 tag in ACA compact naming deployment tests

### DIFF
--- a/tests/Aspire.Deployment.EndToEnd.Tests/AcaCompactNamingDeploymentTests.cs
+++ b/tests/Aspire.Deployment.EndToEnd.Tests/AcaCompactNamingDeploymentTests.cs
@@ -99,12 +99,12 @@ builder.AddAzureContainerAppEnvironment("my-long-env-name")
        .WithCompactResourceNaming();
 
 // Container with a volume triggers storage account creation
-// Use a versioned tag because the unversioned "aspnetapp" tag no longer publishes a
-// linux/amd64 manifest, which causes Azure Container Apps to reject the image. The
-// "aspnetapp-10.0" tag has the same problem (Windows-only). Inspect the live manifest at:
-// https://mcr.microsoft.com/v2/dotnet/samples/manifests/aspnetapp
-// If/when the unversioned tag publishes a linux/amd64 child again, this pin can be removed.
-builder.AddContainer("worker", "mcr.microsoft.com/dotnet/samples", "aspnetapp-9.0")
+// Use the Azure Container Instances "hello world" sample as a generic linux container.
+// We previously used mcr.microsoft.com/dotnet/samples:aspnetapp, but the .NET samples team
+// republishes that tag without guaranteeing a linux/amd64 manifest, which broke ACA
+// provisioning here. azuredocs/aci-helloworld is a purpose-built Azure container demo image
+// (different team, multi-arch) so it's a more reliable choice for a deployment smoke test.
+builder.AddContainer("worker", "mcr.microsoft.com/azuredocs/aci-helloworld", "latest")
        .WithVolume("data", "/app/data");
 
 builder.Build().Run();

--- a/tests/Aspire.Deployment.EndToEnd.Tests/AcaCompactNamingDeploymentTests.cs
+++ b/tests/Aspire.Deployment.EndToEnd.Tests/AcaCompactNamingDeploymentTests.cs
@@ -100,7 +100,10 @@ builder.AddAzureContainerAppEnvironment("my-long-env-name")
 
 // Container with a volume triggers storage account creation
 // Use a versioned tag because the unversioned "aspnetapp" tag no longer publishes a
-// linux/amd64 manifest, which causes Azure Container Apps to reject the image.
+// linux/amd64 manifest, which causes Azure Container Apps to reject the image. The
+// "aspnetapp-10.0" tag has the same problem (Windows-only). Inspect the live manifest at:
+// https://mcr.microsoft.com/v2/dotnet/samples/manifests/aspnetapp
+// If/when the unversioned tag publishes a linux/amd64 child again, this pin can be removed.
 builder.AddContainer("worker", "mcr.microsoft.com/dotnet/samples", "aspnetapp-9.0")
        .WithVolume("data", "/app/data");
 

--- a/tests/Aspire.Deployment.EndToEnd.Tests/AcaCompactNamingDeploymentTests.cs
+++ b/tests/Aspire.Deployment.EndToEnd.Tests/AcaCompactNamingDeploymentTests.cs
@@ -99,7 +99,9 @@ builder.AddAzureContainerAppEnvironment("my-long-env-name")
        .WithCompactResourceNaming();
 
 // Container with a volume triggers storage account creation
-builder.AddContainer("worker", "mcr.microsoft.com/dotnet/samples", "aspnetapp")
+// Use a versioned tag because the unversioned "aspnetapp" tag no longer publishes a
+// linux/amd64 manifest, which causes Azure Container Apps to reject the image.
+builder.AddContainer("worker", "mcr.microsoft.com/dotnet/samples", "aspnetapp-9.0")
        .WithVolume("data", "/app/data");
 
 builder.Build().Run();

--- a/tests/Aspire.Deployment.EndToEnd.Tests/AcaCompactNamingDeploymentTests.cs
+++ b/tests/Aspire.Deployment.EndToEnd.Tests/AcaCompactNamingDeploymentTests.cs
@@ -100,11 +100,13 @@ builder.AddAzureContainerAppEnvironment("my-long-env-name")
 
 // Container with a volume triggers storage account creation
 // Use the Azure Container Instances "hello world" sample as a generic linux container.
-// We previously used mcr.microsoft.com/dotnet/samples:aspnetapp, but the .NET samples team
-// republishes that tag without guaranteeing a linux/amd64 manifest, which broke ACA
-// provisioning here. azuredocs/aci-helloworld is a purpose-built Azure container demo image
-// (different team, multi-arch) so it's a more reliable choice for a deployment smoke test.
+// We previously used mcr.microsoft.com/dotnet/samples:aspnetapp, but per
+// https://github.com/dotnet/dotnet-docker/blob/main/README.samples.md#support those images
+// are not stable and can break at any time (see dotnet/dotnet-docker#7191). The Azure
+// container demo image is owned by a different team and has stable multi-arch manifests.
+// Also pin the image digest so the test cannot break if the tag is republished.
 builder.AddContainer("worker", "mcr.microsoft.com/azuredocs/aci-helloworld", "latest")
+       .WithImageSHA256("456a1150aa41340a14c7be1342deda2cde9e6e7df9fde6b8a69de0ae04f92fad")
        .WithVolume("data", "/app/data");
 
 builder.Build().Run();

--- a/tests/Aspire.Deployment.EndToEnd.Tests/AcaCompactNamingUpgradeDeploymentTests.cs
+++ b/tests/Aspire.Deployment.EndToEnd.Tests/AcaCompactNamingUpgradeDeploymentTests.cs
@@ -228,11 +228,13 @@ public sealed class AcaCompactNamingUpgradeDeploymentTests(ITestOutputHelper out
 builder.AddAzureContainerAppEnvironment("env");
 
 // Use the Azure Container Instances "hello world" sample as a generic linux container.
-// We previously used mcr.microsoft.com/dotnet/samples:aspnetapp, but the .NET samples team
-// republishes that tag without guaranteeing a linux/amd64 manifest, which broke ACA
-// provisioning here. azuredocs/aci-helloworld is a purpose-built Azure container demo image
-// (different team, multi-arch) so it's a more reliable choice for a deployment smoke test.
+// We previously used mcr.microsoft.com/dotnet/samples:aspnetapp, but per
+// https://github.com/dotnet/dotnet-docker/blob/main/README.samples.md#support those images
+// are not stable and can break at any time (see dotnet/dotnet-docker#7191). The Azure
+// container demo image is owned by a different team and has stable multi-arch manifests.
+// Also pin the image digest so the test cannot break if the tag is republished.
 builder.AddContainer("worker", "mcr.microsoft.com/azuredocs/aci-helloworld", "latest")
+       .WithImageSHA256("456a1150aa41340a14c7be1342deda2cde9e6e7df9fde6b8a69de0ae04f92fad")
        .WithVolume("data", "/app/data");
 
 builder.Build().Run();

--- a/tests/Aspire.Deployment.EndToEnd.Tests/AcaCompactNamingUpgradeDeploymentTests.cs
+++ b/tests/Aspire.Deployment.EndToEnd.Tests/AcaCompactNamingUpgradeDeploymentTests.cs
@@ -228,7 +228,10 @@ public sealed class AcaCompactNamingUpgradeDeploymentTests(ITestOutputHelper out
 builder.AddAzureContainerAppEnvironment("env");
 
 // Use a versioned tag because the unversioned "aspnetapp" tag no longer publishes a
-// linux/amd64 manifest, which causes Azure Container Apps to reject the image.
+// linux/amd64 manifest, which causes Azure Container Apps to reject the image. The
+// "aspnetapp-10.0" tag has the same problem (Windows-only). Inspect the live manifest at:
+// https://mcr.microsoft.com/v2/dotnet/samples/manifests/aspnetapp
+// If/when the unversioned tag publishes a linux/amd64 child again, this pin can be removed.
 builder.AddContainer("worker", "mcr.microsoft.com/dotnet/samples", "aspnetapp-9.0")
        .WithVolume("data", "/app/data");
 

--- a/tests/Aspire.Deployment.EndToEnd.Tests/AcaCompactNamingUpgradeDeploymentTests.cs
+++ b/tests/Aspire.Deployment.EndToEnd.Tests/AcaCompactNamingUpgradeDeploymentTests.cs
@@ -227,7 +227,9 @@ public sealed class AcaCompactNamingUpgradeDeploymentTests(ITestOutputHelper out
             var replacement = """
 builder.AddAzureContainerAppEnvironment("env");
 
-builder.AddContainer("worker", "mcr.microsoft.com/dotnet/samples", "aspnetapp")
+// Use a versioned tag because the unversioned "aspnetapp" tag no longer publishes a
+// linux/amd64 manifest, which causes Azure Container Apps to reject the image.
+builder.AddContainer("worker", "mcr.microsoft.com/dotnet/samples", "aspnetapp-9.0")
        .WithVolume("data", "/app/data");
 
 builder.Build().Run();

--- a/tests/Aspire.Deployment.EndToEnd.Tests/AcaCompactNamingUpgradeDeploymentTests.cs
+++ b/tests/Aspire.Deployment.EndToEnd.Tests/AcaCompactNamingUpgradeDeploymentTests.cs
@@ -227,12 +227,12 @@ public sealed class AcaCompactNamingUpgradeDeploymentTests(ITestOutputHelper out
             var replacement = """
 builder.AddAzureContainerAppEnvironment("env");
 
-// Use a versioned tag because the unversioned "aspnetapp" tag no longer publishes a
-// linux/amd64 manifest, which causes Azure Container Apps to reject the image. The
-// "aspnetapp-10.0" tag has the same problem (Windows-only). Inspect the live manifest at:
-// https://mcr.microsoft.com/v2/dotnet/samples/manifests/aspnetapp
-// If/when the unversioned tag publishes a linux/amd64 child again, this pin can be removed.
-builder.AddContainer("worker", "mcr.microsoft.com/dotnet/samples", "aspnetapp-9.0")
+// Use the Azure Container Instances "hello world" sample as a generic linux container.
+// We previously used mcr.microsoft.com/dotnet/samples:aspnetapp, but the .NET samples team
+// republishes that tag without guaranteeing a linux/amd64 manifest, which broke ACA
+// provisioning here. azuredocs/aci-helloworld is a purpose-built Azure container demo image
+// (different team, multi-arch) so it's a more reliable choice for a deployment smoke test.
+builder.AddContainer("worker", "mcr.microsoft.com/azuredocs/aci-helloworld", "latest")
        .WithVolume("data", "/app/data");
 
 builder.Build().Run();


### PR DESCRIPTION
The `AcaCompactNamingDeploymentTests` (and the upgrade variant) have been failing because Azure Container Apps rejects the worker container image:

```
Failed to provision revision for container app 'worker'. Error details:
Field 'template.containers.worker.image' is invalid with details:
'Invalid value: "mcr.microsoft.com/dotnet/samples:aspnetapp":
no child with platform linux/amd64 in index mcr.microsoft.com/dotnet/samples:aspnetapp'
```

The unversioned `mcr.microsoft.com/dotnet/samples:aspnetapp` tag now only publishes a Windows amd64 manifest — there is no `linux/amd64` child anymore. Verified by inspecting the manifest list directly:

```
$ curl -s https://mcr.microsoft.com/v2/dotnet/samples/manifests/aspnetapp \
    -H 'Accept: application/vnd.docker.distribution.manifest.list.v2+json'
# only contains a single windows/amd64 entry
```

The `aspnetapp-10.0` tag has the same problem (Windows only). The `aspnetapp-9.0` tag still publishes the full set of linux platforms (linux/amd64, linux/arm/v7, linux/arm64) plus Windows, so this PR switches both deployment tests to that tag and adds a comment explaining why we can't use the unversioned tag.