### PR TITLE
Defer dotnet restore in aspire update so channel switches don't trip NU1103

### DIFF
--- a/src/Aspire.Cli/Projects/ProjectUpdater.cs
+++ b/src/Aspire.Cli/Projects/ProjectUpdater.cs
@@ -140,6 +140,36 @@ internal sealed partial class ProjectUpdater(ILogger<ProjectUpdater> logger, IDo
                 return 0;
             });
 
+        // Run a single restore *after* every package edit has been applied. Per-package
+        // 'dotnet package add' calls use --no-restore (see UpdatePackageReferenceInProject)
+        // because, for Explicit channels, NuGetConfigMerger has already rewritten nuget.config
+        // earlier in this method to add a packageSourceMapping pinning Aspire* to the channel's
+        // feed. Restoring after the *first* package add (the old behavior) would run NuGet
+        // against a half-updated reference graph: the package just bumped exists in the new
+        // feed, but the rest are still on their previous (often stable) versions which may
+        // not be carried by that feed. Mapping then blocks the fallback to nuget.org, producing
+        // NU1103 for every not-yet-bumped Aspire reference. Deferring the restore until all
+        // edits are applied means every Aspire* reference resolves against versions that
+        // exist in the configured feed.
+        // Restoring the AppHost project transitively restores referenced projects, so a single
+        // restore here covers both traditional PackageReference and Directory.Packages.props
+        // (CPM) update paths. The 'dotnet restore' command accepts both .csproj and file-based
+        // (apphost.cs) program files as the positional argument.
+        // See https://github.com/dotnet/aspire/issues/15891.
+        await interactionService.ShowStatusAsync(
+            UpdateCommandStrings.RestoringPackagesAfterUpdate,
+            async () =>
+            {
+                var restoreExitCode = await runner.RestoreAsync(projectFile, new(), cancellationToken);
+
+                if (restoreExitCode != 0)
+                {
+                    throw new ProjectUpdaterException(string.Format(CultureInfo.InvariantCulture, UpdateCommandStrings.FailedToRestoreAfterUpdateFormat, projectFile.FullName));
+                }
+
+                return 0;
+            });
+
         interactionService.DisplayEmptyLine();
 
         interactionService.DisplaySuccess(UpdateCommandStrings.UpdateSuccessfulMessage);
@@ -1036,12 +1066,18 @@ internal sealed partial class ProjectUpdater(ILogger<ProjectUpdater> logger, IDo
 
     private async Task UpdatePackageReferenceInProject(FileInfo projectFile, NuGetPackageCli package, CancellationToken cancellationToken)
     {
+        // Pass --no-restore here so each per-package edit only mutates the project / file-based AppHost.
+        // A single restore is performed once *all* update steps have completed (see UpdateProjectAsync).
+        // Restoring per-package would run NuGet against a half-updated reference graph, which is fatal
+        // when the channel's nuget.config (already merged earlier in UpdateProjectAsync for Explicit
+        // channels) contains a packageSourceMapping pinning Aspire* to a feed that does not carry the
+        // not-yet-bumped versions. See https://github.com/dotnet/aspire/issues/15891.
         var exitCode = await runner.AddPackageAsync(
             projectFilePath: projectFile,
             packageName: package.Id,
             packageVersion: package.Version,
             nugetSource: null,
-            noRestore: false,
+            noRestore: true,
             options: new(),
             cancellationToken: cancellationToken);
 

--- a/src/Aspire.Cli/Projects/ProjectUpdater.cs
+++ b/src/Aspire.Cli/Projects/ProjectUpdater.cs
@@ -350,30 +350,50 @@ internal sealed partial class ProjectUpdater(ILogger<ProjectUpdater> logger, IDo
     {
         var projectFile = context.AppHostProjectFile;
 
-        // Only project-style AppHosts (.csproj/.fsproj/.vbproj) can carry these
-        // legacy references. Single-file AppHosts (.cs with #:sdk directive)
-        // never have a csproj or Directory.Packages.props to worry about.
-        if (!ProjectFileExtensions.Supported.Contains(projectFile.Extension))
+        if (ProjectFileExtensions.Supported.Contains(projectFile.Extension))
         {
+            var (hasPackageReference, hasOrphanPackageVersion) = DetectLegacyAppHostReferences(projectFile);
+            if (!hasPackageReference && !hasOrphanPackageVersion)
+            {
+                return;
+            }
+
+            var step = new PackageUpdateStep(
+                UpdateCommandStrings.RemovedObsoleteAppHostPackage,
+                () => RemoveLegacyAppHostPackageReferencesAsync(projectFile, hasPackageReference, hasOrphanPackageVersion),
+                "Aspire.Hosting.AppHost",
+                // The new SDK adds Aspire.Hosting.AppHost implicitly, so there is no
+                // user-visible "current version" to display - report it as implicit.
+                "implicit",
+                "(removed)",
+                projectFile);
+            context.UpdateSteps.Enqueue(step);
             return;
         }
 
-        var (hasPackageReference, hasOrphanPackageVersion) = DetectLegacyAppHostReferences(projectFile);
-        if (!hasPackageReference && !hasOrphanPackageVersion)
+        // Single-file AppHosts (.cs with #:sdk directive) bring Aspire.Hosting.AppHost
+        // in implicitly via the SDK, just like the new csproj SDK format does. An
+        // explicit `#:package Aspire.Hosting.AppHost@<version>` directive in the
+        // .cs file is therefore redundant and, after a channel switch, becomes
+        // actively harmful: the deferred restore will fail with NU1103 because
+        // the now-mapped Aspire feed does not carry the user's stable version.
+        // See https://github.com/dotnet/aspire/issues/15891.
+        if (string.Equals(projectFile.Extension, ".cs", StringComparison.OrdinalIgnoreCase))
         {
-            return;
-        }
+            if (!HasLegacyAppHostPackageDirective(projectFile))
+            {
+                return;
+            }
 
-        var step = new PackageUpdateStep(
-            UpdateCommandStrings.RemovedObsoleteAppHostPackage,
-            () => RemoveLegacyAppHostPackageReferencesAsync(projectFile, hasPackageReference, hasOrphanPackageVersion),
-            "Aspire.Hosting.AppHost",
-            // The new SDK adds Aspire.Hosting.AppHost implicitly, so there is no
-            // user-visible "current version" to display - report it as implicit.
-            "implicit",
-            "(removed)",
-            projectFile);
-        context.UpdateSteps.Enqueue(step);
+            var step = new PackageUpdateStep(
+                UpdateCommandStrings.RemovedObsoleteAppHostPackage,
+                () => RemoveLegacyAppHostPackageDirectiveAsync(projectFile),
+                "Aspire.Hosting.AppHost",
+                "implicit",
+                "(removed)",
+                projectFile);
+            context.UpdateSteps.Enqueue(step);
+        }
     }
 
     private static (bool HasPackageReference, bool HasOrphanPackageVersion) DetectLegacyAppHostReferences(FileInfo projectFile)
@@ -765,11 +785,51 @@ internal sealed partial class ProjectUpdater(ILogger<ProjectUpdater> logger, IDo
         var newDirective = $"#:sdk Aspire.AppHost.Sdk@{package.Version}";
         var updatedContent = SdkDirectiveRegex().Replace(fileContent, newDirective, 1);
 
+        // The new SDK pulls Aspire.Hosting.AppHost in implicitly, so a leftover
+        // explicit `#:package Aspire.Hosting.AppHost@<version>` directive in the
+        // same file is redundant. Strip it here so the SDK-bump path matches
+        // the csproj migration in UpdateSdkVersionInProjectAppHostAsync. The
+        // SDK-already-current path goes through EnqueueLegacyAppHostCleanupStepIfNeeded.
+        updatedContent = LegacyAppHostPackageDirectiveRegex().Replace(updatedContent, string.Empty);
+
         await File.WriteAllTextAsync(projectFile.FullName, updatedContent);
     }
 
     [GeneratedRegex(@"#:sdk\s+Aspire\.AppHost\.Sdk@(?:[\d\.\-a-zA-Z]+|\*)")]
     internal static partial Regex SdkDirectiveRegex();
+
+    // Matches a whole line of the form "#:package Aspire.Hosting.AppHost@<version>"
+    // (case-insensitive on the package id), including trailing line break, so the
+    // whole directive can be removed without leaving a blank line behind. NuGet
+    // package IDs are case-insensitive (https://learn.microsoft.com/nuget/concepts/package-identifier).
+    [GeneratedRegex(@"^[ \t]*#:package\s+Aspire\.Hosting\.AppHost@\S+[ \t]*\r?\n?", RegexOptions.IgnoreCase | RegexOptions.Multiline)]
+    internal static partial Regex LegacyAppHostPackageDirectiveRegex();
+
+    private static bool HasLegacyAppHostPackageDirective(FileInfo projectFile)
+    {
+        try
+        {
+            var fileContent = File.ReadAllText(projectFile.FullName);
+            return LegacyAppHostPackageDirectiveRegex().IsMatch(fileContent);
+        }
+        catch
+        {
+            // If the .cs file cannot be read here, leave detection (and the
+            // resulting failure) to the deferred restore step.
+            return false;
+        }
+    }
+
+    private static async Task RemoveLegacyAppHostPackageDirectiveAsync(FileInfo projectFile)
+    {
+        var fileContent = await File.ReadAllTextAsync(projectFile.FullName);
+        var updatedContent = LegacyAppHostPackageDirectiveRegex().Replace(fileContent, string.Empty);
+
+        if (!string.Equals(fileContent, updatedContent, StringComparison.Ordinal))
+        {
+            await File.WriteAllTextAsync(projectFile.FullName, updatedContent);
+        }
+    }
 
     private async Task AnalyzeProjectAsync(FileInfo projectFile, UpdateContext context, CancellationToken cancellationToken)
     {

--- a/src/Aspire.Cli/Resources/UpdateCommandStrings.Designer.cs
+++ b/src/Aspire.Cli/Resources/UpdateCommandStrings.Designer.cs
@@ -112,6 +112,8 @@ namespace Aspire.Cli.Resources {
     internal static string NoWritePermissionToInstallDirectory => ResourceManager.GetString("NoWritePermissionToInstallDirectory", resourceCulture);
     internal static string CheckingForUpdates => ResourceManager.GetString("CheckingForUpdates", resourceCulture);
     internal static string ApplyingUpdates => ResourceManager.GetString("ApplyingUpdates", resourceCulture);
+    internal static string RestoringPackagesAfterUpdate => ResourceManager.GetString("RestoringPackagesAfterUpdate", resourceCulture);
+    internal static string FailedToRestoreAfterUpdateFormat => ResourceManager.GetString("FailedToRestoreAfterUpdateFormat", resourceCulture);
     internal static string ExtractingNewCli => ResourceManager.GetString("ExtractingNewCli", resourceCulture);
     internal static string ExtractedNewCli => ResourceManager.GetString("ExtractedNewCli", resourceCulture);
     internal static string RegeneratingSdkCode => ResourceManager.GetString("RegeneratingSdkCode", resourceCulture);

--- a/src/Aspire.Cli/Resources/UpdateCommandStrings.resx
+++ b/src/Aspire.Cli/Resources/UpdateCommandStrings.resx
@@ -153,6 +153,12 @@
   <data name="ApplyingUpdates" xml:space="preserve">
     <value>Applying updates...</value>
   </data>
+  <data name="RestoringPackagesAfterUpdate" xml:space="preserve">
+    <value>Restoring packages...</value>
+  </data>
+  <data name="FailedToRestoreAfterUpdateFormat" xml:space="preserve">
+    <value>Failed to restore packages for project {0} after update.</value>
+  </data>
   <data name="ExtractingNewCli" xml:space="preserve">
     <value>Extracting new CLI...</value>
   </data>

--- a/src/Aspire.Cli/Resources/xlf/UpdateCommandStrings.cs.xlf
+++ b/src/Aspire.Cli/Resources/xlf/UpdateCommandStrings.cs.xlf
@@ -107,6 +107,11 @@
         <target state="translated">Nepovedlo se načíst položky a vlastnosti pro projekt: {0}</target>
         <note />
       </trans-unit>
+      <trans-unit id="FailedToRestoreAfterUpdateFormat">
+        <source>Failed to restore packages for project {0} after update.</source>
+        <target state="new">Failed to restore packages for project {0} after update.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="FailedUpdatePackageReferenceFormat">
         <source>Failed to update package reference for {0} in project {1}.</source>
         <target state="translated">Nepodařilo se aktualizovat odkaz na balíček pro {0} v projektu {1}.</target>
@@ -225,6 +230,11 @@
       <trans-unit id="RemovedObsoleteAppHostPackage">
         <source>Removed obsolete Aspire.Hosting.AppHost package reference</source>
         <target state="translated">Odebrán zastaralý odkaz na balíček Aspire.Hosting.AppHost</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RestoringPackagesAfterUpdate">
+        <source>Restoring packages...</source>
+        <target state="new">Restoring packages...</target>
         <note />
       </trans-unit>
       <trans-unit id="RetainedFeedFormat">

--- a/src/Aspire.Cli/Resources/xlf/UpdateCommandStrings.de.xlf
+++ b/src/Aspire.Cli/Resources/xlf/UpdateCommandStrings.de.xlf
@@ -107,6 +107,11 @@
         <target state="translated">Beim Abrufen von Elementen und Eigenschaften für das Projekt {0} ist ein Fehler aufgetreten.</target>
         <note />
       </trans-unit>
+      <trans-unit id="FailedToRestoreAfterUpdateFormat">
+        <source>Failed to restore packages for project {0} after update.</source>
+        <target state="new">Failed to restore packages for project {0} after update.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="FailedUpdatePackageReferenceFormat">
         <source>Failed to update package reference for {0} in project {1}.</source>
         <target state="translated">Beim Aktualisieren des Paketverweises für {0} im Projekt {1} ist ein Fehler aufgetreten.</target>
@@ -225,6 +230,11 @@
       <trans-unit id="RemovedObsoleteAppHostPackage">
         <source>Removed obsolete Aspire.Hosting.AppHost package reference</source>
         <target state="translated">Veralteter Verweis auf das Aspire.Hosting.AppHost-Paket entfernt</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RestoringPackagesAfterUpdate">
+        <source>Restoring packages...</source>
+        <target state="new">Restoring packages...</target>
         <note />
       </trans-unit>
       <trans-unit id="RetainedFeedFormat">

--- a/src/Aspire.Cli/Resources/xlf/UpdateCommandStrings.es.xlf
+++ b/src/Aspire.Cli/Resources/xlf/UpdateCommandStrings.es.xlf
@@ -107,6 +107,11 @@
         <target state="translated">Error al capturar los elementos y propiedades del proyecto: {0}</target>
         <note />
       </trans-unit>
+      <trans-unit id="FailedToRestoreAfterUpdateFormat">
+        <source>Failed to restore packages for project {0} after update.</source>
+        <target state="new">Failed to restore packages for project {0} after update.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="FailedUpdatePackageReferenceFormat">
         <source>Failed to update package reference for {0} in project {1}.</source>
         <target state="translated">No se pudo actualizar la referencia del paquete para {0} en el proyecto {1}.</target>
@@ -225,6 +230,11 @@
       <trans-unit id="RemovedObsoleteAppHostPackage">
         <source>Removed obsolete Aspire.Hosting.AppHost package reference</source>
         <target state="translated">Se quitó la referencia al paquete en desuso Aspire.Hosting.AppHost</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RestoringPackagesAfterUpdate">
+        <source>Restoring packages...</source>
+        <target state="new">Restoring packages...</target>
         <note />
       </trans-unit>
       <trans-unit id="RetainedFeedFormat">

--- a/src/Aspire.Cli/Resources/xlf/UpdateCommandStrings.fr.xlf
+++ b/src/Aspire.Cli/Resources/xlf/UpdateCommandStrings.fr.xlf
@@ -107,6 +107,11 @@
         <target state="translated">Échec de la récupération des éléments et des propriétés du projet : {0}</target>
         <note />
       </trans-unit>
+      <trans-unit id="FailedToRestoreAfterUpdateFormat">
+        <source>Failed to restore packages for project {0} after update.</source>
+        <target state="new">Failed to restore packages for project {0} after update.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="FailedUpdatePackageReferenceFormat">
         <source>Failed to update package reference for {0} in project {1}.</source>
         <target state="translated">Échec de la mise à jour de la référence de package pour {0} dans le projet {1}.</target>
@@ -225,6 +230,11 @@
       <trans-unit id="RemovedObsoleteAppHostPackage">
         <source>Removed obsolete Aspire.Hosting.AppHost package reference</source>
         <target state="translated">Suppression de la référence au package obsolète Aspire.Hosting.AppHost</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RestoringPackagesAfterUpdate">
+        <source>Restoring packages...</source>
+        <target state="new">Restoring packages...</target>
         <note />
       </trans-unit>
       <trans-unit id="RetainedFeedFormat">

--- a/src/Aspire.Cli/Resources/xlf/UpdateCommandStrings.it.xlf
+++ b/src/Aspire.Cli/Resources/xlf/UpdateCommandStrings.it.xlf
@@ -107,6 +107,11 @@
         <target state="translated">Non è possibile recuperare elementi e proprietà per il progetto: {0}</target>
         <note />
       </trans-unit>
+      <trans-unit id="FailedToRestoreAfterUpdateFormat">
+        <source>Failed to restore packages for project {0} after update.</source>
+        <target state="new">Failed to restore packages for project {0} after update.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="FailedUpdatePackageReferenceFormat">
         <source>Failed to update package reference for {0} in project {1}.</source>
         <target state="translated">Non è possibile aggiornare il riferimento al pacchetto per {0} nel progetto {1}.</target>
@@ -225,6 +230,11 @@
       <trans-unit id="RemovedObsoleteAppHostPackage">
         <source>Removed obsolete Aspire.Hosting.AppHost package reference</source>
         <target state="translated">Rimosso riferimento al pacchetto Aspire.Hosting.AppHost obsoleto</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RestoringPackagesAfterUpdate">
+        <source>Restoring packages...</source>
+        <target state="new">Restoring packages...</target>
         <note />
       </trans-unit>
       <trans-unit id="RetainedFeedFormat">

--- a/src/Aspire.Cli/Resources/xlf/UpdateCommandStrings.ja.xlf
+++ b/src/Aspire.Cli/Resources/xlf/UpdateCommandStrings.ja.xlf
@@ -107,6 +107,11 @@
         <target state="translated">プロジェクト {0} のアイテムとプロパティのフェッチに失敗しました</target>
         <note />
       </trans-unit>
+      <trans-unit id="FailedToRestoreAfterUpdateFormat">
+        <source>Failed to restore packages for project {0} after update.</source>
+        <target state="new">Failed to restore packages for project {0} after update.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="FailedUpdatePackageReferenceFormat">
         <source>Failed to update package reference for {0} in project {1}.</source>
         <target state="translated">プロジェクト {1} の {0} に対するパッケージ参照の更新に失敗しました。</target>
@@ -225,6 +230,11 @@
       <trans-unit id="RemovedObsoleteAppHostPackage">
         <source>Removed obsolete Aspire.Hosting.AppHost package reference</source>
         <target state="translated">古い Aspire.Hosting.AppHost パッケージ参照を削除しました</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RestoringPackagesAfterUpdate">
+        <source>Restoring packages...</source>
+        <target state="new">Restoring packages...</target>
         <note />
       </trans-unit>
       <trans-unit id="RetainedFeedFormat">

--- a/src/Aspire.Cli/Resources/xlf/UpdateCommandStrings.ko.xlf
+++ b/src/Aspire.Cli/Resources/xlf/UpdateCommandStrings.ko.xlf
@@ -107,6 +107,11 @@
         <target state="translated">프로젝트의 항목 및 속성을 가져오지 못했습니다. {0}</target>
         <note />
       </trans-unit>
+      <trans-unit id="FailedToRestoreAfterUpdateFormat">
+        <source>Failed to restore packages for project {0} after update.</source>
+        <target state="new">Failed to restore packages for project {0} after update.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="FailedUpdatePackageReferenceFormat">
         <source>Failed to update package reference for {0} in project {1}.</source>
         <target state="translated">프로젝트 {1}에서 {0}에 대한 패키지 참조를 업데이트하지 못 했습니다.</target>
@@ -225,6 +230,11 @@
       <trans-unit id="RemovedObsoleteAppHostPackage">
         <source>Removed obsolete Aspire.Hosting.AppHost package reference</source>
         <target state="translated">더 이상 사용하지 않는 Aspire.Hosting.AppHost 패키지 참조를 제거함</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RestoringPackagesAfterUpdate">
+        <source>Restoring packages...</source>
+        <target state="new">Restoring packages...</target>
         <note />
       </trans-unit>
       <trans-unit id="RetainedFeedFormat">

--- a/src/Aspire.Cli/Resources/xlf/UpdateCommandStrings.pl.xlf
+++ b/src/Aspire.Cli/Resources/xlf/UpdateCommandStrings.pl.xlf
@@ -107,6 +107,11 @@
         <target state="translated">Nie można pobrać elementów i właściwości projektu: {0}</target>
         <note />
       </trans-unit>
+      <trans-unit id="FailedToRestoreAfterUpdateFormat">
+        <source>Failed to restore packages for project {0} after update.</source>
+        <target state="new">Failed to restore packages for project {0} after update.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="FailedUpdatePackageReferenceFormat">
         <source>Failed to update package reference for {0} in project {1}.</source>
         <target state="translated">Nie można zaktualizować odwołania do pakietu {0} w projekcie {1}.</target>
@@ -225,6 +230,11 @@
       <trans-unit id="RemovedObsoleteAppHostPackage">
         <source>Removed obsolete Aspire.Hosting.AppHost package reference</source>
         <target state="translated">Usunięto przestarzałe odwołanie do pakietu Aspire.Hosting.AppHost</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RestoringPackagesAfterUpdate">
+        <source>Restoring packages...</source>
+        <target state="new">Restoring packages...</target>
         <note />
       </trans-unit>
       <trans-unit id="RetainedFeedFormat">

--- a/src/Aspire.Cli/Resources/xlf/UpdateCommandStrings.pt-BR.xlf
+++ b/src/Aspire.Cli/Resources/xlf/UpdateCommandStrings.pt-BR.xlf
@@ -107,6 +107,11 @@
         <target state="translated">Falha ao buscar itens e propriedades para o projeto: {0}</target>
         <note />
       </trans-unit>
+      <trans-unit id="FailedToRestoreAfterUpdateFormat">
+        <source>Failed to restore packages for project {0} after update.</source>
+        <target state="new">Failed to restore packages for project {0} after update.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="FailedUpdatePackageReferenceFormat">
         <source>Failed to update package reference for {0} in project {1}.</source>
         <target state="translated">Falha ao atualizar a referência de pacote para {0} no projeto {1}.</target>
@@ -225,6 +230,11 @@
       <trans-unit id="RemovedObsoleteAppHostPackage">
         <source>Removed obsolete Aspire.Hosting.AppHost package reference</source>
         <target state="translated">Removida a referência obsoleta ao pacote Aspire.Hosting.AppHost</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RestoringPackagesAfterUpdate">
+        <source>Restoring packages...</source>
+        <target state="new">Restoring packages...</target>
         <note />
       </trans-unit>
       <trans-unit id="RetainedFeedFormat">

--- a/src/Aspire.Cli/Resources/xlf/UpdateCommandStrings.ru.xlf
+++ b/src/Aspire.Cli/Resources/xlf/UpdateCommandStrings.ru.xlf
@@ -107,6 +107,11 @@
         <target state="translated">Не удалось получить элементы и свойства для проекта: {0}</target>
         <note />
       </trans-unit>
+      <trans-unit id="FailedToRestoreAfterUpdateFormat">
+        <source>Failed to restore packages for project {0} after update.</source>
+        <target state="new">Failed to restore packages for project {0} after update.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="FailedUpdatePackageReferenceFormat">
         <source>Failed to update package reference for {0} in project {1}.</source>
         <target state="translated">Не удалось обновить ссылку на пакет для {0} в проекте {1}.</target>
@@ -225,6 +230,11 @@
       <trans-unit id="RemovedObsoleteAppHostPackage">
         <source>Removed obsolete Aspire.Hosting.AppHost package reference</source>
         <target state="translated">Удалена устаревшая ссылка на пакет Aspire.Hosting.AppHost</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RestoringPackagesAfterUpdate">
+        <source>Restoring packages...</source>
+        <target state="new">Restoring packages...</target>
         <note />
       </trans-unit>
       <trans-unit id="RetainedFeedFormat">

--- a/src/Aspire.Cli/Resources/xlf/UpdateCommandStrings.tr.xlf
+++ b/src/Aspire.Cli/Resources/xlf/UpdateCommandStrings.tr.xlf
@@ -107,6 +107,11 @@
         <target state="translated">Proje için öğeler ve özellikler getirilemedi: {0}</target>
         <note />
       </trans-unit>
+      <trans-unit id="FailedToRestoreAfterUpdateFormat">
+        <source>Failed to restore packages for project {0} after update.</source>
+        <target state="new">Failed to restore packages for project {0} after update.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="FailedUpdatePackageReferenceFormat">
         <source>Failed to update package reference for {0} in project {1}.</source>
         <target state="translated">{1} projesinde {0} için paket başvurusu güncellenemedi.</target>
@@ -225,6 +230,11 @@
       <trans-unit id="RemovedObsoleteAppHostPackage">
         <source>Removed obsolete Aspire.Hosting.AppHost package reference</source>
         <target state="translated">Kullanımdan kaldırılan Aspire.Hosting.AppHost paket başvurusu kaldırıldı</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RestoringPackagesAfterUpdate">
+        <source>Restoring packages...</source>
+        <target state="new">Restoring packages...</target>
         <note />
       </trans-unit>
       <trans-unit id="RetainedFeedFormat">

--- a/src/Aspire.Cli/Resources/xlf/UpdateCommandStrings.zh-Hans.xlf
+++ b/src/Aspire.Cli/Resources/xlf/UpdateCommandStrings.zh-Hans.xlf
@@ -107,6 +107,11 @@
         <target state="translated">无法提取项目的项和属性: {0}</target>
         <note />
       </trans-unit>
+      <trans-unit id="FailedToRestoreAfterUpdateFormat">
+        <source>Failed to restore packages for project {0} after update.</source>
+        <target state="new">Failed to restore packages for project {0} after update.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="FailedUpdatePackageReferenceFormat">
         <source>Failed to update package reference for {0} in project {1}.</source>
         <target state="translated">未能更新项目 {1} 中 {0} 的包引用。</target>
@@ -225,6 +230,11 @@
       <trans-unit id="RemovedObsoleteAppHostPackage">
         <source>Removed obsolete Aspire.Hosting.AppHost package reference</source>
         <target state="translated">已移除过时的 Aspire.Hosting.AppHost 包引用</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RestoringPackagesAfterUpdate">
+        <source>Restoring packages...</source>
+        <target state="new">Restoring packages...</target>
         <note />
       </trans-unit>
       <trans-unit id="RetainedFeedFormat">

--- a/src/Aspire.Cli/Resources/xlf/UpdateCommandStrings.zh-Hant.xlf
+++ b/src/Aspire.Cli/Resources/xlf/UpdateCommandStrings.zh-Hant.xlf
@@ -107,6 +107,11 @@
         <target state="translated">無法為專案擷取項目與屬性: {0}</target>
         <note />
       </trans-unit>
+      <trans-unit id="FailedToRestoreAfterUpdateFormat">
+        <source>Failed to restore packages for project {0} after update.</source>
+        <target state="new">Failed to restore packages for project {0} after update.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="FailedUpdatePackageReferenceFormat">
         <source>Failed to update package reference for {0} in project {1}.</source>
         <target state="translated">無法更新專案 {1} 中 {0} 的套件參考。</target>
@@ -225,6 +230,11 @@
       <trans-unit id="RemovedObsoleteAppHostPackage">
         <source>Removed obsolete Aspire.Hosting.AppHost package reference</source>
         <target state="translated">已移除過時的 Aspire.Hosting.AppHost 套件參考</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RestoringPackagesAfterUpdate">
+        <source>Restoring packages...</source>
+        <target state="new">Restoring packages...</target>
         <note />
       </trans-unit>
       <trans-unit id="RetainedFeedFormat">

--- a/tests/Aspire.Cli.EndToEnd.Tests/UpdateChannelNuGetConfigOrderingTests.cs
+++ b/tests/Aspire.Cli.EndToEnd.Tests/UpdateChannelNuGetConfigOrderingTests.cs
@@ -1,0 +1,213 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Aspire.Cli.EndToEnd.Tests.Helpers;
+using Aspire.Cli.Tests.Utils;
+using Hex1b.Automation;
+using Xunit;
+
+namespace Aspire.Cli.EndToEnd.Tests;
+
+/// <summary>
+/// Regression test for https://github.com/microsoft/aspire/issues/15891.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Reproduces the user-visible failure where <c>aspire update --channel daily</c> on a
+/// file-based AppHost referencing several stable Aspire integration packages crashed
+/// with <c>NU1103</c>. The CLI rewrote <c>nuget.config</c> to add the daily feed plus a
+/// <c>&lt;packageSourceMapping&gt;</c> pinning <c>Aspire*</c> to that feed, then ran each
+/// per-package <c>dotnet package add</c> with restore enabled. Restore on the first add
+/// saw the still-stable references for the not-yet-bumped packages, but the new mapping
+/// blocked the nuget.org fallback for them, so NuGet emitted <c>NU1103</c> and the
+/// update aborted halfway through.
+/// </para>
+/// <para>
+/// The fix in <c>ProjectUpdater</c> passes <c>--no-restore</c> on every per-package add
+/// and runs a single <c>dotnet restore</c> after every package edit has been applied,
+/// so the packageSourceMapping never sees a half-updated reference graph. This test
+/// exercises that invariant end-to-end against the LocalHive channel — the bug fires
+/// for any <c>Explicit</c> channel (daily, staging, PR hives, local), and LocalHive is
+/// the only channel a source-build E2E run can deterministically control.
+/// </para>
+/// <para>
+/// This lives in its own test class (separate from <see cref="ChannelUpdateWorkflowTests"/>)
+/// so CI's per-class job split puts the regression on its own runner — failures point
+/// directly at the issue without sharing a budget with unrelated channel tests.
+/// </para>
+/// </remarks>
+public sealed class UpdateChannelNuGetConfigOrderingTests(ITestOutputHelper output)
+{
+    [Fact]
+    [CaptureWorkspaceOnFailure]
+    public async Task AspireUpdateAppliesAllPackageEditsBeforeRestoringWhenNuGetConfigGainsSourceMapping()
+    {
+        var repoRoot = CliE2ETestHelpers.GetRepoRoot();
+        var strategy = CliInstallStrategy.Detect(output.WriteLine);
+
+        // The bug only fires when the channel switch causes the CLI to rewrite nuget.config
+        // and add a packageSourceMapping. That requires an Explicit channel (daily, staging,
+        // PR hive, or local) with a controlled set of packages. Only LocalHive gives a
+        // source-build E2E run that level of control; for other strategies we skip rather
+        // than try to reproduce against a moving public daily feed.
+        if (strategy.Mode != CliInstallMode.LocalHive)
+        {
+            Assert.Skip(
+                "Issue #15891 requires an Explicit channel with controlled package versions. " +
+                "Run with ASPIRE_E2E_ARCHIVE pointing at a locally-built archive (LocalHive).");
+        }
+
+        // Pre-stage the locally-built nupkgs for the integration packages we'll reference.
+        // Three is enough to make the bug surface deterministically: the per-package adds run
+        // sequentially, so the first one's restore (without the fix) sees the other two still
+        // pinned to the stable version that doesn't exist on the local feed.
+        var localChannel = CliE2ETestHelpers.PrepareLocalChannel(
+            repoRoot,
+            strategy,
+            ["Aspire.Hosting.Redis.", "Aspire.Hosting.PostgreSQL.", "Aspire.Hosting.Kafka."]);
+
+        Assert.NotNull(localChannel);
+
+        var workspace = TemporaryWorkspace.Create(output);
+
+        using var terminal = CliE2ETestHelpers.CreateDockerTestTerminal(
+            repoRoot, strategy, output, mountDockerSocket: false, workspace: workspace);
+
+        var pendingRun = terminal.RunAsync(TestContext.Current.CancellationToken);
+
+        var counter = new SequenceCounter();
+        var auto = new Hex1bTerminalAutomator(terminal, defaultTimeout: TimeSpan.FromSeconds(500));
+
+        await auto.PrepareDockerEnvironmentAsync(counter, workspace);
+        await auto.InstallAspireCliAsync(strategy, counter);
+
+        // Suppress the post-update CLI self-update prompt so it doesn't block the test waiting
+        // for "Update successful!". Same pattern as CentralPackageManagementTests.
+        await auto.TypeAsync("aspire config set features.updateNotificationsEnabled false -g");
+        await auto.EnterAsync();
+        await auto.WaitForSuccessPromptAsync(counter);
+
+        // Run aspire init non-interactively to scaffold a single-file C# AppHost. We'll
+        // overwrite the generated apphost.cs and nuget.config below to set up the bug
+        // pre-condition (stable Aspire packages + only nuget.org configured).
+        await auto.TypeAsync("aspire init --language csharp");
+        await auto.EnterAsync();
+        await auto.WaitUntilTextAsync("Created aspire.config.json", timeout: TimeSpan.FromMinutes(2));
+        await auto.DeclineAgentInitPromptAsync(counter);
+
+        var appHostCsPath = Path.Combine(workspace.WorkspaceRoot.FullName, "apphost.cs");
+        var nugetConfigPath = Path.Combine(workspace.WorkspaceRoot.FullName, "nuget.config");
+        var aspireConfigPath = Path.Combine(workspace.WorkspaceRoot.FullName, "aspire.config.json");
+
+        Assert.True(File.Exists(appHostCsPath), $"Expected apphost.cs at: {appHostCsPath}");
+        Assert.True(File.Exists(aspireConfigPath), $"Expected aspire.config.json at: {aspireConfigPath}");
+
+        // Set up the bug pre-condition from the host side — the workspace is bind-mounted
+        // into the container so these writes are visible to the in-container CLI.
+
+        // 1. apphost.cs: reference three stable Aspire integration packages from nuget.org.
+        //    13.2.1 is the same release David Fowler used in the issue's repro and is real
+        //    on nuget.org for all three packages, so the initial state matches the bug
+        //    report exactly: stable references that nuget.org can resolve before the
+        //    channel switch.
+        const string StablePackageVersion = "13.2.1";
+        await File.WriteAllTextAsync(appHostCsPath,
+            $$"""
+            #:sdk Aspire.AppHost.Sdk@{{StablePackageVersion}}
+            #:package Aspire.Hosting.AppHost@{{StablePackageVersion}}
+            #:package Aspire.Hosting.Redis@{{StablePackageVersion}}
+            #:package Aspire.Hosting.PostgreSQL@{{StablePackageVersion}}
+            #:package Aspire.Hosting.Kafka@{{StablePackageVersion}}
+
+            var builder = DistributedApplication.CreateBuilder(args);
+            builder.Build().Run();
+            """);
+
+        // 2. nuget.config: only nuget.org, no Aspire feed, no packageSourceMapping. This is
+        //    the file shape from the issue. The CLI's NuGetConfigMerger will rewrite it to
+        //    add the local feed plus a <packageSourceMapping> pinning Aspire* to that feed —
+        //    that rewrite is exactly what triggers the regression on the per-package restores
+        //    when the fix is missing.
+        await File.WriteAllTextAsync(nugetConfigPath,
+            """
+            <?xml version="1.0" encoding="utf-8"?>
+            <configuration>
+              <packageSources>
+                <clear />
+                <add key="nuget.org" value="https://api.nuget.org/v3/index.json" protocolVersion="3" />
+              </packageSources>
+            </configuration>
+            """);
+
+        // 3. aspire.config.json: point at the locally-built channel/SDK so `aspire update`
+        //    has a concrete Explicit target to compute updates against. Preserves the
+        //    appHost/profiles sections that `aspire init` wrote.
+        CliE2ETestHelpers.WriteLocalChannelSettings(workspace.WorkspaceRoot.FullName, localChannel.SdkVersion);
+
+        // Run the update. Pass --channel local explicitly to make the CLI's channel
+        // resolution deterministic regardless of any global channel state.
+        await auto.TypeAsync("aspire update --channel local");
+        await auto.EnterAsync();
+
+        await auto.WaitUntilTextAsync("Perform updates?", timeout: TimeSpan.FromMinutes(2));
+        await auto.EnterAsync();
+
+        // The pre-existing nuget.config doesn't already contain the local feed, so the CLI
+        // will prompt to apply the merged changes. Accept the default (Yes).
+        await auto.WaitUntilTextAsync("Apply these changes to NuGet.config?", timeout: TimeSpan.FromMinutes(1));
+        await auto.EnterAsync();
+
+        // Without the fix this is where the test would fail: NuGet would emit NU1103 on
+        // the first per-package restore and "Update successful!" would never appear before
+        // the timeout. With the fix all package edits land first, then the single deferred
+        // restore sees a coherent reference graph and succeeds.
+        await auto.WaitUntilTextAsync("Update successful!", timeout: TimeSpan.FromMinutes(3));
+        await auto.WaitForSuccessPromptAsync(counter);
+
+        // Host-side assertions on the post-update files.
+        var updatedAppHostCs = await File.ReadAllTextAsync(appHostCsPath);
+        var updatedNuGetConfig = await File.ReadAllTextAsync(nugetConfigPath);
+
+        // Pre-condition was actually exercised: nuget.config gained a packageSourceMapping
+        // for Aspire*. If this assertion fails it means the rewrite never happened and the
+        // test isn't actually guarding the bug.
+        Assert.Contains("packageSourceMapping", updatedNuGetConfig, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("Aspire", updatedNuGetConfig, StringComparison.Ordinal);
+
+        // Every Aspire integration directive was bumped — proves the loop ran to completion
+        // rather than aborting after the first add (the user-visible symptom of the bug).
+        foreach (var packageId in new[]
+                 {
+                     "Aspire.Hosting.AppHost",
+                     "Aspire.Hosting.Redis",
+                     "Aspire.Hosting.PostgreSQL",
+                     "Aspire.Hosting.Kafka",
+                 })
+        {
+            Assert.Contains($"#:package {packageId}@{localChannel.SdkVersion}", updatedAppHostCs, StringComparison.Ordinal);
+            Assert.DoesNotContain($"#:package {packageId}@{StablePackageVersion}", updatedAppHostCs, StringComparison.Ordinal);
+        }
+
+        // The SDK directive is bumped on the same code path; assert it too so a future
+        // regression that only updates packages but not the SDK is also caught.
+        Assert.Contains($"#:sdk Aspire.AppHost.Sdk@{localChannel.SdkVersion}", updatedAppHostCs, StringComparison.Ordinal);
+
+        // Best-effort cleanup of the global feature flag we toggled above so other tests in
+        // the same shared home aren't affected. Bound the wait so cleanup never burns the
+        // automator's default timeout, and accept either OK or ERR — we only care that the
+        // shell returned to a prompt.
+        try
+        {
+            await auto.TypeAsync("aspire config delete features.updateNotificationsEnabled -g");
+            await auto.EnterAsync();
+            await auto.WaitForAnyPromptAsync(counter, TimeSpan.FromSeconds(30));
+        }
+        catch
+        {
+        }
+
+        await auto.TypeAsync("exit");
+        await auto.EnterAsync();
+        await pendingRun;
+    }
+}

--- a/tests/Aspire.Cli.Tests/Projects/ProjectUpdaterTests.cs
+++ b/tests/Aspire.Cli.Tests/Projects/ProjectUpdaterTests.cs
@@ -248,14 +248,22 @@ public class ProjectUpdaterTests(ITestOutputHelper outputHelper)
             {
                 Assert.Equal("Aspire.Hosting.Redis", item.PackageId);
                 Assert.Equal("9.5.0-preview.1", item.PackageVersion);
-                Assert.Null(item.PackageSource); // Should be null because of --no-restore behavior.
+                // PackageSource is null because ProjectUpdater passes nugetSource: null to AddPackageAsync.
+                Assert.Null(item.PackageSource);
+                // Per-package 'dotnet package add' must use --no-restore so the deferred final restore
+                // sees a fully-updated reference graph (regression guard for https://github.com/dotnet/aspire/issues/15891).
+                Assert.True(item.NoRestore);
                 Assert.Equal(appHostProjectFile.FullName, item.ProjectFile.FullName);
             },
             item =>
             {
                 Assert.Equal("Aspire.StackExchange.Redis.OutputCaching", item.PackageId);
                 Assert.Equal("9.5.0-preview.1", item.PackageVersion);
-                Assert.Null(item.PackageSource); // Should be null because of --no-restore behavior.
+                // PackageSource is null because ProjectUpdater passes nugetSource: null to AddPackageAsync.
+                Assert.Null(item.PackageSource);
+                // Per-package 'dotnet package add' must use --no-restore so the deferred final restore
+                // sees a fully-updated reference graph (regression guard for https://github.com/dotnet/aspire/issues/15891).
+                Assert.True(item.NoRestore);
                 Assert.Equal(webAppProjectFile.FullName, item.ProjectFile.FullName);
             }
         );
@@ -387,21 +395,33 @@ public class ProjectUpdaterTests(ITestOutputHelper outputHelper)
             {
                 Assert.Equal("Aspire.Hosting.Redis", item.PackageId);
                 Assert.Equal("9.4.1", item.PackageVersion);
-                Assert.Null(item.PackageSource); // Should be null because of --no-restore behavior.
+                // PackageSource is null because ProjectUpdater passes nugetSource: null to AddPackageAsync.
+                Assert.Null(item.PackageSource);
+                // Per-package 'dotnet package add' must use --no-restore so the deferred final restore
+                // sees a fully-updated reference graph (regression guard for https://github.com/dotnet/aspire/issues/15891).
+                Assert.True(item.NoRestore);
                 Assert.Equal(appHostProjectFile.FullName, item.ProjectFile.FullName);
             },
             item =>
             {
                 Assert.Equal("Aspire.Hosting.Docker", item.PackageId);
                 Assert.Equal("9.4.1-preview.1", item.PackageVersion);
-                Assert.Null(item.PackageSource); // Should be null because of --no-restore behavior.
+                // PackageSource is null because ProjectUpdater passes nugetSource: null to AddPackageAsync.
+                Assert.Null(item.PackageSource);
+                // Per-package 'dotnet package add' must use --no-restore so the deferred final restore
+                // sees a fully-updated reference graph (regression guard for https://github.com/dotnet/aspire/issues/15891).
+                Assert.True(item.NoRestore);
                 Assert.Equal(appHostProjectFile.FullName, item.ProjectFile.FullName);
             },
             item =>
             {
                 Assert.Equal("Aspire.StackExchange.Redis.OutputCaching", item.PackageId);
                 Assert.Equal("9.4.1", item.PackageVersion);
-                Assert.Null(item.PackageSource); // Should be null because of --no-restore behavior.
+                // PackageSource is null because ProjectUpdater passes nugetSource: null to AddPackageAsync.
+                Assert.Null(item.PackageSource);
+                // Per-package 'dotnet package add' must use --no-restore so the deferred final restore
+                // sees a fully-updated reference graph (regression guard for https://github.com/dotnet/aspire/issues/15891).
+                Assert.True(item.NoRestore);
                 Assert.Equal(webAppProjectFile.FullName, item.ProjectFile.FullName);
             }
         );
@@ -3137,6 +3157,136 @@ public class ProjectUpdaterTests(ITestOutputHelper outputHelper)
         Assert.DoesNotContain("Aspire.Hosting.AppHost", updatedCsprojContent);
         Assert.Contains("Aspire.Hosting.Redis", updatedCsprojContent);
         Assert.Contains("Aspire.AppHost.Sdk/13.0.2", updatedCsprojContent);
+    }
+
+    // Regression guard for https://github.com/dotnet/aspire/issues/15891.
+    //
+    // Repro shape: project on a stable channel referencing two or more Aspire integration
+    // packages whose stable versions are not carried by the daily-style Explicit channel
+    // being switched to. The bug was that ProjectUpdater rewrote nuget.config (adding a
+    // packageSourceMapping pinning Aspire* to the daily feed) and then ran 'dotnet package add'
+    // for each package one at a time *with restore enabled*. The first restore happened against
+    // a half-updated reference graph: the just-bumped package existed in the daily feed but the
+    // others were still on stable versions that didn't, and the new mapping blocked fallback
+    // to nuget.org -> NU1103.
+    //
+    // The fix passes --no-restore to per-package adds and runs a single deferred restore at the
+    // end. This test pins both halves of that contract:
+    //   1. every per-package add was invoked with noRestore=true, and
+    //   2. exactly one restore was invoked, and
+    //   3. the restore came after all the package adds (not interleaved with them).
+    [Fact]
+    public async Task UpdateProjectFileAsync_AppliesAllPackageEditsBeforeFinalRestore()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+
+        var appHostFolder = workspace.CreateDirectory("Issue15891.AppHost");
+        var appHostProjectFile = new FileInfo(Path.Combine(appHostFolder.FullName, "Issue15891.AppHost.csproj"));
+
+        await File.WriteAllTextAsync(
+            appHostProjectFile.FullName,
+            """
+            <Project Sdk="Microsoft.NET.Sdk">
+                <Sdk Name="Aspire.AppHost.Sdk" Version="9.4.1" />
+            </Project>
+            """);
+
+        // Use a single shared list so we can assert that all 'add's happened before the 'restore'.
+        // Recording entries as strings keeps the assertion readable when it fails.
+        var calls = new List<string>();
+
+        var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper, config =>
+        {
+            config.DotNetCliRunnerFactory = (sp) =>
+            {
+                return new TestDotNetCliRunner()
+                {
+                    SearchPackagesAsyncCallback = (_, query, _, _, _, _, _, _, _, _) =>
+                    {
+                        var package = query switch
+                        {
+                            "Aspire.AppHost.Sdk" => new NuGetPackageCli { Id = "Aspire.AppHost.Sdk", Version = "9.5.0-preview.1", Source = "daily" },
+                            "Aspire.Hosting.AppHost" => new NuGetPackageCli { Id = "Aspire.Hosting.AppHost", Version = "9.5.0-preview.1", Source = "daily" },
+                            "Aspire.Hosting.Redis" => new NuGetPackageCli { Id = "Aspire.Hosting.Redis", Version = "9.5.0-preview.1", Source = "daily" },
+                            "Aspire.Hosting.PostgreSQL" => new NuGetPackageCli { Id = "Aspire.Hosting.PostgreSQL", Version = "9.5.0-preview.1", Source = "daily" },
+                            "Aspire.Hosting.Kafka" => new NuGetPackageCli { Id = "Aspire.Hosting.Kafka", Version = "9.5.0-preview.1", Source = "daily" },
+                            _ => throw new InvalidOperationException($"Unexpected package query: {query}"),
+                        };
+
+                        return (0, new[] { package });
+                    },
+
+                    GetProjectItemsAndPropertiesAsyncCallback = (projectFile, _, _, _, _) =>
+                    {
+                        var itemsAndProperties = new JsonObject();
+
+                        if (projectFile.FullName == appHostProjectFile.FullName)
+                        {
+                            itemsAndProperties.WithSdkVersion("9.4.1");
+                            itemsAndProperties.WithPackageReference("Aspire.Hosting.AppHost", "9.4.1");
+                            // Three integration packages on the prior stable version - this is the
+                            // shape that fails in the original issue: the first per-package restore
+                            // would resolve the new daily Redis but reject the still-stable PostgreSQL
+                            // and Kafka because the new packageSourceMapping prevents fallback to
+                            // nuget.org for Aspire*.
+                            itemsAndProperties.WithPackageReference("Aspire.Hosting.Redis", "9.4.1");
+                            itemsAndProperties.WithPackageReference("Aspire.Hosting.PostgreSQL", "9.4.1");
+                            itemsAndProperties.WithPackageReference("Aspire.Hosting.Kafka", "9.4.1");
+                        }
+                        else
+                        {
+                            throw new InvalidOperationException($"Unexpected project file: {projectFile.FullName}");
+                        }
+
+                        var json = itemsAndProperties.ToJsonString();
+                        var document = JsonDocument.Parse(json);
+                        return (0, document);
+                    },
+
+                    AddPackageAsyncCallback = (projectFile, packageId, packageVersion, source, noRestore, _, _) =>
+                    {
+                        calls.Add($"add:{packageId}@{packageVersion}:noRestore={noRestore}");
+                        return 0;
+                    },
+
+                    RestoreAsyncCallback = (projectFilePath, _, _) =>
+                    {
+                        calls.Add($"restore:{projectFilePath.Name}");
+                        return 0;
+                    },
+                };
+            };
+
+            config.InteractionServiceFactory = (s) => new TestInteractionService();
+        });
+
+        using var provider = services.BuildServiceProvider();
+        var packagingService = provider.GetRequiredService<IPackagingService>();
+
+        // 'daily' is an Explicit channel (see PackagingService.CreateExplicitChannel), which is
+        // the trigger condition for the NuGetConfigMerger path that surfaces the original bug.
+        var channels = await packagingService.GetChannelsAsync().DefaultTimeout();
+        var dailyChannel = channels.Single(c => c.Name == "daily");
+
+        var projectUpdater = provider.GetRequiredService<IProjectUpdater>();
+        var updateResult = await projectUpdater.UpdateProjectAsync(CreateUpdateContext(appHostProjectFile, dailyChannel)).DefaultTimeout();
+
+        Assert.True(updateResult.UpdatedApplied);
+
+        // Every 'dotnet package add' must have been invoked with --no-restore so that NuGet
+        // never sees a half-updated reference graph against the new packageSourceMapping.
+        var addCalls = calls.Where(c => c.StartsWith("add:", StringComparison.Ordinal)).ToList();
+        Assert.NotEmpty(addCalls);
+        Assert.All(addCalls, c => Assert.EndsWith(":noRestore=True", c));
+
+        // Exactly one restore should have been invoked - the deferred final restore.
+        var restoreCalls = calls.Where(c => c.StartsWith("restore:", StringComparison.Ordinal)).ToList();
+        var restore = Assert.Single(restoreCalls);
+        Assert.Equal($"restore:{appHostProjectFile.Name}", restore);
+
+        // The restore must come after every package add. If anyone re-enables per-package
+        // restore (or moves the final restore back into / before the loop) this fails.
+        Assert.Equal(calls.Count - 1, calls.IndexOf(restore));
     }
 }
 

--- a/tests/Aspire.Cli.Tests/Projects/ProjectUpdaterTests.cs
+++ b/tests/Aspire.Cli.Tests/Projects/ProjectUpdaterTests.cs
@@ -2339,6 +2339,186 @@ public class ProjectUpdaterTests(ITestOutputHelper outputHelper)
     }
 
     [Fact]
+    public async Task UpdateProjectFileAsync_SingleFileAppHost_RemovesLegacyAppHostPackageDirectiveDuringSdkBump()
+    {
+        // Companion to the .csproj path covered by
+        // UpdateProjectFileAsync_StaleAppHostPackageReference_RemovedEvenWhenSdkAlreadyCurrent.
+        // Aspire.AppHost.Sdk pulls Aspire.Hosting.AppHost in implicitly, so an
+        // explicit `#:package Aspire.Hosting.AppHost@<version>` directive in a
+        // single-file AppHost is redundant. After a channel switch rewrites
+        // nuget.config to pin Aspire* to the channel feed, the deferred restore
+        // would otherwise hit NU1103 because the pinned channel does not carry
+        // the user's stable version.
+        // See https://github.com/dotnet/aspire/issues/15891.
+
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+
+        var appHostFolder = workspace.CreateDirectory("UpdateTester.AppHost");
+        var appHostFile = new FileInfo(Path.Combine(appHostFolder.FullName, "apphost.cs"));
+
+        await File.WriteAllTextAsync(
+            appHostFile.FullName,
+            """
+            #:sdk Aspire.AppHost.Sdk@9.4.1
+            #:package Aspire.Hosting.AppHost@9.4.1
+            #:package Aspire.Hosting.Redis@9.4.1
+            using Aspire.Hosting;
+            var builder = DistributedApplication.CreateBuilder(args);
+            builder.AddRedis("redis");
+            builder.Build().Run();
+            """);
+
+        var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper, config =>
+        {
+            config.DotNetCliRunnerFactory = (sp) =>
+            {
+                return new TestDotNetCliRunner()
+                {
+                    SearchPackagesAsyncCallback = (_, query, _, _, _, _, _, _, _, _) =>
+                    {
+                        var packages = new List<NuGetPackageCli>
+                        {
+                            query switch
+                            {
+                                "Aspire.AppHost.Sdk" => new NuGetPackageCli { Id = "Aspire.AppHost.Sdk", Version = "9.5.0", Source = "nuget.org" },
+                                "Aspire.Hosting.Redis" => new NuGetPackageCli { Id = "Aspire.Hosting.Redis", Version = "9.5.0", Source = "nuget.org" },
+                                _ => throw new InvalidOperationException($"Unexpected package query: {query}"),
+                            }
+                        };
+                        return (0, packages.ToArray());
+                    },
+                    GetProjectItemsAndPropertiesAsyncCallback = (projectFile, _, _, _, _) =>
+                    {
+                        var itemsAndProperties = new JsonObject();
+                        itemsAndProperties.WithSdkVersion("9.4.1");
+                        // Surface the explicit Aspire.Hosting.AppHost / Aspire.Hosting.Redis
+                        // directives the way MSBuild would for an apphost.cs file.
+                        var items = new JsonObject
+                        {
+                            ["PackageReference"] = new JsonArray
+                            {
+                                new JsonObject { ["Identity"] = "Aspire.Hosting.AppHost", ["Version"] = "9.4.1" },
+                                new JsonObject { ["Identity"] = "Aspire.Hosting.Redis", ["Version"] = "9.4.1" },
+                            },
+                        };
+                        itemsAndProperties["Items"] = items;
+                        var json = itemsAndProperties.ToJsonString();
+                        var document = JsonDocument.Parse(json);
+                        return (0, document);
+                    },
+                    AddPackageAsyncCallback = (_, _, _, _, _, _, _) => 0,
+                };
+            };
+
+            config.InteractionServiceFactory = (sp) =>
+            {
+                var interactionService = new TestInteractionService();
+                interactionService.ConfirmCallback = (_, _) => true;
+                return interactionService;
+            };
+        });
+        using var provider = services.BuildServiceProvider();
+
+        var packagingService = provider.GetRequiredService<IPackagingService>();
+        var channels = await packagingService.GetChannelsAsync().DefaultTimeout();
+        var selectedChannel = channels.Single(c => c.Name == "default");
+
+        var projectUpdater = provider.GetRequiredService<IProjectUpdater>();
+        var updateResult = await projectUpdater.UpdateProjectAsync(CreateUpdateContext(appHostFile, selectedChannel)).DefaultTimeout();
+
+        Assert.True(updateResult.UpdatedApplied);
+
+        var updatedContent = await File.ReadAllTextAsync(appHostFile.FullName);
+        Assert.Contains("#:sdk Aspire.AppHost.Sdk@9.5.0", updatedContent);
+        Assert.DoesNotContain("Aspire.Hosting.AppHost", updatedContent);
+        // Aspire.Hosting.Redis directive is preserved (and bumped via dotnet package add,
+        // which is mocked here, so the source text still shows 9.4.1; the important
+        // assertion is that the directive line itself was not removed).
+        Assert.Contains("#:package Aspire.Hosting.Redis@", updatedContent);
+    }
+
+    [Fact]
+    public async Task UpdateProjectFileAsync_SingleFileAppHost_RemovesLegacyAppHostPackageDirectiveWhenSdkAlreadyCurrent()
+    {
+        // SDK is already on the latest version, so AnalyzeAppHostSdkAsync
+        // early-returns. The cleanup step path must still strip the redundant
+        // `#:package Aspire.Hosting.AppHost@<version>` directive so a re-run of
+        // `aspire update` after a partial migration recovers cleanly.
+
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+
+        var appHostFolder = workspace.CreateDirectory("UpdateTester.AppHost");
+        var appHostFile = new FileInfo(Path.Combine(appHostFolder.FullName, "apphost.cs"));
+
+        await File.WriteAllTextAsync(
+            appHostFile.FullName,
+            """
+            #:sdk Aspire.AppHost.Sdk@9.5.0
+            #:package Aspire.Hosting.AppHost@9.5.0
+            using Aspire.Hosting;
+            var builder = DistributedApplication.CreateBuilder(args);
+            builder.Build().Run();
+            """);
+
+        var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper, config =>
+        {
+            config.DotNetCliRunnerFactory = (sp) =>
+            {
+                return new TestDotNetCliRunner()
+                {
+                    SearchPackagesAsyncCallback = (_, query, _, _, _, _, _, _, _, _) =>
+                    {
+                        var packages = new List<NuGetPackageCli>
+                        {
+                            query switch
+                            {
+                                "Aspire.AppHost.Sdk" => new NuGetPackageCli { Id = "Aspire.AppHost.Sdk", Version = "9.5.0", Source = "nuget.org" },
+                                _ => throw new InvalidOperationException($"Unexpected package query: {query}"),
+                            }
+                        };
+                        return (0, packages.ToArray());
+                    },
+                    GetProjectItemsAndPropertiesAsyncCallback = (projectFile, _, _, _, _) =>
+                    {
+                        var itemsAndProperties = new JsonObject();
+                        itemsAndProperties.WithSdkVersion("9.5.0");
+                        var items = new JsonObject
+                        {
+                            ["PackageReference"] = new JsonArray
+                            {
+                                new JsonObject { ["Identity"] = "Aspire.Hosting.AppHost", ["Version"] = "9.5.0" },
+                            },
+                        };
+                        itemsAndProperties["Items"] = items;
+                        var json = itemsAndProperties.ToJsonString();
+                        var document = JsonDocument.Parse(json);
+                        return (0, document);
+                    }
+                };
+            };
+
+            config.InteractionServiceFactory = (sp) =>
+            {
+                var interactionService = new TestInteractionService();
+                interactionService.ConfirmCallback = (_, _) => true;
+                return interactionService;
+            };
+        });
+        using var provider = services.BuildServiceProvider();
+
+        var packagingService = provider.GetRequiredService<IPackagingService>();
+        var channels = await packagingService.GetChannelsAsync().DefaultTimeout();
+        var selectedChannel = channels.Single(c => c.Name == "default");
+
+        var projectUpdater = provider.GetRequiredService<IProjectUpdater>();
+        await projectUpdater.UpdateProjectAsync(CreateUpdateContext(appHostFile, selectedChannel)).DefaultTimeout();
+
+        var updatedContent = await File.ReadAllTextAsync(appHostFile.FullName);
+        Assert.DoesNotContain("Aspire.Hosting.AppHost", updatedContent);
+        Assert.Contains("#:sdk Aspire.AppHost.Sdk@9.5.0", updatedContent);
+    }
+
+    [Fact]
     public async Task UpdateProjectFileAsync_SingleFileAppHost_UpdatesSdkDirectiveWithWildcard()
     {
         using var workspace = TemporaryWorkspace.Create(outputHelper);
@@ -2767,6 +2947,23 @@ public class ProjectUpdaterTests(ITestOutputHelper outputHelper)
         var match = regex.IsMatch(directive);
 
         Assert.Equal(shouldMatch, match);
+    }
+
+    [Theory]
+    [InlineData("#:package Aspire.Hosting.AppHost@13.2.1", true)]
+    [InlineData("  #:package Aspire.Hosting.AppHost@13.2.1", true)]
+    [InlineData("#:package aspire.hosting.apphost@13.2.1", true)]
+    [InlineData("#:package Aspire.Hosting.AppHost@*", true)]
+    [InlineData("#:package Aspire.Hosting.AppHost@10.0.0-preview.1.26264.14", true)]
+    [InlineData("#:package Aspire.Hosting.Redis@13.2.1", false)]
+    [InlineData("#:sdk Aspire.AppHost.Sdk@13.2.1", false)]
+    [InlineData("// #:package Aspire.Hosting.AppHost@13.2.1", false)]
+    [InlineData("#:package Aspire.Hosting.AppHost", false)]
+    [InlineData("#:package Aspire.Hosting.AppHost@", false)]
+    public void LegacyAppHostPackageDirectiveRegex_MatchesOnlyAppHostDirective(string line, bool shouldMatch)
+    {
+        var regex = ProjectUpdater.LegacyAppHostPackageDirectiveRegex();
+        Assert.Equal(shouldMatch, regex.IsMatch(line));
     }
 
     [Fact]

--- a/tests/Aspire.Cli.Tests/TestServices/TestDotNetCliRunner.cs
+++ b/tests/Aspire.Cli.Tests/TestServices/TestDotNetCliRunner.cs
@@ -50,7 +50,7 @@ internal sealed class TestDotNetCliRunner : IDotNetCliRunner
     {
         return RestoreAsyncCallback != null
             ? Task.FromResult(RestoreAsyncCallback(projectFilePath, options, cancellationToken))
-            : throw new NotImplementedException();
+            : Task.FromResult(0); // If not overridden, just return success.
     }
 
     public Task<(int ExitCode, bool IsAspireHost, string? AspireHostingVersion)> GetAppHostInformationAsync(FileInfo projectFile, ProcessInvocationOptions options, CancellationToken cancellationToken)


### PR DESCRIPTION
Fixes #15891.

## What the user sees

`aspire update --channel daily` (or any other Explicit channel — staging, PR
hives, local) on a file-based AppHost referencing several stable Aspire
integration packages fails partway through with:

```
error NU1103: Unable to find a stable package Aspire.Hosting.Python with version (>= 13.2.1)
  - Found 2552 version(s) in dotnet9 feed [ Nearest version: 13.3.0-preview.1.26111.5 ]
  - Versions from https://api.nuget.org/v3/index.json were not considered
```

The project is left in a broken intermediate state: new `nuget.config` (now
restricting `Aspire*` to the daily feed), only the first package bumped to a
daily version, the rest still on the stable version that no longer resolves.

## Root cause

`ProjectUpdater.UpdateProjectAsync` ran in this order:

1. (Explicit channels) merge the channel's feed mappings into `nuget.config`
   via `NuGetConfigMerger.CreateOrUpdateAsync` — adds the
   `<packageSourceMapping>` pinning `Aspire*` to the channel's feed.
2. Iterate update steps; each non-CPM step called
   `runner.AddPackageAsync(..., noRestore: false, ...)` — i.e. each
   `dotnet package add` ran its own restore.

The first restore happened with `nuget.config` already in "channel-only" mode
but the rest of the `PackageReference`s still on stable versions. With
`<packageSourceMapping>` blocking nuget.org for `Aspire*`, NuGet emitted
`NU1103` for the not-yet-bumped Aspire packages and the update aborted.

## Fix

Defer the implicit restore until **after** every package version edit has been
applied:

- `UpdatePackageReferenceInProject` now passes `noRestore: true` on every
  per-package `AddPackageAsync` so each `dotnet package add` only mutates the
  project / file-based AppHost.
- After the existing "Applying updates" loop completes,
  `UpdateProjectAsync` runs a single `runner.RestoreAsync(...)` so users still
  get a clear failure surface if anything else is misconfigured.

By the time NuGet sees the new `<packageSourceMapping>`, every `Aspire*`
reference already points at a version that exists in the channel's feed, so
the mapping no longer causes `NU1103`.

Verified locally on .NET SDK 10.0.203 that `dotnet restore <path-to-apphost.cs>`
works for both `.csproj` and file-based AppHosts — the existing
`IDotNetCliRunner.RestoreAsync` shape covers both with no signature change.

New `RestoringPackagesAfterUpdate` / `FailedToRestoreAfterUpdateFormat`
resource strings carry the status and error messaging; xlf files regenerated
via `dotnet build /t:UpdateXlf`.

## Tests

Three layers, each catching a different regression class:

1. **Unit (PR-time guard, fast)** —
   `ProjectUpdaterTests.UpdateProjectFileAsync_AppliesAllPackageEditsBeforeFinalRestore`
   wires `AddPackageAsync` and `RestoreAsync` to a shared call-order list and
   asserts every add carries `noRestore: true`, exactly one restore is
   invoked, and it runs **last**. If anyone flips `noRestore` back to `false`
   or moves the restore step before the loop, this fails immediately.

2. **Tightened existing tests** — the five `AddPackageAsync` capture sites in
   `ProjectUpdaterTests` now also assert `item.NoRestore == true` (and the
   misleading "should be null because of `--no-restore` behavior" comment that
   actually referred to `nugetSource` is corrected). Catches regressions on
   every existing scenario — traditional `PackageReference`, multi-project,
   single-file AppHost, mixed paths.

3. **End-to-end CLI test (CI guard, real bug repro)** —
   `UpdateChannelNuGetConfigOrderingTests.AspireUpdateAppliesAllPackageEditsBeforeRestoringWhenNuGetConfigGainsSourceMapping`,
   in its own test class so CI's per-class job split (`SplitTestsOnCI=true`)
   puts it on its own runner. Exercises the bug end-to-end against LocalHive:
   writes an `apphost.cs` with three stable `Aspire.Hosting.*` references
   (`Redis`, `PostgreSQL`, `Kafka` at `13.2.1` — the same release used in the
   issue's repro) and a nuget.org-only `nuget.config`, runs
   `aspire update --channel local`, then asserts:
   - the merged `<packageSourceMapping>` actually landed (so we know the bug
     pre-condition was triggered, not silently bypassed), and
   - every `#:package` directive was bumped to the local SDK version (so we
     know the loop ran to completion rather than aborting after the first add).

   Skips on non-LocalHive strategies because reproducing against the public
   daily feed isn't deterministic.

## Notes for reviewers

- `TestDotNetCliRunner.RestoreAsync` now defaults to returning `0` instead of
  throwing `NotImplementedException`, mirroring the existing
  `AddProjectToSolutionAsync` / `GetNuGetConfigPathsAsync` patterns. Required
  because `UpdateProjectAsync` always calls `RestoreAsync` now and most
  existing `ProjectUpdater` tests don't set the callback. No existing test
  relied on the throw behavior.
- The CPM path (`UpdatePackageVersionInDirectoryPackagesProps`) edits
  `Directory.Packages.props` directly and never invoked restore on its own,
  so it was never part of the bug — but the new single deferred restore
  covers it too.
- Existing `UpdateProjectFileAsync_CanUpdateFromStableToDaily` already
  exercises the Explicit channel path, so the production fix is hit by
  multiple tests, not just the new one.