### PR TITLE
Batch NuGet version lookup for `aspire update`

### DIFF
--- a/src/Aspire.Cli/NuGet/BundleNuGetPackageCache.cs
+++ b/src/Aspire.Cli/NuGet/BundleNuGetPackageCache.cs
@@ -252,6 +252,130 @@ internal sealed class BundleNuGetPackageCache : INuGetPackageCache
         }
     }
 
+    public async Task<IReadOnlyDictionary<string, PackageLatestVersions>> GetLatestVersionsAsync(
+        IEnumerable<string> packageIds,
+        DirectoryInfo workingDirectory,
+        FileInfo? nugetConfigFile,
+        CancellationToken cancellationToken)
+    {
+        var ids = packageIds
+            .Where(static id => !string.IsNullOrEmpty(id))
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .ToList();
+
+        if (ids.Count == 0)
+        {
+            return new Dictionary<string, PackageLatestVersions>(StringComparer.OrdinalIgnoreCase);
+        }
+
+        // Bundle mode: collapse N×2 search subprocesses into a single `aspire-managed nuget versions`
+        // invocation that fans out FindPackageByIdResource calls in-process across every (id × source)
+        // pair. See VersionsCommand for the implementation.
+        var layout = await _bundleService.EnsureExtractedAndGetLayoutAsync(cancellationToken).ConfigureAwait(false);
+        if (layout is null)
+        {
+            throw new InvalidOperationException("Bundle layout not found. Cannot perform NuGet versions lookup in bundle mode.");
+        }
+
+        var managedPath = layout.GetManagedPath();
+        if (managedPath is null || !File.Exists(managedPath))
+        {
+            throw new InvalidOperationException("aspire-managed not found in layout.");
+        }
+
+        var args = new List<string>
+        {
+            "nuget",
+            "versions"
+        };
+
+        foreach (var id in ids)
+        {
+            args.Add("--id");
+            args.Add(id);
+        }
+
+        args.Add("--working-dir");
+        args.Add(workingDirectory.FullName);
+
+        if (nugetConfigFile is not null)
+        {
+            args.Add("--nuget-config");
+            args.Add(nugetConfigFile.FullName);
+        }
+
+        if (_logger.IsEnabled(LogLevel.Debug))
+        {
+            args.Add("--verbose");
+        }
+
+        _logger.LogDebug("Running NuGet versions via aspire-managed for {Count} package id(s)", ids.Count);
+
+        var (exitCode, output, error) = await _layoutProcessRunner.RunAsync(
+            managedPath,
+            args,
+            workingDirectory: workingDirectory.FullName,
+            ct: cancellationToken).ConfigureAwait(false);
+
+        if (!string.IsNullOrWhiteSpace(error))
+        {
+            _logger.LogDebug("NuGetHelper stderr: {Error}", error);
+        }
+
+        if (exitCode != 0)
+        {
+            _logger.LogError("NuGet versions failed with exit code {ExitCode}", exitCode);
+            _logger.LogError("NuGet versions stderr: {Error}", error);
+            _logger.LogError("NuGet versions stdout: {Output}", output);
+            throw new NuGetPackageCacheException($"Package versions lookup failed: {error}");
+        }
+
+        try
+        {
+            if (string.IsNullOrEmpty(output))
+            {
+                _logger.LogWarning("NuGet versions returned empty output");
+                return new Dictionary<string, PackageLatestVersions>(StringComparer.OrdinalIgnoreCase);
+            }
+
+            var result = JsonSerializer.Deserialize(output, BundleVersionsJsonContext.Default.BundleVersionsResult);
+            var dict = new Dictionary<string, PackageLatestVersions>(StringComparer.OrdinalIgnoreCase);
+
+            if (result?.Packages is null)
+            {
+                return dict;
+            }
+
+            foreach (var info in result.Packages)
+            {
+                if (string.IsNullOrEmpty(info.Id))
+                {
+                    continue;
+                }
+
+                NuGetPackage? stable = info.LatestStableVersion is { Length: > 0 }
+                    ? new NuGetPackage { Id = info.Id, Version = info.LatestStableVersion, Source = info.LatestStableSource ?? string.Empty }
+                    : null;
+                NuGetPackage? prerelease = info.LatestPrereleaseVersion is { Length: > 0 }
+                    ? new NuGetPackage { Id = info.Id, Version = info.LatestPrereleaseVersion, Source = info.LatestPrereleaseSource ?? string.Empty }
+                    : null;
+
+                dict[info.Id] = new PackageLatestVersions
+                {
+                    LatestStable = stable,
+                    LatestPrerelease = prerelease
+                };
+            }
+
+            return dict;
+        }
+        catch (JsonException ex)
+        {
+            _logger.LogError(ex, "Failed to parse versions results");
+            throw new NuGetPackageCacheException($"Failed to parse versions results: {ex.Message}");
+        }
+    }
+
     private IEnumerable<NuGetPackage> FilterPackages(IEnumerable<NuGetPackage> packages, Func<string, bool>? filter)
     {
         var showDeprecatedPackages = _features.IsFeatureEnabled(KnownFeatures.ShowDeprecatedPackages, defaultValue: false);
@@ -316,6 +440,27 @@ internal sealed class BundlePackageInfo
 [JsonSerializable(typeof(BundlePackageInfo))]
 [JsonSourceGenerationOptions(PropertyNamingPolicy = JsonKnownNamingPolicy.CamelCase)]
 internal sealed partial class BundleSearchJsonContext : JsonSerializerContext
+{
+}
+
+internal sealed class BundleVersionsResult
+{
+    public List<BundleVersionsInfo>? Packages { get; set; }
+}
+
+internal sealed class BundleVersionsInfo
+{
+    public string Id { get; set; } = "";
+    public string? LatestStableVersion { get; set; }
+    public string? LatestStableSource { get; set; }
+    public string? LatestPrereleaseVersion { get; set; }
+    public string? LatestPrereleaseSource { get; set; }
+}
+
+[JsonSerializable(typeof(BundleVersionsResult))]
+[JsonSerializable(typeof(BundleVersionsInfo))]
+[JsonSourceGenerationOptions(PropertyNamingPolicy = JsonKnownNamingPolicy.CamelCase)]
+internal sealed partial class BundleVersionsJsonContext : JsonSerializerContext
 {
 }
 

--- a/src/Aspire.Cli/NuGet/NuGetPackageCache.cs
+++ b/src/Aspire.Cli/NuGet/NuGetPackageCache.cs
@@ -7,6 +7,7 @@ using System.Collections.Frozen;
 using System.Globalization;
 using Aspire.Cli.Telemetry;
 using Microsoft.Extensions.Caching.Memory;
+using Semver;
 using NuGetPackage = Aspire.Shared.NuGetPackageCli;
 using Aspire.Cli.Configuration;
 
@@ -19,6 +20,30 @@ internal interface INuGetPackageCache
     Task<IEnumerable<NuGetPackage>> GetCliPackagesAsync(DirectoryInfo workingDirectory, bool prerelease, FileInfo? nugetConfigFile, CancellationToken cancellationToken);
     Task<IEnumerable<NuGetPackage>> GetPackagesAsync(DirectoryInfo workingDirectory, string packageId, Func<string, bool>? filter, bool prerelease, FileInfo? nugetConfigFile, bool useCache, CancellationToken cancellationToken);
     Task<IEnumerable<NuGetPackage>> GetPackageVersionsAsync(DirectoryInfo workingDirectory, string exactPackageId, bool prerelease, FileInfo? nugetConfigFile, bool useCache, CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Resolves the latest stable and latest prerelease version for each id in <paramref name="packageIds"/>
+    /// using a single batched lookup against all configured NuGet sources.
+    /// Used by <c>aspire update</c> to avoid issuing one subprocess per package id × quality.
+    /// Returned dictionary is keyed case-insensitively by id; ids with no matches across any source are
+    /// represented by an entry whose <see cref="PackageLatestVersions.LatestStable"/> and
+    /// <see cref="PackageLatestVersions.LatestPrerelease"/> are both <c>null</c>, or are absent entirely.
+    /// </summary>
+    Task<IReadOnlyDictionary<string, PackageLatestVersions>> GetLatestVersionsAsync(
+        IEnumerable<string> packageIds,
+        DirectoryInfo workingDirectory,
+        FileInfo? nugetConfigFile,
+        CancellationToken cancellationToken);
+}
+
+/// <summary>
+/// Latest known stable and prerelease versions for a single package id across all configured sources.
+/// Either field may be <c>null</c> when no matching version exists on any configured source.
+/// </summary>
+internal sealed class PackageLatestVersions
+{
+    public NuGetPackage? LatestStable { get; init; }
+    public NuGetPackage? LatestPrerelease { get; init; }
 }
 
 /// <summary>
@@ -212,6 +237,72 @@ internal sealed class NuGetPackageCache(IDotNetCliRunner cliRunner, IMemoryCache
         };
 
         return collectedPackages.Where(effectiveFilter);
+    }
+
+    public async Task<IReadOnlyDictionary<string, PackageLatestVersions>> GetLatestVersionsAsync(
+        IEnumerable<string> packageIds,
+        DirectoryInfo workingDirectory,
+        FileInfo? nugetConfigFile,
+        CancellationToken cancellationToken)
+    {
+        // SDK transport (no bundle) cannot batch in a single subprocess because `dotnet package search`
+        // accepts only one query per invocation. Issue per-id × per-quality calls in parallel with a
+        // small concurrency cap so users still get a meaningful speedup over today's serial loop without
+        // accidentally fanning out to dozens of concurrent subprocesses on slow networks.
+        var ids = packageIds
+            .Where(static id => !string.IsNullOrEmpty(id))
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .ToList();
+
+        if (ids.Count == 0)
+        {
+            return new Dictionary<string, PackageLatestVersions>(StringComparer.OrdinalIgnoreCase);
+        }
+
+        const int MaxParallelism = 4;
+        using var throttle = new SemaphoreSlim(MaxParallelism);
+
+        var results = new Dictionary<string, PackageLatestVersions>(StringComparer.OrdinalIgnoreCase);
+        var resultsLock = new object();
+
+        async Task ResolveAsync(string id)
+        {
+            await throttle.WaitAsync(cancellationToken).ConfigureAwait(false);
+            try
+            {
+                // Run the stable + prerelease searches concurrently for the same id.
+                var stableTask = GetPackagesAsync(workingDirectory, id, pid => string.Equals(pid, id, StringComparison.OrdinalIgnoreCase), prerelease: false, nugetConfigFile, useCache: true, cancellationToken);
+                var prereleaseTask = GetPackagesAsync(workingDirectory, id, pid => string.Equals(pid, id, StringComparison.OrdinalIgnoreCase), prerelease: true, nugetConfigFile, useCache: true, cancellationToken);
+                await Task.WhenAll(stableTask, prereleaseTask).ConfigureAwait(false);
+
+                var latestStable = PickLatest(stableTask.Result, requirePrerelease: false);
+                var latestPrerelease = PickLatest(prereleaseTask.Result, requirePrerelease: true);
+
+                lock (resultsLock)
+                {
+                    results[id] = new PackageLatestVersions
+                    {
+                        LatestStable = latestStable,
+                        LatestPrerelease = latestPrerelease
+                    };
+                }
+            }
+            finally
+            {
+                throttle.Release();
+            }
+        }
+
+        await Task.WhenAll(ids.Select(ResolveAsync)).ConfigureAwait(false);
+        return results;
+    }
+
+    private static NuGetPackage? PickLatest(IEnumerable<NuGetPackage> packages, bool requirePrerelease)
+    {
+        return packages
+            .Where(p => SemVersion.TryParse(p.Version, SemVersionStyles.Strict, out var sv) && (!requirePrerelease || sv.IsPrerelease))
+            .OrderByDescending(p => SemVersion.Parse(p.Version, SemVersionStyles.Strict), SemVersion.PrecedenceComparer)
+            .FirstOrDefault();
     }
 }
 

--- a/src/Aspire.Cli/Packaging/PackageChannel.cs
+++ b/src/Aspire.Cli/Packaging/PackageChannel.cs
@@ -219,6 +219,46 @@ internal class PackageChannel(string name, PackageChannelQuality quality, Packag
         return filteredPackages;
     }
 
+    public async Task<IReadOnlyDictionary<string, PackageLatestVersions>> GetLatestVersionsAsync(IEnumerable<string> packageIds, DirectoryInfo workingDirectory, CancellationToken cancellationToken)
+    {
+        // Used by `aspire update` to resolve every referenced Aspire.* package's latest version with
+        // a single batched cache lookup, instead of issuing one search per id × quality.
+        var ids = packageIds
+            .Where(static id => !string.IsNullOrEmpty(id))
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .ToList();
+
+        if (ids.Count == 0)
+        {
+            return new Dictionary<string, PackageLatestVersions>(StringComparer.OrdinalIgnoreCase);
+        }
+
+        // For pinned/local-folder hive channels there is no remote feed to query — every package id
+        // resolves to PinnedVersion. This mirrors the early-return in GetIntegrationPackagesAsync.
+        if (PinnedVersion is not null)
+        {
+            var dict = new Dictionary<string, PackageLatestVersions>(StringComparer.OrdinalIgnoreCase);
+            foreach (var id in ids)
+            {
+                var package = new NuGetPackage { Id = id, Version = PinnedVersion, Source = SourceDetails };
+                dict[id] = new PackageLatestVersions
+                {
+                    LatestStable = package,
+                    LatestPrerelease = package
+                };
+            }
+            return dict;
+        }
+
+        using var tempNuGetConfig = Type is PackageChannelType.Explicit ? await TemporaryNuGetConfig.CreateAsync(Mappings!) : null;
+
+        return await nuGetPackageCache.GetLatestVersionsAsync(
+            ids,
+            workingDirectory,
+            tempNuGetConfig?.ConfigFile,
+            cancellationToken).ConfigureAwait(false);
+    }
+
     public async Task<IEnumerable<NuGetPackage>> GetPackageVersionsAsync(string packageId, DirectoryInfo workingDirectory, CancellationToken cancellationToken)
     {
         var tasks = new List<Task<IEnumerable<NuGetPackage>>>();

--- a/src/Aspire.Cli/Projects/ProjectUpdater.cs
+++ b/src/Aspire.Cli/Projects/ProjectUpdater.cs
@@ -8,6 +8,7 @@ using System.Text.RegularExpressions;
 using System.Xml;
 using Aspire.Cli.DotNet;
 using Aspire.Cli.Interaction;
+using Aspire.Cli.NuGet;
 using Aspire.Cli.Packaging;
 using Aspire.Cli.Resources;
 using Aspire.Shared;
@@ -163,6 +164,16 @@ internal sealed partial class ProjectUpdater(ILogger<ProjectUpdater> logger, IDo
     {
         var context = new UpdateContext(projectFile, channel);
 
+        // Prefetch the latest version for every Aspire.* package referenced anywhere in the project
+        // graph in one batched lookup. Without this, the per-step AnalyzePackage* calls below would
+        // each issue their own `dotnet package search` (or `aspire-managed nuget search`) per id ×
+        // quality, serialized through the AnalyzeSteps queue — which is the root cause of the
+        // multi-minute `aspire update` runs reported in https://github.com/microsoft/aspire/issues/12054.
+        // Pre-population is best-effort: GetLatestVersionOfPackageAsync below still falls back to the
+        // per-package search path on cache miss so correctness is preserved when a feed doesn't return
+        // an id from the batch lookup (e.g. local hives, V2 sources, transient errors).
+        await PrefetchLatestPackageVersionsAsync(context, cancellationToken).ConfigureAwait(false);
+
         var appHostAnalyzeStep = new AnalyzeStep(UpdateCommandStrings.AnalyzeAppHost, () => AnalyzeAppHostAsync(context, cancellationToken));
         context.AnalyzeSteps.Enqueue(appHostAnalyzeStep);
 
@@ -172,6 +183,150 @@ internal sealed partial class ProjectUpdater(ILogger<ProjectUpdater> logger, IDo
         }
 
         return (context.UpdateSteps, context.FallbackParsing);
+    }
+
+    private async Task PrefetchLatestPackageVersionsAsync(UpdateContext context, CancellationToken cancellationToken)
+    {
+        try
+        {
+            var ids = await CollectAspirePackageIdsAsync(context, cancellationToken).ConfigureAwait(false);
+            if (ids.Count == 0)
+            {
+                return;
+            }
+
+            var versions = await context.Channel.GetLatestVersionsAsync(ids, context.AppHostProjectFile.Directory!, cancellationToken).ConfigureAwait(false);
+            if (versions.Count == 0)
+            {
+                return;
+            }
+
+            // Mirror the quality semantics applied per-id by GetPackagesAsync: stable channels prefer
+            // a stable version and only fall back to prerelease when no stable exists; prerelease
+            // channels filter to prerelease only; "both" picks the highest precedence regardless.
+            foreach (var (id, latest) in versions)
+            {
+                var picked = SelectForChannelQuality(context.Channel.Quality, latest);
+                if (picked is null)
+                {
+                    // No suitable version known yet — leave the cache empty so the per-package
+                    // fallback in GetLatestVersionOfPackageAsync runs.
+                    continue;
+                }
+
+                var cacheKey = $"LatestPackage-{id}";
+                cache.Set(cacheKey, (NuGetPackageCli?)picked);
+            }
+        }
+        catch (Exception ex)
+        {
+            // Prefetch is a pure performance optimization — never fail the update because of it.
+            logger.LogDebug(ex, "Prefetch of latest Aspire package versions failed; falling back to per-package lookups.");
+        }
+    }
+
+    private static NuGetPackageCli? SelectForChannelQuality(PackageChannelQuality quality, PackageLatestVersions latest)
+    {
+        return quality switch
+        {
+            PackageChannelQuality.Stable => latest.LatestStable ?? latest.LatestPrerelease,
+            PackageChannelQuality.Prerelease => latest.LatestPrerelease,
+            PackageChannelQuality.Both => PickHigherPrecedence(latest.LatestStable, latest.LatestPrerelease),
+            _ => null
+        };
+    }
+
+    private static NuGetPackageCli? PickHigherPrecedence(NuGetPackageCli? a, NuGetPackageCli? b)
+    {
+        if (a is null)
+        {
+            return b;
+        }
+        if (b is null)
+        {
+            return a;
+        }
+
+        if (!SemVersion.TryParse(a.Version, SemVersionStyles.Strict, out var sa))
+        {
+            return b;
+        }
+        if (!SemVersion.TryParse(b.Version, SemVersionStyles.Strict, out var sb))
+        {
+            return a;
+        }
+        return SemVersion.PrecedenceComparer.Compare(sa, sb) >= 0 ? a : b;
+    }
+
+    private async Task<List<string>> CollectAspirePackageIdsAsync(UpdateContext context, CancellationToken cancellationToken)
+    {
+        // Walk the same project graph that AnalyzeProjectAsync visits, but only collect package ids
+        // (no version lookups). The GetItemsAndProperties* methods are MemoryCache-backed, so the
+        // subsequent AnalyzeSteps loop reuses these documents without re-running MSBuild evaluation.
+        var ids = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
+        {
+            // Always include the AppHost SDK because AnalyzeAppHostSdkAsync looks it up directly,
+            // even if it doesn't appear as a PackageReference anywhere in the graph.
+            "Aspire.AppHost.Sdk"
+        };
+
+        var visited = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        var queue = new Queue<FileInfo>();
+        queue.Enqueue(context.AppHostProjectFile);
+
+        while (queue.TryDequeue(out var projectFile))
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            if (!visited.Add(projectFile.FullName))
+            {
+                continue;
+            }
+
+            JsonDocument document;
+            try
+            {
+                document = IsAppHostProject(projectFile, context)
+                    ? await GetItemsAndPropertiesWithFallbackAsync(projectFile, context, cancellationToken).ConfigureAwait(false)
+                    : await GetItemsAndPropertiesAsync(projectFile, cancellationToken).ConfigureAwait(false);
+            }
+            catch (ProjectUpdaterException)
+            {
+                // Non-AppHost projects without fallback may throw; the AnalyzeSteps loop will surface
+                // the error properly. Just skip during prefetch.
+                continue;
+            }
+
+            if (!document.RootElement.TryGetProperty("Items", out var itemsElement))
+            {
+                continue;
+            }
+
+            if (itemsElement.TryGetProperty("ProjectReference", out var projectReferencesElement))
+            {
+                foreach (var projectReference in projectReferencesElement.EnumerateArray())
+                {
+                    if (projectReference.TryGetProperty("FullPath", out var fullPathElement) && fullPathElement.GetString() is { Length: > 0 } fullPath)
+                    {
+                        queue.Enqueue(new FileInfo(fullPath));
+                    }
+                }
+            }
+
+            if (itemsElement.TryGetProperty("PackageReference", out var packageReferencesElement))
+            {
+                foreach (var packageReference in packageReferencesElement.EnumerateArray())
+                {
+                    if (packageReference.TryGetProperty("Identity", out var identityElement) && identityElement.GetString() is { Length: > 0 } packageId
+                        && IsUpdatablePackage(packageId))
+                    {
+                        ids.Add(packageId);
+                    }
+                }
+            }
+        }
+
+        return ids.ToList();
     }
 
     private const string ItemsAndPropertiesCacheKeyPrefix = "ItemsAndProperties";

--- a/src/Aspire.Managed/NuGet/Commands/VersionsCommand.cs
+++ b/src/Aspire.Managed/NuGet/Commands/VersionsCommand.cs
@@ -1,0 +1,306 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.CommandLine;
+using System.Globalization;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using NuGet.Configuration;
+using NuGet.Protocol;
+using NuGet.Protocol.Core.Types;
+using NuGet.Versioning;
+using INuGetLogger = NuGet.Common.ILogger;
+
+namespace Aspire.Managed.NuGet.Commands;
+
+/// <summary>
+/// Versions command - resolves the latest stable and prerelease version for a set of package ids
+/// using NuGet's <see cref="FindPackageByIdResource"/> across all configured sources in parallel.
+/// Used by `aspire update` to collapse N per-package "search" subprocess invocations into a single
+/// batched call. Unlike a search-relevance query, FindPackageByIdResource asks each feed for the
+/// exact id, so the result does not depend on search ranking or take limits.
+/// </summary>
+public static class VersionsCommand
+{
+    /// <summary>
+    /// Creates the versions command.
+    /// </summary>
+    public static Command Create()
+    {
+        var command = new Command("versions", "Resolve the latest stable and prerelease versions for a set of package ids");
+
+        var idOption = new Option<string[]>("--id", "-i")
+        {
+            Description = "Package id to resolve (can be specified multiple times)",
+            Required = true,
+            AllowMultipleArgumentsPerToken = true
+        };
+        command.Options.Add(idOption);
+
+        var sourceOption = new Option<string[]>("--source")
+        {
+            Description = "NuGet feed URL (can specify multiple)",
+            DefaultValueFactory = _ => Array.Empty<string>(),
+            AllowMultipleArgumentsPerToken = true
+        };
+        command.Options.Add(sourceOption);
+
+        var configOption = new Option<string?>("--nuget-config")
+        {
+            Description = "Path to nuget.config file"
+        };
+        command.Options.Add(configOption);
+
+        var workingDirOption = new Option<string?>("--working-dir", "-d")
+        {
+            Description = "Working directory to search for nuget.config"
+        };
+        command.Options.Add(workingDirOption);
+
+        var verboseOption = new Option<bool>("--verbose", "-v")
+        {
+            Description = "Enable verbose output"
+        };
+        command.Options.Add(verboseOption);
+
+        command.SetAction(async (parseResult, ct) =>
+        {
+            var ids = parseResult.GetValue(idOption) ?? [];
+            var sources = parseResult.GetValue(sourceOption) ?? [];
+            var configPath = parseResult.GetValue(configOption);
+            var workingDir = parseResult.GetValue(workingDirOption);
+            var verbose = parseResult.GetValue(verboseOption);
+
+            return await ExecuteAsync(ids, sources, configPath, workingDir, verbose, ct).ConfigureAwait(false);
+        });
+
+        return command;
+    }
+
+    private static async Task<int> ExecuteAsync(
+        string[] ids,
+        string[] explicitSources,
+        string? configPath,
+        string? workingDir,
+        bool verbose,
+        CancellationToken cancellationToken)
+    {
+        var logger = new NuGetLogger(verbose);
+
+        try
+        {
+            var settings = LoadSettings(configPath, workingDir);
+            var packageSources = LoadPackageSources(settings, explicitSources, verbose);
+
+            // Cache the SourceRepository + FindPackageByIdResource per source to avoid re-resolving
+            // service indexes for every id when many ids are requested in one invocation.
+            var resourcesBySource = new Dictionary<PackageSource, FindPackageByIdResource?>();
+            foreach (var source in packageSources)
+            {
+                try
+                {
+                    var repository = Repository.Factory.GetCoreV3(source);
+                    var resource = await repository.GetResourceAsync<FindPackageByIdResource>(cancellationToken).ConfigureAwait(false);
+                    resourcesBySource[source] = resource;
+                }
+                catch (Exception ex)
+                {
+                    Console.Error.WriteLine($"Warning: Failed to initialize source {source.Name}: {ex.Message}");
+                    resourcesBySource[source] = null;
+                }
+            }
+
+            using var cacheContext = new SourceCacheContext();
+
+            // Resolve every id × source pair in parallel. Each query is a single HTTP GET against
+            // the feed's PackageBaseAddress (flat container) for V3 sources.
+            var results = await Task.WhenAll(ids
+                .Distinct(StringComparer.OrdinalIgnoreCase)
+                .Select(id => ResolveIdAsync(id, resourcesBySource, cacheContext, logger, verbose, cancellationToken)))
+                .ConfigureAwait(false);
+
+            var output = new VersionsResult
+            {
+                Packages = results.OrderBy(p => p.Id, StringComparer.OrdinalIgnoreCase).ToList()
+            };
+
+            Console.WriteLine(JsonSerializer.Serialize(output, VersionsJsonContext.Default.VersionsResult));
+            return 0;
+        }
+        catch (Exception ex)
+        {
+            Console.Error.WriteLine($"Error: {ex.Message}");
+            if (verbose)
+            {
+                Console.Error.WriteLine(ex.StackTrace);
+            }
+
+            return 1;
+        }
+    }
+
+    private static async Task<PackageVersionsInfo> ResolveIdAsync(
+        string id,
+        Dictionary<PackageSource, FindPackageByIdResource?> resourcesBySource,
+        SourceCacheContext cacheContext,
+        INuGetLogger logger,
+        bool verbose,
+        CancellationToken cancellationToken)
+    {
+        // Issue parallel GetAllVersionsAsync calls per source for this id; collapse into one
+        // (latestStable, latestPrerelease, source) tuple. We pick the source that returned the
+        // overall winning version so the caller knows where each package came from.
+        var perSource = await Task.WhenAll(resourcesBySource.Select(async kvp =>
+        {
+            var (source, resource) = kvp;
+            if (resource is null)
+            {
+                return (Source: source, Versions: (IEnumerable<NuGetVersion>)Array.Empty<NuGetVersion>());
+            }
+
+            try
+            {
+                var versions = await resource.GetAllVersionsAsync(id, cacheContext, logger, cancellationToken).ConfigureAwait(false);
+                return (Source: source, Versions: versions ?? Array.Empty<NuGetVersion>());
+            }
+            catch (Exception ex)
+            {
+                if (verbose)
+                {
+                    Console.Error.WriteLine(string.Format(CultureInfo.InvariantCulture, "Warning: Failed to get versions for '{0}' from {1}: {2}", id, source.Name, ex.Message));
+                }
+                return (Source: source, Versions: (IEnumerable<NuGetVersion>)Array.Empty<NuGetVersion>());
+            }
+        })).ConfigureAwait(false);
+
+        NuGetVersion? bestStable = null;
+        PackageSource? bestStableSource = null;
+        NuGetVersion? bestPrerelease = null;
+        PackageSource? bestPrereleaseSource = null;
+
+        foreach (var (source, versions) in perSource)
+        {
+            foreach (var version in versions)
+            {
+                if (version.IsPrerelease)
+                {
+                    if (bestPrerelease is null || version > bestPrerelease)
+                    {
+                        bestPrerelease = version;
+                        bestPrereleaseSource = source;
+                    }
+                }
+                else
+                {
+                    if (bestStable is null || version > bestStable)
+                    {
+                        bestStable = version;
+                        bestStableSource = source;
+                    }
+                }
+            }
+        }
+
+        return new PackageVersionsInfo
+        {
+            Id = id,
+            LatestStableVersion = bestStable?.OriginalVersion ?? bestStable?.ToNormalizedString(),
+            LatestStableSource = bestStableSource?.Source,
+            LatestPrereleaseVersion = bestPrerelease?.OriginalVersion ?? bestPrerelease?.ToNormalizedString(),
+            LatestPrereleaseSource = bestPrereleaseSource?.Source
+        };
+    }
+
+    private static ISettings LoadSettings(string? configPath, string? workingDir)
+    {
+        if (!string.IsNullOrEmpty(configPath) && File.Exists(configPath))
+        {
+            var configDir = Path.GetDirectoryName(configPath)!;
+            var configFile = Path.GetFileName(configPath);
+            return Settings.LoadSpecificSettings(configDir, configFile);
+        }
+
+        var searchDir = workingDir ?? Directory.GetCurrentDirectory();
+        return Settings.LoadDefaultSettings(searchDir);
+    }
+
+    private static List<PackageSource> LoadPackageSources(ISettings settings, string[] explicitSources, bool verbose)
+    {
+        var packageSources = new List<PackageSource>();
+
+        foreach (var source in explicitSources)
+        {
+            packageSources.Add(new PackageSource(source));
+            if (verbose)
+            {
+                Console.Error.WriteLine($"Using explicit source: {source}");
+            }
+        }
+
+        if (packageSources.Count == 0)
+        {
+            var provider = new PackageSourceProvider(settings);
+            foreach (var source in provider.LoadPackageSources())
+            {
+                if (source.IsEnabled)
+                {
+                    packageSources.Add(source);
+                    if (verbose)
+                    {
+                        Console.Error.WriteLine($"Using source from config: {source.Name} ({source.Source})");
+                    }
+                }
+            }
+        }
+
+        if (packageSources.Count == 0)
+        {
+            // Match SearchCommand behavior: fall back to nuget.org if no sources are configured at all.
+            var defaultSource = new PackageSource("https://api.nuget.org/v3/index.json", "nuget.org");
+            packageSources.Add(defaultSource);
+            Console.Error.WriteLine("Note: No package sources configured, using nuget.org as fallback.");
+        }
+
+        return packageSources;
+    }
+}
+
+#region JSON Models
+
+/// <summary>
+/// Result of a versions lookup.
+/// </summary>
+public sealed class VersionsResult
+{
+    /// <summary>Gets or sets the list of resolved package versions.</summary>
+    public List<PackageVersionsInfo> Packages { get; set; } = [];
+}
+
+/// <summary>
+/// Latest known stable + prerelease versions for a single package id.
+/// Either field may be null when no matching version exists on any configured source.
+/// </summary>
+public sealed class PackageVersionsInfo
+{
+    /// <summary>Gets or sets the package id.</summary>
+    public string Id { get; set; } = "";
+    /// <summary>Gets or sets the latest stable version observed across sources.</summary>
+    public string? LatestStableVersion { get; set; }
+    /// <summary>Gets or sets the source URL that returned the latest stable version.</summary>
+    public string? LatestStableSource { get; set; }
+    /// <summary>Gets or sets the latest prerelease version observed across sources.</summary>
+    public string? LatestPrereleaseVersion { get; set; }
+    /// <summary>Gets or sets the source URL that returned the latest prerelease version.</summary>
+    public string? LatestPrereleaseSource { get; set; }
+}
+
+[JsonSerializable(typeof(VersionsResult))]
+[JsonSerializable(typeof(PackageVersionsInfo))]
+[JsonSourceGenerationOptions(
+    PropertyNamingPolicy = JsonKnownNamingPolicy.CamelCase,
+    DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull)]
+internal sealed partial class VersionsJsonContext : JsonSerializerContext
+{
+}
+
+#endregion

--- a/src/Aspire.Managed/Program.cs
+++ b/src/Aspire.Managed/Program.cs
@@ -35,6 +35,7 @@ static async Task<int> RunNuGet(string[] args)
 {
     var rootCommand = new RootCommand("Aspire NuGet Helper - Package operations for Aspire CLI bundle");
     rootCommand.Subcommands.Add(SearchCommand.Create());
+    rootCommand.Subcommands.Add(VersionsCommand.Create());
     rootCommand.Subcommands.Add(RestoreCommand.Create());
     rootCommand.Subcommands.Add(LayoutCommand.Create());
     return await rootCommand.Parse(args).InvokeAsync().ConfigureAwait(false);

--- a/tests/Aspire.Cli.Tests/Packaging/PackagingServiceTests.cs
+++ b/tests/Aspire.Cli.Tests/Packaging/PackagingServiceTests.cs
@@ -1183,5 +1183,8 @@ public class PackagingServiceTests(ITestOutputHelper outputHelper)
 
         public Task<IEnumerable<Aspire.Shared.NuGetPackageCli>> GetPackageVersionsAsync(DirectoryInfo workingDirectory, string exactPackageId, bool prerelease, FileInfo? nugetConfigFile, bool useCache, CancellationToken cancellationToken)
             => GetTemplatePackagesAsync(workingDirectory, prerelease, nugetConfigFile, cancellationToken);
+
+        public Task<IReadOnlyDictionary<string, Aspire.Cli.NuGet.PackageLatestVersions>> GetLatestVersionsAsync(IEnumerable<string> packageIds, DirectoryInfo workingDirectory, FileInfo? nugetConfigFile, CancellationToken cancellationToken)
+            => Task.FromResult<IReadOnlyDictionary<string, Aspire.Cli.NuGet.PackageLatestVersions>>(new Dictionary<string, Aspire.Cli.NuGet.PackageLatestVersions>(StringComparer.OrdinalIgnoreCase));
     }
 }

--- a/tests/Aspire.Cli.Tests/TestServices/CallbackNuGetPackageCache.cs
+++ b/tests/Aspire.Cli.Tests/TestServices/CallbackNuGetPackageCache.cs
@@ -25,4 +25,7 @@ internal sealed class CallbackNuGetPackageCache(
 
     public Task<IEnumerable<NuGetPackage>> GetPackageVersionsAsync(DirectoryInfo workingDirectory, string exactPackageId, bool prerelease, FileInfo? nugetConfigFile, bool useCache, CancellationToken cancellationToken)
         => Task.FromResult<IEnumerable<NuGetPackage>>([]);
+
+    public Task<IReadOnlyDictionary<string, PackageLatestVersions>> GetLatestVersionsAsync(IEnumerable<string> packageIds, DirectoryInfo workingDirectory, FileInfo? nugetConfigFile, CancellationToken cancellationToken)
+        => Task.FromResult<IReadOnlyDictionary<string, PackageLatestVersions>>(new Dictionary<string, PackageLatestVersions>(StringComparer.OrdinalIgnoreCase));
 }

--- a/tests/Aspire.Cli.Tests/TestServices/FakeNuGetPackageCache.cs
+++ b/tests/Aspire.Cli.Tests/TestServices/FakeNuGetPackageCache.cs
@@ -34,4 +34,10 @@ internal sealed class FakeNuGetPackageCache : INuGetPackageCache
     public Task<IEnumerable<NuGetPackage>> GetPackageVersionsAsync(DirectoryInfo workingDirectory, string exactPackageId, bool prerelease, FileInfo? nugetConfigFile, bool useCache, CancellationToken cancellationToken)
         => GetPackageVersionsAsyncCallback?.Invoke(workingDirectory, exactPackageId, prerelease, nugetConfigFile, useCache, cancellationToken)
            ?? Task.FromResult<IEnumerable<NuGetPackage>>([]);
+
+    public Func<IEnumerable<string>, DirectoryInfo, FileInfo?, CancellationToken, Task<IReadOnlyDictionary<string, PackageLatestVersions>>>? GetLatestVersionsAsyncCallback { get; set; }
+
+    public Task<IReadOnlyDictionary<string, PackageLatestVersions>> GetLatestVersionsAsync(IEnumerable<string> packageIds, DirectoryInfo workingDirectory, FileInfo? nugetConfigFile, CancellationToken cancellationToken)
+        => GetLatestVersionsAsyncCallback?.Invoke(packageIds, workingDirectory, nugetConfigFile, cancellationToken)
+           ?? Task.FromResult<IReadOnlyDictionary<string, PackageLatestVersions>>(new Dictionary<string, PackageLatestVersions>(StringComparer.OrdinalIgnoreCase));
 }


### PR DESCRIPTION
## Description

`aspire update` was slow (often multi-minute on AzDO/V3 feeds) because it issued one `dotnet package search` (or `aspire-managed nuget search`) call **per Aspire package per quality**, serialized through the AnalyzeSteps queue. With even a moderately-sized AppHost graph this becomes N × 2 subprocesses, each of which pays full feed-handshake + auth cost.

This PR replaces that pattern with a deterministic per-id batch lookup:

- New `aspire-managed nuget versions --id <pkg> ...` subcommand calls `FindPackageByIdResource.GetAllVersionsAsync` per (id × source) in parallel and emits a single JSON document with the latest stable + prerelease per id. This is the same canonical API NuGet restore uses, so we don't depend on feed search relevance heuristics.
- `INuGetPackageCache.GetLatestVersionsAsync` is added with two implementations:
  - `BundleNuGetPackageCache` (the default for the published native-AOT CLI) → one `aspire-managed nuget versions` subprocess for **all** ids.
  - `NuGetPackageCache` (the SDK transport used when the bundle isn't available) → parallel per-id calls with a small concurrency cap so non-bundle users also see a speedup without depending on new SDK features.
- `PackageChannel.GetLatestVersionsAsync` honours `PinnedVersion` (returns synthetic packages without hitting any feed) and creates one `TemporaryNuGetConfig` for explicit channels.
- `ProjectUpdater.GetUpdateStepsAsync` now walks the project graph once up front to collect every distinct `Aspire.*` package id (plus `Aspire.AppHost.Sdk`), then prefetches them in **one** batched call and pre-populates the existing `LatestPackage-{id}` `MemoryCache`. The existing per-id `GetLatestVersionOfPackageAsync` fallback is preserved, so any id missed by the batch (local hives, V2 sources, transient errors) still resolves correctly. Prefetch failures are logged and swallowed because they're a pure perf optimization.

The `MemoryCache`-backed MSBuild evaluations from the collect-ids pass are reused by the analyze pass, so the only new cost is one batched feed call per channel.

Fixes: #12054

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [x] No — existing `ProjectUpdater` and CLI test suites (2,927 + 3 tests) cover the analyze flow and pass against the new prefetch path; the new managed `versions` subcommand is exercised end-to-end by the bundle path. Happy to add dedicated unit tests for `VersionsCommand` JSON shape if reviewers want them.
- Did you add public API?
  - [ ] Yes
  - [x] No (internal CLI surface only).
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
  - [x] No (uses the same NuGet sources, credential providers, and `NuGet.config` resolution as the existing search path).