### PR TITLE
Use arguments for built-in resource commands

### DIFF
--- a/src/Aspire.Cli/Commands/ResourceCommand.cs
+++ b/src/Aspire.Cli/Commands/ResourceCommand.cs
@@ -51,13 +51,16 @@ internal sealed class ResourceCommand : BaseCommand
 
     /// <summary>
     /// Well-known commands with their display metadata.
-    /// The command name is used directly (no mapping needed since the user-facing names match the actual command names).
+    /// The command names are passed through unchanged; entries only customize progress, success, and error text.
     /// </summary>
     private static readonly Dictionary<string, (string ProgressVerb, string BaseVerb, string PastTenseVerb)> s_wellKnownCommands = new(StringComparers.CommandName)
     {
         ["start"] = ("Starting", "start", "started"),
         ["stop"] = ("Stopping", "stop", "stopped"),
         ["restart"] = ("Restarting", "restart", "restarted"),
+        ["rebuild"] = ("Rebuilding", "rebuild", "rebuilt"),
+        ["set-parameter"] = ("Setting parameter for", "set parameter for", "set"),
+        ["delete-parameter"] = ("Deleting parameter for", "delete parameter for", "deleted"),
     };
 
     public ResourceCommand(
@@ -131,7 +134,7 @@ internal sealed class ResourceCommand : BaseCommand
 
         var commandArguments = commandArgumentsResult.Arguments;
 
-        // Map well-known friendly names (start/stop/restart) to their display metadata
+        // Use display metadata for well-known command names.
         if (s_wellKnownCommands.TryGetValue(commandName, out var knownCommand))
         {
             return CommandResult.FromExitCode(await ResourceCommandHelper.ExecuteResourceCommandAsync(

--- a/src/Aspire.Cli/Commands/ResourceCommand.cs
+++ b/src/Aspire.Cli/Commands/ResourceCommand.cs
@@ -366,6 +366,17 @@ internal sealed class ResourceCommand : BaseCommand
             });
         }
 
+        if (argument.Disabled)
+        {
+            option.Validators.Add(result =>
+            {
+                if (result is { Implicit: false })
+                {
+                    result.AddError($"Option '--{optionName}' is disabled.");
+                }
+            });
+        }
+
         var exactName = $"--{argument.Name}";
         if (!string.Equals(exactName, $"--{optionName}", StringComparison.Ordinal))
         {

--- a/src/Aspire.Cli/Commands/ResourceCommand.cs
+++ b/src/Aspire.Cli/Commands/ResourceCommand.cs
@@ -61,6 +61,14 @@ internal sealed class ResourceCommand : BaseCommand
         ["rebuild"] = ("Rebuilding", "rebuild", "rebuilt"),
         ["set-parameter"] = ("Setting parameter for", "set parameter for", "set"),
         ["delete-parameter"] = ("Deleting parameter for", "delete parameter for", "deleted"),
+        ["parameter-set"] = ("Setting parameter for", "set parameter for", "set"),
+        ["parameter-delete"] = ("Deleting parameter for", "delete parameter for", "deleted"),
+    };
+
+    private static readonly Dictionary<string, string> s_legacyCommandNameMap = new(StringComparers.CommandName)
+    {
+        ["parameter-set"] = "set-parameter",
+        ["parameter-delete"] = "delete-parameter",
     };
 
     public ResourceCommand(
@@ -164,10 +172,11 @@ internal sealed class ResourceCommand : BaseCommand
     {
         var snapshots = await connection.GetResourceSnapshotsAsync(includeHidden, cancellationToken).ConfigureAwait(false);
         var resources = ResourceSnapshotMapper.ResolveResources(resourceName, snapshots);
+        var lookupCommandName = s_legacyCommandNameMap.GetValueOrDefault(commandName, commandName);
 
         return resources
             .SelectMany(static resource => resource.Commands)
-            .FirstOrDefault(command => string.Equals(command.Name, commandName, StringComparisons.CommandName));
+            .FirstOrDefault(command => string.Equals(command.Name, lookupCommandName, StringComparisons.CommandName));
     }
 
     private static async Task<(string Name, string Description)[]> GetAvailableCommandMetadataAsync(IAppHostAuxiliaryBackchannel connection, string resourceName, bool includeHidden, CancellationToken cancellationToken)

--- a/src/Aspire.Dashboard/Model/ResourceViewModel.cs
+++ b/src/Aspire.Dashboard/Model/ResourceViewModel.cs
@@ -229,8 +229,10 @@ public sealed class CommandViewModel
     public const string StartCommand = "start";
     public const string StopCommand = "stop";
     public const string RestartCommand = "restart";
-    public const string SetParameterCommand = "parameter-set";
-    private static readonly string[] s_knownResourceCommands = [StartCommand, StopCommand, RestartCommand];
+    public const string RebuildCommand = "rebuild";
+    public const string SetParameterCommand = "set-parameter";
+    public const string DeleteParameterCommand = "delete-parameter";
+    private static readonly string[] s_knownResourceCommands = [StartCommand, StopCommand, RestartCommand, RebuildCommand, SetParameterCommand, DeleteParameterCommand];
 
     public string Name { get; }
     public CommandViewModelState State { get; }

--- a/src/Aspire.Hosting.Browsers/BrowserLogsBuilderExtensions.cs
+++ b/src/Aspire.Hosting.Browsers/BrowserLogsBuilderExtensions.cs
@@ -215,7 +215,7 @@ public static class BrowserLogsBuilderExtensions
                     Description = BrowserCommandStrings.ConfigureTrackedBrowserDescription,
                     IconName = "Settings",
                     IconVariant = IconVariant.Regular,
-                    Arguments = BrowserLogsConfigurationManager.CreateArgumentDefinitions(parentResource.Name),
+                    Arguments = BrowserLogsConfigurationManager.CreateArgumentDefinitions(browserLogsResource),
                     ValidateArguments = context =>
                     {
                         var configurationManager = context.Services.GetRequiredService<BrowserLogsConfigurationManager>();

--- a/src/Aspire.Hosting.Browsers/BrowserLogsBuilderExtensions.cs
+++ b/src/Aspire.Hosting.Browsers/BrowserLogsBuilderExtensions.cs
@@ -203,7 +203,7 @@ public static class BrowserLogsBuilderExtensions
                     try
                     {
                         var configurationManager = context.ServiceProvider.GetRequiredService<BrowserLogsConfigurationManager>();
-                        return await configurationManager.ConfigureAsync(browserLogsResource, context.CancellationToken).ConfigureAwait(false);
+                        return await configurationManager.ConfigureAsync(browserLogsResource, context.Arguments, context.CancellationToken).ConfigureAwait(false);
                     }
                     catch (Exception ex)
                     {
@@ -215,6 +215,12 @@ public static class BrowserLogsBuilderExtensions
                     Description = BrowserCommandStrings.ConfigureTrackedBrowserDescription,
                     IconName = "Settings",
                     IconVariant = IconVariant.Regular,
+                    Arguments = BrowserLogsConfigurationManager.CreateArgumentDefinitions(parentResource.Name),
+                    ValidateArguments = context =>
+                    {
+                        var configurationManager = context.Services.GetRequiredService<BrowserLogsConfigurationManager>();
+                        return configurationManager.ValidateInputsAsync(browserLogsResource, context);
+                    },
                     UpdateState = context =>
                     {
                         var interactionService = context.ServiceProvider.GetRequiredService<IInteractionService>();

--- a/src/Aspire.Hosting.Browsers/BrowserLogsBuilderExtensions.cs
+++ b/src/Aspire.Hosting.Browsers/BrowserLogsBuilderExtensions.cs
@@ -215,7 +215,7 @@ public static class BrowserLogsBuilderExtensions
                     Description = BrowserCommandStrings.ConfigureTrackedBrowserDescription,
                     IconName = "Settings",
                     IconVariant = IconVariant.Regular,
-                    Arguments = BrowserLogsConfigurationManager.CreateArgumentDefinitions(browserLogsResource),
+                    Arguments = BrowserLogsConfigurationManager.CreateArgumentDefinitions(browserLogsResource, builder.ApplicationBuilder.UserSecretsManager.IsAvailable),
                     ValidateArguments = context =>
                     {
                         var configurationManager = context.Services.GetRequiredService<BrowserLogsConfigurationManager>();

--- a/src/Aspire.Hosting.Browsers/BrowserLogsConfigurationManager.cs
+++ b/src/Aspire.Hosting.Browsers/BrowserLogsConfigurationManager.cs
@@ -35,8 +35,9 @@ internal sealed class BrowserLogsConfigurationManager(
     /// Creates the static argument definitions for the configure-tracked-browser command.
     /// Called at command registration time (before services are available).
     /// </summary>
-    internal static IReadOnlyList<InteractionInput> CreateArgumentDefinitions(string parentResourceName)
+    internal static IReadOnlyList<InteractionInput> CreateArgumentDefinitions(BrowserLogsResource resource)
     {
+        var parentResourceName = resource.ParentResource.Name;
         var scopeInput = new InteractionInput
         {
             Name = ScopeInputName,
@@ -65,7 +66,8 @@ internal sealed class BrowserLogsConfigurationManager(
                 AlwaysLoadOnStart = true,
                 LoadCallback = context =>
                 {
-                    LoadBrowserOptions(context);
+                    var configurationManager = context.Services.GetRequiredService<BrowserLogsConfigurationManager>();
+                    configurationManager.LoadBrowserOptions(resource, context);
                     return Task.CompletedTask;
                 }
             }
@@ -77,12 +79,21 @@ internal sealed class BrowserLogsConfigurationManager(
             Label = BrowserCommandStrings.ConfigureTrackedBrowserUserDataModeLabel,
             InputType = InputType.Choice,
             Required = true,
-            Value = BrowserUserDataMode.Shared.ToString(),
             Options =
             [
                 new(nameof(BrowserUserDataMode.Shared), nameof(BrowserUserDataMode.Shared)),
                 new(nameof(BrowserUserDataMode.Isolated), nameof(BrowserUserDataMode.Isolated))
-            ]
+            ],
+            DynamicLoading = new InputLoadOptions
+            {
+                AlwaysLoadOnStart = true,
+                LoadCallback = context =>
+                {
+                    var configurationManager = context.Services.GetRequiredService<BrowserLogsConfigurationManager>();
+                    configurationManager.LoadUserDataModeOptions(resource, context);
+                    return Task.CompletedTask;
+                }
+            }
         };
 
         var profileInput = new InteractionInput
@@ -93,15 +104,14 @@ internal sealed class BrowserLogsConfigurationManager(
             InputType = InputType.Choice,
             Required = false,
             AllowCustomChoice = true,
-            Value = BrowserDefaultProfileValue,
             DynamicLoading = new InputLoadOptions
             {
                 AlwaysLoadOnStart = true,
                 DependsOnInputs = [BrowserInputName, UserDataModeInputName],
                 LoadCallback = context =>
                 {
-                    var mgr = context.Services.GetRequiredService<BrowserLogsConfigurationManager>();
-                    mgr.LoadProfileOptions(context);
+                    var configurationManager = context.Services.GetRequiredService<BrowserLogsConfigurationManager>();
+                    configurationManager.LoadProfileOptions(resource, context);
                     return Task.CompletedTask;
                 }
             }
@@ -121,8 +131,8 @@ internal sealed class BrowserLogsConfigurationManager(
                 AlwaysLoadOnStart = true,
                 LoadCallback = context =>
                 {
-                    var mgr = context.Services.GetRequiredService<BrowserLogsConfigurationManager>();
-                    mgr.LoadSaveToUserSecretsOptions(context);
+                    var configurationManager = context.Services.GetRequiredService<BrowserLogsConfigurationManager>();
+                    configurationManager.LoadSaveToUserSecretsOptions(context);
                     return Task.CompletedTask;
                 }
             }
@@ -161,31 +171,26 @@ internal sealed class BrowserLogsConfigurationManager(
         };
     }
 
-    private static void LoadBrowserOptions(LoadInputContext context)
+    private void LoadBrowserOptions(BrowserLogsResource resource, LoadInputContext context)
     {
-        var options = GetBrowserOptions(context.Input.Value ?? string.Empty);
-        context.Input.Options = options;
-    }
+        if (context.Input.Value is null)
+        {
+            var currentConfiguration = resource.ResolveCurrentConfiguration(configuration, configurationStore);
+            context.Input.Value = currentConfiguration.Browser;
+        }
 
-    private void LoadSaveToUserSecretsOptions(LoadInputContext context)
-    {
-        context.Input.Value ??= userSecretsManager.IsAvailable ? "true" : null;
-        context.Input.Disabled = !userSecretsManager.IsAvailable;
-    }
-
-    private static IReadOnlyList<KeyValuePair<string, string>> GetBrowserOptions(string currentBrowser)
-    {
+        var currentBrowser = context.Input.Value;
         var options = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
         AddKnownBrowser("msedge", BrowserCommandStrings.ConfigureTrackedBrowserEdgeOption);
         AddKnownBrowser("chrome", BrowserCommandStrings.ConfigureTrackedBrowserChromeOption);
         AddKnownBrowser("chromium", BrowserCommandStrings.ConfigureTrackedBrowserChromiumOption);
 
-        if (!options.ContainsKey(currentBrowser))
+        if (!string.IsNullOrEmpty(currentBrowser) && !options.ContainsKey(currentBrowser))
         {
             options[currentBrowser] = currentBrowser;
         }
 
-        return [.. options.Select(static pair => new KeyValuePair<string, string>(pair.Key, pair.Value))];
+        context.Input.Options = [.. options.Select(static pair => new KeyValuePair<string, string>(pair.Key, pair.Value))];
 
         void AddKnownBrowser(string browser, string displayName)
         {
@@ -196,8 +201,29 @@ internal sealed class BrowserLogsConfigurationManager(
         }
     }
 
-    private void LoadProfileOptions(LoadInputContext context)
+    private void LoadUserDataModeOptions(BrowserLogsResource resource, LoadInputContext context)
     {
+        if (context.Input.Value is null)
+        {
+            var currentConfiguration = resource.ResolveCurrentConfiguration(configuration, configurationStore);
+            context.Input.Value = currentConfiguration.UserDataMode.ToString();
+        }
+    }
+
+    private void LoadSaveToUserSecretsOptions(LoadInputContext context)
+    {
+        context.Input.Value ??= userSecretsManager.IsAvailable ? "true" : null;
+        context.Input.Disabled = !userSecretsManager.IsAvailable;
+    }
+
+    private void LoadProfileOptions(BrowserLogsResource resource, LoadInputContext context)
+    {
+        if (context.Input.Value is null)
+        {
+            var currentConfiguration = resource.ResolveCurrentConfiguration(configuration, configurationStore);
+            context.Input.Value = currentConfiguration.Profile ?? BrowserDefaultProfileValue;
+        }
+
         var browser = context.AllInputs[BrowserInputName].Value;
         var profile = context.Input.Value;
 

--- a/src/Aspire.Hosting.Browsers/BrowserLogsConfigurationManager.cs
+++ b/src/Aspire.Hosting.Browsers/BrowserLogsConfigurationManager.cs
@@ -9,58 +9,133 @@ using System.Globalization;
 using Aspire.Hosting.Browsers.Resources;
 using Aspire.Hosting.ApplicationModel;
 using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 
 namespace Aspire.Hosting;
 
 internal sealed class BrowserLogsConfigurationManager(
     IConfiguration configuration,
-    IInteractionService interactionService,
     IUserSecretsManager userSecretsManager,
     DistributedApplicationModel applicationModel,
     BrowserLogsConfigurationStore configurationStore,
     ResourceNotificationService resourceNotificationService,
     ILogger<BrowserLogsConfigurationManager> logger)
 {
-    private const string ScopeInputName = "scope";
-    private const string BrowserInputName = "browser";
-    private const string UserDataModeInputName = "userDataMode";
-    private const string ProfileInputName = "profile";
-    private const string SaveToUserSecretsInputName = "saveToUserSecrets";
-    private const string ResourceScopeValue = "resource";
-    private const string GlobalScopeValue = "global";
-    private const string BrowserDefaultProfileValue = "__aspire_browser_default__";
+    internal const string ScopeInputName = "scope";
+    internal const string BrowserInputName = "browser";
+    internal const string UserDataModeInputName = "userDataMode";
+    internal const string ProfileInputName = "profile";
+    internal const string SaveToUserSecretsInputName = "saveToUserSecrets";
+    internal const string ResourceScopeValue = "resource";
+    internal const string GlobalScopeValue = "global";
+    internal const string BrowserDefaultProfileValue = "__aspire_browser_default__";
 
-    public async Task<ExecuteCommandResult> ConfigureAsync(BrowserLogsResource resource, CancellationToken cancellationToken)
+    /// <summary>
+    /// Creates the static argument definitions for the configure-tracked-browser command.
+    /// Called at command registration time (before services are available).
+    /// </summary>
+    internal static IReadOnlyList<InteractionInput> CreateArgumentDefinitions(string parentResourceName)
+    {
+        var scopeInput = new InteractionInput
+        {
+            Name = ScopeInputName,
+            Label = BrowserCommandStrings.ConfigureTrackedBrowserScopeLabel,
+            InputType = InputType.Choice,
+            Required = true,
+            Value = ResourceScopeValue,
+            Options =
+            [
+                new(ResourceScopeValue, string.Format(CultureInfo.CurrentCulture, BrowserCommandStrings.ConfigureTrackedBrowserResourceScopeOption, parentResourceName)),
+                new(GlobalScopeValue, BrowserCommandStrings.ConfigureTrackedBrowserGlobalScopeOption)
+            ]
+        };
+
+        var browserInput = new InteractionInput
+        {
+            Name = BrowserInputName,
+            Label = BrowserCommandStrings.ConfigureTrackedBrowserBrowserLabel,
+            Description = BrowserCommandStrings.ConfigureTrackedBrowserBrowserDescription,
+            InputType = InputType.Choice,
+            Required = true,
+            AllowCustomChoice = true,
+            // DynamicLoading populates the current browser value and the list of available browsers at prompt time.
+            DynamicLoading = new InputLoadOptions
+            {
+                AlwaysLoadOnStart = true,
+                LoadCallback = context =>
+                {
+                    LoadBrowserOptions(context);
+                    return Task.CompletedTask;
+                }
+            }
+        };
+
+        var userDataModeInput = new InteractionInput
+        {
+            Name = UserDataModeInputName,
+            Label = BrowserCommandStrings.ConfigureTrackedBrowserUserDataModeLabel,
+            InputType = InputType.Choice,
+            Required = true,
+            Value = BrowserUserDataMode.Shared.ToString(),
+            Options =
+            [
+                new(nameof(BrowserUserDataMode.Shared), nameof(BrowserUserDataMode.Shared)),
+                new(nameof(BrowserUserDataMode.Isolated), nameof(BrowserUserDataMode.Isolated))
+            ]
+        };
+
+        var profileInput = new InteractionInput
+        {
+            Name = ProfileInputName,
+            Label = BrowserCommandStrings.ConfigureTrackedBrowserProfileLabel,
+            Description = BrowserCommandStrings.ConfigureTrackedBrowserProfileDescription,
+            InputType = InputType.Choice,
+            Required = false,
+            AllowCustomChoice = true,
+            Value = BrowserDefaultProfileValue,
+            DynamicLoading = new InputLoadOptions
+            {
+                AlwaysLoadOnStart = true,
+                DependsOnInputs = [BrowserInputName, UserDataModeInputName],
+                LoadCallback = context =>
+                {
+                    var mgr = context.Services.GetRequiredService<BrowserLogsConfigurationManager>();
+                    mgr.LoadProfileOptions(context);
+                    return Task.CompletedTask;
+                }
+            }
+        };
+
+        var saveInput = new InteractionInput
+        {
+            Name = SaveToUserSecretsInputName,
+            Label = BrowserCommandStrings.ConfigureTrackedBrowserSaveToUserSecretsLabel,
+            Description = BrowserCommandStrings.ConfigureTrackedBrowserSaveToUserSecretsDescriptionConfigured,
+            EnableDescriptionMarkdown = true,
+            InputType = InputType.Boolean,
+            // Dynamic loading populates the default value and disabled state based on
+            // whether user secrets are available at prompt time.
+            DynamicLoading = new InputLoadOptions
+            {
+                AlwaysLoadOnStart = true,
+                LoadCallback = context =>
+                {
+                    var mgr = context.Services.GetRequiredService<BrowserLogsConfigurationManager>();
+                    mgr.LoadSaveToUserSecretsOptions(context);
+                    return Task.CompletedTask;
+                }
+            }
+        };
+
+        return [scopeInput, browserInput, userDataModeInput, profileInput, saveInput];
+    }
+
+    public async Task<ExecuteCommandResult> ConfigureAsync(BrowserLogsResource resource, InteractionInputCollection arguments, CancellationToken _)
     {
         ArgumentNullException.ThrowIfNull(resource);
 
-        if (!interactionService.IsAvailable)
-        {
-            return CommandResults.Failure(BrowserCommandStrings.ConfigureTrackedBrowserInteractionUnavailable);
-        }
-
-        var currentConfiguration = resource.ResolveCurrentConfiguration(configuration, configurationStore);
-        var inputs = CreateInputs(resource, currentConfiguration);
-        var result = await interactionService.PromptInputsAsync(
-            BrowserCommandStrings.ConfigureTrackedBrowserName,
-            BrowserCommandStrings.ConfigureTrackedBrowserPromptMessage,
-            inputs,
-            new InputsDialogInteractionOptions
-            {
-                PrimaryButtonText = BrowserCommandStrings.ConfigureTrackedBrowserSaveButton,
-                ShowDismiss = true,
-                EnableMessageMarkdown = true,
-                ValidationCallback = context => ValidateInputsAsync(resource, context)
-            },
-            cancellationToken).ConfigureAwait(false);
-
-        if (result.Canceled)
-        {
-            return CommandResults.Canceled();
-        }
-
-        var selected = BrowserLogsConfigurationSelection.FromInputs(result.Data);
+        var selected = BrowserLogsConfigurationSelection.FromInputs(arguments);
         var resolvedConfigurations = ResolveEffectiveConfigurations(resource, selected);
         Apply(resource, selected);
 
@@ -86,88 +161,16 @@ internal sealed class BrowserLogsConfigurationManager(
         };
     }
 
-    private List<InteractionInput> CreateInputs(BrowserLogsResource resource, BrowserConfiguration currentConfiguration)
+    private static void LoadBrowserOptions(LoadInputContext context)
     {
-        var scopeInput = new InteractionInput
-        {
-            Name = ScopeInputName,
-            Label = BrowserCommandStrings.ConfigureTrackedBrowserScopeLabel,
-            InputType = InputType.Choice,
-            Required = true,
-            Value = ResourceScopeValue,
-            Options =
-            [
-                new(ResourceScopeValue, string.Format(CultureInfo.CurrentCulture, BrowserCommandStrings.ConfigureTrackedBrowserResourceScopeOption, resource.ParentResource.Name)),
-                new(GlobalScopeValue, BrowserCommandStrings.ConfigureTrackedBrowserGlobalScopeOption)
-            ]
-        };
-
-        var browserInput = new InteractionInput
-        {
-            Name = BrowserInputName,
-            Label = BrowserCommandStrings.ConfigureTrackedBrowserBrowserLabel,
-            Description = BrowserCommandStrings.ConfigureTrackedBrowserBrowserDescription,
-            InputType = InputType.Choice,
-            Required = true,
-            AllowCustomChoice = true,
-            Value = currentConfiguration.Browser,
-            Options = GetBrowserOptions(currentConfiguration.Browser)
-        };
-
-        var userDataModeInput = new InteractionInput
-        {
-            Name = UserDataModeInputName,
-            Label = BrowserCommandStrings.ConfigureTrackedBrowserUserDataModeLabel,
-            InputType = InputType.Choice,
-            Required = true,
-            Value = currentConfiguration.UserDataMode.ToString(),
-            Options =
-            [
-                new(nameof(BrowserUserDataMode.Shared), nameof(BrowserUserDataMode.Shared)),
-                new(nameof(BrowserUserDataMode.Isolated), nameof(BrowserUserDataMode.Isolated))
-            ]
-        };
-
-        var profileInput = new InteractionInput
-        {
-            Name = ProfileInputName,
-            Label = BrowserCommandStrings.ConfigureTrackedBrowserProfileLabel,
-            Description = BrowserCommandStrings.ConfigureTrackedBrowserProfileDescription,
-            InputType = InputType.Choice,
-            Required = false,
-            AllowCustomChoice = true,
-            Value = currentConfiguration.Profile ?? BrowserDefaultProfileValue,
-            DynamicLoading = new InputLoadOptions
-            {
-                AlwaysLoadOnStart = true,
-                DependsOnInputs = [BrowserInputName, UserDataModeInputName],
-                LoadCallback = context =>
-                {
-                    LoadProfileOptions(context);
-                    return Task.CompletedTask;
-                }
-            }
-        };
-
-        var saveInput = CreateSaveToUserSecretsInput();
-
-        return [scopeInput, browserInput, userDataModeInput, profileInput, saveInput];
+        var options = GetBrowserOptions(context.Input.Value ?? string.Empty);
+        context.Input.Options = options;
     }
 
-    private InteractionInput CreateSaveToUserSecretsInput()
+    private void LoadSaveToUserSecretsOptions(LoadInputContext context)
     {
-        return new InteractionInput
-        {
-            Name = SaveToUserSecretsInputName,
-            Label = BrowserCommandStrings.ConfigureTrackedBrowserSaveToUserSecretsLabel,
-            InputType = InputType.Boolean,
-            Value = userSecretsManager.IsAvailable ? "true" : null,
-            Description = userSecretsManager.IsAvailable
-                ? BrowserCommandStrings.ConfigureTrackedBrowserSaveToUserSecretsDescriptionConfigured
-                : BrowserCommandStrings.ConfigureTrackedBrowserSaveToUserSecretsDescriptionNotConfigured,
-            EnableDescriptionMarkdown = true,
-            Disabled = !userSecretsManager.IsAvailable
-        };
+        context.Input.Value ??= userSecretsManager.IsAvailable ? "true" : null;
+        context.Input.Disabled = !userSecretsManager.IsAvailable;
     }
 
     private static IReadOnlyList<KeyValuePair<string, string>> GetBrowserOptions(string currentBrowser)
@@ -261,7 +264,7 @@ internal sealed class BrowserLogsConfigurationManager(
         return profile.DirectoryName;
     }
 
-    private Task ValidateInputsAsync(BrowserLogsResource resource, InputsDialogValidationContext context)
+    internal Task ValidateInputsAsync(BrowserLogsResource resource, InputsDialogValidationContext context)
     {
         var inputs = context.Inputs;
         var browser = inputs[BrowserInputName];

--- a/src/Aspire.Hosting.Browsers/BrowserLogsConfigurationManager.cs
+++ b/src/Aspire.Hosting.Browsers/BrowserLogsConfigurationManager.cs
@@ -196,13 +196,14 @@ internal sealed class BrowserLogsConfigurationManager(
 
     private void LoadProfileOptions(BrowserLogsResource resource, LoadInputContext context)
     {
+        var currentConfiguration = resource.ResolveCurrentConfiguration(configuration, configurationStore);
         if (context.Input.Value is null)
         {
-            var currentConfiguration = resource.ResolveCurrentConfiguration(configuration, configurationStore);
             context.Input.Value = currentConfiguration.Profile ?? BrowserDefaultProfileValue;
         }
 
-        var browser = context.AllInputs[BrowserInputName].Value;
+        var browser = context.AllInputs[BrowserInputName].Value ?? currentConfiguration.Browser;
+        var userDataModeValue = context.AllInputs[UserDataModeInputName].Value ?? currentConfiguration.UserDataMode.ToString();
         var profile = context.Input.Value;
 
         var options = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
@@ -211,7 +212,7 @@ internal sealed class BrowserLogsConfigurationManager(
         };
 
         var disableProfileInput = true;
-        if (Enum.TryParse<BrowserUserDataMode>(context.AllInputs[UserDataModeInputName].Value, ignoreCase: true, out var userDataMode) &&
+        if (Enum.TryParse<BrowserUserDataMode>(userDataModeValue, ignoreCase: true, out var userDataMode) &&
             userDataMode == BrowserUserDataMode.Shared &&
             !string.IsNullOrWhiteSpace(browser))
         {

--- a/src/Aspire.Hosting.Browsers/BrowserLogsConfigurationManager.cs
+++ b/src/Aspire.Hosting.Browsers/BrowserLogsConfigurationManager.cs
@@ -35,7 +35,7 @@ internal sealed class BrowserLogsConfigurationManager(
     /// Creates the static argument definitions for the configure-tracked-browser command.
     /// Called at command registration time (before services are available).
     /// </summary>
-    internal static IReadOnlyList<InteractionInput> CreateArgumentDefinitions(BrowserLogsResource resource)
+    internal static IReadOnlyList<InteractionInput> CreateArgumentDefinitions(BrowserLogsResource resource, bool userSecretsAvailable)
     {
         var parentResourceName = resource.ParentResource.Name;
         var scopeInput = new InteractionInput
@@ -121,21 +121,13 @@ internal sealed class BrowserLogsConfigurationManager(
         {
             Name = SaveToUserSecretsInputName,
             Label = BrowserCommandStrings.ConfigureTrackedBrowserSaveToUserSecretsLabel,
-            Description = BrowserCommandStrings.ConfigureTrackedBrowserSaveToUserSecretsDescriptionConfigured,
+            Description = userSecretsAvailable
+                ? BrowserCommandStrings.ConfigureTrackedBrowserSaveToUserSecretsDescriptionConfigured
+                : BrowserCommandStrings.ConfigureTrackedBrowserSaveToUserSecretsDescriptionNotConfigured,
             EnableDescriptionMarkdown = true,
             InputType = InputType.Boolean,
-            // Dynamic loading populates the default value and disabled state based on
-            // whether user secrets are available at prompt time.
-            DynamicLoading = new InputLoadOptions
-            {
-                AlwaysLoadOnStart = true,
-                LoadCallback = context =>
-                {
-                    var configurationManager = context.Services.GetRequiredService<BrowserLogsConfigurationManager>();
-                    configurationManager.LoadSaveToUserSecretsOptions(context);
-                    return Task.CompletedTask;
-                }
-            }
+            Value = userSecretsAvailable ? "true" : null,
+            Disabled = !userSecretsAvailable
         };
 
         return [scopeInput, browserInput, userDataModeInput, profileInput, saveInput];
@@ -208,12 +200,6 @@ internal sealed class BrowserLogsConfigurationManager(
             var currentConfiguration = resource.ResolveCurrentConfiguration(configuration, configurationStore);
             context.Input.Value = currentConfiguration.UserDataMode.ToString();
         }
-    }
-
-    private void LoadSaveToUserSecretsOptions(LoadInputContext context)
-    {
-        context.Input.Value ??= userSecretsManager.IsAvailable ? "true" : null;
-        context.Input.Disabled = !userSecretsManager.IsAvailable;
     }
 
     private void LoadProfileOptions(BrowserLogsResource resource, LoadInputContext context)

--- a/src/Aspire.Hosting.Browsers/BrowserLogsConfigurationManager.cs
+++ b/src/Aspire.Hosting.Browsers/BrowserLogsConfigurationManager.cs
@@ -38,6 +38,11 @@ internal sealed class BrowserLogsConfigurationManager(
     internal static IReadOnlyList<InteractionInput> CreateArgumentDefinitions(BrowserLogsResource resource, bool userSecretsAvailable)
     {
         var parentResourceName = resource.ParentResource.Name;
+        var browserOptions = new List<KeyValuePair<string, string>>();
+        AddKnownBrowser("msedge", BrowserCommandStrings.ConfigureTrackedBrowserEdgeOption);
+        AddKnownBrowser("chrome", BrowserCommandStrings.ConfigureTrackedBrowserChromeOption);
+        AddKnownBrowser("chromium", BrowserCommandStrings.ConfigureTrackedBrowserChromiumOption);
+
         var scopeInput = new InteractionInput
         {
             Name = ScopeInputName,
@@ -60,14 +65,14 @@ internal sealed class BrowserLogsConfigurationManager(
             InputType = InputType.Choice,
             Required = true,
             AllowCustomChoice = true,
-            // DynamicLoading populates the current browser value and the list of available browsers at prompt time.
+            Options = browserOptions,
             DynamicLoading = new InputLoadOptions
             {
                 AlwaysLoadOnStart = true,
                 LoadCallback = context =>
                 {
                     var configurationManager = context.Services.GetRequiredService<BrowserLogsConfigurationManager>();
-                    configurationManager.LoadBrowserOptions(resource, context);
+                    configurationManager.LoadBrowserValue(resource, context);
                     return Task.CompletedTask;
                 }
             }
@@ -131,6 +136,14 @@ internal sealed class BrowserLogsConfigurationManager(
         };
 
         return [scopeInput, browserInput, userDataModeInput, profileInput, saveInput];
+
+        void AddKnownBrowser(string browser, string displayName)
+        {
+            if (ChromiumBrowserResolver.TryResolveExecutable(browser) is not null)
+            {
+                browserOptions.Add(new(browser, displayName));
+            }
+        }
     }
 
     public async Task<ExecuteCommandResult> ConfigureAsync(BrowserLogsResource resource, InteractionInputCollection arguments, CancellationToken _)
@@ -163,33 +176,12 @@ internal sealed class BrowserLogsConfigurationManager(
         };
     }
 
-    private void LoadBrowserOptions(BrowserLogsResource resource, LoadInputContext context)
+    private void LoadBrowserValue(BrowserLogsResource resource, LoadInputContext context)
     {
         if (context.Input.Value is null)
         {
             var currentConfiguration = resource.ResolveCurrentConfiguration(configuration, configurationStore);
             context.Input.Value = currentConfiguration.Browser;
-        }
-
-        var currentBrowser = context.Input.Value;
-        var options = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
-        AddKnownBrowser("msedge", BrowserCommandStrings.ConfigureTrackedBrowserEdgeOption);
-        AddKnownBrowser("chrome", BrowserCommandStrings.ConfigureTrackedBrowserChromeOption);
-        AddKnownBrowser("chromium", BrowserCommandStrings.ConfigureTrackedBrowserChromiumOption);
-
-        if (!string.IsNullOrEmpty(currentBrowser) && !options.ContainsKey(currentBrowser))
-        {
-            options[currentBrowser] = currentBrowser;
-        }
-
-        context.Input.Options = [.. options.Select(static pair => new KeyValuePair<string, string>(pair.Key, pair.Value))];
-
-        void AddKnownBrowser(string browser, string displayName)
-        {
-            if (ChromiumBrowserResolver.TryResolveExecutable(browser) is not null)
-            {
-                options[browser] = displayName;
-            }
         }
     }
 

--- a/src/Aspire.Hosting.EntityFrameworkCore/EFResourceBuilderExtensions.cs
+++ b/src/Aspire.Hosting.EntityFrameworkCore/EFResourceBuilderExtensions.cs
@@ -648,6 +648,7 @@ public static class EFResourceBuilderExtensions
                         Name = "name",
                         InputType = InputType.Text,
                         Label = "Migration Name",
+                        Required = true,
                         Placeholder = "e.g. InitialCreate"
                     }
                 ]
@@ -806,13 +807,7 @@ public static class EFResourceBuilderExtensions
             waitForDependencies: false,
             async (executor, logger, interaction) =>
             {
-                // The migration name is provided via the command argument. When not specified
-                // (e.g. non-interactive mode), fall back to a timestamp-based name.
-                var migrationName = context.Arguments.GetString("name");
-                if (string.IsNullOrWhiteSpace(migrationName))
-                {
-                    migrationName = $"Migration_{DateTime.UtcNow:yyyyMMddHHmmss}";
-                }
+                var migrationName = context.Arguments.GetString("name")!;
 
                 var result = await executor.AddMigrationAsync(
                     migrationName,

--- a/src/Aspire.Hosting.EntityFrameworkCore/EFResourceBuilderExtensions.cs
+++ b/src/Aspire.Hosting.EntityFrameworkCore/EFResourceBuilderExtensions.cs
@@ -3,6 +3,7 @@
 
 #pragma warning disable ASPIREPIPELINES001
 #pragma warning disable ASPIREDOTNETTOOL
+#pragma warning disable ASPIREINTERACTION001
 
 using Aspire.Hosting.ApplicationModel;
 using Aspire.Hosting.EntityFrameworkCore;
@@ -639,7 +640,17 @@ public static class EFResourceBuilderExtensions
                 Description = "Create a new migration. Note: The target project will need to be recompiled after adding a migration.",
                 IconName = "Add",
                 IconVariant = IconVariant.Regular,
-                UpdateState = context => GetCommandState(context, migrationResource)
+                UpdateState = context => GetCommandState(context, migrationResource),
+                Arguments =
+                [
+                    new InteractionInput
+                    {
+                        Name = "name",
+                        InputType = InputType.Text,
+                        Label = "Migration Name",
+                        Placeholder = "e.g. InitialCreate"
+                    }
+                ]
             });
 
         migrationBuilder.WithCommand(
@@ -795,27 +806,12 @@ public static class EFResourceBuilderExtensions
             waitForDependencies: false,
             async (executor, logger, interaction) =>
             {
-                string migrationName;
-                if (interaction == null || !interaction.IsAvailable)
+                // The migration name is provided via the command argument. When not specified
+                // (e.g. non-interactive mode), fall back to a timestamp-based name.
+                var migrationName = context.Arguments.GetString("name");
+                if (string.IsNullOrWhiteSpace(migrationName))
                 {
                     migrationName = $"Migration_{DateTime.UtcNow:yyyyMMddHHmmss}";
-                }
-                else
-                {
-                    var inputResult = await interaction.PromptInputAsync(
-                        title: "Add Migration",
-                        message: "Enter the name for the new migration.",
-                        inputLabel: "Migration Name",
-                        placeHolder: "e.g. InitialCreate",
-                        cancellationToken: context.CancellationToken).ConfigureAwait(false);
-
-                    if (inputResult.Canceled || string.IsNullOrWhiteSpace(inputResult.Data?.Value))
-                    {
-                        // Throwing OperationCanceledException lets the wrapper handle state update
-                        throw new OperationCanceledException();
-                    }
-
-                    migrationName = inputResult.Data.Value;
                 }
 
                 var result = await executor.AddMigrationAsync(

--- a/src/Aspire.Hosting.Foundry/PromptAgent/PromptAgentBuilderExtensions.cs
+++ b/src/Aspire.Hosting.Foundry/PromptAgent/PromptAgentBuilderExtensions.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 #pragma warning disable OPENAI001 // Responses API is experimental
+#pragma warning disable ASPIREINTERACTION001
 
 using Aspire.Hosting.ApplicationModel;
 using Aspire.Hosting.Azure;
@@ -9,7 +10,6 @@ using Aspire.Hosting.Foundry;
 using Azure.AI.Extensions.OpenAI;
 using Azure.AI.Projects;
 using Azure.Identity;
-using Microsoft.Extensions.DependencyInjection;
 
 namespace Aspire.Hosting;
 
@@ -77,16 +77,8 @@ public static class PromptAgentBuilderExtensions
             displayName: "Send Message",
             executeCommand: async ctx =>
             {
-                var interactionService = ctx.ServiceProvider.GetRequiredService<IInteractionService>();
-                var inputResult = await interactionService.PromptInputAsync(
-                    title: "Prompt Agent",
-                    message: $"Enter a message to send to '{name}'.",
-                    inputLabel: "Message",
-                    placeHolder: "Hello, what can you do?",
-                    cancellationToken: ctx.CancellationToken
-                ).ConfigureAwait(false);
-
-                if (inputResult.Canceled || string.IsNullOrWhiteSpace(inputResult.Data.Value))
+                var message = ctx.Arguments.GetString("message");
+                if (string.IsNullOrWhiteSpace(message))
                 {
                     return new ExecuteCommandResult { Success = true };
                 }
@@ -102,36 +94,13 @@ public static class PromptAgentBuilderExtensions
                     var projectClient = new AIProjectClient(new Uri(endpoint), new DefaultAzureCredential());
                     var agentRef = new AgentReference(name: name);
                     var responseClient = projectClient.ProjectOpenAIClient.GetProjectResponsesClientForAgent(agentRef);
-                    var response = await responseClient.CreateResponseAsync(inputResult.Data.Value, cancellationToken: ctx.CancellationToken).ConfigureAwait(false);
-                    var outputText = response.Value.GetOutputText();
+                    var response = await responseClient.CreateResponseAsync(message, cancellationToken: ctx.CancellationToken).ConfigureAwait(false);
 
-                    await interactionService.PromptMessageBoxAsync(
-                        title: $"Response from '{name}'",
-                        message: outputText,
-                        options: new()
-                        {
-                            Intent = MessageIntent.Success,
-                            EnableMessageMarkdown = true,
-                            PrimaryButtonText = "OK"
-                        },
-                        cancellationToken: ctx.CancellationToken
-                    ).ConfigureAwait(false);
-
-                    return new ExecuteCommandResult { Success = true };
+                    return CommandResults.Success("Agent response received.", response.Value.GetOutputText(), CommandResultFormat.Markdown, displayImmediately: true);
                 }
                 catch (Exception ex)
                 {
-                    await interactionService.PromptMessageBoxAsync(
-                        title: "Error",
-                        message: $"Failed to invoke agent: {ex.Message}",
-                        options: new()
-                        {
-                            Intent = MessageIntent.Error,
-                            PrimaryButtonText = "OK"
-                        },
-                        cancellationToken: ctx.CancellationToken
-                    ).ConfigureAwait(false);
-                    return new ExecuteCommandResult { Success = false };
+                    return CommandResults.Failure($"Failed to invoke agent: {ex.Message}");
                 }
             },
             commandOptions: new()
@@ -139,6 +108,17 @@ public static class PromptAgentBuilderExtensions
                 IconName = "Agents",
                 IconVariant = IconVariant.Regular,
                 IsHighlighted = true,
+                Arguments =
+                [
+                    new InteractionInput
+                    {
+                        Name = "message",
+                        InputType = InputType.Text,
+                        Label = "Message",
+                        Placeholder = "Hello, what can you do?",
+                        Description = $"Enter a message to send to '{name}'."
+                    }
+                ]
             }
         );
 

--- a/src/Aspire.Hosting.Foundry/PromptAgent/PromptAgentBuilderExtensions.cs
+++ b/src/Aspire.Hosting.Foundry/PromptAgent/PromptAgentBuilderExtensions.cs
@@ -77,11 +77,7 @@ public static class PromptAgentBuilderExtensions
             displayName: "Send Message",
             executeCommand: async ctx =>
             {
-                var message = ctx.Arguments.GetString("message");
-                if (string.IsNullOrWhiteSpace(message))
-                {
-                    return new ExecuteCommandResult { Success = true };
-                }
+                var message = ctx.Arguments.GetString("message")!;
 
                 try
                 {
@@ -115,6 +111,7 @@ public static class PromptAgentBuilderExtensions
                         Name = "message",
                         InputType = InputType.Text,
                         Label = "Message",
+                        Required = true,
                         Placeholder = "Hello, what can you do?",
                         Description = $"Enter a message to send to '{name}'."
                     }

--- a/src/Aspire.Hosting/ApplicationModel/KnownResourceCommands.cs
+++ b/src/Aspire.Hosting/ApplicationModel/KnownResourceCommands.cs
@@ -33,14 +33,16 @@ public static class KnownResourceCommands
     /// <summary>
     /// The command name for setting a parameter value.
     /// </summary>
-    public static readonly string SetParameterCommand = "parameter-set";
+    public static readonly string SetParameterCommand = "set-parameter";
 
     /// <summary>
     /// The command name for deleting a parameter value.
     /// </summary>
-    public static readonly string DeleteParameterCommand = "parameter-delete";
+    public static readonly string DeleteParameterCommand = "delete-parameter";
 
     internal const string LegacyStartCommand = "resource-start";
     internal const string LegacyStopCommand = "resource-stop";
     internal const string LegacyRestartCommand = "resource-restart";
+    internal const string LegacySetParameterCommand = "parameter-set";
+    internal const string LegacyDeleteParameterCommand = "parameter-delete";
 }

--- a/src/Aspire.Hosting/ApplicationModel/ParameterResource.cs
+++ b/src/Aspire.Hosting/ApplicationModel/ParameterResource.cs
@@ -128,7 +128,7 @@ public class ParameterResource : Resource, IExpressionValue
     public bool EnableDescriptionMarkdown { get; set; }
 
 #pragma warning disable ASPIREINTERACTION001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
-    internal InteractionInput CreateInput(string? name = null, bool? required = null)
+    internal InteractionInput CreateInput(string? name = null, bool? required = null, InputLoadOptions? dynamicLoading = null)
     {
         if (this.TryGetLastAnnotation<InputGeneratorAnnotation>(out var annotation))
         {
@@ -143,6 +143,11 @@ public class ParameterResource : Resource, IExpressionValue
                 generatedInput.SetRequired(required.Value);
             }
 
+            if (dynamicLoading is not null)
+            {
+                generatedInput.SetDynamicLoading(dynamicLoading);
+            }
+
             return generatedInput;
         }
 
@@ -154,6 +159,7 @@ public class ParameterResource : Resource, IExpressionValue
             Description = Description,
             EnableDescriptionMarkdown = EnableDescriptionMarkdown,
             Required = required ?? false,
+            DynamicLoading = dynamicLoading,
             Placeholder = string.Format(CultureInfo.CurrentCulture, InteractionStrings.ParametersInputsParameterPlaceholder, Name)
         };
         return input;

--- a/src/Aspire.Hosting/ApplicationModel/ParameterResource.cs
+++ b/src/Aspire.Hosting/ApplicationModel/ParameterResource.cs
@@ -128,17 +128,17 @@ public class ParameterResource : Resource, IExpressionValue
     public bool EnableDescriptionMarkdown { get; set; }
 
 #pragma warning disable ASPIREINTERACTION001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
-    internal InteractionInput CreateInput()
+    internal InteractionInput CreateInput(string? name = null)
     {
         if (this.TryGetLastAnnotation<InputGeneratorAnnotation>(out var annotation))
         {
-            // If the annotation is present, use it to create the input.
-            return annotation.InputGenerator(this);
+            var generatedInput = annotation.InputGenerator(this);
+            return name is null ? generatedInput : RenameInput(generatedInput, name);
         }
 
         var input = new InteractionInput
         {
-            Name = Name,
+            Name = name ?? Name,
             InputType = Secret ? InputType.SecretText : InputType.Text,
             Label = Name,
             Description = Description,
@@ -146,6 +146,31 @@ public class ParameterResource : Resource, IExpressionValue
             Placeholder = string.Format(CultureInfo.CurrentCulture, InteractionStrings.ParametersInputsParameterPlaceholder, Name)
         };
         return input;
+    }
+
+    private static InteractionInput RenameInput(InteractionInput input, string name)
+    {
+        var renamedInput = new InteractionInput
+        {
+            Name = name,
+            InputType = input.InputType,
+            Label = input.Label ?? input.Name,
+            Description = input.Description,
+            EnableDescriptionMarkdown = input.EnableDescriptionMarkdown,
+            Required = input.Required,
+            Options = input.Options,
+            DynamicLoading = input.DynamicLoading,
+            Value = input.Value,
+            Placeholder = input.Placeholder,
+            AllowCustomChoice = input.AllowCustomChoice,
+            Disabled = input.Disabled,
+            MaxLength = input.MaxLength
+        };
+
+        renamedInput.DynamicLoadingState = input.DynamicLoadingState;
+        renamedInput.ValidationErrors.AddRange(input.ValidationErrors);
+
+        return renamedInput;
     }
 #pragma warning restore ASPIREINTERACTION001
 }

--- a/src/Aspire.Hosting/ApplicationModel/ParameterResource.cs
+++ b/src/Aspire.Hosting/ApplicationModel/ParameterResource.cs
@@ -128,12 +128,22 @@ public class ParameterResource : Resource, IExpressionValue
     public bool EnableDescriptionMarkdown { get; set; }
 
 #pragma warning disable ASPIREINTERACTION001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
-    internal InteractionInput CreateInput(string? name = null)
+    internal InteractionInput CreateInput(string? name = null, bool? required = null)
     {
         if (this.TryGetLastAnnotation<InputGeneratorAnnotation>(out var annotation))
         {
             var generatedInput = annotation.InputGenerator(this);
-            return name is null ? generatedInput : RenameInput(generatedInput, name);
+            if (name is not null)
+            {
+                generatedInput.SetName(name);
+            }
+
+            if (required is not null)
+            {
+                generatedInput.SetRequired(required.Value);
+            }
+
+            return generatedInput;
         }
 
         var input = new InteractionInput
@@ -143,34 +153,10 @@ public class ParameterResource : Resource, IExpressionValue
             Label = Name,
             Description = Description,
             EnableDescriptionMarkdown = EnableDescriptionMarkdown,
+            Required = required ?? false,
             Placeholder = string.Format(CultureInfo.CurrentCulture, InteractionStrings.ParametersInputsParameterPlaceholder, Name)
         };
         return input;
-    }
-
-    private static InteractionInput RenameInput(InteractionInput input, string name)
-    {
-        var renamedInput = new InteractionInput
-        {
-            Name = name,
-            InputType = input.InputType,
-            Label = input.Label ?? input.Name,
-            Description = input.Description,
-            EnableDescriptionMarkdown = input.EnableDescriptionMarkdown,
-            Required = input.Required,
-            Options = input.Options,
-            DynamicLoading = input.DynamicLoading,
-            Value = input.Value,
-            Placeholder = input.Placeholder,
-            AllowCustomChoice = input.AllowCustomChoice,
-            Disabled = input.Disabled,
-            MaxLength = input.MaxLength
-        };
-
-        renamedInput.DynamicLoadingState = input.DynamicLoadingState;
-        renamedInput.ValidationErrors.AddRange(input.ValidationErrors);
-
-        return renamedInput;
     }
 #pragma warning restore ASPIREINTERACTION001
 }

--- a/src/Aspire.Hosting/ApplicationModel/ResourceCommandService.cs
+++ b/src/Aspire.Hosting/ApplicationModel/ResourceCommandService.cs
@@ -17,11 +17,13 @@ public class ResourceCommandService
     /// <summary>
     /// Maps legacy command names to their current equivalents for backwards compatibility.
     /// </summary>
-    private static readonly Dictionary<string, string> s_legacyCommandNameMap = new(StringComparer.OrdinalIgnoreCase)
+    private static readonly Dictionary<string, string> s_legacyCommandNameMap = new(StringComparers.CommandName)
     {
         [KnownResourceCommands.LegacyStartCommand] = KnownResourceCommands.StartCommand,
         [KnownResourceCommands.LegacyStopCommand] = KnownResourceCommands.StopCommand,
         [KnownResourceCommands.LegacyRestartCommand] = KnownResourceCommands.RestartCommand,
+        [KnownResourceCommands.LegacySetParameterCommand] = KnownResourceCommands.SetParameterCommand,
+        [KnownResourceCommands.LegacyDeleteParameterCommand] = KnownResourceCommands.DeleteParameterCommand,
     };
 
     private readonly ResourceNotificationService _resourceNotificationService;
@@ -412,14 +414,14 @@ public class ResourceCommandService
     private static ResourceCommandAnnotation? ResolveCommandAnnotation(IResource resource, ref string commandName, ILogger? logger = null)
     {
         var requestedCommandName = commandName;
-        var annotation = resource.Annotations.OfType<ResourceCommandAnnotation>().SingleOrDefault(a => a.Name == requestedCommandName);
+        var annotation = resource.Annotations.OfType<ResourceCommandAnnotation>().SingleOrDefault(a => string.Equals(a.Name, requestedCommandName, StringComparisons.CommandName));
 
         // Backwards compatibility: if the command wasn't found and the caller used a legacy name
         // (e.g. "resource-start"), fall back to the current name (e.g. "start").
         if (annotation is null && s_legacyCommandNameMap.TryGetValue(commandName, out var mappedName))
         {
             logger?.LogDebug("Command '{CommandName}' not found, falling back to '{MappedName}'.", commandName, mappedName);
-            annotation = resource.Annotations.OfType<ResourceCommandAnnotation>().SingleOrDefault(a => a.Name == mappedName);
+            annotation = resource.Annotations.OfType<ResourceCommandAnnotation>().SingleOrDefault(a => string.Equals(a.Name, mappedName, StringComparisons.CommandName));
             if (annotation is not null)
             {
                 commandName = mappedName;

--- a/src/Aspire.Hosting/ApplicationModel/ResourceCommandService.cs
+++ b/src/Aspire.Hosting/ApplicationModel/ResourceCommandService.cs
@@ -221,6 +221,15 @@ public class ResourceCommandService
 
         if (argumentValues is { Count: > 0 })
         {
+            var disabledArgumentNames = annotation.Arguments
+                .Where(argument => argument.Disabled && argumentValues.ContainsKey(argument.Name))
+                .Select(argument => argument.Name)
+                .ToArray();
+            if (disabledArgumentNames.Length > 0)
+            {
+                return (CreateArguments(annotation.Arguments, argumentValues), CreateDisabledArgumentMessage(resolvedCommandName, disabledArgumentNames));
+            }
+
             var argumentNames = new HashSet<string>(
                 annotation.Arguments.Select(argument => argument.Name),
                 StringComparers.InteractionInputName);
@@ -254,6 +263,19 @@ public class ResourceCommandService
         if (orderedArgumentValues is { Count: var argumentCount } && argumentCount > annotation.Arguments.Count)
         {
             return (CreateArguments(annotation.Arguments, orderedArgumentValues: null), $"Command '{resolvedCommandName}' accepts {annotation.Arguments.Count} argument(s), but {argumentCount} were provided.");
+        }
+
+        if (orderedArgumentValues is { Count: > 0 })
+        {
+            var disabledArgumentNames = annotation.Arguments
+                .Take(orderedArgumentValues.Count)
+                .Where(static argument => argument.Disabled)
+                .Select(static argument => argument.Name)
+                .ToArray();
+            if (disabledArgumentNames.Length > 0)
+            {
+                return (CreateArguments(annotation.Arguments, orderedArgumentValues), CreateDisabledArgumentMessage(resolvedCommandName, disabledArgumentNames));
+            }
         }
 
         return (CreateArguments(annotation.Arguments, orderedArgumentValues), null);
@@ -436,6 +458,13 @@ public class ResourceCommandService
         return unknownArgumentNames.Length == 1
             ? $"Unknown argument '{unknownArgumentNames[0]}' for command '{commandName}'."
             : $"Unknown arguments for command '{commandName}': {string.Join(", ", unknownArgumentNames.Select(argumentName => $"'{argumentName}'"))}.";
+    }
+
+    private static string CreateDisabledArgumentMessage(string commandName, string[] disabledArgumentNames)
+    {
+        return disabledArgumentNames.Length == 1
+            ? $"Argument '{disabledArgumentNames[0]}' for command '{commandName}' is disabled."
+            : $"Arguments for command '{commandName}' are disabled: {string.Join(", ", disabledArgumentNames.Select(argumentName => $"'{argumentName}'"))}.";
     }
 
     private async Task<bool> ValidateArgumentsAsync(ResourceCommandAnnotation annotation, InteractionInputCollection arguments, CancellationToken cancellationToken)

--- a/src/Aspire.Hosting/IInteractionService.cs
+++ b/src/Aspire.Hosting/IInteractionService.cs
@@ -263,6 +263,7 @@ public sealed class InteractionInput
 {
     private string _name = null!;
     private bool _required;
+    private InputLoadOptions? _dynamicLoading;
 
     internal string EffectiveLabel => string.IsNullOrWhiteSpace(Label) ? Name : Label;
     internal InputLoadingState? DynamicLoadingState { get; set; }
@@ -274,6 +275,8 @@ public sealed class InteractionInput
     }
 
     internal void SetRequired(bool required) => _required = required;
+
+    internal void SetDynamicLoading(InputLoadOptions? dynamicLoading) => _dynamicLoading = dynamicLoading;
 
     /// <summary>
     /// Gets or sets the name for the input. Used for accessing inputs by name from a keyed collection.
@@ -324,7 +327,11 @@ public sealed class InteractionInput
     /// Dynamic loading is used to load data and update inputs after a prompt has started.
     /// It can also be used to reload data and update inputs after a dependant input has changed.
     /// </summary>
-    public InputLoadOptions? DynamicLoading { get; init; }
+    public InputLoadOptions? DynamicLoading
+    {
+        get => _dynamicLoading;
+        init => _dynamicLoading = value;
+    }
 
     /// <summary>
     /// Gets or sets the value of the input.

--- a/src/Aspire.Hosting/IInteractionService.cs
+++ b/src/Aspire.Hosting/IInteractionService.cs
@@ -261,14 +261,28 @@ public sealed class LoadInputContext
 [DebuggerDisplay("Name = {Name}, InputType = {InputType}, Required = {Required}, Value = {Value}")]
 public sealed class InteractionInput
 {
+    private string _name = null!;
+    private bool _required;
+
     internal string EffectiveLabel => string.IsNullOrWhiteSpace(Label) ? Name : Label;
     internal InputLoadingState? DynamicLoadingState { get; set; }
     internal List<string> ValidationErrors { get; } = [];
+    internal void SetName(string name)
+    {
+        ArgumentNullException.ThrowIfNull(name);
+        _name = name;
+    }
+
+    internal void SetRequired(bool required) => _required = required;
 
     /// <summary>
     /// Gets or sets the name for the input. Used for accessing inputs by name from a keyed collection.
     /// </summary>
-    public required string Name { get; init; }
+    public required string Name
+    {
+        get => _name;
+        init => _name = value;
+    }
 
     /// <summary>
     /// Gets or sets the label for the input. If not specified, the name will be used as the label.
@@ -294,7 +308,11 @@ public sealed class InteractionInput
     /// <summary>
     /// Gets or sets a value indicating whether the input is required.
     /// </summary>
-    public bool Required { get; init; }
+    public bool Required
+    {
+        get => _required;
+        init => _required = value;
+    }
 
     /// <summary>
     /// Gets or sets the options for the input. Only used by <see cref="InputType.Choice"/> inputs.

--- a/src/Aspire.Hosting/Orchestrator/ParameterProcessor.cs
+++ b/src/Aspire.Hosting/Orchestrator/ParameterProcessor.cs
@@ -29,6 +29,7 @@ public sealed class ParameterProcessor(
 {
     internal const string SaveToUserSecretsName = "SaveToUserSecrets";
     internal const string DeleteFromUserSecretsName = "DeleteFromUserSecrets";
+    internal const string SetParameterValueName = "Value";
 
     private readonly List<ParameterResource> _unresolvedParameters = [];
     private readonly object _resolutionTaskLock = new();
@@ -194,7 +195,7 @@ public sealed class ParameterProcessor(
 
     private void AddSetParameterCommand(ParameterResource parameterResource)
     {
-        var valueInput = parameterResource.CreateInput();
+        var valueInput = parameterResource.CreateInput(SetParameterValueName);
 
         // Pre-populate input with existing value if the parameter has one
         try
@@ -227,7 +228,7 @@ public sealed class ParameterProcessor(
             displayName: CommandStrings.SetParameterName,
             executeCommand: async context =>
             {
-                var value = context.Arguments.GetString(valueInput.Name);
+                var value = context.Arguments.GetString(SetParameterValueName);
                 if (string.IsNullOrEmpty(value))
                 {
                     return CommandResults.Success();

--- a/src/Aspire.Hosting/Orchestrator/ParameterProcessor.cs
+++ b/src/Aspire.Hosting/Orchestrator/ParameterProcessor.cs
@@ -195,21 +195,35 @@ public sealed class ParameterProcessor(
 
     private void AddSetParameterCommand(ParameterResource parameterResource)
     {
-        var valueInput = parameterResource.CreateInput(SetParameterValueName, required: true);
-
-        // Pre-populate input with existing value if the parameter has one
-        try
-        {
-            var existingValue = parameterResource.ValueInternal;
-            if (!string.IsNullOrEmpty(existingValue))
+        var valueInput = parameterResource.CreateInput(
+            SetParameterValueName,
+            required: true,
+            dynamicLoading: new InputLoadOptions
             {
-                valueInput.Value = existingValue;
-            }
-        }
-        catch (Exception)
-        {
-            // No existing value, leave input empty
-        }
+                AlwaysLoadOnStart = true,
+                LoadCallback = context =>
+                {
+                    if (context.Input.Value is not null)
+                    {
+                        return Task.CompletedTask;
+                    }
+
+                    try
+                    {
+                        var existingValue = parameterResource.ValueInternal;
+                        if (!string.IsNullOrEmpty(existingValue))
+                        {
+                            context.Input.Value = existingValue;
+                        }
+                    }
+                    catch (Exception)
+                    {
+                        // ValueInternal can throw when the parameter is unresolved; leave the input empty.
+                    }
+
+                    return Task.CompletedTask;
+                }
+            });
 
         var saveInput = new InteractionInput
         {
@@ -241,22 +255,7 @@ public sealed class ParameterProcessor(
         parameterResource.Annotations.Add(new ResourceCommandAnnotation(
             name: KnownResourceCommands.SetParameterCommand,
             displayName: CommandStrings.SetParameterName,
-            executeCommand: async context =>
-            {
-                var value = context.Arguments.GetString(SetParameterValueName);
-                if (string.IsNullOrEmpty(value))
-                {
-                    return CommandResults.Success();
-                }
-
-                var shouldSave = context.Arguments[SaveToUserSecretsName].Value is { Length: > 0 } sv &&
-                    bool.TryParse(sv, out var s) && s;
-
-                await ApplyParameterValueAsync(parameterResource, value, shouldSave, context.CancellationToken).ConfigureAwait(false);
-                OnParameterResolved(_unresolvedParameters, parameterResource);
-
-                return new ExecuteCommandResult { Success = true, Message = string.Format(CultureInfo.InvariantCulture, CommandStrings.ResourceSetParameter, parameterResource.Name) };
-            },
+            executeCommand: context => SetParameterCoreAsync(parameterResource, context.Arguments, context.CancellationToken),
             updateState: _ => ResourceCommandState.Enabled,
             displayDescription: CommandStrings.SetParameterDescription,
             arguments: [valueInput, saveInput],
@@ -271,17 +270,28 @@ public sealed class ParameterProcessor(
             InputType = InputType.Boolean,
             Label = InteractionStrings.ParametersInputsDeleteLabel,
             Description = InteractionStrings.ParametersInputsDeleteDescription,
-            EnableDescriptionMarkdown = true
+            EnableDescriptionMarkdown = true,
+            Disabled = !userSecretsManager.IsAvailable,
+            DynamicLoading = new InputLoadOptions
+            {
+                AlwaysLoadOnStart = true,
+                LoadCallback = async context =>
+                {
+                    if (!userSecretsManager.IsAvailable)
+                    {
+                        context.Input.Disabled = true;
+                        return;
+                    }
+                    var parameterSection = await deploymentStateManager.AcquireSectionAsync(parameterResource.ConfigurationKey, context.CancellationToken).ConfigureAwait(false);
+                    context.Input.Disabled = parameterSection.Data.Count == 0;
+                }
+            }
         };
 
         parameterResource.Annotations.Add(new ResourceCommandAnnotation(
             name: KnownResourceCommands.DeleteParameterCommand,
             displayName: CommandStrings.DeleteParameterName,
-            executeCommand: async context =>
-            {
-                await DeleteParameterCoreAsync(parameterResource, context.Arguments, context.CancellationToken).ConfigureAwait(false);
-                return new ExecuteCommandResult { Success = true, Message = string.Format(CultureInfo.InvariantCulture, CommandStrings.ResourceDeletedParameter, parameterResource.Name) };
-            },
+            executeCommand: context => DeleteParameterCoreAsync(parameterResource, context.Arguments, context.CancellationToken),
             updateState: _ => HasParameterValue(parameterResource) ? ResourceCommandState.Enabled : ResourceCommandState.Hidden,
             displayDescription: CommandStrings.DeleteParameterDescription,
             arguments: [deleteFromSecretsInput],
@@ -304,69 +314,6 @@ public sealed class ParameterProcessor(
         }
     }
 
-    /// <summary>
-    /// Prompts the user to set a value for a single parameter.
-    /// </summary>
-    /// <param name="parameterResource">The parameter resource to set the value for.</param>
-    /// <param name="cancellationToken">A cancellation token.</param>
-    /// <returns>A task that completes when the user has set the value or cancelled.</returns>
-    public async Task SetParameterAsync(ParameterResource parameterResource, CancellationToken cancellationToken = default)
-    {
-        var input = parameterResource.CreateInput();
-
-        // Pre-populate input with existing value if the parameter has one
-        try
-        {
-            var existingValue = parameterResource.ValueInternal;
-            if (!string.IsNullOrEmpty(existingValue))
-            {
-                input.Value = existingValue;
-            }
-        }
-        catch (Exception)
-        {
-            // No existing value, leave input empty
-        }
-
-        var parameterSection = await deploymentStateManager.AcquireSectionAsync(parameterResource.ConfigurationKey, cancellationToken).ConfigureAwait(false);
-        var hasSavedState = parameterSection.Data.Count > 0 && input.Value != null;
-
-        var saveParameterInput = CreateSaveParameterInput(hasSavedState);
-
-        var inputs = new List<InteractionInput> { input, saveParameterInput };
-
-        var result = await interactionService.PromptInputsAsync(
-            InteractionStrings.SetParameterTitle,
-            InteractionStrings.SetParameterMessage,
-            inputs,
-            new InputsDialogInteractionOptions
-            {
-                PrimaryButtonText = InteractionStrings.ParametersInputsPrimaryButtonText,
-                ShowDismiss = true,
-                EnableMessageMarkdown = true,
-            },
-            cancellationToken).ConfigureAwait(false);
-
-        if (result.Canceled)
-        {
-            return;
-        }
-
-        if (string.IsNullOrEmpty(input.Value))
-        {
-            return;
-        }
-
-        var inputValue = input.Value;
-        var shouldSave = saveParameterInput?.Value is not null &&
-            bool.TryParse(saveParameterInput.Value, out var saveToDeploymentState) && saveToDeploymentState;
-
-        await ApplyParameterValueAsync(parameterResource, inputValue, shouldSave, cancellationToken).ConfigureAwait(false);
-
-        // Remove the parameter from unresolved parameters list.
-        OnParameterResolved(_unresolvedParameters, parameterResource);
-    }
-
     private InteractionInput CreateSaveParameterInput(bool hasExistingValue)
     {
         return new InteractionInput
@@ -384,102 +331,24 @@ public sealed class ParameterProcessor(
         };
     }
 
-    /// <summary>
-    /// Deletes a parameter value from the deployment state and marks it as unresolved.
-    /// </summary>
-    /// <param name="parameterResource">The parameter resource to delete the value for.</param>
-    /// <param name="cancellationToken">A cancellation token.</param>
-    /// <returns>A task that completes when the value has been deleted.</returns>
-    public async Task DeleteParameterAsync(ParameterResource parameterResource, CancellationToken cancellationToken = default)
+    internal async Task<ExecuteCommandResult> SetParameterCoreAsync(ParameterResource parameterResource, InteractionInputCollection arguments, CancellationToken cancellationToken)
     {
-        try
+        var value = arguments.GetString(SetParameterValueName);
+        if (string.IsNullOrEmpty(value))
         {
-            var parameterSection = await deploymentStateManager.AcquireSectionAsync(parameterResource.ConfigurationKey, cancellationToken).ConfigureAwait(false);
-            var hasSavedState = parameterSection.Data.Count > 0;
-
-            var message = string.Format(CultureInfo.CurrentCulture, InteractionStrings.DeleteParameterMessage, parameterResource.Name);
-
-            var inputs = new List<InteractionInput>();
-            InteractionInput? deleteFromUserSecretsInput = null;
-
-            // Add checkbox to delete from user secrets if value is saved there
-            if (hasSavedState)
-            {
-                deleteFromUserSecretsInput = new InteractionInput
-                {
-                    Name = DeleteFromUserSecretsName,
-                    InputType = InputType.Boolean,
-                    Label = InteractionStrings.ParametersInputsDeleteLabel,
-                    Description = InteractionStrings.ParametersInputsDeleteDescription,
-                    EnableDescriptionMarkdown = true
-                };
-                inputs.Add(deleteFromUserSecretsInput);
-            }
-
-            var result = await interactionService.PromptInputsAsync(
-                InteractionStrings.DeleteParameterTitle,
-                message,
-                inputs,
-                new InputsDialogInteractionOptions
-                {
-                    PrimaryButtonText = InteractionStrings.DeleteParameterPrimaryButtonText,
-                    ShowDismiss = true,
-                    EnableMessageMarkdown = true,
-                },
-                cancellationToken).ConfigureAwait(false);
-
-            if (result.Canceled)
-            {
-                return;
-            }
-
-            // Check if user wants to delete from user secrets
-            var deleteFromUserSecrets = deleteFromUserSecretsInput?.Value is { Length: > 0 } deleteInputValue &&
-                bool.TryParse(deleteInputValue, out var shouldDelete) && shouldDelete;
-
-            if (deleteFromUserSecrets)
-            {
-                parameterSection.Data.Clear();
-                await deploymentStateManager.DeleteSectionAsync(parameterSection, cancellationToken).ConfigureAwait(false);
-                logger.LogInformation("Parameter value deleted from deployment state for {ParameterName}.", parameterResource.Name);
-
-                loggerService.GetLogger(parameterResource)
-                    .LogInformation("Parameter resource {ResourceName} value has been deleted from user secrets.", parameterResource.Name);
-            }
-            else
-            {
-                logger.LogInformation("Parameter value cleared for {ParameterName} (not deleted from user secrets).", parameterResource.Name);
-
-                loggerService.GetLogger(parameterResource)
-                    .LogInformation("Parameter resource {ResourceName} value has been cleared.", parameterResource.Name);
-            }
-
-            // Add the parameter back to unresolved parameters
-            if (!_unresolvedParameters.Contains(parameterResource))
-            {
-                _unresolvedParameters.Add(parameterResource);
-
-                // Reset the WaitForValueTcs so the parameter can be resolved again
-                var tcs = new TaskCompletionSource<string>(TaskCreationOptions.RunContinuationsAsynchronously);
-                tcs.SetException(new MissingParameterValueException("Parameter value has been deleted."));
-                parameterResource.WaitForValueTcs = tcs;
-
-                // Update the parameter's state to show it's missing a value
-                await UpdateParameterStateAsync(parameterResource, "Parameter value has been deleted", new(KnownResourceStates.ValueMissing, KnownResourceStateStyles.Warn)).ConfigureAwait(false);
-
-                // Start the resolution task if it's not running
-                _ = EnsureParameterResolutionTaskRunningAsync();
-            }
+            return CommandResults.Success();
         }
-        catch (Exception ex)
-        {
-            logger.LogWarning(ex, "Failed to delete parameter {ParameterName} from deployment state.", parameterResource.Name);
-        }
+
+        var shouldSave = arguments[SaveToUserSecretsName].Value is { Length: > 0 } sv &&
+            bool.TryParse(sv, out var s) && s;
+
+        await ApplyParameterValueAsync(parameterResource, value, shouldSave, cancellationToken).ConfigureAwait(false);
+        OnParameterResolved(_unresolvedParameters, parameterResource);
+
+        return new ExecuteCommandResult { Success = true, Message = string.Format(CultureInfo.InvariantCulture, CommandStrings.ResourceSetParameter, parameterResource.Name) };
     }
 
-    // Executes the delete-parameter logic using pre-populated command arguments
-    // instead of prompting. Called by the resource command callback.
-    private async Task DeleteParameterCoreAsync(ParameterResource parameterResource, InteractionInputCollection arguments, CancellationToken cancellationToken)
+    internal async Task<ExecuteCommandResult> DeleteParameterCoreAsync(ParameterResource parameterResource, InteractionInputCollection arguments, CancellationToken cancellationToken)
     {
         try
         {
@@ -525,6 +394,8 @@ public sealed class ParameterProcessor(
         {
             logger.LogWarning(ex, "Failed to delete parameter {ParameterName} from deployment state.", parameterResource.Name);
         }
+
+        return new ExecuteCommandResult { Success = true, Message = string.Format(CultureInfo.InvariantCulture, CommandStrings.ResourceDeletedParameter, parameterResource.Name) };
     }
 
     private async Task ApplyParameterValueAsync(ParameterResource parameterResource, string inputValue, bool saveToDeploymentState, CancellationToken cancellationToken = default)

--- a/src/Aspire.Hosting/Orchestrator/ParameterProcessor.cs
+++ b/src/Aspire.Hosting/Orchestrator/ParameterProcessor.cs
@@ -194,33 +194,81 @@ public sealed class ParameterProcessor(
 
     private void AddSetParameterCommand(ParameterResource parameterResource)
     {
+        var valueInput = parameterResource.CreateInput();
+
+        // Pre-populate input with existing value if the parameter has one
+        try
+        {
+            var existingValue = parameterResource.ValueInternal;
+            if (!string.IsNullOrEmpty(existingValue))
+            {
+                valueInput.Value = existingValue;
+            }
+        }
+        catch (Exception)
+        {
+            // No existing value, leave input empty
+        }
+
+        var saveInput = new InteractionInput
+        {
+            Name = SaveToUserSecretsName,
+            InputType = InputType.Boolean,
+            Label = InteractionStrings.ParametersInputsRememberLabel,
+            Description = !userSecretsManager.IsAvailable
+                ? InteractionStrings.ParametersInputsRememberDescriptionNotConfigured
+                : InteractionStrings.ParametersInputsRememberDescriptionConfigured,
+            EnableDescriptionMarkdown = true,
+            Disabled = !userSecretsManager.IsAvailable
+        };
+
         parameterResource.Annotations.Add(new ResourceCommandAnnotation(
             name: KnownResourceCommands.SetParameterCommand,
             displayName: CommandStrings.SetParameterName,
             executeCommand: async context =>
             {
-                await SetParameterAsync(parameterResource, context.CancellationToken).ConfigureAwait(false);
+                var value = context.Arguments.GetString(valueInput.Name);
+                if (string.IsNullOrEmpty(value))
+                {
+                    return CommandResults.Success();
+                }
+
+                var shouldSave = context.Arguments[SaveToUserSecretsName].Value is { Length: > 0 } sv &&
+                    bool.TryParse(sv, out var s) && s;
+
+                await ApplyParameterValueAsync(parameterResource, value, shouldSave, context.CancellationToken).ConfigureAwait(false);
+                OnParameterResolved(_unresolvedParameters, parameterResource);
+
                 return new ExecuteCommandResult { Success = true, Message = string.Format(CultureInfo.InvariantCulture, CommandStrings.ResourceSetParameter, parameterResource.Name) };
             },
             updateState: _ => ResourceCommandState.Enabled,
             displayDescription: CommandStrings.SetParameterDescription,
-            arguments: null,
+            arguments: [valueInput, saveInput],
             confirmationMessage: null,
             iconName: "Key",
             iconVariant: IconVariant.Regular,
             isHighlighted: true));
+
+        var deleteFromSecretsInput = new InteractionInput
+        {
+            Name = DeleteFromUserSecretsName,
+            InputType = InputType.Boolean,
+            Label = InteractionStrings.ParametersInputsDeleteLabel,
+            Description = InteractionStrings.ParametersInputsDeleteDescription,
+            EnableDescriptionMarkdown = true
+        };
 
         parameterResource.Annotations.Add(new ResourceCommandAnnotation(
             name: KnownResourceCommands.DeleteParameterCommand,
             displayName: CommandStrings.DeleteParameterName,
             executeCommand: async context =>
             {
-                await DeleteParameterAsync(parameterResource, context.CancellationToken).ConfigureAwait(false);
+                await DeleteParameterCoreAsync(parameterResource, context.Arguments, context.CancellationToken).ConfigureAwait(false);
                 return new ExecuteCommandResult { Success = true, Message = string.Format(CultureInfo.InvariantCulture, CommandStrings.ResourceDeletedParameter, parameterResource.Name) };
             },
             updateState: _ => HasParameterValue(parameterResource) ? ResourceCommandState.Enabled : ResourceCommandState.Hidden,
             displayDescription: CommandStrings.DeleteParameterDescription,
-            arguments: null,
+            arguments: [deleteFromSecretsInput],
             confirmationMessage: null,
             iconName: "Delete",
             iconVariant: IconVariant.Regular,
@@ -375,6 +423,56 @@ public sealed class ParameterProcessor(
 
             if (deleteFromUserSecrets)
             {
+                parameterSection.Data.Clear();
+                await deploymentStateManager.DeleteSectionAsync(parameterSection, cancellationToken).ConfigureAwait(false);
+                logger.LogInformation("Parameter value deleted from deployment state for {ParameterName}.", parameterResource.Name);
+
+                loggerService.GetLogger(parameterResource)
+                    .LogInformation("Parameter resource {ResourceName} value has been deleted from user secrets.", parameterResource.Name);
+            }
+            else
+            {
+                logger.LogInformation("Parameter value cleared for {ParameterName} (not deleted from user secrets).", parameterResource.Name);
+
+                loggerService.GetLogger(parameterResource)
+                    .LogInformation("Parameter resource {ResourceName} value has been cleared.", parameterResource.Name);
+            }
+
+            // Add the parameter back to unresolved parameters
+            if (!_unresolvedParameters.Contains(parameterResource))
+            {
+                _unresolvedParameters.Add(parameterResource);
+
+                // Reset the WaitForValueTcs so the parameter can be resolved again
+                var tcs = new TaskCompletionSource<string>(TaskCreationOptions.RunContinuationsAsynchronously);
+                tcs.SetException(new MissingParameterValueException("Parameter value has been deleted."));
+                parameterResource.WaitForValueTcs = tcs;
+
+                // Update the parameter's state to show it's missing a value
+                await UpdateParameterStateAsync(parameterResource, "Parameter value has been deleted", new(KnownResourceStates.ValueMissing, KnownResourceStateStyles.Warn)).ConfigureAwait(false);
+
+                // Start the resolution task if it's not running
+                _ = EnsureParameterResolutionTaskRunningAsync();
+            }
+        }
+        catch (Exception ex)
+        {
+            logger.LogWarning(ex, "Failed to delete parameter {ParameterName} from deployment state.", parameterResource.Name);
+        }
+    }
+
+    // Executes the delete-parameter logic using pre-populated command arguments
+    // instead of prompting. Called by the resource command callback.
+    private async Task DeleteParameterCoreAsync(ParameterResource parameterResource, InteractionInputCollection arguments, CancellationToken cancellationToken)
+    {
+        try
+        {
+            var deleteFromUserSecrets = arguments[DeleteFromUserSecretsName].Value is { Length: > 0 } deleteInputValue &&
+                bool.TryParse(deleteInputValue, out var shouldDelete) && shouldDelete;
+
+            if (deleteFromUserSecrets)
+            {
+                var parameterSection = await deploymentStateManager.AcquireSectionAsync(parameterResource.ConfigurationKey, cancellationToken).ConfigureAwait(false);
                 parameterSection.Data.Clear();
                 await deploymentStateManager.DeleteSectionAsync(parameterSection, cancellationToken).ConfigureAwait(false);
                 logger.LogInformation("Parameter value deleted from deployment state for {ParameterName}.", parameterResource.Name);

--- a/src/Aspire.Hosting/Orchestrator/ParameterProcessor.cs
+++ b/src/Aspire.Hosting/Orchestrator/ParameterProcessor.cs
@@ -238,12 +238,13 @@ public sealed class ParameterProcessor(
             DynamicLoading = new InputLoadOptions
             {
                 AlwaysLoadOnStart = true,
+                DependsOnInputs = [SetParameterValueName],
                 LoadCallback = async context =>
                 {
                     if (context.Input.Value is null)
                     {
                         var parameterSection = await deploymentStateManager.AcquireSectionAsync(parameterResource.ConfigurationKey, context.CancellationToken).ConfigureAwait(false);
-                        if (parameterSection.Data.Count > 0 && !string.IsNullOrEmpty(context.AllInputs[SetParameterValueName].Value))
+                        if (parameterSection.Data.Count > 0)
                         {
                             context.Input.Value = "true";
                         }
@@ -393,6 +394,7 @@ public sealed class ParameterProcessor(
         catch (Exception ex)
         {
             logger.LogWarning(ex, "Failed to delete parameter {ParameterName} from deployment state.", parameterResource.Name);
+            return CommandResults.Failure($"Failed to delete parameter '{parameterResource.Name}'.");
         }
 
         return new ExecuteCommandResult { Success = true, Message = string.Format(CultureInfo.InvariantCulture, CommandStrings.ResourceDeletedParameter, parameterResource.Name) };

--- a/src/Aspire.Hosting/Orchestrator/ParameterProcessor.cs
+++ b/src/Aspire.Hosting/Orchestrator/ParameterProcessor.cs
@@ -315,6 +315,92 @@ public sealed class ParameterProcessor(
         }
     }
 
+    /// <summary>
+    /// Prompts the user to set a value for a single parameter.
+    /// </summary>
+    /// <param name="parameterResource">The parameter resource to set the value for.</param>
+    /// <param name="cancellationToken">The cancellation token to observe while waiting for the interaction to complete.</param>
+    /// <returns>A task that completes when the user has set the value or canceled the interaction.</returns>
+    public async Task SetParameterAsync(ParameterResource parameterResource, CancellationToken cancellationToken = default)
+    {
+        var input = parameterResource.CreateInput(SetParameterValueName);
+
+        try
+        {
+            var existingValue = parameterResource.ValueInternal;
+            if (!string.IsNullOrEmpty(existingValue))
+            {
+                input.Value = existingValue;
+            }
+        }
+        catch (Exception)
+        {
+            // ValueInternal can throw when the parameter is unresolved; leave the input empty.
+        }
+
+        var parameterSection = await deploymentStateManager.AcquireSectionAsync(parameterResource.ConfigurationKey, cancellationToken).ConfigureAwait(false);
+        var hasSavedState = parameterSection.Data.Count > 0 && input.Value is not null;
+        var saveParameterInput = CreateSaveParameterInput(hasSavedState);
+
+        var result = await interactionService.PromptInputsAsync(
+            InteractionStrings.SetParameterTitle,
+            InteractionStrings.SetParameterMessage,
+            [input, saveParameterInput],
+            new InputsDialogInteractionOptions
+            {
+                PrimaryButtonText = InteractionStrings.ParametersInputsPrimaryButtonText,
+                ShowDismiss = true,
+                EnableMessageMarkdown = true,
+            },
+            cancellationToken).ConfigureAwait(false);
+
+        if (!result.Canceled)
+        {
+            await SetParameterCoreAsync(parameterResource, result.Data, cancellationToken).ConfigureAwait(false);
+        }
+    }
+
+    /// <summary>
+    /// Prompts the user to delete a parameter value.
+    /// </summary>
+    /// <param name="parameterResource">The parameter resource to delete the value for.</param>
+    /// <param name="cancellationToken">The cancellation token to observe while waiting for the interaction to complete.</param>
+    /// <returns>A task that completes when the user has deleted the value or canceled the interaction.</returns>
+    public async Task DeleteParameterAsync(ParameterResource parameterResource, CancellationToken cancellationToken = default)
+    {
+        var parameterSection = await deploymentStateManager.AcquireSectionAsync(parameterResource.ConfigurationKey, cancellationToken).ConfigureAwait(false);
+        var hasSavedState = parameterSection.Data.Count > 0;
+        var message = string.Format(CultureInfo.CurrentCulture, InteractionStrings.DeleteParameterMessage, parameterResource.Name);
+        var deleteFromUserSecretsInput = new InteractionInput
+        {
+            Name = DeleteFromUserSecretsName,
+            InputType = InputType.Boolean,
+            Label = InteractionStrings.ParametersInputsDeleteLabel,
+            Description = InteractionStrings.ParametersInputsDeleteDescription,
+            EnableDescriptionMarkdown = true
+        };
+        var inputs = hasSavedState ? [deleteFromUserSecretsInput] : Array.Empty<InteractionInput>();
+
+        var result = await interactionService.PromptInputsAsync(
+            InteractionStrings.DeleteParameterTitle,
+            message,
+            inputs,
+            new InputsDialogInteractionOptions
+            {
+                PrimaryButtonText = InteractionStrings.DeleteParameterPrimaryButtonText,
+                ShowDismiss = true,
+                EnableMessageMarkdown = true,
+            },
+            cancellationToken).ConfigureAwait(false);
+
+        if (result.Canceled)
+        {
+            return;
+        }
+
+        await DeleteParameterCoreAsync(parameterResource, result.Data, cancellationToken).ConfigureAwait(false);
+    }
+
     private InteractionInput CreateSaveParameterInput(bool hasExistingValue)
     {
         return new InteractionInput
@@ -353,7 +439,8 @@ public sealed class ParameterProcessor(
     {
         try
         {
-            var deleteFromUserSecrets = arguments[DeleteFromUserSecretsName].Value is { Length: > 0 } deleteInputValue &&
+            var deleteFromUserSecrets = arguments.TryGetByName(DeleteFromUserSecretsName, out var deleteFromUserSecretsInput) &&
+                deleteFromUserSecretsInput.Value is { Length: > 0 } deleteInputValue &&
                 bool.TryParse(deleteInputValue, out var shouldDelete) && shouldDelete;
 
             if (deleteFromUserSecrets)

--- a/src/Aspire.Hosting/Orchestrator/ParameterProcessor.cs
+++ b/src/Aspire.Hosting/Orchestrator/ParameterProcessor.cs
@@ -195,7 +195,7 @@ public sealed class ParameterProcessor(
 
     private void AddSetParameterCommand(ParameterResource parameterResource)
     {
-        var valueInput = parameterResource.CreateInput(SetParameterValueName);
+        var valueInput = parameterResource.CreateInput(SetParameterValueName, required: true);
 
         // Pre-populate input with existing value if the parameter has one
         try
@@ -220,7 +220,22 @@ public sealed class ParameterProcessor(
                 ? InteractionStrings.ParametersInputsRememberDescriptionNotConfigured
                 : InteractionStrings.ParametersInputsRememberDescriptionConfigured,
             EnableDescriptionMarkdown = true,
-            Disabled = !userSecretsManager.IsAvailable
+            Disabled = !userSecretsManager.IsAvailable,
+            DynamicLoading = new InputLoadOptions
+            {
+                AlwaysLoadOnStart = true,
+                LoadCallback = async context =>
+                {
+                    if (context.Input.Value is null)
+                    {
+                        var parameterSection = await deploymentStateManager.AcquireSectionAsync(parameterResource.ConfigurationKey, context.CancellationToken).ConfigureAwait(false);
+                        if (parameterSection.Data.Count > 0 && !string.IsNullOrEmpty(context.AllInputs[SetParameterValueName].Value))
+                        {
+                            context.Input.Value = "true";
+                        }
+                    }
+                }
+            }
         };
 
         parameterResource.Annotations.Add(new ResourceCommandAnnotation(

--- a/src/Aspire.Hosting/Resources/InteractionStrings.resx
+++ b/src/Aspire.Hosting/Resources/InteractionStrings.resx
@@ -219,7 +219,7 @@
     <comment>Contains markdown. {0} is the parameter name.</comment>
   </data>
   <data name="ParametersInputsDeleteDescription" xml:space="preserve">
-    <value>The value is currently saved in [user secrets](https://aka.ms/aspire/user-secrets).</value>
+    <value>Delete a value that is saved in [user secrets](https://aka.ms/aspire/user-secrets).</value>
     <comment>Contains markdown</comment>
   </data>
   <data name="DeleteParameterPrimaryButtonText" xml:space="preserve">

--- a/src/Aspire.Hosting/Resources/xlf/InteractionStrings.cs.xlf
+++ b/src/Aspire.Hosting/Resources/xlf/InteractionStrings.cs.xlf
@@ -93,8 +93,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ParametersInputsDeleteDescription">
-        <source>The value is currently saved in [user secrets](https://aka.ms/aspire/user-secrets).</source>
-        <target state="new">The value is currently saved in [user secrets](https://aka.ms/aspire/user-secrets).</target>
+        <source>Delete a value that is saved in [user secrets](https://aka.ms/aspire/user-secrets).</source>
+        <target state="new">Delete a value that is saved in [user secrets](https://aka.ms/aspire/user-secrets).</target>
         <note>Contains markdown</note>
       </trans-unit>
       <trans-unit id="ParametersInputsDeleteLabel">

--- a/src/Aspire.Hosting/Resources/xlf/InteractionStrings.de.xlf
+++ b/src/Aspire.Hosting/Resources/xlf/InteractionStrings.de.xlf
@@ -93,8 +93,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ParametersInputsDeleteDescription">
-        <source>The value is currently saved in [user secrets](https://aka.ms/aspire/user-secrets).</source>
-        <target state="new">The value is currently saved in [user secrets](https://aka.ms/aspire/user-secrets).</target>
+        <source>Delete a value that is saved in [user secrets](https://aka.ms/aspire/user-secrets).</source>
+        <target state="new">Delete a value that is saved in [user secrets](https://aka.ms/aspire/user-secrets).</target>
         <note>Contains markdown</note>
       </trans-unit>
       <trans-unit id="ParametersInputsDeleteLabel">

--- a/src/Aspire.Hosting/Resources/xlf/InteractionStrings.es.xlf
+++ b/src/Aspire.Hosting/Resources/xlf/InteractionStrings.es.xlf
@@ -93,8 +93,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ParametersInputsDeleteDescription">
-        <source>The value is currently saved in [user secrets](https://aka.ms/aspire/user-secrets).</source>
-        <target state="new">The value is currently saved in [user secrets](https://aka.ms/aspire/user-secrets).</target>
+        <source>Delete a value that is saved in [user secrets](https://aka.ms/aspire/user-secrets).</source>
+        <target state="new">Delete a value that is saved in [user secrets](https://aka.ms/aspire/user-secrets).</target>
         <note>Contains markdown</note>
       </trans-unit>
       <trans-unit id="ParametersInputsDeleteLabel">

--- a/src/Aspire.Hosting/Resources/xlf/InteractionStrings.fr.xlf
+++ b/src/Aspire.Hosting/Resources/xlf/InteractionStrings.fr.xlf
@@ -93,8 +93,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ParametersInputsDeleteDescription">
-        <source>The value is currently saved in [user secrets](https://aka.ms/aspire/user-secrets).</source>
-        <target state="new">The value is currently saved in [user secrets](https://aka.ms/aspire/user-secrets).</target>
+        <source>Delete a value that is saved in [user secrets](https://aka.ms/aspire/user-secrets).</source>
+        <target state="new">Delete a value that is saved in [user secrets](https://aka.ms/aspire/user-secrets).</target>
         <note>Contains markdown</note>
       </trans-unit>
       <trans-unit id="ParametersInputsDeleteLabel">

--- a/src/Aspire.Hosting/Resources/xlf/InteractionStrings.it.xlf
+++ b/src/Aspire.Hosting/Resources/xlf/InteractionStrings.it.xlf
@@ -93,8 +93,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ParametersInputsDeleteDescription">
-        <source>The value is currently saved in [user secrets](https://aka.ms/aspire/user-secrets).</source>
-        <target state="new">The value is currently saved in [user secrets](https://aka.ms/aspire/user-secrets).</target>
+        <source>Delete a value that is saved in [user secrets](https://aka.ms/aspire/user-secrets).</source>
+        <target state="new">Delete a value that is saved in [user secrets](https://aka.ms/aspire/user-secrets).</target>
         <note>Contains markdown</note>
       </trans-unit>
       <trans-unit id="ParametersInputsDeleteLabel">

--- a/src/Aspire.Hosting/Resources/xlf/InteractionStrings.ja.xlf
+++ b/src/Aspire.Hosting/Resources/xlf/InteractionStrings.ja.xlf
@@ -93,8 +93,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ParametersInputsDeleteDescription">
-        <source>The value is currently saved in [user secrets](https://aka.ms/aspire/user-secrets).</source>
-        <target state="new">The value is currently saved in [user secrets](https://aka.ms/aspire/user-secrets).</target>
+        <source>Delete a value that is saved in [user secrets](https://aka.ms/aspire/user-secrets).</source>
+        <target state="new">Delete a value that is saved in [user secrets](https://aka.ms/aspire/user-secrets).</target>
         <note>Contains markdown</note>
       </trans-unit>
       <trans-unit id="ParametersInputsDeleteLabel">

--- a/src/Aspire.Hosting/Resources/xlf/InteractionStrings.ko.xlf
+++ b/src/Aspire.Hosting/Resources/xlf/InteractionStrings.ko.xlf
@@ -93,8 +93,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ParametersInputsDeleteDescription">
-        <source>The value is currently saved in [user secrets](https://aka.ms/aspire/user-secrets).</source>
-        <target state="new">The value is currently saved in [user secrets](https://aka.ms/aspire/user-secrets).</target>
+        <source>Delete a value that is saved in [user secrets](https://aka.ms/aspire/user-secrets).</source>
+        <target state="new">Delete a value that is saved in [user secrets](https://aka.ms/aspire/user-secrets).</target>
         <note>Contains markdown</note>
       </trans-unit>
       <trans-unit id="ParametersInputsDeleteLabel">

--- a/src/Aspire.Hosting/Resources/xlf/InteractionStrings.pl.xlf
+++ b/src/Aspire.Hosting/Resources/xlf/InteractionStrings.pl.xlf
@@ -93,8 +93,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ParametersInputsDeleteDescription">
-        <source>The value is currently saved in [user secrets](https://aka.ms/aspire/user-secrets).</source>
-        <target state="new">The value is currently saved in [user secrets](https://aka.ms/aspire/user-secrets).</target>
+        <source>Delete a value that is saved in [user secrets](https://aka.ms/aspire/user-secrets).</source>
+        <target state="new">Delete a value that is saved in [user secrets](https://aka.ms/aspire/user-secrets).</target>
         <note>Contains markdown</note>
       </trans-unit>
       <trans-unit id="ParametersInputsDeleteLabel">

--- a/src/Aspire.Hosting/Resources/xlf/InteractionStrings.pt-BR.xlf
+++ b/src/Aspire.Hosting/Resources/xlf/InteractionStrings.pt-BR.xlf
@@ -93,8 +93,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ParametersInputsDeleteDescription">
-        <source>The value is currently saved in [user secrets](https://aka.ms/aspire/user-secrets).</source>
-        <target state="new">The value is currently saved in [user secrets](https://aka.ms/aspire/user-secrets).</target>
+        <source>Delete a value that is saved in [user secrets](https://aka.ms/aspire/user-secrets).</source>
+        <target state="new">Delete a value that is saved in [user secrets](https://aka.ms/aspire/user-secrets).</target>
         <note>Contains markdown</note>
       </trans-unit>
       <trans-unit id="ParametersInputsDeleteLabel">

--- a/src/Aspire.Hosting/Resources/xlf/InteractionStrings.ru.xlf
+++ b/src/Aspire.Hosting/Resources/xlf/InteractionStrings.ru.xlf
@@ -93,8 +93,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ParametersInputsDeleteDescription">
-        <source>The value is currently saved in [user secrets](https://aka.ms/aspire/user-secrets).</source>
-        <target state="new">The value is currently saved in [user secrets](https://aka.ms/aspire/user-secrets).</target>
+        <source>Delete a value that is saved in [user secrets](https://aka.ms/aspire/user-secrets).</source>
+        <target state="new">Delete a value that is saved in [user secrets](https://aka.ms/aspire/user-secrets).</target>
         <note>Contains markdown</note>
       </trans-unit>
       <trans-unit id="ParametersInputsDeleteLabel">

--- a/src/Aspire.Hosting/Resources/xlf/InteractionStrings.tr.xlf
+++ b/src/Aspire.Hosting/Resources/xlf/InteractionStrings.tr.xlf
@@ -93,8 +93,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ParametersInputsDeleteDescription">
-        <source>The value is currently saved in [user secrets](https://aka.ms/aspire/user-secrets).</source>
-        <target state="new">The value is currently saved in [user secrets](https://aka.ms/aspire/user-secrets).</target>
+        <source>Delete a value that is saved in [user secrets](https://aka.ms/aspire/user-secrets).</source>
+        <target state="new">Delete a value that is saved in [user secrets](https://aka.ms/aspire/user-secrets).</target>
         <note>Contains markdown</note>
       </trans-unit>
       <trans-unit id="ParametersInputsDeleteLabel">

--- a/src/Aspire.Hosting/Resources/xlf/InteractionStrings.zh-Hans.xlf
+++ b/src/Aspire.Hosting/Resources/xlf/InteractionStrings.zh-Hans.xlf
@@ -93,8 +93,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ParametersInputsDeleteDescription">
-        <source>The value is currently saved in [user secrets](https://aka.ms/aspire/user-secrets).</source>
-        <target state="new">The value is currently saved in [user secrets](https://aka.ms/aspire/user-secrets).</target>
+        <source>Delete a value that is saved in [user secrets](https://aka.ms/aspire/user-secrets).</source>
+        <target state="new">Delete a value that is saved in [user secrets](https://aka.ms/aspire/user-secrets).</target>
         <note>Contains markdown</note>
       </trans-unit>
       <trans-unit id="ParametersInputsDeleteLabel">

--- a/src/Aspire.Hosting/Resources/xlf/InteractionStrings.zh-Hant.xlf
+++ b/src/Aspire.Hosting/Resources/xlf/InteractionStrings.zh-Hant.xlf
@@ -93,8 +93,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ParametersInputsDeleteDescription">
-        <source>The value is currently saved in [user secrets](https://aka.ms/aspire/user-secrets).</source>
-        <target state="new">The value is currently saved in [user secrets](https://aka.ms/aspire/user-secrets).</target>
+        <source>Delete a value that is saved in [user secrets](https://aka.ms/aspire/user-secrets).</source>
+        <target state="new">Delete a value that is saved in [user secrets](https://aka.ms/aspire/user-secrets).</target>
         <note>Contains markdown</note>
       </trans-unit>
       <trans-unit id="ParametersInputsDeleteLabel">

--- a/tests/Aspire.Cli.EndToEnd.Tests/ResourceCommandTests.cs
+++ b/tests/Aspire.Cli.EndToEnd.Tests/ResourceCommandTests.cs
@@ -16,6 +16,135 @@ public sealed class ResourceCommandTests(ITestOutputHelper output)
 {
     [Fact]
     [CaptureWorkspaceOnFailure]
+    public async Task ResourceCommand_SetAndDeleteParameterUpdatesDescribeOutput()
+    {
+        var repoRoot = CliE2ETestHelpers.GetRepoRoot();
+        var strategy = CliInstallStrategy.Detect(output.WriteLine);
+        var projectSuffix = Guid.NewGuid().ToString("N")[..6];
+        var projectName = $"ResourceParameterCmdApp_{projectSuffix}";
+
+        using var workspace = TemporaryWorkspace.Create(output);
+
+        using var terminal = CliE2ETestHelpers.CreateDockerTestTerminal(repoRoot, strategy, output, workspace: workspace);
+
+        var pendingRun = terminal.RunAsync(TestContext.Current.CancellationToken);
+
+        var counter = new SequenceCounter();
+        var auto = new Hex1bTerminalAutomator(terminal, defaultTimeout: TimeSpan.FromSeconds(500));
+        var testBodyFailed = false;
+
+        try
+        {
+            await auto.PrepareDockerEnvironmentAsync(counter, workspace);
+            await auto.InstallAspireCliAsync(strategy, counter);
+            await auto.AspireNewAsync(projectName, counter, template: AspireTemplate.EmptyAppHost);
+
+            await auto.TypeAsync($"cd {projectName}");
+            await auto.EnterAsync();
+            await auto.WaitForSuccessPromptAsync(counter);
+
+            var appHostFilePath = Path.Combine(workspace.WorkspaceRoot.FullName, projectName, "apphost.cs");
+            var content = File.ReadAllText(appHostFilePath);
+            var sdkLine = content.Split('\n', 2)[0].TrimEnd('\r');
+
+            var newContent = $$"""
+                {{sdkLine}}
+
+                var builder = DistributedApplication.CreateBuilder(args);
+
+                builder.AddParameter("greeting");
+
+                builder.Build().Run();
+                """;
+
+            File.WriteAllText(appHostFilePath, newContent);
+
+            await auto.TypeAsync("aspire start");
+            await auto.EnterAsync();
+            await auto.WaitUntilTextAsync(RunCommandStrings.AppHostStartedSuccessfully, timeout: TimeSpan.FromMinutes(3));
+            await auto.WaitForSuccessPromptAsync(counter);
+
+            await auto.TypeAsync("aspire describe greeting --format json > greeting-unset.json");
+            await auto.EnterAsync();
+            await auto.WaitForSuccessPromptAsync(counter, TimeSpan.FromSeconds(30));
+
+            await auto.TypeAsync("jq -er '.resources[0].state' greeting-unset.json");
+            await auto.EnterAsync();
+            await auto.WaitUntilTextAsync("ValueMissing", timeout: TimeSpan.FromSeconds(10));
+            await auto.WaitForSuccessPromptAsync(counter);
+
+            await auto.TypeAsync("aspire resource greeting set-parameter --value 'Hello world'");
+            await auto.EnterAsync();
+            await auto.WaitUntilTextAsync("Resource 'greeting' set successfully.", timeout: TimeSpan.FromSeconds(30));
+            await auto.WaitForSuccessPromptAsync(counter, TimeSpan.FromSeconds(30));
+
+            await auto.TypeAsync("aspire describe greeting --format json > greeting-set.json");
+            await auto.EnterAsync();
+            await auto.WaitForSuccessPromptAsync(counter, TimeSpan.FromSeconds(30));
+
+            await auto.TypeAsync("jq -er '.resources[0].state' greeting-set.json");
+            await auto.EnterAsync();
+            await auto.WaitUntilTextAsync("Running", timeout: TimeSpan.FromSeconds(10));
+            await auto.WaitForSuccessPromptAsync(counter);
+
+            await auto.TypeAsync("jq -er '.resources[0].properties.Value' greeting-set.json");
+            await auto.EnterAsync();
+            await auto.WaitUntilTextAsync("Hello world", timeout: TimeSpan.FromSeconds(10));
+            await auto.WaitForSuccessPromptAsync(counter);
+
+            await auto.TypeAsync("aspire resource greeting delete-parameter");
+            await auto.EnterAsync();
+            await auto.WaitUntilTextAsync("Resource 'greeting' deleted successfully.", timeout: TimeSpan.FromSeconds(30));
+            await auto.WaitForSuccessPromptAsync(counter, TimeSpan.FromSeconds(30));
+
+            await auto.TypeAsync("aspire describe greeting --format json > greeting-deleted.json");
+            await auto.EnterAsync();
+            await auto.WaitForSuccessPromptAsync(counter, TimeSpan.FromSeconds(30));
+
+            await auto.TypeAsync("jq -er '.resources[0].state' greeting-deleted.json");
+            await auto.EnterAsync();
+            await auto.WaitUntilTextAsync("ValueMissing", timeout: TimeSpan.FromSeconds(10));
+            await auto.WaitForSuccessPromptAsync(counter);
+
+            await auto.TypeAsync("aspire stop");
+            await auto.EnterAsync();
+            await auto.WaitUntilAppHostStoppedSuccessfullyAsync(timeout: TimeSpan.FromMinutes(1));
+            await auto.WaitForSuccessPromptAsync(counter);
+        }
+        catch
+        {
+            testBodyFailed = true;
+            throw;
+        }
+        finally
+        {
+            try
+            {
+                await auto.CaptureAspireDiagnosticsAsync(counter, workspace);
+            }
+            catch
+            {
+                // Best effort diagnostics capture.
+            }
+
+            try
+            {
+                await auto.TypeAsync("exit");
+                await auto.EnterAsync();
+                await pendingRun;
+            }
+            catch
+            {
+                if (!testBodyFailed)
+                {
+                    throw;
+                }
+            }
+        }
+    }
+
+    [Fact]
+    [CaptureWorkspaceOnFailure]
     public async Task ResourceCommand_FailsWhenInteractionServiceIsRequired()
     {
         var repoRoot = CliE2ETestHelpers.GetRepoRoot();

--- a/tests/Aspire.Cli.Tests/Commands/ResourceCommandTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/ResourceCommandTests.cs
@@ -364,29 +364,61 @@ public class ResourceCommandTests(ITestOutputHelper outputHelper)
         Assert.Equal(ExitCodeConstants.Success, exitCode);
     }
 
-    [Fact]
-    public async Task ResourceCommand_AcceptsWellKnownCommandNames()
+    [Theory]
+    [InlineData("start")]
+    [InlineData("stop")]
+    [InlineData("restart")]
+    [InlineData("rebuild")]
+    [InlineData("set-parameter")]
+    [InlineData("delete-parameter")]
+    public async Task ResourceCommand_AcceptsWellKnownCommandNames(string commandName)
     {
         using var workspace = TemporaryWorkspace.Create(outputHelper);
         var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper);
         using var provider = services.BuildServiceProvider();
 
         var command = provider.GetRequiredService<RootCommand>();
+        var result = command.Parse($"resource myresource {commandName} --help");
 
-        // Test with start
-        var startResult = command.Parse("resource myresource start --help");
-        var startExitCode = await startResult.InvokeAsync().DefaultTimeout();
-        Assert.Equal(ExitCodeConstants.Success, startExitCode);
+        var exitCode = await result.InvokeAsync().DefaultTimeout();
 
-        // Test with stop
-        var stopResult = command.Parse("resource myresource stop --help");
-        var stopExitCode = await stopResult.InvokeAsync().DefaultTimeout();
-        Assert.Equal(ExitCodeConstants.Success, stopExitCode);
+        Assert.Equal(ExitCodeConstants.Success, exitCode);
+    }
 
-        // Test with restart
-        var restartResult = command.Parse("resource myresource restart --help");
-        var restartExitCode = await restartResult.InvokeAsync().DefaultTimeout();
-        Assert.Equal(ExitCodeConstants.Success, restartExitCode);
+    [Theory]
+    [InlineData("start", "Starting resource 'myresource'...", "Resource 'myresource' started successfully.")]
+    [InlineData("stop", "Stopping resource 'myresource'...", "Resource 'myresource' stopped successfully.")]
+    [InlineData("restart", "Restarting resource 'myresource'...", "Resource 'myresource' restarted successfully.")]
+    [InlineData("rebuild", "Rebuilding resource 'myresource'...", "Resource 'myresource' rebuilt successfully.")]
+    [InlineData("set-parameter", "Setting parameter for resource 'myresource'...", "Resource 'myresource' set successfully.")]
+    [InlineData("delete-parameter", "Deleting parameter for resource 'myresource'...", "Resource 'myresource' deleted successfully.")]
+    public async Task ResourceCommand_UsesWellKnownCommandDisplayMetadata(string commandName, string statusMessage, string successMessage)
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        var statuses = new List<string>();
+        var interactionService = new TestInteractionService
+        {
+            ShowStatusCallback = statuses.Add
+        };
+
+        var backchannel = new TestAppHostAuxiliaryBackchannel
+        {
+            ExecuteResourceCommandResult = new ExecuteResourceCommandResponse { Success = true }
+        };
+        await using var provider = CreateServiceProvider(workspace, outputHelper, backchannel, interactionService);
+
+        var command = provider.GetRequiredService<RootCommand>();
+        var result = command.Parse($"resource myresource {commandName}");
+
+        var exitCode = await result.InvokeAsync().DefaultTimeout();
+
+        Assert.Equal(ExitCodeConstants.Success, exitCode);
+        Assert.Equal(1, backchannel.ExecuteResourceCommandCallCount);
+        Assert.Collection(
+            statuses,
+            status => Assert.Equal("Scanning for running AppHosts...", status),
+            status => Assert.Equal(statusMessage, status));
+        Assert.Equal(successMessage, Assert.Single(interactionService.DisplayedSuccess));
     }
 
     [Fact]

--- a/tests/Aspire.Cli.Tests/Commands/ResourceCommandTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/ResourceCommandTests.cs
@@ -371,6 +371,8 @@ public class ResourceCommandTests(ITestOutputHelper outputHelper)
     [InlineData("rebuild")]
     [InlineData("set-parameter")]
     [InlineData("delete-parameter")]
+    [InlineData("parameter-set")]
+    [InlineData("parameter-delete")]
     public async Task ResourceCommand_AcceptsWellKnownCommandNames(string commandName)
     {
         using var workspace = TemporaryWorkspace.Create(outputHelper);
@@ -392,6 +394,8 @@ public class ResourceCommandTests(ITestOutputHelper outputHelper)
     [InlineData("rebuild", "Rebuilding resource 'myresource'...", "Resource 'myresource' rebuilt successfully.")]
     [InlineData("set-parameter", "Setting parameter for resource 'myresource'...", "Resource 'myresource' set successfully.")]
     [InlineData("delete-parameter", "Deleting parameter for resource 'myresource'...", "Resource 'myresource' deleted successfully.")]
+    [InlineData("parameter-set", "Setting parameter for resource 'myresource'...", "Resource 'myresource' set successfully.")]
+    [InlineData("parameter-delete", "Deleting parameter for resource 'myresource'...", "Resource 'myresource' deleted successfully.")]
     public async Task ResourceCommand_UsesWellKnownCommandDisplayMetadata(string commandName, string statusMessage, string successMessage)
     {
         using var workspace = TemporaryWorkspace.Create(outputHelper);
@@ -559,6 +563,41 @@ public class ResourceCommandTests(ITestOutputHelper outputHelper)
 
         Assert.Equal(ExitCodeConstants.Success, exitCode);
         AssertJsonObject(backchannel.ExecuteResourceCommandArguments, ("text", "Submitted Aspire!"), ("timeoutMilliseconds", "500"));
+    }
+
+    [Fact]
+    public async Task ResourceCommand_LegacyParameterCommandName_UsesCurrentCommandMetadata()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+
+        var backchannel = new TestAppHostAuxiliaryBackchannel
+        {
+            ExecuteResourceCommandResult = new ExecuteResourceCommandResponse { Success = true },
+            ResourceSnapshots =
+            [
+                CreateResourceSnapshot(
+                    "greeting",
+                    CreateCommand(
+                        "set-parameter",
+                        CreateArgument("Value")))
+            ]
+        };
+        var monitor = new TestAuxiliaryBackchannelMonitor();
+        monitor.AddConnection("hash", "/tmp/test.sock", backchannel);
+
+        var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper, options =>
+        {
+            options.AuxiliaryBackchannelMonitorFactory = _ => monitor;
+        });
+        using var provider = services.BuildServiceProvider();
+
+        var command = provider.GetRequiredService<RootCommand>();
+        var result = command.Parse("resource greeting parameter-set --value \"Hello world\"");
+
+        var exitCode = await result.InvokeAsync().DefaultTimeout();
+
+        Assert.Equal(ExitCodeConstants.Success, exitCode);
+        AssertJsonObject(backchannel.ExecuteResourceCommandArguments, ("Value", "Hello world"));
     }
 
     [Fact]

--- a/tests/Aspire.Cli.Tests/Commands/ResourceCommandTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/ResourceCommandTests.cs
@@ -1010,6 +1010,34 @@ public class ResourceCommandTests(ITestOutputHelper outputHelper)
     }
 
     [Fact]
+    public async Task ResourceCommand_ReturnsInvalidCommandForDisabledCommandOption()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        var interactionService = new TestInteractionService();
+
+        var backchannel = new TestAppHostAuxiliaryBackchannel
+        {
+            ExecuteResourceCommandResult = new ExecuteResourceCommandResponse { Success = true },
+            ResourceSnapshots =
+            [
+                CreateResourceSnapshot(
+                    "web-browser-automation",
+                    CreateCommand("configure", CreateArgument("saveToUserSecrets", inputType: "Boolean", disabled: true)))
+            ]
+        };
+        await using var provider = CreateServiceProvider(workspace, outputHelper, backchannel, interactionService);
+
+        var command = provider.GetRequiredService<RootCommand>();
+        var result = command.Parse("""resource web-browser-automation configure --save-to-user-secrets true""");
+
+        var exitCode = await result.InvokeAsync().DefaultTimeout();
+
+        Assert.Equal(ExitCodeConstants.InvalidCommand, exitCode);
+        Assert.Equal(0, backchannel.ExecuteResourceCommandCallCount);
+        Assert.Equal("Option '--save-to-user-secrets' is disabled.", Assert.Single(interactionService.DisplayedErrors));
+    }
+
+    [Fact]
     public async Task ResourceCommand_DisplaysValidationErrorArgumentNamesAsCliOptions()
     {
         using var workspace = TemporaryWorkspace.Create(outputHelper);
@@ -1972,7 +2000,8 @@ public class ResourceCommandTests(ITestOutputHelper outputHelper)
         bool required = false,
         string? value = null,
         Dictionary<string, string?>? options = null,
-        bool allowCustomChoice = false)
+        bool allowCustomChoice = false,
+        bool disabled = false)
     {
         return new ResourceSnapshotCommandArgument
         {
@@ -1982,7 +2011,8 @@ public class ResourceCommandTests(ITestOutputHelper outputHelper)
             Required = required,
             Value = value,
             Options = options,
-            AllowCustomChoice = allowCustomChoice
+            AllowCustomChoice = allowCustomChoice,
+            Disabled = disabled
         };
     }
 }

--- a/tests/Aspire.Hosting.Browsers.Tests/BrowserLogsBuilderExtensionsTests.cs
+++ b/tests/Aspire.Hosting.Browsers.Tests/BrowserLogsBuilderExtensionsTests.cs
@@ -135,6 +135,42 @@ public class BrowserLogsBuilderExtensionsTests(ITestOutputHelper testOutputHelpe
     }
 
     [Fact]
+    public async Task WithBrowserLogs_ConfigureCommandProfileInputDefaultsToCurrentConfigurationBeforeDependenciesLoad()
+    {
+        using var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Run);
+
+        var web = builder.AddResource(new TestHttpResource("web"))
+            .WithHttpEndpoint(targetPort: 8080)
+            .WithEndpoint("http", endpoint => endpoint.AllocatedEndpoint = new AllocatedEndpoint(endpoint, "localhost", 8080))
+            .WithInitialState(new CustomResourceSnapshot
+            {
+                ResourceType = "TestHttp",
+                State = new ResourceStateSnapshot(KnownResourceStates.Running, KnownResourceStateStyles.Success),
+                Properties = []
+            });
+
+        web.WithBrowserLogs(browser: "custom-browser", profile: "Profile 1", userDataMode: BrowserUserDataMode.Shared);
+
+        using var app = builder.Build();
+        var browserLogsResource = Assert.Single(app.Services.GetRequiredService<DistributedApplicationModel>().Resources.OfType<BrowserLogsResource>());
+        var configureCommand = Assert.Single(browserLogsResource.Annotations.OfType<ResourceCommandAnnotation>(), annotation => annotation.Name == BrowserLogsBuilderExtensions.ConfigureTrackedBrowserCommandName);
+        var arguments = configureCommand.Arguments;
+        var profileInput = arguments.Single(input => input.Name == BrowserLogsConfigurationManager.ProfileInputName);
+
+        await profileInput.DynamicLoading!.LoadCallback(new LoadInputContext
+        {
+            Input = profileInput,
+            AllInputs = new InteractionInputCollection(arguments),
+            Services = app.Services,
+            CancellationToken = CancellationToken.None
+        });
+
+        Assert.Equal("Profile 1", profileInput.Value);
+        Assert.False(profileInput.Disabled);
+        Assert.Contains(profileInput.Options!, option => option.Key == "Profile 1" && option.Value == "Profile 1");
+    }
+
+    [Fact]
     public void WithBrowserLogs_ConfigureCommandSaveInputDescribesUnavailableUserSecrets()
     {
         using var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Run);

--- a/tests/Aspire.Hosting.Browsers.Tests/BrowserLogsBuilderExtensionsTests.cs
+++ b/tests/Aspire.Hosting.Browsers.Tests/BrowserLogsBuilderExtensionsTests.cs
@@ -80,6 +80,60 @@ public class BrowserLogsBuilderExtensionsTests(ITestOutputHelper testOutputHelpe
     }
 
     [Fact]
+    public async Task WithBrowserLogs_ConfigureCommandInputsDefaultToCurrentConfiguration()
+    {
+        using var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Run);
+
+        var web = builder.AddResource(new TestHttpResource("web"))
+            .WithHttpEndpoint(targetPort: 8080)
+            .WithEndpoint("http", endpoint => endpoint.AllocatedEndpoint = new AllocatedEndpoint(endpoint, "localhost", 8080))
+            .WithInitialState(new CustomResourceSnapshot
+            {
+                ResourceType = "TestHttp",
+                State = new ResourceStateSnapshot(KnownResourceStates.Running, KnownResourceStateStyles.Success),
+                Properties = []
+            });
+
+        web.WithBrowserLogs(browser: "custom-browser", profile: "Profile 1", userDataMode: BrowserUserDataMode.Shared);
+
+        using var app = builder.Build();
+        var browserLogsResource = Assert.Single(app.Services.GetRequiredService<DistributedApplicationModel>().Resources.OfType<BrowserLogsResource>());
+        var configureCommand = Assert.Single(browserLogsResource.Annotations.OfType<ResourceCommandAnnotation>(), annotation => annotation.Name == BrowserLogsBuilderExtensions.ConfigureTrackedBrowserCommandName);
+        var arguments = configureCommand.Arguments;
+        var browserInput = arguments.Single(input => input.Name == BrowserLogsConfigurationManager.BrowserInputName);
+        var userDataModeInput = arguments.Single(input => input.Name == BrowserLogsConfigurationManager.UserDataModeInputName);
+        var profileInput = arguments.Single(input => input.Name == BrowserLogsConfigurationManager.ProfileInputName);
+
+        await browserInput.DynamicLoading!.LoadCallback(new LoadInputContext
+        {
+            Input = browserInput,
+            AllInputs = new InteractionInputCollection(arguments),
+            Services = app.Services,
+            CancellationToken = CancellationToken.None
+        });
+        await userDataModeInput.DynamicLoading!.LoadCallback(new LoadInputContext
+        {
+            Input = userDataModeInput,
+            AllInputs = new InteractionInputCollection(arguments),
+            Services = app.Services,
+            CancellationToken = CancellationToken.None
+        });
+        await profileInput.DynamicLoading!.LoadCallback(new LoadInputContext
+        {
+            Input = profileInput,
+            AllInputs = new InteractionInputCollection(arguments),
+            Services = app.Services,
+            CancellationToken = CancellationToken.None
+        });
+
+        Assert.Equal("custom-browser", browserInput.Value);
+        Assert.Equal(nameof(BrowserUserDataMode.Shared), userDataModeInput.Value);
+        Assert.Equal("Profile 1", profileInput.Value);
+        Assert.Contains(browserInput.Options!, option => option.Key == "custom-browser" && option.Value == "custom-browser");
+        Assert.Contains(profileInput.Options!, option => option.Key == "Profile 1" && option.Value == "Profile 1");
+    }
+
+    [Fact]
     public void WithBrowserLogs_UsesResourceSpecificConfigurationWhenArgumentsAreOmitted()
     {
         using var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Run);

--- a/tests/Aspire.Hosting.Browsers.Tests/BrowserLogsBuilderExtensionsTests.cs
+++ b/tests/Aspire.Hosting.Browsers.Tests/BrowserLogsBuilderExtensionsTests.cs
@@ -10,7 +10,6 @@ using System.Text;
 using System.Text.Json;
 using System.Text.Json.Nodes;
 using Aspire.Hosting.ApplicationModel;
-using Aspire.Hosting.Tests;
 using Aspire.Hosting.Browsers.Resources;
 using Aspire.Hosting.Tests.Utils;
 using Aspire.Hosting.Utils;
@@ -343,10 +342,8 @@ public class BrowserLogsBuilderExtensionsTests(ITestOutputHelper testOutputHelpe
     public async Task WithBrowserLogs_ConfigureCommandSavesResourceScopedBrowserSettingsAndAppliesImmediately()
     {
         using var builder = TestDistributedApplicationBuilder.Create(testOutputHelper);
-        var interactionService = new TestInteractionService();
         var userSecretsManager = new RecordingUserSecretsManager();
         builder.Configuration[KnownConfigNames.VersionCheckDisabled] = "true";
-        builder.Services.AddSingleton<IInteractionService>(interactionService);
         builder.Services.AddSingleton<IUserSecretsManager>(userSecretsManager);
 
         var web = builder.AddResource(new TestHttpResource("web"))
@@ -365,32 +362,8 @@ public class BrowserLogsBuilderExtensionsTests(ITestOutputHelper testOutputHelpe
         await app.StartAsync();
 
         var browserLogsResource = app.Services.GetRequiredService<DistributedApplicationModel>().Resources.OfType<BrowserLogsResource>().Single();
-        var commandTask = app.ResourceCommands.ExecuteCommandAsync(browserLogsResource, BrowserLogsBuilderExtensions.ConfigureTrackedBrowserCommandName);
-        var interaction = await interactionService.Interactions.Reader.ReadAsync().DefaultTimeout();
-
-        Assert.Equal(BrowserCommandStrings.ConfigureTrackedBrowserName, interaction.Title);
-        Assert.Equal(BrowserCommandStrings.ConfigureTrackedBrowserPromptMessage, interaction.Message);
-        Assert.Equal(BrowserCommandStrings.ConfigureTrackedBrowserSaveButton, ((InputsDialogInteractionOptions)interaction.Options!).PrimaryButtonText);
-        Assert.Collection(interaction.Inputs,
-            input => Assert.Equal("scope", input.Name),
-            input => Assert.Equal("browser", input.Name),
-            input => Assert.Equal("userDataMode", input.Name),
-            input => Assert.Equal("profile", input.Name),
-            input =>
-            {
-                Assert.Equal("saveToUserSecrets", input.Name);
-                Assert.Equal("true", input.Value);
-                Assert.False(input.Disabled);
-                Assert.Equal(BrowserCommandStrings.ConfigureTrackedBrowserSaveToUserSecretsDescriptionConfigured, input.Description);
-            });
-
-        interaction.Inputs["scope"].Value = "resource";
-        interaction.Inputs["browser"].Value = "msedge";
-        interaction.Inputs["userDataMode"].Value = nameof(BrowserUserDataMode.Shared);
-        interaction.Inputs["profile"].Value = "Default";
-        interaction.CompletionTcs.SetResult(InteractionResult.Ok(interaction.Inputs));
-
-        var result = await commandTask.DefaultTimeout();
+        var arguments = CreateConfigureArguments("resource", "msedge", nameof(BrowserUserDataMode.Shared), "Default", saveToUserSecrets: "true");
+        var result = await app.ResourceCommands.ExecuteCommandAsync(browserLogsResource, BrowserLogsBuilderExtensions.ConfigureTrackedBrowserCommandName, arguments);
 
         Assert.True(result.Success);
         Assert.Equal("msedge", userSecretsManager.Secrets[$"{BrowserLogsBuilderExtensions.BrowserLogsConfigurationSectionName}:web:{BrowserLogsBuilderExtensions.BrowserConfigurationKey}"]);
@@ -409,13 +382,11 @@ public class BrowserLogsBuilderExtensionsTests(ITestOutputHelper testOutputHelpe
     public async Task WithBrowserLogs_ConfigureCommandAppliesRuntimeSettingsWhenUserSecretsAreUnavailable()
     {
         using var builder = TestDistributedApplicationBuilder.Create(testOutputHelper);
-        var interactionService = new TestInteractionService();
         var userSecretsManager = new RecordingUserSecretsManager
         {
             IsAvailable = false
         };
         builder.Configuration[KnownConfigNames.VersionCheckDisabled] = "true";
-        builder.Services.AddSingleton<IInteractionService>(interactionService);
         builder.Services.AddSingleton<IUserSecretsManager>(userSecretsManager);
 
         var web = builder.AddResource(new TestHttpResource("web"))
@@ -434,21 +405,8 @@ public class BrowserLogsBuilderExtensionsTests(ITestOutputHelper testOutputHelpe
         await app.StartAsync();
 
         var browserLogsResource = app.Services.GetRequiredService<DistributedApplicationModel>().Resources.OfType<BrowserLogsResource>().Single();
-        var commandTask = app.ResourceCommands.ExecuteCommandAsync(browserLogsResource, BrowserLogsBuilderExtensions.ConfigureTrackedBrowserCommandName);
-        var interaction = await interactionService.Interactions.Reader.ReadAsync().DefaultTimeout();
-
-        var saveToUserSecrets = interaction.Inputs["saveToUserSecrets"];
-        Assert.True(saveToUserSecrets.Disabled);
-        Assert.Null(saveToUserSecrets.Value);
-        Assert.Equal(BrowserCommandStrings.ConfigureTrackedBrowserSaveToUserSecretsDescriptionNotConfigured, saveToUserSecrets.Description);
-
-        interaction.Inputs["scope"].Value = "resource";
-        interaction.Inputs["browser"].Value = "msedge";
-        interaction.Inputs["userDataMode"].Value = nameof(BrowserUserDataMode.Shared);
-        interaction.Inputs["profile"].Value = "Default";
-        interaction.CompletionTcs.SetResult(InteractionResult.Ok(interaction.Inputs));
-
-        var result = await commandTask.DefaultTimeout();
+        var arguments = CreateConfigureArguments("resource", "msedge", nameof(BrowserUserDataMode.Shared), "Default");
+        var result = await app.ResourceCommands.ExecuteCommandAsync(browserLogsResource, BrowserLogsBuilderExtensions.ConfigureTrackedBrowserCommandName, arguments);
 
         Assert.True(result.Success);
         Assert.Equal(string.Format(CultureInfo.CurrentCulture, BrowserCommandStrings.ConfigureTrackedBrowserApplied, "web"), result.Message);
@@ -467,10 +425,8 @@ public class BrowserLogsBuilderExtensionsTests(ITestOutputHelper testOutputHelpe
     public async Task WithBrowserLogs_ConfigureCommandDoesNotOverrideExplicitBuilderSettings()
     {
         using var builder = TestDistributedApplicationBuilder.Create(testOutputHelper);
-        var interactionService = new TestInteractionService();
         var userSecretsManager = new RecordingUserSecretsManager();
         builder.Configuration[KnownConfigNames.VersionCheckDisabled] = "true";
-        builder.Services.AddSingleton<IInteractionService>(interactionService);
         builder.Services.AddSingleton<IUserSecretsManager>(userSecretsManager);
 
         var web = builder.AddResource(new TestHttpResource("web"))
@@ -489,16 +445,8 @@ public class BrowserLogsBuilderExtensionsTests(ITestOutputHelper testOutputHelpe
         await app.StartAsync();
 
         var browserLogsResource = app.Services.GetRequiredService<DistributedApplicationModel>().Resources.OfType<BrowserLogsResource>().Single();
-        var commandTask = app.ResourceCommands.ExecuteCommandAsync(browserLogsResource, BrowserLogsBuilderExtensions.ConfigureTrackedBrowserCommandName);
-        var interaction = await interactionService.Interactions.Reader.ReadAsync().DefaultTimeout();
-
-        interaction.Inputs["scope"].Value = "resource";
-        interaction.Inputs["browser"].Value = "msedge";
-        interaction.Inputs["userDataMode"].Value = nameof(BrowserUserDataMode.Shared);
-        interaction.Inputs["profile"].Value = "__aspire_browser_default__";
-        interaction.CompletionTcs.SetResult(InteractionResult.Ok(interaction.Inputs));
-
-        var result = await commandTask.DefaultTimeout();
+        var arguments = CreateConfigureArguments("resource", "msedge", nameof(BrowserUserDataMode.Shared), "__aspire_browser_default__", saveToUserSecrets: "true");
+        var result = await app.ResourceCommands.ExecuteCommandAsync(browserLogsResource, BrowserLogsBuilderExtensions.ConfigureTrackedBrowserCommandName, arguments);
 
         Assert.True(result.Success);
         Assert.Equal("msedge", userSecretsManager.Secrets[$"{BrowserLogsBuilderExtensions.BrowserLogsConfigurationSectionName}:web:{BrowserLogsBuilderExtensions.BrowserConfigurationKey}"]);
@@ -515,10 +463,8 @@ public class BrowserLogsBuilderExtensionsTests(ITestOutputHelper testOutputHelpe
     public async Task WithBrowserLogs_ConfigureCommandSavesGlobalSettingsAndClearsProfile()
     {
         using var builder = TestDistributedApplicationBuilder.Create(testOutputHelper);
-        var interactionService = new TestInteractionService();
         var userSecretsManager = new RecordingUserSecretsManager();
         builder.Configuration[KnownConfigNames.VersionCheckDisabled] = "true";
-        builder.Services.AddSingleton<IInteractionService>(interactionService);
         builder.Services.AddSingleton<IUserSecretsManager>(userSecretsManager);
         builder.Configuration[$"{BrowserLogsBuilderExtensions.BrowserLogsConfigurationSectionName}:{BrowserLogsBuilderExtensions.ProfileConfigurationKey}"] = "Profile 1";
 
@@ -538,16 +484,8 @@ public class BrowserLogsBuilderExtensionsTests(ITestOutputHelper testOutputHelpe
         await app.StartAsync();
 
         var browserLogsResource = app.Services.GetRequiredService<DistributedApplicationModel>().Resources.OfType<BrowserLogsResource>().Single();
-        var commandTask = app.ResourceCommands.ExecuteCommandAsync(browserLogsResource, BrowserLogsBuilderExtensions.ConfigureTrackedBrowserCommandName);
-        var interaction = await interactionService.Interactions.Reader.ReadAsync().DefaultTimeout();
-
-        interaction.Inputs["scope"].Value = "global";
-        interaction.Inputs["browser"].Value = "chrome";
-        interaction.Inputs["userDataMode"].Value = nameof(BrowserUserDataMode.Isolated);
-        interaction.Inputs["profile"].Value = "__aspire_browser_default__";
-        interaction.CompletionTcs.SetResult(InteractionResult.Ok(interaction.Inputs));
-
-        var result = await commandTask.DefaultTimeout();
+        var arguments = CreateConfigureArguments("global", "chrome", nameof(BrowserUserDataMode.Isolated), "__aspire_browser_default__", saveToUserSecrets: "true");
+        var result = await app.ResourceCommands.ExecuteCommandAsync(browserLogsResource, BrowserLogsBuilderExtensions.ConfigureTrackedBrowserCommandName, arguments);
 
         Assert.True(result.Success);
         Assert.Equal("chrome", userSecretsManager.Secrets[$"{BrowserLogsBuilderExtensions.BrowserLogsConfigurationSectionName}:{BrowserLogsBuilderExtensions.BrowserConfigurationKey}"]);
@@ -566,12 +504,10 @@ public class BrowserLogsBuilderExtensionsTests(ITestOutputHelper testOutputHelpe
     public async Task WithBrowserLogs_ConfigureCommandDoesNotApplyRuntimeSettingsWhenUserSecretSaveFails()
     {
         using var builder = TestDistributedApplicationBuilder.Create(testOutputHelper);
-        var interactionService = new TestInteractionService();
         var userSecretsManager = new RecordingUserSecretsManager();
         builder.Configuration[KnownConfigNames.VersionCheckDisabled] = "true";
         builder.Configuration[$"{BrowserLogsBuilderExtensions.BrowserLogsConfigurationSectionName}:{BrowserLogsBuilderExtensions.BrowserConfigurationKey}"] = "chrome";
         builder.Configuration[$"{BrowserLogsBuilderExtensions.BrowserLogsConfigurationSectionName}:{BrowserLogsBuilderExtensions.UserDataModeConfigurationKey}"] = nameof(BrowserUserDataMode.Shared);
-        builder.Services.AddSingleton<IInteractionService>(interactionService);
         builder.Services.AddSingleton<IUserSecretsManager>(userSecretsManager);
 
         var userDataModeKey = $"{BrowserLogsBuilderExtensions.BrowserLogsConfigurationSectionName}:web:{BrowserLogsBuilderExtensions.UserDataModeConfigurationKey}";
@@ -593,16 +529,8 @@ public class BrowserLogsBuilderExtensionsTests(ITestOutputHelper testOutputHelpe
         await app.StartAsync();
 
         var browserLogsResource = app.Services.GetRequiredService<DistributedApplicationModel>().Resources.OfType<BrowserLogsResource>().Single();
-        var commandTask = app.ResourceCommands.ExecuteCommandAsync(browserLogsResource, BrowserLogsBuilderExtensions.ConfigureTrackedBrowserCommandName);
-        var interaction = await interactionService.Interactions.Reader.ReadAsync().DefaultTimeout();
-
-        interaction.Inputs["scope"].Value = "resource";
-        interaction.Inputs["browser"].Value = "msedge";
-        interaction.Inputs["userDataMode"].Value = nameof(BrowserUserDataMode.Isolated);
-        interaction.Inputs["profile"].Value = "__aspire_browser_default__";
-        interaction.CompletionTcs.SetResult(InteractionResult.Ok(interaction.Inputs));
-
-        var result = await commandTask.DefaultTimeout();
+        var arguments = CreateConfigureArguments("resource", "msedge", nameof(BrowserUserDataMode.Isolated), "__aspire_browser_default__", saveToUserSecrets: "true");
+        var result = await app.ResourceCommands.ExecuteCommandAsync(browserLogsResource, BrowserLogsBuilderExtensions.ConfigureTrackedBrowserCommandName, arguments);
 
         Assert.False(result.Success);
         Assert.Contains(userDataModeKey, result.Message, StringComparison.Ordinal);
@@ -621,10 +549,8 @@ public class BrowserLogsBuilderExtensionsTests(ITestOutputHelper testOutputHelpe
     public async Task WithBrowserLogs_ConfigureCommandRefreshesAllBrowserLogsResourcesForGlobalSettings()
     {
         using var builder = TestDistributedApplicationBuilder.Create(testOutputHelper);
-        var interactionService = new TestInteractionService();
         var userSecretsManager = new RecordingUserSecretsManager();
         builder.Configuration[KnownConfigNames.VersionCheckDisabled] = "true";
-        builder.Services.AddSingleton<IInteractionService>(interactionService);
         builder.Services.AddSingleton<IUserSecretsManager>(userSecretsManager);
 
         var web = builder.AddResource(new TestHttpResource("web"))
@@ -656,16 +582,8 @@ public class BrowserLogsBuilderExtensionsTests(ITestOutputHelper testOutputHelpe
         var browserLogsResources = app.Services.GetRequiredService<DistributedApplicationModel>().Resources.OfType<BrowserLogsResource>().ToArray();
         var webBrowserLogsResource = browserLogsResources.Single(resource => resource.ParentResource.Name == "web");
         var adminBrowserLogsResource = browserLogsResources.Single(resource => resource.ParentResource.Name == "admin");
-        var commandTask = app.ResourceCommands.ExecuteCommandAsync(webBrowserLogsResource, BrowserLogsBuilderExtensions.ConfigureTrackedBrowserCommandName);
-        var interaction = await interactionService.Interactions.Reader.ReadAsync().DefaultTimeout();
-
-        interaction.Inputs["scope"].Value = "global";
-        interaction.Inputs["browser"].Value = "chrome";
-        interaction.Inputs["userDataMode"].Value = nameof(BrowserUserDataMode.Isolated);
-        interaction.Inputs["profile"].Value = "__aspire_browser_default__";
-        interaction.CompletionTcs.SetResult(InteractionResult.Ok(interaction.Inputs));
-
-        var result = await commandTask.DefaultTimeout();
+        var arguments = CreateConfigureArguments("global", "chrome", nameof(BrowserUserDataMode.Isolated), "__aspire_browser_default__");
+        var result = await app.ResourceCommands.ExecuteCommandAsync(webBrowserLogsResource, BrowserLogsBuilderExtensions.ConfigureTrackedBrowserCommandName, arguments);
 
         Assert.True(result.Success);
 
@@ -681,10 +599,8 @@ public class BrowserLogsBuilderExtensionsTests(ITestOutputHelper testOutputHelpe
     public async Task WithBrowserLogs_ConfigureCommandValidatesEffectiveConfigurationBeforeSaving()
     {
         using var builder = TestDistributedApplicationBuilder.Create(testOutputHelper);
-        var interactionService = new TestInteractionService();
         var userSecretsManager = new RecordingUserSecretsManager();
         builder.Configuration[KnownConfigNames.VersionCheckDisabled] = "true";
-        builder.Services.AddSingleton<IInteractionService>(interactionService);
         builder.Services.AddSingleton<IUserSecretsManager>(userSecretsManager);
 
         var web = builder.AddResource(new TestHttpResource("web"))
@@ -703,19 +619,10 @@ public class BrowserLogsBuilderExtensionsTests(ITestOutputHelper testOutputHelpe
         await app.StartAsync();
 
         var browserLogsResource = app.Services.GetRequiredService<DistributedApplicationModel>().Resources.OfType<BrowserLogsResource>().Single();
-        var commandTask = app.ResourceCommands.ExecuteCommandAsync(browserLogsResource, BrowserLogsBuilderExtensions.ConfigureTrackedBrowserCommandName);
-        var interaction = await interactionService.Interactions.Reader.ReadAsync().DefaultTimeout();
-
-        interaction.Inputs["scope"].Value = "resource";
-        interaction.Inputs["browser"].Value = "chrome";
-        interaction.Inputs["userDataMode"].Value = nameof(BrowserUserDataMode.Isolated);
-        interaction.Inputs["profile"].Value = "__aspire_browser_default__";
-        interaction.CompletionTcs.SetResult(InteractionResult.Ok(interaction.Inputs));
-
-        var result = await commandTask.DefaultTimeout();
+        var arguments = CreateConfigureArguments("resource", "chrome", nameof(BrowserUserDataMode.Isolated), "__aspire_browser_default__");
+        var result = await app.ResourceCommands.ExecuteCommandAsync(browserLogsResource, BrowserLogsBuilderExtensions.ConfigureTrackedBrowserCommandName, arguments);
 
         Assert.False(result.Success);
-        Assert.Contains("Profiles can only be selected", result.Message, StringComparison.Ordinal);
         Assert.Empty(userSecretsManager.Secrets);
         Assert.Empty(userSecretsManager.DeletedSecrets);
 
@@ -1704,6 +1611,20 @@ public class BrowserLogsBuilderExtensionsTests(ITestOutputHelper testOutputHelpe
     }
 
     private sealed class TestHttpResource(string name) : Resource(name), IResourceWithEndpoints;
+
+#pragma warning disable ASPIREINTERACTION001
+    private static InteractionInputCollection CreateConfigureArguments(string scope, string browser, string userDataMode, string profile, string? saveToUserSecrets = null)
+    {
+        return new InteractionInputCollection(
+        [
+            new InteractionInput { Name = "scope", InputType = InputType.Choice, Value = scope },
+            new InteractionInput { Name = "browser", InputType = InputType.Choice, Value = browser },
+            new InteractionInput { Name = "userDataMode", InputType = InputType.Choice, Value = userDataMode },
+            new InteractionInput { Name = "profile", InputType = InputType.Choice, Value = profile },
+            new InteractionInput { Name = "saveToUserSecrets", InputType = InputType.Boolean, Value = saveToUserSecrets },
+        ]);
+    }
+#pragma warning restore ASPIREINTERACTION001
 
     private static bool HasProperty(CustomResourceSnapshot snapshot, string name, object expectedValue) =>
         snapshot.Properties.Any(property => property.Name == name && Equals(property.Value, expectedValue));

--- a/tests/Aspire.Hosting.Browsers.Tests/BrowserLogsBuilderExtensionsTests.cs
+++ b/tests/Aspire.Hosting.Browsers.Tests/BrowserLogsBuilderExtensionsTests.cs
@@ -129,7 +129,8 @@ public class BrowserLogsBuilderExtensionsTests(ITestOutputHelper testOutputHelpe
         Assert.Equal("custom-browser", browserInput.Value);
         Assert.Equal(nameof(BrowserUserDataMode.Shared), userDataModeInput.Value);
         Assert.Equal("Profile 1", profileInput.Value);
-        Assert.Contains(browserInput.Options!, option => option.Key == "custom-browser" && option.Value == "custom-browser");
+        var knownBrowserOptionKeys = new HashSet<string>(["msedge", "chrome", "chromium"], StringComparer.OrdinalIgnoreCase);
+        Assert.All(browserInput.Options!, option => Assert.Contains(option.Key, knownBrowserOptionKeys));
         Assert.Contains(profileInput.Options!, option => option.Key == "Profile 1" && option.Value == "Profile 1");
     }
 

--- a/tests/Aspire.Hosting.Browsers.Tests/BrowserLogsBuilderExtensionsTests.cs
+++ b/tests/Aspire.Hosting.Browsers.Tests/BrowserLogsBuilderExtensionsTests.cs
@@ -134,6 +134,34 @@ public class BrowserLogsBuilderExtensionsTests(ITestOutputHelper testOutputHelpe
     }
 
     [Fact]
+    public void WithBrowserLogs_ConfigureCommandSaveInputDescribesUnavailableUserSecrets()
+    {
+        using var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Run);
+
+        var web = builder.AddResource(new TestHttpResource("web"))
+            .WithHttpEndpoint(targetPort: 8080)
+            .WithEndpoint("http", endpoint => endpoint.AllocatedEndpoint = new AllocatedEndpoint(endpoint, "localhost", 8080))
+            .WithInitialState(new CustomResourceSnapshot
+            {
+                ResourceType = "TestHttp",
+                State = new ResourceStateSnapshot(KnownResourceStates.Running, KnownResourceStateStyles.Success),
+                Properties = []
+            });
+
+        web.WithBrowserLogs();
+
+        using var app = builder.Build();
+        var browserLogsResource = Assert.Single(app.Services.GetRequiredService<DistributedApplicationModel>().Resources.OfType<BrowserLogsResource>());
+        var configureCommand = Assert.Single(browserLogsResource.Annotations.OfType<ResourceCommandAnnotation>(), annotation => annotation.Name == BrowserLogsBuilderExtensions.ConfigureTrackedBrowserCommandName);
+        var arguments = configureCommand.Arguments;
+        var saveInput = arguments.Single(input => input.Name == BrowserLogsConfigurationManager.SaveToUserSecretsInputName);
+
+        Assert.True(saveInput.Disabled);
+        Assert.Null(saveInput.Value);
+        Assert.Equal(BrowserCommandStrings.ConfigureTrackedBrowserSaveToUserSecretsDescriptionNotConfigured, saveInput.Description);
+    }
+
+    [Fact]
     public void WithBrowserLogs_UsesResourceSpecificConfigurationWhenArgumentsAreOmitted()
     {
         using var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Run);

--- a/tests/Aspire.Hosting.EntityFrameworkCore.Tests/EFMigrationCommandsTests.cs
+++ b/tests/Aspire.Hosting.EntityFrameworkCore.Tests/EFMigrationCommandsTests.cs
@@ -66,6 +66,12 @@ public class EFMigrationCommandsTests
 
         Assert.NotNull(addCommand);
         Assert.Contains("Add Migration", addCommand.DisplayName);
+
+#pragma warning disable ASPIREINTERACTION001 // InteractionInput is used to describe resource command arguments.
+        var nameArgument = Assert.Single(addCommand.Arguments);
+#pragma warning restore ASPIREINTERACTION001
+        Assert.Equal("name", nameArgument.Name);
+        Assert.True(nameArgument.Required);
     }
 
     [Fact]

--- a/tests/Aspire.Hosting.Tests/AddParameterTests.cs
+++ b/tests/Aspire.Hosting.Tests/AddParameterTests.cs
@@ -422,6 +422,24 @@ public class AddParameterTests
     }
 
     [Fact]
+    public void ParameterCreateInput_WithNameOverride_UsesOverrideAsInputName()
+    {
+        // Arrange
+        var appBuilder = DistributedApplication.CreateBuilder();
+        var parameter = appBuilder.AddParameter("test")
+            .WithDescription("Test description");
+
+        // Act
+        var input = parameter.Resource.CreateInput("value");
+
+        // Assert
+        Assert.Equal("value", input.Name);
+        Assert.Equal("test", input.Label);
+        Assert.Equal("Test description", input.Description);
+        Assert.Equal(string.Format(InteractionStrings.ParametersInputsParameterPlaceholder, "test"), input.Placeholder);
+    }
+
+    [Fact]
     public void ParameterCreateInput_ForSecretParameter_ReturnsSecretTextInput()
     {
         // Arrange
@@ -466,6 +484,34 @@ public class AddParameterTests
         Assert.Equal("Custom: Custom description", input.Description);
         Assert.Equal("Enter number", input.Placeholder);
         Assert.True(input.EnableDescriptionMarkdown);
+    }
+
+    [Fact]
+    public void ParameterCreateInput_WithCustomGeneratorAndNameOverride_UsesOverrideAsInputName()
+    {
+        // Arrange
+        var appBuilder = DistributedApplication.CreateBuilder();
+        var parameter = appBuilder.AddParameter("test")
+            .WithCustomInput(_ => new InteractionInput
+            {
+                Name = "CustomInput",
+                InputType = InputType.Number,
+                Label = "Custom Label",
+                Description = "Custom description",
+                Placeholder = "Enter number",
+                Value = "5"
+            });
+
+        // Act
+        var input = parameter.Resource.CreateInput("value");
+
+        // Assert
+        Assert.Equal("value", input.Name);
+        Assert.Equal(InputType.Number, input.InputType);
+        Assert.Equal("Custom Label", input.Label);
+        Assert.Equal("Custom description", input.Description);
+        Assert.Equal("Enter number", input.Placeholder);
+        Assert.Equal("5", input.Value);
     }
 
     [Fact]

--- a/tests/Aspire.Hosting.Tests/AddParameterTests.cs
+++ b/tests/Aspire.Hosting.Tests/AddParameterTests.cs
@@ -440,6 +440,22 @@ public class AddParameterTests
     }
 
     [Fact]
+    public void ParameterCreateInput_WithDynamicLoading_SetsDynamicLoading()
+    {
+        var appBuilder = DistributedApplication.CreateBuilder();
+        var parameter = appBuilder.AddParameter("test");
+        var dynamicLoading = new InputLoadOptions
+        {
+            AlwaysLoadOnStart = true,
+            LoadCallback = _ => Task.CompletedTask
+        };
+
+        var input = parameter.Resource.CreateInput(dynamicLoading: dynamicLoading);
+
+        Assert.Same(dynamicLoading, input.DynamicLoading);
+    }
+
+    [Fact]
     public void ParameterCreateInput_ForSecretParameter_ReturnsSecretTextInput()
     {
         // Arrange
@@ -512,6 +528,28 @@ public class AddParameterTests
         Assert.Equal("Custom description", input.Description);
         Assert.Equal("Enter number", input.Placeholder);
         Assert.Equal("5", input.Value);
+    }
+
+    [Fact]
+    public void ParameterCreateInput_WithCustomGeneratorAndDynamicLoading_UsesDynamicLoading()
+    {
+        var appBuilder = DistributedApplication.CreateBuilder();
+        var parameter = appBuilder.AddParameter("test")
+            .WithCustomInput(_ => new InteractionInput
+            {
+                Name = "CustomInput",
+                InputType = InputType.Number,
+                Label = "Custom Label"
+            });
+        var dynamicLoading = new InputLoadOptions
+        {
+            AlwaysLoadOnStart = true,
+            LoadCallback = _ => Task.CompletedTask
+        };
+
+        var input = parameter.Resource.CreateInput(dynamicLoading: dynamicLoading);
+
+        Assert.Same(dynamicLoading, input.DynamicLoading);
     }
 
     [Fact]

--- a/tests/Aspire.Hosting.Tests/Orchestrator/ParameterProcessorTests.cs
+++ b/tests/Aspire.Hosting.Tests/Orchestrator/ParameterProcessorTests.cs
@@ -870,6 +870,32 @@ public class ParameterProcessorTests
     }
 
     [Fact]
+    public async Task ProcessParameterAsync_WithInteractionServiceAvailable_AddsSetParameterValueArgument()
+    {
+        // Arrange
+        var testInteractionService = new TestInteractionService { IsAvailable = true };
+        var parameterProcessor = CreateParameterProcessor(interactionService: testInteractionService);
+        var parameter = CreateParameterResource("testParam", "testValue");
+
+        // Act
+        await parameterProcessor.InitializeParametersAsync([parameter]).DefaultTimeout();
+
+        // Assert
+        var setValueCommand = parameter.Annotations.OfType<ResourceCommandAnnotation>()
+            .Single(a => a.Name == KnownResourceCommands.SetParameterCommand);
+
+        Assert.Collection(
+            setValueCommand.Arguments,
+            valueInput =>
+            {
+                Assert.Equal(ParameterProcessor.SetParameterValueName, valueInput.Name);
+                Assert.Equal("testParam", valueInput.Label);
+                Assert.Equal("testValue", valueInput.Value);
+            },
+            saveInput => Assert.Equal(ParameterProcessor.SaveToUserSecretsName, saveInput.Name));
+    }
+
+    [Fact]
     public async Task ProcessParameterAsync_WithInteractionServiceNotAvailable_DoesNotAddSetParameterCommand()
     {
         // Arrange

--- a/tests/Aspire.Hosting.Tests/Orchestrator/ParameterProcessorTests.cs
+++ b/tests/Aspire.Hosting.Tests/Orchestrator/ParameterProcessorTests.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Globalization;
 using System.Text.Json.Nodes;
 using Aspire.Dashboard.Model;
 using Aspire.Hosting.Pipelines;
@@ -890,10 +891,62 @@ public class ParameterProcessorTests
             {
                 Assert.Equal(ParameterProcessor.SetParameterValueName, valueInput.Name);
                 Assert.Equal("testParam", valueInput.Label);
-                Assert.Equal("testValue", valueInput.Value);
+                Assert.Null(valueInput.Value);
+                Assert.NotNull(valueInput.DynamicLoading);
                 Assert.True(valueInput.Required);
             },
             saveInput => Assert.Equal(ParameterProcessor.SaveToUserSecretsName, saveInput.Name));
+    }
+
+    [Fact]
+    public async Task ProcessParameterAsync_WithExistingValue_LoadsSetParameterValueArgumentOnStart()
+    {
+        var testInteractionService = new TestInteractionService { IsAvailable = true };
+        var parameterProcessor = CreateParameterProcessor(interactionService: testInteractionService);
+        var parameter = CreateParameterResource("testParam", "testValue");
+
+        await parameterProcessor.InitializeParametersAsync([parameter]).DefaultTimeout();
+
+        var setValueCommand = parameter.Annotations.OfType<ResourceCommandAnnotation>()
+            .Single(a => a.Name == KnownResourceCommands.SetParameterCommand);
+        var arguments = new InteractionInputCollection(setValueCommand.Arguments);
+        var valueInput = arguments[ParameterProcessor.SetParameterValueName];
+
+        await valueInput.DynamicLoading!.LoadCallback(new LoadInputContext
+        {
+            Input = valueInput,
+            AllInputs = arguments,
+            Services = new ServiceCollection().BuildServiceProvider(),
+            CancellationToken = CancellationToken.None
+        }).DefaultTimeout();
+
+        Assert.Equal("testValue", valueInput.Value);
+    }
+
+    [Fact]
+    public async Task ProcessParameterAsync_WithExistingInputValue_DoesNotOverwriteSetParameterValueArgumentOnStart()
+    {
+        var testInteractionService = new TestInteractionService { IsAvailable = true };
+        var parameterProcessor = CreateParameterProcessor(interactionService: testInteractionService);
+        var parameter = CreateParameterResource("testParam", "testValue");
+
+        await parameterProcessor.InitializeParametersAsync([parameter]).DefaultTimeout();
+
+        var setValueCommand = parameter.Annotations.OfType<ResourceCommandAnnotation>()
+            .Single(a => a.Name == KnownResourceCommands.SetParameterCommand);
+        var arguments = new InteractionInputCollection(setValueCommand.Arguments);
+        var valueInput = arguments[ParameterProcessor.SetParameterValueName];
+        valueInput.Value = "callerValue";
+
+        await valueInput.DynamicLoading!.LoadCallback(new LoadInputContext
+        {
+            Input = valueInput,
+            AllInputs = arguments,
+            Services = new ServiceCollection().BuildServiceProvider(),
+            CancellationToken = CancellationToken.None
+        }).DefaultTimeout();
+
+        Assert.Equal("callerValue", valueInput.Value);
     }
 
     [Fact]
@@ -908,14 +961,24 @@ public class ParameterProcessorTests
 
         var parameterProcessor = CreateParameterProcessor(
             interactionService: testInteractionService,
-            deploymentStateManager: deploymentStateManager);
+            deploymentStateManager: deploymentStateManager,
+            userSecretsManager: new MockUserSecretsManager());
 
         await parameterProcessor.InitializeParametersAsync([parameter]).DefaultTimeout();
 
         var setValueCommand = parameter.Annotations.OfType<ResourceCommandAnnotation>()
             .Single(a => a.Name == KnownResourceCommands.SetParameterCommand);
         var arguments = new InteractionInputCollection(setValueCommand.Arguments);
+        var valueInput = arguments[ParameterProcessor.SetParameterValueName];
         var saveInput = arguments[ParameterProcessor.SaveToUserSecretsName];
+
+        await valueInput.DynamicLoading!.LoadCallback(new LoadInputContext
+        {
+            Input = valueInput,
+            AllInputs = arguments,
+            Services = new ServiceCollection().BuildServiceProvider(),
+            CancellationToken = CancellationToken.None
+        }).DefaultTimeout();
 
         await saveInput.DynamicLoading!.LoadCallback(new LoadInputContext
         {
@@ -926,6 +989,67 @@ public class ParameterProcessorTests
         }).DefaultTimeout();
 
         Assert.Equal("true", saveInput.Value);
+    }
+
+    [Fact]
+    public async Task ProcessParameterAsync_WithoutSavedState_DisablesDeleteParameterUserSecretsArgumentOnStart()
+    {
+        var testInteractionService = new TestInteractionService { IsAvailable = true };
+        var deploymentStateManager = new CapturingMockDeploymentStateManager();
+        var parameterProcessor = CreateParameterProcessor(
+            interactionService: testInteractionService,
+            deploymentStateManager: deploymentStateManager,
+            userSecretsManager: new MockUserSecretsManager());
+        var parameter = CreateParameterResource("testParam", "testValue");
+
+        await parameterProcessor.InitializeParametersAsync([parameter]).DefaultTimeout();
+
+        var deleteCommand = parameter.Annotations.OfType<ResourceCommandAnnotation>()
+            .Single(a => a.Name == KnownResourceCommands.DeleteParameterCommand);
+        var arguments = new InteractionInputCollection(deleteCommand.Arguments);
+        var deleteInput = arguments[ParameterProcessor.DeleteFromUserSecretsName];
+
+        await deleteInput.DynamicLoading!.LoadCallback(new LoadInputContext
+        {
+            Input = deleteInput,
+            AllInputs = arguments,
+            Services = new ServiceCollection().BuildServiceProvider(),
+            CancellationToken = CancellationToken.None
+        }).DefaultTimeout();
+
+        Assert.True(deleteInput.Disabled);
+    }
+
+    [Fact]
+    public async Task ProcessParameterAsync_WithSavedState_EnablesDeleteParameterUserSecretsArgumentOnStart()
+    {
+        var testInteractionService = new TestInteractionService { IsAvailable = true };
+        var deploymentStateManager = new CapturingMockDeploymentStateManager();
+        var parameter = CreateParameterResource("testParam", "testValue");
+        var section = await deploymentStateManager.AcquireSectionAsync(parameter.ConfigurationKey).DefaultTimeout();
+        section.SetValue("testValue");
+        await deploymentStateManager.SaveSectionAsync(section).DefaultTimeout();
+        var parameterProcessor = CreateParameterProcessor(
+            interactionService: testInteractionService,
+            deploymentStateManager: deploymentStateManager,
+            userSecretsManager: new MockUserSecretsManager());
+
+        await parameterProcessor.InitializeParametersAsync([parameter]).DefaultTimeout();
+
+        var deleteCommand = parameter.Annotations.OfType<ResourceCommandAnnotation>()
+            .Single(a => a.Name == KnownResourceCommands.DeleteParameterCommand);
+        var arguments = new InteractionInputCollection(deleteCommand.Arguments);
+        var deleteInput = arguments[ParameterProcessor.DeleteFromUserSecretsName];
+
+        await deleteInput.DynamicLoading!.LoadCallback(new LoadInputContext
+        {
+            Input = deleteInput,
+            AllInputs = arguments,
+            Services = new ServiceCollection().BuildServiceProvider(),
+            CancellationToken = CancellationToken.None
+        }).DefaultTimeout();
+
+        Assert.False(deleteInput.Disabled);
     }
 
     [Fact]
@@ -946,241 +1070,107 @@ public class ParameterProcessorTests
     }
 
     [Fact]
-    public async Task SetParameterAsync_WithUserInput_UpdatesParameterValue()
+    public async Task SetParameterCoreAsync_WithUserInput_UpdatesParameterValue()
     {
-        // Arrange
-        var testInteractionService = new TestInteractionService { IsAvailable = true };
-        var notificationService = ResourceNotificationServiceTestHelpers.Create();
-        var parameterProcessor = CreateParameterProcessor(
-            notificationService: notificationService,
-            interactionService: testInteractionService);
+        var parameterProcessor = CreateParameterProcessor();
         var parameter = CreateParameterResource("testParam", "initialValue");
 
-        // Initialize the parameter
         await parameterProcessor.InitializeParametersAsync([parameter]).DefaultTimeout();
 
-        // Reset WaitForValueTcs to track updates
         parameter.WaitForValueTcs = new TaskCompletionSource<string>(TaskCreationOptions.RunContinuationsAsynchronously);
 
-        // Act - Start the SetParameterAsync task
-        var setValueTask = Task.Run(async () =>
-        {
-            await parameterProcessor.SetParameterAsync(parameter);
-        });
+        var result = await parameterProcessor.SetParameterCoreAsync(parameter, CreateSetParameterArguments("newValue"), CancellationToken.None).DefaultTimeout();
 
-        // Wait for the input dialog to be presented
-        var inputInteraction = await testInteractionService.Interactions.Reader.ReadAsync().DefaultTimeout();
-        Assert.Equal(InteractionStrings.SetParameterTitle, inputInteraction.Title);
-        Assert.Equal(InteractionStrings.SetParameterMessage, inputInteraction.Message);
-        // Should have 2 inputs: parameter value input + SaveToUserSecrets checkbox (in run mode)
-        Assert.Equal(2, inputInteraction.Inputs.Count);
-        Assert.Equal("testParam", inputInteraction.Inputs["testParam"].Label);
-        // Existing value should be pre-populated
-        Assert.Equal("initialValue", inputInteraction.Inputs["testParam"].Value);
-        // SaveToUserSecrets shouldn't be true because the existing value isn't saved to sate.
-        Assert.Null(inputInteraction.Inputs[ParameterProcessor.SaveToUserSecretsName].Value);
-
-        // Complete the interaction with a new value
-        inputInteraction.Inputs["testParam"].Value = "newValue";
-        inputInteraction.CompletionTcs.SetResult(InteractionResult.Ok(inputInteraction.Inputs));
-
-        // Wait for the set value task to complete
-        await setValueTask.DefaultTimeout();
-
-        // Assert - Parameter value should be updated
+        Assert.True(result.Success);
+        Assert.Equal(string.Format(CultureInfo.InvariantCulture, CommandStrings.ResourceSetParameter, parameter.Name), result.Message);
         Assert.Equal("newValue", await parameter.GetValueAsync(CancellationToken.None).DefaultTimeout());
     }
 
     [Fact]
-    public async Task SetParameterAsync_WhenUserCancels_ParameterValueUnchanged()
+    public async Task SetParameterCoreAsync_WithMissingInput_ParameterValueUnchanged()
     {
-        // Arrange
-        var testInteractionService = new TestInteractionService { IsAvailable = true };
-        var parameterProcessor = CreateParameterProcessor(interactionService: testInteractionService);
+        var parameterProcessor = CreateParameterProcessor();
         var parameter = CreateParameterResource("testParam", "initialValue");
 
-        // Initialize the parameter
         await parameterProcessor.InitializeParametersAsync([parameter]).DefaultTimeout();
 
-        // Reset WaitForValueTcs to track updates
-        var originalTcs = parameter.WaitForValueTcs;
         parameter.WaitForValueTcs = new TaskCompletionSource<string>(TaskCreationOptions.RunContinuationsAsynchronously);
 
-        // Act - Start the SetParameterAsync task
-        var setValueTask = Task.Run(async () =>
-        {
-            await parameterProcessor.SetParameterAsync(parameter);
-        });
+        var result = await parameterProcessor.SetParameterCoreAsync(parameter, CreateSetParameterArguments(value: null), CancellationToken.None).DefaultTimeout();
 
-        // Wait for the input dialog to be presented
-        var inputInteraction = await testInteractionService.Interactions.Reader.ReadAsync().DefaultTimeout();
-
-        // Cancel the interaction
-        inputInteraction.CompletionTcs.SetResult(InteractionResult.Cancel<InteractionInputCollection>());
-
-        // Wait for the set value task to complete
-        await setValueTask.DefaultTimeout();
-
-        // Assert - Parameter value should remain unchanged (WaitForValueTcs not set)
-        Assert.False(parameter.WaitForValueTcs!.Task.IsCompleted);
+        Assert.True(result.Success);
+        Assert.False(parameter.WaitForValueTcs.Task.IsCompleted);
     }
 
     [Fact]
-    public async Task SetParameterAsync_WithSecretParameter_UsesSecretTextInput()
+    public async Task SetParameterCoreAsync_ResolvingLastParameter_CancelsPromptNotification()
     {
-        // Arrange
         var testInteractionService = new TestInteractionService { IsAvailable = true };
         var parameterProcessor = CreateParameterProcessor(interactionService: testInteractionService);
-        var parameter = CreateParameterResource("secretParam", "secretValue", secret: true);
-
-        // Initialize the parameter
-        await parameterProcessor.InitializeParametersAsync([parameter]).DefaultTimeout();
-
-        // Reset WaitForValueTcs to track updates
-        parameter.WaitForValueTcs = new TaskCompletionSource<string>(TaskCreationOptions.RunContinuationsAsynchronously);
-
-        // Act - Start the SetParameterAsync task
-        var setValueTask = Task.Run(async () =>
-        {
-            await parameterProcessor.SetParameterAsync(parameter);
-        });
-
-        // Wait for the input dialog to be presented
-        var inputInteraction = await testInteractionService.Interactions.Reader.ReadAsync().DefaultTimeout();
-
-        // Assert - Should use SecretText input type for secret parameters
-        Assert.Equal(2, inputInteraction.Inputs.Count);
-        Assert.Equal(InputType.SecretText, inputInteraction.Inputs["secretParam"].InputType);
-        // Existing value should be pre-populated for secrets too
-        Assert.Equal("secretValue", inputInteraction.Inputs["secretParam"].Value);
-
-        // Complete the interaction
-        inputInteraction.Inputs["secretParam"].Value = "newSecretValue";
-        inputInteraction.CompletionTcs.SetResult(InteractionResult.Ok(inputInteraction.Inputs));
-
-        await setValueTask.DefaultTimeout();
-
-        // Assert - Parameter value should be updated
-        Assert.Equal("newSecretValue", await parameter.WaitForValueTcs!.Task.DefaultTimeout());
-    }
-
-    [Fact]
-    public async Task SetParameterAsync_ResolvingLastParameter_CancelsPromptNotification()
-    {
-        // Arrange
-        var testInteractionService = new TestInteractionService { IsAvailable = true };
-        var notificationService = ResourceNotificationServiceTestHelpers.Create();
-        var parameterProcessor = CreateParameterProcessor(
-            notificationService: notificationService,
-            interactionService: testInteractionService);
-
         var parameter = CreateParameterWithMissingValue("testParam");
 
-        // Use InitializeParametersAsync to properly set up the internal state
-        // This will trigger HandleUnresolvedParametersAsync in a background task
-        // with the internal _allParametersResolvedCts.Token
         await parameterProcessor.InitializeParametersAsync([parameter]).DefaultTimeout();
 
-        // Wait for the notification to appear from the background task
         var notificationInteraction = await testInteractionService.Interactions.Reader.ReadAsync().DefaultTimeout();
         Assert.Equal(InteractionStrings.ParametersBarTitle, notificationInteraction.Title);
+        Assert.False(notificationInteraction.CancellationToken.IsCancellationRequested);
 
-        // Capture the cancellation token passed to the notification
-        var notificationCancellationToken = notificationInteraction.CancellationToken;
-        Assert.False(notificationCancellationToken.IsCancellationRequested);
+        var result = await parameterProcessor.SetParameterCoreAsync(parameter, CreateSetParameterArguments("resolvedValue"), CancellationToken.None).DefaultTimeout();
 
-        // Now use SetParameterAsync to resolve the parameter (which is the last unresolved parameter)
-        var setValueTask = Task.Run(async () =>
-        {
-            await parameterProcessor.SetParameterAsync(parameter);
-        });
-
-        // Wait for the SetParameterAsync input dialog to appear
-        var inputInteraction = await testInteractionService.Interactions.Reader.ReadAsync().DefaultTimeout();
-        Assert.Equal(InteractionStrings.SetParameterTitle, inputInteraction.Title);
-
-        // Complete the SetParameterAsync interaction with a value
-        inputInteraction.Inputs["testParam"].Value = "resolvedValue";
-        inputInteraction.CompletionTcs.SetResult(InteractionResult.Ok(inputInteraction.Inputs));
-
-        await setValueTask.DefaultTimeout();
-
-        // The parameter should be resolved with the correct value
+        Assert.True(result.Success);
         Assert.Equal("resolvedValue", await parameter.GetValueAsync(CancellationToken.None).DefaultTimeout());
-
-        // Assert - The notification's cancellation token should now be canceled
-        // because the last parameter was resolved via SetParameterAsync
-        Assert.True(notificationCancellationToken.IsCancellationRequested);
+        Assert.True(notificationInteraction.CancellationToken.IsCancellationRequested);
     }
 
     [Fact]
-    public async Task SetParameterAsync_CalledTwice_SecondInteractionShowsPreviousValueAndSaveChecked()
+    public async Task SetParameterCoreAsync_CalledTwice_UpdatesPreviousValueAndSavedState()
     {
-        // Arrange
-        var testInteractionService = new TestInteractionService { IsAvailable = true };
-        var notificationService = ResourceNotificationServiceTestHelpers.Create();
         var capturingStateManager = new CapturingMockDeploymentStateManager();
-        var parameterProcessor = CreateParameterProcessor(
-            notificationService: notificationService,
-            interactionService: testInteractionService,
-            deploymentStateManager: capturingStateManager);
-
+        var parameterProcessor = CreateParameterProcessor(deploymentStateManager: capturingStateManager);
         var parameter = CreateParameterWithMissingValue("testParam");
 
-        // Initialize the parameter - this starts HandleUnresolvedParametersAsync in background
         await parameterProcessor.InitializeParametersAsync([parameter]).DefaultTimeout();
 
-        // Wait for the notification to appear from the background task
-        var notificationInteraction = await testInteractionService.Interactions.Reader.ReadAsync().AsTask().DefaultTimeout();
-        Assert.Equal(InteractionStrings.ParametersBarTitle, notificationInteraction.Title);
-
-        // First SetParameterAsync call - set and save a value
-        var firstSetValueTask = Task.Run(async () =>
-        {
-            await parameterProcessor.SetParameterAsync(parameter);
-        });
-
-        // Wait for the first input dialog
-        var firstInputInteraction = await testInteractionService.Interactions.Reader.ReadAsync().AsTask().DefaultTimeout();
-        Assert.Equal(InteractionStrings.SetParameterTitle, firstInputInteraction.Title);
-
-        // First time: no saved state, so SaveToUserSecrets should be null/unchecked
-        Assert.Null(firstInputInteraction.Inputs[ParameterProcessor.SaveToUserSecretsName].Value);
-
-        // Set the value and enable save
-        firstInputInteraction.Inputs["testParam"].Value = "firstValue";
-        firstInputInteraction.Inputs[ParameterProcessor.SaveToUserSecretsName].Value = "true";
-        firstInputInteraction.CompletionTcs.SetResult(InteractionResult.Ok(firstInputInteraction.Inputs));
-
-        await firstSetValueTask.DefaultTimeout();
-
-        // Verify first value was set
+        await parameterProcessor.SetParameterCoreAsync(parameter, CreateSetParameterArguments("firstValue", saveToUserSecrets: "true"), CancellationToken.None).DefaultTimeout();
         Assert.Equal("firstValue", await parameter.GetValueAsync(CancellationToken.None).DefaultTimeout());
+        Assert.True(capturingStateManager.State.TryGetPropertyValue($"Parameters:{parameter.Name}", out var savedValueNode));
+        Assert.Equal("firstValue", savedValueNode?.GetValue<string>());
 
-        // Second SetParameterAsync call - should show previously set value
-        var secondSetValueTask = Task.Run(async () =>
-        {
-            await parameterProcessor.SetParameterAsync(parameter);
-        });
+        await parameterProcessor.SetParameterCoreAsync(parameter, CreateSetParameterArguments("secondValue", saveToUserSecrets: "true"), CancellationToken.None).DefaultTimeout();
 
-        // Wait for the second input dialog
-        var secondInputInteraction = await testInteractionService.Interactions.Reader.ReadAsync().AsTask().DefaultTimeout();
-        Assert.Equal(InteractionStrings.SetParameterTitle, secondInputInteraction.Title);
-
-        // Assert - Second interaction should have the previously set value pre-populated
-        Assert.Equal("firstValue", secondInputInteraction.Inputs["testParam"].Value);
-
-        // Assert - SaveToUserSecrets should be checked (true) since parameter has saved state
-        Assert.Equal("true", secondInputInteraction.Inputs[ParameterProcessor.SaveToUserSecretsName].Value);
-
-        // Complete the second interaction with a new value
-        secondInputInteraction.Inputs["testParam"].Value = "secondValue";
-        secondInputInteraction.CompletionTcs.SetResult(InteractionResult.Ok(secondInputInteraction.Inputs));
-
-        await secondSetValueTask.DefaultTimeout();
-
-        // Verify second value was set
         Assert.Equal("secondValue", await parameter.GetValueAsync(CancellationToken.None).DefaultTimeout());
+        Assert.True(capturingStateManager.State.TryGetPropertyValue($"Parameters:{parameter.Name}", out savedValueNode));
+        Assert.Equal("secondValue", savedValueNode?.GetValue<string>());
+    }
+
+    private static InteractionInputCollection CreateSetParameterArguments(string? value, string? saveToUserSecrets = null)
+    {
+        return new InteractionInputCollection([
+            new InteractionInput
+            {
+                Name = ParameterProcessor.SetParameterValueName,
+                InputType = InputType.Text,
+                Value = value
+            },
+            new InteractionInput
+            {
+                Name = ParameterProcessor.SaveToUserSecretsName,
+                InputType = InputType.Boolean,
+                Value = saveToUserSecrets
+            }
+        ]);
+    }
+
+    private static InteractionInputCollection CreateDeleteParameterArguments(string? deleteFromUserSecrets = null)
+    {
+        return new InteractionInputCollection([
+            new InteractionInput
+            {
+                Name = ParameterProcessor.DeleteFromUserSecretsName,
+                InputType = InputType.Boolean,
+                Value = deleteFromUserSecrets
+            }
+        ]);
     }
 
     private static ParameterProcessor CreateParameterProcessor(
@@ -1418,213 +1408,67 @@ public class ParameterProcessorTests
     }
 
     [Fact]
-    public async Task SetParameterAsync_WithSavedState_OnlyShowsValueAndSaveInputs()
+    public async Task DeleteParameterCoreAsync_DeletesFromDeploymentState()
     {
-        // Arrange
         var capturingStateManager = new CapturingMockDeploymentStateManager();
-        var testInteractionService = new TestInteractionService { IsAvailable = true };
-        var notificationService = ResourceNotificationServiceTestHelpers.Create();
-        var parameterProcessor = CreateParameterProcessor(
-            notificationService: notificationService,
-            interactionService: testInteractionService,
-            deploymentStateManager: capturingStateManager);
-
+        var parameterProcessor = CreateParameterProcessor(deploymentStateManager: capturingStateManager);
         var parameter = CreateParameterResource("testParam", "initialValue");
 
-        // Initialize the parameter
         await parameterProcessor.InitializeParametersAsync([parameter]).DefaultTimeout();
-
-        // First SetParameterAsync call - set and save a value to establish saved state
-        var firstSetValueTask = Task.Run(async () =>
-        {
-            await parameterProcessor.SetParameterAsync(parameter);
-        });
-
-        var firstInputInteraction = await testInteractionService.Interactions.Reader.ReadAsync().AsTask().DefaultTimeout();
-        // First time: should have 2 inputs (value + save)
-        Assert.Equal(2, firstInputInteraction.Inputs.Count);
-
-        // Set the value and save it
-        firstInputInteraction.Inputs["testParam"].Value = "savedValue";
-        firstInputInteraction.Inputs[ParameterProcessor.SaveToUserSecretsName].Value = "true";
-        firstInputInteraction.CompletionTcs.SetResult(InteractionResult.Ok(firstInputInteraction.Inputs));
-
-        await firstSetValueTask.DefaultTimeout();
-
-        // Second SetParameterAsync call - should still only have 2 inputs (delete is now a separate command)
-        var secondSetValueTask = Task.Run(async () =>
-        {
-            await parameterProcessor.SetParameterAsync(parameter);
-        });
-
-        var secondInputInteraction = await testInteractionService.Interactions.Reader.ReadAsync().AsTask().DefaultTimeout();
-
-        // Assert - Should have 2 inputs: value + save (delete is now a separate command)
-        Assert.Equal(2, secondInputInteraction.Inputs.Count);
-        Assert.True(secondInputInteraction.Inputs.ContainsName("testParam"));
-        Assert.True(secondInputInteraction.Inputs.ContainsName(ParameterProcessor.SaveToUserSecretsName));
-
-        // Complete the interaction
-        secondInputInteraction.CompletionTcs.SetResult(InteractionResult.Ok(secondInputInteraction.Inputs));
-
-        await secondSetValueTask.DefaultTimeout();
-    }
-
-    [Fact]
-    public async Task DeleteParameterAsync_DeletesFromDeploymentState()
-    {
-        // Arrange
-        var capturingStateManager = new CapturingMockDeploymentStateManager();
-        var testInteractionService = new TestInteractionService { IsAvailable = true };
-        var notificationService = ResourceNotificationServiceTestHelpers.Create();
-        var parameterProcessor = CreateParameterProcessor(
-            notificationService: notificationService,
-            interactionService: testInteractionService,
-            deploymentStateManager: capturingStateManager);
-
-        var parameter = CreateParameterResource("testParam", "initialValue");
-
-        // Initialize the parameter
-        await parameterProcessor.InitializeParametersAsync([parameter]).DefaultTimeout();
-
-        // First SetParameterAsync call - set and save a value to establish saved state
-        var firstSetValueTask = Task.Run(async () =>
-        {
-            await parameterProcessor.SetParameterAsync(parameter);
-        });
-
-        var firstInputInteraction = await testInteractionService.Interactions.Reader.ReadAsync().AsTask().DefaultTimeout();
-        firstInputInteraction.Inputs["testParam"].Value = "savedValue";
-        firstInputInteraction.Inputs[ParameterProcessor.SaveToUserSecretsName].Value = "true";
-        firstInputInteraction.CompletionTcs.SetResult(InteractionResult.Ok(firstInputInteraction.Inputs));
-
-        await firstSetValueTask.DefaultTimeout();
-
-        // Verify value was saved
+        await parameterProcessor.SetParameterCoreAsync(parameter, CreateSetParameterArguments("savedValue", saveToUserSecrets: "true"), CancellationToken.None).DefaultTimeout();
         Assert.True(capturingStateManager.State.Count > 0);
 
-        // Call DeleteParameterAsync to delete the value - need to run in background as it shows a prompt
-        var deleteTask = Task.Run(async () =>
-        {
-            await parameterProcessor.DeleteParameterAsync(parameter);
-        });
+        var result = await parameterProcessor.DeleteParameterCoreAsync(parameter, CreateDeleteParameterArguments(deleteFromUserSecrets: "true"), CancellationToken.None).DefaultTimeout();
 
-        // Wait for the delete confirmation dialog
-        var deleteConfirmation = await testInteractionService.Interactions.Reader.ReadAsync().AsTask().DefaultTimeout();
-        Assert.Equal(InteractionStrings.DeleteParameterTitle, deleteConfirmation.Title);
-        // Should have delete from user secrets checkbox since value is saved
-        Assert.True(deleteConfirmation.Inputs.ContainsName(ParameterProcessor.DeleteFromUserSecretsName));
-        Assert.Null(deleteConfirmation.Inputs[ParameterProcessor.DeleteFromUserSecretsName].Value);
-
-        // Confirm the deletion with delete from user secrets checked
-        deleteConfirmation.Inputs[ParameterProcessor.DeleteFromUserSecretsName].Value = "true";
-        deleteConfirmation.CompletionTcs.SetResult(InteractionResult.Ok(deleteConfirmation.Inputs));
-
-        await deleteTask.DefaultTimeout();
-
-        // Assert - State should be cleared
-        // The section still exists but should have no data
+        Assert.True(result.Success);
+        Assert.Equal(string.Format(CultureInfo.InvariantCulture, CommandStrings.ResourceDeletedParameter, parameter.Name), result.Message);
         var section = await capturingStateManager.AcquireSectionAsync($"Parameters:{parameter.Name}").DefaultTimeout();
         Assert.Empty(section.Data);
     }
 
     [Fact]
-    public async Task SetParameterAsync_WithoutSavedState_DoesNotShowDeleteCheckbox()
+    public async Task DeleteParameterCoreAsync_WithoutDeleteFromUserSecrets_DoesNotDeleteDeploymentState()
     {
-        // Arrange
-        var testInteractionService = new TestInteractionService { IsAvailable = true };
-        var notificationService = ResourceNotificationServiceTestHelpers.Create();
-        var parameterProcessor = CreateParameterProcessor(
-            notificationService: notificationService,
-            interactionService: testInteractionService);
-
+        var capturingStateManager = new CapturingMockDeploymentStateManager();
+        var parameterProcessor = CreateParameterProcessor(deploymentStateManager: capturingStateManager);
         var parameter = CreateParameterResource("testParam", "initialValue");
 
-        // Initialize the parameter
         await parameterProcessor.InitializeParametersAsync([parameter]).DefaultTimeout();
+        await parameterProcessor.SetParameterCoreAsync(parameter, CreateSetParameterArguments("savedValue", saveToUserSecrets: "true"), CancellationToken.None).DefaultTimeout();
 
-        // Act - Start the SetParameterAsync task
-        var setValueTask = Task.Run(async () =>
-        {
-            await parameterProcessor.SetParameterAsync(parameter);
-        });
+        var result = await parameterProcessor.DeleteParameterCoreAsync(parameter, CreateDeleteParameterArguments(), CancellationToken.None).DefaultTimeout();
 
-        // Wait for the input dialog to be presented
-        var inputInteraction = await testInteractionService.Interactions.Reader.ReadAsync().AsTask().DefaultTimeout();
-
-        // Assert - Should only have 2 inputs (value + save), no delete checkbox
-        Assert.Equal(2, inputInteraction.Inputs.Count);
-        Assert.True(inputInteraction.Inputs.ContainsName("testParam"));
-        Assert.True(inputInteraction.Inputs.ContainsName(ParameterProcessor.SaveToUserSecretsName));
-        Assert.False(inputInteraction.Inputs.ContainsName("DeleteParameter"));
-
-        // Complete the interaction
-        inputInteraction.CompletionTcs.SetResult(InteractionResult.Cancel<InteractionInputCollection>());
-        await setValueTask.DefaultTimeout();
+        Assert.True(result.Success);
+        Assert.True(capturingStateManager.State.TryGetPropertyValue($"Parameters:{parameter.Name}", out var savedValueNode));
+        Assert.Equal("savedValue", savedValueNode?.GetValue<string>());
     }
 
     [Fact]
-    public async Task DeleteParameterAsync_AddsParameterBackToUnresolvedAndStartsResolutionTask()
+    public async Task DeleteParameterCoreAsync_AddsParameterBackToUnresolvedAndStartsResolutionTask()
     {
-        // Arrange
         var capturingStateManager = new CapturingMockDeploymentStateManager();
         var testInteractionService = new TestInteractionService { IsAvailable = true };
-        var notificationService = ResourceNotificationServiceTestHelpers.Create();
         var parameterProcessor = CreateParameterProcessor(
-            notificationService: notificationService,
             interactionService: testInteractionService,
             deploymentStateManager: capturingStateManager);
-
         var parameter = CreateParameterResource("testParam", "initialValue");
 
-        // Initialize the parameter
         await parameterProcessor.InitializeParametersAsync([parameter]).DefaultTimeout();
+        await parameterProcessor.SetParameterCoreAsync(parameter, CreateSetParameterArguments("savedValue", saveToUserSecrets: "true"), CancellationToken.None).DefaultTimeout();
+        await parameterProcessor.DeleteParameterCoreAsync(parameter, CreateDeleteParameterArguments(), CancellationToken.None).DefaultTimeout();
 
-        // First SetParameterAsync call - set and save a value to establish saved state
-        var firstSetValueTask = Task.Run(async () =>
-        {
-            await parameterProcessor.SetParameterAsync(parameter);
-        });
-
-        var firstInputInteraction = await testInteractionService.Interactions.Reader.ReadAsync().AsTask().DefaultTimeout();
-        firstInputInteraction.Inputs["testParam"].Value = "savedValue";
-        firstInputInteraction.Inputs[ParameterProcessor.SaveToUserSecretsName].Value = "true";
-        firstInputInteraction.CompletionTcs.SetResult(InteractionResult.Ok(firstInputInteraction.Inputs));
-
-        await firstSetValueTask.DefaultTimeout();
-
-        // Call DeleteParameterAsync to delete the value - need to run in background as it shows a prompt
-        var deleteTask = Task.Run(async () =>
-        {
-            await parameterProcessor.DeleteParameterAsync(parameter);
-        });
-
-        // Wait for the delete confirmation dialog
-        var deleteConfirmation = await testInteractionService.Interactions.Reader.ReadAsync().AsTask().DefaultTimeout();
-        Assert.Equal(InteractionStrings.DeleteParameterTitle, deleteConfirmation.Title);
-
-        // Confirm the deletion
-        deleteConfirmation.CompletionTcs.SetResult(InteractionResult.Ok(deleteConfirmation.Inputs));
-
-        await deleteTask.DefaultTimeout();
-
-        // After delete, the resolution task should start and show a notification
         var notificationInteraction = await testInteractionService.Interactions.Reader.ReadAsync().AsTask().DefaultTimeout();
         Assert.Equal(InteractionStrings.ParametersBarTitle, notificationInteraction.Title);
 
-        // Dismiss the notification to proceed to inputs dialog
         notificationInteraction.CompletionTcs.SetResult(InteractionResult.Ok(true));
 
-        // The inputs dialog should appear with the deleted parameter
         var inputsInteraction = await testInteractionService.Interactions.Reader.ReadAsync().AsTask().DefaultTimeout();
         Assert.Equal(InteractionStrings.ParametersInputsTitle, inputsInteraction.Title);
         Assert.True(inputsInteraction.Inputs.ContainsName("testParam"));
 
-        // Complete the interaction with a new value
         inputsInteraction.Inputs["testParam"].Value = "newValue";
         inputsInteraction.CompletionTcs.SetResult(InteractionResult.Ok(inputsInteraction.Inputs));
 
-        // Verify the parameter was resolved with the new value
         Assert.Equal("newValue", await parameter.GetValueAsync(CancellationToken.None).DefaultTimeout());
     }
 

--- a/tests/Aspire.Hosting.Tests/Orchestrator/ParameterProcessorTests.cs
+++ b/tests/Aspire.Hosting.Tests/Orchestrator/ParameterProcessorTests.cs
@@ -1149,6 +1149,33 @@ public class ParameterProcessorTests
         Assert.Equal("secondValue", savedValueNode?.GetValue<string>());
     }
 
+    [Fact]
+    public async Task SetParameterAsync_WithUserInput_UpdatesParameterValueAndSavedState()
+    {
+        var capturingStateManager = new CapturingMockDeploymentStateManager();
+        var testInteractionService = new TestInteractionService { IsAvailable = true };
+        var parameterProcessor = CreateParameterProcessor(
+            interactionService: testInteractionService,
+            deploymentStateManager: capturingStateManager);
+        var parameter = CreateParameterResource("testParam", "initialValue");
+
+        await parameterProcessor.InitializeParametersAsync([parameter]).DefaultTimeout();
+
+        var setParameterTask = parameterProcessor.SetParameterAsync(parameter, CancellationToken.None);
+
+        var inputsInteraction = await testInteractionService.Interactions.Reader.ReadAsync().DefaultTimeout();
+        Assert.Equal(InteractionStrings.SetParameterTitle, inputsInteraction.Title);
+        inputsInteraction.Inputs[ParameterProcessor.SetParameterValueName].Value = "newValue";
+        inputsInteraction.Inputs[ParameterProcessor.SaveToUserSecretsName].Value = "true";
+        inputsInteraction.CompletionTcs.SetResult(InteractionResult.Ok(inputsInteraction.Inputs));
+
+        await setParameterTask.DefaultTimeout();
+
+        Assert.Equal("newValue", await parameter.GetValueAsync(CancellationToken.None).DefaultTimeout());
+        Assert.True(capturingStateManager.State.TryGetPropertyValue($"Parameters:{parameter.Name}", out var savedValueNode));
+        Assert.Equal("newValue", savedValueNode?.GetValue<string>());
+    }
+
     private static InteractionInputCollection CreateSetParameterArguments(string? value, string? saveToUserSecrets = null)
     {
         return new InteractionInputCollection([
@@ -1442,7 +1469,7 @@ public class ParameterProcessorTests
         await parameterProcessor.InitializeParametersAsync([parameter]).DefaultTimeout();
         await parameterProcessor.SetParameterCoreAsync(parameter, CreateSetParameterArguments("savedValue", saveToUserSecrets: "true"), CancellationToken.None).DefaultTimeout();
 
-        var result = await parameterProcessor.DeleteParameterCoreAsync(parameter, CreateDeleteParameterArguments(), CancellationToken.None).DefaultTimeout();
+        var result = await parameterProcessor.DeleteParameterCoreAsync(parameter, new InteractionInputCollection([]), CancellationToken.None).DefaultTimeout();
 
         Assert.True(result.Success);
         Assert.True(capturingStateManager.State.TryGetPropertyValue($"Parameters:{parameter.Name}", out var savedValueNode));
@@ -1490,6 +1517,54 @@ public class ParameterProcessorTests
         Assert.Equal(InteractionStrings.ParametersInputsTitle, inputsInteraction.Title);
         Assert.True(inputsInteraction.Inputs.ContainsName("testParam"));
 
+        inputsInteraction.Inputs["testParam"].Value = "newValue";
+        inputsInteraction.CompletionTcs.SetResult(InteractionResult.Ok(inputsInteraction.Inputs));
+
+        Assert.Equal("newValue", await parameter.GetValueAsync(CancellationToken.None).DefaultTimeout());
+    }
+
+    [Fact]
+    public async Task DeleteParameterAsync_DeletesFromDeploymentState()
+    {
+        var capturingStateManager = new CapturingMockDeploymentStateManager();
+        var testInteractionService = new TestInteractionService { IsAvailable = true };
+        var parameterProcessor = CreateParameterProcessor(
+            interactionService: testInteractionService,
+            deploymentStateManager: capturingStateManager);
+        var parameter = CreateParameterResource("testParam", "initialValue");
+
+        await parameterProcessor.InitializeParametersAsync([parameter]).DefaultTimeout();
+
+        var setParameterTask = parameterProcessor.SetParameterAsync(parameter, CancellationToken.None);
+
+        var setInteraction = await testInteractionService.Interactions.Reader.ReadAsync().DefaultTimeout();
+        setInteraction.Inputs[ParameterProcessor.SetParameterValueName].Value = "savedValue";
+        setInteraction.Inputs[ParameterProcessor.SaveToUserSecretsName].Value = "true";
+        setInteraction.CompletionTcs.SetResult(InteractionResult.Ok(setInteraction.Inputs));
+
+        await setParameterTask.DefaultTimeout();
+        Assert.True(capturingStateManager.State.Count > 0);
+
+        var deleteParameterTask = parameterProcessor.DeleteParameterAsync(parameter, CancellationToken.None);
+
+        var deleteInteraction = await testInteractionService.Interactions.Reader.ReadAsync().DefaultTimeout();
+        Assert.Equal(InteractionStrings.DeleteParameterTitle, deleteInteraction.Title);
+        Assert.True(deleteInteraction.Inputs.ContainsName(ParameterProcessor.DeleteFromUserSecretsName));
+        Assert.Null(deleteInteraction.Inputs[ParameterProcessor.DeleteFromUserSecretsName].Value);
+        deleteInteraction.Inputs[ParameterProcessor.DeleteFromUserSecretsName].Value = "true";
+        deleteInteraction.CompletionTcs.SetResult(InteractionResult.Ok(deleteInteraction.Inputs));
+
+        await deleteParameterTask.DefaultTimeout();
+
+        var section = await capturingStateManager.AcquireSectionAsync($"Parameters:{parameter.Name}").DefaultTimeout();
+        Assert.Empty(section.Data);
+
+        var notificationInteraction = await testInteractionService.Interactions.Reader.ReadAsync().AsTask().DefaultTimeout();
+        Assert.Equal(InteractionStrings.ParametersBarTitle, notificationInteraction.Title);
+        notificationInteraction.CompletionTcs.SetResult(InteractionResult.Ok(true));
+
+        var inputsInteraction = await testInteractionService.Interactions.Reader.ReadAsync().AsTask().DefaultTimeout();
+        Assert.Equal(InteractionStrings.ParametersInputsTitle, inputsInteraction.Title);
         inputsInteraction.Inputs["testParam"].Value = "newValue";
         inputsInteraction.CompletionTcs.SetResult(InteractionResult.Ok(inputsInteraction.Inputs));
 

--- a/tests/Aspire.Hosting.Tests/Orchestrator/ParameterProcessorTests.cs
+++ b/tests/Aspire.Hosting.Tests/Orchestrator/ParameterProcessorTests.cs
@@ -896,6 +896,12 @@ public class ParameterProcessorTests
                 Assert.True(valueInput.Required);
             },
             saveInput => Assert.Equal(ParameterProcessor.SaveToUserSecretsName, saveInput.Name));
+
+        var saveToUserSecretsInput = setValueCommand.Arguments.Single(argument => argument.Name == ParameterProcessor.SaveToUserSecretsName);
+        Assert.NotNull(saveToUserSecretsInput.DynamicLoading);
+        var dependsOnInputs = saveToUserSecretsInput.DynamicLoading.DependsOnInputs;
+        Assert.NotNull(dependsOnInputs);
+        Assert.Equal(ParameterProcessor.SetParameterValueName, Assert.Single(dependsOnInputs));
     }
 
     [Fact]
@@ -1444,6 +1450,24 @@ public class ParameterProcessorTests
     }
 
     [Fact]
+    public async Task DeleteParameterCoreAsync_WhenDeploymentStateDeleteFails_ReturnsFailure()
+    {
+        var capturingStateManager = new CapturingMockDeploymentStateManager { ThrowOnDeleteSection = true };
+        var parameterProcessor = CreateParameterProcessor(deploymentStateManager: capturingStateManager);
+        var parameter = CreateParameterResource("testParam", "initialValue");
+
+        await parameterProcessor.InitializeParametersAsync([parameter]).DefaultTimeout();
+        await parameterProcessor.SetParameterCoreAsync(parameter, CreateSetParameterArguments("savedValue", saveToUserSecrets: "true"), CancellationToken.None).DefaultTimeout();
+
+        var result = await parameterProcessor.DeleteParameterCoreAsync(parameter, CreateDeleteParameterArguments(deleteFromUserSecrets: "true"), CancellationToken.None).DefaultTimeout();
+
+        Assert.False(result.Success);
+        Assert.Equal("Failed to delete parameter 'testParam'.", result.Message);
+        Assert.True(capturingStateManager.State.TryGetPropertyValue($"Parameters:{parameter.Name}", out var savedValueNode));
+        Assert.Equal("savedValue", savedValueNode?.GetValue<string>());
+    }
+
+    [Fact]
     public async Task DeleteParameterCoreAsync_AddsParameterBackToUnresolvedAndStartsResolutionTask()
     {
         var capturingStateManager = new CapturingMockDeploymentStateManager();
@@ -1482,6 +1506,7 @@ public class ParameterProcessorTests
         // Provides the flattened state for verification, matching what FileDeploymentStateManager saves to disk
         public JsonObject State => _flattenedState ?? [];
         public string? StateFilePath => null;
+        public bool ThrowOnDeleteSection { get; init; }
 
         public Task<DeploymentStateSection> AcquireSectionAsync(string sectionName, CancellationToken cancellationToken = default)
         {
@@ -1511,6 +1536,11 @@ public class ParameterProcessorTests
 
         public Task DeleteSectionAsync(DeploymentStateSection section, CancellationToken cancellationToken = default)
         {
+            if (ThrowOnDeleteSection)
+            {
+                throw new IOException("Failed to delete section.");
+            }
+
             // Increment version to allow multiple saves with the same instance (mimics FileDeploymentStateManager)
             section.Version++;
 

--- a/tests/Aspire.Hosting.Tests/Orchestrator/ParameterProcessorTests.cs
+++ b/tests/Aspire.Hosting.Tests/Orchestrator/ParameterProcessorTests.cs
@@ -891,8 +891,41 @@ public class ParameterProcessorTests
                 Assert.Equal(ParameterProcessor.SetParameterValueName, valueInput.Name);
                 Assert.Equal("testParam", valueInput.Label);
                 Assert.Equal("testValue", valueInput.Value);
+                Assert.True(valueInput.Required);
             },
             saveInput => Assert.Equal(ParameterProcessor.SaveToUserSecretsName, saveInput.Name));
+    }
+
+    [Fact]
+    public async Task ProcessParameterAsync_WithSavedState_DefaultsSaveArgumentToTrue()
+    {
+        var testInteractionService = new TestInteractionService { IsAvailable = true };
+        var deploymentStateManager = new CapturingMockDeploymentStateManager();
+        var parameter = CreateParameterResource("testParam", "testValue");
+        var section = await deploymentStateManager.AcquireSectionAsync(parameter.ConfigurationKey).DefaultTimeout();
+        section.SetValue("testValue");
+        await deploymentStateManager.SaveSectionAsync(section).DefaultTimeout();
+
+        var parameterProcessor = CreateParameterProcessor(
+            interactionService: testInteractionService,
+            deploymentStateManager: deploymentStateManager);
+
+        await parameterProcessor.InitializeParametersAsync([parameter]).DefaultTimeout();
+
+        var setValueCommand = parameter.Annotations.OfType<ResourceCommandAnnotation>()
+            .Single(a => a.Name == KnownResourceCommands.SetParameterCommand);
+        var arguments = new InteractionInputCollection(setValueCommand.Arguments);
+        var saveInput = arguments[ParameterProcessor.SaveToUserSecretsName];
+
+        await saveInput.DynamicLoading!.LoadCallback(new LoadInputContext
+        {
+            Input = saveInput,
+            AllInputs = arguments,
+            Services = new ServiceCollection().BuildServiceProvider(),
+            CancellationToken = CancellationToken.None
+        }).DefaultTimeout();
+
+        Assert.Equal("true", saveInput.Value);
     }
 
     [Fact]

--- a/tests/Aspire.Hosting.Tests/ResourceCommandServiceTests.cs
+++ b/tests/Aspire.Hosting.Tests/ResourceCommandServiceTests.cs
@@ -412,6 +412,26 @@ public class ResourceCommandServiceTests(ITestOutputHelper testOutputHelper)
         Assert.True(result.Success);
     }
 
+    [Theory]
+    [InlineData("set-parameter", "parameter-set")]
+    [InlineData("delete-parameter", "parameter-delete")]
+    public async Task ExecuteCommandAsync_LegacyParameterCommandName_FallsBackToCurrentName(string currentCommandName, string legacyCommandName)
+    {
+        using var builder = TestDistributedApplicationBuilder.Create(testOutputHelper);
+
+        var custom = builder.AddResource(new CustomResource("myResource"));
+        custom.WithCommand(name: currentCommandName,
+                displayName: "Parameter command",
+                executeCommand: _ => Task.FromResult(new ExecuteCommandResult { Success = true }));
+
+        var app = builder.Build();
+        await app.StartAsync();
+
+        var result = await app.ResourceCommands.ExecuteCommandAsync(custom.Resource, legacyCommandName);
+
+        Assert.True(result.Success);
+    }
+
     [Fact]
     public async Task ExecuteCommandAsync_SuccessWithResult_ReturnsResultData()
     {

--- a/tests/Aspire.Hosting.Tests/ResourceCommandServiceTests.cs
+++ b/tests/Aspire.Hosting.Tests/ResourceCommandServiceTests.cs
@@ -685,6 +685,70 @@ public class ResourceCommandServiceTests(ITestOutputHelper testOutputHelper)
     }
 
     [Fact]
+    public async Task CreateCommandArguments_DisabledNamedArgumentValues_ReturnsError()
+    {
+        using var builder = TestDistributedApplicationBuilder.Create(testOutputHelper);
+
+        var custom = builder.AddResource(new CustomResource("myResource"));
+        custom.WithCommand(name: "mycommand",
+                displayName: "My command",
+                executeCommand: _ => Task.FromResult(CommandResults.Success()),
+                commandOptions: new CommandOptions
+                {
+                    Arguments =
+                    [
+                        new InteractionInput
+                        {
+                            Name = "saveToUserSecrets",
+                            InputType = InputType.Boolean,
+                            Disabled = true
+                        }
+                    ]
+                });
+
+        var app = builder.Build();
+        await app.StartAsync();
+
+        var argumentValues = new Dictionary<string, string?> { ["saveToUserSecrets"] = "true" };
+        var (arguments, errorMessage) = app.ResourceCommands.CreateCommandArguments("myResource", "mycommand", argumentValues);
+
+        Assert.Equal("Argument 'saveToUserSecrets' for command 'mycommand' is disabled.", errorMessage);
+        Assert.Equal("true", arguments.GetString("saveToUserSecrets"));
+    }
+
+    [Fact]
+    public async Task CreateCommandArguments_DisabledOrderedArgumentValues_ReturnsError()
+    {
+        using var builder = TestDistributedApplicationBuilder.Create(testOutputHelper);
+
+        var custom = builder.AddResource(new CustomResource("myResource"));
+        custom.WithCommand(name: "mycommand",
+                displayName: "My command",
+                executeCommand: _ => Task.FromResult(CommandResults.Success()),
+                commandOptions: new CommandOptions
+                {
+                    Arguments =
+                    [
+                        new InteractionInput
+                        {
+                            Name = "saveToUserSecrets",
+                            InputType = InputType.Boolean,
+                            Disabled = true
+                        }
+                    ]
+                });
+
+        var app = builder.Build();
+        await app.StartAsync();
+
+        IReadOnlyList<string?> argumentValues = ["true"];
+        var (arguments, errorMessage) = app.ResourceCommands.CreateCommandArguments("myResource", "mycommand", argumentValues);
+
+        Assert.Equal("Argument 'saveToUserSecrets' for command 'mycommand' is disabled.", errorMessage);
+        Assert.Equal("true", arguments.GetString("saveToUserSecrets"));
+    }
+
+    [Fact]
     public async Task ExecuteCommandAsync_NoArguments_PassesEmptyArgumentsToCommand()
     {
         using var builder = TestDistributedApplicationBuilder.Create(testOutputHelper);

--- a/tests/Shared/Docker/Dockerfile.e2e
+++ b/tests/Shared/Docker/Dockerfile.e2e
@@ -1,7 +1,7 @@
 # Multi-stage Dockerfile for Aspire E2E testing (.NET variant).
 #
 # Includes: .NET SDK 10.0, Docker CLI (via host socket mount), gh CLI,
-#           Node.js, Python, Aspire install scripts.
+#           jq, Node.js, Python, Aspire install scripts.
 #
 # Usage:
 #   Local dev (build from source):
@@ -59,7 +59,7 @@ ARG UBUNTU_APT_MIRROR=
 COPY tests/Shared/Docker/configure-ubuntu-apt-mirror.sh /usr/local/bin/
 RUN sh /usr/local/bin/configure-ubuntu-apt-mirror.sh "$UBUNTU_APT_MIRROR"
 RUN apt-get update -qq && \
-    apt-get install -y --no-install-recommends gpg docker.io docker-buildx docker-compose-v2 unzip && \
+    apt-get install -y --no-install-recommends gpg docker.io docker-buildx docker-compose-v2 jq unzip && \
     curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg \
       | gpg --dearmor -o /usr/share/keyrings/githubcli-archive-keyring.gpg && \
     echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" \


### PR DESCRIPTION
## Description

Updates built-in resource commands to declare structured `Arguments` on `ResourceCommandAnnotation` so command values can be supplied consistently by callers such as the dashboard, CLI, and MCP instead of each command prompting manually through `IInteractionService`.

Changed commands:

| Command | Project | Arguments |
| --- | --- | --- |
| `parameter-set` | Aspire.Hosting | `value`, `save-to-user-secrets` |
| `parameter-delete` | Aspire.Hosting | `delete-from-user-secrets` |
| `ef-migrations-add` | Aspire.Hosting.EntityFrameworkCore | `name` |
| `configure-tracked-browser` | Aspire.Hosting.Browsers | `scope`, `browser`, `user-data-mode`, `profile`, `save-to-user-secrets` |
| `send-message` | Aspire.Hosting.Foundry | `message` |

Additional changes:

- Updates dashboard resource command mapping for argument-based command execution.
- Returns Foundry `send-message` output through `CommandResultData` instead of an interaction prompt.
- Makes the `set-parameter` value input required and preserves the save-to-user-secrets default when saved deployment state exists.
- Adds hosting and CLI validation so explicitly supplied disabled command arguments are rejected.
- Sets browser logs save-to-user-secrets input state when command arguments are created.
- Adds internal `InteractionInput` helpers for generated parameter inputs to set the command-specific name and required state without cloning the input.
- Adds CLI, hosting, browser, and end-to-end test coverage for argument mapping, parameter set/delete behavior, disabled arguments, and browser input defaults.
- Installs `jq` in the CLI E2E .NET Docker image because the resource command E2E test asserts JSON describe output inside the test container.

## Validation

- `dotnet test --project tests/Aspire.Cli.Tests/Aspire.Cli.Tests.csproj --no-launch-profile -- --filter-not-trait "quarantined=true" --filter-not-trait "outerloop=true"`
- Focused hosting, browser, resource command service, and CLI tests for the changed behavior.
- `git diff --check`

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
