### PR TITLE
Fix TypeScript AppHost RID-specific integration assets

### DIFF
--- a/src/Aspire.Cli/Projects/PrebuiltAppHostServer.cs
+++ b/src/Aspire.Cli/Projects/PrebuiltAppHostServer.cs
@@ -220,7 +220,7 @@ internal sealed class PrebuiltAppHostServer : IAppHostServerProject
             _logger.LogWarning(ex, "Failed to configure NuGet sources for integration project build");
         }
 
-        var projectContent = GenerateIntegrationProjectFile(packageRefs, projectRefs, outputDir, channelSources);
+        var projectContent = GenerateIntegrationProjectFile(packageRefs, projectRefs, outputDir, channelSources, RuntimeInformation.RuntimeIdentifier);
         var projectFilePath = Path.Combine(restoreDir, "IntegrationRestore.csproj");
         await File.WriteAllTextAsync(projectFilePath, projectContent, cancellationToken);
 
@@ -273,7 +273,8 @@ internal sealed class PrebuiltAppHostServer : IAppHostServerProject
         List<IntegrationReference> packageRefs,
         List<IntegrationReference> projectRefs,
         string outputDir,
-        IEnumerable<string>? additionalSources = null)
+        IEnumerable<string>? additionalSources = null,
+        string? runtimeIdentifier = null)
     {
         var propertyGroup = new XElement("PropertyGroup",
             new XElement("TargetFramework", DotNetBasedAppHostServerProject.TargetFramework),
@@ -283,6 +284,11 @@ internal sealed class PrebuiltAppHostServer : IAppHostServerProject
             new XElement("EnableNETAnalyzers", "false"),
             new XElement("GenerateDocumentationFile", "false"),
             new XElement("OutDir", outputDir));
+
+        if (!string.IsNullOrWhiteSpace(runtimeIdentifier))
+        {
+            propertyGroup.Add(new XElement("RuntimeIdentifier", runtimeIdentifier));
+        }
 
         // Add channel sources without replacing the user's nuget.config
         if (additionalSources is not null)

--- a/src/Aspire.Managed/NuGet/Commands/LayoutCommand.cs
+++ b/src/Aspire.Managed/NuGet/Commands/LayoutCommand.cs
@@ -6,6 +6,7 @@ using System.Globalization;
 using System.Runtime.InteropServices;
 using NuGet.Frameworks;
 using NuGet.ProjectModel;
+using NuGet.RuntimeModel;
 
 namespace Aspire.Managed.NuGet.Commands;
 
@@ -15,6 +16,10 @@ namespace Aspire.Managed.NuGet.Commands;
 /// </summary>
 public static class LayoutCommand
 {
+    private const string RuntimeIdentifierGraphResourceName = "Aspire.Managed.RuntimeIdentifierGraph.json";
+    private const string RuntimeAssetType = "runtime";
+    private const string NativeAssetType = "native";
+
     /// <summary>
     /// Creates the layout command.
     /// </summary>
@@ -113,6 +118,8 @@ public static class LayoutCommand
             var skippedCount = 0;
 
             var packagesPath = GetPackagesPath(lockFile);
+            var runtimeGraph = ReadRuntimeGraph();
+            var runtimeIdentifierRanks = GetRuntimeIdentifierRanks(runtimeGraph, effectiveRuntimeIdentifier);
 
             if (verbose)
             {
@@ -129,6 +136,7 @@ public static class LayoutCommand
                     library,
                     packagesPath,
                     outputPath,
+                    runtimeIdentifierRanks,
                     verbose);
 
                 copiedCount += libraryCopiedCount;
@@ -180,6 +188,7 @@ public static class LayoutCommand
         LockFileTargetLibrary library,
         string packagesPath,
         string outputPath,
+        IReadOnlyDictionary<string, int> runtimeIdentifierRanks,
         bool verbose)
     {
         if (library.Type != "package")
@@ -203,7 +212,7 @@ public static class LayoutCommand
 
         var copiedCount = 0;
         copiedCount += CopyRuntimeAssemblies(library.RuntimeAssemblies, packagePath, outputPath, verbose);
-        copiedCount += CopyRuntimeTargets(library.RuntimeTargets, packagePath, outputPath, verbose);
+        copiedCount += CopyRuntimeTargets(library.RuntimeTargets, packagePath, outputPath, runtimeIdentifierRanks, verbose);
         copiedCount += CopyResourceAssemblies(library.ResourceAssemblies, packagePath, outputPath, verbose);
         copiedCount += CopyNativeLibraries(library.NativeLibraries, packagePath, outputPath, verbose);
 
@@ -281,9 +290,11 @@ public static class LayoutCommand
         IEnumerable<LockFileRuntimeTarget> runtimeTargets,
         string packagePath,
         string outputPath,
+        IReadOnlyDictionary<string, int> runtimeIdentifierRanks,
         bool verbose)
     {
         var copiedCount = 0;
+        var bestFlatTargets = new Dictionary<string, FlatRuntimeTargetCandidate>(StringComparer.OrdinalIgnoreCase);
 
         foreach (var runtimeTarget in runtimeTargets)
         {
@@ -307,6 +318,31 @@ public static class LayoutCommand
                 {
                     Console.WriteLine($"  Copy ({runtimeTarget.AssetType} target): {sourcePath} -> {destPath}");
                 }
+            }
+
+            if (TryGetFlatRuntimeTargetRank(runtimeTarget, runtimeIdentifierRanks, out var rank))
+            {
+                // Some packages, including Microsoft.Data.SqlClient, put the real platform
+                // implementation in runtimeTargets while keeping an unsupported assembly in
+                // lib/. The apphost server probes a flat directory, so keep structured copies
+                // for diagnostics but flatten exactly the best RID-compatible asset.
+                var key = $"{runtimeTarget.AssetType}|{Path.GetFileName(sourcePath)}";
+                if (!bestFlatTargets.TryGetValue(key, out var existing) || rank < existing.Rank)
+                {
+                    bestFlatTargets[key] = new FlatRuntimeTargetCandidate(runtimeTarget, sourcePath, rank);
+                }
+            }
+        }
+
+        foreach (var candidate in bestFlatTargets.Values)
+        {
+            var destPath = Path.Combine(outputPath, Path.GetFileName(candidate.SourcePath));
+            CopyAlways(candidate.SourcePath, destPath, createDirectory: false);
+            copiedCount++;
+
+            if (verbose)
+            {
+                Console.WriteLine($"  Copy ({candidate.RuntimeTarget.AssetType} target flat): {candidate.SourcePath} -> {destPath}");
             }
         }
 
@@ -406,6 +442,49 @@ public static class LayoutCommand
         return copiedCount;
     }
 
+    private static RuntimeGraph ReadRuntimeGraph()
+    {
+        using var resourceStream = typeof(LayoutCommand).Assembly.GetManifestResourceStream(RuntimeIdentifierGraphResourceName)
+            ?? throw new InvalidOperationException($"Embedded runtime identifier graph resource '{RuntimeIdentifierGraphResourceName}' was not found.");
+
+        return JsonRuntimeFormat.ReadRuntimeGraph(resourceStream);
+    }
+
+    private static IReadOnlyDictionary<string, int> GetRuntimeIdentifierRanks(RuntimeGraph runtimeGraph, string runtimeIdentifier)
+    {
+        var ranks = new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase);
+        var rank = 0;
+
+        foreach (var candidateRuntimeIdentifier in runtimeGraph.ExpandRuntime(runtimeIdentifier))
+        {
+            ranks.TryAdd(candidateRuntimeIdentifier, rank++);
+        }
+
+        ranks.TryAdd(runtimeIdentifier, 0);
+
+        return ranks;
+    }
+
+    private static bool TryGetFlatRuntimeTargetRank(
+        LockFileRuntimeTarget runtimeTarget,
+        IReadOnlyDictionary<string, int> runtimeIdentifierRanks,
+        out int rank)
+    {
+        rank = 0;
+
+        if (!IsFlattenedRuntimeTargetAssetType(runtimeTarget.AssetType) ||
+            string.IsNullOrWhiteSpace(runtimeTarget.Runtime))
+        {
+            return false;
+        }
+
+        return runtimeIdentifierRanks.TryGetValue(runtimeTarget.Runtime, out rank);
+    }
+
+    private static bool IsFlattenedRuntimeTargetAssetType(string? assetType) =>
+        string.Equals(assetType, RuntimeAssetType, StringComparison.OrdinalIgnoreCase) ||
+        string.Equals(assetType, NativeAssetType, StringComparison.OrdinalIgnoreCase);
+
     private static bool CopyIfNewer(string sourcePath, string destPath, bool createDirectory)
     {
         if (File.Exists(destPath) &&
@@ -423,9 +502,20 @@ public static class LayoutCommand
         return true;
     }
 
+    private static void CopyAlways(string sourcePath, string destPath, bool createDirectory)
+    {
+        if (createDirectory)
+        {
+            Directory.CreateDirectory(Path.GetDirectoryName(destPath)!);
+        }
+
+        File.Copy(sourcePath, destPath, overwrite: true);
+    }
+
     private static bool IsPlaceholderPath(string path)
     {
         return string.Equals(Path.GetFileName(path), "_._", StringComparison.OrdinalIgnoreCase);
     }
 
+    private sealed record FlatRuntimeTargetCandidate(LockFileRuntimeTarget RuntimeTarget, string SourcePath, int Rank);
 }

--- a/tests/Aspire.Cli.Tests/Projects/PrebuiltAppHostServerTests.cs
+++ b/tests/Aspire.Cli.Tests/Projects/PrebuiltAppHostServerTests.cs
@@ -126,6 +126,16 @@ public class PrebuiltAppHostServerTests(ITestOutputHelper outputHelper)
     }
 
     [Fact]
+    public void GenerateIntegrationProjectFile_IncludesRuntimeIdentifierWhenProvided()
+    {
+        var xml = PrebuiltAppHostServer.GenerateIntegrationProjectFile([], [], "/tmp/libs", runtimeIdentifier: "win-x64");
+        var doc = XDocument.Parse(xml);
+
+        var ns = doc.Root!.GetDefaultNamespace();
+        Assert.Equal("win-x64", doc.Descendants(ns + "RuntimeIdentifier").FirstOrDefault()?.Value);
+    }
+
+    [Fact]
     public void GenerateIntegrationProjectFile_WithAdditionalSources_SetsRestoreAdditionalProjectSources()
     {
         var sources = new[] { "/local/packages", "https://my-feed/v3/index.json" };

--- a/tests/Aspire.Hosting.RemoteHost.Tests/LayoutCommandTests.cs
+++ b/tests/Aspire.Hosting.RemoteHost.Tests/LayoutCommandTests.cs
@@ -142,6 +142,66 @@ public class LayoutCommandTests
         }
     }
 
+    [Fact]
+    public async Task LayoutCommand_FlattensBestMatchingRuntimeTargets_WhenRidTargetIsMissing()
+    {
+        var workspaceRoot = Directory.CreateTempSubdirectory("aspire-layout-tests").FullName;
+
+        try
+        {
+            const string runtimeIdentifier = "win-x64";
+            const string nativeFileName = "TestNative.dll";
+
+            var packageRoot = Path.Combine(workspaceRoot, "packages", "test.package", "1.0.0");
+            Directory.CreateDirectory(Path.Combine(packageRoot, "lib", "net10.0"));
+            Directory.CreateDirectory(Path.Combine(packageRoot, "runtimes", "win", "lib", "net10.0"));
+            Directory.CreateDirectory(Path.Combine(packageRoot, "runtimes", "unix", "lib", "net10.0"));
+            Directory.CreateDirectory(Path.Combine(packageRoot, "runtimes", "win-x64", "native"));
+            Directory.CreateDirectory(Path.Combine(packageRoot, "runtimes", "linux-x64", "native"));
+
+            await File.WriteAllTextAsync(Path.Combine(packageRoot, "lib", "net10.0", "Test.Package.dll"), "base");
+            await File.WriteAllTextAsync(Path.Combine(packageRoot, "runtimes", "win", "lib", "net10.0", "Test.Package.dll"), "win");
+            await File.WriteAllTextAsync(Path.Combine(packageRoot, "runtimes", "unix", "lib", "net10.0", "Test.Package.dll"), "unix");
+            await File.WriteAllTextAsync(Path.Combine(packageRoot, "runtimes", "win-x64", "native", nativeFileName), "win-native");
+            await File.WriteAllTextAsync(Path.Combine(packageRoot, "runtimes", "linux-x64", "native", "libTestNative.so"), "linux-native");
+
+            var assetsPath = Path.Combine(workspaceRoot, "project.assets.json");
+            await File.WriteAllTextAsync(assetsPath, CreateAssetsJsonWithRuntimeTargetsOnly(workspaceRoot, nativeFileName));
+
+            var outputPath = Path.Combine(workspaceRoot, "out");
+            var command = LayoutCommand.Create();
+            var parseResult = command.Parse([
+                "--assets", assetsPath,
+                "--output", outputPath,
+                "--framework", "net10.0",
+                "--runtime-identifier", runtimeIdentifier
+            ]);
+
+            var exitCode = await parseResult.InvokeAsync();
+
+            Assert.Equal(0, exitCode);
+            Assert.Equal("win", await File.ReadAllTextAsync(Path.Combine(outputPath, "Test.Package.dll")));
+            Assert.Equal("win-native", await File.ReadAllTextAsync(Path.Combine(outputPath, nativeFileName)));
+            Assert.False(File.Exists(Path.Combine(outputPath, "libTestNative.so")));
+            Assert.Equal(
+                "win",
+                await File.ReadAllTextAsync(Path.Combine(outputPath, "runtimes", "win", "lib", "net10.0", "Test.Package.dll")));
+            Assert.Equal(
+                "unix",
+                await File.ReadAllTextAsync(Path.Combine(outputPath, "runtimes", "unix", "lib", "net10.0", "Test.Package.dll")));
+            Assert.Equal(
+                "linux-native",
+                await File.ReadAllTextAsync(Path.Combine(outputPath, "runtimes", "linux-x64", "native", "libTestNative.so")));
+        }
+        finally
+        {
+            if (Directory.Exists(workspaceRoot))
+            {
+                Directory.Delete(workspaceRoot, recursive: true);
+            }
+        }
+    }
+
     private static string CreateAssetsJsonWithResolvedRidTarget(string rootPath, string runtimeIdentifier, string nativeFileName)
     {
         var packagesPath = Path.Combine(rootPath, "packages") + Path.DirectorySeparatorChar;
@@ -325,6 +385,77 @@ public class LayoutCommandTests
                   "path": "test.package/1.0.0",
                   "files": [
                     "lib/net10.0/Test.Package.dll"
+                  ]
+                }
+              },
+              "packageFolders": {
+                "{{escapedPackagesPath}}": {}
+              },
+              "project": {
+                "version": "1.0.0",
+                "restore": {
+                  "projectUniqueName": "test",
+                  "projectName": "test",
+                  "projectPath": "test",
+                  "packagesPath": "{{escapedPackagesPath}}",
+                  "outputPath": "{{escapedOutputPath}}",
+                  "projectStyle": "PackageReference",
+                  "originalTargetFrameworks": [ "net10.0" ],
+                  "sources": {},
+                  "frameworks": {
+                    "net10.0": {
+                      "targetAlias": "net10.0",
+                      "projectReferences": {}
+                    }
+                  }
+                },
+                "frameworks": {
+                  "net10.0": {
+                    "targetAlias": "net10.0",
+                    "dependencies": {}
+                  }
+                }
+              }
+            }
+            """;
+    }
+
+    private static string CreateAssetsJsonWithRuntimeTargetsOnly(string rootPath, string nativeFileName)
+    {
+        var packagesPath = Path.Combine(rootPath, "packages") + Path.DirectorySeparatorChar;
+        var escapedPackagesPath = packagesPath.Replace("\\", "\\\\");
+        var outputPath = Path.Combine(rootPath, "obj") + Path.DirectorySeparatorChar;
+        var escapedOutputPath = outputPath.Replace("\\", "\\\\");
+
+        return $$"""
+            {
+              "version": 3,
+              "targets": {
+                "net10.0": {
+                  "Test.Package/1.0.0": {
+                    "type": "package",
+                    "runtime": {
+                      "lib/net10.0/Test.Package.dll": {}
+                    },
+                    "runtimeTargets": {
+                      "runtimes/win/lib/net10.0/Test.Package.dll": { "rid": "win", "assetType": "runtime" },
+                      "runtimes/unix/lib/net10.0/Test.Package.dll": { "rid": "unix", "assetType": "runtime" },
+                      "runtimes/win-x64/native/{{nativeFileName}}": { "rid": "win-x64", "assetType": "native" },
+                      "runtimes/linux-x64/native/libTestNative.so": { "rid": "linux-x64", "assetType": "native" }
+                    }
+                  }
+                }
+              },
+              "libraries": {
+                "Test.Package/1.0.0": {
+                  "type": "package",
+                  "path": "test.package/1.0.0",
+                  "files": [
+                    "lib/net10.0/Test.Package.dll",
+                    "runtimes/win/lib/net10.0/Test.Package.dll",
+                    "runtimes/unix/lib/net10.0/Test.Package.dll",
+                    "runtimes/win-x64/native/{{nativeFileName}}",
+                    "runtimes/linux-x64/native/libTestNative.so"
                   ]
                 }
               },


### PR DESCRIPTION
## Description

TypeScript/polyglot AppHosts using the prebuilt AppHost server can materialize integration assemblies into a flat probing directory. When local project integrations are present, the temporary integration restore project did not specify a runtime identifier, which could leave unsupported root assemblies, such as Microsoft.Data.SqlClient, ahead of the Windows runtime asset.

This updates the generated integration restore project to use the current runtime identifier and hardens the NuGet layout command to flatten the best compatible `runtimeTargets` managed/native asset when it falls back to a framework-only target. Structured runtime asset copies are preserved for diagnostics and compatibility.

Validated with focused `LayoutCommandTests` and `PrebuiltAppHostServerTests` coverage for the generated RID property and meaningful RID-specific synthetic assets.

Fixes: #17011

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No