### PR TITLE
Fail fast when bundle lock directory is not writable by current user

### DIFF
--- a/src/Aspire.Cli/Bundles/BundleService.cs
+++ b/src/Aspire.Cli/Bundles/BundleService.cs
@@ -112,11 +112,11 @@ internal sealed class BundleService(IBundlePayloadProvider payloadProvider, ILay
         // Use a file lock for cross-process synchronization
         var lockPath = Path.Combine(destinationPath, ".aspire-bundle-lock");
         logger.LogDebug("Acquiring bundle extraction lock at {LockPath}...", lockPath);
-        using var fileLock = await FileLock.AcquireAsync(lockPath, cancellationToken).ConfigureAwait(false);
-        logger.LogDebug("Bundle extraction lock acquired.");
 
         try
         {
+            using var fileLock = await FileLock.AcquireAsync(lockPath, cancellationToken).ConfigureAwait(false);
+            logger.LogDebug("Bundle extraction lock acquired.");
             // Re-check after acquiring lock — another process may have already extracted
             if (!force && layoutDiscovery.DiscoverLayout() is not null)
             {
@@ -132,6 +132,13 @@ internal sealed class BundleService(IBundlePayloadProvider payloadProvider, ILay
             }
 
             return await ExtractCoreAsync(destinationPath, cancellationToken);
+        }
+        catch (UnauthorizedAccessException ex)
+        {
+            throw new UnauthorizedAccessException(
+                $"Cannot write to bundle extraction directory '{destinationPath}'. " +
+                $"Run the command with elevated permissions (e.g., sudo on Linux/macOS), or reinstall the Aspire CLI to a user-writable location.",
+                ex);
         }
         catch (Exception ex)
         {

--- a/src/Aspire.Cli/Bundles/BundleService.cs
+++ b/src/Aspire.Cli/Bundles/BundleService.cs
@@ -135,10 +135,11 @@ internal sealed class BundleService(IBundlePayloadProvider payloadProvider, ILay
         }
         catch (UnauthorizedAccessException ex)
         {
-            throw new UnauthorizedAccessException(
-                $"Cannot write to bundle extraction directory '{destinationPath}'. " +
-                $"Run the command with elevated permissions (e.g., sudo on Linux/macOS), or reinstall the Aspire CLI to a user-writable location.",
-                ex);
+            logger.LogError(
+                ex,
+                "Failed to extract bundle to {Path}: Insufficient permissions. Run the command with elevated permissions (e.g., sudo on Linux/macOS), or reinstall the Aspire CLI to a user-writable location.",
+                destinationPath);
+            return BundleExtractResult.ExtractionFailed;
         }
         catch (Exception ex)
         {

--- a/src/Aspire.Cli/Commands/UpdateCommand.cs
+++ b/src/Aspire.Cli/Commands/UpdateCommand.cs
@@ -272,13 +272,6 @@ internal sealed class UpdateCommand : BaseCommand
                 }
             }
         }
-        catch (UnauthorizedAccessException ex)
-        {
-            var message = Markup.Escape(ex.Message);
-            Telemetry.RecordError(message, ex);
-            InteractionService.DisplayError(message);
-            return ExitCodeConstants.FailedToUpgradeProject;
-        }
         catch (ProjectUpdaterException ex)
         {
             var message = Markup.Escape(ex.Message);

--- a/src/Aspire.Cli/Commands/UpdateCommand.cs
+++ b/src/Aspire.Cli/Commands/UpdateCommand.cs
@@ -272,6 +272,13 @@ internal sealed class UpdateCommand : BaseCommand
                 }
             }
         }
+        catch (UnauthorizedAccessException ex)
+        {
+            var message = Markup.Escape(ex.Message);
+            Telemetry.RecordError(message, ex);
+            InteractionService.DisplayError(message);
+            return ExitCodeConstants.FailedToUpgradeProject;
+        }
         catch (ProjectUpdaterException ex)
         {
             var message = Markup.Escape(ex.Message);

--- a/src/Aspire.Cli/Utils/FileLock.cs
+++ b/src/Aspire.Cli/Utils/FileLock.cs
@@ -62,6 +62,10 @@ internal sealed class FileLock : IDisposable
         {
             Directory.CreateDirectory(directory);
         }
+        else
+        {
+            directory = Environment.CurrentDirectory;
+        }
 
         while (true)
         {
@@ -77,7 +81,7 @@ internal sealed class FileLock : IDisposable
                 // FileStream constructor throws immediately; on Unix it may also throw
                 // if the file is exclusively locked. Wait and retry.
             }
-            catch (UnauthorizedAccessException)
+            catch (UnauthorizedAccessException) when (IsDirectoryWritable(directory))
             {
                 // Can occur transiently when the lock file is being deleted
                 // (DeleteOnClose) by the process that just released the lock,
@@ -91,6 +95,14 @@ internal sealed class FileLock : IDisposable
 
             await Task.Delay(s_defaultRetryDelay, cancellationToken).ConfigureAwait(false);
         }
+    }
+
+    private static bool IsDirectoryWritable(string directory)
+    {
+        var probe = Path.Combine(directory, $".aspire-write-probe.{Guid.NewGuid():N}");
+        try { using var _ = new FileStream(probe, FileMode.CreateNew, FileAccess.Write, FileShare.None, bufferSize: 1, FileOptions.DeleteOnClose); return true; }
+        catch (UnauthorizedAccessException) { return false; }
+        catch (IOException) { return true; }
     }
 
     /// <summary>

--- a/tests/Aspire.Cli.Tests/Commands/UpdateCommandTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/UpdateCommandTests.cs
@@ -56,6 +56,41 @@ public class UpdateCommandTests(ITestOutputHelper outputHelper)
     }
 
     [Fact]
+    public async Task UpdateCommand_WhenBundleDirectoryNotWritable_DisplaysError()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        var interactionService = new TestInteractionService();
+
+        var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper, options =>
+        {
+            options.ProjectLocatorFactory = _ => new TestProjectLocator()
+            {
+                UseOrFindAppHostProjectFileAsyncCallback = (projectFile, _, _) =>
+                    Task.FromResult<FileInfo?>(new FileInfo(Path.Combine(workspace.WorkspaceRoot.FullName, "AppHost.csproj")))
+            };
+
+            options.InteractionServiceFactory = _ => interactionService;
+            options.DotNetCliRunnerFactory = _ => new TestDotNetCliRunner();
+            options.PackagingServiceFactory = _ => new TestPackagingService();
+
+            options.ProjectUpdaterFactory = _ => new TestProjectUpdater()
+            {
+                UpdateProjectAsyncCallback = (_, _) =>
+                    throw new UnauthorizedAccessException("Cannot write to bundle extraction directory '/usr/local'.")
+            };
+        });
+
+        using var provider = services.BuildServiceProvider();
+        var command = provider.GetRequiredService<RootCommand>();
+        var result = command.Parse("update --yes");
+
+        var exitCode = await result.InvokeAsync().DefaultTimeout();
+
+        Assert.Equal(ExitCodeConstants.FailedToUpgradeProject, exitCode);
+        Assert.Single(interactionService.DisplayedErrors);
+    }
+
+    [Fact]
     public async Task UpdateCommand_WhenProjectOptionSpecified_PassesProjectFileToProjectLocator()
     {
         using var workspace = TemporaryWorkspace.Create(outputHelper);

--- a/tests/Aspire.Cli.Tests/Utils/FileLockTests.cs
+++ b/tests/Aspire.Cli.Tests/Utils/FileLockTests.cs
@@ -1,0 +1,46 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Aspire.Cli.Utils;
+
+namespace Aspire.Cli.Tests.Utils;
+
+public class FileLockTests(ITestOutputHelper outputHelper)
+{
+    [Fact]
+    public async Task AcquireAsync_Succeeds_InWritableDirectory()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        var lockPath = Path.Combine(workspace.WorkspaceRoot.FullName, ".test-lock");
+
+        using var fileLock = await FileLock.AcquireAsync(lockPath);
+
+        Assert.NotNull(fileLock);
+    }
+
+    [Fact]
+    public async Task AcquireAsync_ThrowsUnauthorizedAccessException_WhenDirectoryNotWritable()
+    {
+        if (OperatingSystem.IsWindows())
+        {
+            Assert.Skip("This test is not applicable on Windows due to differences in file system permissions.");
+            return;
+        }
+
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        var lockedDir = Path.Combine(workspace.WorkspaceRoot.FullName, "readonly");
+        Directory.CreateDirectory(lockedDir);
+
+        var originalMode = File.GetUnixFileMode(lockedDir);
+        File.SetUnixFileMode(lockedDir, UnixFileMode.UserRead | UnixFileMode.UserExecute);
+        try
+        {
+            await Assert.ThrowsAsync<UnauthorizedAccessException>(
+                () => FileLock.AcquireAsync(Path.Combine(lockedDir, ".test-lock"), timeout: TimeSpan.FromSeconds(1)));
+        }
+        finally
+        {
+            File.SetUnixFileMode(lockedDir, originalMode);
+        }
+    }
+}


### PR DESCRIPTION
## Description

Previously, acquiring the bundle extraction lock in a system-wide CLI installation (e.g. `/usr/local`) as a non-root user would silently retry for 5 minutes before timing out with a confusing `TimeoutException`.

Add a `when` filter to the `UnauthorizedAccessException` catch in `FileLock` so only transient access errors are swallowed and retried. Permanent permission denials propagate immediately. Move the `AcquireAsync` call inside the existing try/catch in `BundleService` so it is handled the same way as other extraction failures.

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No

## Other

Maybe a bit more work is needed to make the bundles directory configurable, now `aspire update` assumes CLI is installed to something writable like `~/.aspire`  and requires elevation when running from something like `/usr/local`.