### PR TITLE
Bump remaining 3rd-party deps (deferred — pending dotnet-public mirror)

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -133,7 +133,7 @@
     <PackageVersion Include="StackExchange.Redis" Version="2.13.1" />
     <PackageVersion Include="System.IO.Hashing" Version="10.0.8" />
     <PackageVersion Include="Yarp.ReverseProxy" Version="2.3.0" />
-    <PackageVersion Include="StreamJsonRpc" Version="2.24.92" />
+    <PackageVersion Include="StreamJsonRpc" Version="2.22.23" />
     <PackageVersion Include="Semver" Version="3.0.0" />
     <PackageVersion Include="Sigstore" Version="0.5.0" />
     <PackageVersion Include="Tuf" Version="0.5.0" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -14,7 +14,7 @@
     <!-- Azure SDK for .NET dependencies -->
     <PackageVersion Include="Azure.AI.AgentServer.AgentFramework" Version="1.0.0-beta.11" />
     <PackageVersion Include="Azure.AI.Inference" Version="1.0.0-beta.5" />
-    <PackageVersion Include="Azure.AI.OpenAI" Version="2.8.0-beta.1" />
+    <PackageVersion Include="Azure.AI.OpenAI" Version="2.9.0-beta.1" />
     <PackageVersion Include="Azure.AI.Projects" Version="2.1.0-beta.1" />
     <PackageVersion Include="Azure.Data.Tables" Version="12.11.0" />
     <PackageVersion Include="Azure.Extensions.AspNetCore.Configuration.Secrets" Version="1.5.1" />
@@ -106,9 +106,9 @@
     <PackageVersion Include="Hex1b.Tool" Version="0.154.0" />
     <PackageVersion Include="Humanizer.Core" Version="3.0.10" />
     <PackageVersion Include="KubernetesClient" Version="19.0.2" />
-    <PackageVersion Include="JsonPatch.Net" Version="3.3.0" />
+    <PackageVersion Include="JsonPatch.Net" Version="5.0.2" />
     <PackageVersion Include="Markdig" Version="1.2.0" />
-    <PackageVersion Include="Microsoft.AI.Foundry.Local" Version="0.3.0" />
+    <PackageVersion Include="Microsoft.AI.Foundry.Local" Version="1.1.0" />
     <PackageVersion Include="Microsoft.Agents.AI.OpenAI" Version="1.5.0" />
     <PackageVersion Include="Microsoft.Data.SqlClient" Version="7.0.1" />
     <PackageVersion Include="Microsoft.FluentUI.AspNetCore.Components" Version="4.14.1" />
@@ -119,7 +119,7 @@
     <PackageVersion Include="MongoDB.Driver.Core.Extensions.DiagnosticSources" Version="3.0.0" />
     <PackageVersion Include="MySqlConnector.DependencyInjection" Version="2.5.0" />
     <PackageVersion Include="MySqlConnector.Logging.Microsoft.Extensions.Logging" Version="2.1.0" />
-    <PackageVersion Include="NATS.Net" Version="2.7.3" />
+    <PackageVersion Include="NATS.Net" Version="2.8.0" />
     <PackageVersion Include="NCrontab.Signed" Version="3.4.0" />
     <PackageVersion Include="Npgsql.DependencyInjection" Version="10.0.2" />
     <PackageVersion Include="OpenAI" Version="2.10.0" />
@@ -133,7 +133,7 @@
     <PackageVersion Include="StackExchange.Redis" Version="2.13.1" />
     <PackageVersion Include="System.IO.Hashing" Version="10.0.8" />
     <PackageVersion Include="Yarp.ReverseProxy" Version="2.3.0" />
-    <PackageVersion Include="StreamJsonRpc" Version="2.22.23" />
+    <PackageVersion Include="StreamJsonRpc" Version="2.24.92" />
     <PackageVersion Include="Semver" Version="3.0.0" />
     <PackageVersion Include="Sigstore" Version="0.5.0" />
     <PackageVersion Include="Tuf" Version="0.5.0" />
@@ -182,7 +182,7 @@
     <PackageVersion Include="Microsoft.ApplicationInsights.WorkerService" Version="3.1.1" />
     <!-- playground apps dependencies for AzureFunctionsWithDts -->
     <PackageVersion Include="Microsoft.Azure.Functions.Worker.Extensions.DurableTask" Version="1.16.5" />
-    <PackageVersion Include="Microsoft.Azure.Functions.Worker.Extensions.DurableTask.AzureManaged" Version="1.0.1" />
+    <PackageVersion Include="Microsoft.Azure.Functions.Worker.Extensions.DurableTask.AzureManaged" Version="1.8.0" />
     <!-- playground apps dependencies for javascript -->
     <!-- Pinned versions for Component Governance - Remove when root dependencies are updated -->
     <PackageVersion Include="Azure.Core" Version="1.55.0" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -108,7 +108,7 @@
     <PackageVersion Include="KubernetesClient" Version="19.0.2" />
     <PackageVersion Include="JsonPatch.Net" Version="5.0.2" />
     <PackageVersion Include="Markdig" Version="1.2.0" />
-    <PackageVersion Include="Microsoft.AI.Foundry.Local" Version="1.1.0" />
+    <PackageVersion Include="Microsoft.AI.Foundry.Local" Version="0.3.0" />
     <PackageVersion Include="Microsoft.Agents.AI.OpenAI" Version="1.5.0" />
     <PackageVersion Include="Microsoft.Data.SqlClient" Version="7.0.1" />
     <PackageVersion Include="Microsoft.FluentUI.AspNetCore.Components" Version="4.14.1" />

--- a/tests/Aspire.Components.Common.TestUtilities/ConformanceTests.cs
+++ b/tests/Aspire.Components.Common.TestUtilities/ConformanceTests.cs
@@ -385,10 +385,18 @@ public abstract class ConformanceTests<TService, TOptions>
         Assert.Contains(healthReport.Entries, entry => entry.Value.Status == expected);
     }
 
+    // Component ConfigurationSchema.json files don't declare $schema, so JsonSchema.Net 9.x
+    // defaults to Draft 2020-12 (where `definitions` was replaced by `$defs`) and rejects
+    // the older keywords. Pin the build to Draft 7 explicitly so existing schemas keep working.
+    // Use a fresh local SchemaRegistry per call so re-loading the same schema across tests
+    // doesn't fail with "Overwriting registered schemas is not permitted" against the global registry.
+    private static BuildOptions CreateBuildOptions() =>
+        new() { Dialect = Dialect.Draft07, SchemaRegistry = new SchemaRegistry() };
+
     [Fact]
     public void ConfigurationSchemaValidJsonConfigTest()
     {
-        var schema = JsonSchema.FromFile(JsonSchemaPath);
+        var schema = JsonSchema.FromFile(JsonSchemaPath, CreateBuildOptions());
         // JsonSchema.Net 8.x changed JsonSchema.Evaluate to take JsonElement instead of JsonNode.
         using var config = JsonDocument.Parse(ValidJsonConfig);
 
@@ -400,7 +408,7 @@ public abstract class ConformanceTests<TService, TOptions>
     [Fact]
     public void ConfigurationSchemaInvalidJsonConfigTest()
     {
-        var schema = JsonSchema.FromFile(JsonSchemaPath);
+        var schema = JsonSchema.FromFile(JsonSchemaPath, CreateBuildOptions());
 
         foreach ((string json, string error) in InvalidJsonToErrorMessage)
         {

--- a/tests/Aspire.Components.Common.TestUtilities/ConformanceTests.cs
+++ b/tests/Aspire.Components.Common.TestUtilities/ConformanceTests.cs
@@ -2,7 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Diagnostics;
-using System.Text.Json.Nodes;
+using System.Text.Json;
 using Aspire.TestUtilities;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
@@ -389,9 +389,10 @@ public abstract class ConformanceTests<TService, TOptions>
     public void ConfigurationSchemaValidJsonConfigTest()
     {
         var schema = JsonSchema.FromFile(JsonSchemaPath);
-        var config = JsonNode.Parse(ValidJsonConfig);
+        // JsonSchema.Net 8.x changed JsonSchema.Evaluate to take JsonElement instead of JsonNode.
+        using var config = JsonDocument.Parse(ValidJsonConfig);
 
-        var results = schema.Evaluate(config);
+        var results = schema.Evaluate(config.RootElement);
 
         Assert.True(results.IsValid);
     }
@@ -403,9 +404,10 @@ public abstract class ConformanceTests<TService, TOptions>
 
         foreach ((string json, string error) in InvalidJsonToErrorMessage)
         {
-            var config = JsonNode.Parse(json);
-            var results = schema.Evaluate(config, DefaultEvaluationOptions);
-            var detail = results.Details.FirstOrDefault(x => x.HasErrors);
+            using var config = JsonDocument.Parse(json);
+            var results = schema.Evaluate(config.RootElement, DefaultEvaluationOptions);
+            // EvaluationResults.HasErrors was removed in JsonSchema.Net 8.x; use the Errors dictionary directly.
+            var detail = results.Details?.FirstOrDefault(x => x.Errors is { Count: > 0 });
 
             Assert.NotNull(detail);
             Assert.Equal(error, detail.Errors!.First().Value);

--- a/tests/Aspire.Deployment.EndToEnd.Tests/FoundryHostedAgentDeploymentTests.cs
+++ b/tests/Aspire.Deployment.EndToEnd.Tests/FoundryHostedAgentDeploymentTests.cs
@@ -106,70 +106,104 @@ public sealed class FoundryHostedAgentDeploymentTests(ITestOutputHelper output)
 
             Directory.CreateDirectory(hostedAgentDir);
 
-            // Write minimal hosted agent .csproj
-            // The project is created outside the repo, so it has no central package management.
-            // Explicit versions are required, matching those from the playground DotNetHostedAgent.
+            // Write minimal hosted agent .csproj.
+            // The package set and explicit versions below must stay in sync with
+            // playground/FoundryAgents/DotNetHostedAgent/DotNetHostedAgent.csproj.
+            // This project is materialized at test runtime outside the repo, so it does not
+            // participate in central package management; the playground's `VersionOverride`
+            // values become explicit `Version` values here. Update both files together.
             File.WriteAllText(Path.Combine(hostedAgentDir, "DotNetHostedAgent.csproj"), """
-                <Project Sdk="Microsoft.NET.Sdk">
+                <Project Sdk="Microsoft.NET.Sdk.Web">
                   <PropertyGroup>
-                    <OutputType>Exe</OutputType>
                     <TargetFramework>net10.0</TargetFramework>
                     <Nullable>enable</Nullable>
                     <ImplicitUsings>enable</ImplicitUsings>
-                    <EnablePreviewFeatures>true</EnablePreviewFeatures>
+                    <!-- Suppress experimental API warnings from Agent Framework Foundry packages -->
+                    <NoWarn>$(NoWarn);OPENAI001;MAIF001</NoWarn>
                   </PropertyGroup>
                   <ItemGroup>
-                    <PackageReference Include="Azure.AI.AgentServer.AgentFramework" Version="1.0.0-beta.11" />
-                    <PackageReference Include="Azure.AI.Projects" Version="1.2.0-beta.4" />
-                    <PackageReference Include="Azure.AI.OpenAI" Version="2.5.0-beta.1" />
-                    <PackageReference Include="Azure.Identity" Version="1.18.0" />
-                    <PackageReference Include="Microsoft.Agents.AI.OpenAI" Version="1.1.0" />
-                    <PackageReference Include="Microsoft.Extensions.AI" Version="10.4.0" />
-                    <PackageReference Include="Microsoft.Extensions.AI.OpenAI" Version="10.4.0" />
+                    <PackageReference Include="Azure.AI.Projects" Version="2.1.0-beta.1" />
+                    <PackageReference Include="Azure.Identity" Version="1.21.0" />
+                    <PackageReference Include="Microsoft.Agents.AI.Foundry.Hosting" Version="1.4.0-preview.260505.1" />
+                    <PackageReference Include="Microsoft.Extensions.AI" Version="10.5.0" />
+                    <PackageReference Include="ModelContextProtocol" Version="1.1.0" />
                   </ItemGroup>
                 </Project>
                 """);
 
-            // Write minimal hosted agent Program.cs
-            // This follows the same pattern as the playground DotNetHostedAgent:
-            // reads ConnectionStrings__chat, creates an AI agent, and runs on DEFAULT_AD_PORT.
+            // Write minimal hosted agent Program.cs.
+            // Mirrors playground/FoundryAgents/DotNetHostedAgent/Program.cs: reads the
+            // Foundry project + chat connection strings, builds an AIProjectClient-backed
+            // AIAgent, and hosts it as a Foundry Responses endpoint on DEFAULT_AD_PORT.
             File.WriteAllText(Path.Combine(hostedAgentDir, "Program.cs"), """
                 using System.ComponentModel;
                 using System.Data.Common;
-                using Azure.AI.AgentServer.AgentFramework.Extensions;
-                using Azure.AI.OpenAI;
+                using Azure.AI.Projects;
                 using Azure.Identity;
                 using Microsoft.Agents.AI;
+                using Microsoft.Agents.AI.Foundry.Hosting;
                 using Microsoft.Extensions.AI;
+
+                string projectConnectionString = Environment.GetEnvironmentVariable("ConnectionStrings__projmyproject")
+                    ?? throw new InvalidOperationException("ConnectionStrings__projmyproject is not set.");
 
                 string chatConnectionString = Environment.GetEnvironmentVariable("ConnectionStrings__chat")
                     ?? throw new InvalidOperationException("ConnectionStrings__chat is not set.");
 
-                DbConnectionStringBuilder chatConnectionBuilder = new()
+                DbConnectionStringBuilder projectConnectionBuilder = new() { ConnectionString = projectConnectionString };
+                DbConnectionStringBuilder chatConnectionBuilder = new() { ConnectionString = chatConnectionString };
+
+                string projectEndpoint = GetRequiredConnectionValue(projectConnectionBuilder, "Endpoint");
+                string deploymentName = GetRequiredConnectionValue(chatConnectionBuilder, "Deployment");
+
+                if (!Uri.TryCreate(projectEndpoint, UriKind.Absolute, out Uri? projectUri) || projectUri is null)
                 {
-                    ConnectionString = chatConnectionString,
-                };
-
-                string endpoint = chatConnectionBuilder.TryGetValue("Endpoint", out object? epValue) ? epValue?.ToString()! : throw new InvalidOperationException("Missing Endpoint.");
-                string deploymentName = chatConnectionBuilder.TryGetValue("Deployment", out object? dnValue) ? dnValue?.ToString()! : throw new InvalidOperationException("Missing Deployment.");
-
-                Uri openAiEndpoint = new(endpoint);
+                    throw new InvalidOperationException("ConnectionStrings__projmyproject contains an invalid Endpoint value.");
+                }
 
                 [Description("Get a weather forecast")]
                 string GetWeatherForecast() => "Sunny, 25°C";
 
                 DefaultAzureCredential credential = new();
 
-                IChatClient chatClient = new AzureOpenAIClient(openAiEndpoint, credential)
-                    .GetChatClient(deploymentName)
-                    .AsIChatClient();
+                AIAgent agent = new AIProjectClient(projectUri, credential)
+                    .AsAIAgent(
+                        model: deploymentName,
+                        name: "WeatherAgent",
+                        instructions: "You are the Weather Intelligence Agent.",
+                        tools: [AIFunctionFactory.Create(GetWeatherForecast)]);
 
-                AIAgent agent = chatClient.AsAIAgent(
-                    name: "WeatherAgent",
-                    instructions: "You are the Weather Intelligence Agent.",
-                    tools: [AIFunctionFactory.Create(GetWeatherForecast)]);
+                // Bind to the port allocated by Aspire via the DEFAULT_AD_PORT environment variable.
+                string port = Environment.GetEnvironmentVariable("DEFAULT_AD_PORT") ?? "8088";
 
-                await agent.RunAIAgentAsync(telemetrySourceName: "Agents");
+                var builder = WebApplication.CreateBuilder(args);
+                builder.WebHost.UseUrls($"http://+:{port}");
+                builder.Services.AddFoundryResponses(agent);
+
+                var app = builder.Build();
+
+                app.MapFoundryResponses();
+                app.MapGet("/liveness", () => Results.Ok("Healthy"));
+                app.MapGet("/readiness", () => Results.Ok("Ready"));
+
+                app.Run();
+
+                static string GetRequiredConnectionValue(DbConnectionStringBuilder connectionBuilder, string key)
+                {
+                    if (!connectionBuilder.TryGetValue(key, out object? rawValue) || rawValue is null)
+                    {
+                        throw new InvalidOperationException($"Connection string is missing '{key}'.");
+                    }
+
+                    string? value = rawValue.ToString();
+
+                    if (string.IsNullOrWhiteSpace(value))
+                    {
+                        throw new InvalidOperationException($"Connection string has an empty '{key}' value.");
+                    }
+
+                    return value;
+                }
                 """);
 
             // Write Dockerfile for the hosted agent

--- a/tests/Aspire.Hosting.Tests/Schema/SchemaTests.cs
+++ b/tests/Aspire.Hosting.Tests/Schema/SchemaTests.cs
@@ -4,7 +4,7 @@
 #pragma warning disable CS0618 // Type or member is obsolete
 #pragma warning disable ASPIREPIPELINES001
 
-using System.Text.Json.Nodes;
+using System.Text.Json;
 using Aspire.Hosting.Tests.Helpers;
 using Aspire.Hosting.Utils;
 using Azure.Provisioning.KeyVault;
@@ -793,22 +793,24 @@ public class SchemaTests
 
     private static void AssertValid(string manifestText)
     {
-        var manifestJson = JsonNode.Parse(manifestText);
+        // JsonSchema.Net 8.x switched JsonSchema.Evaluate from JsonNode to JsonElement input,
+        // so feed the parsed JsonDocument's root element rather than a JsonNode.
+        using var manifestJson = JsonDocument.Parse(manifestText);
         var schema = GetSchema();
-        var results = schema.Evaluate(manifestJson);
+        var results = schema.Evaluate(manifestJson.RootElement);
 
         if (!results.IsValid)
         {
-            var errorMessages = results.Details.Where(x => x.HasErrors).SelectMany(e => e.Errors!).Select(e => e.Value);
+            var errorMessages = results.Details?.Where(x => x.Errors is not null).SelectMany(e => e.Errors!).Select(e => e.Value);
             Assert.True(results.IsValid, string.Join(Environment.NewLine, errorMessages ?? ["Schema failed validation with no errors"]));
         }
     }
 
     private static void AssertInvalid(string manifestText)
     {
-        var manifestJson = JsonNode.Parse(manifestText);
+        using var manifestJson = JsonDocument.Parse(manifestText);
         var schema = GetSchema();
-        var results = schema.Evaluate(manifestJson);
+        var results = schema.Evaluate(manifestJson.RootElement);
 
         Assert.False(results.IsValid);
     }

--- a/tests/Directory.Packages.props
+++ b/tests/Directory.Packages.props
@@ -6,7 +6,7 @@
   <ItemGroup>
     <!-- unit test dependencies -->
     <PackageVersion Include="bUnit" Version="1.36.0" /> <!-- Can't update passed to 1.37.x versions as those lift up LTS versions when targeting net8 -->
-    <PackageVersion Include="JsonSchema.Net" Version="7.4.0" />
+    <PackageVersion Include="JsonSchema.Net" Version="9.2.1" />
     <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.Analyzer.Testing" Version="1.1.2" />
     <PackageVersion Include="Microsoft.DotNet.RemoteExecutor" Version="$(MicrosoftDotNetRemoteExecutorVersion)" />
     <PackageVersion Include="Microsoft.DotNet.XUnitV3Extensions" Version="$(MicrosoftDotNetXUnitV3ExtensionsVersion)" />


### PR DESCRIPTION
**Draft — blocked on `dotnet-public` AzDO feed mirror or downstream compat work.**

Stacked on top of #17055. This PR bumps the 3rd-party packages that couldn't land in that PR because newer versions either (a) aren't mirrored to the internal `dotnet-public` AzDO feed yet, or (b) cause runtime/analyzer issues with our current build toolchain.

| Package | From | To | Why deferred |
|---|---|---|---|
| `Azure.AI.OpenAI` | 2.8.0-beta.1 | **2.9.0-beta.1** | 2.9.0-beta.1 not on `dotnet-public` feed |
| `NATS.Net` | 2.7.3 | **2.8.0** | 2.8.0 not on `dotnet-public` feed |
| `StreamJsonRpc` | 2.22.23 | **2.24.92** | (a) 2.24.92 not on feed; (b) 2.24.84 analyzer requires Roslyn 4.14.0 but template tests build with .NET 8 SDK / Roslyn 4.11.0 (CS9057 in 16 Templates jobs) |
| `JsonPatch.Net` | 3.3.0 | **5.0.2** | Brings transitive `JsonSchema.Net` 7.0.0 that throws `TypeLoadException: Could not load type 'Json.Pointer.JsonPointer'` at runtime in Hosting + Hosting.Azure tests; needs investigation |
| `Microsoft.AI.Foundry.Local` | 0.3.0 | **1.1.0** | Pulls transitive `Betalgo.Ranul.OpenAI` 9.1.0 — not on `dotnet-public` feed at any version |
| `Microsoft.Azure.Functions.Worker.Extensions.DurableTask.AzureManaged` | 1.0.1 | **1.8.0** | Pulls transitives `Microsoft.DurableTask.Extensions.AzureBlobPayloads`, `Microsoft.DurableTask.AzureManagedBackend.Protobuf`, `Microsoft.DurableTask.Extensions.AzureBlobPayloads.AzureManaged` — none on `dotnet-public` feed |

### Plan

1. Merge #17055 first.
2. Push the missing packages above to the `dotnet-public` AzDO feed.
3. Investigate the JsonPatch.Net 5.x / JsonSchema.Net 7.x type-load issue (likely needs an explicit pin of `JsonPointer.Net` / `JsonSchema.Net`).
4. Investigate the StreamJsonRpc 2.24.x analyzer compat with the template tests (likely needs the templates' SDK roll-forward bumped or the StreamJsonRpc dep removed from template-built apps).
5. Rebase this PR onto `main`, verify the build + CI, mark it Ready for review, and merge.

Restore on this branch is **expected to fail** until step 2 is complete; even when it succeeds, CI is **expected to fail** until steps 3–4 are resolved.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>