### PR TITLE
Fix Keycloak HTTPS primary endpoint

### DIFF
--- a/src/Aspire.Hosting.Keycloak/KeycloakResource.cs
+++ b/src/Aspire.Hosting.Keycloak/KeycloakResource.cs
@@ -14,7 +14,7 @@ public sealed class KeycloakResource(string name, ParameterResource? admin, Para
     : ContainerResource(name), IResourceWithServiceDiscovery
 {
     private const string DefaultAdmin = "admin";
-    internal const string PrimaryEndpointName = "tcp";
+    internal const string PrimaryEndpointName = "http";
 
     /// <summary>
     /// Features to enable for the keycloak resource

--- a/src/Aspire.Hosting.Keycloak/KeycloakResourceBuilderExtensions.cs
+++ b/src/Aspire.Hosting.Keycloak/KeycloakResourceBuilderExtensions.cs
@@ -109,10 +109,18 @@ public static class KeycloakResourceBuilderExtensions
         {
             keycloak.SubscribeHttpsEndpointsUpdate(ctx =>
             {
-                // If a TLS certificate is configured, ensure the keycloak resource has an HTTPS endpoint and
-                // configure the environment variables to use it.
+                // If a TLS certificate is configured, switch the primary endpoint to HTTPS and
+                // tell Keycloak to run its HTTPS listener on the existing endpoint target port.
                 keycloak
-                    .WithHttpsEndpoint(targetPort: DefaultHttpsPort, env: "KC_HTTPS_PORT")
+                    .WithEnvironment(context =>
+                    {
+                        context.EnvironmentVariables["KC_HTTPS_PORT"] = keycloak.GetEndpoint(KeycloakResource.PrimaryEndpointName).Property(EndpointProperty.TargetPort);
+                    })
+                    .WithEndpoint(KeycloakResource.PrimaryEndpointName, ep =>
+                    {
+                        ep.UriScheme = "https";
+                        ep.TargetPort = DefaultHttpsPort;
+                    })
                     .WithEndpoint(ManagementEndpointName, ep => ep.UriScheme = "https");
             });
         }

--- a/tests/Aspire.Hosting.Keycloak.Tests/KeycloakResourceBuilderTests.cs
+++ b/tests/Aspire.Hosting.Keycloak.Tests/KeycloakResourceBuilderTests.cs
@@ -1,10 +1,14 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using Aspire.Hosting.Utils;
+#pragma warning disable ASPIRECERTIFICATES001
+
 using System.Net.Sockets;
-using Microsoft.Extensions.DependencyInjection;
+using System.Security.Cryptography.X509Certificates;
 using Aspire.Hosting.ApplicationModel;
+using Aspire.Hosting.Tests.Utils;
+using Aspire.Hosting.Utils;
+using Microsoft.Extensions.DependencyInjection;
 
 namespace Aspire.Hosting.Keycloak.Tests;
 
@@ -51,6 +55,42 @@ public class KeycloakResourceBuilderTests
         Assert.Equal(KeycloakContainerImageTags.Tag, containerAnnotation.Tag);
         Assert.Equal(KeycloakContainerImageTags.Image, containerAnnotation.Image);
         Assert.Equal(KeycloakContainerImageTags.Registry, containerAnnotation.Registry);
+    }
+
+    [Fact]
+    public async Task AddKeycloakSwitchesPrimaryEndpointToHttpsWhenCertificateAvailable()
+    {
+        using var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Run);
+
+        builder.Services.AddSingleton<IDeveloperCertificateService>(new TestDeveloperCertificateService(
+            new List<X509Certificate2>(),
+            supportsContainerTrust: true,
+            trustCertificate: true,
+            tlsTerminate: false));
+
+        var keycloak = builder.AddKeycloak("keycloak", port: 8080);
+        keycloak.WithAnnotation(new HttpsCertificateAnnotation
+        {
+            UseDeveloperCertificate = true
+        }, ResourceAnnotationMutationBehavior.Replace);
+
+        using var app = builder.Build();
+        var model = app.Services.GetRequiredService<DistributedApplicationModel>();
+
+        var beforeStartEvent = new BeforeStartEvent(app.Services, model);
+        await builder.Eventing.PublishAsync(beforeStartEvent);
+
+        var endpoints = keycloak.Resource.Annotations.OfType<EndpointAnnotation>().ToArray();
+
+        var primaryEndpoint = Assert.Single(endpoints, e => e.Name == "http");
+        Assert.Equal("https", primaryEndpoint.UriScheme);
+        Assert.True(primaryEndpoint.TlsEnabled);
+        Assert.Equal(8443, primaryEndpoint.TargetPort);
+        Assert.Equal(8080, primaryEndpoint.Port);
+        Assert.DoesNotContain(endpoints, e => e.Name == "https");
+
+        var env = await EnvironmentVariableEvaluator.GetEnvironmentVariablesAsync(keycloak.Resource, serviceProvider: app.Services);
+        Assert.Equal("8443", env["KC_HTTPS_PORT"]);
     }
 
     [Fact]


### PR DESCRIPTION
## Description

Update the primary Keycloak endpoint to HTTPS rather than simply adding a second HTTPS endpoint when the dev certificate is enabled. This is a breaking change, but fixes an issue where the Keycloak HTTPS endpoint isn't stable leading to previously issued tokens to become invalid on restart.

Fixes #16979

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
