### PR TITLE
[release/13.3] Update dependencies from https://github.com/microsoft/dcp build 0.23.6

### DIFF
--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -1,33 +1,33 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Dependencies>
   <ProductDependencies>
-    <Dependency Name="Microsoft.DeveloperControlPlane.darwin-amd64" Version="0.23.5">
+    <Dependency Name="Microsoft.DeveloperControlPlane.darwin-amd64" Version="0.23.6">
       <Uri>https://github.com/microsoft/dcp</Uri>
-      <Sha>399a3f82305a96dcb9a805e3ad256872938c2294</Sha>
+      <Sha>dc6ec6508bfc2df2bcdad47eb990d2c2b02f5da9</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DeveloperControlPlane.darwin-arm64" Version="0.23.5">
+    <Dependency Name="Microsoft.DeveloperControlPlane.darwin-arm64" Version="0.23.6">
       <Uri>https://github.com/microsoft/dcp</Uri>
-      <Sha>399a3f82305a96dcb9a805e3ad256872938c2294</Sha>
+      <Sha>dc6ec6508bfc2df2bcdad47eb990d2c2b02f5da9</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DeveloperControlPlane.linux-amd64" Version="0.23.5">
+    <Dependency Name="Microsoft.DeveloperControlPlane.linux-amd64" Version="0.23.6">
       <Uri>https://github.com/microsoft/dcp</Uri>
-      <Sha>399a3f82305a96dcb9a805e3ad256872938c2294</Sha>
+      <Sha>dc6ec6508bfc2df2bcdad47eb990d2c2b02f5da9</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DeveloperControlPlane.linux-arm64" Version="0.23.5">
+    <Dependency Name="Microsoft.DeveloperControlPlane.linux-arm64" Version="0.23.6">
       <Uri>https://github.com/microsoft/dcp</Uri>
-      <Sha>399a3f82305a96dcb9a805e3ad256872938c2294</Sha>
+      <Sha>dc6ec6508bfc2df2bcdad47eb990d2c2b02f5da9</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DeveloperControlPlane.linux-musl-amd64" Version="0.23.5">
+    <Dependency Name="Microsoft.DeveloperControlPlane.linux-musl-amd64" Version="0.23.6">
       <Uri>https://github.com/microsoft/dcp</Uri>
-      <Sha>399a3f82305a96dcb9a805e3ad256872938c2294</Sha>
+      <Sha>dc6ec6508bfc2df2bcdad47eb990d2c2b02f5da9</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DeveloperControlPlane.windows-amd64" Version="0.23.5">
+    <Dependency Name="Microsoft.DeveloperControlPlane.windows-amd64" Version="0.23.6">
       <Uri>https://github.com/microsoft/dcp</Uri>
-      <Sha>399a3f82305a96dcb9a805e3ad256872938c2294</Sha>
+      <Sha>dc6ec6508bfc2df2bcdad47eb990d2c2b02f5da9</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DeveloperControlPlane.windows-arm64" Version="0.23.5">
+    <Dependency Name="Microsoft.DeveloperControlPlane.windows-arm64" Version="0.23.6">
       <Uri>https://github.com/microsoft/dcp</Uri>
-      <Sha>399a3f82305a96dcb9a805e3ad256872938c2294</Sha>
+      <Sha>dc6ec6508bfc2df2bcdad47eb990d2c2b02f5da9</Sha>
     </Dependency>
     <Dependency Name="Microsoft.Extensions.DependencyInjection.AutoActivation" Version="10.5.0">
       <Uri>https://dev.azure.com/dnceng/internal/_git/dotnet-extensions</Uri>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -28,13 +28,13 @@
     <!-- Package versions defined directly in <reporoot>/Directory.Packages.props -->
     <MicrosoftDotnetSdkInternalVersion>8.0.100-rtm.23512.16</MicrosoftDotnetSdkInternalVersion>
     <!-- DCP -->
-    <MicrosoftDeveloperControlPlanedarwinamd64Version>0.23.5</MicrosoftDeveloperControlPlanedarwinamd64Version>
-    <MicrosoftDeveloperControlPlanedarwinarm64Version>0.23.5</MicrosoftDeveloperControlPlanedarwinarm64Version>
-    <MicrosoftDeveloperControlPlanelinuxamd64Version>0.23.5</MicrosoftDeveloperControlPlanelinuxamd64Version>
-    <MicrosoftDeveloperControlPlanelinuxarm64Version>0.23.5</MicrosoftDeveloperControlPlanelinuxarm64Version>
-    <MicrosoftDeveloperControlPlanelinuxmuslamd64Version>0.23.5</MicrosoftDeveloperControlPlanelinuxmuslamd64Version>
-    <MicrosoftDeveloperControlPlanewindowsamd64Version>0.23.5</MicrosoftDeveloperControlPlanewindowsamd64Version>
-    <MicrosoftDeveloperControlPlanewindowsarm64Version>0.23.5</MicrosoftDeveloperControlPlanewindowsarm64Version>
+    <MicrosoftDeveloperControlPlanedarwinamd64Version>0.23.6</MicrosoftDeveloperControlPlanedarwinamd64Version>
+    <MicrosoftDeveloperControlPlanedarwinarm64Version>0.23.6</MicrosoftDeveloperControlPlanedarwinarm64Version>
+    <MicrosoftDeveloperControlPlanelinuxamd64Version>0.23.6</MicrosoftDeveloperControlPlanelinuxamd64Version>
+    <MicrosoftDeveloperControlPlanelinuxarm64Version>0.23.6</MicrosoftDeveloperControlPlanelinuxarm64Version>
+    <MicrosoftDeveloperControlPlanelinuxmuslamd64Version>0.23.6</MicrosoftDeveloperControlPlanelinuxmuslamd64Version>
+    <MicrosoftDeveloperControlPlanewindowsamd64Version>0.23.6</MicrosoftDeveloperControlPlanewindowsamd64Version>
+    <MicrosoftDeveloperControlPlanewindowsarm64Version>0.23.6</MicrosoftDeveloperControlPlanewindowsarm64Version>
     <!-- Other -->
     <MicrosoftDotNetRemoteExecutorVersion>10.0.0-beta.26208.4</MicrosoftDotNetRemoteExecutorVersion>
     <MicrosoftDotNetXUnitV3ExtensionsVersion>10.0.0-beta.26208.4</MicrosoftDotNetXUnitV3ExtensionsVersion>
@@ -166,4 +166,3 @@
     <SystemTextJsonLTSVersion>8.0.6</SystemTextJsonLTSVersion>
   </PropertyGroup>
 </Project>
-


### PR DESCRIPTION
## Description

Updated DCP build with some fixes for k8s OpenAPI generator types that can cause `[SHOULD NOT HAPPEN] failed to update managedFields` errors 