### PR TITLE
Validate `aspire update` for C# AppHosts via dotnet restore

### DIFF
--- a/src/Aspire.Cli/Commands/UpdateCommand.cs
+++ b/src/Aspire.Cli/Commands/UpdateCommand.cs
@@ -47,6 +47,11 @@ internal sealed class UpdateCommand : BaseCommand
     {
         Description = UpdateCommandStrings.NuGetConfigDirOptionDescription
     };
+    private static readonly Option<bool> s_skipRestoreCheckOption = new("--skip-restore-check")
+    {
+        Description = UpdateCommandStrings.SkipRestoreCheckOptionDescription,
+        Hidden = true
+    };
     private readonly Option<string?> _channelOption;
     private readonly Option<string?> _qualityOption;
 
@@ -79,6 +84,7 @@ internal sealed class UpdateCommand : BaseCommand
         Options.Add(s_selfOption);
         Options.Add(s_yesOption);
         Options.Add(s_nugetConfigDirOption);
+        Options.Add(s_skipRestoreCheckOption);
 
         AddNonInteractiveRequiresYesValidator(this, s_yesOption);
 
@@ -235,12 +241,16 @@ internal sealed class UpdateCommand : BaseCommand
             // defaultValue: true means the interactive prompt defaults to "yes" (accept).
             var confirmBinding = PromptBinding.Create(parseResult, s_yesOption, defaultValue: true);
             var nugetConfigDirBinding = PromptBinding.Create(parseResult, s_nugetConfigDirOption);
+            var skipRestoreCheck = parseResult.GetValue(s_skipRestoreCheckOption);
+            var nonInteractive = parseResult.GetValue(RootCommand.NonInteractiveOption);
             var updateContext = new UpdatePackagesContext
             {
                 AppHostFile = projectFile,
                 Channel = channel,
                 ConfirmBinding = confirmBinding,
-                NuGetConfigDirBinding = nugetConfigDirBinding
+                NuGetConfigDirBinding = nugetConfigDirBinding,
+                SkipRestoreCheck = skipRestoreCheck,
+                IsNonInteractive = nonInteractive
             };
             await project.UpdatePackagesAsync(updateContext, cancellationToken);
 

--- a/src/Aspire.Cli/Projects/IAppHostProject.cs
+++ b/src/Aspire.Cli/Projects/IAppHostProject.cs
@@ -42,6 +42,19 @@ internal sealed class UpdatePackagesContext
     /// Enables non-interactive selection via CLI options (e.g. <c>--nuget-config-dir</c>).
     /// </summary>
     public required Interaction.PromptBinding<string?> NuGetConfigDirBinding { get; init; }
+
+    /// <summary>
+    /// When <see langword="true"/>, skip running <c>dotnet restore</c> before and after the update
+    /// to detect newly introduced NuGet warnings or errors. Set by <c>--skip-restore-check</c>.
+    /// </summary>
+    public bool SkipRestoreCheck { get; init; }
+
+    /// <summary>
+    /// When <see langword="true"/>, the user invoked the command in non-interactive mode (e.g. via
+    /// <c>--non-interactive --yes</c>). Updaters must not block on prompts that have no resolved
+    /// value in this mode; instead they should fail-fast so callers (CI scripts) see a non-zero exit.
+    /// </summary>
+    public bool IsNonInteractive { get; init; }
 }
 
 /// <summary>

--- a/src/Aspire.Cli/Projects/ProjectUpdater.cs
+++ b/src/Aspire.Cli/Projects/ProjectUpdater.cs
@@ -77,6 +77,27 @@ internal sealed partial class ProjectUpdater(ILogger<ProjectUpdater> logger, IDo
             return new ProjectUpdateResult { UpdatedApplied = false };
         }
 
+        // Establish a baseline of NuGet diagnostics BEFORE applying updates so we can tell the
+        // difference between issues that pre-existed (which the update may even heal) and issues
+        // newly introduced by the update itself. The baseline is informational only — a failing
+        // pre-restore is not fatal because the update may resolve it.
+        NuGetRestoreResult? baseline = null;
+        if (!context.SkipRestoreCheck)
+        {
+            baseline = await interactionService.ShowStatusAsync(
+                UpdateCommandStrings.BaselineRestoreStatus,
+                () => RunRestoreAndCaptureIssuesAsync(projectFile, cancellationToken));
+
+            if (baseline.HasIssues)
+            {
+                logger.LogDebug(
+                    "Baseline 'dotnet restore' for {ProjectFile} reported {Count} NuGet issue(s) (exitCode={ExitCode}). These will be excluded from the post-update regression check.",
+                    projectFile.FullName,
+                    baseline.Issues.Count,
+                    baseline.ExitCode);
+            }
+        }
+
         if (channel.Type == PackageChannelType.Explicit)
         {
             var (configPathsExitCode, configPaths) = await runner.GetNuGetConfigPathsAsync(projectFile.Directory!, new(), cancellationToken);
@@ -122,7 +143,41 @@ internal sealed partial class ProjectUpdater(ILogger<ProjectUpdater> logger, IDo
                 cancellationToken: cancellationToken);
 
             var nugetConfigDirectory = new DirectoryInfo(selectedPathForNewNuGetConfigFile);
+
+            // Snapshot the NuGet.config that NuGetConfigMerger may create or modify so it can be
+            // rolled back on regression. If no existing file is found, snapshot the default
+            // creation path ("nuget.config" in the target directory).
+            if (!context.SkipRestoreCheck)
+            {
+                var nugetConfigPath = NuGetConfigMerger.TryFindNuGetConfigInDirectory(nugetConfigDirectory, out var existing)
+                    ? existing.FullName
+                    : Path.Combine(nugetConfigDirectory.FullName, "nuget.config");
+                CaptureSnapshot(context, nugetConfigPath);
+            }
+
             await NuGetConfigMerger.CreateOrUpdateAsync(nugetConfigDirectory, channel, (_, orig, proposed, ct) => AnalyzeAndConfirmNuGetConfigChanges(context, orig, proposed, ct), cancellationToken: cancellationToken);
+        }
+
+        // Take snapshots of all files the apply phase will touch so we can rollback if the
+        // post-update restore reveals a regression. The set of mutated files is the union of:
+        //   - the AppHost project file itself (SDK migration / SDK version updates),
+        //   - every distinct PackageUpdateStep.ProjectFile (referenced projects updated by step),
+        //   - the resolved Directory.Packages.props if CPM is in use,
+        //   - the NuGet.config (handled above for Explicit channels).
+        if (!context.SkipRestoreCheck)
+        {
+            CaptureSnapshot(context, projectFile.FullName);
+
+            foreach (var stepProject in updateSteps.OfType<PackageUpdateStep>().Select(s => s.ProjectFile.FullName).Distinct(StringComparer.OrdinalIgnoreCase))
+            {
+                CaptureSnapshot(context, stepProject);
+            }
+
+            var cpmInfo = DetectCentralPackageManagement(projectFile);
+            if (cpmInfo.UsesCentralPackageManagement && cpmInfo.DirectoryPackagesPropsFile is not null)
+            {
+                CaptureSnapshot(context, cpmInfo.DirectoryPackagesPropsFile.FullName);
+            }
         }
 
         interactionService.DisplayEmptyLine();
@@ -142,9 +197,173 @@ internal sealed partial class ProjectUpdater(ILogger<ProjectUpdater> logger, IDo
 
         interactionService.DisplayEmptyLine();
 
+        // Validate the post-update state by running 'dotnet restore' again and comparing the
+        // captured NuGet diagnostics against the baseline. Anything that wasn't in the baseline
+        // is a regression introduced by this update — surface it and let the user choose.
+        if (!context.SkipRestoreCheck && baseline is not null)
+        {
+            var post = await interactionService.ShowStatusAsync(
+                UpdateCommandStrings.PostUpdateRestoreStatus,
+                () => RunRestoreAndCaptureIssuesAsync(projectFile, cancellationToken));
+
+            var newIssues = post.IssuesNotPresentIn(baseline);
+            if (newIssues.Count > 0)
+            {
+                return await HandlePostRestoreRegressionAsync(context, newIssues, cancellationToken);
+            }
+        }
+
         interactionService.DisplaySuccess(UpdateCommandStrings.UpdateSuccessfulMessage);
         return new ProjectUpdateResult { UpdatedApplied = true };
     }
+
+    /// <summary>
+    /// Handles the case where post-update restore introduced issues that were not present in the
+    /// baseline. In interactive mode the user is prompted to rollback or continue. In
+    /// non-interactive mode we never auto-rollback (destructive); we surface the issues and throw
+    /// so the command exits non-zero, mirroring the issue's design intent.
+    /// </summary>
+    private async Task<ProjectUpdateResult> HandlePostRestoreRegressionAsync(UpdatePackagesContext context, IReadOnlyList<NuGetRestoreIssue> newIssues, CancellationToken cancellationToken)
+    {
+        interactionService.DisplayEmptyLine();
+        interactionService.DisplayMessage(KnownEmojis.Warning, $"[yellow]{UpdateCommandStrings.UpdateIntroducedNuGetIssuesHeader.EscapeMarkup()}[/]", allowMarkup: true);
+        foreach (var issue in newIssues)
+        {
+            interactionService.DisplaySubtleMessage($"[yellow]{issue.RawLine.EscapeMarkup()}[/]", allowMarkup: true);
+        }
+        interactionService.DisplayEmptyLine();
+
+        if (context.IsNonInteractive)
+        {
+            interactionService.DisplayError(UpdateCommandStrings.NonInteractiveNewIssuesMessage);
+            throw new ProjectUpdaterException(UpdateCommandStrings.NonInteractiveNewIssuesMessage);
+        }
+
+        var rollback = await interactionService.PromptConfirmAsync(
+            UpdateCommandStrings.RollbackUpdatesPrompt,
+            PromptBinding.CreateDefault(true),
+            cancellationToken: cancellationToken);
+
+        if (!rollback)
+        {
+            interactionService.DisplayMessage(KnownEmojis.Warning, $"[yellow]{UpdateCommandStrings.ContinueWithIssuesMessage.EscapeMarkup()}[/]", allowMarkup: true);
+            return new ProjectUpdateResult { UpdatedApplied = true };
+        }
+
+        await RollbackSnapshotsAsync(context);
+        interactionService.DisplaySuccess(UpdateCommandStrings.RollbackSuccessMessage);
+        return new ProjectUpdateResult { UpdatedApplied = false };
+    }
+
+    private static void CaptureSnapshot(UpdatePackagesContext context, string filePath)
+    {
+        var snapshots = GetOrCreateSnapshots(context);
+        snapshots.Capture(filePath);
+    }
+
+    private async Task RollbackSnapshotsAsync(UpdatePackagesContext context)
+    {
+        var snapshots = GetOrCreateSnapshots(context);
+        await snapshots.RollbackAsync(interactionService, logger);
+    }
+
+    // The snapshot set is stashed on the context so it survives across the explicit-channel branch
+    // (which captures NuGet.config separately) and the apply phase.
+    private static FileSnapshotSet GetOrCreateSnapshots(UpdatePackagesContext context)
+    {
+        if (s_snapshotSets.TryGetValue(context, out var existing))
+        {
+            return existing;
+        }
+
+        var created = new FileSnapshotSet();
+        s_snapshotSets.Add(context, created);
+        return created;
+    }
+
+    // ConditionalWeakTable lets us attach per-context state without modifying the public
+    // UpdatePackagesContext shape further.
+    private static readonly System.Runtime.CompilerServices.ConditionalWeakTable<UpdatePackagesContext, FileSnapshotSet> s_snapshotSets = new();
+
+    /// <summary>
+    /// Runs <c>dotnet restore</c> against the AppHost project, capturing NuGet warning/error lines
+    /// from stdout/stderr. Used both for the pre-update baseline and the post-update validation.
+    /// Never throws on a non-zero exit — the caller decides how to interpret that.
+    /// </summary>
+    private async Task<NuGetRestoreResult> RunRestoreAndCaptureIssuesAsync(FileInfo projectFile, CancellationToken cancellationToken)
+    {
+        var issues = new List<NuGetRestoreIssue>();
+        var seen = new HashSet<(string Code, string NormalizedLine)>();
+
+        // NuGet diagnostics observed in the wild look like:
+        //   /path/to/MyApp.AppHost.csproj : warning NU1605: Detected package downgrade: Foo from 9.0.4 to 9.0.0...
+        //   error NU1101: Unable to find package 'Bar'. No packages exist with this id in source(s)...
+        //   MyApp.csproj(12,3): error NU1605: Detected package downgrade...
+        // The "warning|error NU####" token is the stable part across formats. We pull both the
+        // code and the original line so we can both diff (by code+normalized line) and display
+        // (raw line).
+        void OnLine(string? line)
+        {
+            if (string.IsNullOrWhiteSpace(line))
+            {
+                return;
+            }
+
+            var match = NuGetDiagnosticRegex().Match(line);
+            if (!match.Success)
+            {
+                return;
+            }
+
+            var severity = string.Equals(match.Groups[1].Value, "error", StringComparison.OrdinalIgnoreCase)
+                ? NuGetIssueSeverity.Error
+                : NuGetIssueSeverity.Warning;
+            var code = match.Groups[2].Value;
+            var trimmed = line.Trim();
+            var normalized = NormalizeForDiff(trimmed);
+
+            if (seen.Add((code, normalized)))
+            {
+                issues.Add(new NuGetRestoreIssue(code, severity, trimmed, normalized));
+            }
+        }
+
+        var options = new ProcessInvocationOptions
+        {
+            StandardOutputCallback = OnLine,
+            StandardErrorCallback = OnLine,
+        };
+
+        int exitCode;
+        try
+        {
+            exitCode = await runner.RestoreAsync(projectFile, options, cancellationToken);
+        }
+        catch (Exception ex)
+        {
+            // Treat an exception during restore the same as a failed exit so the baseline still
+            // exists for diff purposes — a thrown post-restore would otherwise be uncomparable.
+            logger.LogDebug(ex, "'dotnet restore' threw while validating {ProjectFile}", projectFile.FullName);
+            exitCode = -1;
+        }
+
+        return new NuGetRestoreResult(exitCode, issues);
+    }
+
+    // Normalize to make the baseline-vs-post comparison resilient to incidental differences
+    // (e.g. absolute paths in the prefix of the line). We strip the leading file-path token
+    // before " : warning|error NUxxxx" if present, leaving just the diagnostic body.
+    //
+    //   "/repo/src/Foo.csproj : warning NU1605: Detected package downgrade: ..."
+    //                       -> "warning NU1605: Detected package downgrade: ..."
+    private static string NormalizeForDiff(string line)
+    {
+        var match = NuGetDiagnosticRegex().Match(line);
+        return match.Success ? line[match.Index..].Trim() : line.Trim();
+    }
+
+    [GeneratedRegex(@"\b(warning|error)\s+(NU\d{4})\b", RegexOptions.IgnoreCase)]
+    private static partial Regex NuGetDiagnosticRegex();
 
     private static bool IsGlobalNuGetConfig(string path)
     {
@@ -1329,3 +1548,82 @@ internal sealed class ProjectUpdaterException : System.Exception
 internal record CentralPackageManagementInfo(bool UsesCentralPackageManagement, FileInfo? DirectoryPackagesPropsFile);
 
 internal record SdkMigrationInfo(bool WillMigrateToNewFormat, bool WillRemoveAppHostPackage);
+
+internal enum NuGetIssueSeverity { Warning, Error }
+
+internal sealed record NuGetRestoreIssue(string Code, NuGetIssueSeverity Severity, string RawLine, string NormalizedLine);
+
+internal sealed record NuGetRestoreResult(int ExitCode, IReadOnlyList<NuGetRestoreIssue> Issues)
+{
+    public bool HasIssues => Issues.Count > 0 || ExitCode != 0;
+
+    /// <summary>
+    /// Returns the issues in this result that are not present in <paramref name="baseline"/> by
+    /// (Code, NormalizedLine). If <paramref name="baseline"/> reported a non-zero exit code with no
+    /// captured issues (i.e. restore was already broken in some non-NuGet way) then a non-zero
+    /// post-restore exit alone is not treated as a regression.
+    /// </summary>
+    public IReadOnlyList<NuGetRestoreIssue> IssuesNotPresentIn(NuGetRestoreResult baseline)
+    {
+        var baselineKeys = baseline.Issues.Select(i => (i.Code, i.NormalizedLine)).ToHashSet();
+        return Issues.Where(i => !baselineKeys.Contains((i.Code, i.NormalizedLine))).ToList();
+    }
+}
+
+/// <summary>
+/// In-memory file snapshot captured before the apply phase of <see cref="ProjectUpdater"/>.
+/// On <see cref="RollbackAsync"/> originals are written back, or files that did not previously
+/// exist are deleted. Errors during restore are surfaced per-file so a single failure does not
+/// abort the rest of the rollback.
+/// </summary>
+internal sealed class FileSnapshotSet
+{
+    private readonly Dictionary<string, byte[]?> _snapshots = new(StringComparer.OrdinalIgnoreCase);
+
+    public void Capture(string path)
+    {
+        if (string.IsNullOrEmpty(path) || _snapshots.ContainsKey(path))
+        {
+            return;
+        }
+
+        try
+        {
+            _snapshots[path] = File.Exists(path) ? File.ReadAllBytes(path) : null;
+        }
+        catch (Exception)
+        {
+            // If we can't read the file, don't capture a snapshot — rollback for this path becomes
+            // a no-op rather than risking writing wrong bytes back later.
+            _snapshots[path] = null;
+        }
+    }
+
+    public async Task RollbackAsync(IInteractionService interactionService, ILogger logger)
+    {
+        foreach (var (path, original) in _snapshots)
+        {
+            try
+            {
+                if (original is null)
+                {
+                    if (File.Exists(path))
+                    {
+                        File.Delete(path);
+                    }
+                }
+                else
+                {
+                    await File.WriteAllBytesAsync(path, original);
+                }
+            }
+            catch (Exception ex)
+            {
+                logger.LogWarning(ex, "Failed to rollback file: {Path}", path);
+                interactionService.DisplayMessage(
+                    KnownEmojis.Warning,
+                    string.Format(CultureInfo.InvariantCulture, UpdateCommandStrings.RollbackFailedFormat, path, ex.Message));
+            }
+        }
+    }
+}

--- a/src/Aspire.Cli/Resources/UpdateCommandStrings.Designer.cs
+++ b/src/Aspire.Cli/Resources/UpdateCommandStrings.Designer.cs
@@ -119,5 +119,14 @@ namespace Aspire.Cli.Resources {
     internal static string SelfOptionDescription => ResourceManager.GetString("SelfOptionDescription", resourceCulture);
     internal static string YesOptionDescription => ResourceManager.GetString("YesOptionDescription", resourceCulture);
     internal static string NuGetConfigDirOptionDescription => ResourceManager.GetString("NuGetConfigDirOptionDescription", resourceCulture);
+    internal static string SkipRestoreCheckOptionDescription => ResourceManager.GetString("SkipRestoreCheckOptionDescription", resourceCulture);
+    internal static string BaselineRestoreStatus => ResourceManager.GetString("BaselineRestoreStatus", resourceCulture);
+    internal static string PostUpdateRestoreStatus => ResourceManager.GetString("PostUpdateRestoreStatus", resourceCulture);
+    internal static string UpdateIntroducedNuGetIssuesHeader => ResourceManager.GetString("UpdateIntroducedNuGetIssuesHeader", resourceCulture);
+    internal static string RollbackUpdatesPrompt => ResourceManager.GetString("RollbackUpdatesPrompt", resourceCulture);
+    internal static string RollbackSuccessMessage => ResourceManager.GetString("RollbackSuccessMessage", resourceCulture);
+    internal static string ContinueWithIssuesMessage => ResourceManager.GetString("ContinueWithIssuesMessage", resourceCulture);
+    internal static string NonInteractiveNewIssuesMessage => ResourceManager.GetString("NonInteractiveNewIssuesMessage", resourceCulture);
+    internal static string RollbackFailedFormat => ResourceManager.GetString("RollbackFailedFormat", resourceCulture);
     }
 }

--- a/src/Aspire.Cli/Resources/UpdateCommandStrings.resx
+++ b/src/Aspire.Cli/Resources/UpdateCommandStrings.resx
@@ -174,4 +174,31 @@
   <data name="NuGetConfigDirOptionDescription" xml:space="preserve">
     <value>Directory to create or update the NuGet.config file in</value>
   </data>
+  <data name="SkipRestoreCheckOptionDescription" xml:space="preserve">
+    <value>Skip running 'dotnet restore' before and after the update to detect new NuGet warnings or errors</value>
+  </data>
+  <data name="BaselineRestoreStatus" xml:space="preserve">
+    <value>Establishing restore baseline...</value>
+  </data>
+  <data name="PostUpdateRestoreStatus" xml:space="preserve">
+    <value>Validating updates with 'dotnet restore'...</value>
+  </data>
+  <data name="UpdateIntroducedNuGetIssuesHeader" xml:space="preserve">
+    <value>The update introduced the following new NuGet issues that were not present before:</value>
+  </data>
+  <data name="RollbackUpdatesPrompt" xml:space="preserve">
+    <value>Rollback the updates to restore the previous state?</value>
+  </data>
+  <data name="RollbackSuccessMessage" xml:space="preserve">
+    <value>Rolled back update changes. Resolve the underlying package conflicts and re-run 'aspire update'.</value>
+  </data>
+  <data name="ContinueWithIssuesMessage" xml:space="preserve">
+    <value>Update applied with new NuGet issues remaining. You will need to resolve them manually before running the AppHost.</value>
+  </data>
+  <data name="NonInteractiveNewIssuesMessage" xml:space="preserve">
+    <value>The update introduced new NuGet issues. Re-run interactively to choose between continuing or rolling back, or pass --skip-restore-check to bypass this check.</value>
+  </data>
+  <data name="RollbackFailedFormat" xml:space="preserve">
+    <value>Failed to fully rollback update changes for '{0}': {1}. Some files may need to be restored manually.</value>
+  </data>
 </root>

--- a/src/Aspire.Cli/Resources/xlf/UpdateCommandStrings.cs.xlf
+++ b/src/Aspire.Cli/Resources/xlf/UpdateCommandStrings.cs.xlf
@@ -37,6 +37,11 @@
         <target state="translated">Používají se aktualizace…</target>
         <note />
       </trans-unit>
+      <trans-unit id="BaselineRestoreStatus">
+        <source>Establishing restore baseline...</source>
+        <target state="new">Establishing restore baseline...</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CentralPackageManagementNotSupported">
         <source>Central package management is currently not supported by 'aspire update'.</source>
         <target state="translated">Centrální správa balíčků není v současné době přes aspire update podporována.</target>
@@ -55,6 +60,11 @@
       <trans-unit id="CheckingForUpdates">
         <source>Checking for updates...</source>
         <target state="translated">Kontrolují se aktualizace…</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ContinueWithIssuesMessage">
+        <source>Update applied with new NuGet issues remaining. You will need to resolve them manually before running the AppHost.</source>
+        <target state="new">Update applied with new NuGet issues remaining. You will need to resolve them manually before running the AppHost.</target>
         <note />
       </trans-unit>
       <trans-unit id="CouldNotFindPackageVersionInDirectoryPackagesProps">
@@ -157,6 +167,11 @@
         <target state="translated">Nelze zapisovat do instalačního adresáře {0}. Spusťte prosím aktualizaci se zvýšenými oprávněními (např. pomocí sudo v Linuxu nebo macOS).</target>
         <note />
       </trans-unit>
+      <trans-unit id="NonInteractiveNewIssuesMessage">
+        <source>The update introduced new NuGet issues. Re-run interactively to choose between continuing or rolling back, or pass --skip-restore-check to bypass this check.</source>
+        <target state="new">The update introduced new NuGet issues. Re-run interactively to choose between continuing or rolling back, or pass --skip-restore-check to bypass this check.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="NuGetConfigDirOptionDescription">
         <source>Directory to create or update the NuGet.config file in</source>
         <target state="new">Directory to create or update the NuGet.config file in</target>
@@ -180,6 +195,11 @@
       <trans-unit id="PerformUpdatesPrompt">
         <source>Perform updates?</source>
         <target state="translated">Provést aktualizace?</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PostUpdateRestoreStatus">
+        <source>Validating updates with 'dotnet restore'...</source>
+        <target state="new">Validating updates with 'dotnet restore'...</target>
         <note />
       </trans-unit>
       <trans-unit id="ProjectArgumentDescription">
@@ -232,6 +252,21 @@
         <target state="translated">Zachováno: {0}</target>
         <note />
       </trans-unit>
+      <trans-unit id="RollbackFailedFormat">
+        <source>Failed to fully rollback update changes for '{0}': {1}. Some files may need to be restored manually.</source>
+        <target state="new">Failed to fully rollback update changes for '{0}': {1}. Some files may need to be restored manually.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RollbackSuccessMessage">
+        <source>Rolled back update changes. Resolve the underlying package conflicts and re-run 'aspire update'.</source>
+        <target state="new">Rolled back update changes. Resolve the underlying package conflicts and re-run 'aspire update'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RollbackUpdatesPrompt">
+        <source>Rollback the updates to restore the previous state?</source>
+        <target state="new">Rollback the updates to restore the previous state?</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SelectChannelPrompt">
         <source>Select a channel:</source>
         <target state="translated">Vyberte kanál:</target>
@@ -242,6 +277,11 @@
         <target state="new">Update the Aspire CLI itself to the latest version</target>
         <note />
       </trans-unit>
+      <trans-unit id="SkipRestoreCheckOptionDescription">
+        <source>Skip running 'dotnet restore' before and after the update to detect new NuGet warnings or errors</source>
+        <target state="new">Skip running 'dotnet restore' before and after the update to detect new NuGet warnings or errors</target>
+        <note />
+      </trans-unit>
       <trans-unit id="UnxpectedCodePath">
         <source>Unexpected code path.</source>
         <target state="translated">Neočekávaná cesta kódu.</target>
@@ -250,6 +290,11 @@
       <trans-unit id="UpdateCliAfterProjectUpdatePrompt">
         <source>An update is available for the Aspire CLI. Would you like to update it now?</source>
         <target state="translated">Pro Aspire CLI je k dispozici aktualizace. Chcete aktualizaci provést nyní?</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UpdateIntroducedNuGetIssuesHeader">
+        <source>The update introduced the following new NuGet issues that were not present before:</source>
+        <target state="new">The update introduced the following new NuGet issues that were not present before:</target>
         <note />
       </trans-unit>
       <trans-unit id="UpdatePackageFormat">

--- a/src/Aspire.Cli/Resources/xlf/UpdateCommandStrings.de.xlf
+++ b/src/Aspire.Cli/Resources/xlf/UpdateCommandStrings.de.xlf
@@ -37,6 +37,11 @@
         <target state="translated">Updates werden angewendet...</target>
         <note />
       </trans-unit>
+      <trans-unit id="BaselineRestoreStatus">
+        <source>Establishing restore baseline...</source>
+        <target state="new">Establishing restore baseline...</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CentralPackageManagementNotSupported">
         <source>Central package management is currently not supported by 'aspire update'.</source>
         <target state="translated">Die zentrale Paketverwaltung wird von „aspire update“ zurzeit nicht unterstützt.</target>
@@ -55,6 +60,11 @@
       <trans-unit id="CheckingForUpdates">
         <source>Checking for updates...</source>
         <target state="translated">Updates werden gesucht...</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ContinueWithIssuesMessage">
+        <source>Update applied with new NuGet issues remaining. You will need to resolve them manually before running the AppHost.</source>
+        <target state="new">Update applied with new NuGet issues remaining. You will need to resolve them manually before running the AppHost.</target>
         <note />
       </trans-unit>
       <trans-unit id="CouldNotFindPackageVersionInDirectoryPackagesProps">
@@ -157,6 +167,11 @@
         <target state="translated">Schreiben in das Installationsverzeichnis „{0}“ ist nicht möglich. Führen Sie das Update mit erhöhten Berechtigungen aus (zum Beispiel mit sudo unter Linux/macOS).</target>
         <note />
       </trans-unit>
+      <trans-unit id="NonInteractiveNewIssuesMessage">
+        <source>The update introduced new NuGet issues. Re-run interactively to choose between continuing or rolling back, or pass --skip-restore-check to bypass this check.</source>
+        <target state="new">The update introduced new NuGet issues. Re-run interactively to choose between continuing or rolling back, or pass --skip-restore-check to bypass this check.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="NuGetConfigDirOptionDescription">
         <source>Directory to create or update the NuGet.config file in</source>
         <target state="new">Directory to create or update the NuGet.config file in</target>
@@ -180,6 +195,11 @@
       <trans-unit id="PerformUpdatesPrompt">
         <source>Perform updates?</source>
         <target state="translated">Update ausführen?</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PostUpdateRestoreStatus">
+        <source>Validating updates with 'dotnet restore'...</source>
+        <target state="new">Validating updates with 'dotnet restore'...</target>
         <note />
       </trans-unit>
       <trans-unit id="ProjectArgumentDescription">
@@ -232,6 +252,21 @@
         <target state="translated">Beibehalten: {0}</target>
         <note />
       </trans-unit>
+      <trans-unit id="RollbackFailedFormat">
+        <source>Failed to fully rollback update changes for '{0}': {1}. Some files may need to be restored manually.</source>
+        <target state="new">Failed to fully rollback update changes for '{0}': {1}. Some files may need to be restored manually.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RollbackSuccessMessage">
+        <source>Rolled back update changes. Resolve the underlying package conflicts and re-run 'aspire update'.</source>
+        <target state="new">Rolled back update changes. Resolve the underlying package conflicts and re-run 'aspire update'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RollbackUpdatesPrompt">
+        <source>Rollback the updates to restore the previous state?</source>
+        <target state="new">Rollback the updates to restore the previous state?</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SelectChannelPrompt">
         <source>Select a channel:</source>
         <target state="translated">Wählen Sie einen Kanal aus.</target>
@@ -242,6 +277,11 @@
         <target state="new">Update the Aspire CLI itself to the latest version</target>
         <note />
       </trans-unit>
+      <trans-unit id="SkipRestoreCheckOptionDescription">
+        <source>Skip running 'dotnet restore' before and after the update to detect new NuGet warnings or errors</source>
+        <target state="new">Skip running 'dotnet restore' before and after the update to detect new NuGet warnings or errors</target>
+        <note />
+      </trans-unit>
       <trans-unit id="UnxpectedCodePath">
         <source>Unexpected code path.</source>
         <target state="translated">Unerwarteter Codepfad</target>
@@ -250,6 +290,11 @@
       <trans-unit id="UpdateCliAfterProjectUpdatePrompt">
         <source>An update is available for the Aspire CLI. Would you like to update it now?</source>
         <target state="translated">Für die Aspire-CLI ist ein Update verfügbar. Möchten Sie es jetzt installieren?</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UpdateIntroducedNuGetIssuesHeader">
+        <source>The update introduced the following new NuGet issues that were not present before:</source>
+        <target state="new">The update introduced the following new NuGet issues that were not present before:</target>
         <note />
       </trans-unit>
       <trans-unit id="UpdatePackageFormat">

--- a/src/Aspire.Cli/Resources/xlf/UpdateCommandStrings.es.xlf
+++ b/src/Aspire.Cli/Resources/xlf/UpdateCommandStrings.es.xlf
@@ -37,6 +37,11 @@
         <target state="translated">Aplicando actualizaciones...</target>
         <note />
       </trans-unit>
+      <trans-unit id="BaselineRestoreStatus">
+        <source>Establishing restore baseline...</source>
+        <target state="new">Establishing restore baseline...</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CentralPackageManagementNotSupported">
         <source>Central package management is currently not supported by 'aspire update'.</source>
         <target state="translated">La administración central de paquetes no es compatible actualmente con "aspire update".</target>
@@ -55,6 +60,11 @@
       <trans-unit id="CheckingForUpdates">
         <source>Checking for updates...</source>
         <target state="translated">Comprobando si hay actualizaciones...</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ContinueWithIssuesMessage">
+        <source>Update applied with new NuGet issues remaining. You will need to resolve them manually before running the AppHost.</source>
+        <target state="new">Update applied with new NuGet issues remaining. You will need to resolve them manually before running the AppHost.</target>
         <note />
       </trans-unit>
       <trans-unit id="CouldNotFindPackageVersionInDirectoryPackagesProps">
@@ -157,6 +167,11 @@
         <target state="translated">No se puede escribir en el directorio de instalación '{0}'. Ejecute la actualización con permisos elevados (por ejemplo, con sudo en Linux o macOS).</target>
         <note />
       </trans-unit>
+      <trans-unit id="NonInteractiveNewIssuesMessage">
+        <source>The update introduced new NuGet issues. Re-run interactively to choose between continuing or rolling back, or pass --skip-restore-check to bypass this check.</source>
+        <target state="new">The update introduced new NuGet issues. Re-run interactively to choose between continuing or rolling back, or pass --skip-restore-check to bypass this check.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="NuGetConfigDirOptionDescription">
         <source>Directory to create or update the NuGet.config file in</source>
         <target state="new">Directory to create or update the NuGet.config file in</target>
@@ -180,6 +195,11 @@
       <trans-unit id="PerformUpdatesPrompt">
         <source>Perform updates?</source>
         <target state="translated">¿Desea realizar actualizaciones?</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PostUpdateRestoreStatus">
+        <source>Validating updates with 'dotnet restore'...</source>
+        <target state="new">Validating updates with 'dotnet restore'...</target>
         <note />
       </trans-unit>
       <trans-unit id="ProjectArgumentDescription">
@@ -232,6 +252,21 @@
         <target state="translated">Retenido: {0}</target>
         <note />
       </trans-unit>
+      <trans-unit id="RollbackFailedFormat">
+        <source>Failed to fully rollback update changes for '{0}': {1}. Some files may need to be restored manually.</source>
+        <target state="new">Failed to fully rollback update changes for '{0}': {1}. Some files may need to be restored manually.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RollbackSuccessMessage">
+        <source>Rolled back update changes. Resolve the underlying package conflicts and re-run 'aspire update'.</source>
+        <target state="new">Rolled back update changes. Resolve the underlying package conflicts and re-run 'aspire update'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RollbackUpdatesPrompt">
+        <source>Rollback the updates to restore the previous state?</source>
+        <target state="new">Rollback the updates to restore the previous state?</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SelectChannelPrompt">
         <source>Select a channel:</source>
         <target state="translated">Seleccionar un canal:</target>
@@ -242,6 +277,11 @@
         <target state="new">Update the Aspire CLI itself to the latest version</target>
         <note />
       </trans-unit>
+      <trans-unit id="SkipRestoreCheckOptionDescription">
+        <source>Skip running 'dotnet restore' before and after the update to detect new NuGet warnings or errors</source>
+        <target state="new">Skip running 'dotnet restore' before and after the update to detect new NuGet warnings or errors</target>
+        <note />
+      </trans-unit>
       <trans-unit id="UnxpectedCodePath">
         <source>Unexpected code path.</source>
         <target state="translated">Ruta de acceso al código inesperada.</target>
@@ -250,6 +290,11 @@
       <trans-unit id="UpdateCliAfterProjectUpdatePrompt">
         <source>An update is available for the Aspire CLI. Would you like to update it now?</source>
         <target state="translated">Hay una actualización disponible para la CLI de Aspire. ¿Quieres actualizarla ahora?</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UpdateIntroducedNuGetIssuesHeader">
+        <source>The update introduced the following new NuGet issues that were not present before:</source>
+        <target state="new">The update introduced the following new NuGet issues that were not present before:</target>
         <note />
       </trans-unit>
       <trans-unit id="UpdatePackageFormat">

--- a/src/Aspire.Cli/Resources/xlf/UpdateCommandStrings.fr.xlf
+++ b/src/Aspire.Cli/Resources/xlf/UpdateCommandStrings.fr.xlf
@@ -37,6 +37,11 @@
         <target state="translated">Application en cours des mises à jour...</target>
         <note />
       </trans-unit>
+      <trans-unit id="BaselineRestoreStatus">
+        <source>Establishing restore baseline...</source>
+        <target state="new">Establishing restore baseline...</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CentralPackageManagementNotSupported">
         <source>Central package management is currently not supported by 'aspire update'.</source>
         <target state="translated">Actuellement, la gestion centralisée des packages n’est pas prise en charge par « aspire update ».</target>
@@ -55,6 +60,11 @@
       <trans-unit id="CheckingForUpdates">
         <source>Checking for updates...</source>
         <target state="translated">Recherche de mises à jour...</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ContinueWithIssuesMessage">
+        <source>Update applied with new NuGet issues remaining. You will need to resolve them manually before running the AppHost.</source>
+        <target state="new">Update applied with new NuGet issues remaining. You will need to resolve them manually before running the AppHost.</target>
         <note />
       </trans-unit>
       <trans-unit id="CouldNotFindPackageVersionInDirectoryPackagesProps">
@@ -157,6 +167,11 @@
         <target state="translated">Impossible d’écrire dans le répertoire d’installation « {0} ». Exécutez la mise à jour avec des autorisations élevées (par exemple, en utilisant sudo sur Linux/macOS).</target>
         <note />
       </trans-unit>
+      <trans-unit id="NonInteractiveNewIssuesMessage">
+        <source>The update introduced new NuGet issues. Re-run interactively to choose between continuing or rolling back, or pass --skip-restore-check to bypass this check.</source>
+        <target state="new">The update introduced new NuGet issues. Re-run interactively to choose between continuing or rolling back, or pass --skip-restore-check to bypass this check.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="NuGetConfigDirOptionDescription">
         <source>Directory to create or update the NuGet.config file in</source>
         <target state="new">Directory to create or update the NuGet.config file in</target>
@@ -180,6 +195,11 @@
       <trans-unit id="PerformUpdatesPrompt">
         <source>Perform updates?</source>
         <target state="translated">Voulez-vous exécuter la mise à jour maintenant ?</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PostUpdateRestoreStatus">
+        <source>Validating updates with 'dotnet restore'...</source>
+        <target state="new">Validating updates with 'dotnet restore'...</target>
         <note />
       </trans-unit>
       <trans-unit id="ProjectArgumentDescription">
@@ -232,6 +252,21 @@
         <target state="translated">Retenu : {0}</target>
         <note />
       </trans-unit>
+      <trans-unit id="RollbackFailedFormat">
+        <source>Failed to fully rollback update changes for '{0}': {1}. Some files may need to be restored manually.</source>
+        <target state="new">Failed to fully rollback update changes for '{0}': {1}. Some files may need to be restored manually.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RollbackSuccessMessage">
+        <source>Rolled back update changes. Resolve the underlying package conflicts and re-run 'aspire update'.</source>
+        <target state="new">Rolled back update changes. Resolve the underlying package conflicts and re-run 'aspire update'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RollbackUpdatesPrompt">
+        <source>Rollback the updates to restore the previous state?</source>
+        <target state="new">Rollback the updates to restore the previous state?</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SelectChannelPrompt">
         <source>Select a channel:</source>
         <target state="translated">Sélectionnez un canal :</target>
@@ -242,6 +277,11 @@
         <target state="new">Update the Aspire CLI itself to the latest version</target>
         <note />
       </trans-unit>
+      <trans-unit id="SkipRestoreCheckOptionDescription">
+        <source>Skip running 'dotnet restore' before and after the update to detect new NuGet warnings or errors</source>
+        <target state="new">Skip running 'dotnet restore' before and after the update to detect new NuGet warnings or errors</target>
+        <note />
+      </trans-unit>
       <trans-unit id="UnxpectedCodePath">
         <source>Unexpected code path.</source>
         <target state="translated">Chemin de code inattendu.</target>
@@ -250,6 +290,11 @@
       <trans-unit id="UpdateCliAfterProjectUpdatePrompt">
         <source>An update is available for the Aspire CLI. Would you like to update it now?</source>
         <target state="translated">Une mise à jour est disponible pour l’interface CLI Aspire. Voulez-vous la mettre à jour maintenant ?</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UpdateIntroducedNuGetIssuesHeader">
+        <source>The update introduced the following new NuGet issues that were not present before:</source>
+        <target state="new">The update introduced the following new NuGet issues that were not present before:</target>
         <note />
       </trans-unit>
       <trans-unit id="UpdatePackageFormat">

--- a/src/Aspire.Cli/Resources/xlf/UpdateCommandStrings.it.xlf
+++ b/src/Aspire.Cli/Resources/xlf/UpdateCommandStrings.it.xlf
@@ -37,6 +37,11 @@
         <target state="translated">Applicazione degli aggiornamenti in corso...</target>
         <note />
       </trans-unit>
+      <trans-unit id="BaselineRestoreStatus">
+        <source>Establishing restore baseline...</source>
+        <target state="new">Establishing restore baseline...</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CentralPackageManagementNotSupported">
         <source>Central package management is currently not supported by 'aspire update'.</source>
         <target state="translated">La gestione centralizzata dei pacchetti non è attualmente supportata da "aspire update".</target>
@@ -55,6 +60,11 @@
       <trans-unit id="CheckingForUpdates">
         <source>Checking for updates...</source>
         <target state="translated">Verifica disponibilità aggiornamenti...</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ContinueWithIssuesMessage">
+        <source>Update applied with new NuGet issues remaining. You will need to resolve them manually before running the AppHost.</source>
+        <target state="new">Update applied with new NuGet issues remaining. You will need to resolve them manually before running the AppHost.</target>
         <note />
       </trans-unit>
       <trans-unit id="CouldNotFindPackageVersionInDirectoryPackagesProps">
@@ -157,6 +167,11 @@
         <target state="translated">Impossibile scrivere nella directory di installazione "{0}". Eseguire l'aggiornamento con autorizzazioni elevate, ad esempio usando sudo su Linux/macOS.</target>
         <note />
       </trans-unit>
+      <trans-unit id="NonInteractiveNewIssuesMessage">
+        <source>The update introduced new NuGet issues. Re-run interactively to choose between continuing or rolling back, or pass --skip-restore-check to bypass this check.</source>
+        <target state="new">The update introduced new NuGet issues. Re-run interactively to choose between continuing or rolling back, or pass --skip-restore-check to bypass this check.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="NuGetConfigDirOptionDescription">
         <source>Directory to create or update the NuGet.config file in</source>
         <target state="new">Directory to create or update the NuGet.config file in</target>
@@ -180,6 +195,11 @@
       <trans-unit id="PerformUpdatesPrompt">
         <source>Perform updates?</source>
         <target state="translated">Eseguire gli aggiornamenti?</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PostUpdateRestoreStatus">
+        <source>Validating updates with 'dotnet restore'...</source>
+        <target state="new">Validating updates with 'dotnet restore'...</target>
         <note />
       </trans-unit>
       <trans-unit id="ProjectArgumentDescription">
@@ -232,6 +252,21 @@
         <target state="translated">Mantenuto: {0}</target>
         <note />
       </trans-unit>
+      <trans-unit id="RollbackFailedFormat">
+        <source>Failed to fully rollback update changes for '{0}': {1}. Some files may need to be restored manually.</source>
+        <target state="new">Failed to fully rollback update changes for '{0}': {1}. Some files may need to be restored manually.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RollbackSuccessMessage">
+        <source>Rolled back update changes. Resolve the underlying package conflicts and re-run 'aspire update'.</source>
+        <target state="new">Rolled back update changes. Resolve the underlying package conflicts and re-run 'aspire update'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RollbackUpdatesPrompt">
+        <source>Rollback the updates to restore the previous state?</source>
+        <target state="new">Rollback the updates to restore the previous state?</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SelectChannelPrompt">
         <source>Select a channel:</source>
         <target state="translated">Selezionare un canale:</target>
@@ -242,6 +277,11 @@
         <target state="new">Update the Aspire CLI itself to the latest version</target>
         <note />
       </trans-unit>
+      <trans-unit id="SkipRestoreCheckOptionDescription">
+        <source>Skip running 'dotnet restore' before and after the update to detect new NuGet warnings or errors</source>
+        <target state="new">Skip running 'dotnet restore' before and after the update to detect new NuGet warnings or errors</target>
+        <note />
+      </trans-unit>
       <trans-unit id="UnxpectedCodePath">
         <source>Unexpected code path.</source>
         <target state="translated">Percorso del codice imprevisto.</target>
@@ -250,6 +290,11 @@
       <trans-unit id="UpdateCliAfterProjectUpdatePrompt">
         <source>An update is available for the Aspire CLI. Would you like to update it now?</source>
         <target state="translated">È disponibile un aggiornamento per l'interfaccia della riga di comando Aspire. Aggiornarla ora?</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UpdateIntroducedNuGetIssuesHeader">
+        <source>The update introduced the following new NuGet issues that were not present before:</source>
+        <target state="new">The update introduced the following new NuGet issues that were not present before:</target>
         <note />
       </trans-unit>
       <trans-unit id="UpdatePackageFormat">

--- a/src/Aspire.Cli/Resources/xlf/UpdateCommandStrings.ja.xlf
+++ b/src/Aspire.Cli/Resources/xlf/UpdateCommandStrings.ja.xlf
@@ -37,6 +37,11 @@
         <target state="translated">更新プログラムを適用しています...</target>
         <note />
       </trans-unit>
+      <trans-unit id="BaselineRestoreStatus">
+        <source>Establishing restore baseline...</source>
+        <target state="new">Establishing restore baseline...</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CentralPackageManagementNotSupported">
         <source>Central package management is currently not supported by 'aspire update'.</source>
         <target state="translated">現在、中央パッケージ管理では、'aspire update' によるサポートがありません。</target>
@@ -55,6 +60,11 @@
       <trans-unit id="CheckingForUpdates">
         <source>Checking for updates...</source>
         <target state="translated">更新プログラムを確認しています...</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ContinueWithIssuesMessage">
+        <source>Update applied with new NuGet issues remaining. You will need to resolve them manually before running the AppHost.</source>
+        <target state="new">Update applied with new NuGet issues remaining. You will need to resolve them manually before running the AppHost.</target>
         <note />
       </trans-unit>
       <trans-unit id="CouldNotFindPackageVersionInDirectoryPackagesProps">
@@ -157,6 +167,11 @@
         <target state="translated">インストール ディレクトリ '{0}' に書き込めません。管理者権限で更新を実行してください (例: Linux/macOS で sudo を使用)。</target>
         <note />
       </trans-unit>
+      <trans-unit id="NonInteractiveNewIssuesMessage">
+        <source>The update introduced new NuGet issues. Re-run interactively to choose between continuing or rolling back, or pass --skip-restore-check to bypass this check.</source>
+        <target state="new">The update introduced new NuGet issues. Re-run interactively to choose between continuing or rolling back, or pass --skip-restore-check to bypass this check.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="NuGetConfigDirOptionDescription">
         <source>Directory to create or update the NuGet.config file in</source>
         <target state="new">Directory to create or update the NuGet.config file in</target>
@@ -180,6 +195,11 @@
       <trans-unit id="PerformUpdatesPrompt">
         <source>Perform updates?</source>
         <target state="translated">更新を実行しますか?</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PostUpdateRestoreStatus">
+        <source>Validating updates with 'dotnet restore'...</source>
+        <target state="new">Validating updates with 'dotnet restore'...</target>
         <note />
       </trans-unit>
       <trans-unit id="ProjectArgumentDescription">
@@ -232,6 +252,21 @@
         <target state="translated">保持済み: {0}</target>
         <note />
       </trans-unit>
+      <trans-unit id="RollbackFailedFormat">
+        <source>Failed to fully rollback update changes for '{0}': {1}. Some files may need to be restored manually.</source>
+        <target state="new">Failed to fully rollback update changes for '{0}': {1}. Some files may need to be restored manually.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RollbackSuccessMessage">
+        <source>Rolled back update changes. Resolve the underlying package conflicts and re-run 'aspire update'.</source>
+        <target state="new">Rolled back update changes. Resolve the underlying package conflicts and re-run 'aspire update'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RollbackUpdatesPrompt">
+        <source>Rollback the updates to restore the previous state?</source>
+        <target state="new">Rollback the updates to restore the previous state?</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SelectChannelPrompt">
         <source>Select a channel:</source>
         <target state="translated">チャネルを選択:</target>
@@ -242,6 +277,11 @@
         <target state="new">Update the Aspire CLI itself to the latest version</target>
         <note />
       </trans-unit>
+      <trans-unit id="SkipRestoreCheckOptionDescription">
+        <source>Skip running 'dotnet restore' before and after the update to detect new NuGet warnings or errors</source>
+        <target state="new">Skip running 'dotnet restore' before and after the update to detect new NuGet warnings or errors</target>
+        <note />
+      </trans-unit>
       <trans-unit id="UnxpectedCodePath">
         <source>Unexpected code path.</source>
         <target state="translated">予期しないコード パスです。</target>
@@ -250,6 +290,11 @@
       <trans-unit id="UpdateCliAfterProjectUpdatePrompt">
         <source>An update is available for the Aspire CLI. Would you like to update it now?</source>
         <target state="translated">Aspire CLI の更新プログラムが利用可能です。今すぐ更新しますか?</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UpdateIntroducedNuGetIssuesHeader">
+        <source>The update introduced the following new NuGet issues that were not present before:</source>
+        <target state="new">The update introduced the following new NuGet issues that were not present before:</target>
         <note />
       </trans-unit>
       <trans-unit id="UpdatePackageFormat">

--- a/src/Aspire.Cli/Resources/xlf/UpdateCommandStrings.ko.xlf
+++ b/src/Aspire.Cli/Resources/xlf/UpdateCommandStrings.ko.xlf
@@ -37,6 +37,11 @@
         <target state="translated">업데이트 적용 중...</target>
         <note />
       </trans-unit>
+      <trans-unit id="BaselineRestoreStatus">
+        <source>Establishing restore baseline...</source>
+        <target state="new">Establishing restore baseline...</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CentralPackageManagementNotSupported">
         <source>Central package management is currently not supported by 'aspire update'.</source>
         <target state="translated">중앙 패키지 관리는 현재 'aspire update'에서 지원되지 않습니다.</target>
@@ -55,6 +60,11 @@
       <trans-unit id="CheckingForUpdates">
         <source>Checking for updates...</source>
         <target state="translated">업데이트를 확인하는 중...</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ContinueWithIssuesMessage">
+        <source>Update applied with new NuGet issues remaining. You will need to resolve them manually before running the AppHost.</source>
+        <target state="new">Update applied with new NuGet issues remaining. You will need to resolve them manually before running the AppHost.</target>
         <note />
       </trans-unit>
       <trans-unit id="CouldNotFindPackageVersionInDirectoryPackagesProps">
@@ -157,6 +167,11 @@
         <target state="translated">설치 디렉터리 '{0}'에 쓸 수 없습니다. 관리자 권한으로 업데이트를 실행하세요(예: Linux/macOS에서 sudo 사용).</target>
         <note />
       </trans-unit>
+      <trans-unit id="NonInteractiveNewIssuesMessage">
+        <source>The update introduced new NuGet issues. Re-run interactively to choose between continuing or rolling back, or pass --skip-restore-check to bypass this check.</source>
+        <target state="new">The update introduced new NuGet issues. Re-run interactively to choose between continuing or rolling back, or pass --skip-restore-check to bypass this check.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="NuGetConfigDirOptionDescription">
         <source>Directory to create or update the NuGet.config file in</source>
         <target state="new">Directory to create or update the NuGet.config file in</target>
@@ -180,6 +195,11 @@
       <trans-unit id="PerformUpdatesPrompt">
         <source>Perform updates?</source>
         <target state="translated">업데이트를 수행하시겠습니까?</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PostUpdateRestoreStatus">
+        <source>Validating updates with 'dotnet restore'...</source>
+        <target state="new">Validating updates with 'dotnet restore'...</target>
         <note />
       </trans-unit>
       <trans-unit id="ProjectArgumentDescription">
@@ -232,6 +252,21 @@
         <target state="translated">보존됨: {0}</target>
         <note />
       </trans-unit>
+      <trans-unit id="RollbackFailedFormat">
+        <source>Failed to fully rollback update changes for '{0}': {1}. Some files may need to be restored manually.</source>
+        <target state="new">Failed to fully rollback update changes for '{0}': {1}. Some files may need to be restored manually.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RollbackSuccessMessage">
+        <source>Rolled back update changes. Resolve the underlying package conflicts and re-run 'aspire update'.</source>
+        <target state="new">Rolled back update changes. Resolve the underlying package conflicts and re-run 'aspire update'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RollbackUpdatesPrompt">
+        <source>Rollback the updates to restore the previous state?</source>
+        <target state="new">Rollback the updates to restore the previous state?</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SelectChannelPrompt">
         <source>Select a channel:</source>
         <target state="translated">채널 선택:</target>
@@ -242,6 +277,11 @@
         <target state="new">Update the Aspire CLI itself to the latest version</target>
         <note />
       </trans-unit>
+      <trans-unit id="SkipRestoreCheckOptionDescription">
+        <source>Skip running 'dotnet restore' before and after the update to detect new NuGet warnings or errors</source>
+        <target state="new">Skip running 'dotnet restore' before and after the update to detect new NuGet warnings or errors</target>
+        <note />
+      </trans-unit>
       <trans-unit id="UnxpectedCodePath">
         <source>Unexpected code path.</source>
         <target state="translated">예기치 않은 코드 경로입니다.</target>
@@ -250,6 +290,11 @@
       <trans-unit id="UpdateCliAfterProjectUpdatePrompt">
         <source>An update is available for the Aspire CLI. Would you like to update it now?</source>
         <target state="translated">Aspire CLI 업데이트가 있습니다. 지금 업데이트하시겠어요?</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UpdateIntroducedNuGetIssuesHeader">
+        <source>The update introduced the following new NuGet issues that were not present before:</source>
+        <target state="new">The update introduced the following new NuGet issues that were not present before:</target>
         <note />
       </trans-unit>
       <trans-unit id="UpdatePackageFormat">

--- a/src/Aspire.Cli/Resources/xlf/UpdateCommandStrings.pl.xlf
+++ b/src/Aspire.Cli/Resources/xlf/UpdateCommandStrings.pl.xlf
@@ -37,6 +37,11 @@
         <target state="translated">Trwa stosowanie aktualizacji...</target>
         <note />
       </trans-unit>
+      <trans-unit id="BaselineRestoreStatus">
+        <source>Establishing restore baseline...</source>
+        <target state="new">Establishing restore baseline...</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CentralPackageManagementNotSupported">
         <source>Central package management is currently not supported by 'aspire update'.</source>
         <target state="translated">Centralne zarządzanie pakietami nie jest obecnie obsługiwane przez „aktualizację Aspire”.</target>
@@ -55,6 +60,11 @@
       <trans-unit id="CheckingForUpdates">
         <source>Checking for updates...</source>
         <target state="translated">Trwa wyszukiwanie aktualizacji...</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ContinueWithIssuesMessage">
+        <source>Update applied with new NuGet issues remaining. You will need to resolve them manually before running the AppHost.</source>
+        <target state="new">Update applied with new NuGet issues remaining. You will need to resolve them manually before running the AppHost.</target>
         <note />
       </trans-unit>
       <trans-unit id="CouldNotFindPackageVersionInDirectoryPackagesProps">
@@ -157,6 +167,11 @@
         <target state="translated">Nie można zapisać w katalogu instalacyjnym „{0}”. Uruchom aktualizację z podniesionymi uprawnieniami (np. używając programu sudo w systemie Linux lub macOS).</target>
         <note />
       </trans-unit>
+      <trans-unit id="NonInteractiveNewIssuesMessage">
+        <source>The update introduced new NuGet issues. Re-run interactively to choose between continuing or rolling back, or pass --skip-restore-check to bypass this check.</source>
+        <target state="new">The update introduced new NuGet issues. Re-run interactively to choose between continuing or rolling back, or pass --skip-restore-check to bypass this check.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="NuGetConfigDirOptionDescription">
         <source>Directory to create or update the NuGet.config file in</source>
         <target state="new">Directory to create or update the NuGet.config file in</target>
@@ -180,6 +195,11 @@
       <trans-unit id="PerformUpdatesPrompt">
         <source>Perform updates?</source>
         <target state="translated">Wykonać aktualizacje?</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PostUpdateRestoreStatus">
+        <source>Validating updates with 'dotnet restore'...</source>
+        <target state="new">Validating updates with 'dotnet restore'...</target>
         <note />
       </trans-unit>
       <trans-unit id="ProjectArgumentDescription">
@@ -232,6 +252,21 @@
         <target state="translated">Utrzymano: {0}</target>
         <note />
       </trans-unit>
+      <trans-unit id="RollbackFailedFormat">
+        <source>Failed to fully rollback update changes for '{0}': {1}. Some files may need to be restored manually.</source>
+        <target state="new">Failed to fully rollback update changes for '{0}': {1}. Some files may need to be restored manually.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RollbackSuccessMessage">
+        <source>Rolled back update changes. Resolve the underlying package conflicts and re-run 'aspire update'.</source>
+        <target state="new">Rolled back update changes. Resolve the underlying package conflicts and re-run 'aspire update'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RollbackUpdatesPrompt">
+        <source>Rollback the updates to restore the previous state?</source>
+        <target state="new">Rollback the updates to restore the previous state?</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SelectChannelPrompt">
         <source>Select a channel:</source>
         <target state="translated">Wybierz kanał:</target>
@@ -242,6 +277,11 @@
         <target state="new">Update the Aspire CLI itself to the latest version</target>
         <note />
       </trans-unit>
+      <trans-unit id="SkipRestoreCheckOptionDescription">
+        <source>Skip running 'dotnet restore' before and after the update to detect new NuGet warnings or errors</source>
+        <target state="new">Skip running 'dotnet restore' before and after the update to detect new NuGet warnings or errors</target>
+        <note />
+      </trans-unit>
       <trans-unit id="UnxpectedCodePath">
         <source>Unexpected code path.</source>
         <target state="translated">Nieoczekiwana ścieżka w kodzie.</target>
@@ -250,6 +290,11 @@
       <trans-unit id="UpdateCliAfterProjectUpdatePrompt">
         <source>An update is available for the Aspire CLI. Would you like to update it now?</source>
         <target state="translated">Dostępna jest aktualizacja narzędzia Aspire CLI. Czy chcesz teraz zaktualizować?</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UpdateIntroducedNuGetIssuesHeader">
+        <source>The update introduced the following new NuGet issues that were not present before:</source>
+        <target state="new">The update introduced the following new NuGet issues that were not present before:</target>
         <note />
       </trans-unit>
       <trans-unit id="UpdatePackageFormat">

--- a/src/Aspire.Cli/Resources/xlf/UpdateCommandStrings.pt-BR.xlf
+++ b/src/Aspire.Cli/Resources/xlf/UpdateCommandStrings.pt-BR.xlf
@@ -37,6 +37,11 @@
         <target state="translated">Aplicando atualizações...</target>
         <note />
       </trans-unit>
+      <trans-unit id="BaselineRestoreStatus">
+        <source>Establishing restore baseline...</source>
+        <target state="new">Establishing restore baseline...</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CentralPackageManagementNotSupported">
         <source>Central package management is currently not supported by 'aspire update'.</source>
         <target state="translated">No momento, o gerenciamento central de pacotes por “atualização de atualização” não ´possui suporte.</target>
@@ -55,6 +60,11 @@
       <trans-unit id="CheckingForUpdates">
         <source>Checking for updates...</source>
         <target state="translated">Verificando atualizações...</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ContinueWithIssuesMessage">
+        <source>Update applied with new NuGet issues remaining. You will need to resolve them manually before running the AppHost.</source>
+        <target state="new">Update applied with new NuGet issues remaining. You will need to resolve them manually before running the AppHost.</target>
         <note />
       </trans-unit>
       <trans-unit id="CouldNotFindPackageVersionInDirectoryPackagesProps">
@@ -157,6 +167,11 @@
         <target state="translated">Não é possível gravar no diretório de instalação '{0}'. Execute a atualização com permissões elevadas (por exemplo, usando sudo no Linux/macOS).</target>
         <note />
       </trans-unit>
+      <trans-unit id="NonInteractiveNewIssuesMessage">
+        <source>The update introduced new NuGet issues. Re-run interactively to choose between continuing or rolling back, or pass --skip-restore-check to bypass this check.</source>
+        <target state="new">The update introduced new NuGet issues. Re-run interactively to choose between continuing or rolling back, or pass --skip-restore-check to bypass this check.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="NuGetConfigDirOptionDescription">
         <source>Directory to create or update the NuGet.config file in</source>
         <target state="new">Directory to create or update the NuGet.config file in</target>
@@ -180,6 +195,11 @@
       <trans-unit id="PerformUpdatesPrompt">
         <source>Perform updates?</source>
         <target state="translated">Executar atualizações?</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PostUpdateRestoreStatus">
+        <source>Validating updates with 'dotnet restore'...</source>
+        <target state="new">Validating updates with 'dotnet restore'...</target>
         <note />
       </trans-unit>
       <trans-unit id="ProjectArgumentDescription">
@@ -232,6 +252,21 @@
         <target state="translated">Retidos: {0}</target>
         <note />
       </trans-unit>
+      <trans-unit id="RollbackFailedFormat">
+        <source>Failed to fully rollback update changes for '{0}': {1}. Some files may need to be restored manually.</source>
+        <target state="new">Failed to fully rollback update changes for '{0}': {1}. Some files may need to be restored manually.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RollbackSuccessMessage">
+        <source>Rolled back update changes. Resolve the underlying package conflicts and re-run 'aspire update'.</source>
+        <target state="new">Rolled back update changes. Resolve the underlying package conflicts and re-run 'aspire update'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RollbackUpdatesPrompt">
+        <source>Rollback the updates to restore the previous state?</source>
+        <target state="new">Rollback the updates to restore the previous state?</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SelectChannelPrompt">
         <source>Select a channel:</source>
         <target state="translated">Selecionar um canal:</target>
@@ -242,6 +277,11 @@
         <target state="new">Update the Aspire CLI itself to the latest version</target>
         <note />
       </trans-unit>
+      <trans-unit id="SkipRestoreCheckOptionDescription">
+        <source>Skip running 'dotnet restore' before and after the update to detect new NuGet warnings or errors</source>
+        <target state="new">Skip running 'dotnet restore' before and after the update to detect new NuGet warnings or errors</target>
+        <note />
+      </trans-unit>
       <trans-unit id="UnxpectedCodePath">
         <source>Unexpected code path.</source>
         <target state="translated">Caminho de código inesperado.</target>
@@ -250,6 +290,11 @@
       <trans-unit id="UpdateCliAfterProjectUpdatePrompt">
         <source>An update is available for the Aspire CLI. Would you like to update it now?</source>
         <target state="translated">Há uma atualização disponível para a CLI do Aspire. Você quer atualizá-la agora?</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UpdateIntroducedNuGetIssuesHeader">
+        <source>The update introduced the following new NuGet issues that were not present before:</source>
+        <target state="new">The update introduced the following new NuGet issues that were not present before:</target>
         <note />
       </trans-unit>
       <trans-unit id="UpdatePackageFormat">

--- a/src/Aspire.Cli/Resources/xlf/UpdateCommandStrings.ru.xlf
+++ b/src/Aspire.Cli/Resources/xlf/UpdateCommandStrings.ru.xlf
@@ -37,6 +37,11 @@
         <target state="translated">Применение обновлений...</target>
         <note />
       </trans-unit>
+      <trans-unit id="BaselineRestoreStatus">
+        <source>Establishing restore baseline...</source>
+        <target state="new">Establishing restore baseline...</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CentralPackageManagementNotSupported">
         <source>Central package management is currently not supported by 'aspire update'.</source>
         <target state="translated">Централизованное управление пакетами в настоящее время не поддерживается функцией "обновление Aspire".</target>
@@ -55,6 +60,11 @@
       <trans-unit id="CheckingForUpdates">
         <source>Checking for updates...</source>
         <target state="translated">Проверка наличия обновлений...</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ContinueWithIssuesMessage">
+        <source>Update applied with new NuGet issues remaining. You will need to resolve them manually before running the AppHost.</source>
+        <target state="new">Update applied with new NuGet issues remaining. You will need to resolve them manually before running the AppHost.</target>
         <note />
       </trans-unit>
       <trans-unit id="CouldNotFindPackageVersionInDirectoryPackagesProps">
@@ -157,6 +167,11 @@
         <target state="translated">Не удается записать в каталог установки "{0}". Запустите обновление с повышенными правами (например, используя sudo в Linux или macOS).</target>
         <note />
       </trans-unit>
+      <trans-unit id="NonInteractiveNewIssuesMessage">
+        <source>The update introduced new NuGet issues. Re-run interactively to choose between continuing or rolling back, or pass --skip-restore-check to bypass this check.</source>
+        <target state="new">The update introduced new NuGet issues. Re-run interactively to choose between continuing or rolling back, or pass --skip-restore-check to bypass this check.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="NuGetConfigDirOptionDescription">
         <source>Directory to create or update the NuGet.config file in</source>
         <target state="new">Directory to create or update the NuGet.config file in</target>
@@ -180,6 +195,11 @@
       <trans-unit id="PerformUpdatesPrompt">
         <source>Perform updates?</source>
         <target state="translated">Выполнить обновления?</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PostUpdateRestoreStatus">
+        <source>Validating updates with 'dotnet restore'...</source>
+        <target state="new">Validating updates with 'dotnet restore'...</target>
         <note />
       </trans-unit>
       <trans-unit id="ProjectArgumentDescription">
@@ -232,6 +252,21 @@
         <target state="translated">Сохранено: {0}</target>
         <note />
       </trans-unit>
+      <trans-unit id="RollbackFailedFormat">
+        <source>Failed to fully rollback update changes for '{0}': {1}. Some files may need to be restored manually.</source>
+        <target state="new">Failed to fully rollback update changes for '{0}': {1}. Some files may need to be restored manually.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RollbackSuccessMessage">
+        <source>Rolled back update changes. Resolve the underlying package conflicts and re-run 'aspire update'.</source>
+        <target state="new">Rolled back update changes. Resolve the underlying package conflicts and re-run 'aspire update'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RollbackUpdatesPrompt">
+        <source>Rollback the updates to restore the previous state?</source>
+        <target state="new">Rollback the updates to restore the previous state?</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SelectChannelPrompt">
         <source>Select a channel:</source>
         <target state="translated">Выберите канал:</target>
@@ -242,6 +277,11 @@
         <target state="new">Update the Aspire CLI itself to the latest version</target>
         <note />
       </trans-unit>
+      <trans-unit id="SkipRestoreCheckOptionDescription">
+        <source>Skip running 'dotnet restore' before and after the update to detect new NuGet warnings or errors</source>
+        <target state="new">Skip running 'dotnet restore' before and after the update to detect new NuGet warnings or errors</target>
+        <note />
+      </trans-unit>
       <trans-unit id="UnxpectedCodePath">
         <source>Unexpected code path.</source>
         <target state="translated">Непредвиденный путь к коду.</target>
@@ -250,6 +290,11 @@
       <trans-unit id="UpdateCliAfterProjectUpdatePrompt">
         <source>An update is available for the Aspire CLI. Would you like to update it now?</source>
         <target state="translated">Доступно обновление для Aspire CLI. Хотите обновить его сейчас?</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UpdateIntroducedNuGetIssuesHeader">
+        <source>The update introduced the following new NuGet issues that were not present before:</source>
+        <target state="new">The update introduced the following new NuGet issues that were not present before:</target>
         <note />
       </trans-unit>
       <trans-unit id="UpdatePackageFormat">

--- a/src/Aspire.Cli/Resources/xlf/UpdateCommandStrings.tr.xlf
+++ b/src/Aspire.Cli/Resources/xlf/UpdateCommandStrings.tr.xlf
@@ -37,6 +37,11 @@
         <target state="translated">Güncelleştirmeler uygulanıyor...</target>
         <note />
       </trans-unit>
+      <trans-unit id="BaselineRestoreStatus">
+        <source>Establishing restore baseline...</source>
+        <target state="new">Establishing restore baseline...</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CentralPackageManagementNotSupported">
         <source>Central package management is currently not supported by 'aspire update'.</source>
         <target state="translated">Merkezi paket yönetimi şu anda 'aspire update' tarafından desteklenmiyor.</target>
@@ -55,6 +60,11 @@
       <trans-unit id="CheckingForUpdates">
         <source>Checking for updates...</source>
         <target state="translated">Güncelleştirmeler denetleniyor...</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ContinueWithIssuesMessage">
+        <source>Update applied with new NuGet issues remaining. You will need to resolve them manually before running the AppHost.</source>
+        <target state="new">Update applied with new NuGet issues remaining. You will need to resolve them manually before running the AppHost.</target>
         <note />
       </trans-unit>
       <trans-unit id="CouldNotFindPackageVersionInDirectoryPackagesProps">
@@ -157,6 +167,11 @@
         <target state="translated">'{0}' yükleme dizinine yazılamıyor. Lütfen güncellemeyi yükseltilmiş izinlerle (örneğin Linux/macOS'ta sudo kullanarak) çalıştırın.</target>
         <note />
       </trans-unit>
+      <trans-unit id="NonInteractiveNewIssuesMessage">
+        <source>The update introduced new NuGet issues. Re-run interactively to choose between continuing or rolling back, or pass --skip-restore-check to bypass this check.</source>
+        <target state="new">The update introduced new NuGet issues. Re-run interactively to choose between continuing or rolling back, or pass --skip-restore-check to bypass this check.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="NuGetConfigDirOptionDescription">
         <source>Directory to create or update the NuGet.config file in</source>
         <target state="new">Directory to create or update the NuGet.config file in</target>
@@ -180,6 +195,11 @@
       <trans-unit id="PerformUpdatesPrompt">
         <source>Perform updates?</source>
         <target state="translated">Güncelleştirmeler uygulansın mı?</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PostUpdateRestoreStatus">
+        <source>Validating updates with 'dotnet restore'...</source>
+        <target state="new">Validating updates with 'dotnet restore'...</target>
         <note />
       </trans-unit>
       <trans-unit id="ProjectArgumentDescription">
@@ -232,6 +252,21 @@
         <target state="translated">Korundu: {0}</target>
         <note />
       </trans-unit>
+      <trans-unit id="RollbackFailedFormat">
+        <source>Failed to fully rollback update changes for '{0}': {1}. Some files may need to be restored manually.</source>
+        <target state="new">Failed to fully rollback update changes for '{0}': {1}. Some files may need to be restored manually.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RollbackSuccessMessage">
+        <source>Rolled back update changes. Resolve the underlying package conflicts and re-run 'aspire update'.</source>
+        <target state="new">Rolled back update changes. Resolve the underlying package conflicts and re-run 'aspire update'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RollbackUpdatesPrompt">
+        <source>Rollback the updates to restore the previous state?</source>
+        <target state="new">Rollback the updates to restore the previous state?</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SelectChannelPrompt">
         <source>Select a channel:</source>
         <target state="translated">Kanal seçin:</target>
@@ -242,6 +277,11 @@
         <target state="new">Update the Aspire CLI itself to the latest version</target>
         <note />
       </trans-unit>
+      <trans-unit id="SkipRestoreCheckOptionDescription">
+        <source>Skip running 'dotnet restore' before and after the update to detect new NuGet warnings or errors</source>
+        <target state="new">Skip running 'dotnet restore' before and after the update to detect new NuGet warnings or errors</target>
+        <note />
+      </trans-unit>
       <trans-unit id="UnxpectedCodePath">
         <source>Unexpected code path.</source>
         <target state="translated">Beklenmeyen kod yolu.</target>
@@ -250,6 +290,11 @@
       <trans-unit id="UpdateCliAfterProjectUpdatePrompt">
         <source>An update is available for the Aspire CLI. Would you like to update it now?</source>
         <target state="translated">Aspire CLI için bir güncelleştirme var. Şimdi güncelleştirmek istiyor musunuz?</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UpdateIntroducedNuGetIssuesHeader">
+        <source>The update introduced the following new NuGet issues that were not present before:</source>
+        <target state="new">The update introduced the following new NuGet issues that were not present before:</target>
         <note />
       </trans-unit>
       <trans-unit id="UpdatePackageFormat">

--- a/src/Aspire.Cli/Resources/xlf/UpdateCommandStrings.zh-Hans.xlf
+++ b/src/Aspire.Cli/Resources/xlf/UpdateCommandStrings.zh-Hans.xlf
@@ -37,6 +37,11 @@
         <target state="translated">正在应用更新...</target>
         <note />
       </trans-unit>
+      <trans-unit id="BaselineRestoreStatus">
+        <source>Establishing restore baseline...</source>
+        <target state="new">Establishing restore baseline...</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CentralPackageManagementNotSupported">
         <source>Central package management is currently not supported by 'aspire update'.</source>
         <target state="translated">"aspire update" 当前不支持中央包管理。</target>
@@ -55,6 +60,11 @@
       <trans-unit id="CheckingForUpdates">
         <source>Checking for updates...</source>
         <target state="translated">正在检查更新...</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ContinueWithIssuesMessage">
+        <source>Update applied with new NuGet issues remaining. You will need to resolve them manually before running the AppHost.</source>
+        <target state="new">Update applied with new NuGet issues remaining. You will need to resolve them manually before running the AppHost.</target>
         <note />
       </trans-unit>
       <trans-unit id="CouldNotFindPackageVersionInDirectoryPackagesProps">
@@ -157,6 +167,11 @@
         <target state="translated">无法写入安装目录“{0}”。请使用提升的权限运行更新(例如，在 Linux/macOS 上使用 sudo)。</target>
         <note />
       </trans-unit>
+      <trans-unit id="NonInteractiveNewIssuesMessage">
+        <source>The update introduced new NuGet issues. Re-run interactively to choose between continuing or rolling back, or pass --skip-restore-check to bypass this check.</source>
+        <target state="new">The update introduced new NuGet issues. Re-run interactively to choose between continuing or rolling back, or pass --skip-restore-check to bypass this check.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="NuGetConfigDirOptionDescription">
         <source>Directory to create or update the NuGet.config file in</source>
         <target state="new">Directory to create or update the NuGet.config file in</target>
@@ -180,6 +195,11 @@
       <trans-unit id="PerformUpdatesPrompt">
         <source>Perform updates?</source>
         <target state="translated">是否执行更新?</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PostUpdateRestoreStatus">
+        <source>Validating updates with 'dotnet restore'...</source>
+        <target state="new">Validating updates with 'dotnet restore'...</target>
         <note />
       </trans-unit>
       <trans-unit id="ProjectArgumentDescription">
@@ -232,6 +252,21 @@
         <target state="translated">已保留: {0}</target>
         <note />
       </trans-unit>
+      <trans-unit id="RollbackFailedFormat">
+        <source>Failed to fully rollback update changes for '{0}': {1}. Some files may need to be restored manually.</source>
+        <target state="new">Failed to fully rollback update changes for '{0}': {1}. Some files may need to be restored manually.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RollbackSuccessMessage">
+        <source>Rolled back update changes. Resolve the underlying package conflicts and re-run 'aspire update'.</source>
+        <target state="new">Rolled back update changes. Resolve the underlying package conflicts and re-run 'aspire update'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RollbackUpdatesPrompt">
+        <source>Rollback the updates to restore the previous state?</source>
+        <target state="new">Rollback the updates to restore the previous state?</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SelectChannelPrompt">
         <source>Select a channel:</source>
         <target state="translated">选择频道:</target>
@@ -242,6 +277,11 @@
         <target state="new">Update the Aspire CLI itself to the latest version</target>
         <note />
       </trans-unit>
+      <trans-unit id="SkipRestoreCheckOptionDescription">
+        <source>Skip running 'dotnet restore' before and after the update to detect new NuGet warnings or errors</source>
+        <target state="new">Skip running 'dotnet restore' before and after the update to detect new NuGet warnings or errors</target>
+        <note />
+      </trans-unit>
       <trans-unit id="UnxpectedCodePath">
         <source>Unexpected code path.</source>
         <target state="translated">意外的代码路径。</target>
@@ -250,6 +290,11 @@
       <trans-unit id="UpdateCliAfterProjectUpdatePrompt">
         <source>An update is available for the Aspire CLI. Would you like to update it now?</source>
         <target state="translated">Aspire CLI 有可用更新。是否现在更新?</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UpdateIntroducedNuGetIssuesHeader">
+        <source>The update introduced the following new NuGet issues that were not present before:</source>
+        <target state="new">The update introduced the following new NuGet issues that were not present before:</target>
         <note />
       </trans-unit>
       <trans-unit id="UpdatePackageFormat">

--- a/src/Aspire.Cli/Resources/xlf/UpdateCommandStrings.zh-Hant.xlf
+++ b/src/Aspire.Cli/Resources/xlf/UpdateCommandStrings.zh-Hant.xlf
@@ -37,6 +37,11 @@
         <target state="translated">正在套用更新...</target>
         <note />
       </trans-unit>
+      <trans-unit id="BaselineRestoreStatus">
+        <source>Establishing restore baseline...</source>
+        <target state="new">Establishing restore baseline...</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CentralPackageManagementNotSupported">
         <source>Central package management is currently not supported by 'aspire update'.</source>
         <target state="translated">中央套件管理目前不受 'aspire update' 支援。</target>
@@ -55,6 +60,11 @@
       <trans-unit id="CheckingForUpdates">
         <source>Checking for updates...</source>
         <target state="translated">正在檢查更新...</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ContinueWithIssuesMessage">
+        <source>Update applied with new NuGet issues remaining. You will need to resolve them manually before running the AppHost.</source>
+        <target state="new">Update applied with new NuGet issues remaining. You will need to resolve them manually before running the AppHost.</target>
         <note />
       </trans-unit>
       <trans-unit id="CouldNotFindPackageVersionInDirectoryPackagesProps">
@@ -157,6 +167,11 @@
         <target state="translated">無法寫入安裝目錄 '{0}'。請使用提高的權限來執行更新 (例如，在Linux/macOS上使用 sudo)。</target>
         <note />
       </trans-unit>
+      <trans-unit id="NonInteractiveNewIssuesMessage">
+        <source>The update introduced new NuGet issues. Re-run interactively to choose between continuing or rolling back, or pass --skip-restore-check to bypass this check.</source>
+        <target state="new">The update introduced new NuGet issues. Re-run interactively to choose between continuing or rolling back, or pass --skip-restore-check to bypass this check.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="NuGetConfigDirOptionDescription">
         <source>Directory to create or update the NuGet.config file in</source>
         <target state="new">Directory to create or update the NuGet.config file in</target>
@@ -180,6 +195,11 @@
       <trans-unit id="PerformUpdatesPrompt">
         <source>Perform updates?</source>
         <target state="translated">執行更新?</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PostUpdateRestoreStatus">
+        <source>Validating updates with 'dotnet restore'...</source>
+        <target state="new">Validating updates with 'dotnet restore'...</target>
         <note />
       </trans-unit>
       <trans-unit id="ProjectArgumentDescription">
@@ -232,6 +252,21 @@
         <target state="translated">已保留: {0}</target>
         <note />
       </trans-unit>
+      <trans-unit id="RollbackFailedFormat">
+        <source>Failed to fully rollback update changes for '{0}': {1}. Some files may need to be restored manually.</source>
+        <target state="new">Failed to fully rollback update changes for '{0}': {1}. Some files may need to be restored manually.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RollbackSuccessMessage">
+        <source>Rolled back update changes. Resolve the underlying package conflicts and re-run 'aspire update'.</source>
+        <target state="new">Rolled back update changes. Resolve the underlying package conflicts and re-run 'aspire update'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RollbackUpdatesPrompt">
+        <source>Rollback the updates to restore the previous state?</source>
+        <target state="new">Rollback the updates to restore the previous state?</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SelectChannelPrompt">
         <source>Select a channel:</source>
         <target state="translated">選取通道:</target>
@@ -242,6 +277,11 @@
         <target state="new">Update the Aspire CLI itself to the latest version</target>
         <note />
       </trans-unit>
+      <trans-unit id="SkipRestoreCheckOptionDescription">
+        <source>Skip running 'dotnet restore' before and after the update to detect new NuGet warnings or errors</source>
+        <target state="new">Skip running 'dotnet restore' before and after the update to detect new NuGet warnings or errors</target>
+        <note />
+      </trans-unit>
       <trans-unit id="UnxpectedCodePath">
         <source>Unexpected code path.</source>
         <target state="translated">未預期的程式碼路徑。</target>
@@ -250,6 +290,11 @@
       <trans-unit id="UpdateCliAfterProjectUpdatePrompt">
         <source>An update is available for the Aspire CLI. Would you like to update it now?</source>
         <target state="translated">更新可用於 Aspire CLI。您現在要更新嗎？</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UpdateIntroducedNuGetIssuesHeader">
+        <source>The update introduced the following new NuGet issues that were not present before:</source>
+        <target state="new">The update introduced the following new NuGet issues that were not present before:</target>
         <note />
       </trans-unit>
       <trans-unit id="UpdatePackageFormat">

--- a/tests/Aspire.Cli.Tests/Projects/ProjectUpdaterTests.cs
+++ b/tests/Aspire.Cli.Tests/Projects/ProjectUpdaterTests.cs
@@ -7,6 +7,7 @@ using Aspire.Cli.DotNet;
 using Aspire.Cli.Interaction;
 using Aspire.Cli.Packaging;
 using Aspire.Cli.Projects;
+using Aspire.Cli.Resources;
 using Aspire.Cli.Tests.TestServices;
 using Aspire.Cli.Tests.Utils;
 using Aspire.Shared;
@@ -3137,6 +3138,222 @@ public class ProjectUpdaterTests(ITestOutputHelper outputHelper)
         Assert.DoesNotContain("Aspire.Hosting.AppHost", updatedCsprojContent);
         Assert.Contains("Aspire.Hosting.Redis", updatedCsprojContent);
         Assert.Contains("Aspire.AppHost.Sdk/13.0.2", updatedCsprojContent);
+    }
+
+    [Fact]
+    public async Task UpdateProjectFileAsync_RestoreCheck_NewIssueAndRollback_RestoresOriginalProjectContent()
+    {
+        await RunRestoreValidationScenarioAsync(
+            preRestoreLines: Array.Empty<string>(),
+            postRestoreLines: ["AppHost.csproj : warning NU1605: Detected package downgrade: Foo from 9.0.4 to 9.0.0"],
+            isNonInteractive: false,
+            skipRestoreCheck: false,
+            rollbackResponse: true,
+            expectedAppliedFlag: false,
+            assertFinalContent: (originalContent, finalContent) =>
+            {
+                // Rollback must restore the file to its pre-update bytes.
+                Assert.Equal(originalContent, finalContent);
+            });
+    }
+
+    [Fact]
+    public async Task UpdateProjectFileAsync_RestoreCheck_NewIssueAndContinue_LeavesUpdatedContent()
+    {
+        await RunRestoreValidationScenarioAsync(
+            preRestoreLines: Array.Empty<string>(),
+            postRestoreLines: ["AppHost.csproj : warning NU1605: Detected package downgrade: Foo from 9.0.4 to 9.0.0"],
+            isNonInteractive: false,
+            skipRestoreCheck: false,
+            rollbackResponse: false,
+            expectedAppliedFlag: true,
+            assertFinalContent: (originalContent, finalContent) =>
+            {
+                // Continue (no rollback): updated content remains.
+                Assert.NotEqual(originalContent, finalContent);
+                Assert.Contains("Aspire.AppHost.Sdk/9.5.0", finalContent);
+            });
+    }
+
+    [Fact]
+    public async Task UpdateProjectFileAsync_RestoreCheck_PreExistingIssueIsNotARegression()
+    {
+        // Both pre and post restore report the SAME NU1605 — update did not introduce it,
+        // and may even have failed to heal it. Either way, we must not prompt or rollback.
+        await RunRestoreValidationScenarioAsync(
+            preRestoreLines: ["AppHost.csproj : warning NU1605: Detected package downgrade: Foo from 9.0.4 to 9.0.0"],
+            postRestoreLines: ["AppHost.csproj : warning NU1605: Detected package downgrade: Foo from 9.0.4 to 9.0.0"],
+            isNonInteractive: false,
+            skipRestoreCheck: false,
+            rollbackResponse: null, // must not be prompted
+            expectedAppliedFlag: true,
+            assertFinalContent: (_, finalContent) =>
+            {
+                Assert.Contains("Aspire.AppHost.Sdk/9.5.0", finalContent);
+            });
+    }
+
+    [Fact]
+    public async Task UpdateProjectFileAsync_RestoreCheck_NonInteractiveWithNewIssueThrows()
+    {
+        await Assert.ThrowsAsync<ProjectUpdaterException>(() => RunRestoreValidationScenarioAsync(
+            preRestoreLines: Array.Empty<string>(),
+            postRestoreLines: ["AppHost.csproj : warning NU1605: Detected package downgrade: Foo from 9.0.4 to 9.0.0"],
+            isNonInteractive: true,
+            skipRestoreCheck: false,
+            rollbackResponse: null,
+            expectedAppliedFlag: false,
+            assertFinalContent: (originalContent, finalContent) =>
+            {
+                // Non-interactive path leaves changes applied (never auto-rollbacks).
+                Assert.NotEqual(originalContent, finalContent);
+            }));
+    }
+
+    [Fact]
+    public async Task UpdateProjectFileAsync_RestoreCheck_SkipFlag_BypassesRestoreEntirely()
+    {
+        var restoreInvocations = 0;
+        await RunRestoreValidationScenarioAsync(
+            preRestoreLines: Array.Empty<string>(),
+            postRestoreLines: ["should not be observed"],
+            isNonInteractive: false,
+            skipRestoreCheck: true,
+            rollbackResponse: null,
+            expectedAppliedFlag: true,
+            assertFinalContent: (_, finalContent) =>
+            {
+                Assert.Contains("Aspire.AppHost.Sdk/9.5.0", finalContent);
+            },
+            onRestoreInvoked: () => restoreInvocations++);
+        Assert.Equal(0, restoreInvocations);
+    }
+
+    [Fact]
+    public async Task UpdateProjectFileAsync_RestoreCheck_PreRestoreFailureIsNonFatal()
+    {
+        // Pre-restore exits non-zero with no captured NU diagnostics — represents a project
+        // that was already broken in some non-NuGet way. The update should still proceed and,
+        // if the post-restore is clean, succeed without prompting.
+        await RunRestoreValidationScenarioAsync(
+            preRestoreLines: Array.Empty<string>(),
+            postRestoreLines: Array.Empty<string>(),
+            isNonInteractive: false,
+            skipRestoreCheck: false,
+            rollbackResponse: null,
+            expectedAppliedFlag: true,
+            assertFinalContent: (_, finalContent) =>
+            {
+                Assert.Contains("Aspire.AppHost.Sdk/9.5.0", finalContent);
+            },
+            preRestoreExitCode: 1);
+    }
+
+    private async Task RunRestoreValidationScenarioAsync(
+        IReadOnlyList<string> preRestoreLines,
+        IReadOnlyList<string> postRestoreLines,
+        bool isNonInteractive,
+        bool skipRestoreCheck,
+        bool? rollbackResponse,
+        bool expectedAppliedFlag,
+        Action<string, string> assertFinalContent,
+        Action? onRestoreInvoked = null,
+        int preRestoreExitCode = 0)
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+
+        var appHostFolder = workspace.CreateDirectory("UpdateTester.AppHost");
+        var appHostProjectFile = new FileInfo(Path.Combine(appHostFolder.FullName, "UpdateTester.AppHost.csproj"));
+
+        var originalContent = """
+            <Project Sdk="Microsoft.NET.Sdk">
+              <Sdk Name="Aspire.AppHost.Sdk" Version="9.4.1" />
+              <PropertyGroup>
+                <OutputType>Exe</OutputType>
+                <TargetFramework>net8.0</TargetFramework>
+              </PropertyGroup>
+            </Project>
+            """;
+        await File.WriteAllTextAsync(appHostProjectFile.FullName, originalContent);
+
+        var restoreCallCount = 0;
+        var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper, config =>
+        {
+            config.DotNetCliRunnerFactory = (sp) =>
+            {
+                return new TestDotNetCliRunner()
+                {
+                    SearchPackagesAsyncCallback = (_, query, _, _, _, _, _, _, _, _) =>
+                    {
+                        var package = query switch
+                        {
+                            "Aspire.AppHost.Sdk" => new NuGetPackageCli { Id = "Aspire.AppHost.Sdk", Version = "9.5.0", Source = "nuget.org" },
+                            _ => throw new InvalidOperationException($"Unexpected package query: {query}"),
+                        };
+                        return (0, new[] { package });
+                    },
+                    GetProjectItemsAndPropertiesAsyncCallback = (projectFile, _, _, _, _) =>
+                    {
+                        var itemsAndProperties = new JsonObject();
+                        itemsAndProperties.WithSdkVersion("9.4.1");
+                        return (0, JsonDocument.Parse(itemsAndProperties.ToJsonString()));
+                    },
+                    RestoreAsyncCallback = (projectFile, options, _) =>
+                    {
+                        onRestoreInvoked?.Invoke();
+                        var isPre = restoreCallCount == 0;
+                        restoreCallCount++;
+                        var lines = isPre ? preRestoreLines : postRestoreLines;
+                        foreach (var line in lines)
+                        {
+                            options.StandardOutputCallback?.Invoke(line);
+                        }
+                        return isPre ? preRestoreExitCode : 0;
+                    },
+                };
+            };
+
+            config.InteractionServiceFactory = (sp) =>
+            {
+                var interactionService = new TestInteractionService();
+                interactionService.ConfirmCallback = (promptText, defaultValue) =>
+                {
+                    if (promptText == UpdateCommandStrings.RollbackUpdatesPrompt)
+                    {
+                        if (rollbackResponse is null)
+                        {
+                            throw new InvalidOperationException("Rollback prompt was not expected for this scenario.");
+                        }
+                        return rollbackResponse.Value;
+                    }
+                    // First confirm: the standard "perform updates?" prompt.
+                    return true;
+                };
+                return interactionService;
+            };
+        });
+        using var provider = services.BuildServiceProvider();
+
+        var packagingService = provider.GetRequiredService<IPackagingService>();
+        var channels = await packagingService.GetChannelsAsync().DefaultTimeout();
+        var selectedChannel = channels.Single(c => c.Name == "default");
+
+        var projectUpdater = provider.GetRequiredService<IProjectUpdater>();
+        var context = new UpdatePackagesContext
+        {
+            AppHostFile = appHostProjectFile,
+            Channel = selectedChannel,
+            ConfirmBinding = PromptBinding.CreateDefault(true),
+            NuGetConfigDirBinding = PromptBinding.CreateDefault<string?>(null),
+            SkipRestoreCheck = skipRestoreCheck,
+            IsNonInteractive = isNonInteractive,
+        };
+
+        var updateResult = await projectUpdater.UpdateProjectAsync(context).DefaultTimeout();
+        Assert.Equal(expectedAppliedFlag, updateResult.UpdatedApplied);
+
+        var finalContent = await File.ReadAllTextAsync(appHostProjectFile.FullName);
+        assertFinalContent(originalContent, finalContent);
     }
 }
 

--- a/tests/Aspire.Cli.Tests/TestServices/TestDotNetCliRunner.cs
+++ b/tests/Aspire.Cli.Tests/TestServices/TestDotNetCliRunner.cs
@@ -50,7 +50,7 @@ internal sealed class TestDotNetCliRunner : IDotNetCliRunner
     {
         return RestoreAsyncCallback != null
             ? Task.FromResult(RestoreAsyncCallback(projectFilePath, options, cancellationToken))
-            : throw new NotImplementedException();
+            : Task.FromResult(0); // Default to a clean restore so tests that don't care about the post-update validation flow continue to pass.
     }
 
     public Task<(int ExitCode, bool IsAspireHost, string? AspireHostingVersion)> GetAppHostInformationAsync(FileInfo projectFile, ProcessInvocationOptions options, CancellationToken cancellationToken)


### PR DESCRIPTION
`aspire update` can silently introduce NuGet downgrade warnings (typically NU1605) that the user only discovers on their next `dotnet run`. This change validates the update by running `dotnet restore` before and after the apply phase and surfacing genuinely new issues.

## Approach

Regression-style diff rather than a hard pre-check. The pre-update restore captures a baseline of `(NU code, normalized line)` pairs; the post-update restore captures the same. Only entries in the post set that are *not* in the baseline count as regressions. This deliberately tolerates pre-existing breakage, since in some cases the update itself is what heals it.

When new issues are detected:

- **Interactive mode**: the user is prompted to rollback (default) or continue. Rollback restores in-memory snapshots of every project file, `Directory.Packages.props`, and the `NuGet.config` touched by the apply phase.
- **Non-interactive mode** (`--non-interactive`): no auto-rollback. Issues are surfaced and the command exits non-zero so CI catches the regression without making a destructive choice on the user's behalf.

A hidden `--skip-restore-check` flag bypasses both restores as an escape hatch.

## Scope

Only `DotNetAppHostProject` (C# / file-based apphosts) routes through `ProjectUpdater.UpdateProjectAsync`, so this is naturally scoped to C# AppHosts as the issue requested. Guest apphosts (TypeScript etc.) are unaffected.

## Notes for reviewers

- Snapshots are captured in-memory after the user confirms updates but before the first apply step runs. The set is the union of every distinct `PackageUpdateStep.ProjectFile`, the AppHost csproj itself, the resolved `Directory.Packages.props` if CPM is in use, and the explicit-channel `NuGet.config` (existing or about-to-be-created path).
- Baseline restore failure (non-zero exit with no captured NU diagnostics) is intentionally non-fatal — the update may be what heals it.
- `TestDotNetCliRunner.RestoreAsync` now defaults to a clean exit code rather than throwing, so existing tests that don't care about the new flow continue to pass.

Fixes: #16754