### PR TITLE
Fix CLI test process callback signatures

### DIFF
--- a/tests/Aspire.Cli.Tests/Commands/DashboardRunCommandTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/DashboardRunCommandTests.cs
@@ -340,7 +340,7 @@ public class DashboardRunCommandTests(ITestOutputHelper outputHelper)
         var readyTcs = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
         var (services, _, executionFactory) = CreateServicesWithLayout(workspace, interactionService: testInteractionService);
         executionFactory.CreateExecutionCallback = (_, _, _, options) =>
-            new TestProcessExecution("fake", [], null, options, (_, _) => (0, null), () => 0)
+            new TestProcessExecution("fake", [], null, options, (_, _, _) => Task.FromResult((0, (string?)null)), () => 0)
             {
                 WaitForExitAsyncCallback = async (processOptions, cancellationToken) =>
                 {

--- a/tests/Aspire.Cli.Tests/TestServices/TestProcessExecutionFactory.cs
+++ b/tests/Aspire.Cli.Tests/TestServices/TestProcessExecutionFactory.cs
@@ -140,7 +140,7 @@ internal sealed class TestProcessExecution : IProcessExecution
 
         if (WaitForExitAsyncCallback is not null)
         {
-            return WaitForExitAsyncCallback(_options, cancellationToken);
+            return await WaitForExitAsyncCallback(_options, cancellationToken).ConfigureAwait(false);
         }
 
         var attempt = _attemptCounter();


### PR DESCRIPTION
## Description

Fixes a `Tests / Cli / Cli` CI compile break on `main`.

`TestProcessExecution.WaitForExitAsync` now awaits the optional async callback instead of returning the callback task directly from an `async Task<int>` method. The `DashboardRunCommandTests` cancellation test stub now passes the three-argument async attempt callback shape expected by `TestProcessExecution`.

Validation:

```text
dotnet build tests/Aspire.Cli.Tests/Aspire.Cli.Tests.csproj --no-restore
dotnet test --project tests/Aspire.Cli.Tests/Aspire.Cli.Tests.csproj --no-launch-profile -- --filter-not-trait "quarantined=true" --filter-not-trait "outerloop=true"

Test run summary: Passed!
  total: 2998
  failed: 0
  succeeded: 2978
  skipped: 20
```

Fixes # (issue)

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
