### PR TITLE
Clean up extension Aspire CLI processes

### DIFF
--- a/extension/src/test/appHostDataRepository.test.ts
+++ b/extension/src/test/appHostDataRepository.test.ts
@@ -250,6 +250,31 @@ suite('AppHostDataRepository global polling', () => {
         repository.dispose();
     });
 
+    test('cli path failure does not disable resources polling', async () => {
+        const clock = sinon.useFakeTimers();
+        getCliPathStub.onFirstCall().rejects(new Error('CLI path unavailable'));
+        getCliPathStub.onSecondCall().resolves('aspire');
+        const repository = new AppHostDataRepository(terminalProvider);
+
+        try {
+            repository.activate();
+            repository.setViewMode('global');
+            repository.setPanelVisible(true);
+            await waitForMicrotasks();
+
+            assert.strictEqual(spawnStub.called, false);
+
+            clock.tick(30000);
+            await waitForMicrotasks();
+
+            assert.strictEqual(spawnStub.calledOnce, true);
+            assert.deepStrictEqual(spawnStub.firstCall.args[2], ['ps', '--format', 'json', '--resources']);
+        } finally {
+            repository.dispose();
+            clock.restore();
+        }
+    });
+
     test('stopped ps does not start fallback after resources failure', async () => {
         const childProcess = new TestChildProcess();
         spawnStub.returns(childProcess);

--- a/extension/src/test/appHostDataRepository.test.ts
+++ b/extension/src/test/appHostDataRepository.test.ts
@@ -11,8 +11,8 @@ class TestChildProcess extends EventEmitter {
     stdout = new PassThrough();
     stderr = new PassThrough();
     killed = false;
-    exitCode = null;
-    signalCode = null;
+    exitCode: number | null = null;
+    signalCode: NodeJS.Signals | null = null;
     killSignals: Array<NodeJS.Signals | number | undefined> = [];
 
     constructor(private readonly _closeOnKill = true) {
@@ -23,9 +23,14 @@ class TestChildProcess extends EventEmitter {
         this.killed = true;
         this.killSignals.push(signal);
         if (this._closeOnKill) {
+            this.exitCode = 0;
             this.emit('close', null);
         }
         return true;
+    }
+
+    markExited(exitCode = 0): void {
+        this.exitCode = exitCode;
     }
 }
 
@@ -187,6 +192,25 @@ suite('AppHostDataRepository', () => {
             clock.restore();
         }
     });
+
+    test('already-exited describe watch is not terminated again', async () => {
+        const childProcess = new TestChildProcess();
+        childProcess.markExited();
+        spawnStub.returns(childProcess);
+        const repository = new AppHostDataRepository(terminalProvider);
+
+        repository.activate();
+        repository.setPanelVisible(true);
+        await waitForMicrotasks();
+
+        repository.setPanelVisible(false);
+
+        assert.strictEqual(childProcess.killed, false);
+        assert.strictEqual(childProcess.listenerCount('close'), 0);
+        assert.strictEqual(childProcess.listenerCount('exit'), 0);
+
+        repository.dispose();
+    });
 });
 
 suite('AppHostDataRepository global polling', () => {
@@ -316,6 +340,28 @@ suite('AppHostDataRepository global polling', () => {
         repository.dispose();
 
         assert.strictEqual(fallbackChildProcess.killed, true);
+    });
+
+    test('synchronously completed ps process is not tracked for later termination', async () => {
+        let childProcess: TestChildProcess | undefined;
+        spawnStub.callsFake((_terminalProvider, _cliPath, _args, options) => {
+            childProcess = new TestChildProcess();
+            options.exitCallback(0);
+            return childProcess;
+        });
+        const repository = new AppHostDataRepository(terminalProvider);
+
+        repository.activate();
+        repository.setViewMode('global');
+        repository.setPanelVisible(true);
+        await waitForMicrotasks();
+
+        repository.setPanelVisible(false);
+
+        assert.ok(childProcess);
+        assert.strictEqual(childProcess.killed, false);
+
+        repository.dispose();
     });
 });
 

--- a/extension/src/test/appHostDataRepository.test.ts
+++ b/extension/src/test/appHostDataRepository.test.ts
@@ -11,10 +11,20 @@ class TestChildProcess extends EventEmitter {
     stdout = new PassThrough();
     stderr = new PassThrough();
     killed = false;
+    exitCode = null;
+    signalCode = null;
+    killSignals: Array<NodeJS.Signals | number | undefined> = [];
 
-    kill(): boolean {
+    constructor(private readonly _closeOnKill = true) {
+        super();
+    }
+
+    kill(signal?: NodeJS.Signals | number): boolean {
         this.killed = true;
-        this.emit('close', null);
+        this.killSignals.push(signal);
+        if (this._closeOnKill) {
+            this.emit('close', null);
+        }
         return true;
     }
 }
@@ -155,6 +165,132 @@ suite('AppHostDataRepository', () => {
         assert.strictEqual(secondChildProcess.killed, true);
 
         repository.dispose();
+    });
+
+    test('stubborn describe watch is force killed', async () => {
+        const clock = sinon.useFakeTimers();
+        const childProcess = new TestChildProcess(false);
+        spawnStub.returns(childProcess);
+        const repository = new AppHostDataRepository(terminalProvider);
+
+        try {
+            repository.activate();
+            repository.setPanelVisible(true);
+            await waitForMicrotasks();
+
+            repository.setPanelVisible(false);
+            clock.tick(5000);
+
+            assert.deepStrictEqual(childProcess.killSignals, [undefined, 'SIGKILL']);
+        } finally {
+            repository.dispose();
+            clock.restore();
+        }
+    });
+});
+
+suite('AppHostDataRepository global polling', () => {
+    let terminalProvider: AspireTerminalProvider;
+    let subscriptions: vscode.Disposable[];
+    let getCliPathStub: sinon.SinonStub;
+    let spawnStub: sinon.SinonStub;
+
+    setup(() => {
+        subscriptions = [];
+        terminalProvider = new AspireTerminalProvider(subscriptions);
+        getCliPathStub = sinon.stub(terminalProvider, 'getAspireCliExecutablePath').resolves('aspire');
+        spawnStub = sinon.stub(cliModule, 'spawnCliProcess');
+        spawnStub.callsFake(() => new TestChildProcess());
+    });
+
+    teardown(() => {
+        spawnStub.restore();
+        getCliPathStub.restore();
+        subscriptions.forEach(subscription => subscription.dispose());
+    });
+
+    test('hiding global panel kills in-flight ps process', async () => {
+        const childProcess = new TestChildProcess();
+        spawnStub.returns(childProcess);
+        const repository = new AppHostDataRepository(terminalProvider);
+
+        repository.activate();
+        repository.setViewMode('global');
+        repository.setPanelVisible(true);
+        await waitForMicrotasks();
+
+        assert.deepStrictEqual(spawnStub.firstCall.args[2], ['ps', '--format', 'json', '--resources']);
+
+        repository.setPanelVisible(false);
+
+        assert.strictEqual(childProcess.killed, true);
+
+        repository.dispose();
+    });
+
+    test('hiding global panel before cli path resolves prevents ps from starting', async () => {
+        const cliPath = createDeferred<string>();
+        getCliPathStub.returns(cliPath.promise);
+        const repository = new AppHostDataRepository(terminalProvider);
+
+        repository.activate();
+        repository.setViewMode('global');
+        repository.setPanelVisible(true);
+        repository.setPanelVisible(false);
+        cliPath.resolve('aspire');
+        await waitForMicrotasks();
+
+        assert.strictEqual(spawnStub.called, false);
+
+        repository.setPanelVisible(true);
+        await waitForMicrotasks();
+
+        assert.strictEqual(spawnStub.calledOnce, true);
+
+        repository.dispose();
+    });
+
+    test('stopped ps does not start fallback after resources failure', async () => {
+        const childProcess = new TestChildProcess();
+        spawnStub.returns(childProcess);
+        const repository = new AppHostDataRepository(terminalProvider);
+
+        repository.activate();
+        repository.setViewMode('global');
+        repository.setPanelVisible(true);
+        await waitForMicrotasks();
+        const exitCallback = spawnStub.firstCall.args[3].exitCallback;
+
+        repository.setPanelVisible(false);
+        exitCallback(1);
+        await waitForMicrotasks();
+
+        assert.strictEqual(spawnStub.calledOnce, true);
+
+        repository.dispose();
+    });
+
+    test('dispose kills in-flight ps fallback process', async () => {
+        const firstChildProcess = new TestChildProcess();
+        const fallbackChildProcess = new TestChildProcess();
+        spawnStub.onFirstCall().returns(firstChildProcess);
+        spawnStub.onSecondCall().returns(fallbackChildProcess);
+        const repository = new AppHostDataRepository(terminalProvider);
+
+        repository.activate();
+        repository.setViewMode('global');
+        repository.setPanelVisible(true);
+        await waitForMicrotasks();
+        const exitCallback = spawnStub.firstCall.args[3].exitCallback;
+
+        exitCallback(1);
+        await waitForMicrotasks();
+
+        assert.strictEqual(spawnStub.calledTwice, true);
+
+        repository.dispose();
+
+        assert.strictEqual(fallbackChildProcess.killed, true);
     });
 });
 

--- a/extension/src/views/AppHostDataRepository.ts
+++ b/extension/src/views/AppHostDataRepository.ts
@@ -584,6 +584,7 @@ export class AppHostDataRepository {
                 const errorMessage = errorFetchingAppHosts(String(error));
                 extensionLogOutputChannel.warn(errorMessage);
                 this._setError(errorMessage);
+                this._fetchInProgress = false;
                 if (this._loadingGlobal) {
                     this._loadingGlobal = false;
                     this._updateLoadingContext();

--- a/extension/src/views/AppHostDataRepository.ts
+++ b/extension/src/views/AppHostDataRepository.ts
@@ -581,7 +581,13 @@ export class AppHostDataRepository {
             cliPath = await this._terminalProvider.getAspireCliExecutablePath();
         } catch (error) {
             if (this._isCurrentPsFetch(fetchVersion)) {
-                callback(1, '', String(error));
+                const errorMessage = errorFetchingAppHosts(String(error));
+                extensionLogOutputChannel.warn(errorMessage);
+                this._setError(errorMessage);
+                if (this._loadingGlobal) {
+                    this._loadingGlobal = false;
+                    this._updateLoadingContext();
+                }
             }
             return;
         }

--- a/extension/src/views/AppHostDataRepository.ts
+++ b/extension/src/views/AppHostDataRepository.ts
@@ -601,12 +601,22 @@ export class AppHostDataRepository {
         let stderr = '';
         let callbackInvoked = false;
 
-        const psProcess = spawnCliProcess(this._terminalProvider, cliPath, args, {
+        let psProcess: ChildProcessWithoutNullStreams | undefined;
+        let psProcessCompletedSynchronously = false;
+        const removePsProcess = () => {
+            if (psProcess) {
+                this._psProcesses.delete(psProcess);
+            } else {
+                psProcessCompletedSynchronously = true;
+            }
+        };
+
+        psProcess = spawnCliProcess(this._terminalProvider, cliPath, args, {
             noExtensionVariables: true,
             stdoutCallback: (data) => { stdout += data; },
             stderrCallback: (data) => { stderr += data; },
             exitCallback: (code) => {
-                this._psProcesses.delete(psProcess);
+                removePsProcess();
                 if (!callbackInvoked) {
                     callbackInvoked = true;
                     if (this._isCurrentPsFetch(fetchVersion)) {
@@ -615,7 +625,7 @@ export class AppHostDataRepository {
                 }
             },
             errorCallback: (error) => {
-                this._psProcesses.delete(psProcess);
+                removePsProcess();
                 extensionLogOutputChannel.warn(errorFetchingAppHosts(error.message));
                 if (!callbackInvoked) {
                     callbackInvoked = true;
@@ -625,7 +635,9 @@ export class AppHostDataRepository {
                 }
             }
         });
-        this._psProcesses.add(psProcess);
+        if (!psProcessCompletedSynchronously) {
+            this._psProcesses.add(psProcess);
+        }
     }
 
     private _terminateProcess(childProcess: ChildProcessWithoutNullStreams, description: string): void {
@@ -679,6 +691,7 @@ export class AppHostDataRepository {
                     cleanup();
                 }
             }, AppHostDataRepository._processShutdownGracePeriodMs);
+            forceKillTimer.unref();
         }
     }
 }

--- a/extension/src/views/AppHostDataRepository.ts
+++ b/extension/src/views/AppHostDataRepository.ts
@@ -61,6 +61,8 @@ export type ViewMode = 'workspace' | 'global';
  *    global mode is selected.
  */
 export class AppHostDataRepository {
+    private static readonly _processShutdownGracePeriodMs = 5000;
+
     private readonly _onDidChangeData = new vscode.EventEmitter<void>();
     readonly onDidChangeData = this._onDidChangeData.event;
 
@@ -81,6 +83,8 @@ export class AppHostDataRepository {
     // ── Global mode state (ps polling) ──
     private _appHosts: AppHostDisplayInfo[] = [];
     private _pollingInterval: ReturnType<typeof setInterval> | undefined;
+    private _psProcesses = new Set<ChildProcessWithoutNullStreams>();
+    private _psFetchVersion = 0;
     private _supportsResources = true;
     private _fetchInProgress = false;
 
@@ -198,7 +202,11 @@ export class AppHostDataRepository {
         this._disposed = true;
         this._stopPolling();
         this._stopDescribeWatch();
-        this._getAppHostsProcess?.kill();
+        if (this._getAppHostsProcess) {
+            const getAppHostsProcess = this._getAppHostsProcess;
+            this._getAppHostsProcess = undefined;
+            this._terminateProcess(getAppHostsProcess, 'aspire extension get-apphosts');
+        }
         this._configChangeDisposable.dispose();
         this._onDidChangeData.dispose();
     }
@@ -408,7 +416,7 @@ export class AppHostDataRepository {
             const describeProcess = this._describeProcess;
             extensionLogOutputChannel.info('Stopping aspire describe --follow for workspace resources');
             this._describeProcess = undefined;
-            describeProcess.kill();
+            this._terminateProcess(describeProcess, 'aspire describe --follow');
         }
         if (options?.clearWorkspaceResources) {
             this._clearWorkspaceResources();
@@ -468,11 +476,17 @@ export class AppHostDataRepository {
     }
 
     private _stopPolling(): void {
+        this._psFetchVersion++;
+        this._fetchInProgress = false;
         if (this._pollingInterval) {
             clearInterval(this._pollingInterval);
             this._pollingInterval = undefined;
             extensionLogOutputChannel.info(`aspire ps polling stopped`);
         }
+        for (const psProcess of this._psProcesses) {
+            this._terminateProcess(psProcess, 'aspire ps');
+        }
+        this._psProcesses.clear();
     }
 
     private _getPollingIntervalMs(): number {
@@ -482,16 +496,17 @@ export class AppHostDataRepository {
     }
 
     private _fetchAppHosts(): void {
-        if (this._fetchInProgress) {
+        if (this._fetchInProgress || this._disposed || !this._shouldPoll) {
             return;
         }
         this._fetchInProgress = true;
+        const fetchVersion = ++this._psFetchVersion;
 
         const args = ['ps', '--format', 'json'];
         if (this._supportsResources) {
             args.push('--resources');
         }
-        this._runPsCommand(args, (code, stdout, stderr) => {
+        this._runPsCommand(args, fetchVersion, (code, stdout, stderr) => {
             if (code === 0) {
                 this._setError(undefined);
                 this._handlePsOutput(stdout);
@@ -499,7 +514,7 @@ export class AppHostDataRepository {
             } else if (this._supportsResources) {
                 this._supportsResources = false;
                 extensionLogOutputChannel.info('aspire ps --resources failed, falling back to aspire ps without --resources');
-                this._runPsCommand(['ps', '--format', 'json'], (retryCode, retryStdout, retryStderr) => {
+                this._runPsCommand(['ps', '--format', 'json'], fetchVersion, (retryCode, retryStdout, retryStderr) => {
                     if (retryCode === 0) {
                         this._setError(undefined);
                         this._handlePsOutput(retryStdout);
@@ -517,6 +532,10 @@ export class AppHostDataRepository {
                 this._fetchInProgress = false;
             }
         });
+    }
+
+    private _isCurrentPsFetch(fetchVersion: number): boolean {
+        return !this._disposed && this._shouldPoll && fetchVersion === this._psFetchVersion;
     }
 
     private _updateLoadingContext(): void {
@@ -556,31 +575,104 @@ export class AppHostDataRepository {
         }
     }
 
-    private async _runPsCommand(args: string[], callback: (code: number, stdout: string, stderr: string) => void): Promise<void> {
-        const cliPath = await this._terminalProvider.getAspireCliExecutablePath();
+    private async _runPsCommand(args: string[], fetchVersion: number, callback: (code: number, stdout: string, stderr: string) => void): Promise<void> {
+        let cliPath: string;
+        try {
+            cliPath = await this._terminalProvider.getAspireCliExecutablePath();
+        } catch (error) {
+            if (this._isCurrentPsFetch(fetchVersion)) {
+                callback(1, '', String(error));
+            }
+            return;
+        }
+
+        if (!this._isCurrentPsFetch(fetchVersion)) {
+            return;
+        }
 
         let stdout = '';
         let stderr = '';
         let callbackInvoked = false;
 
-        spawnCliProcess(this._terminalProvider, cliPath, args, {
+        const psProcess = spawnCliProcess(this._terminalProvider, cliPath, args, {
             noExtensionVariables: true,
             stdoutCallback: (data) => { stdout += data; },
             stderrCallback: (data) => { stderr += data; },
             exitCallback: (code) => {
+                this._psProcesses.delete(psProcess);
                 if (!callbackInvoked) {
                     callbackInvoked = true;
-                    callback(code ?? 1, stdout, stderr);
+                    if (this._isCurrentPsFetch(fetchVersion)) {
+                        callback(code ?? 1, stdout, stderr);
+                    }
                 }
             },
             errorCallback: (error) => {
+                this._psProcesses.delete(psProcess);
                 extensionLogOutputChannel.warn(errorFetchingAppHosts(error.message));
                 if (!callbackInvoked) {
                     callbackInvoked = true;
-                    callback(1, stdout, stderr || error.message);
+                    if (this._isCurrentPsFetch(fetchVersion)) {
+                        callback(1, stdout, stderr || error.message);
+                    }
                 }
             }
         });
+        this._psProcesses.add(psProcess);
+    }
+
+    private _terminateProcess(childProcess: ChildProcessWithoutNullStreams, description: string): void {
+        let exited = childProcess.exitCode !== null || childProcess.signalCode !== null;
+        let forceKillTimer: ReturnType<typeof setTimeout> | undefined;
+        const cleanup = () => {
+            exited = true;
+            childProcess.off('close', cleanup);
+            childProcess.off('exit', cleanup);
+            if (forceKillTimer) {
+                clearTimeout(forceKillTimer);
+                forceKillTimer = undefined;
+            }
+        };
+
+        if (!exited) {
+            childProcess.once('close', cleanup);
+            childProcess.once('exit', cleanup);
+        } else {
+            return;
+        }
+
+        try {
+            if (!childProcess.killed) {
+                const signalSent = childProcess.kill();
+                if (!signalSent) {
+                    cleanup();
+                    return;
+                }
+            }
+        } catch (error) {
+            extensionLogOutputChannel.warn(`Failed to stop ${description}: ${error}`);
+            cleanup();
+            return;
+        }
+
+        if (!exited) {
+            forceKillTimer = setTimeout(() => {
+                if (exited) {
+                    return;
+                }
+
+                extensionLogOutputChannel.warn(`${description} did not exit within ${AppHostDataRepository._processShutdownGracePeriodMs}ms; forcing termination.`);
+                try {
+                    const signalSent = childProcess.kill('SIGKILL');
+                    if (!signalSent) {
+                        cleanup();
+                    }
+                } catch (error) {
+                    extensionLogOutputChannel.warn(`Failed to force stop ${description}: ${error}`);
+                    cleanup();
+                }
+            }, AppHostDataRepository._processShutdownGracePeriodMs);
+        }
     }
 }
 


### PR DESCRIPTION
## Description

The VS Code extension can start background Aspire CLI processes for running AppHost data: `aspire describe --follow`, `aspire ps --format json --resources`, and `aspire extension get-apphosts`. Some lifecycle paths cleaned up timers or repository state without reliably cleaning up the spawned child processes themselves.

This change makes the repository own and clean up those child processes more completely:

- Tracks every in-flight `aspire ps` polling process and terminates it when polling stops or the repository is disposed.
- Uses a polling generation token so stale async `ps` startup/results cannot update state or start the fallback `ps` command after polling was stopped.
- Routes `describe --follow`, `ps`, and `get-apphosts` termination through a shared helper that first sends the normal termination signal and then forces termination if the process does not exit within the grace period.
- Adds focused unit tests for hidden-panel/dispose cleanup, delayed CLI path resolution, fallback suppression, and stubborn `describe --follow` processes.

Fixes # (issue)

Validation:

- `npm run compile-tests`
- `npm run lint`
- `npm run unit-test` (410 passing)
- `npm run compile` (succeeded with existing webpack optional dependency warnings for `bufferutil` / `utf-8-validate` and the existing Express dynamic dependency warning)
- `git diff --check`

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
