### PR TITLE
Throw ArgumentException when subscribing to interface or abstract event type

### DIFF
--- a/src/Aspire.Hosting/Eventing/DistributedApplicationEventing.cs
+++ b/src/Aspire.Hosting/Eventing/DistributedApplicationEventing.cs
@@ -78,7 +78,7 @@ public class DistributedApplicationEventing : IDistributedApplicationEventing
     {
         if (typeof(T).IsInterface || typeof(T).IsAbstract)
         {
-            throw new ArgumentException($"Cannot subscribe to interface or abstract type '{typeof(T).Name}'. Subscribe to a concrete event type instead.", nameof(callback));
+            throw new ArgumentException($"Cannot subscribe to interface or abstract type '{typeof(T).Name}'. Subscribe to a concrete event type instead.");
         }
 
         var subscription = new DistributedApplicationEventSubscription(async (@event, ct) =>

--- a/src/Aspire.Hosting/Eventing/DistributedApplicationEventing.cs
+++ b/src/Aspire.Hosting/Eventing/DistributedApplicationEventing.cs
@@ -76,6 +76,11 @@ public class DistributedApplicationEventing : IDistributedApplicationEventing
     /// <inheritdoc cref="IDistributedApplicationEventing.Subscribe{T}(Func{T, CancellationToken, Task})" />
     public DistributedApplicationEventSubscription Subscribe<T>(Func<T, CancellationToken, Task> callback) where T : IDistributedApplicationEvent
     {
+        if (typeof(T).IsInterface || typeof(T).IsAbstract)
+        {
+            throw new ArgumentException($"Cannot subscribe to interface or abstract type '{typeof(T).Name}'. Subscribe to a concrete event type instead.", nameof(callback));
+        }
+
         var subscription = new DistributedApplicationEventSubscription(async (@event, ct) =>
         {
             var typedEvent = (T)@event;

--- a/tests/Aspire.Hosting.Tests/Eventing/DistributedApplicationBuilderEventingTests.cs
+++ b/tests/Aspire.Hosting.Tests/Eventing/DistributedApplicationBuilderEventingTests.cs
@@ -456,7 +456,48 @@ public class DistributedApplicationBuilderEventingTests(ITestOutputHelper testOu
         Assert.Same(builder, result);
     }
 
+    [Fact]
+    public void SubscribeToInterfaceThrowsArgumentException()
+    {
+        using var builder = TestDistributedApplicationBuilder.Create(testOutputHelper);
+
+        var ex = Assert.Throws<ArgumentException>(() =>
+            builder.Eventing.Subscribe<IDistributedApplicationEvent>((_, _) => Task.CompletedTask));
+
+        Assert.Contains("IDistributedApplicationEvent", ex.Message);
+        Assert.Contains("concrete", ex.Message);
+    }
+
+    [Fact]
+    public void SubscribeToAbstractClassThrowsArgumentException()
+    {
+        using var builder = TestDistributedApplicationBuilder.Create(testOutputHelper);
+
+        var ex = Assert.Throws<ArgumentException>(() =>
+            builder.Eventing.Subscribe<AbstractDummyEvent>((_, _) => Task.CompletedTask));
+
+        Assert.Contains("AbstractDummyEvent", ex.Message);
+        Assert.Contains("concrete", ex.Message);
+    }
+
+    [Fact]
+    public void SubscribeResourceScopedToInterfaceThrowsArgumentException()
+    {
+        using var builder = TestDistributedApplicationBuilder.Create(testOutputHelper);
+        var resource = builder.AddResource(new TestResource("test"));
+
+        var ex = Assert.Throws<ArgumentException>(() =>
+            builder.Eventing.Subscribe<IDistributedApplicationResourceEvent>(resource.Resource, (_, _) => Task.CompletedTask));
+
+        Assert.Contains("IDistributedApplicationResourceEvent", ex.Message);
+        Assert.Contains("concrete", ex.Message);
+    }
+
     public class DummyEvent : IDistributedApplicationEvent
+    {
+    }
+
+    public abstract class AbstractDummyEvent : IDistributedApplicationEvent
     {
     }
 


### PR DESCRIPTION
## Description

Fixes #5565

Calling `Subscribe<IDistributedApplicationEvent>(...)` or `Subscribe<SomeAbstractClass>(...)` silently registered a subscription that would never fire, with no indication to the developer that something was wrong. This is because the internal lookup key is `typeof(T)`, but `PublishAsync<T>` is always called with a concrete type — so the interface/abstract key never matches.

This PR adds a guard at the top of both `Subscribe<T>` overloads in `DistributedApplicationEventing` that throws an `ArgumentException` when `T` is an interface or abstract class, surfacing the problem immediately rather than silently swallowing subscriptions.

### User-facing usage

Before this fix, the following code would silently register a no-op subscription:

```csharp
// Silent bug: callback never fires
builder.Eventing.Subscribe<IDistributedApplicationEvent>((e, ct) => { ... });
```

After this fix, it throws immediately with a clear message:

```
ArgumentException: Cannot subscribe to interface or abstract type 'IDistributedApplicationEvent'. Subscribe to a concrete event type instead.
```

Users should subscribe to concrete types instead:

```csharp
// Correct: subscribe to a concrete event type
builder.Eventing.Subscribe<BeforeStartEvent>((e, ct) => { ... });
```

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
  - [x] No
