### PR TITLE
Separate CLI profiling telemetry export

### DIFF
--- a/src/Aspire.Cli/Commands/AppHostLauncher.cs
+++ b/src/Aspire.Cli/Commands/AppHostLauncher.cs
@@ -264,7 +264,7 @@ internal sealed class AppHostLauncher(
     {
         Process childProcess;
 
-        using (var spawnActivity = profilingTelemetry.StartDetachedSpawnChild(executablePath, childArgs.Count, "run"))
+        using (var spawnActivity = profilingTelemetry.StartDetachedSpawnChild(executablePath, childArgs, "run"))
         {
             try
             {

--- a/src/Aspire.Cli/DotNet/DotNetCliRunner.cs
+++ b/src/Aspire.Cli/DotNet/DotNetCliRunner.cs
@@ -107,11 +107,11 @@ internal sealed class DotNetCliRunner(
 
         // Resolve the dotnet executable path, preferring the private SDK installation if available.
         var dotnetPath = ResolveDotNetPath(finalEnv);
+        var effectiveArgs = AddBinlogArgumentIfConfigured(args, dotnetCommand, projectFile, workingDirectory, processActivity);
         processActivity.SetDotNetResolvedExecutable(
             dotnetPath,
+            effectiveArgs,
             finalEnv.TryGetValue("DOTNET_CLI_USE_MSBUILD_SERVER", out var msBuildServerValue) ? msBuildServerValue : null);
-
-        var effectiveArgs = AddBinlogArgumentIfConfigured(args, dotnetCommand, projectFile, workingDirectory, processActivity);
         processActivity.SetDotNetArgsCount(effectiveArgs.Length);
 
         var outputCounters = new ProcessOutputCounters();

--- a/src/Aspire.Cli/Git/GitRepository.cs
+++ b/src/Aspire.Cli/Git/GitRepository.cs
@@ -34,7 +34,7 @@ internal sealed class GitRepository(CliExecutionContext executionContext, ILogge
             startInfo.ArgumentList.Add("--show-toplevel");
 
             using var process = new Process { StartInfo = startInfo };
-            using var activity = profilingTelemetry.StartGitCommand("rev-parse", startInfo.ArgumentList.Count, executionContext.WorkingDirectory);
+            using var activity = profilingTelemetry.StartGitCommand("rev-parse", startInfo.FileName, startInfo.ArgumentList, executionContext.WorkingDirectory);
 
             process.Start();
             activity.SetProcessId(process.Id);
@@ -117,7 +117,7 @@ internal sealed class GitRepository(CliExecutionContext executionContext, ILogge
             startInfo.ArgumentList.Add("-z");
 
             using var process = new Process { StartInfo = startInfo };
-            using var activity = profilingTelemetry.StartGitCommand("ls-files", startInfo.ArgumentList.Count, searchRoot);
+            using var activity = profilingTelemetry.StartGitCommand("ls-files", startInfo.FileName, startInfo.ArgumentList, searchRoot);
 
             process.Start();
             activity.SetProcessId(process.Id);

--- a/src/Aspire.Cli/Npm/NpmRunner.cs
+++ b/src/Aspire.Cli/Npm/NpmRunner.cs
@@ -355,7 +355,7 @@ internal sealed class NpmRunner(ILogger<NpmRunner> logger, ProfilingTelemetry pr
             var startInfo = CreateNpmProcessStartInfo(npmPath, args, workingDirectory);
 
             using var process = new Process { StartInfo = startInfo };
-            using var activity = profilingTelemetry.StartNpmCommand(npmPath, args.Length, workingDirectory);
+            using var activity = profilingTelemetry.StartNpmCommand(npmPath, args, workingDirectory);
             process.Start();
             activity.SetProcessId(process.Id);
 

--- a/src/Aspire.Cli/Program.cs
+++ b/src/Aspire.Cli/Program.cs
@@ -324,7 +324,8 @@ public class Program
         // Configure OpenTelemetry tracing. TelemetryManager reads configuration and creates
         // separate TracerProvider instances:
         // - Azure Monitor provider with filtering (only exports activities with EXTERNAL_TELEMETRY=true)
-        // - Diagnostic provider for OTLP/console exporters (exports all activities, DEBUG only)
+        // - Profiling provider for explicit startup profiling OTLP export
+        // - Diagnostic provider for DEBUG-only diagnostics
         builder.Services.AddSingleton(sp => new TelemetryManager(sp.GetRequiredService<IConfiguration>(), args));
 
         // Shared services.

--- a/src/Aspire.Cli/Projects/AppHostServerSession.cs
+++ b/src/Aspire.Cli/Projects/AppHostServerSession.cs
@@ -100,7 +100,7 @@ internal sealed class AppHostServerSession : IAppHostServerSession
         }
 
         activity.SetProcessId(serverProcess.Id);
-        activity.SetProcessExecutableName(Path.GetFileName(serverProcess.StartInfo.FileName));
+        activity.SetProcessInvocation(serverProcess.StartInfo.FileName, serverProcess.StartInfo.ArgumentList);
 
         return new AppHostServerSession(
             serverProcess,

--- a/src/Aspire.Cli/Projects/GuestRuntime.cs
+++ b/src/Aspire.Cli/Projects/GuestRuntime.cs
@@ -79,7 +79,7 @@ internal sealed class GuestRuntime
             var launcher = CreateDefaultLauncher();
             using var activity = _profilingTelemetry is null
                 ? default
-                : _profilingTelemetry.StartGuestInitializeCommand(_spec.Language, _spec.DisplayName, commandSpec.Command, args.Length, directory);
+                : _profilingTelemetry.StartGuestInitializeCommand(_spec.Language, _spec.DisplayName, commandSpec.Command, args, directory);
             var (exitCode, output) = await launcher.LaunchAsync(
                 commandSpec.Command,
                 args,
@@ -119,7 +119,7 @@ internal sealed class GuestRuntime
         var launcher = CreateDefaultLauncher();
         using var activity = _profilingTelemetry is null
             ? default
-            : _profilingTelemetry.StartGuestInstallDependencies(_spec.Language, _spec.DisplayName, _spec.InstallDependencies.Command, args.Length, directory);
+            : _profilingTelemetry.StartGuestInstallDependencies(_spec.Language, _spec.DisplayName, _spec.InstallDependencies.Command, args, directory);
         var (exitCode, output) = await launcher.LaunchAsync(
             _spec.InstallDependencies.Command,
             args,
@@ -168,7 +168,10 @@ internal sealed class GuestRuntime
             }
         }
 
-        return await ExecuteCommandAsync(commandSpec, appHostFile, directory, environmentVariables, null, launcher, cancellationToken);
+        var phase = useWatchCommand
+            ? ProfilingTelemetry.Values.GuestCommandPhaseWatchExecute
+            : ProfilingTelemetry.Values.GuestCommandPhaseExecute;
+        return await ExecuteCommandAsync(commandSpec, appHostFile, directory, environmentVariables, null, phase, launcher, cancellationToken);
     }
 
     /// <summary>
@@ -198,7 +201,10 @@ internal sealed class GuestRuntime
             return preExecuteResult;
         }
 
-        return await ExecuteCommandAsync(commandSpec, appHostFile, directory, environmentVariables, publishArgs, launcher, cancellationToken);
+        var phase = _spec.PublishExecute is not null
+            ? ProfilingTelemetry.Values.GuestCommandPhasePublishExecute
+            : ProfilingTelemetry.Values.GuestCommandPhaseExecute;
+        return await ExecuteCommandAsync(commandSpec, appHostFile, directory, environmentVariables, publishArgs, phase, launcher, cancellationToken);
     }
 
     private async Task<(int ExitCode, OutputCollector? Output)> RunPreExecuteCommandsAsync(
@@ -222,7 +228,7 @@ internal sealed class GuestRuntime
             _logger.LogDebug("Launching pre-execution command: {Command} {Args}", commandSpec.Command, string.Join(" ", args));
             using var activity = _profilingTelemetry is null
                 ? default
-                : _profilingTelemetry.StartGuestExecuteCommand(_spec.Language, _spec.DisplayName, commandSpec.Command, args.Length, directory);
+                : _profilingTelemetry.StartGuestExecuteCommand(_spec.Language, _spec.DisplayName, commandSpec.Command, args, directory, ProfilingTelemetry.Values.GuestCommandPhasePreExecute);
             var (exitCode, output) = await preExecuteLauncher.LaunchAsync(commandSpec.Command, args, directory, mergedEnvironment, cancellationToken);
             activity.SetProcessExitCode(exitCode);
             if (exitCode != 0)
@@ -241,6 +247,7 @@ internal sealed class GuestRuntime
         DirectoryInfo directory,
         IDictionary<string, string> environmentVariables,
         string[]? additionalArgs,
+        string phase,
         IGuestProcessLauncher launcher,
         CancellationToken cancellationToken)
     {
@@ -251,7 +258,7 @@ internal sealed class GuestRuntime
         _logger.LogDebug("Launching: {Command} {Args}", commandSpec.Command, string.Join(" ", args));
         using var activity = _profilingTelemetry is null
             ? default
-            : _profilingTelemetry.StartGuestExecuteCommand(_spec.Language, _spec.DisplayName, commandSpec.Command, args.Length, directory);
+            : _profilingTelemetry.StartGuestExecuteCommand(_spec.Language, _spec.DisplayName, commandSpec.Command, args, directory, phase);
         var (exitCode, output) = await launcher.LaunchAsync(commandSpec.Command, args, directory, mergedEnvironment, cancellationToken);
         activity.SetProcessExitCode(exitCode);
         if (exitCode != 0)

--- a/src/Aspire.Cli/Projects/ProcessGuestLauncher.cs
+++ b/src/Aspire.Cli/Projects/ProcessGuestLauncher.cs
@@ -47,13 +47,14 @@ internal sealed class ProcessGuestLauncher : IGuestProcessLauncher
             return (-1, errorOutput);
         }
 
-        activity?.SetTag(TelemetryConstants.Tags.ProcessExecutablePath, resolvedCommand);
-        AddEvent(activity, ProfilingTelemetry.Events.GuestProcessResolved, TelemetryConstants.Tags.ProcessExecutablePath, resolvedCommand);
-        _logger.LogDebug("Executing: {Command} {Args}", resolvedCommand, string.Join(" ", args));
+        var resolvedCommandPath = resolvedCommand ?? throw new InvalidOperationException("Command resolution succeeded without a resolved command path.");
+        ProfilingTelemetry.SetProcessInvocation(activity, resolvedCommandPath, args);
+        AddEvent(activity, ProfilingTelemetry.Events.GuestProcessResolved, TelemetryConstants.Tags.ProcessExecutablePath, resolvedCommandPath);
+        _logger.LogDebug("Executing: {Command} {Args}", resolvedCommandPath, string.Join(" ", args));
 
         var startInfo = new ProcessStartInfo
         {
-            FileName = resolvedCommand,
+            FileName = resolvedCommandPath,
             WorkingDirectory = workingDirectory.FullName,
             RedirectStandardOutput = true,
             RedirectStandardError = true,

--- a/src/Aspire.Cli/Projects/ProcessGuestLauncher.cs
+++ b/src/Aspire.Cli/Projects/ProcessGuestLauncher.cs
@@ -3,6 +3,7 @@
 
 using System.Diagnostics;
 using Aspire.Cli.Diagnostics;
+using Aspire.Cli.Telemetry;
 using Aspire.Cli.Utils;
 using Microsoft.Extensions.Logging;
 
@@ -33,14 +34,21 @@ internal sealed class ProcessGuestLauncher : IGuestProcessLauncher
         IDictionary<string, string> environmentVariables,
         CancellationToken cancellationToken)
     {
+        var activity = GetCurrentProfilingActivity();
+        AddEvent(activity, ProfilingTelemetry.Events.GuestProcessResolveStart);
+
         if (!CommandPathResolver.TryResolveCommand(command, _commandResolver, out var resolvedCommand, out var errorMessage))
         {
+            AddEvent(activity, ProfilingTelemetry.Events.GuestProcessResolveFailed);
+            activity?.SetStatus(ActivityStatusCode.Error, errorMessage);
             _logger.LogError("Command '{Command}' not found in PATH", command);
             var errorOutput = new OutputCollector();
             errorOutput.AppendError(errorMessage!);
             return (-1, errorOutput);
         }
 
+        activity?.SetTag(TelemetryConstants.Tags.ProcessExecutablePath, resolvedCommand);
+        AddEvent(activity, ProfilingTelemetry.Events.GuestProcessResolved, TelemetryConstants.Tags.ProcessExecutablePath, resolvedCommand);
         _logger.LogDebug("Executing: {Command} {Args}", resolvedCommand, string.Join(" ", args));
 
         var startInfo = new ProcessStartInfo
@@ -68,6 +76,8 @@ internal sealed class ProcessGuestLauncher : IGuestProcessLauncher
         var outputCollector = new OutputCollector(_fileLoggerProvider, "AppHost");
         var stdoutCompleted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
         var stderrCompleted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var firstStdoutSeen = 0;
+        var firstStderrSeen = 0;
 
         process.OutputDataReceived += (sender, e) =>
         {
@@ -78,6 +88,11 @@ internal sealed class ProcessGuestLauncher : IGuestProcessLauncher
             }
             else
             {
+                if (Interlocked.Exchange(ref firstStdoutSeen, 1) == 0)
+                {
+                    AddEvent(activity, ProfilingTelemetry.Events.GuestFirstStdout, TelemetryConstants.Tags.ProcessPid, process.Id);
+                }
+
                 _logger.LogTrace("{Language}({ProcessId}) stdout: {Line}", _language, process.Id, e.Data);
                 outputCollector.AppendOutput(e.Data);
             }
@@ -92,24 +107,60 @@ internal sealed class ProcessGuestLauncher : IGuestProcessLauncher
             }
             else
             {
+                if (Interlocked.Exchange(ref firstStderrSeen, 1) == 0)
+                {
+                    AddEvent(activity, ProfilingTelemetry.Events.GuestFirstStderr, TelemetryConstants.Tags.ProcessPid, process.Id);
+                }
+
                 _logger.LogTrace("{Language}({ProcessId}) stderr: {Line}", _language, process.Id, e.Data);
                 outputCollector.AppendError(e.Data);
             }
         };
 
+        AddEvent(activity, ProfilingTelemetry.Events.GuestProcessStart);
         process.Start();
+        activity?.SetTag(TelemetryConstants.Tags.ProcessPid, process.Id);
+        AddEvent(activity, ProfilingTelemetry.Events.GuestProcessStarted, TelemetryConstants.Tags.ProcessPid, process.Id);
         process.BeginOutputReadLine();
         process.BeginErrorReadLine();
 
         await process.WaitForExitAsync(cancellationToken);
+        activity?.SetTag(TelemetryConstants.Tags.ProcessExitCode, process.ExitCode);
+        AddEvent(activity, ProfilingTelemetry.Events.GuestProcessExited, TelemetryConstants.Tags.ProcessExitCode, process.ExitCode);
 
         // Wait for the redirected streams to finish draining so no trailing lines are lost.
         if (!await WaitForDrainAsync(Task.WhenAll(stdoutCompleted.Task, stderrCompleted.Task), cancellationToken))
         {
+            AddEvent(activity, ProfilingTelemetry.Events.GuestOutputDrainTimeout, TelemetryConstants.Tags.ProcessPid, process.Id);
             _logger.LogWarning("{Language}({ProcessId}): Timed out waiting for output streams to drain after process exit", _language, process.Id);
         }
 
         return (process.ExitCode, outputCollector);
+    }
+
+    private static Activity? GetCurrentProfilingActivity()
+    {
+        var activity = Activity.Current;
+        return activity?.Source.Name == ProfilingTelemetry.ActivitySourceName ? activity : null;
+    }
+
+    private static void AddEvent(Activity? activity, string eventName, string? tagName = null, object? tagValue = null)
+    {
+        if (activity is null)
+        {
+            return;
+        }
+
+        if (tagName is null)
+        {
+            activity.AddEvent(new ActivityEvent(eventName));
+            return;
+        }
+
+        activity.AddEvent(new ActivityEvent(eventName, tags: new ActivityTagsCollection
+        {
+            [tagName] = tagValue
+        }));
     }
 
     private static async Task<bool> WaitForDrainAsync(Task drainTask, CancellationToken cancellationToken)

--- a/src/Aspire.Cli/Telemetry/ProfilingTelemetry.cs
+++ b/src/Aspire.Cli/Telemetry/ProfilingTelemetry.cs
@@ -45,6 +45,7 @@ internal sealed class ProfilingTelemetry(IConfiguration configuration) : IDispos
     /// </summary>
     internal static class Activities
     {
+        public const string Process = "aspire/cli/process";
         public const string RunCommand = "aspire/cli/run";
         public const string LsCommand = "aspire/cli/ls";
         public const string LsFindAppHosts = "aspire/cli/ls.find_apphosts";
@@ -58,7 +59,6 @@ internal sealed class ProfilingTelemetry(IConfiguration configuration) : IDispos
         public const string RunAppHostWaitForBackchannel = "aspire/cli/run_apphost.wait_for_backchannel";
         public const string RunAppHostGetDashboardUrls = "aspire/cli/run_apphost.get_dashboard_urls";
         public const string RunAppHostLifetime = "aspire/cli/run_apphost.lifetime";
-        public const string StartAppHostSpawnChild = "aspire/cli/start_apphost.spawn_child";
         public const string StartAppHostWaitForBackchannel = "aspire/cli/start_apphost.wait_for_backchannel";
         public const string StartAppHostGetDashboardUrls = "aspire/cli/start_apphost.get_dashboard_urls";
         public const string BackchannelConnect = "aspire/cli/backchannel.connect";
@@ -70,17 +70,8 @@ internal sealed class ProfilingTelemetry(IConfiguration configuration) : IDispos
         public const string AppHostBuild = "aspire/cli/apphost.build";
         public const string AppHostCheckCompatibility = "aspire/cli/apphost.check_compatibility";
         public const string AppHostRunDotnetLifetime = "aspire/cli/apphost.run_dotnet.lifetime";
-        public const string AppHostServerLifetime = "aspire/cli/apphost_server.lifetime";
-        public const string DotNetRunLifetime = "aspire/cli/dotnet.run.lifetime";
-        public const string GuestInitializeCommand = "aspire/cli/guest.initialize_command";
-        public const string GuestInstallDependencies = "aspire/cli/guest.install_dependencies";
-        public const string GuestExecuteCommand = "aspire/cli/guest.execute_command";
-        public const string GitCommand = "aspire/cli/git.command";
-        public const string NpmCommand = "aspire/cli/npm.command";
         public const string StopCommand = "aspire/cli/stop";
         public const string StopAppHost = "aspire/cli/stop_apphost";
-
-        public static string DotNetCommand(string command) => $"aspire/cli/dotnet.{command}";
     }
 
     /// <summary>
@@ -351,11 +342,10 @@ internal sealed class ProfilingTelemetry(IConfiguration configuration) : IDispos
         return StartActivity(Activities.StartAppHostGetDashboardUrls);
     }
 
-    internal ActivityScope StartDetachedSpawnChild(string executablePath, int argsCount, string childCommand)
+    internal ActivityScope StartDetachedSpawnChild(string executablePath, IReadOnlyList<string> args, string childCommand)
     {
-        var activity = StartActivity(Activities.StartAppHostSpawnChild);
-        activity.SetProcessExecutableName(Path.GetFileName(executablePath));
-        activity.SetProcessCommandArgsCount(argsCount);
+        var activity = StartActivity(Activities.Process, ActivityKind.Client);
+        activity.SetProcessInvocation(executablePath, args);
         activity.SetChildCommand(childCommand);
         return activity;
     }
@@ -371,50 +361,47 @@ internal sealed class ProfilingTelemetry(IConfiguration configuration) : IDispos
 
     internal ActivityScope StartDotNetProcess(string dotnetCommand, FileInfo? projectFile, DirectoryInfo workingDirectory, ProcessInvocationOptions options)
     {
-        var activityName = string.Equals(dotnetCommand, "run", StringComparison.Ordinal)
-            ? Activities.DotNetRunLifetime
-            : Activities.DotNetCommand(dotnetCommand);
-        var activity = StartActivity(activityName, ActivityKind.Client);
+        var activity = StartActivity(Activities.Process, ActivityKind.Client);
         activity.SetDotNetInvocation(dotnetCommand, projectFile, workingDirectory, options);
         return activity;
     }
 
     internal ActivityScope StartAppHostServerLifetime(string implementationName)
     {
-        var activity = StartActivity(Activities.AppHostServerLifetime, ActivityKind.Client);
+        var activity = StartActivity(Activities.Process, ActivityKind.Client);
         activity.SetAppHostServerImplementation(implementationName);
         return activity;
     }
 
     internal ActivityScope StartGuestInitializeCommand(string languageId, string displayName, string command, string[] args, DirectoryInfo workingDirectory)
     {
-        var activity = StartGuestProcessActivity(Activities.GuestInitializeCommand, languageId, displayName, command, args, workingDirectory, Values.GuestCommandPhaseInitialize);
+        var activity = StartGuestProcessActivity(languageId, displayName, command, args, workingDirectory, Values.GuestCommandPhaseInitialize);
         return activity;
     }
 
     internal ActivityScope StartGuestInstallDependencies(string languageId, string displayName, string command, string[] args, DirectoryInfo workingDirectory)
     {
-        var activity = StartGuestProcessActivity(Activities.GuestInstallDependencies, languageId, displayName, command, args, workingDirectory, Values.GuestCommandPhaseInstallDependencies);
+        var activity = StartGuestProcessActivity(languageId, displayName, command, args, workingDirectory, Values.GuestCommandPhaseInstallDependencies);
         return activity;
     }
 
     internal ActivityScope StartGuestExecuteCommand(string languageId, string displayName, string command, string[] args, DirectoryInfo workingDirectory, string phase)
     {
-        var activity = StartGuestProcessActivity(Activities.GuestExecuteCommand, languageId, displayName, command, args, workingDirectory, phase);
+        var activity = StartGuestProcessActivity(languageId, displayName, command, args, workingDirectory, phase);
         return activity;
     }
 
-    internal ActivityScope StartNpmCommand(string command, int argsCount, string workingDirectory)
+    internal ActivityScope StartNpmCommand(string command, IReadOnlyList<string> args, string workingDirectory)
     {
-        var activity = StartActivity(Activities.NpmCommand, ActivityKind.Client);
-        activity.SetNpmInvocation(command, argsCount, workingDirectory);
+        var activity = StartActivity(Activities.Process, ActivityKind.Client);
+        activity.SetNpmInvocation(command, args, workingDirectory);
         return activity;
     }
 
-    internal ActivityScope StartGitCommand(string command, int argsCount, DirectoryInfo workingDirectory)
+    internal ActivityScope StartGitCommand(string command, string executablePath, IReadOnlyList<string> args, DirectoryInfo workingDirectory)
     {
-        var activity = StartActivity(Activities.GitCommand, ActivityKind.Client);
-        activity.SetGitInvocation(command, argsCount, workingDirectory);
+        var activity = StartActivity(Activities.Process, ActivityKind.Client);
+        activity.SetGitInvocation(command, executablePath, args, workingDirectory);
         return activity;
     }
 
@@ -633,9 +620,29 @@ internal sealed class ProfilingTelemetry(IConfiguration configuration) : IDispos
         return string.Equals(value, "true", StringComparison.OrdinalIgnoreCase) || value == "1";
     }
 
-    private ActivityScope StartGuestProcessActivity(string activityName, string languageId, string displayName, string command, string[] args, DirectoryInfo workingDirectory, string phase)
+    internal static void SetProcessInvocation(Activity? activity, string executablePath, IReadOnlyList<string> args)
     {
-        var activity = StartActivity(activityName, ActivityKind.Client);
+        if (activity is null)
+        {
+            return;
+        }
+
+        var executableName = Path.GetFileName(executablePath);
+        if (string.IsNullOrEmpty(executableName))
+        {
+            executableName = executablePath;
+        }
+
+        activity.DisplayName = $"process {executableName}";
+        activity.SetTag(TelemetryConstants.Tags.ProcessExecutableName, executableName);
+        activity.SetTag(TelemetryConstants.Tags.ProcessExecutablePath, executablePath);
+        activity.SetTag(Tags.ProcessCommandArgs, args.ToArray());
+        activity.SetTag(Tags.ProcessCommandArgsCount, args.Count);
+    }
+
+    private ActivityScope StartGuestProcessActivity(string languageId, string displayName, string command, string[] args, DirectoryInfo workingDirectory, string phase)
+    {
+        var activity = StartActivity(Activities.Process, ActivityKind.Client);
         activity.SetGuestInvocation(languageId, displayName, command, args, workingDirectory, phase);
         return activity;
     }
@@ -855,17 +862,14 @@ internal sealed class ProfilingTelemetry(IConfiguration configuration) : IDispos
             SetTag(Tags.GuestCommand, command);
             SetTag(Tags.GuestCommandPhase, phase);
             SetTag(Tags.GuestWorkingDirectory, workingDirectory.FullName);
-            SetProcessExecutableName(Path.GetFileName(command));
-            SetProcessCommandArgs(args);
-            SetProcessCommandArgsCount(args.Length);
+            SetProcessInvocation(command, args);
         }
 
-        public void SetGitInvocation(string command, int argsCount, DirectoryInfo workingDirectory)
+        public void SetGitInvocation(string command, string executablePath, IReadOnlyList<string> args, DirectoryInfo workingDirectory)
         {
             SetTag(Tags.GitCommand, command);
             SetTag(Tags.GitWorkingDirectory, workingDirectory.FullName);
-            SetProcessExecutableName("git");
-            SetProcessCommandArgsCount(argsCount);
+            SetProcessInvocation(executablePath, args);
         }
 
         public void SetGitOutputLengths(int stdoutLength, int stderrLength)
@@ -905,12 +909,11 @@ internal sealed class ProfilingTelemetry(IConfiguration configuration) : IDispos
             };
         }
 
-        public void SetNpmInvocation(string command, int argsCount, string workingDirectory)
+        public void SetNpmInvocation(string command, IReadOnlyList<string> args, string workingDirectory)
         {
             SetTag(Tags.NpmCommand, command);
             SetTag(Tags.NpmWorkingDirectory, workingDirectory);
-            SetProcessExecutableName(Path.GetFileName(command));
-            SetProcessCommandArgsCount(argsCount);
+            SetProcessInvocation(command, args);
         }
 
         public void SetLsInvocation(string outputFormat, bool includeAll)
@@ -921,9 +924,9 @@ internal sealed class ProfilingTelemetry(IConfiguration configuration) : IDispos
 
         public void SetDotNetMsBuildServer(string? msBuildServer) => SetTag(Tags.DotNetMsBuildServer, msBuildServer);
 
-        public void SetDotNetResolvedExecutable(string dotnetPath, string? msBuildServer)
+        public void SetDotNetResolvedExecutable(string dotnetPath, IReadOnlyList<string> args, string? msBuildServer)
         {
-            SetProcessExecutableName(Path.GetFileName(dotnetPath));
+            SetProcessInvocation(dotnetPath, args);
             SetDotNetMsBuildServer(msBuildServer);
         }
 
@@ -944,9 +947,14 @@ internal sealed class ProfilingTelemetry(IConfiguration configuration) : IDispos
 
         public void SetError(Exception exception) => activity?.SetStatus(ActivityStatusCode.Error, exception.Message);
 
+        public void SetProcessInvocation(string executablePath, IReadOnlyList<string> args)
+        {
+            ProfilingTelemetry.SetProcessInvocation(activity, executablePath, args);
+        }
+
         public void SetProcessCommandArgsCount(int argsCount) => SetTag(Tags.ProcessCommandArgsCount, argsCount);
 
-        public void SetProcessCommandArgs(string[] args) => SetTag(Tags.ProcessCommandArgs, args);
+        public void SetProcessCommandArgs(IReadOnlyList<string> args) => SetTag(Tags.ProcessCommandArgs, args.ToArray());
 
         public void SetProcessExecutableName(string? executableName) => SetTag(TelemetryConstants.Tags.ProcessExecutableName, executableName);
 

--- a/src/Aspire.Cli/Telemetry/ProfilingTelemetry.cs
+++ b/src/Aspire.Cli/Telemetry/ProfilingTelemetry.cs
@@ -242,15 +242,16 @@ internal sealed class ProfilingTelemetry(IConfiguration configuration) : IDispos
             return;
         }
 
+        var sessionId = GetProfilingSessionId(activity);
+        if (string.IsNullOrWhiteSpace(sessionId))
+        {
+            return;
+        }
+
         environment[EnvironmentVariables.Enabled] = "true";
         environment[KnownConfigNames.Legacy.StartupProfilingEnabled] = "true";
-
-        var sessionId = GetProfilingSessionId(activity);
-        if (!string.IsNullOrWhiteSpace(sessionId))
-        {
-            environment[EnvironmentVariables.SessionId] = sessionId;
-            environment[KnownConfigNames.Legacy.StartupOperationId] = sessionId;
-        }
+        environment[EnvironmentVariables.SessionId] = sessionId;
+        environment[KnownConfigNames.Legacy.StartupOperationId] = sessionId;
 
         if (!string.IsNullOrWhiteSpace(activity.Id))
         {

--- a/src/Aspire.Cli/Telemetry/ProfilingTelemetry.cs
+++ b/src/Aspire.Cli/Telemetry/ProfilingTelemetry.cs
@@ -154,6 +154,7 @@ internal sealed class ProfilingTelemetry(IConfiguration configuration) : IDispos
         public const string GuestRuntimeLanguage = "aspire.cli.guest.language";
         public const string GuestRuntimeDisplayName = "aspire.cli.guest.display_name";
         public const string GuestCommand = "aspire.cli.guest.command";
+        public const string GuestCommandPhase = "aspire.cli.guest.command.phase";
         public const string GuestWorkingDirectory = "aspire.cli.guest.working_directory";
         public const string GitCommand = "aspire.cli.git.command";
         public const string GitWorkingDirectory = "aspire.cli.git.working_directory";
@@ -163,6 +164,7 @@ internal sealed class ProfilingTelemetry(IConfiguration configuration) : IDispos
         public const string NpmWorkingDirectory = "aspire.cli.npm.working_directory";
         public const string LsIncludeAll = "aspire.cli.ls.include_all";
         public const string LsOutputFormat = "aspire.cli.ls.output_format";
+        public const string ProcessCommandArgs = "process.command_args";
         public const string ProcessCommandArgsCount = "process.command_args.count";
     }
 
@@ -197,6 +199,15 @@ internal sealed class ProfilingTelemetry(IConfiguration configuration) : IDispos
         public const string JsonRpcResponseReceived = "aspire/cli/jsonrpc.response_received";
         public const string JsonRpcStreamFirstItem = "aspire/cli/jsonrpc.stream.first_item";
         public const string JsonRpcStreamCompleted = "aspire/cli/jsonrpc.stream.completed";
+        public const string GuestProcessResolveStart = "aspire/cli/guest.process_resolve_start";
+        public const string GuestProcessResolved = "aspire/cli/guest.process_resolved";
+        public const string GuestProcessResolveFailed = "aspire/cli/guest.process_resolve_failed";
+        public const string GuestProcessStart = "aspire/cli/guest.process_start";
+        public const string GuestProcessStarted = "aspire/cli/guest.process_started";
+        public const string GuestProcessExited = "aspire/cli/guest.process_exited";
+        public const string GuestFirstStdout = "aspire/cli/guest.first_stdout";
+        public const string GuestFirstStderr = "aspire/cli/guest.first_stderr";
+        public const string GuestOutputDrainTimeout = "aspire/cli/guest.output_drain_timeout";
     }
 
     /// <summary>
@@ -210,6 +221,12 @@ internal sealed class ProfilingTelemetry(IConfiguration configuration) : IDispos
         public const string AppHostDiscoverySourceNone = "none";
         public const string AppHostDiscoverySourceGit = "git";
         public const string AppHostDiscoverySourceFilesystem = "filesystem";
+        public const string GuestCommandPhaseInitialize = "initialize";
+        public const string GuestCommandPhaseInstallDependencies = "install_dependencies";
+        public const string GuestCommandPhasePreExecute = "pre_execute";
+        public const string GuestCommandPhaseExecute = "execute";
+        public const string GuestCommandPhaseWatchExecute = "watch_execute";
+        public const string GuestCommandPhasePublishExecute = "publish_execute";
     }
 
     public bool IsEnabled => IsProfilingEnabled(configuration);
@@ -369,21 +386,21 @@ internal sealed class ProfilingTelemetry(IConfiguration configuration) : IDispos
         return activity;
     }
 
-    internal ActivityScope StartGuestInitializeCommand(string languageId, string displayName, string command, int argsCount, DirectoryInfo workingDirectory)
+    internal ActivityScope StartGuestInitializeCommand(string languageId, string displayName, string command, string[] args, DirectoryInfo workingDirectory)
     {
-        var activity = StartGuestProcessActivity(Activities.GuestInitializeCommand, languageId, displayName, command, argsCount, workingDirectory);
+        var activity = StartGuestProcessActivity(Activities.GuestInitializeCommand, languageId, displayName, command, args, workingDirectory, Values.GuestCommandPhaseInitialize);
         return activity;
     }
 
-    internal ActivityScope StartGuestInstallDependencies(string languageId, string displayName, string command, int argsCount, DirectoryInfo workingDirectory)
+    internal ActivityScope StartGuestInstallDependencies(string languageId, string displayName, string command, string[] args, DirectoryInfo workingDirectory)
     {
-        var activity = StartGuestProcessActivity(Activities.GuestInstallDependencies, languageId, displayName, command, argsCount, workingDirectory);
+        var activity = StartGuestProcessActivity(Activities.GuestInstallDependencies, languageId, displayName, command, args, workingDirectory, Values.GuestCommandPhaseInstallDependencies);
         return activity;
     }
 
-    internal ActivityScope StartGuestExecuteCommand(string languageId, string displayName, string command, int argsCount, DirectoryInfo workingDirectory)
+    internal ActivityScope StartGuestExecuteCommand(string languageId, string displayName, string command, string[] args, DirectoryInfo workingDirectory, string phase)
     {
-        var activity = StartGuestProcessActivity(Activities.GuestExecuteCommand, languageId, displayName, command, argsCount, workingDirectory);
+        var activity = StartGuestProcessActivity(Activities.GuestExecuteCommand, languageId, displayName, command, args, workingDirectory, phase);
         return activity;
     }
 
@@ -616,10 +633,10 @@ internal sealed class ProfilingTelemetry(IConfiguration configuration) : IDispos
         return string.Equals(value, "true", StringComparison.OrdinalIgnoreCase) || value == "1";
     }
 
-    private ActivityScope StartGuestProcessActivity(string activityName, string languageId, string displayName, string command, int argsCount, DirectoryInfo workingDirectory)
+    private ActivityScope StartGuestProcessActivity(string activityName, string languageId, string displayName, string command, string[] args, DirectoryInfo workingDirectory, string phase)
     {
         var activity = StartActivity(activityName, ActivityKind.Client);
-        activity.SetGuestInvocation(languageId, displayName, command, argsCount, workingDirectory);
+        activity.SetGuestInvocation(languageId, displayName, command, args, workingDirectory, phase);
         return activity;
     }
 
@@ -831,14 +848,16 @@ internal sealed class ProfilingTelemetry(IConfiguration configuration) : IDispos
             SetTag(Tags.DotNetDebug, options.Debug);
         }
 
-        public void SetGuestInvocation(string languageId, string displayName, string command, int argsCount, DirectoryInfo workingDirectory)
+        public void SetGuestInvocation(string languageId, string displayName, string command, string[] args, DirectoryInfo workingDirectory, string phase)
         {
             SetTag(Tags.GuestRuntimeLanguage, languageId);
             SetTag(Tags.GuestRuntimeDisplayName, displayName);
             SetTag(Tags.GuestCommand, command);
+            SetTag(Tags.GuestCommandPhase, phase);
             SetTag(Tags.GuestWorkingDirectory, workingDirectory.FullName);
             SetProcessExecutableName(Path.GetFileName(command));
-            SetProcessCommandArgsCount(argsCount);
+            SetProcessCommandArgs(args);
+            SetProcessCommandArgsCount(args.Length);
         }
 
         public void SetGitInvocation(string command, int argsCount, DirectoryInfo workingDirectory)
@@ -927,7 +946,11 @@ internal sealed class ProfilingTelemetry(IConfiguration configuration) : IDispos
 
         public void SetProcessCommandArgsCount(int argsCount) => SetTag(Tags.ProcessCommandArgsCount, argsCount);
 
+        public void SetProcessCommandArgs(string[] args) => SetTag(Tags.ProcessCommandArgs, args);
+
         public void SetProcessExecutableName(string? executableName) => SetTag(TelemetryConstants.Tags.ProcessExecutableName, executableName);
+
+        public void SetProcessExecutablePath(string? executablePath) => SetTag(TelemetryConstants.Tags.ProcessExecutablePath, executablePath);
 
         public void SetProcessExitCode(int exitCode) => SetTag(TelemetryConstants.Tags.ProcessExitCode, exitCode);
 

--- a/src/Aspire.Cli/Telemetry/TelemetryConstants.cs
+++ b/src/Aspire.Cli/Telemetry/TelemetryConstants.cs
@@ -49,6 +49,11 @@ internal static class TelemetryConstants
         public const string ProcessExecutableName = "process.executable.name";
 
         /// <summary>
+        /// Tag for the resolved process executable path.
+        /// </summary>
+        public const string ProcessExecutablePath = "process.executable.path";
+
+        /// <summary>
         /// Tag for the process exit code.
         /// </summary>
         public const string ProcessExitCode = "process.exit.code";

--- a/src/Aspire.Cli/Telemetry/TelemetryManager.cs
+++ b/src/Aspire.Cli/Telemetry/TelemetryManager.cs
@@ -10,9 +10,26 @@ using OpenTelemetry.Trace;
 
 namespace Aspire.Cli.Telemetry;
 
+// This file is the CLI's OpenTelemetry wiring point. It decides which ActivitySources
+// are listened to and where they are exported; the activity creation APIs live in
+// AspireCliTelemetry and ProfilingTelemetry.
+//
+// Keep reported telemetry, profiling telemetry, and debug diagnostics on separate providers.
+// Reported telemetry is allowed to leave the machine through Azure Monitor, while
+// profiling and diagnostic telemetry are intentionally local and opt-in because they can
+// include high-cardinality process, path, and startup timing details.
+//
+// Enablement is intentionally separate:
+// - Reported telemetry is on by default and is disabled with ASPIRE_CLI_TELEMETRY_OPTOUT=true.
+// - Profiling telemetry requires ASPIRE_PROFILING_ENABLED=true plus OTEL_EXPORTER_OTLP_ENDPOINT
+//   (and typically OTEL_EXPORTER_OTLP_PROTOCOL=grpc). ASPIRE_STARTUP_PROFILING_ENABLED is the
+//   legacy alias that remains supported for existing scripts.
+// - DEBUG-only diagnostics use ASPIRE_CLI_CONSOLE_EXPORTER_LEVEL=Diagnostic, or OTLP export when
+//   OTEL_EXPORTER_OTLP_ENDPOINT is set without profiling enabled.
+
 /// <summary>
 /// Manages OpenTelemetry TracerProvider instances for the CLI.
-/// Maintains separate providers for Azure Monitor (production telemetry) and debug exporters (OTLP/console).
+/// Maintains separate providers for reported telemetry, profiling telemetry, and debug diagnostics.
 /// </summary>
 internal sealed class TelemetryManager : IDisposable
 {
@@ -28,9 +45,8 @@ internal sealed class TelemetryManager : IDisposable
 #endif
 
     private readonly TracerProvider? _azureMonitorProvider;
-#if DEBUG
-    private readonly TracerProvider? _diagnosticProvider;
-#endif
+    private readonly TracerProvider? _profilingProvider;
+    private readonly TracerProvider? _debugDiagnosticProvider;
 
     private bool _shuttingDown;
 
@@ -45,19 +61,26 @@ internal sealed class TelemetryManager : IDisposable
         var hasOptOutArg = args?.Any(a => CommonOptionNames.InformationalOptionNames.Contains(a)) ?? false;
         var telemetryOptOut = hasOptOutArg || configuration.GetBool(AspireCliTelemetry.TelemetryOptOutConfigKey, defaultValue: false);
 
-#if DEBUG
-        var useOtlpExporter = !string.IsNullOrEmpty(configuration[AspireCliTelemetry.OtlpExporterEndpointConfigKey]);
-        var consoleExporterLevel = configuration.GetEnum<ConsoleExporterLevel>(AspireCliTelemetry.ConsoleExporterLevelConfigKey, defaultValue: null);
         var profilingEnabled =
             configuration.GetBool(Aspire.Hosting.KnownConfigNames.ProfilingEnabled) ??
             configuration.GetBool(Aspire.Hosting.KnownConfigNames.Legacy.StartupProfilingEnabled, defaultValue: false);
+        var requestedOtlpExporter = !string.IsNullOrEmpty(configuration[AspireCliTelemetry.OtlpExporterEndpointConfigKey]);
+        var useProfilingProvider = profilingEnabled && requestedOtlpExporter;
+
+#if DEBUG
+        var consoleExporterLevel = configuration.GetEnum<ConsoleExporterLevel>(AspireCliTelemetry.ConsoleExporterLevelConfigKey, defaultValue: null);
+        // Preserve the DEBUG-only diagnostic OTLP path for non-profiling diagnostics. When
+        // profiling is enabled, the same OTLP endpoint is reserved for the profiling provider
+        // so reported/diagnostic sources do not get mixed into startup profiling exports.
+        var useDebugDiagnosticOtlpExporter = requestedOtlpExporter && !profilingEnabled;
 #else
-        var useOtlpExporter = false;
         ConsoleExporterLevel? consoleExporterLevel = null;
+        var useDebugDiagnosticOtlpExporter = false;
 #endif
+        var useDebugDiagnosticProvider = useDebugDiagnosticOtlpExporter || consoleExporterLevel == ConsoleExporterLevel.Diagnostic;
 
         // Don't create any providers if nothing is enabled
-        if (telemetryOptOut && !useOtlpExporter && consoleExporterLevel is null)
+        if (telemetryOptOut && !useProfilingProvider && !useDebugDiagnosticProvider)
         {
             return;
         }
@@ -90,34 +113,33 @@ internal sealed class TelemetryManager : IDisposable
             _azureMonitorProvider = azureMonitorBuilder.Build();
         }
 
-#if DEBUG
-        // Create diagnostic provider if any diagnostic exporter is enabled.
-        // The diagnostic provider exports diagnostic telemetry.
-        if (useOtlpExporter || consoleExporterLevel == ConsoleExporterLevel.Diagnostic)
+        if (useProfilingProvider)
+        {
+            _profilingProvider = Sdk.CreateTracerProviderBuilder()
+                .AddSource(ProfilingTelemetry.ActivitySourceName)
+                .SetResourceBuilder(resource)
+                .AddOtlpExporter()
+                .Build();
+        }
+
+        if (useDebugDiagnosticProvider)
         {
             var diagnosticBuilder = Sdk.CreateTracerProviderBuilder()
                 .AddSource(AspireCliTelemetry.DiagnosticsActivitySourceName)
-                .AddSource(AspireCliTelemetry.ReportedActivitySourceName)
                 .SetResourceBuilder(resource);
-
-            if (profilingEnabled)
-            {
-                diagnosticBuilder.AddSource(ProfilingTelemetry.ActivitySourceName);
-            }
 
             if (consoleExporterLevel == ConsoleExporterLevel.Diagnostic)
             {
                 diagnosticBuilder.AddConsoleExporter();
             }
 
-            if (useOtlpExporter)
+            if (useDebugDiagnosticOtlpExporter)
             {
                 diagnosticBuilder.AddOtlpExporter();
             }
 
-            _diagnosticProvider = diagnosticBuilder.Build();
+            _debugDiagnosticProvider = diagnosticBuilder.Build();
         }
-#endif
     }
 
     /// <summary>
@@ -125,12 +147,15 @@ internal sealed class TelemetryManager : IDisposable
     /// </summary>
     public bool HasAzureMonitor => _azureMonitorProvider is not null;
 
-#if DEBUG
     /// <summary>
-    /// Gets whether any diagnostic exporter is enabled.
+    /// Gets whether profiling telemetry export is enabled.
     /// </summary>
-    public bool HasDiagnosticProvider => _diagnosticProvider is not null;
-#endif
+    public bool HasProfilingProvider => _profilingProvider is not null;
+
+    /// <summary>
+    /// Gets whether DEBUG-only diagnostic telemetry export is enabled.
+    /// </summary>
+    public bool HasDiagnosticProvider => _debugDiagnosticProvider is not null;
 
     /// <summary>
     /// Shuts down the telemetry providers, flushing any pending telemetry.
@@ -142,9 +167,8 @@ internal sealed class TelemetryManager : IDisposable
         return Task.Run(() =>
         {
             _azureMonitorProvider?.Shutdown(ShutDownTimeoutMilliseconds);
-#if DEBUG
-            _diagnosticProvider?.Shutdown(ShutDownTimeoutMilliseconds);
-#endif
+            _profilingProvider?.Shutdown(ShutDownTimeoutMilliseconds);
+            _debugDiagnosticProvider?.Shutdown(ShutDownTimeoutMilliseconds);
         });
     }
 
@@ -162,9 +186,8 @@ internal sealed class TelemetryManager : IDisposable
             // The shutdown timeout is zero so not to wait for telemetry to be flushed. Don't want to delay tests.
             // Dispose isn't used here because it always flushes telemetry and waits for completion.
             _azureMonitorProvider?.Shutdown(0);
-#if DEBUG
-            _diagnosticProvider?.Shutdown(0);
-#endif
+            _profilingProvider?.Shutdown(0);
+            _debugDiagnosticProvider?.Shutdown(0);
         }
     }
 }

--- a/tests/Aspire.Cli.Tests/Commands/RunCommandTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/RunCommandTests.cs
@@ -1944,6 +1944,23 @@ public class RunCommandTests(ITestOutputHelper outputHelper)
     }
 
     [Fact]
+    public void DetachedChildEnvironment_DoesNotEnableProfilingForNonProfilingActivity()
+    {
+        using var listener = CreateActivityListener("test-detached-child-environment");
+        using var source = new ActivitySource("test-detached-child-environment");
+        using var activity = source.StartActivity("parent");
+        Assert.NotNull(activity);
+
+        var environment = AppHostLauncher.CreateDetachedChildEnvironment(activity);
+
+        Assert.Equal("true", environment[KnownConfigNames.CliRunDetached]);
+        Assert.False(environment.ContainsKey(ProfilingTelemetry.EnvironmentVariables.Enabled));
+        Assert.False(environment.ContainsKey(ProfilingTelemetry.EnvironmentVariables.SessionId));
+        Assert.False(environment.ContainsKey(ProfilingTelemetry.EnvironmentVariables.TraceParent));
+        Assert.False(environment.ContainsKey(ProfilingTelemetry.EnvironmentVariables.TraceState));
+    }
+
+    [Fact]
     public void DetachedChildEnvironment_AllowsMissingProfilingTelemetryContext()
     {
         var environment = AppHostLauncher.CreateDetachedChildEnvironment(null);

--- a/tests/Aspire.Cli.Tests/Commands/RunCommandTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/RunCommandTests.cs
@@ -1944,6 +1944,26 @@ public class RunCommandTests(ITestOutputHelper outputHelper)
     }
 
     [Fact]
+    public void DetachedChildEnvironment_IncludesProfilingTelemetryContextFromActiveProfilingSpan()
+    {
+        using var listener = CreateActivityListener(ProfilingTelemetry.ActivitySourceName);
+        using var profilingTelemetry = new ProfilingTelemetry(CreateConfiguration(
+            (ProfilingTelemetry.EnvironmentVariables.Enabled, "true")));
+
+        using var activity = profilingTelemetry.StartDetachedSpawnChild("aspire", ["run"], childCommand: "run");
+        Assert.True(activity.IsRunning);
+
+        var environment = AppHostLauncher.CreateDetachedChildEnvironment(Activity.Current);
+
+        Assert.Equal("true", environment[KnownConfigNames.CliRunDetached]);
+        Assert.Equal("true", environment[ProfilingTelemetry.EnvironmentVariables.Enabled]);
+        var sessionId = environment[ProfilingTelemetry.EnvironmentVariables.SessionId];
+        Assert.False(string.IsNullOrWhiteSpace(sessionId));
+        Assert.Equal(sessionId, environment[KnownConfigNames.Legacy.StartupOperationId]);
+        Assert.Equal(Activity.Current?.Id, environment[ProfilingTelemetry.EnvironmentVariables.TraceParent]);
+    }
+
+    [Fact]
     public void DetachedChildEnvironment_DoesNotEnableProfilingForNonProfilingActivity()
     {
         using var listener = CreateActivityListener("test-detached-child-environment");
@@ -2033,5 +2053,12 @@ public class RunCommandTests(ITestOutputHelper outputHelper)
         };
         ActivitySource.AddActivityListener(listener);
         return listener;
+    }
+
+    private static IConfiguration CreateConfiguration(params (string Key, string? Value)[] values)
+    {
+        return new ConfigurationBuilder()
+            .AddInMemoryCollection(values.Select(value => new KeyValuePair<string, string?>(value.Key, value.Value)))
+            .Build();
     }
 }

--- a/tests/Aspire.Cli.Tests/Git/GitRepositoryTests.cs
+++ b/tests/Aspire.Cli.Tests/Git/GitRepositoryTests.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Collections.Concurrent;
 using System.Diagnostics;
 using Aspire.Cli.Git;
 using Aspire.Cli.Telemetry;
@@ -119,8 +120,8 @@ public class GitRepositoryTests(ITestOutputHelper outputHelper)
         await GitTestHelper.RunGitAsync(workspace.WorkspaceRoot.FullName, "add", "AppHost.csproj");
         await GitTestHelper.RunGitAsync(workspace.WorkspaceRoot.FullName, "commit", "-m", "init");
 
-        Activity? startedActivity = null;
-        using var listener = CreateProfilingActivityListener(activity => startedActivity = activity);
+        var startedActivities = new ConcurrentBag<Activity>();
+        using var listener = CreateProfilingActivityListener(startedActivities.Add);
         using var profilingTelemetry = CreateProfilingTelemetry(
             (ProfilingTelemetry.EnvironmentVariables.Enabled, "true"),
             (ProfilingTelemetry.EnvironmentVariables.SessionId, "session-1"));
@@ -130,11 +131,16 @@ public class GitRepositoryTests(ITestOutputHelper outputHelper)
         var result = await repo.GetIncludedFilesAsync(workspace.WorkspaceRoot, CancellationToken.None).DefaultTimeout();
 
         Assert.NotNull(result);
-        Assert.NotNull(startedActivity);
-        Assert.Equal(ProfilingTelemetry.Activities.GitCommand, startedActivity.OperationName);
+        var startedActivity = Assert.Single(startedActivities, activity =>
+            activity.GetTagItem(ProfilingTelemetry.Tags.ProfilingSessionId) as string == "session-1" &&
+            activity.GetTagItem(ProfilingTelemetry.Tags.GitCommand) as string == "ls-files");
+        Assert.Equal(ProfilingTelemetry.Activities.Process, startedActivity.OperationName);
+        Assert.Equal("process git", startedActivity.DisplayName);
         Assert.Equal("ls-files", startedActivity.GetTagItem(ProfilingTelemetry.Tags.GitCommand));
         Assert.Equal(workspace.WorkspaceRoot.FullName, startedActivity.GetTagItem(ProfilingTelemetry.Tags.GitWorkingDirectory));
         Assert.Equal("git", startedActivity.GetTagItem(TelemetryConstants.Tags.ProcessExecutableName));
+        Assert.Equal("git", startedActivity.GetTagItem(TelemetryConstants.Tags.ProcessExecutablePath));
+        Assert.Equal(new[] { "ls-files", "--cached", "--others", "--exclude-standard", "-z" }, Assert.IsType<string[]>(startedActivity.GetTagItem(ProfilingTelemetry.Tags.ProcessCommandArgs)));
         Assert.Equal(5, startedActivity.GetTagItem(ProfilingTelemetry.Tags.ProcessCommandArgsCount));
         Assert.Equal(0, startedActivity.GetTagItem(TelemetryConstants.Tags.ProcessExitCode));
         Assert.True((int)startedActivity.GetTagItem(TelemetryConstants.Tags.ProcessPid)! > 0);

--- a/tests/Aspire.Cli.Tests/Projects/GuestRuntimeTests.cs
+++ b/tests/Aspire.Cli.Tests/Projects/GuestRuntimeTests.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Collections.Concurrent;
 using System.Diagnostics;
 using Aspire.Cli.Diagnostics;
 using Aspire.Cli.Projects;
@@ -165,7 +166,7 @@ public class GuestRuntimeTests(ITestOutputHelper outputHelper)
     [Fact]
     public async Task RunAsync_ProfilingTelemetryRecordsGuestCommandPhasesAndArgs()
     {
-        var stoppedActivities = new List<Activity>();
+        var stoppedActivities = new ConcurrentBag<Activity>();
         using var listener = CreateProfilingActivityListener(stoppedActivities.Add);
         using var profilingTelemetry = CreateProfilingTelemetry(
             (ProfilingTelemetry.EnvironmentVariables.Enabled, "true"),
@@ -194,7 +195,9 @@ public class GuestRuntimeTests(ITestOutputHelper outputHelper)
         await runtime.RunAsync(appHostFile, directory, new Dictionary<string, string>(), watchMode: false, launcher, CancellationToken.None);
 
         var guestActivities = stoppedActivities
-            .Where(activity => activity.OperationName == ProfilingTelemetry.Activities.GuestExecuteCommand)
+            .Where(activity => activity.OperationName == ProfilingTelemetry.Activities.Process &&
+                activity.GetTagItem(ProfilingTelemetry.Tags.ProfilingSessionId) as string == "session-1" &&
+                activity.GetTagItem(ProfilingTelemetry.Tags.GuestCommandPhase) is not null)
             .OrderBy(activity => activity.StartTimeUtc)
             .ToArray();
 
@@ -203,6 +206,7 @@ public class GuestRuntimeTests(ITestOutputHelper outputHelper)
             preExecuteActivity =>
             {
                 Assert.Equal(ProfilingTelemetry.Values.GuestCommandPhasePreExecute, preExecuteActivity.GetTagItem(ProfilingTelemetry.Tags.GuestCommandPhase));
+                Assert.Equal("process npx", preExecuteActivity.DisplayName);
                 Assert.Equal("npx", preExecuteActivity.GetTagItem(ProfilingTelemetry.Tags.GuestCommand));
                 Assert.Equal(new[] { "tsc", "--noEmit", "-p", "tsconfig.apphost.json" }, Assert.IsType<string[]>(preExecuteActivity.GetTagItem(ProfilingTelemetry.Tags.ProcessCommandArgs)));
                 Assert.Equal(4, preExecuteActivity.GetTagItem(ProfilingTelemetry.Tags.ProcessCommandArgsCount));
@@ -211,6 +215,7 @@ public class GuestRuntimeTests(ITestOutputHelper outputHelper)
             executeActivity =>
             {
                 Assert.Equal(ProfilingTelemetry.Values.GuestCommandPhaseExecute, executeActivity.GetTagItem(ProfilingTelemetry.Tags.GuestCommandPhase));
+                Assert.Equal("process npx", executeActivity.DisplayName);
                 Assert.Equal("npx", executeActivity.GetTagItem(ProfilingTelemetry.Tags.GuestCommand));
                 Assert.Equal(new[] { "tsx", "--tsconfig", "tsconfig.apphost.json", appHostFile.FullName }, Assert.IsType<string[]>(executeActivity.GetTagItem(ProfilingTelemetry.Tags.ProcessCommandArgs)));
                 Assert.Equal(4, executeActivity.GetTagItem(ProfilingTelemetry.Tags.ProcessCommandArgsCount));
@@ -575,7 +580,7 @@ public class GuestRuntimeTests(ITestOutputHelper outputHelper)
     [Fact]
     public async Task ProcessGuestLauncher_AnnotatesAmbientGuestProfilingActivity()
     {
-        var stoppedActivities = new List<Activity>();
+        var stoppedActivities = new ConcurrentBag<Activity>();
         using var listener = CreateProfilingActivityListener(stoppedActivities.Add);
         using var profilingTelemetry = CreateProfilingTelemetry(
             (ProfilingTelemetry.EnvironmentVariables.Enabled, "true"),
@@ -607,8 +612,14 @@ public class GuestRuntimeTests(ITestOutputHelper outputHelper)
             Assert.Contains(output.GetLines(), line => line.Stream == OutputLineStream.StdOut);
         }
 
-        var activity = Assert.Single(stoppedActivities, activity => activity.OperationName == ProfilingTelemetry.Activities.GuestExecuteCommand);
+        var activity = Assert.Single(stoppedActivities, activity =>
+            activity.OperationName == ProfilingTelemetry.Activities.Process &&
+            activity.GetTagItem(ProfilingTelemetry.Tags.ProfilingSessionId) as string == "session-1" &&
+            activity.GetTagItem(ProfilingTelemetry.Tags.GuestCommand) as string == "dotnet");
+        Assert.Equal("process dotnet", activity.DisplayName);
         Assert.Equal("dotnet", activity.GetTagItem(TelemetryConstants.Tags.ProcessExecutablePath));
+        Assert.Equal(new[] { "--version" }, Assert.IsType<string[]>(activity.GetTagItem(ProfilingTelemetry.Tags.ProcessCommandArgs)));
+        Assert.Equal(1, activity.GetTagItem(ProfilingTelemetry.Tags.ProcessCommandArgsCount));
         Assert.Equal(0, activity.GetTagItem(TelemetryConstants.Tags.ProcessExitCode));
         Assert.True((int)activity.GetTagItem(TelemetryConstants.Tags.ProcessPid)! > 0);
         Assert.Contains(activity.Events, @event => @event.Name == ProfilingTelemetry.Events.GuestProcessResolveStart);

--- a/tests/Aspire.Cli.Tests/Projects/GuestRuntimeTests.cs
+++ b/tests/Aspire.Cli.Tests/Projects/GuestRuntimeTests.cs
@@ -1,11 +1,14 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Diagnostics;
 using Aspire.Cli.Diagnostics;
 using Aspire.Cli.Projects;
+using Aspire.Cli.Telemetry;
 using Aspire.Cli.Tests.TestServices;
 using Aspire.Cli.Utils;
 using Aspire.TypeSystem;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
 
 namespace Aspire.Cli.Tests.Projects;
@@ -16,12 +19,14 @@ public class GuestRuntimeTests(ITestOutputHelper outputHelper)
 
     private GuestRuntime CreateRuntime(
         RuntimeSpec? spec = null,
-        Func<string, string?>? commandResolver = null)
+        Func<string, string?>? commandResolver = null,
+        ProfilingTelemetry? profilingTelemetry = null)
     {
         return new GuestRuntime(
             spec ?? CreateTestSpec(),
             _loggerFactory.CreateLogger<GuestRuntime>(),
-            commandResolver: commandResolver);
+            commandResolver: commandResolver,
+            profilingTelemetry: profilingTelemetry);
     }
 
     private static RuntimeSpec CreateTestSpec(
@@ -155,6 +160,62 @@ public class GuestRuntimeTests(ITestOutputHelper outputHelper)
         Assert.Equal("typecheck-cmd", launcher.Calls[0].Command);
         Assert.Equal(["--project", directory.FullName], launcher.Calls[0].Args);
         Assert.Equal("run-cmd", launcher.Calls[1].Command);
+    }
+
+    [Fact]
+    public async Task RunAsync_ProfilingTelemetryRecordsGuestCommandPhasesAndArgs()
+    {
+        var stoppedActivities = new List<Activity>();
+        using var listener = CreateProfilingActivityListener(stoppedActivities.Add);
+        using var profilingTelemetry = CreateProfilingTelemetry(
+            (ProfilingTelemetry.EnvironmentVariables.Enabled, "true"),
+            (ProfilingTelemetry.EnvironmentVariables.SessionId, "session-1"));
+        using var tempDirectory = new TestTempDirectory();
+
+        var spec = CreateTestSpec(
+            execute: new CommandSpec
+            {
+                Command = "npx",
+                Args = ["tsx", "--tsconfig", "tsconfig.apphost.json", "{appHostFile}"]
+            },
+            preExecute:
+            [
+                new CommandSpec
+                {
+                    Command = "npx",
+                    Args = ["tsc", "--noEmit", "-p", "tsconfig.apphost.json"]
+                }
+            ]);
+        var runtime = CreateRuntime(spec, profilingTelemetry: profilingTelemetry);
+        var launcher = new RecordingLauncher();
+        var directory = new DirectoryInfo(tempDirectory.Path);
+        var appHostFile = new FileInfo(Path.Combine(directory.FullName, "apphost.ts"));
+
+        await runtime.RunAsync(appHostFile, directory, new Dictionary<string, string>(), watchMode: false, launcher, CancellationToken.None);
+
+        var guestActivities = stoppedActivities
+            .Where(activity => activity.OperationName == ProfilingTelemetry.Activities.GuestExecuteCommand)
+            .OrderBy(activity => activity.StartTimeUtc)
+            .ToArray();
+
+        Assert.Collection(
+            guestActivities,
+            preExecuteActivity =>
+            {
+                Assert.Equal(ProfilingTelemetry.Values.GuestCommandPhasePreExecute, preExecuteActivity.GetTagItem(ProfilingTelemetry.Tags.GuestCommandPhase));
+                Assert.Equal("npx", preExecuteActivity.GetTagItem(ProfilingTelemetry.Tags.GuestCommand));
+                Assert.Equal(new[] { "tsc", "--noEmit", "-p", "tsconfig.apphost.json" }, Assert.IsType<string[]>(preExecuteActivity.GetTagItem(ProfilingTelemetry.Tags.ProcessCommandArgs)));
+                Assert.Equal(4, preExecuteActivity.GetTagItem(ProfilingTelemetry.Tags.ProcessCommandArgsCount));
+                Assert.Equal(0, preExecuteActivity.GetTagItem(TelemetryConstants.Tags.ProcessExitCode));
+            },
+            executeActivity =>
+            {
+                Assert.Equal(ProfilingTelemetry.Values.GuestCommandPhaseExecute, executeActivity.GetTagItem(ProfilingTelemetry.Tags.GuestCommandPhase));
+                Assert.Equal("npx", executeActivity.GetTagItem(ProfilingTelemetry.Tags.GuestCommand));
+                Assert.Equal(new[] { "tsx", "--tsconfig", "tsconfig.apphost.json", appHostFile.FullName }, Assert.IsType<string[]>(executeActivity.GetTagItem(ProfilingTelemetry.Tags.ProcessCommandArgs)));
+                Assert.Equal(4, executeActivity.GetTagItem(ProfilingTelemetry.Tags.ProcessCommandArgsCount));
+                Assert.Equal(0, executeActivity.GetTagItem(TelemetryConstants.Tags.ProcessExitCode));
+            });
     }
 
     [Fact]
@@ -512,6 +573,53 @@ public class GuestRuntimeTests(ITestOutputHelper outputHelper)
     }
 
     [Fact]
+    public async Task ProcessGuestLauncher_AnnotatesAmbientGuestProfilingActivity()
+    {
+        var stoppedActivities = new List<Activity>();
+        using var listener = CreateProfilingActivityListener(stoppedActivities.Add);
+        using var profilingTelemetry = CreateProfilingTelemetry(
+            (ProfilingTelemetry.EnvironmentVariables.Enabled, "true"),
+            (ProfilingTelemetry.EnvironmentVariables.SessionId, "session-1"));
+        using var tempDirectory = new TestTempDirectory();
+
+        var launcher = new ProcessGuestLauncher(
+            "test",
+            _loggerFactory.CreateLogger<ProcessGuestLauncher>(),
+            commandResolver: cmd => cmd == "dotnet" ? "dotnet" : null);
+
+        using (profilingTelemetry.StartGuestExecuteCommand(
+            "test/runtime",
+            "Test Runtime",
+            "dotnet",
+            ["--version"],
+            new DirectoryInfo(tempDirectory.Path),
+            ProfilingTelemetry.Values.GuestCommandPhaseExecute))
+        {
+            var (exitCode, output) = await launcher.LaunchAsync(
+                "dotnet",
+                ["--version"],
+                new DirectoryInfo(tempDirectory.Path),
+                new Dictionary<string, string>(),
+                CancellationToken.None);
+
+            Assert.Equal(0, exitCode);
+            Assert.NotNull(output);
+            Assert.Contains(output.GetLines(), line => line.Stream == OutputLineStream.StdOut);
+        }
+
+        var activity = Assert.Single(stoppedActivities, activity => activity.OperationName == ProfilingTelemetry.Activities.GuestExecuteCommand);
+        Assert.Equal("dotnet", activity.GetTagItem(TelemetryConstants.Tags.ProcessExecutablePath));
+        Assert.Equal(0, activity.GetTagItem(TelemetryConstants.Tags.ProcessExitCode));
+        Assert.True((int)activity.GetTagItem(TelemetryConstants.Tags.ProcessPid)! > 0);
+        Assert.Contains(activity.Events, @event => @event.Name == ProfilingTelemetry.Events.GuestProcessResolveStart);
+        Assert.Contains(activity.Events, @event => @event.Name == ProfilingTelemetry.Events.GuestProcessResolved);
+        Assert.Contains(activity.Events, @event => @event.Name == ProfilingTelemetry.Events.GuestProcessStart);
+        Assert.Contains(activity.Events, @event => @event.Name == ProfilingTelemetry.Events.GuestProcessStarted);
+        Assert.Contains(activity.Events, @event => @event.Name == ProfilingTelemetry.Events.GuestFirstStdout);
+        Assert.Contains(activity.Events, @event => @event.Name == ProfilingTelemetry.Events.GuestProcessExited);
+    }
+
+    [Fact]
     public async Task RunAsync_CreatesMissingMigrationFiles()
     {
         using var tempDirectory = new TestTempDirectory();
@@ -639,5 +747,25 @@ public class GuestRuntimeTests(ITestOutputHelper outputHelper)
             var exitCode = ExitCodes.Count > 0 ? ExitCodes.Dequeue() : 0;
             return Task.FromResult<(int, OutputCollector?)>((exitCode, new OutputCollector()));
         }
+    }
+
+    private static ProfilingTelemetry CreateProfilingTelemetry(params (string Key, string? Value)[] values)
+    {
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(values.Select(value => new KeyValuePair<string, string?>(value.Key, value.Value)))
+            .Build();
+        return new ProfilingTelemetry(configuration);
+    }
+
+    private static ActivityListener CreateProfilingActivityListener(Action<Activity> activityStopped)
+    {
+        var listener = new ActivityListener
+        {
+            ShouldListenTo = source => source.Name == ProfilingTelemetry.ActivitySourceName,
+            Sample = (ref ActivityCreationOptions<ActivityContext> _) => ActivitySamplingResult.AllDataAndRecorded,
+            ActivityStopped = activityStopped
+        };
+        ActivitySource.AddActivityListener(listener);
+        return listener;
     }
 }

--- a/tests/Aspire.Cli.Tests/Telemetry/ProfilingTelemetryContextTests.cs
+++ b/tests/Aspire.Cli.Tests/Telemetry/ProfilingTelemetryContextTests.cs
@@ -47,8 +47,8 @@ public class ProfilingTelemetryContextTests
     [Fact]
     public void StartRunCommand_ContinuesConfiguredRemoteParentAndSession()
     {
-        Activity? startedActivity = null;
-        using var listener = CreateActivityListener(ProfilingTelemetry.ActivitySourceName, activity => startedActivity = activity);
+        var startedActivities = new List<Activity>();
+        using var listener = CreateActivityListener(ProfilingTelemetry.ActivitySourceName, startedActivities.Add);
         using var profilingTelemetry = new ProfilingTelemetry(CreateConfiguration(
             (ProfilingTelemetry.EnvironmentVariables.Enabled, "true"),
             (ProfilingTelemetry.EnvironmentVariables.SessionId, "session-1"),
@@ -58,7 +58,7 @@ public class ProfilingTelemetryContextTests
         using var activity = profilingTelemetry.StartRunCommand();
 
         Assert.True(activity.IsRunning);
-        Assert.NotNull(startedActivity);
+        var startedActivity = Assert.Single(startedActivities, activity => activity.OperationName == ProfilingTelemetry.Activities.RunCommand);
         Assert.Equal("0102030405060708090a0b0c0d0e0f10", startedActivity.TraceId.ToString());
         Assert.Equal("session-1", startedActivity.GetBaggageItem(ProfilingTelemetry.Baggage.SessionId));
         Assert.Equal("session-1", startedActivity.GetTagItem(ProfilingTelemetry.Tags.ProfilingSessionId));
@@ -83,8 +83,8 @@ public class ProfilingTelemetryContextTests
     [Fact]
     public void StartRunCommand_ReadsLegacyStartupNames()
     {
-        Activity? startedActivity = null;
-        using var listener = CreateActivityListener(ProfilingTelemetry.ActivitySourceName, activity => startedActivity = activity);
+        var startedActivities = new List<Activity>();
+        using var listener = CreateActivityListener(ProfilingTelemetry.ActivitySourceName, startedActivities.Add);
         using var profilingTelemetry = new ProfilingTelemetry(CreateConfiguration(
             (KnownConfigNames.Legacy.StartupProfilingEnabled, "true"),
             (KnownConfigNames.Legacy.StartupOperationId, "session-1"),
@@ -94,7 +94,7 @@ public class ProfilingTelemetryContextTests
         using var activity = profilingTelemetry.StartRunCommand();
 
         Assert.True(activity.IsRunning);
-        Assert.NotNull(startedActivity);
+        var startedActivity = Assert.Single(startedActivities, activity => activity.OperationName == ProfilingTelemetry.Activities.RunCommand);
         Assert.Equal("0102030405060708090a0b0c0d0e0f10", startedActivity.TraceId.ToString());
         Assert.Equal("session-1", startedActivity.GetBaggageItem(ProfilingTelemetry.Baggage.SessionId));
     }

--- a/tests/Aspire.Cli.Tests/Telemetry/ProfilingTelemetryContextTests.cs
+++ b/tests/Aspire.Cli.Tests/Telemetry/ProfilingTelemetryContextTests.cs
@@ -45,6 +45,20 @@ public class ProfilingTelemetryContextTests
     }
 
     [Fact]
+    public void AddActivityContextToEnvironment_IgnoresNonProfilingActivity()
+    {
+        using var listener = CreateActivityListener("test-profiling-context");
+        using var source = new ActivitySource("test-profiling-context");
+        using var activity = source.StartActivity("parent");
+        Assert.NotNull(activity);
+
+        var environment = new Dictionary<string, string>();
+        ProfilingTelemetry.AddActivityContextToEnvironment(activity, environment);
+
+        Assert.Empty(environment);
+    }
+
+    [Fact]
     public void StartRunCommand_ContinuesConfiguredRemoteParentAndSession()
     {
         var startedActivities = new List<Activity>();

--- a/tests/Aspire.Cli.Tests/Telemetry/ProfilingTelemetryTests.cs
+++ b/tests/Aspire.Cli.Tests/Telemetry/ProfilingTelemetryTests.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Diagnostics;
+using Aspire.Cli.DotNet;
 using Aspire.Cli.Telemetry;
 using Microsoft.Extensions.Configuration;
 
@@ -42,6 +43,75 @@ public class ProfilingTelemetryTests
     }
 
     [Fact]
+    public void ProcessSpansUseConsistentExecutableAndArgumentTags()
+    {
+        var startedActivities = new List<Activity>();
+        using var listener = CreateProfilingActivityListener(startedActivities.Add);
+        using var profilingTelemetry = new ProfilingTelemetry(CreateConfiguration(
+            (ProfilingTelemetry.EnvironmentVariables.Enabled, "true"),
+            (ProfilingTelemetry.EnvironmentVariables.SessionId, "session-1")));
+        var aspirePath = Path.Combine("tools", "aspire");
+        var npmPath = Path.Combine("node", "npm");
+        var workingDirectory = Directory.GetCurrentDirectory();
+
+        using (profilingTelemetry.StartDetachedSpawnChild(aspirePath, ["run", "--project", "AppHost"], childCommand: "run"))
+        {
+        }
+
+        using (profilingTelemetry.StartNpmCommand(npmPath, ["exec", "--", "tsx", "apphost.ts"], workingDirectory))
+        {
+        }
+
+        using (var dotnetActivity = profilingTelemetry.StartDotNetProcess("run", null, new DirectoryInfo(workingDirectory), new ProcessInvocationOptions()))
+        {
+            dotnetActivity.SetDotNetResolvedExecutable("dotnet", ["run", "--project", "AppHost"], msBuildServer: null);
+        }
+
+        using (profilingTelemetry.StartGitCommand("ls-files", "git", ["ls-files", "--cached"], new DirectoryInfo(workingDirectory)))
+        {
+        }
+
+        Assert.Collection(
+            startedActivities,
+            spawnActivity =>
+            {
+                Assert.Equal(ProfilingTelemetry.Activities.Process, spawnActivity.OperationName);
+                Assert.Equal("process aspire", spawnActivity.DisplayName);
+                Assert.Equal("aspire", spawnActivity.GetTagItem(TelemetryConstants.Tags.ProcessExecutableName));
+                Assert.Equal(aspirePath, spawnActivity.GetTagItem(TelemetryConstants.Tags.ProcessExecutablePath));
+                Assert.Equal(new[] { "run", "--project", "AppHost" }, Assert.IsType<string[]>(spawnActivity.GetTagItem(ProfilingTelemetry.Tags.ProcessCommandArgs)));
+                Assert.Equal(3, spawnActivity.GetTagItem(ProfilingTelemetry.Tags.ProcessCommandArgsCount));
+            },
+            npmActivity =>
+            {
+                Assert.Equal(ProfilingTelemetry.Activities.Process, npmActivity.OperationName);
+                Assert.Equal("process npm", npmActivity.DisplayName);
+                Assert.Equal("npm", npmActivity.GetTagItem(TelemetryConstants.Tags.ProcessExecutableName));
+                Assert.Equal(npmPath, npmActivity.GetTagItem(TelemetryConstants.Tags.ProcessExecutablePath));
+                Assert.Equal(new[] { "exec", "--", "tsx", "apphost.ts" }, Assert.IsType<string[]>(npmActivity.GetTagItem(ProfilingTelemetry.Tags.ProcessCommandArgs)));
+                Assert.Equal(4, npmActivity.GetTagItem(ProfilingTelemetry.Tags.ProcessCommandArgsCount));
+            },
+            dotnetActivity =>
+            {
+                Assert.Equal(ProfilingTelemetry.Activities.Process, dotnetActivity.OperationName);
+                Assert.Equal("process dotnet", dotnetActivity.DisplayName);
+                Assert.Equal("dotnet", dotnetActivity.GetTagItem(TelemetryConstants.Tags.ProcessExecutableName));
+                Assert.Equal("dotnet", dotnetActivity.GetTagItem(TelemetryConstants.Tags.ProcessExecutablePath));
+                Assert.Equal(new[] { "run", "--project", "AppHost" }, Assert.IsType<string[]>(dotnetActivity.GetTagItem(ProfilingTelemetry.Tags.ProcessCommandArgs)));
+                Assert.Equal(3, dotnetActivity.GetTagItem(ProfilingTelemetry.Tags.ProcessCommandArgsCount));
+            },
+            gitActivity =>
+            {
+                Assert.Equal(ProfilingTelemetry.Activities.Process, gitActivity.OperationName);
+                Assert.Equal("process git", gitActivity.DisplayName);
+                Assert.Equal("git", gitActivity.GetTagItem(TelemetryConstants.Tags.ProcessExecutableName));
+                Assert.Equal("git", gitActivity.GetTagItem(TelemetryConstants.Tags.ProcessExecutablePath));
+                Assert.Equal(new[] { "ls-files", "--cached" }, Assert.IsType<string[]>(gitActivity.GetTagItem(ProfilingTelemetry.Tags.ProcessCommandArgs)));
+                Assert.Equal(2, gitActivity.GetTagItem(ProfilingTelemetry.Tags.ProcessCommandArgsCount));
+            });
+    }
+
+    [Fact]
     public void ProfilingSpansReuseSessionFromAmbientActivityBaggage()
     {
         var startedActivities = new List<Activity>();
@@ -55,7 +125,7 @@ public class ProfilingTelemetryTests
 
         parentActivity.SetBaggage(ProfilingTelemetry.Baggage.SessionId, "session-1");
 
-        using (profilingTelemetry.StartDetachedSpawnChild("aspire", argsCount: 1, childCommand: "start"))
+        using (profilingTelemetry.StartDetachedSpawnChild("aspire", ["run"], childCommand: "start"))
         {
         }
 
@@ -87,7 +157,7 @@ public class ProfilingTelemetryTests
 
         using (diagnosticSource.StartActivity("diagnostic"))
         {
-            using (profilingTelemetry.StartDetachedSpawnChild("aspire", argsCount: 1, childCommand: "start"))
+            using (profilingTelemetry.StartDetachedSpawnChild("aspire", ["run"], childCommand: "start"))
             {
             }
         }

--- a/tests/Aspire.Cli.Tests/Telemetry/TelemetryConfigurationTests.cs
+++ b/tests/Aspire.Cli.Tests/Telemetry/TelemetryConfigurationTests.cs
@@ -1,6 +1,8 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Diagnostics;
+using Aspire.Cli.Commands;
 using Aspire.Cli.Telemetry;
 using Aspire.Cli.Tests.TestServices;
 using Microsoft.Extensions.Configuration;
@@ -76,6 +78,25 @@ public class TelemetryConfigurationTests
         Assert.False(telemetryManager.HasProfilingProvider, "Expected profiling export to require explicit profiling opt-in");
         Assert.True(telemetryManager.HasAzureMonitor, "Expected Azure Monitor to be enabled (connection string is hardcoded)");
 #endif
+    }
+
+    [Fact]
+    public void OtlpExporter_WithDetachedNonProfilingContext_DoesNotEnableProfilingProvider()
+    {
+        using var listener = CreateActivityListener("test-detached-non-profiling-context");
+        using var source = new ActivitySource("test-detached-non-profiling-context");
+        using var activity = source.StartActivity("parent");
+        Assert.NotNull(activity);
+
+        var config = AppHostLauncher.CreateDetachedChildEnvironment(activity);
+        config[AspireCliTelemetry.OtlpExporterEndpointConfigKey] = "http://localhost:4317";
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(config.Select(pair => new KeyValuePair<string, string?>(pair.Key, pair.Value)))
+            .Build();
+
+        using var manager = new TelemetryManager(configuration);
+
+        Assert.False(manager.HasProfilingProvider, "Expected detached child profiling export to require an actual profiling session");
     }
 
     [Fact]
@@ -162,5 +183,16 @@ public class TelemetryConfigurationTests
         var manager = new TelemetryManager(configuration, [flag]);
 
         Assert.False(manager.HasAzureMonitor);
+    }
+
+    private static ActivityListener CreateActivityListener(string sourceName)
+    {
+        var listener = new ActivityListener
+        {
+            ShouldListenTo = source => source.Name == sourceName,
+            Sample = (ref ActivityCreationOptions<ActivityContext> _) => ActivitySamplingResult.AllDataAndRecorded
+        };
+        ActivitySource.AddActivityListener(listener);
+        return listener;
     }
 }

--- a/tests/Aspire.Cli.Tests/Telemetry/TelemetryConfigurationTests.cs
+++ b/tests/Aspire.Cli.Tests/Telemetry/TelemetryConfigurationTests.cs
@@ -54,7 +54,7 @@ public class TelemetryConfigurationTests
     }
 
     [Fact]
-    public async Task OtlpExporter_EnabledInDebugOnly_WhenEndpointProvided()
+    public async Task OtlpExporter_WithoutProfiling_EnablesOnlyDebugDiagnostics_WhenEndpointProvided()
     {
         var config = new Dictionary<string, string?>
         {
@@ -67,36 +67,74 @@ public class TelemetryConfigurationTests
 
 #if DEBUG
         Assert.True(telemetryManager.HasDiagnosticProvider, "Expected TelemetryManager to have diagnostic provider enabled when OTLP endpoint is configured in DEBUG mode");
+        Assert.False(telemetryManager.HasProfilingProvider, "Expected profiling export to require explicit profiling opt-in");
         // Azure Monitor is also enabled since connection string is hardcoded
         Assert.True(telemetryManager.HasAzureMonitor, "Expected TelemetryManager to have Azure Monitor enabled (connection string is hardcoded)");
 #else
-        // In RELEASE mode, OTLP exporter is disabled, Azure Monitor is enabled by default
+        // In RELEASE mode, diagnostic OTLP export requires explicit profiling opt-in.
+        Assert.False(telemetryManager.HasDiagnosticProvider, "Expected TelemetryManager to require profiling before enabling diagnostic OTLP export in RELEASE mode");
+        Assert.False(telemetryManager.HasProfilingProvider, "Expected profiling export to require explicit profiling opt-in");
         Assert.True(telemetryManager.HasAzureMonitor, "Expected Azure Monitor to be enabled (connection string is hardcoded)");
 #endif
     }
 
+    [Fact]
+    public async Task OtlpExporter_WithProfiling_EnablesProfilingProviderWhenTelemetryOptedOut()
+    {
+        var config = new Dictionary<string, string?>
+        {
+            [AspireCliTelemetry.TelemetryOptOutConfigKey] = "true",
+            [AspireCliTelemetry.OtlpExporterEndpointConfigKey] = "http://localhost:4317",
+            [Aspire.Hosting.KnownConfigNames.ProfilingEnabled] = "true"
+        };
+
+        using var host = await BuildHostAsync(config);
+
+        var telemetryManager = host.Services.GetRequiredService<TelemetryManager>();
+
+        Assert.False(telemetryManager.HasAzureMonitor, "Expected Azure Monitor to honor telemetry opt-out");
+        Assert.False(telemetryManager.HasDiagnosticProvider, "Expected profiling export to stay separate from debug diagnostics");
+        Assert.True(telemetryManager.HasProfilingProvider, "Expected profiling OTLP export to work even when reported telemetry is opted out");
+    }
+
+    [Fact]
+    public async Task OtlpExporter_WithProfiling_KeepsReportedTelemetryAndProfilingSeparate()
+    {
+        var config = new Dictionary<string, string?>
+        {
+            [AspireCliTelemetry.OtlpExporterEndpointConfigKey] = "http://localhost:4317",
+            [Aspire.Hosting.KnownConfigNames.ProfilingEnabled] = "true"
+        };
+
+        using var host = await BuildHostAsync(config);
+
+        var telemetryManager = host.Services.GetRequiredService<TelemetryManager>();
+
+        Assert.True(telemetryManager.HasAzureMonitor, "Expected reported telemetry to keep using the Azure Monitor provider");
+        Assert.True(telemetryManager.HasProfilingProvider, "Expected profiling telemetry to use the profiling provider");
+        Assert.False(telemetryManager.HasDiagnosticProvider, "Expected profiling OTLP export to avoid the debug diagnostics provider");
+    }
+
 #if DEBUG
     [Fact]
-    public async Task DiagnosticProvider_IncludesReportedActivitySource()
+    public async Task DiagnosticProvider_IncludesDiagnosticActivitySource()
     {
         // Configure console exporter at Diagnostic level to enable the diagnostic provider
         var config = new Dictionary<string, string?>
         {
+            [AspireCliTelemetry.TelemetryOptOutConfigKey] = "true",
             [AspireCliTelemetry.ConsoleExporterLevelConfigKey] = "Diagnostic"
         };
 
         using var host = await BuildHostAsync(config);
 
         var telemetryManager = host.Services.GetRequiredService<TelemetryManager>();
+        Assert.False(telemetryManager.HasAzureMonitor);
         Assert.True(telemetryManager.HasDiagnosticProvider);
+        Assert.False(telemetryManager.HasProfilingProvider);
 
         var telemetry = host.Services.GetRequiredService<AspireCliTelemetry>();
         await telemetry.InitializeAsync().DefaultTimeout();
-
-        // The diagnostic provider should listen to both activity sources.
-        // Verify reported activities are captured by starting one and checking it's not null.
-        using var reportedActivity = telemetry.StartReportedActivity("TestReportedActivity");
-        Assert.NotNull(reportedActivity);
 
         using var diagnosticActivity = telemetry.StartDiagnosticActivity("TestDiagnosticActivity");
         Assert.NotNull(diagnosticActivity);

--- a/tools/StartupOtelValidator/ValidateStartupOtelExport.cs
+++ b/tools/StartupOtelValidator/ValidateStartupOtelExport.cs
@@ -185,12 +185,20 @@ static List<ExportedSpan> ReadExportedSpans(string exportDirectory)
                         File: Path.GetFileName(tracePath),
                         Scope: scopeName,
                         Name: GetStringProperty(span, "name"),
+                        StartTimeUnixNano: GetStringProperty(span, "startTimeUnixNano"),
+                        EndTimeUnixNano: GetStringProperty(span, "endTimeUnixNano"),
+                        DurationMilliseconds: GetSpanDurationMilliseconds(span),
                         TraceId: GetStringProperty(span, "traceId"),
                         SpanId: GetStringProperty(span, "spanId"),
                         ParentSpanId: GetStringProperty(span, "parentSpanId"),
                         ProfilingSessionId: GetSpanAttributeValue(span, ProfilingSessionIdAttribute) ?? GetSpanAttributeValue(span, LegacyStartupOperationIdAttribute),
                         CommandName: GetSpanAttributeValue(span, "aspire.cli.command.name"),
                         ProcessId: GetSpanAttributeValue(span, "process.pid"),
+                        ProcessExecutableName: GetSpanAttributeValue(span, "process.executable.name"),
+                        ProcessExecutablePath: GetSpanAttributeValue(span, "process.executable.path"),
+                        GuestCommand: GetSpanAttributeValue(span, "aspire.cli.guest.command"),
+                        GuestCommandPhase: GetSpanAttributeValue(span, "aspire.cli.guest.command.phase"),
+                        ProcessCommandArgs: GetSpanAttributeValues(span, "process.command_args"),
                         DcpCreateObjectId: GetSpanAttributeValue(span, "aspire.hosting.dcp.create_object.id"),
                         DcpCreateObjectKind: GetSpanAttributeValue(span, "aspire.hosting.dcp.create_object.kind"),
                         DcpCreateObjectName: GetSpanAttributeValue(span, "aspire.hosting.dcp.create_object.name"),
@@ -203,6 +211,19 @@ static List<ExportedSpan> ReadExportedSpans(string exportDirectory)
     }
 
     return spans;
+}
+
+static double? GetSpanDurationMilliseconds(JsonElement span)
+{
+    var start = GetStringProperty(span, "startTimeUnixNano");
+    var end = GetStringProperty(span, "endTimeUnixNano");
+    if (!long.TryParse(start, out var startUnixNano) ||
+        !long.TryParse(end, out var endUnixNano))
+    {
+        return null;
+    }
+
+    return Math.Round((endUnixNano - startUnixNano) / 1_000_000d, 2);
 }
 
 static List<string> ReadLinkSpanIds(JsonElement span)
@@ -246,6 +267,50 @@ static string? GetSpanAttributeValue(JsonElement span, string key)
                 _ => null
             };
         }
+    }
+
+    return null;
+}
+
+static List<string> GetSpanAttributeValues(JsonElement span, string key)
+{
+    foreach (var attribute in EnumerateArrayProperty(span, "attributes"))
+    {
+        if (GetStringProperty(attribute, "key") != key || !TryGetProperty(attribute, "value", out var value))
+        {
+            continue;
+        }
+
+        if (TryGetProperty(value, "arrayValue", out var arrayValue))
+        {
+            return EnumerateArrayProperty(arrayValue, "values")
+                .Select(GetAttributeValue)
+                .Where(value => !string.IsNullOrEmpty(value))
+                .Select(value => value!)
+                .ToList();
+        }
+
+        return GetAttributeValue(value) is { } scalarValue ? [scalarValue] : [];
+    }
+
+    return [];
+}
+
+static string? GetAttributeValue(JsonElement value)
+{
+    foreach (var propertyName in new[] { "stringValue", "intValue", "doubleValue", "boolValue" })
+    {
+        if (!TryGetProperty(value, propertyName, out var propertyValue))
+        {
+            continue;
+        }
+
+        return propertyValue.ValueKind switch
+        {
+            JsonValueKind.String => propertyValue.GetString(),
+            JsonValueKind.Number or JsonValueKind.True or JsonValueKind.False => propertyValue.GetRawText(),
+            _ => null
+        };
     }
 
     return null;
@@ -357,12 +422,20 @@ static void WriteExportedSpan(Utf8JsonWriter writer, ExportedSpan span)
     WriteString(writer, nameof(ExportedSpan.File), span.File);
     WriteString(writer, nameof(ExportedSpan.Scope), span.Scope);
     WriteString(writer, nameof(ExportedSpan.Name), span.Name);
+    WriteString(writer, nameof(ExportedSpan.StartTimeUnixNano), span.StartTimeUnixNano);
+    WriteString(writer, nameof(ExportedSpan.EndTimeUnixNano), span.EndTimeUnixNano);
+    WriteNumber(writer, nameof(ExportedSpan.DurationMilliseconds), span.DurationMilliseconds);
     WriteString(writer, nameof(ExportedSpan.TraceId), span.TraceId);
     WriteString(writer, nameof(ExportedSpan.SpanId), span.SpanId);
     WriteString(writer, nameof(ExportedSpan.ParentSpanId), span.ParentSpanId);
     WriteString(writer, nameof(ExportedSpan.ProfilingSessionId), span.ProfilingSessionId);
     WriteString(writer, nameof(ExportedSpan.CommandName), span.CommandName);
     WriteString(writer, nameof(ExportedSpan.ProcessId), span.ProcessId);
+    WriteString(writer, nameof(ExportedSpan.ProcessExecutableName), span.ProcessExecutableName);
+    WriteString(writer, nameof(ExportedSpan.ProcessExecutablePath), span.ProcessExecutablePath);
+    WriteString(writer, nameof(ExportedSpan.GuestCommand), span.GuestCommand);
+    WriteString(writer, nameof(ExportedSpan.GuestCommandPhase), span.GuestCommandPhase);
+    WriteStringArray(writer, nameof(ExportedSpan.ProcessCommandArgs), span.ProcessCommandArgs);
     WriteString(writer, nameof(ExportedSpan.DcpCreateObjectId), span.DcpCreateObjectId);
     WriteString(writer, nameof(ExportedSpan.DcpCreateObjectKind), span.DcpCreateObjectKind);
     WriteString(writer, nameof(ExportedSpan.DcpCreateObjectName), span.DcpCreateObjectName);
@@ -411,6 +484,18 @@ static void WriteString(Utf8JsonWriter writer, string propertyName, string? valu
     }
 }
 
+static void WriteNumber(Utf8JsonWriter writer, string propertyName, double? value)
+{
+    if (value is null)
+    {
+        writer.WriteNull(propertyName);
+    }
+    else
+    {
+        writer.WriteNumber(propertyName, value.Value);
+    }
+}
+
 static void WriteStringArray(Utf8JsonWriter writer, string propertyName, IReadOnlyList<string> values)
 {
     writer.WriteStartArray(propertyName);
@@ -425,12 +510,20 @@ internal sealed record ExportedSpan(
     string File,
     string? Scope,
     string? Name,
+    string? StartTimeUnixNano,
+    string? EndTimeUnixNano,
+    double? DurationMilliseconds,
     string? TraceId,
     string? SpanId,
     string? ParentSpanId,
     string? ProfilingSessionId,
     string? CommandName,
     string? ProcessId,
+    string? ProcessExecutableName,
+    string? ProcessExecutablePath,
+    string? GuestCommand,
+    string? GuestCommandPhase,
+    List<string> ProcessCommandArgs,
     string? DcpCreateObjectId,
     string? DcpCreateObjectKind,
     string? DcpCreateObjectName,

--- a/tools/StartupOtelValidator/ValidateStartupOtelExport.cs
+++ b/tools/StartupOtelValidator/ValidateStartupOtelExport.cs
@@ -39,15 +39,19 @@ foreach (var profilingGroup in profilingGroups)
         var traceSpans = traceGroup.ToList();
         var hasStartCommandSpan = traceSpans.Any(span =>
             span.Scope == "Aspire.Cli.Profiling" &&
-            span.Name == "aspire/cli/start_apphost.spawn_child");
+            span.Name?.StartsWith("process ", StringComparison.Ordinal) == true &&
+            span.ChildCommand == "run" &&
+            !string.IsNullOrEmpty(span.ProcessExecutableName) &&
+            span.ProcessCommandArgs.Count > 0);
         var hasChildDiagnosticSpan = traceSpans.Any(span =>
             span.Scope == "Aspire.Cli.Profiling" &&
-            Contains(span.Name,
-                "aspire/cli/apphost.ensure_dev_certificates",
-                "aspire/cli/backchannel.connect",
-                "aspire/cli/backchannel.get_dashboard_urls",
-                "aspire/cli/dotnet.build",
-                "aspire/cli/run"));
+            (Contains(span.Name,
+                    "aspire/cli/apphost.ensure_dev_certificates",
+                    "aspire/cli/backchannel.connect",
+                    "aspire/cli/backchannel.get_dashboard_urls",
+                    "aspire/cli/run") ||
+                (span.Name?.StartsWith("process ", StringComparison.Ordinal) == true &&
+                    span.DotNetCommand == "build")));
         var hasHostingDcpSpan = traceSpans.Any(span =>
             span.Scope == "Aspire.Hosting.Profiling" &&
             Contains(span.Name,
@@ -193,6 +197,11 @@ static List<ExportedSpan> ReadExportedSpans(string exportDirectory)
                         ParentSpanId: GetStringProperty(span, "parentSpanId"),
                         ProfilingSessionId: GetSpanAttributeValue(span, ProfilingSessionIdAttribute) ?? GetSpanAttributeValue(span, LegacyStartupOperationIdAttribute),
                         CommandName: GetSpanAttributeValue(span, "aspire.cli.command.name"),
+                        ChildCommand: GetSpanAttributeValue(span, "aspire.cli.child.command"),
+                        DotNetCommand: GetSpanAttributeValue(span, "aspire.cli.dotnet.command"),
+                        GitCommand: GetSpanAttributeValue(span, "aspire.cli.git.command"),
+                        NpmCommand: GetSpanAttributeValue(span, "aspire.cli.npm.command"),
+                        AppHostServerImplementation: GetSpanAttributeValue(span, "aspire.cli.apphost_server.implementation"),
                         ProcessId: GetSpanAttributeValue(span, "process.pid"),
                         ProcessExecutableName: GetSpanAttributeValue(span, "process.executable.name"),
                         ProcessExecutablePath: GetSpanAttributeValue(span, "process.executable.path"),
@@ -430,6 +439,11 @@ static void WriteExportedSpan(Utf8JsonWriter writer, ExportedSpan span)
     WriteString(writer, nameof(ExportedSpan.ParentSpanId), span.ParentSpanId);
     WriteString(writer, nameof(ExportedSpan.ProfilingSessionId), span.ProfilingSessionId);
     WriteString(writer, nameof(ExportedSpan.CommandName), span.CommandName);
+    WriteString(writer, nameof(ExportedSpan.ChildCommand), span.ChildCommand);
+    WriteString(writer, nameof(ExportedSpan.DotNetCommand), span.DotNetCommand);
+    WriteString(writer, nameof(ExportedSpan.GitCommand), span.GitCommand);
+    WriteString(writer, nameof(ExportedSpan.NpmCommand), span.NpmCommand);
+    WriteString(writer, nameof(ExportedSpan.AppHostServerImplementation), span.AppHostServerImplementation);
     WriteString(writer, nameof(ExportedSpan.ProcessId), span.ProcessId);
     WriteString(writer, nameof(ExportedSpan.ProcessExecutableName), span.ProcessExecutableName);
     WriteString(writer, nameof(ExportedSpan.ProcessExecutablePath), span.ProcessExecutablePath);
@@ -518,6 +532,11 @@ internal sealed record ExportedSpan(
     string? ParentSpanId,
     string? ProfilingSessionId,
     string? CommandName,
+    string? ChildCommand,
+    string? DotNetCommand,
+    string? GitCommand,
+    string? NpmCommand,
+    string? AppHostServerImplementation,
     string? ProcessId,
     string? ProcessExecutableName,
     string? ProcessExecutablePath,


### PR DESCRIPTION
## Description

Startup profiling for installed or bundled CLI builds was missing the CLI side of the trace because CLI profiling spans were only exported through the DEBUG-only diagnostic provider. That made TypeScript AppHost startup traces show Hosting/DCP activity but not the parent CLI, child CLI, or guest process work that dominates wall-clock startup.

This change keeps telemetry streams separate and makes startup profiling usable end to end for release CLI builds:

- Reported CLI telemetry stays on the Azure Monitor provider and listens only to `Aspire.Cli.Reported`.
- Startup profiling uses its own OTLP provider and listens only to `Aspire.Cli.Profiling` when profiling and an OTLP endpoint are explicitly configured.
- DEBUG diagnostics stay on their own DEBUG-only provider and no longer share reported or profiling sources.
- CLI process launches now emit generic process spans named by executable, such as `process aspire.exe`, `process npm.CMD`, `process npx.CMD`, and `process aspire-managed.exe`.
- Process spans use consistent tags for `process.executable.name`, `process.executable.path`, `process.command_args`, and `process.command_args.count`, with contextual tags for guest phase, child command, dotnet/npm/git command, and AppHost server implementation.
- The startup OTEL validator summary includes process names, paths, args, start/end times, and durations so the exported trace is readable without opening every raw OTLP file.

### User-facing usage

Profiling a release CLI now uses the profiling stream:

```powershell
$env:ASPIRE_PROFILING_ENABLED = "true"
$env:OTEL_EXPORTER_OTLP_ENDPOINT = "http://localhost:4317"
$env:OTEL_EXPORTER_OTLP_PROTOCOL = "grpc"
aspire start
```

`ASPIRE_STARTUP_PROFILING_ENABLED` remains supported as a legacy alias for existing startup profiling scripts.

### LocalHive e2e validation

Validated with a LocalHive build (`13.4.0-local.20260514.t233119`) using `eng/scripts/verify-startup-otel.ps1` against a TypeScript AppHost. The run produced a dashboard OTEL export and `span-summary.json` at:

```text
C:\Users\davifowl\AppData\Local\Temp\aspire-startup-otel-instrumented-localhive-a9fe501f65974d45bc35688f209a63b9\20260514-163304\startup-otel-export.zip
C:\Users\davifowl\AppData\Local\Temp\aspire-startup-otel-instrumented-localhive-a9fe501f65974d45bc35688f209a63b9\20260514-163304\span-summary.json
```

The timings below are overlapping wall-clock spans, not additive exclusive time. The harness trace starts with an explicit restore, then `aspire start` begins at about 6.5s into the trace.

| Duration | Span/process | What it shows |
| --- | --- | --- |
| 5.2s | `process aspire-managed.exe` | Restore-time AppHost server process |
| 3.1s | `process npm.CMD` | Restore-time `npm install` |
| 13.3s | `aspire/cli/run` | Child CLI `run` command lifetime during `aspire start` |
| 13.2s | `process aspire-managed.exe` | Start-time AppHost server process lifetime |
| 10.2s | `aspire/cli/start_apphost.wait_for_backchannel` | Parent `start` waiting for child CLI/AppHost backchannel metadata |
| 7.9s | `process npx.CMD` | Guest execute phase: `npx --no-install tsx --tsconfig tsconfig.apphost.json apphost.ts` |
| 7.1s | `aspire/cli/run_apphost.wait_for_backchannel` | Child CLI waiting for the AppHost server backchannel connection |
| 2.6s | `aspire/cli/run_apphost.get_dashboard_urls` | Child CLI retrieving dashboard URLs |
| 2.1s | `process npx.CMD` | Guest pre-execute phase: `npx --no-install tsc --noEmit -p tsconfig.apphost.json` |
| 1.7s | `aspire.hosting.dcp.run_application` | Hosting DCP startup work |
| 1.0s | `process npm.CMD` | Start-time `npm install` |
| 11ms | `process aspire.exe` | Parent CLI spawning the detached child `run` process |

The main time is in TypeScript guest startup and readiness: `tsx` takes about 7.9s, and the child CLI spends about 7.1s waiting for the AppHost server backchannel. DCP startup is much smaller at about 1.7s, and child CLI process spawn is negligible.

Fixes # (issue)

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No