### PR TITLE
Add Node LTS matrix for TypeScript AppHost validation

### DIFF
--- a/.github/workflows/polyglot-validation.yml
+++ b/.github/workflows/polyglot-validation.yml
@@ -236,7 +236,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: [22, 24, 26]
+        node-version: ${{ fromJson(github.event_name == 'pull_request' && '[24]' || '[22,24]') }}
     steps:
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -285,6 +285,7 @@ jobs:
       - name: Run TypeScript SDK validation
         run: |
           docker run --rm \
+            -e ASPIRE_CLI_CHANNEL=${{ github.event_name == 'pull_request' && format('pr-{0}', github.event.pull_request.number) || 'daily' }} \
             -v "${{ github.workspace }}:/workspace" \
             -v /var/run/docker.sock:/var/run/docker.sock \
             polyglot-typescript-node-${{ matrix.node-version }}

--- a/.github/workflows/polyglot-validation.yml
+++ b/.github/workflows/polyglot-validation.yml
@@ -231,8 +231,12 @@ jobs:
             polyglot-rust
 
   validate_typescript:
-    name: TypeScript SDK Validation
+    name: TypeScript SDK Validation (Node ${{ matrix.node-version }}.x)
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        node-version: [22, 24, 26]
     steps:
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -273,8 +277,9 @@ jobs:
       - name: Build TypeScript validation image
         run: |
           docker build \
+            --build-arg NODE_VERSION=${{ matrix.node-version }} \
             -f .github/workflows/polyglot-validation/Dockerfile.typescript \
-            -t polyglot-typescript \
+            -t polyglot-typescript-node-${{ matrix.node-version }} \
             .github/workflows/polyglot-validation/
 
       - name: Run TypeScript SDK validation
@@ -282,7 +287,7 @@ jobs:
           docker run --rm \
             -v "${{ github.workspace }}:/workspace" \
             -v /var/run/docker.sock:/var/run/docker.sock \
-            polyglot-typescript
+            polyglot-typescript-node-${{ matrix.node-version }}
 
   results:
     if: always()

--- a/.github/workflows/polyglot-validation.yml
+++ b/.github/workflows/polyglot-validation.yml
@@ -11,6 +11,9 @@ on:
         required: false
         type: string
 
+env:
+  POLYGLOT_ASPIRE_CLI_CHANNEL: ${{ github.event_name == 'pull_request' && format('pr-{0}', github.event.pull_request.number) || 'daily' }}
+
 jobs:
   validate_python:
     name: Python SDK Validation
@@ -62,6 +65,7 @@ jobs:
       - name: Run Python SDK validation
         run: |
           docker run --rm \
+            -e ASPIRE_CLI_CHANNEL="${POLYGLOT_ASPIRE_CLI_CHANNEL}" \
             -v "${{ github.workspace }}:/workspace" \
             -v /var/run/docker.sock:/var/run/docker.sock \
             polyglot-python
@@ -116,6 +120,7 @@ jobs:
       - name: Run Go SDK validation
         run: |
           docker run --rm \
+            -e ASPIRE_CLI_CHANNEL="${POLYGLOT_ASPIRE_CLI_CHANNEL}" \
             -v "${{ github.workspace }}:/workspace" \
             -v /var/run/docker.sock:/var/run/docker.sock \
             polyglot-go
@@ -170,6 +175,7 @@ jobs:
       - name: Run Java SDK validation
         run: |
           docker run --rm \
+            -e ASPIRE_CLI_CHANNEL="${POLYGLOT_ASPIRE_CLI_CHANNEL}" \
             -v "${{ github.workspace }}:/workspace" \
             -v /var/run/docker.sock:/var/run/docker.sock \
             polyglot-java
@@ -226,6 +232,7 @@ jobs:
       - name: Run Rust SDK validation
         run: |
           docker run --rm \
+            -e ASPIRE_CLI_CHANNEL="${POLYGLOT_ASPIRE_CLI_CHANNEL}" \
             -v "${{ github.workspace }}:/workspace" \
             -v /var/run/docker.sock:/var/run/docker.sock \
             polyglot-rust
@@ -285,7 +292,7 @@ jobs:
       - name: Run TypeScript SDK validation
         run: |
           docker run --rm \
-            -e ASPIRE_CLI_CHANNEL=${{ github.event_name == 'pull_request' && format('pr-{0}', github.event.pull_request.number) || 'daily' }} \
+            -e ASPIRE_CLI_CHANNEL="${POLYGLOT_ASPIRE_CLI_CHANNEL}" \
             -v "${{ github.workspace }}:/workspace" \
             -v /var/run/docker.sock:/var/run/docker.sock \
             polyglot-typescript-node-${{ matrix.node-version }}

--- a/.github/workflows/polyglot-validation/Dockerfile.typescript
+++ b/.github/workflows/polyglot-validation/Dockerfile.typescript
@@ -13,6 +13,7 @@
 FROM ubuntu:24.04
 
 ARG NODE_VERSION=22
+ENV DEBIAN_FRONTEND=noninteractive
 
 # Install the requested Node.js runtime plus system dependencies.
 # Start from a neutral base so every matrix leg uses the same NodeSource-installed
@@ -25,6 +26,7 @@ RUN case "$NODE_VERSION" in 22|24|26) ;; *) echo "Unsupported NODE_VERSION: $NOD
     wget \
     docker.io \
     jq \
+    libicu-dev \
     && rm -rf /var/lib/apt/lists/* && \
     curl -fsSL "https://deb.nodesource.com/setup_${NODE_VERSION}.x" | bash - && \
     apt-get install -y --no-install-recommends \

--- a/.github/workflows/polyglot-validation/Dockerfile.typescript
+++ b/.github/workflows/polyglot-validation/Dockerfile.typescript
@@ -10,16 +10,26 @@
 #
 # Note: Expects self-extracting binary and NuGet artifacts to be pre-downloaded to /workspace/artifacts/
 #
-FROM mcr.microsoft.com/devcontainers/typescript-node:22
+FROM ubuntu:24.04
 
-# Ensure Yarn APT repository signing key is available (base image includes Yarn repo)
-RUN curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | gpg --dearmor | sudo tee /etc/apt/keyrings/yarn-archive-keyring.gpg > /dev/null
+ARG NODE_VERSION=22
 
-# Install system dependencies (wget, docker CLI, jq for JSON manipulation)
-RUN apt-get update && apt-get install -y \
+# Install the requested Node.js runtime plus system dependencies.
+# Start from a neutral base so every matrix leg uses the same NodeSource-installed
+# runtime rather than inheriting a specific Node version.
+RUN case "$NODE_VERSION" in 22|24|26) ;; *) echo "Unsupported NODE_VERSION: $NODE_VERSION" >&2; exit 1 ;; esac && \
+    apt-get update && apt-get install -y --no-install-recommends \
+    ca-certificates \
+    curl \
+    gpg \
     wget \
     docker.io \
     jq \
+    && rm -rf /var/lib/apt/lists/* && \
+    curl -fsSL "https://deb.nodesource.com/setup_${NODE_VERSION}.x" | bash - && \
+    apt-get install -y --no-install-recommends \
+    nodejs \
+    && node --version | grep -E "^v${NODE_VERSION}\\." \
     && rm -rf /var/lib/apt/lists/*
 
 # Pre-configure Aspire CLI path

--- a/.github/workflows/polyglot-validation/Dockerfile.typescript
+++ b/.github/workflows/polyglot-validation/Dockerfile.typescript
@@ -10,27 +10,19 @@
 #
 # Note: Expects self-extracting binary and NuGet artifacts to be pre-downloaded to /workspace/artifacts/
 #
-FROM ubuntu:24.04
+ARG NODE_VERSION=24
+FROM mcr.microsoft.com/devcontainers/typescript-node:${NODE_VERSION}
+ARG NODE_VERSION
 
-ARG NODE_VERSION=22
-ENV DEBIAN_FRONTEND=noninteractive
+# Ensure Yarn APT repository signing key is available (base image includes Yarn repo)
+RUN curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | gpg --dearmor | sudo tee /etc/apt/keyrings/yarn-archive-keyring.gpg > /dev/null
 
-# Install the requested Node.js runtime plus system dependencies.
-# Start from a neutral base so every matrix leg uses the same NodeSource-installed
-# runtime rather than inheriting a specific Node version.
-RUN case "$NODE_VERSION" in 22|24|26) ;; *) echo "Unsupported NODE_VERSION: $NODE_VERSION" >&2; exit 1 ;; esac && \
-    apt-get update && apt-get install -y --no-install-recommends \
-    ca-certificates \
-    curl \
-    gpg \
+# Install system dependencies and verify the MCR base image provides the requested Node.js runtime.
+RUN case "$NODE_VERSION" in 22|24) ;; *) echo "Unsupported NODE_VERSION: $NODE_VERSION" >&2; exit 1 ;; esac && \
+    apt-get update && apt-get install -y \
     wget \
     docker.io \
     jq \
-    libicu-dev \
-    && rm -rf /var/lib/apt/lists/* && \
-    curl -fsSL "https://deb.nodesource.com/setup_${NODE_VERSION}.x" | bash - && \
-    apt-get install -y --no-install-recommends \
-    nodejs \
     && node --version | grep -E "^v${NODE_VERSION}\\." \
     && rm -rf /var/lib/apt/lists/*
 

--- a/.github/workflows/polyglot-validation/setup-local-cli.sh
+++ b/.github/workflows/polyglot-validation/setup-local-cli.sh
@@ -44,13 +44,8 @@ fi
 
 # Auto-detect PR identity from .nupkg filenames (e.g. "Aspire.Hosting.AppHost.13.4.0-pr.16820.g3703c5c4.nupkg")
 # so PR-built packages land in the same hive the CLI's CliExecutionContext.Channel
-# resolves to ("pr-<N>").
-#
-# Polyglot validation is PR-only (gated in .github/workflows/tests.yml on
-# github.event_name == 'pull_request'). On non-PR builds the CLI archive is baked
-# with channel=daily/staging, the .nupkg filenames lack the -pr.<N>.gSHA suffix, and
-# this script has no way to derive a hive label that the CLI will look in — so we
-# fail loud instead of silently writing to hives/local/ where the CLI won't read.
+# resolves to ("pr-<N>"). Main branch validation passes ASPIRE_CLI_CHANNEL=daily
+# because main-built packages do not carry a PR suffix.
 #
 # Anchor on Aspire.Hosting.AppHost because:
 #   - It is the core MSBuild SDK package every AppHost references; removing/renaming it
@@ -73,11 +68,12 @@ fi
 SUFFIX=$(basename "$SAMPLE_NUPKG" | sed -nE 's/.*-(pr\.[0-9]+\.[0-9a-g]+).*\.nupkg$/\1/p')
 if [[ "$SUFFIX" =~ ^pr\.([0-9]+)\.[0-9a-g]+$ ]]; then
     HIVE_LABEL="pr-${BASH_REMATCH[1]}"
+elif [[ "${ASPIRE_CLI_CHANNEL:-}" =~ ^(daily|staging|local)$ ]]; then
+    HIVE_LABEL="$ASPIRE_CLI_CHANNEL"
 else
     echo "ERROR: Could not derive PR identity from $(basename "$SAMPLE_NUPKG")." >&2
-    echo "       Polyglot validation is PR-only and expects a '-pr.<N>.g<sha>' suffix on the built nupkgs." >&2
-    echo "       If you are seeing this on a non-PR build, the polyglot_validation job in tests.yml is" >&2
-    echo "       running outside its 'github.event_name == pull_request' guard." >&2
+    echo "       PR validation expects a '-pr.<N>.g<sha>' suffix on the built nupkgs." >&2
+    echo "       Non-PR validation must set ASPIRE_CLI_CHANNEL to daily, staging, or local." >&2
     exit 1
 fi
 HIVE_DIR="$ASPIRE_HOME/hives/$HIVE_LABEL/packages"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -194,13 +194,9 @@ jobs:
 
   polyglot_validation:
     name: Polyglot SDK Validation
-    # Polyglot validation only makes sense on pull_request runs: the CLI archive baked
-    # for push events to main/release/** carries channel=daily/staging, but
-    # setup-local-cli.sh writes packages into the auto-detected PR hive (hives/pr-<N>/).
-    # On non-PR builds there is no PR suffix in the .nupkg filenames, so the hive label
-    # cannot be derived and the validation would be a silent no-op. See
-    # .github/workflows/polyglot-validation/setup-local-cli.sh for the matching guard.
-    if: ${{ github.event_name == 'pull_request' }}
+    # Pull requests validate the current TypeScript AppHost LTS runtime. Main branch
+    # builds add the older supported LTS runtime without adding that cost to every PR.
+    if: ${{ github.event_name == 'pull_request' || github.ref == 'refs/heads/main' }}
     uses: ./.github/workflows/polyglot-validation.yml
     needs: [build_packages, build_cli_archive_linux]
     with:
@@ -408,9 +404,8 @@ jobs:
         #   tests, so an empty matrix and 'skipped' result are expected.
         # - cli_starter_validation_windows: this job only runs for pull requests and is expected to
         #   be skipped for other workflow events.
-        # - polyglot_validation: this job only runs for pull requests (the CLI archive baked for
-        #   non-PR events carries channel=daily/staging which setup-local-cli.sh cannot resolve
-        #   to a hive label) and is expected to be skipped for other workflow events.
+        # - polyglot_validation: this job runs for pull requests and main branch builds; it is
+        #   expected to be skipped for other workflow events.
         # All other jobs in this gate are required, and a 'skipped' result is treated as a failure.
         if: >-
           ${{ always() &&
@@ -431,12 +426,14 @@ jobs:
                  needs.polyglot_validation.result == 'skipped')) ||
                (github.event_name != 'pull_request' &&
                 (needs.extension_tests_win.result == 'skipped' ||
-                 needs.typescript_sdk_tests.result == 'skipped' ||
-                 needs.tests_no_nugets.result == 'skipped' ||
-                 needs.tests_requires_nugets_linux.result == 'skipped' ||
-                 needs.tests_requires_nugets_windows.result == 'skipped' ||
-                 (fromJson(needs.setup_for_tests.outputs.tests_matrix_requires_nugets_macos).include[0] != null &&
-                  needs.tests_requires_nugets_macos.result == 'skipped')))) }}
+                  needs.typescript_sdk_tests.result == 'skipped' ||
+                  needs.tests_no_nugets.result == 'skipped' ||
+                  needs.tests_requires_nugets_linux.result == 'skipped' ||
+                  needs.tests_requires_nugets_windows.result == 'skipped' ||
+                  (github.ref == 'refs/heads/main' &&
+                   needs.polyglot_validation.result == 'skipped') ||
+                  (fromJson(needs.setup_for_tests.outputs.tests_matrix_requires_nugets_macos).include[0] != null &&
+                   needs.tests_requires_nugets_macos.result == 'skipped')))) }}
         run: |
           echo "One or more dependent jobs failed."
           exit 1


### PR DESCRIPTION
## Description

TypeScript AppHost polyglot validation should prove the currently supported runtime without making every PR pay for every supported Node line. This keeps PR validation focused on the current Node LTS runtime and adds the older supported LTS runtime only on main branch builds.

The TypeScript validation image now uses the supported MCR devcontainer TypeScript Node image for the selected Node version instead of installing Node into an Ubuntu base. PR runs validate Node 24.x; main branch builds validate Node 22.x and 24.x. Node 25.x is intentionally not included, and this does not add TypeScript AppHost validation for Node 20.x.

Node 26.x is also intentionally not included in this PR because the supported MCR devcontainer TypeScript Node image does not currently publish a Node 26 tag. Adding Node 26 coverage would require returning to the unsupported Ubuntu/NodeSource image workaround that review feedback rejected.

Fixes: #17030

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No