### PR TITLE
Add render command link scenario

### DIFF
--- a/src/Aspire.Cli/Commands/RenderCommand.cs
+++ b/src/Aspire.Cli/Commands/RenderCommand.cs
@@ -48,6 +48,7 @@ internal sealed class RenderCommand : BaseCommand
         ["markdown-interactive"] = "Render markdown with DisplayMarkdown (interactive)",
         ["markdown-plain"] = "Render markdown as plain text with DisplayRawText (non-interactive)",
         ["markdown-renderable"] = "Render markdown via ConvertToRenderable with ANSI disabled",
+        ["links"] = "Render terminal links with SafeLink and SafeFileLink",
         ["debug-activities"] = "Debug pipeline activities (calls ProcessPublishingActivitiesDebugAsync)",
         ["pipeline-activities"] = "Pipeline activities with spinner (calls ProcessAndDisplayPublishingActivitiesAsync)",
         ["publish-summary-all"] = "Publish summary timeline (stress scenarios)",
@@ -124,8 +125,14 @@ internal sealed class RenderCommand : BaseCommand
             return CommandResult.FromExitCode(await ExecuteChoiceAsync(requestedScenario, parseResult.GetValue(s_consoleWidthOption), cancellationToken));
         }
 
+        var renderedPreviousChoice = false;
         while (true)
         {
+            if (renderedPreviousChoice)
+            {
+                InteractionService.DisplayEmptyLine();
+            }
+
             var choice = await InteractionService.PromptForSelectionAsync(
                 "What do you want to test?",
                 s_choices.Keys,
@@ -137,6 +144,8 @@ internal sealed class RenderCommand : BaseCommand
             {
                 return CommandResult.FromExitCode(exitCode);
             }
+
+            renderedPreviousChoice = true;
         }
     }
 
@@ -176,6 +185,8 @@ internal sealed class RenderCommand : BaseCommand
                     return TestMarkdownRenderPlainText();
                 case "markdown-renderable":
                     return TestMarkdownRenderRenderable();
+                case "links":
+                    return await TestLinksAsync(cancellationToken);
                 case "debug-activities":
                     return await RenderDebugActivitiesAsync(cancellationToken);
                 case "pipeline-activities":
@@ -369,6 +380,20 @@ internal sealed class RenderCommand : BaseCommand
 
         InteractionService.DisplayEmptyLine();
         InteractionService.DisplayMessage(KnownEmojis.StopSign, "Mixed methods test complete.");
+    }
+
+    private async Task<int> TestLinksAsync(CancellationToken cancellationToken)
+    {
+        var tempDirectory = Directory.CreateTempSubdirectory("aspire-render-links-");
+        var filePath = Path.Combine(tempDirectory.FullName, "safe file link sample.txt");
+        await File.WriteAllTextAsync(filePath, "This file is used to smoke test SafeFileLink rendering.", cancellationToken).ConfigureAwait(false);
+        InteractionService.DisplaySubtleMessage($"Temporary file created at {filePath}", allowMarkup: false);
+
+        InteractionService.DisplayPlainText($"Supports links: {InteractionService.SupportsLinks}");
+        InteractionService.DisplayMarkupLine($"SafeLink: {MarkupHelpers.SafeLink(InteractionService, "https://www.aspire.dev/", "Aspire documentation")}");
+        InteractionService.DisplayMarkupLine($"SafeFileLink: {MarkupHelpers.SafeFileLink(InteractionService, filePath)}");
+
+        return ExitCodeConstants.Success;
     }
 
     private int RenderPublishSummaryScenarios(IEnumerable<string> scenarioKeys)


### PR DESCRIPTION
## Description

Adds a debug-only render scenario for terminal links so CLI rendering can smoke test both `MarkupHelpers.SafeLink` and `MarkupHelpers.SafeFileLink` from the hidden `aspire render` command.

The new `links` scenario renders a link to Aspire documentation, creates a real file named `safe file link sample.txt` under a randomly named temp directory, and renders that file path with `SafeFileLink`. The interactive render loop also inserts a blank separator before showing the choices again after a previous scenario completes, which makes repeated render passes easier to scan.

<img width="1466" height="194" alt="image" src="https://github.com/user-attachments/assets/a217c7dc-48ff-4529-a1ef-75c72980bb07" />

Fixes https://github.com/microsoft/aspire/issues/16788

### User-facing usage

Debug builds can run the scenario directly:

```bash
aspire render --scenario links
```

Validation performed:

```text
dotnet build src/Aspire.Cli/Aspire.Cli.csproj
```

The build succeeded. It emitted copy retry warnings because an existing `aspire.exe` process was holding the debug apphost output, but the project built successfully.

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [x] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
