### PR TITLE
Use app token for automated PR pushes

### DIFF
--- a/.github/actions/create-pull-request/action.yml
+++ b/.github/actions/create-pull-request/action.yml
@@ -47,7 +47,10 @@ runs:
       env:
         GH_TOKEN: ${{ inputs.token }}
       run: |
-        # Use the provided token for both git and gh operations
+        # actions/checkout persists GITHUB_TOKEN as an extraheader by default. If
+        # that credential wins for git push, GitHub suppresses the PR synchronize
+        # workflows. Remove it so pushes use the supplied token instead.
+        git config --local --unset-all http.https://github.com/.extraheader || true
         gh auth setup-git
 
     - name: Commit and push changes
@@ -57,6 +60,7 @@ runs:
       env:
         BRANCH: ${{ inputs.branch }}
         COMMIT_MESSAGE: ${{ inputs.commit-message }}
+        GH_TOKEN: ${{ inputs.token }}
       run: |
         # Check for any changes (staged, unstaged, or untracked)
         if git diff --quiet && git diff --cached --quiet && [ -z "$(git ls-files --others --exclude-standard)" ]; then


### PR DESCRIPTION
Automated pull-request workflows create branches with a GitHub App token, but `actions/checkout` can leave the workflow `GITHUB_TOKEN` configured for later `git push` commands. When that credential is used, GitHub suppresses the `pull_request.synchronize` event, so CI does not run after automated PR updates.

This updates the shared `create-pull-request` action to remove checkout's persisted credential before configuring git with the supplied token, and makes the push step explicitly authenticate with that token. This keeps existing updater workflows on the shared action and avoids close/reopen workarounds.