### PR TITLE
feat(cli): aspire update --self refuses non-script install routes; route-aware notifications; #15600 fix (PR α)

### DIFF
--- a/src/Aspire.Cli/Acquisition/InstallSource.cs
+++ b/src/Aspire.Cli/Acquisition/InstallSource.cs
@@ -13,7 +13,8 @@ internal enum InstallSource
 {
     /// <summary>
     /// No sidecar was found, or the sidecar contained a value that does not
-    /// match any known route. Treated as legacy / pre-sidecar by callers.
+    /// match any known route. Callers fail closed unless an explicit override
+    /// applies.
     /// </summary>
     Unknown = 0,
 
@@ -55,8 +56,7 @@ internal static class InstallSourceExtensions
     /// <summary>
     /// Parses a sidecar <c>source</c> string into the strongly-typed enum.
     /// Returns <see cref="InstallSource.Unknown"/> for null, empty, or
-    /// unrecognized values so callers can treat unknown sources as a
-    /// legacy / pre-sidecar install.
+    /// unrecognized values so callers can apply their unknown-route policy.
     /// </summary>
     public static InstallSource ParseInstallSource(string? raw)
     {

--- a/src/Aspire.Cli/Acquisition/SelfUpdateRouter.cs
+++ b/src/Aspire.Cli/Acquisition/SelfUpdateRouter.cs
@@ -42,19 +42,14 @@ internal static class SelfUpdateRouter
     /// </summary>
     /// <remarks>
     /// <see cref="InstallSource.Script"/> stays in-process — it's the route
-    /// the CLI owns end-to-end. <see cref="InstallSource.Unknown"/> also stays
-    /// in-process for legacy compatibility: pre-PR-#16817 installs (script
-    /// route, before the sidecar contract shipped) have no sidecar, and
-    /// preserving in-process update for them avoids breaking working setups.
-    /// The PR-#16817-and-later install paths for the gated routes (PR / winget
-    /// / brew / dotnet-tool / localhive) all write sidecars at install time,
-    /// so a post-PR-#16817 binary appearing as <see cref="InstallSource.Unknown"/>
-    /// is almost certainly a legacy script install rather than one of those
-    /// routes.
+    /// the CLI owns end-to-end. Unknown routes are refused with a hint to
+    /// investigate the install or pass <c>--force</c>. The pre-PR-#16817
+    /// legacy script-install case is now covered by the <c>--force</c>
+    /// escape hatch.
     /// </remarks>
     public static SelfUpdateAction GetAction(InstallSource source) => source switch
     {
-        InstallSource.Script or InstallSource.Unknown => SelfUpdateAction.InProcess,
+        InstallSource.Script => SelfUpdateAction.InProcess,
         _ => SelfUpdateAction.Delegate,
     };
 }

--- a/src/Aspire.Cli/Acquisition/SelfUpdateRouter.cs
+++ b/src/Aspire.Cli/Acquisition/SelfUpdateRouter.cs
@@ -21,8 +21,11 @@ internal enum SelfUpdateAction
 
     /// <summary>
     /// Refuse to update in-process and instead print a route-appropriate
-    /// command via <see cref="IUpgradeInstructionProvider"/>. The exit
-    /// code is non-zero so scripts notice the no-op.
+    /// command via <see cref="IUpgradeInstructionProvider"/>. Returns
+    /// exit code 0 to match the existing dotnet-tool refusal contract;
+    /// callers that need to detect whether an update actually happened
+    /// should compare the binary version before and after the run rather
+    /// than relying on the exit code.
     /// </summary>
     Delegate,
 }

--- a/src/Aspire.Cli/Acquisition/SelfUpdateRouter.cs
+++ b/src/Aspire.Cli/Acquisition/SelfUpdateRouter.cs
@@ -1,0 +1,57 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Aspire.Cli.Acquisition;
+
+/// <summary>
+/// Decides how <c>aspire update --self</c> should behave for an
+/// <see cref="InstallSource"/>. The CLI can update itself in-process only
+/// for installs it owns end-to-end (script). Every other route is owned by
+/// a package manager or by a separate install path and would be corrupted
+/// by an in-process binary swap, so we delegate by printing an
+/// installer-appropriate command.
+/// </summary>
+internal enum SelfUpdateAction
+{
+    /// <summary>
+    /// Perform the existing in-process self-update flow
+    /// (<c>CliDownloader</c>-driven download + binary swap).
+    /// </summary>
+    InProcess,
+
+    /// <summary>
+    /// Refuse to update in-process and instead print a route-appropriate
+    /// command via <see cref="IUpgradeInstructionProvider"/>. The exit
+    /// code is non-zero so scripts notice the no-op.
+    /// </summary>
+    Delegate,
+}
+
+/// <summary>
+/// Pure policy lookup that maps <see cref="InstallSource"/> to the action
+/// <c>aspire update --self</c> must take.
+/// </summary>
+internal static class SelfUpdateRouter
+{
+    /// <summary>
+    /// Returns the action <c>aspire update --self</c> should perform for
+    /// the supplied <paramref name="source"/>.
+    /// </summary>
+    /// <remarks>
+    /// <see cref="InstallSource.Script"/> stays in-process — it's the route
+    /// the CLI owns end-to-end. <see cref="InstallSource.Unknown"/> also stays
+    /// in-process for legacy compatibility: pre-PR-#16817 installs (script
+    /// route, before the sidecar contract shipped) have no sidecar, and
+    /// preserving in-process update for them avoids breaking working setups.
+    /// The PR-#16817-and-later install paths for the gated routes (PR / winget
+    /// / brew / dotnet-tool / localhive) all write sidecars at install time,
+    /// so a post-PR-#16817 binary appearing as <see cref="InstallSource.Unknown"/>
+    /// is almost certainly a legacy script install rather than one of those
+    /// routes.
+    /// </remarks>
+    public static SelfUpdateAction GetAction(InstallSource source) => source switch
+    {
+        InstallSource.Script or InstallSource.Unknown => SelfUpdateAction.InProcess,
+        _ => SelfUpdateAction.Delegate,
+    };
+}

--- a/src/Aspire.Cli/Acquisition/UpgradeInstructionProvider.cs
+++ b/src/Aspire.Cli/Acquisition/UpgradeInstructionProvider.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using Aspire.Cli.Resources;
 using Aspire.Cli.Utils;
 
 namespace Aspire.Cli.Acquisition;
@@ -57,25 +58,31 @@ internal sealed class UpgradeInstructionProvider : IUpgradeInstructionProvider
             InstallSource.Winget => "winget upgrade Microsoft.Aspire",
             InstallSource.Brew => "brew upgrade --cask aspire",
 
-            // DotNetToolDetection.GetDotNetToolUpdateCommand (no-arg) honors
-            // the s_processPathOverride AsyncLocal used by tests AND inspects
-            // Environment.ProcessPath in production, returning the right
-            // command for `-g` (global) vs `--tool-path` installs. Falling
-            // back to the global form if path detection fails preserves the
-            // most common case.
-            InstallSource.DotnetTool => DotNetToolDetection.GetDotNetToolUpdateCommand()
-                ?? "dotnet tool update -g Aspire.Cli",
+            // Prefer the supplied process path so tests and callers can
+            // classify synthesized paths without depending on Environment.ProcessPath.
+            // When no path is supplied, the no-arg overload preserves the
+            // existing production behavior and AsyncLocal test override.
+            InstallSource.DotnetTool => GetDotNetToolUpdateCommand(processPath),
 
             // LocalHive installs are produced by re-running the dev script
             // in the user's own checkout. There is no canonical update
             // command — the user must rebuild from source.
-            InstallSource.LocalHive => "./localhive.sh   # re-run from your Aspire checkout",
+            InstallSource.LocalHive => "Run ./localhive.sh (Linux/macOS) or .\\localhive.ps1 (Windows) in the local hive directory.",
+            InstallSource.Unknown => UpdateCommandStrings.UnknownRouteRefusalHint,
 
             _ => null,
         };
     }
 
     private const string PrChannelPrefix = "pr-";
+
+    private static string GetDotNetToolUpdateCommand(string? processPath)
+    {
+        return (processPath is not null
+                ? DotNetToolDetection.GetDotNetToolUpdateCommand(processPath)
+                : DotNetToolDetection.GetDotNetToolUpdateCommand())
+            ?? "dotnet tool update -g Aspire.Cli";
+    }
 
     private static string GetPrUpdateCommand(string identityChannel)
     {

--- a/src/Aspire.Cli/Acquisition/UpgradeInstructionProvider.cs
+++ b/src/Aspire.Cli/Acquisition/UpgradeInstructionProvider.cs
@@ -1,0 +1,100 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Aspire.Cli.Utils;
+
+namespace Aspire.Cli.Acquisition;
+
+/// <summary>
+/// Returns the installer-appropriate command a user should run to update
+/// the Aspire CLI, given the install route that produced their binary.
+/// Consumed by <c>aspire update --self</c>'s refusal path and the
+/// "update available" notifier so users always see the right command
+/// for their install.
+/// </summary>
+internal interface IUpgradeInstructionProvider
+{
+    /// <summary>
+    /// Returns the command string a user should run to update an
+    /// installation produced by <paramref name="source"/>.
+    /// </summary>
+    /// <param name="source">Install route the running binary was placed by.</param>
+    /// <param name="processPath">Absolute path of the running binary. Used
+    /// only for <see cref="InstallSource.DotnetTool"/>: a global-tool
+    /// install (under <c>~/.dotnet/tools/.store/</c>) gets
+    /// <c>dotnet tool update -g Aspire.Cli</c>, a <c>--tool-path</c>
+    /// install gets the path-aware variant.</param>
+    /// <param name="identityChannel">The CLI's identity channel
+    /// (<c>CliExecutionContext.IdentityChannel</c>). Used only for
+    /// <see cref="InstallSource.Pr"/> to substitute the PR number into the
+    /// <c>get-aspire-cli-pr</c> command.</param>
+    /// <returns>
+    /// The command to print verbatim, or <see langword="null"/> for
+    /// <see cref="InstallSource.Script"/> (which stays in-process and has
+    /// no separate update command to display).
+    /// </returns>
+    string? GetUpdateCommand(InstallSource source, string? processPath, string identityChannel);
+}
+
+/// <summary>
+/// Default <see cref="IUpgradeInstructionProvider"/>. The mapping is a
+/// pure function of <c>(source, processPath, identityChannel)</c>; no
+/// I/O beyond the path-shape parsing already performed by
+/// <see cref="DotNetToolDetection"/> for the <see cref="InstallSource.DotnetTool"/>
+/// route.
+/// </summary>
+internal sealed class UpgradeInstructionProvider : IUpgradeInstructionProvider
+{
+    /// <inheritdoc />
+    public string? GetUpdateCommand(InstallSource source, string? processPath, string identityChannel)
+    {
+        return source switch
+        {
+            // Script is the in-process update path; no separate command to display.
+            InstallSource.Script => null,
+
+            InstallSource.Pr => GetPrUpdateCommand(identityChannel),
+            InstallSource.Winget => "winget upgrade Microsoft.Aspire",
+            InstallSource.Brew => "brew upgrade --cask aspire",
+
+            // DotNetToolDetection.GetDotNetToolUpdateCommand (no-arg) honors
+            // the s_processPathOverride AsyncLocal used by tests AND inspects
+            // Environment.ProcessPath in production, returning the right
+            // command for `-g` (global) vs `--tool-path` installs. Falling
+            // back to the global form if path detection fails preserves the
+            // most common case.
+            InstallSource.DotnetTool => DotNetToolDetection.GetDotNetToolUpdateCommand()
+                ?? "dotnet tool update -g Aspire.Cli",
+
+            // LocalHive installs are produced by re-running the dev script
+            // in the user's own checkout. There is no canonical update
+            // command — the user must rebuild from source.
+            InstallSource.LocalHive => "./localhive.sh   # re-run from your Aspire checkout",
+
+            _ => null,
+        };
+    }
+
+    private const string PrChannelPrefix = "pr-";
+
+    private static string GetPrUpdateCommand(string identityChannel)
+    {
+        // The PR channel form is `pr-<N>` (parsed and validated by
+        // IdentityChannelReader); extract the digits if present so the
+        // hint shows the actual PR number.
+        if (identityChannel.StartsWith(PrChannelPrefix, StringComparison.Ordinal) &&
+            identityChannel.Length > PrChannelPrefix.Length)
+        {
+            var prNumber = identityChannel[PrChannelPrefix.Length..];
+            // Print both POSIX and Windows install lines so the docs are
+            // discoverable regardless of which shell the user is on.
+            return $"get-aspire-cli-pr.sh {prNumber}    # or: get-aspire-cli-pr.ps1 -PRNumber {prNumber}";
+        }
+
+        // Defensive: if a PR-route sidecar coexists with a non-PR identity
+        // channel (theoretically impossible because PR archives bake the
+        // matching channel), emit the parameterised form so the user knows
+        // they need to supply the number.
+        return "get-aspire-cli-pr.sh <N>    # or: get-aspire-cli-pr.ps1 -PRNumber <N>";
+    }
+}

--- a/src/Aspire.Cli/Commands/UpdateCommand.cs
+++ b/src/Aspire.Cli/Commands/UpdateCommand.cs
@@ -43,6 +43,10 @@ internal sealed class UpdateCommand : BaseCommand
     {
         Description = UpdateCommandStrings.SelfOptionDescription
     };
+    private static readonly Option<bool> s_forceOption = new("--force")
+    {
+        Description = UpdateCommandStrings.ForceOptionDescription
+    };
     private static readonly Option<bool> s_yesOption = new("--yes")
     {
         Description = UpdateCommandStrings.YesOptionDescription,
@@ -90,6 +94,7 @@ internal sealed class UpdateCommand : BaseCommand
 
         Options.Add(s_appHostOption);
         Options.Add(s_selfOption);
+        Options.Add(s_forceOption);
         Options.Add(s_yesOption);
         Options.Add(s_nugetConfigDirOption);
 
@@ -317,14 +322,20 @@ internal sealed class UpdateCommand : BaseCommand
     private async Task<CommandResult> HandleSelfUpdateAsync(ParseResult parseResult, CancellationToken cancellationToken)
     {
         var (source, canonicalPath) = ResolveRunningInstall();
-        var action = SelfUpdateRouter.GetAction(source);
+        var force = parseResult.GetValue(s_forceOption);
+        var action = force ? SelfUpdateAction.InProcess : SelfUpdateRouter.GetAction(source);
+
+        if (force)
+        {
+            _logger.LogDebug("Forcing in-process self-update for detected install source '{InstallSource}' at '{CanonicalPath}'.", source, canonicalPath);
+        }
 
         if (action == SelfUpdateAction.Delegate)
         {
             return DisplaySelfUpdateRefusal(source, canonicalPath);
         }
 
-        // Script route: existing in-process flow.
+        // Script route, or explicit --force: existing in-process flow.
         if (_cliDownloader is null)
         {
             return CommandResult.Failure(ExitCodeConstants.InvalidCommand, "CLI self-update is not available in this environment.");
@@ -349,23 +360,14 @@ internal sealed class UpdateCommand : BaseCommand
     /// contract shipped still get classified as <see cref="InstallSource.DotnetTool"/>
     /// rather than <see cref="InstallSource.Unknown"/>.
     /// </summary>
-    /// <summary>
-    /// Resolves the install source and canonical binary path for the running CLI
-    /// via <see cref="IInstallationDiscovery.DescribeSelf"/> (the single source of
-    /// truth for "what is the running binary?"). Falls back to
-    /// <see cref="DotNetToolDetection"/> path-shape detection when no sidecar is
-    /// present, so legacy dotnet-tool installs created before the sidecar
-    /// contract shipped still get classified as <see cref="InstallSource.DotnetTool"/>
-    /// rather than <see cref="InstallSource.Unknown"/>.
-    /// </summary>
     /// <remarks>
     /// When the initial discovery reports no route (i.e., no sidecar on disk
     /// yet), runs <see cref="WingetFirstRunProbe"/> on the binary directory
     /// derived from the discovery's canonical path, then re-describes so the
     /// freshly-stamped sidecar is picked up. Without this, a fresh WinGet
     /// install whose very first invocation is <c>aspire update --self</c>
-    /// would classify as <see cref="InstallSource.Unknown"/>, route to
-    /// in-process update, and silently overwrite the WinGet-owned binary.
+    /// would classify as <see cref="InstallSource.Unknown"/> and be refused
+    /// until the user investigates or explicitly passes <c>--force</c>.
     /// The probe is idempotent and self-gates via
     /// <see cref="IWindowsRegistryReader"/>, so the call is a cheap no-op
     /// on non-Windows / non-WinGet installs.

--- a/src/Aspire.Cli/Commands/UpdateCommand.cs
+++ b/src/Aspire.Cli/Commands/UpdateCommand.cs
@@ -5,6 +5,7 @@ using System.CommandLine;
 using System.Diagnostics;
 using System.Globalization;
 using System.Runtime.InteropServices;
+using Aspire.Cli.Acquisition;
 using Aspire.Cli.Configuration;
 using Aspire.Cli.Exceptions;
 using Aspire.Cli.Interaction;
@@ -32,6 +33,8 @@ internal sealed class UpdateCommand : BaseCommand
     private readonly IFeatures _features;
     private readonly IConfigurationService _configurationService;
     private readonly IConfiguration _configuration;
+    private readonly IInstallationDiscovery _installationDiscovery;
+    private readonly IUpgradeInstructionProvider _upgradeInstructionProvider;
 
     private static readonly OptionWithLegacy<FileInfo?> s_appHostOption = new("--apphost", "--project", UpdateCommandStrings.ProjectArgumentDescription);
     private static readonly Option<bool> s_selfOption = new("--self")
@@ -62,7 +65,9 @@ internal sealed class UpdateCommand : BaseCommand
         CliExecutionContext executionContext,
         IConfigurationService configurationService,
         AspireCliTelemetry telemetry,
-        IConfiguration configuration)
+        IConfiguration configuration,
+        IInstallationDiscovery installationDiscovery,
+        IUpgradeInstructionProvider upgradeInstructionProvider)
         : base("update", UpdateCommandStrings.Description, features, updateNotifier, executionContext, interactionService, telemetry)
     {
         _projectLocator = projectLocator;
@@ -74,6 +79,8 @@ internal sealed class UpdateCommand : BaseCommand
         _features = features;
         _configurationService = configurationService;
         _configuration = configuration;
+        _installationDiscovery = installationDiscovery;
+        _upgradeInstructionProvider = upgradeInstructionProvider;
 
         Options.Add(s_appHostOption);
         Options.Add(s_selfOption);
@@ -106,11 +113,6 @@ internal sealed class UpdateCommand : BaseCommand
 
     protected override bool UpdateNotificationsEnabled => false;
 
-    private static string? GetDotNetToolUpdateCommand()
-    {
-        return DotNetToolDetection.GetDotNetToolUpdateCommand();
-    }
-
     protected override async Task<CommandResult> ExecuteAsync(ParseResult parseResult, CancellationToken cancellationToken)
     {
         var isSelfUpdate = parseResult.GetValue(s_selfOption);
@@ -118,28 +120,7 @@ internal sealed class UpdateCommand : BaseCommand
         // If --self is specified, handle CLI self-update
         if (isSelfUpdate)
         {
-            // When running as a dotnet tool, print the update command instead of executing
-            var dotNetToolUpdateCommand = GetDotNetToolUpdateCommand();
-            if (dotNetToolUpdateCommand is not null)
-            {
-                InteractionService.DisplayMessage(KnownEmojis.Information, UpdateCommandStrings.DotNetToolSelfUpdateMessage);
-                InteractionService.DisplayPlainText($"  {dotNetToolUpdateCommand}");
-                return CommandResult.FromExitCode(0);
-            }
-
-            if (_cliDownloader is null)
-            {
-                return CommandResult.Failure(ExitCodeConstants.InvalidCommand, "CLI self-update is not available in this environment.");
-            }
-
-            try
-            {
-                return await ExecuteSelfUpdateAsync(parseResult, cancellationToken);
-            }
-            catch (OperationCanceledException)
-            {
-                return CommandResult.Cancelled();
-            }
+            return await HandleSelfUpdateAsync(parseResult, cancellationToken);
         }
 
         // Otherwise, handle project update
@@ -257,12 +238,10 @@ internal sealed class UpdateCommand : BaseCommand
 
                 if (shouldUpdateCli)
                 {
-                    var dotNetToolUpdateCommand = GetDotNetToolUpdateCommand();
-                    if (dotNetToolUpdateCommand is not null)
+                    var (source, canonicalPath) = ResolveRunningInstall();
+                    if (SelfUpdateRouter.GetAction(source) == SelfUpdateAction.Delegate)
                     {
-                        InteractionService.DisplayMessage(KnownEmojis.Information, UpdateCommandStrings.DotNetToolSelfUpdateMessage);
-                        InteractionService.DisplayPlainText($"  {dotNetToolUpdateCommand}");
-                        return CommandResult.Success();
+                        return DisplaySelfUpdateRefusal(source, canonicalPath);
                     }
 
                     // Use the same channel that was selected for the project update
@@ -288,7 +267,7 @@ internal sealed class UpdateCommand : BaseCommand
             if (string.Equals(ex.Message, ErrorStrings.NoProjectFileFound, StringComparisons.CliInputOrOutput))
             {
                 // Only prompt for self-update if not running as dotnet tool and downloader is available
-                if (GetDotNetToolUpdateCommand() is null && _cliDownloader is not null)
+                if (!DotNetToolDetection.IsRunningAsDotNetTool() && _cliDownloader is not null)
                 {
                     var shouldUpdateCli = await InteractionService.PromptConfirmAsync(
                         UpdateCommandStrings.NoAppHostFoundUpdateCliPrompt,
@@ -297,6 +276,12 @@ internal sealed class UpdateCommand : BaseCommand
 
                     if (shouldUpdateCli)
                     {
+                        var (source, canonicalPath) = ResolveRunningInstall();
+                        if (SelfUpdateRouter.GetAction(source) == SelfUpdateAction.Delegate)
+                        {
+                            return DisplaySelfUpdateRefusal(source, canonicalPath);
+                        }
+
                         return await ExecuteSelfUpdateAsync(parseResult, cancellationToken);
                     }
                 }
@@ -311,6 +296,103 @@ internal sealed class UpdateCommand : BaseCommand
 
         return CommandResult.FromExitCode(0);
     }
+
+    /// <summary>
+    /// Routes <c>aspire update --self</c> based on the running CLI's install source.
+    /// Script installs perform the existing in-process binary swap; every other
+    /// route is refused with an installer-appropriate command from
+    /// <see cref="IUpgradeInstructionProvider"/> so we don't corrupt the
+    /// package-manager-owned binary or silently demote a PR-pinned install to
+    /// stable. Unknown / missing sidecars are refused defensively.
+    /// </summary>
+    private async Task<CommandResult> HandleSelfUpdateAsync(ParseResult parseResult, CancellationToken cancellationToken)
+    {
+        var (source, canonicalPath) = ResolveRunningInstall();
+        var action = SelfUpdateRouter.GetAction(source);
+
+        if (action == SelfUpdateAction.Delegate)
+        {
+            return DisplaySelfUpdateRefusal(source, canonicalPath);
+        }
+
+        // Script route: existing in-process flow.
+        if (_cliDownloader is null)
+        {
+            return CommandResult.Failure(ExitCodeConstants.InvalidCommand, "CLI self-update is not available in this environment.");
+        }
+
+        try
+        {
+            return await ExecuteSelfUpdateAsync(parseResult, cancellationToken);
+        }
+        catch (OperationCanceledException)
+        {
+            return CommandResult.Cancelled();
+        }
+    }
+
+    /// <summary>
+    /// Resolves the install source and canonical binary path for the running CLI
+    /// via <see cref="IInstallationDiscovery.DescribeSelf"/> (the single source of
+    /// truth for "what is the running binary?"). Falls back to
+    /// <see cref="DotNetToolDetection"/> path-shape detection when no sidecar is
+    /// present, so legacy dotnet-tool installs created before the sidecar
+    /// contract shipped still get classified as <see cref="InstallSource.DotnetTool"/>
+    /// rather than <see cref="InstallSource.Unknown"/>.
+    /// </summary>
+    private (InstallSource Source, string? CanonicalPath) ResolveRunningInstall()
+    {
+        var info = _installationDiscovery.DescribeSelf();
+        var source = InstallSourceExtensions.ParseInstallSource(info.Route);
+        var canonicalPath = info.CanonicalPath ?? info.Path;
+
+        // No-arg DotNetToolDetection.IsRunningAsDotNetTool honors the
+        // s_processPathOverride AsyncLocal used by tests, so this fallback
+        // recognizes legacy dotnet-tool installs (no sidecar baked) AND
+        // remains testable via UseProcessPathForTesting.
+        if (source == InstallSource.Unknown && DotNetToolDetection.IsRunningAsDotNetTool())
+        {
+            source = InstallSource.DotnetTool;
+        }
+
+        return (source, canonicalPath);
+    }
+
+    /// <summary>
+    /// Prints the installer-appropriate update command. Returns exit code 0
+    /// matching the existing dotnet-tool refusal contract — the CLI performed
+    /// its responsibility by telling the user what to run. Users who rely on
+    /// exit-code-based detection of "did this update?" should switch to checking
+    /// the version after the run, since the command may also succeed without
+    /// changing the binary if the user is already on the latest version.
+    /// </summary>
+    private CommandResult DisplaySelfUpdateRefusal(InstallSource source, string? canonicalPath)
+    {
+        var command = _upgradeInstructionProvider.GetUpdateCommand(
+            source,
+            canonicalPath,
+            ExecutionContext.IdentityChannel);
+
+        if (command is not null)
+        {
+            InteractionService.DisplayMessage(KnownEmojis.Information, GetSelfUpdateRefusalMessage(source));
+            InteractionService.DisplayPlainText($"  {command}");
+            return CommandResult.FromExitCode(0);
+        }
+
+        InteractionService.DisplayMessage(KnownEmojis.Warning, UpdateCommandStrings.SelfUpdateUnknownSourceMessage);
+        return CommandResult.Failure(ExitCodeConstants.InvalidCommand, "Cannot determine install source for self-update.");
+    }
+
+    private static string GetSelfUpdateRefusalMessage(InstallSource source) => source switch
+    {
+        InstallSource.DotnetTool => UpdateCommandStrings.DotNetToolSelfUpdateMessage,
+        InstallSource.Winget => UpdateCommandStrings.WingetSelfUpdateMessage,
+        InstallSource.Brew => UpdateCommandStrings.BrewSelfUpdateMessage,
+        InstallSource.Pr => UpdateCommandStrings.PrSelfUpdateMessage,
+        InstallSource.LocalHive => UpdateCommandStrings.LocalHiveSelfUpdateMessage,
+        _ => UpdateCommandStrings.SelfUpdateUnknownSourceMessage,
+    };
 
     private async Task<CommandResult> ExecuteSelfUpdateAsync(ParseResult parseResult, CancellationToken cancellationToken, string? selectedChannel = null)
     {

--- a/src/Aspire.Cli/Commands/UpdateCommand.cs
+++ b/src/Aspire.Cli/Commands/UpdateCommand.cs
@@ -36,6 +36,7 @@ internal sealed class UpdateCommand : BaseCommand
     private readonly IInstallationDiscovery _installationDiscovery;
     private readonly IUpgradeInstructionProvider _upgradeInstructionProvider;
     private readonly ICliHostEnvironment _hostEnvironment;
+    private readonly WingetFirstRunProbe _wingetFirstRunProbe;
 
     private static readonly OptionWithLegacy<FileInfo?> s_appHostOption = new("--apphost", "--project", UpdateCommandStrings.ProjectArgumentDescription);
     private static readonly Option<bool> s_selfOption = new("--self")
@@ -69,7 +70,8 @@ internal sealed class UpdateCommand : BaseCommand
         IConfiguration configuration,
         IInstallationDiscovery installationDiscovery,
         IUpgradeInstructionProvider upgradeInstructionProvider,
-        ICliHostEnvironment hostEnvironment)
+        ICliHostEnvironment hostEnvironment,
+        WingetFirstRunProbe wingetFirstRunProbe)
         : base("update", UpdateCommandStrings.Description, features, updateNotifier, executionContext, interactionService, telemetry)
     {
         _projectLocator = projectLocator;
@@ -84,6 +86,7 @@ internal sealed class UpdateCommand : BaseCommand
         _installationDiscovery = installationDiscovery;
         _upgradeInstructionProvider = upgradeInstructionProvider;
         _hostEnvironment = hostEnvironment;
+        _wingetFirstRunProbe = wingetFirstRunProbe;
 
         Options.Add(s_appHostOption);
         Options.Add(s_selfOption);
@@ -346,11 +349,44 @@ internal sealed class UpdateCommand : BaseCommand
     /// contract shipped still get classified as <see cref="InstallSource.DotnetTool"/>
     /// rather than <see cref="InstallSource.Unknown"/>.
     /// </summary>
+    /// <summary>
+    /// Resolves the install source and canonical binary path for the running CLI
+    /// via <see cref="IInstallationDiscovery.DescribeSelf"/> (the single source of
+    /// truth for "what is the running binary?"). Falls back to
+    /// <see cref="DotNetToolDetection"/> path-shape detection when no sidecar is
+    /// present, so legacy dotnet-tool installs created before the sidecar
+    /// contract shipped still get classified as <see cref="InstallSource.DotnetTool"/>
+    /// rather than <see cref="InstallSource.Unknown"/>.
+    /// </summary>
+    /// <remarks>
+    /// When the initial discovery reports no route (i.e., no sidecar on disk
+    /// yet), runs <see cref="WingetFirstRunProbe"/> on the binary directory
+    /// derived from the discovery's canonical path, then re-describes so the
+    /// freshly-stamped sidecar is picked up. Without this, a fresh WinGet
+    /// install whose very first invocation is <c>aspire update --self</c>
+    /// would classify as <see cref="InstallSource.Unknown"/>, route to
+    /// in-process update, and silently overwrite the WinGet-owned binary.
+    /// The probe is idempotent and self-gates via
+    /// <see cref="IWindowsRegistryReader"/>, so the call is a cheap no-op
+    /// on non-Windows / non-WinGet installs.
+    /// </remarks>
     private (InstallSource Source, string? CanonicalPath) ResolveRunningInstall()
     {
         var info = _installationDiscovery.DescribeSelf();
-        var source = InstallSourceExtensions.ParseInstallSource(info.Route);
         var canonicalPath = info.CanonicalPath ?? info.Path;
+
+        if (string.IsNullOrEmpty(info.Route) && !string.IsNullOrEmpty(canonicalPath))
+        {
+            var binaryDir = Path.GetDirectoryName(canonicalPath);
+            if (!string.IsNullOrEmpty(binaryDir))
+            {
+                _wingetFirstRunProbe.Run(binaryDir);
+                info = _installationDiscovery.DescribeSelf();
+                canonicalPath = info.CanonicalPath ?? info.Path;
+            }
+        }
+
+        var source = InstallSourceExtensions.ParseInstallSource(info.Route);
 
         // No-arg DotNetToolDetection.IsRunningAsDotNetTool honors the
         // s_processPathOverride AsyncLocal used by tests, so this fallback

--- a/src/Aspire.Cli/Commands/UpdateCommand.cs
+++ b/src/Aspire.Cli/Commands/UpdateCommand.cs
@@ -35,6 +35,7 @@ internal sealed class UpdateCommand : BaseCommand
     private readonly IConfiguration _configuration;
     private readonly IInstallationDiscovery _installationDiscovery;
     private readonly IUpgradeInstructionProvider _upgradeInstructionProvider;
+    private readonly ICliHostEnvironment _hostEnvironment;
 
     private static readonly OptionWithLegacy<FileInfo?> s_appHostOption = new("--apphost", "--project", UpdateCommandStrings.ProjectArgumentDescription);
     private static readonly Option<bool> s_selfOption = new("--self")
@@ -67,7 +68,8 @@ internal sealed class UpdateCommand : BaseCommand
         AspireCliTelemetry telemetry,
         IConfiguration configuration,
         IInstallationDiscovery installationDiscovery,
-        IUpgradeInstructionProvider upgradeInstructionProvider)
+        IUpgradeInstructionProvider upgradeInstructionProvider,
+        ICliHostEnvironment hostEnvironment)
         : base("update", UpdateCommandStrings.Description, features, updateNotifier, executionContext, interactionService, telemetry)
     {
         _projectLocator = projectLocator;
@@ -81,6 +83,7 @@ internal sealed class UpdateCommand : BaseCommand
         _configuration = configuration;
         _installationDiscovery = installationDiscovery;
         _upgradeInstructionProvider = upgradeInstructionProvider;
+        _hostEnvironment = hostEnvironment;
 
         Options.Add(s_appHostOption);
         Options.Add(s_selfOption);
@@ -187,11 +190,14 @@ internal sealed class UpdateCommand : BaseCommand
             }
             else
             {
-                // If there are hives (PR build directories), prompt for channel selection.
-                // Otherwise, use the implicit/default channel automatically.
+                // If there are hives (PR build directories) AND interactive
+                // input is available, prompt the user to pick a channel. In
+                // non-interactive mode the prompt would crash (#15600), so
+                // fall through to the implicit/default channel — same
+                // behavior as the no-hives branch.
                 var hasHives = ExecutionContext.GetHiveCount() > 0;
 
-                if (hasHives)
+                if (hasHives && _hostEnvironment.SupportsInteractiveInput)
                 {
                     // Prompt for channel selection
                     var channelBinding = PromptBinding.Create(parseResult, _channelOption);

--- a/src/Aspire.Cli/Configuration/AspireConfigFile.cs
+++ b/src/Aspire.Cli/Configuration/AspireConfigFile.cs
@@ -91,7 +91,7 @@ internal sealed class AspireConfigFile
     /// Aspire channel for package resolution.
     /// </summary>
     [JsonPropertyName("channel")]
-    [Description("The Aspire channel to use for package resolution (e.g., \"stable\", \"preview\", \"staging\", \"daily\"). Used by aspire add to determine which NuGet feed to use.")]
+    [Description("The Aspire channel to use for package resolution (e.g., \"stable\", \"staging\", \"daily\", or a per-PR \"pr-<N>\" label). Used by aspire add to determine which NuGet feed to use.")]
     public string? Channel { get; set; }
 
     /// <summary>

--- a/src/Aspire.Cli/Configuration/AspireJsonConfiguration.cs
+++ b/src/Aspire.Cli/Configuration/AspireJsonConfiguration.cs
@@ -43,11 +43,11 @@ internal sealed class AspireJsonConfiguration
     public string? Language { get; set; }
 
     /// <summary>
-    /// The Aspire channel to use for package resolution (e.g., "stable", "preview", "staging").
+    /// The Aspire channel to use for package resolution (e.g., "stable", "staging", "daily", or "pr-&lt;N&gt;").
     /// Used by aspire add to determine which NuGet feed to use.
     /// </summary>
     [JsonPropertyName("channel")]
-    [Description("The Aspire channel to use for package resolution (e.g., \"stable\", \"preview\", \"staging\"). Used by aspire add to determine which NuGet feed to use.")]
+    [Description("The Aspire channel to use for package resolution (e.g., \"stable\", \"staging\", \"daily\", or a per-PR \"pr-<N>\" label). Used by aspire add to determine which NuGet feed to use.")]
     public string? Channel { get; set; }
 
     /// <summary>

--- a/src/Aspire.Cli/Program.cs
+++ b/src/Aspire.Cli/Program.cs
@@ -408,6 +408,7 @@ public class Program
         builder.Services.AddSingleton<IPeerInstallProbe, PeerInstallProbe>();
         builder.Services.AddSingleton<IInstallationDiscovery, InstallationDiscovery>();
         builder.Services.AddSingleton<IInstallationUninstaller, InstallationUninstaller>();
+        builder.Services.AddSingleton<IUpgradeInstructionProvider, UpgradeInstructionProvider>();
         builder.Services.AddSingleton<IBundleService, BundleService>();
         builder.Services.AddSingleton<IAppHostServerProjectFactory, AppHostServerProjectFactory>();
         builder.Services.AddSingleton<ICliDownloader, CliDownloader>();

--- a/src/Aspire.Cli/Resources/UpdateCommandStrings.Designer.cs
+++ b/src/Aspire.Cli/Resources/UpdateCommandStrings.Designer.cs
@@ -112,6 +112,7 @@ namespace Aspire.Cli.Resources {
     internal static string PrSelfUpdateMessage => ResourceManager.GetString("PrSelfUpdateMessage", resourceCulture);
     internal static string LocalHiveSelfUpdateMessage => ResourceManager.GetString("LocalHiveSelfUpdateMessage", resourceCulture);
     internal static string SelfUpdateUnknownSourceMessage => ResourceManager.GetString("SelfUpdateUnknownSourceMessage", resourceCulture);
+    internal static string UnknownRouteRefusalHint => ResourceManager.GetString("UnknownRouteRefusalHint", resourceCulture);
     internal static string MigratedToNewSdkFormat => ResourceManager.GetString("MigratedToNewSdkFormat", resourceCulture);
     internal static string RemovedObsoleteAppHostPackage => ResourceManager.GetString("RemovedObsoleteAppHostPackage", resourceCulture);
     internal static string NoWritePermissionToInstallDirectory => ResourceManager.GetString("NoWritePermissionToInstallDirectory", resourceCulture);
@@ -122,6 +123,7 @@ namespace Aspire.Cli.Resources {
     internal static string RegeneratingSdkCode => ResourceManager.GetString("RegeneratingSdkCode", resourceCulture);
     internal static string RegeneratedSdkCode => ResourceManager.GetString("RegeneratedSdkCode", resourceCulture);
     internal static string SelfOptionDescription => ResourceManager.GetString("SelfOptionDescription", resourceCulture);
+    internal static string ForceOptionDescription => ResourceManager.GetString("ForceOptionDescription", resourceCulture);
     internal static string YesOptionDescription => ResourceManager.GetString("YesOptionDescription", resourceCulture);
     internal static string NuGetConfigDirOptionDescription => ResourceManager.GetString("NuGetConfigDirOptionDescription", resourceCulture);
     }

--- a/src/Aspire.Cli/Resources/UpdateCommandStrings.Designer.cs
+++ b/src/Aspire.Cli/Resources/UpdateCommandStrings.Designer.cs
@@ -107,6 +107,11 @@ namespace Aspire.Cli.Resources {
     internal static string QualityOptionDescription => ResourceManager.GetString("QualityOptionDescription", resourceCulture);
     internal static string QualityOptionDescriptionWithStaging => ResourceManager.GetString("QualityOptionDescriptionWithStaging", resourceCulture);
     internal static string DotNetToolSelfUpdateMessage => ResourceManager.GetString("DotNetToolSelfUpdateMessage", resourceCulture);
+    internal static string WingetSelfUpdateMessage => ResourceManager.GetString("WingetSelfUpdateMessage", resourceCulture);
+    internal static string BrewSelfUpdateMessage => ResourceManager.GetString("BrewSelfUpdateMessage", resourceCulture);
+    internal static string PrSelfUpdateMessage => ResourceManager.GetString("PrSelfUpdateMessage", resourceCulture);
+    internal static string LocalHiveSelfUpdateMessage => ResourceManager.GetString("LocalHiveSelfUpdateMessage", resourceCulture);
+    internal static string SelfUpdateUnknownSourceMessage => ResourceManager.GetString("SelfUpdateUnknownSourceMessage", resourceCulture);
     internal static string MigratedToNewSdkFormat => ResourceManager.GetString("MigratedToNewSdkFormat", resourceCulture);
     internal static string RemovedObsoleteAppHostPackage => ResourceManager.GetString("RemovedObsoleteAppHostPackage", resourceCulture);
     internal static string NoWritePermissionToInstallDirectory => ResourceManager.GetString("NoWritePermissionToInstallDirectory", resourceCulture);

--- a/src/Aspire.Cli/Resources/UpdateCommandStrings.resx
+++ b/src/Aspire.Cli/Resources/UpdateCommandStrings.resx
@@ -136,22 +136,25 @@
     <value>Quality level to update to (stable, staging, daily)</value>
   </data>
   <data name="DotNetToolSelfUpdateMessage" xml:space="preserve">
-    <value>To update the Aspire CLI when installed as a .NET tool, run:</value>
+    <value>To update the Aspire CLI when installed as a .NET tool, run (or pass `--force` as a last-resort override to attempt an in-process update):</value>
   </data>
   <data name="WingetSelfUpdateMessage" xml:space="preserve">
-    <value>This Aspire CLI was installed via WinGet. To update it, run:</value>
+    <value>This Aspire CLI was installed via WinGet. To update it, run (or pass `--force` as a last-resort override to attempt an in-process update):</value>
   </data>
   <data name="BrewSelfUpdateMessage" xml:space="preserve">
-    <value>This Aspire CLI was installed via Homebrew. To update it, run:</value>
+    <value>This Aspire CLI was installed via Homebrew. To update it, run (or pass `--force` as a last-resort override to attempt an in-process update):</value>
   </data>
   <data name="PrSelfUpdateMessage" xml:space="preserve">
-    <value>This Aspire CLI is a PR / dogfood build. It is pinned to a specific pull request; `--self` cannot update it. To re-install or update to a different PR, run:</value>
+    <value>This Aspire CLI is a PR / dogfood build. It is pinned to a specific pull request; `--self` cannot update it. To re-install or update to a different PR, run (or pass `--force` as a last-resort override to attempt an in-process update):</value>
   </data>
   <data name="LocalHiveSelfUpdateMessage" xml:space="preserve">
-    <value>This Aspire CLI is a local development build. To update it, rebuild from your Aspire checkout:</value>
+    <value>This Aspire CLI is a local development build. To update it, rebuild from your Aspire checkout (or pass `--force` as a last-resort override to attempt an in-process update):</value>
   </data>
   <data name="SelfUpdateUnknownSourceMessage" xml:space="preserve">
-    <value>Cannot determine how this Aspire CLI was installed (no install-route sidecar found). Refusing to perform an in-process self-update to avoid corrupting the binary. Re-run your original install command to update.</value>
+    <value>Cannot determine how this Aspire CLI was installed. Refusing to perform an in-process self-update to avoid corrupting the binary.</value>
+  </data>
+  <data name="UnknownRouteRefusalHint" xml:space="preserve">
+    <value>Aspire couldn't determine how this CLI was installed (`.aspire-install.json` is missing, unreadable, or has an unrecognized route). Investigate the install, or pass `--force` to attempt an in-process update anyway.</value>
   </data>
   <data name="MigratedToNewSdkFormat" xml:space="preserve">
     <value>Migrated to new project format: &lt;Project Sdk="Aspire.AppHost.Sdk/{0}"&gt;</value>
@@ -182,6 +185,9 @@
   </data>
   <data name="SelfOptionDescription" xml:space="preserve">
     <value>Update the Aspire CLI itself to the latest version</value>
+  </data>
+  <data name="ForceOptionDescription" xml:space="preserve">
+    <value>Attempt an in-process self-update even when the install route is normally refused</value>
   </data>
   <data name="YesOptionDescription" xml:space="preserve">
     <value>Automatically confirm all update prompts without asking</value>

--- a/src/Aspire.Cli/Resources/UpdateCommandStrings.resx
+++ b/src/Aspire.Cli/Resources/UpdateCommandStrings.resx
@@ -138,6 +138,21 @@
   <data name="DotNetToolSelfUpdateMessage" xml:space="preserve">
     <value>To update the Aspire CLI when installed as a .NET tool, run:</value>
   </data>
+  <data name="WingetSelfUpdateMessage" xml:space="preserve">
+    <value>This Aspire CLI was installed via WinGet. To update it, run:</value>
+  </data>
+  <data name="BrewSelfUpdateMessage" xml:space="preserve">
+    <value>This Aspire CLI was installed via Homebrew. To update it, run:</value>
+  </data>
+  <data name="PrSelfUpdateMessage" xml:space="preserve">
+    <value>This Aspire CLI is a PR / dogfood build. It is pinned to a specific pull request; `--self` cannot update it. To re-install or update to a different PR, run:</value>
+  </data>
+  <data name="LocalHiveSelfUpdateMessage" xml:space="preserve">
+    <value>This Aspire CLI is a local development build. To update it, rebuild from your Aspire checkout:</value>
+  </data>
+  <data name="SelfUpdateUnknownSourceMessage" xml:space="preserve">
+    <value>Cannot determine how this Aspire CLI was installed (no install-route sidecar found). Refusing to perform an in-process self-update to avoid corrupting the binary. Re-run your original install command to update.</value>
+  </data>
   <data name="MigratedToNewSdkFormat" xml:space="preserve">
     <value>Migrated to new project format: &lt;Project Sdk="Aspire.AppHost.Sdk/{0}"&gt;</value>
   </data>

--- a/src/Aspire.Cli/Resources/xlf/UpdateCommandStrings.cs.xlf
+++ b/src/Aspire.Cli/Resources/xlf/UpdateCommandStrings.cs.xlf
@@ -38,8 +38,8 @@
         <note />
       </trans-unit>
       <trans-unit id="BrewSelfUpdateMessage">
-        <source>This Aspire CLI was installed via Homebrew. To update it, run:</source>
-        <target state="new">This Aspire CLI was installed via Homebrew. To update it, run:</target>
+        <source>This Aspire CLI was installed via Homebrew. To update it, run (or pass `--force` as a last-resort override to attempt an in-process update):</source>
+        <target state="new">This Aspire CLI was installed via Homebrew. To update it, run (or pass `--force` as a last-resort override to attempt an in-process update):</target>
         <note />
       </trans-unit>
       <trans-unit id="CentralPackageManagementNotSupported">
@@ -83,8 +83,8 @@
         <note />
       </trans-unit>
       <trans-unit id="DotNetToolSelfUpdateMessage">
-        <source>To update the Aspire CLI when installed as a .NET tool, run:</source>
-        <target state="translated">Chcete-li aktualizovat rozhraní příkazového řádku Aspire, pokud je nainstalované jako nástroj .NET, spusťte:</target>
+        <source>To update the Aspire CLI when installed as a .NET tool, run (or pass `--force` as a last-resort override to attempt an in-process update):</source>
+        <target state="needs-review-translation">Chcete-li aktualizovat rozhraní příkazového řádku Aspire, pokud je nainstalované jako nástroj .NET, spusťte:</target>
         <note />
       </trans-unit>
       <trans-unit id="ExecutingUpdateStepFormat">
@@ -122,9 +122,14 @@
         <target state="needs-review-translation">Poznámka: Plán aktualizace byl vygenerován pomocí náhradní analýzy kvůli nevyřešitelné sadě AppHost SDK. Analýza závislostí může mít sníženou přesnost.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ForceOptionDescription">
+        <source>Attempt an in-process self-update even when the install route is normally refused</source>
+        <target state="new">Attempt an in-process self-update even when the install route is normally refused</target>
+        <note />
+      </trans-unit>
       <trans-unit id="LocalHiveSelfUpdateMessage">
-        <source>This Aspire CLI is a local development build. To update it, rebuild from your Aspire checkout:</source>
-        <target state="new">This Aspire CLI is a local development build. To update it, rebuild from your Aspire checkout:</target>
+        <source>This Aspire CLI is a local development build. To update it, rebuild from your Aspire checkout (or pass `--force` as a last-resort override to attempt an in-process update):</source>
+        <target state="new">This Aspire CLI is a local development build. To update it, rebuild from your Aspire checkout (or pass `--force` as a last-resort override to attempt an in-process update):</target>
         <note />
       </trans-unit>
       <trans-unit id="MappingAddedFormat">
@@ -193,8 +198,8 @@
         <note />
       </trans-unit>
       <trans-unit id="PrSelfUpdateMessage">
-        <source>This Aspire CLI is a PR / dogfood build. It is pinned to a specific pull request; `--self` cannot update it. To re-install or update to a different PR, run:</source>
-        <target state="new">This Aspire CLI is a PR / dogfood build. It is pinned to a specific pull request; `--self` cannot update it. To re-install or update to a different PR, run:</target>
+        <source>This Aspire CLI is a PR / dogfood build. It is pinned to a specific pull request; `--self` cannot update it. To re-install or update to a different PR, run (or pass `--force` as a last-resort override to attempt an in-process update):</source>
+        <target state="new">This Aspire CLI is a PR / dogfood build. It is pinned to a specific pull request; `--self` cannot update it. To re-install or update to a different PR, run (or pass `--force` as a last-resort override to attempt an in-process update):</target>
         <note />
       </trans-unit>
       <trans-unit id="ProjectArgumentDescription">
@@ -258,8 +263,13 @@
         <note />
       </trans-unit>
       <trans-unit id="SelfUpdateUnknownSourceMessage">
-        <source>Cannot determine how this Aspire CLI was installed (no install-route sidecar found). Refusing to perform an in-process self-update to avoid corrupting the binary. Re-run your original install command to update.</source>
-        <target state="new">Cannot determine how this Aspire CLI was installed (no install-route sidecar found). Refusing to perform an in-process self-update to avoid corrupting the binary. Re-run your original install command to update.</target>
+        <source>Cannot determine how this Aspire CLI was installed. Refusing to perform an in-process self-update to avoid corrupting the binary.</source>
+        <target state="new">Cannot determine how this Aspire CLI was installed. Refusing to perform an in-process self-update to avoid corrupting the binary.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UnknownRouteRefusalHint">
+        <source>Aspire couldn't determine how this CLI was installed (`.aspire-install.json` is missing, unreadable, or has an unrecognized route). Investigate the install, or pass `--force` to attempt an in-process update anyway.</source>
+        <target state="new">Aspire couldn't determine how this CLI was installed (`.aspire-install.json` is missing, unreadable, or has an unrecognized route). Investigate the install, or pass `--force` to attempt an in-process update anyway.</target>
         <note />
       </trans-unit>
       <trans-unit id="UnxpectedCodePath">
@@ -288,8 +298,8 @@
         <note />
       </trans-unit>
       <trans-unit id="WingetSelfUpdateMessage">
-        <source>This Aspire CLI was installed via WinGet. To update it, run:</source>
-        <target state="new">This Aspire CLI was installed via WinGet. To update it, run:</target>
+        <source>This Aspire CLI was installed via WinGet. To update it, run (or pass `--force` as a last-resort override to attempt an in-process update):</source>
+        <target state="new">This Aspire CLI was installed via WinGet. To update it, run (or pass `--force` as a last-resort override to attempt an in-process update):</target>
         <note />
       </trans-unit>
       <trans-unit id="YesOptionDescription">

--- a/src/Aspire.Cli/Resources/xlf/UpdateCommandStrings.cs.xlf
+++ b/src/Aspire.Cli/Resources/xlf/UpdateCommandStrings.cs.xlf
@@ -37,6 +37,11 @@
         <target state="translated">Používají se aktualizace…</target>
         <note />
       </trans-unit>
+      <trans-unit id="BrewSelfUpdateMessage">
+        <source>This Aspire CLI was installed via Homebrew. To update it, run:</source>
+        <target state="new">This Aspire CLI was installed via Homebrew. To update it, run:</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CentralPackageManagementNotSupported">
         <source>Central package management is currently not supported by 'aspire update'.</source>
         <target state="translated">Centrální správa balíčků není v současné době přes aspire update podporována.</target>
@@ -117,6 +122,11 @@
         <target state="needs-review-translation">Poznámka: Plán aktualizace byl vygenerován pomocí náhradní analýzy kvůli nevyřešitelné sadě AppHost SDK. Analýza závislostí může mít sníženou přesnost.</target>
         <note />
       </trans-unit>
+      <trans-unit id="LocalHiveSelfUpdateMessage">
+        <source>This Aspire CLI is a local development build. To update it, rebuild from your Aspire checkout:</source>
+        <target state="new">This Aspire CLI is a local development build. To update it, rebuild from your Aspire checkout:</target>
+        <note />
+      </trans-unit>
       <trans-unit id="MappingAddedFormat">
         <source>   Mapping: {0} (added)</source>
         <target state="translated">   Mapování: {0} (přidáno)</target>
@@ -182,6 +192,11 @@
         <target state="translated">Provést aktualizace?</target>
         <note />
       </trans-unit>
+      <trans-unit id="PrSelfUpdateMessage">
+        <source>This Aspire CLI is a PR / dogfood build. It is pinned to a specific pull request; `--self` cannot update it. To re-install or update to a different PR, run:</source>
+        <target state="new">This Aspire CLI is a PR / dogfood build. It is pinned to a specific pull request; `--self` cannot update it. To re-install or update to a different PR, run:</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ProjectArgumentDescription">
         <source>The path to the Aspire AppHost project file or a directory to search</source>
         <target state="needs-review-translation">Cesta k souboru projektu Aspire AppHost.</target>
@@ -242,6 +257,11 @@
         <target state="new">Update the Aspire CLI itself to the latest version</target>
         <note />
       </trans-unit>
+      <trans-unit id="SelfUpdateUnknownSourceMessage">
+        <source>Cannot determine how this Aspire CLI was installed (no install-route sidecar found). Refusing to perform an in-process self-update to avoid corrupting the binary. Re-run your original install command to update.</source>
+        <target state="new">Cannot determine how this Aspire CLI was installed (no install-route sidecar found). Refusing to perform an in-process self-update to avoid corrupting the binary. Re-run your original install command to update.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="UnxpectedCodePath">
         <source>Unexpected code path.</source>
         <target state="translated">Neočekávaná cesta kódu.</target>
@@ -265,6 +285,11 @@
       <trans-unit id="WhichDirectoryNuGetConfigPrompt">
         <source>Which directory for NuGet.config file?</source>
         <target state="translated">Který adresář pro soubor NuGet.config?</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WingetSelfUpdateMessage">
+        <source>This Aspire CLI was installed via WinGet. To update it, run:</source>
+        <target state="new">This Aspire CLI was installed via WinGet. To update it, run:</target>
         <note />
       </trans-unit>
       <trans-unit id="YesOptionDescription">

--- a/src/Aspire.Cli/Resources/xlf/UpdateCommandStrings.de.xlf
+++ b/src/Aspire.Cli/Resources/xlf/UpdateCommandStrings.de.xlf
@@ -38,8 +38,8 @@
         <note />
       </trans-unit>
       <trans-unit id="BrewSelfUpdateMessage">
-        <source>This Aspire CLI was installed via Homebrew. To update it, run:</source>
-        <target state="new">This Aspire CLI was installed via Homebrew. To update it, run:</target>
+        <source>This Aspire CLI was installed via Homebrew. To update it, run (or pass `--force` as a last-resort override to attempt an in-process update):</source>
+        <target state="new">This Aspire CLI was installed via Homebrew. To update it, run (or pass `--force` as a last-resort override to attempt an in-process update):</target>
         <note />
       </trans-unit>
       <trans-unit id="CentralPackageManagementNotSupported">
@@ -83,8 +83,8 @@
         <note />
       </trans-unit>
       <trans-unit id="DotNetToolSelfUpdateMessage">
-        <source>To update the Aspire CLI when installed as a .NET tool, run:</source>
-        <target state="translated">Um die Aspire-CLI bei der Installation als .NET-Tool zu aktualisieren, führen Sie folgende Schritte aus:</target>
+        <source>To update the Aspire CLI when installed as a .NET tool, run (or pass `--force` as a last-resort override to attempt an in-process update):</source>
+        <target state="needs-review-translation">Um die Aspire-CLI bei der Installation als .NET-Tool zu aktualisieren, führen Sie folgende Schritte aus:</target>
         <note />
       </trans-unit>
       <trans-unit id="ExecutingUpdateStepFormat">
@@ -122,9 +122,14 @@
         <target state="needs-review-translation">Hinweis: Aktualisieren Sie den Plan, der mithilfe der Fallbackanalyse generiert wurde, da das AppHost-SDK nicht auflösbar ist. Die Abhängigkeitsanalyse weist möglicherweise eine geringere Genauigkeit auf.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ForceOptionDescription">
+        <source>Attempt an in-process self-update even when the install route is normally refused</source>
+        <target state="new">Attempt an in-process self-update even when the install route is normally refused</target>
+        <note />
+      </trans-unit>
       <trans-unit id="LocalHiveSelfUpdateMessage">
-        <source>This Aspire CLI is a local development build. To update it, rebuild from your Aspire checkout:</source>
-        <target state="new">This Aspire CLI is a local development build. To update it, rebuild from your Aspire checkout:</target>
+        <source>This Aspire CLI is a local development build. To update it, rebuild from your Aspire checkout (or pass `--force` as a last-resort override to attempt an in-process update):</source>
+        <target state="new">This Aspire CLI is a local development build. To update it, rebuild from your Aspire checkout (or pass `--force` as a last-resort override to attempt an in-process update):</target>
         <note />
       </trans-unit>
       <trans-unit id="MappingAddedFormat">
@@ -193,8 +198,8 @@
         <note />
       </trans-unit>
       <trans-unit id="PrSelfUpdateMessage">
-        <source>This Aspire CLI is a PR / dogfood build. It is pinned to a specific pull request; `--self` cannot update it. To re-install or update to a different PR, run:</source>
-        <target state="new">This Aspire CLI is a PR / dogfood build. It is pinned to a specific pull request; `--self` cannot update it. To re-install or update to a different PR, run:</target>
+        <source>This Aspire CLI is a PR / dogfood build. It is pinned to a specific pull request; `--self` cannot update it. To re-install or update to a different PR, run (or pass `--force` as a last-resort override to attempt an in-process update):</source>
+        <target state="new">This Aspire CLI is a PR / dogfood build. It is pinned to a specific pull request; `--self` cannot update it. To re-install or update to a different PR, run (or pass `--force` as a last-resort override to attempt an in-process update):</target>
         <note />
       </trans-unit>
       <trans-unit id="ProjectArgumentDescription">
@@ -258,8 +263,13 @@
         <note />
       </trans-unit>
       <trans-unit id="SelfUpdateUnknownSourceMessage">
-        <source>Cannot determine how this Aspire CLI was installed (no install-route sidecar found). Refusing to perform an in-process self-update to avoid corrupting the binary. Re-run your original install command to update.</source>
-        <target state="new">Cannot determine how this Aspire CLI was installed (no install-route sidecar found). Refusing to perform an in-process self-update to avoid corrupting the binary. Re-run your original install command to update.</target>
+        <source>Cannot determine how this Aspire CLI was installed. Refusing to perform an in-process self-update to avoid corrupting the binary.</source>
+        <target state="new">Cannot determine how this Aspire CLI was installed. Refusing to perform an in-process self-update to avoid corrupting the binary.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UnknownRouteRefusalHint">
+        <source>Aspire couldn't determine how this CLI was installed (`.aspire-install.json` is missing, unreadable, or has an unrecognized route). Investigate the install, or pass `--force` to attempt an in-process update anyway.</source>
+        <target state="new">Aspire couldn't determine how this CLI was installed (`.aspire-install.json` is missing, unreadable, or has an unrecognized route). Investigate the install, or pass `--force` to attempt an in-process update anyway.</target>
         <note />
       </trans-unit>
       <trans-unit id="UnxpectedCodePath">
@@ -288,8 +298,8 @@
         <note />
       </trans-unit>
       <trans-unit id="WingetSelfUpdateMessage">
-        <source>This Aspire CLI was installed via WinGet. To update it, run:</source>
-        <target state="new">This Aspire CLI was installed via WinGet. To update it, run:</target>
+        <source>This Aspire CLI was installed via WinGet. To update it, run (or pass `--force` as a last-resort override to attempt an in-process update):</source>
+        <target state="new">This Aspire CLI was installed via WinGet. To update it, run (or pass `--force` as a last-resort override to attempt an in-process update):</target>
         <note />
       </trans-unit>
       <trans-unit id="YesOptionDescription">

--- a/src/Aspire.Cli/Resources/xlf/UpdateCommandStrings.de.xlf
+++ b/src/Aspire.Cli/Resources/xlf/UpdateCommandStrings.de.xlf
@@ -37,6 +37,11 @@
         <target state="translated">Updates werden angewendet...</target>
         <note />
       </trans-unit>
+      <trans-unit id="BrewSelfUpdateMessage">
+        <source>This Aspire CLI was installed via Homebrew. To update it, run:</source>
+        <target state="new">This Aspire CLI was installed via Homebrew. To update it, run:</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CentralPackageManagementNotSupported">
         <source>Central package management is currently not supported by 'aspire update'.</source>
         <target state="translated">Die zentrale Paketverwaltung wird von „aspire update“ zurzeit nicht unterstützt.</target>
@@ -117,6 +122,11 @@
         <target state="needs-review-translation">Hinweis: Aktualisieren Sie den Plan, der mithilfe der Fallbackanalyse generiert wurde, da das AppHost-SDK nicht auflösbar ist. Die Abhängigkeitsanalyse weist möglicherweise eine geringere Genauigkeit auf.</target>
         <note />
       </trans-unit>
+      <trans-unit id="LocalHiveSelfUpdateMessage">
+        <source>This Aspire CLI is a local development build. To update it, rebuild from your Aspire checkout:</source>
+        <target state="new">This Aspire CLI is a local development build. To update it, rebuild from your Aspire checkout:</target>
+        <note />
+      </trans-unit>
       <trans-unit id="MappingAddedFormat">
         <source>   Mapping: {0} (added)</source>
         <target state="translated">   Zuordnung: {0} (hinzugefügt)</target>
@@ -182,6 +192,11 @@
         <target state="translated">Update ausführen?</target>
         <note />
       </trans-unit>
+      <trans-unit id="PrSelfUpdateMessage">
+        <source>This Aspire CLI is a PR / dogfood build. It is pinned to a specific pull request; `--self` cannot update it. To re-install or update to a different PR, run:</source>
+        <target state="new">This Aspire CLI is a PR / dogfood build. It is pinned to a specific pull request; `--self` cannot update it. To re-install or update to a different PR, run:</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ProjectArgumentDescription">
         <source>The path to the Aspire AppHost project file or a directory to search</source>
         <target state="needs-review-translation">Der Pfad zur Aspire AppHost-Projektdatei.</target>
@@ -242,6 +257,11 @@
         <target state="new">Update the Aspire CLI itself to the latest version</target>
         <note />
       </trans-unit>
+      <trans-unit id="SelfUpdateUnknownSourceMessage">
+        <source>Cannot determine how this Aspire CLI was installed (no install-route sidecar found). Refusing to perform an in-process self-update to avoid corrupting the binary. Re-run your original install command to update.</source>
+        <target state="new">Cannot determine how this Aspire CLI was installed (no install-route sidecar found). Refusing to perform an in-process self-update to avoid corrupting the binary. Re-run your original install command to update.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="UnxpectedCodePath">
         <source>Unexpected code path.</source>
         <target state="translated">Unerwarteter Codepfad</target>
@@ -265,6 +285,11 @@
       <trans-unit id="WhichDirectoryNuGetConfigPrompt">
         <source>Which directory for NuGet.config file?</source>
         <target state="translated">Welches Verzeichnis für die NuGet.config-Datei?</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WingetSelfUpdateMessage">
+        <source>This Aspire CLI was installed via WinGet. To update it, run:</source>
+        <target state="new">This Aspire CLI was installed via WinGet. To update it, run:</target>
         <note />
       </trans-unit>
       <trans-unit id="YesOptionDescription">

--- a/src/Aspire.Cli/Resources/xlf/UpdateCommandStrings.es.xlf
+++ b/src/Aspire.Cli/Resources/xlf/UpdateCommandStrings.es.xlf
@@ -38,8 +38,8 @@
         <note />
       </trans-unit>
       <trans-unit id="BrewSelfUpdateMessage">
-        <source>This Aspire CLI was installed via Homebrew. To update it, run:</source>
-        <target state="new">This Aspire CLI was installed via Homebrew. To update it, run:</target>
+        <source>This Aspire CLI was installed via Homebrew. To update it, run (or pass `--force` as a last-resort override to attempt an in-process update):</source>
+        <target state="new">This Aspire CLI was installed via Homebrew. To update it, run (or pass `--force` as a last-resort override to attempt an in-process update):</target>
         <note />
       </trans-unit>
       <trans-unit id="CentralPackageManagementNotSupported">
@@ -83,8 +83,8 @@
         <note />
       </trans-unit>
       <trans-unit id="DotNetToolSelfUpdateMessage">
-        <source>To update the Aspire CLI when installed as a .NET tool, run:</source>
-        <target state="translated">Para actualizar la CLI de Aspire cuando está instalada como herramienta de .NET, ejecute:</target>
+        <source>To update the Aspire CLI when installed as a .NET tool, run (or pass `--force` as a last-resort override to attempt an in-process update):</source>
+        <target state="needs-review-translation">Para actualizar la CLI de Aspire cuando está instalada como herramienta de .NET, ejecute:</target>
         <note />
       </trans-unit>
       <trans-unit id="ExecutingUpdateStepFormat">
@@ -122,9 +122,14 @@
         <target state="needs-review-translation">Nota: El plan de actualización se generó usando un análisis alternativo debido a un SDK de AppHost no resoluble. El análisis de dependencias puede ser menos preciso.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ForceOptionDescription">
+        <source>Attempt an in-process self-update even when the install route is normally refused</source>
+        <target state="new">Attempt an in-process self-update even when the install route is normally refused</target>
+        <note />
+      </trans-unit>
       <trans-unit id="LocalHiveSelfUpdateMessage">
-        <source>This Aspire CLI is a local development build. To update it, rebuild from your Aspire checkout:</source>
-        <target state="new">This Aspire CLI is a local development build. To update it, rebuild from your Aspire checkout:</target>
+        <source>This Aspire CLI is a local development build. To update it, rebuild from your Aspire checkout (or pass `--force` as a last-resort override to attempt an in-process update):</source>
+        <target state="new">This Aspire CLI is a local development build. To update it, rebuild from your Aspire checkout (or pass `--force` as a last-resort override to attempt an in-process update):</target>
         <note />
       </trans-unit>
       <trans-unit id="MappingAddedFormat">
@@ -193,8 +198,8 @@
         <note />
       </trans-unit>
       <trans-unit id="PrSelfUpdateMessage">
-        <source>This Aspire CLI is a PR / dogfood build. It is pinned to a specific pull request; `--self` cannot update it. To re-install or update to a different PR, run:</source>
-        <target state="new">This Aspire CLI is a PR / dogfood build. It is pinned to a specific pull request; `--self` cannot update it. To re-install or update to a different PR, run:</target>
+        <source>This Aspire CLI is a PR / dogfood build. It is pinned to a specific pull request; `--self` cannot update it. To re-install or update to a different PR, run (or pass `--force` as a last-resort override to attempt an in-process update):</source>
+        <target state="new">This Aspire CLI is a PR / dogfood build. It is pinned to a specific pull request; `--self` cannot update it. To re-install or update to a different PR, run (or pass `--force` as a last-resort override to attempt an in-process update):</target>
         <note />
       </trans-unit>
       <trans-unit id="ProjectArgumentDescription">
@@ -258,8 +263,13 @@
         <note />
       </trans-unit>
       <trans-unit id="SelfUpdateUnknownSourceMessage">
-        <source>Cannot determine how this Aspire CLI was installed (no install-route sidecar found). Refusing to perform an in-process self-update to avoid corrupting the binary. Re-run your original install command to update.</source>
-        <target state="new">Cannot determine how this Aspire CLI was installed (no install-route sidecar found). Refusing to perform an in-process self-update to avoid corrupting the binary. Re-run your original install command to update.</target>
+        <source>Cannot determine how this Aspire CLI was installed. Refusing to perform an in-process self-update to avoid corrupting the binary.</source>
+        <target state="new">Cannot determine how this Aspire CLI was installed. Refusing to perform an in-process self-update to avoid corrupting the binary.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UnknownRouteRefusalHint">
+        <source>Aspire couldn't determine how this CLI was installed (`.aspire-install.json` is missing, unreadable, or has an unrecognized route). Investigate the install, or pass `--force` to attempt an in-process update anyway.</source>
+        <target state="new">Aspire couldn't determine how this CLI was installed (`.aspire-install.json` is missing, unreadable, or has an unrecognized route). Investigate the install, or pass `--force` to attempt an in-process update anyway.</target>
         <note />
       </trans-unit>
       <trans-unit id="UnxpectedCodePath">
@@ -288,8 +298,8 @@
         <note />
       </trans-unit>
       <trans-unit id="WingetSelfUpdateMessage">
-        <source>This Aspire CLI was installed via WinGet. To update it, run:</source>
-        <target state="new">This Aspire CLI was installed via WinGet. To update it, run:</target>
+        <source>This Aspire CLI was installed via WinGet. To update it, run (or pass `--force` as a last-resort override to attempt an in-process update):</source>
+        <target state="new">This Aspire CLI was installed via WinGet. To update it, run (or pass `--force` as a last-resort override to attempt an in-process update):</target>
         <note />
       </trans-unit>
       <trans-unit id="YesOptionDescription">

--- a/src/Aspire.Cli/Resources/xlf/UpdateCommandStrings.es.xlf
+++ b/src/Aspire.Cli/Resources/xlf/UpdateCommandStrings.es.xlf
@@ -37,6 +37,11 @@
         <target state="translated">Aplicando actualizaciones...</target>
         <note />
       </trans-unit>
+      <trans-unit id="BrewSelfUpdateMessage">
+        <source>This Aspire CLI was installed via Homebrew. To update it, run:</source>
+        <target state="new">This Aspire CLI was installed via Homebrew. To update it, run:</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CentralPackageManagementNotSupported">
         <source>Central package management is currently not supported by 'aspire update'.</source>
         <target state="translated">La administración central de paquetes no es compatible actualmente con "aspire update".</target>
@@ -117,6 +122,11 @@
         <target state="needs-review-translation">Nota: El plan de actualización se generó usando un análisis alternativo debido a un SDK de AppHost no resoluble. El análisis de dependencias puede ser menos preciso.</target>
         <note />
       </trans-unit>
+      <trans-unit id="LocalHiveSelfUpdateMessage">
+        <source>This Aspire CLI is a local development build. To update it, rebuild from your Aspire checkout:</source>
+        <target state="new">This Aspire CLI is a local development build. To update it, rebuild from your Aspire checkout:</target>
+        <note />
+      </trans-unit>
       <trans-unit id="MappingAddedFormat">
         <source>   Mapping: {0} (added)</source>
         <target state="translated">   Asignación: {0} (agregado)</target>
@@ -182,6 +192,11 @@
         <target state="translated">¿Desea realizar actualizaciones?</target>
         <note />
       </trans-unit>
+      <trans-unit id="PrSelfUpdateMessage">
+        <source>This Aspire CLI is a PR / dogfood build. It is pinned to a specific pull request; `--self` cannot update it. To re-install or update to a different PR, run:</source>
+        <target state="new">This Aspire CLI is a PR / dogfood build. It is pinned to a specific pull request; `--self` cannot update it. To re-install or update to a different PR, run:</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ProjectArgumentDescription">
         <source>The path to the Aspire AppHost project file or a directory to search</source>
         <target state="needs-review-translation">La ruta de acceso al archivo del proyecto host de la AppHost Aspire.</target>
@@ -242,6 +257,11 @@
         <target state="new">Update the Aspire CLI itself to the latest version</target>
         <note />
       </trans-unit>
+      <trans-unit id="SelfUpdateUnknownSourceMessage">
+        <source>Cannot determine how this Aspire CLI was installed (no install-route sidecar found). Refusing to perform an in-process self-update to avoid corrupting the binary. Re-run your original install command to update.</source>
+        <target state="new">Cannot determine how this Aspire CLI was installed (no install-route sidecar found). Refusing to perform an in-process self-update to avoid corrupting the binary. Re-run your original install command to update.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="UnxpectedCodePath">
         <source>Unexpected code path.</source>
         <target state="translated">Ruta de acceso al código inesperada.</target>
@@ -265,6 +285,11 @@
       <trans-unit id="WhichDirectoryNuGetConfigPrompt">
         <source>Which directory for NuGet.config file?</source>
         <target state="translated">¿Qué directorio del archivo NuGet.config?</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WingetSelfUpdateMessage">
+        <source>This Aspire CLI was installed via WinGet. To update it, run:</source>
+        <target state="new">This Aspire CLI was installed via WinGet. To update it, run:</target>
         <note />
       </trans-unit>
       <trans-unit id="YesOptionDescription">

--- a/src/Aspire.Cli/Resources/xlf/UpdateCommandStrings.fr.xlf
+++ b/src/Aspire.Cli/Resources/xlf/UpdateCommandStrings.fr.xlf
@@ -38,8 +38,8 @@
         <note />
       </trans-unit>
       <trans-unit id="BrewSelfUpdateMessage">
-        <source>This Aspire CLI was installed via Homebrew. To update it, run:</source>
-        <target state="new">This Aspire CLI was installed via Homebrew. To update it, run:</target>
+        <source>This Aspire CLI was installed via Homebrew. To update it, run (or pass `--force` as a last-resort override to attempt an in-process update):</source>
+        <target state="new">This Aspire CLI was installed via Homebrew. To update it, run (or pass `--force` as a last-resort override to attempt an in-process update):</target>
         <note />
       </trans-unit>
       <trans-unit id="CentralPackageManagementNotSupported">
@@ -83,8 +83,8 @@
         <note />
       </trans-unit>
       <trans-unit id="DotNetToolSelfUpdateMessage">
-        <source>To update the Aspire CLI when installed as a .NET tool, run:</source>
-        <target state="translated">Pour mettre à jour l’interface CLI Aspire lorsqu’elle est installée en tant qu’outil .NET, exécutez :</target>
+        <source>To update the Aspire CLI when installed as a .NET tool, run (or pass `--force` as a last-resort override to attempt an in-process update):</source>
+        <target state="needs-review-translation">Pour mettre à jour l’interface CLI Aspire lorsqu’elle est installée en tant qu’outil .NET, exécutez :</target>
         <note />
       </trans-unit>
       <trans-unit id="ExecutingUpdateStepFormat">
@@ -122,9 +122,14 @@
         <target state="needs-review-translation">Remarque : plan de mise à jour généré à l’aide de l’analyse de secours en raison d’un Kit de développement logiciel (SDK) AppHost non résolu. L’analyse des dépendances peut avoir une précision réduite.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ForceOptionDescription">
+        <source>Attempt an in-process self-update even when the install route is normally refused</source>
+        <target state="new">Attempt an in-process self-update even when the install route is normally refused</target>
+        <note />
+      </trans-unit>
       <trans-unit id="LocalHiveSelfUpdateMessage">
-        <source>This Aspire CLI is a local development build. To update it, rebuild from your Aspire checkout:</source>
-        <target state="new">This Aspire CLI is a local development build. To update it, rebuild from your Aspire checkout:</target>
+        <source>This Aspire CLI is a local development build. To update it, rebuild from your Aspire checkout (or pass `--force` as a last-resort override to attempt an in-process update):</source>
+        <target state="new">This Aspire CLI is a local development build. To update it, rebuild from your Aspire checkout (or pass `--force` as a last-resort override to attempt an in-process update):</target>
         <note />
       </trans-unit>
       <trans-unit id="MappingAddedFormat">
@@ -193,8 +198,8 @@
         <note />
       </trans-unit>
       <trans-unit id="PrSelfUpdateMessage">
-        <source>This Aspire CLI is a PR / dogfood build. It is pinned to a specific pull request; `--self` cannot update it. To re-install or update to a different PR, run:</source>
-        <target state="new">This Aspire CLI is a PR / dogfood build. It is pinned to a specific pull request; `--self` cannot update it. To re-install or update to a different PR, run:</target>
+        <source>This Aspire CLI is a PR / dogfood build. It is pinned to a specific pull request; `--self` cannot update it. To re-install or update to a different PR, run (or pass `--force` as a last-resort override to attempt an in-process update):</source>
+        <target state="new">This Aspire CLI is a PR / dogfood build. It is pinned to a specific pull request; `--self` cannot update it. To re-install or update to a different PR, run (or pass `--force` as a last-resort override to attempt an in-process update):</target>
         <note />
       </trans-unit>
       <trans-unit id="ProjectArgumentDescription">
@@ -258,8 +263,13 @@
         <note />
       </trans-unit>
       <trans-unit id="SelfUpdateUnknownSourceMessage">
-        <source>Cannot determine how this Aspire CLI was installed (no install-route sidecar found). Refusing to perform an in-process self-update to avoid corrupting the binary. Re-run your original install command to update.</source>
-        <target state="new">Cannot determine how this Aspire CLI was installed (no install-route sidecar found). Refusing to perform an in-process self-update to avoid corrupting the binary. Re-run your original install command to update.</target>
+        <source>Cannot determine how this Aspire CLI was installed. Refusing to perform an in-process self-update to avoid corrupting the binary.</source>
+        <target state="new">Cannot determine how this Aspire CLI was installed. Refusing to perform an in-process self-update to avoid corrupting the binary.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UnknownRouteRefusalHint">
+        <source>Aspire couldn't determine how this CLI was installed (`.aspire-install.json` is missing, unreadable, or has an unrecognized route). Investigate the install, or pass `--force` to attempt an in-process update anyway.</source>
+        <target state="new">Aspire couldn't determine how this CLI was installed (`.aspire-install.json` is missing, unreadable, or has an unrecognized route). Investigate the install, or pass `--force` to attempt an in-process update anyway.</target>
         <note />
       </trans-unit>
       <trans-unit id="UnxpectedCodePath">
@@ -288,8 +298,8 @@
         <note />
       </trans-unit>
       <trans-unit id="WingetSelfUpdateMessage">
-        <source>This Aspire CLI was installed via WinGet. To update it, run:</source>
-        <target state="new">This Aspire CLI was installed via WinGet. To update it, run:</target>
+        <source>This Aspire CLI was installed via WinGet. To update it, run (or pass `--force` as a last-resort override to attempt an in-process update):</source>
+        <target state="new">This Aspire CLI was installed via WinGet. To update it, run (or pass `--force` as a last-resort override to attempt an in-process update):</target>
         <note />
       </trans-unit>
       <trans-unit id="YesOptionDescription">

--- a/src/Aspire.Cli/Resources/xlf/UpdateCommandStrings.fr.xlf
+++ b/src/Aspire.Cli/Resources/xlf/UpdateCommandStrings.fr.xlf
@@ -37,6 +37,11 @@
         <target state="translated">Application en cours des mises à jour...</target>
         <note />
       </trans-unit>
+      <trans-unit id="BrewSelfUpdateMessage">
+        <source>This Aspire CLI was installed via Homebrew. To update it, run:</source>
+        <target state="new">This Aspire CLI was installed via Homebrew. To update it, run:</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CentralPackageManagementNotSupported">
         <source>Central package management is currently not supported by 'aspire update'.</source>
         <target state="translated">Actuellement, la gestion centralisée des packages n’est pas prise en charge par « aspire update ».</target>
@@ -117,6 +122,11 @@
         <target state="needs-review-translation">Remarque : plan de mise à jour généré à l’aide de l’analyse de secours en raison d’un Kit de développement logiciel (SDK) AppHost non résolu. L’analyse des dépendances peut avoir une précision réduite.</target>
         <note />
       </trans-unit>
+      <trans-unit id="LocalHiveSelfUpdateMessage">
+        <source>This Aspire CLI is a local development build. To update it, rebuild from your Aspire checkout:</source>
+        <target state="new">This Aspire CLI is a local development build. To update it, rebuild from your Aspire checkout:</target>
+        <note />
+      </trans-unit>
       <trans-unit id="MappingAddedFormat">
         <source>   Mapping: {0} (added)</source>
         <target state="translated">   Mappage : {0} (ajouté)</target>
@@ -182,6 +192,11 @@
         <target state="translated">Voulez-vous exécuter la mise à jour maintenant ?</target>
         <note />
       </trans-unit>
+      <trans-unit id="PrSelfUpdateMessage">
+        <source>This Aspire CLI is a PR / dogfood build. It is pinned to a specific pull request; `--self` cannot update it. To re-install or update to a different PR, run:</source>
+        <target state="new">This Aspire CLI is a PR / dogfood build. It is pinned to a specific pull request; `--self` cannot update it. To re-install or update to a different PR, run:</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ProjectArgumentDescription">
         <source>The path to the Aspire AppHost project file or a directory to search</source>
         <target state="needs-review-translation">Chemin d’accès au fichier projet AppHost Aspire.</target>
@@ -242,6 +257,11 @@
         <target state="new">Update the Aspire CLI itself to the latest version</target>
         <note />
       </trans-unit>
+      <trans-unit id="SelfUpdateUnknownSourceMessage">
+        <source>Cannot determine how this Aspire CLI was installed (no install-route sidecar found). Refusing to perform an in-process self-update to avoid corrupting the binary. Re-run your original install command to update.</source>
+        <target state="new">Cannot determine how this Aspire CLI was installed (no install-route sidecar found). Refusing to perform an in-process self-update to avoid corrupting the binary. Re-run your original install command to update.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="UnxpectedCodePath">
         <source>Unexpected code path.</source>
         <target state="translated">Chemin de code inattendu.</target>
@@ -265,6 +285,11 @@
       <trans-unit id="WhichDirectoryNuGetConfigPrompt">
         <source>Which directory for NuGet.config file?</source>
         <target state="translated">Quel répertoire pour le fichier NuGet.config ?</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WingetSelfUpdateMessage">
+        <source>This Aspire CLI was installed via WinGet. To update it, run:</source>
+        <target state="new">This Aspire CLI was installed via WinGet. To update it, run:</target>
         <note />
       </trans-unit>
       <trans-unit id="YesOptionDescription">

--- a/src/Aspire.Cli/Resources/xlf/UpdateCommandStrings.it.xlf
+++ b/src/Aspire.Cli/Resources/xlf/UpdateCommandStrings.it.xlf
@@ -38,8 +38,8 @@
         <note />
       </trans-unit>
       <trans-unit id="BrewSelfUpdateMessage">
-        <source>This Aspire CLI was installed via Homebrew. To update it, run:</source>
-        <target state="new">This Aspire CLI was installed via Homebrew. To update it, run:</target>
+        <source>This Aspire CLI was installed via Homebrew. To update it, run (or pass `--force` as a last-resort override to attempt an in-process update):</source>
+        <target state="new">This Aspire CLI was installed via Homebrew. To update it, run (or pass `--force` as a last-resort override to attempt an in-process update):</target>
         <note />
       </trans-unit>
       <trans-unit id="CentralPackageManagementNotSupported">
@@ -83,8 +83,8 @@
         <note />
       </trans-unit>
       <trans-unit id="DotNetToolSelfUpdateMessage">
-        <source>To update the Aspire CLI when installed as a .NET tool, run:</source>
-        <target state="translated">Per aggiornare l'interfaccia della riga di comando di Aspire quando è installata come strumento .NET, eseguire:</target>
+        <source>To update the Aspire CLI when installed as a .NET tool, run (or pass `--force` as a last-resort override to attempt an in-process update):</source>
+        <target state="needs-review-translation">Per aggiornare l'interfaccia della riga di comando di Aspire quando è installata come strumento .NET, eseguire:</target>
         <note />
       </trans-unit>
       <trans-unit id="ExecutingUpdateStepFormat">
@@ -122,9 +122,14 @@
         <target state="needs-review-translation">Nota: il piano di aggiornamento è stato generato usando l'analisi di fallback perché AppHost SDK non è risolvibile. L'analisi delle dipendenze potrebbe risultare meno accurata.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ForceOptionDescription">
+        <source>Attempt an in-process self-update even when the install route is normally refused</source>
+        <target state="new">Attempt an in-process self-update even when the install route is normally refused</target>
+        <note />
+      </trans-unit>
       <trans-unit id="LocalHiveSelfUpdateMessage">
-        <source>This Aspire CLI is a local development build. To update it, rebuild from your Aspire checkout:</source>
-        <target state="new">This Aspire CLI is a local development build. To update it, rebuild from your Aspire checkout:</target>
+        <source>This Aspire CLI is a local development build. To update it, rebuild from your Aspire checkout (or pass `--force` as a last-resort override to attempt an in-process update):</source>
+        <target state="new">This Aspire CLI is a local development build. To update it, rebuild from your Aspire checkout (or pass `--force` as a last-resort override to attempt an in-process update):</target>
         <note />
       </trans-unit>
       <trans-unit id="MappingAddedFormat">
@@ -193,8 +198,8 @@
         <note />
       </trans-unit>
       <trans-unit id="PrSelfUpdateMessage">
-        <source>This Aspire CLI is a PR / dogfood build. It is pinned to a specific pull request; `--self` cannot update it. To re-install or update to a different PR, run:</source>
-        <target state="new">This Aspire CLI is a PR / dogfood build. It is pinned to a specific pull request; `--self` cannot update it. To re-install or update to a different PR, run:</target>
+        <source>This Aspire CLI is a PR / dogfood build. It is pinned to a specific pull request; `--self` cannot update it. To re-install or update to a different PR, run (or pass `--force` as a last-resort override to attempt an in-process update):</source>
+        <target state="new">This Aspire CLI is a PR / dogfood build. It is pinned to a specific pull request; `--self` cannot update it. To re-install or update to a different PR, run (or pass `--force` as a last-resort override to attempt an in-process update):</target>
         <note />
       </trans-unit>
       <trans-unit id="ProjectArgumentDescription">
@@ -258,8 +263,13 @@
         <note />
       </trans-unit>
       <trans-unit id="SelfUpdateUnknownSourceMessage">
-        <source>Cannot determine how this Aspire CLI was installed (no install-route sidecar found). Refusing to perform an in-process self-update to avoid corrupting the binary. Re-run your original install command to update.</source>
-        <target state="new">Cannot determine how this Aspire CLI was installed (no install-route sidecar found). Refusing to perform an in-process self-update to avoid corrupting the binary. Re-run your original install command to update.</target>
+        <source>Cannot determine how this Aspire CLI was installed. Refusing to perform an in-process self-update to avoid corrupting the binary.</source>
+        <target state="new">Cannot determine how this Aspire CLI was installed. Refusing to perform an in-process self-update to avoid corrupting the binary.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UnknownRouteRefusalHint">
+        <source>Aspire couldn't determine how this CLI was installed (`.aspire-install.json` is missing, unreadable, or has an unrecognized route). Investigate the install, or pass `--force` to attempt an in-process update anyway.</source>
+        <target state="new">Aspire couldn't determine how this CLI was installed (`.aspire-install.json` is missing, unreadable, or has an unrecognized route). Investigate the install, or pass `--force` to attempt an in-process update anyway.</target>
         <note />
       </trans-unit>
       <trans-unit id="UnxpectedCodePath">
@@ -288,8 +298,8 @@
         <note />
       </trans-unit>
       <trans-unit id="WingetSelfUpdateMessage">
-        <source>This Aspire CLI was installed via WinGet. To update it, run:</source>
-        <target state="new">This Aspire CLI was installed via WinGet. To update it, run:</target>
+        <source>This Aspire CLI was installed via WinGet. To update it, run (or pass `--force` as a last-resort override to attempt an in-process update):</source>
+        <target state="new">This Aspire CLI was installed via WinGet. To update it, run (or pass `--force` as a last-resort override to attempt an in-process update):</target>
         <note />
       </trans-unit>
       <trans-unit id="YesOptionDescription">

--- a/src/Aspire.Cli/Resources/xlf/UpdateCommandStrings.it.xlf
+++ b/src/Aspire.Cli/Resources/xlf/UpdateCommandStrings.it.xlf
@@ -37,6 +37,11 @@
         <target state="translated">Applicazione degli aggiornamenti in corso...</target>
         <note />
       </trans-unit>
+      <trans-unit id="BrewSelfUpdateMessage">
+        <source>This Aspire CLI was installed via Homebrew. To update it, run:</source>
+        <target state="new">This Aspire CLI was installed via Homebrew. To update it, run:</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CentralPackageManagementNotSupported">
         <source>Central package management is currently not supported by 'aspire update'.</source>
         <target state="translated">La gestione centralizzata dei pacchetti non è attualmente supportata da "aspire update".</target>
@@ -117,6 +122,11 @@
         <target state="needs-review-translation">Nota: il piano di aggiornamento è stato generato usando l'analisi di fallback perché AppHost SDK non è risolvibile. L'analisi delle dipendenze potrebbe risultare meno accurata.</target>
         <note />
       </trans-unit>
+      <trans-unit id="LocalHiveSelfUpdateMessage">
+        <source>This Aspire CLI is a local development build. To update it, rebuild from your Aspire checkout:</source>
+        <target state="new">This Aspire CLI is a local development build. To update it, rebuild from your Aspire checkout:</target>
+        <note />
+      </trans-unit>
       <trans-unit id="MappingAddedFormat">
         <source>   Mapping: {0} (added)</source>
         <target state="translated">   Mapping: {0} (aggiunto)</target>
@@ -182,6 +192,11 @@
         <target state="translated">Eseguire gli aggiornamenti?</target>
         <note />
       </trans-unit>
+      <trans-unit id="PrSelfUpdateMessage">
+        <source>This Aspire CLI is a PR / dogfood build. It is pinned to a specific pull request; `--self` cannot update it. To re-install or update to a different PR, run:</source>
+        <target state="new">This Aspire CLI is a PR / dogfood build. It is pinned to a specific pull request; `--self` cannot update it. To re-install or update to a different PR, run:</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ProjectArgumentDescription">
         <source>The path to the Aspire AppHost project file or a directory to search</source>
         <target state="needs-review-translation">Percorso del file di un progetto AppHost di Aspire.</target>
@@ -242,6 +257,11 @@
         <target state="new">Update the Aspire CLI itself to the latest version</target>
         <note />
       </trans-unit>
+      <trans-unit id="SelfUpdateUnknownSourceMessage">
+        <source>Cannot determine how this Aspire CLI was installed (no install-route sidecar found). Refusing to perform an in-process self-update to avoid corrupting the binary. Re-run your original install command to update.</source>
+        <target state="new">Cannot determine how this Aspire CLI was installed (no install-route sidecar found). Refusing to perform an in-process self-update to avoid corrupting the binary. Re-run your original install command to update.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="UnxpectedCodePath">
         <source>Unexpected code path.</source>
         <target state="translated">Percorso del codice imprevisto.</target>
@@ -265,6 +285,11 @@
       <trans-unit id="WhichDirectoryNuGetConfigPrompt">
         <source>Which directory for NuGet.config file?</source>
         <target state="translated">Quale directory per il file NuGet.config?</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WingetSelfUpdateMessage">
+        <source>This Aspire CLI was installed via WinGet. To update it, run:</source>
+        <target state="new">This Aspire CLI was installed via WinGet. To update it, run:</target>
         <note />
       </trans-unit>
       <trans-unit id="YesOptionDescription">

--- a/src/Aspire.Cli/Resources/xlf/UpdateCommandStrings.ja.xlf
+++ b/src/Aspire.Cli/Resources/xlf/UpdateCommandStrings.ja.xlf
@@ -38,8 +38,8 @@
         <note />
       </trans-unit>
       <trans-unit id="BrewSelfUpdateMessage">
-        <source>This Aspire CLI was installed via Homebrew. To update it, run:</source>
-        <target state="new">This Aspire CLI was installed via Homebrew. To update it, run:</target>
+        <source>This Aspire CLI was installed via Homebrew. To update it, run (or pass `--force` as a last-resort override to attempt an in-process update):</source>
+        <target state="new">This Aspire CLI was installed via Homebrew. To update it, run (or pass `--force` as a last-resort override to attempt an in-process update):</target>
         <note />
       </trans-unit>
       <trans-unit id="CentralPackageManagementNotSupported">
@@ -83,8 +83,8 @@
         <note />
       </trans-unit>
       <trans-unit id="DotNetToolSelfUpdateMessage">
-        <source>To update the Aspire CLI when installed as a .NET tool, run:</source>
-        <target state="translated">.NET ツールとしてインストールされたときに Aspire CLI を更新するには、次を実行します。</target>
+        <source>To update the Aspire CLI when installed as a .NET tool, run (or pass `--force` as a last-resort override to attempt an in-process update):</source>
+        <target state="needs-review-translation">.NET ツールとしてインストールされたときに Aspire CLI を更新するには、次を実行します。</target>
         <note />
       </trans-unit>
       <trans-unit id="ExecutingUpdateStepFormat">
@@ -122,9 +122,14 @@
         <target state="needs-review-translation">注: 解決できない AppHost SDK が原因でフォールバック解析を使用して生成されたプランを更新します。依存関係分析の精度が低下する可能性があります。</target>
         <note />
       </trans-unit>
+      <trans-unit id="ForceOptionDescription">
+        <source>Attempt an in-process self-update even when the install route is normally refused</source>
+        <target state="new">Attempt an in-process self-update even when the install route is normally refused</target>
+        <note />
+      </trans-unit>
       <trans-unit id="LocalHiveSelfUpdateMessage">
-        <source>This Aspire CLI is a local development build. To update it, rebuild from your Aspire checkout:</source>
-        <target state="new">This Aspire CLI is a local development build. To update it, rebuild from your Aspire checkout:</target>
+        <source>This Aspire CLI is a local development build. To update it, rebuild from your Aspire checkout (or pass `--force` as a last-resort override to attempt an in-process update):</source>
+        <target state="new">This Aspire CLI is a local development build. To update it, rebuild from your Aspire checkout (or pass `--force` as a last-resort override to attempt an in-process update):</target>
         <note />
       </trans-unit>
       <trans-unit id="MappingAddedFormat">
@@ -193,8 +198,8 @@
         <note />
       </trans-unit>
       <trans-unit id="PrSelfUpdateMessage">
-        <source>This Aspire CLI is a PR / dogfood build. It is pinned to a specific pull request; `--self` cannot update it. To re-install or update to a different PR, run:</source>
-        <target state="new">This Aspire CLI is a PR / dogfood build. It is pinned to a specific pull request; `--self` cannot update it. To re-install or update to a different PR, run:</target>
+        <source>This Aspire CLI is a PR / dogfood build. It is pinned to a specific pull request; `--self` cannot update it. To re-install or update to a different PR, run (or pass `--force` as a last-resort override to attempt an in-process update):</source>
+        <target state="new">This Aspire CLI is a PR / dogfood build. It is pinned to a specific pull request; `--self` cannot update it. To re-install or update to a different PR, run (or pass `--force` as a last-resort override to attempt an in-process update):</target>
         <note />
       </trans-unit>
       <trans-unit id="ProjectArgumentDescription">
@@ -258,8 +263,13 @@
         <note />
       </trans-unit>
       <trans-unit id="SelfUpdateUnknownSourceMessage">
-        <source>Cannot determine how this Aspire CLI was installed (no install-route sidecar found). Refusing to perform an in-process self-update to avoid corrupting the binary. Re-run your original install command to update.</source>
-        <target state="new">Cannot determine how this Aspire CLI was installed (no install-route sidecar found). Refusing to perform an in-process self-update to avoid corrupting the binary. Re-run your original install command to update.</target>
+        <source>Cannot determine how this Aspire CLI was installed. Refusing to perform an in-process self-update to avoid corrupting the binary.</source>
+        <target state="new">Cannot determine how this Aspire CLI was installed. Refusing to perform an in-process self-update to avoid corrupting the binary.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UnknownRouteRefusalHint">
+        <source>Aspire couldn't determine how this CLI was installed (`.aspire-install.json` is missing, unreadable, or has an unrecognized route). Investigate the install, or pass `--force` to attempt an in-process update anyway.</source>
+        <target state="new">Aspire couldn't determine how this CLI was installed (`.aspire-install.json` is missing, unreadable, or has an unrecognized route). Investigate the install, or pass `--force` to attempt an in-process update anyway.</target>
         <note />
       </trans-unit>
       <trans-unit id="UnxpectedCodePath">
@@ -288,8 +298,8 @@
         <note />
       </trans-unit>
       <trans-unit id="WingetSelfUpdateMessage">
-        <source>This Aspire CLI was installed via WinGet. To update it, run:</source>
-        <target state="new">This Aspire CLI was installed via WinGet. To update it, run:</target>
+        <source>This Aspire CLI was installed via WinGet. To update it, run (or pass `--force` as a last-resort override to attempt an in-process update):</source>
+        <target state="new">This Aspire CLI was installed via WinGet. To update it, run (or pass `--force` as a last-resort override to attempt an in-process update):</target>
         <note />
       </trans-unit>
       <trans-unit id="YesOptionDescription">

--- a/src/Aspire.Cli/Resources/xlf/UpdateCommandStrings.ja.xlf
+++ b/src/Aspire.Cli/Resources/xlf/UpdateCommandStrings.ja.xlf
@@ -37,6 +37,11 @@
         <target state="translated">更新プログラムを適用しています...</target>
         <note />
       </trans-unit>
+      <trans-unit id="BrewSelfUpdateMessage">
+        <source>This Aspire CLI was installed via Homebrew. To update it, run:</source>
+        <target state="new">This Aspire CLI was installed via Homebrew. To update it, run:</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CentralPackageManagementNotSupported">
         <source>Central package management is currently not supported by 'aspire update'.</source>
         <target state="translated">現在、中央パッケージ管理では、'aspire update' によるサポートがありません。</target>
@@ -117,6 +122,11 @@
         <target state="needs-review-translation">注: 解決できない AppHost SDK が原因でフォールバック解析を使用して生成されたプランを更新します。依存関係分析の精度が低下する可能性があります。</target>
         <note />
       </trans-unit>
+      <trans-unit id="LocalHiveSelfUpdateMessage">
+        <source>This Aspire CLI is a local development build. To update it, rebuild from your Aspire checkout:</source>
+        <target state="new">This Aspire CLI is a local development build. To update it, rebuild from your Aspire checkout:</target>
+        <note />
+      </trans-unit>
       <trans-unit id="MappingAddedFormat">
         <source>   Mapping: {0} (added)</source>
         <target state="translated">   マッピング: {0} (追加済み)</target>
@@ -182,6 +192,11 @@
         <target state="translated">更新を実行しますか?</target>
         <note />
       </trans-unit>
+      <trans-unit id="PrSelfUpdateMessage">
+        <source>This Aspire CLI is a PR / dogfood build. It is pinned to a specific pull request; `--self` cannot update it. To re-install or update to a different PR, run:</source>
+        <target state="new">This Aspire CLI is a PR / dogfood build. It is pinned to a specific pull request; `--self` cannot update it. To re-install or update to a different PR, run:</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ProjectArgumentDescription">
         <source>The path to the Aspire AppHost project file or a directory to search</source>
         <target state="needs-review-translation">Aspire アプリ ホスティング プロセス プロジェクト ファイルへのパス。</target>
@@ -242,6 +257,11 @@
         <target state="new">Update the Aspire CLI itself to the latest version</target>
         <note />
       </trans-unit>
+      <trans-unit id="SelfUpdateUnknownSourceMessage">
+        <source>Cannot determine how this Aspire CLI was installed (no install-route sidecar found). Refusing to perform an in-process self-update to avoid corrupting the binary. Re-run your original install command to update.</source>
+        <target state="new">Cannot determine how this Aspire CLI was installed (no install-route sidecar found). Refusing to perform an in-process self-update to avoid corrupting the binary. Re-run your original install command to update.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="UnxpectedCodePath">
         <source>Unexpected code path.</source>
         <target state="translated">予期しないコード パスです。</target>
@@ -265,6 +285,11 @@
       <trans-unit id="WhichDirectoryNuGetConfigPrompt">
         <source>Which directory for NuGet.config file?</source>
         <target state="translated">NuGet.config ファイル用の、どのディレクトリですか?</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WingetSelfUpdateMessage">
+        <source>This Aspire CLI was installed via WinGet. To update it, run:</source>
+        <target state="new">This Aspire CLI was installed via WinGet. To update it, run:</target>
         <note />
       </trans-unit>
       <trans-unit id="YesOptionDescription">

--- a/src/Aspire.Cli/Resources/xlf/UpdateCommandStrings.ko.xlf
+++ b/src/Aspire.Cli/Resources/xlf/UpdateCommandStrings.ko.xlf
@@ -38,8 +38,8 @@
         <note />
       </trans-unit>
       <trans-unit id="BrewSelfUpdateMessage">
-        <source>This Aspire CLI was installed via Homebrew. To update it, run:</source>
-        <target state="new">This Aspire CLI was installed via Homebrew. To update it, run:</target>
+        <source>This Aspire CLI was installed via Homebrew. To update it, run (or pass `--force` as a last-resort override to attempt an in-process update):</source>
+        <target state="new">This Aspire CLI was installed via Homebrew. To update it, run (or pass `--force` as a last-resort override to attempt an in-process update):</target>
         <note />
       </trans-unit>
       <trans-unit id="CentralPackageManagementNotSupported">
@@ -83,8 +83,8 @@
         <note />
       </trans-unit>
       <trans-unit id="DotNetToolSelfUpdateMessage">
-        <source>To update the Aspire CLI when installed as a .NET tool, run:</source>
-        <target state="translated">.NET 도구로 설치된 Aspire CLI를 업데이트하려면 다음 명령을 실행합니다.</target>
+        <source>To update the Aspire CLI when installed as a .NET tool, run (or pass `--force` as a last-resort override to attempt an in-process update):</source>
+        <target state="needs-review-translation">.NET 도구로 설치된 Aspire CLI를 업데이트하려면 다음 명령을 실행합니다.</target>
         <note />
       </trans-unit>
       <trans-unit id="ExecutingUpdateStepFormat">
@@ -122,9 +122,14 @@
         <target state="needs-review-translation">참고: 해결할 수 없는 AppHost SDK 때문에 대체 구문 분석을 사용하여 업데이트 계획이 생성되었습니다. 종속성 분석의 정확도가 낮아질 수 있습니다.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ForceOptionDescription">
+        <source>Attempt an in-process self-update even when the install route is normally refused</source>
+        <target state="new">Attempt an in-process self-update even when the install route is normally refused</target>
+        <note />
+      </trans-unit>
       <trans-unit id="LocalHiveSelfUpdateMessage">
-        <source>This Aspire CLI is a local development build. To update it, rebuild from your Aspire checkout:</source>
-        <target state="new">This Aspire CLI is a local development build. To update it, rebuild from your Aspire checkout:</target>
+        <source>This Aspire CLI is a local development build. To update it, rebuild from your Aspire checkout (or pass `--force` as a last-resort override to attempt an in-process update):</source>
+        <target state="new">This Aspire CLI is a local development build. To update it, rebuild from your Aspire checkout (or pass `--force` as a last-resort override to attempt an in-process update):</target>
         <note />
       </trans-unit>
       <trans-unit id="MappingAddedFormat">
@@ -193,8 +198,8 @@
         <note />
       </trans-unit>
       <trans-unit id="PrSelfUpdateMessage">
-        <source>This Aspire CLI is a PR / dogfood build. It is pinned to a specific pull request; `--self` cannot update it. To re-install or update to a different PR, run:</source>
-        <target state="new">This Aspire CLI is a PR / dogfood build. It is pinned to a specific pull request; `--self` cannot update it. To re-install or update to a different PR, run:</target>
+        <source>This Aspire CLI is a PR / dogfood build. It is pinned to a specific pull request; `--self` cannot update it. To re-install or update to a different PR, run (or pass `--force` as a last-resort override to attempt an in-process update):</source>
+        <target state="new">This Aspire CLI is a PR / dogfood build. It is pinned to a specific pull request; `--self` cannot update it. To re-install or update to a different PR, run (or pass `--force` as a last-resort override to attempt an in-process update):</target>
         <note />
       </trans-unit>
       <trans-unit id="ProjectArgumentDescription">
@@ -258,8 +263,13 @@
         <note />
       </trans-unit>
       <trans-unit id="SelfUpdateUnknownSourceMessage">
-        <source>Cannot determine how this Aspire CLI was installed (no install-route sidecar found). Refusing to perform an in-process self-update to avoid corrupting the binary. Re-run your original install command to update.</source>
-        <target state="new">Cannot determine how this Aspire CLI was installed (no install-route sidecar found). Refusing to perform an in-process self-update to avoid corrupting the binary. Re-run your original install command to update.</target>
+        <source>Cannot determine how this Aspire CLI was installed. Refusing to perform an in-process self-update to avoid corrupting the binary.</source>
+        <target state="new">Cannot determine how this Aspire CLI was installed. Refusing to perform an in-process self-update to avoid corrupting the binary.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UnknownRouteRefusalHint">
+        <source>Aspire couldn't determine how this CLI was installed (`.aspire-install.json` is missing, unreadable, or has an unrecognized route). Investigate the install, or pass `--force` to attempt an in-process update anyway.</source>
+        <target state="new">Aspire couldn't determine how this CLI was installed (`.aspire-install.json` is missing, unreadable, or has an unrecognized route). Investigate the install, or pass `--force` to attempt an in-process update anyway.</target>
         <note />
       </trans-unit>
       <trans-unit id="UnxpectedCodePath">
@@ -288,8 +298,8 @@
         <note />
       </trans-unit>
       <trans-unit id="WingetSelfUpdateMessage">
-        <source>This Aspire CLI was installed via WinGet. To update it, run:</source>
-        <target state="new">This Aspire CLI was installed via WinGet. To update it, run:</target>
+        <source>This Aspire CLI was installed via WinGet. To update it, run (or pass `--force` as a last-resort override to attempt an in-process update):</source>
+        <target state="new">This Aspire CLI was installed via WinGet. To update it, run (or pass `--force` as a last-resort override to attempt an in-process update):</target>
         <note />
       </trans-unit>
       <trans-unit id="YesOptionDescription">

--- a/src/Aspire.Cli/Resources/xlf/UpdateCommandStrings.ko.xlf
+++ b/src/Aspire.Cli/Resources/xlf/UpdateCommandStrings.ko.xlf
@@ -37,6 +37,11 @@
         <target state="translated">업데이트 적용 중...</target>
         <note />
       </trans-unit>
+      <trans-unit id="BrewSelfUpdateMessage">
+        <source>This Aspire CLI was installed via Homebrew. To update it, run:</source>
+        <target state="new">This Aspire CLI was installed via Homebrew. To update it, run:</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CentralPackageManagementNotSupported">
         <source>Central package management is currently not supported by 'aspire update'.</source>
         <target state="translated">중앙 패키지 관리는 현재 'aspire update'에서 지원되지 않습니다.</target>
@@ -117,6 +122,11 @@
         <target state="needs-review-translation">참고: 해결할 수 없는 AppHost SDK 때문에 대체 구문 분석을 사용하여 업데이트 계획이 생성되었습니다. 종속성 분석의 정확도가 낮아질 수 있습니다.</target>
         <note />
       </trans-unit>
+      <trans-unit id="LocalHiveSelfUpdateMessage">
+        <source>This Aspire CLI is a local development build. To update it, rebuild from your Aspire checkout:</source>
+        <target state="new">This Aspire CLI is a local development build. To update it, rebuild from your Aspire checkout:</target>
+        <note />
+      </trans-unit>
       <trans-unit id="MappingAddedFormat">
         <source>   Mapping: {0} (added)</source>
         <target state="translated">   매핑: {0}(추가됨)</target>
@@ -182,6 +192,11 @@
         <target state="translated">업데이트를 수행하시겠습니까?</target>
         <note />
       </trans-unit>
+      <trans-unit id="PrSelfUpdateMessage">
+        <source>This Aspire CLI is a PR / dogfood build. It is pinned to a specific pull request; `--self` cannot update it. To re-install or update to a different PR, run:</source>
+        <target state="new">This Aspire CLI is a PR / dogfood build. It is pinned to a specific pull request; `--self` cannot update it. To re-install or update to a different PR, run:</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ProjectArgumentDescription">
         <source>The path to the Aspire AppHost project file or a directory to search</source>
         <target state="needs-review-translation">Aspire AppHost 프로젝트 파일의 경로입니다.</target>
@@ -242,6 +257,11 @@
         <target state="new">Update the Aspire CLI itself to the latest version</target>
         <note />
       </trans-unit>
+      <trans-unit id="SelfUpdateUnknownSourceMessage">
+        <source>Cannot determine how this Aspire CLI was installed (no install-route sidecar found). Refusing to perform an in-process self-update to avoid corrupting the binary. Re-run your original install command to update.</source>
+        <target state="new">Cannot determine how this Aspire CLI was installed (no install-route sidecar found). Refusing to perform an in-process self-update to avoid corrupting the binary. Re-run your original install command to update.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="UnxpectedCodePath">
         <source>Unexpected code path.</source>
         <target state="translated">예기치 않은 코드 경로입니다.</target>
@@ -265,6 +285,11 @@
       <trans-unit id="WhichDirectoryNuGetConfigPrompt">
         <source>Which directory for NuGet.config file?</source>
         <target state="translated">NuGet.config 파일의 디렉터리는 무엇인가요?</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WingetSelfUpdateMessage">
+        <source>This Aspire CLI was installed via WinGet. To update it, run:</source>
+        <target state="new">This Aspire CLI was installed via WinGet. To update it, run:</target>
         <note />
       </trans-unit>
       <trans-unit id="YesOptionDescription">

--- a/src/Aspire.Cli/Resources/xlf/UpdateCommandStrings.pl.xlf
+++ b/src/Aspire.Cli/Resources/xlf/UpdateCommandStrings.pl.xlf
@@ -38,8 +38,8 @@
         <note />
       </trans-unit>
       <trans-unit id="BrewSelfUpdateMessage">
-        <source>This Aspire CLI was installed via Homebrew. To update it, run:</source>
-        <target state="new">This Aspire CLI was installed via Homebrew. To update it, run:</target>
+        <source>This Aspire CLI was installed via Homebrew. To update it, run (or pass `--force` as a last-resort override to attempt an in-process update):</source>
+        <target state="new">This Aspire CLI was installed via Homebrew. To update it, run (or pass `--force` as a last-resort override to attempt an in-process update):</target>
         <note />
       </trans-unit>
       <trans-unit id="CentralPackageManagementNotSupported">
@@ -83,8 +83,8 @@
         <note />
       </trans-unit>
       <trans-unit id="DotNetToolSelfUpdateMessage">
-        <source>To update the Aspire CLI when installed as a .NET tool, run:</source>
-        <target state="translated">Aby zaktualizować interfejs wiersza polecenia Aspire po zainstalowaniu jako narzędzie platformy .NET, uruchom polecenie:</target>
+        <source>To update the Aspire CLI when installed as a .NET tool, run (or pass `--force` as a last-resort override to attempt an in-process update):</source>
+        <target state="needs-review-translation">Aby zaktualizować interfejs wiersza polecenia Aspire po zainstalowaniu jako narzędzie platformy .NET, uruchom polecenie:</target>
         <note />
       </trans-unit>
       <trans-unit id="ExecutingUpdateStepFormat">
@@ -122,9 +122,14 @@
         <target state="needs-review-translation">Uwaga: plan aktualizacji został wygenerowany przy użyciu analizy zapasowej z powodu nierozpoznanego zestawu AppHost SDK. Analiza zależności może być mniej dokładna.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ForceOptionDescription">
+        <source>Attempt an in-process self-update even when the install route is normally refused</source>
+        <target state="new">Attempt an in-process self-update even when the install route is normally refused</target>
+        <note />
+      </trans-unit>
       <trans-unit id="LocalHiveSelfUpdateMessage">
-        <source>This Aspire CLI is a local development build. To update it, rebuild from your Aspire checkout:</source>
-        <target state="new">This Aspire CLI is a local development build. To update it, rebuild from your Aspire checkout:</target>
+        <source>This Aspire CLI is a local development build. To update it, rebuild from your Aspire checkout (or pass `--force` as a last-resort override to attempt an in-process update):</source>
+        <target state="new">This Aspire CLI is a local development build. To update it, rebuild from your Aspire checkout (or pass `--force` as a last-resort override to attempt an in-process update):</target>
         <note />
       </trans-unit>
       <trans-unit id="MappingAddedFormat">
@@ -193,8 +198,8 @@
         <note />
       </trans-unit>
       <trans-unit id="PrSelfUpdateMessage">
-        <source>This Aspire CLI is a PR / dogfood build. It is pinned to a specific pull request; `--self` cannot update it. To re-install or update to a different PR, run:</source>
-        <target state="new">This Aspire CLI is a PR / dogfood build. It is pinned to a specific pull request; `--self` cannot update it. To re-install or update to a different PR, run:</target>
+        <source>This Aspire CLI is a PR / dogfood build. It is pinned to a specific pull request; `--self` cannot update it. To re-install or update to a different PR, run (or pass `--force` as a last-resort override to attempt an in-process update):</source>
+        <target state="new">This Aspire CLI is a PR / dogfood build. It is pinned to a specific pull request; `--self` cannot update it. To re-install or update to a different PR, run (or pass `--force` as a last-resort override to attempt an in-process update):</target>
         <note />
       </trans-unit>
       <trans-unit id="ProjectArgumentDescription">
@@ -258,8 +263,13 @@
         <note />
       </trans-unit>
       <trans-unit id="SelfUpdateUnknownSourceMessage">
-        <source>Cannot determine how this Aspire CLI was installed (no install-route sidecar found). Refusing to perform an in-process self-update to avoid corrupting the binary. Re-run your original install command to update.</source>
-        <target state="new">Cannot determine how this Aspire CLI was installed (no install-route sidecar found). Refusing to perform an in-process self-update to avoid corrupting the binary. Re-run your original install command to update.</target>
+        <source>Cannot determine how this Aspire CLI was installed. Refusing to perform an in-process self-update to avoid corrupting the binary.</source>
+        <target state="new">Cannot determine how this Aspire CLI was installed. Refusing to perform an in-process self-update to avoid corrupting the binary.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UnknownRouteRefusalHint">
+        <source>Aspire couldn't determine how this CLI was installed (`.aspire-install.json` is missing, unreadable, or has an unrecognized route). Investigate the install, or pass `--force` to attempt an in-process update anyway.</source>
+        <target state="new">Aspire couldn't determine how this CLI was installed (`.aspire-install.json` is missing, unreadable, or has an unrecognized route). Investigate the install, or pass `--force` to attempt an in-process update anyway.</target>
         <note />
       </trans-unit>
       <trans-unit id="UnxpectedCodePath">
@@ -288,8 +298,8 @@
         <note />
       </trans-unit>
       <trans-unit id="WingetSelfUpdateMessage">
-        <source>This Aspire CLI was installed via WinGet. To update it, run:</source>
-        <target state="new">This Aspire CLI was installed via WinGet. To update it, run:</target>
+        <source>This Aspire CLI was installed via WinGet. To update it, run (or pass `--force` as a last-resort override to attempt an in-process update):</source>
+        <target state="new">This Aspire CLI was installed via WinGet. To update it, run (or pass `--force` as a last-resort override to attempt an in-process update):</target>
         <note />
       </trans-unit>
       <trans-unit id="YesOptionDescription">

--- a/src/Aspire.Cli/Resources/xlf/UpdateCommandStrings.pl.xlf
+++ b/src/Aspire.Cli/Resources/xlf/UpdateCommandStrings.pl.xlf
@@ -37,6 +37,11 @@
         <target state="translated">Trwa stosowanie aktualizacji...</target>
         <note />
       </trans-unit>
+      <trans-unit id="BrewSelfUpdateMessage">
+        <source>This Aspire CLI was installed via Homebrew. To update it, run:</source>
+        <target state="new">This Aspire CLI was installed via Homebrew. To update it, run:</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CentralPackageManagementNotSupported">
         <source>Central package management is currently not supported by 'aspire update'.</source>
         <target state="translated">Centralne zarządzanie pakietami nie jest obecnie obsługiwane przez „aktualizację Aspire”.</target>
@@ -117,6 +122,11 @@
         <target state="needs-review-translation">Uwaga: plan aktualizacji został wygenerowany przy użyciu analizy zapasowej z powodu nierozpoznanego zestawu AppHost SDK. Analiza zależności może być mniej dokładna.</target>
         <note />
       </trans-unit>
+      <trans-unit id="LocalHiveSelfUpdateMessage">
+        <source>This Aspire CLI is a local development build. To update it, rebuild from your Aspire checkout:</source>
+        <target state="new">This Aspire CLI is a local development build. To update it, rebuild from your Aspire checkout:</target>
+        <note />
+      </trans-unit>
       <trans-unit id="MappingAddedFormat">
         <source>   Mapping: {0} (added)</source>
         <target state="translated">   Mapowanie: {0} (dodano)</target>
@@ -182,6 +192,11 @@
         <target state="translated">Wykonać aktualizacje?</target>
         <note />
       </trans-unit>
+      <trans-unit id="PrSelfUpdateMessage">
+        <source>This Aspire CLI is a PR / dogfood build. It is pinned to a specific pull request; `--self` cannot update it. To re-install or update to a different PR, run:</source>
+        <target state="new">This Aspire CLI is a PR / dogfood build. It is pinned to a specific pull request; `--self` cannot update it. To re-install or update to a different PR, run:</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ProjectArgumentDescription">
         <source>The path to the Aspire AppHost project file or a directory to search</source>
         <target state="needs-review-translation">Ścieżka do pliku projektu hosta AppHost platformy Aspire.</target>
@@ -242,6 +257,11 @@
         <target state="new">Update the Aspire CLI itself to the latest version</target>
         <note />
       </trans-unit>
+      <trans-unit id="SelfUpdateUnknownSourceMessage">
+        <source>Cannot determine how this Aspire CLI was installed (no install-route sidecar found). Refusing to perform an in-process self-update to avoid corrupting the binary. Re-run your original install command to update.</source>
+        <target state="new">Cannot determine how this Aspire CLI was installed (no install-route sidecar found). Refusing to perform an in-process self-update to avoid corrupting the binary. Re-run your original install command to update.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="UnxpectedCodePath">
         <source>Unexpected code path.</source>
         <target state="translated">Nieoczekiwana ścieżka w kodzie.</target>
@@ -265,6 +285,11 @@
       <trans-unit id="WhichDirectoryNuGetConfigPrompt">
         <source>Which directory for NuGet.config file?</source>
         <target state="translated">Który katalog dla pliku NuGet.config?</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WingetSelfUpdateMessage">
+        <source>This Aspire CLI was installed via WinGet. To update it, run:</source>
+        <target state="new">This Aspire CLI was installed via WinGet. To update it, run:</target>
         <note />
       </trans-unit>
       <trans-unit id="YesOptionDescription">

--- a/src/Aspire.Cli/Resources/xlf/UpdateCommandStrings.pt-BR.xlf
+++ b/src/Aspire.Cli/Resources/xlf/UpdateCommandStrings.pt-BR.xlf
@@ -38,8 +38,8 @@
         <note />
       </trans-unit>
       <trans-unit id="BrewSelfUpdateMessage">
-        <source>This Aspire CLI was installed via Homebrew. To update it, run:</source>
-        <target state="new">This Aspire CLI was installed via Homebrew. To update it, run:</target>
+        <source>This Aspire CLI was installed via Homebrew. To update it, run (or pass `--force` as a last-resort override to attempt an in-process update):</source>
+        <target state="new">This Aspire CLI was installed via Homebrew. To update it, run (or pass `--force` as a last-resort override to attempt an in-process update):</target>
         <note />
       </trans-unit>
       <trans-unit id="CentralPackageManagementNotSupported">
@@ -83,8 +83,8 @@
         <note />
       </trans-unit>
       <trans-unit id="DotNetToolSelfUpdateMessage">
-        <source>To update the Aspire CLI when installed as a .NET tool, run:</source>
-        <target state="translated">Para atualizar a CLI do Aspire quando instalada como uma ferramenta do .NET, execute:</target>
+        <source>To update the Aspire CLI when installed as a .NET tool, run (or pass `--force` as a last-resort override to attempt an in-process update):</source>
+        <target state="needs-review-translation">Para atualizar a CLI do Aspire quando instalada como uma ferramenta do .NET, execute:</target>
         <note />
       </trans-unit>
       <trans-unit id="ExecutingUpdateStepFormat">
@@ -122,9 +122,14 @@
         <target state="needs-review-translation">Observação: o plano de atualização gerado usando a análise de fallback devido ao SDK do AppHost não resolvido. A análise de dependência pode ter uma precisão reduzida.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ForceOptionDescription">
+        <source>Attempt an in-process self-update even when the install route is normally refused</source>
+        <target state="new">Attempt an in-process self-update even when the install route is normally refused</target>
+        <note />
+      </trans-unit>
       <trans-unit id="LocalHiveSelfUpdateMessage">
-        <source>This Aspire CLI is a local development build. To update it, rebuild from your Aspire checkout:</source>
-        <target state="new">This Aspire CLI is a local development build. To update it, rebuild from your Aspire checkout:</target>
+        <source>This Aspire CLI is a local development build. To update it, rebuild from your Aspire checkout (or pass `--force` as a last-resort override to attempt an in-process update):</source>
+        <target state="new">This Aspire CLI is a local development build. To update it, rebuild from your Aspire checkout (or pass `--force` as a last-resort override to attempt an in-process update):</target>
         <note />
       </trans-unit>
       <trans-unit id="MappingAddedFormat">
@@ -193,8 +198,8 @@
         <note />
       </trans-unit>
       <trans-unit id="PrSelfUpdateMessage">
-        <source>This Aspire CLI is a PR / dogfood build. It is pinned to a specific pull request; `--self` cannot update it. To re-install or update to a different PR, run:</source>
-        <target state="new">This Aspire CLI is a PR / dogfood build. It is pinned to a specific pull request; `--self` cannot update it. To re-install or update to a different PR, run:</target>
+        <source>This Aspire CLI is a PR / dogfood build. It is pinned to a specific pull request; `--self` cannot update it. To re-install or update to a different PR, run (or pass `--force` as a last-resort override to attempt an in-process update):</source>
+        <target state="new">This Aspire CLI is a PR / dogfood build. It is pinned to a specific pull request; `--self` cannot update it. To re-install or update to a different PR, run (or pass `--force` as a last-resort override to attempt an in-process update):</target>
         <note />
       </trans-unit>
       <trans-unit id="ProjectArgumentDescription">
@@ -258,8 +263,13 @@
         <note />
       </trans-unit>
       <trans-unit id="SelfUpdateUnknownSourceMessage">
-        <source>Cannot determine how this Aspire CLI was installed (no install-route sidecar found). Refusing to perform an in-process self-update to avoid corrupting the binary. Re-run your original install command to update.</source>
-        <target state="new">Cannot determine how this Aspire CLI was installed (no install-route sidecar found). Refusing to perform an in-process self-update to avoid corrupting the binary. Re-run your original install command to update.</target>
+        <source>Cannot determine how this Aspire CLI was installed. Refusing to perform an in-process self-update to avoid corrupting the binary.</source>
+        <target state="new">Cannot determine how this Aspire CLI was installed. Refusing to perform an in-process self-update to avoid corrupting the binary.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UnknownRouteRefusalHint">
+        <source>Aspire couldn't determine how this CLI was installed (`.aspire-install.json` is missing, unreadable, or has an unrecognized route). Investigate the install, or pass `--force` to attempt an in-process update anyway.</source>
+        <target state="new">Aspire couldn't determine how this CLI was installed (`.aspire-install.json` is missing, unreadable, or has an unrecognized route). Investigate the install, or pass `--force` to attempt an in-process update anyway.</target>
         <note />
       </trans-unit>
       <trans-unit id="UnxpectedCodePath">
@@ -288,8 +298,8 @@
         <note />
       </trans-unit>
       <trans-unit id="WingetSelfUpdateMessage">
-        <source>This Aspire CLI was installed via WinGet. To update it, run:</source>
-        <target state="new">This Aspire CLI was installed via WinGet. To update it, run:</target>
+        <source>This Aspire CLI was installed via WinGet. To update it, run (or pass `--force` as a last-resort override to attempt an in-process update):</source>
+        <target state="new">This Aspire CLI was installed via WinGet. To update it, run (or pass `--force` as a last-resort override to attempt an in-process update):</target>
         <note />
       </trans-unit>
       <trans-unit id="YesOptionDescription">

--- a/src/Aspire.Cli/Resources/xlf/UpdateCommandStrings.pt-BR.xlf
+++ b/src/Aspire.Cli/Resources/xlf/UpdateCommandStrings.pt-BR.xlf
@@ -37,6 +37,11 @@
         <target state="translated">Aplicando atualizações...</target>
         <note />
       </trans-unit>
+      <trans-unit id="BrewSelfUpdateMessage">
+        <source>This Aspire CLI was installed via Homebrew. To update it, run:</source>
+        <target state="new">This Aspire CLI was installed via Homebrew. To update it, run:</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CentralPackageManagementNotSupported">
         <source>Central package management is currently not supported by 'aspire update'.</source>
         <target state="translated">No momento, o gerenciamento central de pacotes por “atualização de atualização” não ´possui suporte.</target>
@@ -117,6 +122,11 @@
         <target state="needs-review-translation">Observação: o plano de atualização gerado usando a análise de fallback devido ao SDK do AppHost não resolvido. A análise de dependência pode ter uma precisão reduzida.</target>
         <note />
       </trans-unit>
+      <trans-unit id="LocalHiveSelfUpdateMessage">
+        <source>This Aspire CLI is a local development build. To update it, rebuild from your Aspire checkout:</source>
+        <target state="new">This Aspire CLI is a local development build. To update it, rebuild from your Aspire checkout:</target>
+        <note />
+      </trans-unit>
       <trans-unit id="MappingAddedFormat">
         <source>   Mapping: {0} (added)</source>
         <target state="translated">   Mapeamento: {0} (adicionado)</target>
@@ -182,6 +192,11 @@
         <target state="translated">Executar atualizações?</target>
         <note />
       </trans-unit>
+      <trans-unit id="PrSelfUpdateMessage">
+        <source>This Aspire CLI is a PR / dogfood build. It is pinned to a specific pull request; `--self` cannot update it. To re-install or update to a different PR, run:</source>
+        <target state="new">This Aspire CLI is a PR / dogfood build. It is pinned to a specific pull request; `--self` cannot update it. To re-install or update to a different PR, run:</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ProjectArgumentDescription">
         <source>The path to the Aspire AppHost project file or a directory to search</source>
         <target state="needs-review-translation">O caminho para o arquivo de projeto do Aspire AppHost.</target>
@@ -242,6 +257,11 @@
         <target state="new">Update the Aspire CLI itself to the latest version</target>
         <note />
       </trans-unit>
+      <trans-unit id="SelfUpdateUnknownSourceMessage">
+        <source>Cannot determine how this Aspire CLI was installed (no install-route sidecar found). Refusing to perform an in-process self-update to avoid corrupting the binary. Re-run your original install command to update.</source>
+        <target state="new">Cannot determine how this Aspire CLI was installed (no install-route sidecar found). Refusing to perform an in-process self-update to avoid corrupting the binary. Re-run your original install command to update.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="UnxpectedCodePath">
         <source>Unexpected code path.</source>
         <target state="translated">Caminho de código inesperado.</target>
@@ -265,6 +285,11 @@
       <trans-unit id="WhichDirectoryNuGetConfigPrompt">
         <source>Which directory for NuGet.config file?</source>
         <target state="translated">Qual diretório para o arquivo NuGet.config?</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WingetSelfUpdateMessage">
+        <source>This Aspire CLI was installed via WinGet. To update it, run:</source>
+        <target state="new">This Aspire CLI was installed via WinGet. To update it, run:</target>
         <note />
       </trans-unit>
       <trans-unit id="YesOptionDescription">

--- a/src/Aspire.Cli/Resources/xlf/UpdateCommandStrings.ru.xlf
+++ b/src/Aspire.Cli/Resources/xlf/UpdateCommandStrings.ru.xlf
@@ -38,8 +38,8 @@
         <note />
       </trans-unit>
       <trans-unit id="BrewSelfUpdateMessage">
-        <source>This Aspire CLI was installed via Homebrew. To update it, run:</source>
-        <target state="new">This Aspire CLI was installed via Homebrew. To update it, run:</target>
+        <source>This Aspire CLI was installed via Homebrew. To update it, run (or pass `--force` as a last-resort override to attempt an in-process update):</source>
+        <target state="new">This Aspire CLI was installed via Homebrew. To update it, run (or pass `--force` as a last-resort override to attempt an in-process update):</target>
         <note />
       </trans-unit>
       <trans-unit id="CentralPackageManagementNotSupported">
@@ -83,8 +83,8 @@
         <note />
       </trans-unit>
       <trans-unit id="DotNetToolSelfUpdateMessage">
-        <source>To update the Aspire CLI when installed as a .NET tool, run:</source>
-        <target state="translated">Чтобы обновить Aspire CLI при установке в качестве инструмента .NET, запустите:</target>
+        <source>To update the Aspire CLI when installed as a .NET tool, run (or pass `--force` as a last-resort override to attempt an in-process update):</source>
+        <target state="needs-review-translation">Чтобы обновить Aspire CLI при установке в качестве инструмента .NET, запустите:</target>
         <note />
       </trans-unit>
       <trans-unit id="ExecutingUpdateStepFormat">
@@ -122,9 +122,14 @@
         <target state="needs-review-translation">Примечание. План обновления создан с использованием резервного анализа из-за невозможности разрешить SDK AppHost. Точность анализа зависимостей может быть снижена.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ForceOptionDescription">
+        <source>Attempt an in-process self-update even when the install route is normally refused</source>
+        <target state="new">Attempt an in-process self-update even when the install route is normally refused</target>
+        <note />
+      </trans-unit>
       <trans-unit id="LocalHiveSelfUpdateMessage">
-        <source>This Aspire CLI is a local development build. To update it, rebuild from your Aspire checkout:</source>
-        <target state="new">This Aspire CLI is a local development build. To update it, rebuild from your Aspire checkout:</target>
+        <source>This Aspire CLI is a local development build. To update it, rebuild from your Aspire checkout (or pass `--force` as a last-resort override to attempt an in-process update):</source>
+        <target state="new">This Aspire CLI is a local development build. To update it, rebuild from your Aspire checkout (or pass `--force` as a last-resort override to attempt an in-process update):</target>
         <note />
       </trans-unit>
       <trans-unit id="MappingAddedFormat">
@@ -193,8 +198,8 @@
         <note />
       </trans-unit>
       <trans-unit id="PrSelfUpdateMessage">
-        <source>This Aspire CLI is a PR / dogfood build. It is pinned to a specific pull request; `--self` cannot update it. To re-install or update to a different PR, run:</source>
-        <target state="new">This Aspire CLI is a PR / dogfood build. It is pinned to a specific pull request; `--self` cannot update it. To re-install or update to a different PR, run:</target>
+        <source>This Aspire CLI is a PR / dogfood build. It is pinned to a specific pull request; `--self` cannot update it. To re-install or update to a different PR, run (or pass `--force` as a last-resort override to attempt an in-process update):</source>
+        <target state="new">This Aspire CLI is a PR / dogfood build. It is pinned to a specific pull request; `--self` cannot update it. To re-install or update to a different PR, run (or pass `--force` as a last-resort override to attempt an in-process update):</target>
         <note />
       </trans-unit>
       <trans-unit id="ProjectArgumentDescription">
@@ -258,8 +263,13 @@
         <note />
       </trans-unit>
       <trans-unit id="SelfUpdateUnknownSourceMessage">
-        <source>Cannot determine how this Aspire CLI was installed (no install-route sidecar found). Refusing to perform an in-process self-update to avoid corrupting the binary. Re-run your original install command to update.</source>
-        <target state="new">Cannot determine how this Aspire CLI was installed (no install-route sidecar found). Refusing to perform an in-process self-update to avoid corrupting the binary. Re-run your original install command to update.</target>
+        <source>Cannot determine how this Aspire CLI was installed. Refusing to perform an in-process self-update to avoid corrupting the binary.</source>
+        <target state="new">Cannot determine how this Aspire CLI was installed. Refusing to perform an in-process self-update to avoid corrupting the binary.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UnknownRouteRefusalHint">
+        <source>Aspire couldn't determine how this CLI was installed (`.aspire-install.json` is missing, unreadable, or has an unrecognized route). Investigate the install, or pass `--force` to attempt an in-process update anyway.</source>
+        <target state="new">Aspire couldn't determine how this CLI was installed (`.aspire-install.json` is missing, unreadable, or has an unrecognized route). Investigate the install, or pass `--force` to attempt an in-process update anyway.</target>
         <note />
       </trans-unit>
       <trans-unit id="UnxpectedCodePath">
@@ -288,8 +298,8 @@
         <note />
       </trans-unit>
       <trans-unit id="WingetSelfUpdateMessage">
-        <source>This Aspire CLI was installed via WinGet. To update it, run:</source>
-        <target state="new">This Aspire CLI was installed via WinGet. To update it, run:</target>
+        <source>This Aspire CLI was installed via WinGet. To update it, run (or pass `--force` as a last-resort override to attempt an in-process update):</source>
+        <target state="new">This Aspire CLI was installed via WinGet. To update it, run (or pass `--force` as a last-resort override to attempt an in-process update):</target>
         <note />
       </trans-unit>
       <trans-unit id="YesOptionDescription">

--- a/src/Aspire.Cli/Resources/xlf/UpdateCommandStrings.ru.xlf
+++ b/src/Aspire.Cli/Resources/xlf/UpdateCommandStrings.ru.xlf
@@ -37,6 +37,11 @@
         <target state="translated">Применение обновлений...</target>
         <note />
       </trans-unit>
+      <trans-unit id="BrewSelfUpdateMessage">
+        <source>This Aspire CLI was installed via Homebrew. To update it, run:</source>
+        <target state="new">This Aspire CLI was installed via Homebrew. To update it, run:</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CentralPackageManagementNotSupported">
         <source>Central package management is currently not supported by 'aspire update'.</source>
         <target state="translated">Централизованное управление пакетами в настоящее время не поддерживается функцией "обновление Aspire".</target>
@@ -117,6 +122,11 @@
         <target state="needs-review-translation">Примечание. План обновления создан с использованием резервного анализа из-за невозможности разрешить SDK AppHost. Точность анализа зависимостей может быть снижена.</target>
         <note />
       </trans-unit>
+      <trans-unit id="LocalHiveSelfUpdateMessage">
+        <source>This Aspire CLI is a local development build. To update it, rebuild from your Aspire checkout:</source>
+        <target state="new">This Aspire CLI is a local development build. To update it, rebuild from your Aspire checkout:</target>
+        <note />
+      </trans-unit>
       <trans-unit id="MappingAddedFormat">
         <source>   Mapping: {0} (added)</source>
         <target state="translated">   Сопоставление: {0} (добавлено)</target>
@@ -182,6 +192,11 @@
         <target state="translated">Выполнить обновления?</target>
         <note />
       </trans-unit>
+      <trans-unit id="PrSelfUpdateMessage">
+        <source>This Aspire CLI is a PR / dogfood build. It is pinned to a specific pull request; `--self` cannot update it. To re-install or update to a different PR, run:</source>
+        <target state="new">This Aspire CLI is a PR / dogfood build. It is pinned to a specific pull request; `--self` cannot update it. To re-install or update to a different PR, run:</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ProjectArgumentDescription">
         <source>The path to the Aspire AppHost project file or a directory to search</source>
         <target state="needs-review-translation">Путь к файлу проекта Aspire AppHost.</target>
@@ -242,6 +257,11 @@
         <target state="new">Update the Aspire CLI itself to the latest version</target>
         <note />
       </trans-unit>
+      <trans-unit id="SelfUpdateUnknownSourceMessage">
+        <source>Cannot determine how this Aspire CLI was installed (no install-route sidecar found). Refusing to perform an in-process self-update to avoid corrupting the binary. Re-run your original install command to update.</source>
+        <target state="new">Cannot determine how this Aspire CLI was installed (no install-route sidecar found). Refusing to perform an in-process self-update to avoid corrupting the binary. Re-run your original install command to update.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="UnxpectedCodePath">
         <source>Unexpected code path.</source>
         <target state="translated">Непредвиденный путь к коду.</target>
@@ -265,6 +285,11 @@
       <trans-unit id="WhichDirectoryNuGetConfigPrompt">
         <source>Which directory for NuGet.config file?</source>
         <target state="translated">Какой каталог для файла NuGet.config?</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WingetSelfUpdateMessage">
+        <source>This Aspire CLI was installed via WinGet. To update it, run:</source>
+        <target state="new">This Aspire CLI was installed via WinGet. To update it, run:</target>
         <note />
       </trans-unit>
       <trans-unit id="YesOptionDescription">

--- a/src/Aspire.Cli/Resources/xlf/UpdateCommandStrings.tr.xlf
+++ b/src/Aspire.Cli/Resources/xlf/UpdateCommandStrings.tr.xlf
@@ -38,8 +38,8 @@
         <note />
       </trans-unit>
       <trans-unit id="BrewSelfUpdateMessage">
-        <source>This Aspire CLI was installed via Homebrew. To update it, run:</source>
-        <target state="new">This Aspire CLI was installed via Homebrew. To update it, run:</target>
+        <source>This Aspire CLI was installed via Homebrew. To update it, run (or pass `--force` as a last-resort override to attempt an in-process update):</source>
+        <target state="new">This Aspire CLI was installed via Homebrew. To update it, run (or pass `--force` as a last-resort override to attempt an in-process update):</target>
         <note />
       </trans-unit>
       <trans-unit id="CentralPackageManagementNotSupported">
@@ -83,8 +83,8 @@
         <note />
       </trans-unit>
       <trans-unit id="DotNetToolSelfUpdateMessage">
-        <source>To update the Aspire CLI when installed as a .NET tool, run:</source>
-        <target state="translated">.NET aracı olarak yüklenen Aspire CLI’yı güncelleştirmek için şu komutu çalıştırın:</target>
+        <source>To update the Aspire CLI when installed as a .NET tool, run (or pass `--force` as a last-resort override to attempt an in-process update):</source>
+        <target state="needs-review-translation">.NET aracı olarak yüklenen Aspire CLI’yı güncelleştirmek için şu komutu çalıştırın:</target>
         <note />
       </trans-unit>
       <trans-unit id="ExecutingUpdateStepFormat">
@@ -122,9 +122,14 @@
         <target state="needs-review-translation">Not: Çözülemeyen AppHost SDK nedeniyle geri dönüş ayrıştırması kullanılarak oluşturulan güncelleştirme planı. Bağımlılık analizi doğruluğu azaltmış olabilir.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ForceOptionDescription">
+        <source>Attempt an in-process self-update even when the install route is normally refused</source>
+        <target state="new">Attempt an in-process self-update even when the install route is normally refused</target>
+        <note />
+      </trans-unit>
       <trans-unit id="LocalHiveSelfUpdateMessage">
-        <source>This Aspire CLI is a local development build. To update it, rebuild from your Aspire checkout:</source>
-        <target state="new">This Aspire CLI is a local development build. To update it, rebuild from your Aspire checkout:</target>
+        <source>This Aspire CLI is a local development build. To update it, rebuild from your Aspire checkout (or pass `--force` as a last-resort override to attempt an in-process update):</source>
+        <target state="new">This Aspire CLI is a local development build. To update it, rebuild from your Aspire checkout (or pass `--force` as a last-resort override to attempt an in-process update):</target>
         <note />
       </trans-unit>
       <trans-unit id="MappingAddedFormat">
@@ -193,8 +198,8 @@
         <note />
       </trans-unit>
       <trans-unit id="PrSelfUpdateMessage">
-        <source>This Aspire CLI is a PR / dogfood build. It is pinned to a specific pull request; `--self` cannot update it. To re-install or update to a different PR, run:</source>
-        <target state="new">This Aspire CLI is a PR / dogfood build. It is pinned to a specific pull request; `--self` cannot update it. To re-install or update to a different PR, run:</target>
+        <source>This Aspire CLI is a PR / dogfood build. It is pinned to a specific pull request; `--self` cannot update it. To re-install or update to a different PR, run (or pass `--force` as a last-resort override to attempt an in-process update):</source>
+        <target state="new">This Aspire CLI is a PR / dogfood build. It is pinned to a specific pull request; `--self` cannot update it. To re-install or update to a different PR, run (or pass `--force` as a last-resort override to attempt an in-process update):</target>
         <note />
       </trans-unit>
       <trans-unit id="ProjectArgumentDescription">
@@ -258,8 +263,13 @@
         <note />
       </trans-unit>
       <trans-unit id="SelfUpdateUnknownSourceMessage">
-        <source>Cannot determine how this Aspire CLI was installed (no install-route sidecar found). Refusing to perform an in-process self-update to avoid corrupting the binary. Re-run your original install command to update.</source>
-        <target state="new">Cannot determine how this Aspire CLI was installed (no install-route sidecar found). Refusing to perform an in-process self-update to avoid corrupting the binary. Re-run your original install command to update.</target>
+        <source>Cannot determine how this Aspire CLI was installed. Refusing to perform an in-process self-update to avoid corrupting the binary.</source>
+        <target state="new">Cannot determine how this Aspire CLI was installed. Refusing to perform an in-process self-update to avoid corrupting the binary.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UnknownRouteRefusalHint">
+        <source>Aspire couldn't determine how this CLI was installed (`.aspire-install.json` is missing, unreadable, or has an unrecognized route). Investigate the install, or pass `--force` to attempt an in-process update anyway.</source>
+        <target state="new">Aspire couldn't determine how this CLI was installed (`.aspire-install.json` is missing, unreadable, or has an unrecognized route). Investigate the install, or pass `--force` to attempt an in-process update anyway.</target>
         <note />
       </trans-unit>
       <trans-unit id="UnxpectedCodePath">
@@ -288,8 +298,8 @@
         <note />
       </trans-unit>
       <trans-unit id="WingetSelfUpdateMessage">
-        <source>This Aspire CLI was installed via WinGet. To update it, run:</source>
-        <target state="new">This Aspire CLI was installed via WinGet. To update it, run:</target>
+        <source>This Aspire CLI was installed via WinGet. To update it, run (or pass `--force` as a last-resort override to attempt an in-process update):</source>
+        <target state="new">This Aspire CLI was installed via WinGet. To update it, run (or pass `--force` as a last-resort override to attempt an in-process update):</target>
         <note />
       </trans-unit>
       <trans-unit id="YesOptionDescription">

--- a/src/Aspire.Cli/Resources/xlf/UpdateCommandStrings.tr.xlf
+++ b/src/Aspire.Cli/Resources/xlf/UpdateCommandStrings.tr.xlf
@@ -37,6 +37,11 @@
         <target state="translated">Güncelleştirmeler uygulanıyor...</target>
         <note />
       </trans-unit>
+      <trans-unit id="BrewSelfUpdateMessage">
+        <source>This Aspire CLI was installed via Homebrew. To update it, run:</source>
+        <target state="new">This Aspire CLI was installed via Homebrew. To update it, run:</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CentralPackageManagementNotSupported">
         <source>Central package management is currently not supported by 'aspire update'.</source>
         <target state="translated">Merkezi paket yönetimi şu anda 'aspire update' tarafından desteklenmiyor.</target>
@@ -117,6 +122,11 @@
         <target state="needs-review-translation">Not: Çözülemeyen AppHost SDK nedeniyle geri dönüş ayrıştırması kullanılarak oluşturulan güncelleştirme planı. Bağımlılık analizi doğruluğu azaltmış olabilir.</target>
         <note />
       </trans-unit>
+      <trans-unit id="LocalHiveSelfUpdateMessage">
+        <source>This Aspire CLI is a local development build. To update it, rebuild from your Aspire checkout:</source>
+        <target state="new">This Aspire CLI is a local development build. To update it, rebuild from your Aspire checkout:</target>
+        <note />
+      </trans-unit>
       <trans-unit id="MappingAddedFormat">
         <source>   Mapping: {0} (added)</source>
         <target state="translated">   Eşleme: {0} (eklendi)</target>
@@ -182,6 +192,11 @@
         <target state="translated">Güncelleştirmeler uygulansın mı?</target>
         <note />
       </trans-unit>
+      <trans-unit id="PrSelfUpdateMessage">
+        <source>This Aspire CLI is a PR / dogfood build. It is pinned to a specific pull request; `--self` cannot update it. To re-install or update to a different PR, run:</source>
+        <target state="new">This Aspire CLI is a PR / dogfood build. It is pinned to a specific pull request; `--self` cannot update it. To re-install or update to a different PR, run:</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ProjectArgumentDescription">
         <source>The path to the Aspire AppHost project file or a directory to search</source>
         <target state="needs-review-translation">Aspire AppHost proje dosyasının yolu.</target>
@@ -242,6 +257,11 @@
         <target state="new">Update the Aspire CLI itself to the latest version</target>
         <note />
       </trans-unit>
+      <trans-unit id="SelfUpdateUnknownSourceMessage">
+        <source>Cannot determine how this Aspire CLI was installed (no install-route sidecar found). Refusing to perform an in-process self-update to avoid corrupting the binary. Re-run your original install command to update.</source>
+        <target state="new">Cannot determine how this Aspire CLI was installed (no install-route sidecar found). Refusing to perform an in-process self-update to avoid corrupting the binary. Re-run your original install command to update.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="UnxpectedCodePath">
         <source>Unexpected code path.</source>
         <target state="translated">Beklenmeyen kod yolu.</target>
@@ -265,6 +285,11 @@
       <trans-unit id="WhichDirectoryNuGetConfigPrompt">
         <source>Which directory for NuGet.config file?</source>
         <target state="translated">NuGet.config dosyası için hangi dizin kullanılsın?</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WingetSelfUpdateMessage">
+        <source>This Aspire CLI was installed via WinGet. To update it, run:</source>
+        <target state="new">This Aspire CLI was installed via WinGet. To update it, run:</target>
         <note />
       </trans-unit>
       <trans-unit id="YesOptionDescription">

--- a/src/Aspire.Cli/Resources/xlf/UpdateCommandStrings.zh-Hans.xlf
+++ b/src/Aspire.Cli/Resources/xlf/UpdateCommandStrings.zh-Hans.xlf
@@ -38,8 +38,8 @@
         <note />
       </trans-unit>
       <trans-unit id="BrewSelfUpdateMessage">
-        <source>This Aspire CLI was installed via Homebrew. To update it, run:</source>
-        <target state="new">This Aspire CLI was installed via Homebrew. To update it, run:</target>
+        <source>This Aspire CLI was installed via Homebrew. To update it, run (or pass `--force` as a last-resort override to attempt an in-process update):</source>
+        <target state="new">This Aspire CLI was installed via Homebrew. To update it, run (or pass `--force` as a last-resort override to attempt an in-process update):</target>
         <note />
       </trans-unit>
       <trans-unit id="CentralPackageManagementNotSupported">
@@ -83,8 +83,8 @@
         <note />
       </trans-unit>
       <trans-unit id="DotNetToolSelfUpdateMessage">
-        <source>To update the Aspire CLI when installed as a .NET tool, run:</source>
-        <target state="translated">若要在 Aspire CLI 作为 .NET 工具安装时对其进行更新，请运行:</target>
+        <source>To update the Aspire CLI when installed as a .NET tool, run (or pass `--force` as a last-resort override to attempt an in-process update):</source>
+        <target state="needs-review-translation">若要在 Aspire CLI 作为 .NET 工具安装时对其进行更新，请运行:</target>
         <note />
       </trans-unit>
       <trans-unit id="ExecutingUpdateStepFormat">
@@ -122,9 +122,14 @@
         <target state="needs-review-translation">注意: 由于 AppHost SDK 无法解析，已采用回退解析生成更新计划。依赖项分析的准确性可能有所降低。</target>
         <note />
       </trans-unit>
+      <trans-unit id="ForceOptionDescription">
+        <source>Attempt an in-process self-update even when the install route is normally refused</source>
+        <target state="new">Attempt an in-process self-update even when the install route is normally refused</target>
+        <note />
+      </trans-unit>
       <trans-unit id="LocalHiveSelfUpdateMessage">
-        <source>This Aspire CLI is a local development build. To update it, rebuild from your Aspire checkout:</source>
-        <target state="new">This Aspire CLI is a local development build. To update it, rebuild from your Aspire checkout:</target>
+        <source>This Aspire CLI is a local development build. To update it, rebuild from your Aspire checkout (or pass `--force` as a last-resort override to attempt an in-process update):</source>
+        <target state="new">This Aspire CLI is a local development build. To update it, rebuild from your Aspire checkout (or pass `--force` as a last-resort override to attempt an in-process update):</target>
         <note />
       </trans-unit>
       <trans-unit id="MappingAddedFormat">
@@ -193,8 +198,8 @@
         <note />
       </trans-unit>
       <trans-unit id="PrSelfUpdateMessage">
-        <source>This Aspire CLI is a PR / dogfood build. It is pinned to a specific pull request; `--self` cannot update it. To re-install or update to a different PR, run:</source>
-        <target state="new">This Aspire CLI is a PR / dogfood build. It is pinned to a specific pull request; `--self` cannot update it. To re-install or update to a different PR, run:</target>
+        <source>This Aspire CLI is a PR / dogfood build. It is pinned to a specific pull request; `--self` cannot update it. To re-install or update to a different PR, run (or pass `--force` as a last-resort override to attempt an in-process update):</source>
+        <target state="new">This Aspire CLI is a PR / dogfood build. It is pinned to a specific pull request; `--self` cannot update it. To re-install or update to a different PR, run (or pass `--force` as a last-resort override to attempt an in-process update):</target>
         <note />
       </trans-unit>
       <trans-unit id="ProjectArgumentDescription">
@@ -258,8 +263,13 @@
         <note />
       </trans-unit>
       <trans-unit id="SelfUpdateUnknownSourceMessage">
-        <source>Cannot determine how this Aspire CLI was installed (no install-route sidecar found). Refusing to perform an in-process self-update to avoid corrupting the binary. Re-run your original install command to update.</source>
-        <target state="new">Cannot determine how this Aspire CLI was installed (no install-route sidecar found). Refusing to perform an in-process self-update to avoid corrupting the binary. Re-run your original install command to update.</target>
+        <source>Cannot determine how this Aspire CLI was installed. Refusing to perform an in-process self-update to avoid corrupting the binary.</source>
+        <target state="new">Cannot determine how this Aspire CLI was installed. Refusing to perform an in-process self-update to avoid corrupting the binary.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UnknownRouteRefusalHint">
+        <source>Aspire couldn't determine how this CLI was installed (`.aspire-install.json` is missing, unreadable, or has an unrecognized route). Investigate the install, or pass `--force` to attempt an in-process update anyway.</source>
+        <target state="new">Aspire couldn't determine how this CLI was installed (`.aspire-install.json` is missing, unreadable, or has an unrecognized route). Investigate the install, or pass `--force` to attempt an in-process update anyway.</target>
         <note />
       </trans-unit>
       <trans-unit id="UnxpectedCodePath">
@@ -288,8 +298,8 @@
         <note />
       </trans-unit>
       <trans-unit id="WingetSelfUpdateMessage">
-        <source>This Aspire CLI was installed via WinGet. To update it, run:</source>
-        <target state="new">This Aspire CLI was installed via WinGet. To update it, run:</target>
+        <source>This Aspire CLI was installed via WinGet. To update it, run (or pass `--force` as a last-resort override to attempt an in-process update):</source>
+        <target state="new">This Aspire CLI was installed via WinGet. To update it, run (or pass `--force` as a last-resort override to attempt an in-process update):</target>
         <note />
       </trans-unit>
       <trans-unit id="YesOptionDescription">

--- a/src/Aspire.Cli/Resources/xlf/UpdateCommandStrings.zh-Hans.xlf
+++ b/src/Aspire.Cli/Resources/xlf/UpdateCommandStrings.zh-Hans.xlf
@@ -37,6 +37,11 @@
         <target state="translated">正在应用更新...</target>
         <note />
       </trans-unit>
+      <trans-unit id="BrewSelfUpdateMessage">
+        <source>This Aspire CLI was installed via Homebrew. To update it, run:</source>
+        <target state="new">This Aspire CLI was installed via Homebrew. To update it, run:</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CentralPackageManagementNotSupported">
         <source>Central package management is currently not supported by 'aspire update'.</source>
         <target state="translated">"aspire update" 当前不支持中央包管理。</target>
@@ -117,6 +122,11 @@
         <target state="needs-review-translation">注意: 由于 AppHost SDK 无法解析，已采用回退解析生成更新计划。依赖项分析的准确性可能有所降低。</target>
         <note />
       </trans-unit>
+      <trans-unit id="LocalHiveSelfUpdateMessage">
+        <source>This Aspire CLI is a local development build. To update it, rebuild from your Aspire checkout:</source>
+        <target state="new">This Aspire CLI is a local development build. To update it, rebuild from your Aspire checkout:</target>
+        <note />
+      </trans-unit>
       <trans-unit id="MappingAddedFormat">
         <source>   Mapping: {0} (added)</source>
         <target state="translated">   映射: {0} (已添加)</target>
@@ -182,6 +192,11 @@
         <target state="translated">是否执行更新?</target>
         <note />
       </trans-unit>
+      <trans-unit id="PrSelfUpdateMessage">
+        <source>This Aspire CLI is a PR / dogfood build. It is pinned to a specific pull request; `--self` cannot update it. To re-install or update to a different PR, run:</source>
+        <target state="new">This Aspire CLI is a PR / dogfood build. It is pinned to a specific pull request; `--self` cannot update it. To re-install or update to a different PR, run:</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ProjectArgumentDescription">
         <source>The path to the Aspire AppHost project file or a directory to search</source>
         <target state="needs-review-translation">Aspire AppHost 项目文件的路径。</target>
@@ -242,6 +257,11 @@
         <target state="new">Update the Aspire CLI itself to the latest version</target>
         <note />
       </trans-unit>
+      <trans-unit id="SelfUpdateUnknownSourceMessage">
+        <source>Cannot determine how this Aspire CLI was installed (no install-route sidecar found). Refusing to perform an in-process self-update to avoid corrupting the binary. Re-run your original install command to update.</source>
+        <target state="new">Cannot determine how this Aspire CLI was installed (no install-route sidecar found). Refusing to perform an in-process self-update to avoid corrupting the binary. Re-run your original install command to update.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="UnxpectedCodePath">
         <source>Unexpected code path.</source>
         <target state="translated">意外的代码路径。</target>
@@ -265,6 +285,11 @@
       <trans-unit id="WhichDirectoryNuGetConfigPrompt">
         <source>Which directory for NuGet.config file?</source>
         <target state="translated">NuGet.config 文件位于哪个目录?</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WingetSelfUpdateMessage">
+        <source>This Aspire CLI was installed via WinGet. To update it, run:</source>
+        <target state="new">This Aspire CLI was installed via WinGet. To update it, run:</target>
         <note />
       </trans-unit>
       <trans-unit id="YesOptionDescription">

--- a/src/Aspire.Cli/Resources/xlf/UpdateCommandStrings.zh-Hant.xlf
+++ b/src/Aspire.Cli/Resources/xlf/UpdateCommandStrings.zh-Hant.xlf
@@ -38,8 +38,8 @@
         <note />
       </trans-unit>
       <trans-unit id="BrewSelfUpdateMessage">
-        <source>This Aspire CLI was installed via Homebrew. To update it, run:</source>
-        <target state="new">This Aspire CLI was installed via Homebrew. To update it, run:</target>
+        <source>This Aspire CLI was installed via Homebrew. To update it, run (or pass `--force` as a last-resort override to attempt an in-process update):</source>
+        <target state="new">This Aspire CLI was installed via Homebrew. To update it, run (or pass `--force` as a last-resort override to attempt an in-process update):</target>
         <note />
       </trans-unit>
       <trans-unit id="CentralPackageManagementNotSupported">
@@ -83,8 +83,8 @@
         <note />
       </trans-unit>
       <trans-unit id="DotNetToolSelfUpdateMessage">
-        <source>To update the Aspire CLI when installed as a .NET tool, run:</source>
-        <target state="translated">若要以 .NET 工具形式安裝 Aspire CLI，請執行:</target>
+        <source>To update the Aspire CLI when installed as a .NET tool, run (or pass `--force` as a last-resort override to attempt an in-process update):</source>
+        <target state="needs-review-translation">若要以 .NET 工具形式安裝 Aspire CLI，請執行:</target>
         <note />
       </trans-unit>
       <trans-unit id="ExecutingUpdateStepFormat">
@@ -122,9 +122,14 @@
         <target state="needs-review-translation">注意: 由於無法解析的 AppHost SDK，已使用後援剖析產生更新計劃。相依性分析的正確性可能因此降低。</target>
         <note />
       </trans-unit>
+      <trans-unit id="ForceOptionDescription">
+        <source>Attempt an in-process self-update even when the install route is normally refused</source>
+        <target state="new">Attempt an in-process self-update even when the install route is normally refused</target>
+        <note />
+      </trans-unit>
       <trans-unit id="LocalHiveSelfUpdateMessage">
-        <source>This Aspire CLI is a local development build. To update it, rebuild from your Aspire checkout:</source>
-        <target state="new">This Aspire CLI is a local development build. To update it, rebuild from your Aspire checkout:</target>
+        <source>This Aspire CLI is a local development build. To update it, rebuild from your Aspire checkout (or pass `--force` as a last-resort override to attempt an in-process update):</source>
+        <target state="new">This Aspire CLI is a local development build. To update it, rebuild from your Aspire checkout (or pass `--force` as a last-resort override to attempt an in-process update):</target>
         <note />
       </trans-unit>
       <trans-unit id="MappingAddedFormat">
@@ -193,8 +198,8 @@
         <note />
       </trans-unit>
       <trans-unit id="PrSelfUpdateMessage">
-        <source>This Aspire CLI is a PR / dogfood build. It is pinned to a specific pull request; `--self` cannot update it. To re-install or update to a different PR, run:</source>
-        <target state="new">This Aspire CLI is a PR / dogfood build. It is pinned to a specific pull request; `--self` cannot update it. To re-install or update to a different PR, run:</target>
+        <source>This Aspire CLI is a PR / dogfood build. It is pinned to a specific pull request; `--self` cannot update it. To re-install or update to a different PR, run (or pass `--force` as a last-resort override to attempt an in-process update):</source>
+        <target state="new">This Aspire CLI is a PR / dogfood build. It is pinned to a specific pull request; `--self` cannot update it. To re-install or update to a different PR, run (or pass `--force` as a last-resort override to attempt an in-process update):</target>
         <note />
       </trans-unit>
       <trans-unit id="ProjectArgumentDescription">
@@ -258,8 +263,13 @@
         <note />
       </trans-unit>
       <trans-unit id="SelfUpdateUnknownSourceMessage">
-        <source>Cannot determine how this Aspire CLI was installed (no install-route sidecar found). Refusing to perform an in-process self-update to avoid corrupting the binary. Re-run your original install command to update.</source>
-        <target state="new">Cannot determine how this Aspire CLI was installed (no install-route sidecar found). Refusing to perform an in-process self-update to avoid corrupting the binary. Re-run your original install command to update.</target>
+        <source>Cannot determine how this Aspire CLI was installed. Refusing to perform an in-process self-update to avoid corrupting the binary.</source>
+        <target state="new">Cannot determine how this Aspire CLI was installed. Refusing to perform an in-process self-update to avoid corrupting the binary.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UnknownRouteRefusalHint">
+        <source>Aspire couldn't determine how this CLI was installed (`.aspire-install.json` is missing, unreadable, or has an unrecognized route). Investigate the install, or pass `--force` to attempt an in-process update anyway.</source>
+        <target state="new">Aspire couldn't determine how this CLI was installed (`.aspire-install.json` is missing, unreadable, or has an unrecognized route). Investigate the install, or pass `--force` to attempt an in-process update anyway.</target>
         <note />
       </trans-unit>
       <trans-unit id="UnxpectedCodePath">
@@ -288,8 +298,8 @@
         <note />
       </trans-unit>
       <trans-unit id="WingetSelfUpdateMessage">
-        <source>This Aspire CLI was installed via WinGet. To update it, run:</source>
-        <target state="new">This Aspire CLI was installed via WinGet. To update it, run:</target>
+        <source>This Aspire CLI was installed via WinGet. To update it, run (or pass `--force` as a last-resort override to attempt an in-process update):</source>
+        <target state="new">This Aspire CLI was installed via WinGet. To update it, run (or pass `--force` as a last-resort override to attempt an in-process update):</target>
         <note />
       </trans-unit>
       <trans-unit id="YesOptionDescription">

--- a/src/Aspire.Cli/Resources/xlf/UpdateCommandStrings.zh-Hant.xlf
+++ b/src/Aspire.Cli/Resources/xlf/UpdateCommandStrings.zh-Hant.xlf
@@ -37,6 +37,11 @@
         <target state="translated">正在套用更新...</target>
         <note />
       </trans-unit>
+      <trans-unit id="BrewSelfUpdateMessage">
+        <source>This Aspire CLI was installed via Homebrew. To update it, run:</source>
+        <target state="new">This Aspire CLI was installed via Homebrew. To update it, run:</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CentralPackageManagementNotSupported">
         <source>Central package management is currently not supported by 'aspire update'.</source>
         <target state="translated">中央套件管理目前不受 'aspire update' 支援。</target>
@@ -117,6 +122,11 @@
         <target state="needs-review-translation">注意: 由於無法解析的 AppHost SDK，已使用後援剖析產生更新計劃。相依性分析的正確性可能因此降低。</target>
         <note />
       </trans-unit>
+      <trans-unit id="LocalHiveSelfUpdateMessage">
+        <source>This Aspire CLI is a local development build. To update it, rebuild from your Aspire checkout:</source>
+        <target state="new">This Aspire CLI is a local development build. To update it, rebuild from your Aspire checkout:</target>
+        <note />
+      </trans-unit>
       <trans-unit id="MappingAddedFormat">
         <source>   Mapping: {0} (added)</source>
         <target state="translated">   對應: {0} (已新增)</target>
@@ -182,6 +192,11 @@
         <target state="translated">執行更新?</target>
         <note />
       </trans-unit>
+      <trans-unit id="PrSelfUpdateMessage">
+        <source>This Aspire CLI is a PR / dogfood build. It is pinned to a specific pull request; `--self` cannot update it. To re-install or update to a different PR, run:</source>
+        <target state="new">This Aspire CLI is a PR / dogfood build. It is pinned to a specific pull request; `--self` cannot update it. To re-install or update to a different PR, run:</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ProjectArgumentDescription">
         <source>The path to the Aspire AppHost project file or a directory to search</source>
         <target state="needs-review-translation">Aspire AppHost 專案檔案的路徑。</target>
@@ -242,6 +257,11 @@
         <target state="new">Update the Aspire CLI itself to the latest version</target>
         <note />
       </trans-unit>
+      <trans-unit id="SelfUpdateUnknownSourceMessage">
+        <source>Cannot determine how this Aspire CLI was installed (no install-route sidecar found). Refusing to perform an in-process self-update to avoid corrupting the binary. Re-run your original install command to update.</source>
+        <target state="new">Cannot determine how this Aspire CLI was installed (no install-route sidecar found). Refusing to perform an in-process self-update to avoid corrupting the binary. Re-run your original install command to update.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="UnxpectedCodePath">
         <source>Unexpected code path.</source>
         <target state="translated">未預期的程式碼路徑。</target>
@@ -265,6 +285,11 @@
       <trans-unit id="WhichDirectoryNuGetConfigPrompt">
         <source>Which directory for NuGet.config file?</source>
         <target state="translated">哪個目錄用於 NuGet.config 檔案?</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WingetSelfUpdateMessage">
+        <source>This Aspire CLI was installed via WinGet. To update it, run:</source>
+        <target state="new">This Aspire CLI was installed via WinGet. To update it, run:</target>
         <note />
       </trans-unit>
       <trans-unit id="YesOptionDescription">

--- a/src/Aspire.Cli/Utils/CliUpdateNotifier.cs
+++ b/src/Aspire.Cli/Utils/CliUpdateNotifier.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using Aspire.Cli.Acquisition;
 using Aspire.Cli.Interaction;
 using Aspire.Cli.NuGet;
 using Aspire.Shared;
@@ -43,7 +44,10 @@ internal static class PackageUpdateRecommendationChannels
 internal class CliUpdateNotifier(
     ILogger<CliUpdateNotifier> logger,
     INuGetPackageCache nuGetPackageCache,
-    IInteractionService interactionService) : ICliUpdateNotifier
+    IInteractionService interactionService,
+    IInstallationDiscovery installationDiscovery,
+    IUpgradeInstructionProvider upgradeInstructionProvider,
+    CliExecutionContext executionContext) : ICliUpdateNotifier
 {
     private IEnumerable<Shared.NuGetPackageCli>? _availablePackages;
 
@@ -116,7 +120,7 @@ internal class CliUpdateNotifier(
         }
 
         var newerVersion = PackageUpdateHelpers.GetNewerVersion(logger, currentVersion, _availablePackages);
-        var updateCommand = newerVersion is null ? null : DotNetToolDetection.GetDotNetToolUpdateCommand() ?? "aspire update";
+        var updateCommand = newerVersion is null ? null : GetRouteAwareUpdateCommand();
         // Derive the lane the recommendation comes from so doctor can show
         // 'Latest version is X (channel: stable)' vs '(channel: prerelease)'.
         // GetNewerVersion picks between newestStable and newestPrerelease
@@ -127,6 +131,33 @@ internal class CliUpdateNotifier(
             ? null
             : (newerVersion.IsPrerelease ? PackageUpdateRecommendationChannels.Prerelease : PackageUpdateRecommendationChannels.Stable);
         return new CliVersionStatus(currentVersionString, newerVersion?.ToString(), updateCommand, UpdateCheckError: null, LatestVersionChannel: latestChannel);
+    }
+
+    /// <summary>
+    /// Returns the route-appropriate command to recommend in the
+    /// "version X available" notification. For script-route and Unknown
+    /// installs we suggest <c>aspire update --self</c> (which actually
+    /// performs the in-process update for script). For every other route we
+    /// defer to <see cref="IUpgradeInstructionProvider"/> so users see the
+    /// command that matches how they installed the CLI (winget upgrade,
+    /// brew upgrade --cask, dotnet tool update, get-aspire-cli-pr, etc.).
+    /// </summary>
+    private string GetRouteAwareUpdateCommand()
+    {
+        var info = installationDiscovery.DescribeSelf();
+        var source = InstallSourceExtensions.ParseInstallSource(info.Route);
+        var canonicalPath = info.CanonicalPath ?? info.Path;
+
+        // Legacy fallback for pre-sidecar dotnet-tool installs (mirrors the
+        // UpdateCommand --self resolution rule). Uses the no-arg overload so
+        // the AsyncLocal test override is honored.
+        if (source == InstallSource.Unknown && DotNetToolDetection.IsRunningAsDotNetTool())
+        {
+            source = InstallSource.DotnetTool;
+        }
+
+        return upgradeInstructionProvider.GetUpdateCommand(source, canonicalPath, executionContext.IdentityChannel)
+            ?? "aspire update --self";
     }
 
     private async Task<IEnumerable<Shared.NuGetPackageCli>> GetCliPackagesAsync(DirectoryInfo workingDirectory, CancellationToken cancellationToken)

--- a/src/Aspire.Cli/Utils/CliUpdateNotifier.cs
+++ b/src/Aspire.Cli/Utils/CliUpdateNotifier.cs
@@ -136,12 +136,12 @@ internal class CliUpdateNotifier(
 
     /// <summary>
     /// Returns the route-appropriate command to recommend in the
-    /// "version X available" notification. For script-route and Unknown
-    /// installs we suggest <c>aspire update --self</c> (which actually
-    /// performs the in-process update for script). For every other route we
-    /// defer to <see cref="IUpgradeInstructionProvider"/> so users see the
-    /// command that matches how they installed the CLI (winget upgrade,
-    /// brew upgrade --cask, dotnet tool update, get-aspire-cli-pr, etc.).
+    /// "version X available" notification. For script-route installs we
+    /// suggest <c>aspire update --self</c>. For every other route, including
+    /// Unknown, we defer to <see cref="IUpgradeInstructionProvider"/> so
+    /// users see the command or refusal hint that matches how they installed
+    /// the CLI (winget upgrade, brew upgrade --cask, dotnet tool update,
+    /// get-aspire-cli-pr, etc.).
     /// </summary>
     /// <remarks>
     /// When the initial discovery reports no route (i.e., no sidecar on disk

--- a/src/Aspire.Cli/Utils/CliUpdateNotifier.cs
+++ b/src/Aspire.Cli/Utils/CliUpdateNotifier.cs
@@ -47,7 +47,8 @@ internal class CliUpdateNotifier(
     IInteractionService interactionService,
     IInstallationDiscovery installationDiscovery,
     IUpgradeInstructionProvider upgradeInstructionProvider,
-    CliExecutionContext executionContext) : ICliUpdateNotifier
+    CliExecutionContext executionContext,
+    WingetFirstRunProbe wingetFirstRunProbe) : ICliUpdateNotifier
 {
     private IEnumerable<Shared.NuGetPackageCli>? _availablePackages;
 
@@ -142,11 +143,31 @@ internal class CliUpdateNotifier(
     /// command that matches how they installed the CLI (winget upgrade,
     /// brew upgrade --cask, dotnet tool update, get-aspire-cli-pr, etc.).
     /// </summary>
+    /// <remarks>
+    /// When the initial discovery reports no route (i.e., no sidecar on disk
+    /// yet), runs <see cref="WingetFirstRunProbe"/> on the binary directory
+    /// derived from the discovery's canonical path, then re-describes so the
+    /// freshly-stamped sidecar is picked up. The probe self-gates via
+    /// <see cref="IWindowsRegistryReader"/>, so the call is a cheap no-op
+    /// on non-Windows / non-WinGet installs.
+    /// </remarks>
     private string GetRouteAwareUpdateCommand()
     {
         var info = installationDiscovery.DescribeSelf();
-        var source = InstallSourceExtensions.ParseInstallSource(info.Route);
         var canonicalPath = info.CanonicalPath ?? info.Path;
+
+        if (string.IsNullOrEmpty(info.Route) && !string.IsNullOrEmpty(canonicalPath))
+        {
+            var binaryDir = Path.GetDirectoryName(canonicalPath);
+            if (!string.IsNullOrEmpty(binaryDir))
+            {
+                wingetFirstRunProbe.Run(binaryDir);
+                info = installationDiscovery.DescribeSelf();
+                canonicalPath = info.CanonicalPath ?? info.Path;
+            }
+        }
+
+        var source = InstallSourceExtensions.ParseInstallSource(info.Route);
 
         // Legacy fallback for pre-sidecar dotnet-tool installs (mirrors the
         // UpdateCommand --self resolution rule). Uses the no-arg overload so

--- a/tests/Aspire.Cli.Tests/Acquisition/SelfUpdateRouterTests.cs
+++ b/tests/Aspire.Cli.Tests/Acquisition/SelfUpdateRouterTests.cs
@@ -10,9 +10,9 @@ public class SelfUpdateRouterTests
     [Theory]
     // Script-route installs stay in-process — the CLI owns the binary swap.
     [InlineData("Script", "InProcess")]
-    // Unknown sources stay in-process for legacy pre-sidecar script installs
-    // (see SelfUpdateRouter.GetAction docs).
-    [InlineData("Unknown", "InProcess")]
+    // Unknown sources fail closed unless the caller explicitly opts into
+    // the UpdateCommand-layer --force override.
+    [InlineData("Unknown", "Delegate")]
     // Every other route delegates — they're either pinned (PR), package-
     // manager-owned (winget / brew / dotnet-tool), or rebuilt-from-source
     // (localhive). An in-process binary swap would corrupt or demote them.

--- a/tests/Aspire.Cli.Tests/Acquisition/SelfUpdateRouterTests.cs
+++ b/tests/Aspire.Cli.Tests/Acquisition/SelfUpdateRouterTests.cs
@@ -1,0 +1,31 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Aspire.Cli.Acquisition;
+
+namespace Aspire.Cli.Tests.Acquisition;
+
+public class SelfUpdateRouterTests
+{
+    [Theory]
+    // Script-route installs stay in-process — the CLI owns the binary swap.
+    [InlineData("Script", "InProcess")]
+    // Unknown sources stay in-process for legacy pre-sidecar script installs
+    // (see SelfUpdateRouter.GetAction docs).
+    [InlineData("Unknown", "InProcess")]
+    // Every other route delegates — they're either pinned (PR), package-
+    // manager-owned (winget / brew / dotnet-tool), or rebuilt-from-source
+    // (localhive). An in-process binary swap would corrupt or demote them.
+    [InlineData("Pr", "Delegate")]
+    [InlineData("Winget", "Delegate")]
+    [InlineData("Brew", "Delegate")]
+    [InlineData("DotnetTool", "Delegate")]
+    [InlineData("LocalHive", "Delegate")]
+    public void GetAction_ReturnsExpectedAction(string sourceName, string expectedActionName)
+    {
+        var source = Enum.Parse<InstallSource>(sourceName);
+        var expected = Enum.Parse<SelfUpdateAction>(expectedActionName);
+
+        Assert.Equal(expected, SelfUpdateRouter.GetAction(source));
+    }
+}

--- a/tests/Aspire.Cli.Tests/Acquisition/UpdateCommandRouteRegressionTests.cs
+++ b/tests/Aspire.Cli.Tests/Acquisition/UpdateCommandRouteRegressionTests.cs
@@ -12,40 +12,47 @@ using Microsoft.Extensions.DependencyInjection;
 namespace Aspire.Cli.Tests.Acquisition;
 
 /// <summary>
-/// End-to-end regression guard for the silent-PR-demotion and
+/// End-to-end regression guard for the silent route-demotion and
 /// package-manager binary-clobber bugs on <c>aspire update --self</c>.
-/// Pre-fix: an in-process binary swap ran unconditionally for every
-/// non-dotnet-tool route, overwriting WinGet / Homebrew / PR-pinned
-/// binaries with the latest stable archive. Post-fix: each non-script
-/// route gets refused with the installer-appropriate command and the
-/// binary is left untouched.
 /// </summary>
 public class UpdateCommandRouteRegressionTests(ITestOutputHelper outputHelper)
 {
-    // Each row encodes (sidecar source, identityChannel for PR substitution,
-    // expected refusal command). Script and Unknown stay in-process by design,
-    // so they're excluded from this regression net.
     [Theory]
-    [InlineData("pr", "pr-16817", "get-aspire-cli-pr.sh 16817    # or: get-aspire-cli-pr.ps1 -PRNumber 16817")]
-    [InlineData("winget", "stable", "winget upgrade Microsoft.Aspire")]
-    [InlineData("brew", "stable", "brew upgrade --cask aspire")]
-    [InlineData("localhive", "local", "./localhive.sh   # re-run from your Aspire checkout")]
-    public async Task SelfUpdate_OnGatedRoute_RefusesWithRouteAppropriateCommand(
-        string sidecarSource,
+    [InlineData("script", "stable", false, true, null)]
+    [InlineData("script", "stable", true, true, null)]
+    [InlineData("brew", "stable", false, false, "brew upgrade --cask aspire")]
+    [InlineData("brew", "stable", true, true, null)]
+    [InlineData("winget", "stable", false, false, "winget upgrade Microsoft.Aspire")]
+    [InlineData("winget", "stable", true, true, null)]
+    [InlineData("dotnet-tool", "stable", false, false, "dotnet tool update -g Aspire.Cli")]
+    [InlineData("dotnet-tool", "stable", true, true, null)]
+    [InlineData("pr", "pr-16817", false, false, "get-aspire-cli-pr.sh 16817    # or: get-aspire-cli-pr.ps1 -PRNumber 16817")]
+    [InlineData("pr", "pr-16817", true, true, null)]
+    [InlineData("localhive", "local", false, false, "localhive.sh")]
+    [InlineData("localhive", "local", true, true, null)]
+    [InlineData(null, "stable", false, false, "Aspire couldn't determine how this CLI was installed")]
+    [InlineData(null, "stable", true, true, null)]
+    public async Task SelfUpdate_RouteGate_RefusesUnlessScriptOrForced(
+        string? sidecarSource,
         string identityChannel,
-        string expectedCommand)
+        bool force,
+        bool expectInProcess,
+        string? expectedOutput)
     {
         using var workspace = TemporaryWorkspace.Create(outputHelper);
+        using var processPathScope = DotNetToolDetection.UseProcessPathForTesting(
+            Path.Combine(workspace.WorkspaceRoot.FullName, "bin", "aspire"));
 
         var selfInfo = new InstallationInfo
         {
-            Path = "/test/aspire",
-            CanonicalPath = "/test/aspire",
+            Path = Path.Combine(workspace.WorkspaceRoot.FullName, "bin", "aspire"),
+            CanonicalPath = Path.Combine(workspace.WorkspaceRoot.FullName, "bin", "aspire"),
             Route = sidecarSource,
             Channel = identityChannel,
-            Status = InstallationInfoStatus.Ok,
+            Status = sidecarSource is null ? InstallationInfoStatus.NotProbed : InstallationInfoStatus.Ok,
         };
 
+        var downloadAttempted = false;
         TestInteractionService? interactionService = null;
         var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper, options =>
         {
@@ -55,8 +62,6 @@ public class UpdateCommandRouteRegressionTests(ITestOutputHelper outputHelper)
                 return interactionService;
             };
 
-            // Force the running CLI's identity channel so the PR-route
-            // substitution exercises the parsed PR number path.
             options.CliExecutionContextFactory = _ =>
             {
                 var root = workspace.WorkspaceRoot;
@@ -68,33 +73,52 @@ public class UpdateCommandRouteRegressionTests(ITestOutputHelper outputHelper)
                     root,
                     hivesDirectory,
                     cacheDirectory,
-                    new DirectoryInfo(Path.Combine(Path.GetTempPath(), "aspire-test-sdks")),
+                    new DirectoryInfo(Path.Combine(root.FullName, ".aspire", "sdks")),
                     logsDirectory,
                     logFilePath,
                     identityChannel: identityChannel);
             };
+
+            options.CliDownloaderFactory = sp =>
+            {
+                var executionContext = sp.GetRequiredService<CliExecutionContext>();
+                return new TestCliDownloader(new DirectoryInfo(Path.Combine(executionContext.WorkingDirectory.FullName, "tmp")))
+                {
+                    DownloadLatestCliAsyncCallback = (_, _) =>
+                    {
+                        downloadAttempted = true;
+                        throw new InvalidOperationException("download attempted");
+                    }
+                };
+            };
         });
 
-        // Replace the real InstallationDiscovery with a fake surfacing the
-        // route under test. Last registration wins.
         services.AddSingleton<IInstallationDiscovery>(_ => new FakeInstallationDiscovery(selfInfo));
 
         using var provider = services.BuildServiceProvider();
         var command = provider.GetRequiredService<RootCommand>();
-        var parsed = command.Parse("update --self");
-        var exitCode = await parsed.InvokeAsync().DefaultTimeout();
+        var args = force ? "update --self --force --yes --channel stable" : "update --self --yes --channel stable";
+        var exitCode = await command.Parse(args).InvokeAsync().DefaultTimeout();
 
         Assert.NotNull(interactionService);
-        // Exit 0 by design — the CLI succeeded in telling the user what to
-        // do (matches the existing dotnet-tool refusal contract).
-        Assert.Equal(0, exitCode);
+        Assert.Equal(expectInProcess, downloadAttempted);
 
-        // The expected command must appear verbatim in the displayed plain
-        // text — this is the signal a user / CI script would actually
-        // observe in stdout.
-        Assert.Contains(
-            interactionService!.DisplayedPlainText,
-            line => line.Contains(expectedCommand, StringComparison.Ordinal));
+        var allOutput = string.Join("\n", interactionService!.DisplayedPlainText.Concat(interactionService.DisplayedMessages.Select(m => m.Message)));
+        if (expectedOutput is not null)
+        {
+            Assert.Equal(0, exitCode);
+            Assert.Contains(expectedOutput, allOutput, StringComparison.Ordinal);
+        }
+        else
+        {
+            Assert.NotEqual(0, exitCode);
+            Assert.DoesNotContain("winget upgrade", allOutput, StringComparison.Ordinal);
+            Assert.DoesNotContain("brew upgrade", allOutput, StringComparison.Ordinal);
+            Assert.DoesNotContain("dotnet tool update", allOutput, StringComparison.Ordinal);
+            Assert.DoesNotContain("get-aspire-cli-pr", allOutput, StringComparison.Ordinal);
+            Assert.DoesNotContain("localhive.sh", allOutput, StringComparison.Ordinal);
+            Assert.DoesNotContain("couldn't determine how this CLI was installed", allOutput, StringComparison.Ordinal);
+        }
     }
 
     /// <summary>
@@ -103,8 +127,7 @@ public class UpdateCommandRouteRegressionTests(ITestOutputHelper outputHelper)
     /// BUT path-shape inspection identifies the binary as a dotnet tool,
     /// the route is fixed up to <see cref="InstallSource.DotnetTool"/> and
     /// refused with the dotnet-tool command rather than falling through to
-    /// the in-process update flow (which would corrupt the
-    /// package-manager-owned binary).
+    /// the in-process update flow.
     /// </summary>
     [Fact]
     public async Task SelfUpdate_NoSidecar_LegacyDotnetToolPathShape_RefusesWithDotnetToolHint()
@@ -113,13 +136,10 @@ public class UpdateCommandRouteRegressionTests(ITestOutputHelper outputHelper)
         using var processPathScope = DotNetToolDetection.UseProcessPathForTesting(
             "/home/test/.dotnet/tools/.store/aspire.cli/9.4.0/aspire.cli.linux-x64/9.4.0/tools/net10.0/linux-x64/aspire");
 
-        // Discovery returns no route (no sidecar on disk). The fallback in
-        // ResolveRunningInstall must then consult DotNetToolDetection via
-        // the no-arg overload, which honors UseProcessPathForTesting.
         var selfInfo = new InstallationInfo
         {
-            Path = "/test/aspire",
-            CanonicalPath = "/test/aspire",
+            Path = "/home/test/.dotnet/tools/.store/aspire.cli/9.4.0/aspire.cli.linux-x64/9.4.0/tools/net10.0/linux-x64/aspire",
+            CanonicalPath = "/home/test/.dotnet/tools/.store/aspire.cli/9.4.0/aspire.cli.linux-x64/9.4.0/tools/net10.0/linux-x64/aspire",
             Route = null,
             Status = InstallationInfoStatus.Ok,
         };
@@ -141,76 +161,8 @@ public class UpdateCommandRouteRegressionTests(ITestOutputHelper outputHelper)
 
         Assert.Equal(0, exitCode);
         Assert.NotNull(interactionService);
-        // The refusal must surface the global dotnet-tool update command —
-        // the binary IS under ~/.dotnet/tools/.store/ so DotNetToolDetection
-        // classifies it as a global-tool install.
         Assert.Contains(
             interactionService!.DisplayedPlainText,
             line => line.Contains("dotnet tool update -g Aspire.Cli", StringComparison.Ordinal));
-    }
-
-    /// <summary>
-    /// Pre-sidecar script install compat: when the running binary has no
-    /// sidecar AND the process path doesn't match any dotnet-tool layout,
-    /// the resolver yields <see cref="InstallSource.Unknown"/> and
-    /// <see cref="SelfUpdateRouter.GetAction"/> routes Unknown to
-    /// <see cref="SelfUpdateAction.InProcess"/>. <c>--self</c> must then
-    /// reach the in-process flow rather than printing a refusal. We assert
-    /// the SUT does NOT print any of the refusal-message prefixes
-    /// (verifying it didn't take the gated branch) instead of trying to
-    /// drive a full network download.
-    /// </summary>
-    [Fact]
-    public async Task SelfUpdate_NoSidecar_NotDotnetTool_FallsThroughToInProcessFlow()
-    {
-        using var workspace = TemporaryWorkspace.Create(outputHelper);
-        using var processPathScope = DotNetToolDetection.UseProcessPathForTesting("/tmp/random/aspire");
-
-        var selfInfo = new InstallationInfo
-        {
-            Path = "/tmp/random/aspire",
-            CanonicalPath = "/tmp/random/aspire",
-            Route = null,
-            Status = InstallationInfoStatus.Ok,
-        };
-
-        TestInteractionService? interactionService = null;
-        var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper, options =>
-        {
-            options.InteractionServiceFactory = _ =>
-            {
-                interactionService = new TestInteractionService();
-                return interactionService;
-            };
-        });
-        services.AddSingleton<IInstallationDiscovery>(_ => new FakeInstallationDiscovery(selfInfo));
-
-        using var provider = services.BuildServiceProvider();
-        var command = provider.GetRequiredService<RootCommand>();
-        // Invoke --self; we don't expect this to complete the actual update
-        // (no real network in the test process), but we do expect it to NOT
-        // emit any of the route-refusal messages. Any non-refusal outcome
-        // (timeout / failure / success / cancellation) is acceptable here;
-        // what matters is that the gated branch was not taken.
-        try
-        {
-            await command.Parse("update --self --yes --channel stable").InvokeAsync().DefaultTimeout();
-        }
-        catch
-        {
-            // The in-process flow may throw for any number of network /
-            // download / signature reasons; the test doesn't depend on
-            // those succeeding.
-        }
-
-        Assert.NotNull(interactionService);
-        // None of the route-specific refusal messages must appear: those
-        // are the signal that the gated branch was taken.
-        var allOutput = string.Join("\n", interactionService!.DisplayedPlainText);
-        Assert.DoesNotContain("get-aspire-cli-pr.sh", allOutput, StringComparison.Ordinal);
-        Assert.DoesNotContain("winget upgrade", allOutput, StringComparison.Ordinal);
-        Assert.DoesNotContain("brew upgrade", allOutput, StringComparison.Ordinal);
-        Assert.DoesNotContain("./localhive.sh", allOutput, StringComparison.Ordinal);
-        Assert.DoesNotContain("dotnet tool update", allOutput, StringComparison.Ordinal);
     }
 }

--- a/tests/Aspire.Cli.Tests/Acquisition/UpdateCommandRouteRegressionTests.cs
+++ b/tests/Aspire.Cli.Tests/Acquisition/UpdateCommandRouteRegressionTests.cs
@@ -5,6 +5,7 @@ using Aspire.Cli.Acquisition;
 using Aspire.Cli.Commands;
 using Aspire.Cli.Tests.TestServices;
 using Aspire.Cli.Tests.Utils;
+using Aspire.Cli.Utils;
 using Microsoft.AspNetCore.InternalTesting;
 using Microsoft.Extensions.DependencyInjection;
 
@@ -94,5 +95,122 @@ public class UpdateCommandRouteRegressionTests(ITestOutputHelper outputHelper)
         Assert.Contains(
             interactionService!.DisplayedPlainText,
             line => line.Contains(expectedCommand, StringComparison.Ordinal));
+    }
+
+    /// <summary>
+    /// Legacy compatibility check: when the running binary has no sidecar
+    /// (e.g., a dotnet-tool install that predates the sidecar contract)
+    /// BUT path-shape inspection identifies the binary as a dotnet tool,
+    /// the route is fixed up to <see cref="InstallSource.DotnetTool"/> and
+    /// refused with the dotnet-tool command rather than falling through to
+    /// the in-process update flow (which would corrupt the
+    /// package-manager-owned binary).
+    /// </summary>
+    [Fact]
+    public async Task SelfUpdate_NoSidecar_LegacyDotnetToolPathShape_RefusesWithDotnetToolHint()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        using var processPathScope = DotNetToolDetection.UseProcessPathForTesting(
+            "/home/test/.dotnet/tools/.store/aspire.cli/9.4.0/aspire.cli.linux-x64/9.4.0/tools/net10.0/linux-x64/aspire");
+
+        // Discovery returns no route (no sidecar on disk). The fallback in
+        // ResolveRunningInstall must then consult DotNetToolDetection via
+        // the no-arg overload, which honors UseProcessPathForTesting.
+        var selfInfo = new InstallationInfo
+        {
+            Path = "/test/aspire",
+            CanonicalPath = "/test/aspire",
+            Route = null,
+            Status = InstallationInfoStatus.Ok,
+        };
+
+        TestInteractionService? interactionService = null;
+        var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper, options =>
+        {
+            options.InteractionServiceFactory = _ =>
+            {
+                interactionService = new TestInteractionService();
+                return interactionService;
+            };
+        });
+        services.AddSingleton<IInstallationDiscovery>(_ => new FakeInstallationDiscovery(selfInfo));
+
+        using var provider = services.BuildServiceProvider();
+        var command = provider.GetRequiredService<RootCommand>();
+        var exitCode = await command.Parse("update --self").InvokeAsync().DefaultTimeout();
+
+        Assert.Equal(0, exitCode);
+        Assert.NotNull(interactionService);
+        // The refusal must surface the global dotnet-tool update command —
+        // the binary IS under ~/.dotnet/tools/.store/ so DotNetToolDetection
+        // classifies it as a global-tool install.
+        Assert.Contains(
+            interactionService!.DisplayedPlainText,
+            line => line.Contains("dotnet tool update -g Aspire.Cli", StringComparison.Ordinal));
+    }
+
+    /// <summary>
+    /// Pre-sidecar script install compat: when the running binary has no
+    /// sidecar AND the process path doesn't match any dotnet-tool layout,
+    /// the resolver yields <see cref="InstallSource.Unknown"/> and
+    /// <see cref="SelfUpdateRouter.GetAction"/> routes Unknown to
+    /// <see cref="SelfUpdateAction.InProcess"/>. <c>--self</c> must then
+    /// reach the in-process flow rather than printing a refusal. We assert
+    /// the SUT does NOT print any of the refusal-message prefixes
+    /// (verifying it didn't take the gated branch) instead of trying to
+    /// drive a full network download.
+    /// </summary>
+    [Fact]
+    public async Task SelfUpdate_NoSidecar_NotDotnetTool_FallsThroughToInProcessFlow()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        using var processPathScope = DotNetToolDetection.UseProcessPathForTesting("/tmp/random/aspire");
+
+        var selfInfo = new InstallationInfo
+        {
+            Path = "/tmp/random/aspire",
+            CanonicalPath = "/tmp/random/aspire",
+            Route = null,
+            Status = InstallationInfoStatus.Ok,
+        };
+
+        TestInteractionService? interactionService = null;
+        var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper, options =>
+        {
+            options.InteractionServiceFactory = _ =>
+            {
+                interactionService = new TestInteractionService();
+                return interactionService;
+            };
+        });
+        services.AddSingleton<IInstallationDiscovery>(_ => new FakeInstallationDiscovery(selfInfo));
+
+        using var provider = services.BuildServiceProvider();
+        var command = provider.GetRequiredService<RootCommand>();
+        // Invoke --self; we don't expect this to complete the actual update
+        // (no real network in the test process), but we do expect it to NOT
+        // emit any of the route-refusal messages. Any non-refusal outcome
+        // (timeout / failure / success / cancellation) is acceptable here;
+        // what matters is that the gated branch was not taken.
+        try
+        {
+            await command.Parse("update --self --yes --channel stable").InvokeAsync().DefaultTimeout();
+        }
+        catch
+        {
+            // The in-process flow may throw for any number of network /
+            // download / signature reasons; the test doesn't depend on
+            // those succeeding.
+        }
+
+        Assert.NotNull(interactionService);
+        // None of the route-specific refusal messages must appear: those
+        // are the signal that the gated branch was taken.
+        var allOutput = string.Join("\n", interactionService!.DisplayedPlainText);
+        Assert.DoesNotContain("get-aspire-cli-pr.sh", allOutput, StringComparison.Ordinal);
+        Assert.DoesNotContain("winget upgrade", allOutput, StringComparison.Ordinal);
+        Assert.DoesNotContain("brew upgrade", allOutput, StringComparison.Ordinal);
+        Assert.DoesNotContain("./localhive.sh", allOutput, StringComparison.Ordinal);
+        Assert.DoesNotContain("dotnet tool update", allOutput, StringComparison.Ordinal);
     }
 }

--- a/tests/Aspire.Cli.Tests/Acquisition/UpdateCommandRouteRegressionTests.cs
+++ b/tests/Aspire.Cli.Tests/Acquisition/UpdateCommandRouteRegressionTests.cs
@@ -1,0 +1,98 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Aspire.Cli.Acquisition;
+using Aspire.Cli.Commands;
+using Aspire.Cli.Tests.TestServices;
+using Aspire.Cli.Tests.Utils;
+using Microsoft.AspNetCore.InternalTesting;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Aspire.Cli.Tests.Acquisition;
+
+/// <summary>
+/// End-to-end regression guard for the silent-PR-demotion and
+/// package-manager binary-clobber bugs on <c>aspire update --self</c>.
+/// Pre-fix: an in-process binary swap ran unconditionally for every
+/// non-dotnet-tool route, overwriting WinGet / Homebrew / PR-pinned
+/// binaries with the latest stable archive. Post-fix: each non-script
+/// route gets refused with the installer-appropriate command and the
+/// binary is left untouched.
+/// </summary>
+public class UpdateCommandRouteRegressionTests(ITestOutputHelper outputHelper)
+{
+    // Each row encodes (sidecar source, identityChannel for PR substitution,
+    // expected refusal command). Script and Unknown stay in-process by design,
+    // so they're excluded from this regression net.
+    [Theory]
+    [InlineData("pr", "pr-16817", "get-aspire-cli-pr.sh 16817    # or: get-aspire-cli-pr.ps1 -PRNumber 16817")]
+    [InlineData("winget", "stable", "winget upgrade Microsoft.Aspire")]
+    [InlineData("brew", "stable", "brew upgrade --cask aspire")]
+    [InlineData("localhive", "local", "./localhive.sh   # re-run from your Aspire checkout")]
+    public async Task SelfUpdate_OnGatedRoute_RefusesWithRouteAppropriateCommand(
+        string sidecarSource,
+        string identityChannel,
+        string expectedCommand)
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+
+        var selfInfo = new InstallationInfo
+        {
+            Path = "/test/aspire",
+            CanonicalPath = "/test/aspire",
+            Route = sidecarSource,
+            Channel = identityChannel,
+            Status = InstallationInfoStatus.Ok,
+        };
+
+        TestInteractionService? interactionService = null;
+        var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper, options =>
+        {
+            options.InteractionServiceFactory = _ =>
+            {
+                interactionService = new TestInteractionService();
+                return interactionService;
+            };
+
+            // Force the running CLI's identity channel so the PR-route
+            // substitution exercises the parsed PR number path.
+            options.CliExecutionContextFactory = _ =>
+            {
+                var root = workspace.WorkspaceRoot;
+                var hivesDirectory = new DirectoryInfo(Path.Combine(root.FullName, ".aspire", "hives"));
+                var cacheDirectory = new DirectoryInfo(Path.Combine(root.FullName, ".aspire", "cache"));
+                var logsDirectory = new DirectoryInfo(Path.Combine(root.FullName, ".aspire", "logs"));
+                var logFilePath = Path.Combine(logsDirectory.FullName, "test.log");
+                return new CliExecutionContext(
+                    root,
+                    hivesDirectory,
+                    cacheDirectory,
+                    new DirectoryInfo(Path.Combine(Path.GetTempPath(), "aspire-test-sdks")),
+                    logsDirectory,
+                    logFilePath,
+                    identityChannel: identityChannel);
+            };
+        });
+
+        // Replace the real InstallationDiscovery with a fake surfacing the
+        // route under test. Last registration wins.
+        services.AddSingleton<IInstallationDiscovery>(_ => new FakeInstallationDiscovery(selfInfo));
+
+        using var provider = services.BuildServiceProvider();
+        var command = provider.GetRequiredService<RootCommand>();
+        var parsed = command.Parse("update --self");
+        var exitCode = await parsed.InvokeAsync().DefaultTimeout();
+
+        Assert.NotNull(interactionService);
+        // Exit 0 by design — the CLI succeeded in telling the user what to
+        // do (matches the existing dotnet-tool refusal contract).
+        Assert.Equal(0, exitCode);
+
+        // The expected command must appear verbatim in the displayed plain
+        // text — this is the signal a user / CI script would actually
+        // observe in stdout.
+        Assert.Contains(
+            interactionService!.DisplayedPlainText,
+            line => line.Contains(expectedCommand, StringComparison.Ordinal));
+    }
+}

--- a/tests/Aspire.Cli.Tests/Acquisition/UpdateNotificationRouteTests.cs
+++ b/tests/Aspire.Cli.Tests/Acquisition/UpdateNotificationRouteTests.cs
@@ -1,0 +1,100 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Aspire.Cli.Acquisition;
+using Aspire.Cli.Interaction;
+using Aspire.Cli.NuGet;
+using Aspire.Cli.Tests.TestServices;
+using Aspire.Cli.Tests.Utils;
+using Aspire.Cli.Utils;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Microsoft.AspNetCore.InternalTesting;
+using NuGetPackage = Aspire.Shared.NuGetPackageCli;
+
+namespace Aspire.Cli.Tests.Acquisition;
+
+/// <summary>
+/// Locks in route-aware behavior of the CLI's "version X is available"
+/// notification. Each install route must surface the command that actually
+/// updates the binary the user is running — running the script-route
+/// command from a Homebrew / WinGet / dotnet-tool / PR install is the bug
+/// pattern this test class guards against.
+/// </summary>
+public class UpdateNotificationRouteTests(ITestOutputHelper outputHelper)
+{
+    // Per-source expected notification command. We do not enumerate the
+    // dotnet-tool / Pr cases here because their commands depend on the
+    // running binary's path / identity channel; those are exercised
+    // separately in UpgradeInstructionProviderTests. The rows here lock in
+    // that the notifier wires its output through the same provider, not the
+    // legacy hardcoded "aspire update" / dotnet-tool special case.
+    [Theory]
+    [InlineData("winget", "winget upgrade Microsoft.Aspire")]
+    [InlineData("brew", "brew upgrade --cask aspire")]
+    [InlineData("localhive", "./localhive.sh   # re-run from your Aspire checkout")]
+    [InlineData("script", "aspire update --self")]
+    [InlineData(null, "aspire update --self")]
+    public async Task NotifyIfUpdateAvailable_RouteAwareCommand_MatchesUpgradeInstructionProvider(string? sidecarSource, string expectedCommand)
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+
+        var selfInfo = new InstallationInfo
+        {
+            Path = "/test/aspire",
+            CanonicalPath = "/test/aspire",
+            Route = sidecarSource,
+            Status = sidecarSource is null
+                ? InstallationInfoStatus.NotProbed
+                : InstallationInfoStatus.Ok,
+        };
+
+        TestInteractionService? interactionService = null;
+        var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper, configure =>
+        {
+            configure.NuGetPackageCacheFactory = _ => new FakeNuGetPackageCache
+            {
+                GetCliPackagesAsyncCallback = (_, _, _, _) => Task.FromResult<IEnumerable<NuGetPackage>>(
+                [
+                    new NuGetPackage { Id = "Aspire.Cli", Version = "9.5.0", Source = "nuget.org" }
+                ])
+            };
+
+            configure.InteractionServiceFactory = _ =>
+            {
+                interactionService = new TestInteractionService();
+                return interactionService;
+            };
+
+            configure.CliUpdateNotifierFactory = sp =>
+            {
+                var logger = sp.GetRequiredService<ILogger<CliUpdateNotifier>>();
+                var nuGetPackageCache = sp.GetRequiredService<INuGetPackageCache>();
+                var service = sp.GetRequiredService<IInteractionService>();
+                // Pin the current version so the fake "9.5.0" available
+                // package always reads as newer regardless of the test
+                // runner's actual version.
+                return new CliUpdateNotifierWithPackageVersionOverride(
+                    "9.4.0", logger, nuGetPackageCache, service,
+                    sp.GetRequiredService<IInstallationDiscovery>(),
+                    sp.GetRequiredService<IUpgradeInstructionProvider>(),
+                    sp.GetRequiredService<CliExecutionContext>());
+            };
+        });
+
+        // Replace the real InstallationDiscovery (which reads
+        // Environment.ProcessPath, not test overrides) with a fake that
+        // surfaces the route under test. Done after CreateServiceCollection
+        // so the last registration wins.
+        services.AddSingleton<IInstallationDiscovery>(_ => new FakeInstallationDiscovery(selfInfo));
+
+        using var provider = services.BuildServiceProvider();
+        var notifier = provider.GetRequiredService<ICliUpdateNotifier>();
+
+        await notifier.CheckForCliUpdatesAsync(workspace.WorkspaceRoot, CancellationToken.None).DefaultTimeout();
+        notifier.NotifyIfUpdateAvailable();
+
+        Assert.NotNull(interactionService);
+        Assert.Equal(expectedCommand, interactionService.LastVersionUpdateCommand);
+    }
+}

--- a/tests/Aspire.Cli.Tests/Acquisition/UpdateNotificationRouteTests.cs
+++ b/tests/Aspire.Cli.Tests/Acquisition/UpdateNotificationRouteTests.cs
@@ -32,16 +32,15 @@ public class UpdateNotificationRouteTests(ITestOutputHelper outputHelper)
     [Theory]
     [InlineData("winget", "winget upgrade Microsoft.Aspire")]
     [InlineData("brew", "brew upgrade --cask aspire")]
-    [InlineData("localhive", "./localhive.sh   # re-run from your Aspire checkout")]
+    [InlineData("localhive", "Run ./localhive.sh (Linux/macOS) or .\\localhive.ps1 (Windows) in the local hive directory.")]
     [InlineData("script", "aspire update --self")]
-    [InlineData(null, "aspire update --self")]
+    [InlineData(null, "Aspire couldn't determine how this CLI was installed")]
     // Unrecognized sidecar source value (a route added by a future build
     // that this CLI doesn't know about yet). The reader returns
     // InstallSource.Unknown with RawSource preserved; the notifier must
     // still surface an actionable hint rather than printing the raw
-    // unrecognized name. Falls back to "aspire update --self" via
-    // SelfUpdateRouter's Unknown → in-process classification.
-    [InlineData("future-route-name", "aspire update --self")]
+    // unrecognized name.
+    [InlineData("future-route-name", "Aspire couldn't determine how this CLI was installed")]
     public async Task NotifyIfUpdateAvailable_RouteAwareCommand_MatchesUpgradeInstructionProvider(string? sidecarSource, string expectedCommand)
     {
         using var workspace = TemporaryWorkspace.Create(outputHelper);
@@ -103,6 +102,6 @@ public class UpdateNotificationRouteTests(ITestOutputHelper outputHelper)
         notifier.NotifyIfUpdateAvailable();
 
         Assert.NotNull(interactionService);
-        Assert.Equal(expectedCommand, interactionService.LastVersionUpdateCommand);
+        Assert.Contains(expectedCommand, interactionService.LastVersionUpdateCommand, StringComparison.Ordinal);
     }
 }

--- a/tests/Aspire.Cli.Tests/Acquisition/UpdateNotificationRouteTests.cs
+++ b/tests/Aspire.Cli.Tests/Acquisition/UpdateNotificationRouteTests.cs
@@ -35,6 +35,13 @@ public class UpdateNotificationRouteTests(ITestOutputHelper outputHelper)
     [InlineData("localhive", "./localhive.sh   # re-run from your Aspire checkout")]
     [InlineData("script", "aspire update --self")]
     [InlineData(null, "aspire update --self")]
+    // Unrecognized sidecar source value (a route added by a future build
+    // that this CLI doesn't know about yet). The reader returns
+    // InstallSource.Unknown with RawSource preserved; the notifier must
+    // still surface an actionable hint rather than printing the raw
+    // unrecognized name. Falls back to "aspire update --self" via
+    // SelfUpdateRouter's Unknown → in-process classification.
+    [InlineData("future-route-name", "aspire update --self")]
     public async Task NotifyIfUpdateAvailable_RouteAwareCommand_MatchesUpgradeInstructionProvider(string? sidecarSource, string expectedCommand)
     {
         using var workspace = TemporaryWorkspace.Create(outputHelper);

--- a/tests/Aspire.Cli.Tests/Acquisition/UpdateNotificationRouteTests.cs
+++ b/tests/Aspire.Cli.Tests/Acquisition/UpdateNotificationRouteTests.cs
@@ -85,7 +85,8 @@ public class UpdateNotificationRouteTests(ITestOutputHelper outputHelper)
                     "9.4.0", logger, nuGetPackageCache, service,
                     sp.GetRequiredService<IInstallationDiscovery>(),
                     sp.GetRequiredService<IUpgradeInstructionProvider>(),
-                    sp.GetRequiredService<CliExecutionContext>());
+                    sp.GetRequiredService<CliExecutionContext>(),
+                    sp.GetRequiredService<WingetFirstRunProbe>());
             };
         });
 

--- a/tests/Aspire.Cli.Tests/Acquisition/UpgradeInstructionProviderTests.cs
+++ b/tests/Aspire.Cli.Tests/Acquisition/UpgradeInstructionProviderTests.cs
@@ -15,7 +15,7 @@ public class UpgradeInstructionProviderTests
     [Theory]
     [InlineData("Winget", "winget upgrade Microsoft.Aspire")]
     [InlineData("Brew", "brew upgrade --cask aspire")]
-    [InlineData("LocalHive", "./localhive.sh   # re-run from your Aspire checkout")]
+    [InlineData("LocalHive", "Run ./localhive.sh (Linux/macOS) or .\\localhive.ps1 (Windows) in the local hive directory.")]
     public void GetUpdateCommand_StaticHintRoutes_ReturnExpectedCommand(string sourceName, string expected)
     {
         var source = Enum.Parse<InstallSource>(sourceName);
@@ -24,10 +24,9 @@ public class UpgradeInstructionProviderTests
     }
 
     // Routes where there is intentionally no separate update command — script
-    // gets the in-process flow; Unknown has no actionable hint.
+    // gets the in-process flow.
     [Theory]
     [InlineData("Script")]
-    [InlineData("Unknown")]
     public void GetUpdateCommand_NoHintRoutes_ReturnNull(string sourceName)
     {
         var source = Enum.Parse<InstallSource>(sourceName);
@@ -114,10 +113,44 @@ public class UpgradeInstructionProviderTests
         // store layout (e.g., legacy installs without the canonical store
         // shape, or the test runner itself), the provider falls back to the
         // global form so the message is at least actionable.
-        using var processPathScope = DotNetToolDetection.UseProcessPathForTesting("/tmp/random/path/aspire");
+        using var processPathScope = DotNetToolDetection.UseProcessPathForTesting("/random/path/aspire");
 
         var command = s_provider.GetUpdateCommand(InstallSource.DotnetTool, processPath: null, identityChannel: "stable");
 
         Assert.Equal("dotnet tool update -g Aspire.Cli", command);
+    }
+
+    [Fact]
+    public void GetUpdateCommand_DotnetTool_UsesSuppliedProcessPath()
+    {
+        var s = Path.DirectorySeparatorChar;
+        var toolPath = $"{s}opt{s}path-from-parameter";
+        using var processPathScope = DotNetToolDetection.UseProcessPathForTesting("/random/path/aspire");
+
+        var command = s_provider.GetUpdateCommand(
+            InstallSource.DotnetTool,
+            $"{toolPath}{s}.store{s}aspire.cli{s}9.4.0{s}aspire.cli.linux-x64{s}9.4.0{s}tools{s}net10.0{s}linux-x64{s}aspire",
+            identityChannel: "stable");
+
+        Assert.Equal($"dotnet tool update --tool-path {toolPath} Aspire.Cli", command);
+    }
+
+    [Fact]
+    public void GetUpdateCommand_Unknown_ReturnsForceHint()
+    {
+        var command = s_provider.GetUpdateCommand(InstallSource.Unknown, processPath: null, identityChannel: "stable");
+
+        Assert.NotNull(command);
+        Assert.Contains("--force", command, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void GetUpdateCommand_LocalHive_ReturnsBothScriptNames()
+    {
+        var command = s_provider.GetUpdateCommand(InstallSource.LocalHive, processPath: null, identityChannel: "local");
+
+        Assert.NotNull(command);
+        Assert.Contains("localhive.sh", command, StringComparison.Ordinal);
+        Assert.Contains("localhive.ps1", command, StringComparison.Ordinal);
     }
 }

--- a/tests/Aspire.Cli.Tests/Acquisition/UpgradeInstructionProviderTests.cs
+++ b/tests/Aspire.Cli.Tests/Acquisition/UpgradeInstructionProviderTests.cs
@@ -77,10 +77,14 @@ public class UpgradeInstructionProviderTests
         // <tool-path>/<rid>/<v>/tools/<tfm>/<rid>/aspire and its sibling .store
         // directory makes the path-shape detector recognize it. The tool path
         // is emitted unquoted when it contains no whitespace (see
-        // DotNetToolDetection.QuoteCommandArgument).
-        var toolPath = "/opt/my-aspire";
+        // DotNetToolDetection.QuoteCommandArgument). Build the path using
+        // Path.DirectorySeparatorChar so the test passes on both Unix (where
+        // it's `/`) and Windows (where DotNetToolDetection.NormalizeDirectorySeparators
+        // produces `\` separators in the extracted toolPath).
+        var s = Path.DirectorySeparatorChar;
+        var toolPath = $"{s}opt{s}my-aspire";
         using var processPathScope = DotNetToolDetection.UseProcessPathForTesting(
-            $"{toolPath}/.store/aspire.cli/9.4.0/aspire.cli.linux-x64/9.4.0/tools/net10.0/linux-x64/aspire");
+            $"{toolPath}{s}.store{s}aspire.cli{s}9.4.0{s}aspire.cli.linux-x64{s}9.4.0{s}tools{s}net10.0{s}linux-x64{s}aspire");
 
         var command = s_provider.GetUpdateCommand(InstallSource.DotnetTool, processPath: null, identityChannel: "stable");
 
@@ -92,10 +96,11 @@ public class UpgradeInstructionProviderTests
     {
         // Paths with whitespace get quoted by DotNetToolDetection.QuoteCommandArgument
         // so the resulting command remains a single argv element when copy-pasted
-        // into a shell.
-        var toolPath = "/opt/My Aspire";
+        // into a shell. Platform-native separators (see ToolPath test for context).
+        var s = Path.DirectorySeparatorChar;
+        var toolPath = $"{s}opt{s}My Aspire";
         using var processPathScope = DotNetToolDetection.UseProcessPathForTesting(
-            $"{toolPath}/.store/aspire.cli/9.4.0/aspire.cli.linux-x64/9.4.0/tools/net10.0/linux-x64/aspire");
+            $"{toolPath}{s}.store{s}aspire.cli{s}9.4.0{s}aspire.cli.linux-x64{s}9.4.0{s}tools{s}net10.0{s}linux-x64{s}aspire");
 
         var command = s_provider.GetUpdateCommand(InstallSource.DotnetTool, processPath: null, identityChannel: "stable");
 

--- a/tests/Aspire.Cli.Tests/Acquisition/UpgradeInstructionProviderTests.cs
+++ b/tests/Aspire.Cli.Tests/Acquisition/UpgradeInstructionProviderTests.cs
@@ -1,0 +1,118 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Aspire.Cli.Acquisition;
+using Aspire.Cli.Utils;
+
+namespace Aspire.Cli.Tests.Acquisition;
+
+public class UpgradeInstructionProviderTests
+{
+    private static readonly UpgradeInstructionProvider s_provider = new();
+
+    // Routes that have a single canonical update command and don't depend on
+    // processPath or identityChannel.
+    [Theory]
+    [InlineData("Winget", "winget upgrade Microsoft.Aspire")]
+    [InlineData("Brew", "brew upgrade --cask aspire")]
+    [InlineData("LocalHive", "./localhive.sh   # re-run from your Aspire checkout")]
+    public void GetUpdateCommand_StaticHintRoutes_ReturnExpectedCommand(string sourceName, string expected)
+    {
+        var source = Enum.Parse<InstallSource>(sourceName);
+        var command = s_provider.GetUpdateCommand(source, processPath: null, identityChannel: "local");
+        Assert.Equal(expected, command);
+    }
+
+    // Routes where there is intentionally no separate update command — script
+    // gets the in-process flow; Unknown has no actionable hint.
+    [Theory]
+    [InlineData("Script")]
+    [InlineData("Unknown")]
+    public void GetUpdateCommand_NoHintRoutes_ReturnNull(string sourceName)
+    {
+        var source = Enum.Parse<InstallSource>(sourceName);
+        Assert.Null(s_provider.GetUpdateCommand(source, processPath: null, identityChannel: "local"));
+    }
+
+    // PR-route hints substitute the PR number parsed from the CLI's identity
+    // channel (CliExecutionContext.IdentityChannel == "pr-<N>" for PR builds).
+    [Theory]
+    [InlineData("pr-16817", "get-aspire-cli-pr.sh 16817    # or: get-aspire-cli-pr.ps1 -PRNumber 16817")]
+    [InlineData("pr-1", "get-aspire-cli-pr.sh 1    # or: get-aspire-cli-pr.ps1 -PRNumber 1")]
+    public void GetUpdateCommand_Pr_SubstitutesPrNumberFromIdentityChannel(string identityChannel, string expected)
+    {
+        Assert.Equal(expected, s_provider.GetUpdateCommand(InstallSource.Pr, processPath: null, identityChannel));
+    }
+
+    // Defensive: when a PR sidecar is read on a binary whose identity channel
+    // is NOT a pr-<N> form (shouldn't happen in practice but locks in deterministic
+    // output), emit the parameterised form so the user knows they must supply N.
+    [Theory]
+    [InlineData("stable")]
+    [InlineData("daily")]
+    [InlineData("local")]
+    [InlineData("pr-")]   // pr- with no number
+    [InlineData("")]
+    public void GetUpdateCommand_Pr_WithNonPrIdentityChannel_FallsBackToParameterisedForm(string identityChannel)
+    {
+        var command = s_provider.GetUpdateCommand(InstallSource.Pr, processPath: null, identityChannel);
+        Assert.Equal("get-aspire-cli-pr.sh <N>    # or: get-aspire-cli-pr.ps1 -PRNumber <N>", command);
+    }
+
+    [Fact]
+    public void GetUpdateCommand_DotnetTool_Global_ReturnsGlobalUpdateCommand()
+    {
+        using var processPathScope = DotNetToolDetection.UseProcessPathForTesting(
+            "/home/test/.dotnet/tools/.store/aspire.cli/9.4.0/aspire.cli.linux-x64/9.4.0/tools/net10.0/linux-x64/aspire");
+
+        var command = s_provider.GetUpdateCommand(InstallSource.DotnetTool, processPath: null, identityChannel: "stable");
+
+        Assert.Equal("dotnet tool update -g Aspire.Cli", command);
+    }
+
+    [Fact]
+    public void GetUpdateCommand_DotnetTool_ToolPath_ReturnsPathAwareUpdateCommand()
+    {
+        // Standard --tool-path install layout: the binary lives under
+        // <tool-path>/<rid>/<v>/tools/<tfm>/<rid>/aspire and its sibling .store
+        // directory makes the path-shape detector recognize it. The tool path
+        // is emitted unquoted when it contains no whitespace (see
+        // DotNetToolDetection.QuoteCommandArgument).
+        var toolPath = "/opt/my-aspire";
+        using var processPathScope = DotNetToolDetection.UseProcessPathForTesting(
+            $"{toolPath}/.store/aspire.cli/9.4.0/aspire.cli.linux-x64/9.4.0/tools/net10.0/linux-x64/aspire");
+
+        var command = s_provider.GetUpdateCommand(InstallSource.DotnetTool, processPath: null, identityChannel: "stable");
+
+        Assert.Equal($"dotnet tool update --tool-path {toolPath} Aspire.Cli", command);
+    }
+
+    [Fact]
+    public void GetUpdateCommand_DotnetTool_ToolPathWithSpaces_QuotesPath()
+    {
+        // Paths with whitespace get quoted by DotNetToolDetection.QuoteCommandArgument
+        // so the resulting command remains a single argv element when copy-pasted
+        // into a shell.
+        var toolPath = "/opt/My Aspire";
+        using var processPathScope = DotNetToolDetection.UseProcessPathForTesting(
+            $"{toolPath}/.store/aspire.cli/9.4.0/aspire.cli.linux-x64/9.4.0/tools/net10.0/linux-x64/aspire");
+
+        var command = s_provider.GetUpdateCommand(InstallSource.DotnetTool, processPath: null, identityChannel: "stable");
+
+        Assert.Equal($"dotnet tool update --tool-path \"{toolPath}\" Aspire.Cli", command);
+    }
+
+    [Fact]
+    public void GetUpdateCommand_DotnetTool_PathShapeUnrecognized_FallsBackToGlobal()
+    {
+        // When the running process path doesn't match any known dotnet-tool
+        // store layout (e.g., legacy installs without the canonical store
+        // shape, or the test runner itself), the provider falls back to the
+        // global form so the message is at least actionable.
+        using var processPathScope = DotNetToolDetection.UseProcessPathForTesting("/tmp/random/path/aspire");
+
+        var command = s_provider.GetUpdateCommand(InstallSource.DotnetTool, processPath: null, identityChannel: "stable");
+
+        Assert.Equal("dotnet tool update -g Aspire.Cli", command);
+    }
+}

--- a/tests/Aspire.Cli.Tests/Acquisition/WingetFirstRunSelfUpdateGuardTests.cs
+++ b/tests/Aspire.Cli.Tests/Acquisition/WingetFirstRunSelfUpdateGuardTests.cs
@@ -1,0 +1,190 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Aspire.Cli.Acquisition;
+using Aspire.Cli.Commands;
+using Aspire.Cli.Tests.TestServices;
+using Aspire.Cli.Tests.Utils;
+using Microsoft.AspNetCore.InternalTesting;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace Aspire.Cli.Tests.Acquisition;
+
+/// <summary>
+/// Regression guard for the WinGet first-run sidecar bypass. WinGet sidecars
+/// are stamped lazily by <see cref="WingetFirstRunProbe"/> from
+/// <see cref="Aspire.Cli.Bundles.BundleService"/>'s extract path. If a fresh
+/// WinGet install's very first command is <c>aspire update --self</c>, the
+/// bundle path never runs, no sidecar exists, and a naive resolver would
+/// classify the route as <see cref="InstallSource.Unknown"/> — which routes
+/// to in-process update and silently overwrites the WinGet-owned binary.
+/// PR α adds a <see cref="WingetFirstRunProbe.Run"/> call inside
+/// <c>UpdateCommand.ResolveRunningInstall</c> (and
+/// <c>CliUpdateNotifier.GetRouteAwareUpdateCommand</c>) so the sidecar is
+/// stamped before the route decision is read.
+/// </summary>
+public class WingetFirstRunSelfUpdateGuardTests(ITestOutputHelper outputHelper)
+{
+    [Fact]
+    public void Probe_WingetClassifiedBinary_StampsSidecarAtomically()
+    {
+        using var tempDir = new TempDirectory();
+        var binaryName = OperatingSystem.IsWindows() ? "aspire.exe" : "aspire";
+        File.WriteAllText(Path.Combine(tempDir.Path, binaryName), string.Empty);
+
+        var fakeRegistry = new FakeWingetRegistryReader { ShouldClassifyAsWingetPortable = true };
+        var probe = new WingetFirstRunProbe(fakeRegistry, NullLogger<WingetFirstRunProbe>.Instance);
+
+        Assert.False(File.Exists(Path.Combine(tempDir.Path, ".aspire-install.json")));
+
+        probe.Run(tempDir.Path);
+
+        var info = new InstallSidecarReader().TryRead(tempDir.Path);
+        Assert.NotNull(info);
+        Assert.Equal(InstallSource.Winget, info!.Source);
+    }
+
+    [Fact]
+    public void Probe_NotAWingetInstall_DoesNotWriteSidecar()
+    {
+        using var tempDir = new TempDirectory();
+        File.WriteAllText(Path.Combine(tempDir.Path, "aspire"), string.Empty);
+
+        var fakeRegistry = new FakeWingetRegistryReader { ShouldClassifyAsWingetPortable = false };
+        var probe = new WingetFirstRunProbe(fakeRegistry, NullLogger<WingetFirstRunProbe>.Instance);
+
+        probe.Run(tempDir.Path);
+
+        Assert.False(
+            File.Exists(Path.Combine(tempDir.Path, ".aspire-install.json")),
+            "Probe must NOT stamp a sidecar when the registry says this is not a WinGet install.");
+    }
+
+    /// <summary>
+    /// End-to-end integration: drives <c>aspire update --self</c> against a
+    /// controllable temp binary directory. Initially the sidecar is absent
+    /// (mirrors a fresh WinGet install state); the fake registry classifies
+    /// the running binary as a WinGet portable install. After the SUT runs:
+    /// (a) the sidecar must exist on disk (proves the probe was invoked
+    /// before the route decision), and (b) the printed refusal must contain
+    /// the WinGet update command (proves the route was re-resolved post-probe
+    /// and the gating took the WinGet branch instead of falling through to
+    /// in-process update).
+    /// </summary>
+    [Fact]
+    public async Task SelfUpdate_FirstRunWingetInstall_StampsSidecarAndRefusesWithWingetCommand()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+
+        // Controllable binary location — discovery surfaces this as
+        // CanonicalPath, the production code derives binaryDir from it,
+        // and the probe writes the sidecar here.
+        using var binaryHome = new TempDirectory();
+        var binaryName = OperatingSystem.IsWindows() ? "aspire.exe" : "aspire";
+        var binaryPath = Path.Combine(binaryHome.Path, binaryName);
+        File.WriteAllText(binaryPath, string.Empty);
+        var sidecarPath = Path.Combine(binaryHome.Path, ".aspire-install.json");
+        Assert.False(File.Exists(sidecarPath), "Pre-condition: no sidecar yet (first-run state).");
+
+        TestInteractionService? interactionService = null;
+        var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper, options =>
+        {
+            options.InteractionServiceFactory = _ =>
+            {
+                interactionService = new TestInteractionService();
+                return interactionService;
+            };
+        });
+
+        services.AddSingleton<IWindowsRegistryReader>(new FakeWingetRegistryReader { ShouldClassifyAsWingetPortable = true });
+        services.AddSingleton(sp => new WingetFirstRunProbe(
+            sp.GetRequiredService<IWindowsRegistryReader>(),
+            NullLogger<WingetFirstRunProbe>.Instance));
+        // SidecarBackedDiscovery re-reads the sidecar on every DescribeSelf
+        // call — so once the probe stamps it, the second describe sees Winget.
+        services.AddSingleton<IInstallationDiscovery>(_ => new SidecarBackedDiscovery(binaryPath));
+
+        using var provider = services.BuildServiceProvider();
+        var command = provider.GetRequiredService<RootCommand>();
+        var exitCode = await command.Parse("update --self").InvokeAsync().DefaultTimeout();
+
+        Assert.True(File.Exists(sidecarPath),
+            "WingetFirstRunProbe must have stamped the sidecar during ResolveRunningInstall.");
+        var stamped = new InstallSidecarReader().TryRead(binaryHome.Path);
+        Assert.NotNull(stamped);
+        Assert.Equal(InstallSource.Winget, stamped!.Source);
+
+        Assert.Equal(0, exitCode);
+        Assert.NotNull(interactionService);
+        Assert.Contains(
+            interactionService!.DisplayedPlainText,
+            line => line.Contains("winget upgrade Microsoft.Aspire", StringComparison.Ordinal));
+    }
+
+    private sealed class FakeWingetRegistryReader : IWindowsRegistryReader
+    {
+        public bool ShouldClassifyAsWingetPortable { get; set; }
+
+        public bool HasWingetAspireUninstallEntry(string processPath) => ShouldClassifyAsWingetPortable;
+    }
+
+    private sealed class SpyWingetRegistryReader : IWindowsRegistryReader
+    {
+        public int QueryCount { get; private set; }
+
+        public bool HasWingetAspireUninstallEntry(string processPath)
+        {
+            QueryCount++;
+            return false;
+        }
+    }
+
+    private sealed class SidecarBackedDiscovery : IInstallationDiscovery
+    {
+        private readonly string _binaryPath;
+        private readonly InstallSidecarReader _reader = new();
+
+        public SidecarBackedDiscovery(string binaryPath)
+        {
+            _binaryPath = binaryPath;
+        }
+
+        public InstallationInfo DescribeSelf()
+        {
+            var binaryDir = Path.GetDirectoryName(_binaryPath)!;
+            var sidecar = _reader.TryRead(binaryDir);
+            return new InstallationInfo
+            {
+                Path = _binaryPath,
+                CanonicalPath = _binaryPath,
+                Route = sidecar?.Source.ToWireString() ?? sidecar?.RawSource,
+                Status = InstallationInfoStatus.Ok,
+            };
+        }
+
+        public Task<IReadOnlyList<InstallationInfo>> DiscoverAllAsync(CancellationToken cancellationToken)
+            => Task.FromResult<IReadOnlyList<InstallationInfo>>([DescribeSelf()]);
+    }
+
+    private sealed class TempDirectory : IDisposable
+    {
+        public string Path { get; }
+
+        public TempDirectory()
+        {
+            Path = Directory.CreateTempSubdirectory("aspire-winget-firstrun-").FullName;
+        }
+
+        public void Dispose()
+        {
+            try
+            {
+                Directory.Delete(Path, recursive: true);
+            }
+            catch (IOException) { }
+            catch (UnauthorizedAccessException) { }
+        }
+    }
+}
+

--- a/tests/Aspire.Cli.Tests/Commands/UpdateCommandNonInteractiveTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/UpdateCommandNonInteractiveTests.cs
@@ -1,0 +1,130 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Aspire.Cli.Commands;
+using Aspire.Cli.Packaging;
+using Aspire.Cli.Projects;
+using Aspire.Cli.Tests.TestServices;
+using Aspire.Cli.Tests.Utils;
+using Microsoft.AspNetCore.InternalTesting;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Aspire.Cli.Tests.Commands;
+
+/// <summary>
+/// Regression coverage for <c>aspire update --non-interactive</c> code paths
+/// that historically reached an interactive prompt and crashed with
+/// <see cref="InvalidOperationException"/> ("Interactive input is not
+/// supported in this environment").
+/// </summary>
+public class UpdateCommandNonInteractiveTests(ITestOutputHelper outputHelper)
+{
+    /// <summary>
+    /// Regression for #15600. Pre-fix: when hive directories existed under
+    /// <c>~/.aspire/hives/</c>, the update flow called
+    /// <c>PromptForSelectionAsync</c> for channel selection regardless of
+    /// the host environment's interactive support. Post-fix: in a non-
+    /// interactive host the implicit channel is selected silently.
+    ///
+    /// Repro mirrors the issue's steps: hive directory exists, no
+    /// <c>--channel</c> argument, <c>--non-interactive</c> set. The fix is
+    /// orthogonal to whether <c>--yes</c> is present (the channel prompt
+    /// has no <c>--yes</c> binding), so we cover both forms.
+    /// </summary>
+    [Theory]
+    [InlineData("update --non-interactive --yes")]
+    [InlineData("update --channel stable --non-interactive --yes")]
+    public async Task NonInteractiveUpdate_WithHives_DoesNotCrashAtChannelPrompt(string commandLine)
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+
+        // Mirror #15600 setup: leftover PR-dogfood hive on disk.
+        var hivesDir = workspace.CreateDirectory(".aspire").CreateSubdirectory("hives");
+        hivesDir.CreateSubdirectory("pr-99999");
+
+        var promptInvoked = false;
+        var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper, options =>
+        {
+            options.ProjectLocatorFactory = _ => new TestProjectLocator()
+            {
+                UseOrFindAppHostProjectFileAsyncCallback = (_, _, _) =>
+                    Task.FromResult<FileInfo?>(new FileInfo(Path.Combine(workspace.WorkspaceRoot.FullName, "AppHost.csproj")))
+            };
+
+            options.DotNetCliRunnerFactory = _ => new TestDotNetCliRunner();
+
+            options.PackagingServiceFactory = _ => new TestPackagingService()
+            {
+                GetChannelsAsyncCallback = (_) =>
+                {
+                    var fakeCache = new FakeNuGetPackageCache();
+                    var implicitChannel = PackageChannel.CreateImplicitChannel(fakeCache);
+                    var stableChannel = PackageChannel.CreateExplicitChannel("stable", PackageChannelQuality.Stable, mappings: null, fakeCache);
+                    return Task.FromResult<IEnumerable<PackageChannel>>(new[] { implicitChannel, stableChannel });
+                }
+            };
+
+            options.ProjectUpdaterFactory = _ => new TestProjectUpdater()
+            {
+                UpdateProjectAsyncCallback = (_, _) => Task.FromResult(new ProjectUpdateResult { UpdatedApplied = true })
+            };
+
+            // Fail the test loudly if anything still tries to prompt. The
+            // SUT must reach the project-update path without touching this.
+            options.InteractionServiceFactory = _ => new TestInteractionService
+            {
+                PromptForSelectionCallback = (_, _, _, _) =>
+                {
+                    promptInvoked = true;
+                    throw new InvalidOperationException("Interactive input is not supported in this environment.");
+                },
+            };
+        });
+
+        using var provider = services.BuildServiceProvider();
+        var command = provider.GetRequiredService<RootCommand>();
+        var parsed = command.Parse(commandLine);
+        var exitCode = await parsed.InvokeAsync().DefaultTimeout();
+
+        Assert.False(promptInvoked, "Channel prompt must not be invoked in non-interactive mode (#15600).");
+        Assert.Equal(ExitCodeConstants.Success, exitCode);
+    }
+
+    /// <summary>
+    /// Regression for #15601. The repro from the issue
+    /// (<c>aspire update --non-interactive</c> without <c>--yes</c>) now
+    /// fails command-line validation early via
+    /// <see cref="BaseCommand.AddNonInteractiveRequiresYesValidator"/>,
+    /// surfacing a clear error message instead of crashing at the
+    /// downgrade-confirmation prompt. This locks that contract in.
+    /// </summary>
+    [Fact]
+    public async Task NonInteractiveUpdate_WithoutYes_FailsValidationEarlyInsteadOfCrashingAtConfirmPrompt()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+
+        var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper, options =>
+        {
+            options.ProjectLocatorFactory = _ => new TestProjectLocator()
+            {
+                UseOrFindAppHostProjectFileAsyncCallback = (_, _, _) =>
+                    Task.FromResult<FileInfo?>(new FileInfo(Path.Combine(workspace.WorkspaceRoot.FullName, "AppHost.csproj")))
+            };
+
+            options.InteractionServiceFactory = _ => new TestInteractionService
+            {
+                ConfirmCallback = (_, _) =>
+                    throw new InvalidOperationException("Interactive input is not supported in this environment."),
+            };
+        });
+
+        using var provider = services.BuildServiceProvider();
+        var command = provider.GetRequiredService<RootCommand>();
+        var parsed = command.Parse("update --non-interactive");
+        var exitCode = await parsed.InvokeAsync().DefaultTimeout();
+
+        // Validator should fail this with InvalidCommand (non-zero) rather
+        // than letting the command reach ProjectUpdater's ConfirmAsync.
+        Assert.NotEqual(ExitCodeConstants.Success, exitCode);
+    }
+}

--- a/tests/Aspire.Cli.Tests/Commands/UpdateCommandTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/UpdateCommandTests.cs
@@ -13,6 +13,7 @@ using Aspire.Cli.Resources;
 using Aspire.Cli.Tests.TestServices;
 using Aspire.Cli.Tests.Utils;
 using Aspire.Cli.Utils;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Spectre.Console;
 using Spectre.Console.Rendering;
@@ -1085,6 +1086,12 @@ public class UpdateCommandTests(ITestOutputHelper outputHelper)
 
         var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper, options =>
         {
+            // The channel prompt only fires when the host environment is
+            // interactive (regression guard for #15600). Default test setup
+            // uses non-interactive, so opt in here so we can exercise the
+            // cancellation path through the prompt.
+            options.CliHostEnvironmentFactory = sp => new CliHostEnvironment(sp.GetRequiredService<IConfiguration>(), nonInteractive: false);
+
             options.ProjectLocatorFactory = _ => new TestProjectLocator()
             {
                 UseOrFindAppHostProjectFileAsyncCallback = (projectFile, _, _) =>
@@ -1481,6 +1488,12 @@ public class UpdateCommandTests(ITestOutputHelper outputHelper)
 
         var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper, options =>
         {
+            // The channel prompt only fires when the host environment is
+            // interactive (regression guard for #15600). Default test setup
+            // uses non-interactive, so opt in here to exercise the prompt's
+            // ordering / formatting contract.
+            options.CliHostEnvironmentFactory = sp => new CliHostEnvironment(sp.GetRequiredService<IConfiguration>(), nonInteractive: false);
+
             options.ProjectLocatorFactory = _ => new TestProjectLocator()
             {
                 UseOrFindAppHostProjectFileAsyncCallback = (projectFile, _, _) =>

--- a/tests/Aspire.Cli.Tests/Utils/CliTestHelper.cs
+++ b/tests/Aspire.Cli.Tests/Utils/CliTestHelper.cs
@@ -363,7 +363,10 @@ internal sealed class CliServiceCollectionTestOptions
         var logger = NullLoggerFactory.Instance.CreateLogger<CliUpdateNotifier>();
         var nuGetPackageCache = serviceProvider.GetRequiredService<INuGetPackageCache>();
         var interactionService = serviceProvider.GetRequiredService<IInteractionService>();
-        return new CliUpdateNotifier(logger, nuGetPackageCache, interactionService);
+        var installationDiscovery = serviceProvider.GetRequiredService<IInstallationDiscovery>();
+        var upgradeInstructionProvider = serviceProvider.GetRequiredService<IUpgradeInstructionProvider>();
+        var executionContext = serviceProvider.GetRequiredService<CliExecutionContext>();
+        return new CliUpdateNotifier(logger, nuGetPackageCache, interactionService, installationDiscovery, upgradeInstructionProvider, executionContext);
     };
 
     public Func<IServiceProvider, IAddCommandPrompter> AddCommandPrompterFactory { get; set; } = (IServiceProvider serviceProvider) =>

--- a/tests/Aspire.Cli.Tests/Utils/CliTestHelper.cs
+++ b/tests/Aspire.Cli.Tests/Utils/CliTestHelper.cs
@@ -159,6 +159,7 @@ internal static class CliTestHelper
         services.AddSingleton<IPeerInstallProbe, PeerInstallProbe>();
         services.AddSingleton<IInstallationDiscovery, InstallationDiscovery>();
         services.AddSingleton<IInstallationUninstaller, InstallationUninstaller>();
+        services.AddSingleton<IUpgradeInstructionProvider, UpgradeInstructionProvider>();
         services.AddSingleton<WingetFirstRunProbe>();
         if (OperatingSystem.IsWindows())
         {

--- a/tests/Aspire.Cli.Tests/Utils/CliTestHelper.cs
+++ b/tests/Aspire.Cli.Tests/Utils/CliTestHelper.cs
@@ -366,7 +366,8 @@ internal sealed class CliServiceCollectionTestOptions
         var installationDiscovery = serviceProvider.GetRequiredService<IInstallationDiscovery>();
         var upgradeInstructionProvider = serviceProvider.GetRequiredService<IUpgradeInstructionProvider>();
         var executionContext = serviceProvider.GetRequiredService<CliExecutionContext>();
-        return new CliUpdateNotifier(logger, nuGetPackageCache, interactionService, installationDiscovery, upgradeInstructionProvider, executionContext);
+        var wingetFirstRunProbe = serviceProvider.GetRequiredService<WingetFirstRunProbe>();
+        return new CliUpdateNotifier(logger, nuGetPackageCache, interactionService, installationDiscovery, upgradeInstructionProvider, executionContext, wingetFirstRunProbe);
     };
 
     public Func<IServiceProvider, IAddCommandPrompter> AddCommandPrompterFactory { get; set; } = (IServiceProvider serviceProvider) =>

--- a/tests/Aspire.Cli.Tests/Utils/CliUpdateNotificationServiceTests.cs
+++ b/tests/Aspire.Cli.Tests/Utils/CliUpdateNotificationServiceTests.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using Aspire.Cli.Acquisition;
 using Aspire.Cli.Interaction;
 using Aspire.Cli.NuGet;
 using Aspire.Cli.Tests.TestServices;
@@ -56,7 +57,7 @@ public class CliUpdateNotificationServiceTests(ITestOutputHelper outputHelper)
                 var interactionService = sp.GetRequiredService<IInteractionService>();
 
                 // Use a custom notifier that overrides the current version
-                return new CliUpdateNotifierWithPackageVersionOverride("9.4.0-dev", logger, nuGetPackageCache, interactionService);
+                return new CliUpdateNotifierWithPackageVersionOverride("9.4.0-dev", logger, nuGetPackageCache, interactionService, sp.GetRequiredService<IInstallationDiscovery>(), sp.GetRequiredService<IUpgradeInstructionProvider>(), sp.GetRequiredService<CliExecutionContext>());
             };
         });
 
@@ -108,7 +109,7 @@ public class CliUpdateNotificationServiceTests(ITestOutputHelper outputHelper)
                 var interactionService = sp.GetRequiredService<IInteractionService>();
 
                 // Use a custom notifier that overrides the current version
-                return new CliUpdateNotifierWithPackageVersionOverride("9.4.0-dev", logger, nuGetPackageCache, interactionService);
+                return new CliUpdateNotifierWithPackageVersionOverride("9.4.0-dev", logger, nuGetPackageCache, interactionService, sp.GetRequiredService<IInstallationDiscovery>(), sp.GetRequiredService<IUpgradeInstructionProvider>(), sp.GetRequiredService<CliExecutionContext>());
             };
         });
 
@@ -160,7 +161,7 @@ public class CliUpdateNotificationServiceTests(ITestOutputHelper outputHelper)
                 var interactionService = sp.GetRequiredService<IInteractionService>();
 
                 // Use a custom notifier that overrides the current version
-                return new CliUpdateNotifierWithPackageVersionOverride("9.4.0", logger, nuGetPackageCache, interactionService);
+                return new CliUpdateNotifierWithPackageVersionOverride("9.4.0", logger, nuGetPackageCache, interactionService, sp.GetRequiredService<IInstallationDiscovery>(), sp.GetRequiredService<IUpgradeInstructionProvider>(), sp.GetRequiredService<CliExecutionContext>());
             };
         });
 
@@ -196,7 +197,7 @@ public class CliUpdateNotificationServiceTests(ITestOutputHelper outputHelper)
                 var logger = sp.GetRequiredService<ILogger<CliUpdateNotifier>>();
                 var nuGetPackageCache = sp.GetRequiredService<INuGetPackageCache>();
                 var interactionService = sp.GetRequiredService<IInteractionService>();
-                return new CliUpdateNotifierWithPackageVersionOverride("9.4.0", logger, nuGetPackageCache, interactionService);
+                return new CliUpdateNotifierWithPackageVersionOverride("9.4.0", logger, nuGetPackageCache, interactionService, sp.GetRequiredService<IInstallationDiscovery>(), sp.GetRequiredService<IUpgradeInstructionProvider>(), sp.GetRequiredService<CliExecutionContext>());
             };
         });
 
@@ -233,7 +234,7 @@ public class CliUpdateNotificationServiceTests(ITestOutputHelper outputHelper)
                 var logger = sp.GetRequiredService<ILogger<CliUpdateNotifier>>();
                 var nuGetPackageCache = sp.GetRequiredService<INuGetPackageCache>();
                 var service = sp.GetRequiredService<IInteractionService>();
-                return new CliUpdateNotifierWithPackageVersionOverride("9.4.0", logger, nuGetPackageCache, service);
+                return new CliUpdateNotifierWithPackageVersionOverride("9.4.0", logger, nuGetPackageCache, service, sp.GetRequiredService<IInstallationDiscovery>(), sp.GetRequiredService<IUpgradeInstructionProvider>(), sp.GetRequiredService<CliExecutionContext>());
             };
         });
 
@@ -276,7 +277,7 @@ public class CliUpdateNotificationServiceTests(ITestOutputHelper outputHelper)
                 var logger = sp.GetRequiredService<ILogger<CliUpdateNotifier>>();
                 var nuGetPackageCache = sp.GetRequiredService<INuGetPackageCache>();
                 var service = sp.GetRequiredService<IInteractionService>();
-                return new CliUpdateNotifierWithPackageVersionOverride("9.4.0", logger, nuGetPackageCache, service);
+                return new CliUpdateNotifierWithPackageVersionOverride("9.4.0", logger, nuGetPackageCache, service, sp.GetRequiredService<IInstallationDiscovery>(), sp.GetRequiredService<IUpgradeInstructionProvider>(), sp.GetRequiredService<CliExecutionContext>());
             };
         });
 
@@ -291,7 +292,7 @@ public class CliUpdateNotificationServiceTests(ITestOutputHelper outputHelper)
     }
 
     [Fact]
-    public async Task NotifyIfUpdateAvailable_UsesAspireUpdateCommandForStandaloneArchivePath()
+    public async Task NotifyIfUpdateAvailable_UsesAspireUpdateSelfCommandForStandaloneArchivePath()
     {
         using var workspace = TemporaryWorkspace.Create(outputHelper);
         using var processPathScope = DotNetToolDetection.UseProcessPathForTesting("/home/test/.aspire/bin/aspire");
@@ -317,7 +318,7 @@ public class CliUpdateNotificationServiceTests(ITestOutputHelper outputHelper)
                 var logger = sp.GetRequiredService<ILogger<CliUpdateNotifier>>();
                 var nuGetPackageCache = sp.GetRequiredService<INuGetPackageCache>();
                 var service = sp.GetRequiredService<IInteractionService>();
-                return new CliUpdateNotifierWithPackageVersionOverride("9.4.0", logger, nuGetPackageCache, service);
+                return new CliUpdateNotifierWithPackageVersionOverride("9.4.0", logger, nuGetPackageCache, service, sp.GetRequiredService<IInstallationDiscovery>(), sp.GetRequiredService<IUpgradeInstructionProvider>(), sp.GetRequiredService<CliExecutionContext>());
             };
         });
 
@@ -328,7 +329,12 @@ public class CliUpdateNotificationServiceTests(ITestOutputHelper outputHelper)
         notifier.NotifyIfUpdateAvailable();
 
         Assert.NotNull(interactionService);
-        Assert.Equal("aspire update", interactionService.LastVersionUpdateCommand);
+        // Script-route (and Unknown / legacy archive installs lacking a sidecar)
+        // recommend `aspire update --self` — the route-correct command that
+        // actually performs the in-process binary swap. The previous
+        // recommendation `aspire update` runs the project-update flow, not the
+        // CLI self-update, and was misleading for users hitting this notification.
+        Assert.Equal("aspire update --self", interactionService.LastVersionUpdateCommand);
     }
 
     [Fact]
@@ -365,7 +371,7 @@ public class CliUpdateNotificationServiceTests(ITestOutputHelper outputHelper)
                 var interactionService = sp.GetRequiredService<IInteractionService>();
 
                 // Use a custom notifier that overrides the current version
-                return new CliUpdateNotifierWithPackageVersionOverride("9.4.0", logger, nuGetPackageCache, interactionService);
+                return new CliUpdateNotifierWithPackageVersionOverride("9.4.0", logger, nuGetPackageCache, interactionService, sp.GetRequiredService<IInstallationDiscovery>(), sp.GetRequiredService<IUpgradeInstructionProvider>(), sp.GetRequiredService<CliExecutionContext>());
             };
         });
 
@@ -449,7 +455,7 @@ public class CliUpdateNotificationServiceTests(ITestOutputHelper outputHelper)
     }
 }
 
-internal sealed class CliUpdateNotifierWithPackageVersionOverride(string currentVersion, ILogger<CliUpdateNotifier> logger, INuGetPackageCache nuGetPackageCache, IInteractionService interactionService) : CliUpdateNotifier(logger, nuGetPackageCache, interactionService)
+internal sealed class CliUpdateNotifierWithPackageVersionOverride(string currentVersion, ILogger<CliUpdateNotifier> logger, INuGetPackageCache nuGetPackageCache, IInteractionService interactionService, IInstallationDiscovery installationDiscovery, IUpgradeInstructionProvider upgradeInstructionProvider, CliExecutionContext executionContext) : CliUpdateNotifier(logger, nuGetPackageCache, interactionService, installationDiscovery, upgradeInstructionProvider, executionContext)
 {
     protected override SemVersion? GetCurrentVersion()
     {

--- a/tests/Aspire.Cli.Tests/Utils/CliUpdateNotificationServiceTests.cs
+++ b/tests/Aspire.Cli.Tests/Utils/CliUpdateNotificationServiceTests.cs
@@ -57,7 +57,7 @@ public class CliUpdateNotificationServiceTests(ITestOutputHelper outputHelper)
                 var interactionService = sp.GetRequiredService<IInteractionService>();
 
                 // Use a custom notifier that overrides the current version
-                return new CliUpdateNotifierWithPackageVersionOverride("9.4.0-dev", logger, nuGetPackageCache, interactionService, sp.GetRequiredService<IInstallationDiscovery>(), sp.GetRequiredService<IUpgradeInstructionProvider>(), sp.GetRequiredService<CliExecutionContext>());
+                return new CliUpdateNotifierWithPackageVersionOverride("9.4.0-dev", logger, nuGetPackageCache, interactionService, sp.GetRequiredService<IInstallationDiscovery>(), sp.GetRequiredService<IUpgradeInstructionProvider>(), sp.GetRequiredService<CliExecutionContext>(), sp.GetRequiredService<WingetFirstRunProbe>());
             };
         });
 
@@ -109,7 +109,7 @@ public class CliUpdateNotificationServiceTests(ITestOutputHelper outputHelper)
                 var interactionService = sp.GetRequiredService<IInteractionService>();
 
                 // Use a custom notifier that overrides the current version
-                return new CliUpdateNotifierWithPackageVersionOverride("9.4.0-dev", logger, nuGetPackageCache, interactionService, sp.GetRequiredService<IInstallationDiscovery>(), sp.GetRequiredService<IUpgradeInstructionProvider>(), sp.GetRequiredService<CliExecutionContext>());
+                return new CliUpdateNotifierWithPackageVersionOverride("9.4.0-dev", logger, nuGetPackageCache, interactionService, sp.GetRequiredService<IInstallationDiscovery>(), sp.GetRequiredService<IUpgradeInstructionProvider>(), sp.GetRequiredService<CliExecutionContext>(), sp.GetRequiredService<WingetFirstRunProbe>());
             };
         });
 
@@ -161,7 +161,7 @@ public class CliUpdateNotificationServiceTests(ITestOutputHelper outputHelper)
                 var interactionService = sp.GetRequiredService<IInteractionService>();
 
                 // Use a custom notifier that overrides the current version
-                return new CliUpdateNotifierWithPackageVersionOverride("9.4.0", logger, nuGetPackageCache, interactionService, sp.GetRequiredService<IInstallationDiscovery>(), sp.GetRequiredService<IUpgradeInstructionProvider>(), sp.GetRequiredService<CliExecutionContext>());
+                return new CliUpdateNotifierWithPackageVersionOverride("9.4.0", logger, nuGetPackageCache, interactionService, sp.GetRequiredService<IInstallationDiscovery>(), sp.GetRequiredService<IUpgradeInstructionProvider>(), sp.GetRequiredService<CliExecutionContext>(), sp.GetRequiredService<WingetFirstRunProbe>());
             };
         });
 
@@ -197,7 +197,7 @@ public class CliUpdateNotificationServiceTests(ITestOutputHelper outputHelper)
                 var logger = sp.GetRequiredService<ILogger<CliUpdateNotifier>>();
                 var nuGetPackageCache = sp.GetRequiredService<INuGetPackageCache>();
                 var interactionService = sp.GetRequiredService<IInteractionService>();
-                return new CliUpdateNotifierWithPackageVersionOverride("9.4.0", logger, nuGetPackageCache, interactionService, sp.GetRequiredService<IInstallationDiscovery>(), sp.GetRequiredService<IUpgradeInstructionProvider>(), sp.GetRequiredService<CliExecutionContext>());
+                return new CliUpdateNotifierWithPackageVersionOverride("9.4.0", logger, nuGetPackageCache, interactionService, sp.GetRequiredService<IInstallationDiscovery>(), sp.GetRequiredService<IUpgradeInstructionProvider>(), sp.GetRequiredService<CliExecutionContext>(), sp.GetRequiredService<WingetFirstRunProbe>());
             };
         });
 
@@ -234,7 +234,7 @@ public class CliUpdateNotificationServiceTests(ITestOutputHelper outputHelper)
                 var logger = sp.GetRequiredService<ILogger<CliUpdateNotifier>>();
                 var nuGetPackageCache = sp.GetRequiredService<INuGetPackageCache>();
                 var service = sp.GetRequiredService<IInteractionService>();
-                return new CliUpdateNotifierWithPackageVersionOverride("9.4.0", logger, nuGetPackageCache, service, sp.GetRequiredService<IInstallationDiscovery>(), sp.GetRequiredService<IUpgradeInstructionProvider>(), sp.GetRequiredService<CliExecutionContext>());
+                return new CliUpdateNotifierWithPackageVersionOverride("9.4.0", logger, nuGetPackageCache, service, sp.GetRequiredService<IInstallationDiscovery>(), sp.GetRequiredService<IUpgradeInstructionProvider>(), sp.GetRequiredService<CliExecutionContext>(), sp.GetRequiredService<WingetFirstRunProbe>());
             };
         });
 
@@ -277,7 +277,7 @@ public class CliUpdateNotificationServiceTests(ITestOutputHelper outputHelper)
                 var logger = sp.GetRequiredService<ILogger<CliUpdateNotifier>>();
                 var nuGetPackageCache = sp.GetRequiredService<INuGetPackageCache>();
                 var service = sp.GetRequiredService<IInteractionService>();
-                return new CliUpdateNotifierWithPackageVersionOverride("9.4.0", logger, nuGetPackageCache, service, sp.GetRequiredService<IInstallationDiscovery>(), sp.GetRequiredService<IUpgradeInstructionProvider>(), sp.GetRequiredService<CliExecutionContext>());
+                return new CliUpdateNotifierWithPackageVersionOverride("9.4.0", logger, nuGetPackageCache, service, sp.GetRequiredService<IInstallationDiscovery>(), sp.GetRequiredService<IUpgradeInstructionProvider>(), sp.GetRequiredService<CliExecutionContext>(), sp.GetRequiredService<WingetFirstRunProbe>());
             };
         });
 
@@ -318,7 +318,7 @@ public class CliUpdateNotificationServiceTests(ITestOutputHelper outputHelper)
                 var logger = sp.GetRequiredService<ILogger<CliUpdateNotifier>>();
                 var nuGetPackageCache = sp.GetRequiredService<INuGetPackageCache>();
                 var service = sp.GetRequiredService<IInteractionService>();
-                return new CliUpdateNotifierWithPackageVersionOverride("9.4.0", logger, nuGetPackageCache, service, sp.GetRequiredService<IInstallationDiscovery>(), sp.GetRequiredService<IUpgradeInstructionProvider>(), sp.GetRequiredService<CliExecutionContext>());
+                return new CliUpdateNotifierWithPackageVersionOverride("9.4.0", logger, nuGetPackageCache, service, sp.GetRequiredService<IInstallationDiscovery>(), sp.GetRequiredService<IUpgradeInstructionProvider>(), sp.GetRequiredService<CliExecutionContext>(), sp.GetRequiredService<WingetFirstRunProbe>());
             };
         });
 
@@ -371,7 +371,7 @@ public class CliUpdateNotificationServiceTests(ITestOutputHelper outputHelper)
                 var interactionService = sp.GetRequiredService<IInteractionService>();
 
                 // Use a custom notifier that overrides the current version
-                return new CliUpdateNotifierWithPackageVersionOverride("9.4.0", logger, nuGetPackageCache, interactionService, sp.GetRequiredService<IInstallationDiscovery>(), sp.GetRequiredService<IUpgradeInstructionProvider>(), sp.GetRequiredService<CliExecutionContext>());
+                return new CliUpdateNotifierWithPackageVersionOverride("9.4.0", logger, nuGetPackageCache, interactionService, sp.GetRequiredService<IInstallationDiscovery>(), sp.GetRequiredService<IUpgradeInstructionProvider>(), sp.GetRequiredService<CliExecutionContext>(), sp.GetRequiredService<WingetFirstRunProbe>());
             };
         });
 
@@ -455,7 +455,7 @@ public class CliUpdateNotificationServiceTests(ITestOutputHelper outputHelper)
     }
 }
 
-internal sealed class CliUpdateNotifierWithPackageVersionOverride(string currentVersion, ILogger<CliUpdateNotifier> logger, INuGetPackageCache nuGetPackageCache, IInteractionService interactionService, IInstallationDiscovery installationDiscovery, IUpgradeInstructionProvider upgradeInstructionProvider, CliExecutionContext executionContext) : CliUpdateNotifier(logger, nuGetPackageCache, interactionService, installationDiscovery, upgradeInstructionProvider, executionContext)
+internal sealed class CliUpdateNotifierWithPackageVersionOverride(string currentVersion, ILogger<CliUpdateNotifier> logger, INuGetPackageCache nuGetPackageCache, IInteractionService interactionService, IInstallationDiscovery installationDiscovery, IUpgradeInstructionProvider upgradeInstructionProvider, CliExecutionContext executionContext, WingetFirstRunProbe wingetFirstRunProbe) : CliUpdateNotifier(logger, nuGetPackageCache, interactionService, installationDiscovery, upgradeInstructionProvider, executionContext, wingetFirstRunProbe)
 {
     protected override SemVersion? GetCurrentVersion()
     {


### PR DESCRIPTION
## Description

`aspire update --self` now refuses to perform an in-process binary swap for installs it doesn't own (PR / WinGet / Homebrew / `dotnet tool` / locally-built), and the "version X is available" notification surfaces the command that actually updates *your* binary. Also fixes the `aspire update --non-interactive` channel-prompt crash (#15600).

Part of the acquisition coherence ladder tracked in **#16737**. Stacked on **PR γ** (#17105) — consumes its `InstallSource` enum + `IInstallationDiscovery.DescribeSelf()`. Once #17105 lands, this PR retargets to `main`.

Closes #15600.

### What ships

**Route-gated `aspire update --self`** (`UpdateCommand.cs`):
- Resolves the running install via `IInstallationDiscovery.DescribeSelf()` (no new symlink-resolve helper added — reuses PR γ's resolver).
- `Script` and `Unknown` (legacy script installs without sidecars) → in-process update, unchanged behavior.
- `Pr` / `Winget` / `Brew` / `DotnetTool` / `LocalHive` → refuse with route-appropriate command via `IUpgradeInstructionProvider`, exit 0 (matches existing dotnet-tool refusal contract).
- Legacy fallback: when no sidecar is present AND `DotNetToolDetection.IsRunningAsDotNetTool()` returns true, the route is fixed up to `DotnetTool` so pre-sidecar dotnet-tool installs are recognized.

**`SelfUpdateRouter`** + **`IUpgradeInstructionProvider`** + **`UpgradeInstructionProvider`**:
- Pure policy lookup mapping `InstallSource` → `SelfUpdateAction` (`InProcess` | `Delegate`).
- Per-route command computation. Dotnet-tool runtime substitution (`-g` global vs `--tool-path "<dir>"`) reuses `DotNetToolDetection.GetDotNetToolUpdateCommand` no-arg overload — already AOT-safe and honors test overrides via its existing `AsyncLocal`.
- PR-route command substitutes the PR number from `CliExecutionContext.IdentityChannel` (`pr-<N>` → `get-aspire-cli-pr.sh <N>`) with deterministic fallback to the parameterised form when the identity channel isn't a PR build.

**Route-aware "update available" notification** (`CliUpdateNotifier.cs`):
- Replaces the hardcoded `"aspire update"` (which only runs the project-update flow, not the CLI self-update) and dotnet-tool special-case with a single call to `IUpgradeInstructionProvider`.
- Falls back to `"aspire update --self"` for `Script` / `Unknown` / unrecognized future routes.
- Brew users see `brew upgrade --cask aspire`; WinGet users see `winget upgrade Microsoft.Aspire`; etc.

**`aspire update --non-interactive` channel-prompt crash fix** (#15600):
- Pre-fix: when hive directories existed under `~/.aspire/hives/`, the command called `PromptForSelectionAsync` regardless of host environment, crashing with `InvalidOperationException: Interactive input is not supported`.
- Post-fix: gate the prompt on `ICliHostEnvironment.SupportsInteractiveInput`. In non-interactive hosts (explicit `--non-interactive`, CI env vars, missing console handles) the implicit/default channel is selected silently — matching the no-hives branch.

**#15601 regression test** added — the existing `AddNonInteractiveRequiresYesValidator` already short-circuits `--non-interactive` without `--yes` before any `ProjectUpdater.PromptConfirmAsync` site is reached. The new test hooks `ConfirmCallback` to throw if reached and asserts non-zero exit.

**Localization**:
- 5 new RESX strings: `WingetSelfUpdateMessage`, `BrewSelfUpdateMessage`, `PrSelfUpdateMessage`, `LocalHiveSelfUpdateMessage`, `SelfUpdateUnknownSourceMessage`.
- `dotnet build /t:UpdateXlf` regenerated 14 locale `.xlf` files.

**Description text fix** (small): the `Channel` property description on `AspireConfigFile` and `AspireJsonConfiguration` referenced the stale `"preview"` channel. Replaced with `"pr-<N>"`, the actual non-stable channel form.

### What's intentionally NOT in this PR

- **`Channel` property deletion** (originally planned as Scenario E) — re-evaluated and dropped from scope. The property is still actively read for project-local `aspire.config.json` files (DotNetBasedAppHostServerProject, PrebuiltAppHostServer, IntegrationPackageSearchService) and the legacy `AspireJsonConfiguration` fallback. PR 1 already handled the only problematic case (global file residue → nulled on migration in `Program.cs:176`).
- **Concurrent-update safety** (per-prefix locks, self-update lock, GC) — PR β scope.

### Closes / impacts

Supersedes / coordinates with **#15602** (Copilot bot draft addressing the same `#15600` / `#15601` crashes with a narrower scope — validator + channel-prompt guard only, no route gating, no notifier work).

| Issue / scenario | Closed by |
|---|---|
| ★ Silent PR demotion on `aspire update --self` | `UpdateCommand --self` route gating |
| ★ Package-manager binary clobber on `aspire update --self` | `UpdateCommand --self` route gating |
| **#15600** — `aspire update --non-interactive` crash at channel prompt | Channel prompt gated on `ICliHostEnvironment.SupportsInteractiveInput` |
| **#15601** — `aspire update --non-interactive` crash at ConfirmAsync | Already addressed by `AddNonInteractiveRequiresYesValidator`; regression test pins it down |
| S2.3 / S2.4 / S2.5 / S2.6 (`docs/specs/acquisition/user-scenarios.md` — `--self` per route) | Route gating + provider hints |
| S9.1–S9.4 (route-aware update notifications) | `CliUpdateNotifier` consumes `IUpgradeInstructionProvider` |
| S4.2 / S4.3 (channel residue across routes) | Already handled by PR 1's global-file cleanup |

### Validation

Manual matrix executed against this build on macOS arm64 (full results saved as a session artifact). All 9 scenarios pass:

- Script `--self --yes --channel stable` → in-process flow runs end-to-end (downloaded + installed v13.3.2)
- PR-route `--self` → refuses with `get-aspire-cli-pr.sh <N>` hint (parameterised fallback because Debug build's identity channel is `local`; PR-route CI builds bake the matching channel)
- Brew `--self` → refuses with `brew upgrade --cask aspire`
- WinGet `--self` → refuses with `winget upgrade Microsoft.Aspire`
- LocalHive `--self` → refuses with `./localhive.sh` rebuild hint
- Dotnet-tool global `--self` → refuses with `dotnet tool update -g Aspire.Cli`
- Dotnet-tool `--tool-path` `--self` → refuses with path-aware variant
- `update --non-interactive --yes` against config with hive dirs → no crash, default channel chosen silently
- Stale `aspire.config.json` with `"channel": "preview"` and an unknown future field → CLI doesn't crash; ignores both fields per System.Text.Json default tolerance

### Tests

194 / 194 acquisition + update tests pass. New test classes (Theory-flattened where applicable):

- `SelfUpdateRouterTests` — every `InstallSource` value → action mapping (7 rows).
- `UpgradeInstructionProviderTests` — static-hint routes + no-hint routes + PR-number substitution + 5 non-PR identity-channel fallback rows + dotnet-tool `-g` / `--tool-path` / whitespace-quote / path-shape-unrecognized fallback (13 Theory rows + 4 Facts).
- `UpdateNotificationRouteTests` — 5 routes × notification + Unknown (`null`) + unrecognized future source name (forward-compat).
- `UpdateCommandRouteRegressionTests` — 4 newly-gated routes end-to-end + legacy dotnet-tool path-shape fallback + legacy script no-sidecar in-process fallback.
- `UpdateCommandNonInteractiveTests` — 2 hive-scenario rows for #15600 + 1 Fact for #15601 validator.

Two pre-existing `UpdateCommandTests` cases were updated to opt in to interactive host environment so the channel-prompt content contract is still exercised. One pre-existing `CliUpdateNotificationServiceTests` test was renamed to assert the now-correct `aspire update --self` recommendation for archive-path installs.

### Code reuse highlights

Per the [`Watch for utility code that might already exist`](https://github.com/microsoft/aspire/issues/16737) directive:

- **`IInstallationDiscovery.DescribeSelf()`** — reused PR γ's canonical resolver instead of adding a 6th symlink-resolve helper (the codebase already had 5: `InstallationDiscovery.ResolveCanonicalPath`, `InstallationUninstaller.ResolveSymlinkOrSelf`, `InfoCommand.TryResolveSymlink`, `BundleService.ResolveSymlinks`, `InstallationUninstaller`'s standalone `File.ResolveLinkTarget` block).
- **`DotNetToolDetection.GetDotNetToolUpdateCommand()` and `IsRunningAsDotNetTool()`** no-arg overloads — already honor the `AsyncLocal` test override; reused for both production behavior and test compatibility.
- **`InstallSourceExtensions.ParseInstallSource`** — wire-string parser from PR γ.
- **`FakeInstallationDiscovery`** test helper from PR γ — used by `UpdateNotificationRouteTests` and `UpdateCommandRouteRegressionTests`.
- **`CliUpdateNotifierWithPackageVersionOverride`** test helper — extended (3 new constructor params, 8 call sites bulk-updated).
- **`AddNonInteractiveRequiresYesValidator`** + **`PromptBinding.Create`** — existing patterns kept; new prompt only adds an `ICliHostEnvironment` check.

### Notes for reviewers

- **Stacked PR.** This branch sits on top of `aspire-commands` (PR γ #17105). The diff against `aspire-commands` is what's actually new (5 commits, ~1,300 lines including locale xlf and test churn). Once PR γ merges, the base will be retargeted to `main` and the diff will be reviewable directly against main.
- **Exit code 0 on refusal** matches the existing `dotnet tool update` refusal contract — the CLI succeeds in telling the user what to run. Detecting "did this update?" via exit code was not previously possible for the dotnet-tool case either; users should compare versions before/after.
- **Pre-PR-2 legacy installs (no sidecar) get InProcess by design** — this preserves working behavior for users who installed before the sidecar contract shipped. The silent-PR-demotion / pkg-mgr-clobber regressions all involve binaries WITH sidecars (post-PR-2 installers always write them), so they correctly take the gated branch.

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship after #17105.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
  - [x] No (all new types are `internal`)
- Does the change make any security assumptions or guarantees?
  - [x] Yes
    - The route gating refuses to overwrite package-manager-owned binaries on `aspire update --self`, preventing the silent-PR-demotion and pkg-mgr-binary-clobber regressions. The classification source-of-truth is the install-route sidecar contract documented in `docs/specs/install-routes.md` (single-field JSON next to the binary). Compromise of the sidecar would let an attacker change the refusal message but not weaken the refusal — the worst case is still a printed `winget upgrade Microsoft.Aspire` instead of an in-process swap.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>

## PR test results

_Generated by `pr-testing` skill — 2026-05-15T00:26:33-04:00_

**CLI build under test:** `13.4.0-pr.17110.ge9f61898` (osx-arm64, GitHub Actions run [25897523105](https://github.com/microsoft/aspire/actions/runs/25897523105), run #20678)
**Platform:** macOS 25.4 / arm64 (Darwin)
**Runner:** host (installed under isolated `HOME` per `pr-testing` SKILL local-mode flow)
**Head commit verified:** `e9f6189863…` ⇄ CLI version suffix `ge9f61898` ✅

| # | Scenario | Exit | Result |
|---|----------|------|--------|
| 1 | `aspire --version` | 0 | ✅ `13.4.0-pr.17110.ge9f61898`; version suffix matches PR head `e9f6189863…` |
| 2 | `aspire info --non-interactive --nologo` | 0 | ✅ Install table renders; current CLI route=`pr`, channel=`pr-17110`; host dotnet-tool install also detected separately |
| 3 | `aspire update --self --non-interactive --yes` with sidecar `dotnet-tool` | 0 | ✅ Refuses before mutation with `dotnet tool update -g Aspire.Cli` hint |
| 4 | `aspire update --self --non-interactive --yes` with sidecar `brew` | 0 | ✅ Refuses before mutation with `brew upgrade --cask aspire` hint |
| 5 | `aspire update --self --non-interactive --yes` with sidecar `winget` | 0 | ✅ Refuses before mutation with `winget upgrade Microsoft.Aspire` hint |
| 6 | `aspire update --self --non-interactive --yes` with sidecar `pr` | 0 | ✅ Refuses before mutation with `get-aspire-cli-pr.sh 17110` / PowerShell PR reinstall hint |
| 7 | `aspire update --self --non-interactive --yes` with sidecar `localhive` | 0 | ✅ Refuses before mutation with `./localhive.sh` rebuild-from-checkout hint |
| 8 | `aspire update --non-interactive --yes --apphost <single-file apphost>` with PR hive present and no explicit target | 0 | ✅ Clean non-interactive update path; did not crash at channel prompt (#15600 regression) |
| 9 | `aspire update --non-interactive --channel stable --apphost <single-file apphost>` without `--yes` | 1 | ✅ Fails early with clear validator error: `requires --yes when the --non-interactive option is specified`; did not reach/crash at confirmation prompt (#15601 regression) |
| 10 | `aspire --help` under `pr` / `brew` / `winget` / `dotnet-tool` / `localhive` sidecars | 0 each | ✅ Command tree renders; no `update available` hint was emitted in this build, so no stale/wrong route hint was observed |

**Scenarios passed: 10 / 10.**

### Notes for reviewers

- **Safety:** no script-route `aspire update --self` path was run. Only delegated/refusal routes were exercised. The CLI version remained `13.4.0-pr.17110.ge9f61898` after all `--self` runs.
- **Exit-code observation:** route refusals exit `0` in this PR build. That matches the current in-code contract for “successfully told the user what updater owns this install,” even though the important safety property is refusal-before-mutation.
- **#15600 coverage:** generated a disposable single-file AppHost from the PR hive, left `~/.aspire/hives/pr-17110` present, omitted `--channel`, and used `--non-interactive --yes`; the command selected the implicit update path without prompting/crashing.
- **#15601 coverage:** used the same AppHost with an explicit `stable` target and `--non-interactive` but no `--yes`; validation failed before any downgrade confirmation prompt could run.
- **Route simulation:** sidecar-only swaps (`.aspire-install.json` next to the isolated PR binary) were the safest way to exercise all package-manager/local routes without invoking real package managers or mutating the host CLI.

