### PR TITLE
Stabilize replicated resource URL test

### DIFF
--- a/tests/Aspire.Hosting.Tests/WithUrlsTests.cs
+++ b/tests/Aspire.Hosting.Tests/WithUrlsTests.cs
@@ -382,11 +382,9 @@ public class WithUrlsTests(ITestOutputHelper testOutputHelper)
         await app.StartAsync();
 
         // Wait for the resource to have URLs allocated (before it starts running)
-        using var cts = AsyncTestHelpers.CreateDefaultTimeoutTokenSource();
         var resourceEvent = await rns.WaitForResourceAsync(
             servicea.Resource.Name,
-            e => e.Snapshot.Urls.Length > 0,
-            cts.Token);
+            e => e.Snapshot.Urls.Length > 0).DefaultTimeout();
 
         await app.StopAsync().DefaultTimeout();
 
@@ -409,11 +407,9 @@ public class WithUrlsTests(ITestOutputHelper testOutputHelper)
         await app.StartAsync();
 
         // Wait for URLs to be populated
-        using var cts = AsyncTestHelpers.CreateDefaultTimeoutTokenSource();
         var resourceEvent = await rns.WaitForResourceAsync(
             servicea.Resource.Name,
-            e => e.Snapshot.Urls.Length > 0,
-            cts.Token);
+            e => e.Snapshot.Urls.Length > 0).DefaultTimeout();
 
         await app.StopAsync().DefaultTimeout();
 
@@ -470,8 +466,6 @@ public class WithUrlsTests(ITestOutputHelper testOutputHelper)
         await using var app = await builder.BuildAsync();
         var rns = app.Services.GetRequiredService<ResourceNotificationService>();
 
-        using var cts = AsyncTestHelpers.CreateDefaultTimeoutTokenSource(TestConstants.LongTimeoutDuration);
-
         var urlSnapshots = new List<UrlSnapshot[]>();
 
         static string FormatUrls(IEnumerable<UrlSnapshot> urls) =>
@@ -479,7 +473,7 @@ public class WithUrlsTests(ITestOutputHelper testOutputHelper)
 
         var watchTask = Task.Run(async () =>
         {
-            await foreach (var notification in rns.WatchAsync(cts.Token))
+            await foreach (var notification in rns.WatchAsync())
             {
                 if (notification.Resource == servicea.Resource && notification.Snapshot.Urls.Length > 0)
                 {
@@ -497,8 +491,8 @@ public class WithUrlsTests(ITestOutputHelper testOutputHelper)
         });
 
         await app.StartAsync();
-        await rns.WaitForResourceAsync(servicea.Resource.Name, KnownResourceStates.Running, cts.Token);
-        await watchTask;
+        await rns.WaitForResourceAsync(servicea.Resource.Name, KnownResourceStates.Running).DefaultTimeout();
+        await watchTask.DefaultTimeout();
         await app.StopAsync().DefaultTimeout();
 
         // Log all captured snapshots for diagnostics
@@ -588,8 +582,6 @@ public class WithUrlsTests(ITestOutputHelper testOutputHelper)
         await using var app = await builder.BuildAsync();
         var rns = app.Services.GetRequiredService<ResourceNotificationService>();
 
-        using var cts = AsyncTestHelpers.CreateDefaultTimeoutTokenSource(TestConstants.LongTimeoutDuration);
-
         var urlSnapshots = new List<UrlSnapshot[]>();
 
         static string FormatUrls(IEnumerable<UrlSnapshot> urls) =>
@@ -597,7 +589,7 @@ public class WithUrlsTests(ITestOutputHelper testOutputHelper)
 
         var watchTask = Task.Run(async () =>
         {
-            await foreach (var notification in rns.WatchAsync(cts.Token))
+            await foreach (var notification in rns.WatchAsync())
             {
                 if (notification.Resource == custom.Resource && notification.Snapshot.Urls.Length > 0)
                 {
@@ -615,8 +607,8 @@ public class WithUrlsTests(ITestOutputHelper testOutputHelper)
         });
 
         await app.StartAsync();
-        await rns.WaitForResourceAsync(custom.Resource.Name, KnownResourceStates.Running, cts.Token);
-        await watchTask;
+        await rns.WaitForResourceAsync(custom.Resource.Name, KnownResourceStates.Running).DefaultTimeout();
+        await watchTask.DefaultTimeout();
         await app.StopAsync().DefaultTimeout();
 
         // Log all captured snapshots for diagnostics
@@ -674,11 +666,9 @@ public class WithUrlsTests(ITestOutputHelper testOutputHelper)
         await app.StartAsync();
 
         // Wait for running state with multiple URLs
-        using var cts = AsyncTestHelpers.CreateDefaultTimeoutTokenSource();
         var resourceEvent = await rns.WaitForResourceAsync(
             "servicea",
-            e => e.Snapshot.State == KnownResourceStates.Running && e.Snapshot.Urls.Length > 1,
-            cts.Token);
+            e => e.Snapshot.State == KnownResourceStates.Running && e.Snapshot.Urls.Length > 1).DefaultTimeout();
 
         await app.StopAsync().DefaultTimeout();
 

--- a/tests/Aspire.Hosting.Tests/WithUrlsTests.cs
+++ b/tests/Aspire.Hosting.Tests/WithUrlsTests.cs
@@ -384,10 +384,7 @@ public class WithUrlsTests(ITestOutputHelper testOutputHelper)
         // Wait for the resource to have URLs allocated (before it starts running)
         var resourceEvent = await rns.WaitForResourceAsync(
             servicea.Resource.Name,
-            e => e.Snapshot.Urls.Length == 1
-                && e.Snapshot.Urls[0].Name == httpEndpoint.EndpointName
-                && e.Snapshot.Urls[0].IsInactive
-                && e.Snapshot.Urls[0].Url == "https://example.com").DefaultTimeout();
+            e => e.Snapshot.Urls.Length == 1).DefaultTimeout();
 
         await app.StopAsync().DefaultTimeout();
 
@@ -476,7 +473,7 @@ public class WithUrlsTests(ITestOutputHelper testOutputHelper)
 
         var watchTask = Task.Run(async () =>
         {
-            await foreach (var notification in rns.WatchAsync())
+            await foreach (var notification in rns.WatchAsync().DefaultTimeout())
             {
                 if (notification.Resource == servicea.Resource && notification.Snapshot.Urls.Length > 0)
                 {
@@ -592,7 +589,7 @@ public class WithUrlsTests(ITestOutputHelper testOutputHelper)
 
         var watchTask = Task.Run(async () =>
         {
-            await foreach (var notification in rns.WatchAsync())
+            await foreach (var notification in rns.WatchAsync().DefaultTimeout())
             {
                 if (notification.Resource == custom.Resource && notification.Snapshot.Urls.Length > 0)
                 {

--- a/tests/Aspire.Hosting.Tests/WithUrlsTests.cs
+++ b/tests/Aspire.Hosting.Tests/WithUrlsTests.cs
@@ -441,14 +441,18 @@ public class WithUrlsTests(ITestOutputHelper testOutputHelper)
 
         await app.StartAsync();
 
-        // Wait for the resource to be running
-        using var cts = AsyncTestHelpers.CreateDefaultTimeoutTokenSource();
+        // Wait for the resource to be running with its expected URLs. Running and URL
+        // activation are published through separate notification paths, and CI can observe
+        // the state transition before the URL snapshot catches up.
+        using var cts = AsyncTestHelpers.CreateDefaultTimeoutTokenSource(TestConstants.LongTimeoutDuration);
         var resourceEvent = await rns.WaitForResourceAsync(
             servicea.Resource.Name,
-            e => e.Snapshot.State == KnownResourceStates.Running,
+            e => e.Snapshot.State == KnownResourceStates.Running
+                && e.Snapshot.Urls.Length == 2
+                && e.Snapshot.Urls.All(url => !url.IsInactive),
             cts.Token);
 
-        await app.StopAsync().DefaultTimeout();
+        await app.StopAsync().DefaultTimeout(TestConstants.LongTimeoutTimeSpan);
 
         Assert.Equal(2, resourceEvent.Snapshot.Urls.Length);
         Assert.Collection(resourceEvent.Snapshot.Urls,

--- a/tests/Aspire.Hosting.Tests/WithUrlsTests.cs
+++ b/tests/Aspire.Hosting.Tests/WithUrlsTests.cs
@@ -444,15 +444,13 @@ public class WithUrlsTests(ITestOutputHelper testOutputHelper)
         // Wait for the resource to be running with its expected URLs. Running and URL
         // activation are published through separate notification paths, and CI can observe
         // the state transition before the URL snapshot catches up.
-        using var cts = AsyncTestHelpers.CreateDefaultTimeoutTokenSource(TestConstants.LongTimeoutDuration);
         var resourceEvent = await rns.WaitForResourceAsync(
             servicea.Resource.Name,
             e => e.Snapshot.State == KnownResourceStates.Running
                 && e.Snapshot.Urls.Length == 2
-                && e.Snapshot.Urls.All(url => !url.IsInactive),
-            cts.Token);
+                && e.Snapshot.Urls.All(url => !url.IsInactive)).DefaultTimeout();
 
-        await app.StopAsync().DefaultTimeout(TestConstants.LongTimeoutTimeSpan);
+        await app.StopAsync().DefaultTimeout();
 
         Assert.Equal(2, resourceEvent.Snapshot.Urls.Length);
         Assert.Collection(resourceEvent.Snapshot.Urls,

--- a/tests/Aspire.Hosting.Tests/WithUrlsTests.cs
+++ b/tests/Aspire.Hosting.Tests/WithUrlsTests.cs
@@ -384,7 +384,10 @@ public class WithUrlsTests(ITestOutputHelper testOutputHelper)
         // Wait for the resource to have URLs allocated (before it starts running)
         var resourceEvent = await rns.WaitForResourceAsync(
             servicea.Resource.Name,
-            e => e.Snapshot.Urls.Length > 0).DefaultTimeout();
+            e => e.Snapshot.Urls.Length == 1
+                && e.Snapshot.Urls[0].Name == httpEndpoint.EndpointName
+                && e.Snapshot.Urls[0].IsInactive
+                && e.Snapshot.Urls[0].Url == "https://example.com").DefaultTimeout();
 
         await app.StopAsync().DefaultTimeout();
 
@@ -409,7 +412,7 @@ public class WithUrlsTests(ITestOutputHelper testOutputHelper)
         // Wait for URLs to be populated
         var resourceEvent = await rns.WaitForResourceAsync(
             servicea.Resource.Name,
-            e => e.Snapshot.Urls.Length > 0).DefaultTimeout();
+            e => e.Snapshot.Urls.Length == 3).DefaultTimeout();
 
         await app.StopAsync().DefaultTimeout();
 
@@ -668,7 +671,7 @@ public class WithUrlsTests(ITestOutputHelper testOutputHelper)
         // Wait for running state with multiple URLs
         var resourceEvent = await rns.WaitForResourceAsync(
             "servicea",
-            e => e.Snapshot.State == KnownResourceStates.Running && e.Snapshot.Urls.Length > 1).DefaultTimeout();
+            e => e.Snapshot.State == KnownResourceStates.Running && e.Snapshot.Urls.Length == 4).DefaultTimeout();
 
         await app.StopAsync().DefaultTimeout();
 


### PR DESCRIPTION
## Description

Stabilizes `Aspire.Hosting.Tests.WithUrlsTests.ExpectedNumberOfUrlsForReplicatedResource` after a Windows CI failure in https://github.com/microsoft/aspire/actions/runs/25892284028.

The test previously waited only for the replicated project resource to enter `Running` before asserting its URL snapshot. Running state and URL activation are published through separate notification paths, so CI can observe the state transition before the URL snapshot has caught up. The test now waits for the resource to be running with the expected active URL set before asserting.

This also normalizes remaining `WithUrlsTests` resource waits to use `DefaultTimeout()` instead of creating cancellation token sources in the test body.

Validation:
- `dotnet build tests\Aspire.Hosting.Tests\Aspire.Hosting.Tests.csproj --no-restore -v:q`
- `dotnet test --project tests\Aspire.Hosting.Tests\Aspire.Hosting.Tests.csproj --no-build --no-launch-profile -- --filter-method "*.EndpointUrlsAreInitiallyInactive" --filter-method "*.MultipleUrlsForSingleEndpointAreIncludedInUrlSnapshot" --filter-method "*.ExpectedNumberOfUrlsForReplicatedResource" --filter-method "*.ProjectResourceUrlsTransitionThroughExpectedLifecycleStates" --filter-method "*.CustomResourceUrlsTransitionThroughExpectedLifecycleStates" --filter-method "*.UrlsAreMarkedAsInternalDependingOnDisplayLocation" --filter-not-trait "quarantined=true" --filter-not-trait "outerloop=true"`

Fixes # (issue)

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
