### PR TITLE
Handle canceled backchannel streams

### DIFF
--- a/src/Aspire.Cli/Backchannel/AppHostCliBackchannel.cs
+++ b/src/Aspire.Cli/Backchannel/AppHostCliBackchannel.cs
@@ -90,83 +90,79 @@ internal sealed class AppHostCliBackchannel(
         return state;
     }
 
-    public async IAsyncEnumerable<BackchannelLogEntry> GetAppHostLogEntriesAsync([EnumeratorCancellation] CancellationToken cancellationToken)
+    public IAsyncEnumerable<BackchannelLogEntry> GetAppHostLogEntriesAsync(CancellationToken cancellationToken)
+    {
+        return InvokeStreamingRpcAsync<BackchannelLogEntry>(
+            (rpc, ct) => rpc.InvokeStreamingWithProfilingAsync<BackchannelLogEntry>(
+                profilingTelemetry, "apphost", "GetAppHostLogEntriesAsync", [], ct),
+            "AppHost log entries",
+            cancellationToken);
+    }
+
+    public IAsyncEnumerable<RpcResourceState> GetResourceStatesAsync(CancellationToken cancellationToken)
+    {
+        return InvokeStreamingRpcAsync<RpcResourceState>(
+            (rpc, ct) => rpc.InvokeStreamingWithProfilingAsync<RpcResourceState>(
+                profilingTelemetry, "apphost", "GetResourceStatesAsync", [], ct),
+            "resource states",
+            cancellationToken);
+    }
+
+    /// <summary>
+    /// Invokes a streaming RPC method, handling reconnection when auto-reconnect is enabled.
+    /// </summary>
+    private async IAsyncEnumerable<T> InvokeStreamingRpcAsync<T>(
+        Func<JsonRpc, CancellationToken, Task<IAsyncEnumerable<T>>> startStream,
+        string operationName,
+        [EnumeratorCancellation] CancellationToken cancellationToken)
     {
         while (!cancellationToken.IsCancellationRequested)
         {
-            IAsyncEnumerable<BackchannelLogEntry>? logEntries = null;
+            IAsyncEnumerable<T>? items = null;
             try
             {
                 using var activity = telemetry.StartDiagnosticActivity();
                 var rpc = await GetRpcTaskAsync().WaitAsync(cancellationToken).ConfigureAwait(false);
 
-                logger.LogDebug("Requesting AppHost log entries");
+                logger.LogDebug("Requesting {OperationName}", operationName);
 
-                logEntries = await rpc.InvokeStreamingWithProfilingAsync<BackchannelLogEntry>(
-                    profilingTelemetry,
-                    "apphost",
-                    "GetAppHostLogEntriesAsync",
-                    [],
-                    cancellationToken).ConfigureAwait(false);
+                items = await startStream(rpc, cancellationToken).ConfigureAwait(false);
 
-                logger.LogDebug("Received AppHost log entries async enumerable");
+                logger.LogDebug("Received {OperationName} async enumerable", operationName);
             }
             catch (Exception ex) when (_autoReconnect && !cancellationToken.IsCancellationRequested && IsConnectionLostException(ex))
             {
-                logger.LogDebug("Connection lost while getting log entries, waiting for reconnect...");
+                logger.LogDebug("Connection lost while getting {OperationName}, waiting for reconnect...", operationName);
                 await WaitForReconnectionAsync(cancellationToken).ConfigureAwait(false);
                 continue;
             }
 
-            if (logEntries is not null)
+            var reportingEnumerable = new ReportingAsyncEnumerable<T>(items);
+            await foreach (var item in EnumerateWithReconnect(reportingEnumerable, cancellationToken))
             {
-                await foreach (var entry in EnumerateWithReconnect(logEntries, cancellationToken))
-                {
-                    yield return entry;
-                }
+                yield return item;
+            }
+
+            // If we exit the enumeration loop because of a connection loss, the reporting enumerable will indicate that we should retry.
+            // If not then the enumerable ended with no more data. We can exit the method.
+            if (!reportingEnumerable.RetryBecauseConnectionLost)
+            {
+                yield break;
             }
         }
     }
 
-    public async IAsyncEnumerable<RpcResourceState> GetResourceStatesAsync([EnumeratorCancellation] CancellationToken cancellationToken)
+    private sealed class ReportingAsyncEnumerable<T>(IAsyncEnumerable<T> source) : IAsyncEnumerable<T>
     {
-        while (!cancellationToken.IsCancellationRequested)
+        public bool RetryBecauseConnectionLost { get; set; }
+
+        public IAsyncEnumerator<T> GetAsyncEnumerator(CancellationToken cancellationToken = default)
         {
-            IAsyncEnumerable<RpcResourceState>? resourceStates = null;
-            try
-            {
-                using var activity = telemetry.StartDiagnosticActivity();
-                var rpc = await GetRpcTaskAsync().WaitAsync(cancellationToken).ConfigureAwait(false);
-
-                logger.LogDebug("Requesting resource states");
-
-                resourceStates = await rpc.InvokeStreamingWithProfilingAsync<RpcResourceState>(
-                    profilingTelemetry,
-                    "apphost",
-                    "GetResourceStatesAsync",
-                    [],
-                    cancellationToken).ConfigureAwait(false);
-
-                logger.LogDebug("Received resource states async enumerable");
-            }
-            catch (Exception ex) when (_autoReconnect && !cancellationToken.IsCancellationRequested && IsConnectionLostException(ex))
-            {
-                logger.LogDebug("Connection lost while getting resource states, waiting for reconnect...");
-                await WaitForReconnectionAsync(cancellationToken).ConfigureAwait(false);
-                continue;
-            }
-
-            if (resourceStates is not null)
-            {
-                await foreach (var state in EnumerateWithReconnect(resourceStates, cancellationToken))
-                {
-                    yield return state;
-                }
-            }
+            return source.GetAsyncEnumerator(cancellationToken);
         }
     }
 
-    private async IAsyncEnumerable<T> EnumerateWithReconnect<T>(IAsyncEnumerable<T> source, [EnumeratorCancellation] CancellationToken cancellationToken)
+    private async IAsyncEnumerable<T> EnumerateWithReconnect<T>(ReportingAsyncEnumerable<T> source, [EnumeratorCancellation] CancellationToken cancellationToken)
     {
         var enumerator = source.GetAsyncEnumerator(cancellationToken);
         try
@@ -186,6 +182,8 @@ internal sealed class AppHostCliBackchannel(
                 }
                 catch (Exception ex) when (_autoReconnect && !cancellationToken.IsCancellationRequested && IsConnectionLostException(ex))
                 {
+                    source.RetryBecauseConnectionLost = true;
+
                     logger.LogDebug("Connection lost during enumeration, will restart after reconnect");
                     yield break; // Exit this enumeration, outer loop will restart
                 }
@@ -428,31 +426,13 @@ internal sealed class AppHostCliBackchannel(
         logger.LogWarning("Timed out waiting for backchannel reconnection");
     }
 
-    public async IAsyncEnumerable<PublishingActivity> GetPublishingActivitiesAsync([EnumeratorCancellation] CancellationToken cancellationToken)
+    public IAsyncEnumerable<PublishingActivity> GetPublishingActivitiesAsync(CancellationToken cancellationToken)
     {
-        using var activity = telemetry.StartDiagnosticActivity();
-        var rpc = await GetRpcTaskAsync().WaitAsync(cancellationToken).ConfigureAwait(false);
-
-        logger.LogDebug("Requesting publishing activities.");
-
-        var publishingActivities = await rpc.InvokeStreamingWithProfilingAsync<PublishingActivity>(
-            profilingTelemetry,
-            "apphost",
-            "GetPublishingActivitiesAsync",
-            [],
-            cancellationToken).ConfigureAwait(false);
-
-        logger.LogDebug("Received publishing activities.");
-
-        if (publishingActivities is null)
-        {
-            yield break;
-        }
-
-        await foreach (var state in publishingActivities.WithCancellation(cancellationToken))
-        {
-            yield return state;
-        }
+        return InvokeStreamingRpcAsync<PublishingActivity>(
+            (rpc, ct) => rpc.InvokeStreamingWithProfilingAsync<PublishingActivity>(
+                profilingTelemetry, "apphost", "GetPublishingActivitiesAsync", [], ct),
+            "publishing activities",
+            cancellationToken);
     }
 
     public async Task<string[]> GetCapabilitiesAsync(CancellationToken cancellationToken)

--- a/src/Aspire.Cli/Backchannel/ProfilingJsonRpcExtensions.cs
+++ b/src/Aspire.Cli/Backchannel/ProfilingJsonRpcExtensions.cs
@@ -64,7 +64,7 @@ internal static class ProfilingJsonRpcExtensions
         }
     }
 
-    public static async Task<IAsyncEnumerable<T>?> InvokeStreamingWithProfilingAsync<T>(
+    public static async Task<IAsyncEnumerable<T>> InvokeStreamingWithProfilingAsync<T>(
         this JsonRpc rpc,
         ProfilingTelemetry? profilingTelemetry,
         string connectionName,
@@ -82,11 +82,6 @@ internal static class ProfilingJsonRpcExtensions
         {
             var response = await rpc.InvokeWithCancellationAsync<IAsyncEnumerable<T>>(methodName, arguments, cancellationToken).ConfigureAwait(false);
             activity.AddJsonRpcResponseReceivedEvent();
-            if (response is null)
-            {
-                activity.Dispose();
-                return null;
-            }
 
             return EnumerateWithProfiling(response, activity, cancellationToken);
         }

--- a/src/Aspire.Cli/Commands/RunCommand.cs
+++ b/src/Aspire.Cli/Commands/RunCommand.cs
@@ -134,6 +134,9 @@ internal sealed class RunCommand : BaseCommand
 
     protected override async Task<CommandResult> ExecuteAsync(ParseResult parseResult, CancellationToken cancellationToken)
     {
+        using var cts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+        var linkedToken = cts.Token;
+
         var passedAppHostProjectFile = parseResult.GetValue(AppHostLauncher.s_appHostOption);
         var detach = parseResult.GetValue(s_detachOption);
         _isDetachMode = detach;
@@ -165,7 +168,7 @@ internal sealed class RunCommand : BaseCommand
         // Handle detached mode - spawn child process and exit
         if (detach)
         {
-            return await ExecuteDetachedAsync(parseResult, passedAppHostProjectFile, isExtensionHost, cancellationToken);
+            return await ExecuteDetachedAsync(parseResult, passedAppHostProjectFile, isExtensionHost, linkedToken);
         }
 
         // A user may run `aspire run` in an Aspire terminal in VS Code. In this case, intercept and prompt
@@ -206,7 +209,7 @@ internal sealed class RunCommand : BaseCommand
                     passedAppHostProjectFile,
                     multipleAppHostBehavior,
                     createSettingsFile: true,
-                    cancellationToken);
+                    linkedToken);
             }
             var effectiveAppHostFile = searchResult.SelectedProjectFile;
 
@@ -232,7 +235,7 @@ internal sealed class RunCommand : BaseCommand
             RunningInstanceResult runningInstanceResult;
             using (var stopRunningInstanceActivity = _profilingTelemetry.StartRunAppHostStopExistingInstance())
             {
-                runningInstanceResult = await project.FindAndStopRunningInstanceAsync(effectiveAppHostFile, ExecutionContext.HomeDirectory, cancellationToken);
+                runningInstanceResult = await project.FindAndStopRunningInstanceAsync(effectiveAppHostFile, ExecutionContext.HomeDirectory, linkedToken);
                 stopRunningInstanceActivity.SetAppHostRunningInstanceResult(runningInstanceResult);
             }
 
@@ -269,14 +272,14 @@ internal sealed class RunCommand : BaseCommand
             Task<int> pendingRun;
             using (_profilingTelemetry.StartRunAppHostStartProject(project.LanguageId, noBuild, waitForDebugger))
             {
-                pendingRun = project.RunAsync(context, cancellationToken);
+                pendingRun = project.RunAsync(context, linkedToken);
             }
 
             // Wait for the build to complete first (project handles its own build status spinners)
             bool buildSuccess;
             using (var waitForBuildActivity = _profilingTelemetry.StartRunAppHostWaitForBuild())
             {
-                buildSuccess = await buildCompletionSource.Task.WaitAsync(cancellationToken);
+                buildSuccess = await buildCompletionSource.Task.WaitAsync(linkedToken);
                 waitForBuildActivity.SetAppHostBuildSuccess(buildSuccess);
             }
             if (!buildSuccess)
@@ -302,12 +305,12 @@ internal sealed class RunCommand : BaseCommand
             {
                 backchannel = await InteractionService.ShowStatusAsync(
                     RunCommandStrings.ConnectingToAppHost,
-                    async () => await backchannelCompletionSource.Task.WaitAsync(cancellationToken));
+                    async () => await backchannelCompletionSource.Task.WaitAsync(linkedToken));
                 waitForBackchannelActivity.SetAppHostBackchannelConnected(true);
             }
 
             // Set up log capture - writes to unified CLI log file
-            var pendingLogCapture = CaptureAppHostLogsAsync(_fileLoggerProvider, backchannel, _interactionService, cancellationToken);
+            var pendingLogCapture = CaptureAppHostLogsAsync(_fileLoggerProvider, backchannel, _interactionService, linkedToken);
 
             // Get dashboard URLs
             DashboardUrlsState dashboardUrls;
@@ -315,7 +318,7 @@ internal sealed class RunCommand : BaseCommand
             {
                 dashboardUrls = await InteractionService.ShowStatusAsync(
                     RunCommandStrings.StartingDashboard,
-                    async () => await backchannel.GetDashboardUrlsAsync(cancellationToken));
+                    async () => await backchannel.GetDashboardUrlsAsync(linkedToken));
                 getDashboardUrlsActivity.SetAppHostDashboardHealthy(dashboardUrls.DashboardHealthy);
             }
 
@@ -392,8 +395,8 @@ internal sealed class RunCommand : BaseCommand
                 {
                     await InteractionService.DisplayLiveAsync(BuildLiveRenderable(), async updateTarget =>
                     {
-                        var resourceStates = backchannel.GetResourceStatesAsync(cancellationToken);
-                        await foreach (var resourceState in resourceStates.WithCancellation(cancellationToken))
+                        var resourceStates = backchannel.GetResourceStatesAsync(linkedToken);
+                        await foreach (var resourceState in resourceStates.WithCancellation(linkedToken))
                         {
                             ProcessResourceState(resourceState, (resource, endpoint) =>
                             {
@@ -403,7 +406,7 @@ internal sealed class RunCommand : BaseCommand
                         }
                     });
                 }
-                catch (ConnectionLostException) when (cancellationToken.IsCancellationRequested)
+                catch (ConnectionLostException) when (linkedToken.IsCancellationRequested)
                 {
                     // Orderly shutdown
                 }
@@ -422,6 +425,14 @@ internal sealed class RunCommand : BaseCommand
             using (var lifetimeActivity = _profilingTelemetry.StartRunAppHostLifetime())
             {
                 runActivity?.Stop();
+
+                // Signal the backchannel when the app host process exits so streaming
+                // retry loops (e.g. log capture) stop instead of reconnecting endlessly.
+                _ = pendingRun.ContinueWith(_ =>
+                {
+                    //backchannel.NotifyAppHostExited();
+                    cts.Cancel();
+                }, TaskScheduler.Default);
 
                 try
                 {
@@ -442,7 +453,7 @@ internal sealed class RunCommand : BaseCommand
                     : CommandResult.FromExitCode(exitCode);
             }
         }
-        catch (OperationCanceledException ex) when (ex.CancellationToken == cancellationToken || ex is ExtensionOperationCanceledException)
+        catch (OperationCanceledException ex) when (ex.CancellationToken == linkedToken || ex is ExtensionOperationCanceledException)
         {
             runActivity?.SetTag(TelemetryConstants.Tags.ErrorType, "canceled");
 

--- a/src/Aspire.Cli/Commands/RunCommand.cs
+++ b/src/Aspire.Cli/Commands/RunCommand.cs
@@ -430,8 +430,15 @@ internal sealed class RunCommand : BaseCommand
                 // retry loops (e.g. log capture) stop instead of reconnecting endlessly.
                 _ = pendingRun.ContinueWith(_ =>
                 {
-                    //backchannel.NotifyAppHostExited();
-                    cts.Cancel();
+                    try
+                    {
+                        cts.Cancel();
+                    }
+                    catch (ObjectDisposedException)
+                    {
+                        // The CTS may already be disposed if pendingLogCapture completed
+                        // independently (e.g. connection lost) before this callback ran.
+                    }
                 }, TaskScheduler.Default);
 
                 try

--- a/src/Aspire.Cli/Commands/RunCommand.cs
+++ b/src/Aspire.Cli/Commands/RunCommand.cs
@@ -134,9 +134,6 @@ internal sealed class RunCommand : BaseCommand
 
     protected override async Task<CommandResult> ExecuteAsync(ParseResult parseResult, CancellationToken cancellationToken)
     {
-        using var cts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
-        var linkedToken = cts.Token;
-
         var passedAppHostProjectFile = parseResult.GetValue(AppHostLauncher.s_appHostOption);
         var detach = parseResult.GetValue(s_detachOption);
         _isDetachMode = detach;
@@ -168,7 +165,7 @@ internal sealed class RunCommand : BaseCommand
         // Handle detached mode - spawn child process and exit
         if (detach)
         {
-            return await ExecuteDetachedAsync(parseResult, passedAppHostProjectFile, isExtensionHost, linkedToken);
+            return await ExecuteDetachedAsync(parseResult, passedAppHostProjectFile, isExtensionHost, cancellationToken);
         }
 
         // A user may run `aspire run` in an Aspire terminal in VS Code. In this case, intercept and prompt
@@ -209,7 +206,7 @@ internal sealed class RunCommand : BaseCommand
                     passedAppHostProjectFile,
                     multipleAppHostBehavior,
                     createSettingsFile: true,
-                    linkedToken);
+                    cancellationToken);
             }
             var effectiveAppHostFile = searchResult.SelectedProjectFile;
 
@@ -235,7 +232,7 @@ internal sealed class RunCommand : BaseCommand
             RunningInstanceResult runningInstanceResult;
             using (var stopRunningInstanceActivity = _profilingTelemetry.StartRunAppHostStopExistingInstance())
             {
-                runningInstanceResult = await project.FindAndStopRunningInstanceAsync(effectiveAppHostFile, ExecutionContext.HomeDirectory, linkedToken);
+                runningInstanceResult = await project.FindAndStopRunningInstanceAsync(effectiveAppHostFile, ExecutionContext.HomeDirectory, cancellationToken);
                 stopRunningInstanceActivity.SetAppHostRunningInstanceResult(runningInstanceResult);
             }
 
@@ -272,14 +269,14 @@ internal sealed class RunCommand : BaseCommand
             Task<int> pendingRun;
             using (_profilingTelemetry.StartRunAppHostStartProject(project.LanguageId, noBuild, waitForDebugger))
             {
-                pendingRun = project.RunAsync(context, linkedToken);
+                pendingRun = project.RunAsync(context, cancellationToken);
             }
 
             // Wait for the build to complete first (project handles its own build status spinners)
             bool buildSuccess;
             using (var waitForBuildActivity = _profilingTelemetry.StartRunAppHostWaitForBuild())
             {
-                buildSuccess = await buildCompletionSource.Task.WaitAsync(linkedToken);
+                buildSuccess = await buildCompletionSource.Task.WaitAsync(cancellationToken);
                 waitForBuildActivity.SetAppHostBuildSuccess(buildSuccess);
             }
             if (!buildSuccess)
@@ -305,12 +302,12 @@ internal sealed class RunCommand : BaseCommand
             {
                 backchannel = await InteractionService.ShowStatusAsync(
                     RunCommandStrings.ConnectingToAppHost,
-                    async () => await backchannelCompletionSource.Task.WaitAsync(linkedToken));
+                    async () => await backchannelCompletionSource.Task.WaitAsync(cancellationToken));
                 waitForBackchannelActivity.SetAppHostBackchannelConnected(true);
             }
 
             // Set up log capture - writes to unified CLI log file
-            var pendingLogCapture = CaptureAppHostLogsAsync(_fileLoggerProvider, backchannel, _interactionService, linkedToken);
+            var pendingLogCapture = CaptureAppHostLogsAsync(_fileLoggerProvider, backchannel, _interactionService, cancellationToken);
 
             // Get dashboard URLs
             DashboardUrlsState dashboardUrls;
@@ -318,7 +315,7 @@ internal sealed class RunCommand : BaseCommand
             {
                 dashboardUrls = await InteractionService.ShowStatusAsync(
                     RunCommandStrings.StartingDashboard,
-                    async () => await backchannel.GetDashboardUrlsAsync(linkedToken));
+                    async () => await backchannel.GetDashboardUrlsAsync(cancellationToken));
                 getDashboardUrlsActivity.SetAppHostDashboardHealthy(dashboardUrls.DashboardHealthy);
             }
 
@@ -395,8 +392,8 @@ internal sealed class RunCommand : BaseCommand
                 {
                     await InteractionService.DisplayLiveAsync(BuildLiveRenderable(), async updateTarget =>
                     {
-                        var resourceStates = backchannel.GetResourceStatesAsync(linkedToken);
-                        await foreach (var resourceState in resourceStates.WithCancellation(linkedToken))
+                        var resourceStates = backchannel.GetResourceStatesAsync(cancellationToken);
+                        await foreach (var resourceState in resourceStates.WithCancellation(cancellationToken))
                         {
                             ProcessResourceState(resourceState, (resource, endpoint) =>
                             {
@@ -406,7 +403,7 @@ internal sealed class RunCommand : BaseCommand
                         }
                     });
                 }
-                catch (ConnectionLostException) when (linkedToken.IsCancellationRequested)
+                catch (ConnectionLostException) when (cancellationToken.IsCancellationRequested)
                 {
                     // Orderly shutdown
                 }
@@ -426,29 +423,14 @@ internal sealed class RunCommand : BaseCommand
             {
                 runActivity?.Stop();
 
-                // Signal the backchannel when the app host process exits so streaming
-                // retry loops (e.g. log capture) stop instead of reconnecting endlessly.
-                _ = pendingRun.ContinueWith(_ =>
-                {
-                    try
-                    {
-                        cts.Cancel();
-                    }
-                    catch (ObjectDisposedException)
-                    {
-                        // The CTS may already be disposed if pendingLogCapture completed
-                        // independently (e.g. connection lost) before this callback ran.
-                    }
-                }, TaskScheduler.Default);
-
                 try
                 {
                     await pendingLogCapture;
                 }
                 catch (Exception ex)
                 {
-                    InteractionService.DisplayError("Error capturing logs from AppHost.");
-                    _logger.LogError(ex, "Error capturing logs from AppHost.");
+                    _logger.LogWarning(ex, "Failed to capture logs from AppHost");
+                    InteractionService.DisplayMessage(KnownEmojis.Warning, "No longer receiving logs from AppHost.");
                 }
 
                 var exitCode = await pendingRun;
@@ -460,7 +442,7 @@ internal sealed class RunCommand : BaseCommand
                     : CommandResult.FromExitCode(exitCode);
             }
         }
-        catch (OperationCanceledException ex) when (ex.CancellationToken == linkedToken || ex is ExtensionOperationCanceledException)
+        catch (OperationCanceledException ex) when (ex.CancellationToken == cancellationToken || ex is ExtensionOperationCanceledException)
         {
             runActivity?.SetTag(TelemetryConstants.Tags.ErrorType, "canceled");
 

--- a/src/Aspire.Cli/Commands/RunCommand.cs
+++ b/src/Aspire.Cli/Commands/RunCommand.cs
@@ -422,7 +422,17 @@ internal sealed class RunCommand : BaseCommand
             using (var lifetimeActivity = _profilingTelemetry.StartRunAppHostLifetime())
             {
                 runActivity?.Stop();
-                await pendingLogCapture;
+
+                try
+                {
+                    await pendingLogCapture;
+                }
+                catch (Exception ex)
+                {
+                    InteractionService.DisplayError("Error capturing logs from AppHost.");
+                    _logger.LogError(ex, "Error capturing logs from AppHost.");
+                }
+
                 var exitCode = await pendingRun;
                 lifetimeActivity.SetProcessExitCode(exitCode);
 

--- a/src/Aspire.Hosting/Backchannel/AppHostRpcTarget.cs
+++ b/src/Aspire.Hosting/Backchannel/AppHostRpcTarget.cs
@@ -25,9 +25,11 @@ internal class AppHostRpcTarget(
 
     public async IAsyncEnumerable<BackchannelLogEntry> GetAppHostLogEntriesAsync([EnumeratorCancellation] CancellationToken cancellationToken)
     {
-        // Cancel immediately if shutdown has already been requested.
-        // Throw error rather than exiting to avoid clients retrying call.
-        _shutdownCts.Token.ThrowIfCancellationRequested();
+        // Complete the stream immediately if shutdown has already been requested.
+        if (_shutdownCts.IsCancellationRequested)
+        {
+            yield break;
+        }
 
         // Create a linked token source that will be cancelled when shutdown is requested
         using var linkedCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken, _shutdownCts.Token);
@@ -65,9 +67,11 @@ internal class AppHostRpcTarget(
 
     public async IAsyncEnumerable<PublishingActivity> GetPublishingActivitiesAsync([EnumeratorCancellation] CancellationToken cancellationToken)
     {
-        // Cancel immediately if shutdown has already been requested.
-        // Throw error rather than exiting to avoid clients retrying call.
-        _shutdownCts.Token.ThrowIfCancellationRequested();
+        // Complete the stream immediately if shutdown has already been requested.
+        if (_shutdownCts.IsCancellationRequested)
+        {
+            yield break;
+        }
 
         // Create a linked token source that will be cancelled when shutdown is requested
         using var linkedCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken, _shutdownCts.Token);
@@ -100,9 +104,11 @@ internal class AppHostRpcTarget(
 
     public async IAsyncEnumerable<RpcResourceState> GetResourceStatesAsync([EnumeratorCancellation] CancellationToken cancellationToken)
     {
-        // Cancel immediately if shutdown has already been requested.
-        // Throw error rather than exiting to avoid clients retrying call.
-        _shutdownCts.Token.ThrowIfCancellationRequested();
+        // Complete the stream immediately if shutdown has already been requested.
+        if (_shutdownCts.IsCancellationRequested)
+        {
+            yield break;
+        }
 
         // Create a linked token source that will be cancelled when shutdown is requested
         using var linkedCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken, _shutdownCts.Token);

--- a/src/Aspire.Hosting/Backchannel/AppHostRpcTarget.cs
+++ b/src/Aspire.Hosting/Backchannel/AppHostRpcTarget.cs
@@ -29,6 +29,13 @@ internal class AppHostRpcTarget(
         using var linkedCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken, _shutdownCts.Token);
         var linkedToken = linkedCts.Token;
 
+        // If cancellation was already requested, exit immediately to avoid subscribing to log events unnecessarily.
+        // This can happen if the app host is shutting down.
+        if (linkedToken.IsCancellationRequested)
+        {
+            yield break;
+        }
+
         var loggerProvider = serviceProvider.GetService<BackchannelLoggerProvider>();
         if (loggerProvider is null)
         {
@@ -65,10 +72,17 @@ internal class AppHostRpcTarget(
         using var linkedCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken, _shutdownCts.Token);
         var linkedToken = linkedCts.Token;
 
+        // If cancellation was already requested, exit immediately to avoid subscribing to log events unnecessarily.
+        // This can happen if the app host is shutting down.
+        if (linkedToken.IsCancellationRequested)
+        {
+            yield break;
+        }
+
         while (!linkedToken.IsCancellationRequested)
         {
             PublishingActivity? publishingActivity = null;
-            
+
             try
             {
                 publishingActivity = await activityReporter.ActivityItemUpdated.Reader.ReadAsync(linkedToken).ConfigureAwait(false);
@@ -95,6 +109,13 @@ internal class AppHostRpcTarget(
         // Create a linked token source that will be cancelled when shutdown is requested
         using var linkedCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken, _shutdownCts.Token);
         var linkedToken = linkedCts.Token;
+
+        // If cancellation was already requested, exit immediately to avoid subscribing to log events unnecessarily.
+        // This can happen if the app host is shutting down.
+        if (linkedToken.IsCancellationRequested)
+        {
+            yield break;
+        }
 
         var resourceEvents = resourceNotificationService.WatchAsync(linkedToken);
 
@@ -136,10 +157,10 @@ internal class AppHostRpcTarget(
     public Task RequestStopAsync(CancellationToken cancellationToken)
     {
         _ = cancellationToken;
-        
+
         // Cancel inflight streaming RPC calls before stopping the application
         _shutdownCts.Cancel();
-        
+
         lifetime.StopApplication();
         return Task.CompletedTask;
     }

--- a/src/Aspire.Hosting/Backchannel/AppHostRpcTarget.cs
+++ b/src/Aspire.Hosting/Backchannel/AppHostRpcTarget.cs
@@ -25,16 +25,13 @@ internal class AppHostRpcTarget(
 
     public async IAsyncEnumerable<BackchannelLogEntry> GetAppHostLogEntriesAsync([EnumeratorCancellation] CancellationToken cancellationToken)
     {
+        // Cancel immediately if shutdown has already been requested.
+        // Throw error rather than exiting to avoid clients retrying call.
+        _shutdownCts.Token.ThrowIfCancellationRequested();
+
         // Create a linked token source that will be cancelled when shutdown is requested
         using var linkedCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken, _shutdownCts.Token);
         var linkedToken = linkedCts.Token;
-
-        // If cancellation was already requested, exit immediately to avoid subscribing to log events unnecessarily.
-        // This can happen if the app host is shutting down.
-        if (linkedToken.IsCancellationRequested)
-        {
-            yield break;
-        }
 
         var loggerProvider = serviceProvider.GetService<BackchannelLoggerProvider>();
         if (loggerProvider is null)
@@ -68,16 +65,13 @@ internal class AppHostRpcTarget(
 
     public async IAsyncEnumerable<PublishingActivity> GetPublishingActivitiesAsync([EnumeratorCancellation] CancellationToken cancellationToken)
     {
+        // Cancel immediately if shutdown has already been requested.
+        // Throw error rather than exiting to avoid clients retrying call.
+        _shutdownCts.Token.ThrowIfCancellationRequested();
+
         // Create a linked token source that will be cancelled when shutdown is requested
         using var linkedCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken, _shutdownCts.Token);
         var linkedToken = linkedCts.Token;
-
-        // If cancellation was already requested, exit immediately to avoid subscribing to log events unnecessarily.
-        // This can happen if the app host is shutting down.
-        if (linkedToken.IsCancellationRequested)
-        {
-            yield break;
-        }
 
         while (!linkedToken.IsCancellationRequested)
         {
@@ -106,16 +100,13 @@ internal class AppHostRpcTarget(
 
     public async IAsyncEnumerable<RpcResourceState> GetResourceStatesAsync([EnumeratorCancellation] CancellationToken cancellationToken)
     {
+        // Cancel immediately if shutdown has already been requested.
+        // Throw error rather than exiting to avoid clients retrying call.
+        _shutdownCts.Token.ThrowIfCancellationRequested();
+
         // Create a linked token source that will be cancelled when shutdown is requested
         using var linkedCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken, _shutdownCts.Token);
         var linkedToken = linkedCts.Token;
-
-        // If cancellation was already requested, exit immediately to avoid subscribing to log events unnecessarily.
-        // This can happen if the app host is shutting down.
-        if (linkedToken.IsCancellationRequested)
-        {
-            yield break;
-        }
 
         var resourceEvents = resourceNotificationService.WatchAsync(linkedToken);
 
@@ -123,7 +114,7 @@ internal class AppHostRpcTarget(
         // since yield return cannot appear in a try/catch block.
         await foreach (var resourceEvent in AsyncEnumerableUtils.ReadUntilCancelledAsync(resourceEvents, linkedToken).ConfigureAwait(false))
         {
-            if (resourceEvent.Resource.Name == "aspire-dashboard")
+            if (string.Equals(resourceEvent.Resource.Name, KnownResourceNames.AspireDashboard, StringComparisons.ResourceName))
             {
                 // Skip the dashboard resource, as it is handled separately.
                 continue;


### PR DESCRIPTION
## Description

Backchannel streaming RPC methods can be called while the app host is shutting down. This change exits immediately when the linked cancellation token has already been canceled so those streams avoid subscribing to log, publishing activity, or resource state notifications unnecessarily during shutdown.

Fixes https://github.com/microsoft/aspire/issues/16732

Validation: Not run (packaged the existing staged change into a branch and PR).

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [x] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
