### PR TITLE
Skip CLI self-update download when archive checksum matches installed binary

### DIFF
--- a/src/Aspire.Cli/Commands/UpdateCommand.cs
+++ b/src/Aspire.Cli/Commands/UpdateCommand.cs
@@ -359,7 +359,6 @@ internal sealed class UpdateCommand : BaseCommand
             // binary already matches the latest published build for the channel. The
             // marker file lives next to the installed binary and records the SHA-512
             // of the archive that was extracted to produce it. See issue #16730.
-            string? remoteChecksum = null;
             if (!force)
             {
                 var markerPath = TryGetChecksumMarkerPath(currentExePath);
@@ -367,15 +366,15 @@ internal sealed class UpdateCommand : BaseCommand
                 {
                     try
                     {
-                        remoteChecksum = await _cliDownloader!.GetLatestChecksumAsync(channel, cancellationToken);
-                        var localChecksum = NormalizeChecksumValue(await File.ReadAllTextAsync(markerPath, cancellationToken));
+                        var remoteChecksum = await _cliDownloader!.GetLatestChecksumAsync(channel, cancellationToken);
+                        var localChecksum = CliDownloader.NormalizeChecksum(await File.ReadAllTextAsync(markerPath, cancellationToken));
 
                         if (string.Equals(remoteChecksum, localChecksum, StringComparison.Ordinal))
                         {
                             var version = VersionHelper.GetDefaultSdkVersion();
                             var message = string.Format(CultureInfo.CurrentCulture, UpdateCommandStrings.AlreadyUpToDateMessageFormat, version);
                             InteractionService.DisplaySuccess(message);
-                            return ExitCodeConstants.Success;
+                            return CommandResult.Success();
                         }
 
                         _logger.LogDebug(
@@ -393,7 +392,6 @@ internal sealed class UpdateCommand : BaseCommand
                         // marker, etc.) fall through to the normal download path. We
                         // never want a probe failure to block an explicit update.
                         _logger.LogDebug(ex, "Failed to probe published checksum; falling back to full download.");
-                        remoteChecksum = null;
                     }
                 }
             }
@@ -401,9 +399,11 @@ internal sealed class UpdateCommand : BaseCommand
             // Download the latest CLI
             var archivePath = await _cliDownloader!.DownloadLatestCliAsync(channel, cancellationToken);
 
-            // Capture the checksum we already fetched (if any) so we can write the
-            // marker after a successful install without recomputing it.
-            await ExtractAndUpdateAsync(archivePath, remoteChecksum, cancellationToken);
+            // Always compute the marker checksum from the archive on disk rather
+            // than reusing the probe value: the publisher could have rolled out
+            // a new build between our probe and the download, in which case the
+            // probed value no longer corresponds to the bytes we just installed.
+            await ExtractAndUpdateAsync(archivePath, cancellationToken);
 
             return CommandResult.Success();
         }
@@ -427,29 +427,7 @@ internal sealed class UpdateCommand : BaseCommand
         return string.IsNullOrEmpty(installDir) ? null : Path.Combine(installDir, ChecksumMarkerFileName);
     }
 
-    private static string NormalizeChecksumValue(string raw)
-    {
-        // Mirror CliDownloader.NormalizeChecksum: trim, take leading hex token,
-        // lowercase. Kept private to avoid coupling UpdateCommand to the
-        // downloader's internal helper.
-        var trimmed = raw.Trim();
-        var firstWhitespace = -1;
-        for (var i = 0; i < trimmed.Length; i++)
-        {
-            if (char.IsWhiteSpace(trimmed[i]))
-            {
-                firstWhitespace = i;
-                break;
-            }
-        }
-        if (firstWhitespace > 0)
-        {
-            trimmed = trimmed.Substring(0, firstWhitespace);
-        }
-        return trimmed.ToLowerInvariant();
-    }
-
-    private async Task ExtractAndUpdateAsync(string archivePath, string? archiveChecksum, CancellationToken cancellationToken)
+    private async Task ExtractAndUpdateAsync(string archivePath, CancellationToken cancellationToken)
     {
         // Install to the same directory as the current CLI executable
         var currentExePath = DotNetToolDetection.GetEffectiveProcessPath();
@@ -533,13 +511,13 @@ internal sealed class UpdateCommand : BaseCommand
                 // published archive matches what we just installed (issue #16730).
                 // Written only after version verification succeeds, so a failed
                 // install can never leave behind a marker that misrepresents the
-                // installed binary. If we don't have a checksum (e.g. the probe
-                // failed before download), compute one from the archive on disk
-                // so future runs can still benefit from the no-op short-circuit.
+                // installed binary. Computed from the archive on disk so the
+                // value always corresponds to the bytes we actually installed,
+                // even if the publisher rolled out a new build between our
+                // earlier checksum probe and this download.
                 try
                 {
-                    var checksumToPersist = archiveChecksum
-                        ?? await ComputeArchiveChecksumAsync(archivePath, cancellationToken);
+                    var checksumToPersist = await ComputeArchiveChecksumAsync(archivePath, cancellationToken);
                     var markerPath = Path.Combine(installDir, ChecksumMarkerFileName);
                     await WriteMarkerAtomicallyAsync(markerPath, checksumToPersist, cancellationToken);
                 }

--- a/src/Aspire.Cli/Commands/UpdateCommand.cs
+++ b/src/Aspire.Cli/Commands/UpdateCommand.cs
@@ -5,6 +5,7 @@ using System.CommandLine;
 using System.Diagnostics;
 using System.Globalization;
 using System.Runtime.InteropServices;
+using System.Security.Cryptography;
 using Aspire.Cli.Configuration;
 using Aspire.Cli.Exceptions;
 using Aspire.Cli.Interaction;
@@ -47,6 +48,11 @@ internal sealed class UpdateCommand : BaseCommand
     {
         Description = UpdateCommandStrings.NuGetConfigDirOptionDescription
     };
+    private static readonly Option<bool> s_forceOption = new("--force")
+    {
+        Description = UpdateCommandStrings.ForceOptionDescription,
+        Aliases = { "-f" }
+    };
     private readonly Option<string?> _channelOption;
     private readonly Option<string?> _qualityOption;
 
@@ -79,6 +85,7 @@ internal sealed class UpdateCommand : BaseCommand
         Options.Add(s_selfOption);
         Options.Add(s_yesOption);
         Options.Add(s_nugetConfigDirOption);
+        Options.Add(s_forceOption);
 
         AddNonInteractiveRequiresYesValidator(this, s_yesOption);
 
@@ -315,6 +322,7 @@ internal sealed class UpdateCommand : BaseCommand
     private async Task<CommandResult> ExecuteSelfUpdateAsync(ParseResult parseResult, CancellationToken cancellationToken, string? selectedChannel = null)
     {
         var channel = selectedChannel ?? parseResult.GetValue(_channelOption) ?? parseResult.GetValue(_qualityOption);
+        var force = parseResult.GetValue(s_forceOption);
 
         // If channel is not specified, prompt the user to select one. The choice
         // applies only to this self-update invocation; subsequent 'aspire new'
@@ -338,7 +346,7 @@ internal sealed class UpdateCommand : BaseCommand
         try
         {
             // Get current executable path for display purposes only
-            var currentExePath = Environment.ProcessPath;
+            var currentExePath = DotNetToolDetection.GetEffectiveProcessPath();
             if (string.IsNullOrEmpty(currentExePath))
             {
                 return CommandResult.Failure(ExitCodeConstants.InvalidCommand, "Unable to determine the current executable path.");
@@ -347,11 +355,55 @@ internal sealed class UpdateCommand : BaseCommand
             InteractionService.DisplayMessage(KnownEmojis.Package, $"Current CLI location: {currentExePath}");
             InteractionService.DisplayMessage(KnownEmojis.UpButton, $"Updating to channel: {channel}");
 
+            // Probe the published checksum so we can short-circuit when the installed
+            // binary already matches the latest published build for the channel. The
+            // marker file lives next to the installed binary and records the SHA-512
+            // of the archive that was extracted to produce it. See issue #16730.
+            string? remoteChecksum = null;
+            if (!force)
+            {
+                var markerPath = TryGetChecksumMarkerPath(currentExePath);
+                if (markerPath is not null && File.Exists(markerPath))
+                {
+                    try
+                    {
+                        remoteChecksum = await _cliDownloader!.GetLatestChecksumAsync(channel, cancellationToken);
+                        var localChecksum = NormalizeChecksumValue(await File.ReadAllTextAsync(markerPath, cancellationToken));
+
+                        if (string.Equals(remoteChecksum, localChecksum, StringComparison.Ordinal))
+                        {
+                            var version = VersionHelper.GetDefaultSdkVersion();
+                            var message = string.Format(CultureInfo.CurrentCulture, UpdateCommandStrings.AlreadyUpToDateMessageFormat, version);
+                            InteractionService.DisplaySuccess(message);
+                            return ExitCodeConstants.Success;
+                        }
+
+                        _logger.LogDebug(
+                            "Installed CLI checksum {LocalChecksum} differs from latest published checksum {RemoteChecksum}; proceeding with update.",
+                            localChecksum,
+                            remoteChecksum);
+                    }
+                    catch (OperationCanceledException)
+                    {
+                        throw;
+                    }
+                    catch (Exception ex)
+                    {
+                        // If the probe fails for any reason (network error, malformed
+                        // marker, etc.) fall through to the normal download path. We
+                        // never want a probe failure to block an explicit update.
+                        _logger.LogDebug(ex, "Failed to probe published checksum; falling back to full download.");
+                        remoteChecksum = null;
+                    }
+                }
+            }
+
             // Download the latest CLI
             var archivePath = await _cliDownloader!.DownloadLatestCliAsync(channel, cancellationToken);
 
-            // Extract and update to $HOME/.aspire/bin
-            await ExtractAndUpdateAsync(archivePath, cancellationToken);
+            // Capture the checksum we already fetched (if any) so we can write the
+            // marker after a successful install without recomputing it.
+            await ExtractAndUpdateAsync(archivePath, remoteChecksum, cancellationToken);
 
             return CommandResult.Success();
         }
@@ -367,10 +419,40 @@ internal sealed class UpdateCommand : BaseCommand
         }
     }
 
-    private async Task ExtractAndUpdateAsync(string archivePath, CancellationToken cancellationToken)
+    internal const string ChecksumMarkerFileName = "aspire.sha512";
+
+    private static string? TryGetChecksumMarkerPath(string currentExePath)
+    {
+        var installDir = Path.GetDirectoryName(currentExePath);
+        return string.IsNullOrEmpty(installDir) ? null : Path.Combine(installDir, ChecksumMarkerFileName);
+    }
+
+    private static string NormalizeChecksumValue(string raw)
+    {
+        // Mirror CliDownloader.NormalizeChecksum: trim, take leading hex token,
+        // lowercase. Kept private to avoid coupling UpdateCommand to the
+        // downloader's internal helper.
+        var trimmed = raw.Trim();
+        var firstWhitespace = -1;
+        for (var i = 0; i < trimmed.Length; i++)
+        {
+            if (char.IsWhiteSpace(trimmed[i]))
+            {
+                firstWhitespace = i;
+                break;
+            }
+        }
+        if (firstWhitespace > 0)
+        {
+            trimmed = trimmed.Substring(0, firstWhitespace);
+        }
+        return trimmed.ToLowerInvariant();
+    }
+
+    private async Task ExtractAndUpdateAsync(string archivePath, string? archiveChecksum, CancellationToken cancellationToken)
     {
         // Install to the same directory as the current CLI executable
-        var currentExePath = Environment.ProcessPath;
+        var currentExePath = DotNetToolDetection.GetEffectiveProcessPath();
         if (string.IsNullOrEmpty(currentExePath))
         {
             throw new InvalidOperationException("Unable to determine current CLI location.");
@@ -445,6 +527,26 @@ internal sealed class UpdateCommand : BaseCommand
 
                 // If we get here, the update was successful, clean up old backups
                 FileDeleteHelper.TryCleanupOldItems(exeDir, exeName);
+
+                // Persist the archive checksum next to the installed binary so a
+                // subsequent `aspire update --self` can short-circuit when the
+                // published archive matches what we just installed (issue #16730).
+                // Written only after version verification succeeds, so a failed
+                // install can never leave behind a marker that misrepresents the
+                // installed binary. If we don't have a checksum (e.g. the probe
+                // failed before download), compute one from the archive on disk
+                // so future runs can still benefit from the no-op short-circuit.
+                try
+                {
+                    var checksumToPersist = archiveChecksum
+                        ?? await ComputeArchiveChecksumAsync(archivePath, cancellationToken);
+                    var markerPath = Path.Combine(installDir, ChecksumMarkerFileName);
+                    await WriteMarkerAtomicallyAsync(markerPath, checksumToPersist, cancellationToken);
+                }
+                catch (Exception ex)
+                {
+                    _logger.LogWarning(ex, "Failed to write CLI checksum marker; future updates will re-download.");
+                }
 
                 // The new binary will extract its embedded bundle on first run via EnsureExtractedAsync.
                 // No proactive extraction needed — the payload is inside the new binary's embedded resources,
@@ -569,5 +671,26 @@ internal sealed class UpdateCommand : BaseCommand
         {
             _logger.LogWarning(ex, "Failed to clean up directory {Directory}", directory);
         }
+    }
+
+    private static async Task<string> ComputeArchiveChecksumAsync(string archivePath, CancellationToken cancellationToken)
+    {
+        // Mirrors CliDownloader.ValidateChecksumAsync: the published .sha512
+        // companion files use SHA-512 over the archive bytes, so the marker
+        // we persist must use the same algorithm to compare cleanly.
+        using var sha512 = SHA512.Create();
+        await using var fileStream = new FileStream(archivePath, FileMode.Open, FileAccess.Read, FileShare.Read);
+        var hashBytes = await sha512.ComputeHashAsync(fileStream, cancellationToken);
+        return Convert.ToHexString(hashBytes).ToLowerInvariant();
+    }
+
+    private static async Task WriteMarkerAtomicallyAsync(string markerPath, string checksum, CancellationToken cancellationToken)
+    {
+        // Write to a sibling temp file then atomically swap into place so a
+        // crash mid-write can't leave a half-written marker that would cause
+        // false "already up to date" results on the next run.
+        var tempPath = $"{markerPath}.tmp.{Guid.NewGuid():N}";
+        await File.WriteAllTextAsync(tempPath, checksum, cancellationToken);
+        File.Move(tempPath, markerPath, overwrite: true);
     }
 }

--- a/src/Aspire.Cli/Resources/UpdateCommandStrings.Designer.cs
+++ b/src/Aspire.Cli/Resources/UpdateCommandStrings.Designer.cs
@@ -119,5 +119,8 @@ namespace Aspire.Cli.Resources {
     internal static string SelfOptionDescription => ResourceManager.GetString("SelfOptionDescription", resourceCulture);
     internal static string YesOptionDescription => ResourceManager.GetString("YesOptionDescription", resourceCulture);
     internal static string NuGetConfigDirOptionDescription => ResourceManager.GetString("NuGetConfigDirOptionDescription", resourceCulture);
+    internal static string ForceOptionDescription => ResourceManager.GetString("ForceOptionDescription", resourceCulture);
+    internal static string AlreadyUpToDateMessage => ResourceManager.GetString("AlreadyUpToDateMessage", resourceCulture);
+    internal static string AlreadyUpToDateMessageFormat => ResourceManager.GetString("AlreadyUpToDateMessageFormat", resourceCulture);
     }
 }

--- a/src/Aspire.Cli/Resources/UpdateCommandStrings.resx
+++ b/src/Aspire.Cli/Resources/UpdateCommandStrings.resx
@@ -174,4 +174,13 @@
   <data name="NuGetConfigDirOptionDescription" xml:space="preserve">
     <value>Directory to create or update the NuGet.config file in</value>
   </data>
+  <data name="ForceOptionDescription" xml:space="preserve">
+    <value>Force the self-update to download and install even if the installed CLI already matches the latest published build</value>
+  </data>
+  <data name="AlreadyUpToDateMessage" xml:space="preserve">
+    <value>Aspire CLI is already up to date.</value>
+  </data>
+  <data name="AlreadyUpToDateMessageFormat" xml:space="preserve">
+    <value>Aspire CLI is already up to date (version {0}).</value>
+  </data>
 </root>

--- a/src/Aspire.Cli/Resources/xlf/UpdateCommandStrings.cs.xlf
+++ b/src/Aspire.Cli/Resources/xlf/UpdateCommandStrings.cs.xlf
@@ -7,6 +7,16 @@
         <target state="translated">Přidáno: {0}</target>
         <note />
       </trans-unit>
+      <trans-unit id="AlreadyUpToDateMessage">
+        <source>Aspire CLI is already up to date.</source>
+        <target state="new">Aspire CLI is already up to date.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AlreadyUpToDateMessageFormat">
+        <source>Aspire CLI is already up to date (version {0}).</source>
+        <target state="new">Aspire CLI is already up to date (version {0}).</target>
+        <note />
+      </trans-unit>
       <trans-unit id="AnalyzeAppHost">
         <source>Analyze AppHost</source>
         <target state="needs-review-translation">Analyzovat hostitele aplikací</target>
@@ -115,6 +125,11 @@
       <trans-unit id="FallbackParsingWarning">
         <source>Note: Update plan generated using fallback parsing due to unresolvable AppHost SDK. Dependency analysis may have reduced accuracy.</source>
         <target state="needs-review-translation">Poznámka: Plán aktualizace byl vygenerován pomocí náhradní analýzy kvůli nevyřešitelné sadě AppHost SDK. Analýza závislostí může mít sníženou přesnost.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ForceOptionDescription">
+        <source>Force the self-update to download and install even if the installed CLI already matches the latest published build</source>
+        <target state="new">Force the self-update to download and install even if the installed CLI already matches the latest published build</target>
         <note />
       </trans-unit>
       <trans-unit id="MappingAddedFormat">

--- a/src/Aspire.Cli/Resources/xlf/UpdateCommandStrings.de.xlf
+++ b/src/Aspire.Cli/Resources/xlf/UpdateCommandStrings.de.xlf
@@ -7,6 +7,16 @@
         <target state="translated">Hinzugefügt: {0}</target>
         <note />
       </trans-unit>
+      <trans-unit id="AlreadyUpToDateMessage">
+        <source>Aspire CLI is already up to date.</source>
+        <target state="new">Aspire CLI is already up to date.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AlreadyUpToDateMessageFormat">
+        <source>Aspire CLI is already up to date (version {0}).</source>
+        <target state="new">Aspire CLI is already up to date (version {0}).</target>
+        <note />
+      </trans-unit>
       <trans-unit id="AnalyzeAppHost">
         <source>Analyze AppHost</source>
         <target state="needs-review-translation">App-Host analysieren</target>
@@ -115,6 +125,11 @@
       <trans-unit id="FallbackParsingWarning">
         <source>Note: Update plan generated using fallback parsing due to unresolvable AppHost SDK. Dependency analysis may have reduced accuracy.</source>
         <target state="needs-review-translation">Hinweis: Aktualisieren Sie den Plan, der mithilfe der Fallbackanalyse generiert wurde, da das AppHost-SDK nicht auflösbar ist. Die Abhängigkeitsanalyse weist möglicherweise eine geringere Genauigkeit auf.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ForceOptionDescription">
+        <source>Force the self-update to download and install even if the installed CLI already matches the latest published build</source>
+        <target state="new">Force the self-update to download and install even if the installed CLI already matches the latest published build</target>
         <note />
       </trans-unit>
       <trans-unit id="MappingAddedFormat">

--- a/src/Aspire.Cli/Resources/xlf/UpdateCommandStrings.es.xlf
+++ b/src/Aspire.Cli/Resources/xlf/UpdateCommandStrings.es.xlf
@@ -7,6 +7,16 @@
         <target state="translated">Agregado: {0}</target>
         <note />
       </trans-unit>
+      <trans-unit id="AlreadyUpToDateMessage">
+        <source>Aspire CLI is already up to date.</source>
+        <target state="new">Aspire CLI is already up to date.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AlreadyUpToDateMessageFormat">
+        <source>Aspire CLI is already up to date (version {0}).</source>
+        <target state="new">Aspire CLI is already up to date (version {0}).</target>
+        <note />
+      </trans-unit>
       <trans-unit id="AnalyzeAppHost">
         <source>Analyze AppHost</source>
         <target state="needs-review-translation">Analizar host de aplicación</target>
@@ -115,6 +125,11 @@
       <trans-unit id="FallbackParsingWarning">
         <source>Note: Update plan generated using fallback parsing due to unresolvable AppHost SDK. Dependency analysis may have reduced accuracy.</source>
         <target state="needs-review-translation">Nota: El plan de actualización se generó usando un análisis alternativo debido a un SDK de AppHost no resoluble. El análisis de dependencias puede ser menos preciso.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ForceOptionDescription">
+        <source>Force the self-update to download and install even if the installed CLI already matches the latest published build</source>
+        <target state="new">Force the self-update to download and install even if the installed CLI already matches the latest published build</target>
         <note />
       </trans-unit>
       <trans-unit id="MappingAddedFormat">

--- a/src/Aspire.Cli/Resources/xlf/UpdateCommandStrings.fr.xlf
+++ b/src/Aspire.Cli/Resources/xlf/UpdateCommandStrings.fr.xlf
@@ -7,6 +7,16 @@
         <target state="translated">Ajouté : {0}</target>
         <note />
       </trans-unit>
+      <trans-unit id="AlreadyUpToDateMessage">
+        <source>Aspire CLI is already up to date.</source>
+        <target state="new">Aspire CLI is already up to date.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AlreadyUpToDateMessageFormat">
+        <source>Aspire CLI is already up to date (version {0}).</source>
+        <target state="new">Aspire CLI is already up to date (version {0}).</target>
+        <note />
+      </trans-unit>
       <trans-unit id="AnalyzeAppHost">
         <source>Analyze AppHost</source>
         <target state="needs-review-translation">Analyser l’hôte d’application</target>
@@ -115,6 +125,11 @@
       <trans-unit id="FallbackParsingWarning">
         <source>Note: Update plan generated using fallback parsing due to unresolvable AppHost SDK. Dependency analysis may have reduced accuracy.</source>
         <target state="needs-review-translation">Remarque : plan de mise à jour généré à l’aide de l’analyse de secours en raison d’un Kit de développement logiciel (SDK) AppHost non résolu. L’analyse des dépendances peut avoir une précision réduite.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ForceOptionDescription">
+        <source>Force the self-update to download and install even if the installed CLI already matches the latest published build</source>
+        <target state="new">Force the self-update to download and install even if the installed CLI already matches the latest published build</target>
         <note />
       </trans-unit>
       <trans-unit id="MappingAddedFormat">

--- a/src/Aspire.Cli/Resources/xlf/UpdateCommandStrings.it.xlf
+++ b/src/Aspire.Cli/Resources/xlf/UpdateCommandStrings.it.xlf
@@ -7,6 +7,16 @@
         <target state="translated">Aggiunto: {0}</target>
         <note />
       </trans-unit>
+      <trans-unit id="AlreadyUpToDateMessage">
+        <source>Aspire CLI is already up to date.</source>
+        <target state="new">Aspire CLI is already up to date.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AlreadyUpToDateMessageFormat">
+        <source>Aspire CLI is already up to date (version {0}).</source>
+        <target state="new">Aspire CLI is already up to date (version {0}).</target>
+        <note />
+      </trans-unit>
       <trans-unit id="AnalyzeAppHost">
         <source>Analyze AppHost</source>
         <target state="needs-review-translation">Analizza host delle app</target>
@@ -115,6 +125,11 @@
       <trans-unit id="FallbackParsingWarning">
         <source>Note: Update plan generated using fallback parsing due to unresolvable AppHost SDK. Dependency analysis may have reduced accuracy.</source>
         <target state="needs-review-translation">Nota: il piano di aggiornamento è stato generato usando l'analisi di fallback perché AppHost SDK non è risolvibile. L'analisi delle dipendenze potrebbe risultare meno accurata.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ForceOptionDescription">
+        <source>Force the self-update to download and install even if the installed CLI already matches the latest published build</source>
+        <target state="new">Force the self-update to download and install even if the installed CLI already matches the latest published build</target>
         <note />
       </trans-unit>
       <trans-unit id="MappingAddedFormat">

--- a/src/Aspire.Cli/Resources/xlf/UpdateCommandStrings.ja.xlf
+++ b/src/Aspire.Cli/Resources/xlf/UpdateCommandStrings.ja.xlf
@@ -7,6 +7,16 @@
         <target state="translated">追加済み: {0}</target>
         <note />
       </trans-unit>
+      <trans-unit id="AlreadyUpToDateMessage">
+        <source>Aspire CLI is already up to date.</source>
+        <target state="new">Aspire CLI is already up to date.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AlreadyUpToDateMessageFormat">
+        <source>Aspire CLI is already up to date (version {0}).</source>
+        <target state="new">Aspire CLI is already up to date (version {0}).</target>
+        <note />
+      </trans-unit>
       <trans-unit id="AnalyzeAppHost">
         <source>Analyze AppHost</source>
         <target state="needs-review-translation">アプリ ホスティング プロセスの分析</target>
@@ -115,6 +125,11 @@
       <trans-unit id="FallbackParsingWarning">
         <source>Note: Update plan generated using fallback parsing due to unresolvable AppHost SDK. Dependency analysis may have reduced accuracy.</source>
         <target state="needs-review-translation">注: 解決できない AppHost SDK が原因でフォールバック解析を使用して生成されたプランを更新します。依存関係分析の精度が低下する可能性があります。</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ForceOptionDescription">
+        <source>Force the self-update to download and install even if the installed CLI already matches the latest published build</source>
+        <target state="new">Force the self-update to download and install even if the installed CLI already matches the latest published build</target>
         <note />
       </trans-unit>
       <trans-unit id="MappingAddedFormat">

--- a/src/Aspire.Cli/Resources/xlf/UpdateCommandStrings.ko.xlf
+++ b/src/Aspire.Cli/Resources/xlf/UpdateCommandStrings.ko.xlf
@@ -7,6 +7,16 @@
         <target state="translated">추가됨: {0}</target>
         <note />
       </trans-unit>
+      <trans-unit id="AlreadyUpToDateMessage">
+        <source>Aspire CLI is already up to date.</source>
+        <target state="new">Aspire CLI is already up to date.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AlreadyUpToDateMessageFormat">
+        <source>Aspire CLI is already up to date (version {0}).</source>
+        <target state="new">Aspire CLI is already up to date (version {0}).</target>
+        <note />
+      </trans-unit>
       <trans-unit id="AnalyzeAppHost">
         <source>Analyze AppHost</source>
         <target state="needs-review-translation">앱 호스트 분석</target>
@@ -115,6 +125,11 @@
       <trans-unit id="FallbackParsingWarning">
         <source>Note: Update plan generated using fallback parsing due to unresolvable AppHost SDK. Dependency analysis may have reduced accuracy.</source>
         <target state="needs-review-translation">참고: 해결할 수 없는 AppHost SDK 때문에 대체 구문 분석을 사용하여 업데이트 계획이 생성되었습니다. 종속성 분석의 정확도가 낮아질 수 있습니다.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ForceOptionDescription">
+        <source>Force the self-update to download and install even if the installed CLI already matches the latest published build</source>
+        <target state="new">Force the self-update to download and install even if the installed CLI already matches the latest published build</target>
         <note />
       </trans-unit>
       <trans-unit id="MappingAddedFormat">

--- a/src/Aspire.Cli/Resources/xlf/UpdateCommandStrings.pl.xlf
+++ b/src/Aspire.Cli/Resources/xlf/UpdateCommandStrings.pl.xlf
@@ -7,6 +7,16 @@
         <target state="translated">Dodano: {0}</target>
         <note />
       </trans-unit>
+      <trans-unit id="AlreadyUpToDateMessage">
+        <source>Aspire CLI is already up to date.</source>
+        <target state="new">Aspire CLI is already up to date.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AlreadyUpToDateMessageFormat">
+        <source>Aspire CLI is already up to date (version {0}).</source>
+        <target state="new">Aspire CLI is already up to date (version {0}).</target>
+        <note />
+      </trans-unit>
       <trans-unit id="AnalyzeAppHost">
         <source>Analyze AppHost</source>
         <target state="needs-review-translation">Analizowanie hosta aplikacji</target>
@@ -115,6 +125,11 @@
       <trans-unit id="FallbackParsingWarning">
         <source>Note: Update plan generated using fallback parsing due to unresolvable AppHost SDK. Dependency analysis may have reduced accuracy.</source>
         <target state="needs-review-translation">Uwaga: plan aktualizacji został wygenerowany przy użyciu analizy zapasowej z powodu nierozpoznanego zestawu AppHost SDK. Analiza zależności może być mniej dokładna.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ForceOptionDescription">
+        <source>Force the self-update to download and install even if the installed CLI already matches the latest published build</source>
+        <target state="new">Force the self-update to download and install even if the installed CLI already matches the latest published build</target>
         <note />
       </trans-unit>
       <trans-unit id="MappingAddedFormat">

--- a/src/Aspire.Cli/Resources/xlf/UpdateCommandStrings.pt-BR.xlf
+++ b/src/Aspire.Cli/Resources/xlf/UpdateCommandStrings.pt-BR.xlf
@@ -7,6 +7,16 @@
         <target state="translated">Adicionado: {0}</target>
         <note />
       </trans-unit>
+      <trans-unit id="AlreadyUpToDateMessage">
+        <source>Aspire CLI is already up to date.</source>
+        <target state="new">Aspire CLI is already up to date.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AlreadyUpToDateMessageFormat">
+        <source>Aspire CLI is already up to date (version {0}).</source>
+        <target state="new">Aspire CLI is already up to date (version {0}).</target>
+        <note />
+      </trans-unit>
       <trans-unit id="AnalyzeAppHost">
         <source>Analyze AppHost</source>
         <target state="needs-review-translation">Analisar o Host de Aplicativo</target>
@@ -115,6 +125,11 @@
       <trans-unit id="FallbackParsingWarning">
         <source>Note: Update plan generated using fallback parsing due to unresolvable AppHost SDK. Dependency analysis may have reduced accuracy.</source>
         <target state="needs-review-translation">Observação: o plano de atualização gerado usando a análise de fallback devido ao SDK do AppHost não resolvido. A análise de dependência pode ter uma precisão reduzida.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ForceOptionDescription">
+        <source>Force the self-update to download and install even if the installed CLI already matches the latest published build</source>
+        <target state="new">Force the self-update to download and install even if the installed CLI already matches the latest published build</target>
         <note />
       </trans-unit>
       <trans-unit id="MappingAddedFormat">

--- a/src/Aspire.Cli/Resources/xlf/UpdateCommandStrings.ru.xlf
+++ b/src/Aspire.Cli/Resources/xlf/UpdateCommandStrings.ru.xlf
@@ -7,6 +7,16 @@
         <target state="translated">Добавлено: {0}</target>
         <note />
       </trans-unit>
+      <trans-unit id="AlreadyUpToDateMessage">
+        <source>Aspire CLI is already up to date.</source>
+        <target state="new">Aspire CLI is already up to date.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AlreadyUpToDateMessageFormat">
+        <source>Aspire CLI is already up to date (version {0}).</source>
+        <target state="new">Aspire CLI is already up to date (version {0}).</target>
+        <note />
+      </trans-unit>
       <trans-unit id="AnalyzeAppHost">
         <source>Analyze AppHost</source>
         <target state="needs-review-translation">Анализ хоста приложений</target>
@@ -115,6 +125,11 @@
       <trans-unit id="FallbackParsingWarning">
         <source>Note: Update plan generated using fallback parsing due to unresolvable AppHost SDK. Dependency analysis may have reduced accuracy.</source>
         <target state="needs-review-translation">Примечание. План обновления создан с использованием резервного анализа из-за невозможности разрешить SDK AppHost. Точность анализа зависимостей может быть снижена.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ForceOptionDescription">
+        <source>Force the self-update to download and install even if the installed CLI already matches the latest published build</source>
+        <target state="new">Force the self-update to download and install even if the installed CLI already matches the latest published build</target>
         <note />
       </trans-unit>
       <trans-unit id="MappingAddedFormat">

--- a/src/Aspire.Cli/Resources/xlf/UpdateCommandStrings.tr.xlf
+++ b/src/Aspire.Cli/Resources/xlf/UpdateCommandStrings.tr.xlf
@@ -7,6 +7,16 @@
         <target state="translated">Eklendi: {0}</target>
         <note />
       </trans-unit>
+      <trans-unit id="AlreadyUpToDateMessage">
+        <source>Aspire CLI is already up to date.</source>
+        <target state="new">Aspire CLI is already up to date.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AlreadyUpToDateMessageFormat">
+        <source>Aspire CLI is already up to date (version {0}).</source>
+        <target state="new">Aspire CLI is already up to date (version {0}).</target>
+        <note />
+      </trans-unit>
       <trans-unit id="AnalyzeAppHost">
         <source>Analyze AppHost</source>
         <target state="needs-review-translation">Uygulama Ana İşlemi</target>
@@ -115,6 +125,11 @@
       <trans-unit id="FallbackParsingWarning">
         <source>Note: Update plan generated using fallback parsing due to unresolvable AppHost SDK. Dependency analysis may have reduced accuracy.</source>
         <target state="needs-review-translation">Not: Çözülemeyen AppHost SDK nedeniyle geri dönüş ayrıştırması kullanılarak oluşturulan güncelleştirme planı. Bağımlılık analizi doğruluğu azaltmış olabilir.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ForceOptionDescription">
+        <source>Force the self-update to download and install even if the installed CLI already matches the latest published build</source>
+        <target state="new">Force the self-update to download and install even if the installed CLI already matches the latest published build</target>
         <note />
       </trans-unit>
       <trans-unit id="MappingAddedFormat">

--- a/src/Aspire.Cli/Resources/xlf/UpdateCommandStrings.zh-Hans.xlf
+++ b/src/Aspire.Cli/Resources/xlf/UpdateCommandStrings.zh-Hans.xlf
@@ -7,6 +7,16 @@
         <target state="translated">已添加: {0}</target>
         <note />
       </trans-unit>
+      <trans-unit id="AlreadyUpToDateMessage">
+        <source>Aspire CLI is already up to date.</source>
+        <target state="new">Aspire CLI is already up to date.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AlreadyUpToDateMessageFormat">
+        <source>Aspire CLI is already up to date (version {0}).</source>
+        <target state="new">Aspire CLI is already up to date (version {0}).</target>
+        <note />
+      </trans-unit>
       <trans-unit id="AnalyzeAppHost">
         <source>Analyze AppHost</source>
         <target state="needs-review-translation">分析应用主机</target>
@@ -115,6 +125,11 @@
       <trans-unit id="FallbackParsingWarning">
         <source>Note: Update plan generated using fallback parsing due to unresolvable AppHost SDK. Dependency analysis may have reduced accuracy.</source>
         <target state="needs-review-translation">注意: 由于 AppHost SDK 无法解析，已采用回退解析生成更新计划。依赖项分析的准确性可能有所降低。</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ForceOptionDescription">
+        <source>Force the self-update to download and install even if the installed CLI already matches the latest published build</source>
+        <target state="new">Force the self-update to download and install even if the installed CLI already matches the latest published build</target>
         <note />
       </trans-unit>
       <trans-unit id="MappingAddedFormat">

--- a/src/Aspire.Cli/Resources/xlf/UpdateCommandStrings.zh-Hant.xlf
+++ b/src/Aspire.Cli/Resources/xlf/UpdateCommandStrings.zh-Hant.xlf
@@ -7,6 +7,16 @@
         <target state="translated">已新增: {0}</target>
         <note />
       </trans-unit>
+      <trans-unit id="AlreadyUpToDateMessage">
+        <source>Aspire CLI is already up to date.</source>
+        <target state="new">Aspire CLI is already up to date.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AlreadyUpToDateMessageFormat">
+        <source>Aspire CLI is already up to date (version {0}).</source>
+        <target state="new">Aspire CLI is already up to date (version {0}).</target>
+        <note />
+      </trans-unit>
       <trans-unit id="AnalyzeAppHost">
         <source>Analyze AppHost</source>
         <target state="needs-review-translation">分析應用程式主機</target>
@@ -115,6 +125,11 @@
       <trans-unit id="FallbackParsingWarning">
         <source>Note: Update plan generated using fallback parsing due to unresolvable AppHost SDK. Dependency analysis may have reduced accuracy.</source>
         <target state="needs-review-translation">注意: 由於無法解析的 AppHost SDK，已使用後援剖析產生更新計劃。相依性分析的正確性可能因此降低。</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ForceOptionDescription">
+        <source>Force the self-update to download and install even if the installed CLI already matches the latest published build</source>
+        <target state="new">Force the self-update to download and install even if the installed CLI already matches the latest published build</target>
         <note />
       </trans-unit>
       <trans-unit id="MappingAddedFormat">

--- a/src/Aspire.Cli/Utils/CliDownloader.cs
+++ b/src/Aspire.Cli/Utils/CliDownloader.cs
@@ -16,6 +16,15 @@ namespace Aspire.Cli.Utils;
 internal interface ICliDownloader
 {
     Task<string> DownloadLatestCliAsync(string channelName, CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Fetches the published SHA-512 checksum for the latest CLI archive on
+    /// the given channel without downloading the archive itself. The checksum
+    /// is returned as a lowercase hex string with surrounding whitespace
+    /// trimmed. Used to short-circuit a full download when the installed
+    /// binary already matches the latest published build.
+    /// </summary>
+    Task<string> GetLatestChecksumAsync(string channelName, CancellationToken cancellationToken);
 }
 
 internal class CliDownloader(
@@ -28,48 +37,42 @@ internal class CliDownloader(
     
     private static readonly HttpClient s_httpClient = new();
 
+    public async Task<string> GetLatestChecksumAsync(string channelName, CancellationToken cancellationToken)
+    {
+        var info = await BuildChannelDownloadInfoAsync(channelName, cancellationToken);
+
+        logger.LogDebug("Fetching checksum from {Url}", info.ChecksumUrl);
+
+        using var cts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+        cts.CancelAfter(TimeSpan.FromSeconds(ChecksumDownloadTimeoutSeconds));
+
+        using var response = await s_httpClient.GetAsync(info.ChecksumUrl, cts.Token);
+        response.EnsureSuccessStatusCode();
+
+        var raw = await response.Content.ReadAsStringAsync(cts.Token);
+        return NormalizeChecksum(raw);
+    }
+
     public async Task<string> DownloadLatestCliAsync(string channelName, CancellationToken cancellationToken)
     {
-        // Get the channel information from PackagingService
-        var channels = await packagingService.GetChannelsAsync(cancellationToken);
-        var channel = channels.FirstOrDefault(c => c.Name.Equals(channelName, StringComparison.OrdinalIgnoreCase));
-        
-        if (channel is null)
-        {
-            throw new ArgumentException($"Unsupported channel '{channelName}'. Available channels: {string.Join(", ", channels.Select(c => c.Name))}");
-        }
-
-        if (string.IsNullOrEmpty(channel.CliDownloadBaseUrl))
-        {
-            throw new InvalidOperationException($"Channel '{channelName}' does not support CLI downloads.");
-        }
-
-        var baseUrl = channel.CliDownloadBaseUrl.TrimEnd('/');
-
-        var (os, arch) = DetectPlatform();
-        var runtimeIdentifier = $"{os}-{arch}";
-        var extension = os == "win" ? "zip" : "tar.gz";
-        var archiveFilename = $"aspire-cli-{runtimeIdentifier}.{extension}";
-        var checksumFilename = $"{archiveFilename}.sha512";
-        var archiveUrl = $"{baseUrl}/{archiveFilename}";
-        var checksumUrl = $"{baseUrl}/{checksumFilename}";
+        var info = await BuildChannelDownloadInfoAsync(channelName, cancellationToken);
 
         // Create temp directory for download
         var tempDir = Directory.CreateTempSubdirectory("aspire-cli-download").FullName;
 
         try
         {
-            var archivePath = Path.Combine(tempDir, archiveFilename);
-            var checksumPath = Path.Combine(tempDir, checksumFilename);
-            var archiveDescriptor = GetDownloadDescriptor(archiveUrl, $"the {channel.Name} channel");
+            var archivePath = Path.Combine(tempDir, info.ArchiveFilename);
+            var checksumPath = Path.Combine(tempDir, info.ChecksumFilename);
+            var archiveDescriptor = GetDownloadDescriptor(info.ArchiveUrl, $"the {info.ChannelName} channel");
 
             _ = await interactionService.ShowStatusAsync($"Downloading {archiveDescriptor}", async () =>
             {
-                logger.LogDebug("Downloading archive from {Url} to {Path}", archiveUrl, archivePath);
-                await DownloadFileAsync(archiveUrl, archivePath, ArchiveDownloadTimeoutSeconds, cancellationToken);
+                logger.LogDebug("Downloading archive from {Url} to {Path}", info.ArchiveUrl, archivePath);
+                await DownloadFileAsync(info.ArchiveUrl, archivePath, ArchiveDownloadTimeoutSeconds, cancellationToken);
 
-                logger.LogDebug("Downloading checksum from {Url} to {Path}", checksumUrl, checksumPath);
-                await DownloadFileAsync(checksumUrl, checksumPath, ChecksumDownloadTimeoutSeconds, cancellationToken);
+                logger.LogDebug("Downloading checksum from {Url} to {Path}", info.ChecksumUrl, checksumPath);
+                await DownloadFileAsync(info.ChecksumUrl, checksumPath, ChecksumDownloadTimeoutSeconds, cancellationToken);
                 
                 return 0; // Return dummy value for ShowStatusAsync
             });
@@ -98,6 +101,71 @@ internal class CliDownloader(
             throw;
         }
     }
+
+    private async Task<ChannelDownloadInfo> BuildChannelDownloadInfoAsync(string channelName, CancellationToken cancellationToken)
+    {
+        var channels = await packagingService.GetChannelsAsync(cancellationToken);
+        var channel = channels.FirstOrDefault(c => c.Name.Equals(channelName, StringComparison.OrdinalIgnoreCase));
+
+        if (channel is null)
+        {
+            throw new ArgumentException($"Unsupported channel '{channelName}'. Available channels: {string.Join(", ", channels.Select(c => c.Name))}");
+        }
+
+        if (string.IsNullOrEmpty(channel.CliDownloadBaseUrl))
+        {
+            throw new InvalidOperationException($"Channel '{channelName}' does not support CLI downloads.");
+        }
+
+        var baseUrl = channel.CliDownloadBaseUrl.TrimEnd('/');
+        var (os, arch) = DetectPlatform();
+        var runtimeIdentifier = $"{os}-{arch}";
+        var extension = os == "win" ? "zip" : "tar.gz";
+        var archiveFilename = $"aspire-cli-{runtimeIdentifier}.{extension}";
+        var checksumFilename = $"{archiveFilename}.sha512";
+
+        return new ChannelDownloadInfo(
+            channel.Name,
+            archiveFilename,
+            checksumFilename,
+            $"{baseUrl}/{archiveFilename}",
+            $"{baseUrl}/{checksumFilename}");
+    }
+
+    internal static string NormalizeChecksum(string raw)
+    {
+        // The published .sha512 file format mirrors `sha512sum` output. Two shapes
+        // are observed across our publishing infrastructure:
+        //   1. "<hex>\n"                                     (just the digest)
+        //   2. "<hex>  aspire-cli-<rid>.tar.gz\n"            (digest + filename)
+        // Take the leading hex token only and lowercase so comparisons are stable.
+        var trimmed = raw.Trim();
+        var firstWhitespace = IndexOfWhitespace(trimmed);
+        if (firstWhitespace > 0)
+        {
+            trimmed = trimmed.Substring(0, firstWhitespace);
+        }
+        return trimmed.ToLowerInvariant();
+    }
+
+    private static int IndexOfWhitespace(string value)
+    {
+        for (var i = 0; i < value.Length; i++)
+        {
+            if (char.IsWhiteSpace(value[i]))
+            {
+                return i;
+            }
+        }
+        return -1;
+    }
+
+    private readonly record struct ChannelDownloadInfo(
+        string ChannelName,
+        string ArchiveFilename,
+        string ChecksumFilename,
+        string ArchiveUrl,
+        string ChecksumUrl);
 
     internal static string GetDownloadDescriptor(string url, string? source = null)
     {
@@ -204,7 +272,7 @@ internal class CliDownloader(
 
     private static async Task ValidateChecksumAsync(string archivePath, string checksumPath, CancellationToken cancellationToken)
     {
-        var expectedChecksum = (await File.ReadAllTextAsync(checksumPath, cancellationToken)).Trim().ToLowerInvariant();
+        var expectedChecksum = NormalizeChecksum(await File.ReadAllTextAsync(checksumPath, cancellationToken));
 
         using var sha512 = SHA512.Create();
         await using var fileStream = new FileStream(archivePath, FileMode.Open, FileAccess.Read, FileShare.Read);

--- a/src/Aspire.Cli/Utils/DotNetToolDetection.cs
+++ b/src/Aspire.Cli/Utils/DotNetToolDetection.cs
@@ -291,6 +291,17 @@ internal static class DotNetToolDetection
         return new ProcessPathOverrideScope(previousValue);
     }
 
+    /// <summary>
+    /// Returns the current process path, honoring any test override applied via
+    /// <see cref="UseProcessPathForTesting"/>. Use this instead of
+    /// <see cref="Environment.ProcessPath"/> directly when a code path needs to
+    /// reason about the installed CLI's location and must remain testable.
+    /// </summary>
+    internal static string? GetEffectiveProcessPath()
+    {
+        return s_processPathOverride.Value ?? Environment.ProcessPath;
+    }
+
     private static bool IsAspireExecutable(string executable)
     {
         return string.Equals(executable, "aspire", StringComparison.OrdinalIgnoreCase)

--- a/tests/Aspire.Cli.Tests/Commands/UpdateCommandTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/UpdateCommandTests.cs
@@ -1928,6 +1928,190 @@ public class UpdateCommandTests(ITestOutputHelper outputHelper)
     // to roll back any prior write. That rollback path is covered by the stable row of
     // UpdateCommand_SelfUpdate_DoesNotWriteChannelToGlobalConfiguration above (asserts both
     // DoesNotContain set + DoesNotContain delete) — no standalone test required here.
+
+    // Issue #16730: `aspire update --self` should be a no-op when the installed binary's
+    // recorded archive checksum matches the latest published checksum. The marker file
+    // (aspire.sha512) is written next to the installed binary after a successful install.
+
+    [Fact]
+    public async Task UpdateCommand_SelfUpdate_WhenChecksumMatchesMarker_SkipsDownload()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        using var tempDirectory = new TestTempDirectory();
+
+        // Pretend the running CLI lives in a temp dir so we can drop a marker file
+        // that the command will read. Use a non-tool layout so the dotnet-tool
+        // detection short-circuit does not fire first.
+        var installDir = Path.Combine(tempDirectory.Path, "aspire-bin");
+        Directory.CreateDirectory(installDir);
+        var processPath = Path.Combine(installDir, GetAspireExecutableName());
+        File.WriteAllText(processPath, string.Empty);
+        using var processPathScope = DotNetToolDetection.UseProcessPathForTesting(processPath);
+
+        const string sharedChecksum = "abc123def456";
+        File.WriteAllText(Path.Combine(installDir, UpdateCommand.ChecksumMarkerFileName), sharedChecksum + "\n");
+
+        var downloadInvoked = false;
+        var checksumProbeInvoked = false;
+        var interactionService = new TestInteractionService();
+
+        var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper, options =>
+        {
+            options.InteractionServiceFactory = _ => interactionService;
+            options.CliDownloaderFactory = _ => new TestCliDownloader(workspace.WorkspaceRoot)
+            {
+                GetLatestChecksumAsyncCallback = (_, _) =>
+                {
+                    checksumProbeInvoked = true;
+                    return Task.FromResult(sharedChecksum);
+                },
+                DownloadLatestCliAsyncCallback = (_, _) =>
+                {
+                    downloadInvoked = true;
+                    return Task.FromResult(string.Empty);
+                }
+            };
+        });
+
+        using var provider = services.BuildServiceProvider();
+        var command = provider.GetRequiredService<RootCommand>();
+        var result = command.Parse("update --self --channel daily");
+
+        var exitCode = await result.InvokeAsync().DefaultTimeout();
+
+        Assert.Equal(ExitCodeConstants.Success, exitCode);
+        Assert.True(checksumProbeInvoked, "Checksum probe should be invoked to compare against the marker.");
+        Assert.False(downloadInvoked, "Archive download should be skipped when the checksum already matches.");
+    }
+
+    [Fact]
+    public async Task UpdateCommand_SelfUpdate_WhenChecksumMismatchesMarker_PerformsUpdateAndRewritesMarker()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        using var tempDirectory = new TestTempDirectory();
+        var installDir = Path.Combine(tempDirectory.Path, "aspire-bin");
+        Directory.CreateDirectory(installDir);
+        var processPath = Path.Combine(installDir, GetAspireExecutableName());
+        File.WriteAllText(processPath, string.Empty);
+        using var processPathScope = DotNetToolDetection.UseProcessPathForTesting(processPath);
+
+        var markerPath = Path.Combine(installDir, UpdateCommand.ChecksumMarkerFileName);
+        File.WriteAllText(markerPath, "stale-marker-checksum\n");
+
+        var downloadInvoked = false;
+        var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper, options =>
+        {
+            options.CliDownloaderFactory = _ => new TestCliDownloader(workspace.WorkspaceRoot)
+            {
+                GetLatestChecksumAsyncCallback = (_, _) => Task.FromResult("fresh-remote-checksum"),
+                DownloadLatestCliAsyncCallback = (_, _) =>
+                {
+                    downloadInvoked = true;
+                    var archivePath = Path.Combine(workspace.WorkspaceRoot.FullName, "test-cli.tar.gz");
+                    File.WriteAllText(archivePath, "fake archive");
+                    return Task.FromResult(archivePath);
+                }
+            };
+        });
+
+        using var provider = services.BuildServiceProvider();
+        var command = provider.GetRequiredService<RootCommand>();
+        var result = command.Parse("update --self --channel daily");
+
+        // Extraction will fail (fake archive), but the download must have been attempted
+        // because the marker checksum did not match the remote checksum.
+        await result.InvokeAsync().DefaultTimeout();
+
+        Assert.True(downloadInvoked, "Archive download should run when the marker checksum does not match.");
+    }
+
+    [Fact]
+    public async Task UpdateCommand_SelfUpdate_WhenNoMarkerExists_PerformsUpdate()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        using var tempDirectory = new TestTempDirectory();
+        var installDir = Path.Combine(tempDirectory.Path, "aspire-bin");
+        Directory.CreateDirectory(installDir);
+        var processPath = Path.Combine(installDir, GetAspireExecutableName());
+        File.WriteAllText(processPath, string.Empty);
+        using var processPathScope = DotNetToolDetection.UseProcessPathForTesting(processPath);
+        // No marker file is created.
+
+        var checksumProbeInvoked = false;
+        var downloadInvoked = false;
+        var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper, options =>
+        {
+            options.CliDownloaderFactory = _ => new TestCliDownloader(workspace.WorkspaceRoot)
+            {
+                GetLatestChecksumAsyncCallback = (_, _) =>
+                {
+                    checksumProbeInvoked = true;
+                    return Task.FromResult("any-checksum");
+                },
+                DownloadLatestCliAsyncCallback = (_, _) =>
+                {
+                    downloadInvoked = true;
+                    var archivePath = Path.Combine(workspace.WorkspaceRoot.FullName, "test-cli.tar.gz");
+                    File.WriteAllText(archivePath, "fake archive");
+                    return Task.FromResult(archivePath);
+                }
+            };
+        });
+
+        using var provider = services.BuildServiceProvider();
+        var command = provider.GetRequiredService<RootCommand>();
+        var result = command.Parse("update --self --channel daily");
+
+        await result.InvokeAsync().DefaultTimeout();
+
+        Assert.False(checksumProbeInvoked, "Checksum probe should be skipped when no marker file exists.");
+        Assert.True(downloadInvoked, "Archive download should run when no marker exists.");
+    }
+
+    [Fact]
+    public async Task UpdateCommand_SelfUpdate_WithForce_AlwaysDownloads()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        using var tempDirectory = new TestTempDirectory();
+        var installDir = Path.Combine(tempDirectory.Path, "aspire-bin");
+        Directory.CreateDirectory(installDir);
+        var processPath = Path.Combine(installDir, GetAspireExecutableName());
+        File.WriteAllText(processPath, string.Empty);
+        using var processPathScope = DotNetToolDetection.UseProcessPathForTesting(processPath);
+
+        const string sharedChecksum = "matching-checksum";
+        File.WriteAllText(Path.Combine(installDir, UpdateCommand.ChecksumMarkerFileName), sharedChecksum);
+
+        var checksumProbeInvoked = false;
+        var downloadInvoked = false;
+        var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper, options =>
+        {
+            options.CliDownloaderFactory = _ => new TestCliDownloader(workspace.WorkspaceRoot)
+            {
+                GetLatestChecksumAsyncCallback = (_, _) =>
+                {
+                    checksumProbeInvoked = true;
+                    return Task.FromResult(sharedChecksum);
+                },
+                DownloadLatestCliAsyncCallback = (_, _) =>
+                {
+                    downloadInvoked = true;
+                    var archivePath = Path.Combine(workspace.WorkspaceRoot.FullName, "test-cli.tar.gz");
+                    File.WriteAllText(archivePath, "fake archive");
+                    return Task.FromResult(archivePath);
+                }
+            };
+        });
+
+        using var provider = services.BuildServiceProvider();
+        var command = provider.GetRequiredService<RootCommand>();
+        var result = command.Parse("update --self --channel daily --force");
+
+        await result.InvokeAsync().DefaultTimeout();
+
+        Assert.False(checksumProbeInvoked, "--force should bypass the checksum probe entirely.");
+        Assert.True(downloadInvoked, "--force must always trigger an archive download.");
+    }
 }
 
 // Helper class to track DisplayCancellationMessage calls

--- a/tests/Aspire.Cli.Tests/TestServices/TestCliDownloader.cs
+++ b/tests/Aspire.Cli.Tests/TestServices/TestCliDownloader.cs
@@ -19,6 +19,8 @@ internal sealed class TestCliDownloader : ICliDownloader
 
     public Func<string, CancellationToken, Task<string>>? DownloadLatestCliAsyncCallback { get; set; }
 
+    public Func<string, CancellationToken, Task<string>>? GetLatestChecksumAsyncCallback { get; set; }
+
     public Task<string> DownloadLatestCliAsync(string quality, CancellationToken cancellationToken)
     {
         if (DownloadLatestCliAsyncCallback is not null)
@@ -37,5 +39,18 @@ internal sealed class TestCliDownloader : ICliDownloader
         var path = Path.Combine(_tempDirectory.FullName, filename);
         
         return Task.FromResult(path);
+    }
+
+    public Task<string> GetLatestChecksumAsync(string channelName, CancellationToken cancellationToken)
+    {
+        if (GetLatestChecksumAsyncCallback is not null)
+        {
+            return GetLatestChecksumAsyncCallback(channelName, cancellationToken);
+        }
+
+        // Default to a unique value per call so the no-op short-circuit in
+        // UpdateCommand never triggers unless a test opts in by configuring
+        // the callback.
+        return Task.FromResult(Guid.NewGuid().ToString("N"));
     }
 }

--- a/tests/Aspire.Cli.Tests/Utils/CliDownloaderTests.cs
+++ b/tests/Aspire.Cli.Tests/Utils/CliDownloaderTests.cs
@@ -24,4 +24,15 @@ public class CliDownloaderTests
         Assert.DoesNotContain("ga/", descriptor, StringComparison.OrdinalIgnoreCase);
         Assert.DoesNotContain("rc/", descriptor, StringComparison.OrdinalIgnoreCase);
     }
+
+    [Theory]
+    [InlineData("abcdef\n", "abcdef")]
+    [InlineData("ABCDEF", "abcdef")]
+    [InlineData("  ABCDEF  \n", "abcdef")]
+    [InlineData("abcdef  aspire-cli-osx-arm64.tar.gz\n", "abcdef")]
+    [InlineData("ABCDEF\taspire-cli-linux-x64.tar.gz", "abcdef")]
+    public void NormalizeChecksum_StripsCompanionFilename_AndLowercases(string raw, string expected)
+    {
+        Assert.Equal(expected, CliDownloader.NormalizeChecksum(raw));
+    }
 }


### PR DESCRIPTION
## Description

`aspire update --self --channel <c>` re-downloads tens of MB on every invocation, even when the installed binary already matches the latest published archive. This makes scripted/CI usage and routine "is there an update?" checks unnecessarily slow and bandwidth-heavy.

This change short-circuits the update when the small published `.sha512` matches a marker file (`aspire.sha512`) we write next to the installed binary on a successful install. The probe fetches only the tiny checksum file (~129 bytes); on match we report "already up to date" and exit without touching the multi-MB archive.

Approach:

- New `ICliDownloader.GetLatestChecksumAsync` fetches and normalizes the published `.sha512` (handles both bare-hex and `sha512sum`-style `<hex>  <filename>` shapes).
- `UpdateCommand` reads the local `aspire.sha512` marker (next to the install dir resolved from the process path) and compares against the probe before downloading.
- On a successful install, the checksum is persisted atomically (temp file + `File.Move(overwrite: true)`) so a failed install can never poison the marker. If the checksum is unavailable we hash the archive on disk so future runs can still benefit.
- New `--force` / `-f` opts out of the short-circuit.
- `DotNetToolDetection` exposes `GetEffectiveProcessPath()` so the existing `AsyncLocal` test override applies to the install-dir resolution too, keeping the new logic unit-testable without writing into the test runner directory.

Probe failures (network errors, malformed marker) are caught and silently fall through to the normal download path so the probe never blocks an explicit update; `OperationCanceledException` is rethrown.

Fixes: #16730

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [x] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [x] No
  - [ ] No

The marker check is an optimization, not a trust boundary: a mismatching/missing marker just falls through to the existing download + verify path. SHA-512 is used here because it must match the published `.sha512` algorithm.