### PR TITLE
Make release workflow dispatch ref configurable (default: main)

### DIFF
--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -71,6 +71,7 @@ Before starting a release:
    | `SkipHomebrewPublish` | Set `true` if re-running after Homebrew success | `false` |
    | `SkipGitHubTasks` | Set `true` to skip dispatching the GH workflow | `false` |
    | `SkipReleaseAssets` | Set `true` to skip uploading aspire-cli-* assets to the GitHub release | `false` |
+   | `GitHubTasksWorkflowRef` | Ref to load `release-github-tasks.yml` from when dispatching. Only affects the workflow source — the release branch/commit are passed via inputs. Override only when testing pipeline changes on a topic branch. | `main` |
 
 5. Click "Run" and monitor the pipeline. The final stage (`GitHubTasks`)
    dispatches `release-github-tasks.yml`, waits for it to complete, and

--- a/eng/pipelines/release-publish-nuget.yml
+++ b/eng/pipelines/release-publish-nuget.yml
@@ -71,6 +71,17 @@ parameters:
     type: boolean
     default: false
 
+  # Ref used when invoking `workflow_dispatch` against release-github-tasks.yml.
+  # GitHub loads the workflow file *from this ref*, so it controls which version
+  # of the workflow runs. The branch/commit being released is passed separately
+  # via the `release_branch` and `commit_sha` workflow inputs, so this ref only
+  # affects the workflow source — not what gets tagged or released. Defaults to
+  # 'main' so workflow fixes don't require backporting to every release branch.
+  - name: GitHubTasksWorkflowRef
+    displayName: 'Ref to dispatch release-github-tasks.yml from (workflow source only)'
+    type: string
+    default: 'main'
+
 variables:
   - template: /eng/pipelines/common-variables.yml@self
   - template: /eng/common/templates-official/variables/pool-providers.yml@self
@@ -712,7 +723,7 @@ extends:
                     -Owner         'microsoft' `
                     -Repo          'aspire' `
                     -WorkflowFile  'release-github-tasks.yml' `
-                    -Ref           "$(ReleaseBranchDerived)" `
+                    -Ref           '${{ parameters.GitHubTasksWorkflowRef }}' `
                     -Inputs        $inputs
                 displayName: 'Dispatch release-github-tasks and wait'
                 env:


### PR DESCRIPTION
Follow-up to #17073.

## Problem

The first chained release dispatch failed at the `authorize` step with `User permission level: none` ([failed run](https://github.com/microsoft/aspire/actions/runs/25930365885/job/76222402634)).

Root cause: the AzDO pipeline dispatched `release-github-tasks.yml` against `release/13.3`, and `workflow_dispatch` loads the workflow file *from the ref you pass it*. `release/13.3` was cut before #17073 merged, so the executing copy of the workflow had the pre-bot-bypass authorize step — which calls `repos/.../collaborators/<bot>/permission` and gets back `none` because GitHub App bots are not collaborators.

## Fix

Make the dispatch ref a pipeline parameter, defaulted to `main`:

- Workflow source is always taken from the latest `main` (no need to backport every workflow tweak to every active release branch).
- The release branch and signed commit are still passed via the `release_branch` / `commit_sha` workflow inputs — what gets tagged and released is unchanged.
- The new `GitHubTasksWorkflowRef` parameter lets a release manager override the ref when testing pipeline changes on a topic branch.

The workflow doesn't reference `github.ref`, `github.sha`, or `github.ref_name` anywhere, so switching the source ref away from the release branch is safe.

## Test plan

After this merges, re-run the AzDO release pipeline for 13.3 (with `SkipNuGetPublish=true`, `SkipChannelPromotion=true`, etc. — keeping `SkipGitHubTasks=false`). The dispatched workflow will now load from `main` and hit the bot-bypass branch in the authorize step.