### PR TITLE
Hardcode GaChannelName and fix release pipeline docs

### DIFF
--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -6,7 +6,7 @@ This document describes the release process for microsoft/aspire, including both
 
 The Aspire release process involves two main automation components:
 
-1. **Azure DevOps Pipeline** (`eng/pipelines/release-publish-nuget.yml`)
+1. **Azure DevOps Pipeline** (`microsoft-aspire-Release-To-NuGet`, defined in `eng/pipelines/release-publish-nuget.yml`)
    - Publishes NuGet packages to NuGet.org
    - Promotes the build to the GA channel via darc
 
@@ -22,7 +22,6 @@ Before starting a release:
 
 1. **Signed Build**: Have a successful signed build from the official `dotnet-aspire` pipeline
    - The build will be selected from a dropdown when running the release pipeline
-   - The build should have a `BAR ID - NNNNNN` tag (auto-extracted by the pipeline)
 
 2. **Release Branch**: Ensure the release branch exists (e.g., `release/9.2`)
 
@@ -34,7 +33,7 @@ Before starting a release:
 
 ### Step 1: Publish NuGet Packages (Azure DevOps)
 
-1. Navigate to the Azure DevOps pipeline: `release-publish-nuget`
+1. Navigate to the Azure DevOps pipeline: `microsoft-aspire-Release-To-NuGet`
 2. Click "Run pipeline"
 3. Under **Resources**, select the source build from the `aspire-build` dropdown
    - This shows recent builds from the `dotnet-aspire` pipeline
@@ -43,7 +42,6 @@ Before starting a release:
 
    | Parameter | Description | Example |
    |-----------|-------------|---------|
-   | `GaChannelName` | Target GA channel | `Aspire 9.x GA` |
    | `DryRun` | Set `true` to test without publishing | `false` |
    | `SkipNuGetPublish` | Set `true` if re-running after NuGet success | `false` |
    | `SkipChannelPromotion` | Set `true` if re-running after darc success | `false` |
@@ -195,11 +193,11 @@ The workflow checks for existing PRs before creating. If a PR exists with a diff
 │                                                                         │
 │  ┌──────────────────────────────────────────────────────────────────┐   │
 │  │                    Azure DevOps Pipeline                         │   │
-│  │                release-publish-nuget.yml                         │   │
+│  │                microsoft-aspire-Release-To-NuGet                  │   │
+│  │                (release-publish-nuget.yml)                       │   │
 │  │          (1ES.Official.PipelineTemplate.yml)                     │   │
 │  │                                                                  │   │
 │  │  Resource: aspire-build (select from dropdown)                   │   │
-│  │  Input: GaChannelName                                            │   │
 │  │                                                                  │   │
 │  │  ┌─────────────┐   ┌──────────────┐   ┌──────────────────────┐   │   │
 │  │  │  Validate   │──▶│ Extract BAR  │──▶│  Download & Verify   │   │   │

--- a/eng/pipelines/release-publish-nuget.yml
+++ b/eng/pipelines/release-publish-nuget.yml
@@ -12,11 +12,6 @@ trigger: none  # Manual trigger only
 pr: none       # Not triggered by PRs
 
 parameters:
-  - name: GaChannelName
-    displayName: 'GA Channel Name'
-    type: string
-    default: 'Aspire 9.x GA'
-
   - name: DryRun
     displayName: 'Dry Run (skip actual publish - for testing)'
     type: boolean
@@ -44,6 +39,9 @@ parameters:
     default: false
 
 variables:
+  # The GA channel name is tied to the .NET runtime version (9.x), not the Aspire package version.
+  - name: GaChannelName
+    value: 'Aspire 9.x GA'
   - template: /eng/pipelines/common-variables.yml@self
   - template: /eng/common/templates-official/variables/pool-providers.yml@self
   # Variable group containing secrets (VscePublishToken for future use)
@@ -253,7 +251,7 @@ extends:
                   Write-Host "Source Build ID: $(resources.pipeline.aspire-build.runID)"
                   Write-Host "Source Build Name: $(resources.pipeline.aspire-build.runName)"
                   Write-Host "Source Build URI: $(resources.pipeline.aspire-build.runURI)"
-                  Write-Host "GA Channel: ${{ parameters.GaChannelName }}"
+                  Write-Host "GA Channel: $(GaChannelName)"
                   Write-Host "Dry Run: ${{ parameters.DryRun }}"
                   Write-Host "Skip NuGet Publish: ${{ parameters.SkipNuGetPublish }}"
                   Write-Host "Skip Channel Promotion: ${{ parameters.SkipChannelPromotion }}"
@@ -443,7 +441,7 @@ extends:
                     scriptLocation: 'inlineScript'
                     inlineScript: |
                       $barBuildId = "$(BarBuildId)"
-                      $channelName = "${{ parameters.GaChannelName }}"
+                      $channelName = "$(GaChannelName)"
                       $dryRun = [System.Convert]::ToBoolean("${{ parameters.DryRun }}")
                       $azdoToken = $env:SYSTEM_ACCESSTOKEN
 
@@ -490,7 +488,7 @@ extends:
                   } else {
                     Write-Host "║ BAR Build ID:   $(BarBuildId)"
                   }
-                  Write-Host "║ GA Channel:     ${{ parameters.GaChannelName }}"
+                  Write-Host "║ GA Channel:     $(GaChannelName)"
                   Write-Host "║ Dry Run:        ${{ parameters.DryRun }}"
                   Write-Host "╠═══════════════════════════════════════════════════════════════╣"
                   Write-Host "║ NuGet Publish:  ${{ parameters.SkipNuGetPublish }}" -NoNewline


### PR DESCRIPTION
The `GaChannelName` parameter in the release pipeline was exposed as a user-facing input, but it should always be `Aspire 9.x GA` -- the channel name reflects the .NET runtime version, not the Aspire package version. This was confusing and error-prone (e.g., someone might assume it should be `Aspire 13.x GA` for a 13.x release).

Changes:
- **Hardcode `GaChannelName`** as a pipeline variable instead of a parameter in `release-publish-nuget.yml`, with a comment explaining why it's tied to the runtime version
- **Fix pipeline name references** in `release-process.md` -- the actual AzDO pipeline is named `microsoft-aspire-Release-To-NuGet`, not `release-publish-nuget`
- **Remove outdated prerequisite** about manually verifying BAR ID tags, which are calculated automatically by the pipeline