### PR TITLE
Skip flaky test on Windows: ExpectedNumberOfUrlsForReplicatedResource

### DIFF
--- a/tests/Aspire.Hosting.Tests/WithUrlsTests.cs
+++ b/tests/Aspire.Hosting.Tests/WithUrlsTests.cs
@@ -4,7 +4,6 @@
 using Aspire.Hosting.Dashboard;
 using Aspire.Hosting.Eventing;
 using Aspire.Hosting.Utils;
-using Aspire.TestUtilities;
 using Microsoft.AspNetCore.InternalTesting;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
@@ -422,7 +421,7 @@ public class WithUrlsTests(ITestOutputHelper testOutputHelper)
     }
 
     [Fact]
-    [ActiveIssue("https://github.com/microsoft/aspire/issues/17136", typeof(Microsoft.AspNetCore.InternalTesting.PlatformDetection), nameof(Microsoft.AspNetCore.InternalTesting.PlatformDetection.IsWindows))]
+    [ActiveIssue("https://github.com/microsoft/aspire/issues/17136", typeof(global::Aspire.TestUtilities.PlatformDetection), nameof(global::Aspire.TestUtilities.PlatformDetection.IsWindows))]
     public async Task ExpectedNumberOfUrlsForReplicatedResource()
     {
         // This test creates a single project resource with a custom URL and

--- a/tests/Aspire.Hosting.Tests/WithUrlsTests.cs
+++ b/tests/Aspire.Hosting.Tests/WithUrlsTests.cs
@@ -8,6 +8,7 @@ using Microsoft.AspNetCore.InternalTesting;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
+using PlatformDetection = Aspire.TestUtilities.PlatformDetection;
 
 namespace Aspire.Hosting.Tests;
 
@@ -421,7 +422,7 @@ public class WithUrlsTests(ITestOutputHelper testOutputHelper)
     }
 
     [Fact]
-    [ActiveIssue("https://github.com/microsoft/aspire/issues/17136", typeof(global::Aspire.TestUtilities.PlatformDetection), nameof(global::Aspire.TestUtilities.PlatformDetection.IsWindows))]
+    [ActiveIssue("https://github.com/microsoft/aspire/issues/17136", typeof(PlatformDetection), nameof(PlatformDetection.IsWindows))]
     public async Task ExpectedNumberOfUrlsForReplicatedResource()
     {
         // This test creates a single project resource with a custom URL and

--- a/tests/Aspire.Hosting.Tests/WithUrlsTests.cs
+++ b/tests/Aspire.Hosting.Tests/WithUrlsTests.cs
@@ -4,6 +4,7 @@
 using Aspire.Hosting.Dashboard;
 using Aspire.Hosting.Eventing;
 using Aspire.Hosting.Utils;
+using Aspire.TestUtilities;
 using Microsoft.AspNetCore.InternalTesting;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
@@ -421,6 +422,7 @@ public class WithUrlsTests(ITestOutputHelper testOutputHelper)
     }
 
     [Fact]
+    [ActiveIssue("https://github.com/microsoft/aspire/issues/17136", typeof(PlatformDetection), nameof(PlatformDetection.IsWindows))]
     public async Task ExpectedNumberOfUrlsForReplicatedResource()
     {
         // This test creates a single project resource with a custom URL and

--- a/tests/Aspire.Hosting.Tests/WithUrlsTests.cs
+++ b/tests/Aspire.Hosting.Tests/WithUrlsTests.cs
@@ -422,7 +422,7 @@ public class WithUrlsTests(ITestOutputHelper testOutputHelper)
     }
 
     [Fact]
-    [ActiveIssue("https://github.com/microsoft/aspire/issues/17136", typeof(PlatformDetection), nameof(PlatformDetection.IsWindows))]
+    [ActiveIssue("https://github.com/microsoft/aspire/issues/17136", typeof(Microsoft.AspNetCore.InternalTesting.PlatformDetection), nameof(Microsoft.AspNetCore.InternalTesting.PlatformDetection.IsWindows))]
     public async Task ExpectedNumberOfUrlsForReplicatedResource()
     {
         // This test creates a single project resource with a custom URL and


### PR DESCRIPTION
## Summary

This PR temporarily skips `Aspire.Hosting.Tests.WithUrlsTests.ExpectedNumberOfUrlsForReplicatedResource` on Windows by adding an `[ActiveIssue]` attribute scoped with `PlatformDetection.IsWindows`.

The suspected root cause is tracked by #17136. A DCP-side fix is in progress for shutdown ordering so controller children stop before API/log teardown and resource log release; this PR keeps the Aspire-side mitigation narrow until that fix lands and is validated.

## Changes

- Added a Windows-only `[ActiveIssue]` attribute referencing #17136
- Left non-Windows test execution unchanged
- Avoided broader quarantine or suppression of neighboring tests

## Verification

- `./restore.sh`
- `./.dotnet/dotnet build tests/Aspire.Hosting.Tests/Aspire.Hosting.Tests.csproj --no-restore -v:minimal`
- `./.dotnet/dotnet test --project tests/Aspire.Hosting.Tests/Aspire.Hosting.Tests.csproj --no-build --no-launch-profile -- --filter-method "*.ExpectedNumberOfUrlsForReplicatedResource" --filter-not-trait "quarantined=true" --filter-not-trait "outerloop=true"`

## Related Issue

Addresses #17136

---

**Note:** This PR does not close the related issue. The skip should be removed once the DCP-side shutdown fix lands and the Windows CI flake is resolved. https://github.com/microsoft/dcp/pull/155