### PR TITLE
Fix PR acquisition script feedback

### DIFF
--- a/eng/scripts/get-aspire-cli-pr.ps1
+++ b/eng/scripts/get-aspire-cli-pr.ps1
@@ -682,14 +682,13 @@ function Update-PathEnvironment {
 
     if (Test-PathContainsDirectory -PathValue $env:PATH -Directory $CliBinDir) {
         Write-Message "Path $CliBinDir already exists in PATH, skipping addition" -Level Info
-        return
-    }
-
-    # Update current session PATH
-    $currentPathArray = $env:PATH.Split($pathSeparator, [StringSplitOptions]::RemoveEmptyEntries)
-    if ($PSCmdlet.ShouldProcess("PATH environment variable", "Add $CliBinDir to current session")) {
-        $env:PATH = (@($CliBinDir) + $currentPathArray) -join $pathSeparator
-        Write-Message "Added $CliBinDir to PATH for current session" -Level Info
+    } else {
+        # Update current session PATH
+        $currentPathArray = if ($env:PATH) { $env:PATH.Split($pathSeparator, [StringSplitOptions]::RemoveEmptyEntries) } else { @() }
+        if ($PSCmdlet.ShouldProcess("PATH environment variable", "Add $CliBinDir to current session")) {
+            $env:PATH = (@($CliBinDir) + $currentPathArray) -join $pathSeparator
+            Write-Message "Added $CliBinDir to PATH for current session" -Level Info
+        }
     }
 
     # Update persistent PATH for Windows
@@ -1822,6 +1821,12 @@ OPTIONS:
     if ($InstallMode -eq 'Tool' -and $HiveOnly) {
         Write-Message "Error: -HiveOnly cannot be combined with -InstallMode Tool: -HiveOnly skips the CLI install, but -InstallMode Tool installs Aspire.Cli as a .NET tool." -Level Error
         Write-Message "Drop one of the two flags. Both archive and tool modes populate the hive." -Level Info
+        if ($InvokedFromFile) { exit 1 } else { return 1 }
+    }
+
+    if ($InstallMode -ne 'Tool' -and $Force) {
+        Write-Message "Error: -Force can only be combined with -InstallMode Tool: archive mode installs from downloaded binaries and does not use dotnet tool update." -Level Error
+        Write-Message "Use -InstallMode Tool with -Force, or drop -Force." -Level Info
         if ($InvokedFromFile) { exit 1 } else { return 1 }
     }
 

--- a/eng/scripts/get-aspire-cli-pr.sh
+++ b/eng/scripts/get-aspire-cli-pr.sh
@@ -1587,6 +1587,12 @@ main() {
         exit 1
     fi
 
+    if [[ "$INSTALL_MODE" != "tool" && "$FORCE" == true ]]; then
+        say_error "--force can only be combined with --install-mode tool: archive mode installs from downloaded binaries and does not use dotnet tool update."
+        say_info "Use --install-mode tool with --force, or drop --force."
+        exit 1
+    fi
+
     if [[ "$INSTALL_MODE" == "tool" ]]; then
         if ! validate_tool_mode_runtime_identifier; then
             exit 1

--- a/tests/Aspire.Acquisition.Tests/Scripts/Common/TestEnvironment.cs
+++ b/tests/Aspire.Acquisition.Tests/Scripts/Common/TestEnvironment.cs
@@ -110,11 +110,11 @@ public sealed class TestEnvironment : IDisposable
                 )
                 echo "%ENDPOINT%" | findstr /C:"/actions/workflows/" >nul 2>&1
                 if not errorlevel 1 (
-                    if "%HAS_JQ%"=="true" (
-                        echo 987654321
-                    ) else (
-                        echo {"workflow_runs":[{"id":987654321,"conclusion":"success"}]}
-                    )
+                    rem Workflow-run endpoints include '&' query separators. When PowerShell
+                    rem invokes this .cmd shim, cmd.exe treats those as command separators before
+                    rem this script can see later arguments like --jq, so this endpoint must keep
+                    rem returning the scalar value used by the scripts' --jq path.
+                    echo 987654321
                     exit 0
                 )
                 echo {}

--- a/tests/Aspire.Acquisition.Tests/Scripts/Common/TestEnvironment.cs
+++ b/tests/Aspire.Acquisition.Tests/Scripts/Common/TestEnvironment.cs
@@ -91,23 +91,30 @@ public sealed class TestEnvironment : IDisposable
                 goto :api_arg_loop
 
                 :api_args_done
-                if not "%HAS_JQ%"=="true" (
-                    echo {"_mock_missing_jq":true}
-                    exit 1
-                )
-
                 if "%ENDPOINT%"=="graphql" (
+                    if not "%HAS_JQ%"=="true" (
+                        echo {"_mock_missing_jq":true}
+                        exit 1
+                    )
                     echo abc123def456789012345678901234567890abcd
                     exit 0
                 )
                 echo "%ENDPOINT%" | findstr /C:"/pulls/" >nul 2>&1
                 if not errorlevel 1 (
+                    if not "%HAS_JQ%"=="true" (
+                        echo {"_mock_missing_jq":true}
+                        exit 1
+                    )
                     echo abc123def456789012345678901234567890abcd
                     exit 0
                 )
                 echo "%ENDPOINT%" | findstr /C:"/actions/workflows/" >nul 2>&1
                 if not errorlevel 1 (
-                    echo 987654321
+                    if "%HAS_JQ%"=="true" (
+                        echo 987654321
+                    ) else (
+                        echo {"workflow_runs":[{"id":987654321,"conclusion":"success"}]}
+                    )
                     exit 0
                 )
                 echo {}
@@ -228,20 +235,23 @@ public sealed class TestEnvironment : IDisposable
                         esac
                     done
 
-                    if [ -z "$jq_filter" ]; then
-                        echo '{"_mock_missing_jq":true}'
-                        exit 1
-                    fi
-
                     # PR head SHA lookup: repos/.../pulls/<number>
                     if echo "$endpoint" | grep -q "/pulls/"; then
+                        if [ -z "$jq_filter" ]; then
+                            echo '{"_mock_missing_jq":true}'
+                            exit 1
+                        fi
                         echo "abc123def456789012345678901234567890abcd"
                         exit 0
                     fi
 
                     # Workflow run lookup: repos/.../actions/workflows/...
                     if echo "$endpoint" | grep -q "/actions/workflows/"; then
-                        echo "987654321"
+                        if [ -n "$jq_filter" ]; then
+                            echo "987654321"
+                        else
+                            echo '{"workflow_runs":[{"id":987654321,"conclusion":"success"}]}'
+                        fi
                         exit 0
                     fi
 

--- a/tests/Aspire.Acquisition.Tests/Scripts/Common/TestEnvironment.cs
+++ b/tests/Aspire.Acquisition.Tests/Scripts/Common/TestEnvironment.cs
@@ -235,6 +235,15 @@ public sealed class TestEnvironment : IDisposable
                         esac
                     done
 
+                    if [ "$endpoint" = "graphql" ]; then
+                        if [ -z "$jq_filter" ]; then
+                            echo '{"_mock_missing_jq":true}'
+                            exit 1
+                        fi
+                        echo "abc123def456789012345678901234567890abcd"
+                        exit 0
+                    fi
+
                     # PR head SHA lookup: repos/.../pulls/<number>
                     if echo "$endpoint" | grep -q "/pulls/"; then
                         if [ -z "$jq_filter" ]; then

--- a/tests/Aspire.Acquisition.Tests/Scripts/Common/TestEnvironment.cs
+++ b/tests/Aspire.Acquisition.Tests/Scripts/Common/TestEnvironment.cs
@@ -74,10 +74,28 @@ public sealed class TestEnvironment : IDisposable
                 exit 0
 
                 :api
-                rem The scripts only use these mocked API calls with --jq, so return the scalar
-                rem values directly. Avoid parsing the jq expression because it can contain cmd
-                rem metacharacters such as pipes.
                 set "ENDPOINT=%~2"
+                shift
+                shift
+                set "HAS_JQ="
+                rem The scripts only use these mocked API calls with --jq. Scan only for the
+                rem flag and avoid parsing the jq expression because it can contain cmd
+                rem metacharacters such as pipes.
+                :api_arg_loop
+                if "%~1"=="" goto :api_args_done
+                if "%~1"=="--jq" (
+                    set "HAS_JQ=true"
+                    goto :api_args_done
+                )
+                shift
+                goto :api_arg_loop
+
+                :api_args_done
+                if not "%HAS_JQ%"=="true" (
+                    echo {"_mock_missing_jq":true}
+                    exit 1
+                )
+
                 if "%ENDPOINT%"=="graphql" (
                     echo abc123def456789012345678901234567890abcd
                     exit 0
@@ -210,23 +228,20 @@ public sealed class TestEnvironment : IDisposable
                         esac
                     done
 
+                    if [ -z "$jq_filter" ]; then
+                        echo '{"_mock_missing_jq":true}'
+                        exit 1
+                    fi
+
                     # PR head SHA lookup: repos/.../pulls/<number>
                     if echo "$endpoint" | grep -q "/pulls/"; then
-                        if [ -n "$jq_filter" ]; then
-                            echo "abc123def456789012345678901234567890abcd"
-                        else
-                            echo '{"head":{"sha":"abc123def456789012345678901234567890abcd"}}'
-                        fi
+                        echo "abc123def456789012345678901234567890abcd"
                         exit 0
                     fi
 
                     # Workflow run lookup: repos/.../actions/workflows/...
                     if echo "$endpoint" | grep -q "/actions/workflows/"; then
-                        if [ -n "$jq_filter" ]; then
-                            echo "987654321"
-                        else
-                            echo '{"workflow_runs":[{"id":987654321,"conclusion":"success"}]}'
-                        fi
+                        echo "987654321"
                         exit 0
                     fi
 

--- a/tests/Aspire.Acquisition.Tests/Scripts/Common/TestEnvironment.cs
+++ b/tests/Aspire.Acquisition.Tests/Scripts/Common/TestEnvironment.cs
@@ -256,11 +256,11 @@ public sealed class TestEnvironment : IDisposable
 
                     # Workflow run lookup: repos/.../actions/workflows/...
                     if echo "$endpoint" | grep -q "/actions/workflows/"; then
-                        if [ -n "$jq_filter" ]; then
-                            echo "987654321"
-                        else
-                            echo '{"workflow_runs":[{"id":987654321,"conclusion":"success"}]}'
+                        if [ -z "$jq_filter" ]; then
+                            echo '{"_mock_missing_jq":true}'
+                            exit 1
                         fi
+                        echo "987654321"
                         exit 0
                     fi
 

--- a/tests/Aspire.Acquisition.Tests/Scripts/PRScriptPSFunctionTests.cs
+++ b/tests/Aspire.Acquisition.Tests/Scripts/PRScriptPSFunctionTests.cs
@@ -77,6 +77,34 @@ public class PRScriptPSFunctionTests(ITestOutputHelper testOutput)
         Assert.Equal(expected, result.Output.Trim());
     }
 
+    [Fact]
+    public async Task UpdatePathEnvironment_WhenCurrentPathAlreadyContainsDirectory_StillUpdatesGitHubPath()
+    {
+        using var env = new TestEnvironment();
+        var cliBinDir = Path.Combine(env.TempDirectory, "cli-bin");
+        var existingPath = $"{cliBinDir}{Path.PathSeparator}{Path.Combine(env.TempDirectory, "other-bin")}";
+        var githubPath = Path.Combine(env.TempDirectory, "github-path.txt");
+
+        using var cmd = new ScriptFunctionCommand(
+            s_prScript,
+            $"""
+            $Script:HostOS = 'linux'
+            $env:PATH = '{existingPath}'
+            $env:GITHUB_ACTIONS = 'true'
+            $env:GITHUB_PATH = '{githubPath}'
+            Update-PathEnvironment -CliBinDir '{cliBinDir}'
+            Get-Content -LiteralPath '{githubPath}'
+            """,
+            env,
+            _testOutput);
+
+        var result = await cmd.ExecuteAsync();
+
+        result.EnsureSuccessful();
+        Assert.Contains("already exists in PATH", result.Output);
+        Assert.Contains(cliBinDir, result.Output);
+    }
+
     #endregion
 
     #region Get-VersionSuffixFromPackages

--- a/tests/Aspire.Acquisition.Tests/Scripts/PRScriptPSFunctionTests.cs
+++ b/tests/Aspire.Acquisition.Tests/Scripts/PRScriptPSFunctionTests.cs
@@ -93,7 +93,6 @@ public class PRScriptPSFunctionTests(ITestOutputHelper testOutput)
             $env:GITHUB_ACTIONS = 'true'
             $env:GITHUB_PATH = '{githubPath}'
             Update-PathEnvironment -CliBinDir '{cliBinDir}'
-            Get-Content -LiteralPath '{githubPath}'
             """,
             env,
             _testOutput);
@@ -102,7 +101,7 @@ public class PRScriptPSFunctionTests(ITestOutputHelper testOutput)
 
         result.EnsureSuccessful();
         Assert.Contains("already exists in PATH", result.Output);
-        Assert.Contains(cliBinDir, result.Output);
+        Assert.Contains(cliBinDir, await File.ReadAllLinesAsync(githubPath));
     }
 
     #endregion

--- a/tests/Aspire.Acquisition.Tests/Scripts/PRScriptPowerShellTests.cs
+++ b/tests/Aspire.Acquisition.Tests/Scripts/PRScriptPowerShellTests.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using Aspire.TestUtilities;
+using Aspire.Templates.Tests;
 using Xunit;
 
 namespace Aspire.Acquisition.Tests.Scripts;
@@ -90,6 +91,20 @@ public class PRScriptPowerShellTests(ITestOutputHelper testOutput)
 
         result.EnsureSuccessful();
         Assert.Contains("12345", result.Output);
+    }
+
+    [Fact]
+    public async Task MockGhApiWithoutJqFailsLoudly()
+    {
+        using var env = new TestEnvironment();
+        var mockBinPath = await env.CreateMockGhScriptAsync(_testOutput);
+        var mockGhPath = Path.Combine(mockBinPath, OperatingSystem.IsWindows() ? "gh.cmd" : "gh");
+        using var cmd = new ToolCommand(mockGhPath, _testOutput, "mock-gh");
+
+        var result = await cmd.ExecuteAsync("api", "repos/microsoft/aspire/pulls/12345");
+
+        Assert.NotEqual(0, result.ExitCode);
+        Assert.Contains("_mock_missing_jq", result.Output);
     }
 
     [Fact]

--- a/tests/Aspire.Acquisition.Tests/Scripts/PRScriptPowerShellTests.cs
+++ b/tests/Aspire.Acquisition.Tests/Scripts/PRScriptPowerShellTests.cs
@@ -108,6 +108,34 @@ public class PRScriptPowerShellTests(ITestOutputHelper testOutput)
     }
 
     [Fact]
+    public async Task MockGhApiGraphQlWithoutJqFailsLoudly()
+    {
+        using var env = new TestEnvironment();
+        var mockBinPath = await env.CreateMockGhScriptAsync(_testOutput);
+        var mockGhPath = Path.Combine(mockBinPath, OperatingSystem.IsWindows() ? "gh.cmd" : "gh");
+        using var cmd = new ToolCommand(mockGhPath, _testOutput, "mock-gh");
+
+        var result = await cmd.ExecuteAsync("api", "graphql");
+
+        Assert.NotEqual(0, result.ExitCode);
+        Assert.Contains("_mock_missing_jq", result.Output);
+    }
+
+    [Fact]
+    public async Task MockGhApiGraphQlWithJqReturnsHeadSha()
+    {
+        using var env = new TestEnvironment();
+        var mockBinPath = await env.CreateMockGhScriptAsync(_testOutput);
+        var mockGhPath = Path.Combine(mockBinPath, OperatingSystem.IsWindows() ? "gh.cmd" : "gh");
+        using var cmd = new ToolCommand(mockGhPath, _testOutput, "mock-gh");
+
+        var result = await cmd.ExecuteAsync("api", "graphql", "--jq", ".data.repository.pullRequest.headRefOid");
+
+        result.EnsureSuccessful();
+        Assert.Equal("abc123def456789012345678901234567890abcd", result.Output.Trim());
+    }
+
+    [Fact]
     public async Task CustomInstallPath_IsRecognized()
     {
         using var env = new TestEnvironment();

--- a/tests/Aspire.Acquisition.Tests/Scripts/PRScriptShellTests.cs
+++ b/tests/Aspire.Acquisition.Tests/Scripts/PRScriptShellTests.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using Aspire.Templates.Tests;
 using Microsoft.DotNet.XUnitExtensions;
 using Xunit;
 
@@ -81,6 +82,34 @@ public class PRScriptShellTests(ITestOutputHelper testOutput)
         result.EnsureSuccessful();
         Assert.Contains("12345", result.Output);
         Assert.Contains("[DRY RUN]", result.Output);
+    }
+
+    [Fact]
+    public async Task MockGhApiWorkflowWithoutJqFailsLoudly()
+    {
+        using var env = new TestEnvironment();
+        var mockBinPath = await env.CreateMockGhScriptAsync(_testOutput);
+        var mockGhPath = Path.Combine(mockBinPath, "gh");
+        using var cmd = new ToolCommand(mockGhPath, _testOutput, "mock-gh");
+
+        var result = await cmd.ExecuteAsync("api", "repos/microsoft/aspire/actions/workflows/ci.yml/runs?event=pull_request&head_sha=abc123");
+
+        Assert.NotEqual(0, result.ExitCode);
+        Assert.Contains("_mock_missing_jq", result.Output);
+    }
+
+    [Fact]
+    public async Task MockGhApiWorkflowWithJqReturnsRunId()
+    {
+        using var env = new TestEnvironment();
+        var mockBinPath = await env.CreateMockGhScriptAsync(_testOutput);
+        var mockGhPath = Path.Combine(mockBinPath, "gh");
+        using var cmd = new ToolCommand(mockGhPath, _testOutput, "mock-gh");
+
+        var result = await cmd.ExecuteAsync("api", "repos/microsoft/aspire/actions/workflows/ci.yml/runs?event=pull_request&head_sha=abc123", "--jq", ".workflow_runs[0].id");
+
+        result.EnsureSuccessful();
+        Assert.Equal("987654321", result.Output.Trim());
     }
 
     [Fact]

--- a/tests/Aspire.Acquisition.Tests/Scripts/PRScriptToolModeTests.cs
+++ b/tests/Aspire.Acquisition.Tests/Scripts/PRScriptToolModeTests.cs
@@ -361,6 +361,26 @@ public class PRScriptToolModeTests(ITestOutputHelper testOutput)
 
     [Fact]
     [SkipOnPlatform(TestPlatforms.Windows, "Bash script tests require bash shell")]
+    public async Task Bash_ArchiveMode_RejectsForce()
+    {
+        using var env = new TestEnvironment();
+        var localDir = Path.Combine(env.TempDirectory, "artifacts");
+        await CreateLocalDirWithAspireCliPackageAsync(localDir);
+
+        using var cmd = new ScriptToolCommand(ScriptPaths.PRShell, env, _testOutput);
+        var result = await cmd.ExecuteAsync(
+            "--local-dir", localDir,
+            "--force",
+            "--dry-run", "--skip-path");
+
+        Assert.NotEqual(0, result.ExitCode);
+        Assert.Contains("--force can only be combined with --install-mode tool", result.Output);
+        Assert.DoesNotContain("dotnet tool install --", result.Output);
+        Assert.DoesNotContain("dotnet tool update --", result.Output);
+    }
+
+    [Fact]
+    [SkipOnPlatform(TestPlatforms.Windows, "Bash script tests require bash shell")]
     public async Task Bash_ToolMode_InstallFailureSuggestsForce()
     {
         using var env = new TestEnvironment();
@@ -914,6 +934,26 @@ public class PRScriptToolModeTests(ITestOutputHelper testOutput)
         Assert.Contains("-HiveOnly cannot be combined with -InstallMode Tool", result.Output);
         Assert.DoesNotContain("dotnet tool install", result.Output);
         Assert.DoesNotContain("dotnet tool update", result.Output);
+    }
+
+    [Fact]
+    [RequiresTools(["pwsh"])]
+    public async Task Ps_ArchiveMode_RejectsForce()
+    {
+        using var env = new TestEnvironment();
+        var localDir = Path.Combine(env.TempDirectory, "artifacts");
+        await CreateLocalDirWithAspireCliPackageAsync(localDir);
+
+        using var cmd = new ScriptToolCommand(ScriptPaths.PRPowerShell, env, _testOutput);
+        var result = await cmd.ExecuteAsync(
+            "-LocalDir", localDir,
+            "-Force",
+            "-SkipPath", "-WhatIf");
+
+        Assert.NotEqual(0, result.ExitCode);
+        Assert.Contains("-Force can only be combined with -InstallMode Tool", result.Output);
+        Assert.DoesNotContain("dotnet tool install --", result.Output);
+        Assert.DoesNotContain("dotnet tool update --", result.Output);
     }
 
     [Fact]


### PR DESCRIPTION
## Description

Follow-up to https://github.com/microsoft/aspire/pull/16535 based on David Pine's review feedback.

This fixes the PR dogfooding acquisition scripts so:

- PowerShell PATH updates no longer return early when the install directory is already in the current process PATH; Windows User PATH persistence and GitHub Actions `GITHUB_PATH` updates still run.
- `--force` / `-Force` is rejected outside dotnet-tool install mode instead of being silently accepted and ignored in archive mode.
- Mocked `gh api` calls in acquisition tests fail loudly when `--jq` is omitted, matching the script contract and making future test refactors easier to diagnose.

Validation:

```bash
./restore.sh
dotnet test --project tests/Aspire.Acquisition.Tests/Aspire.Acquisition.Tests.csproj --no-launch-profile -- --filter-class "*.PRScriptToolModeTests" --filter-class "*.PRScriptPowerShellTests" --filter-class "*.PRScriptPSFunctionTests" --filter-not-trait "quarantined=true" --filter-not-trait "outerloop=true"
dotnet test --project tests/Aspire.Acquisition.Tests/Aspire.Acquisition.Tests.csproj --no-launch-profile -- --filter-not-trait "quarantined=true" --filter-not-trait "outerloop=true"
```

Fixes # (issue)

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
