### PR TITLE
docs(cli): fix staging/daily channel example in ScaffoldingService comment

### DIFF
--- a/src/Aspire.Cli/Scaffolding/ScaffoldingService.cs
+++ b/src/Aspire.Cli/Scaffolding/ScaffoldingService.cs
@@ -66,10 +66,10 @@ internal sealed class ScaffoldingService : IScaffoldingService
         // or NewCommand's identity-match against a registered Explicit channel — see
         // `CliTemplateFactory.EmptyTemplate.cs` for how `ScaffoldContext.Channel` is sourced).
         // Do NOT fall back to `CliExecutionContext.IdentityChannel`: an identity that isn't a
-        // registered channel (e.g. `daily` on a CLI without the staging feature flag, or `pr-<N>`
-        // on a machine without the matching hive) would otherwise pin a channel name that no
-        // PSM rule can satisfy. When unset, `PrebuiltAppHostServer` aggregates sources from
-        // every registered channel so `aspire add` / `aspire restore` still find the right
+        // registered channel (e.g. `staging` on a CLI without the staging feature flag, or
+        // `pr-<N>` on a machine without the matching hive) would otherwise pin a channel name
+        // that no PSM rule can satisfy. When unset, `PrebuiltAppHostServer` aggregates sources
+        // from every registered channel so `aspire add` / `aspire restore` still find the right
         // packages without a per-project pin.
         if (!string.IsNullOrEmpty(context.Channel))
         {


### PR DESCRIPTION
Follow-up to review feedback on #17120 (https://github.com/microsoft/aspire/pull/17120#discussion_r3251500523).

The comment in `ScaffoldingService.ScaffoldGuestLanguageAsync` used `daily` as the example of an identity that could pin a channel name without a matching PSM rule. That's inverted: in `PackagingService`, `daily` is registered unconditionally, while `staging` is the channel gated behind the staging feature flag. Updated the example to `staging` so the comment matches the actual channel-registration behavior.

Comment-only change, no behavior impact.