### PR TITLE
Add ATS nullable scalar support

### DIFF
--- a/src/Aspire.Hosting.CodeGeneration.Python/AtsPythonCodeGenerator.cs
+++ b/src/Aspire.Hosting.CodeGeneration.Python/AtsPythonCodeGenerator.cs
@@ -209,7 +209,7 @@ internal sealed class AtsPythonCodeGenerator : ICodeGenerator
             return wrapperClassName;
         }
 
-        return typeRef.Category switch
+        var mappedType = typeRef.Category switch
         {
             AtsTypeCategory.Primitive => MapPrimitiveType(typeRef.TypeId),
             AtsTypeCategory.Enum => MapEnumType(typeRef.TypeId),
@@ -225,6 +225,19 @@ internal sealed class AtsPythonCodeGenerator : ICodeGenerator
             AtsTypeCategory.Unknown => "typing.Any",  // Unknown types use 'Any' since they're not in the ATS universe
             _ => "typing.Any"  // Fallback for any unhandled categories
         };
+        return ApplyNullableType(typeRef, mappedType);
+    }
+
+    private static string ApplyNullableType(AtsTypeRef typeRef, string mappedType)
+    {
+        if (typeRef.IsNullable != true || typeRef.Category is not (AtsTypeCategory.Primitive or AtsTypeCategory.Enum))
+        {
+            return mappedType;
+        }
+
+        return typeRef.TypeId is AtsConstants.Void or AtsConstants.Any or AtsConstants.CancellationToken
+            ? mappedType
+            : $"{mappedType} | None";
     }
 
     /// <summary>

--- a/src/Aspire.Hosting.CodeGeneration.TypeScript/AtsTypeScriptCodeGenerator.cs
+++ b/src/Aspire.Hosting.CodeGeneration.TypeScript/AtsTypeScriptCodeGenerator.cs
@@ -208,7 +208,7 @@ internal sealed class AtsTypeScriptCodeGenerator : ICodeGenerator
             return GetInterfaceName(wrapperClassName);
         }
 
-        return typeRef.Category switch
+        var mappedType = typeRef.Category switch
         {
             AtsTypeCategory.Primitive => MapPrimitiveType(typeRef.TypeId),
             AtsTypeCategory.Enum => MapEnumType(typeRef.TypeId),
@@ -224,6 +224,19 @@ internal sealed class AtsTypeScriptCodeGenerator : ICodeGenerator
             AtsTypeCategory.Unknown => "any",  // Unknown types use 'any' since they're not in the ATS universe
             _ => "any"  // Fallback for any unhandled categories
         };
+        return ApplyNullableType(typeRef, mappedType);
+    }
+
+    private static string ApplyNullableType(AtsTypeRef typeRef, string mappedType)
+    {
+        if (typeRef.IsNullable != true || typeRef.Category is not (AtsTypeCategory.Primitive or AtsTypeCategory.Enum))
+        {
+            return mappedType;
+        }
+
+        return typeRef.TypeId is AtsConstants.Void or AtsConstants.Any or AtsConstants.CancellationToken
+            ? mappedType
+            : $"{mappedType} | null";
     }
 
     /// <summary>

--- a/src/Aspire.Hosting.RemoteHost/AtsCapabilityScanner.cs
+++ b/src/Aspire.Hosting.RemoteHost/AtsCapabilityScanner.cs
@@ -1068,6 +1068,7 @@ public static class AtsCapabilityScanner
 
         // Collect public properties for the DTO interface
         var properties = new List<AtsDtoPropertyInfo>();
+        var nullabilityContext = new NullabilityInfoContext();
 
         foreach (var prop in type.GetProperties(BindingFlags.Public | BindingFlags.Instance))
         {
@@ -1090,6 +1091,7 @@ public static class AtsCapabilityScanner
             {
                 continue;
             }
+            propTypeRef = WithNullability(propTypeRef, prop.PropertyType, nullabilityContext.Create(prop).ReadState);
 
             IReadOnlyList<AtsCallbackParameterInfo>? callbackParameters = null;
             AtsTypeRef? callbackReturnType = null;
@@ -1100,7 +1102,7 @@ public static class AtsCapabilityScanner
 
             var propDocumentation = GetXmlDocumentation(prop);
             var propDescription = propDocumentation?.Summary;
-            var isOptional = !prop.CanWrite || Nullable.GetUnderlyingType(prop.PropertyType) is not null;
+            var isOptional = !prop.CanWrite || propTypeRef.IsNullable == true;
 
             properties.Add(new AtsDtoPropertyInfo
             {
@@ -1509,10 +1511,10 @@ public static class AtsCapabilityScanner
         var lastDot = fullName.LastIndexOf('.');
         var package = lastDot >= 0 ? fullName[..lastDot] : assemblyName;
 
-        // Check for ExposeProperties and ExposeMethods flags
         var typeExportAttr = assemblyExportAttr ?? GetAspireExportAttribute(contextType);
         var exposeAllProperties = typeExportAttr?.ExposeProperties == true || HasExposePropertiesAttribute(contextType);
         var exposeAllMethods = typeExportAttr?.ExposeMethods == true || HasExposeMethodsAttribute(contextType);
+        var nullabilityContext = new NullabilityInfoContext();
 
         // Scan properties
         foreach (var property in contextType.GetProperties(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance | BindingFlags.Static))
@@ -1612,6 +1614,9 @@ public static class AtsCapabilityScanner
                     // Skip properties with unmapped types
                     continue;
                 }
+                var propertyNullability = nullabilityContext.Create(property);
+                var getterTypeRef = WithNullability(propertyTypeRef!, propType, propertyNullability.ReadState);
+                var setterTypeRef = WithNullability(propertyTypeRef!, propType, propertyNullability.WriteState);
 
                 // Create type ref for the context type with full inheritance info
                 var contextTypeRef = CreateHandleTypeRef(contextType);
@@ -1649,7 +1654,7 @@ public static class AtsCapabilityScanner
                                 DefaultValue = null
                             }
                         ],
-                        ReturnType = propertyTypeRef!,
+                        ReturnType = getterTypeRef,
                         TargetTypeId = typeId,
                         TargetType = contextTypeRef,
                         TargetParameterName = "context",
@@ -1693,9 +1698,9 @@ public static class AtsCapabilityScanner
                             new AtsParameterInfo
                             {
                                 Name = "value",
-                                Type = propertyTypeRef!,
+                                Type = setterTypeRef,
                                 IsOptional = false,
-                                IsNullable = false,
+                                IsNullable = setterTypeRef.IsNullable == true,
                                 IsCallback = false,
                                 Documentation = propertyDocumentation,
                                 DefaultValue = null
@@ -2541,6 +2546,32 @@ public static class AtsCapabilityScanner
         TypeId = AtsConstants.Void,
         Category = AtsTypeCategory.Primitive
     };
+
+    private static AtsTypeRef WithNullability(AtsTypeRef typeRef, Type declaredType, NullabilityState nullabilityState)
+    {
+        var isNullable = nullabilityState == NullabilityState.Nullable ||
+            Nullable.GetUnderlyingType(declaredType) is not null;
+        if (!isNullable)
+        {
+            return typeRef;
+        }
+
+        return new AtsTypeRef
+        {
+            TypeId = typeRef.TypeId,
+            ClrType = typeRef.ClrType,
+            Category = typeRef.Category,
+            IsInterface = typeRef.IsInterface,
+            IsNullable = true,
+            ElementType = typeRef.ElementType,
+            KeyType = typeRef.KeyType,
+            ValueType = typeRef.ValueType,
+            IsReadOnly = typeRef.IsReadOnly,
+            UnionTypes = typeRef.UnionTypes,
+            ImplementedInterfaces = typeRef.ImplementedInterfaces,
+            BaseType = typeRef.BaseType
+        };
+    }
 
     /// <summary>
     /// Creates an AtsTypeRef from a CLR type, optionally collecting enum types.

--- a/src/Aspire.Hosting.RemoteHost/AtsCapabilityScanner.cs
+++ b/src/Aspire.Hosting.RemoteHost/AtsCapabilityScanner.cs
@@ -1102,7 +1102,7 @@ public static class AtsCapabilityScanner
 
             var propDocumentation = GetXmlDocumentation(prop);
             var propDescription = propDocumentation?.Summary;
-            var isOptional = !prop.CanWrite || propTypeRef.IsNullable == true;
+            var isOptional = !prop.CanWrite || Nullable.GetUnderlyingType(prop.PropertyType) is not null;
 
             properties.Add(new AtsDtoPropertyInfo
             {
@@ -1700,7 +1700,7 @@ public static class AtsCapabilityScanner
                                 Name = "value",
                                 Type = setterTypeRef,
                                 IsOptional = false,
-                                IsNullable = setterTypeRef.IsNullable == true,
+                                IsNullable = false,
                                 IsCallback = false,
                                 Documentation = propertyDocumentation,
                                 DefaultValue = null

--- a/src/Aspire.TypeSystem/AtsCapabilityInfo.cs
+++ b/src/Aspire.TypeSystem/AtsCapabilityInfo.cs
@@ -384,7 +384,6 @@ public sealed class AtsParameterInfo
     /// <summary>
     /// Gets or sets whether this parameter is nullable.
     /// </summary>
-    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
     public bool IsNullable { get; init; }
 
     /// <summary>

--- a/src/Aspire.TypeSystem/AtsCapabilityInfo.cs
+++ b/src/Aspire.TypeSystem/AtsCapabilityInfo.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Diagnostics.CodeAnalysis;
+using System.Text.Json.Serialization;
 
 namespace Aspire.TypeSystem;
 
@@ -33,6 +34,17 @@ public sealed class AtsTypeRef
     /// Only meaningful for Handle category types.
     /// </summary>
     public bool IsInterface { get; init; }
+
+    /// <summary>
+    /// Gets or sets whether this type reference accepts a JSON null value at its current use site.
+    /// </summary>
+    /// <remarks>
+    /// Nullability is attached to the type reference as it appears in a capability or DTO property.
+    /// Nested element, key, and value type nullability is only represented when those nested
+    /// references were scanned from member metadata that exposes nullability information.
+    /// </remarks>
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
+    public bool? IsNullable { get; init; }
 
     /// <summary>
     /// Gets or sets the element type reference for Array/List types.
@@ -370,6 +382,7 @@ public sealed class AtsParameterInfo
     /// <summary>
     /// Gets or sets whether this parameter is nullable.
     /// </summary>
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
     public bool IsNullable { get; init; }
 
     /// <summary>

--- a/src/Aspire.TypeSystem/AtsCapabilityInfo.cs
+++ b/src/Aspire.TypeSystem/AtsCapabilityInfo.cs
@@ -42,6 +42,8 @@ public sealed class AtsTypeRef
     /// Nullability is attached to the type reference as it appears in a capability or DTO property.
     /// Nested element, key, and value type nullability is only represented when those nested
     /// references were scanned from member metadata that exposes nullability information.
+    /// For example, a DTO property declared as <code>string?</code> produces a nullable string
+    /// type reference, while the same CLR <see cref="string" /> type on a non-nullable property does not.
     /// </remarks>
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
     public bool? IsNullable { get; init; }

--- a/tests/Aspire.Hosting.CodeGeneration.Python.Tests/AtsPythonCodeGeneratorTests.cs
+++ b/tests/Aspire.Hosting.CodeGeneration.Python.Tests/AtsPythonCodeGeneratorTests.cs
@@ -294,6 +294,22 @@ public class AtsPythonCodeGeneratorTests
     }
 
     [Fact]
+    public void GeneratedCode_NullableScalarProperties_GenerateNullableTypes()
+    {
+        var atsContext = CreateContextFromBothAssemblies();
+
+        var files = _generator.GenerateDistributedApplication(atsContext);
+        var aspirePy = files["aspire_app.py"];
+
+        Assert.Contains("OptionalField: str | None", aspirePy);
+        Assert.Contains("def description(self) -> str | None:", aspirePy);
+        Assert.Contains("def description(self, value: str | None) -> None:", aspirePy);
+        Assert.Contains("Name: str", aspirePy);
+        Assert.Contains("def name(self) -> str:", aspirePy);
+        Assert.Contains("def name(self, value: str) -> None:", aspirePy);
+    }
+
+    [Fact]
     public void GeneratedCode_SanitizesPythonKeywordIdentifiers()
     {
         var files = _generator.GenerateDistributedApplication(CreateContextWithKeywordParameter());

--- a/tests/Aspire.Hosting.CodeGeneration.Python.Tests/AtsPythonCodeGeneratorTests.cs
+++ b/tests/Aspire.Hosting.CodeGeneration.Python.Tests/AtsPythonCodeGeneratorTests.cs
@@ -294,22 +294,6 @@ public class AtsPythonCodeGeneratorTests
     }
 
     [Fact]
-    public void GeneratedCode_NullableScalarProperties_GenerateNullableTypes()
-    {
-        var atsContext = CreateContextFromBothAssemblies();
-
-        var files = _generator.GenerateDistributedApplication(atsContext);
-        var aspirePy = files["aspire_app.py"];
-
-        Assert.Contains("OptionalField: str | None", aspirePy);
-        Assert.Contains("def description(self) -> str | None:", aspirePy);
-        Assert.Contains("def description(self, value: str | None) -> None:", aspirePy);
-        Assert.Contains("Name: str", aspirePy);
-        Assert.Contains("def name(self) -> str:", aspirePy);
-        Assert.Contains("def name(self, value: str) -> None:", aspirePy);
-    }
-
-    [Fact]
     public void GeneratedCode_SanitizesPythonKeywordIdentifiers()
     {
         var files = _generator.GenerateDistributedApplication(CreateContextWithKeywordParameter());

--- a/tests/Aspire.Hosting.CodeGeneration.Python.Tests/Snapshots/AtsGeneratedAspire.verified.py
+++ b/tests/Aspire.Hosting.CodeGeneration.Python.Tests/Snapshots/AtsGeneratedAspire.verified.py
@@ -1,4 +1,4 @@
-﻿#   -------------------------------------------------------------
+#   -------------------------------------------------------------
 #   Copyright (c) Microsoft Corporation. All rights reserved.
 #   Licensed under the MIT License. See LICENSE in project root for information.
 #
@@ -1543,7 +1543,7 @@ class TestConfigDto(typing.TypedDict, total=False):
     Name: str
     Port: int
     Enabled: bool
-    OptionalField: str
+    OptionalField: str | None
 
 class TestDeeplyNestedDto(typing.TypedDict, total=False):
     NestedData: AspireDict[str, AspireList[TestConfigDto]]
@@ -1655,16 +1655,16 @@ class TestCallbackContext:
         return self._handle
 
     @_uncached_property
-    def name(self) -> str:
+    def name(self) -> str | None:
         """Gets the Name property"""
         result = self._client.invoke_capability(
             'Aspire.Hosting.CodeGeneration.TypeScript.Tests.TestTypes/TestCallbackContext.name',
             {'context': self._handle}
         )
-        return typing.cast(str, result)
+        return typing.cast(str | None, result)
 
     @name.setter
-    def name(self, value: str) -> None:
+    def name(self, value: str | None) -> None:
         """Sets the Name property"""
         self._client.invoke_capability(
             'Aspire.Hosting.CodeGeneration.TypeScript.Tests.TestTypes/TestCallbackContext.setName',
@@ -1764,16 +1764,16 @@ class TestEnvironmentContext:
         )
 
     @_uncached_property
-    def description(self) -> str:
+    def description(self) -> str | None:
         """Gets the Description property"""
         result = self._client.invoke_capability(
             'Aspire.Hosting.CodeGeneration.TypeScript.Tests.TestTypes/TestEnvironmentContext.description',
             {'context': self._handle}
         )
-        return typing.cast(str, result)
+        return typing.cast(str | None, result)
 
     @description.setter
-    def description(self, value: str) -> None:
+    def description(self, value: str | None) -> None:
         """Sets the Description property"""
         self._client.invoke_capability(
             'Aspire.Hosting.CodeGeneration.TypeScript.Tests.TestTypes/TestEnvironmentContext.setDescription',

--- a/tests/Aspire.Hosting.CodeGeneration.Python.Tests/Snapshots/TwoPassScanningGeneratedAspire.verified.py
+++ b/tests/Aspire.Hosting.CodeGeneration.Python.Tests/Snapshots/TwoPassScanningGeneratedAspire.verified.py
@@ -1713,7 +1713,7 @@ class DataVolumeParameters(typing.TypedDict, total=False):
 
 class AddContainerOptions(typing.TypedDict, total=False):
     Image: str
-    Tag: str
+    Tag: str | None
 
 class CertificateTrustExecutionConfigurationContext(typing.TypedDict, total=False):
     CertificateBundlePath: ReferenceExpression
@@ -1727,14 +1727,14 @@ class CertificateTrustExecutionConfigurationExportData(typing.TypedDict, total=F
     CustomBundlePaths: typing.Iterable[str]
 
 class CommandOptions(typing.TypedDict, total=False):
-    Description: str
+    Description: str | None
     Parameter: typing.Any
     Arguments: typing.Iterable[InteractionInput]
     ValidateArguments: typing.Callable
     Visibility: ResourceCommandVisibility
-    ConfirmationMessage: str
-    IconName: str
-    IconVariant: IconVariant
+    ConfirmationMessage: str | None
+    IconName: str | None
+    IconVariant: IconVariant | None
     IsHighlighted: bool
     UpdateState: typing.Callable
 
@@ -1745,19 +1745,19 @@ class CommandResultData(typing.TypedDict, total=False):
 
 class CreateBuilderOptions(typing.TypedDict, total=False):
     Args: typing.Iterable[str]
-    ProjectDirectory: str
-    AppHostFilePath: str
-    ContainerRegistryOverride: str
+    ProjectDirectory: str | None
+    AppHostFilePath: str | None
+    ContainerRegistryOverride: str | None
     DisableDashboard: bool
-    DashboardApplicationName: str
+    DashboardApplicationName: str | None
     AllowUnsecuredTransport: bool
     EnableResourceLogging: bool
 
 class ExecuteCommandResult(typing.TypedDict, total=False):
     Success: bool
     Canceled: bool
-    ErrorMessage: str
-    Message: str
+    ErrorMessage: str | None
+    Message: str | None
     Data: CommandResultData
 
 class GenerateParameterDefault(typing.TypedDict, total=False):
@@ -1772,14 +1772,14 @@ class GenerateParameterDefault(typing.TypedDict, total=False):
     MinSpecial: int
 
 class HttpCommandExportOptions(typing.TypedDict, total=False):
-    Description: str
-    ConfirmationMessage: str
-    IconName: str
-    IconVariant: IconVariant
+    Description: str | None
+    ConfirmationMessage: str | None
+    IconName: str | None
+    IconVariant: IconVariant | None
     IsHighlighted: bool
-    CommandName: str
-    EndpointName: str
-    MethodName: str
+    CommandName: str | None
+    EndpointName: str | None
+    MethodName: str | None
     ResultMode: HttpCommandResultMode
 
 class HttpsCertificateExecutionConfigurationContext(typing.TypedDict, total=False):
@@ -1789,60 +1789,60 @@ class HttpsCertificateExecutionConfigurationContext(typing.TypedDict, total=Fals
 
 class HttpsCertificateExecutionConfigurationExportData(typing.TypedDict, total=False):
     Subject: str
-    Thumbprint: str
+    Thumbprint: str | None
     KeyPathExpression: str
     PfxPathExpression: str
     IsKeyPathReferenced: bool
     IsPfxPathReferenced: bool
-    Password: str
+    Password: str | None
 
 class HttpsCertificateInfo(typing.TypedDict, total=False):
     Subject: str
     Issuer: str
-    Thumbprint: str
+    Thumbprint: str | None
 
 class InteractionInput(typing.TypedDict, total=False):
     Name: str
-    Label: str
-    Description: str
+    Label: str | None
+    Description: str | None
     EnableDescriptionMarkdown: bool
     InputType: InputType
     Required: bool
     Options: typing.Iterable[typing.Any]
     DynamicLoading: typing.Any
-    Value: str
-    Placeholder: str
+    Value: str | None
+    Placeholder: str | None
     AllowCustomChoice: bool
     Disabled: bool
-    MaxLength: int
+    MaxLength: int | None
 
 class ProcessCommandExportOptions(typing.TypedDict, total=False):
-    ExecutablePath: str
+    ExecutablePath: str | None
     Arguments: typing.Iterable[str]
-    WorkingDirectory: str
+    WorkingDirectory: str | None
     EnvironmentVariables: typing.Mapping[str, str]
-    InheritEnvironmentVariables: bool
-    StandardInputContent: str
-    KillEntireProcessTree: bool
+    InheritEnvironmentVariables: bool | None
+    StandardInputContent: str | None
+    KillEntireProcessTree: bool | None
     CommandOptions: CommandOptions
-    MaxOutputLineCount: int
-    DisplayImmediately: bool
+    MaxOutputLineCount: int | None
+    DisplayImmediately: bool | None
     SuccessExitCodes: typing.Iterable[int]
 
 class ProcessCommandResultExportOptions(typing.TypedDict, total=False):
     CommandOptions: CommandOptions
-    MaxOutputLineCount: int
-    DisplayImmediately: bool
+    MaxOutputLineCount: int | None
+    DisplayImmediately: bool | None
     SuccessExitCodes: typing.Iterable[int]
 
 class ProcessCommandSpecExportData(typing.TypedDict, total=False):
-    ExecutablePath: str
+    ExecutablePath: str | None
     Arguments: typing.Iterable[str]
-    WorkingDirectory: str
+    WorkingDirectory: str | None
     EnvironmentVariables: typing.Mapping[str, str]
-    InheritEnvironmentVariables: bool
-    StandardInputContent: str
-    KillEntireProcessTree: bool
+    InheritEnvironmentVariables: bool | None
+    StandardInputContent: str | None
+    KillEntireProcessTree: bool | None
 
 class ReferenceEnvironmentInjectionOptions(typing.TypedDict, total=False):
     ConnectionString: bool
@@ -1853,14 +1853,14 @@ class ReferenceEnvironmentInjectionOptions(typing.TypedDict, total=False):
 class ResourceEventDto(typing.TypedDict, total=False):
     ResourceName: str
     ResourceId: str
-    State: str
-    StateStyle: str
-    HealthStatus: str
-    ExitCode: int
+    State: str | None
+    StateStyle: str | None
+    HealthStatus: str | None
+    ExitCode: int | None
 
 class ResourceUrlAnnotation(typing.TypedDict, total=False):
     Url: str
-    DisplayText: str
+    DisplayText: str | None
     Endpoint: EndpointReference
     DisplayLocation: UrlDisplayLocation
 
@@ -1868,7 +1868,7 @@ class TestConfigDto(typing.TypedDict, total=False):
     Name: str
     Port: int
     Enabled: bool
-    OptionalField: str
+    OptionalField: str | None
 
 class TestDeeplyNestedDto(typing.TypedDict, total=False):
     NestedData: AspireDict[str, AspireList[TestConfigDto]]
@@ -3465,16 +3465,16 @@ class ContainerImagePushOptions:
         return self._handle
 
     @_uncached_property
-    def remote_image_name(self) -> str:
+    def remote_image_name(self) -> str | None:
         """Gets the RemoteImageName property"""
         result = self._client.invoke_capability(
             'Aspire.Hosting.ApplicationModel/ContainerImagePushOptions.remoteImageName',
             {'context': self._handle}
         )
-        return typing.cast(str, result)
+        return typing.cast(str | None, result)
 
     @remote_image_name.setter
-    def remote_image_name(self, value: str) -> None:
+    def remote_image_name(self, value: str | None) -> None:
         """Sets the RemoteImageName property"""
         self._client.invoke_capability(
             'Aspire.Hosting.ApplicationModel/ContainerImagePushOptions.setRemoteImageName',
@@ -3482,16 +3482,16 @@ class ContainerImagePushOptions:
         )
 
     @_uncached_property
-    def remote_image_tag(self) -> str:
+    def remote_image_tag(self) -> str | None:
         """Gets the RemoteImageTag property"""
         result = self._client.invoke_capability(
             'Aspire.Hosting.ApplicationModel/ContainerImagePushOptions.remoteImageTag',
             {'context': self._handle}
         )
-        return typing.cast(str, result)
+        return typing.cast(str | None, result)
 
     @remote_image_tag.setter
-    def remote_image_tag(self, value: str) -> None:
+    def remote_image_tag(self, value: str | None) -> None:
         """Sets the RemoteImageTag property"""
         self._client.invoke_capability(
             'Aspire.Hosting.ApplicationModel/ContainerImagePushOptions.setRemoteImageTag',
@@ -4113,13 +4113,13 @@ class EndpointReference:
         return typing.cast(str, result)
 
     @_cached_property
-    def error_message(self) -> str:
+    def error_message(self) -> str | None:
         """Gets the ErrorMessage property"""
         result = self._client.invoke_capability(
             'Aspire.Hosting.ApplicationModel/EndpointReference.errorMessage',
             {'context': self._handle}
         )
-        return typing.cast(str, result)
+        return typing.cast(str | None, result)
 
     @_cached_property
     def is_allocated(self) -> bool:
@@ -4194,13 +4194,13 @@ class EndpointReference:
         return typing.cast(int, result)
 
     @_cached_property
-    def target_port(self) -> int:
+    def target_port(self) -> int | None:
         """Gets the TargetPort property"""
         result = self._client.invoke_capability(
             'Aspire.Hosting.ApplicationModel/EndpointReference.targetPort',
             {'context': self._handle}
         )
-        return typing.cast(int, result)
+        return typing.cast(int | None, result)
 
     @_cached_property
     def host(self) -> str:
@@ -4347,16 +4347,16 @@ class EndpointUpdateContext:
         )
 
     @_uncached_property
-    def port(self) -> int:
+    def port(self) -> int | None:
         """Gets the Port property"""
         result = self._client.invoke_capability(
             'Aspire.Hosting.ApplicationModel/EndpointUpdateContext.port',
             {'context': self._handle}
         )
-        return typing.cast(int, result)
+        return typing.cast(int | None, result)
 
     @port.setter
-    def port(self, value: int) -> None:
+    def port(self, value: int | None) -> None:
         """Sets the Port property"""
         self._client.invoke_capability(
             'Aspire.Hosting.ApplicationModel/EndpointUpdateContext.setPort',
@@ -4364,16 +4364,16 @@ class EndpointUpdateContext:
         )
 
     @_uncached_property
-    def target_port(self) -> int:
+    def target_port(self) -> int | None:
         """Gets the TargetPort property"""
         result = self._client.invoke_capability(
             'Aspire.Hosting.ApplicationModel/EndpointUpdateContext.targetPort',
             {'context': self._handle}
         )
-        return typing.cast(int, result)
+        return typing.cast(int | None, result)
 
     @target_port.setter
-    def target_port(self, value: int) -> None:
+    def target_port(self, value: int | None) -> None:
         """Sets the TargetPort property"""
         self._client.invoke_capability(
             'Aspire.Hosting.ApplicationModel/EndpointUpdateContext.setTargetPort',
@@ -5065,13 +5065,13 @@ class PipelineStep:
         return typing.cast(str, result)
 
     @_cached_property
-    def description(self) -> str:
+    def description(self) -> str | None:
         """Gets the human-readable description of the step"""
         result = self._client.invoke_capability(
             'Aspire.Hosting.Pipelines/PipelineStep.description',
             {'context': self._handle}
         )
-        return typing.cast(str, result)
+        return typing.cast(str | None, result)
 
     def depends_on(self, step_name: str) -> None:
         """Adds a dependency on another step by name"""
@@ -5274,16 +5274,16 @@ class ProjectResourceOptions:
         return self._handle
 
     @_uncached_property
-    def launch_profile_name(self) -> str:
+    def launch_profile_name(self) -> str | None:
         """Gets the LaunchProfileName property"""
         result = self._client.invoke_capability(
             'Aspire.Hosting/ProjectResourceOptions.launchProfileName',
             {'context': self._handle}
         )
-        return typing.cast(str, result)
+        return typing.cast(str | None, result)
 
     @launch_profile_name.setter
-    def launch_profile_name(self, value: str) -> None:
+    def launch_profile_name(self, value: str | None) -> None:
         """Sets the LaunchProfileName property"""
         self._client.invoke_capability(
             'Aspire.Hosting/ProjectResourceOptions.setLaunchProfileName',
@@ -5732,16 +5732,16 @@ class TestCallbackContext:
         return self._handle
 
     @_uncached_property
-    def name(self) -> str:
+    def name(self) -> str | None:
         """Gets the Name property"""
         result = self._client.invoke_capability(
             'Aspire.Hosting.CodeGeneration.TypeScript.Tests.TestTypes/TestCallbackContext.name',
             {'context': self._handle}
         )
-        return typing.cast(str, result)
+        return typing.cast(str | None, result)
 
     @name.setter
-    def name(self, value: str) -> None:
+    def name(self, value: str | None) -> None:
         """Sets the Name property"""
         self._client.invoke_capability(
             'Aspire.Hosting.CodeGeneration.TypeScript.Tests.TestTypes/TestCallbackContext.setName',
@@ -5841,16 +5841,16 @@ class TestEnvironmentContext:
         )
 
     @_uncached_property
-    def description(self) -> str:
+    def description(self) -> str | None:
         """Gets the Description property"""
         result = self._client.invoke_capability(
             'Aspire.Hosting.CodeGeneration.TypeScript.Tests.TestTypes/TestEnvironmentContext.description',
             {'context': self._handle}
         )
-        return typing.cast(str, result)
+        return typing.cast(str | None, result)
 
     @description.setter
-    def description(self, value: str) -> None:
+    def description(self, value: str | None) -> None:
         """Sets the Description property"""
         self._client.invoke_capability(
             'Aspire.Hosting.CodeGeneration.TypeScript.Tests.TestTypes/TestEnvironmentContext.setDescription',

--- a/tests/Aspire.Hosting.CodeGeneration.Python.Tests/Snapshots/TwoPassScanningGeneratedAspire.verified.py
+++ b/tests/Aspire.Hosting.CodeGeneration.Python.Tests/Snapshots/TwoPassScanningGeneratedAspire.verified.py
@@ -2074,16 +2074,16 @@ class AbstractConfigurationSection:
         return typing.cast(str, result)
 
     @_uncached_property
-    def value(self) -> str:
+    def value(self) -> str | None:
         """Gets the Value property"""
         result = self._client.invoke_capability(
             'Microsoft.Extensions.Configuration/IConfigurationSection.value',
             {'context': self._handle}
         )
-        return typing.cast(str, result)
+        return typing.cast(str | None, result)
 
     @value.setter
-    def value(self, value: str) -> None:
+    def value(self, value: str | None) -> None:
         """Sets the Value property"""
         self._client.invoke_capability(
             'Microsoft.Extensions.Configuration/IConfigurationSection.setValue',
@@ -3591,13 +3591,13 @@ class ContainerMountAnnotation:
         return self._handle
 
     @_cached_property
-    def source(self) -> str:
+    def source(self) -> str | None:
         """Gets the Source property"""
         result = self._client.invoke_capability(
             'Aspire.Hosting.ApplicationModel/ContainerMountAnnotation.source',
             {'context': self._handle}
         )
-        return typing.cast(str, result)
+        return typing.cast(str | None, result)
 
     @_cached_property
     def target(self) -> str:

--- a/tests/Aspire.Hosting.CodeGeneration.TypeScript.JsTests/tests/nullableProperties.test.ts
+++ b/tests/Aspire.Hosting.CodeGeneration.TypeScript.JsTests/tests/nullableProperties.test.ts
@@ -1,0 +1,118 @@
+import { describe, it, expect, vi } from 'vitest';
+import {
+    AspireClient,
+    Handle,
+} from '@aspire/transport';
+
+interface MockClient extends AspireClient {
+    calls: { capabilityId: string; args: Record<string, unknown> | undefined }[];
+}
+
+function createMockClient(responses?: Map<string, unknown>): MockClient {
+    const calls: { capabilityId: string; args: Record<string, unknown> | undefined }[] = [];
+    const client = Object.create(AspireClient.prototype);
+    Object.defineProperty(client, 'calls', { value: calls, writable: true });
+    Object.defineProperty(client, 'connected', { get: () => true });
+    Object.defineProperty(client, 'invokeCapability', {
+        value: vi.fn(async (capabilityId: string, args?: Record<string, unknown>) => {
+            calls.push({ capabilityId, args });
+            return responses?.get(capabilityId);
+        }),
+    });
+    return client as MockClient;
+}
+
+class NullableScalarContext {
+    private readonly _handle: Handle;
+    private readonly _client: MockClient;
+
+    public constructor(handle: Handle, client: MockClient) {
+        this._handle = handle;
+        this._client = client;
+    }
+
+    public name = {
+        get: async (): Promise<string> => {
+            return await this._client.invokeCapability<string>(
+                'Test.NullableScalarContext.name',
+                { context: this._handle }
+            );
+        },
+        set: async (value: string): Promise<void> => {
+            await this._client.invokeCapability<void>(
+                'Test.NullableScalarContext.setName',
+                { context: this._handle, value }
+            );
+        },
+    };
+
+    public description = {
+        get: async (): Promise<string | null> => {
+            return await this._client.invokeCapability<string | null>(
+                'Test.NullableScalarContext.description',
+                { context: this._handle }
+            );
+        },
+        set: async (value: string | null): Promise<void> => {
+            await this._client.invokeCapability<void>(
+                'Test.NullableScalarContext.setDescription',
+                { context: this._handle, value }
+            );
+        },
+    };
+}
+
+function createContext(responses?: Map<string, unknown>) {
+    const client = createMockClient(responses);
+    const handle = new Handle({ $handle: 'context-1', $type: 'Test.NullableScalarContext' });
+    return { client, context: new NullableScalarContext(handle, client), handle };
+}
+
+describe('generated nullable scalar property accessors', () => {
+    it('returns null from nullable scalar getters', async () => {
+        const { context, client, handle } = createContext(new Map([
+            ['Test.NullableScalarContext.description', null],
+        ]));
+
+        await expect(context.description.get()).resolves.toBeNull();
+        expect(client.calls).toEqual([
+            {
+                capabilityId: 'Test.NullableScalarContext.description',
+                args: { context: handle },
+            },
+        ]);
+    });
+
+    it('sends null through nullable scalar setters', async () => {
+        const { context, client, handle } = createContext();
+
+        await context.description.set(null);
+
+        expect(client.calls).toEqual([
+            {
+                capabilityId: 'Test.NullableScalarContext.setDescription',
+                args: { context: handle, value: null },
+            },
+        ]);
+    });
+
+    it('keeps non-null scalar getter and setter behavior unchanged', async () => {
+        const { context, client, handle } = createContext(new Map([
+            ['Test.NullableScalarContext.name', 'cache'],
+        ]));
+
+        await expect(context.name.get()).resolves.toBe('cache');
+        await context.name.set('api');
+
+        expect(client.calls).toEqual([
+            {
+                capabilityId: 'Test.NullableScalarContext.name',
+                args: { context: handle },
+            },
+            {
+                capabilityId: 'Test.NullableScalarContext.setName',
+                args: { context: handle, value: 'api' },
+            },
+        ]);
+    });
+});

--- a/tests/Aspire.Hosting.CodeGeneration.TypeScript.Tests/Snapshots/AtsGeneratedAspire.verified.ts
+++ b/tests/Aspire.Hosting.CodeGeneration.TypeScript.Tests/Snapshots/AtsGeneratedAspire.verified.ts
@@ -181,14 +181,6 @@ export interface GetStatusAsyncOptions {
     cancellationToken?: AbortSignal | CancellationToken;
 }
 
-export interface SetDescriptionOptions {
-    value?: string | null;
-}
-
-export interface SetNameOptions {
-    value?: string | null;
-}
-
 export interface WaitForReadyAsyncOptions {
     cancellationToken?: AbortSignal | CancellationToken;
 }

--- a/tests/Aspire.Hosting.CodeGeneration.TypeScript.Tests/Snapshots/AtsGeneratedAspire.verified.ts
+++ b/tests/Aspire.Hosting.CodeGeneration.TypeScript.Tests/Snapshots/AtsGeneratedAspire.verified.ts
@@ -127,7 +127,7 @@ export interface TestConfigDto {
     /** A value indicating whether the test config is enabled. */
     enabled?: boolean;
     /** An optional test config field. */
-    optionalField?: string;
+    optionalField?: string | null;
 }
 
 /** Test DTO with deeply nested generic types. */
@@ -181,6 +181,14 @@ export interface GetStatusAsyncOptions {
     cancellationToken?: AbortSignal | CancellationToken;
 }
 
+export interface SetDescriptionOptions {
+    value?: string | null;
+}
+
+export interface SetNameOptions {
+    value?: string | null;
+}
+
 export interface WaitForReadyAsyncOptions {
     cancellationToken?: AbortSignal | CancellationToken;
 }
@@ -222,8 +230,8 @@ export interface TestCallbackContext {
     toJSON(): MarshalledHandle;
     /** Gets the Name property */
     name: {
-        get: () => Promise<string>;
-        set: (value: string) => Promise<void>;
+        get: () => Promise<string | null>;
+        set: (value: string | null) => Promise<void>;
     };
     /** Gets the Value property */
     value: {
@@ -249,13 +257,13 @@ class TestCallbackContextImpl implements TestCallbackContext {
     toJSON(): MarshalledHandle { return this._handle.toJSON(); }
 
     name = {
-        get: async (): Promise<string> => {
-            return await this._client.invokeCapability<string>(
+        get: async (): Promise<string | null> => {
+            return await this._client.invokeCapability<string | null>(
                 'Aspire.Hosting.CodeGeneration.TypeScript.Tests.TestTypes/TestCallbackContext.name',
                 { context: this._handle }
             );
         },
-        set: async (value: string): Promise<void> => {
+        set: async (value: string | null): Promise<void> => {
             await this._client.invokeCapability<void>(
                 'Aspire.Hosting.CodeGeneration.TypeScript.Tests.TestTypes/TestCallbackContext.setName',
                 { context: this._handle, value }
@@ -362,8 +370,8 @@ export interface TestEnvironmentContext {
     };
     /** Gets the Description property */
     description: {
-        get: () => Promise<string>;
-        set: (value: string) => Promise<void>;
+        get: () => Promise<string | null>;
+        set: (value: string | null) => Promise<void>;
     };
     /** Gets the Priority property */
     priority: {
@@ -399,13 +407,13 @@ class TestEnvironmentContextImpl implements TestEnvironmentContext {
     };
 
     description = {
-        get: async (): Promise<string> => {
-            return await this._client.invokeCapability<string>(
+        get: async (): Promise<string | null> => {
+            return await this._client.invokeCapability<string | null>(
                 'Aspire.Hosting.CodeGeneration.TypeScript.Tests.TestTypes/TestEnvironmentContext.description',
                 { context: this._handle }
             );
         },
-        set: async (value: string): Promise<void> => {
+        set: async (value: string | null): Promise<void> => {
             await this._client.invokeCapability<void>(
                 'Aspire.Hosting.CodeGeneration.TypeScript.Tests.TestTypes/TestEnvironmentContext.setDescription',
                 { context: this._handle, value }

--- a/tests/Aspire.Hosting.CodeGeneration.TypeScript.Tests/Snapshots/TwoPassScanningGeneratedAspire.verified.ts
+++ b/tests/Aspire.Hosting.CodeGeneration.TypeScript.Tests/Snapshots/TwoPassScanningGeneratedAspire.verified.ts
@@ -1288,39 +1288,6 @@ export interface SaveStateJsonOptions {
     cancellationToken?: AbortSignal | CancellationToken;
 }
 
-export interface SetDescriptionOptions {
-    value?: string | null;
-}
-
-export interface SetLaunchProfileNameOptions {
-    /** The launch profile to use. If `null` then the default launch profile will be used. */
-    value?: string | null;
-}
-
-export interface SetNameOptions {
-    value?: string | null;
-}
-
-export interface SetPortOptions {
-    /** Gets or sets the desired host port. */
-    value?: number | null;
-}
-
-export interface SetRemoteImageNameOptions {
-    /** Gets or sets the remote image name (repository path without registry endpoint or tag). */
-    value?: string | null;
-}
-
-export interface SetRemoteImageTagOptions {
-    /** Gets or sets the remote image tag. */
-    value?: string | null;
-}
-
-export interface SetTargetPortOptions {
-    /** Gets or sets the target port. */
-    value?: number | null;
-}
-
 export interface UpdateTaskMarkdownOptions {
     cancellationToken?: AbortSignal | CancellationToken;
 }

--- a/tests/Aspire.Hosting.CodeGeneration.TypeScript.Tests/Snapshots/TwoPassScanningGeneratedAspire.verified.ts
+++ b/tests/Aspire.Hosting.CodeGeneration.TypeScript.Tests/Snapshots/TwoPassScanningGeneratedAspire.verified.ts
@@ -1,4 +1,4 @@
-// aspire.ts - Capability-based Aspire SDK
+﻿// aspire.ts - Capability-based Aspire SDK
 // This SDK uses the ATS (Aspire Type System) capability API.
 // Capabilities are endpoints like 'Aspire.Hosting/createBuilder'.
 //
@@ -2194,7 +2194,7 @@ class ContainerImageReferenceImpl implements ContainerImageReference {
 export interface ContainerMountAnnotation {
     toJSON(): MarshalledHandle;
     /** Gets the source of the bind mount or name if a volume. Can be `null` if the mount is an anonymous volume. */
-    source(): Promise<string>;
+    source(): Promise<string | null>;
     /** Gets the target of the mount. */
     target(): Promise<string>;
     /** Gets the type of the mount. */
@@ -2214,8 +2214,8 @@ class ContainerMountAnnotationImpl implements ContainerMountAnnotation {
     /** Serialize for JSON-RPC transport */
     toJSON(): MarshalledHandle { return this._handle.toJSON(); }
 
-    async source(): Promise<string> {
-        return await this._client.invokeCapability<string>(
+    async source(): Promise<string | null> {
+        return await this._client.invokeCapability<string | null>(
             'Aspire.Hosting.ApplicationModel/ContainerMountAnnotation.source',
             { context: this._handle }
         );
@@ -7296,8 +7296,8 @@ export interface ConfigurationSection {
     path(): Promise<string>;
     /** Gets the Value property */
     value: {
-        get: () => Promise<string>;
-        set: (value: string) => Promise<void>;
+        get: () => Promise<string | null>;
+        set: (value: string | null) => Promise<void>;
     };
 }
 
@@ -7327,13 +7327,13 @@ class ConfigurationSectionImpl implements ConfigurationSection {
     }
 
     value = {
-        get: async (): Promise<string> => {
-            return await this._client.invokeCapability<string>(
+        get: async (): Promise<string | null> => {
+            return await this._client.invokeCapability<string | null>(
                 'Microsoft.Extensions.Configuration/IConfigurationSection.value',
                 { context: this._handle }
             );
         },
-        set: async (value: string): Promise<void> => {
+        set: async (value: string | null): Promise<void> => {
             await this._client.invokeCapability<void>(
                 'Microsoft.Extensions.Configuration/IConfigurationSection.setValue',
                 { context: this._handle, value }

--- a/tests/Aspire.Hosting.CodeGeneration.TypeScript.Tests/Snapshots/TwoPassScanningGeneratedAspire.verified.ts
+++ b/tests/Aspire.Hosting.CodeGeneration.TypeScript.Tests/Snapshots/TwoPassScanningGeneratedAspire.verified.ts
@@ -688,7 +688,7 @@ export interface AddContainerOptions {
     /** The container image name. */
     image?: string;
     /** The container image tag. */
-    tag?: string;
+    tag?: string | null;
 }
 
 /** Context for configuring certificate trust configuration properties. */
@@ -716,7 +716,7 @@ export interface CertificateTrustExecutionConfigurationExportData {
 /** Optional configuration for resource commands added with `WithCommand``1`. */
 export interface CommandOptions {
     /** Optional description of the command, to be shown in the UI. Could be used as a tooltip. May be localized. */
-    description?: string;
+    description?: string | null;
     /** Obsolete optional parameter that configures the command in some way. Clients must return any value provided by the server when invoking the command. */
     parameter?: any;
     /**
@@ -746,11 +746,11 @@ export interface CommandOptions {
      */
     visibility?: ResourceCommandVisibility;
     /** When a confirmation message is specified, the UI will prompt with an OK/Cancel dialog and the confirmation message before starting the command. */
-    confirmationMessage?: string;
+    confirmationMessage?: string | null;
     /** The icon name for the command. The name should be a valid FluentUI icon name from . */
-    iconName?: string;
+    iconName?: string | null;
     /** The icon variant. */
-    iconVariant?: IconVariant;
+    iconVariant?: IconVariant | null;
     /** A flag indicating whether the command is highlighted in the UI. */
     isHighlighted?: boolean;
     /** A callback that is used to update the command state. The callback is executed when the command's resource snapshot is updated. If a callback isn't specified, the command is always enabled. */
@@ -772,15 +772,15 @@ export interface CreateBuilderOptions {
     /** The command line arguments. */
     args?: string[];
     /** The directory containing the AppHost project file. */
-    projectDirectory?: string;
+    projectDirectory?: string | null;
     /** The full path to the AppHost file (e.g., apphost.ts, apphost.py). Used for consistent socket path computation across CLI and AppHost. */
-    appHostFilePath?: string;
+    appHostFilePath?: string | null;
     /** When containers are used, use this value to override the container registry. */
-    containerRegistryOverride?: string;
+    containerRegistryOverride?: string | null;
     /** Determines whether the dashboard is disabled. */
     disableDashboard?: boolean;
     /** The application name to display in the dashboard. */
-    dashboardApplicationName?: string;
+    dashboardApplicationName?: string | null;
     /** Allows the use of HTTP urls for the AppHost resource endpoint. */
     allowUnsecuredTransport?: boolean;
     /** Enables resource logging. */
@@ -796,9 +796,9 @@ export interface ExecuteCommandResult {
     /** A flag that indicates whether the command was canceled by the user. */
     canceled?: boolean;
     /** An optional error message that can be set when the command is unsuccessful. */
-    errorMessage?: string;
+    errorMessage?: string | null;
     /** An optional message associated with the command result. */
-    message?: string;
+    message?: string | null;
     /** An optional value produced by the command. */
     data?: CommandResultData;
 }
@@ -853,21 +853,21 @@ export interface GenerateParameterDefault {
 /** ATS-friendly configuration for resource HTTP commands. */
 export interface HttpCommandExportOptions {
     /** Optional description of the command, to be shown in the UI. */
-    description?: string;
+    description?: string | null;
     /** When a confirmation message is specified, the UI will prompt with an OK/Cancel dialog before starting the command. */
-    confirmationMessage?: string;
+    confirmationMessage?: string | null;
     /** The icon name for the command. */
-    iconName?: string;
+    iconName?: string | null;
     /** The icon variant. */
-    iconVariant?: IconVariant;
+    iconVariant?: IconVariant | null;
     /** A flag indicating whether the command is highlighted in the UI. */
     isHighlighted?: boolean;
     /** Gets or sets the command name. */
-    commandName?: string;
+    commandName?: string | null;
     /** Gets or sets the HTTP endpoint name to send the request to when the command is invoked. */
-    endpointName?: string;
+    endpointName?: string | null;
     /** Gets or sets the HTTP method name to use when sending the request. */
-    methodName?: string;
+    methodName?: string | null;
     /** Gets or sets how the HTTP response content should be returned as command result data. */
     resultMode?: HttpCommandResultMode;
 }
@@ -887,7 +887,7 @@ export interface HttpsCertificateExecutionConfigurationExportData {
     /** The certificate subject. */
     subject?: string;
     /** The certificate thumbprint. */
-    thumbprint?: string;
+    thumbprint?: string | null;
     /** The expression for the key path reference. */
     keyPathExpression?: string;
     /** The expression for the PFX path reference. */
@@ -897,7 +897,7 @@ export interface HttpsCertificateExecutionConfigurationExportData {
     /** Indicates whether the PFX path was referenced. */
     isPfxPathReferenced?: boolean;
     /** The certificate password, if any. */
-    password?: string;
+    password?: string | null;
 }
 
 /** ATS-friendly certificate metadata supplied to HTTPS certificate configuration callbacks. */
@@ -907,31 +907,31 @@ export interface HttpsCertificateInfo {
     /** The certificate issuer. */
     issuer?: string;
     /** The certificate thumbprint. */
-    thumbprint?: string;
+    thumbprint?: string | null;
 }
 
 /** ATS-friendly configuration for resource process commands. */
 export interface ProcessCommandExportOptions {
     /** The executable path or command name to start. */
-    executablePath?: string;
+    executablePath?: string | null;
     /** The command-line arguments for the process. */
     arguments?: string[];
     /** The working directory for the process. */
-    workingDirectory?: string;
+    workingDirectory?: string | null;
     /** The environment variables to set for the process. */
     environmentVariables?: Record<string, string>;
     /** A value indicating whether the process should inherit the current environment variables. */
-    inheritEnvironmentVariables?: boolean;
+    inheritEnvironmentVariables?: boolean | null;
     /** Standard input content to write to the process after it starts. */
-    standardInputContent?: string;
+    standardInputContent?: string | null;
     /** A value indicating whether the entire process tree should be killed when the process is disposed. */
-    killEntireProcessTree?: boolean;
+    killEntireProcessTree?: boolean | null;
     /** Optional command configuration. */
     commandOptions?: CommandOptions;
     /** The maximum number of stdout and stderr output lines returned as command result data. */
-    maxOutputLineCount?: number;
+    maxOutputLineCount?: number | null;
     /** A value indicating whether returned command output should be displayed immediately in the dashboard. */
-    displayImmediately?: boolean;
+    displayImmediately?: boolean | null;
     /** The exit codes that are treated as a successful command invocation. */
     successExitCodes?: number[];
 }
@@ -941,9 +941,9 @@ export interface ProcessCommandResultExportOptions {
     /** Optional command configuration. */
     commandOptions?: CommandOptions;
     /** The maximum number of stdout and stderr output lines returned as command result data. */
-    maxOutputLineCount?: number;
+    maxOutputLineCount?: number | null;
     /** A value indicating whether returned command output should be displayed immediately in the dashboard. */
-    displayImmediately?: boolean;
+    displayImmediately?: boolean | null;
     /** The exit codes that are treated as a successful command invocation. */
     successExitCodes?: number[];
 }
@@ -951,19 +951,19 @@ export interface ProcessCommandResultExportOptions {
 /** ATS-friendly process specification for resource process command callbacks. */
 export interface ProcessCommandSpecExportData {
     /** The executable path or command name to start. */
-    executablePath?: string;
+    executablePath?: string | null;
     /** The command-line arguments for the process. */
     arguments?: string[];
     /** The working directory for the process. */
-    workingDirectory?: string;
+    workingDirectory?: string | null;
     /** The environment variables to set for the process. */
     environmentVariables?: Record<string, string>;
     /** A value indicating whether the process should inherit the current environment variables. */
-    inheritEnvironmentVariables?: boolean;
+    inheritEnvironmentVariables?: boolean | null;
     /** Standard input content to write to the process after it starts. */
-    standardInputContent?: string;
+    standardInputContent?: string | null;
     /** A value indicating whether the entire process tree should be killed when the process is disposed. */
-    killEntireProcessTree?: boolean;
+    killEntireProcessTree?: boolean | null;
 }
 
 /** Options that control which reference information is injected into environment variables. */
@@ -985,13 +985,13 @@ export interface ResourceEventDto {
     /** The unique resource ID. */
     resourceId?: string;
     /** The current state text. */
-    state?: string;
+    state?: string | null;
     /** The state style (e.g., "success", "warn", "error"). */
-    stateStyle?: string;
+    stateStyle?: string | null;
     /** The health status of the resource. */
-    healthStatus?: string;
+    healthStatus?: string | null;
     /** The exit code if the resource has exited. */
-    exitCode?: number;
+    exitCode?: number | null;
 }
 
 /** A URL that should be displayed for a resource. */
@@ -999,7 +999,7 @@ export interface ResourceUrlAnnotation {
     /** The URL. When rendered as a link this will be used as the link target. */
     url?: string;
     /** The name of the URL. When rendered as a link this will be used as the linked text. */
-    displayText?: string;
+    displayText?: string | null;
     /** The endpoint associated with this URL. Can be `null` if this URL is not associated with an endpoint. */
     endpoint?: EndpointReference;
     /** Locations where this URL should be shown on the dashboard. Defaults to `SummaryAndDetails`. */
@@ -1015,7 +1015,7 @@ export interface TestConfigDto {
     /** A value indicating whether the test config is enabled. */
     enabled?: boolean;
     /** An optional test config field. */
-    optionalField?: string;
+    optionalField?: string | null;
 }
 
 /** Test DTO with deeply nested generic types. */
@@ -1286,6 +1286,39 @@ export interface RunOptions {
 export interface SaveStateJsonOptions {
     /** The cancellation token. */
     cancellationToken?: AbortSignal | CancellationToken;
+}
+
+export interface SetDescriptionOptions {
+    value?: string | null;
+}
+
+export interface SetLaunchProfileNameOptions {
+    /** The launch profile to use. If `null` then the default launch profile will be used. */
+    value?: string | null;
+}
+
+export interface SetNameOptions {
+    value?: string | null;
+}
+
+export interface SetPortOptions {
+    /** Gets or sets the desired host port. */
+    value?: number | null;
+}
+
+export interface SetRemoteImageNameOptions {
+    /** Gets or sets the remote image name (repository path without registry endpoint or tag). */
+    value?: string | null;
+}
+
+export interface SetRemoteImageTagOptions {
+    /** Gets or sets the remote image tag. */
+    value?: string | null;
+}
+
+export interface SetTargetPortOptions {
+    /** Gets or sets the target port. */
+    value?: number | null;
 }
 
 export interface UpdateTaskMarkdownOptions {
@@ -2015,13 +2048,13 @@ export interface ContainerImagePushOptions {
     toJSON(): MarshalledHandle;
     /** Gets or sets the remote image name (repository path without registry endpoint or tag). */
     remoteImageName: {
-        get: () => Promise<string>;
-        set: (value: string) => Promise<void>;
+        get: () => Promise<string | null>;
+        set: (value: string | null) => Promise<void>;
     };
     /** Gets or sets the remote image tag. */
     remoteImageTag: {
-        get: () => Promise<string>;
-        set: (value: string) => Promise<void>;
+        get: () => Promise<string | null>;
+        set: (value: string | null) => Promise<void>;
     };
 }
 
@@ -2044,13 +2077,13 @@ class ContainerImagePushOptionsImpl implements ContainerImagePushOptions {
     toJSON(): MarshalledHandle { return this._handle.toJSON(); }
 
     remoteImageName = {
-        get: async (): Promise<string> => {
-            return await this._client.invokeCapability<string>(
+        get: async (): Promise<string | null> => {
+            return await this._client.invokeCapability<string | null>(
                 'Aspire.Hosting.ApplicationModel/ContainerImagePushOptions.remoteImageName',
                 { context: this._handle }
             );
         },
-        set: async (value: string): Promise<void> => {
+        set: async (value: string | null): Promise<void> => {
             await this._client.invokeCapability<void>(
                 'Aspire.Hosting.ApplicationModel/ContainerImagePushOptions.setRemoteImageName',
                 { context: this._handle, value }
@@ -2059,13 +2092,13 @@ class ContainerImagePushOptionsImpl implements ContainerImagePushOptions {
     };
 
     remoteImageTag = {
-        get: async (): Promise<string> => {
-            return await this._client.invokeCapability<string>(
+        get: async (): Promise<string | null> => {
+            return await this._client.invokeCapability<string | null>(
                 'Aspire.Hosting.ApplicationModel/ContainerImagePushOptions.remoteImageTag',
                 { context: this._handle }
             );
         },
-        set: async (value: string): Promise<void> => {
+        set: async (value: string | null): Promise<void> => {
             await this._client.invokeCapability<void>(
                 'Aspire.Hosting.ApplicationModel/ContainerImagePushOptions.setRemoteImageTag',
                 { context: this._handle, value }
@@ -3263,7 +3296,7 @@ export interface EndpointReference {
     /** Gets the name of the endpoint associated with the endpoint reference. */
     endpointName(): Promise<string>;
     /** Gets or sets a custom error message to be thrown when the endpoint annotation is not found. */
-    errorMessage(): Promise<string>;
+    errorMessage(): Promise<string | null>;
     /** Gets a value indicating whether the endpoint is allocated. */
     isAllocated(): Promise<boolean>;
     /** Gets a value indicating whether the endpoint exists. */
@@ -3291,7 +3324,7 @@ export interface EndpointReference {
     /** Gets the port for this endpoint. */
     port(): Promise<number>;
     /** Gets the target port for this endpoint. If the port is dynamically allocated, this will return `null`. */
-    targetPort(): Promise<number>;
+    targetPort(): Promise<number | null>;
     /** Gets the host for this endpoint. */
     host(): Promise<string>;
     /** Gets the scheme for this endpoint. */
@@ -3330,7 +3363,7 @@ export interface EndpointReferencePromise extends PromiseLike<EndpointReference>
     /** Gets the name of the endpoint associated with the endpoint reference. */
     endpointName(): Promise<string>;
     /** Gets or sets a custom error message to be thrown when the endpoint annotation is not found. */
-    errorMessage(): Promise<string>;
+    errorMessage(): Promise<string | null>;
     /** Gets a value indicating whether the endpoint is allocated. */
     isAllocated(): Promise<boolean>;
     /** Gets a value indicating whether the endpoint exists. */
@@ -3358,7 +3391,7 @@ export interface EndpointReferencePromise extends PromiseLike<EndpointReference>
     /** Gets the port for this endpoint. */
     port(): Promise<number>;
     /** Gets the target port for this endpoint. If the port is dynamically allocated, this will return `null`. */
-    targetPort(): Promise<number>;
+    targetPort(): Promise<number | null>;
     /** Gets the host for this endpoint. */
     host(): Promise<string>;
     /** Gets the scheme for this endpoint. */
@@ -3420,8 +3453,8 @@ class EndpointReferenceImpl implements EndpointReference {
         );
     }
 
-    async errorMessage(): Promise<string> {
-        return await this._client.invokeCapability<string>(
+    async errorMessage(): Promise<string | null> {
+        return await this._client.invokeCapability<string | null>(
             'Aspire.Hosting.ApplicationModel/EndpointReference.errorMessage',
             { context: this._handle }
         );
@@ -3483,8 +3516,8 @@ class EndpointReferenceImpl implements EndpointReference {
         );
     }
 
-    async targetPort(): Promise<number> {
-        return await this._client.invokeCapability<number>(
+    async targetPort(): Promise<number | null> {
+        return await this._client.invokeCapability<number | null>(
             'Aspire.Hosting.ApplicationModel/EndpointReference.targetPort',
             { context: this._handle }
         );
@@ -3583,7 +3616,7 @@ class EndpointReferencePromiseImpl implements EndpointReferencePromise {
         return this._promise.then(obj => obj.endpointName());
     }
 
-    errorMessage(): Promise<string> {
+    errorMessage(): Promise<string | null> {
         return this._promise.then(obj => obj.errorMessage());
     }
 
@@ -3619,7 +3652,7 @@ class EndpointReferencePromiseImpl implements EndpointReferencePromise {
         return this._promise.then(obj => obj.port());
     }
 
-    targetPort(): Promise<number> {
+    targetPort(): Promise<number | null> {
         return this._promise.then(obj => obj.targetPort());
     }
 
@@ -3718,13 +3751,13 @@ export interface EndpointUpdateContext {
     };
     /** Gets or sets the desired host port. */
     port: {
-        get: () => Promise<number>;
-        set: (value: number) => Promise<void>;
+        get: () => Promise<number | null>;
+        set: (value: number | null) => Promise<void>;
     };
     /** Gets or sets the target port. */
     targetPort: {
-        get: () => Promise<number>;
-        set: (value: number) => Promise<void>;
+        get: () => Promise<number | null>;
+        set: (value: number | null) => Promise<void>;
     };
     /** Gets or sets the URI scheme. */
     uriScheme: {
@@ -3797,13 +3830,13 @@ class EndpointUpdateContextImpl implements EndpointUpdateContext {
     };
 
     port = {
-        get: async (): Promise<number> => {
-            return await this._client.invokeCapability<number>(
+        get: async (): Promise<number | null> => {
+            return await this._client.invokeCapability<number | null>(
                 'Aspire.Hosting.ApplicationModel/EndpointUpdateContext.port',
                 { context: this._handle }
             );
         },
-        set: async (value: number): Promise<void> => {
+        set: async (value: number | null): Promise<void> => {
             await this._client.invokeCapability<void>(
                 'Aspire.Hosting.ApplicationModel/EndpointUpdateContext.setPort',
                 { context: this._handle, value }
@@ -3812,13 +3845,13 @@ class EndpointUpdateContextImpl implements EndpointUpdateContext {
     };
 
     targetPort = {
-        get: async (): Promise<number> => {
-            return await this._client.invokeCapability<number>(
+        get: async (): Promise<number | null> => {
+            return await this._client.invokeCapability<number | null>(
                 'Aspire.Hosting.ApplicationModel/EndpointUpdateContext.targetPort',
                 { context: this._handle }
             );
         },
-        set: async (value: number): Promise<void> => {
+        set: async (value: number | null): Promise<void> => {
             await this._client.invokeCapability<void>(
                 'Aspire.Hosting.ApplicationModel/EndpointUpdateContext.setTargetPort',
                 { context: this._handle, value }
@@ -5087,7 +5120,7 @@ export interface PipelineStep {
      *
      * This projection avoids exporting an ATS setter for the public init-only `Description` property.
      */
-    description(): Promise<string>;
+    description(): Promise<string | null>;
     /**
      * Adds a dependency on another step.
      * @param stepName The name of the step to depend on.
@@ -5117,7 +5150,7 @@ export interface PipelineStepPromise extends PromiseLike<PipelineStep> {
      *
      * This projection avoids exporting an ATS setter for the public init-only `Description` property.
      */
-    description(): Promise<string>;
+    description(): Promise<string | null>;
     /**
      * Adds a dependency on another step.
      * @param stepName The name of the step to depend on.
@@ -5153,8 +5186,8 @@ class PipelineStepImpl implements PipelineStep {
         );
     }
 
-    async description(): Promise<string> {
-        return await this._client.invokeCapability<string>(
+    async description(): Promise<string | null> {
+        return await this._client.invokeCapability<string | null>(
             'Aspire.Hosting.Pipelines/PipelineStep.description',
             { context: this._handle }
         );
@@ -5235,7 +5268,7 @@ class PipelineStepPromiseImpl implements PipelineStepPromise {
         return this._promise.then(obj => obj.name());
     }
 
-    description(): Promise<string> {
+    description(): Promise<string | null> {
         return this._promise.then(obj => obj.description());
     }
 
@@ -5573,8 +5606,8 @@ export interface ProjectResourceOptions {
     toJSON(): MarshalledHandle;
     /** The launch profile to use. If `null` then the default launch profile will be used. */
     launchProfileName: {
-        get: () => Promise<string>;
-        set: (value: string) => Promise<void>;
+        get: () => Promise<string | null>;
+        set: (value: string | null) => Promise<void>;
     };
     /** If set, no launch profile will be used, and LaunchProfileName will be ignored. */
     excludeLaunchProfile: {
@@ -5600,13 +5633,13 @@ class ProjectResourceOptionsImpl implements ProjectResourceOptions {
     toJSON(): MarshalledHandle { return this._handle.toJSON(); }
 
     launchProfileName = {
-        get: async (): Promise<string> => {
-            return await this._client.invokeCapability<string>(
+        get: async (): Promise<string | null> => {
+            return await this._client.invokeCapability<string | null>(
                 'Aspire.Hosting/ProjectResourceOptions.launchProfileName',
                 { context: this._handle }
             );
         },
-        set: async (value: string): Promise<void> => {
+        set: async (value: string | null): Promise<void> => {
             await this._client.invokeCapability<void>(
                 'Aspire.Hosting/ProjectResourceOptions.setLaunchProfileName',
                 { context: this._handle, value }
@@ -6563,8 +6596,8 @@ export interface TestCallbackContext {
     toJSON(): MarshalledHandle;
     /** Gets the Name property */
     name: {
-        get: () => Promise<string>;
-        set: (value: string) => Promise<void>;
+        get: () => Promise<string | null>;
+        set: (value: string | null) => Promise<void>;
     };
     /** Gets the Value property */
     value: {
@@ -6590,13 +6623,13 @@ class TestCallbackContextImpl implements TestCallbackContext {
     toJSON(): MarshalledHandle { return this._handle.toJSON(); }
 
     name = {
-        get: async (): Promise<string> => {
-            return await this._client.invokeCapability<string>(
+        get: async (): Promise<string | null> => {
+            return await this._client.invokeCapability<string | null>(
                 'Aspire.Hosting.CodeGeneration.TypeScript.Tests.TestTypes/TestCallbackContext.name',
                 { context: this._handle }
             );
         },
-        set: async (value: string): Promise<void> => {
+        set: async (value: string | null): Promise<void> => {
             await this._client.invokeCapability<void>(
                 'Aspire.Hosting.CodeGeneration.TypeScript.Tests.TestTypes/TestCallbackContext.setName',
                 { context: this._handle, value }
@@ -6703,8 +6736,8 @@ export interface TestEnvironmentContext {
     };
     /** Gets the Description property */
     description: {
-        get: () => Promise<string>;
-        set: (value: string) => Promise<void>;
+        get: () => Promise<string | null>;
+        set: (value: string | null) => Promise<void>;
     };
     /** Gets the Priority property */
     priority: {
@@ -6740,13 +6773,13 @@ class TestEnvironmentContextImpl implements TestEnvironmentContext {
     };
 
     description = {
-        get: async (): Promise<string> => {
-            return await this._client.invokeCapability<string>(
+        get: async (): Promise<string | null> => {
+            return await this._client.invokeCapability<string | null>(
                 'Aspire.Hosting.CodeGeneration.TypeScript.Tests.TestTypes/TestEnvironmentContext.description',
                 { context: this._handle }
             );
         },
-        set: async (value: string): Promise<void> => {
+        set: async (value: string | null): Promise<void> => {
             await this._client.invokeCapability<void>(
                 'Aspire.Hosting.CodeGeneration.TypeScript.Tests.TestTypes/TestEnvironmentContext.setDescription',
                 { context: this._handle, value }

--- a/tests/Aspire.Hosting.RemoteHost.Tests/AtsCapabilityScannerTests.cs
+++ b/tests/Aspire.Hosting.RemoteHost.Tests/AtsCapabilityScannerTests.cs
@@ -377,7 +377,7 @@ public class AtsCapabilityScannerTests
         var nullableString = Assert.Single(dto.Properties, p => p.Name == nameof(NullableScalarDto.NullableString));
         Assert.Equal(AtsConstants.String, nullableString.Type.TypeId);
         Assert.True(nullableString.Type.IsNullable);
-        Assert.True(nullableString.IsOptional);
+        Assert.False(nullableString.IsOptional);
 
         var requiredString = Assert.Single(dto.Properties, p => p.Name == nameof(NullableScalarDto.RequiredString));
         Assert.Equal(AtsConstants.String, requiredString.Type.TypeId);

--- a/tests/Aspire.Hosting.RemoteHost.Tests/AtsCapabilityScannerTests.cs
+++ b/tests/Aspire.Hosting.RemoteHost.Tests/AtsCapabilityScannerTests.cs
@@ -368,6 +368,34 @@ public class AtsCapabilityScannerTests
     }
 
     [Fact]
+    public void ScanAssembly_DtoNullableScalarProperties_SetTypeRefNullability()
+    {
+        var result = AtsCapabilityScanner.ScanAssembly(typeof(AtsCapabilityScannerTests).Assembly);
+
+        var dto = Assert.Single(result.DtoTypes, d => d.ClrType == typeof(NullableScalarDto));
+
+        var nullableString = Assert.Single(dto.Properties, p => p.Name == nameof(NullableScalarDto.NullableString));
+        Assert.Equal(AtsConstants.String, nullableString.Type.TypeId);
+        Assert.True(nullableString.Type.IsNullable);
+        Assert.True(nullableString.IsOptional);
+
+        var requiredString = Assert.Single(dto.Properties, p => p.Name == nameof(NullableScalarDto.RequiredString));
+        Assert.Equal(AtsConstants.String, requiredString.Type.TypeId);
+        Assert.NotEqual(true, requiredString.Type.IsNullable);
+        Assert.False(requiredString.IsOptional);
+
+        var nullableNumber = Assert.Single(dto.Properties, p => p.Name == nameof(NullableScalarDto.NullableNumber));
+        Assert.Equal(AtsConstants.Number, nullableNumber.Type.TypeId);
+        Assert.True(nullableNumber.Type.IsNullable);
+        Assert.True(nullableNumber.IsOptional);
+
+        var requiredNumber = Assert.Single(dto.Properties, p => p.Name == nameof(NullableScalarDto.RequiredNumber));
+        Assert.Equal(AtsConstants.Number, requiredNumber.Type.TypeId);
+        Assert.NotEqual(true, requiredNumber.Type.IsNullable);
+        Assert.False(requiredNumber.IsOptional);
+    }
+
+    [Fact]
     public void ScanAssembly_TargetSpecificMethodShadowsGenericExpandedMethodOnlyForThatTarget()
     {
         var result = AtsCapabilityScanner.ScanAssembly(typeof(AtsCapabilityScannerTests).Assembly);
@@ -577,6 +605,30 @@ public class AtsCapabilityScannerTests
     private sealed class ShadowedEnvironmentResource(string name) : Resource(name), IResourceWithEnvironment;
 
     private sealed class OtherEnvironmentResource(string name) : Resource(name), IResourceWithEnvironment;
+
+    [AspireDto]
+    private sealed class NullableScalarDto
+    {
+        public string? NullableString { get; set; }
+
+        public string RequiredString { get; set; } = "";
+
+        public int? NullableNumber { get; set; }
+
+        public int RequiredNumber { get; set; }
+    }
+
+    [AspireExport(ExposeProperties = true)]
+    private sealed class NullableScalarContext
+    {
+        public string? NullableString { get; set; }
+
+        public string RequiredString { get; set; } = "";
+
+        public int? NullableNumber { get; set; }
+
+        public int RequiredNumber { get; set; }
+    }
 
     [AspireExport(ExposeProperties = true)]
     private class BaseExportedProperties

--- a/tests/Aspire.Hosting.RemoteHost.Tests/AtsCapabilityScannerTests.cs
+++ b/tests/Aspire.Hosting.RemoteHost.Tests/AtsCapabilityScannerTests.cs
@@ -619,18 +619,6 @@ public class AtsCapabilityScannerTests
     }
 
     [AspireExport(ExposeProperties = true)]
-    private sealed class NullableScalarContext
-    {
-        public string? NullableString { get; set; }
-
-        public string RequiredString { get; set; } = "";
-
-        public int? NullableNumber { get; set; }
-
-        public int RequiredNumber { get; set; }
-    }
-
-    [AspireExport(ExposeProperties = true)]
     private class BaseExportedProperties
     {
         public string Name { get; } = "";

--- a/tests/PolyglotAppHosts/Aspire.Hosting.Azure.EventHubs/TypeScript/apphost.ts
+++ b/tests/PolyglotAppHosts/Aspire.Hosting.Azure.EventHubs/TypeScript/apphost.ts
@@ -8,10 +8,10 @@ await eventHubs.withEventHubsRoleAssignments(eventHubs, [AzureEventHubsRole.Azur
 const hub = await eventHubs.addHub('orders', { hubName: 'orders-hub' });
 await hub.withProperties(async (configuredHub) => {
     await configuredHub.hubName.set('orders-hub');
-    const _hubName: string = await configuredHub.hubName.get();
+    const _hubName: string | null = await configuredHub.hubName.get();
 
     await configuredHub.partitionCount.set(2);
-    const _partitionCount: number | undefined = await configuredHub.partitionCount.get();
+    const _partitionCount: number | null = await configuredHub.partitionCount.get();
 });
 
 const _hubParent = await hub.parent();

--- a/tests/PolyglotAppHosts/Aspire.Hosting.Azure.ServiceBus/TypeScript/apphost.ts
+++ b/tests/PolyglotAppHosts/Aspire.Hosting.Azure.ServiceBus/TypeScript/apphost.ts
@@ -78,10 +78,10 @@ await queue.withProperties(async (q) => {
     await q.requiresSession.set(false);
 
     // Read back properties to verify getter generation
-    const _dlq: boolean = await q.deadLetteringOnMessageExpiration.get();
-    const _ttl: number = await q.defaultMessageTimeToLive.get();
-    const _fwd: string = await q.forwardTo.get();
-    const _maxDel: number = await q.maxDeliveryCount.get();
+    const _dlq: boolean | null = await q.deadLetteringOnMessageExpiration.get();
+    const _ttl: number | null = await q.defaultMessageTimeToLive.get();
+    const _fwd: string | null = await q.forwardTo.get();
+    const _maxDel: number | null = await q.maxDeliveryCount.get();
 });
 
 await topic.withProperties(async (t) => {
@@ -89,7 +89,7 @@ await topic.withProperties(async (t) => {
     await t.duplicateDetectionHistoryTimeWindow.set(3000000000);  // 5 min in ticks
     await t.requiresDuplicateDetection.set(false);
 
-    const _dupDetect: boolean = await t.requiresDuplicateDetection.get();
+    const _dupDetect: boolean | null = await t.requiresDuplicateDetection.get();
 });
 
 await subscription.withProperties(async (s) => {
@@ -102,7 +102,7 @@ await subscription.withProperties(async (s) => {
     await s.requiresSession.set(false);
 
     // Read back a subscription property
-    const _lock: number = await s.lockDuration.get();
+    const _lock: number | null = await s.lockDuration.get();
 
     // Add rules using AspireList.add() and the DTO types
     const rules = await s.rules();

--- a/tests/PolyglotAppHosts/Aspire.Hosting.Docker/TypeScript/apphost.ts
+++ b/tests/PolyglotAppHosts/Aspire.Hosting.Docker/TypeScript/apphost.ts
@@ -15,10 +15,10 @@ const _hostAddressValueExpression: string | null = await hostAddressExpression.g
 
 await compose.withProperties(async (environment) => {
     await environment.defaultNetworkName.set("validation-network");
-    const _defaultNetworkName: string = await environment.defaultNetworkName.get();
+    const _defaultNetworkName: string | null = await environment.defaultNetworkName.get();
 
     await environment.dashboardEnabled.set(true);
-    const _dashboardEnabled: boolean = await environment.dashboardEnabled.get();
+    const _dashboardEnabled: boolean | null = await environment.dashboardEnabled.get();
 
     const _environmentName: string = await environment.name();
 });
@@ -80,15 +80,15 @@ await api.publishAsDockerComposeService(async (composeService, service) => {
     const composeEnvironment = await composeService.parent();
     const _composeEnvironmentName: string = await composeEnvironment.name();
 
-    const _serviceContainerName: string = await service.containerName.get();
-    const _serviceRestart: string = await service.restart.get();
+    const _serviceContainerName: string | null = await service.containerName.get();
+    const _serviceRestart: string | null = await service.restart.get();
     const _serviceConfigsCount: number = await service.configs.count();
     const _serviceSecretsCount: number = await service.secrets.count();
     const _serviceUlimitsCount: number = await service.ulimits.count();
 });
 
-const _resolvedDefaultNetworkName: string = await compose.defaultNetworkName.get();
-const _resolvedDashboardEnabled: boolean = await compose.dashboardEnabled.get();
+const _resolvedDefaultNetworkName: string | null = await compose.defaultNetworkName.get();
+const _resolvedDashboardEnabled: boolean | null = await compose.dashboardEnabled.get();
 const _resolvedName: string = await compose.name();
 
 await builder.build().run();

--- a/tests/PolyglotAppHosts/Aspire.Hosting.Foundry/TypeScript/apphost.ts
+++ b/tests/PolyglotAppHosts/Aspire.Hosting.Foundry/TypeScript/apphost.ts
@@ -9,7 +9,7 @@ const chat = await foundry
     .withProperties(async (deployment) => {
         await deployment.deploymentName.set('chat-deployment');
         await deployment.skuCapacity.set(10);
-        const _capacity: number = await deployment.skuCapacity.get();
+        const _capacity: number | null = await deployment.skuCapacity.get();
     });
 
 const model: FoundryModel = FoundryModels.OpenAI.Gpt41Mini;

--- a/tests/PolyglotAppHosts/Aspire.Hosting.Kubernetes/TypeScript/apphost.ts
+++ b/tests/PolyglotAppHosts/Aspire.Hosting.Kubernetes/TypeScript/apphost.ts
@@ -27,26 +27,26 @@ await kubernetes.withHelm({
 
 await kubernetes.withProperties(async (environment) => {
     await environment.defaultStorageType.set('pvc');
-    const _configuredDefaultStorageType: string = await environment.defaultStorageType.get();
+    const _configuredDefaultStorageType: string | null = await environment.defaultStorageType.get();
 
     await environment.defaultStorageClassName.set('fast-storage');
-    const _configuredDefaultStorageClassName: string | undefined = await environment.defaultStorageClassName.get();
+    const _configuredDefaultStorageClassName: string | null = await environment.defaultStorageClassName.get();
 
     await environment.defaultStorageSize.set('5Gi');
-    const _configuredDefaultStorageSize: string = await environment.defaultStorageSize.get();
+    const _configuredDefaultStorageSize: string | null = await environment.defaultStorageSize.get();
 
     await environment.defaultStorageReadWritePolicy.set('ReadWriteMany');
-    const _configuredDefaultStorageReadWritePolicy: string = await environment.defaultStorageReadWritePolicy.get();
+    const _configuredDefaultStorageReadWritePolicy: string | null = await environment.defaultStorageReadWritePolicy.get();
 
     await environment.defaultImagePullPolicy.set('Always');
-    const _configuredDefaultImagePullPolicy: string = await environment.defaultImagePullPolicy.get();
+    const _configuredDefaultImagePullPolicy: string | null = await environment.defaultImagePullPolicy.get();
 
     await environment.defaultServiceType.set('LoadBalancer');
-    const _configuredDefaultServiceType: string = await environment.defaultServiceType.get();
+    const _configuredDefaultServiceType: string | null = await environment.defaultServiceType.get();
 });
 
-const _resolvedDefaultStorageClassName: string | undefined = await kubernetes.defaultStorageClassName.get();
-const _resolvedDefaultServiceType: string = await kubernetes.defaultServiceType.get();
+const _resolvedDefaultStorageClassName: string | null = await kubernetes.defaultStorageClassName.get();
+const _resolvedDefaultServiceType: string | null = await kubernetes.defaultServiceType.get();
 
 const gateway = await kubernetes.addGateway('public-gateway');
 await gateway.withHostname('gateway.example.com');

--- a/tests/PolyglotAppHosts/Aspire.Hosting/TypeScript/apphost.ts
+++ b/tests/PolyglotAppHosts/Aspire.Hosting/TypeScript/apphost.ts
@@ -376,7 +376,7 @@ await container.withPipelineConfiguration(async (configContext) => {
     const taggedSteps = await configPipeline.stepsByTag(WellKnownPipelineTags.BuildCompute);
 
     const _stepName: string = await allSteps[0].name();
-    const _description: string = await allSteps[0].description();
+    const _description: string | null = await allSteps[0].description();
 
     await allSteps[0].addTag("validated");
     await allSteps[0].dependsOn("restore");


### PR DESCRIPTION
## Description

Generated polyglot SDKs currently lose C# nullable scalar property metadata, so nullable properties such as `string?` are emitted as non-nullable SDK types. This adds ATS type-reference nullability at member use sites and projects that metadata into generated TypeScript and Python scalar output.

The scanner now captures DTO and context property nullability with `NullabilityInfoContext`. TypeScript emits `| null` and Python emits `| None` for nullable primitive/enum type references, while Go, Java, and Rust behavior is intentionally unchanged. The metadata only serializes when nullable to avoid broad snapshot churn.

Related issue: N/A

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [x] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [x] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [x] Yes
      - [ ] No
  - [ ] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No