### PR TITLE
Trigger daily smoke tests after asset publishing

### DIFF
--- a/.github/workflows/tests-daily-smoke.yml
+++ b/.github/workflows/tests-daily-smoke.yml
@@ -5,6 +5,8 @@
 #
 name: Daily CLI Smoke Tests
 
+run-name: Daily CLI Smoke Tests (${{ inputs.quality || 'dev' }})${{ inputs.dispatch_id && format(' - {0}', inputs.dispatch_id) || '' }}
+
 on:
   workflow_dispatch:
     inputs:
@@ -17,6 +19,15 @@ on:
           - dev
           - staging
           - release
+      create_issue_on_failure:
+        description: 'Create an issue if the smoke tests fail'
+        required: false
+        default: false
+        type: boolean
+      dispatch_id:
+        description: 'Optional dispatch correlation ID'
+        required: false
+        type: string
 
   schedule:
     # Run daily at 6 AM UTC
@@ -247,7 +258,7 @@ jobs:
     name: Create Issue on Failure
     needs: [smoke-test]
     runs-on: ubuntu-latest
-    if: ${{ failure() && github.event_name == 'schedule' }}
+    if: ${{ failure() && (github.event_name == 'schedule' || inputs.create_issue_on_failure) }}
     permissions:
       actions: read
       issues: write
@@ -279,7 +290,7 @@ jobs:
               `The daily CLI smoke tests failed on ${date}.`,
               '',
               `**Workflow Run:** ${runUrl}`,
-              `**Quality:** ${quality} (daily build)`,
+              `**Install quality:** ${quality}`,
               '',
               cliVersionSummary,
               '',

--- a/eng/pipelines/azure-pipelines.yml
+++ b/eng/pipelines/azure-pipelines.yml
@@ -52,7 +52,8 @@ variables:
   - template: /eng/common/templates-official/variables/pool-providers.yml@self
 
   # Variable group containing VscePublishToken for VS Code Marketplace publishing
-  - ${{ if eq(parameters.publishVSCodeExtension, true) }}:
+  # and aspire-repo-bot credentials for post-asset GitHub workflow dispatch.
+  - ${{ if or(eq(parameters.publishVSCodeExtension, true), eq(variables['_PackagesPublished'], 'true')) }}:
     - group: Aspire-Release-Secrets
 
   - name: _BuildConfig
@@ -94,12 +95,6 @@ variables:
       value: /p:DotNetSignType=$(_SignType) /p:TeamName=$(_TeamName) /p:Sign=$(_Sign) /p:DotNetPublishUsingPipelines=true
     - name: _Sign
       value: true
-
-  # Packages are published only on internal, non-PR builds on publishing branches
-  # (main, release/*, internal/release/*). Feature branches and PR builds don't
-  # have Maestro default channels so archive URLs won't be valid.
-  - name: _PackagesPublished
-    value: ${{ and(ne(variables['_RunAsPublic'], 'true'), ne(variables['Build.Reason'], 'PullRequest'), or(eq(variables['Build.SourceBranch'], 'refs/heads/main'), startsWith(variables['Build.SourceBranch'], 'refs/heads/release/'), startsWith(variables['Build.SourceBranch'], 'refs/heads/internal/release/'))) }}
 
 resources:
   repositories:
@@ -420,6 +415,65 @@ extends:
       #       GitHubOrg: microsoft
       #       MirrorRepo: aspire
       #       MirrorBranch: main
+
+      - ${{ if eq(variables['_PackagesPublished'], 'true') }}:
+        - job: DispatchDailySmokeTests
+          displayName: Dispatch Daily CLI Smoke Tests
+          dependsOn: Asset_Registry_Publish
+          timeoutInMinutes: 15
+          pool:
+            name: NetCore1ESPool-Internal
+            image: windows.vs2026preview.scout.amd64
+            os: windows
+          steps:
+            - checkout: self
+              displayName: Checkout repo (for dispatch script)
+              fetchDepth: 1
+
+            # pwsh (not powershell): Get-AspireBotInstallationToken.ps1 uses
+            # RSA.ImportFromPem, which is only available in .NET Core 3.0+ / .NET 5+.
+            # The legacy `powershell:` shorthand runs Windows PowerShell 5.1 on
+            # .NET Framework, which doesn't have that API and would fail at runtime.
+            - pwsh: |
+                $sourceBranch = "$(Build.SourceBranch)"
+                $quality = if ($sourceBranch.StartsWith('refs/heads/release/', [System.StringComparison]::OrdinalIgnoreCase) -or $sourceBranch.StartsWith('refs/heads/internal/release/', [System.StringComparison]::OrdinalIgnoreCase)) { "staging" } else { "dev" }
+                $dispatchId = "azdo-$(Build.BuildId)-$(System.JobAttempt)"
+                $expectedRunDisplayTitle = "Daily CLI Smoke Tests ($quality) - $dispatchId"
+
+                Write-Host "Source branch: $sourceBranch -> smoke quality: $quality"
+                Write-Host "Dispatch ID: $dispatchId"
+
+                $inputs = @{
+                  quality                 = $quality
+                  create_issue_on_failure = "true"
+                  dispatch_id             = $dispatchId
+                }
+
+                & "$(Build.SourcesDirectory)/eng/pipelines/scripts/dispatch-release-github-tasks.ps1" `
+                  -AppId         "$env:ASPIRE_BOT_APP_ID" `
+                  -PrivateKeyPem "$env:ASPIRE_BOT_PRIVATE_KEY" `
+                  -Owner         'microsoft' `
+                  -Repo          'aspire' `
+                  -WorkflowFile  'tests-daily-smoke.yml' `
+                  -Ref           'main' `
+                  -Inputs        $inputs `
+                  -ExpectedRunDisplayTitle $expectedRunDisplayTitle `
+                  -NoWait
+              displayName: Dispatch tests-daily-smoke
+              env:
+                # Secrets must be mapped explicitly into env so PowerShell can
+                # read them; AzDO doesn't expose secret variables to scripts
+                # by default.
+                ASPIRE_BOT_APP_ID: $(aspire-bot-app-id)
+                ASPIRE_BOT_PRIVATE_KEY: $(aspire-bot-private-key)
+
+            - powershell: |
+                Write-Host ""
+                Write-Host "Dispatched run: $env:DISPATCHED_RUN_URL"
+              displayName: Print dispatched run URL
+              condition: always()
+              env:
+                DISPATCHED_RUN_URL: $(DispatchedRunUrl)
 
     # ----------------------------------------------------------------
     # Generate and test installer packages (WinGet + Homebrew).

--- a/eng/pipelines/common-variables.yml
+++ b/eng/pipelines/common-variables.yml
@@ -33,3 +33,9 @@ variables:
     - ${{ else }}:
       - name: PostBuildSign
         value: true
+
+  # Packages are published only on internal, non-PR builds on publishing branches
+  # (main, release/*, internal/release/*). Feature branches and PR builds don't
+  # have Maestro default channels so archive URLs won't be valid.
+  - name: _PackagesPublished
+    value: ${{ and(ne(variables['_RunAsPublic'], 'true'), ne(variables['Build.Reason'], 'PullRequest'), or(eq(variables['Build.SourceBranch'], 'refs/heads/main'), startsWith(variables['Build.SourceBranch'], 'refs/heads/release/'), startsWith(variables['Build.SourceBranch'], 'refs/heads/internal/release/'))) }}

--- a/eng/pipelines/scripts/dispatch-release-github-tasks.ps1
+++ b/eng/pipelines/scripts/dispatch-release-github-tasks.ps1
@@ -1,10 +1,10 @@
-# Dispatches the release-github-tasks.yml workflow on microsoft/aspire as the
-# aspire-repo-bot GitHub App, then polls the resulting run until it completes.
-# Exits 0 only if the dispatched run concludes with 'success'.
+# Dispatches a GitHub Actions workflow on microsoft/aspire as the aspire-repo-bot
+# GitHub App, optionally polling the resulting run until it completes. When
+# -NoWait is specified, exits 0 once the run is resolved.
 #
-# This script is invoked from the AzDO release-publish-nuget pipeline as the
-# final stage of a release. It centralizes the workflow dispatch, run-id
-# resolution, and run polling so the pipeline YAML stays declarative.
+# This script is invoked from AzDO pipelines that need to dispatch GitHub
+# Actions workflows. It centralizes workflow dispatch, run-id resolution, and
+# optional run polling so the pipeline YAML stays declarative.
 #
 # Authentication (mint a GitHub App installation access token) is delegated to
 # Get-AspireBotInstallationToken.ps1 so the same flow can be reused by other
@@ -15,7 +15,7 @@
 #   1. POST /repos/{owner}/{repo}/actions/workflows/{file}/dispatches with the installation token.
 #   2. Poll GET /repos/.../actions/runs filtered by workflow + branch to find the run we just queued
 #      (workflow_dispatch does not return a run id directly — this is the documented workaround).
-#   3. Poll the run until status=completed; succeed only if conclusion=success.
+#   3. Unless -NoWait is specified, poll the run until status=completed; succeed only if conclusion=success.
 
 [CmdletBinding()]
 param(
@@ -26,6 +26,8 @@ param(
     [Parameter(Mandatory = $true)][string]$WorkflowFile,
     [Parameter(Mandatory = $true)][string]$Ref,
     [Parameter(Mandatory = $true)][hashtable]$Inputs,
+    [Parameter()][string]$ExpectedRunDisplayTitle,
+    [Parameter()][switch]$NoWait,
     [Parameter()][int]$PollIntervalSeconds = 30,
     [Parameter()][int]$PollTimeoutMinutes = 60
 )
@@ -61,7 +63,7 @@ function Invoke-GitHubApi {
     return Invoke-RestMethod @params
 }
 
-Write-Host "=== Dispatch Release GitHub Tasks ==="
+Write-Host "=== Dispatch GitHub Actions Workflow ==="
 Write-Host "Target: $Owner/$Repo workflow=$WorkflowFile ref=$Ref"
 Write-Host "Inputs:"
 foreach ($key in $Inputs.Keys) {
@@ -115,13 +117,22 @@ while ([DateTime]::UtcNow -lt $resolveDeadline -and -not $runId) {
     }
 
     if ($runs.workflow_runs -and $runs.workflow_runs.Count -gt 0) {
+        $candidates = $runs.workflow_runs
+        if (-not [string]::IsNullOrWhiteSpace($ExpectedRunDisplayTitle)) {
+            $candidates = $candidates | Where-Object { $_.display_title -eq $ExpectedRunDisplayTitle }
+        }
+
+        if (-not $candidates) {
+            Write-Host "  Waiting for dispatched run to appear..."
+            continue
+        }
+
         # The list endpoint returns runs newest first. We pick the newest run
-        # that satisfies the created>=dispatchedAt-30s filter — the dispatch we
-        # just issued is by definition the most recent qualifying run on this
-        # branch+workflow. Picking the oldest qualifying run would attach us
-        # to an earlier dispatch within the clock-skew window (e.g. a quick
-        # re-run of this AzDO stage).
-        $candidate = $runs.workflow_runs | Sort-Object -Property created_at -Descending | Select-Object -First 1
+        # that satisfies the created>=dispatchedAt-30s filter and, when
+        # provided, the expected display title. The title is important for
+        # fire-and-forget dispatches where multiple builds can dispatch the same
+        # workflow on the same ref close together.
+        $candidate = $candidates | Sort-Object -Property created_at -Descending | Select-Object -First 1
         $runId = $candidate.id
         $runHtmlUrl = $candidate.html_url
         Write-Host "✓ Resolved dispatched run: $runHtmlUrl (id=$runId)"
@@ -139,6 +150,11 @@ if (-not $runId) {
 # Surface the run URL in the AzDO job summary regardless of outcome.
 Write-Host "##vso[task.setvariable variable=DispatchedRunUrl]$runHtmlUrl"
 Write-Host "##[section]Dispatched run: $runHtmlUrl"
+
+if ($NoWait) {
+    Write-Host "NoWait specified; not polling dispatched workflow completion."
+    exit 0
+}
 
 # Poll the run until it reaches a terminal state.
 $pollDeadline = [DateTime]::UtcNow.AddMinutes($PollTimeoutMinutes)


### PR DESCRIPTION
## Description

Official AzDO builds publish the assets consumed by the daily and staging CLI install channels, but the CLI smoke workflow was only running on its schedule. This dispatches `.github/workflows/tests-daily-smoke.yml` after the official build publishes assets so newly published main and release-branch assets get smoke coverage promptly.

This change:
- Adds a post-asset `DispatchDailySmokeTests` job in `eng/pipelines/azure-pipelines.yml`, gated by the shared `_PackagesPublished` variable.
- Uses `dev` quality for `main` builds and `staging` quality for `release/*` and `internal/release/*` builds.
- Keeps the AzDO job fire-and-forget by adding `-NoWait` to the shared GitHub workflow dispatch script.
- Adds a dispatch correlation ID to the smoke workflow run name so concurrent builds resolve the correct GitHub Actions run URL.
- Lets AzDO-dispatched smoke failures create issues via the workflow's existing issue-creation job.

Validation:
- Parsed changed YAML files.
- Parsed `dispatch-release-github-tasks.ps1` with the PowerShell parser.
- Checked wiring assertions for the published-assets gate, quality selection, fire-and-forget dispatch, run correlation, and failure issue creation.
- Ran PR polish review; fixed the concurrency correlation issue it found.

Fixes # (issue)

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [x] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
