### PR TITLE
CLI: Print app host CLI log path when connected to a running app host

### DIFF
--- a/src/Aspire.Cli/Aspire.Cli.csproj
+++ b/src/Aspire.Cli/Aspire.Cli.csproj
@@ -124,6 +124,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <Compile Include="$(SharedDir)CliExitCodes.cs" Link="CliExitCodes.cs" />
     <Compile Include="$(SharedDir)AppHostProfilePortGenerator.cs" Link="Utils\AppHostProfilePortGenerator.cs" />
     <Compile Include="$(SharedDir)AssemblyVersionHelper.cs" Link="Utils\AssemblyVersionHelper.cs" />
     <Compile Include="$(SharedDir)BundleDiscovery.cs" Link="Layout\BundleDiscovery.cs" />

--- a/src/Aspire.Cli/Backchannel/AppHostAuxiliaryBackchannel.cs
+++ b/src/Aspire.Cli/Backchannel/AppHostAuxiliaryBackchannel.cs
@@ -457,7 +457,8 @@ internal sealed class AppHostAuxiliaryBackchannel : IAppHostAuxiliaryBackchannel
                 AspireHostVersion = "unknown",
                 AppHostPath = legacyInfo.AppHostPath,
                 CliProcessId = legacyInfo.CliProcessId,
-                StartedAt = legacyInfo.StartedAt
+                StartedAt = legacyInfo.StartedAt,
+                CliLogFilePath = legacyInfo.CliLogFilePath
             };
         }
 

--- a/src/Aspire.Cli/Backchannel/AppHostConnectionResolver.cs
+++ b/src/Aspire.Cli/Backchannel/AppHostConnectionResolver.cs
@@ -29,7 +29,7 @@ internal sealed class AppHostConnectionResult
     public int? ExitCode { get; init; }
 
     [MemberNotNullWhen(true, nameof(ExitCode))]
-    public bool IsProjectResolutionError => ExitCode is ExitCodeConstants.FailedToFindProject or ExitCodeConstants.SdkNotInstalled;
+    public bool IsProjectResolutionError => ExitCode is CliExitCodes.FailedToFindProject or CliExitCodes.SdkNotInstalled;
 }
 
 /// <summary>
@@ -121,7 +121,7 @@ internal sealed class AppHostConnectionResolver(
                     return new AppHostConnectionResult
                     {
                         ErrorMessage = InteractionServiceStrings.ProjectOptionSpecifiedDirectoryContainsNoAppHosts,
-                        ExitCode = ExitCodeConstants.FailedToFindProject,
+                        ExitCode = CliExitCodes.FailedToFindProject,
                     };
                 }
             }
@@ -130,7 +130,7 @@ internal sealed class AppHostConnectionResolver(
                 return new AppHostConnectionResult
                 {
                     ErrorMessage = InteractionServiceStrings.ProjectOptionDoesntExist,
-                    ExitCode = ExitCodeConstants.FailedToFindProject,
+                    ExitCode = CliExitCodes.FailedToFindProject,
                 };
             }
 
@@ -148,7 +148,9 @@ internal sealed class AppHostConnectionResolver(
                         socketPath, logger, cancellationToken, profilingTelemetry).ConfigureAwait(false);
                     if (connection is not null)
                     {
-                        return new AppHostConnectionResult { Connection = connection };
+                        var result = new AppHostConnectionResult { Connection = connection };
+                        StoreAppHostCliLogFilePath(result);
+                        return result;
                     }
                 }
                 catch (Exception ex)
@@ -217,7 +219,21 @@ internal sealed class AppHostConnectionResolver(
             return new AppHostConnectionResult { ErrorMessage = notFoundMessage };
         }
 
-        return new AppHostConnectionResult { Connection = selectedConnection };
+        var selectedResult = new AppHostConnectionResult { Connection = selectedConnection };
+        StoreAppHostCliLogFilePath(selectedResult);
+        return selectedResult;
+    }
+
+    /// <summary>
+    /// Stores the app host's CLI log file path on the execution context so that
+    /// <see cref="Commands.BaseCommand"/> can display it alongside the current CLI's log path on failure.
+    /// </summary>
+    internal void StoreAppHostCliLogFilePath(AppHostConnectionResult result)
+    {
+        if (result.Success && result.Connection.AppHostInfo?.CliLogFilePath is { } cliLogFilePath)
+        {
+            executionContext.AppHostCliLogFilePath = cliLogFilePath;
+        }
     }
 
     /// <summary>

--- a/src/Aspire.Cli/Backchannel/ExtensionRpcTarget.cs
+++ b/src/Aspire.Cli/Backchannel/ExtensionRpcTarget.cs
@@ -45,7 +45,7 @@ internal class ExtensionRpcTarget(IConfiguration configuration) : IExtensionRpcT
 
     public Task StopCliAsync()
     {
-        Environment.Exit(ExitCodeConstants.Success);
+        Environment.Exit(CliExitCodes.Success);
         return Task.CompletedTask;
     }
 

--- a/src/Aspire.Cli/CliExecutionContext.cs
+++ b/src/Aspire.Cli/CliExecutionContext.cs
@@ -54,6 +54,12 @@ internal sealed class CliExecutionContext(DirectoryInfo workingDirectory, Direct
     /// </summary>
     public string LogFilePath { get; } = logFilePath;
 
+    /// <summary>
+    /// Gets or sets the log file path of the CLI process managing the connected app host.
+    /// This is populated after connecting to a running app host via <see cref="Backchannel.AppHostConnectionResolver"/>.
+    /// </summary>
+    public string? AppHostCliLogFilePath { get; set; }
+
     public DirectoryInfo HomeDirectory { get; } = homeDirectory ?? new DirectoryInfo(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile));
     public bool DebugMode { get; } = debugMode;
 

--- a/src/Aspire.Cli/Commands/AddCommand.cs
+++ b/src/Aspire.Cli/Commands/AddCommand.cs
@@ -77,7 +77,7 @@ internal sealed class AddCommand : BaseCommand
 
             if (effectiveAppHostProjectFile is null)
             {
-                return CommandResult.Failure(ExitCodeConstants.FailedToFindProject);
+                return CommandResult.Failure(CliExitCodes.FailedToFindProject);
             }
 
             // Get the appropriate project handler
@@ -88,7 +88,7 @@ internal sealed class AddCommand : BaseCommand
             {
                 if (!await SdkInstallHelper.EnsureSdkInstalledAsync(_sdkInstaller, InteractionService, Telemetry, cancellationToken: cancellationToken))
                 {
-                    return CommandResult.Failure(ExitCodeConstants.SdkNotInstalled);
+                    return CommandResult.Failure(CliExitCodes.SdkNotInstalled);
                 }
             }
 
@@ -111,7 +111,7 @@ internal sealed class AddCommand : BaseCommand
 
             if (!packagesWithShortName.Any())
             {
-                return CommandResult.Failure(ExitCodeConstants.FailedToAddPackage, AddCommandStrings.NoPackagesFound);
+                return CommandResult.Failure(CliExitCodes.FailedToAddPackage, AddCommandStrings.NoPackagesFound);
             }
 
             var filteredPackagesWithShortName = packagesWithShortName
@@ -200,7 +200,7 @@ internal sealed class AddCommand : BaseCommand
             }
             else if (runningInstanceResult == RunningInstanceResult.StopFailed)
             {
-                return CommandResult.Failure(ExitCodeConstants.FailedToAddPackage, AddCommandStrings.UnableToStopRunningInstances);
+                return CommandResult.Failure(CliExitCodes.FailedToAddPackage, AddCommandStrings.UnableToStopRunningInstances);
             }
 
             var success = await InteractionService.ShowStatusAsync(
@@ -214,7 +214,7 @@ internal sealed class AddCommand : BaseCommand
                 {
                     InteractionService.DisplayLines(outputCollector.GetLines());
                 }
-                return CommandResult.Failure(ExitCodeConstants.FailedToAddPackage, string.Format(CultureInfo.CurrentCulture, AddCommandStrings.PackageInstallationFailed, ExitCodeConstants.FailedToAddPackage));
+                return CommandResult.Failure(CliExitCodes.FailedToAddPackage, string.Format(CultureInfo.CurrentCulture, AddCommandStrings.PackageInstallationFailed, CliExitCodes.FailedToAddPackage));
             }
 
             InteractionService.DisplaySuccess(string.Format(CultureInfo.CurrentCulture, AddCommandStrings.PackageAddedSuccessfully, selectedNuGetPackage.Package.Id, selectedNuGetPackage.Package.Version));
@@ -231,7 +231,7 @@ internal sealed class AddCommand : BaseCommand
         catch (EmptyChoicesException ex)
         {
             Telemetry.RecordError(ex.Message, ex);
-            return CommandResult.Failure(ExitCodeConstants.FailedToAddPackage, ex.Message);
+            return CommandResult.Failure(CliExitCodes.FailedToAddPackage, ex.Message);
         }
         catch (Exception ex)
         {
@@ -241,7 +241,7 @@ internal sealed class AddCommand : BaseCommand
             }
             var errorMessage = string.Format(CultureInfo.CurrentCulture, AddCommandStrings.ErrorOccurredWhileAddingPackage, ex.Message);
             Telemetry.RecordError(errorMessage, ex);
-            return CommandResult.Failure(ExitCodeConstants.FailedToAddPackage, errorMessage);
+            return CommandResult.Failure(CliExitCodes.FailedToAddPackage, errorMessage);
         }
     }
 

--- a/src/Aspire.Cli/Commands/AgentInitCommand.cs
+++ b/src/Aspire.Cli/Commands/AgentInitCommand.cs
@@ -107,7 +107,7 @@ internal sealed class AgentInitCommand : BaseCommand, IPackageMetaPrefetchingCom
         PromptBinding<bool> agentInitBinding,
         CancellationToken cancellationToken)
     {
-        if (previousResultExitCode != ExitCodeConstants.Success)
+        if (previousResultExitCode != CliExitCodes.Success)
         {
             return new(previousResultExitCode, [], []);
         }
@@ -125,7 +125,7 @@ internal sealed class AgentInitCommand : BaseCommand, IPackageMetaPrefetchingCom
             return await ExecuteAgentInitAsync(workspaceRoot, parseResult: null, cancellationToken);
         }
 
-        return new(ExitCodeConstants.Success, [], []);
+        return new(CliExitCodes.Success, [], []);
     }
 
     protected override async Task<CommandResult> ExecuteAsync(ParseResult parseResult, CancellationToken cancellationToken)
@@ -382,7 +382,7 @@ internal sealed class AgentInitCommand : BaseCommand, IPackageMetaPrefetchingCom
         }
 
         return new(
-            hasErrors ? ExitCodeConstants.InvalidCommand : ExitCodeConstants.Success,
+            hasErrors ? CliExitCodes.InvalidCommand : CliExitCodes.Success,
             selectedLocations,
             selectedSkills);
     }

--- a/src/Aspire.Cli/Commands/AgentMcpCommand.cs
+++ b/src/Aspire.Cli/Commands/AgentMcpCommand.cs
@@ -106,7 +106,7 @@ internal sealed class AgentMcpCommand : BaseCommand
             if (!UrlHelper.IsHttpUrl(dashboardUrl))
             {
                 _logger.LogError("Invalid --dashboard-url: {DashboardUrl}", dashboardUrl);
-                return CommandResult.Failure(ExitCodeConstants.InvalidCommand, string.Format(CultureInfo.CurrentCulture, TelemetryCommandStrings.DashboardUrlInvalid, dashboardUrl));
+                return CommandResult.Failure(CliExitCodes.InvalidCommand, string.Format(CultureInfo.CurrentCulture, TelemetryCommandStrings.DashboardUrlInvalid, dashboardUrl));
             }
 
             _dashboardOnlyMode = true;

--- a/src/Aspire.Cli/Commands/ApiGetCommand.cs
+++ b/src/Aspire.Cli/Commands/ApiGetCommand.cs
@@ -69,7 +69,7 @@ internal sealed class ApiGetCommand : BaseCommand
 
         if (item is null)
         {
-            return CommandResult.Failure(ExitCodeConstants.InvalidCommand, string.Format(CultureInfo.CurrentCulture, ApiCommandStrings.ApiNotFound, id));
+            return CommandResult.Failure(CliExitCodes.InvalidCommand, string.Format(CultureInfo.CurrentCulture, ApiCommandStrings.ApiNotFound, id));
         }
 
         if (format is OutputFormat.Json)

--- a/src/Aspire.Cli/Commands/AppHostConnectionResultHandler.cs
+++ b/src/Aspire.Cli/Commands/AppHostConnectionResultHandler.cs
@@ -30,7 +30,7 @@ internal static class AppHostConnectionResultHandler
         }
 
         interactionService.DisplayMessage(KnownEmojis.Information, errorMessage);
-        return ExitCodeConstants.Success;
+        return CliExitCodes.Success;
     }
 
     private static string GetFailureMessage(AppHostConnectionResult result)

--- a/src/Aspire.Cli/Commands/AppHostLauncher.cs
+++ b/src/Aspire.Cli/Commands/AppHostLauncher.cs
@@ -112,7 +112,7 @@ internal sealed class AppHostLauncher(
 
         if (effectiveAppHostFile is null)
         {
-            return CommandResult.Failure(ExitCodeConstants.FailedToFindProject);
+            return CommandResult.Failure(CliExitCodes.FailedToFindProject);
         }
 
         logger.LogDebug("Starting AppHost in background: {AppHostPath}", effectiveAppHostFile.FullName);
@@ -122,6 +122,7 @@ internal sealed class AppHostLauncher(
 
         // Build child process arguments
         var childLogFile = GenerateChildLogFilePath(executionContext.LogsDirectory.FullName, timeProvider);
+        executionContext.AppHostCliLogFilePath = childLogFile;
         var (executablePath, childArgs) = BuildChildProcessArgs(effectiveAppHostFile, childLogFile, isolated, globalArgs, additionalArgs);
 
         // Compute the expected socket prefix for backchannel detection
@@ -155,7 +156,7 @@ internal sealed class AppHostLauncher(
         // Handle failure cases
         if (launchResult.Backchannel is null || launchResult.ChildProcess is null)
         {
-            return CommandResult.FromExitCode(HandleLaunchFailure(launchResult, childLogFile));
+            return CommandResult.FromExitCode(HandleLaunchFailure(launchResult));
         }
 
         // Display results
@@ -346,12 +347,12 @@ internal sealed class AppHostLauncher(
         return new LaunchResult(childProcess, null, null, false, 0);
     }
 
-    private int HandleLaunchFailure(LaunchResult result, string childLogFile)
+    private int HandleLaunchFailure(LaunchResult result)
     {
         if (result.ChildProcess is null)
         {
             interactionService.DisplayError(RunCommandStrings.FailedToStartAppHost);
-            return ExitCodeConstants.FailedToDotnetRunAppHost;
+            return CliExitCodes.FailedToDotnetRunAppHost;
         }
 
         if (result.ChildExitedEarly)
@@ -375,16 +376,7 @@ internal sealed class AppHostLauncher(
             }
         }
 
-        var checkLogsMessage = string.Format(
-            CultureInfo.CurrentCulture,
-            RunCommandStrings.CheckLogsForDetails,
-            MarkupHelpers.SafeFileLink(interactionService, childLogFile));
-        interactionService.DisplayMessage(
-            KnownEmojis.MagnifyingGlassTiltedLeft,
-            checkLogsMessage,
-            allowMarkup: true);
-
-        return ExitCodeConstants.FailedToDotnetRunAppHost;
+        return CliExitCodes.FailedToDotnetRunAppHost;
     }
 
     private void DisplayLaunchResult(
@@ -433,7 +425,7 @@ internal sealed class AppHostLauncher(
     {
         return childExitCode switch
         {
-            ExitCodeConstants.FailedToBuildArtifacts => RunCommandStrings.AppHostFailedToBuild,
+            CliExitCodes.FailedToBuildArtifacts => RunCommandStrings.AppHostFailedToBuild,
             _ => string.Format(CultureInfo.CurrentCulture, RunCommandStrings.AppHostExitedWithCode, childExitCode)
         };
     }

--- a/src/Aspire.Cli/Commands/BaseCommand.cs
+++ b/src/Aspire.Cli/Commands/BaseCommand.cs
@@ -36,7 +36,7 @@ internal abstract class BaseCommand : Command
         _executionContext = executionContext;
         InteractionService = interactionService;
         Telemetry = telemetry;
-        SetAction(async (parseResult, cancellationToken) =>
+        SetAction((Func<ParseResult, CancellationToken, Task<int>>)(async (parseResult, cancellationToken) =>
         {
             // Set the command on the execution context so background services can access it
             _executionContext.Command = this;
@@ -58,7 +58,7 @@ internal abstract class BaseCommand : Command
             catch (NonInteractiveException)
             {
                 // Error messages have already been displayed by the interaction service.
-                result = CommandResult.Failure(ExitCodeConstants.MissingRequiredArgument);
+                result = CommandResult.Failure((int)CliExitCodes.MissingRequiredArgument);
             }
 
             if (result.ErrorMessage is not null)
@@ -80,12 +80,22 @@ internal abstract class BaseCommand : Command
             // Display the CLI log file path on non-zero exit codes so the user knows
             // where to find diagnostic details. Suppress for user-input errors where
             // the log wouldn't contain useful context (e.g., missing required arguments).
-            if (result.ExitCode != ExitCodeConstants.Success && result.ExitCode != ExitCodeConstants.MissingRequiredArgument)
+            if (result.ExitCode != CliExitCodes.Success && result.ExitCode != CliExitCodes.MissingRequiredArgument)
             {
                 interactionService.DisplayMessage(
                     KnownEmojis.PageFacingUp,
                     string.Format(CultureInfo.CurrentCulture, InteractionServiceStrings.SeeLogsAt, MarkupHelpers.SafeFileLink(interactionService, executionContext.LogFilePath)),
                     allowMarkup: true);
+
+                // If we connected to a running app host, also display the log file path of
+                // the CLI process that launched it so users can diagnose issues in both processes.
+                if (executionContext.AppHostCliLogFilePath is not null)
+                {
+                    interactionService.DisplayMessage(
+                        KnownEmojis.MagnifyingGlassTiltedLeft,
+                        string.Format(CultureInfo.CurrentCulture, InteractionServiceStrings.SeeAppHostLogsAt, MarkupHelpers.SafeFileLink(interactionService, executionContext.AppHostCliLogFilePath)),
+                        allowMarkup: true);
+                }
             }
 
             if (UpdateNotificationsEnabled && features.IsFeatureEnabled(KnownFeatures.UpdateNotificationsEnabled, true))
@@ -101,7 +111,7 @@ internal abstract class BaseCommand : Command
             }
 
             return result.ExitCode;
-        });
+        }));
     }
 
     protected abstract Task<CommandResult> ExecuteAsync(ParseResult parseResult, CancellationToken cancellationToken);

--- a/src/Aspire.Cli/Commands/CacheCommand.cs
+++ b/src/Aspire.Cli/Commands/CacheCommand.cs
@@ -62,7 +62,7 @@ internal sealed class CacheCommand : ParentCommand
                 var errorMessage = string.Format(CultureInfo.CurrentCulture, CacheCommandStrings.CacheClearFailed, ex.Message);
                 Telemetry.RecordError(errorMessage, ex);
                 InteractionService.DisplayError(errorMessage);
-                return Task.FromResult(CommandResult.Failure(ExitCodeConstants.InvalidCommand));
+                return Task.FromResult(CommandResult.Failure(CliExitCodes.InvalidCommand));
             }
         }
 

--- a/src/Aspire.Cli/Commands/CertificatesCleanCommand.cs
+++ b/src/Aspire.Cli/Commands/CertificatesCleanCommand.cs
@@ -36,18 +36,18 @@ internal sealed class CertificatesCleanCommand : BaseCommand
         if (result.Success)
         {
             InteractionService.DisplaySuccess(CertificatesCommandStrings.CleanSuccess);
-            return Task.FromResult(CommandResult.FromExitCode(ExitCodeConstants.Success));
+            return Task.FromResult(CommandResult.FromExitCode(CliExitCodes.Success));
         }
 
         if (result.WasCancelled)
         {
             InteractionService.DisplayMessage(KnownEmojis.Warning, CertificatesCommandStrings.CleanCancelled);
-            return Task.FromResult(CommandResult.FromExitCode(ExitCodeConstants.FailedToTrustCertificates));
+            return Task.FromResult(CommandResult.FromExitCode(CliExitCodes.FailedToTrustCertificates));
         }
 
         var details = string.Format(CultureInfo.CurrentCulture, CertificatesCommandStrings.CleanFailureDetailsFormat, result.ErrorMessage);
         InteractionService.DisplayError(details);
         InteractionService.DisplayError(CertificatesCommandStrings.CleanFailure);
-        return Task.FromResult(CommandResult.FromExitCode(ExitCodeConstants.FailedToTrustCertificates));
+        return Task.FromResult(CommandResult.FromExitCode(CliExitCodes.FailedToTrustCertificates));
     }
 }

--- a/src/Aspire.Cli/Commands/CertificatesTrustCommand.cs
+++ b/src/Aspire.Cli/Commands/CertificatesTrustCommand.cs
@@ -41,10 +41,10 @@ internal sealed class CertificatesTrustCommand : BaseCommand
 
         if (result.WasCancelled)
         {
-            return CommandResult.Failure(ExitCodeConstants.FailedToTrustCertificates);
+            return CommandResult.Failure(CliExitCodes.FailedToTrustCertificates);
         }
 
         var details = string.Format(CultureInfo.CurrentCulture, CertificatesCommandStrings.TrustFailureDetailsFormat, result.ResultCode);
-        return CommandResult.Failure(ExitCodeConstants.FailedToTrustCertificates, $"{CertificatesCommandStrings.TrustFailure} {details}");
+        return CommandResult.Failure(CliExitCodes.FailedToTrustCertificates, $"{CertificatesCommandStrings.TrustFailure} {details}");
     }
 }

--- a/src/Aspire.Cli/Commands/CommandResult.cs
+++ b/src/Aspire.Cli/Commands/CommandResult.cs
@@ -24,7 +24,7 @@ internal sealed class CommandResult
         ShouldDisplayCancellationMessage = shouldDisplayCancellationMessage;
     }
 
-    public static CommandResult Success() => new(ExitCodeConstants.Success);
+    public static CommandResult Success() => new(CliExitCodes.Success);
 
     public static CommandResult Failure(int exitCode, string? errorMessage = null) => new(exitCode, errorMessage);
 
@@ -32,17 +32,17 @@ internal sealed class CommandResult
     /// Indicates the command was cancelled by the user (e.g. Ctrl+C).
     /// <see cref="BaseCommand"/> displays the cancellation message centrally.
     /// </summary>
-    public static CommandResult Cancelled(int exitCode = ExitCodeConstants.Cancelled) => new(exitCode, shouldDisplayCancellationMessage: true);
+    public static CommandResult Cancelled(int exitCode = CliExitCodes.Cancelled) => new(exitCode, shouldDisplayCancellationMessage: true);
 
     /// <summary>
     /// Indicates the command should display help and return an invalid-command exit code.
     /// </summary>
-    public static CommandResult DisplayHelp() => new(ExitCodeConstants.InvalidCommand, shouldDisplayHelp: true);
+    public static CommandResult DisplayHelp() => new(CliExitCodes.InvalidCommand, shouldDisplayHelp: true);
 
     /// <summary>
     /// Creates a result from a raw exit code with no error message.
     /// Useful when wrapping calls that return plain exit codes.
     /// </summary>
     public static CommandResult FromExitCode(int exitCode) =>
-        exitCode == ExitCodeConstants.Success ? Success() : Failure(exitCode);
+        exitCode == CliExitCodes.Success ? Success() : Failure(exitCode);
 }

--- a/src/Aspire.Cli/Commands/ConfigCommand.cs
+++ b/src/Aspire.Cli/Commands/ConfigCommand.cs
@@ -84,7 +84,7 @@ internal sealed class ConfigCommand : BaseCommand
             var key = parseResult.GetValue(s_keyArgument);
             if (key is null)
             {
-                return CommandResult.Failure(ExitCodeConstants.InvalidCommand, ErrorStrings.ConfigurationKeyRequired);
+                return CommandResult.Failure(CliExitCodes.InvalidCommand, ErrorStrings.ConfigurationKeyRequired);
             }
 
             return CommandResult.FromExitCode(await ExecuteAsync(key, cancellationToken));
@@ -103,12 +103,12 @@ internal sealed class ConfigCommand : BaseCommand
             if (value is not null)
             {
                 InteractionService.DisplayPlainText(value);
-                return ExitCodeConstants.Success;
+                return CliExitCodes.Success;
             }
             else
             {
                 InteractionService.DisplayError(string.Format(CultureInfo.CurrentCulture, ErrorStrings.ConfigurationKeyNotFound, key));
-                return ExitCodeConstants.ConfigNotFound;
+                return CliExitCodes.ConfigNotFound;
             }
         }
     }
@@ -146,12 +146,12 @@ internal sealed class ConfigCommand : BaseCommand
 
             if (key is null)
             {
-                return CommandResult.Failure(ExitCodeConstants.InvalidCommand, ErrorStrings.ConfigurationKeyRequired);
+                return CommandResult.Failure(CliExitCodes.InvalidCommand, ErrorStrings.ConfigurationKeyRequired);
             }
 
             if (value is null)
             {
-                return CommandResult.Failure(ExitCodeConstants.InvalidCommand, ErrorStrings.ConfigurationValueRequired);
+                return CommandResult.Failure(CliExitCodes.InvalidCommand, ErrorStrings.ConfigurationValueRequired);
             }
 
             return CommandResult.FromExitCode(await ExecuteAsync(key, value, isGlobal, cancellationToken));
@@ -175,13 +175,13 @@ internal sealed class ConfigCommand : BaseCommand
             if (AppHostPathConfigurationPolicy.IsLegacyAppHostPathKey(key))
             {
                 InteractionService.DisplayError(ErrorStrings.LegacyAppHostPathCannotBeSetWithConfigCommand);
-                return ExitCodeConstants.InvalidCommand;
+                return CliExitCodes.InvalidCommand;
             }
 
             if (isGlobal && !AppHostPathConfigurationPolicy.IsGloballySettableKey(key))
             {
                 InteractionService.DisplayError(ErrorStrings.GlobalAppHostPathCannotBeSetWithConfigCommand);
-                return ExitCodeConstants.InvalidCommand;
+                return CliExitCodes.InvalidCommand;
             }
 
             try
@@ -193,14 +193,14 @@ internal sealed class ConfigCommand : BaseCommand
                     : string.Format(CultureInfo.CurrentCulture, ConfigCommandStrings.ConfigurationKeySetLocally, key,
                         value));
 
-                return ExitCodeConstants.Success;
+                return CliExitCodes.Success;
             }
             catch (Exception ex)
             {
                 var errorMessage = string.Format(CultureInfo.CurrentCulture, ErrorStrings.ErrorSettingConfiguration, ex.Message);
                 Telemetry.RecordError(errorMessage, ex);
                 InteractionService.DisplayError(errorMessage);
-                return ExitCodeConstants.InvalidCommand;
+                return CliExitCodes.InvalidCommand;
             }
         }
     }
@@ -239,7 +239,7 @@ internal sealed class ConfigCommand : BaseCommand
                 if (Path.Exists(settingsFilePath))
                 {
                     extensionInteractionService.OpenEditor(settingsFilePath);
-                    return ExitCodeConstants.Success;
+                    return CliExitCodes.Success;
                 }
             }
 
@@ -257,7 +257,7 @@ internal sealed class ConfigCommand : BaseCommand
                 {
                     // Show hint about --all flag when there's no config and user didn't pass --all
                     InteractionService.DisplayMarkupLine($"  [dim]{ConfigCommandStrings.ListCommand_AllFeaturesHint.EscapeMarkup()}[/]");
-                    return ExitCodeConstants.Success;
+                    return CliExitCodes.Success;
                 }
 
                 // showAll=true: fall through to show available features below
@@ -319,7 +319,7 @@ internal sealed class ConfigCommand : BaseCommand
                 }
             }
 
-            return ExitCodeConstants.Success;
+            return CliExitCodes.Success;
 
             static int MaxWidth(string header, IEnumerable<string> localValues, IEnumerable<string> globalValues)
             {
@@ -385,7 +385,7 @@ internal sealed class ConfigCommand : BaseCommand
 
             if (key is null)
             {
-                return CommandResult.Failure(ExitCodeConstants.InvalidCommand, ErrorStrings.ConfigurationKeyRequired);
+                return CommandResult.Failure(CliExitCodes.InvalidCommand, ErrorStrings.ConfigurationKeyRequired);
             }
 
             return CommandResult.FromExitCode(await ExecuteAsync(key, isGlobal, cancellationToken));
@@ -399,7 +399,7 @@ internal sealed class ConfigCommand : BaseCommand
             if (value is null)
             {
                 InteractionService.DisplayError(string.Format(CultureInfo.CurrentCulture, ErrorStrings.ConfigurationKeyNotFound, key));
-                return ExitCodeConstants.ConfigNotFound;
+                return CliExitCodes.ConfigNotFound;
             }
 
             var isGlobal = await InteractionService.PromptForSelectionAsync(
@@ -428,12 +428,12 @@ internal sealed class ConfigCommand : BaseCommand
                         InteractionService.DisplaySuccess(string.Format(CultureInfo.CurrentCulture, ConfigCommandStrings.ConfigurationKeyDeletedLocally, key));
                     }
 
-                    return ExitCodeConstants.Success;
+                    return CliExitCodes.Success;
                 }
                 else
                 {
                     InteractionService.DisplayError(string.Format(CultureInfo.CurrentCulture, ErrorStrings.ConfigurationKeyNotFound, key));
-                    return ExitCodeConstants.InvalidCommand;
+                    return CliExitCodes.InvalidCommand;
                 }
             }
             catch (Exception ex)
@@ -441,7 +441,7 @@ internal sealed class ConfigCommand : BaseCommand
                 var errorMessage = string.Format(CultureInfo.CurrentCulture, ErrorStrings.ErrorDeletingConfiguration, ex.Message);
                 Telemetry.RecordError(errorMessage, ex);
                 InteractionService.DisplayError(errorMessage);
-                return ExitCodeConstants.InvalidCommand;
+                return CliExitCodes.InvalidCommand;
             }
         }
     }
@@ -522,7 +522,7 @@ internal sealed class ConfigCommand : BaseCommand
                 }
             }
 
-            return Task.FromResult(ExitCodeConstants.Success);
+            return Task.FromResult(CliExitCodes.Success);
         }
     }
 }

--- a/src/Aspire.Cli/Commands/DashboardRunCommand.cs
+++ b/src/Aspire.Cli/Commands/DashboardRunCommand.cs
@@ -87,13 +87,13 @@ internal sealed class DashboardRunCommand : BaseCommand
         var layout = await _bundleService.EnsureExtractedAndGetLayoutAsync(cancellationToken).ConfigureAwait(false);
         if (layout is null)
         {
-            return CommandResult.Failure(ExitCodeConstants.DashboardFailure, DashboardCommandStrings.BundleLayoutNotFound);
+            return CommandResult.Failure(CliExitCodes.DashboardFailure, DashboardCommandStrings.BundleLayoutNotFound);
         }
 
         var managedPath = layout.GetManagedPath();
         if (managedPath is null || !File.Exists(managedPath))
         {
-            return CommandResult.Failure(ExitCodeConstants.DashboardFailure, DashboardCommandStrings.ManagedBinaryNotFound);
+            return CommandResult.Failure(CliExitCodes.DashboardFailure, DashboardCommandStrings.ManagedBinaryNotFound);
         }
 
         var dashboardArgs = new List<string> { "dashboard" };
@@ -384,7 +384,7 @@ internal sealed class DashboardRunCommand : BaseCommand
         {
             _logger.LogError(ex, "Failed to start dashboard process: {ManagedPath}", managedPath);
             _interactionService.DisplayError(string.Format(CultureInfo.CurrentCulture, DashboardCommandStrings.DashboardFailedToStart, ex.Message));
-            return CommandResult.Failure(ExitCodeConstants.DashboardFailure);
+            return CommandResult.Failure(CliExitCodes.DashboardFailure);
         }
 
         using var _ = process;
@@ -422,7 +422,7 @@ internal sealed class DashboardRunCommand : BaseCommand
 
             // Command is designed to be cancellable by the user (e.g. Ctrl+C) at any time.
             // Treat cancellation as a successful exit since the user intentionally stopped the dashboard.
-            return CommandResult.Cancelled(ExitCodeConstants.Success);
+            return CommandResult.Cancelled(CliExitCodes.Success);
         }
 
         if (completedTask != readyTcs.Task)
@@ -452,7 +452,7 @@ internal sealed class DashboardRunCommand : BaseCommand
                 process.Kill(entireProcessTree: true);
             }
 
-            return CommandResult.Failure(ExitCodeConstants.DashboardFailure);
+            return CommandResult.Failure(CliExitCodes.DashboardFailure);
         }
 
         // Dashboard is ready.
@@ -472,7 +472,7 @@ internal sealed class DashboardRunCommand : BaseCommand
                 process.Kill(entireProcessTree: true);
             }
 
-            return CommandResult.Cancelled(ExitCodeConstants.Success);
+            return CommandResult.Cancelled(CliExitCodes.Success);
         }
 
         if (process.ExitCode != 0)
@@ -480,6 +480,6 @@ internal sealed class DashboardRunCommand : BaseCommand
             _interactionService.DisplayError(GetExitCodeMessage(process.ExitCode));
         }
 
-        return process.ExitCode == 0 ? CommandResult.Success() : CommandResult.Failure(ExitCodeConstants.DashboardFailure);
+        return process.ExitCode == 0 ? CommandResult.Success() : CommandResult.Failure(CliExitCodes.DashboardFailure);
     }
 }

--- a/src/Aspire.Cli/Commands/DescribeCommand.cs
+++ b/src/Aspire.Cli/Commands/DescribeCommand.cs
@@ -203,7 +203,7 @@ internal sealed class DescribeCommand : BaseCommand
         if (resourceName is not null && snapshots.Count == 0)
         {
             _interactionService.DisplayError(string.Format(CultureInfo.CurrentCulture, DescribeCommandStrings.ResourceNotFound, resourceName));
-            return ExitCodeConstants.FailedToFindProject;
+            return CliExitCodes.FailedToFindProject;
         }
 
         var resourceList = ResourceSnapshotMapper.MapToResourceJsonList(snapshots, dashboardBaseUrl);
@@ -220,7 +220,7 @@ internal sealed class DescribeCommand : BaseCommand
             DisplayResourcesTable(snapshots, dashboardBaseUrl);
         }
 
-        return ExitCodeConstants.Success;
+        return CliExitCodes.Success;
     }
 
     private async Task<int> ExecuteWatchAsync(IAppHostAuxiliaryBackchannel connection, ResourceSnapshotWatcher resourceWatcher, string? dashboardBaseUrl, string? resourceName, OutputFormat format, CancellationToken cancellationToken)
@@ -282,7 +282,7 @@ internal sealed class DescribeCommand : BaseCommand
             }
         }
 
-        return ExitCodeConstants.Success;
+        return CliExitCodes.Success;
     }
     private void DisplayResourcesTable(IReadOnlyList<ResourceSnapshot> snapshots, string? dashboardBaseUrl)
     {

--- a/src/Aspire.Cli/Commands/DocsGetCommand.cs
+++ b/src/Aspire.Cli/Commands/DocsGetCommand.cs
@@ -74,7 +74,7 @@ internal sealed class DocsGetCommand : BaseCommand
 
         if (doc is null)
         {
-            return CommandResult.Failure(ExitCodeConstants.InvalidCommand, string.Format(CultureInfo.CurrentCulture, DocsCommandStrings.DocumentNotFound, slug));
+            return CommandResult.Failure(CliExitCodes.InvalidCommand, string.Format(CultureInfo.CurrentCulture, DocsCommandStrings.DocumentNotFound, slug));
         }
 
         if (format is OutputFormat.Json)

--- a/src/Aspire.Cli/Commands/DocsListCommand.cs
+++ b/src/Aspire.Cli/Commands/DocsListCommand.cs
@@ -61,7 +61,7 @@ internal sealed class DocsListCommand : BaseCommand
 
         if (docs.Count is 0)
         {
-            return CommandResult.Failure(ExitCodeConstants.InvalidCommand, DocsCommandStrings.NoDocumentationAvailable);
+            return CommandResult.Failure(CliExitCodes.InvalidCommand, DocsCommandStrings.NoDocumentationAvailable);
         }
 
         if (format is OutputFormat.Json)

--- a/src/Aspire.Cli/Commands/DoctorCommand.cs
+++ b/src/Aspire.Cli/Commands/DoctorCommand.cs
@@ -60,7 +60,7 @@ internal sealed class DoctorCommand : BaseCommand
 
         // Exit code: 0 if no failures (warnings are OK), 1 (InvalidCommand) if any failures
         var hasFailures = results.Any(r => r.Status == EnvironmentCheckStatus.Fail);
-        return CommandResult.FromExitCode(hasFailures ? ExitCodeConstants.InvalidCommand : ExitCodeConstants.Success);
+        return CommandResult.FromExitCode(hasFailures ? CliExitCodes.InvalidCommand : CliExitCodes.Success);
     }
 
     private void OutputJson(IReadOnlyList<EnvironmentCheckResult> results)

--- a/src/Aspire.Cli/Commands/ExportCommand.cs
+++ b/src/Aspire.Cli/Commands/ExportCommand.cs
@@ -94,7 +94,7 @@ internal sealed class ExportCommand : BaseCommand
         // Validate mutual exclusivity of --apphost and --dashboard-url
         if (passedAppHostProjectFile is not null && dashboardUrl is not null)
         {
-            return CommandResult.Failure(ExitCodeConstants.InvalidCommand, TelemetryCommandStrings.DashboardUrlAndAppHostExclusive);
+            return CommandResult.Failure(CliExitCodes.InvalidCommand, TelemetryCommandStrings.DashboardUrlAndAppHostExclusive);
         }
 
         // Default file name if not specified
@@ -133,12 +133,12 @@ internal sealed class ExportCommand : BaseCommand
             _logger.LogError(ex, "Failed to export telemetry data from dashboard");
             var errorInfo = await TelemetryCommandHelpers.FormatTelemetryErrorAsync(ex, dashboardApi.BaseUrl!, true, _httpClientFactory, _logger, cancellationToken);
             TelemetryCommandHelpers.DisplayTelemetryError(_interactionService, errorInfo);
-            return CommandResult.Failure(ExitCodeConstants.DashboardFailure);
+            return CommandResult.Failure(CliExitCodes.DashboardFailure);
         }
         catch (Exception ex)
         {
             _logger.LogError(ex, "Failed to export telemetry data");
-            return CommandResult.Failure(ExitCodeConstants.DashboardFailure, string.Format(CultureInfo.CurrentCulture, ExportCommandStrings.FailedToExport, ex.Message));
+            return CommandResult.Failure(CliExitCodes.DashboardFailure, string.Format(CultureInfo.CurrentCulture, ExportCommandStrings.FailedToExport, ex.Message));
         }
     }
 
@@ -178,13 +178,13 @@ internal sealed class ExportCommand : BaseCommand
             if (!ResourceSnapshotMapper.WhereMatchesResourceName(snapshots, resourceName).Any())
             {
                 _interactionService.DisplayError(string.Format(CultureInfo.CurrentCulture, ExportCommandStrings.ResourceNotFound, resourceName));
-                return ExitCodeConstants.InvalidCommand;
+                return CliExitCodes.InvalidCommand;
             }
         }
         else if (resourceName is null && connection is not null && snapshots.Count == 0)
         {
             _interactionService.DisplayMessage(KnownEmojis.Information, ExportCommandStrings.NoResourcesFound);
-            return ExitCodeConstants.Success;
+            return CliExitCodes.Success;
         }
 
         // Resolve which telemetry resources match the filter
@@ -236,7 +236,7 @@ internal sealed class ExportCommand : BaseCommand
         exportArchive.WriteToFile(fullPath);
 
         _interactionService.DisplayMessage(KnownEmojis.CheckMarkButton, string.Format(CultureInfo.CurrentCulture, ExportCommandStrings.ExportComplete, fullPath));
-        return ExitCodeConstants.Success;
+        return CliExitCodes.Success;
     }
 
     private static void AddResources(ExportArchive exportArchive, IReadOnlyList<ResourceSnapshot> snapshots, string? resourceName)

--- a/src/Aspire.Cli/Commands/ExtensionInternalCommand.cs
+++ b/src/Aspire.Cli/Commands/ExtensionInternalCommand.cs
@@ -23,7 +23,7 @@ internal sealed class ExtensionInternalCommand : BaseCommand
 
     protected override Task<CommandResult> ExecuteAsync(ParseResult parseResult, CancellationToken cancellationToken)
     {
-        return Task.FromResult(CommandResult.FromExitCode(ExitCodeConstants.Success));
+        return Task.FromResult(CommandResult.FromExitCode(CliExitCodes.Success));
     }
 
     private sealed class GetAppHostCandidatesCommand : BaseCommand
@@ -54,7 +54,7 @@ internal sealed class ExtensionInternalCommand : BaseCommand
             }
             catch
             {
-                return CommandResult.Failure(ExitCodeConstants.FailedToFindProject);
+                return CommandResult.Failure(CliExitCodes.FailedToFindProject);
             }
         }
     }

--- a/src/Aspire.Cli/Commands/InitCommand.cs
+++ b/src/Aspire.Cli/Commands/InitCommand.cs
@@ -131,7 +131,7 @@ internal sealed class InitCommand : BaseCommand
             ? await DropCSharpSkeletonAsync(workingDirectory, solutionFile, cancellationToken)
             : await DropPolyglotSkeletonAsync(selectedProject.LanguageId, workingDirectory, cancellationToken);
 
-        if (dropResult != ExitCodeConstants.Success)
+        if (dropResult != CliExitCodes.Success)
         {
             return CommandResult.Failure(dropResult, InteractionServiceStrings.ProjectCouldNotBeCreated);
         }
@@ -162,10 +162,10 @@ internal sealed class InitCommand : BaseCommand
         // This prompt lets users choose which skills to install — including aspireify.
         var workspaceRoot = solutionFile?.Directory ?? workingDirectory;
         var agentInitBinding = PromptBinding.CreateInvertedBoolConfirm(parseResult, NewCommand.s_suppressAgentInitOption, defaultValue: true);
-        var agentInitResult = await _agentInitCommand.PromptAndChainAsync(InteractionService, ExitCodeConstants.Success, workspaceRoot, agentInitBinding, cancellationToken);
+        var agentInitResult = await _agentInitCommand.PromptAndChainAsync(InteractionService, CliExitCodes.Success, workspaceRoot, agentInitBinding, cancellationToken);
 
         // Step 5: Print follow-up commands only when the user selected the one-time init skill.
-        if (agentInitResult.ExitCode == ExitCodeConstants.Success &&
+        if (agentInitResult.ExitCode == CliExitCodes.Success &&
             agentInitResult.SelectedSkills.Contains(SkillDefinition.Aspireify))
         {
             var commands = GetAspireifyCommands(agentInitResult.SelectedLocations);
@@ -260,7 +260,7 @@ internal sealed class InitCommand : BaseCommand
         if (File.Exists(appHostPath))
         {
             InteractionService.DisplayMessage(KnownEmojis.CheckMarkButton, "apphost.cs already exists — skipping.");
-            return ExitCodeConstants.Success;
+            return CliExitCodes.Success;
         }
 
         // Drop bare single-file apphost. Pin the SDK version so later operations
@@ -289,7 +289,7 @@ internal sealed class InitCommand : BaseCommand
         // had a `profiles` section. Use the SAME ports for apphost.run.json so the two
         // files always agree on dashboard / OTLP / resource service endpoints.
         var (configResult, effectivePorts) = DropAspireConfig(workingDirectory, "apphost.cs", language: null, ports);
-        if (configResult != ExitCodeConstants.Success)
+        if (configResult != CliExitCodes.Success)
         {
             return configResult;
         }
@@ -302,7 +302,7 @@ internal sealed class InitCommand : BaseCommand
         // `aspire run`, but `dotnet run apphost.cs` does not go through that path).
         DropAppHostRunJson(workingDirectory, effectivePorts);
 
-        return ExitCodeConstants.Success;
+        return CliExitCodes.Success;
     }
 
     private async Task<int> DropCSharpProjectSkeletonAsync(FileInfo solutionFile, CancellationToken cancellationToken)
@@ -342,7 +342,7 @@ internal sealed class InitCommand : BaseCommand
         if (Directory.Exists(appHostDirPath))
         {
             InteractionService.DisplayMessage(KnownEmojis.CheckMarkButton, $"{appHostDirName}/ already exists — skipping.");
-            return ExitCodeConstants.Success;
+            return CliExitCodes.Success;
         }
 
         // Resolve the channel-aware template package version + feed mapping. The running
@@ -382,12 +382,12 @@ internal sealed class InitCommand : BaseCommand
         catch (ChannelNotFoundException ex)
         {
             InteractionService.DisplayError(ex.Message);
-            return ExitCodeConstants.FailedToInstallTemplates;
+            return CliExitCodes.FailedToInstallTemplates;
         }
         catch (EmptyChoicesException ex)
         {
             InteractionService.DisplayError(ex.Message);
-            return ExitCodeConstants.FailedToInstallTemplates;
+            return CliExitCodes.FailedToInstallTemplates;
         }
         catch (NuGetPackageCacheException ex)
         {
@@ -396,7 +396,7 @@ internal sealed class InitCommand : BaseCommand
             // init code went straight to `dotnet new install` and never invoked a NuGet search, so this catch
             // restores parity with the prior init failure mode for these scenarios.
             InteractionService.DisplayError(ex.Message);
-            return ExitCodeConstants.FailedToInstallTemplates;
+            return CliExitCodes.FailedToInstallTemplates;
         }
 
         // The aspire-apphost template ships in the Aspire.ProjectTemplates package.
@@ -413,7 +413,7 @@ internal sealed class InitCommand : BaseCommand
         {
             InteractionService.DisplayLines(installOutcome.OutputLines);
             InteractionService.DisplayError(string.Format(CultureInfo.CurrentCulture, TemplatingStrings.TemplateInstallationFailed, installOutcome.ExitCode));
-            return ExitCodeConstants.FailedToInstallTemplates;
+            return CliExitCodes.FailedToInstallTemplates;
         }
 
         // Use the aspire-apphost template to generate a correct AppHost project
@@ -434,12 +434,12 @@ internal sealed class InitCommand : BaseCommand
         if (result != 0)
         {
             InteractionService.DisplayError($"Failed to create AppHost from template (exit code {result}).");
-            return ExitCodeConstants.FailedToCreateNewProject;
+            return CliExitCodes.FailedToCreateNewProject;
         }
 
         InteractionService.DisplayMessage(KnownEmojis.CheckMarkButton, $"Created {appHostDirName}/");
 
-        return ExitCodeConstants.Success;
+        return CliExitCodes.Success;
     }
 
     private async Task<int> DropPolyglotSkeletonAsync(string languageId, DirectoryInfo workingDirectory, CancellationToken cancellationToken)
@@ -454,18 +454,18 @@ internal sealed class InitCommand : BaseCommand
         if (File.Exists(appHostPath))
         {
             InteractionService.DisplayMessage(KnownEmojis.CheckMarkButton, $"{appHostFileName} already exists — skipping.");
-            return ExitCodeConstants.Success;
+            return CliExitCodes.Success;
         }
 
         var context = new ScaffoldContext(language, workingDirectory, workingDirectory.Name);
         var scaffolded = await _scaffoldingService.ScaffoldAsync(context, cancellationToken);
         if (!scaffolded)
         {
-            return ExitCodeConstants.FailedToCreateNewProject;
+            return CliExitCodes.FailedToCreateNewProject;
         }
 
         InteractionService.DisplayMessage(KnownEmojis.CheckMarkButton, $"Created {appHostFileName}");
-        return ExitCodeConstants.Success;
+        return CliExitCodes.Success;
     }
 
     private (int ExitCode, AppHostProfilePorts EffectivePorts) DropAspireConfig(DirectoryInfo directory, string appHostPath, string? language, AppHostProfilePorts? ports = null)
@@ -492,7 +492,7 @@ internal sealed class InitCommand : BaseCommand
                 {
                     InteractionService.DisplayError($"Failed to parse existing {AspireConfigFile.FileName} at '{configPath}': {ex.Message}");
                     InteractionService.DisplayMessage(KnownEmojis.Warning, $"Fix or remove {AspireConfigFile.FileName} and re-run `aspire init`.");
-                    return (ExitCodeConstants.FailedToCreateNewProject, default);
+                    return (CliExitCodes.FailedToCreateNewProject, default);
                 }
             }
         }
@@ -576,7 +576,7 @@ internal sealed class InitCommand : BaseCommand
         File.WriteAllText(configPath, JsonSerializer.Serialize(settings, JsonSourceGenerationContext.RelaxedEscaping.JsonObject));
 
         InteractionService.DisplayMessage(KnownEmojis.CheckMarkButton, $"Created {AspireConfigFile.FileName}");
-        return (ExitCodeConstants.Success, effectivePorts);
+        return (CliExitCodes.Success, effectivePorts);
     }
 
     // Best-effort extraction of the dashboard / OTLP / resource service ports from an

--- a/src/Aspire.Cli/Commands/IntegrationPackageSearchService.cs
+++ b/src/Aspire.Cli/Commands/IntegrationPackageSearchService.cs
@@ -107,7 +107,7 @@ internal sealed class IntegrationPackageSearchService(
         catch (JsonException ex)
         {
             interactionService.DisplayError(ex.Message);
-            return (ConfiguredChannel: null, ExitCode: ExitCodeConstants.FailedToLoadConfiguration);
+            return (ConfiguredChannel: null, ExitCode: CliExitCodes.FailedToLoadConfiguration);
         }
     }
 

--- a/src/Aspire.Cli/Commands/IntegrationSearchCommand.cs
+++ b/src/Aspire.Cli/Commands/IntegrationSearchCommand.cs
@@ -86,7 +86,7 @@ internal abstract class IntegrationDiscoveryCommand : BaseCommand
         {
             var errorMessage = string.Format(CultureInfo.CurrentCulture, AddCommandStrings.ErrorOccurredWhileSearchingIntegrations, ex.Message);
             Telemetry.RecordError(errorMessage, ex);
-            return CommandResult.Failure(ExitCodeConstants.FailedToSearchIntegrations, errorMessage);
+            return CommandResult.Failure(CliExitCodes.FailedToSearchIntegrations, errorMessage);
         }
     }
 
@@ -115,7 +115,7 @@ internal abstract class IntegrationDiscoveryCommand : BaseCommand
         {
             var json = JsonSerializer.Serialize(results, JsonSourceGenerationContext.RelaxedEscaping.IntegrationSearchResultArray);
             InteractionService.DisplayRawText(json, ConsoleOutput.Standard);
-            return ExitCodeConstants.Success;
+            return CliExitCodes.Success;
         }
 
         if (results.Length == 0)
@@ -129,7 +129,7 @@ internal abstract class IntegrationDiscoveryCommand : BaseCommand
                 InteractionService.DisplayError(AddCommandStrings.NoPackagesFound);
             }
 
-            return ExitCodeConstants.Success;
+            return CliExitCodes.Success;
         }
 
         if (searchTerm is not null)
@@ -155,7 +155,7 @@ internal abstract class IntegrationDiscoveryCommand : BaseCommand
         }
 
         InteractionService.DisplayRenderable(table);
-        return ExitCodeConstants.Success;
+        return CliExitCodes.Success;
     }
 }
 

--- a/src/Aspire.Cli/Commands/LogsCommand.cs
+++ b/src/Aspire.Cli/Commands/LogsCommand.cs
@@ -160,7 +160,7 @@ internal sealed class LogsCommand : BaseCommand
         // Validate --tail value
         if (tail.HasValue && tail.Value < 1)
         {
-            return CommandResult.Failure(ExitCodeConstants.InvalidCommand, LogsCommandStrings.TailMustBePositive);
+            return CommandResult.Failure(CliExitCodes.InvalidCommand, LogsCommandStrings.TailMustBePositive);
         }
 
         var result = await _connectionResolver.ResolveConnectionAsync(
@@ -190,7 +190,7 @@ internal sealed class LogsCommand : BaseCommand
         {
             if (!ResourceSnapshotMapper.WhereMatchesResourceName(resourceWatcher.GetAllResources(), resourceName).Any())
             {
-                return CommandResult.Failure(ExitCodeConstants.InvalidCommand, string.Format(CultureInfo.CurrentCulture, LogsCommandStrings.ResourceNotFound, resourceName));
+                return CommandResult.Failure(CliExitCodes.InvalidCommand, string.Format(CultureInfo.CurrentCulture, LogsCommandStrings.ResourceNotFound, resourceName));
             }
         }
         else
@@ -295,7 +295,7 @@ internal sealed class LogsCommand : BaseCommand
             }
         }
 
-        return ExitCodeConstants.Success;
+        return CliExitCodes.Success;
     }
 
     private async Task<int> ExecuteWatchAsync(
@@ -368,7 +368,7 @@ internal sealed class LogsCommand : BaseCommand
             OutputLogLine(entry, format, timestamps);
         }
 
-        return ExitCodeConstants.Success;
+        return CliExitCodes.Success;
     }
 
     /// <summary>

--- a/src/Aspire.Cli/Commands/McpCallCommand.cs
+++ b/src/Aspire.Cli/Commands/McpCallCommand.cs
@@ -79,7 +79,7 @@ internal sealed class McpCallCommand : BaseCommand
 
         if (!result.Success)
         {
-            return CommandResult.FromExitCode(AppHostConnectionResultHandler.DisplayFailureAsError(result, _interactionService, ExitCodeConstants.FailedToDotnetRunAppHost));
+            return CommandResult.FromExitCode(AppHostConnectionResultHandler.DisplayFailureAsError(result, _interactionService, CliExitCodes.FailedToDotnetRunAppHost));
         }
 
         var connection = result.Connection!;
@@ -93,7 +93,7 @@ internal sealed class McpCallCommand : BaseCommand
                 using var doc = JsonDocument.Parse(inputJson);
                 if (doc.RootElement.ValueKind != JsonValueKind.Object)
                 {
-                    return CommandResult.Failure(ExitCodeConstants.InvalidCommand, "Invalid JSON input: expected a JSON object.");
+                    return CommandResult.Failure(CliExitCodes.InvalidCommand, "Invalid JSON input: expected a JSON object.");
                 }
                 var dict = new Dictionary<string, JsonElement>();
                 foreach (var prop in doc.RootElement.EnumerateObject())
@@ -104,7 +104,7 @@ internal sealed class McpCallCommand : BaseCommand
             }
             catch (JsonException ex)
             {
-                return CommandResult.Failure(ExitCodeConstants.InvalidCommand, $"Invalid JSON input: {ex.Message}");
+                return CommandResult.Failure(CliExitCodes.InvalidCommand, $"Invalid JSON input: {ex.Message}");
             }
         }
 
@@ -141,14 +141,14 @@ internal sealed class McpCallCommand : BaseCommand
 
             if (callResult.IsError == true)
             {
-                return CommandResult.Failure(ExitCodeConstants.InvalidCommand);
+                return CommandResult.Failure(CliExitCodes.InvalidCommand);
             }
 
             return CommandResult.Success();
         }
         catch (Exception ex)
         {
-            return CommandResult.Failure(ExitCodeConstants.InvalidCommand, $"Failed to call tool '{toolName}' on resource '{resourceName}': {ex.Message}");
+            return CommandResult.Failure(CliExitCodes.InvalidCommand, $"Failed to call tool '{toolName}' on resource '{resourceName}': {ex.Message}");
         }
     }
 }

--- a/src/Aspire.Cli/Commands/NewCommand.cs
+++ b/src/Aspire.Cli/Commands/NewCommand.cs
@@ -401,13 +401,13 @@ internal sealed class NewCommand : BaseCommand, IPackageMetaPrefetchingCommand
         var template = await GetProjectTemplateAsync(availableTemplates, parseResult, cancellationToken);
         if (template is null)
         {
-            return CommandResult.Failure(ExitCodeConstants.InvalidCommand);
+            return CommandResult.Failure(CliExitCodes.InvalidCommand);
         }
 
         var (languageResolutionSuccess, selectedLanguageId) = await ResolveSelectedLanguageAsync(template, parseResult, cancellationToken);
         if (!languageResolutionSuccess)
         {
-            return CommandResult.Failure(ExitCodeConstants.InvalidCommand);
+            return CommandResult.Failure(CliExitCodes.InvalidCommand);
         }
 
         var version = parseResult.GetValue(s_versionOption);
@@ -418,7 +418,7 @@ internal sealed class NewCommand : BaseCommand, IPackageMetaPrefetchingCommand
             var resolveResult = await ResolveCliTemplateVersionAsync(parseResult, cancellationToken);
             if (!resolveResult.Success)
             {
-                return CommandResult.Failure(ExitCodeConstants.InvalidCommand, resolveResult.ErrorMessage);
+                return CommandResult.Failure(CliExitCodes.InvalidCommand, resolveResult.ErrorMessage);
             }
 
             version = resolveResult.Version;

--- a/src/Aspire.Cli/Commands/PipelineCommandBase.cs
+++ b/src/Aspire.Cli/Commands/PipelineCommandBase.cs
@@ -153,7 +153,7 @@ internal abstract class PipelineCommandBase : BaseCommand
 
                 if (passedAppHostProjectFile is null)
                 {
-                    return CommandResult.Failure(ExitCodeConstants.FailedToFindProject);
+                    return CommandResult.Failure(CliExitCodes.FailedToFindProject);
                 }
             }
 
@@ -186,7 +186,7 @@ internal abstract class PipelineCommandBase : BaseCommand
             {
                 // Send terminal progress bar stop sequence
                 StopTerminalProgressBar();
-                return CommandResult.Failure(ExitCodeConstants.FailedToFindProject);
+                return CommandResult.Failure(CliExitCodes.FailedToFindProject);
             }
 
             var project = _projectFactory.GetProject(effectiveAppHostFile);
@@ -234,7 +234,7 @@ internal abstract class PipelineCommandBase : BaseCommand
                 InteractionService.DisplayMessage(KnownEmojis.Bug, InteractionServiceStrings.WaitingForDebuggerToAttachToAppHost);
             }
 
-            var backchannel = await InteractionService.ShowStatusAsync(GetProgressMessage(parseResult), async () =>
+            var backchannel = await InteractionService.ShowStatusAsync(GetProgressMessage(parseResult), (Func<Task<IAppHostCliBackchannel>>)(async () =>
             {
                 var completedTask = await Task.WhenAny(backchannelCompletionSource.Task, pendingRun);
                 if (completedTask == backchannelCompletionSource.Task)
@@ -252,7 +252,7 @@ internal abstract class PipelineCommandBase : BaseCommand
                 // DotNetCliRunner returns Success immediately after delegating to LaunchAppHostAsync,
                 // so pendingRun completes before the backchannel is established. In this case,
                 // continue waiting for the backchannel rather than throwing.
-                if (!completedTask.IsFaulted && await pendingRun == ExitCodeConstants.Success
+                if (!completedTask.IsFaulted && await pendingRun == CliExitCodes.Success
                     && ExtensionHelper.IsExtensionHost(InteractionService, out _, out _))
                 {
                     return await backchannelCompletionSource.Task;
@@ -262,7 +262,7 @@ internal abstract class PipelineCommandBase : BaseCommand
                 // Include possible error if the run task faulted.
                 var innerException = completedTask.IsFaulted ? completedTask.Exception : null;
                 throw new InvalidOperationException("Run completed without returning a backchannel.", innerException);
-            }, emoji: KnownEmojis.HammerAndWrench);
+            }), emoji: KnownEmojis.HammerAndWrench);
 
             // If --list-steps was specified, get pipeline steps and print them instead of executing
             var listSteps = parseResult.GetValue(s_listStepsOption);
@@ -322,7 +322,7 @@ internal abstract class PipelineCommandBase : BaseCommand
             // return a failure exit code.
             if (!noFailuresReported)
             {
-                return CommandResult.Failure(ExitCodeConstants.FailedToBuildArtifacts);
+                return CommandResult.Failure(CliExitCodes.FailedToBuildArtifacts);
             }
 
             // Both apphost exit code and backchannel indicate success
@@ -335,7 +335,7 @@ internal abstract class PipelineCommandBase : BaseCommand
             _logger.LogDebug(ex, "Operation was cancelled.");
             var canceledMessage = GetCanceledMessage();
             Telemetry.RecordError(canceledMessage, ex);
-            return CommandResult.Failure(ExitCodeConstants.FailedToBuildArtifacts, canceledMessage);
+            return CommandResult.Failure(CliExitCodes.FailedToBuildArtifacts, canceledMessage);
         }
         catch (ProjectLocatorException ex)
         {
@@ -347,14 +347,14 @@ internal abstract class PipelineCommandBase : BaseCommand
         {
             // SDK not installed - message already displayed by EnsureSdkInstalledAsync
             StopTerminalProgressBar();
-            return CommandResult.Failure(ExitCodeConstants.SdkNotInstalled);
+            return CommandResult.Failure(CliExitCodes.SdkNotInstalled);
         }
         catch (AppHostIncompatibleException ex)
         {
             // Send terminal progress bar stop sequence on exception
             StopTerminalProgressBar();
             Telemetry.RecordError($"AppHost is incompatible. Required capability: {ex.RequiredCapability}", ex);
-            return CommandResult.Failure(ExitCodeConstants.AppHostIncompatible, ex.Message);
+            return CommandResult.Failure(CliExitCodes.AppHostIncompatible, ex.Message);
         }
         catch (FailedToConnectBackchannelConnection ex)
         {
@@ -367,7 +367,7 @@ internal abstract class PipelineCommandBase : BaseCommand
             {
                 InteractionService.DisplayLines(outputCollector.GetLines());
             }
-            return CommandResult.Failure(ExitCodeConstants.FailedToBuildArtifacts);
+            return CommandResult.Failure(CliExitCodes.FailedToBuildArtifacts);
         }
         catch (ConnectionLostException ex)
         {
@@ -380,7 +380,7 @@ internal abstract class PipelineCommandBase : BaseCommand
             {
                 InteractionService.DisplayLines(outputCollector.GetLines());
             }
-            return CommandResult.FromExitCode(pendingRun is { } && debugMode ? await pendingRun : ExitCodeConstants.FailedToBuildArtifacts);
+            return CommandResult.FromExitCode(pendingRun is { } && debugMode ? await pendingRun : CliExitCodes.FailedToBuildArtifacts);
         }
         catch (Exception ex)
         {
@@ -393,7 +393,7 @@ internal abstract class PipelineCommandBase : BaseCommand
             {
                 InteractionService.DisplayLines(outputCollector.GetLines());
             }
-            return CommandResult.Failure(ExitCodeConstants.FailedToBuildArtifacts);
+            return CommandResult.Failure(CliExitCodes.FailedToBuildArtifacts);
         }
     }
 

--- a/src/Aspire.Cli/Commands/PsCommand.cs
+++ b/src/Aspire.Cli/Commands/PsCommand.cs
@@ -30,6 +30,9 @@ internal sealed class AppHostDisplayInfo
     public string? DashboardUrl { get; init; }
 
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? LogFilePath { get; init; }
+
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     public List<ResourceJson>? Resources { get; set; }
 }
 
@@ -164,6 +167,7 @@ internal sealed class PsCommand : BaseCommand
             var appHostPath = info.AppHostPath;
             var appHostPid = info.ProcessId;
             var cliPid = info.CliProcessId;
+            var cliLogFilePath = info.CliLogFilePath;
 
             try
             {
@@ -175,6 +179,7 @@ internal sealed class PsCommand : BaseCommand
                         sdkVersion = GetSdkVersion(v2Info.AspireHostVersion);
                         appHostPath = string.IsNullOrWhiteSpace(v2Info.AppHostPath) ? appHostPath : v2Info.AppHostPath;
                         cliPid = v2Info.CliProcessId ?? cliPid;
+                        cliLogFilePath = v2Info.CliLogFilePath ?? cliLogFilePath;
 
                         if (int.TryParse(v2Info.Pid, NumberStyles.Integer, CultureInfo.InvariantCulture, out var parsedPid))
                         {
@@ -221,6 +226,7 @@ internal sealed class PsCommand : BaseCommand
                 SdkVersion = sdkVersion,
                 CliPid = cliPid,
                 DashboardUrl = dashboardUrl,
+                LogFilePath = cliLogFilePath,
                 Resources = resources
             });
         }
@@ -248,11 +254,20 @@ internal sealed class PsCommand : BaseCommand
 
         var shortPaths = FileSystemHelper.ShortenPaths(appHosts.Select(a => a.AppHostPath).ToList());
 
+        // Only show the CLI Log column when at least one app host has a log file path.
+        var includeCliLog = appHosts.Any(a => !string.IsNullOrEmpty(a.LogFilePath));
+
         var table = new Table();
         table.AddBoldColumn(PsCommandStrings.HeaderPath);
         table.AddBoldColumn(PsCommandStrings.HeaderSdk);
         table.AddBoldColumn(PsCommandStrings.HeaderPid);
         table.AddBoldColumn(PsCommandStrings.HeaderCliPid);
+
+        if (includeCliLog)
+        {
+            table.AddBoldColumn(PsCommandStrings.HeaderCliLog);
+        }
+
         table.AddBoldColumn(PsCommandStrings.HeaderDashboard);
 
         foreach (var appHost in appHosts)
@@ -272,12 +287,28 @@ internal sealed class PsCommand : BaseCommand
                 }
             }
 
-            table.AddRow(
+            var columns = new List<string>
+            {
                 Markup.Escape(shortPath),
                 Markup.Escape(appHost.SdkVersion ?? "-"),
                 appHost.AppHostPid.ToString(CultureInfo.InvariantCulture),
                 cliPid,
-                dashboard);
+            };
+
+            if (includeCliLog)
+            {
+                var logDisplay = "-";
+                if (!string.IsNullOrEmpty(appHost.LogFilePath))
+                {
+                    logDisplay = MarkupHelpers.SafeFileLink(_interactionService, appHost.LogFilePath, Path.GetFileName(appHost.LogFilePath));
+                }
+
+                columns.Add(logDisplay);
+            }
+
+            columns.Add(dashboard);
+
+            table.AddRow(columns.ToArray());
         }
 
         _interactionService.DisplayRenderable(table);

--- a/src/Aspire.Cli/Commands/RenderCommand.cs
+++ b/src/Aspire.Cli/Commands/RenderCommand.cs
@@ -140,7 +140,7 @@ internal sealed class RenderCommand : BaseCommand
                 cancellationToken: cancellationToken);
 
             var exitCode = await ExecuteChoiceAsync(choice, parseResult.GetValue(s_consoleWidthOption), cancellationToken);
-            if (choice == "exit" || exitCode != ExitCodeConstants.Success)
+            if (choice == "exit" || exitCode != CliExitCodes.Success)
             {
                 return CommandResult.FromExitCode(exitCode);
             }
@@ -178,7 +178,7 @@ internal sealed class RenderCommand : BaseCommand
                     return await TestChoiceSimpleAsync(cancellationToken);
                 case "mixed":
                     await TestMixedMethodsAsync(cancellationToken);
-                    return ExitCodeConstants.Success;
+                    return CliExitCodes.Success;
                 case "markdown-interactive":
                     return TestMarkdownRenderInteractive();
                 case "markdown-plain":
@@ -194,7 +194,7 @@ internal sealed class RenderCommand : BaseCommand
                 case "publish-summary-all":
                     return RenderPublishSummaryScenarios(s_publishSummaryScenarioDescriptions.Keys.Where(k => !StringComparers.CommandName.Equals(k, "publish-summary-all")));
                 case "exit":
-                    return ExitCodeConstants.Success;
+                    return CliExitCodes.Success;
                 default:
                     if (s_publishSummaryScenarioDescriptions.ContainsKey(choice))
                     {
@@ -203,7 +203,7 @@ internal sealed class RenderCommand : BaseCommand
 
                     InteractionService.DisplayError($"Unknown render scenario '{choice}'.");
                     InteractionService.DisplayPlainText("Use 'aspire render --list-scenarios' to see supported values.");
-                    return ExitCodeConstants.InvalidCommand;
+                    return CliExitCodes.InvalidCommand;
             }
         }
         finally
@@ -234,7 +234,7 @@ internal sealed class RenderCommand : BaseCommand
             InteractionService.DisplayMessage(emoji, $"DisplayMessage with {emoji.Name}");
         }
 
-        return ExitCodeConstants.Success;
+        return CliExitCodes.Success;
     }
 
     private int TestDisplayStyles()
@@ -243,7 +243,7 @@ internal sealed class RenderCommand : BaseCommand
         InteractionService.DisplaySuccess("Operation completed successfully.");
         InteractionService.DisplaySubtleMessage("This is a subtle hint.");
         InteractionService.DisplayCancellationMessage();
-        return ExitCodeConstants.Success;
+        return CliExitCodes.Success;
     }
 
     private async Task<int> TestShowStatusAsync(CancellationToken cancellationToken)
@@ -260,7 +260,7 @@ internal sealed class RenderCommand : BaseCommand
                 emoji: emoji);
         }
 
-        return ExitCodeConstants.Success;
+        return CliExitCodes.Success;
     }
 
     private async Task<int> TestShowStatusWithMarkupAsync(CancellationToken cancellationToken)
@@ -275,7 +275,7 @@ internal sealed class RenderCommand : BaseCommand
             emoji: KnownEmojis.Package,
             allowMarkup: true);
 
-        return ExitCodeConstants.Success;
+        return CliExitCodes.Success;
     }
 
     private async Task<int> TestShowStatusEscapedAsync(CancellationToken cancellationToken)
@@ -289,7 +289,7 @@ internal sealed class RenderCommand : BaseCommand
             },
             emoji: KnownEmojis.Package);
 
-        return ExitCodeConstants.Success;
+        return CliExitCodes.Success;
     }
 
     private async Task<int> TestChoiceWithFormatterAsync(CancellationToken cancellationToken)
@@ -310,7 +310,7 @@ internal sealed class RenderCommand : BaseCommand
             p => $"{p.Item1.EscapeMarkup()} [dim]v{p.Item2}[/] ({p.Item3})",
             cancellationToken: cancellationToken);
 
-        return ExitCodeConstants.Success;
+        return CliExitCodes.Success;
     }
 
     private async Task<int> TestChoiceSimpleAsync(CancellationToken cancellationToken)
@@ -324,7 +324,7 @@ internal sealed class RenderCommand : BaseCommand
             cancellationToken: cancellationToken);
 
         InteractionService.DisplayMessage(KnownEmojis.Rocket, $"Deploying to {selected}...");
-        return ExitCodeConstants.Success;
+        return CliExitCodes.Success;
     }
 
     private async Task TestMixedMethodsAsync(CancellationToken cancellationToken)
@@ -393,7 +393,7 @@ internal sealed class RenderCommand : BaseCommand
         InteractionService.DisplayMarkupLine($"SafeLink: {MarkupHelpers.SafeLink(InteractionService, "https://www.aspire.dev/", "Aspire documentation")}");
         InteractionService.DisplayMarkupLine($"SafeFileLink: {MarkupHelpers.SafeFileLink(InteractionService, filePath)}");
 
-        return ExitCodeConstants.Success;
+        return CliExitCodes.Success;
     }
 
     private int RenderPublishSummaryScenarios(IEnumerable<string> scenarioKeys)
@@ -410,7 +410,7 @@ internal sealed class RenderCommand : BaseCommand
             logger.WriteSummary();
         }
 
-        return ExitCodeConstants.Success;
+        return CliExitCodes.Success;
     }
 
     private static PublishSummaryRenderScenario CreatePublishSummaryScenario(string scenarioKey) => scenarioKey switch
@@ -512,7 +512,7 @@ internal sealed class RenderCommand : BaseCommand
         var succeeded = await command.ProcessPublishingActivitiesDebugAsync(activities, backchannel: null!, cancellationToken);
         InteractionService.DisplayEmptyLine();
         InteractionService.DisplaySubtleMessage($"ProcessPublishingActivitiesDebugAsync returned succeeded={succeeded}", allowMarkup: false);
-        return ExitCodeConstants.Success;
+        return CliExitCodes.Success;
     }
 
     private async Task<int> RenderPipelineActivitiesAsync(CancellationToken cancellationToken)
@@ -522,7 +522,7 @@ internal sealed class RenderCommand : BaseCommand
         var succeeded = await command.ProcessAndDisplayPublishingActivitiesAsync(activities, backchannel: null!, isDebugOrTraceLoggingEnabled: true, cancellationToken);
         InteractionService.DisplayEmptyLine();
         InteractionService.DisplaySubtleMessage($"ProcessAndDisplayPublishingActivitiesAsync returned succeeded={succeeded}", allowMarkup: false);
-        return ExitCodeConstants.Success;
+        return CliExitCodes.Success;
     }
 
 #pragma warning disable IDE0060 // Remove unused parameter — cancellationToken is used by the generated async iterator via [EnumeratorCancellation]
@@ -779,14 +779,14 @@ internal sealed class RenderCommand : BaseCommand
     private int TestMarkdownRenderInteractive()
     {
         InteractionService.DisplayMarkdown(MarkdownShowcase);
-        return ExitCodeConstants.Success;
+        return CliExitCodes.Success;
     }
 
     private int TestMarkdownRenderPlainText()
     {
         var plainText = MarkdownToSpectreConverter.ConvertToPlainText(MarkdownShowcase);
         InteractionService.DisplayRawText(plainText);
-        return ExitCodeConstants.Success;
+        return CliExitCodes.Success;
     }
 
     private int TestMarkdownRenderRenderable()
@@ -803,7 +803,7 @@ internal sealed class RenderCommand : BaseCommand
         console.Write(renderable);
 
         InteractionService.DisplayRawText(writer.ToString());
-        return ExitCodeConstants.Success;
+        return CliExitCodes.Success;
     }
 }
 

--- a/src/Aspire.Cli/Commands/ResourceCommand.cs
+++ b/src/Aspire.Cli/Commands/ResourceCommand.cs
@@ -129,7 +129,7 @@ internal sealed class ResourceCommand : BaseCommand
 
         if (!result.Success)
         {
-            return CommandResult.FromExitCode(AppHostConnectionResultHandler.DisplayFailureAsError(result, _interactionService, ExitCodeConstants.FailedToFindProject));
+            return CommandResult.FromExitCode(AppHostConnectionResultHandler.DisplayFailureAsError(result, _interactionService, CliExitCodes.FailedToFindProject));
         }
 
         var connection = result.Connection!;
@@ -137,7 +137,7 @@ internal sealed class ResourceCommand : BaseCommand
         var commandArgumentsResult = CreateCommandArguments(command, capturedArguments);
         if (commandArgumentsResult.ErrorMessage is { } errorMessage)
         {
-            return CommandResult.Failure(ExitCodeConstants.InvalidCommand, errorMessage);
+            return CommandResult.Failure(CliExitCodes.InvalidCommand, errorMessage);
         }
 
         var commandArguments = commandArgumentsResult.Arguments;
@@ -541,7 +541,7 @@ internal sealed class ResourceCommand : BaseCommand
             }
 
             WriteResourceCommandHelp(parseResult.InvocationConfiguration.Output, parseResult.CommandResult, request.ResourceName, resourceCommand);
-            return ExitCodeConstants.Success;
+            return CliExitCodes.Success;
         }
 
         private async Task WriteAvailableCommandsAsync(ParseResult parseResult, string resourceName, CancellationToken cancellationToken)

--- a/src/Aspire.Cli/Commands/ResourceCommandHelper.cs
+++ b/src/Aspire.Cli/Commands/ResourceCommandHelper.cs
@@ -93,7 +93,7 @@ internal static class ResourceCommandHelper
         else if (response.Canceled)
         {
             interactionService.DisplayMessage(KnownEmojis.Warning, $"Command '{commandName}' on '{resourceName}' was canceled.");
-            return ExitCodeConstants.FailedToExecuteResourceCommand;
+            return CliExitCodes.FailedToExecuteResourceCommand;
         }
         else
         {
@@ -109,7 +109,7 @@ internal static class ResourceCommandHelper
             DisplayCommandResult(interactionService, response.Value);
         }
 
-        return response.Success ? ExitCodeConstants.Success : ExitCodeConstants.FailedToExecuteResourceCommand;
+        return response.Success ? CliExitCodes.Success : CliExitCodes.FailedToExecuteResourceCommand;
     }
 
     private static int HandleResponse(
@@ -127,7 +127,7 @@ internal static class ResourceCommandHelper
         else if (response.Canceled)
         {
             interactionService.DisplayMessage(KnownEmojis.Warning, $"{progressVerb} command for '{resourceName}' was canceled.");
-            return ExitCodeConstants.FailedToExecuteResourceCommand;
+            return CliExitCodes.FailedToExecuteResourceCommand;
         }
         else
         {
@@ -143,7 +143,7 @@ internal static class ResourceCommandHelper
             DisplayCommandResult(interactionService, response.Value);
         }
 
-        return response.Success ? ExitCodeConstants.Success : ExitCodeConstants.FailedToExecuteResourceCommand;
+        return response.Success ? CliExitCodes.Success : CliExitCodes.FailedToExecuteResourceCommand;
     }
 
     private static void DisplayCommandResult(IInteractionService interactionService, ExecuteResourceCommandResult result)

--- a/src/Aspire.Cli/Commands/RestoreCommand.cs
+++ b/src/Aspire.Cli/Commands/RestoreCommand.cs
@@ -109,26 +109,26 @@ internal sealed class RestoreCommand : BaseCommand
                     return CommandResult.Success();
                 }
 
-                return CommandResult.Failure(ExitCodeConstants.FailedToBuildArtifacts);
+                return CommandResult.Failure(CliExitCodes.FailedToBuildArtifacts);
             }
 
             if (effectiveAppHostFile is null)
             {
-                return CommandResult.Failure(ExitCodeConstants.FailedToFindProject);
+                return CommandResult.Failure(CliExitCodes.FailedToFindProject);
             }
 
             var project = _projectFactory.TryGetProject(effectiveAppHostFile);
 
             if (project is null)
             {
-                return CommandResult.Failure(ExitCodeConstants.FailedToFindProject, RestoreCommandStrings.UnrecognizedAppHostType);
+                return CommandResult.Failure(CliExitCodes.FailedToFindProject, RestoreCommandStrings.UnrecognizedAppHostType);
             }
 
             if (project is DotNetAppHostProject)
             {
                 if (!await SdkInstallHelper.EnsureSdkInstalledAsync(_sdkInstaller, InteractionService, Telemetry, cancellationToken: cancellationToken))
                 {
-                    return CommandResult.Failure(ExitCodeConstants.SdkNotInstalled);
+                    return CommandResult.Failure(CliExitCodes.SdkNotInstalled);
                 }
 
                 var appHostDirectory = effectiveAppHostFile.Directory!;
@@ -146,7 +146,7 @@ internal sealed class RestoreCommand : BaseCommand
                     return CommandResult.Success();
                 }
 
-                return CommandResult.Failure(ExitCodeConstants.FailedToBuildArtifacts);
+                return CommandResult.Failure(CliExitCodes.FailedToBuildArtifacts);
             }
 
             if (project is GuestAppHostProject guestProject)
@@ -166,10 +166,10 @@ internal sealed class RestoreCommand : BaseCommand
                     return CommandResult.Success();
                 }
 
-                return CommandResult.Failure(ExitCodeConstants.FailedToBuildArtifacts);
+                return CommandResult.Failure(CliExitCodes.FailedToBuildArtifacts);
             }
 
-            return CommandResult.Failure(ExitCodeConstants.FailedToFindProject, RestoreCommandStrings.UnrecognizedAppHostType);
+            return CommandResult.Failure(CliExitCodes.FailedToFindProject, RestoreCommandStrings.UnrecognizedAppHostType);
         }
         catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
         {
@@ -183,7 +183,7 @@ internal sealed class RestoreCommand : BaseCommand
         {
             var errorMessage = string.Format(CultureInfo.CurrentCulture, InteractionServiceStrings.UnexpectedErrorOccurred, ex.Message);
             Telemetry.RecordError(errorMessage, ex);
-            return CommandResult.Failure(ExitCodeConstants.FailedToBuildArtifacts, errorMessage);
+            return CommandResult.Failure(CliExitCodes.FailedToBuildArtifacts, errorMessage);
         }
     }
 

--- a/src/Aspire.Cli/Commands/RootCommand.cs
+++ b/src/Aspire.Cli/Commands/RootCommand.cs
@@ -182,21 +182,21 @@ internal sealed class RootCommand : BaseRootCommand
         Options.Add(CliWaitForDebuggerOption);
 
         // Handle standalone 'aspire' or 'aspire --banner' (no subcommand)
-        this.SetAction((context, cancellationToken) =>
+        this.SetAction((Func<ParseResult, CancellationToken, Task<int>>)((context, cancellationToken) =>
         {
             var bannerRequested = context.GetValue(BannerOption);
             if (bannerRequested)
             {
                 // If --banner was passed, we've already shown it in Main, just exit successfully
-                return Task.FromResult(ExitCodeConstants.Success);
+                return Task.FromResult((int)CliExitCodes.Success);
             }
 
             // No subcommand provided - show grouped help but return InvalidCommand to signal usage error
             var writer = _ansiConsole.Profile.Out.Writer;
             var consoleWidth = _ansiConsole.Profile.Width;
             GroupedHelpWriter.WriteHelp(this, writer, consoleWidth);
-            return Task.FromResult(ExitCodeConstants.InvalidCommand);
-        });
+            return Task.FromResult((int)CliExitCodes.InvalidCommand);
+        }));
 
         Subcommands.Add(newCommand);
         Subcommands.Add(initCommand);

--- a/src/Aspire.Cli/Commands/RunCommand.cs
+++ b/src/Aspire.Cli/Commands/RunCommand.cs
@@ -151,7 +151,7 @@ internal sealed class RunCommand : BaseCommand
         // Validate that --format is only used with --detach
         if (format == OutputFormat.Json && !detach)
         {
-            return CommandResult.Failure(ExitCodeConstants.InvalidCommand, RunCommandStrings.FormatRequiresDetach);
+            return CommandResult.Failure(CliExitCodes.InvalidCommand, RunCommandStrings.FormatRequiresDetach);
         }
 
         // Validate that --no-build is not used when watch mode would be enabled
@@ -159,7 +159,7 @@ internal sealed class RunCommand : BaseCommand
         var watchModeEnabled = _features.IsFeatureEnabled(KnownFeatures.DefaultWatchEnabled, defaultValue: false) || (isExtensionHost && !startDebugSession);
         if (noBuild && watchModeEnabled)
         {
-            return CommandResult.Failure(ExitCodeConstants.InvalidCommand, RunCommandStrings.NoBuildNotSupportedWithWatchMode);
+            return CommandResult.Failure(CliExitCodes.InvalidCommand, RunCommandStrings.NoBuildNotSupportedWithWatchMode);
         }
 
         // Handle detached mode - spawn child process and exit
@@ -213,7 +213,7 @@ internal sealed class RunCommand : BaseCommand
             if (effectiveAppHostFile is null)
             {
                 runActivity?.SetTag(TelemetryConstants.Tags.ErrorType, "project_not_found");
-                return CommandResult.Failure(ExitCodeConstants.FailedToFindProject);
+                return CommandResult.Failure(CliExitCodes.FailedToFindProject);
             }
 
             // Resolve the language for this file and get the appropriate handler
@@ -221,7 +221,7 @@ internal sealed class RunCommand : BaseCommand
             if (project is null)
             {
                 runActivity?.SetTag(TelemetryConstants.Tags.ErrorType, "project_not_found");
-                return CommandResult.Failure(ExitCodeConstants.FailedToFindProject, "Unrecognized app host type.");
+                return CommandResult.Failure(CliExitCodes.FailedToFindProject, "Unrecognized app host type.");
             }
 
             runActivity?.SetTag(TelemetryConstants.Tags.AppHostLanguage, project.LanguageId);
@@ -437,8 +437,8 @@ internal sealed class RunCommand : BaseCommand
                 lifetimeActivity.SetProcessExitCode(exitCode);
 
                 // Cancelled by user (e.g., Ctrl+C) - treat as successful exit since the user intentionally stopped the AppHost.
-                return exitCode == ExitCodeConstants.Cancelled
-                    ? CommandResult.Cancelled(ExitCodeConstants.Success)
+                return exitCode == CliExitCodes.Cancelled
+                    ? CommandResult.Cancelled(CliExitCodes.Success)
                     : CommandResult.FromExitCode(exitCode);
             }
         }
@@ -448,7 +448,7 @@ internal sealed class RunCommand : BaseCommand
 
             // Command is designed to be cancellable by the user (e.g. Ctrl+C) at any time.
             // Treat cancellation as a successful exit since the user intentionally stopped the AppHost.
-            return CommandResult.Cancelled(ExitCodeConstants.Success);
+            return CommandResult.Cancelled(CliExitCodes.Success);
         }
         catch (ProjectLocatorException ex)
         {
@@ -466,14 +466,14 @@ internal sealed class RunCommand : BaseCommand
             runActivity?.SetTag(TelemetryConstants.Tags.ErrorType, "certificate_trust_failed");
             var errorMessage = string.Format(CultureInfo.CurrentCulture, TemplatingStrings.CertificateTrustError, ex.Message);
             Telemetry.RecordError(errorMessage, ex);
-            return CommandResult.Failure(ExitCodeConstants.FailedToTrustCertificates, errorMessage);
+            return CommandResult.Failure(CliExitCodes.FailedToTrustCertificates, errorMessage);
         }
         catch (FailedToConnectBackchannelConnection ex)
         {
             runActivity?.SetTag(TelemetryConstants.Tags.ErrorType, "backchannel_connection_failed");
             var errorMessage = string.Format(CultureInfo.CurrentCulture, InteractionServiceStrings.ErrorConnectingToAppHost, ex.Message);
             Telemetry.RecordError(errorMessage, ex);
-            return CommandResult.Failure(ExitCodeConstants.FailedToDotnetRunAppHost, errorMessage);
+            return CommandResult.Failure(CliExitCodes.FailedToDotnetRunAppHost, errorMessage);
         }
         catch (ConnectionLostException) when (isExtensionHost)
         {
@@ -486,7 +486,7 @@ internal sealed class RunCommand : BaseCommand
             runActivity?.SetTag(TelemetryConstants.Tags.ErrorType, ex.GetType().FullName);
             var errorMessage = string.Format(CultureInfo.CurrentCulture, InteractionServiceStrings.UnexpectedErrorOccurred, ex.Message);
             Telemetry.RecordError(errorMessage, ex);
-            return CommandResult.Failure(ExitCodeConstants.FailedToDotnetRunAppHost, errorMessage);
+            return CommandResult.Failure(CliExitCodes.FailedToDotnetRunAppHost, errorMessage);
         }
         finally
         {
@@ -695,16 +695,16 @@ internal sealed class RunCommand : BaseCommand
     /// <para><b>Failure Modes:</b></para>
     /// <list type="number">
     /// <item><b>Project not found</b>: No AppHost project found in the current directory or specified path.
-    /// Returns <see cref="ExitCodeConstants.FailedToFindProject"/>.</item>
+    /// Returns <see cref="CliExitCodes.FailedToFindProject"/>.</item>
     /// <item><b>Failed to spawn child process</b>: Process.Start fails (e.g., executable not found).
-    /// Returns <see cref="ExitCodeConstants.FailedToDotnetRunAppHost"/>.</item>
+    /// Returns <see cref="CliExitCodes.FailedToDotnetRunAppHost"/>.</item>
     /// <item><b>Child process exits early</b>: The child 'aspire run' process exits before the backchannel
     /// is established (e.g., build failure, configuration error). Detected via WaitForExitAsync racing
     /// with the poll delay. Shows exit code and log file path.
-    /// Returns <see cref="ExitCodeConstants.FailedToDotnetRunAppHost"/>.</item>
+    /// Returns <see cref="CliExitCodes.FailedToDotnetRunAppHost"/>.</item>
     /// <item><b>Timeout waiting for backchannel</b>: The auxiliary backchannel socket doesn't appear
     /// within 120 seconds. The child process is killed. Shows timeout message and log file path.
-    /// Returns <see cref="ExitCodeConstants.FailedToDotnetRunAppHost"/>.</item>
+    /// Returns <see cref="CliExitCodes.FailedToDotnetRunAppHost"/>.</item>
     /// </list>
     /// <para>On any failure, the log file path is displayed so the user can investigate.</para>
     /// </remarks>

--- a/src/Aspire.Cli/Commands/Sdk/SdkDumpCommand.cs
+++ b/src/Aspire.Cli/Commands/Sdk/SdkDumpCommand.cs
@@ -84,7 +84,7 @@ internal sealed class SdkDumpCommand : BaseCommand
                 var projectFile = new FileInfo(arg);
                 if (!projectFile.Exists)
                 {
-                    return CommandResult.Failure(ExitCodeConstants.FailedToFindProject, $"Integration project not found: {projectFile.FullName}");
+                    return CommandResult.Failure(CliExitCodes.FailedToFindProject, $"Integration project not found: {projectFile.FullName}");
                 }
 
                 integrations.Add(IntegrationReference.FromProject(
@@ -99,12 +99,12 @@ internal sealed class SdkDumpCommand : BaseCommand
 
                 if (string.IsNullOrWhiteSpace(packageName) || string.IsNullOrWhiteSpace(packageVersion) || packageName.Contains('@'))
                 {
-                    return CommandResult.Failure(ExitCodeConstants.InvalidCommand, $"Invalid package format '{arg}'. Expected PackageName@Version (e.g. Aspire.Hosting.Redis@9.2.0).");
+                    return CommandResult.Failure(CliExitCodes.InvalidCommand, $"Invalid package format '{arg}'. Expected PackageName@Version (e.g. Aspire.Hosting.Redis@9.2.0).");
                 }
 
                 if (!SemVersion.TryParse(packageVersion, SemVersionStyles.Any, out _))
                 {
-                    return CommandResult.Failure(ExitCodeConstants.InvalidCommand, $"Invalid version '{packageVersion}' in '{arg}'. Expected a valid NuGet version (e.g. 9.2.0).");
+                    return CommandResult.Failure(CliExitCodes.InvalidCommand, $"Invalid version '{packageVersion}' in '{arg}'. Expected a valid NuGet version (e.g. 9.2.0).");
                 }
 
                 _logger.LogDebug("Parsed package reference {PackageName} version {Version}", packageName, packageVersion);
@@ -112,7 +112,7 @@ internal sealed class SdkDumpCommand : BaseCommand
             }
             else
             {
-                return CommandResult.Failure(ExitCodeConstants.InvalidCommand, $"Invalid integration argument '{arg}'. Expected a .csproj path or PackageName@Version format.");
+                return CommandResult.Failure(CliExitCodes.InvalidCommand, $"Invalid integration argument '{arg}'. Expected a .csproj path or PackageName@Version format.");
             }
         }
 
@@ -159,7 +159,7 @@ internal sealed class SdkDumpCommand : BaseCommand
                         InteractionService.DisplayMessage(KnownEmojis.Wrench, line);
                     }
                 }
-                return ExitCodeConstants.FailedToBuildArtifacts;
+                return CliExitCodes.FailedToBuildArtifacts;
             }
 
             await using var serverSession = AppHostServerSession.Start(
@@ -228,7 +228,7 @@ internal sealed class SdkDumpCommand : BaseCommand
 
             // Return error code if there are errors in diagnostics
             var hasErrors = capabilities.Diagnostics.Exists(d => d.Severity == "Error");
-            return hasErrors ? ExitCodeConstants.InvalidCommand : ExitCodeConstants.Success;
+            return hasErrors ? CliExitCodes.InvalidCommand : CliExitCodes.Success;
         }
         finally
         {

--- a/src/Aspire.Cli/Commands/Sdk/SdkGenerateCommand.cs
+++ b/src/Aspire.Cli/Commands/Sdk/SdkGenerateCommand.cs
@@ -68,19 +68,19 @@ internal sealed class SdkGenerateCommand : BaseCommand
         // Validate the integration project exists
         if (!integrationProject.Exists)
         {
-            return CommandResult.Failure(ExitCodeConstants.FailedToFindProject, $"Integration project not found: {integrationProject.FullName}");
+            return CommandResult.Failure(CliExitCodes.FailedToFindProject, $"Integration project not found: {integrationProject.FullName}");
         }
 
         if (!integrationProject.Extension.Equals(".csproj", StringComparison.OrdinalIgnoreCase))
         {
-            return CommandResult.Failure(ExitCodeConstants.InvalidCommand, $"Expected a .csproj file, got: {integrationProject.Extension}");
+            return CommandResult.Failure(CliExitCodes.InvalidCommand, $"Expected a .csproj file, got: {integrationProject.Extension}");
         }
 
         // Resolve the language info
         var languageInfo = await GetLanguageInfoAsync(language, cancellationToken);
         if (languageInfo is null)
         {
-            return CommandResult.Failure(ExitCodeConstants.InvalidCommand, $"Unsupported language: {language}");
+            return CommandResult.Failure(CliExitCodes.InvalidCommand, $"Unsupported language: {language}");
         }
 
         // Create output directory if it doesn't exist
@@ -154,7 +154,7 @@ internal sealed class SdkGenerateCommand : BaseCommand
                         InteractionService.DisplayMessage(KnownEmojis.Wrench, line);
                     }
                 }
-                return ExitCodeConstants.FailedToBuildArtifacts;
+                return CliExitCodes.FailedToBuildArtifacts;
             }
 
             await using var serverSession = AppHostServerSession.Start(
@@ -193,7 +193,7 @@ internal sealed class SdkGenerateCommand : BaseCommand
 
             InteractionService.DisplaySuccess($"Generated {generatedFiles.Count} files in {outputDir.FullName}");
 
-            return ExitCodeConstants.Success;
+            return CliExitCodes.Success;
         }
         finally
         {

--- a/src/Aspire.Cli/Commands/SecretDeleteCommand.cs
+++ b/src/Aspire.Cli/Commands/SecretDeleteCommand.cs
@@ -49,12 +49,12 @@ internal sealed class SecretDeleteCommand : BaseCommand
         var result = await _secretStoreResolver.ResolveAsync(projectFile, autoInit: false, cancellationToken);
         if (result is null)
         {
-            return CommandResult.Failure(ExitCodeConstants.FailedToFindProject, SecretCommandStrings.CouldNotFindAppHost);
+            return CommandResult.Failure(CliExitCodes.FailedToFindProject, SecretCommandStrings.CouldNotFindAppHost);
         }
 
         if (!result.Store.Remove(key))
         {
-            return CommandResult.Failure(ExitCodeConstants.ConfigNotFound, string.Format(CultureInfo.CurrentCulture, SecretCommandStrings.SecretNotFound, key.EscapeMarkup()));
+            return CommandResult.Failure(CliExitCodes.ConfigNotFound, string.Format(CultureInfo.CurrentCulture, SecretCommandStrings.SecretNotFound, key.EscapeMarkup()));
         }
 
         result.Store.Save();

--- a/src/Aspire.Cli/Commands/SecretGetCommand.cs
+++ b/src/Aspire.Cli/Commands/SecretGetCommand.cs
@@ -49,13 +49,13 @@ internal sealed class SecretGetCommand : BaseCommand
         var result = await _secretStoreResolver.ResolveAsync(projectFile, autoInit: false, cancellationToken);
         if (result is null)
         {
-            return CommandResult.Failure(ExitCodeConstants.FailedToFindProject, SecretCommandStrings.CouldNotFindAppHost);
+            return CommandResult.Failure(CliExitCodes.FailedToFindProject, SecretCommandStrings.CouldNotFindAppHost);
         }
 
         var value = result.Store.Get(key);
         if (value is null)
         {
-            return CommandResult.Failure(ExitCodeConstants.ConfigNotFound, string.Format(CultureInfo.CurrentCulture, SecretCommandStrings.SecretNotFound, key.EscapeMarkup()));
+            return CommandResult.Failure(CliExitCodes.ConfigNotFound, string.Format(CultureInfo.CurrentCulture, SecretCommandStrings.SecretNotFound, key.EscapeMarkup()));
         }
 
         // Write value to stdout (machine-readable)

--- a/src/Aspire.Cli/Commands/SecretListCommand.cs
+++ b/src/Aspire.Cli/Commands/SecretListCommand.cs
@@ -49,7 +49,7 @@ internal sealed class SecretListCommand : BaseCommand
         var result = await _secretStoreResolver.ResolveAsync(projectFile, autoInit: false, cancellationToken);
         if (result is null)
         {
-            return CommandResult.Failure(ExitCodeConstants.FailedToFindProject, SecretCommandStrings.CouldNotFindAppHost);
+            return CommandResult.Failure(CliExitCodes.FailedToFindProject, SecretCommandStrings.CouldNotFindAppHost);
         }
 
         var secrets = result.Store.ToList();

--- a/src/Aspire.Cli/Commands/SecretPathCommand.cs
+++ b/src/Aspire.Cli/Commands/SecretPathCommand.cs
@@ -39,7 +39,7 @@ internal sealed class SecretPathCommand : BaseCommand
         var result = await _secretStoreResolver.ResolveAsync(projectFile, autoInit: false, cancellationToken);
         if (result is null)
         {
-            return CommandResult.Failure(ExitCodeConstants.FailedToFindProject, SecretCommandStrings.CouldNotFindAppHost);
+            return CommandResult.Failure(CliExitCodes.FailedToFindProject, SecretCommandStrings.CouldNotFindAppHost);
         }
 
         InteractionService.DisplayRawText(result.Store.FilePath, consoleOverride: ConsoleOutput.Standard);

--- a/src/Aspire.Cli/Commands/SecretSetCommand.cs
+++ b/src/Aspire.Cli/Commands/SecretSetCommand.cs
@@ -57,7 +57,7 @@ internal sealed class SecretSetCommand : BaseCommand
         var result = await _secretStoreResolver.ResolveAsync(projectFile, autoInit: true, cancellationToken);
         if (result is null)
         {
-            return CommandResult.Failure(ExitCodeConstants.FailedToFindProject, SecretCommandStrings.CouldNotFindAppHost);
+            return CommandResult.Failure(CliExitCodes.FailedToFindProject, SecretCommandStrings.CouldNotFindAppHost);
         }
 
         result.Store.Set(key, value);

--- a/src/Aspire.Cli/Commands/SetupCommand.cs
+++ b/src/Aspire.Cli/Commands/SetupCommand.cs
@@ -52,7 +52,7 @@ internal sealed class SetupCommand : BaseCommand
         var processPath = Environment.ProcessPath;
         if (string.IsNullOrEmpty(processPath))
         {
-            return CommandResult.Failure(ExitCodeConstants.FailedToBuildArtifacts, "Could not determine the CLI executable path.");
+            return CommandResult.Failure(CliExitCodes.FailedToBuildArtifacts, "Could not determine the CLI executable path.");
         }
 
         // `aspire setup` uses a route-independent default (parent of the binary's dir).
@@ -65,7 +65,7 @@ internal sealed class SetupCommand : BaseCommand
 
         if (string.IsNullOrEmpty(installPath))
         {
-            return CommandResult.Failure(ExitCodeConstants.FailedToBuildArtifacts, "Could not determine the installation path.");
+            return CommandResult.Failure(CliExitCodes.FailedToBuildArtifacts, "Could not determine the installation path.");
         }
 
         // Extract with spinner
@@ -93,7 +93,7 @@ internal sealed class SetupCommand : BaseCommand
                 break;
 
             case BundleExtractResult.ExtractionFailed:
-                return CommandResult.Failure(ExitCodeConstants.FailedToBuildArtifacts, $"Bundle was extracted to {installPath} but layout validation failed.");
+                return CommandResult.Failure(CliExitCodes.FailedToBuildArtifacts, $"Bundle was extracted to {installPath} but layout validation failed.");
         }
 
         return exitCode;

--- a/src/Aspire.Cli/Commands/StopCommand.cs
+++ b/src/Aspire.Cli/Commands/StopCommand.cs
@@ -74,7 +74,7 @@ internal sealed class StopCommand : BaseCommand
         // Validate mutual exclusivity of --all and --project
         if (stopAll && passedAppHostProjectFile is not null)
         {
-            return CommandResult.Failure(CompleteStopActivity(activity, ExitCodeConstants.FailedToFindProject), string.Format(CultureInfo.InvariantCulture, StopCommandStrings.AllAndProjectMutuallyExclusive, s_allOption.Name, s_appHostOption.Name));
+            return CommandResult.Failure(CompleteStopActivity(activity, CliExitCodes.FailedToFindProject), string.Format(CultureInfo.InvariantCulture, StopCommandStrings.AllAndProjectMutuallyExclusive, s_allOption.Name, s_appHostOption.Name));
         }
 
         // Handle --all: stop all running AppHosts
@@ -112,7 +112,7 @@ internal sealed class StopCommand : BaseCommand
         if (allConnections.Length == 0)
         {
             _interactionService.DisplayError(SharedCommandStrings.AppHostNotRunning);
-            return ExitCodeConstants.FailedToFindProject;
+            return CliExitCodes.FailedToFindProject;
         }
 
         // In non-interactive mode, only consider in-scope AppHosts (under current directory)
@@ -129,7 +129,7 @@ internal sealed class StopCommand : BaseCommand
 
         // Multiple in-scope AppHosts or none in scope: error with guidance
         _interactionService.DisplayError(string.Format(CultureInfo.InvariantCulture, StopCommandStrings.MultipleAppHostsNonInteractive, s_appHostOption.Name, s_allOption.Name));
-        return ExitCodeConstants.FailedToFindProject;
+        return CliExitCodes.FailedToFindProject;
     }
 
     /// <summary>
@@ -166,7 +166,7 @@ internal sealed class StopCommand : BaseCommand
         if (allConnections.Length == 0)
         {
             _interactionService.DisplayError(SharedCommandStrings.AppHostNotRunning);
-            return ExitCodeConstants.FailedToFindProject;
+            return CliExitCodes.FailedToFindProject;
         }
 
         _logger.LogDebug("Found {Count} running AppHost(s) to stop", allConnections.Length);
@@ -190,11 +190,11 @@ internal sealed class StopCommand : BaseCommand
         }).ToArray();
 
         var results = await Task.WhenAll(stopTasks);
-        var allStopped = results.All(exitCode => exitCode == ExitCodeConstants.Success);
+        var allStopped = results.All(exitCode => exitCode == CliExitCodes.Success);
 
         _logger.LogDebug("Stop all completed. All stopped: {AllStopped}", allStopped);
 
-        return allStopped ? ExitCodeConstants.Success : ExitCodeConstants.FailedToDotnetRunAppHost;
+        return allStopped ? CliExitCodes.Success : CliExitCodes.FailedToDotnetRunAppHost;
     }
 
     /// <summary>
@@ -276,7 +276,7 @@ internal sealed class StopCommand : BaseCommand
             else if (!rpcSucceeded)
             {
                 _interactionService.DisplayError(string.Format(CultureInfo.CurrentCulture, StopCommandStrings.FailedToStopAppHost, appHostIdentifier));
-                return CompleteStopActivity(activity, ExitCodeConstants.FailedToDotnetRunAppHost);
+                return CompleteStopActivity(activity, CliExitCodes.FailedToDotnetRunAppHost);
             }
         }
 
@@ -325,19 +325,19 @@ internal sealed class StopCommand : BaseCommand
         if (stopped)
         {
             _interactionService.DisplaySuccess(string.Format(CultureInfo.CurrentCulture, StopCommandStrings.AppHostStoppedSuccessfully, appHostIdentifier));
-            return CompleteStopActivity(activity, ExitCodeConstants.Success);
+            return CompleteStopActivity(activity, CliExitCodes.Success);
         }
         else
         {
             _interactionService.DisplayError(string.Format(CultureInfo.CurrentCulture, StopCommandStrings.FailedToStopAppHost, appHostIdentifier));
-            return CompleteStopActivity(activity, ExitCodeConstants.FailedToDotnetRunAppHost);
+            return CompleteStopActivity(activity, CliExitCodes.FailedToDotnetRunAppHost);
         }
     }
 
     private static int CompleteStopActivity(ProfilingTelemetry.ActivityScope activity, int exitCode)
     {
         activity.SetProcessExitCode(exitCode);
-        if (exitCode != ExitCodeConstants.Success)
+        if (exitCode != CliExitCodes.Success)
         {
             activity.SetError($"Stop exited with code {exitCode}.");
         }

--- a/src/Aspire.Cli/Commands/TelemetryCommandHelpers.cs
+++ b/src/Aspire.Cli/Commands/TelemetryCommandHelpers.cs
@@ -201,7 +201,7 @@ internal static class TelemetryCommandHelpers
         if (projectFile is not null && dashboardUrl is not null)
         {
             interactionService.DisplayError(TelemetryCommandStrings.DashboardUrlAndAppHostExclusive);
-            return DashboardApiResult.Failure(ExitCodeConstants.InvalidCommand);
+            return DashboardApiResult.Failure(CliExitCodes.InvalidCommand);
         }
 
         // Direct dashboard URL mode — bypass AppHost discovery
@@ -220,7 +220,7 @@ internal static class TelemetryCommandHelpers
                     new TelemetryErrorInfo(
                         string.Format(CultureInfo.CurrentCulture, TelemetryCommandStrings.DashboardUrlInvalid, dashboardUrl),
                         TelemetryCommandStrings.DashboardUrlInvalidHint));
-                return DashboardApiResult.Failure(ExitCodeConstants.InvalidCommand);
+                return DashboardApiResult.Failure(CliExitCodes.InvalidCommand);
             }
 
             // If no explicit --api-key was provided but a login token was found in the URL,
@@ -245,7 +245,7 @@ internal static class TelemetryCommandHelpers
                             TelemetryCommandStrings.DashboardLoginTokenFailedAnonymousHint),
                     };
                     DisplayTelemetryError(interactionService, errorInfo);
-                    return DashboardApiResult.Failure(ExitCodeConstants.DashboardFailure);
+                    return DashboardApiResult.Failure(CliExitCodes.DashboardFailure);
                 }
 
                 apiKey = exchangeResult.ApiKey;
@@ -279,7 +279,7 @@ internal static class TelemetryCommandHelpers
                     new TelemetryErrorInfo(
                         TelemetryCommandStrings.DashboardNotAvailable,
                         TelemetryCommandStrings.DashboardNotAvailableHint));
-                return DashboardApiResult.Failure(ExitCodeConstants.DashboardFailure);
+                return DashboardApiResult.Failure(CliExitCodes.DashboardFailure);
             }
 
             // Dashboard is optional — return success with null API info

--- a/src/Aspire.Cli/Commands/TelemetryLogsCommand.cs
+++ b/src/Aspire.Cli/Commands/TelemetryLogsCommand.cs
@@ -101,7 +101,7 @@ internal sealed class TelemetryLogsCommand : BaseCommand
         // Validate --limit value
         if (limit.HasValue && limit.Value < 1)
         {
-            return CommandResult.Failure(ExitCodeConstants.InvalidCommand, TelemetryCommandStrings.LimitMustBePositive);
+            return CommandResult.Failure(CliExitCodes.InvalidCommand, TelemetryCommandStrings.LimitMustBePositive);
         }
 
         var dashboardApi = await TelemetryCommandHelpers.GetDashboardApiAsync(
@@ -144,7 +144,7 @@ internal sealed class TelemetryLogsCommand : BaseCommand
             if (!TelemetryCommandHelpers.TryResolveResourceNames(resource, resources, out var resolvedResources))
             {
                 _interactionService.DisplayError($"Resource '{resource}' not found.");
-                return ExitCodeConstants.InvalidCommand;
+                return CliExitCodes.InvalidCommand;
             }
 
             // Build URL with query parameters
@@ -166,7 +166,7 @@ internal sealed class TelemetryLogsCommand : BaseCommand
             _logger.LogError(ex, "Failed to fetch logs from Dashboard API");
             var errorInfo = await TelemetryCommandHelpers.FormatTelemetryErrorAsync(ex, baseUrl, dashboardOnly, _httpClientFactory, _logger, cancellationToken);
             TelemetryCommandHelpers.DisplayTelemetryError(_interactionService, errorInfo);
-            return ExitCodeConstants.DashboardFailure;
+            return CliExitCodes.DashboardFailure;
         }
     }
 
@@ -189,7 +189,7 @@ internal sealed class TelemetryLogsCommand : BaseCommand
             DisplayLogsSnapshot(json, allResources);
         }
 
-        return ExitCodeConstants.Success;
+        return CliExitCodes.Success;
     }
 
     private async Task<int> StreamLogsAsync(HttpClient client, string url, OutputFormat format, IReadOnlyList<IOtlpResource> allResources, string dashboardUrl, CancellationToken cancellationToken)
@@ -215,7 +215,7 @@ internal sealed class TelemetryLogsCommand : BaseCommand
             }
         }
 
-        return ExitCodeConstants.Success;
+        return CliExitCodes.Success;
     }
 
     private void DisplayLogsSnapshot(string json, IReadOnlyList<IOtlpResource> allResources)

--- a/src/Aspire.Cli/Commands/TelemetrySpansCommand.cs
+++ b/src/Aspire.Cli/Commands/TelemetrySpansCommand.cs
@@ -94,7 +94,7 @@ internal sealed class TelemetrySpansCommand : BaseCommand
         // Validate --limit value
         if (limit.HasValue && limit.Value < 1)
         {
-            return CommandResult.Failure(ExitCodeConstants.InvalidCommand, TelemetryCommandStrings.LimitMustBePositive);
+            return CommandResult.Failure(CliExitCodes.InvalidCommand, TelemetryCommandStrings.LimitMustBePositive);
         }
 
         var dashboardApi = await TelemetryCommandHelpers.GetDashboardApiAsync(
@@ -137,7 +137,7 @@ internal sealed class TelemetrySpansCommand : BaseCommand
             if (!TelemetryCommandHelpers.TryResolveResourceNames(resource, resources, out var resolvedResources))
             {
                 _interactionService.DisplayError($"Resource '{resource}' not found.");
-                return ExitCodeConstants.InvalidCommand;
+                return CliExitCodes.InvalidCommand;
             }
 
             // Build URL with query parameters
@@ -161,7 +161,7 @@ internal sealed class TelemetrySpansCommand : BaseCommand
             _logger.LogError(ex, "Failed to fetch spans from Dashboard API");
             var errorInfo = await TelemetryCommandHelpers.FormatTelemetryErrorAsync(ex, baseUrl, dashboardOnly, _httpClientFactory, _logger, cancellationToken);
             TelemetryCommandHelpers.DisplayTelemetryError(_interactionService, errorInfo);
-            return ExitCodeConstants.DashboardFailure;
+            return CliExitCodes.DashboardFailure;
         }
     }
 
@@ -184,7 +184,7 @@ internal sealed class TelemetrySpansCommand : BaseCommand
             DisplaySpansSnapshot(json, allResources, dashboardUrl);
         }
 
-        return ExitCodeConstants.Success;
+        return CliExitCodes.Success;
     }
 
     private async Task<int> StreamSpansAsync(HttpClient client, string url, OutputFormat format, IReadOnlyList<IOtlpResource> allResources, string dashboardUrl, CancellationToken cancellationToken)
@@ -210,7 +210,7 @@ internal sealed class TelemetrySpansCommand : BaseCommand
             }
         }
 
-        return ExitCodeConstants.Success;
+        return CliExitCodes.Success;
     }
 
     private void DisplaySpansSnapshot(string json, IReadOnlyList<IOtlpResource> allResources, string dashboardUrl)

--- a/src/Aspire.Cli/Commands/TelemetryTracesCommand.cs
+++ b/src/Aspire.Cli/Commands/TelemetryTracesCommand.cs
@@ -92,7 +92,7 @@ internal sealed class TelemetryTracesCommand : BaseCommand
         // Validate --limit value
         if (limit.HasValue && limit.Value < 1)
         {
-            return CommandResult.Failure(ExitCodeConstants.InvalidCommand, TelemetryCommandStrings.LimitMustBePositive);
+            return CommandResult.Failure(CliExitCodes.InvalidCommand, TelemetryCommandStrings.LimitMustBePositive);
         }
 
         var dashboardApi = await TelemetryCommandHelpers.GetDashboardApiAsync(
@@ -119,7 +119,7 @@ internal sealed class TelemetryTracesCommand : BaseCommand
             _logger.LogError(ex, "Failed to fetch traces from Dashboard API");
             var errorInfo = await TelemetryCommandHelpers.FormatTelemetryErrorAsync(ex, dashboardApi.BaseUrl!, dashboardUrl is not null, _httpClientFactory, _logger, cancellationToken);
             TelemetryCommandHelpers.DisplayTelemetryError(_interactionService, errorInfo);
-            return CommandResult.Failure(ExitCodeConstants.DashboardFailure);
+            return CommandResult.Failure(CliExitCodes.DashboardFailure);
         }
     }
 
@@ -149,7 +149,7 @@ internal sealed class TelemetryTracesCommand : BaseCommand
         if (response.StatusCode == System.Net.HttpStatusCode.NotFound)
         {
             _interactionService.DisplayError(string.Format(CultureInfo.CurrentCulture, TelemetryCommandStrings.TraceNotFound, traceId));
-            return ExitCodeConstants.InvalidCommand;
+            return CliExitCodes.InvalidCommand;
         }
 
         TelemetryCommandHelpers.EnsureTelemetryApiResponse(response);
@@ -178,7 +178,7 @@ internal sealed class TelemetryTracesCommand : BaseCommand
             DisplayTraceDetails(json, traceId, allOtlpResources, dashboardUrl);
         }
 
-        return ExitCodeConstants.Success;
+        return CliExitCodes.Success;
     }
 
     private async Task<int> FetchTracesAsync(
@@ -201,7 +201,7 @@ internal sealed class TelemetryTracesCommand : BaseCommand
         if (!TelemetryCommandHelpers.TryResolveResourceNames(resource, resources, out var resolvedResources))
         {
             _interactionService.DisplayError($"Resource '{resource}' not found.");
-            return ExitCodeConstants.InvalidCommand;
+            return CliExitCodes.InvalidCommand;
         }
 
         var allOtlpResources = TelemetryCommandHelpers.ToOtlpResources(resources);
@@ -230,7 +230,7 @@ internal sealed class TelemetryTracesCommand : BaseCommand
             DisplayTracesTable(json, allOtlpResources, dashboardUrl);
         }
 
-        return ExitCodeConstants.Success;
+        return CliExitCodes.Success;
     }
 
     private void DisplayTracesTable(string json, IReadOnlyList<IOtlpResource> allResources, string dashboardUrl)

--- a/src/Aspire.Cli/Commands/UpdateCommand.cs
+++ b/src/Aspire.Cli/Commands/UpdateCommand.cs
@@ -129,7 +129,7 @@ internal sealed class UpdateCommand : BaseCommand
 
             if (_cliDownloader is null)
             {
-                return CommandResult.Failure(ExitCodeConstants.InvalidCommand, "CLI self-update is not available in this environment.");
+                return CommandResult.Failure(CliExitCodes.InvalidCommand, "CLI self-update is not available in this environment.");
             }
 
             try
@@ -149,7 +149,7 @@ internal sealed class UpdateCommand : BaseCommand
             var projectFile = await _projectLocator.UseOrFindAppHostProjectFileAsync(passedAppHostProjectFile, createSettingsFile: true, cancellationToken);
             if (projectFile is null)
             {
-                return CommandResult.Failure(ExitCodeConstants.FailedToFindProject);
+                return CommandResult.Failure(CliExitCodes.FailedToFindProject);
             }
 
             var project = _projectFactory.GetProject(projectFile);
@@ -274,13 +274,13 @@ internal sealed class UpdateCommand : BaseCommand
         {
             var message = Markup.Escape(ex.Message);
             Telemetry.RecordError(message, ex);
-            return CommandResult.Failure(ExitCodeConstants.FailedToUpgradeProject, message);
+            return CommandResult.Failure(CliExitCodes.FailedToUpgradeProject, message);
         }
         catch (ChannelNotFoundException ex)
         {
             var message = Markup.Escape(ex.Message);
             Telemetry.RecordError(message, ex);
-            return CommandResult.Failure(ExitCodeConstants.FailedToUpgradeProject, message);
+            return CommandResult.Failure(CliExitCodes.FailedToUpgradeProject, message);
         }
         catch (ProjectLocatorException ex)
         {
@@ -341,7 +341,7 @@ internal sealed class UpdateCommand : BaseCommand
             var currentExePath = Environment.ProcessPath;
             if (string.IsNullOrEmpty(currentExePath))
             {
-                return CommandResult.Failure(ExitCodeConstants.InvalidCommand, "Unable to determine the current executable path.");
+                return CommandResult.Failure(CliExitCodes.InvalidCommand, "Unable to determine the current executable path.");
             }
 
             InteractionService.DisplayMessage(KnownEmojis.Package, $"Current CLI location: {currentExePath}");
@@ -363,7 +363,7 @@ internal sealed class UpdateCommand : BaseCommand
         {
             Telemetry.RecordError("Failed to update CLI", ex);
             var errorMessage = $"Failed to update CLI: {ex.Message}";
-            return CommandResult.Failure(ExitCodeConstants.InvalidCommand, errorMessage);
+            return CommandResult.Failure(CliExitCodes.InvalidCommand, errorMessage);
         }
     }
 

--- a/src/Aspire.Cli/Commands/WaitCommand.cs
+++ b/src/Aspire.Cli/Commands/WaitCommand.cs
@@ -77,13 +77,13 @@ internal sealed class WaitCommand : BaseCommand
         // Validate status value
         if (!IsValidStatus(status))
         {
-            return CommandResult.Failure(ExitCodeConstants.InvalidCommand, string.Format(CultureInfo.CurrentCulture, WaitCommandStrings.InvalidStatusValue, status));
+            return CommandResult.Failure(CliExitCodes.InvalidCommand, string.Format(CultureInfo.CurrentCulture, WaitCommandStrings.InvalidStatusValue, status));
         }
 
         // Validate timeout
         if (timeoutSeconds <= 0)
         {
-            return CommandResult.Failure(ExitCodeConstants.InvalidCommand, WaitCommandStrings.TimeoutMustBePositive);
+            return CommandResult.Failure(CliExitCodes.InvalidCommand, WaitCommandStrings.TimeoutMustBePositive);
         }
 
         // Resolve connection to a running AppHost
@@ -96,7 +96,7 @@ internal sealed class WaitCommand : BaseCommand
 
         if (!result.Success)
         {
-            return CommandResult.FromExitCode(AppHostConnectionResultHandler.DisplayFailureAsError(result, _interactionService, ExitCodeConstants.FailedToFindProject));
+            return CommandResult.FromExitCode(AppHostConnectionResultHandler.DisplayFailureAsError(result, _interactionService, CliExitCodes.FailedToFindProject));
         }
 
         var connection = result.Connection!;
@@ -119,36 +119,36 @@ internal sealed class WaitCommand : BaseCommand
 
         var exitCode = await _interactionService.ShowStatusAsync(
             string.Format(CultureInfo.CurrentCulture, WaitCommandStrings.WaitingForResource, resourceName, statusLabel),
-            async () =>
+            (Func<Task<int>>)(async () =>
             {
                 var response = await connection.WaitForResourceAsync(resourceName, status, timeoutSeconds, cancellationToken).ConfigureAwait(false);
 
                 if (response.Success)
                 {
-                    return ExitCodeConstants.Success;
+                    return CliExitCodes.Success;
                 }
 
                 if (response.ResourceNotFound)
                 {
                     _interactionService.DisplayError(string.Format(CultureInfo.CurrentCulture, WaitCommandStrings.ResourceNotFound, resourceName));
-                    return ExitCodeConstants.WaitResourceFailed;
+                    return CliExitCodes.WaitResourceFailed;
                 }
 
                 if (response.TimedOut)
                 {
                     _interactionService.DisplayError(string.Format(CultureInfo.CurrentCulture, WaitCommandStrings.WaitTimedOut, resourceName, statusLabel, timeoutSeconds));
-                    return ExitCodeConstants.WaitTimeout;
+                    return CliExitCodes.WaitTimeout;
                 }
 
                 // Resource entered a failed state
                 _interactionService.DisplayError(string.Format(CultureInfo.CurrentCulture, WaitCommandStrings.ResourceEnteredFailedState, resourceName, response.State ?? response.ErrorMessage));
-                return ExitCodeConstants.WaitResourceFailed;
-            });
+                return CliExitCodes.WaitResourceFailed;
+            }));
 
         // Reset cursor position after spinner
         _interactionService.DisplayPlainText("");
 
-        if (exitCode == ExitCodeConstants.Success)
+        if (exitCode == CliExitCodes.Success)
         {
             var elapsed = _timeProvider.GetElapsedTime(startTimestamp);
             _interactionService.DisplaySuccess(string.Format(CultureInfo.CurrentCulture, WaitCommandStrings.ResourceReachedTargetStatus, resourceName, statusLabel, elapsed.TotalSeconds));

--- a/src/Aspire.Cli/DotNet/DotNetCliRunner.cs
+++ b/src/Aspire.Cli/DotNet/DotNetCliRunner.cs
@@ -142,7 +142,7 @@ internal sealed class DotNetCliRunner(
 
                 _ = StartBackchannelAsync(null, socketPath!, backchannelCompletionSource, cancellationToken);
 
-                return ExitCodeConstants.Success;
+                return CliExitCodes.Success;
             }
         }
 
@@ -152,7 +152,7 @@ internal sealed class DotNetCliRunner(
         if (!started)
         {
             processActivity.SetError("Process failed to start.");
-            return ExitCodeConstants.FailedToDotnetRunAppHost;
+            return CliExitCodes.FailedToDotnetRunAppHost;
         }
 
         if (backchannelCompletionSource is not null && socketPath is not null)
@@ -289,6 +289,10 @@ internal sealed class DotNetCliRunner(
         // Set the CLI process start time for robust orphan detection to prevent PID reuse issues.
         // The AppHost will verify both PID and start time to ensure it's monitoring the correct process.
         env[KnownConfigNames.CliProcessStarted] = GetCurrentProcessStartTimeUnixSeconds().ToString(CultureInfo.InvariantCulture);
+
+        // Pass the CLI log file path so that querying CLI processes (e.g., aspire resource, aspire stop)
+        // can surface it to help users diagnose issues in the managing CLI process.
+        env[KnownConfigNames.CliLogFilePath] = executionContext.LogFilePath;
 
         // Always set MSBUILDTERMINALLOGGER=false for all dotnet command executions to ensure consistent terminal logger behavior
         env[KnownConfigNames.MsBuildTerminalLogger] = "false";
@@ -793,7 +797,7 @@ internal sealed class DotNetCliRunner(
             if (stdout is null)
             {
                 logger.LogError("Failed to read stdout from the process. This should never happen.");
-                return (ExitCodeConstants.FailedToInstallTemplates, null);
+                return (CliExitCodes.FailedToInstallTemplates, null);
             }
 
             // NOTE: This parsing logic is hopefully temporary and in the future we'll
@@ -1276,7 +1280,7 @@ internal sealed class DotNetCliRunner(
             if (stdout is null)
             {
                 logger.LogError("Failed to read stdout from the process. This should never happen.");
-                return (ExitCodeConstants.FailedToAddPackage, null);
+                return (CliExitCodes.FailedToAddPackage, null);
             }
 
             try
@@ -1294,7 +1298,7 @@ internal sealed class DotNetCliRunner(
             catch (JsonException ex)
             {
                 logger.LogError($"Failed to read JSON returned by the package search. {ex.Message}");
-                return (ExitCodeConstants.FailedToAddPackage, null);
+                return (CliExitCodes.FailedToAddPackage, null);
             }
 
         }

--- a/src/Aspire.Cli/Interaction/ConsoleInteractionService.cs
+++ b/src/Aspire.Cli/Interaction/ConsoleInteractionService.cs
@@ -362,7 +362,7 @@ internal class ConsoleInteractionService : IInteractionService
         MessageConsole.MarkupLine($"\t[bold]{InteractionServiceStrings.AspireCLIVersion}[/]: {cliInformationalVersion.EscapeMarkup()}");
         MessageConsole.MarkupLine($"\t[bold]{InteractionServiceStrings.RequiredCapability}[/]: {ex.RequiredCapability.EscapeMarkup()}");
         MessageConsole.WriteLine();
-        return ExitCodeConstants.AppHostIncompatible;
+        return CliExitCodes.AppHostIncompatible;
     }
 
     public void DisplayError(string errorMessage, bool allowMarkup = false)

--- a/src/Aspire.Cli/Program.cs
+++ b/src/Aspire.Cli/Program.cs
@@ -754,7 +754,7 @@ public class Program
 
             logger.LogError(ex, "Failed to load configuration or start CLI.");
             errorWriter.WriteLine(ex.Message);
-            return ExitCodeConstants.FailedToStartCli;
+            return CliExitCodes.FailedToStartCli;
         }
 
         // Ensure dispose of app when Main exits.

--- a/src/Aspire.Cli/Projects/AppHostServerProject.cs
+++ b/src/Aspire.Cli/Projects/AppHostServerProject.cs
@@ -45,7 +45,8 @@ internal sealed class AppHostServerProjectFactory(
                 repoRoot,
                 dotNetCliRunner,
                 packagingService,
-                loggerFactory.CreateLogger<DotNetBasedAppHostServerProject>());
+                loggerFactory.CreateLogger<DotNetBasedAppHostServerProject>(),
+                logFilePath: executionContext.LogFilePath);
         }
 
         // Priority 2: Ensure bundle is extracted and check for layout

--- a/src/Aspire.Cli/Projects/DotNetAppHostProject.cs
+++ b/src/Aspire.Cli/Projects/DotNetAppHostProject.cs
@@ -228,7 +228,7 @@ internal sealed class DotNetAppHostProject : IAppHostProject
         {
             // Signal build failure so RunCommand doesn't wait forever
             context.BuildCompletionSource?.TrySetResult(false);
-            return ExitCodeConstants.SdkNotInstalled;
+            return CliExitCodes.SdkNotInstalled;
         }
 
         var effectiveAppHostFile = context.AppHostFile;
@@ -412,7 +412,7 @@ internal sealed class DotNetAppHostProject : IAppHostProject
             if (!compatibilityCheck.IsCompatibleAppHost)
             {
                 context.BuildCompletionSource?.TrySetResult(false);
-                return ExitCodeConstants.FailedToDotnetRunAppHost;
+                return CliExitCodes.FailedToDotnetRunAppHost;
             }
 
             return null;
@@ -470,7 +470,7 @@ internal sealed class DotNetAppHostProject : IAppHostProject
         // generic "project could not be built" message.
         context.OutputCollector = buildOutputCollector;
         context.BuildCompletionSource?.TrySetResult(false);
-        return ExitCodeConstants.FailedToBuildArtifacts;
+        return CliExitCodes.FailedToBuildArtifacts;
     }
 
     private async Task<(bool IsCompatibleAppHost, bool SupportsBackchannel, string? AspireHostingVersion)> CheckAppHostCompatibilityAsync(
@@ -707,7 +707,7 @@ internal sealed class DotNetAppHostProject : IAppHostProject
                 // Signal the backchannel completion source so the caller doesn't wait forever
                 context.BackchannelCompletionSource?.TrySetException(
                     new InvalidOperationException("The app host build failed."));
-                return ExitCodeConstants.FailedToBuildArtifacts;
+                return CliExitCodes.FailedToBuildArtifacts;
             }
         }
 

--- a/src/Aspire.Cli/Projects/DotNetBasedAppHostServerProject.cs
+++ b/src/Aspire.Cli/Projects/DotNetBasedAppHostServerProject.cs
@@ -42,6 +42,7 @@ internal sealed class DotNetBasedAppHostServerProject : IAppHostServerProject
     private readonly IDotNetCliRunner _dotNetCliRunner;
     private readonly IPackagingService _packagingService;
     private readonly ILogger _logger;
+    private readonly string? _logFilePath;
 
     public DotNetBasedAppHostServerProject(
         string appPath,
@@ -50,7 +51,8 @@ internal sealed class DotNetBasedAppHostServerProject : IAppHostServerProject
         IDotNetCliRunner dotNetCliRunner,
         IPackagingService packagingService,
         ILogger<DotNetBasedAppHostServerProject> logger,
-        string? projectModelPath = null)
+        string? projectModelPath = null,
+        string? logFilePath = null)
     {
         _appPath = Path.GetFullPath(appPath);
         _appPath = new Uri(_appPath).LocalPath;
@@ -60,6 +62,7 @@ internal sealed class DotNetBasedAppHostServerProject : IAppHostServerProject
         _dotNetCliRunner = dotNetCliRunner;
         _packagingService = packagingService;
         _logger = logger;
+        _logFilePath = logFilePath;
 
         var pathHash = SHA256.HashData(Encoding.UTF8.GetBytes(_appPath));
 
@@ -85,6 +88,8 @@ internal sealed class DotNetBasedAppHostServerProject : IAppHostServerProject
     public string ProjectModelPath => _projectModelPath;
     public string UserSecretsId => _userSecretsId;
     public string BuildPath => Path.Combine(_projectModelPath, BuildFolder);
+
+    internal string? LogFilePath => _logFilePath;
 
     /// <summary>
     /// Gets the full path to the AppHost server project file.
@@ -473,6 +478,7 @@ internal sealed class DotNetBasedAppHostServerProject : IAppHostServerProject
         startInfo.Environment["REMOTE_APP_HOST_SOCKET_PATH"] = _socketPath;
         startInfo.Environment["REMOTE_APP_HOST_PID"] = hostPid.ToString(System.Globalization.CultureInfo.InvariantCulture);
         startInfo.Environment[KnownConfigNames.CliProcessId] = hostPid.ToString(System.Globalization.CultureInfo.InvariantCulture);
+        startInfo.Environment[KnownConfigNames.CliLogFilePath] = _logFilePath;
 
         // Dev mode uses debug builds which require Development environment
         // for the dashboard to resolve static web assets correctly

--- a/src/Aspire.Cli/Projects/GuestAppHostProject.cs
+++ b/src/Aspire.Cli/Projects/GuestAppHostProject.cs
@@ -369,7 +369,7 @@ internal sealed class GuestAppHostProject : IAppHostProject, IGuestAppHostSdkGen
                 // Set OutputCollector so RunCommand can display errors
                 context.OutputCollector = buildResult.Output;
                 context.BuildCompletionSource?.TrySetResult(false);
-                return ExitCodeConstants.FailedToBuildArtifacts;
+                return CliExitCodes.FailedToBuildArtifacts;
             }
 
             // Store output collector in context for exception handling by RunCommand
@@ -430,7 +430,7 @@ internal sealed class GuestAppHostProject : IAppHostProject, IGuestAppHostSdkGen
             {
                 _interactionService.DisplayLines(appHostServerOutputCollector.GetLines());
                 _interactionService.DisplayError("App host exited unexpectedly.");
-                return ExitCodeConstants.FailedToDotnetRunAppHost;
+                return CliExitCodes.FailedToDotnetRunAppHost;
             }
 
             // Step 5: Connect to server for RPC calls
@@ -500,7 +500,7 @@ internal sealed class GuestAppHostProject : IAppHostProject, IGuestAppHostSdkGen
             if (_guestRuntime is null)
             {
                 _interactionService.DisplayError("GuestRuntime not initialized.");
-                return ExitCodeConstants.FailedToDotnetRunAppHost;
+                return CliExitCodes.FailedToDotnetRunAppHost;
             }
 
             IGuestProcessLauncher launcher;
@@ -588,7 +588,7 @@ internal sealed class GuestAppHostProject : IAppHostProject, IGuestAppHostSdkGen
         {
             // Signal that build/preparation failed so RunCommand doesn't hang waiting
             context.BuildCompletionSource?.TrySetResult(false);
-            return ExitCodeConstants.Cancelled;
+            return CliExitCodes.Cancelled;
         }
         catch (Exception ex)
         {
@@ -596,7 +596,7 @@ internal sealed class GuestAppHostProject : IAppHostProject, IGuestAppHostSdkGen
             context.BuildCompletionSource?.TrySetResult(false);
             _logger.LogError(ex, "Failed to run {Language} AppHost", DisplayName);
             _interactionService.DisplayError($"Failed to run {DisplayName} AppHost: {ex.Message}");
-            return ExitCodeConstants.FailedToDotnetRunAppHost;
+            return CliExitCodes.FailedToDotnetRunAppHost;
         }
     }
 
@@ -856,7 +856,7 @@ internal sealed class GuestAppHostProject : IAppHostProject, IGuestAppHostSdkGen
                 // Signal the backchannel completion source so the caller doesn't wait forever
                 context.BackchannelCompletionSource?.TrySetException(
                     new InvalidOperationException("The app host preparation failed."));
-                return ExitCodeConstants.FailedToBuildArtifacts;
+                return CliExitCodes.FailedToBuildArtifacts;
             }
 
             // Store output collector in context for exception handling
@@ -904,7 +904,7 @@ internal sealed class GuestAppHostProject : IAppHostProject, IGuestAppHostSdkGen
             {
                 _interactionService.DisplayLines(appHostServerOutputCollector.GetLines());
                 _interactionService.DisplayError("App host exited unexpectedly.");
-                return ExitCodeConstants.FailedToDotnetRunAppHost;
+                return CliExitCodes.FailedToDotnetRunAppHost;
             }
 
             // Step 3: Connect to server for RPC calls
@@ -1016,13 +1016,13 @@ internal sealed class GuestAppHostProject : IAppHostProject, IGuestAppHostSdkGen
         }
         catch (OperationCanceledException)
         {
-            return ExitCodeConstants.Cancelled;
+            return CliExitCodes.Cancelled;
         }
         catch (Exception ex)
         {
             _logger.LogError(ex, "Failed to publish {Language} AppHost", DisplayName);
             _interactionService.DisplayError($"Failed to publish {DisplayName} AppHost: {ex.Message}");
-            return ExitCodeConstants.FailedToDotnetRunAppHost;
+            return CliExitCodes.FailedToDotnetRunAppHost;
         }
     }
 
@@ -1427,7 +1427,7 @@ internal sealed class GuestAppHostProject : IAppHostProject, IGuestAppHostSdkGen
         if (_guestRuntime is null)
         {
             _interactionService.DisplayError("GuestRuntime not initialized. This is a bug.");
-            return ExitCodeConstants.FailedToBuildArtifacts;
+            return CliExitCodes.FailedToBuildArtifacts;
         }
 
         var (initResult, initOutput) = await _guestRuntime.InitializeAsync(directory, cancellationToken);
@@ -1485,7 +1485,7 @@ internal sealed class GuestAppHostProject : IAppHostProject, IGuestAppHostSdkGen
         if (_guestRuntime is null)
         {
             _interactionService.DisplayError("GuestRuntime not initialized. This is a bug.");
-            return (ExitCodeConstants.FailedToDotnetRunAppHost, new OutputCollector());
+            return (CliExitCodes.FailedToDotnetRunAppHost, new OutputCollector());
         }
 
         return await _guestRuntime.RunAsync(appHostFile, directory, environmentVariables, watchMode, launcher, cancellationToken);
@@ -1507,7 +1507,7 @@ internal sealed class GuestAppHostProject : IAppHostProject, IGuestAppHostSdkGen
         if (_guestRuntime is null)
         {
             _interactionService.DisplayError("GuestRuntime not initialized. This is a bug.");
-            return (ExitCodeConstants.FailedToDotnetRunAppHost, new OutputCollector());
+            return (CliExitCodes.FailedToDotnetRunAppHost, new OutputCollector());
         }
 
         return await _guestRuntime.PublishAsync(appHostFile, directory, environmentVariables, publishArgs, _guestRuntime.CreateDefaultLauncher(), cancellationToken);

--- a/src/Aspire.Cli/Projects/PrebuiltAppHostServer.cs
+++ b/src/Aspire.Cli/Projects/PrebuiltAppHostServer.cs
@@ -611,6 +611,7 @@ internal sealed class PrebuiltAppHostServer : IAppHostServerProject
         startInfo.Environment["REMOTE_APP_HOST_SOCKET_PATH"] = _socketPath;
         startInfo.Environment["REMOTE_APP_HOST_PID"] = hostPid.ToString(System.Globalization.CultureInfo.InvariantCulture);
         startInfo.Environment[KnownConfigNames.CliProcessId] = hostPid.ToString(System.Globalization.CultureInfo.InvariantCulture);
+        startInfo.Environment[KnownConfigNames.CliLogFilePath] = _executionContext.LogFilePath;
 
         if (_integrationLibsPath is not null)
         {

--- a/src/Aspire.Cli/Projects/ProjectLocator.cs
+++ b/src/Aspire.Cli/Projects/ProjectLocator.cs
@@ -825,22 +825,22 @@ internal static class ProjectLocatorErrorHelper
         return ex.FailureReason switch
         {
             ProjectLocatorFailureReason.MultipleProjectFilesFound when projectOptionSpecifiedAsDirectory
-                => (ExitCodeConstants.FailedToFindProject, InteractionServiceStrings.ProjectOptionSpecifiedDirectoryContainsMultipleAppHosts),
+                => (CliExitCodes.FailedToFindProject, InteractionServiceStrings.ProjectOptionSpecifiedDirectoryContainsMultipleAppHosts),
             ProjectLocatorFailureReason.ProjectFileDoesntExist or ProjectLocatorFailureReason.NoProjectFileFound when projectOptionSpecifiedAsDirectory
-                => (ExitCodeConstants.FailedToFindProject, InteractionServiceStrings.ProjectOptionSpecifiedDirectoryContainsNoAppHosts),
+                => (CliExitCodes.FailedToFindProject, InteractionServiceStrings.ProjectOptionSpecifiedDirectoryContainsNoAppHosts),
             ProjectLocatorFailureReason.UnsupportedProjects
-                => (ExitCodeConstants.SdkNotInstalled, InteractionServiceStrings.NoSupportedAppHostsFound),
+                => (CliExitCodes.SdkNotInstalled, InteractionServiceStrings.NoSupportedAppHostsFound),
             ProjectLocatorFailureReason.ProjectFileNotAppHostProject
-                => (ExitCodeConstants.FailedToFindProject, InteractionServiceStrings.SpecifiedProjectFileNotAppHostProject),
+                => (CliExitCodes.FailedToFindProject, InteractionServiceStrings.SpecifiedProjectFileNotAppHostProject),
             ProjectLocatorFailureReason.ProjectFileDoesntExist
-                => (ExitCodeConstants.FailedToFindProject, InteractionServiceStrings.ProjectOptionDoesntExist),
+                => (CliExitCodes.FailedToFindProject, InteractionServiceStrings.ProjectOptionDoesntExist),
             ProjectLocatorFailureReason.MultipleProjectFilesFound
-                => (ExitCodeConstants.FailedToFindProject, InteractionServiceStrings.ProjectOptionNotSpecifiedMultipleAppHostsFound),
+                => (CliExitCodes.FailedToFindProject, InteractionServiceStrings.ProjectOptionNotSpecifiedMultipleAppHostsFound),
             ProjectLocatorFailureReason.NoProjectFileFound
-                => (ExitCodeConstants.FailedToFindProject, InteractionServiceStrings.ProjectOptionNotSpecifiedNoCsprojFound),
+                => (CliExitCodes.FailedToFindProject, InteractionServiceStrings.ProjectOptionNotSpecifiedNoCsprojFound),
             ProjectLocatorFailureReason.AppHostsMayNotBeBuildable
-                => (ExitCodeConstants.FailedToFindProject, InteractionServiceStrings.UnbuildableAppHostsDetected),
-            _ => (ExitCodeConstants.FailedToFindProject, string.Format(CultureInfo.CurrentCulture, InteractionServiceStrings.UnexpectedErrorOccurred, ex.Message))
+                => (CliExitCodes.FailedToFindProject, InteractionServiceStrings.UnbuildableAppHostsDetected),
+            _ => (CliExitCodes.FailedToFindProject, string.Format(CultureInfo.CurrentCulture, InteractionServiceStrings.UnexpectedErrorOccurred, ex.Message))
         };
     }
 }

--- a/src/Aspire.Cli/Resources/InteractionServiceStrings.Designer.cs
+++ b/src/Aspire.Cli/Resources/InteractionServiceStrings.Designer.cs
@@ -439,6 +439,15 @@ namespace Aspire.Cli.Resources {
         }
 
         /// <summary>
+        ///   Looks up a localized string similar to See app host logs at {0}.
+        /// </summary>
+        public static string SeeAppHostLogsAt {
+            get {
+                return ResourceManager.GetString("SeeAppHostLogsAt", resourceCulture);
+            }
+        }
+
+        /// <summary>
         ///   Looks up a localized string similar to Waiting for debugger to attach to apphost process.
         /// </summary>
         public static string WaitingForDebuggerToAttachToAppHost {

--- a/src/Aspire.Cli/Resources/InteractionServiceStrings.resx
+++ b/src/Aspire.Cli/Resources/InteractionServiceStrings.resx
@@ -226,6 +226,10 @@
     <value>See logs at {0}</value>
     <comment>{0} is the log file path</comment>
   </data>
+  <data name="SeeAppHostLogsAt" xml:space="preserve">
+    <value>See AppHost logs at {0}</value>
+    <comment>{0} is the log file path of the CLI process managing the AppHost</comment>
+  </data>
   <data name="WaitingForDebuggerToAttachToAppHost" xml:space="preserve">
     <value>Waiting for debugger to attach to AppHost process</value>
   </data>

--- a/src/Aspire.Cli/Resources/PsCommandStrings.Designer.cs
+++ b/src/Aspire.Cli/Resources/PsCommandStrings.Designer.cs
@@ -87,6 +87,12 @@ namespace Aspire.Cli.Resources {
             }
         }
 
+        public static string HeaderCliLog {
+            get {
+                return ResourceManager.GetString("HeaderCliLog", resourceCulture);
+            }
+        }
+
         public static string UnknownPath {
             get {
                 return ResourceManager.GetString("UnknownPath", resourceCulture);

--- a/src/Aspire.Cli/Resources/PsCommandStrings.resx
+++ b/src/Aspire.Cli/Resources/PsCommandStrings.resx
@@ -138,6 +138,9 @@
   <data name="HeaderDashboard" xml:space="preserve">
     <value>Dashboard</value>
   </data>
+  <data name="HeaderCliLog" xml:space="preserve">
+    <value>Logs</value>
+  </data>
   <data name="UnknownPath" xml:space="preserve">
     <value>Unknown</value>
   </data>

--- a/src/Aspire.Cli/Resources/xlf/InteractionServiceStrings.cs.xlf
+++ b/src/Aspire.Cli/Resources/xlf/InteractionServiceStrings.cs.xlf
@@ -172,6 +172,11 @@
         <target state="translated">Vyhledávání…</target>
         <note />
       </trans-unit>
+      <trans-unit id="SeeAppHostLogsAt">
+        <source>See AppHost logs at {0}</source>
+        <target state="new">See AppHost logs at {0}</target>
+        <note>{0} is the log file path of the CLI process managing the AppHost</note>
+      </trans-unit>
       <trans-unit id="SeeLogsAt">
         <source>See logs at {0}</source>
         <target state="translated">Protokoly najdete na {0}</target>

--- a/src/Aspire.Cli/Resources/xlf/InteractionServiceStrings.de.xlf
+++ b/src/Aspire.Cli/Resources/xlf/InteractionServiceStrings.de.xlf
@@ -172,6 +172,11 @@
         <target state="translated">Suche wird ausgeführt...</target>
         <note />
       </trans-unit>
+      <trans-unit id="SeeAppHostLogsAt">
+        <source>See AppHost logs at {0}</source>
+        <target state="new">See AppHost logs at {0}</target>
+        <note>{0} is the log file path of the CLI process managing the AppHost</note>
+      </trans-unit>
       <trans-unit id="SeeLogsAt">
         <source>See logs at {0}</source>
         <target state="translated">Protokolle unter {0} anzeigen.</target>

--- a/src/Aspire.Cli/Resources/xlf/InteractionServiceStrings.es.xlf
+++ b/src/Aspire.Cli/Resources/xlf/InteractionServiceStrings.es.xlf
@@ -172,6 +172,11 @@
         <target state="translated">Buscando...</target>
         <note />
       </trans-unit>
+      <trans-unit id="SeeAppHostLogsAt">
+        <source>See AppHost logs at {0}</source>
+        <target state="new">See AppHost logs at {0}</target>
+        <note>{0} is the log file path of the CLI process managing the AppHost</note>
+      </trans-unit>
       <trans-unit id="SeeLogsAt">
         <source>See logs at {0}</source>
         <target state="translated">Consulte los registros en {0}</target>

--- a/src/Aspire.Cli/Resources/xlf/InteractionServiceStrings.fr.xlf
+++ b/src/Aspire.Cli/Resources/xlf/InteractionServiceStrings.fr.xlf
@@ -172,6 +172,11 @@
         <target state="translated">Recherche en cours...</target>
         <note />
       </trans-unit>
+      <trans-unit id="SeeAppHostLogsAt">
+        <source>See AppHost logs at {0}</source>
+        <target state="new">See AppHost logs at {0}</target>
+        <note>{0} is the log file path of the CLI process managing the AppHost</note>
+      </trans-unit>
       <trans-unit id="SeeLogsAt">
         <source>See logs at {0}</source>
         <target state="translated">Consultez les journaux à l’emplacement {0}</target>

--- a/src/Aspire.Cli/Resources/xlf/InteractionServiceStrings.it.xlf
+++ b/src/Aspire.Cli/Resources/xlf/InteractionServiceStrings.it.xlf
@@ -172,6 +172,11 @@
         <target state="translated">Ricerca in corso...</target>
         <note />
       </trans-unit>
+      <trans-unit id="SeeAppHostLogsAt">
+        <source>See AppHost logs at {0}</source>
+        <target state="new">See AppHost logs at {0}</target>
+        <note>{0} is the log file path of the CLI process managing the AppHost</note>
+      </trans-unit>
       <trans-unit id="SeeLogsAt">
         <source>See logs at {0}</source>
         <target state="translated">Consultare i log in {0}</target>

--- a/src/Aspire.Cli/Resources/xlf/InteractionServiceStrings.ja.xlf
+++ b/src/Aspire.Cli/Resources/xlf/InteractionServiceStrings.ja.xlf
@@ -172,6 +172,11 @@
         <target state="translated">検索しています...</target>
         <note />
       </trans-unit>
+      <trans-unit id="SeeAppHostLogsAt">
+        <source>See AppHost logs at {0}</source>
+        <target state="new">See AppHost logs at {0}</target>
+        <note>{0} is the log file path of the CLI process managing the AppHost</note>
+      </trans-unit>
       <trans-unit id="SeeLogsAt">
         <source>See logs at {0}</source>
         <target state="translated">{0} でログを表示する</target>

--- a/src/Aspire.Cli/Resources/xlf/InteractionServiceStrings.ko.xlf
+++ b/src/Aspire.Cli/Resources/xlf/InteractionServiceStrings.ko.xlf
@@ -172,6 +172,11 @@
         <target state="translated">검색 중...</target>
         <note />
       </trans-unit>
+      <trans-unit id="SeeAppHostLogsAt">
+        <source>See AppHost logs at {0}</source>
+        <target state="new">See AppHost logs at {0}</target>
+        <note>{0} is the log file path of the CLI process managing the AppHost</note>
+      </trans-unit>
       <trans-unit id="SeeLogsAt">
         <source>See logs at {0}</source>
         <target state="translated">{0}에서 로그 보기</target>

--- a/src/Aspire.Cli/Resources/xlf/InteractionServiceStrings.pl.xlf
+++ b/src/Aspire.Cli/Resources/xlf/InteractionServiceStrings.pl.xlf
@@ -172,6 +172,11 @@
         <target state="translated">Trwa wyszukiwanie...</target>
         <note />
       </trans-unit>
+      <trans-unit id="SeeAppHostLogsAt">
+        <source>See AppHost logs at {0}</source>
+        <target state="new">See AppHost logs at {0}</target>
+        <note>{0} is the log file path of the CLI process managing the AppHost</note>
+      </trans-unit>
       <trans-unit id="SeeLogsAt">
         <source>See logs at {0}</source>
         <target state="translated">Zobacz dzienniki pod adresem {0}</target>

--- a/src/Aspire.Cli/Resources/xlf/InteractionServiceStrings.pt-BR.xlf
+++ b/src/Aspire.Cli/Resources/xlf/InteractionServiceStrings.pt-BR.xlf
@@ -172,6 +172,11 @@
         <target state="translated">Pesquisando...</target>
         <note />
       </trans-unit>
+      <trans-unit id="SeeAppHostLogsAt">
+        <source>See AppHost logs at {0}</source>
+        <target state="new">See AppHost logs at {0}</target>
+        <note>{0} is the log file path of the CLI process managing the AppHost</note>
+      </trans-unit>
       <trans-unit id="SeeLogsAt">
         <source>See logs at {0}</source>
         <target state="translated">Ver logs em {0}</target>

--- a/src/Aspire.Cli/Resources/xlf/InteractionServiceStrings.ru.xlf
+++ b/src/Aspire.Cli/Resources/xlf/InteractionServiceStrings.ru.xlf
@@ -172,6 +172,11 @@
         <target state="translated">Выполняется поиск...</target>
         <note />
       </trans-unit>
+      <trans-unit id="SeeAppHostLogsAt">
+        <source>See AppHost logs at {0}</source>
+        <target state="new">See AppHost logs at {0}</target>
+        <note>{0} is the log file path of the CLI process managing the AppHost</note>
+      </trans-unit>
       <trans-unit id="SeeLogsAt">
         <source>See logs at {0}</source>
         <target state="translated">См. журналы по адресу {0}</target>

--- a/src/Aspire.Cli/Resources/xlf/InteractionServiceStrings.tr.xlf
+++ b/src/Aspire.Cli/Resources/xlf/InteractionServiceStrings.tr.xlf
@@ -172,6 +172,11 @@
         <target state="translated">Aranıyor...</target>
         <note />
       </trans-unit>
+      <trans-unit id="SeeAppHostLogsAt">
+        <source>See AppHost logs at {0}</source>
+        <target state="new">See AppHost logs at {0}</target>
+        <note>{0} is the log file path of the CLI process managing the AppHost</note>
+      </trans-unit>
       <trans-unit id="SeeLogsAt">
         <source>See logs at {0}</source>
         <target state="translated">{0} adresinde günlüklere bakın</target>

--- a/src/Aspire.Cli/Resources/xlf/InteractionServiceStrings.zh-Hans.xlf
+++ b/src/Aspire.Cli/Resources/xlf/InteractionServiceStrings.zh-Hans.xlf
@@ -172,6 +172,11 @@
         <target state="translated">正在搜索...</target>
         <note />
       </trans-unit>
+      <trans-unit id="SeeAppHostLogsAt">
+        <source>See AppHost logs at {0}</source>
+        <target state="new">See AppHost logs at {0}</target>
+        <note>{0} is the log file path of the CLI process managing the AppHost</note>
+      </trans-unit>
       <trans-unit id="SeeLogsAt">
         <source>See logs at {0}</source>
         <target state="translated">请参阅 {0} 处的日志</target>

--- a/src/Aspire.Cli/Resources/xlf/InteractionServiceStrings.zh-Hant.xlf
+++ b/src/Aspire.Cli/Resources/xlf/InteractionServiceStrings.zh-Hant.xlf
@@ -172,6 +172,11 @@
         <target state="translated">正在搜尋...</target>
         <note />
       </trans-unit>
+      <trans-unit id="SeeAppHostLogsAt">
+        <source>See AppHost logs at {0}</source>
+        <target state="new">See AppHost logs at {0}</target>
+        <note>{0} is the log file path of the CLI process managing the AppHost</note>
+      </trans-unit>
       <trans-unit id="SeeLogsAt">
         <source>See logs at {0}</source>
         <target state="translated">請參閱 {0} 中的記錄</target>

--- a/src/Aspire.Cli/Resources/xlf/PsCommandStrings.cs.xlf
+++ b/src/Aspire.Cli/Resources/xlf/PsCommandStrings.cs.xlf
@@ -7,6 +7,11 @@
         <target state="needs-review-translation">Vypíše spuštěné hostitele aplikací Aspire.</target>
         <note />
       </trans-unit>
+      <trans-unit id="HeaderCliLog">
+        <source>Logs</source>
+        <target state="new">Logs</target>
+        <note />
+      </trans-unit>
       <trans-unit id="HeaderCliPid">
         <source>CLI PID</source>
         <target state="translated">CLI PID</target>

--- a/src/Aspire.Cli/Resources/xlf/PsCommandStrings.de.xlf
+++ b/src/Aspire.Cli/Resources/xlf/PsCommandStrings.de.xlf
@@ -7,6 +7,11 @@
         <target state="needs-review-translation">Listet die laufenden Aspire-AppHosts auf.</target>
         <note />
       </trans-unit>
+      <trans-unit id="HeaderCliLog">
+        <source>Logs</source>
+        <target state="new">Logs</target>
+        <note />
+      </trans-unit>
       <trans-unit id="HeaderCliPid">
         <source>CLI PID</source>
         <target state="translated">CLI PID</target>

--- a/src/Aspire.Cli/Resources/xlf/PsCommandStrings.es.xlf
+++ b/src/Aspire.Cli/Resources/xlf/PsCommandStrings.es.xlf
@@ -7,6 +7,11 @@
         <target state="needs-review-translation">Lista de host de aplicaciones Aspire en ejecución.</target>
         <note />
       </trans-unit>
+      <trans-unit id="HeaderCliLog">
+        <source>Logs</source>
+        <target state="new">Logs</target>
+        <note />
+      </trans-unit>
       <trans-unit id="HeaderCliPid">
         <source>CLI PID</source>
         <target state="translated">CLI PID</target>

--- a/src/Aspire.Cli/Resources/xlf/PsCommandStrings.fr.xlf
+++ b/src/Aspire.Cli/Resources/xlf/PsCommandStrings.fr.xlf
@@ -7,6 +7,11 @@
         <target state="needs-review-translation">Liste des hôtes d’application Aspire en cours d’exécution.</target>
         <note />
       </trans-unit>
+      <trans-unit id="HeaderCliLog">
+        <source>Logs</source>
+        <target state="new">Logs</target>
+        <note />
+      </trans-unit>
       <trans-unit id="HeaderCliPid">
         <source>CLI PID</source>
         <target state="translated">CLI PID</target>

--- a/src/Aspire.Cli/Resources/xlf/PsCommandStrings.it.xlf
+++ b/src/Aspire.Cli/Resources/xlf/PsCommandStrings.it.xlf
@@ -7,6 +7,11 @@
         <target state="needs-review-translation">Elenca apphost Aspire in esecuzione.</target>
         <note />
       </trans-unit>
+      <trans-unit id="HeaderCliLog">
+        <source>Logs</source>
+        <target state="new">Logs</target>
+        <note />
+      </trans-unit>
       <trans-unit id="HeaderCliPid">
         <source>CLI PID</source>
         <target state="translated">CLI PID</target>

--- a/src/Aspire.Cli/Resources/xlf/PsCommandStrings.ja.xlf
+++ b/src/Aspire.Cli/Resources/xlf/PsCommandStrings.ja.xlf
@@ -7,6 +7,11 @@
         <target state="needs-review-translation">実行中の Aspire apphost を一覧表示します。</target>
         <note />
       </trans-unit>
+      <trans-unit id="HeaderCliLog">
+        <source>Logs</source>
+        <target state="new">Logs</target>
+        <note />
+      </trans-unit>
       <trans-unit id="HeaderCliPid">
         <source>CLI PID</source>
         <target state="translated">CLI PID</target>

--- a/src/Aspire.Cli/Resources/xlf/PsCommandStrings.ko.xlf
+++ b/src/Aspire.Cli/Resources/xlf/PsCommandStrings.ko.xlf
@@ -7,6 +7,11 @@
         <target state="needs-review-translation">실행 중인 Aspire AppHost를 나열합니다.</target>
         <note />
       </trans-unit>
+      <trans-unit id="HeaderCliLog">
+        <source>Logs</source>
+        <target state="new">Logs</target>
+        <note />
+      </trans-unit>
       <trans-unit id="HeaderCliPid">
         <source>CLI PID</source>
         <target state="translated">CLI PID</target>

--- a/src/Aspire.Cli/Resources/xlf/PsCommandStrings.pl.xlf
+++ b/src/Aspire.Cli/Resources/xlf/PsCommandStrings.pl.xlf
@@ -7,6 +7,11 @@
         <target state="needs-review-translation">Wyświetl listę uruchomionych hostów aplikacji Aspire.</target>
         <note />
       </trans-unit>
+      <trans-unit id="HeaderCliLog">
+        <source>Logs</source>
+        <target state="new">Logs</target>
+        <note />
+      </trans-unit>
       <trans-unit id="HeaderCliPid">
         <source>CLI PID</source>
         <target state="translated">Identyfikator PID interfejsu wiersza polecenia</target>

--- a/src/Aspire.Cli/Resources/xlf/PsCommandStrings.pt-BR.xlf
+++ b/src/Aspire.Cli/Resources/xlf/PsCommandStrings.pt-BR.xlf
@@ -7,6 +7,11 @@
         <target state="needs-review-translation">Listar os apphosts Aspire em execução.</target>
         <note />
       </trans-unit>
+      <trans-unit id="HeaderCliLog">
+        <source>Logs</source>
+        <target state="new">Logs</target>
+        <note />
+      </trans-unit>
       <trans-unit id="HeaderCliPid">
         <source>CLI PID</source>
         <target state="translated">CLI PID</target>

--- a/src/Aspire.Cli/Resources/xlf/PsCommandStrings.ru.xlf
+++ b/src/Aspire.Cli/Resources/xlf/PsCommandStrings.ru.xlf
@@ -7,6 +7,11 @@
         <target state="needs-review-translation">Перечислить запущенные apphosts Aspire.</target>
         <note />
       </trans-unit>
+      <trans-unit id="HeaderCliLog">
+        <source>Logs</source>
+        <target state="new">Logs</target>
+        <note />
+      </trans-unit>
       <trans-unit id="HeaderCliPid">
         <source>CLI PID</source>
         <target state="translated">PID CLI</target>

--- a/src/Aspire.Cli/Resources/xlf/PsCommandStrings.tr.xlf
+++ b/src/Aspire.Cli/Resources/xlf/PsCommandStrings.tr.xlf
@@ -7,6 +7,11 @@
         <target state="needs-review-translation">Çalışan bir Aspire uygulama ana işlemlerini listeleyin.</target>
         <note />
       </trans-unit>
+      <trans-unit id="HeaderCliLog">
+        <source>Logs</source>
+        <target state="new">Logs</target>
+        <note />
+      </trans-unit>
       <trans-unit id="HeaderCliPid">
         <source>CLI PID</source>
         <target state="translated">CLI PID</target>

--- a/src/Aspire.Cli/Resources/xlf/PsCommandStrings.zh-Hans.xlf
+++ b/src/Aspire.Cli/Resources/xlf/PsCommandStrings.zh-Hans.xlf
@@ -7,6 +7,11 @@
         <target state="needs-review-translation">列出正在运行的 Aspire AppHost。</target>
         <note />
       </trans-unit>
+      <trans-unit id="HeaderCliLog">
+        <source>Logs</source>
+        <target state="new">Logs</target>
+        <note />
+      </trans-unit>
       <trans-unit id="HeaderCliPid">
         <source>CLI PID</source>
         <target state="translated">CLI PID</target>

--- a/src/Aspire.Cli/Resources/xlf/PsCommandStrings.zh-Hant.xlf
+++ b/src/Aspire.Cli/Resources/xlf/PsCommandStrings.zh-Hant.xlf
@@ -7,6 +7,11 @@
         <target state="needs-review-translation">列出正在執行的 Aspire AppHost。</target>
         <note />
       </trans-unit>
+      <trans-unit id="HeaderCliLog">
+        <source>Logs</source>
+        <target state="new">Logs</target>
+        <note />
+      </trans-unit>
       <trans-unit id="HeaderCliPid">
         <source>CLI PID</source>
         <target state="translated">CLI PID</target>

--- a/src/Aspire.Cli/Templating/CliTemplateFactory.EmptyTemplate.cs
+++ b/src/Aspire.Cli/Templating/CliTemplateFactory.EmptyTemplate.cs
@@ -18,14 +18,14 @@ internal sealed partial class CliTemplateFactory
         if (string.IsNullOrWhiteSpace(languageId))
         {
             _interactionService.DisplayError("Language selection is required.");
-            return new TemplateResult(ExitCodeConstants.InvalidCommand);
+            return new TemplateResult(CliExitCodes.InvalidCommand);
         }
 
         var language = _languageDiscovery.GetLanguageById(languageId);
         if (language is null)
         {
             _interactionService.DisplayError($"Unknown language: '{languageId}'");
-            return new TemplateResult(ExitCodeConstants.InvalidCommand);
+            return new TemplateResult(CliExitCodes.InvalidCommand);
         }
 
         var projectName = inputs.Name;
@@ -38,7 +38,7 @@ internal sealed partial class CliTemplateFactory
         var outputPath = await ResolveOutputPathAsync(inputs, template.PathDeriver, projectName, parseResult, cancellationToken);
         if (outputPath is null)
         {
-            return new TemplateResult(ExitCodeConstants.FailedToCreateNewProject);
+            return new TemplateResult(CliExitCodes.FailedToCreateNewProject);
         }
 
         _logger.LogDebug("Applying empty AppHost template. LanguageId: {LanguageId}, Language: {LanguageDisplayName}, ProjectName: {ProjectName}, OutputPath: {OutputPath}.", languageId, language.DisplayName, projectName, outputPath);
@@ -62,7 +62,7 @@ internal sealed partial class CliTemplateFactory
 
             templateResult = await _interactionService.ShowStatusAsync(
                 TemplatingStrings.CreatingNewProject,
-                async () =>
+                (Func<Task<TemplateResult>>)(async () =>
                 {
                     if (isCsharp)
                     {
@@ -80,7 +80,7 @@ internal sealed partial class CliTemplateFactory
                             Channel: inputs.Channel);
                         if (!await _scaffoldingService.ScaffoldAsync(context, cancellationToken))
                         {
-                            return new TemplateResult(ExitCodeConstants.FailedToCreateNewProject);
+                            return new TemplateResult((int)CliExitCodes.FailedToCreateNewProject);
                         }
 
                         if (useLocalhostTld)
@@ -89,10 +89,10 @@ internal sealed partial class CliTemplateFactory
                         }
                     }
 
-                    return new TemplateResult(ExitCodeConstants.Success, outputPath);
-                }, emoji: KnownEmojis.Rocket);
+                    return new TemplateResult((int)CliExitCodes.Success, outputPath);
+                }), emoji: KnownEmojis.Rocket);
 
-            if (templateResult.ExitCode != ExitCodeConstants.Success)
+            if (templateResult.ExitCode != CliExitCodes.Success)
             {
                 return templateResult;
             }
@@ -100,7 +100,7 @@ internal sealed partial class CliTemplateFactory
         catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
         {
             _interactionService.DisplayError($"Failed to create project files: {ex.Message}");
-            return new TemplateResult(ExitCodeConstants.FailedToCreateNewProject);
+            return new TemplateResult(CliExitCodes.FailedToCreateNewProject);
         }
 
         _interactionService.DisplaySuccess($"Created {language.DisplayName.EscapeMarkup()} project at {outputPath.EscapeMarkup()}");

--- a/src/Aspire.Cli/Templating/CliTemplateFactory.GoStarterTemplate.cs
+++ b/src/Aspire.Cli/Templating/CliTemplateFactory.GoStarterTemplate.cs
@@ -22,14 +22,14 @@ internal sealed partial class CliTemplateFactory
         if (string.IsNullOrWhiteSpace(inputs.Version))
         {
             _interactionService.DisplayError("Unable to determine Aspire version for the Go starter template.");
-            return new TemplateResult(ExitCodeConstants.InvalidCommand);
+            return new TemplateResult(CliExitCodes.InvalidCommand);
         }
 
         var aspireVersion = inputs.Version;
         var outputPath = await ResolveOutputPathAsync(inputs, template.PathDeriver, projectName, parseResult, cancellationToken);
         if (outputPath is null)
         {
-            return new TemplateResult(ExitCodeConstants.FailedToCreateNewProject);
+            return new TemplateResult(CliExitCodes.FailedToCreateNewProject);
         }
 
         _logger.LogDebug("Applying Go starter template. ProjectName: {ProjectName}, OutputPath: {OutputPath}, AspireVersion: {AspireVersion}.", projectName, outputPath, aspireVersion);
@@ -46,7 +46,7 @@ internal sealed partial class CliTemplateFactory
 
             templateResult = await _interactionService.ShowStatusAsync(
                 "Creating new Aspire Go project...",
-                async () =>
+                (Func<Task<TemplateResult>>)(async () =>
                 {
                     var projectNameLower = projectName.ToLowerInvariant();
                     var ports = GenerateRandomPorts();
@@ -65,7 +65,7 @@ internal sealed partial class CliTemplateFactory
                     if (appHostProject is not IGuestAppHostSdkGenerator guestProject)
                     {
                         _interactionService.DisplayError("Automatic 'aspire restore' is unavailable for the new Go starter project because no Go AppHost SDK generator was found.");
-                        return new TemplateResult(ExitCodeConstants.FailedToBuildArtifacts, outputPath);
+                        return new TemplateResult((int)CliExitCodes.FailedToBuildArtifacts, outputPath);
                     }
 
                     _logger.LogDebug("Generating SDK code for Go starter in '{OutputPath}'.", outputPath);
@@ -73,13 +73,13 @@ internal sealed partial class CliTemplateFactory
                     if (!restoreSucceeded)
                     {
                         _interactionService.DisplayError("Automatic 'aspire restore' failed for the new Go starter project. Run 'aspire restore' in the project directory for more details.");
-                        return new TemplateResult(ExitCodeConstants.FailedToBuildArtifacts, outputPath);
+                        return new TemplateResult((int)CliExitCodes.FailedToBuildArtifacts, outputPath);
                     }
 
-                    return new TemplateResult(ExitCodeConstants.Success, outputPath);
-                }, emoji: KnownEmojis.Rocket);
+                    return new TemplateResult((int)CliExitCodes.Success, outputPath);
+                }), emoji: KnownEmojis.Rocket);
 
-            if (templateResult.ExitCode != ExitCodeConstants.Success)
+            if (templateResult.ExitCode != CliExitCodes.Success)
             {
                 return templateResult;
             }
@@ -87,7 +87,7 @@ internal sealed partial class CliTemplateFactory
         catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
         {
             _interactionService.DisplayError($"Failed to create project files: {ex.Message}");
-            return new TemplateResult(ExitCodeConstants.FailedToCreateNewProject);
+            return new TemplateResult(CliExitCodes.FailedToCreateNewProject);
         }
 
         _interactionService.DisplaySuccess($"Created Go starter project at {outputPath.EscapeMarkup()}");

--- a/src/Aspire.Cli/Templating/CliTemplateFactory.PythonStarterTemplate.cs
+++ b/src/Aspire.Cli/Templating/CliTemplateFactory.PythonStarterTemplate.cs
@@ -24,14 +24,14 @@ internal sealed partial class CliTemplateFactory
         if (string.IsNullOrWhiteSpace(inputs.Version))
         {
             _interactionService.DisplayError("Unable to determine Aspire version for the Python starter template.");
-            return new TemplateResult(ExitCodeConstants.InvalidCommand);
+            return new TemplateResult(CliExitCodes.InvalidCommand);
         }
 
         var aspireVersion = inputs.Version;
         var outputPath = await ResolveOutputPathAsync(inputs, template.PathDeriver, projectName, parseResult, cancellationToken);
         if (outputPath is null)
         {
-            return new TemplateResult(ExitCodeConstants.FailedToCreateNewProject);
+            return new TemplateResult(CliExitCodes.FailedToCreateNewProject);
         }
 
         _logger.LogDebug("Applying Python starter template. ProjectName: {ProjectName}, OutputPath: {OutputPath}, AspireVersion: {AspireVersion}.", projectName, outputPath, aspireVersion);
@@ -49,7 +49,7 @@ internal sealed partial class CliTemplateFactory
 
             templateResult = await _interactionService.ShowStatusAsync(
                 TemplatingStrings.CreatingNewProject,
-                async () =>
+                (Func<Task<TemplateResult>>)(async () =>
                 {
                     var projectNameLower = projectName.ToLowerInvariant();
 
@@ -80,7 +80,7 @@ internal sealed partial class CliTemplateFactory
                     if (appHostProject is not IGuestAppHostSdkGenerator guestProject)
                     {
                         _interactionService.DisplayError("Automatic 'aspire restore' is unavailable for the new Python starter project because no TypeScript AppHost SDK generator was found.");
-                        return new TemplateResult(ExitCodeConstants.FailedToBuildArtifacts, outputPath);
+                        return new TemplateResult((int)CliExitCodes.FailedToBuildArtifacts, outputPath);
                     }
 
                     _logger.LogDebug("Generating SDK code for Python starter in '{OutputPath}'.", outputPath);
@@ -88,13 +88,13 @@ internal sealed partial class CliTemplateFactory
                     if (!restoreSucceeded)
                     {
                         _interactionService.DisplayError("Automatic 'aspire restore' failed for the new Python starter project. Run 'aspire restore' in the project directory for more details.");
-                        return new TemplateResult(ExitCodeConstants.FailedToBuildArtifacts, outputPath);
+                        return new TemplateResult((int)CliExitCodes.FailedToBuildArtifacts, outputPath);
                     }
 
-                    return new TemplateResult(ExitCodeConstants.Success, outputPath);
-                }, emoji: KnownEmojis.Rocket);
+                    return new TemplateResult((int)CliExitCodes.Success, outputPath);
+                }), emoji: KnownEmojis.Rocket);
 
-            if (templateResult.ExitCode != ExitCodeConstants.Success)
+            if (templateResult.ExitCode != CliExitCodes.Success)
             {
                 return templateResult;
             }
@@ -102,7 +102,7 @@ internal sealed partial class CliTemplateFactory
         catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
         {
             _interactionService.DisplayError($"Failed to create project files: {ex.Message}");
-            return new TemplateResult(ExitCodeConstants.FailedToCreateNewProject);
+            return new TemplateResult(CliExitCodes.FailedToCreateNewProject);
         }
 
         _interactionService.DisplaySuccess($"Created Python starter project at {outputPath.EscapeMarkup()}");

--- a/src/Aspire.Cli/Templating/CliTemplateFactory.TypeScriptStarterTemplate.cs
+++ b/src/Aspire.Cli/Templating/CliTemplateFactory.TypeScriptStarterTemplate.cs
@@ -24,14 +24,14 @@ internal sealed partial class CliTemplateFactory
         if (string.IsNullOrWhiteSpace(inputs.Version))
         {
             _interactionService.DisplayError("Unable to determine Aspire version for the TypeScript starter template.");
-            return new TemplateResult(ExitCodeConstants.InvalidCommand);
+            return new TemplateResult(CliExitCodes.InvalidCommand);
         }
 
         var aspireVersion = inputs.Version;
         var outputPath = await ResolveOutputPathAsync(inputs, template.PathDeriver, projectName, parseResult, cancellationToken);
         if (outputPath is null)
         {
-            return new TemplateResult(ExitCodeConstants.FailedToCreateNewProject);
+            return new TemplateResult(CliExitCodes.FailedToCreateNewProject);
         }
 
         _logger.LogDebug("Applying TypeScript starter template. ProjectName: {ProjectName}, OutputPath: {OutputPath}, AspireVersion: {AspireVersion}.", projectName, outputPath, aspireVersion);
@@ -48,7 +48,7 @@ internal sealed partial class CliTemplateFactory
 
             templateResult = await _interactionService.ShowStatusAsync(
                 TemplatingStrings.CreatingNewProject,
-                async () =>
+                (Func<Task<TemplateResult>>)(async () =>
                 {
                     var projectNameLower = projectName.ToLowerInvariant();
 
@@ -76,7 +76,7 @@ internal sealed partial class CliTemplateFactory
                     if (appHostProject is not IGuestAppHostSdkGenerator guestProject)
                     {
                         _interactionService.DisplayError("Automatic 'aspire restore' is unavailable for the new TypeScript starter project because no TypeScript AppHost SDK generator was found.");
-                        return new TemplateResult(ExitCodeConstants.FailedToBuildArtifacts, outputPath);
+                        return new TemplateResult((int)CliExitCodes.FailedToBuildArtifacts, outputPath);
                     }
 
                     _logger.LogDebug("Generating SDK code for TypeScript starter in '{OutputPath}'.", outputPath);
@@ -84,13 +84,13 @@ internal sealed partial class CliTemplateFactory
                     if (!restoreSucceeded)
                     {
                         _interactionService.DisplayError("Automatic 'aspire restore' failed for the new TypeScript starter project. Run 'aspire restore' in the project directory for more details.");
-                        return new TemplateResult(ExitCodeConstants.FailedToBuildArtifacts, outputPath);
+                        return new TemplateResult((int)CliExitCodes.FailedToBuildArtifacts, outputPath);
                     }
 
-                    return new TemplateResult(ExitCodeConstants.Success, outputPath);
-                }, emoji: KnownEmojis.Rocket);
+                    return new TemplateResult((int)CliExitCodes.Success, outputPath);
+                }), emoji: KnownEmojis.Rocket);
 
-            if (templateResult.ExitCode != ExitCodeConstants.Success)
+            if (templateResult.ExitCode != CliExitCodes.Success)
             {
                 return templateResult;
             }
@@ -98,7 +98,7 @@ internal sealed partial class CliTemplateFactory
         catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
         {
             _interactionService.DisplayError($"Failed to create project files: {ex.Message}");
-            return new TemplateResult(ExitCodeConstants.FailedToCreateNewProject);
+            return new TemplateResult(CliExitCodes.FailedToCreateNewProject);
         }
 
         _interactionService.DisplaySuccess($"Created TypeScript starter project at {outputPath.EscapeMarkup()}");

--- a/src/Aspire.Cli/Templating/DotNetTemplateFactory.cs
+++ b/src/Aspire.Cli/Templating/DotNetTemplateFactory.cs
@@ -438,7 +438,7 @@ internal class DotNetTemplateFactory(
     {
         if (!await SdkInstallHelper.EnsureSdkInstalledAsync(sdkInstaller, interactionService, telemetry, cancellationToken: cancellationToken))
         {
-            return new TemplateResult(ExitCodeConstants.SdkNotInstalled);
+            return new TemplateResult(CliExitCodes.SdkNotInstalled);
         }
 
         var name = await GetProjectNameAsync(inputs, template.Name, parseResult, cancellationToken);
@@ -446,7 +446,7 @@ internal class DotNetTemplateFactory(
 
         if (outputPath is null)
         {
-            return new TemplateResult(ExitCodeConstants.FailedToCreateNewProject);
+            return new TemplateResult(CliExitCodes.FailedToCreateNewProject);
         }
 
         return await ApplyTemplateAsync(template, inputs, name, outputPath, parseResult, extraArgsCallback, cancellationToken);
@@ -482,7 +482,7 @@ internal class DotNetTemplateFactory(
             {
                 interactionService.DisplayLines(installOutcome.OutputLines);
                 interactionService.DisplayError(string.Format(CultureInfo.CurrentCulture, TemplatingStrings.TemplateInstallationFailed, installOutcome.ExitCode));
-                return new TemplateResult(ExitCodeConstants.FailedToInstallTemplates);
+                return new TemplateResult(CliExitCodes.FailedToInstallTemplates);
             }
 
             interactionService.DisplayMessage(KnownEmojis.Package, string.Format(CultureInfo.CurrentCulture, TemplatingStrings.UsingProjectTemplatesVersion, installOutcome.TemplateVersion));
@@ -516,12 +516,12 @@ internal class DotNetTemplateFactory(
                 if (newProjectExitCode == 73)
                 {
                     interactionService.DisplayError(TemplatingStrings.ProjectAlreadyExists);
-                    return new TemplateResult(ExitCodeConstants.FailedToCreateNewProject);
+                    return new TemplateResult(CliExitCodes.FailedToCreateNewProject);
                 }
 
                 interactionService.DisplayLines(newProjectCollector.GetLines());
                 interactionService.DisplayError(string.Format(CultureInfo.CurrentCulture, TemplatingStrings.ProjectCreationFailed, newProjectExitCode));
-                return new TemplateResult(ExitCodeConstants.FailedToCreateNewProject);
+                return new TemplateResult(CliExitCodes.FailedToCreateNewProject);
             }
 
             // Trust certificates (result not used since we're not launching an AppHost)
@@ -533,26 +533,26 @@ internal class DotNetTemplateFactory(
 
             interactionService.DisplaySuccess(string.Format(CultureInfo.CurrentCulture, TemplatingStrings.ProjectCreatedSuccessfully, outputPath));
 
-            return new TemplateResult(ExitCodeConstants.Success, outputPath);
+            return new TemplateResult(CliExitCodes.Success, outputPath);
         }
         catch (OperationCanceledException)
         {
-            return new TemplateResult(ExitCodeConstants.Cancelled);
+            return new TemplateResult(CliExitCodes.Cancelled);
         }
         catch (CertificateServiceException ex)
         {
             interactionService.DisplayError(string.Format(CultureInfo.CurrentCulture, TemplatingStrings.CertificateTrustError, ex.Message));
-            return new TemplateResult(ExitCodeConstants.FailedToTrustCertificates);
+            return new TemplateResult(CliExitCodes.FailedToTrustCertificates);
         }
         catch (Exceptions.ChannelNotFoundException ex)
         {
             interactionService.DisplayError(ex.Message);
-            return new TemplateResult(ExitCodeConstants.FailedToCreateNewProject);
+            return new TemplateResult(CliExitCodes.FailedToCreateNewProject);
         }
         catch (EmptyChoicesException ex)
         {
             interactionService.DisplayError(ex.Message);
-            return new TemplateResult(ExitCodeConstants.FailedToCreateNewProject);
+            return new TemplateResult(CliExitCodes.FailedToCreateNewProject);
         }
         catch (NuGetPackageCacheException ex)
         {
@@ -561,7 +561,7 @@ internal class DotNetTemplateFactory(
             // init code went straight to `dotnet new install` and never invoked a NuGet search, so this catch
             // restores parity with the prior init failure mode for these scenarios.
             interactionService.DisplayError(ex.Message);
-            return new TemplateResult(ExitCodeConstants.FailedToCreateNewProject);
+            return new TemplateResult(CliExitCodes.FailedToCreateNewProject);
         }
     }
 

--- a/src/Aspire.Cli/Utils/MarkupHelpers.cs
+++ b/src/Aspire.Cli/Utils/MarkupHelpers.cs
@@ -57,18 +57,55 @@ internal static class MarkupHelpers
     /// </summary>
     public static string SafeFileLink(bool supportsLinks, string filePath)
     {
+        return SafeFileLink(supportsLinks, filePath, displayName: null);
+    }
+
+    /// <summary>
+    /// Builds a clickable file-link markup string for the specified file path
+    /// when the console supports links, otherwise returns a plain-text fallback.
+    /// The displayed text is <paramref name="displayName"/> (or the full path when
+    /// <see langword="null"/>). If the path cannot be resolved to a valid URI
+    /// (e.g. it came from an external process and is malformed), the display name
+    /// is returned as escaped plain text.
+    /// </summary>
+    public static string SafeFileLink(IInteractionService interactionService, string filePath, string? displayName)
+    {
+        return SafeFileLink(interactionService.SupportsLinks, filePath, displayName);
+    }
+
+    /// <summary>
+    /// Builds a clickable file-link markup string for the specified file path
+    /// when the console supports links, otherwise returns a plain-text fallback.
+    /// The displayed text is <paramref name="displayName"/> (or the full path when
+    /// <see langword="null"/>). If the path cannot be resolved to a valid URI
+    /// (e.g. it came from an external process and is malformed), the display name
+    /// is returned as escaped plain text.
+    /// </summary>
+    public static string SafeFileLink(bool supportsLinks, string filePath, string? displayName)
+    {
         if (string.IsNullOrEmpty(filePath))
         {
             return string.Empty;
         }
 
+        displayName ??= filePath;
+
         if (!supportsLinks)
         {
-            return filePath.EscapeMarkup();
+            return displayName.EscapeMarkup();
         }
 
-        var fileUri = new Uri(Path.GetFullPath(filePath)).AbsoluteUri;
-
-        return SafeLink(supportsLinks: true, fileUri, filePath);
+        try
+        {
+            var fileUri = new Uri(Path.GetFullPath(filePath)).AbsoluteUri;
+            return SafeLink(supportsLinks: true, fileUri, displayName);
+        }
+        catch (Exception)
+        {
+            // The path may come from an external process (e.g. via backchannel) and
+            // could be malformed. Fall back to plain escaped text so the error-display
+            // path in BaseCommand doesn't throw and mask the original failure.
+            return displayName.EscapeMarkup();
+        }
     }
 }

--- a/src/Aspire.Hosting/ApplicationModel/ResourceCommandAnnotation.cs
+++ b/src/Aspire.Hosting/ApplicationModel/ResourceCommandAnnotation.cs
@@ -218,6 +218,11 @@ public static class CommandResults
     public static ExecuteCommandResult Success() => new() { Success = true };
 
     /// <summary>
+    /// Produces a success result.
+    /// </summary>
+    public static ExecuteCommandResult Success(string message) => new() { Success = true, Message = message };
+
+    /// <summary>
     /// Produces a success result with a message and result data.
     /// </summary>
     /// <param name="message">The message associated with the result.</param>

--- a/src/Aspire.Hosting/Backchannel/AuxiliaryBackchannelRpcTarget.cs
+++ b/src/Aspire.Hosting/Backchannel/AuxiliaryBackchannelRpcTarget.cs
@@ -72,7 +72,8 @@ internal sealed class AuxiliaryBackchannelRpcTarget(
             AspireHostVersion = AssemblyVersionHelper.GetDisplayVersion(typeof(AuxiliaryBackchannelRpcTarget).Assembly) ?? "unknown",
             AppHostPath = legacyInfo.AppHostPath,
             CliProcessId = legacyInfo.CliProcessId,
-            StartedAt = legacyInfo.StartedAt
+            StartedAt = legacyInfo.StartedAt,
+            CliLogFilePath = legacyInfo.CliLogFilePath
         };
     }
 
@@ -662,7 +663,8 @@ internal sealed class AuxiliaryBackchannelRpcTarget(
             ProcessId = Environment.ProcessId,
             CliProcessId = cliProcessId,
             StartedAt = new DateTimeOffset(Process.GetCurrentProcess().StartTime),
-            CliStartedAt = cliStartedAt
+            CliStartedAt = cliStartedAt,
+            CliLogFilePath = configuration[KnownConfigNames.CliLogFilePath]
         });
     }
 

--- a/src/Aspire.Hosting/Backchannel/BackchannelDataTypes.cs
+++ b/src/Aspire.Hosting/Backchannel/BackchannelDataTypes.cs
@@ -158,6 +158,11 @@ internal sealed class GetAppHostInfoResponse
     /// Gets when the AppHost process started.
     /// </summary>
     public DateTimeOffset? StartedAt { get; init; }
+
+    /// <summary>
+    /// Gets the log file path of the CLI process that launched the AppHost, if applicable.
+    /// </summary>
+    public string? CliLogFilePath { get; init; }
 }
 
 /// <summary>
@@ -1352,6 +1357,12 @@ internal sealed class AppHostInformation
     /// This value is only set when the AppHost is launched via the Aspire CLI.
     /// </summary>
     public DateTimeOffset? CliStartedAt { get; init; }
+
+    /// <summary>
+    /// Gets or sets the log file path of the CLI process that launched the AppHost.
+    /// This value is only set when the AppHost is launched via the Aspire CLI.
+    /// </summary>
+    public string? CliLogFilePath { get; init; }
 }
 
 /// <summary>

--- a/src/Shared/CliExitCodes.cs
+++ b/src/Shared/CliExitCodes.cs
@@ -3,7 +3,7 @@
 
 namespace Aspire.Cli;
 
-internal static class ExitCodeConstants
+internal static class CliExitCodes
 {
     public const int Success = 0;
     public const int InvalidCommand = 1;

--- a/src/Shared/KnownConfigNames.cs
+++ b/src/Shared/KnownConfigNames.cs
@@ -33,6 +33,7 @@ internal static class KnownConfigNames
     public const string RemoteAppHostToken = "ASPIRE_REMOTE_APPHOST_TOKEN";
     public const string CliProcessId = "ASPIRE_CLI_PID";
     public const string CliProcessStarted = "ASPIRE_CLI_STARTED";
+    public const string CliLogFilePath = "ASPIRE_CLI_LOG_FILE";
     public const string CliRunDetached = "ASPIRE_CLI_RUN_DETACHED";
     public const string IntegrationLibsPath = "ASPIRE_INTEGRATION_LIBS_PATH";
     public const string IntegrationProbeManifestPath = "ASPIRE_INTEGRATION_PROBE_MANIFEST_PATH";

--- a/tests/Aspire.Cli.EndToEnd.Tests/Aspire.Cli.EndToEnd.Tests.csproj
+++ b/tests/Aspire.Cli.EndToEnd.Tests/Aspire.Cli.EndToEnd.Tests.csproj
@@ -53,6 +53,7 @@
   </ItemGroup>
 
   <ItemGroup>
+      <Compile Include="$(SharedDir)CliExitCodes.cs" Link="shared\CliExitCodes.cs" />
       <Compile Include="$(TestsSharedDir)TemporaryRepo.cs" Link="shared\TemporaryRepo.cs" />
       <Compile Include="$(TestsSharedDir)CliInstallStrategy.cs" Link="shared\CliInstallStrategy.cs" />
       <Compile Include="$(TestsSharedDir)CliPackageDiscovery.cs" Link="shared\CliPackageDiscovery.cs" />

--- a/tests/Aspire.Cli.EndToEnd.Tests/ResourceCommandTests.cs
+++ b/tests/Aspire.Cli.EndToEnd.Tests/ResourceCommandTests.cs
@@ -366,13 +366,10 @@ public sealed class ResourceCommandTests(ITestOutputHelper output)
                 "APPHOST_LOG=$(grep 'See AppHost logs at' /tmp/resource-cmd-output.txt | sed 's/.*See AppHost logs at //')",
                 counter);
 
-            // Debug: Show what was captured in stderr and the extracted APPHOST_LOG value
+            // Debug: Show what was captured in stderr and the extracted APPHOST_LOG value.
+            // Run these in a single command with || true so they always complete even if one step fails.
             await auto.RunCommandAsync(
-                "echo '=== Contents of /tmp/resource-cmd-output.txt ===' && cat /tmp/resource-cmd-output.txt",
-                counter);
-
-            await auto.RunCommandAsync(
-                "echo '=== APPHOST_LOG value ===' && echo \"$APPHOST_LOG\"",
+                "echo '=== Contents of /tmp/resource-cmd-output.txt ===' && cat /tmp/resource-cmd-output.txt && echo && echo '=== APPHOST_LOG value ===' && echo \"$APPHOST_LOG\" && echo '=== End debug output ===' || true",
                 counter);
 
             await auto.RunCommandFailFastAsync(

--- a/tests/Aspire.Cli.EndToEnd.Tests/ResourceCommandTests.cs
+++ b/tests/Aspire.Cli.EndToEnd.Tests/ResourceCommandTests.cs
@@ -380,11 +380,6 @@ public sealed class ResourceCommandTests(ITestOutputHelper output)
                 counter,
                 TimeSpan.FromSeconds(10));
 
-            // Debug: dump the AppHost log content so we can see what's actually in it.
-            await auto.RunCommandAsync(
-                "echo '=== APPHOST_LOG content ===' && cat \"$APPHOST_LOG\" && echo '=== End APPHOST_LOG ===' || true",
-                counter);
-
             // Verify the log file contains the custom log entry written by the
             // command handler via ILogger before returning the failure result.
             await auto.RunCommandFailFastAsync(

--- a/tests/Aspire.Cli.EndToEnd.Tests/ResourceCommandTests.cs
+++ b/tests/Aspire.Cli.EndToEnd.Tests/ResourceCommandTests.cs
@@ -362,8 +362,11 @@ public sealed class ResourceCommandTests(ITestOutputHelper output)
 
             // Extract the AppHost log file path from the captured output and verify
             // it exists and is non-empty.
+            // Extract the AppHost log file path from the captured output. The CLI
+            // wraps paths in OSC 8 terminal hyperlinks (\e]8;...;\e\\path\e]8;;\e\\),
+            // so we must strip those escape sequences before extracting the path.
             await auto.RunCommandAsync(
-                "APPHOST_LOG=$(grep 'See AppHost logs at' /tmp/resource-cmd-output.txt | sed 's/.*See AppHost logs at //')",
+                "APPHOST_LOG=$(sed 's/\\x1b\\][^\\x1b]*\\x1b\\\\//g' /tmp/resource-cmd-output.txt | grep 'See AppHost logs at' | sed 's/.*See AppHost logs at //')",
                 counter);
 
             // Debug: Show what was captured in stderr and the extracted APPHOST_LOG value.

--- a/tests/Aspire.Cli.EndToEnd.Tests/ResourceCommandTests.cs
+++ b/tests/Aspire.Cli.EndToEnd.Tests/ResourceCommandTests.cs
@@ -377,9 +377,15 @@ public sealed class ResourceCommandTests(ITestOutputHelper output)
                 counter,
                 TimeSpan.FromSeconds(10));
 
-            // Verify the log file contains CLI log entries (Aspire.Cli namespace).
+            // Debug: dump the AppHost log content so we can see what's actually in it.
+            await auto.RunCommandAsync(
+                "echo '=== APPHOST_LOG content ===' && cat \"$APPHOST_LOG\" && echo '=== End APPHOST_LOG ===' || true",
+                counter);
+
+            // Verify the log file contains the custom log entry written by the
+            // command handler via ILogger before returning the failure result.
             await auto.RunCommandFailFastAsync(
-                "grep -q 'Aspire\\.Cli' \"$APPHOST_LOG\"",
+                "grep -q 'CUSTOM_E2E_LOG_ENTRY_FOR_VERIFICATION' \"$APPHOST_LOG\"",
                 counter,
                 TimeSpan.FromSeconds(10));
 

--- a/tests/Aspire.Cli.EndToEnd.Tests/ResourceCommandTests.cs
+++ b/tests/Aspire.Cli.EndToEnd.Tests/ResourceCommandTests.cs
@@ -366,15 +366,23 @@ public sealed class ResourceCommandTests(ITestOutputHelper output)
                 "APPHOST_LOG=$(grep 'See AppHost logs at' /tmp/resource-cmd-output.txt | sed 's/.*See AppHost logs at //')",
                 counter);
 
+            // Debug: Show what was captured in stderr and the extracted APPHOST_LOG value
+            await auto.RunCommandAsync(
+                "echo '=== Contents of /tmp/resource-cmd-output.txt ===' && cat /tmp/resource-cmd-output.txt",
+                counter);
+
+            await auto.RunCommandAsync(
+                "echo '=== APPHOST_LOG value ===' && echo \"$APPHOST_LOG\"",
+                counter);
+
             await auto.RunCommandFailFastAsync(
                 "test -n \"$APPHOST_LOG\" && test -s \"$APPHOST_LOG\"",
                 counter,
                 TimeSpan.FromSeconds(10));
 
-            // Verify the log file contains the custom log entry written by the
-            // resource command via context.Logger.
+            // Verify the log file contains CLI log entries (Aspire.Cli namespace).
             await auto.RunCommandFailFastAsync(
-                "grep -q 'CUSTOM_E2E_LOG_ENTRY_FOR_VERIFICATION' \"$APPHOST_LOG\"",
+                "grep -q 'Aspire\\.Cli' \"$APPHOST_LOG\"",
                 counter,
                 TimeSpan.FromSeconds(10));
 

--- a/tests/Aspire.Cli.EndToEnd.Tests/ResourceCommandTests.cs
+++ b/tests/Aspire.Cli.EndToEnd.Tests/ResourceCommandTests.cs
@@ -349,9 +349,9 @@ public sealed class ResourceCommandTests(ITestOutputHelper output)
             await auto.WaitUntilTextAsync(RunCommandStrings.AppHostStartedSuccessfully, timeout: TimeSpan.FromMinutes(3));
             await auto.WaitForSuccessPromptAsync(counter);
 
-            // Run the failing resource command, capturing stderr so we can extract the
+            // Run the failing resource command, capturing stdout and stderr so we can extract the
             // AppHost log path from the "See AppHost logs at <path>" message.
-            await auto.TypeAsync("aspire resource cache fail-with-log 2> /tmp/resource-cmd-output.txt");
+            await auto.TypeAsync("aspire resource cache fail-with-log > /tmp/resource-cmd-output.txt 2>&1");
             await auto.EnterAsync();
             await auto.WaitForAnyPromptAsync(counter, timeout: TimeSpan.FromSeconds(30));
 

--- a/tests/Aspire.Cli.EndToEnd.Tests/ResourceCommandTests.cs
+++ b/tests/Aspire.Cli.EndToEnd.Tests/ResourceCommandTests.cs
@@ -23,7 +23,7 @@ public sealed class ResourceCommandTests(ITestOutputHelper output)
         var projectSuffix = Guid.NewGuid().ToString("N")[..6];
         var projectName = $"ResourceParameterCmdApp_{projectSuffix}";
 
-        using var workspace = TemporaryWorkspace.Create(output);
+        var workspace = TemporaryWorkspace.Create(output);
 
         using var terminal = CliE2ETestHelpers.CreateDockerTestTerminal(repoRoot, strategy, output, workspace: workspace);
 
@@ -152,7 +152,7 @@ public sealed class ResourceCommandTests(ITestOutputHelper output)
         var projectSuffix = Guid.NewGuid().ToString("N")[..6];
         var projectName = $"ResourceCmdApp_{projectSuffix}";
 
-        using var workspace = TemporaryWorkspace.Create(output);
+        var workspace = TemporaryWorkspace.Create(output);
 
         using var terminal = CliE2ETestHelpers.CreateDockerTestTerminal(repoRoot, strategy, output, mountDockerSocket: true, workspace: workspace);
 
@@ -173,7 +173,7 @@ public sealed class ResourceCommandTests(ITestOutputHelper output)
             await auto.WaitForSuccessPromptAsync(counter);
 
             // Read the generated apphost.cs so we can extract the #:sdk line with the
-            // resolved version, then replace the entire file with a minimal app host
+            // resolved version, then replace the entire file with a minimal AppHost
             // that has a placeholder resource and a command that uses IInteractionService.
             var appHostFilePath = Path.Combine(workspace.WorkspaceRoot.FullName, projectName, "apphost.cs");
             var content = File.ReadAllText(appHostFilePath);
@@ -205,13 +205,18 @@ public sealed class ResourceCommandTests(ITestOutputHelper output)
                                 title: "Prompt title",
                                 message: "Prompt message",
                                 inputLabel: "Name",
-                                placeHolder: "placeholder").WaitAsync(TimeSpan.FromSeconds(5));
+                                placeHolder: "placeholder").WaitAsync(TimeSpan.FromSeconds(10));
 
-                            return CommandResults.Failure("Prompt unexpectedly completed without throwing.");
+                            // We're looking for a failure. Treat a successful prompt completion as a test failure since that would
+                            // indicate the interaction service is available when it shouldn't be.
+                            return CommandResults.Success("Prompt unexpectedly completed without throwing.");
                         }
                         catch (TimeoutException)
                         {
-                            return CommandResults.Failure("Prompt timed out after 5 seconds.");
+                            // We're looking for a failure, and the most likely failure mode if the interaction service is incorrectly
+                            // available would be that the prompt hangs waiting for input that will never come.
+                            // Treat a timeout as a success since that indicates the interaction service is not available to show the prompt.
+                            return CommandResults.Success("Prompt timed out after 10 seconds.");
                         }
                     });
 
@@ -229,13 +234,151 @@ public sealed class ResourceCommandTests(ITestOutputHelper output)
             await auto.EnterAsync();
             await auto.WaitUntilTextAsync("Failed to execute command 'needs-interaction' on resource 'cache'", timeout: TimeSpan.FromSeconds(30));
             await auto.WaitUntilTextAsync("InteractionService is not available", timeout: TimeSpan.FromSeconds(30));
+            await auto.WaitUntilTextAsync("See logs at", timeout: TimeSpan.FromSeconds(30));
+            await auto.WaitUntilTextAsync("See AppHost logs at", timeout: TimeSpan.FromSeconds(30));
             await auto.WaitForAnyPromptAsync(counter, timeout: TimeSpan.FromSeconds(30));
 
-            await auto.TypeAsync("if [ $? -eq 0 ]; then echo RESOURCE_CMD_SUCCEEDED_UNEXPECTEDLY; else echo RESOURCE_CMD_FAILED_AS_EXPECTED; fi");
+            await auto.TypeAsync($"if [ $? -eq {CliExitCodes.FailedToExecuteResourceCommand} ]; then echo RESOURCE_CMD_EXIT_CODE_CORRECT; else echo RESOURCE_CMD_UNEXPECTED_EXIT_CODE; fi");
             await auto.EnterAsync();
-            await auto.WaitUntilTextAsync("RESOURCE_CMD_FAILED_AS_EXPECTED", timeout: TimeSpan.FromSeconds(10));
+            await auto.WaitUntilTextAsync("RESOURCE_CMD_EXIT_CODE_CORRECT", timeout: TimeSpan.FromSeconds(10));
             await auto.WaitForSuccessPromptAsync(counter);
 
+            await auto.TypeAsync("aspire stop");
+            await auto.EnterAsync();
+            await auto.WaitUntilAppHostStoppedSuccessfullyAsync(timeout: TimeSpan.FromMinutes(1));
+            await auto.WaitForSuccessPromptAsync(counter);
+        }
+        catch
+        {
+            testBodyFailed = true;
+            throw;
+        }
+        finally
+        {
+            try
+            {
+                await auto.CaptureAspireDiagnosticsAsync(counter, workspace);
+            }
+            catch
+            {
+                // Best effort diagnostics capture.
+            }
+
+            try
+            {
+                await auto.TypeAsync("exit");
+                await auto.EnterAsync();
+                await pendingRun;
+            }
+            catch
+            {
+                if (!testBodyFailed)
+                {
+                    throw;
+                }
+            }
+        }
+    }
+
+    [Fact]
+    [CaptureWorkspaceOnFailure]
+    public async Task ResourceCommand_FailedExecution_DisplaysAppHostLogPathAndLogContainsEntries()
+    {
+        var repoRoot = CliE2ETestHelpers.GetRepoRoot();
+        var strategy = CliInstallStrategy.Detect(output.WriteLine);
+        var projectSuffix = Guid.NewGuid().ToString("N")[..6];
+        var projectName = $"ResourceCmdLogApp_{projectSuffix}";
+
+        var workspace = TemporaryWorkspace.Create(output);
+
+        using var terminal = CliE2ETestHelpers.CreateDockerTestTerminal(repoRoot, strategy, output, mountDockerSocket: true, workspace: workspace);
+
+        var pendingRun = terminal.RunAsync(TestContext.Current.CancellationToken);
+
+        var counter = new SequenceCounter();
+        var auto = new Hex1bTerminalAutomator(terminal, defaultTimeout: TimeSpan.FromSeconds(500));
+        var testBodyFailed = false;
+
+        try
+        {
+            await auto.PrepareDockerEnvironmentAsync(counter, workspace, enableDcpDiagnostics: true);
+            await auto.InstallAspireCliAsync(strategy, counter);
+            await auto.AspireNewAsync(projectName, counter, template: AspireTemplate.EmptyAppHost);
+
+            await auto.TypeAsync($"cd {projectName}");
+            await auto.EnterAsync();
+            await auto.WaitForSuccessPromptAsync(counter);
+
+            // Replace the generated apphost.cs with a minimal AppHost that has a
+            // command writing to context.Logger before returning a failure result.
+            var appHostFilePath = Path.Combine(workspace.WorkspaceRoot.FullName, projectName, "apphost.cs");
+            var content = File.ReadAllText(appHostFilePath);
+
+            // Extract the first line (#:sdk directive) so the replacement uses the same SDK version.
+            var sdkLine = content.Split('\n', 2)[0].TrimEnd('\r');
+
+            var newContent = $$"""
+                {{sdkLine}}
+
+                using Microsoft.Extensions.DependencyInjection;
+                using Microsoft.Extensions.Logging;
+
+                var builder = DistributedApplication.CreateBuilder(args);
+
+                var cache = builder.AddContainer("cache", "redis");
+
+                cache.WithCommand(
+                    name: "fail-with-log",
+                    displayName: "Fail with log",
+                    executeCommand: context =>
+                    {
+                        var logger = context.ServiceProvider.GetRequiredService<ILogger<Program>>();
+                        logger.LogInformation("CUSTOM_E2E_LOG_ENTRY_FOR_VERIFICATION");
+
+                        return Task.FromResult(CommandResults.Failure("Command failed intentionally."));
+                    });
+
+                builder.Build().Run();
+                """;
+
+            File.WriteAllText(appHostFilePath, newContent);
+
+            // Start the AppHost in detached mode.
+            await auto.TypeAsync("aspire start");
+            await auto.EnterAsync();
+            await auto.WaitUntilTextAsync(RunCommandStrings.AppHostStartedSuccessfully, timeout: TimeSpan.FromMinutes(3));
+            await auto.WaitForSuccessPromptAsync(counter);
+
+            // Run the failing resource command, capturing stderr so we can extract the
+            // AppHost log path from the "See AppHost logs at <path>" message.
+            await auto.TypeAsync("aspire resource cache fail-with-log 2> /tmp/resource-cmd-output.txt");
+            await auto.EnterAsync();
+            await auto.WaitForAnyPromptAsync(counter, timeout: TimeSpan.FromSeconds(30));
+
+            await auto.TypeAsync($"if [ $? -eq {CliExitCodes.FailedToExecuteResourceCommand} ]; then echo RESOURCE_CMD_EXIT_CODE_CORRECT; else echo RESOURCE_CMD_UNEXPECTED_EXIT_CODE; fi");
+            await auto.EnterAsync();
+            await auto.WaitUntilTextAsync("RESOURCE_CMD_EXIT_CODE_CORRECT", timeout: TimeSpan.FromSeconds(10));
+            await auto.WaitForSuccessPromptAsync(counter);
+
+            // Extract the AppHost log file path from the captured output and verify
+            // it exists and is non-empty.
+            await auto.RunCommandAsync(
+                "APPHOST_LOG=$(grep 'See AppHost logs at' /tmp/resource-cmd-output.txt | sed 's/.*See AppHost logs at //')",
+                counter);
+
+            await auto.RunCommandFailFastAsync(
+                "test -n \"$APPHOST_LOG\" && test -s \"$APPHOST_LOG\"",
+                counter,
+                TimeSpan.FromSeconds(10));
+
+            // Verify the log file contains the custom log entry written by the
+            // resource command via context.Logger.
+            await auto.RunCommandFailFastAsync(
+                "grep -q 'CUSTOM_E2E_LOG_ENTRY_FOR_VERIFICATION' \"$APPHOST_LOG\"",
+                counter,
+                TimeSpan.FromSeconds(10));
+
+            // Stop the AppHost.
             await auto.TypeAsync("aspire stop");
             await auto.EnterAsync();
             await auto.WaitUntilAppHostStoppedSuccessfullyAsync(timeout: TimeSpan.FromMinutes(1));

--- a/tests/Aspire.Cli.Tests/Backchannel/AppHostConnectionResolverTests.cs
+++ b/tests/Aspire.Cli.Tests/Backchannel/AppHostConnectionResolverTests.cs
@@ -57,7 +57,7 @@ public class AppHostConnectionResolverTests(ITestOutputHelper outputHelper)
         var result = new AppHostConnectionResult
         {
             ErrorMessage = "failed",
-            ExitCode = ExitCodeConstants.FailedToCreateNewProject
+            ExitCode = CliExitCodes.FailedToCreateNewProject
         };
 
         Assert.False(result.IsProjectResolutionError);
@@ -91,7 +91,7 @@ public class AppHostConnectionResolverTests(ITestOutputHelper outputHelper)
 
         Assert.False(result.Success);
         Assert.True(result.IsProjectResolutionError);
-        Assert.Equal(ExitCodeConstants.FailedToFindProject, result.ExitCode);
+        Assert.Equal(CliExitCodes.FailedToFindProject, result.ExitCode);
         Assert.Equal(InteractionServiceStrings.ProjectOptionSpecifiedDirectoryContainsMultipleAppHosts, result.ErrorMessage);
     }
 
@@ -123,7 +123,7 @@ public class AppHostConnectionResolverTests(ITestOutputHelper outputHelper)
 
         Assert.False(result.Success);
         Assert.True(result.IsProjectResolutionError);
-        Assert.Equal(ExitCodeConstants.FailedToFindProject, result.ExitCode);
+        Assert.Equal(CliExitCodes.FailedToFindProject, result.ExitCode);
         Assert.Equal(InteractionServiceStrings.ProjectOptionSpecifiedDirectoryContainsNoAppHosts, result.ErrorMessage);
     }
 

--- a/tests/Aspire.Cli.Tests/CliSmokeTests.cs
+++ b/tests/Aspire.Cli.Tests/CliSmokeTests.cs
@@ -14,10 +14,10 @@ public class CliSmokeTests(ITestOutputHelper outputHelper)
     };
 
     [Theory]
-    [InlineData(new string[] { }, ExitCodeConstants.InvalidCommand)]
-    [InlineData(new[] { "-d", "--help" }, ExitCodeConstants.Success)]
-    [InlineData(new[] { "--help" }, ExitCodeConstants.Success)]
-    [InlineData(new[] { "--version" }, ExitCodeConstants.Success)]
+    [InlineData(new string[] { }, CliExitCodes.InvalidCommand)]
+    [InlineData(new[] { "-d", "--help" }, CliExitCodes.Success)]
+    [InlineData(new[] { "--help" }, CliExitCodes.Success)]
+    [InlineData(new[] { "--version" }, CliExitCodes.Success)]
     public async Task MainReturnsExpectedExitCode(string[] args, int expectedExitCode)
     {
         var exitCode = await Program.Main(args).DefaultTimeout();
@@ -126,7 +126,7 @@ public class CliSmokeTests(ITestOutputHelper outputHelper)
     [Fact]
     public void RenderScenarioOutputsPublishSummaryStressCase()
     {
-        using var result = RemoteExecutor.Invoke(async () =>
+        using var result = RemoteExecutor.Invoke((Func<Task>)(async () =>
         {
             await using var outputWriter = new StringWriter();
             await using var errorWriter = new StringWriter();
@@ -147,13 +147,13 @@ public class CliSmokeTests(ITestOutputHelper outputHelper)
 
             Console.WriteLine(combinedOutput);
 
-            Assert.Equal(ExitCodeConstants.Success, exitCode);
+            Assert.Equal((int)CliExitCodes.Success, exitCode);
             Assert.Contains("=== Duration extremes ===", combinedOutput);
             Assert.Contains("Steps Summary:", combinedOutput);
             Assert.Contains("Tiny 0.2ms event", combinedOutput);
             Assert.Contains("Zero event", combinedOutput);
             Assert.Contains('╴', combinedOutput);
-        }, options: s_remoteInvokeOptions);
+        }), options: s_remoteInvokeOptions);
 
         outputHelper.WriteLine(result.Process.StandardOutput.ReadToEnd());
     }

--- a/tests/Aspire.Cli.Tests/Commands/AddCommandTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/AddCommandTests.cs
@@ -74,7 +74,7 @@ public class AddCommandTests(ITestOutputHelper outputHelper)
 
         var exitCode = await result.InvokeAsync().DefaultTimeout();
 
-        Assert.Equal(ExitCodeConstants.InvalidCommand, exitCode);
+        Assert.Equal(CliExitCodes.InvalidCommand, exitCode);
         Assert.Empty(rawJson);
     }
 
@@ -105,7 +105,7 @@ public class AddCommandTests(ITestOutputHelper outputHelper)
 
         var exitCode = await result.InvokeAsync().DefaultTimeout();
 
-        Assert.Equal(ExitCodeConstants.InvalidCommand, exitCode);
+        Assert.Equal(CliExitCodes.InvalidCommand, exitCode);
         Assert.Empty(rawJson);
     }
 
@@ -181,7 +181,7 @@ public class AddCommandTests(ITestOutputHelper outputHelper)
 
         var exitCode = await result.InvokeAsync().DefaultTimeout();
 
-        Assert.Equal(ExitCodeConstants.Success, exitCode);
+        Assert.Equal(CliExitCodes.Success, exitCode);
         Assert.False(projectLocatorWasCalled);
         Assert.False(promptedForIntegration);
         Assert.False(promptedForVersion);
@@ -224,7 +224,7 @@ public class AddCommandTests(ITestOutputHelper outputHelper)
 
         var exitCode = await result.InvokeAsync().DefaultTimeout();
 
-        Assert.Equal(ExitCodeConstants.Success, exitCode);
+        Assert.Equal(CliExitCodes.Success, exitCode);
         Assert.Empty(ReadIntegrationResults(rawJson));
     }
 
@@ -249,7 +249,7 @@ public class AddCommandTests(ITestOutputHelper outputHelper)
 
         var exitCode = await result.InvokeAsync().DefaultTimeout();
 
-        Assert.Equal(ExitCodeConstants.FailedToSearchIntegrations, exitCode);
+        Assert.Equal(CliExitCodes.FailedToSearchIntegrations, exitCode);
     }
 
     [Fact]
@@ -299,7 +299,7 @@ public class AddCommandTests(ITestOutputHelper outputHelper)
 
         var exitCode = await result.InvokeAsync().DefaultTimeout();
 
-        Assert.Equal(ExitCodeConstants.Success, exitCode);
+        Assert.Equal(CliExitCodes.Success, exitCode);
         Assert.False(addPackageWasCalled);
 
         var integrations = ReadIntegrationResults(rawJson);
@@ -345,7 +345,7 @@ public class AddCommandTests(ITestOutputHelper outputHelper)
 
         var exitCode = await result.InvokeAsync().DefaultTimeout();
 
-        Assert.Equal(ExitCodeConstants.Success, exitCode);
+        Assert.Equal(CliExitCodes.Success, exitCode);
 
         var integrations = ReadIntegrationResults(rawJson);
         var integration = Assert.Single(integrations);
@@ -399,7 +399,7 @@ public class AddCommandTests(ITestOutputHelper outputHelper)
 
         var exitCode = await result.InvokeAsync().DefaultTimeout();
 
-        Assert.Equal(ExitCodeConstants.Success, exitCode);
+        Assert.Equal(CliExitCodes.Success, exitCode);
 
         var integration = Assert.Single(ReadIntegrationResults(rawJson));
         Assert.Equal("Aspire.Hosting.Redis", integration.Package);
@@ -446,7 +446,7 @@ public class AddCommandTests(ITestOutputHelper outputHelper)
 
         var exitCode = await result.InvokeAsync().DefaultTimeout();
 
-        Assert.Equal(ExitCodeConstants.Success, exitCode);
+        Assert.Equal(CliExitCodes.Success, exitCode);
 
         var integration = Assert.Single(ReadIntegrationResults(rawJson));
         Assert.Equal("Aspire.Hosting.Redis", integration.Package);
@@ -499,7 +499,7 @@ public class AddCommandTests(ITestOutputHelper outputHelper)
 
         var exitCode = await result.InvokeAsync().DefaultTimeout();
 
-        Assert.Equal(ExitCodeConstants.Success, exitCode);
+        Assert.Equal(CliExitCodes.Success, exitCode);
         Assert.False(addPackageWasCalled);
 
         var integrations = ReadIntegrationResults(rawJson);
@@ -1258,7 +1258,7 @@ public class AddCommandTests(ITestOutputHelper outputHelper)
 
         var exitCode = await result.InvokeAsync().DefaultTimeout();
 
-        Assert.Equal(ExitCodeConstants.FailedToAddPackage, exitCode);
+        Assert.Equal(CliExitCodes.FailedToAddPackage, exitCode);
         Assert.False(promptedForVersion);
         Assert.False(addPackageWasCalled);
         Assert.Contains(testInteractionService.DisplayedErrors, error => error.Contains("13.2.0") && error.Contains("Aspire.Hosting.Redis"));
@@ -1335,7 +1335,7 @@ public class AddCommandTests(ITestOutputHelper outputHelper)
 
         var exitCode = await result.InvokeAsync().DefaultTimeout();
 
-        Assert.Equal(ExitCodeConstants.FailedToAddPackage, exitCode);
+        Assert.Equal(CliExitCodes.FailedToAddPackage, exitCode);
         Assert.False(promptedForIntegration);
         Assert.False(promptedForVersion);
         Assert.False(addPackageWasCalled);
@@ -1523,7 +1523,7 @@ public class AddCommandTests(ITestOutputHelper outputHelper)
         var result = command.Parse("add");
 
         var exitCode = await result.InvokeAsync().DefaultTimeout();
-        Assert.Equal(ExitCodeConstants.FailedToAddPackage, exitCode);
+        Assert.Equal(CliExitCodes.FailedToAddPackage, exitCode);
         Assert.Contains(testInteractionService.DisplayedErrors, e => e.Contains(AddCommandStrings.NoIntegrationPackagesFound));
     }
 
@@ -2222,7 +2222,7 @@ public class AddCommandFuzzySearchTests(ITestOutputHelper outputHelper)
 
         var exitCode = await result.InvokeAsync().DefaultTimeout();
 
-        Assert.Equal(ExitCodeConstants.FailedToAddPackage, exitCode);
+        Assert.Equal(CliExitCodes.FailedToAddPackage, exitCode);
         Assert.False(addPackageWasCalled);
         Assert.Contains(string.Format(AddCommandStrings.SpecifiedVersionRequiresExactPackageMatch, "postgre"), testInteractionService.DisplayedErrors);
     }
@@ -2274,7 +2274,7 @@ public class AddCommandFuzzySearchTests(ITestOutputHelper outputHelper)
 
         var exitCode = await result.InvokeAsync().DefaultTimeout();
 
-        Assert.Equal(ExitCodeConstants.FailedToAddPackage, exitCode);
+        Assert.Equal(CliExitCodes.FailedToAddPackage, exitCode);
         Assert.False(addPackageWasCalled);
         Assert.Contains(string.Format(AddCommandStrings.SpecifiedVersionRequiresExactPackageMatch, "nonexistentpackage"), testInteractionService.DisplayedErrors);
     }
@@ -2524,7 +2524,7 @@ public class AddCommandFuzzySearchTests(ITestOutputHelper outputHelper)
 
         var exitCode = await result.InvokeAsync().DefaultTimeout();
 
-        Assert.Equal(ExitCodeConstants.FailedToAddPackage, exitCode);
+        Assert.Equal(CliExitCodes.FailedToAddPackage, exitCode);
         Assert.True(promptedForIntegration);
         Assert.False(promptedForVersion);
         Assert.False(addPackageWasCalled);
@@ -2699,7 +2699,7 @@ public class AddCommandFuzzySearchTests(ITestOutputHelper outputHelper)
 
         var exitCode = await result.InvokeAsync().DefaultTimeout();
 
-        Assert.Equal(ExitCodeConstants.FailedToAddPackage, exitCode);
+        Assert.Equal(CliExitCodes.FailedToAddPackage, exitCode);
         Assert.True(promptedForIntegration);
         Assert.False(promptedForVersion);
         Assert.False(addPackageWasCalled);

--- a/tests/Aspire.Cli.Tests/Commands/AgentInitCommandTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/AgentInitCommandTests.cs
@@ -79,7 +79,7 @@ public class AgentInitCommandTests(ITestOutputHelper outputHelper)
 
         var exitCode = await result.InvokeAsync().DefaultTimeout();
 
-        Assert.Equal(ExitCodeConstants.InvalidCommand, exitCode);
+        Assert.Equal(CliExitCodes.InvalidCommand, exitCode);
 
         var expectedSkillDirectoryPath = Path.Combine(invalidRootFilePath, ".agents", "skills", SkillDefinition.Aspire.Name);
         Assert.Contains(
@@ -101,7 +101,7 @@ public class AgentInitCommandTests(ITestOutputHelper outputHelper)
         var exitCode = await result.InvokeAsync().DefaultTimeout();
 
         // Exit code is InvalidCommand because FakeNpmRunner cannot resolve Playwright CLI in tests.
-        Assert.Equal(ExitCodeConstants.InvalidCommand, exitCode);
+        Assert.Equal(CliExitCodes.InvalidCommand, exitCode);
 
         // Verify that the aspire skill was installed to all locations
         Assert.True(File.Exists(Path.Combine(workspace.WorkspaceRoot.FullName, ".agents", "skills", "aspire", "SKILL.md")));
@@ -123,7 +123,7 @@ public class AgentInitCommandTests(ITestOutputHelper outputHelper)
 
         var exitCode = await result.InvokeAsync().DefaultTimeout();
 
-        Assert.Equal(ExitCodeConstants.Success, exitCode);
+        Assert.Equal(CliExitCodes.Success, exitCode);
 
         // No locations selected, so no skill directories should be created
         var agentsDir = Path.Combine(workspace.WorkspaceRoot.FullName, ".agents");
@@ -143,7 +143,7 @@ public class AgentInitCommandTests(ITestOutputHelper outputHelper)
 
         var exitCode = await result.InvokeAsync().DefaultTimeout();
 
-        Assert.Equal(ExitCodeConstants.Success, exitCode);
+        Assert.Equal(CliExitCodes.Success, exitCode);
     }
 
     [Fact]
@@ -160,7 +160,7 @@ public class AgentInitCommandTests(ITestOutputHelper outputHelper)
         var exitCode = await result.InvokeAsync().DefaultTimeout();
 
         // Default skill is Aspire, which gets installed. Playwright is not default so not selected.
-        Assert.Equal(ExitCodeConstants.Success, exitCode);
+        Assert.Equal(CliExitCodes.Success, exitCode);
 
         // Verify the default aspire skill was installed
         var aspireSkillPath = Path.Combine(workspace.WorkspaceRoot.FullName, ".agents", "skills", "aspire", "SKILL.md");
@@ -180,7 +180,7 @@ public class AgentInitCommandTests(ITestOutputHelper outputHelper)
 
         var exitCode = await result.InvokeAsync().DefaultTimeout();
 
-        Assert.Equal(ExitCodeConstants.MissingRequiredArgument, exitCode);
+        Assert.Equal(CliExitCodes.MissingRequiredArgument, exitCode);
     }
 
     [Fact]
@@ -196,7 +196,7 @@ public class AgentInitCommandTests(ITestOutputHelper outputHelper)
 
         var exitCode = await result.InvokeAsync().DefaultTimeout();
 
-        Assert.Equal(ExitCodeConstants.Success, exitCode);
+        Assert.Equal(CliExitCodes.Success, exitCode);
 
         // Verify that the default aspire skill was installed under the working directory
         var aspireSkillPath = Path.Combine(workspace.WorkspaceRoot.FullName, ".agents", "skills", "aspire", "SKILL.md");
@@ -216,7 +216,7 @@ public class AgentInitCommandTests(ITestOutputHelper outputHelper)
 
         var exitCode = await result.InvokeAsync().DefaultTimeout();
 
-        Assert.Equal(ExitCodeConstants.Success, exitCode);
+        Assert.Equal(CliExitCodes.Success, exitCode);
 
         // No skills selected, so no skill files should be created
         var aspireSkillPath = Path.Combine(workspace.WorkspaceRoot.FullName, ".agents", "skills", "aspire");
@@ -237,7 +237,7 @@ public class AgentInitCommandTests(ITestOutputHelper outputHelper)
 
         var exitCode = await result.InvokeAsync().DefaultTimeout();
 
-        Assert.Equal(ExitCodeConstants.Success, exitCode);
+        Assert.Equal(CliExitCodes.Success, exitCode);
     }
 
     private static CliExecutionContext CreateExecutionContext(DirectoryInfo workingDirectory, DirectoryInfo homeDirectory)

--- a/tests/Aspire.Cli.Tests/Commands/AgentMcpCommandTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/AgentMcpCommandTests.cs
@@ -579,7 +579,7 @@ public class AgentMcpCommandTests(ITestOutputHelper outputHelper)
 
         var result = await agentMcpCommand.ExecuteCommandAsync(parseResult, CancellationToken.None).DefaultTimeout();
 
-        Assert.Equal(ExitCodeConstants.InvalidCommand, result.ExitCode);
+        Assert.Equal(CliExitCodes.InvalidCommand, result.ExitCode);
     }
 
     private static string GetResultText(CallToolResult result)

--- a/tests/Aspire.Cli.Tests/Commands/ApiCommandTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/ApiCommandTests.cs
@@ -24,7 +24,7 @@ public class ApiCommandTests(ITestOutputHelper outputHelper)
         var result = command.Parse("docs api");
 
         var exitCode = await result.InvokeAsync().DefaultTimeout();
-        Assert.Equal(ExitCodeConstants.InvalidCommand, exitCode);
+        Assert.Equal(CliExitCodes.InvalidCommand, exitCode);
     }
 
     [Fact]
@@ -41,7 +41,7 @@ public class ApiCommandTests(ITestOutputHelper outputHelper)
         var result = command.Parse("docs api list csharp");
 
         var exitCode = await result.InvokeAsync().DefaultTimeout();
-        Assert.Equal(ExitCodeConstants.Success, exitCode);
+        Assert.Equal(CliExitCodes.Success, exitCode);
     }
 
     [Fact]
@@ -58,7 +58,7 @@ public class ApiCommandTests(ITestOutputHelper outputHelper)
         var result = command.Parse("docs api search emulator --language typescript --format json");
 
         var exitCode = await result.InvokeAsync().DefaultTimeout();
-        Assert.Equal(ExitCodeConstants.Success, exitCode);
+        Assert.Equal(CliExitCodes.Success, exitCode);
     }
 
     [Fact]
@@ -75,7 +75,7 @@ public class ApiCommandTests(ITestOutputHelper outputHelper)
         var result = command.Parse("docs api get csharp/aspire.test.package/testtype");
 
         var exitCode = await result.InvokeAsync().DefaultTimeout();
-        Assert.Equal(ExitCodeConstants.Success, exitCode);
+        Assert.Equal(CliExitCodes.Success, exitCode);
     }
 
     [Fact]
@@ -92,7 +92,7 @@ public class ApiCommandTests(ITestOutputHelper outputHelper)
         var result = command.Parse("docs api get missing/id");
 
         var exitCode = await result.InvokeAsync().DefaultTimeout();
-        Assert.NotEqual(ExitCodeConstants.Success, exitCode);
+        Assert.NotEqual(CliExitCodes.Success, exitCode);
     }
 }
 

--- a/tests/Aspire.Cli.Tests/Commands/CacheCommandTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/CacheCommandTests.cs
@@ -22,7 +22,7 @@ public class CacheCommandTests(ITestOutputHelper outputHelper)
 
         var exitCode = await result.InvokeAsync().DefaultTimeout();
 
-        Assert.Equal(ExitCodeConstants.InvalidCommand, exitCode);
+        Assert.Equal(CliExitCodes.InvalidCommand, exitCode);
     }
 
     [Fact]
@@ -58,7 +58,7 @@ public class CacheCommandTests(ITestOutputHelper outputHelper)
 
         var exitCode = await result.InvokeAsync().DefaultTimeout();
 
-        Assert.Equal(ExitCodeConstants.Success, exitCode);
+        Assert.Equal(CliExitCodes.Success, exitCode);
         Assert.False(File.Exists(Path.Combine(restoreDir.FullName, "test.dll")));
     }
 
@@ -79,7 +79,7 @@ public class CacheCommandTests(ITestOutputHelper outputHelper)
 
         var exitCode = await result.InvokeAsync().DefaultTimeout();
 
-        Assert.Equal(ExitCodeConstants.Success, exitCode);
+        Assert.Equal(CliExitCodes.Success, exitCode);
     }
 
     [Fact]

--- a/tests/Aspire.Cli.Tests/Commands/CertificatesCommandTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/CertificatesCommandTests.cs
@@ -21,7 +21,7 @@ public class CertificatesCommandTests(ITestOutputHelper outputHelper)
 
         var exitCode = await result.InvokeAsync().DefaultTimeout();
 
-        Assert.Equal(ExitCodeConstants.Success, exitCode);
+        Assert.Equal(CliExitCodes.Success, exitCode);
     }
 
     [Fact]
@@ -36,7 +36,7 @@ public class CertificatesCommandTests(ITestOutputHelper outputHelper)
 
         var exitCode = await result.InvokeAsync().DefaultTimeout();
 
-        Assert.Equal(ExitCodeConstants.Success, exitCode);
+        Assert.Equal(CliExitCodes.Success, exitCode);
     }
 
     [Fact]
@@ -51,6 +51,6 @@ public class CertificatesCommandTests(ITestOutputHelper outputHelper)
 
         var exitCode = await result.InvokeAsync().DefaultTimeout();
 
-        Assert.Equal(ExitCodeConstants.Success, exitCode);
+        Assert.Equal(CliExitCodes.Success, exitCode);
     }
 }

--- a/tests/Aspire.Cli.Tests/Commands/ConfigCommandTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/ConfigCommandTests.cs
@@ -76,7 +76,7 @@ public class ConfigCommandTests(ITestOutputHelper outputHelper)
         var result = command.Parse("config");
 
         var exitCode = await result.InvokeAsync().DefaultTimeout();
-        Assert.Equal(ExitCodeConstants.InvalidCommand, exitCode);
+        Assert.Equal(CliExitCodes.InvalidCommand, exitCode);
     }
 
     [Fact]
@@ -774,7 +774,7 @@ public class ConfigCommandTests(ITestOutputHelper outputHelper)
 
         var exitCode = await result.InvokeAsync().DefaultTimeout();
 
-        Assert.Equal(ExitCodeConstants.Success, exitCode);
+        Assert.Equal(CliExitCodes.Success, exitCode);
 
         var configPath = Path.Combine(workspace.WorkspaceRoot.FullName, AspireConfigFile.FileName);
         var json = await File.ReadAllTextAsync(configPath);
@@ -804,7 +804,7 @@ public class ConfigCommandTests(ITestOutputHelper outputHelper)
 
         var exitCode = await result.InvokeAsync().DefaultTimeout();
 
-        Assert.Equal(ExitCodeConstants.Success, exitCode);
+        Assert.Equal(CliExitCodes.Success, exitCode);
 
         var configPath = Path.Combine(workspace.WorkspaceRoot.FullName, AspireConfigFile.FileName);
         var json = await File.ReadAllTextAsync(configPath);
@@ -836,7 +836,7 @@ public class ConfigCommandTests(ITestOutputHelper outputHelper)
 
         var exitCode = await result.InvokeAsync().DefaultTimeout();
 
-        Assert.Equal(ExitCodeConstants.InvalidCommand, exitCode);
+        Assert.Equal(CliExitCodes.InvalidCommand, exitCode);
         Assert.Equal(GetErrorString(expectedErrorResourceName), Assert.Single(testInteractionService.DisplayedErrors));
 
         var settingsPath = provider.GetRequiredService<IConfigurationService>().GetSettingsFilePath(isGlobal: true);
@@ -869,7 +869,7 @@ public class ConfigCommandTests(ITestOutputHelper outputHelper)
 
         var exitCode = await result.InvokeAsync().DefaultTimeout();
 
-        Assert.Equal(ExitCodeConstants.InvalidCommand, exitCode);
+        Assert.Equal(CliExitCodes.InvalidCommand, exitCode);
 
         var configPath = Path.Combine(workspace.WorkspaceRoot.FullName, AspireConfigFile.FileName);
         Assert.False(File.Exists(configPath));
@@ -887,7 +887,7 @@ public class ConfigCommandTests(ITestOutputHelper outputHelper)
 
         var exitCode = await result.InvokeAsync().DefaultTimeout();
 
-        Assert.Equal(ExitCodeConstants.Success, exitCode);
+        Assert.Equal(CliExitCodes.Success, exitCode);
 
         var settingsPath = provider.GetRequiredService<IConfigurationService>().GetSettingsFilePath(isGlobal: false);
         var json = await File.ReadAllTextAsync(settingsPath);

--- a/tests/Aspire.Cli.Tests/Commands/DashboardRunCommandTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/DashboardRunCommandTests.cs
@@ -38,7 +38,7 @@ public class DashboardRunCommandTests(ITestOutputHelper outputHelper)
 
         var exitCode = await result.InvokeAsync().DefaultTimeout();
 
-        Assert.Equal(ExitCodeConstants.DashboardFailure, exitCode);
+        Assert.Equal(CliExitCodes.DashboardFailure, exitCode);
         var errorMessage = Assert.Single(testInteractionService.DisplayedErrors);
         Assert.Equal(DashboardCommandStrings.BundleLayoutNotFound, errorMessage);
     }
@@ -55,7 +55,7 @@ public class DashboardRunCommandTests(ITestOutputHelper outputHelper)
 
         var exitCode = await result.InvokeAsync().DefaultTimeout();
 
-        Assert.Equal(ExitCodeConstants.Success, exitCode);
+        Assert.Equal(CliExitCodes.Success, exitCode);
     }
 
     [Theory]
@@ -147,7 +147,7 @@ public class DashboardRunCommandTests(ITestOutputHelper outputHelper)
 
         var exitCode = await result.InvokeAsync().DefaultTimeout();
 
-        Assert.Equal(ExitCodeConstants.Success, exitCode);
+        Assert.Equal(CliExitCodes.Success, exitCode);
         Assert.NotNull(capturedArgs);
         Assert.DoesNotContain(capturedArgs, arg => arg.Contains("ASPIRE_DASHBOARD_UNSECURED_ALLOW_ANONYMOUS"));
     }
@@ -167,7 +167,7 @@ public class DashboardRunCommandTests(ITestOutputHelper outputHelper)
 
         var exitCode = await result.InvokeAsync().DefaultTimeout();
 
-        Assert.Equal(ExitCodeConstants.Success, exitCode);
+        Assert.Equal(CliExitCodes.Success, exitCode);
         Assert.NotNull(capturedArgs);
         Assert.Collection(capturedArgs,
             arg => Assert.Equal("dashboard", arg),
@@ -197,7 +197,7 @@ public class DashboardRunCommandTests(ITestOutputHelper outputHelper)
 
         var exitCode = await result.InvokeAsync().DefaultTimeout();
 
-        Assert.Equal(ExitCodeConstants.Success, exitCode);
+        Assert.Equal(CliExitCodes.Success, exitCode);
         Assert.NotNull(capturedArgs);
         Assert.Contains(expectedArg, capturedArgs);
     }
@@ -217,7 +217,7 @@ public class DashboardRunCommandTests(ITestOutputHelper outputHelper)
 
         var exitCode = await result.InvokeAsync().DefaultTimeout();
 
-        Assert.Equal(ExitCodeConstants.Success, exitCode);
+        Assert.Equal(CliExitCodes.Success, exitCode);
         Assert.NotNull(capturedEnv);
         Assert.True(capturedEnv.ContainsKey("DASHBOARD__FRONTEND__BROWSERTOKEN"));
         Assert.False(string.IsNullOrEmpty(capturedEnv["DASHBOARD__FRONTEND__BROWSERTOKEN"]));
@@ -241,7 +241,7 @@ public class DashboardRunCommandTests(ITestOutputHelper outputHelper)
 
         var exitCode = await result.InvokeAsync().DefaultTimeout();
 
-        Assert.Equal(ExitCodeConstants.Success, exitCode);
+        Assert.Equal(CliExitCodes.Success, exitCode);
         Assert.NotNull(capturedArgs);
         Assert.Collection(capturedArgs,
             arg => Assert.Equal("dashboard", arg),
@@ -267,7 +267,7 @@ public class DashboardRunCommandTests(ITestOutputHelper outputHelper)
 
         var exitCode = await result.InvokeAsync().DefaultTimeout();
 
-        Assert.Equal(ExitCodeConstants.Success, exitCode);
+        Assert.Equal(CliExitCodes.Success, exitCode);
         Assert.NotNull(capturedArgs);
         Assert.Collection(capturedArgs,
             arg => Assert.Equal("dashboard", arg),
@@ -294,7 +294,7 @@ public class DashboardRunCommandTests(ITestOutputHelper outputHelper)
 
         var exitCode = await result.InvokeAsync().DefaultTimeout();
 
-        Assert.Equal(ExitCodeConstants.DashboardFailure, exitCode);
+        Assert.Equal(CliExitCodes.DashboardFailure, exitCode);
     }
 
     [Fact]
@@ -325,7 +325,7 @@ public class DashboardRunCommandTests(ITestOutputHelper outputHelper)
 
         var exitCode = await result.InvokeAsync().DefaultTimeout();
 
-        Assert.Equal(ExitCodeConstants.DashboardFailure, exitCode);
+        Assert.Equal(CliExitCodes.DashboardFailure, exitCode);
         var errorMessage = Assert.Single(testInteractionService.DisplayedErrors);
         var expectedMessage = string.Format(CultureInfo.CurrentCulture, DashboardCommandStrings.DashboardFailedToStart, $"Failed to start process: {managedPath}");
         Assert.Equal(expectedMessage, errorMessage);
@@ -363,7 +363,7 @@ public class DashboardRunCommandTests(ITestOutputHelper outputHelper)
 
         var exitCode = await pendingRun.DefaultTimeout();
 
-        Assert.Equal(ExitCodeConstants.Success, exitCode);
+        Assert.Equal(CliExitCodes.Success, exitCode);
         Assert.Equal(1, testInteractionService.DisplayCancellationMessageCount);
     }
 

--- a/tests/Aspire.Cli.Tests/Commands/DeployCommandTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/DeployCommandTests.cs
@@ -59,7 +59,7 @@ public class DeployCommandTests(ITestOutputHelper outputHelper)
         var exitCode = await result.InvokeAsync().DefaultTimeout();
 
         // Assert
-        Assert.Equal(ExitCodeConstants.FailedToFindProject, exitCode); // Ensure the command fails
+        Assert.Equal(CliExitCodes.FailedToFindProject, exitCode); // Ensure the command fails
     }
 
     [Fact]
@@ -93,7 +93,7 @@ public class DeployCommandTests(ITestOutputHelper outputHelper)
         var exitCode = await result.InvokeAsync().DefaultTimeout();
 
         // Assert
-        Assert.Equal(ExitCodeConstants.AppHostIncompatible, exitCode); // Ensure the command fails
+        Assert.Equal(CliExitCodes.AppHostIncompatible, exitCode); // Ensure the command fails
     }
 
     [Fact]
@@ -127,7 +127,7 @@ public class DeployCommandTests(ITestOutputHelper outputHelper)
         var exitCode = await result.InvokeAsync().DefaultTimeout();
 
         // Assert
-        Assert.Equal(ExitCodeConstants.FailedToBuildArtifacts, exitCode); // Ensure the command fails
+        Assert.Equal(CliExitCodes.FailedToBuildArtifacts, exitCode); // Ensure the command fails
     }
 
     [Fact]
@@ -395,7 +395,7 @@ public class DeployCommandTests(ITestOutputHelper outputHelper)
         var exitCode = await result.InvokeAsync().DefaultTimeout();
 
         // Assert
-        Assert.Equal(ExitCodeConstants.FailedToBuildArtifacts, exitCode); // Ensure the command returns a non-zero exit code
+        Assert.Equal(CliExitCodes.FailedToBuildArtifacts, exitCode); // Ensure the command returns a non-zero exit code
 
         static async IAsyncEnumerable<PublishingActivity> GetFailedDeploymentActivities([EnumeratorCancellation] CancellationToken cancellationToken)
         {

--- a/tests/Aspire.Cli.Tests/Commands/DescribeCommandTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/DescribeCommandTests.cs
@@ -27,7 +27,7 @@ public class DescribeCommandTests(ITestOutputHelper outputHelper)
         var result = command.Parse("describe --help");
         var exitCode = await result.InvokeAsync().DefaultTimeout();
 
-        Assert.Equal(ExitCodeConstants.Success, exitCode);
+        Assert.Equal(CliExitCodes.Success, exitCode);
     }
 
     [Fact]
@@ -43,7 +43,7 @@ public class DescribeCommandTests(ITestOutputHelper outputHelper)
         var exitCode = await result.InvokeAsync().DefaultTimeout();
 
         // Should succeed - no running AppHost is not an error (like Unix ps with no processes)
-        Assert.Equal(ExitCodeConstants.Success, exitCode);
+        Assert.Equal(CliExitCodes.Success, exitCode);
     }
 
     [Theory]
@@ -61,7 +61,7 @@ public class DescribeCommandTests(ITestOutputHelper outputHelper)
 
         var exitCode = await result.InvokeAsync().DefaultTimeout();
 
-        Assert.Equal(ExitCodeConstants.Success, exitCode);
+        Assert.Equal(CliExitCodes.Success, exitCode);
     }
 
     [Theory]
@@ -79,7 +79,7 @@ public class DescribeCommandTests(ITestOutputHelper outputHelper)
 
         var exitCode = await result.InvokeAsync().DefaultTimeout();
 
-        Assert.Equal(ExitCodeConstants.Success, exitCode);
+        Assert.Equal(CliExitCodes.Success, exitCode);
     }
 
     [Fact]
@@ -94,7 +94,7 @@ public class DescribeCommandTests(ITestOutputHelper outputHelper)
 
         var exitCode = await result.InvokeAsync().DefaultTimeout();
 
-        Assert.NotEqual(ExitCodeConstants.Success, exitCode);
+        Assert.NotEqual(CliExitCodes.Success, exitCode);
     }
 
     [Fact]
@@ -109,7 +109,7 @@ public class DescribeCommandTests(ITestOutputHelper outputHelper)
 
         var exitCode = await result.InvokeAsync().DefaultTimeout();
 
-        Assert.Equal(ExitCodeConstants.Success, exitCode);
+        Assert.Equal(CliExitCodes.Success, exitCode);
     }
 
     [Fact]
@@ -124,7 +124,7 @@ public class DescribeCommandTests(ITestOutputHelper outputHelper)
 
         var exitCode = await result.InvokeAsync().DefaultTimeout();
 
-        Assert.Equal(ExitCodeConstants.Success, exitCode);
+        Assert.Equal(CliExitCodes.Success, exitCode);
     }
 
     [Fact]
@@ -139,7 +139,7 @@ public class DescribeCommandTests(ITestOutputHelper outputHelper)
 
         var exitCode = await result.InvokeAsync().DefaultTimeout();
 
-        Assert.Equal(ExitCodeConstants.Success, exitCode);
+        Assert.Equal(CliExitCodes.Success, exitCode);
     }
 
     [Fact]
@@ -154,7 +154,7 @@ public class DescribeCommandTests(ITestOutputHelper outputHelper)
 
         var exitCode = await result.InvokeAsync().DefaultTimeout();
 
-        Assert.Equal(ExitCodeConstants.Success, exitCode);
+        Assert.Equal(CliExitCodes.Success, exitCode);
     }
 
     [Fact]
@@ -169,7 +169,7 @@ public class DescribeCommandTests(ITestOutputHelper outputHelper)
 
         var exitCode = await result.InvokeAsync().DefaultTimeout();
 
-        Assert.Equal(ExitCodeConstants.Success, exitCode);
+        Assert.Equal(CliExitCodes.Success, exitCode);
     }
 
     [Fact]
@@ -184,7 +184,7 @@ public class DescribeCommandTests(ITestOutputHelper outputHelper)
 
         var exitCode = await result.InvokeAsync().DefaultTimeout();
 
-        Assert.Equal(ExitCodeConstants.Success, exitCode);
+        Assert.Equal(CliExitCodes.Success, exitCode);
     }
 
     [Fact]
@@ -275,7 +275,7 @@ public class DescribeCommandTests(ITestOutputHelper outputHelper)
 
         var exitCode = await result.InvokeAsync().DefaultTimeout();
 
-        Assert.Equal(ExitCodeConstants.Success, exitCode);
+        Assert.Equal(CliExitCodes.Success, exitCode);
 
         // Parse all JSON lines from output
         var jsonLines = outputWriter.Logs
@@ -319,7 +319,7 @@ public class DescribeCommandTests(ITestOutputHelper outputHelper)
 
         var exitCode = await result.InvokeAsync().DefaultTimeout();
 
-        Assert.Equal(ExitCodeConstants.Success, exitCode);
+        Assert.Equal(CliExitCodes.Success, exitCode);
 
         // Filter to lines containing the resource name indicator
         var resourceLines = outputWriter.Logs
@@ -352,7 +352,7 @@ public class DescribeCommandTests(ITestOutputHelper outputHelper)
 
         var exitCode = await result.InvokeAsync().DefaultTimeout();
 
-        Assert.Equal(ExitCodeConstants.Success, exitCode);
+        Assert.Equal(CliExitCodes.Success, exitCode);
 
         var jsonLines = outputWriter.Logs
             .Where(l => l.TrimStart().StartsWith("{", StringComparison.Ordinal))
@@ -382,7 +382,7 @@ public class DescribeCommandTests(ITestOutputHelper outputHelper)
 
         var exitCode = await result.InvokeAsync().DefaultTimeout();
 
-        Assert.Equal(ExitCodeConstants.Success, exitCode);
+        Assert.Equal(CliExitCodes.Success, exitCode);
         Assert.Single(outputWriter.Logs, l => l.TrimStart().StartsWith("{", StringComparison.Ordinal));
         Assert.Contains(InteractionServiceStrings.AppHostShutDown, errorWriter.ToString(), StringComparison.Ordinal);
     }
@@ -411,7 +411,7 @@ public class DescribeCommandTests(ITestOutputHelper outputHelper)
 
         var exitCode = await pendingRun.DefaultTimeout();
 
-        Assert.Equal(ExitCodeConstants.Success, exitCode);
+        Assert.Equal(CliExitCodes.Success, exitCode);
         Assert.DoesNotContain(InteractionServiceStrings.AppHostConnectionLostGeneric, errorWriter.ToString(), StringComparison.Ordinal);
         Assert.DoesNotContain(InteractionServiceStrings.AppHostShutDown, errorWriter.ToString(), StringComparison.Ordinal);
     }
@@ -433,7 +433,7 @@ public class DescribeCommandTests(ITestOutputHelper outputHelper)
 
         var exitCode = await result.InvokeAsync().DefaultTimeout();
 
-        Assert.Equal(ExitCodeConstants.Success, exitCode);
+        Assert.Equal(CliExitCodes.Success, exitCode);
 
         var jsonOutput = string.Join("", outputWriter.Logs);
         var deserialized = JsonSerializer.Deserialize(jsonOutput, ResourcesCommandJsonContext.RelaxedEscaping.ResourcesOutput);
@@ -461,7 +461,7 @@ public class DescribeCommandTests(ITestOutputHelper outputHelper)
 
         var exitCode = await result.InvokeAsync().DefaultTimeout();
 
-        Assert.Equal(ExitCodeConstants.Success, exitCode);
+        Assert.Equal(CliExitCodes.Success, exitCode);
 
         var jsonLines = outputWriter.Logs
             .Where(l => l.TrimStart().StartsWith("{", StringComparison.Ordinal))
@@ -491,7 +491,7 @@ public class DescribeCommandTests(ITestOutputHelper outputHelper)
 
         var exitCode = await result.InvokeAsync().DefaultTimeout();
 
-        Assert.Equal(ExitCodeConstants.Success, exitCode);
+        Assert.Equal(CliExitCodes.Success, exitCode);
 
         var jsonOutput = string.Join("", outputWriter.Logs);
         var deserialized = JsonSerializer.Deserialize(jsonOutput, ResourcesCommandJsonContext.RelaxedEscaping.ResourcesOutput);
@@ -517,7 +517,7 @@ public class DescribeCommandTests(ITestOutputHelper outputHelper)
 
         var exitCode = await result.InvokeAsync().DefaultTimeout();
 
-        Assert.Equal(ExitCodeConstants.Success, exitCode);
+        Assert.Equal(CliExitCodes.Success, exitCode);
 
         var jsonOutput = string.Join("", outputWriter.Logs);
         var deserialized = JsonSerializer.Deserialize(jsonOutput, ResourcesCommandJsonContext.RelaxedEscaping.ResourcesOutput);
@@ -544,7 +544,7 @@ public class DescribeCommandTests(ITestOutputHelper outputHelper)
 
         var exitCode = await result.InvokeAsync().DefaultTimeout();
 
-        Assert.Equal(ExitCodeConstants.Success, exitCode);
+        Assert.Equal(CliExitCodes.Success, exitCode);
 
         var jsonOutput = string.Join("", outputWriter.Logs);
         var deserialized = JsonSerializer.Deserialize(jsonOutput, ResourcesCommandJsonContext.RelaxedEscaping.ResourcesOutput);
@@ -569,7 +569,7 @@ public class DescribeCommandTests(ITestOutputHelper outputHelper)
 
         var exitCode = await result.InvokeAsync().DefaultTimeout();
 
-        Assert.Equal(ExitCodeConstants.Success, exitCode);
+        Assert.Equal(CliExitCodes.Success, exitCode);
 
         var jsonLines = outputWriter.Logs
             .Where(l => l.TrimStart().StartsWith("{", StringComparison.Ordinal))
@@ -597,7 +597,7 @@ public class DescribeCommandTests(ITestOutputHelper outputHelper)
 
         var exitCode = await result.InvokeAsync().DefaultTimeout();
 
-        Assert.Equal(ExitCodeConstants.Success, exitCode);
+        Assert.Equal(CliExitCodes.Success, exitCode);
 
         var jsonLines = outputWriter.Logs
             .Where(l => l.TrimStart().StartsWith("{", StringComparison.Ordinal))

--- a/tests/Aspire.Cli.Tests/Commands/DestroyCommandTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/DestroyCommandTests.cs
@@ -57,7 +57,7 @@ public class DestroyCommandTests(ITestOutputHelper outputHelper)
         var result = command.Parse("destroy --apphost invalid.csproj");
         var exitCode = await result.InvokeAsync().DefaultTimeout();
 
-        Assert.Equal(ExitCodeConstants.FailedToFindProject, exitCode);
+        Assert.Equal(CliExitCodes.FailedToFindProject, exitCode);
     }
 
     [Fact]
@@ -152,7 +152,7 @@ public class DestroyCommandTests(ITestOutputHelper outputHelper)
         var result = command.Parse(commandLine);
         var exitCode = await result.InvokeAsync().DefaultTimeout();
 
-        Assert.Equal(ExitCodeConstants.InvalidCommand, exitCode);
+        Assert.Equal(CliExitCodes.InvalidCommand, exitCode);
         var error = Assert.Single(result.Errors);
         Assert.Equal(string.Format(System.Globalization.CultureInfo.CurrentCulture, SharedCommandStrings.NonInteractiveRequiresYesFormat, "destroy"), error.Message);
         Assert.False(appHostStarted);
@@ -326,7 +326,7 @@ public class DestroyCommandTests(ITestOutputHelper outputHelper)
         var result = command.Parse("destroy --yes");
         var exitCode = await result.InvokeAsync().DefaultTimeout();
 
-        Assert.Equal(ExitCodeConstants.FailedToBuildArtifacts, exitCode);
+        Assert.Equal(CliExitCodes.FailedToBuildArtifacts, exitCode);
 
         static async IAsyncEnumerable<PublishingActivity> GetFailedDestroyActivities([EnumeratorCancellation] CancellationToken cancellationToken)
         {

--- a/tests/Aspire.Cli.Tests/Commands/DoCommandTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/DoCommandTests.cs
@@ -279,7 +279,7 @@ public class DoCommandTests(ITestOutputHelper outputHelper)
         var exitCode = await result.InvokeAsync().DefaultTimeout();
 
         // Assert
-        Assert.Equal(ExitCodeConstants.FailedToFindProject, exitCode);
+        Assert.Equal(CliExitCodes.FailedToFindProject, exitCode);
     }
 
     [Fact]

--- a/tests/Aspire.Cli.Tests/Commands/DocsCommandTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/DocsCommandTests.cs
@@ -25,7 +25,7 @@ public class DocsCommandTests(ITestOutputHelper outputHelper)
 
         var exitCode = await result.InvokeAsync().DefaultTimeout();
         // Returns InvalidCommand exit code when no subcommand is provided (shows help)
-        Assert.Equal(ExitCodeConstants.InvalidCommand, exitCode);
+        Assert.Equal(CliExitCodes.InvalidCommand, exitCode);
     }
 
     [Fact]

--- a/tests/Aspire.Cli.Tests/Commands/DoctorCommandTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/DoctorCommandTests.cs
@@ -29,7 +29,7 @@ public class DoctorCommandTests(ITestOutputHelper outputHelper)
         var exitCode = await result.InvokeAsync().DefaultTimeout();
         
         // Help should return success
-        Assert.Equal(ExitCodeConstants.Success, exitCode);
+        Assert.Equal(CliExitCodes.Success, exitCode);
     }
 
     [Fact]
@@ -53,7 +53,7 @@ public class DoctorCommandTests(ITestOutputHelper outputHelper)
 
         var exitCode = await result.InvokeAsync().DefaultTimeout();
 
-        Assert.Equal(ExitCodeConstants.Success, exitCode);
+        Assert.Equal(CliExitCodes.Success, exitCode);
 
         var (json, console) = Assert.Single(interactionService.DisplayedRawText);
         Assert.Equal(ConsoleOutput.Standard, console);
@@ -95,7 +95,7 @@ public class DoctorCommandTests(ITestOutputHelper outputHelper)
 
         var exitCode = await result.InvokeAsync().DefaultTimeout();
 
-        Assert.Equal(ExitCodeConstants.Success, exitCode);
+        Assert.Equal(CliExitCodes.Success, exitCode);
 
         var (json, _) = Assert.Single(interactionService.DisplayedRawText);
         using var document = JsonDocument.Parse(json);
@@ -155,7 +155,7 @@ public class DoctorCommandTests(ITestOutputHelper outputHelper)
 
         var exitCode = await result.InvokeAsync().DefaultTimeout();
 
-        Assert.Equal(ExitCodeConstants.Success, exitCode);
+        Assert.Equal(CliExitCodes.Success, exitCode);
         Assert.False(runnerCalled);
 
         var (json, _) = Assert.Single(interactionService.DisplayedRawText);
@@ -201,7 +201,7 @@ public class DoctorCommandTests(ITestOutputHelper outputHelper)
 
         var exitCode = await result.InvokeAsync().DefaultTimeout();
 
-        Assert.Equal(ExitCodeConstants.Success, exitCode);
+        Assert.Equal(CliExitCodes.Success, exitCode);
         Assert.False(versionLookupCalled);
 
         var (json, _) = Assert.Single(interactionService.DisplayedRawText);
@@ -240,7 +240,7 @@ public class DoctorCommandTests(ITestOutputHelper outputHelper)
 
         var exitCode = await result.InvokeAsync().DefaultTimeout();
 
-        Assert.Equal(ExitCodeConstants.Success, exitCode);
+        Assert.Equal(CliExitCodes.Success, exitCode);
         Assert.False(versionLookupCalled);
 
         var (json, _) = Assert.Single(interactionService.DisplayedRawText);
@@ -278,7 +278,7 @@ public class DoctorCommandTests(ITestOutputHelper outputHelper)
 
         var exitCode = await result.InvokeAsync().DefaultTimeout();
 
-        Assert.Equal(ExitCodeConstants.Success, exitCode);
+        Assert.Equal(CliExitCodes.Success, exitCode);
 
         var (json, _) = Assert.Single(interactionService.DisplayedRawText);
         using var document = JsonDocument.Parse(json);
@@ -315,7 +315,7 @@ public class DoctorCommandTests(ITestOutputHelper outputHelper)
 
         var exitCode = await result.InvokeAsync().DefaultTimeout();
 
-        Assert.Equal(ExitCodeConstants.Success, exitCode);
+        Assert.Equal(CliExitCodes.Success, exitCode);
         Assert.False(versionLookupCalled);
 
         var (json, _) = Assert.Single(interactionService.DisplayedRawText);
@@ -351,7 +351,7 @@ public class DoctorCommandTests(ITestOutputHelper outputHelper)
 
         var exitCode = await result.InvokeAsync().DefaultTimeout();
 
-        Assert.Equal(ExitCodeConstants.Success, exitCode);
+        Assert.Equal(CliExitCodes.Success, exitCode);
 
         var (json, _) = Assert.Single(interactionService.DisplayedRawText);
         using var document = JsonDocument.Parse(json);
@@ -390,7 +390,7 @@ public class DoctorCommandTests(ITestOutputHelper outputHelper)
 
         var exitCode = await result.InvokeAsync().DefaultTimeout();
 
-        Assert.Equal(ExitCodeConstants.Success, exitCode);
+        Assert.Equal(CliExitCodes.Success, exitCode);
 
         var (json, _) = Assert.Single(interactionService.DisplayedRawText);
         using var document = JsonDocument.Parse(json);
@@ -437,7 +437,7 @@ public class DoctorCommandTests(ITestOutputHelper outputHelper)
 
         var exitCode = await result.InvokeAsync().DefaultTimeout();
 
-        Assert.Equal(ExitCodeConstants.Success, exitCode);
+        Assert.Equal(CliExitCodes.Success, exitCode);
 
         var (json, _) = Assert.Single(interactionService.DisplayedRawText);
         using var document = JsonDocument.Parse(json);

--- a/tests/Aspire.Cli.Tests/Commands/ExportCommandTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/ExportCommandTests.cs
@@ -62,7 +62,7 @@ public class ExportCommandTests(ITestOutputHelper outputHelper)
 
         var exitCode = await result.InvokeAsync().DefaultTimeout();
 
-        Assert.Equal(ExitCodeConstants.Success, exitCode);
+        Assert.Equal(CliExitCodes.Success, exitCode);
         Assert.True(File.Exists(outputPath), "Export zip file should be created");
 
         using var archive = ZipFile.OpenRead(outputPath);
@@ -133,7 +133,7 @@ public class ExportCommandTests(ITestOutputHelper outputHelper)
 
         var exitCode = await result.InvokeAsync().DefaultTimeout();
 
-        Assert.Equal(ExitCodeConstants.Success, exitCode);
+        Assert.Equal(CliExitCodes.Success, exitCode);
         Assert.True(File.Exists(outputPath), $"Export zip file should be created at the specified path: {outputPath}");
         Assert.True(Directory.Exists(customDir), "Nested output directory should be created automatically");
     }
@@ -168,7 +168,7 @@ public class ExportCommandTests(ITestOutputHelper outputHelper)
 
         // The command succeeds but displays "not found" because there is no
         // socket file for the specified apphost.
-        Assert.Equal(ExitCodeConstants.Success, exitCode);
+        Assert.Equal(CliExitCodes.Success, exitCode);
         Assert.False(File.Exists(outputPath), "No zip should be created when the AppHost is not running");
     }
 
@@ -281,7 +281,7 @@ public class ExportCommandTests(ITestOutputHelper outputHelper)
 
         var exitCode = await result.InvokeAsync().DefaultTimeout();
 
-        Assert.Equal(ExitCodeConstants.Success, exitCode);
+        Assert.Equal(CliExitCodes.Success, exitCode);
         Assert.True(File.Exists(outputPath), "Export zip file should be created");
 
         using var archive = ZipFile.OpenRead(outputPath);
@@ -343,7 +343,7 @@ public class ExportCommandTests(ITestOutputHelper outputHelper)
 
         var exitCode = await result.InvokeAsync().DefaultTimeout();
 
-        Assert.Equal(ExitCodeConstants.Success, exitCode);
+        Assert.Equal(CliExitCodes.Success, exitCode);
         Assert.True(File.Exists(outputPath), "Export zip file should be created");
 
         using var archive = ZipFile.OpenRead(outputPath);
@@ -461,7 +461,7 @@ public class ExportCommandTests(ITestOutputHelper outputHelper)
 
         var exitCode = await result.InvokeAsync().DefaultTimeout();
 
-        Assert.Equal(ExitCodeConstants.Success, exitCode);
+        Assert.Equal(CliExitCodes.Success, exitCode);
         Assert.True(File.Exists(outputPath), "Export zip file should be created");
 
         using var archive = ZipFile.OpenRead(outputPath);
@@ -519,7 +519,7 @@ public class ExportCommandTests(ITestOutputHelper outputHelper)
 
         var exitCode = await result.InvokeAsync().DefaultTimeout();
 
-        Assert.Equal(ExitCodeConstants.Success, exitCode);
+        Assert.Equal(CliExitCodes.Success, exitCode);
         Assert.True(File.Exists(outputPath), "Export zip file should be created");
 
         using var archive = ZipFile.OpenRead(outputPath);
@@ -579,7 +579,7 @@ public class ExportCommandTests(ITestOutputHelper outputHelper)
 
         var exitCode = await result.InvokeAsync().DefaultTimeout();
 
-        Assert.Equal(ExitCodeConstants.Success, exitCode);
+        Assert.Equal(CliExitCodes.Success, exitCode);
         Assert.True(File.Exists(outputPath), "Export zip file should be created");
 
         using var archive = ZipFile.OpenRead(outputPath);
@@ -629,7 +629,7 @@ public class ExportCommandTests(ITestOutputHelper outputHelper)
 
         var exitCode = await result.InvokeAsync().DefaultTimeout();
 
-        Assert.Equal(ExitCodeConstants.Success, exitCode);
+        Assert.Equal(CliExitCodes.Success, exitCode);
         Assert.True(File.Exists(outputPath));
 
         using var archive = ZipFile.OpenRead(outputPath);
@@ -671,7 +671,7 @@ public class ExportCommandTests(ITestOutputHelper outputHelper)
 
         var exitCode = await result.InvokeAsync().DefaultTimeout();
 
-        Assert.Equal(ExitCodeConstants.Success, exitCode);
+        Assert.Equal(CliExitCodes.Success, exitCode);
         Assert.True(File.Exists(outputPath));
 
         using var archive = ZipFile.OpenRead(outputPath);
@@ -715,7 +715,7 @@ public class ExportCommandTests(ITestOutputHelper outputHelper)
 
         var exitCode = await result.InvokeAsync().DefaultTimeout();
 
-        Assert.Equal(ExitCodeConstants.Success, exitCode);
+        Assert.Equal(CliExitCodes.Success, exitCode);
         Assert.True(File.Exists(outputPath));
 
         using var archive = ZipFile.OpenRead(outputPath);
@@ -751,7 +751,7 @@ public class ExportCommandTests(ITestOutputHelper outputHelper)
 
         var exitCode = await result.InvokeAsync().DefaultTimeout();
 
-        Assert.Equal(ExitCodeConstants.InvalidCommand, exitCode);
+        Assert.Equal(CliExitCodes.InvalidCommand, exitCode);
         Assert.False(File.Exists(outputPath), "No zip should be created when the resource doesn't exist");
     }
 
@@ -790,7 +790,7 @@ public class ExportCommandTests(ITestOutputHelper outputHelper)
 
         var exitCode = await result.InvokeAsync().DefaultTimeout();
 
-        Assert.Equal(ExitCodeConstants.Success, exitCode);
+        Assert.Equal(CliExitCodes.Success, exitCode);
         Assert.True(File.Exists(outputPath), "Export zip file should be created");
 
         using var archive = ZipFile.OpenRead(outputPath);
@@ -837,7 +837,7 @@ public class ExportCommandTests(ITestOutputHelper outputHelper)
 
         var exitCode = await result.InvokeAsync().DefaultTimeout();
 
-        Assert.Equal(ExitCodeConstants.Success, exitCode);
+        Assert.Equal(CliExitCodes.Success, exitCode);
         Assert.True(File.Exists(outputPath), "Export zip file should be created even without dashboard");
 
         using var archive = ZipFile.OpenRead(outputPath);

--- a/tests/Aspire.Cli.Tests/Commands/ExtensionInternalCommandTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/ExtensionInternalCommandTests.cs
@@ -50,7 +50,7 @@ public class ExtensionInternalCommandTests(ITestOutputHelper outputHelper)
         var result = command.Parse("extension");
 
         var exitCode = await result.InvokeAsync().DefaultTimeout();
-        Assert.Equal(ExitCodeConstants.Success, exitCode);
+        Assert.Equal(CliExitCodes.Success, exitCode);
     }
 
     [Fact]
@@ -71,7 +71,7 @@ public class ExtensionInternalCommandTests(ITestOutputHelper outputHelper)
         var result = command.Parse("extension get-apphosts");
 
         var exitCode = await result.InvokeAsync().DefaultTimeout();
-        Assert.Equal(ExitCodeConstants.Success, exitCode);
+        Assert.Equal(CliExitCodes.Success, exitCode);
 
         // Join all captured output and deserialize
         var allOutput = string.Join(string.Empty, capturedOutput.Logs);
@@ -113,7 +113,7 @@ public class ExtensionInternalCommandTests(ITestOutputHelper outputHelper)
         var result = command.Parse("extension get-apphosts");
 
         var exitCode = await result.InvokeAsync().DefaultTimeout();
-        Assert.Equal(ExitCodeConstants.Success, exitCode);
+        Assert.Equal(CliExitCodes.Success, exitCode);
 
         // Join all captured output and deserialize
         var allOutput = string.Join(string.Empty, capturedOutput.Logs);
@@ -152,7 +152,7 @@ public class ExtensionInternalCommandTests(ITestOutputHelper outputHelper)
         var result = command.Parse("extension get-apphosts");
 
         var exitCode = await result.InvokeAsync().DefaultTimeout();
-        Assert.Equal(ExitCodeConstants.FailedToFindProject, exitCode);
+        Assert.Equal(CliExitCodes.FailedToFindProject, exitCode);
     }
 
     [Fact]
@@ -170,7 +170,7 @@ public class ExtensionInternalCommandTests(ITestOutputHelper outputHelper)
         var result = command.Parse("extension get-apphosts");
 
         var exitCode = await result.InvokeAsync().DefaultTimeout();
-        Assert.Equal(ExitCodeConstants.FailedToFindProject, exitCode);
+        Assert.Equal(CliExitCodes.FailedToFindProject, exitCode);
     }
 
     [Fact]

--- a/tests/Aspire.Cli.Tests/Commands/InitCommandTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/InitCommandTests.cs
@@ -100,7 +100,7 @@ public class InitCommandTests(ITestOutputHelper outputHelper)
         var parseResult = initCommand.Parse("init");
         var exitCode = await parseResult.InvokeAsync().DefaultTimeout();
 
-        Assert.Equal(ExitCodeConstants.Success, exitCode);
+        Assert.Equal(CliExitCodes.Success, exitCode);
         Assert.Equal("aspire-apphost", capturedTemplateName);
         Assert.Equal("Test.AppHost", capturedName);
         Assert.Contains("Test.AppHost", capturedOutputPath);
@@ -143,7 +143,7 @@ public class InitCommandTests(ITestOutputHelper outputHelper)
         var parseResult = initCommand.Parse("init");
         var exitCode = await parseResult.InvokeAsync().DefaultTimeout();
 
-        Assert.Equal(ExitCodeConstants.Success, exitCode);
+        Assert.Equal(CliExitCodes.Success, exitCode);
         Assert.Equal("aspire-apphost", capturedTemplateName);
         Assert.False(File.Exists(Path.Combine(workspace.WorkspaceRoot.FullName, "aspire.config.json")));
     }
@@ -160,7 +160,7 @@ public class InitCommandTests(ITestOutputHelper outputHelper)
         var parseResult = initCommand.Parse("init");
         var exitCode = await parseResult.InvokeAsync().DefaultTimeout();
 
-        Assert.Equal(ExitCodeConstants.Success, exitCode);
+        Assert.Equal(CliExitCodes.Success, exitCode);
         Assert.True(File.Exists(Path.Combine(workspace.WorkspaceRoot.FullName, "apphost.cs")));
 
         var config = JsonNode.Parse(File.ReadAllText(Path.Combine(workspace.WorkspaceRoot.FullName, "aspire.config.json")))!.AsObject();
@@ -186,7 +186,7 @@ public class InitCommandTests(ITestOutputHelper outputHelper)
         var parseResult = initCommand.Parse("init");
         var exitCode = await parseResult.InvokeAsync().DefaultTimeout();
 
-        Assert.Equal(ExitCodeConstants.Success, exitCode);
+        Assert.Equal(CliExitCodes.Success, exitCode);
 
         var runJsonPath = Path.Combine(workspace.WorkspaceRoot.FullName, "apphost.run.json");
         Assert.True(File.Exists(runJsonPath), "apphost.run.json should be created so `dotnet run apphost.cs` works.");
@@ -267,7 +267,7 @@ public class InitCommandTests(ITestOutputHelper outputHelper)
         var parseResult = initCommand.Parse("init");
         var exitCode = await parseResult.InvokeAsync().DefaultTimeout();
 
-        Assert.Equal(ExitCodeConstants.Success, exitCode);
+        Assert.Equal(CliExitCodes.Success, exitCode);
 
         var runJson = JsonNode.Parse(File.ReadAllText(Path.Combine(workspace.WorkspaceRoot.FullName, "apphost.run.json")))!.AsObject();
         var profiles = runJson["profiles"]!.AsObject();
@@ -318,7 +318,7 @@ public class InitCommandTests(ITestOutputHelper outputHelper)
         var parseResult = initCommand.Parse("init");
         var exitCode = await parseResult.InvokeAsync().DefaultTimeout();
 
-        Assert.Equal(ExitCodeConstants.Success, exitCode);
+        Assert.Equal(CliExitCodes.Success, exitCode);
 
         // The user's customizations must be preserved verbatim — only the appHost.path
         // is allowed to be touched (since that's the primary purpose of DropAspireConfig).
@@ -356,7 +356,7 @@ public class InitCommandTests(ITestOutputHelper outputHelper)
         var parseResult = initCommand.Parse("init --source https://example.test/v3/index.json --version 13.0.0 --channel daily --suppress-agent-init");
         var exitCode = await parseResult.InvokeAsync().DefaultTimeout();
 
-        Assert.Equal(ExitCodeConstants.Success, exitCode);
+        Assert.Equal(CliExitCodes.Success, exitCode);
         Assert.True(File.Exists(Path.Combine(workspace.WorkspaceRoot.FullName, "apphost.cs")));
         Assert.Contains(interactionService.DisplayedMessages, m => m.Message.Contains("`aspire init --source` is deprecated", StringComparison.Ordinal));
         Assert.Contains(interactionService.DisplayedMessages, m => m.Message.Contains("`aspire init --version` is deprecated", StringComparison.Ordinal));
@@ -391,7 +391,7 @@ public class InitCommandTests(ITestOutputHelper outputHelper)
         var parseResult = initCommand.Parse("init");
         var exitCode = await parseResult.InvokeAsync().DefaultTimeout();
 
-        Assert.Equal(ExitCodeConstants.Success, exitCode);
+        Assert.Equal(CliExitCodes.Success, exitCode);
         Assert.True(File.Exists(Path.Combine(workspace.WorkspaceRoot.FullName, "apphost.ts")));
 
         var config = JsonNode.Parse(File.ReadAllText(Path.Combine(workspace.WorkspaceRoot.FullName, "aspire.config.json")))!.AsObject();
@@ -437,7 +437,7 @@ public class InitCommandTests(ITestOutputHelper outputHelper)
         var parseResult = initCommand.Parse("init --language typescript");
         var exitCode = await parseResult.InvokeAsync().DefaultTimeout();
 
-        Assert.Equal(ExitCodeConstants.Success, exitCode);
+        Assert.Equal(CliExitCodes.Success, exitCode);
         Assert.Contains(interactionService.DisplayedMessages, m => m.Message == "Aspire AppHost created! To complete setup, run one of:");
         Assert.DoesNotContain(subtleMessages, m => m.Contains("copilot", StringComparison.OrdinalIgnoreCase));
         Assert.Contains("  claude \"run the aspireify skill\"", subtleMessages);
@@ -481,7 +481,7 @@ public class InitCommandTests(ITestOutputHelper outputHelper)
         var parseResult = initCommand.Parse("init --language typescript");
         var exitCode = await parseResult.InvokeAsync().DefaultTimeout();
 
-        Assert.Equal(ExitCodeConstants.Success, exitCode);
+        Assert.Equal(CliExitCodes.Success, exitCode);
         Assert.DoesNotContain(interactionService.DisplayedMessages, m => m.Message.Contains("To complete setup", StringComparison.Ordinal));
         Assert.DoesNotContain(subtleMessages, m => m.Contains("run the aspireify skill", StringComparison.Ordinal));
     }
@@ -498,7 +498,7 @@ public class InitCommandTests(ITestOutputHelper outputHelper)
         var parseResult = initCommand.Parse("init");
         var exitCode = await parseResult.InvokeAsync().DefaultTimeout();
 
-        Assert.Equal(ExitCodeConstants.Success, exitCode);
+        Assert.Equal(CliExitCodes.Success, exitCode);
 
         var appHostPath = Path.Combine(workspace.WorkspaceRoot.FullName, "apphost.cs");
         var appHostContent = await File.ReadAllTextAsync(appHostPath);
@@ -532,7 +532,7 @@ public class InitCommandTests(ITestOutputHelper outputHelper)
         var parseResult = initCommand.Parse("init");
         var exitCode = await parseResult.InvokeAsync().DefaultTimeout();
 
-        Assert.Equal(ExitCodeConstants.Success, exitCode);
+        Assert.Equal(CliExitCodes.Success, exitCode);
 
         var merged = JsonNode.Parse(await File.ReadAllTextAsync(configPath))!.AsObject();
         Assert.Equal("apphost.cs", merged["appHost"]!.AsObject()["path"]!.GetValue<string>());
@@ -580,7 +580,7 @@ public class InitCommandTests(ITestOutputHelper outputHelper)
         var parseResult = initCommand.Parse("init");
         var exitCode = await parseResult.InvokeAsync().DefaultTimeout();
 
-        Assert.Equal(ExitCodeConstants.Success, exitCode);
+        Assert.Equal(CliExitCodes.Success, exitCode);
         Assert.Equal(preExistingContent, await File.ReadAllTextAsync(appHostPath));
     }
 
@@ -622,7 +622,7 @@ public class InitCommandTests(ITestOutputHelper outputHelper)
         var parseResult = initCommand.Parse("init");
         var exitCode = await parseResult.InvokeAsync().DefaultTimeout();
 
-        Assert.Equal(ExitCodeConstants.Success, exitCode);
+        Assert.Equal(CliExitCodes.Success, exitCode);
         Assert.Null(capturedNuGetConfigFile);
         // The implicit channel surfaces the package's Source field as the nugetSource even when no
         // temporary config is generated, so nugetSource may be non-null. The contract this test guards
@@ -709,7 +709,7 @@ public class InitCommandTests(ITestOutputHelper outputHelper)
         var parseResult = initCommand.Parse("init");
         var exitCode = await parseResult.InvokeAsync().DefaultTimeout();
 
-        Assert.Equal(ExitCodeConstants.Success, exitCode);
+        Assert.Equal(CliExitCodes.Success, exitCode);
         Assert.Equal("13.3.0", capturedTemplateVersion);
     }
 
@@ -762,7 +762,7 @@ public class InitCommandTests(ITestOutputHelper outputHelper)
         var parseResult = initCommand.Parse("init");
         var exitCode = await parseResult.InvokeAsync().DefaultTimeout();
 
-        Assert.Equal(ExitCodeConstants.FailedToInstallTemplates, exitCode);
+        Assert.Equal(CliExitCodes.FailedToInstallTemplates, exitCode);
         Assert.Contains(interactionService.DisplayedErrors, e => e.Contains("simulated network failure", StringComparison.Ordinal));
     }
 
@@ -817,7 +817,7 @@ public class InitCommandTests(ITestOutputHelper outputHelper)
         var parseResult = initCommand.Parse("init");
         var exitCode = await parseResult.InvokeAsync().DefaultTimeout();
 
-        Assert.Equal(ExitCodeConstants.Success, exitCode);
+        Assert.Equal(CliExitCodes.Success, exitCode);
         Assert.Equal(SourceForChannel(contextChannel), capturedNuGetSource);
     }
 
@@ -866,7 +866,7 @@ public class InitCommandTests(ITestOutputHelper outputHelper)
         var parseResult = initCommand.Parse("init");
         var exitCode = await parseResult.InvokeAsync().DefaultTimeout();
 
-        Assert.Equal(ExitCodeConstants.Success, exitCode);
+        Assert.Equal(CliExitCodes.Success, exitCode);
         Assert.Equal(SourceForChannel("pr-12345"), capturedNuGetSource);
     }
 
@@ -900,7 +900,7 @@ public class InitCommandTests(ITestOutputHelper outputHelper)
         var parseResult = initCommand.Parse("init");
         var exitCode = await parseResult.InvokeAsync().DefaultTimeout();
 
-        Assert.Equal(ExitCodeConstants.Success, exitCode);
+        Assert.Equal(CliExitCodes.Success, exitCode);
         Assert.True(File.Exists(Path.Combine(workspace.WorkspaceRoot.FullName, "apphost.cs")));
 
         var nugetConfigPath = Path.Combine(workspace.WorkspaceRoot.FullName, "nuget.config");
@@ -974,7 +974,7 @@ public class InitCommandTests(ITestOutputHelper outputHelper)
         var parseResult = initCommand.Parse("init");
         var exitCode = await parseResult.InvokeAsync().DefaultTimeout();
 
-        Assert.Equal(ExitCodeConstants.Success, exitCode);
+        Assert.Equal(CliExitCodes.Success, exitCode);
     }
 
     /// <summary>
@@ -1059,7 +1059,7 @@ public class InitCommandTests(ITestOutputHelper outputHelper)
         var parseResult = initCommand.Parse("init");
         var exitCode = await parseResult.InvokeAsync().DefaultTimeout();
 
-        Assert.Equal(ExitCodeConstants.Success, exitCode);
+        Assert.Equal(CliExitCodes.Success, exitCode);
         Assert.Equal("13.3.0", capturedTemplateVersion);
     }
 
@@ -1126,7 +1126,7 @@ public class InitCommandTests(ITestOutputHelper outputHelper)
         var parseResult = initCommand.Parse("init");
         var exitCode = await parseResult.InvokeAsync().DefaultTimeout();
 
-        Assert.Equal(ExitCodeConstants.Success, exitCode);
+        Assert.Equal(CliExitCodes.Success, exitCode);
 
         Assert.True(File.Exists(nugetConfigPath), $"nuget.config should be created in the solution directory for channel '{contextChannel}'.");
         Assert.NotNull(nugetConfigContentAtNewProjectTime);
@@ -1175,7 +1175,7 @@ public class InitCommandTests(ITestOutputHelper outputHelper)
         var parseResult = initCommand.Parse("init");
         var exitCode = await parseResult.InvokeAsync().DefaultTimeout();
 
-        Assert.Equal(ExitCodeConstants.Success, exitCode);
+        Assert.Equal(CliExitCodes.Success, exitCode);
         var nugetConfigPath = Path.Combine(workspace.WorkspaceRoot.FullName, "nuget.config");
         Assert.True(File.Exists(nugetConfigPath), "rerun must create the workspace nuget.config even though the AppHost dir already exists.");
         AssertNuGetConfigHasChannelShape(nugetConfigPath, contextChannel);
@@ -1212,7 +1212,7 @@ public class InitCommandTests(ITestOutputHelper outputHelper)
         var parseResult = initCommand.Parse("init");
         var exitCode = await parseResult.InvokeAsync().DefaultTimeout();
 
-        Assert.Equal(ExitCodeConstants.Success, exitCode);
+        Assert.Equal(CliExitCodes.Success, exitCode);
         var nugetConfigPath = Path.Combine(workspace.WorkspaceRoot.FullName, "nuget.config");
         Assert.True(File.Exists(nugetConfigPath), "rerun must create the workspace nuget.config even though apphost.cs already exists.");
         AssertNuGetConfigHasChannelShape(nugetConfigPath, contextChannel);
@@ -1261,7 +1261,7 @@ public class InitCommandTests(ITestOutputHelper outputHelper)
         var parseResult = initCommand.Parse("init");
         var exitCode = await parseResult.InvokeAsync().DefaultTimeout();
 
-        Assert.Equal(ExitCodeConstants.Success, exitCode);
+        Assert.Equal(CliExitCodes.Success, exitCode);
         Assert.True(File.Exists(Path.Combine(solutionDir.FullName, "nuget.config")),
             "nuget.config must be written in the solution directory, not the working directory.");
         Assert.False(File.Exists(Path.Combine(workspace.WorkspaceRoot.FullName, "nuget.config")),
@@ -1323,7 +1323,7 @@ public class InitCommandTests(ITestOutputHelper outputHelper)
         var parseResult = initCommand.Parse("init");
         var exitCode = await parseResult.InvokeAsync().DefaultTimeout();
 
-        Assert.Equal(ExitCodeConstants.Success, exitCode);
+        Assert.Equal(CliExitCodes.Success, exitCode);
 
         var merged = File.ReadAllText(nugetConfigPath);
         Assert.Contains(userFeedUrl, merged);
@@ -1374,7 +1374,7 @@ public class InitCommandTests(ITestOutputHelper outputHelper)
         var parseResult = initCommand.Parse("init");
         var exitCode = await parseResult.InvokeAsync().DefaultTimeout();
 
-        Assert.Equal(ExitCodeConstants.Success, exitCode);
+        Assert.Equal(CliExitCodes.Success, exitCode);
         var nugetConfigPath = Path.Combine(workspace.WorkspaceRoot.FullName, "nuget.config");
         var content = File.ReadAllText(nugetConfigPath);
 
@@ -1441,7 +1441,7 @@ public class InitCommandTests(ITestOutputHelper outputHelper)
         var parseResult = initCommand.Parse("init");
         var exitCode = await parseResult.InvokeAsync().DefaultTimeout();
 
-        Assert.Equal(ExitCodeConstants.Success, exitCode);
+        Assert.Equal(CliExitCodes.Success, exitCode);
         Assert.False(
             File.Exists(Path.Combine(workspace.WorkspaceRoot.FullName, "nuget.config")),
             "no workspace nuget.config should be written when no matching channel exists for IdentityChannel='local'.");
@@ -1488,7 +1488,7 @@ public class InitCommandTests(ITestOutputHelper outputHelper)
         var parseResult = initCommand.Parse("init");
         var exitCode = await parseResult.InvokeAsync().DefaultTimeout();
 
-        Assert.Equal(ExitCodeConstants.Success, exitCode);
+        Assert.Equal(CliExitCodes.Success, exitCode);
         var nugetConfigPath = Path.Combine(workspace.WorkspaceRoot.FullName, "nuget.config");
         Assert.True(File.Exists(nugetConfigPath));
         AssertNuGetConfigHasChannelShape(nugetConfigPath, contextChannel);

--- a/tests/Aspire.Cli.Tests/Commands/LogsCommandTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/LogsCommandTests.cs
@@ -28,7 +28,7 @@ public class LogsCommandTests(ITestOutputHelper outputHelper)
         var exitCode = await result.InvokeAsync().DefaultTimeout();
 
         // Help should return success
-        Assert.Equal(ExitCodeConstants.Success, exitCode);
+        Assert.Equal(CliExitCodes.Success, exitCode);
     }
 
     [Fact]
@@ -130,7 +130,7 @@ public class LogsCommandTests(ITestOutputHelper outputHelper)
         var exitCode = await result.InvokeAsync().DefaultTimeout();
 
         // Should fail validation
-        Assert.NotEqual(ExitCodeConstants.Success, exitCode);
+        Assert.NotEqual(CliExitCodes.Success, exitCode);
     }
 
     [Theory]
@@ -151,7 +151,7 @@ public class LogsCommandTests(ITestOutputHelper outputHelper)
         var exitCode = await result.InvokeAsync().DefaultTimeout();
 
         // Help should succeed (validation passed)
-        Assert.Equal(ExitCodeConstants.Success, exitCode);
+        Assert.Equal(CliExitCodes.Success, exitCode);
     }
 
     [Fact]
@@ -168,7 +168,7 @@ public class LogsCommandTests(ITestOutputHelper outputHelper)
         var exitCode = await result.InvokeAsync().DefaultTimeout();
 
         // Should succeed - no running AppHost is not an error
-        Assert.Equal(ExitCodeConstants.Success, exitCode);
+        Assert.Equal(CliExitCodes.Success, exitCode);
     }
 
     [Theory]
@@ -187,7 +187,7 @@ public class LogsCommandTests(ITestOutputHelper outputHelper)
 
         var exitCode = await result.InvokeAsync().DefaultTimeout();
 
-        Assert.Equal(ExitCodeConstants.Success, exitCode);
+        Assert.Equal(CliExitCodes.Success, exitCode);
     }
 
     [Theory]
@@ -205,7 +205,7 @@ public class LogsCommandTests(ITestOutputHelper outputHelper)
 
         var exitCode = await result.InvokeAsync().DefaultTimeout();
 
-        Assert.Equal(ExitCodeConstants.Success, exitCode);
+        Assert.Equal(CliExitCodes.Success, exitCode);
     }
 
     [Fact]
@@ -221,7 +221,7 @@ public class LogsCommandTests(ITestOutputHelper outputHelper)
         var exitCode = await result.InvokeAsync().DefaultTimeout();
 
         // Invalid format should cause parsing error
-        Assert.NotEqual(ExitCodeConstants.Success, exitCode);
+        Assert.NotEqual(CliExitCodes.Success, exitCode);
     }
 
     [Fact]
@@ -236,7 +236,7 @@ public class LogsCommandTests(ITestOutputHelper outputHelper)
 
         var exitCode = await result.InvokeAsync().DefaultTimeout();
 
-        Assert.Equal(ExitCodeConstants.Success, exitCode);
+        Assert.Equal(CliExitCodes.Success, exitCode);
     }
 
     [Fact]
@@ -251,7 +251,7 @@ public class LogsCommandTests(ITestOutputHelper outputHelper)
 
         var exitCode = await result.InvokeAsync().DefaultTimeout();
 
-        Assert.Equal(ExitCodeConstants.Success, exitCode);
+        Assert.Equal(CliExitCodes.Success, exitCode);
     }
 
     [Fact]
@@ -267,7 +267,7 @@ public class LogsCommandTests(ITestOutputHelper outputHelper)
 
         var exitCode = await result.InvokeAsync().DefaultTimeout();
 
-        Assert.Equal(ExitCodeConstants.Success, exitCode);
+        Assert.Equal(CliExitCodes.Success, exitCode);
     }
 
     [Fact]
@@ -381,7 +381,7 @@ public class LogsCommandTests(ITestOutputHelper outputHelper)
 
         var exitCode = await result.InvokeAsync().DefaultTimeout();
 
-        Assert.Equal(ExitCodeConstants.Success, exitCode);
+        Assert.Equal(CliExitCodes.Success, exitCode);
 
         var jsonOutput = outputWriter.Logs.FirstOrDefault(l => l.Contains("\"logs\""));
         Assert.NotNull(jsonOutput);
@@ -411,7 +411,7 @@ public class LogsCommandTests(ITestOutputHelper outputHelper)
 
         var exitCode = await result.InvokeAsync().DefaultTimeout();
 
-        Assert.Equal(ExitCodeConstants.Success, exitCode);
+        Assert.Equal(CliExitCodes.Success, exitCode);
 
         // Plain text output uses "[resourceName] content" format
         // Replicas share the same DisplayName, so the unique Name should be used instead
@@ -440,11 +440,11 @@ public class LogsCommandTests(ITestOutputHelper outputHelper)
 
         if (expectError)
         {
-            Assert.Equal(ExitCodeConstants.InvalidCommand, exitCode);
+            Assert.Equal(CliExitCodes.InvalidCommand, exitCode);
         }
         else
         {
-            Assert.Equal(ExitCodeConstants.Success, exitCode);
+            Assert.Equal(CliExitCodes.Success, exitCode);
         }
     }
 
@@ -460,7 +460,7 @@ public class LogsCommandTests(ITestOutputHelper outputHelper)
 
         var exitCode = await result.InvokeAsync().DefaultTimeout();
 
-        Assert.Equal(ExitCodeConstants.Success, exitCode);
+        Assert.Equal(CliExitCodes.Success, exitCode);
 
         var jsonOutput = outputWriter.Logs.FirstOrDefault(l => l.Contains("\"logs\""));
         Assert.NotNull(jsonOutput);
@@ -498,7 +498,7 @@ public class LogsCommandTests(ITestOutputHelper outputHelper)
 
         var exitCode = await result.InvokeAsync().DefaultTimeout();
 
-        Assert.Equal(ExitCodeConstants.Success, exitCode);
+        Assert.Equal(CliExitCodes.Success, exitCode);
 
         var jsonOutput = outputWriter.Logs.FirstOrDefault(l => l.Contains("\"logs\""));
         Assert.NotNull(jsonOutput);
@@ -537,7 +537,7 @@ public class LogsCommandTests(ITestOutputHelper outputHelper)
 
         var exitCode = await result.InvokeAsync().DefaultTimeout();
 
-        Assert.Equal(ExitCodeConstants.Success, exitCode);
+        Assert.Equal(CliExitCodes.Success, exitCode);
 
         // Logs are sorted by timestamp, timestamp prefix is ISO 8601 round-trip format
         var logLines = outputWriter.Logs.Where(l => l.StartsWith("2025-", StringComparison.Ordinal)).ToList();
@@ -559,7 +559,7 @@ public class LogsCommandTests(ITestOutputHelper outputHelper)
 
         var exitCode = await result.InvokeAsync().DefaultTimeout();
 
-        Assert.Equal(ExitCodeConstants.Success, exitCode);
+        Assert.Equal(CliExitCodes.Success, exitCode);
 
         // Without --timestamps, log lines start with "[resourceName]" with no timestamp prefix
         // Logs are sorted by timestamp
@@ -595,7 +595,7 @@ public class LogsCommandTests(ITestOutputHelper outputHelper)
 
         var exitCode = await result.InvokeAsync().DefaultTimeout();
 
-        Assert.Equal(ExitCodeConstants.Success, exitCode);
+        Assert.Equal(CliExitCodes.Success, exitCode);
 
         var logLine = Assert.Single(outputWriter.Logs, l => l.StartsWith("[", StringComparison.Ordinal));
         Assert.Equal("[redis] Ready to accept connections", logLine);
@@ -627,7 +627,7 @@ public class LogsCommandTests(ITestOutputHelper outputHelper)
 
         var exitCode = await result.InvokeAsync().DefaultTimeout();
 
-        Assert.Equal(ExitCodeConstants.Success, exitCode);
+        Assert.Equal(CliExitCodes.Success, exitCode);
 
         var jsonOutput = outputWriter.Logs.First(l => l.Contains("\"logs\"", StringComparison.Ordinal));
         var logsOutput = JsonSerializer.Deserialize(jsonOutput, LogsCommandJsonContext.Snapshot.LogsOutput);
@@ -649,7 +649,7 @@ public class LogsCommandTests(ITestOutputHelper outputHelper)
 
         var exitCode = await result.InvokeAsync().DefaultTimeout();
 
-        Assert.Equal(ExitCodeConstants.Success, exitCode);
+        Assert.Equal(CliExitCodes.Success, exitCode);
 
         var jsonOutput = outputWriter.Logs.FirstOrDefault(l => l.Contains("\"logs\""));
         Assert.NotNull(jsonOutput);
@@ -674,7 +674,7 @@ public class LogsCommandTests(ITestOutputHelper outputHelper)
 
         var exitCode = await result.InvokeAsync().DefaultTimeout();
 
-        Assert.Equal(ExitCodeConstants.Success, exitCode);
+        Assert.Equal(CliExitCodes.Success, exitCode);
 
         var jsonOutput = outputWriter.Logs.FirstOrDefault(l => l.Contains("\"logs\""));
         Assert.NotNull(jsonOutput);
@@ -699,7 +699,7 @@ public class LogsCommandTests(ITestOutputHelper outputHelper)
 
         var exitCode = await result.InvokeAsync().DefaultTimeout();
 
-        Assert.Equal(ExitCodeConstants.Success, exitCode);
+        Assert.Equal(CliExitCodes.Success, exitCode);
 
         var jsonOutput = outputWriter.Logs.FirstOrDefault(l => l.Contains("\"logs\""));
         Assert.NotNull(jsonOutput);
@@ -784,7 +784,7 @@ public class LogsCommandTests(ITestOutputHelper outputHelper)
 
         var exitCode = await result.InvokeAsync().DefaultTimeout();
 
-        Assert.Equal(ExitCodeConstants.Success, exitCode);
+        Assert.Equal(CliExitCodes.Success, exitCode);
 
         var jsonOutput = outputWriter.Logs.FirstOrDefault(l => l.Contains("\"logs\""));
         Assert.NotNull(jsonOutput);
@@ -893,7 +893,7 @@ public class LogsCommandTests(ITestOutputHelper outputHelper)
 
         var exitCode = await result.InvokeAsync().DefaultTimeout();
 
-        Assert.Equal(ExitCodeConstants.Success, exitCode);
+        Assert.Equal(CliExitCodes.Success, exitCode);
         Assert.Contains(outputWriter.Logs, l => l.Contains("[redis] Ready to accept connections", StringComparison.Ordinal));
         Assert.DoesNotContain(outputWriter.Logs, l => l.Contains("late-hidden", StringComparison.Ordinal));
     }
@@ -915,7 +915,7 @@ public class LogsCommandTests(ITestOutputHelper outputHelper)
 
         var exitCode = await result.InvokeAsync().DefaultTimeout();
 
-        Assert.Equal(ExitCodeConstants.Success, exitCode);
+        Assert.Equal(CliExitCodes.Success, exitCode);
         Assert.Single(outputWriter.Logs, l => l.TrimStart().StartsWith("{", StringComparison.Ordinal));
         Assert.DoesNotContain(outputWriter.Logs, l => l.Contains("unexpected error occurred", StringComparison.OrdinalIgnoreCase));
         Assert.Contains(InteractionServiceStrings.AppHostConnectionLostGeneric, errorWriter.ToString(), StringComparison.Ordinal);
@@ -938,7 +938,7 @@ public class LogsCommandTests(ITestOutputHelper outputHelper)
 
         var exitCode = await result.InvokeAsync().DefaultTimeout();
 
-        Assert.Equal(ExitCodeConstants.Success, exitCode);
+        Assert.Equal(CliExitCodes.Success, exitCode);
         Assert.Single(outputWriter.Logs, l => l.TrimStart().StartsWith("{", StringComparison.Ordinal));
         Assert.Contains(InteractionServiceStrings.AppHostShutDown, errorWriter.ToString(), StringComparison.Ordinal);
     }
@@ -965,7 +965,7 @@ public class LogsCommandTests(ITestOutputHelper outputHelper)
 
         var exitCode = await pendingRun.DefaultTimeout();
 
-        Assert.Equal(ExitCodeConstants.Success, exitCode);
+        Assert.Equal(CliExitCodes.Success, exitCode);
         Assert.DoesNotContain(InteractionServiceStrings.AppHostConnectionLostGeneric, errorWriter.ToString(), StringComparison.Ordinal);
         Assert.DoesNotContain(InteractionServiceStrings.AppHostShutDown, errorWriter.ToString(), StringComparison.Ordinal);
     }
@@ -1050,7 +1050,7 @@ public class LogsCommandTests(ITestOutputHelper outputHelper)
 
         var exitCode = await result.InvokeAsync().DefaultTimeout();
 
-        Assert.Equal(ExitCodeConstants.Success, exitCode);
+        Assert.Equal(CliExitCodes.Success, exitCode);
 
         var jsonOutput = outputWriter.Logs.FirstOrDefault(l => l.Contains("\"logs\""));
         Assert.NotNull(jsonOutput);
@@ -1081,7 +1081,7 @@ public class LogsCommandTests(ITestOutputHelper outputHelper)
 
         var exitCode = await result.InvokeAsync().DefaultTimeout();
 
-        Assert.Equal(ExitCodeConstants.Success, exitCode);
+        Assert.Equal(CliExitCodes.Success, exitCode);
 
         var jsonOutput = outputWriter.Logs.FirstOrDefault(l => l.Contains("\"logs\""));
         Assert.NotNull(jsonOutput);
@@ -1110,7 +1110,7 @@ public class LogsCommandTests(ITestOutputHelper outputHelper)
 
         var exitCode = await result.InvokeAsync().DefaultTimeout();
 
-        Assert.Equal(ExitCodeConstants.Success, exitCode);
+        Assert.Equal(CliExitCodes.Success, exitCode);
 
         var jsonOutput = outputWriter.Logs.FirstOrDefault(l => l.Contains("\"logs\""));
         Assert.NotNull(jsonOutput);
@@ -1142,7 +1142,7 @@ public class LogsCommandTests(ITestOutputHelper outputHelper)
 
         var exitCode = await result.InvokeAsync().DefaultTimeout();
 
-        Assert.Equal(ExitCodeConstants.Success, exitCode);
+        Assert.Equal(CliExitCodes.Success, exitCode);
 
         var request = Assert.Single(requests);
         Assert.Equal("redis", request.ResourceName);
@@ -1190,7 +1190,7 @@ public class LogsCommandTests(ITestOutputHelper outputHelper)
 
         var exitCode = await result.InvokeAsync().DefaultTimeout();
 
-        Assert.Equal(ExitCodeConstants.Success, exitCode);
+        Assert.Equal(CliExitCodes.Success, exitCode);
         Assert.Empty(consoleRequests);
 
         var request = Assert.Single(batchRequests);
@@ -1226,7 +1226,7 @@ public class LogsCommandTests(ITestOutputHelper outputHelper)
 
         var exitCode = await result.InvokeAsync().DefaultTimeout();
 
-        Assert.Equal(ExitCodeConstants.Success, exitCode);
+        Assert.Equal(CliExitCodes.Success, exitCode);
 
         var jsonOutput = outputWriter.Logs.FirstOrDefault(l => l.Contains("\"logs\"", StringComparison.Ordinal));
         Assert.NotNull(jsonOutput);
@@ -1271,7 +1271,7 @@ public class LogsCommandTests(ITestOutputHelper outputHelper)
 
         var exitCode = await result.InvokeAsync().DefaultTimeout();
 
-        Assert.Equal(ExitCodeConstants.Success, exitCode);
+        Assert.Equal(CliExitCodes.Success, exitCode);
         Assert.Empty(consoleRequests);
 
         var legacyRequest = Assert.Single(legacyRequests);
@@ -1320,7 +1320,7 @@ public class LogsCommandTests(ITestOutputHelper outputHelper)
 
         var exitCode = await result.InvokeAsync().DefaultTimeout();
 
-        Assert.Equal(ExitCodeConstants.Success, exitCode);
+        Assert.Equal(CliExitCodes.Success, exitCode);
         Assert.Empty(consoleRequests);
 
         var legacyRequest = Assert.Single(legacyRequests);
@@ -1349,7 +1349,7 @@ public class LogsCommandTests(ITestOutputHelper outputHelper)
 
         var exitCode = await result.InvokeAsync().DefaultTimeout();
 
-        Assert.Equal(ExitCodeConstants.Success, exitCode);
+        Assert.Equal(CliExitCodes.Success, exitCode);
 
         // The tail output should only contain lines matching the search
         Assert.DoesNotContain(outputWriter.Logs, l => l.Contains("Ready to accept connections", StringComparison.Ordinal));

--- a/tests/Aspire.Cli.Tests/Commands/LsCommandTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/LsCommandTests.cs
@@ -27,7 +27,7 @@ public class LsCommandTests(ITestOutputHelper outputHelper)
 
         var exitCode = await result.InvokeAsync().DefaultTimeout();
 
-        Assert.Equal(ExitCodeConstants.Success, exitCode);
+        Assert.Equal(CliExitCodes.Success, exitCode);
     }
 
     [Fact]
@@ -42,7 +42,7 @@ public class LsCommandTests(ITestOutputHelper outputHelper)
 
         var exitCode = await result.InvokeAsync().DefaultTimeout();
 
-        Assert.Equal(ExitCodeConstants.Success, exitCode);
+        Assert.Equal(CliExitCodes.Success, exitCode);
     }
 
     [Theory]
@@ -60,7 +60,7 @@ public class LsCommandTests(ITestOutputHelper outputHelper)
 
         var exitCode = await result.InvokeAsync().DefaultTimeout();
 
-        Assert.Equal(ExitCodeConstants.Success, exitCode);
+        Assert.Equal(CliExitCodes.Success, exitCode);
     }
 
     [Fact]
@@ -75,7 +75,7 @@ public class LsCommandTests(ITestOutputHelper outputHelper)
 
         var exitCode = await result.InvokeAsync().DefaultTimeout();
 
-        Assert.NotEqual(ExitCodeConstants.Success, exitCode);
+        Assert.NotEqual(CliExitCodes.Success, exitCode);
     }
 
     [Fact]
@@ -106,7 +106,7 @@ public class LsCommandTests(ITestOutputHelper outputHelper)
 
         var exitCode = await result.InvokeAsync().DefaultTimeout();
 
-        Assert.Equal(ExitCodeConstants.Success, exitCode);
+        Assert.Equal(CliExitCodes.Success, exitCode);
 
         var jsonOutput = string.Join(string.Empty, textWriter.Logs);
         var candidateAppHosts = JsonSerializer.Deserialize(jsonOutput, JsonSourceGenerationContext.RelaxedEscaping.ListCandidateAppHostDisplayInfo);
@@ -146,7 +146,7 @@ public class LsCommandTests(ITestOutputHelper outputHelper)
 
         var exitCode = await result.InvokeAsync().DefaultTimeout();
 
-        Assert.Equal(ExitCodeConstants.Success, exitCode);
+        Assert.Equal(CliExitCodes.Success, exitCode);
 
         var jsonOutput = string.Join(string.Empty, textWriter.Logs);
         using var document = JsonDocument.Parse(jsonOutput);
@@ -182,7 +182,7 @@ public class LsCommandTests(ITestOutputHelper outputHelper)
 
         var exitCode = await result.InvokeAsync().DefaultTimeout();
 
-        Assert.Equal(ExitCodeConstants.Success, exitCode);
+        Assert.Equal(CliExitCodes.Success, exitCode);
 
         var output = string.Join('\n', textWriter.Logs);
         Assert.Contains("\u001b[32mbuildable", output);
@@ -215,7 +215,7 @@ public class LsCommandTests(ITestOutputHelper outputHelper)
 
         var exitCode = await result.InvokeAsync().DefaultTimeout();
 
-        Assert.Equal(ExitCodeConstants.Success, exitCode);
+        Assert.Equal(CliExitCodes.Success, exitCode);
         Assert.Equal(AppHostDiscoveryScope.DefaultFiltered, capturedScope);
     }
 
@@ -244,7 +244,7 @@ public class LsCommandTests(ITestOutputHelper outputHelper)
 
         var exitCode = await result.InvokeAsync().DefaultTimeout();
 
-        Assert.Equal(ExitCodeConstants.Success, exitCode);
+        Assert.Equal(CliExitCodes.Success, exitCode);
         Assert.Equal(AppHostDiscoveryScope.AllFiles, capturedScope);
     }
 
@@ -280,7 +280,7 @@ public class LsCommandTests(ITestOutputHelper outputHelper)
 
         var exitCode = await result.InvokeAsync().DefaultTimeout();
 
-        Assert.Equal(ExitCodeConstants.Success, exitCode);
+        Assert.Equal(CliExitCodes.Success, exitCode);
 
         var lsActivity = Assert.Single(startedActivities, activity => activity.OperationName == ProfilingTelemetry.Activities.LsCommand);
         Assert.Equal("json", lsActivity.GetTagItem(ProfilingTelemetry.Tags.LsOutputFormat));

--- a/tests/Aspire.Cli.Tests/Commands/McpCommandTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/McpCommandTests.cs
@@ -22,7 +22,7 @@ public class McpCommandTests(ITestOutputHelper outputHelper)
 
         var exitCode = await result.InvokeAsync().DefaultTimeout();
 
-        Assert.Equal(ExitCodeConstants.InvalidCommand, exitCode);
+        Assert.Equal(CliExitCodes.InvalidCommand, exitCode);
     }
 
     [Fact]
@@ -109,7 +109,7 @@ public class McpCommandTests(ITestOutputHelper outputHelper)
 
         var exitCode = await result.InvokeAsync().DefaultTimeout();
 
-        Assert.Equal(ExitCodeConstants.InvalidCommand, exitCode);
+        Assert.Equal(CliExitCodes.InvalidCommand, exitCode);
     }
 
     [Fact]

--- a/tests/Aspire.Cli.Tests/Commands/NewCommandChannelResolutionTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/NewCommandChannelResolutionTests.cs
@@ -106,7 +106,7 @@ public class NewCommandChannelResolutionTests(ITestOutputHelper outputHelper)
         var parseResult = newCommand.Parse("new aspire-starter --name TestApp --output ./output --use-redis-cache --test-framework None");
         var exitCode = await parseResult.InvokeAsync().DefaultTimeout();
 
-        Assert.Equal(ExitCodeConstants.Success, exitCode);
+        Assert.Equal(CliExitCodes.Success, exitCode);
         // The template version came from the Implicit channel's package cache. If the tripwire
         // had been triggered, the run would have failed before reaching install.
         Assert.Equal("13.3.0", capturedTemplateVersion);
@@ -253,7 +253,7 @@ public class NewCommandChannelResolutionTests(ITestOutputHelper outputHelper)
                 capturedInputs.Channel = inputs.Channel;
                 var outputPath = Path.Combine(workspace.WorkspaceRoot.FullName, "captured");
                 Directory.CreateDirectory(outputPath);
-                return Task.FromResult(new TemplateResult(ExitCodeConstants.Success, outputPath));
+                return Task.FromResult(new TemplateResult(CliExitCodes.Success, outputPath));
             },
             runtime: TemplateRuntime.Cli,
             languageId: KnownLanguageId.TypeScript);
@@ -274,7 +274,7 @@ public class NewCommandChannelResolutionTests(ITestOutputHelper outputHelper)
         var parseResult = newCommand.Parse($"new fake-cli-template --name TestApp --output ./captured{channelArg}");
         var exitCode = await parseResult.InvokeAsync().DefaultTimeout();
 
-        Assert.Equal(ExitCodeConstants.Success, exitCode);
+        Assert.Equal(CliExitCodes.Success, exitCode);
         return capturedInputs;
     }
 

--- a/tests/Aspire.Cli.Tests/Commands/NewCommandTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/NewCommandTests.cs
@@ -35,7 +35,7 @@ public class NewCommandTests(ITestOutputHelper outputHelper)
         var result = command.Parse("new --help");
 
         var exitCode = await result.InvokeAsync().DefaultTimeout();
-        Assert.Equal(ExitCodeConstants.Success, exitCode);
+        Assert.Equal(CliExitCodes.Success, exitCode);
     }
 
     [Fact]
@@ -90,7 +90,7 @@ public class NewCommandTests(ITestOutputHelper outputHelper)
         var result = command.Parse("new aspire-starter --use-redis-cache --test-framework None");
 
         var exitCode = await result.InvokeAsync().DefaultTimeout();
-        Assert.Equal(ExitCodeConstants.Success, exitCode);
+        Assert.Equal(CliExitCodes.Success, exitCode);
     }
 
     [Fact]
@@ -128,7 +128,7 @@ public class NewCommandTests(ITestOutputHelper outputHelper)
         var result = command.Parse("new aspire-starter --use-redis-cache --test-framework None");
 
         var exitCode = await result.InvokeAsync().DefaultTimeout();
-        Assert.Equal(ExitCodeConstants.Success, exitCode);
+        Assert.Equal(CliExitCodes.Success, exitCode);
         Assert.Equal("aspire-starter", capturedDefaultProjectName);
         Assert.Equal("./CustomName", capturedDefaultOutputPath);
     }
@@ -161,7 +161,7 @@ public class NewCommandTests(ITestOutputHelper outputHelper)
         var result = command.Parse("new aspire-starter --name MyApp --output ./output --use-redis-cache --test-framework None");
 
         var exitCode = await result.InvokeAsync().DefaultTimeout();
-        Assert.Equal(ExitCodeConstants.Success, exitCode);
+        Assert.Equal(CliExitCodes.Success, exitCode);
         Assert.False(promptedForName);
     }
 
@@ -193,7 +193,7 @@ public class NewCommandTests(ITestOutputHelper outputHelper)
         var result = command.Parse("new aspire-starter --output notsrc --use-redis-cache --test-framework None");
 
         var exitCode = await result.InvokeAsync().DefaultTimeout();
-        Assert.Equal(ExitCodeConstants.Success, exitCode);
+        Assert.Equal(CliExitCodes.Success, exitCode);
         Assert.False(promptedForPath);
     }
 
@@ -273,7 +273,7 @@ public class NewCommandTests(ITestOutputHelper outputHelper)
         var exitCode = await result.InvokeAsync().DefaultTimeout();
         
         // Assert
-        Assert.Equal(ExitCodeConstants.Success, exitCode);
+        Assert.Equal(CliExitCodes.Success, exitCode);
         Assert.Equal("stable", channelNameUsed); // Verify the stable channel was used
         Assert.False(promptedForVersion); // Should not prompt when --channel is specified
     }
@@ -350,7 +350,7 @@ public class NewCommandTests(ITestOutputHelper outputHelper)
         var exitCode = await result.InvokeAsync().DefaultTimeout();
         
         // Assert
-        Assert.Equal(ExitCodeConstants.Success, exitCode);
+        Assert.Equal(CliExitCodes.Success, exitCode);
         Assert.Equal("9.2.0", selectedVersion); // Should auto-select highest version (9.2.0)
         Assert.False(promptedForVersion); // Should not prompt when --channel is specified
     }
@@ -460,7 +460,7 @@ public class NewCommandTests(ITestOutputHelper outputHelper)
         var result = command.Parse("new aspire-starter --name MyApp --output ./output --use-redis-cache --test-framework None");
 
         var exitCode = await result.InvokeAsync().DefaultTimeout();
-        Assert.Equal(ExitCodeConstants.Success, exitCode);
+        Assert.Equal(CliExitCodes.Success, exitCode);
         Assert.False(promptedForTemplate);
     }
 
@@ -492,7 +492,7 @@ public class NewCommandTests(ITestOutputHelper outputHelper)
         var result = command.Parse("new aspire-starter --name MyApp --output ./output --use-redis-cache --test-framework None --version 9.2.0");
 
         var exitCode = await result.InvokeAsync().DefaultTimeout(TestConstants.LongTimeoutDuration);
-        Assert.Equal(ExitCodeConstants.Success, exitCode);
+        Assert.Equal(CliExitCodes.Success, exitCode);
         Assert.False(promptedForTemplateVersion);
     }
 
@@ -525,7 +525,7 @@ public class NewCommandTests(ITestOutputHelper outputHelper)
 
         var exitCode = await result.InvokeAsync().DefaultTimeout();
 
-        Assert.Equal(ExitCodeConstants.FailedToCreateNewProject, exitCode);
+        Assert.Equal(CliExitCodes.FailedToCreateNewProject, exitCode);
         Assert.NotNull(testInteractionService);
         Assert.Contains(testInteractionService.DisplayedErrors, e => e.Contains(TemplatingStrings.NoTemplateVersionsFound));
     }
@@ -566,7 +566,7 @@ public class NewCommandTests(ITestOutputHelper outputHelper)
         var result = command.Parse("new aspire-starter --use-redis-cache --test-framework None");
 
         var exitCode = await result.InvokeAsync().DefaultTimeout();
-        Assert.Equal(ExitCodeConstants.FailedToTrustCertificates, exitCode);
+        Assert.Equal(CliExitCodes.FailedToTrustCertificates, exitCode);
     }
 
     [Fact]
@@ -604,7 +604,7 @@ public class NewCommandTests(ITestOutputHelper outputHelper)
         var result = command.Parse("new aspire-starter --use-redis-cache --test-framework None");
 
         var exitCode = await result.InvokeAsync().DefaultTimeout();
-        Assert.Equal(ExitCodeConstants.FailedToCreateNewProject, exitCode);
+        Assert.Equal(CliExitCodes.FailedToCreateNewProject, exitCode);
     }
 
     private IServiceCollection CreateServiceCollection(
@@ -692,7 +692,7 @@ public class NewCommandTests(ITestOutputHelper outputHelper)
         var result = command.Parse("new aspire-starter --name TestApp --output ./output");
 
         var exitCode = await result.InvokeAsync().DefaultTimeout();
-        Assert.Equal(ExitCodeConstants.Success, exitCode);
+        Assert.Equal(CliExitCodes.Success, exitCode);
 
         // Verify that template version was prompted before template options
         Assert.Contains("TemplateVersion", operationOrder);
@@ -755,7 +755,7 @@ public class NewCommandTests(ITestOutputHelper outputHelper)
         var result = command.Parse($"new aspire-starter --use-redis-cache --test-framework None");
 
         var exitCode = await result.InvokeAsync().DefaultTimeout();
-        Assert.Equal(ExitCodeConstants.Success, exitCode);
+        Assert.Equal(CliExitCodes.Success, exitCode);
 
         // Verify that the default output path is derived from the project name (which contains markup characters)
         var expectedPath = $"./{projectNameWithMarkup}";
@@ -814,7 +814,7 @@ public class NewCommandTests(ITestOutputHelper outputHelper)
         var result = command.Parse("new --name TestApp --output ./output");
 
         var exitCode = await result.InvokeAsync().DefaultTimeout();
-        Assert.Equal(ExitCodeConstants.Success, exitCode);
+        Assert.Equal(CliExitCodes.Success, exitCode);
         Assert.Equal(KnownLanguageId.TypeScript, scaffoldedLanguageId);
         Assert.NotNull(promptedTemplates);
         Assert.Contains((KnownTemplateId.CSharpEmptyAppHost, "Empty AppHost (Choose language...)"), promptedTemplates);
@@ -884,7 +884,7 @@ public class NewCommandTests(ITestOutputHelper outputHelper)
         var result = command.Parse("new --name TestApp --output ./output");
 
         var exitCode = await result.InvokeAsync().DefaultTimeout();
-        Assert.Equal(ExitCodeConstants.Success, exitCode);
+        Assert.Equal(CliExitCodes.Success, exitCode);
         Assert.NotNull(promptedTemplateDescriptions);
         Assert.Equal(["Empty AppHost (Choose language...)"], promptedTemplateDescriptions);
     }
@@ -919,7 +919,7 @@ public class NewCommandTests(ITestOutputHelper outputHelper)
         var result = command.Parse("new aspire-empty --name TestApp --output ./output");
 
         var exitCode = await result.InvokeAsync().DefaultTimeout();
-        Assert.Equal(ExitCodeConstants.Success, exitCode);
+        Assert.Equal(CliExitCodes.Success, exitCode);
         Assert.NotNull(promptedLanguages);
         Assert.Contains(KnownLanguageId.CSharpDisplayName, promptedLanguages);
         Assert.Contains("TypeScript (Node.js)", promptedLanguages);
@@ -980,7 +980,7 @@ public class NewCommandTests(ITestOutputHelper outputHelper)
         var result = command.Parse("new aspire-empty --name TestApp --output ./output");
 
         var exitCode = await result.InvokeAsync().DefaultTimeout();
-        Assert.Equal(ExitCodeConstants.Success, exitCode);
+        Assert.Equal(CliExitCodes.Success, exitCode);
         Assert.Equal(KnownLanguageId.Java, scaffoldedLanguageId);
         Assert.NotNull(promptedLanguages);
         Assert.Contains(KnownLanguageId.CSharpDisplayName, promptedLanguages);
@@ -1043,7 +1043,7 @@ public class NewCommandTests(ITestOutputHelper outputHelper)
         var result = command.Parse("new aspire-empty --name TestApp --output ./output");
 
         var exitCode = await result.InvokeAsync().DefaultTimeout();
-        Assert.Equal(ExitCodeConstants.Success, exitCode);
+        Assert.Equal(CliExitCodes.Success, exitCode);
         Assert.True(languagePrompted);
         Assert.Equal(KnownLanguageId.Java, scaffoldedLanguageId);
     }
@@ -1071,7 +1071,7 @@ public class NewCommandTests(ITestOutputHelper outputHelper)
         var result = command.Parse("new aspire-empty --name TestApp --output ./output --language typescript --localhost-tld false --suppress-agent-init");
 
         var exitCode = await result.InvokeAsync().DefaultTimeout();
-        Assert.Equal(ExitCodeConstants.Success, exitCode);
+        Assert.Equal(CliExitCodes.Success, exitCode);
         Assert.Equal(KnownLanguageId.TypeScript, scaffoldedLanguageId);
         Assert.True(File.Exists(Path.Combine(workspace.WorkspaceRoot.FullName, "output", "apphost.ts")));
     }
@@ -1108,7 +1108,7 @@ public class NewCommandTests(ITestOutputHelper outputHelper)
         var result = command.Parse("new aspire-java-empty --name TestApp --output ./output --localhost-tld false");
 
         var exitCode = await result.InvokeAsync().DefaultTimeout();
-        Assert.Equal(ExitCodeConstants.Success, exitCode);
+        Assert.Equal(CliExitCodes.Success, exitCode);
         Assert.Equal(KnownLanguageId.Java, scaffoldedLanguageId);
         Assert.True(File.Exists(Path.Combine(workspace.WorkspaceRoot.FullName, "output", "AppHost.java")));
     }
@@ -1144,7 +1144,7 @@ public class NewCommandTests(ITestOutputHelper outputHelper)
         var result = command.Parse("new aspire-py-empty --name TestApp --output ./output --localhost-tld false");
 
         var exitCode = await result.InvokeAsync().DefaultTimeout();
-        Assert.Equal(ExitCodeConstants.Success, exitCode);
+        Assert.Equal(CliExitCodes.Success, exitCode);
         Assert.Equal(KnownLanguageId.Python, scaffoldedLanguageId);
         Assert.True(File.Exists(Path.Combine(workspace.WorkspaceRoot.FullName, "output", "apphost.py")));
     }
@@ -1161,7 +1161,7 @@ public class NewCommandTests(ITestOutputHelper outputHelper)
         var result = command.Parse("new aspire-empty --name TestApp --output ./output --localhost-tld false");
 
         var exitCode = await result.InvokeAsync().DefaultTimeout();
-        Assert.Equal(ExitCodeConstants.Success, exitCode);
+        Assert.Equal(CliExitCodes.Success, exitCode);
         Assert.True(File.Exists(Path.Combine(workspace.WorkspaceRoot.FullName, "output", "apphost.cs")));
     }
 
@@ -1177,7 +1177,7 @@ public class NewCommandTests(ITestOutputHelper outputHelper)
         var result = command.Parse("new aspire-empty --name TestApp --output ./output --localhost-tld false --suppress-agent-init");
 
         var exitCode = await result.InvokeAsync().DefaultTimeout();
-        Assert.Equal(ExitCodeConstants.Success, exitCode);
+        Assert.Equal(CliExitCodes.Success, exitCode);
 
         var outputDir = Path.Combine(workspace.WorkspaceRoot.FullName, "output");
         var aspireConfigPath = Path.Combine(outputDir, "aspire.config.json");
@@ -1207,7 +1207,7 @@ public class NewCommandTests(ITestOutputHelper outputHelper)
         var result = command.Parse("new aspire-empty --name TestApp --output ./output --localhost-tld --suppress-agent-init");
 
         var exitCode = await result.InvokeAsync().DefaultTimeout();
-        Assert.Equal(ExitCodeConstants.Success, exitCode);
+        Assert.Equal(CliExitCodes.Success, exitCode);
 
         var outputDir = Path.Combine(workspace.WorkspaceRoot.FullName, "output");
         var aspireConfigPath = Path.Combine(outputDir, "aspire.config.json");
@@ -1284,7 +1284,7 @@ public class NewCommandTests(ITestOutputHelper outputHelper)
         var result = command.Parse("new aspire-empty --name TestApp --output ./output");
 
         var exitCode = await result.InvokeAsync().DefaultTimeout();
-        Assert.Equal(ExitCodeConstants.Success, exitCode);
+        Assert.Equal(CliExitCodes.Success, exitCode);
         Assert.True(localhostPrompted);
 
         var runProfilePath = Path.Combine(workspace.WorkspaceRoot.FullName, "output", "aspire.config.json");
@@ -1316,7 +1316,7 @@ public class NewCommandTests(ITestOutputHelper outputHelper)
         var result = command.Parse("new aspire-ts-empty --name TestApp --output ./output --localhost-tld false");
 
         var exitCode = await result.InvokeAsync().DefaultTimeout();
-        Assert.Equal(ExitCodeConstants.Success, exitCode);
+        Assert.Equal(CliExitCodes.Success, exitCode);
         Assert.True(scaffoldingInvoked);
     }
 
@@ -1364,7 +1364,7 @@ public class NewCommandTests(ITestOutputHelper outputHelper)
         var result = command.Parse("new aspire-ts-empty --name TestApp --output ./output --channel stable --localhost-tld false");
 
         var exitCode = await result.InvokeAsync().DefaultTimeout();
-        Assert.Equal(ExitCodeConstants.Success, exitCode);
+        Assert.Equal(CliExitCodes.Success, exitCode);
         Assert.Equal("9.2.0", scaffoldSdkVersion);
         Assert.Equal("stable", scaffoldChannel);
     }
@@ -1405,7 +1405,7 @@ public class NewCommandTests(ITestOutputHelper outputHelper)
         var result = command.Parse("new aspire-ts-empty --name TestApp --localhost-tld false");
 
         var exitCode = await result.InvokeAsync().DefaultTimeout();
-        Assert.Equal(ExitCodeConstants.Success, exitCode);
+        Assert.Equal(CliExitCodes.Success, exitCode);
         Assert.NotNull(capturedTargetDirectory);
 
         // The output path should be properly normalized without "./" segments
@@ -1483,7 +1483,7 @@ public class NewCommandTests(ITestOutputHelper outputHelper)
         var result = command.Parse("new aspire-ts-empty --name TestApp --output ./output");
 
         var exitCode = await result.InvokeAsync().DefaultTimeout();
-        Assert.Equal(ExitCodeConstants.Success, exitCode);
+        Assert.Equal(CliExitCodes.Success, exitCode);
         Assert.True(scaffoldingInvoked);
         Assert.True(localhostPrompted);
 
@@ -1563,7 +1563,7 @@ public class NewCommandTests(ITestOutputHelper outputHelper)
 
         var exitCode = await result.InvokeAsync().DefaultTimeout();
 
-        Assert.Equal(ExitCodeConstants.Success, exitCode);
+        Assert.Equal(CliExitCodes.Success, exitCode);
         Assert.True(buildAndGenerateCalled);
         Assert.Equal("daily", channelSeenByProject);
         Assert.Equal("9.2.0", sdkVersionSeenByProject);
@@ -1628,7 +1628,7 @@ public class NewCommandTests(ITestOutputHelper outputHelper)
 
         var exitCode = await result.InvokeAsync().DefaultTimeout();
 
-        Assert.Equal(ExitCodeConstants.FailedToBuildArtifacts, exitCode);
+        Assert.Equal(CliExitCodes.FailedToBuildArtifacts, exitCode);
         Assert.Collection(interactionService.DisplayedErrors,
             error => Assert.Equal("Automatic 'aspire restore' failed for the new TypeScript starter project. Run 'aspire restore' in the project directory for more details.", error));
     }
@@ -1657,7 +1657,7 @@ public class NewCommandTests(ITestOutputHelper outputHelper)
         // GetTemplates() did not pass the nonInteractive flag, causing
         // the template to try to prompt for options.
         var exitCode = await result.InvokeAsync().DefaultTimeout();
-        Assert.Equal(ExitCodeConstants.Success, exitCode);
+        Assert.Equal(CliExitCodes.Success, exitCode);
     }
 
     [Fact]
@@ -1699,7 +1699,7 @@ public class NewCommandTests(ITestOutputHelper outputHelper)
 
         var exitCode = await result.InvokeAsync().DefaultTimeout();
 
-        Assert.Equal(ExitCodeConstants.MissingRequiredArgument, exitCode);
+        Assert.Equal(CliExitCodes.MissingRequiredArgument, exitCode);
         Assert.NotNull(testInteractionService);
         Assert.Contains(testInteractionService.DisplayedErrors,
             e => string.Equals(e, NewCommandStrings.NonInteractiveTemplateRequired, StringComparison.Ordinal));
@@ -1745,7 +1745,7 @@ public class NewCommandTests(ITestOutputHelper outputHelper)
 
         var exitCode = await result.InvokeAsync().DefaultTimeout();
 
-        Assert.Equal(ExitCodeConstants.Success, exitCode);
+        Assert.Equal(CliExitCodes.Success, exitCode);
         // The default project name is derived from the template name
         Assert.Equal("aspire-starter", capturedProjectName);
         // The default output path is derived from the template name
@@ -1788,7 +1788,7 @@ public class NewCommandTests(ITestOutputHelper outputHelper)
 
         var exitCode = await result.InvokeAsync().DefaultTimeout();
 
-        Assert.Equal(ExitCodeConstants.Success, exitCode);
+        Assert.Equal(CliExitCodes.Success, exitCode);
         Assert.Equal("MyProject", capturedProjectName);
         Assert.NotNull(capturedOutputPath);
         Assert.Contains("my-project", capturedOutputPath);
@@ -1831,7 +1831,7 @@ public class NewCommandTests(ITestOutputHelper outputHelper)
 
         var exitCode = await result.InvokeAsync().DefaultTimeout();
 
-        Assert.Equal(ExitCodeConstants.Success, exitCode);
+        Assert.Equal(CliExitCodes.Success, exitCode);
 
         // Agent init should not have run — no skill files should exist
         var skillPath = Path.Combine(outputDir, ".agents", "skills", "aspire", "SKILL.md");
@@ -1972,7 +1972,7 @@ public class NewCommandTests(ITestOutputHelper outputHelper)
 
         var exitCode = await result.InvokeAsync().DefaultTimeout();
 
-        Assert.Equal(ExitCodeConstants.Success, exitCode);
+        Assert.Equal(CliExitCodes.Success, exitCode);
         Assert.NotNull(capturedOutputPath);
 
         // Output path should have the project name appended as a subdirectory
@@ -2031,7 +2031,7 @@ public class NewCommandTests(ITestOutputHelper outputHelper)
 
         var exitCode = await result.InvokeAsync().DefaultTimeout();
 
-        Assert.Equal(ExitCodeConstants.Success, exitCode);
+        Assert.Equal(CliExitCodes.Success, exitCode);
         Assert.NotNull(capturedOutputPath);
 
         // Output path should NOT have the project name double-appended
@@ -2088,7 +2088,7 @@ public class NewCommandTests(ITestOutputHelper outputHelper)
 
         var exitCode = await result.InvokeAsync().DefaultTimeout();
 
-        Assert.Equal(ExitCodeConstants.Success, exitCode);
+        Assert.Equal(CliExitCodes.Success, exitCode);
         Assert.NotNull(capturedOutputPath);
 
         // In console mode, the output path should NOT have project name appended
@@ -2150,7 +2150,7 @@ public class NewCommandTests(ITestOutputHelper outputHelper)
 
             var exitCode = await result.InvokeAsync().DefaultTimeout();
 
-            Assert.Equal(ExitCodeConstants.Success, exitCode);
+            Assert.Equal(CliExitCodes.Success, exitCode);
             Assert.NotNull(capturedOutputPath);
             Assert.Equal(expectedPathFactory(workspace.WorkspaceRoot.FullName), capturedOutputPath);
         }
@@ -2185,7 +2185,7 @@ public class NewCommandTests(ITestOutputHelper outputHelper)
 
         var exitCode = await result.InvokeAsync().DefaultTimeout();
 
-        Assert.Equal(ExitCodeConstants.Success, exitCode);
+        Assert.Equal(CliExitCodes.Success, exitCode);
 
         // Agent init should not have run — no skill files should exist
         var skillPath = Path.Combine(workspace.WorkspaceRoot.FullName, "output", ".agents", "skills", "aspire", "SKILL.md");
@@ -2211,7 +2211,7 @@ public class NewCommandTests(ITestOutputHelper outputHelper)
 
         var exitCode = await result.InvokeAsync().DefaultTimeout();
 
-        Assert.Equal(ExitCodeConstants.Success, exitCode);
+        Assert.Equal(CliExitCodes.Success, exitCode);
 
         // Agent init should have run — default skill files should exist
         var skillPath = Path.Combine(workspace.WorkspaceRoot.FullName, "output", ".agents", "skills", "aspire", "SKILL.md");
@@ -2237,7 +2237,7 @@ public class NewCommandTests(ITestOutputHelper outputHelper)
 
         var exitCode = await result.InvokeAsync().DefaultTimeout();
 
-        Assert.Equal(ExitCodeConstants.Success, exitCode);
+        Assert.Equal(CliExitCodes.Success, exitCode);
 
         // Default is to run agent init
         var skillPath = Path.Combine(workspace.WorkspaceRoot.FullName, "output", ".agents", "skills", "aspire", "SKILL.md");
@@ -2268,7 +2268,7 @@ public class NewCommandTests(ITestOutputHelper outputHelper)
         var result = command.Parse($"new aspire-starter --name TestApp --output {existingDir.FullName} --use-redis-cache --test-framework None");
 
         var exitCode = await result.InvokeAsync().DefaultTimeout();
-        Assert.Equal(ExitCodeConstants.FailedToCreateNewProject, exitCode);
+        Assert.Equal(CliExitCodes.FailedToCreateNewProject, exitCode);
         Assert.NotNull(testInteractionService);
         var expectedError = string.Format(CultureInfo.CurrentCulture, NewCommandStrings.OutputDirectoryNotEmptyNonInteractive, existingDir.FullName);
         var e = Assert.Single(testInteractionService.DisplayedErrors);
@@ -2290,7 +2290,7 @@ public class NewCommandTests(ITestOutputHelper outputHelper)
         var result = command.Parse($"new aspire-starter --name TestApp --output {emptyDir.FullName} --use-redis-cache --test-framework None");
 
         var exitCode = await result.InvokeAsync().DefaultTimeout();
-        Assert.Equal(ExitCodeConstants.Success, exitCode);
+        Assert.Equal(CliExitCodes.Success, exitCode);
     }
 
     [Fact]
@@ -2325,7 +2325,7 @@ public class NewCommandTests(ITestOutputHelper outputHelper)
         var result = command.Parse("new aspire-starter --use-redis-cache --test-framework None");
 
         var exitCode = await result.InvokeAsync().DefaultTimeout();
-        Assert.Equal(ExitCodeConstants.Success, exitCode);
+        Assert.Equal(CliExitCodes.Success, exitCode);
         Assert.Equal("./aspire-starter-2", capturedDefaultPath);
     }
 
@@ -2350,7 +2350,7 @@ public class NewCommandTests(ITestOutputHelper outputHelper)
         var result = command.Parse($"new aspire-starter --name TestApp --output {invalidPath} --use-redis-cache --test-framework None");
 
         var exitCode = await result.InvokeAsync().DefaultTimeout();
-        Assert.Equal(ExitCodeConstants.FailedToCreateNewProject, exitCode);
+        Assert.Equal(CliExitCodes.FailedToCreateNewProject, exitCode);
         Assert.NotNull(testInteractionService);
         var expectedError = string.Format(CultureInfo.CurrentCulture, NewCommandStrings.OutputPathContainsInvalidCharacters, invalidPath);
         var e = Assert.Single(testInteractionService.DisplayedErrors);
@@ -2395,7 +2395,7 @@ public class NewCommandTests(ITestOutputHelper outputHelper)
         var result = command.Parse("new aspire-starter --name TestApp --output . --use-redis-cache --test-framework None");
 
         var exitCode = await result.InvokeAsync().DefaultTimeout();
-        Assert.Equal(ExitCodeConstants.Success, exitCode);
+        Assert.Equal(CliExitCodes.Success, exitCode);
         Assert.Equal(projectDir.FullName, capturedOutputPath);
     }
 
@@ -2455,7 +2455,7 @@ public class NewCommandTests(ITestOutputHelper outputHelper)
 
         var exitCode = await result.InvokeAsync().DefaultTimeout();
 
-        Assert.Equal(ExitCodeConstants.FailedToCreateNewProject, exitCode);
+        Assert.Equal(CliExitCodes.FailedToCreateNewProject, exitCode);
         Assert.Contains(interactionService.DisplayedErrors, e => e.Contains("simulated network failure", StringComparison.Ordinal));
     }
 }

--- a/tests/Aspire.Cli.Tests/Commands/PsCommandTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/PsCommandTests.cs
@@ -29,7 +29,7 @@ public class PsCommandTests(ITestOutputHelper outputHelper)
 
         var exitCode = await result.InvokeAsync().DefaultTimeout();
 
-        Assert.Equal(ExitCodeConstants.Success, exitCode);
+        Assert.Equal(CliExitCodes.Success, exitCode);
     }
 
     [Fact]
@@ -45,7 +45,7 @@ public class PsCommandTests(ITestOutputHelper outputHelper)
         var exitCode = await result.InvokeAsync().DefaultTimeout();
 
         // ps should succeed even with no running AppHosts (just shows empty list)
-        Assert.Equal(ExitCodeConstants.Success, exitCode);
+        Assert.Equal(CliExitCodes.Success, exitCode);
     }
 
     [Theory]
@@ -63,7 +63,7 @@ public class PsCommandTests(ITestOutputHelper outputHelper)
 
         var exitCode = await result.InvokeAsync().DefaultTimeout();
 
-        Assert.Equal(ExitCodeConstants.Success, exitCode);
+        Assert.Equal(CliExitCodes.Success, exitCode);
     }
 
     [Theory]
@@ -81,7 +81,7 @@ public class PsCommandTests(ITestOutputHelper outputHelper)
 
         var exitCode = await result.InvokeAsync().DefaultTimeout();
 
-        Assert.Equal(ExitCodeConstants.Success, exitCode);
+        Assert.Equal(CliExitCodes.Success, exitCode);
     }
 
     [Fact]
@@ -96,7 +96,7 @@ public class PsCommandTests(ITestOutputHelper outputHelper)
 
         var exitCode = await result.InvokeAsync().DefaultTimeout();
 
-        Assert.NotEqual(ExitCodeConstants.Success, exitCode);
+        Assert.NotEqual(CliExitCodes.Success, exitCode);
     }
 
     [Fact]
@@ -146,7 +146,7 @@ public class PsCommandTests(ITestOutputHelper outputHelper)
 
         var exitCode = await result.InvokeAsync().DefaultTimeout();
 
-        Assert.Equal(ExitCodeConstants.Success, exitCode);
+        Assert.Equal(CliExitCodes.Success, exitCode);
 
         var jsonOutput = string.Join(string.Empty, textWriter.Logs);
 
@@ -198,7 +198,7 @@ public class PsCommandTests(ITestOutputHelper outputHelper)
 
         var exitCode = await result.InvokeAsync().DefaultTimeout();
 
-        Assert.Equal(ExitCodeConstants.Success, exitCode);
+        Assert.Equal(CliExitCodes.Success, exitCode);
 
         var jsonOutput = string.Join(string.Empty, textWriter.Logs);
         using var document = JsonDocument.Parse(jsonOutput);
@@ -236,7 +236,7 @@ public class PsCommandTests(ITestOutputHelper outputHelper)
 
         var exitCode = await result.InvokeAsync().DefaultTimeout();
 
-        Assert.Equal(ExitCodeConstants.Success, exitCode);
+        Assert.Equal(CliExitCodes.Success, exitCode);
 
         var jsonOutput = string.Join(string.Empty, textWriter.Logs);
         using var document = JsonDocument.Parse(jsonOutput);
@@ -282,7 +282,7 @@ public class PsCommandTests(ITestOutputHelper outputHelper)
 
         var exitCode = await result.InvokeAsync().DefaultTimeout();
 
-        Assert.Equal(ExitCodeConstants.Success, exitCode);
+        Assert.Equal(CliExitCodes.Success, exitCode);
 
         var jsonOutput = string.Join(string.Empty, textWriter.Logs);
         using var document = JsonDocument.Parse(jsonOutput);
@@ -324,7 +324,7 @@ public class PsCommandTests(ITestOutputHelper outputHelper)
 
         var exitCode = await result.InvokeAsync().DefaultTimeout();
 
-        Assert.Equal(ExitCodeConstants.Success, exitCode);
+        Assert.Equal(CliExitCodes.Success, exitCode);
 
         var jsonOutput = string.Join(string.Empty, textWriter.Logs);
 
@@ -370,7 +370,7 @@ public class PsCommandTests(ITestOutputHelper outputHelper)
 
         var exitCode = await result.InvokeAsync().DefaultTimeout();
 
-        Assert.Equal(ExitCodeConstants.Success, exitCode);
+        Assert.Equal(CliExitCodes.Success, exitCode);
 
         var output = string.Join(Environment.NewLine, textWriter.Logs);
         var normalizedOutput = output.Replace(Environment.NewLine, string.Empty, StringComparison.Ordinal);
@@ -403,7 +403,7 @@ public class PsCommandTests(ITestOutputHelper outputHelper)
 
         var exitCode = await result.InvokeAsync().DefaultTimeout();
 
-        Assert.Equal(ExitCodeConstants.Success, exitCode);
+        Assert.Equal(CliExitCodes.Success, exitCode);
 
         var output = string.Join(Environment.NewLine, textWriter.Logs);
         var normalizedOutput = output.Replace(Environment.NewLine, string.Empty, StringComparison.Ordinal);
@@ -444,7 +444,7 @@ public class PsCommandTests(ITestOutputHelper outputHelper)
 
         var exitCode = await result.InvokeAsync().DefaultTimeout();
 
-        Assert.Equal(ExitCodeConstants.Success, exitCode);
+        Assert.Equal(CliExitCodes.Success, exitCode);
 
         var output = string.Join(Environment.NewLine, textWriter.Logs);
         Assert.Contains("SDK", output, StringComparison.Ordinal);
@@ -467,7 +467,7 @@ public class PsCommandTests(ITestOutputHelper outputHelper)
 
         var exitCode = await result.InvokeAsync().DefaultTimeout();
 
-        Assert.Equal(ExitCodeConstants.Success, exitCode);
+        Assert.Equal(CliExitCodes.Success, exitCode);
 
         var json = string.Join(string.Empty, textWriter.Logs);
         var document = JsonDocument.Parse(json);
@@ -533,7 +533,7 @@ public class PsCommandTests(ITestOutputHelper outputHelper)
 
         var exitCode = await result.InvokeAsync().DefaultTimeout();
 
-        Assert.Equal(ExitCodeConstants.Success, exitCode);
+        Assert.Equal(CliExitCodes.Success, exitCode);
 
         var jsonOutput = string.Join(string.Empty, textWriter.Logs);
         var appHosts = JsonSerializer.Deserialize(jsonOutput, PsCommandJsonContext.RelaxedEscaping.ListAppHostDisplayInfo);
@@ -595,7 +595,7 @@ public class PsCommandTests(ITestOutputHelper outputHelper)
 
         var exitCode = await result.InvokeAsync().DefaultTimeout();
 
-        Assert.Equal(ExitCodeConstants.Success, exitCode);
+        Assert.Equal(CliExitCodes.Success, exitCode);
 
         var jsonOutput = string.Join(string.Empty, textWriter.Logs);
         var appHosts = JsonSerializer.Deserialize(jsonOutput, PsCommandJsonContext.RelaxedEscaping.ListAppHostDisplayInfo);
@@ -649,8 +649,210 @@ public class PsCommandTests(ITestOutputHelper outputHelper)
 
         var exitCode = await result.InvokeAsync().DefaultTimeout();
 
-        Assert.Equal(ExitCodeConstants.Success, exitCode);
+        Assert.Equal(CliExitCodes.Success, exitCode);
         Assert.False(resourcesFetched, "Resources should not be fetched when output format is table");
+    }
+
+    [Fact]
+    public async Task PsCommand_JsonFormat_IncludesLogFilePath()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        var textWriter = new TestOutputTextWriter(outputHelper);
+
+        var monitor = new TestAuxiliaryBackchannelMonitor();
+        var connection = new TestAppHostAuxiliaryBackchannel
+        {
+            IsInScope = true,
+            AppHostInfo = new AppHostInformation
+            {
+                AppHostPath = Path.Combine(workspace.WorkspaceRoot.FullName, "App1", "App1.AppHost.csproj"),
+                ProcessId = 1234,
+                CliLogFilePath = "/logs/cli_20260516T120000_abcd1234.log"
+            }
+        };
+        monitor.AddConnection("hash1", "socket.hash1", connection);
+
+        var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper, options =>
+        {
+            options.OutputTextWriter = textWriter;
+            options.AuxiliaryBackchannelMonitorFactory = _ => monitor;
+        });
+        using var provider = services.BuildServiceProvider();
+
+        var command = provider.GetRequiredService<RootCommand>();
+        var result = command.Parse("ps --format json");
+
+        var exitCode = await result.InvokeAsync().DefaultTimeout();
+
+        Assert.Equal(CliExitCodes.Success, exitCode);
+
+        var jsonOutput = string.Join(string.Empty, textWriter.Logs);
+        var appHosts = JsonSerializer.Deserialize(jsonOutput, PsCommandJsonContext.RelaxedEscaping.ListAppHostDisplayInfo);
+        Assert.NotNull(appHosts);
+        Assert.Single(appHosts);
+        Assert.Equal("/logs/cli_20260516T120000_abcd1234.log", appHosts[0].LogFilePath);
+    }
+
+    [Fact]
+    public async Task PsCommand_JsonFormat_IncludesLogFilePath_FromV2Override()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        var textWriter = new TestOutputTextWriter(outputHelper);
+
+        var monitor = new TestAuxiliaryBackchannelMonitor();
+        var connection = new TestAppHostAuxiliaryBackchannel
+        {
+            IsInScope = true,
+            AppHostInfo = new AppHostInformation
+            {
+                AppHostPath = Path.Combine(workspace.WorkspaceRoot.FullName, "App1", "App1.AppHost.csproj"),
+                ProcessId = 1234,
+                CliLogFilePath = "/logs/v1_path.log"
+            },
+            AppHostInfoResponse = new GetAppHostInfoResponse
+            {
+                Pid = "1234",
+                AppHostPath = Path.Combine(workspace.WorkspaceRoot.FullName, "App1", "App1.AppHost.csproj"),
+                AspireHostVersion = "10.0.0",
+                CliLogFilePath = "/logs/v2_override_path.log"
+            }
+        };
+        monitor.AddConnection("hash1", "socket.hash1", connection);
+
+        var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper, options =>
+        {
+            options.OutputTextWriter = textWriter;
+            options.AuxiliaryBackchannelMonitorFactory = _ => monitor;
+        });
+        using var provider = services.BuildServiceProvider();
+
+        var command = provider.GetRequiredService<RootCommand>();
+        var result = command.Parse("ps --format json");
+
+        var exitCode = await result.InvokeAsync().DefaultTimeout();
+
+        Assert.Equal(CliExitCodes.Success, exitCode);
+
+        var jsonOutput = string.Join(string.Empty, textWriter.Logs);
+        var appHosts = JsonSerializer.Deserialize(jsonOutput, PsCommandJsonContext.RelaxedEscaping.ListAppHostDisplayInfo);
+        Assert.NotNull(appHosts);
+        Assert.Single(appHosts);
+        Assert.Equal("/logs/v2_override_path.log", appHosts[0].LogFilePath);
+    }
+
+    [Fact]
+    public async Task PsCommand_JsonFormat_OmitsLogFilePath_WhenNull()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        var textWriter = new TestOutputTextWriter(outputHelper);
+
+        var monitor = new TestAuxiliaryBackchannelMonitor();
+        var connection = new TestAppHostAuxiliaryBackchannel
+        {
+            IsInScope = true,
+            AppHostInfo = new AppHostInformation
+            {
+                AppHostPath = Path.Combine(workspace.WorkspaceRoot.FullName, "App1", "App1.AppHost.csproj"),
+                ProcessId = 1234
+            }
+        };
+        monitor.AddConnection("hash1", "socket.hash1", connection);
+
+        var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper, options =>
+        {
+            options.OutputTextWriter = textWriter;
+            options.AuxiliaryBackchannelMonitorFactory = _ => monitor;
+        });
+        using var provider = services.BuildServiceProvider();
+
+        var command = provider.GetRequiredService<RootCommand>();
+        var result = command.Parse("ps --format json");
+
+        var exitCode = await result.InvokeAsync().DefaultTimeout();
+
+        Assert.Equal(CliExitCodes.Success, exitCode);
+
+        var jsonOutput = string.Join(string.Empty, textWriter.Logs);
+        using var document = JsonDocument.Parse(jsonOutput);
+        var firstElement = document.RootElement[0];
+        Assert.False(firstElement.TryGetProperty("logFilePath", out _));
+    }
+
+    [Fact]
+    public async Task PsCommand_TableFormat_ShowsLogsColumn_WhenLogPathPresent()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        var textWriter = new TestOutputTextWriter(outputHelper);
+
+        var monitor = new TestAuxiliaryBackchannelMonitor();
+        var connection = new TestAppHostAuxiliaryBackchannel
+        {
+            IsInScope = true,
+            AppHostInfo = new AppHostInformation
+            {
+                AppHostPath = Path.Combine(workspace.WorkspaceRoot.FullName, "App1", "App1.AppHost.csproj"),
+                ProcessId = 1234,
+                CliLogFilePath = "/logs/cli_session.log"
+            }
+        };
+        monitor.AddConnection("hash1", "socket.hash1", connection);
+
+        var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper, options =>
+        {
+            options.OutputTextWriter = textWriter;
+            options.AuxiliaryBackchannelMonitorFactory = _ => monitor;
+            options.DisableAnsi = true;
+        });
+        using var provider = services.BuildServiceProvider();
+
+        var command = provider.GetRequiredService<RootCommand>();
+        var result = command.Parse("ps");
+
+        var exitCode = await result.InvokeAsync().DefaultTimeout();
+
+        Assert.Equal(CliExitCodes.Success, exitCode);
+
+        var output = string.Join(Environment.NewLine, textWriter.Logs);
+        Assert.Contains("Logs", output, StringComparison.Ordinal);
+        Assert.Contains("cli_session.log", output, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task PsCommand_TableFormat_HidesLogsColumn_WhenNoLogPathPresent()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        var textWriter = new TestOutputTextWriter(outputHelper);
+
+        var monitor = new TestAuxiliaryBackchannelMonitor();
+        var connection = new TestAppHostAuxiliaryBackchannel
+        {
+            IsInScope = true,
+            AppHostInfo = new AppHostInformation
+            {
+                AppHostPath = Path.Combine(workspace.WorkspaceRoot.FullName, "App1", "App1.AppHost.csproj"),
+                ProcessId = 1234
+            }
+        };
+        monitor.AddConnection("hash1", "socket.hash1", connection);
+
+        var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper, options =>
+        {
+            options.OutputTextWriter = textWriter;
+            options.AuxiliaryBackchannelMonitorFactory = _ => monitor;
+            options.DisableAnsi = true;
+        });
+        using var provider = services.BuildServiceProvider();
+
+        var command = provider.GetRequiredService<RootCommand>();
+        var result = command.Parse("ps");
+
+        var exitCode = await result.InvokeAsync().DefaultTimeout();
+
+        Assert.Equal(CliExitCodes.Success, exitCode);
+
+        var output = string.Join(Environment.NewLine, textWriter.Logs);
+        // "Logs" should not appear as a column header when no app host has a log path
+        Assert.DoesNotContain("Logs", output, StringComparison.Ordinal);
     }
 
     private sealed class TestAppHostBackchannelServer : IDisposable

--- a/tests/Aspire.Cli.Tests/Commands/PublishCommandTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/PublishCommandTests.cs
@@ -53,7 +53,7 @@ public class PublishCommandTests(ITestOutputHelper outputHelper)
         var exitCode = await result.InvokeAsync().DefaultTimeout();
 
         // Assert
-        Assert.Equal(ExitCodeConstants.FailedToFindProject, exitCode); // Ensure the command fails
+        Assert.Equal(CliExitCodes.FailedToFindProject, exitCode); // Ensure the command fails
     }
 
     [Fact]
@@ -84,7 +84,7 @@ public class PublishCommandTests(ITestOutputHelper outputHelper)
         var exitCode = await result.InvokeAsync().DefaultTimeout();
 
         // Assert
-        Assert.Equal(ExitCodeConstants.AppHostIncompatible, exitCode); // Ensure the command fails
+        Assert.Equal(CliExitCodes.AppHostIncompatible, exitCode); // Ensure the command fails
     }
 
     [Fact]
@@ -115,7 +115,7 @@ public class PublishCommandTests(ITestOutputHelper outputHelper)
         var exitCode = await result.InvokeAsync().DefaultTimeout();
 
         // Assert
-        Assert.Equal(ExitCodeConstants.FailedToBuildArtifacts, exitCode); // Ensure the command fails
+        Assert.Equal(CliExitCodes.FailedToBuildArtifacts, exitCode); // Ensure the command fails
     }
 
     [Fact]
@@ -158,7 +158,7 @@ public class PublishCommandTests(ITestOutputHelper outputHelper)
         var exitCode = await result.InvokeAsync().DefaultTimeout();
 
         // Assert
-        Assert.Equal(ExitCodeConstants.FailedToBuildArtifacts, exitCode); // Ensure the command fails
+        Assert.Equal(CliExitCodes.FailedToBuildArtifacts, exitCode); // Ensure the command fails
     }
 
     [Fact]

--- a/tests/Aspire.Cli.Tests/Commands/ResourceCommandHelperTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/ResourceCommandHelperTests.cs
@@ -211,7 +211,7 @@ public class ResourceCommandHelperTests
             arguments: null,
             cancellationToken: CancellationToken.None).DefaultTimeout();
 
-        Assert.Equal(ExitCodeConstants.FailedToExecuteResourceCommand, exitCode);
+        Assert.Equal(CliExitCodes.FailedToExecuteResourceCommand, exitCode);
         var error = Assert.Single(interactionService.DisplayedErrors);
         Assert.Contains("Command argument validation failed.", error);
         Assert.Contains("--target: Target must not be prod.", error);
@@ -241,7 +241,7 @@ public class ResourceCommandHelperTests
             arguments: null,
             cancellationToken: CancellationToken.None).DefaultTimeout();
 
-        Assert.Equal(ExitCodeConstants.FailedToExecuteResourceCommand, exitCode);
+        Assert.Equal(CliExitCodes.FailedToExecuteResourceCommand, exitCode);
         var error = Assert.Single(interactionService.DisplayedErrors);
         Assert.Contains("Failed to execute command 'ss' on resource 'test-resource'", error);
         Assert.Contains("Command 'ss' not available for resource 'test-resource'.", error);

--- a/tests/Aspire.Cli.Tests/Commands/ResourceCommandTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/ResourceCommandTests.cs
@@ -1,11 +1,13 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Globalization;
 using System.Text.Json;
 using System.Text.Json.Nodes;
 using Aspire.Cli.Backchannel;
 using Aspire.Cli.Commands;
 using Aspire.Cli.Projects;
+using Aspire.Cli.Resources;
 using Aspire.Cli.Tests.TestServices;
 using Aspire.Cli.Tests.Utils;
 using Microsoft.AspNetCore.InternalTesting;
@@ -28,7 +30,7 @@ public class ResourceCommandTests(ITestOutputHelper outputHelper)
 
         var exitCode = await result.InvokeAsync().DefaultTimeout();
 
-        Assert.Equal(ExitCodeConstants.Success, exitCode);
+        Assert.Equal(CliExitCodes.Success, exitCode);
     }
 
     [Fact]
@@ -60,7 +62,7 @@ public class ResourceCommandTests(ITestOutputHelper outputHelper)
 
         var exitCode = await result.InvokeAsync(new InvocationConfiguration { Output = helpWriter }).DefaultTimeout();
 
-        Assert.Equal(ExitCodeConstants.Success, exitCode);
+        Assert.Equal(CliExitCodes.Success, exitCode);
         await Verify(helpWriter.ToString(), extension: "txt");
     }
 
@@ -91,7 +93,7 @@ public class ResourceCommandTests(ITestOutputHelper outputHelper)
 
         var exitCode = await result.InvokeAsync(new InvocationConfiguration { Output = helpWriter }).DefaultTimeout();
 
-        Assert.Equal(ExitCodeConstants.Success, exitCode);
+        Assert.Equal(CliExitCodes.Success, exitCode);
         await Verify(helpWriter.ToString(), extension: "txt");
     }
 
@@ -117,7 +119,7 @@ public class ResourceCommandTests(ITestOutputHelper outputHelper)
         var exitCode = await result.InvokeAsync(new InvocationConfiguration { Output = helpWriter }).DefaultTimeout();
         var helpOutput = helpWriter.ToString();
 
-        Assert.Equal(ExitCodeConstants.Success, exitCode);
+        Assert.Equal(CliExitCodes.Success, exitCode);
         Assert.Contains("Execute a command on a resource", helpOutput);
         Assert.DoesNotContain("Available resource commands:", helpOutput);
     }
@@ -140,7 +142,7 @@ public class ResourceCommandTests(ITestOutputHelper outputHelper)
         var exitCode = await result.InvokeAsync(new InvocationConfiguration { Output = helpWriter }).DefaultTimeout();
         var helpOutput = helpWriter.ToString();
 
-        Assert.Equal(ExitCodeConstants.Success, exitCode);
+        Assert.Equal(CliExitCodes.Success, exitCode);
         Assert.Contains("Execute a command on a resource", helpOutput);
         Assert.DoesNotContain("Available resource commands:", helpOutput);
     }
@@ -181,7 +183,7 @@ public class ResourceCommandTests(ITestOutputHelper outputHelper)
         var exitCode = await result.InvokeAsync(new InvocationConfiguration { Output = helpWriter }).DefaultTimeout();
         var helpOutput = helpWriter.ToString();
 
-        Assert.Equal(ExitCodeConstants.Success, exitCode);
+        Assert.Equal(CliExitCodes.Success, exitCode);
         Assert.False(prompted);
         Assert.Contains("Execute a command on a resource", helpOutput);
         Assert.DoesNotContain("Available resource commands:", helpOutput);
@@ -230,7 +232,7 @@ public class ResourceCommandTests(ITestOutputHelper outputHelper)
         var exitCode = await result.InvokeAsync(new InvocationConfiguration { Output = helpWriter }).DefaultTimeout();
         var helpOutput = helpWriter.ToString();
 
-        Assert.Equal(ExitCodeConstants.Success, exitCode);
+        Assert.Equal(CliExitCodes.Success, exitCode);
         Assert.False(prompted);
         Assert.Contains("Execute a command on a resource", helpOutput);
         Assert.DoesNotContain("Available resource commands:", helpOutput);
@@ -259,7 +261,7 @@ public class ResourceCommandTests(ITestOutputHelper outputHelper)
 
         var exitCode = await result.InvokeAsync(new InvocationConfiguration { Output = helpWriter }).DefaultTimeout();
 
-        Assert.Equal(ExitCodeConstants.Success, exitCode);
+        Assert.Equal(CliExitCodes.Success, exitCode);
         await Verify(helpWriter.ToString(), extension: "txt");
     }
 
@@ -277,7 +279,7 @@ public class ResourceCommandTests(ITestOutputHelper outputHelper)
         Assert.Equal("The 'resource' argument is required.", error.Message);
 
         var exitCode = await result.InvokeAsync().DefaultTimeout();
-        Assert.NotEqual(ExitCodeConstants.Success, exitCode);
+        Assert.NotEqual(CliExitCodes.Success, exitCode);
     }
 
     [Theory]
@@ -296,7 +298,7 @@ public class ResourceCommandTests(ITestOutputHelper outputHelper)
         Assert.Equal("The 'resource' argument is required.", error.Message);
 
         var exitCode = await result.InvokeAsync().DefaultTimeout();
-        Assert.NotEqual(ExitCodeConstants.Success, exitCode);
+        Assert.NotEqual(CliExitCodes.Success, exitCode);
     }
 
     [Fact]
@@ -313,7 +315,7 @@ public class ResourceCommandTests(ITestOutputHelper outputHelper)
         Assert.Equal("The 'command' argument is required.", error.Message);
 
         var exitCode = await result.InvokeAsync().DefaultTimeout();
-        Assert.NotEqual(ExitCodeConstants.Success, exitCode);
+        Assert.NotEqual(CliExitCodes.Success, exitCode);
     }
 
     [Theory]
@@ -333,7 +335,7 @@ public class ResourceCommandTests(ITestOutputHelper outputHelper)
         Assert.Equal("The 'command' argument is required.", error.Message);
 
         var exitCode = await result.InvokeAsync().DefaultTimeout();
-        Assert.NotEqual(ExitCodeConstants.Success, exitCode);
+        Assert.NotEqual(CliExitCodes.Success, exitCode);
     }
 
     [Fact]
@@ -347,7 +349,7 @@ public class ResourceCommandTests(ITestOutputHelper outputHelper)
         var result = command.Parse("resource myresource my-command --help");
 
         var exitCode = await result.InvokeAsync().DefaultTimeout();
-        Assert.Equal(ExitCodeConstants.Success, exitCode);
+        Assert.Equal(CliExitCodes.Success, exitCode);
     }
 
     [Fact]
@@ -361,7 +363,7 @@ public class ResourceCommandTests(ITestOutputHelper outputHelper)
         var result = command.Parse("resource myresource my-command --apphost /path/to/project.csproj --help");
 
         var exitCode = await result.InvokeAsync().DefaultTimeout();
-        Assert.Equal(ExitCodeConstants.Success, exitCode);
+        Assert.Equal(CliExitCodes.Success, exitCode);
     }
 
     [Theory]
@@ -384,7 +386,7 @@ public class ResourceCommandTests(ITestOutputHelper outputHelper)
 
         var exitCode = await result.InvokeAsync().DefaultTimeout();
 
-        Assert.Equal(ExitCodeConstants.Success, exitCode);
+        Assert.Equal(CliExitCodes.Success, exitCode);
     }
 
     [Theory]
@@ -416,7 +418,7 @@ public class ResourceCommandTests(ITestOutputHelper outputHelper)
 
         var exitCode = await result.InvokeAsync().DefaultTimeout();
 
-        Assert.Equal(ExitCodeConstants.Success, exitCode);
+        Assert.Equal(CliExitCodes.Success, exitCode);
         Assert.Equal(1, backchannel.ExecuteResourceCommandCallCount);
         Assert.Collection(
             statuses,
@@ -436,7 +438,7 @@ public class ResourceCommandTests(ITestOutputHelper outputHelper)
         var result = command.Parse("resource myresource start --apphost /path/to/project.csproj --help");
 
         var exitCode = await result.InvokeAsync().DefaultTimeout();
-        Assert.Equal(ExitCodeConstants.Success, exitCode);
+        Assert.Equal(CliExitCodes.Success, exitCode);
     }
 
     [Fact]
@@ -460,7 +462,7 @@ public class ResourceCommandTests(ITestOutputHelper outputHelper)
 
         var exitCode = await result.InvokeAsync().DefaultTimeout();
 
-        Assert.Equal(ExitCodeConstants.Success, exitCode);
+        Assert.Equal(CliExitCodes.Success, exitCode);
         Assert.Equal(1, backchannel.ExecuteResourceCommandCallCount);
         Assert.Contains("Executing command 'Start' on resource 'myresource'...", statuses);
     }
@@ -497,7 +499,7 @@ public class ResourceCommandTests(ITestOutputHelper outputHelper)
 
         var exitCode = await result.InvokeAsync().DefaultTimeout();
 
-        Assert.Equal(ExitCodeConstants.InvalidCommand, exitCode);
+        Assert.Equal(CliExitCodes.InvalidCommand, exitCode);
         Assert.Equal(0, backchannel.ExecuteResourceCommandCallCount);
     }
 
@@ -524,7 +526,7 @@ public class ResourceCommandTests(ITestOutputHelper outputHelper)
 
         var exitCode = await result.InvokeAsync().DefaultTimeout();
 
-        Assert.Equal(ExitCodeConstants.Success, exitCode);
+        Assert.Equal(CliExitCodes.Success, exitCode);
         Assert.Null(backchannel.ExecuteResourceCommandArguments);
         Assert.True(backchannel.ExecuteResourceCommandOptions?.NonInteractive == true);
     }
@@ -561,7 +563,7 @@ public class ResourceCommandTests(ITestOutputHelper outputHelper)
 
         var exitCode = await result.InvokeAsync().DefaultTimeout();
 
-        Assert.Equal(ExitCodeConstants.Success, exitCode);
+        Assert.Equal(CliExitCodes.Success, exitCode);
         AssertJsonObject(backchannel.ExecuteResourceCommandArguments, ("text", "Submitted Aspire!"), ("timeoutMilliseconds", "500"));
     }
 
@@ -596,7 +598,7 @@ public class ResourceCommandTests(ITestOutputHelper outputHelper)
 
         var exitCode = await result.InvokeAsync().DefaultTimeout();
 
-        Assert.Equal(ExitCodeConstants.Success, exitCode);
+        Assert.Equal(CliExitCodes.Success, exitCode);
         AssertJsonObject(backchannel.ExecuteResourceCommandArguments, ("Value", "Hello world"));
     }
 
@@ -629,7 +631,7 @@ public class ResourceCommandTests(ITestOutputHelper outputHelper)
 
         var exitCode = await result.InvokeAsync().DefaultTimeout();
 
-        Assert.Equal(ExitCodeConstants.InvalidCommand, exitCode);
+        Assert.Equal(CliExitCodes.InvalidCommand, exitCode);
         Assert.Equal(0, backchannel.ExecuteResourceCommandCallCount);
     }
 
@@ -656,7 +658,7 @@ public class ResourceCommandTests(ITestOutputHelper outputHelper)
 
         var exitCode = await result.InvokeAsync().DefaultTimeout();
 
-        Assert.Equal(ExitCodeConstants.Success, exitCode);
+        Assert.Equal(CliExitCodes.Success, exitCode);
         AssertJsonObject(backchannel.ExecuteResourceCommandArguments, ("https://example.com/?q=aspire", null));
     }
 
@@ -683,7 +685,7 @@ public class ResourceCommandTests(ITestOutputHelper outputHelper)
 
         var exitCode = await result.InvokeAsync().DefaultTimeout();
 
-        Assert.Equal(ExitCodeConstants.Success, exitCode);
+        Assert.Equal(CliExitCodes.Success, exitCode);
         AssertJsonObject(backchannel.ExecuteResourceCommandArguments, ("#submit", null), ("extra", null));
     }
 
@@ -710,7 +712,7 @@ public class ResourceCommandTests(ITestOutputHelper outputHelper)
 
         var exitCode = await result.InvokeAsync().DefaultTimeout();
 
-        Assert.Equal(ExitCodeConstants.Success, exitCode);
+        Assert.Equal(CliExitCodes.Success, exitCode);
         AssertJsonObject(backchannel.ExecuteResourceCommandArguments, ("--selector #submit", null), ("--count 2", null));
     }
 
@@ -737,7 +739,7 @@ public class ResourceCommandTests(ITestOutputHelper outputHelper)
 
         var exitCode = await result.InvokeAsync().DefaultTimeout();
 
-        Assert.Equal(ExitCodeConstants.Success, exitCode);
+        Assert.Equal(CliExitCodes.Success, exitCode);
         AssertJsonObject(backchannel.ExecuteResourceCommandArguments, ("--verbose", null));
     }
 
@@ -757,7 +759,7 @@ public class ResourceCommandTests(ITestOutputHelper outputHelper)
 
         var exitCode = await result.InvokeAsync().DefaultTimeout();
 
-        Assert.Equal(ExitCodeConstants.Success, exitCode);
+        Assert.Equal(CliExitCodes.Success, exitCode);
         AssertJsonObject(backchannel.ExecuteResourceCommandArguments, ("--selector #submit", null));
     }
 
@@ -793,7 +795,7 @@ public class ResourceCommandTests(ITestOutputHelper outputHelper)
 
         var exitCode = await result.InvokeAsync().DefaultTimeout();
 
-        Assert.Equal(ExitCodeConstants.Success, exitCode);
+        Assert.Equal(CliExitCodes.Success, exitCode);
         AssertJsonObject(backchannel.ExecuteResourceCommandArguments, ("timeoutMilliseconds", "500"));
     }
 
@@ -821,7 +823,7 @@ public class ResourceCommandTests(ITestOutputHelper outputHelper)
 
         var exitCode = await result.InvokeAsync().DefaultTimeout();
 
-        Assert.Equal(ExitCodeConstants.Success, exitCode);
+        Assert.Equal(CliExitCodes.Success, exitCode);
         AssertJsonObject(backchannel.ExecuteResourceCommandArguments, ("--message hello", null));
     }
 
@@ -857,7 +859,7 @@ public class ResourceCommandTests(ITestOutputHelper outputHelper)
 
         var exitCode = await result.InvokeAsync().DefaultTimeout();
 
-        Assert.Equal(ExitCodeConstants.Success, exitCode);
+        Assert.Equal(CliExitCodes.Success, exitCode);
         AssertJsonObject(backchannel.ExecuteResourceCommandArguments, ("timeoutMilliseconds", "500"), ("proxy", "true"));
     }
 
@@ -888,7 +890,7 @@ public class ResourceCommandTests(ITestOutputHelper outputHelper)
 
         var exitCode = await result.InvokeAsync().DefaultTimeout();
 
-        Assert.Equal(ExitCodeConstants.Success, exitCode);
+        Assert.Equal(CliExitCodes.Success, exitCode);
         AssertJsonObject(backchannel.ExecuteResourceCommandArguments, ("proxy", expectedValue));
     }
 
@@ -923,7 +925,7 @@ public class ResourceCommandTests(ITestOutputHelper outputHelper)
 
         var exitCode = await result.InvokeAsync().DefaultTimeout();
 
-        Assert.Equal(ExitCodeConstants.Success, exitCode);
+        Assert.Equal(CliExitCodes.Success, exitCode);
         AssertJsonObject(backchannel.ExecuteResourceCommandArguments, ("flavor", "chocolate"));
     }
 
@@ -959,7 +961,7 @@ public class ResourceCommandTests(ITestOutputHelper outputHelper)
 
         var exitCode = await result.InvokeAsync().DefaultTimeout();
 
-        Assert.Equal(ExitCodeConstants.InvalidCommand, exitCode);
+        Assert.Equal(CliExitCodes.InvalidCommand, exitCode);
         Assert.Equal(0, backchannel.ExecuteResourceCommandCallCount);
         var error = Assert.Single(interactionService.DisplayedErrors);
         Assert.Contains("--flavor", error);
@@ -989,7 +991,7 @@ public class ResourceCommandTests(ITestOutputHelper outputHelper)
 
         var exitCode = await result.InvokeAsync().DefaultTimeout();
 
-        Assert.Equal(ExitCodeConstants.InvalidCommand, exitCode);
+        Assert.Equal(CliExitCodes.InvalidCommand, exitCode);
         Assert.Equal(0, backchannel.ExecuteResourceCommandCallCount);
         var error = Assert.Single(interactionService.DisplayedErrors);
         Assert.Equal("Unrecognized command option '--unknown value'.", error);
@@ -1015,7 +1017,7 @@ public class ResourceCommandTests(ITestOutputHelper outputHelper)
 
         var exitCode = await result.InvokeAsync().DefaultTimeout();
 
-        Assert.Equal(ExitCodeConstants.Success, exitCode);
+        Assert.Equal(CliExitCodes.Success, exitCode);
         AssertJsonObject(backchannel.ExecuteResourceCommandArguments, ("--mm ss", null));
     }
 
@@ -1042,7 +1044,7 @@ public class ResourceCommandTests(ITestOutputHelper outputHelper)
 
         var exitCode = await result.InvokeAsync().DefaultTimeout();
 
-        Assert.Equal(ExitCodeConstants.InvalidCommand, exitCode);
+        Assert.Equal(CliExitCodes.InvalidCommand, exitCode);
         Assert.Equal(0, backchannel.ExecuteResourceCommandCallCount);
         var error = Assert.Single(interactionService.DisplayedErrors);
         Assert.Contains("maybe", error);
@@ -1071,7 +1073,7 @@ public class ResourceCommandTests(ITestOutputHelper outputHelper)
 
         var exitCode = await result.InvokeAsync().DefaultTimeout();
 
-        Assert.Equal(ExitCodeConstants.InvalidCommand, exitCode);
+        Assert.Equal(CliExitCodes.InvalidCommand, exitCode);
         Assert.Equal(0, backchannel.ExecuteResourceCommandCallCount);
         Assert.Equal("Option '--save-to-user-secrets' is disabled.", Assert.Single(interactionService.DisplayedErrors));
     }
@@ -1111,10 +1113,48 @@ public class ResourceCommandTests(ITestOutputHelper outputHelper)
 
         var exitCode = await result.InvokeAsync().DefaultTimeout();
 
-        Assert.Equal(ExitCodeConstants.FailedToExecuteResourceCommand, exitCode);
+        Assert.Equal(CliExitCodes.FailedToExecuteResourceCommand, exitCode);
         var error = Assert.Single(interactionService.DisplayedErrors);
         Assert.Contains("--timeout-seconds: Value must be greater than 0.", error);
         Assert.DoesNotContain("timeoutSeconds:", error);
+    }
+
+    [Fact]
+    public async Task ResourceCommand_FailedExecution_DisplaysAppHostCliLogFilePath()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        var interactionService = new TestInteractionService();
+
+        var backchannel = new TestAppHostAuxiliaryBackchannel
+        {
+            AppHostInfo = new AppHostInformation
+            {
+                AppHostPath = "/app/AppHost.csproj",
+                ProcessId = 42,
+                CliLogFilePath = "/tmp/aspire-logs/cli_apphost_20260516.log"
+            },
+            ExecuteResourceCommandResult = new ExecuteResourceCommandResponse
+            {
+                Success = false,
+                Message = "Something went wrong."
+            }
+        };
+        await using var provider = CreateServiceProvider(workspace, outputHelper, backchannel, interactionService);
+
+        var command = provider.GetRequiredService<RootCommand>();
+        var result = command.Parse("resource myresource my-command");
+
+        var exitCode = await result.InvokeAsync().DefaultTimeout();
+
+        Assert.Equal(CliExitCodes.FailedToExecuteResourceCommand, exitCode);
+
+        var executionContext = provider.GetRequiredService<CliExecutionContext>();
+        var expectedCliLogMessage = string.Format(CultureInfo.CurrentCulture, InteractionServiceStrings.SeeLogsAt, executionContext.LogFilePath);
+        var expectedAppHostLogMessage = string.Format(CultureInfo.CurrentCulture, InteractionServiceStrings.SeeAppHostLogsAt, "/tmp/aspire-logs/cli_apphost_20260516.log");
+
+        // Verify both the CLI log path and app host log path are displayed when the command fails
+        Assert.Contains(interactionService.DisplayedMessages, m => m.Message == expectedCliLogMessage);
+        Assert.Contains(interactionService.DisplayedMessages, m => m.Message == expectedAppHostLogMessage);
     }
 
     [Fact]
@@ -1175,7 +1215,7 @@ public class ResourceCommandTests(ITestOutputHelper outputHelper)
 
         var exitCode = await result.InvokeAsync().DefaultTimeout();
 
-        Assert.Equal(ExitCodeConstants.Success, exitCode);
+        Assert.Equal(CliExitCodes.Success, exitCode);
         AssertJsonObject(backchannel.ExecuteResourceCommandArguments, ("flavor", "strawberry"));
     }
 
@@ -1205,7 +1245,7 @@ public class ResourceCommandTests(ITestOutputHelper outputHelper)
 
         var exitCode = await result.InvokeAsync().DefaultTimeout();
 
-        Assert.Equal(ExitCodeConstants.Success, exitCode);
+        Assert.Equal(CliExitCodes.Success, exitCode);
         AssertJsonObject(backchannel.ExecuteResourceCommandArguments);
     }
 
@@ -1238,7 +1278,7 @@ public class ResourceCommandTests(ITestOutputHelper outputHelper)
 
         var exitCode = await result.InvokeAsync().DefaultTimeout();
 
-        Assert.Equal(ExitCodeConstants.InvalidCommand, exitCode);
+        Assert.Equal(CliExitCodes.InvalidCommand, exitCode);
         Assert.Equal(0, backchannel.ExecuteResourceCommandCallCount);
         var error = Assert.Single(interactionService.DisplayedErrors);
         Assert.Contains(expectedOptionName, error);
@@ -1267,7 +1307,7 @@ public class ResourceCommandTests(ITestOutputHelper outputHelper)
 
         var exitCode = await result.InvokeAsync().DefaultTimeout();
 
-        Assert.Equal(ExitCodeConstants.InvalidCommand, exitCode);
+        Assert.Equal(CliExitCodes.InvalidCommand, exitCode);
         Assert.Equal(0, backchannel.ExecuteResourceCommandCallCount);
         var error = Assert.Single(interactionService.DisplayedErrors);
         Assert.Contains("--timeoutMilliseconds", error);
@@ -1296,7 +1336,7 @@ public class ResourceCommandTests(ITestOutputHelper outputHelper)
 
         var exitCode = await result.InvokeAsync().DefaultTimeout();
 
-        Assert.Equal(ExitCodeConstants.InvalidCommand, exitCode);
+        Assert.Equal(CliExitCodes.InvalidCommand, exitCode);
         Assert.Equal(0, backchannel.ExecuteResourceCommandCallCount);
     }
 
@@ -1326,7 +1366,7 @@ public class ResourceCommandTests(ITestOutputHelper outputHelper)
 
         var exitCode = await result.InvokeAsync().DefaultTimeout();
 
-        Assert.Equal(ExitCodeConstants.InvalidCommand, exitCode);
+        Assert.Equal(CliExitCodes.InvalidCommand, exitCode);
         Assert.Equal(0, backchannel.ExecuteResourceCommandCallCount);
         var error = Assert.Single(interactionService.DisplayedErrors);
         Assert.Contains("--selector", error);
@@ -1358,7 +1398,7 @@ public class ResourceCommandTests(ITestOutputHelper outputHelper)
 
         var exitCode = await result.InvokeAsync().DefaultTimeout();
 
-        Assert.Equal(ExitCodeConstants.InvalidCommand, exitCode);
+        Assert.Equal(CliExitCodes.InvalidCommand, exitCode);
         Assert.Equal(0, backchannel.ExecuteResourceCommandCallCount);
         var error = Assert.Single(interactionService.DisplayedErrors);
         Assert.Contains("--selector", error);
@@ -1396,7 +1436,7 @@ public class ResourceCommandTests(ITestOutputHelper outputHelper)
 
         var exitCode = await result.InvokeAsync().DefaultTimeout();
 
-        Assert.Equal(ExitCodeConstants.InvalidCommand, exitCode);
+        Assert.Equal(CliExitCodes.InvalidCommand, exitCode);
         Assert.Equal(0, backchannel.ExecuteResourceCommandCallCount);
     }
 
@@ -1432,7 +1472,7 @@ public class ResourceCommandTests(ITestOutputHelper outputHelper)
 
         var exitCode = await result.InvokeAsync().DefaultTimeout();
 
-        Assert.Equal(ExitCodeConstants.InvalidCommand, exitCode);
+        Assert.Equal(CliExitCodes.InvalidCommand, exitCode);
         Assert.Equal(0, backchannel.ExecuteResourceCommandCallCount);
     }
 
@@ -1467,7 +1507,7 @@ public class ResourceCommandTests(ITestOutputHelper outputHelper)
 
         var exitCode = await result.InvokeAsync().DefaultTimeout();
 
-        Assert.Equal(ExitCodeConstants.Success, exitCode);
+        Assert.Equal(CliExitCodes.Success, exitCode);
         AssertJsonObject(backchannel.ExecuteResourceCommandArguments, ("logLevel", "Debug"));
     }
 
@@ -1496,7 +1536,7 @@ public class ResourceCommandTests(ITestOutputHelper outputHelper)
 
         var exitCode = await result.InvokeAsync().DefaultTimeout();
 
-        Assert.Equal(ExitCodeConstants.Success, exitCode);
+        Assert.Equal(CliExitCodes.Success, exitCode);
         AssertJsonObject(backchannel.ExecuteResourceCommandArguments, ("message", "from delimiter"), ("timeoutMilliseconds", "10"));
     }
 
@@ -1525,7 +1565,7 @@ public class ResourceCommandTests(ITestOutputHelper outputHelper)
 
         var exitCode = await result.InvokeAsync().DefaultTimeout();
 
-        Assert.Equal(ExitCodeConstants.Success, exitCode);
+        Assert.Equal(CliExitCodes.Success, exitCode);
         Assert.Equal(1, backchannel.ExecuteResourceCommandCallCount);
         AssertJsonObject(backchannel.ExecuteResourceCommandArguments, ("message", "from hidden resource"));
     }
@@ -1554,7 +1594,7 @@ public class ResourceCommandTests(ITestOutputHelper outputHelper)
 
         var exitCode = await result.InvokeAsync().DefaultTimeout();
 
-        Assert.Equal(ExitCodeConstants.Success, exitCode);
+        Assert.Equal(CliExitCodes.Success, exitCode);
         AssertJsonObject(backchannel.ExecuteResourceCommandArguments);
     }
 
@@ -1589,7 +1629,7 @@ public class ResourceCommandTests(ITestOutputHelper outputHelper)
 
         var exitCode = await result.InvokeAsync().DefaultTimeout();
 
-        Assert.Equal(ExitCodeConstants.Success, exitCode);
+        Assert.Equal(CliExitCodes.Success, exitCode);
         AssertJsonObject(backchannel.ExecuteResourceCommandArguments, ("noProxy", "localhost"));
     }
 
@@ -1624,7 +1664,7 @@ public class ResourceCommandTests(ITestOutputHelper outputHelper)
 
         var exitCode = await result.InvokeAsync().DefaultTimeout();
 
-        Assert.Equal(ExitCodeConstants.InvalidCommand, exitCode);
+        Assert.Equal(CliExitCodes.InvalidCommand, exitCode);
         Assert.Equal(0, backchannel.ExecuteResourceCommandCallCount);
     }
 
@@ -1642,7 +1682,7 @@ public class ResourceCommandTests(ITestOutputHelper outputHelper)
         var exitCode = await result.InvokeAsync(new InvocationConfiguration { Output = helpWriter }).DefaultTimeout();
         var helpOutput = helpWriter.ToString();
 
-        Assert.Equal(ExitCodeConstants.Success, exitCode);
+        Assert.Equal(CliExitCodes.Success, exitCode);
         Assert.Contains("Execute a command on a resource", helpOutput);
         Assert.Contains("resource <resource> <command>", helpOutput);
     }
@@ -1681,7 +1721,7 @@ public class ResourceCommandTests(ITestOutputHelper outputHelper)
         var exitCode = await result.InvokeAsync(new InvocationConfiguration { Output = helpWriter }).DefaultTimeout();
         var helpOutput = helpWriter.ToString();
 
-        Assert.Equal(ExitCodeConstants.Success, exitCode);
+        Assert.Equal(CliExitCodes.Success, exitCode);
         Assert.Contains("Waits for text in the browser.", helpOutput);
         Assert.Contains("--selector <value>", helpOutput);
         Assert.Contains("Selector to wait for. Required.", helpOutput);
@@ -1715,7 +1755,7 @@ public class ResourceCommandTests(ITestOutputHelper outputHelper)
         var exitCode = await result.InvokeAsync(new InvocationConfiguration { Output = helpWriter }).DefaultTimeout();
         var helpOutput = helpWriter.ToString();
 
-        Assert.Equal(ExitCodeConstants.Success, exitCode);
+        Assert.Equal(CliExitCodes.Success, exitCode);
         Assert.Equal(0, backchannel.ExecuteResourceCommandCallCount);
         Assert.Contains("Waits for text in the browser.", helpOutput);
         Assert.Contains("--selector <value>", helpOutput);
@@ -1744,7 +1784,7 @@ public class ResourceCommandTests(ITestOutputHelper outputHelper)
 
         var exitCode = await result.InvokeAsync(new InvocationConfiguration { Output = helpWriter }).DefaultTimeout();
 
-        Assert.Equal(ExitCodeConstants.Success, exitCode);
+        Assert.Equal(CliExitCodes.Success, exitCode);
         Assert.Equal(1, backchannel.ExecuteResourceCommandCallCount);
         Assert.DoesNotContain("Usage:", helpWriter.ToString());
         AssertJsonObject(backchannel.ExecuteResourceCommandArguments, ("--help", null));
@@ -1783,7 +1823,7 @@ public class ResourceCommandTests(ITestOutputHelper outputHelper)
         var exitCode = await result.InvokeAsync(new InvocationConfiguration { Output = helpWriter }).DefaultTimeout();
         var helpOutput = helpWriter.ToString();
 
-        Assert.Equal(ExitCodeConstants.Success, exitCode);
+        Assert.Equal(CliExitCodes.Success, exitCode);
         Assert.Contains("aspire resource web-browser-automation configure [options] [[--] <command-options>...]", helpOutput);
         Assert.Contains("--log-level <value>", helpOutput);
         Assert.Contains("Log level for the resource command.", helpOutput);
@@ -1813,7 +1853,7 @@ public class ResourceCommandTests(ITestOutputHelper outputHelper)
         var exitCode = await result.InvokeAsync(new InvocationConfiguration { Output = helpWriter }).DefaultTimeout();
         var helpOutput = helpWriter.ToString();
 
-        Assert.Equal(ExitCodeConstants.Success, exitCode);
+        Assert.Equal(CliExitCodes.Success, exitCode);
         Assert.Contains("--apphost <apphost>", helpOutput);
         Assert.Contains("-?, -h, /?, /h, --help", helpOutput);
         Assert.Contains("-l, --log-level <log-level>", helpOutput);
@@ -1850,7 +1890,7 @@ public class ResourceCommandTests(ITestOutputHelper outputHelper)
         var exitCode = await result.InvokeAsync(new InvocationConfiguration { Output = helpWriter }).DefaultTimeout();
         var helpOutput = helpWriter.ToString();
 
-        Assert.Equal(ExitCodeConstants.Success, exitCode);
+        Assert.Equal(CliExitCodes.Success, exitCode);
         Assert.Contains("--count <value>", helpOutput);
         Assert.Contains("Count value. Default: 5.", helpOutput);
         Assert.DoesNotContain("Count value. Required.", helpOutput);
@@ -1871,7 +1911,7 @@ public class ResourceCommandTests(ITestOutputHelper outputHelper)
         var exitCode = await result.InvokeAsync(new InvocationConfiguration { Output = helpWriter }).DefaultTimeout();
         var helpOutput = helpWriter.ToString();
 
-        Assert.Equal(ExitCodeConstants.Success, exitCode);
+        Assert.Equal(CliExitCodes.Success, exitCode);
         Assert.Contains("Usage:", helpOutput);
         Assert.DoesNotContain("Command options:", helpOutput);
     }
@@ -1897,7 +1937,7 @@ public class ResourceCommandTests(ITestOutputHelper outputHelper)
         var exitCode = await result.InvokeAsync(new InvocationConfiguration { Output = helpWriter }).DefaultTimeout();
         var helpOutput = helpWriter.ToString();
 
-        Assert.Equal(ExitCodeConstants.Success, exitCode);
+        Assert.Equal(CliExitCodes.Success, exitCode);
         Assert.Contains("Usage:", helpOutput);
         Assert.DoesNotContain("Command options:", helpOutput);
     }
@@ -1947,7 +1987,7 @@ public class ResourceCommandTests(ITestOutputHelper outputHelper)
 
         var exitCode = await result.InvokeAsync(new InvocationConfiguration { Output = helpWriter }).DefaultTimeout();
 
-        Assert.Equal(ExitCodeConstants.Success, exitCode);
+        Assert.Equal(CliExitCodes.Success, exitCode);
         await Verify(helpWriter.ToString(), extension: "txt");
     }
 

--- a/tests/Aspire.Cli.Tests/Commands/RestoreCommandTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/RestoreCommandTests.cs
@@ -21,7 +21,7 @@ public class RestoreCommandTests(ITestOutputHelper outputHelper)
         var restoreCalled = false;
         string? capturedProjectFilePath = null;
 
-        var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper, options =>
+        var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper, (Action<CliServiceCollectionTestOptions>?)(options =>
         {
             options.DotNetCliRunnerFactory = _ => new TestDotNetCliRunner
             {
@@ -29,10 +29,10 @@ public class RestoreCommandTests(ITestOutputHelper outputHelper)
                 {
                     restoreCalled = true;
                     capturedProjectFilePath = projectFilePath.FullName;
-                    return Aspire.Cli.ExitCodeConstants.Success;
+                    return (int)Aspire.Cli.CliExitCodes.Success;
                 }
             };
-        });
+        }));
         using var provider = services.BuildServiceProvider();
 
         var command = provider.GetRequiredService<RootCommand>();
@@ -40,7 +40,7 @@ public class RestoreCommandTests(ITestOutputHelper outputHelper)
 
         var exitCode = await result.InvokeAsync().DefaultTimeout();
 
-        Assert.Equal(Aspire.Cli.ExitCodeConstants.Success, exitCode);
+        Assert.Equal(Aspire.Cli.CliExitCodes.Success, exitCode);
         Assert.True(restoreCalled);
         Assert.Equal(appHostFile.FullName, capturedProjectFilePath);
     }
@@ -53,21 +53,21 @@ public class RestoreCommandTests(ITestOutputHelper outputHelper)
         await File.WriteAllTextAsync(appHostFile.FullName, "<Project Sdk=\"Microsoft.NET.Sdk\" />");
 
         var restoreCalled = false;
-        var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper, options =>
+        var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper, (Action<CliServiceCollectionTestOptions>?)(options =>
         {
             options.DotNetSdkInstallerFactory = _ => new TestDotNetSdkInstaller
             {
-                CheckAsyncCallback = _ => (false, null, "9.0.302")
+                CheckAsyncCallback = _ => ((bool Success, string? HighestDetectedVersion, string MinimumRequiredVersion))(false, null, "9.0.302")
             };
             options.DotNetCliRunnerFactory = _ => new TestDotNetCliRunner
             {
                 RestoreAsyncCallback = (_, _, _) =>
                 {
                     restoreCalled = true;
-                    return Aspire.Cli.ExitCodeConstants.Success;
+                    return (int)Aspire.Cli.CliExitCodes.Success;
                 }
             };
-        });
+        }));
         using var provider = services.BuildServiceProvider();
 
         var command = provider.GetRequiredService<RootCommand>();
@@ -75,7 +75,7 @@ public class RestoreCommandTests(ITestOutputHelper outputHelper)
 
         var exitCode = await result.InvokeAsync().DefaultTimeout();
 
-        Assert.Equal(Aspire.Cli.ExitCodeConstants.SdkNotInstalled, exitCode);
+        Assert.Equal(Aspire.Cli.CliExitCodes.SdkNotInstalled, exitCode);
         Assert.False(restoreCalled);
     }
 }

--- a/tests/Aspire.Cli.Tests/Commands/RunCommandTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/RunCommandTests.cs
@@ -58,7 +58,7 @@ public class RunCommandTests(ITestOutputHelper outputHelper)
         var result = command.Parse("run");
 
         var exitCode = await result.InvokeAsync().DefaultTimeout();
-        Assert.Equal(ExitCodeConstants.FailedToFindProject, exitCode);
+        Assert.Equal(CliExitCodes.FailedToFindProject, exitCode);
     }
 
     [Fact]
@@ -89,7 +89,7 @@ public class RunCommandTests(ITestOutputHelper outputHelper)
 
         var exitCode = await result.InvokeAsync().DefaultTimeout();
 
-        Assert.Equal(ExitCodeConstants.FailedToFindProject, exitCode);
+        Assert.Equal(CliExitCodes.FailedToFindProject, exitCode);
     }
 
     [Fact]
@@ -106,7 +106,7 @@ public class RunCommandTests(ITestOutputHelper outputHelper)
         var result = command.Parse("run");
 
         var exitCode = await result.InvokeAsync().DefaultTimeout();
-        Assert.Equal(ExitCodeConstants.FailedToFindProject, exitCode);
+        Assert.Equal(CliExitCodes.FailedToFindProject, exitCode);
     }
 
     [Fact]
@@ -124,7 +124,7 @@ public class RunCommandTests(ITestOutputHelper outputHelper)
 
         var exitCode = await result.InvokeAsync().DefaultTimeout();
 
-        Assert.Equal(ExitCodeConstants.FailedToFindProject, exitCode);
+        Assert.Equal(CliExitCodes.FailedToFindProject, exitCode);
     }
 
     [Fact]
@@ -172,7 +172,7 @@ public class RunCommandTests(ITestOutputHelper outputHelper)
     [Fact]
     public void GetDetachedFailureMessage_ReturnsBuildSpecificMessage_ForBuildFailureExitCode()
     {
-        var message = AppHostLauncher.GetDetachedFailureMessage(ExitCodeConstants.FailedToBuildArtifacts);
+        var message = AppHostLauncher.GetDetachedFailureMessage(CliExitCodes.FailedToBuildArtifacts);
 
         Assert.Equal(RunCommandStrings.AppHostFailedToBuild, message);
     }
@@ -255,7 +255,7 @@ public class RunCommandTests(ITestOutputHelper outputHelper)
         var result = command.Parse("run");
 
         var exitCode = await result.InvokeAsync().DefaultTimeout();
-        Assert.Equal(ExitCodeConstants.FailedToTrustCertificates, exitCode);
+        Assert.Equal(CliExitCodes.FailedToTrustCertificates, exitCode);
     }
 
     private sealed class ThrowingCertificateService : Aspire.Cli.Certificates.ICertificateService
@@ -401,7 +401,7 @@ public class RunCommandTests(ITestOutputHelper outputHelper)
         cts.Cancel();
 
         var exitCode = await pendingRun.DefaultTimeout();
-        Assert.Equal(ExitCodeConstants.Success, exitCode);
+        Assert.Equal(CliExitCodes.Success, exitCode);
     }
 
     [Fact]
@@ -417,7 +417,7 @@ public class RunCommandTests(ITestOutputHelper outputHelper)
                 var backchannel = sp.GetRequiredService<IAppHostCliBackchannel>();
                 backchannelCompletionSource!.SetResult(backchannel);
 
-                return Task.FromResult(ExitCodeConstants.Cancelled);
+                return Task.FromResult(CliExitCodes.Cancelled);
             };
 
             return runner;
@@ -444,7 +444,7 @@ public class RunCommandTests(ITestOutputHelper outputHelper)
 
         var exitCode = await result.InvokeAsync().DefaultTimeout(TestConstants.LongTimeoutDuration);
 
-        Assert.Equal(ExitCodeConstants.Success, exitCode);
+        Assert.Equal(CliExitCodes.Success, exitCode);
     }
 
     [Fact]
@@ -499,7 +499,7 @@ public class RunCommandTests(ITestOutputHelper outputHelper)
         cts.Cancel();
 
         var exitCode = await pendingRun.DefaultTimeout(TestConstants.LongTimeoutDuration);
-        Assert.Equal(ExitCodeConstants.Success, exitCode);
+        Assert.Equal(CliExitCodes.Success, exitCode);
     }
 
     [Fact]
@@ -610,7 +610,7 @@ public class RunCommandTests(ITestOutputHelper outputHelper)
         var exitCode = await pendingRun.DefaultTimeout(TestConstants.LongTimeoutDuration);
 
         // The command should handle cancellation gracefully
-        Assert.Equal(ExitCodeConstants.Success, exitCode);
+        Assert.Equal(CliExitCodes.Success, exitCode);
         Assert.Equal(1, testInteractionService.DisplayCancellationMessageCount);
 
         // Verify a warning was displayed (not an error)
@@ -712,7 +712,7 @@ public class RunCommandTests(ITestOutputHelper outputHelper)
         cts.Cancel();
         var exitCode = await pendingRun.DefaultTimeout();
 
-        Assert.Equal(ExitCodeConstants.Success, exitCode);
+        Assert.Equal(CliExitCodes.Success, exitCode);
         Assert.False(buildCalled, "Build should be skipped when extension DevKit capability is available.");
     }
 
@@ -782,7 +782,7 @@ public class RunCommandTests(ITestOutputHelper outputHelper)
         cts.Cancel();
         var exitCode = await pendingRun.DefaultTimeout();
 
-        Assert.Equal(ExitCodeConstants.Success, exitCode);
+        Assert.Equal(CliExitCodes.Success, exitCode);
         Assert.False(buildCalled, "Build should be skipped when running in extension.");
     }
 
@@ -855,7 +855,7 @@ public class RunCommandTests(ITestOutputHelper outputHelper)
 
         var exitCode = await pendingRun.DefaultTimeout();
 
-        Assert.Equal(ExitCodeConstants.Success, exitCode);
+        Assert.Equal(CliExitCodes.Success, exitCode);
         Assert.True(buildCalled, "Build should be called when extension has build-dotnet-using-cli capability.");
     }
 
@@ -908,7 +908,7 @@ public class RunCommandTests(ITestOutputHelper outputHelper)
 
         var exitCode = await result.InvokeAsync().DefaultTimeout();
 
-        Assert.Equal(ExitCodeConstants.FailedToBuildArtifacts, exitCode);
+        Assert.Equal(CliExitCodes.FailedToBuildArtifacts, exitCode);
         Assert.True(buildCalled, "Build should be called before launching the AppHost in extension no-debug mode.");
         Assert.False(runCalled, "AppHost should not be launched when the pre-build fails.");
     }
@@ -1078,7 +1078,7 @@ public class RunCommandTests(ITestOutputHelper outputHelper)
 
         var exitCode = await result.InvokeAsync().DefaultTimeout();
 
-        Assert.Equal(ExitCodeConstants.FailedToBuildArtifacts, exitCode);
+        Assert.Equal(CliExitCodes.FailedToBuildArtifacts, exitCode);
         Assert.False(runCalled, "The AppHost should not be started when the initial build fails in watch mode.");
     }
 
@@ -1676,7 +1676,7 @@ public class RunCommandTests(ITestOutputHelper outputHelper)
             cts.Cancel();
 
             var exitCode = await pendingRun.DefaultTimeout();
-            Assert.Equal(ExitCodeConstants.Success, exitCode);
+            Assert.Equal(CliExitCodes.Success, exitCode);
 
             // Verify DcpPublisher__RandomizePorts is set to true for isolated mode
             Assert.True(capturedEnv.ContainsKey("DcpPublisher__RandomizePorts"), "DcpPublisher__RandomizePorts should be set in isolated mode");
@@ -1730,7 +1730,7 @@ public class RunCommandTests(ITestOutputHelper outputHelper)
         var exitCode = await result.InvokeAsync().DefaultTimeout();
 
         // Should return InvalidCommand error because --no-build is not supported with watch mode enabled
-        Assert.Equal(ExitCodeConstants.InvalidCommand, exitCode);
+        Assert.Equal(CliExitCodes.InvalidCommand, exitCode);
     }
 
     [Fact]
@@ -1883,7 +1883,7 @@ public class RunCommandTests(ITestOutputHelper outputHelper)
 
         var exitCode = await pendingRun.DefaultTimeout();
 
-        Assert.Equal(ExitCodeConstants.Success, exitCode);
+        Assert.Equal(CliExitCodes.Success, exitCode);
         Assert.False(startDebugSessionCalled, "StartDebugSessionAsync should not be called in non-interactive mode.");
     }
 

--- a/tests/Aspire.Cli.Tests/Commands/SdkCommandTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/SdkCommandTests.cs
@@ -22,7 +22,7 @@ public class SdkCommandTests(ITestOutputHelper outputHelper)
 
         var exitCode = await result.InvokeAsync().DefaultTimeout();
 
-        Assert.Equal(ExitCodeConstants.InvalidCommand, exitCode);
+        Assert.Equal(CliExitCodes.InvalidCommand, exitCode);
     }
 
     [Fact]

--- a/tests/Aspire.Cli.Tests/Commands/SdkDumpCommandTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/SdkDumpCommandTests.cs
@@ -67,7 +67,7 @@ public class SdkDumpCommandTests(ITestOutputHelper outputHelper)
 
         var exitCode = await result.InvokeAsync().DefaultTimeout();
 
-        Assert.Equal(ExitCodeConstants.FailedToFindProject, exitCode);
+        Assert.Equal(CliExitCodes.FailedToFindProject, exitCode);
     }
 
     [Fact]
@@ -82,7 +82,7 @@ public class SdkDumpCommandTests(ITestOutputHelper outputHelper)
 
         var exitCode = await result.InvokeAsync().DefaultTimeout();
 
-        Assert.Equal(ExitCodeConstants.InvalidCommand, exitCode);
+        Assert.Equal(CliExitCodes.InvalidCommand, exitCode);
     }
 
     [Fact]
@@ -97,7 +97,7 @@ public class SdkDumpCommandTests(ITestOutputHelper outputHelper)
 
         var exitCode = await result.InvokeAsync().DefaultTimeout();
 
-        Assert.Equal(ExitCodeConstants.InvalidCommand, exitCode);
+        Assert.Equal(CliExitCodes.InvalidCommand, exitCode);
     }
 
     [Fact]
@@ -112,7 +112,7 @@ public class SdkDumpCommandTests(ITestOutputHelper outputHelper)
 
         var exitCode = await result.InvokeAsync().DefaultTimeout();
 
-        Assert.Equal(ExitCodeConstants.InvalidCommand, exitCode);
+        Assert.Equal(CliExitCodes.InvalidCommand, exitCode);
     }
 
     [Fact]
@@ -127,7 +127,7 @@ public class SdkDumpCommandTests(ITestOutputHelper outputHelper)
 
         var exitCode = await result.InvokeAsync().DefaultTimeout();
 
-        Assert.Equal(ExitCodeConstants.InvalidCommand, exitCode);
+        Assert.Equal(CliExitCodes.InvalidCommand, exitCode);
     }
 
     [Fact]
@@ -184,14 +184,14 @@ public class SdkDumpCommandTests(ITestOutputHelper outputHelper)
         var exitCode = await result.InvokeAsync().DefaultTimeout();
 
         // "Aspire.Hosting.Redis@" is not a valid semver, so it should fail version validation
-        Assert.Equal(ExitCodeConstants.InvalidCommand, exitCode);
+        Assert.Equal(CliExitCodes.InvalidCommand, exitCode);
     }
 
     [Fact]
     public void SdkDumpCi_ForHostingProject_DoesNotEmitWarnings()
     {
         // Assertions and skips inside the callback are surfaced back to the parent test process.
-        using var result = RemoteExecutor.Invoke(async (baseDirectory) =>
+        using var result = RemoteExecutor.Invoke((Func<string, Task>)(async (baseDirectory) =>
         {
             var repoRoot = TryFindRepoRoot(baseDirectory);
             if (repoRoot is null)
@@ -219,7 +219,7 @@ public class SdkDumpCommandTests(ITestOutputHelper outputHelper)
                 // ExtraLongTimeout because this spawns a real dotnet build of Aspire.Hosting.csproj
                 // in a child process, which can exceed the default timeout under concurrent test load.
                 var exitCode = await Program.Main(["sdk", "dump", "--format", "ci", "--output", outputPath, projectPath]).DefaultTimeout(TestConstants.ExtraLongTimeoutTimeSpan);
-                Assert.Equal(ExitCodeConstants.Success, exitCode);
+                Assert.Equal((int)CliExitCodes.Success, exitCode);
 
                 var output = await File.ReadAllTextAsync(outputPath);
                 Assert.NotEmpty(output);
@@ -244,7 +244,7 @@ public class SdkDumpCommandTests(ITestOutputHelper outputHelper)
                     Directory.Delete(tempDirectory, recursive: true);
                 }
             }
-        }, AppContext.BaseDirectory, options: s_remoteInvokeOptions);
+        }), AppContext.BaseDirectory, options: s_remoteInvokeOptions);
 
         outputHelper.WriteLine(result.Process.StandardOutput.ReadToEnd());
     }

--- a/tests/Aspire.Cli.Tests/Commands/SdkInstallerTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/SdkInstallerTests.cs
@@ -46,7 +46,7 @@ public class SdkInstallerTests(ITestOutputHelper outputHelper)
         var result = command.Parse("run");
 
         var exitCode = await result.InvokeAsync().DefaultTimeout();
-        Assert.Equal(ExitCodeConstants.SdkNotInstalled, exitCode);
+        Assert.Equal(CliExitCodes.SdkNotInstalled, exitCode);
     }
 
     [Fact]
@@ -71,7 +71,7 @@ public class SdkInstallerTests(ITestOutputHelper outputHelper)
         var result = command.Parse("add");
 
         var exitCode = await result.InvokeAsync().DefaultTimeout();
-        Assert.Equal(ExitCodeConstants.SdkNotInstalled, exitCode);
+        Assert.Equal(CliExitCodes.SdkNotInstalled, exitCode);
     }
 
     [Fact]
@@ -95,7 +95,7 @@ public class SdkInstallerTests(ITestOutputHelper outputHelper)
 
         var exitCode = await result.InvokeAsync().DefaultTimeout();
         // aspire-starter is not registered when SDK is unavailable, so it's an invalid command
-        Assert.Equal(ExitCodeConstants.InvalidCommand, exitCode);
+        Assert.Equal(CliExitCodes.InvalidCommand, exitCode);
     }
 
     [Fact]
@@ -133,7 +133,7 @@ public class SdkInstallerTests(ITestOutputHelper outputHelper)
         var result = command.Parse("publish");
 
         var exitCode = await result.InvokeAsync().DefaultTimeout();
-        Assert.Equal(ExitCodeConstants.SdkNotInstalled, exitCode);
+        Assert.Equal(CliExitCodes.SdkNotInstalled, exitCode);
     }
 
     [Fact]
@@ -171,7 +171,7 @@ public class SdkInstallerTests(ITestOutputHelper outputHelper)
         var result = command.Parse("deploy");
 
         var exitCode = await result.InvokeAsync().DefaultTimeout();
-        Assert.Equal(ExitCodeConstants.SdkNotInstalled, exitCode);
+        Assert.Equal(CliExitCodes.SdkNotInstalled, exitCode);
     }
 
     [Fact]
@@ -194,6 +194,6 @@ public class SdkInstallerTests(ITestOutputHelper outputHelper)
 
         var exitCode = await result.InvokeAsync().DefaultTimeout();
         // Should fail at project location, not SDK check
-        Assert.Equal(ExitCodeConstants.FailedToFindProject, exitCode);
+        Assert.Equal(CliExitCodes.FailedToFindProject, exitCode);
     }
 }

--- a/tests/Aspire.Cli.Tests/Commands/SecretCommandTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/SecretCommandTests.cs
@@ -35,7 +35,7 @@ public class SecretCommandTests(ITestOutputHelper outputHelper)
         var result = command.Parse($"secret path --apphost \"{appHostFile.FullName}\"");
         var exitCode = await result.InvokeAsync().DefaultTimeout();
 
-        Assert.Equal(ExitCodeConstants.Success, exitCode);
+        Assert.Equal(CliExitCodes.Success, exitCode);
         Assert.Contains(expectedPath, outputWriter.Logs);
     }
 
@@ -61,7 +61,7 @@ public class SecretCommandTests(ITestOutputHelper outputHelper)
         var result = command.Parse($"secret path --apphost \"{appHostFile.FullName}\"");
         var exitCode = await result.InvokeAsync().DefaultTimeout();
 
-        Assert.Equal(ExitCodeConstants.Success, exitCode);
+        Assert.Equal(CliExitCodes.Success, exitCode);
         Assert.Contains(expectedPath, outputWriter.Logs);
     }
 

--- a/tests/Aspire.Cli.Tests/Commands/StartCommandTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/StartCommandTests.cs
@@ -1,12 +1,17 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Globalization;
 using Aspire.Cli.Commands;
+using Aspire.Cli.Projects;
+using Aspire.Cli.Resources;
+using Aspire.Cli.Tests.TestServices;
 using Aspire.Cli.Tests.Utils;
 using Aspire.Cli.Utils;
 using Microsoft.AspNetCore.InternalTesting;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
 
 namespace Aspire.Cli.Tests.Commands;
 
@@ -24,7 +29,7 @@ public class StartCommandTests(ITestOutputHelper outputHelper)
 
         var exitCode = await result.InvokeAsync().DefaultTimeout();
 
-        Assert.Equal(ExitCodeConstants.Success, exitCode);
+        Assert.Equal(CliExitCodes.Success, exitCode);
     }
 
     [Fact]
@@ -38,7 +43,7 @@ public class StartCommandTests(ITestOutputHelper outputHelper)
         var result = command.Parse("start --no-build --help");
 
         var exitCode = await result.InvokeAsync().DefaultTimeout();
-        Assert.Equal(ExitCodeConstants.Success, exitCode);
+        Assert.Equal(CliExitCodes.Success, exitCode);
     }
 
     [Fact]
@@ -52,7 +57,7 @@ public class StartCommandTests(ITestOutputHelper outputHelper)
         var result = command.Parse("start --format json --help");
 
         var exitCode = await result.InvokeAsync().DefaultTimeout();
-        Assert.Equal(ExitCodeConstants.Success, exitCode);
+        Assert.Equal(CliExitCodes.Success, exitCode);
     }
 
     [Fact]
@@ -66,7 +71,7 @@ public class StartCommandTests(ITestOutputHelper outputHelper)
         var result = command.Parse("start --isolated --help");
 
         var exitCode = await result.InvokeAsync().DefaultTimeout();
-        Assert.Equal(ExitCodeConstants.Success, exitCode);
+        Assert.Equal(CliExitCodes.Success, exitCode);
     }
 
     [Fact]
@@ -112,7 +117,7 @@ public class StartCommandTests(ITestOutputHelper outputHelper)
 
         var exitCode = await result.InvokeAsync().DefaultTimeout();
 
-        Assert.Equal(ExitCodeConstants.FailedToFindProject, exitCode);
+        Assert.Equal(CliExitCodes.FailedToFindProject, exitCode);
     }
 
     [Fact]
@@ -142,6 +147,78 @@ public class StartCommandTests(ITestOutputHelper outputHelper)
 
         var exitCode = await result.InvokeAsync().DefaultTimeout();
 
-        Assert.Equal(ExitCodeConstants.FailedToFindProject, exitCode);
+        Assert.Equal(CliExitCodes.FailedToFindProject, exitCode);
+    }
+
+    [Fact]
+    public async Task StartCommand_LaunchFailure_DisplaysBothLogPaths()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        var interactionService = new TestInteractionService();
+
+        // Create a fake .csproj file so the path exists on disk for the process launcher.
+        var appHostDir = workspace.WorkspaceRoot.CreateSubdirectory("AppHost");
+        var appHostFile = new FileInfo(Path.Combine(appHostDir.FullName, "AppHost.csproj"));
+        await File.WriteAllTextAsync(appHostFile.FullName, "<Project />");
+
+        // Use TestProjectLocator to bypass msbuild evaluation and return the fake project directly.
+        var projectLocator = new TestProjectLocator
+        {
+            UseOrFindAppHostProjectFileWithBehaviorAsyncCallback = (_, _, _, _) =>
+                Task.FromResult(new AppHostProjectSearchResult(appHostFile, [appHostFile]))
+        };
+
+        var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper, options =>
+        {
+            options.InteractionServiceFactory = _ => interactionService;
+            options.ProjectLocatorFactory = _ => projectLocator;
+            options.CliHostEnvironmentFactory = sp =>
+            {
+                var configuration = sp.GetRequiredService<IConfiguration>();
+                return new CliHostEnvironment(configuration, nonInteractive: true);
+            };
+        });
+
+        // Replace TimeProvider with one that immediately exceeds the backchannel wait
+        // timeout so the test doesn't wait for a real process to exit.
+        services.Replace(ServiceDescriptor.Singleton<TimeProvider>(new InstantTimeoutTimeProvider()));
+
+        using var provider = services.BuildServiceProvider();
+
+        var command = provider.GetRequiredService<RootCommand>();
+        var result = command.Parse($"start --apphost {appHostFile.FullName}");
+
+        var exitCode = await result.InvokeAsync().DefaultTimeout();
+
+        Assert.Equal(CliExitCodes.FailedToDotnetRunAppHost, exitCode);
+
+        var executionContext = provider.GetRequiredService<CliExecutionContext>();
+        var expectedCliLogMessage = string.Format(CultureInfo.CurrentCulture, InteractionServiceStrings.SeeLogsAt, executionContext.LogFilePath);
+
+        // The AppHost log path should have been set on the execution context and
+        // BaseCommand's shared error handling should display both paths.
+        Assert.NotNull(executionContext.AppHostCliLogFilePath);
+        Assert.Contains(interactionService.DisplayedMessages, m => m.Message == expectedCliLogMessage);
+
+        var expectedAppHostLogMessage = string.Format(CultureInfo.CurrentCulture, InteractionServiceStrings.SeeAppHostLogsAt, executionContext.AppHostCliLogFilePath);
+        Assert.Contains(interactionService.DisplayedMessages, m => m.Message == expectedAppHostLogMessage);
+    }
+
+    /// <summary>
+    /// A TimeProvider that causes the backchannel wait loop to time out immediately.
+    /// The first call (used for <c>startTime</c>) returns the base time; subsequent
+    /// calls return a time 200 seconds later, exceeding the 120-second timeout.
+    /// </summary>
+    private sealed class InstantTimeoutTimeProvider : TimeProvider
+    {
+        private int _callCount;
+        private readonly DateTimeOffset _start = DateTimeOffset.UtcNow;
+
+        public override DateTimeOffset GetUtcNow()
+        {
+            return Interlocked.Increment(ref _callCount) <= 1
+                ? _start
+                : _start.AddSeconds(200);
+        }
     }
 }

--- a/tests/Aspire.Cli.Tests/Commands/StopCommandTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/StopCommandTests.cs
@@ -31,7 +31,7 @@ public class StopCommandTests(ITestOutputHelper outputHelper)
 
         var exitCode = await result.InvokeAsync().DefaultTimeout();
 
-        Assert.Equal(ExitCodeConstants.Success, exitCode);
+        Assert.Equal(CliExitCodes.Success, exitCode);
     }
 
     [Fact]
@@ -45,7 +45,7 @@ public class StopCommandTests(ITestOutputHelper outputHelper)
         var result = command.Parse("stop myresource");
 
         var exitCode = await result.InvokeAsync().DefaultTimeout();
-        Assert.NotEqual(ExitCodeConstants.Success, exitCode);
+        Assert.NotEqual(CliExitCodes.Success, exitCode);
     }
 
     [Fact]
@@ -67,7 +67,7 @@ public class StopCommandTests(ITestOutputHelper outputHelper)
 
         var exitCode = await result.InvokeAsync().DefaultTimeout();
 
-        Assert.Equal(ExitCodeConstants.FailedToFindProject, exitCode);
+        Assert.Equal(CliExitCodes.FailedToFindProject, exitCode);
     }
 
     [Fact]
@@ -99,7 +99,7 @@ public class StopCommandTests(ITestOutputHelper outputHelper)
         var exitCode = await result.InvokeAsync().DefaultTimeout();
 
         Assert.True(projectLocatorInvoked);
-        Assert.Equal(ExitCodeConstants.Success, exitCode);
+        Assert.Equal(CliExitCodes.Success, exitCode);
         var displayedMessage = Assert.Single(interactionService.DisplayedMessages);
         Assert.Equal(
             string.Format(SharedCommandStrings.AppHostNotRunningAtPath, Path.Combine("Resolved.AppHost", "Resolved.AppHost.csproj")),
@@ -132,7 +132,7 @@ public class StopCommandTests(ITestOutputHelper outputHelper)
 
         var exitCode = await result.InvokeAsync().DefaultTimeout();
 
-        Assert.Equal(ExitCodeConstants.Success, exitCode);
+        Assert.Equal(CliExitCodes.Success, exitCode);
 
         var expectedPath1 = Path.Combine("App1", "AppHost.cs");
         var expectedPath2 = Path.Combine("App2", "AppHost.cs");
@@ -168,7 +168,7 @@ public class StopCommandTests(ITestOutputHelper outputHelper)
 
         var exitCode = await result.InvokeAsync().DefaultTimeout();
 
-        Assert.Equal(ExitCodeConstants.Success, exitCode);
+        Assert.Equal(CliExitCodes.Success, exitCode);
 
         var expectedPath = "App1.AppHost.csproj";
         var expectedIdentifier1 = string.Format(CultureInfo.CurrentCulture, StopCommandStrings.AppHostIdentifierWithProcessId, expectedPath, processId1);
@@ -202,7 +202,7 @@ public class StopCommandTests(ITestOutputHelper outputHelper)
 
         var exitCode = await result.InvokeAsync().DefaultTimeout();
 
-        Assert.Equal(ExitCodeConstants.Success, exitCode);
+        Assert.Equal(CliExitCodes.Success, exitCode);
 
         var expectedPath = Path.Combine("App1", "App1.AppHost", "App1.AppHost.csproj");
         Assert.Contains(statusMessages, message => message == string.Format(CultureInfo.CurrentCulture, StopCommandStrings.StoppingAppHost, expectedPath));
@@ -235,7 +235,7 @@ public class StopCommandTests(ITestOutputHelper outputHelper)
 
         var exitCode = await result.InvokeAsync().DefaultTimeout();
 
-        Assert.Equal(ExitCodeConstants.Success, exitCode);
+        Assert.Equal(CliExitCodes.Success, exitCode);
 
         Assert.Contains(statusMessages, message => message == string.Format(CultureInfo.CurrentCulture, StopCommandStrings.StoppingAppHost, appHostPath));
         Assert.Contains(interactionService.DisplayedSuccess, message => message == string.Format(CultureInfo.CurrentCulture, StopCommandStrings.AppHostStoppedSuccessfully, appHostPath));
@@ -271,12 +271,12 @@ public class StopCommandTests(ITestOutputHelper outputHelper)
 
         var exitCode = await result.InvokeAsync().DefaultTimeout();
 
-        Assert.Equal(ExitCodeConstants.Success, exitCode);
+        Assert.Equal(CliExitCodes.Success, exitCode);
 
         var stopCommandActivity = Assert.Single(stoppedActivities, activity => activity.OperationName == ProfilingTelemetry.Activities.StopCommand);
         Assert.Equal(true, stopCommandActivity.GetTagItem(ProfilingTelemetry.Tags.AppHostStopAll));
         Assert.Equal(2, stopCommandActivity.GetTagItem(ProfilingTelemetry.Tags.AppHostStopCount));
-        Assert.Equal(ExitCodeConstants.Success, stopCommandActivity.GetTagItem(TelemetryConstants.Tags.ProcessExitCode));
+        Assert.Equal(CliExitCodes.Success, stopCommandActivity.GetTagItem(TelemetryConstants.Tags.ProcessExitCode));
 
         var stopAppHostActivities = stoppedActivities.Where(activity => activity.OperationName == ProfilingTelemetry.Activities.StopAppHost).ToArray();
         Assert.Equal(2, stopAppHostActivities.Length);
@@ -287,7 +287,7 @@ public class StopCommandTests(ITestOutputHelper outputHelper)
                 .Select(activity => Assert.IsType<int>(activity.GetTagItem(TelemetryConstants.Tags.ProcessPid)))
                 .Order()
                 .ToArray());
-        Assert.All(stopAppHostActivities, activity => Assert.Equal(ExitCodeConstants.Success, activity.GetTagItem(TelemetryConstants.Tags.ProcessExitCode)));
+        Assert.All(stopAppHostActivities, activity => Assert.Equal(CliExitCodes.Success, activity.GetTagItem(TelemetryConstants.Tags.ProcessExitCode)));
     }
 
     private static TestAppHostAuxiliaryBackchannel CreateConnection(string appHostPath, int processId, bool isInScope = true)

--- a/tests/Aspire.Cli.Tests/Commands/TelemetryCommandTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/TelemetryCommandTests.cs
@@ -31,7 +31,7 @@ public class TelemetryCommandTests(ITestOutputHelper outputHelper)
 
         var exitCode = await result.InvokeAsync().DefaultTimeout();
 
-        Assert.Equal(ExitCodeConstants.InvalidCommand, exitCode);
+        Assert.Equal(CliExitCodes.InvalidCommand, exitCode);
     }
 
     [Fact]
@@ -230,7 +230,7 @@ public class TelemetryCommandTests(ITestOutputHelper outputHelper)
 
         var exitCode = await result.InvokeAsync().DefaultTimeout();
 
-        Assert.Equal(ExitCodeConstants.DashboardFailure, exitCode);
+        Assert.Equal(CliExitCodes.DashboardFailure, exitCode);
         var errorMessage = Assert.Single(testInteractionService.DisplayedErrors);
         var expectedMessage = GetExpectedErrorMessage(expectedMessageKey);
         Assert.Equal(expectedMessage, errorMessage);

--- a/tests/Aspire.Cli.Tests/Commands/TelemetryLogsCommandTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/TelemetryLogsCommandTests.cs
@@ -31,7 +31,7 @@ public class TelemetryLogsCommandTests(ITestOutputHelper outputHelper)
 
         var exitCode = await result.InvokeAsync().DefaultTimeout();
 
-        Assert.Equal(ExitCodeConstants.Success, exitCode);
+        Assert.Equal(CliExitCodes.Success, exitCode);
     }
 
     [Theory]
@@ -49,7 +49,7 @@ public class TelemetryLogsCommandTests(ITestOutputHelper outputHelper)
 
         var exitCode = await result.InvokeAsync().DefaultTimeout();
 
-        Assert.Equal(ExitCodeConstants.InvalidCommand, exitCode);
+        Assert.Equal(CliExitCodes.InvalidCommand, exitCode);
     }
 
     [Fact]
@@ -75,7 +75,7 @@ public class TelemetryLogsCommandTests(ITestOutputHelper outputHelper)
 
         var exitCode = await result.InvokeAsync().DefaultTimeout();
 
-        Assert.Equal(ExitCodeConstants.Success, exitCode);
+        Assert.Equal(CliExitCodes.Success, exitCode);
 
         // With ANSI disabled, output is plain text: "timestamp severity resourceName body"
         var logLines = outputWriter.Logs.Where(l => l.Contains("redis") || l.Contains("apiservice")).ToList();
@@ -110,7 +110,7 @@ public class TelemetryLogsCommandTests(ITestOutputHelper outputHelper)
 
         var exitCode = await result.InvokeAsync().DefaultTimeout();
 
-        Assert.Equal(ExitCodeConstants.Success, exitCode);
+        Assert.Equal(CliExitCodes.Success, exitCode);
 
         // Replicas get shortened GUID appended: apiservice-11111111 and apiservice-aaaaaaaa
         var logLines = outputWriter.Logs.Where(l => l.Contains("apiservice")).ToList();
@@ -140,7 +140,7 @@ public class TelemetryLogsCommandTests(ITestOutputHelper outputHelper)
 
         var exitCode = await result.InvokeAsync().DefaultTimeout();
 
-        Assert.Equal(ExitCodeConstants.Success, exitCode);
+        Assert.Equal(CliExitCodes.Success, exitCode);
 
         var logLine = Assert.Single(outputWriter.Logs, l => l.Contains("apiservice", StringComparison.Ordinal));
         Assert.Equal($"{FormatHelpers.FormatConsoleTime(TimeProvider.System, s_testTime)} INFO apiservice Request received", logLine);
@@ -220,7 +220,7 @@ public class TelemetryLogsCommandTests(ITestOutputHelper outputHelper)
 
         var exitCode = await result.InvokeAsync().DefaultTimeout();
 
-        Assert.Equal(ExitCodeConstants.Success, exitCode);
+        Assert.Equal(CliExitCodes.Success, exitCode);
         var logLines = outputWriter.Logs.Where(l => l.Contains("redis")).ToList();
         Assert.Single(logLines);
         Assert.Contains("Ready to accept connections", logLines[0]);
@@ -272,7 +272,7 @@ public class TelemetryLogsCommandTests(ITestOutputHelper outputHelper)
 
         var exitCode = await result.InvokeAsync().DefaultTimeout();
 
-        Assert.Equal(ExitCodeConstants.Success, exitCode);
+        Assert.Equal(CliExitCodes.Success, exitCode);
         Assert.Equal("my-secret-key", capturedApiKey);
     }
 
@@ -294,7 +294,7 @@ public class TelemetryLogsCommandTests(ITestOutputHelper outputHelper)
 
         var exitCode = await result.InvokeAsync().DefaultTimeout();
 
-        Assert.Equal(ExitCodeConstants.InvalidCommand, exitCode);
+        Assert.Equal(CliExitCodes.InvalidCommand, exitCode);
         var errorMessage = Assert.Single(testInteractionService.DisplayedErrors);
         Assert.Equal(TelemetryCommandStrings.DashboardUrlAndAppHostExclusive, errorMessage);
     }
@@ -317,7 +317,7 @@ public class TelemetryLogsCommandTests(ITestOutputHelper outputHelper)
 
         var exitCode = await result.InvokeAsync().DefaultTimeout();
 
-        Assert.Equal(ExitCodeConstants.InvalidCommand, exitCode);
+        Assert.Equal(CliExitCodes.InvalidCommand, exitCode);
         var errorMessage = Assert.Single(testInteractionService.DisplayedErrors);
         Assert.Equal(string.Format(CultureInfo.CurrentCulture, TelemetryCommandStrings.DashboardUrlInvalid, "not-a-url"), errorMessage);
     }
@@ -355,7 +355,7 @@ public class TelemetryLogsCommandTests(ITestOutputHelper outputHelper)
 
         var exitCode = await result.InvokeAsync().DefaultTimeout();
 
-        Assert.Equal(ExitCodeConstants.DashboardFailure, exitCode);
+        Assert.Equal(CliExitCodes.DashboardFailure, exitCode);
         var errorMessage = Assert.Single(testInteractionService.DisplayedErrors);
         Assert.Equal(TelemetryCommandStrings.DashboardAuthFailed, errorMessage);
     }
@@ -398,7 +398,7 @@ public class TelemetryLogsCommandTests(ITestOutputHelper outputHelper)
 
         var exitCode = await result.InvokeAsync().DefaultTimeout();
 
-        Assert.Equal(ExitCodeConstants.DashboardFailure, exitCode);
+        Assert.Equal(CliExitCodes.DashboardFailure, exitCode);
         var errorMessage = Assert.Single(testInteractionService.DisplayedErrors);
         Assert.Equal(string.Format(CultureInfo.CurrentCulture, TelemetryCommandStrings.DashboardApiNotEnabled, "http://localhost:18888"), errorMessage);
     }
@@ -437,7 +437,7 @@ public class TelemetryLogsCommandTests(ITestOutputHelper outputHelper)
 
         var exitCode = await result.InvokeAsync().DefaultTimeout();
 
-        Assert.Equal(ExitCodeConstants.DashboardFailure, exitCode);
+        Assert.Equal(CliExitCodes.DashboardFailure, exitCode);
         var errorMessage = Assert.Single(testInteractionService.DisplayedErrors);
         Assert.Equal(string.Format(CultureInfo.CurrentCulture, TelemetryCommandStrings.DashboardConnectionFailed, "http://localhost:18888"), errorMessage);
     }
@@ -467,7 +467,7 @@ public class TelemetryLogsCommandTests(ITestOutputHelper outputHelper)
 
         var exitCode = await result.InvokeAsync().DefaultTimeout();
 
-        Assert.Equal(ExitCodeConstants.DashboardFailure, exitCode);
+        Assert.Equal(CliExitCodes.DashboardFailure, exitCode);
         var errorMessage = Assert.Single(testInteractionService.DisplayedErrors);
         Assert.Equal(string.Format(CultureInfo.CurrentCulture, TelemetryCommandStrings.DashboardConnectionFailed, "http://localhost:18888"), errorMessage);
     }
@@ -507,7 +507,7 @@ public class TelemetryLogsCommandTests(ITestOutputHelper outputHelper)
 
         var exitCode = await result.InvokeAsync().DefaultTimeout();
 
-        Assert.Equal(ExitCodeConstants.DashboardFailure, exitCode);
+        Assert.Equal(CliExitCodes.DashboardFailure, exitCode);
         var errorMessage = Assert.Single(testInteractionService.DisplayedErrors);
         Assert.Equal(string.Format(CultureInfo.CurrentCulture, TelemetryCommandStrings.DashboardApiNotEnabled, "http://localhost:18888"), errorMessage);
     }
@@ -563,7 +563,7 @@ public class TelemetryLogsCommandTests(ITestOutputHelper outputHelper)
 
         var exitCode = await result.InvokeAsync().DefaultTimeout();
 
-        Assert.Equal(ExitCodeConstants.Success, exitCode);
+        Assert.Equal(CliExitCodes.Success, exitCode);
         // Verify the request went to the base URL (without /login path)
         Assert.NotNull(capturedBaseUrl);
         Assert.DoesNotContain("/login", capturedBaseUrl);
@@ -645,7 +645,7 @@ public class TelemetryLogsCommandTests(ITestOutputHelper outputHelper)
 
         var exitCode = await result.InvokeAsync().DefaultTimeout();
 
-        Assert.Equal(ExitCodeConstants.Success, exitCode);
+        Assert.Equal(CliExitCodes.Success, exitCode);
 
         var jsonLine = outputWriter.Logs.Single(l => l.TrimStart().StartsWith('['));
         var formattedJson = TelemetryTestHelper.FormatJson(jsonLine);
@@ -711,7 +711,7 @@ public class TelemetryLogsCommandTests(ITestOutputHelper outputHelper)
 
         var exitCode = await result.InvokeAsync().DefaultTimeout();
 
-        Assert.Equal(ExitCodeConstants.Success, exitCode);
+        Assert.Equal(CliExitCodes.Success, exitCode);
         Assert.NotNull(capturedUrl);
         Assert.Contains("search=timeout", capturedUrl);
     }

--- a/tests/Aspire.Cli.Tests/Commands/TelemetrySpansCommandTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/TelemetrySpansCommandTests.cs
@@ -30,7 +30,7 @@ public class TelemetrySpansCommandTests(ITestOutputHelper outputHelper)
 
         var exitCode = await result.InvokeAsync().DefaultTimeout();
 
-        Assert.Equal(ExitCodeConstants.Success, exitCode);
+        Assert.Equal(CliExitCodes.Success, exitCode);
     }
 
     [Theory]
@@ -48,7 +48,7 @@ public class TelemetrySpansCommandTests(ITestOutputHelper outputHelper)
 
         var exitCode = await result.InvokeAsync().DefaultTimeout();
 
-        Assert.Equal(ExitCodeConstants.InvalidCommand, exitCode);
+        Assert.Equal(CliExitCodes.InvalidCommand, exitCode);
     }
 
     [Fact]
@@ -74,7 +74,7 @@ public class TelemetrySpansCommandTests(ITestOutputHelper outputHelper)
 
         var exitCode = await result.InvokeAsync().DefaultTimeout();
 
-        Assert.Equal(ExitCodeConstants.Success, exitCode);
+        Assert.Equal(CliExitCodes.Success, exitCode);
 
         // Span output format: "timestamp STATUS shortSpanId resourceName     duration spanName"
         var spanLines = outputWriter.Logs.Where(l => l.Contains("frontend") || l.Contains("backend")).ToList();
@@ -109,7 +109,7 @@ public class TelemetrySpansCommandTests(ITestOutputHelper outputHelper)
 
         var exitCode = await result.InvokeAsync().DefaultTimeout();
 
-        Assert.Equal(ExitCodeConstants.Success, exitCode);
+        Assert.Equal(CliExitCodes.Success, exitCode);
 
         // Replicas get shortened GUID appended
         var spanLines = outputWriter.Logs.Where(l => l.Contains("apiservice")).ToList();
@@ -193,7 +193,7 @@ public class TelemetrySpansCommandTests(ITestOutputHelper outputHelper)
 
         var exitCode = await result.InvokeAsync().DefaultTimeout();
 
-        Assert.Equal(ExitCodeConstants.Success, exitCode);
+        Assert.Equal(CliExitCodes.Success, exitCode);
         var spanLines = outputWriter.Logs.Where(l => l.Contains("frontend")).ToList();
         Assert.Single(spanLines);
         Assert.Contains("GET /index", spanLines[0]);
@@ -217,7 +217,7 @@ public class TelemetrySpansCommandTests(ITestOutputHelper outputHelper)
 
         var exitCode = await result.InvokeAsync().DefaultTimeout();
 
-        Assert.Equal(ExitCodeConstants.InvalidCommand, exitCode);
+        Assert.Equal(CliExitCodes.InvalidCommand, exitCode);
         var errorMessage = Assert.Single(testInteractionService.DisplayedErrors);
         Assert.Equal(TelemetryCommandStrings.DashboardUrlAndAppHostExclusive, errorMessage);
     }
@@ -255,7 +255,7 @@ public class TelemetrySpansCommandTests(ITestOutputHelper outputHelper)
 
         var exitCode = await result.InvokeAsync().DefaultTimeout();
 
-        Assert.Equal(ExitCodeConstants.DashboardFailure, exitCode);
+        Assert.Equal(CliExitCodes.DashboardFailure, exitCode);
         var errorMessage = Assert.Single(testInteractionService.DisplayedErrors);
         Assert.Equal(TelemetryCommandStrings.DashboardAuthFailed, errorMessage);
     }
@@ -295,7 +295,7 @@ public class TelemetrySpansCommandTests(ITestOutputHelper outputHelper)
 
         var exitCode = await result.InvokeAsync().DefaultTimeout();
 
-        Assert.Equal(ExitCodeConstants.DashboardFailure, exitCode);
+        Assert.Equal(CliExitCodes.DashboardFailure, exitCode);
         var errorMessage = Assert.Single(testInteractionService.DisplayedErrors);
         Assert.Equal(string.Format(System.Globalization.CultureInfo.CurrentCulture, TelemetryCommandStrings.DashboardApiNotEnabled, "http://localhost:18888"), errorMessage);
     }
@@ -379,7 +379,7 @@ public class TelemetrySpansCommandTests(ITestOutputHelper outputHelper)
 
         var exitCode = await result.InvokeAsync().DefaultTimeout();
 
-        Assert.Equal(ExitCodeConstants.Success, exitCode);
+        Assert.Equal(CliExitCodes.Success, exitCode);
 
         var jsonLine = outputWriter.Logs.Single(l => l.TrimStart().StartsWith('['));
         var formattedJson = TelemetryTestHelper.FormatJson(jsonLine);
@@ -450,7 +450,7 @@ public class TelemetrySpansCommandTests(ITestOutputHelper outputHelper)
 
         var exitCode = await result.InvokeAsync().DefaultTimeout();
 
-        Assert.Equal(ExitCodeConstants.Success, exitCode);
+        Assert.Equal(CliExitCodes.Success, exitCode);
         Assert.NotNull(capturedUrl);
         Assert.Contains("search=", capturedUrl);
     }

--- a/tests/Aspire.Cli.Tests/Commands/TelemetryTracesCommandTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/TelemetryTracesCommandTests.cs
@@ -30,7 +30,7 @@ public class TelemetryTracesCommandTests(ITestOutputHelper outputHelper)
 
         var exitCode = await result.InvokeAsync().DefaultTimeout();
 
-        Assert.Equal(ExitCodeConstants.Success, exitCode);
+        Assert.Equal(CliExitCodes.Success, exitCode);
     }
 
     [Theory]
@@ -48,7 +48,7 @@ public class TelemetryTracesCommandTests(ITestOutputHelper outputHelper)
 
         var exitCode = await result.InvokeAsync().DefaultTimeout();
 
-        Assert.Equal(ExitCodeConstants.InvalidCommand, exitCode);
+        Assert.Equal(CliExitCodes.InvalidCommand, exitCode);
     }
 
     [Fact]
@@ -74,7 +74,7 @@ public class TelemetryTracesCommandTests(ITestOutputHelper outputHelper)
 
         var exitCode = await result.InvokeAsync().DefaultTimeout();
 
-        Assert.Equal(ExitCodeConstants.Success, exitCode);
+        Assert.Equal(CliExitCodes.Success, exitCode);
 
         // Parse table data rows for assertion
         var dataRows = ParseTableDataRows(outputWriter.Logs);
@@ -125,7 +125,7 @@ public class TelemetryTracesCommandTests(ITestOutputHelper outputHelper)
 
         var exitCode = await result.InvokeAsync().DefaultTimeout();
 
-        Assert.Equal(ExitCodeConstants.Success, exitCode);
+        Assert.Equal(CliExitCodes.Success, exitCode);
 
         // Parse table data rows for assertion
         var dataRows = ParseTableDataRows(outputWriter.Logs);
@@ -241,7 +241,7 @@ public class TelemetryTracesCommandTests(ITestOutputHelper outputHelper)
 
         var exitCode = await result.InvokeAsync().DefaultTimeout();
 
-        Assert.Equal(ExitCodeConstants.Success, exitCode);
+        Assert.Equal(CliExitCodes.Success, exitCode);
         var dataRows = ParseTableDataRows(outputWriter.Logs);
         Assert.Single(dataRows);
         Assert.Contains("frontend", dataRows[0][1]);
@@ -265,7 +265,7 @@ public class TelemetryTracesCommandTests(ITestOutputHelper outputHelper)
 
         var exitCode = await result.InvokeAsync().DefaultTimeout();
 
-        Assert.Equal(ExitCodeConstants.InvalidCommand, exitCode);
+        Assert.Equal(CliExitCodes.InvalidCommand, exitCode);
         var errorMessage = Assert.Single(testInteractionService.DisplayedErrors);
         Assert.Equal(TelemetryCommandStrings.DashboardUrlAndAppHostExclusive, errorMessage);
     }
@@ -303,7 +303,7 @@ public class TelemetryTracesCommandTests(ITestOutputHelper outputHelper)
 
         var exitCode = await result.InvokeAsync().DefaultTimeout();
 
-        Assert.Equal(ExitCodeConstants.DashboardFailure, exitCode);
+        Assert.Equal(CliExitCodes.DashboardFailure, exitCode);
         var errorMessage = Assert.Single(testInteractionService.DisplayedErrors);
         Assert.Equal(TelemetryCommandStrings.DashboardAuthFailed, errorMessage);
     }
@@ -386,7 +386,7 @@ public class TelemetryTracesCommandTests(ITestOutputHelper outputHelper)
 
         var exitCode = await result.InvokeAsync().DefaultTimeout();
 
-        Assert.Equal(ExitCodeConstants.Success, exitCode);
+        Assert.Equal(CliExitCodes.Success, exitCode);
 
         var jsonLine = outputWriter.Logs.Single(l => l.TrimStart().StartsWith('['));
         var formattedJson = TelemetryTestHelper.FormatJson(jsonLine);
@@ -470,7 +470,7 @@ public class TelemetryTracesCommandTests(ITestOutputHelper outputHelper)
 
         var exitCode = await result.InvokeAsync().DefaultTimeout();
 
-        Assert.Equal(ExitCodeConstants.Success, exitCode);
+        Assert.Equal(CliExitCodes.Success, exitCode);
 
         var jsonLine = outputWriter.Logs.Single(l => l.TrimStart().StartsWith('['));
         Assert.Equal("[]", jsonLine);
@@ -519,7 +519,7 @@ public class TelemetryTracesCommandTests(ITestOutputHelper outputHelper)
 
         var exitCode = await result.InvokeAsync().DefaultTimeout();
 
-        Assert.Equal(ExitCodeConstants.Success, exitCode);
+        Assert.Equal(CliExitCodes.Success, exitCode);
         Assert.NotNull(capturedUrl);
         Assert.Contains("search=frontend", capturedUrl);
     }

--- a/tests/Aspire.Cli.Tests/Commands/UpdateCommandTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/UpdateCommandTests.cs
@@ -33,7 +33,7 @@ public class UpdateCommandTests(ITestOutputHelper outputHelper)
         var result = command.Parse("update --help");
 
         var exitCode = await result.InvokeAsync().DefaultTimeout();
-        Assert.Equal(ExitCodeConstants.Success, exitCode);
+        Assert.Equal(CliExitCodes.Success, exitCode);
     }
 
     [Theory]
@@ -50,7 +50,7 @@ public class UpdateCommandTests(ITestOutputHelper outputHelper)
         var result = command.Parse(commandLine);
         var exitCode = await result.InvokeAsync().DefaultTimeout();
 
-        Assert.Equal(ExitCodeConstants.InvalidCommand, exitCode);
+        Assert.Equal(CliExitCodes.InvalidCommand, exitCode);
         var error = Assert.Single(result.Errors);
         Assert.Equal(string.Format(System.Globalization.CultureInfo.CurrentCulture, SharedCommandStrings.NonInteractiveRequiresYesFormat, "update"), error.Message);
     }
@@ -98,7 +98,7 @@ public class UpdateCommandTests(ITestOutputHelper outputHelper)
         var exitCode = await result.InvokeAsync().DefaultTimeout();
 
         // Assert
-        Assert.Equal(ExitCodeConstants.Success, exitCode);
+        Assert.Equal(CliExitCodes.Success, exitCode);
         Assert.True(projectLocatorInvoked);
         Assert.NotNull(capturedProjectFile);
         Assert.Equal("AppHost.csproj", capturedProjectFile.Name);
@@ -214,7 +214,7 @@ public class UpdateCommandTests(ITestOutputHelper outputHelper)
         Assert.True(confirmCallbackInvoked, "Confirm prompt should have been shown");
         Assert.NotNull(confirmPrompt);
         Assert.Contains("Would you like to update the Aspire CLI", confirmPrompt);
-        Assert.Equal(ExitCodeConstants.FailedToFindProject, exitCode);
+        Assert.Equal(CliExitCodes.FailedToFindProject, exitCode);
     }
 
     [Fact]
@@ -289,7 +289,7 @@ public class UpdateCommandTests(ITestOutputHelper outputHelper)
         Assert.True(confirmCallbackInvoked, "Confirm prompt should have been shown after successful project update");
         Assert.NotNull(confirmPrompt);
         Assert.Contains("An update is available for the Aspire CLI", confirmPrompt);
-        Assert.Equal(ExitCodeConstants.Success, exitCode);
+        Assert.Equal(CliExitCodes.Success, exitCode);
     }
 
     [Fact]
@@ -360,7 +360,7 @@ public class UpdateCommandTests(ITestOutputHelper outputHelper)
 
         var exitCode = await result.InvokeAsync().DefaultTimeout();
 
-        Assert.Equal(ExitCodeConstants.Success, exitCode);
+        Assert.Equal(CliExitCodes.Success, exitCode);
         Assert.False(downloaderInvoked, "Archive self-update should not be used for dotnet tool installs.");
         Assert.Contains(interactionService.DisplayedPlainText, text => text.Contains("dotnet tool update -g Aspire.Cli", StringComparison.Ordinal));
     }
@@ -435,7 +435,7 @@ public class UpdateCommandTests(ITestOutputHelper outputHelper)
 
         var exitCode = await result.InvokeAsync().DefaultTimeout();
 
-        Assert.Equal(ExitCodeConstants.Success, exitCode);
+        Assert.Equal(CliExitCodes.Success, exitCode);
         Assert.False(downloaderInvoked, "Archive self-update should not be used for dotnet tool installs.");
         Assert.Contains(interactionService.DisplayedPlainText, text => text.Contains($"dotnet tool update --tool-path \"{toolPath}\" Aspire.Cli", StringComparison.Ordinal));
     }
@@ -477,7 +477,7 @@ public class UpdateCommandTests(ITestOutputHelper outputHelper)
 
         var exitCode = await result.InvokeAsync().DefaultTimeout();
 
-        Assert.Equal(ExitCodeConstants.Success, exitCode);
+        Assert.Equal(CliExitCodes.Success, exitCode);
         Assert.True(updateProjectInvoked);
         Assert.False(confirmBindingResolved);
         Assert.False(confirmBindingValue);
@@ -520,7 +520,7 @@ public class UpdateCommandTests(ITestOutputHelper outputHelper)
 
         var exitCode = await result.InvokeAsync().DefaultTimeout();
 
-        Assert.Equal(ExitCodeConstants.Success, exitCode);
+        Assert.Equal(CliExitCodes.Success, exitCode);
         Assert.True(updateProjectInvoked);
         Assert.True(confirmBindingResolved);
         Assert.True(confirmBindingValue);
@@ -594,7 +594,7 @@ public class UpdateCommandTests(ITestOutputHelper outputHelper)
 
         // Assert
         Assert.False(confirmCallbackInvoked, "Confirm prompt should NOT have been shown for channels without CLI download support");
-        Assert.Equal(ExitCodeConstants.Success, exitCode);
+        Assert.Equal(CliExitCodes.Success, exitCode);
     }
 
     [Fact]
@@ -615,7 +615,7 @@ public class UpdateCommandTests(ITestOutputHelper outputHelper)
 
         var exitCode = await result.InvokeAsync().DefaultTimeout();
 
-        Assert.Equal(ExitCodeConstants.Success, exitCode);
+        Assert.Equal(CliExitCodes.Success, exitCode);
         Assert.Contains(interactionService.DisplayedPlainText, text => text.Contains("dotnet tool update -g Aspire.Cli", StringComparison.Ordinal));
     }
 
@@ -639,7 +639,7 @@ public class UpdateCommandTests(ITestOutputHelper outputHelper)
 
         var exitCode = await result.InvokeAsync().DefaultTimeout();
 
-        Assert.Equal(ExitCodeConstants.Success, exitCode);
+        Assert.Equal(CliExitCodes.Success, exitCode);
         Assert.Contains(interactionService.DisplayedPlainText, text => text.Contains($"dotnet tool update --tool-path \"{toolPath}\" Aspire.Cli", StringComparison.Ordinal));
     }
 
@@ -677,7 +677,7 @@ public class UpdateCommandTests(ITestOutputHelper outputHelper)
         var exitCode = await result.InvokeAsync().DefaultTimeout();
 
         Assert.False(confirmCallbackInvoked, "Archive self-update prompt should not be shown for dotnet tool installs.");
-        Assert.Equal(ExitCodeConstants.FailedToFindProject, exitCode);
+        Assert.Equal(CliExitCodes.FailedToFindProject, exitCode);
     }
 
     [Fact]
@@ -873,7 +873,7 @@ public class UpdateCommandTests(ITestOutputHelper outputHelper)
         Assert.False(promptForSelectionInvoked, "Channel prompt should not be shown when --channel is provided");
         Assert.NotNull(capturedChannel);
         Assert.Equal("daily", capturedChannel.Name);
-        Assert.Equal(ExitCodeConstants.Success, exitCode);
+        Assert.Equal(CliExitCodes.Success, exitCode);
     }
 
     [Fact]
@@ -938,7 +938,7 @@ public class UpdateCommandTests(ITestOutputHelper outputHelper)
         Assert.False(promptForSelectionInvoked, "Channel prompt should not be shown when --quality is provided");
         Assert.NotNull(capturedChannel);
         Assert.Equal("daily", capturedChannel.Name);
-        Assert.Equal(ExitCodeConstants.Success, exitCode);
+        Assert.Equal(CliExitCodes.Success, exitCode);
     }
 
     [Fact]
@@ -995,7 +995,7 @@ public class UpdateCommandTests(ITestOutputHelper outputHelper)
         Assert.Contains("invalid", errorMessage);
         Assert.Contains("stable", errorMessage);
         Assert.Contains("daily", errorMessage);
-        Assert.Equal(ExitCodeConstants.FailedToUpgradeProject, exitCode);
+        Assert.Equal(CliExitCodes.FailedToUpgradeProject, exitCode);
     }
 
     [Fact]
@@ -1059,7 +1059,7 @@ public class UpdateCommandTests(ITestOutputHelper outputHelper)
         Assert.False(promptForSelectionInvoked, "Channel prompt should not be shown");
         Assert.NotNull(capturedChannel);
         Assert.Equal("stable", capturedChannel.Name);
-        Assert.Equal(ExitCodeConstants.Success, exitCode);
+        Assert.Equal(CliExitCodes.Success, exitCode);
     }
 
     [Fact]
@@ -1117,7 +1117,7 @@ public class UpdateCommandTests(ITestOutputHelper outputHelper)
 
         // Assert
         Assert.True(cancellationMessageDisplayed, "Cancellation message should have been displayed");
-        Assert.Equal(ExitCodeConstants.Cancelled, exitCode);
+        Assert.Equal(CliExitCodes.Cancelled, exitCode);
     }
 
     [Fact]
@@ -1178,7 +1178,7 @@ public class UpdateCommandTests(ITestOutputHelper outputHelper)
         var exitCode = await result.InvokeAsync().DefaultTimeout();
 
         // Assert
-        Assert.Equal(ExitCodeConstants.Success, exitCode);
+        Assert.Equal(CliExitCodes.Success, exitCode);
         Assert.False(promptForSelectionInvoked, "Channel selection prompt should not be shown when there are no hives");
         Assert.Equal("default", updatedWithChannel); // Implicit channel is named "default"
     }
@@ -1197,7 +1197,7 @@ public class UpdateCommandTests(ITestOutputHelper outputHelper)
             workspace,
             updateArgs: "update");
 
-        Assert.Equal(ExitCodeConstants.Success, exitCode);
+        Assert.Equal(CliExitCodes.Success, exitCode);
         Assert.False(promptInvoked, "Channel selection prompt should not be shown when channel is configured locally");
         Assert.Equal("staging", updatedWithChannel);
     }
@@ -1218,7 +1218,7 @@ public class UpdateCommandTests(ITestOutputHelper outputHelper)
             workspace,
             updateArgs: "update");
 
-        Assert.Equal(ExitCodeConstants.Success, exitCode);
+        Assert.Equal(CliExitCodes.Success, exitCode);
         Assert.False(promptInvoked, "Channel selection prompt should not be shown when channel is configured globally");
         Assert.Equal("staging", updatedWithChannel);
     }
@@ -1236,7 +1236,7 @@ public class UpdateCommandTests(ITestOutputHelper outputHelper)
             workspace,
             updateArgs: "update --channel daily");
 
-        Assert.Equal(ExitCodeConstants.Success, exitCode);
+        Assert.Equal(CliExitCodes.Success, exitCode);
         Assert.False(promptInvoked, "Channel selection prompt should not be shown when --channel is specified");
         Assert.Equal("daily", updatedWithChannel);
     }
@@ -1258,7 +1258,7 @@ public class UpdateCommandTests(ITestOutputHelper outputHelper)
             workspace,
             updateArgs: "update");
 
-        Assert.Equal(ExitCodeConstants.Success, exitCode);
+        Assert.Equal(CliExitCodes.Success, exitCode);
         Assert.False(promptInvoked, "Channel selection prompt should not be shown when channel is configured");
         Assert.Equal("staging", updatedWithChannel);
     }
@@ -1279,7 +1279,7 @@ public class UpdateCommandTests(ITestOutputHelper outputHelper)
             workspace,
             updateArgs: "update");
 
-        Assert.Equal(ExitCodeConstants.Success, exitCode);
+        Assert.Equal(CliExitCodes.Success, exitCode);
         Assert.False(promptInvoked, "Channel selection prompt should not be shown when channel is configured");
         Assert.NotEqual("default", updatedWithChannel);
         Assert.Equal("staging", updatedWithChannel);
@@ -1331,7 +1331,7 @@ public class UpdateCommandTests(ITestOutputHelper outputHelper)
 
         var exitCode = await result.InvokeAsync().DefaultTimeout();
 
-        Assert.Equal(ExitCodeConstants.FailedToUpgradeProject, exitCode);
+        Assert.Equal(CliExitCodes.FailedToUpgradeProject, exitCode);
     }
 
     [Fact]
@@ -1351,7 +1351,7 @@ public class UpdateCommandTests(ITestOutputHelper outputHelper)
             updateArgs: $"update --apphost {Path.Combine(projectDirectory.FullName, "AppHost.csproj")}",
             projectDirectory: projectDirectory);
 
-        Assert.Equal(ExitCodeConstants.Success, exitCode);
+        Assert.Equal(CliExitCodes.Success, exitCode);
         Assert.False(promptInvoked, "Channel selection prompt should not be shown when channel is configured locally to the project");
         Assert.Equal("staging", updatedWithChannel);
     }
@@ -1378,7 +1378,7 @@ public class UpdateCommandTests(ITestOutputHelper outputHelper)
             updateArgs: $"update --apphost {Path.Combine(projectDirectory.FullName, "AppHost.csproj")}",
             projectDirectory: projectDirectory);
 
-        Assert.Equal(ExitCodeConstants.Success, exitCode);
+        Assert.Equal(CliExitCodes.Success, exitCode);
         Assert.False(promptInvoked, "Channel selection prompt should not be shown when channel is configured locally to the project");
         Assert.Equal("staging", updatedWithChannel);
     }
@@ -1408,7 +1408,7 @@ public class UpdateCommandTests(ITestOutputHelper outputHelper)
             updateArgs: $"update --apphost {Path.Combine(projectDirectory.FullName, "AppHost.csproj")}",
             projectDirectory: projectDirectory);
 
-        Assert.Equal(ExitCodeConstants.Success, exitCode);
+        Assert.Equal(CliExitCodes.Success, exitCode);
         Assert.False(promptInvoked, "Channel selection prompt should not be shown when channel is configured globally");
         Assert.Equal("staging", updatedWithChannel);
     }
@@ -1431,7 +1431,7 @@ public class UpdateCommandTests(ITestOutputHelper outputHelper)
             workspace,
             updateArgs: "update --channel daily");
 
-        Assert.Equal(ExitCodeConstants.Success, exitCode);
+        Assert.Equal(CliExitCodes.Success, exitCode);
         Assert.False(promptInvoked, "Channel selection prompt should not be shown when --channel is specified even if hives are present");
         Assert.Equal("daily", updatedWithChannel);
     }
@@ -1455,7 +1455,7 @@ public class UpdateCommandTests(ITestOutputHelper outputHelper)
             workspace,
             updateArgs: "update");
 
-        Assert.Equal(ExitCodeConstants.Success, exitCode);
+        Assert.Equal(CliExitCodes.Success, exitCode);
         Assert.False(promptInvoked, "Channel selection prompt should not be shown when channel is configured locally, even with hives present");
         Assert.Equal("staging", updatedWithChannel);
     }
@@ -1529,7 +1529,7 @@ public class UpdateCommandTests(ITestOutputHelper outputHelper)
         var result = command.Parse("update");
         var exitCode = await result.InvokeAsync().DefaultTimeout();
 
-        Assert.Equal(ExitCodeConstants.Success, exitCode);
+        Assert.Equal(CliExitCodes.Success, exitCode);
         Assert.NotNull(capturedChoices);
         Assert.NotNull(capturedFormatter);
 
@@ -1654,7 +1654,7 @@ public class UpdateCommandTests(ITestOutputHelper outputHelper)
 
         // Assert
         Assert.True(cancellationMessageDisplayed, "Cancellation message should have been displayed");
-        Assert.Equal(ExitCodeConstants.Cancelled, exitCode);
+        Assert.Equal(CliExitCodes.Cancelled, exitCode);
     }
 
     [Fact]
@@ -1838,7 +1838,7 @@ public class UpdateCommandTests(ITestOutputHelper outputHelper)
 
         var exitCode = await result.InvokeAsync().DefaultTimeout();
 
-        Assert.Equal(ExitCodeConstants.Success, exitCode);
+        Assert.Equal(CliExitCodes.Success, exitCode);
         Assert.False(promptForSelectionInvoked, "No selection prompt should be shown in non-interactive mode with --channel");
         Assert.False(confirmCallbackInvoked, "No confirm prompt should be shown in non-interactive mode with --yes");
         Assert.NotNull(capturedChannel);

--- a/tests/Aspire.Cli.Tests/Commands/WaitCommandTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/WaitCommandTests.cs
@@ -24,7 +24,7 @@ public class WaitCommandTests(ITestOutputHelper outputHelper)
 
         var exitCode = await result.InvokeAsync().DefaultTimeout();
 
-        Assert.Equal(ExitCodeConstants.Success, exitCode);
+        Assert.Equal(CliExitCodes.Success, exitCode);
     }
 
     [Fact]
@@ -39,7 +39,7 @@ public class WaitCommandTests(ITestOutputHelper outputHelper)
 
         // Missing required argument should fail
         var exitCode = await result.InvokeAsync().DefaultTimeout();
-        Assert.NotEqual(ExitCodeConstants.Success, exitCode);
+        Assert.NotEqual(CliExitCodes.Success, exitCode);
     }
 
     [Fact]
@@ -53,7 +53,7 @@ public class WaitCommandTests(ITestOutputHelper outputHelper)
         var result = command.Parse("wait myresource --help");
 
         var exitCode = await result.InvokeAsync().DefaultTimeout();
-        Assert.Equal(ExitCodeConstants.Success, exitCode);
+        Assert.Equal(CliExitCodes.Success, exitCode);
     }
 
     [Fact]
@@ -67,7 +67,7 @@ public class WaitCommandTests(ITestOutputHelper outputHelper)
         var result = command.Parse("wait myresource --apphost /path/to/project.csproj --help");
 
         var exitCode = await result.InvokeAsync().DefaultTimeout();
-        Assert.Equal(ExitCodeConstants.Success, exitCode);
+        Assert.Equal(CliExitCodes.Success, exitCode);
     }
 
     [Fact]
@@ -81,7 +81,7 @@ public class WaitCommandTests(ITestOutputHelper outputHelper)
         var result = command.Parse("wait myresource --status up --help");
 
         var exitCode = await result.InvokeAsync().DefaultTimeout();
-        Assert.Equal(ExitCodeConstants.Success, exitCode);
+        Assert.Equal(CliExitCodes.Success, exitCode);
     }
 
     [Fact]
@@ -95,7 +95,7 @@ public class WaitCommandTests(ITestOutputHelper outputHelper)
         var result = command.Parse("wait myresource --timeout 60 --help");
 
         var exitCode = await result.InvokeAsync().DefaultTimeout();
-        Assert.Equal(ExitCodeConstants.Success, exitCode);
+        Assert.Equal(CliExitCodes.Success, exitCode);
     }
 
     [Theory]
@@ -112,7 +112,7 @@ public class WaitCommandTests(ITestOutputHelper outputHelper)
         var result = command.Parse($"wait myresource --status {status} --help");
 
         var exitCode = await result.InvokeAsync().DefaultTimeout();
-        Assert.Equal(ExitCodeConstants.Success, exitCode);
+        Assert.Equal(CliExitCodes.Success, exitCode);
     }
 
     [Theory]
@@ -129,7 +129,7 @@ public class WaitCommandTests(ITestOutputHelper outputHelper)
         var result = command.Parse($"wait myresource --status {status} --help");
 
         var exitCode = await result.InvokeAsync().DefaultTimeout();
-        Assert.Equal(ExitCodeConstants.Success, exitCode);
+        Assert.Equal(CliExitCodes.Success, exitCode);
     }
 
     [Fact]
@@ -159,7 +159,7 @@ public class WaitCommandTests(ITestOutputHelper outputHelper)
         var result = command.Parse("wait nonexistent --timeout 5");
 
         var exitCode = await result.InvokeAsync().DefaultTimeout();
-        Assert.Equal(ExitCodeConstants.WaitResourceFailed, exitCode);
+        Assert.Equal(CliExitCodes.WaitResourceFailed, exitCode);
     }
 
     [Fact]
@@ -184,7 +184,7 @@ public class WaitCommandTests(ITestOutputHelper outputHelper)
         var result = command.Parse("wait myapp --status up --timeout 5");
 
         var exitCode = await result.InvokeAsync().DefaultTimeout();
-        Assert.Equal(ExitCodeConstants.Success, exitCode);
+        Assert.Equal(CliExitCodes.Success, exitCode);
     }
 
     [Fact]
@@ -209,7 +209,7 @@ public class WaitCommandTests(ITestOutputHelper outputHelper)
         var result = command.Parse("wait mydb --status healthy --timeout 5");
 
         var exitCode = await result.InvokeAsync().DefaultTimeout();
-        Assert.Equal(ExitCodeConstants.Success, exitCode);
+        Assert.Equal(CliExitCodes.Success, exitCode);
     }
 
     [Fact]
@@ -239,7 +239,7 @@ public class WaitCommandTests(ITestOutputHelper outputHelper)
         var result = command.Parse("wait mydb --status healthy --timeout 2");
 
         var exitCode = await result.InvokeAsync().DefaultTimeout();
-        Assert.Equal(ExitCodeConstants.WaitTimeout, exitCode);
+        Assert.Equal(CliExitCodes.WaitTimeout, exitCode);
     }
 
     [Fact]
@@ -264,7 +264,7 @@ public class WaitCommandTests(ITestOutputHelper outputHelper)
         var result = command.Parse("wait worker --status down --timeout 5");
 
         var exitCode = await result.InvokeAsync().DefaultTimeout();
-        Assert.Equal(ExitCodeConstants.Success, exitCode);
+        Assert.Equal(CliExitCodes.Success, exitCode);
     }
 
     [Fact]
@@ -294,6 +294,6 @@ public class WaitCommandTests(ITestOutputHelper outputHelper)
         var result = command.Parse("wait myapp --status up --timeout 5");
 
         var exitCode = await result.InvokeAsync().DefaultTimeout();
-        Assert.Equal(ExitCodeConstants.WaitResourceFailed, exitCode);
+        Assert.Equal(CliExitCodes.WaitResourceFailed, exitCode);
     }
 }

--- a/tests/Aspire.Cli.Tests/DotNet/DotNetCliRunnerTests.cs
+++ b/tests/Aspire.Cli.Tests/DotNet/DotNetCliRunnerTests.cs
@@ -619,7 +619,7 @@ public class DotNetCliRunnerTests(ITestOutputHelper outputHelper)
             cancellationToken: CancellationToken.None).DefaultTimeout();
 
         await launchAppHostCalledTcs.Task.DefaultTimeout();
-        Assert.Equal(ExitCodeConstants.Success, exitCode);
+        Assert.Equal(CliExitCodes.Success, exitCode);
     }
 
     [Fact]
@@ -1813,5 +1813,44 @@ public class DotNetCliRunnerTests(ITestOutputHelper outputHelper)
             CancellationToken.None).DefaultTimeout();
 
         Assert.Equal(0, exitCode);
+    }
+
+    [Fact]
+    public async Task RunAsyncSetsCliLogFilePathEnvironmentVariable()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        var projectFile = new FileInfo(Path.Combine(workspace.WorkspaceRoot.FullName, "AppHost.csproj"));
+        await File.WriteAllTextAsync(projectFile.FullName, "Not a real project file.");
+
+        var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper);
+        using var provider = services.BuildServiceProvider();
+
+        var options = new ProcessInvocationOptions();
+
+        Dictionary<string, string>? capturedEnv = null;
+        var executionContext = CreateExecutionContext(workspace.WorkspaceRoot);
+        var runner = DotNetCliRunnerTestHelper.Create(
+            provider,
+            executionContext,
+            (args, env, _, _) =>
+            {
+                capturedEnv = env?.ToDictionary();
+            },
+            0);
+
+        var exitCode = await runner.RunAsync(
+            projectFile: projectFile,
+            watch: false,
+            noBuild: true,
+            noRestore: true,
+            args: ["--operation", "inspect"],
+            env: new Dictionary<string, string>(),
+            null,
+            options,
+            CancellationToken.None).DefaultTimeout();
+
+        Assert.Equal(0, exitCode);
+        Assert.NotNull(capturedEnv);
+        Assert.Equal(executionContext.LogFilePath, capturedEnv[KnownConfigNames.CliLogFilePath]);
     }
 }

--- a/tests/Aspire.Cli.Tests/Projects/AppHostServerProjectTests.cs
+++ b/tests/Aspire.Cli.Tests/Projects/AppHostServerProjectTests.cs
@@ -296,7 +296,7 @@ public class AppHostServerProjectTests(ITestOutputHelper outputHelper) : IDispos
         };
 
         var runner = new TestDotNetCliRunner();
-        
+
         // Use a real logger to capture debug output for diagnostics
         using var loggerFactory = LoggerFactory.Create(builder =>
         {
@@ -355,12 +355,12 @@ public class AppHostServerProjectTests(ITestOutputHelper outputHelper) : IDispos
     {
         var dirInfo = new DirectoryInfo(path);
         output.WriteLine($"{indent}{dirInfo.Name}/");
-        
+
         foreach (var file in dirInfo.GetFiles())
         {
             output.WriteLine($"{indent}  {file.Name}");
         }
-        
+
         foreach (var dir in dirInfo.GetDirectories())
         {
             DumpDirectoryTree(dir.FullName, output, indent + "  ");

--- a/tests/Aspire.Cli.Tests/Projects/GuestAppHostProjectTests.cs
+++ b/tests/Aspire.Cli.Tests/Projects/GuestAppHostProjectTests.cs
@@ -678,7 +678,7 @@ public class GuestAppHostProjectTests : IDisposable
         };
 
         var exitCode = await project.RunAsync(context, CancellationToken.None);
-        Assert.Equal(ExitCodeConstants.FailedToBuildArtifacts, exitCode);
+        Assert.Equal(CliExitCodes.FailedToBuildArtifacts, exitCode);
 
         var reloaded = AspireConfigFile.Load(_workspace.WorkspaceRoot.FullName);
         Assert.NotNull(reloaded);

--- a/tests/Aspire.Cli.Tests/Projects/PrebuiltAppHostServerTests.cs
+++ b/tests/Aspire.Cli.Tests/Projects/PrebuiltAppHostServerTests.cs
@@ -13,6 +13,7 @@ using Aspire.Cli.Tests.TestServices;
 using Aspire.Cli.Tests.Utils;
 using Aspire.Hosting;
 using Aspire.Shared;
+using Microsoft.Extensions.Logging.Abstractions;
 
 namespace Aspire.Cli.Tests.Projects;
 
@@ -1175,6 +1176,35 @@ public class PrebuiltAppHostServerTests(ITestOutputHelper outputHelper)
             typeof(PrebuiltAppHostServer)
                 .GetField("_workingDirectory", System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic)!
                 .GetValue(server));
+    }
+
+    [Fact]
+    public void CreateStartInfo_SetsCliLogFilePathEnvironmentVariable()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        var layout = CreateBundleLayout(workspace);
+        var executionContext = TestExecutionContextFactory.CreateTestContext();
+        var nugetService = new BundleNuGetService(
+            new FixedLayoutDiscovery(layout),
+            new LayoutProcessRunner(new TestProcessExecutionFactory()),
+            new TestFeatures(),
+            executionContext,
+            NullLogger<BundleNuGetService>.Instance);
+
+        var server = new PrebuiltAppHostServer(
+            workspace.WorkspaceRoot.FullName,
+            "test.sock",
+            layout,
+            nugetService,
+            new TestDotNetCliRunner(),
+            new TestDotNetSdkInstaller(),
+            MockPackagingServiceFactory.Create(),
+            executionContext,
+            NullLogger<PrebuiltAppHostServer>.Instance);
+
+        var startInfo = server.CreateStartInfo(123);
+
+        Assert.Equal(executionContext.LogFilePath, startInfo.Environment[KnownConfigNames.CliLogFilePath]);
     }
 
     private static void DeleteWorkingDirectory(string workingDirectory)

--- a/tests/Aspire.Cli.Tests/TestServices/TestAppHostAuxiliaryBackchannel.cs
+++ b/tests/Aspire.Cli.Tests/TestServices/TestAppHostAuxiliaryBackchannel.cs
@@ -107,7 +107,8 @@ internal sealed class TestAppHostAuxiliaryBackchannel : IAppHostAuxiliaryBackcha
             AspireHostVersion = "unknown",
             AppHostPath = AppHostInfo.AppHostPath,
             CliProcessId = AppHostInfo.CliProcessId,
-            StartedAt = AppHostInfo.StartedAt
+            StartedAt = AppHostInfo.StartedAt,
+            CliLogFilePath = AppHostInfo.CliLogFilePath
         });
     }
 

--- a/tests/Aspire.Hosting.Tests/Backchannel/AuxiliaryBackchannelRpcTargetTests.cs
+++ b/tests/Aspire.Hosting.Tests/Backchannel/AuxiliaryBackchannelRpcTargetTests.cs
@@ -1400,6 +1400,62 @@ public class AuxiliaryBackchannelRpcTargetTests(ITestOutputHelper outputHelper)
 
         await app.StopAsync().DefaultTimeout();
     }
+
+    [Fact]
+    public async Task GetAppHostInformationAsync_ReturnsCliLogFilePath_WhenConfigured()
+    {
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["AppHost:Path"] = "/path/to/apphost.csproj",
+                [KnownConfigNames.CliProcessId] = "5678",
+                [KnownConfigNames.CliLogFilePath] = "/logs/cli_20260516T120000_abcd1234.log"
+            })
+            .Build();
+
+        using var services = new ServiceCollection()
+            .AddSingleton<IConfiguration>(configuration)
+            .AddSingleton<ProfilingTelemetry>()
+            .BuildServiceProvider();
+
+        var target = new AuxiliaryBackchannelRpcTarget(
+            NullLogger<AuxiliaryBackchannelRpcTarget>.Instance,
+            configuration,
+            services.GetRequiredService<ProfilingTelemetry>(),
+            services);
+
+        var result = await target.GetAppHostInformationAsync().DefaultTimeout();
+
+        Assert.Equal("/logs/cli_20260516T120000_abcd1234.log", result.CliLogFilePath);
+        Assert.Equal(5678, result.CliProcessId);
+    }
+
+    [Fact]
+    public async Task GetAppHostInfoAsync_IncludesCliLogFilePath()
+    {
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["AppHost:Path"] = "/path/to/apphost.csproj",
+                [KnownConfigNames.CliLogFilePath] = "/logs/cli_session.log"
+            })
+            .Build();
+
+        using var services = new ServiceCollection()
+            .AddSingleton<IConfiguration>(configuration)
+            .AddSingleton<ProfilingTelemetry>()
+            .BuildServiceProvider();
+
+        var target = new AuxiliaryBackchannelRpcTarget(
+            NullLogger<AuxiliaryBackchannelRpcTarget>.Instance,
+            configuration,
+            services.GetRequiredService<ProfilingTelemetry>(),
+            services);
+
+        var result = await target.GetAppHostInfoAsync().DefaultTimeout();
+
+        Assert.Equal("/logs/cli_session.log", result.CliLogFilePath);
+    }
 }
 
 #pragma warning restore ASPIREINTERACTION001


### PR DESCRIPTION
## Description

When the Aspire CLI connects to a running app host, the CLI log file path is now communicated back through the backchannel so it can be surfaced to users. This helps users find relevant CLI logs for debugging, especially when a resource command fails.

Fixes #17012

### Changes

- **Environment variable propagation**: The CLI sets `ASPIRE_CLI_LOG_FILE` when launching the app host, so the app host knows the log file location.
- **Backchannel return**: The app host returns `CliLogFilePath` through both the legacy `AppHostInformation` and V2 `GetAppHostInfoResponse` backchannel types.
- **Failed command output**: When a resource command execution fails, the CLI now prints the log file path so users can inspect detailed logs.
- **`aspire ps` output**: A new "Logs" column is conditionally displayed in the table output (only when at least one app host has a log path). The log path is rendered as a clickable file link with just the filename as display text. The JSON output includes a `logFilePath` field.
- **Rename `ExitCodeConstants` → `CliExitCodes`**: Moved the exit code constants to a shared file (`src/Shared/CliExitCodes.cs`) and renamed the class for clarity. This is a mechanical rename across all CLI source and test files.
- **New `CommandResults.Success(string)` overload**: Added a convenience overload for producing a success result with a message (used in E2E test app host code).

### User-facing usage

When a resource command fails, the CLI now shows the log path:

```
See logs at ~/.aspire/logs/cli_20260516T123456_abc12345.log
See AppHost logs at ~/.aspire/logs/cli_20260516T123456_def67890.log
```

The `aspire ps` command includes a "Logs" column with a clickable link to the log file:

```
┌──────────────┬─────────┬───────┬─────────┬──────────────────────────────────┬───────────────────────────────┐
│ Path         │ SDK     │ PID   │ CLI PID │ Logs                             │ Dashboard                     │
├──────────────┼─────────┼───────┼─────────┼──────────────────────────────────┼───────────────────────────────┤
│ ./AppHost    │ 10.0.0  │ 12345 │ 67890   │ cli_20260516T123456_abc12345.log │ http://localhost:18888/login.. │
└──────────────┴─────────┴───────┴─────────┴──────────────────────────────────┴───────────────────────────────┘
```

JSON output (`aspire ps --format json`) includes:
```json
[
  {
    "appHostPath": "./AppHost",
    "appHostPid": 12345,
    "cliPid": 67890,
    "logFilePath": "~/.aspire/logs/cli_20260516T123456_abc12345.log",
    "dashboardUrl": "http://localhost:18888/login?t=..."
  }
]
```

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [x] Yes — `CommandResults.Success(string message)` overload in `Aspire.Hosting`
  - [ ] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
  - [x] No
