### PR TITLE
Bump OpenTelemetry JS deps to address GHSA-q7rr-3cgh-j5r3

### DIFF
--- a/playground/JavaAppHost/api/package.json
+++ b/playground/JavaAppHost/api/package.json
@@ -6,13 +6,13 @@
     "start": "tsx src/index.ts"
   },
   "dependencies": {
-    "@opentelemetry/auto-instrumentations-node": "^0.71.0",
-    "@opentelemetry/exporter-logs-otlp-grpc": "^0.213.0",
-    "@opentelemetry/exporter-metrics-otlp-grpc": "^0.213.0",
-    "@opentelemetry/exporter-trace-otlp-grpc": "^0.213.0",
-    "@opentelemetry/sdk-logs": "^0.213.0",
-    "@opentelemetry/sdk-metrics": "^2.6.0",
-    "@opentelemetry/sdk-node": "^0.213.0",
+    "@opentelemetry/auto-instrumentations-node": "^0.76.0",
+    "@opentelemetry/exporter-logs-otlp-grpc": "^0.218.0",
+    "@opentelemetry/exporter-metrics-otlp-grpc": "^0.218.0",
+    "@opentelemetry/exporter-trace-otlp-grpc": "^0.218.0",
+    "@opentelemetry/sdk-logs": "^0.218.0",
+    "@opentelemetry/sdk-metrics": "^2.7.1",
+    "@opentelemetry/sdk-node": "^0.218.0",
     "express": "^5.1.0"
   },
   "devDependencies": {

--- a/src/Aspire.Cli/Templating/Templates/java-starter/api/package.json
+++ b/src/Aspire.Cli/Templating/Templates/java-starter/api/package.json
@@ -6,13 +6,13 @@
     "start": "tsx src/index.ts"
   },
   "dependencies": {
-    "@opentelemetry/auto-instrumentations-node": "^0.71.0",
-    "@opentelemetry/exporter-logs-otlp-grpc": "^0.213.0",
-    "@opentelemetry/exporter-metrics-otlp-grpc": "^0.213.0",
-    "@opentelemetry/exporter-trace-otlp-grpc": "^0.213.0",
-    "@opentelemetry/sdk-logs": "^0.213.0",
-    "@opentelemetry/sdk-metrics": "^2.6.0",
-    "@opentelemetry/sdk-node": "^0.213.0",
+    "@opentelemetry/auto-instrumentations-node": "^0.76.0",
+    "@opentelemetry/exporter-logs-otlp-grpc": "^0.218.0",
+    "@opentelemetry/exporter-metrics-otlp-grpc": "^0.218.0",
+    "@opentelemetry/exporter-trace-otlp-grpc": "^0.218.0",
+    "@opentelemetry/sdk-logs": "^0.218.0",
+    "@opentelemetry/sdk-metrics": "^2.7.1",
+    "@opentelemetry/sdk-node": "^0.218.0",
     "express": "^5.1.0"
   },
   "devDependencies": {

--- a/src/Aspire.Cli/Templating/Templates/ts-starter/api/package.json
+++ b/src/Aspire.Cli/Templating/Templates/ts-starter/api/package.json
@@ -6,13 +6,13 @@
     "start": "tsx src/index.ts"
   },
   "dependencies": {
-    "@opentelemetry/auto-instrumentations-node": "^0.71.0",
-    "@opentelemetry/exporter-logs-otlp-grpc": "^0.213.0",
-    "@opentelemetry/exporter-metrics-otlp-grpc": "^0.213.0",
-    "@opentelemetry/exporter-trace-otlp-grpc": "^0.213.0",
-    "@opentelemetry/sdk-logs": "^0.213.0",
-    "@opentelemetry/sdk-metrics": "^2.6.0",
-    "@opentelemetry/sdk-node": "^0.213.0",
+    "@opentelemetry/auto-instrumentations-node": "^0.76.0",
+    "@opentelemetry/exporter-logs-otlp-grpc": "^0.218.0",
+    "@opentelemetry/exporter-metrics-otlp-grpc": "^0.218.0",
+    "@opentelemetry/exporter-trace-otlp-grpc": "^0.218.0",
+    "@opentelemetry/sdk-logs": "^0.218.0",
+    "@opentelemetry/sdk-metrics": "^2.7.1",
+    "@opentelemetry/sdk-node": "^0.218.0",
     "express": "^5.1.0"
   },
   "devDependencies": {


### PR DESCRIPTION
## Summary

Patches **6 of the 29 open Dependabot alerts** on this repo by bumping OpenTelemetry JS dependencies in three JavaScript manifests. The remaining 23 alerts are covered by [#17157](https://github.com/microsoft/aspire/pull/17157) (Dependabot) and are intentionally out of scope here.

| GHSA | Severity | Package | Vulnerable | Patched at |
| --- | --- | --- | --- | --- |
| [GHSA-q7rr-3cgh-j5r3](https://github.com/advisories/GHSA-q7rr-3cgh-j5r3) | High | `@opentelemetry/sdk-node` | `< 0.217.0` | `0.217.0` |
| [GHSA-q7rr-3cgh-j5r3](https://github.com/advisories/GHSA-q7rr-3cgh-j5r3) | High | `@opentelemetry/auto-instrumentations-node` | `< 0.75.0` | `0.75.0` |

> _Prometheus exporter process crash via malformed HTTP request._ Both packages ship the affected exporter; either path triggers the same DoS.

Alert numbers fixed: **#1033, #1034, #1035, #1040, #1041, #1042**.

## Why the bigger bump (`^0.213.0` → `^0.218.0`, etc.)

The minimum patched versions are `sdk-node@0.217.0` / `auto-instrumentations-node@0.75.0`, but the OpenTelemetry JS SDK packages release in lockstep and `@opentelemetry/sdk-node` pins its transitive deps to **exact** matching versions (e.g. `"@opentelemetry/exporter-trace-otlp-grpc": "0.218.0"`). Leaving the other manifest entries at `^0.213.0` while bumping `sdk-node` to `^0.218.0` would still resolve correctly via the caret range, but the manifest would be misleading. Aligning the whole set to the current release wave (`0.218.0` for unstable packages, `2.7.1` for stable `sdk-metrics`) keeps the manifest honest about what actually installs.

## Files

- `playground/JavaAppHost/api/package.json`
- `src/Aspire.Cli/Templating/Templates/java-starter/api/package.json`
- `src/Aspire.Cli/Templating/Templates/ts-starter/api/package.json`

These three files have no committed lockfile, which is why Dependabot didn't auto-bump them along with the lockfile-based manifests in [#17157](https://github.com/microsoft/aspire/pull/17157).

## Why Dependabot couldn't do this

Dependabot's npm/yarn updater needs a lockfile to compute a deterministic update. For manifests without one, it skips the bump even when the package.json range is vulnerable — that's why all 6 OTel alerts show up against `package.json` (not `package-lock.json`) and why none of them appear in #17157.

## Validation

Validated locally with `npm install --package-lock-only` against a scratch copy of `playground/JavaAppHost/api/package.json`:

```text
@opentelemetry/auto-instrumentations-node   0.76.0
@opentelemetry/exporter-logs-otlp-grpc      0.218.0
@opentelemetry/exporter-metrics-otlp-grpc   0.218.0
@opentelemetry/exporter-trace-otlp-grpc     0.218.0
@opentelemetry/sdk-logs                     0.218.0
@opentelemetry/sdk-metrics                  2.7.1
@opentelemetry/sdk-node                     0.218.0
```

`npm audit` against the resolved tree reports **0 vulnerabilities**.

## Risk notes for reviewers

- OpenTelemetry JS unstable packages (`0.x`) can include breaking changes between minors. This jumps from `0.213` → `0.218` (5 minor releases). The user-facing surface in the affected files is just `new NodeSDK({...}).start()` in the templates / playground, which has been stable across recent minors, but reviewers may want to pin tighter (e.g. exact `0.217.0` / `0.75.0`) if a more conservative change is preferred.
- None of these three manifests are exercised by CI builds or tests in this repo (no lockfile, no `npm install` step in CI). The blast radius is: (a) `aspire init` users templating `java-starter` or `ts-starter` and then running `npm install`, and (b) anyone running the `JavaAppHost` playground locally.

## Related

- Dependabot PR #17157 covers the remaining 23 alerts (`fast-uri`, `@babel/plugin-transform-modules-systemjs`, `next`) across the lockfile-based manifests in `extension/`, `playground/AspireWithJavaScript/{Angular,React}/`, and `tests/.../JsPublish/nextjs/`.
