### PR TITLE
Unpreview Aspire CLI deployment commands

### DIFF
--- a/src/Aspire.Cli/README.md
+++ b/src/Aspire.Cli/README.md
@@ -29,7 +29,7 @@ aspire <command> [options]
 | `new` | Create a new app from an Aspire starter template. |
 | `init` | Initialize Aspire in an existing codebase. |
 | `add [<integration>]` | Add a hosting integration to the apphost. |
-| `update` | Update integrations in the Aspire project. (Preview) |
+| `update` | Update integrations in the Aspire project. |
 | `run` | Run an apphost in development mode. |
 | `stop` | Stop a running apphost or the specified resource. |
 | `ps` | List running apphosts. |
@@ -56,9 +56,10 @@ aspire <command> [options]
 
 | Command | Description |
 |---------|-------------|
-| `publish` | Generate deployment artifacts for an apphost. (Preview) |
-| `deploy` | Deploy an apphost to its deployment targets. (Preview) |
-| `do <step>` | Execute a specific pipeline step and its dependencies. (Preview) |
+| `publish` | Generate deployment artifacts for an apphost. |
+| `deploy` | Deploy an apphost to its deployment targets. |
+| `destroy` | Destroy a previously deployed AppHost environment. |
+| `do <step>` | Execute a specific pipeline step and its dependencies. |
 
 ### Tools & Configuration
 

--- a/src/Aspire.Cli/Resources/DeployCommandStrings.Designer.cs
+++ b/src/Aspire.Cli/Resources/DeployCommandStrings.Designer.cs
@@ -70,7 +70,7 @@ namespace Aspire.Cli.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Deploy an Aspire apphost project to its supported deployment targets. (Preview).
+        ///   Looks up a localized string similar to Deploy an Aspire apphost project to its supported deployment targets.
         /// </summary>
         public static string Description {
             get {

--- a/src/Aspire.Cli/Resources/DeployCommandStrings.resx
+++ b/src/Aspire.Cli/Resources/DeployCommandStrings.resx
@@ -118,7 +118,7 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="Description" xml:space="preserve">
-    <value>Deploy an AppHost to its deployment targets (Preview)</value>
+    <value>Deploy an AppHost to its deployment targets</value>
   </data>
   <data name="OutputPathArgumentDescription" xml:space="preserve">
     <value>The optional output path for deployment artifacts</value>

--- a/src/Aspire.Cli/Resources/DestroyCommandStrings.Designer.cs
+++ b/src/Aspire.Cli/Resources/DestroyCommandStrings.Designer.cs
@@ -70,7 +70,7 @@ namespace Aspire.Cli.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Destroy a previously deployed AppHost environment (Preview).
+        ///   Looks up a localized string similar to Destroy a previously deployed AppHost environment.
         /// </summary>
         public static string Description {
             get {

--- a/src/Aspire.Cli/Resources/DestroyCommandStrings.resx
+++ b/src/Aspire.Cli/Resources/DestroyCommandStrings.resx
@@ -118,7 +118,7 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="Description" xml:space="preserve">
-    <value>Destroy a previously deployed AppHost environment (Preview)</value>
+    <value>Destroy a previously deployed AppHost environment</value>
   </data>
   <data name="OutputPathArgumentDescription" xml:space="preserve">
     <value>The output path containing the deployment artifacts to destroy</value>

--- a/src/Aspire.Cli/Resources/DoCommandStrings.Designer.cs
+++ b/src/Aspire.Cli/Resources/DoCommandStrings.Designer.cs
@@ -61,7 +61,7 @@ namespace Aspire.Cli.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Execute a specific pipeline step and its dependencies. (Preview).
+        ///   Looks up a localized string similar to Execute a specific pipeline step and its dependencies.
         /// </summary>
         public static string Description {
             get {

--- a/src/Aspire.Cli/Resources/DoCommandStrings.resx
+++ b/src/Aspire.Cli/Resources/DoCommandStrings.resx
@@ -118,7 +118,7 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="Description" xml:space="preserve">
-    <value>Execute a specific pipeline step and its dependencies (Preview)</value>
+    <value>Execute a specific pipeline step and its dependencies</value>
   </data>
   <data name="OutputPathArgumentDescription" xml:space="preserve">
     <value>The optional output path for artifacts</value>

--- a/src/Aspire.Cli/Resources/PublishCommandStrings.Designer.cs
+++ b/src/Aspire.Cli/Resources/PublishCommandStrings.Designer.cs
@@ -61,7 +61,7 @@ namespace Aspire.Cli.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Generates deployment artifacts for an Aspire apphost. (Preview).
+        ///   Looks up a localized string similar to Generates deployment artifacts for an Aspire apphost.
         /// </summary>
         public static string Description {
             get {

--- a/src/Aspire.Cli/Resources/PublishCommandStrings.resx
+++ b/src/Aspire.Cli/Resources/PublishCommandStrings.resx
@@ -118,7 +118,7 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="Description" xml:space="preserve">
-    <value>Generate deployment artifacts for an AppHost (Preview)</value>
+    <value>Generate deployment artifacts for an AppHost</value>
   </data>
   <data name="SelectAPublisher" xml:space="preserve">
     <value>Select a publisher:</value>

--- a/src/Aspire.Cli/Resources/UpdateCommandStrings.Designer.cs
+++ b/src/Aspire.Cli/Resources/UpdateCommandStrings.Designer.cs
@@ -50,7 +50,7 @@ namespace Aspire.Cli.Resources {
         }
 
         /// <summary>
-        ///   Looks up a localized string similar to Update integrations in the Aspire project. (Preview)
+        ///   Looks up a localized string similar to Update integrations in the Aspire project.
         /// </summary>
         internal static string Description {
             get {

--- a/src/Aspire.Cli/Resources/UpdateCommandStrings.resx
+++ b/src/Aspire.Cli/Resources/UpdateCommandStrings.resx
@@ -13,7 +13,7 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="Description" xml:space="preserve">
-    <value>Update integrations in the Aspire project (Preview)</value>
+    <value>Update integrations in the Aspire project</value>
   </data>
   <data name="ProjectArgumentDescription" xml:space="preserve">
     <value>The path to the Aspire AppHost project file or a directory to search</value>

--- a/src/Aspire.Cli/Resources/xlf/DeployCommandStrings.cs.xlf
+++ b/src/Aspire.Cli/Resources/xlf/DeployCommandStrings.cs.xlf
@@ -13,8 +13,8 @@
         <note />
       </trans-unit>
       <trans-unit id="Description">
-        <source>Deploy an AppHost to its deployment targets (Preview)</source>
-        <target state="needs-review-translation">Nasaďte obsah hostitele aplikací Aspire do svých definovaných cílů nasazení. (Preview)</target>
+        <source>Deploy an AppHost to its deployment targets</source>
+        <target state="needs-review-translation">Nasaďte obsah hostitele aplikací Aspire do svých definovaných cílů nasazení.</target>
         <note />
       </trans-unit>
       <trans-unit id="OperationCompletedPrefix">

--- a/src/Aspire.Cli/Resources/xlf/DeployCommandStrings.de.xlf
+++ b/src/Aspire.Cli/Resources/xlf/DeployCommandStrings.de.xlf
@@ -13,7 +13,7 @@
         <note />
       </trans-unit>
       <trans-unit id="Description">
-        <source>Deploy an AppHost to its deployment targets (Preview)</source>
+        <source>Deploy an AppHost to its deployment targets</source>
         <target state="needs-review-translation">Stellen Sie die Inhalte eines Aspire-AppHosts auf den definierten Bereitstellungszielen bereit. (Vorschau)</target>
         <note />
       </trans-unit>

--- a/src/Aspire.Cli/Resources/xlf/DeployCommandStrings.es.xlf
+++ b/src/Aspire.Cli/Resources/xlf/DeployCommandStrings.es.xlf
@@ -13,7 +13,7 @@
         <note />
       </trans-unit>
       <trans-unit id="Description">
-        <source>Deploy an AppHost to its deployment targets (Preview)</source>
+        <source>Deploy an AppHost to its deployment targets</source>
         <target state="needs-review-translation">Implemente el contenido de un AppHost de Aspire en sus destinos de implementación definidos. (Versión preliminar)</target>
         <note />
       </trans-unit>

--- a/src/Aspire.Cli/Resources/xlf/DeployCommandStrings.fr.xlf
+++ b/src/Aspire.Cli/Resources/xlf/DeployCommandStrings.fr.xlf
@@ -13,7 +13,7 @@
         <note />
       </trans-unit>
       <trans-unit id="Description">
-        <source>Deploy an AppHost to its deployment targets (Preview)</source>
+        <source>Deploy an AppHost to its deployment targets</source>
         <target state="needs-review-translation">Déployez le contenu d’un Aspire AppHost vers les cibles de déploiement définies. (Préversion)</target>
         <note />
       </trans-unit>

--- a/src/Aspire.Cli/Resources/xlf/DeployCommandStrings.it.xlf
+++ b/src/Aspire.Cli/Resources/xlf/DeployCommandStrings.it.xlf
@@ -13,7 +13,7 @@
         <note />
       </trans-unit>
       <trans-unit id="Description">
-        <source>Deploy an AppHost to its deployment targets (Preview)</source>
+        <source>Deploy an AppHost to its deployment targets</source>
         <target state="needs-review-translation">Distribuire il contenuto di un AppHost Aspire alle destinazioni di distribuzione definite. (Anteprima)</target>
         <note />
       </trans-unit>

--- a/src/Aspire.Cli/Resources/xlf/DeployCommandStrings.ja.xlf
+++ b/src/Aspire.Cli/Resources/xlf/DeployCommandStrings.ja.xlf
@@ -13,7 +13,7 @@
         <note />
       </trans-unit>
       <trans-unit id="Description">
-        <source>Deploy an AppHost to its deployment targets (Preview)</source>
+        <source>Deploy an AppHost to its deployment targets</source>
         <target state="needs-review-translation">Aspire AppHost のコンテンツを定義された展開先にデプロイします。(プレビュー)</target>
         <note />
       </trans-unit>

--- a/src/Aspire.Cli/Resources/xlf/DeployCommandStrings.ko.xlf
+++ b/src/Aspire.Cli/Resources/xlf/DeployCommandStrings.ko.xlf
@@ -13,7 +13,7 @@
         <note />
       </trans-unit>
       <trans-unit id="Description">
-        <source>Deploy an AppHost to its deployment targets (Preview)</source>
+        <source>Deploy an AppHost to its deployment targets</source>
         <target state="needs-review-translation">Aspire 앱호스트의 콘텐츠를 정의된 배포 대상에 배포하세요. (미리 보기)</target>
         <note />
       </trans-unit>

--- a/src/Aspire.Cli/Resources/xlf/DeployCommandStrings.pl.xlf
+++ b/src/Aspire.Cli/Resources/xlf/DeployCommandStrings.pl.xlf
@@ -13,7 +13,7 @@
         <note />
       </trans-unit>
       <trans-unit id="Description">
-        <source>Deploy an AppHost to its deployment targets (Preview)</source>
+        <source>Deploy an AppHost to its deployment targets</source>
         <target state="needs-review-translation">Wdróż zawartość hosta AppHost platformy Aspire w zdefiniowanych miejscach docelowych wdrożenia. (Wersja zapoznawcza)</target>
         <note />
       </trans-unit>

--- a/src/Aspire.Cli/Resources/xlf/DeployCommandStrings.pt-BR.xlf
+++ b/src/Aspire.Cli/Resources/xlf/DeployCommandStrings.pt-BR.xlf
@@ -13,7 +13,7 @@
         <note />
       </trans-unit>
       <trans-unit id="Description">
-        <source>Deploy an AppHost to its deployment targets (Preview)</source>
+        <source>Deploy an AppHost to its deployment targets</source>
         <target state="needs-review-translation">Implante o conteúdo de um Aspire AppHost em seus destinos de implantação definidos. (Versão Prévia)</target>
         <note />
       </trans-unit>

--- a/src/Aspire.Cli/Resources/xlf/DeployCommandStrings.ru.xlf
+++ b/src/Aspire.Cli/Resources/xlf/DeployCommandStrings.ru.xlf
@@ -13,7 +13,7 @@
         <note />
       </trans-unit>
       <trans-unit id="Description">
-        <source>Deploy an AppHost to its deployment targets (Preview)</source>
+        <source>Deploy an AppHost to its deployment targets</source>
         <target state="needs-review-translation">Развернуть содержимое хоста приложений Aspire на заданных целевых объектах развертывания. (Предварительная версия)</target>
         <note />
       </trans-unit>

--- a/src/Aspire.Cli/Resources/xlf/DeployCommandStrings.tr.xlf
+++ b/src/Aspire.Cli/Resources/xlf/DeployCommandStrings.tr.xlf
@@ -13,7 +13,7 @@
         <note />
       </trans-unit>
       <trans-unit id="Description">
-        <source>Deploy an AppHost to its deployment targets (Preview)</source>
+        <source>Deploy an AppHost to its deployment targets</source>
         <target state="needs-review-translation">Bir Aspire AppHost içeriğini tanımlanan dağıtım hedeflerine dağıtın. (Önizleme)</target>
         <note />
       </trans-unit>

--- a/src/Aspire.Cli/Resources/xlf/DeployCommandStrings.zh-Hans.xlf
+++ b/src/Aspire.Cli/Resources/xlf/DeployCommandStrings.zh-Hans.xlf
@@ -13,7 +13,7 @@
         <note />
       </trans-unit>
       <trans-unit id="Description">
-        <source>Deploy an AppHost to its deployment targets (Preview)</source>
+        <source>Deploy an AppHost to its deployment targets</source>
         <target state="needs-review-translation">将 Aspire 应用主机的内容部署到其定义的部署目标。(预览版)</target>
         <note />
       </trans-unit>

--- a/src/Aspire.Cli/Resources/xlf/DeployCommandStrings.zh-Hant.xlf
+++ b/src/Aspire.Cli/Resources/xlf/DeployCommandStrings.zh-Hant.xlf
@@ -13,7 +13,7 @@
         <note />
       </trans-unit>
       <trans-unit id="Description">
-        <source>Deploy an AppHost to its deployment targets (Preview)</source>
+        <source>Deploy an AppHost to its deployment targets</source>
         <target state="needs-review-translation">將 Aspire AppHost 的內容部署至其定義的部署目標。(預覽)</target>
         <note />
       </trans-unit>

--- a/src/Aspire.Cli/Resources/xlf/DestroyCommandStrings.cs.xlf
+++ b/src/Aspire.Cli/Resources/xlf/DestroyCommandStrings.cs.xlf
@@ -3,8 +3,8 @@
   <file datatype="xml" source-language="en" target-language="cs" original="../DestroyCommandStrings.resx">
     <body>
       <trans-unit id="Description">
-        <source>Destroy a previously deployed AppHost environment (Preview)</source>
-        <target state="new">Destroy a previously deployed AppHost environment (Preview)</target>
+        <source>Destroy a previously deployed AppHost environment</source>
+        <target state="new">Destroy a previously deployed AppHost environment</target>
         <note />
       </trans-unit>
       <trans-unit id="DestroyCanceled">

--- a/src/Aspire.Cli/Resources/xlf/DestroyCommandStrings.de.xlf
+++ b/src/Aspire.Cli/Resources/xlf/DestroyCommandStrings.de.xlf
@@ -3,8 +3,8 @@
   <file datatype="xml" source-language="en" target-language="de" original="../DestroyCommandStrings.resx">
     <body>
       <trans-unit id="Description">
-        <source>Destroy a previously deployed AppHost environment (Preview)</source>
-        <target state="new">Destroy a previously deployed AppHost environment (Preview)</target>
+        <source>Destroy a previously deployed AppHost environment</source>
+        <target state="new">Destroy a previously deployed AppHost environment</target>
         <note />
       </trans-unit>
       <trans-unit id="DestroyCanceled">

--- a/src/Aspire.Cli/Resources/xlf/DestroyCommandStrings.es.xlf
+++ b/src/Aspire.Cli/Resources/xlf/DestroyCommandStrings.es.xlf
@@ -3,8 +3,8 @@
   <file datatype="xml" source-language="en" target-language="es" original="../DestroyCommandStrings.resx">
     <body>
       <trans-unit id="Description">
-        <source>Destroy a previously deployed AppHost environment (Preview)</source>
-        <target state="new">Destroy a previously deployed AppHost environment (Preview)</target>
+        <source>Destroy a previously deployed AppHost environment</source>
+        <target state="new">Destroy a previously deployed AppHost environment</target>
         <note />
       </trans-unit>
       <trans-unit id="DestroyCanceled">

--- a/src/Aspire.Cli/Resources/xlf/DestroyCommandStrings.fr.xlf
+++ b/src/Aspire.Cli/Resources/xlf/DestroyCommandStrings.fr.xlf
@@ -3,8 +3,8 @@
   <file datatype="xml" source-language="en" target-language="fr" original="../DestroyCommandStrings.resx">
     <body>
       <trans-unit id="Description">
-        <source>Destroy a previously deployed AppHost environment (Preview)</source>
-        <target state="new">Destroy a previously deployed AppHost environment (Preview)</target>
+        <source>Destroy a previously deployed AppHost environment</source>
+        <target state="new">Destroy a previously deployed AppHost environment</target>
         <note />
       </trans-unit>
       <trans-unit id="DestroyCanceled">

--- a/src/Aspire.Cli/Resources/xlf/DestroyCommandStrings.it.xlf
+++ b/src/Aspire.Cli/Resources/xlf/DestroyCommandStrings.it.xlf
@@ -3,8 +3,8 @@
   <file datatype="xml" source-language="en" target-language="it" original="../DestroyCommandStrings.resx">
     <body>
       <trans-unit id="Description">
-        <source>Destroy a previously deployed AppHost environment (Preview)</source>
-        <target state="new">Destroy a previously deployed AppHost environment (Preview)</target>
+        <source>Destroy a previously deployed AppHost environment</source>
+        <target state="new">Destroy a previously deployed AppHost environment</target>
         <note />
       </trans-unit>
       <trans-unit id="DestroyCanceled">

--- a/src/Aspire.Cli/Resources/xlf/DestroyCommandStrings.ja.xlf
+++ b/src/Aspire.Cli/Resources/xlf/DestroyCommandStrings.ja.xlf
@@ -3,8 +3,8 @@
   <file datatype="xml" source-language="en" target-language="ja" original="../DestroyCommandStrings.resx">
     <body>
       <trans-unit id="Description">
-        <source>Destroy a previously deployed AppHost environment (Preview)</source>
-        <target state="new">Destroy a previously deployed AppHost environment (Preview)</target>
+        <source>Destroy a previously deployed AppHost environment</source>
+        <target state="new">Destroy a previously deployed AppHost environment</target>
         <note />
       </trans-unit>
       <trans-unit id="DestroyCanceled">

--- a/src/Aspire.Cli/Resources/xlf/DestroyCommandStrings.ko.xlf
+++ b/src/Aspire.Cli/Resources/xlf/DestroyCommandStrings.ko.xlf
@@ -3,8 +3,8 @@
   <file datatype="xml" source-language="en" target-language="ko" original="../DestroyCommandStrings.resx">
     <body>
       <trans-unit id="Description">
-        <source>Destroy a previously deployed AppHost environment (Preview)</source>
-        <target state="new">Destroy a previously deployed AppHost environment (Preview)</target>
+        <source>Destroy a previously deployed AppHost environment</source>
+        <target state="new">Destroy a previously deployed AppHost environment</target>
         <note />
       </trans-unit>
       <trans-unit id="DestroyCanceled">

--- a/src/Aspire.Cli/Resources/xlf/DestroyCommandStrings.pl.xlf
+++ b/src/Aspire.Cli/Resources/xlf/DestroyCommandStrings.pl.xlf
@@ -3,8 +3,8 @@
   <file datatype="xml" source-language="en" target-language="pl" original="../DestroyCommandStrings.resx">
     <body>
       <trans-unit id="Description">
-        <source>Destroy a previously deployed AppHost environment (Preview)</source>
-        <target state="new">Destroy a previously deployed AppHost environment (Preview)</target>
+        <source>Destroy a previously deployed AppHost environment</source>
+        <target state="new">Destroy a previously deployed AppHost environment</target>
         <note />
       </trans-unit>
       <trans-unit id="DestroyCanceled">

--- a/src/Aspire.Cli/Resources/xlf/DestroyCommandStrings.pt-BR.xlf
+++ b/src/Aspire.Cli/Resources/xlf/DestroyCommandStrings.pt-BR.xlf
@@ -3,8 +3,8 @@
   <file datatype="xml" source-language="en" target-language="pt-BR" original="../DestroyCommandStrings.resx">
     <body>
       <trans-unit id="Description">
-        <source>Destroy a previously deployed AppHost environment (Preview)</source>
-        <target state="new">Destroy a previously deployed AppHost environment (Preview)</target>
+        <source>Destroy a previously deployed AppHost environment</source>
+        <target state="new">Destroy a previously deployed AppHost environment</target>
         <note />
       </trans-unit>
       <trans-unit id="DestroyCanceled">

--- a/src/Aspire.Cli/Resources/xlf/DestroyCommandStrings.ru.xlf
+++ b/src/Aspire.Cli/Resources/xlf/DestroyCommandStrings.ru.xlf
@@ -3,8 +3,8 @@
   <file datatype="xml" source-language="en" target-language="ru" original="../DestroyCommandStrings.resx">
     <body>
       <trans-unit id="Description">
-        <source>Destroy a previously deployed AppHost environment (Preview)</source>
-        <target state="new">Destroy a previously deployed AppHost environment (Preview)</target>
+        <source>Destroy a previously deployed AppHost environment</source>
+        <target state="new">Destroy a previously deployed AppHost environment</target>
         <note />
       </trans-unit>
       <trans-unit id="DestroyCanceled">

--- a/src/Aspire.Cli/Resources/xlf/DestroyCommandStrings.tr.xlf
+++ b/src/Aspire.Cli/Resources/xlf/DestroyCommandStrings.tr.xlf
@@ -3,8 +3,8 @@
   <file datatype="xml" source-language="en" target-language="tr" original="../DestroyCommandStrings.resx">
     <body>
       <trans-unit id="Description">
-        <source>Destroy a previously deployed AppHost environment (Preview)</source>
-        <target state="new">Destroy a previously deployed AppHost environment (Preview)</target>
+        <source>Destroy a previously deployed AppHost environment</source>
+        <target state="new">Destroy a previously deployed AppHost environment</target>
         <note />
       </trans-unit>
       <trans-unit id="DestroyCanceled">

--- a/src/Aspire.Cli/Resources/xlf/DestroyCommandStrings.zh-Hans.xlf
+++ b/src/Aspire.Cli/Resources/xlf/DestroyCommandStrings.zh-Hans.xlf
@@ -3,8 +3,8 @@
   <file datatype="xml" source-language="en" target-language="zh-Hans" original="../DestroyCommandStrings.resx">
     <body>
       <trans-unit id="Description">
-        <source>Destroy a previously deployed AppHost environment (Preview)</source>
-        <target state="new">Destroy a previously deployed AppHost environment (Preview)</target>
+        <source>Destroy a previously deployed AppHost environment</source>
+        <target state="new">Destroy a previously deployed AppHost environment</target>
         <note />
       </trans-unit>
       <trans-unit id="DestroyCanceled">

--- a/src/Aspire.Cli/Resources/xlf/DestroyCommandStrings.zh-Hant.xlf
+++ b/src/Aspire.Cli/Resources/xlf/DestroyCommandStrings.zh-Hant.xlf
@@ -3,8 +3,8 @@
   <file datatype="xml" source-language="en" target-language="zh-Hant" original="../DestroyCommandStrings.resx">
     <body>
       <trans-unit id="Description">
-        <source>Destroy a previously deployed AppHost environment (Preview)</source>
-        <target state="new">Destroy a previously deployed AppHost environment (Preview)</target>
+        <source>Destroy a previously deployed AppHost environment</source>
+        <target state="new">Destroy a previously deployed AppHost environment</target>
         <note />
       </trans-unit>
       <trans-unit id="DestroyCanceled">

--- a/src/Aspire.Cli/Resources/xlf/DoCommandStrings.cs.xlf
+++ b/src/Aspire.Cli/Resources/xlf/DoCommandStrings.cs.xlf
@@ -3,8 +3,8 @@
   <file datatype="xml" source-language="en" target-language="cs" original="../DoCommandStrings.resx">
     <body>
       <trans-unit id="Description">
-        <source>Execute a specific pipeline step and its dependencies (Preview)</source>
-        <target state="needs-review-translation">Umožňuje provést konkrétní krok kanálu a jeho závislosti. (Preview)</target>
+        <source>Execute a specific pipeline step and its dependencies</source>
+        <target state="needs-review-translation">Umožňuje provést konkrétní krok kanálu a jeho závislosti.</target>
         <note />
       </trans-unit>
       <trans-unit id="GeneratingArtifacts">

--- a/src/Aspire.Cli/Resources/xlf/DoCommandStrings.de.xlf
+++ b/src/Aspire.Cli/Resources/xlf/DoCommandStrings.de.xlf
@@ -3,7 +3,7 @@
   <file datatype="xml" source-language="en" target-language="de" original="../DoCommandStrings.resx">
     <body>
       <trans-unit id="Description">
-        <source>Execute a specific pipeline step and its dependencies (Preview)</source>
+        <source>Execute a specific pipeline step and its dependencies</source>
         <target state="needs-review-translation">Führen Sie einen bestimmten Pipelineschritt und seine Abhängigkeiten aus. (Vorschau)</target>
         <note />
       </trans-unit>

--- a/src/Aspire.Cli/Resources/xlf/DoCommandStrings.es.xlf
+++ b/src/Aspire.Cli/Resources/xlf/DoCommandStrings.es.xlf
@@ -3,7 +3,7 @@
   <file datatype="xml" source-language="en" target-language="es" original="../DoCommandStrings.resx">
     <body>
       <trans-unit id="Description">
-        <source>Execute a specific pipeline step and its dependencies (Preview)</source>
+        <source>Execute a specific pipeline step and its dependencies</source>
         <target state="needs-review-translation">Ejecute un paso de canalización específico y sus dependencias. (Versión preliminar)</target>
         <note />
       </trans-unit>

--- a/src/Aspire.Cli/Resources/xlf/DoCommandStrings.fr.xlf
+++ b/src/Aspire.Cli/Resources/xlf/DoCommandStrings.fr.xlf
@@ -3,7 +3,7 @@
   <file datatype="xml" source-language="en" target-language="fr" original="../DoCommandStrings.resx">
     <body>
       <trans-unit id="Description">
-        <source>Execute a specific pipeline step and its dependencies (Preview)</source>
+        <source>Execute a specific pipeline step and its dependencies</source>
         <target state="needs-review-translation">Exécuter une étape spécifique du pipeline ainsi que ses dépendances. (Préversion)</target>
         <note />
       </trans-unit>

--- a/src/Aspire.Cli/Resources/xlf/DoCommandStrings.it.xlf
+++ b/src/Aspire.Cli/Resources/xlf/DoCommandStrings.it.xlf
@@ -3,7 +3,7 @@
   <file datatype="xml" source-language="en" target-language="it" original="../DoCommandStrings.resx">
     <body>
       <trans-unit id="Description">
-        <source>Execute a specific pipeline step and its dependencies (Preview)</source>
+        <source>Execute a specific pipeline step and its dependencies</source>
         <target state="needs-review-translation">Esegui un passaggio specifico della pipeline e le relative dipendenze. (Anteprima)</target>
         <note />
       </trans-unit>

--- a/src/Aspire.Cli/Resources/xlf/DoCommandStrings.ja.xlf
+++ b/src/Aspire.Cli/Resources/xlf/DoCommandStrings.ja.xlf
@@ -3,7 +3,7 @@
   <file datatype="xml" source-language="en" target-language="ja" original="../DoCommandStrings.resx">
     <body>
       <trans-unit id="Description">
-        <source>Execute a specific pipeline step and its dependencies (Preview)</source>
+        <source>Execute a specific pipeline step and its dependencies</source>
         <target state="needs-review-translation">特定のパイプライン ステップとその依存関係を実行します。(プレビュー)</target>
         <note />
       </trans-unit>

--- a/src/Aspire.Cli/Resources/xlf/DoCommandStrings.ko.xlf
+++ b/src/Aspire.Cli/Resources/xlf/DoCommandStrings.ko.xlf
@@ -3,7 +3,7 @@
   <file datatype="xml" source-language="en" target-language="ko" original="../DoCommandStrings.resx">
     <body>
       <trans-unit id="Description">
-        <source>Execute a specific pipeline step and its dependencies (Preview)</source>
+        <source>Execute a specific pipeline step and its dependencies</source>
         <target state="needs-review-translation">특정 파이프라인 단계와 그에 필요한 종속 항목을 실행하세요. (미리 보기)</target>
         <note />
       </trans-unit>

--- a/src/Aspire.Cli/Resources/xlf/DoCommandStrings.pl.xlf
+++ b/src/Aspire.Cli/Resources/xlf/DoCommandStrings.pl.xlf
@@ -3,7 +3,7 @@
   <file datatype="xml" source-language="en" target-language="pl" original="../DoCommandStrings.resx">
     <body>
       <trans-unit id="Description">
-        <source>Execute a specific pipeline step and its dependencies (Preview)</source>
+        <source>Execute a specific pipeline step and its dependencies</source>
         <target state="needs-review-translation">Wykonaj określony krok potoku i jego zależności. (Wersja zapoznawcza)</target>
         <note />
       </trans-unit>

--- a/src/Aspire.Cli/Resources/xlf/DoCommandStrings.pt-BR.xlf
+++ b/src/Aspire.Cli/Resources/xlf/DoCommandStrings.pt-BR.xlf
@@ -3,7 +3,7 @@
   <file datatype="xml" source-language="en" target-language="pt-BR" original="../DoCommandStrings.resx">
     <body>
       <trans-unit id="Description">
-        <source>Execute a specific pipeline step and its dependencies (Preview)</source>
+        <source>Execute a specific pipeline step and its dependencies</source>
         <target state="needs-review-translation">Executar uma etapa específica do pipeline e suas dependências. (Visualização)</target>
         <note />
       </trans-unit>

--- a/src/Aspire.Cli/Resources/xlf/DoCommandStrings.ru.xlf
+++ b/src/Aspire.Cli/Resources/xlf/DoCommandStrings.ru.xlf
@@ -3,7 +3,7 @@
   <file datatype="xml" source-language="en" target-language="ru" original="../DoCommandStrings.resx">
     <body>
       <trans-unit id="Description">
-        <source>Execute a specific pipeline step and its dependencies (Preview)</source>
+        <source>Execute a specific pipeline step and its dependencies</source>
         <target state="needs-review-translation">Выполнение определенного шага конвейера и его зависимостей. (Предварительный просмотр)</target>
         <note />
       </trans-unit>

--- a/src/Aspire.Cli/Resources/xlf/DoCommandStrings.tr.xlf
+++ b/src/Aspire.Cli/Resources/xlf/DoCommandStrings.tr.xlf
@@ -3,7 +3,7 @@
   <file datatype="xml" source-language="en" target-language="tr" original="../DoCommandStrings.resx">
     <body>
       <trans-unit id="Description">
-        <source>Execute a specific pipeline step and its dependencies (Preview)</source>
+        <source>Execute a specific pipeline step and its dependencies</source>
         <target state="needs-review-translation">Belirli bir işlem hattı adımını ve bağımlılıklarını yürütün. (Önizleme)</target>
         <note />
       </trans-unit>

--- a/src/Aspire.Cli/Resources/xlf/DoCommandStrings.zh-Hans.xlf
+++ b/src/Aspire.Cli/Resources/xlf/DoCommandStrings.zh-Hans.xlf
@@ -3,7 +3,7 @@
   <file datatype="xml" source-language="en" target-language="zh-Hans" original="../DoCommandStrings.resx">
     <body>
       <trans-unit id="Description">
-        <source>Execute a specific pipeline step and its dependencies (Preview)</source>
+        <source>Execute a specific pipeline step and its dependencies</source>
         <target state="needs-review-translation">执行特定的管道步骤及其依赖项。(预览版)</target>
         <note />
       </trans-unit>

--- a/src/Aspire.Cli/Resources/xlf/DoCommandStrings.zh-Hant.xlf
+++ b/src/Aspire.Cli/Resources/xlf/DoCommandStrings.zh-Hant.xlf
@@ -3,7 +3,7 @@
   <file datatype="xml" source-language="en" target-language="zh-Hant" original="../DoCommandStrings.resx">
     <body>
       <trans-unit id="Description">
-        <source>Execute a specific pipeline step and its dependencies (Preview)</source>
+        <source>Execute a specific pipeline step and its dependencies</source>
         <target state="needs-review-translation">執行特定管線步驟及其相依性。(預覽)</target>
         <note />
       </trans-unit>

--- a/src/Aspire.Cli/Resources/xlf/PublishCommandStrings.cs.xlf
+++ b/src/Aspire.Cli/Resources/xlf/PublishCommandStrings.cs.xlf
@@ -3,8 +3,8 @@
   <file datatype="xml" source-language="en" target-language="cs" original="../PublishCommandStrings.resx">
     <body>
       <trans-unit id="Description">
-        <source>Generate deployment artifacts for an AppHost (Preview)</source>
-        <target state="needs-review-translation">Generuje artefakty nasazení pro hostitele aplikací Aspire. (Preview)</target>
+        <source>Generate deployment artifacts for an AppHost</source>
+        <target state="needs-review-translation">Generuje artefakty nasazení pro hostitele aplikací Aspire.</target>
         <note />
       </trans-unit>
       <trans-unit id="GeneratingArtifacts">

--- a/src/Aspire.Cli/Resources/xlf/PublishCommandStrings.de.xlf
+++ b/src/Aspire.Cli/Resources/xlf/PublishCommandStrings.de.xlf
@@ -3,7 +3,7 @@
   <file datatype="xml" source-language="en" target-language="de" original="../PublishCommandStrings.resx">
     <body>
       <trans-unit id="Description">
-        <source>Generate deployment artifacts for an AppHost (Preview)</source>
+        <source>Generate deployment artifacts for an AppHost</source>
         <target state="needs-review-translation">Generiert Bereitstellungsartefakte für einen Aspire-App-Host. (Vorschau)</target>
         <note />
       </trans-unit>

--- a/src/Aspire.Cli/Resources/xlf/PublishCommandStrings.es.xlf
+++ b/src/Aspire.Cli/Resources/xlf/PublishCommandStrings.es.xlf
@@ -3,7 +3,7 @@
   <file datatype="xml" source-language="en" target-language="es" original="../PublishCommandStrings.resx">
     <body>
       <trans-unit id="Description">
-        <source>Generate deployment artifacts for an AppHost (Preview)</source>
+        <source>Generate deployment artifacts for an AppHost</source>
         <target state="needs-review-translation">Genera artefactos de implementación para un host de aplicaciones Aspire. (Versión preliminar)</target>
         <note />
       </trans-unit>

--- a/src/Aspire.Cli/Resources/xlf/PublishCommandStrings.fr.xlf
+++ b/src/Aspire.Cli/Resources/xlf/PublishCommandStrings.fr.xlf
@@ -3,7 +3,7 @@
   <file datatype="xml" source-language="en" target-language="fr" original="../PublishCommandStrings.resx">
     <body>
       <trans-unit id="Description">
-        <source>Generate deployment artifacts for an AppHost (Preview)</source>
+        <source>Generate deployment artifacts for an AppHost</source>
         <target state="needs-review-translation">Génère des artefacts de déploiement pour un Aspire AppHost. (Préversion)</target>
         <note />
       </trans-unit>

--- a/src/Aspire.Cli/Resources/xlf/PublishCommandStrings.it.xlf
+++ b/src/Aspire.Cli/Resources/xlf/PublishCommandStrings.it.xlf
@@ -3,7 +3,7 @@
   <file datatype="xml" source-language="en" target-language="it" original="../PublishCommandStrings.resx">
     <body>
       <trans-unit id="Description">
-        <source>Generate deployment artifacts for an AppHost (Preview)</source>
+        <source>Generate deployment artifacts for an AppHost</source>
         <target state="needs-review-translation">Genera artefatti della distribuzione per un AppHost Aspire. (Anteprima)</target>
         <note />
       </trans-unit>

--- a/src/Aspire.Cli/Resources/xlf/PublishCommandStrings.ja.xlf
+++ b/src/Aspire.Cli/Resources/xlf/PublishCommandStrings.ja.xlf
@@ -3,7 +3,7 @@
   <file datatype="xml" source-language="en" target-language="ja" original="../PublishCommandStrings.resx">
     <body>
       <trans-unit id="Description">
-        <source>Generate deployment artifacts for an AppHost (Preview)</source>
+        <source>Generate deployment artifacts for an AppHost</source>
         <target state="needs-review-translation">Aspire アプリ ホスティング プロセスのデプロイ成果物を生成します。(プレビュー)</target>
         <note />
       </trans-unit>

--- a/src/Aspire.Cli/Resources/xlf/PublishCommandStrings.ko.xlf
+++ b/src/Aspire.Cli/Resources/xlf/PublishCommandStrings.ko.xlf
@@ -3,7 +3,7 @@
   <file datatype="xml" source-language="en" target-language="ko" original="../PublishCommandStrings.resx">
     <body>
       <trans-unit id="Description">
-        <source>Generate deployment artifacts for an AppHost (Preview)</source>
+        <source>Generate deployment artifacts for an AppHost</source>
         <target state="needs-review-translation">Aspire 앱호스트에 대한 배포 아티팩트를 생성합니다. (미리 보기)</target>
         <note />
       </trans-unit>

--- a/src/Aspire.Cli/Resources/xlf/PublishCommandStrings.pl.xlf
+++ b/src/Aspire.Cli/Resources/xlf/PublishCommandStrings.pl.xlf
@@ -3,7 +3,7 @@
   <file datatype="xml" source-language="en" target-language="pl" original="../PublishCommandStrings.resx">
     <body>
       <trans-unit id="Description">
-        <source>Generate deployment artifacts for an AppHost (Preview)</source>
+        <source>Generate deployment artifacts for an AppHost</source>
         <target state="needs-review-translation">Generuje artefakty wdrożenia dla hosta AppHost platformy Aspire. (Wersja zapoznawcza)</target>
         <note />
       </trans-unit>

--- a/src/Aspire.Cli/Resources/xlf/PublishCommandStrings.pt-BR.xlf
+++ b/src/Aspire.Cli/Resources/xlf/PublishCommandStrings.pt-BR.xlf
@@ -3,7 +3,7 @@
   <file datatype="xml" source-language="en" target-language="pt-BR" original="../PublishCommandStrings.resx">
     <body>
       <trans-unit id="Description">
-        <source>Generate deployment artifacts for an AppHost (Preview)</source>
+        <source>Generate deployment artifacts for an AppHost</source>
         <target state="needs-review-translation">Gera artefatos de implantação para um Aspire apphost. (Versão Prévia)</target>
         <note />
       </trans-unit>

--- a/src/Aspire.Cli/Resources/xlf/PublishCommandStrings.ru.xlf
+++ b/src/Aspire.Cli/Resources/xlf/PublishCommandStrings.ru.xlf
@@ -3,7 +3,7 @@
   <file datatype="xml" source-language="en" target-language="ru" original="../PublishCommandStrings.resx">
     <body>
       <trans-unit id="Description">
-        <source>Generate deployment artifacts for an AppHost (Preview)</source>
+        <source>Generate deployment artifacts for an AppHost</source>
         <target state="needs-review-translation">Генерирует артефакты развертывания для хоста приложений Aspire. (Предварительная версия)</target>
         <note />
       </trans-unit>

--- a/src/Aspire.Cli/Resources/xlf/PublishCommandStrings.tr.xlf
+++ b/src/Aspire.Cli/Resources/xlf/PublishCommandStrings.tr.xlf
@@ -3,7 +3,7 @@
   <file datatype="xml" source-language="en" target-language="tr" original="../PublishCommandStrings.resx">
     <body>
       <trans-unit id="Description">
-        <source>Generate deployment artifacts for an AppHost (Preview)</source>
+        <source>Generate deployment artifacts for an AppHost</source>
         <target state="needs-review-translation">Bir Aspire AppHost için dağıtım yapıtları oluşturur. (Önizleme)</target>
         <note />
       </trans-unit>

--- a/src/Aspire.Cli/Resources/xlf/PublishCommandStrings.zh-Hans.xlf
+++ b/src/Aspire.Cli/Resources/xlf/PublishCommandStrings.zh-Hans.xlf
@@ -3,7 +3,7 @@
   <file datatype="xml" source-language="en" target-language="zh-Hans" original="../PublishCommandStrings.resx">
     <body>
       <trans-unit id="Description">
-        <source>Generate deployment artifacts for an AppHost (Preview)</source>
+        <source>Generate deployment artifacts for an AppHost</source>
         <target state="needs-review-translation">为 Aspire 应用主机生成部署项目。(预览版)</target>
         <note />
       </trans-unit>

--- a/src/Aspire.Cli/Resources/xlf/PublishCommandStrings.zh-Hant.xlf
+++ b/src/Aspire.Cli/Resources/xlf/PublishCommandStrings.zh-Hant.xlf
@@ -3,7 +3,7 @@
   <file datatype="xml" source-language="en" target-language="zh-Hant" original="../PublishCommandStrings.resx">
     <body>
       <trans-unit id="Description">
-        <source>Generate deployment artifacts for an AppHost (Preview)</source>
+        <source>Generate deployment artifacts for an AppHost</source>
         <target state="needs-review-translation">為 Aspire AppHost 產生部署成品。(預覽)</target>
         <note />
       </trans-unit>

--- a/src/Aspire.Cli/Resources/xlf/UpdateCommandStrings.cs.xlf
+++ b/src/Aspire.Cli/Resources/xlf/UpdateCommandStrings.cs.xlf
@@ -73,8 +73,8 @@
         <note />
       </trans-unit>
       <trans-unit id="Description">
-        <source>Update integrations in the Aspire project (Preview)</source>
-        <target state="needs-review-translation">Aktualizujte integrace v projektu Aspire. (Preview)</target>
+        <source>Update integrations in the Aspire project</source>
+        <target state="needs-review-translation">Aktualizujte integrace v projektu Aspire.</target>
         <note />
       </trans-unit>
       <trans-unit id="DotNetToolSelfUpdateMessage">

--- a/src/Aspire.Cli/Resources/xlf/UpdateCommandStrings.de.xlf
+++ b/src/Aspire.Cli/Resources/xlf/UpdateCommandStrings.de.xlf
@@ -73,7 +73,7 @@
         <note />
       </trans-unit>
       <trans-unit id="Description">
-        <source>Update integrations in the Aspire project (Preview)</source>
+        <source>Update integrations in the Aspire project</source>
         <target state="needs-review-translation">Dient zum Aktualisieren von Integrationen im Aproject. (Vorschau)</target>
         <note />
       </trans-unit>

--- a/src/Aspire.Cli/Resources/xlf/UpdateCommandStrings.es.xlf
+++ b/src/Aspire.Cli/Resources/xlf/UpdateCommandStrings.es.xlf
@@ -73,7 +73,7 @@
         <note />
       </trans-unit>
       <trans-unit id="Description">
-        <source>Update integrations in the Aspire project (Preview)</source>
+        <source>Update integrations in the Aspire project</source>
         <target state="needs-review-translation">Actualizar las integraciones en el proyecto Aspire. (Versión preliminar)</target>
         <note />
       </trans-unit>

--- a/src/Aspire.Cli/Resources/xlf/UpdateCommandStrings.fr.xlf
+++ b/src/Aspire.Cli/Resources/xlf/UpdateCommandStrings.fr.xlf
@@ -73,7 +73,7 @@
         <note />
       </trans-unit>
       <trans-unit id="Description">
-        <source>Update integrations in the Aspire project (Preview)</source>
+        <source>Update integrations in the Aspire project</source>
         <target state="needs-review-translation">Mettre à jour les intégrations dans le projet Aspire. (Préversion)</target>
         <note />
       </trans-unit>

--- a/src/Aspire.Cli/Resources/xlf/UpdateCommandStrings.it.xlf
+++ b/src/Aspire.Cli/Resources/xlf/UpdateCommandStrings.it.xlf
@@ -73,7 +73,7 @@
         <note />
       </trans-unit>
       <trans-unit id="Description">
-        <source>Update integrations in the Aspire project (Preview)</source>
+        <source>Update integrations in the Aspire project</source>
         <target state="needs-review-translation">Consente di aggiornare le integrazioni nel progetto di Aspire. (Anteprima)</target>
         <note />
       </trans-unit>

--- a/src/Aspire.Cli/Resources/xlf/UpdateCommandStrings.ja.xlf
+++ b/src/Aspire.Cli/Resources/xlf/UpdateCommandStrings.ja.xlf
@@ -73,7 +73,7 @@
         <note />
       </trans-unit>
       <trans-unit id="Description">
-        <source>Update integrations in the Aspire project (Preview)</source>
+        <source>Update integrations in the Aspire project</source>
         <target state="needs-review-translation">Aspire プロジェクトの統合を更新します。(プレビュー)</target>
         <note />
       </trans-unit>

--- a/src/Aspire.Cli/Resources/xlf/UpdateCommandStrings.ko.xlf
+++ b/src/Aspire.Cli/Resources/xlf/UpdateCommandStrings.ko.xlf
@@ -73,7 +73,7 @@
         <note />
       </trans-unit>
       <trans-unit id="Description">
-        <source>Update integrations in the Aspire project (Preview)</source>
+        <source>Update integrations in the Aspire project</source>
         <target state="needs-review-translation">Aspire 프로젝트에서 통합을 업데이트합니다. (미리 보기)</target>
         <note />
       </trans-unit>

--- a/src/Aspire.Cli/Resources/xlf/UpdateCommandStrings.pl.xlf
+++ b/src/Aspire.Cli/Resources/xlf/UpdateCommandStrings.pl.xlf
@@ -73,7 +73,7 @@
         <note />
       </trans-unit>
       <trans-unit id="Description">
-        <source>Update integrations in the Aspire project (Preview)</source>
+        <source>Update integrations in the Aspire project</source>
         <target state="needs-review-translation">Zaktualizuj integracje w projekcie Aspire. (Wersja zapoznawcza)</target>
         <note />
       </trans-unit>

--- a/src/Aspire.Cli/Resources/xlf/UpdateCommandStrings.pt-BR.xlf
+++ b/src/Aspire.Cli/Resources/xlf/UpdateCommandStrings.pt-BR.xlf
@@ -73,7 +73,7 @@
         <note />
       </trans-unit>
       <trans-unit id="Description">
-        <source>Update integrations in the Aspire project (Preview)</source>
+        <source>Update integrations in the Aspire project</source>
         <target state="needs-review-translation">Atualizar integrações no projeto Aspire. (Versão Prévia)</target>
         <note />
       </trans-unit>

--- a/src/Aspire.Cli/Resources/xlf/UpdateCommandStrings.ru.xlf
+++ b/src/Aspire.Cli/Resources/xlf/UpdateCommandStrings.ru.xlf
@@ -73,7 +73,7 @@
         <note />
       </trans-unit>
       <trans-unit id="Description">
-        <source>Update integrations in the Aspire project (Preview)</source>
+        <source>Update integrations in the Aspire project</source>
         <target state="needs-review-translation">Обновление интеграций в проекте Aspire. (предварительная версия)</target>
         <note />
       </trans-unit>

--- a/src/Aspire.Cli/Resources/xlf/UpdateCommandStrings.tr.xlf
+++ b/src/Aspire.Cli/Resources/xlf/UpdateCommandStrings.tr.xlf
@@ -73,7 +73,7 @@
         <note />
       </trans-unit>
       <trans-unit id="Description">
-        <source>Update integrations in the Aspire project (Preview)</source>
+        <source>Update integrations in the Aspire project</source>
         <target state="needs-review-translation">Aspire projesindeki tümleştirme güncelleştirmelerini yapın. (Önizleme)</target>
         <note />
       </trans-unit>

--- a/src/Aspire.Cli/Resources/xlf/UpdateCommandStrings.zh-Hans.xlf
+++ b/src/Aspire.Cli/Resources/xlf/UpdateCommandStrings.zh-Hans.xlf
@@ -73,7 +73,7 @@
         <note />
       </trans-unit>
       <trans-unit id="Description">
-        <source>Update integrations in the Aspire project (Preview)</source>
+        <source>Update integrations in the Aspire project</source>
         <target state="needs-review-translation">更新 Aspire 项目中的集成。(预览版)</target>
         <note />
       </trans-unit>

--- a/src/Aspire.Cli/Resources/xlf/UpdateCommandStrings.zh-Hant.xlf
+++ b/src/Aspire.Cli/Resources/xlf/UpdateCommandStrings.zh-Hant.xlf
@@ -73,7 +73,7 @@
         <note />
       </trans-unit>
       <trans-unit id="Description">
-        <source>Update integrations in the Aspire project (Preview)</source>
+        <source>Update integrations in the Aspire project</source>
         <target state="needs-review-translation">更新 Aspire 專案中的整合。(預覽)</target>
         <note />
       </trans-unit>


### PR DESCRIPTION
## Description

The CLI deployment/update commands are no longer preview, so the command help and CLI README should not label them that way. This updates the localized command description resources for `aspire deploy`, `aspire destroy`, `aspire do`, `aspire publish`, and `aspire update`, and refreshes the related XLIFF source strings.

The CLI README now also lists `destroy` in the Deployment command table.

### User-facing usage

Root help now shows these commands without the preview moniker:

```text
App commands:
  update                           Update integrations in the Aspire project

Deployment:
  deploy                           Deploy an AppHost to its deployment targets
  destroy                          Destroy a previously deployed AppHost environment
  do [<step>]                      Execute a specific pipeline step and its dependencies
  publish                          Generate deployment artifacts for an AppHost
```

The dashboard command remains preview-labeled:

```text
Monitoring:
  dashboard                        Manage the Aspire dashboard (Preview)
```

Validation:
- `dotnet build /t:UpdateXlf src/Aspire.Cli/Aspire.Cli.csproj`
- `dotnet build src/Aspire.Cli/Aspire.Cli.csproj /p:SkipNativeBuild=true`
- `dotnet artifacts/bin/Aspire.Cli/Debug/net10.0/aspire.dll --help`

Fixes # (issue)

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [x] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
