### PR TITLE
Fix CLI cancellation disposal race on shutdown

### DIFF
--- a/src/Aspire.Cli/ConsoleCancellationManager.cs
+++ b/src/Aspire.Cli/ConsoleCancellationManager.cs
@@ -1,0 +1,60 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Runtime.InteropServices;
+
+namespace Aspire.Cli;
+
+/// <summary>
+/// Manages Ctrl+C and SIGTERM signal handling with a shared CancellationTokenSource.
+/// Disposing this instance unregisters all signal handlers and disposes the token source.
+/// </summary>
+internal sealed class ConsoleCancellationManager : IDisposable
+{
+    private readonly CancellationTokenSource _cts = new();
+    private readonly CancellationToken _token;
+    private readonly ConsoleCancelEventHandler _cancelKeyPressHandler;
+    private readonly PosixSignalRegistration? _sigTermRegistration;
+
+    public ConsoleCancellationManager()
+    {
+        _token = _cts.Token;
+        _cancelKeyPressHandler = (sender, eventArgs) =>
+        {
+            TryCancel();
+            eventArgs.Cancel = true;
+        };
+        Console.CancelKeyPress += _cancelKeyPressHandler;
+
+        _sigTermRegistration = OperatingSystem.IsWindows()
+            ? null
+            : PosixSignalRegistration.Create(PosixSignal.SIGTERM, context =>
+            {
+                TryCancel();
+                context.Cancel = true;
+            });
+    }
+
+    public CancellationToken Token => _token;
+
+    public bool IsCancellationRequested => _cts.IsCancellationRequested;
+
+    private void TryCancel()
+    {
+        try
+        {
+            _cts.Cancel();
+        }
+        catch (ObjectDisposedException)
+        {
+            // A signal can race with process shutdown after cancellation resources are disposed.
+        }
+    }
+
+    public void Dispose()
+    {
+        Console.CancelKeyPress -= _cancelKeyPressHandler;
+        _sigTermRegistration?.Dispose();
+        _cts.Dispose();
+    }
+}

--- a/src/Aspire.Cli/Program.cs
+++ b/src/Aspire.Cli/Program.cs
@@ -722,7 +722,6 @@ public class Program
         // Setup handling of CTRL-C and SIGTERM as early as possible so that if
         // we get a signal anywhere that is not handled by Spectre Console
         // already that we know to trigger cancellation.
-        // Using declaration ensures cleanup even if BuildApplicationAsync/StartAsync fails early.
         using var cancellationManager = new ConsoleCancellationManager();
 
         Console.OutputEncoding = Encoding.UTF8;

--- a/src/Aspire.Cli/Program.cs
+++ b/src/Aspire.Cli/Program.cs
@@ -4,7 +4,6 @@
 using System.CommandLine;
 using System.Diagnostics;
 using System.Globalization;
-using System.Runtime.InteropServices;
 using System.Text;
 using System.Text.Json;
 using Aspire.Cli.Acquisition;
@@ -720,24 +719,11 @@ public class Program
 
     public static async Task<int> Main(string[] args)
     {
-        // Setup handling of CTRL-C as early as possible so that if
-        // we get a CTRL-C anywhere that is not handled by Spectre Console
+        // Setup handling of CTRL-C and SIGTERM as early as possible so that if
+        // we get a signal anywhere that is not handled by Spectre Console
         // already that we know to trigger cancellation.
-        var cts = new CancellationTokenSource();
-        ConsoleCancelEventHandler cancelKeyPressHandler = (sender, eventArgs) =>
-        {
-            TryCancel(cts);
-            eventArgs.Cancel = true;
-        };
-        Console.CancelKeyPress += cancelKeyPressHandler;
-
-        var sigTermRegistration = OperatingSystem.IsWindows()
-            ? null
-            : PosixSignalRegistration.Create(PosixSignal.SIGTERM, context =>
-            {
-                TryCancel(cts);
-                context.Cancel = true;
-            });
+        // Using declaration ensures cleanup even if BuildApplicationAsync/StartAsync fails early.
+        using var cancellationManager = new ConsoleCancellationManager();
 
         Console.OutputEncoding = Encoding.UTF8;
 
@@ -781,7 +767,7 @@ public class Program
         app.Services.GetRequiredService<IFeatures>().LogFeatureState();
 
         // Display first run experience if this is the first time the CLI is run on this machine
-        await DisplayFirstTimeUseNoticeIfNeededAsync(app.Services, args, cts.Token);
+        await DisplayFirstTimeUseNoticeIfNeededAsync(app.Services, args, cancellationManager.Token);
 
         var rootCommand = app.Services.GetRequiredService<RootCommand>();
         var invokeConfig = new InvocationConfiguration()
@@ -815,7 +801,7 @@ public class Program
 
             mainActivity?.SetTag(TelemetryConstants.Tags.CommandName, commandName);
 
-            var exitCode = await parseResult.InvokeAsync(invokeConfig, cts.Token);
+            var exitCode = await parseResult.InvokeAsync(invokeConfig, cancellationManager.Token);
 
             // Log exit code for debugging
             logger.LogInformation("Exit code: {ExitCode}", exitCode);
@@ -832,9 +818,9 @@ public class Program
             // Allows logging of exceptions to telemetry.
 
             // Don't log or display cancellation exceptions.
-            // Check both Ctrl+C cancellation (cts.IsCancellationRequested) and
+            // Check both Ctrl+C cancellation (cancellationManager.IsCancellationRequested) and
             // extension prompt cancellation (ExtensionOperationCanceledException).
-            if (!(ex is OperationCanceledException && cts.IsCancellationRequested) && ex is not ExtensionOperationCanceledException)
+            if (!(ex is OperationCanceledException && cancellationManager.IsCancellationRequested) && ex is not ExtensionOperationCanceledException)
             {
                 logger.LogError(ex, "An unexpected error occurred.");
 
@@ -859,22 +845,6 @@ public class Program
 
             await app.StopAsync().ConfigureAwait(false);
             await shutdownTelemetryTask;
-
-            Console.CancelKeyPress -= cancelKeyPressHandler;
-            sigTermRegistration?.Dispose();
-            cts.Dispose();
-        }
-
-        static void TryCancel(CancellationTokenSource source)
-        {
-            try
-            {
-                source.Cancel();
-            }
-            catch (ObjectDisposedException)
-            {
-                // A signal can race with process shutdown after cancellation resources are disposed.
-            }
         }
     }
 

--- a/src/Aspire.Cli/Program.cs
+++ b/src/Aspire.Cli/Program.cs
@@ -723,17 +723,19 @@ public class Program
         // Setup handling of CTRL-C as early as possible so that if
         // we get a CTRL-C anywhere that is not handled by Spectre Console
         // already that we know to trigger cancellation.
-        using var cts = new CancellationTokenSource();
-        Console.CancelKeyPress += (sender, eventArgs) =>
+        var cts = new CancellationTokenSource();
+        ConsoleCancelEventHandler cancelKeyPressHandler = (sender, eventArgs) =>
         {
-            cts.Cancel();
+            TryCancel(cts);
             eventArgs.Cancel = true;
         };
-        using var sigTermRegistration = OperatingSystem.IsWindows()
+        Console.CancelKeyPress += cancelKeyPressHandler;
+
+        var sigTermRegistration = OperatingSystem.IsWindows()
             ? null
             : PosixSignalRegistration.Create(PosixSignal.SIGTERM, context =>
             {
-                cts.Cancel();
+                TryCancel(cts);
                 context.Cancel = true;
             });
 
@@ -857,6 +859,22 @@ public class Program
 
             await app.StopAsync().ConfigureAwait(false);
             await shutdownTelemetryTask;
+
+            Console.CancelKeyPress -= cancelKeyPressHandler;
+            sigTermRegistration?.Dispose();
+            cts.Dispose();
+        }
+
+        static void TryCancel(CancellationTokenSource source)
+        {
+            try
+            {
+                source.Cancel();
+            }
+            catch (ObjectDisposedException)
+            {
+                // A signal can race with process shutdown after cancellation resources are disposed.
+            }
         }
     }
 


### PR DESCRIPTION
## Description

Fixes a shutdown race in the Aspire CLI where signal callbacks can call `CancellationTokenSource.Cancel()` after the source is disposed, causing:

`System.ObjectDisposedException: The CancellationTokenSource has been disposed.`

For example: https://github.com/microsoft/aspire/pull/17141#issuecomment-4468213486

The change in [src/Aspire.Cli/Program.cs](src/Aspire.Cli/Program.cs) updates startup cancellation wiring to:
- Register removable signal handlers.
- Route Ctrl+C and SIGTERM through a shared safe cancellation helper.
- Catch `ObjectDisposedException` in that helper for late-signal races.
- Unregister handlers and dispose registrations/CTS in an explicit shutdown order.

This keeps shutdown cancellation behavior intact while preventing process aborts from late signal delivery during teardown.

Validation run:
- `dotnet test --project .\tests\Aspire.Cli.Tests\Aspire.Cli.Tests.csproj --no-launch-profile -- --filter-not-trait "quarantined=true" --filter-not-trait "outerloop=true"` (passed: 3073, skipped: 12)
- `dotnet test --project .\tests\Aspire.Cli.EndToEnd.Tests\Aspire.Cli.EndToEnd.Tests.csproj --no-launch-profile -- --filter-not-trait "quarantined=true" --filter-not-trait "outerloop=true"` (failed in local environment because Docker daemon pipe `//./pipe/dockerDesktopLinuxEngine` was unavailable)

Fixes # (issue)

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [x] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
