### PR TITLE
Fix flaky NewCommandChannelResolutionTests by isolating home directory

### DIFF
--- a/tests/Aspire.Cli.Tests/Agents/ClaudeCodeAgentEnvironmentScannerTests.cs
+++ b/tests/Aspire.Cli.Tests/Agents/ClaudeCodeAgentEnvironmentScannerTests.cs
@@ -109,13 +109,8 @@ public class ClaudeCodeAgentEnvironmentScannerTests(ITestOutputHelper outputHelp
 
     private static CliExecutionContext CreateExecutionContext(DirectoryInfo workingDirectory)
     {
-        return new CliExecutionContext(
-            workingDirectory: workingDirectory,
-            hivesDirectory: workingDirectory,
-            cacheDirectory: workingDirectory,
-            sdksDirectory: workingDirectory,
-            logsDirectory: workingDirectory,
-            logFilePath: "test.log",
+        return TestExecutionContextHelper.CreateExecutionContext(
+            workingDirectory,
             debugMode: false,
             environmentVariables: new Dictionary<string, string?>(),
             homeDirectory: workingDirectory);

--- a/tests/Aspire.Cli.Tests/Agents/CopilotCliAgentEnvironmentScannerTests.cs
+++ b/tests/Aspire.Cli.Tests/Agents/CopilotCliAgentEnvironmentScannerTests.cs
@@ -191,13 +191,8 @@ public class CopilotCliAgentEnvironmentScannerTests(ITestOutputHelper outputHelp
 
     private static CliExecutionContext CreateExecutionContext(DirectoryInfo workingDirectory)
     {
-        return new CliExecutionContext(
-            workingDirectory: workingDirectory,
-            hivesDirectory: workingDirectory,
-            cacheDirectory: workingDirectory,
-            sdksDirectory: workingDirectory,
-            logsDirectory: workingDirectory,
-            logFilePath: "test.log",
+        return TestExecutionContextHelper.CreateExecutionContext(
+            workingDirectory,
             debugMode: false,
             environmentVariables: new Dictionary<string, string?>(),
             homeDirectory: workingDirectory);
@@ -209,14 +204,9 @@ public class CopilotCliAgentEnvironmentScannerTests(ITestOutputHelper outputHelp
         {
             ["TERM_PROGRAM"] = "vscode"
         };
-        
-        return new CliExecutionContext(
-            workingDirectory: workingDirectory,
-            hivesDirectory: workingDirectory,
-            cacheDirectory: workingDirectory,
-            sdksDirectory: workingDirectory,
-            logsDirectory: workingDirectory,
-            logFilePath: "test.log",
+
+        return TestExecutionContextHelper.CreateExecutionContext(
+            workingDirectory,
             debugMode: false,
             environmentVariables: environmentVariables,
             homeDirectory: workingDirectory);

--- a/tests/Aspire.Cli.Tests/Agents/VsCodeAgentEnvironmentScannerTests.cs
+++ b/tests/Aspire.Cli.Tests/Agents/VsCodeAgentEnvironmentScannerTests.cs
@@ -394,13 +394,8 @@ public class VsCodeAgentEnvironmentScannerTests(ITestOutputHelper outputHelper)
         // (the scanner ignores .vscode in the home directory as that's for user settings, not workspace config)
         homeDirectory ??= new DirectoryInfo(Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString()));
 
-        return new CliExecutionContext(
-            workingDirectory: workingDirectory,
-            hivesDirectory: workingDirectory,
-            cacheDirectory: workingDirectory,
-            sdksDirectory: workingDirectory,
-            logsDirectory: workingDirectory,
-            logFilePath: "test.log",
+        return TestExecutionContextHelper.CreateExecutionContext(
+            workingDirectory,
             debugMode: false,
             environmentVariables: environmentVariables,
             homeDirectory: homeDirectory);

--- a/tests/Aspire.Cli.Tests/Backchannel/AppHostConnectionResolverTests.cs
+++ b/tests/Aspire.Cli.Tests/Backchannel/AppHostConnectionResolverTests.cs
@@ -129,20 +129,8 @@ public class AppHostConnectionResolverTests(ITestOutputHelper outputHelper)
 
     private static CliExecutionContext CreateExecutionContext(DirectoryInfo workingDirectory)
     {
-        var settingsDirectory = workingDirectory.CreateSubdirectory(".aspire");
-        var hivesDirectory = settingsDirectory.CreateSubdirectory("hives");
-        var cacheDirectory = settingsDirectory.CreateSubdirectory("cache");
-        var sdksDirectory = workingDirectory.CreateSubdirectory("sdks");
-        var logsDirectory = workingDirectory.CreateSubdirectory("logs");
-        var logFilePath = Path.Combine(logsDirectory.FullName, "test.log");
-
-        return new CliExecutionContext(
+        return TestExecutionContextHelper.CreateExecutionContext(
             workingDirectory,
-            hivesDirectory,
-            cacheDirectory,
-            sdksDirectory,
-            logsDirectory,
-            logFilePath,
             homeDirectory: workingDirectory);
     }
 

--- a/tests/Aspire.Cli.Tests/Caching/DiskCacheTests.cs
+++ b/tests/Aspire.Cli.Tests/Caching/DiskCacheTests.cs
@@ -17,9 +17,7 @@ public class DiskCacheTests(ITestOutputHelper outputHelper)
         var values = new Dictionary<string,string?>();
         configure?.Invoke(values);
         var configuration = new ConfigurationBuilder().AddInMemoryCollection(values).Build();
-        var hives = new DirectoryInfo(Path.Combine(workspace.WorkspaceRoot.FullName, ".aspire", "hives"));
-        var cacheDir = new DirectoryInfo(Path.Combine(workspace.WorkspaceRoot.FullName, ".aspire", "cache"));
-        var ctx = new CliExecutionContext(workspace.WorkspaceRoot, hives, cacheDir, new DirectoryInfo(Path.Combine(Path.GetTempPath(), "aspire-test-runtimes")), new DirectoryInfo(Path.Combine(Path.GetTempPath(), "aspire-test-logs")), "test.log");
+        var ctx = workspace.CreateExecutionContext();
         var loggerFactory = NullLoggerFactory.Instance; // no-op logging is fine here
         var logger = loggerFactory.CreateLogger<DiskCache>();
         return new DiskCache(logger, ctx, configuration);

--- a/tests/Aspire.Cli.Tests/Commands/AgentInitCommandTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/AgentInitCommandTests.cs
@@ -242,17 +242,8 @@ public class AgentInitCommandTests(ITestOutputHelper outputHelper)
 
     private static CliExecutionContext CreateExecutionContext(DirectoryInfo workingDirectory, DirectoryInfo homeDirectory)
     {
-        var hivesDirectory = new DirectoryInfo(Path.Combine(workingDirectory.FullName, ".aspire", "hives"));
-        var cacheDirectory = new DirectoryInfo(Path.Combine(workingDirectory.FullName, ".aspire", "cache"));
-        var logsDirectory = new DirectoryInfo(Path.Combine(workingDirectory.FullName, ".aspire", "logs"));
-        var logFilePath = Path.Combine(logsDirectory.FullName, "test.log");
-        return new CliExecutionContext(
+        return TestExecutionContextHelper.CreateExecutionContext(
             workingDirectory,
-            hivesDirectory,
-            cacheDirectory,
-            new DirectoryInfo(Path.Combine(Path.GetTempPath(), "aspire-test-sdks")),
-            logsDirectory,
-            logFilePath,
             homeDirectory: homeDirectory);
     }
 }

--- a/tests/Aspire.Cli.Tests/Commands/DashboardRunCommandTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/DashboardRunCommandTests.cs
@@ -484,13 +484,7 @@ public class DashboardRunCommandTests(ITestOutputHelper outputHelper)
 
         using var workspace = TemporaryWorkspace.Create(outputHelper);
         var logFilePath = Path.Combine(workspace.WorkspaceRoot.FullName, "cli [dashboard].log");
-        var executionContext = new CliExecutionContext(
-            workingDirectory: workspace.WorkspaceRoot,
-            hivesDirectory: workspace.WorkspaceRoot,
-            cacheDirectory: workspace.WorkspaceRoot,
-            sdksDirectory: workspace.WorkspaceRoot,
-            logsDirectory: workspace.WorkspaceRoot,
-            logFilePath: logFilePath);
+        var executionContext = workspace.CreateExecutionContext(logFilePath: logFilePath);
 
         var interactionService = new ConsoleInteractionService(
             new ConsoleEnvironment(console, console),
@@ -549,12 +543,7 @@ public class DashboardRunCommandTests(ITestOutputHelper outputHelper)
 
     private static CliExecutionContext CreateExecutionContext(TemporaryWorkspace workspace, Dictionary<string, string?> envVars)
     {
-        var dir = workspace.WorkspaceRoot;
-        var hivesDir = new DirectoryInfo(Path.Combine(dir.FullName, ".aspire", "hives"));
-        var cacheDir = new DirectoryInfo(Path.Combine(dir.FullName, ".aspire", "cache"));
-        var logsDir = new DirectoryInfo(Path.Combine(dir.FullName, ".aspire", "logs"));
-        var logFile = Path.Combine(logsDir.FullName, "test.log");
-        return new CliExecutionContext(dir, hivesDir, cacheDir, new DirectoryInfo(Path.Combine(Path.GetTempPath(), "aspire-test-sdks")), logsDir, logFile, environmentVariables: envVars);
+        return workspace.CreateExecutionContext(environmentVariables: envVars);
     }
 
     private sealed class FakeLayoutDiscovery(LayoutConfiguration layout) : ILayoutDiscovery

--- a/tests/Aspire.Cli.Tests/Commands/InitCommandTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/InitCommandTests.cs
@@ -1501,19 +1501,8 @@ public class InitCommandTests(ITestOutputHelper outputHelper)
 
     private static CliExecutionContext BuildExecutionContext(DirectoryInfo workingDirectory, string channel)
     {
-        var hivesDirectory = new DirectoryInfo(Path.Combine(workingDirectory.FullName, ".aspire", "hives"));
-        var cacheDirectory = new DirectoryInfo(Path.Combine(workingDirectory.FullName, ".aspire", "cache"));
-        var sdksDirectory = new DirectoryInfo(Path.Combine(workingDirectory.FullName, ".aspire", "sdks"));
-        var logsDirectory = new DirectoryInfo(Path.Combine(workingDirectory.FullName, ".aspire", "logs"));
-        var logFilePath = Path.Combine(logsDirectory.FullName, "test.log");
-
-        return new CliExecutionContext(
-            workingDirectory: workingDirectory,
-            hivesDirectory: hivesDirectory,
-            cacheDirectory: cacheDirectory,
-            sdksDirectory: sdksDirectory,
-            logsDirectory: logsDirectory,
-            logFilePath: logFilePath,
+        return TestExecutionContextHelper.CreateExecutionContext(
+            workingDirectory,
             identityChannel: channel);
     }
 

--- a/tests/Aspire.Cli.Tests/Commands/NewCommandChannelResolutionTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/NewCommandChannelResolutionTests.cs
@@ -368,8 +368,7 @@ public class NewCommandChannelResolutionTests(ITestOutputHelper outputHelper)
     private static CliExecutionContext BuildExecutionContextWithIdentity(TemporaryWorkspace workspace, string identityChannel)
     {
         return workspace.CreateExecutionContext(
-            identityChannel: identityChannel,
-            homeDirectory: new DirectoryInfo(Path.Combine(workspace.WorkspaceRoot.FullName, "fake-home")));
+            identityChannel: identityChannel);
     }
 
     private sealed class CapturedTemplateInputs

--- a/tests/Aspire.Cli.Tests/Commands/NewCommandChannelResolutionTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/NewCommandChannelResolutionTests.cs
@@ -367,24 +367,9 @@ public class NewCommandChannelResolutionTests(ITestOutputHelper outputHelper)
 
     private static CliExecutionContext BuildExecutionContextWithIdentity(TemporaryWorkspace workspace, string identityChannel)
     {
-        var workingDirectory = workspace.WorkspaceRoot;
-        var hivesDirectory = new DirectoryInfo(Path.Combine(workingDirectory.FullName, ".aspire", "hives"));
-        var cacheDirectory = new DirectoryInfo(Path.Combine(workingDirectory.FullName, ".aspire", "cache"));
-        var sdksDirectory = new DirectoryInfo(Path.Combine(workingDirectory.FullName, ".aspire", "sdks"));
-        var logsDirectory = new DirectoryInfo(Path.Combine(workingDirectory.FullName, ".aspire", "logs"));
-        var logFilePath = Path.Combine(logsDirectory.FullName, "test.log");
-        // Use a workspace-scoped home directory so concurrent tests don't collide
-        // when installing user-level agent skills to ~/.agents/skills/.
-        var homeDirectory = new DirectoryInfo(Path.Combine(workingDirectory.FullName, "fake-home"));
-        return new CliExecutionContext(
-            workingDirectory,
-            hivesDirectory,
-            cacheDirectory,
-            sdksDirectory,
-            logsDirectory,
-            logFilePath,
-            homeDirectory: homeDirectory,
-            identityChannel: identityChannel);
+        return workspace.CreateExecutionContext(
+            identityChannel: identityChannel,
+            homeDirectory: new DirectoryInfo(Path.Combine(workspace.WorkspaceRoot.FullName, "fake-home")));
     }
 
     private sealed class CapturedTemplateInputs

--- a/tests/Aspire.Cli.Tests/Commands/NewCommandChannelResolutionTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/NewCommandChannelResolutionTests.cs
@@ -373,6 +373,9 @@ public class NewCommandChannelResolutionTests(ITestOutputHelper outputHelper)
         var sdksDirectory = new DirectoryInfo(Path.Combine(workingDirectory.FullName, ".aspire", "sdks"));
         var logsDirectory = new DirectoryInfo(Path.Combine(workingDirectory.FullName, ".aspire", "logs"));
         var logFilePath = Path.Combine(logsDirectory.FullName, "test.log");
+        // Use a workspace-scoped home directory so concurrent tests don't collide
+        // when installing user-level agent skills to ~/.agents/skills/.
+        var homeDirectory = new DirectoryInfo(Path.Combine(workingDirectory.FullName, "fake-home"));
         return new CliExecutionContext(
             workingDirectory,
             hivesDirectory,
@@ -380,6 +383,7 @@ public class NewCommandChannelResolutionTests(ITestOutputHelper outputHelper)
             sdksDirectory,
             logsDirectory,
             logFilePath,
+            homeDirectory: homeDirectory,
             identityChannel: identityChannel);
     }
 

--- a/tests/Aspire.Cli.Tests/Commands/NewCommandTemplateConfigPersistenceTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/NewCommandTemplateConfigPersistenceTests.cs
@@ -317,19 +317,6 @@ public class NewCommandTemplateConfigPersistenceTests(ITestOutputHelper outputHe
 
     private static CliExecutionContext BuildExecutionContextWithIdentity(TemporaryWorkspace workspace, string identityChannel)
     {
-        var workingDirectory = workspace.WorkspaceRoot;
-        var hivesDirectory = new DirectoryInfo(Path.Combine(workingDirectory.FullName, ".aspire", "hives"));
-        var cacheDirectory = new DirectoryInfo(Path.Combine(workingDirectory.FullName, ".aspire", "cache"));
-        var sdksDirectory = new DirectoryInfo(Path.Combine(workingDirectory.FullName, ".aspire", "sdks"));
-        var logsDirectory = new DirectoryInfo(Path.Combine(workingDirectory.FullName, ".aspire", "logs"));
-        var logFilePath = Path.Combine(logsDirectory.FullName, "test.log");
-        return new CliExecutionContext(
-            workingDirectory,
-            hivesDirectory,
-            cacheDirectory,
-            sdksDirectory,
-            logsDirectory,
-            logFilePath,
-            identityChannel: identityChannel);
+        return workspace.CreateExecutionContext(identityChannel: identityChannel);
     }
 }

--- a/tests/Aspire.Cli.Tests/Commands/NewCommandTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/NewCommandTests.cs
@@ -2372,14 +2372,10 @@ public class NewCommandTests(ITestOutputHelper outputHelper)
         {
             options.CliExecutionContextFactory = _ =>
             {
-                var root = workspace.WorkspaceRoot.FullName;
-                return new CliExecutionContext(
-                    projectDir,
-                    new DirectoryInfo(Path.Combine(root, ".aspire", "hives")),
-                    new DirectoryInfo(Path.Combine(root, ".aspire", "cache")),
-                    new DirectoryInfo(Path.Combine(Path.GetTempPath(), "aspire-test-sdks")),
-                    new DirectoryInfo(Path.Combine(root, ".aspire", "logs")),
-                    Path.Combine(root, ".aspire", "logs", "test.log"));
+                // Use projectDir as the working directory but root the .aspire/*
+                // directories under the workspace so test infra doesn't pollute the project dir.
+                return TestExecutionContextHelper.CreateExecutionContext(
+                    projectDir);
             };
 
             options.DotNetCliRunnerFactory = _ =>

--- a/tests/Aspire.Cli.Tests/Commands/RunCommandTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/RunCommandTests.cs
@@ -517,13 +517,7 @@ public class RunCommandTests(ITestOutputHelper outputHelper)
 
         using var workspace = TemporaryWorkspace.Create(outputHelper);
         var logFilePath = Path.Combine(workspace.WorkspaceRoot.FullName, "cli [run].log");
-        var executionContext = new CliExecutionContext(
-            workingDirectory: workspace.WorkspaceRoot,
-            hivesDirectory: workspace.WorkspaceRoot,
-            cacheDirectory: workspace.WorkspaceRoot,
-            sdksDirectory: workspace.WorkspaceRoot,
-            logsDirectory: workspace.WorkspaceRoot,
-            logFilePath: logFilePath);
+        var executionContext = workspace.CreateExecutionContext(logFilePath: logFilePath);
 
         var interactionService = new ConsoleInteractionService(
             new ConsoleEnvironment(console, console),
@@ -1219,9 +1213,7 @@ public class RunCommandTests(ITestOutputHelper outputHelper)
 
         var options = new ProcessInvocationOptions();
 
-        var executionContext = new CliExecutionContext(
-            workingDirectory: workspace.WorkspaceRoot, hivesDirectory: workspace.WorkspaceRoot.CreateSubdirectory(".aspire").CreateSubdirectory("hives"), cacheDirectory: workspace.WorkspaceRoot.CreateSubdirectory(".aspire").CreateSubdirectory("cache"), sdksDirectory: new DirectoryInfo(Path.Combine(Path.GetTempPath(), "aspire-test-sdks")), logsDirectory: new DirectoryInfo(Path.Combine(Path.GetTempPath(), "aspire-test-logs")), logFilePath: "test.log"
-        );
+        var executionContext = workspace.CreateExecutionContext();
 
         var runner = DotNetCliRunnerTestHelper.Create(
             provider,
@@ -1269,9 +1261,7 @@ public class RunCommandTests(ITestOutputHelper outputHelper)
 
         var options = new ProcessInvocationOptions();
 
-        var executionContext = new CliExecutionContext(
-            workingDirectory: workspace.WorkspaceRoot, hivesDirectory: workspace.WorkspaceRoot.CreateSubdirectory(".aspire").CreateSubdirectory("hives"), cacheDirectory: workspace.WorkspaceRoot.CreateSubdirectory(".aspire").CreateSubdirectory("cache"), sdksDirectory: new DirectoryInfo(Path.Combine(Path.GetTempPath(), "aspire-test-sdks")), logsDirectory: new DirectoryInfo(Path.Combine(Path.GetTempPath(), "aspire-test-logs")), logFilePath: "test.log"
-        );
+        var executionContext = workspace.CreateExecutionContext();
 
         var runner = DotNetCliRunnerTestHelper.Create(
             provider,
@@ -1315,9 +1305,7 @@ public class RunCommandTests(ITestOutputHelper outputHelper)
 
         var options = new ProcessInvocationOptions { Debug = true };
 
-        var executionContext = new CliExecutionContext(
-            workingDirectory: workspace.WorkspaceRoot, hivesDirectory: workspace.WorkspaceRoot.CreateSubdirectory(".aspire").CreateSubdirectory("hives"), cacheDirectory: workspace.WorkspaceRoot.CreateSubdirectory(".aspire").CreateSubdirectory("cache"), sdksDirectory: new DirectoryInfo(Path.Combine(Path.GetTempPath(), "aspire-test-sdks")), logsDirectory: new DirectoryInfo(Path.Combine(Path.GetTempPath(), "aspire-test-logs")), logFilePath: "test.log"
-        );
+        var executionContext = workspace.CreateExecutionContext();
 
         var runner = DotNetCliRunnerTestHelper.Create(
             provider,
@@ -1365,9 +1353,7 @@ public class RunCommandTests(ITestOutputHelper outputHelper)
 
         var options = new ProcessInvocationOptions { Debug = false };
 
-        var executionContext = new CliExecutionContext(
-            workingDirectory: workspace.WorkspaceRoot, hivesDirectory: workspace.WorkspaceRoot.CreateSubdirectory(".aspire").CreateSubdirectory("hives"), cacheDirectory: workspace.WorkspaceRoot.CreateSubdirectory(".aspire").CreateSubdirectory("cache"), sdksDirectory: new DirectoryInfo(Path.Combine(Path.GetTempPath(), "aspire-test-sdks")), logsDirectory: new DirectoryInfo(Path.Combine(Path.GetTempPath(), "aspire-test-logs")), logFilePath: "test.log"
-        );
+        var executionContext = workspace.CreateExecutionContext();
 
         var runner = DotNetCliRunnerTestHelper.Create(
             provider,
@@ -1410,9 +1396,7 @@ public class RunCommandTests(ITestOutputHelper outputHelper)
 
         var options = new ProcessInvocationOptions { Debug = true };
 
-        var executionContext = new CliExecutionContext(
-            workingDirectory: workspace.WorkspaceRoot, hivesDirectory: workspace.WorkspaceRoot.CreateSubdirectory(".aspire").CreateSubdirectory("hives"), cacheDirectory: workspace.WorkspaceRoot.CreateSubdirectory(".aspire").CreateSubdirectory("cache"), sdksDirectory: new DirectoryInfo(Path.Combine(Path.GetTempPath(), "aspire-test-sdks")), logsDirectory: new DirectoryInfo(Path.Combine(Path.GetTempPath(), "aspire-test-logs")), logFilePath: "test.log"
-        );
+        var executionContext = workspace.CreateExecutionContext();
 
         var runner = DotNetCliRunnerTestHelper.Create(
             provider,
@@ -1456,9 +1440,7 @@ public class RunCommandTests(ITestOutputHelper outputHelper)
 
         var options = new ProcessInvocationOptions();
 
-        var executionContext = new CliExecutionContext(
-            workingDirectory: workspace.WorkspaceRoot, hivesDirectory: workspace.WorkspaceRoot.CreateSubdirectory(".aspire").CreateSubdirectory("hives"), cacheDirectory: workspace.WorkspaceRoot.CreateSubdirectory(".aspire").CreateSubdirectory("cache"), sdksDirectory: new DirectoryInfo(Path.Combine(Path.GetTempPath(), "aspire-test-sdks")), logsDirectory: new DirectoryInfo(Path.Combine(Path.GetTempPath(), "aspire-test-logs")), logFilePath: "test.log"
-        );
+        var executionContext = workspace.CreateExecutionContext();
 
         var runner = DotNetCliRunnerTestHelper.Create(
             provider,
@@ -1502,9 +1484,7 @@ public class RunCommandTests(ITestOutputHelper outputHelper)
 
         var options = new ProcessInvocationOptions();
 
-        var executionContext = new CliExecutionContext(
-            workingDirectory: workspace.WorkspaceRoot, hivesDirectory: workspace.WorkspaceRoot.CreateSubdirectory(".aspire").CreateSubdirectory("hives"), cacheDirectory: workspace.WorkspaceRoot.CreateSubdirectory(".aspire").CreateSubdirectory("cache"), sdksDirectory: new DirectoryInfo(Path.Combine(Path.GetTempPath(), "aspire-test-sdks")), logsDirectory: new DirectoryInfo(Path.Combine(Path.GetTempPath(), "aspire-test-logs")), logFilePath: "test.log"
-        );
+        var executionContext = workspace.CreateExecutionContext();
 
         var runner = DotNetCliRunnerTestHelper.Create(
             provider,

--- a/tests/Aspire.Cli.Tests/Configuration/ConfigurationServiceTests.cs
+++ b/tests/Aspire.Cli.Tests/Configuration/ConfigurationServiceTests.cs
@@ -25,14 +25,7 @@ public class ConfigurationServiceTests(ITestOutputHelper outputHelper)
             File.WriteAllText(settingsFilePath, existingContent);
         }
 
-        var logsDir = new DirectoryInfo(Path.Combine(workspace.WorkspaceRoot.FullName, "logs"));
-        var executionContext = new CliExecutionContext(
-            workspace.WorkspaceRoot,
-            new DirectoryInfo(Path.Combine(workspace.WorkspaceRoot.FullName, ".aspire", "hives")),
-            new DirectoryInfo(Path.Combine(workspace.WorkspaceRoot.FullName, ".aspire", "cache")),
-            new DirectoryInfo(Path.Combine(Path.GetTempPath(), "aspire-test-runtimes")),
-            logsDir,
-            "test.log");
+        var executionContext = workspace.CreateExecutionContext();
 
         var configBuilder = new ConfigurationBuilder();
         var configuration = configBuilder.Build();

--- a/tests/Aspire.Cli.Tests/DotNet/DotNetCliRunnerTests.cs
+++ b/tests/Aspire.Cli.Tests/DotNet/DotNetCliRunnerTests.cs
@@ -18,12 +18,7 @@ public class DotNetCliRunnerTests(ITestOutputHelper outputHelper)
 {
     private static Aspire.Cli.CliExecutionContext CreateExecutionContext(DirectoryInfo workingDirectory)
     {
-        // NOTE: This would normally be in the users home directory, but for tests we create
-        //       it in the temporary workspace directory.
-        var settingsDirectory = workingDirectory.CreateSubdirectory(".aspire");
-        var hivesDirectory = settingsDirectory.CreateSubdirectory("hives");
-        var cacheDirectory = new DirectoryInfo(Path.Combine(workingDirectory.FullName, ".aspire", "cache"));
-        return new CliExecutionContext(workingDirectory, hivesDirectory, cacheDirectory, new DirectoryInfo(Path.Combine(Path.GetTempPath(), "aspire-test-runtimes")), new DirectoryInfo(Path.Combine(Path.GetTempPath(), "aspire-test-logs")), "test.log");
+        return TestExecutionContextHelper.CreateExecutionContext(workingDirectory);
     }
 
     [Fact]

--- a/tests/Aspire.Cli.Tests/Git/GitRepositoryTests.cs
+++ b/tests/Aspire.Cli.Tests/Git/GitRepositoryTests.cs
@@ -14,21 +14,11 @@ namespace Aspire.Cli.Tests.Git;
 
 public class GitRepositoryTests(ITestOutputHelper outputHelper)
 {
-    private static CliExecutionContext CreateExecutionContext(DirectoryInfo workingDirectory)
-    {
-        var settings = workingDirectory.CreateSubdirectory(".aspire-cli-state");
-        var hives = settings.CreateSubdirectory("hives");
-        var cache = settings.CreateSubdirectory("cache");
-        var sdks = settings.CreateSubdirectory("sdks");
-        var logs = settings.CreateSubdirectory("logs");
-        return new CliExecutionContext(workingDirectory, hives, cache, sdks, logs, "test.log");
-    }
-
     [Fact]
     public async Task GetIncludedFilesAsync_OutsideRepo_ReturnsNull()
     {
         using var workspace = TemporaryWorkspace.Create(outputHelper);
-        var executionContext = CreateExecutionContext(workspace.WorkspaceRoot);
+        var executionContext = workspace.CreateExecutionContext();
         using var profilingTelemetry = CreateProfilingTelemetry();
         var repo = new GitRepository(executionContext, NullLogger<GitRepository>.Instance, profilingTelemetry);
 
@@ -68,7 +58,7 @@ public class GitRepositoryTests(ITestOutputHelper outputHelper)
         await GitTestHelper.RunGitAsync(workspace.WorkspaceRoot.FullName, "add", "App/AppHost.csproj", ".gitignore");
         await GitTestHelper.RunGitAsync(workspace.WorkspaceRoot.FullName, "commit", "-m", "init");
 
-        var executionContext = CreateExecutionContext(workspace.WorkspaceRoot);
+        var executionContext = workspace.CreateExecutionContext();
         using var profilingTelemetry = CreateProfilingTelemetry();
         var repo = new GitRepository(executionContext, NullLogger<GitRepository>.Instance, profilingTelemetry);
 
@@ -97,7 +87,7 @@ public class GitRepositoryTests(ITestOutputHelper outputHelper)
         // listed by `git ls-files --cached`.
         File.Delete(trackedFile);
 
-        var executionContext = CreateExecutionContext(workspace.WorkspaceRoot);
+        var executionContext = workspace.CreateExecutionContext();
         using var profilingTelemetry = CreateProfilingTelemetry();
         var repo = new GitRepository(executionContext, NullLogger<GitRepository>.Instance, profilingTelemetry);
 
@@ -125,7 +115,7 @@ public class GitRepositoryTests(ITestOutputHelper outputHelper)
         using var profilingTelemetry = CreateProfilingTelemetry(
             (ProfilingTelemetry.EnvironmentVariables.Enabled, "true"),
             (ProfilingTelemetry.EnvironmentVariables.SessionId, "session-1"));
-        var executionContext = CreateExecutionContext(workspace.WorkspaceRoot);
+        var executionContext = workspace.CreateExecutionContext();
         var repo = new GitRepository(executionContext, NullLogger<GitRepository>.Instance, profilingTelemetry);
 
         var result = await repo.GetIncludedFilesAsync(workspace.WorkspaceRoot, CancellationToken.None).DefaultTimeout();

--- a/tests/Aspire.Cli.Tests/Mcp/ListAppHostsToolTests.cs
+++ b/tests/Aspire.Cli.Tests/Mcp/ListAppHostsToolTests.cs
@@ -166,9 +166,7 @@ public class ListAppHostsToolTests(ITestOutputHelper outputHelper)
 
     private static CliExecutionContext CreateCliExecutionContext(DirectoryInfo workingDirectory)
     {
-        var hivesDirectory = new DirectoryInfo(Path.Combine(workingDirectory.FullName, ".aspire", "hives"));
-        var cacheDirectory = new DirectoryInfo(Path.Combine(workingDirectory.FullName, ".aspire", "cache"));
-        return new CliExecutionContext(workingDirectory, hivesDirectory, cacheDirectory, new DirectoryInfo(Path.Combine(Path.GetTempPath(), "aspire-test-sdks")), new DirectoryInfo(Path.Combine(Path.GetTempPath(), "aspire-test-logs")), "test.log");
+        return TestExecutionContextHelper.CreateExecutionContext(workingDirectory);
     }
 
     private static AppHostAuxiliaryBackchannel CreateAppHostConnection(string hash, string socketPath, AppHostInformation appHostInfo, bool isInScope)

--- a/tests/Aspire.Cli.Tests/Mcp/MockPackagingService.cs
+++ b/tests/Aspire.Cli.Tests/Mcp/MockPackagingService.cs
@@ -4,6 +4,7 @@
 using Aspire.Cli.Backchannel;
 using Aspire.Cli.Packaging;
 using Aspire.Cli.Tests.TestServices;
+using Aspire.Cli.Tests.Utils;
 using Aspire.Shared;
 
 namespace Aspire.Cli.Tests.Mcp;
@@ -32,13 +33,8 @@ internal static class TestExecutionContextFactory
 {
     public static CliExecutionContext CreateTestContext()
     {
-        return new CliExecutionContext(
-            new DirectoryInfo(Path.GetTempPath()),
-            new DirectoryInfo(Path.Combine(Path.GetTempPath(), "hives")),
-            new DirectoryInfo(Path.Combine(Path.GetTempPath(), "cache")),
-            new DirectoryInfo(Path.Combine(Path.GetTempPath(), "sdks")),
-            new DirectoryInfo(Path.Combine(Path.GetTempPath(), "logs")),
-            "test.log");
+        return TestExecutionContextHelper.CreateExecutionContext(
+            new DirectoryInfo(Path.GetTempPath()));
     }
 }
 

--- a/tests/Aspire.Cli.Tests/NuGet/NuGetPackagePrefetcherTests.cs
+++ b/tests/Aspire.Cli.Tests/NuGet/NuGetPackagePrefetcherTests.cs
@@ -6,6 +6,7 @@ using System.Diagnostics;
 using Aspire.Cli.Commands;
 using Aspire.Cli.NuGet;
 using Aspire.Cli.Tests.TestServices;
+using Aspire.Cli.Tests.Utils;
 using Microsoft.AspNetCore.InternalTesting;
 using Microsoft.Extensions.Logging.Testing;
 
@@ -17,9 +18,7 @@ public class NuGetPackagePrefetcherTests
     public void CliExecutionContextSetsCommand()
     {
         var workingDir = new DirectoryInfo(Environment.CurrentDirectory);
-        var hivesDir = new DirectoryInfo(Path.Combine(Environment.CurrentDirectory, "hives"));
-    var cacheDir = new DirectoryInfo(Path.Combine(workingDir.FullName, ".aspire", "cache"));
-    var executionContext = new CliExecutionContext(workingDir, hivesDir, cacheDir, new DirectoryInfo(Path.Combine(Path.GetTempPath(), "aspire-test-runtimes")), new DirectoryInfo(Path.Combine(Path.GetTempPath(), "aspire-test-logs")), "test.log");
+        var executionContext = TestExecutionContextHelper.CreateExecutionContext(workingDir);
         
         Assert.Null(executionContext.Command);
         
@@ -187,15 +186,7 @@ public class NuGetPackagePrefetcherTests
     private static CliExecutionContext CreateExecutionContext()
     {
         var workingDir = new DirectoryInfo(Environment.CurrentDirectory);
-        var hivesDir = new DirectoryInfo(Path.Combine(Environment.CurrentDirectory, "hives"));
-        var cacheDir = new DirectoryInfo(Path.Combine(workingDir.FullName, ".aspire", "cache"));
-        return new CliExecutionContext(
-            workingDir,
-            hivesDir,
-            cacheDir,
-            new DirectoryInfo(Path.Combine(Path.GetTempPath(), "aspire-test-runtimes")),
-            new DirectoryInfo(Path.Combine(Path.GetTempPath(), "aspire-test-logs")),
-            "test.log");
+        return TestExecutionContextHelper.CreateExecutionContext(workingDir);
     }
 }
 

--- a/tests/Aspire.Cli.Tests/NuGet/NuGetPackagePrefetcherTests.cs
+++ b/tests/Aspire.Cli.Tests/NuGet/NuGetPackagePrefetcherTests.cs
@@ -19,9 +19,9 @@ public class NuGetPackagePrefetcherTests
     {
         var workingDir = new DirectoryInfo(Environment.CurrentDirectory);
         var executionContext = TestExecutionContextHelper.CreateExecutionContext(workingDir);
-        
+
         Assert.Null(executionContext.Command);
-        
+
         var testCommand = new TestCommand();
         executionContext.Command = testCommand;
         Assert.Same(testCommand, executionContext.Command);

--- a/tests/Aspire.Cli.Tests/NuGet/NuGetSignatureVerificationEnablerTests.cs
+++ b/tests/Aspire.Cli.Tests/NuGet/NuGetSignatureVerificationEnablerTests.cs
@@ -3,6 +3,7 @@
 
 using Aspire.Cli.NuGet;
 using Aspire.Cli.Tests.TestServices;
+using Aspire.Cli.Tests.Utils;
 
 namespace Aspire.Cli.Tests.NuGet;
 
@@ -11,9 +12,7 @@ public class NuGetSignatureVerificationEnablerTests
     private static CliExecutionContext CreateContext(Dictionary<string, string?>? envVars = null)
     {
         var dir = new DirectoryInfo(Path.GetTempPath());
-        return new CliExecutionContext(
-            dir, dir, dir, dir, dir, "test.log",
-            environmentVariables: envVars);
+        return TestExecutionContextHelper.CreateExecutionContext(dir, environmentVariables: envVars);
     }
 
     [Fact]

--- a/tests/Aspire.Cli.Tests/Packaging/NuGetConfigMergerSnapshotTests.cs
+++ b/tests/Aspire.Cli.Tests/Packaging/NuGetConfigMergerSnapshotTests.cs
@@ -49,8 +49,7 @@ public class NuGetConfigMergerSnapshotTests
         var hivesDir = root.CreateSubdirectory("hives");
         // Add a deterministic PR hive for testing realistic PR channel mappings.
         hivesDir.CreateSubdirectory("pr-1234");
-        var cacheDir = new DirectoryInfo(Path.Combine(root.FullName, ".aspire", "cache"));
-        var executionContext = new CliExecutionContext(root, hivesDir, cacheDir, new DirectoryInfo(Path.Combine(Path.GetTempPath(), "aspire-test-runtimes")), new DirectoryInfo(Path.Combine(Path.GetTempPath(), "aspire-test-logs")), "test.log");
+        var executionContext = TestExecutionContextHelper.CreateExecutionContext(root, hivesDirectory: hivesDir);
         var packagingService = CreatePackagingService(executionContext);
 
         // Existing config purposely minimal (no packageSourceMapping yet)
@@ -99,8 +98,7 @@ public class NuGetConfigMergerSnapshotTests
         var hivesDir = root.CreateSubdirectory("hives");
         // Add a deterministic PR hive for testing realistic PR channel mappings.
         hivesDir.CreateSubdirectory("pr-1234");
-        var cacheDir2 = new DirectoryInfo(Path.Combine(root.FullName, ".aspire", "cache"));
-        var executionContext = new CliExecutionContext(root, hivesDir, cacheDir2, new DirectoryInfo(Path.Combine(Path.GetTempPath(), "aspire-test-runtimes")), new DirectoryInfo(Path.Combine(Path.GetTempPath(), "aspire-test-logs")), "test.log");
+        var executionContext = TestExecutionContextHelper.CreateExecutionContext(root, hivesDirectory: hivesDir);
         var packagingService = CreatePackagingService(executionContext);
 
         // Existing config purposely minimal (no packageSourceMapping yet)
@@ -162,8 +160,7 @@ public class NuGetConfigMergerSnapshotTests
         var hivesDir = root.CreateSubdirectory("hives");
         // Add a deterministic PR hive for testing realistic PR channel mappings.
         hivesDir.CreateSubdirectory("pr-1234");
-        var cacheDir3 = new DirectoryInfo(Path.Combine(root.FullName, ".aspire", "cache"));
-        var executionContext = new CliExecutionContext(root, hivesDir, cacheDir3, new DirectoryInfo(Path.Combine(Path.GetTempPath(), "aspire-test-runtimes")), new DirectoryInfo(Path.Combine(Path.GetTempPath(), "aspire-test-logs")), "test.log");
+        var executionContext = TestExecutionContextHelper.CreateExecutionContext(root, hivesDirectory: hivesDir);
         var packagingService = CreatePackagingService(executionContext);
 
         // Existing config purposely minimal (no packageSourceMapping yet)
@@ -224,8 +221,7 @@ public class NuGetConfigMergerSnapshotTests
         var hivesDir = root.CreateSubdirectory("hives");
         // Add a deterministic PR hive for testing realistic PR channel mappings.
         hivesDir.CreateSubdirectory("pr-1234");
-        var cacheDir4 = new DirectoryInfo(Path.Combine(root.FullName, ".aspire", "cache"));
-        var executionContext = new CliExecutionContext(root, hivesDir, cacheDir4, new DirectoryInfo(Path.Combine(Path.GetTempPath(), "aspire-test-runtimes")), new DirectoryInfo(Path.Combine(Path.GetTempPath(), "aspire-test-logs")), "test.log");
+        var executionContext = TestExecutionContextHelper.CreateExecutionContext(root, hivesDirectory: hivesDir);
         var packagingService = CreatePackagingService(executionContext);
 
         // Existing config purposely minimal (no packageSourceMapping yet)
@@ -284,8 +280,7 @@ public class NuGetConfigMergerSnapshotTests
         var hivesDir = root.CreateSubdirectory("hives");
         // Add a deterministic PR hive for testing realistic PR channel mappings.
         hivesDir.CreateSubdirectory("pr-1234");
-        var cacheDir5 = new DirectoryInfo(Path.Combine(root.FullName, ".aspire", "cache"));
-        var executionContext = new CliExecutionContext(root, hivesDir, cacheDir5, new DirectoryInfo(Path.Combine(Path.GetTempPath(), "aspire-test-runtimes")), new DirectoryInfo(Path.Combine(Path.GetTempPath(), "aspire-test-logs")), "test.log");
+        var executionContext = TestExecutionContextHelper.CreateExecutionContext(root, hivesDirectory: hivesDir);
         var packagingService = CreatePackagingService(executionContext);
 
         // Existing config purposely minimal (no packageSourceMapping yet)

--- a/tests/Aspire.Cli.Tests/Packaging/PackagingServiceTests.cs
+++ b/tests/Aspire.Cli.Tests/Packaging/PackagingServiceTests.cs
@@ -23,8 +23,7 @@ public class PackagingServiceTests(ITestOutputHelper outputHelper)
         using var workspace = TemporaryWorkspace.Create(outputHelper);
         var tempDir = workspace.WorkspaceRoot;
         var hivesDir = new DirectoryInfo(Path.Combine(tempDir.FullName, ".aspire", "hives"));
-        var cacheDir = new DirectoryInfo(Path.Combine(tempDir.FullName, ".aspire", "cache"));
-        var executionContext = new CliExecutionContext(tempDir, hivesDir, cacheDir, new DirectoryInfo(Path.Combine(Path.GetTempPath(), "aspire-test-runtimes")), new DirectoryInfo(Path.Combine(Path.GetTempPath(), "aspire-test-logs")), "test.log");
+        var executionContext = TestExecutionContextHelper.CreateExecutionContext(tempDir, hivesDirectory: hivesDir);
         
         var features = new TestFeatures();
         var configuration = new ConfigurationBuilder().Build();
@@ -68,8 +67,7 @@ public class PackagingServiceTests(ITestOutputHelper outputHelper)
         using var workspace = TemporaryWorkspace.Create(outputHelper);
         var tempDir = workspace.WorkspaceRoot;
         var hivesDir = new DirectoryInfo(Path.Combine(tempDir.FullName, ".aspire", "hives"));
-        var cacheDir = new DirectoryInfo(Path.Combine(tempDir.FullName, ".aspire", "cache"));
-        var executionContext = new CliExecutionContext(tempDir, hivesDir, cacheDir, new DirectoryInfo(Path.Combine(Path.GetTempPath(), "aspire-test-runtimes")), new DirectoryInfo(Path.Combine(Path.GetTempPath(), "aspire-test-logs")), "test.log");
+        var executionContext = TestExecutionContextHelper.CreateExecutionContext(tempDir, hivesDirectory: hivesDir);
 
         var features = new TestFeatures();
         var configuration = new ConfigurationBuilder().Build();
@@ -93,8 +91,7 @@ public class PackagingServiceTests(ITestOutputHelper outputHelper)
         using var workspace = TemporaryWorkspace.Create(outputHelper);
         var tempDir = workspace.WorkspaceRoot;
         var hivesDir = new DirectoryInfo(Path.Combine(tempDir.FullName, ".aspire", "hives"));
-        var cacheDir = new DirectoryInfo(Path.Combine(tempDir.FullName, ".aspire", "cache"));
-        var executionContext = new CliExecutionContext(tempDir, hivesDir, cacheDir, new DirectoryInfo(Path.Combine(Path.GetTempPath(), "aspire-test-runtimes")), new DirectoryInfo(Path.Combine(Path.GetTempPath(), "aspire-test-logs")), "test.log");
+        var executionContext = TestExecutionContextHelper.CreateExecutionContext(tempDir, hivesDirectory: hivesDir);
         
         var features = new TestFeatures();
         features.SetFeature(KnownFeatures.StagingChannelEnabled, true);
@@ -137,8 +134,7 @@ public class PackagingServiceTests(ITestOutputHelper outputHelper)
         using var workspace = TemporaryWorkspace.Create(outputHelper);
         var tempDir = workspace.WorkspaceRoot;
         var hivesDir = new DirectoryInfo(Path.Combine(tempDir.FullName, ".aspire", "hives"));
-        var cacheDir = new DirectoryInfo(Path.Combine(tempDir.FullName, ".aspire", "cache"));
-        var executionContext = new CliExecutionContext(tempDir, hivesDir, cacheDir, new DirectoryInfo(Path.Combine(Path.GetTempPath(), "aspire-test-runtimes")), new DirectoryInfo(Path.Combine(Path.GetTempPath(), "aspire-test-logs")), "test.log");
+        var executionContext = TestExecutionContextHelper.CreateExecutionContext(tempDir, hivesDirectory: hivesDir);
         
         var features = new TestFeatures();
         features.SetFeature(KnownFeatures.StagingChannelEnabled, true);
@@ -170,8 +166,7 @@ public class PackagingServiceTests(ITestOutputHelper outputHelper)
         using var workspace = TemporaryWorkspace.Create(outputHelper);
         var tempDir = workspace.WorkspaceRoot;
         var hivesDir = new DirectoryInfo(Path.Combine(tempDir.FullName, ".aspire", "hives"));
-        var cacheDir = new DirectoryInfo(Path.Combine(tempDir.FullName, ".aspire", "cache"));
-        var executionContext = new CliExecutionContext(tempDir, hivesDir, cacheDir, new DirectoryInfo(Path.Combine(Path.GetTempPath(), "aspire-test-runtimes")), new DirectoryInfo(Path.Combine(Path.GetTempPath(), "aspire-test-logs")), "test.log");
+        var executionContext = TestExecutionContextHelper.CreateExecutionContext(tempDir, hivesDirectory: hivesDir);
         
         var features = new TestFeatures();
         features.SetFeature(KnownFeatures.StagingChannelEnabled, true);
@@ -203,8 +198,7 @@ public class PackagingServiceTests(ITestOutputHelper outputHelper)
         using var workspace = TemporaryWorkspace.Create(outputHelper);
         var tempDir = workspace.WorkspaceRoot;
         var hivesDir = new DirectoryInfo(Path.Combine(tempDir.FullName, ".aspire", "hives"));
-        var cacheDir = new DirectoryInfo(Path.Combine(tempDir.FullName, ".aspire", "cache"));
-        var executionContext = new CliExecutionContext(tempDir, hivesDir, cacheDir, new DirectoryInfo(Path.Combine(Path.GetTempPath(), "aspire-test-runtimes")), new DirectoryInfo(Path.Combine(Path.GetTempPath(), "aspire-test-logs")), "test.log");
+        var executionContext = TestExecutionContextHelper.CreateExecutionContext(tempDir, hivesDirectory: hivesDir);
         
         var features = new TestFeatures();
         features.SetFeature(KnownFeatures.StagingChannelEnabled, true);
@@ -235,8 +229,7 @@ public class PackagingServiceTests(ITestOutputHelper outputHelper)
         using var workspace = TemporaryWorkspace.Create(outputHelper);
         var tempDir = workspace.WorkspaceRoot;
         var hivesDir = new DirectoryInfo(Path.Combine(tempDir.FullName, ".aspire", "hives"));
-        var cacheDir = new DirectoryInfo(Path.Combine(tempDir.FullName, ".aspire", "cache"));
-        var executionContext = new CliExecutionContext(tempDir, hivesDir, cacheDir, new DirectoryInfo(Path.Combine(Path.GetTempPath(), "aspire-test-runtimes")), new DirectoryInfo(Path.Combine(Path.GetTempPath(), "aspire-test-logs")), "test.log");
+        var executionContext = TestExecutionContextHelper.CreateExecutionContext(tempDir, hivesDirectory: hivesDir);
         
         var features = new TestFeatures();
         features.SetFeature(KnownFeatures.StagingChannelEnabled, true);
@@ -266,8 +259,7 @@ public class PackagingServiceTests(ITestOutputHelper outputHelper)
         using var workspace = TemporaryWorkspace.Create(outputHelper);
         var tempDir = workspace.WorkspaceRoot;
         var hivesDir = new DirectoryInfo(Path.Combine(tempDir.FullName, ".aspire", "hives"));
-        var cacheDir = new DirectoryInfo(Path.Combine(tempDir.FullName, ".aspire", "cache"));
-        var executionContext = new CliExecutionContext(tempDir, hivesDir, cacheDir, new DirectoryInfo(Path.Combine(Path.GetTempPath(), "aspire-test-runtimes")), new DirectoryInfo(Path.Combine(Path.GetTempPath(), "aspire-test-logs")), "test.log");
+        var executionContext = TestExecutionContextHelper.CreateExecutionContext(tempDir, hivesDirectory: hivesDir);
         
         var features = new TestFeatures();
         features.SetFeature(KnownFeatures.StagingChannelEnabled, true);
@@ -297,8 +289,7 @@ public class PackagingServiceTests(ITestOutputHelper outputHelper)
         using var workspace = TemporaryWorkspace.Create(outputHelper);
         var tempDir = workspace.WorkspaceRoot;
         var hivesDir = new DirectoryInfo(Path.Combine(tempDir.FullName, ".aspire", "hives"));
-        var cacheDir = new DirectoryInfo(Path.Combine(tempDir.FullName, ".aspire", "cache"));
-        var executionContext = new CliExecutionContext(tempDir, hivesDir, cacheDir, new DirectoryInfo(Path.Combine(Path.GetTempPath(), "aspire-test-runtimes")), new DirectoryInfo(Path.Combine(Path.GetTempPath(), "aspire-test-logs")), "test.log");
+        var executionContext = TestExecutionContextHelper.CreateExecutionContext(tempDir, hivesDirectory: hivesDir);
         
         var features = new TestFeatures();
         features.SetFeature(KnownFeatures.StagingChannelEnabled, true);
@@ -328,8 +319,7 @@ public class PackagingServiceTests(ITestOutputHelper outputHelper)
         using var workspace = TemporaryWorkspace.Create(outputHelper);
         var tempDir = workspace.WorkspaceRoot;
         var hivesDir = new DirectoryInfo(Path.Combine(tempDir.FullName, ".aspire", "hives"));
-        var cacheDir = new DirectoryInfo(Path.Combine(tempDir.FullName, ".aspire", "cache"));
-        var executionContext = new CliExecutionContext(tempDir, hivesDir, cacheDir, new DirectoryInfo(Path.Combine(Path.GetTempPath(), "aspire-test-runtimes")), new DirectoryInfo(Path.Combine(Path.GetTempPath(), "aspire-test-logs")), "test.log");
+        var executionContext = TestExecutionContextHelper.CreateExecutionContext(tempDir, hivesDirectory: hivesDir);
         
         var features = new TestFeatures();
         features.SetFeature(KnownFeatures.StagingChannelEnabled, true);
@@ -369,7 +359,7 @@ public class PackagingServiceTests(ITestOutputHelper outputHelper)
             .Build();
 
         var packagingService = new PackagingService(
-            new CliExecutionContext(tempDir, tempDir, tempDir, new DirectoryInfo(Path.Combine(Path.GetTempPath(), "aspire-test-runtimes")), new DirectoryInfo(Path.Combine(Path.GetTempPath(), "aspire-test-logs")), "test.log"), 
+            TestExecutionContextHelper.CreateExecutionContext(tempDir), 
             new FakeNuGetPackageCache(), 
             features, 
             configuration,
@@ -408,14 +398,13 @@ public class PackagingServiceTests(ITestOutputHelper outputHelper)
         using var workspace = TemporaryWorkspace.Create(outputHelper);
         var tempDir = workspace.WorkspaceRoot;
         var hivesDir = new DirectoryInfo(Path.Combine(tempDir.FullName, ".aspire", "hives"));
-        var cacheDir = new DirectoryInfo(Path.Combine(tempDir.FullName, ".aspire", "cache"));
         
         // Create some PR hives to ensure staging appears before them
         hivesDir.Create();
         Directory.CreateDirectory(Path.Combine(hivesDir.FullName, "pr-10167"));
         Directory.CreateDirectory(Path.Combine(hivesDir.FullName, "pr-11832"));
         
-        var executionContext = new CliExecutionContext(tempDir, hivesDir, cacheDir, new DirectoryInfo(Path.Combine(Path.GetTempPath(), "aspire-test-runtimes")), new DirectoryInfo(Path.Combine(Path.GetTempPath(), "aspire-test-logs")), "test.log");
+        var executionContext = TestExecutionContextHelper.CreateExecutionContext(tempDir, hivesDirectory: hivesDir);
         
         var features = new TestFeatures();
         features.SetFeature(KnownFeatures.StagingChannelEnabled, true);
@@ -465,13 +454,12 @@ public class PackagingServiceTests(ITestOutputHelper outputHelper)
         using var workspace = TemporaryWorkspace.Create(outputHelper);
         var tempDir = workspace.WorkspaceRoot;
         var hivesDir = new DirectoryInfo(Path.Combine(tempDir.FullName, ".aspire", "hives"));
-        var cacheDir = new DirectoryInfo(Path.Combine(tempDir.FullName, ".aspire", "cache"));
         
         // Create some PR hives
         hivesDir.Create();
         Directory.CreateDirectory(Path.Combine(hivesDir.FullName, "pr-12345"));
         
-        var executionContext = new CliExecutionContext(tempDir, hivesDir, cacheDir, new DirectoryInfo(Path.Combine(Path.GetTempPath(), "aspire-test-runtimes")), new DirectoryInfo(Path.Combine(Path.GetTempPath(), "aspire-test-logs")), "test.log");
+        var executionContext = TestExecutionContextHelper.CreateExecutionContext(tempDir, hivesDirectory: hivesDir);
         
         var features = new TestFeatures();
         // Staging disabled by default
@@ -506,8 +494,7 @@ public class PackagingServiceTests(ITestOutputHelper outputHelper)
         using var workspace = TemporaryWorkspace.Create(outputHelper);
         var tempDir = workspace.WorkspaceRoot;
         var hivesDir = new DirectoryInfo(Path.Combine(tempDir.FullName, ".aspire", "hives"));
-        var cacheDir = new DirectoryInfo(Path.Combine(tempDir.FullName, ".aspire", "cache"));
-        var executionContext = new CliExecutionContext(tempDir, hivesDir, cacheDir, new DirectoryInfo(Path.Combine(Path.GetTempPath(), "aspire-test-runtimes")), new DirectoryInfo(Path.Combine(Path.GetTempPath(), "aspire-test-logs")), "test.log");
+        var executionContext = TestExecutionContextHelper.CreateExecutionContext(tempDir, hivesDirectory: hivesDir);
         
         var features = new TestFeatures();
         features.SetFeature(KnownFeatures.StagingChannelEnabled, true);
@@ -542,8 +529,7 @@ public class PackagingServiceTests(ITestOutputHelper outputHelper)
         using var workspace = TemporaryWorkspace.Create(outputHelper);
         var tempDir = workspace.WorkspaceRoot;
         var hivesDir = new DirectoryInfo(Path.Combine(tempDir.FullName, ".aspire", "hives"));
-        var cacheDir = new DirectoryInfo(Path.Combine(tempDir.FullName, ".aspire", "cache"));
-        var executionContext = new CliExecutionContext(tempDir, hivesDir, cacheDir, new DirectoryInfo(Path.Combine(Path.GetTempPath(), "aspire-test-runtimes")), new DirectoryInfo(Path.Combine(Path.GetTempPath(), "aspire-test-logs")), "test.log");
+        var executionContext = TestExecutionContextHelper.CreateExecutionContext(tempDir, hivesDirectory: hivesDir);
         
         var features = new TestFeatures();
         features.SetFeature(KnownFeatures.StagingChannelEnabled, true);
@@ -578,8 +564,7 @@ public class PackagingServiceTests(ITestOutputHelper outputHelper)
         using var workspace = TemporaryWorkspace.Create(outputHelper);
         var tempDir = workspace.WorkspaceRoot;
         var hivesDir = new DirectoryInfo(Path.Combine(tempDir.FullName, ".aspire", "hives"));
-        var cacheDir = new DirectoryInfo(Path.Combine(tempDir.FullName, ".aspire", "cache"));
-        var executionContext = new CliExecutionContext(tempDir, hivesDir, cacheDir, new DirectoryInfo(Path.Combine(Path.GetTempPath(), "aspire-test-runtimes")), new DirectoryInfo(Path.Combine(Path.GetTempPath(), "aspire-test-logs")), "test.log");
+        var executionContext = TestExecutionContextHelper.CreateExecutionContext(tempDir, hivesDirectory: hivesDir);
         
         var features = new TestFeatures();
         features.SetFeature(KnownFeatures.StagingChannelEnabled, true);
@@ -629,7 +614,7 @@ public class PackagingServiceTests(ITestOutputHelper outputHelper)
             .Build();
 
         var packagingService = new PackagingService(
-            new CliExecutionContext(tempDir, tempDir, tempDir, new DirectoryInfo(Path.Combine(Path.GetTempPath(), "aspire-test-runtimes")), new DirectoryInfo(Path.Combine(Path.GetTempPath(), "aspire-test-logs")), "test.log"), 
+            TestExecutionContextHelper.CreateExecutionContext(tempDir), 
             new FakeNuGetPackageCache(), 
             features, 
             configuration,
@@ -660,8 +645,7 @@ public class PackagingServiceTests(ITestOutputHelper outputHelper)
         using var workspace = TemporaryWorkspace.Create(outputHelper);
         var tempDir = workspace.WorkspaceRoot;
         var hivesDir = new DirectoryInfo(Path.Combine(tempDir.FullName, ".aspire", "hives"));
-        var cacheDir = new DirectoryInfo(Path.Combine(tempDir.FullName, ".aspire", "cache"));
-        var executionContext = new CliExecutionContext(tempDir, hivesDir, cacheDir, new DirectoryInfo(Path.Combine(Path.GetTempPath(), "aspire-test-runtimes")), new DirectoryInfo(Path.Combine(Path.GetTempPath(), "aspire-test-logs")), "test.log");
+        var executionContext = TestExecutionContextHelper.CreateExecutionContext(tempDir, hivesDirectory: hivesDir);
         
         var features = new TestFeatures();
         features.SetFeature(KnownFeatures.StagingChannelEnabled, true);
@@ -693,8 +677,7 @@ public class PackagingServiceTests(ITestOutputHelper outputHelper)
         using var workspace = TemporaryWorkspace.Create(outputHelper);
         var tempDir = workspace.WorkspaceRoot;
         var hivesDir = new DirectoryInfo(Path.Combine(tempDir.FullName, ".aspire", "hives"));
-        var cacheDir = new DirectoryInfo(Path.Combine(tempDir.FullName, ".aspire", "cache"));
-        var executionContext = new CliExecutionContext(tempDir, hivesDir, cacheDir, new DirectoryInfo(Path.Combine(Path.GetTempPath(), "aspire-test-runtimes")), new DirectoryInfo(Path.Combine(Path.GetTempPath(), "aspire-test-logs")), "test.log");
+        var executionContext = TestExecutionContextHelper.CreateExecutionContext(tempDir, hivesDirectory: hivesDir);
         
         var features = new TestFeatures();
         features.SetFeature(KnownFeatures.StagingChannelEnabled, true);
@@ -724,8 +707,7 @@ public class PackagingServiceTests(ITestOutputHelper outputHelper)
         using var workspace = TemporaryWorkspace.Create(outputHelper);
         var tempDir = workspace.WorkspaceRoot;
         var hivesDir = new DirectoryInfo(Path.Combine(tempDir.FullName, ".aspire", "hives"));
-        var cacheDir = new DirectoryInfo(Path.Combine(tempDir.FullName, ".aspire", "cache"));
-        var executionContext = new CliExecutionContext(tempDir, hivesDir, cacheDir, new DirectoryInfo(Path.Combine(Path.GetTempPath(), "aspire-test-runtimes")), new DirectoryInfo(Path.Combine(Path.GetTempPath(), "aspire-test-logs")), "test.log");
+        var executionContext = TestExecutionContextHelper.CreateExecutionContext(tempDir, hivesDirectory: hivesDir);
         
         var features = new TestFeatures();
         features.SetFeature(KnownFeatures.StagingChannelEnabled, true);
@@ -756,8 +738,7 @@ public class PackagingServiceTests(ITestOutputHelper outputHelper)
         using var workspace = TemporaryWorkspace.Create(outputHelper);
         var tempDir = workspace.WorkspaceRoot;
         var hivesDir = new DirectoryInfo(Path.Combine(tempDir.FullName, ".aspire", "hives"));
-        var cacheDir = new DirectoryInfo(Path.Combine(tempDir.FullName, ".aspire", "cache"));
-        var executionContext = new CliExecutionContext(tempDir, hivesDir, cacheDir, new DirectoryInfo(Path.Combine(Path.GetTempPath(), "aspire-test-runtimes")), new DirectoryInfo(Path.Combine(Path.GetTempPath(), "aspire-test-logs")), "test.log");
+        var executionContext = TestExecutionContextHelper.CreateExecutionContext(tempDir, hivesDirectory: hivesDir);
         var localPackagesDir = new DirectoryInfo(Path.Combine(hivesDir.FullName, "local", "packages"));
         localPackagesDir.Create();
 
@@ -787,8 +768,7 @@ public class PackagingServiceTests(ITestOutputHelper outputHelper)
         using var workspace = TemporaryWorkspace.Create(outputHelper);
         var tempDir = workspace.WorkspaceRoot;
         var hivesDir = new DirectoryInfo(Path.Combine(tempDir.FullName, ".aspire", "hives"));
-        var cacheDir = new DirectoryInfo(Path.Combine(tempDir.FullName, ".aspire", "cache"));
-        var executionContext = new CliExecutionContext(tempDir, hivesDir, cacheDir, new DirectoryInfo(Path.Combine(Path.GetTempPath(), "aspire-test-runtimes")), new DirectoryInfo(Path.Combine(Path.GetTempPath(), "aspire-test-logs")), "test.log");
+        var executionContext = TestExecutionContextHelper.CreateExecutionContext(tempDir, hivesDirectory: hivesDir);
         var localPackagesDir = new DirectoryInfo(Path.Combine(hivesDir.FullName, "local", "packages"));
         localPackagesDir.Create();
 
@@ -829,8 +809,7 @@ public class PackagingServiceTests(ITestOutputHelper outputHelper)
         using var workspace = TemporaryWorkspace.Create(outputHelper);
         var tempDir = workspace.WorkspaceRoot;
         var hivesDir = new DirectoryInfo(Path.Combine(tempDir.FullName, ".aspire", "hives"));
-        var cacheDir = new DirectoryInfo(Path.Combine(tempDir.FullName, ".aspire", "cache"));
-        var executionContext = new CliExecutionContext(tempDir, hivesDir, cacheDir, new DirectoryInfo(Path.Combine(Path.GetTempPath(), "aspire-test-runtimes")), new DirectoryInfo(Path.Combine(Path.GetTempPath(), "aspire-test-logs")), "test.log");
+        var executionContext = TestExecutionContextHelper.CreateExecutionContext(tempDir, hivesDirectory: hivesDir);
 
         var features = new TestFeatures();
         features.SetFeature(KnownFeatures.StagingChannelEnabled, true);
@@ -882,8 +861,7 @@ public class PackagingServiceTests(ITestOutputHelper outputHelper)
         using var workspace = TemporaryWorkspace.Create(outputHelper);
         var tempDir = workspace.WorkspaceRoot;
         var hivesDir = new DirectoryInfo(Path.Combine(tempDir.FullName, ".aspire", "hives"));
-        var cacheDir = new DirectoryInfo(Path.Combine(tempDir.FullName, ".aspire", "cache"));
-        var executionContext = new CliExecutionContext(tempDir, hivesDir, cacheDir, new DirectoryInfo(Path.Combine(Path.GetTempPath(), "aspire-test-runtimes")), new DirectoryInfo(Path.Combine(Path.GetTempPath(), "aspire-test-logs")), "test.log");
+        var executionContext = TestExecutionContextHelper.CreateExecutionContext(tempDir, hivesDirectory: hivesDir);
 
         var features = new TestFeatures();
         features.SetFeature(KnownFeatures.StagingChannelEnabled, true);
@@ -934,8 +912,7 @@ public class PackagingServiceTests(ITestOutputHelper outputHelper)
         using var workspace = TemporaryWorkspace.Create(outputHelper);
         var tempDir = workspace.WorkspaceRoot;
         var hivesDir = new DirectoryInfo(Path.Combine(tempDir.FullName, ".aspire", "hives"));
-        var cacheDir = new DirectoryInfo(Path.Combine(tempDir.FullName, ".aspire", "cache"));
-        var executionContext = new CliExecutionContext(tempDir, hivesDir, cacheDir, new DirectoryInfo(Path.Combine(Path.GetTempPath(), "aspire-test-runtimes")), new DirectoryInfo(Path.Combine(Path.GetTempPath(), "aspire-test-logs")), "test.log");
+        var executionContext = TestExecutionContextHelper.CreateExecutionContext(tempDir, hivesDirectory: hivesDir);
 
         var features = new TestFeatures();
         features.SetFeature(KnownFeatures.StagingChannelEnabled, true);
@@ -981,7 +958,6 @@ public class PackagingServiceTests(ITestOutputHelper outputHelper)
         using var workspace = TemporaryWorkspace.Create(outputHelper);
         var tempDir = workspace.WorkspaceRoot;
         var hivesDir = new DirectoryInfo(Path.Combine(tempDir.FullName, ".aspire", "hives"));
-        var cacheDir = new DirectoryInfo(Path.Combine(tempDir.FullName, ".aspire", "cache"));
 
         // Hive directory named "local" (as written by get-aspire-cli-pr.sh --local-dir)
         const string localHiveName = "local";
@@ -992,10 +968,7 @@ public class PackagingServiceTests(ITestOutputHelper outputHelper)
         File.WriteAllText(Path.Combine(localPackagesDir.FullName, $"Aspire.ProjectTemplates.{pinnedVersion}.nupkg"), string.Empty);
 
         // CLI binary built with AspireCliChannel=local
-        var executionContext = new CliExecutionContext(tempDir, hivesDir, cacheDir,
-            new DirectoryInfo(Path.Combine(tempDir.FullName, "aspire-test-runtimes")),
-            new DirectoryInfo(Path.Combine(tempDir.FullName, "aspire-test-logs")),
-            "test.log", identityChannel: "local");
+        var executionContext = TestExecutionContextHelper.CreateExecutionContext(tempDir, hivesDirectory: hivesDir, identityChannel: "local");
 
         var packagingService = new PackagingService(executionContext, new FakeNuGetPackageCache(), new TestFeatures(), new ConfigurationBuilder().Build(), NullLogger<PackagingService>.Instance);
 
@@ -1019,7 +992,6 @@ public class PackagingServiceTests(ITestOutputHelper outputHelper)
         using var workspace = TemporaryWorkspace.Create(outputHelper);
         var tempDir = workspace.WorkspaceRoot;
         var hivesDir = new DirectoryInfo(Path.Combine(tempDir.FullName, ".aspire", "hives"));
-        var cacheDir = new DirectoryInfo(Path.Combine(tempDir.FullName, ".aspire", "cache"));
 
         const string runHiveName = "run-99999";
         var runPackagesDir = new DirectoryInfo(Path.Combine(hivesDir.FullName, runHiveName, "packages"));
@@ -1030,10 +1002,7 @@ public class PackagingServiceTests(ITestOutputHelper outputHelper)
 
         // CLI binary built with non-local channel ("daily") — explicit so the test stays
         // accurate even as the CliExecutionContext default channel evolves.
-        var executionContext = new CliExecutionContext(tempDir, hivesDir, cacheDir,
-            new DirectoryInfo(Path.Combine(Path.GetTempPath(), "aspire-test-runtimes")),
-            new DirectoryInfo(Path.Combine(Path.GetTempPath(), "aspire-test-logs")),
-            "test.log", identityChannel: "daily");
+        var executionContext = TestExecutionContextHelper.CreateExecutionContext(tempDir, hivesDirectory: hivesDir, identityChannel: "daily");
 
         var packagingService = new PackagingService(executionContext, new FakeNuGetPackageCache(), new TestFeatures(), new ConfigurationBuilder().Build(), NullLogger<PackagingService>.Instance);
 
@@ -1057,11 +1026,7 @@ public class PackagingServiceTests(ITestOutputHelper outputHelper)
         using var workspace = TemporaryWorkspace.Create(outputHelper);
         var tempDir = workspace.WorkspaceRoot;
         var hivesDir = new DirectoryInfo(Path.Combine(tempDir.FullName, ".aspire", "hives"));
-        var cacheDir = new DirectoryInfo(Path.Combine(tempDir.FullName, ".aspire", "cache"));
-        var executionContext = new CliExecutionContext(tempDir, hivesDir, cacheDir,
-            new DirectoryInfo(Path.Combine(Path.GetTempPath(), "aspire-test-runtimes")),
-            new DirectoryInfo(Path.Combine(Path.GetTempPath(), "aspire-test-logs")),
-            "test.log");
+        var executionContext = TestExecutionContextHelper.CreateExecutionContext(tempDir, hivesDirectory: hivesDir);
 
         var localPackagesDir = new DirectoryInfo(Path.Combine(hivesDir.FullName, "local", "packages"));
         localPackagesDir.Create();
@@ -1100,11 +1065,7 @@ public class PackagingServiceTests(ITestOutputHelper outputHelper)
         using var workspace = TemporaryWorkspace.Create(outputHelper);
         var tempDir = workspace.WorkspaceRoot;
         var hivesDir = new DirectoryInfo(Path.Combine(tempDir.FullName, ".aspire", "hives"));
-        var cacheDir = new DirectoryInfo(Path.Combine(tempDir.FullName, ".aspire", "cache"));
-        var executionContext = new CliExecutionContext(tempDir, hivesDir, cacheDir,
-            new DirectoryInfo(Path.Combine(Path.GetTempPath(), "aspire-test-runtimes")),
-            new DirectoryInfo(Path.Combine(Path.GetTempPath(), "aspire-test-logs")),
-            "test.log");
+        var executionContext = TestExecutionContextHelper.CreateExecutionContext(tempDir, hivesDirectory: hivesDir);
 
         var localPackagesDir = new DirectoryInfo(Path.Combine(hivesDir.FullName, PackageChannelNames.Local, "packages"));
         localPackagesDir.Create();
@@ -1144,11 +1105,7 @@ public class PackagingServiceTests(ITestOutputHelper outputHelper)
         using var workspace = TemporaryWorkspace.Create(outputHelper);
         var tempDir = workspace.WorkspaceRoot;
         var hivesDir = new DirectoryInfo(Path.Combine(tempDir.FullName, ".aspire", "hives"));
-        var cacheDir = new DirectoryInfo(Path.Combine(tempDir.FullName, ".aspire", "cache"));
-        var executionContext = new CliExecutionContext(tempDir, hivesDir, cacheDir,
-            new DirectoryInfo(Path.Combine(Path.GetTempPath(), "aspire-test-runtimes")),
-            new DirectoryInfo(Path.Combine(Path.GetTempPath(), "aspire-test-logs")),
-            "test.log");
+        var executionContext = TestExecutionContextHelper.CreateExecutionContext(tempDir, hivesDirectory: hivesDir);
 
         // Create the hive root but no `packages/` subdir — directory-exists-but-unpopulated.
         var localHiveDir = new DirectoryInfo(Path.Combine(hivesDir.FullName, PackageChannelNames.Local));
@@ -1178,11 +1135,7 @@ public class PackagingServiceTests(ITestOutputHelper outputHelper)
         using var workspace = TemporaryWorkspace.Create(outputHelper);
         var tempDir = workspace.WorkspaceRoot;
         var hivesDir = new DirectoryInfo(Path.Combine(tempDir.FullName, ".aspire", "hives"));
-        var cacheDir = new DirectoryInfo(Path.Combine(tempDir.FullName, ".aspire", "cache"));
-        var executionContext = new CliExecutionContext(tempDir, hivesDir, cacheDir,
-            new DirectoryInfo(Path.Combine(Path.GetTempPath(), "aspire-test-runtimes")),
-            new DirectoryInfo(Path.Combine(Path.GetTempPath(), "aspire-test-logs")),
-            "test.log");
+        var executionContext = TestExecutionContextHelper.CreateExecutionContext(tempDir, hivesDirectory: hivesDir);
 
         var localPackagesDir = new DirectoryInfo(Path.Combine(hivesDir.FullName, PackageChannelNames.Local, "packages"));
         localPackagesDir.Create();

--- a/tests/Aspire.Cli.Tests/Projects/GuestAppHostProjectTests.cs
+++ b/tests/Aspire.Cli.Tests/Projects/GuestAppHostProjectTests.cs
@@ -704,15 +704,10 @@ public class GuestAppHostProjectTests : IDisposable
 
         var logFilePath = Path.Combine(_workspace.WorkspaceRoot.FullName, $"test-guest-{Guid.NewGuid()}.log");
 
-        var workspace = new DirectoryInfo(AppContext.BaseDirectory);
-        var executionContext = new CliExecutionContext(
-            workingDirectory: workspace,
-            hivesDirectory: workspace,
-            cacheDirectory: workspace,
-            sdksDirectory: workspace,
-            logsDirectory: workspace,
-            logFilePath: logFilePath,
-            identityChannel: identityChannel);
+        var executionContext = TestExecutionContextHelper.CreateExecutionContext(
+            new DirectoryInfo(AppContext.BaseDirectory),
+            identityChannel: identityChannel,
+            logFilePath: logFilePath);
 
         return new GuestAppHostProject(
             language: language,

--- a/tests/Aspire.Cli.Tests/Projects/ProjectLocatorTests.cs
+++ b/tests/Aspire.Cli.Tests/Projects/ProjectLocatorTests.cs
@@ -23,12 +23,9 @@ public class ProjectLocatorTests(ITestOutputHelper outputHelper)
 {
     private static Aspire.Cli.CliExecutionContext CreateExecutionContext(DirectoryInfo workingDirectory, IReadOnlyDictionary<string, string?>? environmentVariables = null)
     {
-        // NOTE: This would normally be in the users home directory, but for tests we create
-        //       it in the temporary workspace directory.
-        var settingsDirectory = workingDirectory.CreateSubdirectory(".aspire");
-        var hivesDirectory = settingsDirectory.CreateSubdirectory("hives");
-        var cacheDirectory = new DirectoryInfo(Path.Combine(workingDirectory.FullName, ".aspire", "cache"));
-        return new CliExecutionContext(workingDirectory, hivesDirectory, cacheDirectory, new DirectoryInfo(Path.Combine(Path.GetTempPath(), "aspire-test-runtimes")), new DirectoryInfo(Path.Combine(Path.GetTempPath(), "aspire-test-logs")), "test.log", environmentVariables: environmentVariables);
+        return TestExecutionContextHelper.CreateExecutionContext(
+            workingDirectory,
+            environmentVariables: environmentVariables);
     }
 
     [Fact]

--- a/tests/Aspire.Cli.Tests/Projects/ProjectUpdaterTests.cs
+++ b/tests/Aspire.Cli.Tests/Projects/ProjectUpdaterTests.cs
@@ -1408,12 +1408,7 @@ public class ProjectUpdaterTests(ITestOutputHelper outputHelper)
 
     private static Aspire.Cli.CliExecutionContext CreateExecutionContext(DirectoryInfo workingDirectory)
     {
-        // NOTE: This would normally be in the users home directory, but for tests we create
-        //       it in the temporary workspace directory.
-        var settingsDirectory = workingDirectory.CreateSubdirectory(".aspire");
-        var hivesDirectory = settingsDirectory.CreateSubdirectory("hives");
-        var cacheDirectory = new DirectoryInfo(Path.Combine(workingDirectory.FullName, ".aspire", "cache"));
-        return new CliExecutionContext(workingDirectory, hivesDirectory, cacheDirectory, new DirectoryInfo(Path.Combine(Path.GetTempPath(), "aspire-test-runtimes")), new DirectoryInfo(Path.Combine(Path.GetTempPath(), "aspire-test-logs")), "test.log");
+        return TestExecutionContextHelper.CreateExecutionContext(workingDirectory);
     }
 
     [Fact]

--- a/tests/Aspire.Cli.Tests/Templating/DotNetTemplateFactoryTests.cs
+++ b/tests/Aspire.Cli.Tests/Templating/DotNetTemplateFactoryTests.cs
@@ -347,9 +347,7 @@ public class DotNetTemplateFactoryTests
         var packagingService = new TestPackagingService();
         var prompter = new TestNewCommandPrompter();
         var workingDirectory = new DirectoryInfo("/tmp");
-        var hivesDirectory = new DirectoryInfo("/tmp/hives");
-        var cacheDirectory = new DirectoryInfo("/tmp/cache");
-        var executionContext = new CliExecutionContext(workingDirectory, hivesDirectory, cacheDirectory, new DirectoryInfo(Path.Combine(Path.GetTempPath(), "aspire-test-runtimes")), new DirectoryInfo(Path.Combine(Path.GetTempPath(), "aspire-test-logs")), "test.log");
+        var executionContext = TestExecutionContextHelper.CreateExecutionContext(workingDirectory);
         sdkInstaller ??= new TestDotNetSdkInstaller();
         var telemetry = TestTelemetryHelper.CreateInitializedTelemetry();
         var hostEnvironment = new FakeCliHostEnvironment(nonInteractive);

--- a/tests/Aspire.Cli.Tests/Templating/TemplateNuGetConfigServiceTests.cs
+++ b/tests/Aspire.Cli.Tests/Templating/TemplateNuGetConfigServiceTests.cs
@@ -261,12 +261,9 @@ public class TemplateNuGetConfigServiceTests(ITestOutputHelper outputHelper)
 
     private static CliExecutionContext CreateExecutionContextWithHives(DirectoryInfo workingDirectory, DirectoryInfo hivesDirectory)
     {
-        var cacheDirectory = new DirectoryInfo(Path.Combine(workingDirectory.FullName, ".aspire", "cache"));
-        var sdksDirectory = new DirectoryInfo(Path.Combine(workingDirectory.FullName, ".aspire", "sdks"));
-        var logsDirectory = new DirectoryInfo(Path.Combine(workingDirectory.FullName, ".aspire", "logs"));
-        return new CliExecutionContext(
-            workingDirectory, hivesDirectory, cacheDirectory, sdksDirectory, logsDirectory,
-            Path.Combine(logsDirectory.FullName, "test.log"));
+        return TestExecutionContextHelper.CreateExecutionContext(
+            workingDirectory,
+            hivesDirectory: hivesDirectory);
     }
 
     private static TemplateNuGetConfigService CreateService(

--- a/tests/Aspire.Cli.Tests/Utils/CliTestHelper.cs
+++ b/tests/Aspire.Cli.Tests/Utils/CliTestHelper.cs
@@ -278,11 +278,7 @@ internal sealed class CliServiceCollectionTestOptions
 
     private CliExecutionContext CreateDefaultCliExecutionContextFactory(IServiceProvider provider)
     {
-        var hivesDirectory = new DirectoryInfo(Path.Combine(WorkingDirectory.FullName, ".aspire", "hives"));
-        var cacheDirectory = new DirectoryInfo(Path.Combine(WorkingDirectory.FullName, ".aspire", "cache"));
-        var logsDirectory = new DirectoryInfo(Path.Combine(WorkingDirectory.FullName, ".aspire", "logs"));
-        var logFilePath = Path.Combine(logsDirectory.FullName, "test.log");
-        return new CliExecutionContext(WorkingDirectory, hivesDirectory, cacheDirectory, new DirectoryInfo(Path.Combine(Path.GetTempPath(), "aspire-test-sdks")), logsDirectory, logFilePath, packagesDirectory: PackagesDirectory);
+        return TestExecutionContextHelper.CreateExecutionContext(WorkingDirectory, packagesDirectory: PackagesDirectory);
     }
 
     public DirectoryInfo WorkingDirectory { get; set; }

--- a/tests/Aspire.Cli.Tests/Utils/TestExecutionContextHelper.cs
+++ b/tests/Aspire.Cli.Tests/Utils/TestExecutionContextHelper.cs
@@ -54,6 +54,10 @@ internal static class TestExecutionContextHelper
     {
         var root = rootDirectory.FullName;
         hivesDirectory ??= new DirectoryInfo(Path.Combine(root, ".aspire", "hives"));
+        // Always default homeDirectory to a workspace-scoped path so user-level agent
+        // skill installs go to an isolated directory instead of the real user profile,
+        // which causes file-locking conflicts when tests run concurrently.
+        homeDirectory ??= new DirectoryInfo(Path.Combine(root, ".home"));
         var cacheDirectory = new DirectoryInfo(Path.Combine(root, ".aspire", "cache"));
         var sdksDirectory = new DirectoryInfo(Path.Combine(root, ".aspire", "sdks"));
         var logsDirectory = new DirectoryInfo(Path.Combine(root, ".aspire", "logs"));

--- a/tests/Aspire.Cli.Tests/Utils/TestExecutionContextHelper.cs
+++ b/tests/Aspire.Cli.Tests/Utils/TestExecutionContextHelper.cs
@@ -1,0 +1,75 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Aspire.Cli.Tests.Utils;
+
+/// <summary>
+/// Shared factory for building <see cref="CliExecutionContext"/> instances in tests.
+/// Centralizes the boilerplate of wiring up .aspire/* subdirectories so every test
+/// gets workspace-scoped isolation by default.
+/// </summary>
+internal static class TestExecutionContextHelper
+{
+    /// <summary>
+    /// Creates a <see cref="CliExecutionContext"/> rooted under
+    /// <paramref name="workspace"/>.<see cref="TemporaryWorkspace.WorkspaceRoot"/>.
+    /// All .aspire/* directories are scoped to the workspace so concurrent tests
+    /// do not collide on shared paths.
+    /// </summary>
+    public static CliExecutionContext CreateExecutionContext(
+        this TemporaryWorkspace workspace,
+        string identityChannel = "local",
+        DirectoryInfo? homeDirectory = null,
+        DirectoryInfo? hivesDirectory = null,
+        IReadOnlyDictionary<string, string?>? environmentVariables = null,
+        DirectoryInfo? packagesDirectory = null,
+        bool debugMode = false,
+        string? logFilePath = null)
+    {
+        return CreateExecutionContext(
+            workspace.WorkspaceRoot,
+            identityChannel: identityChannel,
+            homeDirectory: homeDirectory,
+            hivesDirectory: hivesDirectory,
+            environmentVariables: environmentVariables,
+            packagesDirectory: packagesDirectory,
+            debugMode: debugMode,
+            logFilePath: logFilePath);
+    }
+
+    /// <summary>
+    /// Creates a <see cref="CliExecutionContext"/> rooted under the supplied
+    /// <paramref name="rootDirectory"/>. All .aspire/* directories are scoped to
+    /// that root so concurrent tests do not collide on shared paths.
+    /// </summary>
+    public static CliExecutionContext CreateExecutionContext(
+        DirectoryInfo rootDirectory,
+        string identityChannel = "local",
+        DirectoryInfo? homeDirectory = null,
+        DirectoryInfo? hivesDirectory = null,
+        IReadOnlyDictionary<string, string?>? environmentVariables = null,
+        DirectoryInfo? packagesDirectory = null,
+        bool debugMode = false,
+        string? logFilePath = null)
+    {
+        var root = rootDirectory.FullName;
+        hivesDirectory ??= new DirectoryInfo(Path.Combine(root, ".aspire", "hives"));
+        var cacheDirectory = new DirectoryInfo(Path.Combine(root, ".aspire", "cache"));
+        var sdksDirectory = new DirectoryInfo(Path.Combine(root, ".aspire", "sdks"));
+        var logsDirectory = new DirectoryInfo(Path.Combine(root, ".aspire", "logs"));
+        logFilePath ??= Path.Combine(logsDirectory.FullName, "test.log");
+
+        return new CliExecutionContext(
+            rootDirectory,
+            hivesDirectory,
+            cacheDirectory,
+            sdksDirectory,
+            logsDirectory,
+            logFilePath,
+            debugMode: debugMode,
+            environmentVariables: environmentVariables,
+            homeDirectory: homeDirectory,
+            packagesDirectory: packagesDirectory,
+            identityChannel: identityChannel);
+    }
+}

--- a/tests/Aspire.Cli.Tests/Utils/TestExecutionContextHelper.cs
+++ b/tests/Aspire.Cli.Tests/Utils/TestExecutionContextHelper.cs
@@ -19,21 +19,13 @@ internal static class TestExecutionContextHelper
     public static CliExecutionContext CreateExecutionContext(
         this TemporaryWorkspace workspace,
         string identityChannel = "local",
-        DirectoryInfo? homeDirectory = null,
-        DirectoryInfo? hivesDirectory = null,
         IReadOnlyDictionary<string, string?>? environmentVariables = null,
-        DirectoryInfo? packagesDirectory = null,
-        bool debugMode = false,
         string? logFilePath = null)
     {
         return CreateExecutionContext(
             workspace.WorkspaceRoot,
             identityChannel: identityChannel,
-            homeDirectory: homeDirectory,
-            hivesDirectory: hivesDirectory,
             environmentVariables: environmentVariables,
-            packagesDirectory: packagesDirectory,
-            debugMode: debugMode,
             logFilePath: logFilePath);
     }
 
@@ -54,9 +46,6 @@ internal static class TestExecutionContextHelper
     {
         var root = rootDirectory.FullName;
         hivesDirectory ??= new DirectoryInfo(Path.Combine(root, ".aspire", "hives"));
-        // Always default homeDirectory to a workspace-scoped path so user-level agent
-        // skill installs go to an isolated directory instead of the real user profile,
-        // which causes file-locking conflicts when tests run concurrently.
         homeDirectory ??= new DirectoryInfo(Path.Combine(root, ".home"));
         var cacheDirectory = new DirectoryInfo(Path.Combine(root, ".aspire", "cache"));
         var sdksDirectory = new DirectoryInfo(Path.Combine(root, ".aspire", "sdks"));


### PR DESCRIPTION
## Description

Fix flaky `NewCommandChannelResolutionTests` by isolating the home directory per test instance.

`BuildExecutionContextWithIdentity` did not pass a `homeDirectory` to `CliExecutionContext`, so it defaulted to the real user profile (`C:\Users\runneradmin`). When the `new` command runs agent init, user-level skills are installed to the shared `~/.agents/skills/` path. Concurrent tests writing to the same global path caused file-locking conflicts:

> ❌ Failed to install aspireify skill at C:\Users\runneradmin\.agents\skills\aspireify: The process cannot access the file 'C:\Users\runneradmin\.agents\skills\aspireify\references\docker-compose.md' because it is being used by another process.

This made the command return exit code 1 instead of the expected 0.

The fix passes a workspace-scoped `homeDirectory` (inside the per-test temp directory) so each test instance writes skills to its own isolated path, matching the pattern already used by `AgentInitCommandTests`.

Failing CI run: https://github.com/microsoft/aspire/actions/runs/25975039889

cc @radical (original test author)

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
