### PR TITLE
Support VS Code resource command arguments

### DIFF
--- a/extension/loc/xlf/aspire-vscode.xlf
+++ b/extension/loc/xlf/aspire-vscode.xlf
@@ -565,5 +565,8 @@
     <trans-unit id="aspire-vscode.strings.aspireRestoreFailed">
       <source xml:lang="en">aspire restore failed for {0}: {1}</source>
     </trans-unit>
+    <trans-unit id="aspire-vscode.strings.resourceCommandArgumentInputTitle">
+      <source xml:lang="en">{0}: {1}</source>
+    </trans-unit>
   </body></file>
 </xliff>

--- a/extension/loc/xlf/aspire-vscode.xlf
+++ b/extension/loc/xlf/aspire-vscode.xlf
@@ -106,6 +106,9 @@
     <trans-unit id="aspire-vscode.strings.resourceCommandContinue">
       <source xml:lang="en">Continue</source>
     </trans-unit>
+    <trans-unit id="aspire-vscode.strings.resourceCommandDontShowAgain">
+      <source xml:lang="en">Don't show again</source>
+    </trans-unit>
     <trans-unit id="configuration.aspire.enableAspireDashboardAutoLaunch">
       <source xml:lang="en">Controls what happens with the Aspire Dashboard when debugging starts.</source>
     </trans-unit>

--- a/extension/loc/xlf/aspire-vscode.xlf
+++ b/extension/loc/xlf/aspire-vscode.xlf
@@ -103,6 +103,9 @@
     <trans-unit id="command.configureLaunchJson">
       <source xml:lang="en">Configure launch.json file</source>
     </trans-unit>
+    <trans-unit id="aspire-vscode.strings.resourceCommandContinue">
+      <source xml:lang="en">Continue</source>
+    </trans-unit>
     <trans-unit id="configuration.aspire.enableAspireDashboardAutoLaunch">
       <source xml:lang="en">Controls what happens with the Aspire Dashboard when debugging starts.</source>
     </trans-unit>
@@ -123,6 +126,9 @@
     </trans-unit>
     <trans-unit id="walkthrough.getStarted.createProject.title">
       <source xml:lang="en">Create a new project</source>
+    </trans-unit>
+    <trans-unit id="aspire-vscode.strings.resourceCommandCustomChoiceDescription">
+      <source xml:lang="en">Custom value</source>
     </trans-unit>
     <trans-unit id="aspire-vscode.strings.dcpServerNotInitialized">
       <source xml:lang="en">DCP server not initialized - cannot forward debug output.</source>
@@ -177,6 +183,9 @@
     </trans-unit>
     <trans-unit id="aspire-vscode.strings.processExceptionOccurred">
       <source xml:lang="en">Encountered an exception ({0}) while running the following command: {1}.</source>
+    </trans-unit>
+    <trans-unit id="aspire-vscode.strings.resourceCommandInvalidNumber">
+      <source xml:lang="en">Enter a number using digits and an optional decimal point.</source>
     </trans-unit>
     <trans-unit id="aspire-vscode.strings.enterPipelineStep">
       <source xml:lang="en">Enter the pipeline step to execute</source>
@@ -409,6 +418,9 @@
     <trans-unit id="walkthrough.getStarted.runApp.title">
       <source xml:lang="en">Run your app</source>
     </trans-unit>
+    <trans-unit id="aspire-vscode.strings.resourceCommandArgumentsTitle">
+      <source xml:lang="en">Run {0}</source>
+    </trans-unit>
     <trans-unit id="aspire-vscode.strings.runProject">
       <source xml:lang="en">Run {0}</source>
     </trans-unit>
@@ -496,6 +508,9 @@
     <trans-unit id="extension.debug.step">
       <source xml:lang="en">The pipeline step name to execute when command is &apos;do&apos;</source>
     </trans-unit>
+    <trans-unit id="aspire-vscode.strings.resourceCommandSecretWarning">
+      <source xml:lang="en">This command has secret arguments. Values are masked while you enter them, but they are passed to the Aspire CLI terminal and may be visible in terminal history or scrollback.</source>
+    </trans-unit>
     <trans-unit id="aspire-vscode.strings.fieldRequired">
       <source xml:lang="en">This field is required.</source>
     </trans-unit>
@@ -505,8 +520,14 @@
     <trans-unit id="command.update">
       <source xml:lang="en">Update integrations</source>
     </trans-unit>
+    <trans-unit id="aspire-vscode.strings.resourceCommandCustomChoice">
+      <source xml:lang="en">Use &quot;{0}&quot;</source>
+    </trans-unit>
     <trans-unit id="configuration.aspire.dashboardBrowser.openExternalBrowser">
       <source xml:lang="en">Use the system default browser (cannot auto-close).</source>
+    </trans-unit>
+    <trans-unit id="aspire-vscode.strings.resourceCommandMaxLength">
+      <source xml:lang="en">Value must be {0} characters or fewer.</source>
     </trans-unit>
     <trans-unit id="command.verifyCliInstalled">
       <source xml:lang="en">Verify Aspire CLI installation</source>

--- a/extension/loc/xlf/aspire-vscode.xlf
+++ b/extension/loc/xlf/aspire-vscode.xlf
@@ -106,9 +106,6 @@
     <trans-unit id="aspire-vscode.strings.resourceCommandContinue">
       <source xml:lang="en">Continue</source>
     </trans-unit>
-    <trans-unit id="aspire-vscode.strings.resourceCommandDontShowAgain">
-      <source xml:lang="en">Don't show again</source>
-    </trans-unit>
     <trans-unit id="configuration.aspire.enableAspireDashboardAutoLaunch">
       <source xml:lang="en">Controls what happens with the Aspire Dashboard when debugging starts.</source>
     </trans-unit>
@@ -168,6 +165,9 @@
     </trans-unit>
     <trans-unit id="aspire-vscode.strings.doYouWantToSetDefaultApphost">
       <source xml:lang="en">Do you want to set {0} as the default AppHost for this workspace?</source>
+    </trans-unit>
+    <trans-unit id="aspire-vscode.strings.resourceCommandDontShowAgain">
+      <source xml:lang="en">Don&apos;t show again</source>
     </trans-unit>
     <trans-unit id="aspire-vscode.strings.dontShowAgainLabel">
       <source xml:lang="en">Don&apos;t show again</source>

--- a/extension/loc/xlf/aspire-vscode.xlf
+++ b/extension/loc/xlf/aspire-vscode.xlf
@@ -185,7 +185,7 @@
       <source xml:lang="en">Encountered an exception ({0}) while running the following command: {1}.</source>
     </trans-unit>
     <trans-unit id="aspire-vscode.strings.resourceCommandInvalidNumber">
-      <source xml:lang="en">Enter a number using digits and an optional decimal point.</source>
+      <source xml:lang="en">Enter a number using invariant culture, for example 1, -1.5, or 1e3.</source>
     </trans-unit>
     <trans-unit id="aspire-vscode.strings.enterPipelineStep">
       <source xml:lang="en">Enter the pipeline step to execute</source>

--- a/extension/package.nls.json
+++ b/extension/package.nls.json
@@ -181,6 +181,7 @@
   "mcpServerDefinitionProviders.aspire.label": "Aspire",
   "aspire-vscode.strings.selectDashboardPlaceholder": "Select a dashboard to open",
   "aspire-vscode.strings.resourceCommandArgumentsTitle": "Run {0}",
+  "aspire-vscode.strings.resourceCommandArgumentInputTitle": "{0}: {1}",
   "aspire-vscode.strings.resourceCommandCustomChoice": "Use \"{0}\"",
   "aspire-vscode.strings.resourceCommandCustomChoiceDescription": "Custom value",
   "aspire-vscode.strings.resourceCommandSecretWarning": "This command has secret arguments. Values are masked while you enter them, but they are passed to the Aspire CLI terminal and may be visible in terminal history or scrollback.",

--- a/extension/package.nls.json
+++ b/extension/package.nls.json
@@ -179,5 +179,12 @@
   "walkthrough.getStarted.nextSteps.title": "Next steps",
   "walkthrough.getStarted.nextSteps.description": "You're all set! Add integrations for databases, messaging, and cloud services, or deploy your app to production.\n\n[Add an integration](command:aspire-vscode.add)\n\n[Open Aspire docs](https://aspire.dev/docs/)",
   "mcpServerDefinitionProviders.aspire.label": "Aspire",
-  "aspire-vscode.strings.selectDashboardPlaceholder": "Select a dashboard to open"
+  "aspire-vscode.strings.selectDashboardPlaceholder": "Select a dashboard to open",
+  "aspire-vscode.strings.resourceCommandArgumentsTitle": "Run {0}",
+  "aspire-vscode.strings.resourceCommandCustomChoice": "Use \"{0}\"",
+  "aspire-vscode.strings.resourceCommandCustomChoiceDescription": "Custom value",
+  "aspire-vscode.strings.resourceCommandSecretWarning": "This command has secret arguments. Values are masked while you enter them, but they are passed to the Aspire CLI terminal and may be visible in terminal history or scrollback.",
+  "aspire-vscode.strings.resourceCommandContinue": "Continue",
+  "aspire-vscode.strings.resourceCommandInvalidNumber": "Enter a number using digits and an optional decimal point.",
+  "aspire-vscode.strings.resourceCommandMaxLength": "Value must be {0} characters or fewer."
 }

--- a/extension/package.nls.json
+++ b/extension/package.nls.json
@@ -185,6 +185,7 @@
   "aspire-vscode.strings.resourceCommandCustomChoiceDescription": "Custom value",
   "aspire-vscode.strings.resourceCommandSecretWarning": "This command has secret arguments. Values are masked while you enter them, but they are passed to the Aspire CLI terminal and may be visible in terminal history or scrollback.",
   "aspire-vscode.strings.resourceCommandContinue": "Continue",
+  "aspire-vscode.strings.resourceCommandDontShowAgain": "Don't show again",
   "aspire-vscode.strings.resourceCommandInvalidNumber": "Enter a number using invariant culture, for example 1, -1.5, or 1e3.",
   "aspire-vscode.strings.resourceCommandMaxLength": "Value must be {0} characters or fewer."
 }

--- a/extension/package.nls.json
+++ b/extension/package.nls.json
@@ -185,6 +185,6 @@
   "aspire-vscode.strings.resourceCommandCustomChoiceDescription": "Custom value",
   "aspire-vscode.strings.resourceCommandSecretWarning": "This command has secret arguments. Values are masked while you enter them, but they are passed to the Aspire CLI terminal and may be visible in terminal history or scrollback.",
   "aspire-vscode.strings.resourceCommandContinue": "Continue",
-  "aspire-vscode.strings.resourceCommandInvalidNumber": "Enter a number using digits and an optional decimal point.",
+  "aspire-vscode.strings.resourceCommandInvalidNumber": "Enter a number using invariant culture, for example 1, -1.5, or 1e3.",
   "aspire-vscode.strings.resourceCommandMaxLength": "Value must be {0} characters or fewer."
 }

--- a/extension/src/editor/AspireCodeLensProvider.ts
+++ b/extension/src/editor/AspireCodeLensProvider.ts
@@ -292,7 +292,7 @@ export class AspireCodeLensProvider implements vscode.CodeLensProvider {
                         title: label,
                         command: 'aspire-vscode.codeLensResourceAction',
                         tooltip: cmd.description ?? cmdName,
-                        arguments: [resource.name, cmdName, appHost.appHostPath],
+                        arguments: [resource.name, cmdName, appHost.appHostPath, cmd],
                     }));
                 }
             }

--- a/extension/src/extension.ts
+++ b/extension/src/extension.ts
@@ -35,6 +35,8 @@ import { AspireGutterDecorationProvider } from './editor/AspireGutterDecorationP
 import { AppHostFilePresenceWatcher } from './editor/AppHostFilePresenceWatcher';
 import { getSupportedLanguageIds } from './editor/parsers/AppHostResourceParser';
 import { readGitCommitSha } from './utils/versionInfo';
+import { collectResourceCommandArguments } from './views/ResourceCommandArguments';
+import { ResourceCommandJson } from './views/AppHostDataRepository';
 
 let aspireExtensionContext = new AspireExtensionContext();
 
@@ -134,12 +136,17 @@ export async function activate(context: vscode.ExtensionContext) {
   const languageFilters = getSupportedLanguageIds().map(lang => ({ language: lang, scheme: 'file' }));
   const codeLensRegistration = vscode.languages.registerCodeLensProvider(languageFilters, codeLensProvider);
   const codeLensDebugPipelineStepRegistration = vscode.commands.registerCommand('aspire-vscode.codeLensDebugPipelineStep', (stepName: string) => editorCommandProvider.tryExecuteDoAppHost(false, stepName));
-  const codeLensResourceActionRegistration = vscode.commands.registerCommand('aspire-vscode.codeLensResourceAction', (resourceName: string, action: string, appHostPath: string) => {
+  const codeLensResourceActionRegistration = vscode.commands.registerCommand('aspire-vscode.codeLensResourceAction', async (resourceName: string, action: string, appHostPath: string, resourceCommand?: ResourceCommandJson) => {
+    const additionalArgs = await collectResourceCommandArguments(action, resourceCommand);
+    if (additionalArgs === undefined) {
+      return;
+    }
+
     let command = `resource "${resourceName}" ${action}`;
     if (appHostPath) {
       command += ` --apphost "${appHostPath}"`;
     }
-    terminalProvider.sendAspireCommandToAspireTerminal(command);
+    terminalProvider.sendAspireCommandToAspireTerminal(command, true, additionalArgs);
   });
   const codeLensViewLogsRegistration = vscode.commands.registerCommand('aspire-vscode.codeLensViewLogs', (resourceName: string, appHostPath: string) => {
     let command = `logs "${resourceName}"`;

--- a/extension/src/extension.ts
+++ b/extension/src/extension.ts
@@ -85,7 +85,7 @@ export async function activate(context: vscode.ExtensionContext) {
 
   // Aspire panel - running app hosts tree view
   const dataRepository = new AppHostDataRepository(terminalProvider);
-  const appHostTreeProvider = new AspireAppHostTreeProvider(dataRepository, terminalProvider);
+  const appHostTreeProvider = new AspireAppHostTreeProvider(dataRepository, terminalProvider, context.globalState);
   const appHostTreeView = vscode.window.createTreeView('aspire-vscode.runningAppHosts', {
     treeDataProvider: appHostTreeProvider,
     showCollapseAll: true,
@@ -137,12 +137,12 @@ export async function activate(context: vscode.ExtensionContext) {
   const codeLensRegistration = vscode.languages.registerCodeLensProvider(languageFilters, codeLensProvider);
   const codeLensDebugPipelineStepRegistration = vscode.commands.registerCommand('aspire-vscode.codeLensDebugPipelineStep', (stepName: string) => editorCommandProvider.tryExecuteDoAppHost(false, stepName));
   const codeLensResourceActionRegistration = vscode.commands.registerCommand('aspire-vscode.codeLensResourceAction', async (resourceName: string, action: string, appHostPath: string, resourceCommand?: ResourceCommandJson) => {
-    const additionalArgs = await collectResourceCommandArguments(action, resourceCommand);
+    const additionalArgs = await collectResourceCommandArguments(action, resourceCommand, { secretWarningState: context.globalState });
     if (additionalArgs === undefined) {
       return;
     }
 
-    let command = `resource "${resourceName}" ${action}`;
+    let command = `resource "${resourceName}" "${action}"`;
     if (appHostPath) {
       command += ` --apphost "${appHostPath}"`;
     }

--- a/extension/src/extension.ts
+++ b/extension/src/extension.ts
@@ -35,7 +35,7 @@ import { AspireGutterDecorationProvider } from './editor/AspireGutterDecorationP
 import { AppHostFilePresenceWatcher } from './editor/AppHostFilePresenceWatcher';
 import { getSupportedLanguageIds } from './editor/parsers/AppHostResourceParser';
 import { readGitCommitSha } from './utils/versionInfo';
-import { collectResourceCommandArguments } from './views/ResourceCommandArguments';
+import { collectResourceCommandArguments, hasSecretResourceCommandArguments } from './views/ResourceCommandArguments';
 import { ResourceCommandJson } from './views/AppHostDataRepository';
 
 let aspireExtensionContext = new AspireExtensionContext();
@@ -146,7 +146,7 @@ export async function activate(context: vscode.ExtensionContext) {
     if (appHostPath) {
       command += ` --apphost "${appHostPath}"`;
     }
-    terminalProvider.sendAspireCommandToAspireTerminal(command, true, additionalArgs);
+    terminalProvider.sendAspireCommandToAspireTerminal(command, true, additionalArgs, { redactAdditionalArgs: hasSecretResourceCommandArguments(resourceCommand) });
   });
   const codeLensViewLogsRegistration = vscode.commands.registerCommand('aspire-vscode.codeLensViewLogs', (resourceName: string, appHostPath: string) => {
     let command = `logs "${resourceName}"`;

--- a/extension/src/loc/strings.ts
+++ b/extension/src/loc/strings.ts
@@ -62,6 +62,7 @@ export const resourcesGroupLabel = vscode.l10n.t('Resources');
 export const noCommandsAvailable = vscode.l10n.t('No commands available for this resource.');
 export const selectCommandPlaceholder = vscode.l10n.t('Select a command to execute');
 export const resourceCommandArgumentsTitle = (command: string) => vscode.l10n.t('Run {0}', command);
+export const resourceCommandArgumentInputTitle = (command: string, input: string) => vscode.l10n.t('{0}: {1}', command, input);
 export const resourceCommandCustomChoice = (value: string) => vscode.l10n.t('Use "{0}"', value);
 export const resourceCommandCustomChoiceDescription = vscode.l10n.t('Custom value');
 export const resourceCommandSecretWarning = vscode.l10n.t('This command has secret arguments. Values are masked while you enter them, but they are passed to the Aspire CLI terminal and may be visible in terminal history or scrollback.');

--- a/extension/src/loc/strings.ts
+++ b/extension/src/loc/strings.ts
@@ -61,6 +61,13 @@ export const errorFetchingAppHosts = (error: string) => vscode.l10n.t('Error fet
 export const resourcesGroupLabel = vscode.l10n.t('Resources');
 export const noCommandsAvailable = vscode.l10n.t('No commands available for this resource.');
 export const selectCommandPlaceholder = vscode.l10n.t('Select a command to execute');
+export const resourceCommandArgumentsTitle = (command: string) => vscode.l10n.t('Run {0}', command);
+export const resourceCommandCustomChoice = (value: string) => vscode.l10n.t('Use "{0}"', value);
+export const resourceCommandCustomChoiceDescription = vscode.l10n.t('Custom value');
+export const resourceCommandSecretWarning = vscode.l10n.t('This command has secret arguments. Values are masked while you enter them, but they are passed to the Aspire CLI terminal and may be visible in terminal history or scrollback.');
+export const resourceCommandContinue = vscode.l10n.t('Continue');
+export const resourceCommandInvalidNumber = vscode.l10n.t('Enter a number using digits and an optional decimal point.');
+export const resourceCommandMaxLength = (length: number) => vscode.l10n.t('Value must be {0} characters or fewer.', length);
 export const selectDashboardPlaceholder = vscode.l10n.t('Select a dashboard to open');
 export const workspaceAppHostLabel = vscode.l10n.t('Workspace AppHost');
 export const resourceCountDescription = (count: number) => vscode.l10n.t('({0} resources)', count);

--- a/extension/src/loc/strings.ts
+++ b/extension/src/loc/strings.ts
@@ -66,6 +66,7 @@ export const resourceCommandCustomChoice = (value: string) => vscode.l10n.t('Use
 export const resourceCommandCustomChoiceDescription = vscode.l10n.t('Custom value');
 export const resourceCommandSecretWarning = vscode.l10n.t('This command has secret arguments. Values are masked while you enter them, but they are passed to the Aspire CLI terminal and may be visible in terminal history or scrollback.');
 export const resourceCommandContinue = vscode.l10n.t('Continue');
+export const resourceCommandDontShowAgain = vscode.l10n.t("Don't show again");
 export const resourceCommandInvalidNumber = vscode.l10n.t('Enter a number using invariant culture, for example 1, -1.5, or 1e3.');
 export const resourceCommandMaxLength = (length: number) => vscode.l10n.t('Value must be {0} characters or fewer.', length);
 export const selectDashboardPlaceholder = vscode.l10n.t('Select a dashboard to open');

--- a/extension/src/loc/strings.ts
+++ b/extension/src/loc/strings.ts
@@ -66,7 +66,7 @@ export const resourceCommandCustomChoice = (value: string) => vscode.l10n.t('Use
 export const resourceCommandCustomChoiceDescription = vscode.l10n.t('Custom value');
 export const resourceCommandSecretWarning = vscode.l10n.t('This command has secret arguments. Values are masked while you enter them, but they are passed to the Aspire CLI terminal and may be visible in terminal history or scrollback.');
 export const resourceCommandContinue = vscode.l10n.t('Continue');
-export const resourceCommandInvalidNumber = vscode.l10n.t('Enter a number using digits and an optional decimal point.');
+export const resourceCommandInvalidNumber = vscode.l10n.t('Enter a number using invariant culture, for example 1, -1.5, or 1e3.');
 export const resourceCommandMaxLength = (length: number) => vscode.l10n.t('Value must be {0} characters or fewer.', length);
 export const selectDashboardPlaceholder = vscode.l10n.t('Select a dashboard to open');
 export const workspaceAppHostLabel = vscode.l10n.t('Workspace AppHost');

--- a/extension/src/server/interactionService.ts
+++ b/extension/src/server/interactionService.ts
@@ -285,6 +285,7 @@ export class InteractionService implements IInteractionService {
         }
 
         extensionLogOutputChannel.info(`Displaying message: ${emoji} ${message}`);
+        this.clearProgressNotification();
         vscode.window.showInformationMessage(formatText(message));
     }
 
@@ -297,6 +298,7 @@ export class InteractionService implements IInteractionService {
         }
 
         extensionLogOutputChannel.info(`Displaying success message: ${message}`);
+        this.clearProgressNotification();
         vscode.window.showInformationMessage(formatText(message));
     }
 
@@ -312,6 +314,7 @@ export class InteractionService implements IInteractionService {
 
     displayPlainText(message: string) {
         extensionLogOutputChannel.info(`Displaying plain text: ${message}`);
+        this.clearProgressNotification();
         vscode.window.showInformationMessage(formatText(message));
     }
 
@@ -406,6 +409,8 @@ export class InteractionService implements IInteractionService {
     }
 
     async displayLines(lines: ConsoleLine[]) {
+        this.clearProgressNotification();
+
         const debugSession = this._getAspireDebugSession();
         const aspireTerminal = !debugSession ? this._getAspireTerminal?.() : undefined;
         for (const line of lines) {
@@ -422,6 +427,7 @@ export class InteractionService implements IInteractionService {
 
     displayCancellationMessage() {
         extensionLogOutputChannel.info(`Cancelled Aspire operation.`);
+        this.clearProgressNotification();
     }
 
     async openEditor(path: string) {

--- a/extension/src/test/aspireTerminalProvider.test.ts
+++ b/extension/src/test/aspireTerminalProvider.test.ts
@@ -174,5 +174,42 @@ suite('AspireTerminalProvider tests', () => {
                 getAspireTerminalStub.restore();
             }
         });
+
+        test('quotes additional arguments with spaces and shell metacharacters', async () => {
+            resolveCliPathStub.resolves({ cliPath: 'aspire', available: true, source: 'path' });
+            let executedCommand: string | undefined;
+            const terminal = {
+                shellIntegration: {
+                    executeCommand: (commandLine: string) => {
+                        executedCommand = commandLine;
+                        return {} as vscode.TerminalShellExecution;
+                    }
+                },
+                sendText: () => { },
+                show: () => { }
+            } as unknown as vscode.Terminal;
+            const getAspireTerminalStub = sinon.stub(terminalProvider, 'getAspireTerminal').returns({
+                terminal,
+                dispose: () => { }
+            });
+
+            try {
+                await terminalProvider.sendAspireCommandToAspireTerminal('resource "web" "configure"', true, [
+                    '--',
+                    '--message',
+                    'hello world "quoted" $PATH ; & | < >',
+                    '--path',
+                    "it's fine",
+                ]);
+
+                const expected = process.platform === 'win32'
+                    ? '& "aspire" resource "web" "configure" "--" "--message" "hello world `"quoted`" `$PATH ; & | < >" "--path" "it\'s fine"'
+                    : 'aspire resource "web" "configure" \'--\' \'--message\' \'hello world "quoted" $PATH ; & | < >\' \'--path\' \'it\'"\'"\'s fine\'';
+                assert.strictEqual(executedCommand, expected);
+            }
+            finally {
+                getAspireTerminalStub.restore();
+            }
+        });
     });
 });

--- a/extension/src/test/aspireTerminalProvider.test.ts
+++ b/extension/src/test/aspireTerminalProvider.test.ts
@@ -1,7 +1,7 @@
 import * as assert from 'assert';
 import * as vscode from 'vscode';
 import * as sinon from 'sinon';
-import { AspireTerminalProvider } from '../utils/AspireTerminalProvider';
+import { AspireTerminalProvider, quoteShellArg } from '../utils/AspireTerminalProvider';
 import * as cliPathModule from '../utils/cliPath';
 import { EnvironmentVariables } from '../utils/environment';
 import { extensionLogOutputChannel } from '../utils/logging';
@@ -249,6 +249,72 @@ suite('AspireTerminalProvider tests', () => {
                 getAspireTerminalStub.restore();
                 infoStub.restore();
             }
+        });
+    });
+
+    // The Windows quoting form targets PowerShell (powershell.exe / pwsh.exe),
+    // which is VS Code's default integrated terminal on Windows. The Unix
+    // form uses POSIX single-quote quoting, which is interpreted identically
+    // by bash, zsh, dash, sh, and fish. These tests run on every host OS so
+    // we get coverage of both branches regardless of where the test executes.
+    suite('quoteShellArg (cross-platform)', () => {
+        suite('win32 (PowerShell / pwsh)', () => {
+            const cases: { name: string; input: string; expected: string }[] = [
+                { name: 'plain value', input: 'hello', expected: '"hello"' },
+                { name: 'value with spaces', input: 'hello world', expected: '"hello world"' },
+                { name: 'embedded double quote', input: 'say "hi"', expected: '"say `"hi`""' },
+                { name: 'embedded single quote', input: "it's fine", expected: `"it's fine"` },
+                { name: 'variable expansion $env', input: '$env:USERPROFILE', expected: '"`$env:USERPROFILE"' },
+                { name: 'variable expansion $var', input: '$PATH', expected: '"`$PATH"' },
+                { name: 'subshell expansion $(...)', input: '$(whoami)', expected: '"`$(whoami)"' },
+                { name: 'backtick subshell', input: '`whoami`', expected: '"``whoami``"' },
+                { name: 'backslash sequences', input: 'C:\\Program Files\\Aspire', expected: '"C:\\Program Files\\Aspire"' },
+                { name: 'backslash followed by quote', input: 'a\\"b', expected: '"a\\`"b"' },
+                { name: 'pipe and chaining', input: 'a | b; c && d', expected: '"a | b; c && d"' },
+                { name: 'redirection', input: '> out.txt < in.txt', expected: '"> out.txt < in.txt"' },
+                { name: 'newline', input: 'line1\nline2', expected: '"line1\nline2"' },
+                { name: 'mixed dollar quote backtick', input: '`$x"y"`', expected: '"```$x`"y`"``"' },
+                { name: 'attempted PowerShell break-out', input: '"; Remove-Item C:\\ -Recurse #', expected: '"`"; Remove-Item C:\\ -Recurse #"' },
+                { name: 'subshell with backticks and dollar', input: '`echo $(rm -rf /)`', expected: '"``echo `$(rm -rf /)``"' },
+                { name: 'empty string', input: '', expected: '""' },
+                { name: 'only special characters', input: '`$"', expected: '"```$`""' },
+            ];
+
+            for (const { name, input, expected } of cases) {
+                test(name, () => {
+                    assert.strictEqual(quoteShellArg(input, 'win32'), expected);
+                });
+            }
+        });
+
+        suite('posix (bash / zsh / sh / fish)', () => {
+            const cases: { name: string; input: string; expected: string }[] = [
+                { name: 'plain value', input: 'hello', expected: `'hello'` },
+                { name: 'value with spaces', input: 'hello world', expected: `'hello world'` },
+                { name: 'embedded double quote', input: 'say "hi"', expected: `'say "hi"'` },
+                { name: 'embedded single quote', input: "it's fine", expected: `'it'"'"'s fine'` },
+                { name: 'multiple single quotes', input: "''", expected: `''"'"''"'"''` },
+                { name: 'variable expansion', input: '$HOME', expected: `'$HOME'` },
+                { name: 'subshell expansion $(...)', input: '$(whoami)', expected: `'$(whoami)'` },
+                { name: 'backtick subshell', input: '`whoami`', expected: `'\`whoami\`'` },
+                { name: 'glob characters', input: '* ? [a-z]', expected: `'* ? [a-z]'` },
+                { name: 'pipe and chaining', input: 'a | b; c && d', expected: `'a | b; c && d'` },
+                { name: 'redirection', input: '> out.txt < in.txt', expected: `'> out.txt < in.txt'` },
+                { name: 'newline', input: 'line1\nline2', expected: `'line1\nline2'` },
+                { name: 'attempted bash break-out', input: `'; rm -rf / #`, expected: `''"'"'; rm -rf / #'` },
+                { name: 'backslash', input: 'a\\b', expected: `'a\\b'` },
+                { name: 'empty string', input: '', expected: `''` },
+            ];
+
+            for (const { name, input, expected } of cases) {
+                test(name, () => {
+                    assert.strictEqual(quoteShellArg(input, 'linux'), expected);
+                });
+            }
+
+            test('darwin uses identical posix quoting', () => {
+                assert.strictEqual(quoteShellArg(`it's fine`, 'darwin'), `'it'"'"'s fine'`);
+            });
         });
     });
 });

--- a/extension/src/test/aspireTerminalProvider.test.ts
+++ b/extension/src/test/aspireTerminalProvider.test.ts
@@ -142,5 +142,37 @@ suite('AspireTerminalProvider tests', () => {
                 getAspireTerminalStub.restore();
             }
         });
+
+        test('puts extension-added CLI flags before additional pass-through arguments', async () => {
+            resolveCliPathStub.resolves({ cliPath: 'aspire', available: true, source: 'path' });
+            isCliDebugLoggingEnabledStub.returns(true);
+            let executedCommand: string | undefined;
+            const terminal = {
+                shellIntegration: {
+                    executeCommand: (commandLine: string) => {
+                        executedCommand = commandLine;
+                        return {} as vscode.TerminalShellExecution;
+                    }
+                },
+                sendText: () => { },
+                show: () => { }
+            } as unknown as vscode.Terminal;
+            const getAspireTerminalStub = sinon.stub(terminalProvider, 'getAspireTerminal').returns({
+                terminal,
+                dispose: () => { }
+            });
+
+            try {
+                await terminalProvider.sendAspireCommandToAspireTerminal('resource "web" "configure"', true, ['--', '--message', 'hello world']);
+
+                const expected = process.platform === 'win32'
+                    ? '& "aspire" resource "web" "configure" "--debug" "--" "--message" "hello world"'
+                    : 'aspire resource "web" "configure" \'--debug\' \'--\' \'--message\' \'hello world\'';
+                assert.strictEqual(executedCommand, expected);
+            }
+            finally {
+                getAspireTerminalStub.restore();
+            }
+        });
     });
 });

--- a/extension/src/test/aspireTerminalProvider.test.ts
+++ b/extension/src/test/aspireTerminalProvider.test.ts
@@ -83,12 +83,14 @@ suite('AspireTerminalProvider tests', () => {
 
         test('uses shell integration to execute command when available', async () => {
             resolveCliPathStub.resolves({ cliPath: 'aspire', available: true, source: 'path' });
+            const events: string[] = [];
             const sentTexts: string[] = [];
             let executedCommand: string | undefined;
             let shown = false;
             const terminal = {
                 shellIntegration: {
                     executeCommand: (commandLine: string) => {
+                        events.push('execute');
                         executedCommand = commandLine;
                         return {} as vscode.TerminalShellExecution;
                     }
@@ -97,6 +99,7 @@ suite('AspireTerminalProvider tests', () => {
                     sentTexts.push(text);
                 },
                 show: () => {
+                    events.push('show');
                     shown = true;
                 }
             } as unknown as vscode.Terminal;
@@ -111,6 +114,7 @@ suite('AspireTerminalProvider tests', () => {
                 assert.strictEqual(executedCommand, expectedCommand);
                 assert.deepStrictEqual(sentTexts, []);
                 assert.strictEqual(shown, true);
+                assert.deepStrictEqual(events, ['show', 'execute']);
             }
             finally {
                 getAspireTerminalStub.restore();

--- a/extension/src/test/aspireTerminalProvider.test.ts
+++ b/extension/src/test/aspireTerminalProvider.test.ts
@@ -4,6 +4,7 @@ import * as sinon from 'sinon';
 import { AspireTerminalProvider } from '../utils/AspireTerminalProvider';
 import * as cliPathModule from '../utils/cliPath';
 import { EnvironmentVariables } from '../utils/environment';
+import { extensionLogOutputChannel } from '../utils/logging';
 
 suite('AspireTerminalProvider tests', () => {
     let terminalProvider: AspireTerminalProvider;
@@ -209,6 +210,44 @@ suite('AspireTerminalProvider tests', () => {
             }
             finally {
                 getAspireTerminalStub.restore();
+            }
+        });
+
+        test('redacts additional arguments from logs when requested', async () => {
+            resolveCliPathStub.resolves({ cliPath: 'aspire', available: true, source: 'path' });
+            let executedCommand: string | undefined;
+            const infoStub = sinon.stub(extensionLogOutputChannel, 'info');
+            const terminal = {
+                shellIntegration: {
+                    executeCommand: (commandLine: string) => {
+                        executedCommand = commandLine;
+                        return {} as vscode.TerminalShellExecution;
+                    }
+                },
+                sendText: () => { },
+                show: () => { }
+            } as unknown as vscode.Terminal;
+            const getAspireTerminalStub = sinon.stub(terminalProvider, 'getAspireTerminal').returns({
+                terminal,
+                dispose: () => { }
+            });
+
+            try {
+                await terminalProvider.sendAspireCommandToAspireTerminal('resource "web" "configure"', true, [
+                    '--',
+                    '--secret',
+                    'super-secret',
+                ], { redactAdditionalArgs: true });
+
+                assert.ok(executedCommand?.includes('super-secret'));
+                assert.strictEqual(infoStub.calledOnce, true);
+                const logMessage = infoStub.firstCall.args[0];
+                assert.ok(logMessage.includes('[redacted command arguments]'));
+                assert.ok(!logMessage.includes('super-secret'));
+            }
+            finally {
+                getAspireTerminalStub.restore();
+                infoStub.restore();
             }
         });
     });

--- a/extension/src/test/resourceCommandArguments.test.ts
+++ b/extension/src/test/resourceCommandArguments.test.ts
@@ -45,6 +45,43 @@ suite('ResourceCommandArguments', () => {
         assert.deepStrictEqual(buildResourceCommandCliArgs(values), ['--', '--enabled=false']);
     });
 
+    test('submits choice option values instead of display labels', () => {
+        const values: ResourceCommandArgumentValue[] = [
+            {
+                input: makeInput({
+                    name: 'mode',
+                    inputType: 'Choice',
+                    options: {
+                        'dry-run': 'Dry run',
+                    },
+                }),
+                value: 'dry-run',
+            },
+        ];
+
+        assert.deepStrictEqual(buildResourceCommandCliArgs(values), ['--', '--mode', 'dry-run']);
+    });
+
+    test('preserves spaces quotes and shell metacharacters as single argument values', () => {
+        const value = 'hello world "quoted" $PATH ; & | < >';
+        const values: ResourceCommandArgumentValue[] = [
+            { input: makeInput({ name: 'message' }), value },
+        ];
+
+        assert.deepStrictEqual(buildResourceCommandCliArgs(values), ['--', '--message', value]);
+    });
+
+    test('skips empty optional non-boolean inputs but submits booleans', () => {
+        const values: ResourceCommandArgumentValue[] = [
+            { input: makeInput({ name: 'optionalText', inputType: 'Text' }), value: '' },
+            { input: makeInput({ name: 'optionalSecret', inputType: 'SecretText' }), value: '' },
+            { input: makeInput({ name: 'optionalNumber', inputType: 'Number' }), value: '' },
+            { input: makeInput({ name: 'requireHealthy', inputType: 'Boolean' }), value: 'false' },
+        ];
+
+        assert.deepStrictEqual(buildResourceCommandCliArgs(values), ['--', '--requireHealthy=false']);
+    });
+
     test('omits delimiter when no values are submitted', () => {
         const values: ResourceCommandArgumentValue[] = [
             { input: makeInput({ name: 'optional' }), value: '' },
@@ -59,10 +96,17 @@ suite('ResourceCommandArguments', () => {
         assert.strictEqual(getResourceCommandArgumentValidationMessage(input, '   '), 'This field is required.');
     });
 
+    test('does not require boolean input text', () => {
+        const input = makeInput({ inputType: 'Boolean', required: true });
+
+        assert.strictEqual(getResourceCommandArgumentValidationMessage(input, ''), undefined);
+    });
+
     test('validates invariant-culture numbers', () => {
         const input = makeInput({ inputType: 'Number' });
 
         assert.strictEqual(getResourceCommandArgumentValidationMessage(input, '1.5'), undefined);
+        assert.strictEqual(getResourceCommandArgumentValidationMessage(input, '-1.5'), undefined);
         assert.strictEqual(getResourceCommandArgumentValidationMessage(input, '1,5'), 'Enter a number using digits and an optional decimal point.');
     });
 

--- a/extension/src/test/resourceCommandArguments.test.ts
+++ b/extension/src/test/resourceCommandArguments.test.ts
@@ -209,13 +209,17 @@ suite('ResourceCommandArguments', () => {
 
     test('stores secret warning suppression when requested', async () => {
         const memento = new TestMemento();
-        const warningStub = sinon.stub(vscode.window, 'showWarningMessage').resolves("Don't show again" as never);
+        const suppressWarningItem: vscode.QuickPickItem & { suppressFutureWarnings: boolean } = { label: "Don't show again", suppressFutureWarnings: true };
+        const quickPickStub = sinon.stub(vscode.window, 'showQuickPick').resolves(suppressWarningItem as never);
+        const warningStub = sinon.stub(vscode.window, 'showWarningMessage');
 
         try {
             assert.strictEqual(await confirmSecretArgumentWarning(memento), true);
             assert.strictEqual(memento.get(resourceCommandSecretWarningSuppressedKey), true);
+            assert.strictEqual(warningStub.called, false);
         }
         finally {
+            quickPickStub.restore();
             warningStub.restore();
         }
     });
@@ -223,14 +227,14 @@ suite('ResourceCommandArguments', () => {
     test('skips secret warning when suppression is stored', async () => {
         const memento = new TestMemento();
         await memento.update(resourceCommandSecretWarningSuppressedKey, true);
-        const warningStub = sinon.stub(vscode.window, 'showWarningMessage');
+        const quickPickStub = sinon.stub(vscode.window, 'showQuickPick');
 
         try {
             assert.strictEqual(await confirmSecretArgumentWarning(memento), true);
-            assert.strictEqual(warningStub.called, false);
+            assert.strictEqual(quickPickStub.called, false);
         }
         finally {
-            warningStub.restore();
+            quickPickStub.restore();
         }
     });
 });

--- a/extension/src/test/resourceCommandArguments.test.ts
+++ b/extension/src/test/resourceCommandArguments.test.ts
@@ -1,0 +1,74 @@
+import * as assert from 'assert';
+import {
+    buildResourceCommandCliArgs,
+    getResourceCommandArgumentValidationMessage,
+    ResourceCommandArgumentValue,
+} from '../views/ResourceCommandArguments';
+import { ResourceCommandArgumentInputJson } from '../views/AppHostDataRepository';
+
+function makeInput(overrides: Partial<ResourceCommandArgumentInputJson> = {}): ResourceCommandArgumentInputJson {
+    return {
+        name: 'message',
+        label: 'Message',
+        description: null,
+        inputType: 'Text',
+        required: false,
+        placeholder: null,
+        value: null,
+        options: null,
+        maxLength: null,
+        ...overrides,
+    };
+}
+
+suite('ResourceCommandArguments', () => {
+    test('builds exact-name command options after delimiter', () => {
+        const values: ResourceCommandArgumentValue[] = [
+            { input: makeInput({ name: 'LogLevel', inputType: 'Choice' }), value: 'Debug' },
+            { input: makeInput({ name: 'timeoutMilliseconds', inputType: 'Number' }), value: '1000' },
+        ];
+
+        assert.deepStrictEqual(buildResourceCommandCliArgs(values), [
+            '--',
+            '--LogLevel',
+            'Debug',
+            '--timeoutMilliseconds',
+            '1000',
+        ]);
+    });
+
+    test('encodes boolean values as single option tokens', () => {
+        const values: ResourceCommandArgumentValue[] = [
+            { input: makeInput({ name: 'enabled', inputType: 'Boolean' }), value: 'false' },
+        ];
+
+        assert.deepStrictEqual(buildResourceCommandCliArgs(values), ['--', '--enabled=false']);
+    });
+
+    test('omits delimiter when no values are submitted', () => {
+        const values: ResourceCommandArgumentValue[] = [
+            { input: makeInput({ name: 'optional' }), value: '' },
+        ];
+
+        assert.deepStrictEqual(buildResourceCommandCliArgs(values), []);
+    });
+
+    test('validates required input', () => {
+        const input = makeInput({ required: true });
+
+        assert.strictEqual(getResourceCommandArgumentValidationMessage(input, '   '), 'This field is required.');
+    });
+
+    test('validates invariant-culture numbers', () => {
+        const input = makeInput({ inputType: 'Number' });
+
+        assert.strictEqual(getResourceCommandArgumentValidationMessage(input, '1.5'), undefined);
+        assert.strictEqual(getResourceCommandArgumentValidationMessage(input, '1,5'), 'Enter a number using digits and an optional decimal point.');
+    });
+
+    test('validates maximum length', () => {
+        const input = makeInput({ maxLength: 3 });
+
+        assert.strictEqual(getResourceCommandArgumentValidationMessage(input, 'abcd'), 'Value must be 3 characters or fewer.');
+    });
+});

--- a/extension/src/test/resourceCommandArguments.test.ts
+++ b/extension/src/test/resourceCommandArguments.test.ts
@@ -31,10 +31,8 @@ suite('ResourceCommandArguments', () => {
 
         assert.deepStrictEqual(buildResourceCommandCliArgs(values), [
             '--',
-            '--LogLevel',
-            'Debug',
-            '--timeoutMilliseconds',
-            '1000',
+            '--LogLevel=Debug',
+            '--timeoutMilliseconds=1000',
         ]);
     });
 
@@ -60,7 +58,7 @@ suite('ResourceCommandArguments', () => {
             },
         ];
 
-        assert.deepStrictEqual(buildResourceCommandCliArgs(values), ['--', '--mode', 'dry-run']);
+        assert.deepStrictEqual(buildResourceCommandCliArgs(values), ['--', '--mode=dry-run']);
     });
 
     test('preserves spaces quotes and shell metacharacters as single argument values', () => {
@@ -69,7 +67,20 @@ suite('ResourceCommandArguments', () => {
             { input: makeInput({ name: 'message' }), value },
         ];
 
-        assert.deepStrictEqual(buildResourceCommandCliArgs(values), ['--', '--message', value]);
+        assert.deepStrictEqual(buildResourceCommandCliArgs(values), ['--', `--message=${value}`]);
+    });
+
+    test('preserves option-like values without splitting them off as new options', () => {
+        const values: ResourceCommandArgumentValue[] = [
+            { input: makeInput({ name: 'message' }), value: '--help' },
+            { input: makeInput({ name: 'flag', inputType: 'Choice' }), value: '-x' },
+        ];
+
+        assert.deepStrictEqual(buildResourceCommandCliArgs(values), [
+            '--',
+            '--message=--help',
+            '--flag=-x',
+        ]);
     });
 
     test('skips empty optional non-boolean inputs but submits booleans', () => {
@@ -81,6 +92,37 @@ suite('ResourceCommandArguments', () => {
         ];
 
         assert.deepStrictEqual(buildResourceCommandCliArgs(values), ['--', '--requireHealthy=false']);
+    });
+
+    test('submits empty value to clear a prefilled text or choice default', () => {
+        const values: ResourceCommandArgumentValue[] = [
+            { input: makeInput({ name: 'message', inputType: 'Text', value: 'previous' }), value: '' },
+            { input: makeInput({ name: 'token', inputType: 'SecretText', value: 'old-token' }), value: '' },
+            {
+                input: makeInput({
+                    name: 'mode',
+                    inputType: 'Choice',
+                    value: 'previous',
+                    allowCustomChoice: true,
+                }),
+                value: '',
+            },
+        ];
+
+        assert.deepStrictEqual(buildResourceCommandCliArgs(values), [
+            '--',
+            '--message=',
+            '--token=',
+            '--mode=',
+        ]);
+    });
+
+    test('skips empty number even when a default value was prefilled', () => {
+        const values: ResourceCommandArgumentValue[] = [
+            { input: makeInput({ name: 'timeout', inputType: 'Number', value: '42' }), value: '' },
+        ];
+
+        assert.deepStrictEqual(buildResourceCommandCliArgs(values), []);
     });
 
     test('omits delimiter when no values are submitted', () => {

--- a/extension/src/test/resourceCommandArguments.test.ts
+++ b/extension/src/test/resourceCommandArguments.test.ts
@@ -1,8 +1,12 @@
 import * as assert from 'assert';
+import * as sinon from 'sinon';
+import * as vscode from 'vscode';
 import {
     buildResourceCommandCliArgs,
+    confirmSecretArgumentWarning,
     getResourceCommandArgumentValidationMessage,
     hasSecretResourceCommandArguments,
+    resourceCommandSecretWarningSuppressedKey,
     ResourceCommandArgumentValue,
 } from '../views/ResourceCommandArguments';
 import { ResourceCommandArgumentInputJson } from '../views/AppHostDataRepository';
@@ -20,6 +24,28 @@ function makeInput(overrides: Partial<ResourceCommandArgumentInputJson> = {}): R
         maxLength: null,
         ...overrides,
     };
+}
+
+class TestMemento implements vscode.Memento {
+    private readonly values = new Map<string, unknown>();
+
+    keys(): readonly string[] {
+        return [...this.values.keys()];
+    }
+
+    get<T>(key: string): T | undefined;
+    get<T>(key: string, defaultValue: T): T;
+    get<T>(key: string, defaultValue?: T): T | undefined {
+        return this.values.has(key) ? this.values.get(key) as T : defaultValue;
+    }
+
+    update(key: string, value: unknown): Thenable<void> {
+        this.values.set(key, value);
+        return Promise.resolve();
+    }
+
+    setKeysForSync(): void {
+    }
 }
 
 suite('ResourceCommandArguments', () => {
@@ -179,5 +205,32 @@ suite('ResourceCommandArguments', () => {
                 makeInput({ inputType: 'SecretText', disabled: true }),
             ],
         }), false);
+    });
+
+    test('stores secret warning suppression when requested', async () => {
+        const memento = new TestMemento();
+        const warningStub = sinon.stub(vscode.window, 'showWarningMessage').resolves("Don't show again" as never);
+
+        try {
+            assert.strictEqual(await confirmSecretArgumentWarning(memento), true);
+            assert.strictEqual(memento.get(resourceCommandSecretWarningSuppressedKey), true);
+        }
+        finally {
+            warningStub.restore();
+        }
+    });
+
+    test('skips secret warning when suppression is stored', async () => {
+        const memento = new TestMemento();
+        await memento.update(resourceCommandSecretWarningSuppressedKey, true);
+        const warningStub = sinon.stub(vscode.window, 'showWarningMessage');
+
+        try {
+            assert.strictEqual(await confirmSecretArgumentWarning(memento), true);
+            assert.strictEqual(warningStub.called, false);
+        }
+        finally {
+            warningStub.restore();
+        }
     });
 });

--- a/extension/src/test/resourceCommandArguments.test.ts
+++ b/extension/src/test/resourceCommandArguments.test.ts
@@ -2,6 +2,7 @@ import * as assert from 'assert';
 import {
     buildResourceCommandCliArgs,
     getResourceCommandArgumentValidationMessage,
+    hasSecretResourceCommandArguments,
     ResourceCommandArgumentValue,
 } from '../views/ResourceCommandArguments';
 import { ResourceCommandArgumentInputJson } from '../views/AppHostDataRepository';
@@ -107,12 +108,34 @@ suite('ResourceCommandArguments', () => {
 
         assert.strictEqual(getResourceCommandArgumentValidationMessage(input, '1.5'), undefined);
         assert.strictEqual(getResourceCommandArgumentValidationMessage(input, '-1.5'), undefined);
-        assert.strictEqual(getResourceCommandArgumentValidationMessage(input, '1,5'), 'Enter a number using digits and an optional decimal point.');
+        assert.strictEqual(getResourceCommandArgumentValidationMessage(input, '.5'), undefined);
+        assert.strictEqual(getResourceCommandArgumentValidationMessage(input, '1e3'), undefined);
+        assert.strictEqual(getResourceCommandArgumentValidationMessage(input, '+1.5E-2'), undefined);
+        assert.strictEqual(getResourceCommandArgumentValidationMessage(input, '1,5'), 'Enter a number using invariant culture, for example 1, -1.5, or 1e3.');
     });
 
     test('validates maximum length', () => {
         const input = makeInput({ maxLength: 3 });
 
         assert.strictEqual(getResourceCommandArgumentValidationMessage(input, 'abcd'), 'Value must be 3 characters or fewer.');
+    });
+
+    test('detects enabled secret text arguments', () => {
+        assert.strictEqual(hasSecretResourceCommandArguments({
+            description: null,
+            argumentInputs: [
+                makeInput({ inputType: 'Text' }),
+                makeInput({ inputType: 'SecretText' }),
+            ],
+        }), true);
+    });
+
+    test('ignores disabled secret text arguments', () => {
+        assert.strictEqual(hasSecretResourceCommandArguments({
+            description: null,
+            argumentInputs: [
+                makeInput({ inputType: 'SecretText', disabled: true }),
+            ],
+        }), false);
     });
 });

--- a/extension/src/test/rpc/interactionServiceTests.test.ts
+++ b/extension/src/test/rpc/interactionServiceTests.test.ts
@@ -173,6 +173,23 @@ suite('InteractionService endpoints', () => {
 		showInformationMessageSpy.restore();
 	});
 
+	test("displaySuccess clears active progress notification", async () => {
+		const testInfo = await createTestRpcServer();
+		const showInformationMessageStub = sinon.stub(vscode.window, 'showInformationMessage').resolves();
+
+		try {
+			testInfo.interactionService.showStatus('Executing test command...');
+			assert.strictEqual((testInfo.interactionService as any)._progressNotifier.isActive, true);
+
+			testInfo.interactionService.displaySuccess('Test success message');
+
+			assert.strictEqual((testInfo.interactionService as any)._progressNotifier.isActive, false);
+		}
+		finally {
+			showInformationMessageStub.restore();
+		}
+	});
+
 	test("displaySubtleMessage endpoint", async () => {
 		const testInfo = await createTestRpcServer();
 		const setStatusBarMessageSpy = sinon.spy(vscode.window, 'setStatusBarMessage');

--- a/extension/src/utils/AspireTerminalProvider.ts
+++ b/extension/src/utils/AspireTerminalProvider.ts
@@ -23,13 +23,33 @@ export interface SendAspireCommandOptions {
     redactAdditionalArgs?: boolean;
 }
 
-function quoteShellArg(arg: string): string {
-    if (process.platform === 'win32') {
-        // On Windows PowerShell, wrap in double quotes and escape interpolation characters.
+/**
+ * Quotes a single argument for safe interpolation into a shell command line.
+ *
+ * Windows: The output targets PowerShell (powershell.exe / pwsh.exe), which is
+ * VS Code's default integrated terminal on Windows. The argument is wrapped in
+ * double quotes and the interpolation-significant characters (backtick, double
+ * quote, dollar sign) are backtick-escaped. This form is NOT safe for cmd.exe;
+ * users who have configured cmd.exe as their default terminal may see
+ * unexpected behavior. End-to-end coverage through a real child process is
+ * out of scope for this helper.
+ *
+ * Unix: The output uses POSIX single-quote quoting, which is interpreted the
+ * same way by bash, zsh, dash, sh, and fish. Embedded single quotes are split
+ * out and rejoined with a double-quoted single quote.
+ *
+ * @param arg The raw argument value to quote.
+ * @param platform Override for the target platform. Defaults to
+ * `process.platform`, but tests pass an explicit value to validate both
+ * branches regardless of the host OS.
+ */
+export function quoteShellArg(arg: string, platform: NodeJS.Platform = process.platform): string {
+    if (platform === 'win32') {
+        // Order matters: escape backticks first so that the backticks we
+        // introduce when escaping " and $ are not themselves re-escaped.
         return `"${arg.replace(/`/g, '``').replace(/"/g, '`"').replace(/\$/g, '`$')}"`;
     }
 
-    // On Unix, wrap in single quotes and escape inner single quotes.
     return `'${arg.replace(/'/g, "'\"'\"'")}'`;
 }
 
@@ -103,14 +123,14 @@ export class AspireTerminalProvider implements vscode.Disposable {
             : extensionArgs;
 
         if (cliArgs.length > 0) {
-            const quotedArgs = cliArgs.map(quoteShellArg);
+            const quotedArgs = cliArgs.map(arg => quoteShellArg(arg));
             command += ' ' + quotedArgs.join(' ');
         }
 
         const aspireTerminal = this.getAspireTerminal();
         let logCommand = command;
         if (options?.redactAdditionalArgs && additionalArgs && additionalArgs.length > 0) {
-            const logArgs = extensionArgs.map(quoteShellArg);
+            const logArgs = extensionArgs.map(arg => quoteShellArg(arg));
             logArgs.push('[redacted command arguments]');
             logCommand = `${baseCommand} ${logArgs.join(' ')}`;
         }

--- a/extension/src/utils/AspireTerminalProvider.ts
+++ b/extension/src/utils/AspireTerminalProvider.ts
@@ -74,25 +74,30 @@ export class AspireTerminalProvider implements vscode.Disposable {
             command = `${quotedPath} ${subcommand}`;
         }
 
+        const cliArgs: string[] = [];
+        if (this.isCliDebugLoggingEnabled()) {
+            cliArgs.push('--debug');
+        }
+
+        if (process.env[EnvironmentVariables.ASPIRE_CLI_STOP_ON_ENTRY] === 'true') {
+            cliArgs.push('--cli-wait-for-debugger');
+        }
+
         if (additionalArgs && additionalArgs.length > 0) {
-            const quotedArgs = additionalArgs.map(arg => {
+            cliArgs.push(...additionalArgs);
+        }
+
+        if (cliArgs.length > 0) {
+            const quotedArgs = cliArgs.map(arg => {
                 if (process.platform === 'win32') {
-                    // On Windows PowerShell, wrap in double quotes and escape inner double quotes
-                    return `"${arg.replace(/"/g, '`"')}"`;
+                    // On Windows PowerShell, wrap in double quotes and escape interpolation characters.
+                    return `"${arg.replace(/`/g, '``').replace(/"/g, '`"').replace(/\$/g, '`$')}"`;
                 } else {
                     // On Unix, wrap in single quotes and escape inner single quotes
                     return `'${arg.replace(/'/g, "'\"'\"'")}'`;
                 }
             });
             command += ' ' + quotedArgs.join(' ');
-        }
-
-        if (this.isCliDebugLoggingEnabled()) {
-            command += ' --debug';
-        }
-
-        if (process.env[EnvironmentVariables.ASPIRE_CLI_STOP_ON_ENTRY] === 'true') {
-            command += ' --cli-wait-for-debugger';
         }
 
         const aspireTerminal = this.getAspireTerminal();

--- a/extension/src/utils/AspireTerminalProvider.ts
+++ b/extension/src/utils/AspireTerminalProvider.ts
@@ -136,6 +136,10 @@ export class AspireTerminalProvider implements vscode.Disposable {
         }
         extensionLogOutputChannel.info(`Sending command to Aspire terminal: ${logCommand}`);
 
+        if (showTerminal) {
+            aspireTerminal.terminal.show();
+        }
+
         if (aspireTerminal.terminal.shellIntegration) {
             aspireTerminal.terminal.shellIntegration.executeCommand(command);
         }
@@ -146,9 +150,6 @@ export class AspireTerminalProvider implements vscode.Disposable {
             aspireTerminal.terminal.sendText(command);
         }
 
-        if (showTerminal) {
-            aspireTerminal.terminal.show();
-        }
     }
 
     getAspireTerminal(forceCreate?: boolean): AspireTerminal {

--- a/extension/src/utils/AspireTerminalProvider.ts
+++ b/extension/src/utils/AspireTerminalProvider.ts
@@ -19,6 +19,20 @@ export interface AspireTerminal {
     dispose: () => void;
 }
 
+export interface SendAspireCommandOptions {
+    redactAdditionalArgs?: boolean;
+}
+
+function quoteShellArg(arg: string): string {
+    if (process.platform === 'win32') {
+        // On Windows PowerShell, wrap in double quotes and escape interpolation characters.
+        return `"${arg.replace(/`/g, '``').replace(/"/g, '`"').replace(/\$/g, '`$')}"`;
+    }
+
+    // On Unix, wrap in single quotes and escape inner single quotes.
+    return `'${arg.replace(/'/g, "'\"'\"'")}'`;
+}
+
 export class AspireTerminalProvider implements vscode.Disposable {
     private _terminalByDebugSessionId: Map<string | null, AspireTerminal> = new Map();
     private _rpcServerConnectionInfo?: RpcServerConnectionInfo;
@@ -59,7 +73,7 @@ export class AspireTerminalProvider implements vscode.Disposable {
         this._dcpServerConnectionInfo = value;
     }
 
-    async sendAspireCommandToAspireTerminal(subcommand: string, showTerminal: boolean = true, additionalArgs?: string[]) {
+    async sendAspireCommandToAspireTerminal(subcommand: string, showTerminal: boolean = true, additionalArgs?: string[], options?: SendAspireCommandOptions) {
         const cliPath = await this.getAspireCliExecutablePath();
 
         // On Windows, use & to execute paths, especially those with special characters
@@ -73,35 +87,34 @@ export class AspireTerminalProvider implements vscode.Disposable {
             const quotedPath = /[\s"'`$!*?()&|<>;]/.test(cliPath) ? `'${cliPath.replace(/'/g, `'\"'\"'`)}'` : cliPath;
             command = `${quotedPath} ${subcommand}`;
         }
+        const baseCommand = command;
 
-        const cliArgs: string[] = [];
+        const extensionArgs: string[] = [];
         if (this.isCliDebugLoggingEnabled()) {
-            cliArgs.push('--debug');
+            extensionArgs.push('--debug');
         }
 
         if (process.env[EnvironmentVariables.ASPIRE_CLI_STOP_ON_ENTRY] === 'true') {
-            cliArgs.push('--cli-wait-for-debugger');
+            extensionArgs.push('--cli-wait-for-debugger');
         }
 
-        if (additionalArgs && additionalArgs.length > 0) {
-            cliArgs.push(...additionalArgs);
-        }
+        const cliArgs = additionalArgs && additionalArgs.length > 0
+            ? [...extensionArgs, ...additionalArgs]
+            : extensionArgs;
 
         if (cliArgs.length > 0) {
-            const quotedArgs = cliArgs.map(arg => {
-                if (process.platform === 'win32') {
-                    // On Windows PowerShell, wrap in double quotes and escape interpolation characters.
-                    return `"${arg.replace(/`/g, '``').replace(/"/g, '`"').replace(/\$/g, '`$')}"`;
-                } else {
-                    // On Unix, wrap in single quotes and escape inner single quotes
-                    return `'${arg.replace(/'/g, "'\"'\"'")}'`;
-                }
-            });
+            const quotedArgs = cliArgs.map(quoteShellArg);
             command += ' ' + quotedArgs.join(' ');
         }
 
         const aspireTerminal = this.getAspireTerminal();
-        extensionLogOutputChannel.info(`Sending command to Aspire terminal: ${command}`);
+        let logCommand = command;
+        if (options?.redactAdditionalArgs && additionalArgs && additionalArgs.length > 0) {
+            const logArgs = extensionArgs.map(quoteShellArg);
+            logArgs.push('[redacted command arguments]');
+            logCommand = `${baseCommand} ${logArgs.join(' ')}`;
+        }
+        extensionLogOutputChannel.info(`Sending command to Aspire terminal: ${logCommand}`);
 
         if (aspireTerminal.terminal.shellIntegration) {
             aspireTerminal.terminal.shellIntegration.executeCommand(command);

--- a/extension/src/views/AppHostDataRepository.ts
+++ b/extension/src/views/AppHostDataRepository.ts
@@ -20,6 +20,8 @@ export interface ResourceCommandJson {
     argumentInputs?: ResourceCommandArgumentInputJson[] | null;
 }
 
+// Mirrors the CLI JSON contract in src/Shared/Model/Serialization/ResourceJson.cs
+// (`ResourceCommandArgumentJson`), populated by Aspire.Cli's ResourceSnapshotMapper.
 export interface ResourceCommandArgumentInputJson {
     name: string;
     label: string | null;

--- a/extension/src/views/AppHostDataRepository.ts
+++ b/extension/src/views/AppHostDataRepository.ts
@@ -16,6 +16,23 @@ export interface ResourceUrlJson {
 
 export interface ResourceCommandJson {
     description: string | null;
+    visibility?: string | null;
+    argumentInputs?: ResourceCommandArgumentInputJson[] | null;
+}
+
+export interface ResourceCommandArgumentInputJson {
+    name: string;
+    label: string | null;
+    description: string | null;
+    enableDescriptionMarkdown?: boolean;
+    inputType: 'Text' | 'SecretText' | 'Choice' | 'Boolean' | 'Number';
+    required?: boolean;
+    placeholder: string | null;
+    value: string | null;
+    options: Record<string, string | null> | null;
+    allowCustomChoice?: boolean;
+    disabled?: boolean;
+    maxLength: number | null;
 }
 
 export interface ResourceHealthReportJson {

--- a/extension/src/views/AppHostDataRepository.ts
+++ b/extension/src/views/AppHostDataRepository.ts
@@ -20,6 +20,19 @@ export interface ResourceCommandJson {
     argumentInputs?: ResourceCommandArgumentInputJson[] | null;
 }
 
+// Resource command argument input types. Values match the strings emitted by the CLI
+// JSON contract (ResourceCommandArgumentJson.InputType in
+// src/Shared/Model/Serialization/ResourceJson.cs).
+export const ResourceCommandInputType = {
+    Text: 'Text',
+    SecretText: 'SecretText',
+    Choice: 'Choice',
+    Boolean: 'Boolean',
+    Number: 'Number',
+} as const;
+
+export type ResourceCommandInputType = typeof ResourceCommandInputType[keyof typeof ResourceCommandInputType];
+
 // Mirrors the CLI JSON contract in src/Shared/Model/Serialization/ResourceJson.cs
 // (`ResourceCommandArgumentJson`), populated by Aspire.Cli's ResourceSnapshotMapper.
 export interface ResourceCommandArgumentInputJson {
@@ -27,7 +40,7 @@ export interface ResourceCommandArgumentInputJson {
     label: string | null;
     description: string | null;
     enableDescriptionMarkdown?: boolean;
-    inputType: 'Text' | 'SecretText' | 'Choice' | 'Boolean' | 'Number';
+    inputType: ResourceCommandInputType;
     required?: boolean;
     placeholder: string | null;
     value: string | null;

--- a/extension/src/views/AspireAppHostTreeProvider.ts
+++ b/extension/src/views/AspireAppHostTreeProvider.ts
@@ -326,6 +326,7 @@ export class AspireAppHostTreeProvider implements vscode.TreeDataProvider<TreeEl
     constructor(
         private readonly _repository: AppHostDataRepository,
         private readonly _terminalProvider: AspireTerminalProvider,
+        private readonly _secretWarningState?: vscode.Memento,
     ) {
         this._dataSubscription = this._repository.onDidChangeData(() => {
             this._onDidChangeTreeData.fire();
@@ -713,7 +714,7 @@ export class AspireAppHostTreeProvider implements vscode.TreeDataProvider<TreeEl
             return;
         }
 
-        const additionalArgs = await collectResourceCommandArguments(selected.label, selected.command);
+        const additionalArgs = await collectResourceCommandArguments(selected.label, selected.command, { secretWarningState: this._secretWarningState });
         if (additionalArgs === undefined) {
             return;
         }

--- a/extension/src/views/AspireAppHostTreeProvider.ts
+++ b/extension/src/views/AspireAppHostTreeProvider.ts
@@ -33,6 +33,7 @@ import {
     ViewMode,
     shortenPaths,
 } from './AppHostDataRepository';
+import { collectResourceCommandArguments } from './ResourceCommandArguments';
 
 type TreeElement = AppHostItem | PidItem | EndpointUrlItem | ResourcesGroupItem | ResourceItem | WorkspaceResourcesItem | HealthChecksGroupItem | HealthCheckItem;
 
@@ -701,6 +702,7 @@ export class AspireAppHostTreeProvider implements vscode.TreeDataProvider<TreeEl
         const items = Object.entries(commands).map(([name, cmd]) => ({
             label: name,
             description: cmd.description ?? undefined,
+            command: cmd,
         }));
 
         const selected = await vscode.window.showQuickPick(items, {
@@ -711,16 +713,12 @@ export class AspireAppHostTreeProvider implements vscode.TreeDataProvider<TreeEl
             return;
         }
 
-        if (this._repository.viewMode === 'workspace') {
-            const appHostFlag = this._repository.workspaceAppHostPath ? ` --apphost "${this._repository.workspaceAppHostPath}"` : '';
-            this._terminalProvider.sendAspireCommandToAspireTerminal(`resource "${element.resource.name}" "${selected.label}"${appHostFlag}`);
+        const additionalArgs = await collectResourceCommandArguments(selected.label, selected.command);
+        if (additionalArgs === undefined) {
             return;
         }
 
-        const appHost = this._findAppHostForResource(element);
-        if (appHost) {
-            this._terminalProvider.sendAspireCommandToAspireTerminal(`resource "${element.resource.name}" "${selected.label}" --apphost "${appHost.appHostPath}"`);
-        }
+        this._runResourceCommand(element, `"${selected.label}"`, ...additionalArgs);
     }
 
     async copyAppHostPath(element: AppHostItem): Promise<void> {
@@ -749,11 +747,11 @@ export class AspireAppHostTreeProvider implements vscode.TreeDataProvider<TreeEl
     }
 
     private _runResourceCommand(element: ResourceItem, command: string, ...extraArgs: string[]): void {
-        const suffix = extraArgs.length > 0 ? ` ${extraArgs.join(' ')}` : '';
+        const additionalArgs = extraArgs.length > 0 ? extraArgs : undefined;
 
         if (this._repository.viewMode === 'workspace') {
             const appHostFlag = this._repository.workspaceAppHostPath ? ` --apphost "${this._repository.workspaceAppHostPath}"` : '';
-            this._terminalProvider.sendAspireCommandToAspireTerminal(`resource "${element.resource.name}" ${command}${suffix}${appHostFlag}`);
+            this._terminalProvider.sendAspireCommandToAspireTerminal(`resource "${element.resource.name}" ${command}${appHostFlag}`, true, additionalArgs);
             return;
         }
 
@@ -761,7 +759,7 @@ export class AspireAppHostTreeProvider implements vscode.TreeDataProvider<TreeEl
         if (!appHost) {
             return;
         }
-        this._terminalProvider.sendAspireCommandToAspireTerminal(`resource "${element.resource.name}" ${command} --apphost "${appHost.appHostPath}"${suffix}`);
+        this._terminalProvider.sendAspireCommandToAspireTerminal(`resource "${element.resource.name}" ${command} --apphost "${appHost.appHostPath}"`, true, additionalArgs);
     }
 
     private _findAppHostForResource(element: ResourceItem): AppHostDisplayInfo | undefined {

--- a/extension/src/views/AspireAppHostTreeProvider.ts
+++ b/extension/src/views/AspireAppHostTreeProvider.ts
@@ -33,7 +33,7 @@ import {
     ViewMode,
     shortenPaths,
 } from './AppHostDataRepository';
-import { collectResourceCommandArguments } from './ResourceCommandArguments';
+import { collectResourceCommandArguments, hasSecretResourceCommandArguments } from './ResourceCommandArguments';
 
 type TreeElement = AppHostItem | PidItem | EndpointUrlItem | ResourcesGroupItem | ResourceItem | WorkspaceResourcesItem | HealthChecksGroupItem | HealthCheckItem;
 
@@ -718,7 +718,7 @@ export class AspireAppHostTreeProvider implements vscode.TreeDataProvider<TreeEl
             return;
         }
 
-        this._runResourceCommand(element, `"${selected.label}"`, ...additionalArgs);
+        this._runResourceCommand(element, `"${selected.label}"`, additionalArgs, hasSecretResourceCommandArguments(selected.command));
     }
 
     async copyAppHostPath(element: AppHostItem): Promise<void> {
@@ -746,12 +746,10 @@ export class AspireAppHostTreeProvider implements vscode.TreeDataProvider<TreeEl
         vscode.commands.executeCommand('simpleBrowser.show', element.url);
     }
 
-    private _runResourceCommand(element: ResourceItem, command: string, ...extraArgs: string[]): void {
-        const additionalArgs = extraArgs.length > 0 ? extraArgs : undefined;
-
+    private _runResourceCommand(element: ResourceItem, command: string, additionalArgs?: string[], redactAdditionalArgs = false): void {
         if (this._repository.viewMode === 'workspace') {
             const appHostFlag = this._repository.workspaceAppHostPath ? ` --apphost "${this._repository.workspaceAppHostPath}"` : '';
-            this._terminalProvider.sendAspireCommandToAspireTerminal(`resource "${element.resource.name}" ${command}${appHostFlag}`, true, additionalArgs);
+            this._terminalProvider.sendAspireCommandToAspireTerminal(`resource "${element.resource.name}" ${command}${appHostFlag}`, true, additionalArgs, { redactAdditionalArgs });
             return;
         }
 
@@ -759,7 +757,7 @@ export class AspireAppHostTreeProvider implements vscode.TreeDataProvider<TreeEl
         if (!appHost) {
             return;
         }
-        this._terminalProvider.sendAspireCommandToAspireTerminal(`resource "${element.resource.name}" ${command} --apphost "${appHost.appHostPath}"`, true, additionalArgs);
+        this._terminalProvider.sendAspireCommandToAspireTerminal(`resource "${element.resource.name}" ${command} --apphost "${appHost.appHostPath}"`, true, additionalArgs, { redactAdditionalArgs });
     }
 
     private _findAppHostForResource(element: ResourceItem): AppHostDisplayInfo | undefined {

--- a/extension/src/views/ResourceCommandArguments.ts
+++ b/extension/src/views/ResourceCommandArguments.ts
@@ -22,6 +22,8 @@ interface ResourceCommandChoiceItem extends vscode.QuickPickItem {
     value: string;
 }
 
+// Resource command number inputs are forwarded to the CLI, which parses them with invariant culture.
+// Accept examples like "1", "-1", and "1.5"; reject locale-specific values like "1,5".
 const numberPattern = /^-?\d+(\.\d+)?$/;
 
 export async function collectResourceCommandArguments(commandName: string, command: ResourceCommandJson | undefined): Promise<string[] | undefined> {

--- a/extension/src/views/ResourceCommandArguments.ts
+++ b/extension/src/views/ResourceCommandArguments.ts
@@ -3,6 +3,7 @@ import {
     fieldRequired,
     noLabel,
     resourceCommandArgumentsTitle,
+    resourceCommandArgumentInputTitle,
     resourceCommandContinue,
     resourceCommandCustomChoice,
     resourceCommandCustomChoiceDescription,
@@ -52,11 +53,11 @@ export async function collectResourceCommandArguments(commandName: string, comma
     }
 
     const values: ResourceCommandArgumentValue[] = [];
-    const title = resourceCommandArgumentsTitle(commandName);
+    const commandTitle = resourceCommandArgumentsTitle(commandName);
 
     for (let i = 0; i < inputs.length; i++) {
         const input = inputs[i];
-        const value = await promptForArgumentValue(title, input, i + 1, inputs.length);
+        const value = await promptForArgumentValue(commandTitle, input, i + 1, inputs.length);
         if (value === undefined) {
             return undefined;
         }
@@ -153,7 +154,7 @@ async function promptForTextArgument(title: string, input: ResourceCommandArgume
         const inputBox = vscode.window.createInputBox();
         let settled = false;
 
-        inputBox.title = title;
+        inputBox.title = getArgumentInputTitle(title, input);
         inputBox.step = step;
         inputBox.totalSteps = totalSteps;
         inputBox.value = input.value ?? '';
@@ -197,7 +198,7 @@ async function promptForBooleanArgument(title: string, input: ResourceCommandArg
         const quickPick = vscode.window.createQuickPick<ResourceCommandChoiceItem>();
         let settled = false;
 
-        quickPick.title = title;
+        quickPick.title = getArgumentInputTitle(title, input);
         quickPick.step = step;
         quickPick.totalSteps = totalSteps;
         quickPick.placeholder = input.placeholder ?? getArgumentPrompt(input);
@@ -229,7 +230,7 @@ async function promptForChoiceArgument(title: string, input: ResourceCommandArgu
         const quickPick = vscode.window.createQuickPick<ResourceCommandChoiceItem>();
         let settled = false;
 
-        quickPick.title = title;
+        quickPick.title = getArgumentInputTitle(title, input);
         quickPick.step = step;
         quickPick.totalSteps = totalSteps;
         quickPick.placeholder = input.placeholder ?? getArgumentPrompt(input);
@@ -337,6 +338,10 @@ function shouldSubmitValue(input: ResourceCommandArgumentInputJson, value: strin
 
 function getArgumentPrompt(input: ResourceCommandArgumentInputJson): string {
     return input.description ?? getArgumentLabel(input);
+}
+
+function getArgumentInputTitle(commandTitle: string, input: ResourceCommandArgumentInputJson): string {
+    return resourceCommandArgumentInputTitle(commandTitle, getArgumentLabel(input));
 }
 
 function getArgumentLabel(input: ResourceCommandArgumentInputJson): string {

--- a/extension/src/views/ResourceCommandArguments.ts
+++ b/extension/src/views/ResourceCommandArguments.ts
@@ -23,6 +23,10 @@ interface ResourceCommandChoiceItem extends vscode.QuickPickItem {
     value: string;
 }
 
+interface SecretWarningItem extends vscode.QuickPickItem {
+    suppressFutureWarnings: boolean;
+}
+
 export const resourceCommandSecretWarningSuppressedKey = 'resourceCommandArguments.secretWarningSuppressed';
 
 export interface ResourceCommandArgumentOptions {
@@ -68,18 +72,25 @@ export async function confirmSecretArgumentWarning(secretWarningState: vscode.Me
         return true;
     }
 
-    const result = await vscode.window.showWarningMessage(
-        resourceCommandSecretWarning,
-        { modal: true },
-        resourceCommandContinue,
-        resourceCommandDontShowAgain);
+    const continueItem: SecretWarningItem = { label: resourceCommandContinue, suppressFutureWarnings: false };
+    const dontShowAgainItem: SecretWarningItem = { label: resourceCommandDontShowAgain, suppressFutureWarnings: true };
 
-    if (result === resourceCommandDontShowAgain) {
+    // Keep this warning in the QuickInput flow instead of a notification toast. Resource commands
+    // already prompt for arguments here, and using a toast as a blocking pre-prompt can leave a
+    // stale notification visible when focus immediately moves into the next input.
+    const result = await vscode.window.showQuickPick(
+        [continueItem, dontShowAgainItem],
+        {
+            title: resourceCommandSecretWarning,
+            ignoreFocusOut: true,
+        });
+
+    if (result?.suppressFutureWarnings) {
         await secretWarningState?.update(resourceCommandSecretWarningSuppressedKey, true);
         return true;
     }
 
-    return result === resourceCommandContinue;
+    return result !== undefined;
 }
 
 export function hasSecretResourceCommandArguments(command: ResourceCommandJson | undefined): boolean {

--- a/extension/src/views/ResourceCommandArguments.ts
+++ b/extension/src/views/ResourceCommandArguments.ts
@@ -1,0 +1,283 @@
+import * as vscode from 'vscode';
+import {
+    fieldRequired,
+    noLabel,
+    resourceCommandArgumentsTitle,
+    resourceCommandContinue,
+    resourceCommandCustomChoice,
+    resourceCommandCustomChoiceDescription,
+    resourceCommandInvalidNumber,
+    resourceCommandMaxLength,
+    resourceCommandSecretWarning,
+    yesLabel,
+} from '../loc/strings';
+import { ResourceCommandArgumentInputJson, ResourceCommandJson } from './AppHostDataRepository';
+
+export interface ResourceCommandArgumentValue {
+    input: ResourceCommandArgumentInputJson;
+    value: string;
+}
+
+interface ResourceCommandChoiceItem extends vscode.QuickPickItem {
+    value: string;
+}
+
+const numberPattern = /^-?\d+(\.\d+)?$/;
+
+export async function collectResourceCommandArguments(commandName: string, command: ResourceCommandJson | undefined): Promise<string[] | undefined> {
+    const inputs = command?.argumentInputs?.filter(input => !input.disabled) ?? [];
+    if (inputs.length === 0) {
+        return [];
+    }
+
+    if (inputs.some(input => input.inputType === 'SecretText')) {
+        const result = await vscode.window.showWarningMessage(resourceCommandSecretWarning, { modal: true }, resourceCommandContinue);
+        if (result !== resourceCommandContinue) {
+            return undefined;
+        }
+    }
+
+    const values: ResourceCommandArgumentValue[] = [];
+    const title = resourceCommandArgumentsTitle(commandName);
+
+    for (let i = 0; i < inputs.length; i++) {
+        const input = inputs[i];
+        const value = await promptForArgumentValue(title, input, i + 1, inputs.length);
+        if (value === undefined) {
+            return undefined;
+        }
+
+        values.push({ input, value });
+    }
+
+    return buildResourceCommandCliArgs(values);
+}
+
+export function buildResourceCommandCliArgs(values: readonly ResourceCommandArgumentValue[]): string[] {
+    const args: string[] = [];
+
+    for (const { input, value } of values) {
+        if (!shouldSubmitValue(input, value)) {
+            continue;
+        }
+
+        const optionName = `--${input.name}`;
+        if (input.inputType === 'Boolean') {
+            args.push(`${optionName}=${value === 'true' ? 'true' : 'false'}`);
+        }
+        else {
+            args.push(optionName, value);
+        }
+    }
+
+    return args.length > 0 ? ['--', ...args] : [];
+}
+
+export function getResourceCommandArgumentValidationMessage(input: ResourceCommandArgumentInputJson, value: string): string | undefined {
+    if (input.required && input.inputType !== 'Boolean' && value.trim().length === 0) {
+        return fieldRequired;
+    }
+
+    if (input.maxLength !== null && input.maxLength !== undefined && value.length > input.maxLength) {
+        return resourceCommandMaxLength(input.maxLength);
+    }
+
+    if (input.inputType === 'Number' && value.trim().length > 0 && !numberPattern.test(value.trim())) {
+        return resourceCommandInvalidNumber;
+    }
+
+    return undefined;
+}
+
+async function promptForArgumentValue(title: string, input: ResourceCommandArgumentInputJson, step: number, totalSteps: number): Promise<string | undefined> {
+    switch (input.inputType) {
+        case 'Choice':
+            return promptForChoiceArgument(title, input, step, totalSteps);
+        case 'Boolean':
+            return promptForBooleanArgument(title, input, step, totalSteps);
+        case 'Text':
+        case 'SecretText':
+        case 'Number':
+            return promptForTextArgument(title, input, step, totalSteps);
+    }
+}
+
+async function promptForTextArgument(title: string, input: ResourceCommandArgumentInputJson, step: number, totalSteps: number): Promise<string | undefined> {
+    return new Promise<string | undefined>(resolve => {
+        const inputBox = vscode.window.createInputBox();
+        let settled = false;
+
+        inputBox.title = title;
+        inputBox.step = step;
+        inputBox.totalSteps = totalSteps;
+        inputBox.value = input.value ?? '';
+        inputBox.password = input.inputType === 'SecretText';
+        inputBox.prompt = getArgumentPrompt(input);
+        inputBox.placeholder = input.placeholder ?? getArgumentLabel(input);
+        inputBox.ignoreFocusOut = true;
+        inputBox.validationMessage = getResourceCommandArgumentValidationMessage(input, inputBox.value);
+
+        const finish = (value: string | undefined) => {
+            if (!settled) {
+                settled = true;
+                inputBox.dispose();
+                resolve(value);
+            }
+        };
+
+        inputBox.onDidChangeValue(value => {
+            inputBox.validationMessage = getResourceCommandArgumentValidationMessage(input, value);
+        });
+        inputBox.onDidAccept(() => {
+            const validationMessage = getResourceCommandArgumentValidationMessage(input, inputBox.value);
+            if (validationMessage) {
+                inputBox.validationMessage = validationMessage;
+                return;
+            }
+
+            finish(input.inputType === 'Number' ? inputBox.value.trim() : inputBox.value);
+        });
+        inputBox.onDidHide(() => finish(undefined));
+        inputBox.show();
+    });
+}
+
+async function promptForBooleanArgument(title: string, input: ResourceCommandArgumentInputJson, step: number, totalSteps: number): Promise<string | undefined> {
+    const trueItem: ResourceCommandChoiceItem = { label: yesLabel, value: 'true' };
+    const falseItem: ResourceCommandChoiceItem = { label: noLabel, value: 'false' };
+    const items = [trueItem, falseItem];
+
+    return new Promise<string | undefined>(resolve => {
+        const quickPick = vscode.window.createQuickPick<ResourceCommandChoiceItem>();
+        let settled = false;
+
+        quickPick.title = title;
+        quickPick.step = step;
+        quickPick.totalSteps = totalSteps;
+        quickPick.placeholder = input.placeholder ?? getArgumentPrompt(input);
+        quickPick.ignoreFocusOut = true;
+        quickPick.items = items;
+        quickPick.activeItems = [input.value?.toLowerCase() === 'true' ? trueItem : falseItem];
+
+        const finish = (value: string | undefined) => {
+            if (!settled) {
+                settled = true;
+                quickPick.dispose();
+                resolve(value);
+            }
+        };
+
+        quickPick.onDidAccept(() => finish((quickPick.selectedItems[0] ?? quickPick.activeItems[0])?.value));
+        quickPick.onDidHide(() => finish(undefined));
+        quickPick.show();
+    });
+}
+
+async function promptForChoiceArgument(title: string, input: ResourceCommandArgumentInputJson, step: number, totalSteps: number): Promise<string | undefined> {
+    const options = Object.entries(input.options ?? {});
+    if (options.length === 0 && input.allowCustomChoice) {
+        return promptForTextArgument(title, input, step, totalSteps);
+    }
+
+    return new Promise<string | undefined>(resolve => {
+        const quickPick = vscode.window.createQuickPick<ResourceCommandChoiceItem>();
+        let settled = false;
+
+        quickPick.title = title;
+        quickPick.step = step;
+        quickPick.totalSteps = totalSteps;
+        quickPick.placeholder = input.placeholder ?? getArgumentPrompt(input);
+        quickPick.ignoreFocusOut = true;
+        quickPick.matchOnDescription = true;
+        quickPick.items = createChoiceItems(input, quickPick.value);
+
+        const activeItem = findChoiceItem(input, quickPick.items);
+        if (activeItem) {
+            quickPick.activeItems = [activeItem];
+        }
+
+        const finish = (value: string | undefined) => {
+            if (!settled) {
+                settled = true;
+                quickPick.dispose();
+                resolve(value);
+            }
+        };
+
+        quickPick.onDidChangeValue(value => {
+            if (input.allowCustomChoice) {
+                quickPick.items = createChoiceItems(input, value);
+                if (quickPick.items.length > 0 && quickPick.items[0].description === resourceCommandCustomChoiceDescription) {
+                    quickPick.activeItems = [quickPick.items[0]];
+                }
+            }
+        });
+        quickPick.onDidAccept(() => {
+            const selected = quickPick.selectedItems[0] ?? quickPick.activeItems[0];
+            if (selected) {
+                finish(selected.value);
+                return;
+            }
+
+            if (input.allowCustomChoice) {
+                finish(quickPick.value);
+            }
+        });
+        quickPick.onDidHide(() => finish(undefined));
+        quickPick.show();
+    });
+}
+
+function createChoiceItems(input: ResourceCommandArgumentInputJson, customValue: string): ResourceCommandChoiceItem[] {
+    const optionItems = Object.entries(input.options ?? {}).map(([value, label]) => ({
+        label: label ?? value,
+        description: label ? value : undefined,
+        value,
+    }));
+
+    const trimmedCustomValue = customValue.trim();
+    if (!input.allowCustomChoice || trimmedCustomValue.length === 0) {
+        return optionItems;
+    }
+
+    const matchesExistingOption = optionItems.some(item =>
+        item.value.localeCompare(trimmedCustomValue, undefined, { sensitivity: 'accent' }) === 0 ||
+        item.label.localeCompare(trimmedCustomValue, undefined, { sensitivity: 'accent' }) === 0);
+
+    if (matchesExistingOption) {
+        return optionItems;
+    }
+
+    return [
+        {
+            label: resourceCommandCustomChoice(trimmedCustomValue),
+            description: resourceCommandCustomChoiceDescription,
+            value: trimmedCustomValue,
+        },
+        ...optionItems,
+    ];
+}
+
+function findChoiceItem(input: ResourceCommandArgumentInputJson, items: readonly ResourceCommandChoiceItem[]): ResourceCommandChoiceItem | undefined {
+    if (input.value) {
+        return items.find(item => item.value === input.value);
+    }
+
+    return !input.placeholder && !input.allowCustomChoice ? items[0] : undefined;
+}
+
+function shouldSubmitValue(input: ResourceCommandArgumentInputJson, value: string): boolean {
+    if (input.inputType === 'Boolean') {
+        return true;
+    }
+
+    return value.length > 0;
+}
+
+function getArgumentPrompt(input: ResourceCommandArgumentInputJson): string {
+    return input.description ?? getArgumentLabel(input);
+}
+
+function getArgumentLabel(input: ResourceCommandArgumentInputJson): string {
+    return input.label ?? input.name;
+}

--- a/extension/src/views/ResourceCommandArguments.ts
+++ b/extension/src/views/ResourceCommandArguments.ts
@@ -73,7 +73,9 @@ export function buildResourceCommandCliArgs(values: readonly ResourceCommandArgu
             args.push(`${optionName}=${value === 'true' ? 'true' : 'false'}`);
         }
         else {
-            args.push(optionName, value);
+            // Use --name=value so that values starting with '-' or '--' are not parsed by
+            // System.CommandLine as another option on the resource command.
+            args.push(`${optionName}=${value}`);
         }
     }
 
@@ -196,6 +198,11 @@ async function promptForChoiceArgument(title: string, input: ResourceCommandArgu
         quickPick.placeholder = input.placeholder ?? getArgumentPrompt(input);
         quickPick.ignoreFocusOut = true;
         quickPick.matchOnDescription = true;
+        // Seed the QuickPick value so a custom default that is not among the predefined options
+        // surfaces as the "Use custom value" item and is preselected.
+        if (input.allowCustomChoice && input.value) {
+            quickPick.value = input.value;
+        }
         quickPick.items = createChoiceItems(input, quickPick.value);
 
         const activeItem = findChoiceItem(input, quickPick.items);
@@ -278,7 +285,17 @@ function shouldSubmitValue(input: ResourceCommandArgumentInputJson, value: strin
         return true;
     }
 
-    return value.length > 0;
+    if (value.length > 0) {
+        return true;
+    }
+
+    // Empty number values cannot be parsed by the CLI, so fall back to the snapshot default.
+    if (input.inputType === 'Number') {
+        return false;
+    }
+
+    // The user cleared a prefilled value, so submit the empty string to override the snapshot default.
+    return (input.value ?? '').length > 0;
 }
 
 function getArgumentPrompt(input: ResourceCommandArgumentInputJson): string {

--- a/extension/src/views/ResourceCommandArguments.ts
+++ b/extension/src/views/ResourceCommandArguments.ts
@@ -8,6 +8,7 @@ import {
     resourceCommandCustomChoiceDescription,
     resourceCommandInvalidNumber,
     resourceCommandMaxLength,
+    resourceCommandDontShowAgain,
     resourceCommandSecretWarning,
     yesLabel,
 } from '../loc/strings';
@@ -22,20 +23,26 @@ interface ResourceCommandChoiceItem extends vscode.QuickPickItem {
     value: string;
 }
 
+export const resourceCommandSecretWarningSuppressedKey = 'resourceCommandArguments.secretWarningSuppressed';
+
+export interface ResourceCommandArgumentOptions {
+    secretWarningState?: vscode.Memento;
+}
+
 // Resource command number inputs are forwarded to hosting, which validates with
 // double.TryParse(NumberStyles.Float, InvariantCulture). Accept examples like "1",
 // "-1.5", ".5", and "1e3"; reject locale-specific values like "1,5".
 const numberPattern = /^[+-]?(?:(?:\d+(?:\.\d*)?)|(?:\.\d+))(?:[eE][+-]?\d+)?$/;
 
-export async function collectResourceCommandArguments(commandName: string, command: ResourceCommandJson | undefined): Promise<string[] | undefined> {
+export async function collectResourceCommandArguments(commandName: string, command: ResourceCommandJson | undefined, options?: ResourceCommandArgumentOptions): Promise<string[] | undefined> {
     const inputs = command?.argumentInputs?.filter(input => !input.disabled) ?? [];
     if (inputs.length === 0) {
         return [];
     }
 
     if (inputs.some(input => input.inputType === ResourceCommandInputType.SecretText)) {
-        const result = await vscode.window.showWarningMessage(resourceCommandSecretWarning, { modal: true }, resourceCommandContinue);
-        if (result !== resourceCommandContinue) {
+        const confirmed = await confirmSecretArgumentWarning(options?.secretWarningState);
+        if (!confirmed) {
             return undefined;
         }
     }
@@ -54,6 +61,25 @@ export async function collectResourceCommandArguments(commandName: string, comma
     }
 
     return buildResourceCommandCliArgs(values);
+}
+
+export async function confirmSecretArgumentWarning(secretWarningState: vscode.Memento | undefined): Promise<boolean> {
+    if (secretWarningState?.get<boolean>(resourceCommandSecretWarningSuppressedKey)) {
+        return true;
+    }
+
+    const result = await vscode.window.showWarningMessage(
+        resourceCommandSecretWarning,
+        { modal: true },
+        resourceCommandContinue,
+        resourceCommandDontShowAgain);
+
+    if (result === resourceCommandDontShowAgain) {
+        await secretWarningState?.update(resourceCommandSecretWarningSuppressedKey, true);
+        return true;
+    }
+
+    return result === resourceCommandContinue;
 }
 
 export function hasSecretResourceCommandArguments(command: ResourceCommandJson | undefined): boolean {

--- a/extension/src/views/ResourceCommandArguments.ts
+++ b/extension/src/views/ResourceCommandArguments.ts
@@ -43,6 +43,9 @@ export interface ResourceCommandArgumentOptions {
 const numberPattern = /^[+-]?(?:(?:\d+(?:\.\d*)?)|(?:\.\d+))(?:[eE][+-]?\d+)?$/;
 
 export async function collectResourceCommandArguments(commandName: string, command: ResourceCommandJson | undefined, options?: ResourceCommandArgumentOptions): Promise<string[] | undefined> {
+    // This flow only supports the static argumentInputs snapshot emitted by the CLI today. It
+    // does not re-query arguments or options while prompting, so dynamic inputs whose choices or
+    // validation depend on previously-entered values need a future protocol/UI change.
     const inputs = command?.argumentInputs?.filter(input => !input.disabled) ?? [];
     if (inputs.length === 0) {
         return [];

--- a/extension/src/views/ResourceCommandArguments.ts
+++ b/extension/src/views/ResourceCommandArguments.ts
@@ -337,7 +337,8 @@ function shouldSubmitValue(input: ResourceCommandArgumentInputJson, value: strin
 }
 
 function getArgumentPrompt(input: ResourceCommandArgumentInputJson): string {
-    return input.description ?? getArgumentLabel(input);
+    const label = getArgumentLabel(input);
+    return input.description ? resourceCommandArgumentInputTitle(label, input.description) : label;
 }
 
 function getArgumentInputTitle(commandTitle: string, input: ResourceCommandArgumentInputJson): string {

--- a/extension/src/views/ResourceCommandArguments.ts
+++ b/extension/src/views/ResourceCommandArguments.ts
@@ -11,7 +11,7 @@ import {
     resourceCommandSecretWarning,
     yesLabel,
 } from '../loc/strings';
-import { ResourceCommandArgumentInputJson, ResourceCommandJson } from './AppHostDataRepository';
+import { ResourceCommandArgumentInputJson, ResourceCommandInputType, ResourceCommandJson } from './AppHostDataRepository';
 
 export interface ResourceCommandArgumentValue {
     input: ResourceCommandArgumentInputJson;
@@ -33,7 +33,7 @@ export async function collectResourceCommandArguments(commandName: string, comma
         return [];
     }
 
-    if (inputs.some(input => input.inputType === 'SecretText')) {
+    if (inputs.some(input => input.inputType === ResourceCommandInputType.SecretText)) {
         const result = await vscode.window.showWarningMessage(resourceCommandSecretWarning, { modal: true }, resourceCommandContinue);
         if (result !== resourceCommandContinue) {
             return undefined;
@@ -57,7 +57,7 @@ export async function collectResourceCommandArguments(commandName: string, comma
 }
 
 export function hasSecretResourceCommandArguments(command: ResourceCommandJson | undefined): boolean {
-    return command?.argumentInputs?.some(input => !input.disabled && input.inputType === 'SecretText') ?? false;
+    return command?.argumentInputs?.some(input => !input.disabled && input.inputType === ResourceCommandInputType.SecretText) ?? false;
 }
 
 export function buildResourceCommandCliArgs(values: readonly ResourceCommandArgumentValue[]): string[] {
@@ -69,7 +69,7 @@ export function buildResourceCommandCliArgs(values: readonly ResourceCommandArgu
         }
 
         const optionName = `--${input.name}`;
-        if (input.inputType === 'Boolean') {
+        if (input.inputType === ResourceCommandInputType.Boolean) {
             args.push(`${optionName}=${value === 'true' ? 'true' : 'false'}`);
         }
         else {
@@ -83,7 +83,7 @@ export function buildResourceCommandCliArgs(values: readonly ResourceCommandArgu
 }
 
 export function getResourceCommandArgumentValidationMessage(input: ResourceCommandArgumentInputJson, value: string): string | undefined {
-    if (input.required && input.inputType !== 'Boolean' && value.trim().length === 0) {
+    if (input.required && input.inputType !== ResourceCommandInputType.Boolean && value.trim().length === 0) {
         return fieldRequired;
     }
 
@@ -91,7 +91,7 @@ export function getResourceCommandArgumentValidationMessage(input: ResourceComma
         return resourceCommandMaxLength(input.maxLength);
     }
 
-    if (input.inputType === 'Number' && value.trim().length > 0 && !numberPattern.test(value.trim())) {
+    if (input.inputType === ResourceCommandInputType.Number && value.trim().length > 0 && !numberPattern.test(value.trim())) {
         return resourceCommandInvalidNumber;
     }
 
@@ -100,13 +100,13 @@ export function getResourceCommandArgumentValidationMessage(input: ResourceComma
 
 async function promptForArgumentValue(title: string, input: ResourceCommandArgumentInputJson, step: number, totalSteps: number): Promise<string | undefined> {
     switch (input.inputType) {
-        case 'Choice':
+        case ResourceCommandInputType.Choice:
             return promptForChoiceArgument(title, input, step, totalSteps);
-        case 'Boolean':
+        case ResourceCommandInputType.Boolean:
             return promptForBooleanArgument(title, input, step, totalSteps);
-        case 'Text':
-        case 'SecretText':
-        case 'Number':
+        case ResourceCommandInputType.Text:
+        case ResourceCommandInputType.SecretText:
+        case ResourceCommandInputType.Number:
             return promptForTextArgument(title, input, step, totalSteps);
     }
 }
@@ -120,7 +120,7 @@ async function promptForTextArgument(title: string, input: ResourceCommandArgume
         inputBox.step = step;
         inputBox.totalSteps = totalSteps;
         inputBox.value = input.value ?? '';
-        inputBox.password = input.inputType === 'SecretText';
+        inputBox.password = input.inputType === ResourceCommandInputType.SecretText;
         inputBox.prompt = getArgumentPrompt(input);
         inputBox.placeholder = input.placeholder ?? getArgumentLabel(input);
         inputBox.ignoreFocusOut = true;
@@ -144,7 +144,7 @@ async function promptForTextArgument(title: string, input: ResourceCommandArgume
                 return;
             }
 
-            finish(input.inputType === 'Number' ? inputBox.value.trim() : inputBox.value);
+            finish(input.inputType === ResourceCommandInputType.Number ? inputBox.value.trim() : inputBox.value);
         });
         inputBox.onDidHide(() => finish(undefined));
         inputBox.show();
@@ -281,7 +281,7 @@ function findChoiceItem(input: ResourceCommandArgumentInputJson, items: readonly
 }
 
 function shouldSubmitValue(input: ResourceCommandArgumentInputJson, value: string): boolean {
-    if (input.inputType === 'Boolean') {
+    if (input.inputType === ResourceCommandInputType.Boolean) {
         return true;
     }
 
@@ -290,7 +290,7 @@ function shouldSubmitValue(input: ResourceCommandArgumentInputJson, value: strin
     }
 
     // Empty number values cannot be parsed by the CLI, so fall back to the snapshot default.
-    if (input.inputType === 'Number') {
+    if (input.inputType === ResourceCommandInputType.Number) {
         return false;
     }
 

--- a/extension/src/views/ResourceCommandArguments.ts
+++ b/extension/src/views/ResourceCommandArguments.ts
@@ -31,6 +31,9 @@ interface SecretWarningItem extends vscode.QuickPickItem {
 export const resourceCommandSecretWarningSuppressedKey = 'resourceCommandArguments.secretWarningSuppressed';
 
 export interface ResourceCommandArgumentOptions {
+    // Callers pass ExtensionContext.globalState here. The suppression is one extension-wide
+    // preference for the current VS Code profile on this machine, not per workspace, AppHost,
+    // project, resource, or command.
     secretWarningState?: vscode.Memento;
 }
 

--- a/extension/src/views/ResourceCommandArguments.ts
+++ b/extension/src/views/ResourceCommandArguments.ts
@@ -22,9 +22,10 @@ interface ResourceCommandChoiceItem extends vscode.QuickPickItem {
     value: string;
 }
 
-// Resource command number inputs are forwarded to the CLI, which parses them with invariant culture.
-// Accept examples like "1", "-1", and "1.5"; reject locale-specific values like "1,5".
-const numberPattern = /^-?\d+(\.\d+)?$/;
+// Resource command number inputs are forwarded to hosting, which validates with
+// double.TryParse(NumberStyles.Float, InvariantCulture). Accept examples like "1",
+// "-1.5", ".5", and "1e3"; reject locale-specific values like "1,5".
+const numberPattern = /^[+-]?(?:(?:\d+(?:\.\d*)?)|(?:\.\d+))(?:[eE][+-]?\d+)?$/;
 
 export async function collectResourceCommandArguments(commandName: string, command: ResourceCommandJson | undefined): Promise<string[] | undefined> {
     const inputs = command?.argumentInputs?.filter(input => !input.disabled) ?? [];
@@ -53,6 +54,10 @@ export async function collectResourceCommandArguments(commandName: string, comma
     }
 
     return buildResourceCommandCliArgs(values);
+}
+
+export function hasSecretResourceCommandArguments(command: ResourceCommandJson | undefined): boolean {
+    return command?.argumentInputs?.some(input => !input.disabled && input.inputType === 'SecretText') ?? false;
 }
 
 export function buildResourceCommandCliArgs(values: readonly ResourceCommandArgumentValue[]): string[] {

--- a/src/Shared/Model/Serialization/ResourceJson.cs
+++ b/src/Shared/Model/Serialization/ResourceJson.cs
@@ -232,6 +232,8 @@ internal sealed class ResourceCommandJson
 
 /// <summary>
 /// Represents a command invocation argument input in JSON format.
+/// Keep this contract in sync with the VS Code extension's ResourceCommandArgumentInputJson
+/// in extension/src/views/AppHostDataRepository.ts.
 /// </summary>
 internal sealed class ResourceCommandArgumentJson
 {


### PR DESCRIPTION
## Description

Adds VS Code extension support for Aspire resource commands that declare argument inputs. Previously, resource commands with required arguments could be invoked from the extension, but the extension had no native prompt flow for supplying those values, so commands like the Stress playground `validate-arguments` command ran without arguments and failed validation.

The extension now reads command `argumentInputs` from the Aspire CLI resource JSON, prompts with native VS Code QuickInput controls, and passes the collected values to `aspire resource` after the CLI pass-through delimiter. Both the Aspire resource tree command path and CodeLens custom command path use the shared argument collection helper.

### User-facing usage

When a resource command defines arguments, users are prompted in VS Code before the command is sent to the Aspire terminal. The prompt shows the command, the current argument label, and the argument description so users know which value they are entering. For example, the Stress playground `argument-commands` resource can collect:

```text
Target: stress-apiservice
Mode: success
Timeout seconds: 30
Require healthy: true
```

The extension sends the equivalent CLI invocation using pass-through arguments that preserve option-like values:

```bash
aspire resource "argument-commands" "validate-arguments" -- --target=stress-apiservice --mode=success --timeoutSeconds=30 --requireHealthy=true
```

Secret text inputs are masked while entered. Because values still execute through the Aspire terminal, the extension warns users that secret values may be visible in terminal history or scrollback; the warning is shown inside the QuickInput flow and supports `Don't show again` via extension global state.

Other UX details covered by this PR:

- Tree and CodeLens resource commands share the same argument prompting and CLI argument construction.
- Command/resource names are quoted consistently when sent to the Aspire terminal.
- The Aspire terminal is shown before command dispatch so fast failures are visible.
- Additional argument values are redacted from extension logs when a command has enabled secret inputs.

Validation:

- `cd extension && npm run compile-tests -- --pretty false && npm run lint -- --quiet && npx vscode-test --grep "ResourceCommandArguments"`
- `cd extension && npm run compile-tests -- --pretty false && npx vscode-test --grep "ResourceCommandArguments|AspireTerminalProvider"`
- `cd extension && npm run compile -- --mode development`
- VS Code Extension Host UI smoke for the Stress tree resource-command path using native QuickInput controls.
- VS Code Extension Host UI smoke for the Stress CodeLens resource-command path using native QuickInput controls.
- Manual VS Code Extension Development Host check against `playground/Stress` confirmed the argument label is visible in the prompt text.
- PR dogfood CLI version check and Stress tree/CodeLens smoke report: https://github.com/microsoft/aspire/pull/17187#issuecomment-4469844841

Fixes #16910

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
