### PR TITLE
Fix Component Governance warnings

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -184,10 +184,12 @@
     <PackageVersion Include="Microsoft.Azure.Functions.Worker.Extensions.DurableTask" Version="1.16.5" />
     <PackageVersion Include="Microsoft.Azure.Functions.Worker.Extensions.DurableTask.AzureManaged" Version="1.0.1" />
     <!-- playground apps dependencies for javascript -->
-    <PackageVersion Include="Swashbuckle.AspNetCore" Version="10.1.7" />
     <!-- Pinned versions for Component Governance - Remove when root dependencies are updated -->
     <PackageVersion Include="Azure.Core" Version="1.55.0" />
     <PackageVersion Include="Azure.Identity" Version="1.21.0" />
+    <!-- MongoDB.Driver pulls these compression packages transitively; pin them here until its dependency metadata no longer requests CG-flagged versions. -->
+    <PackageVersion Include="SharpCompress" Version="1.0.0" />
+    <PackageVersion Include="Snappier" Version="1.3.1" />
     <!-- https://github.com/Azure/azure-cosmos-dotnet-v3/pull/3313 -->
     <PackageVersion Include="Newtonsoft.Json" Version="13.0.4" />
   </ItemGroup>

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "10.0.201",
+    "version": "10.0.300",
     "rollForward": "major",
     "allowPrerelease": true,
     "paths": [
@@ -10,7 +10,7 @@
     "errorMessage": "The .NET SDK could not be found. Run ./restore.sh (Linux/macOS) or ./restore.cmd (Windows) to install the local SDK."
   },
   "tools": {
-    "dotnet": "10.0.201",
+    "dotnet": "10.0.300",
     "runtimes": {
       "dotnet/x64": [
         "$(DotNetRuntimePreviousVersionForTesting)",

--- a/playground/AspireWithJavaScript/AspireJavaScript.MinimalApi/AspireJavaScript.MinimalApi.csproj
+++ b/playground/AspireWithJavaScript/AspireJavaScript.MinimalApi/AspireJavaScript.MinimalApi.csproj
@@ -9,7 +9,6 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.OpenApi" />
-    <PackageReference Include="Swashbuckle.AspNetCore" />
   </ItemGroup>
 
   <ItemGroup>

--- a/playground/PostgresEndToEnd/PostgresEndToEnd.JavaService/pom.xml
+++ b/playground/PostgresEndToEnd/PostgresEndToEnd.JavaService/pom.xml
@@ -13,59 +13,38 @@
         <maven.compiler.source>17</maven.compiler.source>
         <maven.compiler.target>17</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <netty.version>4.1.133.Final</netty.version>
+        <reactor-netty.version>1.2.17</reactor-netty.version>
     </properties>
-
-    <repositories>
-        <repository>
-            <id>central</id>
-            <url>https://repo.maven.apache.org/maven2</url>
-        </repository>
-    </repositories>
-
-    <pluginRepositories>
-        <pluginRepository>
-            <id>central</id>
-            <url>https://repo.maven.apache.org/maven2</url>
-        </pluginRepository>
-    </pluginRepositories>
 
     <dependencyManagement>
         <dependencies>
             <!--
-                These overrides pin transitive versions brought in by azure-identity (via azure-core,
-                msal4j, reactor-netty, etc.) and the PostgreSQL JDBC driver. They exist so Component
-                Governance sees the patched versions rather than whatever older versions the upstream
-                BOMs would otherwise resolve.
+                These overrides pin transitive versions brought in by azure-identity, Javalin,
+                and the PostgreSQL JDBC driver so Component Governance sees patched versions
+                rather than older versions from upstream dependency metadata.
             -->
+            <dependency>
+                <groupId>io.netty</groupId>
+                <artifactId>netty-bom</artifactId>
+                <version>${netty.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
             <dependency>
                 <groupId>org.postgresql</groupId>
                 <artifactId>postgresql</artifactId>
                 <version>42.7.11</version>
             </dependency>
             <dependency>
-                <groupId>io.netty</groupId>
-                <artifactId>netty-codec-http2</artifactId>
-                <version>4.1.133.Final</version>
-            </dependency>
-            <dependency>
-                <groupId>com.nimbusds</groupId>
-                <artifactId>nimbus-jose-jwt</artifactId>
-                <version>9.48</version>
-            </dependency>
-            <dependency>
                 <groupId>io.projectreactor.netty</groupId>
                 <artifactId>reactor-netty-core</artifactId>
-                <version>1.0.48</version>
+                <version>${reactor-netty.version}</version>
             </dependency>
             <dependency>
                 <groupId>io.projectreactor.netty</groupId>
                 <artifactId>reactor-netty-http</artifactId>
-                <version>1.0.48</version>
-            </dependency>
-            <dependency>
-                <groupId>io.netty</groupId>
-                <artifactId>netty-handler</artifactId>
-                <version>4.1.133.Final</version>
+                <version>${reactor-netty.version}</version>
             </dependency>
         </dependencies>
     </dependencyManagement>


### PR DESCRIPTION
## Description

AzDO pipeline 1602 was still reporting Component Governance and CFS warnings after the previous cleanup because a few build inputs were still pinned to flagged versions or resolving vulnerable transitives from upstream dependency metadata.

This change updates those inputs without adding new direct dependencies:

- Bumps the repo-local .NET SDK/toolset from 10.0.201 to 10.0.300 so CG no longer reports the older SDK/runtime component.
- Removes unused Swashbuckle from the JavaScript playground project, which removes the associated SwaggerUI component alert. The project does not call Swashbuckle APIs such as `AddSwaggerGen`, `UseSwagger`, `UseSwaggerUI`, or `WithOpenApi`; it only retains the template Swagger comment and the existing `Microsoft.AspNetCore.OpenApi` reference.
- Pins the MongoDB.Driver compression transitives (`SharpCompress` and `Snappier`) through NuGet Central Package Management transitive pinning, with comments explaining why they are present.
- Updates the Java playground dependency management to use the Netty BOM and Azure-compatible Reactor Netty 1.2 line, removes the stale Nimbus override, and removes explicit Maven Central repository declarations so CI relies on the configured feed/mirror policy.

Validation:

- `restore.cmd`
- `build.cmd /p:SkipNativeBuild=true`
- `dotnet build playground\AspireWithJavaScript\AspireJavaScript.MinimalApi\AspireJavaScript.MinimalApi.csproj --no-restore /p:SkipNativeBuild=true`
- `dotnet list Aspire.slnx package --include-transitive` confirmed `SharpCompress 1.0.0` and `Snappier 1.3.1` resolve.

Fixes # (issue)

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [x] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No