### PR TITLE
Use OrdinalIgnoreCase for EnvironmentVariableName comparer

### DIFF
--- a/src/Shared/StringComparers.cs
+++ b/src/Shared/StringComparers.cs
@@ -17,7 +17,7 @@ internal static class StringComparers
     public static StringComparer ResourceOwnerKind => StringComparer.Ordinal;
     public static StringComparer ResourceOwnerUid => StringComparer.Ordinal;
     public static StringComparer UserTextSearch => StringComparer.CurrentCultureIgnoreCase;
-    public static StringComparer EnvironmentVariableName => StringComparer.InvariantCultureIgnoreCase;
+    public static StringComparer EnvironmentVariableName => StringComparer.OrdinalIgnoreCase;
     public static StringComparer Url => StringComparer.OrdinalIgnoreCase;
     public static StringComparer UrlPath => StringComparer.OrdinalIgnoreCase;
     public static StringComparer UrlHost => StringComparer.OrdinalIgnoreCase;
@@ -49,7 +49,7 @@ internal static class StringComparisons
     public static StringComparison ResourceOwnerKind => StringComparison.Ordinal;
     public static StringComparison ResourceOwnerUid => StringComparison.Ordinal;
     public static StringComparison UserTextSearch => StringComparison.CurrentCultureIgnoreCase;
-    public static StringComparison EnvironmentVariableName => StringComparison.InvariantCultureIgnoreCase;
+    public static StringComparison EnvironmentVariableName => StringComparison.OrdinalIgnoreCase;
     public static StringComparison Url => StringComparison.OrdinalIgnoreCase;
     public static StringComparison UrlPath => StringComparison.OrdinalIgnoreCase;
     public static StringComparison UrlHost => StringComparison.OrdinalIgnoreCase;


### PR DESCRIPTION
## Description

`EnvironmentVariableName` in `StringComparers` and `StringComparisons` was using `InvariantCultureIgnoreCase`, while every other non-culture-sensitive comparer in the file uses `OrdinalIgnoreCase`.

Environment variable names are programmatic ASCII identifiers, not user-facing text. `InvariantCultureIgnoreCase` adds unnecessary linguistic case-folding overhead (e.g., Turkish İ/ı rules) with no benefit over `OrdinalIgnoreCase`, which is faster and consistent with how the .NET runtime itself handles env var lookups on Windows.

## Changes

- Changed `StringComparers.EnvironmentVariableName` from `InvariantCultureIgnoreCase` to `OrdinalIgnoreCase`
- Changed `StringComparisons.EnvironmentVariableName` from `InvariantCultureIgnoreCase` to `OrdinalIgnoreCase`