### PR TITLE
Calculate VerticalThreshold dynamically based on menu/popover content

### DIFF
--- a/src/Aspire.Dashboard/Components/Controls/AspireMenu.razor
+++ b/src/Aspire.Dashboard/Components/Controls/AspireMenu.razor
@@ -3,7 +3,7 @@
 @inherits FluentComponentBase
 
 @* aspire-menu-container is added to the div parent of FluentMenu, not the FluentMenu *@
-<FluentMenu Class="aspire-menu-container" @ref="_menu" Anchor="@Anchor" Anchored="@Anchored" Open="@Open" OpenChanged="OnOpenChanged" Style="@Style" VerticalThreshold="@VerticalThreshold" HorizontalThreshold="200">
+<FluentMenu Class="aspire-menu-container" @ref="_menu" Anchor="@Anchor" Anchored="@Anchored" Open="@Open" OpenChanged="OnOpenChanged" Style="@Style" VerticalThreshold="@CalculatedVerticalThreshold" HorizontalThreshold="200">
     @foreach (var item in Items)
     {
         @RenderMenuItem(item)

--- a/src/Aspire.Dashboard/Components/Controls/AspireMenu.razor.cs
+++ b/src/Aspire.Dashboard/Components/Controls/AspireMenu.razor.cs
@@ -22,7 +22,7 @@ public partial class AspireMenu : FluentComponentBase
     public bool Anchored { get; set; } = true;
 
     [Parameter]
-    public int VerticalThreshold { get; set; } = 200;
+    public int? VerticalThreshold { get; set; }
 
     /// <summary>
     /// Raised when the <see cref="Open"/> property changed.
@@ -32,6 +32,12 @@ public partial class AspireMenu : FluentComponentBase
 
     [Parameter]
     public required IReadOnlyList<MenuButtonItem> Items { get; set; }
+
+    // Each menu item is approximately 32px tall, plus 16px padding for the menu container.
+    private const int EstimatedItemHeight = 32;
+    private const int MenuVerticalPadding = 16;
+
+    private int CalculatedVerticalThreshold => VerticalThreshold ?? (Items.Count * EstimatedItemHeight + MenuVerticalPadding);
 
     public async Task CloseAsync()
     {
@@ -62,7 +68,7 @@ public partial class AspireMenu : FluentComponentBase
                 left = clientX;
             }
 
-            if (clientY + menu.VerticalThreshold > screenHeight)
+            if (clientY + CalculatedVerticalThreshold > screenHeight)
             {
                 bottom = screenHeight - clientY;
             }

--- a/src/Aspire.Dashboard/Components/Controls/Chart/ChartFilters.razor
+++ b/src/Aspire.Dashboard/Components/Controls/Chart/ChartFilters.razor
@@ -55,7 +55,8 @@
                                       Appearance="@(context.AreAllValuesSelected is true ? Appearance.Stealth : Appearance.Accent)"
                                       @onclick="() => context.PopupVisible = !context.PopupVisible"
                                       aria-label="@(context.AreAllValuesSelected is true ? Loc[nameof(ControlsStrings.ChartContainerAllTags)] : Loc[nameof(ControlsStrings.ChartContainerFilteredTags)])"/>
-                        <FluentPopover AnchorId="@id" @bind-Open="context.PopupVisible" VerticalThreshold="200" AutoFocus="false">
+                        @* Each item is approximately 36px tall, plus 48px for the header and container padding. The popover body has a CSS max-height of 300px. *@
+                        <FluentPopover AnchorId="@id" @bind-Open="context.PopupVisible" VerticalThreshold="@(Math.Min(context.Values.Count * 36 + 48, 300))" AutoFocus="false">
                             <Header>@context.Name</Header>
                             <Body>
                             <FluentStack Orientation="Orientation.Vertical" Class="dimension-popup">

--- a/src/Aspire.Dashboard/Components/Controls/Chart/ChartFilters.razor
+++ b/src/Aspire.Dashboard/Components/Controls/Chart/ChartFilters.razor
@@ -55,8 +55,8 @@
                                       Appearance="@(context.AreAllValuesSelected is true ? Appearance.Stealth : Appearance.Accent)"
                                       @onclick="() => context.PopupVisible = !context.PopupVisible"
                                       aria-label="@(context.AreAllValuesSelected is true ? Loc[nameof(ControlsStrings.ChartContainerAllTags)] : Loc[nameof(ControlsStrings.ChartContainerFilteredTags)])"/>
-                        @* Each item is approximately 36px tall, plus 48px for the header and container padding. The popover body has a CSS max-height of 300px. *@
-                        <FluentPopover AnchorId="@id" @bind-Open="context.PopupVisible" VerticalThreshold="@(Math.Min(context.Values.Count * 36 + 48, 300))" AutoFocus="false">
+                        @* Each item is approximately 36px tall, plus 48px for the header and container padding. Include the always-rendered "All" checkbox row. The popover body has a CSS max-height of 300px. *@
+                        <FluentPopover AnchorId="@id" @bind-Open="context.PopupVisible" VerticalThreshold="@(Math.Min((context.Values.Count + 1) * 36 + 48, 300))" AutoFocus="false">
                             <Header>@context.Name</Header>
                             <Body>
                             <FluentStack Orientation="Orientation.Vertical" Class="dimension-popup">

--- a/src/Aspire.Dashboard/Components/Pages/Metrics.razor.css
+++ b/src/Aspire.Dashboard/Components/Pages/Metrics.razor.css
@@ -73,17 +73,20 @@
     margin-bottom: 15px;
 }
 
-::deep .dimension-popup {
-    max-width: 500px;
+::deep .fluent-popover-content {
+    overflow-wrap: normal;
+    word-break: normal;
+    max-height: 300px;
+    overflow-y: auto;
+    max-width: 400px;
     min-width: 100px;
     overflow-x: hidden;
 }
 
-::deep .fluent-popover-content {
-    overflow-wrap: normal;
-    word-break: normal;
-    max-height: 400px;
-    overflow-y: auto;
+::deep .fluent-popover-content div[part="header"] {
+    font-size: 16px;
+    line-height: normal;
+    margin-bottom: 8px;
 }
 
 ::deep .metrics-tree {

--- a/src/Aspire.Dashboard/Components/Pages/Resources.razor
+++ b/src/Aspire.Dashboard/Components/Pages/Resources.razor
@@ -251,7 +251,7 @@
                         </div>
                     </div>
                     <FluentOverlay @bind-Visible="_contextMenuOpen" OnClose="ContextMenuClosed" Transparent="true" FullScreen="true" />
-                    <AspireMenu @bind-Open="_contextMenuOpen" @ref="_contextMenu" Anchor="resources-summary-layout-id" Anchored="false" Items="_contextMenuItems" VerticalThreshold="300" />
+                    <AspireMenu @bind-Open="_contextMenuOpen" @ref="_contextMenu" Anchor="resources-summary-layout-id" Anchored="false" Items="_contextMenuItems" />
                 </Summary>
                 <Details>
                     <ResourceDetails Resource="context"

--- a/src/Aspire.Dashboard/Components/ResourcesGridColumns/UrlsColumnDisplay.razor
+++ b/src/Aspire.Dashboard/Components/ResourcesGridColumns/UrlsColumnDisplay.razor
@@ -35,7 +35,8 @@ else if (DisplayedUrls.Count > 1)
                 var items = overflow.ItemsOverflow.ToList();
             }
             <div @onclick:stopPropagation="true">
-                <FluentPopover AnchorId="@overflow.IdMoreButton" @bind-Open="_popoverVisible" VerticalThreshold="200" AutoFocus="false">
+                @* Each item is approximately 36px tall, plus 48px for the header and container padding. The popover body has a CSS max-height of 400px. *@
+                <FluentPopover AnchorId="@overflow.IdMoreButton" @bind-Open="_popoverVisible" VerticalThreshold="@(Math.Min(items.Count * 36 + 48, 300))" AutoFocus="false">
                     <Header>
                         @Loc[nameof(Resources.Columns.UrlsColumnDisplayOverflowTitle)]
                     </Header>

--- a/src/Aspire.Dashboard/Components/ResourcesGridColumns/UrlsColumnDisplay.razor
+++ b/src/Aspire.Dashboard/Components/ResourcesGridColumns/UrlsColumnDisplay.razor
@@ -35,7 +35,7 @@ else if (DisplayedUrls.Count > 1)
                 var items = overflow.ItemsOverflow.ToList();
             }
             <div @onclick:stopPropagation="true">
-                @* Each item is approximately 36px tall, plus 48px for the header and container padding. The popover body has a CSS max-height of 400px. *@
+                @* Each item is approximately 36px tall, plus 48px for the header and container padding. The popover body has a CSS max-height of 300px. *@
                 <FluentPopover AnchorId="@overflow.IdMoreButton" @bind-Open="_popoverVisible" VerticalThreshold="@(Math.Min(items.Count * 36 + 48, 300))" AutoFocus="false">
                     <Header>
                         @Loc[nameof(Resources.Columns.UrlsColumnDisplayOverflowTitle)]

--- a/src/Aspire.Dashboard/Components/ResourcesGridColumns/UrlsColumnDisplay.razor.css
+++ b/src/Aspire.Dashboard/Components/ResourcesGridColumns/UrlsColumnDisplay.razor.css
@@ -9,16 +9,23 @@
     text-overflow: ellipsis;
 }
 
-::deep.url-popup {
-    max-width: 500px;
-    max-height: 400px;
-    overflow-x: hidden;
-    overflow-y: auto;
-    padding: 5px 10px;
-}
-
 ::deep.url-link {
-    margin-bottom: 4px;
     overflow: hidden;
     text-overflow: ellipsis;
+}
+
+::deep .fluent-popover-content {
+    overflow-wrap: normal;
+    word-break: normal;
+    max-height: 300px;
+    overflow-y: auto;
+    max-width: 400px;
+    overflow-x: hidden;
+    cursor: default;
+}
+
+::deep .fluent-popover-content div[part="header"] {
+    font-size: 16px;
+    line-height: normal;
+    margin-bottom: 8px;
 }


### PR DESCRIPTION
## Summary

Instead of hardcoding `VerticalThreshold` values (200/300px), calculate them dynamically based on the number of items being displayed. This ensures menus and popovers correctly flip above the cursor when there isn't enough space below, regardless of how many items they contain.

## Changes

- **AspireMenu**: Changed `VerticalThreshold` from a hardcoded default (200) to a calculated value based on `Items.Count` (32px per item + 16px container padding). The parameter is now nullable — callers can still override explicitly if needed.
- **UrlsColumnDisplay**: Calculate threshold from overflow URL count (32px per link + 48px for header/padding). Also fixed inherited `cursor: pointer` leaking into popover content from the parent button.
- **ChartFilters**: Calculate threshold from filter values count (36px per checkbox + 48px for header/padding), capped at 448px to respect the CSS `max-height: 400px` on the popover body.
- **Resources.razor**: Removed hardcoded `VerticalThreshold="300"` since the dynamic calculation handles it.

Note that this won't fix submenus with many items, but that's a rare situation. That fix needs to happen in FluentUI: https://github.com/microsoft/fluentui-blazor/issues/4870

Fixes https://github.com/microsoft/aspire/issues/3137
Fixes https://github.com/microsoft/aspire/issues/15173
Fixes https://github.com/microsoft/aspire/issues/16894