### PR TITLE
Use grid layout in DisplayMessage/DisplayError for better text wrapping

### DIFF
--- a/src/Aspire.Cli/Commands/RenderCommand.cs
+++ b/src/Aspire.Cli/Commands/RenderCommand.cs
@@ -234,6 +234,11 @@ internal sealed class RenderCommand : BaseCommand
             InteractionService.DisplayMessage(emoji, $"DisplayMessage with {emoji.Name}");
         }
 
+        InteractionService.DisplayEmptyLine();
+        InteractionService.DisplayMessage(KnownEmojis.Rocket, "This is a much longer message that is designed to test how text wraps when the terminal window is narrow. It should wrap cleanly beneath the text column without pushing content under the emoji icon on the left side of the display.");
+        InteractionService.DisplayMessage(KnownEmojis.CheckMarkButton, "Successfully deployed the application to the remote environment. The deployment included 14 services, 3 databases, and 2 message brokers. All health checks passed and the application is now accepting traffic on the configured endpoints.");
+        InteractionService.DisplayError("Something went terribly wrong while attempting to connect to the remote application host. The connection timed out after 30 seconds. Please verify that the host is running and that the network configuration allows traffic on the specified port.");
+
         return CliExitCodes.Success;
     }
 
@@ -243,6 +248,10 @@ internal sealed class RenderCommand : BaseCommand
         InteractionService.DisplaySuccess("Operation completed successfully.");
         InteractionService.DisplaySubtleMessage("This is a subtle hint.");
         InteractionService.DisplayCancellationMessage();
+
+        InteractionService.DisplayEmptyLine();
+        InteractionService.DisplayError("Failed to resolve package 'Aspire.Hosting.Azure.CosmosDB' version 9.2.0. The package source 'https://api.nuget.org/v3/index.json' returned a 503 Service Unavailable response. Please check your network connection and try again, or configure an alternative package source in your NuGet.config file.");
+        InteractionService.DisplaySuccess("All 47 integration tests passed successfully across 3 target frameworks (net8.0, net9.0, net10.0). Total execution time: 2 minutes and 14 seconds. Code coverage increased from 78.3% to 82.1%.");
         return CliExitCodes.Success;
     }
 

--- a/src/Aspire.Cli/Interaction/ConsoleInteractionService.cs
+++ b/src/Aspire.Cli/Interaction/ConsoleInteractionService.cs
@@ -382,7 +382,21 @@ internal class ConsoleInteractionService : IInteractionService
         }
 
         var displayMessage = allowMarkup ? message : message.EscapeMarkup();
-        MessageConsole.MarkupLine(ConsoleHelpers.FormatEmojiPrefix(emoji, MessageConsole) + displayMessage);
+
+        // Use a grid to keep the icon in a fixed first column so long text wraps
+        // without pushing under the emoji prefix.
+        var grid = new Grid();
+        grid.AddColumn();
+        grid.AddColumn();
+        grid.Columns[0].NoWrap = true;
+        grid.Columns[0].Padding = new Padding(0);
+        grid.Columns[1].Padding = new Padding(0);
+
+        grid.AddRow(
+            new Markup(ConsoleHelpers.FormatEmojiPrefix(emoji, MessageConsole)),
+            new Markup(displayMessage));
+
+        MessageConsole.Write(grid);
     }
 
     public void DisplayPlainText(string message)


### PR DESCRIPTION
## Summary

Updates `DisplayMessage` and `DisplayError` in `ConsoleInteractionService` to use a two-column `Grid` layout (emoji in column 1, message text in column 2) so that long messages wrap cleanly beneath the text column without pushing content under the icon.

This matches the pattern used by `RenderQuoteToRenderable` in the markdown-to-Spectre converter.

<img width="1123" height="235" alt="image" src="https://github.com/user-attachments/assets/77beeb15-4e8b-42b4-8d22-5f7034810039" />

## Changes

- **ConsoleInteractionService.cs**: Replace `MarkupLine` with a `Grid` that places the emoji prefix in a fixed non-wrapping first column and the message in a second column that wraps naturally.
- **RenderCommand.cs**: Add long-text examples in `TestDisplayMessage` and `TestDisplayStyles` to exercise and demonstrate the improved wrapping behavior.

## Testing

All 3111 CLI tests pass (0 failures, 12 skipped platform-specific tests).