### PR TITLE
Improve AppHost compatibility error guidance

### DIFF
--- a/src/Aspire.Cli/Interaction/ConsoleInteractionService.cs
+++ b/src/Aspire.Cli/Interaction/ConsoleInteractionService.cs
@@ -8,6 +8,7 @@ using Aspire.Cli.Resources;
 using Aspire.Cli.Utils;
 using Aspire.Cli.Utils.Markdown;
 using Microsoft.Extensions.Logging;
+using Semver;
 using Spectre.Console;
 using Spectre.Console.Rendering;
 
@@ -354,16 +355,53 @@ internal class ConsoleInteractionService : IInteractionService
     public int DisplayIncompatibleVersionError(AppHostIncompatibleException ex, string appHostHostingVersion)
     {
         var cliInformationalVersion = VersionHelper.GetDefaultTemplateVersion();
+        var guidance = GetAppHostCompatibilityGuidance(appHostHostingVersion, cliInformationalVersion);
 
-        DisplayError(InteractionServiceStrings.AppHostNotCompatibleConsiderUpgrading);
+        DisplayError(guidance.Message);
         MessageConsole.WriteLine();
         MessageConsole.MarkupLine(
             $"\t[bold]{InteractionServiceStrings.AspireHostingSDKVersion}[/]: {appHostHostingVersion.EscapeMarkup()}");
         MessageConsole.MarkupLine($"\t[bold]{InteractionServiceStrings.AspireCLIVersion}[/]: {cliInformationalVersion.EscapeMarkup()}");
         MessageConsole.MarkupLine($"\t[bold]{InteractionServiceStrings.RequiredCapability}[/]: {ex.RequiredCapability.EscapeMarkup()}");
         MessageConsole.WriteLine();
+
+        if (guidance is { UpdateCommand: not null, UpdateMessage: not null })
+        {
+            MessageConsole.MarkupLine($"\t[bold]{guidance.UpdateMessage.EscapeMarkup()}[/]");
+            MessageConsole.MarkupLine($"\t{guidance.UpdateCommand.EscapeMarkup()}");
+            MessageConsole.WriteLine();
+        }
+
         return CliExitCodes.AppHostIncompatible;
     }
+
+    private static AppHostCompatibilityGuidance GetAppHostCompatibilityGuidance(string appHostHostingVersion, string cliInformationalVersion)
+    {
+        if (SemVersion.TryParse(appHostHostingVersion, SemVersionStyles.Any, out var appHostVersion) &&
+            SemVersion.TryParse(cliInformationalVersion, SemVersionStyles.Any, out var cliVersion))
+        {
+            var comparison = appHostVersion.ComparePrecedenceTo(cliVersion);
+            if (comparison < 0)
+            {
+                return new(
+                    InteractionServiceStrings.AppHostNotCompatibleUpdateAppHost,
+                    InteractionServiceStrings.AppHostPackageUpdateMessage,
+                    FormattableString.Invariant($"dotnet add package Aspire.Hosting --version {cliInformationalVersion}"));
+            }
+
+            if (comparison > 0)
+            {
+                return new(
+                    InteractionServiceStrings.AppHostNotCompatibleUpdateCli,
+                    InteractionServiceStrings.AspireCliUpdateMessage,
+                    FormattableString.Invariant($"dotnet tool update -g Aspire.Cli --version {appHostHostingVersion}"));
+            }
+        }
+
+        return new(InteractionServiceStrings.AppHostNotCompatibleConsiderUpgrading, null, null);
+    }
+
+    private sealed record AppHostCompatibilityGuidance(string Message, string? UpdateMessage, string? UpdateCommand);
 
     public void DisplayError(string errorMessage, bool allowMarkup = false)
     {

--- a/src/Aspire.Cli/Resources/InteractionServiceStrings.Designer.cs
+++ b/src/Aspire.Cli/Resources/InteractionServiceStrings.Designer.cs
@@ -70,6 +70,42 @@ namespace Aspire.Cli.Resources {
         }
 
         /// <summary>
+        ///   Looks up a localized string similar to The AppHost version is older than the Aspire CLI. Update the Aspire.Hosting package in the AppHost project..
+        /// </summary>
+        public static string AppHostNotCompatibleUpdateAppHost {
+            get {
+                return ResourceManager.GetString("AppHostNotCompatibleUpdateAppHost", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to The AppHost version is newer than the Aspire CLI. Update the Aspire CLI..
+        /// </summary>
+        public static string AppHostNotCompatibleUpdateCli {
+            get {
+                return ResourceManager.GetString("AppHostNotCompatibleUpdateCli", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to To update the AppHost package, run:.
+        /// </summary>
+        public static string AppHostPackageUpdateMessage {
+            get {
+                return ResourceManager.GetString("AppHostPackageUpdateMessage", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to To update the Aspire CLI when installed as a .NET tool, run:.
+        /// </summary>
+        public static string AspireCliUpdateMessage {
+            get {
+                return ResourceManager.GetString("AspireCliUpdateMessage", resourceCulture);
+            }
+        }
+
+        /// <summary>
         ///   Looks up a localized string similar to Aspire CLI Version.
         /// </summary>
         public static string AspireCLIVersion {

--- a/src/Aspire.Cli/Resources/InteractionServiceStrings.resx
+++ b/src/Aspire.Cli/Resources/InteractionServiceStrings.resx
@@ -124,6 +124,18 @@
   <data name="AppHostNotCompatibleConsiderUpgrading" xml:space="preserve">
     <value>The AppHost version is not compatible. Please upgrade the AppHost or Aspire CLI.</value>
   </data>
+  <data name="AppHostNotCompatibleUpdateAppHost" xml:space="preserve">
+    <value>The AppHost version is older than the Aspire CLI. Update the Aspire.Hosting package in the AppHost project.</value>
+  </data>
+  <data name="AppHostNotCompatibleUpdateCli" xml:space="preserve">
+    <value>The AppHost version is newer than the Aspire CLI. Update the Aspire CLI.</value>
+  </data>
+  <data name="AppHostPackageUpdateMessage" xml:space="preserve">
+    <value>To update the AppHost package, run:</value>
+  </data>
+  <data name="AspireCliUpdateMessage" xml:space="preserve">
+    <value>To update the Aspire CLI when installed as a .NET tool, run:</value>
+  </data>
   <data name="AspireHostingSDKVersion" xml:space="preserve">
     <value>Aspire.Hosting Version</value>
   </data>

--- a/src/Aspire.Cli/Resources/xlf/InteractionServiceStrings.cs.xlf
+++ b/src/Aspire.Cli/Resources/xlf/InteractionServiceStrings.cs.xlf
@@ -17,6 +17,21 @@
         <target state="needs-review-translation">Verze AppHost není kompatibilní. Upgradujte prosím hostitele aplikací nebo rozhraní příkazového řádku Aspire.</target>
         <note />
       </trans-unit>
+      <trans-unit id="AppHostNotCompatibleUpdateAppHost">
+        <source>The AppHost version is older than the Aspire CLI. Update the Aspire.Hosting package in the AppHost project.</source>
+        <target state="new">The AppHost version is older than the Aspire CLI. Update the Aspire.Hosting package in the AppHost project.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AppHostNotCompatibleUpdateCli">
+        <source>The AppHost version is newer than the Aspire CLI. Update the Aspire CLI.</source>
+        <target state="new">The AppHost version is newer than the Aspire CLI. Update the Aspire CLI.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AppHostPackageUpdateMessage">
+        <source>To update the AppHost package, run:</source>
+        <target state="new">To update the AppHost package, run:</target>
+        <note />
+      </trans-unit>
       <trans-unit id="AppHostShutDown">
         <source>The application shut down.</source>
         <target state="new">The application shut down.</target>
@@ -25,6 +40,11 @@
       <trans-unit id="AspireCLIVersion">
         <source>Aspire CLI Version</source>
         <target state="translated">Verze Aspire CLI</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AspireCliUpdateMessage">
+        <source>To update the Aspire CLI when installed as a .NET tool, run:</source>
+        <target state="new">To update the Aspire CLI when installed as a .NET tool, run:</target>
         <note />
       </trans-unit>
       <trans-unit id="AspireHostingSDKVersion">

--- a/src/Aspire.Cli/Resources/xlf/InteractionServiceStrings.de.xlf
+++ b/src/Aspire.Cli/Resources/xlf/InteractionServiceStrings.de.xlf
@@ -17,6 +17,21 @@
         <target state="needs-review-translation">Die AppHost-Version ist nicht kompatibel. Aktualisieren Sie den AppHost oder die Aspire-CLI.</target>
         <note />
       </trans-unit>
+      <trans-unit id="AppHostNotCompatibleUpdateAppHost">
+        <source>The AppHost version is older than the Aspire CLI. Update the Aspire.Hosting package in the AppHost project.</source>
+        <target state="new">The AppHost version is older than the Aspire CLI. Update the Aspire.Hosting package in the AppHost project.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AppHostNotCompatibleUpdateCli">
+        <source>The AppHost version is newer than the Aspire CLI. Update the Aspire CLI.</source>
+        <target state="new">The AppHost version is newer than the Aspire CLI. Update the Aspire CLI.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AppHostPackageUpdateMessage">
+        <source>To update the AppHost package, run:</source>
+        <target state="new">To update the AppHost package, run:</target>
+        <note />
+      </trans-unit>
       <trans-unit id="AppHostShutDown">
         <source>The application shut down.</source>
         <target state="new">The application shut down.</target>
@@ -25,6 +40,11 @@
       <trans-unit id="AspireCLIVersion">
         <source>Aspire CLI Version</source>
         <target state="translated">Aspire CLI-Version</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AspireCliUpdateMessage">
+        <source>To update the Aspire CLI when installed as a .NET tool, run:</source>
+        <target state="new">To update the Aspire CLI when installed as a .NET tool, run:</target>
         <note />
       </trans-unit>
       <trans-unit id="AspireHostingSDKVersion">

--- a/src/Aspire.Cli/Resources/xlf/InteractionServiceStrings.es.xlf
+++ b/src/Aspire.Cli/Resources/xlf/InteractionServiceStrings.es.xlf
@@ -17,6 +17,21 @@
         <target state="needs-review-translation">La versión de AppHost no es compatible. Actualice el apphost o la CLI de Aspire.</target>
         <note />
       </trans-unit>
+      <trans-unit id="AppHostNotCompatibleUpdateAppHost">
+        <source>The AppHost version is older than the Aspire CLI. Update the Aspire.Hosting package in the AppHost project.</source>
+        <target state="new">The AppHost version is older than the Aspire CLI. Update the Aspire.Hosting package in the AppHost project.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AppHostNotCompatibleUpdateCli">
+        <source>The AppHost version is newer than the Aspire CLI. Update the Aspire CLI.</source>
+        <target state="new">The AppHost version is newer than the Aspire CLI. Update the Aspire CLI.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AppHostPackageUpdateMessage">
+        <source>To update the AppHost package, run:</source>
+        <target state="new">To update the AppHost package, run:</target>
+        <note />
+      </trans-unit>
       <trans-unit id="AppHostShutDown">
         <source>The application shut down.</source>
         <target state="new">The application shut down.</target>
@@ -25,6 +40,11 @@
       <trans-unit id="AspireCLIVersion">
         <source>Aspire CLI Version</source>
         <target state="translated">Versión de la CLI de Aspire</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AspireCliUpdateMessage">
+        <source>To update the Aspire CLI when installed as a .NET tool, run:</source>
+        <target state="new">To update the Aspire CLI when installed as a .NET tool, run:</target>
         <note />
       </trans-unit>
       <trans-unit id="AspireHostingSDKVersion">

--- a/src/Aspire.Cli/Resources/xlf/InteractionServiceStrings.fr.xlf
+++ b/src/Aspire.Cli/Resources/xlf/InteractionServiceStrings.fr.xlf
@@ -17,6 +17,21 @@
         <target state="needs-review-translation">La version de l’AppHost n’est pas compatible. Veuillez mettre à jour l’AppHost ou l’interface CLI Aspire.</target>
         <note />
       </trans-unit>
+      <trans-unit id="AppHostNotCompatibleUpdateAppHost">
+        <source>The AppHost version is older than the Aspire CLI. Update the Aspire.Hosting package in the AppHost project.</source>
+        <target state="new">The AppHost version is older than the Aspire CLI. Update the Aspire.Hosting package in the AppHost project.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AppHostNotCompatibleUpdateCli">
+        <source>The AppHost version is newer than the Aspire CLI. Update the Aspire CLI.</source>
+        <target state="new">The AppHost version is newer than the Aspire CLI. Update the Aspire CLI.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AppHostPackageUpdateMessage">
+        <source>To update the AppHost package, run:</source>
+        <target state="new">To update the AppHost package, run:</target>
+        <note />
+      </trans-unit>
       <trans-unit id="AppHostShutDown">
         <source>The application shut down.</source>
         <target state="new">The application shut down.</target>
@@ -25,6 +40,11 @@
       <trans-unit id="AspireCLIVersion">
         <source>Aspire CLI Version</source>
         <target state="translated">Version de l’interface CLI Aspire</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AspireCliUpdateMessage">
+        <source>To update the Aspire CLI when installed as a .NET tool, run:</source>
+        <target state="new">To update the Aspire CLI when installed as a .NET tool, run:</target>
         <note />
       </trans-unit>
       <trans-unit id="AspireHostingSDKVersion">

--- a/src/Aspire.Cli/Resources/xlf/InteractionServiceStrings.it.xlf
+++ b/src/Aspire.Cli/Resources/xlf/InteractionServiceStrings.it.xlf
@@ -17,6 +17,21 @@
         <target state="needs-review-translation">La versione di AppHost non è compatibile. Aggiornare AppHost o l'interfaccia della riga di comando di Aspire.</target>
         <note />
       </trans-unit>
+      <trans-unit id="AppHostNotCompatibleUpdateAppHost">
+        <source>The AppHost version is older than the Aspire CLI. Update the Aspire.Hosting package in the AppHost project.</source>
+        <target state="new">The AppHost version is older than the Aspire CLI. Update the Aspire.Hosting package in the AppHost project.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AppHostNotCompatibleUpdateCli">
+        <source>The AppHost version is newer than the Aspire CLI. Update the Aspire CLI.</source>
+        <target state="new">The AppHost version is newer than the Aspire CLI. Update the Aspire CLI.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AppHostPackageUpdateMessage">
+        <source>To update the AppHost package, run:</source>
+        <target state="new">To update the AppHost package, run:</target>
+        <note />
+      </trans-unit>
       <trans-unit id="AppHostShutDown">
         <source>The application shut down.</source>
         <target state="new">The application shut down.</target>
@@ -25,6 +40,11 @@
       <trans-unit id="AspireCLIVersion">
         <source>Aspire CLI Version</source>
         <target state="translated">Versione dell'interfaccia della riga di comando Aspire</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AspireCliUpdateMessage">
+        <source>To update the Aspire CLI when installed as a .NET tool, run:</source>
+        <target state="new">To update the Aspire CLI when installed as a .NET tool, run:</target>
         <note />
       </trans-unit>
       <trans-unit id="AspireHostingSDKVersion">

--- a/src/Aspire.Cli/Resources/xlf/InteractionServiceStrings.ja.xlf
+++ b/src/Aspire.Cli/Resources/xlf/InteractionServiceStrings.ja.xlf
@@ -17,6 +17,21 @@
         <target state="needs-review-translation">AppHost のバージョンに互換性がありません。AppHost または Aspire CLI をアップグレードしてください。</target>
         <note />
       </trans-unit>
+      <trans-unit id="AppHostNotCompatibleUpdateAppHost">
+        <source>The AppHost version is older than the Aspire CLI. Update the Aspire.Hosting package in the AppHost project.</source>
+        <target state="new">The AppHost version is older than the Aspire CLI. Update the Aspire.Hosting package in the AppHost project.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AppHostNotCompatibleUpdateCli">
+        <source>The AppHost version is newer than the Aspire CLI. Update the Aspire CLI.</source>
+        <target state="new">The AppHost version is newer than the Aspire CLI. Update the Aspire CLI.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AppHostPackageUpdateMessage">
+        <source>To update the AppHost package, run:</source>
+        <target state="new">To update the AppHost package, run:</target>
+        <note />
+      </trans-unit>
       <trans-unit id="AppHostShutDown">
         <source>The application shut down.</source>
         <target state="new">The application shut down.</target>
@@ -25,6 +40,11 @@
       <trans-unit id="AspireCLIVersion">
         <source>Aspire CLI Version</source>
         <target state="translated">Aspire CLI バージョン</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AspireCliUpdateMessage">
+        <source>To update the Aspire CLI when installed as a .NET tool, run:</source>
+        <target state="new">To update the Aspire CLI when installed as a .NET tool, run:</target>
         <note />
       </trans-unit>
       <trans-unit id="AspireHostingSDKVersion">

--- a/src/Aspire.Cli/Resources/xlf/InteractionServiceStrings.ko.xlf
+++ b/src/Aspire.Cli/Resources/xlf/InteractionServiceStrings.ko.xlf
@@ -17,6 +17,21 @@
         <target state="needs-review-translation">AppHost 버전이 호환되지 않습니다. AppHost 또는 Aspire CLI를 업그레이드해 주세요.</target>
         <note />
       </trans-unit>
+      <trans-unit id="AppHostNotCompatibleUpdateAppHost">
+        <source>The AppHost version is older than the Aspire CLI. Update the Aspire.Hosting package in the AppHost project.</source>
+        <target state="new">The AppHost version is older than the Aspire CLI. Update the Aspire.Hosting package in the AppHost project.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AppHostNotCompatibleUpdateCli">
+        <source>The AppHost version is newer than the Aspire CLI. Update the Aspire CLI.</source>
+        <target state="new">The AppHost version is newer than the Aspire CLI. Update the Aspire CLI.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AppHostPackageUpdateMessage">
+        <source>To update the AppHost package, run:</source>
+        <target state="new">To update the AppHost package, run:</target>
+        <note />
+      </trans-unit>
       <trans-unit id="AppHostShutDown">
         <source>The application shut down.</source>
         <target state="new">The application shut down.</target>
@@ -25,6 +40,11 @@
       <trans-unit id="AspireCLIVersion">
         <source>Aspire CLI Version</source>
         <target state="translated">Aspire CLI 버전</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AspireCliUpdateMessage">
+        <source>To update the Aspire CLI when installed as a .NET tool, run:</source>
+        <target state="new">To update the Aspire CLI when installed as a .NET tool, run:</target>
         <note />
       </trans-unit>
       <trans-unit id="AspireHostingSDKVersion">

--- a/src/Aspire.Cli/Resources/xlf/InteractionServiceStrings.pl.xlf
+++ b/src/Aspire.Cli/Resources/xlf/InteractionServiceStrings.pl.xlf
@@ -17,6 +17,21 @@
         <target state="needs-review-translation">Wersja hosta AppHost jest niezgodna. Uaktualnij hosta AppHost lub interfejs wiersza polecenia platformy Aspire.</target>
         <note />
       </trans-unit>
+      <trans-unit id="AppHostNotCompatibleUpdateAppHost">
+        <source>The AppHost version is older than the Aspire CLI. Update the Aspire.Hosting package in the AppHost project.</source>
+        <target state="new">The AppHost version is older than the Aspire CLI. Update the Aspire.Hosting package in the AppHost project.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AppHostNotCompatibleUpdateCli">
+        <source>The AppHost version is newer than the Aspire CLI. Update the Aspire CLI.</source>
+        <target state="new">The AppHost version is newer than the Aspire CLI. Update the Aspire CLI.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AppHostPackageUpdateMessage">
+        <source>To update the AppHost package, run:</source>
+        <target state="new">To update the AppHost package, run:</target>
+        <note />
+      </trans-unit>
       <trans-unit id="AppHostShutDown">
         <source>The application shut down.</source>
         <target state="new">The application shut down.</target>
@@ -25,6 +40,11 @@
       <trans-unit id="AspireCLIVersion">
         <source>Aspire CLI Version</source>
         <target state="translated">Wersja interfejsu wiersza polecenia platformy Aspire</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AspireCliUpdateMessage">
+        <source>To update the Aspire CLI when installed as a .NET tool, run:</source>
+        <target state="new">To update the Aspire CLI when installed as a .NET tool, run:</target>
         <note />
       </trans-unit>
       <trans-unit id="AspireHostingSDKVersion">

--- a/src/Aspire.Cli/Resources/xlf/InteractionServiceStrings.pt-BR.xlf
+++ b/src/Aspire.Cli/Resources/xlf/InteractionServiceStrings.pt-BR.xlf
@@ -17,6 +17,21 @@
         <target state="needs-review-translation">A versão do AppHost não é compatível. Atualize o apphost ou o Aspire CLI.</target>
         <note />
       </trans-unit>
+      <trans-unit id="AppHostNotCompatibleUpdateAppHost">
+        <source>The AppHost version is older than the Aspire CLI. Update the Aspire.Hosting package in the AppHost project.</source>
+        <target state="new">The AppHost version is older than the Aspire CLI. Update the Aspire.Hosting package in the AppHost project.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AppHostNotCompatibleUpdateCli">
+        <source>The AppHost version is newer than the Aspire CLI. Update the Aspire CLI.</source>
+        <target state="new">The AppHost version is newer than the Aspire CLI. Update the Aspire CLI.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AppHostPackageUpdateMessage">
+        <source>To update the AppHost package, run:</source>
+        <target state="new">To update the AppHost package, run:</target>
+        <note />
+      </trans-unit>
       <trans-unit id="AppHostShutDown">
         <source>The application shut down.</source>
         <target state="new">The application shut down.</target>
@@ -25,6 +40,11 @@
       <trans-unit id="AspireCLIVersion">
         <source>Aspire CLI Version</source>
         <target state="translated">Versão da CLI do Aspire</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AspireCliUpdateMessage">
+        <source>To update the Aspire CLI when installed as a .NET tool, run:</source>
+        <target state="new">To update the Aspire CLI when installed as a .NET tool, run:</target>
         <note />
       </trans-unit>
       <trans-unit id="AspireHostingSDKVersion">

--- a/src/Aspire.Cli/Resources/xlf/InteractionServiceStrings.ru.xlf
+++ b/src/Aspire.Cli/Resources/xlf/InteractionServiceStrings.ru.xlf
@@ -17,6 +17,21 @@
         <target state="needs-review-translation">Версия AppHost несовместима. Обновите хост приложений или Aspire CLI.</target>
         <note />
       </trans-unit>
+      <trans-unit id="AppHostNotCompatibleUpdateAppHost">
+        <source>The AppHost version is older than the Aspire CLI. Update the Aspire.Hosting package in the AppHost project.</source>
+        <target state="new">The AppHost version is older than the Aspire CLI. Update the Aspire.Hosting package in the AppHost project.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AppHostNotCompatibleUpdateCli">
+        <source>The AppHost version is newer than the Aspire CLI. Update the Aspire CLI.</source>
+        <target state="new">The AppHost version is newer than the Aspire CLI. Update the Aspire CLI.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AppHostPackageUpdateMessage">
+        <source>To update the AppHost package, run:</source>
+        <target state="new">To update the AppHost package, run:</target>
+        <note />
+      </trans-unit>
       <trans-unit id="AppHostShutDown">
         <source>The application shut down.</source>
         <target state="new">The application shut down.</target>
@@ -25,6 +40,11 @@
       <trans-unit id="AspireCLIVersion">
         <source>Aspire CLI Version</source>
         <target state="translated">Версия CLI Aspire</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AspireCliUpdateMessage">
+        <source>To update the Aspire CLI when installed as a .NET tool, run:</source>
+        <target state="new">To update the Aspire CLI when installed as a .NET tool, run:</target>
         <note />
       </trans-unit>
       <trans-unit id="AspireHostingSDKVersion">

--- a/src/Aspire.Cli/Resources/xlf/InteractionServiceStrings.tr.xlf
+++ b/src/Aspire.Cli/Resources/xlf/InteractionServiceStrings.tr.xlf
@@ -17,6 +17,21 @@
         <target state="needs-review-translation">AppHost sürümü uyumlu değil. Lütfen AppHost veya Aspire CLI'yı yükseltin.</target>
         <note />
       </trans-unit>
+      <trans-unit id="AppHostNotCompatibleUpdateAppHost">
+        <source>The AppHost version is older than the Aspire CLI. Update the Aspire.Hosting package in the AppHost project.</source>
+        <target state="new">The AppHost version is older than the Aspire CLI. Update the Aspire.Hosting package in the AppHost project.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AppHostNotCompatibleUpdateCli">
+        <source>The AppHost version is newer than the Aspire CLI. Update the Aspire CLI.</source>
+        <target state="new">The AppHost version is newer than the Aspire CLI. Update the Aspire CLI.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AppHostPackageUpdateMessage">
+        <source>To update the AppHost package, run:</source>
+        <target state="new">To update the AppHost package, run:</target>
+        <note />
+      </trans-unit>
       <trans-unit id="AppHostShutDown">
         <source>The application shut down.</source>
         <target state="new">The application shut down.</target>
@@ -25,6 +40,11 @@
       <trans-unit id="AspireCLIVersion">
         <source>Aspire CLI Version</source>
         <target state="translated">Aspire CLI Sürümü</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AspireCliUpdateMessage">
+        <source>To update the Aspire CLI when installed as a .NET tool, run:</source>
+        <target state="new">To update the Aspire CLI when installed as a .NET tool, run:</target>
         <note />
       </trans-unit>
       <trans-unit id="AspireHostingSDKVersion">

--- a/src/Aspire.Cli/Resources/xlf/InteractionServiceStrings.zh-Hans.xlf
+++ b/src/Aspire.Cli/Resources/xlf/InteractionServiceStrings.zh-Hans.xlf
@@ -17,6 +17,21 @@
         <target state="needs-review-translation">AppHost 版本不兼容。请升级应用主机或 Aspire CLI。</target>
         <note />
       </trans-unit>
+      <trans-unit id="AppHostNotCompatibleUpdateAppHost">
+        <source>The AppHost version is older than the Aspire CLI. Update the Aspire.Hosting package in the AppHost project.</source>
+        <target state="new">The AppHost version is older than the Aspire CLI. Update the Aspire.Hosting package in the AppHost project.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AppHostNotCompatibleUpdateCli">
+        <source>The AppHost version is newer than the Aspire CLI. Update the Aspire CLI.</source>
+        <target state="new">The AppHost version is newer than the Aspire CLI. Update the Aspire CLI.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AppHostPackageUpdateMessage">
+        <source>To update the AppHost package, run:</source>
+        <target state="new">To update the AppHost package, run:</target>
+        <note />
+      </trans-unit>
       <trans-unit id="AppHostShutDown">
         <source>The application shut down.</source>
         <target state="new">The application shut down.</target>
@@ -25,6 +40,11 @@
       <trans-unit id="AspireCLIVersion">
         <source>Aspire CLI Version</source>
         <target state="translated">Aspire CLI 版本</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AspireCliUpdateMessage">
+        <source>To update the Aspire CLI when installed as a .NET tool, run:</source>
+        <target state="new">To update the Aspire CLI when installed as a .NET tool, run:</target>
         <note />
       </trans-unit>
       <trans-unit id="AspireHostingSDKVersion">

--- a/src/Aspire.Cli/Resources/xlf/InteractionServiceStrings.zh-Hant.xlf
+++ b/src/Aspire.Cli/Resources/xlf/InteractionServiceStrings.zh-Hant.xlf
@@ -17,6 +17,21 @@
         <target state="needs-review-translation">應用程式主機版本不相容。請升級應用程式主機或 Aspire CLI。</target>
         <note />
       </trans-unit>
+      <trans-unit id="AppHostNotCompatibleUpdateAppHost">
+        <source>The AppHost version is older than the Aspire CLI. Update the Aspire.Hosting package in the AppHost project.</source>
+        <target state="new">The AppHost version is older than the Aspire CLI. Update the Aspire.Hosting package in the AppHost project.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AppHostNotCompatibleUpdateCli">
+        <source>The AppHost version is newer than the Aspire CLI. Update the Aspire CLI.</source>
+        <target state="new">The AppHost version is newer than the Aspire CLI. Update the Aspire CLI.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AppHostPackageUpdateMessage">
+        <source>To update the AppHost package, run:</source>
+        <target state="new">To update the AppHost package, run:</target>
+        <note />
+      </trans-unit>
       <trans-unit id="AppHostShutDown">
         <source>The application shut down.</source>
         <target state="new">The application shut down.</target>
@@ -25,6 +40,11 @@
       <trans-unit id="AspireCLIVersion">
         <source>Aspire CLI Version</source>
         <target state="translated">Aspire CLI 版本</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AspireCliUpdateMessage">
+        <source>To update the Aspire CLI when installed as a .NET tool, run:</source>
+        <target state="new">To update the Aspire CLI when installed as a .NET tool, run:</target>
         <note />
       </trans-unit>
       <trans-unit id="AspireHostingSDKVersion">

--- a/tests/Aspire.Cli.Tests/Interaction/ConsoleInteractionServiceTests.cs
+++ b/tests/Aspire.Cli.Tests/Interaction/ConsoleInteractionServiceTests.cs
@@ -452,6 +452,48 @@ public class ConsoleInteractionServiceTests
     }
 
     [Fact]
+    public void DisplayIncompatibleVersionError_WhenAppHostIsOlder_ShowsAppHostUpdateCommand()
+    {
+        var output = new StringBuilder();
+        var console = AnsiConsole.Create(new AnsiConsoleSettings
+        {
+            Ansi = AnsiSupport.No,
+            ColorSystem = ColorSystemSupport.NoColors,
+            Out = new AnsiConsoleOutput(new StringWriter(output))
+        });
+
+        var interactionService = CreateInteractionService(console);
+        var ex = new AppHostIncompatibleException("Incompatible version", "testCapability");
+
+        interactionService.DisplayIncompatibleVersionError(ex, "9.2.0");
+
+        var outputString = output.ToString();
+        Assert.Contains("older than the Aspire CLI", outputString);
+        Assert.Contains($"dotnet add package Aspire.Hosting --version {VersionHelper.GetDefaultTemplateVersion()}", outputString);
+    }
+
+    [Fact]
+    public void DisplayIncompatibleVersionError_WhenCliIsOlder_ShowsCliUpdateCommand()
+    {
+        var output = new StringBuilder();
+        var console = AnsiConsole.Create(new AnsiConsoleSettings
+        {
+            Ansi = AnsiSupport.No,
+            ColorSystem = ColorSystemSupport.NoColors,
+            Out = new AnsiConsoleOutput(new StringWriter(output))
+        });
+
+        var interactionService = CreateInteractionService(console);
+        var ex = new AppHostIncompatibleException("Incompatible version", "testCapability");
+
+        interactionService.DisplayIncompatibleVersionError(ex, "99.0.0");
+
+        var outputString = output.ToString();
+        Assert.Contains("newer than the Aspire CLI", outputString);
+        Assert.Contains("dotnet tool update -g Aspire.Cli --version 99.0.0", outputString);
+    }
+
+    [Fact]
     public void DisplayMessage_WithMarkupCharactersInMessage_AutoEscapesByDefault()
     {
         // Arrange


### PR DESCRIPTION
## Description

Fixes #10559

This updates the AppHost incompatibility error so it tells the user which side is older and what to update next. When the AppHost Aspire.Hosting version is older than the CLI template version, it prints a `dotnet add package Aspire.Hosting --version <cli version>` command. When the AppHost is newer, it prints a `dotnet tool update -g Aspire.Cli --version <apphost version>` command.

Verification:

- `./restore.cmd`
- `./.dotnet/dotnet.exe build /t:UpdateXlf src/Aspire.Cli/Aspire.Cli.csproj`
- `./.dotnet/dotnet.exe test tests/Aspire.Cli.Tests/Aspire.Cli.Tests.csproj --no-restore -- --filter-class "*.ConsoleInteractionServiceTests" --filter-not-trait "quarantined=true" --filter-not-trait "outerloop=true"`
- `git diff --check`

This was implemented with Codex assistance, with the patch kept focused and manually reviewed.

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
