### PR TITLE
Surface container runtime warnings during aspire run

### DIFF
--- a/src/Aspire.Cli/Commands/RunCommand.cs
+++ b/src/Aspire.Cli/Commands/RunCommand.cs
@@ -684,6 +684,7 @@ internal sealed class RunCommand : BaseCommand
             await Task.Yield();
 
             var logEntries = backchannel.GetAppHostLogEntriesAsync(cancellationToken);
+            var displayedContainerRuntimeWarning = false;
 
             await foreach (var entry in logEntries.WithCancellation(cancellationToken))
             {
@@ -694,6 +695,12 @@ internal sealed class RunCommand : BaseCommand
                         // Send only information+ level logs to the extension host.
                         extensionInteractionService.WriteDebugSessionMessage(entry.Message, entry.LogLevel is not LogLevel.Error and not LogLevel.Critical, "\x1b[2m");
                     }
+                }
+
+                if (!displayedContainerRuntimeWarning && IsContainerRuntimeAvailabilityWarning(entry))
+                {
+                    interactionService.DisplayMessage(KnownEmojis.Warning, entry.Message);
+                    displayedContainerRuntimeWarning = true;
                 }
 
                 // Write to the unified log file via FileLoggerProvider
@@ -711,6 +718,23 @@ internal sealed class RunCommand : BaseCommand
             // Just swallow this exception because this is an orderly shutdown of the backchannel.
             return;
         }
+    }
+
+    private static bool IsContainerRuntimeAvailabilityWarning(BackchannelLogEntry entry)
+    {
+        if (entry.LogLevel is not (LogLevel.Warning or LogLevel.Error or LogLevel.Critical))
+        {
+            return false;
+        }
+
+        if (!entry.CategoryName.StartsWith("Aspire.Hosting.Dcp.", StringComparison.Ordinal))
+        {
+            return false;
+        }
+
+        return entry.Message.Contains("Container runtime", StringComparison.OrdinalIgnoreCase) &&
+            (entry.Message.Contains("appears to be unhealthy", StringComparison.OrdinalIgnoreCase) ||
+             entry.Message.Contains("could not be found", StringComparison.OrdinalIgnoreCase));
     }
 
     private readonly Dictionary<string, RpcResourceState> _resourceStates = new();

--- a/tests/Aspire.Cli.Tests/Commands/RunCommandTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/RunCommandTests.cs
@@ -1948,6 +1948,57 @@ public class RunCommandTests(ITestOutputHelper outputHelper)
             line => Assert.Equal("[2026-03-16 12:00:00.000] [INFO] [AppHost/Lifetime] Application started", line),
             line => Assert.Equal("[2026-03-16 12:00:01.000] [WARN] [AppHost/Kestrel] Slow response", line),
             line => Assert.Equal("[2026-03-16 12:00:02.000] [FAIL] [AppHost/SimpleCategory] Connection refused", line));
+        Assert.Empty(interactionService.DisplayedMessages);
+
+        async IAsyncEnumerable<BackchannelLogEntry> YieldEntries([EnumeratorCancellation] CancellationToken cancellationToken)
+        {
+            foreach (var entry in entries)
+            {
+                yield return entry;
+            }
+            await Task.CompletedTask;
+        }
+    }
+
+    [Fact]
+    public async Task CaptureAppHostLogsAsync_DisplaysContainerRuntimeWarning()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        var logFilePath = Path.Combine(workspace.WorkspaceRoot.FullName, "test.log");
+        var errorWriter = new TestStartupErrorWriter();
+        using var fileLoggerProvider = new FileLoggerProvider(logFilePath, errorWriter);
+
+        var entries = new BackchannelLogEntry[]
+        {
+            new()
+            {
+                Timestamp = new DateTimeOffset(2026, 3, 16, 12, 0, 0, TimeSpan.Zero),
+                LogLevel = LogLevel.Warning,
+                Message = "Container runtime 'docker' was found but appears to be unhealthy. Ensure that Docker is running.",
+                EventId = new EventId(),
+                CategoryName = "Aspire.Hosting.Dcp.DcpHost"
+            },
+            new()
+            {
+                Timestamp = new DateTimeOffset(2026, 3, 16, 12, 0, 1, TimeSpan.Zero),
+                LogLevel = LogLevel.Warning,
+                Message = "Container runtime 'docker' was found but appears to be unhealthy. Ensure that Docker is running.",
+                EventId = new EventId(),
+                CategoryName = "Aspire.Hosting.Dcp.DcpHost"
+            },
+        };
+
+        var backchannel = new TestAppHostBackchannel
+        {
+            GetAppHostLogEntriesAsyncCallback = YieldEntries
+        };
+        var interactionService = new TestInteractionService();
+
+        await RunCommand.CaptureAppHostLogsAsync(fileLoggerProvider, backchannel, interactionService, CancellationToken.None);
+
+        var displayedMessage = Assert.Single(interactionService.DisplayedMessages);
+        Assert.Equal(KnownEmojis.Warning, displayedMessage.Emoji);
+        Assert.Contains("Container runtime 'docker'", displayedMessage.Message);
 
         async IAsyncEnumerable<BackchannelLogEntry> YieldEntries([EnumeratorCancellation] CancellationToken cancellationToken)
         {


### PR DESCRIPTION
## Description

Fixes #10621

This surfaces the AppHost container-runtime availability warning in `aspire run` output instead of only writing it to the AppHost log file. The CLI now detects DCP container runtime warnings from the AppHost log stream, prints the first one as a warning, and still writes all log entries to the unified log file.

The detection is intentionally narrow: DCP category, warning-or-higher, and the existing container runtime unavailable/unhealthy message shapes.

Verification:

- `./restore.cmd`
- `./.dotnet/dotnet.exe test tests/Aspire.Cli.Tests/Aspire.Cli.Tests.csproj --no-restore -- --filter-class "*.RunCommandTests" --filter-method "*CaptureAppHostLogsAsync*" --filter-not-trait "quarantined=true" --filter-not-trait "outerloop=true"`
- `git diff --check`

This was implemented with Codex assistance, with the patch kept focused and manually reviewed.

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
