### PR TITLE
Fix race condition in WatchDashboardLogs_WrittenToHostLoggerFactory test

### DIFF
--- a/tests/Aspire.Hosting.Tests/Dashboard/DashboardEventHandlersTests.cs
+++ b/tests/Aspire.Hosting.Tests/Dashboard/DashboardEventHandlersTests.cs
@@ -48,21 +48,17 @@ public class DashboardEventHandlersTests(ITestOutputHelper testOutputHelper)
         var model = new DistributedApplicationModel(new ResourceCollection());
         await hook.OnBeforeStartAsync(new BeforeStartEvent(new TestServiceProvider(), model), CancellationToken.None).DefaultTimeout();
 
-        await resourceNotificationService.PublishUpdateAsync(model.Resources.Single(), s => s).DefaultTimeout();
-
-        string resourceId = default!;
-        await foreach (var item in resourceLoggerService.WatchAnySubscribersAsync().DefaultTimeout())
-        {
-            if (item.Name.StartsWith(KnownResourceNames.AspireDashboard) && item.AnySubscribers)
-            {
-                resourceId = item.Name;
-                break;
-            }
-        }
+        // Get the resource ID from the DCP instances annotation that was added during OnBeforeStartAsync.
+        var dashboardResource = model.Resources.Single(r => string.Equals(r.Name, KnownResourceNames.AspireDashboard, StringComparisons.ResourceName));
+        var resourceId = dashboardResource.GetResolvedResourceNames()[0];
 
         // Act
+        // Add the log before publishing the notification. The log is stored in-memory and will be
+        // replayed when WatchResourceLogsAsync subscribes after receiving the notification.
         var dashboardLoggerState = resourceLoggerService.GetResourceLoggerState(resourceId);
         dashboardLoggerState.AddLog(LogEntry.Create(timestamp, logMessage, isErrorMessage: false), inMemorySource: true);
+
+        await resourceNotificationService.PublishUpdateAsync(dashboardResource, s => s).DefaultTimeout();
 
         // Assert
         while (true)


### PR DESCRIPTION
## Description

Fixes intermittent timeout in `WatchDashboardLogs_WrittenToHostLoggerFactory` test.

The test was timing out because it relied on `WatchAnySubscribersAsync` to detect when the background log watcher subscribed to the resource logger. If the background task (`WatchResourceLogsAsync`) completed its subscription before the test started observing `WatchAnySubscribersAsync`, the `OnSubscribersChanged` event was missed, causing a 30-second timeout.

The fix removes the race by:
1. Getting the resource ID directly from the `DcpInstancesAnnotation` (populated during `OnBeforeStartAsync`)
2. Adding the log with `inMemorySource: true` before calling `PublishUpdateAsync`
3. The background watcher replays in-memory entries when it eventually subscribes, making the test deterministic regardless of timing

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
- Did you add public API?
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [x] No
