### PR TITLE
Always log dashboard startup summary across auth modes

### DIFF
--- a/src/Aspire.Dashboard/DashboardWebApplication.cs
+++ b/src/Aspire.Dashboard/DashboardWebApplication.cs
@@ -424,13 +424,21 @@ public sealed class DashboardWebApplication : IAsyncDisposable
             if (frontendEndpointInfo != null)
             {
                 var options = _app.Services.GetRequiredService<IOptionsMonitor<DashboardOptions>>().CurrentValue;
+                // Always print a dashboard summary including dashboard and OTLP endpoints.
+                var token = options.Frontend.AuthMode == FrontendAuthMode.BrowserToken ? options.Frontend.BrowserToken : null;
+                var otlpGrpcAddress = _otlpServiceGrpcEndPointAccessor?.Invoke().GetResolvedAddress(replaceIPAnyWithLocalhost: true);
+                var otlpHttpAddress = _otlpServiceHttpEndPointAccessor?.Invoke().GetResolvedAddress(replaceIPAnyWithLocalhost: true);
                 // DOTNET_RUNNING_IN_CONTAINER is a well-known environment variable added by official .NET images.
                 // https://learn.microsoft.com/dotnet/core/tools/dotnet-environment-variables#dotnet_running_in_container-and-dotnet_running_in_containers
                 var isContainer = _app.Configuration.GetBool("DOTNET_RUNNING_IN_CONTAINER") ?? false;
 
-                // Always print the dashboard URL. When using browser token auth, include the login token.
-                var token = options.Frontend.AuthMode == FrontendAuthMode.BrowserToken ? options.Frontend.BrowserToken : null;
-                LoggingHelpers.WriteDashboardUrl(_logger, frontendEndpointInfo.GetResolvedAddress(replaceIPAnyWithLocalhost: true), token, isContainer);
+                LoggingHelpers.WriteDashboardSummary(
+                    _logger,
+                    frontendEndpointInfo.GetResolvedAddress(replaceIPAnyWithLocalhost: true),
+                    otlpGrpcAddress,
+                    otlpHttpAddress,
+                    token,
+                    isContainer);
             }
 
             // One-off async initialization of telemetry service.

--- a/src/Aspire.Dashboard/DashboardWebApplication.cs
+++ b/src/Aspire.Dashboard/DashboardWebApplication.cs
@@ -420,24 +420,7 @@ public sealed class DashboardWebApplication : IAsyncDisposable
                 _logger.LogWarning("Dashboard API is unsecured. Untrusted apps can access sensitive telemetry data.");
             }
 
-            // Always print a dashboard summary including dashboard and OTLP endpoints,
-            // even when the frontend endpoint isn't available.
-            var options = _app.Services.GetRequiredService<IOptionsMonitor<DashboardOptions>>().CurrentValue;
-            var token = options.Frontend.AuthMode == FrontendAuthMode.BrowserToken ? options.Frontend.BrowserToken : null;
-            var frontendAddress = frontendEndpointInfo?.GetResolvedAddress(replaceIPAnyWithLocalhost: true);
-            var otlpGrpcAddress = _otlpServiceGrpcEndPointAccessor?.Invoke().GetResolvedAddress(replaceIPAnyWithLocalhost: true);
-            var otlpHttpAddress = _otlpServiceHttpEndPointAccessor?.Invoke().GetResolvedAddress(replaceIPAnyWithLocalhost: true);
-            // DOTNET_RUNNING_IN_CONTAINER is a well-known environment variable added by official .NET images.
-            // https://learn.microsoft.com/dotnet/core/tools/dotnet-environment-variables#dotnet_running_in_container-and-dotnet_running_in_containers
-            var isContainer = _app.Configuration.GetBool("DOTNET_RUNNING_IN_CONTAINER") ?? false;
-
-            LoggingHelpers.WriteDashboardSummary(
-                _logger,
-                frontendAddress,
-                otlpGrpcAddress,
-                otlpHttpAddress,
-                token,
-                isContainer);
+            PrintSummary(frontendEndpointInfo);
 
             // One-off async initialization of telemetry service.
             var telemetryService = _app.Services.GetRequiredService<DashboardTelemetryService>();
@@ -538,6 +521,27 @@ public sealed class DashboardWebApplication : IAsyncDisposable
         _app.MapTelemetryApi(dashboardOptions);
         _app.MapDashboardApi(dashboardOptions);
         _app.MapDashboardHealthChecks();
+    }
+
+    private void PrintSummary(ResolvedEndpointInfo? frontendEndpointInfo)
+    {
+        var options = _app.Services.GetRequiredService<IOptionsMonitor<DashboardOptions>>().CurrentValue;
+        var token = options.Frontend.AuthMode == FrontendAuthMode.BrowserToken ? options.Frontend.BrowserToken : null;
+        var frontendAddress = frontendEndpointInfo?.GetResolvedAddress(replaceIPAnyWithLocalhost: true);
+        var otlpGrpcAddress = _otlpServiceGrpcEndPointAccessor?.Invoke().GetResolvedAddress(replaceIPAnyWithLocalhost: true);
+        var otlpHttpAddress = _otlpServiceHttpEndPointAccessor?.Invoke().GetResolvedAddress(replaceIPAnyWithLocalhost: true);
+
+        // DOTNET_RUNNING_IN_CONTAINER is a well-known environment variable added by official .NET images.
+        // https://learn.microsoft.com/dotnet/core/tools/dotnet-environment-variables#dotnet_running_in_container-and-dotnet_running_in_containers
+        var isContainer = _app.Configuration.GetBool("DOTNET_RUNNING_IN_CONTAINER") ?? false;
+
+        LoggingHelpers.WriteDashboardSummary(
+            _logger,
+            frontendAddress,
+            otlpGrpcAddress,
+            otlpHttpAddress,
+            token,
+            isContainer);
     }
 
     private ILogger<DashboardWebApplication> GetLogger()

--- a/src/Aspire.Dashboard/DashboardWebApplication.cs
+++ b/src/Aspire.Dashboard/DashboardWebApplication.cs
@@ -420,27 +420,24 @@ public sealed class DashboardWebApplication : IAsyncDisposable
                 _logger.LogWarning("Dashboard API is unsecured. Untrusted apps can access sensitive telemetry data.");
             }
 
-            // Log frontend login URL last at startup so it's easy to find in the logs.
-            if (frontendEndpointInfo != null)
-            {
-                var options = _app.Services.GetRequiredService<IOptionsMonitor<DashboardOptions>>().CurrentValue;
-                // Always print a dashboard summary including dashboard and OTLP endpoints.
-                var token = options.Frontend.AuthMode == FrontendAuthMode.BrowserToken ? options.Frontend.BrowserToken : null;
-                var frontendAddress = frontendEndpointInfo.GetResolvedAddress(replaceIPAnyWithLocalhost: true);
-                var otlpGrpcAddress = _otlpServiceGrpcEndPointAccessor?.Invoke().GetResolvedAddress(replaceIPAnyWithLocalhost: true);
-                var otlpHttpAddress = _otlpServiceHttpEndPointAccessor?.Invoke().GetResolvedAddress(replaceIPAnyWithLocalhost: true);
-                // DOTNET_RUNNING_IN_CONTAINER is a well-known environment variable added by official .NET images.
-                // https://learn.microsoft.com/dotnet/core/tools/dotnet-environment-variables#dotnet_running_in_container-and-dotnet_running_in_containers
-                var isContainer = _app.Configuration.GetBool("DOTNET_RUNNING_IN_CONTAINER") ?? false;
+            // Always print a dashboard summary including dashboard and OTLP endpoints,
+            // even when the frontend endpoint isn't available.
+            var options = _app.Services.GetRequiredService<IOptionsMonitor<DashboardOptions>>().CurrentValue;
+            var token = options.Frontend.AuthMode == FrontendAuthMode.BrowserToken ? options.Frontend.BrowserToken : null;
+            var frontendAddress = frontendEndpointInfo?.GetResolvedAddress(replaceIPAnyWithLocalhost: true);
+            var otlpGrpcAddress = _otlpServiceGrpcEndPointAccessor?.Invoke().GetResolvedAddress(replaceIPAnyWithLocalhost: true);
+            var otlpHttpAddress = _otlpServiceHttpEndPointAccessor?.Invoke().GetResolvedAddress(replaceIPAnyWithLocalhost: true);
+            // DOTNET_RUNNING_IN_CONTAINER is a well-known environment variable added by official .NET images.
+            // https://learn.microsoft.com/dotnet/core/tools/dotnet-environment-variables#dotnet_running_in_container-and-dotnet_running_in_containers
+            var isContainer = _app.Configuration.GetBool("DOTNET_RUNNING_IN_CONTAINER") ?? false;
 
-                LoggingHelpers.WriteDashboardSummary(
-                    _logger,
-                    frontendAddress,
-                    otlpGrpcAddress,
-                    otlpHttpAddress,
-                    token,
-                    isContainer);
-            }
+            LoggingHelpers.WriteDashboardSummary(
+                _logger,
+                frontendAddress,
+                otlpGrpcAddress,
+                otlpHttpAddress,
+                token,
+                isContainer);
 
             // One-off async initialization of telemetry service.
             var telemetryService = _app.Services.GetRequiredService<DashboardTelemetryService>();

--- a/src/Aspire.Dashboard/DashboardWebApplication.cs
+++ b/src/Aspire.Dashboard/DashboardWebApplication.cs
@@ -424,14 +424,13 @@ public sealed class DashboardWebApplication : IAsyncDisposable
             if (frontendEndpointInfo != null)
             {
                 var options = _app.Services.GetRequiredService<IOptionsMonitor<DashboardOptions>>().CurrentValue;
-                if (options.Frontend.AuthMode == FrontendAuthMode.BrowserToken)
-                {
-                    // DOTNET_RUNNING_IN_CONTAINER is a well-known environment variable added by official .NET images.
-                    // https://learn.microsoft.com/dotnet/core/tools/dotnet-environment-variables#dotnet_running_in_container-and-dotnet_running_in_containers
-                    var isContainer = _app.Configuration.GetBool("DOTNET_RUNNING_IN_CONTAINER") ?? false;
+                // DOTNET_RUNNING_IN_CONTAINER is a well-known environment variable added by official .NET images.
+                // https://learn.microsoft.com/dotnet/core/tools/dotnet-environment-variables#dotnet_running_in_container-and-dotnet_running_in_containers
+                var isContainer = _app.Configuration.GetBool("DOTNET_RUNNING_IN_CONTAINER") ?? false;
 
-                    LoggingHelpers.WriteDashboardUrl(_logger, frontendEndpointInfo.GetResolvedAddress(replaceIPAnyWithLocalhost: true), options.Frontend.BrowserToken, isContainer);
-                }
+                // Always print the dashboard URL. When using browser token auth, include the login token.
+                var token = options.Frontend.AuthMode == FrontendAuthMode.BrowserToken ? options.Frontend.BrowserToken : null;
+                LoggingHelpers.WriteDashboardUrl(_logger, frontendEndpointInfo.GetResolvedAddress(replaceIPAnyWithLocalhost: true), token, isContainer);
             }
 
             // One-off async initialization of telemetry service.

--- a/src/Aspire.Dashboard/DashboardWebApplication.cs
+++ b/src/Aspire.Dashboard/DashboardWebApplication.cs
@@ -426,6 +426,7 @@ public sealed class DashboardWebApplication : IAsyncDisposable
                 var options = _app.Services.GetRequiredService<IOptionsMonitor<DashboardOptions>>().CurrentValue;
                 // Always print a dashboard summary including dashboard and OTLP endpoints.
                 var token = options.Frontend.AuthMode == FrontendAuthMode.BrowserToken ? options.Frontend.BrowserToken : null;
+                var frontendAddress = frontendEndpointInfo.GetResolvedAddress(replaceIPAnyWithLocalhost: true);
                 var otlpGrpcAddress = _otlpServiceGrpcEndPointAccessor?.Invoke().GetResolvedAddress(replaceIPAnyWithLocalhost: true);
                 var otlpHttpAddress = _otlpServiceHttpEndPointAccessor?.Invoke().GetResolvedAddress(replaceIPAnyWithLocalhost: true);
                 // DOTNET_RUNNING_IN_CONTAINER is a well-known environment variable added by official .NET images.
@@ -434,7 +435,7 @@ public sealed class DashboardWebApplication : IAsyncDisposable
 
                 LoggingHelpers.WriteDashboardSummary(
                     _logger,
-                    frontendEndpointInfo.GetResolvedAddress(replaceIPAnyWithLocalhost: true),
+                    frontendAddress,
                     otlpGrpcAddress,
                     otlpHttpAddress,
                     token,

--- a/src/Aspire.Dashboard/Model/Assistant/AIContextProvider.cs
+++ b/src/Aspire.Dashboard/Model/Assistant/AIContextProvider.cs
@@ -281,7 +281,7 @@ public class AIContextProvider : IAIContextProvider
         // Explicitly disable AI in configuration.
         if (_dashboardOptions.CurrentValue.AI.Disabled.GetValueOrDefault())
         {
-            _logger.LogInformation("AI is disabled in configuration.");
+            _logger.LogDebug("AI is disabled in configuration.");
             return false;
         }
 

--- a/src/Aspire.Hosting/Dashboard/DashboardEventHandlers.cs
+++ b/src/Aspire.Hosting/Dashboard/DashboardEventHandlers.cs
@@ -400,10 +400,7 @@ internal sealed class DashboardEventHandlers(IConfiguration configuration,
 
             distributedApplicationLogger.LogInformation("Now listening on: {DashboardUrl}", dashboardUrl.TrimEnd('/'));
 
-            if (!string.IsNullOrEmpty(browserToken))
-            {
-                LoggingHelpers.WriteDashboardUrl(distributedApplicationLogger, dashboardUrl, browserToken, isContainer: false);
-            }
+            LoggingHelpers.WriteDashboardSummary(distributedApplicationLogger, dashboardUrl, otlpGrpcEndpointUrl, otlpHttpEndpointUrl, browserToken, isContainer: false);
         });
 
         foreach (var d in dashboardUrls?.Split(';', StringSplitOptions.RemoveEmptyEntries) ?? [])

--- a/src/Shared/LoggingHelpers.cs
+++ b/src/Shared/LoggingHelpers.cs
@@ -3,35 +3,66 @@
 
 using Aspire.Hosting.Utils;
 using Microsoft.Extensions.Logging;
+using System.Text;
 
 namespace Aspire.Hosting;
 
 internal static class LoggingHelpers
 {
-    public static void WriteDashboardUrl(ILogger logger, string? dashboardUrls, string? token, bool isContainer)
+    public static void WriteDashboardSummary(ILogger logger, string? dashboardUrls, string? otlpGrpcUrls, string? otlpHttpUrls, string? token, bool isContainer = false)
     {
         if (!StringUtils.TryGetUriFromDelimitedString(dashboardUrls, ";", out var firstDashboardUrl))
         {
             return;
         }
 
-        if (!string.IsNullOrEmpty(token))
+        static string? GetEndpointAuthority(string? urls)
         {
-            var message = !isContainer
-                ? "Login to the dashboard at {DashboardLoginUrl}"
-                : "Login to the dashboard at {DashboardLoginUrl} . The URL may need changes depending on how network access to the container is configured.";
-
-            var dashboardUrl = $"{firstDashboardUrl.GetLeftPart(UriPartial.Authority)}/login?t={token}";
-            logger.LogInformation(message, dashboardUrl);
+            return StringUtils.TryGetUriFromDelimitedString(urls, ";", out var firstUrl)
+                ? firstUrl.GetLeftPart(UriPartial.Authority)
+                : null;
         }
-        else
+
+        var dashboardUrl = firstDashboardUrl.GetLeftPart(UriPartial.Authority);
+        var otlpGrpcUrl = GetEndpointAuthority(otlpGrpcUrls);
+        var otlpHttpUrl = GetEndpointAuthority(otlpHttpUrls);
+        var loginUrl = !string.IsNullOrEmpty(token)
+            ? $"{dashboardUrl}/login?t={token}"
+            : null;
+
+        var templateBuilder = new StringBuilder();
+        var parameters = new List<object?>();
+
+        templateBuilder
+            .Append("Aspire Dashboard").Append('\n')
+            .Append('\n')
+            .Append("Dashboard:    {DashboardUrl}").Append('\n');
+        parameters.Add(dashboardUrl);
+
+        if (loginUrl is not null)
         {
-            var message = !isContainer
-                ? "The dashboard is available at {DashboardUrl}"
-                : "The dashboard is available at {DashboardUrl} . The URL may need changes depending on how network access to the container is configured.";
-
-            var dashboardUrl = firstDashboardUrl.GetLeftPart(UriPartial.Authority);
-            logger.LogInformation(message, dashboardUrl);
+            templateBuilder.Append("Login URL:    {LoginUrl}").Append('\n');
+            parameters.Add(loginUrl);
         }
+
+        if (otlpGrpcUrl is not null)
+        {
+            templateBuilder.Append("OTLP/gRPC:    {OtlpGrpcUrl}").Append('\n');
+            parameters.Add(otlpGrpcUrl);
+        }
+
+        if (otlpHttpUrl is not null)
+        {
+            templateBuilder.Append("OTLP/HTTP:    {OtlpHttpUrl}").Append('\n');
+            parameters.Add(otlpHttpUrl);
+        }
+
+        if (isContainer)
+        {
+            templateBuilder.Append('\n');
+            templateBuilder.Append("URLs may need changes depending on how network access to the container is configured.").Append('\n');
+        }
+
+        logger.LogInformation(templateBuilder.ToString(), parameters.ToArray());
     }
 }

--- a/src/Shared/LoggingHelpers.cs
+++ b/src/Shared/LoggingHelpers.cs
@@ -10,18 +10,27 @@ internal static class LoggingHelpers
 {
     public static void WriteDashboardUrl(ILogger logger, string? dashboardUrls, string? token, bool isContainer)
     {
-        if (string.IsNullOrEmpty(token))
+        if (!StringUtils.TryGetUriFromDelimitedString(dashboardUrls, ";", out var firstDashboardUrl))
         {
-            throw new InvalidOperationException("Token must be provided.");
+            return;
         }
 
-        if (StringUtils.TryGetUriFromDelimitedString(dashboardUrls, ";", out var firstDashboardUrl))
+        if (!string.IsNullOrEmpty(token))
         {
             var message = !isContainer
                 ? "Login to the dashboard at {DashboardLoginUrl}"
                 : "Login to the dashboard at {DashboardLoginUrl} . The URL may need changes depending on how network access to the container is configured.";
 
             var dashboardUrl = $"{firstDashboardUrl.GetLeftPart(UriPartial.Authority)}/login?t={token}";
+            logger.LogInformation(message, dashboardUrl);
+        }
+        else
+        {
+            var message = !isContainer
+                ? "The dashboard is available at {DashboardUrl}"
+                : "The dashboard is available at {DashboardUrl} . The URL may need changes depending on how network access to the container is configured.";
+
+            var dashboardUrl = firstDashboardUrl.GetLeftPart(UriPartial.Authority);
             logger.LogInformation(message, dashboardUrl);
         }
     }

--- a/src/Shared/LoggingHelpers.cs
+++ b/src/Shared/LoggingHelpers.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using Microsoft.Extensions.Logging;
+using System.Diagnostics;
 using System.Text;
 
 namespace Aspire.Hosting;
@@ -10,6 +11,11 @@ internal static class LoggingHelpers
 {
     public static void WriteDashboardSummary(ILogger logger, string? dashboardUrl, string? otlpGrpcUrl, string? otlpHttpUrl, string? token, bool isContainer = false)
     {
+        // Callers should pass a single resolved URL, not a semicolon-delimited list.
+        AssertSingleUrl(dashboardUrl, nameof(dashboardUrl));
+        AssertSingleUrl(otlpGrpcUrl, nameof(otlpGrpcUrl));
+        AssertSingleUrl(otlpHttpUrl, nameof(otlpHttpUrl));
+
         static string? GetAuthority(string? url)
         {
             return Uri.TryCreate(url, UriKind.Absolute, out var uri)
@@ -69,5 +75,11 @@ internal static class LoggingHelpers
         }
 
         logger.LogInformation(templateBuilder.ToString(), parameters.ToArray());
+    }
+
+    [Conditional("DEBUG")]
+    private static void AssertSingleUrl(string? url, string paramName)
+    {
+        Debug.Assert(url is null || !url.Contains(';'), $"{paramName} should not contain ';': {url}");
     }
 }

--- a/src/Shared/LoggingHelpers.cs
+++ b/src/Shared/LoggingHelpers.cs
@@ -1,7 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using Aspire.Hosting.Utils;
 using Microsoft.Extensions.Logging;
 using System.Text;
 
@@ -9,25 +8,27 @@ namespace Aspire.Hosting;
 
 internal static class LoggingHelpers
 {
-    public static void WriteDashboardSummary(ILogger logger, string? dashboardUrls, string? otlpGrpcUrls, string? otlpHttpUrls, string? token, bool isContainer = false)
+    public static void WriteDashboardSummary(ILogger logger, string? dashboardUrl, string? otlpGrpcUrl, string? otlpHttpUrl, string? token, bool isContainer = false)
     {
-        if (!StringUtils.TryGetUriFromDelimitedString(dashboardUrls, ";", out var firstDashboardUrl))
+        static string? GetAuthority(string? url)
+        {
+            return Uri.TryCreate(url, UriKind.Absolute, out var uri)
+                ? uri.GetLeftPart(UriPartial.Authority)
+                : null;
+        }
+
+        var dashboardAuthority = GetAuthority(dashboardUrl);
+        var otlpGrpcAuthority = GetAuthority(otlpGrpcUrl);
+        var otlpHttpAuthority = GetAuthority(otlpHttpUrl);
+
+        // Nothing to log if we have no URLs at all.
+        if (dashboardAuthority is null && otlpGrpcAuthority is null && otlpHttpAuthority is null)
         {
             return;
         }
 
-        static string? GetEndpointAuthority(string? urls)
-        {
-            return StringUtils.TryGetUriFromDelimitedString(urls, ";", out var firstUrl)
-                ? firstUrl.GetLeftPart(UriPartial.Authority)
-                : null;
-        }
-
-        var dashboardUrl = firstDashboardUrl.GetLeftPart(UriPartial.Authority);
-        var otlpGrpcUrl = GetEndpointAuthority(otlpGrpcUrls);
-        var otlpHttpUrl = GetEndpointAuthority(otlpHttpUrls);
-        var loginUrl = !string.IsNullOrEmpty(token)
-            ? $"{dashboardUrl}/login?t={token}"
+        var loginUrl = !string.IsNullOrEmpty(token) && dashboardAuthority is not null
+            ? $"{dashboardAuthority}/login?t={token}"
             : null;
 
         var templateBuilder = new StringBuilder();
@@ -35,9 +36,13 @@ internal static class LoggingHelpers
 
         templateBuilder
             .Append("Aspire Dashboard").Append('\n')
-            .Append('\n')
-            .Append("Dashboard:    {DashboardUrl}").Append('\n');
-        parameters.Add(dashboardUrl);
+            .Append('\n');
+
+        if (dashboardAuthority is not null)
+        {
+            templateBuilder.Append("Dashboard:    {DashboardUrl}").Append('\n');
+            parameters.Add(dashboardAuthority);
+        }
 
         if (loginUrl is not null)
         {
@@ -45,16 +50,16 @@ internal static class LoggingHelpers
             parameters.Add(loginUrl);
         }
 
-        if (otlpGrpcUrl is not null)
+        if (otlpGrpcAuthority is not null)
         {
             templateBuilder.Append("OTLP/gRPC:    {OtlpGrpcUrl}").Append('\n');
-            parameters.Add(otlpGrpcUrl);
+            parameters.Add(otlpGrpcAuthority);
         }
 
-        if (otlpHttpUrl is not null)
+        if (otlpHttpAuthority is not null)
         {
             templateBuilder.Append("OTLP/HTTP:    {OtlpHttpUrl}").Append('\n');
-            parameters.Add(otlpHttpUrl);
+            parameters.Add(otlpHttpAuthority);
         }
 
         if (isContainer)

--- a/tests/Aspire.Dashboard.Tests/Integration/FrontendBrowserTokenAuthTests.cs
+++ b/tests/Aspire.Dashboard.Tests/Integration/FrontendBrowserTokenAuthTests.cs
@@ -206,9 +206,10 @@ public class FrontendBrowserTokenAuthTests
             },
             w =>
             {
-                Assert.Equal("Login to the dashboard at {DashboardLoginUrl}", LogTestHelpers.GetValue(w, "{OriginalFormat}"));
+                Assert.StartsWith("Aspire Dashboard", (string)LogTestHelpers.GetValue(w, "{OriginalFormat}")!);
 
-                var uri = new Uri((string)LogTestHelpers.GetValue(w, "DashboardLoginUrl")!, UriKind.Absolute);
+                var loginUrl = (string)LogTestHelpers.GetValue(w, "LoginUrl")!;
+                var uri = new Uri(loginUrl, UriKind.Absolute);
                 var queryString = HttpUtility.ParseQueryString(uri.Query);
                 Assert.NotNull(queryString["t"]);
             });
@@ -235,10 +236,11 @@ public class FrontendBrowserTokenAuthTests
         // Assert
         var l = testSink.Writes.Where(w => w.LoggerName == typeof(DashboardWebApplication).FullName).ToList();
 
-        // Testing via the log template is kind of hacky. If this becomes a problem then consider adding proper log definitions and match via ID.
-        var loginLinkLog = l.Single(w => "Login to the dashboard at {DashboardLoginUrl}" == (string?)LogTestHelpers.GetValue(w, "{OriginalFormat}"));
+        // The login URL is now part of the summary log message.
+        var summaryLog = l.Single(w => ((string?)LogTestHelpers.GetValue(w, "{OriginalFormat}"))?.StartsWith("Aspire Dashboard") == true);
 
-        var uri = new Uri((string)LogTestHelpers.GetValue(loginLinkLog, "DashboardLoginUrl")!, UriKind.Absolute);
+        var loginUrl = (string)LogTestHelpers.GetValue(summaryLog, "LoginUrl")!;
+        var uri = new Uri(loginUrl, UriKind.Absolute);
         var queryString = HttpUtility.ParseQueryString(uri.Query);
         Assert.NotNull(queryString["t"]);
 
@@ -262,7 +264,9 @@ public class FrontendBrowserTokenAuthTests
         // Assert
         var l = testSink.Writes.Where(w => w.LoggerName == typeof(DashboardWebApplication).FullName).ToList();
 
-        // Testing via the log template is kind of hacky. If this becomes a problem then consider adding proper log definitions and match via ID.
-        Assert.Single(l, w => (string?)LogTestHelpers.GetValue(w, "{OriginalFormat}") == "Login to the dashboard at {DashboardLoginUrl} . The URL may need changes depending on how network access to the container is configured.");
+        // The container message is now part of the summary log message.
+        var summaryLog = l.Single(w => ((string?)LogTestHelpers.GetValue(w, "{OriginalFormat}"))?.StartsWith("Aspire Dashboard") == true);
+        var containerMessage = "URLs may need changes depending on how network access to the container is configured.";
+        Assert.Contains(containerMessage, summaryLog.Message);
     }
 }

--- a/tests/Aspire.Dashboard.Tests/Integration/StartupTests.cs
+++ b/tests/Aspire.Dashboard.Tests/Integration/StartupTests.cs
@@ -660,6 +660,10 @@ public class StartupTests(ITestOutputHelper testOutputHelper)
             {
                 Assert.Equal("Dashboard API is unsecured. Untrusted apps can access sensitive telemetry data.", LogTestHelpers.GetValue(w, "{OriginalFormat}"));
                 Assert.Equal(LogLevel.Warning, w.LogLevel);
+            },
+            w =>
+            {
+                Assert.StartsWith("Aspire Dashboard", (string)LogTestHelpers.GetValue(w, "{OriginalFormat}")!);
             });
     }
 
@@ -696,6 +700,10 @@ public class StartupTests(ITestOutputHelper testOutputHelper)
             {
                 Assert.Equal("Dashboard API is unsecured. Untrusted apps can access sensitive telemetry data.", LogTestHelpers.GetValue(w, "{OriginalFormat}"));
                 Assert.Equal(LogLevel.Warning, w.LogLevel);
+            },
+            w =>
+            {
+                Assert.StartsWith("Aspire Dashboard", (string)LogTestHelpers.GetValue(w, "{OriginalFormat}")!);
             });
     }
 
@@ -836,6 +844,10 @@ public class StartupTests(ITestOutputHelper testOutputHelper)
             {
                 Assert.Equal("Dashboard API is unsecured. Untrusted apps can access sensitive telemetry data.", LogTestHelpers.GetValue(w, "{OriginalFormat}"));
                 Assert.Equal(LogLevel.Warning, w.LogLevel);
+            },
+            w =>
+            {
+                Assert.StartsWith("Aspire Dashboard", (string)LogTestHelpers.GetValue(w, "{OriginalFormat}")!);
             });
     }
 

--- a/tests/Aspire.Dashboard.Tests/LoggingHelpersTests.cs
+++ b/tests/Aspire.Dashboard.Tests/LoggingHelpersTests.cs
@@ -11,108 +11,177 @@ namespace Aspire.Dashboard.Tests;
 public class LoggingHelpersTests
 {
     [Fact]
-    public void WriteDashboardUrl_WithToken_LogsLoginUrl()
+    public void WriteDashboardSummary_WithTokenAndOtlpEndpoints_LogsSummaryAndStructuredUrls()
     {
         var sink = new TestSink();
         var logger = new TestLogger("TestLogger", sink, enabled: true);
 
-        LoggingHelpers.WriteDashboardUrl(logger, "http://localhost:18888", "abc123", isContainer: false);
+        LoggingHelpers.WriteDashboardSummary(
+            logger,
+            "http://localhost:18888",
+            "http://localhost:18889",
+            "http://localhost:18890",
+            "abc123");
 
         var write = Assert.Single(sink.Writes);
         Assert.Equal(LogLevel.Information, write.LogLevel);
-        Assert.Contains("/login?t=abc123", write.Message);
-        Assert.Contains("Login to the dashboard at", write.Message);
+        Assert.NotNull(write.Message);
+        var lines = GetMessageLines(write.Message!);
+
+        Assert.Collection(lines,
+            line => Assert.Equal("Aspire Dashboard", line),
+            line => Assert.Equal(string.Empty, line),
+            line => Assert.Equal("Dashboard:    http://localhost:18888", line),
+            line => Assert.Equal("Login URL:    http://localhost:18888/login?t=abc123", line),
+            line => Assert.Equal("OTLP/gRPC:    http://localhost:18889", line),
+            line => Assert.Equal("OTLP/HTTP:    http://localhost:18890", line),
+            line => Assert.Equal(string.Empty, line));
+
+        Assert.Equal("http://localhost:18888", LogTestHelpers.GetValue(write, "DashboardUrl"));
+        Assert.Equal("http://localhost:18889", LogTestHelpers.GetValue(write, "OtlpGrpcUrl"));
+        Assert.Equal("http://localhost:18890", LogTestHelpers.GetValue(write, "OtlpHttpUrl"));
+        Assert.Equal("http://localhost:18888/login?t=abc123", LogTestHelpers.GetValue(write, "LoginUrl"));
     }
 
     [Fact]
-    public void WriteDashboardUrl_WithToken_IsContainer_LogsContainerMessage()
+    public void WriteDashboardSummary_WithoutToken_DoesNotIncludeLoginUrl()
     {
         var sink = new TestSink();
         var logger = new TestLogger("TestLogger", sink, enabled: true);
 
-        LoggingHelpers.WriteDashboardUrl(logger, "http://localhost:18888", "abc123", isContainer: true);
+        LoggingHelpers.WriteDashboardSummary(
+            logger,
+            "http://localhost:18888",
+            "http://localhost:18889",
+            "http://localhost:18890",
+            token: null);
 
         var write = Assert.Single(sink.Writes);
         Assert.Equal(LogLevel.Information, write.LogLevel);
-        Assert.Contains("/login?t=abc123", write.Message);
-        Assert.Contains("URL may need changes depending on how network access to the container is configured", write.Message);
+        Assert.NotNull(write.Message);
+        var lines = GetMessageLines(write.Message!);
+
+        Assert.Collection(lines,
+            line => Assert.Equal("Aspire Dashboard", line),
+            line => Assert.Equal(string.Empty, line),
+            line => Assert.Equal("Dashboard:    http://localhost:18888", line),
+            line => Assert.Equal("OTLP/gRPC:    http://localhost:18889", line),
+            line => Assert.Equal("OTLP/HTTP:    http://localhost:18890", line),
+            line => Assert.Equal(string.Empty, line));
+
+        Assert.Null(LogTestHelpers.GetValue(write, "LoginUrl"));
     }
 
     [Fact]
-    public void WriteDashboardUrl_WithoutToken_LogsDashboardUrl()
+    public void WriteDashboardSummary_InvalidDashboardUrl_DoesNotLog()
     {
         var sink = new TestSink();
         var logger = new TestLogger("TestLogger", sink, enabled: true);
 
-        LoggingHelpers.WriteDashboardUrl(logger, "http://localhost:18888", token: null, isContainer: false);
-
-        var write = Assert.Single(sink.Writes);
-        Assert.Equal(LogLevel.Information, write.LogLevel);
-        Assert.Contains("The dashboard is available at", write.Message);
-        Assert.Contains("http://localhost:18888", write.Message);
-        Assert.DoesNotContain("/login?t=", write.Message);
-    }
-
-    [Fact]
-    public void WriteDashboardUrl_WithoutToken_IsContainer_LogsContainerMessage()
-    {
-        var sink = new TestSink();
-        var logger = new TestLogger("TestLogger", sink, enabled: true);
-
-        LoggingHelpers.WriteDashboardUrl(logger, "http://localhost:18888", token: null, isContainer: true);
-
-        var write = Assert.Single(sink.Writes);
-        Assert.Equal(LogLevel.Information, write.LogLevel);
-        Assert.Contains("The dashboard is available at", write.Message);
-        Assert.Contains("URL may need changes depending on how network access to the container is configured", write.Message);
-    }
-
-    [Fact]
-    public void WriteDashboardUrl_EmptyToken_LogsDashboardUrlWithoutLogin()
-    {
-        var sink = new TestSink();
-        var logger = new TestLogger("TestLogger", sink, enabled: true);
-
-        LoggingHelpers.WriteDashboardUrl(logger, "http://localhost:18888", token: "", isContainer: false);
-
-        var write = Assert.Single(sink.Writes);
-        Assert.Equal(LogLevel.Information, write.LogLevel);
-        Assert.Contains("The dashboard is available at", write.Message);
-        Assert.DoesNotContain("/login?t=", write.Message);
-    }
-
-    [Fact]
-    public void WriteDashboardUrl_InvalidUrl_DoesNotLog()
-    {
-        var sink = new TestSink();
-        var logger = new TestLogger("TestLogger", sink, enabled: true);
-
-        LoggingHelpers.WriteDashboardUrl(logger, "not-a-url", token: "abc123", isContainer: false);
+        LoggingHelpers.WriteDashboardSummary(logger, "not-a-url", "http://localhost:18889", "http://localhost:18890", token: "abc123");
 
         Assert.Empty(sink.Writes);
     }
 
     [Fact]
-    public void WriteDashboardUrl_NullUrl_DoesNotLog()
+    public void WriteDashboardSummary_NullDashboardUrl_DoesNotLog()
     {
         var sink = new TestSink();
         var logger = new TestLogger("TestLogger", sink, enabled: true);
 
-        LoggingHelpers.WriteDashboardUrl(logger, dashboardUrls: null, token: "abc123", isContainer: false);
+        LoggingHelpers.WriteDashboardSummary(
+            logger,
+            dashboardUrls: null,
+            otlpGrpcUrls: "http://localhost:18889",
+            otlpHttpUrls: "http://localhost:18890",
+            token: "abc123");
 
         Assert.Empty(sink.Writes);
     }
 
     [Fact]
-    public void WriteDashboardUrl_SemicolonDelimitedUrls_UsesFirstUrl()
+    public void WriteDashboardSummary_SemicolonDelimitedUrls_UsesFirstUrls()
     {
         var sink = new TestSink();
         var logger = new TestLogger("TestLogger", sink, enabled: true);
 
-        LoggingHelpers.WriteDashboardUrl(logger, "http://localhost:18888;http://localhost:19999", "mytoken", isContainer: false);
+        LoggingHelpers.WriteDashboardSummary(
+            logger,
+            "http://localhost:18888;http://localhost:19999",
+            "http://localhost:18889;http://localhost:19998",
+            "http://localhost:18890;http://localhost:19997",
+            "mytoken");
 
         var write = Assert.Single(sink.Writes);
-        Assert.Contains("http://localhost:18888/login?t=mytoken", write.Message);
-        Assert.DoesNotContain("19999", write.Message);
+        Assert.NotNull(write.Message);
+        var lines = GetMessageLines(write.Message!);
+
+        Assert.Collection(lines,
+            line => Assert.Equal("Aspire Dashboard", line),
+            line => Assert.Equal(string.Empty, line),
+            line => Assert.Equal("Dashboard:    http://localhost:18888", line),
+            line => Assert.Equal("Login URL:    http://localhost:18888/login?t=mytoken", line),
+            line => Assert.Equal("OTLP/gRPC:    http://localhost:18889", line),
+            line => Assert.Equal("OTLP/HTTP:    http://localhost:18890", line),
+            line => Assert.Equal(string.Empty, line));
+
+        Assert.Equal("http://localhost:18888", LogTestHelpers.GetValue(write, "DashboardUrl"));
+        Assert.Equal("http://localhost:18889", LogTestHelpers.GetValue(write, "OtlpGrpcUrl"));
+        Assert.Equal("http://localhost:18890", LogTestHelpers.GetValue(write, "OtlpHttpUrl"));
+        Assert.Equal("http://localhost:18888/login?t=mytoken", LogTestHelpers.GetValue(write, "LoginUrl"));
+    }
+
+    [Fact]
+    public void WriteDashboardSummary_WithoutOtlpEndpoints_DoesNotIncludeOtlpLines()
+    {
+        var sink = new TestSink();
+        var logger = new TestLogger("TestLogger", sink, enabled: true);
+
+        LoggingHelpers.WriteDashboardSummary(
+            logger,
+            "http://localhost:18888",
+            otlpGrpcUrls: null,
+            otlpHttpUrls: null,
+            token: "abc123");
+
+        var write = Assert.Single(sink.Writes);
+        Assert.NotNull(write.Message);
+        var lines = GetMessageLines(write.Message!);
+
+        Assert.Collection(lines,
+            line => Assert.Equal("Aspire Dashboard", line),
+            line => Assert.Equal(string.Empty, line),
+            line => Assert.Equal("Dashboard:    http://localhost:18888", line),
+            line => Assert.Equal("Login URL:    http://localhost:18888/login?t=abc123", line),
+            line => Assert.Equal(string.Empty, line));
+
+        Assert.Null(LogTestHelpers.GetValue(write, "OtlpGrpcUrl"));
+        Assert.Null(LogTestHelpers.GetValue(write, "OtlpHttpUrl"));
+    }
+
+    [Fact]
+    public void WriteDashboardSummary_IsContainer_IncludesContainerMessage()
+    {
+        var sink = new TestSink();
+        var logger = new TestLogger("TestLogger", sink, enabled: true);
+
+        LoggingHelpers.WriteDashboardSummary(
+            logger,
+            "http://localhost:18888",
+            otlpGrpcUrls: null,
+            otlpHttpUrls: null,
+            token: "abc123",
+            isContainer: true);
+
+        var write = Assert.Single(sink.Writes);
+        Assert.NotNull(write.Message);
+        var containerMessage = "URLs may need changes depending on how network access to the container is configured.";
+
+        Assert.Contains(containerMessage, write.Message);
+    }
+
+    private static string[] GetMessageLines(string message)
+    {
+        return message.Replace("\r", string.Empty).Split('\n');
     }
 }

--- a/tests/Aspire.Dashboard.Tests/LoggingHelpersTests.cs
+++ b/tests/Aspire.Dashboard.Tests/LoggingHelpersTests.cs
@@ -1,0 +1,118 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Aspire.Hosting;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Testing;
+using Xunit;
+
+namespace Aspire.Dashboard.Tests;
+
+public class LoggingHelpersTests
+{
+    [Fact]
+    public void WriteDashboardUrl_WithToken_LogsLoginUrl()
+    {
+        var sink = new TestSink();
+        var logger = new TestLogger("TestLogger", sink, enabled: true);
+
+        LoggingHelpers.WriteDashboardUrl(logger, "http://localhost:18888", "abc123", isContainer: false);
+
+        var write = Assert.Single(sink.Writes);
+        Assert.Equal(LogLevel.Information, write.LogLevel);
+        Assert.Contains("/login?t=abc123", write.Message);
+        Assert.Contains("Login to the dashboard at", write.Message);
+    }
+
+    [Fact]
+    public void WriteDashboardUrl_WithToken_IsContainer_LogsContainerMessage()
+    {
+        var sink = new TestSink();
+        var logger = new TestLogger("TestLogger", sink, enabled: true);
+
+        LoggingHelpers.WriteDashboardUrl(logger, "http://localhost:18888", "abc123", isContainer: true);
+
+        var write = Assert.Single(sink.Writes);
+        Assert.Equal(LogLevel.Information, write.LogLevel);
+        Assert.Contains("/login?t=abc123", write.Message);
+        Assert.Contains("URL may need changes depending on how network access to the container is configured", write.Message);
+    }
+
+    [Fact]
+    public void WriteDashboardUrl_WithoutToken_LogsDashboardUrl()
+    {
+        var sink = new TestSink();
+        var logger = new TestLogger("TestLogger", sink, enabled: true);
+
+        LoggingHelpers.WriteDashboardUrl(logger, "http://localhost:18888", token: null, isContainer: false);
+
+        var write = Assert.Single(sink.Writes);
+        Assert.Equal(LogLevel.Information, write.LogLevel);
+        Assert.Contains("The dashboard is available at", write.Message);
+        Assert.Contains("http://localhost:18888", write.Message);
+        Assert.DoesNotContain("/login?t=", write.Message);
+    }
+
+    [Fact]
+    public void WriteDashboardUrl_WithoutToken_IsContainer_LogsContainerMessage()
+    {
+        var sink = new TestSink();
+        var logger = new TestLogger("TestLogger", sink, enabled: true);
+
+        LoggingHelpers.WriteDashboardUrl(logger, "http://localhost:18888", token: null, isContainer: true);
+
+        var write = Assert.Single(sink.Writes);
+        Assert.Equal(LogLevel.Information, write.LogLevel);
+        Assert.Contains("The dashboard is available at", write.Message);
+        Assert.Contains("URL may need changes depending on how network access to the container is configured", write.Message);
+    }
+
+    [Fact]
+    public void WriteDashboardUrl_EmptyToken_LogsDashboardUrlWithoutLogin()
+    {
+        var sink = new TestSink();
+        var logger = new TestLogger("TestLogger", sink, enabled: true);
+
+        LoggingHelpers.WriteDashboardUrl(logger, "http://localhost:18888", token: "", isContainer: false);
+
+        var write = Assert.Single(sink.Writes);
+        Assert.Equal(LogLevel.Information, write.LogLevel);
+        Assert.Contains("The dashboard is available at", write.Message);
+        Assert.DoesNotContain("/login?t=", write.Message);
+    }
+
+    [Fact]
+    public void WriteDashboardUrl_InvalidUrl_DoesNotLog()
+    {
+        var sink = new TestSink();
+        var logger = new TestLogger("TestLogger", sink, enabled: true);
+
+        LoggingHelpers.WriteDashboardUrl(logger, "not-a-url", token: "abc123", isContainer: false);
+
+        Assert.Empty(sink.Writes);
+    }
+
+    [Fact]
+    public void WriteDashboardUrl_NullUrl_DoesNotLog()
+    {
+        var sink = new TestSink();
+        var logger = new TestLogger("TestLogger", sink, enabled: true);
+
+        LoggingHelpers.WriteDashboardUrl(logger, dashboardUrls: null, token: "abc123", isContainer: false);
+
+        Assert.Empty(sink.Writes);
+    }
+
+    [Fact]
+    public void WriteDashboardUrl_SemicolonDelimitedUrls_UsesFirstUrl()
+    {
+        var sink = new TestSink();
+        var logger = new TestLogger("TestLogger", sink, enabled: true);
+
+        LoggingHelpers.WriteDashboardUrl(logger, "http://localhost:18888;http://localhost:19999", "mytoken", isContainer: false);
+
+        var write = Assert.Single(sink.Writes);
+        Assert.Contains("http://localhost:18888/login?t=mytoken", write.Message);
+        Assert.DoesNotContain("19999", write.Message);
+    }
+}

--- a/tests/Aspire.Dashboard.Tests/LoggingHelpersTests.cs
+++ b/tests/Aspire.Dashboard.Tests/LoggingHelpersTests.cs
@@ -73,62 +73,87 @@ public class LoggingHelpersTests
     }
 
     [Fact]
-    public void WriteDashboardSummary_InvalidDashboardUrl_DoesNotLog()
+    public void WriteDashboardSummary_InvalidDashboardUrl_LogsOtlpEndpoints()
     {
         var sink = new TestSink();
         var logger = new TestLogger("TestLogger", sink, enabled: true);
 
         LoggingHelpers.WriteDashboardSummary(logger, "not-a-url", "http://localhost:18889", "http://localhost:18890", token: "abc123");
 
-        Assert.Empty(sink.Writes);
-    }
-
-    [Fact]
-    public void WriteDashboardSummary_NullDashboardUrl_DoesNotLog()
-    {
-        var sink = new TestSink();
-        var logger = new TestLogger("TestLogger", sink, enabled: true);
-
-        LoggingHelpers.WriteDashboardSummary(
-            logger,
-            dashboardUrls: null,
-            otlpGrpcUrls: "http://localhost:18889",
-            otlpHttpUrls: "http://localhost:18890",
-            token: "abc123");
-
-        Assert.Empty(sink.Writes);
-    }
-
-    [Fact]
-    public void WriteDashboardSummary_SemicolonDelimitedUrls_UsesFirstUrls()
-    {
-        var sink = new TestSink();
-        var logger = new TestLogger("TestLogger", sink, enabled: true);
-
-        LoggingHelpers.WriteDashboardSummary(
-            logger,
-            "http://localhost:18888;http://localhost:19999",
-            "http://localhost:18889;http://localhost:19998",
-            "http://localhost:18890;http://localhost:19997",
-            "mytoken");
-
         var write = Assert.Single(sink.Writes);
+        Assert.Equal(LogLevel.Information, write.LogLevel);
         Assert.NotNull(write.Message);
         var lines = GetMessageLines(write.Message!);
 
         Assert.Collection(lines,
             line => Assert.Equal("Aspire Dashboard", line),
             line => Assert.Equal(string.Empty, line),
-            line => Assert.Equal("Dashboard:    http://localhost:18888", line),
-            line => Assert.Equal("Login URL:    http://localhost:18888/login?t=mytoken", line),
+            line => Assert.Equal("OTLP/gRPC:    http://localhost:18889", line),
+            line => Assert.Equal("OTLP/HTTP:    http://localhost:18890", line),
+            line => Assert.Equal(string.Empty, line));
+    }
+
+    [Fact]
+    public void WriteDashboardSummary_NullDashboardUrl_LogsOtlpEndpoints()
+    {
+        var sink = new TestSink();
+        var logger = new TestLogger("TestLogger", sink, enabled: true);
+
+        LoggingHelpers.WriteDashboardSummary(
+            logger,
+            dashboardUrl: null,
+            otlpGrpcUrl: "http://localhost:18889",
+            otlpHttpUrl: "http://localhost:18890",
+            token: "abc123");
+
+        var write = Assert.Single(sink.Writes);
+        Assert.Equal(LogLevel.Information, write.LogLevel);
+        Assert.NotNull(write.Message);
+        var lines = GetMessageLines(write.Message!);
+
+        Assert.Collection(lines,
+            line => Assert.Equal("Aspire Dashboard", line),
+            line => Assert.Equal(string.Empty, line),
             line => Assert.Equal("OTLP/gRPC:    http://localhost:18889", line),
             line => Assert.Equal("OTLP/HTTP:    http://localhost:18890", line),
             line => Assert.Equal(string.Empty, line));
 
-        Assert.Equal("http://localhost:18888", LogTestHelpers.GetValue(write, "DashboardUrl"));
+        Assert.Null(LogTestHelpers.GetValue(write, "DashboardUrl"));
+        Assert.Null(LogTestHelpers.GetValue(write, "LoginUrl"));
         Assert.Equal("http://localhost:18889", LogTestHelpers.GetValue(write, "OtlpGrpcUrl"));
         Assert.Equal("http://localhost:18890", LogTestHelpers.GetValue(write, "OtlpHttpUrl"));
-        Assert.Equal("http://localhost:18888/login?t=mytoken", LogTestHelpers.GetValue(write, "LoginUrl"));
+    }
+
+    [Fact]
+    public void WriteDashboardSummary_AllUrlsInvalid_DoesNotLog()
+    {
+        var sink = new TestSink();
+        var logger = new TestLogger("TestLogger", sink, enabled: true);
+
+        LoggingHelpers.WriteDashboardSummary(
+            logger,
+            dashboardUrl: "not-a-url",
+            otlpGrpcUrl: "also-invalid",
+            otlpHttpUrl: "nope",
+            token: "abc123");
+
+        Assert.Empty(sink.Writes);
+    }
+
+    [Fact]
+    public void WriteDashboardSummary_AllUrlsNull_DoesNotLog()
+    {
+        var sink = new TestSink();
+        var logger = new TestLogger("TestLogger", sink, enabled: true);
+
+        LoggingHelpers.WriteDashboardSummary(
+            logger,
+            dashboardUrl: null,
+            otlpGrpcUrl: null,
+            otlpHttpUrl: null,
+            token: "abc123");
+
+        Assert.Empty(sink.Writes);
     }
 
     [Fact]
@@ -140,8 +165,8 @@ public class LoggingHelpersTests
         LoggingHelpers.WriteDashboardSummary(
             logger,
             "http://localhost:18888",
-            otlpGrpcUrls: null,
-            otlpHttpUrls: null,
+            otlpGrpcUrl: null,
+            otlpHttpUrl: null,
             token: "abc123");
 
         var write = Assert.Single(sink.Writes);
@@ -168,8 +193,8 @@ public class LoggingHelpersTests
         LoggingHelpers.WriteDashboardSummary(
             logger,
             "http://localhost:18888",
-            otlpGrpcUrls: null,
-            otlpHttpUrls: null,
+            otlpGrpcUrl: null,
+            otlpHttpUrl: null,
             token: "abc123",
             isContainer: true);
 

--- a/tests/Shared/TemplatesTesting/AspireProject.cs
+++ b/tests/Shared/TemplatesTesting/AspireProject.cs
@@ -17,7 +17,7 @@ public partial class AspireProject : IAsyncDisposable
 {
     public const int DashboardAvailabilityTimeoutSecs = 60;
     private const int AppStartupWaitTimeoutSecs = 5 * 60;
-    private static readonly Regex s_dashboardUrlRegex = new(@"Login to the dashboard at (?<url>.*)", RegexOptions.Compiled);
+    private static readonly Regex s_dashboardUrlRegex = new(@"Login URL:\s+(?<url>.*)", RegexOptions.Compiled);
 
     public static string GetNuGetConfigPathFor(TestTargetFramework targetFramework) =>
         Path.Combine(BuildEnvironment.TestAssetsPath, "nuget8.config");


### PR DESCRIPTION
## Description

This PR ensures startup logs always include dashboard access details, regardless of frontend auth mode.

Previously, dashboard URL logging was gated on `FrontendAuthMode.BrowserToken`, so standalone/non-token scenarios could start successfully without printing a usable dashboard URL.

This change introduces a unified startup summary log and updates call sites/tests accordingly.

Fixes #16095

## What changed

### 1) Replaced token-only URL logging with a unified summary helper

- Replaced `LoggingHelpers.WriteDashboardUrl(...)` with:
  - `LoggingHelpers.WriteDashboardSummary(ILogger logger, string? dashboardUrls, string? otlpGrpcUrls, string? otlpHttpUrls, string? token, bool isContainer = false)`
- New helper behavior:
  - Returns without logging if no valid dashboard URL is available
  - Always logs a dashboard summary block when a dashboard URL is available
  - Includes `Login URL` only when a token is present
  - Includes OTLP gRPC/HTTP entries when configured
  - Includes container networking guidance when `isContainer == true`
  - Keeps structured logging properties (`DashboardUrl`, `LoginUrl`, `OtlpGrpcUrl`, `OtlpHttpUrl`) for testability/querying

### 2) Dashboard startup logging now always emits summary

In `DashboardWebApplication`:

- Removed BrowserToken-only guard around startup URL logging
- Computes optional token based on auth mode:
  - BrowserToken mode => token included
  - Other modes => token omitted
- Passes resolved frontend + OTLP addresses into `WriteDashboardSummary(...)`
- Preserves existing container detection behavior (`DOTNET_RUNNING_IN_CONTAINER`)

### 3) AppHost dashboard event handler also uses summary logging

In `DashboardEventHandlers`:

- Replaced conditional token-only `WriteDashboardUrl(...)` call with unconditional `WriteDashboardSummary(...)`
- Continues to log `Now listening on: ...` for readiness/parsing compatibility, then logs summary

### 4) Reduced AI disabled log noise

In `AIContextProvider`:

- Changed:
  - `"AI is disabled in configuration."`
  - from `LogInformation` to `LogDebug`

This keeps default/expected disabled state out of normal information-level startup output.

## Test updates

- Updated integration tests that previously matched the old login-only template to match the new startup summary format and `LoginUrl` property.
- Added targeted `LoggingHelpersTests` covering:
  - token + OTLP endpoints present
  - no token (no login URL)
  - invalid/null dashboard URL (no log)
  - semicolon-delimited URL handling (first URL chosen)
  - no OTLP endpoints
  - container message inclusion
- Updated startup integration expectations to include the new summary log line.

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
- Did you add public API?
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [x] No