### PR TITLE
Improve aspire-deployment skill routing

### DIFF
--- a/.agents/skills/aspire-deployment/SKILL.md
+++ b/.agents/skills/aspire-deployment/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: aspire-deployment
-description: "Deploy Aspire applications to Docker Compose, Kubernetes, Azure, or AWS. Use this before generic cloud deployment guidance for workspaces that are already Aspire apps. Covers target selection, C# or TypeScript AppHost detection, docs-backed API lookup, parameter and secret preflight, publish/deploy preview, deployment execution, and teardown. Prefer this skill for requests like deploy an Aspire app, deploy to Azure or AWS as an Aspire app, deploy to Azure Container Apps/App Service/Azure Kubernetes Service (AKS), generate Docker Compose or Kubernetes artifacts, publish Aspire deployment artifacts, tear down an Aspire deployment, or validate an Aspire deployment plan."
+description: "**WORKFLOW SKILL** — Deploy Aspire apps from AppHost models to Docker Compose, Kubernetes, Azure, or AWS. WHEN: \"deploy Aspire app\", \"publish Aspire artifacts\", \"deploy to Azure Container Apps\", \"generate Kubernetes artifacts\", \"tear down Aspire deployment\". INVOKES: aspire CLI, Aspire docs, target cloud/container CLIs. FOR SINGLE OPERATIONS: use generic Azure, Kubernetes, Docker, or AWS tools only when no Aspire AppHost exists."
 ---
 
 # Aspire Deployment


### PR DESCRIPTION
## Description

Improves the newly added `aspire-deployment` skill routing so agent hosts can more reliably select it for Aspire deployment workflows.

The previous frontmatter description was structurally valid but dense: it used 94 words and did not include explicit `WHEN:` trigger phrases. This updates the description to Sensei's cross-model optimized format with:

- A `**WORKFLOW SKILL**` prefix
- Five quoted `WHEN:` triggers for Aspire deployment scenarios
- `INVOKES:` routing clarity for Aspire CLI/docs and target deployment tools
- `FOR SINGLE OPERATIONS:` guidance to avoid using this skill when no Aspire AppHost exists

### Sensei report

| Metric | Before | After |
| --- | --- | --- |
| Frontmatter description | 677 chars / 94 words | 444 chars / 60 words |
| Skill file tokens | 3614 | 3555 |
| Skill file chars | 14453 | 14220 |
| Skill file lines | 194 | 194 |
| Trigger format | No `WHEN:` or `USE FOR:` trigger format | `WHEN:` with 5 quoted triggers |
| Routing clarity | No skill type prefix / `INVOKES:` / `FOR SINGLE OPERATIONS:` | `**WORKFLOW SKILL**`, `INVOKES:`, and `FOR SINGLE OPERATIONS:` |
| Cross-model word count | Warning: 94 words, over the 60-word target | Passed: 60 words |
| Cross-model trigger format | Warning: explicit trigger format missing | Passed: preferred `WHEN:` format |
| Token budget | Passed: under 5000-token hard limit | Passed: under 5000-token hard limit |

Remaining advisory notes: Sensei still classifies the skill as comprehensive because it has 7 reference modules and 3555 tokens. This is within the current token limit, but future cleanup could consolidate target references if routing or performance becomes noisy.

Validation performed:

```bash
cd ~/.copilot/skills/sensei
npm run tokens -- count .agents/skills/aspire-deployment/SKILL.md
npm run tokens -- check .agents/skills/aspire-deployment/SKILL.md
npm run tokens -- score .agents/skills/aspire-deployment
./restore.sh
./dotnet.sh test --project tests/Aspire.Cli.Tests/Aspire.Cli.Tests.csproj --no-launch-profile -- --filter-class "*.CommonAgentApplicatorsTests" --filter-not-trait "quarantined=true" --filter-not-trait "outerloop=true"
```

Fixes #17208

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
