### PR TITLE
Validate Foundry role assignments in TS apphost

### DIFF
--- a/tests/PolyglotAppHosts/Aspire.Hosting.Foundry/TypeScript/apphost.ts
+++ b/tests/PolyglotAppHosts/Aspire.Hosting.Foundry/TypeScript/apphost.ts
@@ -1,4 +1,4 @@
-import { AzureContainerRegistryRole, FoundryModels, type FoundryModel, createBuilder } from './.modules/aspire.js';
+import { AzureContainerRegistryRole, FoundryModels, FoundryRole, type FoundryModel, createBuilder } from './.modules/aspire.js';
 
 const builder = await createBuilder();
 
@@ -125,6 +125,7 @@ await hostedAgent.publishAsHostedAgent({
 
 const api = await builder.addContainer('api', 'nginx');
 await foundry.withContainerRegistryRoleAssignments(registry, [AzureContainerRegistryRole.AcrPull]);
+await api.withFoundryRoleAssignments(foundry, [FoundryRole.CognitiveServicesOpenAIUser]);
 
 const _deploymentName = await chat.deploymentName.get();
 const _modelName = await chat.modelName.get();


### PR DESCRIPTION
## Description

Adds TypeScript polyglot AppHost coverage for the Foundry role assignment API so docs and release validation include the supported `FoundryRole` plus `withFoundryRoleAssignments(...)` snippet. This confirms the generated TypeScript surface remains available for Aspire 13.4 docs work; no product generator change is required.

Fixes #

N/A

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
