### PR TITLE
Add aspire doctor diagnostics for TypeScript AppHost package managers

### DIFF
--- a/src/Aspire.Cli/Commands/DoctorCommand.cs
+++ b/src/Aspire.Cli/Commands/DoctorCommand.cs
@@ -171,6 +171,7 @@ internal sealed class DoctorCommand : BaseCommand
         {
             "sdk" => DoctorCommandStrings.SdkCategoryHeader,
             "container" => DoctorCommandStrings.ContainerCategoryHeader,
+            "polyglot" => DoctorCommandStrings.PolyglotCategoryHeader,
             "environment" => DoctorCommandStrings.EnvironmentCategoryHeader,
             _ => category
         };
@@ -182,7 +183,8 @@ internal sealed class DoctorCommand : BaseCommand
         {
             "sdk" => 1,
             "container" => 2,
-            "environment" => 3,
+            "polyglot" => 3,
+            "environment" => 4,
             _ => 99
         };
     }

--- a/src/Aspire.Cli/Program.cs
+++ b/src/Aspire.Cli/Program.cs
@@ -346,6 +346,8 @@ public class Program
         builder.Services.AddSingleton<IEnvironmentCheck, DeprecatedWorkloadCheck>();
         builder.Services.AddSingleton<IEnvironmentCheck, DevCertsCheck>();
         builder.Services.AddSingleton<IEnvironmentCheck, ContainerRuntimeCheck>();
+        builder.Services.AddSingleton<IEnvironmentCheck, NodeJsRuntimeCheck>();
+        builder.Services.AddSingleton<IEnvironmentCheck, TypeScriptAppHostPackageManagerCheck>();
         builder.Services.AddSingleton<IEnvironmentCheck, DeprecatedAgentConfigCheck>();
         builder.Services.AddSingleton<IEnvironmentChecker, EnvironmentChecker>();
 

--- a/src/Aspire.Cli/Resources/DoctorCommandStrings.Designer.cs
+++ b/src/Aspire.Cli/Resources/DoctorCommandStrings.Designer.cs
@@ -139,5 +139,131 @@ namespace Aspire.Cli.Resources {
                 return ResourceManager.GetString("CheckingPrerequisites", resourceCulture);
             }
         }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Polyglot AppHost.
+        /// </summary>
+        public static string PolyglotCategoryHeader {
+            get {
+                return ResourceManager.GetString("PolyglotCategoryHeader", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to {0} {1} is installed.
+        /// </summary>
+        public static string PackageManagerInstalled {
+            get {
+                return ResourceManager.GetString("PackageManagerInstalled", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to {0} is installed.
+        /// </summary>
+        public static string PackageManagerInstalledNoVersion {
+            get {
+                return ResourceManager.GetString("PackageManagerInstalledNoVersion", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to {0} not found but required by this TypeScript AppHost.
+        /// </summary>
+        public static string PackageManagerMissing {
+            get {
+                return ResourceManager.GetString("PackageManagerMissing", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Install {0} to run this TypeScript AppHost..
+        /// </summary>
+        public static string PackageManagerMissingFix {
+            get {
+                return ResourceManager.GetString("PackageManagerMissingFix", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to npx not found but required by npm-managed TypeScript AppHosts.
+        /// </summary>
+        public static string NpxMissing {
+            get {
+                return ResourceManager.GetString("NpxMissing", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to npx ships with Node.js; ensure your Node.js installation is on PATH..
+        /// </summary>
+        public static string NpxMissingFix {
+            get {
+                return ResourceManager.GetString("NpxMissingFix", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Yarn Classic (v1) detected; Aspire supports Yarn 4 or later.
+        /// </summary>
+        public static string YarnClassicUnsupported {
+            get {
+                return ResourceManager.GetString("YarnClassicUnsupported", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Upgrade to Yarn 4+ via 'corepack prepare yarn@stable --activate' or follow the Yarn install guide..
+        /// </summary>
+        public static string YarnClassicUnsupportedFix {
+            get {
+                return ResourceManager.GetString("YarnClassicUnsupportedFix", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Node.js not found but required by this TypeScript AppHost.
+        /// </summary>
+        public static string NodeJsMissing {
+            get {
+                return ResourceManager.GetString("NodeJsMissing", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Install Node.js 20.19+ or 22.13+ from https://nodejs.org/..
+        /// </summary>
+        public static string NodeJsMissingFix {
+            get {
+                return ResourceManager.GetString("NodeJsMissingFix", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Node.js {0} is below the supported version (20.19+ or 22.13+).
+        /// </summary>
+        public static string NodeJsOutdated {
+            get {
+                return ResourceManager.GetString("NodeJsOutdated", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Upgrade Node.js to 20.19+ or 22.13+ from https://nodejs.org/..
+        /// </summary>
+        public static string NodeJsOutdatedFix {
+            get {
+                return ResourceManager.GetString("NodeJsOutdatedFix", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Node.js {0} is installed.
+        /// </summary>
+        public static string NodeJsInstalled {
+            get {
+                return ResourceManager.GetString("NodeJsInstalled", resourceCulture);
+            }
+        }
     }
 }

--- a/src/Aspire.Cli/Resources/DoctorCommandStrings.resx
+++ b/src/Aspire.Cli/Resources/DoctorCommandStrings.resx
@@ -85,4 +85,52 @@
   <data name="CheckingPrerequisites" xml:space="preserve">
     <value>Checking Aspire environment...</value>
   </data>
+  <data name="PolyglotCategoryHeader" xml:space="preserve">
+    <value>Polyglot AppHost</value>
+  </data>
+  <data name="PackageManagerInstalled" xml:space="preserve">
+    <value>{0} {1} is installed</value>
+    <comment>{0} is the package manager display name (e.g., 'npm'), {1} is the version or path.</comment>
+  </data>
+  <data name="PackageManagerInstalledNoVersion" xml:space="preserve">
+    <value>{0} is installed</value>
+    <comment>{0} is the package manager display name (e.g., 'npm').</comment>
+  </data>
+  <data name="PackageManagerMissing" xml:space="preserve">
+    <value>{0} not found but required by this TypeScript AppHost</value>
+    <comment>{0} is the package manager display name (e.g., 'pnpm').</comment>
+  </data>
+  <data name="PackageManagerMissingFix" xml:space="preserve">
+    <value>Install {0} to run this TypeScript AppHost.</value>
+    <comment>{0} is the package manager display name (e.g., 'pnpm').</comment>
+  </data>
+  <data name="NpxMissing" xml:space="preserve">
+    <value>npx not found but required by npm-managed TypeScript AppHosts</value>
+  </data>
+  <data name="NpxMissingFix" xml:space="preserve">
+    <value>npx ships with Node.js; ensure your Node.js installation is on PATH.</value>
+  </data>
+  <data name="YarnClassicUnsupported" xml:space="preserve">
+    <value>Yarn Classic (v1) detected; Aspire supports Yarn 4 or later</value>
+  </data>
+  <data name="YarnClassicUnsupportedFix" xml:space="preserve">
+    <value>Upgrade to Yarn 4+ via 'corepack prepare yarn@stable --activate' or follow the Yarn install guide.</value>
+  </data>
+  <data name="NodeJsMissing" xml:space="preserve">
+    <value>Node.js not found but required by this TypeScript AppHost</value>
+  </data>
+  <data name="NodeJsMissingFix" xml:space="preserve">
+    <value>Install Node.js 20.19+ or 22.13+ from https://nodejs.org/.</value>
+  </data>
+  <data name="NodeJsOutdated" xml:space="preserve">
+    <value>Node.js {0} is below the supported version (20.19+ or 22.13+)</value>
+    <comment>{0} is the detected Node.js version string.</comment>
+  </data>
+  <data name="NodeJsOutdatedFix" xml:space="preserve">
+    <value>Upgrade Node.js to 20.19+ or 22.13+ from https://nodejs.org/.</value>
+  </data>
+  <data name="NodeJsInstalled" xml:space="preserve">
+    <value>Node.js {0} is installed</value>
+    <comment>{0} is the detected Node.js version string.</comment>
+  </data>
 </root>

--- a/src/Aspire.Cli/Resources/xlf/DoctorCommandStrings.cs.xlf
+++ b/src/Aspire.Cli/Resources/xlf/DoctorCommandStrings.cs.xlf
@@ -37,6 +37,66 @@
         <target state="translated">Výstupní formát (tabulka nebo JSON)</target>
         <note />
       </trans-unit>
+      <trans-unit id="NodeJsInstalled">
+        <source>Node.js {0} is installed</source>
+        <target state="new">Node.js {0} is installed</target>
+        <note>{0} is the detected Node.js version string.</note>
+      </trans-unit>
+      <trans-unit id="NodeJsMissing">
+        <source>Node.js not found but required by this TypeScript AppHost</source>
+        <target state="new">Node.js not found but required by this TypeScript AppHost</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NodeJsMissingFix">
+        <source>Install Node.js 20.19+ or 22.13+ from https://nodejs.org/.</source>
+        <target state="new">Install Node.js 20.19+ or 22.13+ from https://nodejs.org/.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NodeJsOutdated">
+        <source>Node.js {0} is below the supported version (20.19+ or 22.13+)</source>
+        <target state="new">Node.js {0} is below the supported version (20.19+ or 22.13+)</target>
+        <note>{0} is the detected Node.js version string.</note>
+      </trans-unit>
+      <trans-unit id="NodeJsOutdatedFix">
+        <source>Upgrade Node.js to 20.19+ or 22.13+ from https://nodejs.org/.</source>
+        <target state="new">Upgrade Node.js to 20.19+ or 22.13+ from https://nodejs.org/.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NpxMissing">
+        <source>npx not found but required by npm-managed TypeScript AppHosts</source>
+        <target state="new">npx not found but required by npm-managed TypeScript AppHosts</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NpxMissingFix">
+        <source>npx ships with Node.js; ensure your Node.js installation is on PATH.</source>
+        <target state="new">npx ships with Node.js; ensure your Node.js installation is on PATH.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PackageManagerInstalled">
+        <source>{0} {1} is installed</source>
+        <target state="new">{0} {1} is installed</target>
+        <note>{0} is the package manager display name (e.g., 'npm'), {1} is the version or path.</note>
+      </trans-unit>
+      <trans-unit id="PackageManagerInstalledNoVersion">
+        <source>{0} is installed</source>
+        <target state="new">{0} is installed</target>
+        <note>{0} is the package manager display name (e.g., 'npm').</note>
+      </trans-unit>
+      <trans-unit id="PackageManagerMissing">
+        <source>{0} not found but required by this TypeScript AppHost</source>
+        <target state="new">{0} not found but required by this TypeScript AppHost</target>
+        <note>{0} is the package manager display name (e.g., 'pnpm').</note>
+      </trans-unit>
+      <trans-unit id="PackageManagerMissingFix">
+        <source>Install {0} to run this TypeScript AppHost.</source>
+        <target state="new">Install {0} to run this TypeScript AppHost.</target>
+        <note>{0} is the package manager display name (e.g., 'pnpm').</note>
+      </trans-unit>
+      <trans-unit id="PolyglotCategoryHeader">
+        <source>Polyglot AppHost</source>
+        <target state="new">Polyglot AppHost</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SdkCategoryHeader">
         <source>.NET SDK</source>
         <target state="translated">Sada .NET SDK</target>
@@ -45,6 +105,16 @@
       <trans-unit id="SummaryFormat">
         <source>Summary: {0} passed, {1} warnings, {2} failed</source>
         <target state="translated">Shrnutí – úspěšné: {0}, upozornění: {1}, selhalo: {2}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="YarnClassicUnsupported">
+        <source>Yarn Classic (v1) detected; Aspire supports Yarn 4 or later</source>
+        <target state="new">Yarn Classic (v1) detected; Aspire supports Yarn 4 or later</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="YarnClassicUnsupportedFix">
+        <source>Upgrade to Yarn 4+ via 'corepack prepare yarn@stable --activate' or follow the Yarn install guide.</source>
+        <target state="new">Upgrade to Yarn 4+ via 'corepack prepare yarn@stable --activate' or follow the Yarn install guide.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Aspire.Cli/Resources/xlf/DoctorCommandStrings.de.xlf
+++ b/src/Aspire.Cli/Resources/xlf/DoctorCommandStrings.de.xlf
@@ -37,6 +37,66 @@
         <target state="translated">Ausgabeformat (Tabelle oder JSON).</target>
         <note />
       </trans-unit>
+      <trans-unit id="NodeJsInstalled">
+        <source>Node.js {0} is installed</source>
+        <target state="new">Node.js {0} is installed</target>
+        <note>{0} is the detected Node.js version string.</note>
+      </trans-unit>
+      <trans-unit id="NodeJsMissing">
+        <source>Node.js not found but required by this TypeScript AppHost</source>
+        <target state="new">Node.js not found but required by this TypeScript AppHost</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NodeJsMissingFix">
+        <source>Install Node.js 20.19+ or 22.13+ from https://nodejs.org/.</source>
+        <target state="new">Install Node.js 20.19+ or 22.13+ from https://nodejs.org/.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NodeJsOutdated">
+        <source>Node.js {0} is below the supported version (20.19+ or 22.13+)</source>
+        <target state="new">Node.js {0} is below the supported version (20.19+ or 22.13+)</target>
+        <note>{0} is the detected Node.js version string.</note>
+      </trans-unit>
+      <trans-unit id="NodeJsOutdatedFix">
+        <source>Upgrade Node.js to 20.19+ or 22.13+ from https://nodejs.org/.</source>
+        <target state="new">Upgrade Node.js to 20.19+ or 22.13+ from https://nodejs.org/.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NpxMissing">
+        <source>npx not found but required by npm-managed TypeScript AppHosts</source>
+        <target state="new">npx not found but required by npm-managed TypeScript AppHosts</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NpxMissingFix">
+        <source>npx ships with Node.js; ensure your Node.js installation is on PATH.</source>
+        <target state="new">npx ships with Node.js; ensure your Node.js installation is on PATH.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PackageManagerInstalled">
+        <source>{0} {1} is installed</source>
+        <target state="new">{0} {1} is installed</target>
+        <note>{0} is the package manager display name (e.g., 'npm'), {1} is the version or path.</note>
+      </trans-unit>
+      <trans-unit id="PackageManagerInstalledNoVersion">
+        <source>{0} is installed</source>
+        <target state="new">{0} is installed</target>
+        <note>{0} is the package manager display name (e.g., 'npm').</note>
+      </trans-unit>
+      <trans-unit id="PackageManagerMissing">
+        <source>{0} not found but required by this TypeScript AppHost</source>
+        <target state="new">{0} not found but required by this TypeScript AppHost</target>
+        <note>{0} is the package manager display name (e.g., 'pnpm').</note>
+      </trans-unit>
+      <trans-unit id="PackageManagerMissingFix">
+        <source>Install {0} to run this TypeScript AppHost.</source>
+        <target state="new">Install {0} to run this TypeScript AppHost.</target>
+        <note>{0} is the package manager display name (e.g., 'pnpm').</note>
+      </trans-unit>
+      <trans-unit id="PolyglotCategoryHeader">
+        <source>Polyglot AppHost</source>
+        <target state="new">Polyglot AppHost</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SdkCategoryHeader">
         <source>.NET SDK</source>
         <target state="translated">.NET-SDK</target>
@@ -45,6 +105,16 @@
       <trans-unit id="SummaryFormat">
         <source>Summary: {0} passed, {1} warnings, {2} failed</source>
         <target state="translated">Zusammenfassung: {0} erfolgreich, {1} Warnungen, {2} fehlgeschlagen</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="YarnClassicUnsupported">
+        <source>Yarn Classic (v1) detected; Aspire supports Yarn 4 or later</source>
+        <target state="new">Yarn Classic (v1) detected; Aspire supports Yarn 4 or later</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="YarnClassicUnsupportedFix">
+        <source>Upgrade to Yarn 4+ via 'corepack prepare yarn@stable --activate' or follow the Yarn install guide.</source>
+        <target state="new">Upgrade to Yarn 4+ via 'corepack prepare yarn@stable --activate' or follow the Yarn install guide.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Aspire.Cli/Resources/xlf/DoctorCommandStrings.es.xlf
+++ b/src/Aspire.Cli/Resources/xlf/DoctorCommandStrings.es.xlf
@@ -37,6 +37,66 @@
         <target state="translated">Formato de salida (tabla o JSON).</target>
         <note />
       </trans-unit>
+      <trans-unit id="NodeJsInstalled">
+        <source>Node.js {0} is installed</source>
+        <target state="new">Node.js {0} is installed</target>
+        <note>{0} is the detected Node.js version string.</note>
+      </trans-unit>
+      <trans-unit id="NodeJsMissing">
+        <source>Node.js not found but required by this TypeScript AppHost</source>
+        <target state="new">Node.js not found but required by this TypeScript AppHost</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NodeJsMissingFix">
+        <source>Install Node.js 20.19+ or 22.13+ from https://nodejs.org/.</source>
+        <target state="new">Install Node.js 20.19+ or 22.13+ from https://nodejs.org/.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NodeJsOutdated">
+        <source>Node.js {0} is below the supported version (20.19+ or 22.13+)</source>
+        <target state="new">Node.js {0} is below the supported version (20.19+ or 22.13+)</target>
+        <note>{0} is the detected Node.js version string.</note>
+      </trans-unit>
+      <trans-unit id="NodeJsOutdatedFix">
+        <source>Upgrade Node.js to 20.19+ or 22.13+ from https://nodejs.org/.</source>
+        <target state="new">Upgrade Node.js to 20.19+ or 22.13+ from https://nodejs.org/.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NpxMissing">
+        <source>npx not found but required by npm-managed TypeScript AppHosts</source>
+        <target state="new">npx not found but required by npm-managed TypeScript AppHosts</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NpxMissingFix">
+        <source>npx ships with Node.js; ensure your Node.js installation is on PATH.</source>
+        <target state="new">npx ships with Node.js; ensure your Node.js installation is on PATH.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PackageManagerInstalled">
+        <source>{0} {1} is installed</source>
+        <target state="new">{0} {1} is installed</target>
+        <note>{0} is the package manager display name (e.g., 'npm'), {1} is the version or path.</note>
+      </trans-unit>
+      <trans-unit id="PackageManagerInstalledNoVersion">
+        <source>{0} is installed</source>
+        <target state="new">{0} is installed</target>
+        <note>{0} is the package manager display name (e.g., 'npm').</note>
+      </trans-unit>
+      <trans-unit id="PackageManagerMissing">
+        <source>{0} not found but required by this TypeScript AppHost</source>
+        <target state="new">{0} not found but required by this TypeScript AppHost</target>
+        <note>{0} is the package manager display name (e.g., 'pnpm').</note>
+      </trans-unit>
+      <trans-unit id="PackageManagerMissingFix">
+        <source>Install {0} to run this TypeScript AppHost.</source>
+        <target state="new">Install {0} to run this TypeScript AppHost.</target>
+        <note>{0} is the package manager display name (e.g., 'pnpm').</note>
+      </trans-unit>
+      <trans-unit id="PolyglotCategoryHeader">
+        <source>Polyglot AppHost</source>
+        <target state="new">Polyglot AppHost</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SdkCategoryHeader">
         <source>.NET SDK</source>
         <target state="translated">SDK de .NET</target>
@@ -45,6 +105,16 @@
       <trans-unit id="SummaryFormat">
         <source>Summary: {0} passed, {1} warnings, {2} failed</source>
         <target state="translated">Resumen: {0} correctos, {1} advertencias, {2} fallos</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="YarnClassicUnsupported">
+        <source>Yarn Classic (v1) detected; Aspire supports Yarn 4 or later</source>
+        <target state="new">Yarn Classic (v1) detected; Aspire supports Yarn 4 or later</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="YarnClassicUnsupportedFix">
+        <source>Upgrade to Yarn 4+ via 'corepack prepare yarn@stable --activate' or follow the Yarn install guide.</source>
+        <target state="new">Upgrade to Yarn 4+ via 'corepack prepare yarn@stable --activate' or follow the Yarn install guide.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Aspire.Cli/Resources/xlf/DoctorCommandStrings.fr.xlf
+++ b/src/Aspire.Cli/Resources/xlf/DoctorCommandStrings.fr.xlf
@@ -37,6 +37,66 @@
         <target state="translated">Format de sortie (Tableau ou JSON).</target>
         <note />
       </trans-unit>
+      <trans-unit id="NodeJsInstalled">
+        <source>Node.js {0} is installed</source>
+        <target state="new">Node.js {0} is installed</target>
+        <note>{0} is the detected Node.js version string.</note>
+      </trans-unit>
+      <trans-unit id="NodeJsMissing">
+        <source>Node.js not found but required by this TypeScript AppHost</source>
+        <target state="new">Node.js not found but required by this TypeScript AppHost</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NodeJsMissingFix">
+        <source>Install Node.js 20.19+ or 22.13+ from https://nodejs.org/.</source>
+        <target state="new">Install Node.js 20.19+ or 22.13+ from https://nodejs.org/.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NodeJsOutdated">
+        <source>Node.js {0} is below the supported version (20.19+ or 22.13+)</source>
+        <target state="new">Node.js {0} is below the supported version (20.19+ or 22.13+)</target>
+        <note>{0} is the detected Node.js version string.</note>
+      </trans-unit>
+      <trans-unit id="NodeJsOutdatedFix">
+        <source>Upgrade Node.js to 20.19+ or 22.13+ from https://nodejs.org/.</source>
+        <target state="new">Upgrade Node.js to 20.19+ or 22.13+ from https://nodejs.org/.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NpxMissing">
+        <source>npx not found but required by npm-managed TypeScript AppHosts</source>
+        <target state="new">npx not found but required by npm-managed TypeScript AppHosts</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NpxMissingFix">
+        <source>npx ships with Node.js; ensure your Node.js installation is on PATH.</source>
+        <target state="new">npx ships with Node.js; ensure your Node.js installation is on PATH.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PackageManagerInstalled">
+        <source>{0} {1} is installed</source>
+        <target state="new">{0} {1} is installed</target>
+        <note>{0} is the package manager display name (e.g., 'npm'), {1} is the version or path.</note>
+      </trans-unit>
+      <trans-unit id="PackageManagerInstalledNoVersion">
+        <source>{0} is installed</source>
+        <target state="new">{0} is installed</target>
+        <note>{0} is the package manager display name (e.g., 'npm').</note>
+      </trans-unit>
+      <trans-unit id="PackageManagerMissing">
+        <source>{0} not found but required by this TypeScript AppHost</source>
+        <target state="new">{0} not found but required by this TypeScript AppHost</target>
+        <note>{0} is the package manager display name (e.g., 'pnpm').</note>
+      </trans-unit>
+      <trans-unit id="PackageManagerMissingFix">
+        <source>Install {0} to run this TypeScript AppHost.</source>
+        <target state="new">Install {0} to run this TypeScript AppHost.</target>
+        <note>{0} is the package manager display name (e.g., 'pnpm').</note>
+      </trans-unit>
+      <trans-unit id="PolyglotCategoryHeader">
+        <source>Polyglot AppHost</source>
+        <target state="new">Polyglot AppHost</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SdkCategoryHeader">
         <source>.NET SDK</source>
         <target state="translated">Kit de développement logiciel (SDK) .NET</target>
@@ -45,6 +105,16 @@
       <trans-unit id="SummaryFormat">
         <source>Summary: {0} passed, {1} warnings, {2} failed</source>
         <target state="translated">Résumé : {0} réussis, {1} avertissements, {2} échoués</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="YarnClassicUnsupported">
+        <source>Yarn Classic (v1) detected; Aspire supports Yarn 4 or later</source>
+        <target state="new">Yarn Classic (v1) detected; Aspire supports Yarn 4 or later</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="YarnClassicUnsupportedFix">
+        <source>Upgrade to Yarn 4+ via 'corepack prepare yarn@stable --activate' or follow the Yarn install guide.</source>
+        <target state="new">Upgrade to Yarn 4+ via 'corepack prepare yarn@stable --activate' or follow the Yarn install guide.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Aspire.Cli/Resources/xlf/DoctorCommandStrings.it.xlf
+++ b/src/Aspire.Cli/Resources/xlf/DoctorCommandStrings.it.xlf
@@ -37,6 +37,66 @@
         <target state="translated">Formato di output (Tabella o JSON).</target>
         <note />
       </trans-unit>
+      <trans-unit id="NodeJsInstalled">
+        <source>Node.js {0} is installed</source>
+        <target state="new">Node.js {0} is installed</target>
+        <note>{0} is the detected Node.js version string.</note>
+      </trans-unit>
+      <trans-unit id="NodeJsMissing">
+        <source>Node.js not found but required by this TypeScript AppHost</source>
+        <target state="new">Node.js not found but required by this TypeScript AppHost</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NodeJsMissingFix">
+        <source>Install Node.js 20.19+ or 22.13+ from https://nodejs.org/.</source>
+        <target state="new">Install Node.js 20.19+ or 22.13+ from https://nodejs.org/.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NodeJsOutdated">
+        <source>Node.js {0} is below the supported version (20.19+ or 22.13+)</source>
+        <target state="new">Node.js {0} is below the supported version (20.19+ or 22.13+)</target>
+        <note>{0} is the detected Node.js version string.</note>
+      </trans-unit>
+      <trans-unit id="NodeJsOutdatedFix">
+        <source>Upgrade Node.js to 20.19+ or 22.13+ from https://nodejs.org/.</source>
+        <target state="new">Upgrade Node.js to 20.19+ or 22.13+ from https://nodejs.org/.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NpxMissing">
+        <source>npx not found but required by npm-managed TypeScript AppHosts</source>
+        <target state="new">npx not found but required by npm-managed TypeScript AppHosts</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NpxMissingFix">
+        <source>npx ships with Node.js; ensure your Node.js installation is on PATH.</source>
+        <target state="new">npx ships with Node.js; ensure your Node.js installation is on PATH.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PackageManagerInstalled">
+        <source>{0} {1} is installed</source>
+        <target state="new">{0} {1} is installed</target>
+        <note>{0} is the package manager display name (e.g., 'npm'), {1} is the version or path.</note>
+      </trans-unit>
+      <trans-unit id="PackageManagerInstalledNoVersion">
+        <source>{0} is installed</source>
+        <target state="new">{0} is installed</target>
+        <note>{0} is the package manager display name (e.g., 'npm').</note>
+      </trans-unit>
+      <trans-unit id="PackageManagerMissing">
+        <source>{0} not found but required by this TypeScript AppHost</source>
+        <target state="new">{0} not found but required by this TypeScript AppHost</target>
+        <note>{0} is the package manager display name (e.g., 'pnpm').</note>
+      </trans-unit>
+      <trans-unit id="PackageManagerMissingFix">
+        <source>Install {0} to run this TypeScript AppHost.</source>
+        <target state="new">Install {0} to run this TypeScript AppHost.</target>
+        <note>{0} is the package manager display name (e.g., 'pnpm').</note>
+      </trans-unit>
+      <trans-unit id="PolyglotCategoryHeader">
+        <source>Polyglot AppHost</source>
+        <target state="new">Polyglot AppHost</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SdkCategoryHeader">
         <source>.NET SDK</source>
         <target state="translated">.NET SDK</target>
@@ -45,6 +105,16 @@
       <trans-unit id="SummaryFormat">
         <source>Summary: {0} passed, {1} warnings, {2} failed</source>
         <target state="translated">Riepilogo: {0} superati, {1} avvisi, {2} non superati</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="YarnClassicUnsupported">
+        <source>Yarn Classic (v1) detected; Aspire supports Yarn 4 or later</source>
+        <target state="new">Yarn Classic (v1) detected; Aspire supports Yarn 4 or later</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="YarnClassicUnsupportedFix">
+        <source>Upgrade to Yarn 4+ via 'corepack prepare yarn@stable --activate' or follow the Yarn install guide.</source>
+        <target state="new">Upgrade to Yarn 4+ via 'corepack prepare yarn@stable --activate' or follow the Yarn install guide.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Aspire.Cli/Resources/xlf/DoctorCommandStrings.ja.xlf
+++ b/src/Aspire.Cli/Resources/xlf/DoctorCommandStrings.ja.xlf
@@ -37,6 +37,66 @@
         <target state="translated">出力形式 (テーブルまたは JSON)。</target>
         <note />
       </trans-unit>
+      <trans-unit id="NodeJsInstalled">
+        <source>Node.js {0} is installed</source>
+        <target state="new">Node.js {0} is installed</target>
+        <note>{0} is the detected Node.js version string.</note>
+      </trans-unit>
+      <trans-unit id="NodeJsMissing">
+        <source>Node.js not found but required by this TypeScript AppHost</source>
+        <target state="new">Node.js not found but required by this TypeScript AppHost</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NodeJsMissingFix">
+        <source>Install Node.js 20.19+ or 22.13+ from https://nodejs.org/.</source>
+        <target state="new">Install Node.js 20.19+ or 22.13+ from https://nodejs.org/.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NodeJsOutdated">
+        <source>Node.js {0} is below the supported version (20.19+ or 22.13+)</source>
+        <target state="new">Node.js {0} is below the supported version (20.19+ or 22.13+)</target>
+        <note>{0} is the detected Node.js version string.</note>
+      </trans-unit>
+      <trans-unit id="NodeJsOutdatedFix">
+        <source>Upgrade Node.js to 20.19+ or 22.13+ from https://nodejs.org/.</source>
+        <target state="new">Upgrade Node.js to 20.19+ or 22.13+ from https://nodejs.org/.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NpxMissing">
+        <source>npx not found but required by npm-managed TypeScript AppHosts</source>
+        <target state="new">npx not found but required by npm-managed TypeScript AppHosts</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NpxMissingFix">
+        <source>npx ships with Node.js; ensure your Node.js installation is on PATH.</source>
+        <target state="new">npx ships with Node.js; ensure your Node.js installation is on PATH.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PackageManagerInstalled">
+        <source>{0} {1} is installed</source>
+        <target state="new">{0} {1} is installed</target>
+        <note>{0} is the package manager display name (e.g., 'npm'), {1} is the version or path.</note>
+      </trans-unit>
+      <trans-unit id="PackageManagerInstalledNoVersion">
+        <source>{0} is installed</source>
+        <target state="new">{0} is installed</target>
+        <note>{0} is the package manager display name (e.g., 'npm').</note>
+      </trans-unit>
+      <trans-unit id="PackageManagerMissing">
+        <source>{0} not found but required by this TypeScript AppHost</source>
+        <target state="new">{0} not found but required by this TypeScript AppHost</target>
+        <note>{0} is the package manager display name (e.g., 'pnpm').</note>
+      </trans-unit>
+      <trans-unit id="PackageManagerMissingFix">
+        <source>Install {0} to run this TypeScript AppHost.</source>
+        <target state="new">Install {0} to run this TypeScript AppHost.</target>
+        <note>{0} is the package manager display name (e.g., 'pnpm').</note>
+      </trans-unit>
+      <trans-unit id="PolyglotCategoryHeader">
+        <source>Polyglot AppHost</source>
+        <target state="new">Polyglot AppHost</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SdkCategoryHeader">
         <source>.NET SDK</source>
         <target state="translated">.NET SDK</target>
@@ -45,6 +105,16 @@
       <trans-unit id="SummaryFormat">
         <source>Summary: {0} passed, {1} warnings, {2} failed</source>
         <target state="translated">概要: {0} 成功、{1} 警告、{2} 失敗</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="YarnClassicUnsupported">
+        <source>Yarn Classic (v1) detected; Aspire supports Yarn 4 or later</source>
+        <target state="new">Yarn Classic (v1) detected; Aspire supports Yarn 4 or later</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="YarnClassicUnsupportedFix">
+        <source>Upgrade to Yarn 4+ via 'corepack prepare yarn@stable --activate' or follow the Yarn install guide.</source>
+        <target state="new">Upgrade to Yarn 4+ via 'corepack prepare yarn@stable --activate' or follow the Yarn install guide.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Aspire.Cli/Resources/xlf/DoctorCommandStrings.ko.xlf
+++ b/src/Aspire.Cli/Resources/xlf/DoctorCommandStrings.ko.xlf
@@ -37,6 +37,66 @@
         <target state="translated">출력 형식(테이블 또는 JSON)입니다.</target>
         <note />
       </trans-unit>
+      <trans-unit id="NodeJsInstalled">
+        <source>Node.js {0} is installed</source>
+        <target state="new">Node.js {0} is installed</target>
+        <note>{0} is the detected Node.js version string.</note>
+      </trans-unit>
+      <trans-unit id="NodeJsMissing">
+        <source>Node.js not found but required by this TypeScript AppHost</source>
+        <target state="new">Node.js not found but required by this TypeScript AppHost</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NodeJsMissingFix">
+        <source>Install Node.js 20.19+ or 22.13+ from https://nodejs.org/.</source>
+        <target state="new">Install Node.js 20.19+ or 22.13+ from https://nodejs.org/.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NodeJsOutdated">
+        <source>Node.js {0} is below the supported version (20.19+ or 22.13+)</source>
+        <target state="new">Node.js {0} is below the supported version (20.19+ or 22.13+)</target>
+        <note>{0} is the detected Node.js version string.</note>
+      </trans-unit>
+      <trans-unit id="NodeJsOutdatedFix">
+        <source>Upgrade Node.js to 20.19+ or 22.13+ from https://nodejs.org/.</source>
+        <target state="new">Upgrade Node.js to 20.19+ or 22.13+ from https://nodejs.org/.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NpxMissing">
+        <source>npx not found but required by npm-managed TypeScript AppHosts</source>
+        <target state="new">npx not found but required by npm-managed TypeScript AppHosts</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NpxMissingFix">
+        <source>npx ships with Node.js; ensure your Node.js installation is on PATH.</source>
+        <target state="new">npx ships with Node.js; ensure your Node.js installation is on PATH.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PackageManagerInstalled">
+        <source>{0} {1} is installed</source>
+        <target state="new">{0} {1} is installed</target>
+        <note>{0} is the package manager display name (e.g., 'npm'), {1} is the version or path.</note>
+      </trans-unit>
+      <trans-unit id="PackageManagerInstalledNoVersion">
+        <source>{0} is installed</source>
+        <target state="new">{0} is installed</target>
+        <note>{0} is the package manager display name (e.g., 'npm').</note>
+      </trans-unit>
+      <trans-unit id="PackageManagerMissing">
+        <source>{0} not found but required by this TypeScript AppHost</source>
+        <target state="new">{0} not found but required by this TypeScript AppHost</target>
+        <note>{0} is the package manager display name (e.g., 'pnpm').</note>
+      </trans-unit>
+      <trans-unit id="PackageManagerMissingFix">
+        <source>Install {0} to run this TypeScript AppHost.</source>
+        <target state="new">Install {0} to run this TypeScript AppHost.</target>
+        <note>{0} is the package manager display name (e.g., 'pnpm').</note>
+      </trans-unit>
+      <trans-unit id="PolyglotCategoryHeader">
+        <source>Polyglot AppHost</source>
+        <target state="new">Polyglot AppHost</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SdkCategoryHeader">
         <source>.NET SDK</source>
         <target state="translated">.NET SDK</target>
@@ -45,6 +105,16 @@
       <trans-unit id="SummaryFormat">
         <source>Summary: {0} passed, {1} warnings, {2} failed</source>
         <target state="translated">요약: {0}개 통과, {1}개 경고, {2}개 실패</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="YarnClassicUnsupported">
+        <source>Yarn Classic (v1) detected; Aspire supports Yarn 4 or later</source>
+        <target state="new">Yarn Classic (v1) detected; Aspire supports Yarn 4 or later</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="YarnClassicUnsupportedFix">
+        <source>Upgrade to Yarn 4+ via 'corepack prepare yarn@stable --activate' or follow the Yarn install guide.</source>
+        <target state="new">Upgrade to Yarn 4+ via 'corepack prepare yarn@stable --activate' or follow the Yarn install guide.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Aspire.Cli/Resources/xlf/DoctorCommandStrings.pl.xlf
+++ b/src/Aspire.Cli/Resources/xlf/DoctorCommandStrings.pl.xlf
@@ -37,6 +37,66 @@
         <target state="translated">Format danych wyjściowych (Tabela lub JSON).</target>
         <note />
       </trans-unit>
+      <trans-unit id="NodeJsInstalled">
+        <source>Node.js {0} is installed</source>
+        <target state="new">Node.js {0} is installed</target>
+        <note>{0} is the detected Node.js version string.</note>
+      </trans-unit>
+      <trans-unit id="NodeJsMissing">
+        <source>Node.js not found but required by this TypeScript AppHost</source>
+        <target state="new">Node.js not found but required by this TypeScript AppHost</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NodeJsMissingFix">
+        <source>Install Node.js 20.19+ or 22.13+ from https://nodejs.org/.</source>
+        <target state="new">Install Node.js 20.19+ or 22.13+ from https://nodejs.org/.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NodeJsOutdated">
+        <source>Node.js {0} is below the supported version (20.19+ or 22.13+)</source>
+        <target state="new">Node.js {0} is below the supported version (20.19+ or 22.13+)</target>
+        <note>{0} is the detected Node.js version string.</note>
+      </trans-unit>
+      <trans-unit id="NodeJsOutdatedFix">
+        <source>Upgrade Node.js to 20.19+ or 22.13+ from https://nodejs.org/.</source>
+        <target state="new">Upgrade Node.js to 20.19+ or 22.13+ from https://nodejs.org/.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NpxMissing">
+        <source>npx not found but required by npm-managed TypeScript AppHosts</source>
+        <target state="new">npx not found but required by npm-managed TypeScript AppHosts</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NpxMissingFix">
+        <source>npx ships with Node.js; ensure your Node.js installation is on PATH.</source>
+        <target state="new">npx ships with Node.js; ensure your Node.js installation is on PATH.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PackageManagerInstalled">
+        <source>{0} {1} is installed</source>
+        <target state="new">{0} {1} is installed</target>
+        <note>{0} is the package manager display name (e.g., 'npm'), {1} is the version or path.</note>
+      </trans-unit>
+      <trans-unit id="PackageManagerInstalledNoVersion">
+        <source>{0} is installed</source>
+        <target state="new">{0} is installed</target>
+        <note>{0} is the package manager display name (e.g., 'npm').</note>
+      </trans-unit>
+      <trans-unit id="PackageManagerMissing">
+        <source>{0} not found but required by this TypeScript AppHost</source>
+        <target state="new">{0} not found but required by this TypeScript AppHost</target>
+        <note>{0} is the package manager display name (e.g., 'pnpm').</note>
+      </trans-unit>
+      <trans-unit id="PackageManagerMissingFix">
+        <source>Install {0} to run this TypeScript AppHost.</source>
+        <target state="new">Install {0} to run this TypeScript AppHost.</target>
+        <note>{0} is the package manager display name (e.g., 'pnpm').</note>
+      </trans-unit>
+      <trans-unit id="PolyglotCategoryHeader">
+        <source>Polyglot AppHost</source>
+        <target state="new">Polyglot AppHost</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SdkCategoryHeader">
         <source>.NET SDK</source>
         <target state="translated">.NET SDK</target>
@@ -45,6 +105,16 @@
       <trans-unit id="SummaryFormat">
         <source>Summary: {0} passed, {1} warnings, {2} failed</source>
         <target state="translated">Podsumowanie: zaliczone {0}, ostrzeżenia {1}, niezaliczone {2}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="YarnClassicUnsupported">
+        <source>Yarn Classic (v1) detected; Aspire supports Yarn 4 or later</source>
+        <target state="new">Yarn Classic (v1) detected; Aspire supports Yarn 4 or later</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="YarnClassicUnsupportedFix">
+        <source>Upgrade to Yarn 4+ via 'corepack prepare yarn@stable --activate' or follow the Yarn install guide.</source>
+        <target state="new">Upgrade to Yarn 4+ via 'corepack prepare yarn@stable --activate' or follow the Yarn install guide.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Aspire.Cli/Resources/xlf/DoctorCommandStrings.pt-BR.xlf
+++ b/src/Aspire.Cli/Resources/xlf/DoctorCommandStrings.pt-BR.xlf
@@ -37,6 +37,66 @@
         <target state="translated">Formato de saída (Tabela ou Json).</target>
         <note />
       </trans-unit>
+      <trans-unit id="NodeJsInstalled">
+        <source>Node.js {0} is installed</source>
+        <target state="new">Node.js {0} is installed</target>
+        <note>{0} is the detected Node.js version string.</note>
+      </trans-unit>
+      <trans-unit id="NodeJsMissing">
+        <source>Node.js not found but required by this TypeScript AppHost</source>
+        <target state="new">Node.js not found but required by this TypeScript AppHost</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NodeJsMissingFix">
+        <source>Install Node.js 20.19+ or 22.13+ from https://nodejs.org/.</source>
+        <target state="new">Install Node.js 20.19+ or 22.13+ from https://nodejs.org/.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NodeJsOutdated">
+        <source>Node.js {0} is below the supported version (20.19+ or 22.13+)</source>
+        <target state="new">Node.js {0} is below the supported version (20.19+ or 22.13+)</target>
+        <note>{0} is the detected Node.js version string.</note>
+      </trans-unit>
+      <trans-unit id="NodeJsOutdatedFix">
+        <source>Upgrade Node.js to 20.19+ or 22.13+ from https://nodejs.org/.</source>
+        <target state="new">Upgrade Node.js to 20.19+ or 22.13+ from https://nodejs.org/.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NpxMissing">
+        <source>npx not found but required by npm-managed TypeScript AppHosts</source>
+        <target state="new">npx not found but required by npm-managed TypeScript AppHosts</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NpxMissingFix">
+        <source>npx ships with Node.js; ensure your Node.js installation is on PATH.</source>
+        <target state="new">npx ships with Node.js; ensure your Node.js installation is on PATH.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PackageManagerInstalled">
+        <source>{0} {1} is installed</source>
+        <target state="new">{0} {1} is installed</target>
+        <note>{0} is the package manager display name (e.g., 'npm'), {1} is the version or path.</note>
+      </trans-unit>
+      <trans-unit id="PackageManagerInstalledNoVersion">
+        <source>{0} is installed</source>
+        <target state="new">{0} is installed</target>
+        <note>{0} is the package manager display name (e.g., 'npm').</note>
+      </trans-unit>
+      <trans-unit id="PackageManagerMissing">
+        <source>{0} not found but required by this TypeScript AppHost</source>
+        <target state="new">{0} not found but required by this TypeScript AppHost</target>
+        <note>{0} is the package manager display name (e.g., 'pnpm').</note>
+      </trans-unit>
+      <trans-unit id="PackageManagerMissingFix">
+        <source>Install {0} to run this TypeScript AppHost.</source>
+        <target state="new">Install {0} to run this TypeScript AppHost.</target>
+        <note>{0} is the package manager display name (e.g., 'pnpm').</note>
+      </trans-unit>
+      <trans-unit id="PolyglotCategoryHeader">
+        <source>Polyglot AppHost</source>
+        <target state="new">Polyglot AppHost</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SdkCategoryHeader">
         <source>.NET SDK</source>
         <target state="translated">SDK do .NET</target>
@@ -45,6 +105,16 @@
       <trans-unit id="SummaryFormat">
         <source>Summary: {0} passed, {1} warnings, {2} failed</source>
         <target state="translated">Resumo: {0} aprovado, {1} avisos, {2} falha</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="YarnClassicUnsupported">
+        <source>Yarn Classic (v1) detected; Aspire supports Yarn 4 or later</source>
+        <target state="new">Yarn Classic (v1) detected; Aspire supports Yarn 4 or later</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="YarnClassicUnsupportedFix">
+        <source>Upgrade to Yarn 4+ via 'corepack prepare yarn@stable --activate' or follow the Yarn install guide.</source>
+        <target state="new">Upgrade to Yarn 4+ via 'corepack prepare yarn@stable --activate' or follow the Yarn install guide.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Aspire.Cli/Resources/xlf/DoctorCommandStrings.ru.xlf
+++ b/src/Aspire.Cli/Resources/xlf/DoctorCommandStrings.ru.xlf
@@ -37,6 +37,66 @@
         <target state="translated">Формат вывода (таблица или JSON).</target>
         <note />
       </trans-unit>
+      <trans-unit id="NodeJsInstalled">
+        <source>Node.js {0} is installed</source>
+        <target state="new">Node.js {0} is installed</target>
+        <note>{0} is the detected Node.js version string.</note>
+      </trans-unit>
+      <trans-unit id="NodeJsMissing">
+        <source>Node.js not found but required by this TypeScript AppHost</source>
+        <target state="new">Node.js not found but required by this TypeScript AppHost</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NodeJsMissingFix">
+        <source>Install Node.js 20.19+ or 22.13+ from https://nodejs.org/.</source>
+        <target state="new">Install Node.js 20.19+ or 22.13+ from https://nodejs.org/.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NodeJsOutdated">
+        <source>Node.js {0} is below the supported version (20.19+ or 22.13+)</source>
+        <target state="new">Node.js {0} is below the supported version (20.19+ or 22.13+)</target>
+        <note>{0} is the detected Node.js version string.</note>
+      </trans-unit>
+      <trans-unit id="NodeJsOutdatedFix">
+        <source>Upgrade Node.js to 20.19+ or 22.13+ from https://nodejs.org/.</source>
+        <target state="new">Upgrade Node.js to 20.19+ or 22.13+ from https://nodejs.org/.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NpxMissing">
+        <source>npx not found but required by npm-managed TypeScript AppHosts</source>
+        <target state="new">npx not found but required by npm-managed TypeScript AppHosts</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NpxMissingFix">
+        <source>npx ships with Node.js; ensure your Node.js installation is on PATH.</source>
+        <target state="new">npx ships with Node.js; ensure your Node.js installation is on PATH.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PackageManagerInstalled">
+        <source>{0} {1} is installed</source>
+        <target state="new">{0} {1} is installed</target>
+        <note>{0} is the package manager display name (e.g., 'npm'), {1} is the version or path.</note>
+      </trans-unit>
+      <trans-unit id="PackageManagerInstalledNoVersion">
+        <source>{0} is installed</source>
+        <target state="new">{0} is installed</target>
+        <note>{0} is the package manager display name (e.g., 'npm').</note>
+      </trans-unit>
+      <trans-unit id="PackageManagerMissing">
+        <source>{0} not found but required by this TypeScript AppHost</source>
+        <target state="new">{0} not found but required by this TypeScript AppHost</target>
+        <note>{0} is the package manager display name (e.g., 'pnpm').</note>
+      </trans-unit>
+      <trans-unit id="PackageManagerMissingFix">
+        <source>Install {0} to run this TypeScript AppHost.</source>
+        <target state="new">Install {0} to run this TypeScript AppHost.</target>
+        <note>{0} is the package manager display name (e.g., 'pnpm').</note>
+      </trans-unit>
+      <trans-unit id="PolyglotCategoryHeader">
+        <source>Polyglot AppHost</source>
+        <target state="new">Polyglot AppHost</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SdkCategoryHeader">
         <source>.NET SDK</source>
         <target state="translated">Пакет SDK .NET</target>
@@ -45,6 +105,16 @@
       <trans-unit id="SummaryFormat">
         <source>Summary: {0} passed, {1} warnings, {2} failed</source>
         <target state="translated">Сводка: {0} успешно, предупреждений: {1}, {2} с ошибками</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="YarnClassicUnsupported">
+        <source>Yarn Classic (v1) detected; Aspire supports Yarn 4 or later</source>
+        <target state="new">Yarn Classic (v1) detected; Aspire supports Yarn 4 or later</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="YarnClassicUnsupportedFix">
+        <source>Upgrade to Yarn 4+ via 'corepack prepare yarn@stable --activate' or follow the Yarn install guide.</source>
+        <target state="new">Upgrade to Yarn 4+ via 'corepack prepare yarn@stable --activate' or follow the Yarn install guide.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Aspire.Cli/Resources/xlf/DoctorCommandStrings.tr.xlf
+++ b/src/Aspire.Cli/Resources/xlf/DoctorCommandStrings.tr.xlf
@@ -37,6 +37,66 @@
         <target state="translated">Çıktı biçimi (Tablo veya Json).</target>
         <note />
       </trans-unit>
+      <trans-unit id="NodeJsInstalled">
+        <source>Node.js {0} is installed</source>
+        <target state="new">Node.js {0} is installed</target>
+        <note>{0} is the detected Node.js version string.</note>
+      </trans-unit>
+      <trans-unit id="NodeJsMissing">
+        <source>Node.js not found but required by this TypeScript AppHost</source>
+        <target state="new">Node.js not found but required by this TypeScript AppHost</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NodeJsMissingFix">
+        <source>Install Node.js 20.19+ or 22.13+ from https://nodejs.org/.</source>
+        <target state="new">Install Node.js 20.19+ or 22.13+ from https://nodejs.org/.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NodeJsOutdated">
+        <source>Node.js {0} is below the supported version (20.19+ or 22.13+)</source>
+        <target state="new">Node.js {0} is below the supported version (20.19+ or 22.13+)</target>
+        <note>{0} is the detected Node.js version string.</note>
+      </trans-unit>
+      <trans-unit id="NodeJsOutdatedFix">
+        <source>Upgrade Node.js to 20.19+ or 22.13+ from https://nodejs.org/.</source>
+        <target state="new">Upgrade Node.js to 20.19+ or 22.13+ from https://nodejs.org/.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NpxMissing">
+        <source>npx not found but required by npm-managed TypeScript AppHosts</source>
+        <target state="new">npx not found but required by npm-managed TypeScript AppHosts</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NpxMissingFix">
+        <source>npx ships with Node.js; ensure your Node.js installation is on PATH.</source>
+        <target state="new">npx ships with Node.js; ensure your Node.js installation is on PATH.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PackageManagerInstalled">
+        <source>{0} {1} is installed</source>
+        <target state="new">{0} {1} is installed</target>
+        <note>{0} is the package manager display name (e.g., 'npm'), {1} is the version or path.</note>
+      </trans-unit>
+      <trans-unit id="PackageManagerInstalledNoVersion">
+        <source>{0} is installed</source>
+        <target state="new">{0} is installed</target>
+        <note>{0} is the package manager display name (e.g., 'npm').</note>
+      </trans-unit>
+      <trans-unit id="PackageManagerMissing">
+        <source>{0} not found but required by this TypeScript AppHost</source>
+        <target state="new">{0} not found but required by this TypeScript AppHost</target>
+        <note>{0} is the package manager display name (e.g., 'pnpm').</note>
+      </trans-unit>
+      <trans-unit id="PackageManagerMissingFix">
+        <source>Install {0} to run this TypeScript AppHost.</source>
+        <target state="new">Install {0} to run this TypeScript AppHost.</target>
+        <note>{0} is the package manager display name (e.g., 'pnpm').</note>
+      </trans-unit>
+      <trans-unit id="PolyglotCategoryHeader">
+        <source>Polyglot AppHost</source>
+        <target state="new">Polyglot AppHost</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SdkCategoryHeader">
         <source>.NET SDK</source>
         <target state="translated">.NET SDK</target>
@@ -45,6 +105,16 @@
       <trans-unit id="SummaryFormat">
         <source>Summary: {0} passed, {1} warnings, {2} failed</source>
         <target state="translated">Özet: {0} başarılı, {1} uyarı, {2} başarısız</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="YarnClassicUnsupported">
+        <source>Yarn Classic (v1) detected; Aspire supports Yarn 4 or later</source>
+        <target state="new">Yarn Classic (v1) detected; Aspire supports Yarn 4 or later</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="YarnClassicUnsupportedFix">
+        <source>Upgrade to Yarn 4+ via 'corepack prepare yarn@stable --activate' or follow the Yarn install guide.</source>
+        <target state="new">Upgrade to Yarn 4+ via 'corepack prepare yarn@stable --activate' or follow the Yarn install guide.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Aspire.Cli/Resources/xlf/DoctorCommandStrings.zh-Hans.xlf
+++ b/src/Aspire.Cli/Resources/xlf/DoctorCommandStrings.zh-Hans.xlf
@@ -37,6 +37,66 @@
         <target state="translated">输出格式(表格或 Json)。</target>
         <note />
       </trans-unit>
+      <trans-unit id="NodeJsInstalled">
+        <source>Node.js {0} is installed</source>
+        <target state="new">Node.js {0} is installed</target>
+        <note>{0} is the detected Node.js version string.</note>
+      </trans-unit>
+      <trans-unit id="NodeJsMissing">
+        <source>Node.js not found but required by this TypeScript AppHost</source>
+        <target state="new">Node.js not found but required by this TypeScript AppHost</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NodeJsMissingFix">
+        <source>Install Node.js 20.19+ or 22.13+ from https://nodejs.org/.</source>
+        <target state="new">Install Node.js 20.19+ or 22.13+ from https://nodejs.org/.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NodeJsOutdated">
+        <source>Node.js {0} is below the supported version (20.19+ or 22.13+)</source>
+        <target state="new">Node.js {0} is below the supported version (20.19+ or 22.13+)</target>
+        <note>{0} is the detected Node.js version string.</note>
+      </trans-unit>
+      <trans-unit id="NodeJsOutdatedFix">
+        <source>Upgrade Node.js to 20.19+ or 22.13+ from https://nodejs.org/.</source>
+        <target state="new">Upgrade Node.js to 20.19+ or 22.13+ from https://nodejs.org/.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NpxMissing">
+        <source>npx not found but required by npm-managed TypeScript AppHosts</source>
+        <target state="new">npx not found but required by npm-managed TypeScript AppHosts</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NpxMissingFix">
+        <source>npx ships with Node.js; ensure your Node.js installation is on PATH.</source>
+        <target state="new">npx ships with Node.js; ensure your Node.js installation is on PATH.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PackageManagerInstalled">
+        <source>{0} {1} is installed</source>
+        <target state="new">{0} {1} is installed</target>
+        <note>{0} is the package manager display name (e.g., 'npm'), {1} is the version or path.</note>
+      </trans-unit>
+      <trans-unit id="PackageManagerInstalledNoVersion">
+        <source>{0} is installed</source>
+        <target state="new">{0} is installed</target>
+        <note>{0} is the package manager display name (e.g., 'npm').</note>
+      </trans-unit>
+      <trans-unit id="PackageManagerMissing">
+        <source>{0} not found but required by this TypeScript AppHost</source>
+        <target state="new">{0} not found but required by this TypeScript AppHost</target>
+        <note>{0} is the package manager display name (e.g., 'pnpm').</note>
+      </trans-unit>
+      <trans-unit id="PackageManagerMissingFix">
+        <source>Install {0} to run this TypeScript AppHost.</source>
+        <target state="new">Install {0} to run this TypeScript AppHost.</target>
+        <note>{0} is the package manager display name (e.g., 'pnpm').</note>
+      </trans-unit>
+      <trans-unit id="PolyglotCategoryHeader">
+        <source>Polyglot AppHost</source>
+        <target state="new">Polyglot AppHost</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SdkCategoryHeader">
         <source>.NET SDK</source>
         <target state="translated">.NET SDK</target>
@@ -45,6 +105,16 @@
       <trans-unit id="SummaryFormat">
         <source>Summary: {0} passed, {1} warnings, {2} failed</source>
         <target state="translated">摘要: {0} 通过,{1} 警告， {2} 失败</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="YarnClassicUnsupported">
+        <source>Yarn Classic (v1) detected; Aspire supports Yarn 4 or later</source>
+        <target state="new">Yarn Classic (v1) detected; Aspire supports Yarn 4 or later</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="YarnClassicUnsupportedFix">
+        <source>Upgrade to Yarn 4+ via 'corepack prepare yarn@stable --activate' or follow the Yarn install guide.</source>
+        <target state="new">Upgrade to Yarn 4+ via 'corepack prepare yarn@stable --activate' or follow the Yarn install guide.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Aspire.Cli/Resources/xlf/DoctorCommandStrings.zh-Hant.xlf
+++ b/src/Aspire.Cli/Resources/xlf/DoctorCommandStrings.zh-Hant.xlf
@@ -37,6 +37,66 @@
         <target state="translated">輸出格式 (資料表或 Json)。</target>
         <note />
       </trans-unit>
+      <trans-unit id="NodeJsInstalled">
+        <source>Node.js {0} is installed</source>
+        <target state="new">Node.js {0} is installed</target>
+        <note>{0} is the detected Node.js version string.</note>
+      </trans-unit>
+      <trans-unit id="NodeJsMissing">
+        <source>Node.js not found but required by this TypeScript AppHost</source>
+        <target state="new">Node.js not found but required by this TypeScript AppHost</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NodeJsMissingFix">
+        <source>Install Node.js 20.19+ or 22.13+ from https://nodejs.org/.</source>
+        <target state="new">Install Node.js 20.19+ or 22.13+ from https://nodejs.org/.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NodeJsOutdated">
+        <source>Node.js {0} is below the supported version (20.19+ or 22.13+)</source>
+        <target state="new">Node.js {0} is below the supported version (20.19+ or 22.13+)</target>
+        <note>{0} is the detected Node.js version string.</note>
+      </trans-unit>
+      <trans-unit id="NodeJsOutdatedFix">
+        <source>Upgrade Node.js to 20.19+ or 22.13+ from https://nodejs.org/.</source>
+        <target state="new">Upgrade Node.js to 20.19+ or 22.13+ from https://nodejs.org/.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NpxMissing">
+        <source>npx not found but required by npm-managed TypeScript AppHosts</source>
+        <target state="new">npx not found but required by npm-managed TypeScript AppHosts</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NpxMissingFix">
+        <source>npx ships with Node.js; ensure your Node.js installation is on PATH.</source>
+        <target state="new">npx ships with Node.js; ensure your Node.js installation is on PATH.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PackageManagerInstalled">
+        <source>{0} {1} is installed</source>
+        <target state="new">{0} {1} is installed</target>
+        <note>{0} is the package manager display name (e.g., 'npm'), {1} is the version or path.</note>
+      </trans-unit>
+      <trans-unit id="PackageManagerInstalledNoVersion">
+        <source>{0} is installed</source>
+        <target state="new">{0} is installed</target>
+        <note>{0} is the package manager display name (e.g., 'npm').</note>
+      </trans-unit>
+      <trans-unit id="PackageManagerMissing">
+        <source>{0} not found but required by this TypeScript AppHost</source>
+        <target state="new">{0} not found but required by this TypeScript AppHost</target>
+        <note>{0} is the package manager display name (e.g., 'pnpm').</note>
+      </trans-unit>
+      <trans-unit id="PackageManagerMissingFix">
+        <source>Install {0} to run this TypeScript AppHost.</source>
+        <target state="new">Install {0} to run this TypeScript AppHost.</target>
+        <note>{0} is the package manager display name (e.g., 'pnpm').</note>
+      </trans-unit>
+      <trans-unit id="PolyglotCategoryHeader">
+        <source>Polyglot AppHost</source>
+        <target state="new">Polyglot AppHost</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SdkCategoryHeader">
         <source>.NET SDK</source>
         <target state="translated">.NET SDK</target>
@@ -45,6 +105,16 @@
       <trans-unit id="SummaryFormat">
         <source>Summary: {0} passed, {1} warnings, {2} failed</source>
         <target state="translated">摘要: {0} 個通過、{1} 個警告、{2} 個已失敗</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="YarnClassicUnsupported">
+        <source>Yarn Classic (v1) detected; Aspire supports Yarn 4 or later</source>
+        <target state="new">Yarn Classic (v1) detected; Aspire supports Yarn 4 or later</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="YarnClassicUnsupportedFix">
+        <source>Upgrade to Yarn 4+ via 'corepack prepare yarn@stable --activate' or follow the Yarn install guide.</source>
+        <target state="new">Upgrade to Yarn 4+ via 'corepack prepare yarn@stable --activate' or follow the Yarn install guide.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Aspire.Cli/Utils/EnvironmentChecker/AppHostPackageManagerResolver.cs
+++ b/src/Aspire.Cli/Utils/EnvironmentChecker/AppHostPackageManagerResolver.cs
@@ -1,0 +1,260 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Text.Json;
+using System.Text.Json.Nodes;
+
+namespace Aspire.Cli.Utils.EnvironmentChecker;
+
+/// <summary>
+/// Identifies a supported package manager for a TypeScript AppHost.
+/// </summary>
+internal enum AppHostPackageManager
+{
+    /// <summary>
+    /// npm (the default package manager bundled with Node.js).
+    /// </summary>
+    Npm,
+
+    /// <summary>
+    /// pnpm.
+    /// </summary>
+    Pnpm,
+
+    /// <summary>
+    /// Bun.
+    /// </summary>
+    Bun,
+
+    /// <summary>
+    /// Yarn 2 or later (Berry). This is the only supported Yarn line.
+    /// </summary>
+    YarnBerry,
+
+    /// <summary>
+    /// Yarn Classic (v1). Detected for diagnostic purposes only; not supported by Aspire.
+    /// </summary>
+    YarnClassic,
+}
+
+/// <summary>
+/// Describes how a package manager was resolved for a TypeScript AppHost directory.
+/// </summary>
+/// <param name="PackageManager">The resolved package manager.</param>
+/// <param name="Source">The source that drove the resolution (e.g., the path of a lockfile or "default").</param>
+/// <param name="DeclaredVersion">The version declared in the <c>packageManager</c> field of <c>package.json</c>, when available.</param>
+internal sealed record AppHostPackageManagerResolution(
+    AppHostPackageManager PackageManager,
+    string Source,
+    string? DeclaredVersion = null);
+
+/// <summary>
+/// Resolves the package manager configured for a TypeScript AppHost directory.
+/// </summary>
+/// <remarks>
+/// The resolver mirrors the conventions documented for TypeScript AppHosts:
+/// <list type="number">
+///   <item>The <c>packageManager</c> field of <c>package.json</c> wins (e.g., <c>"pnpm@8.6.0"</c>).</item>
+///   <item>Lockfile presence in the AppHost directory.</item>
+///   <item>Lockfile presence in the immediate parent directory (for workspace-style repos).</item>
+///   <item>If nothing is found, the default is npm.</item>
+/// </list>
+/// Markers above the immediate parent are intentionally ignored.
+/// </remarks>
+internal static class AppHostPackageManagerResolver
+{
+    /// <summary>
+    /// Resolves the package manager configured for the AppHost rooted at <paramref name="appHostDirectory"/>.
+    /// </summary>
+    /// <param name="appHostDirectory">The directory containing <c>apphost.ts</c>.</param>
+    /// <returns>The resolved package manager and the source that drove the decision.</returns>
+    public static AppHostPackageManagerResolution Resolve(DirectoryInfo appHostDirectory)
+    {
+        ArgumentNullException.ThrowIfNull(appHostDirectory);
+
+        // 1. packageManager field in package.json (apphost dir first, then immediate parent).
+        if (TryReadPackageManagerField(appHostDirectory, out var fieldResolution))
+        {
+            return fieldResolution;
+        }
+
+        var parent = appHostDirectory.Parent;
+        if (parent is not null && TryReadPackageManagerField(parent, out var parentFieldResolution))
+        {
+            return parentFieldResolution;
+        }
+
+        // 2. Lockfile detection in the AppHost directory.
+        if (TryDetectFromLockfiles(appHostDirectory, out var lockfileResolution))
+        {
+            return lockfileResolution;
+        }
+
+        // 3. Lockfile detection in the immediate parent directory (workspace-style).
+        if (parent is not null && TryDetectFromLockfiles(parent, out var parentLockfileResolution))
+        {
+            return parentLockfileResolution;
+        }
+
+        // 4. Default to npm.
+        return new AppHostPackageManagerResolution(AppHostPackageManager.Npm, "default");
+    }
+
+    /// <summary>
+    /// Gets the conventional executable name for a package manager.
+    /// </summary>
+    public static string GetExecutableName(AppHostPackageManager packageManager)
+    {
+        return packageManager switch
+        {
+            AppHostPackageManager.Npm => "npm",
+            AppHostPackageManager.Pnpm => "pnpm",
+            AppHostPackageManager.Bun => "bun",
+            AppHostPackageManager.YarnBerry or AppHostPackageManager.YarnClassic => "yarn",
+            _ => throw new ArgumentOutOfRangeException(nameof(packageManager), packageManager, "Unknown package manager."),
+        };
+    }
+
+    private static bool TryReadPackageManagerField(DirectoryInfo directory, out AppHostPackageManagerResolution resolution)
+    {
+        var packageJsonPath = Path.Combine(directory.FullName, "package.json");
+        if (!File.Exists(packageJsonPath))
+        {
+            resolution = null!;
+            return false;
+        }
+
+        try
+        {
+            using var stream = File.OpenRead(packageJsonPath);
+            var node = JsonNode.Parse(stream, documentOptions: new JsonDocumentOptions
+            {
+                CommentHandling = JsonCommentHandling.Skip,
+                AllowTrailingCommas = true,
+            });
+
+            if (node is not JsonObject obj)
+            {
+                resolution = null!;
+                return false;
+            }
+
+            if (!obj.TryGetPropertyValue("packageManager", out var packageManagerNode) ||
+                packageManagerNode?.GetValue<string>() is not { Length: > 0 } value)
+            {
+                resolution = null!;
+                return false;
+            }
+
+            // The packageManager field follows the form "<name>@<version>[+<sha-256-hash>]".
+            var atIndex = value.IndexOf('@');
+            var name = atIndex < 0 ? value : value[..atIndex];
+            var version = atIndex < 0 || atIndex == value.Length - 1
+                ? null
+                : value[(atIndex + 1)..];
+
+            // Strip integrity suffix if present (e.g., "@8.6.0+sha256:abc...").
+            if (version is not null)
+            {
+                var plusIndex = version.IndexOf('+');
+                if (plusIndex >= 0)
+                {
+                    version = version[..plusIndex];
+                }
+            }
+
+            var packageManager = name.Trim().ToLowerInvariant() switch
+            {
+                "npm" => AppHostPackageManager.Npm,
+                "pnpm" => AppHostPackageManager.Pnpm,
+                "bun" => AppHostPackageManager.Bun,
+                "yarn" => ClassifyYarn(version, directory),
+                _ => (AppHostPackageManager?)null,
+            };
+
+            if (packageManager is null)
+            {
+                resolution = null!;
+                return false;
+            }
+
+            resolution = new AppHostPackageManagerResolution(
+                packageManager.Value,
+                $"packageManager field in {packageJsonPath}",
+                version);
+            return true;
+        }
+        catch (Exception ex) when (ex is JsonException or IOException or UnauthorizedAccessException)
+        {
+            resolution = null!;
+            return false;
+        }
+    }
+
+    private static bool TryDetectFromLockfiles(DirectoryInfo directory, out AppHostPackageManagerResolution resolution)
+    {
+        // Order matters: most-specific markers first.
+        var pnpmLock = Path.Combine(directory.FullName, "pnpm-lock.yaml");
+        if (File.Exists(pnpmLock))
+        {
+            resolution = new AppHostPackageManagerResolution(AppHostPackageManager.Pnpm, pnpmLock);
+            return true;
+        }
+
+        var bunLock = Path.Combine(directory.FullName, "bun.lock");
+        if (File.Exists(bunLock))
+        {
+            resolution = new AppHostPackageManagerResolution(AppHostPackageManager.Bun, bunLock);
+            return true;
+        }
+
+        var bunLockb = Path.Combine(directory.FullName, "bun.lockb");
+        if (File.Exists(bunLockb))
+        {
+            resolution = new AppHostPackageManagerResolution(AppHostPackageManager.Bun, bunLockb);
+            return true;
+        }
+
+        var yarnLock = Path.Combine(directory.FullName, "yarn.lock");
+        if (File.Exists(yarnLock))
+        {
+            var yarn = ClassifyYarn(version: null, directory);
+            resolution = new AppHostPackageManagerResolution(yarn, yarnLock);
+            return true;
+        }
+
+        var npmLock = Path.Combine(directory.FullName, "package-lock.json");
+        if (File.Exists(npmLock))
+        {
+            resolution = new AppHostPackageManagerResolution(AppHostPackageManager.Npm, npmLock);
+            return true;
+        }
+
+        resolution = null!;
+        return false;
+    }
+
+    private static AppHostPackageManager ClassifyYarn(string? version, DirectoryInfo directory)
+    {
+        // Explicit version from packageManager field is the strongest signal.
+        if (!string.IsNullOrWhiteSpace(version))
+        {
+            // Accept SemVer-like prefixes (e.g., "4.1.0", "4.1.0-rc.1").
+            var dotIndex = version.IndexOf('.');
+            var majorText = dotIndex < 0 ? version : version[..dotIndex];
+            if (int.TryParse(majorText, out var major))
+            {
+                return major >= 2 ? AppHostPackageManager.YarnBerry : AppHostPackageManager.YarnClassic;
+            }
+        }
+
+        // Berry projects ship .yarnrc.yml and/or a .yarn/ directory at the AppHost root.
+        if (File.Exists(Path.Combine(directory.FullName, ".yarnrc.yml")) ||
+            Directory.Exists(Path.Combine(directory.FullName, ".yarn")))
+        {
+            return AppHostPackageManager.YarnBerry;
+        }
+
+        return AppHostPackageManager.YarnClassic;
+    }
+}

--- a/src/Aspire.Cli/Utils/EnvironmentChecker/NodeJsRuntimeCheck.cs
+++ b/src/Aspire.Cli/Utils/EnvironmentChecker/NodeJsRuntimeCheck.cs
@@ -1,0 +1,275 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Diagnostics;
+using System.Globalization;
+using System.Text.RegularExpressions;
+using Aspire.Cli.Resources;
+using Microsoft.Extensions.Logging;
+
+namespace Aspire.Cli.Utils.EnvironmentChecker;
+
+/// <summary>
+/// Verifies that a supported Node.js runtime is available for a TypeScript AppHost.
+/// </summary>
+/// <remarks>
+/// The check is gated on TypeScript AppHost discovery and is skipped when the
+/// resolved AppHost package manager is Bun (which ships its own runtime). When
+/// Node.js is missing, the check fails; when an older Node version is detected
+/// the check emits a warning rather than blocking <c>aspire doctor</c>.
+/// </remarks>
+internal sealed partial class NodeJsRuntimeCheck(
+    CliExecutionContext executionContext,
+    ILogger<NodeJsRuntimeCheck> logger) : IEnvironmentCheck
+{
+    private const string CategoryName = "polyglot";
+    private const string DocsLink = "https://nodejs.org/";
+    private const string CheckName = "nodejs";
+
+    private static readonly TimeSpan s_processTimeout = TimeSpan.FromSeconds(10);
+
+    /// <summary>
+    /// Minimum supported Node.js versions, expressed per major line.
+    /// </summary>
+    private static readonly (int Major, int Minor, int Patch)[] s_minimumSupportedVersions =
+    [
+        (20, 19, 0),
+        (22, 13, 0),
+    ];
+
+    public int Order => 45; // Before the package-manager check (50).
+
+    public async Task<IReadOnlyList<EnvironmentCheckResult>> CheckAsync(CancellationToken cancellationToken = default)
+    {
+        var location = TypeScriptAppHostDiscovery.TryDiscover(executionContext.WorkingDirectory);
+        if (location is null)
+        {
+            return [];
+        }
+
+        AppHostPackageManagerResolution resolution;
+        try
+        {
+            resolution = AppHostPackageManagerResolver.Resolve(location.AppHostDirectory);
+        }
+        catch (Exception ex)
+        {
+            logger.LogDebug(ex, "Failed to resolve package manager for TypeScript AppHost at {Directory}", location.AppHostDirectory.FullName);
+            return [];
+        }
+
+        // Bun ships its own runtime; we don't require a Node.js install for Bun-managed AppHosts.
+        if (resolution.PackageManager == AppHostPackageManager.Bun)
+        {
+            return [];
+        }
+
+        var path = PathLookupHelper.FindFullPathFromPath("node");
+        if (path is null)
+        {
+            return
+            [
+                new EnvironmentCheckResult
+                {
+                    Category = CategoryName,
+                    Name = CheckName,
+                    Status = EnvironmentCheckStatus.Fail,
+                    Message = DoctorCommandStrings.NodeJsMissing,
+                    Fix = DoctorCommandStrings.NodeJsMissingFix,
+                    Link = DocsLink,
+                },
+            ];
+        }
+
+        var version = await TryGetNodeVersionAsync(cancellationToken);
+        if (version is null)
+        {
+            // Node is on PATH but its version is unknown; treat as a pass with a hint.
+            return
+            [
+                new EnvironmentCheckResult
+                {
+                    Category = CategoryName,
+                    Name = CheckName,
+                    Status = EnvironmentCheckStatus.Pass,
+                    Message = string.Format(CultureInfo.CurrentCulture, DoctorCommandStrings.NodeJsInstalled, "(version unknown)"),
+                    Details = path,
+                },
+            ];
+        }
+
+        if (!IsSupportedVersion(version))
+        {
+            return
+            [
+                new EnvironmentCheckResult
+                {
+                    Category = CategoryName,
+                    Name = CheckName,
+                    Status = EnvironmentCheckStatus.Warning,
+                    Message = string.Format(CultureInfo.CurrentCulture, DoctorCommandStrings.NodeJsOutdated, version),
+                    Details = path,
+                    Fix = DoctorCommandStrings.NodeJsOutdatedFix,
+                    Link = DocsLink,
+                },
+            ];
+        }
+
+        return
+        [
+            new EnvironmentCheckResult
+            {
+                Category = CategoryName,
+                Name = CheckName,
+                Status = EnvironmentCheckStatus.Pass,
+                Message = string.Format(CultureInfo.CurrentCulture, DoctorCommandStrings.NodeJsInstalled, version),
+                Details = path,
+            },
+        ];
+    }
+
+    private async Task<string?> TryGetNodeVersionAsync(CancellationToken cancellationToken)
+    {
+        try
+        {
+            var psi = new ProcessStartInfo
+            {
+                FileName = "node",
+                Arguments = "--version",
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+                CreateNoWindow = true,
+            };
+
+            using var process = Process.Start(psi);
+            if (process is null)
+            {
+                return null;
+            }
+
+            using var timeoutCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+            timeoutCts.CancelAfter(s_processTimeout);
+
+            string output;
+            try
+            {
+                output = await process.StandardOutput.ReadToEndAsync(timeoutCts.Token);
+                await process.WaitForExitAsync(timeoutCts.Token);
+            }
+            catch (OperationCanceledException) when (!cancellationToken.IsCancellationRequested)
+            {
+                try
+                {
+                    process.Kill(entireProcessTree: true);
+                }
+                catch
+                {
+                    // Best effort cleanup.
+                }
+                return null;
+            }
+
+            if (process.ExitCode != 0)
+            {
+                return null;
+            }
+
+            return ExtractVersion(output);
+        }
+        catch (Exception ex)
+        {
+            logger.LogDebug(ex, "Failed to invoke node --version");
+            return null;
+        }
+    }
+
+    internal static string? ExtractVersion(string nodeOutput)
+    {
+        if (string.IsNullOrWhiteSpace(nodeOutput))
+        {
+            return null;
+        }
+
+        var match = NodeVersionRegex().Match(nodeOutput);
+        return match.Success ? match.Value : null;
+    }
+
+    internal static bool IsSupportedVersion(string version)
+    {
+        if (!TryParseVersion(version, out var parsed))
+        {
+            return true;
+        }
+
+        // Major versions newer than our known matrix are considered supported.
+        var maxKnownMajor = 0;
+        foreach (var (major, _, _) in s_minimumSupportedVersions)
+        {
+            if (major > maxKnownMajor)
+            {
+                maxKnownMajor = major;
+            }
+        }
+
+        if (parsed.Major > maxKnownMajor)
+        {
+            return true;
+        }
+
+        foreach (var (major, minor, patch) in s_minimumSupportedVersions)
+        {
+            if (parsed.Major == major)
+            {
+                if (parsed.Minor > minor)
+                {
+                    return true;
+                }
+
+                if (parsed.Minor == minor)
+                {
+                    return parsed.Patch >= patch;
+                }
+
+                return false;
+            }
+        }
+
+        // Major versions older than every known floor are not supported.
+        return false;
+    }
+
+    private static bool TryParseVersion(string value, out (int Major, int Minor, int Patch) parsed)
+    {
+        parsed = default;
+
+        var match = NodeVersionRegex().Match(value);
+        if (!match.Success)
+        {
+            return false;
+        }
+
+        var parts = match.Value.Split('.');
+        if (!int.TryParse(parts[0], NumberStyles.Integer, CultureInfo.InvariantCulture, out var major))
+        {
+            return false;
+        }
+
+        var minor = 0;
+        var patch = 0;
+        if (parts.Length > 1)
+        {
+            _ = int.TryParse(parts[1], NumberStyles.Integer, CultureInfo.InvariantCulture, out minor);
+        }
+        if (parts.Length > 2)
+        {
+            _ = int.TryParse(parts[2], NumberStyles.Integer, CultureInfo.InvariantCulture, out patch);
+        }
+
+        parsed = (major, minor, patch);
+        return true;
+    }
+
+    [GeneratedRegex(@"\d+\.\d+\.\d+")]
+    private static partial Regex NodeVersionRegex();
+}

--- a/src/Aspire.Cli/Utils/EnvironmentChecker/TypeScriptAppHostDiscovery.cs
+++ b/src/Aspire.Cli/Utils/EnvironmentChecker/TypeScriptAppHostDiscovery.cs
@@ -1,0 +1,173 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Text.Json;
+using System.Text.Json.Nodes;
+
+namespace Aspire.Cli.Utils.EnvironmentChecker;
+
+/// <summary>
+/// Describes a TypeScript AppHost discovered relative to a working directory.
+/// </summary>
+/// <param name="AppHostFile">The <c>apphost.ts</c> file that was discovered.</param>
+/// <param name="AppHostDirectory">The directory containing <see cref="AppHostFile"/>.</param>
+internal sealed record TypeScriptAppHostLocation(FileInfo AppHostFile, DirectoryInfo AppHostDirectory);
+
+/// <summary>
+/// Discovers a TypeScript AppHost (<c>apphost.ts</c>) near the current working directory.
+/// </summary>
+/// <remarks>
+/// The discovery is intentionally narrow to keep <c>aspire doctor</c> noise-free for
+/// non-polyglot projects. It searches:
+/// <list type="number">
+///   <item>The working directory itself.</item>
+///   <item>Each immediate subdirectory of the working directory (one level only).</item>
+///   <item>Hints from <c>.aspire/settings.json</c> when its <c>language</c> indicates TypeScript.</item>
+/// </list>
+/// </remarks>
+internal static class TypeScriptAppHostDiscovery
+{
+    private const string AppHostFileName = "apphost.ts";
+    private const string PackageJsonFileName = "package.json";
+    private const string SettingsFolderName = ".aspire";
+    private const string SettingsFileName = "settings.json";
+
+    private static readonly string[] s_typeScriptLanguageMarkers =
+    [
+        "typescript/nodejs",
+        "typescript",
+    ];
+
+    /// <summary>
+    /// Attempts to discover a TypeScript AppHost near <paramref name="workingDirectory"/>.
+    /// </summary>
+    /// <param name="workingDirectory">The directory to start searching from.</param>
+    /// <returns>The discovered AppHost location, or <see langword="null"/> if none was found.</returns>
+    public static TypeScriptAppHostLocation? TryDiscover(DirectoryInfo workingDirectory)
+    {
+        ArgumentNullException.ThrowIfNull(workingDirectory);
+
+        if (!workingDirectory.Exists)
+        {
+            return null;
+        }
+
+        // 1. apphost.ts in the working directory itself.
+        if (TryGetLocation(workingDirectory, out var location))
+        {
+            return location;
+        }
+
+        // 2. apphost.ts in a directory referenced by .aspire/settings.json.
+        if (TryFromSettings(workingDirectory, out location))
+        {
+            return location;
+        }
+
+        // 3. apphost.ts in any immediate subdirectory.
+        foreach (var child in EnumerateChildDirectoriesSafely(workingDirectory))
+        {
+            if (TryGetLocation(child, out location))
+            {
+                return location;
+            }
+        }
+
+        return null;
+    }
+
+    private static bool TryGetLocation(DirectoryInfo directory, out TypeScriptAppHostLocation location)
+    {
+        var appHostPath = Path.Combine(directory.FullName, AppHostFileName);
+        var packageJsonPath = Path.Combine(directory.FullName, PackageJsonFileName);
+
+        if (File.Exists(appHostPath) && File.Exists(packageJsonPath))
+        {
+            location = new TypeScriptAppHostLocation(new FileInfo(appHostPath), directory);
+            return true;
+        }
+
+        location = null!;
+        return false;
+    }
+
+    private static bool TryFromSettings(DirectoryInfo workingDirectory, out TypeScriptAppHostLocation location)
+    {
+        location = null!;
+
+        var settingsPath = Path.Combine(workingDirectory.FullName, SettingsFolderName, SettingsFileName);
+        if (!File.Exists(settingsPath))
+        {
+            return false;
+        }
+
+        string? language;
+        string? appHostPath;
+        try
+        {
+            using var stream = File.OpenRead(settingsPath);
+            var node = JsonNode.Parse(stream, documentOptions: new JsonDocumentOptions
+            {
+                CommentHandling = JsonCommentHandling.Skip,
+                AllowTrailingCommas = true,
+            });
+
+            if (node is not JsonObject obj)
+            {
+                return false;
+            }
+
+            language = obj["language"]?.GetValue<string>();
+            appHostPath = obj["appHostPath"]?.GetValue<string>();
+        }
+        catch (Exception ex) when (ex is JsonException or IOException or UnauthorizedAccessException)
+        {
+            return false;
+        }
+
+        if (language is null ||
+            !s_typeScriptLanguageMarkers.Any(marker => string.Equals(marker, language, StringComparison.OrdinalIgnoreCase)))
+        {
+            return false;
+        }
+
+        if (string.IsNullOrWhiteSpace(appHostPath))
+        {
+            return TryGetLocation(workingDirectory, out location);
+        }
+
+        var resolved = Path.IsPathRooted(appHostPath)
+            ? appHostPath
+            : Path.GetFullPath(Path.Combine(workingDirectory.FullName, appHostPath));
+
+        var directory = new DirectoryInfo(Path.GetDirectoryName(resolved) ?? workingDirectory.FullName);
+        return TryGetLocation(directory, out location);
+    }
+
+    private static IEnumerable<DirectoryInfo> EnumerateChildDirectoriesSafely(DirectoryInfo workingDirectory)
+    {
+        DirectoryInfo[] children;
+        try
+        {
+            children = workingDirectory.GetDirectories();
+        }
+        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
+        {
+            yield break;
+        }
+
+        foreach (var child in children)
+        {
+            // Skip well-known noise directories.
+            if (child.Name.StartsWith('.') ||
+                string.Equals(child.Name, "node_modules", StringComparison.OrdinalIgnoreCase) ||
+                string.Equals(child.Name, "bin", StringComparison.OrdinalIgnoreCase) ||
+                string.Equals(child.Name, "obj", StringComparison.OrdinalIgnoreCase))
+            {
+                continue;
+            }
+
+            yield return child;
+        }
+    }
+}

--- a/src/Aspire.Cli/Utils/EnvironmentChecker/TypeScriptAppHostPackageManagerCheck.cs
+++ b/src/Aspire.Cli/Utils/EnvironmentChecker/TypeScriptAppHostPackageManagerCheck.cs
@@ -1,0 +1,330 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Diagnostics;
+using System.Globalization;
+using System.Text.RegularExpressions;
+using Aspire.Cli.Resources;
+using Microsoft.Extensions.Logging;
+
+namespace Aspire.Cli.Utils.EnvironmentChecker;
+
+/// <summary>
+/// Verifies that the package-manager tooling required by the TypeScript AppHost in the
+/// current workspace is installed on PATH.
+/// </summary>
+/// <remarks>
+/// The check is gated on TypeScript AppHost discovery: when no <c>apphost.ts</c> is
+/// found near the working directory, an empty result list is returned and the
+/// <c>polyglot</c> category does not appear in <c>aspire doctor</c> output.
+/// </remarks>
+internal sealed partial class TypeScriptAppHostPackageManagerCheck(
+    CliExecutionContext executionContext,
+    ILogger<TypeScriptAppHostPackageManagerCheck> logger) : IEnvironmentCheck
+{
+    private const string CategoryName = "polyglot";
+    private const string DocsLink = "https://aka.ms/aspire-prerequisites";
+
+    private static readonly TimeSpan s_processTimeout = TimeSpan.FromSeconds(10);
+
+    public int Order => 50; // After container (40) and dev-certs (35).
+
+    public async Task<IReadOnlyList<EnvironmentCheckResult>> CheckAsync(CancellationToken cancellationToken = default)
+    {
+        var location = TypeScriptAppHostDiscovery.TryDiscover(executionContext.WorkingDirectory);
+        if (location is null)
+        {
+            return [];
+        }
+
+        AppHostPackageManagerResolution resolution;
+        try
+        {
+            resolution = AppHostPackageManagerResolver.Resolve(location.AppHostDirectory);
+        }
+        catch (Exception ex)
+        {
+            logger.LogDebug(ex, "Failed to resolve package manager for TypeScript AppHost at {Directory}", location.AppHostDirectory.FullName);
+            return [];
+        }
+
+        logger.LogDebug(
+            "Resolved package manager {PackageManager} for TypeScript AppHost at {Directory} (source: {Source})",
+            resolution.PackageManager,
+            location.AppHostDirectory.FullName,
+            resolution.Source);
+
+        var results = new List<EnvironmentCheckResult>();
+
+        switch (resolution.PackageManager)
+        {
+            case AppHostPackageManager.Npm:
+                results.Add(await CheckCommandAsync(
+                    displayName: "npm",
+                    executableName: "npm",
+                    installLink: GetInstallLink(AppHostPackageManager.Npm),
+                    checkName: "npm",
+                    cancellationToken));
+
+                results.Add(await CheckNpxAsync(cancellationToken));
+                break;
+
+            case AppHostPackageManager.Pnpm:
+                results.Add(await CheckCommandAsync(
+                    displayName: "pnpm",
+                    executableName: "pnpm",
+                    installLink: GetInstallLink(AppHostPackageManager.Pnpm),
+                    checkName: "pnpm",
+                    cancellationToken));
+                break;
+
+            case AppHostPackageManager.Bun:
+                results.Add(await CheckCommandAsync(
+                    displayName: "Bun",
+                    executableName: "bun",
+                    installLink: GetInstallLink(AppHostPackageManager.Bun),
+                    checkName: "bun",
+                    cancellationToken));
+                break;
+
+            case AppHostPackageManager.YarnBerry:
+                results.Add(await CheckYarnAsync(cancellationToken));
+                break;
+
+            case AppHostPackageManager.YarnClassic:
+                results.Add(BuildYarnClassicWarning());
+                break;
+        }
+
+        return results;
+    }
+
+    private async Task<EnvironmentCheckResult> CheckCommandAsync(
+        string displayName,
+        string executableName,
+        string installLink,
+        string checkName,
+        CancellationToken cancellationToken)
+    {
+        var path = PathLookupHelper.FindFullPathFromPath(executableName);
+        if (path is null)
+        {
+            return new EnvironmentCheckResult
+            {
+                Category = CategoryName,
+                Name = $"package-manager-{checkName}",
+                Status = EnvironmentCheckStatus.Fail,
+                Message = string.Format(CultureInfo.CurrentCulture, DoctorCommandStrings.PackageManagerMissing, displayName),
+                Fix = string.Format(CultureInfo.CurrentCulture, DoctorCommandStrings.PackageManagerMissingFix, displayName),
+                Link = installLink,
+            };
+        }
+
+        var version = await TryGetVersionAsync(executableName, cancellationToken);
+
+        var message = version is null
+            ? string.Format(CultureInfo.CurrentCulture, DoctorCommandStrings.PackageManagerInstalledNoVersion, displayName)
+            : string.Format(CultureInfo.CurrentCulture, DoctorCommandStrings.PackageManagerInstalled, displayName, version);
+
+        return new EnvironmentCheckResult
+        {
+            Category = CategoryName,
+            Name = $"package-manager-{checkName}",
+            Status = EnvironmentCheckStatus.Pass,
+            Message = message,
+            Details = path,
+        };
+    }
+
+    private async Task<EnvironmentCheckResult> CheckNpxAsync(CancellationToken cancellationToken)
+    {
+        var path = PathLookupHelper.FindFullPathFromPath("npx");
+        if (path is null)
+        {
+            return new EnvironmentCheckResult
+            {
+                Category = CategoryName,
+                Name = "package-manager-npx",
+                Status = EnvironmentCheckStatus.Fail,
+                Message = DoctorCommandStrings.NpxMissing,
+                Fix = DoctorCommandStrings.NpxMissingFix,
+                Link = GetInstallLink(AppHostPackageManager.Npm),
+            };
+        }
+
+        var version = await TryGetVersionAsync("npx", cancellationToken);
+
+        var message = version is null
+            ? string.Format(CultureInfo.CurrentCulture, DoctorCommandStrings.PackageManagerInstalledNoVersion, "npx")
+            : string.Format(CultureInfo.CurrentCulture, DoctorCommandStrings.PackageManagerInstalled, "npx", version);
+
+        return new EnvironmentCheckResult
+        {
+            Category = CategoryName,
+            Name = "package-manager-npx",
+            Status = EnvironmentCheckStatus.Pass,
+            Message = message,
+            Details = path,
+        };
+    }
+
+    private async Task<EnvironmentCheckResult> CheckYarnAsync(CancellationToken cancellationToken)
+    {
+        var path = PathLookupHelper.FindFullPathFromPath("yarn");
+        if (path is null)
+        {
+            return new EnvironmentCheckResult
+            {
+                Category = CategoryName,
+                Name = "package-manager-yarn",
+                Status = EnvironmentCheckStatus.Fail,
+                Message = string.Format(CultureInfo.CurrentCulture, DoctorCommandStrings.PackageManagerMissing, "Yarn"),
+                Fix = string.Format(CultureInfo.CurrentCulture, DoctorCommandStrings.PackageManagerMissingFix, "Yarn"),
+                Link = GetInstallLink(AppHostPackageManager.YarnBerry),
+            };
+        }
+
+        var version = await TryGetVersionAsync("yarn", cancellationToken);
+
+        // If we couldn't determine the version, give the user the benefit of the doubt.
+        if (version is null)
+        {
+            return new EnvironmentCheckResult
+            {
+                Category = CategoryName,
+                Name = "package-manager-yarn",
+                Status = EnvironmentCheckStatus.Pass,
+                Message = string.Format(CultureInfo.CurrentCulture, DoctorCommandStrings.PackageManagerInstalledNoVersion, "Yarn"),
+                Details = path,
+            };
+        }
+
+        if (TryParseMajorVersion(version, out var major) && major < 2)
+        {
+            return new EnvironmentCheckResult
+            {
+                Category = CategoryName,
+                Name = "package-manager-yarn",
+                Status = EnvironmentCheckStatus.Warning,
+                Message = DoctorCommandStrings.YarnClassicUnsupported,
+                Details = string.Format(CultureInfo.CurrentCulture, "yarn --version reported {0} at {1}", version, path),
+                Fix = DoctorCommandStrings.YarnClassicUnsupportedFix,
+                Link = GetInstallLink(AppHostPackageManager.YarnBerry),
+            };
+        }
+
+        return new EnvironmentCheckResult
+        {
+            Category = CategoryName,
+            Name = "package-manager-yarn",
+            Status = EnvironmentCheckStatus.Pass,
+            Message = string.Format(CultureInfo.CurrentCulture, DoctorCommandStrings.PackageManagerInstalled, "Yarn", version),
+            Details = path,
+        };
+    }
+
+    private static EnvironmentCheckResult BuildYarnClassicWarning()
+    {
+        return new EnvironmentCheckResult
+        {
+            Category = CategoryName,
+            Name = "package-manager-yarn",
+            Status = EnvironmentCheckStatus.Warning,
+            Message = DoctorCommandStrings.YarnClassicUnsupported,
+            Fix = DoctorCommandStrings.YarnClassicUnsupportedFix,
+            Link = GetInstallLink(AppHostPackageManager.YarnBerry),
+        };
+    }
+
+    private async Task<string?> TryGetVersionAsync(string executableName, CancellationToken cancellationToken)
+    {
+        try
+        {
+            var psi = new ProcessStartInfo
+            {
+                FileName = executableName,
+                Arguments = "--version",
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+                CreateNoWindow = true,
+            };
+
+            using var process = Process.Start(psi);
+            if (process is null)
+            {
+                return null;
+            }
+
+            using var timeoutCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+            timeoutCts.CancelAfter(s_processTimeout);
+
+            string output;
+            try
+            {
+                output = await process.StandardOutput.ReadToEndAsync(timeoutCts.Token);
+                await process.WaitForExitAsync(timeoutCts.Token);
+            }
+            catch (OperationCanceledException) when (!cancellationToken.IsCancellationRequested)
+            {
+                try
+                {
+                    process.Kill(entireProcessTree: true);
+                }
+                catch
+                {
+                    // Best effort cleanup.
+                }
+                return null;
+            }
+
+            if (process.ExitCode != 0)
+            {
+                return null;
+            }
+
+            var trimmed = output.Trim();
+            return string.IsNullOrEmpty(trimmed) ? null : NormalizeVersion(trimmed);
+        }
+        catch (Exception ex)
+        {
+            logger.LogDebug(ex, "Failed to invoke {Executable} --version", executableName);
+            return null;
+        }
+    }
+
+    private static string NormalizeVersion(string value)
+    {
+        // Some tools emit additional text (e.g., npm prints multiple lines on first run).
+        var match = VersionRegex().Match(value);
+        return match.Success ? match.Value : value;
+    }
+
+    private static bool TryParseMajorVersion(string version, out int major)
+    {
+        var match = VersionRegex().Match(version);
+        if (!match.Success)
+        {
+            major = 0;
+            return false;
+        }
+
+        var firstSegment = match.Value.Split('.', 2)[0];
+        return int.TryParse(firstSegment, NumberStyles.Integer, CultureInfo.InvariantCulture, out major);
+    }
+
+    private static string GetInstallLink(AppHostPackageManager packageManager)
+    {
+        return packageManager switch
+        {
+            AppHostPackageManager.Npm => "https://nodejs.org/",
+            AppHostPackageManager.Pnpm => "https://pnpm.io/installation",
+            AppHostPackageManager.Bun => "https://bun.sh/docs/installation",
+            AppHostPackageManager.YarnBerry or AppHostPackageManager.YarnClassic => "https://yarnpkg.com/getting-started/install",
+            _ => DocsLink,
+        };
+    }
+
+    [GeneratedRegex(@"\d+(?:\.\d+)*(?:[\-\+][\w\.\-]+)?")]
+    private static partial Regex VersionRegex();
+}

--- a/tests/Aspire.Cli.Tests/Commands/DoctorCommandTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/DoctorCommandTests.cs
@@ -2,8 +2,9 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using Aspire.Cli.Tests.Utils;
-using Microsoft.Extensions.DependencyInjection;
+using Aspire.Cli.Utils.EnvironmentChecker;
 using Microsoft.AspNetCore.InternalTesting;
+using Microsoft.Extensions.DependencyInjection;
 
 namespace Aspire.Cli.Tests.Commands;
 
@@ -20,8 +21,39 @@ public class DoctorCommandTests(ITestOutputHelper outputHelper)
         var result = command.Parse("doctor --help");
 
         var exitCode = await result.InvokeAsync().DefaultTimeout();
-        
+
         // Help should return success
         Assert.Equal(ExitCodeConstants.Success, exitCode);
+    }
+
+    [Fact]
+    public async Task DoctorCommand_SkipsPolyglotChecks_WhenNoTypeScriptAppHostIsPresent()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper);
+        var provider = services.BuildServiceProvider();
+
+        var checker = provider.GetRequiredService<IEnvironmentChecker>();
+        var results = await checker.CheckAllAsync(TestContext.Current.CancellationToken).DefaultTimeout();
+
+        Assert.DoesNotContain(results, r => r.Category == "polyglot");
+    }
+
+    [Fact]
+    public async Task DoctorCommand_RunsPolyglotChecks_WhenTypeScriptAppHostIsPresent()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        File.WriteAllText(Path.Combine(workspace.WorkspaceRoot.FullName, "apphost.ts"), string.Empty);
+        File.WriteAllText(Path.Combine(workspace.WorkspaceRoot.FullName, "package.json"), """{ "packageManager": "yarn@1.22.22" }""");
+
+        var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper);
+        var provider = services.BuildServiceProvider();
+
+        var checker = provider.GetRequiredService<IEnvironmentChecker>();
+        var results = await checker.CheckAllAsync(TestContext.Current.CancellationToken).DefaultTimeout();
+
+        var polyglotResults = results.Where(r => r.Category == "polyglot").ToList();
+        Assert.NotEmpty(polyglotResults);
+        Assert.Contains(polyglotResults, r => r.Name == "package-manager-yarn" && r.Status == EnvironmentCheckStatus.Warning);
     }
 }

--- a/tests/Aspire.Cli.Tests/Utils/CliTestHelper.cs
+++ b/tests/Aspire.Cli.Tests/Utils/CliTestHelper.cs
@@ -146,6 +146,8 @@ internal static class CliTestHelper
         services.AddSingleton<IEnvironmentCheck, DeprecatedWorkloadCheck>();
         services.AddSingleton<IEnvironmentCheck, DevCertsCheck>();
         services.AddSingleton<IEnvironmentCheck, ContainerRuntimeCheck>();
+        services.AddSingleton<IEnvironmentCheck, NodeJsRuntimeCheck>();
+        services.AddSingleton<IEnvironmentCheck, TypeScriptAppHostPackageManagerCheck>();
         services.AddSingleton<IEnvironmentCheck, DeprecatedAgentConfigCheck>();
         services.AddSingleton<IEnvironmentChecker, EnvironmentChecker>();
 

--- a/tests/Aspire.Cli.Tests/Utils/EnvironmentChecker/AppHostPackageManagerResolverTests.cs
+++ b/tests/Aspire.Cli.Tests/Utils/EnvironmentChecker/AppHostPackageManagerResolverTests.cs
@@ -1,0 +1,205 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Aspire.Cli.Utils.EnvironmentChecker;
+
+namespace Aspire.Cli.Tests.Utils.EnvironmentChecks;
+
+public class AppHostPackageManagerResolverTests(ITestOutputHelper outputHelper)
+{
+    [Fact]
+    public void Resolve_DefaultsToNpm_WhenNoMarkersPresent()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        var appHostDir = workspace.CreateDirectory("apphost");
+
+        var result = AppHostPackageManagerResolver.Resolve(appHostDir);
+
+        Assert.Equal(AppHostPackageManager.Npm, result.PackageManager);
+        Assert.Equal("default", result.Source);
+        Assert.Null(result.DeclaredVersion);
+    }
+
+    [Theory]
+    [InlineData("npm@10.2.0", nameof(AppHostPackageManager.Npm), "10.2.0")]
+    [InlineData("pnpm@8.6.0", nameof(AppHostPackageManager.Pnpm), "8.6.0")]
+    [InlineData("bun@1.1.30", nameof(AppHostPackageManager.Bun), "1.1.30")]
+    [InlineData("yarn@4.1.0", nameof(AppHostPackageManager.YarnBerry), "4.1.0")]
+    [InlineData("yarn@1.22.22", nameof(AppHostPackageManager.YarnClassic), "1.22.22")]
+    public void Resolve_ReadsPackageManagerField(string fieldValue, string expectedName, string expectedVersion)
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        var appHostDir = workspace.CreateDirectory("apphost");
+        WritePackageJson(appHostDir, $$"""{ "packageManager": "{{fieldValue}}" }""");
+
+        var result = AppHostPackageManagerResolver.Resolve(appHostDir);
+
+        Assert.Equal(Enum.Parse<AppHostPackageManager>(expectedName), result.PackageManager);
+        Assert.Equal(expectedVersion, result.DeclaredVersion);
+        Assert.Contains("packageManager", result.Source);
+    }
+
+    [Fact]
+    public void Resolve_StripsIntegrityHashFromPackageManagerField()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        var appHostDir = workspace.CreateDirectory("apphost");
+        WritePackageJson(appHostDir, """{ "packageManager": "pnpm@8.6.0+sha256:abcd1234" }""");
+
+        var result = AppHostPackageManagerResolver.Resolve(appHostDir);
+
+        Assert.Equal(AppHostPackageManager.Pnpm, result.PackageManager);
+        Assert.Equal("8.6.0", result.DeclaredVersion);
+    }
+
+    [Fact]
+    public void Resolve_FallsBackToImmediateParentForPackageManagerField()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        WritePackageJson(workspace.WorkspaceRoot, """{ "packageManager": "pnpm@8.6.0" }""");
+
+        var appHostDir = workspace.CreateDirectory("apphost");
+
+        var result = AppHostPackageManagerResolver.Resolve(appHostDir);
+
+        Assert.Equal(AppHostPackageManager.Pnpm, result.PackageManager);
+    }
+
+    [Theory]
+    [InlineData("pnpm-lock.yaml", nameof(AppHostPackageManager.Pnpm))]
+    [InlineData("bun.lock", nameof(AppHostPackageManager.Bun))]
+    [InlineData("bun.lockb", nameof(AppHostPackageManager.Bun))]
+    [InlineData("package-lock.json", nameof(AppHostPackageManager.Npm))]
+    public void Resolve_DetectsLockfileInAppHostDirectory(string lockfileName, string expectedName)
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        var appHostDir = workspace.CreateDirectory("apphost");
+        File.WriteAllText(Path.Combine(appHostDir.FullName, lockfileName), string.Empty);
+
+        var result = AppHostPackageManagerResolver.Resolve(appHostDir);
+
+        Assert.Equal(Enum.Parse<AppHostPackageManager>(expectedName), result.PackageManager);
+        Assert.Equal(Path.Combine(appHostDir.FullName, lockfileName), result.Source);
+    }
+
+    [Fact]
+    public void Resolve_DetectsYarnClassicFromLockfileAlone()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        var appHostDir = workspace.CreateDirectory("apphost");
+        File.WriteAllText(Path.Combine(appHostDir.FullName, "yarn.lock"), string.Empty);
+
+        var result = AppHostPackageManagerResolver.Resolve(appHostDir);
+
+        Assert.Equal(AppHostPackageManager.YarnClassic, result.PackageManager);
+    }
+
+    [Fact]
+    public void Resolve_DetectsYarnBerryWhenYarnrcYmlPresent()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        var appHostDir = workspace.CreateDirectory("apphost");
+        File.WriteAllText(Path.Combine(appHostDir.FullName, "yarn.lock"), string.Empty);
+        File.WriteAllText(Path.Combine(appHostDir.FullName, ".yarnrc.yml"), string.Empty);
+
+        var result = AppHostPackageManagerResolver.Resolve(appHostDir);
+
+        Assert.Equal(AppHostPackageManager.YarnBerry, result.PackageManager);
+    }
+
+    [Fact]
+    public void Resolve_DetectsYarnBerryWhenYarnFolderPresent()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        var appHostDir = workspace.CreateDirectory("apphost");
+        File.WriteAllText(Path.Combine(appHostDir.FullName, "yarn.lock"), string.Empty);
+        Directory.CreateDirectory(Path.Combine(appHostDir.FullName, ".yarn"));
+
+        var result = AppHostPackageManagerResolver.Resolve(appHostDir);
+
+        Assert.Equal(AppHostPackageManager.YarnBerry, result.PackageManager);
+    }
+
+    [Fact]
+    public void Resolve_FallsBackToImmediateParentForLockfiles()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        File.WriteAllText(Path.Combine(workspace.WorkspaceRoot.FullName, "pnpm-lock.yaml"), string.Empty);
+
+        var appHostDir = workspace.CreateDirectory("apphost");
+
+        var result = AppHostPackageManagerResolver.Resolve(appHostDir);
+
+        Assert.Equal(AppHostPackageManager.Pnpm, result.PackageManager);
+    }
+
+    [Fact]
+    public void Resolve_IgnoresLockfilesAboveImmediateParent()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        File.WriteAllText(Path.Combine(workspace.WorkspaceRoot.FullName, "pnpm-lock.yaml"), string.Empty);
+
+        var parent = workspace.CreateDirectory("workspace");
+        var appHostDir = parent.CreateSubdirectory("apphost");
+
+        var result = AppHostPackageManagerResolver.Resolve(appHostDir);
+
+        Assert.Equal(AppHostPackageManager.Npm, result.PackageManager);
+        Assert.Equal("default", result.Source);
+    }
+
+    [Fact]
+    public void Resolve_PrefersPackageManagerFieldOverLockfile()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        var appHostDir = workspace.CreateDirectory("apphost");
+        WritePackageJson(appHostDir, """{ "packageManager": "pnpm@8.6.0" }""");
+        File.WriteAllText(Path.Combine(appHostDir.FullName, "package-lock.json"), "{}");
+
+        var result = AppHostPackageManagerResolver.Resolve(appHostDir);
+
+        Assert.Equal(AppHostPackageManager.Pnpm, result.PackageManager);
+    }
+
+    [Fact]
+    public void Resolve_IgnoresInvalidPackageManagerField()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        var appHostDir = workspace.CreateDirectory("apphost");
+        WritePackageJson(appHostDir, """{ "packageManager": "unknown@1.0.0" }""");
+
+        var result = AppHostPackageManagerResolver.Resolve(appHostDir);
+
+        Assert.Equal(AppHostPackageManager.Npm, result.PackageManager);
+        Assert.Equal("default", result.Source);
+    }
+
+    [Fact]
+    public void Resolve_IgnoresMalformedPackageJson()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        var appHostDir = workspace.CreateDirectory("apphost");
+        File.WriteAllText(Path.Combine(appHostDir.FullName, "package.json"), "{ not valid json");
+
+        var result = AppHostPackageManagerResolver.Resolve(appHostDir);
+
+        Assert.Equal(AppHostPackageManager.Npm, result.PackageManager);
+    }
+
+    [Theory]
+    [InlineData(nameof(AppHostPackageManager.Npm), "npm")]
+    [InlineData(nameof(AppHostPackageManager.Pnpm), "pnpm")]
+    [InlineData(nameof(AppHostPackageManager.Bun), "bun")]
+    [InlineData(nameof(AppHostPackageManager.YarnBerry), "yarn")]
+    [InlineData(nameof(AppHostPackageManager.YarnClassic), "yarn")]
+    public void GetExecutableName_ReturnsExpected(string packageManagerName, string expected)
+    {
+        var packageManager = Enum.Parse<AppHostPackageManager>(packageManagerName);
+        Assert.Equal(expected, AppHostPackageManagerResolver.GetExecutableName(packageManager));
+    }
+
+    private static void WritePackageJson(DirectoryInfo directory, string contents)
+    {
+        File.WriteAllText(Path.Combine(directory.FullName, "package.json"), contents);
+    }
+}

--- a/tests/Aspire.Cli.Tests/Utils/EnvironmentChecker/NodeJsRuntimeCheckTests.cs
+++ b/tests/Aspire.Cli.Tests/Utils/EnvironmentChecker/NodeJsRuntimeCheckTests.cs
@@ -1,0 +1,108 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Aspire.Cli.Utils.EnvironmentChecker;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace Aspire.Cli.Tests.Utils.EnvironmentChecks;
+
+public class NodeJsRuntimeCheckTests(ITestOutputHelper outputHelper)
+{
+    [Fact]
+    public async Task CheckAsync_ReturnsEmpty_WhenNoTypeScriptAppHostPresent()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        var executionContext = BuildExecutionContext(workspace.WorkspaceRoot);
+        var check = new NodeJsRuntimeCheck(executionContext, NullLogger<NodeJsRuntimeCheck>.Instance);
+
+        var results = await check.CheckAsync(TestContext.Current.CancellationToken);
+
+        Assert.Empty(results);
+    }
+
+    [Fact]
+    public async Task CheckAsync_SkipsNodeProbe_WhenBunIsResolved()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        File.WriteAllText(Path.Combine(workspace.WorkspaceRoot.FullName, "apphost.ts"), string.Empty);
+        File.WriteAllText(Path.Combine(workspace.WorkspaceRoot.FullName, "package.json"), """{ "packageManager": "bun@1.1.30" }""");
+
+        var executionContext = BuildExecutionContext(workspace.WorkspaceRoot);
+        var check = new NodeJsRuntimeCheck(executionContext, NullLogger<NodeJsRuntimeCheck>.Instance);
+
+        var results = await check.CheckAsync(TestContext.Current.CancellationToken);
+
+        Assert.Empty(results);
+    }
+
+    [Theory]
+    [InlineData("v20.19.0", "20.19.0")]
+    [InlineData("v22.13.5", "22.13.5")]
+    [InlineData("v24.0.0", "24.0.0")]
+    [InlineData("v18.20.4\n", "18.20.4")]
+    [InlineData("node v22.13.0", "22.13.0")]
+    public void ExtractVersion_ReturnsExpected(string input, string expected)
+    {
+        var result = NodeJsRuntimeCheck.ExtractVersion(input);
+
+        Assert.Equal(expected, result);
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("   ")]
+    [InlineData("unknown")]
+    [InlineData("vNaN.NaN")]
+    public void ExtractVersion_ReturnsNull_ForInvalidInput(string input)
+    {
+        var result = NodeJsRuntimeCheck.ExtractVersion(input);
+
+        Assert.Null(result);
+    }
+
+    [Theory]
+    [InlineData("20.19.0", true)]
+    [InlineData("20.19.5", true)]
+    [InlineData("20.20.0", true)]
+    [InlineData("22.13.0", true)]
+    [InlineData("22.13.5", true)]
+    [InlineData("22.20.0", true)]
+    [InlineData("24.0.0", true)]
+    [InlineData("99.0.0", true)]
+    public void IsSupportedVersion_ReturnsTrue_ForSupportedRanges(string version, bool expected)
+    {
+        Assert.Equal(expected, NodeJsRuntimeCheck.IsSupportedVersion(version));
+    }
+
+    [Theory]
+    [InlineData("20.18.0")]
+    [InlineData("20.0.0")]
+    [InlineData("22.12.0")]
+    [InlineData("22.0.0")]
+    [InlineData("18.20.4")]
+    [InlineData("16.0.0")]
+    [InlineData("21.0.0")]
+    public void IsSupportedVersion_ReturnsFalse_ForUnsupportedVersions(string version)
+    {
+        Assert.False(NodeJsRuntimeCheck.IsSupportedVersion(version));
+    }
+
+    [Fact]
+    public void IsSupportedVersion_ReturnsTrue_ForUnparseableVersions()
+    {
+        // Defensive: when we can't parse the version, assume support to avoid noisy warnings.
+        Assert.True(NodeJsRuntimeCheck.IsSupportedVersion("not-a-version"));
+    }
+
+    private static CliExecutionContext BuildExecutionContext(DirectoryInfo workingDirectory)
+    {
+        var aspireRoot = new DirectoryInfo(Path.Combine(workingDirectory.FullName, ".aspire"));
+        var hives = new DirectoryInfo(Path.Combine(aspireRoot.FullName, "hives"));
+        var cache = new DirectoryInfo(Path.Combine(aspireRoot.FullName, "cache"));
+        var sdks = new DirectoryInfo(Path.Combine(Path.GetTempPath(), "aspire-test-sdks"));
+        var logs = new DirectoryInfo(Path.Combine(aspireRoot.FullName, "logs"));
+        var logFile = Path.Combine(logs.FullName, "test.log");
+
+        return new CliExecutionContext(workingDirectory, hives, cache, sdks, logs, logFile);
+    }
+}

--- a/tests/Aspire.Cli.Tests/Utils/EnvironmentChecker/TypeScriptAppHostDiscoveryTests.cs
+++ b/tests/Aspire.Cli.Tests/Utils/EnvironmentChecker/TypeScriptAppHostDiscoveryTests.cs
@@ -1,0 +1,116 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Aspire.Cli.Utils.EnvironmentChecker;
+
+namespace Aspire.Cli.Tests.Utils.EnvironmentChecks;
+
+public class TypeScriptAppHostDiscoveryTests(ITestOutputHelper outputHelper)
+{
+    [Fact]
+    public void TryDiscover_ReturnsNull_WhenNoAppHostExists()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+
+        var result = TypeScriptAppHostDiscovery.TryDiscover(workspace.WorkspaceRoot);
+
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public void TryDiscover_FindsAppHostInWorkingDirectory()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        WriteAppHostFiles(workspace.WorkspaceRoot);
+
+        var result = TypeScriptAppHostDiscovery.TryDiscover(workspace.WorkspaceRoot);
+
+        Assert.NotNull(result);
+        Assert.Equal(workspace.WorkspaceRoot.FullName, result!.AppHostDirectory.FullName);
+        Assert.Equal("apphost.ts", result.AppHostFile.Name);
+    }
+
+    [Fact]
+    public void TryDiscover_FindsAppHostInImmediateChildDirectory()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        var appHostDir = workspace.CreateDirectory("apphost");
+        WriteAppHostFiles(appHostDir);
+
+        var result = TypeScriptAppHostDiscovery.TryDiscover(workspace.WorkspaceRoot);
+
+        Assert.NotNull(result);
+        Assert.Equal(appHostDir.FullName, result!.AppHostDirectory.FullName);
+    }
+
+    [Fact]
+    public void TryDiscover_SkipsHiddenAndNoiseDirectories()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        var nodeModules = workspace.CreateDirectory("node_modules");
+        WriteAppHostFiles(nodeModules);
+
+        var binDir = workspace.CreateDirectory("bin");
+        WriteAppHostFiles(binDir);
+
+        var result = TypeScriptAppHostDiscovery.TryDiscover(workspace.WorkspaceRoot);
+
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public void TryDiscover_RequiresBothAppHostAndPackageJson()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        File.WriteAllText(Path.Combine(workspace.WorkspaceRoot.FullName, "apphost.ts"), string.Empty);
+
+        var result = TypeScriptAppHostDiscovery.TryDiscover(workspace.WorkspaceRoot);
+
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public void TryDiscover_UsesSettingsLanguageHint()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        var appHostDir = workspace.CreateDirectory("apphost");
+        WriteAppHostFiles(appHostDir);
+
+        // Override the empty settings file created by TemporaryWorkspace.Create.
+        var settingsPath = Path.Combine(workspace.WorkspaceRoot.FullName, ".aspire", "settings.json");
+        File.WriteAllText(settingsPath, """{ "language": "typescript/nodejs" }""");
+
+        var result = TypeScriptAppHostDiscovery.TryDiscover(workspace.WorkspaceRoot);
+
+        Assert.NotNull(result);
+        Assert.Equal(appHostDir.FullName, result!.AppHostDirectory.FullName);
+    }
+
+    [Fact]
+    public void TryDiscover_IgnoresSettingsWithUnknownLanguage()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        var settingsPath = Path.Combine(workspace.WorkspaceRoot.FullName, ".aspire", "settings.json");
+        File.WriteAllText(settingsPath, """{ "language": "csharp" }""");
+
+        var result = TypeScriptAppHostDiscovery.TryDiscover(workspace.WorkspaceRoot);
+
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public void TryDiscover_ReturnsNull_WhenWorkingDirectoryDoesNotExist()
+    {
+        var nonexistent = new DirectoryInfo(Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString()));
+
+        var result = TypeScriptAppHostDiscovery.TryDiscover(nonexistent);
+
+        Assert.Null(result);
+    }
+
+    private static void WriteAppHostFiles(DirectoryInfo directory)
+    {
+        File.WriteAllText(Path.Combine(directory.FullName, "apphost.ts"), string.Empty);
+        File.WriteAllText(Path.Combine(directory.FullName, "package.json"), "{}");
+    }
+}

--- a/tests/Aspire.Cli.Tests/Utils/EnvironmentChecker/TypeScriptAppHostPackageManagerCheckTests.cs
+++ b/tests/Aspire.Cli.Tests/Utils/EnvironmentChecker/TypeScriptAppHostPackageManagerCheckTests.cs
@@ -1,0 +1,80 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Aspire.Cli.Utils.EnvironmentChecker;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace Aspire.Cli.Tests.Utils.EnvironmentChecks;
+
+public class TypeScriptAppHostPackageManagerCheckTests(ITestOutputHelper outputHelper)
+{
+    [Fact]
+    public async Task CheckAsync_ReturnsEmpty_WhenNoTypeScriptAppHostPresent()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        var executionContext = BuildExecutionContext(workspace.WorkspaceRoot);
+        var check = new TypeScriptAppHostPackageManagerCheck(executionContext, NullLogger<TypeScriptAppHostPackageManagerCheck>.Instance);
+
+        var results = await check.CheckAsync(TestContext.Current.CancellationToken);
+
+        Assert.Empty(results);
+    }
+
+    [Fact]
+    public async Task CheckAsync_EmitsYarnClassicWarning_WhenYarnClassicDetected()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        File.WriteAllText(Path.Combine(workspace.WorkspaceRoot.FullName, "apphost.ts"), string.Empty);
+        File.WriteAllText(Path.Combine(workspace.WorkspaceRoot.FullName, "package.json"), """{ "packageManager": "yarn@1.22.22" }""");
+
+        var executionContext = BuildExecutionContext(workspace.WorkspaceRoot);
+        var check = new TypeScriptAppHostPackageManagerCheck(executionContext, NullLogger<TypeScriptAppHostPackageManagerCheck>.Instance);
+
+        var results = await check.CheckAsync(TestContext.Current.CancellationToken);
+
+        var result = Assert.Single(results);
+        Assert.Equal(EnvironmentCheckStatus.Warning, result.Status);
+        Assert.Equal("polyglot", result.Category);
+        Assert.Equal("package-manager-yarn", result.Name);
+        Assert.NotNull(result.Link);
+        Assert.NotNull(result.Fix);
+    }
+
+    [Fact]
+    public async Task CheckAsync_AssignsPolyglotCategoryToAllResults()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        File.WriteAllText(Path.Combine(workspace.WorkspaceRoot.FullName, "apphost.ts"), string.Empty);
+        File.WriteAllText(Path.Combine(workspace.WorkspaceRoot.FullName, "package.json"), "{}");
+
+        var executionContext = BuildExecutionContext(workspace.WorkspaceRoot);
+        var check = new TypeScriptAppHostPackageManagerCheck(executionContext, NullLogger<TypeScriptAppHostPackageManagerCheck>.Instance);
+
+        var results = await check.CheckAsync(TestContext.Current.CancellationToken);
+
+        Assert.NotEmpty(results);
+        Assert.All(results, r => Assert.Equal("polyglot", r.Category));
+    }
+
+    [Fact]
+    public void Order_IsAfterContainerRuntime()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        var executionContext = BuildExecutionContext(workspace.WorkspaceRoot);
+        var check = new TypeScriptAppHostPackageManagerCheck(executionContext, NullLogger<TypeScriptAppHostPackageManagerCheck>.Instance);
+
+        Assert.True(check.Order >= 45);
+    }
+
+    private static CliExecutionContext BuildExecutionContext(DirectoryInfo workingDirectory)
+    {
+        var aspireRoot = new DirectoryInfo(Path.Combine(workingDirectory.FullName, ".aspire"));
+        var hives = new DirectoryInfo(Path.Combine(aspireRoot.FullName, "hives"));
+        var cache = new DirectoryInfo(Path.Combine(aspireRoot.FullName, "cache"));
+        var sdks = new DirectoryInfo(Path.Combine(Path.GetTempPath(), "aspire-test-sdks"));
+        var logs = new DirectoryInfo(Path.Combine(aspireRoot.FullName, "logs"));
+        var logFile = Path.Combine(logs.FullName, "test.log");
+
+        return new CliExecutionContext(workingDirectory, hives, cache, sdks, logs, logFile);
+    }
+}


### PR DESCRIPTION
## Description

Adds two new `IEnvironmentCheck` implementations to `aspire doctor` so that TypeScript AppHost (`apphost.ts`) package-manager and runtime requirements are validated before users hit a low-signal "command not found" error from `aspire run`.

When an `apphost.ts` is discovered next to the working directory (or via `.aspire/settings.json`), the resolver inspects the `packageManager` field in `package.json` (immediate-parent aware), falls back to lockfile detection (`pnpm-lock.yaml`, `bun.lock(b)`, `yarn.lock`, `package-lock.json`), then defaults to npm. Yarn Berry vs Classic is disambiguated by version field, `.yarnrc.yml`, or `.yarn/` directory ΓÇö matching the conventions used by `Aspire.Hosting.JavaScript`.

Results land under a new `polyglot` doctor category between `container` and `environment`. The checks are skipped entirely for non-TS workspaces so nothing changes for existing .NET-only AppHosts.

### Diagnostics surfaced

| Condition | Severity |
| --- | --- |
| Missing `npm` / `pnpm` / `bun` / `yarn` CLI | Fail |
| Missing `npx` (npm path) | Fail |
| Yarn Classic (v1) detected | Warning |
| Node.js not on PATH (non-Bun managers) | Fail |
| Node.js below 20.19 / 22.13 floor | Warning |
| Bun-managed AppHost | Skips Node check |

Fixes #17032

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
- Did you add public API?
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [x] No
- Does the change require an update in our Aspire docs?
  - [x] No
