### PR TITLE
Revert pipeline SDK to 10.0.201

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "10.0.300",
+    "version": "10.0.201",
     "rollForward": "major",
     "allowPrerelease": true,
     "paths": [
@@ -10,7 +10,7 @@
     "errorMessage": "The .NET SDK could not be found. Run ./restore.sh (Linux/macOS) or ./restore.cmd (Windows) to install the local SDK."
   },
   "tools": {
-    "dotnet": "10.0.300",
+    "dotnet": "10.0.201",
     "runtimes": {
       "dotnet/x64": [
         "$(DotNetRuntimePreviousVersionForTesting)",


### PR DESCRIPTION
## Description

Azure DevOps pipeline definition 1602 started failing after PR #17190 bumped the repository SDK/tooling version from 10.0.201 to 10.0.300. The earliest failures hit native Windows packaging in `Microsoft.NET.ILLink.targets` during `ComputeManagedAssemblies`, and later failures hit `darc` tool installation because `dotnet tool install microsoft.dotnet.darc --add-source` is incompatible with the current package source mapping setup.

This reverts only the `global.json` SDK and `tools.dotnet` values back to `10.0.201` to unblock the pipeline while preserving the other Component Governance dependency fixes from PR #17190.

Validation:
- Parsed `global.json` with PowerShell `ConvertFrom-Json`.
- Inspected `git diff -- global.json` and confirmed only `sdk.version` and `tools.dotnet` changed.

Fixes # (issue)

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [x] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
