### PR TITLE
Add server-side support for CLI dependent choice validation

### DIFF
--- a/src/Aspire.Cli/Backchannel/BackchannelJsonSerializerContext.cs
+++ b/src/Aspire.Cli/Backchannel/BackchannelJsonSerializerContext.cs
@@ -86,6 +86,9 @@ namespace Aspire.Cli.Backchannel;
 [JsonSerializable(typeof(PipelineStepInfo[]))]
 [JsonSerializable(typeof(GetPipelineStepsRequest))]
 [JsonSerializable(typeof(GetPipelineStepsResponse))]
+[JsonSerializable(typeof(LoadDynamicArgumentOptionsRequest))]
+[JsonSerializable(typeof(LoadDynamicArgumentOptionsResponse))]
+[JsonSerializable(typeof(LoadDynamicArgumentOptionsStatus))]
 internal partial class BackchannelJsonSerializerContext : JsonSerializerContext
 {
     [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2026:RequiresUnreferencedCode", Justification = "Using the Json source generator.")]

--- a/src/Aspire.Hosting/ApplicationModel/ResourceCommandService.cs
+++ b/src/Aspire.Hosting/ApplicationModel/ResourceCommandService.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Globalization;
+using Aspire.Hosting.Backchannel;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 
@@ -372,6 +373,89 @@ public class ResourceCommandService
 
         logger.LogInformation("Command '{CommandName}' not available.", commandName);
         return new ExecuteCommandResult { Success = false, Message = $"Command '{commandName}' not available for resource '{resource.GetResolvedDisplayResourceName(resourceId)}'." };
+    }
+
+    internal async Task<LoadDynamicArgumentOptionsResponse> LoadDynamicArgumentOptionsAsync(
+        string resourceId,
+        string commandName,
+        string argumentName,
+        IReadOnlyDictionary<string, string?>? currentValues,
+        CancellationToken cancellationToken)
+    {
+        if (!_resourceNotificationService.TryGetCurrentState(resourceId, out var resourceEvent))
+        {
+            return new LoadDynamicArgumentOptionsResponse { Status = LoadDynamicArgumentOptionsStatus.ResourceNotFound };
+        }
+
+        var resolvedCommandName = commandName;
+        var logger = _resourceLoggerService.GetLogger(resourceId);
+        var annotation = ResolveCommandAnnotation(resourceEvent.Resource, ref resolvedCommandName, logger);
+
+        if (annotation is null)
+        {
+            return new LoadDynamicArgumentOptionsResponse { Status = LoadDynamicArgumentOptionsStatus.CommandNotFound };
+        }
+
+        var targetInput = annotation.Arguments.FirstOrDefault(a =>
+            string.Equals(a.Name, argumentName, StringComparisons.InteractionInputName));
+
+        if (targetInput is null)
+        {
+            return new LoadDynamicArgumentOptionsResponse { Status = LoadDynamicArgumentOptionsStatus.ArgumentNotFound };
+        }
+
+        if (targetInput.DynamicLoading is not { } dynamicLoading)
+        {
+            return new LoadDynamicArgumentOptionsResponse { Status = LoadDynamicArgumentOptionsStatus.NotDynamic };
+        }
+
+        var collection = CreateArguments(annotation.Arguments, currentValues);
+
+        if (!ShouldLoadDynamicCommandArgument(dynamicLoading, collection))
+        {
+            var missing = dynamicLoading.DependsOnInputs?
+                .Where(d => !collection.TryGetByName(d, out var i) || string.IsNullOrEmpty(i.Value))
+                .ToArray();
+
+            return new LoadDynamicArgumentOptionsResponse
+            {
+                Status = LoadDynamicArgumentOptionsStatus.DependenciesNotSatisfied,
+                MissingDependencies = missing
+            };
+        }
+
+        if (!collection.TryGetByName(argumentName, out var inputClone))
+        {
+            return new LoadDynamicArgumentOptionsResponse { Status = LoadDynamicArgumentOptionsStatus.ArgumentNotFound };
+        }
+
+        try
+        {
+            await dynamicLoading.LoadCallback(new LoadInputContext
+            {
+                AllInputs = collection,
+                Input = inputClone,
+                Services = _serviceProvider,
+                CancellationToken = cancellationToken
+            }).ConfigureAwait(false);
+        }
+        catch (Exception ex)
+        {
+            logger.LogWarning(ex, "Failed to load dynamic options for argument '{ArgumentName}' on command '{CommandName}'.", argumentName, commandName);
+            return new LoadDynamicArgumentOptionsResponse
+            {
+                Status = LoadDynamicArgumentOptionsStatus.Error,
+                Message = ex.Message
+            };
+        }
+
+        return new LoadDynamicArgumentOptionsResponse
+        {
+            Status = LoadDynamicArgumentOptionsStatus.Loaded,
+            Options = inputClone.Options?
+                .Select(keyValuePair => new KeyValuePair<string, string?>(keyValuePair.Key, keyValuePair.Value))
+                .ToArray()
+        };
     }
 
     internal async Task<ExecuteCommandResult> ValidateCommandArgumentsAsync(string resourceId, string commandName, InteractionInputCollection arguments, CancellationToken cancellationToken)

--- a/src/Aspire.Hosting/Backchannel/AuxiliaryBackchannelRpcTarget.cs
+++ b/src/Aspire.Hosting/Backchannel/AuxiliaryBackchannelRpcTarget.cs
@@ -323,6 +323,26 @@ internal sealed class AuxiliaryBackchannelRpcTarget(
         };
     }
 
+    /// <summary>
+    /// Loads the dynamic Choice options for a single resource command argument given partial input values, without executing the command.
+    /// </summary>
+    /// <param name="request">The load request describing the target argument and the current input values.</param>
+    /// <param name="cancellationToken">A cancellation token.</param>
+    /// <returns>A response describing the load outcome.</returns>
+    public async Task<LoadDynamicArgumentOptionsResponse> LoadDynamicArgumentOptionsAsync(LoadDynamicArgumentOptionsRequest request, CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+        using var activity = profilingTelemetry.StartJsonRpcServerCall(nameof(LoadDynamicArgumentOptionsAsync), streaming: false, request.TraceContext);
+
+        var resourceCommandService = serviceProvider.GetRequiredService<ResourceCommandService>();
+        return await resourceCommandService.LoadDynamicArgumentOptionsAsync(
+            request.ResourceId,
+            request.CommandName,
+            request.ArgumentName,
+            request.CurrentValues,
+            cancellationToken).ConfigureAwait(false);
+    }
+
     private static (InteractionInputCollection Arguments, string? ErrorMessage) CreateCommandArguments(ResourceCommandService resourceCommandService, ExecuteResourceCommandRequest request)
     {
         var arguments = request.Arguments;

--- a/src/Aspire.Hosting/Backchannel/AuxiliaryBackchannelRpcTarget.cs
+++ b/src/Aspire.Hosting/Backchannel/AuxiliaryBackchannelRpcTarget.cs
@@ -50,7 +50,7 @@ internal sealed class AuxiliaryBackchannelRpcTarget(
 
         return Task.FromResult(new GetCapabilitiesResponse
         {
-            Capabilities = [AuxiliaryBackchannelCapabilities.V1, AuxiliaryBackchannelCapabilities.V2, AuxiliaryBackchannelCapabilities.V3]
+            Capabilities = [AuxiliaryBackchannelCapabilities.V1, AuxiliaryBackchannelCapabilities.V2, AuxiliaryBackchannelCapabilities.V3, AuxiliaryBackchannelCapabilities.V4]
         });
     }
 

--- a/src/Aspire.Hosting/Backchannel/AuxiliaryBackchannelRpcTarget.cs
+++ b/src/Aspire.Hosting/Backchannel/AuxiliaryBackchannelRpcTarget.cs
@@ -875,7 +875,11 @@ internal sealed class AuxiliaryBackchannelRpcTarget(
                     Options = CreateOptionsDictionary(i.Options),
                     AllowCustomChoice = i.AllowCustomChoice,
                     Disabled = i.Disabled,
-                    MaxLength = i.MaxLength
+                    MaxLength = i.MaxLength,
+                    IsDynamic = i.DynamicLoading is not null,
+                    DependsOnInputs = i.DynamicLoading?.DependsOnInputs is { Count: > 0 } deps
+                        ? deps.ToArray()
+                        : null
                 }).ToArray(),
                 Visibility = c.Visibility.ToString(),
                 State = c.State.ToString()

--- a/src/Aspire.Hosting/Backchannel/BackchannelDataTypes.cs
+++ b/src/Aspire.Hosting/Backchannel/BackchannelDataTypes.cs
@@ -1170,6 +1170,16 @@ internal sealed class ResourceSnapshotCommandArgument
     /// Gets the maximum length for text inputs.
     /// </summary>
     public int? MaxLength { get; init; }
+
+    /// <summary>
+    /// Gets a value indicating whether the argument's allowed values are loaded dynamically based on prior input values.
+    /// </summary>
+    public bool IsDynamic { get; init; }
+
+    /// <summary>
+    /// Gets the names of inputs this argument depends on for dynamic loading, in the same order they appear on the command.
+    /// </summary>
+    public IReadOnlyList<string>? DependsOnInputs { get; init; }
 }
 
 /// <summary>

--- a/src/Aspire.Hosting/Backchannel/BackchannelDataTypes.cs
+++ b/src/Aspire.Hosting/Backchannel/BackchannelDataTypes.cs
@@ -50,6 +50,11 @@ internal static class AuxiliaryBackchannelCapabilities
     /// </summary>
     public const string V3 = "aux.v3";
 
+    /// <summary>
+    /// Version 4 capabilities: Dynamic resource command argument option loading (<see cref="LoadDynamicArgumentOptionsRequest"/>).
+    /// </summary>
+    public const string V4 = "aux.v4";
+
 }
 
 /// <summary>
@@ -1180,6 +1185,109 @@ internal sealed class ResourceSnapshotCommandArgument
     /// Gets the names of inputs this argument depends on for dynamic loading, in the same order they appear on the command.
     /// </summary>
     public IReadOnlyList<string>? DependsOnInputs { get; init; }
+}
+
+/// <summary>
+/// Request for loading the dynamic options of a single resource command argument given the partial values for prior inputs.
+/// </summary>
+internal sealed class LoadDynamicArgumentOptionsRequest : BackchannelRequest
+{
+    /// <summary>
+    /// Gets the resource identifier (the resolved instance name).
+    /// </summary>
+    public required string ResourceId { get; init; }
+
+    /// <summary>
+    /// Gets the command name as it appears on the resource (legacy aliases are resolved server-side).
+    /// </summary>
+    public required string CommandName { get; init; }
+
+    /// <summary>
+    /// Gets the name of the argument whose dynamic options should be loaded.
+    /// </summary>
+    public required string ArgumentName { get; init; }
+
+    /// <summary>
+    /// Gets the user-supplied values for the command's arguments, keyed by argument name. Missing keys are treated as unset.
+    /// </summary>
+    public Dictionary<string, string?>? CurrentValues { get; init; }
+
+    /// <inheritdoc />
+    public override LoadDynamicArgumentOptionsRequest WithTraceContext(BackchannelTraceContext traceContext) => new()
+    {
+        ResourceId = ResourceId,
+        CommandName = CommandName,
+        ArgumentName = ArgumentName,
+        CurrentValues = CurrentValues,
+        TraceContext = traceContext
+    };
+}
+
+/// <summary>
+/// Indicates the outcome of a <see cref="LoadDynamicArgumentOptionsRequest"/>.
+/// </summary>
+internal enum LoadDynamicArgumentOptionsStatus
+{
+    /// <summary>
+    /// Options were loaded successfully and are available on the response.
+    /// </summary>
+    Loaded,
+
+    /// <summary>
+    /// The argument's <c>DependsOnInputs</c> were not all satisfied with the supplied values. The dependent options were not loaded.
+    /// </summary>
+    DependenciesNotSatisfied,
+
+    /// <summary>
+    /// The target argument is not configured for dynamic loading.
+    /// </summary>
+    NotDynamic,
+
+    /// <summary>
+    /// The requested resource could not be located.
+    /// </summary>
+    ResourceNotFound,
+
+    /// <summary>
+    /// The requested command could not be located on the resource.
+    /// </summary>
+    CommandNotFound,
+
+    /// <summary>
+    /// The named argument does not exist on the command.
+    /// </summary>
+    ArgumentNotFound,
+
+    /// <summary>
+    /// The dynamic load callback threw or otherwise failed.
+    /// </summary>
+    Error
+}
+
+/// <summary>
+/// Response for <see cref="LoadDynamicArgumentOptionsRequest"/>.
+/// </summary>
+internal sealed class LoadDynamicArgumentOptionsResponse
+{
+    /// <summary>
+    /// Gets the outcome of the load operation.
+    /// </summary>
+    public required LoadDynamicArgumentOptionsStatus Status { get; init; }
+
+    /// <summary>
+    /// Gets the loaded option entries when <see cref="Status"/> is <see cref="LoadDynamicArgumentOptionsStatus.Loaded"/>.
+    /// </summary>
+    public KeyValuePair<string, string?>[]? Options { get; init; }
+
+    /// <summary>
+    /// Gets the names of dependencies missing values when <see cref="Status"/> is <see cref="LoadDynamicArgumentOptionsStatus.DependenciesNotSatisfied"/>.
+    /// </summary>
+    public string[]? MissingDependencies { get; init; }
+
+    /// <summary>
+    /// Gets a human-readable message describing the outcome, primarily used for <see cref="LoadDynamicArgumentOptionsStatus.Error"/>.
+    /// </summary>
+    public string? Message { get; init; }
 }
 
 /// <summary>

--- a/tests/Aspire.Cli.Tests/Commands/ResourceCommandTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/ResourceCommandTests.cs
@@ -1991,6 +1991,48 @@ public class ResourceCommandTests(ITestOutputHelper outputHelper)
         await Verify(helpWriter.ToString(), extension: "txt");
     }
 
+    //* Reproduces https://github.com/dotnet/aspire/issues/16907
+    [Fact]
+    public async Task ResourceCommand_ReturnsInvalidCommandForInvalidDependentChoiceCommandOption()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        var interactionService = new TestInteractionService();
+
+        var backchannel = new TestAppHostAuxiliaryBackchannel
+        {
+            ExecuteResourceCommandResult = new ExecuteResourceCommandResponse { Success = true },
+            ResourceSnapshots =
+            [
+                CreateResourceSnapshot(
+                    "web-browser-automation",
+                    CreateCommand(
+                        "configure",
+                        CreateArgument(
+                            "region",
+                            inputType: "Choice",
+                            options: new Dictionary<string, string?>
+                            {
+                                ["us"] = "United States",
+                                ["eu"] = "Europe"
+                            }),
+                        CreateArgument(
+                            "zone",
+                            inputType: "Choice",
+                            options: null)))
+            ]
+        };
+        await using var provider = CreateServiceProvider(workspace, outputHelper, backchannel, interactionService);
+
+        var command = provider.GetRequiredService<RootCommand>();
+        var result = command.Parse(
+            """resource web-browser-automation configure --region us --zone definitely-not-a-zone""");
+
+        var exitCode = await result.InvokeAsync().DefaultTimeout();
+
+        Assert.Equal(CliExitCodes.InvalidCommand, exitCode);
+        Assert.Equal(0, backchannel.ExecuteResourceCommandCallCount);
+    }
+
     private static void AssertJsonObject(JsonNode? actual, params (string Name, string? Value)[] expected)
     {
         Assert.NotNull(actual);

--- a/tests/Aspire.Hosting.Tests/ResourceCommandServiceTests.cs
+++ b/tests/Aspire.Hosting.Tests/ResourceCommandServiceTests.cs
@@ -5,6 +5,7 @@ using System.Threading.Channels;
 using Aspire.Hosting.Utils;
 using Microsoft.AspNetCore.InternalTesting;
 using Microsoft.Extensions.DependencyInjection;
+using LoadDynamicArgumentOptionsStatus = Aspire.Hosting.Backchannel.LoadDynamicArgumentOptionsStatus;
 
 namespace Aspire.Hosting.Tests;
 
@@ -332,7 +333,7 @@ public class ResourceCommandServiceTests(ITestOutputHelper testOutputHelper)
             """, result.Message);
     }
 
-    [Fact] 
+    [Fact]
     public void CommandResults_Canceled_ProducesCorrectResult()
     {
         // Act
@@ -1300,6 +1301,195 @@ public class ResourceCommandServiceTests(ITestOutputHelper testOutputHelper)
         Assert.NotNull(result.Data);
         Assert.Equal("hello world", result.Data.Value);
         Assert.Equal(CommandResultFormat.Text, result.Data.Format);
+    }
+
+    [Fact]
+    public async Task LoadDynamicArgumentOptionsAsync_LoadsOptions_WhenDependenciesSatisfied()
+    {
+        using var builder = TestDistributedApplicationBuilder.Create(testOutputHelper);
+
+        var loadCount = 0;
+        builder.AddResource(new CustomResource("myResource"))
+            .WithCommand(name: "mycommand",
+                displayName: "My command",
+                executeCommand: _ => Task.FromResult(CommandResults.Success()),
+                commandOptions: new CommandOptions
+                {
+                    Arguments =
+                    [
+                        new InteractionInput
+                        {
+                            Name = "subscription",
+                            InputType = InputType.Choice,
+                            Required = true,
+                            Options = [KeyValuePair.Create("sub-a", "Subscription A")]
+                        },
+                        new InteractionInput
+                        {
+                            Name = "location",
+                            InputType = InputType.Choice,
+                            Required = true,
+                            DynamicLoading = new InputLoadOptions
+                            {
+                                DependsOnInputs = ["subscription"],
+                                LoadCallback = context =>
+                                {
+                                    loadCount++;
+                                    context.Input.Options = [KeyValuePair.Create("westus", "West US")];
+                                    return Task.CompletedTask;
+                                }
+                            }
+                        }
+                    ]
+                });
+
+        var app = builder.Build();
+        await app.StartAsync();
+
+        var response = await app.ResourceCommands.LoadDynamicArgumentOptionsAsync(
+            "myResource",
+            "mycommand",
+            "location",
+            new Dictionary<string, string?> { ["subscription"] = "sub-a" },
+            CancellationToken.None).DefaultTimeout();
+
+        Assert.Equal(LoadDynamicArgumentOptionsStatus.Loaded, response.Status);
+        Assert.Equal(1, loadCount);
+        Assert.NotNull(response.Options);
+        var loaded = Assert.Single(response.Options);
+        Assert.Equal("westus", loaded.Key);
+        Assert.Equal("West US", loaded.Value);
+    }
+
+    [Fact]
+    public async Task LoadDynamicArgumentOptionsAsync_ReturnsDependenciesNotSatisfied_WhenDependencyMissing()
+    {
+        using var builder = TestDistributedApplicationBuilder.Create(testOutputHelper);
+
+        var loadCount = 0;
+        builder.AddResource(new CustomResource("myResource"))
+            .WithCommand(name: "mycommand",
+                displayName: "My command",
+                executeCommand: _ => Task.FromResult(CommandResults.Success()),
+                commandOptions: new CommandOptions
+                {
+                    Arguments =
+                    [
+                        new InteractionInput
+                        {
+                            Name = "subscription",
+                            InputType = InputType.Choice,
+                            Required = true,
+                            Options = [KeyValuePair.Create("sub-a", "Subscription A")]
+                        },
+                        new InteractionInput
+                        {
+                            Name = "location",
+                            InputType = InputType.Choice,
+                            DynamicLoading = new InputLoadOptions
+                            {
+                                DependsOnInputs = ["subscription"],
+                                LoadCallback = context =>
+                                {
+                                    loadCount++;
+                                    return Task.CompletedTask;
+                                }
+                            }
+                        }
+                    ]
+                });
+
+        var app = builder.Build();
+        await app.StartAsync();
+
+        var response = await app.ResourceCommands.LoadDynamicArgumentOptionsAsync(
+            "myResource",
+            "mycommand",
+            "location",
+            currentValues: null,
+            CancellationToken.None).DefaultTimeout();
+
+        Assert.Equal(LoadDynamicArgumentOptionsStatus.DependenciesNotSatisfied, response.Status);
+        Assert.Equal(0, loadCount);
+        Assert.NotNull(response.MissingDependencies);
+        Assert.Equal("subscription", Assert.Single(response.MissingDependencies));
+        Assert.Null(response.Options);
+    }
+
+    [Fact]
+    public async Task LoadDynamicArgumentOptionsAsync_ReturnsNotDynamic_WhenArgumentHasNoDynamicLoading()
+    {
+        using var builder = TestDistributedApplicationBuilder.Create(testOutputHelper);
+
+        builder.AddResource(new CustomResource("myResource"))
+            .WithCommand(name: "mycommand",
+                displayName: "My command",
+                executeCommand: _ => Task.FromResult(CommandResults.Success()),
+                commandOptions: new CommandOptions
+                {
+                    Arguments =
+                    [
+                        new InteractionInput
+                        {
+                            Name = "subscription",
+                            InputType = InputType.Choice,
+                            Options = [KeyValuePair.Create("sub-a", "Subscription A")]
+                        }
+                    ]
+                });
+
+        var app = builder.Build();
+        await app.StartAsync();
+
+        var response = await app.ResourceCommands.LoadDynamicArgumentOptionsAsync(
+            "myResource",
+            "mycommand",
+            "subscription",
+            currentValues: null,
+            CancellationToken.None).DefaultTimeout();
+
+        Assert.Equal(LoadDynamicArgumentOptionsStatus.NotDynamic, response.Status);
+        Assert.Null(response.Options);
+    }
+
+    [Fact]
+    public async Task LoadDynamicArgumentOptionsAsync_ReturnsError_WhenLoadCallbackThrows()
+    {
+        using var builder = TestDistributedApplicationBuilder.Create(testOutputHelper);
+
+        builder.AddResource(new CustomResource("myResource"))
+            .WithCommand(name: "mycommand",
+                displayName: "My command",
+                executeCommand: _ => Task.FromResult(CommandResults.Success()),
+                commandOptions: new CommandOptions
+                {
+                    Arguments =
+                    [
+                        new InteractionInput
+                        {
+                            Name = "location",
+                            InputType = InputType.Choice,
+                            DynamicLoading = new InputLoadOptions
+                            {
+                                AlwaysLoadOnStart = true,
+                                LoadCallback = _ => throw new InvalidOperationException("kaboom")
+                            }
+                        }
+                    ]
+                });
+
+        var app = builder.Build();
+        await app.StartAsync();
+
+        var response = await app.ResourceCommands.LoadDynamicArgumentOptionsAsync(
+            "myResource",
+            "mycommand",
+            "location",
+            currentValues: null,
+            CancellationToken.None).DefaultTimeout();
+
+        Assert.Equal(LoadDynamicArgumentOptionsStatus.Error, response.Status);
+        Assert.Equal("kaboom", response.Message);
     }
 
     private static string CreateBuildOutputTestProject(string directoryPath, string buildOutputMarker)


### PR DESCRIPTION
- `IsDynamic` + `DependsOnInputs` on `ResourceSnapshotCommandArgument` so the CLI can tell dependent choices
- New backchannel capability `aux.v4` and `LoadDynamicArgumentOptionsAsync` RPC
- Status enum + matching DTOs, registered in the CLI's JSON source-gen context

## Description

Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes #16907

## Checklist

- Is this feature complete?
  - [ ] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [ ] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [ ] No
