### PR TITLE
Graduate Azure Container Apps job APIs

### DIFF
--- a/src/Aspire.Hosting.Azure.AppContainers/AzureContainerAppExtensions.cs
+++ b/src/Aspire.Hosting.Azure.AppContainers/AzureContainerAppExtensions.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 #pragma warning disable ASPIREPIPELINES001
-#pragma warning disable ASPIREAZURE002 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
 #pragma warning disable ASPIREAZURE003 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
 
 using System.Diagnostics;

--- a/src/Aspire.Hosting.Azure.AppContainers/AzureContainerAppJobCustomizationAnnotation.cs
+++ b/src/Aspire.Hosting.Azure.AppContainers/AzureContainerAppJobCustomizationAnnotation.cs
@@ -1,7 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.Diagnostics.CodeAnalysis;
 using Aspire.Hosting.ApplicationModel;
 using Azure.Provisioning.AppContainers;
 
@@ -10,7 +9,6 @@ namespace Aspire.Hosting.Azure;
 /// <summary>
 /// Represents an annotation for customizing an Azure Container App Job.
 /// </summary>
-[Experimental("ASPIREAZURE002", UrlFormat = "https://aka.ms/aspire/diagnostics/{0}")]
 public sealed class AzureContainerAppJobCustomizationAnnotation(Action<AzureResourceInfrastructure, ContainerAppJob> configure)
     : IResourceAnnotation
 {

--- a/src/Aspire.Hosting.Azure.AppContainers/ContainerAppEnvironmentContext.cs
+++ b/src/Aspire.Hosting.Azure.AppContainers/ContainerAppEnvironmentContext.cs
@@ -1,8 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-#pragma warning disable ASPIREAZURE002 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
-
 using Aspire.Hosting.ApplicationModel;
 using Aspire.Hosting.Azure.AppContainers;
 using Microsoft.Extensions.Logging;

--- a/src/Aspire.Hosting.Azure.AppContainers/ContainerAppExtensions.cs
+++ b/src/Aspire.Hosting.Azure.AppContainers/ContainerAppExtensions.cs
@@ -151,7 +151,6 @@ public static class ContainerAppExtensions
     /// <para>This overload allows custom configuration of the container app job via a callback.</para>
     /// </remarks>
     [AspireExportIgnore(Reason = "Polyglot app hosts use the internal publishAsAzureContainerAppJob dispatcher export.")]
-    [Experimental("ASPIREAZURE002", UrlFormat = "https://aka.ms/aspire/diagnostics/{0}")]
     public static IResourceBuilder<T> PublishAsAzureContainerAppJob<T>(this IResourceBuilder<T> resource, Action<AzureResourceInfrastructure, ContainerAppJob> configure)
         where T : IComputeResource
     {
@@ -189,7 +188,6 @@ public static class ContainerAppExtensions
     /// </example>
     /// </remarks>
     [AspireExportIgnore(Reason = "Polyglot app hosts use the internal publishAsAzureContainerAppJob dispatcher export.")]
-    [Experimental("ASPIREAZURE002", UrlFormat = "https://aka.ms/aspire/diagnostics/{0}")]
     public static IResourceBuilder<T> PublishAsAzureContainerAppJob<T>(this IResourceBuilder<T> resource)
         where T : IComputeResource
     {
@@ -203,7 +201,6 @@ public static class ContainerAppExtensions
     }
 
     [AspireExport("publishAsAzureContainerAppJob", Description = "Configures the compute resource as an Azure Container App Job")]
-    [Experimental("ASPIREAZURE002", UrlFormat = "https://aka.ms/aspire/diagnostics/{0}")]
     internal static IResourceBuilder<T> PublishAsAzureContainerAppJobForPolyglot<T>(
         this IResourceBuilder<T> resource,
         Action<AzureResourceInfrastructure, ContainerAppJob>? configure = null)
@@ -237,7 +234,6 @@ public static class ContainerAppExtensions
     /// <para>This overload allows custom configuration of the scheduled container app job via a callback.</para>
     /// </remarks>
     [AspireExportIgnore(Reason = "Polyglot app hosts use the internal publishAsScheduledAzureContainerAppJob dispatcher export.")]
-    [Experimental("ASPIREAZURE002", UrlFormat = "https://aka.ms/aspire/diagnostics/{0}")]
     public static IResourceBuilder<T> PublishAsScheduledAzureContainerAppJob<T>(this IResourceBuilder<T> resource, string cronExpression, Action<AzureResourceInfrastructure, ContainerAppJob>? configure = null)
         where T : IComputeResource
     {
@@ -253,26 +249,7 @@ public static class ContainerAppExtensions
         });
     }
 
-    /// <summary>
-    /// Configures the specified compute resource as a scheduled Azure Container App Job with the provided cron expression.
-    /// </summary>
-    /// <typeparam name="T">The type of the compute resource.</typeparam>
-    /// <param name="resource">The compute resource builder.</param>
-    /// <param name="cronExpression">The cron expression that defines the schedule for the job.</param>
-    /// <returns>The updated compute resource builder.</returns>
-    /// <remarks>
-    /// This method is a convenience wrapper that configures the job with a schedule trigger using the specified cron expression.
-    /// </remarks>
-    [AspireExportIgnore(Reason = "Polyglot app hosts use the internal publishAsScheduledAzureContainerAppJob dispatcher export.")]
-    [Experimental("ASPIREAZURE002", UrlFormat = "https://aka.ms/aspire/diagnostics/{0}")]
-    internal static IResourceBuilder<T> PublishAsScheduledAzureContainerAppJob<T>(this IResourceBuilder<T> resource, string cronExpression)
-        where T : IComputeResource
-    {
-        return resource.PublishAsScheduledAzureContainerAppJob(cronExpression, configure: null);
-    }
-
     [AspireExport("publishAsScheduledAzureContainerAppJob", Description = "Configures the compute resource as a scheduled Azure Container App Job")]
-    [Experimental("ASPIREAZURE002", UrlFormat = "https://aka.ms/aspire/diagnostics/{0}")]
     internal static IResourceBuilder<T> PublishAsScheduledAzureContainerAppJobForPolyglot<T>(
         this IResourceBuilder<T> resource,
         string cronExpression,

--- a/src/Aspire.Hosting.Azure.AppContainers/ContainerAppJobContext.cs
+++ b/src/Aspire.Hosting.Azure.AppContainers/ContainerAppJobContext.cs
@@ -1,8 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-#pragma warning disable ASPIREAZURE002 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
-
 using Aspire.Hosting.ApplicationModel;
 using Azure.Provisioning;
 using Azure.Provisioning.AppContainers;

--- a/tests/Aspire.Hosting.Azure.Tests/AzureContainerAppsTests.cs
+++ b/tests/Aspire.Hosting.Azure.Tests/AzureContainerAppsTests.cs
@@ -3,7 +3,6 @@
 
 #pragma warning disable ASPIREACADOMAINS001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
 #pragma warning disable ASPIRECOMPUTE002 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
-#pragma warning disable ASPIREAZURE002 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
 #pragma warning disable ASPIREDOCKERFILEBUILDER001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
 #pragma warning disable ASPIREPIPELINES001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
 #pragma warning disable ASPIREACANAMING001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.


### PR DESCRIPTION
## Description

Issue #17175 tracks graduating experimental Aspire APIs. This PR handles the Azure Container Apps job subset so consumers can use the ACA job publishing APIs without suppressing `ASPIREAZURE002`.

This removes the experimental marker from the existing `PublishAsAzureContainerAppJob` and `PublishAsScheduledAzureContainerAppJob` APIs, the related job customization annotation, and the internal polyglot dispatcher exports. Runtime behavior and generated ACA job infrastructure are unchanged; this only graduates the API surface and removes stale suppressions.

### User-facing usage

Consumers can continue configuring manual and scheduled ACA jobs without experimental diagnostics:

```csharp
builder.AddContainer("manual-job", "myimage")
       .PublishAsAzureContainerAppJob();

builder.AddContainer("scheduled-job", "myimage")
       .PublishAsScheduledAzureContainerAppJob("0 0 * * *");
```

Validation:

```text
.\dotnet.cmd test --project tests\Aspire.Hosting.Azure.Tests\Aspire.Hosting.Azure.Tests.csproj --no-launch-profile -- --filter-class "*.AzureContainerAppsTests" --filter-not-trait "quarantined=true" --filter-not-trait "outerloop=true"
.\dotnet.cmd test --project tests\Aspire.Hosting.CodeGeneration.TypeScript.Tests\Aspire.Hosting.CodeGeneration.TypeScript.Tests.csproj --no-launch-profile -- --filter-method "*.Scanner_AzureProvisioningCallbacks_ExposeTypedCustomizationProperties" --filter-not-trait "quarantined=true" --filter-not-trait "outerloop=true"
```

Contributes to #17175

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No