### PR TITLE
Fix check-changed-files action to use three-dot diff

### DIFF
--- a/.github/actions/check-changed-files/action.yml
+++ b/.github/actions/check-changed-files/action.yml
@@ -121,10 +121,14 @@ runs:
           exit 1
         fi
 
-        # Get list of changed files for pull requests
+        # Get list of changed files for pull requests.
+        # Use a three-dot (merge-base) diff so we only see files the PR itself changed,
+        # not files that diverged on the base branch since the PR was opened. This matches
+        # what `gh pr view --json files` and the GitHub PR Files tab show. A two-dot diff
+        # would also include unrelated base-branch changes when the PR is behind its base.
         BASE_REF="${{ github.event.pull_request.base.sha }}"
         HEAD_REF="${{ github.event.pull_request.head.sha }}"
-        if ! CHANGED_FILES=$(git diff --name-only "$BASE_REF".."$HEAD_REF" 2>/dev/null); then
+        if ! CHANGED_FILES=$(git diff --name-only "$BASE_REF"..."$HEAD_REF" 2>/dev/null); then
           echo "Error: Failed to get changed files. Base ref: $BASE_REF HEAD ref: $HEAD_REF"
           exit 1
         fi


### PR DESCRIPTION
## Problem

`.github/actions/check-changed-files/action.yml` used a **two-dot** diff (`BASE..HEAD`) to compute the list of files changed by a PR. That's a direct snapshot comparison between the tip of the base branch and the PR head — so when the PR branch is behind its base, every file that diverged on the base branch since the merge-base shows up as "changed" in the PR, even though the PR author never touched it.

The CI-skip logic in the `prepare_for_ci` job (`.github/workflows/ci.yml`) feeds those files into `eng/testing/github-ci-trigger-patterns.txt` and refuses to skip CI when there are "unmatched" files — so PRs that should skip full CI end up running it.

## Concrete repro

PR #17150 only changes 7 files (release pipeline yamls, docs, workflows), all of which match patterns in `eng/testing/github-ci-trigger-patterns.txt`. CI should skip. Instead, full CI ran because the branch is ~36 commits behind `main`, and the action reported two unrelated `extension/src/...` files as "changed" (they were modified on main after the PR was opened).

Job log evidence from [run 26061467579 / job 76622796473](https://github.com/microsoft/aspire/actions/runs/26061467579/job/76622796473):

```
Matched files: .github/workflows/release-github-tasks.yml .github/workflows/release-notes-generate.lock.yml .github/workflows/release-notes-generate.md docs/release-process.md eng/pipelines/azure-pipelines.yml eng/pipelines/release-publish-nuget.yml eng/testing/github-ci-trigger-patterns.txt
Unmatched files: extension/src/test/appHostDataRepository.test.ts extension/src/views/AppHostDataRepository.ts
```

The two unmatched files were never touched by PR #17150 — confirmed by `gh pr view 17150 --json files` (returns the 7 actual files only).

## Fix

Switch to a **three-dot** diff (`BASE...HEAD`), which is merge-base aware (`git diff $(git merge-base BASE HEAD) HEAD`) and matches exactly what `gh pr view --json files` and the GitHub PR Files tab show.

The behavior change is strictly: fewer false-positives for "changed" files. The only consumer of this action is the `prepare_for_ci` job in `ci.yml`, and the change can only make the skip logic more accurate (it will never cause a PR that touches non-pattern files to incorrectly skip CI).

No tests exist for this action.

Motivating example: #17150.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>