### PR TITLE
Shorten backchannel socket paths

### DIFF
--- a/src/Aspire.Cli/Backchannel/AuxiliaryBackchannelMonitor.cs
+++ b/src/Aspire.Cli/Backchannel/AuxiliaryBackchannelMonitor.cs
@@ -8,6 +8,7 @@ using System.Runtime.CompilerServices;
 using Aspire.Cli.Commands;
 using Aspire.Cli.Telemetry;
 using Aspire.Cli.Utils;
+using Aspire.Hosting.Backchannel;
 using Microsoft.Extensions.FileProviders;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
@@ -26,10 +27,18 @@ internal sealed class AuxiliaryBackchannelMonitor(
 {
     private static readonly TimeSpan s_maxRetryElapsed = TimeSpan.FromSeconds(3);
     private static readonly TimeSpan s_maxRetryDelay = TimeSpan.FromSeconds(1);
+
+    // Compact socket file names have no prefix to reduce the path length as much as possible and avoid socket path length limits,
+    // which are much shorter than typical file path limits (e.g. 108 BYTES on Windows/Linux).
+    // But this means we need to watch for all files while keeping backchannel sockets in a directory separate 
+    // from other CLI-managed files.
+    private const string CompactSocketWatchPattern = "*";
+    private const string LegacySocketWatchPattern = "aux*.sock.*";
     
     // Outer key: hash (prefix), Inner key: socketPath, Value: connection
     private readonly ConcurrentDictionary<string, ConcurrentDictionary<string, AppHostAuxiliaryBackchannel>> _connectionsByHash = new();
-    private readonly string _backchannelsDirectory = GetBackchannelsDirectory();
+    private readonly string _backchannelsDirectory = BackchannelConstants.GetBackchannelsDirectory(GetHomeDirectory());
+    private readonly string _legacyBackchannelsDirectory = BackchannelConstants.GetLegacyBackchannelsDirectory(GetHomeDirectory());
 
     // Track known socket files to detect additions and removals
     private readonly HashSet<string> _knownSocketFiles = new(StringComparer.OrdinalIgnoreCase);
@@ -152,11 +161,10 @@ internal sealed class AuxiliaryBackchannelMonitor(
 
             logger.LogInformation("Starting auxiliary backchannel monitor for {CommandType}", command.GetType().Name);
 
-            // Ensure the backchannels directory exists
-            if (!Directory.Exists(_backchannelsDirectory))
-            {
-                Directory.CreateDirectory(_backchannelsDirectory);
-            }
+            // Ensure both directories exist so the monitor can see compact sockets and
+            // sockets created by older AppHosts that still use the legacy location.
+            Directory.CreateDirectory(_backchannelsDirectory);
+            Directory.CreateDirectory(_legacyBackchannelsDirectory);
 
             // Scan for existing sockets on startup.
             await ProcessDirectoryChangesAsync(stoppingToken).ConfigureAwait(false);
@@ -165,9 +173,14 @@ internal sealed class AuxiliaryBackchannelMonitor(
             using var fileProvider = new PhysicalFileProvider(_backchannelsDirectory);
             fileProvider.UsePollingFileWatcher = true;
             fileProvider.UseActivePolling = true;
+            using var legacyFileProvider = new PhysicalFileProvider(_legacyBackchannelsDirectory);
+            legacyFileProvider.UsePollingFileWatcher = true;
+            legacyFileProvider.UseActivePolling = true;
 
             // Run the watcher loop until cancellation
-            var fileWatcherTask = RunFileWatcherLoopAsync(fileProvider, stoppingToken);
+            var fileWatcherTask = Task.WhenAll(
+                RunFileWatcherLoopAsync(fileProvider, CompactSocketWatchPattern, stoppingToken),
+                RunFileWatcherLoopAsync(legacyFileProvider, LegacySocketWatchPattern, stoppingToken));
 
             await fileWatcherTask.ConfigureAwait(false);
         }
@@ -206,15 +219,7 @@ internal sealed class AuxiliaryBackchannelMonitor(
         await _scanLock.WaitAsync(cancellationToken).ConfigureAwait(false);
         try
         {
-            // Support both "auxi.sock.*" (new) and "aux.sock.*" (old) for backward compatibility
-            // Note: "aux" is a reserved device name on Windows < 11, but we still scan for it
-            // to support connections from older CLI versions
-            // Using "aux*.sock.*" wildcard to match both patterns
-            var currentFiles = new HashSet<string>(
-                Directory.Exists(_backchannelsDirectory)
-                    ? Directory.GetFiles(_backchannelsDirectory, "aux*.sock.*")
-                    : [],
-                StringComparer.OrdinalIgnoreCase);
+            var currentFiles = new HashSet<string>(GetSocketFiles(), StringComparer.OrdinalIgnoreCase);
 
             // Find new files (files that exist now but weren't known before)
             var newFiles = currentFiles.Except(_knownSocketFiles, StringComparer.OrdinalIgnoreCase).ToList();
@@ -495,20 +500,42 @@ internal sealed class AuxiliaryBackchannelMonitor(
         await Task.CompletedTask.ConfigureAwait(false);
     }
 
-    private static string GetBackchannelsDirectory()
+    private IEnumerable<string> GetSocketFiles()
     {
-        var homeDirectory = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
-        return Path.Combine(homeDirectory, ".aspire", "cli", "backchannels");
+        if (Directory.Exists(_backchannelsDirectory))
+        {
+            foreach (var socketPath in Directory.GetFiles(_backchannelsDirectory))
+            {
+                if (AppHostHelper.ExtractHashFromSocketPath(socketPath) is not null)
+                {
+                    yield return socketPath;
+                }
+            }
+        }
+
+        if (Directory.Exists(_legacyBackchannelsDirectory))
+        {
+            // Support both "auxi.sock.*" and "aux.sock.*" for backward compatibility.
+            // Note: "aux" is a reserved device name on Windows < 11, but we still scan for it
+            // to support sockets created by older AppHost versions.
+            foreach (var socketPath in Directory.GetFiles(_legacyBackchannelsDirectory, "aux*.sock.*"))
+            {
+                yield return socketPath;
+            }
+        }
     }
+
+    private static string GetHomeDirectory()
+        => Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
 
     /// <summary>
     /// Runs the file watcher loop that triggers scans when file changes are detected.
     /// </summary>
-    private async Task RunFileWatcherLoopAsync(IFileProvider fileProvider, CancellationToken cancellationToken)
+    private async Task RunFileWatcherLoopAsync(IFileProvider fileProvider, string watchPattern, CancellationToken cancellationToken)
     {
         try
         {
-            await foreach (var changed in WatchForChangesAsync(fileProvider, cancellationToken))
+            await foreach (var changed in WatchForChangesAsync(fileProvider, watchPattern, cancellationToken))
             {
                 await ProcessDirectoryChangesAsync(cancellationToken).ConfigureAwait(false);
             }
@@ -522,13 +549,11 @@ internal sealed class AuxiliaryBackchannelMonitor(
     /// <summary>
     /// Watches for file changes in the backchannels directory using change tokens.
     /// </summary>
-    private static async IAsyncEnumerable<bool> WatchForChangesAsync(IFileProvider fileProvider, [EnumeratorCancellation] CancellationToken cancellationToken)
+    private static async IAsyncEnumerable<bool> WatchForChangesAsync(IFileProvider fileProvider, string watchPattern, [EnumeratorCancellation] CancellationToken cancellationToken)
     {
         while (!cancellationToken.IsCancellationRequested)
         {
-            // Watch for both "auxi.sock.*" (new) and "aux.sock.*" (old) patterns for backward compatibility
-            // Using "aux*.sock.*" wildcard to match both patterns
-            var changeToken = fileProvider.Watch("aux*.sock.*");
+            var changeToken = fileProvider.Watch(watchPattern);
             var tcs = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
 
             using var registration = changeToken.RegisterChangeCallback(state => ((TaskCompletionSource<bool>)state!).TrySetResult(true), tcs);

--- a/src/Aspire.Cli/Commands/AppHostLauncher.cs
+++ b/src/Aspire.Cli/Commands/AppHostLauncher.cs
@@ -141,12 +141,12 @@ internal sealed class AppHostLauncher(
             effectiveAppHostFile.FullName,
             executionContext.HomeDirectory.FullName);
         var expectedHash = AppHostHelper.ExtractHashFromSocketPath(expectedSocketPrefix)!;
-        var legacyHash = AppHostHelper.ComputeLegacyHash(effectiveAppHostFile.FullName);
+        var legacyHashes = AppHostHelper.ComputeLegacyHashes(effectiveAppHostFile.FullName);
 
         logger.LogDebug("Waiting for socket with prefix: {SocketPrefix}, Hash: {Hash}", expectedSocketPrefix, expectedHash);
-        if (legacyHash is not null)
+        if (legacyHashes.Length > 0)
         {
-            logger.LogDebug("Also searching for legacy hash: {LegacyHash}", legacyHash);
+            logger.LogDebug("Also searching for legacy hash(es): {LegacyHashes}", string.Join(", ", legacyHashes));
         }
 
         // If --wait-for-debugger is active, show a message so the user knows the AppHost
@@ -165,7 +165,7 @@ internal sealed class AppHostLauncher(
         {
             launchResult = await interactionService.ShowStatusAsync(
                 RunCommandStrings.StartingAppHostInBackground,
-                () => LaunchAndWaitForBackchannelAsync(executablePath, childArgs, expectedHash, legacyHash, cancellationToken));
+                () => LaunchAndWaitForBackchannelAsync(executablePath, childArgs, expectedHash, legacyHashes, cancellationToken));
         }
         catch (OperationCanceledException)
         {
@@ -322,7 +322,7 @@ internal sealed class AppHostLauncher(
         string executablePath,
         List<string> childArgs,
         string expectedHash,
-        string? legacyHash,
+        IReadOnlyList<string> legacyHashes,
         CancellationToken cancellationToken)
     {
         Process childProcess;
@@ -352,7 +352,7 @@ internal sealed class AppHostLauncher(
 
         var startTime = timeProvider.GetUtcNow();
         var timeout = TimeSpan.FromSeconds(120);
-        using var waitForBackchannelActivity = profilingTelemetry.StartDetachedWaitForBackchannel(childProcess.Id, expectedHash, legacyHash is not null);
+        using var waitForBackchannelActivity = profilingTelemetry.StartDetachedWaitForBackchannel(childProcess.Id, expectedHash, legacyHashes.Count > 0);
         var scanCount = 0;
         IAppHostAuxiliaryBackchannel? connection = null;
         DashboardUrlsState? dashboardUrls = null;
@@ -376,7 +376,7 @@ internal sealed class AppHostLauncher(
                 scanCount++;
 
                 connection ??= backchannelMonitor.GetConnectionsByHash(expectedHash).FirstOrDefault()
-                    ?? (legacyHash is not null ? backchannelMonitor.GetConnectionsByHash(legacyHash).FirstOrDefault() : null);
+                    ?? legacyHashes.SelectMany(backchannelMonitor.GetConnectionsByHash).FirstOrDefault();
                 if (connection is not null)
                 {
                     waitForBackchannelActivity.SetBackchannelScanCount(scanCount);

--- a/src/Aspire.Cli/Utils/AppHostHelper.cs
+++ b/src/Aspire.Cli/Utils/AppHostHelper.cs
@@ -102,8 +102,8 @@ internal static class AppHostHelper
     /// Computes the auxiliary backchannel socket path prefix for a given AppHost project file.
     /// </summary>
     /// <remarks>
-    /// Since socket names now include a randomized instance hash and the AppHost's PID
-    /// (e.g., <c>auxi.sock.{hash}.{instanceHash}.{pid}</c>),
+    /// Since socket names now include a randomized instance ID and the AppHost's PID
+    /// (e.g., <c>{appHostId}{instanceId}.{pid}</c>),
     /// the CLI cannot compute the exact socket path. Use this prefix with a glob pattern
     /// to find matching sockets, or use <see cref="FindMatchingSockets"/> instead.
     /// </remarks>
@@ -122,6 +122,14 @@ internal static class AppHostHelper
         => BackchannelConstants.ComputeLegacyHash(appHostPath);
 
     /// <summary>
+    /// Computes all legacy hashes for backward compatibility with older AppHosts.
+    /// </summary>
+    /// <param name="appHostPath">The full path to the AppHost project file or assembly.</param>
+    /// <returns>The legacy hashes to search.</returns>
+    internal static string[] ComputeLegacyHashes(string appHostPath)
+        => BackchannelConstants.ComputeLegacyHashes(appHostPath);
+
+    /// <summary>
     /// Finds all socket files matching the given AppHost path.
     /// </summary>
     /// <param name="appHostPath">The full path to the AppHost project file or assembly.</param>
@@ -134,8 +142,9 @@ internal static class AppHostHelper
     /// Extracts the hash portion from an auxiliary socket path.
     /// </summary>
     /// <remarks>
-    /// Works with old format (<c>auxi.sock.{hash}</c>), previous format (<c>auxi.sock.{hash}.{pid}</c>),
-    /// and current format (<c>auxi.sock.{hash}.{instanceHash}.{pid}</c>).
+    /// Works with compact format (<c>{appHostId}{instanceId}.{pid}</c>), old format (<c>auxi.sock.{hash}</c>),
+    /// previous format (<c>auxi.sock.{hash}.{pid}</c>), and legacy current format
+    /// (<c>auxi.sock.{hash}.{instanceHash}.{pid}</c>).
     /// </remarks>
     /// <param name="socketPath">The full socket path (e.g., "/path/to/auxi.sock.b67075ff12d56865.a1b2c3d4e5f6.12345").</param>
     /// <returns>The hash portion (e.g., "b67075ff12d56865"), or null if the format is unrecognized.</returns>

--- a/src/Aspire.Cli/Utils/CliPathHelper.cs
+++ b/src/Aspire.Cli/Utils/CliPathHelper.cs
@@ -184,33 +184,25 @@ internal static class CliPathHelper
     /// </summary>
     /// <param name="socketPrefix">The socket file prefix.</param>
     internal static string CreateUnixDomainSocketPath(string socketPrefix)
-        => CreateSocketPath(socketPrefix, isGuestAppHost: false);
+        => CreateSocketPath(socketPrefix);
 
     internal static string CreateGuestAppHostSocketPath(string socketPrefix)
-        => CreateSocketPath(socketPrefix, isGuestAppHost: true);
+        => OperatingSystem.IsWindows()
+            ? CreateSocketName(socketPrefix)
+            : CreateSocketPath(socketPrefix);
 
-    private static string CreateSocketPath(string socketPrefix, bool isGuestAppHost)
+    private static string CreateSocketPath(string socketPrefix)
     {
-        var socketName = $"{socketPrefix}.{BackchannelConstants.CreateRandomIdentifier()}";
-
-        if (isGuestAppHost && OperatingSystem.IsWindows())
-        {
-            return socketName;
-        }
-
-        var socketDirectory = GetCliSocketDirectory();
-        Directory.CreateDirectory(socketDirectory);
-        return Path.Combine(socketDirectory, socketName);
+        var homeDirectory = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
+        var socketPath = BackchannelConstants.ComputeCliSocketPath(homeDirectory, socketPrefix);
+        Directory.CreateDirectory(Path.GetDirectoryName(socketPath)!);
+        return socketPath;
     }
 
-    private static string GetCliHomeDirectory()
-        => Path.Combine(GetAspireHomeDirectory(), "cli");
-
-    private static string GetCliRuntimeDirectory()
-        => Path.Combine(GetCliHomeDirectory(), "runtime");
-
-    private static string GetCliSocketDirectory()
-        => Path.Combine(GetCliRuntimeDirectory(), "sockets");
+    private static string CreateSocketName(string socketPrefix)
+    {
+        return BackchannelConstants.ComputeSocketFileName(socketPrefix);
+    }
 
     private static string? TryResolveSymlinkTarget(string path, ILogger? logger, string fallbackDescription)
     {

--- a/src/Aspire.Hosting/Backchannel/AuxiliaryBackchannelService.cs
+++ b/src/Aspire.Hosting/Backchannel/AuxiliaryBackchannelService.cs
@@ -59,8 +59,16 @@ internal sealed class AuxiliaryBackchannelService(
             var appHostPath = configuration["AppHost:FilePath"] ?? configuration["AppHost:Path"];
             if (!string.IsNullOrEmpty(appHostPath))
             {
-                var hash = BackchannelConstants.ComputeHash(appHostPath);
-                var orphansDeleted = BackchannelConstants.CleanupOrphanedSockets(directory!, hash, Environment.ProcessId);
+                var appHostId = BackchannelConstants.ComputeAppHostId(appHostPath);
+                var orphansDeleted = BackchannelConstants.CleanupOrphanedSockets(directory!, appHostId, Environment.ProcessId);
+
+                var homeDirectory = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
+                var legacyDirectory = BackchannelConstants.GetLegacyBackchannelsDirectory(homeDirectory);
+                foreach (var legacyHash in BackchannelConstants.ComputeLegacyHashes(appHostPath))
+                {
+                    orphansDeleted += BackchannelConstants.CleanupOrphanedSockets(legacyDirectory, legacyHash, Environment.ProcessId, prefixedFilesOnly: true);
+                }
+
                 if (orphansDeleted > 0)
                 {
                     logger.LogDebug("Cleaned up {Count} orphaned socket(s) from previous instances.", orphansDeleted);
@@ -209,9 +217,8 @@ internal sealed class AuxiliaryBackchannelService(
             return BackchannelConstants.ComputeSocketPath(appHostPath, homeDirectory, Environment.ProcessId);
         }
 
-        // Fallback: Generate socket path using process ID as the "hash" (rare edge case)
-        var backchannelsDir = BackchannelConstants.GetBackchannelsDirectory(homeDirectory);
-        var fallbackHash = BackchannelConstants.ComputeHash(Environment.ProcessId.ToString(System.Globalization.CultureInfo.InvariantCulture));
-        return Path.Combine(backchannelsDir, $"{BackchannelConstants.SocketPrefix}.{fallbackHash}.{Environment.ProcessId}");
+        // Fallback: Generate socket path using process ID as the AppHost ID seed (rare edge case)
+        var fallbackAppHostId = BackchannelConstants.ComputeAppHostId(Environment.ProcessId.ToString(System.Globalization.CultureInfo.InvariantCulture));
+        return BackchannelConstants.ComputeSocketPathFromAppHostId(fallbackAppHostId, homeDirectory, Environment.ProcessId);
     }
 }

--- a/src/Shared/BackchannelConstants.cs
+++ b/src/Shared/BackchannelConstants.cs
@@ -21,53 +21,40 @@ namespace Aspire.Hosting.Backchannel;
 /// The backchannel is a Unix domain socket that enables bidirectional communication:
 /// </para>
 /// <list type="bullet">
-/// <item>CLI → AppHost: Commands (stop, get info, etc.)</item>
-/// <item>AppHost → CLI: Status updates, events</item>
+/// <item>CLI -> AppHost: Commands (stop, get info, etc.)</item>
+/// <item>AppHost -> CLI: Status updates, events</item>
 /// </list>
 /// <para>
 /// <strong>Socket File Location</strong>
 /// </para>
 /// <para>
-/// Socket files are stored in: <c>~/.aspire/cli/backchannels/</c>
+/// Compact socket files are stored in: <c>~/.aspire/cli/bch/</c>
 /// </para>
 /// <para>
 /// <strong>Socket Naming Format</strong>
 /// </para>
 /// <para>
-/// New format: <c>auxi.sock.{appHostHash}.{instanceHash}.{pid}</c>
+/// Compact format: <c>{appHostId}{instanceId}.{pid}</c>
 /// </para>
 /// <list type="bullet">
-/// <item><c>auxi.sock</c> - Prefix (not "aux" because that's reserved on Windows)</item>
-/// <item><c>{appHostHash}</c> - xxHash(AppHost project path)[0:16] - identifies the AppHost project</item>
-/// <item><c>{instanceHash}</c> - random hex identifier[0:12] - makes each socket name non-deterministic</item>
+/// <item><c>{appHostId}</c> - xxHash(AppHost project path) encoded as 11 base64url chars - identifies the AppHost project</item>
+/// <item><c>{instanceId}</c> - 48-bit random identifier encoded as 8 base64url chars - makes each socket name non-deterministic</item>
 /// <item><c>{pid}</c> - Process ID of the AppHost - identifies the specific instance</item>
 /// </list>
 /// <para>
-/// Previous format (for backward compatibility): <c>auxi.sock.{appHostHash}.{pid}</c>
+/// Legacy current format: <c>auxi.sock.{appHostHash}.{instanceHash}.{pid}</c>
 /// </para>
 /// <para>
-/// Old format (for backward compatibility): <c>auxi.sock.{appHostHash}</c>
+/// Legacy previous format: <c>auxi.sock.{appHostHash}.{pid}</c>
 /// </para>
 /// <para>
-/// <strong>Why PID in the Filename?</strong>
-/// </para>
-/// <list type="bullet">
-/// <item>Multiple instances of the same AppHost can run simultaneously</item>
-/// <item>Orphan detection: if PID doesn't exist, socket is orphaned and can be deleted</item>
-/// <item>Fast cleanup without needing to attempt connection</item>
-/// </list>
-/// <para>
-/// <strong>Backward Compatibility</strong>
-/// </para>
-/// <para>
-/// Old CLI versions use glob pattern <c>aux*.sock.*</c> which matches the new format.
-/// Old CLIs will work with new AppHosts, they just won't benefit from PID-based orphan detection.
+/// Legacy old format: <c>auxi.sock.{appHostHash}</c>
 /// </para>
 /// </remarks>
 internal static class BackchannelConstants
 {
     /// <summary>
-    /// Prefix for auxiliary backchannel sockets.
+    /// Prefix for legacy auxiliary backchannel sockets.
     /// </summary>
     /// <remarks>
     /// Uses "auxi" instead of "aux" because "aux" is a reserved device name on Windows
@@ -77,40 +64,63 @@ internal static class BackchannelConstants
     public const string SocketPrefix = "auxi.sock";
 
     /// <summary>
-    /// Number of hex characters to use from the stable xxHash-based AppHost identifier.
+    /// Number of hex characters to use from the stable xxHash-based legacy AppHost identifier.
     /// </summary>
-    /// <remarks>
-    /// Using 16 chars (64 bits) balances uniqueness against path length constraints.
-    /// Unix socket paths are limited to ~104 characters on most systems.
-    /// Full path example: ~/.aspire/cli/backchannels/auxi.sock.bc43b855b6848166.a1b2c3d4e5f6.46730
-    /// = ~78 characters, well under the limit.
-    /// </remarks>
     public const int HashLength = 16;
 
     /// <summary>
-    /// Number of hex characters to use for compact local identifiers.
+    /// Number of hex characters to use for compact legacy local identifiers.
     /// </summary>
-    /// <remarks>
-    /// Using 12 chars (48 bits) keeps socket and package cache paths short while still providing
-    /// enough variation for local file names that are not part of a security boundary.
-    /// </remarks>
     public const int CompactIdentifierLength = 12;
 
     /// <summary>
-    /// Number of hex characters to use from the randomized instance identifier.
+    /// Number of hex characters to use from the randomized legacy instance identifier.
     /// </summary>
     public const int InstanceHashLength = CompactIdentifierLength;
 
     /// <summary>
-    /// Gets the backchannels directory path for the given home directory.
+    /// Number of base64url characters in a compact AppHost identifier.
+    /// </summary>
+    public const int CompactAppHostIdLength = 11;
+
+    /// <summary>
+    /// Number of base64url characters in a compact instance identifier.
+    /// </summary>
+    public const int CompactInstanceIdLength = 8;
+
+    private const int CompactAppHostIdByteCount = 8;
+    private const int CompactInstanceIdByteCount = 6;
+    private const int MacOSSocketPathBytesIncludingNull = 104;
+    private const int DefaultSocketPathBytesIncludingNull = 108;
+
+    /// <summary>
+    /// Gets the compact backchannels directory path for the given home directory.
     /// </summary>
     /// <param name="homeDirectory">The user's home directory.</param>
-    /// <returns>The full path to the backchannels directory.</returns>
+    /// <returns>The full path to the compact backchannels directory.</returns>
     public static string GetBackchannelsDirectory(string homeDirectory)
+        => Path.Combine(homeDirectory, ".aspire", "cli", "bch");
+
+    /// <summary>
+    /// Gets the legacy backchannels directory path for the given home directory.
+    /// </summary>
+    /// <param name="homeDirectory">The user's home directory.</param>
+    /// <returns>The full path to the legacy backchannels directory.</returns>
+    public static string GetLegacyBackchannelsDirectory(string homeDirectory)
         => Path.Combine(homeDirectory, ".aspire", "cli", "backchannels");
 
     /// <summary>
-    /// Computes the hash portion of the socket name from an AppHost path.
+    /// Computes the compact AppHost identifier from an AppHost path.
+    /// </summary>
+    /// <param name="appHostPath">The full path to the AppHost project file.</param>
+    /// <returns>An 11-character base64url string.</returns>
+    public static string ComputeAppHostId(string appHostPath)
+    {
+        return ComputeStableBase64UrlIdentifier(NormalizePath(appHostPath), CompactAppHostIdByteCount);
+    }
+
+    /// <summary>
+    /// Computes the legacy hash portion of the socket name from an AppHost path.
     /// </summary>
     /// <remarks>
     /// On Windows the drive letter is normalized to uppercase before hashing so that
@@ -172,6 +182,19 @@ internal static class BackchannelConstants
     }
 
     /// <summary>
+    /// Computes all legacy hashes that should be searched for an AppHost path.
+    /// </summary>
+    /// <param name="appHostPath">The full path to the AppHost project file.</param>
+    /// <returns>The normalized legacy hash plus any pre-normalization fallback hash.</returns>
+    public static string[] ComputeLegacyHashes(string appHostPath)
+    {
+        var currentHash = ComputeHash(appHostPath);
+        var legacyHash = ComputeLegacyHash(appHostPath);
+
+        return legacyHash is null ? [currentHash] : [currentHash, legacyHash];
+    }
+
+    /// <summary>
     /// Normalizes the path for consistent hashing by uppercasing the Windows drive letter.
     /// </summary>
     private static string NormalizePath(string path)
@@ -191,7 +214,7 @@ internal static class BackchannelConstants
     /// Computes the full socket path for an AppHost instance.
     /// </summary>
     /// <remarks>
-    /// Called by AppHost when creating the socket. Includes a randomized instance hash and the PID
+    /// Called by AppHost when creating the socket. Includes a randomized instance ID and the PID
     /// to ensure uniqueness across multiple instances of the same AppHost.
     /// </remarks>
     /// <param name="appHostPath">The full path to the AppHost project file.</param>
@@ -200,136 +223,130 @@ internal static class BackchannelConstants
     /// <returns>The full socket path including PID.</returns>
     public static string ComputeSocketPath(string appHostPath, string homeDirectory, int processId)
     {
-        var dir = GetBackchannelsDirectory(homeDirectory);
-        var hash = ComputeHash(appHostPath);
-        var instanceHash = CreateRandomIdentifier(InstanceHashLength);
-        return Path.Combine(dir, $"{SocketPrefix}.{hash}.{instanceHash}.{processId}");
+        var appHostId = ComputeAppHostId(appHostPath);
+        return ComputeSocketPathFromAppHostId(appHostId, homeDirectory, processId);
     }
 
     /// <summary>
-    /// Computes the socket path prefix for finding sockets (without PID).
+    /// Computes the full socket path for an AppHost identifier.
+    /// </summary>
+    /// <param name="appHostId">The compact AppHost identifier.</param>
+    /// <param name="homeDirectory">The user's home directory.</param>
+    /// <param name="processId">The process ID of the AppHost.</param>
+    /// <returns>The full socket path including PID.</returns>
+    public static string ComputeSocketPathFromAppHostId(string appHostId, string homeDirectory, int processId)
+    {
+        ValidateCompactAppHostId(appHostId);
+
+        var dir = GetBackchannelsDirectory(homeDirectory);
+        var instanceId = CreateRandomBase64UrlIdentifier();
+        var socketPath = Path.Combine(dir, $"{appHostId}{instanceId}.{processId.ToString(CultureInfo.InvariantCulture)}");
+        ValidateSocketPathLength(socketPath);
+
+        return socketPath;
+    }
+
+    /// <summary>
+    /// Computes a randomized CLI-managed Unix socket path.
+    /// </summary>
+    /// <param name="homeDirectory">The user's home directory.</param>
+    /// <param name="socketPrefix">The logical socket prefix requested by the caller.</param>
+    /// <returns>The full socket path.</returns>
+    public static string ComputeCliSocketPath(string homeDirectory, string socketPrefix)
+    {
+        ArgumentException.ThrowIfNullOrEmpty(socketPrefix);
+
+        var dir = GetBackchannelsDirectory(homeDirectory);
+        var socketName = ComputeSocketFileName(socketPrefix);
+        var socketPath = Path.Combine(dir, socketName);
+        ValidateSocketPathLength(socketPath);
+
+        return socketPath;
+    }
+
+    public static string ComputeSocketFileName(string socketPrefix)
+    {
+        ArgumentException.ThrowIfNullOrEmpty(socketPrefix);
+
+        return $"{GetCompactCliSocketPrefix(socketPrefix)}{CreateRandomBase64UrlIdentifier()}";
+    }
+
+    /// <summary>
+    /// Computes the socket path prefix for finding compact sockets.
     /// </summary>
     /// <remarks>
     /// Called by CLI when searching for sockets. Since the CLI doesn't know the
-    /// AppHost's PID, it uses this prefix with a glob pattern to find matching sockets.
+    /// AppHost's PID or instance ID, it uses this prefix with a glob pattern to find matching sockets.
     /// </remarks>
     /// <param name="appHostPath">The full path to the AppHost project file.</param>
     /// <param name="homeDirectory">The user's home directory.</param>
-    /// <returns>The socket path prefix (without PID suffix).</returns>
+    /// <returns>The socket path prefix.</returns>
     public static string ComputeSocketPrefix(string appHostPath, string homeDirectory)
     {
         var dir = GetBackchannelsDirectory(homeDirectory);
-        var hash = ComputeHash(appHostPath);
-        return Path.Combine(dir, $"{SocketPrefix}.{hash}");
+        var appHostId = ComputeAppHostId(appHostPath);
+        return Path.Combine(dir, appHostId);
     }
 
     /// <summary>
     /// Finds all socket files matching the given AppHost path.
     /// </summary>
     /// <remarks>
-    /// Returns all socket files for an AppHost, regardless of PID. This includes
-    /// old format (<c>auxi.sock.{hash}</c>), previous format (<c>auxi.sock.{hash}.{pid}</c>),
-    /// and current format (<c>auxi.sock.{hash}.{instanceHash}.{pid}</c>).
+    /// Returns all compact socket files for an AppHost and falls back to legacy
+    /// <c>auxi.sock.{hash}</c>, <c>auxi.sock.{hash}.{pid}</c>, and
+    /// <c>auxi.sock.{hash}.{instanceHash}.{pid}</c> names for older AppHosts.
     /// </remarks>
     /// <param name="appHostPath">The full path to the AppHost project file.</param>
     /// <param name="homeDirectory">The user's home directory.</param>
     /// <returns>An array of socket file paths, or empty if none found.</returns>
     public static string[] FindMatchingSockets(string appHostPath, string homeDirectory)
     {
-        var dir = GetBackchannelsDirectory(homeDirectory);
+        var results = new List<string>();
 
-        if (!Directory.Exists(dir))
+        var compactDir = GetBackchannelsDirectory(homeDirectory);
+        var appHostId = ComputeAppHostId(appHostPath);
+        results.AddRange(FindCompactSocketsByAppHostId(compactDir, appHostId));
+
+        var legacyDir = GetLegacyBackchannelsDirectory(homeDirectory);
+        foreach (var legacyHash in ComputeLegacyHashes(appHostPath))
         {
-            return [];
+            results.AddRange(FindLegacySocketsByPrefix(legacyDir, $"{SocketPrefix}.{legacyHash}"));
+            results.AddRange(FindLegacySocketsByPrefix(legacyDir, $"aux.sock.{legacyHash}"));
         }
 
-        var hash = ComputeHash(appHostPath);
-        var prefixFileName = $"{SocketPrefix}.{hash}";
-        var results = FindSocketsByPrefix(dir, prefixFileName);
-
-        // Also search for sockets created by older AppHosts that used the raw (unnormalized) path hash.
-        var legacyHash = ComputeLegacyHash(appHostPath);
-        if (legacyHash is not null)
-        {
-            var legacyPrefixFileName = $"{SocketPrefix}.{legacyHash}";
-            var legacyResults = FindSocketsByPrefix(dir, legacyPrefixFileName);
-            if (legacyResults.Length > 0)
-            {
-                results = [.. results, .. legacyResults];
-            }
-        }
-
-        return results;
+        return results.Distinct(StringComparer.Ordinal).ToArray();
     }
 
     /// <summary>
-    /// Finds socket files in <paramref name="directory"/> whose names match
-    /// <paramref name="prefixFileName"/> in any of the supported socket name formats.
-    /// </summary>
-    private static string[] FindSocketsByPrefix(string directory, string prefixFileName)
-    {
-        // Match old format (auxi.sock.{hash}), previous format (auxi.sock.{hash}.{pid}),
-        // and current format (auxi.sock.{hash}.{instanceHash}.{pid})
-        // Use pattern with "*" to match optional PID suffix
-        var allMatches = Directory.GetFiles(directory, prefixFileName + "*");
-
-        // Filter to only include exact match (old format), .{pid} suffix (previous format),
-        // or .{instanceHash}.{pid} suffix (current format). This avoids matching
-        // auxi.sock.{hash}abc (different hash that starts with same chars) and files
-        // like auxi.sock.{hash}.12345.bak.
-        return allMatches.Where(f =>
-        {
-            var fileName = Path.GetFileName(f);
-            if (fileName == prefixFileName)
-            {
-                return true; // Old format: exact match
-            }
-
-            if (!fileName.StartsWith(prefixFileName + ".", StringComparison.Ordinal))
-            {
-                return false;
-            }
-
-            var suffix = fileName[(prefixFileName.Length + 1)..];
-            var segments = suffix.Split('.');
-
-            if (segments.Length == 1 &&
-                int.TryParse(segments[0], NumberStyles.None, CultureInfo.InvariantCulture, out _))
-            {
-                return true; // Previous format: prefix followed by integer PID
-            }
-
-            return segments.Length == 2 &&
-                   IsHex(segments[0]) &&
-                   int.TryParse(segments[1], NumberStyles.None, CultureInfo.InvariantCulture, out _);
-        }).ToArray();
-    }
-
-    /// <summary>
-    /// Extracts the hash from a socket filename.
+    /// Extracts the AppHost identifier from a socket filename.
     /// </summary>
     /// <remarks>
-    /// Works with old format (<c>auxi.sock.{hash}</c>), previous format (<c>auxi.sock.{hash}.{pid}</c>),
-    /// and current format (<c>auxi.sock.{hash}.{instanceHash}.{pid}</c>).
+    /// Works with compact format (<c>{appHostId}{instanceId}.{pid}</c>) and legacy
+    /// formats (<c>auxi.sock.{hash}</c>, <c>auxi.sock.{hash}.{pid}</c>,
+    /// and <c>auxi.sock.{hash}.{instanceHash}.{pid}</c>).
     /// </remarks>
     /// <param name="socketPath">The full socket path or filename.</param>
-    /// <returns>The hash portion, or <c>null</c> if the format is unrecognized.</returns>
+    /// <returns>The AppHost identifier or hash portion, or <c>null</c> if the format is unrecognized.</returns>
     public static string? ExtractHash(string socketPath)
     {
         var fileName = Path.GetFileName(socketPath);
 
-        // Handle current format: auxi.sock.{hash}.{instanceHash}.{pid}
-        // Handle previous format: auxi.sock.{hash}.{pid}
-        // Handle old format: auxi.sock.{hash}
+        if (TryExtractCompactAppHostId(fileName, out var appHostId))
+        {
+            return appHostId;
+        }
+
+        // Handle legacy current format: auxi.sock.{hash}.{instanceHash}.{pid}
+        // Handle legacy previous format: auxi.sock.{hash}.{pid}
+        // Handle legacy old format: auxi.sock.{hash}
         if (fileName.StartsWith($"{SocketPrefix}.", StringComparison.Ordinal))
         {
-            var afterPrefix = fileName[($"{SocketPrefix}.".Length)..];
-            // If there's another dot, it's a multi-segment format - return just the AppHost hash part
+            var afterPrefix = fileName[$"{SocketPrefix}.".Length..];
             var dotIndex = afterPrefix.IndexOf('.');
             return dotIndex > 0 ? afterPrefix[..dotIndex] : afterPrefix;
         }
 
-        // Handle legacy format: aux.sock.{hash}
+        // Handle oldest legacy format: aux.sock.{hash}
         if (fileName.StartsWith("aux.sock.", StringComparison.Ordinal))
         {
             var afterPrefix = fileName["aux.sock.".Length..];
@@ -353,6 +370,7 @@ internal static class BackchannelConstants
         {
             return pid;
         }
+
         return null;
     }
 
@@ -385,26 +403,18 @@ internal static class BackchannelConstants
     }
 
     /// <summary>
-    /// Cleans up orphaned socket files for a specific AppHost hash.
+    /// Cleans up orphaned socket files for a specific AppHost identifier or legacy hash.
     /// </summary>
     /// <remarks>
-    /// <para>
-    /// Called by AppHost on startup to clean up sockets from previous crashed instances.
-    /// This ensures orphan cleanup happens even if the user has an old CLI that doesn't
-    /// support PID-based orphan detection.
-    /// </para>
-    /// <para>
-    /// <strong>Limitation:</strong> This method only cleans up sockets that include a PID
-    /// (<c>auxi.sock.{hash}.{pid}</c> or <c>auxi.sock.{hash}.{instanceHash}.{pid}</c>)
-    /// because old format sockets (<c>auxi.sock.{hash}</c>) don't have a PID for orphan detection.
-    /// Old format sockets are cleaned up via connection-based detection in the CLI.
-    /// </para>
+    /// This method only cleans up sockets that include a PID because old format sockets
+    /// do not have a PID for orphan detection.
     /// </remarks>
     /// <param name="backchannelsDirectory">The backchannels directory path.</param>
-    /// <param name="hash">The AppHost hash to match.</param>
+    /// <param name="hash">The AppHost identifier or legacy hash to match.</param>
     /// <param name="currentPid">The current process ID (to avoid deleting own socket).</param>
+    /// <param name="prefixedFilesOnly">If true, only delete files that start with the expected prefix (e.g., "auxi.sock.{hash}"). This speeds up file detection, but the prefix is only used by legacy sockets.</param>
     /// <returns>The number of orphaned sockets deleted.</returns>
-    public static int CleanupOrphanedSockets(string backchannelsDirectory, string hash, int currentPid)
+    public static int CleanupOrphanedSockets(string backchannelsDirectory, string hash, int currentPid, bool prefixedFilesOnly = false)
     {
         var deleted = 0;
 
@@ -413,10 +423,16 @@ internal static class BackchannelConstants
             return deleted;
         }
 
-        // Find all sockets for this hash across all supported formats.
-        var pattern = $"{SocketPrefix}.{hash}*";
-        foreach (var socketPath in Directory.GetFiles(backchannelsDirectory, pattern))
+        var files = prefixedFilesOnly
+            ? Directory.GetFiles(backchannelsDirectory, $"{SocketPrefix}.{hash}*")
+            : Directory.GetFiles(backchannelsDirectory);
+        foreach (var socketPath in files)
         {
+            if (!string.Equals(ExtractHash(socketPath), hash, StringComparison.Ordinal))
+            {
+                continue;
+            }
+
             var pid = ExtractPid(socketPath);
             if (pid.HasValue && pid.Value != currentPid && !ProcessExists(pid.Value))
             {
@@ -430,15 +446,15 @@ internal static class BackchannelConstants
                         deleted++;
                     }
                 }
-                catch
+                catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
                 {
-                    // Ignore deletion failures
                 }
             }
         }
 
         return deleted;
     }
+
     /// <summary>
     /// Computes a compact stable identifier from a string value.
     /// </summary>
@@ -460,7 +476,7 @@ internal static class BackchannelConstants
     }
 
     /// <summary>
-    /// Creates a compact randomized identifier.
+    /// Creates a compact randomized hex identifier.
     /// </summary>
     /// <param name="length">The number of lowercase hex characters to return.</param>
     /// <returns>A lowercase hex identifier truncated to <paramref name="length"/> characters.</returns>
@@ -474,12 +490,211 @@ internal static class BackchannelConstants
         return ToLowerHexIdentifier(randomBytes, length);
     }
 
+    /// <summary>
+    /// Creates a compact randomized base64url identifier.
+    /// </summary>
+    /// <param name="byteCount">The number of random bytes to encode.</param>
+    /// <returns>An unpadded base64url identifier.</returns>
+    public static string CreateRandomBase64UrlIdentifier(int byteCount = CompactInstanceIdByteCount)
+    {
+        ArgumentOutOfRangeException.ThrowIfNegativeOrZero(byteCount);
+
+        Span<byte> randomBytes = stackalloc byte[byteCount];
+        RandomNumberGenerator.Fill(randomBytes);
+
+        return ToBase64UrlIdentifier(randomBytes);
+    }
+
+    /// <summary>
+    /// Gets the Unix domain socket path byte limit for the current platform, including the trailing null byte.
+    /// </summary>
+    /// <returns>The maximum number of bytes including the trailing null byte.</returns>
+    public static int GetMaxSocketPathBytesIncludingNull()
+        => OperatingSystem.IsMacOS() ? MacOSSocketPathBytesIncludingNull : DefaultSocketPathBytesIncludingNull;
+
+    /// <summary>
+    /// Gets the UTF-8 byte count for a Unix domain socket path, including the trailing null byte.
+    /// </summary>
+    /// <param name="socketPath">The socket path.</param>
+    /// <returns>The byte count including the trailing null byte.</returns>
+    public static int GetSocketPathByteCountIncludingNull(string socketPath)
+    {
+        ArgumentNullException.ThrowIfNull(socketPath);
+
+        return Encoding.UTF8.GetByteCount(socketPath) + 1;
+    }
+
+    /// <summary>
+    /// Validates that a Unix domain socket path fits within the current platform's byte limit.
+    /// </summary>
+    /// <param name="socketPath">The socket path to validate.</param>
+    /// <exception cref="InvalidOperationException">Thrown when the path exceeds the platform byte limit.</exception>
+    public static void ValidateSocketPathLength(string socketPath)
+    {
+        var byteCount = GetSocketPathByteCountIncludingNull(socketPath);
+        var maxByteCount = GetMaxSocketPathBytesIncludingNull();
+
+        if (byteCount > maxByteCount)
+        {
+            throw new InvalidOperationException(
+                $"The Unix domain socket path '{socketPath}' is {byteCount.ToString(CultureInfo.InvariantCulture)} bytes including the trailing null byte, " +
+                $"which exceeds the {maxByteCount.ToString(CultureInfo.InvariantCulture)}-byte limit on this platform.");
+        }
+    }
+
+    private static string[] FindCompactSocketsByAppHostId(string directory, string appHostId)
+    {
+        if (!Directory.Exists(directory))
+        {
+            return [];
+        }
+
+        return Directory.GetFiles(directory, appHostId + "*")
+            .Where(f =>
+            {
+                var fileName = Path.GetFileName(f);
+                return TryExtractCompactAppHostId(fileName, out var extractedAppHostId) &&
+                       string.Equals(extractedAppHostId, appHostId, StringComparison.Ordinal);
+            })
+            .ToArray();
+    }
+
+    /// <summary>
+    /// Finds socket files in <paramref name="directory"/> whose names match
+    /// <paramref name="prefixFileName"/> in any of the supported legacy socket name formats.
+    /// </summary>
+    private static string[] FindLegacySocketsByPrefix(string directory, string prefixFileName)
+    {
+        if (!Directory.Exists(directory))
+        {
+            return [];
+        }
+
+        // Match old format (auxi.sock.{hash}), previous format (auxi.sock.{hash}.{pid}),
+        // and current legacy format (auxi.sock.{hash}.{instanceHash}.{pid}).
+        var allMatches = Directory.GetFiles(directory, prefixFileName + "*");
+
+        // Filter to only include exact match (old format), .{pid} suffix (previous format),
+        // or .{instanceHash}.{pid} suffix (current legacy format). This avoids matching
+        // auxi.sock.{hash}abc (different hash that starts with same chars) and files
+        // like auxi.sock.{hash}.12345.bak.
+        return allMatches.Where(f =>
+        {
+            var fileName = Path.GetFileName(f);
+            if (fileName == prefixFileName)
+            {
+                return true; // Old format: exact match
+            }
+
+            if (!fileName.StartsWith(prefixFileName + ".", StringComparison.Ordinal))
+            {
+                return false;
+            }
+
+            var suffix = fileName[(prefixFileName.Length + 1)..];
+            var segments = suffix.Split('.');
+
+            if (segments.Length == 1 &&
+                int.TryParse(segments[0], NumberStyles.None, CultureInfo.InvariantCulture, out _))
+            {
+                return true; // Previous format: prefix followed by integer PID
+            }
+
+            return segments.Length == 2 &&
+                   IsHex(segments[0]) &&
+                   int.TryParse(segments[1], NumberStyles.None, CultureInfo.InvariantCulture, out _);
+        }).ToArray();
+    }
+
+    private static bool TryExtractCompactAppHostId(string fileName, out string appHostId)
+    {
+        appHostId = string.Empty;
+
+        if (fileName.Length == CompactAppHostIdLength && IsBase64UrlIdentifier(fileName))
+        {
+            appHostId = fileName;
+            return true;
+        }
+
+        var pidSeparatorIndex = CompactAppHostIdLength + CompactInstanceIdLength;
+        if (fileName.Length <= pidSeparatorIndex ||
+            fileName[pidSeparatorIndex] != '.')
+        {
+            return false;
+        }
+
+        var candidateAppHostId = fileName[..CompactAppHostIdLength];
+        var instanceId = fileName[CompactAppHostIdLength..pidSeparatorIndex];
+        var pidText = fileName[(pidSeparatorIndex + 1)..];
+
+        if (IsBase64UrlIdentifier(candidateAppHostId) &&
+            IsBase64UrlIdentifier(instanceId) &&
+            int.TryParse(pidText, NumberStyles.None, CultureInfo.InvariantCulture, out _))
+        {
+            appHostId = candidateAppHostId;
+            return true;
+        }
+
+        return false;
+    }
+
+    private static void ValidateCompactAppHostId(string appHostId)
+    {
+        ArgumentException.ThrowIfNullOrEmpty(appHostId);
+
+        if (appHostId.Length != CompactAppHostIdLength || !IsBase64UrlIdentifier(appHostId))
+        {
+            throw new ArgumentException(
+                $"The compact AppHost identifier must be {CompactAppHostIdLength.ToString(CultureInfo.InvariantCulture)} base64url characters.",
+                nameof(appHostId));
+        }
+    }
+
+    private static string ComputeStableBase64UrlIdentifier(string value, int byteCount)
+    {
+        ArgumentException.ThrowIfNullOrEmpty(value);
+        ArgumentOutOfRangeException.ThrowIfNegativeOrZero(byteCount);
+
+        var xxHash = new XxHash3();
+        xxHash.Append(Encoding.UTF8.GetBytes(value));
+        var hash = xxHash.GetCurrentHash();
+        ArgumentOutOfRangeException.ThrowIfGreaterThan(byteCount, hash.Length);
+
+        return ToBase64UrlIdentifier(hash.AsSpan(0, byteCount));
+    }
+
+    private static string GetCompactCliSocketPrefix(string socketPrefix)
+    {
+        if (socketPrefix.StartsWith("cli", StringComparison.OrdinalIgnoreCase))
+        {
+            return "c";
+        }
+
+        if (socketPrefix.StartsWith("apphost", StringComparison.OrdinalIgnoreCase))
+        {
+            return "h";
+        }
+
+        return "s";
+    }
+
     private static bool IsHex(string value)
         => !string.IsNullOrEmpty(value) && value.All(static c => char.IsAsciiHexDigit(c));
+
+    private static bool IsBase64UrlIdentifier(string value)
+        => !string.IsNullOrEmpty(value) && value.All(static c => char.IsAsciiLetterOrDigit(c) || c is '-' or '_');
 
     private static string ToLowerHexIdentifier(ReadOnlySpan<byte> bytes, int length)
     {
         var hex = Convert.ToHexString(bytes).ToLowerInvariant();
         return hex[..Math.Min(length, hex.Length)];
+    }
+
+    private static string ToBase64UrlIdentifier(ReadOnlySpan<byte> bytes)
+    {
+        return Convert.ToBase64String(bytes)
+            .TrimEnd('=')
+            .Replace('+', '-')
+            .Replace('/', '_');
     }
 }

--- a/src/Shared/BackchannelConstants.cs
+++ b/src/Shared/BackchannelConstants.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Buffers.Text;
 using System.Diagnostics;
 using System.Globalization;
 using System.IO.Hashing;
@@ -123,10 +124,11 @@ internal static class BackchannelConstants
     /// Computes the legacy hash portion of the socket name from an AppHost path.
     /// </summary>
     /// <remarks>
-    /// On Windows the drive letter is normalized to uppercase before hashing so that
-    /// "C:\App\MyApp.csproj" and "c:\App\MyApp.csproj" produce the same hash.
-    /// Without this, the CLI and AppHost can derive different drive-letter casings
-    /// (e.g. <c>FileInfo.FullName</c> vs MSBuild metadata) and fail to match sockets.
+    /// On Windows the entire path is upper-cased before hashing so that paths differing
+    /// only in casing (for example, <c>FileInfo.FullName</c> on the CLI side vs. MSBuild
+    /// metadata on the AppHost side) produce the same hash. On other platforms the path
+    /// is hashed as-is because case-sensitive APFS exists on macOS and Linux file systems
+    /// are case-sensitive.
     /// </remarks>
     /// <param name="appHostPath">The full path to the AppHost project file.</param>
     /// <returns>A 16-character lowercase hex string.</returns>
@@ -145,7 +147,6 @@ internal static class BackchannelConstants
     /// </remarks>
     /// <param name="appHostPath">The full path to the AppHost project file.</param>
     /// <returns>A 16-character lowercase hex string, or <c>null</c> if it matches the current hash.</returns>
-    // TODO: Remove legacy hash support once all supported AppHost versions use normalized hashing.
     public static string? ComputeLegacyHash(string appHostPath)
     {
         if (!OperatingSystem.IsWindows())
@@ -184,30 +185,43 @@ internal static class BackchannelConstants
     /// <summary>
     /// Computes all legacy hashes that should be searched for an AppHost path.
     /// </summary>
+    /// <remarks>
+    /// Returns, in order: the current normalized hash, the drive-letter-only normalized hash
+    /// (produced by AppHost versions that only upper-cased the drive letter before hashing),
+    /// and any raw-path fallback returned by <see cref="ComputeLegacyHash"/>. Duplicates are
+    /// removed.
+    /// </remarks>
     /// <param name="appHostPath">The full path to the AppHost project file.</param>
-    /// <returns>The normalized legacy hash plus any pre-normalization fallback hash.</returns>
+    /// <returns>All hash variants that should be searched.</returns>
     public static string[] ComputeLegacyHashes(string appHostPath)
     {
         var currentHash = ComputeHash(appHostPath);
-        var legacyHash = ComputeLegacyHash(appHostPath);
+        var rawLegacyHash = ComputeLegacyHash(appHostPath);
 
-        return legacyHash is null ? [currentHash] : [currentHash, legacyHash];
+        var results = new List<string>() { currentHash };
+        if (rawLegacyHash is not null && !results.Contains(rawLegacyHash, StringComparer.Ordinal))
+        {
+            results.Add(rawLegacyHash);
+        }
+
+        return results.ToArray();
     }
 
     /// <summary>
-    /// Normalizes the path for consistent hashing by uppercasing the Windows drive letter.
+    /// Normalizes the path for consistent hashing.
     /// </summary>
+    /// <remarks>
+    /// On Windows the entire path is upper-cased with <see cref="string.ToUpperInvariant"/>.
+    /// NTFS/ReFS treat paths as case-insensitive, but neither <c>FileInfo.FullName</c> (CLI side)
+    /// nor MSBuild metadata (AppHost side) canonicalizes casing against disk, so any segment
+    /// can differ between the two sides. <c>ToUpperInvariant</c> is deterministic across
+    /// machines and cultures, so both sides always agree on the same hash input.
+    /// On macOS and Linux the path is returned unchanged: case-sensitive APFS exists on macOS
+    /// and Linux file systems are case-sensitive by default.
+    /// </remarks>
     private static string NormalizePath(string path)
     {
-        // On Windows, the drive letter casing can differ between callers
-        // (e.g. FileInfo.FullName produces "C:\..." while MSBuild metadata may produce "c:\...").
-        // Uppercase only the drive letter so both sides hash identically.
-        if (OperatingSystem.IsWindows() && path.Length >= 2 && path[1] == ':')
-        {
-            return char.ToUpperInvariant(path[0]) + path[1..];
-        }
-
-        return path;
+        return OperatingSystem.IsWindows() ? path.ToUpperInvariant() : path;
     }
 
     /// <summary>
@@ -469,10 +483,8 @@ internal static class BackchannelConstants
     {
         ArgumentException.ThrowIfNullOrEmpty(value);
         ArgumentOutOfRangeException.ThrowIfNegativeOrZero(length);
-        var xxHash = new XxHash3();
-        xxHash.Append(Encoding.UTF8.GetBytes(value));
-
-        return ToLowerHexIdentifier(xxHash.GetCurrentHash(), length);
+        var hashBytes = XxHash3.Hash(Encoding.UTF8.GetBytes(value));
+        return ToLowerHexIdentifier(hashBytes, length);
     }
 
     /// <summary>

--- a/tests/Aspire.Cli.Tests/Utils/AppHostHelperTests.cs
+++ b/tests/Aspire.Cli.Tests/Utils/AppHostHelperTests.cs
@@ -4,29 +4,26 @@
 using Aspire.Cli.Tests.Telemetry;
 using Aspire.Cli.Tests.TestServices;
 using Aspire.Cli.Utils;
+using Aspire.Hosting.Backchannel;
 
 namespace Aspire.Cli.Tests.Utils;
 
 public class AppHostHelperTests(ITestOutputHelper outputHelper)
 {
     [Fact]
-    public void ComputeAuxiliarySocketPrefix_UsesAuxiPrefix()
+    public void ComputeAuxiliarySocketPrefix_UsesCompactBackchannelDirectory()
     {
-        // Arrange
         var appHostPath = Path.Combine("path", "to", "MyApp.AppHost.csproj");
         var homeDirectory = Path.Combine(Path.GetTempPath(), "testuser");
 
-        // Act
         var socketPrefix = AppHostHelper.ComputeAuxiliarySocketPrefix(appHostPath, homeDirectory);
 
-        // Assert
         var fileName = Path.GetFileName(socketPrefix);
-        Assert.StartsWith("auxi.sock.", fileName);
+        Assert.Matches("^[A-Za-z0-9_-]{11}$", fileName);
         
-        // Verify the directory is under the backchannels folder
         var dir = Path.GetDirectoryName(socketPrefix);
         Assert.NotNull(dir);
-        Assert.EndsWith("backchannels", dir);
+        Assert.Equal(Path.Combine(homeDirectory, ".aspire", "cli", "bch"), dir);
     }
 
     [Fact]
@@ -63,43 +60,61 @@ public class AppHostHelperTests(ITestOutputHelper outputHelper)
     [Fact]
     public void ComputeAuxiliarySocketPrefix_DoesNotUseReservedWindowsName()
     {
-        // This test verifies that the socket path does not use "aux" which is a reserved
-        // device name on Windows < 11 (from DOS days: CON, PRN, AUX, NUL, COM1-9, LPT1-9)
-        
-        // Arrange
         var appHostPath = "/path/to/MyApp.AppHost.csproj";
         var homeDirectory = "/home/user";
 
-        // Act
         var socketPrefix = AppHostHelper.ComputeAuxiliarySocketPrefix(appHostPath, homeDirectory);
 
-        // Assert
         var fileName = Path.GetFileName(socketPrefix);
-        
-        // Should use "auxi" prefix, not "aux"
-        Assert.StartsWith("auxi.sock.", fileName);
+        Assert.Equal(11, fileName.Length);
+        Assert.DoesNotContain("auxi.sock.", fileName);
         Assert.DoesNotContain("aux.sock.", fileName);
     }
 
     [Fact]
-    public void ComputeAuxiliarySocketPrefix_HashIs16Characters()
+    public void ComputeAuxiliarySocketPrefix_AppHostIdIs11Base64UrlCharacters()
     {
         var appHostPath = "/path/to/MyApp.AppHost.csproj";
         var homeDirectory = "/home/user";
 
         var socketPrefix = AppHostHelper.ComputeAuxiliarySocketPrefix(appHostPath, homeDirectory);
 
-        // Format is: auxi.sock.{hash} where hash is 16 chars
         var fileName = Path.GetFileName(socketPrefix);
-        var hash = fileName["auxi.sock.".Length..];
-        Assert.Equal(16, hash.Length);
-        Assert.Matches("^[a-f0-9]+$", hash);
+        Assert.Equal(11, fileName.Length);
+        Assert.Matches("^[A-Za-z0-9_-]+$", fileName);
     }
 
     [Fact]
-    public void ExtractHashFromSocketPath_ExtractsHashFromNewFormat()
+    public void ComputeSocketPath_UsesUtf8ByteCountLimitForNonAsciiHomeDirectory()
     {
-        // Current format: auxi.sock.{hash}.{instanceHash}.{pid}
+        var homeDirectory = @"C:\Users\TanakaTarou（田中太郎）";
+        var appHostPath = @"C:\src\MyApp.AppHost\MyApp.AppHost.csproj";
+        var processId = 26688;
+        var oldSocketPath = Path.Combine(homeDirectory, ".aspire", "cli", "backchannels", "auxi.sock.3a579b6853b74a71.fee67dd76369.26688");
+
+        var socketPath = BackchannelConstants.ComputeSocketPath(appHostPath, homeDirectory, processId);
+
+        Assert.True(
+            BackchannelConstants.GetSocketPathByteCountIncludingNull(oldSocketPath) > BackchannelConstants.GetMaxSocketPathBytesIncludingNull(),
+            $"The legacy path should exceed the platform byte limit for this regression case: {oldSocketPath}");
+        Assert.True(
+            BackchannelConstants.GetSocketPathByteCountIncludingNull(socketPath) <= BackchannelConstants.GetMaxSocketPathBytesIncludingNull(),
+            $"The compact path should fit the platform byte limit: {socketPath}");
+    }
+
+    [Fact]
+    public void ExtractHashFromSocketPath_ExtractsHashFromCompactFormat()
+    {
+        var socketPath = "/home/user/.aspire/cli/bch/AbCdEfGhIjkLmNoPqRs.12345";
+
+        var hash = AppHostHelper.ExtractHashFromSocketPath(socketPath);
+
+        Assert.Equal("AbCdEfGhIjk", hash);
+    }
+
+    [Fact]
+    public void ExtractHashFromSocketPath_ExtractsHashFromLegacyCurrentFormat()
+    {
         var socketPath = "/home/user/.aspire/cli/backchannels/auxi.sock.abc123def4567890.a1b2c3d4e5f6.12345";
         
         var hash = AppHostHelper.ExtractHashFromSocketPath(socketPath);
@@ -110,7 +125,6 @@ public class AppHostHelperTests(ITestOutputHelper outputHelper)
     [Fact]
     public void ExtractHashFromSocketPath_ExtractsHashFromPreviousFormat()
     {
-        // Previous format: auxi.sock.{hash}.{pid}
         var socketPath = "/home/user/.aspire/cli/backchannels/auxi.sock.abc123def4567890.12345";
 
         var hash = AppHostHelper.ExtractHashFromSocketPath(socketPath);
@@ -121,7 +135,6 @@ public class AppHostHelperTests(ITestOutputHelper outputHelper)
     [Fact]
     public void ExtractHashFromSocketPath_ExtractsHashFromOldFormat()
     {
-        // Old format: auxi.sock.{hash}
         var socketPath = "/home/user/.aspire/cli/backchannels/auxi.sock.abc123def4567890";
         
         var hash = AppHostHelper.ExtractHashFromSocketPath(socketPath);
@@ -132,7 +145,6 @@ public class AppHostHelperTests(ITestOutputHelper outputHelper)
     [Fact]
     public void ExtractHashFromSocketPath_ExtractsHashFromLegacyAuxFormat()
     {
-        // Legacy format: aux.sock.{hash}
         var socketPath = "/home/user/.aspire/cli/backchannels/aux.sock.abc123def4567890";
         
         var hash = AppHostHelper.ExtractHashFromSocketPath(socketPath);
@@ -153,7 +165,7 @@ public class AppHostHelperTests(ITestOutputHelper outputHelper)
     [Fact]
     public void ExtractPidFromSocketPath_ExtractsPidFromNewFormat()
     {
-        // Current format: auxi.sock.{hash}.{instanceHash}.{pid}
+        // Legacy current format: auxi.sock.{hash}.{instanceHash}.{pid}
         var socketPath = "/home/user/.aspire/cli/backchannels/auxi.sock.abc123def4567890.a1b2c3d4e5f6.12345";
         
         var pid = AppHostHelper.ExtractPidFromSocketPath(socketPath);
@@ -164,7 +176,7 @@ public class AppHostHelperTests(ITestOutputHelper outputHelper)
     [Fact]
     public void ExtractPidFromSocketPath_ExtractsPidFromPreviousFormat()
     {
-        // Previous format: auxi.sock.{hash}.{pid}
+        // Legacy previous format: auxi.sock.{hash}.{pid}
         var socketPath = "/home/user/.aspire/cli/backchannels/auxi.sock.abc123def4567890.12345";
 
         var pid = AppHostHelper.ExtractPidFromSocketPath(socketPath);
@@ -230,23 +242,20 @@ public class AppHostHelperTests(ITestOutputHelper outputHelper)
     public void FindMatchingSockets_FindsMatchingSocketFiles()
     {
         using var workspace = TemporaryWorkspace.Create(outputHelper);
-        var backchannelsDir = Path.Combine(workspace.WorkspaceRoot.FullName, ".aspire", "cli", "backchannels");
+        var backchannelsDir = Path.Combine(workspace.WorkspaceRoot.FullName, ".aspire", "cli", "bch");
         Directory.CreateDirectory(backchannelsDir);
 
         var appHostPath = "/path/to/MyApp.AppHost.csproj";
         
-        // Get the hash by extracting from computed prefix
         var prefix = AppHostHelper.ComputeAuxiliarySocketPrefix(appHostPath, workspace.WorkspaceRoot.FullName);
-        var hash = Path.GetFileName(prefix)["auxi.sock.".Length..];
+        var appHostId = Path.GetFileName(prefix);
         
-        // Create matching socket files in both current and previous formats.
-        var socket1 = Path.Combine(backchannelsDir, $"auxi.sock.{hash}.a1b2c3d4e5f6.12345");
-        var socket2 = Path.Combine(backchannelsDir, $"auxi.sock.{hash}.67890");
+        var socket1 = Path.Combine(backchannelsDir, $"{appHostId}a1b2C3d4.12345");
+        var socket2 = Path.Combine(backchannelsDir, $"{appHostId}Z9y8X7w6.67890");
         File.WriteAllText(socket1, "");
         File.WriteAllText(socket2, "");
         
-        // Create a non-matching socket file (different hash)
-        var otherSocket = Path.Combine(backchannelsDir, "auxi.sock.differenthash123.99999");
+        var otherSocket = Path.Combine(backchannelsDir, "differentId1a1b2C3d4.99999");
         File.WriteAllText(otherSocket, "");
         
         var sockets = AppHostHelper.FindMatchingSockets(appHostPath, workspace.WorkspaceRoot.FullName);
@@ -261,46 +270,40 @@ public class AppHostHelperTests(ITestOutputHelper outputHelper)
     public void FindMatchingSockets_FindsOldFormatSocketsWithoutPid()
     {
         using var workspace = TemporaryWorkspace.Create(outputHelper);
-        var backchannelsDir = Path.Combine(workspace.WorkspaceRoot.FullName, ".aspire", "cli", "backchannels");
-        Directory.CreateDirectory(backchannelsDir);
+        var legacyBackchannelsDir = Path.Combine(workspace.WorkspaceRoot.FullName, ".aspire", "cli", "backchannels");
+        Directory.CreateDirectory(legacyBackchannelsDir);
 
         var appHostPath = "/path/to/MyApp.AppHost.csproj";
         
-        // Get the hash by extracting from computed prefix
-        var prefix = AppHostHelper.ComputeAuxiliarySocketPrefix(appHostPath, workspace.WorkspaceRoot.FullName);
-        var hash = Path.GetFileName(prefix)["auxi.sock.".Length..];
+        var hash = AppHostHelper.ComputeLegacyHashes(appHostPath)[0];
         
-        // Create old format socket (no PID) - for backward compatibility
-        var oldFormatSocket = Path.Combine(backchannelsDir, $"auxi.sock.{hash}");
+        var oldFormatSocket = Path.Combine(legacyBackchannelsDir, $"auxi.sock.{hash}");
         File.WriteAllText(oldFormatSocket, "");
         
-        // Create new format socket (with PID)
-        var newFormatSocket = Path.Combine(backchannelsDir, $"auxi.sock.{hash}.12345");
-        File.WriteAllText(newFormatSocket, "");
+        var legacyPidSocket = Path.Combine(legacyBackchannelsDir, $"auxi.sock.{hash}.12345");
+        File.WriteAllText(legacyPidSocket, "");
         
         var sockets = AppHostHelper.FindMatchingSockets(appHostPath, workspace.WorkspaceRoot.FullName);
         
         // Should find both old and new format
         Assert.Equal(2, sockets.Length);
         Assert.Contains(oldFormatSocket, sockets);
-        Assert.Contains(newFormatSocket, sockets);
+        Assert.Contains(legacyPidSocket, sockets);
     }
 
     [Fact]
     public void FindMatchingSockets_DoesNotMatchSimilarHashes()
     {
         using var workspace = TemporaryWorkspace.Create(outputHelper);
-        var backchannelsDir = Path.Combine(workspace.WorkspaceRoot.FullName, ".aspire", "cli", "backchannels");
+        var backchannelsDir = Path.Combine(workspace.WorkspaceRoot.FullName, ".aspire", "cli", "bch");
         Directory.CreateDirectory(backchannelsDir);
 
         var appHostPath = "/path/to/MyApp.AppHost.csproj";
         
-        // Get the hash by extracting from computed prefix
         var prefix = AppHostHelper.ComputeAuxiliarySocketPrefix(appHostPath, workspace.WorkspaceRoot.FullName);
-        var hash = Path.GetFileName(prefix)["auxi.sock.".Length..];
+        var appHostId = Path.GetFileName(prefix);
         
-        // Create a socket with a hash that starts with the same chars but is different
-        var similarSocket = Path.Combine(backchannelsDir, $"auxi.sock.{hash}xyz.12345");
+        var similarSocket = Path.Combine(backchannelsDir, $"{appHostId}xyz.12345");
         File.WriteAllText(similarSocket, "");
         
         var sockets = AppHostHelper.FindMatchingSockets(appHostPath, workspace.WorkspaceRoot.FullName);
@@ -313,13 +316,13 @@ public class AppHostHelperTests(ITestOutputHelper outputHelper)
     public void FindMatchingSockets_ReturnsEmptyWhenNoMatchingFiles()
     {
         using var workspace = TemporaryWorkspace.Create(outputHelper);
-        var backchannelsDir = Path.Combine(workspace.WorkspaceRoot.FullName, ".aspire", "cli", "backchannels");
+        var backchannelsDir = Path.Combine(workspace.WorkspaceRoot.FullName, ".aspire", "cli", "bch");
         Directory.CreateDirectory(backchannelsDir);
 
         var appHostPath = "/path/to/MyApp.AppHost.csproj";
         
         // Create sockets for a DIFFERENT app host
-        var otherSocket = Path.Combine(backchannelsDir, "auxi.sock.differenthash123.99999");
+        var otherSocket = Path.Combine(backchannelsDir, "differentId1a1b2C3d4.99999");
         File.WriteAllText(otherSocket, "");
         
         var sockets = AppHostHelper.FindMatchingSockets(appHostPath, workspace.WorkspaceRoot.FullName);
@@ -331,30 +334,26 @@ public class AppHostHelperTests(ITestOutputHelper outputHelper)
     public void CleanupOrphanedSockets_CleansUpBothOldAndNewFormatSockets()
     {
         using var workspace = TemporaryWorkspace.Create(outputHelper);
-        var backchannelsDir = Path.Combine(workspace.WorkspaceRoot.FullName, ".aspire", "cli", "backchannels");
+        var backchannelsDir = Path.Combine(workspace.WorkspaceRoot.FullName, ".aspire", "cli", "bch");
         Directory.CreateDirectory(backchannelsDir);
 
         var appHostPath = "/path/to/MyApp.AppHost.csproj";
         
-        // Get the hash
         var prefix = AppHostHelper.ComputeAuxiliarySocketPrefix(appHostPath, workspace.WorkspaceRoot.FullName);
-        var hash = AppHostHelper.ExtractHashFromSocketPath(prefix)!;
+        var appHostId = AppHostHelper.ExtractHashFromSocketPath(prefix)!;
         
-        // Create old format socket (no PID) - should NOT be cleaned up (can't detect orphan without PID)
-        var oldFormatSocket = Path.Combine(backchannelsDir, $"auxi.sock.{hash}");
+        var oldFormatSocket = Path.Combine(backchannelsDir, appHostId);
         File.WriteAllText(oldFormatSocket, "");
         
-        // Create new format socket with a dead PID (use int.MaxValue - 1 as unlikely to exist)
         var deadPid = int.MaxValue - 1;
-        var orphanedSocket = Path.Combine(backchannelsDir, $"auxi.sock.{hash}.{deadPid}");
+        var orphanedSocket = Path.Combine(backchannelsDir, $"{appHostId}a1b2C3d4.{deadPid}");
         File.WriteAllText(orphanedSocket, "");
         
-        // Create new format socket with current PID (should NOT be deleted)
         var currentPid = Environment.ProcessId;
-        var liveSocket = Path.Combine(backchannelsDir, $"auxi.sock.{hash}.{currentPid}");
+        var liveSocket = Path.Combine(backchannelsDir, $"{appHostId}Z9y8X7w6.{currentPid}");
         File.WriteAllText(liveSocket, "");
         
-        var deleted = AppHostHelper.CleanupOrphanedSockets(backchannelsDir, hash, currentPid);
+        var deleted = AppHostHelper.CleanupOrphanedSockets(backchannelsDir, appHostId, currentPid);
         
         // Should only delete the orphaned socket (dead PID)
         Assert.Equal(1, deleted);
@@ -404,8 +403,7 @@ public class AppHostHelperTests(ITestOutputHelper outputHelper)
         Assert.NotNull(lowerLegacyHash);
         Assert.Equal(lowerLegacyHash, upperLegacyHash);
 
-        var currentPrefix = AppHostHelper.ComputeAuxiliarySocketPrefix(upperDrivePath, Path.GetTempPath());
-        var currentHash = Path.GetFileName(currentPrefix)["auxi.sock.".Length..];
+        var currentHash = AppHostHelper.ComputeLegacyHashes(upperDrivePath)[0];
         Assert.NotEqual(currentHash, upperLegacyHash);
     }
 
@@ -428,7 +426,7 @@ public class AppHostHelperTests(ITestOutputHelper outputHelper)
             "Drive letter normalization only applies on Windows.");
 
         using var workspace = TemporaryWorkspace.Create(outputHelper);
-        var backchannelsDir = Path.Combine(workspace.WorkspaceRoot.FullName, ".aspire", "cli", "backchannels");
+        var backchannelsDir = Path.Combine(workspace.WorkspaceRoot.FullName, ".aspire", "cli", "bch");
         Directory.CreateDirectory(backchannelsDir);
 
         // Simulate the real-world mismatch: FileInfo.FullName yields an uppercase drive letter
@@ -437,15 +435,14 @@ public class AppHostHelperTests(ITestOutputHelper outputHelper)
         var upperDrivePath = @"C:\Development\MyApp\MyApp.AppHost.csproj";
         var lowerDrivePath = @"c:\Development\MyApp\MyApp.AppHost.csproj";
 
-        // Both should produce the same hash after drive-letter normalization.
+        // Both should produce the same AppHost ID after drive-letter normalization.
         var upperPrefix = AppHostHelper.ComputeAuxiliarySocketPrefix(upperDrivePath, workspace.WorkspaceRoot.FullName);
         var lowerPrefix = AppHostHelper.ComputeAuxiliarySocketPrefix(lowerDrivePath, workspace.WorkspaceRoot.FullName);
         Assert.Equal(upperPrefix, lowerPrefix);
 
-        var hash = Path.GetFileName(upperPrefix)["auxi.sock.".Length..];
+        var appHostId = Path.GetFileName(upperPrefix);
 
-        // Create a socket file using the normalized hash (simulates a new AppHost)
-        var socket = Path.Combine(backchannelsDir, $"auxi.sock.{hash}.a1b2c3d4e5f6.12345");
+        var socket = Path.Combine(backchannelsDir, $"{appHostId}a1b2C3d4.12345");
         File.WriteAllText(socket, "");
 
         // Both path variants should find the socket
@@ -478,9 +475,7 @@ public class AppHostHelperTests(ITestOutputHelper outputHelper)
         var legacySocket = Path.Combine(backchannelsDir, $"auxi.sock.{legacyHash}.a1b2c3d4e5f6.99999");
         File.WriteAllText(legacySocket, "");
 
-        // The current normalized hash differs from the legacy hash
-        var currentPrefix = AppHostHelper.ComputeAuxiliarySocketPrefix(appHostPath, workspace.WorkspaceRoot.FullName);
-        var currentHash = Path.GetFileName(currentPrefix)["auxi.sock.".Length..];
+        var currentHash = AppHostHelper.ComputeLegacyHashes(appHostPath)[0];
         Assert.NotEqual(currentHash, legacyHash);
 
         // FindMatchingSockets should still find the legacy socket via fallback

--- a/tests/Aspire.Cli.Tests/Utils/AppHostHelperTests.cs
+++ b/tests/Aspire.Cli.Tests/Utils/AppHostHelperTests.cs
@@ -20,7 +20,7 @@ public class AppHostHelperTests(ITestOutputHelper outputHelper)
 
         var fileName = Path.GetFileName(socketPrefix);
         Assert.Matches("^[A-Za-z0-9_-]{11}$", fileName);
-        
+
         var dir = Path.GetDirectoryName(socketPrefix);
         Assert.NotNull(dir);
         Assert.Equal(Path.Combine(homeDirectory, ".aspire", "cli", "bch"), dir);
@@ -116,9 +116,9 @@ public class AppHostHelperTests(ITestOutputHelper outputHelper)
     public void ExtractHashFromSocketPath_ExtractsHashFromLegacyCurrentFormat()
     {
         var socketPath = "/home/user/.aspire/cli/backchannels/auxi.sock.abc123def4567890.a1b2c3d4e5f6.12345";
-        
+
         var hash = AppHostHelper.ExtractHashFromSocketPath(socketPath);
-        
+
         Assert.Equal("abc123def4567890", hash);
     }
 
@@ -136,9 +136,9 @@ public class AppHostHelperTests(ITestOutputHelper outputHelper)
     public void ExtractHashFromSocketPath_ExtractsHashFromOldFormat()
     {
         var socketPath = "/home/user/.aspire/cli/backchannels/auxi.sock.abc123def4567890";
-        
+
         var hash = AppHostHelper.ExtractHashFromSocketPath(socketPath);
-        
+
         Assert.Equal("abc123def4567890", hash);
     }
 
@@ -146,9 +146,9 @@ public class AppHostHelperTests(ITestOutputHelper outputHelper)
     public void ExtractHashFromSocketPath_ExtractsHashFromLegacyAuxFormat()
     {
         var socketPath = "/home/user/.aspire/cli/backchannels/aux.sock.abc123def4567890";
-        
+
         var hash = AppHostHelper.ExtractHashFromSocketPath(socketPath);
-        
+
         Assert.Equal("abc123def4567890", hash);
     }
 
@@ -156,9 +156,9 @@ public class AppHostHelperTests(ITestOutputHelper outputHelper)
     public void ExtractHashFromSocketPath_ReturnsNullForUnrecognizedFormat()
     {
         var socketPath = "/home/user/.aspire/cli/backchannels/unknown.sock.abc123";
-        
+
         var hash = AppHostHelper.ExtractHashFromSocketPath(socketPath);
-        
+
         Assert.Null(hash);
     }
 
@@ -167,9 +167,9 @@ public class AppHostHelperTests(ITestOutputHelper outputHelper)
     {
         // Legacy current format: auxi.sock.{hash}.{instanceHash}.{pid}
         var socketPath = "/home/user/.aspire/cli/backchannels/auxi.sock.abc123def4567890.a1b2c3d4e5f6.12345";
-        
+
         var pid = AppHostHelper.ExtractPidFromSocketPath(socketPath);
-        
+
         Assert.Equal(12345, pid);
     }
 
@@ -189,9 +189,9 @@ public class AppHostHelperTests(ITestOutputHelper outputHelper)
     {
         // Old format: auxi.sock.{hash} - no PID
         var socketPath = "/home/user/.aspire/cli/backchannels/auxi.sock.abc123def4567890";
-        
+
         var pid = AppHostHelper.ExtractPidFromSocketPath(socketPath);
-        
+
         Assert.Null(pid);
     }
 
@@ -200,9 +200,9 @@ public class AppHostHelperTests(ITestOutputHelper outputHelper)
     {
         // Invalid PID (not a number)
         var socketPath = "/home/user/.aspire/cli/backchannels/auxi.sock.abc123def4567890.notapid";
-        
+
         var pid = AppHostHelper.ExtractPidFromSocketPath(socketPath);
-        
+
         Assert.Null(pid);
     }
 
@@ -210,9 +210,9 @@ public class AppHostHelperTests(ITestOutputHelper outputHelper)
     public void ProcessExists_ReturnsTrueForCurrentProcess()
     {
         var currentPid = Environment.ProcessId;
-        
+
         var exists = AppHostHelper.ProcessExists(currentPid);
-        
+
         Assert.True(exists);
     }
 
@@ -221,9 +221,9 @@ public class AppHostHelperTests(ITestOutputHelper outputHelper)
     {
         // Use a very high PID that's unlikely to exist
         var invalidPid = int.MaxValue - 1;
-        
+
         var exists = AppHostHelper.ProcessExists(invalidPid);
-        
+
         Assert.False(exists);
     }
 
@@ -232,9 +232,9 @@ public class AppHostHelperTests(ITestOutputHelper outputHelper)
     {
         var appHostPath = "/path/to/MyApp.AppHost.csproj";
         var homeDirectory = "/nonexistent/home/directory";
-        
+
         var sockets = AppHostHelper.FindMatchingSockets(appHostPath, homeDirectory);
-        
+
         Assert.Empty(sockets);
     }
 
@@ -246,20 +246,20 @@ public class AppHostHelperTests(ITestOutputHelper outputHelper)
         Directory.CreateDirectory(backchannelsDir);
 
         var appHostPath = "/path/to/MyApp.AppHost.csproj";
-        
+
         var prefix = AppHostHelper.ComputeAuxiliarySocketPrefix(appHostPath, workspace.WorkspaceRoot.FullName);
         var appHostId = Path.GetFileName(prefix);
-        
+
         var socket1 = Path.Combine(backchannelsDir, $"{appHostId}a1b2C3d4.12345");
         var socket2 = Path.Combine(backchannelsDir, $"{appHostId}Z9y8X7w6.67890");
         File.WriteAllText(socket1, "");
         File.WriteAllText(socket2, "");
-        
+
         var otherSocket = Path.Combine(backchannelsDir, "differentId1a1b2C3d4.99999");
         File.WriteAllText(otherSocket, "");
-        
+
         var sockets = AppHostHelper.FindMatchingSockets(appHostPath, workspace.WorkspaceRoot.FullName);
-        
+
         Assert.Equal(2, sockets.Length);
         Assert.Contains(socket1, sockets);
         Assert.Contains(socket2, sockets);
@@ -274,17 +274,17 @@ public class AppHostHelperTests(ITestOutputHelper outputHelper)
         Directory.CreateDirectory(legacyBackchannelsDir);
 
         var appHostPath = "/path/to/MyApp.AppHost.csproj";
-        
+
         var hash = AppHostHelper.ComputeLegacyHashes(appHostPath)[0];
-        
+
         var oldFormatSocket = Path.Combine(legacyBackchannelsDir, $"auxi.sock.{hash}");
         File.WriteAllText(oldFormatSocket, "");
-        
+
         var legacyPidSocket = Path.Combine(legacyBackchannelsDir, $"auxi.sock.{hash}.12345");
         File.WriteAllText(legacyPidSocket, "");
-        
+
         var sockets = AppHostHelper.FindMatchingSockets(appHostPath, workspace.WorkspaceRoot.FullName);
-        
+
         // Should find both old and new format
         Assert.Equal(2, sockets.Length);
         Assert.Contains(oldFormatSocket, sockets);
@@ -299,15 +299,20 @@ public class AppHostHelperTests(ITestOutputHelper outputHelper)
         Directory.CreateDirectory(backchannelsDir);
 
         var appHostPath = "/path/to/MyApp.AppHost.csproj";
-        
+
         var prefix = AppHostHelper.ComputeAuxiliarySocketPrefix(appHostPath, workspace.WorkspaceRoot.FullName);
         var appHostId = Path.GetFileName(prefix);
-        
-        var similarSocket = Path.Combine(backchannelsDir, $"{appHostId}xyz.12345");
-        File.WriteAllText(similarSocket, "");
-        
+
+        // 8 base64url chars but missing the '.' separator before PID
+        var badSeparator = Path.Combine(backchannelsDir, $"{appHostId}AbCdEfGhX12345");
+        File.WriteAllText(badSeparator, "");
+
+        // Correct structure but non-integer PID
+        var badPid = Path.Combine(backchannelsDir, $"{appHostId}AbCdEfGh.notapid");
+        File.WriteAllText(badPid, "");
+
         var sockets = AppHostHelper.FindMatchingSockets(appHostPath, workspace.WorkspaceRoot.FullName);
-        
+
         // Should NOT match the similar hash
         Assert.Empty(sockets);
     }
@@ -320,13 +325,13 @@ public class AppHostHelperTests(ITestOutputHelper outputHelper)
         Directory.CreateDirectory(backchannelsDir);
 
         var appHostPath = "/path/to/MyApp.AppHost.csproj";
-        
+
         // Create sockets for a DIFFERENT app host
         var otherSocket = Path.Combine(backchannelsDir, "differentId1a1b2C3d4.99999");
         File.WriteAllText(otherSocket, "");
-        
+
         var sockets = AppHostHelper.FindMatchingSockets(appHostPath, workspace.WorkspaceRoot.FullName);
-        
+
         Assert.Empty(sockets);
     }
 
@@ -338,23 +343,23 @@ public class AppHostHelperTests(ITestOutputHelper outputHelper)
         Directory.CreateDirectory(backchannelsDir);
 
         var appHostPath = "/path/to/MyApp.AppHost.csproj";
-        
+
         var prefix = AppHostHelper.ComputeAuxiliarySocketPrefix(appHostPath, workspace.WorkspaceRoot.FullName);
         var appHostId = AppHostHelper.ExtractHashFromSocketPath(prefix)!;
-        
+
         var oldFormatSocket = Path.Combine(backchannelsDir, appHostId);
         File.WriteAllText(oldFormatSocket, "");
-        
+
         var deadPid = int.MaxValue - 1;
         var orphanedSocket = Path.Combine(backchannelsDir, $"{appHostId}a1b2C3d4.{deadPid}");
         File.WriteAllText(orphanedSocket, "");
-        
+
         var currentPid = Environment.ProcessId;
         var liveSocket = Path.Combine(backchannelsDir, $"{appHostId}Z9y8X7w6.{currentPid}");
         File.WriteAllText(liveSocket, "");
-        
+
         var deleted = AppHostHelper.CleanupOrphanedSockets(backchannelsDir, appHostId, currentPid);
-        
+
         // Should only delete the orphaned socket (dead PID)
         Assert.Equal(1, deleted);
         Assert.True(File.Exists(oldFormatSocket), "Old format socket should still exist (can't detect orphan)");
@@ -388,7 +393,7 @@ public class AppHostHelperTests(ITestOutputHelper outputHelper)
     }
 
     [Fact]
-    public void ComputeLegacyHash_WhenUppercaseDrivePathOnWindows_ReturnsLowercaseDriveLegacyHash()
+    public void ComputeLegacyHashes_IncludesDriveLetterOnlyHashSharedAcrossCasings()
     {
         Assert.SkipWhen(!OperatingSystem.IsWindows(),
             "Drive-letter legacy fallback behavior only applies on Windows.");
@@ -396,15 +401,19 @@ public class AppHostHelperTests(ITestOutputHelper outputHelper)
         var upperDrivePath = @"C:\Path\To\MyApp.AppHost.csproj";
         var lowerDrivePath = @"c:\Path\To\MyApp.AppHost.csproj";
 
-        var upperLegacyHash = AppHostHelper.ComputeLegacyHash(upperDrivePath);
-        var lowerLegacyHash = AppHostHelper.ComputeLegacyHash(lowerDrivePath);
+        var upperHashes = AppHostHelper.ComputeLegacyHashes(upperDrivePath);
+        var lowerHashes = AppHostHelper.ComputeLegacyHashes(lowerDrivePath);
 
-        Assert.NotNull(upperLegacyHash);
-        Assert.NotNull(lowerLegacyHash);
-        Assert.Equal(lowerLegacyHash, upperLegacyHash);
+        // The drive-letter-only normalized hash (produced by AppHost versions that only
+        // upper-cased the drive letter) must appear in both arrays so sockets created by
+        // those AppHosts are still discoverable regardless of which drive-letter casing
+        // the current caller has.
+        var shared = upperHashes.Intersect(lowerHashes, StringComparer.Ordinal).ToArray();
+        Assert.NotEmpty(shared);
 
-        var currentHash = AppHostHelper.ComputeLegacyHashes(upperDrivePath)[0];
-        Assert.NotEqual(currentHash, upperLegacyHash);
+        // The current (full-uppercase on Windows) hash must also be shared because the
+        // entire path is now normalized.
+        Assert.Equal(upperHashes[0], lowerHashes[0]);
     }
 
     [Fact]
@@ -417,6 +426,41 @@ public class AppHostHelperTests(ITestOutputHelper outputHelper)
         var legacyHash = AppHostHelper.ComputeLegacyHash(appHostPath);
 
         Assert.Null(legacyHash);
+    }
+
+    [Fact]
+    public void ComputeHash_IsCaseInsensitiveAcrossFullPathOnWindows()
+    {
+        Assert.SkipWhen(!OperatingSystem.IsWindows(),
+            "Full-path normalization only applies on Windows.");
+
+        var upper = @"C:\Foo\Bar\App.AppHost.csproj";
+        var mixed = @"c:\foo\BAR\app.apphost.CSPROJ";
+
+        Assert.Equal(BackchannelConstants.ComputeHash(upper), BackchannelConstants.ComputeHash(mixed));
+        Assert.Equal(BackchannelConstants.ComputeAppHostId(upper), BackchannelConstants.ComputeAppHostId(mixed));
+    }
+
+    [Fact]
+    public void FindMatchingSockets_FindsCompactSocketAcrossPathCasing()
+    {
+        Assert.SkipWhen(!OperatingSystem.IsWindows(),
+            "Full-path normalization only applies on Windows.");
+
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        var backchannelsDir = Path.Combine(workspace.WorkspaceRoot.FullName, ".aspire", "cli", "bch");
+        Directory.CreateDirectory(backchannelsDir);
+
+        var upperPath = @"C:\Foo\Bar\App.AppHost.csproj";
+        var mixedPath = @"c:\foo\BAR\app.apphost.CSPROJ";
+
+        var appHostId = BackchannelConstants.ComputeAppHostId(upperPath);
+        var socket = Path.Combine(backchannelsDir, $"{appHostId}a1b2C3d4.12345");
+        File.WriteAllText(socket, "");
+
+        var found = AppHostHelper.FindMatchingSockets(mixedPath, workspace.WorkspaceRoot.FullName);
+        Assert.Single(found);
+        Assert.Contains(socket, found);
     }
 
     [Fact]

--- a/tests/Aspire.Cli.Tests/Utils/CliPathHelperTests.cs
+++ b/tests/Aspire.Cli.Tests/Utils/CliPathHelperTests.cs
@@ -20,16 +20,18 @@ public class CliPathHelperTests(ITestOutputHelper outputHelper)
 
         if (OperatingSystem.IsWindows())
         {
-            Assert.Matches("^apphost\\.sock\\.[a-f0-9]{12}$", socketPath1);
-            Assert.Matches("^apphost\\.sock\\.[a-f0-9]{12}$", socketPath2);
+            Assert.Equal(Path.GetFileName(socketPath1), socketPath1);
+            Assert.Equal(Path.GetFileName(socketPath2), socketPath2);
+            Assert.Matches("^h[A-Za-z0-9_-]{8}$", socketPath1);
+            Assert.Matches("^h[A-Za-z0-9_-]{8}$", socketPath2);
         }
         else
         {
-            var expectedDirectory = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), ".aspire", "cli", "runtime", "sockets");
+            var expectedDirectory = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), ".aspire", "cli", "bch");
             Assert.Equal(expectedDirectory, Path.GetDirectoryName(socketPath1));
             Assert.Equal(expectedDirectory, Path.GetDirectoryName(socketPath2));
-            Assert.Matches("^apphost\\.sock\\.[a-f0-9]{12}$", Path.GetFileName(socketPath1));
-            Assert.Matches("^apphost\\.sock\\.[a-f0-9]{12}$", Path.GetFileName(socketPath2));
+            Assert.Matches("^h[A-Za-z0-9_-]{8}$", Path.GetFileName(socketPath1));
+            Assert.Matches("^h[A-Za-z0-9_-]{8}$", Path.GetFileName(socketPath2));
         }
     }
 
@@ -43,11 +45,11 @@ public class CliPathHelperTests(ITestOutputHelper outputHelper)
 
         Assert.NotEqual(socketPath1, socketPath2);
 
-        var expectedDirectory = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), ".aspire", "cli", "runtime", "sockets");
+        var expectedDirectory = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), ".aspire", "cli", "bch");
         Assert.Equal(expectedDirectory, Path.GetDirectoryName(socketPath1));
         Assert.Equal(expectedDirectory, Path.GetDirectoryName(socketPath2));
-        Assert.Matches("^apphost\\.sock\\.[a-f0-9]{12}$", Path.GetFileName(socketPath1));
-        Assert.Matches("^apphost\\.sock\\.[a-f0-9]{12}$", Path.GetFileName(socketPath2));
+        Assert.Matches("^h[A-Za-z0-9_-]{8}$", Path.GetFileName(socketPath1));
+        Assert.Matches("^h[A-Za-z0-9_-]{8}$", Path.GetFileName(socketPath2));
     }
 
     [Theory]

--- a/tests/Aspire.Hosting.Tests/Backchannel/AuxiliaryBackchannelTests.cs
+++ b/tests/Aspire.Hosting.Tests/Backchannel/AuxiliaryBackchannelTests.cs
@@ -271,10 +271,8 @@ public class AuxiliaryBackchannelTests(ITestOutputHelper outputHelper)
     }
 
     [Fact]
-    public async Task SocketPathUsesAuxiPrefix()
+    public async Task SocketPathUsesCompactFormat()
     {
-        // This test verifies that the socket path uses "auxi.sock." prefix instead of "aux.sock."
-        // to avoid Windows reserved device name issues (AUX is reserved on Windows < 11)
         using var builder = TestDistributedApplicationBuilder.CreateWithTestContainerRegistry(outputHelper);
 
         using var app = builder.Build();
@@ -286,11 +284,16 @@ public class AuxiliaryBackchannelTests(ITestOutputHelper outputHelper)
         await service.ListeningTask.DefaultTimeout();
         Assert.NotNull(service.SocketPath);
 
-        // Verify that the socket path uses "auxi.sock." prefix
         var fileName = Path.GetFileName(service.SocketPath);
-        Assert.StartsWith("auxi.sock.", fileName);
+        Assert.Matches("^[A-Za-z0-9_-]{19}\\.[0-9]+$", fileName);
 
-        // Verify that the socket file can be created (not blocked by Windows reserved names)
+        var directory = Path.GetDirectoryName(service.SocketPath);
+        Assert.NotNull(directory);
+        Assert.EndsWith(Path.Combine(".aspire", "cli", "bch"), directory);
+        Assert.True(
+            BackchannelConstants.GetSocketPathByteCountIncludingNull(service.SocketPath) <= BackchannelConstants.GetMaxSocketPathBytesIncludingNull(),
+            $"Socket path should fit the platform byte limit: {service.SocketPath}");
+
         Assert.True(File.Exists(service.SocketPath), $"Socket file should exist at: {service.SocketPath}");
 
         outputHelper.WriteLine($"Socket path: {service.SocketPath}");

--- a/tests/Aspire.Hosting.Tests/Utils/UnixSocketHelper.cs
+++ b/tests/Aspire.Hosting.Tests/Utils/UnixSocketHelper.cs
@@ -1,6 +1,8 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using Aspire.Hosting.Backchannel;
+
 namespace Aspire.Hosting.Tests.Utils;
 
 internal static class UnixSocketHelper
@@ -8,15 +10,14 @@ internal static class UnixSocketHelper
     public static string GetBackchannelSocketPath()
     {
         var homeDirectory = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
-        var aspireCliPath = Path.Combine(homeDirectory, ".aspire", "cli", "backchannels");
+        var socketPath = BackchannelConstants.ComputeCliSocketPath(homeDirectory, "cli.sock");
+        var aspireCliPath = Path.GetDirectoryName(socketPath)!;
 
         if (!Directory.Exists(aspireCliPath))
         {
             Directory.CreateDirectory(aspireCliPath);
         }
 
-        var uniqueSocketPathSegment = Guid.NewGuid().ToString("N");
-        var socketPath = Path.Combine(aspireCliPath, $"cli.sock.{uniqueSocketPathSegment}");
         return socketPath;
     }
 


### PR DESCRIPTION
## Description

Fixes #15752

Users with long or non-ASCII home directory paths can exceed the byte-based Unix domain socket path limits when Aspire creates backchannel sockets. This shortens the backchannel socket location and file names so AppHost/CLI communication has more path budget while preserving the visible process ID for debugging.

### User-facing usage

No new CLI syntax is required. Existing `aspire run` and MCP workflows use shorter backchannel socket paths under `~/.aspire/cli/bch/`, and the CLI still discovers legacy sockets under `~/.aspire/cli/backchannels/` when connecting to AppHosts built with older libraries.

### Implementation details

- Uses compact base64url identifiers for the AppHost and random instance portions of socket names.
- Keeps the AppHost PID in decimal form in the socket file name.
- Validates socket paths by UTF-8 byte length, including the trailing null byte.
- Adds CLI fallback discovery and cleanup for legacy socket name formats.
- Watches both compact and legacy backchannel directories so newly-created sockets are detected.

### Validation

- `dotnet build tests\Aspire.Cli.Tests\Aspire.Cli.Tests.csproj --no-restore /p:SkipNativeBuild=true`
- `dotnet build tests\Aspire.Hosting.Tests\Aspire.Hosting.Tests.csproj --no-restore /p:SkipNativeBuild=true`
- `dotnet test --project tests\Aspire.Cli.Tests\Aspire.Cli.Tests.csproj --no-launch-profile -- --filter-class "*.AppHostHelperTests" --filter-not-trait "quarantined=true" --filter-not-trait "outerloop=true"`
- `dotnet test --project tests\Aspire.Cli.Tests\Aspire.Cli.Tests.csproj --no-launch-profile -- --filter-class "*.CliPathHelperTests" --filter-not-trait "quarantined=true" --filter-not-trait "outerloop=true"`
- `dotnet test --project tests\Aspire.Hosting.Tests\Aspire.Hosting.Tests.csproj --no-launch-profile -- --filter-method "*.SocketPathUsesCompactFormat" --filter-not-trait "quarantined=true" --filter-not-trait "outerloop=true"`
- `dotnet test --project tests\Aspire.Hosting.Tests\Aspire.Hosting.Tests.csproj --no-build --no-launch-profile -- --filter-class "*.AppHostBackchannelTests" --filter-not-trait "quarantined=true" --filter-not-trait "outerloop=true"`

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
