### PR TITLE
Sync FoundryHostedAgent test deps with playground

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -7,44 +7,44 @@
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
     <CentralPackageTransitivePinningEnabled>true</CentralPackageTransitivePinningEnabled>
     <!-- The Npgsql versions used when using Npgsql EF Core on net8/net9. The major versions need to match between Npgsql and EF Core. -->
-    <Npgsql8Version>8.0.6</Npgsql8Version>
-    <Npgsql9Version>9.0.4</Npgsql9Version>
+    <Npgsql8Version>8.0.9</Npgsql8Version>
+    <Npgsql9Version>9.0.5</Npgsql9Version>
   </PropertyGroup>
   <ItemGroup>
     <!-- Azure SDK for .NET dependencies -->
     <PackageVersion Include="Azure.AI.AgentServer.AgentFramework" Version="1.0.0-beta.11" />
     <PackageVersion Include="Azure.AI.Inference" Version="1.0.0-beta.5" />
-    <PackageVersion Include="Azure.AI.OpenAI" Version="2.5.0-beta.1" />
+    <PackageVersion Include="Azure.AI.OpenAI" Version="2.8.0-beta.1" />
     <PackageVersion Include="Azure.AI.Projects" Version="2.1.0-beta.1" />
     <PackageVersion Include="Azure.Data.Tables" Version="12.11.0" />
-    <PackageVersion Include="Azure.Extensions.AspNetCore.Configuration.Secrets" Version="1.4.0" />
+    <PackageVersion Include="Azure.Extensions.AspNetCore.Configuration.Secrets" Version="1.5.1" />
     <PackageVersion Include="Azure.Messaging.EventHubs" Version="5.12.2" />
     <PackageVersion Include="Azure.Messaging.EventHubs.Processor" Version="5.12.2" />
     <PackageVersion Include="Azure.Messaging.ServiceBus" Version="7.20.1" />
-    <PackageVersion Include="Azure.Search.Documents" Version="11.7.0" />
+    <PackageVersion Include="Azure.Search.Documents" Version="12.0.0" />
     <PackageVersion Include="Azure.Messaging.WebPubSub" Version="1.6.0" />
-    <PackageVersion Include="Azure.Security.KeyVault.Secrets" Version="4.8.0" />
+    <PackageVersion Include="Azure.Security.KeyVault.Secrets" Version="4.11.0" />
     <PackageVersion Include="Azure.Security.KeyVault.Certificates" Version="4.8.0" />
-    <PackageVersion Include="Azure.Security.KeyVault.Keys" Version="4.8.0" />
-    <PackageVersion Include="Azure.Storage.Blobs" Version="12.26.0" />
-    <PackageVersion Include="Azure.Storage.Files.DataLake" Version="12.23.0" />
-    <PackageVersion Include="Azure.Storage.Files.Shares" Version="12.24.0" />
-    <PackageVersion Include="Azure.Storage.Queues" Version="12.24.0" />
-    <PackageVersion Include="Microsoft.Azure.Cosmos" Version="3.54.0" />
-    <PackageVersion Include="Microsoft.Azure.Kusto.Data" Version="14.0.3" />
-    <PackageVersion Include="Microsoft.Azure.Kusto.Ingest" Version="14.0.3" />
-    <PackageVersion Include="Microsoft.Azure.SignalR" Version="1.32.0" />
-    <PackageVersion Include="Microsoft.Azure.SignalR.Management" Version="1.32.0" />
+    <PackageVersion Include="Azure.Security.KeyVault.Keys" Version="4.10.0" />
+    <PackageVersion Include="Azure.Storage.Blobs" Version="12.28.0" />
+    <PackageVersion Include="Azure.Storage.Files.DataLake" Version="12.26.0" />
+    <PackageVersion Include="Azure.Storage.Files.Shares" Version="12.26.0" />
+    <PackageVersion Include="Azure.Storage.Queues" Version="12.26.0" />
+    <PackageVersion Include="Microsoft.Azure.Cosmos" Version="3.59.0" />
+    <PackageVersion Include="Microsoft.Azure.Kusto.Data" Version="14.1.2" />
+    <PackageVersion Include="Microsoft.Azure.Kusto.Ingest" Version="14.1.2" />
+    <PackageVersion Include="Microsoft.Azure.SignalR" Version="1.33.0" />
+    <PackageVersion Include="Microsoft.Azure.SignalR.Management" Version="1.33.0" />
     <PackageVersion Include="Microsoft.Azure.StackExchangeRedis" Version="3.3.1" />
-    <PackageVersion Include="Microsoft.Extensions.Azure" Version="1.13.1" />
-    <PackageVersion Include="Microsoft.Extensions.Configuration.AzureAppConfiguration" Version="8.4.0" />
+    <PackageVersion Include="Microsoft.Extensions.Azure" Version="1.14.0" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration.AzureAppConfiguration" Version="8.5.0" />
     <!-- Azure Management SDK for .NET dependencies -->
     <PackageVersion Include="Azure.Provisioning" Version="1.5.0" />
     <PackageVersion Include="Azure.Provisioning.AppConfiguration" Version="1.1.0" />
     <PackageVersion Include="Azure.Provisioning.AppContainers" Version="1.2.0" />
     <PackageVersion Include="Azure.Provisioning.AppService" Version="1.3.1" />
     <PackageVersion Include="Azure.Provisioning.ApplicationInsights" Version="1.1.0" />
-    <PackageVersion Include="Azure.Provisioning.Cdn" Version="1.0.0-beta.1" />
+    <PackageVersion Include="Azure.Provisioning.Cdn" Version="1.0.0-beta.2" />
     <PackageVersion Include="Azure.Provisioning.ContainerRegistry" Version="1.1.0" />
     <PackageVersion Include="Azure.Provisioning.ContainerService" Version="1.0.0-beta.6" />
     <PackageVersion Include="Azure.Provisioning.CognitiveServices" Version="1.2.0" />
@@ -89,58 +89,58 @@
     <PackageVersion Include="Microsoft.Build.Utilities.Core" Version="17.9.5" /> <!-- This should not be updated, so we support older VS versions -->
     <PackageVersion Include="Microsoft.IO.Redist" Version="6.1.3" /> <!-- Pinned transitive dependency to address vulnerability. This is a transitive dependency of Microsoft.Build.Utilities.Core -->
     <!-- NuGet dependencies -->
-    <PackageVersion Include="NuGet.Commands" Version="6.14.0" />
-    <PackageVersion Include="NuGet.ProjectModel" Version="6.14.0" />
-    <PackageVersion Include="NuGet.Protocol" Version="6.14.0" />
-    <PackageVersion Include="NuGet.Resolver" Version="6.14.0" />
+    <PackageVersion Include="NuGet.Commands" Version="7.6.0" />
+    <PackageVersion Include="NuGet.ProjectModel" Version="7.6.0" />
+    <PackageVersion Include="NuGet.Protocol" Version="7.6.0" />
+    <PackageVersion Include="NuGet.Resolver" Version="7.6.0" />
     <!-- external dependencies -->
-    <PackageVersion Include="Confluent.Kafka" Version="2.13.0" />
-    <PackageVersion Include="Dapper" Version="2.1.66" />
+    <PackageVersion Include="Confluent.Kafka" Version="2.14.0" />
+    <PackageVersion Include="Dapper" Version="2.1.72" />
     <PackageVersion Include="DnsClient" Version="1.8.0" />
-    <PackageVersion Include="Google.Protobuf" Version="3.33.5" />
-    <PackageVersion Include="Grpc.AspNetCore" Version="2.76.0" />
-    <PackageVersion Include="Grpc.Net.ClientFactory" Version="2.76.0" />
-    <PackageVersion Include="Grpc.Tools" Version="2.78.0" />
-    <PackageVersion Include="Hex1b" Version="0.133.0" />
-    <PackageVersion Include="Hex1b.McpServer" Version="0.133.0" />
-    <PackageVersion Include="Hex1b.Tool" Version="0.133.0" />
-    <PackageVersion Include="Humanizer.Core" Version="2.14.1" />
-    <PackageVersion Include="KubernetesClient" Version="18.0.13" />
-    <PackageVersion Include="JsonPatch.Net" Version="3.3.0" />
-    <PackageVersion Include="Markdig" Version="0.45.0" />
+    <PackageVersion Include="Google.Protobuf" Version="3.34.1" />
+    <PackageVersion Include="Grpc.AspNetCore" Version="2.80.0" />
+    <PackageVersion Include="Grpc.Net.ClientFactory" Version="2.80.0" />
+    <PackageVersion Include="Grpc.Tools" Version="2.80.0" />
+    <PackageVersion Include="Hex1b" Version="0.154.0" />
+    <PackageVersion Include="Hex1b.McpServer" Version="0.154.0" />
+    <PackageVersion Include="Hex1b.Tool" Version="0.154.0" />
+    <PackageVersion Include="Humanizer.Core" Version="3.0.10" />
+    <PackageVersion Include="KubernetesClient" Version="19.0.2" />
+    <PackageVersion Include="JsonPatch.Net" Version="5.0.2" />
+    <PackageVersion Include="Markdig" Version="1.2.0" />
     <PackageVersion Include="Microsoft.AI.Foundry.Local" Version="0.3.0" />
-    <PackageVersion Include="Microsoft.Agents.AI.OpenAI" Version="1.1.0" />
-    <PackageVersion Include="Microsoft.Data.SqlClient" Version="6.1.4" />
+    <PackageVersion Include="Microsoft.Agents.AI.OpenAI" Version="1.5.0" />
+    <PackageVersion Include="Microsoft.Data.SqlClient" Version="7.0.1" />
     <PackageVersion Include="Microsoft.FluentUI.AspNetCore.Components" Version="4.14.1" />
     <PackageVersion Include="Microsoft.FluentUI.AspNetCore.Components.Icons" Version="4.14.1" />
     <PackageVersion Include="Milvus.Client" Version="2.3.0-preview.1" /> <!-- No stable release available -->
-    <PackageVersion Include="ModelContextProtocol" Version="1.0.0" />
-    <PackageVersion Include="MongoDB.Driver" Version="3.6.0" />
+    <PackageVersion Include="ModelContextProtocol" Version="1.3.0" />
+    <PackageVersion Include="MongoDB.Driver" Version="3.8.1" />
     <PackageVersion Include="MongoDB.Driver.Core.Extensions.DiagnosticSources" Version="3.0.0" />
     <PackageVersion Include="MySqlConnector.DependencyInjection" Version="2.5.0" />
     <PackageVersion Include="MySqlConnector.Logging.Microsoft.Extensions.Logging" Version="2.1.0" />
-    <PackageVersion Include="NATS.Net" Version="2.7.2" />
+    <PackageVersion Include="NATS.Net" Version="2.7.3" />
     <PackageVersion Include="NCrontab.Signed" Version="3.4.0" />
-    <PackageVersion Include="Npgsql.DependencyInjection" Version="10.0.1" />
+    <PackageVersion Include="Npgsql.DependencyInjection" Version="10.0.2" />
     <PackageVersion Include="OpenAI" Version="2.10.0" />
-    <PackageVersion Include="Oracle.ManagedDataAccess.OpenTelemetry" Version="23.26.100" />
-    <PackageVersion Include="Polly.Core" Version="8.6.5" />
-    <PackageVersion Include="Polly.Extensions" Version="8.6.5" />
+    <PackageVersion Include="Oracle.ManagedDataAccess.OpenTelemetry" Version="23.26.200" />
+    <PackageVersion Include="Polly.Core" Version="8.6.6" />
+    <PackageVersion Include="Polly.Extensions" Version="8.6.6" />
     <PackageVersion Include="Pomelo.EntityFrameworkCore.MySql" Version="9.0.0" />
-    <PackageVersion Include="Qdrant.Client" Version="1.16.1" />
-    <PackageVersion Include="RabbitMQ.Client" Version="7.2.0" />
+    <PackageVersion Include="Qdrant.Client" Version="1.18.1" />
+    <PackageVersion Include="RabbitMQ.Client" Version="7.2.1" />
     <PackageVersion Include="Spectre.Console" Version="0.55.2" />
-    <PackageVersion Include="StackExchange.Redis" Version="2.11.0" />
-    <PackageVersion Include="System.IO.Hashing" Version="10.0.3" />
+    <PackageVersion Include="StackExchange.Redis" Version="2.13.1" />
+    <PackageVersion Include="System.IO.Hashing" Version="10.0.8" />
     <PackageVersion Include="Yarp.ReverseProxy" Version="2.3.0" />
-    <PackageVersion Include="StreamJsonRpc" Version="2.22.23" />
+    <PackageVersion Include="StreamJsonRpc" Version="2.24.84" />
     <PackageVersion Include="Semver" Version="3.0.0" />
-    <PackageVersion Include="Sigstore" Version="0.4.0" />
-    <PackageVersion Include="Tuf" Version="0.4.0" />
-    <PackageVersion Include="Microsoft.DevTunnels.Connections" Version="1.3.12" />
+    <PackageVersion Include="Sigstore" Version="0.5.0" />
+    <PackageVersion Include="Tuf" Version="0.5.0" />
+    <PackageVersion Include="Microsoft.DevTunnels.Connections" Version="1.3.48" />
     <!-- Open Telemetry -->
     <PackageVersion Include="Azure.Monitor.OpenTelemetry.Exporter" Version="$(AzureMonitorOpenTelemetryExporterVersion)" />
-    <PackageVersion Include="Npgsql.OpenTelemetry" Version="10.0.1" />
+    <PackageVersion Include="Npgsql.OpenTelemetry" Version="10.0.2" />
     <PackageVersion Include="OpenTelemetry.Exporter.Console" Version="1.15.3" />
     <PackageVersion Include="OpenTelemetry.Exporter.InMemory" Version="1.15.3" />
     <PackageVersion Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="$(OpenTelemetryExporterOpenTelemetryProtocolVersion)" />
@@ -153,40 +153,40 @@
     <!-- build dependencies -->
     <PackageVersion Include="BenchmarkDotNet" Version="0.15.8" />
     <PackageVersion Include="MicroBuild.Plugins.SwixBuild.Dotnet" Version="1.1.87-gba258badda" />
-    <PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="4.14.0" />
-    <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.14.0" />
+    <PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="5.3.0" />
+    <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="5.3.0" />
     <PackageVersion Include="Microsoft.Signed.Wix" Version="$(MicrosoftSignedWixVersion)" />
     <PackageVersion Include="Microsoft.DotNet.Build.Tasks.Archives" Version="$(MicrosoftDotNetBuildTasksArchivesVersion)" />
     <PackageVersion Include="Microsoft.DotNet.GenAPI.Task" Version="9.0.103-servicing.25065.25" />
-    <PackageVersion Include="System.CommandLine" Version="2.0.0" />
+    <PackageVersion Include="System.CommandLine" Version="2.0.8" />
     <!-- test dependencies shared with playground -->
     <PackageVersion Include="xunit.v3.assert" Version="$(XunitV3Version)" />
     <!-- playground apps dependencies -->
-    <PackageVersion Include="Microsoft.Orleans.Clustering.AzureStorage" Version="9.2.1" />
-    <PackageVersion Include="Microsoft.Orleans.Persistence.AzureStorage" Version="9.2.1" />
-    <PackageVersion Include="Microsoft.Orleans.Client" Version="9.2.1" />
-    <PackageVersion Include="Microsoft.Orleans.Server" Version="9.2.1" />
-    <PackageVersion Include="Microsoft.Orleans.Sdk" Version="9.2.1" />
+    <PackageVersion Include="Microsoft.Orleans.Clustering.AzureStorage" Version="10.1.0" />
+    <PackageVersion Include="Microsoft.Orleans.Persistence.AzureStorage" Version="10.1.0" />
+    <PackageVersion Include="Microsoft.Orleans.Client" Version="10.1.0" />
+    <PackageVersion Include="Microsoft.Orleans.Server" Version="10.1.0" />
+    <PackageVersion Include="Microsoft.Orleans.Sdk" Version="10.1.0" />
     <!-- playground apps dependencies for AzureAppConfiguration -->
-    <PackageVersion Include="Microsoft.Azure.AppConfiguration.AspNetCore" Version="8.4.0" />
+    <PackageVersion Include="Microsoft.Azure.AppConfiguration.AspNetCore" Version="8.5.0" />
     <!-- playground apps dependencies for AzureFunctionsEndToEnd -->
-    <PackageVersion Include="Microsoft.Azure.Functions.Worker" Version="2.2.0" />
+    <PackageVersion Include="Microsoft.Azure.Functions.Worker" Version="2.52.0" />
     <PackageVersion Include="Microsoft.Azure.Functions.Worker.Extensions.Http.AspNetCore" Version="2.1.0" />
-    <PackageVersion Include="Microsoft.Azure.Functions.Worker.Extensions.Storage.Blobs" Version="6.8.0" />
-    <PackageVersion Include="Microsoft.Azure.Functions.Worker.Extensions.Storage.Queues" Version="5.5.3" />
+    <PackageVersion Include="Microsoft.Azure.Functions.Worker.Extensions.Storage.Blobs" Version="6.8.1" />
+    <PackageVersion Include="Microsoft.Azure.Functions.Worker.Extensions.Storage.Queues" Version="5.5.4" />
     <PackageVersion Include="Microsoft.Azure.Functions.Worker.Extensions.ServiceBus" Version="5.24.0" />
     <PackageVersion Include="Microsoft.Azure.Functions.Worker.Extensions.EventHubs" Version="6.5.0" />
-    <PackageVersion Include="Microsoft.Azure.Functions.Worker.Extensions.CosmosDb" Version="4.14.0" />
-    <PackageVersion Include="Microsoft.Azure.Functions.Worker.OpenTelemetry" Version="1.1.0-preview6" />
-    <PackageVersion Include="Microsoft.Azure.Functions.Worker.Sdk" Version="2.0.5" />
-    <PackageVersion Include="Microsoft.ApplicationInsights.WorkerService" Version="2.23.0" />
+    <PackageVersion Include="Microsoft.Azure.Functions.Worker.Extensions.CosmosDb" Version="4.15.0" />
+    <PackageVersion Include="Microsoft.Azure.Functions.Worker.OpenTelemetry" Version="1.2.0" />
+    <PackageVersion Include="Microsoft.Azure.Functions.Worker.Sdk" Version="2.0.7" />
+    <PackageVersion Include="Microsoft.ApplicationInsights.WorkerService" Version="3.1.1" />
     <!-- playground apps dependencies for AzureFunctionsWithDts -->
-    <PackageVersion Include="Microsoft.Azure.Functions.Worker.Extensions.DurableTask" Version="1.11.0" />
+    <PackageVersion Include="Microsoft.Azure.Functions.Worker.Extensions.DurableTask" Version="1.16.5" />
     <PackageVersion Include="Microsoft.Azure.Functions.Worker.Extensions.DurableTask.AzureManaged" Version="1.0.1" />
     <!-- playground apps dependencies for javascript -->
-    <PackageVersion Include="Swashbuckle.AspNetCore" Version="9.0.6" />
+    <PackageVersion Include="Swashbuckle.AspNetCore" Version="10.1.7" />
     <!-- Pinned versions for Component Governance - Remove when root dependencies are updated -->
-    <PackageVersion Include="Azure.Core" Version="1.53.0" />
+    <PackageVersion Include="Azure.Core" Version="1.55.0" />
     <PackageVersion Include="Azure.Identity" Version="1.21.0" />
     <!-- https://github.com/Azure/azure-cosmos-dotnet-v3/pull/3313 -->
     <PackageVersion Include="Newtonsoft.Json" Version="13.0.4" />
@@ -232,9 +232,9 @@
     <PackageVersion Include="Microsoft.EntityFrameworkCore.Design" Version="$(MicrosoftEntityFrameworkCoreDesignLTSVersion)" />
     <PackageVersion Include="Microsoft.EntityFrameworkCore.SqlServer" Version="$(MicrosoftEntityFrameworkCoreSqlServerLTSVersion)" />
     <PackageVersion Include="Microsoft.EntityFrameworkCore.Tools" Version="$(MicrosoftEntityFrameworkCoreToolsLTSVersion)" />
-    <PackageVersion Include="MongoDB.EntityFrameworkCore" Version="8.2.3" />
+    <PackageVersion Include="MongoDB.EntityFrameworkCore" Version="8.4.1" />
     <PackageVersion Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="8.0.11" />
-    <PackageVersion Include="Oracle.EntityFrameworkCore" Version="8.23.26000" />
+    <PackageVersion Include="Oracle.EntityFrameworkCore" Version="8.23.26200" />
     <!-- ASP.NET Core -->
     <PackageVersion Include="Microsoft.AspNetCore.Authentication.Certificate" Version="$(MicrosoftAspNetCoreAuthenticationCertificateLTSVersion)" />
     <PackageVersion Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="$(MicrosoftAspNetCoreAuthenticationJwtBearerLTSVersion)" />
@@ -242,7 +242,7 @@
     <PackageVersion Include="Microsoft.AspNetCore.OpenApi" Version="$(MicrosoftAspNetCoreOpenApiLTSVersion)" />
     <PackageVersion Include="Microsoft.AspNetCore.OutputCaching.StackExchangeRedis" Version="$(MicrosoftAspNetCoreOutputCachingStackExchangeRedisLTSVersion)" />
     <PackageVersion Include="Microsoft.AspNetCore.TestHost" Version="$(MicrosoftAspNetCoreTestHostLTSVersion)" />
-    <PackageVersion Include="Microsoft.OpenApi" Version="3.1.1" />
+    <PackageVersion Include="Microsoft.OpenApi" Version="3.5.3" />
     <PackageVersion Include="Microsoft.Extensions.Caching.StackExchangeRedis" Version="$(MicrosoftExtensionsCachingStackExchangeRedisLTSVersion)" />
     <PackageVersion Include="Microsoft.Extensions.Diagnostics.HealthChecks.EntityFrameworkCore" Version="$(MicrosoftExtensionsDiagnosticsHealthChecksEntityFrameworkCoreLTSVersion)" />
     <PackageVersion Include="Microsoft.Extensions.Diagnostics.HealthChecks" Version="$(MicrosoftExtensionsDiagnosticsHealthChecksLTSVersion)" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -14,7 +14,7 @@
     <!-- Azure SDK for .NET dependencies -->
     <PackageVersion Include="Azure.AI.AgentServer.AgentFramework" Version="1.0.0-beta.11" />
     <PackageVersion Include="Azure.AI.Inference" Version="1.0.0-beta.5" />
-    <PackageVersion Include="Azure.AI.OpenAI" Version="2.8.0-beta.1" />
+    <PackageVersion Include="Azure.AI.OpenAI" Version="2.9.0-beta.1" />
     <PackageVersion Include="Azure.AI.Projects" Version="2.1.0-beta.1" />
     <PackageVersion Include="Azure.Data.Tables" Version="12.11.0" />
     <PackageVersion Include="Azure.Extensions.AspNetCore.Configuration.Secrets" Version="1.5.1" />
@@ -108,7 +108,7 @@
     <PackageVersion Include="KubernetesClient" Version="19.0.2" />
     <PackageVersion Include="JsonPatch.Net" Version="5.0.2" />
     <PackageVersion Include="Markdig" Version="1.2.0" />
-    <PackageVersion Include="Microsoft.AI.Foundry.Local" Version="0.3.0" />
+    <PackageVersion Include="Microsoft.AI.Foundry.Local" Version="1.1.0" />
     <PackageVersion Include="Microsoft.Agents.AI.OpenAI" Version="1.5.0" />
     <PackageVersion Include="Microsoft.Data.SqlClient" Version="7.0.1" />
     <PackageVersion Include="Microsoft.FluentUI.AspNetCore.Components" Version="4.14.1" />
@@ -119,7 +119,7 @@
     <PackageVersion Include="MongoDB.Driver.Core.Extensions.DiagnosticSources" Version="3.0.0" />
     <PackageVersion Include="MySqlConnector.DependencyInjection" Version="2.5.0" />
     <PackageVersion Include="MySqlConnector.Logging.Microsoft.Extensions.Logging" Version="2.1.0" />
-    <PackageVersion Include="NATS.Net" Version="2.7.3" />
+    <PackageVersion Include="NATS.Net" Version="2.8.0" />
     <PackageVersion Include="NCrontab.Signed" Version="3.4.0" />
     <PackageVersion Include="Npgsql.DependencyInjection" Version="10.0.2" />
     <PackageVersion Include="OpenAI" Version="2.10.0" />
@@ -133,7 +133,7 @@
     <PackageVersion Include="StackExchange.Redis" Version="2.13.1" />
     <PackageVersion Include="System.IO.Hashing" Version="10.0.8" />
     <PackageVersion Include="Yarp.ReverseProxy" Version="2.3.0" />
-    <PackageVersion Include="StreamJsonRpc" Version="2.24.84" />
+    <PackageVersion Include="StreamJsonRpc" Version="2.24.92" />
     <PackageVersion Include="Semver" Version="3.0.0" />
     <PackageVersion Include="Sigstore" Version="0.5.0" />
     <PackageVersion Include="Tuf" Version="0.5.0" />
@@ -182,7 +182,7 @@
     <PackageVersion Include="Microsoft.ApplicationInsights.WorkerService" Version="3.1.1" />
     <!-- playground apps dependencies for AzureFunctionsWithDts -->
     <PackageVersion Include="Microsoft.Azure.Functions.Worker.Extensions.DurableTask" Version="1.16.5" />
-    <PackageVersion Include="Microsoft.Azure.Functions.Worker.Extensions.DurableTask.AzureManaged" Version="1.0.1" />
+    <PackageVersion Include="Microsoft.Azure.Functions.Worker.Extensions.DurableTask.AzureManaged" Version="1.8.0" />
     <!-- playground apps dependencies for javascript -->
     <PackageVersion Include="Swashbuckle.AspNetCore" Version="10.1.7" />
     <!-- Pinned versions for Component Governance - Remove when root dependencies are updated -->

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -106,7 +106,7 @@
     <PackageVersion Include="Hex1b.Tool" Version="0.154.0" />
     <PackageVersion Include="Humanizer.Core" Version="3.0.10" />
     <PackageVersion Include="KubernetesClient" Version="19.0.2" />
-    <PackageVersion Include="JsonPatch.Net" Version="5.0.2" />
+    <PackageVersion Include="JsonPatch.Net" Version="3.3.0" />
     <PackageVersion Include="Markdig" Version="1.2.0" />
     <PackageVersion Include="Microsoft.AI.Foundry.Local" Version="0.3.0" />
     <PackageVersion Include="Microsoft.Agents.AI.OpenAI" Version="1.5.0" />
@@ -133,7 +133,7 @@
     <PackageVersion Include="StackExchange.Redis" Version="2.13.1" />
     <PackageVersion Include="System.IO.Hashing" Version="10.0.8" />
     <PackageVersion Include="Yarp.ReverseProxy" Version="2.3.0" />
-    <PackageVersion Include="StreamJsonRpc" Version="2.24.84" />
+    <PackageVersion Include="StreamJsonRpc" Version="2.22.23" />
     <PackageVersion Include="Semver" Version="3.0.0" />
     <PackageVersion Include="Sigstore" Version="0.5.0" />
     <PackageVersion Include="Tuf" Version="0.5.0" />

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -55,7 +55,7 @@
     <OpenTelemetryInstrumentationExtensionsHostingVersion>1.15.3</OpenTelemetryInstrumentationExtensionsHostingVersion>
     <OpenTelemetryInstrumentationRuntimeVersion>1.15.1</OpenTelemetryInstrumentationRuntimeVersion>
     <OpenTelemetryExporterOpenTelemetryProtocolVersion>1.15.3</OpenTelemetryExporterOpenTelemetryProtocolVersion>
-    <AzureMonitorOpenTelemetryExporterVersion>1.5.0</AzureMonitorOpenTelemetryExporterVersion>
+    <AzureMonitorOpenTelemetryExporterVersion>1.8.0</AzureMonitorOpenTelemetryExporterVersion>
     <!-- Aspire.Cli uses a preview version of StreamJsonRpc which is needed for native AOT support. -->
     <StreamJsonRpcPackageVersionForCli>2.23.32-alpha</StreamJsonRpcPackageVersionForCli>
     <!-- MicroBuild.Core version for VS Code extension signing -->

--- a/src/Aspire.Dashboard/Components/Controls/ResourceDetails.razor
+++ b/src/Aspire.Dashboard/Components/Controls/ResourceDetails.razor
@@ -6,7 +6,7 @@
 @using Microsoft.Extensions.Diagnostics.HealthChecks
 
 @inject IStringLocalizer<ControlsStrings> ControlStringsLoc
-@inject IStringLocalizer<Resources> Loc
+@inject IStringLocalizer<Aspire.Dashboard.Resources.Resources> Loc
 @inject IStringLocalizer<Columns> ColumnsLoc
 
 <div class="resource-details-layout">
@@ -23,7 +23,7 @@
                           ButtonClass="resource-details-actions"
                           Icon="@(new Icons.Regular.Size20.Options())"
                           Items="@_resourceActionsMenuItems"
-                          Title="@Loc[nameof(Resources.ResourcesChangeViewOptions)]"
+                          Title="@Loc[nameof(Aspire.Dashboard.Resources.Resources.ResourcesChangeViewOptions)]"
                           slot="end" />
     </FluentToolbar>
     <div class="property-grid-container">
@@ -235,7 +235,7 @@
                     </AspireTemplateColumn>
                     <AspireTemplateColumn Title="@ControlStringsLoc[nameof(ControlsStrings.DetailsColumnHeader)]" Class="detailsColumn">
                         <GridValue ValueDescription="@ControlStringsLoc[nameof(ControlsStrings.DetailsColumnHeader)]"
-                                   Value="@(context.HealthStatus is null ? Loc[nameof(Resources.WaitingForHealthDataMessage)] : context.DisplayedDescription)"
+                                   Value="@(context.HealthStatus is null ? Loc[nameof(Aspire.Dashboard.Resources.Resources.WaitingForHealthDataMessage)] : context.DisplayedDescription)"
                                    EnableHighlighting="@(!string.IsNullOrEmpty(_filter))"
                                    HighlightText="@_filter"
                                    TextVisualizerTitle="@context.Name">

--- a/src/Components/Aspire.Azure.Search.Documents/ConfigurationSchema.json
+++ b/src/Components/Aspire.Azure.Search.Documents/ConfigurationSchema.json
@@ -115,7 +115,7 @@
                           "description": "Gets the client retry options."
                         }
                       },
-                      "description": "Provides the client configuration options for connecting to Azure Cognitive Search."
+                      "description": "Client options for clients in this library."
                     },
                     "DisableHealthChecks": {
                       "type": "boolean",

--- a/tests/Aspire.Deployment.EndToEnd.Tests/FoundryHostedAgentDeploymentTests.cs
+++ b/tests/Aspire.Deployment.EndToEnd.Tests/FoundryHostedAgentDeploymentTests.cs
@@ -106,70 +106,104 @@ public sealed class FoundryHostedAgentDeploymentTests(ITestOutputHelper output)
 
             Directory.CreateDirectory(hostedAgentDir);
 
-            // Write minimal hosted agent .csproj
-            // The project is created outside the repo, so it has no central package management.
-            // Explicit versions are required, matching those from the playground DotNetHostedAgent.
+            // Write minimal hosted agent .csproj.
+            // The package set and explicit versions below must stay in sync with
+            // playground/FoundryAgents/DotNetHostedAgent/DotNetHostedAgent.csproj.
+            // This project is materialized at test runtime outside the repo, so it does not
+            // participate in central package management; the playground's `VersionOverride`
+            // values become explicit `Version` values here. Update both files together.
             File.WriteAllText(Path.Combine(hostedAgentDir, "DotNetHostedAgent.csproj"), """
-                <Project Sdk="Microsoft.NET.Sdk">
+                <Project Sdk="Microsoft.NET.Sdk.Web">
                   <PropertyGroup>
-                    <OutputType>Exe</OutputType>
                     <TargetFramework>net10.0</TargetFramework>
                     <Nullable>enable</Nullable>
                     <ImplicitUsings>enable</ImplicitUsings>
-                    <EnablePreviewFeatures>true</EnablePreviewFeatures>
+                    <!-- Suppress experimental API warnings from Agent Framework Foundry packages -->
+                    <NoWarn>$(NoWarn);OPENAI001;MAIF001</NoWarn>
                   </PropertyGroup>
                   <ItemGroup>
-                    <PackageReference Include="Azure.AI.AgentServer.AgentFramework" Version="1.0.0-beta.11" />
-                    <PackageReference Include="Azure.AI.Projects" Version="1.2.0-beta.4" />
-                    <PackageReference Include="Azure.AI.OpenAI" Version="2.5.0-beta.1" />
-                    <PackageReference Include="Azure.Identity" Version="1.18.0" />
-                    <PackageReference Include="Microsoft.Agents.AI.OpenAI" Version="1.1.0" />
-                    <PackageReference Include="Microsoft.Extensions.AI" Version="10.4.0" />
-                    <PackageReference Include="Microsoft.Extensions.AI.OpenAI" Version="10.4.0" />
+                    <PackageReference Include="Azure.AI.Projects" Version="2.1.0-beta.1" />
+                    <PackageReference Include="Azure.Identity" Version="1.21.0" />
+                    <PackageReference Include="Microsoft.Agents.AI.Foundry.Hosting" Version="1.4.0-preview.260505.1" />
+                    <PackageReference Include="Microsoft.Extensions.AI" Version="10.5.0" />
+                    <PackageReference Include="ModelContextProtocol" Version="1.1.0" />
                   </ItemGroup>
                 </Project>
                 """);
 
-            // Write minimal hosted agent Program.cs
-            // This follows the same pattern as the playground DotNetHostedAgent:
-            // reads ConnectionStrings__chat, creates an AI agent, and runs on DEFAULT_AD_PORT.
+            // Write minimal hosted agent Program.cs.
+            // Mirrors playground/FoundryAgents/DotNetHostedAgent/Program.cs: reads the
+            // Foundry project + chat connection strings, builds an AIProjectClient-backed
+            // AIAgent, and hosts it as a Foundry Responses endpoint on DEFAULT_AD_PORT.
             File.WriteAllText(Path.Combine(hostedAgentDir, "Program.cs"), """
                 using System.ComponentModel;
                 using System.Data.Common;
-                using Azure.AI.AgentServer.AgentFramework.Extensions;
-                using Azure.AI.OpenAI;
+                using Azure.AI.Projects;
                 using Azure.Identity;
                 using Microsoft.Agents.AI;
+                using Microsoft.Agents.AI.Foundry.Hosting;
                 using Microsoft.Extensions.AI;
+
+                string projectConnectionString = Environment.GetEnvironmentVariable("ConnectionStrings__projmyproject")
+                    ?? throw new InvalidOperationException("ConnectionStrings__projmyproject is not set.");
 
                 string chatConnectionString = Environment.GetEnvironmentVariable("ConnectionStrings__chat")
                     ?? throw new InvalidOperationException("ConnectionStrings__chat is not set.");
 
-                DbConnectionStringBuilder chatConnectionBuilder = new()
+                DbConnectionStringBuilder projectConnectionBuilder = new() { ConnectionString = projectConnectionString };
+                DbConnectionStringBuilder chatConnectionBuilder = new() { ConnectionString = chatConnectionString };
+
+                string projectEndpoint = GetRequiredConnectionValue(projectConnectionBuilder, "Endpoint");
+                string deploymentName = GetRequiredConnectionValue(chatConnectionBuilder, "Deployment");
+
+                if (!Uri.TryCreate(projectEndpoint, UriKind.Absolute, out Uri? projectUri) || projectUri is null)
                 {
-                    ConnectionString = chatConnectionString,
-                };
-
-                string endpoint = chatConnectionBuilder.TryGetValue("Endpoint", out object? epValue) ? epValue?.ToString()! : throw new InvalidOperationException("Missing Endpoint.");
-                string deploymentName = chatConnectionBuilder.TryGetValue("Deployment", out object? dnValue) ? dnValue?.ToString()! : throw new InvalidOperationException("Missing Deployment.");
-
-                Uri openAiEndpoint = new(endpoint);
+                    throw new InvalidOperationException("ConnectionStrings__projmyproject contains an invalid Endpoint value.");
+                }
 
                 [Description("Get a weather forecast")]
                 string GetWeatherForecast() => "Sunny, 25°C";
 
                 DefaultAzureCredential credential = new();
 
-                IChatClient chatClient = new AzureOpenAIClient(openAiEndpoint, credential)
-                    .GetChatClient(deploymentName)
-                    .AsIChatClient();
+                AIAgent agent = new AIProjectClient(projectUri, credential)
+                    .AsAIAgent(
+                        model: deploymentName,
+                        name: "WeatherAgent",
+                        instructions: "You are the Weather Intelligence Agent.",
+                        tools: [AIFunctionFactory.Create(GetWeatherForecast)]);
 
-                AIAgent agent = chatClient.AsAIAgent(
-                    name: "WeatherAgent",
-                    instructions: "You are the Weather Intelligence Agent.",
-                    tools: [AIFunctionFactory.Create(GetWeatherForecast)]);
+                // Bind to the port allocated by Aspire via the DEFAULT_AD_PORT environment variable.
+                string port = Environment.GetEnvironmentVariable("DEFAULT_AD_PORT") ?? "8088";
 
-                await agent.RunAIAgentAsync(telemetrySourceName: "Agents");
+                var builder = WebApplication.CreateBuilder(args);
+                builder.WebHost.UseUrls($"http://+:{port}");
+                builder.Services.AddFoundryResponses(agent);
+
+                var app = builder.Build();
+
+                app.MapFoundryResponses();
+                app.MapGet("/liveness", () => Results.Ok("Healthy"));
+                app.MapGet("/readiness", () => Results.Ok("Ready"));
+
+                app.Run();
+
+                static string GetRequiredConnectionValue(DbConnectionStringBuilder connectionBuilder, string key)
+                {
+                    if (!connectionBuilder.TryGetValue(key, out object? rawValue) || rawValue is null)
+                    {
+                        throw new InvalidOperationException($"Connection string is missing '{key}'.");
+                    }
+
+                    string? value = rawValue.ToString();
+
+                    if (string.IsNullOrWhiteSpace(value))
+                    {
+                        throw new InvalidOperationException($"Connection string has an empty '{key}' value.");
+                    }
+
+                    return value;
+                }
                 """);
 
             // Write Dockerfile for the hosted agent


### PR DESCRIPTION
Only merge after #17056 since it's targeting it.

In this branch, `tests/Aspire.Deployment.EndToEnd.Tests/FoundryHostedAgentDeploymentTests.cs` materializes a `DotNetHostedAgent` project at test runtime with explicit package versions because it sits outside central package management. Those versions had drifted from the playground.

This change regenerates the test's `DotNetHostedAgent.csproj` and `Program.cs` to mirror `playground/FoundryAgents/DotNetHostedAgent/`:

**Package set now matches the playground (with explicit `Version=` values):**

- `Azure.AI.Projects` 2.1.0-beta.1
- `Azure.Identity` 1.21.0 (central version on this branch)
- `Microsoft.Agents.AI.Foundry.Hosting` 1.4.0-preview.260505.1
- `Microsoft.Extensions.AI` 10.5.0
- `ModelContextProtocol` 1.1.0

**Removed** (no longer used by the playground): `Azure.AI.AgentServer.AgentFramework`, `Azure.AI.OpenAI`, `Microsoft.Agents.AI.OpenAI`, `Microsoft.Extensions.AI.OpenAI`.

The generated `Program.cs` is also updated to use the `AIProjectClient` + `Microsoft.Agents.AI.Foundry.Hosting` (`AddFoundryResponses` / `MapFoundryResponses`) path that the playground uses, instead of the old `AzureOpenAIClient` + `RunAIAgentAsync` path that depended on the removed packages.

A comment at the source of these templates calls out the invariant: both locations live outside central package management and must be updated together.

### Validation

- `./restore.sh` succeeds.
- `./dotnet.sh build tests/Aspire.Deployment.EndToEnd.Tests/Aspire.Deployment.EndToEnd.Tests.csproj` succeeds (0 warnings, 0 errors).
- The end-to-end test itself is `[ActiveIssue("https://github.com/microsoft/aspire/issues/16330")]` and not run in CI, so this is a no-op at runtime today; the change keeps the test deployable when it is re-enabled.