### PR TITLE
Route DisplayError output to stderr consistently

### DIFF
--- a/src/Aspire.Cli/Interaction/ConsoleInteractionService.cs
+++ b/src/Aspire.Cli/Interaction/ConsoleInteractionService.cs
@@ -369,17 +369,21 @@ internal class ConsoleInteractionService : IInteractionService
     public void DisplayError(string errorMessage, bool allowMarkup = false)
     {
         var formatted = allowMarkup ? errorMessage : errorMessage.EscapeMarkup();
-        DisplayMessage(KnownEmojis.CrossMark, $"[red bold]{formatted}[/]", allowMarkup: true);
+        // Always write errors to stderr so callers can capture them separately from stdout.
+        WriteEmojiMessage(_errorConsole, _stderrLogger, KnownEmojis.CrossMark, $"[red bold]{formatted}[/]", allowMarkup: true);
     }
 
     public void DisplayMessage(KnownEmoji emoji, string message, bool allowMarkup = false)
+        => WriteEmojiMessage(MessageConsole, MessageLogger, emoji, message, allowMarkup);
+
+    private static void WriteEmojiMessage(IAnsiConsole target, ILogger logger, KnownEmoji emoji, string message, bool allowMarkup)
     {
-        if (MessageLogger.IsEnabled(LogLevel.Information))
+        if (logger.IsEnabled(LogLevel.Information))
         {
             // Only attempt to parse/remove markup when the message is expected to contain it.
             // Plain text messages may contain characters like '[' that would be rejected by the markup parser.
             var logMessage = allowMarkup ? message.RemoveMarkup() : message;
-            MessageLogger.LogInformation("{Message}", ConsoleHelpers.FormatEmojiPrefix(emoji, MessageConsole, replaceEmoji: true) + logMessage);
+            logger.LogInformation("{Message}", ConsoleHelpers.FormatEmojiPrefix(emoji, target, replaceEmoji: true) + logMessage);
         }
 
         var displayMessage = allowMarkup ? message : message.EscapeMarkup();
@@ -394,10 +398,10 @@ internal class ConsoleInteractionService : IInteractionService
         grid.Columns[1].Padding = new Padding(0);
 
         grid.AddRow(
-            new Markup(ConsoleHelpers.FormatEmojiPrefix(emoji, MessageConsole)),
+            new Markup(ConsoleHelpers.FormatEmojiPrefix(emoji, target)),
             new Markup(displayMessage));
 
-        MessageConsole.Write(grid);
+        target.Write(grid);
     }
 
     public void DisplayPlainText(string message)

--- a/tests/Aspire.Cli.Tests/Interaction/ConsoleInteractionServiceTests.cs
+++ b/tests/Aspire.Cli.Tests/Interaction/ConsoleInteractionServiceTests.cs
@@ -611,6 +611,63 @@ public class ConsoleInteractionServiceTests
     }
 
     [Fact]
+    public void DisplayError_WritesToStderr_RegardlessOfConsoleSetting()
+    {
+        var stdoutOutput = new StringBuilder();
+        var stderrOutput = new StringBuilder();
+        var stdoutConsole = AnsiConsole.Create(new AnsiConsoleSettings
+        {
+            Ansi = AnsiSupport.No,
+            ColorSystem = ColorSystemSupport.NoColors,
+            Out = new AnsiConsoleOutput(new StringWriter(stdoutOutput))
+        });
+        var stderrConsole = AnsiConsole.Create(new AnsiConsoleSettings
+        {
+            Ansi = AnsiSupport.No,
+            ColorSystem = ColorSystemSupport.NoColors,
+            Out = new AnsiConsoleOutput(new StringWriter(stderrOutput))
+        });
+
+        var executionContext = CreateExecutionContext();
+        var consoleEnvironment = new ConsoleEnvironment(stdoutConsole, stderrConsole);
+        var interactionService = new ConsoleInteractionService(consoleEnvironment, executionContext, TestHelpers.CreateInteractiveHostEnvironment(), NullLoggerFactory.Instance);
+
+        // Console defaults to Standard (stdout), but errors should still go to stderr
+        interactionService.DisplayError("Something went wrong");
+
+        Assert.Empty(stdoutOutput.ToString());
+        Assert.Contains("Something went wrong", stderrOutput.ToString());
+    }
+
+    [Fact]
+    public void DisplayMessage_WritesToStdout_WhenConsoleIsStandard()
+    {
+        var stdoutOutput = new StringBuilder();
+        var stderrOutput = new StringBuilder();
+        var stdoutConsole = AnsiConsole.Create(new AnsiConsoleSettings
+        {
+            Ansi = AnsiSupport.No,
+            ColorSystem = ColorSystemSupport.NoColors,
+            Out = new AnsiConsoleOutput(new StringWriter(stdoutOutput))
+        });
+        var stderrConsole = AnsiConsole.Create(new AnsiConsoleSettings
+        {
+            Ansi = AnsiSupport.No,
+            ColorSystem = ColorSystemSupport.NoColors,
+            Out = new AnsiConsoleOutput(new StringWriter(stderrOutput))
+        });
+
+        var executionContext = CreateExecutionContext();
+        var consoleEnvironment = new ConsoleEnvironment(stdoutConsole, stderrConsole);
+        var interactionService = new ConsoleInteractionService(consoleEnvironment, executionContext, TestHelpers.CreateInteractiveHostEnvironment(), NullLoggerFactory.Instance);
+
+        interactionService.DisplayMessage(KnownEmojis.Information, "Status update");
+
+        Assert.Contains("Status update", stdoutOutput.ToString());
+        Assert.Empty(stderrOutput.ToString());
+    }
+
+    [Fact]
     public void DisplayMessage_WithUnescapedMarkup_AutoEscapesAndDoesNotThrow()
     {
         // Arrange - verifies that DisplayMessage auto-escapes by default


### PR DESCRIPTION
Fixes #16136

`DisplayError` routed through `MessageConsole`, which defaults to stdout. Errors only went to stderr as a side effect of `--output json` mode. This fix makes `DisplayError` always write to `_errorConsole` (stderr) directly.
   
  **Repro (before fix):**
   ```powershell
   aspire stop --non-interactive 1>$null
   # Error "No running AppHost found" is hidden — it went to stdout
```
 
After fix:

```
 aspire stop --non-interactive 1>$null
 # ❌ No running AppHost found. Use 'aspire run' to start one first.
 # Error appears because it's now on stderr
```