### PR TITLE
Require external endpoint for Kubernetes ingress/gateway routes

### DIFF
--- a/.agents/skills/aspire-deployment/references/kubernetes.md
+++ b/.agents/skills/aspire-deployment/references/kubernetes.md
@@ -85,6 +85,7 @@ Make these changes in the AppHost:
 5. For TypeScript AppHosts, verify the current language-specific docs before assuming an equivalent assignment API.
 6. Use `k8s.WithHelm(...)` / `k8s.withHelm(...)` only when the user needs chart name, release name, namespace, chart version, or other Helm settings.
 7. Use `k8s.AddGateway(...)`, `k8s.AddIngress(...)`, or the TypeScript equivalents when public exposure is required. Otherwise services remain internal by default. For a simple public web frontend on a cloud Kubernetes provider, a per-resource `LoadBalancer` Service can be the direct exposure model; keep backend/internal services as `ClusterIP`.
+   - **Routed endpoints must be marked external.** Any endpoint routed by an Ingress or Gateway (via `WithRoute(...)` or `WithDefaultBackend(...)`) must come from a resource that opts in with `.WithExternalHttpEndpoints()` (C#) or `isExternal: true` on the endpoint annotation. `aspire publish` fails fast with an `InvalidOperationException` from `EndpointRoutingValidation` if a non-external endpoint is routed, so always pair `AddIngress`/`AddGateway` plumbing with explicit external opt-in on the target resource. This applies to AKS through `AzureKubernetesEnvironment` as well.
 8. Use `PublishAsKubernetesService(...)` / `publishAsKubernetesService(...)` only for per-resource Kubernetes manifest customization.
 
 ## Azure Kubernetes Service (AKS) setup

--- a/src/Aspire.Hosting.Kubernetes/Extensions/EndpointRoutingValidation.cs
+++ b/src/Aspire.Hosting.Kubernetes/Extensions/EndpointRoutingValidation.cs
@@ -1,0 +1,57 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Aspire.Hosting.ApplicationModel;
+
+namespace Aspire.Hosting.Kubernetes.Extensions;
+
+/// <summary>
+/// Helpers that validate publish-time intent for endpoints that are being
+/// routed by ingress / gateway-style resources.
+/// </summary>
+/// <remarks>
+/// Ingress and Gateway resources expose their backing service to traffic that
+/// originates outside the cluster, so it is a privacy/security footgun to
+/// route an <see cref="EndpointReference"/> that the resource owner never
+/// flagged as external. The check is performed during publish (when the
+/// Helm chart is materialized) rather than at <c>WithRoute</c> call time
+/// because authoring order is not significant: a user may legitimately
+/// register the route before calling
+/// <see cref="ResourceBuilderExtensions.WithExternalHttpEndpoints{T}"/> or
+/// setting <see cref="EndpointAnnotation.IsExternal"/> directly.
+/// </remarks>
+internal static class EndpointRoutingValidation
+{
+    /// <summary>
+    /// Throws an <see cref="InvalidOperationException"/> when the supplied
+    /// endpoint is not marked external on its <see cref="EndpointAnnotation"/>.
+    /// </summary>
+    /// <param name="endpoint">The routed endpoint reference.</param>
+    /// <param name="routingResourceKind">The kind of routing resource (e.g., <c>"Ingress"</c> or <c>"Gateway"</c>).</param>
+    /// <param name="routingResourceName">The name of the routing resource that owns the route.</param>
+    public static void ThrowIfEndpointNotExternal(
+        EndpointReference endpoint,
+        string routingResourceKind,
+        string routingResourceName)
+    {
+        ArgumentNullException.ThrowIfNull(endpoint);
+        ArgumentException.ThrowIfNullOrEmpty(routingResourceKind);
+        ArgumentException.ThrowIfNullOrEmpty(routingResourceName);
+
+        // EndpointAnnotation captures publish-time intent — the endpoint
+        // is external if and only if the author explicitly opted in, either
+        // through .WithExternalHttpEndpoints() or by passing isExternal: true
+        // when creating the endpoint annotation.
+        if (endpoint.EndpointAnnotation.IsExternal)
+        {
+            return;
+        }
+
+        throw new InvalidOperationException(
+            $"Resource '{endpoint.Resource.Name}' endpoint '{endpoint.EndpointName}' is not marked as external " +
+            $"but is being routed by {routingResourceKind} '{routingResourceName}'. " +
+            $"Call .WithExternalHttpEndpoints() on the target resource or pass isExternal: true when " +
+            $"creating the endpoint annotation. {routingResourceKind} routes may only expose endpoints " +
+            $"that are explicitly marked external.");
+    }
+}

--- a/src/Aspire.Hosting.Kubernetes/KubernetesEnvironmentResource.cs
+++ b/src/Aspire.Hosting.Kubernetes/KubernetesEnvironmentResource.cs
@@ -546,6 +546,20 @@ public sealed class KubernetesEnvironmentResource : Resource, IComputeEnvironmen
                 continue;
             }
 
+            // Validate at publish time that every routed endpoint is flagged
+            // external. We do this before BuildIngressObject runs so the user
+            // sees the validation error before any partial work or warnings
+            // about missing deployment targets are emitted.
+            foreach (var route in ingressResource.Routes)
+            {
+                EndpointRoutingValidation.ThrowIfEndpointNotExternal(route.Endpoint, "Ingress", ingressResource.Name);
+            }
+
+            if (ingressResource.DefaultBackend is { } defaultBackend)
+            {
+                EndpointRoutingValidation.ThrowIfEndpointNotExternal(defaultBackend.Endpoint, "Ingress", ingressResource.Name);
+            }
+
             var ingress = await BuildIngressObject(ingressResource, deploymentTargets, logger, cancellationToken).ConfigureAwait(false);
             if (ingress is not null)
             {
@@ -741,6 +755,13 @@ public sealed class KubernetesEnvironmentResource : Resource, IComputeEnvironmen
             {
                 logger.LogWarning("Gateway '{GatewayName}' has no routes configured. Skipping.", gatewayResource.Name);
                 continue;
+            }
+
+            // Validate that every routed endpoint is flagged external before
+            // we materialize the Gateway and HTTPRoute objects.
+            foreach (var route in gatewayResource.Routes)
+            {
+                EndpointRoutingValidation.ThrowIfEndpointNotExternal(route.Endpoint, "Gateway", gatewayResource.Name);
             }
 
             await BuildGatewayObjects(gatewayResource, deploymentTargets, logger, cancellationToken).ConfigureAwait(false);

--- a/tests/Aspire.Cli.EndToEnd.Tests/KubernetesPublishRequiresExternalEndpointTests.cs
+++ b/tests/Aspire.Cli.EndToEnd.Tests/KubernetesPublishRequiresExternalEndpointTests.cs
@@ -31,11 +31,9 @@ public sealed class KubernetesPublishRequiresExternalEndpointTests(ITestOutputHe
             // publish-time validation in EndpointRoutingValidation should
             // throw before any Helm output is generated.
             appHostBodyExtension: """
-            #pragma warning disable ASPIREHOSTINGAZURE001
             var kube = builder.AddKubernetesEnvironment("kube");
             var api = builder.AddContainer("api", "nginx").WithHttpEndpoint(targetPort: 80);
             kube.AddIngress("public").WithRoute("/", api.GetEndpoint("http"));
-            #pragma warning restore ASPIREHOSTINGAZURE001
             """);
     }
 
@@ -45,11 +43,9 @@ public sealed class KubernetesPublishRequiresExternalEndpointTests(ITestOutputHe
     {
         await RunPublishFailureScenarioAsync(
             appHostBodyExtension: """
-            #pragma warning disable ASPIREHOSTINGAZURE001
             var kube = builder.AddKubernetesEnvironment("kube");
             var api = builder.AddContainer("api", "nginx").WithHttpEndpoint(targetPort: 80);
             kube.AddGateway("public").WithRoute("/", api.GetEndpoint("http"));
-            #pragma warning restore ASPIREHOSTINGAZURE001
             """);
     }
 

--- a/tests/Aspire.Cli.EndToEnd.Tests/KubernetesPublishRequiresExternalEndpointTests.cs
+++ b/tests/Aspire.Cli.EndToEnd.Tests/KubernetesPublishRequiresExternalEndpointTests.cs
@@ -1,0 +1,159 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Globalization;
+using Aspire.Cli.EndToEnd.Tests.Helpers;
+using Aspire.Cli.Tests.Utils;
+using Hex1b.Automation;
+using Xunit;
+
+namespace Aspire.Cli.EndToEnd.Tests;
+
+/// <summary>
+/// End-to-end coverage for the Kubernetes ingress/gateway validation that
+/// requires routed endpoints to be marked external (see
+/// <c>EndpointRoutingValidation.ThrowIfEndpointNotExternal</c>). The CLI
+/// surface check matters because the validation throws during model
+/// materialization on the <c>aspire publish</c> path and we want a regression
+/// guard that exercises the full publish pipeline, not just the unit-level
+/// helper.
+/// </summary>
+public sealed class KubernetesPublishRequiresExternalEndpointTests(ITestOutputHelper output)
+{
+    private const string ProjectName = "AspireK8sExternalCheck";
+
+    [Fact]
+    [CaptureWorkspaceOnFailure]
+    public async Task IngressWithoutExternalEndpoint_FailsPublishWithGuidance()
+    {
+        await RunPublishFailureScenarioAsync(
+            // Wire an ingress that routes a non-external HTTP endpoint. The
+            // publish-time validation in EndpointRoutingValidation should
+            // throw before any Helm output is generated.
+            appHostBodyExtension: """
+            #pragma warning disable ASPIREHOSTINGAZURE001
+            var kube = builder.AddKubernetesEnvironment("kube");
+            var api = builder.AddContainer("api", "nginx").WithHttpEndpoint(targetPort: 80);
+            kube.AddIngress("public").WithRoute("/", api.GetEndpoint("http"));
+            #pragma warning restore ASPIREHOSTINGAZURE001
+            """);
+    }
+
+    [Fact]
+    [CaptureWorkspaceOnFailure]
+    public async Task GatewayWithoutExternalEndpoint_FailsPublishWithGuidance()
+    {
+        await RunPublishFailureScenarioAsync(
+            appHostBodyExtension: """
+            #pragma warning disable ASPIREHOSTINGAZURE001
+            var kube = builder.AddKubernetesEnvironment("kube");
+            var api = builder.AddContainer("api", "nginx").WithHttpEndpoint(targetPort: 80);
+            kube.AddGateway("public").WithRoute("/", api.GetEndpoint("http"));
+            #pragma warning restore ASPIREHOSTINGAZURE001
+            """);
+    }
+
+    private async Task RunPublishFailureScenarioAsync(string appHostBodyExtension)
+    {
+        var repoRoot = CliE2ETestHelpers.GetRepoRoot();
+        var strategy = CliInstallStrategy.Detect(output.WriteLine);
+        var workspace = TemporaryWorkspace.Create(output);
+
+        using var terminal = CliE2ETestHelpers.CreateDockerTestTerminal(repoRoot, strategy, output, workspace: workspace);
+
+        var pendingRun = terminal.RunAsync(TestContext.Current.CancellationToken);
+
+        var counter = new SequenceCounter();
+        var auto = new Hex1bTerminalAutomator(terminal, defaultTimeout: TimeSpan.FromSeconds(500));
+        var testBodyFailed = false;
+
+        try
+        {
+            await auto.PrepareDockerEnvironmentAsync(counter, workspace);
+            await auto.InstallAspireCliAsync(strategy, counter);
+
+            // EmptyAppHost gives us a minimal csproj-based AppHost we can mutate.
+            await auto.AspireNewAsync(ProjectName, counter, template: AspireTemplate.EmptyAppHost);
+
+            // cd into the project so subsequent `aspire add` and `aspire publish`
+            // commands resolve the AppHost via repo-root discovery.
+            await auto.TypeAsync($"cd {ProjectName}");
+            await auto.EnterAsync();
+            await auto.WaitForSuccessPromptAsync(counter);
+
+            // The Kubernetes hosting package is required to compile the AppHost code
+            // we're about to write. `aspire add` resolves the version against the
+            // same feed configuration the rest of the CLI uses (including PR builds).
+            await auto.TypeAsync("aspire add Aspire.Hosting.Kubernetes");
+            await auto.EnterAsync();
+            await auto.WaitForAspireAddCompletionAsync(counter, TimeSpan.FromSeconds(180));
+
+            // Patch AppHost.cs in-place. The EmptyAppHost template emits a single
+            // `builder.Build().Run();` line we replace; failing to find it should
+            // surface as a clear test failure rather than a silently no-op publish.
+            var projectDir = Path.Combine(workspace.WorkspaceRoot.FullName, ProjectName);
+            var appHostDir = Path.Combine(projectDir, $"{ProjectName}.AppHost");
+            var appHostFilePath = Path.Combine(appHostDir, "AppHost.cs");
+            var content = File.ReadAllText(appHostFilePath);
+            const string buildRunPattern = "builder.Build().Run();";
+            Assert.Contains(buildRunPattern, content);
+            content = content.Replace(buildRunPattern, appHostBodyExtension + Environment.NewLine + buildRunPattern);
+            File.WriteAllText(appHostFilePath, content);
+
+            // ASPIRE_PLAYGROUND interferes with `--non-interactive`. See
+            // KubernetesPublishTests for full context.
+            await auto.TypeAsync("unset ASPIRE_PLAYGROUND");
+            await auto.EnterAsync();
+            await auto.WaitForSuccessPromptAsync(counter);
+
+            // Drive aspire publish. The validation throws an InvalidOperationException
+            // during model materialization, so publish should exit with a non-zero code
+            // and surface our guidance message verbatim in stderr/stdout.
+            await auto.TypeAsync("aspire publish -o helm-output --non-interactive");
+            await auto.EnterAsync();
+
+            var expectedCounter = counter.Value;
+            // We don't pin to a specific exit code — the publish pipeline currently
+            // surfaces validation failures as exit 1, but treating any non-zero
+            // ERR:* prompt as the success condition keeps this test stable across
+            // future exit-code refactors.
+            var errorPromptSearcher = new CellPatternSearcher()
+                .FindPattern(expectedCounter.ToString(CultureInfo.InvariantCulture))
+                .RightText(" ERR:");
+
+            await auto.WaitUntilAsync(
+                snapshot => errorPromptSearcher.Search(snapshot).Count > 0,
+                TimeSpan.FromMinutes(5),
+                description: "waiting for aspire publish to fail");
+            counter.Increment();
+
+            // After the publish exits, scrape the screen for the guidance fragments.
+            // We use a generous WaitUntilTextAsync so any in-progress rendering
+            // settles before we assert.
+            await auto.WaitUntilTextAsync("WithExternalHttpEndpoints", timeout: TimeSpan.FromSeconds(30));
+            await auto.WaitUntilTextAsync("'api'", timeout: TimeSpan.FromSeconds(30));
+            await auto.WaitUntilTextAsync("'public'", timeout: TimeSpan.FromSeconds(30));
+        }
+        catch
+        {
+            testBodyFailed = true;
+            throw;
+        }
+        finally
+        {
+            try
+            {
+                await auto.TypeAsync("exit");
+                await auto.EnterAsync();
+                await pendingRun;
+            }
+            catch
+            {
+                if (!testBodyFailed)
+                {
+                    throw;
+                }
+            }
+        }
+    }
+}

--- a/tests/Aspire.Cli.EndToEnd.Tests/KubernetesPublishRequiresExternalEndpointTests.cs
+++ b/tests/Aspire.Cli.EndToEnd.Tests/KubernetesPublishRequiresExternalEndpointTests.cs
@@ -53,7 +53,7 @@ public sealed class KubernetesPublishRequiresExternalEndpointTests(ITestOutputHe
     {
         var repoRoot = CliE2ETestHelpers.GetRepoRoot();
         var strategy = CliInstallStrategy.Detect(output.WriteLine);
-        var workspace = TemporaryWorkspace.Create(output);
+        using var workspace = TemporaryWorkspace.Create(output);
 
         using var terminal = CliE2ETestHelpers.CreateDockerTestTerminal(repoRoot, strategy, output, workspace: workspace);
 

--- a/tests/Aspire.Cli.EndToEnd.Tests/KubernetesPublishRequiresExternalEndpointTests.cs
+++ b/tests/Aspire.Cli.EndToEnd.Tests/KubernetesPublishRequiresExternalEndpointTests.cs
@@ -87,9 +87,10 @@ public sealed class KubernetesPublishRequiresExternalEndpointTests(ITestOutputHe
             await auto.EnterAsync();
             await auto.WaitForAspireAddCompletionAsync(counter, TimeSpan.FromSeconds(180));
 
-            // Patch AppHost.cs in-place. The EmptyAppHost template emits a single
-            // `builder.Build().Run();` line we replace; failing to find it should
-            // surface as a clear test failure rather than a silently no-op publish.
+            // Patch AppHost.cs in-place. The Starter template's AppHost.cs ends
+            // with `builder.Build().Run();`; we insert the K8s wiring immediately
+            // before it. Failing to find the marker should surface as a clear
+            // test failure rather than a silently no-op publish.
             var projectDir = Path.Combine(workspace.WorkspaceRoot.FullName, ProjectName);
             var appHostDir = Path.Combine(projectDir, $"{ProjectName}.AppHost");
             var appHostFilePath = Path.Combine(appHostDir, "AppHost.cs");

--- a/tests/Aspire.Cli.EndToEnd.Tests/KubernetesPublishRequiresExternalEndpointTests.cs
+++ b/tests/Aspire.Cli.EndToEnd.Tests/KubernetesPublishRequiresExternalEndpointTests.cs
@@ -68,8 +68,11 @@ public sealed class KubernetesPublishRequiresExternalEndpointTests(ITestOutputHe
             await auto.PrepareDockerEnvironmentAsync(counter, workspace);
             await auto.InstallAspireCliAsync(strategy, counter);
 
-            // EmptyAppHost gives us a minimal csproj-based AppHost we can mutate.
-            await auto.AspireNewAsync(ProjectName, counter, template: AspireTemplate.EmptyAppHost);
+            // The starter template gives us the conventional
+            // `{ProjectName}/{ProjectName}.AppHost/AppHost.cs` layout, matching
+            // KubernetesPublishTests so the AppHost-mutation logic below stays
+            // consistent across both tests.
+            await auto.AspireNewAsync(ProjectName, counter, useRedisCache: false);
 
             // cd into the project so subsequent `aspire add` and `aspire publish`
             // commands resolve the AppHost via repo-root discovery.

--- a/tests/Aspire.Deployment.EndToEnd.Tests/AksAzureKubernetesEnvironmentCertManagerDeploymentTests.cs
+++ b/tests/Aspire.Deployment.EndToEnd.Tests/AksAzureKubernetesEnvironmentCertManagerDeploymentTests.cs
@@ -149,6 +149,9 @@ var letsEncrypt = certManager.AddIssuer("letsencrypt-staging")
 // its FQDN, the tls-fqdn-discovery pipeline step patches it onto the listener and the
 // cm-issuer-apply step ensures the ClusterIssuer is present so cert-manager can complete
 // the HTTP-01 challenge against the AGC FQDN.
+// The Gateway route validation requires the routed endpoint to be marked external.
+apiService.WithExternalHttpEndpoints();
+
 aks.AddGateway("api-gw")
     .WithLoadBalancer(publicLb)
     .WithRoute("/", apiService.GetEndpoint("http"))

--- a/tests/Aspire.Deployment.EndToEnd.Tests/AksAzureKubernetesEnvironmentGatewayDeploymentTests.cs
+++ b/tests/Aspire.Deployment.EndToEnd.Tests/AksAzureKubernetesEnvironmentGatewayDeploymentTests.cs
@@ -141,6 +141,9 @@ var publicLb = aks.AddLoadBalancer("public", albSubnet);
 // stamps the alb.networking.azure.io association annotations and defaults the
 // gatewayClassName to "azure-alb-external". Routing "/" (Prefix) so any path the
 // starter template's apiservice exposes (/, /weatherforecast) flows through.
+// The Gateway route validation requires the routed endpoint to be marked external.
+apiService.WithExternalHttpEndpoints();
+
 aks.AddGateway("api-gw")
     .WithLoadBalancer(publicLb)
     .WithRoute("/", apiService.GetEndpoint("http"));

--- a/tests/Aspire.Deployment.EndToEnd.Tests/KubernetesGatewayTlsDeploymentTests.cs
+++ b/tests/Aspire.Deployment.EndToEnd.Tests/KubernetesGatewayTlsDeploymentTests.cs
@@ -291,6 +291,10 @@ var k8s = builder.AddKubernetesEnvironment("k8s")
         helm.WithChartVersion(builder.AddParameter("chartversion"));
     });
 
+// The Gateway route validation requires the routed endpoint to be marked
+// external. The starter template's `webfrontend` does not opt in by default.
+webfrontend.WithExternalHttpEndpoints();
+
 var gateway = k8s.AddGateway("ingress")
     .WithGatewayClass("azure-alb-external")
     .WithGatewayAnnotation("alb.networking.azure.io/alb-name", "alb-aspire")

--- a/tests/Aspire.Hosting.Azure.Kubernetes.Tests/AzureKubernetesIngressTests.cs
+++ b/tests/Aspire.Hosting.Azure.Kubernetes.Tests/AzureKubernetesIngressTests.cs
@@ -21,7 +21,8 @@ public class AzureKubernetesIngressTests
             .WithIngressClass("nginx");
 
         var api = builder.AddContainer("myapi", "nginx")
-            .WithHttpEndpoint(targetPort: 8080);
+            .WithHttpEndpoint(targetPort: 8080)
+            .WithExternalHttpEndpoints();
 
         ingress.WithRoute("/", api.GetEndpoint("http"));
 
@@ -125,8 +126,49 @@ public class AzureKubernetesIngressTests
         Assert.NotNull(gateway.Resource.GatewayClassName);
         var resolvedClass = await gateway.Resource.GatewayClassName!.GetValueAsync(default);
         Assert.Equal("custom-class", resolvedClass);
+    }
 
-        Assert.True(gateway.Resource.GatewayAnnotations.ContainsKey("alb.networking.azure.io/alb-name"));
-        Assert.True(gateway.Resource.GatewayAnnotations.ContainsKey("alb.networking.azure.io/alb-namespace"));
+    [Fact]
+    public void AksAddIngress_WithRoute_NonExternalEndpoint_ThrowsOnPublish()
+    {
+        using var tempDir = new TestTempDirectory();
+        var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish, tempDir.Path);
+
+        var aks = builder.AddAzureKubernetesEnvironment("aks");
+        var ingress = aks.AddIngress("public").WithIngressClass("nginx");
+
+        var api = builder.AddContainer("myapi", "nginx")
+            .WithHttpEndpoint(targetPort: 8080);
+
+        ingress.WithRoute("/", api.GetEndpoint("http"));
+
+        var app = builder.Build();
+        var aggregate = Assert.Throws<AggregateException>(app.Run);
+        var ex = aggregate.Flatten().InnerExceptions.OfType<InvalidOperationException>().First(e => e.Message.Contains("WithExternalHttpEndpoints"));
+
+        Assert.Contains("myapi", ex.Message);
+        Assert.Contains("WithExternalHttpEndpoints", ex.Message);
+    }
+
+    [Fact]
+    public void AksAddGateway_WithRoute_NonExternalEndpoint_ThrowsOnPublish()
+    {
+        using var tempDir = new TestTempDirectory();
+        var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish, tempDir.Path);
+
+        var aks = builder.AddAzureKubernetesEnvironment("aks");
+        var gateway = aks.AddGateway("public").WithGatewayClass("nginx");
+
+        var api = builder.AddContainer("myapi", "nginx")
+            .WithHttpEndpoint(targetPort: 8080);
+
+        gateway.WithRoute("/", api.GetEndpoint("http"));
+
+        var app = builder.Build();
+        var aggregate = Assert.Throws<AggregateException>(app.Run);
+        var ex = aggregate.Flatten().InnerExceptions.OfType<InvalidOperationException>().First(e => e.Message.Contains("WithExternalHttpEndpoints"));
+
+        Assert.Contains("myapi", ex.Message);
+        Assert.Contains("WithExternalHttpEndpoints", ex.Message);
     }
 }

--- a/tests/Aspire.Hosting.Azure.Kubernetes.Tests/AzureKubernetesIngressTests.cs
+++ b/tests/Aspire.Hosting.Azure.Kubernetes.Tests/AzureKubernetesIngressTests.cs
@@ -126,6 +126,9 @@ public class AzureKubernetesIngressTests
         Assert.NotNull(gateway.Resource.GatewayClassName);
         var resolvedClass = await gateway.Resource.GatewayClassName!.GetValueAsync(default);
         Assert.Equal("custom-class", resolvedClass);
+
+        Assert.True(gateway.Resource.GatewayAnnotations.ContainsKey("alb.networking.azure.io/alb-name"));
+        Assert.True(gateway.Resource.GatewayAnnotations.ContainsKey("alb.networking.azure.io/alb-namespace"));
     }
 
     [Fact]

--- a/tests/Aspire.Hosting.Kubernetes.Tests/KubernetesGatewayTests.cs
+++ b/tests/Aspire.Hosting.Kubernetes.Tests/KubernetesGatewayTests.cs
@@ -18,7 +18,8 @@ public class KubernetesGatewayTests
             .WithGatewayClass("nginx");
 
         var api = builder.AddContainer("myapi", "nginx")
-            .WithHttpEndpoint(targetPort: 8080);
+            .WithHttpEndpoint(targetPort: 8080)
+            .WithExternalHttpEndpoints();
 
         gateway.WithRoute("/api", api.GetEndpoint("http"));
 
@@ -59,7 +60,8 @@ public class KubernetesGatewayTests
         var gateway = k8s.AddGateway("public").WithGatewayClass("test");
 
         var api = builder.AddContainer("myapi", "nginx")
-            .WithHttpEndpoint(targetPort: 8080);
+            .WithHttpEndpoint(targetPort: 8080)
+            .WithExternalHttpEndpoints();
 
         gateway.WithRoute("api.example.com", "/", api.GetEndpoint("http"));
 
@@ -85,7 +87,8 @@ public class KubernetesGatewayTests
         var gateway = k8s.AddGateway("public").WithGatewayClass("test");
 
         var api = builder.AddContainer("myapi", "nginx")
-            .WithHttpEndpoint(targetPort: 8080);
+            .WithHttpEndpoint(targetPort: 8080)
+            .WithExternalHttpEndpoints();
 
         gateway
             .WithRoute("api.example.com", "/", api.GetEndpoint("http"))
@@ -116,7 +119,8 @@ public class KubernetesGatewayTests
         var gateway = k8s.AddGateway("public").WithGatewayClass("test");
 
         var api = builder.AddContainer("myapi", "nginx")
-            .WithHttpEndpoint(targetPort: 8080);
+            .WithHttpEndpoint(targetPort: 8080)
+            .WithExternalHttpEndpoints();
 
         gateway
             .WithRoute("api.example.com", "/", api.GetEndpoint("http"))
@@ -141,10 +145,12 @@ public class KubernetesGatewayTests
         var gateway = k8s.AddGateway("public").WithGatewayClass("test");
 
         var api = builder.AddContainer("myapi", "nginx")
-            .WithHttpEndpoint(targetPort: 8080);
+            .WithHttpEndpoint(targetPort: 8080)
+            .WithExternalHttpEndpoints();
 
         var web = builder.AddContainer("myweb", "nginx")
-            .WithHttpEndpoint(targetPort: 80);
+            .WithHttpEndpoint(targetPort: 80)
+            .WithExternalHttpEndpoints();
 
         // Two routes on the same host ΓåÆ should be grouped into one HTTPRoute
         gateway.WithRoute("example.com", "/api", api.GetEndpoint("http"));
@@ -238,7 +244,8 @@ public class KubernetesGatewayTests
         var gateway = k8s.AddGateway("public").WithGatewayClass("azure-alb-external");
 
         var api = builder.AddContainer("myapi", "nginx")
-            .WithHttpEndpoint(targetPort: 8080);
+            .WithHttpEndpoint(targetPort: 8080)
+            .WithExternalHttpEndpoints();
 
         // WithTls() without WithHostname() — should still generate an HTTPS listener
         gateway
@@ -284,7 +291,8 @@ public class KubernetesGatewayTests
         var gateway = k8s.AddGateway("public").WithGatewayClass("azure-alb-external");
 
         var api = builder.AddContainer("myapi", "nginx")
-            .WithHttpEndpoint(targetPort: 8080);
+            .WithHttpEndpoint(targetPort: 8080)
+            .WithExternalHttpEndpoints();
 
         gateway
             .WithRoute("/", api.GetEndpoint("http"))
@@ -308,5 +316,78 @@ public class KubernetesGatewayTests
         var nextListenerOrEnd = lines.FindIndex(httpsIndex + 1, l => l.StartsWith("- name:") || l == "");
         var httpsSection = lines.Skip(httpsIndex).Take((nextListenerOrEnd > httpsIndex ? nextListenerOrEnd : lines.Count) - httpsIndex).ToList();
         Assert.Contains(httpsSection, l => l.Contains("hostname:") && l.Contains("api.example.com"));
+    }
+
+    [Fact]
+    public void AddGateway_WithRoute_NonExternalEndpoint_ThrowsOnPublish()
+    {
+        using var tempDir = new TestTempDirectory();
+        var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish, tempDir.Path);
+
+        var k8s = builder.AddKubernetesEnvironment("env");
+        var gateway = k8s.AddGateway("public").WithGatewayClass("test");
+
+        // Intentionally omit WithExternalHttpEndpoints — the publish-time
+        // validation must surface a clear, actionable error.
+        var api = builder.AddContainer("myapi", "nginx")
+            .WithHttpEndpoint(targetPort: 8080);
+
+        gateway.WithRoute("/api", api.GetEndpoint("http"));
+
+        var app = builder.Build();
+        var aggregate = Assert.Throws<AggregateException>(app.Run);
+        var ex = aggregate.Flatten().InnerExceptions.OfType<InvalidOperationException>().First(e => e.Message.Contains("WithExternalHttpEndpoints"));
+
+        Assert.Contains("myapi", ex.Message);
+        Assert.Contains("public", ex.Message);
+        Assert.Contains("WithExternalHttpEndpoints", ex.Message);
+    }
+
+    [Fact]
+    public void AddGateway_WithHostRoute_NonExternalEndpoint_ThrowsOnPublish()
+    {
+        using var tempDir = new TestTempDirectory();
+        var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish, tempDir.Path);
+
+        var k8s = builder.AddKubernetesEnvironment("env");
+        var gateway = k8s.AddGateway("public").WithGatewayClass("test");
+
+        var api = builder.AddContainer("myapi", "nginx")
+            .WithHttpEndpoint(targetPort: 8080);
+
+        gateway.WithRoute("api.example.com", "/", api.GetEndpoint("http"));
+
+        var app = builder.Build();
+        var aggregate = Assert.Throws<AggregateException>(app.Run);
+        var ex = aggregate.Flatten().InnerExceptions.OfType<InvalidOperationException>().First(e => e.Message.Contains("WithExternalHttpEndpoints"));
+
+        Assert.Contains("myapi", ex.Message);
+        Assert.Contains("WithExternalHttpEndpoints", ex.Message);
+    }
+
+    [Fact]
+    public async Task AddGateway_WithRoute_ExternalEndpoint_Succeeds()
+    {
+        using var tempDir = new TestTempDirectory();
+        var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish, tempDir.Path);
+
+        var k8s = builder.AddKubernetesEnvironment("env");
+        var gateway = k8s.AddGateway("public").WithGatewayClass("test");
+
+        // WithExternalHttpEndpoints applied AFTER WithRoute to prove that
+        // authoring order does not matter — validation runs at publish time.
+        var api = builder.AddContainer("myapi", "nginx")
+            .WithHttpEndpoint(targetPort: 8080);
+
+        gateway.WithRoute("/api", api.GetEndpoint("http"));
+        api.WithExternalHttpEndpoints();
+
+        var app = builder.Build();
+        app.Run();
+
+        var gatewayFile = Path.Combine(tempDir.Path, "templates", "public", "public.yaml");
+        Assert.True(File.Exists(gatewayFile));
+        var content = await File.ReadAllTextAsync(gatewayFile);
+        Assert.Contains("Gateway", content);
     }
 }

--- a/tests/Aspire.Hosting.Kubernetes.Tests/KubernetesIngressTests.cs
+++ b/tests/Aspire.Hosting.Kubernetes.Tests/KubernetesIngressTests.cs
@@ -18,7 +18,8 @@ public class KubernetesIngressTests
             .WithIngressClass("nginx");
 
         var api = builder.AddContainer("myapi", "nginx")
-            .WithHttpEndpoint(targetPort: 8080);
+            .WithHttpEndpoint(targetPort: 8080)
+            .WithExternalHttpEndpoints();
 
         ingress.WithRoute("/api", api.GetEndpoint("http"));
 
@@ -48,7 +49,8 @@ public class KubernetesIngressTests
         var ingress = k8s.AddIngress("public");
 
         var api = builder.AddContainer("myapi", "nginx")
-            .WithHttpEndpoint(targetPort: 8080);
+            .WithHttpEndpoint(targetPort: 8080)
+            .WithExternalHttpEndpoints();
 
         ingress.WithRoute("api.example.com", "/", api.GetEndpoint("http"));
 
@@ -73,7 +75,8 @@ public class KubernetesIngressTests
         var ingress = k8s.AddIngress("public");
 
         var api = builder.AddContainer("myapi", "nginx")
-            .WithHttpEndpoint(targetPort: 8080);
+            .WithHttpEndpoint(targetPort: 8080)
+            .WithExternalHttpEndpoints();
 
         ingress
             .WithRoute("api.example.com", "/", api.GetEndpoint("http"))
@@ -100,7 +103,8 @@ public class KubernetesIngressTests
         var ingress = k8s.AddIngress("public");
 
         var api = builder.AddContainer("myapi", "nginx")
-            .WithHttpEndpoint(targetPort: 8080);
+            .WithHttpEndpoint(targetPort: 8080)
+            .WithExternalHttpEndpoints();
 
         ingress
             .WithRoute("api.example.com", "/", api.GetEndpoint("http"))
@@ -129,10 +133,12 @@ public class KubernetesIngressTests
         var ingress = k8s.AddIngress("public");
 
         var api = builder.AddContainer("myapi", "nginx")
-            .WithHttpEndpoint(targetPort: 8080);
+            .WithHttpEndpoint(targetPort: 8080)
+            .WithExternalHttpEndpoints();
 
         var web = builder.AddContainer("myweb", "nginx")
-            .WithHttpEndpoint(targetPort: 80);
+            .WithHttpEndpoint(targetPort: 80)
+            .WithExternalHttpEndpoints();
 
         // Two routes on the same host
         ingress.WithRoute("example.com", "/api", api.GetEndpoint("http"));
@@ -161,7 +167,8 @@ public class KubernetesIngressTests
             .WithIngressAnnotation("nginx.ingress.kubernetes.io/rewrite-target", "/$1");
 
         var api = builder.AddContainer("myapi", "nginx")
-            .WithHttpEndpoint(targetPort: 8080);
+            .WithHttpEndpoint(targetPort: 8080)
+            .WithExternalHttpEndpoints();
 
         ingress.WithRoute("/", api.GetEndpoint("http"));
 
@@ -184,7 +191,8 @@ public class KubernetesIngressTests
         var ingress = k8s.AddIngress("public");
 
         var api = builder.AddContainer("myapi", "nginx")
-            .WithHttpEndpoint(targetPort: 8080);
+            .WithHttpEndpoint(targetPort: 8080)
+            .WithExternalHttpEndpoints();
 
         ingress.WithRoute("/exact", api.GetEndpoint("http"), IngressPathType.Exact);
 
@@ -255,10 +263,12 @@ public class KubernetesIngressTests
             .WithIngressClass("internal");
 
         var api = builder.AddContainer("myapi", "nginx")
-            .WithHttpEndpoint(targetPort: 8080);
+            .WithHttpEndpoint(targetPort: 8080)
+            .WithExternalHttpEndpoints();
 
         var admin = builder.AddContainer("myadmin", "nginx")
-            .WithHttpEndpoint(targetPort: 9090);
+            .WithHttpEndpoint(targetPort: 9090)
+            .WithExternalHttpEndpoints();
 
         publicIngress.WithRoute("/", api.GetEndpoint("http"));
         internalIngress.WithRoute("/admin", admin.GetEndpoint("http"));
@@ -290,7 +300,8 @@ public class KubernetesIngressTests
         var ingress = k8s.AddIngress("public");
 
         var web = builder.AddContainer("myweb", "nginx")
-            .WithHttpEndpoint(targetPort: 8080);
+            .WithHttpEndpoint(targetPort: 8080)
+            .WithExternalHttpEndpoints();
 
         // TLS host + default backend but NO explicit route for the TLS host.
         // The ingress should auto-generate a rule for the TLS host.
@@ -324,7 +335,8 @@ public class KubernetesIngressTests
         var ingress = k8s.AddIngress("public");
 
         var web = builder.AddContainer("myweb", "nginx")
-            .WithHttpEndpoint(targetPort: 8080);
+            .WithHttpEndpoint(targetPort: 8080)
+            .WithExternalHttpEndpoints();
 
         // Explicit route for the TLS host ΓÇö should NOT auto-generate another one
         ingress
@@ -380,5 +392,78 @@ public class KubernetesIngressTests
 
         Assert.Equal(k8s.Resource, ingress.Resource.Parent);
         Assert.IsType<KubernetesIngressResource>(ingress.Resource);
+    }
+
+    [Fact]
+    public void AddIngress_WithRoute_NonExternalEndpoint_ThrowsOnPublish()
+    {
+        using var tempDir = new TestTempDirectory();
+        var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish, tempDir.Path);
+
+        var k8s = builder.AddKubernetesEnvironment("env");
+        var ingress = k8s.AddIngress("public");
+
+        // Intentionally omit WithExternalHttpEndpoints to ensure the publish-time
+        // validation fires and surfaces a clear, actionable message.
+        var api = builder.AddContainer("myapi", "nginx")
+            .WithHttpEndpoint(targetPort: 8080);
+
+        ingress.WithRoute("/", api.GetEndpoint("http"));
+
+        var app = builder.Build();
+        var aggregate = Assert.Throws<AggregateException>(app.Run);
+        var ex = aggregate.Flatten().InnerExceptions.OfType<InvalidOperationException>().First(e => e.Message.Contains("WithExternalHttpEndpoints"));
+
+        Assert.Contains("myapi", ex.Message);
+        Assert.Contains("public", ex.Message);
+        Assert.Contains("WithExternalHttpEndpoints", ex.Message);
+    }
+
+    [Fact]
+    public void AddIngress_WithDefaultBackend_NonExternalEndpoint_ThrowsOnPublish()
+    {
+        using var tempDir = new TestTempDirectory();
+        var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish, tempDir.Path);
+
+        var k8s = builder.AddKubernetesEnvironment("env");
+        var ingress = k8s.AddIngress("public");
+
+        var web = builder.AddContainer("myweb", "nginx")
+            .WithHttpEndpoint(targetPort: 8080);
+
+        ingress.WithDefaultBackend(web.GetEndpoint("http"));
+
+        var app = builder.Build();
+        var aggregate = Assert.Throws<AggregateException>(app.Run);
+        var ex = aggregate.Flatten().InnerExceptions.OfType<InvalidOperationException>().First(e => e.Message.Contains("WithExternalHttpEndpoints"));
+
+        Assert.Contains("myweb", ex.Message);
+        Assert.Contains("public", ex.Message);
+        Assert.Contains("WithExternalHttpEndpoints", ex.Message);
+    }
+
+    [Fact]
+    public async Task AddIngress_WithRoute_ExternalEndpoint_Succeeds()
+    {
+        using var tempDir = new TestTempDirectory();
+        var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish, tempDir.Path);
+
+        var k8s = builder.AddKubernetesEnvironment("env");
+        var ingress = k8s.AddIngress("public");
+
+        // WithExternalHttpEndpoints applied AFTER WithRoute to demonstrate that
+        // authoring order does not matter: validation runs at publish time.
+        var api = builder.AddContainer("myapi", "nginx")
+            .WithHttpEndpoint(targetPort: 8080);
+
+        ingress.WithRoute("/", api.GetEndpoint("http"));
+
+        api.WithExternalHttpEndpoints();
+
+        var app = builder.Build();
+        app.Run();
+
+        var ingressPath = Path.Combine(tempDir.Path, "templates", "public", "public.yaml");
+        Assert.True(File.Exists(ingressPath));
     }
 }


### PR DESCRIPTION
## Description

Today the Kubernetes `AddIngress` / `AddGateway` APIs will happily route any endpoint passed to `WithRoute(...)` / `WithDefaultBackend(...)`, even one that the resource owner never marked external. That is a privacy / security footgun: an ingress or gateway exposes its backing service to traffic from outside the cluster, so the routed endpoint should have been an explicit opt-in via `WithExternalHttpEndpoints()` (or `isExternal: true`). Front Door already enforces this; the K8s and AKS paths did not.

This change adds that check on the publish path. A new internal helper `EndpointRoutingValidation.ThrowIfEndpointNotExternal` is called from `KubernetesEnvironmentResource.ProcessIngressResources` / `ProcessGatewayResources` during model materialization, so the user gets a clear `InvalidOperationException` (with the resource name, endpoint name, ingress/gateway name, and a pointer at `WithExternalHttpEndpoints()`) before any Helm output is generated. AKS is covered automatically because `AddAzureKubernetesEnvironment` delegates ingress/gateway routing to the same code path.

Validation runs at publish time rather than at `WithRoute(...)` call time on purpose: authoring order is not significant. Users may legitimately register a route and then call `WithExternalHttpEndpoints()` afterwards, so we want to evaluate intent once the model is finalized.

### Tests
- 6 new K8s unit tests and 2 new AKS unit tests covering positive and negative cases for `WithRoute`, `WithHostRoute`, and `WithDefaultBackend`.
- All pre-existing K8s / AKS / deployment E2E tests whose routed endpoints were not previously marked external have been updated to call `WithExternalHttpEndpoints()` on the target resource (Polyglot Go AppHost needed no change because it does not call `WithRoute`).
- New CLI E2E test `KubernetesPublishRequiresExternalEndpointTests` scaffolds an EmptyAppHost, wires an ingress (and a gateway, in a sibling fact) at a non-external endpoint, runs `aspire publish --non-interactive`, and asserts the CLI exits non-zero with the guidance text on screen.

### Notes for reviewers
- The exception bubbles out of a pipeline step, so it is wrapped in `AggregateException` at the `app.Run()` boundary. The new unit tests flatten and assert on the `InvalidOperationException` whose message contains `WithExternalHttpEndpoints`.
- Aligning the existing Front Door `GetOriginEndpoint` check on the same shared helper is intentionally out of scope for this PR; the K8s path is the immediate gap.

Fixes # (issue)

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [x] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [x] No
  - [ ] No