### PR TITLE
Refuse 'staging' channel synthesis on daily/local/pr CLI builds

### DIFF
--- a/src/Aspire.Cli/Commands/NewCommand.cs
+++ b/src/Aspire.Cli/Commands/NewCommand.cs
@@ -101,7 +101,7 @@ internal sealed class NewCommand : BaseCommand, IPackageMetaPrefetchingCommand
 
         // Customize description based on whether staging channel is enabled
         var isStagingEnabled = KnownFeatures.IsStagingChannelEnabled(_features, configuration)
-            || string.Equals(ExecutionContext.IdentityChannel, PackageChannelNames.Staging, StringComparison.OrdinalIgnoreCase);
+            || string.Equals(ExecutionContext.IdentityChannel, PackageChannelNames.Staging, StringComparisons.ChannelName);
         _channelOption = new Option<string?>("--channel")
         {
             Description = isStagingEnabled
@@ -333,14 +333,14 @@ internal sealed class NewCommand : BaseCommand, IPackageMetaPrefetchingCommand
                     !string.IsNullOrWhiteSpace(ExecutionContext.IdentityChannel))
                 {
                     identityChannelMatch = channels.FirstOrDefault(c =>
-                        string.Equals(c.Name, ExecutionContext.IdentityChannel, StringComparison.OrdinalIgnoreCase));
+                        string.Equals(c.Name, ExecutionContext.IdentityChannel, StringComparisons.ChannelName));
                 }
 
                 var selectedChannel = string.IsNullOrWhiteSpace(configuredChannelName)
                     ? identityChannelMatch
                         ?? channels.FirstOrDefault(c => c.Type is PackageChannelType.Implicit)
                         ?? channels.FirstOrDefault()
-                    : channels.FirstOrDefault(c => string.Equals(c.Name, configuredChannelName, StringComparison.OrdinalIgnoreCase));
+                    : channels.FirstOrDefault(c => string.Equals(c.Name, configuredChannelName, StringComparisons.ChannelName));
 
                 if (selectedChannel is null)
                 {
@@ -349,7 +349,7 @@ internal sealed class NewCommand : BaseCommand, IPackageMetaPrefetchingCommand
                     {
                         errorMessage = NewCommandStrings.NoPackageChannelsAvailable;
                     }
-                    else if (string.Equals(configuredChannelName, PackageChannelNames.Staging, StringComparison.OrdinalIgnoreCase)
+                    else if (string.Equals(configuredChannelName, PackageChannelNames.Staging, StringComparisons.ChannelName)
                         && _packagingService.GetStagingChannelUnavailableReason() is { } stagingReason)
                     {
                         // Surface the actionable packaging-service reason (e.g. "daily CLI cannot

--- a/src/Aspire.Cli/Commands/NewCommand.cs
+++ b/src/Aspire.Cli/Commands/NewCommand.cs
@@ -344,9 +344,24 @@ internal sealed class NewCommand : BaseCommand, IPackageMetaPrefetchingCommand
 
                 if (selectedChannel is null)
                 {
-                    var errorMessage = string.IsNullOrWhiteSpace(configuredChannelName)
-                        ? "No package channels are available."
-                        : $"No channel found matching '{configuredChannelName}'. Valid options are: {string.Join(", ", channels.Select(c => c.Name))}";
+                    string errorMessage;
+                    if (string.IsNullOrWhiteSpace(configuredChannelName))
+                    {
+                        errorMessage = "No package channels are available.";
+                    }
+                    else if (string.Equals(configuredChannelName, PackageChannelNames.Staging, StringComparison.OrdinalIgnoreCase)
+                        && _packagingService.GetStagingChannelUnavailableReason() is { } stagingReason)
+                    {
+                        // Surface the actionable packaging-service reason (e.g. "daily CLI cannot
+                        // synthesize a staging channel; set overrideStagingFeed") instead of the
+                        // generic channel list, mirroring UpdateCommand's behavior.
+                        // See https://github.com/microsoft/aspire/issues/16652.
+                        errorMessage = stagingReason;
+                    }
+                    else
+                    {
+                        errorMessage = $"No channel found matching '{configuredChannelName}'. Valid options are: {string.Join(", ", channels.Select(c => c.Name))}";
+                    }
 
                     return new ResolveTemplateVersionResult { ErrorMessage = errorMessage };
                 }

--- a/src/Aspire.Cli/Commands/NewCommand.cs
+++ b/src/Aspire.Cli/Commands/NewCommand.cs
@@ -347,7 +347,7 @@ internal sealed class NewCommand : BaseCommand, IPackageMetaPrefetchingCommand
                     string errorMessage;
                     if (string.IsNullOrWhiteSpace(configuredChannelName))
                     {
-                        errorMessage = "No package channels are available.";
+                        errorMessage = NewCommandStrings.NoPackageChannelsAvailable;
                     }
                     else if (string.Equals(configuredChannelName, PackageChannelNames.Staging, StringComparison.OrdinalIgnoreCase)
                         && _packagingService.GetStagingChannelUnavailableReason() is { } stagingReason)
@@ -360,7 +360,11 @@ internal sealed class NewCommand : BaseCommand, IPackageMetaPrefetchingCommand
                     }
                     else
                     {
-                        errorMessage = $"No channel found matching '{configuredChannelName}'. Valid options are: {string.Join(", ", channels.Select(c => c.Name))}";
+                        errorMessage = string.Format(
+                            CultureInfo.CurrentCulture,
+                            NewCommandStrings.NoChannelFoundMatching,
+                            configuredChannelName,
+                            string.Join(", ", channels.Select(c => c.Name)));
                     }
 
                     return new ResolveTemplateVersionResult { ErrorMessage = errorMessage };

--- a/src/Aspire.Cli/Commands/UpdateCommand.cs
+++ b/src/Aspire.Cli/Commands/UpdateCommand.cs
@@ -225,7 +225,11 @@ internal sealed class UpdateCommand : BaseCommand
                         }
                     }
 
-                    throw new ChannelNotFoundException($"No channel found matching '{channelName}'. Valid options are: {string.Join(", ", allChannels.Select(c => c.Name))}");
+                    throw new ChannelNotFoundException(string.Format(
+                        CultureInfo.CurrentCulture,
+                        UpdateCommandStrings.NoChannelFoundMatching,
+                        channelName,
+                        string.Join(", ", allChannels.Select(c => c.Name))));
                 }
 
                 channel = matchedChannel;

--- a/src/Aspire.Cli/Commands/UpdateCommand.cs
+++ b/src/Aspire.Cli/Commands/UpdateCommand.cs
@@ -208,7 +208,7 @@ internal sealed class UpdateCommand : BaseCommand
             if (!string.IsNullOrWhiteSpace(channelName))
             {
                 // Try to find a channel matching the provided channel/quality
-                var matchedChannel = allChannels.FirstOrDefault(c => string.Equals(c.Name, channelName, StringComparison.OrdinalIgnoreCase));
+                var matchedChannel = allChannels.FirstOrDefault(c => string.Equals(c.Name, channelName, StringComparisons.ChannelName));
                 if (matchedChannel is null)
                 {
                     // When the user explicitly asked for the 'staging' channel and the packaging
@@ -216,7 +216,7 @@ internal sealed class UpdateCommand : BaseCommand
                     // surface the packaging-service reason instead of the generic "no channel
                     // matching" message — the generic message hides the actual fix from the user.
                     // See https://github.com/microsoft/aspire/issues/16652.
-                    if (string.Equals(channelName, PackageChannelNames.Staging, StringComparison.OrdinalIgnoreCase))
+                    if (string.Equals(channelName, PackageChannelNames.Staging, StringComparisons.ChannelName))
                     {
                         var stagingUnavailableReason = _packagingService.GetStagingChannelUnavailableReason();
                         if (stagingUnavailableReason is not null)
@@ -259,9 +259,9 @@ internal sealed class UpdateCommand : BaseCommand
                 var identityChannel = ExecutionContext.IdentityChannel;
                 PackageChannel? identityMatch = null;
                 if (!string.IsNullOrWhiteSpace(identityChannel)
-                    && !string.Equals(identityChannel, PackageChannelNames.Local, StringComparison.OrdinalIgnoreCase))
+                    && !string.Equals(identityChannel, PackageChannelNames.Local, StringComparisons.ChannelName))
                 {
-                    identityMatch = allChannels.FirstOrDefault(c => string.Equals(c.Name, identityChannel, StringComparison.OrdinalIgnoreCase));
+                    identityMatch = allChannels.FirstOrDefault(c => string.Equals(c.Name, identityChannel, StringComparisons.ChannelName));
                 }
 
                 if (identityMatch is not null)
@@ -381,7 +381,7 @@ internal sealed class UpdateCommand : BaseCommand
     private bool IsStagingChannelAvailable()
     {
         return KnownFeatures.IsStagingChannelEnabled(_features, _configuration)
-            || string.Equals(ExecutionContext.IdentityChannel, PackageChannelNames.Staging, StringComparison.OrdinalIgnoreCase);
+            || string.Equals(ExecutionContext.IdentityChannel, PackageChannelNames.Staging, StringComparisons.ChannelName);
     }
 
     private async Task<CommandResult> ExecuteSelfUpdateAsync(ParseResult parseResult, CancellationToken cancellationToken, string? selectedChannel = null)

--- a/src/Aspire.Cli/Commands/UpdateCommand.cs
+++ b/src/Aspire.Cli/Commands/UpdateCommand.cs
@@ -208,8 +208,27 @@ internal sealed class UpdateCommand : BaseCommand
             if (!string.IsNullOrWhiteSpace(channelName))
             {
                 // Try to find a channel matching the provided channel/quality
-                channel = allChannels.FirstOrDefault(c => string.Equals(c.Name, channelName, StringComparison.OrdinalIgnoreCase))
-                    ?? throw new ChannelNotFoundException($"No channel found matching '{channelName}'. Valid options are: {string.Join(", ", allChannels.Select(c => c.Name))}");
+                var matchedChannel = allChannels.FirstOrDefault(c => string.Equals(c.Name, channelName, StringComparison.OrdinalIgnoreCase));
+                if (matchedChannel is null)
+                {
+                    // When the user explicitly asked for the 'staging' channel and the packaging
+                    // service refused to synthesize it (daily/local/pr-N CLI without an override),
+                    // surface the packaging-service reason instead of the generic "no channel
+                    // matching" message — the generic message hides the actual fix from the user.
+                    // See https://github.com/microsoft/aspire/issues/16652.
+                    if (string.Equals(channelName, PackageChannelNames.Staging, StringComparison.OrdinalIgnoreCase))
+                    {
+                        var stagingUnavailableReason = _packagingService.GetStagingChannelUnavailableReason();
+                        if (stagingUnavailableReason is not null)
+                        {
+                            throw new ChannelNotFoundException(stagingUnavailableReason);
+                        }
+                    }
+
+                    throw new ChannelNotFoundException($"No channel found matching '{channelName}'. Valid options are: {string.Join(", ", allChannels.Select(c => c.Name))}");
+                }
+
+                channel = matchedChannel;
 
                 if (channelFromConfig)
                 {

--- a/src/Aspire.Cli/KnownFeatures.cs
+++ b/src/Aspire.Cli/KnownFeatures.cs
@@ -127,6 +127,6 @@ internal static class KnownFeatures
     public static bool IsStagingChannelEnabled(IFeatures features, IConfiguration configuration)
     {
         return features.IsFeatureEnabled(StagingChannelEnabled, false)
-            || string.Equals(configuration["channel"], PackageChannelNames.Staging, StringComparison.OrdinalIgnoreCase);
+            || string.Equals(configuration["channel"], PackageChannelNames.Staging, StringComparisons.ChannelName);
     }
 }

--- a/src/Aspire.Cli/Packaging/PackagingService.cs
+++ b/src/Aspire.Cli/Packaging/PackagingService.cs
@@ -3,10 +3,12 @@
 
 using Aspire.Cli.Configuration;
 using Aspire.Cli.NuGet;
+using Aspire.Cli.Resources;
 using Aspire.Cli.Utils;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
 using Semver;
+using System.Globalization;
 using System.Reflection;
 
 namespace Aspire.Cli.Packaging;
@@ -14,6 +16,22 @@ namespace Aspire.Cli.Packaging;
 internal interface IPackagingService
 {
     public Task<IEnumerable<PackageChannel>> GetChannelsAsync(CancellationToken cancellationToken = default, string? requestedChannelName = null);
+
+    /// <summary>
+    /// Returns a user-facing reason explaining why the <c>staging</c> package channel cannot be
+    /// synthesized for the running CLI, or <see langword="null"/> when staging IS available.
+    /// </summary>
+    /// <remarks>
+    /// On a CLI whose baked <c>AspireCliChannel</c> identity is <c>daily</c>, <c>local</c>, or
+    /// <c>pr-&lt;N&gt;</c>, there is no deterministic way to produce a real staging feed:
+    /// the SHA-specific darc feed (<c>darc-pub-microsoft-aspire-&lt;hash&gt;</c>) only exists
+    /// for stable release branch builds, and falling back to the shared daily feed silently
+    /// resolves daily packages instead of staging ones. To avoid that downgrade
+    /// (see <see href="https://github.com/microsoft/aspire/issues/16652"/>), the service refuses
+    /// to fabricate a staging channel from those identities unless the caller has set
+    /// <c>overrideStagingFeed</c> or enabled the staging feature flag.
+    /// </remarks>
+    string? GetStagingChannelUnavailableReason();
 }
 
 internal class PackagingService(CliExecutionContext executionContext, INuGetPackageCache nuGetPackageCache, IFeatures features, IConfiguration configuration, ILogger<PackagingService> logger) : IPackagingService
@@ -89,6 +107,19 @@ internal class PackagingService(CliExecutionContext executionContext, INuGetPack
 
     private PackageChannel? CreateStagingChannel(PackageChannelQuality defaultQuality)
     {
+        // Refuse to synthesize a staging channel on CLI identities that cannot produce a real
+        // staging feed (daily, local, pr-<N>). Silently falling back to the shared daily feed or
+        // a non-existent SHA-specific darc feed is the bug tracked by
+        // https://github.com/microsoft/aspire/issues/16652. The escape hatches (explicit
+        // overrideStagingFeed, or the StagingChannelEnabled feature flag) are honored inside
+        // IsStagingChannelSynthesisAllowed below.
+        var unavailableReason = GetStagingChannelUnavailableReason();
+        if (unavailableReason is not null)
+        {
+            logger.LogWarning("Refusing to synthesize 'staging' package channel: {Reason}", unavailableReason);
+            return null;
+        }
+
         var stagingQuality = GetStagingQuality(defaultQuality);
         var hasExplicitFeedOverride = !string.IsNullOrEmpty(configuration["overrideStagingFeed"]);
 
@@ -113,7 +144,58 @@ internal class PackagingService(CliExecutionContext executionContext, INuGetPack
             new PackageMapping(PackageMapping.AllPackages, "https://api.nuget.org/v3/index.json")
         }, nuGetPackageCache, configureGlobalPackagesFolder: !useSharedFeed, cliDownloadBaseUrl: "https://aka.ms/dotnet/9/aspire/rc/daily", pinnedVersion: pinnedVersion, logger: logger);
 
+        // Surface the resolved staging routing so users can see what `--channel staging` actually
+        // picked (the "show what was resolved" suggestion from the issue RCA). Pinned version is
+        // optional and only set when configured via stagingPinToCliVersion.
+        logger.LogInformation(
+            "Resolved 'staging' channel: feed={FeedUrl}, quality={Quality}, pinnedVersion={PinnedVersion}",
+            stagingFeedUrl,
+            stagingQuality,
+            pinnedVersion ?? "(none)");
+
         return stagingChannel;
+    }
+
+    /// <inheritdoc />
+    public string? GetStagingChannelUnavailableReason()
+    {
+        if (IsStagingChannelSynthesisAllowed())
+        {
+            return null;
+        }
+
+        return string.Format(
+            CultureInfo.CurrentCulture,
+            PackagingStrings.StagingChannelUnavailableOnDailyCli,
+            executionContext.IdentityChannel);
+    }
+
+    private bool IsStagingChannelSynthesisAllowed()
+    {
+        // Explicit feed override always wins: the caller has told us exactly which feed to use,
+        // so we don't need to infer one from the CLI identity.
+        if (!string.IsNullOrEmpty(configuration["overrideStagingFeed"]))
+        {
+            return true;
+        }
+
+        // The staging feature flag is an explicit developer/test opt-in that predates this
+        // gating; preserve it for back-compat with existing developer workflows.
+        if (features.IsFeatureEnabled(KnownFeatures.StagingChannelEnabled, false))
+        {
+            return true;
+        }
+
+        // Only stable and staging CLI builds can deterministically resolve a staging feed:
+        //   - stable: the SHA-specific darc-pub-microsoft-aspire-<hash> feed exists for the
+        //     stable release branch commit baked into the CLI.
+        //   - staging: dogfoods staging packages (see #17155 which auto-registers the staging
+        //     channel for the staging CLI identity).
+        // For daily, local, and pr-<N> identities, falling back to either the SHA feed (no real
+        // darc feed exists) or the shared daily feed silently resolves daily packages — the
+        // exact bug tracked by https://github.com/microsoft/aspire/issues/16652.
+        return string.Equals(executionContext.IdentityChannel, PackageChannelNames.Stable, StringComparison.OrdinalIgnoreCase)
+            || string.Equals(executionContext.IdentityChannel, PackageChannelNames.Staging, StringComparison.OrdinalIgnoreCase);
     }
 
     private string? GetStagingFeedUrl(bool useSharedFeed)

--- a/src/Aspire.Cli/Packaging/PackagingService.cs
+++ b/src/Aspire.Cli/Packaging/PackagingService.cs
@@ -99,9 +99,9 @@ internal class PackagingService(CliExecutionContext executionContext, INuGetPack
         // dogfood staging packages even before a project-level channel pin exists, and
         // callers that already resolved a staging channel from another project directory
         // need the channel materialized before they can match it below.
-        var stagingChannelConfigured = string.Equals(configuration["channel"], PackageChannelNames.Staging, StringComparison.OrdinalIgnoreCase);
-        var stagingChannelRequested = string.Equals(requestedChannelName, PackageChannelNames.Staging, StringComparison.OrdinalIgnoreCase);
-        var stagingIdentityChannel = string.Equals(executionContext.IdentityChannel, PackageChannelNames.Staging, StringComparison.OrdinalIgnoreCase);
+        var stagingChannelConfigured = string.Equals(configuration["channel"], PackageChannelNames.Staging, StringComparisons.ChannelName);
+        var stagingChannelRequested = string.Equals(requestedChannelName, PackageChannelNames.Staging, StringComparisons.ChannelName);
+        var stagingIdentityChannel = string.Equals(executionContext.IdentityChannel, PackageChannelNames.Staging, StringComparisons.ChannelName);
         var stagingFeatureEnabled = features.IsFeatureEnabled(KnownFeatures.StagingChannelEnabled, false);
         if (stagingFeatureEnabled || stagingChannelConfigured || stagingChannelRequested || stagingIdentityChannel)
         {
@@ -231,8 +231,8 @@ internal class PackagingService(CliExecutionContext executionContext, INuGetPack
         // For daily, local, and pr-<N> identities, falling back to either the SHA feed (no real
         // darc feed exists) or the shared daily feed silently resolves daily packages — the
         // exact bug tracked by https://github.com/microsoft/aspire/issues/16652.
-        return string.Equals(executionContext.IdentityChannel, PackageChannelNames.Stable, StringComparison.OrdinalIgnoreCase)
-            || string.Equals(executionContext.IdentityChannel, PackageChannelNames.Staging, StringComparison.OrdinalIgnoreCase);
+        return string.Equals(executionContext.IdentityChannel, PackageChannelNames.Stable, StringComparisons.ChannelName)
+            || string.Equals(executionContext.IdentityChannel, PackageChannelNames.Staging, StringComparisons.ChannelName);
     }
 
     private string? GetStagingFeedUrl(bool useSharedFeed)

--- a/src/Aspire.Cli/Packaging/PackagingService.cs
+++ b/src/Aspire.Cli/Packaging/PackagingService.cs
@@ -36,6 +36,21 @@ internal interface IPackagingService
 
 internal class PackagingService(CliExecutionContext executionContext, INuGetPackageCache nuGetPackageCache, IFeatures features, IConfiguration configuration, ILogger<PackagingService> logger) : IPackagingService
 {
+    // Cached result of the staging-channel availability check. The inputs (CLI identity,
+    // overrideStagingFeed, StagingChannelEnabled feature) are effectively static for the
+    // process lifetime, so computing this once avoids re-formatting the localized reason
+    // string on every GetChannelsAsync call (callers fan out across NewCommand,
+    // UpdateCommand, IntegrationPackageSearchService, NuGetPackagePrefetcher, etc.).
+    private Lazy<string?>? _stagingUnavailableReasonCache;
+
+    // One-shot guards so the refusal warning / successful-resolution info line are emitted
+    // at most once per CLI process instead of on every GetChannelsAsync invocation. Many
+    // commands (and the background NuGetPackagePrefetcher) call GetChannelsAsync repeatedly;
+    // logging on each call produced excessive noise — particularly the refusal warning when
+    // a project's aspire.config.json pins `channel: staging` on a daily/local CLI.
+    private int _stagingRefusalLogged;
+    private int _stagingResolutionLogged;
+
     public Task<IEnumerable<PackageChannel>> GetChannelsAsync(CancellationToken cancellationToken = default, string? requestedChannelName = null)
     {
         var defaultChannel = PackageChannel.CreateImplicitChannel(nuGetPackageCache, logger);
@@ -116,7 +131,10 @@ internal class PackagingService(CliExecutionContext executionContext, INuGetPack
         var unavailableReason = GetStagingChannelUnavailableReason();
         if (unavailableReason is not null)
         {
-            logger.LogWarning("Refusing to synthesize 'staging' package channel: {Reason}", unavailableReason);
+            if (Interlocked.Exchange(ref _stagingRefusalLogged, 1) == 0)
+            {
+                logger.LogWarning("Refusing to synthesize 'staging' package channel: {Reason}", unavailableReason);
+            }
             return null;
         }
 
@@ -146,18 +164,37 @@ internal class PackagingService(CliExecutionContext executionContext, INuGetPack
 
         // Surface the resolved staging routing so users can see what `--channel staging` actually
         // picked (the "show what was resolved" suggestion from the issue RCA). Pinned version is
-        // optional and only set when configured via stagingPinToCliVersion.
-        logger.LogInformation(
-            "Resolved 'staging' channel: feed={FeedUrl}, quality={Quality}, pinnedVersion={PinnedVersion}",
-            stagingFeedUrl,
-            stagingQuality,
-            pinnedVersion ?? "(none)");
+        // optional and only set when configured via stagingPinToCliVersion. Emitted once per
+        // process to avoid repeating on every GetChannelsAsync call.
+        if (Interlocked.Exchange(ref _stagingResolutionLogged, 1) == 0)
+        {
+            logger.LogInformation(
+                "Resolved 'staging' channel: feed={FeedUrl}, quality={Quality}, pinnedVersion={PinnedVersion}",
+                stagingFeedUrl,
+                stagingQuality,
+                pinnedVersion ?? "(none)");
+        }
 
         return stagingChannel;
     }
 
     /// <inheritdoc />
     public string? GetStagingChannelUnavailableReason()
+    {
+        // Cache the (possibly null) reason for the process lifetime. Lazy<T> handles the
+        // double-check locking so concurrent first callers don't both pay the format cost.
+        var cache = _stagingUnavailableReasonCache;
+        if (cache is null)
+        {
+            cache = new Lazy<string?>(ComputeStagingChannelUnavailableReason, isThreadSafe: true);
+            Interlocked.CompareExchange(ref _stagingUnavailableReasonCache, cache, null);
+            cache = _stagingUnavailableReasonCache;
+        }
+
+        return cache!.Value;
+    }
+
+    private string? ComputeStagingChannelUnavailableReason()
     {
         if (IsStagingChannelSynthesisAllowed())
         {

--- a/src/Aspire.Cli/Packaging/PackagingService.cs
+++ b/src/Aspire.Cli/Packaging/PackagingService.cs
@@ -34,14 +34,30 @@ internal interface IPackagingService
     string? GetStagingChannelUnavailableReason();
 }
 
-internal class PackagingService(CliExecutionContext executionContext, INuGetPackageCache nuGetPackageCache, IFeatures features, IConfiguration configuration, ILogger<PackagingService> logger) : IPackagingService
+internal class PackagingService : IPackagingService
 {
+    private readonly CliExecutionContext _executionContext;
+    private readonly INuGetPackageCache _nuGetPackageCache;
+    private readonly IFeatures _features;
+    private readonly IConfiguration _configuration;
+    private readonly ILogger<PackagingService> _logger;
+
     // Cached result of the staging-channel availability check. The inputs (CLI identity,
     // overrideStagingFeed, StagingChannelEnabled feature) are effectively static for the
     // process lifetime, so computing this once avoids re-formatting the localized reason
     // string on every GetChannelsAsync call (callers fan out across NewCommand,
     // UpdateCommand, IntegrationPackageSearchService, NuGetPackagePrefetcher, etc.).
-    private Lazy<string?>? _stagingUnavailableReasonCache;
+    private readonly Lazy<string?> _stagingUnavailableReasonCache;
+
+    public PackagingService(CliExecutionContext executionContext, INuGetPackageCache nuGetPackageCache, IFeatures features, IConfiguration configuration, ILogger<PackagingService> logger)
+    {
+        _executionContext = executionContext;
+        _nuGetPackageCache = nuGetPackageCache;
+        _features = features;
+        _configuration = configuration;
+        _logger = logger;
+        _stagingUnavailableReasonCache = new Lazy<string?>(ComputeStagingChannelUnavailableReason);
+    }
 
     // One-shot guards so the refusal warning / successful-resolution info line are emitted
     // at most once per CLI process instead of on every GetChannelsAsync invocation. Many
@@ -53,18 +69,18 @@ internal class PackagingService(CliExecutionContext executionContext, INuGetPack
 
     public Task<IEnumerable<PackageChannel>> GetChannelsAsync(CancellationToken cancellationToken = default, string? requestedChannelName = null)
     {
-        var defaultChannel = PackageChannel.CreateImplicitChannel(nuGetPackageCache, logger);
+        var defaultChannel = PackageChannel.CreateImplicitChannel(_nuGetPackageCache, _logger);
         
         var stableChannel = PackageChannel.CreateExplicitChannel(PackageChannelNames.Stable, PackageChannelQuality.Stable, new[]
         {
             new PackageMapping(PackageMapping.AllPackages, "https://api.nuget.org/v3/index.json")
-        }, nuGetPackageCache, cliDownloadBaseUrl: "https://aka.ms/dotnet/9/aspire/ga/daily", logger: logger);
+        }, _nuGetPackageCache, cliDownloadBaseUrl: "https://aka.ms/dotnet/9/aspire/ga/daily", logger: _logger);
 
         var dailyChannel = PackageChannel.CreateExplicitChannel(PackageChannelNames.Daily, PackageChannelQuality.Prerelease, new[]
         {
             new PackageMapping("Aspire*", "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet9/nuget/v3/index.json"),
             new PackageMapping(PackageMapping.AllPackages, "https://api.nuget.org/v3/index.json")
-        }, nuGetPackageCache, cliDownloadBaseUrl: "https://aka.ms/dotnet/9/aspire/daily", logger: logger);
+        }, _nuGetPackageCache, cliDownloadBaseUrl: "https://aka.ms/dotnet/9/aspire/daily", logger: _logger);
 
         var prPackageChannels = new List<PackageChannel>();
 
@@ -72,9 +88,9 @@ internal class PackagingService(CliExecutionContext executionContext, INuGetPack
         // intermediate directory structure which may not exist in some
         // contexts (e.g. in our Codespace where we have the CLI on the 
         // path but not in the $HOME/.aspire/bin folder).
-        if (executionContext.HivesDirectory.Exists)
+        if (_executionContext.HivesDirectory.Exists)
         {
-            var prHives = executionContext.HivesDirectory.GetDirectories();
+            var prHives = _executionContext.HivesDirectory.GetDirectories();
             foreach (var prHive in prHives)
             {
                 // The packages subdirectory contains the actual .nupkg files
@@ -87,7 +103,7 @@ internal class PackagingService(CliExecutionContext executionContext, INuGetPack
                 {
                     new PackageMapping("Aspire*", packagesPath),
                     new PackageMapping(PackageMapping.AllPackages, "https://api.nuget.org/v3/index.json")
-                }, nuGetPackageCache, pinnedVersion: pinnedVersion, logger: logger);
+                }, _nuGetPackageCache, pinnedVersion: pinnedVersion, logger: _logger);
 
                 prPackageChannels.Add(prChannel);
             }
@@ -99,10 +115,10 @@ internal class PackagingService(CliExecutionContext executionContext, INuGetPack
         // dogfood staging packages even before a project-level channel pin exists, and
         // callers that already resolved a staging channel from another project directory
         // need the channel materialized before they can match it below.
-        var stagingChannelConfigured = string.Equals(configuration["channel"], PackageChannelNames.Staging, StringComparisons.ChannelName);
+        var stagingChannelConfigured = string.Equals(_configuration["channel"], PackageChannelNames.Staging, StringComparisons.ChannelName);
         var stagingChannelRequested = string.Equals(requestedChannelName, PackageChannelNames.Staging, StringComparisons.ChannelName);
-        var stagingIdentityChannel = string.Equals(executionContext.IdentityChannel, PackageChannelNames.Staging, StringComparisons.ChannelName);
-        var stagingFeatureEnabled = features.IsFeatureEnabled(KnownFeatures.StagingChannelEnabled, false);
+        var stagingIdentityChannel = string.Equals(_executionContext.IdentityChannel, PackageChannelNames.Staging, StringComparisons.ChannelName);
+        var stagingFeatureEnabled = _features.IsFeatureEnabled(KnownFeatures.StagingChannelEnabled, false);
         if (stagingFeatureEnabled || stagingChannelConfigured || stagingChannelRequested || stagingIdentityChannel)
         {
             var defaultQuality = stagingChannelConfigured || stagingChannelRequested || stagingIdentityChannel ? PackageChannelQuality.Both : PackageChannelQuality.Stable;
@@ -133,13 +149,13 @@ internal class PackagingService(CliExecutionContext executionContext, INuGetPack
         {
             if (Interlocked.Exchange(ref _stagingRefusalLogged, 1) == 0)
             {
-                logger.LogWarning("Refusing to synthesize 'staging' package channel: {Reason}", unavailableReason);
+                _logger.LogWarning("Refusing to synthesize 'staging' package channel: {Reason}", unavailableReason);
             }
             return null;
         }
 
         var stagingQuality = GetStagingQuality(defaultQuality);
-        var hasExplicitFeedOverride = !string.IsNullOrEmpty(configuration["overrideStagingFeed"]);
+        var hasExplicitFeedOverride = !string.IsNullOrEmpty(_configuration["overrideStagingFeed"]);
 
         // When quality is Prerelease or Both and no explicit feed override is set,
         // use the shared daily feed instead of the SHA-specific feed. SHA-specific
@@ -160,7 +176,7 @@ internal class PackagingService(CliExecutionContext executionContext, INuGetPack
         {
             new PackageMapping("Aspire*", stagingFeedUrl),
             new PackageMapping(PackageMapping.AllPackages, "https://api.nuget.org/v3/index.json")
-        }, nuGetPackageCache, configureGlobalPackagesFolder: !useSharedFeed, cliDownloadBaseUrl: "https://aka.ms/dotnet/9/aspire/rc/daily", pinnedVersion: pinnedVersion, logger: logger);
+        }, _nuGetPackageCache, configureGlobalPackagesFolder: !useSharedFeed, cliDownloadBaseUrl: "https://aka.ms/dotnet/9/aspire/rc/daily", pinnedVersion: pinnedVersion, logger: _logger);
 
         // Surface the resolved staging routing so users can see what `--channel staging` actually
         // picked (the "show what was resolved" suggestion from the issue RCA). Pinned version is
@@ -168,7 +184,7 @@ internal class PackagingService(CliExecutionContext executionContext, INuGetPack
         // process to avoid repeating on every GetChannelsAsync call.
         if (Interlocked.Exchange(ref _stagingResolutionLogged, 1) == 0)
         {
-            logger.LogInformation(
+            _logger.LogInformation(
                 "Resolved 'staging' channel: feed={FeedUrl}, quality={Quality}, pinnedVersion={PinnedVersion}",
                 stagingFeedUrl,
                 stagingQuality,
@@ -179,20 +195,7 @@ internal class PackagingService(CliExecutionContext executionContext, INuGetPack
     }
 
     /// <inheritdoc />
-    public string? GetStagingChannelUnavailableReason()
-    {
-        // Cache the (possibly null) reason for the process lifetime. Lazy<T> handles the
-        // double-check locking so concurrent first callers don't both pay the format cost.
-        var cache = _stagingUnavailableReasonCache;
-        if (cache is null)
-        {
-            cache = new Lazy<string?>(ComputeStagingChannelUnavailableReason, isThreadSafe: true);
-            Interlocked.CompareExchange(ref _stagingUnavailableReasonCache, cache, null);
-            cache = _stagingUnavailableReasonCache;
-        }
-
-        return cache!.Value;
-    }
+    public string? GetStagingChannelUnavailableReason() => _stagingUnavailableReasonCache.Value;
 
     private string? ComputeStagingChannelUnavailableReason()
     {
@@ -204,21 +207,21 @@ internal class PackagingService(CliExecutionContext executionContext, INuGetPack
         return string.Format(
             CultureInfo.CurrentCulture,
             PackagingStrings.StagingChannelUnavailableOnDailyCli,
-            executionContext.IdentityChannel);
+            _executionContext.IdentityChannel);
     }
 
     private bool IsStagingChannelSynthesisAllowed()
     {
         // Explicit feed override always wins: the caller has told us exactly which feed to use,
         // so we don't need to infer one from the CLI identity.
-        if (!string.IsNullOrEmpty(configuration["overrideStagingFeed"]))
+        if (!string.IsNullOrEmpty(_configuration["overrideStagingFeed"]))
         {
             return true;
         }
 
         // The staging feature flag is an explicit developer/test opt-in that predates this
         // gating; preserve it for back-compat with existing developer workflows.
-        if (features.IsFeatureEnabled(KnownFeatures.StagingChannelEnabled, false))
+        if (_features.IsFeatureEnabled(KnownFeatures.StagingChannelEnabled, false))
         {
             return true;
         }
@@ -231,14 +234,14 @@ internal class PackagingService(CliExecutionContext executionContext, INuGetPack
         // For daily, local, and pr-<N> identities, falling back to either the SHA feed (no real
         // darc feed exists) or the shared daily feed silently resolves daily packages — the
         // exact bug tracked by https://github.com/microsoft/aspire/issues/16652.
-        return string.Equals(executionContext.IdentityChannel, PackageChannelNames.Stable, StringComparisons.ChannelName)
-            || string.Equals(executionContext.IdentityChannel, PackageChannelNames.Staging, StringComparisons.ChannelName);
+        return string.Equals(_executionContext.IdentityChannel, PackageChannelNames.Stable, StringComparisons.ChannelName)
+            || string.Equals(_executionContext.IdentityChannel, PackageChannelNames.Staging, StringComparisons.ChannelName);
     }
 
     private string? GetStagingFeedUrl(bool useSharedFeed)
     {
-        // Check for configuration override first
-        var overrideFeed = configuration["overrideStagingFeed"];
+        // Check for _configuration override first
+        var overrideFeed = _configuration["overrideStagingFeed"];
         if (!string.IsNullOrEmpty(overrideFeed))
         {
             // Validate that the override URL is well-formed
@@ -282,8 +285,8 @@ internal class PackagingService(CliExecutionContext executionContext, INuGetPack
 
     private PackageChannelQuality GetStagingQuality(PackageChannelQuality defaultQuality)
     {
-        // Check for configuration override
-        var overrideQuality = configuration["overrideStagingQuality"];
+        // Check for _configuration override
+        var overrideQuality = _configuration["overrideStagingQuality"];
         if (!string.IsNullOrEmpty(overrideQuality))
         {
             // Try to parse the quality value (case-insensitive)
@@ -301,7 +304,7 @@ internal class PackagingService(CliExecutionContext executionContext, INuGetPack
     private string? GetStagingPinnedVersion(bool useSharedFeed)
     {
         // Only pin versions when using the shared feed and the config flag is set
-        var pinToCliVersion = configuration["stagingPinToCliVersion"];
+        var pinToCliVersion = _configuration["stagingPinToCliVersion"];
         if (!useSharedFeed || !string.Equals(pinToCliVersion, "true", StringComparison.OrdinalIgnoreCase))
         {
             return null;

--- a/src/Aspire.Cli/Packaging/PackagingService.cs
+++ b/src/Aspire.Cli/Packaging/PackagingService.cs
@@ -36,6 +36,12 @@ internal interface IPackagingService
 
 internal class PackagingService : IPackagingService
 {
+    // Configuration key used to override the staging feed URL. When non-empty,
+    // PackagingService treats staging as available regardless of the CLI's
+    // identity channel (see IsStagingChannelSynthesisAllowed). Surfaced from
+    // tests via InternalsVisibleTo so a single literal change can't drift.
+    internal const string OverrideStagingFeedConfigKey = "overrideStagingFeed";
+
     private readonly CliExecutionContext _executionContext;
     private readonly INuGetPackageCache _nuGetPackageCache;
     private readonly IFeatures _features;
@@ -155,7 +161,7 @@ internal class PackagingService : IPackagingService
         }
 
         var stagingQuality = GetStagingQuality(defaultQuality);
-        var hasExplicitFeedOverride = !string.IsNullOrEmpty(_configuration["overrideStagingFeed"]);
+        var hasExplicitFeedOverride = !string.IsNullOrEmpty(_configuration[OverrideStagingFeedConfigKey]);
 
         // When quality is Prerelease or Both and no explicit feed override is set,
         // use the shared daily feed instead of the SHA-specific feed. SHA-specific
@@ -214,7 +220,7 @@ internal class PackagingService : IPackagingService
     {
         // Explicit feed override always wins: the caller has told us exactly which feed to use,
         // so we don't need to infer one from the CLI identity.
-        if (!string.IsNullOrEmpty(_configuration["overrideStagingFeed"]))
+        if (!string.IsNullOrEmpty(_configuration[OverrideStagingFeedConfigKey]))
         {
             return true;
         }
@@ -241,7 +247,7 @@ internal class PackagingService : IPackagingService
     private string? GetStagingFeedUrl(bool useSharedFeed)
     {
         // Check for _configuration override first
-        var overrideFeed = _configuration["overrideStagingFeed"];
+        var overrideFeed = _configuration[OverrideStagingFeedConfigKey];
         if (!string.IsNullOrEmpty(overrideFeed))
         {
             // Validate that the override URL is well-formed

--- a/src/Aspire.Cli/Projects/PrebuiltAppHostServer.cs
+++ b/src/Aspire.Cli/Projects/PrebuiltAppHostServer.cs
@@ -459,10 +459,40 @@ internal sealed class PrebuiltAppHostServer : IAppHostServerProject
     }
 
     /// <summary>
+    /// Throws when the caller asked for the staging channel but the running CLI's packaging
+    /// service refuses to synthesize one (daily/local/pr-<c>N</c> identity without
+    /// <c>overrideStagingFeed</c> or the <c>StagingChannelEnabled</c> feature flag). Surfaces
+    /// the same actionable reason the <c>update</c> and <c>new</c> commands display so the
+    /// bundled AppHost restore path doesn't silently downgrade to the daily feed.
+    /// </summary>
+    private void ThrowIfStagingUnavailable(string? requestedChannel)
+    {
+        if (!string.Equals(requestedChannel, PackageChannelNames.Staging, StringComparison.OrdinalIgnoreCase))
+        {
+            return;
+        }
+
+        var reason = _packagingService.GetStagingChannelUnavailableReason();
+        if (reason is not null)
+        {
+            throw new InvalidOperationException(reason);
+        }
+    }
+
+    /// <summary>
     /// Gets NuGet sources from the resolved channel for bundled restore.
     /// </summary>
-    private async Task<IEnumerable<string>?> GetNuGetSourcesAsync(string? requestedChannel, CancellationToken cancellationToken)
+    internal async Task<IEnumerable<string>?> GetNuGetSourcesAsync(string? requestedChannel, CancellationToken cancellationToken)
     {
+        // Refuse to silently downgrade staging restores to the shared daily feed when the running
+        // CLI cannot synthesize a real staging channel (daily/local/pr-<N>). PackagingService omits
+        // the staging channel in that case; without this check the lookup below falls through to
+        // "all explicit channels" — which on a daily CLI is the shared daily feed — and restore
+        // silently succeeds against the wrong feed. Surfacing the actionable
+        // GetStagingChannelUnavailableReason() mirrors UpdateCommand/NewCommand and closes the
+        // bundled-AppHost arm of https://github.com/microsoft/aspire/issues/16652.
+        ThrowIfStagingUnavailable(requestedChannel);
+
         var sources = new List<string>();
 
         try
@@ -504,12 +534,17 @@ internal sealed class PrebuiltAppHostServer : IAppHostServerProject
         return sources.Count > 0 ? sources : null;
     }
 
-    private async Task<TemporaryNuGetConfig?> TryCreateTemporaryNuGetConfigAsync(string? requestedChannel, CancellationToken cancellationToken)
+    internal async Task<TemporaryNuGetConfig?> TryCreateTemporaryNuGetConfigAsync(string? requestedChannel, CancellationToken cancellationToken)
     {
         if (string.IsNullOrEmpty(requestedChannel))
         {
             return null;
         }
+
+        // Same staging refusal as GetNuGetSourcesAsync: if the CLI cannot synthesize staging,
+        // surface the actionable reason instead of returning null and letting restore proceed
+        // against whichever sources the caller resolved separately.
+        ThrowIfStagingUnavailable(requestedChannel);
 
         var channels = await _packagingService.GetChannelsAsync(cancellationToken, requestedChannel);
         var channel = channels.FirstOrDefault(c =>

--- a/src/Aspire.Cli/Projects/PrebuiltAppHostServer.cs
+++ b/src/Aspire.Cli/Projects/PrebuiltAppHostServer.cs
@@ -467,7 +467,7 @@ internal sealed class PrebuiltAppHostServer : IAppHostServerProject
     /// </summary>
     private void ThrowIfStagingUnavailable(string? requestedChannel)
     {
-        if (!string.Equals(requestedChannel, PackageChannelNames.Staging, StringComparison.OrdinalIgnoreCase))
+        if (!string.Equals(requestedChannel, PackageChannelNames.Staging, StringComparisons.ChannelName))
         {
             return;
         }
@@ -502,7 +502,7 @@ internal sealed class PrebuiltAppHostServer : IAppHostServerProject
             IEnumerable<PackageChannel> explicitChannels;
             if (!string.IsNullOrEmpty(requestedChannel))
             {
-                var matchingChannel = channels.FirstOrDefault(c => string.Equals(c.Name, requestedChannel, StringComparison.OrdinalIgnoreCase));
+                var matchingChannel = channels.FirstOrDefault(c => string.Equals(c.Name, requestedChannel, StringComparisons.ChannelName));
                 explicitChannels = matchingChannel is not null ? [matchingChannel] : channels.Where(c => c.Type == PackageChannelType.Explicit);
             }
             else
@@ -550,7 +550,7 @@ internal sealed class PrebuiltAppHostServer : IAppHostServerProject
         var channel = channels.FirstOrDefault(c =>
             c.Type == PackageChannelType.Explicit &&
             c.Mappings is { Length: > 0 } &&
-            string.Equals(c.Name, requestedChannel, StringComparison.OrdinalIgnoreCase));
+            string.Equals(c.Name, requestedChannel, StringComparisons.ChannelName));
 
         if (channel?.Mappings is null)
         {
@@ -564,7 +564,7 @@ internal sealed class PrebuiltAppHostServer : IAppHostServerProject
         // regardless of which CLI identity (CliExecutionContext.IdentityChannel) is running.
         // Keying on the resolved channel.Name (rather than the input requestedChannel) is robust
         // to alias/normalization in the channel lookup above.
-        if (string.Equals(channel.Name, PackageChannelNames.Local, StringComparison.OrdinalIgnoreCase))
+        if (string.Equals(channel.Name, PackageChannelNames.Local, StringComparisons.ChannelName))
         {
             return null;
         }

--- a/src/Aspire.Cli/Resources/NewCommandStrings.Designer.cs
+++ b/src/Aspire.Cli/Resources/NewCommandStrings.Designer.cs
@@ -168,5 +168,17 @@ namespace Aspire.Cli.Resources {
                 return ResourceManager.GetString("OutputPathContainsInvalidCharacters", resourceCulture);
             }
         }
+
+        public static string NoPackageChannelsAvailable {
+            get {
+                return ResourceManager.GetString("NoPackageChannelsAvailable", resourceCulture);
+            }
+        }
+
+        public static string NoChannelFoundMatching {
+            get {
+                return ResourceManager.GetString("NoChannelFoundMatching", resourceCulture);
+            }
+        }
     }
 }

--- a/src/Aspire.Cli/Resources/NewCommandStrings.resx
+++ b/src/Aspire.Cli/Resources/NewCommandStrings.resx
@@ -163,4 +163,10 @@
   <data name="OutputPathContainsInvalidCharacters" xml:space="preserve">
     <value>The output path '{0}' contains invalid characters.</value>
   </data>
+  <data name="NoPackageChannelsAvailable" xml:space="preserve">
+    <value>No package channels are available.</value>
+  </data>
+  <data name="NoChannelFoundMatching" xml:space="preserve">
+    <value>No channel found matching '{0}'. Valid options are: {1}.</value>
+  </data>
 </root>

--- a/src/Aspire.Cli/Resources/PackagingStrings.Designer.cs
+++ b/src/Aspire.Cli/Resources/PackagingStrings.Designer.cs
@@ -64,5 +64,14 @@ namespace Aspire.Cli.Resources {
                 return ResourceManager.GetString("BasedOnNuGetConfig", resourceCulture);
             }
         }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The 'staging' channel cannot be resolved from a CLI with identity '{0}'. Daily, local, and per-PR CLI builds do not have a deterministic staging feed. Install a staging or stable Aspire CLI, or set 'overrideStagingFeed' (for example: aspire config set -g overrideStagingFeed &lt;feed-url&gt;) to point at the staging feed you want to use.
+        /// </summary>
+        internal static string StagingChannelUnavailableOnDailyCli {
+            get {
+                return ResourceManager.GetString("StagingChannelUnavailableOnDailyCli", resourceCulture);
+            }
+        }
     }
 }

--- a/src/Aspire.Cli/Resources/PackagingStrings.resx
+++ b/src/Aspire.Cli/Resources/PackagingStrings.resx
@@ -121,4 +121,8 @@
     <value>based on NuGet.config</value>
     <comment>Source details text shown for packages from implicit channel or channels without Aspire* package source mappings</comment>
   </data>
+  <data name="StagingChannelUnavailableOnDailyCli" xml:space="preserve">
+    <value>The 'staging' channel cannot be resolved from a CLI with identity '{0}'. Daily, local, and per-PR CLI builds do not have a deterministic staging feed. Install a staging or stable Aspire CLI, or set 'overrideStagingFeed' (for example: aspire config set -g overrideStagingFeed &lt;feed-url&gt;) to point at the staging feed you want to use.</value>
+    <comment>{0} is the running CLI's baked identity channel (one of daily, local, or pr-N). Shown when --channel staging is requested on a CLI that cannot produce a real staging feed. Tracks https://github.com/microsoft/aspire/issues/16652.</comment>
+  </data>
 </root>

--- a/src/Aspire.Cli/Resources/UpdateCommandStrings.Designer.cs
+++ b/src/Aspire.Cli/Resources/UpdateCommandStrings.Designer.cs
@@ -121,5 +121,6 @@ namespace Aspire.Cli.Resources {
     internal static string SelfOptionDescription => ResourceManager.GetString("SelfOptionDescription", resourceCulture);
     internal static string YesOptionDescription => ResourceManager.GetString("YesOptionDescription", resourceCulture);
     internal static string NuGetConfigDirOptionDescription => ResourceManager.GetString("NuGetConfigDirOptionDescription", resourceCulture);
+    internal static string NoChannelFoundMatching => ResourceManager.GetString("NoChannelFoundMatching", resourceCulture);
     }
 }

--- a/src/Aspire.Cli/Resources/UpdateCommandStrings.resx
+++ b/src/Aspire.Cli/Resources/UpdateCommandStrings.resx
@@ -180,4 +180,7 @@
   <data name="NuGetConfigDirOptionDescription" xml:space="preserve">
     <value>Directory to create or update the NuGet.config file in</value>
   </data>
+  <data name="NoChannelFoundMatching" xml:space="preserve">
+    <value>No channel found matching '{0}'. Valid options are: {1}.</value>
+  </data>
 </root>

--- a/src/Aspire.Cli/Resources/xlf/NewCommandStrings.cs.xlf
+++ b/src/Aspire.Cli/Resources/xlf/NewCommandStrings.cs.xlf
@@ -42,6 +42,16 @@
         <target state="needs-review-translation">Název projektu, který se má vytvořit</target>
         <note />
       </trans-unit>
+      <trans-unit id="NoChannelFoundMatching">
+        <source>No channel found matching '{0}'. Valid options are: {1}.</source>
+        <target state="new">No channel found matching '{0}'. Valid options are: {1}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NoPackageChannelsAvailable">
+        <source>No package channels are available.</source>
+        <target state="new">No package channels are available.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="NonInteractiveTemplateRequired">
         <source>A template must be specified when running in non-interactive mode. Use 'aspire new &lt;template&gt;'.</source>
         <target state="new">A template must be specified when running in non-interactive mode. Use 'aspire new &lt;template&gt;'.</target>

--- a/src/Aspire.Cli/Resources/xlf/NewCommandStrings.de.xlf
+++ b/src/Aspire.Cli/Resources/xlf/NewCommandStrings.de.xlf
@@ -42,6 +42,16 @@
         <target state="needs-review-translation">Der Name des zu erstellenden Projekts.</target>
         <note />
       </trans-unit>
+      <trans-unit id="NoChannelFoundMatching">
+        <source>No channel found matching '{0}'. Valid options are: {1}.</source>
+        <target state="new">No channel found matching '{0}'. Valid options are: {1}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NoPackageChannelsAvailable">
+        <source>No package channels are available.</source>
+        <target state="new">No package channels are available.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="NonInteractiveTemplateRequired">
         <source>A template must be specified when running in non-interactive mode. Use 'aspire new &lt;template&gt;'.</source>
         <target state="new">A template must be specified when running in non-interactive mode. Use 'aspire new &lt;template&gt;'.</target>

--- a/src/Aspire.Cli/Resources/xlf/NewCommandStrings.es.xlf
+++ b/src/Aspire.Cli/Resources/xlf/NewCommandStrings.es.xlf
@@ -42,6 +42,16 @@
         <target state="needs-review-translation">El nombre del proyecto que se va a crear.</target>
         <note />
       </trans-unit>
+      <trans-unit id="NoChannelFoundMatching">
+        <source>No channel found matching '{0}'. Valid options are: {1}.</source>
+        <target state="new">No channel found matching '{0}'. Valid options are: {1}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NoPackageChannelsAvailable">
+        <source>No package channels are available.</source>
+        <target state="new">No package channels are available.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="NonInteractiveTemplateRequired">
         <source>A template must be specified when running in non-interactive mode. Use 'aspire new &lt;template&gt;'.</source>
         <target state="new">A template must be specified when running in non-interactive mode. Use 'aspire new &lt;template&gt;'.</target>

--- a/src/Aspire.Cli/Resources/xlf/NewCommandStrings.fr.xlf
+++ b/src/Aspire.Cli/Resources/xlf/NewCommandStrings.fr.xlf
@@ -42,6 +42,16 @@
         <target state="needs-review-translation">Nom du projet à créer.</target>
         <note />
       </trans-unit>
+      <trans-unit id="NoChannelFoundMatching">
+        <source>No channel found matching '{0}'. Valid options are: {1}.</source>
+        <target state="new">No channel found matching '{0}'. Valid options are: {1}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NoPackageChannelsAvailable">
+        <source>No package channels are available.</source>
+        <target state="new">No package channels are available.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="NonInteractiveTemplateRequired">
         <source>A template must be specified when running in non-interactive mode. Use 'aspire new &lt;template&gt;'.</source>
         <target state="new">A template must be specified when running in non-interactive mode. Use 'aspire new &lt;template&gt;'.</target>

--- a/src/Aspire.Cli/Resources/xlf/NewCommandStrings.it.xlf
+++ b/src/Aspire.Cli/Resources/xlf/NewCommandStrings.it.xlf
@@ -42,6 +42,16 @@
         <target state="needs-review-translation">Nome del progetto da creare.</target>
         <note />
       </trans-unit>
+      <trans-unit id="NoChannelFoundMatching">
+        <source>No channel found matching '{0}'. Valid options are: {1}.</source>
+        <target state="new">No channel found matching '{0}'. Valid options are: {1}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NoPackageChannelsAvailable">
+        <source>No package channels are available.</source>
+        <target state="new">No package channels are available.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="NonInteractiveTemplateRequired">
         <source>A template must be specified when running in non-interactive mode. Use 'aspire new &lt;template&gt;'.</source>
         <target state="new">A template must be specified when running in non-interactive mode. Use 'aspire new &lt;template&gt;'.</target>

--- a/src/Aspire.Cli/Resources/xlf/NewCommandStrings.ja.xlf
+++ b/src/Aspire.Cli/Resources/xlf/NewCommandStrings.ja.xlf
@@ -42,6 +42,16 @@
         <target state="needs-review-translation">作成するプロジェクトの名前。</target>
         <note />
       </trans-unit>
+      <trans-unit id="NoChannelFoundMatching">
+        <source>No channel found matching '{0}'. Valid options are: {1}.</source>
+        <target state="new">No channel found matching '{0}'. Valid options are: {1}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NoPackageChannelsAvailable">
+        <source>No package channels are available.</source>
+        <target state="new">No package channels are available.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="NonInteractiveTemplateRequired">
         <source>A template must be specified when running in non-interactive mode. Use 'aspire new &lt;template&gt;'.</source>
         <target state="new">A template must be specified when running in non-interactive mode. Use 'aspire new &lt;template&gt;'.</target>

--- a/src/Aspire.Cli/Resources/xlf/NewCommandStrings.ko.xlf
+++ b/src/Aspire.Cli/Resources/xlf/NewCommandStrings.ko.xlf
@@ -42,6 +42,16 @@
         <target state="needs-review-translation">만들 프로젝트의 이름입니다.</target>
         <note />
       </trans-unit>
+      <trans-unit id="NoChannelFoundMatching">
+        <source>No channel found matching '{0}'. Valid options are: {1}.</source>
+        <target state="new">No channel found matching '{0}'. Valid options are: {1}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NoPackageChannelsAvailable">
+        <source>No package channels are available.</source>
+        <target state="new">No package channels are available.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="NonInteractiveTemplateRequired">
         <source>A template must be specified when running in non-interactive mode. Use 'aspire new &lt;template&gt;'.</source>
         <target state="new">A template must be specified when running in non-interactive mode. Use 'aspire new &lt;template&gt;'.</target>

--- a/src/Aspire.Cli/Resources/xlf/NewCommandStrings.pl.xlf
+++ b/src/Aspire.Cli/Resources/xlf/NewCommandStrings.pl.xlf
@@ -42,6 +42,16 @@
         <target state="needs-review-translation">Nazwa projektu do utworzenia.</target>
         <note />
       </trans-unit>
+      <trans-unit id="NoChannelFoundMatching">
+        <source>No channel found matching '{0}'. Valid options are: {1}.</source>
+        <target state="new">No channel found matching '{0}'. Valid options are: {1}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NoPackageChannelsAvailable">
+        <source>No package channels are available.</source>
+        <target state="new">No package channels are available.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="NonInteractiveTemplateRequired">
         <source>A template must be specified when running in non-interactive mode. Use 'aspire new &lt;template&gt;'.</source>
         <target state="new">A template must be specified when running in non-interactive mode. Use 'aspire new &lt;template&gt;'.</target>

--- a/src/Aspire.Cli/Resources/xlf/NewCommandStrings.pt-BR.xlf
+++ b/src/Aspire.Cli/Resources/xlf/NewCommandStrings.pt-BR.xlf
@@ -42,6 +42,16 @@
         <target state="needs-review-translation">O nome do projeto a ser criado.</target>
         <note />
       </trans-unit>
+      <trans-unit id="NoChannelFoundMatching">
+        <source>No channel found matching '{0}'. Valid options are: {1}.</source>
+        <target state="new">No channel found matching '{0}'. Valid options are: {1}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NoPackageChannelsAvailable">
+        <source>No package channels are available.</source>
+        <target state="new">No package channels are available.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="NonInteractiveTemplateRequired">
         <source>A template must be specified when running in non-interactive mode. Use 'aspire new &lt;template&gt;'.</source>
         <target state="new">A template must be specified when running in non-interactive mode. Use 'aspire new &lt;template&gt;'.</target>

--- a/src/Aspire.Cli/Resources/xlf/NewCommandStrings.ru.xlf
+++ b/src/Aspire.Cli/Resources/xlf/NewCommandStrings.ru.xlf
@@ -42,6 +42,16 @@
         <target state="needs-review-translation">Имя создаваемого проекта.</target>
         <note />
       </trans-unit>
+      <trans-unit id="NoChannelFoundMatching">
+        <source>No channel found matching '{0}'. Valid options are: {1}.</source>
+        <target state="new">No channel found matching '{0}'. Valid options are: {1}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NoPackageChannelsAvailable">
+        <source>No package channels are available.</source>
+        <target state="new">No package channels are available.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="NonInteractiveTemplateRequired">
         <source>A template must be specified when running in non-interactive mode. Use 'aspire new &lt;template&gt;'.</source>
         <target state="new">A template must be specified when running in non-interactive mode. Use 'aspire new &lt;template&gt;'.</target>

--- a/src/Aspire.Cli/Resources/xlf/NewCommandStrings.tr.xlf
+++ b/src/Aspire.Cli/Resources/xlf/NewCommandStrings.tr.xlf
@@ -42,6 +42,16 @@
         <target state="needs-review-translation">Oluşturulacak projenin adı.</target>
         <note />
       </trans-unit>
+      <trans-unit id="NoChannelFoundMatching">
+        <source>No channel found matching '{0}'. Valid options are: {1}.</source>
+        <target state="new">No channel found matching '{0}'. Valid options are: {1}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NoPackageChannelsAvailable">
+        <source>No package channels are available.</source>
+        <target state="new">No package channels are available.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="NonInteractiveTemplateRequired">
         <source>A template must be specified when running in non-interactive mode. Use 'aspire new &lt;template&gt;'.</source>
         <target state="new">A template must be specified when running in non-interactive mode. Use 'aspire new &lt;template&gt;'.</target>

--- a/src/Aspire.Cli/Resources/xlf/NewCommandStrings.zh-Hans.xlf
+++ b/src/Aspire.Cli/Resources/xlf/NewCommandStrings.zh-Hans.xlf
@@ -42,6 +42,16 @@
         <target state="needs-review-translation">要创建的项目的名称。</target>
         <note />
       </trans-unit>
+      <trans-unit id="NoChannelFoundMatching">
+        <source>No channel found matching '{0}'. Valid options are: {1}.</source>
+        <target state="new">No channel found matching '{0}'. Valid options are: {1}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NoPackageChannelsAvailable">
+        <source>No package channels are available.</source>
+        <target state="new">No package channels are available.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="NonInteractiveTemplateRequired">
         <source>A template must be specified when running in non-interactive mode. Use 'aspire new &lt;template&gt;'.</source>
         <target state="new">A template must be specified when running in non-interactive mode. Use 'aspire new &lt;template&gt;'.</target>

--- a/src/Aspire.Cli/Resources/xlf/NewCommandStrings.zh-Hant.xlf
+++ b/src/Aspire.Cli/Resources/xlf/NewCommandStrings.zh-Hant.xlf
@@ -42,6 +42,16 @@
         <target state="needs-review-translation">要建立專案之名稱。</target>
         <note />
       </trans-unit>
+      <trans-unit id="NoChannelFoundMatching">
+        <source>No channel found matching '{0}'. Valid options are: {1}.</source>
+        <target state="new">No channel found matching '{0}'. Valid options are: {1}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NoPackageChannelsAvailable">
+        <source>No package channels are available.</source>
+        <target state="new">No package channels are available.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="NonInteractiveTemplateRequired">
         <source>A template must be specified when running in non-interactive mode. Use 'aspire new &lt;template&gt;'.</source>
         <target state="new">A template must be specified when running in non-interactive mode. Use 'aspire new &lt;template&gt;'.</target>

--- a/src/Aspire.Cli/Resources/xlf/PackagingStrings.cs.xlf
+++ b/src/Aspire.Cli/Resources/xlf/PackagingStrings.cs.xlf
@@ -7,6 +7,11 @@
         <target state="translated">na základě souboru NuGet.config</target>
         <note>Source details text shown for packages from implicit channel or channels without Aspire* package source mappings</note>
       </trans-unit>
+      <trans-unit id="StagingChannelUnavailableOnDailyCli">
+        <source>The 'staging' channel cannot be resolved from a CLI with identity '{0}'. Daily, local, and per-PR CLI builds do not have a deterministic staging feed. Install a staging or stable Aspire CLI, or set 'overrideStagingFeed' (for example: aspire config set -g overrideStagingFeed &lt;feed-url&gt;) to point at the staging feed you want to use.</source>
+        <target state="new">The 'staging' channel cannot be resolved from a CLI with identity '{0}'. Daily, local, and per-PR CLI builds do not have a deterministic staging feed. Install a staging or stable Aspire CLI, or set 'overrideStagingFeed' (for example: aspire config set -g overrideStagingFeed &lt;feed-url&gt;) to point at the staging feed you want to use.</target>
+        <note>{0} is the running CLI's baked identity channel (one of daily, local, or pr-N). Shown when --channel staging is requested on a CLI that cannot produce a real staging feed. Tracks https://github.com/microsoft/aspire/issues/16652.</note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Aspire.Cli/Resources/xlf/PackagingStrings.de.xlf
+++ b/src/Aspire.Cli/Resources/xlf/PackagingStrings.de.xlf
@@ -7,6 +7,11 @@
         <target state="translated">basierend auf NuGet.config</target>
         <note>Source details text shown for packages from implicit channel or channels without Aspire* package source mappings</note>
       </trans-unit>
+      <trans-unit id="StagingChannelUnavailableOnDailyCli">
+        <source>The 'staging' channel cannot be resolved from a CLI with identity '{0}'. Daily, local, and per-PR CLI builds do not have a deterministic staging feed. Install a staging or stable Aspire CLI, or set 'overrideStagingFeed' (for example: aspire config set -g overrideStagingFeed &lt;feed-url&gt;) to point at the staging feed you want to use.</source>
+        <target state="new">The 'staging' channel cannot be resolved from a CLI with identity '{0}'. Daily, local, and per-PR CLI builds do not have a deterministic staging feed. Install a staging or stable Aspire CLI, or set 'overrideStagingFeed' (for example: aspire config set -g overrideStagingFeed &lt;feed-url&gt;) to point at the staging feed you want to use.</target>
+        <note>{0} is the running CLI's baked identity channel (one of daily, local, or pr-N). Shown when --channel staging is requested on a CLI that cannot produce a real staging feed. Tracks https://github.com/microsoft/aspire/issues/16652.</note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Aspire.Cli/Resources/xlf/PackagingStrings.es.xlf
+++ b/src/Aspire.Cli/Resources/xlf/PackagingStrings.es.xlf
@@ -7,6 +7,11 @@
         <target state="translated">basado en NuGet.config</target>
         <note>Source details text shown for packages from implicit channel or channels without Aspire* package source mappings</note>
       </trans-unit>
+      <trans-unit id="StagingChannelUnavailableOnDailyCli">
+        <source>The 'staging' channel cannot be resolved from a CLI with identity '{0}'. Daily, local, and per-PR CLI builds do not have a deterministic staging feed. Install a staging or stable Aspire CLI, or set 'overrideStagingFeed' (for example: aspire config set -g overrideStagingFeed &lt;feed-url&gt;) to point at the staging feed you want to use.</source>
+        <target state="new">The 'staging' channel cannot be resolved from a CLI with identity '{0}'. Daily, local, and per-PR CLI builds do not have a deterministic staging feed. Install a staging or stable Aspire CLI, or set 'overrideStagingFeed' (for example: aspire config set -g overrideStagingFeed &lt;feed-url&gt;) to point at the staging feed you want to use.</target>
+        <note>{0} is the running CLI's baked identity channel (one of daily, local, or pr-N). Shown when --channel staging is requested on a CLI that cannot produce a real staging feed. Tracks https://github.com/microsoft/aspire/issues/16652.</note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Aspire.Cli/Resources/xlf/PackagingStrings.fr.xlf
+++ b/src/Aspire.Cli/Resources/xlf/PackagingStrings.fr.xlf
@@ -7,6 +7,11 @@
         <target state="translated">basé sur NuGet.config</target>
         <note>Source details text shown for packages from implicit channel or channels without Aspire* package source mappings</note>
       </trans-unit>
+      <trans-unit id="StagingChannelUnavailableOnDailyCli">
+        <source>The 'staging' channel cannot be resolved from a CLI with identity '{0}'. Daily, local, and per-PR CLI builds do not have a deterministic staging feed. Install a staging or stable Aspire CLI, or set 'overrideStagingFeed' (for example: aspire config set -g overrideStagingFeed &lt;feed-url&gt;) to point at the staging feed you want to use.</source>
+        <target state="new">The 'staging' channel cannot be resolved from a CLI with identity '{0}'. Daily, local, and per-PR CLI builds do not have a deterministic staging feed. Install a staging or stable Aspire CLI, or set 'overrideStagingFeed' (for example: aspire config set -g overrideStagingFeed &lt;feed-url&gt;) to point at the staging feed you want to use.</target>
+        <note>{0} is the running CLI's baked identity channel (one of daily, local, or pr-N). Shown when --channel staging is requested on a CLI that cannot produce a real staging feed. Tracks https://github.com/microsoft/aspire/issues/16652.</note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Aspire.Cli/Resources/xlf/PackagingStrings.it.xlf
+++ b/src/Aspire.Cli/Resources/xlf/PackagingStrings.it.xlf
@@ -7,6 +7,11 @@
         <target state="translated">basato su NuGet.config</target>
         <note>Source details text shown for packages from implicit channel or channels without Aspire* package source mappings</note>
       </trans-unit>
+      <trans-unit id="StagingChannelUnavailableOnDailyCli">
+        <source>The 'staging' channel cannot be resolved from a CLI with identity '{0}'. Daily, local, and per-PR CLI builds do not have a deterministic staging feed. Install a staging or stable Aspire CLI, or set 'overrideStagingFeed' (for example: aspire config set -g overrideStagingFeed &lt;feed-url&gt;) to point at the staging feed you want to use.</source>
+        <target state="new">The 'staging' channel cannot be resolved from a CLI with identity '{0}'. Daily, local, and per-PR CLI builds do not have a deterministic staging feed. Install a staging or stable Aspire CLI, or set 'overrideStagingFeed' (for example: aspire config set -g overrideStagingFeed &lt;feed-url&gt;) to point at the staging feed you want to use.</target>
+        <note>{0} is the running CLI's baked identity channel (one of daily, local, or pr-N). Shown when --channel staging is requested on a CLI that cannot produce a real staging feed. Tracks https://github.com/microsoft/aspire/issues/16652.</note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Aspire.Cli/Resources/xlf/PackagingStrings.ja.xlf
+++ b/src/Aspire.Cli/Resources/xlf/PackagingStrings.ja.xlf
@@ -7,6 +7,11 @@
         <target state="translated">NuGet.config に基づきます</target>
         <note>Source details text shown for packages from implicit channel or channels without Aspire* package source mappings</note>
       </trans-unit>
+      <trans-unit id="StagingChannelUnavailableOnDailyCli">
+        <source>The 'staging' channel cannot be resolved from a CLI with identity '{0}'. Daily, local, and per-PR CLI builds do not have a deterministic staging feed. Install a staging or stable Aspire CLI, or set 'overrideStagingFeed' (for example: aspire config set -g overrideStagingFeed &lt;feed-url&gt;) to point at the staging feed you want to use.</source>
+        <target state="new">The 'staging' channel cannot be resolved from a CLI with identity '{0}'. Daily, local, and per-PR CLI builds do not have a deterministic staging feed. Install a staging or stable Aspire CLI, or set 'overrideStagingFeed' (for example: aspire config set -g overrideStagingFeed &lt;feed-url&gt;) to point at the staging feed you want to use.</target>
+        <note>{0} is the running CLI's baked identity channel (one of daily, local, or pr-N). Shown when --channel staging is requested on a CLI that cannot produce a real staging feed. Tracks https://github.com/microsoft/aspire/issues/16652.</note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Aspire.Cli/Resources/xlf/PackagingStrings.ko.xlf
+++ b/src/Aspire.Cli/Resources/xlf/PackagingStrings.ko.xlf
@@ -7,6 +7,11 @@
         <target state="translated">NuGet.config 기반</target>
         <note>Source details text shown for packages from implicit channel or channels without Aspire* package source mappings</note>
       </trans-unit>
+      <trans-unit id="StagingChannelUnavailableOnDailyCli">
+        <source>The 'staging' channel cannot be resolved from a CLI with identity '{0}'. Daily, local, and per-PR CLI builds do not have a deterministic staging feed. Install a staging or stable Aspire CLI, or set 'overrideStagingFeed' (for example: aspire config set -g overrideStagingFeed &lt;feed-url&gt;) to point at the staging feed you want to use.</source>
+        <target state="new">The 'staging' channel cannot be resolved from a CLI with identity '{0}'. Daily, local, and per-PR CLI builds do not have a deterministic staging feed. Install a staging or stable Aspire CLI, or set 'overrideStagingFeed' (for example: aspire config set -g overrideStagingFeed &lt;feed-url&gt;) to point at the staging feed you want to use.</target>
+        <note>{0} is the running CLI's baked identity channel (one of daily, local, or pr-N). Shown when --channel staging is requested on a CLI that cannot produce a real staging feed. Tracks https://github.com/microsoft/aspire/issues/16652.</note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Aspire.Cli/Resources/xlf/PackagingStrings.pl.xlf
+++ b/src/Aspire.Cli/Resources/xlf/PackagingStrings.pl.xlf
@@ -7,6 +7,11 @@
         <target state="translated">na podstawie pliku NuGet.config</target>
         <note>Source details text shown for packages from implicit channel or channels without Aspire* package source mappings</note>
       </trans-unit>
+      <trans-unit id="StagingChannelUnavailableOnDailyCli">
+        <source>The 'staging' channel cannot be resolved from a CLI with identity '{0}'. Daily, local, and per-PR CLI builds do not have a deterministic staging feed. Install a staging or stable Aspire CLI, or set 'overrideStagingFeed' (for example: aspire config set -g overrideStagingFeed &lt;feed-url&gt;) to point at the staging feed you want to use.</source>
+        <target state="new">The 'staging' channel cannot be resolved from a CLI with identity '{0}'. Daily, local, and per-PR CLI builds do not have a deterministic staging feed. Install a staging or stable Aspire CLI, or set 'overrideStagingFeed' (for example: aspire config set -g overrideStagingFeed &lt;feed-url&gt;) to point at the staging feed you want to use.</target>
+        <note>{0} is the running CLI's baked identity channel (one of daily, local, or pr-N). Shown when --channel staging is requested on a CLI that cannot produce a real staging feed. Tracks https://github.com/microsoft/aspire/issues/16652.</note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Aspire.Cli/Resources/xlf/PackagingStrings.pt-BR.xlf
+++ b/src/Aspire.Cli/Resources/xlf/PackagingStrings.pt-BR.xlf
@@ -7,6 +7,11 @@
         <target state="translated">com base em NuGet.config</target>
         <note>Source details text shown for packages from implicit channel or channels without Aspire* package source mappings</note>
       </trans-unit>
+      <trans-unit id="StagingChannelUnavailableOnDailyCli">
+        <source>The 'staging' channel cannot be resolved from a CLI with identity '{0}'. Daily, local, and per-PR CLI builds do not have a deterministic staging feed. Install a staging or stable Aspire CLI, or set 'overrideStagingFeed' (for example: aspire config set -g overrideStagingFeed &lt;feed-url&gt;) to point at the staging feed you want to use.</source>
+        <target state="new">The 'staging' channel cannot be resolved from a CLI with identity '{0}'. Daily, local, and per-PR CLI builds do not have a deterministic staging feed. Install a staging or stable Aspire CLI, or set 'overrideStagingFeed' (for example: aspire config set -g overrideStagingFeed &lt;feed-url&gt;) to point at the staging feed you want to use.</target>
+        <note>{0} is the running CLI's baked identity channel (one of daily, local, or pr-N). Shown when --channel staging is requested on a CLI that cannot produce a real staging feed. Tracks https://github.com/microsoft/aspire/issues/16652.</note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Aspire.Cli/Resources/xlf/PackagingStrings.ru.xlf
+++ b/src/Aspire.Cli/Resources/xlf/PackagingStrings.ru.xlf
@@ -7,6 +7,11 @@
         <target state="translated">на основе NuGet.config</target>
         <note>Source details text shown for packages from implicit channel or channels without Aspire* package source mappings</note>
       </trans-unit>
+      <trans-unit id="StagingChannelUnavailableOnDailyCli">
+        <source>The 'staging' channel cannot be resolved from a CLI with identity '{0}'. Daily, local, and per-PR CLI builds do not have a deterministic staging feed. Install a staging or stable Aspire CLI, or set 'overrideStagingFeed' (for example: aspire config set -g overrideStagingFeed &lt;feed-url&gt;) to point at the staging feed you want to use.</source>
+        <target state="new">The 'staging' channel cannot be resolved from a CLI with identity '{0}'. Daily, local, and per-PR CLI builds do not have a deterministic staging feed. Install a staging or stable Aspire CLI, or set 'overrideStagingFeed' (for example: aspire config set -g overrideStagingFeed &lt;feed-url&gt;) to point at the staging feed you want to use.</target>
+        <note>{0} is the running CLI's baked identity channel (one of daily, local, or pr-N). Shown when --channel staging is requested on a CLI that cannot produce a real staging feed. Tracks https://github.com/microsoft/aspire/issues/16652.</note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Aspire.Cli/Resources/xlf/PackagingStrings.tr.xlf
+++ b/src/Aspire.Cli/Resources/xlf/PackagingStrings.tr.xlf
@@ -7,6 +7,11 @@
         <target state="translated">NuGet.config tabanlı</target>
         <note>Source details text shown for packages from implicit channel or channels without Aspire* package source mappings</note>
       </trans-unit>
+      <trans-unit id="StagingChannelUnavailableOnDailyCli">
+        <source>The 'staging' channel cannot be resolved from a CLI with identity '{0}'. Daily, local, and per-PR CLI builds do not have a deterministic staging feed. Install a staging or stable Aspire CLI, or set 'overrideStagingFeed' (for example: aspire config set -g overrideStagingFeed &lt;feed-url&gt;) to point at the staging feed you want to use.</source>
+        <target state="new">The 'staging' channel cannot be resolved from a CLI with identity '{0}'. Daily, local, and per-PR CLI builds do not have a deterministic staging feed. Install a staging or stable Aspire CLI, or set 'overrideStagingFeed' (for example: aspire config set -g overrideStagingFeed &lt;feed-url&gt;) to point at the staging feed you want to use.</target>
+        <note>{0} is the running CLI's baked identity channel (one of daily, local, or pr-N). Shown when --channel staging is requested on a CLI that cannot produce a real staging feed. Tracks https://github.com/microsoft/aspire/issues/16652.</note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Aspire.Cli/Resources/xlf/PackagingStrings.zh-Hans.xlf
+++ b/src/Aspire.Cli/Resources/xlf/PackagingStrings.zh-Hans.xlf
@@ -7,6 +7,11 @@
         <target state="translated">基于 NuGet.config</target>
         <note>Source details text shown for packages from implicit channel or channels without Aspire* package source mappings</note>
       </trans-unit>
+      <trans-unit id="StagingChannelUnavailableOnDailyCli">
+        <source>The 'staging' channel cannot be resolved from a CLI with identity '{0}'. Daily, local, and per-PR CLI builds do not have a deterministic staging feed. Install a staging or stable Aspire CLI, or set 'overrideStagingFeed' (for example: aspire config set -g overrideStagingFeed &lt;feed-url&gt;) to point at the staging feed you want to use.</source>
+        <target state="new">The 'staging' channel cannot be resolved from a CLI with identity '{0}'. Daily, local, and per-PR CLI builds do not have a deterministic staging feed. Install a staging or stable Aspire CLI, or set 'overrideStagingFeed' (for example: aspire config set -g overrideStagingFeed &lt;feed-url&gt;) to point at the staging feed you want to use.</target>
+        <note>{0} is the running CLI's baked identity channel (one of daily, local, or pr-N). Shown when --channel staging is requested on a CLI that cannot produce a real staging feed. Tracks https://github.com/microsoft/aspire/issues/16652.</note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Aspire.Cli/Resources/xlf/PackagingStrings.zh-Hant.xlf
+++ b/src/Aspire.Cli/Resources/xlf/PackagingStrings.zh-Hant.xlf
@@ -7,6 +7,11 @@
         <target state="translated">根據 NuGet.config</target>
         <note>Source details text shown for packages from implicit channel or channels without Aspire* package source mappings</note>
       </trans-unit>
+      <trans-unit id="StagingChannelUnavailableOnDailyCli">
+        <source>The 'staging' channel cannot be resolved from a CLI with identity '{0}'. Daily, local, and per-PR CLI builds do not have a deterministic staging feed. Install a staging or stable Aspire CLI, or set 'overrideStagingFeed' (for example: aspire config set -g overrideStagingFeed &lt;feed-url&gt;) to point at the staging feed you want to use.</source>
+        <target state="new">The 'staging' channel cannot be resolved from a CLI with identity '{0}'. Daily, local, and per-PR CLI builds do not have a deterministic staging feed. Install a staging or stable Aspire CLI, or set 'overrideStagingFeed' (for example: aspire config set -g overrideStagingFeed &lt;feed-url&gt;) to point at the staging feed you want to use.</target>
+        <note>{0} is the running CLI's baked identity channel (one of daily, local, or pr-N). Shown when --channel staging is requested on a CLI that cannot produce a real staging feed. Tracks https://github.com/microsoft/aspire/issues/16652.</note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Aspire.Cli/Resources/xlf/UpdateCommandStrings.cs.xlf
+++ b/src/Aspire.Cli/Resources/xlf/UpdateCommandStrings.cs.xlf
@@ -152,6 +152,11 @@
         <target state="translated">V souboru NuGet.config se nezjistily žádné změny.</target>
         <note />
       </trans-unit>
+      <trans-unit id="NoChannelFoundMatching">
+        <source>No channel found matching '{0}'. Valid options are: {1}.</source>
+        <target state="new">No channel found matching '{0}'. Valid options are: {1}.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="NoPackageFoundFormat">
         <source>No package found with ID '{0}' in channel '{1}'.</source>
         <target state="translated">V kanálu {1} nebyl nalezen žádný balíček s ID {0}.</target>

--- a/src/Aspire.Cli/Resources/xlf/UpdateCommandStrings.de.xlf
+++ b/src/Aspire.Cli/Resources/xlf/UpdateCommandStrings.de.xlf
@@ -152,6 +152,11 @@
         <target state="translated">In NuGet.config wurden keine Änderungen festgestellt.</target>
         <note />
       </trans-unit>
+      <trans-unit id="NoChannelFoundMatching">
+        <source>No channel found matching '{0}'. Valid options are: {1}.</source>
+        <target state="new">No channel found matching '{0}'. Valid options are: {1}.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="NoPackageFoundFormat">
         <source>No package found with ID '{0}' in channel '{1}'.</source>
         <target state="translated">Im Kanal „{0}“ wurde kein Paket mit der ID „{1}“ gefunden.</target>

--- a/src/Aspire.Cli/Resources/xlf/UpdateCommandStrings.es.xlf
+++ b/src/Aspire.Cli/Resources/xlf/UpdateCommandStrings.es.xlf
@@ -152,6 +152,11 @@
         <target state="translated">No se detectaron cambios en NuGet.config</target>
         <note />
       </trans-unit>
+      <trans-unit id="NoChannelFoundMatching">
+        <source>No channel found matching '{0}'. Valid options are: {1}.</source>
+        <target state="new">No channel found matching '{0}'. Valid options are: {1}.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="NoPackageFoundFormat">
         <source>No package found with ID '{0}' in channel '{1}'.</source>
         <target state="translated">No se encontró ningún paquete con id. "{0}" en el canal "{1}".</target>

--- a/src/Aspire.Cli/Resources/xlf/UpdateCommandStrings.fr.xlf
+++ b/src/Aspire.Cli/Resources/xlf/UpdateCommandStrings.fr.xlf
@@ -152,6 +152,11 @@
         <target state="translated">Aucune modification n’a été détectée dans NuGet.config</target>
         <note />
       </trans-unit>
+      <trans-unit id="NoChannelFoundMatching">
+        <source>No channel found matching '{0}'. Valid options are: {1}.</source>
+        <target state="new">No channel found matching '{0}'. Valid options are: {1}.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="NoPackageFoundFormat">
         <source>No package found with ID '{0}' in channel '{1}'.</source>
         <target state="translated">Aucun package trouvé avec l’ID « {0} » dans le canal « {1} ».</target>

--- a/src/Aspire.Cli/Resources/xlf/UpdateCommandStrings.it.xlf
+++ b/src/Aspire.Cli/Resources/xlf/UpdateCommandStrings.it.xlf
@@ -152,6 +152,11 @@
         <target state="translated">Nessuna modifica rilevata in NuGet.config</target>
         <note />
       </trans-unit>
+      <trans-unit id="NoChannelFoundMatching">
+        <source>No channel found matching '{0}'. Valid options are: {1}.</source>
+        <target state="new">No channel found matching '{0}'. Valid options are: {1}.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="NoPackageFoundFormat">
         <source>No package found with ID '{0}' in channel '{1}'.</source>
         <target state="translated">Non sono stati trovati pacchetti con ID "{0}" nel canale "{1}".</target>

--- a/src/Aspire.Cli/Resources/xlf/UpdateCommandStrings.ja.xlf
+++ b/src/Aspire.Cli/Resources/xlf/UpdateCommandStrings.ja.xlf
@@ -152,6 +152,11 @@
         <target state="translated">NuGet.config に変更は検出されませんでした</target>
         <note />
       </trans-unit>
+      <trans-unit id="NoChannelFoundMatching">
+        <source>No channel found matching '{0}'. Valid options are: {1}.</source>
+        <target state="new">No channel found matching '{0}'. Valid options are: {1}.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="NoPackageFoundFormat">
         <source>No package found with ID '{0}' in channel '{1}'.</source>
         <target state="translated">チャネル '{1}' 内に、ID '{0}' を含むパッケージが見つかりませんでした。</target>

--- a/src/Aspire.Cli/Resources/xlf/UpdateCommandStrings.ko.xlf
+++ b/src/Aspire.Cli/Resources/xlf/UpdateCommandStrings.ko.xlf
@@ -152,6 +152,11 @@
         <target state="translated">NuGet.config에서 변경 내용이 검색되지 않음</target>
         <note />
       </trans-unit>
+      <trans-unit id="NoChannelFoundMatching">
+        <source>No channel found matching '{0}'. Valid options are: {1}.</source>
+        <target state="new">No channel found matching '{0}'. Valid options are: {1}.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="NoPackageFoundFormat">
         <source>No package found with ID '{0}' in channel '{1}'.</source>
         <target state="translated">채널 '{1}'에서 ID '{0}'의 패키지를 찾을 수 없습니다.</target>

--- a/src/Aspire.Cli/Resources/xlf/UpdateCommandStrings.pl.xlf
+++ b/src/Aspire.Cli/Resources/xlf/UpdateCommandStrings.pl.xlf
@@ -152,6 +152,11 @@
         <target state="translated">Nie wykryto żadnych zmian w pliku NuGet.config</target>
         <note />
       </trans-unit>
+      <trans-unit id="NoChannelFoundMatching">
+        <source>No channel found matching '{0}'. Valid options are: {1}.</source>
+        <target state="new">No channel found matching '{0}'. Valid options are: {1}.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="NoPackageFoundFormat">
         <source>No package found with ID '{0}' in channel '{1}'.</source>
         <target state="translated">Nie znaleziono pakietu o identyfikatorze „{0}” w kanale „{1}”.</target>

--- a/src/Aspire.Cli/Resources/xlf/UpdateCommandStrings.pt-BR.xlf
+++ b/src/Aspire.Cli/Resources/xlf/UpdateCommandStrings.pt-BR.xlf
@@ -152,6 +152,11 @@
         <target state="translated">Nenhuma alteração detectada no NuGet.config</target>
         <note />
       </trans-unit>
+      <trans-unit id="NoChannelFoundMatching">
+        <source>No channel found matching '{0}'. Valid options are: {1}.</source>
+        <target state="new">No channel found matching '{0}'. Valid options are: {1}.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="NoPackageFoundFormat">
         <source>No package found with ID '{0}' in channel '{1}'.</source>
         <target state="translated">Nenhum pacote encontrado com a ID “{0}” no canal “{1}”.</target>

--- a/src/Aspire.Cli/Resources/xlf/UpdateCommandStrings.ru.xlf
+++ b/src/Aspire.Cli/Resources/xlf/UpdateCommandStrings.ru.xlf
@@ -152,6 +152,11 @@
         <target state="translated">Изменений в NuGet.config не обнаружено</target>
         <note />
       </trans-unit>
+      <trans-unit id="NoChannelFoundMatching">
+        <source>No channel found matching '{0}'. Valid options are: {1}.</source>
+        <target state="new">No channel found matching '{0}'. Valid options are: {1}.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="NoPackageFoundFormat">
         <source>No package found with ID '{0}' in channel '{1}'.</source>
         <target state="translated">Не найден пакет с идентификатором "{0}" в канале "{1}".</target>

--- a/src/Aspire.Cli/Resources/xlf/UpdateCommandStrings.tr.xlf
+++ b/src/Aspire.Cli/Resources/xlf/UpdateCommandStrings.tr.xlf
@@ -152,6 +152,11 @@
         <target state="translated">NuGet.config dosyasında değişiklik algılanmadı</target>
         <note />
       </trans-unit>
+      <trans-unit id="NoChannelFoundMatching">
+        <source>No channel found matching '{0}'. Valid options are: {1}.</source>
+        <target state="new">No channel found matching '{0}'. Valid options are: {1}.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="NoPackageFoundFormat">
         <source>No package found with ID '{0}' in channel '{1}'.</source>
         <target state="translated">'{1}' kanalında '{0}' kimliğine sahip paket bulunamadı.</target>

--- a/src/Aspire.Cli/Resources/xlf/UpdateCommandStrings.zh-Hans.xlf
+++ b/src/Aspire.Cli/Resources/xlf/UpdateCommandStrings.zh-Hans.xlf
@@ -152,6 +152,11 @@
         <target state="translated">NuGet.config 中未检测到任何更改</target>
         <note />
       </trans-unit>
+      <trans-unit id="NoChannelFoundMatching">
+        <source>No channel found matching '{0}'. Valid options are: {1}.</source>
+        <target state="new">No channel found matching '{0}'. Valid options are: {1}.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="NoPackageFoundFormat">
         <source>No package found with ID '{0}' in channel '{1}'.</source>
         <target state="translated">在频道 "{0}" 中找不到 ID 为 "{1}" 的包。</target>

--- a/src/Aspire.Cli/Resources/xlf/UpdateCommandStrings.zh-Hant.xlf
+++ b/src/Aspire.Cli/Resources/xlf/UpdateCommandStrings.zh-Hant.xlf
@@ -152,6 +152,11 @@
         <target state="translated">未偵測到 NuGet.config 中的變更</target>
         <note />
       </trans-unit>
+      <trans-unit id="NoChannelFoundMatching">
+        <source>No channel found matching '{0}'. Valid options are: {1}.</source>
+        <target state="new">No channel found matching '{0}'. Valid options are: {1}.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="NoPackageFoundFormat">
         <source>No package found with ID '{0}' in channel '{1}'.</source>
         <target state="translated">在通道 '{1}' 中找不到識別碼為 '{0}' 的套件。</target>

--- a/src/Shared/StringComparers.cs
+++ b/src/Shared/StringComparers.cs
@@ -35,6 +35,7 @@ internal static class StringComparers
     public static StringComparer NetworkID => StringComparer.Ordinal;
     public static StringComparer NuGetPackageId => StringComparer.OrdinalIgnoreCase;
     public static StringComparer FullTextSearch => StringComparer.OrdinalIgnoreCase;
+    public static StringComparer ChannelName => StringComparer.OrdinalIgnoreCase;
 }
 
 internal static class StringComparisons
@@ -67,4 +68,5 @@ internal static class StringComparisons
     public static StringComparison NetworkID => StringComparison.Ordinal;
     public static StringComparison NuGetPackageId => StringComparison.OrdinalIgnoreCase;
     public static StringComparison FullTextSearch => StringComparison.OrdinalIgnoreCase;
+    public static StringComparison ChannelName => StringComparison.OrdinalIgnoreCase;
 }

--- a/tests/Aspire.Cli.Tests/Commands/UpdateCommandTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/UpdateCommandTests.cs
@@ -1351,6 +1351,71 @@ public class UpdateCommandTests(ITestOutputHelper outputHelper)
     }
 
     [Fact]
+    public async Task UpdateCommand_ChannelStagingRequestedButPackagingServiceReportsUnavailable_SurfacesStagingReason()
+    {
+        // Regression: https://github.com/microsoft/aspire/issues/16652
+        // When `aspire update --channel staging` is run on a daily/local/pr-N CLI, the packaging
+        // service refuses to synthesize the staging channel and returns a reason explaining why.
+        // UpdateCommand must surface that reason in its error path instead of the generic
+        // "No channel found matching 'staging'" message — the generic message hides the actual
+        // recovery action (set overrideStagingFeed or install a staging CLI) from the user.
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+
+        const string unavailableReason = "FAKE staging unavailable reason (identity=daily)";
+
+        TestInteractionService? capturedInteractionService = null;
+
+        var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper, options =>
+        {
+            options.ProjectLocatorFactory = _ => new TestProjectLocator
+            {
+                UseOrFindAppHostProjectFileAsyncCallback = (projectFile, _, _) =>
+                    Task.FromResult<FileInfo?>(new FileInfo(Path.Combine(workspace.WorkspaceRoot.FullName, "AppHost.csproj")))
+            };
+
+            options.InteractionServiceFactory = _ =>
+            {
+                capturedInteractionService = new TestInteractionService();
+                return capturedInteractionService;
+            };
+
+            options.DotNetCliRunnerFactory = _ => new TestDotNetCliRunner();
+            options.ProjectUpdaterFactory = _ => new TestProjectUpdater();
+
+            options.PackagingServiceFactory = _ => new TestPackagingService
+            {
+                // Simulate the production PackagingService refusing staging synthesis: staging is
+                // omitted from the channel list AND GetStagingChannelUnavailableReason() reports
+                // a non-null, user-facing reason.
+                GetChannelsAsyncCallback = _ =>
+                {
+                    var fakeCache = new FakeNuGetPackageCache();
+                    return Task.FromResult<IEnumerable<PackageChannel>>(new[]
+                    {
+                        PackageChannel.CreateImplicitChannel(fakeCache),
+                        PackageChannel.CreateExplicitChannel("daily", PackageChannelQuality.Both, mappings: null, fakeCache),
+                    });
+                },
+                GetStagingChannelUnavailableReasonCallback = () => unavailableReason
+            };
+        });
+
+        using var provider = services.BuildServiceProvider();
+
+        var command = provider.GetRequiredService<RootCommand>();
+        var result = command.Parse("update --channel staging");
+
+        var exitCode = await result.InvokeAsync().DefaultTimeout();
+
+        Assert.Equal(CliExitCodes.FailedToUpgradeProject, exitCode);
+
+        Assert.NotNull(capturedInteractionService);
+        var errorText = string.Join("\n", capturedInteractionService!.DisplayedErrors);
+        Assert.Contains(unavailableReason, errorText);
+        Assert.DoesNotContain("No channel found matching", errorText);
+    }
+
+    [Fact]
     public async Task UpdateCommand_ProjectInOtherDirectory_UsesProjectLocalConfiguredChannel()
     {
         // The CLI runs with `cwd == workspace.WorkspaceRoot` and we point --apphost at a project

--- a/tests/Aspire.Cli.Tests/Packaging/PackagingServiceTests.cs
+++ b/tests/Aspire.Cli.Tests/Packaging/PackagingServiceTests.cs
@@ -269,6 +269,17 @@ public class PackagingServiceTests(ITestOutputHelper outputHelper)
 
         Assert.Contains(PackageChannelNames.Staging, channels.Select(c => c.Name));
         Assert.Null(packagingService.GetStagingChannelUnavailableReason());
+
+        // Isolate the feature-flag gate itself: IsStagingChannelSynthesisAllowed short-circuits on
+        // overrideStagingFeed before the feature flag is ever checked, so the assertions above
+        // would still pass if the feature-flag branch were removed. Build a second service whose
+        // only opt-in is the StagingChannelEnabled feature flag (no overrideStagingFeed) and
+        // assert that the gate alone reports the channel as available. We deliberately do not
+        // call GetChannelsAsync() here because the full channel-creation path requires an
+        // AssemblyInformationalVersion that is not guaranteed in test hosts.
+        var featureFlagOnlyConfig = new ConfigurationBuilder().Build();
+        var featureFlagOnlyService = new PackagingService(executionContext, new FakeNuGetPackageCache(), features, featureFlagOnlyConfig, NullLogger<PackagingService>.Instance);
+        Assert.Null(featureFlagOnlyService.GetStagingChannelUnavailableReason());
     }
 
     /// <summary>

--- a/tests/Aspire.Cli.Tests/Packaging/PackagingServiceTests.cs
+++ b/tests/Aspire.Cli.Tests/Packaging/PackagingServiceTests.cs
@@ -100,13 +100,49 @@ public class PackagingServiceTests(ITestOutputHelper outputHelper)
     }
 
     [Fact]
-    public async Task GetChannelsAsync_WhenConfigurationChannelIsStagingWithoutQualityOverride_DefaultsToBothAndSharedFeed()
+    public async Task GetChannelsAsync_WhenConfigurationChannelIsStagingOnLocalCli_DoesNotIncludeStagingChannel()
     {
+        // Regression: https://github.com/microsoft/aspire/issues/16652
+        // A local/daily/pr-N CLI must not silently fabricate a 'staging' channel from the shared
+        // daily feed when config asks for staging — that resolves daily packages, not staging.
+        // The escape hatches (overrideStagingFeed or the staging feature flag) are covered by
+        // other tests in this file.
         using var workspace = TemporaryWorkspace.Create(outputHelper);
         var tempDir = workspace.WorkspaceRoot;
         var hivesDir = new DirectoryInfo(Path.Combine(tempDir.FullName, ".aspire", "hives"));
         var cacheDir = new DirectoryInfo(Path.Combine(tempDir.FullName, ".aspire", "cache"));
         var executionContext = new CliExecutionContext(tempDir, hivesDir, cacheDir, new DirectoryInfo(Path.Combine(Path.GetTempPath(), "aspire-test-runtimes")), new DirectoryInfo(Path.Combine(Path.GetTempPath(), "aspire-test-logs")), "test.log");
+
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["channel"] = PackageChannelNames.Staging
+            })
+            .Build();
+        var packagingService = new PackagingService(executionContext, new FakeNuGetPackageCache(), new TestFeatures(), configuration, NullLogger<PackagingService>.Instance);
+
+        var channels = await packagingService.GetChannelsAsync().DefaultTimeout();
+
+        var channelNames = channels.Select(c => c.Name).ToList();
+        Assert.DoesNotContain(PackageChannelNames.Staging, channelNames);
+
+        var reason = packagingService.GetStagingChannelUnavailableReason();
+        Assert.NotNull(reason);
+        Assert.Contains(PackageChannelNames.Local, reason);
+    }
+
+    [Fact]
+    public async Task GetChannelsAsync_WhenConfigurationChannelIsStagingOnStableCli_IncludesStagingChannelWithSharedFeed()
+    {
+        // Counterpart to the local/daily refusal: a stable-identity CLI can synthesize staging
+        // because the SHA-specific darc feed for the stable commit exists. With quality=Both
+        // (the default for stagingChannelConfigured), useSharedFeed=true so the channel points
+        // at the shared dnceng/dotnet9 feed.
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        var tempDir = workspace.WorkspaceRoot;
+        var hivesDir = new DirectoryInfo(Path.Combine(tempDir.FullName, ".aspire", "hives"));
+        var cacheDir = new DirectoryInfo(Path.Combine(tempDir.FullName, ".aspire", "cache"));
+        var executionContext = new CliExecutionContext(tempDir, hivesDir, cacheDir, new DirectoryInfo(Path.Combine(Path.GetTempPath(), "aspire-test-runtimes")), new DirectoryInfo(Path.Combine(Path.GetTempPath(), "aspire-test-logs")), "test.log", identityChannel: PackageChannelNames.Stable);
 
         var configuration = new ConfigurationBuilder()
             .AddInMemoryCollection(new Dictionary<string, string?>
@@ -124,6 +160,115 @@ public class PackagingServiceTests(ITestOutputHelper outputHelper)
         Assert.Contains(stagingChannel.Mappings!, m =>
             m.PackageFilter == "Aspire*" &&
             m.Source == "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet9/nuget/v3/index.json");
+
+        Assert.Null(packagingService.GetStagingChannelUnavailableReason());
+    }
+
+    [Fact]
+    public async Task GetChannelsAsync_WhenChannelStagingRequestedOnDailyCli_DoesNotIncludeStagingChannel()
+    {
+        // Direct repro of https://github.com/microsoft/aspire/issues/16652.
+        // A daily CLI invoked with `aspire update --channel staging` must NOT synthesize a
+        // staging channel from either the SHA-specific darc feed (which doesn't exist for daily
+        // commits) or the shared daily feed (which contains daily packages, not staging).
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        var tempDir = workspace.WorkspaceRoot;
+        var hivesDir = new DirectoryInfo(Path.Combine(tempDir.FullName, ".aspire", "hives"));
+        var cacheDir = new DirectoryInfo(Path.Combine(tempDir.FullName, ".aspire", "cache"));
+        var executionContext = new CliExecutionContext(tempDir, hivesDir, cacheDir, new DirectoryInfo(Path.Combine(Path.GetTempPath(), "aspire-test-runtimes")), new DirectoryInfo(Path.Combine(Path.GetTempPath(), "aspire-test-logs")), "test.log", identityChannel: PackageChannelNames.Daily);
+
+        var packagingService = new PackagingService(executionContext, new FakeNuGetPackageCache(), new TestFeatures(), new ConfigurationBuilder().Build(), NullLogger<PackagingService>.Instance);
+
+        var channels = await packagingService.GetChannelsAsync(requestedChannelName: PackageChannelNames.Staging).DefaultTimeout();
+
+        var channelNames = channels.Select(c => c.Name).ToList();
+        Assert.DoesNotContain(PackageChannelNames.Staging, channelNames);
+
+        var reason = packagingService.GetStagingChannelUnavailableReason();
+        Assert.NotNull(reason);
+        Assert.Contains(PackageChannelNames.Daily, reason);
+    }
+
+    [Fact]
+    public async Task GetChannelsAsync_WhenChannelStagingRequestedOnDailyCliWithOverrideFeed_IncludesStagingChannel()
+    {
+        // The overrideStagingFeed escape hatch must still work on a daily CLI: when the user has
+        // explicitly named the staging feed, we trust them and synthesize the channel.
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        var tempDir = workspace.WorkspaceRoot;
+        var hivesDir = new DirectoryInfo(Path.Combine(tempDir.FullName, ".aspire", "hives"));
+        var cacheDir = new DirectoryInfo(Path.Combine(tempDir.FullName, ".aspire", "cache"));
+        var executionContext = new CliExecutionContext(tempDir, hivesDir, cacheDir, new DirectoryInfo(Path.Combine(Path.GetTempPath(), "aspire-test-runtimes")), new DirectoryInfo(Path.Combine(Path.GetTempPath(), "aspire-test-logs")), "test.log", identityChannel: PackageChannelNames.Daily);
+
+        var overrideUrl = "https://example.com/staging/v3/index.json";
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["overrideStagingFeed"] = overrideUrl
+            })
+            .Build();
+        var packagingService = new PackagingService(executionContext, new FakeNuGetPackageCache(), new TestFeatures(), configuration, NullLogger<PackagingService>.Instance);
+
+        var channels = await packagingService.GetChannelsAsync(requestedChannelName: PackageChannelNames.Staging).DefaultTimeout();
+
+        var stagingChannel = channels.First(c => c.Name == PackageChannelNames.Staging);
+        Assert.Contains(stagingChannel.Mappings!, m => m.PackageFilter == "Aspire*" && m.Source == overrideUrl);
+        Assert.Null(packagingService.GetStagingChannelUnavailableReason());
+    }
+
+    [Theory]
+    [InlineData(PackageChannelNames.Local)]
+    [InlineData("pr-12345")]
+    public async Task GetChannelsAsync_WhenChannelStagingRequestedOnNonReleaseIdentityWithoutOverride_DoesNotIncludeStagingChannel(string identity)
+    {
+        // The same gating applies to local and per-PR CLI identities. Per-PR (pr-<N>) builds
+        // have a hive label baked in by CI but no staging feed of their own.
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        var tempDir = workspace.WorkspaceRoot;
+        var hivesDir = new DirectoryInfo(Path.Combine(tempDir.FullName, ".aspire", "hives"));
+        var cacheDir = new DirectoryInfo(Path.Combine(tempDir.FullName, ".aspire", "cache"));
+        var executionContext = new CliExecutionContext(tempDir, hivesDir, cacheDir, new DirectoryInfo(Path.Combine(Path.GetTempPath(), "aspire-test-runtimes")), new DirectoryInfo(Path.Combine(Path.GetTempPath(), "aspire-test-logs")), "test.log", identityChannel: identity);
+
+        var packagingService = new PackagingService(executionContext, new FakeNuGetPackageCache(), new TestFeatures(), new ConfigurationBuilder().Build(), NullLogger<PackagingService>.Instance);
+
+        var channels = await packagingService.GetChannelsAsync(requestedChannelName: PackageChannelNames.Staging).DefaultTimeout();
+
+        Assert.DoesNotContain(PackageChannelNames.Staging, channels.Select(c => c.Name));
+
+        var reason = packagingService.GetStagingChannelUnavailableReason();
+        Assert.NotNull(reason);
+        Assert.Contains(identity, reason);
+    }
+
+    [Fact]
+    public async Task GetChannelsAsync_WhenChannelStagingRequestedOnDailyCliWithFeatureFlag_IncludesStagingChannel()
+    {
+        // Back-compat: the StagingChannelEnabled feature flag is an explicit developer/test opt-in
+        // and continues to bypass the identity gating. Without an override feed the SHA-specific
+        // path needs an AssemblyInformationalVersion to resolve, which is not guaranteed in test
+        // hosts, so we also supply overrideStagingFeed to make the test deterministic.
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        var tempDir = workspace.WorkspaceRoot;
+        var hivesDir = new DirectoryInfo(Path.Combine(tempDir.FullName, ".aspire", "hives"));
+        var cacheDir = new DirectoryInfo(Path.Combine(tempDir.FullName, ".aspire", "cache"));
+        var executionContext = new CliExecutionContext(tempDir, hivesDir, cacheDir, new DirectoryInfo(Path.Combine(Path.GetTempPath(), "aspire-test-runtimes")), new DirectoryInfo(Path.Combine(Path.GetTempPath(), "aspire-test-logs")), "test.log", identityChannel: PackageChannelNames.Daily);
+
+        var features = new TestFeatures();
+        features.SetFeature(KnownFeatures.StagingChannelEnabled, true);
+
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["overrideStagingFeed"] = "https://example.com/staging/v3/index.json"
+            })
+            .Build();
+
+        var packagingService = new PackagingService(executionContext, new FakeNuGetPackageCache(), features, configuration, NullLogger<PackagingService>.Instance);
+
+        var channels = await packagingService.GetChannelsAsync().DefaultTimeout();
+
+        Assert.Contains(PackageChannelNames.Staging, channels.Select(c => c.Name));
+        Assert.Null(packagingService.GetStagingChannelUnavailableReason());
     }
 
     /// <summary>

--- a/tests/Aspire.Cli.Tests/Packaging/PackagingServiceTests.cs
+++ b/tests/Aspire.Cli.Tests/Packaging/PackagingServiceTests.cs
@@ -62,7 +62,7 @@ public class PackagingServiceTests(ITestOutputHelper outputHelper)
         var configuration = new ConfigurationBuilder()
             .AddInMemoryCollection(new Dictionary<string, string?>
             {
-                ["overrideStagingFeed"] = "https://example.com/nuget/v3/index.json"
+                [PackagingService.OverrideStagingFeedConfigKey] = "https://example.com/nuget/v3/index.json"
             })
             .Build();
         var packagingService = new PackagingService(executionContext, new FakeNuGetPackageCache(), new TestFeatures(), configuration, NullLogger<PackagingService>.Instance);
@@ -204,7 +204,7 @@ public class PackagingServiceTests(ITestOutputHelper outputHelper)
         var configuration = new ConfigurationBuilder()
             .AddInMemoryCollection(new Dictionary<string, string?>
             {
-                ["overrideStagingFeed"] = overrideUrl
+                [PackagingService.OverrideStagingFeedConfigKey] = overrideUrl
             })
             .Build();
         var packagingService = new PackagingService(executionContext, new FakeNuGetPackageCache(), new TestFeatures(), configuration, NullLogger<PackagingService>.Instance);
@@ -259,7 +259,7 @@ public class PackagingServiceTests(ITestOutputHelper outputHelper)
         var configuration = new ConfigurationBuilder()
             .AddInMemoryCollection(new Dictionary<string, string?>
             {
-                ["overrideStagingFeed"] = "https://example.com/staging/v3/index.json"
+                [PackagingService.OverrideStagingFeedConfigKey] = "https://example.com/staging/v3/index.json"
             })
             .Build();
 
@@ -332,7 +332,7 @@ public class PackagingServiceTests(ITestOutputHelper outputHelper)
         var configuration = new ConfigurationBuilder()
             .AddInMemoryCollection(new Dictionary<string, string?>
             {
-                ["overrideStagingFeed"] = testFeedUrl
+                [PackagingService.OverrideStagingFeedConfigKey] = testFeedUrl
             })
             .Build();
 
@@ -375,7 +375,7 @@ public class PackagingServiceTests(ITestOutputHelper outputHelper)
         var configuration = new ConfigurationBuilder()
             .AddInMemoryCollection(new Dictionary<string, string?>
             {
-                ["overrideStagingFeed"] = customFeedUrl
+                [PackagingService.OverrideStagingFeedConfigKey] = customFeedUrl
             })
             .Build();
 
@@ -407,7 +407,7 @@ public class PackagingServiceTests(ITestOutputHelper outputHelper)
         var configuration = new ConfigurationBuilder()
             .AddInMemoryCollection(new Dictionary<string, string?>
             {
-                ["overrideStagingFeed"] = azureDevOpsFeedUrl
+                [PackagingService.OverrideStagingFeedConfigKey] = azureDevOpsFeedUrl
             })
             .Build();
 
@@ -439,7 +439,7 @@ public class PackagingServiceTests(ITestOutputHelper outputHelper)
         var configuration = new ConfigurationBuilder()
             .AddInMemoryCollection(new Dictionary<string, string?>
             {
-                ["overrideStagingFeed"] = invalidFeedUrl
+                [PackagingService.OverrideStagingFeedConfigKey] = invalidFeedUrl
             })
             .Build();
 
@@ -469,7 +469,7 @@ public class PackagingServiceTests(ITestOutputHelper outputHelper)
         var configuration = new ConfigurationBuilder()
             .AddInMemoryCollection(new Dictionary<string, string?>
             {
-                ["overrideStagingFeed"] = "https://example.com/nuget/v3/index.json",
+                [PackagingService.OverrideStagingFeedConfigKey] = "https://example.com/nuget/v3/index.json",
                 ["overrideStagingQuality"] = "Prerelease"
             })
             .Build();
@@ -499,7 +499,7 @@ public class PackagingServiceTests(ITestOutputHelper outputHelper)
         var configuration = new ConfigurationBuilder()
             .AddInMemoryCollection(new Dictionary<string, string?>
             {
-                ["overrideStagingFeed"] = "https://example.com/nuget/v3/index.json",
+                [PackagingService.OverrideStagingFeedConfigKey] = "https://example.com/nuget/v3/index.json",
                 ["overrideStagingQuality"] = "Both"
             })
             .Build();
@@ -529,7 +529,7 @@ public class PackagingServiceTests(ITestOutputHelper outputHelper)
         var configuration = new ConfigurationBuilder()
             .AddInMemoryCollection(new Dictionary<string, string?>
             {
-                ["overrideStagingFeed"] = "https://example.com/nuget/v3/index.json",
+                [PackagingService.OverrideStagingFeedConfigKey] = "https://example.com/nuget/v3/index.json",
                 ["overrideStagingQuality"] = "InvalidValue"
             })
             .Build();
@@ -559,7 +559,7 @@ public class PackagingServiceTests(ITestOutputHelper outputHelper)
         var configuration = new ConfigurationBuilder()
             .AddInMemoryCollection(new Dictionary<string, string?>
             {
-                ["overrideStagingFeed"] = "https://example.com/nuget/v3/index.json"
+                [PackagingService.OverrideStagingFeedConfigKey] = "https://example.com/nuget/v3/index.json"
             })
             .Build();
 
@@ -586,7 +586,7 @@ public class PackagingServiceTests(ITestOutputHelper outputHelper)
         var configuration = new ConfigurationBuilder()
             .AddInMemoryCollection(new Dictionary<string, string?>
             {
-                ["overrideStagingFeed"] = "https://pkgs.dev.azure.com/dnceng/public/_packaging/darc-pub-microsoft-aspire-48a11dae/nuget/v3/index.json"
+                [PackagingService.OverrideStagingFeedConfigKey] = "https://pkgs.dev.azure.com/dnceng/public/_packaging/darc-pub-microsoft-aspire-48a11dae/nuget/v3/index.json"
             })
             .Build();
 
@@ -644,7 +644,7 @@ public class PackagingServiceTests(ITestOutputHelper outputHelper)
         var configuration = new ConfigurationBuilder()
             .AddInMemoryCollection(new Dictionary<string, string?>
             {
-                ["overrideStagingFeed"] = "https://example.com/nuget/v3/index.json"
+                [PackagingService.OverrideStagingFeedConfigKey] = "https://example.com/nuget/v3/index.json"
             })
             .Build();
 
@@ -807,7 +807,7 @@ public class PackagingServiceTests(ITestOutputHelper outputHelper)
             .AddInMemoryCollection(new Dictionary<string, string?>
             {
                 ["overrideStagingQuality"] = "Prerelease",
-                ["overrideStagingFeed"] = customFeed
+                [PackagingService.OverrideStagingFeedConfigKey] = customFeed
             })
             .Build();
 
@@ -947,7 +947,7 @@ public class PackagingServiceTests(ITestOutputHelper outputHelper)
         var configuration = new ConfigurationBuilder()
             .AddInMemoryCollection(new Dictionary<string, string?>
             {
-                ["overrideStagingFeed"] = "https://example.com/nuget/v3/index.json",
+                [PackagingService.OverrideStagingFeedConfigKey] = "https://example.com/nuget/v3/index.json",
                 ["stagingPinToCliVersion"] = "true"
             })
             .Build();

--- a/tests/Aspire.Cli.Tests/Projects/PrebuiltAppHostServerTests.cs
+++ b/tests/Aspire.Cli.Tests/Projects/PrebuiltAppHostServerTests.cs
@@ -423,6 +423,130 @@ public class PrebuiltAppHostServerTests(ITestOutputHelper outputHelper)
         Assert.Null(result);
     }
 
+    [Fact]
+    public async Task TryCreateTemporaryNuGetConfig_StagingRequested_RefusesWhenPackagingServiceReportsUnavailable()
+    {
+        // Regression for radical's review of #17235: on a daily/local/pr CLI the packaging service
+        // refuses to synthesize a 'staging' channel and surfaces the actionable reason. The bundled
+        // AppHost restore must not silently fall through to a different feed — it must propagate
+        // that reason so the user sees the same message the update/new commands now show.
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+
+        var executionContext = CreateContextWithIdentityChannel("daily");
+        const string unavailableReason =
+            "Staging unavailable on this daily CLI build. Set overrideStagingFeed or enable the StagingChannelEnabled feature flag to use it.";
+        var server = CreateServerWithUnavailableStagingChannel(workspace, executionContext, unavailableReason);
+
+        var ex = await Assert.ThrowsAsync<InvalidOperationException>(
+            () => InvokeTryCreateTemporaryNuGetConfigAsync(server, "staging"));
+        Assert.Equal(unavailableReason, ex.Message);
+    }
+
+    [Fact]
+    public async Task GetNuGetSources_StagingRequested_RefusesWhenPackagingServiceReportsUnavailable()
+    {
+        // Companion of the TryCreateTemporaryNuGetConfig test above. Without this guard,
+        // GetNuGetSourcesAsync's "no match -> all explicit channels" fallback hands the
+        // shared daily feed to nuget restore on a daily-identity CLI even though the project
+        // pinned channel: staging.
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+
+        var executionContext = CreateContextWithIdentityChannel("daily");
+        const string unavailableReason =
+            "Staging unavailable on this daily CLI build. Set overrideStagingFeed or enable the StagingChannelEnabled feature flag to use it.";
+        var server = CreateServerWithUnavailableStagingChannel(workspace, executionContext, unavailableReason);
+
+        var ex = await Assert.ThrowsAsync<InvalidOperationException>(
+            () => server.GetNuGetSourcesAsync("staging", CancellationToken.None));
+        Assert.Equal(unavailableReason, ex.Message);
+    }
+
+    [Fact]
+    public async Task GetNuGetSources_NonStagingRequest_NotAffectedByStagingUnavailableReason()
+    {
+        // Negative control: the staging refusal must only fire for requestedChannel == "staging".
+        // A request for any other channel name must continue to resolve normally even when the
+        // packaging service is reporting staging-unavailable.
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+
+        var executionContext = CreateContextWithIdentityChannel("daily");
+        var mappings = new[]
+        {
+            new PackageMapping(PackageMapping.AllPackages, "https://pkgs.dev.azure.com/fake/v3/index.json")
+        };
+        var dailyChannel = PackageChannel.CreateExplicitChannel(
+            "daily", PackageChannelQuality.Both, mappings, new FakeNuGetPackageCache());
+        var packagingService = new TestPackagingService
+        {
+            GetChannelsAsyncCallback = _ => Task.FromResult<IEnumerable<PackageChannel>>([dailyChannel]),
+            GetStagingChannelUnavailableReasonCallback = () => "Staging unavailable"
+        };
+
+        var nugetService = new BundleNuGetService(
+            new NullLayoutDiscovery(),
+            new LayoutProcessRunner(new TestProcessExecutionFactory()),
+            new TestFeatures(),
+            executionContext,
+            NullLogger<BundleNuGetService>.Instance);
+
+        var server = new PrebuiltAppHostServer(
+            workspace.WorkspaceRoot.FullName,
+            "test.sock",
+            new LayoutConfiguration(),
+            nugetService,
+            new TestDotNetCliRunner(),
+            new TestDotNetSdkInstaller(),
+            packagingService,
+            executionContext,
+            NullLogger.Instance);
+
+        var sources = await server.GetNuGetSourcesAsync("daily", CancellationToken.None);
+
+        Assert.NotNull(sources);
+        Assert.Contains("https://pkgs.dev.azure.com/fake/v3/index.json", sources);
+    }
+
+    private static PrebuiltAppHostServer CreateServerWithUnavailableStagingChannel(
+        TemporaryWorkspace workspace,
+        CliExecutionContext executionContext,
+        string unavailableReason)
+    {
+        // Mirrors what PackagingService does on a daily/local/pr CLI: omits 'staging' from
+        // GetChannelsAsync and surfaces the actionable reason via GetStagingChannelUnavailableReason.
+        // We hand back the 'daily' channel because that is the shared explicit channel the
+        // pre-fix fallback path would have silently picked up.
+        var mappings = new[]
+        {
+            new PackageMapping(PackageMapping.AllPackages, "https://pkgs.dev.azure.com/fake/v3/index.json")
+        };
+        var dailyChannel = PackageChannel.CreateExplicitChannel(
+            "daily", PackageChannelQuality.Both, mappings, new FakeNuGetPackageCache());
+
+        var packagingService = new TestPackagingService
+        {
+            GetChannelsAsyncCallback = _ => Task.FromResult<IEnumerable<PackageChannel>>([dailyChannel]),
+            GetStagingChannelUnavailableReasonCallback = () => unavailableReason
+        };
+
+        var nugetService = new BundleNuGetService(
+            new NullLayoutDiscovery(),
+            new LayoutProcessRunner(new TestProcessExecutionFactory()),
+            new TestFeatures(),
+            executionContext,
+            NullLogger<BundleNuGetService>.Instance);
+
+        return new PrebuiltAppHostServer(
+            workspace.WorkspaceRoot.FullName,
+            "test.sock",
+            new LayoutConfiguration(),
+            nugetService,
+            new TestDotNetCliRunner(),
+            new TestDotNetSdkInstaller(),
+            packagingService,
+            executionContext,
+            NullLogger.Instance);
+    }
+
     private static CliExecutionContext CreateContextWithIdentityChannel(string identityChannel) =>
         new(new DirectoryInfo(Path.GetTempPath()),
             new DirectoryInfo(Path.Combine(Path.GetTempPath(), "hives")),

--- a/tests/Aspire.Cli.Tests/TestServices/TestPackagingService.cs
+++ b/tests/Aspire.Cli.Tests/TestServices/TestPackagingService.cs
@@ -9,6 +9,14 @@ internal sealed class TestPackagingService : IPackagingService
 {
     public Func<CancellationToken, Task<IEnumerable<PackageChannel>>>? GetChannelsAsyncCallback { get; set; }
 
+    /// <summary>
+    /// Optional callback to control the reason returned by
+    /// <see cref="GetStagingChannelUnavailableReason"/>. When <see langword="null"/> (the default),
+    /// the fake reports staging as available (returns <see langword="null"/>) so existing tests
+    /// that don't care about staging gating keep working unchanged.
+    /// </summary>
+    public Func<string?>? GetStagingChannelUnavailableReasonCallback { get; set; }
+
     public Task<IEnumerable<PackageChannel>> GetChannelsAsync(CancellationToken cancellationToken = default, string? requestedChannelName = null)
     {
         if (GetChannelsAsyncCallback is not null)
@@ -19,5 +27,10 @@ internal sealed class TestPackagingService : IPackagingService
         // Default: Return a fake channel with template packages
         var testChannel = PackageChannel.CreateImplicitChannel(new FakeNuGetPackageCache());
         return Task.FromResult<IEnumerable<PackageChannel>>(new[] { testChannel });
+    }
+
+    public string? GetStagingChannelUnavailableReason()
+    {
+        return GetStagingChannelUnavailableReasonCallback?.Invoke();
     }
 }


### PR DESCRIPTION
## Description

Fixes: #16652

On a daily Aspire CLI, `aspire update --channel staging` silently resolved to **daily** package versions. The packaging service was synthesizing the `staging` channel relative to the running CLI build:

- For stable-quality staging, it built a darc feed URL from the running CLI's commit hash (`darc-pub-microsoft-aspire-<hash>`). That feed only exists for stable release branch commits, never for daily ones.
- For prerelease/Both quality staging without an explicit `overrideStagingFeed`, it fell back to the shared daily feed (`pkgs.dev.azure.com/.../dotnet9/...`), which contains daily packages.

Either way, a daily CLI's `--channel staging` ended up resolving daily versions and reporting them as "staging".

### Approach

Gate staging-channel synthesis on the CLI's baked identity (`CliExecutionContext.IdentityChannel`, sourced from `[AssemblyMetadata("AspireCliChannel", ...)]` and validated by `IdentityChannelReader`):

- `stable` identity: SHA-specific `darc-pub-microsoft-aspire-<hash>` feed is real, allow synthesis.
- `staging` identity: dogfoods staging packages (per #17155), allow synthesis.
- `daily`, `local`, `pr-<N>` identity: refuse and return a localized reason naming the running identity and pointing at `overrideStagingFeed` (escape hatch) or installing a staging/stable CLI.

Escape hatches preserved:

- An explicit `overrideStagingFeed` configuration entry always allows synthesis regardless of identity.
- The `StagingChannelEnabled` feature flag continues to opt in for dev/test scenarios.

`UpdateCommand` now surfaces the packaging-service-provided reason when `--channel staging` is requested but refused, instead of the generic `No channel found matching 'staging'` message that hid the actual recovery action from users.

When staging IS synthesized, the resolved feed URL, quality, and pinned version are logged at Information so users can see what `--channel staging` actually selected (the "show what was resolved" suggestion from the issue RCA).

### Why this differs from the closed PR #16717

The earlier PR keyed availability off the assembly *version string* (Arcade preview vs 3+ identifier daily) and required a new test seam (`internal:packaging:cliVersionForTesting`).

This PR keys off `CliExecutionContext.IdentityChannel` instead. It is deterministic, cleaner, doesn't need a new test seam, and naturally covers `local` and `pr-<N>` builds. The signal was already baked into the CLI assembly and validated centrally.

### Validation

```bash
# On a daily CLI
aspire update --channel staging
# Now exits FailedToUpgradeProject with a localized message naming the daily
# identity and pointing at overrideStagingFeed / installing a staging CLI,
# instead of resolving daily packages.

# Escape hatch still works
aspire config set -g overrideStagingFeed <feed-url>
aspire update --channel staging
# Succeeds; logs "Resolved 'staging' channel: feed=..., quality=..., pinnedVersion=...".

# Default behavior unaffected
aspire update
# Unchanged; only the explicit --channel staging path is touched on daily CLIs.
```

Stable / staging-identity CLIs are unaffected.

### Automated coverage

- `tests/Aspire.Cli.Tests/Packaging/PackagingServiceTests.cs` adds the full identity matrix: stable, staging, daily, local, `pr-12345`, daily + `overrideStagingFeed`, daily + `StagingChannelEnabled` feature flag. The previous test that asserted the buggy local-CLI shared-feed behavior is rewritten to assert refusal.
- `tests/Aspire.Cli.Tests/Commands/UpdateCommandTests.cs` adds a regression test verifying that `--channel staging` surfaces the staging-specific reason via `DisplayError` and exits `FailedToUpgradeProject`.
- `TestPackagingService` gains a matching fake member that defaults to reporting staging as available, so existing tests stay unchanged.

All 3,217 `Aspire.Cli.Tests` pass locally.

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
  - [x] No