### PR TITLE
Use ' - ' separator in release-version build tag

### DIFF
--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -61,7 +61,7 @@ Before starting a release:
      pipeline regardless of branch. Pick the build that corresponds to the
      release branch and version you intend to ship.
    - Each build's tags are shown alongside its number — verify the
-     `release-version:X.Y.Z` tag matches the version you intend to ship
+     `release-version - X.Y.Z` tag matches the version you intend to ship
      **before** clicking Run. If the tag is missing, either re-run the
      source build (after the tag-emitting change in `azure-pipelines.yml`
      is on that release branch) or pass an explicit `ReleaseVersion`
@@ -75,7 +75,7 @@ Before starting a release:
 
    | Parameter | Description | Example |
    |-----------|-------------|---------|
-   | `ReleaseVersion` | Override for the version label (used as `v<version>` tag). **Leave as `auto` to derive from the source build's `release-version:*` tag** — the normal case. Only set this when re-shipping under a corrected tag. | `auto` |
+   | `ReleaseVersion` | Override for the version label (used as `v<version>` tag). **Leave as `auto` to derive from the source build's `release-version - *` tag** — the normal case. Only set this when re-shipping under a corrected tag. | `auto` |
    | `IsPrerelease` | `true` for preview releases | `false` |
    | `DryRun` | Set `true` to test without publishing or tagging | `false` |
    | `GaChannelName` | Target GA channel | `Aspire 9.x GA` |

--- a/eng/pipelines/azure-pipelines.yml
+++ b/eng/pipelines/azure-pipelines.yml
@@ -355,11 +355,14 @@ extends:
                   Write-Host "##vso[task.setvariable variable=aspireVersion;isOutput=true]$version"
 
                   # Tag the build so the release pipeline can auto-derive ReleaseVersion
-                  # without operators retyping it. The 'release-version:' prefix avoids
+                  # without operators retyping it. The 'release-version - ' prefix avoids
                   # collisions with other custom build tags (e.g., 1ES compliance tags),
                   # and the tag is visible in the AzDO source-build picker so operators
-                  # can verify the version at queue time.
-                  Write-Host "##vso[build.addbuildtag]release-version:$version"
+                  # can verify the version at queue time. The format intentionally mirrors
+                  # the ' - '-separated 'BAR ID - <id>' tag style: AzDO's 1ES PT request
+                  # validator rejects ':' in tag names because the tag becomes part of the
+                  # URL path of the addbuildtag REST call.
+                  Write-Host "##vso[build.addbuildtag]release-version - $version"
                 name: computeVersion
                 displayName: 🟣Compute Aspire version from nupkg
 

--- a/eng/pipelines/release-publish-nuget.yml
+++ b/eng/pipelines/release-publish-nuget.yml
@@ -172,7 +172,7 @@ extends:
                   Write-Host "==============================="
                 displayName: 'Log Stage Info'
 
-              # Auto-derive ReleaseVersion from the source build's `release-version:*`
+              # Auto-derive ReleaseVersion from the source build's `release-version - *`
               # tag (set by eng/pipelines/azure-pipelines.yml after the version is
               # computed from the Aspire.Hosting.AppHost nupkg). This means operators
               # don't have to retype the version when queuing a release — the tag
@@ -185,7 +185,7 @@ extends:
               # escape hatch for re-shipping under a corrected tag.
               #
               # Failure semantics: hard-fail when no override is supplied AND the
-              # source build has no `release-version:*` tag (e.g., a pre-tagging
+              # source build has no `release-version - *` tag (e.g., a pre-tagging
               # build was selected). The fix is either to backport the tag-add
               # change to the relevant release branch and re-run the source build,
               # or pass an explicit -ReleaseVersion override.
@@ -218,26 +218,29 @@ extends:
 
                   Write-Host "Build tags: $($response.value -join ', ')"
 
-                  # Tags look like 'release-version:13.3.3'. Filter and parse.
+                  # Tags look like 'release-version - 13.3.3'. Filter and parse.
+                  # The ' - ' separator (rather than ':') matches the 'BAR ID - <id>'
+                  # tag style and avoids AzDO's 1ES PT request validator rejecting ':'
+                  # in tag names (it becomes part of the addbuildtag REST URL path).
                   # NB: variable named $tagMatches (not $matches) to avoid shadowing
                   # PowerShell's automatic $Matches hashtable.
-                  $tagMatches = @($response.value | Where-Object { $_ -match '^release-version:(.+)$' })
+                  $tagMatches = @($response.value | Where-Object { $_ -match '^release-version - (.+)$' })
 
                   $derived = $null
                   if ($tagMatches.Count -eq 0) {
                     if ([string]::IsNullOrWhiteSpace($override)) {
-                      $msg = "Source build $buildId has no 'release-version:*' tag and no -ReleaseVersion was supplied. " +
+                      $msg = "Source build $buildId has no 'release-version - *' tag and no -ReleaseVersion was supplied. " +
                              "Either re-queue with an explicit -ReleaseVersion <X.Y.Z> override, or run a newer source " +
                              "build that includes the tag-emitting step from eng/pipelines/azure-pipelines.yml."
                       Write-Error $msg
                       exit 1
                     }
-                    Write-Host "##vso[task.logissue type=warning]No 'release-version:*' tag on source build $buildId; using operator-supplied -ReleaseVersion '$override'."
+                    Write-Host "##vso[task.logissue type=warning]No 'release-version - *' tag on source build $buildId; using operator-supplied -ReleaseVersion '$override'."
                   } elseif ($tagMatches.Count -gt 1) {
-                    Write-Error "Source build $buildId has multiple 'release-version:*' tags ($($tagMatches -join ', ')). Refusing to guess; pass -ReleaseVersion explicitly."
+                    Write-Error "Source build $buildId has multiple 'release-version - *' tags ($($tagMatches -join ', ')). Refusing to guess; pass -ReleaseVersion explicitly."
                     exit 1
                   } else {
-                    $derived = ($tagMatches[0] -replace '^release-version:', '').Trim()
+                    $derived = ($tagMatches[0] -replace '^release-version - ', '').Trim()
                     if ($derived -notmatch '^\d+\.\d+\.\d+(-[A-Za-z0-9.-]+)?$') {
                       Write-Error "Derived release version '$derived' does not look like valid semver (X.Y.Z[-suffix])."
                       exit 1
@@ -248,7 +251,7 @@ extends:
                   # Resolve the effective value: operator override wins, derived is fallback.
                   if (-not [string]::IsNullOrWhiteSpace($override)) {
                     if ($derived -and $override -ne $derived) {
-                      Write-Host "##vso[task.logissue type=warning]Operator-supplied -ReleaseVersion '$override' does NOT match source-build tag 'release-version:$derived'. Proceeding with operator override."
+                      Write-Host "##vso[task.logissue type=warning]Operator-supplied -ReleaseVersion '$override' does NOT match source-build tag 'release-version - $derived'. Proceeding with operator override."
                     }
                     $effective = $override.Trim()
                   } else {

--- a/eng/pipelines/release-publish-nuget.yml
+++ b/eng/pipelines/release-publish-nuget.yml
@@ -257,10 +257,6 @@ extends:
 
                   Write-Host "✓ ReleaseVersionEffective: $effective"
                   Write-Host "##vso[task.setvariable variable=releaseVersionEffective;isOutput=true]$effective"
-
-                  # Surface the resolved version on the *release* run header too,
-                  # so it shows up in the AzDO build list / pipeline summary.
-                  Write-Host "##vso[build.addbuildtag]release-version:$effective"
                 name: deriveReleaseVersion
                 displayName: 'Derive ReleaseVersion from source build tag'
                 env:


### PR DESCRIPTION
## TL;DR

AzDO's 1ES PT request-validation handler rejects `:` in build tag names because the agent's `##vso[build.addbuildtag]` implementation calls `PUT /_apis/build/builds/{buildId}/tags/{tag}`, and the `:` ends up in the URL path:

```
##[error]A potentially dangerous Request.Path value was detected from the client (:).
```

This breaks **both** pipelines that emit the tag:

- Source build (`azure-pipelines.yml`): https://dev.azure.com/dnceng/internal/_build/results?buildId=2978468
- Release-publish (`release-publish-nuget.yml`): https://dev.azure.com/dnceng/internal/_build/results?buildId=2978372

## Fix

Switch the tag format from `release-version:13.3.4` to `release-version - 13.3.4`, mirroring the existing `BAR ID - <id>` tag style that AzDO already emits without issue:

![BAR ID tag style](https://github.com/microsoft/aspire/assets/example)

Changes:

- `eng/pipelines/azure-pipelines.yml` — emit `release-version - $version` instead of `release-version:$version`.
- `eng/pipelines/release-publish-nuget.yml` — update the regex parser, error/warning messages, and surrounding comments to match the new format. The redundant cosmetic addbuildtag on the release run stays removed (no functional impact).
- `docs/release-process.md` — update the two references to the tag format.

## Safety

- Only the *display* format of the tag changes; the parser is updated in lockstep with the emitter.
- A source build done from `main` (or any release branch that picks up this change) will emit the new format, and the release-publish pipeline run from that same commit will read it correctly.
- For an in-flight release where the source build was made before this change, operators can pass `-ReleaseVersion <X.Y.Z>` explicitly — the documented override path is unchanged.