### PR TITLE
Forward AppHostFilePath/ProjectDirectory from Rust, Go, and Java SDKs

### DIFF
--- a/src/Aspire.Hosting.CodeGeneration.Go/AtsGoCodeGenerator.cs
+++ b/src/Aspire.Hosting.CodeGeneration.Go/AtsGoCodeGenerator.cs
@@ -1863,8 +1863,14 @@ internal sealed class AtsGoCodeGenerator : ICodeGenerator
             WriteLine("\t}");
         }
         WriteLine("\tif _, ok := resolved[\"Args\"]; !ok { resolved[\"Args\"] = os.Args[1:] }");
+        // ASPIRE_PROJECT_DIRECTORY is set by the CLI so the host reports the correct project
+        // directory (not the cwd) when matching --apphost <directory> requests.
         WriteLine("\tif projectDirectory, ok := resolved[\"ProjectDirectory\"].(string); !ok || projectDirectory == \"\" {");
-        WriteLine("\t\tif pwd, err := os.Getwd(); err == nil { resolved[\"ProjectDirectory\"] = pwd }");
+        WriteLine("\t\tif projectDirectory := os.Getenv(\"ASPIRE_PROJECT_DIRECTORY\"); projectDirectory != \"\" {");
+        WriteLine("\t\t\tresolved[\"ProjectDirectory\"] = projectDirectory");
+        WriteLine("\t\t} else if pwd, err := os.Getwd(); err == nil {");
+        WriteLine("\t\t\tresolved[\"ProjectDirectory\"] = pwd");
+        WriteLine("\t\t}");
         WriteLine("\t}");
         WriteLine("\tif appHostFilePath, ok := resolved[\"AppHostFilePath\"].(string); !ok || appHostFilePath == \"\" {");
         WriteLine("\t\tif appHostFilePath := os.Getenv(\"ASPIRE_APPHOST_FILEPATH\"); appHostFilePath != \"\" { resolved[\"AppHostFilePath\"] = appHostFilePath }");

--- a/src/Aspire.Hosting.CodeGeneration.Java/AtsJavaCodeGenerator.cs
+++ b/src/Aspire.Hosting.CodeGeneration.Java/AtsJavaCodeGenerator.cs
@@ -1840,8 +1840,14 @@ internal sealed class AtsJavaCodeGenerator : ICodeGenerator
         WriteLine("            // Note: Java doesn't have easy access to command line args from here");
         WriteLine("            resolvedOptions.put(\"Args\", new String[0]);");
         WriteLine("        }");
+        // ASPIRE_PROJECT_DIRECTORY is set by the CLI so the host reports the correct project
+        // directory (not the JVM's user.dir) when matching --apphost <directory> requests.
         WriteLine("        if (resolvedOptions.get(\"ProjectDirectory\") == null) {");
-        WriteLine("            resolvedOptions.put(\"ProjectDirectory\", System.getProperty(\"user.dir\"));");
+        WriteLine("            String projectDirectory = System.getenv(\"ASPIRE_PROJECT_DIRECTORY\");");
+        WriteLine("            if (projectDirectory == null || projectDirectory.isEmpty()) {");
+        WriteLine("                projectDirectory = System.getProperty(\"user.dir\");");
+        WriteLine("            }");
+        WriteLine("            resolvedOptions.put(\"ProjectDirectory\", projectDirectory);");
         WriteLine("        }");
         WriteLine("        if (resolvedOptions.get(\"AppHostFilePath\") == null) {");
         WriteLine("            String appHostFilePath = System.getenv(\"ASPIRE_APPHOST_FILEPATH\");");

--- a/src/Aspire.Hosting.CodeGeneration.Rust/AtsRustCodeGenerator.cs
+++ b/src/Aspire.Hosting.CodeGeneration.Rust/AtsRustCodeGenerator.cs
@@ -737,8 +737,28 @@ internal sealed class AtsRustCodeGenerator : ICodeGenerator
         WriteLine("        resolved_options.insert(\"Args\".to_string(), serde_json::to_value(args).unwrap_or(Value::Null));");
         WriteLine("    }");
         WriteLine("    if !resolved_options.contains_key(\"ProjectDirectory\") {");
-        WriteLine("        if let Ok(pwd) = std::env::current_dir() {");
-        WriteLine("            resolved_options.insert(\"ProjectDirectory\".to_string(), Value::String(pwd.to_string_lossy().to_string()));");
+        // ASPIRE_PROJECT_DIRECTORY is set by the CLI so the host reports the correct project
+        // directory (not the cwd) when matching --apphost <directory> requests.
+        WriteLine("        if let Ok(project_directory) = std::env::var(\"ASPIRE_PROJECT_DIRECTORY\") {");
+        WriteLine("            if !project_directory.is_empty() {");
+        WriteLine("                resolved_options.insert(\"ProjectDirectory\".to_string(), Value::String(project_directory));");
+        WriteLine("            }");
+        WriteLine("        }");
+        WriteLine("        if !resolved_options.contains_key(\"ProjectDirectory\") {");
+        WriteLine("            if let Ok(pwd) = std::env::current_dir() {");
+        WriteLine("                resolved_options.insert(\"ProjectDirectory\".to_string(), Value::String(pwd.to_string_lossy().to_string()));");
+        WriteLine("            }");
+        WriteLine("        }");
+        WriteLine("    }");
+        // ASPIRE_APPHOST_FILEPATH is set by the CLI so the host reports the original AppHost file
+        // path (e.g. apphost.rs) back through GetAppHostInformationAsync. Without this the host
+        // falls back to the aspire-managed entry assembly name and the CLI cannot match
+        // --apphost <directory> against the running AppHost.
+        WriteLine("    if !resolved_options.contains_key(\"AppHostFilePath\") {");
+        WriteLine("        if let Ok(app_host_file_path) = std::env::var(\"ASPIRE_APPHOST_FILEPATH\") {");
+        WriteLine("            if !app_host_file_path.is_empty() {");
+        WriteLine("                resolved_options.insert(\"AppHostFilePath\".to_string(), Value::String(app_host_file_path));");
+        WriteLine("            }");
         WriteLine("        }");
         WriteLine("    }");
         WriteLine("    let mut args: HashMap<String, Value> = HashMap::new();");

--- a/src/Aspire.Hosting.CodeGeneration.Rust/AtsRustCodeGenerator.cs
+++ b/src/Aspire.Hosting.CodeGeneration.Rust/AtsRustCodeGenerator.cs
@@ -739,15 +739,10 @@ internal sealed class AtsRustCodeGenerator : ICodeGenerator
         WriteLine("    if !resolved_options.contains_key(\"ProjectDirectory\") {");
         // ASPIRE_PROJECT_DIRECTORY is set by the CLI so the host reports the correct project
         // directory (not the cwd) when matching --apphost <directory> requests.
-        WriteLine("        if let Ok(project_directory) = std::env::var(\"ASPIRE_PROJECT_DIRECTORY\") {");
-        WriteLine("            if !project_directory.is_empty() {");
-        WriteLine("                resolved_options.insert(\"ProjectDirectory\".to_string(), Value::String(project_directory));");
-        WriteLine("            }");
-        WriteLine("        }");
-        WriteLine("        if !resolved_options.contains_key(\"ProjectDirectory\") {");
-        WriteLine("            if let Ok(pwd) = std::env::current_dir() {");
-        WriteLine("                resolved_options.insert(\"ProjectDirectory\".to_string(), Value::String(pwd.to_string_lossy().to_string()));");
-        WriteLine("            }");
+        WriteLine("        if let Some(project_directory) = std::env::var(\"ASPIRE_PROJECT_DIRECTORY\").ok().filter(|s| !s.is_empty()) {");
+        WriteLine("            resolved_options.insert(\"ProjectDirectory\".to_string(), Value::String(project_directory));");
+        WriteLine("        } else if let Ok(pwd) = std::env::current_dir() {");
+        WriteLine("            resolved_options.insert(\"ProjectDirectory\".to_string(), Value::String(pwd.to_string_lossy().to_string()));");
         WriteLine("        }");
         WriteLine("    }");
         // ASPIRE_APPHOST_FILEPATH is set by the CLI so the host reports the original AppHost file

--- a/tests/Aspire.Cli.EndToEnd.Tests/JavaPolyglotApphostDirectoryTests.cs
+++ b/tests/Aspire.Cli.EndToEnd.Tests/JavaPolyglotApphostDirectoryTests.cs
@@ -1,0 +1,118 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Aspire.Cli.EndToEnd.Tests.Helpers;
+using Aspire.Cli.Resources;
+using Aspire.Cli.Tests.Utils;
+using Hex1b.Automation;
+using Xunit;
+
+namespace Aspire.Cli.EndToEnd.Tests;
+
+/// <summary>
+/// Regression coverage for https://github.com/microsoft/aspire/issues/16513.
+/// Polyglot (non-.NET) AppHosts run under a generic host process named "aspire-managed",
+/// so without the env-var-based AppHostPath wiring in <c>AtsJavaCodeGenerator</c> the AppHost
+/// reports its path as "&lt;dir&gt;/aspire-managed" and <c>aspire &lt;cmd&gt; --apphost
+/// &lt;directory&gt;</c> cannot match the running guest AppHost via its backchannel socket.
+/// This test duplicates the JavaPolyglotTests setup but starts the AppHost in the background
+/// and then issues <c>aspire stop --non-interactive --apphost &lt;directory&gt;</c> from an
+/// unrelated cwd so the stop command is forced to resolve the AppHost via the path the host
+/// reported over the backchannel.
+/// Each test class runs as a separate CI job for parallelization.
+/// </summary>
+public sealed class JavaPolyglotApphostDirectoryTests(ITestOutputHelper output)
+{
+    [Fact]
+    [CaptureWorkspaceOnFailure]
+    public async Task StopJavaPolyglotAppHostUsingApphostDirectory()
+    {
+        var repoRoot = CliE2ETestHelpers.GetRepoRoot();
+        var strategy = CliInstallStrategy.Detect(output.WriteLine);
+        var workspace = TemporaryWorkspace.Create(output);
+
+        using var terminal = CliE2ETestHelpers.CreateDockerTestTerminal(repoRoot, strategy, output, variant: CliE2ETestHelpers.DockerfileVariant.PolyglotJava, mountDockerSocket: true, workspace: workspace);
+
+        var pendingRun = terminal.RunAsync(TestContext.Current.CancellationToken);
+
+        var counter = new SequenceCounter();
+        var auto = new Hex1bTerminalAutomator(terminal, defaultTimeout: TimeSpan.FromSeconds(500));
+
+        await auto.PrepareDockerEnvironmentAsync(counter, workspace);
+        await auto.InstallAspireCliAsync(strategy, counter);
+        await auto.EnableExperimentalJavaSupportAsync(counter);
+
+        // Put the AppHost in a subdirectory so we can `cd ..` away from it and then resolve it
+        // back via `--apphost javaapp`. That forces AppHost discovery through the path the
+        // running host reported over the backchannel (the bug scenario from issue 16513),
+        // rather than through the current working directory.
+        await auto.TypeAsync("mkdir javaapp && cd javaapp");
+        await auto.EnterAsync();
+        await auto.WaitForSuccessPromptAsync(counter);
+
+        await auto.TypeAsync("aspire init");
+        await auto.EnterAsync();
+        await auto.WaitUntilTextAsync("Which language would you like to use?", timeout: TimeSpan.FromSeconds(30));
+        await auto.DownAsync();
+        await auto.DownAsync();
+        await auto.WaitUntilTextAsync("> Java", timeout: TimeSpan.FromSeconds(5));
+        await auto.EnterAsync();
+        await auto.WaitUntilTextAsync("Created AppHost.java", timeout: TimeSpan.FromMinutes(2));
+        await auto.DeclineAgentInitPromptAsync(counter);
+
+        await auto.TypeAsync("npm create -y vite@latest viteapp -- --template vanilla-ts --no-interactive");
+        await auto.EnterAsync();
+        await auto.WaitForSuccessPromptAsync(counter, TimeSpan.FromMinutes(2));
+
+        await auto.TypeAsync("cd viteapp && npm install && cd ..");
+        await auto.EnterAsync();
+        await auto.WaitForSuccessPromptAsync(counter, TimeSpan.FromMinutes(2));
+
+        await auto.TypeAsync("aspire add Aspire.Hosting.JavaScript");
+        await auto.EnterAsync();
+        await auto.WaitUntilTextAsync("The package Aspire.Hosting.", timeout: TimeSpan.FromMinutes(2));
+        await auto.WaitForSuccessPromptAsync(counter);
+
+        var appHostPath = Path.Combine(workspace.WorkspaceRoot.FullName, "javaapp", "AppHost.java");
+        var newContent = """
+            import aspire.*;
+
+            void main(String[] args) throws Exception {
+                var builder = DistributedApplication.CreateBuilder(args);
+
+                ViteAppResource viteApp = builder.addViteApp("viteapp", "./viteapp");
+
+                builder.build().run();
+            }
+            """;
+
+        File.WriteAllText(appHostPath, newContent);
+
+        // Start the AppHost in the background (returns to the prompt once the AppHost reports it
+        // has started over the backchannel).
+        await auto.TypeAsync("aspire start");
+        await auto.EnterAsync();
+        await auto.WaitUntilTextAsync(RunCommandStrings.AppHostStartedSuccessfully, timeout: TimeSpan.FromMinutes(3));
+        await auto.WaitForSuccessPromptAsync(counter);
+
+        await auto.ClearScreenAsync(counter);
+
+        // Leave the AppHost directory so the only way `aspire stop` can find the running guest
+        // AppHost is via the AppHostPath it reported over the backchannel. Without the env-var
+        // fix, the reported path ends in "aspire-managed" and this stop call would fail with
+        // "AppHost not running at path".
+        await auto.TypeAsync("cd ..");
+        await auto.EnterAsync();
+        await auto.WaitForSuccessPromptAsync(counter);
+
+        await auto.TypeAsync("aspire stop --non-interactive --apphost javaapp");
+        await auto.EnterAsync();
+        await auto.WaitUntilAppHostStoppedSuccessfullyAsync(timeout: TimeSpan.FromMinutes(1));
+        await auto.WaitForSuccessPromptAsync(counter);
+
+        await auto.TypeAsync("exit");
+        await auto.EnterAsync();
+
+        await pendingRun;
+    }
+}

--- a/tests/Aspire.Cli.EndToEnd.Tests/TypeScriptPolyglotApphostDirectoryTests.cs
+++ b/tests/Aspire.Cli.EndToEnd.Tests/TypeScriptPolyglotApphostDirectoryTests.cs
@@ -1,0 +1,122 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Aspire.Cli.EndToEnd.Tests.Helpers;
+using Aspire.Cli.Resources;
+using Aspire.Cli.Tests.Utils;
+using Hex1b.Automation;
+using Xunit;
+
+namespace Aspire.Cli.EndToEnd.Tests;
+
+/// <summary>
+/// Regression coverage for https://github.com/microsoft/aspire/issues/16513.
+/// TypeScript polyglot AppHosts run under the generic "aspire-managed" host process.
+/// <c>AtsTypeScriptCodeGenerator</c> forwards <c>ASPIRE_APPHOST_FILEPATH</c> /
+/// <c>ASPIRE_PROJECT_DIRECTORY</c> through <c>createBuilder</c> so the AppHost reports its
+/// real path over the backchannel; this test guards that wiring by starting the AppHost in
+/// the background and stopping it from an unrelated cwd via
+/// <c>aspire stop --apphost &lt;directory&gt;</c>. If the forwarding ever regresses the stop
+/// call would fail to locate the running AppHost.
+/// Each test class runs as a separate CI job for parallelization.
+/// </summary>
+public sealed class TypeScriptPolyglotApphostDirectoryTests(ITestOutputHelper output)
+{
+    [Fact]
+    [CaptureWorkspaceOnFailure]
+    public async Task StopTypeScriptPolyglotAppHostUsingApphostDirectory()
+    {
+        var repoRoot = CliE2ETestHelpers.GetRepoRoot();
+        var strategy = CliInstallStrategy.Detect(output.WriteLine);
+        var workspace = TemporaryWorkspace.Create(output);
+        var localChannel = CliE2ETestHelpers.PrepareLocalChannel(repoRoot, strategy,
+            ["Aspire.Hosting.CodeGeneration.TypeScript.", "Aspire.Hosting.JavaScript."]);
+
+        // LocalHive strategy only: PrepareLocalChannel returned a real channel, so pass
+        // --channel local explicitly. Other strategies return null and rely on the CLI's baked
+        // channel + ambient NuGet feeds.
+        var channelArgument = localChannel is not null ? " --channel local" : string.Empty;
+
+        using var terminal = CliE2ETestHelpers.CreateDockerTestTerminal(repoRoot, strategy, output, variant: CliE2ETestHelpers.DockerfileVariant.Polyglot, mountDockerSocket: true, workspace: workspace);
+
+        var pendingRun = terminal.RunAsync(TestContext.Current.CancellationToken);
+
+        var counter = new SequenceCounter();
+        var auto = new Hex1bTerminalAutomator(terminal, defaultTimeout: TimeSpan.FromSeconds(500));
+
+        await auto.PrepareDockerEnvironmentAsync(counter, workspace);
+        await auto.InstallAspireCliAsync(strategy, counter);
+
+        // Put the AppHost in a subdirectory so the stop command must resolve the AppHost via
+        // the path the running host reported over the backchannel rather than via the current
+        // cwd. This is the scenario from issue 16513.
+        await auto.TypeAsync("mkdir tsapp && cd tsapp");
+        await auto.EnterAsync();
+        await auto.WaitForSuccessPromptAsync(counter);
+
+        await auto.TypeAsync($"aspire init --language typescript --non-interactive{channelArgument}");
+        await auto.EnterAsync();
+        await auto.WaitUntilTextAsync("Created apphost.ts", timeout: TimeSpan.FromMinutes(2));
+        await auto.DeclineAgentInitPromptAsync(counter);
+
+        var projectRoot = Path.Combine(workspace.WorkspaceRoot.FullName, "tsapp");
+
+        if (localChannel is not null)
+        {
+            CliE2ETestHelpers.WriteLocalChannelSettings(projectRoot, localChannel.SdkVersion);
+        }
+
+        await auto.TypeAsync("npm create -y vite@latest viteapp -- --template vanilla-ts --no-interactive");
+        await auto.EnterAsync();
+        await auto.WaitForSuccessPromptAsync(counter, TimeSpan.FromMinutes(2));
+
+        await auto.TypeAsync("cd viteapp && npm install && cd ..");
+        await auto.EnterAsync();
+        await auto.WaitForSuccessPromptAsync(counter, TimeSpan.FromMinutes(2));
+
+        await auto.TypeAsync("aspire add Aspire.Hosting.JavaScript");
+        await auto.EnterAsync();
+        await auto.WaitForAspireAddSuccessAsync(counter, TimeSpan.FromMinutes(2));
+
+        var appHostPath = Path.Combine(projectRoot, "apphost.ts");
+        var newContent = """
+            // Aspire TypeScript AppHost
+            // For more information, see: https://aspire.dev
+
+            import { createBuilder } from './.modules/aspire.js';
+
+            const builder = await createBuilder();
+
+            const viteApp = await builder.addViteApp("viteapp", "./viteapp");
+
+            await builder.build().run();
+            """;
+
+        File.WriteAllText(appHostPath, newContent);
+
+        // Start the AppHost in the background. `aspire start` returns to the prompt once the
+        // backchannel is established and the AppHost reports it has started.
+        await auto.TypeAsync("aspire start");
+        await auto.EnterAsync();
+        await auto.WaitUntilTextAsync(RunCommandStrings.AppHostStartedSuccessfully, timeout: TimeSpan.FromMinutes(3));
+        await auto.WaitForSuccessPromptAsync(counter);
+
+        await auto.ClearScreenAsync(counter);
+
+        // Leave the AppHost directory so the only way `aspire stop` can find the running guest
+        // AppHost is via the AppHostPath it reported over the backchannel.
+        await auto.TypeAsync("cd ..");
+        await auto.EnterAsync();
+        await auto.WaitForSuccessPromptAsync(counter);
+
+        await auto.TypeAsync("aspire stop --non-interactive --apphost tsapp");
+        await auto.EnterAsync();
+        await auto.WaitUntilAppHostStoppedSuccessfullyAsync(timeout: TimeSpan.FromMinutes(1));
+        await auto.WaitForSuccessPromptAsync(counter);
+
+        await auto.TypeAsync("exit");
+        await auto.EnterAsync();
+
+        await pendingRun;
+    }
+}

--- a/tests/Aspire.Hosting.CodeGeneration.Go.Tests/Snapshots/AtsGeneratedAspire.verified.go
+++ b/tests/Aspire.Hosting.CodeGeneration.Go.Tests/Snapshots/AtsGeneratedAspire.verified.go
@@ -2338,7 +2338,11 @@ func CreateBuilder() (IDistributedApplicationBuilder, error) {
 	resolved := map[string]any{}
 	if _, ok := resolved["Args"]; !ok { resolved["Args"] = os.Args[1:] }
 	if projectDirectory, ok := resolved["ProjectDirectory"].(string); !ok || projectDirectory == "" {
-		if pwd, err := os.Getwd(); err == nil { resolved["ProjectDirectory"] = pwd }
+		if projectDirectory := os.Getenv("ASPIRE_PROJECT_DIRECTORY"); projectDirectory != "" {
+			resolved["ProjectDirectory"] = projectDirectory
+		} else if pwd, err := os.Getwd(); err == nil {
+			resolved["ProjectDirectory"] = pwd
+		}
 	}
 	if appHostFilePath, ok := resolved["AppHostFilePath"].(string); !ok || appHostFilePath == "" {
 		if appHostFilePath := os.Getenv("ASPIRE_APPHOST_FILEPATH"); appHostFilePath != "" { resolved["AppHostFilePath"] = appHostFilePath }

--- a/tests/Aspire.Hosting.CodeGeneration.Go.Tests/Snapshots/TwoPassScanningGeneratedAspire.verified.go
+++ b/tests/Aspire.Hosting.CodeGeneration.Go.Tests/Snapshots/TwoPassScanningGeneratedAspire.verified.go
@@ -25183,7 +25183,11 @@ func CreateBuilder(options ...*CreateBuilderOptions) (DistributedApplicationBuil
 	}
 	if _, ok := resolved["Args"]; !ok { resolved["Args"] = os.Args[1:] }
 	if projectDirectory, ok := resolved["ProjectDirectory"].(string); !ok || projectDirectory == "" {
-		if pwd, err := os.Getwd(); err == nil { resolved["ProjectDirectory"] = pwd }
+		if projectDirectory := os.Getenv("ASPIRE_PROJECT_DIRECTORY"); projectDirectory != "" {
+			resolved["ProjectDirectory"] = projectDirectory
+		} else if pwd, err := os.Getwd(); err == nil {
+			resolved["ProjectDirectory"] = pwd
+		}
 	}
 	if appHostFilePath, ok := resolved["AppHostFilePath"].(string); !ok || appHostFilePath == "" {
 		if appHostFilePath := os.Getenv("ASPIRE_APPHOST_FILEPATH"); appHostFilePath != "" { resolved["AppHostFilePath"] = appHostFilePath }

--- a/tests/Aspire.Hosting.CodeGeneration.Java.Tests/Snapshots/AtsGeneratedAspire.verified.java
+++ b/tests/Aspire.Hosting.CodeGeneration.Java.Tests/Snapshots/AtsGeneratedAspire.verified.java
@@ -39,7 +39,11 @@ public class Aspire {
             resolvedOptions.put("Args", new String[0]);
         }
         if (resolvedOptions.get("ProjectDirectory") == null) {
-            resolvedOptions.put("ProjectDirectory", System.getProperty("user.dir"));
+            String projectDirectory = System.getenv("ASPIRE_PROJECT_DIRECTORY");
+            if (projectDirectory == null || projectDirectory.isEmpty()) {
+                projectDirectory = System.getProperty("user.dir");
+            }
+            resolvedOptions.put("ProjectDirectory", projectDirectory);
         }
         if (resolvedOptions.get("AppHostFilePath") == null) {
             String appHostFilePath = System.getenv("ASPIRE_APPHOST_FILEPATH");

--- a/tests/Aspire.Hosting.CodeGeneration.Java.Tests/Snapshots/TwoPassScanningGeneratedAspire.verified.java
+++ b/tests/Aspire.Hosting.CodeGeneration.Java.Tests/Snapshots/TwoPassScanningGeneratedAspire.verified.java
@@ -240,7 +240,11 @@ public class Aspire {
             resolvedOptions.put("Args", new String[0]);
         }
         if (resolvedOptions.get("ProjectDirectory") == null) {
-            resolvedOptions.put("ProjectDirectory", System.getProperty("user.dir"));
+            String projectDirectory = System.getenv("ASPIRE_PROJECT_DIRECTORY");
+            if (projectDirectory == null || projectDirectory.isEmpty()) {
+                projectDirectory = System.getProperty("user.dir");
+            }
+            resolvedOptions.put("ProjectDirectory", projectDirectory);
         }
         if (resolvedOptions.get("AppHostFilePath") == null) {
             String appHostFilePath = System.getenv("ASPIRE_APPHOST_FILEPATH");

--- a/tests/Aspire.Hosting.CodeGeneration.Rust.Tests/Snapshots/AtsGeneratedAspire.verified.rs
+++ b/tests/Aspire.Hosting.CodeGeneration.Rust.Tests/Snapshots/AtsGeneratedAspire.verified.rs
@@ -1748,8 +1748,22 @@ pub fn create_builder(options: Option<CreateBuilderOptions>) -> Result<IDistribu
         resolved_options.insert("Args".to_string(), serde_json::to_value(args).unwrap_or(Value::Null));
     }
     if !resolved_options.contains_key("ProjectDirectory") {
-        if let Ok(pwd) = std::env::current_dir() {
-            resolved_options.insert("ProjectDirectory".to_string(), Value::String(pwd.to_string_lossy().to_string()));
+        if let Ok(project_directory) = std::env::var("ASPIRE_PROJECT_DIRECTORY") {
+            if !project_directory.is_empty() {
+                resolved_options.insert("ProjectDirectory".to_string(), Value::String(project_directory));
+            }
+        }
+        if !resolved_options.contains_key("ProjectDirectory") {
+            if let Ok(pwd) = std::env::current_dir() {
+                resolved_options.insert("ProjectDirectory".to_string(), Value::String(pwd.to_string_lossy().to_string()));
+            }
+        }
+    }
+    if !resolved_options.contains_key("AppHostFilePath") {
+        if let Ok(app_host_file_path) = std::env::var("ASPIRE_APPHOST_FILEPATH") {
+            if !app_host_file_path.is_empty() {
+                resolved_options.insert("AppHostFilePath".to_string(), Value::String(app_host_file_path));
+            }
         }
     }
     let mut args: HashMap<String, Value> = HashMap::new();

--- a/tests/Aspire.Hosting.CodeGeneration.Rust.Tests/Snapshots/AtsGeneratedAspire.verified.rs
+++ b/tests/Aspire.Hosting.CodeGeneration.Rust.Tests/Snapshots/AtsGeneratedAspire.verified.rs
@@ -1,4 +1,4 @@
-//! aspire.rs - Capability-based Aspire SDK
+﻿//! aspire.rs - Capability-based Aspire SDK
 //! GENERATED CODE - DO NOT EDIT
 
 use std::collections::HashMap;
@@ -1748,15 +1748,10 @@ pub fn create_builder(options: Option<CreateBuilderOptions>) -> Result<IDistribu
         resolved_options.insert("Args".to_string(), serde_json::to_value(args).unwrap_or(Value::Null));
     }
     if !resolved_options.contains_key("ProjectDirectory") {
-        if let Ok(project_directory) = std::env::var("ASPIRE_PROJECT_DIRECTORY") {
-            if !project_directory.is_empty() {
-                resolved_options.insert("ProjectDirectory".to_string(), Value::String(project_directory));
-            }
-        }
-        if !resolved_options.contains_key("ProjectDirectory") {
-            if let Ok(pwd) = std::env::current_dir() {
-                resolved_options.insert("ProjectDirectory".to_string(), Value::String(pwd.to_string_lossy().to_string()));
-            }
+        if let Some(project_directory) = std::env::var("ASPIRE_PROJECT_DIRECTORY").ok().filter(|s| !s.is_empty()) {
+            resolved_options.insert("ProjectDirectory".to_string(), Value::String(project_directory));
+        } else if let Ok(pwd) = std::env::current_dir() {
+            resolved_options.insert("ProjectDirectory".to_string(), Value::String(pwd.to_string_lossy().to_string()));
         }
     }
     if !resolved_options.contains_key("AppHostFilePath") {

--- a/tests/Aspire.Hosting.CodeGeneration.Rust.Tests/Snapshots/TwoPassScanningGeneratedAspire.verified.rs
+++ b/tests/Aspire.Hosting.CodeGeneration.Rust.Tests/Snapshots/TwoPassScanningGeneratedAspire.verified.rs
@@ -18006,8 +18006,22 @@ pub fn create_builder(options: Option<CreateBuilderOptions>) -> Result<IDistribu
         resolved_options.insert("Args".to_string(), serde_json::to_value(args).unwrap_or(Value::Null));
     }
     if !resolved_options.contains_key("ProjectDirectory") {
-        if let Ok(pwd) = std::env::current_dir() {
-            resolved_options.insert("ProjectDirectory".to_string(), Value::String(pwd.to_string_lossy().to_string()));
+        if let Ok(project_directory) = std::env::var("ASPIRE_PROJECT_DIRECTORY") {
+            if !project_directory.is_empty() {
+                resolved_options.insert("ProjectDirectory".to_string(), Value::String(project_directory));
+            }
+        }
+        if !resolved_options.contains_key("ProjectDirectory") {
+            if let Ok(pwd) = std::env::current_dir() {
+                resolved_options.insert("ProjectDirectory".to_string(), Value::String(pwd.to_string_lossy().to_string()));
+            }
+        }
+    }
+    if !resolved_options.contains_key("AppHostFilePath") {
+        if let Ok(app_host_file_path) = std::env::var("ASPIRE_APPHOST_FILEPATH") {
+            if !app_host_file_path.is_empty() {
+                resolved_options.insert("AppHostFilePath".to_string(), Value::String(app_host_file_path));
+            }
         }
     }
     let mut args: HashMap<String, Value> = HashMap::new();

--- a/tests/Aspire.Hosting.CodeGeneration.Rust.Tests/Snapshots/TwoPassScanningGeneratedAspire.verified.rs
+++ b/tests/Aspire.Hosting.CodeGeneration.Rust.Tests/Snapshots/TwoPassScanningGeneratedAspire.verified.rs
@@ -18006,15 +18006,10 @@ pub fn create_builder(options: Option<CreateBuilderOptions>) -> Result<IDistribu
         resolved_options.insert("Args".to_string(), serde_json::to_value(args).unwrap_or(Value::Null));
     }
     if !resolved_options.contains_key("ProjectDirectory") {
-        if let Ok(project_directory) = std::env::var("ASPIRE_PROJECT_DIRECTORY") {
-            if !project_directory.is_empty() {
-                resolved_options.insert("ProjectDirectory".to_string(), Value::String(project_directory));
-            }
-        }
-        if !resolved_options.contains_key("ProjectDirectory") {
-            if let Ok(pwd) = std::env::current_dir() {
-                resolved_options.insert("ProjectDirectory".to_string(), Value::String(pwd.to_string_lossy().to_string()));
-            }
+        if let Some(project_directory) = std::env::var("ASPIRE_PROJECT_DIRECTORY").ok().filter(|s| !s.is_empty()) {
+            resolved_options.insert("ProjectDirectory".to_string(), Value::String(project_directory));
+        } else if let Ok(pwd) = std::env::current_dir() {
+            resolved_options.insert("ProjectDirectory".to_string(), Value::String(pwd.to_string_lossy().to_string()));
         }
     }
     if !resolved_options.contains_key("AppHostFilePath") {


### PR DESCRIPTION
## Description

When a user runs `aspire <command> --apphost <directory>` against a running polyglot AppHost, the CLI matches the value against the `AppHostPath` that the host reports through `GetAppHostInformationAsync`. That value comes from `AppHost:FilePath` (set from `CreateBuilderOptions.AppHostFilePath`) and falls back to `AppHost:Path` which, for a polyglot AppHost, is computed from the entry assembly name — `aspire-managed`. When the SDK does not forward `AppHostFilePath` to the host, the reported path ends with `…/aspire-managed`, so the user's `--apphost <directory>` value never matches and commands like `aspire describe --apphost <directory>` fail to find the running AppHost.

The CLI already sets `ASPIRE_APPHOST_FILEPATH` and `ASPIRE_PROJECT_DIRECTORY` for every guest AppHost (`GuestAppHostProject.cs`). TypeScript and Python `createBuilder` both honor those environment variables; the Rust, Go, and Java generators did not, so polyglot AppHosts in those languages still hit this bug. This change brings those three SDKs to parity.

After updating the language SDK and matching CLI (13.4), `aspire --apphost <directory>` resolves a running guest AppHost for all five polyglot languages (TypeScript, Python, Rust, Go, Java).

Implementation details:

- `AtsRustCodeGenerator.create_builder` now falls back to `ASPIRE_PROJECT_DIRECTORY` before `std::env::current_dir()` and reads `ASPIRE_APPHOST_FILEPATH` into `AppHostFilePath` when not set. Previously neither environment variable was read.
- `AtsGoCodeGenerator` falls back to `os.Getenv("ASPIRE_PROJECT_DIRECTORY")` before `os.Getwd()`. The existing `ASPIRE_APPHOST_FILEPATH` fallback is unchanged.
- `AtsJavaCodeGenerator` falls back to `System.getenv("ASPIRE_PROJECT_DIRECTORY")` before `user.dir`. The existing `ASPIRE_APPHOST_FILEPATH` fallback is unchanged.
- Updates the Verify snapshots for the Go, Java, and Rust codegen tests.

Fixes #16513

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
