### PR TITLE
Fix AzDO build-tag failure by replacing ':' with '_' in release-version tag

### DIFF
--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -61,7 +61,7 @@ Before starting a release:
      pipeline regardless of branch. Pick the build that corresponds to the
      release branch and version you intend to ship.
    - Each build's tags are shown alongside its number — verify the
-     `release-version:X.Y.Z` tag matches the version you intend to ship
+     `release-version_X.Y.Z` tag matches the version you intend to ship
      **before** clicking Run. If the tag is missing, either re-run the
      source build (after the tag-emitting change in `azure-pipelines.yml`
      is on that release branch) or pass an explicit `ReleaseVersion`
@@ -75,7 +75,7 @@ Before starting a release:
 
    | Parameter | Description | Example |
    |-----------|-------------|---------|
-   | `ReleaseVersion` | Override for the version label (used as `v<version>` tag). **Leave as `auto` to derive from the source build's `release-version:*` tag** — the normal case. Only set this when re-shipping under a corrected tag. | `auto` |
+   | `ReleaseVersion` | Override for the version label (used as `v<version>` tag). **Leave as `auto` to derive from the source build's `release-version_*` tag** — the normal case. Only set this when re-shipping under a corrected tag. | `auto` |
    | `IsPrerelease` | `true` for preview releases | `false` |
    | `DryRun` | Set `true` to test without publishing or tagging | `false` |
    | `GaChannelName` | Target GA channel | `Aspire 9.x GA` |

--- a/eng/pipelines/azure-pipelines.yml
+++ b/eng/pipelines/azure-pipelines.yml
@@ -355,11 +355,18 @@ extends:
                   Write-Host "##vso[task.setvariable variable=aspireVersion;isOutput=true]$version"
 
                   # Tag the build so the release pipeline can auto-derive ReleaseVersion
-                  # without operators retyping it. The 'release-version:' prefix avoids
+                  # without operators retyping it. The 'release-version_' prefix avoids
                   # collisions with other custom build tags (e.g., 1ES compliance tags),
                   # and the tag is visible in the AzDO source-build picker so operators
                   # can verify the version at queue time.
-                  Write-Host "##vso[build.addbuildtag]release-version:$version"
+                  #
+                  # NB: we deliberately use '_' rather than ':' as the separator because
+                  # AzDO's task.addbuildtag command writes the tag via a REST endpoint
+                  # whose URL path contains the raw tag value; ASP.NET's request
+                  # validator rejects ':' in path segments with "A potentially dangerous
+                  # Request.Path value was detected from the client (:)", which fails
+                  # the pipeline step. '_' is path-safe and equally readable.
+                  Write-Host "##vso[build.addbuildtag]release-version_$version"
                 name: computeVersion
                 displayName: 🟣Compute Aspire version from nupkg
 

--- a/eng/pipelines/release-publish-nuget.yml
+++ b/eng/pipelines/release-publish-nuget.yml
@@ -172,7 +172,7 @@ extends:
                   Write-Host "==============================="
                 displayName: 'Log Stage Info'
 
-              # Auto-derive ReleaseVersion from the source build's `release-version:*`
+              # Auto-derive ReleaseVersion from the source build's `release-version_*`
               # tag (set by eng/pipelines/azure-pipelines.yml after the version is
               # computed from the Aspire.Hosting.AppHost nupkg). This means operators
               # don't have to retype the version when queuing a release — the tag
@@ -185,7 +185,7 @@ extends:
               # escape hatch for re-shipping under a corrected tag.
               #
               # Failure semantics: hard-fail when no override is supplied AND the
-              # source build has no `release-version:*` tag (e.g., a pre-tagging
+              # source build has no `release-version_*` tag (e.g., a pre-tagging
               # build was selected). The fix is either to backport the tag-add
               # change to the relevant release branch and re-run the source build,
               # or pass an explicit -ReleaseVersion override.
@@ -218,26 +218,32 @@ extends:
 
                   Write-Host "Build tags: $($response.value -join ', ')"
 
-                  # Tags look like 'release-version:13.3.3'. Filter and parse.
+                  # Tags look like 'release-version_13.3.3'. Filter and parse.
                   # NB: variable named $tagMatches (not $matches) to avoid shadowing
                   # PowerShell's automatic $Matches hashtable.
-                  $tagMatches = @($response.value | Where-Object { $_ -match '^release-version:(.+)$' })
+                  #
+                  # We use '_' rather than ':' as the prefix separator because AzDO's
+                  # task.addbuildtag REST call rejects ':' in path segments with
+                  # "A potentially dangerous Request.Path value was detected from the
+                  # client (:)". Old source builds tagged with ':' (pre-#17XXX) won't
+                  # match here — pass -ReleaseVersion explicitly to publish from those.
+                  $tagMatches = @($response.value | Where-Object { $_ -match '^release-version_(.+)$' })
 
                   $derived = $null
                   if ($tagMatches.Count -eq 0) {
                     if ([string]::IsNullOrWhiteSpace($override)) {
-                      $msg = "Source build $buildId has no 'release-version:*' tag and no -ReleaseVersion was supplied. " +
+                      $msg = "Source build $buildId has no 'release-version_*' tag and no -ReleaseVersion was supplied. " +
                              "Either re-queue with an explicit -ReleaseVersion <X.Y.Z> override, or run a newer source " +
                              "build that includes the tag-emitting step from eng/pipelines/azure-pipelines.yml."
                       Write-Error $msg
                       exit 1
                     }
-                    Write-Host "##vso[task.logissue type=warning]No 'release-version:*' tag on source build $buildId; using operator-supplied -ReleaseVersion '$override'."
+                    Write-Host "##vso[task.logissue type=warning]No 'release-version_*' tag on source build $buildId; using operator-supplied -ReleaseVersion '$override'."
                   } elseif ($tagMatches.Count -gt 1) {
-                    Write-Error "Source build $buildId has multiple 'release-version:*' tags ($($tagMatches -join ', ')). Refusing to guess; pass -ReleaseVersion explicitly."
+                    Write-Error "Source build $buildId has multiple 'release-version_*' tags ($($tagMatches -join ', ')). Refusing to guess; pass -ReleaseVersion explicitly."
                     exit 1
                   } else {
-                    $derived = ($tagMatches[0] -replace '^release-version:', '').Trim()
+                    $derived = ($tagMatches[0] -replace '^release-version_', '').Trim()
                     if ($derived -notmatch '^\d+\.\d+\.\d+(-[A-Za-z0-9.-]+)?$') {
                       Write-Error "Derived release version '$derived' does not look like valid semver (X.Y.Z[-suffix])."
                       exit 1
@@ -248,7 +254,7 @@ extends:
                   # Resolve the effective value: operator override wins, derived is fallback.
                   if (-not [string]::IsNullOrWhiteSpace($override)) {
                     if ($derived -and $override -ne $derived) {
-                      Write-Host "##vso[task.logissue type=warning]Operator-supplied -ReleaseVersion '$override' does NOT match source-build tag 'release-version:$derived'. Proceeding with operator override."
+                      Write-Host "##vso[task.logissue type=warning]Operator-supplied -ReleaseVersion '$override' does NOT match source-build tag 'release-version_$derived'. Proceeding with operator override."
                     }
                     $effective = $override.Trim()
                   } else {
@@ -260,7 +266,7 @@ extends:
 
                   # Surface the resolved version on the *release* run header too,
                   # so it shows up in the AzDO build list / pipeline summary.
-                  Write-Host "##vso[build.addbuildtag]release-version:$effective"
+                  Write-Host "##vso[build.addbuildtag]release-version_$effective"
                 name: deriveReleaseVersion
                 displayName: 'Derive ReleaseVersion from source build tag'
                 env:


### PR DESCRIPTION
## Description

The `🟣Compute Aspire version from nupkg` step in `azure-pipelines.yml` (introduced in #17150) is currently failing the main Windows build with:

> `##[error]A potentially dangerous Request.Path value was detected from the client (:).`

AzDO's `task.addbuildtag` logging command writes the tag via a REST call whose URL path contains the raw tag value. ASP.NET's request validator rejects `:` in path segments, so `release-version:13.4.0-preview.1.26268.13` blows up the step after it has already computed and logged the version.

The fix swaps the prefix separator from `:` to `_`, which is path-safe and equally readable. Updated together so the auto-derivation contract stays consistent:

- `eng/pipelines/azure-pipelines.yml` — the failing producer.
- `eng/pipelines/release-publish-nuget.yml` — matching producer write, consumer regex, plus error/warning message text.
- `docs/release-process.md` — operator-facing references to the tag format.

A comment at each write site documents why `:` was avoided so this isn't regressed by a "tidy up" later.

**Note on existing builds:** source builds previously tagged with `release-version:X.Y.Z` won't auto-derive in the release pipeline after this change. Operators can still publish those by passing `-ReleaseVersion` explicitly (the existing override escape hatch already documented in `release-process.md`).

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [x] No
- Did you add public API?
  - [ ] Yes
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
  - [x] No