### PR TITLE
Optimize no-build AppHost project inspection

### DIFF
--- a/src/Aspire.Cli/Caching/AppHostInfoDiskCache.cs
+++ b/src/Aspire.Cli/Caching/AppHostInfoDiskCache.cs
@@ -1,0 +1,349 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Globalization;
+using System.IO.Hashing;
+using System.Text;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using System.Text.Json.Serialization.Metadata;
+using Aspire.Cli.Configuration;
+using Microsoft.Extensions.Logging;
+
+namespace Aspire.Cli.Caching;
+
+/// <summary>
+/// Content-keyed disk cache for the AppHost MSBuild project inspection.
+/// </summary>
+/// <remarks>
+/// Reliable invalidation is achieved by making the inputs that drive the cached MSBuild
+/// evaluation part of the cache key itself. Any change to a tracked input produces a different
+/// key, which means a cache miss and a fresh re-evaluation. There is no need for a time-based
+/// staleness window for correctness — only for janitorial cleanup of orphaned entries.
+/// This mirrors the shape of the SDK's own MSBuild-output caches: incremental targets include
+/// inputs such as <c>$(ProjectAssetsFile)</c>, <c>$(ProjectAssetsCacheFile)</c>, and
+/// <c>$(MSBuildAllProjects)</c>. This cache sits before the MSBuild call it is trying to avoid,
+/// so it fingerprints stable filesystem beacons that represent those same inputs instead of
+/// asking MSBuild for another evaluation.
+///
+/// Tracked inputs (see <see cref="ComputeKeyAsync"/>):
+/// <list type="bullet">
+///   <item>The .csproj absolute path and its last-write time.</item>
+///   <item>The mtime of <c>obj/project.assets.json</c> next to the .csproj. NuGet writes this
+///         file on every restore, so any package-graph change (Central Package Management
+///         version bumps, transitive package updates, SDK changes that affect restore) advances
+///         this timestamp.</item>
+///   <item>The mtimes of <c>Directory.Build.props</c>, <c>Directory.Build.targets</c>,
+///         <c>Directory.Packages.props</c>, and <c>Directory.Packages.targets</c> found by
+///         walking up from the project directory to either a <c>.git</c> boundary or the
+///         filesystem root. This catches transitive .props edits that the user has not yet
+///         restored against.</item>
+///   <item>The mtime of <c>global.json</c> walking up the same path, to catch SDK pin
+///         changes that do not trigger a restore.</item>
+///   <item>A schema version constant, bumped when the set of cached properties changes.</item>
+/// </list>
+///
+/// The cache only stores metadata from the AppHost inspection target, not build outputs or runtime
+/// state, so a stale hit can only reuse stale answers such as the AppHost marker, Aspire.Hosting
+/// version, CLI bundle opt-in, or user-secrets ID. The known stale-hit cases are the inputs MSBuild
+/// can see but this pre-MSBuild fingerprint cannot reliably discover without doing another
+/// evaluation:
+/// <list type="bullet">
+///   <item>Edits to <c>.targets</c> or <c>.props</c> files imported from OUTSIDE the project
+///         directory tree (e.g. <c>&lt;Import Project="..\..\shared.targets"/&gt;</c>).</item>
+///   <item>Custom imports whose path changes are not reflected by one of the conventional
+///         walk-up files tracked above.</item>
+///   <item>External manipulation of <c>project.assets.json</c> mtime, or a restore/package graph
+///         change that does not update that file's timestamp.</item>
+/// </list>
+///
+/// Users with such setups can recover by touching the .csproj, running <c>dotnet restore</c>,
+/// running <c>aspire cache clear</c>, or running
+/// <c>aspire config set dotnetAppHostInfoCacheDisabled true</c>.
+/// </remarks>
+internal sealed class AppHostInfoDiskCache : IAppHostInfoDiskCache
+{
+    // Bump this when the cached property set changes so old entries are ignored.
+    // v1 caches: IsAspireHost, AspireHostingVersion, AspireUseCliBundle, UserSecretsId.
+    private const string SchemaVersion = "v1";
+
+    // Keep AppHost inspection entries isolated from other Aspire caches so `aspire cache clear`
+    // can delete the whole subtree without needing to understand the file naming scheme.
+    private const string SubDirectoryName = "apphost-info";
+
+    // Escape hatch for users whose projects rely on imported files that are not represented in
+    // the fingerprint. This intentionally goes through IConfigurationService instead of the
+    // process-wide IConfiguration so only `aspire config set dotnetAppHostInfoCacheDisabled true`
+    // participates; environment variables with the same name must not disable the cache.
+    private const string DisableConfigKey = "dotnetAppHostInfoCacheDisabled";
+
+    // We cannot rely only on MSBuildAllProjects here because cache hits happen before MSBuild
+    // runs. The previous evaluation can tell us which files were imported then, but it cannot
+    // reveal a newly added Directory.Build.* or Directory.Packages.* file that would change the
+    // next evaluation unless we probe those conventional walk-up locations ourselves.
+    private static readonly string[] s_trackedSiblingFiles =
+    [
+        "Directory.Build.props",
+        "Directory.Build.targets",
+        "Directory.Packages.props",
+        "Directory.Packages.targets",
+    ];
+
+    private static JsonTypeInfo<AppHostInfoCacheEntry> EntryTypeInfo =>
+        JsonSourceGenerationContext.Default.AppHostInfoCacheEntry;
+
+    private readonly ILogger<AppHostInfoDiskCache> _logger;
+    private readonly DirectoryInfo _cacheDirectory;
+    private readonly IConfigurationService _configurationService;
+
+    public AppHostInfoDiskCache(ILogger<AppHostInfoDiskCache> logger, CliExecutionContext executionContext, IConfigurationService configurationService)
+    {
+        _logger = logger;
+        _cacheDirectory = new DirectoryInfo(Path.Combine(executionContext.CacheDirectory.FullName, SubDirectoryName));
+        _configurationService = configurationService;
+    }
+
+    public async Task<AppHostInfoCacheEntry?> TryGetAsync(FileInfo projectFile, CancellationToken cancellationToken)
+    {
+        if (await IsDisabledAsync(projectFile, cancellationToken).ConfigureAwait(false))
+        {
+            return null;
+        }
+
+        try
+        {
+            var key = GetCacheKey(projectFile);
+            var path = Path.Combine(_cacheDirectory.FullName, $"{key}.json");
+            if (!File.Exists(path))
+            {
+                _logger.LogTrace("AppHost info cache miss for {Project} (key {Key})", projectFile.FullName, key);
+                return null;
+            }
+
+            var json = await File.ReadAllTextAsync(path, cancellationToken).ConfigureAwait(false);
+            var entry = JsonSerializer.Deserialize(json, EntryTypeInfo);
+            if (entry is null || !string.Equals(entry.SchemaVersion, SchemaVersion, StringComparison.Ordinal))
+            {
+                // Schema mismatch — treat as miss, the new value will overwrite.
+                _logger.LogTrace("AppHost info cache schema mismatch for {Project}", projectFile.FullName);
+                return null;
+            }
+
+            _logger.LogTrace("AppHost info cache hit for {Project} (key {Key})", projectFile.FullName, key);
+            return entry;
+        }
+        catch (Exception ex)
+        {
+            // Any read or deserialization failure is non-fatal: just miss the cache.
+            _logger.LogDebug(ex, "Failed to read AppHost info cache for {Project}", projectFile.FullName);
+            return null;
+        }
+    }
+
+    public async Task SetAsync(FileInfo projectFile, string expectedCacheKey, AppHostInfoCacheEntry entry, CancellationToken cancellationToken)
+    {
+        if (await IsDisabledAsync(projectFile, cancellationToken).ConfigureAwait(false))
+        {
+            return;
+        }
+
+        string? tempPath = null;
+
+        try
+        {
+            if (!_cacheDirectory.Exists)
+            {
+                _cacheDirectory.Create();
+            }
+
+            var key = GetCacheKey(projectFile);
+            if (!string.Equals(key, expectedCacheKey, StringComparison.Ordinal))
+            {
+                // The key is captured before MSBuild runs and checked again before publishing.
+                // Without this guard, a project/import/assets edit that lands during evaluation
+                // could write stale metadata under the new input key.
+                _logger.LogTrace(
+                    "Skipping AppHost info cache write for {Project}; cache key changed from {ExpectedKey} to {CurrentKey}",
+                    projectFile.FullName,
+                    expectedCacheKey,
+                    key);
+                return;
+            }
+
+            var path = Path.Combine(_cacheDirectory.FullName, $"{key}.json");
+
+            // Same pattern used by dotnet/sdk's SdkReleaseMetadataCache: write a complete
+            // payload to a random file in the target directory, then atomically replace the
+            // stable project/input-scoped file so readers never see partial JSON.
+            // See https://github.com/dotnet/sdk/blob/main/src/Cli/dotnet/SdkVulnerability/SdkReleaseMetadataCache.cs
+            tempPath = Path.Combine(_cacheDirectory.FullName, $"{Path.GetRandomFileName()}.tmp");
+            var payload = JsonSerializer.Serialize(entry with { SchemaVersion = SchemaVersion }, EntryTypeInfo);
+            await File.WriteAllTextAsync(tempPath, payload, cancellationToken).ConfigureAwait(false);
+
+            // File.Move(..., overwrite: true) is atomic on the same volume on POSIX and on
+            // Windows since .NET 5. If two CLIs race here the loser overwrites with identical
+            // content (same key → same payload), so the result is consistent either way.
+            File.Move(tempPath, path, overwrite: true);
+            _logger.LogTrace("Stored AppHost info cache entry for {Project} (key {Key})", projectFile.FullName, key);
+        }
+        catch (Exception ex)
+        {
+            if (tempPath is not null)
+            {
+                TryDeleteTemporaryFile(tempPath, _logger);
+            }
+
+            _logger.LogDebug(ex, "Failed to write AppHost info cache for {Project}", projectFile.FullName);
+        }
+    }
+
+    private static void TryDeleteTemporaryFile(string tempPath, ILogger logger)
+    {
+        try
+        {
+            File.Delete(tempPath);
+        }
+        catch (Exception ex)
+        {
+            logger.LogDebug(ex, "Failed to delete temporary AppHost info cache file {Path}", tempPath);
+        }
+    }
+
+    /// <summary>
+    /// Computes a stable, content-derived cache key for the supplied project file.
+    /// The key is a hex-encoded XxHash3 of a delimited string of inputs; it is suitable for
+    /// use as a filename on all platforms.
+    /// </summary>
+    public string GetCacheKey(FileInfo projectFile) => ComputeKeyAsync(projectFile);
+
+    private async Task<bool> IsDisabledAsync(FileInfo projectFile, CancellationToken cancellationToken)
+    {
+        var startDirectory = projectFile.Directory ?? new DirectoryInfo(Environment.CurrentDirectory);
+        var value = await _configurationService.GetConfigurationFromDirectoryAsync(DisableConfigKey, startDirectory, cancellationToken: cancellationToken).ConfigureAwait(false);
+        return string.Equals(value, "true", StringComparison.OrdinalIgnoreCase);
+    }
+
+    internal static string ComputeKeyAsync(FileInfo projectFile)
+    {
+        // Raw fingerprint shape:
+        //   v1|/repo/app/AppHost.csproj|csproj=638831006400000000|assets=638831006410000000|...
+        // Each file input is represented by a stable tag and its UTC last-write timestamp ticks,
+        // or '-' when the file is absent/inaccessible. The raw fingerprint intentionally includes full
+        // paths so two projects with identical mtimes cannot collide, but that makes it too long
+        // and path-sensitive for a portable filename. Hash it with XxHash3 so the cache file is
+        // short, filename-safe, and non-cryptographic (this is only cache identity, not security).
+        var sb = new StringBuilder(512);
+        sb.Append(SchemaVersion);
+        sb.Append('|');
+        sb.Append(projectFile.FullName);
+        sb.Append('|');
+        AppendMtime(sb, projectFile.FullName, "csproj");
+
+        var projectDir = projectFile.Directory?.FullName;
+        if (projectDir is not null)
+        {
+            // obj/project.assets.json is NuGet's resolved package graph for this project.
+            // The SDK also treats it as an incremental build input:
+            // https://github.com/dotnet/sdk/blob/main/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.targets
+            // The AppHost inspection reads PackageReference/PackageVersion-derived items,
+            // so the cache must notice changes that come from restore inputs outside the
+            // .csproj itself: Central Package Management edits, transitive updates, SDK
+            // changes that affect restore, or a fresh restore after package graph changes.
+            AppendMtime(sb, Path.Combine(projectDir, "obj", "project.assets.json"), "assets");
+
+            // Walk up to a .git boundary or filesystem root and stat any
+            // Directory.Build.* / Directory.Packages.* / global.json we find along the way.
+            // Files higher up shadow files lower down in MSBuild, but for cache invalidation
+            // we just need to detect ANY change. AppendMtime records each entry as
+            // "tag=ticks" (or "tag=-" when absent); the path itself is used only to stat the
+            // file, not appended to the string. That is sufficient here because (a) the
+            // project's absolute path is already at the head of the fingerprint, and (b) the
+            // positional order of these per-directory entries in the walkup sequence
+            // implicitly identifies which directory each tick belongs to.
+            var dir = projectFile.Directory;
+            while (dir is not null)
+            {
+                foreach (var siblingName in s_trackedSiblingFiles)
+                {
+                    AppendMtime(sb, Path.Combine(dir.FullName, siblingName), siblingName);
+                }
+                AppendMtime(sb, Path.Combine(dir.FullName, "global.json"), "globaljson");
+
+                // Stop at a .git boundary — typically the repo root, which is far enough
+                // for MSBuild import resolution and avoids walking the entire user profile.
+                // In a regular checkout `.git` is a directory; in a worktree, submodule, or
+                // certain tool-managed setups it is a regular file that points at the real
+                // git dir (e.g. "gitdir: /path/to/parent/.git/worktrees/foo"). Check both so
+                // the walk terminates in those layouts as well.
+                // https://git-scm.com/docs/git-worktree#_details
+                var gitMarker = Path.Combine(dir.FullName, ".git");
+                if (Directory.Exists(gitMarker) || File.Exists(gitMarker))
+                {
+                    break;
+                }
+
+                dir = dir.Parent;
+            }
+        }
+
+        var bytes = Encoding.UTF8.GetBytes(sb.ToString());
+        var hash = XxHash3.Hash(bytes);
+        return Convert.ToHexString(hash);
+    }
+
+    // "mtime" is shorthand for modification time: FileInfo.LastWriteTimeUtc converted to
+    // DateTime ticks. We use UTC ticks instead of formatted timestamps so the fingerprint is
+    // culture-invariant and stable across processes.
+    private static void AppendMtime(StringBuilder sb, string path, string tag)
+    {
+        sb.Append('|');
+        sb.Append(tag);
+        sb.Append('=');
+        try
+        {
+            var info = new FileInfo(path);
+            if (info.Exists)
+            {
+                sb.Append(info.LastWriteTimeUtc.Ticks.ToString(CultureInfo.InvariantCulture));
+            }
+            else
+            {
+                sb.Append('-');
+            }
+        }
+        catch
+        {
+            // A stat failure (permission denied, transient IO) collapses to the "missing"
+            // marker. Worst case we get a cache miss until the situation resolves.
+            sb.Append('-');
+        }
+    }
+}
+
+internal interface IAppHostInfoDiskCache
+{
+    string GetCacheKey(FileInfo projectFile);
+    Task<AppHostInfoCacheEntry?> TryGetAsync(FileInfo projectFile, CancellationToken cancellationToken);
+    Task SetAsync(FileInfo projectFile, string expectedCacheKey, AppHostInfoCacheEntry entry, CancellationToken cancellationToken);
+}
+
+internal sealed record AppHostInfoCacheEntry
+{
+    [JsonPropertyName("schemaVersion")]
+    public string SchemaVersion { get; init; } = "v1";
+
+    [JsonPropertyName("exitCode")]
+    public int ExitCode { get; init; }
+
+    [JsonPropertyName("isAspireHost")]
+    public bool IsAspireHost { get; init; }
+
+    [JsonPropertyName("aspireHostingVersion")]
+    public string? AspireHostingVersion { get; init; }
+
+    [JsonPropertyName("isUsingCliBundle")]
+    public bool IsUsingCliBundle { get; init; }
+
+    [JsonPropertyName("userSecretsId")]
+    public string? UserSecretsId { get; init; }
+}

--- a/src/Aspire.Cli/JsonSourceGenerationContext.cs
+++ b/src/Aspire.Cli/JsonSourceGenerationContext.cs
@@ -5,6 +5,8 @@ using System.Text.Encodings.Web;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 using System.Text.Json.Nodes;
+using Aspire.Cli.Caching;
+using Aspire.Cli.Projects;
 using Aspire.Cli.Certificates;
 using Aspire.Cli.Commands;
 using Aspire.Cli.Configuration;
@@ -49,6 +51,8 @@ namespace Aspire.Cli;
 [JsonSerializable(typeof(IntegrationSearchResult[]))]
 [JsonSerializable(typeof(string[]))]
 [JsonSerializable(typeof(List<CandidateAppHostDisplayInfo>))]
+[JsonSerializable(typeof(AppHostInfoCacheEntry))]
+[JsonSerializable(typeof(AppHostProjectInspectionOutput))]
 internal partial class JsonSourceGenerationContext : JsonSerializerContext
 {
     private static JsonSourceGenerationContext? s_relaxedEscaping;

--- a/src/Aspire.Cli/Program.cs
+++ b/src/Aspire.Cli/Program.cs
@@ -385,6 +385,8 @@ public class Program
 
         builder.Services.AddTransient<IDotNetCliRunner, DotNetCliRunner>();
         builder.Services.AddSingleton<IDiskCache, DiskCache>();
+        builder.Services.AddSingleton<IAppHostInfoDiskCache, AppHostInfoDiskCache>();
+        builder.Services.AddSingleton<IAppHostInfoResolver, AppHostInfoResolver>();
         builder.Services.AddSingleton<IDotNetSdkInstaller, DotNetSdkInstaller>();
         builder.Services.AddTransient<IAppHostCliBackchannel, AppHostCliBackchannel>();
 

--- a/src/Aspire.Cli/Projects/AppHostInfoResolver.cs
+++ b/src/Aspire.Cli/Projects/AppHostInfoResolver.cs
@@ -1,0 +1,271 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Collections.Concurrent;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using Aspire.Cli.Caching;
+using Aspire.Cli.DotNet;
+
+namespace Aspire.Cli.Projects;
+
+internal interface IAppHostInfoResolver
+{
+    Task<AppHostProjectInfo> GetAppHostInfoAsync(FileInfo projectFile, CancellationToken cancellationToken);
+}
+
+internal sealed class AppHostInfoResolver(IDotNetCliRunner runner, IAppHostInfoDiskCache diskCache) : IAppHostInfoResolver
+{
+    private readonly ConcurrentDictionary<(string Path, DateTime LastWriteUtc), Task<AppHostProjectInfo>> _cache = new();
+
+    public async Task<AppHostProjectInfo> GetAppHostInfoAsync(FileInfo projectFile, CancellationToken cancellationToken)
+    {
+        // Refresh so FileInfo reflects the on-disk mtime even when callers pass a long-lived instance.
+        projectFile.Refresh();
+        var key = (projectFile.FullName, projectFile.LastWriteTimeUtc);
+        var task = GetOrAddSharedFetch(key, projectFile);
+
+        try
+        {
+            // The MSBuild probe is shared by all callers for this project snapshot, so it cannot
+            // use any one caller's token. Apply cancellation to each waiter instead; otherwise one
+            // cancelled validation could cancel the shared probe for unrelated callers.
+            var result = await task.WaitAsync(cancellationToken).ConfigureAwait(false);
+            if (result.ExitCode != 0)
+            {
+                // Transient MSBuild failures should not poison long-lived CLI processes.
+                _cache.TryRemove(key, out _);
+            }
+
+            return result;
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested && !task.IsCompleted)
+        {
+            throw;
+        }
+        catch
+        {
+            // A cancelled or faulted in-flight probe must not become the answer for later runs.
+            _cache.TryRemove(key, out _);
+            throw;
+        }
+    }
+
+    private Task<AppHostProjectInfo> GetOrAddSharedFetch((string Path, DateTime LastWriteUtc) key, FileInfo projectFile)
+    {
+        while (true)
+        {
+            if (_cache.TryGetValue(key, out var existingTask))
+            {
+                return existingTask;
+            }
+
+            // ConcurrentDictionary.GetOrAdd can run value factories more than once under contention.
+            // Add a TaskCompletionSource placeholder first, then run the MSBuild probe only if this
+            // caller won the TryAdd race. Losers loop back and await the winner's task.
+            var completion = new TaskCompletionSource<AppHostProjectInfo>(TaskCreationOptions.RunContinuationsAsynchronously);
+            if (_cache.TryAdd(key, completion.Task))
+            {
+                _ = CompleteSharedFetchAsync(key, projectFile, completion);
+                return completion.Task;
+            }
+        }
+    }
+
+    private async Task CompleteSharedFetchAsync((string Path, DateTime LastWriteUtc) key, FileInfo projectFile, TaskCompletionSource<AppHostProjectInfo> completion)
+    {
+        try
+        {
+            var result = await FetchAppHostInfoCoreAsync(projectFile, CancellationToken.None).ConfigureAwait(false);
+            completion.TrySetResult(result);
+        }
+        catch (Exception ex)
+        {
+            // Match the retry behavior in GetAppHostInfoAsync: transient MSBuild/cache failures
+            // should complete all current waiters, then allow the next caller to try again.
+            completion.TrySetException(ex);
+            _cache.TryRemove(key, out _);
+        }
+    }
+
+    private async Task<AppHostProjectInfo> FetchAppHostInfoCoreAsync(FileInfo projectFile, CancellationToken cancellationToken)
+    {
+        // First, see if a previous CLI invocation already cached the answer on disk. The
+        // cache key includes mtimes of the tracked inputs that affect this metadata query, so a
+        // hit means those inputs have not changed since that previous evaluation. This is not a
+        // build-output cache; normal build/no-build semantics still decide whether .cs changes are
+        // compiled before the AppHost runs.
+        var diskEntry = await diskCache.TryGetAsync(projectFile, cancellationToken).ConfigureAwait(false);
+        if (diskEntry is not null)
+        {
+            return new AppHostProjectInfo(
+                ExitCode: diskEntry.ExitCode,
+                IsAspireHost: diskEntry.IsAspireHost,
+                AspireHostingVersion: diskEntry.AspireHostingVersion,
+                IsUsingCliBundle: diskEntry.IsUsingCliBundle,
+                UserSecretsId: diskEntry.UserSecretsId);
+        }
+
+        // Capture the input fingerprint before evaluating MSBuild. If any tracked input changes
+        // while MSBuild is running, SetAsync will skip writing this now-stale result.
+        var expectedCacheKey = diskCache.GetCacheKey(projectFile);
+
+        // Mirror the property/item shape used by DotNetCliRunner.GetAppHostInformationAsync and
+        // additionally request AspireUseCliBundle and UserSecretsId so the CLI bundle handoff
+        // and --isolated user-secrets clone do not require their own MSBuild evaluations.
+        // Adding extra -getProperty names is an evaluation-only cost.
+        var (exitCode, jsonDocument) = await runner.GetProjectItemsAndPropertiesAsync(
+            projectFile,
+            items: ["PackageReference", "AspireProjectOrPackageReference", "PackageVersion"],
+            properties: ["IsAspireHost", "AspireHostingSDKVersion", "AspireUseCliBundle", "UserSecretsId"],
+            new ProcessInvocationOptions(),
+            cancellationToken).ConfigureAwait(false);
+
+        if (exitCode != 0 || jsonDocument is null)
+        {
+            // Do not persist failure responses to memory or disk — a transient MSBuild error should
+            // not sit in a cache and short-circuit later successful evaluations.
+            // DotNetCliRunner already logged the failing MSBuild stdout/stderr before returning
+            // null here; keep the non-zero exit code so callers can surface the normal
+            // "not buildable AppHost" project-resolution behavior instead of treating this as a
+            // negative cache entry.
+            return new AppHostProjectInfo(ExitCode: exitCode, IsAspireHost: false, AspireHostingVersion: null, IsUsingCliBundle: false, UserSecretsId: null);
+        }
+
+        AppHostProjectInfo info;
+        using (jsonDocument)
+        {
+            var msbuildOutput = JsonSerializer.Deserialize(
+                jsonDocument.RootElement,
+                JsonSourceGenerationContext.Default.AppHostProjectInspectionOutput);
+
+            info = ParseAppHostInfo(msbuildOutput, exitCode);
+        }
+
+        // Persist successful evaluations so the next CLI process can short-circuit MSBuild
+        // entirely when the inputs are unchanged. Failures inside the cache write are
+        // swallowed; cache misses never break a run.
+        await diskCache.SetAsync(projectFile, expectedCacheKey, new AppHostInfoCacheEntry
+        {
+            ExitCode = info.ExitCode,
+            IsAspireHost = info.IsAspireHost,
+            AspireHostingVersion = info.AspireHostingVersion,
+            IsUsingCliBundle = info.IsUsingCliBundle,
+            UserSecretsId = info.UserSecretsId,
+        }, cancellationToken).ConfigureAwait(false);
+
+        return info;
+    }
+
+    private static AppHostProjectInfo ParseAppHostInfo(AppHostProjectInspectionOutput? msbuildOutput, int exitCode)
+    {
+        var properties = msbuildOutput?.Properties;
+        if (properties is null)
+        {
+            return new AppHostProjectInfo(ExitCode: exitCode, IsAspireHost: false, AspireHostingVersion: null, IsUsingCliBundle: false, UserSecretsId: null);
+        }
+
+        var isUsingCliBundle = string.Equals(properties.AspireUseCliBundle, "true", StringComparison.OrdinalIgnoreCase);
+
+        var userSecretsId = string.IsNullOrWhiteSpace(properties.UserSecretsId) ? null : properties.UserSecretsId;
+
+        var isAspireHost = string.Equals(properties.IsAspireHost, "true", StringComparison.Ordinal);
+
+        if (!isAspireHost)
+        {
+            return new AppHostProjectInfo(ExitCode: exitCode, IsAspireHost: false, AspireHostingVersion: null, IsUsingCliBundle: isUsingCliBundle, UserSecretsId: userSecretsId);
+        }
+
+        // Try to get Aspire.Hosting version from PackageReference items first, then fall back
+        // to AspireProjectOrPackageReference (for SDK-provided refs) and PackageVersion (CPM),
+        // then finally to the SDK version. Mirrors DotNetCliRunner.GetAppHostInformationAsync.
+        string? aspireHostingVersion = null;
+
+        var items = msbuildOutput?.Items;
+        if (items is not null)
+        {
+            aspireHostingVersion = GetPackageVersionFromItems(items.PackageReference, "Aspire.Hosting")
+                ?? GetPackageVersionFromItems(items.PackageReference, "Aspire.Hosting.AppHost");
+
+            aspireHostingVersion ??= GetPackageVersionFromItems(items.AspireProjectOrPackageReference, "Aspire.Hosting")
+                ?? GetPackageVersionFromItems(items.AspireProjectOrPackageReference, "Aspire.Hosting.AppHost");
+
+            aspireHostingVersion ??= GetPackageVersionFromItems(items.PackageVersion, "Aspire.Hosting")
+                ?? GetPackageVersionFromItems(items.PackageVersion, "Aspire.Hosting.AppHost");
+        }
+
+        aspireHostingVersion ??= properties.AspireHostingSDKVersion;
+
+        return new AppHostProjectInfo(ExitCode: exitCode, IsAspireHost: true, AspireHostingVersion: aspireHostingVersion, IsUsingCliBundle: isUsingCliBundle, UserSecretsId: userSecretsId);
+    }
+
+    private static string? GetPackageVersionFromItems(IReadOnlyList<AppHostProjectInspectionItem>? items, string packageId)
+    {
+        if (items is null)
+        {
+            return null;
+        }
+
+        foreach (var item in items)
+        {
+            if (string.Equals(item.Identity, packageId, StringComparison.Ordinal))
+            {
+                return item.Version;
+            }
+        }
+
+        return null;
+    }
+}
+
+internal sealed record AppHostProjectInfo(
+    int ExitCode,
+    bool IsAspireHost,
+    string? AspireHostingVersion,
+    bool IsUsingCliBundle,
+    string? UserSecretsId);
+
+internal sealed record AppHostProjectInspectionOutput
+{
+    [JsonPropertyName("Properties")]
+    public AppHostProjectInspectionProperties? Properties { get; init; }
+
+    [JsonPropertyName("Items")]
+    public AppHostProjectInspectionItems? Items { get; init; }
+}
+
+internal sealed record AppHostProjectInspectionProperties
+{
+    [JsonPropertyName("IsAspireHost")]
+    public string? IsAspireHost { get; init; }
+
+    [JsonPropertyName("AspireHostingSDKVersion")]
+    public string? AspireHostingSDKVersion { get; init; }
+
+    [JsonPropertyName("AspireUseCliBundle")]
+    public string? AspireUseCliBundle { get; init; }
+
+    [JsonPropertyName("UserSecretsId")]
+    public string? UserSecretsId { get; init; }
+}
+
+internal sealed record AppHostProjectInspectionItems
+{
+    [JsonPropertyName("PackageReference")]
+    public IReadOnlyList<AppHostProjectInspectionItem>? PackageReference { get; init; }
+
+    [JsonPropertyName("AspireProjectOrPackageReference")]
+    public IReadOnlyList<AppHostProjectInspectionItem>? AspireProjectOrPackageReference { get; init; }
+
+    [JsonPropertyName("PackageVersion")]
+    public IReadOnlyList<AppHostProjectInspectionItem>? PackageVersion { get; init; }
+}
+
+internal sealed record AppHostProjectInspectionItem
+{
+    [JsonPropertyName("Identity")]
+    public string? Identity { get; init; }
+
+    [JsonPropertyName("Version")]
+    public string? Version { get; init; }
+}

--- a/src/Aspire.Cli/Projects/DotNetAppHostProject.cs
+++ b/src/Aspire.Cli/Projects/DotNetAppHostProject.cs
@@ -39,6 +39,7 @@ internal sealed class DotNetAppHostProject : IAppHostProject
     private readonly RunningInstanceManager _runningInstanceManager;
     private readonly Diagnostics.FileLoggerProvider _fileLoggerProvider;
     private readonly Program.CliLoggingOptions _loggingOptions;
+    private readonly IAppHostInfoResolver _appHostInfoResolver;
 
     private static readonly string[] s_detectionPatterns = ["*.csproj", "*.fsproj", "*.vbproj", "apphost.cs"];
     internal static IReadOnlyCollection<string> ProjectExtensions { get; } =
@@ -57,6 +58,7 @@ internal sealed class DotNetAppHostProject : IAppHostProject
         ILogger<DotNetAppHostProject> logger,
         Diagnostics.FileLoggerProvider fileLoggerProvider,
         Program.CliLoggingOptions loggingOptions,
+        IAppHostInfoResolver appHostInfoResolver,
         TimeProvider? timeProvider = null)
     {
         _runner = runner;
@@ -71,6 +73,7 @@ internal sealed class DotNetAppHostProject : IAppHostProject
         _logger = logger;
         _fileLoggerProvider = fileLoggerProvider;
         _loggingOptions = loggingOptions;
+        _appHostInfoResolver = appHostInfoResolver;
         _timeProvider = timeProvider ?? TimeProvider.System;
         _runningInstanceManager = new RunningInstanceManager(_logger, _interactionService, _timeProvider);
     }
@@ -184,8 +187,9 @@ internal sealed class DotNetAppHostProject : IAppHostProject
             return new AppHostValidationResult(IsValid: IsValidSingleFileAppHost(appHostFile));
         }
 
-        // For project files, check if it's a valid Aspire AppHost using GetAppHostInformationAsync
-        var information = await _runner.GetAppHostInformationAsync(appHostFile, new ProcessInvocationOptions(), cancellationToken);
+        // The resolver owns the cache/MSBuild fallback so validation and later run/publish
+        // decisions share a single source of truth for AppHost project metadata.
+        var information = await _appHostInfoResolver.GetAppHostInfoAsync(appHostFile, cancellationToken);
 
         if (information.ExitCode == 0 && information.IsAspireHost)
         {
@@ -206,7 +210,7 @@ internal sealed class DotNetAppHostProject : IAppHostProject
         // Use the same MSBuild-based inspection as validation so version resolution
         // follows the project model that run/publish already rely on, including
         // SDK-style projects, package references, and Central Package Management.
-        var information = await _runner.GetAppHostInformationAsync(appHostFile, new ProcessInvocationOptions(), cancellationToken);
+        var information = await _appHostInfoResolver.GetAppHostInfoAsync(appHostFile, cancellationToken);
         return information.ExitCode == 0 && information.IsAspireHost
             ? information.AspireHostingVersion
             : null;
@@ -409,7 +413,7 @@ internal sealed class DotNetAppHostProject : IAppHostProject
                 return buildExitCode;
             }
 
-            var compatibilityCheck = await CheckAppHostCompatibilityAsync(effectiveAppHostFile, isSingleFileAppHost, context.WorkingDirectory, cancellationToken);
+            var compatibilityCheck = await CheckAppHostCompatibilityAsync(effectiveAppHostFile, isSingleFileAppHost, cancellationToken);
             if (!compatibilityCheck.IsCompatibleAppHost)
             {
                 context.BuildCompletionSource?.TrySetResult(false);
@@ -474,22 +478,33 @@ internal sealed class DotNetAppHostProject : IAppHostProject
         return CliExitCodes.FailedToBuildArtifacts;
     }
 
-    private async Task<(bool IsCompatibleAppHost, bool SupportsBackchannel, string? AspireHostingVersion)> CheckAppHostCompatibilityAsync(
+    private async Task<(bool IsCompatibleAppHost, string? AspireHostingVersion)> CheckAppHostCompatibilityAsync(
         FileInfo effectiveAppHostFile,
         bool isSingleFileAppHost,
-        DirectoryInfo workingDirectory,
         CancellationToken cancellationToken)
     {
         if (isSingleFileAppHost)
         {
-            return (true, true, VersionHelper.GetDefaultTemplateVersion());
+            return (true, VersionHelper.GetDefaultTemplateVersion());
         }
 
         using var compatibilityActivity = _profilingTelemetry.StartAppHostCheckCompatibility();
-        var appHostCompatibilityCheck = await AppHostHelper.CheckAppHostCompatibilityAsync(_runner, _interactionService, effectiveAppHostFile, _telemetry, workingDirectory, _fileLoggerProvider.LogFilePath, cancellationToken);
+
+        // Reuse the cached MSBuild result from ValidateAppHostAsync so we do not pay for a
+        // second `dotnet msbuild -getProperty/-getItem` invocation just to gate compatibility.
+        // Issue #17197: the legacy code path went runner → MSBuild for both validation and
+        // the compatibility gate, doubling project inspection cost on every `aspire run`.
+        var info = await _appHostInfoResolver.GetAppHostInfoAsync(effectiveAppHostFile, cancellationToken);
+        var appHostCompatibilityCheck = AppHostHelper.EvaluateAppHostCompatibility(
+            info.ExitCode,
+            info.IsAspireHost,
+            info.AspireHostingVersion,
+            _interactionService,
+            _fileLoggerProvider.LogFilePath);
+
         compatibilityActivity.SetAppHostCompatibility(
             appHostCompatibilityCheck.IsCompatibleAppHost,
-            appHostCompatibilityCheck.SupportsBackchannel,
+            supportsBackchannel: appHostCompatibilityCheck.IsCompatibleAppHost,
             appHostCompatibilityCheck.AspireHostingVersion);
 
         return appHostCompatibilityCheck;
@@ -656,13 +671,12 @@ internal sealed class DotNetAppHostProject : IAppHostProject
         // Check compatibility for project-based apphosts
         if (!isSingleFileAppHost)
         {
-            var compatibilityCheck = await AppHostHelper.CheckAppHostCompatibilityAsync(
-                _runner,
-                _interactionService,
+            // Route through the cached helper so publish shares the same MSBuild
+            // inspection result that PublishCommand's earlier ValidateAppHostAsync
+            // populated. Issue #17197.
+            var compatibilityCheck = await CheckAppHostCompatibilityAsync(
                 effectiveAppHostFile,
-                _telemetry,
-                context.WorkingDirectory,
-                _fileLoggerProvider.LogFilePath,
+                isSingleFileAppHost: false,
                 cancellationToken);
 
             if (!compatibilityCheck.IsCompatibleAppHost)
@@ -824,27 +838,11 @@ internal sealed class DotNetAppHostProject : IAppHostProject
     {
         try
         {
-            var (exitCode, jsonDocument) = await _runner.GetProjectItemsAndPropertiesAsync(
-                projectFile,
-                items: [],
-                properties: ["UserSecretsId"],
-                new ProcessInvocationOptions(),
-                cancellationToken);
-
-            if (exitCode != 0 || jsonDocument is null)
-            {
-                return null;
-            }
-
-            var rootElement = jsonDocument.RootElement;
-            if (rootElement.TryGetProperty("Properties", out var properties) &&
-                properties.TryGetProperty("UserSecretsId", out var userSecretsIdElement))
-            {
-                var value = userSecretsIdElement.GetString();
-                return string.IsNullOrWhiteSpace(value) ? null : value;
-            }
-
-            return null;
+            // Read UserSecretsId from the shared AppHost build info cache so isolated mode
+            // does not pay for a second `dotnet msbuild -getProperty` invocation when the
+            // run path already fetched the AppHost metadata for validation/compat.
+            var info = await _appHostInfoResolver.GetAppHostInfoAsync(projectFile, cancellationToken);
+            return info.UserSecretsId;
         }
         catch (Exception ex)
         {
@@ -855,26 +853,10 @@ internal sealed class DotNetAppHostProject : IAppHostProject
 
     private async Task<bool> IsUsingCliBundleAsync(FileInfo projectFile, CancellationToken cancellationToken)
     {
-        var (exitCode, jsonDocument) = await _runner.GetProjectItemsAndPropertiesAsync(
-            projectFile,
-            items: [],
-            properties: ["AspireUseCliBundle"],
-            new ProcessInvocationOptions(),
-            cancellationToken);
-
-        if (exitCode != 0 || jsonDocument is null)
-        {
-            return false;
-        }
-
-        var rootElement = jsonDocument.RootElement;
-        if (!rootElement.TryGetProperty("Properties", out var properties) ||
-            !properties.TryGetProperty("AspireUseCliBundle", out var useCliBundleElement))
-        {
-            return false;
-        }
-
-        return string.Equals(useCliBundleElement.GetString(), "true", StringComparison.OrdinalIgnoreCase);
+        // Reuse the cached MSBuild result so `AspireUseCliBundle` is fetched alongside the
+        // IsAspireHost/version inspection rather than triggering a third project evaluation.
+        var info = await _appHostInfoResolver.GetAppHostInfoAsync(projectFile, cancellationToken);
+        return info.IsUsingCliBundle;
     }
 
     private async Task ConfigureCliBundleEnvironmentAsync(Dictionary<string, string> env, CancellationToken cancellationToken)
@@ -928,4 +910,5 @@ internal sealed class DotNetAppHostProject : IAppHostProject
 
         return null;
     }
+
 }

--- a/src/Aspire.Cli/Utils/AppHostHelper.cs
+++ b/src/Aspire.Cli/Utils/AppHostHelper.cs
@@ -14,40 +14,59 @@ namespace Aspire.Cli.Utils;
 
 internal static class AppHostHelper
 {
-    internal static async Task<(bool IsCompatibleAppHost, bool SupportsBackchannel, string? AspireHostingVersion)> CheckAppHostCompatibilityAsync(IDotNetCliRunner runner, IInteractionService interactionService, FileInfo projectFile, AspireCliTelemetry telemetry, DirectoryInfo workingDirectory, string logFilePath, CancellationToken cancellationToken)
+    internal static async Task<(bool IsCompatibleAppHost, string? AspireHostingVersion)> CheckAppHostCompatibilityAsync(IDotNetCliRunner runner, IInteractionService interactionService, FileInfo projectFile, AspireCliTelemetry telemetry, DirectoryInfo workingDirectory, string logFilePath, CancellationToken cancellationToken)
     {
         var appHostInformation = await GetAppHostInformationAsync(runner, interactionService, projectFile, telemetry, workingDirectory, cancellationToken);
 
-        if (appHostInformation.ExitCode != 0)
+        return EvaluateAppHostCompatibility(
+            appHostInformation.ExitCode,
+            appHostInformation.IsAspireHost,
+            appHostInformation.AspireHostingVersion,
+            interactionService,
+            logFilePath);
+    }
+
+    /// <summary>
+    /// Applies the SemVer minimum-version gate (and user-facing error display) for an AppHost
+    /// using already-fetched project information. Use this when the caller has cached the
+    /// MSBuild result and wants to avoid issuing another <c>dotnet msbuild -getProperty</c>
+    /// invocation to evaluate compatibility.
+    /// </summary>
+    internal static (bool IsCompatibleAppHost, string? AspireHostingVersion) EvaluateAppHostCompatibility(
+        int exitCode,
+        bool isAspireHost,
+        string? aspireHostingVersion,
+        IInteractionService interactionService,
+        string logFilePath)
+    {
+        if (exitCode != 0)
         {
             interactionService.DisplayError(string.Format(CultureInfo.CurrentCulture, ErrorStrings.ProjectCouldNotBeAnalyzed, logFilePath));
-            return (false, false, null);
+            return (false, null);
         }
 
-        if (!appHostInformation.IsAspireHost)
+        if (!isAspireHost)
         {
             interactionService.DisplayError(ErrorStrings.ProjectIsNotAppHost);
-            return (false, false, null);
+            return (false, null);
         }
 
-        if (!SemVersion.TryParse(appHostInformation.AspireHostingVersion, out var aspireVersion))
+        if (!SemVersion.TryParse(aspireHostingVersion, out var aspireVersion))
         {
             interactionService.DisplayError(ErrorStrings.CouldNotParseAspireSDKVersion);
-            return (false, false, null);
+            return (false, null);
         }
 
         var minimumVersion = SemVersion.Parse("9.2.0");
         if (aspireVersion.ComparePrecedenceTo(minimumVersion) < 0)
         {
-            interactionService.DisplayError(string.Format(CultureInfo.CurrentCulture, ErrorStrings.AspireSDKVersionNotSupported, appHostInformation.AspireHostingVersion));
-            return (false, false, appHostInformation.AspireHostingVersion);
+            interactionService.DisplayError(string.Format(CultureInfo.CurrentCulture, ErrorStrings.AspireSDKVersionNotSupported, aspireHostingVersion));
+            return (false, aspireHostingVersion);
         }
-        else
-        {
-            // NOTE: When we go to support < 9.2.0 app hosts this is where we'll make
-            //       a determination as to whether the apphsot supports backchannel or not.
-            return (true, true, appHostInformation.AspireHostingVersion);
-        }
+
+        // NOTE: When we go to support < 9.2.0 app hosts this is where we'll make
+        //       a determination as to whether the apphost supports backchannel or not.
+        return (true, aspireHostingVersion);
     }
 
     internal static async Task<(int ExitCode, bool IsAspireHost, string? AspireHostingVersion)> GetAppHostInformationAsync(IDotNetCliRunner runner, IInteractionService interactionService, FileInfo projectFile, AspireCliTelemetry telemetry, DirectoryInfo workingDirectory, CancellationToken cancellationToken)

--- a/src/Aspire.Hosting/Backchannel/AppHostRpcTarget.cs
+++ b/src/Aspire.Hosting/Backchannel/AppHostRpcTarget.cs
@@ -213,11 +213,11 @@ internal class AppHostRpcTarget(
         // and store the results. The "baseline.v0" capability is the bare minimum
         // that we need as of CLI version 9.2-preview*.
         //
-        // Some capabilties will be opt in. For example in 9.3 we might refine the
+        // Some capabilities will be opt in. For example in 9.3 we might refine the
         // publishing activities API to return more information, or add log streaming
-        // features. So that would add a new capability that the apphsot can report
+        // features. So that would add a new capability that the apphost can report
         // on initial backchannel negotiation and the CLI can adapt its behavior around
-        // that. There may be scenarios where we need to break compataiblity at which
+        // that. There may be scenarios where we need to break compatibility at which
         // point we might increase the baseline version that the apphost reports.
         //
         // The ability to support a back channel at all is determined by the CLI by

--- a/tests/Aspire.Cli.Tests/Caching/AppHostInfoDiskCacheTests.cs
+++ b/tests/Aspire.Cli.Tests/Caching/AppHostInfoDiskCacheTests.cs
@@ -1,0 +1,276 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Aspire.Cli.Caching;
+using Aspire.Cli.Configuration;
+using Aspire.Cli.Tests.TestServices;
+using Aspire.Cli.Tests.Utils;
+using Microsoft.AspNetCore.InternalTesting;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace Aspire.Cli.Tests.Caching;
+
+public class AppHostInfoDiskCacheTests(ITestOutputHelper outputHelper)
+{
+    private static AppHostInfoDiskCache CreateCache(TemporaryWorkspace workspace, IConfigurationService? configurationService = null)
+    {
+        var ctx = workspace.CreateExecutionContext();
+        return new AppHostInfoDiskCache(NullLogger<AppHostInfoDiskCache>.Instance, ctx, configurationService ?? new TestConfigurationService());
+    }
+
+    private static AppHostInfoDiskCache CreateCacheWithRealConfigurationService(TemporaryWorkspace workspace, Dictionary<string, string?>? processConfigurationValues = null)
+    {
+        var ctx = workspace.CreateExecutionContext();
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(processConfigurationValues ?? new Dictionary<string, string?>())
+            .Build();
+        var globalSettingsFile = new FileInfo(Path.Combine(workspace.WorkspaceRoot.FullName, ".aspire", "settings.global.json"));
+        var configurationService = new ConfigurationService(configuration, ctx, globalSettingsFile, NullLogger<ConfigurationService>.Instance);
+        return new AppHostInfoDiskCache(NullLogger<AppHostInfoDiskCache>.Instance, ctx, configurationService);
+    }
+
+    private static FileInfo CreateProjectFile(TemporaryWorkspace workspace, string name = "Test.AppHost.csproj")
+    {
+        var path = Path.Combine(workspace.WorkspaceRoot.FullName, name);
+        File.WriteAllText(path, "<Project Sdk=\"Microsoft.NET.Sdk\" />");
+        return new FileInfo(path);
+    }
+
+    private static AppHostInfoCacheEntry SampleEntry() => new()
+    {
+        ExitCode = 0,
+        IsAspireHost = true,
+        AspireHostingVersion = "9.5.0",
+        IsUsingCliBundle = false,
+        UserSecretsId = "12345",
+    };
+
+    [Fact]
+    public async Task CacheMissThenHit()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        var cache = CreateCache(workspace);
+        var projectFile = CreateProjectFile(workspace);
+
+        var miss = await cache.TryGetAsync(projectFile, CancellationToken.None).DefaultTimeout();
+        Assert.Null(miss);
+
+        await cache.SetAsync(projectFile, cache.GetCacheKey(projectFile), SampleEntry(), CancellationToken.None).DefaultTimeout();
+
+        // FileInfo caches metadata on first stat, so create a fresh instance after the write.
+        var freshProject = new FileInfo(projectFile.FullName);
+        var hit = await cache.TryGetAsync(freshProject, CancellationToken.None).DefaultTimeout();
+        Assert.NotNull(hit);
+        Assert.True(hit!.IsAspireHost);
+        Assert.Equal("9.5.0", hit.AspireHostingVersion);
+        Assert.Equal("12345", hit.UserSecretsId);
+    }
+
+    [Fact]
+    public async Task TouchingProjectFileInvalidatesCacheEntry()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        var cache = CreateCache(workspace);
+        var projectFile = CreateProjectFile(workspace);
+
+        await cache.SetAsync(projectFile, cache.GetCacheKey(projectFile), SampleEntry(), CancellationToken.None).DefaultTimeout();
+
+        // Make sure the mtime tick actually changes (filesystem resolution can be coarse).
+        await Task.Delay(50).DefaultTimeout();
+        File.WriteAllText(projectFile.FullName, "<Project Sdk=\"Microsoft.NET.Sdk\" />\n<!-- edit -->");
+        File.SetLastWriteTimeUtc(projectFile.FullName, DateTime.UtcNow.AddSeconds(2));
+
+        var freshProject = new FileInfo(projectFile.FullName);
+        var hit = await cache.TryGetAsync(freshProject, CancellationToken.None).DefaultTimeout();
+        Assert.Null(hit);
+    }
+
+    [Fact]
+    public async Task TouchingProjectAssetsJsonInvalidatesCacheEntry()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        var cache = CreateCache(workspace);
+        var projectFile = CreateProjectFile(workspace);
+
+        await cache.SetAsync(projectFile, cache.GetCacheKey(projectFile), SampleEntry(), CancellationToken.None).DefaultTimeout();
+
+        // Simulate a `dotnet restore` writing obj/project.assets.json next to the .csproj.
+        var objDir = Directory.CreateDirectory(Path.Combine(workspace.WorkspaceRoot.FullName, "obj"));
+        var assetsPath = Path.Combine(objDir.FullName, "project.assets.json");
+        File.WriteAllText(assetsPath, "{}");
+
+        var hit = await cache.TryGetAsync(new FileInfo(projectFile.FullName), CancellationToken.None).DefaultTimeout();
+        Assert.Null(hit);
+    }
+
+    [Fact]
+    public async Task TouchingDirectoryPackagesPropsInvalidatesCacheEntry()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        var cache = CreateCache(workspace);
+        var projectFile = CreateProjectFile(workspace);
+
+        await cache.SetAsync(projectFile, cache.GetCacheKey(projectFile), SampleEntry(), CancellationToken.None).DefaultTimeout();
+
+        // Drop a Directory.Packages.props next to the project; the cache key walks up to
+        // catch this even when nothing else changed.
+        File.WriteAllText(Path.Combine(workspace.WorkspaceRoot.FullName, "Directory.Packages.props"), "<Project />");
+
+        var hit = await cache.TryGetAsync(new FileInfo(projectFile.FullName), CancellationToken.None).DefaultTimeout();
+        Assert.Null(hit);
+    }
+
+    [Fact]
+    public async Task DisabledCacheNeverReadsOrWrites()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        File.WriteAllText(Path.Combine(workspace.WorkspaceRoot.FullName, AspireConfigFile.FileName), """
+        {
+          "dotnetAppHostInfoCacheDisabled": "true"
+        }
+        """);
+        var cache = CreateCacheWithRealConfigurationService(workspace);
+        var projectFile = CreateProjectFile(workspace);
+
+        await cache.SetAsync(projectFile, cache.GetCacheKey(projectFile), SampleEntry(), CancellationToken.None).DefaultTimeout();
+        var hit = await cache.TryGetAsync(projectFile, CancellationToken.None).DefaultTimeout();
+        Assert.Null(hit);
+
+        // Nothing should have been written to disk.
+        var cacheDir = Path.Combine(workspace.WorkspaceRoot.FullName, ".aspire", "cache", "apphost-info");
+        Assert.False(Directory.Exists(cacheDir) && Directory.EnumerateFiles(cacheDir).Any());
+    }
+
+    [Fact]
+    public async Task ProcessConfigurationValueDoesNotDisableCache()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        var cache = CreateCacheWithRealConfigurationService(workspace, new Dictionary<string, string?>
+        {
+            ["dotnetAppHostInfoCacheDisabled"] = "true",
+        });
+        var projectFile = CreateProjectFile(workspace);
+
+        await cache.SetAsync(projectFile, cache.GetCacheKey(projectFile), SampleEntry(), CancellationToken.None).DefaultTimeout();
+        var hit = await cache.TryGetAsync(projectFile, CancellationToken.None).DefaultTimeout();
+
+        Assert.NotNull(hit);
+    }
+
+    [Fact]
+    public async Task ConcurrentWritesToSameKeyLeaveReadableCacheEntry()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        var cache = CreateCache(workspace);
+        var projectFile = CreateProjectFile(workspace);
+
+        await Task.WhenAll(Enumerable.Range(0, 20).Select(i =>
+        {
+            var entry = SampleEntry() with
+            {
+                AspireHostingVersion = $"9.5.{i}",
+                UserSecretsId = $"secrets-{i}",
+            };
+            return cache.SetAsync(projectFile, cache.GetCacheKey(projectFile), entry, CancellationToken.None);
+        })).DefaultTimeout();
+
+        var cacheDir = Path.Combine(workspace.WorkspaceRoot.FullName, ".aspire", "cache", "apphost-info");
+        Assert.Empty(Directory.EnumerateFiles(cacheDir, "*.tmp"));
+
+        var hit = await cache.TryGetAsync(new FileInfo(projectFile.FullName), CancellationToken.None).DefaultTimeout();
+        Assert.NotNull(hit);
+        Assert.StartsWith("9.5.", hit!.AspireHostingVersion, StringComparison.Ordinal);
+        Assert.StartsWith("secrets-", hit.UserSecretsId, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task SetAsync_SkipsWriteWhenProjectKeyChangesAfterEvaluation()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        var cache = CreateCache(workspace);
+        var projectFile = CreateProjectFile(workspace);
+        var expectedKey = cache.GetCacheKey(projectFile);
+
+        await Task.Delay(50).DefaultTimeout();
+        File.WriteAllText(projectFile.FullName, "<Project Sdk=\"Microsoft.NET.Sdk\" />\n<!-- edit -->");
+        File.SetLastWriteTimeUtc(projectFile.FullName, DateTime.UtcNow.AddSeconds(2));
+
+        await cache.SetAsync(new FileInfo(projectFile.FullName), expectedKey, SampleEntry(), CancellationToken.None).DefaultTimeout();
+
+        var hit = await cache.TryGetAsync(new FileInfo(projectFile.FullName), CancellationToken.None).DefaultTimeout();
+        Assert.Null(hit);
+    }
+
+    [Fact]
+    public void ComputeKey_IsStableForUnchangedInputs()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        var projectFile = CreateProjectFile(workspace);
+
+        var key1 = AppHostInfoDiskCache.ComputeKeyAsync(new FileInfo(projectFile.FullName));
+        var key2 = AppHostInfoDiskCache.ComputeKeyAsync(new FileInfo(projectFile.FullName));
+        Assert.Equal(key1, key2);
+        Assert.NotEmpty(key1);
+    }
+
+    [Fact]
+    public void ComputeKey_DiffersByProjectPath()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        var projectA = CreateProjectFile(workspace, "A.csproj");
+        var projectB = CreateProjectFile(workspace, "B.csproj");
+
+        var keyA = AppHostInfoDiskCache.ComputeKeyAsync(projectA);
+        var keyB = AppHostInfoDiskCache.ComputeKeyAsync(projectB);
+        Assert.NotEqual(keyA, keyB);
+    }
+
+    [Fact]
+    public void ComputeKey_WalksAboveTenParentDirectories()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+
+        var projectDir = workspace.WorkspaceRoot.FullName;
+        for (var i = 0; i < 11; i++)
+        {
+            projectDir = Directory.CreateDirectory(Path.Combine(projectDir, $"level-{i}")).FullName;
+        }
+
+        var projectFile = new FileInfo(Path.Combine(projectDir, "Deep.AppHost.csproj"));
+        File.WriteAllText(projectFile.FullName, "<Project Sdk=\"Microsoft.NET.Sdk\" />");
+
+        var keyBeforeImport = AppHostInfoDiskCache.ComputeKeyAsync(projectFile);
+        File.WriteAllText(Path.Combine(workspace.WorkspaceRoot.FullName, "Directory.Build.props"), "<Project />");
+        var keyAfterImport = AppHostInfoDiskCache.ComputeKeyAsync(new FileInfo(projectFile.FullName));
+
+        Assert.NotEqual(keyBeforeImport, keyAfterImport);
+    }
+
+    [Fact]
+    public void ComputeKey_StopsAtGitFileBoundary()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+
+        var parentImport = Path.Combine(workspace.WorkspaceRoot.FullName, "Directory.Build.props");
+        File.WriteAllText(parentImport, "<Project />");
+
+        var repoRoot = Directory.CreateDirectory(Path.Combine(workspace.WorkspaceRoot.FullName, "worktree-root"));
+        File.WriteAllText(
+            Path.Combine(repoRoot.FullName, ".git"),
+            $"gitdir: {Path.Combine(workspace.WorkspaceRoot.FullName, ".git", "worktrees", "worktree-root")}");
+
+        var projectDir = Directory.CreateDirectory(Path.Combine(repoRoot.FullName, "src", "AppHost"));
+        var projectFile = new FileInfo(Path.Combine(projectDir.FullName, "AppHost.csproj"));
+        File.WriteAllText(projectFile.FullName, "<Project Sdk=\"Microsoft.NET.Sdk\" />");
+
+        var keyBeforeParentImportEdit = AppHostInfoDiskCache.ComputeKeyAsync(projectFile);
+
+        File.WriteAllText(parentImport, "<Project><!-- above git boundary edit --></Project>");
+        File.SetLastWriteTimeUtc(parentImport, DateTime.UtcNow.AddSeconds(2));
+
+        var keyAfterParentImportEdit = AppHostInfoDiskCache.ComputeKeyAsync(new FileInfo(projectFile.FullName));
+
+        Assert.Equal(keyBeforeParentImportEdit, keyAfterParentImportEdit);
+    }
+}

--- a/tests/Aspire.Cli.Tests/Commands/CacheCommandTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/CacheCommandTests.cs
@@ -63,6 +63,28 @@ public class CacheCommandTests(ITestOutputHelper outputHelper)
     }
 
     [Fact]
+    public async Task CacheClear_ClearsAppHostInfoDiskCache()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        var appHostInfoCacheDir = new DirectoryInfo(Path.Combine(workspace.WorkspaceRoot.FullName, ".aspire", "cache", "apphost-info"));
+        appHostInfoCacheDir.Create();
+        var cacheEntry = Path.Combine(appHostInfoCacheDir.FullName, "entry.json");
+        await File.WriteAllTextAsync(cacheEntry, "{}").DefaultTimeout();
+
+        var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper);
+        using var provider = services.BuildServiceProvider();
+
+        var command = provider.GetRequiredService<RootCommand>();
+        var result = command.Parse("cache clear");
+
+        var exitCode = await result.InvokeAsync().DefaultTimeout();
+
+        Assert.Equal(CliExitCodes.Success, exitCode);
+        Assert.False(File.Exists(cacheEntry));
+        Assert.False(appHostInfoCacheDir.Exists);
+    }
+
+    [Fact]
     public async Task CacheClear_HandlesNonExistentPackagesDirectory()
     {
         using var workspace = TemporaryWorkspace.Create(outputHelper);

--- a/tests/Aspire.Cli.Tests/Commands/RunCommandTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/RunCommandTests.cs
@@ -1779,12 +1779,21 @@ public class RunCommandTests(ITestOutputHelper outputHelper)
                 runner.BuildAsyncCallback = (projectFile, noRestore, options, ct) => 0;
                 runner.GetAppHostInformationAsyncCallback = (projectFile, options, ct) => (0, true, VersionHelper.GetDefaultTemplateVersion());
 
-                // Return UserSecretsId when GetProjectItemsAndPropertiesAsync is called
+                // After issue #17197 the AppHost MSBuild inspection is fetched once and cached,
+                // so the IsAspireHost shape and UserSecretsId both come back in the same response.
                 runner.GetProjectItemsAndPropertiesAsyncCallback = (projectFile, items, properties, options, ct) =>
                 {
-                    var json = $$$"""{"Properties": {"UserSecretsId": "{{{originalUserSecretsId}}}"}}""";
-                    var doc = JsonDocument.Parse(json);
-                    return (0, doc);
+                    var json = $$$"""
+                        {
+                          "Properties": {
+                            "IsAspireHost": "true",
+                            "AspireHostingSDKVersion": "{{{VersionHelper.GetDefaultTemplateVersion()}}}",
+                            "UserSecretsId": "{{{originalUserSecretsId}}}"
+                          },
+                          "Items": {}
+                        }
+                        """;
+                    return (0, JsonDocument.Parse(json));
                 };
 
                 runner.RunAsyncCallback = async (projectFile, watch, noBuild, noRestore, args, env, backchannelCompletionSource, options, ct) =>

--- a/tests/Aspire.Cli.Tests/Projects/AppHostInfoResolverTests.cs
+++ b/tests/Aspire.Cli.Tests/Projects/AppHostInfoResolverTests.cs
@@ -1,0 +1,195 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Text.Json;
+using Aspire.Cli.Caching;
+using Aspire.Cli.Projects;
+using Aspire.Cli.Tests.TestServices;
+using Aspire.Cli.Tests.Utils;
+using Microsoft.AspNetCore.InternalTesting;
+
+namespace Aspire.Cli.Tests.Projects;
+
+public sealed class AppHostInfoResolverTests(ITestOutputHelper outputHelper)
+{
+    [Fact]
+    public async Task GetAppHostInfoAsync_UsesDiskCacheWhenPresent()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        var projectFile = CreateProjectFile(workspace);
+        var runner = new TestDotNetCliRunner
+        {
+            GetProjectItemsAndPropertiesAsyncCallback = (_, _, _, _, _) => throw new InvalidOperationException("MSBuild should not run on disk cache hit."),
+        };
+        var diskCache = new TestAppHostInfoDiskCache
+        {
+            Entry = new AppHostInfoCacheEntry
+            {
+                ExitCode = 0,
+                IsAspireHost = true,
+                AspireHostingVersion = "9.5.0",
+                IsUsingCliBundle = true,
+                UserSecretsId = "secrets",
+            },
+        };
+        var resolver = new AppHostInfoResolver(runner, diskCache);
+
+        var info = await resolver.GetAppHostInfoAsync(projectFile, CancellationToken.None).DefaultTimeout();
+
+        Assert.True(info.IsAspireHost);
+        Assert.Equal("9.5.0", info.AspireHostingVersion);
+        Assert.True(info.IsUsingCliBundle);
+        Assert.Equal("secrets", info.UserSecretsId);
+    }
+
+    [Fact]
+    public async Task GetAppHostInfoAsync_CachesSuccessfulMsBuildEvaluationInMemory()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        var projectFile = CreateProjectFile(workspace);
+        var msbuildCalls = 0;
+        var runner = new TestDotNetCliRunner
+        {
+            GetProjectItemsAndPropertiesAsyncCallback = (_, _, _, _, _) =>
+            {
+                msbuildCalls++;
+                return (0, CreateAppHostInfoJson());
+            },
+        };
+        var resolver = new AppHostInfoResolver(runner, new NullAppHostInfoDiskCache());
+
+        var first = await resolver.GetAppHostInfoAsync(projectFile, CancellationToken.None).DefaultTimeout();
+        var second = await resolver.GetAppHostInfoAsync(projectFile, CancellationToken.None).DefaultTimeout();
+
+        Assert.True(first.IsAspireHost);
+        Assert.True(second.IsAspireHost);
+        Assert.Equal(1, msbuildCalls);
+    }
+
+    [Fact]
+    public async Task GetAppHostInfoAsync_DoesNotCacheFailedMsBuildEvaluationInMemory()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        var projectFile = CreateProjectFile(workspace);
+        var msbuildCalls = 0;
+        var runner = new TestDotNetCliRunner
+        {
+            GetProjectItemsAndPropertiesAsyncCallback = (_, _, _, _, _) =>
+            {
+                msbuildCalls++;
+                return msbuildCalls == 1
+                    ? (1, null)
+                    : (0, CreateAppHostInfoJson());
+            },
+        };
+        var resolver = new AppHostInfoResolver(runner, new NullAppHostInfoDiskCache());
+
+        var failed = await resolver.GetAppHostInfoAsync(projectFile, CancellationToken.None).DefaultTimeout();
+        var succeeded = await resolver.GetAppHostInfoAsync(projectFile, CancellationToken.None).DefaultTimeout();
+
+        Assert.Equal(1, failed.ExitCode);
+        Assert.True(succeeded.IsAspireHost);
+        Assert.Equal(2, msbuildCalls);
+    }
+
+    [Fact]
+    public async Task GetAppHostInfoAsync_CoalescesConcurrentMsBuildEvaluationInMemory()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        var projectFile = CreateProjectFile(workspace);
+        var started = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var complete = new TaskCompletionSource<(int ExitCode, JsonDocument? Output)>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var msbuildCalls = 0;
+        var runner = new TestDotNetCliRunner
+        {
+            GetProjectItemsAndPropertiesAsyncCallbackAsync = (_, _, _, _, _) =>
+            {
+                Interlocked.Increment(ref msbuildCalls);
+                started.TrySetResult();
+                return complete.Task;
+            },
+        };
+        var resolver = new AppHostInfoResolver(runner, new NullAppHostInfoDiskCache());
+
+        var tasks = Enumerable.Range(0, 10)
+            .Select(_ => resolver.GetAppHostInfoAsync(projectFile, CancellationToken.None))
+            .ToArray();
+
+        await started.Task.DefaultTimeout();
+        complete.SetResult((0, CreateAppHostInfoJson()));
+        var results = await Task.WhenAll(tasks).DefaultTimeout();
+
+        Assert.All(results, result => Assert.True(result.IsAspireHost));
+        Assert.Equal(1, msbuildCalls);
+    }
+
+    [Fact]
+    public async Task GetAppHostInfoAsync_CallerCancellationDoesNotCancelSharedEvaluation()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        var projectFile = CreateProjectFile(workspace);
+        var started = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var complete = new TaskCompletionSource<(int ExitCode, JsonDocument? Output)>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var msbuildCalls = 0;
+        var runner = new TestDotNetCliRunner
+        {
+            GetProjectItemsAndPropertiesAsyncCallbackAsync = (_, _, _, _, cancellationToken) =>
+            {
+                Assert.False(cancellationToken.CanBeCanceled);
+                Interlocked.Increment(ref msbuildCalls);
+                started.TrySetResult();
+                return complete.Task;
+            },
+        };
+        var resolver = new AppHostInfoResolver(runner, new NullAppHostInfoDiskCache());
+
+        using var cancellationTokenSource = new CancellationTokenSource();
+        var canceledWaiter = resolver.GetAppHostInfoAsync(projectFile, cancellationTokenSource.Token);
+
+        await started.Task.DefaultTimeout();
+        await cancellationTokenSource.CancelAsync();
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(async () => await canceledWaiter).DefaultTimeout();
+
+        complete.SetResult((0, CreateAppHostInfoJson()));
+        var uncanceledWaiter = await resolver.GetAppHostInfoAsync(projectFile, CancellationToken.None).DefaultTimeout();
+
+        Assert.True(uncanceledWaiter.IsAspireHost);
+        Assert.Equal(1, msbuildCalls);
+    }
+
+    private static FileInfo CreateProjectFile(TemporaryWorkspace workspace)
+    {
+        var path = Path.Combine(workspace.WorkspaceRoot.FullName, "Test.AppHost.csproj");
+        File.WriteAllText(path, "<Project Sdk=\"Microsoft.NET.Sdk\" />");
+        return new FileInfo(path);
+    }
+
+    private static JsonDocument CreateAppHostInfoJson()
+    {
+        return JsonDocument.Parse("""
+            {
+              "Properties": {
+                "IsAspireHost": "true",
+                "AspireHostingSDKVersion": "9.5.0",
+                "AspireUseCliBundle": "true",
+                "UserSecretsId": "secrets"
+              },
+              "Items": {}
+            }
+            """);
+    }
+
+    private sealed class TestAppHostInfoDiskCache : IAppHostInfoDiskCache
+    {
+        public AppHostInfoCacheEntry? Entry { get; init; }
+
+        public string GetCacheKey(FileInfo projectFile)
+            => "test-key";
+
+        public Task<AppHostInfoCacheEntry?> TryGetAsync(FileInfo projectFile, CancellationToken cancellationToken)
+            => Task.FromResult(Entry);
+
+        public Task SetAsync(FileInfo projectFile, string expectedCacheKey, AppHostInfoCacheEntry entry, CancellationToken cancellationToken)
+            => Task.CompletedTask;
+    }
+}

--- a/tests/Aspire.Cli.Tests/Projects/DotNetAppHostProjectTests.cs
+++ b/tests/Aspire.Cli.Tests/Projects/DotNetAppHostProjectTests.cs
@@ -5,6 +5,7 @@ using Aspire.Cli.Projects;
 using Aspire.Cli.Layout;
 using Aspire.Cli.Tests.TestServices;
 using Aspire.Cli.Tests.Utils;
+using Aspire.Cli.Utils;
 using Aspire.Shared;
 using Microsoft.Extensions.DependencyInjection;
 using System.Text.Json;
@@ -205,10 +206,12 @@ public class DotNetAppHostProjectTests(ITestOutputHelper outputHelper) : IDispos
             GetProjectItemsAndPropertiesAsyncCallback = (_, _, properties, _, _) =>
             {
                 Assert.Contains("AspireUseCliBundle", properties);
-                return (0, JsonDocument.Parse("""
+                return (0, JsonDocument.Parse($$"""
                     {
                       "Properties": {
                         "MSBuildVersion": "17.0.0",
+                        "IsAspireHost": "true",
+                        "AspireHostingSDKVersion": "{{VersionHelper.GetDefaultTemplateVersion()}}",
                         "AspireUseCliBundle": "true"
                       },
                       "Items": {}

--- a/tests/Aspire.Cli.Tests/TestServices/NullDiskCache.cs
+++ b/tests/Aspire.Cli.Tests/TestServices/NullDiskCache.cs
@@ -20,3 +20,18 @@ internal sealed class NullDiskCache : IDiskCache
     public Task ClearAsync(CancellationToken cancellationToken = default)
         => Task.CompletedTask;
 }
+
+/// <summary>
+/// A no-op AppHost info disk cache used in tests. Always returns null on get and ignores set.
+/// </summary>
+internal sealed class NullAppHostInfoDiskCache : IAppHostInfoDiskCache
+{
+    public string GetCacheKey(FileInfo projectFile)
+        => string.Empty;
+
+    public Task<AppHostInfoCacheEntry?> TryGetAsync(FileInfo projectFile, CancellationToken cancellationToken)
+        => Task.FromResult<AppHostInfoCacheEntry?>(null);
+
+    public Task SetAsync(FileInfo projectFile, string expectedCacheKey, AppHostInfoCacheEntry entry, CancellationToken cancellationToken)
+        => Task.CompletedTask;
+}

--- a/tests/Aspire.Cli.Tests/TestServices/TestDotNetCliRunner.cs
+++ b/tests/Aspire.Cli.Tests/TestServices/TestDotNetCliRunner.cs
@@ -17,6 +17,7 @@ internal sealed class TestDotNetCliRunner : IDotNetCliRunner
     public Func<FileInfo, ProcessInvocationOptions, CancellationToken, int>? RestoreAsyncCallback { get; set; }
     public Func<FileInfo, ProcessInvocationOptions, CancellationToken, (int ExitCode, bool IsAspireHost, string? AspireHostingVersion)>? GetAppHostInformationAsyncCallback { get; set; }
     public Func<DirectoryInfo, ProcessInvocationOptions, CancellationToken, (int ExitCode, string[] ConfigPaths)>? GetNuGetConfigPathsAsyncCallback { get; set; }
+    public Func<FileInfo, string[], string[], ProcessInvocationOptions, CancellationToken, Task<(int ExitCode, JsonDocument? Output)>>? GetProjectItemsAndPropertiesAsyncCallbackAsync { get; set; }
     public Func<FileInfo, string[], string[], ProcessInvocationOptions, CancellationToken, (int ExitCode, JsonDocument? Output)>? GetProjectItemsAndPropertiesAsyncCallback { get; set; }
     public Func<string, string, FileInfo?, string?, bool, ProcessInvocationOptions, CancellationToken, (int ExitCode, string? TemplateVersion)>? InstallTemplateAsyncCallback { get; set; }
     public Func<string, string, string, ProcessInvocationOptions, CancellationToken, int>? NewProjectAsyncCallback { get; set; }
@@ -80,9 +81,49 @@ internal sealed class TestDotNetCliRunner : IDotNetCliRunner
 
     public Task<(int ExitCode, JsonDocument? Output)> GetProjectItemsAndPropertiesAsync(FileInfo projectFile, string[] items, string[] properties, ProcessInvocationOptions options, CancellationToken cancellationToken)
     {
-        return GetProjectItemsAndPropertiesAsyncCallback != null
-            ? Task.FromResult(GetProjectItemsAndPropertiesAsyncCallback(projectFile, items, properties, options, cancellationToken))
-            : Task.FromResult<(int, JsonDocument?)>((0, JsonDocument.Parse("""{"Properties":{},"Items":{}}""")));
+        if (GetProjectItemsAndPropertiesAsyncCallbackAsync != null)
+        {
+            return GetProjectItemsAndPropertiesAsyncCallbackAsync(projectFile, items, properties, options, cancellationToken);
+        }
+
+        if (GetProjectItemsAndPropertiesAsyncCallback != null)
+        {
+            return Task.FromResult(GetProjectItemsAndPropertiesAsyncCallback(projectFile, items, properties, options, cancellationToken));
+        }
+
+        // DotNetAppHostProject collapsed its three legacy MSBuild round-trips into a single
+        // GetProjectItemsAndPropertiesAsync call (issue #17197). Tests that pre-date that
+        // change still configure GetAppHostInformationAsyncCallback to control compatibility
+        // gating, so honor it here by synthesizing the JSON shape the production code expects.
+        if (GetAppHostInformationAsyncCallback != null)
+        {
+            var (exitCode, isAspireHost, aspireHostingVersion) = GetAppHostInformationAsyncCallback(projectFile, options, cancellationToken);
+            var versionJson = aspireHostingVersion is null ? "null" : $"\"{aspireHostingVersion}\"";
+            var json = $$"""
+                {
+                  "Properties": {
+                    "IsAspireHost": "{{(isAspireHost ? "true" : "false")}}",
+                    "AspireHostingSDKVersion": {{versionJson}}
+                  },
+                  "Items": {}
+                }
+                """;
+            return Task.FromResult<(int, JsonDocument?)>((exitCode, JsonDocument.Parse(json)));
+        }
+
+        // Default response: shape it so DotNetAppHostProject treats the project as a valid
+        // Aspire host with the default template version. Most tests rely on the implicit
+        // "valid AppHost" default.
+        var defaultJson = $$"""
+            {
+              "Properties": {
+                "IsAspireHost": "true",
+                "AspireHostingSDKVersion": "{{VersionHelper.GetDefaultTemplateVersion()}}"
+              },
+              "Items": {}
+            }
+            """;
+        return Task.FromResult<(int, JsonDocument?)>((0, JsonDocument.Parse(defaultJson)));
     }
 
     public Task<(int ExitCode, string? TemplateVersion)> InstallTemplateAsync(string packageName, string version, FileInfo? nugetConfigFile, string? nugetSource, bool force, ProcessInvocationOptions options, CancellationToken cancellationToken)

--- a/tests/Aspire.Cli.Tests/Utils/AppHostHelperTests.cs
+++ b/tests/Aspire.Cli.Tests/Utils/AppHostHelperTests.cs
@@ -381,7 +381,7 @@ public class AppHostHelperTests(ITestOutputHelper outputHelper)
         var projectFile = new FileInfo(Path.Combine(Path.GetTempPath(), "test.csproj"));
         var workingDirectory = new DirectoryInfo(Path.GetTempPath());
 
-        var (isCompatible, _, returnedVersion) = await AppHostHelper.CheckAppHostCompatibilityAsync(
+        var (isCompatible, returnedVersion) = await AppHostHelper.CheckAppHostCompatibilityAsync(
             runner, interactionService, projectFile, telemetry, workingDirectory, "test.log", CancellationToken.None);
 
         Assert.Equal(expectedCompatible, isCompatible);

--- a/tests/Aspire.Cli.Tests/Utils/CliTestHelper.cs
+++ b/tests/Aspire.Cli.Tests/Utils/CliTestHelper.cs
@@ -128,6 +128,8 @@ internal static class CliTestHelper
         services.AddSingleton(options.PackagingServiceFactory);
         services.AddSingleton(options.CliExecutionContextFactory);
         services.AddSingleton(options.DiskCacheFactory);
+        services.AddSingleton<IAppHostInfoDiskCache, NullAppHostInfoDiskCache>();
+        services.AddSingleton<IAppHostInfoResolver, AppHostInfoResolver>();
         services.AddSingleton(options.CliHostEnvironmentFactory);
         services.AddSingleton(options.CliDownloaderFactory);
         services.AddSingleton(options.FirstTimeUseNoticeSentinelFactory);


### PR DESCRIPTION
## Description

`aspire run --no-build` for .NET AppHost projects was spending startup time re-evaluating the same AppHost MSBuild metadata multiple times before launching the AppHost. This change centralizes AppHost metadata resolution so each CLI process evaluates the project once, and then persists successful inspection results in a project-input disk cache for subsequent CLI runs.

The resolver now owns the single source of truth for AppHost project metadata used by validation, compatibility checks, CLI bundle handoff, and isolated user-secrets cloning. The disk cache is keyed by the project path plus filesystem inputs that affect the evaluated MSBuild result, including the project file, restore assets file, conventional Directory.Build/Directory.Packages imports, global.json, and an explicit cache schema version. Writes use a random temp file plus atomic replace, and the resolver re-checks the cache key before publishing a result so a project edit during MSBuild evaluation cannot write stale metadata under a new key.

`aspire cache clear` removes the AppHost info cache. Users can disable the disk cache with the normal Aspire config command:

```bash
aspire config set dotnetAppHostInfoCacheDisabled true
```

The toggle is read through Aspire config files/global config rather than environment variables. Disabling the disk cache still keeps the per-process in-memory coalescing, so a single CLI invocation does not regress to the original repeated MSBuild inspections.

### Validation

- `dotnet build tests/Aspire.Cli.Tests/Aspire.Cli.Tests.csproj /p:SkipNativeBuild=true --no-restore`
- `dotnet test --project tests/Aspire.Cli.Tests/Aspire.Cli.Tests.csproj --no-build --no-launch-profile -- --filter-class "*.AppHostInfoResolverTests" --filter-class "*.AppHostInfoDiskCacheTests" --filter-class "*.CacheCommandTests" --filter-not-trait "quarantined=true" --filter-not-trait "outerloop=true"`
- `dotnet test --project tests/Aspire.Cli.Tests/Aspire.Cli.Tests.csproj --no-launch-profile -- --filter-class "*.AppHostInfoDiskCacheTests" --filter-not-trait "quarantined=true" --filter-not-trait "outerloop=true"`
- Startup profile captures with update notifications disabled:

| Scenario | Wall | CLI command minus 8s capture delay | `find_apphost` | AppHost inspection MSBuild |
| --- | ---: | ---: | ---: | ---: |
| Cache disabled | 17.6s | 5.81s | 701.7ms | 1 x 618.6ms |
| Cold disk cache | 16.1s | 4.79s | 695.4ms | 1 x 658.6ms |
| Warm disk cache | 15.1s | 3.81s | 23.7ms | 0 |

Fixes #17197

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
