### PR TITLE
Surface friendly staging-unavailable reason in 'aspire update --self'

### DIFF
--- a/src/Aspire.Cli/Commands/UpdateCommand.cs
+++ b/src/Aspire.Cli/Commands/UpdateCommand.cs
@@ -413,6 +413,23 @@ internal sealed class UpdateCommand : BaseCommand
 
         try
         {
+            // Mirror the pre-check that the project-update path already performs (see the
+            // matching block above that handles `--channel staging`): when the user has
+            // asked for the `staging` channel but the running CLI's identity cannot
+            // synthesize a real staging feed (daily/local/pr-<N> without overrideStagingFeed
+            // or the StagingChannelEnabled feature flag), surface the friendly explanation
+            // from PackagingService instead of letting CliDownloader throw the generic
+            // "Unsupported channel 'staging'. Available channels: …" error.
+            // See https://github.com/microsoft/aspire/issues/16807.
+            if (string.Equals(channel, PackageChannelNames.Staging, StringComparisons.ChannelName))
+            {
+                var stagingUnavailableReason = _packagingService.GetStagingChannelUnavailableReason();
+                if (stagingUnavailableReason is not null)
+                {
+                    throw new ChannelNotFoundException(stagingUnavailableReason);
+                }
+            }
+
             // Get current executable path for display purposes only
             var currentExePath = Environment.ProcessPath;
             if (string.IsNullOrEmpty(currentExePath))
@@ -434,6 +451,15 @@ internal sealed class UpdateCommand : BaseCommand
         catch (OperationCanceledException)
         {
             return CommandResult.Cancelled();
+        }
+        catch (ChannelNotFoundException ex)
+        {
+            // Surface the packaging-service reason verbatim (no "Failed to update CLI: " prefix)
+            // and use the same exit code as the project-update path so scripted callers see a
+            // consistent failure shape regardless of which entry point hit the unavailable channel.
+            var message = Markup.Escape(ex.Message);
+            Telemetry.RecordError(message, ex);
+            return CommandResult.Failure(CliExitCodes.FailedToUpgradeProject, message);
         }
         catch (Exception ex)
         {

--- a/tests/Aspire.Cli.Tests/Commands/UpdateCommandTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/UpdateCommandTests.cs
@@ -2209,6 +2209,168 @@ public class UpdateCommandTests(ITestOutputHelper outputHelper)
         Assert.Contains(PackageChannelNames.Daily, channelList);
     }
 
+    [Theory]
+    [InlineData(PackageChannelNames.Daily)]
+    [InlineData(PackageChannelNames.Local)]
+    [InlineData("pr-12345")]
+    public async Task UpdateCommand_SelfUpdate_ChannelStagingOnIdentityThatCannotSynthesizeStaging_SurfacesFriendlyReason(string identityChannel)
+    {
+        // Regression: https://github.com/microsoft/aspire/issues/16807
+        // `aspire update --self --channel staging` (and the post-project-update CLI prompt
+        // that dispatches to the same method) used to bypass the friendly
+        // GetStagingChannelUnavailableReason() lookup and instead surface CliDownloader's
+        // generic "Unsupported channel 'staging'. Available channels: …" error. The
+        // self-update path must now mirror the project-update path: when staging is
+        // requested but the packaging service refuses to synthesize it, return a
+        // FailedToUpgradeProject failure whose message is the reason verbatim, and never
+        // hit the downloader.
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+
+        const string unavailableReason = "FAKE staging unavailable reason (identity test)";
+
+        TestInteractionService? capturedInteractionService = null;
+        var downloaderInvoked = false;
+
+        var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper, options =>
+        {
+            options.CliExecutionContextFactory = _ => workspace.CreateExecutionContext(identityChannel: identityChannel);
+
+            options.InteractionServiceFactory = _ =>
+            {
+                capturedInteractionService = new TestInteractionService();
+                return capturedInteractionService;
+            };
+
+            options.PackagingServiceFactory = _ => new TestPackagingService
+            {
+                GetStagingChannelUnavailableReasonCallback = () => unavailableReason
+            };
+
+            options.CliDownloaderFactory = _ => new TestCliDownloader(workspace.WorkspaceRoot)
+            {
+                DownloadLatestCliAsyncCallback = (channel, ct) =>
+                {
+                    downloaderInvoked = true;
+                    var archivePath = Path.Combine(workspace.WorkspaceRoot.FullName, "test-cli.tar.gz");
+                    File.WriteAllText(archivePath, "fake archive");
+                    return Task.FromResult(archivePath);
+                }
+            };
+        });
+
+        using var provider = services.BuildServiceProvider();
+
+        var command = provider.GetRequiredService<RootCommand>();
+        var result = command.Parse("update --self --channel staging");
+
+        var exitCode = await result.InvokeAsync().DefaultTimeout();
+
+        Assert.Equal(CliExitCodes.FailedToUpgradeProject, exitCode);
+        Assert.False(downloaderInvoked, "CliDownloader must not be invoked when staging is reported unavailable");
+
+        Assert.NotNull(capturedInteractionService);
+        var errorText = string.Join("\n", capturedInteractionService!.DisplayedErrors);
+        Assert.Contains(unavailableReason, errorText);
+        Assert.DoesNotContain("Unsupported channel", errorText);
+        Assert.DoesNotContain("Failed to update CLI:", errorText);
+    }
+
+    [Fact]
+    public async Task UpdateCommand_SelfUpdate_ChannelStagingWhenPackagingServiceReportsAvailable_InvokesDownloader()
+    {
+        // Positive companion to the regression test above: when the packaging service
+        // reports staging as available (GetStagingChannelUnavailableReason returns null —
+        // e.g. identity is stable/staging, overrideStagingFeed is set, or the staging
+        // feature flag is on), the self-update path must NOT short-circuit and must
+        // dispatch through to CliDownloader with the staging channel name.
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+
+        string? capturedChannel = null;
+
+        var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper, options =>
+        {
+            options.CliExecutionContextFactory = _ => workspace.CreateExecutionContext(identityChannel: PackageChannelNames.Staging);
+
+            options.PackagingServiceFactory = _ => new TestPackagingService
+            {
+                // Explicitly null — staging IS available for this CLI identity.
+                GetStagingChannelUnavailableReasonCallback = () => null
+            };
+
+            options.CliDownloaderFactory = _ => new TestCliDownloader(workspace.WorkspaceRoot)
+            {
+                DownloadLatestCliAsyncCallback = (channel, ct) =>
+                {
+                    capturedChannel = channel;
+                    var archivePath = Path.Combine(workspace.WorkspaceRoot.FullName, "test-cli.tar.gz");
+                    File.WriteAllText(archivePath, "fake archive");
+                    return Task.FromResult(archivePath);
+                }
+            };
+        });
+
+        using var provider = services.BuildServiceProvider();
+
+        var command = provider.GetRequiredService<RootCommand>();
+        var result = command.Parse("update --self --channel staging");
+
+        // Extraction of the fake archive will fail, so we don't assert on exit code here.
+        // The contract under test is that the downloader receives 'staging', proving the
+        // staging pre-check did NOT short-circuit when the packaging service said staging
+        // is available.
+        await result.InvokeAsync().DefaultTimeout();
+
+        Assert.Equal(PackageChannelNames.Staging, capturedChannel);
+    }
+
+    [Fact]
+    public async Task UpdateCommand_SelfUpdate_NonStagingChannelOnDailyCli_DoesNotConsultStagingUnavailableReason()
+    {
+        // Negative companion: the staging-unavailable pre-check must be scoped to the
+        // staging channel only. Updating to stable/daily on a daily CLI must not call
+        // GetStagingChannelUnavailableReason() (avoids unrelated work) and must dispatch
+        // straight to the downloader.
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+
+        var stagingReasonConsulted = false;
+        string? capturedChannel = null;
+
+        var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper, options =>
+        {
+            options.CliExecutionContextFactory = _ => workspace.CreateExecutionContext(identityChannel: PackageChannelNames.Daily);
+
+            options.PackagingServiceFactory = _ => new TestPackagingService
+            {
+                GetStagingChannelUnavailableReasonCallback = () =>
+                {
+                    stagingReasonConsulted = true;
+                    return "should-not-be-surfaced";
+                }
+            };
+
+            options.CliDownloaderFactory = _ => new TestCliDownloader(workspace.WorkspaceRoot)
+            {
+                DownloadLatestCliAsyncCallback = (channel, ct) =>
+                {
+                    capturedChannel = channel;
+                    var archivePath = Path.Combine(workspace.WorkspaceRoot.FullName, "test-cli.tar.gz");
+                    File.WriteAllText(archivePath, "fake archive");
+                    return Task.FromResult(archivePath);
+                }
+            };
+        });
+
+        using var provider = services.BuildServiceProvider();
+
+        var command = provider.GetRequiredService<RootCommand>();
+        var result = command.Parse("update --self --channel daily");
+
+        await result.InvokeAsync().DefaultTimeout();
+
+        Assert.False(stagingReasonConsulted, "Staging unavailable-reason must not be consulted when the channel is not 'staging'");
+        Assert.Equal(PackageChannelNames.Daily, capturedChannel);
+    }
+
     [Fact]
     public async Task UpdateCommand_SelfOption_IsAvailableAndParseable()
     {


### PR DESCRIPTION
## Description

Fixes #16807.

When a user on a non-stable Aspire CLI build (daily, local-dev, or per-PR `pr-<N>`) sets `channel: staging` and runs `aspire update --self` — or accepts the post-project-update "update the CLI too?" prompt — they used to see an unhelpful error:

```
❌ Failed to update CLI: Unsupported channel 'staging'. Available channels: default, stable, daily, pr-16716
```

That message tells the user *what* didn't work but not *why*, doesn't mention that their CLI identity is the problem, and doesn't point at the `overrideStagingFeed` / `StagingChannelEnabled` escape hatches. The regular project-update path (`aspire update --channel staging`) already produces a friendly explanation via `PackagingService.GetStagingChannelUnavailableReason()` — the self-update path just wasn't consulting it.

After this change, the self-update path mirrors the project-update path: the same friendly reason is surfaced verbatim with the `FailedToUpgradeProject` exit code, regardless of whether the user came in via `aspire update`, `aspire update --self`, or accepted the CLI-update prompt at the end of `aspire update`, and regardless of whether their CLI identity is `daily`, `local`, or `pr-<N>`.

### Implementation

In `UpdateCommand.ExecuteSelfUpdateAsync`:

- After the channel is resolved (either from `--channel`/`--quality` or the interactive prompt), if it equals `staging`, call `_packagingService.GetStagingChannelUnavailableReason()` first and throw `ChannelNotFoundException(reason)` when non-null — same wiring as the project-update path.
- Added a dedicated `catch (ChannelNotFoundException)` returning `CommandResult.Failure(CliExitCodes.FailedToUpgradeProject, Markup.Escape(ex.Message))` with `Telemetry.RecordError` — same exit code and message handling as the project-update catch, so scripted callers see a consistent failure shape regardless of entry point. The downloader is never invoked in this case.

The post-project-update CLI prompt path inherits the fix automatically because it dispatches through the same method.

### Gap 2 (issue mentions `13.4.0-dev` heuristic) — already resolved

The issue's Gap 2 references `PackagingService.IsCliPrereleaseDailyBuild` and version-string parsing. That heuristic no longer exists: channel identity is now read from baked-in `[AssemblyMetadata("AspireCliChannel", …)]` via `Acquisition/IdentityChannelReader.cs`. A pure local-dev build is labeled `local` at build time, which already fails `IsStagingChannelSynthesisAllowed()` and produces a non-null `GetStagingChannelUnavailableReason()`. The InlineData test cases the issue suggested target a method that doesn't exist anymore; equivalent coverage is provided by the new `identityChannel: "local"` and `identityChannel: "pr-12345"` cases in the negative-path Theory below.

### User-facing usage

Before:

```text
$ aspire update --self --channel staging
❌ Failed to update CLI: Unsupported channel 'staging'. Available channels: default, stable, daily, pr-16716
```

After (exact wording comes from the localized `StagingChannelUnavailableOnDailyCli` resource string and includes the running CLI's identity channel name and the recovery actions):

```text
$ aspire update --self --channel staging
❌ The 'staging' channel cannot be synthesized on this CLI build (identity: 'daily'). …
```

### Tests

Added three unit tests in `tests/Aspire.Cli.Tests/Commands/UpdateCommandTests.cs`:

- **Negative regression (Theory)** — `UpdateCommand_SelfUpdate_ChannelStagingOnIdentityThatCannotSynthesizeStaging_SurfacesFriendlyReason` covers `daily`, `local`, and `pr-12345` identities. Asserts exit code `FailedToUpgradeProject`, the displayed error contains the packaging-service reason, does NOT contain `"Unsupported channel"` or `"Failed to update CLI:"`, and the `CliDownloader` is never invoked.
- **Positive** — `UpdateCommand_SelfUpdate_ChannelStagingWhenPackagingServiceReportsAvailable_InvokesDownloader` asserts that when staging IS available (`GetStagingChannelUnavailableReason() == null`) the pre-check does not short-circuit and the downloader receives `'staging'`.
- **Non-staging negative** — `UpdateCommand_SelfUpdate_NonStagingChannelOnDailyCli_DoesNotConsultStagingUnavailableReason` asserts the staging pre-check is scoped to the staging channel and never consults the staging reason for `--channel daily`.

All 66 tests in `UpdateCommandTests` and all 40 tests in `PackagingServiceTests` pass.

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
