### PR TITLE
Fix release pipeline: GitHubTasks stage deps and aspire-cli-* download pattern

### DIFF
--- a/eng/pipelines/release-publish-nuget.yml
+++ b/eng/pipelines/release-publish-nuget.yml
@@ -763,7 +763,16 @@ extends:
       # without performing a real release.
       - stage: GitHubTasks
         displayName: 'Dispatch GitHub Release Tasks'
-        dependsOn: Release
+        # PrepareArtifacts is listed explicitly (in addition to Release) so the
+        # jobs in this stage can resolve
+        # stageDependencies.PrepareArtifacts.PrepareJob.outputs['deriveReleaseVersion.releaseVersionEffective'].
+        # AzDO only exposes stageDependencies for stages named directly in dependsOn —
+        # the relationship is NOT transitive through Release. Without this, the
+        # ReleaseVersionEffective variable silently evaluates to empty and the GitHub
+        # workflow dispatch fails with HTTP 422 "Required input 'release_version' not provided".
+        dependsOn:
+          - Release
+          - PrepareArtifacts
         condition: |
           and(
             in(dependencies.Release.result, 'Succeeded', 'SucceededWithIssues'),

--- a/eng/pipelines/release-publish-nuget.yml
+++ b/eng/pipelines/release-publish-nuget.yml
@@ -898,7 +898,12 @@ extends:
               - download: aspire-build
                 displayName: 'Download aspire-cli-* from Source Build'
                 artifact: BlobArtifacts
-                patterns: 'aspire-cli-*'
+                # The download task enumerates artifact items with the artifact
+                # name as a path prefix (e.g. 'BlobArtifacts/aspire-cli-...'), so
+                # a bare 'aspire-cli-*' minimatch glob excludes every file and
+                # the target directory never gets created. Use '**/aspire-cli-*'
+                # to match files under the artifact root.
+                patterns: '**/aspire-cli-*'
 
               # pwsh (not powershell): publish-release-cli-assets.ps1 calls
               # Get-AspireBotInstallationToken.ps1, which uses RSA.ImportFromPem


### PR DESCRIPTION
Fixes two issues blocking a green run of the release pipeline.

## 1. `ReleaseVersionEffective` resolves to empty in `GitHubTasks` stage

The `GitHubTasks` stage's jobs reference

`\\yaml
ReleaseVersionEffective: $[ stageDependencies.PrepareArtifacts.PrepareJob.outputs['deriveReleaseVersion.releaseVersionEffective'] ]
\\\`

but the stage previously only declared `dependsOn: Release`. AzDO does not make `stageDependencies` transitive — only stages named directly in `dependsOn` are reachable — so the expression silently evaluated to empty and the GitHub workflow_dispatch failed with:

> HTTP 422: Required input 'release_version' not provided

Confirmed in build [2978542](https://dev.azure.com/dnceng/internal/_build/results?buildId=2978542) (log id 137). `PrepareArtifacts` is now listed alongside `Release` so the variable resolves.

## 2. `aspire-cli-*` download pattern matches zero files

In `PublishReleaseAssetsJob`, the download step used:

`\\yaml
- download: aspire-build
  artifact: BlobArtifacts
  patterns: 'aspire-cli-*'
\\\`

The download task enumerates artifact items with the artifact name as a path prefix (e.g. `BlobArtifacts/aspire-cli-linux-x64-13.3.4.tar.gz`), so the bare `aspire-cli-*` minimatch glob excluded every file. Zero files were downloaded, the target directory was never created, and the next step failed with:

> Assets directory 'D:\a\\_work\1\aspire-build\BlobArtifacts' does not exist. Did the download step run?

Confirmed in build [2978586](https://dev.azure.com/dnceng/internal/_build/results?buildId=2978586) (log id 163 shows `0 matches` and every `aspire-cli-*` file `Item excluded`). Pattern is now `**/aspire-cli-*`.

## Validation

Issue #1 confirmed fixed in dry-run build 2978586 (workflow_dispatch accepted with correct `release_version`); issue #2 surfaced in that same run as the next blocker and is fixed here.
