### PR TITLE
Improve ConsoleCancellationManager with process termination timeout

### DIFF
--- a/src/Aspire.Cli/Commands/BaseCommand.cs
+++ b/src/Aspire.Cli/Commands/BaseCommand.cs
@@ -58,7 +58,7 @@ internal abstract class BaseCommand : Command
             catch (NonInteractiveException)
             {
                 // Error messages have already been displayed by the interaction service.
-                result = CommandResult.Failure((int)CliExitCodes.MissingRequiredArgument);
+                result = CommandResult.Failure(CliExitCodes.MissingRequiredArgument);
             }
 
             var isErrorExitCode = result.ExitCode != CliExitCodes.Success;

--- a/src/Aspire.Cli/ConsoleCancellationManager.cs
+++ b/src/Aspire.Cli/ConsoleCancellationManager.cs
@@ -24,7 +24,7 @@ internal sealed class ConsoleCancellationManager : IDisposable
     private Task<int>? _startedHandler;
     private int _cancelCalled;
 
-    internal readonly TaskCompletionSource<int> _processTerminationCompletionSource = new(TaskCreationOptions.RunContinuationsAsynchronously);
+    private readonly TaskCompletionSource<int> _processTerminationCompletionSource = new(TaskCreationOptions.RunContinuationsAsynchronously);
 
     /// <summary>
     /// A completion source that is signaled with a native exit code when the running handler

--- a/src/Aspire.Cli/ConsoleCancellationManager.cs
+++ b/src/Aspire.Cli/ConsoleCancellationManager.cs
@@ -46,6 +46,8 @@ internal sealed class ConsoleCancellationManager : IDisposable
 
         // Prefer PosixSignalRegistration for both SIGINT and SIGTERM as it handles
         // both signals uniformly and allows cancelling SIGTERM (which Console.CancelKeyPress cannot).
+        // Despite the name, PosixSignalRegistration is supported on Windows: the runtime maps
+        // SIGINT to CTRL_C_EVENT and SIGTERM to CTRL_CLOSE_EVENT/CTRL_SHUTDOWN_EVENT.
         if (!OperatingSystem.IsAndroid()
             && !OperatingSystem.IsIOS()
             && !OperatingSystem.IsTvOS()

--- a/src/Aspire.Cli/ConsoleCancellationManager.cs
+++ b/src/Aspire.Cli/ConsoleCancellationManager.cs
@@ -22,8 +22,9 @@ internal sealed class ConsoleCancellationManager : IDisposable
     private readonly PosixSignalRegistration? _sigTermRegistration;
     private readonly CancellationToken _token;
     private Task<int>? _startedHandler;
+    private int _cancelCalled;
 
-    internal readonly TaskCompletionSource<int> _processTerminationCompletionSource = new();
+    internal readonly TaskCompletionSource<int> _processTerminationCompletionSource = new(TaskCreationOptions.RunContinuationsAsynchronously);
 
     /// <summary>
     /// A completion source that is signaled with a native exit code when the running handler
@@ -56,11 +57,9 @@ internal sealed class ConsoleCancellationManager : IDisposable
             _sigIntRegistration = PosixSignalRegistration.Create(PosixSignal.SIGINT, OnPosixSignal);
             _sigTermRegistration = PosixSignalRegistration.Create(PosixSignal.SIGTERM, OnPosixSignal);
         }
-        else
-        {
-            Console.CancelKeyPress += OnCancelKeyPress;
-            AppDomain.CurrentDomain.ProcessExit += OnProcessExit;
-        }
+
+        Console.CancelKeyPress += OnCancelKeyPress;
+        AppDomain.CurrentDomain.ProcessExit += OnProcessExit;
     }
 
     public CancellationToken Token => _token;
@@ -83,6 +82,12 @@ internal sealed class ConsoleCancellationManager : IDisposable
 
     private void Cancel(int forcedTerminationExitCode)
     {
+        // Ensure only the first signal triggers cancellation logic; subsequent signals are no-ops.
+        if (Interlocked.CompareExchange(ref _cancelCalled, 1, 0) != 0)
+        {
+            return;
+        }
+
         // Request cancellation so cooperative listeners can begin shutting down.
         try
         {
@@ -114,16 +119,11 @@ internal sealed class ConsoleCancellationManager : IDisposable
 
     public void Dispose()
     {
-        if (_sigIntRegistration is not null)
-        {
-            _sigIntRegistration.Dispose();
-            _sigTermRegistration?.Dispose();
-        }
-        else
-        {
-            Console.CancelKeyPress -= OnCancelKeyPress;
-            AppDomain.CurrentDomain.ProcessExit -= OnProcessExit;
-        }
+        _sigIntRegistration?.Dispose();
+        _sigTermRegistration?.Dispose();
+
+        Console.CancelKeyPress -= OnCancelKeyPress;
+        AppDomain.CurrentDomain.ProcessExit -= OnProcessExit;
 
         _cts.Dispose();
     }

--- a/src/Aspire.Cli/ConsoleCancellationManager.cs
+++ b/src/Aspire.Cli/ConsoleCancellationManager.cs
@@ -53,11 +53,12 @@ internal sealed class ConsoleCancellationManager : IDisposable
         {
             _sigIntRegistration = PosixSignalRegistration.Create(PosixSignal.SIGINT, OnPosixSignal);
             _sigTermRegistration = PosixSignalRegistration.Create(PosixSignal.SIGTERM, OnPosixSignal);
-            return;
         }
-
-        Console.CancelKeyPress += OnCancelKeyPress;
-        AppDomain.CurrentDomain.ProcessExit += OnProcessExit;
+        else
+        {
+            Console.CancelKeyPress += OnCancelKeyPress;
+            AppDomain.CurrentDomain.ProcessExit += OnProcessExit;
+        }
     }
 
     public CancellationToken Token => _token;
@@ -115,11 +116,13 @@ internal sealed class ConsoleCancellationManager : IDisposable
         {
             _sigIntRegistration.Dispose();
             _sigTermRegistration?.Dispose();
-            return;
+        }
+        else
+        {
+            Console.CancelKeyPress -= OnCancelKeyPress;
+            AppDomain.CurrentDomain.ProcessExit -= OnProcessExit;
         }
 
-        Console.CancelKeyPress -= OnCancelKeyPress;
-        AppDomain.CurrentDomain.ProcessExit -= OnProcessExit;
         _cts.Dispose();
     }
 }

--- a/src/Aspire.Cli/ConsoleCancellationManager.cs
+++ b/src/Aspire.Cli/ConsoleCancellationManager.cs
@@ -6,41 +6,81 @@ using System.Runtime.InteropServices;
 namespace Aspire.Cli;
 
 /// <summary>
-/// Manages Ctrl+C and SIGTERM signal handling with a shared CancellationTokenSource.
+/// Manages Ctrl+C, SIGINT, and SIGTERM signal handling with a shared CancellationTokenSource.
+/// After cancellation is requested, waits up to <c>processTerminationTimeout</c> for the running
+/// handler to complete before signaling forced termination via <see cref="ProcessTerminationCompletionSource"/>.
 /// Disposing this instance unregisters all signal handlers and disposes the token source.
 /// </summary>
 internal sealed class ConsoleCancellationManager : IDisposable
 {
+    private const int SigIntExitCode = 130;
+    private const int SigTermExitCode = 143;
+
     private readonly CancellationTokenSource _cts = new();
-    private readonly CancellationToken _token;
-    private readonly ConsoleCancelEventHandler _cancelKeyPressHandler;
+    private readonly TimeSpan _processTerminationTimeout;
+    private readonly PosixSignalRegistration? _sigIntRegistration;
     private readonly PosixSignalRegistration? _sigTermRegistration;
+    private readonly CancellationToken _token;
+    private Task<int>? _startedHandler;
 
-    public ConsoleCancellationManager()
+    internal readonly TaskCompletionSource<int> _processTerminationCompletionSource = new();
+
+    /// <summary>
+    /// A completion source that is signaled with a native exit code when the running handler
+    /// does not complete within the configured timeout after a termination signal.
+    /// </summary>
+    internal TaskCompletionSource<int> ProcessTerminationCompletionSource => _processTerminationCompletionSource;
+
+    /// <summary>
+    /// Sets the handler task that represents the currently executing command. When a termination
+    /// signal arrives, the manager will wait for this task to complete within the configured timeout.
+    /// </summary>
+    internal void SetStartedHandler(Task<int> handler) => Volatile.Write(ref _startedHandler, handler);
+
+    public ConsoleCancellationManager(TimeSpan processTerminationTimeout)
     {
-        _token = _cts.Token;
-        _cancelKeyPressHandler = (sender, eventArgs) =>
-        {
-            TryCancel();
-            eventArgs.Cancel = true;
-        };
-        Console.CancelKeyPress += _cancelKeyPressHandler;
+        _processTerminationTimeout = processTerminationTimeout;
 
-        _sigTermRegistration = OperatingSystem.IsWindows()
-            ? null
-            : PosixSignalRegistration.Create(PosixSignal.SIGTERM, context =>
-            {
-                TryCancel();
-                context.Cancel = true;
-            });
+        // Set to a field so getting the token doesn't error after dispose.
+        _token = _cts.Token;
+
+        // Prefer PosixSignalRegistration for both SIGINT and SIGTERM as it handles
+        // both signals uniformly and allows cancelling SIGTERM (which Console.CancelKeyPress cannot).
+        if (!OperatingSystem.IsAndroid()
+            && !OperatingSystem.IsIOS()
+            && !OperatingSystem.IsTvOS()
+            && !OperatingSystem.IsBrowser())
+        {
+            _sigIntRegistration = PosixSignalRegistration.Create(PosixSignal.SIGINT, OnPosixSignal);
+            _sigTermRegistration = PosixSignalRegistration.Create(PosixSignal.SIGTERM, OnPosixSignal);
+            return;
+        }
+
+        Console.CancelKeyPress += OnCancelKeyPress;
+        AppDomain.CurrentDomain.ProcessExit += OnProcessExit;
     }
 
     public CancellationToken Token => _token;
 
     public bool IsCancellationRequested => _cts.IsCancellationRequested;
 
-    private void TryCancel()
+    private void OnPosixSignal(PosixSignalContext context)
     {
+        context.Cancel = true;
+        Cancel(context.Signal == PosixSignal.SIGINT ? SigIntExitCode : SigTermExitCode);
+    }
+
+    private void OnCancelKeyPress(object? sender, ConsoleCancelEventArgs e)
+    {
+        e.Cancel = true;
+        Cancel(SigIntExitCode);
+    }
+
+    private void OnProcessExit(object? sender, EventArgs e) => Cancel(SigTermExitCode);
+
+    private void Cancel(int forcedTerminationExitCode)
+    {
+        // Request cancellation so cooperative listeners can begin shutting down.
         try
         {
             _cts.Cancel();
@@ -48,13 +88,38 @@ internal sealed class ConsoleCancellationManager : IDisposable
         catch (ObjectDisposedException)
         {
             // A signal can race with process shutdown after cancellation resources are disposed.
+            return;
+        }
+
+        try
+        {
+            var startedHandler = Volatile.Read(ref _startedHandler);
+
+            // Wait for the configured interval to allow graceful shutdown.
+            if (startedHandler is null || !startedHandler.Wait(_processTerminationTimeout))
+            {
+                // If the handler does not finish within configured time, use the completion
+                // source to signal forced completion (preserving native exit code).
+                _processTerminationCompletionSource.TrySetResult(forcedTerminationExitCode);
+            }
+        }
+        catch (AggregateException)
+        {
+            // The task was cancelled or an exception was thrown during task execution.
         }
     }
 
     public void Dispose()
     {
-        Console.CancelKeyPress -= _cancelKeyPressHandler;
-        _sigTermRegistration?.Dispose();
+        if (_sigIntRegistration is not null)
+        {
+            _sigIntRegistration.Dispose();
+            _sigTermRegistration?.Dispose();
+            return;
+        }
+
+        Console.CancelKeyPress -= OnCancelKeyPress;
+        AppDomain.CurrentDomain.ProcessExit -= OnProcessExit;
         _cts.Dispose();
     }
 }

--- a/src/Aspire.Cli/Program.cs
+++ b/src/Aspire.Cli/Program.cs
@@ -844,6 +844,7 @@ public class Program
                     if (firstCompletedTask != handlerTask)
                     {
                         // The termination signal triggered cancellation and the timeout has completed. Kill the process.
+                        // handlerTask is not awaited because the process is shutting down and we assume the task is hung.
                         logger.LogWarning("Timeout waiting for cancellation from termination signal.");
                     }
 

--- a/src/Aspire.Cli/Program.cs
+++ b/src/Aspire.Cli/Program.cs
@@ -864,11 +864,7 @@ public class Program
                 // Log exit code for debugging
                 logger.LogInformation("Exit code: {ExitCode}", exitCode);
             }
-            catch (OperationCanceledException) when (cancellationManager.IsCancellationRequested)
-            {
-                exitCode = CliExitCodes.Cancelled;
-            }
-            catch (ExtensionOperationCanceledException)
+            catch (OperationCanceledException ex) when (cancellationManager.IsCancellationRequested || ex is ExtensionOperationCanceledException)
             {
                 exitCode = CliExitCodes.Cancelled;
             }

--- a/src/Aspire.Cli/Program.cs
+++ b/src/Aspire.Cli/Program.cs
@@ -841,6 +841,12 @@ public class Program
 
                     // Wait for either the handler to complete or a termination signal to trigger cancellation and timeout.
                     var firstCompletedTask = await Task.WhenAny(handlerTask, cancellationManager.ProcessTerminationCompletionSource.Task);
+                    if (firstCompletedTask != handlerTask)
+                    {
+                        // The termination signal triggered cancellation and the timeout has completed. Kill the process.
+                        logger.LogWarning("Timeout waiting for cancellation from termination signal.");
+                    }
+
                     exitCode = await firstCompletedTask; // return the result or propagate the exception
 
                     // Set telemetry tags based on how the command completed.
@@ -858,32 +864,27 @@ public class Program
                 // Log exit code for debugging
                 logger.LogInformation("Exit code: {ExitCode}", exitCode);
             }
+            catch (OperationCanceledException) when (cancellationManager.IsCancellationRequested)
+            {
+                exitCode = CliExitCodes.Cancelled;
+            }
+            catch (ExtensionOperationCanceledException)
+            {
+                exitCode = CliExitCodes.Cancelled;
+            }
             catch (Exception ex)
             {
-                exitCode = 1;
-                // Catch block is used instead of System.Commandline's default handler behavior.
-                // Allows logging of exceptions to telemetry.
+                exitCode = CliExitCodes.InvalidCommand;
 
-                // Don't log or display cancellation exceptions.
-                // Check both Ctrl+C cancellation (cancellationManager.IsCancellationRequested) and
-                // extension prompt cancellation (ExtensionOperationCanceledException).
-                if (!(ex is OperationCanceledException && cancellationManager.IsCancellationRequested) && ex is not ExtensionOperationCanceledException)
-                {
-                    logger.LogError(ex, "An unexpected error occurred.");
-
-                    telemetry.RecordError("An unexpected error occurred.", ex);
-
-                    errorWriter.WriteLine(string.Format(CultureInfo.CurrentCulture, InteractionServiceStrings.UnexpectedErrorOccurred, ex.Message));
-                }
-
-                // Log exit code for debugging
-                logger.LogError("Exit code: {ExitCode} (exception)", exitCode);
-
-                mainActivity?.SetTag(TelemetryConstants.Tags.ProcessExitCode, exitCode);
+                logger.LogError(ex, "An unexpected error occurred.");
+                telemetry.RecordError("An unexpected error occurred.", ex);
+                errorWriter.WriteLine(string.Format(CultureInfo.CurrentCulture, InteractionServiceStrings.UnexpectedErrorOccurred, ex.Message));
             }
-
-            mainActivity?.SetTag(TelemetryConstants.Tags.ProcessExitCode, exitCode);
-            mainActivity?.Stop();
+            finally
+            {
+                mainActivity?.SetTag(TelemetryConstants.Tags.ProcessExitCode, exitCode);
+                mainActivity?.Stop();
+            }
 
             if (profileCaptureSession is not null)
             {

--- a/src/Aspire.Cli/Program.cs
+++ b/src/Aspire.Cli/Program.cs
@@ -729,7 +729,7 @@ public class Program
         // Setup handling of CTRL-C and SIGTERM as early as possible so that if
         // we get a signal anywhere that is not handled by Spectre Console
         // already that we know to trigger cancellation.
-        using var cancellationManager = new ConsoleCancellationManager();
+        using var cancellationManager = new ConsoleCancellationManager(processTerminationTimeout: TimeSpan.FromSeconds(5));
 
         Console.OutputEncoding = Encoding.UTF8;
 
@@ -788,7 +788,9 @@ public class Program
         var invokeConfig = new InvocationConfiguration()
         {
             // Disable default exception handler so we can log exceptions to telemetry.
-            EnableDefaultExceptionHandler = false
+            EnableDefaultExceptionHandler = false,
+            // Set timeout to null so that System.Commandline doesn't manage cancellation tokens or timeouts for us.
+            ProcessTerminationTimeout = null
         };
 
         app.Services.GetRequiredService<CliExecutionContext>();
@@ -833,7 +835,15 @@ public class Program
                         profileCommandActivity = profilingTelemetry.StartCommand(commandName);
                     }
 
-                    exitCode = await parseResult.InvokeAsync(invokeConfig, cancellationManager.Token);
+                    // Parse commandline and invoke the handler.
+                    var handlerTask = parseResult.InvokeAsync(invokeConfig, cancellationManager.Token);
+                    cancellationManager.SetStartedHandler(handlerTask);
+
+                    // Wait for either the handler to complete or a termination signal to trigger cancellation and timeout.
+                    var firstCompletedTask = await Task.WhenAny(handlerTask, cancellationManager.ProcessTerminationCompletionSource.Task);
+                    exitCode = await firstCompletedTask; // return the result or propagate the exception
+
+                    // Set telemetry tags based on how the command completed.
                     profileCommandActivity.SetProcessExitCode(exitCode);
                     if (exitCode != CliExitCodes.Success)
                     {


### PR DESCRIPTION
## Summary

Errors were caused by a race between System.Commandline built-in cancellaiton handling and Aspire CLIs. Disabled System.Commandline by removing its timeout, and moved timeout feature to our type.

---

Merges improvements from [`System.CommandLine.ProcessTerminationHandler`](https://github.com/dotnet/command-line-api/blob/main/src/System.CommandLine/Invocation/ProcessTerminationHandler.cs) into `ConsoleCancellationManager` to provide a graceful shutdown timeout when the CLI receives termination signals.

## Changes

- **Process termination timeout (5s)**: After a signal is received and cancellation is requested, the manager waits up to 5 seconds for the running command to finish gracefully before signaling forced termination.
- **PosixSignalRegistration for both SIGINT and SIGTERM**: Previously only SIGTERM used `PosixSignalRegistration`; now both signals use the preferred API uniformly (with fallback to `Console.CancelKeyPress` + `AppDomain.ProcessExit` on unsupported platforms).
- **Task.WhenAny racing**: The main invocation races the handler task against the `ProcessTerminationCompletionSource` so the process exits promptly with the correct signal exit code (130 for SIGINT, 143 for SIGTERM) if the handler doesn't finish within the timeout.

## Fixes

- Fixes https://github.com/microsoft/aspire/issues/17203
- Fixes https://github.com/microsoft/aspire/issues/17223