### PR TITLE
Fix Manage button overlapping Close button in Settings dialog at high zoom

### DIFF
--- a/src/Aspire.Dashboard/Components/Dialogs/SettingsDialog.razor
+++ b/src/Aspire.Dashboard/Components/Dialogs/SettingsDialog.razor
@@ -3,7 +3,7 @@
 @inject IStringLocalizer<Dialogs> Loc
 
 <FluentDialogBody>
-    <FluentStack Orientation="Orientation.Vertical" Style="display: flex; height: 100%" VerticalGap="12">
+    <FluentStack Orientation="Orientation.Vertical" Style="display: flex; height: 100%; overflow-y: auto;" VerticalGap="12">
         <div class="input-container">
             <FluentRadioGroup TValue="string"
                               Label="@Loc[nameof(Dialogs.SettingsDialogTheme)]"


### PR DESCRIPTION
## Description

At 200% zoom with 1280x768 resolution, the "Manage" button in the Settings dialog overlaps with the "Close" button in the dialog footer. This is because the `FluentStack` container inside the dialog body did not have `overflow-y: auto`, so content would extend beyond the available space instead of scrolling.

This fix adds `overflow-y: auto` to the Settings dialog's `FluentStack` style so that the content scrolls when the viewport is constrained, preventing the overlap.

Related: #17254

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [x] No
- Did you add public API?
  - [ ] Yes
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
  - [x] No