### PR TITLE
Optimize AppHost RID selection

### DIFF
--- a/src/Aspire.AppHost.Sdk/Aspire.AppHost.Sdk.csproj
+++ b/src/Aspire.AppHost.Sdk/Aspire.AppHost.Sdk.csproj
@@ -28,8 +28,8 @@
   </ItemGroup>
 
   <Target Name="_PublishAndPackRIDTool">
-    <MSBuild Projects="$(MSBuildThisFileDirectory)Aspire.RuntimeIdentifier.Tool\Aspire.RuntimeIdentifier.Tool.csproj" 
-             Targets="Publish" 
+    <MSBuild Projects="$(MSBuildThisFileDirectory)Aspire.RuntimeIdentifier.Tool\Aspire.RuntimeIdentifier.Tool.csproj"
+             Targets="Publish"
              Properties="Configuration=$(Configuration);Platform=$(Platform)" />
 
     <ItemGroup>

--- a/src/Aspire.AppHost.Sdk/SDK/Sdk.in.targets
+++ b/src/Aspire.AppHost.Sdk/SDK/Sdk.in.targets
@@ -126,26 +126,43 @@
 
     <PropertyGroup>
       <_AspireUseSdkPickBestRid Condition="'$(_AspireUseSdkPickBestRid)' == '' and '$(NETCoreSdkVersion)' != '' and $([MSBuild]::VersionGreaterThanOrEquals('$(NETCoreSdkVersion)', '10.0.100'))">true</_AspireUseSdkPickBestRid>
+      <!-- AddReferenceToDashboardAndDCP can run more than once in a build, so reset transient
+           outputs before deciding whether the out-of-proc fallback is needed. -->
+      <_AspireRunRidToolFallback>false</_AspireRunRidToolFallback>
+      <_DashboardAndDcpRID />
     </PropertyGroup>
+    <ItemGroup>
+      <_AspireRidToolOutput Remove="@(_AspireRidToolOutput)" />
+    </ItemGroup>
 
-    <!-- .NET 10 SDKs provide the RID-selection task in-process. Keep the older out-of-proc tool
-         fallback so Aspire.AppHost.Sdk remains compatible with older supported SDKs. -->
+    <!-- .NET 10 SDKs provide the RID-selection task in-process, which is much faster than spawning
+         the out-of-proc Aspire.RuntimeIdentifier.Tool. If the in-proc task fails for any reason
+         (for example, a missing runtime graph file or an unrecognized target RID), we downgrade
+         the failure to a warning and fall through to the legacy tool so the build can still
+         resolve a RID. -->
     <Microsoft.NET.Build.Tasks.PickBestRid Condition="'$(_AspireUseSdkPickBestRid)' == 'true'"
                                            RuntimeGraphPath="$(BundledRuntimeIdentifierGraphFile)"
                                            TargetRid="$(NETCoreSdkRuntimeIdentifier)"
-                                           SupportedRids="@(_DashboardAndDCPSupportedTargetingRIDs)">
+                                           SupportedRids="@(_DashboardAndDCPSupportedTargetingRIDs)"
+                                           ContinueOnError="WarnAndContinue">
       <Output TaskParameter="MatchingRid" PropertyName="_DashboardAndDcpRID" />
     </Microsoft.NET.Build.Tasks.PickBestRid>
 
+    <!-- Run the out-of-proc Aspire.RuntimeIdentifier.Tool fallback when the in-proc task is unavailable
+         (older SDKs) or when it failed to produce a RID. -->
+    <PropertyGroup>
+      <_AspireRunRidToolFallback Condition="'$(_DashboardAndDcpRID)' == ''">true</_AspireRunRidToolFallback>
+    </PropertyGroup>
+
     <!-- If running in .NET Core, DOTNET_HOST_PATH is set to point to the dotnet executable being used
     for the build. -->
-    <PropertyGroup Condition="'$(_AspireUseSdkPickBestRid)' != 'true'">
+    <PropertyGroup Condition="'$(_AspireRunRidToolFallback)' == 'true'">
       <_DotNetHostPath>$(DOTNET_HOST_PATH)</_DotNetHostPath>
     </PropertyGroup>
 
     <!-- If running on .NET Framework MSBuild, then DOTNET_HOST_PATH won't be set, so we need to construct
     the path using well-known properties. -->
-    <PropertyGroup Condition="'$(_AspireUseSdkPickBestRid)' != 'true' and '$(_DotNetHostPath)' == ''">
+    <PropertyGroup Condition="'$(_AspireRunRidToolFallback)' == 'true' and '$(_DotNetHostPath)' == ''">
       <_DotNetHostDirectory>$(NetCoreRoot)</_DotNetHostDirectory>
       <_DotNetHostFileName>dotnet</_DotNetHostFileName>
       <_DotNetHostFileName Condition="'$(OS)' == 'Windows_NT'">dotnet.exe</_DotNetHostFileName>
@@ -154,7 +171,7 @@
     </PropertyGroup>
 
     <!-- Call Aspire.RuntimeIdentifier.Tool to get the RIDs for Dashboard and DCP packages -->
-    <Exec Condition="'$(_AspireUseSdkPickBestRid)' != 'true'"
+    <Exec Condition="'$(_AspireRunRidToolFallback)' == 'true'"
           Command="&quot;$(_DotNetHostPath)&quot; exec &quot;$(AspireRidToolExecutable)&quot; --runtimeGraphPath &quot;$(BundledRuntimeIdentifierGraphFile)&quot; --supportedRids &quot;@(_DashboardAndDCPSupportedTargetingRIDs -> '%(Identity)', ',')&quot; --netcoreSdkRuntimeIdentifier &quot;$(NETCoreSdkRuntimeIdentifier)&quot;"
           ConsoleToMSBuild="true"
           StandardOutputImportance="Low"
@@ -163,13 +180,13 @@
       <Output TaskParameter="ConsoleOutput" ItemName="_AspireRidToolOutput" />
     </Exec>
 
-    <Error Condition="'$(_AspireUseSdkPickBestRid)' != 'true' and $(_AspireRidToolExitCode) != 0" Text="Failed to run Aspire.RuntimeIdentifier.Tool. Exit code: $(_AspireRidToolExitCode). Output: @(_AspireRidToolOutput)" />
+    <Error Condition="'$(_AspireRunRidToolFallback)' == 'true' and $(_AspireRidToolExitCode) != 0" Text="Failed to run Aspire.RuntimeIdentifier.Tool. Exit code: $(_AspireRidToolExitCode). Output: @(_AspireRidToolOutput)" />
 
-    <PropertyGroup Condition="'$(_AspireUseSdkPickBestRid)' != 'true'">
+    <PropertyGroup Condition="'$(_AspireRunRidToolFallback)' == 'true'">
       <_DashboardAndDcpRID>@(_AspireRidToolOutput)</_DashboardAndDcpRID>
     </PropertyGroup>
 
-    <Error Condition="'$(_DashboardAndDcpRID)' == ''" Text="Failed to resolve a RID for Aspire Dashboard and DCP package references. NETCoreSdkRuntimeIdentifier='$(NETCoreSdkRuntimeIdentifier)', NETCoreSdkVersion='$(NETCoreSdkVersion)', UsedSdkPickBestRidTask='$(_AspireUseSdkPickBestRid)', SupportedRids='@(_DashboardAndDCPSupportedTargetingRIDs)'." />
+    <Error Condition="'$(_DashboardAndDcpRID)' == ''" Text="Failed to resolve a RID for Aspire Dashboard and DCP package references. NETCoreSdkRuntimeIdentifier='$(NETCoreSdkRuntimeIdentifier)', NETCoreSdkVersion='$(NETCoreSdkVersion)', UsedSdkPickBestRidTask='$(_AspireUseSdkPickBestRid)', UsedRidToolFallback='$(_AspireRunRidToolFallback)', SupportedRids='@(_DashboardAndDCPSupportedTargetingRIDs)'." />
 
     <!-- Now that we have the version, we add the package references -->
     <ItemGroup>

--- a/src/Aspire.AppHost.Sdk/SDK/Sdk.in.targets
+++ b/src/Aspire.AppHost.Sdk/SDK/Sdk.in.targets
@@ -125,7 +125,7 @@
     </ItemGroup>
 
     <PropertyGroup>
-      <_AspireUseSdkPickBestRid Condition="'$(_AspireUseSdkPickBestRid)' == '' and '$(NETCoreSdkVersion)' != '' and !$([MSBuild]::VersionLessThan('$(NETCoreSdkVersion)', '10.0.100'))">true</_AspireUseSdkPickBestRid>
+      <_AspireUseSdkPickBestRid Condition="'$(_AspireUseSdkPickBestRid)' == '' and '$(NETCoreSdkVersion)' != '' and $([MSBuild]::VersionGreaterThanOrEquals('$(NETCoreSdkVersion)', '10.0.100'))">true</_AspireUseSdkPickBestRid>
     </PropertyGroup>
 
     <!-- .NET 10 SDKs provide the RID-selection task in-process. Keep the older out-of-proc tool
@@ -168,7 +168,7 @@
       <_DashboardAndDcpRID>@(_AspireRidToolOutput)</_DashboardAndDcpRID>
     </PropertyGroup>
 
-    <Error Condition="'$(_DashboardAndDcpRID)' == ''" Text="Failed to resolve a RID for Aspire Dashboard and DCP package references." />
+    <Error Condition="'$(_DashboardAndDcpRID)' == ''" Text="Failed to resolve a RID for Aspire Dashboard and DCP package references. NETCoreSdkRuntimeIdentifier='$(NETCoreSdkRuntimeIdentifier)', NETCoreSdkVersion='$(NETCoreSdkVersion)', UsedSdkPickBestRidTask='$(_AspireUseSdkPickBestRid)', SupportedRids='@(_DashboardAndDCPSupportedTargetingRIDs)'." />
 
     <!-- Now that we have the version, we add the package references -->
     <ItemGroup>

--- a/src/Aspire.AppHost.Sdk/SDK/Sdk.in.targets
+++ b/src/Aspire.AppHost.Sdk/SDK/Sdk.in.targets
@@ -124,15 +124,28 @@
       <_DashboardAndDCPSupportedTargetingRIDs Include="osx-arm64" />
     </ItemGroup>
 
+    <PropertyGroup>
+      <_AspireUseSdkPickBestRid Condition="'$(_AspireUseSdkPickBestRid)' == '' and '$(NETCoreSdkVersion)' != '' and !$([MSBuild]::VersionLessThan('$(NETCoreSdkVersion)', '10.0.100'))">true</_AspireUseSdkPickBestRid>
+    </PropertyGroup>
+
+    <!-- .NET 10 SDKs provide the RID-selection task in-process. Keep the older out-of-proc tool
+         fallback so Aspire.AppHost.Sdk remains compatible with older supported SDKs. -->
+    <Microsoft.NET.Build.Tasks.PickBestRid Condition="'$(_AspireUseSdkPickBestRid)' == 'true'"
+                                           RuntimeGraphPath="$(BundledRuntimeIdentifierGraphFile)"
+                                           TargetRid="$(NETCoreSdkRuntimeIdentifier)"
+                                           SupportedRids="@(_DashboardAndDCPSupportedTargetingRIDs)">
+      <Output TaskParameter="MatchingRid" PropertyName="_DashboardAndDcpRID" />
+    </Microsoft.NET.Build.Tasks.PickBestRid>
+
     <!-- If running in .NET Core, DOTNET_HOST_PATH is set to point to the dotnet executable being used
     for the build. -->
-    <PropertyGroup>
+    <PropertyGroup Condition="'$(_AspireUseSdkPickBestRid)' != 'true'">
       <_DotNetHostPath>$(DOTNET_HOST_PATH)</_DotNetHostPath>
     </PropertyGroup>
 
     <!-- If running on .NET Framework MSBuild, then DOTNET_HOST_PATH won't be set, so we need to construct
     the path using well-known properties. -->
-    <PropertyGroup Condition="'$(_DotNetHostPath)' == ''">
+    <PropertyGroup Condition="'$(_AspireUseSdkPickBestRid)' != 'true' and '$(_DotNetHostPath)' == ''">
       <_DotNetHostDirectory>$(NetCoreRoot)</_DotNetHostDirectory>
       <_DotNetHostFileName>dotnet</_DotNetHostFileName>
       <_DotNetHostFileName Condition="'$(OS)' == 'Windows_NT'">dotnet.exe</_DotNetHostFileName>
@@ -140,8 +153,8 @@
       <_DotNetHostPath>$(_DotNetHostDirectory)\$(_DotNetHostFileName)</_DotNetHostPath>
     </PropertyGroup>
 
-    <!-- Call Aspire.RuntimeIdentifier.Tool to get the RIDs for Dashboard and DCP packages -->
-    <Exec Command="&quot;$(_DotNetHostPath)&quot; exec &quot;$(AspireRidToolExecutable)&quot; --runtimeGraphPath &quot;$(BundledRuntimeIdentifierGraphFile)&quot; --supportedRids &quot;@(_DashboardAndDCPSupportedTargetingRIDs -> '%(Identity)', ',')&quot; --netcoreSdkRuntimeIdentifier &quot;$(NETCoreSdkRuntimeIdentifier)&quot;"
+    <Exec Condition="'$(_AspireUseSdkPickBestRid)' != 'true'"
+          Command="&quot;$(_DotNetHostPath)&quot; exec &quot;$(AspireRidToolExecutable)&quot; --runtimeGraphPath &quot;$(BundledRuntimeIdentifierGraphFile)&quot; --supportedRids &quot;@(_DashboardAndDCPSupportedTargetingRIDs -> '%(Identity)', ',')&quot; --netcoreSdkRuntimeIdentifier &quot;$(NETCoreSdkRuntimeIdentifier)&quot;"
           ConsoleToMSBuild="true"
           StandardOutputImportance="Low"
           IgnoreExitCode="true">
@@ -149,12 +162,13 @@
       <Output TaskParameter="ConsoleOutput" ItemName="_AspireRidToolOutput" />
     </Exec>
 
-    <Error Condition="$(_AspireRidToolExitCode) != 0" Text="Failed to run Aspire.RuntimeIdentifier.Tool. Exit code: $(_AspireRidToolExitCode). Output: @(_AspireRidToolOutput)" />
+    <Error Condition="'$(_AspireUseSdkPickBestRid)' != 'true' and $(_AspireRidToolExitCode) != 0" Text="Failed to run Aspire.RuntimeIdentifier.Tool. Exit code: $(_AspireRidToolExitCode). Output: @(_AspireRidToolOutput)" />
 
-    <PropertyGroup>
+    <PropertyGroup Condition="'$(_AspireUseSdkPickBestRid)' != 'true'">
       <_DashboardAndDcpRID>@(_AspireRidToolOutput)</_DashboardAndDcpRID>
     </PropertyGroup>
 
+    <Error Condition="'$(_DashboardAndDcpRID)' == ''" Text="Failed to resolve a RID for Aspire Dashboard and DCP package references." />
 
     <!-- Now that we have the version, we add the package references -->
     <ItemGroup>

--- a/src/Aspire.AppHost.Sdk/SDK/Sdk.in.targets
+++ b/src/Aspire.AppHost.Sdk/SDK/Sdk.in.targets
@@ -153,6 +153,7 @@
       <_DotNetHostPath>$(_DotNetHostDirectory)\$(_DotNetHostFileName)</_DotNetHostPath>
     </PropertyGroup>
 
+    <!-- Call Aspire.RuntimeIdentifier.Tool to get the RIDs for Dashboard and DCP packages -->
     <Exec Condition="'$(_AspireUseSdkPickBestRid)' != 'true'"
           Command="&quot;$(_DotNetHostPath)&quot; exec &quot;$(AspireRidToolExecutable)&quot; --runtimeGraphPath &quot;$(BundledRuntimeIdentifierGraphFile)&quot; --supportedRids &quot;@(_DashboardAndDCPSupportedTargetingRIDs -> '%(Identity)', ',')&quot; --netcoreSdkRuntimeIdentifier &quot;$(NETCoreSdkRuntimeIdentifier)&quot;"
           ConsoleToMSBuild="true"

--- a/tests/Aspire.Hosting.Sdk.Tests/AppHostSdkTargetsTests.cs
+++ b/tests/Aspire.Hosting.Sdk.Tests/AppHostSdkTargetsTests.cs
@@ -27,6 +27,7 @@ public class AppHostSdkTargetsTests
         var packageReferences = await RunAddReferenceToDashboardAndDcpAsync(extraProjectXml: null);
 
         Assert.Contains("UseSdkPickBestRid=true", packageReferences);
+        Assert.Contains("RunRidToolFallback=false", packageReferences);
         AssertDashboardAndOrchestrationReferences(packageReferences);
     }
 
@@ -48,6 +49,7 @@ public class AppHostSdkTargetsTests
         var packageReferences = await RunAddReferenceToDashboardAndDcpAsync(extraProjectXml);
 
         Assert.Contains("UseSdkPickBestRid=false", packageReferences);
+        Assert.Contains("RunRidToolFallback=true", packageReferences);
         AssertDashboardAndOrchestrationReferences(packageReferences);
     }
 
@@ -81,7 +83,7 @@ public class AppHostSdkTargetsTests
 
               <Target Name="WritePackageReferences" DependsOnTargets="AddReferenceToDashboardAndDCP">
                 <WriteLinesToFile File="$(BaseIntermediateOutputPath)package-references.txt"
-                                  Lines="UseSdkPickBestRid=$(_AspireUseSdkPickBestRid);@(PackageReference->'%(Identity)=%(Version)')"
+                                  Lines="UseSdkPickBestRid=$(_AspireUseSdkPickBestRid);RunRidToolFallback=$(_AspireRunRidToolFallback);@(PackageReference->'%(Identity)=%(Version)')"
                                   Overwrite="true" />
               </Target>
 

--- a/tests/Aspire.Hosting.Sdk.Tests/AppHostSdkTargetsTests.cs
+++ b/tests/Aspire.Hosting.Sdk.Tests/AppHostSdkTargetsTests.cs
@@ -1,0 +1,131 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Diagnostics;
+using System.Security;
+using Xunit;
+
+namespace Aspire.Hosting.Sdk.Tests;
+
+public class AppHostSdkTargetsTests
+{
+    private static readonly string[] s_supportedRids =
+    [
+        "win-x64",
+        "win-arm64",
+        "linux-x64",
+        "linux-arm64",
+        "linux-musl-x64",
+        "osx-x64",
+        "osx-arm64"
+    ];
+
+    [Fact]
+    public async Task AddReferenceToDashboardAndDcpUsesSdkRidSelectionTask()
+    {
+        var repoRoot = GetRepoRoot();
+        using var tempDirectory = new TestTempDirectory();
+
+        var projectDirectory = Path.Combine(tempDirectory.Path, "AppHost");
+        Directory.CreateDirectory(projectDirectory);
+
+        var sdkTargetsPath = SecurityElement.Escape(Path.Combine(repoRoot, "src", "Aspire.AppHost.Sdk", "SDK", "Sdk.in.targets"));
+        var packageReferencesPath = Path.Combine(projectDirectory, "obj", "package-references.txt");
+
+        await File.WriteAllTextAsync(Path.Combine(projectDirectory, "AppHost.csproj"),
+            $$"""
+            <Project Sdk="Microsoft.NET.Sdk">
+
+              <PropertyGroup>
+                <TargetFramework>net8.0</TargetFramework>
+                <SkipAspireWorkloadManifest>true</SkipAspireWorkloadManifest>
+              </PropertyGroup>
+
+              <ItemGroup>
+                <PackageReference Include="Aspire.Hosting.AppHost" Version="13.4.0" />
+              </ItemGroup>
+
+              <Import Project="{{sdkTargetsPath}}" />
+
+              <Target Name="WritePackageReferences" DependsOnTargets="AddReferenceToDashboardAndDCP">
+                <WriteLinesToFile File="$(BaseIntermediateOutputPath)package-references.txt"
+                                  Lines="UseSdkPickBestRid=$(_AspireUseSdkPickBestRid);@(PackageReference->'%(Identity)=%(Version)')"
+                                  Overwrite="true" />
+              </Target>
+
+            </Project>
+            """);
+
+        var result = await RunDotNetAsync(projectDirectory, "msbuild -nologo -t:WritePackageReferences");
+
+        Assert.True(result.ExitCode == 0, result.Output);
+
+        var packageReferences = await File.ReadAllLinesAsync(packageReferencesPath);
+        Assert.Contains("UseSdkPickBestRid=true", packageReferences);
+
+        var dashboardReference = Assert.Single(packageReferences, static packageReference => packageReference.StartsWith("Aspire.Dashboard.Sdk.", StringComparison.Ordinal));
+        var orchestrationReference = Assert.Single(packageReferences, static packageReference => packageReference.StartsWith("Aspire.Hosting.Orchestration.", StringComparison.Ordinal));
+
+        var dashboardRid = GetPackageRid(dashboardReference, "Aspire.Dashboard.Sdk.");
+        var orchestrationRid = GetPackageRid(orchestrationReference, "Aspire.Hosting.Orchestration.");
+
+        Assert.Equal(dashboardRid, orchestrationRid);
+        Assert.Contains(dashboardRid, s_supportedRids);
+        Assert.Equal($"Aspire.Dashboard.Sdk.{dashboardRid}=13.4.0", dashboardReference);
+        Assert.Equal($"Aspire.Hosting.Orchestration.{dashboardRid}=13.4.0", orchestrationReference);
+    }
+
+    private static string GetPackageRid(string packageReference, string prefix)
+    {
+        var equalsIndex = packageReference.IndexOf('=');
+        Assert.True(equalsIndex > prefix.Length, $"Package reference '{packageReference}' did not contain a RID.");
+
+        return packageReference[prefix.Length..equalsIndex];
+    }
+
+    private static async Task<(int ExitCode, string Output)> RunDotNetAsync(string workingDirectory, string arguments)
+    {
+        using var process = Process.Start(new ProcessStartInfo("dotnet", arguments)
+        {
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+            CreateNoWindow = true,
+            WorkingDirectory = workingDirectory
+        });
+
+        Assert.NotNull(process);
+
+        var outputTask = process.StandardOutput.ReadToEndAsync();
+        var errorTask = process.StandardError.ReadToEndAsync();
+
+        using var cts = new CancellationTokenSource(TimeSpan.FromMinutes(3));
+
+        try
+        {
+            await process.WaitForExitAsync(cts.Token);
+        }
+        catch (OperationCanceledException)
+        {
+            process.Kill(entireProcessTree: true);
+            throw new TimeoutException($"dotnet {arguments} timed out after 3 minutes.");
+        }
+
+        var output = await outputTask;
+        var error = await errorTask;
+
+        return (process.ExitCode, output + error);
+    }
+
+    private static string GetRepoRoot()
+    {
+        var directory = AppContext.BaseDirectory;
+
+        while (directory is not null && !Directory.Exists(Path.Combine(directory, ".git")) && !File.Exists(Path.Combine(directory, ".git")))
+        {
+            directory = Directory.GetParent(directory)?.FullName;
+        }
+
+        return directory ?? throw new InvalidOperationException("Could not find repository root.");
+    }
+}

--- a/tests/Aspire.Hosting.Sdk.Tests/AppHostSdkTargetsTests.cs
+++ b/tests/Aspire.Hosting.Sdk.Tests/AppHostSdkTargetsTests.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Diagnostics;
+using System.Reflection;
 using System.Security;
 using Xunit;
 
@@ -22,6 +23,35 @@ public class AppHostSdkTargetsTests
 
     [Fact]
     public async Task AddReferenceToDashboardAndDcpUsesSdkRidSelectionTask()
+    {
+        var packageReferences = await RunAddReferenceToDashboardAndDcpAsync(extraProjectXml: null);
+
+        Assert.Contains("UseSdkPickBestRid=true", packageReferences);
+        AssertDashboardAndOrchestrationReferences(packageReferences);
+    }
+
+    [Fact]
+    public async Task AddReferenceToDashboardAndDcpFallsBackToRuntimeIdentifierToolForOlderSdks()
+    {
+        // Force the pre-.NET 10 code path by disabling the in-proc PickBestRid task and pointing the
+        // Exec call at the locally-built Aspire.RuntimeIdentifier.Tool assembly (which is normally
+        // resolved out of the packed SDK's tools folder).
+        var ridToolPath = GetAspireRuntimeIdentifierToolPath();
+
+        var extraProjectXml = $"""
+              <PropertyGroup>
+                <_AspireUseSdkPickBestRid>false</_AspireUseSdkPickBestRid>
+                <AspireRidToolExecutable>{SecurityElement.Escape(ridToolPath)}</AspireRidToolExecutable>
+              </PropertyGroup>
+            """;
+
+        var packageReferences = await RunAddReferenceToDashboardAndDcpAsync(extraProjectXml);
+
+        Assert.Contains("UseSdkPickBestRid=false", packageReferences);
+        AssertDashboardAndOrchestrationReferences(packageReferences);
+    }
+
+    private static async Task<string[]> RunAddReferenceToDashboardAndDcpAsync(string? extraProjectXml)
     {
         var repoRoot = GetRepoRoot();
         using var tempDirectory = new TestTempDirectory();
@@ -47,6 +77,8 @@ public class AppHostSdkTargetsTests
 
               <Import Project="{{sdkTargetsPath}}" />
 
+            {{extraProjectXml}}
+
               <Target Name="WritePackageReferences" DependsOnTargets="AddReferenceToDashboardAndDCP">
                 <WriteLinesToFile File="$(BaseIntermediateOutputPath)package-references.txt"
                                   Lines="UseSdkPickBestRid=$(_AspireUseSdkPickBestRid);@(PackageReference->'%(Identity)=%(Version)')"
@@ -60,9 +92,11 @@ public class AppHostSdkTargetsTests
 
         Assert.True(result.ExitCode == 0, result.Output);
 
-        var packageReferences = await File.ReadAllLinesAsync(packageReferencesPath);
-        Assert.Contains("UseSdkPickBestRid=true", packageReferences);
+        return await File.ReadAllLinesAsync(packageReferencesPath);
+    }
 
+    private static void AssertDashboardAndOrchestrationReferences(string[] packageReferences)
+    {
         var dashboardReference = Assert.Single(packageReferences, static packageReference => packageReference.StartsWith("Aspire.Dashboard.Sdk.", StringComparison.Ordinal));
         var orchestrationReference = Assert.Single(packageReferences, static packageReference => packageReference.StartsWith("Aspire.Hosting.Orchestration.", StringComparison.Ordinal));
 
@@ -73,6 +107,20 @@ public class AppHostSdkTargetsTests
         Assert.Contains(dashboardRid, s_supportedRids);
         Assert.Equal($"Aspire.Dashboard.Sdk.{dashboardRid}=13.4.0", dashboardReference);
         Assert.Equal($"Aspire.Hosting.Orchestration.{dashboardRid}=13.4.0", orchestrationReference);
+    }
+
+    private static string GetAspireRuntimeIdentifierToolPath()
+    {
+        // The path to the locally-built RID tool is baked into the test assembly via AssemblyMetadata
+        // so the test can locate it regardless of the configuration the test was built with.
+        var assembly = typeof(AppHostSdkTargetsTests).Assembly;
+        var toolPath = assembly
+            .GetCustomAttributes<AssemblyMetadataAttribute>()
+            .Single(a => string.Equals(a.Key, "AspireRuntimeIdentifierToolPath", StringComparison.Ordinal))
+            .Value;
+        Assert.False(string.IsNullOrEmpty(toolPath), "AspireRuntimeIdentifierToolPath assembly metadata is not set.");
+        Assert.True(File.Exists(toolPath), $"Aspire.RuntimeIdentifier.Tool was not built at '{toolPath}'. Build the test project to produce it.");
+        return toolPath!;
     }
 
     private static string GetPackageRid(string packageReference, string prefix)

--- a/tests/Aspire.Hosting.Sdk.Tests/Aspire.Hosting.Sdk.Tests.csproj
+++ b/tests/Aspire.Hosting.Sdk.Tests/Aspire.Hosting.Sdk.Tests.csproj
@@ -5,6 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <Compile Include="$(TestsSharedDir)TempDirectory.cs" Link="shared/TempDirectory.cs" />
     <Compile Include="..\..\src\Aspire.AppHost.Sdk\Aspire.RuntimeIdentifier.Tool\NuGetUtils.cs" Link="Product\NuGetUtils.cs" />
     <None Include="$(BundledRuntimeIdentifierGraphFile)" Link="RuntimeIdentifierGraph.json" CopyToOutputDirectory="Always" />
   </ItemGroup>

--- a/tests/Aspire.Hosting.Sdk.Tests/Aspire.Hosting.Sdk.Tests.csproj
+++ b/tests/Aspire.Hosting.Sdk.Tests/Aspire.Hosting.Sdk.Tests.csproj
@@ -11,6 +11,20 @@
   </ItemGroup>
 
   <ItemGroup>
+    <!-- Build the runtime identifier tool so the fallback path test can invoke it via dotnet exec. -->
+    <ProjectReference Include="..\..\src\Aspire.AppHost.Sdk\Aspire.RuntimeIdentifier.Tool\Aspire.RuntimeIdentifier.Tool.csproj"
+                      ReferenceOutputAssembly="false"
+                      SkipGetTargetFrameworkProperties="true"
+                      Private="false"
+                      ExcludeAssets="all" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <!-- Expose the built RID tool path to tests via assembly metadata so the older-SDK fallback can be exercised. -->
+    <AssemblyMetadata Include="AspireRuntimeIdentifierToolPath" Value="$(ArtifactsBinDir)Aspire.RuntimeIdentifier.Tool\$(Configuration)\$(DefaultTargetFramework)\Aspire.RuntimeIdentifier.Tool.dll" />
+  </ItemGroup>
+
+  <ItemGroup>
     <PackageReference Include="NuGet.ProjectModel" />
   </ItemGroup>
 


### PR DESCRIPTION
## Description

Warm AppHost builds were spending a noticeable amount of time in `AddReferenceToDashboardAndDCP` because each target execution launched the packaged RID helper process to select the Dashboard/DCP RID package. This change uses the .NET SDK-owned `Microsoft.NET.Build.Tasks.PickBestRid` task when running on .NET 10 SDKs, avoiding the external `dotnet exec Aspire.RuntimeIdentifier.Tool.dll` call on the hot path.

The existing `Aspire.RuntimeIdentifier.Tool` remains packaged and is still used as a fallback for older SDKs, so this is not a breaking change for supported environments that do not have the SDK task.

### Performance numbers

The before numbers come from the issue binlog/profile investigation using a localhive Release CLI and plain `aspire run --capture-profile --capture-profile-delay 8 --non-interactive --nologo`.

| Scenario | Before | After |
| --- | --- | --- |
| Normal starter warm `aspire run` | `aspire/cli/apphost.build` profile span: 1.97s. MSBuild binlog duration: 1.738s. `AddReferenceToDashboardAndDCP`: 745 ms total over 3 executions. RID helper `Exec`: 743 ms total over 3 executions. | `AddReferenceToDashboardAndDCP`: 0 ms total over 3 executions. SDK `PickBestRid`: 0 ms total over 3 executions. RID helper `Exec`: 0 matches. `Aspire.RuntimeIdentifier.Tool`: 0 matches on the hot path. |
| Single-file AppHost warm `aspire run` | Main build span: 2.78s plus 0.73s inspection build. Binlogs: 2.230s and 0.520s. `AddReferenceToDashboardAndDCP`: 655 ms total over 3 executions. RID helper `Exec`: 652 ms total over 3 executions. | The repeated out-of-proc RID helper launch is removed on .NET 10 SDKs. The post-change binlog shows SDK `PickBestRid` instead of `Exec`, with no `Aspire.RuntimeIdentifier.Tool` execution on the hot path. |
| Isolated warm `dotnet build` of packed PR AppHost SDK | N/A | Build succeeded with 0 warnings/errors. MSBuild elapsed: 2.17s (`real 2.46s`). `AddReferenceToDashboardAndDCP`: 12 ms. SDK `Microsoft.NET.Build.Tasks.PickBestRid`: 11 ms. `Exec`: 0 matches. |

Validation:
- `dotnet test --project tests/Aspire.Hosting.Sdk.Tests/Aspire.Hosting.Sdk.Tests.csproj --no-launch-profile -- --filter-not-trait "quarantined=true" --filter-not-trait "outerloop=true"`
- `dotnet test --project tests/Aspire.Hosting.Sdk.Tests/Aspire.Hosting.Sdk.Tests.csproj --no-launch-profile -- --filter-method "*.AddReferenceToDashboardAndDcpUsesSdkRidSelectionTask" --filter-not-trait "quarantined=true" --filter-not-trait "outerloop=true"`
- `dotnet restore src/Aspire.AppHost.Sdk/Aspire.AppHost.Sdk.csproj`
- `dotnet pack src/Aspire.AppHost.Sdk/Aspire.AppHost.Sdk.csproj --no-restore -c Debug`
- Manual fallback smoke test with `_AspireUseSdkPickBestRid=false`
- Warm build binlog check: `AddReferenceToDashboardAndDCP` 12 ms, SDK `PickBestRid` 11 ms, no `Exec` task for RID selection

Fixes: #17250

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No