### PR TITLE
Move InitCommand hardcoded strings to resource file for localization

### DIFF
--- a/src/Aspire.Cli/Commands/InitCommand.cs
+++ b/src/Aspire.Cli/Commands/InitCommand.cs
@@ -175,8 +175,8 @@ internal sealed class InitCommand : BaseCommand
                 InteractionService.DisplayMessage(
                     KnownEmojis.Dizzy,
                     commands.Count == 1
-                        ? "Aspire AppHost created! To complete setup, run:"
-                        : "Aspire AppHost created! To complete setup, run one of:");
+                        ? InitCommandStrings.AppHostCreatedRunOne
+                        : InitCommandStrings.AppHostCreatedRunOneOf);
                 InteractionService.DisplayEmptyLine();
 
                 foreach (var command in commands)
@@ -202,7 +202,7 @@ internal sealed class InitCommand : BaseCommand
         {
             InteractionService.DisplayMessage(
                 KnownEmojis.Warning,
-                $"`aspire init {optionName}` is deprecated and no longer affects generated AppHosts. It is accepted for compatibility and will be removed in a future version.");
+                string.Format(CultureInfo.CurrentCulture, InitCommandStrings.DeprecatedOptionWarning, optionName));
         }
     }
 
@@ -259,7 +259,7 @@ internal sealed class InitCommand : BaseCommand
         var appHostPath = Path.Combine(workingDirectory.FullName, "apphost.cs");
         if (File.Exists(appHostPath))
         {
-            InteractionService.DisplayMessage(KnownEmojis.CheckMarkButton, "apphost.cs already exists — skipping.");
+            InteractionService.DisplayMessage(KnownEmojis.Information, string.Format(CultureInfo.CurrentCulture, InitCommandStrings.FileAlreadyExistsSkipping, "apphost.cs"));
             return CliExitCodes.Success;
         }
 
@@ -277,7 +277,7 @@ internal sealed class InitCommand : BaseCommand
             builder.Build().Run();
             """;
         File.WriteAllText(appHostPath, appHostContent);
-        InteractionService.DisplayMessage(KnownEmojis.CheckMarkButton, "Created apphost.cs");
+        InteractionService.DisplayMessage(KnownEmojis.CheckMarkButton, string.Format(CultureInfo.CurrentCulture, InitCommandStrings.CreatedFile, "apphost.cs"));
 
         // Generate one set of ports so aspire.config.json (used by `aspire run`) and
         // apphost.run.json (used by `dotnet run apphost.cs`) agree on the dashboard /
@@ -341,7 +341,7 @@ internal sealed class InitCommand : BaseCommand
 
         if (Directory.Exists(appHostDirPath))
         {
-            InteractionService.DisplayMessage(KnownEmojis.CheckMarkButton, $"{appHostDirName}/ already exists — skipping.");
+            InteractionService.DisplayMessage(KnownEmojis.Information, string.Format(CultureInfo.CurrentCulture, InitCommandStrings.FileAlreadyExistsSkipping, $"{appHostDirName}/"));
             return CliExitCodes.Success;
         }
 
@@ -405,7 +405,7 @@ internal sealed class InitCommand : BaseCommand
         var installOutcome = await _templateNuGetConfigService.InstallTemplatePackageAsync(
             selection,
             _runner,
-            "Installing Aspire project templates...",
+            InitCommandStrings.InstallingAspireProjectTemplates,
             statusEmoji: null,
             cancellationToken);
 
@@ -419,7 +419,7 @@ internal sealed class InitCommand : BaseCommand
         // Use the aspire-apphost template to generate a correct AppHost project
         // with proper launchSettings.json, .csproj, and Program.cs.
         var result = await InteractionService.ShowStatusAsync(
-            "Creating AppHost from template...",
+            InitCommandStrings.CreatingAppHostFromTemplate,
             async () =>
             {
                 return await _runner.NewProjectAsync(
@@ -433,11 +433,11 @@ internal sealed class InitCommand : BaseCommand
 
         if (result != 0)
         {
-            InteractionService.DisplayError($"Failed to create AppHost from template (exit code {result}).");
+            InteractionService.DisplayError(string.Format(CultureInfo.CurrentCulture, InitCommandStrings.FailedToCreateAppHostFromTemplate, result));
             return CliExitCodes.FailedToCreateNewProject;
         }
 
-        InteractionService.DisplayMessage(KnownEmojis.CheckMarkButton, $"Created {appHostDirName}/");
+        InteractionService.DisplayMessage(KnownEmojis.CheckMarkButton, string.Format(CultureInfo.CurrentCulture, InitCommandStrings.CreatedFile, $"{appHostDirName}/"));
 
         return CliExitCodes.Success;
     }
@@ -453,7 +453,7 @@ internal sealed class InitCommand : BaseCommand
         var appHostPath = Path.Combine(workingDirectory.FullName, appHostFileName);
         if (File.Exists(appHostPath))
         {
-            InteractionService.DisplayMessage(KnownEmojis.CheckMarkButton, $"{appHostFileName} already exists — skipping.");
+            InteractionService.DisplayMessage(KnownEmojis.Information, string.Format(CultureInfo.CurrentCulture, InitCommandStrings.FileAlreadyExistsSkipping, appHostFileName));
             return CliExitCodes.Success;
         }
 
@@ -464,7 +464,7 @@ internal sealed class InitCommand : BaseCommand
             return CliExitCodes.FailedToCreateNewProject;
         }
 
-        InteractionService.DisplayMessage(KnownEmojis.CheckMarkButton, $"Created {appHostFileName}");
+        InteractionService.DisplayMessage(KnownEmojis.CheckMarkButton, string.Format(CultureInfo.CurrentCulture, InitCommandStrings.CreatedFile, appHostFileName));
         return CliExitCodes.Success;
     }
 
@@ -490,8 +490,8 @@ internal sealed class InitCommand : BaseCommand
                 }
                 catch (JsonException ex)
                 {
-                    InteractionService.DisplayError($"Failed to parse existing {AspireConfigFile.FileName} at '{configPath}': {ex.Message}");
-                    InteractionService.DisplayMessage(KnownEmojis.Warning, $"Fix or remove {AspireConfigFile.FileName} and re-run `aspire init`.");
+                    InteractionService.DisplayError(string.Format(CultureInfo.CurrentCulture, InitCommandStrings.FailedToParseExistingConfig, AspireConfigFile.FileName, configPath, ex.Message));
+                    InteractionService.DisplayMessage(KnownEmojis.Warning, string.Format(CultureInfo.CurrentCulture, InitCommandStrings.FixOrRemoveConfigAndRerun, AspireConfigFile.FileName));
                     return (CliExitCodes.FailedToCreateNewProject, default);
                 }
             }
@@ -575,7 +575,7 @@ internal sealed class InitCommand : BaseCommand
 
         File.WriteAllText(configPath, JsonSerializer.Serialize(settings, JsonSourceGenerationContext.RelaxedEscaping.JsonObject));
 
-        InteractionService.DisplayMessage(KnownEmojis.CheckMarkButton, $"Created {AspireConfigFile.FileName}");
+        InteractionService.DisplayMessage(KnownEmojis.CheckMarkButton, string.Format(CultureInfo.CurrentCulture, InitCommandStrings.CreatedFile, AspireConfigFile.FileName));
         return (CliExitCodes.Success, effectivePorts);
     }
 
@@ -703,7 +703,7 @@ internal sealed class InitCommand : BaseCommand
 
         File.WriteAllText(path, JsonSerializer.Serialize(settings, JsonSourceGenerationContext.RelaxedEscaping.JsonObject));
 
-        InteractionService.DisplayMessage(KnownEmojis.CheckMarkButton, $"Created {fileName}");
+        InteractionService.DisplayMessage(KnownEmojis.CheckMarkButton, string.Format(CultureInfo.CurrentCulture, InitCommandStrings.CreatedFile, fileName));
     }
 
 }

--- a/src/Aspire.Cli/Resources/InitCommandStrings.Designer.cs
+++ b/src/Aspire.Cli/Resources/InitCommandStrings.Designer.cs
@@ -128,5 +128,65 @@ namespace Aspire.Cli.Resources {
                 return ResourceManager.GetString("LanguageOptionDescription", resourceCulture);
             }
         }
+
+        internal static string AppHostCreatedRunOne {
+            get {
+                return ResourceManager.GetString("AppHostCreatedRunOne", resourceCulture);
+            }
+        }
+
+        internal static string AppHostCreatedRunOneOf {
+            get {
+                return ResourceManager.GetString("AppHostCreatedRunOneOf", resourceCulture);
+            }
+        }
+
+        internal static string DeprecatedOptionWarning {
+            get {
+                return ResourceManager.GetString("DeprecatedOptionWarning", resourceCulture);
+            }
+        }
+
+        internal static string FileAlreadyExistsSkipping {
+            get {
+                return ResourceManager.GetString("FileAlreadyExistsSkipping", resourceCulture);
+            }
+        }
+
+        internal static string CreatedFile {
+            get {
+                return ResourceManager.GetString("CreatedFile", resourceCulture);
+            }
+        }
+
+        internal static string InstallingAspireProjectTemplates {
+            get {
+                return ResourceManager.GetString("InstallingAspireProjectTemplates", resourceCulture);
+            }
+        }
+
+        internal static string CreatingAppHostFromTemplate {
+            get {
+                return ResourceManager.GetString("CreatingAppHostFromTemplate", resourceCulture);
+            }
+        }
+
+        internal static string FailedToCreateAppHostFromTemplate {
+            get {
+                return ResourceManager.GetString("FailedToCreateAppHostFromTemplate", resourceCulture);
+            }
+        }
+
+        internal static string FailedToParseExistingConfig {
+            get {
+                return ResourceManager.GetString("FailedToParseExistingConfig", resourceCulture);
+            }
+        }
+
+        internal static string FixOrRemoveConfigAndRerun {
+            get {
+                return ResourceManager.GetString("FixOrRemoveConfigAndRerun", resourceCulture);
+            }
+        }
     }
 }

--- a/src/Aspire.Cli/Resources/InitCommandStrings.resx
+++ b/src/Aspire.Cli/Resources/InitCommandStrings.resx
@@ -102,4 +102,34 @@
   <data name="LanguageOptionDescription" xml:space="preserve">
     <value>The programming language for the AppHost (csharp, typescript)</value>
   </data>
+  <data name="AppHostCreatedRunOne" xml:space="preserve">
+    <value>Aspire AppHost created! To complete setup, run:</value>
+  </data>
+  <data name="AppHostCreatedRunOneOf" xml:space="preserve">
+    <value>Aspire AppHost created! To complete setup, run one of:</value>
+  </data>
+  <data name="DeprecatedOptionWarning" xml:space="preserve">
+    <value>`aspire init {0}` is deprecated and no longer affects generated AppHosts. It is accepted for compatibility and will be removed in a future version.</value>
+  </data>
+  <data name="FileAlreadyExistsSkipping" xml:space="preserve">
+    <value>{0} already exists — skipping.</value>
+  </data>
+  <data name="CreatedFile" xml:space="preserve">
+    <value>Created {0}</value>
+  </data>
+  <data name="InstallingAspireProjectTemplates" xml:space="preserve">
+    <value>Installing Aspire project templates...</value>
+  </data>
+  <data name="CreatingAppHostFromTemplate" xml:space="preserve">
+    <value>Creating AppHost from template...</value>
+  </data>
+  <data name="FailedToCreateAppHostFromTemplate" xml:space="preserve">
+    <value>Failed to create AppHost from template (exit code {0}).</value>
+  </data>
+  <data name="FailedToParseExistingConfig" xml:space="preserve">
+    <value>Failed to parse existing {0} at '{1}': {2}</value>
+  </data>
+  <data name="FixOrRemoveConfigAndRerun" xml:space="preserve">
+    <value>Fix or remove {0} and re-run `aspire init`.</value>
+  </data>
 </root>

--- a/src/Aspire.Cli/Resources/xlf/InitCommandStrings.cs.xlf
+++ b/src/Aspire.Cli/Resources/xlf/InitCommandStrings.cs.xlf
@@ -17,9 +17,29 @@
         <target state="translated">Přidává se projekt ServiceDefaults do řešení...</target>
         <note />
       </trans-unit>
+      <trans-unit id="AppHostCreatedRunOne">
+        <source>Aspire AppHost created! To complete setup, run:</source>
+        <target state="new">Aspire AppHost created! To complete setup, run:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AppHostCreatedRunOneOf">
+        <source>Aspire AppHost created! To complete setup, run one of:</source>
+        <target state="new">Aspire AppHost created! To complete setup, run one of:</target>
+        <note />
+      </trans-unit>
       <trans-unit id="AspireInitializationComplete">
         <source>Aspire initialization complete!</source>
         <target state="translated">Inicializace Aspire se dokončila!</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CreatedFile">
+        <source>Created {0}</source>
+        <target state="new">Created {0}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CreatingAppHostFromTemplate">
+        <source>Creating AppHost from template...</source>
+        <target state="new">Creating AppHost from template...</target>
         <note />
       </trans-unit>
       <trans-unit id="CreatingAppHostProject">
@@ -32,9 +52,39 @@
         <target state="translated">Vytváří se projekt ServiceDefaults...</target>
         <note />
       </trans-unit>
+      <trans-unit id="DeprecatedOptionWarning">
+        <source>`aspire init {0}` is deprecated and no longer affects generated AppHosts. It is accepted for compatibility and will be removed in a future version.</source>
+        <target state="new">`aspire init {0}` is deprecated and no longer affects generated AppHosts. It is accepted for compatibility and will be removed in a future version.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Description">
         <source>Initialize Aspire in an existing codebase</source>
         <target state="needs-review-translation">Inicializujte podporu Aspire v existujícím řešení nebo vytvořte AppHost s jedním souborem.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FailedToCreateAppHostFromTemplate">
+        <source>Failed to create AppHost from template (exit code {0}).</source>
+        <target state="new">Failed to create AppHost from template (exit code {0}).</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FailedToParseExistingConfig">
+        <source>Failed to parse existing {0} at '{1}': {2}</source>
+        <target state="new">Failed to parse existing {0} at '{1}': {2}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FileAlreadyExistsSkipping">
+        <source>{0} already exists — skipping.</source>
+        <target state="new">{0} already exists — skipping.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FixOrRemoveConfigAndRerun">
+        <source>Fix or remove {0} and re-run `aspire init`.</source>
+        <target state="new">Fix or remove {0} and re-run `aspire init`.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InstallingAspireProjectTemplates">
+        <source>Installing Aspire project templates...</source>
+        <target state="new">Installing Aspire project templates...</target>
         <note />
       </trans-unit>
       <trans-unit id="LanguageOptionDescription">

--- a/src/Aspire.Cli/Resources/xlf/InitCommandStrings.de.xlf
+++ b/src/Aspire.Cli/Resources/xlf/InitCommandStrings.de.xlf
@@ -17,9 +17,29 @@
         <target state="translated">ServiceDefaults-Projekt wird der Lösung hinzugefügt …</target>
         <note />
       </trans-unit>
+      <trans-unit id="AppHostCreatedRunOne">
+        <source>Aspire AppHost created! To complete setup, run:</source>
+        <target state="new">Aspire AppHost created! To complete setup, run:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AppHostCreatedRunOneOf">
+        <source>Aspire AppHost created! To complete setup, run one of:</source>
+        <target state="new">Aspire AppHost created! To complete setup, run one of:</target>
+        <note />
+      </trans-unit>
       <trans-unit id="AspireInitializationComplete">
         <source>Aspire initialization complete!</source>
         <target state="translated">Die Initialisierung von Aspire ist abgeschlossen!</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CreatedFile">
+        <source>Created {0}</source>
+        <target state="new">Created {0}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CreatingAppHostFromTemplate">
+        <source>Creating AppHost from template...</source>
+        <target state="new">Creating AppHost from template...</target>
         <note />
       </trans-unit>
       <trans-unit id="CreatingAppHostProject">
@@ -32,9 +52,39 @@
         <target state="translated">ServiceDefaults-Projekt wird erstellt …</target>
         <note />
       </trans-unit>
+      <trans-unit id="DeprecatedOptionWarning">
+        <source>`aspire init {0}` is deprecated and no longer affects generated AppHosts. It is accepted for compatibility and will be removed in a future version.</source>
+        <target state="new">`aspire init {0}` is deprecated and no longer affects generated AppHosts. It is accepted for compatibility and will be removed in a future version.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Description">
         <source>Initialize Aspire in an existing codebase</source>
         <target state="needs-review-translation">Initialisieren der Unterstützung von Aspire in einer vorhandenen Lösung, oder Erstellen einen AppHosts mit nur einer Datei.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FailedToCreateAppHostFromTemplate">
+        <source>Failed to create AppHost from template (exit code {0}).</source>
+        <target state="new">Failed to create AppHost from template (exit code {0}).</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FailedToParseExistingConfig">
+        <source>Failed to parse existing {0} at '{1}': {2}</source>
+        <target state="new">Failed to parse existing {0} at '{1}': {2}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FileAlreadyExistsSkipping">
+        <source>{0} already exists — skipping.</source>
+        <target state="new">{0} already exists — skipping.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FixOrRemoveConfigAndRerun">
+        <source>Fix or remove {0} and re-run `aspire init`.</source>
+        <target state="new">Fix or remove {0} and re-run `aspire init`.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InstallingAspireProjectTemplates">
+        <source>Installing Aspire project templates...</source>
+        <target state="new">Installing Aspire project templates...</target>
         <note />
       </trans-unit>
       <trans-unit id="LanguageOptionDescription">

--- a/src/Aspire.Cli/Resources/xlf/InitCommandStrings.es.xlf
+++ b/src/Aspire.Cli/Resources/xlf/InitCommandStrings.es.xlf
@@ -17,9 +17,29 @@
         <target state="translated">Agregando el proyecto ServiceDefaults a la solución...</target>
         <note />
       </trans-unit>
+      <trans-unit id="AppHostCreatedRunOne">
+        <source>Aspire AppHost created! To complete setup, run:</source>
+        <target state="new">Aspire AppHost created! To complete setup, run:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AppHostCreatedRunOneOf">
+        <source>Aspire AppHost created! To complete setup, run one of:</source>
+        <target state="new">Aspire AppHost created! To complete setup, run one of:</target>
+        <note />
+      </trans-unit>
       <trans-unit id="AspireInitializationComplete">
         <source>Aspire initialization complete!</source>
         <target state="translated">Se ha completado la inicialización de Aspire.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CreatedFile">
+        <source>Created {0}</source>
+        <target state="new">Created {0}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CreatingAppHostFromTemplate">
+        <source>Creating AppHost from template...</source>
+        <target state="new">Creating AppHost from template...</target>
         <note />
       </trans-unit>
       <trans-unit id="CreatingAppHostProject">
@@ -32,9 +52,39 @@
         <target state="translated">Creando proyecto ServiceDefaults...</target>
         <note />
       </trans-unit>
+      <trans-unit id="DeprecatedOptionWarning">
+        <source>`aspire init {0}` is deprecated and no longer affects generated AppHosts. It is accepted for compatibility and will be removed in a future version.</source>
+        <target state="new">`aspire init {0}` is deprecated and no longer affects generated AppHosts. It is accepted for compatibility and will be removed in a future version.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Description">
         <source>Initialize Aspire in an existing codebase</source>
         <target state="needs-review-translation">Inicializa la compatibilidad con Initialize en una solución existente o crea un AppHost de un solo archivo.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FailedToCreateAppHostFromTemplate">
+        <source>Failed to create AppHost from template (exit code {0}).</source>
+        <target state="new">Failed to create AppHost from template (exit code {0}).</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FailedToParseExistingConfig">
+        <source>Failed to parse existing {0} at '{1}': {2}</source>
+        <target state="new">Failed to parse existing {0} at '{1}': {2}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FileAlreadyExistsSkipping">
+        <source>{0} already exists — skipping.</source>
+        <target state="new">{0} already exists — skipping.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FixOrRemoveConfigAndRerun">
+        <source>Fix or remove {0} and re-run `aspire init`.</source>
+        <target state="new">Fix or remove {0} and re-run `aspire init`.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InstallingAspireProjectTemplates">
+        <source>Installing Aspire project templates...</source>
+        <target state="new">Installing Aspire project templates...</target>
         <note />
       </trans-unit>
       <trans-unit id="LanguageOptionDescription">

--- a/src/Aspire.Cli/Resources/xlf/InitCommandStrings.fr.xlf
+++ b/src/Aspire.Cli/Resources/xlf/InitCommandStrings.fr.xlf
@@ -17,9 +17,29 @@
         <target state="translated">Ajout du projet ServiceDefaults à la solution...</target>
         <note />
       </trans-unit>
+      <trans-unit id="AppHostCreatedRunOne">
+        <source>Aspire AppHost created! To complete setup, run:</source>
+        <target state="new">Aspire AppHost created! To complete setup, run:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AppHostCreatedRunOneOf">
+        <source>Aspire AppHost created! To complete setup, run one of:</source>
+        <target state="new">Aspire AppHost created! To complete setup, run one of:</target>
+        <note />
+      </trans-unit>
       <trans-unit id="AspireInitializationComplete">
         <source>Aspire initialization complete!</source>
         <target state="translated">Initialisation d’Aspire terminée</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CreatedFile">
+        <source>Created {0}</source>
+        <target state="new">Created {0}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CreatingAppHostFromTemplate">
+        <source>Creating AppHost from template...</source>
+        <target state="new">Creating AppHost from template...</target>
         <note />
       </trans-unit>
       <trans-unit id="CreatingAppHostProject">
@@ -32,9 +52,39 @@
         <target state="translated">Création du projet ServiceDefaults...</target>
         <note />
       </trans-unit>
+      <trans-unit id="DeprecatedOptionWarning">
+        <source>`aspire init {0}` is deprecated and no longer affects generated AppHosts. It is accepted for compatibility and will be removed in a future version.</source>
+        <target state="new">`aspire init {0}` is deprecated and no longer affects generated AppHosts. It is accepted for compatibility and will be removed in a future version.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Description">
         <source>Initialize Aspire in an existing codebase</source>
         <target state="needs-review-translation">Initialisez la prise en charge d’Aspire dans une solution existante ou créez un AppHost à fichier unique.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FailedToCreateAppHostFromTemplate">
+        <source>Failed to create AppHost from template (exit code {0}).</source>
+        <target state="new">Failed to create AppHost from template (exit code {0}).</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FailedToParseExistingConfig">
+        <source>Failed to parse existing {0} at '{1}': {2}</source>
+        <target state="new">Failed to parse existing {0} at '{1}': {2}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FileAlreadyExistsSkipping">
+        <source>{0} already exists — skipping.</source>
+        <target state="new">{0} already exists — skipping.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FixOrRemoveConfigAndRerun">
+        <source>Fix or remove {0} and re-run `aspire init`.</source>
+        <target state="new">Fix or remove {0} and re-run `aspire init`.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InstallingAspireProjectTemplates">
+        <source>Installing Aspire project templates...</source>
+        <target state="new">Installing Aspire project templates...</target>
         <note />
       </trans-unit>
       <trans-unit id="LanguageOptionDescription">

--- a/src/Aspire.Cli/Resources/xlf/InitCommandStrings.it.xlf
+++ b/src/Aspire.Cli/Resources/xlf/InitCommandStrings.it.xlf
@@ -17,9 +17,29 @@
         <target state="translated">Aggiunta del progetto ServiceDefaults alla soluzione in corso...</target>
         <note />
       </trans-unit>
+      <trans-unit id="AppHostCreatedRunOne">
+        <source>Aspire AppHost created! To complete setup, run:</source>
+        <target state="new">Aspire AppHost created! To complete setup, run:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AppHostCreatedRunOneOf">
+        <source>Aspire AppHost created! To complete setup, run one of:</source>
+        <target state="new">Aspire AppHost created! To complete setup, run one of:</target>
+        <note />
+      </trans-unit>
       <trans-unit id="AspireInitializationComplete">
         <source>Aspire initialization complete!</source>
         <target state="translated">Inizializzazione di Aspire completata.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CreatedFile">
+        <source>Created {0}</source>
+        <target state="new">Created {0}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CreatingAppHostFromTemplate">
+        <source>Creating AppHost from template...</source>
+        <target state="new">Creating AppHost from template...</target>
         <note />
       </trans-unit>
       <trans-unit id="CreatingAppHostProject">
@@ -32,9 +52,39 @@
         <target state="translated">Creazione del progetto ServiceDefaults in corso...</target>
         <note />
       </trans-unit>
+      <trans-unit id="DeprecatedOptionWarning">
+        <source>`aspire init {0}` is deprecated and no longer affects generated AppHosts. It is accepted for compatibility and will be removed in a future version.</source>
+        <target state="new">`aspire init {0}` is deprecated and no longer affects generated AppHosts. It is accepted for compatibility and will be removed in a future version.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Description">
         <source>Initialize Aspire in an existing codebase</source>
         <target state="needs-review-translation">Inizializzare il supporto Aspire in una soluzione esistente o creare un AppHost a file singolo.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FailedToCreateAppHostFromTemplate">
+        <source>Failed to create AppHost from template (exit code {0}).</source>
+        <target state="new">Failed to create AppHost from template (exit code {0}).</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FailedToParseExistingConfig">
+        <source>Failed to parse existing {0} at '{1}': {2}</source>
+        <target state="new">Failed to parse existing {0} at '{1}': {2}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FileAlreadyExistsSkipping">
+        <source>{0} already exists — skipping.</source>
+        <target state="new">{0} already exists — skipping.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FixOrRemoveConfigAndRerun">
+        <source>Fix or remove {0} and re-run `aspire init`.</source>
+        <target state="new">Fix or remove {0} and re-run `aspire init`.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InstallingAspireProjectTemplates">
+        <source>Installing Aspire project templates...</source>
+        <target state="new">Installing Aspire project templates...</target>
         <note />
       </trans-unit>
       <trans-unit id="LanguageOptionDescription">

--- a/src/Aspire.Cli/Resources/xlf/InitCommandStrings.ja.xlf
+++ b/src/Aspire.Cli/Resources/xlf/InitCommandStrings.ja.xlf
@@ -17,9 +17,29 @@
         <target state="translated">ServiceDefaults プロジェクトをソリューションに追加しています...</target>
         <note />
       </trans-unit>
+      <trans-unit id="AppHostCreatedRunOne">
+        <source>Aspire AppHost created! To complete setup, run:</source>
+        <target state="new">Aspire AppHost created! To complete setup, run:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AppHostCreatedRunOneOf">
+        <source>Aspire AppHost created! To complete setup, run one of:</source>
+        <target state="new">Aspire AppHost created! To complete setup, run one of:</target>
+        <note />
+      </trans-unit>
       <trans-unit id="AspireInitializationComplete">
         <source>Aspire initialization complete!</source>
         <target state="translated">Aspire の初期化が完了しました。</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CreatedFile">
+        <source>Created {0}</source>
+        <target state="new">Created {0}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CreatingAppHostFromTemplate">
+        <source>Creating AppHost from template...</source>
+        <target state="new">Creating AppHost from template...</target>
         <note />
       </trans-unit>
       <trans-unit id="CreatingAppHostProject">
@@ -32,9 +52,39 @@
         <target state="translated">ServiceDefaults プロジェクトを作成しています...</target>
         <note />
       </trans-unit>
+      <trans-unit id="DeprecatedOptionWarning">
+        <source>`aspire init {0}` is deprecated and no longer affects generated AppHosts. It is accepted for compatibility and will be removed in a future version.</source>
+        <target state="new">`aspire init {0}` is deprecated and no longer affects generated AppHosts. It is accepted for compatibility and will be removed in a future version.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Description">
         <source>Initialize Aspire in an existing codebase</source>
         <target state="needs-review-translation">既存のソリューションで Aspire サポートを初期化するか、単一ファイルの AppHost を作成します。</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FailedToCreateAppHostFromTemplate">
+        <source>Failed to create AppHost from template (exit code {0}).</source>
+        <target state="new">Failed to create AppHost from template (exit code {0}).</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FailedToParseExistingConfig">
+        <source>Failed to parse existing {0} at '{1}': {2}</source>
+        <target state="new">Failed to parse existing {0} at '{1}': {2}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FileAlreadyExistsSkipping">
+        <source>{0} already exists — skipping.</source>
+        <target state="new">{0} already exists — skipping.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FixOrRemoveConfigAndRerun">
+        <source>Fix or remove {0} and re-run `aspire init`.</source>
+        <target state="new">Fix or remove {0} and re-run `aspire init`.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InstallingAspireProjectTemplates">
+        <source>Installing Aspire project templates...</source>
+        <target state="new">Installing Aspire project templates...</target>
         <note />
       </trans-unit>
       <trans-unit id="LanguageOptionDescription">

--- a/src/Aspire.Cli/Resources/xlf/InitCommandStrings.ko.xlf
+++ b/src/Aspire.Cli/Resources/xlf/InitCommandStrings.ko.xlf
@@ -17,9 +17,29 @@
         <target state="translated">솔루션에 ServiceDefaults 프로젝트를 추가하는 중...</target>
         <note />
       </trans-unit>
+      <trans-unit id="AppHostCreatedRunOne">
+        <source>Aspire AppHost created! To complete setup, run:</source>
+        <target state="new">Aspire AppHost created! To complete setup, run:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AppHostCreatedRunOneOf">
+        <source>Aspire AppHost created! To complete setup, run one of:</source>
+        <target state="new">Aspire AppHost created! To complete setup, run one of:</target>
+        <note />
+      </trans-unit>
       <trans-unit id="AspireInitializationComplete">
         <source>Aspire initialization complete!</source>
         <target state="translated">Aspire 초기화 완료</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CreatedFile">
+        <source>Created {0}</source>
+        <target state="new">Created {0}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CreatingAppHostFromTemplate">
+        <source>Creating AppHost from template...</source>
+        <target state="new">Creating AppHost from template...</target>
         <note />
       </trans-unit>
       <trans-unit id="CreatingAppHostProject">
@@ -32,9 +52,39 @@
         <target state="translated">ServiceDefaults 프로젝트를 만드는 중...</target>
         <note />
       </trans-unit>
+      <trans-unit id="DeprecatedOptionWarning">
+        <source>`aspire init {0}` is deprecated and no longer affects generated AppHosts. It is accepted for compatibility and will be removed in a future version.</source>
+        <target state="new">`aspire init {0}` is deprecated and no longer affects generated AppHosts. It is accepted for compatibility and will be removed in a future version.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Description">
         <source>Initialize Aspire in an existing codebase</source>
         <target state="needs-review-translation">기존 솔루션에서 Aspire 지원을 초기화하거나 단일 파일 AppHost를 만듭니다.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FailedToCreateAppHostFromTemplate">
+        <source>Failed to create AppHost from template (exit code {0}).</source>
+        <target state="new">Failed to create AppHost from template (exit code {0}).</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FailedToParseExistingConfig">
+        <source>Failed to parse existing {0} at '{1}': {2}</source>
+        <target state="new">Failed to parse existing {0} at '{1}': {2}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FileAlreadyExistsSkipping">
+        <source>{0} already exists — skipping.</source>
+        <target state="new">{0} already exists — skipping.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FixOrRemoveConfigAndRerun">
+        <source>Fix or remove {0} and re-run `aspire init`.</source>
+        <target state="new">Fix or remove {0} and re-run `aspire init`.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InstallingAspireProjectTemplates">
+        <source>Installing Aspire project templates...</source>
+        <target state="new">Installing Aspire project templates...</target>
         <note />
       </trans-unit>
       <trans-unit id="LanguageOptionDescription">

--- a/src/Aspire.Cli/Resources/xlf/InitCommandStrings.pl.xlf
+++ b/src/Aspire.Cli/Resources/xlf/InitCommandStrings.pl.xlf
@@ -17,9 +17,29 @@
         <target state="translated">Trwa dodawanie projektu ServiceDefaults do rozwiązania...</target>
         <note />
       </trans-unit>
+      <trans-unit id="AppHostCreatedRunOne">
+        <source>Aspire AppHost created! To complete setup, run:</source>
+        <target state="new">Aspire AppHost created! To complete setup, run:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AppHostCreatedRunOneOf">
+        <source>Aspire AppHost created! To complete setup, run one of:</source>
+        <target state="new">Aspire AppHost created! To complete setup, run one of:</target>
+        <note />
+      </trans-unit>
       <trans-unit id="AspireInitializationComplete">
         <source>Aspire initialization complete!</source>
         <target state="translated">Inicjalizacja Aspire została zakończona.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CreatedFile">
+        <source>Created {0}</source>
+        <target state="new">Created {0}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CreatingAppHostFromTemplate">
+        <source>Creating AppHost from template...</source>
+        <target state="new">Creating AppHost from template...</target>
         <note />
       </trans-unit>
       <trans-unit id="CreatingAppHostProject">
@@ -32,9 +52,39 @@
         <target state="translated">Trwa tworzenie projektu ServiceDefaults...</target>
         <note />
       </trans-unit>
+      <trans-unit id="DeprecatedOptionWarning">
+        <source>`aspire init {0}` is deprecated and no longer affects generated AppHosts. It is accepted for compatibility and will be removed in a future version.</source>
+        <target state="new">`aspire init {0}` is deprecated and no longer affects generated AppHosts. It is accepted for compatibility and will be removed in a future version.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Description">
         <source>Initialize Aspire in an existing codebase</source>
         <target state="needs-review-translation">Zainicjuj obsługę Aspire w istniejącym rozwiązaniu lub utwórz AppHost składający się z jednego pliku.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FailedToCreateAppHostFromTemplate">
+        <source>Failed to create AppHost from template (exit code {0}).</source>
+        <target state="new">Failed to create AppHost from template (exit code {0}).</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FailedToParseExistingConfig">
+        <source>Failed to parse existing {0} at '{1}': {2}</source>
+        <target state="new">Failed to parse existing {0} at '{1}': {2}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FileAlreadyExistsSkipping">
+        <source>{0} already exists — skipping.</source>
+        <target state="new">{0} already exists — skipping.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FixOrRemoveConfigAndRerun">
+        <source>Fix or remove {0} and re-run `aspire init`.</source>
+        <target state="new">Fix or remove {0} and re-run `aspire init`.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InstallingAspireProjectTemplates">
+        <source>Installing Aspire project templates...</source>
+        <target state="new">Installing Aspire project templates...</target>
         <note />
       </trans-unit>
       <trans-unit id="LanguageOptionDescription">

--- a/src/Aspire.Cli/Resources/xlf/InitCommandStrings.pt-BR.xlf
+++ b/src/Aspire.Cli/Resources/xlf/InitCommandStrings.pt-BR.xlf
@@ -17,9 +17,29 @@
         <target state="translated">Adicionando o projeto ServiceDefaults à solução...</target>
         <note />
       </trans-unit>
+      <trans-unit id="AppHostCreatedRunOne">
+        <source>Aspire AppHost created! To complete setup, run:</source>
+        <target state="new">Aspire AppHost created! To complete setup, run:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AppHostCreatedRunOneOf">
+        <source>Aspire AppHost created! To complete setup, run one of:</source>
+        <target state="new">Aspire AppHost created! To complete setup, run one of:</target>
+        <note />
+      </trans-unit>
       <trans-unit id="AspireInitializationComplete">
         <source>Aspire initialization complete!</source>
         <target state="translated">Inicialização do Aspire concluída!</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CreatedFile">
+        <source>Created {0}</source>
+        <target state="new">Created {0}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CreatingAppHostFromTemplate">
+        <source>Creating AppHost from template...</source>
+        <target state="new">Creating AppHost from template...</target>
         <note />
       </trans-unit>
       <trans-unit id="CreatingAppHostProject">
@@ -32,9 +52,39 @@
         <target state="translated">Criando o projeto ServiceDefaults...</target>
         <note />
       </trans-unit>
+      <trans-unit id="DeprecatedOptionWarning">
+        <source>`aspire init {0}` is deprecated and no longer affects generated AppHosts. It is accepted for compatibility and will be removed in a future version.</source>
+        <target state="new">`aspire init {0}` is deprecated and no longer affects generated AppHosts. It is accepted for compatibility and will be removed in a future version.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Description">
         <source>Initialize Aspire in an existing codebase</source>
         <target state="needs-review-translation">Ative o suporte ao Aspire em uma solução existente ou crie um AppHost de arquivo único.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FailedToCreateAppHostFromTemplate">
+        <source>Failed to create AppHost from template (exit code {0}).</source>
+        <target state="new">Failed to create AppHost from template (exit code {0}).</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FailedToParseExistingConfig">
+        <source>Failed to parse existing {0} at '{1}': {2}</source>
+        <target state="new">Failed to parse existing {0} at '{1}': {2}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FileAlreadyExistsSkipping">
+        <source>{0} already exists — skipping.</source>
+        <target state="new">{0} already exists — skipping.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FixOrRemoveConfigAndRerun">
+        <source>Fix or remove {0} and re-run `aspire init`.</source>
+        <target state="new">Fix or remove {0} and re-run `aspire init`.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InstallingAspireProjectTemplates">
+        <source>Installing Aspire project templates...</source>
+        <target state="new">Installing Aspire project templates...</target>
         <note />
       </trans-unit>
       <trans-unit id="LanguageOptionDescription">

--- a/src/Aspire.Cli/Resources/xlf/InitCommandStrings.ru.xlf
+++ b/src/Aspire.Cli/Resources/xlf/InitCommandStrings.ru.xlf
@@ -17,9 +17,29 @@
         <target state="translated">Добавление проекта ServiceDefaults в решение...</target>
         <note />
       </trans-unit>
+      <trans-unit id="AppHostCreatedRunOne">
+        <source>Aspire AppHost created! To complete setup, run:</source>
+        <target state="new">Aspire AppHost created! To complete setup, run:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AppHostCreatedRunOneOf">
+        <source>Aspire AppHost created! To complete setup, run one of:</source>
+        <target state="new">Aspire AppHost created! To complete setup, run one of:</target>
+        <note />
+      </trans-unit>
       <trans-unit id="AspireInitializationComplete">
         <source>Aspire initialization complete!</source>
         <target state="translated">Инициализация Aspire завершена!</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CreatedFile">
+        <source>Created {0}</source>
+        <target state="new">Created {0}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CreatingAppHostFromTemplate">
+        <source>Creating AppHost from template...</source>
+        <target state="new">Creating AppHost from template...</target>
         <note />
       </trans-unit>
       <trans-unit id="CreatingAppHostProject">
@@ -32,9 +52,39 @@
         <target state="translated">Создание проекта ServiceDefaults...</target>
         <note />
       </trans-unit>
+      <trans-unit id="DeprecatedOptionWarning">
+        <source>`aspire init {0}` is deprecated and no longer affects generated AppHosts. It is accepted for compatibility and will be removed in a future version.</source>
+        <target state="new">`aspire init {0}` is deprecated and no longer affects generated AppHosts. It is accepted for compatibility and will be removed in a future version.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Description">
         <source>Initialize Aspire in an existing codebase</source>
         <target state="needs-review-translation">Инициализируйте поддержку Aspire в существующем решении или создайте однофайловый AppHost.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FailedToCreateAppHostFromTemplate">
+        <source>Failed to create AppHost from template (exit code {0}).</source>
+        <target state="new">Failed to create AppHost from template (exit code {0}).</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FailedToParseExistingConfig">
+        <source>Failed to parse existing {0} at '{1}': {2}</source>
+        <target state="new">Failed to parse existing {0} at '{1}': {2}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FileAlreadyExistsSkipping">
+        <source>{0} already exists — skipping.</source>
+        <target state="new">{0} already exists — skipping.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FixOrRemoveConfigAndRerun">
+        <source>Fix or remove {0} and re-run `aspire init`.</source>
+        <target state="new">Fix or remove {0} and re-run `aspire init`.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InstallingAspireProjectTemplates">
+        <source>Installing Aspire project templates...</source>
+        <target state="new">Installing Aspire project templates...</target>
         <note />
       </trans-unit>
       <trans-unit id="LanguageOptionDescription">

--- a/src/Aspire.Cli/Resources/xlf/InitCommandStrings.tr.xlf
+++ b/src/Aspire.Cli/Resources/xlf/InitCommandStrings.tr.xlf
@@ -17,9 +17,29 @@
         <target state="translated">ServiceDefaults projesi çözüme ekleniyor...</target>
         <note />
       </trans-unit>
+      <trans-unit id="AppHostCreatedRunOne">
+        <source>Aspire AppHost created! To complete setup, run:</source>
+        <target state="new">Aspire AppHost created! To complete setup, run:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AppHostCreatedRunOneOf">
+        <source>Aspire AppHost created! To complete setup, run one of:</source>
+        <target state="new">Aspire AppHost created! To complete setup, run one of:</target>
+        <note />
+      </trans-unit>
       <trans-unit id="AspireInitializationComplete">
         <source>Aspire initialization complete!</source>
         <target state="translated">Aspire başlatma tamamlandı!</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CreatedFile">
+        <source>Created {0}</source>
+        <target state="new">Created {0}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CreatingAppHostFromTemplate">
+        <source>Creating AppHost from template...</source>
+        <target state="new">Creating AppHost from template...</target>
         <note />
       </trans-unit>
       <trans-unit id="CreatingAppHostProject">
@@ -32,9 +52,39 @@
         <target state="translated">ServiceDefaults projesi oluşturuluyor...</target>
         <note />
       </trans-unit>
+      <trans-unit id="DeprecatedOptionWarning">
+        <source>`aspire init {0}` is deprecated and no longer affects generated AppHosts. It is accepted for compatibility and will be removed in a future version.</source>
+        <target state="new">`aspire init {0}` is deprecated and no longer affects generated AppHosts. It is accepted for compatibility and will be removed in a future version.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Description">
         <source>Initialize Aspire in an existing codebase</source>
         <target state="needs-review-translation">Mevcut bir çözümde Aspire desteğini başlatın veya tek dosyalı bir AppHost oluşturun.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FailedToCreateAppHostFromTemplate">
+        <source>Failed to create AppHost from template (exit code {0}).</source>
+        <target state="new">Failed to create AppHost from template (exit code {0}).</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FailedToParseExistingConfig">
+        <source>Failed to parse existing {0} at '{1}': {2}</source>
+        <target state="new">Failed to parse existing {0} at '{1}': {2}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FileAlreadyExistsSkipping">
+        <source>{0} already exists — skipping.</source>
+        <target state="new">{0} already exists — skipping.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FixOrRemoveConfigAndRerun">
+        <source>Fix or remove {0} and re-run `aspire init`.</source>
+        <target state="new">Fix or remove {0} and re-run `aspire init`.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InstallingAspireProjectTemplates">
+        <source>Installing Aspire project templates...</source>
+        <target state="new">Installing Aspire project templates...</target>
         <note />
       </trans-unit>
       <trans-unit id="LanguageOptionDescription">

--- a/src/Aspire.Cli/Resources/xlf/InitCommandStrings.zh-Hans.xlf
+++ b/src/Aspire.Cli/Resources/xlf/InitCommandStrings.zh-Hans.xlf
@@ -17,9 +17,29 @@
         <target state="translated">正在将 ServiceDefaults 项目添加到解决方案中...</target>
         <note />
       </trans-unit>
+      <trans-unit id="AppHostCreatedRunOne">
+        <source>Aspire AppHost created! To complete setup, run:</source>
+        <target state="new">Aspire AppHost created! To complete setup, run:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AppHostCreatedRunOneOf">
+        <source>Aspire AppHost created! To complete setup, run one of:</source>
+        <target state="new">Aspire AppHost created! To complete setup, run one of:</target>
+        <note />
+      </trans-unit>
       <trans-unit id="AspireInitializationComplete">
         <source>Aspire initialization complete!</source>
         <target state="translated">Aspire 初始化完成!</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CreatedFile">
+        <source>Created {0}</source>
+        <target state="new">Created {0}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CreatingAppHostFromTemplate">
+        <source>Creating AppHost from template...</source>
+        <target state="new">Creating AppHost from template...</target>
         <note />
       </trans-unit>
       <trans-unit id="CreatingAppHostProject">
@@ -32,9 +52,39 @@
         <target state="translated">正在创建 ServiceDefaults 项目...</target>
         <note />
       </trans-unit>
+      <trans-unit id="DeprecatedOptionWarning">
+        <source>`aspire init {0}` is deprecated and no longer affects generated AppHosts. It is accepted for compatibility and will be removed in a future version.</source>
+        <target state="new">`aspire init {0}` is deprecated and no longer affects generated AppHosts. It is accepted for compatibility and will be removed in a future version.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Description">
         <source>Initialize Aspire in an existing codebase</source>
         <target state="needs-review-translation">在现有解决方案中初始化 Aspire 支持，或创建单文件 AppHost。</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FailedToCreateAppHostFromTemplate">
+        <source>Failed to create AppHost from template (exit code {0}).</source>
+        <target state="new">Failed to create AppHost from template (exit code {0}).</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FailedToParseExistingConfig">
+        <source>Failed to parse existing {0} at '{1}': {2}</source>
+        <target state="new">Failed to parse existing {0} at '{1}': {2}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FileAlreadyExistsSkipping">
+        <source>{0} already exists — skipping.</source>
+        <target state="new">{0} already exists — skipping.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FixOrRemoveConfigAndRerun">
+        <source>Fix or remove {0} and re-run `aspire init`.</source>
+        <target state="new">Fix or remove {0} and re-run `aspire init`.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InstallingAspireProjectTemplates">
+        <source>Installing Aspire project templates...</source>
+        <target state="new">Installing Aspire project templates...</target>
         <note />
       </trans-unit>
       <trans-unit id="LanguageOptionDescription">

--- a/src/Aspire.Cli/Resources/xlf/InitCommandStrings.zh-Hant.xlf
+++ b/src/Aspire.Cli/Resources/xlf/InitCommandStrings.zh-Hant.xlf
@@ -17,9 +17,29 @@
         <target state="translated">正在將 ServiceDefaults 專案新增至解決方案...</target>
         <note />
       </trans-unit>
+      <trans-unit id="AppHostCreatedRunOne">
+        <source>Aspire AppHost created! To complete setup, run:</source>
+        <target state="new">Aspire AppHost created! To complete setup, run:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AppHostCreatedRunOneOf">
+        <source>Aspire AppHost created! To complete setup, run one of:</source>
+        <target state="new">Aspire AppHost created! To complete setup, run one of:</target>
+        <note />
+      </trans-unit>
       <trans-unit id="AspireInitializationComplete">
         <source>Aspire initialization complete!</source>
         <target state="translated">Aspire 初始化完成!</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CreatedFile">
+        <source>Created {0}</source>
+        <target state="new">Created {0}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CreatingAppHostFromTemplate">
+        <source>Creating AppHost from template...</source>
+        <target state="new">Creating AppHost from template...</target>
         <note />
       </trans-unit>
       <trans-unit id="CreatingAppHostProject">
@@ -32,9 +52,39 @@
         <target state="translated">正在建立 ServiceDefaults 專案...</target>
         <note />
       </trans-unit>
+      <trans-unit id="DeprecatedOptionWarning">
+        <source>`aspire init {0}` is deprecated and no longer affects generated AppHosts. It is accepted for compatibility and will be removed in a future version.</source>
+        <target state="new">`aspire init {0}` is deprecated and no longer affects generated AppHosts. It is accepted for compatibility and will be removed in a future version.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Description">
         <source>Initialize Aspire in an existing codebase</source>
         <target state="needs-review-translation">將現有解決方案中的 Aspire 支援初始化，或建立單一檔案 AppHost。</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FailedToCreateAppHostFromTemplate">
+        <source>Failed to create AppHost from template (exit code {0}).</source>
+        <target state="new">Failed to create AppHost from template (exit code {0}).</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FailedToParseExistingConfig">
+        <source>Failed to parse existing {0} at '{1}': {2}</source>
+        <target state="new">Failed to parse existing {0} at '{1}': {2}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FileAlreadyExistsSkipping">
+        <source>{0} already exists — skipping.</source>
+        <target state="new">{0} already exists — skipping.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FixOrRemoveConfigAndRerun">
+        <source>Fix or remove {0} and re-run `aspire init`.</source>
+        <target state="new">Fix or remove {0} and re-run `aspire init`.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InstallingAspireProjectTemplates">
+        <source>Installing Aspire project templates...</source>
+        <target state="new">Installing Aspire project templates...</target>
         <note />
       </trans-unit>
       <trans-unit id="LanguageOptionDescription">


### PR DESCRIPTION
## Description

Changed aspire init emoji when file already exits. Before:

<img width="659" height="66" alt="image" src="https://github.com/user-attachments/assets/6f716722-8812-4c8f-bef0-64cb23c1b6e7" />

After:

<img width="669" height="67" alt="image" src="https://github.com/user-attachments/assets/ab06fe8e-b21f-4783-a9b2-76daddd51947" />

Also,

Move all hardcoded user-facing message strings from `InitCommand.cs` into `InitCommandStrings.resx` so they can be localized. The extracted strings include:

- AppHost creation success messages (`"Aspire AppHost created! To complete setup, run:"`)
- Deprecated option warnings
- File-already-exists / skipping messages
- Template installation status messages
- AppHost template creation failure messages
- Config parse error and recovery messages
- Generic "Created {0}" file messages

Updated `InitCommandStrings.Designer.cs` and all `xlf` translation files accordingly.

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [x] No
- Did you add public API?
  - [ ] Yes
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
  - [x] No