### PR TITLE
Fix stack overflow when opening child dialog from notification center

### DIFF
--- a/src/Aspire.Dashboard/Components/Dialogs/NotificationEntryComponent.razor.cs
+++ b/src/Aspire.Dashboard/Components/Dialogs/NotificationEntryComponent.razor.cs
@@ -16,9 +16,6 @@ public partial class NotificationEntryComponent : ComponentBase
     [Parameter]
     public EventCallback OnDismiss { get; set; }
 
-    [CascadingParameter]
-    public FluentDialog Dialog { get; set; } = default!;
-
     private string IntentClass => Entry.Intent switch
     {
         MessageIntent.Success => "intent-success",

--- a/src/Aspire.Dashboard/Components/Dialogs/NotificationEntryComponent.razor.cs
+++ b/src/Aspire.Dashboard/Components/Dialogs/NotificationEntryComponent.razor.cs
@@ -16,6 +16,9 @@ public partial class NotificationEntryComponent : ComponentBase
     [Parameter]
     public EventCallback OnDismiss { get; set; }
 
+    [CascadingParameter]
+    public FluentDialog Dialog { get; set; } = default!;
+
     private string IntentClass => Entry.Intent switch
     {
         MessageIntent.Success => "intent-success",

--- a/src/Aspire.Dashboard/Components/Dialogs/NotificationEntryComponent.razor.cs
+++ b/src/Aspire.Dashboard/Components/Dialogs/NotificationEntryComponent.razor.cs
@@ -49,7 +49,15 @@ public partial class NotificationEntryComponent : ComponentBase
     {
         if (Entry.PrimaryAction is { } primaryAction)
         {
-            await primaryAction.OnClick();
+            try
+            {
+                Dialog.Hide();
+                await primaryAction.OnClick();
+            }
+            finally
+            {
+                Dialog.Show();
+            }
         }
     }
 }

--- a/src/Aspire.Dashboard/Components/Dialogs/TextVisualizerDialog.razor.cs
+++ b/src/Aspire.Dashboard/Components/Dialogs/TextVisualizerDialog.razor.cs
@@ -114,7 +114,7 @@ public partial class TextVisualizerDialog : ComponentBase
         return _markdownProcessor ??= new MarkdownProcessor(ControlsStringsLoc, safeUrlSchemes: MarkdownHelpers.SafeUrlSchemes, extensions: []);
     }
 
-    public static async Task OpenDialogAsync(OpenTextVisualizerDialogOptions options)
+    public static async Task<IDialogReference> OpenDialogAsync(OpenTextVisualizerDialogOptions options)
     {
         var width = options.DialogService.IsDesktop ? "75vw" : "100vw";
         var parameters = new DialogParameters
@@ -126,7 +126,7 @@ public partial class TextVisualizerDialog : ComponentBase
             PreventScroll = true,
         };
 
-        await options.DialogService.ShowDialogAsync<TextVisualizerDialog>(
+        return await options.DialogService.ShowDialogAsync<TextVisualizerDialog>(
             new TextVisualizerDialogViewModel(options.Value, options.ValueDescription, options.ContainsSecret, options.DownloadFileName, options.FixedFormat), parameters);
     }
 

--- a/src/Aspire.Dashboard/Components/Layout/MainLayout.razor.cs
+++ b/src/Aspire.Dashboard/Components/Layout/MainLayout.razor.cs
@@ -324,7 +324,7 @@ public partial class MainLayout : IGlobalKeydownListener, IAsyncDisposable
             Title = Loc[nameof(Resources.Layout.MainLayoutNotificationCenterTitle)],
             PrimaryAction = Loc[nameof(Resources.Layout.MainLayoutSettingsDialogClose)].Value,
             SecondaryAction = null,
-            TrapFocus = false, // This dialog launches child dialogs, and multiple dialogs can't trap focus correctly
+            TrapFocus = true,
             Modal = true,
             Alignment = HorizontalAlignment.Right,
             Width = "350px",

--- a/src/Aspire.Dashboard/Components/Layout/MainLayout.razor.cs
+++ b/src/Aspire.Dashboard/Components/Layout/MainLayout.razor.cs
@@ -324,7 +324,7 @@ public partial class MainLayout : IGlobalKeydownListener, IAsyncDisposable
             Title = Loc[nameof(Resources.Layout.MainLayoutNotificationCenterTitle)],
             PrimaryAction = Loc[nameof(Resources.Layout.MainLayoutSettingsDialogClose)].Value,
             SecondaryAction = null,
-            TrapFocus = true,
+            TrapFocus = false, // This dialog launches child dialogs, and multiple dialogs can't trap focus correctly
             Modal = true,
             Alignment = HorizontalAlignment.Right,
             Width = "350px",

--- a/src/Aspire.Dashboard/Model/DashboardCommandExecutor.cs
+++ b/src/Aspire.Dashboard/Model/DashboardCommandExecutor.cs
@@ -292,12 +292,15 @@ public sealed class DashboardCommandExecutor(
             _ => null
         };
 
-        await TextVisualizerDialog.OpenDialogAsync(new OpenTextVisualizerDialogOptions
+        var reference = await TextVisualizerDialog.OpenDialogAsync(new OpenTextVisualizerDialogOptions
         {
             DialogService = dialogService,
             ValueDescription = command.GetDisplayName(),
             Value = response.Result.Value,
             FixedFormat = fixedFormat
-        }).ConfigureAwait(false);
+        }).ConfigureAwait(true);
+
+        // Await the result to wait here until the dialog is closed.
+        await reference.Result.ConfigureAwait(true);
     }
 }


### PR DESCRIPTION
## Summary

Fixes #16593

When clicking "View Response" from the Notifications Center dialog, a child dialog (TextVisualizer) opens. Because both dialogs have focus trapping enabled, the Fluent UI focus-trap handlers recurse infinitely between them, causing `RangeError: Maximum call stack size exceeded`.

## Fix

Hide the parent notification center dialog while the child dialog is open, then restore it after the child closes. This prevents multiple dialogs from competing for focus simultaneously.

## Changes

- **NotificationEntryComponent.razor.cs**: Hide the parent dialog before executing the primary action (which opens a child dialog), and restore it in a `finally` block after the child dialog closes.
- **TextVisualizerDialog.razor.cs**: Return `IDialogReference` from `OpenDialogAsync` so callers can await the dialog's completion.
- **DashboardCommandExecutor.cs**: Await the child dialog's result so `OnClick` doesn't return until the child dialog is closed. Use `ConfigureAwait(true)` to stay on the Blazor sync context.

## Testing

Manually verified that:
1. Opening the notification center and clicking "View Response" no longer throws a stack overflow
2. The notification center dialog reappears after closing the child dialog
3. If the child dialog throws, the parent dialog is still restored (via `finally`)