### PR TITLE
Enrich AppHost codegen TypeLoadException diagnostics

### DIFF
--- a/src/Aspire.Cli/Backchannel/BackchannelJsonSerializerContext.cs
+++ b/src/Aspire.Cli/Backchannel/BackchannelJsonSerializerContext.cs
@@ -8,6 +8,7 @@ using System.Text.Json.Serialization;
 using System.Text.Json.Serialization.Metadata;
 using Aspire.Cli.Commands;
 using Aspire.Cli.Commands.Sdk;
+using Aspire.Cli.Projects;
 using Aspire.TypeSystem;
 using Spectre.Console;
 using StreamJsonRpc;
@@ -62,6 +63,9 @@ namespace Aspire.Cli.Backchannel;
 [JsonSerializable(typeof(JsonNode))]
 [JsonSerializable(typeof(CapabilitiesInfo))]
 [JsonSerializable(typeof(CommonErrorData))]
+[JsonSerializable(typeof(AppHostCodeGenerationDiagnostic))]
+[JsonSerializable(typeof(AppHostLoadedAssemblyInfo))]
+[JsonSerializable(typeof(List<AppHostLoadedAssemblyInfo>))]
 // V2 API request/response types
 [JsonSerializable(typeof(GetCapabilitiesRequest))]
 [JsonSerializable(typeof(BackchannelTraceContext))]

--- a/src/Aspire.Cli/Commands/Sdk/SdkDumpCommand.cs
+++ b/src/Aspire.Cli/Commands/Sdk/SdkDumpCommand.cs
@@ -366,7 +366,7 @@ internal sealed class SdkDumpCommand : BaseCommand
 
             return new IntegrationDumpResult(integration.Name, Success: true, HasErrors: capabilities.Diagnostics.Exists(d => d.Severity == "Error"));
         }
-        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException or InvalidDataException or InvalidOperationException or RemoteInvocationException)
+        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException or InvalidDataException or InvalidOperationException or RemoteInvocationException or AppHostCodeGenerationException)
         {
             _logger.LogWarning(ex, "Failed to dump capabilities for integration {IntegrationName}", integration.Name);
             return new IntegrationDumpResult(integration.Name, Success: false, HasErrors: false, ex.Message);

--- a/src/Aspire.Cli/Projects/AppHostCodeGenerationDiagnostic.cs
+++ b/src/Aspire.Cli/Projects/AppHostCodeGenerationDiagnostic.cs
@@ -1,0 +1,105 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Text.Json.Serialization;
+
+namespace Aspire.Cli.Projects;
+
+/// <summary>
+/// JSON-RPC error codes returned by the AppHost server for code-generation failures.
+/// </summary>
+/// <remarks>
+/// Values mirror those defined server-side in <c>Aspire.Hosting.RemoteHost</c>.
+/// </remarks>
+internal static class AppHostCodeGenerationErrorCodes
+{
+    /// <summary>
+    /// The AppHost server failed to load reflection-based code generation metadata.
+    /// Typically caused by an assembly-version mismatch between the bundled
+    /// <c>Aspire.Hosting</c> runtime and the user-restored integration assemblies.
+    /// </summary>
+    public const int IncompatibleAspireSdk = -32050;
+}
+
+/// <summary>
+/// CLI-side representation of the structured diagnostic payload the AppHost server attaches to
+/// code-generation failures (mirrors <c>CodeGenerationDiagnostic</c> in
+/// <c>Aspire.Hosting.RemoteHost</c>). The JSON shape is contractual; updating one side without
+/// the other will break the round-trip.
+/// </summary>
+internal sealed class AppHostCodeGenerationDiagnostic
+{
+    /// <summary>
+    /// Gets the CLR type name of the original exception thrown by the AppHost server
+    /// (e.g. <c>System.TypeLoadException</c>).
+    /// </summary>
+    [JsonPropertyName("originalExceptionType")]
+    public string OriginalExceptionType { get; init; } = "";
+
+    /// <summary>
+    /// Gets the name of the type that failed to load, if known.
+    /// </summary>
+    [JsonPropertyName("typeName")]
+    public string? TypeName { get; init; }
+
+    /// <summary>
+    /// Gets the name of the missing member, if the failure was a missing-method or
+    /// missing-field error.
+    /// </summary>
+    [JsonPropertyName("memberName")]
+    public string? MemberName { get; init; }
+
+    /// <summary>
+    /// Gets the informational version of the bundled <c>Aspire.Hosting</c> assembly on the
+    /// server side, if it could be discovered.
+    /// </summary>
+    [JsonPropertyName("runtimeAspireHostingVersion")]
+    public string? RuntimeAspireHostingVersion { get; init; }
+
+    /// <summary>
+    /// Gets the on-disk location of the bundled <c>Aspire.Hosting</c> assembly, if it could be
+    /// discovered.
+    /// </summary>
+    [JsonPropertyName("runtimeAspireHostingPath")]
+    public string? RuntimeAspireHostingPath { get; init; }
+
+    /// <summary>
+    /// Gets the loaded integration assemblies probed by the AppHost server at the time of the
+    /// failure.
+    /// </summary>
+    [JsonPropertyName("loadedAssemblies")]
+    public List<AppHostLoadedAssemblyInfo> LoadedAssemblies { get; init; } = [];
+
+    /// <summary>
+    /// Gets a short, language-agnostic remediation hint suitable for surfacing to AppHost
+    /// authors.
+    /// </summary>
+    [JsonPropertyName("remediationHint")]
+    public string? RemediationHint { get; init; }
+}
+
+/// <summary>
+/// Identity information for a single loaded assembly captured at the time of a code-generation
+/// failure.
+/// </summary>
+internal sealed class AppHostLoadedAssemblyInfo
+{
+    /// <summary>
+    /// Gets the simple name of the assembly (e.g. <c>Aspire.Hosting.JavaScript</c>).
+    /// </summary>
+    [JsonPropertyName("name")]
+    public string Name { get; init; } = "";
+
+    /// <summary>
+    /// Gets the informational version of the assembly, when present, otherwise the assembly
+    /// version.
+    /// </summary>
+    [JsonPropertyName("informationalVersion")]
+    public string? InformationalVersion { get; init; }
+
+    /// <summary>
+    /// Gets the on-disk location of the assembly when available.
+    /// </summary>
+    [JsonPropertyName("location")]
+    public string? Location { get; init; }
+}

--- a/src/Aspire.Cli/Projects/AppHostCodeGenerationDiagnostic.cs
+++ b/src/Aspire.Cli/Projects/AppHostCodeGenerationDiagnostic.cs
@@ -1,8 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.Text.Json.Serialization;
-
 namespace Aspire.Cli.Projects;
 
 /// <summary>
@@ -33,48 +31,41 @@ internal sealed class AppHostCodeGenerationDiagnostic
     /// Gets the CLR type name of the original exception thrown by the AppHost server
     /// (e.g. <c>System.TypeLoadException</c>).
     /// </summary>
-    [JsonPropertyName("originalExceptionType")]
     public string OriginalExceptionType { get; init; } = "";
 
     /// <summary>
     /// Gets the name of the type that failed to load, if known.
     /// </summary>
-    [JsonPropertyName("typeName")]
     public string? TypeName { get; init; }
 
     /// <summary>
     /// Gets the name of the missing member, if the failure was a missing-method or
     /// missing-field error.
     /// </summary>
-    [JsonPropertyName("memberName")]
     public string? MemberName { get; init; }
 
     /// <summary>
     /// Gets the informational version of the bundled <c>Aspire.Hosting</c> assembly on the
     /// server side, if it could be discovered.
     /// </summary>
-    [JsonPropertyName("runtimeAspireHostingVersion")]
     public string? RuntimeAspireHostingVersion { get; init; }
 
     /// <summary>
     /// Gets the on-disk location of the bundled <c>Aspire.Hosting</c> assembly, if it could be
     /// discovered.
     /// </summary>
-    [JsonPropertyName("runtimeAspireHostingPath")]
     public string? RuntimeAspireHostingPath { get; init; }
 
     /// <summary>
     /// Gets the loaded integration assemblies probed by the AppHost server at the time of the
     /// failure.
     /// </summary>
-    [JsonPropertyName("loadedAssemblies")]
     public List<AppHostLoadedAssemblyInfo> LoadedAssemblies { get; init; } = [];
 
     /// <summary>
     /// Gets a short, language-agnostic remediation hint suitable for surfacing to AppHost
     /// authors.
     /// </summary>
-    [JsonPropertyName("remediationHint")]
     public string? RemediationHint { get; init; }
 }
 
@@ -87,19 +78,16 @@ internal sealed class AppHostLoadedAssemblyInfo
     /// <summary>
     /// Gets the simple name of the assembly (e.g. <c>Aspire.Hosting.JavaScript</c>).
     /// </summary>
-    [JsonPropertyName("name")]
     public string Name { get; init; } = "";
 
     /// <summary>
     /// Gets the informational version of the assembly, when present, otherwise the assembly
     /// version.
     /// </summary>
-    [JsonPropertyName("informationalVersion")]
     public string? InformationalVersion { get; init; }
 
     /// <summary>
     /// Gets the on-disk location of the assembly when available.
     /// </summary>
-    [JsonPropertyName("location")]
     public string? Location { get; init; }
 }

--- a/src/Aspire.Cli/Projects/AppHostCodeGenerationException.cs
+++ b/src/Aspire.Cli/Projects/AppHostCodeGenerationException.cs
@@ -1,0 +1,29 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Aspire.Cli.Projects;
+
+/// <summary>
+/// Thrown by <see cref="AppHostRpcClient"/> when the AppHost server reports a reflection-based
+/// code-generation failure. Carries a structured <see cref="AppHostCodeGenerationDiagnostic"/>
+/// payload supplied by the server so the CLI can render an actionable, tiered diagnostic.
+/// </summary>
+/// <remarks>
+/// The <see cref="Exception.Message"/> always contains the short, language-agnostic message the
+/// server produced; the full structured payload — including .NET-specific identifiers such as
+/// type names and assembly identities — is exposed via <see cref="Diagnostic"/> and is only
+/// rendered to the user when <c>--debug</c> is supplied.
+/// </remarks>
+internal sealed class AppHostCodeGenerationException : Exception
+{
+    public AppHostCodeGenerationException(string message, AppHostCodeGenerationDiagnostic diagnostic, Exception? innerException = null)
+        : base(message, innerException)
+    {
+        Diagnostic = diagnostic;
+    }
+
+    /// <summary>
+    /// Gets the structured diagnostic payload that accompanied the RPC failure.
+    /// </summary>
+    public AppHostCodeGenerationDiagnostic Diagnostic { get; }
+}

--- a/src/Aspire.Cli/Projects/AppHostRpcClient.cs
+++ b/src/Aspire.Cli/Projects/AppHostRpcClient.cs
@@ -3,6 +3,7 @@
 
 using System.IO.Pipes;
 using System.Net.Sockets;
+using System.Text.Json;
 using Aspire.Cli.Backchannel;
 using Aspire.Cli.Telemetry;
 using Aspire.TypeSystem;
@@ -94,19 +95,19 @@ internal sealed class AppHostRpcClient : IAppHostRpcClient
 
     /// <inheritdoc />
     public Task<Dictionary<string, string>> GenerateCodeAsync(string languageId, CancellationToken cancellationToken)
-        => InvokeAsync<Dictionary<string, string>>("generateCode", [languageId, null], cancellationToken);
+        => InvokeCodeGenerationAsync<Dictionary<string, string>>("generateCode", [languageId, null], cancellationToken);
 
     /// <inheritdoc />
     public Task<Dictionary<string, string>> GenerateCodeForAssemblyAsync(string languageId, string assemblyName, CancellationToken cancellationToken)
-        => InvokeAsync<Dictionary<string, string>>("generateCode", [languageId, assemblyName], cancellationToken);
+        => InvokeCodeGenerationAsync<Dictionary<string, string>>("generateCode", [languageId, assemblyName], cancellationToken);
 
     /// <inheritdoc />
     public Task<Commands.Sdk.CapabilitiesInfo> GetCapabilitiesAsync(CancellationToken cancellationToken)
-        => InvokeAsync<Commands.Sdk.CapabilitiesInfo>("getCapabilities", [null], cancellationToken);
+        => InvokeCodeGenerationAsync<Commands.Sdk.CapabilitiesInfo>("getCapabilities", [null], cancellationToken);
 
     /// <inheritdoc />
     public Task<Commands.Sdk.CapabilitiesInfo> GetCapabilitiesForAssembliesAsync(IReadOnlyList<string> assemblyNames, CancellationToken cancellationToken)
-        => InvokeAsync<Commands.Sdk.CapabilitiesInfo>("getCapabilities", [assemblyNames], cancellationToken);
+        => InvokeCodeGenerationAsync<Commands.Sdk.CapabilitiesInfo>("getCapabilities", [assemblyNames], cancellationToken);
 
     /// <inheritdoc />
     public Task<T> InvokeAsync<T>(string methodName, object?[] parameters, CancellationToken cancellationToken)
@@ -115,6 +116,57 @@ internal sealed class AppHostRpcClient : IAppHostRpcClient
     /// <inheritdoc />
     public Task InvokeAsync(string methodName, object?[] parameters, CancellationToken cancellationToken)
         => _jsonRpc.InvokeWithProfilingAsync(_profilingTelemetry, ConnectionName, methodName, parameters, cancellationToken);
+
+    /// <summary>
+    /// Invokes a code-generation RPC method and rethrows structured load/type failures as
+    /// <see cref="AppHostCodeGenerationException"/> so the CLI can render an actionable
+    /// diagnostic instead of an empty or .NET-specific error message.
+    /// </summary>
+    private async Task<T> InvokeCodeGenerationAsync<T>(string methodName, object?[] parameters, CancellationToken cancellationToken)
+    {
+        try
+        {
+            return await _jsonRpc.InvokeWithProfilingAsync<T>(_profilingTelemetry, ConnectionName, methodName, parameters, cancellationToken).ConfigureAwait(false);
+        }
+        catch (RemoteInvocationException ex) when (ex.ErrorCode == AppHostCodeGenerationErrorCodes.IncompatibleAspireSdk)
+        {
+            var diagnostic = TryReadDiagnostic(ex);
+            if (diagnostic is null)
+            {
+                throw;
+            }
+
+            throw new AppHostCodeGenerationException(ex.Message, diagnostic, ex);
+        }
+    }
+
+    /// <summary>
+    /// Extracts a <see cref="AppHostCodeGenerationDiagnostic"/> from a <see cref="RemoteInvocationException"/>'s
+    /// structured error data, returning <see langword="null"/> if the payload is missing or
+    /// can't be deserialized.
+    /// </summary>
+    private static AppHostCodeGenerationDiagnostic? TryReadDiagnostic(RemoteInvocationException exception)
+    {
+        if (exception.DeserializedErrorData is AppHostCodeGenerationDiagnostic typed)
+        {
+            return typed;
+        }
+
+        var payload = exception.DeserializedErrorData ?? exception.ErrorData;
+        if (payload is JsonElement element)
+        {
+            try
+            {
+                return element.Deserialize(BackchannelJsonSerializerContext.Default.AppHostCodeGenerationDiagnostic);
+            }
+            catch (JsonException)
+            {
+                return null;
+            }
+        }
+
+        return null;
+    }
 
     /// <inheritdoc />
     public async ValueTask DisposeAsync()

--- a/src/Aspire.Cli/Projects/GuestAppHostProject.cs
+++ b/src/Aspire.Cli/Projects/GuestAppHostProject.cs
@@ -1702,6 +1702,11 @@ internal sealed class GuestAppHostProject : IAppHostProject, IGuestAppHostSdkGen
             exception.Diagnostic.MemberName ?? "<none>",
             exception.Diagnostic.RuntimeAspireHostingVersion ?? "<none>",
             exception.Diagnostic.LoadedAssemblies.Count);
+        _logger.LogDebug(
+            "Code generation diagnostic payload: {DiagnosticPayload}",
+            JsonSerializer.Serialize(
+                exception.Diagnostic,
+                BackchannelJsonSerializerContext.Default.AppHostCodeGenerationDiagnostic));
 
         if (!_executionContext.DebugMode)
         {

--- a/src/Aspire.Cli/Projects/GuestAppHostProject.cs
+++ b/src/Aspire.Cli/Projects/GuestAppHostProject.cs
@@ -700,6 +700,14 @@ internal sealed class GuestAppHostProject : IAppHostProject, IGuestAppHostSdkGen
             context.BuildCompletionSource?.TrySetResult(false);
             return CliExitCodes.Cancelled;
         }
+        catch (AppHostCodeGenerationException ex)
+        {
+            // We already rendered an actionable, tiered diagnostic in GenerateCodeViaRpcAsync.
+            // Avoid double-printing here — just log and return the standard failure exit code.
+            context.BuildCompletionSource?.TrySetResult(false);
+            _logger.LogError(ex, "Code generation failed for {Language} AppHost", DisplayName);
+            return CliExitCodes.FailedToDotnetRunAppHost;
+        }
         catch (Exception ex)
         {
             // Signal that build/preparation failed so RunCommand doesn't hang waiting
@@ -1041,8 +1049,13 @@ internal sealed class GuestAppHostProject : IAppHostProject, IGuestAppHostSdkGen
 
                     await EnsureRuntimeCreatedAsync(directory, rpcClient, cancellationToken);
                 }
-                catch
+                catch (Exception ex)
                 {
+                    // The backchannel connection task was started before code generation
+                    // (see StartBackchannelConnectionAsync above); fault it eagerly so the
+                    // caller doesn't wait out the connection timeout when generateCode fails.
+                    context.BackchannelCompletionSource?.TrySetException(ex);
+
                     // Once Start() succeeds we own the server process, so dispose it here when
                     // post-start work fails - the `await using` below isn't in scope yet.
                     await serverSession.DisposeAsync();
@@ -1503,10 +1516,22 @@ internal sealed class GuestAppHostProject : IAppHostProject, IGuestAppHostSdkGen
         // The code generator is registered by its Language property, not the runtime ID
         var codeGenerator = _resolvedLanguage.CodeGenerator;
 
+        WarnIfCliSdkVersionSkew(appPath);
+
         _logger.LogDebug("Generating {CodeGenerator} code via RPC for {Count} packages", codeGenerator, integrationsList.Count);
 
         // Use the typed RPC method
-        var files = await rpcClient.GenerateCodeAsync(codeGenerator, cancellationToken);
+        Dictionary<string, string> files;
+        try
+        {
+            files = await rpcClient.GenerateCodeAsync(codeGenerator, cancellationToken);
+        }
+        catch (AppHostCodeGenerationException ex)
+        {
+            RenderCodeGenerationFailure(ex);
+            throw;
+        }
+
         var outputPath = Path.Combine(appPath, LanguageInfo.GeneratedFolderName);
         // Legacy TypeScript AppHosts (`apphost.ts`) still import generated files from
         // `./.modules/aspire.js`. When that scaffold shape is detected, convert the
@@ -1576,6 +1601,132 @@ internal sealed class GuestAppHostProject : IAppHostProject, IGuestAppHostSdkGen
             ? appHostFile.Name.Equals(TypeScriptAppHostFileName, StringComparison.OrdinalIgnoreCase)
             : File.Exists(Path.Combine(appPath, TypeScriptAppHostFileName)) &&
                 !File.Exists(Path.Combine(appPath, TypeScriptMtsAppHostFileName));
+    }
+
+    /// <summary>
+    /// Emits a single pre-flight warning when the installed CLI version doesn't match the SDK
+    /// version pinned in <c>aspire.config.json</c>. This is a best-effort heuristic — we keep it
+    /// purely informational and let code-generation try first so that benign skew (e.g. a
+    /// daily-build CLI against a stable SDK) doesn't block valid scenarios.
+    /// </summary>
+    private void WarnIfCliSdkVersionSkew(string appPath)
+    {
+        try
+        {
+            var configDir = ConfigurationHelper.GetConfigRootDirectory(new DirectoryInfo(appPath));
+            var config = AspireConfigFile.Load(configDir.FullName);
+            var configuredSdkVersion = config?.SdkVersion;
+            if (string.IsNullOrWhiteSpace(configuredSdkVersion))
+            {
+                return;
+            }
+
+            var cliVersion = VersionHelper.GetDefaultSdkVersion();
+            if (!IsKnownIncompatibleSkew(cliVersion, configuredSdkVersion))
+            {
+                return;
+            }
+
+            var message = string.Format(
+                System.Globalization.CultureInfo.CurrentCulture,
+                ErrorStrings.CodegenVersionSkewWarning,
+                cliVersion,
+                configuredSdkVersion);
+            _interactionService.DisplayMessage(KnownEmojis.Warning, $"[yellow]{Markup.Escape(message)}[/]", allowMarkup: true);
+            _logger.LogDebug("Aspire CLI/SDK version skew detected (CLI={CliVersion}, SDK={SdkVersion})", cliVersion, configuredSdkVersion);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogDebug(ex, "Failed to evaluate CLI/SDK version skew prior to code generation.");
+        }
+    }
+
+    /// <summary>
+    /// Returns <see langword="true"/> when the supplied CLI and SDK versions look mismatched in a
+    /// way that is worth warning about. We deliberately tolerate metadata-only differences
+    /// (build suffixes, +commit hashes) and only flag a skew when the parsed major/minor/patch
+    /// numbers disagree.
+    /// </summary>
+    internal static bool IsKnownIncompatibleSkew(string cliVersion, string sdkVersion)
+    {
+        if (!SemVersion.TryParse(NormalizeVersion(cliVersion), SemVersionStyles.Any, out var cli) ||
+            !SemVersion.TryParse(NormalizeVersion(sdkVersion), SemVersionStyles.Any, out var sdk))
+        {
+            return !string.Equals(cliVersion, sdkVersion, StringComparison.OrdinalIgnoreCase);
+        }
+
+        return cli.Major != sdk.Major || cli.Minor != sdk.Minor || cli.Patch != sdk.Patch;
+    }
+
+    internal static string NormalizeVersion(string version)
+    {
+        var plusIndex = version.IndexOf('+');
+        return plusIndex > 0 ? version[..plusIndex] : version;
+    }
+
+    /// <summary>
+    /// Renders a <see cref="AppHostCodeGenerationException"/> to the user with .NET-specific
+    /// details tiered behind <c>--debug</c> so that polyglot AppHost authors aren't confronted
+    /// with C#/CLR jargon by default. The full structured payload is always written to the debug
+    /// log file via the logger's <c>LogDebug</c> call regardless of mode.
+    /// </summary>
+    private void RenderCodeGenerationFailure(AppHostCodeGenerationException exception)
+    {
+        var summary = string.Format(
+            System.Globalization.CultureInfo.CurrentCulture,
+            ErrorStrings.CodegenIncompatibleSdkSummary,
+            DisplayName);
+        _interactionService.DisplayError(summary);
+
+        var hint = exception.Diagnostic.RemediationHint;
+        if (!string.IsNullOrWhiteSpace(hint))
+        {
+            _interactionService.DisplayMessage(KnownEmojis.Information, $"[grey]{Markup.Escape(hint!)}[/]", allowMarkup: true);
+        }
+
+        _logger.LogDebug(
+            "Code generation failed. OriginalExceptionType={OriginalExceptionType}, TypeName={TypeName}, MemberName={MemberName}, RuntimeAspireHostingVersion={RuntimeVersion}, LoadedAssemblies={LoadedCount}",
+            exception.Diagnostic.OriginalExceptionType,
+            exception.Diagnostic.TypeName ?? "<none>",
+            exception.Diagnostic.MemberName ?? "<none>",
+            exception.Diagnostic.RuntimeAspireHostingVersion ?? "<none>",
+            exception.Diagnostic.LoadedAssemblies.Count);
+
+        if (!_executionContext.DebugMode)
+        {
+            _interactionService.DisplayMessage(KnownEmojis.Information, $"[grey]{Markup.Escape(ErrorStrings.CodegenDebugHint)}[/]", allowMarkup: true);
+            return;
+        }
+
+        _interactionService.DisplayMessage(KnownEmojis.Microscope, $"[grey]{Markup.Escape(ErrorStrings.CodegenDebugHeader)}[/]", allowMarkup: true);
+        var diagnostic = exception.Diagnostic;
+        if (!string.IsNullOrWhiteSpace(diagnostic.OriginalExceptionType))
+        {
+            _interactionService.DisplayMessage(KnownEmojis.Microscope, $"[grey]  Exception: {Markup.Escape(diagnostic.OriginalExceptionType)}[/]", allowMarkup: true);
+        }
+        if (!string.IsNullOrWhiteSpace(diagnostic.TypeName))
+        {
+            _interactionService.DisplayMessage(KnownEmojis.Microscope, $"[grey]  Type: {Markup.Escape(diagnostic.TypeName!)}[/]", allowMarkup: true);
+        }
+        if (!string.IsNullOrWhiteSpace(diagnostic.MemberName))
+        {
+            _interactionService.DisplayMessage(KnownEmojis.Microscope, $"[grey]  Member: {Markup.Escape(diagnostic.MemberName!)}[/]", allowMarkup: true);
+        }
+        if (!string.IsNullOrWhiteSpace(diagnostic.RuntimeAspireHostingVersion))
+        {
+            _interactionService.DisplayMessage(
+                KnownEmojis.Microscope,
+                $"[grey]  Runtime Aspire.Hosting: {Markup.Escape(diagnostic.RuntimeAspireHostingVersion!)}[/]",
+                allowMarkup: true);
+        }
+        foreach (var assembly in diagnostic.LoadedAssemblies)
+        {
+            var version = assembly.InformationalVersion ?? "<unknown>";
+            _interactionService.DisplayMessage(
+                KnownEmojis.Microscope,
+                $"[grey]  • {Markup.Escape(assembly.Name)} {Markup.Escape(version)}[/]",
+                allowMarkup: true);
+        }
     }
 
     /// <summary>

--- a/src/Aspire.Cli/Projects/GuestAppHostProject.cs
+++ b/src/Aspire.Cli/Projects/GuestAppHostProject.cs
@@ -1633,7 +1633,6 @@ internal sealed class GuestAppHostProject : IAppHostProject, IGuestAppHostSdkGen
                 cliVersion,
                 configuredSdkVersion);
             _interactionService.DisplayMessage(KnownEmojis.Warning, $"[yellow]{Markup.Escape(message)}[/]", allowMarkup: true);
-            _logger.LogDebug("Aspire CLI/SDK version skew detected (CLI={CliVersion}, SDK={SdkVersion})", cliVersion, configuredSdkVersion);
         }
         catch (Exception ex)
         {
@@ -1647,6 +1646,15 @@ internal sealed class GuestAppHostProject : IAppHostProject, IGuestAppHostSdkGen
     /// (build suffixes, +commit hashes) and only flag a skew when the parsed major/minor/patch
     /// numbers disagree.
     /// </summary>
+    /// <summary>
+    /// Returns <see langword="true"/> when the supplied CLI and SDK versions differ in a way that
+    /// is known to produce ABI incompatibilities — specifically when they differ in
+    /// <see cref="SemVersion.Major"/>, <see cref="SemVersion.Minor"/>, <see cref="SemVersion.Patch"/>,
+    /// or in their prerelease identifiers (e.g. <c>13.4.0-preview.1.26218.1</c> vs
+    /// <c>13.4.0-preview.1.26227.1</c>, which was the exact reproduction case in
+    /// <see href="https://github.com/microsoft/aspire/issues/16709"/>). Build metadata
+    /// (everything after <c>+</c>) is ignored per the SemVer spec.
+    /// </summary>
     internal static bool IsKnownIncompatibleSkew(string cliVersion, string sdkVersion)
     {
         if (!SemVersion.TryParse(NormalizeVersion(cliVersion), SemVersionStyles.Any, out var cli) ||
@@ -1655,7 +1663,10 @@ internal sealed class GuestAppHostProject : IAppHostProject, IGuestAppHostSdkGen
             return !string.Equals(cliVersion, sdkVersion, StringComparison.OrdinalIgnoreCase);
         }
 
-        return cli.Major != sdk.Major || cli.Minor != sdk.Minor || cli.Patch != sdk.Patch;
+        // Compare full precedence, which covers Major/Minor/Patch *and* prerelease identifiers
+        // but (per the SemVer spec) ignores build metadata. NormalizeVersion already strips '+'
+        // suffixes defensively for parsers that include them in precedence.
+        return SemVersion.ComparePrecedence(cli, sdk) != 0;
     }
 
     internal static string NormalizeVersion(string version)
@@ -1702,30 +1713,24 @@ internal sealed class GuestAppHostProject : IAppHostProject, IGuestAppHostSdkGen
         var diagnostic = exception.Diagnostic;
         if (!string.IsNullOrWhiteSpace(diagnostic.OriginalExceptionType))
         {
-            _interactionService.DisplayMessage(KnownEmojis.Microscope, $"[grey]  Exception: {Markup.Escape(diagnostic.OriginalExceptionType)}[/]", allowMarkup: true);
+            _interactionService.DisplayPlainText($"   Exception: {diagnostic.OriginalExceptionType}");
         }
         if (!string.IsNullOrWhiteSpace(diagnostic.TypeName))
         {
-            _interactionService.DisplayMessage(KnownEmojis.Microscope, $"[grey]  Type: {Markup.Escape(diagnostic.TypeName!)}[/]", allowMarkup: true);
+            _interactionService.DisplayPlainText($"   Type: {diagnostic.TypeName}");
         }
         if (!string.IsNullOrWhiteSpace(diagnostic.MemberName))
         {
-            _interactionService.DisplayMessage(KnownEmojis.Microscope, $"[grey]  Member: {Markup.Escape(diagnostic.MemberName!)}[/]", allowMarkup: true);
+            _interactionService.DisplayPlainText($"   Member: {diagnostic.MemberName}");
         }
         if (!string.IsNullOrWhiteSpace(diagnostic.RuntimeAspireHostingVersion))
         {
-            _interactionService.DisplayMessage(
-                KnownEmojis.Microscope,
-                $"[grey]  Runtime Aspire.Hosting: {Markup.Escape(diagnostic.RuntimeAspireHostingVersion!)}[/]",
-                allowMarkup: true);
+            _interactionService.DisplayPlainText($"   Runtime Aspire.Hosting: {diagnostic.RuntimeAspireHostingVersion}");
         }
         foreach (var assembly in diagnostic.LoadedAssemblies)
         {
             var version = assembly.InformationalVersion ?? "<unknown>";
-            _interactionService.DisplayMessage(
-                KnownEmojis.Microscope,
-                $"[grey]  • {Markup.Escape(assembly.Name)} {Markup.Escape(version)}[/]",
-                allowMarkup: true);
+            _interactionService.DisplayPlainText($"   • {assembly.Name} {version}");
         }
     }
 

--- a/src/Aspire.Cli/Resources/ErrorStrings.Designer.cs
+++ b/src/Aspire.Cli/Resources/ErrorStrings.Designer.cs
@@ -416,5 +416,41 @@ namespace Aspire.Cli.Resources {
                 return ResourceManager.GetString("InvalidJsonInConfigFile", resourceCulture);
             }
         }
+
+        /// <summary>
+        ///   Looks up a localized string similar to The installed Aspire CLI version ({0}) differs from the configured Aspire SDK version ({1}). If you run into errors, run 'aspire update' to align them..
+        /// </summary>
+        public static string CodegenVersionSkewWarning {
+            get {
+                return ResourceManager.GetString("CodegenVersionSkewWarning", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to {0} SDK code generation failed because the installed Aspire CLI appears to be incompatible with the configured Aspire SDK. Run 'aspire update' to align the CLI and SDK and try again..
+        /// </summary>
+        public static string CodegenIncompatibleSdkSummary {
+            get {
+                return ResourceManager.GetString("CodegenIncompatibleSdkSummary", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Run with '--debug' for full diagnostic details..
+        /// </summary>
+        public static string CodegenDebugHint {
+            get {
+                return ResourceManager.GetString("CodegenDebugHint", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Diagnostic details:.
+        /// </summary>
+        public static string CodegenDebugHeader {
+            get {
+                return ResourceManager.GetString("CodegenDebugHeader", resourceCulture);
+            }
+        }
     }
 }

--- a/src/Aspire.Cli/Resources/ErrorStrings.resx
+++ b/src/Aspire.Cli/Resources/ErrorStrings.resx
@@ -262,4 +262,18 @@
     <value>The configuration file '{0}' contains invalid JSON: {1}</value>
     <comment>{0} is the file path, {1} is the exception message</comment>
   </data>
+  <data name="CodegenVersionSkewWarning" xml:space="preserve">
+    <value>The installed Aspire CLI version ({0}) differs from the configured Aspire SDK version ({1}). If you run into errors, run 'aspire update' to align them.</value>
+    <comment>{0} is the CLI version, {1} is the SDK version configured in aspire.config.json.</comment>
+  </data>
+  <data name="CodegenIncompatibleSdkSummary" xml:space="preserve">
+    <value>{0} SDK code generation failed because the installed Aspire CLI appears to be incompatible with the configured Aspire SDK. Run 'aspire update' to align the CLI and SDK and try again.</value>
+    <comment>{0} is the AppHost language display name, e.g. 'TypeScript (Node.js)'.</comment>
+  </data>
+  <data name="CodegenDebugHint" xml:space="preserve">
+    <value>Run with '--debug' for full diagnostic details.</value>
+  </data>
+  <data name="CodegenDebugHeader" xml:space="preserve">
+    <value>Diagnostic details:</value>
+  </data>
 </root>

--- a/src/Aspire.Cli/Resources/xlf/ErrorStrings.cs.xlf
+++ b/src/Aspire.Cli/Resources/xlf/ErrorStrings.cs.xlf
@@ -57,6 +57,26 @@
         <target state="new">Developer certificates are only partially trusted. Trust them interactively by running 'aspire certs trust'.</target>
         <note />
       </trans-unit>
+      <trans-unit id="CodegenDebugHeader">
+        <source>Diagnostic details:</source>
+        <target state="new">Diagnostic details:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CodegenDebugHint">
+        <source>Run with '--debug' for full diagnostic details.</source>
+        <target state="new">Run with '--debug' for full diagnostic details.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CodegenIncompatibleSdkSummary">
+        <source>{0} SDK code generation failed because the installed Aspire CLI appears to be incompatible with the configured Aspire SDK. Run 'aspire update' to align the CLI and SDK and try again.</source>
+        <target state="new">{0} SDK code generation failed because the installed Aspire CLI appears to be incompatible with the configured Aspire SDK. Run 'aspire update' to align the CLI and SDK and try again.</target>
+        <note>{0} is the AppHost language display name, e.g. 'TypeScript (Node.js)'.</note>
+      </trans-unit>
+      <trans-unit id="CodegenVersionSkewWarning">
+        <source>The installed Aspire CLI version ({0}) differs from the configured Aspire SDK version ({1}). If you run into errors, run 'aspire update' to align them.</source>
+        <target state="new">The installed Aspire CLI version ({0}) differs from the configured Aspire SDK version ({1}). If you run into errors, run 'aspire update' to align them.</target>
+        <note>{0} is the CLI version, {1} is the SDK version configured in aspire.config.json.</note>
+      </trans-unit>
       <trans-unit id="CommandNotSupportedWithSingleFileAppHost">
         <source>This command is not yet supported with single file AppHosts.</source>
         <target state="needs-review-translation">Tento příkaz zatím není pro funkci AppHost pro jednosouborové scénáře podporován.</target>

--- a/src/Aspire.Cli/Resources/xlf/ErrorStrings.de.xlf
+++ b/src/Aspire.Cli/Resources/xlf/ErrorStrings.de.xlf
@@ -57,6 +57,26 @@
         <target state="new">Developer certificates are only partially trusted. Trust them interactively by running 'aspire certs trust'.</target>
         <note />
       </trans-unit>
+      <trans-unit id="CodegenDebugHeader">
+        <source>Diagnostic details:</source>
+        <target state="new">Diagnostic details:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CodegenDebugHint">
+        <source>Run with '--debug' for full diagnostic details.</source>
+        <target state="new">Run with '--debug' for full diagnostic details.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CodegenIncompatibleSdkSummary">
+        <source>{0} SDK code generation failed because the installed Aspire CLI appears to be incompatible with the configured Aspire SDK. Run 'aspire update' to align the CLI and SDK and try again.</source>
+        <target state="new">{0} SDK code generation failed because the installed Aspire CLI appears to be incompatible with the configured Aspire SDK. Run 'aspire update' to align the CLI and SDK and try again.</target>
+        <note>{0} is the AppHost language display name, e.g. 'TypeScript (Node.js)'.</note>
+      </trans-unit>
+      <trans-unit id="CodegenVersionSkewWarning">
+        <source>The installed Aspire CLI version ({0}) differs from the configured Aspire SDK version ({1}). If you run into errors, run 'aspire update' to align them.</source>
+        <target state="new">The installed Aspire CLI version ({0}) differs from the configured Aspire SDK version ({1}). If you run into errors, run 'aspire update' to align them.</target>
+        <note>{0} is the CLI version, {1} is the SDK version configured in aspire.config.json.</note>
+      </trans-unit>
       <trans-unit id="CommandNotSupportedWithSingleFileAppHost">
         <source>This command is not yet supported with single file AppHosts.</source>
         <target state="needs-review-translation">Dieser Befehl wird für AppHosts mit einer einzelnen Datei noch nicht unterstützt.</target>

--- a/src/Aspire.Cli/Resources/xlf/ErrorStrings.es.xlf
+++ b/src/Aspire.Cli/Resources/xlf/ErrorStrings.es.xlf
@@ -57,6 +57,26 @@
         <target state="new">Developer certificates are only partially trusted. Trust them interactively by running 'aspire certs trust'.</target>
         <note />
       </trans-unit>
+      <trans-unit id="CodegenDebugHeader">
+        <source>Diagnostic details:</source>
+        <target state="new">Diagnostic details:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CodegenDebugHint">
+        <source>Run with '--debug' for full diagnostic details.</source>
+        <target state="new">Run with '--debug' for full diagnostic details.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CodegenIncompatibleSdkSummary">
+        <source>{0} SDK code generation failed because the installed Aspire CLI appears to be incompatible with the configured Aspire SDK. Run 'aspire update' to align the CLI and SDK and try again.</source>
+        <target state="new">{0} SDK code generation failed because the installed Aspire CLI appears to be incompatible with the configured Aspire SDK. Run 'aspire update' to align the CLI and SDK and try again.</target>
+        <note>{0} is the AppHost language display name, e.g. 'TypeScript (Node.js)'.</note>
+      </trans-unit>
+      <trans-unit id="CodegenVersionSkewWarning">
+        <source>The installed Aspire CLI version ({0}) differs from the configured Aspire SDK version ({1}). If you run into errors, run 'aspire update' to align them.</source>
+        <target state="new">The installed Aspire CLI version ({0}) differs from the configured Aspire SDK version ({1}). If you run into errors, run 'aspire update' to align them.</target>
+        <note>{0} is the CLI version, {1} is the SDK version configured in aspire.config.json.</note>
+      </trans-unit>
       <trans-unit id="CommandNotSupportedWithSingleFileAppHost">
         <source>This command is not yet supported with single file AppHosts.</source>
         <target state="needs-review-translation">Este comando aún no es compatible con AppHosts de un solo archivo.</target>

--- a/src/Aspire.Cli/Resources/xlf/ErrorStrings.fr.xlf
+++ b/src/Aspire.Cli/Resources/xlf/ErrorStrings.fr.xlf
@@ -57,6 +57,26 @@
         <target state="new">Developer certificates are only partially trusted. Trust them interactively by running 'aspire certs trust'.</target>
         <note />
       </trans-unit>
+      <trans-unit id="CodegenDebugHeader">
+        <source>Diagnostic details:</source>
+        <target state="new">Diagnostic details:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CodegenDebugHint">
+        <source>Run with '--debug' for full diagnostic details.</source>
+        <target state="new">Run with '--debug' for full diagnostic details.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CodegenIncompatibleSdkSummary">
+        <source>{0} SDK code generation failed because the installed Aspire CLI appears to be incompatible with the configured Aspire SDK. Run 'aspire update' to align the CLI and SDK and try again.</source>
+        <target state="new">{0} SDK code generation failed because the installed Aspire CLI appears to be incompatible with the configured Aspire SDK. Run 'aspire update' to align the CLI and SDK and try again.</target>
+        <note>{0} is the AppHost language display name, e.g. 'TypeScript (Node.js)'.</note>
+      </trans-unit>
+      <trans-unit id="CodegenVersionSkewWarning">
+        <source>The installed Aspire CLI version ({0}) differs from the configured Aspire SDK version ({1}). If you run into errors, run 'aspire update' to align them.</source>
+        <target state="new">The installed Aspire CLI version ({0}) differs from the configured Aspire SDK version ({1}). If you run into errors, run 'aspire update' to align them.</target>
+        <note>{0} is the CLI version, {1} is the SDK version configured in aspire.config.json.</note>
+      </trans-unit>
       <trans-unit id="CommandNotSupportedWithSingleFileAppHost">
         <source>This command is not yet supported with single file AppHosts.</source>
         <target state="needs-review-translation">Cette commande n’est pas encore prise en charge avec les hôtes d’application à fichier unique.</target>

--- a/src/Aspire.Cli/Resources/xlf/ErrorStrings.it.xlf
+++ b/src/Aspire.Cli/Resources/xlf/ErrorStrings.it.xlf
@@ -57,6 +57,26 @@
         <target state="new">Developer certificates are only partially trusted. Trust them interactively by running 'aspire certs trust'.</target>
         <note />
       </trans-unit>
+      <trans-unit id="CodegenDebugHeader">
+        <source>Diagnostic details:</source>
+        <target state="new">Diagnostic details:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CodegenDebugHint">
+        <source>Run with '--debug' for full diagnostic details.</source>
+        <target state="new">Run with '--debug' for full diagnostic details.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CodegenIncompatibleSdkSummary">
+        <source>{0} SDK code generation failed because the installed Aspire CLI appears to be incompatible with the configured Aspire SDK. Run 'aspire update' to align the CLI and SDK and try again.</source>
+        <target state="new">{0} SDK code generation failed because the installed Aspire CLI appears to be incompatible with the configured Aspire SDK. Run 'aspire update' to align the CLI and SDK and try again.</target>
+        <note>{0} is the AppHost language display name, e.g. 'TypeScript (Node.js)'.</note>
+      </trans-unit>
+      <trans-unit id="CodegenVersionSkewWarning">
+        <source>The installed Aspire CLI version ({0}) differs from the configured Aspire SDK version ({1}). If you run into errors, run 'aspire update' to align them.</source>
+        <target state="new">The installed Aspire CLI version ({0}) differs from the configured Aspire SDK version ({1}). If you run into errors, run 'aspire update' to align them.</target>
+        <note>{0} is the CLI version, {1} is the SDK version configured in aspire.config.json.</note>
+      </trans-unit>
       <trans-unit id="CommandNotSupportedWithSingleFileAppHost">
         <source>This command is not yet supported with single file AppHosts.</source>
         <target state="needs-review-translation">Questo comando non è ancora supportato con AppHost a file singolo.</target>

--- a/src/Aspire.Cli/Resources/xlf/ErrorStrings.ja.xlf
+++ b/src/Aspire.Cli/Resources/xlf/ErrorStrings.ja.xlf
@@ -57,6 +57,26 @@
         <target state="new">Developer certificates are only partially trusted. Trust them interactively by running 'aspire certs trust'.</target>
         <note />
       </trans-unit>
+      <trans-unit id="CodegenDebugHeader">
+        <source>Diagnostic details:</source>
+        <target state="new">Diagnostic details:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CodegenDebugHint">
+        <source>Run with '--debug' for full diagnostic details.</source>
+        <target state="new">Run with '--debug' for full diagnostic details.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CodegenIncompatibleSdkSummary">
+        <source>{0} SDK code generation failed because the installed Aspire CLI appears to be incompatible with the configured Aspire SDK. Run 'aspire update' to align the CLI and SDK and try again.</source>
+        <target state="new">{0} SDK code generation failed because the installed Aspire CLI appears to be incompatible with the configured Aspire SDK. Run 'aspire update' to align the CLI and SDK and try again.</target>
+        <note>{0} is the AppHost language display name, e.g. 'TypeScript (Node.js)'.</note>
+      </trans-unit>
+      <trans-unit id="CodegenVersionSkewWarning">
+        <source>The installed Aspire CLI version ({0}) differs from the configured Aspire SDK version ({1}). If you run into errors, run 'aspire update' to align them.</source>
+        <target state="new">The installed Aspire CLI version ({0}) differs from the configured Aspire SDK version ({1}). If you run into errors, run 'aspire update' to align them.</target>
+        <note>{0} is the CLI version, {1} is the SDK version configured in aspire.config.json.</note>
+      </trans-unit>
       <trans-unit id="CommandNotSupportedWithSingleFileAppHost">
         <source>This command is not yet supported with single file AppHosts.</source>
         <target state="needs-review-translation">このコマンドは、単一ファイルの AppHost ではまだサポートされていません。</target>

--- a/src/Aspire.Cli/Resources/xlf/ErrorStrings.ko.xlf
+++ b/src/Aspire.Cli/Resources/xlf/ErrorStrings.ko.xlf
@@ -57,6 +57,26 @@
         <target state="new">Developer certificates are only partially trusted. Trust them interactively by running 'aspire certs trust'.</target>
         <note />
       </trans-unit>
+      <trans-unit id="CodegenDebugHeader">
+        <source>Diagnostic details:</source>
+        <target state="new">Diagnostic details:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CodegenDebugHint">
+        <source>Run with '--debug' for full diagnostic details.</source>
+        <target state="new">Run with '--debug' for full diagnostic details.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CodegenIncompatibleSdkSummary">
+        <source>{0} SDK code generation failed because the installed Aspire CLI appears to be incompatible with the configured Aspire SDK. Run 'aspire update' to align the CLI and SDK and try again.</source>
+        <target state="new">{0} SDK code generation failed because the installed Aspire CLI appears to be incompatible with the configured Aspire SDK. Run 'aspire update' to align the CLI and SDK and try again.</target>
+        <note>{0} is the AppHost language display name, e.g. 'TypeScript (Node.js)'.</note>
+      </trans-unit>
+      <trans-unit id="CodegenVersionSkewWarning">
+        <source>The installed Aspire CLI version ({0}) differs from the configured Aspire SDK version ({1}). If you run into errors, run 'aspire update' to align them.</source>
+        <target state="new">The installed Aspire CLI version ({0}) differs from the configured Aspire SDK version ({1}). If you run into errors, run 'aspire update' to align them.</target>
+        <note>{0} is the CLI version, {1} is the SDK version configured in aspire.config.json.</note>
+      </trans-unit>
       <trans-unit id="CommandNotSupportedWithSingleFileAppHost">
         <source>This command is not yet supported with single file AppHosts.</source>
         <target state="needs-review-translation">이 명령은 단일 파일 AppHosts에서 아직 지원되지 않습니다.</target>

--- a/src/Aspire.Cli/Resources/xlf/ErrorStrings.pl.xlf
+++ b/src/Aspire.Cli/Resources/xlf/ErrorStrings.pl.xlf
@@ -57,6 +57,26 @@
         <target state="new">Developer certificates are only partially trusted. Trust them interactively by running 'aspire certs trust'.</target>
         <note />
       </trans-unit>
+      <trans-unit id="CodegenDebugHeader">
+        <source>Diagnostic details:</source>
+        <target state="new">Diagnostic details:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CodegenDebugHint">
+        <source>Run with '--debug' for full diagnostic details.</source>
+        <target state="new">Run with '--debug' for full diagnostic details.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CodegenIncompatibleSdkSummary">
+        <source>{0} SDK code generation failed because the installed Aspire CLI appears to be incompatible with the configured Aspire SDK. Run 'aspire update' to align the CLI and SDK and try again.</source>
+        <target state="new">{0} SDK code generation failed because the installed Aspire CLI appears to be incompatible with the configured Aspire SDK. Run 'aspire update' to align the CLI and SDK and try again.</target>
+        <note>{0} is the AppHost language display name, e.g. 'TypeScript (Node.js)'.</note>
+      </trans-unit>
+      <trans-unit id="CodegenVersionSkewWarning">
+        <source>The installed Aspire CLI version ({0}) differs from the configured Aspire SDK version ({1}). If you run into errors, run 'aspire update' to align them.</source>
+        <target state="new">The installed Aspire CLI version ({0}) differs from the configured Aspire SDK version ({1}). If you run into errors, run 'aspire update' to align them.</target>
+        <note>{0} is the CLI version, {1} is the SDK version configured in aspire.config.json.</note>
+      </trans-unit>
       <trans-unit id="CommandNotSupportedWithSingleFileAppHost">
         <source>This command is not yet supported with single file AppHosts.</source>
         <target state="needs-review-translation">To polecenie nie jest jeszcze obsługiwane w przypadku hostów AppHost z jednym plikiem.</target>

--- a/src/Aspire.Cli/Resources/xlf/ErrorStrings.pt-BR.xlf
+++ b/src/Aspire.Cli/Resources/xlf/ErrorStrings.pt-BR.xlf
@@ -57,6 +57,26 @@
         <target state="new">Developer certificates are only partially trusted. Trust them interactively by running 'aspire certs trust'.</target>
         <note />
       </trans-unit>
+      <trans-unit id="CodegenDebugHeader">
+        <source>Diagnostic details:</source>
+        <target state="new">Diagnostic details:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CodegenDebugHint">
+        <source>Run with '--debug' for full diagnostic details.</source>
+        <target state="new">Run with '--debug' for full diagnostic details.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CodegenIncompatibleSdkSummary">
+        <source>{0} SDK code generation failed because the installed Aspire CLI appears to be incompatible with the configured Aspire SDK. Run 'aspire update' to align the CLI and SDK and try again.</source>
+        <target state="new">{0} SDK code generation failed because the installed Aspire CLI appears to be incompatible with the configured Aspire SDK. Run 'aspire update' to align the CLI and SDK and try again.</target>
+        <note>{0} is the AppHost language display name, e.g. 'TypeScript (Node.js)'.</note>
+      </trans-unit>
+      <trans-unit id="CodegenVersionSkewWarning">
+        <source>The installed Aspire CLI version ({0}) differs from the configured Aspire SDK version ({1}). If you run into errors, run 'aspire update' to align them.</source>
+        <target state="new">The installed Aspire CLI version ({0}) differs from the configured Aspire SDK version ({1}). If you run into errors, run 'aspire update' to align them.</target>
+        <note>{0} is the CLI version, {1} is the SDK version configured in aspire.config.json.</note>
+      </trans-unit>
       <trans-unit id="CommandNotSupportedWithSingleFileAppHost">
         <source>This command is not yet supported with single file AppHosts.</source>
         <target state="needs-review-translation">Este comando ainda não tem suporte para AppHosts de arquivo único.</target>

--- a/src/Aspire.Cli/Resources/xlf/ErrorStrings.ru.xlf
+++ b/src/Aspire.Cli/Resources/xlf/ErrorStrings.ru.xlf
@@ -57,6 +57,26 @@
         <target state="new">Developer certificates are only partially trusted. Trust them interactively by running 'aspire certs trust'.</target>
         <note />
       </trans-unit>
+      <trans-unit id="CodegenDebugHeader">
+        <source>Diagnostic details:</source>
+        <target state="new">Diagnostic details:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CodegenDebugHint">
+        <source>Run with '--debug' for full diagnostic details.</source>
+        <target state="new">Run with '--debug' for full diagnostic details.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CodegenIncompatibleSdkSummary">
+        <source>{0} SDK code generation failed because the installed Aspire CLI appears to be incompatible with the configured Aspire SDK. Run 'aspire update' to align the CLI and SDK and try again.</source>
+        <target state="new">{0} SDK code generation failed because the installed Aspire CLI appears to be incompatible with the configured Aspire SDK. Run 'aspire update' to align the CLI and SDK and try again.</target>
+        <note>{0} is the AppHost language display name, e.g. 'TypeScript (Node.js)'.</note>
+      </trans-unit>
+      <trans-unit id="CodegenVersionSkewWarning">
+        <source>The installed Aspire CLI version ({0}) differs from the configured Aspire SDK version ({1}). If you run into errors, run 'aspire update' to align them.</source>
+        <target state="new">The installed Aspire CLI version ({0}) differs from the configured Aspire SDK version ({1}). If you run into errors, run 'aspire update' to align them.</target>
+        <note>{0} is the CLI version, {1} is the SDK version configured in aspire.config.json.</note>
+      </trans-unit>
       <trans-unit id="CommandNotSupportedWithSingleFileAppHost">
         <source>This command is not yet supported with single file AppHosts.</source>
         <target state="needs-review-translation">Эта команда пока не поддерживается для одиночных файлов AppHost.</target>

--- a/src/Aspire.Cli/Resources/xlf/ErrorStrings.tr.xlf
+++ b/src/Aspire.Cli/Resources/xlf/ErrorStrings.tr.xlf
@@ -57,6 +57,26 @@
         <target state="new">Developer certificates are only partially trusted. Trust them interactively by running 'aspire certs trust'.</target>
         <note />
       </trans-unit>
+      <trans-unit id="CodegenDebugHeader">
+        <source>Diagnostic details:</source>
+        <target state="new">Diagnostic details:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CodegenDebugHint">
+        <source>Run with '--debug' for full diagnostic details.</source>
+        <target state="new">Run with '--debug' for full diagnostic details.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CodegenIncompatibleSdkSummary">
+        <source>{0} SDK code generation failed because the installed Aspire CLI appears to be incompatible with the configured Aspire SDK. Run 'aspire update' to align the CLI and SDK and try again.</source>
+        <target state="new">{0} SDK code generation failed because the installed Aspire CLI appears to be incompatible with the configured Aspire SDK. Run 'aspire update' to align the CLI and SDK and try again.</target>
+        <note>{0} is the AppHost language display name, e.g. 'TypeScript (Node.js)'.</note>
+      </trans-unit>
+      <trans-unit id="CodegenVersionSkewWarning">
+        <source>The installed Aspire CLI version ({0}) differs from the configured Aspire SDK version ({1}). If you run into errors, run 'aspire update' to align them.</source>
+        <target state="new">The installed Aspire CLI version ({0}) differs from the configured Aspire SDK version ({1}). If you run into errors, run 'aspire update' to align them.</target>
+        <note>{0} is the CLI version, {1} is the SDK version configured in aspire.config.json.</note>
+      </trans-unit>
       <trans-unit id="CommandNotSupportedWithSingleFileAppHost">
         <source>This command is not yet supported with single file AppHosts.</source>
         <target state="needs-review-translation">Bu komut, tek dosya Uygulama Ana İşlemlerinde henüz desteklenmemektedir.</target>

--- a/src/Aspire.Cli/Resources/xlf/ErrorStrings.zh-Hans.xlf
+++ b/src/Aspire.Cli/Resources/xlf/ErrorStrings.zh-Hans.xlf
@@ -57,6 +57,26 @@
         <target state="new">Developer certificates are only partially trusted. Trust them interactively by running 'aspire certs trust'.</target>
         <note />
       </trans-unit>
+      <trans-unit id="CodegenDebugHeader">
+        <source>Diagnostic details:</source>
+        <target state="new">Diagnostic details:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CodegenDebugHint">
+        <source>Run with '--debug' for full diagnostic details.</source>
+        <target state="new">Run with '--debug' for full diagnostic details.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CodegenIncompatibleSdkSummary">
+        <source>{0} SDK code generation failed because the installed Aspire CLI appears to be incompatible with the configured Aspire SDK. Run 'aspire update' to align the CLI and SDK and try again.</source>
+        <target state="new">{0} SDK code generation failed because the installed Aspire CLI appears to be incompatible with the configured Aspire SDK. Run 'aspire update' to align the CLI and SDK and try again.</target>
+        <note>{0} is the AppHost language display name, e.g. 'TypeScript (Node.js)'.</note>
+      </trans-unit>
+      <trans-unit id="CodegenVersionSkewWarning">
+        <source>The installed Aspire CLI version ({0}) differs from the configured Aspire SDK version ({1}). If you run into errors, run 'aspire update' to align them.</source>
+        <target state="new">The installed Aspire CLI version ({0}) differs from the configured Aspire SDK version ({1}). If you run into errors, run 'aspire update' to align them.</target>
+        <note>{0} is the CLI version, {1} is the SDK version configured in aspire.config.json.</note>
+      </trans-unit>
       <trans-unit id="CommandNotSupportedWithSingleFileAppHost">
         <source>This command is not yet supported with single file AppHosts.</source>
         <target state="needs-review-translation">单文件应用主机尚不支持此命令。</target>

--- a/src/Aspire.Cli/Resources/xlf/ErrorStrings.zh-Hant.xlf
+++ b/src/Aspire.Cli/Resources/xlf/ErrorStrings.zh-Hant.xlf
@@ -57,6 +57,26 @@
         <target state="new">Developer certificates are only partially trusted. Trust them interactively by running 'aspire certs trust'.</target>
         <note />
       </trans-unit>
+      <trans-unit id="CodegenDebugHeader">
+        <source>Diagnostic details:</source>
+        <target state="new">Diagnostic details:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CodegenDebugHint">
+        <source>Run with '--debug' for full diagnostic details.</source>
+        <target state="new">Run with '--debug' for full diagnostic details.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CodegenIncompatibleSdkSummary">
+        <source>{0} SDK code generation failed because the installed Aspire CLI appears to be incompatible with the configured Aspire SDK. Run 'aspire update' to align the CLI and SDK and try again.</source>
+        <target state="new">{0} SDK code generation failed because the installed Aspire CLI appears to be incompatible with the configured Aspire SDK. Run 'aspire update' to align the CLI and SDK and try again.</target>
+        <note>{0} is the AppHost language display name, e.g. 'TypeScript (Node.js)'.</note>
+      </trans-unit>
+      <trans-unit id="CodegenVersionSkewWarning">
+        <source>The installed Aspire CLI version ({0}) differs from the configured Aspire SDK version ({1}). If you run into errors, run 'aspire update' to align them.</source>
+        <target state="new">The installed Aspire CLI version ({0}) differs from the configured Aspire SDK version ({1}). If you run into errors, run 'aspire update' to align them.</target>
+        <note>{0} is the CLI version, {1} is the SDK version configured in aspire.config.json.</note>
+      </trans-unit>
       <trans-unit id="CommandNotSupportedWithSingleFileAppHost">
         <source>This command is not yet supported with single file AppHosts.</source>
         <target state="needs-review-translation">單一檔案 AppHost 尚不支援此命令。</target>

--- a/src/Aspire.Cli/Utils/CliPathHelper.cs
+++ b/src/Aspire.Cli/Utils/CliPathHelper.cs
@@ -220,7 +220,7 @@ internal static class CliPathHelper
     /// <see cref="CleanupStaleCliSockets(string, TimeSpan, TimeProvider)"/>.
     /// </summary>
     /// <remarks>
-    /// Unlike <see cref="BackchannelConstants.CleanupOrphanedSockets(string, string, int)"/>,
+    /// Unlike <see cref="BackchannelConstants.CleanupOrphanedSockets"/>,
     /// CLI sockets don't encode the process ID in their filename — they're created with a random
     /// GUID-style suffix — so the only reliable signal we have for "this is stale" is the file's
     /// mtime. We pick a generous default threshold so an in-flight long-running run never has its

--- a/src/Aspire.Cli/Utils/CliPathHelper.cs
+++ b/src/Aspire.Cli/Utils/CliPathHelper.cs
@@ -11,6 +11,13 @@ internal static class CliPathHelper
 {
     internal const string AspireHomeEnvironmentVariable = "ASPIRE_HOME";
 
+    // The maximum age before a leftover cli.sock.* file in the runtime sockets directory is
+    // pruned. 24 hours is comfortably longer than any legitimate Aspire CLI run and short enough
+    // that stale entries don't pile up indefinitely after crashes (see issue #16709).
+    internal static readonly TimeSpan s_staleSocketThreshold = TimeSpan.FromHours(24);
+
+    private static int s_socketDirectorySwept;
+
     internal static string GetAspireHomeDirectory(string? processPath = null, ILogger? logger = null)
     {
         var effectiveProcessPath = processPath ?? Environment.ProcessPath;
@@ -205,11 +212,62 @@ internal static class CliPathHelper
             ? CreateSocketName(socketPrefix)
             : CreateSocketPath(socketPrefix);
 
+    /// <summary>
+    /// Prunes leftover CLI socket files from <c>~/.aspire/cli/runtime/sockets/</c> whose last
+    /// modified timestamp is older than <paramref name="maxAge"/>. Returns the number of files
+    /// that were deleted. Exceptions from individual file deletions are swallowed so a single
+    /// permission-denied or locked file can't break startup. Exposed for tests via
+    /// <see cref="CleanupStaleCliSockets(string, TimeSpan, TimeProvider)"/>.
+    /// </summary>
+    /// <remarks>
+    /// Unlike <see cref="BackchannelConstants.CleanupOrphanedSockets(string, string, int)"/>,
+    /// CLI sockets don't encode the process ID in their filename — they're created with a random
+    /// GUID-style suffix — so the only reliable signal we have for "this is stale" is the file's
+    /// mtime. We pick a generous default threshold so an in-flight long-running run never has its
+    /// socket pruned out from under it.
+    /// </remarks>
+    internal static int CleanupStaleCliSockets(string socketDirectory, TimeSpan maxAge, TimeProvider? timeProvider = null)
+    {
+        if (!Directory.Exists(socketDirectory))
+        {
+            return 0;
+        }
+
+        var now = (timeProvider ?? TimeProvider.System).GetUtcNow();
+        var deleted = 0;
+
+        foreach (var path in Directory.EnumerateFiles(socketDirectory, "cli.sock.*"))
+        {
+            try
+            {
+                var lastWrite = File.GetLastWriteTimeUtc(path);
+                if (now - lastWrite >= maxAge)
+                {
+                    File.Delete(path);
+                    deleted++;
+                }
+            }
+            catch
+            {
+                // Best-effort cleanup; one bad file should not block CLI startup.
+            }
+        }
+
+        return deleted;
+    }
+
     private static string CreateSocketPath(string socketPrefix)
     {
         var homeDirectory = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
         var socketPath = BackchannelConstants.ComputeCliSocketPath(homeDirectory, socketPrefix);
-        Directory.CreateDirectory(Path.GetDirectoryName(socketPath)!);
+        var socketDirectory = Path.GetDirectoryName(socketPath)!;
+        Directory.CreateDirectory(socketDirectory);
+
+        if (Interlocked.CompareExchange(ref s_socketDirectorySwept, 1, 0) == 0)
+        {
+            CleanupStaleCliSockets(socketDirectory, s_staleSocketThreshold);
+        }
+
         return socketPath;
     }
 

--- a/src/Aspire.Cli/Utils/CliPathHelper.cs
+++ b/src/Aspire.Cli/Utils/CliPathHelper.cs
@@ -11,7 +11,7 @@ internal static class CliPathHelper
 {
     internal const string AspireHomeEnvironmentVariable = "ASPIRE_HOME";
 
-    // The maximum age before a leftover cli.sock.* file in the runtime sockets directory is
+    // The maximum age before a leftover CLI socket file in the runtime sockets directory is
     // pruned. 24 hours is comfortably longer than any legitimate Aspire CLI run and short enough
     // that stale entries don't pile up indefinitely after crashes (see issue #16709).
     internal static readonly TimeSpan s_staleSocketThreshold = TimeSpan.FromHours(24);
@@ -236,7 +236,8 @@ internal static class CliPathHelper
         var now = (timeProvider ?? TimeProvider.System).GetUtcNow();
         var deleted = 0;
 
-        foreach (var path in Directory.EnumerateFiles(socketDirectory, "cli.sock.*"))
+        var socketFileSearchPattern = BackchannelConstants.ComputeSocketFileSearchPattern("cli.sock");
+        foreach (var path in Directory.EnumerateFiles(socketDirectory, socketFileSearchPattern))
         {
             try
             {

--- a/src/Aspire.Hosting.RemoteHost/AssemblyLoader.cs
+++ b/src/Aspire.Hosting.RemoteHost/AssemblyLoader.cs
@@ -3,6 +3,7 @@
 
 using System.Reflection;
 using System.Runtime.Loader;
+using Aspire.Hosting.RemoteHost.CodeGeneration;
 using Aspire.Hosting.RemoteHost.Diagnostics;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
@@ -66,6 +67,54 @@ internal sealed class AssemblyLoader
             activity.SetError(ex);
             throw;
         }
+    }
+
+    /// <summary>
+    /// Snapshots the currently loaded ATS integration assemblies as
+    /// <see cref="CodeGenerationLoadedAssemblyInfo"/> records suitable for inclusion in a
+    /// diagnostic payload. Returns an empty list when no assemblies have been loaded yet so the
+    /// caller can include the result unconditionally.
+    /// </summary>
+    /// <remarks>
+    /// This intentionally avoids forcing <see cref="GetAssemblies"/> to run if it hasn't already,
+    /// because we want to capture the actual state at the moment a failure occurred rather than
+    /// triggering the load (which may itself throw).
+    /// </remarks>
+    public IReadOnlyList<CodeGenerationLoadedAssemblyInfo> GetLoadedAssemblyDiagnostics()
+    {
+        var infos = new List<CodeGenerationLoadedAssemblyInfo>();
+        if (!_assemblies.IsValueCreated)
+        {
+            return infos;
+        }
+
+        foreach (var assembly in _assemblies.Value)
+        {
+            infos.Add(CreateAssemblyInfo(assembly));
+        }
+
+        return infos;
+    }
+
+    private static CodeGenerationLoadedAssemblyInfo CreateAssemblyInfo(Assembly assembly)
+    {
+        var name = assembly.GetName();
+        string? location;
+        try
+        {
+            location = string.IsNullOrEmpty(assembly.Location) ? null : assembly.Location;
+        }
+        catch
+        {
+            location = null;
+        }
+
+        return new CodeGenerationLoadedAssemblyInfo
+        {
+            Name = name.Name ?? assembly.FullName ?? "<unknown>",
+            InformationalVersion = CodeGenerationDiagnosticBuilder.GetInformationalVersion(assembly),
+            Location = location
+        };
     }
 
     internal static IReadOnlyList<string> GetAssemblyNamesToLoad(

--- a/src/Aspire.Hosting.RemoteHost/CodeGeneration/CodeGenerationDiagnostic.cs
+++ b/src/Aspire.Hosting.RemoteHost/CodeGeneration/CodeGenerationDiagnostic.cs
@@ -225,7 +225,10 @@ internal static class CodeGenerationDiagnosticBuilder
         string? runtimePath = null;
         var loaded = new List<CodeGenerationLoadedAssemblyInfo>();
 
-        var runtimeAspireHosting = typeof(global::Aspire.Hosting.RemoteHost.AssemblyLoader).Assembly;
+        // Locate the actually-loaded Aspire.Hosting assembly (the runtime that backed the failing
+        // codegen). We avoid `typeof(Aspire.Hosting.X).Assembly` because Aspire.Hosting.RemoteHost
+        // does not reference Aspire.Hosting; if for any reason it isn't in AppDomain.Assemblies we
+        // leave the version null rather than substituting a sibling like Aspire.Hosting.RemoteHost.
         var aspireHostingAssembly = AppDomain.CurrentDomain
             .GetAssemblies()
             .FirstOrDefault(a => string.Equals(a.GetName().Name, "Aspire.Hosting", StringComparison.OrdinalIgnoreCase));
@@ -234,11 +237,6 @@ internal static class CodeGenerationDiagnosticBuilder
         {
             runtimeVersion = GetInformationalVersion(aspireHostingAssembly);
             runtimePath = TryGetLocation(aspireHostingAssembly);
-        }
-        else if (runtimeAspireHosting is not null)
-        {
-            runtimeVersion = GetInformationalVersion(runtimeAspireHosting);
-            runtimePath = TryGetLocation(runtimeAspireHosting);
         }
 
         if (assemblyLoader is null)

--- a/src/Aspire.Hosting.RemoteHost/CodeGeneration/CodeGenerationDiagnostic.cs
+++ b/src/Aspire.Hosting.RemoteHost/CodeGeneration/CodeGenerationDiagnostic.cs
@@ -1,0 +1,299 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Reflection;
+using Microsoft.Extensions.Logging;
+using StreamJsonRpc;
+
+namespace Aspire.Hosting.RemoteHost.CodeGeneration;
+
+/// <summary>
+/// JSON-RPC error codes used by the AppHost server for code-generation failures.
+/// </summary>
+/// <remarks>
+/// Values are within the JSON-RPC reserved server-error range (<c>-32000</c> to <c>-32099</c>).
+/// </remarks>
+internal static class CodeGenerationErrorCodes
+{
+    /// <summary>
+    /// The AppHost server failed to load or JIT-compile reflection-based code generation
+    /// metadata. Typically caused by an assembly-version mismatch between the bundled
+    /// <c>Aspire.Hosting</c> runtime and the user-restored integration assemblies.
+    /// </summary>
+    public const int IncompatibleAspireSdk = -32050;
+}
+
+/// <summary>
+/// Structured payload describing a reflection-load failure encountered while servicing a
+/// code-generation RPC method.
+/// </summary>
+/// <remarks>
+/// Carried as <see cref="LocalRpcException.ErrorData"/> from the server to the CLI so that the
+/// CLI can render an actionable diagnostic. The shape is intentionally flat and JSON-serializable
+/// so it survives the StreamJsonRpc <c>SystemTextJsonFormatter</c> round-trip without requiring
+/// shared types between the server and the CLI.
+/// </remarks>
+internal sealed class CodeGenerationDiagnostic
+{
+    /// <summary>
+    /// Gets the CLR type name of the original exception (e.g. <c>System.TypeLoadException</c>).
+    /// </summary>
+    public string OriginalExceptionType { get; init; } = "";
+
+    /// <summary>
+    /// Gets the name of the type that failed to load, if known. Populated from
+    /// <see cref="TypeLoadException.TypeName"/> when available.
+    /// </summary>
+    public string? TypeName { get; init; }
+
+    /// <summary>
+    /// Gets the name of the missing member, if the failure was a
+    /// <see cref="MissingMethodException"/> or <see cref="MissingFieldException"/>.
+    /// </summary>
+    public string? MemberName { get; init; }
+
+    /// <summary>
+    /// Gets the <see cref="AssemblyInformationalVersionAttribute"/> value of the bundled
+    /// <c>Aspire.Hosting</c> assembly on the server side, if it could be discovered.
+    /// </summary>
+    public string? RuntimeAspireHostingVersion { get; init; }
+
+    /// <summary>
+    /// Gets the on-disk location of the bundled <c>Aspire.Hosting</c> assembly, if it could be
+    /// discovered.
+    /// </summary>
+    public string? RuntimeAspireHostingPath { get; init; }
+
+    /// <summary>
+    /// Gets the loaded <c>Aspire.Hosting*</c> integration assemblies that were probed by the
+    /// AppHost server at the time of the failure.
+    /// </summary>
+    public List<CodeGenerationLoadedAssemblyInfo> LoadedAssemblies { get; init; } = [];
+
+    /// <summary>
+    /// Gets a short, language-agnostic remediation hint suitable for surfacing to AppHost
+    /// authors (e.g. instructing them to run <c>aspire update</c>).
+    /// </summary>
+    public string? RemediationHint { get; init; }
+}
+
+/// <summary>
+/// Identity information for a single loaded assembly captured at the time of a code-generation
+/// failure.
+/// </summary>
+internal sealed class CodeGenerationLoadedAssemblyInfo
+{
+    /// <summary>
+    /// Gets the simple name of the assembly (e.g. <c>Aspire.Hosting.JavaScript</c>).
+    /// </summary>
+    public string Name { get; init; } = "";
+
+    /// <summary>
+    /// Gets the value of the assembly's <see cref="AssemblyInformationalVersionAttribute"/>
+    /// when present, otherwise the assembly version.
+    /// </summary>
+    public string? InformationalVersion { get; init; }
+
+    /// <summary>
+    /// Gets the on-disk location of the assembly when available.
+    /// </summary>
+    public string? Location { get; init; }
+}
+
+/// <summary>
+/// Builds <see cref="CodeGenerationDiagnostic"/> payloads from caught reflection-load
+/// exceptions and converts them into <see cref="LocalRpcException"/> instances that StreamJsonRpc
+/// will propagate to the CLI with structured error data.
+/// </summary>
+internal static class CodeGenerationDiagnosticBuilder
+{
+    private const string SafeMessage =
+        "Aspire SDK code generation failed because the installed Aspire CLI appears to be incompatible with the configured SDK version. Run 'aspire update' to align the CLI and SDK and try again.";
+
+    private const string RemediationHint =
+        "Run 'aspire update' to align the installed Aspire CLI with the configured SDK version, then retry.";
+
+    /// <summary>
+    /// Inspects the supplied exception (and any inner exceptions) and, if it looks like a
+    /// reflection/load failure, returns a <see cref="LocalRpcException"/> carrying a
+    /// <see cref="CodeGenerationDiagnostic"/> in its <see cref="LocalRpcException.ErrorData"/>.
+    /// Returns <see langword="null"/> for exceptions that are not reflection-load failures.
+    /// </summary>
+    public static LocalRpcException? TryCreateRpcException(Exception exception, AssemblyLoader? assemblyLoader, ILogger? logger = null)
+    {
+        var loadException = FindReflectionLoadException(exception);
+        if (loadException is null)
+        {
+            return null;
+        }
+
+        var diagnostic = BuildDiagnostic(loadException, assemblyLoader, logger);
+
+        return new LocalRpcException(SafeMessage)
+        {
+            ErrorCode = CodeGenerationErrorCodes.IncompatibleAspireSdk,
+            ErrorData = diagnostic
+        };
+    }
+
+    /// <summary>
+    /// Builds a <see cref="CodeGenerationDiagnostic"/> from the supplied exception without
+    /// wrapping it in a <see cref="LocalRpcException"/>. Exposed for testing.
+    /// </summary>
+    internal static CodeGenerationDiagnostic BuildDiagnostic(Exception exception, AssemblyLoader? assemblyLoader, ILogger? logger = null)
+    {
+        string? typeName = null;
+        string? memberName = null;
+
+        switch (exception)
+        {
+            case TypeLoadException tle:
+                typeName = tle.TypeName;
+                break;
+            case MissingMethodException mme:
+                memberName = SanitizeMemberMessage(mme.Message);
+                break;
+            case MissingFieldException mfe:
+                memberName = SanitizeMemberMessage(mfe.Message);
+                break;
+            case FileLoadException fle:
+                typeName = fle.FileName;
+                break;
+            case BadImageFormatException bife:
+                typeName = bife.FileName;
+                break;
+        }
+
+        var (runtimeVersion, runtimePath, loadedAssemblies) = CaptureLoadedAssemblies(assemblyLoader, logger);
+
+        return new CodeGenerationDiagnostic
+        {
+            OriginalExceptionType = exception.GetType().FullName ?? exception.GetType().Name,
+            TypeName = typeName,
+            MemberName = memberName,
+            RuntimeAspireHostingVersion = runtimeVersion,
+            RuntimeAspireHostingPath = runtimePath,
+            LoadedAssemblies = loadedAssemblies,
+            RemediationHint = RemediationHint
+        };
+    }
+
+    /// <summary>
+    /// Walks the exception chain and returns the first inner exception that looks like a
+    /// reflection-load failure, or <see langword="null"/> if none is found.
+    /// </summary>
+    internal static Exception? FindReflectionLoadException(Exception? exception)
+    {
+        for (var current = exception; current is not null; current = current.InnerException)
+        {
+            if (current is ReflectionTypeLoadException rtle)
+            {
+                foreach (var loaderException in rtle.LoaderExceptions)
+                {
+                    if (loaderException is not null && IsReflectionLoadException(loaderException))
+                    {
+                        return loaderException;
+                    }
+                }
+
+                // No specific loader exception matched, but the RTLE itself is a reflection-load
+                // failure — fall through and return it from the IsReflectionLoadException check below.
+            }
+
+            if (IsReflectionLoadException(current))
+            {
+                return current;
+            }
+        }
+
+        return null;
+    }
+
+    private static bool IsReflectionLoadException(Exception exception) => exception
+        is TypeLoadException
+        or MissingMethodException
+        or MissingFieldException
+        or FileLoadException
+        or BadImageFormatException
+        or ReflectionTypeLoadException;
+
+    private static (string? Version, string? Path, List<CodeGenerationLoadedAssemblyInfo> Assemblies) CaptureLoadedAssemblies(
+        AssemblyLoader? assemblyLoader,
+        ILogger? logger)
+    {
+        string? runtimeVersion = null;
+        string? runtimePath = null;
+        var loaded = new List<CodeGenerationLoadedAssemblyInfo>();
+
+        var runtimeAspireHosting = typeof(global::Aspire.Hosting.RemoteHost.AssemblyLoader).Assembly;
+        var aspireHostingAssembly = AppDomain.CurrentDomain
+            .GetAssemblies()
+            .FirstOrDefault(a => string.Equals(a.GetName().Name, "Aspire.Hosting", StringComparison.OrdinalIgnoreCase));
+
+        if (aspireHostingAssembly is not null)
+        {
+            runtimeVersion = GetInformationalVersion(aspireHostingAssembly);
+            runtimePath = TryGetLocation(aspireHostingAssembly);
+        }
+        else if (runtimeAspireHosting is not null)
+        {
+            runtimeVersion = GetInformationalVersion(runtimeAspireHosting);
+            runtimePath = TryGetLocation(runtimeAspireHosting);
+        }
+
+        if (assemblyLoader is null)
+        {
+            return (runtimeVersion, runtimePath, loaded);
+        }
+
+        try
+        {
+            foreach (var info in assemblyLoader.GetLoadedAssemblyDiagnostics())
+            {
+                loaded.Add(info);
+            }
+        }
+        catch (Exception ex)
+        {
+            logger?.LogDebug(ex, "Failed to capture loaded assembly diagnostics while building code-generation diagnostic.");
+        }
+
+        return (runtimeVersion, runtimePath, loaded);
+    }
+
+    internal static string? GetInformationalVersion(Assembly assembly)
+    {
+        var informational = assembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>()?.InformationalVersion;
+        if (!string.IsNullOrWhiteSpace(informational))
+        {
+            return informational;
+        }
+
+        return assembly.GetName().Version?.ToString();
+    }
+
+    private static string? TryGetLocation(Assembly assembly)
+    {
+        try
+        {
+            return string.IsNullOrEmpty(assembly.Location) ? null : assembly.Location;
+        }
+        catch
+        {
+            return null;
+        }
+    }
+
+    private static string? SanitizeMemberMessage(string? message)
+    {
+        if (string.IsNullOrWhiteSpace(message))
+        {
+            return null;
+        }
+
+        // The CLR's Missing*Exception messages are typically of the form
+        //   "Method not found: 'System.Void Aspire.Hosting.X.Y.Z(Aspire.Hosting.Foo)'."
+        // We keep them verbatim; the CLI controls whether they are surfaced to the user.
+        return message;
+    }
+}

--- a/src/Aspire.Hosting.RemoteHost/CodeGeneration/CodeGenerationService.cs
+++ b/src/Aspire.Hosting.RemoteHost/CodeGeneration/CodeGenerationService.cs
@@ -19,6 +19,7 @@ internal sealed class CodeGenerationService
     private readonly JsonRpcAuthenticationState _authenticationState;
     private readonly AtsContextFactory _atsContextFactory;
     private readonly CodeGeneratorResolver _resolver;
+    private readonly AssemblyLoader _assemblyLoader;
     private readonly ILogger<CodeGenerationService> _logger;
     private readonly RemoteHostProfilingTelemetry _profilingTelemetry;
 
@@ -26,12 +27,14 @@ internal sealed class CodeGenerationService
         JsonRpcAuthenticationState authenticationState,
         AtsContextFactory atsContextFactory,
         CodeGeneratorResolver resolver,
+        AssemblyLoader assemblyLoader,
         ILogger<CodeGenerationService> logger,
         RemoteHostProfilingTelemetry profilingTelemetry)
     {
         _authenticationState = authenticationState;
         _atsContextFactory = atsContextFactory;
         _resolver = resolver;
+        _assemblyLoader = assemblyLoader;
         _logger = logger;
         _profilingTelemetry = profilingTelemetry;
     }
@@ -85,6 +88,11 @@ internal sealed class CodeGenerationService
         {
             activity.SetError(ex);
             _logger.LogError(ex, "<< getCapabilities() failed");
+            var wrapped = CodeGenerationDiagnosticBuilder.TryCreateRpcException(ex, _assemblyLoader, _logger);
+            if (wrapped is not null)
+            {
+                throw wrapped;
+            }
             throw;
         }
     }
@@ -251,6 +259,11 @@ internal sealed class CodeGenerationService
         {
             activity.SetError(ex);
             _logger.LogError(ex, "<< generateCode({Language}) failed", language);
+            var wrapped = CodeGenerationDiagnosticBuilder.TryCreateRpcException(ex, _assemblyLoader, _logger);
+            if (wrapped is not null)
+            {
+                throw wrapped;
+            }
             throw;
         }
     }

--- a/src/Shared/BackchannelConstants.cs
+++ b/src/Shared/BackchannelConstants.cs
@@ -286,6 +286,17 @@ internal static class BackchannelConstants
     }
 
     /// <summary>
+    /// Computes the search pattern for randomized socket files created with the specified logical
+    /// socket prefix.
+    /// </summary>
+    public static string ComputeSocketFileSearchPattern(string socketPrefix)
+    {
+        ArgumentException.ThrowIfNullOrEmpty(socketPrefix);
+
+        return $"{GetCompactCliSocketPrefix(socketPrefix)}{new string('?', CompactInstanceIdLength)}";
+    }
+
+    /// <summary>
     /// Computes the socket path prefix for finding compact sockets.
     /// </summary>
     /// <remarks>

--- a/tests/Aspire.Cli.Tests/Projects/AppHostCodeGenerationDiagnosticWireContractTests.cs
+++ b/tests/Aspire.Cli.Tests/Projects/AppHostCodeGenerationDiagnosticWireContractTests.cs
@@ -1,0 +1,99 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Text.Json;
+using Aspire.Cli.Backchannel;
+using Aspire.Cli.Projects;
+
+namespace Aspire.Cli.Tests.Projects;
+
+/// <summary>
+/// Guards the wire contract between the AppHost server's reflection-based
+/// <c>SystemTextJsonFormatter</c> (default <see cref="JsonSerializerOptions"/>, no naming policy,
+/// PascalCase on the wire) and the CLI source-generated
+/// <see cref="BackchannelJsonSerializerContext"/>. If either side adopts a naming policy or
+/// renames a property, this test must catch it before the diagnostic silently degrades to
+/// "all null" on the CLI as in issue #16709.
+/// </summary>
+public class AppHostCodeGenerationDiagnosticWireContractTests
+{
+    [Fact]
+    public void Deserialize_PascalCaseServerPayload_PopulatesAllFields()
+    {
+        const string serverJson =
+            """
+            {
+              "OriginalExceptionType": "System.TypeLoadException",
+              "TypeName": "Aspire.Hosting.SomeType",
+              "MemberName": "Void Foo()",
+              "RuntimeAspireHostingVersion": "13.4.0-preview.1.26218.1",
+              "RuntimeAspireHostingPath": "C:\\aspire\\Aspire.Hosting.dll",
+              "LoadedAssemblies": [
+                {
+                  "Name": "Aspire.Hosting.CodeGeneration.TypeScript",
+                  "InformationalVersion": "13.4.0-preview.1.26227.1",
+                  "Location": "C:\\aspire\\Aspire.Hosting.CodeGeneration.TypeScript.dll"
+                }
+              ],
+              "RemediationHint": "Run 'aspire update'."
+            }
+            """;
+
+        var diagnostic = JsonSerializer.Deserialize(
+            serverJson,
+            BackchannelJsonSerializerContext.Default.AppHostCodeGenerationDiagnostic);
+
+        Assert.NotNull(diagnostic);
+        Assert.Equal("System.TypeLoadException", diagnostic.OriginalExceptionType);
+        Assert.Equal("Aspire.Hosting.SomeType", diagnostic.TypeName);
+        Assert.Equal("Void Foo()", diagnostic.MemberName);
+        Assert.Equal("13.4.0-preview.1.26218.1", diagnostic.RuntimeAspireHostingVersion);
+        Assert.Equal("C:\\aspire\\Aspire.Hosting.dll", diagnostic.RuntimeAspireHostingPath);
+        Assert.Equal("Run 'aspire update'.", diagnostic.RemediationHint);
+        var loaded = Assert.Single(diagnostic.LoadedAssemblies);
+        Assert.Equal("Aspire.Hosting.CodeGeneration.TypeScript", loaded.Name);
+        Assert.Equal("13.4.0-preview.1.26227.1", loaded.InformationalVersion);
+        Assert.Equal("C:\\aspire\\Aspire.Hosting.CodeGeneration.TypeScript.dll", loaded.Location);
+    }
+
+    [Fact]
+    public void Roundtrip_UsingRpcFormatterOptions_PreservesAllFields()
+    {
+        // Use the exact same JsonSerializerOptions the StreamJsonRpc formatter uses on the CLI
+        // side. This catches the case where the wire-level deserializer differs from the typed
+        // JsonTypeInfo<T> deserializer used by TryReadDiagnostic.
+        var options = BackchannelJsonSerializerContext.CreateJsonSerializerOptions();
+
+        var source = new AppHostCodeGenerationDiagnostic
+        {
+            OriginalExceptionType = "System.TypeLoadException",
+            TypeName = "Aspire.Hosting.SomeType",
+            MemberName = "Void Foo()",
+            RuntimeAspireHostingVersion = "13.4.0-preview.1.26218.1",
+            RuntimeAspireHostingPath = "/aspire/Aspire.Hosting.dll",
+            LoadedAssemblies =
+            [
+                new AppHostLoadedAssemblyInfo
+                {
+                    Name = "Aspire.Hosting.CodeGeneration.TypeScript",
+                    InformationalVersion = "13.4.0-preview.1.26227.1",
+                    Location = "/aspire/Aspire.Hosting.CodeGeneration.TypeScript.dll"
+                }
+            ],
+            RemediationHint = "Run 'aspire update'."
+        };
+
+        var json = JsonSerializer.Serialize(source, typeof(AppHostCodeGenerationDiagnostic), options);
+        var roundtripped = (AppHostCodeGenerationDiagnostic?)JsonSerializer.Deserialize(json, typeof(AppHostCodeGenerationDiagnostic), options);
+
+        Assert.NotNull(roundtripped);
+        Assert.Equal(source.OriginalExceptionType, roundtripped.OriginalExceptionType);
+        Assert.Equal(source.TypeName, roundtripped.TypeName);
+        Assert.Equal(source.MemberName, roundtripped.MemberName);
+        Assert.Equal(source.RuntimeAspireHostingVersion, roundtripped.RuntimeAspireHostingVersion);
+        Assert.Equal(source.RemediationHint, roundtripped.RemediationHint);
+        var loaded = Assert.Single(roundtripped.LoadedAssemblies);
+        Assert.Equal(source.LoadedAssemblies[0].Name, loaded.Name);
+        Assert.Equal(source.LoadedAssemblies[0].InformationalVersion, loaded.InformationalVersion);
+    }
+}

--- a/tests/Aspire.Cli.Tests/Projects/GuestAppHostProjectSkewTests.cs
+++ b/tests/Aspire.Cli.Tests/Projects/GuestAppHostProjectSkewTests.cs
@@ -10,11 +10,18 @@ public class GuestAppHostProjectSkewTests
     [Theory]
     [InlineData("13.1.0", "13.1.0", false)]
     [InlineData("13.1.0-preview.1.26218.1", "13.1.0-preview.1.26218.1", false)]
-    [InlineData("13.1.0-preview.1.26218.1", "13.1.0-preview.1.26227.1", false)]
+    // Build metadata (everything after '+') is SemVer-spec ignored for precedence.
+    [InlineData("13.1.0-preview.1.26218.1+abc", "13.1.0-preview.1.26218.1+def", false)]
+    // Issue #16709 reproduction: same M.M.P prerelease tag with different daily build numbers
+    // is detected as skew (this was the exact failure case).
+    [InlineData("13.1.0-preview.1.26218.1", "13.1.0-preview.1.26227.1", true)]
+    // Release vs prerelease of the same M.M.P is skew.
+    [InlineData("13.1.0", "13.1.0-preview.1", true)]
+    [InlineData("13.1.0-preview.1", "13.1.0", true)]
     [InlineData("13.1.0", "13.2.0", true)]
     [InlineData("13.1.0", "14.0.0", true)]
     [InlineData("13.1.0", "13.1.1", true)]
-    public void IsKnownIncompatibleSkew_DetectsMajorMinorPatchChanges(string cli, string sdk, bool expected)
+    public void IsKnownIncompatibleSkew_DetectsMajorMinorPatchAndPrereleaseChanges(string cli, string sdk, bool expected)
     {
         var result = GuestAppHostProject.IsKnownIncompatibleSkew(cli, sdk);
 

--- a/tests/Aspire.Cli.Tests/Projects/GuestAppHostProjectSkewTests.cs
+++ b/tests/Aspire.Cli.Tests/Projects/GuestAppHostProjectSkewTests.cs
@@ -1,0 +1,39 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Aspire.Cli.Projects;
+
+namespace Aspire.Cli.Tests.Projects;
+
+public class GuestAppHostProjectSkewTests
+{
+    [Theory]
+    [InlineData("13.1.0", "13.1.0", false)]
+    [InlineData("13.1.0-preview.1.26218.1", "13.1.0-preview.1.26218.1", false)]
+    [InlineData("13.1.0-preview.1.26218.1", "13.1.0-preview.1.26227.1", false)]
+    [InlineData("13.1.0", "13.2.0", true)]
+    [InlineData("13.1.0", "14.0.0", true)]
+    [InlineData("13.1.0", "13.1.1", true)]
+    public void IsKnownIncompatibleSkew_DetectsMajorMinorPatchChanges(string cli, string sdk, bool expected)
+    {
+        var result = GuestAppHostProject.IsKnownIncompatibleSkew(cli, sdk);
+
+        Assert.Equal(expected, result);
+    }
+
+    [Fact]
+    public void IsKnownIncompatibleSkew_FallsBackToStringCompareForUnparseable()
+    {
+        Assert.True(GuestAppHostProject.IsKnownIncompatibleSkew("not-a-version", "also-not-a-version-but-different"));
+        Assert.False(GuestAppHostProject.IsKnownIncompatibleSkew("identical", "identical"));
+    }
+
+    [Theory]
+    [InlineData("13.1.0+build.5", "13.1.0")]
+    [InlineData("13.1.0-preview.1+sha.abc123", "13.1.0-preview.1")]
+    [InlineData("13.1.0", "13.1.0")]
+    public void NormalizeVersion_StripsBuildSuffix(string input, string expected)
+    {
+        Assert.Equal(expected, GuestAppHostProject.NormalizeVersion(input));
+    }
+}

--- a/tests/Aspire.Cli.Tests/Utils/CliPathHelperTests.cs
+++ b/tests/Aspire.Cli.Tests/Utils/CliPathHelperTests.cs
@@ -301,20 +301,19 @@ public class CliPathHelperTests(ITestOutputHelper outputHelper)
     [Fact]
     public void CleanupStaleCliSockets_DeletesFilesOlderThanThreshold()
     {
-        var tempDir = Path.Combine(Path.GetTempPath(), "aspire-cli-sockets-" + Guid.NewGuid().ToString("N"));
-        Directory.CreateDirectory(tempDir);
+        var tempDir = Directory.CreateTempSubdirectory("aspire-cli-sockets-");
         try
         {
-            var staleFile = Path.Combine(tempDir, "cli.sock.stale");
+            var staleFile = Path.Combine(tempDir.FullName, "cli.sock.stale");
             File.WriteAllText(staleFile, string.Empty);
-            var freshFile = Path.Combine(tempDir, "cli.sock.fresh");
+            var freshFile = Path.Combine(tempDir.FullName, "cli.sock.fresh");
             File.WriteAllText(freshFile, string.Empty);
 
             var fakeTime = new FakeTimeProvider(DateTimeOffset.UtcNow);
             File.SetLastWriteTimeUtc(staleFile, fakeTime.GetUtcNow().UtcDateTime - TimeSpan.FromHours(48));
             File.SetLastWriteTimeUtc(freshFile, fakeTime.GetUtcNow().UtcDateTime - TimeSpan.FromMinutes(5));
 
-            var deleted = CliPathHelper.CleanupStaleCliSockets(tempDir, TimeSpan.FromHours(24), fakeTime);
+            var deleted = CliPathHelper.CleanupStaleCliSockets(tempDir.FullName, TimeSpan.FromHours(24), fakeTime);
 
             Assert.Equal(1, deleted);
             Assert.False(File.Exists(staleFile));
@@ -322,27 +321,26 @@ public class CliPathHelperTests(ITestOutputHelper outputHelper)
         }
         finally
         {
-            Directory.Delete(tempDir, recursive: true);
+            tempDir.Delete(recursive: true);
         }
     }
 
     [Fact]
     public void CleanupStaleCliSockets_OnlyMatchesCliSockPrefix()
     {
-        var tempDir = Path.Combine(Path.GetTempPath(), "aspire-cli-sockets-" + Guid.NewGuid().ToString("N"));
-        Directory.CreateDirectory(tempDir);
+        var tempDir = Directory.CreateTempSubdirectory("aspire-cli-sockets-");
         try
         {
-            var matching = Path.Combine(tempDir, "cli.sock.abc123");
+            var matching = Path.Combine(tempDir.FullName, "cli.sock.abc123");
             File.WriteAllText(matching, string.Empty);
-            var unrelated = Path.Combine(tempDir, "apphost.sock.xyz");
+            var unrelated = Path.Combine(tempDir.FullName, "apphost.sock.xyz");
             File.WriteAllText(unrelated, string.Empty);
 
             var fakeTime = new FakeTimeProvider(DateTimeOffset.UtcNow);
             File.SetLastWriteTimeUtc(matching, fakeTime.GetUtcNow().UtcDateTime - TimeSpan.FromHours(48));
             File.SetLastWriteTimeUtc(unrelated, fakeTime.GetUtcNow().UtcDateTime - TimeSpan.FromHours(48));
 
-            var deleted = CliPathHelper.CleanupStaleCliSockets(tempDir, TimeSpan.FromHours(24), fakeTime);
+            var deleted = CliPathHelper.CleanupStaleCliSockets(tempDir.FullName, TimeSpan.FromHours(24), fakeTime);
 
             Assert.Equal(1, deleted);
             Assert.False(File.Exists(matching));
@@ -350,14 +348,17 @@ public class CliPathHelperTests(ITestOutputHelper outputHelper)
         }
         finally
         {
-            Directory.Delete(tempDir, recursive: true);
+            tempDir.Delete(recursive: true);
         }
     }
 
     [Fact]
     public void CleanupStaleCliSockets_MissingDirectoryIsNoOp()
     {
-        var missingDir = Path.Combine(Path.GetTempPath(), "aspire-cli-sockets-missing-" + Guid.NewGuid().ToString("N"));
+        // Create-then-delete to guarantee a unique path we know doesn't exist on disk.
+        var probe = Directory.CreateTempSubdirectory("aspire-cli-sockets-missing-");
+        var missingDir = probe.FullName;
+        probe.Delete();
 
         var deleted = CliPathHelper.CleanupStaleCliSockets(missingDir, TimeSpan.FromHours(24));
 
@@ -367,17 +368,16 @@ public class CliPathHelperTests(ITestOutputHelper outputHelper)
     [Fact]
     public void CleanupStaleCliSockets_EmptyDirectoryReturnsZero()
     {
-        var tempDir = Path.Combine(Path.GetTempPath(), "aspire-cli-sockets-" + Guid.NewGuid().ToString("N"));
-        Directory.CreateDirectory(tempDir);
+        var tempDir = Directory.CreateTempSubdirectory("aspire-cli-sockets-");
         try
         {
-            var deleted = CliPathHelper.CleanupStaleCliSockets(tempDir, TimeSpan.FromHours(24));
+            var deleted = CliPathHelper.CleanupStaleCliSockets(tempDir.FullName, TimeSpan.FromHours(24));
 
             Assert.Equal(0, deleted);
         }
         finally
         {
-            Directory.Delete(tempDir, recursive: true);
+            tempDir.Delete(recursive: true);
         }
     }
 }

--- a/tests/Aspire.Cli.Tests/Utils/CliPathHelperTests.cs
+++ b/tests/Aspire.Cli.Tests/Utils/CliPathHelperTests.cs
@@ -3,6 +3,7 @@
 
 using Aspire.Cli.Acquisition;
 using Aspire.Cli.Utils;
+using Aspire.Hosting.Backchannel;
 using Microsoft.Extensions.Time.Testing;
 
 namespace Aspire.Cli.Tests.Utils;
@@ -301,19 +302,21 @@ public class CliPathHelperTests(ITestOutputHelper outputHelper)
     [Fact]
     public void CleanupStaleCliSockets_DeletesFilesOlderThanThreshold()
     {
-        var tempDir = Directory.CreateTempSubdirectory("aspire-cli-sockets-");
+        var tempRoot = Directory.CreateTempSubdirectory("aspire-cli-sockets-");
         try
         {
-            var staleFile = Path.Combine(tempDir.FullName, "cli.sock.stale");
+            var staleFile = BackchannelConstants.ComputeCliSocketPath(tempRoot.FullName, "cli.sock");
+            Directory.CreateDirectory(Path.GetDirectoryName(staleFile)!);
             File.WriteAllText(staleFile, string.Empty);
-            var freshFile = Path.Combine(tempDir.FullName, "cli.sock.fresh");
+            var freshFile = BackchannelConstants.ComputeCliSocketPath(tempRoot.FullName, "cli.sock");
             File.WriteAllText(freshFile, string.Empty);
 
             var fakeTime = new FakeTimeProvider(DateTimeOffset.UtcNow);
             File.SetLastWriteTimeUtc(staleFile, fakeTime.GetUtcNow().UtcDateTime - TimeSpan.FromHours(48));
             File.SetLastWriteTimeUtc(freshFile, fakeTime.GetUtcNow().UtcDateTime - TimeSpan.FromMinutes(5));
 
-            var deleted = CliPathHelper.CleanupStaleCliSockets(tempDir.FullName, TimeSpan.FromHours(24), fakeTime);
+            var socketDirectory = Path.GetDirectoryName(staleFile)!;
+            var deleted = CliPathHelper.CleanupStaleCliSockets(socketDirectory, TimeSpan.FromHours(24), fakeTime);
 
             Assert.Equal(1, deleted);
             Assert.False(File.Exists(staleFile));
@@ -321,26 +324,28 @@ public class CliPathHelperTests(ITestOutputHelper outputHelper)
         }
         finally
         {
-            tempDir.Delete(recursive: true);
+            tempRoot.Delete(recursive: true);
         }
     }
 
     [Fact]
     public void CleanupStaleCliSockets_OnlyMatchesCliSockPrefix()
     {
-        var tempDir = Directory.CreateTempSubdirectory("aspire-cli-sockets-");
+        var tempRoot = Directory.CreateTempSubdirectory("aspire-cli-sockets-");
         try
         {
-            var matching = Path.Combine(tempDir.FullName, "cli.sock.abc123");
+            var matching = BackchannelConstants.ComputeCliSocketPath(tempRoot.FullName, "cli.sock");
+            Directory.CreateDirectory(Path.GetDirectoryName(matching)!);
             File.WriteAllText(matching, string.Empty);
-            var unrelated = Path.Combine(tempDir.FullName, "apphost.sock.xyz");
+            var unrelated = BackchannelConstants.ComputeCliSocketPath(tempRoot.FullName, "apphost.sock");
             File.WriteAllText(unrelated, string.Empty);
 
             var fakeTime = new FakeTimeProvider(DateTimeOffset.UtcNow);
             File.SetLastWriteTimeUtc(matching, fakeTime.GetUtcNow().UtcDateTime - TimeSpan.FromHours(48));
             File.SetLastWriteTimeUtc(unrelated, fakeTime.GetUtcNow().UtcDateTime - TimeSpan.FromHours(48));
 
-            var deleted = CliPathHelper.CleanupStaleCliSockets(tempDir.FullName, TimeSpan.FromHours(24), fakeTime);
+            var socketDirectory = Path.GetDirectoryName(matching)!;
+            var deleted = CliPathHelper.CleanupStaleCliSockets(socketDirectory, TimeSpan.FromHours(24), fakeTime);
 
             Assert.Equal(1, deleted);
             Assert.False(File.Exists(matching));
@@ -348,7 +353,7 @@ public class CliPathHelperTests(ITestOutputHelper outputHelper)
         }
         finally
         {
-            tempDir.Delete(recursive: true);
+            tempRoot.Delete(recursive: true);
         }
     }
 

--- a/tests/Aspire.Cli.Tests/Utils/CliPathHelperTests.cs
+++ b/tests/Aspire.Cli.Tests/Utils/CliPathHelperTests.cs
@@ -3,6 +3,7 @@
 
 using Aspire.Cli.Acquisition;
 using Aspire.Cli.Utils;
+using Microsoft.Extensions.Time.Testing;
 
 namespace Aspire.Cli.Tests.Utils;
 
@@ -295,5 +296,88 @@ public class CliPathHelperTests(ITestOutputHelper outputHelper)
         File.WriteAllText(Path.Combine(binaryDir, InstallSidecarReader.SidecarFileName), $$"""{"source":"{{source}}"}""");
 
         return binaryPath;
+    }
+
+    [Fact]
+    public void CleanupStaleCliSockets_DeletesFilesOlderThanThreshold()
+    {
+        var tempDir = Path.Combine(Path.GetTempPath(), "aspire-cli-sockets-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(tempDir);
+        try
+        {
+            var staleFile = Path.Combine(tempDir, "cli.sock.stale");
+            File.WriteAllText(staleFile, string.Empty);
+            var freshFile = Path.Combine(tempDir, "cli.sock.fresh");
+            File.WriteAllText(freshFile, string.Empty);
+
+            var fakeTime = new FakeTimeProvider(DateTimeOffset.UtcNow);
+            File.SetLastWriteTimeUtc(staleFile, fakeTime.GetUtcNow().UtcDateTime - TimeSpan.FromHours(48));
+            File.SetLastWriteTimeUtc(freshFile, fakeTime.GetUtcNow().UtcDateTime - TimeSpan.FromMinutes(5));
+
+            var deleted = CliPathHelper.CleanupStaleCliSockets(tempDir, TimeSpan.FromHours(24), fakeTime);
+
+            Assert.Equal(1, deleted);
+            Assert.False(File.Exists(staleFile));
+            Assert.True(File.Exists(freshFile));
+        }
+        finally
+        {
+            Directory.Delete(tempDir, recursive: true);
+        }
+    }
+
+    [Fact]
+    public void CleanupStaleCliSockets_OnlyMatchesCliSockPrefix()
+    {
+        var tempDir = Path.Combine(Path.GetTempPath(), "aspire-cli-sockets-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(tempDir);
+        try
+        {
+            var matching = Path.Combine(tempDir, "cli.sock.abc123");
+            File.WriteAllText(matching, string.Empty);
+            var unrelated = Path.Combine(tempDir, "apphost.sock.xyz");
+            File.WriteAllText(unrelated, string.Empty);
+
+            var fakeTime = new FakeTimeProvider(DateTimeOffset.UtcNow);
+            File.SetLastWriteTimeUtc(matching, fakeTime.GetUtcNow().UtcDateTime - TimeSpan.FromHours(48));
+            File.SetLastWriteTimeUtc(unrelated, fakeTime.GetUtcNow().UtcDateTime - TimeSpan.FromHours(48));
+
+            var deleted = CliPathHelper.CleanupStaleCliSockets(tempDir, TimeSpan.FromHours(24), fakeTime);
+
+            Assert.Equal(1, deleted);
+            Assert.False(File.Exists(matching));
+            Assert.True(File.Exists(unrelated));
+        }
+        finally
+        {
+            Directory.Delete(tempDir, recursive: true);
+        }
+    }
+
+    [Fact]
+    public void CleanupStaleCliSockets_MissingDirectoryIsNoOp()
+    {
+        var missingDir = Path.Combine(Path.GetTempPath(), "aspire-cli-sockets-missing-" + Guid.NewGuid().ToString("N"));
+
+        var deleted = CliPathHelper.CleanupStaleCliSockets(missingDir, TimeSpan.FromHours(24));
+
+        Assert.Equal(0, deleted);
+    }
+
+    [Fact]
+    public void CleanupStaleCliSockets_EmptyDirectoryReturnsZero()
+    {
+        var tempDir = Path.Combine(Path.GetTempPath(), "aspire-cli-sockets-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(tempDir);
+        try
+        {
+            var deleted = CliPathHelper.CleanupStaleCliSockets(tempDir, TimeSpan.FromHours(24));
+
+            Assert.Equal(0, deleted);
+        }
+        finally
+        {
+            Directory.Delete(tempDir, recursive: true);
+        }
     }
 }

--- a/tests/Aspire.Hosting.RemoteHost.Tests/CodeGenerationDiagnosticBuilderTests.cs
+++ b/tests/Aspire.Hosting.RemoteHost.Tests/CodeGenerationDiagnosticBuilderTests.cs
@@ -1,0 +1,111 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Reflection;
+using Aspire.Hosting.RemoteHost.CodeGeneration;
+using StreamJsonRpc;
+using Xunit;
+
+namespace Aspire.Hosting.RemoteHost.Tests;
+
+public class CodeGenerationDiagnosticBuilderTests
+{
+    [Fact]
+    public void TryCreateRpcException_NonReflectionFailure_ReturnsNull()
+    {
+        var result = CodeGenerationDiagnosticBuilder.TryCreateRpcException(
+            new InvalidOperationException("plain failure"),
+            assemblyLoader: null);
+
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public void TryCreateRpcException_TypeLoadException_ReturnsLocalRpcExceptionWithDiagnostic()
+    {
+        var typeLoad = new TypeLoadException("type not found")
+        {
+            // TypeName/Message can be empty when the JIT throws — exercise the empty path here
+            // separately; for this test we want to confirm the wrapping path itself works.
+        };
+
+        var result = CodeGenerationDiagnosticBuilder.TryCreateRpcException(typeLoad, assemblyLoader: null);
+
+        var localRpc = Assert.IsType<LocalRpcException>(result);
+        Assert.Equal(CodeGenerationErrorCodes.IncompatibleAspireSdk, localRpc.ErrorCode);
+        var diagnostic = Assert.IsType<CodeGenerationDiagnostic>(localRpc.ErrorData);
+        Assert.Equal(typeof(TypeLoadException).FullName, diagnostic.OriginalExceptionType);
+        Assert.False(string.IsNullOrWhiteSpace(diagnostic.RemediationHint));
+        Assert.False(string.IsNullOrWhiteSpace(localRpc.Message));
+        // The default message must NOT leak the .NET-specific type name.
+        Assert.DoesNotContain("TypeLoadException", localRpc.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void TryCreateRpcException_TypeLoadExceptionWithEmptyMessage_ReturnsStructuredDiagnostic()
+    {
+        // Repro of issue #16709: JIT-thrown TypeLoadException with no Message — we must still
+        // produce a non-empty, actionable Message on the wire.
+        var typeLoad = new TypeLoadException();
+
+        var result = CodeGenerationDiagnosticBuilder.TryCreateRpcException(typeLoad, assemblyLoader: null);
+
+        var localRpc = Assert.IsType<LocalRpcException>(result);
+        Assert.False(string.IsNullOrWhiteSpace(localRpc.Message));
+        var diagnostic = Assert.IsType<CodeGenerationDiagnostic>(localRpc.ErrorData);
+        Assert.Equal(typeof(TypeLoadException).FullName, diagnostic.OriginalExceptionType);
+    }
+
+    [Fact]
+    public void TryCreateRpcException_MissingMethodException_PopulatesMemberName()
+    {
+        var missing = new MissingMethodException("System.Void Aspire.Hosting.Foo.Bar()");
+
+        var result = CodeGenerationDiagnosticBuilder.TryCreateRpcException(missing, assemblyLoader: null);
+
+        var localRpc = Assert.IsType<LocalRpcException>(result);
+        var diagnostic = Assert.IsType<CodeGenerationDiagnostic>(localRpc.ErrorData);
+        Assert.Equal(typeof(MissingMethodException).FullName, diagnostic.OriginalExceptionType);
+        Assert.False(string.IsNullOrWhiteSpace(diagnostic.MemberName));
+    }
+
+    [Fact]
+    public void TryCreateRpcException_WrappedTypeLoadException_FindsInnerCause()
+    {
+        var inner = new TypeLoadException("nested");
+        var outer = new InvalidOperationException("wrapper", inner);
+
+        var result = CodeGenerationDiagnosticBuilder.TryCreateRpcException(outer, assemblyLoader: null);
+
+        var localRpc = Assert.IsType<LocalRpcException>(result);
+        var diagnostic = Assert.IsType<CodeGenerationDiagnostic>(localRpc.ErrorData);
+        Assert.Equal(typeof(TypeLoadException).FullName, diagnostic.OriginalExceptionType);
+    }
+
+    [Fact]
+    public void TryCreateRpcException_ReflectionTypeLoadException_FindsLoaderException()
+    {
+        var loader = new TypeLoadException("missing type");
+        var rtle = new ReflectionTypeLoadException([null], [loader]);
+
+        var result = CodeGenerationDiagnosticBuilder.TryCreateRpcException(rtle, assemblyLoader: null);
+
+        var localRpc = Assert.IsType<LocalRpcException>(result);
+        var diagnostic = Assert.IsType<CodeGenerationDiagnostic>(localRpc.ErrorData);
+        Assert.Equal(typeof(TypeLoadException).FullName, diagnostic.OriginalExceptionType);
+    }
+
+    [Fact]
+    public void BuildDiagnostic_CapturesRuntimeAspireHostingVersion()
+    {
+        // BuildDiagnostic looks for the loaded Aspire.Hosting assembly via AppDomain. Calling
+        // any Aspire.Hosting type forces its assembly to be loaded so the search succeeds.
+        _ = typeof(global::Aspire.Hosting.DistributedApplication);
+
+        var diagnostic = CodeGenerationDiagnosticBuilder.BuildDiagnostic(
+            new TypeLoadException(),
+            assemblyLoader: null);
+
+        Assert.False(string.IsNullOrWhiteSpace(diagnostic.RuntimeAspireHostingVersion));
+    }
+}

--- a/tests/Aspire.Hosting.RemoteHost.Tests/CodeGenerationDiagnosticBuilderTests.cs
+++ b/tests/Aspire.Hosting.RemoteHost.Tests/CodeGenerationDiagnosticBuilderTests.cs
@@ -108,4 +108,24 @@ public class CodeGenerationDiagnosticBuilderTests
 
         Assert.False(string.IsNullOrWhiteSpace(diagnostic.RuntimeAspireHostingVersion));
     }
+
+    [Fact]
+    public void BuildDiagnostic_RuntimeAspireHostingVersion_DoesNotFallBackToRemoteHostAssembly()
+    {
+        _ = typeof(global::Aspire.Hosting.DistributedApplication);
+
+        var diagnostic = CodeGenerationDiagnosticBuilder.BuildDiagnostic(
+            new TypeLoadException(),
+            assemblyLoader: null);
+
+        var aspireHosting = AppDomain.CurrentDomain.GetAssemblies()
+            .First(a => string.Equals(a.GetName().Name, "Aspire.Hosting", StringComparison.OrdinalIgnoreCase));
+        var aspireHostingVersion = aspireHosting
+            .GetCustomAttribute<AssemblyInformationalVersionAttribute>()?.InformationalVersion
+            ?? aspireHosting.GetName().Version?.ToString();
+
+        // Guards #16709 finding #3: prior code fell back to typeof(AssemblyLoader).Assembly which is
+        // Aspire.Hosting.RemoteHost - a sibling, not the runtime that backed the failing codegen.
+        Assert.Equal(aspireHostingVersion, diagnostic.RuntimeAspireHostingVersion);
+    }
 }

--- a/tests/Aspire.Hosting.RemoteHost.Tests/ServiceErrorMessageTests.cs
+++ b/tests/Aspire.Hosting.RemoteHost.Tests/ServiceErrorMessageTests.cs
@@ -95,7 +95,7 @@ public class ServiceErrorMessageTests
         var atsContextFactory = new AtsContextFactory(loader, NullLogger<AtsContextFactory>.Instance, telemetry);
 
         var lang = new LanguageService(auth, langResolver, NullLogger<LanguageService>.Instance, telemetry);
-        var code = new CodeGenerationService(auth, atsContextFactory, codeResolver, NullLogger<CodeGenerationService>.Instance, telemetry);
+        var code = new CodeGenerationService(auth, atsContextFactory, codeResolver, loader, NullLogger<CodeGenerationService>.Instance, telemetry);
         return (lang, code);
     }
 
@@ -130,7 +130,7 @@ public class ServiceErrorMessageTests
 
         var auth = CreateAuthenticatedState();
         var atsContextFactory = new AtsContextFactory(loader, NullLogger<AtsContextFactory>.Instance, telemetry);
-        return new CodeGenerationService(auth, atsContextFactory, codeResolver, NullLogger<CodeGenerationService>.Instance, telemetry);
+        return new CodeGenerationService(auth, atsContextFactory, codeResolver, loader, NullLogger<CodeGenerationService>.Instance, telemetry);
     }
 
     // The default state is "authenticated" when no JsonRpcAuthToken is present in configuration.


### PR DESCRIPTION
# TypeScript AppHost code generation can fail with empty TypeLoadException

Fix #16709, closes #16959

## Description

When the installed Aspire CLI ships an `aspire-managed` server whose bundled `Aspire.Hosting.dll` is on a different build than the user-restored `Aspire.Hosting.CodeGeneration.TypeScript` / `Aspire.Hosting.JavaScript` / `Aspire.TypeSystem` DLLs (case reported in #16709 was CLI `26218` + SDK `26227`), reflection-based code generation can throw a JIT-emitted `TypeLoadException` with no message. That exception travels back to the CLI over JSON-RPC with no message, no type name, and no assembly identity, producing:

```
❌ Failed to run TypeScript (Node.js) AppHost:
System.TypeLoadException:
   at Aspire.Hosting.CodeGeneration.TypeScript.AtsTypeScriptCodeGenerator.GenerateAspireSdk(...)
```

…followed by a 60-second backchannel timeout.

## Changes

Three coordinated improvements:

1. **Server-side: enrich reflection-load exceptions before they cross the JSON-RPC boundary.**
   - New `CodeGenerationDiagnosticBuilder` in `Aspire.Hosting.RemoteHost.CodeGeneration` wraps `TypeLoadException`, `MissingMethodException`, `MissingFieldException`, `BadImageFormatException`, `FileLoadException`, and `ReflectionTypeLoadException` (including walking `LoaderExceptions`) into a `LocalRpcException` with **two parts**:
     - **`Message`** — short, safe, language-agnostic: *"… SDK code generation failed because the installed Aspire CLI appears to be incompatible with the configured Aspire SDK. Run 'aspire update' to align the CLI and SDK and try again."* No .NET type names, no assembly identities.
     - **`ErrorData`** (structured `CodeGenerationDiagnostic`) — `TypeName`, `MemberName`, loaded ATS assemblies + informational versions, runtime `Aspire.Hosting` version, original exception type, remediation hint.
   - JSON-RPC error code `-32050` (reserved server-error range) used as the contract between server and CLI.
   - `AssemblyLoader.GetLoadedAssemblyDiagnostics()` exposes a snapshot of loaded ATS assemblies for the diagnostic payload.

2. **CLI-side: tiered output + actionable post-failure diagnostic.**
   - **Pre-flight (always shown):** when `VersionHelper.GetDefaultTemplateVersion()` and `aspire.config.json` SDK version differ on major/minor/patch (modulo build suffix), emit a yellow warning naming both versions and pointing at `aspire update`.
   - **Default failure rendering (non-debug):** show the safe summary + remediation hint + closing line *"Run with `--debug` for full diagnostic details."* Full structured payload is logged via `LogDebug` regardless.
   - **`--debug` failure rendering:** also display `OriginalExceptionType`, `TypeName`, `MemberName`, runtime `Aspire.Hosting` version, and loaded assemblies so a maintainer can diagnose the underlying CLR problem.
   - Fault `BackchannelCompletionSource` immediately on codegen failure so users no longer wait through the 60-second timeout.
   - New `AppHostCodeGenerationDiagnostic` (CLI mirror DTO) + `AppHostCodeGenerationException` typed exception. The diagnostic DTO is registered in `BackchannelJsonSerializerContext` for AOT-safe deserialization of `RemoteInvocationException.DeserializedErrorData` / `ErrorData` `JsonElement`.

3. **CLI-side: prune stale backchannel sockets at startup.**
   - `CliPathHelper.CleanupStaleCliSockets(directory, maxAge, timeProvider?)` deletes `cli.sock.*` files in `~/.aspire/cli/runtime/sockets/` older than 24 hours (mtime-based, since the filename encodes only a random GUID — no PID). Runs lazily once per process via `Interlocked.CompareExchange`. Pure housekeeping — no user-visible output, exceptions on individual files are swallowed.

## Tests

- `tests/Aspire.Hosting.RemoteHost.Tests/CodeGenerationDiagnosticBuilderTests.cs` *(new, 7 tests)* — non-reflection exception returns null; `TypeLoadException` (with/without message) wraps to LocalRpcException + structured ErrorData; default `Message` doesn't leak the .NET type name; `MissingMethodException` populates `MemberName`; wrapped/inner-exception walking; `ReflectionTypeLoadException.LoaderExceptions` walking; runtime `Aspire.Hosting` version capture.
- `tests/Aspire.Cli.Tests/Projects/GuestAppHostProjectSkewTests.cs` *(new, 10 tests)* — `IsKnownIncompatibleSkew` correctly flags major/minor/patch differences while ignoring build suffix; `NormalizeVersion` strips `+build` metadata; falls back to string comparison for unparseable versions.
- `tests/Aspire.Cli.Tests/Utils/CliPathHelperTests.cs` — extended with 4 janitor tests: stale files deleted, newer files kept, only `cli.sock.*` prefix matched, missing directory and empty directory are no-ops. Uses `Microsoft.Extensions.Time.Testing.FakeTimeProvider` for deterministic time.

## User-visible behavior change

**Before (issue #16709):**
```
❌ Failed to run TypeScript (Node.js) AppHost:
System.TypeLoadException:
   at Aspire.Hosting.CodeGeneration.TypeScript.AtsTypeScriptCodeGenerator.GenerateAspireSdk(...)
[60 second wait]
```

**After (default):**
```
⚠  The installed Aspire CLI version (13.4.0-preview.1.26218.1) differs from the configured
   Aspire SDK version (13.4.0-preview.1.26227.1). If you run into errors, run 'aspire update'
   to align them.
❌ TypeScript (Node.js) SDK code generation failed because the installed Aspire CLI appears
   to be incompatible with the configured Aspire SDK. Run 'aspire update' to align the CLI
   and SDK and try again.
ℹ  Run with '--debug' for full diagnostic details.
[exits immediately]
```

**After (`--debug`):**
…same as above, plus:
```
🔬 Diagnostic details:
🔬   Exception: System.TypeLoadException
🔬   Type: Aspire.Hosting.SomeType
🔬   Runtime Aspire.Hosting: 13.4.0-preview.1.26218.1+abc123
🔬   • Aspire.Hosting.CodeGeneration.TypeScript 13.4.0-preview.1.26227.1+def456
🔬   • Aspire.TypeSystem 13.4.0-preview.1.26227.1+def456
```

## Build / test verification

- `./build.cmd /p:SkipNativeBuild=true` → clean.
- 11 new tests pass locally. The 3 pre-existing failures I saw (`AssemblyLoaderTests.GetAssemblies_AddsAssemblyNamesToProfilingSpan`, `RemoteHostProfilingTelemetryTests.AssemblyLoad_AddsAssemblyNames`, `ListConsoleLogsToolTests.ListConsoleLogsTool_ReturnsLogs_ForSpecificResource`) reproduce on a clean `upstream/main` checkout without my changes and are unrelated (parallel-listener race on a shared static `ActivitySource`, and a Windows CRLF/LF expectation, respectively).
- XLF files auto-regenerated by the build for the 4 new ErrorStrings entries; they'll be retranslated by the loc workflow.

## Out of scope / notes

- No retry on `TypeLoadException` — we surface a clear diagnostic and exit, matching the issue's *Expected behavior*.
- No automatic mutation of `aspire.config.json` to pin a matching SDK version; we suggest `aspire update` in the message.
- Stale socket sweep deletes by mtime only because `cli.sock.<guid>` files don't encode a PID. The 24h threshold is comfortably longer than any legitimate Aspire CLI run.
- **Privacy/UX:** by default, no .NET type names, no `Aspire.Hosting*` assembly identities, no CLR stack traces are shown to the user. Those details are only revealed with `--debug` (and are always written to the existing debug log file at `~/.aspire/logs/cli_*.log`).

Closes #16709.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>