### PR TITLE
Fix workflow warning sources

### DIFF
--- a/.github/actions/create-pull-request/action.yml
+++ b/.github/actions/create-pull-request/action.yml
@@ -111,11 +111,10 @@ runs:
           # the maintainer can fix the workflow input on their own schedule.
           LABEL_ARGS=()
           if [ -n "$LABELS" ]; then
-            # Fetch every label name in the repo. We use `--paginate` (and a
-            # generous --limit per page) so this stays correct even if the repo
-            # ever grows past a few hundred labels — `--limit` alone is an upper
-            # bound, not automatic pagination.
-            EXISTING_LABELS=$(gh label list --paginate --limit 500 --json name --jq '.[].name' 2>/dev/null || echo '')
+            # Fetch every label name in the repo. `gh label list` does not
+            # support pagination, so use the REST API directly to avoid
+            # misclassifying valid labels when the repository grows past one page.
+            EXISTING_LABELS=$(gh api "repos/${GITHUB_REPOSITORY}/labels?per_page=100" --paginate --jq '.[].name' 2>/dev/null || echo '')
             while IFS= read -r label; do
               label=$(echo "$label" | xargs)  # trim whitespace
               if [ -z "$label" ]; then

--- a/.github/workflows/apply-test-attributes.yml
+++ b/.github/workflows/apply-test-attributes.yml
@@ -384,7 +384,7 @@ jobs:
     - name: Generate GitHub App Token
       if: success()
       id: app-token
-      uses: actions/create-github-app-token@df432ceedc7162793a195dd1713ff69aefc7379e # v2.0.6
+      uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
       with:
         app-id: ${{ secrets.ASPIRE_BOT_APP_ID }}
         private-key: ${{ secrets.ASPIRE_BOT_PRIVATE_KEY }}

--- a/.github/workflows/backmerge-release.yml
+++ b/.github/workflows/backmerge-release.yml
@@ -19,7 +19,7 @@ jobs:
     steps:
       - name: Generate GitHub App Token
         id: app-token
-        uses: actions/create-github-app-token@df432ceedc7162793a195dd1713ff69aefc7379e # v2.0.6
+        uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
         with:
           app-id: ${{ secrets.ASPIRE_BOT_APP_ID }}
           private-key: ${{ secrets.ASPIRE_BOT_PRIVATE_KEY }}

--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -102,7 +102,7 @@ jobs:
     # to avoid minting a privileged token for unauthorized users.
     - name: Generate GitHub App Token
       id: app-token
-      uses: actions/create-github-app-token@df432ceedc7162793a195dd1713ff69aefc7379e # v2.0.6
+      uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
       with:
         app-id: ${{ secrets.ASPIRE_BOT_APP_ID }}
         private-key: ${{ secrets.ASPIRE_BOT_PRIVATE_KEY }}

--- a/.github/workflows/generate-api-diffs.yml
+++ b/.github/workflows/generate-api-diffs.yml
@@ -30,7 +30,7 @@ jobs:
 
       - name: Generate GitHub App Token
         id: app-token
-        uses: actions/create-github-app-token@df432ceedc7162793a195dd1713ff69aefc7379e # v2.0.6
+        uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
         with:
           app-id: ${{ secrets.ASPIRE_BOT_APP_ID }}
           private-key: ${{ secrets.ASPIRE_BOT_PRIVATE_KEY }}

--- a/.github/workflows/generate-ats-diffs.yml
+++ b/.github/workflows/generate-ats-diffs.yml
@@ -78,7 +78,7 @@ jobs:
 
       - name: Generate GitHub App Token
         id: app-token
-        uses: actions/create-github-app-token@df432ceedc7162793a195dd1713ff69aefc7379e # v2.0.6
+        uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
         with:
           app-id: ${{ secrets.ASPIRE_BOT_APP_ID }}
           private-key: ${{ secrets.ASPIRE_BOT_PRIVATE_KEY }}

--- a/.github/workflows/refresh-manifests.yml
+++ b/.github/workflows/refresh-manifests.yml
@@ -28,7 +28,7 @@ jobs:
 
       - name: Generate GitHub App Token
         id: app-token
-        uses: actions/create-github-app-token@df432ceedc7162793a195dd1713ff69aefc7379e # v2.0.6
+        uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
         with:
           app-id: ${{ secrets.ASPIRE_BOT_APP_ID }}
           private-key: ${{ secrets.ASPIRE_BOT_PRIVATE_KEY }}

--- a/.github/workflows/release-github-tasks.yml
+++ b/.github/workflows/release-github-tasks.yml
@@ -192,7 +192,7 @@ jobs:
       # cascade into other workflow runs).
       - name: Generate GitHub App Token
         id: app-token
-        uses: actions/create-github-app-token@df432ceedc7162793a195dd1713ff69aefc7379e # v2.0.6
+        uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
         with:
           app-id: ${{ secrets.ASPIRE_BOT_APP_ID }}
           private-key: ${{ secrets.ASPIRE_BOT_PRIVATE_KEY }}
@@ -343,7 +343,7 @@ jobs:
     steps:
       - name: Generate GitHub App Token
         id: app-token
-        uses: actions/create-github-app-token@df432ceedc7162793a195dd1713ff69aefc7379e # v2.0.6
+        uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
         with:
           app-id: ${{ secrets.ASPIRE_BOT_APP_ID }}
           private-key: ${{ secrets.ASPIRE_BOT_PRIVATE_KEY }}
@@ -426,7 +426,7 @@ jobs:
     steps:
       - name: Generate GitHub App Token
         id: app-token
-        uses: actions/create-github-app-token@df432ceedc7162793a195dd1713ff69aefc7379e # v2.0.6
+        uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
         with:
           app-id: ${{ secrets.ASPIRE_BOT_APP_ID }}
           private-key: ${{ secrets.ASPIRE_BOT_PRIVATE_KEY }}

--- a/.github/workflows/update-ai-foundry-models.yml
+++ b/.github/workflows/update-ai-foundry-models.yml
@@ -25,7 +25,7 @@ jobs:
 
       - name: Generate GitHub App Token
         id: app-token
-        uses: actions/create-github-app-token@df432ceedc7162793a195dd1713ff69aefc7379e # v2.0.6
+        uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
         with:
           app-id: ${{ secrets.ASPIRE_BOT_APP_ID }}
           private-key: ${{ secrets.ASPIRE_BOT_PRIVATE_KEY }}

--- a/.github/workflows/update-azure-vm-sizes.yml
+++ b/.github/workflows/update-azure-vm-sizes.yml
@@ -29,7 +29,7 @@ jobs:
 
       - name: Generate GitHub App Token
         id: app-token
-        uses: actions/create-github-app-token@df432ceedc7162793a195dd1713ff69aefc7379e # v2.0.6
+        uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
         with:
           app-id: ${{ secrets.ASPIRE_BOT_APP_ID }}
           private-key: ${{ secrets.ASPIRE_BOT_PRIVATE_KEY }}

--- a/.github/workflows/update-dependencies.yml
+++ b/.github/workflows/update-dependencies.yml
@@ -41,7 +41,7 @@ jobs:
 
       - name: Generate GitHub App Token
         id: app-token
-        uses: actions/create-github-app-token@df432ceedc7162793a195dd1713ff69aefc7379e # v2.0.6
+        uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
         with:
           app-id: ${{ secrets.ASPIRE_BOT_APP_ID }}
           private-key: ${{ secrets.ASPIRE_BOT_PRIVATE_KEY }}

--- a/.github/workflows/update-github-models.yml
+++ b/.github/workflows/update-github-models.yml
@@ -26,7 +26,7 @@ jobs:
 
       - name: Generate GitHub App Token
         id: app-token
-        uses: actions/create-github-app-token@df432ceedc7162793a195dd1713ff69aefc7379e # v2.0.6
+        uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
         with:
           app-id: ${{ secrets.ASPIRE_BOT_APP_ID }}
           private-key: ${{ secrets.ASPIRE_BOT_PRIVATE_KEY }}


### PR DESCRIPTION
## Description

Fixes the warning annotations from the `Release GitHub Tasks` workflow run by addressing both root causes:

- Updates `actions/create-github-app-token` from v2.0.6 to v3.1.1 so workflows use the Node 24-compatible action instead of the deprecated Node 20 action runtime.
- Fixes the local `create-pull-request` composite action's label validation. The action was calling unsupported `gh label list --paginate`, suppressing the error, and then treating valid repository labels like `area-engineering-systems` as missing. It now uses the paginated GitHub REST API label endpoint.

Validation:
- Confirmed the workflow run warnings were three Node 20 action deprecation annotations and one skipped-label annotation.
- Confirmed `area-engineering-systems` exists in the repository.
- Confirmed the new REST API label lookup returns `area-engineering-systems`.
- Confirmed no old `actions/create-github-app-token` v2.0.6 pins or unsupported `gh label list --paginate` usages remain under `.github`.
- Ran `git diff --check`.

Fixes # (issue)

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [x] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
