### PR TITLE
Fix Azure provisioning resource group location prompt

### DIFF
--- a/src/Aspire.Dashboard/Model/Interaction/InputViewModel.cs
+++ b/src/Aspire.Dashboard/Model/Interaction/InputViewModel.cs
@@ -17,24 +17,9 @@ public sealed class InputViewModel
 
     public void SetInput(InteractionInput input)
     {
-        string value;
-        if (Input == null)
-        {
-            value = input.Value;
-        }
-        else
-        {
-            // Only overwrite the local value if the input was loading and is no longer loading (update could have come from server)
-            // This avoids changes in local values being overwritten by a dynamic server update.
-            if (Input.Loading && !input.Loading)
-            {
-                value = input.Value;
-            }
-            else
-            {
-                value = Input.Value;
-            }
-        }
+        var value = Input is null || ShouldUseIncomingValue(Input, input)
+            ? input.Value
+            : Input.Value;
         input.Value = value;
 
         Input = input;
@@ -136,5 +121,12 @@ public sealed class InputViewModel
         }
 
         return true;
+    }
+
+    private static bool ShouldUseIncomingValue(InteractionInput current, InteractionInput incoming)
+    {
+        // Preserve local edits during ordinary updates, but accept server-provided values when
+        // dynamic loading completes or when the input is disabled and therefore server-owned.
+        return (current.Loading && !incoming.Loading) || incoming.Disabled;
     }
 }

--- a/tests/Aspire.Dashboard.Tests/Model/InputViewModelTests.cs
+++ b/tests/Aspire.Dashboard.Tests/Model/InputViewModelTests.cs
@@ -259,4 +259,54 @@ public class InputViewModelTests
 
         Assert.Equal(initialVersion, viewModel.ChoiceVersion);
     }
+
+    [Fact]
+    public void SetInput_DisabledInputUsesIncomingValue()
+    {
+        var input = new InteractionInput
+        {
+            Label = "Location",
+            InputType = InputType.Choice,
+            Placeholder = "Select a location",
+            Disabled = true
+        };
+        var viewModel = new InputViewModel(input);
+
+        var updatedInput = new InteractionInput
+        {
+            Label = "Location",
+            InputType = InputType.Choice,
+            Placeholder = "Select a location",
+            Disabled = true,
+            Value = "westus"
+        };
+        updatedInput.Options.Add("westus", "West US");
+
+        viewModel.SetInput(updatedInput);
+
+        Assert.Equal("westus", viewModel.Value);
+    }
+
+    [Fact]
+    public void SetInput_EnabledInputPreservesLocalValue()
+    {
+        var input = new InteractionInput
+        {
+            Label = "Name",
+            InputType = InputType.Text,
+            Value = "local"
+        };
+        var viewModel = new InputViewModel(input);
+
+        var updatedInput = new InteractionInput
+        {
+            Label = "Name",
+            InputType = InputType.Text,
+            Value = "server"
+        };
+
+        viewModel.SetInput(updatedInput);
+
+        Assert.Equal("local", viewModel.Value);
+    }
 }


### PR DESCRIPTION
## Description

Fixes #17275

The Azure provisioning dialog could get stuck when a user selected an existing resource group because the Location field was disabled, required, and sometimes left empty in the dashboard's local input model.

Users can now proceed after selecting an existing resource group. The disabled Location input accepts the server-provided resource group location, while enabled inputs still preserve in-progress local edits during interaction updates.

### User-facing usage

In the Azure provisioning dialog, selecting an existing resource group now populates the disabled Location field with that resource group's location instead of leaving it empty and blocking submission.

Validation:

```text
dotnet test --project tests\Aspire.Dashboard.Tests\Aspire.Dashboard.Tests.csproj --no-launch-profile -- --filter-class "*.InputViewModelTests" --filter-not-trait "quarantined=true" --filter-not-trait "outerloop=true"
Test run summary: Passed!
  total: 13
```

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
