### PR TITLE
Prompt for Aspire new project location in VS Code

### DIFF
--- a/extension/package.nls.json
+++ b/extension/package.nls.json
@@ -121,6 +121,7 @@
   "aspire-vscode.strings.openCliInstallInstructions": "See CLI installation instructions",
   "aspire-vscode.strings.dismissLabel": "Dismiss",
   "aspire-vscode.strings.selectDirectoryTitle": "Select directory",
+  "aspire-vscode.strings.unableToAddFolderToWorkspace": "Unable to add folder to workspace: {0}",
   "aspire-vscode.strings.selectFileTitle": "Select file",
   "aspire-vscode.strings.enterPipelineStep": "Enter the pipeline step to execute",
   "aspire-vscode.strings.runningAspireRestore": "Running aspire restore on {0} ...",

--- a/extension/src/loc/strings.ts
+++ b/extension/src/loc/strings.ts
@@ -108,6 +108,7 @@ export const openCliInstallInstructions = vscode.l10n.t('See CLI installation in
 export const cliNotAvailable = vscode.l10n.t('Aspire CLI is not available on PATH. Please install it and restart VS Code.');
 export const cliFoundAtDefaultPath = (path: string) => vscode.l10n.t('Aspire CLI found at {0}. The extension will use this path.', path);
 export const selectDirectoryTitle = vscode.l10n.t('Select directory');
+export const unableToAddFolderToWorkspace = (path: string) => vscode.l10n.t('Unable to add folder to workspace: {0}', path);
 export const runningAspireRestore = (configPath: string) => vscode.l10n.t('Running aspire restore on {0} ...', configPath);
 export const runningAspireRestoreProgress = (completed: number, total: number) => vscode.l10n.t('Running aspire restore ({0}/{1} projects) ...', completed, total);
 export const aspireRestoreCompleted = (configPath: string) => vscode.l10n.t('Aspire restore completed for {0}.', configPath);

--- a/extension/src/server/interactionService.ts
+++ b/extension/src/server/interactionService.ts
@@ -433,14 +433,22 @@ export class InteractionService implements IInteractionService {
     async openEditor(path: string) {
         extensionLogOutputChannel.info(`Opening path: ${path}`);
 
-        // check if is folder
         if (await isDirectory(path)) {
             if (isFolderOpenInWorkspace(path)) {
                 return;
             }
 
             const uri = vscode.Uri.file(path);
-            vscode.commands.executeCommand('vscode.openFolder', uri, { forceNewWindow: false });
+            const workspaceFolders = vscode.workspace.workspaceFolders;
+            if (workspaceFolders && workspaceFolders.length > 0) {
+                if (!vscode.workspace.updateWorkspaceFolders(workspaceFolders.length, 0, { uri })) {
+                    extensionLogOutputChannel.warn(`Unable to add folder to workspace: ${path}`);
+                }
+
+                return;
+            }
+
+            await vscode.commands.executeCommand('vscode.openFolder', uri, { forceNewWindow: false });
         }
         else {
             const fileUri = vscode.Uri.file(path);

--- a/extension/src/server/interactionService.ts
+++ b/extension/src/server/interactionService.ts
@@ -2,7 +2,7 @@ import { MessageConnection } from 'vscode-jsonrpc';
 import * as vscode from 'vscode';
 import * as fs from 'fs/promises';
 import { getRelativePathToWorkspace, isFolderOpenInWorkspace } from '../utils/workspace';
-import { yesLabel, noLabel, directLink, codespacesLink, openAspireDashboard, settingsLabel, failedToShowPromptEmpty, incompatibleAppHostError, aspireHostingSdkVersion, aspireCliVersion, requiredCapability, fieldRequired, aspireDebugSessionNotInitialized, errorMessage, failedToStartDebugSession, dashboard, codespaces, selectDirectoryTitle, selectFileTitle } from '../loc/strings';
+import { yesLabel, noLabel, directLink, codespacesLink, openAspireDashboard, settingsLabel, failedToShowPromptEmpty, incompatibleAppHostError, aspireHostingSdkVersion, aspireCliVersion, requiredCapability, fieldRequired, aspireDebugSessionNotInitialized, errorMessage, failedToStartDebugSession, dashboard, codespaces, selectDirectoryTitle, selectFileTitle, unableToAddFolderToWorkspace } from '../loc/strings';
 import { ICliRpcClient } from './rpcClient';
 import { ProgressNotifier } from './progressNotifier';
 import { applyTextStyle, formatText } from '../utils/strings';
@@ -442,7 +442,9 @@ export class InteractionService implements IInteractionService {
             const workspaceFolders = vscode.workspace.workspaceFolders;
             if (workspaceFolders && workspaceFolders.length > 0) {
                 if (!vscode.workspace.updateWorkspaceFolders(workspaceFolders.length, 0, { uri })) {
-                    extensionLogOutputChannel.warn(`Unable to add folder to workspace: ${path}`);
+                    const message = unableToAddFolderToWorkspace(path);
+                    extensionLogOutputChannel.warn(message);
+                    vscode.window.showWarningMessage(message);
                 }
 
                 return;

--- a/extension/src/test/rpc/interactionServiceTests.test.ts
+++ b/extension/src/test/rpc/interactionServiceTests.test.ts
@@ -238,7 +238,7 @@ suite('InteractionService endpoints', () => {
 			const updateArgs = updateWorkspaceFoldersStub.getCall(0).args;
 			assert.strictEqual(updateArgs[0], 1, 'Should add after existing workspace folders');
 			assert.strictEqual(updateArgs[1], 0, 'Should not remove existing workspace folders');
-			assert.strictEqual(updateArgs[2].uri.fsPath, projectPath, 'Should add the new project folder');
+			assertPathEqual(updateArgs[2].uri.fsPath, projectPath, 'Should add the new project folder');
 			assert.strictEqual(executeCommandStub.callCount, 0, 'Should not replace the workspace with vscode.openFolder');
 		}
 		finally {
@@ -268,7 +268,7 @@ suite('InteractionService endpoints', () => {
 			assert.strictEqual(executeCommandStub.callCount, 1, 'Should open the new project folder');
 			const executeArgs = executeCommandStub.getCall(0).args;
 			assert.strictEqual(executeArgs[0], 'vscode.openFolder');
-			assert.strictEqual(executeArgs[1].fsPath, projectPath);
+			assertPathEqual(executeArgs[1].fsPath, projectPath);
 			assert.deepStrictEqual(executeArgs[2], { forceNewWindow: false });
 		}
 		finally {
@@ -388,6 +388,16 @@ type RpcServerTestInfo = {
 	rpcClient: ICliRpcClient;
 	interactionService: IInteractionService;
 };
+
+function assertPathEqual(actual: string, expected: string, message?: string) {
+	assert.strictEqual(normalizePathForComparison(actual), normalizePathForComparison(expected), message);
+}
+
+function normalizePathForComparison(value: string) {
+	const normalized = path.normalize(value);
+
+	return process.platform === 'win32' ? normalized.toLowerCase() : normalized;
+}
 
 class TestCliRpcClient implements ICliRpcClient {
     debugSessionId: string | null;

--- a/extension/src/test/rpc/interactionServiceTests.test.ts
+++ b/extension/src/test/rpc/interactionServiceTests.test.ts
@@ -1,4 +1,7 @@
 import * as assert from 'assert';
+import * as fs from 'fs/promises';
+import * as os from 'os';
+import * as path from 'path';
 import * as vscode from 'vscode';
 import * as sinon from 'sinon';
 
@@ -204,6 +207,74 @@ suite('InteractionService endpoints', () => {
 		testInfo.interactionService.displayEmptyLine();
 		assert.ok(stub.calledWith('\n'));
 		stub.restore();
+	});
+
+	test("openEditor adds folder to existing workspace", async () => {
+		const tempRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'aspire-open-editor-'));
+		const workspacePath = path.join(tempRoot, 'workspace');
+		const projectPath = path.join(tempRoot, 'MyFirstApp');
+		await fs.mkdir(workspacePath);
+		await fs.mkdir(projectPath);
+
+		const sandbox = sinon.createSandbox();
+
+		try {
+			const testInfo = await createTestRpcServer();
+			const workspaceFolder = {
+				uri: vscode.Uri.file(workspacePath),
+				name: 'workspace',
+				index: 0
+			} as vscode.WorkspaceFolder;
+
+			sandbox.stub(vscode.workspace, 'workspaceFolders').value([workspaceFolder]);
+			sandbox.stub(vscode.workspace, 'getWorkspaceFolder').callsFake((uri: vscode.Uri) =>
+				uri.fsPath === workspaceFolder.uri.fsPath ? workspaceFolder : undefined);
+			const updateWorkspaceFoldersStub = sandbox.stub(vscode.workspace, 'updateWorkspaceFolders').returns(true);
+			const executeCommandStub = sandbox.stub(vscode.commands, 'executeCommand').resolves();
+
+			await testInfo.interactionService.openEditor(projectPath);
+
+			assert.strictEqual(updateWorkspaceFoldersStub.callCount, 1, 'Should update workspace folders once');
+			const updateArgs = updateWorkspaceFoldersStub.getCall(0).args;
+			assert.strictEqual(updateArgs[0], 1, 'Should add after existing workspace folders');
+			assert.strictEqual(updateArgs[1], 0, 'Should not remove existing workspace folders');
+			assert.strictEqual(updateArgs[2].uri.fsPath, projectPath, 'Should add the new project folder');
+			assert.strictEqual(executeCommandStub.callCount, 0, 'Should not replace the workspace with vscode.openFolder');
+		}
+		finally {
+			sandbox.restore();
+			await fs.rm(tempRoot, { recursive: true, force: true });
+		}
+	});
+
+	test("openEditor opens folder when there is no workspace", async () => {
+		const tempRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'aspire-open-editor-'));
+		const projectPath = path.join(tempRoot, 'MyFirstApp');
+		await fs.mkdir(projectPath);
+
+		const sandbox = sinon.createSandbox();
+
+		try {
+			const testInfo = await createTestRpcServer();
+
+			sandbox.stub(vscode.workspace, 'workspaceFolders').value(undefined);
+			sandbox.stub(vscode.workspace, 'getWorkspaceFolder').returns(undefined);
+			const updateWorkspaceFoldersStub = sandbox.stub(vscode.workspace, 'updateWorkspaceFolders').returns(true);
+			const executeCommandStub = sandbox.stub(vscode.commands, 'executeCommand').resolves();
+
+			await testInfo.interactionService.openEditor(projectPath);
+
+			assert.strictEqual(updateWorkspaceFoldersStub.callCount, 0, 'Should not update workspace folders when no workspace exists');
+			assert.strictEqual(executeCommandStub.callCount, 1, 'Should open the new project folder');
+			const executeArgs = executeCommandStub.getCall(0).args;
+			assert.strictEqual(executeArgs[0], 'vscode.openFolder');
+			assert.strictEqual(executeArgs[1].fsPath, projectPath);
+			assert.deepStrictEqual(executeArgs[2], { forceNewWindow: false });
+		}
+		finally {
+			sandbox.restore();
+			await fs.rm(tempRoot, { recursive: true, force: true });
+		}
 	});
 
 	test("displayDashboardUrls writes URLs to output channel and shows info message when autoLaunch is notification", async () => {

--- a/extension/src/test/rpc/interactionServiceTests.test.ts
+++ b/extension/src/test/rpc/interactionServiceTests.test.ts
@@ -277,6 +277,42 @@ suite('InteractionService endpoints', () => {
 		}
 	});
 
+	test("openEditor shows warning when folder cannot be added to existing workspace", async () => {
+		const tempRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'aspire-open-editor-'));
+		const workspacePath = path.join(tempRoot, 'workspace');
+		const projectPath = path.join(tempRoot, 'MyFirstApp');
+		await fs.mkdir(workspacePath);
+		await fs.mkdir(projectPath);
+
+		const sandbox = sinon.createSandbox();
+
+		try {
+			const testInfo = await createTestRpcServer();
+			const workspaceFolder = {
+				uri: vscode.Uri.file(workspacePath),
+				name: 'workspace',
+				index: 0
+			} as vscode.WorkspaceFolder;
+
+			sandbox.stub(vscode.workspace, 'workspaceFolders').value([workspaceFolder]);
+			sandbox.stub(vscode.workspace, 'getWorkspaceFolder').callsFake((uri: vscode.Uri) =>
+				uri.fsPath === workspaceFolder.uri.fsPath ? workspaceFolder : undefined);
+			sandbox.stub(vscode.workspace, 'updateWorkspaceFolders').returns(false);
+			const executeCommandStub = sandbox.stub(vscode.commands, 'executeCommand').resolves();
+			const showWarningMessageStub = sandbox.stub(vscode.window, 'showWarningMessage').resolves(undefined);
+
+			await testInfo.interactionService.openEditor(projectPath);
+
+			assert.strictEqual(executeCommandStub.callCount, 0, 'Should not replace the workspace with vscode.openFolder');
+			assert.strictEqual(showWarningMessageStub.callCount, 1, 'Should warn when the project folder was not added');
+			assert.ok(showWarningMessageStub.getCall(0).args[0].includes(projectPath), 'Warning should include the project folder path');
+		}
+		finally {
+			sandbox.restore();
+			await fs.rm(tempRoot, { recursive: true, force: true });
+		}
+	});
+
 	test("displayDashboardUrls writes URLs to output channel and shows info message when autoLaunch is notification", async () => {
 		const stub = sinon.stub(extensionLogOutputChannel, 'info');
 		const showInformationMessageStub = sinon.stub(vscode.window, 'showInformationMessage').resolves();

--- a/src/Aspire.Cli/Commands/NewCommand.cs
+++ b/src/Aspire.Cli/Commands/NewCommand.cs
@@ -478,7 +478,7 @@ internal interface INewCommandPrompter
 {
     Task<ITemplate> PromptForTemplateAsync(ITemplate[] validTemplates, CancellationToken cancellationToken);
     Task<string> PromptForProjectNameAsync(string defaultName, ParseResult parseResult, CancellationToken cancellationToken);
-    Task<string> PromptForOutputPath(string v, ParseResult parseResult, Func<string, ValidationResult>? validator = null, CancellationToken cancellationToken = default);
+    Task<string> PromptForOutputPath(string v, ParseResult parseResult, Func<string, ValidationResult>? validator = null, CancellationToken cancellationToken = default, Func<string, string>? outputPathResolver = null);
 }
 
 internal interface ITemplateVersionPrompter
@@ -591,15 +591,23 @@ internal class NewCommandPrompter(IInteractionService interactionService) : INew
         return await topSelection.Action(cancellationToken);
     }
 
-    public virtual async Task<string> PromptForOutputPath(string path, ParseResult parseResult, Func<string, ValidationResult>? validator = null, CancellationToken cancellationToken = default)
+    public virtual async Task<string> PromptForOutputPath(string path, ParseResult parseResult, Func<string, ValidationResult>? validator = null, CancellationToken cancellationToken = default, Func<string, string>? outputPathResolver = null)
     {
-        return await interactionService.PromptForFilePathAsync(
+        var resolvedValidator = validator;
+        if (validator is not null && outputPathResolver is not null)
+        {
+            resolvedValidator = candidatePath => validator(outputPathResolver(candidatePath));
+        }
+
+        var outputPath = await interactionService.PromptForFilePathAsync(
             NewCommandStrings.EnterTheOutputPath,
-            validator: validator,
+            validator: resolvedValidator,
             binding: PromptBinding.Create(parseResult, NewCommand.s_outputOption, path),
             directory: true,
             cancellationToken: cancellationToken
             );
+
+        return outputPathResolver?.Invoke(outputPath) ?? outputPath;
     }
 
     public virtual async Task<string> PromptForProjectNameAsync(string defaultName, ParseResult parseResult, CancellationToken cancellationToken)

--- a/src/Aspire.Cli/Resources/NewCommandStrings.Designer.cs
+++ b/src/Aspire.Cli/Resources/NewCommandStrings.Designer.cs
@@ -100,6 +100,30 @@ namespace Aspire.Cli.Resources {
                 return ResourceManager.GetString("EnterTheProjectName", resourceCulture);
             }
         }
+
+        public static string SelectProjectCreationLocation
+        {
+            get
+            {
+                return ResourceManager.GetString("SelectProjectCreationLocation", resourceCulture);
+            }
+        }
+
+        public static string CreateProjectNameSubdirectoryChoice
+        {
+            get
+            {
+                return ResourceManager.GetString("CreateProjectNameSubdirectoryChoice", resourceCulture);
+            }
+        }
+
+        public static string CreateProjectDirectlyInSelectedFolderChoice
+        {
+            get
+            {
+                return ResourceManager.GetString("CreateProjectDirectlyInSelectedFolderChoice", resourceCulture);
+            }
+        }
         
         public static string InvalidProjectName {
             get {

--- a/src/Aspire.Cli/Resources/NewCommandStrings.resx
+++ b/src/Aspire.Cli/Resources/NewCommandStrings.resx
@@ -133,6 +133,15 @@
   <data name="EnterTheProjectName" xml:space="preserve">
     <value>Enter the project name</value>
   </data>
+  <data name="SelectProjectCreationLocation" xml:space="preserve">
+    <value>Where do you want the project to be created?</value>
+  </data>
+  <data name="CreateProjectNameSubdirectoryChoice" xml:space="preserve">
+    <value>In a subdirectory named '{0}' in the selected folder</value>
+  </data>
+  <data name="CreateProjectDirectlyInSelectedFolderChoice" xml:space="preserve">
+    <value>Directly in the selected folder</value>
+  </data>
   <data name="InvalidProjectName" xml:space="preserve">
     <value>Invalid project name.</value>
   </data>

--- a/src/Aspire.Cli/Resources/xlf/NewCommandStrings.cs.xlf
+++ b/src/Aspire.Cli/Resources/xlf/NewCommandStrings.cs.xlf
@@ -12,6 +12,16 @@
         <target state="translated">Kanál, který se má použít pro šablony (stabilní, příprava, denní)</target>
         <note />
       </trans-unit>
+      <trans-unit id="CreateProjectDirectlyInSelectedFolderChoice">
+        <source>Directly in the selected folder</source>
+        <target state="new">Directly in the selected folder</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CreateProjectNameSubdirectoryChoice">
+        <source>In a subdirectory named '{0}' in the selected folder</source>
+        <target state="new">In a subdirectory named '{0}' in the selected folder</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Description">
         <source>Create a new app from an Aspire starter template</source>
         <target state="needs-review-translation">Vytvořte nový projekt Aspire.</target>
@@ -90,6 +100,11 @@
       <trans-unit id="SelectATemplateVersion">
         <source>Select a template version:</source>
         <target state="translated">Vyberte verzi šablony:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SelectProjectCreationLocation">
+        <source>Where do you want the project to be created?</source>
+        <target state="new">Where do you want the project to be created?</target>
         <note />
       </trans-unit>
       <trans-unit id="SourceArgumentDescription">

--- a/src/Aspire.Cli/Resources/xlf/NewCommandStrings.de.xlf
+++ b/src/Aspire.Cli/Resources/xlf/NewCommandStrings.de.xlf
@@ -12,6 +12,16 @@
         <target state="translated">Kanal für Vorlagen (stabil, Staging, täglich)</target>
         <note />
       </trans-unit>
+      <trans-unit id="CreateProjectDirectlyInSelectedFolderChoice">
+        <source>Directly in the selected folder</source>
+        <target state="new">Directly in the selected folder</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CreateProjectNameSubdirectoryChoice">
+        <source>In a subdirectory named '{0}' in the selected folder</source>
+        <target state="new">In a subdirectory named '{0}' in the selected folder</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Description">
         <source>Create a new app from an Aspire starter template</source>
         <target state="needs-review-translation">Erstellen Sie ein neues Aspire-Projekt.</target>
@@ -90,6 +100,11 @@
       <trans-unit id="SelectATemplateVersion">
         <source>Select a template version:</source>
         <target state="translated">Vorlagenversion auswählen:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SelectProjectCreationLocation">
+        <source>Where do you want the project to be created?</source>
+        <target state="new">Where do you want the project to be created?</target>
         <note />
       </trans-unit>
       <trans-unit id="SourceArgumentDescription">

--- a/src/Aspire.Cli/Resources/xlf/NewCommandStrings.es.xlf
+++ b/src/Aspire.Cli/Resources/xlf/NewCommandStrings.es.xlf
@@ -12,6 +12,16 @@
         <target state="translated">Canal que se va a usar para plantillas (estable, de ensayo, diariamente)</target>
         <note />
       </trans-unit>
+      <trans-unit id="CreateProjectDirectlyInSelectedFolderChoice">
+        <source>Directly in the selected folder</source>
+        <target state="new">Directly in the selected folder</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CreateProjectNameSubdirectoryChoice">
+        <source>In a subdirectory named '{0}' in the selected folder</source>
+        <target state="new">In a subdirectory named '{0}' in the selected folder</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Description">
         <source>Create a new app from an Aspire starter template</source>
         <target state="needs-review-translation">Crear un nuevo proyecto Aspire.</target>
@@ -90,6 +100,11 @@
       <trans-unit id="SelectATemplateVersion">
         <source>Select a template version:</source>
         <target state="translated">Seleccione una versión de plantilla:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SelectProjectCreationLocation">
+        <source>Where do you want the project to be created?</source>
+        <target state="new">Where do you want the project to be created?</target>
         <note />
       </trans-unit>
       <trans-unit id="SourceArgumentDescription">

--- a/src/Aspire.Cli/Resources/xlf/NewCommandStrings.fr.xlf
+++ b/src/Aspire.Cli/Resources/xlf/NewCommandStrings.fr.xlf
@@ -12,6 +12,16 @@
         <target state="translated">Canal à utiliser pour les modèles (stable, gestion intermédiaire, quotidien)</target>
         <note />
       </trans-unit>
+      <trans-unit id="CreateProjectDirectlyInSelectedFolderChoice">
+        <source>Directly in the selected folder</source>
+        <target state="new">Directly in the selected folder</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CreateProjectNameSubdirectoryChoice">
+        <source>In a subdirectory named '{0}' in the selected folder</source>
+        <target state="new">In a subdirectory named '{0}' in the selected folder</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Description">
         <source>Create a new app from an Aspire starter template</source>
         <target state="needs-review-translation">Créez un nouveau projet Aspire.</target>
@@ -90,6 +100,11 @@
       <trans-unit id="SelectATemplateVersion">
         <source>Select a template version:</source>
         <target state="translated">Sélectionner une version de modèle :</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SelectProjectCreationLocation">
+        <source>Where do you want the project to be created?</source>
+        <target state="new">Where do you want the project to be created?</target>
         <note />
       </trans-unit>
       <trans-unit id="SourceArgumentDescription">

--- a/src/Aspire.Cli/Resources/xlf/NewCommandStrings.it.xlf
+++ b/src/Aspire.Cli/Resources/xlf/NewCommandStrings.it.xlf
@@ -12,6 +12,16 @@
         <target state="translated">Canale da usare per i modelli (stabile, temporaneo, giornaliero)</target>
         <note />
       </trans-unit>
+      <trans-unit id="CreateProjectDirectlyInSelectedFolderChoice">
+        <source>Directly in the selected folder</source>
+        <target state="new">Directly in the selected folder</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CreateProjectNameSubdirectoryChoice">
+        <source>In a subdirectory named '{0}' in the selected folder</source>
+        <target state="new">In a subdirectory named '{0}' in the selected folder</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Description">
         <source>Create a new app from an Aspire starter template</source>
         <target state="needs-review-translation">Creare un nuovo progetto Aspire.</target>
@@ -90,6 +100,11 @@
       <trans-unit id="SelectATemplateVersion">
         <source>Select a template version:</source>
         <target state="translated">Selezionare una versione di modello:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SelectProjectCreationLocation">
+        <source>Where do you want the project to be created?</source>
+        <target state="new">Where do you want the project to be created?</target>
         <note />
       </trans-unit>
       <trans-unit id="SourceArgumentDescription">

--- a/src/Aspire.Cli/Resources/xlf/NewCommandStrings.ja.xlf
+++ b/src/Aspire.Cli/Resources/xlf/NewCommandStrings.ja.xlf
@@ -12,6 +12,16 @@
         <target state="translated">テンプレートに使用するチャネル (安定、ステージング、毎日)</target>
         <note />
       </trans-unit>
+      <trans-unit id="CreateProjectDirectlyInSelectedFolderChoice">
+        <source>Directly in the selected folder</source>
+        <target state="new">Directly in the selected folder</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CreateProjectNameSubdirectoryChoice">
+        <source>In a subdirectory named '{0}' in the selected folder</source>
+        <target state="new">In a subdirectory named '{0}' in the selected folder</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Description">
         <source>Create a new app from an Aspire starter template</source>
         <target state="needs-review-translation">新しい Aspire プロジェクトを作成します。</target>
@@ -90,6 +100,11 @@
       <trans-unit id="SelectATemplateVersion">
         <source>Select a template version:</source>
         <target state="translated">テンプレート のバージョンを選択してください:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SelectProjectCreationLocation">
+        <source>Where do you want the project to be created?</source>
+        <target state="new">Where do you want the project to be created?</target>
         <note />
       </trans-unit>
       <trans-unit id="SourceArgumentDescription">

--- a/src/Aspire.Cli/Resources/xlf/NewCommandStrings.ko.xlf
+++ b/src/Aspire.Cli/Resources/xlf/NewCommandStrings.ko.xlf
@@ -12,6 +12,16 @@
         <target state="translated">템플릿에 사용할 채널(안정, 스테이징, 데일리)</target>
         <note />
       </trans-unit>
+      <trans-unit id="CreateProjectDirectlyInSelectedFolderChoice">
+        <source>Directly in the selected folder</source>
+        <target state="new">Directly in the selected folder</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CreateProjectNameSubdirectoryChoice">
+        <source>In a subdirectory named '{0}' in the selected folder</source>
+        <target state="new">In a subdirectory named '{0}' in the selected folder</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Description">
         <source>Create a new app from an Aspire starter template</source>
         <target state="needs-review-translation">새 Aspire 프로젝트를 만듭니다.</target>
@@ -90,6 +100,11 @@
       <trans-unit id="SelectATemplateVersion">
         <source>Select a template version:</source>
         <target state="translated">템플릿 버전 선택:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SelectProjectCreationLocation">
+        <source>Where do you want the project to be created?</source>
+        <target state="new">Where do you want the project to be created?</target>
         <note />
       </trans-unit>
       <trans-unit id="SourceArgumentDescription">

--- a/src/Aspire.Cli/Resources/xlf/NewCommandStrings.pl.xlf
+++ b/src/Aspire.Cli/Resources/xlf/NewCommandStrings.pl.xlf
@@ -12,6 +12,16 @@
         <target state="translated">Kanał do użycia dla szablonów (stabilny, przejściowy, zdalny)</target>
         <note />
       </trans-unit>
+      <trans-unit id="CreateProjectDirectlyInSelectedFolderChoice">
+        <source>Directly in the selected folder</source>
+        <target state="new">Directly in the selected folder</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CreateProjectNameSubdirectoryChoice">
+        <source>In a subdirectory named '{0}' in the selected folder</source>
+        <target state="new">In a subdirectory named '{0}' in the selected folder</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Description">
         <source>Create a new app from an Aspire starter template</source>
         <target state="needs-review-translation">Utwórz nowy projekt usługi Aspire.</target>
@@ -90,6 +100,11 @@
       <trans-unit id="SelectATemplateVersion">
         <source>Select a template version:</source>
         <target state="translated">Wybierz wersję szablonu:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SelectProjectCreationLocation">
+        <source>Where do you want the project to be created?</source>
+        <target state="new">Where do you want the project to be created?</target>
         <note />
       </trans-unit>
       <trans-unit id="SourceArgumentDescription">

--- a/src/Aspire.Cli/Resources/xlf/NewCommandStrings.pt-BR.xlf
+++ b/src/Aspire.Cli/Resources/xlf/NewCommandStrings.pt-BR.xlf
@@ -12,6 +12,16 @@
         <target state="translated">Canal a ser usado para modelos (estável, preparo, diariamente)</target>
         <note />
       </trans-unit>
+      <trans-unit id="CreateProjectDirectlyInSelectedFolderChoice">
+        <source>Directly in the selected folder</source>
+        <target state="new">Directly in the selected folder</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CreateProjectNameSubdirectoryChoice">
+        <source>In a subdirectory named '{0}' in the selected folder</source>
+        <target state="new">In a subdirectory named '{0}' in the selected folder</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Description">
         <source>Create a new app from an Aspire starter template</source>
         <target state="needs-review-translation">Criar um projeto Aspire.</target>
@@ -90,6 +100,11 @@
       <trans-unit id="SelectATemplateVersion">
         <source>Select a template version:</source>
         <target state="translated">Selecione uma versão de modelo:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SelectProjectCreationLocation">
+        <source>Where do you want the project to be created?</source>
+        <target state="new">Where do you want the project to be created?</target>
         <note />
       </trans-unit>
       <trans-unit id="SourceArgumentDescription">

--- a/src/Aspire.Cli/Resources/xlf/NewCommandStrings.ru.xlf
+++ b/src/Aspire.Cli/Resources/xlf/NewCommandStrings.ru.xlf
@@ -12,6 +12,16 @@
         <target state="translated">Используемый канал для шаблонов (стабильный, промежуточный, ежедневный)</target>
         <note />
       </trans-unit>
+      <trans-unit id="CreateProjectDirectlyInSelectedFolderChoice">
+        <source>Directly in the selected folder</source>
+        <target state="new">Directly in the selected folder</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CreateProjectNameSubdirectoryChoice">
+        <source>In a subdirectory named '{0}' in the selected folder</source>
+        <target state="new">In a subdirectory named '{0}' in the selected folder</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Description">
         <source>Create a new app from an Aspire starter template</source>
         <target state="needs-review-translation">Создайте новый проект Aspire.</target>
@@ -90,6 +100,11 @@
       <trans-unit id="SelectATemplateVersion">
         <source>Select a template version:</source>
         <target state="translated">Выберите версию шаблона:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SelectProjectCreationLocation">
+        <source>Where do you want the project to be created?</source>
+        <target state="new">Where do you want the project to be created?</target>
         <note />
       </trans-unit>
       <trans-unit id="SourceArgumentDescription">

--- a/src/Aspire.Cli/Resources/xlf/NewCommandStrings.tr.xlf
+++ b/src/Aspire.Cli/Resources/xlf/NewCommandStrings.tr.xlf
@@ -12,6 +12,16 @@
         <target state="translated">Şablonlar için kullanılacak kanal (kararlı, hazırlama, günlük)</target>
         <note />
       </trans-unit>
+      <trans-unit id="CreateProjectDirectlyInSelectedFolderChoice">
+        <source>Directly in the selected folder</source>
+        <target state="new">Directly in the selected folder</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CreateProjectNameSubdirectoryChoice">
+        <source>In a subdirectory named '{0}' in the selected folder</source>
+        <target state="new">In a subdirectory named '{0}' in the selected folder</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Description">
         <source>Create a new app from an Aspire starter template</source>
         <target state="needs-review-translation">Yeni bir Aspire projesi oluşturun.</target>
@@ -90,6 +100,11 @@
       <trans-unit id="SelectATemplateVersion">
         <source>Select a template version:</source>
         <target state="translated">Bir şablon sürümü seçin:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SelectProjectCreationLocation">
+        <source>Where do you want the project to be created?</source>
+        <target state="new">Where do you want the project to be created?</target>
         <note />
       </trans-unit>
       <trans-unit id="SourceArgumentDescription">

--- a/src/Aspire.Cli/Resources/xlf/NewCommandStrings.zh-Hans.xlf
+++ b/src/Aspire.Cli/Resources/xlf/NewCommandStrings.zh-Hans.xlf
@@ -12,6 +12,16 @@
         <target state="translated">用于模板的频道(稳定、暂存、每日)</target>
         <note />
       </trans-unit>
+      <trans-unit id="CreateProjectDirectlyInSelectedFolderChoice">
+        <source>Directly in the selected folder</source>
+        <target state="new">Directly in the selected folder</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CreateProjectNameSubdirectoryChoice">
+        <source>In a subdirectory named '{0}' in the selected folder</source>
+        <target state="new">In a subdirectory named '{0}' in the selected folder</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Description">
         <source>Create a new app from an Aspire starter template</source>
         <target state="needs-review-translation">创建新的 Aspire 项目。</target>
@@ -90,6 +100,11 @@
       <trans-unit id="SelectATemplateVersion">
         <source>Select a template version:</source>
         <target state="translated">选择模板版本:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SelectProjectCreationLocation">
+        <source>Where do you want the project to be created?</source>
+        <target state="new">Where do you want the project to be created?</target>
         <note />
       </trans-unit>
       <trans-unit id="SourceArgumentDescription">

--- a/src/Aspire.Cli/Resources/xlf/NewCommandStrings.zh-Hant.xlf
+++ b/src/Aspire.Cli/Resources/xlf/NewCommandStrings.zh-Hant.xlf
@@ -12,6 +12,16 @@
         <target state="translated">用於範本的通道 (穩定、暫存、每日)</target>
         <note />
       </trans-unit>
+      <trans-unit id="CreateProjectDirectlyInSelectedFolderChoice">
+        <source>Directly in the selected folder</source>
+        <target state="new">Directly in the selected folder</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CreateProjectNameSubdirectoryChoice">
+        <source>In a subdirectory named '{0}' in the selected folder</source>
+        <target state="new">In a subdirectory named '{0}' in the selected folder</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Description">
         <source>Create a new app from an Aspire starter template</source>
         <target state="needs-review-translation">建立新的 Aspire 專案。</target>
@@ -90,6 +100,11 @@
       <trans-unit id="SelectATemplateVersion">
         <source>Select a template version:</source>
         <target state="translated">選取範本版本:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SelectProjectCreationLocation">
+        <source>Where do you want the project to be created?</source>
+        <target state="new">Where do you want the project to be created?</target>
         <note />
       </trans-unit>
       <trans-unit id="SourceArgumentDescription">

--- a/src/Aspire.Cli/Templating/CliTemplateFactory.cs
+++ b/src/Aspire.Cli/Templating/CliTemplateFactory.cs
@@ -229,16 +229,45 @@ internal sealed partial class CliTemplateFactory : ITemplateFactory
 
     private async Task<string?> ResolveOutputPathAsync(TemplateInputs inputs, Func<CliExecutionContext, string, string> pathDeriver, string projectName, System.CommandLine.ParseResult parseResult, CancellationToken cancellationToken)
     {
-        return await OutputPathHelper.ResolveOutputPathAsync(
+        var isExtensionHost = ExtensionHelper.IsExtensionHost(_interactionService, out _, out _);
+        var createProjectNameSubdirectory = await OutputPathHelper.ShouldCreateProjectNameSubdirectoryAsync(
+            _interactionService,
+            isExtensionHost,
+            inputs.Output is not null,
+            projectName,
+            cancellationToken);
+
+        var outputPath = await OutputPathHelper.ResolveOutputPathAsync(
             inputs.Output,
             _executionContext.WorkingDirectory.FullName,
             async () =>
             {
                 var defaultOutputPath = pathDeriver(_executionContext, projectName);
-                var outputPathValidator = OutputPathHelper.CreateOutputPathValidator(_executionContext.WorkingDirectory.FullName);
+                var outputPathValidator = createProjectNameSubdirectory
+                    ? OutputPathHelper.CreateExtensionOutputPathValidator(_executionContext.WorkingDirectory.FullName, projectName)
+                    : OutputPathHelper.CreateOutputPathValidator(_executionContext.WorkingDirectory.FullName);
                 return await _prompter.PromptForOutputPath(defaultOutputPath, parseResult, outputPathValidator, cancellationToken);
             },
             _interactionService);
+
+        if (outputPath is null)
+        {
+            return null;
+        }
+
+        if (createProjectNameSubdirectory)
+        {
+            var extensionOutputPath = OutputPathHelper.ResolveExtensionOutputPath(outputPath, projectName, _executionContext.WorkingDirectory.FullName, inputs.Output is not null);
+            if (extensionOutputPath.ErrorMessage is not null)
+            {
+                _interactionService.DisplayError(extensionOutputPath.ErrorMessage);
+                return null;
+            }
+
+            outputPath = extensionOutputPath.OutputPath;
+        }
+
+        return outputPath;
     }
 
     private static string ApplyTokens(string content, string projectName, string projectNameLower, string aspireVersion, AppHostProfilePorts ports, string hostName = "localhost")

--- a/src/Aspire.Cli/Templating/CliTemplateFactory.cs
+++ b/src/Aspire.Cli/Templating/CliTemplateFactory.cs
@@ -230,44 +230,24 @@ internal sealed partial class CliTemplateFactory : ITemplateFactory
     private async Task<string?> ResolveOutputPathAsync(TemplateInputs inputs, Func<CliExecutionContext, string, string> pathDeriver, string projectName, System.CommandLine.ParseResult parseResult, CancellationToken cancellationToken)
     {
         var isExtensionHost = ExtensionHelper.IsExtensionHost(_interactionService, out _, out _);
-        var createProjectNameSubdirectory = await OutputPathHelper.ShouldCreateProjectNameSubdirectoryAsync(
+        var createProjectNameSubdirectory = await OutputPathHelper.PromptExtensionCreateProjectNameSubdirectoryAsync(
             _interactionService,
             isExtensionHost,
             inputs.Output is not null,
             projectName,
             cancellationToken);
 
-        var outputPath = await OutputPathHelper.ResolveOutputPathAsync(
+        var outputPathResolver = OutputPathHelper.CreateProjectNameSubdirectoryOutputPathResolver(createProjectNameSubdirectory, projectName);
+        return await OutputPathHelper.ResolveOutputPathAsync(
             inputs.Output,
             _executionContext.WorkingDirectory.FullName,
             async () =>
             {
                 var defaultOutputPath = pathDeriver(_executionContext, projectName);
-                var outputPathValidator = createProjectNameSubdirectory
-                    ? OutputPathHelper.CreateExtensionOutputPathValidator(_executionContext.WorkingDirectory.FullName, projectName)
-                    : OutputPathHelper.CreateOutputPathValidator(_executionContext.WorkingDirectory.FullName);
-                return await _prompter.PromptForOutputPath(defaultOutputPath, parseResult, outputPathValidator, cancellationToken);
+                var outputPathValidator = OutputPathHelper.CreateOutputPathValidator(_executionContext.WorkingDirectory.FullName);
+                return await _prompter.PromptForOutputPath(defaultOutputPath, parseResult, outputPathValidator, cancellationToken, outputPathResolver);
             },
             _interactionService);
-
-        if (outputPath is null)
-        {
-            return null;
-        }
-
-        if (createProjectNameSubdirectory)
-        {
-            var extensionOutputPath = OutputPathHelper.ResolveExtensionOutputPath(outputPath, projectName, _executionContext.WorkingDirectory.FullName, inputs.Output is not null);
-            if (extensionOutputPath.ErrorMessage is not null)
-            {
-                _interactionService.DisplayError(extensionOutputPath.ErrorMessage);
-                return null;
-            }
-
-            outputPath = extensionOutputPath.OutputPath;
-        }
-
-        return outputPath;
     }
 
     private static string ApplyTokens(string content, string projectName, string projectNameLower, string aspireVersion, AppHostProfilePorts ports, string hostName = "localhost")

--- a/src/Aspire.Cli/Templating/DotNetTemplateFactory.cs
+++ b/src/Aspire.Cli/Templating/DotNetTemplateFactory.cs
@@ -595,13 +595,23 @@ internal class DotNetTemplateFactory(
 
     private async Task<string?> GetOutputPathAsync(TemplateInputs inputs, Func<CliExecutionContext, string, string> pathDeriver, string projectName, ParseResult parseResult, CancellationToken cancellationToken)
     {
+        var isExtensionHost = ExtensionHelper.IsExtensionHost(interactionService, out _, out _);
+        var createProjectNameSubdirectory = await OutputPathHelper.ShouldCreateProjectNameSubdirectoryAsync(
+            interactionService,
+            isExtensionHost,
+            inputs.Output is not null,
+            projectName,
+            cancellationToken);
+
         var outputPath = await OutputPathHelper.ResolveOutputPathAsync(
             inputs.Output,
             executionContext.WorkingDirectory.FullName,
             async () =>
             {
                 var defaultPath = pathDeriver(executionContext, projectName);
-                var validator = OutputPathHelper.CreateOutputPathValidator(executionContext.WorkingDirectory.FullName);
+                var validator = createProjectNameSubdirectory
+                    ? OutputPathHelper.CreateExtensionOutputPathValidator(executionContext.WorkingDirectory.FullName, projectName)
+                    : OutputPathHelper.CreateOutputPathValidator(executionContext.WorkingDirectory.FullName);
                 return await prompter.PromptForOutputPath(defaultPath, parseResult, validator, cancellationToken);
             },
             interactionService);
@@ -611,32 +621,16 @@ internal class DotNetTemplateFactory(
             return null;
         }
 
-        // When running in extension mode (VS Code), the folder picker returns the parent
-        // directory the user selected. Append the project name as a subdirectory so the
-        // project gets its own clean folder, matching the git-clone convention.
-        if (ExtensionHelper.IsExtensionHost(interactionService, out _, out _)
-            && !projectName.Equals(".", StringComparison.Ordinal)
-            && !projectName.Equals("..", StringComparison.Ordinal))
+        if (createProjectNameSubdirectory)
         {
-            var normalizedOutputPath = Path.TrimEndingDirectorySeparator(outputPath);
-
-            if (!string.Equals(Path.GetFileName(normalizedOutputPath), projectName, StringComparison.OrdinalIgnoreCase))
+            var extensionOutputPath = OutputPathHelper.ResolveExtensionOutputPath(outputPath, projectName, executionContext.WorkingDirectory.FullName, inputs.Output is not null);
+            if (extensionOutputPath.ErrorMessage is not null)
             {
-                outputPath = Path.Combine(normalizedOutputPath, projectName);
-            }
-            else
-            {
-                outputPath = normalizedOutputPath;
-            }
-
-            // Re-validate the adjusted path for non-empty directory since appending the
-            // project name may target a different directory than the one already validated.
-            var validationError = OutputPathHelper.ValidateOutputPath(outputPath, executionContext.WorkingDirectory.FullName, isExplicitOutput: inputs.Output is not null);
-            if (validationError is not null)
-            {
-                interactionService.DisplayError(validationError);
+                interactionService.DisplayError(extensionOutputPath.ErrorMessage);
                 return null;
             }
+
+            outputPath = extensionOutputPath.OutputPath;
         }
 
         return outputPath;

--- a/src/Aspire.Cli/Templating/DotNetTemplateFactory.cs
+++ b/src/Aspire.Cli/Templating/DotNetTemplateFactory.cs
@@ -596,43 +596,23 @@ internal class DotNetTemplateFactory(
     private async Task<string?> GetOutputPathAsync(TemplateInputs inputs, Func<CliExecutionContext, string, string> pathDeriver, string projectName, ParseResult parseResult, CancellationToken cancellationToken)
     {
         var isExtensionHost = ExtensionHelper.IsExtensionHost(interactionService, out _, out _);
-        var createProjectNameSubdirectory = await OutputPathHelper.ShouldCreateProjectNameSubdirectoryAsync(
+        var createProjectNameSubdirectory = await OutputPathHelper.PromptExtensionCreateProjectNameSubdirectoryAsync(
             interactionService,
             isExtensionHost,
             inputs.Output is not null,
             projectName,
             cancellationToken);
 
-        var outputPath = await OutputPathHelper.ResolveOutputPathAsync(
+        var outputPathResolver = OutputPathHelper.CreateProjectNameSubdirectoryOutputPathResolver(createProjectNameSubdirectory, projectName);
+        return await OutputPathHelper.ResolveOutputPathAsync(
             inputs.Output,
             executionContext.WorkingDirectory.FullName,
             async () =>
             {
                 var defaultPath = pathDeriver(executionContext, projectName);
-                var validator = createProjectNameSubdirectory
-                    ? OutputPathHelper.CreateExtensionOutputPathValidator(executionContext.WorkingDirectory.FullName, projectName)
-                    : OutputPathHelper.CreateOutputPathValidator(executionContext.WorkingDirectory.FullName);
-                return await prompter.PromptForOutputPath(defaultPath, parseResult, validator, cancellationToken);
+                var validator = OutputPathHelper.CreateOutputPathValidator(executionContext.WorkingDirectory.FullName);
+                return await prompter.PromptForOutputPath(defaultPath, parseResult, validator, cancellationToken, outputPathResolver);
             },
             interactionService);
-
-        if (outputPath is null)
-        {
-            return null;
-        }
-
-        if (createProjectNameSubdirectory)
-        {
-            var extensionOutputPath = OutputPathHelper.ResolveExtensionOutputPath(outputPath, projectName, executionContext.WorkingDirectory.FullName, inputs.Output is not null);
-            if (extensionOutputPath.ErrorMessage is not null)
-            {
-                interactionService.DisplayError(extensionOutputPath.ErrorMessage);
-                return null;
-            }
-
-            outputPath = extensionOutputPath.OutputPath;
-        }
-
-        return outputPath;
     }
 }

--- a/src/Aspire.Cli/Templating/OutputPathHelper.cs
+++ b/src/Aspire.Cli/Templating/OutputPathHelper.cs
@@ -86,6 +86,56 @@ internal static class OutputPathHelper
     }
 
     /// <summary>
+    /// Creates a validator for extension folder picker selections after applying the project directory adjustment.
+    /// </summary>
+    internal static Func<string, ValidationResult> CreateExtensionOutputPathValidator(string workingDirectory, string projectName)
+    {
+        return path =>
+        {
+            string? validationResult;
+            if (!CanCreateProjectNameSubdirectory(projectName))
+            {
+                validationResult = ValidateOutputPath(path, workingDirectory, isExplicitOutput: false);
+            }
+            else
+            {
+                validationResult = ResolveExtensionOutputPath(path, projectName, workingDirectory, isExplicitOutput: false).ErrorMessage;
+            }
+
+            if (validationResult is not null)
+            {
+                return ValidationResult.Error(validationResult);
+            }
+
+            return ValidationResult.Success();
+        };
+    }
+
+    internal static async Task<bool> ShouldCreateProjectNameSubdirectoryAsync(
+        IInteractionService interactionService,
+        bool isExtensionHost,
+        bool isExplicitOutput,
+        string projectName,
+        CancellationToken cancellationToken)
+    {
+        if (!isExtensionHost
+            || isExplicitOutput
+            || !CanCreateProjectNameSubdirectory(projectName))
+        {
+            return false;
+        }
+
+        var subdirectoryChoice = string.Format(CultureInfo.CurrentCulture, NewCommandStrings.CreateProjectNameSubdirectoryChoice, projectName);
+        var selectedChoice = await interactionService.PromptForSelectionAsync(
+            NewCommandStrings.SelectProjectCreationLocation,
+            [subdirectoryChoice, NewCommandStrings.CreateProjectDirectlyInSelectedFolderChoice],
+            static choice => choice,
+            cancellationToken: cancellationToken);
+
+        return string.Equals(selectedChoice, subdirectoryChoice, StringComparison.Ordinal);
+    }
+
+    /// <summary>
     /// Validates a (possibly relative) output path before resolution. Returns an error message if the path
     /// contains invalid characters or targets a non-empty existing directory, or <see langword="null"/> if valid.
     /// </summary>
@@ -106,6 +156,29 @@ internal static class OutputPathHelper
 
         return null;
     }
+
+    /// <summary>
+    /// Adjusts an extension-selected parent folder to point at the project-specific output directory.
+    /// </summary>
+    internal static (string OutputPath, string? ErrorMessage) ResolveExtensionOutputPath(string outputPath, string projectName, string workingDirectory, bool isExplicitOutput)
+    {
+        if (!CanCreateProjectNameSubdirectory(projectName))
+        {
+            return (outputPath, null);
+        }
+
+        var normalizedOutputPath = Path.TrimEndingDirectorySeparator(outputPath);
+        var adjustedOutputPath = string.Equals(Path.GetFileName(normalizedOutputPath), projectName, StringComparison.OrdinalIgnoreCase)
+            ? normalizedOutputPath
+            : Path.Combine(normalizedOutputPath, projectName);
+
+        var validationError = ValidateOutputPath(adjustedOutputPath, workingDirectory, isExplicitOutput);
+        return (adjustedOutputPath, validationError);
+    }
+
+    private static bool CanCreateProjectNameSubdirectory(string projectName) =>
+        !projectName.Equals(".", StringComparison.Ordinal)
+        && !projectName.Equals("..", StringComparison.Ordinal);
 
     private static string SanitizeBaseName(string baseName)
     {

--- a/src/Aspire.Cli/Templating/OutputPathHelper.cs
+++ b/src/Aspire.Cli/Templating/OutputPathHelper.cs
@@ -85,33 +85,7 @@ internal static class OutputPathHelper
         };
     }
 
-    /// <summary>
-    /// Creates a validator for extension folder picker selections after applying the project directory adjustment.
-    /// </summary>
-    internal static Func<string, ValidationResult> CreateExtensionOutputPathValidator(string workingDirectory, string projectName)
-    {
-        return path =>
-        {
-            string? validationResult;
-            if (!CanCreateProjectNameSubdirectory(projectName))
-            {
-                validationResult = ValidateOutputPath(path, workingDirectory, isExplicitOutput: false);
-            }
-            else
-            {
-                validationResult = ResolveExtensionOutputPath(path, projectName, workingDirectory, isExplicitOutput: false).ErrorMessage;
-            }
-
-            if (validationResult is not null)
-            {
-                return ValidationResult.Error(validationResult);
-            }
-
-            return ValidationResult.Success();
-        };
-    }
-
-    internal static async Task<bool> ShouldCreateProjectNameSubdirectoryAsync(
+    internal static async Task<bool> PromptExtensionCreateProjectNameSubdirectoryAsync(
         IInteractionService interactionService,
         bool isExtensionHost,
         bool isExplicitOutput,
@@ -133,6 +107,16 @@ internal static class OutputPathHelper
             cancellationToken: cancellationToken);
 
         return string.Equals(selectedChoice, subdirectoryChoice, StringComparison.Ordinal);
+    }
+
+    internal static Func<string, string>? CreateProjectNameSubdirectoryOutputPathResolver(bool createProjectNameSubdirectory, string projectName)
+    {
+        if (!createProjectNameSubdirectory || !CanCreateProjectNameSubdirectory(projectName))
+        {
+            return null;
+        }
+
+        return outputPath => AppendProjectNameSubdirectory(outputPath, projectName);
     }
 
     /// <summary>
@@ -157,23 +141,12 @@ internal static class OutputPathHelper
         return null;
     }
 
-    /// <summary>
-    /// Adjusts an extension-selected parent folder to point at the project-specific output directory.
-    /// </summary>
-    internal static (string OutputPath, string? ErrorMessage) ResolveExtensionOutputPath(string outputPath, string projectName, string workingDirectory, bool isExplicitOutput)
+    private static string AppendProjectNameSubdirectory(string outputPath, string projectName)
     {
-        if (!CanCreateProjectNameSubdirectory(projectName))
-        {
-            return (outputPath, null);
-        }
-
         var normalizedOutputPath = Path.TrimEndingDirectorySeparator(outputPath);
-        var adjustedOutputPath = string.Equals(Path.GetFileName(normalizedOutputPath), projectName, StringComparison.OrdinalIgnoreCase)
+        return string.Equals(Path.GetFileName(normalizedOutputPath), projectName, StringComparison.OrdinalIgnoreCase)
             ? normalizedOutputPath
             : Path.Combine(normalizedOutputPath, projectName);
-
-        var validationError = ValidateOutputPath(adjustedOutputPath, workingDirectory, isExplicitOutput);
-        return (adjustedOutputPath, validationError);
     }
 
     private static bool CanCreateProjectNameSubdirectory(string projectName) =>

--- a/tests/Aspire.Cli.Tests/Commands/NewCommandTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/NewCommandTests.cs
@@ -2242,6 +2242,317 @@ public class NewCommandTests(ITestOutputHelper outputHelper)
     }
 
     [Fact]
+    public async Task NewCommandInExtensionModeAppendsProjectNameToCliTemplateOutputPath()
+    {
+        const string projectName = "MyFirstApp";
+
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        DirectoryInfo? capturedTargetDirectory = null;
+
+        var services = CreateServiceCollection(workspace, options =>
+        {
+            options.CliHostEnvironmentFactory = _ => TestHelpers.CreateInteractiveHostEnvironment();
+            options.InteractionServiceFactory = sp => new TestExtensionInteractionService(sp);
+            options.ExtensionBackchannelFactory = _ => new TestExtensionBackchannel
+            {
+                HasCapabilityAsyncCallback = (c, _) => Task.FromResult(c is "baseline.v1"),
+            };
+
+            options.NewCommandPrompterFactory = (sp) =>
+            {
+                var interactionService = sp.GetRequiredService<IInteractionService>();
+                var prompter = new TestNewCommandPrompter(interactionService);
+
+                prompter.PromptForOutputPathCallback = (_) =>
+                    Path.Combine(workspace.WorkspaceRoot.FullName, "source");
+
+                return prompter;
+            };
+        });
+
+        services.AddSingleton<IScaffoldingService>(new TestScaffoldingService
+        {
+            ScaffoldAsyncCallback = (context, cancellationToken) =>
+            {
+                capturedTargetDirectory = context.TargetDirectory;
+                File.WriteAllText(Path.Combine(context.TargetDirectory.FullName, "apphost.ts"), "// test apphost");
+                return Task.FromResult(true);
+            }
+        });
+
+        using var provider = services.BuildServiceProvider();
+
+        var command = provider.GetRequiredService<RootCommand>();
+        var result = command.Parse($"new {KnownTemplateId.TypeScriptEmptyAppHost} --name {projectName} --version 9.2.0 --localhost-tld false");
+
+        var exitCode = await result.InvokeAsync().DefaultTimeout();
+
+        Assert.Equal(CliExitCodes.Success, exitCode);
+        Assert.NotNull(capturedTargetDirectory);
+        var expectedPath = Path.Combine(workspace.WorkspaceRoot.FullName, "source", projectName);
+        Assert.Equal(expectedPath, capturedTargetDirectory.FullName);
+        Assert.True(File.Exists(Path.Combine(expectedPath, "apphost.ts")));
+    }
+
+    [Fact]
+    public async Task NewCommandInExtensionModeValidatesAdjustedCliTemplateOutputPath()
+    {
+        const string projectName = "MyFirstApp";
+
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        var selectedParent = workspace.CreateDirectory("source");
+        File.WriteAllText(Path.Combine(selectedParent.FullName, "existing.txt"), "existing content");
+
+        DirectoryInfo? capturedTargetDirectory = null;
+        var selectedParentWasValidated = false;
+
+        var services = CreateServiceCollection(workspace, options =>
+        {
+            options.CliHostEnvironmentFactory = _ => TestHelpers.CreateInteractiveHostEnvironment();
+            options.InteractionServiceFactory = sp => new TestExtensionInteractionService(sp);
+            options.ExtensionBackchannelFactory = _ => new TestExtensionBackchannel
+            {
+                HasCapabilityAsyncCallback = (c, _) => Task.FromResult(c is "baseline.v1"),
+            };
+
+            options.NewCommandPrompterFactory = (sp) =>
+            {
+                var interactionService = sp.GetRequiredService<IInteractionService>();
+                var prompter = new TestNewCommandPrompter(interactionService);
+
+                prompter.PromptForOutputPathWithValidatorCallback = (_, validator) =>
+                {
+                    Assert.NotNull(validator);
+                    var validationResult = validator(selectedParent.FullName);
+                    selectedParentWasValidated = true;
+                    Assert.True(validationResult.Successful, validationResult.Message);
+                    return selectedParent.FullName;
+                };
+
+                return prompter;
+            };
+        });
+
+        services.AddSingleton<IScaffoldingService>(new TestScaffoldingService
+        {
+            ScaffoldAsyncCallback = (context, cancellationToken) =>
+            {
+                capturedTargetDirectory = context.TargetDirectory;
+                File.WriteAllText(Path.Combine(context.TargetDirectory.FullName, "apphost.ts"), "// test apphost");
+                return Task.FromResult(true);
+            }
+        });
+
+        using var provider = services.BuildServiceProvider();
+
+        var command = provider.GetRequiredService<RootCommand>();
+        var result = command.Parse($"new {KnownTemplateId.TypeScriptEmptyAppHost} --name {projectName} --version 9.2.0 --localhost-tld false");
+
+        var exitCode = await result.InvokeAsync().DefaultTimeout();
+
+        Assert.Equal(CliExitCodes.Success, exitCode);
+        Assert.True(selectedParentWasValidated);
+        Assert.NotNull(capturedTargetDirectory);
+        var expectedPath = Path.Combine(selectedParent.FullName, projectName);
+        Assert.Equal(expectedPath, capturedTargetDirectory.FullName);
+        Assert.True(File.Exists(Path.Combine(expectedPath, "apphost.ts")));
+    }
+
+    [Fact]
+    public async Task NewCommandInExtensionModePromptsBeforeFolderPickerForCliTemplateSubdirectory()
+    {
+        const string projectName = "MyFirstApp";
+
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        var selectedParent = workspace.CreateDirectory("source");
+        DirectoryInfo? capturedTargetDirectory = null;
+        var selectionPrompted = false;
+        const string expectedPrompt = "Where do you want the project to be created?";
+        var expectedSubdirectoryChoice = $"In a subdirectory named '{projectName}' in the selected folder";
+        const string expectedDirectChoice = "Directly in the selected folder";
+
+        var services = CreateServiceCollection(workspace, options =>
+        {
+            options.CliHostEnvironmentFactory = _ => TestHelpers.CreateInteractiveHostEnvironment();
+            options.InteractionServiceFactory = sp => new TestExtensionInteractionService(sp)
+            {
+                ConfirmCallback = (_, defaultValue) => defaultValue,
+                SelectionCallback = (promptText, choices) =>
+                {
+                    Assert.Equal(expectedPrompt, promptText);
+                    Assert.Equal([expectedSubdirectoryChoice, expectedDirectChoice], choices);
+                    selectionPrompted = true;
+                    return expectedSubdirectoryChoice;
+                }
+            };
+            options.ExtensionBackchannelFactory = _ => new TestExtensionBackchannel
+            {
+                HasCapabilityAsyncCallback = (c, _) => Task.FromResult(c is "baseline.v1"),
+            };
+
+            options.NewCommandPrompterFactory = (sp) =>
+            {
+                var interactionService = sp.GetRequiredService<IInteractionService>();
+                var prompter = new TestNewCommandPrompter(interactionService);
+
+                prompter.PromptForOutputPathCallback = (_) =>
+                {
+                    Assert.True(selectionPrompted);
+                    return selectedParent.FullName;
+                };
+
+                return prompter;
+            };
+        });
+
+        services.AddSingleton<IScaffoldingService>(new TestScaffoldingService
+        {
+            ScaffoldAsyncCallback = (context, cancellationToken) =>
+            {
+                capturedTargetDirectory = context.TargetDirectory;
+                File.WriteAllText(Path.Combine(context.TargetDirectory.FullName, "apphost.ts"), "// test apphost");
+                return Task.FromResult(true);
+            }
+        });
+
+        using var provider = services.BuildServiceProvider();
+
+        var command = provider.GetRequiredService<RootCommand>();
+        var result = command.Parse($"new {KnownTemplateId.TypeScriptEmptyAppHost} --name {projectName} --version 9.2.0 --localhost-tld false");
+
+        var exitCode = await result.InvokeAsync().DefaultTimeout();
+
+        Assert.Equal(CliExitCodes.Success, exitCode);
+        Assert.True(selectionPrompted);
+        Assert.NotNull(capturedTargetDirectory);
+        var expectedPath = Path.Combine(selectedParent.FullName, projectName);
+        Assert.Equal(expectedPath, capturedTargetDirectory.FullName);
+        Assert.True(File.Exists(Path.Combine(expectedPath, "apphost.ts")));
+    }
+
+    [Fact]
+    public async Task NewCommandInExtensionModeUsesSelectedCliTemplateOutputPathWhenSubdirectoryDeclined()
+    {
+        const string projectName = "MyFirstApp";
+
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        var selectedOutputPath = workspace.CreateDirectory("source");
+        DirectoryInfo? capturedTargetDirectory = null;
+        var selectionPrompted = false;
+        const string expectedPrompt = "Where do you want the project to be created?";
+        var expectedSubdirectoryChoice = $"In a subdirectory named '{projectName}' in the selected folder";
+        const string expectedDirectChoice = "Directly in the selected folder";
+
+        var services = CreateServiceCollection(workspace, options =>
+        {
+            options.CliHostEnvironmentFactory = _ => TestHelpers.CreateInteractiveHostEnvironment();
+            options.InteractionServiceFactory = sp => new TestExtensionInteractionService(sp)
+            {
+                ConfirmCallback = (_, defaultValue) => defaultValue,
+                SelectionCallback = (promptText, choices) =>
+                {
+                    Assert.Equal(expectedPrompt, promptText);
+                    Assert.Equal([expectedSubdirectoryChoice, expectedDirectChoice], choices);
+                    selectionPrompted = true;
+                    return expectedDirectChoice;
+                }
+            };
+            options.ExtensionBackchannelFactory = _ => new TestExtensionBackchannel
+            {
+                HasCapabilityAsyncCallback = (c, _) => Task.FromResult(c is "baseline.v1"),
+            };
+
+            options.NewCommandPrompterFactory = (sp) =>
+            {
+                var interactionService = sp.GetRequiredService<IInteractionService>();
+                var prompter = new TestNewCommandPrompter(interactionService);
+
+                prompter.PromptForOutputPathCallback = (_) =>
+                    selectedOutputPath.FullName;
+
+                return prompter;
+            };
+        });
+
+        services.AddSingleton<IScaffoldingService>(new TestScaffoldingService
+        {
+            ScaffoldAsyncCallback = (context, cancellationToken) =>
+            {
+                capturedTargetDirectory = context.TargetDirectory;
+                File.WriteAllText(Path.Combine(context.TargetDirectory.FullName, "apphost.ts"), "// test apphost");
+                return Task.FromResult(true);
+            }
+        });
+
+        using var provider = services.BuildServiceProvider();
+
+        var command = provider.GetRequiredService<RootCommand>();
+        var result = command.Parse($"new {KnownTemplateId.TypeScriptEmptyAppHost} --name {projectName} --version 9.2.0 --localhost-tld false");
+
+        var exitCode = await result.InvokeAsync().DefaultTimeout();
+
+        Assert.Equal(CliExitCodes.Success, exitCode);
+        Assert.True(selectionPrompted);
+        Assert.NotNull(capturedTargetDirectory);
+        Assert.Equal(selectedOutputPath.FullName, capturedTargetDirectory.FullName);
+        Assert.True(File.Exists(Path.Combine(selectedOutputPath.FullName, "apphost.ts")));
+        Assert.False(File.Exists(Path.Combine(selectedOutputPath.FullName, projectName, "apphost.ts")));
+    }
+
+    [Fact]
+    public async Task NewCommandInExtensionModeDoesNotDoubleAppendProjectNameToCliTemplateOutputPath()
+    {
+        const string projectName = "MyFirstApp";
+
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        DirectoryInfo? capturedTargetDirectory = null;
+
+        var services = CreateServiceCollection(workspace, options =>
+        {
+            options.CliHostEnvironmentFactory = _ => TestHelpers.CreateInteractiveHostEnvironment();
+            options.InteractionServiceFactory = sp => new TestExtensionInteractionService(sp);
+            options.ExtensionBackchannelFactory = _ => new TestExtensionBackchannel
+            {
+                HasCapabilityAsyncCallback = (c, _) => Task.FromResult(c is "baseline.v1"),
+            };
+
+            options.NewCommandPrompterFactory = (sp) =>
+            {
+                var interactionService = sp.GetRequiredService<IInteractionService>();
+                var prompter = new TestNewCommandPrompter(interactionService);
+
+                prompter.PromptForOutputPathCallback = (_) =>
+                    Path.Combine(workspace.WorkspaceRoot.FullName, "source", projectName);
+
+                return prompter;
+            };
+        });
+
+        services.AddSingleton<IScaffoldingService>(new TestScaffoldingService
+        {
+            ScaffoldAsyncCallback = (context, cancellationToken) =>
+            {
+                capturedTargetDirectory = context.TargetDirectory;
+                File.WriteAllText(Path.Combine(context.TargetDirectory.FullName, "apphost.ts"), "// test apphost");
+                return Task.FromResult(true);
+            }
+        });
+
+        using var provider = services.BuildServiceProvider();
+
+        var command = provider.GetRequiredService<RootCommand>();
+        var result = command.Parse($"new {KnownTemplateId.TypeScriptEmptyAppHost} --name {projectName} --version 9.2.0 --localhost-tld false");
+
+        var exitCode = await result.InvokeAsync().DefaultTimeout();
+
+        Assert.Equal(CliExitCodes.Success, exitCode);
+        Assert.NotNull(capturedTargetDirectory);
+        var expectedPath = Path.Combine(workspace.WorkspaceRoot.FullName, "source", projectName);
+        Assert.Equal(expectedPath, capturedTargetDirectory.FullName);
+        Assert.True(File.Exists(Path.Combine(expectedPath, "apphost.ts")));
+    }
+
+    [Fact]
     public async Task NewCommandNonInteractive_SuppressAgentInitTrue_SkipsAgentInit()
     {
         using var workspace = TemporaryWorkspace.Create(outputHelper);

--- a/tests/Aspire.Cli.Tests/Templating/DotNetTemplateFactoryTests.cs
+++ b/tests/Aspire.Cli.Tests/Templating/DotNetTemplateFactoryTests.cs
@@ -473,7 +473,7 @@ public class DotNetTemplateFactoryTests
         public Task<string> PromptForProjectNameAsync(string defaultName, ParseResult parseResult, CancellationToken cancellationToken)
             => throw new NotImplementedException();
 
-        public Task<string> PromptForOutputPath(string defaultPath, ParseResult parseResult, Func<string, ValidationResult>? validator = null, CancellationToken cancellationToken = default)
+        public Task<string> PromptForOutputPath(string defaultPath, ParseResult parseResult, Func<string, ValidationResult>? validator = null, CancellationToken cancellationToken = default, Func<string, string>? outputPathResolver = null)
             => throw new NotImplementedException();
 
         public Task<(Aspire.Shared.NuGetPackageCli Package, PackageChannel Channel)> PromptForTemplatesVersionAsync(IEnumerable<(Aspire.Shared.NuGetPackageCli Package, PackageChannel Channel)> packages, CancellationToken cancellationToken)

--- a/tests/Aspire.Cli.Tests/TestServices/TestExtensionInteractionService.cs
+++ b/tests/Aspire.Cli.Tests/TestServices/TestExtensionInteractionService.cs
@@ -23,6 +23,8 @@ internal sealed class TestExtensionInteractionService(IServiceProvider servicePr
     public Action<DashboardUrlsState>? DisplayDashboardUrlsCallback { get; set; }
     public Action<string, string?, bool>? StartDebugSessionCallback { get; set; }
     public Action<string, bool>? ConsoleDisplaySubtleMessageCallback { get; set; }
+    public Func<string, bool, bool>? ConfirmCallback { get; set; }
+    public Func<string, IReadOnlyList<string>, string>? SelectionCallback { get; set; }
 
     public IExtensionBackchannel Backchannel { get; } = serviceProvider.GetRequiredService<IExtensionBackchannel>();
 
@@ -48,12 +50,23 @@ internal sealed class TestExtensionInteractionService(IServiceProvider servicePr
 
     public Task<T> PromptForSelectionAsync<T>(string promptText, IEnumerable<T> choices, Func<T, string> choiceFormatter, PromptBinding<string?>? binding = null, bool echoSelected = true, CancellationToken cancellationToken = default) where T : notnull
     {
-        if (!choices.Any())
+        var choicesArray = choices.ToArray();
+        if (choicesArray.Length == 0)
         {
             throw new EmptyChoicesException($"No items available for selection: {promptText}");
         }
 
-        return Task.FromResult(choices.First());
+        if (SelectionCallback is not null)
+        {
+            var selected = SelectionCallback(promptText, choicesArray.Select(choiceFormatter).ToArray());
+            var matchingChoice = choicesArray.FirstOrDefault(c => string.Equals(choiceFormatter(c), selected, StringComparison.Ordinal));
+            if (matchingChoice is not null)
+            {
+                return Task.FromResult(matchingChoice);
+            }
+        }
+
+        return Task.FromResult(choicesArray.First());
     }
 
     public Task<IReadOnlyList<T>> PromptForSelectionsAsync<T>(string promptText, IEnumerable<T> choices, Func<T, string> choiceFormatter, IEnumerable<T>? preSelected = null, bool optional = false, PromptBinding<string?>? binding = null, bool echoSelected = true, CancellationToken cancellationToken = default) where T : notnull
@@ -124,7 +137,8 @@ internal sealed class TestExtensionInteractionService(IServiceProvider servicePr
 
     public Task<bool> PromptConfirmAsync(string promptText, PromptBinding<bool>? binding = null, CancellationToken cancellationToken = default)
     {
-        return Task.FromResult(true);
+        var defaultValue = binding?.DefaultValue ?? false;
+        return Task.FromResult(ConfirmCallback?.Invoke(promptText, defaultValue) ?? true);
     }
 
     public void DisplaySubtleMessage(string message, bool allowMarkup = false)

--- a/tests/Aspire.Cli.Tests/TestServices/TestNewCommandPrompter.cs
+++ b/tests/Aspire.Cli.Tests/TestServices/TestNewCommandPrompter.cs
@@ -17,6 +17,7 @@ internal sealed class TestNewCommandPrompter(IInteractionService interactionServ
     public Func<ITemplate[], ITemplate>? PromptForTemplateCallback { get; set; }
     public Func<string, string>? PromptForProjectNameCallback { get; set; }
     public Func<string, string>? PromptForOutputPathCallback { get; set; }
+    public Func<string, Func<string, ValidationResult>?, string>? PromptForOutputPathWithValidatorCallback { get; set; }
 
     public override Task<ITemplate> PromptForTemplateAsync(ITemplate[] validTemplates, CancellationToken cancellationToken)
     {
@@ -38,10 +39,14 @@ internal sealed class TestNewCommandPrompter(IInteractionService interactionServ
 
     public override Task<string> PromptForOutputPath(string path, ParseResult parseResult, Func<string, ValidationResult>? validator = null, CancellationToken cancellationToken = default)
     {
-        return PromptForOutputPathCallback switch
+        return PromptForOutputPathWithValidatorCallback switch
         {
-            { } callback => Task.FromResult(callback(path)),
-            _ => Task.FromResult(path) // If no callback is provided just accept the default.
+            { } callback => Task.FromResult(callback(path, validator)),
+            _ => PromptForOutputPathCallback switch
+            {
+                { } callback => Task.FromResult(callback(path)),
+                _ => Task.FromResult(path) // If no callback is provided just accept the default.
+            }
         };
     }
 

--- a/tests/Aspire.Cli.Tests/TestServices/TestNewCommandPrompter.cs
+++ b/tests/Aspire.Cli.Tests/TestServices/TestNewCommandPrompter.cs
@@ -37,17 +37,25 @@ internal sealed class TestNewCommandPrompter(IInteractionService interactionServ
         };
     }
 
-    public override Task<string> PromptForOutputPath(string path, ParseResult parseResult, Func<string, ValidationResult>? validator = null, CancellationToken cancellationToken = default)
+    public override Task<string> PromptForOutputPath(string path, ParseResult parseResult, Func<string, ValidationResult>? validator = null, CancellationToken cancellationToken = default, Func<string, string>? outputPathResolver = null)
     {
-        return PromptForOutputPathWithValidatorCallback switch
+        var resolvedValidator = validator;
+        if (validator is not null && outputPathResolver is not null)
         {
-            { } callback => Task.FromResult(callback(path, validator)),
+            resolvedValidator = candidatePath => validator(outputPathResolver(candidatePath));
+        }
+
+        var outputPath = PromptForOutputPathWithValidatorCallback switch
+        {
+            { } callback => callback(path, resolvedValidator),
             _ => PromptForOutputPathCallback switch
             {
-                { } callback => Task.FromResult(callback(path)),
-                _ => Task.FromResult(path) // If no callback is provided just accept the default.
+                { } callback => callback(path),
+                _ => path // If no callback is provided just accept the default.
             }
         };
+
+        return Task.FromResult(outputPathResolver?.Invoke(outputPath) ?? outputPath);
     }
 
     public override Task<(NuGetPackage Package, PackageChannel Channel)> PromptForTemplatesVersionAsync(IEnumerable<(NuGetPackage Package, PackageChannel Channel)> candidatePackages, CancellationToken cancellationToken)


### PR DESCRIPTION
## Description

Fixes #16850

When `aspire new` is launched from the VS Code extension, selecting a folder currently creates the new project directly inside that selected folder. This change asks users where the project should be created before opening the folder picker, so they can choose either a project-name subdirectory or the selected folder itself.

The resolved output path is shared by both CLI-owned templates and .NET templates, avoids double-appending the project name, and validates the final creation path. After creation, the VS Code extension adds the project folder to existing workspaces; when there is no open folder/workspace, it opens the created project folder.

### User-facing usage

The VS Code `aspire new` flow now asks:

```text
Where do you want the project to be created?
```

With choices:

```text
In a subdirectory named '{0}' in the selected folder
Directly in the selected folder
```

### Validation

- `cd extension && npm run compile-tests -- --pretty false && npm run lint && npm run unit-test -- --grep "openEditor"`
- `MSBUILDTERMINALLOGGER=false dotnet test --project tests/Aspire.Cli.Tests/Aspire.Cli.Tests.csproj --no-launch-profile -- --filter-class "*.NewCommandTests" --filter-not-trait "quarantined=true" --filter-not-trait "outerloop=true"`
- `git diff HEAD --check`

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
