### PR TITLE
Protect CLI bundle versions with leases

### DIFF
--- a/src/Aspire.Cli/Aspire.Cli.csproj
+++ b/src/Aspire.Cli/Aspire.Cli.csproj
@@ -128,6 +128,7 @@
     <Compile Include="$(SharedDir)AppHostProfilePortGenerator.cs" Link="Utils\AppHostProfilePortGenerator.cs" />
     <Compile Include="$(SharedDir)AssemblyVersionHelper.cs" Link="Utils\AssemblyVersionHelper.cs" />
     <Compile Include="$(SharedDir)BundleDiscovery.cs" Link="Layout\BundleDiscovery.cs" />
+    <Compile Include="$(SharedDir)BundleVersionLease.cs" Link="Bundles\BundleVersionLease.cs" />
     <Compile Include="$(SharedDir)ChannelExtensions.cs" Link="Utils\ChannelExtensions.cs" />
     <Compile Include="$(SharedDir)EnumerableExtensions.cs" Link="Utils\EnumerableExtensions.cs" />
     <Compile Include="$(SharedDir)KnownConfigNames.cs" Link="Utils\KnownConfigNames.cs" />

--- a/src/Aspire.Cli/Bundles/BundleLayoutLease.cs
+++ b/src/Aspire.Cli/Bundles/BundleLayoutLease.cs
@@ -1,0 +1,60 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Aspire.Cli.Layout;
+using Aspire.Shared;
+
+namespace Aspire.Cli.Bundles;
+
+/// <summary>
+/// Represents a bundle layout rooted in a stable version directory and, when applicable, its active lease.
+/// </summary>
+internal sealed class BundleLayoutLease : IDisposable
+{
+    private readonly BundleVersionLease? _lease;
+
+    internal BundleLayoutLease(string? versionId, string? versionDirectory, LayoutConfiguration layout, BundleVersionLease? lease)
+    {
+        VersionId = versionId;
+        VersionDirectory = versionDirectory;
+        Layout = layout;
+        _lease = lease;
+    }
+
+    /// <summary>
+    /// Gets the resolved bundle version id, or <see langword="null"/> for unleased fallback layouts.
+    /// </summary>
+    public string? VersionId { get; }
+
+    /// <summary>
+    /// Gets the resolved bundle version directory, or <see langword="null"/> for unleased fallback layouts.
+    /// </summary>
+    public string? VersionDirectory { get; }
+
+    /// <summary>
+    /// Gets the version-rooted layout configuration.
+    /// </summary>
+    public LayoutConfiguration Layout { get; }
+
+    /// <summary>
+    /// Gets whether this result holds an active version lease.
+    /// </summary>
+    public bool HasLease => _lease is not null;
+
+    /// <summary>
+    /// Adds lease handoff environment variables for a bundle-owned child process.
+    /// </summary>
+    public void AddEnvironment(IDictionary<string, string> environmentVariables)
+    {
+        if (VersionDirectory is not null)
+        {
+            BundleVersionLease.AddEnvironment(environmentVariables, VersionDirectory);
+        }
+    }
+
+    /// <inheritdoc/>
+    public void Dispose()
+    {
+        _lease?.Dispose();
+    }
+}

--- a/src/Aspire.Cli/Bundles/BundleLayoutLease.cs
+++ b/src/Aspire.Cli/Bundles/BundleLayoutLease.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Diagnostics;
 using Aspire.Cli.Layout;
 using Aspire.Shared;
 
@@ -13,23 +14,11 @@ internal sealed class BundleLayoutLease : IDisposable
 {
     private readonly BundleVersionLease? _lease;
 
-    internal BundleLayoutLease(string? versionId, string? versionDirectory, LayoutConfiguration layout, BundleVersionLease? lease)
+    internal BundleLayoutLease(LayoutConfiguration layout, BundleVersionLease? lease)
     {
-        VersionId = versionId;
-        VersionDirectory = versionDirectory;
         Layout = layout;
         _lease = lease;
     }
-
-    /// <summary>
-    /// Gets the resolved bundle version id, or <see langword="null"/> for unleased fallback layouts.
-    /// </summary>
-    public string? VersionId { get; }
-
-    /// <summary>
-    /// Gets the resolved bundle version directory, or <see langword="null"/> for unleased fallback layouts.
-    /// </summary>
-    public string? VersionDirectory { get; }
 
     /// <summary>
     /// Gets the version-rooted layout configuration.
@@ -45,10 +34,18 @@ internal sealed class BundleLayoutLease : IDisposable
     /// Adds lease handoff environment variables for a bundle-owned child process.
     /// </summary>
     public void AddEnvironment(IDictionary<string, string> environmentVariables)
+        => _lease?.AddEnvironment(environmentVariables);
+
+    /// <summary>
+    /// Adds lease handoff environment variables to a child process.
+    /// </summary>
+    public void AddEnvironment(ProcessStartInfo startInfo)
     {
-        if (VersionDirectory is not null)
+        ArgumentNullException.ThrowIfNull(startInfo);
+
+        if (_lease is not null)
         {
-            BundleVersionLease.AddEnvironment(environmentVariables, VersionDirectory);
+            startInfo.Environment[BundleDiscovery.BundleVersionDirectoryEnvVar] = _lease.VersionDirectory;
         }
     }
 

--- a/src/Aspire.Cli/Bundles/BundleService.cs
+++ b/src/Aspire.Cli/Bundles/BundleService.cs
@@ -70,36 +70,9 @@ internal sealed class BundleService(
     /// <inheritdoc/>
     public async Task EnsureExtractedAsync(CancellationToken cancellationToken = default)
     {
-        if (!IsBundle)
-        {
-            logger.LogDebug("No embedded bundle payload, skipping extraction.");
-            return;
-        }
-
-        var processPath = ProcessPathOverride ?? Environment.ProcessPath;
-        if (string.IsNullOrEmpty(processPath))
-        {
-            logger.LogDebug("ProcessPath is null or empty, skipping bundle extraction.");
-            return;
-        }
-
-        // The winget portable installer has no post-install hook, so the CLI
-        // self-stamps the install-route sidecar on first run. No-op on
-        // non-Windows and once the sidecar already exists.
-        if (wingetFirstRunProbe is not null && OperatingSystem.IsWindows())
-        {
-            var realBinaryPath = ResolveSymlinks(processPath, logger);
-            var binaryDir = Path.GetDirectoryName(realBinaryPath);
-            if (!string.IsNullOrEmpty(binaryDir))
-            {
-                wingetFirstRunProbe.Run(binaryDir);
-            }
-        }
-
-        var extractDir = GetDefaultExtractDir(processPath);
+        var extractDir = GetBundleExtractDirForCurrentProcess();
         if (string.IsNullOrEmpty(extractDir))
         {
-            logger.LogDebug("Could not determine extraction directory from {ProcessPath}, skipping.", processPath);
             return;
         }
 
@@ -123,11 +96,8 @@ internal sealed class BundleService(
     /// <inheritdoc/>
     public async Task<BundleLayoutLease?> EnsureExtractedAndAcquireLayoutAsync(string holderKind, string? commandName = null, CancellationToken cancellationToken = default)
     {
-        await EnsureExtractedAsync(cancellationToken).ConfigureAwait(false);
-
-        var processPath = ProcessPathOverride ?? Environment.ProcessPath;
-        var extractDir = string.IsNullOrEmpty(processPath) ? null : GetDefaultExtractDir(processPath);
-        if (!IsBundle || string.IsNullOrEmpty(extractDir))
+        var extractDir = GetBundleExtractDirForCurrentProcess();
+        if (string.IsNullOrEmpty(extractDir))
         {
             var fallbackLayout = layoutDiscovery.DiscoverLayout();
             return fallbackLayout is null
@@ -137,6 +107,16 @@ internal sealed class BundleService(
 
         var lockPath = Path.Combine(extractDir, ".aspire-bundle-lock");
         using var fileLock = await FileLock.AcquireAsync(lockPath, cancellationToken).ConfigureAwait(false);
+
+        // Extraction cleanup and lease acquisition must share the same critical section;
+        // otherwise a concurrent upgrade can delete the just-resolved active version
+        // before this process protects it with a lease.
+        var result = await ExtractAsyncCore(extractDir, force: false, cancellationToken).ConfigureAwait(false);
+        if (result is BundleExtractResult.ExtractionFailed)
+        {
+            throw new InvalidOperationException(
+                "Bundle extraction failed. Run 'aspire setup --force' to retry, or reinstall the Aspire CLI.");
+        }
 
         var activeVersion = ResolveActiveVersionDirectory(extractDir);
         if (activeVersion is null)
@@ -177,6 +157,11 @@ internal sealed class BundleService(
         using var fileLock = await FileLock.AcquireAsync(lockPath, cancellationToken).ConfigureAwait(false);
         logger.LogDebug("Bundle extraction lock acquired.");
 
+        return await ExtractAsyncCore(destinationPath, force, cancellationToken).ConfigureAwait(false);
+    }
+
+    private async Task<BundleExtractResult> ExtractAsyncCore(string destinationPath, bool force, CancellationToken cancellationToken)
+    {
         try
         {
             // Re-check after acquiring lock — another process may have already extracted
@@ -200,6 +185,44 @@ internal sealed class BundleService(
             logger.LogError(ex, "Failed to extract bundle to {Path}", destinationPath);
             return BundleExtractResult.ExtractionFailed;
         }
+    }
+
+    private string? GetBundleExtractDirForCurrentProcess()
+    {
+        if (!IsBundle)
+        {
+            logger.LogDebug("No embedded bundle payload, skipping extraction.");
+            return null;
+        }
+
+        var processPath = ProcessPathOverride ?? Environment.ProcessPath;
+        if (string.IsNullOrEmpty(processPath))
+        {
+            logger.LogDebug("ProcessPath is null or empty, skipping bundle extraction.");
+            return null;
+        }
+
+        // The winget portable installer has no post-install hook, so the CLI
+        // self-stamps the install-route sidecar on first run. No-op on
+        // non-Windows and once the sidecar already exists.
+        if (wingetFirstRunProbe is not null && OperatingSystem.IsWindows())
+        {
+            var realBinaryPath = ResolveSymlinks(processPath, logger);
+            var binaryDir = Path.GetDirectoryName(realBinaryPath);
+            if (!string.IsNullOrEmpty(binaryDir))
+            {
+                wingetFirstRunProbe.Run(binaryDir);
+            }
+        }
+
+        var extractDir = GetDefaultExtractDir(processPath);
+        if (string.IsNullOrEmpty(extractDir))
+        {
+            logger.LogDebug("Could not determine extraction directory from {ProcessPath}, skipping.", processPath);
+            return null;
+        }
+
+        return extractDir;
     }
 
     private async Task<BundleExtractResult> ExtractCoreAsync(string destinationPath, CancellationToken cancellationToken)

--- a/src/Aspire.Cli/Bundles/BundleService.cs
+++ b/src/Aspire.Cli/Bundles/BundleService.cs
@@ -121,6 +121,48 @@ internal sealed class BundleService(
     }
 
     /// <inheritdoc/>
+    public async Task<BundleLayoutLease?> EnsureExtractedAndAcquireLayoutAsync(string holderKind, string? commandName = null, CancellationToken cancellationToken = default)
+    {
+        await EnsureExtractedAsync(cancellationToken).ConfigureAwait(false);
+
+        var processPath = ProcessPathOverride ?? Environment.ProcessPath;
+        var extractDir = string.IsNullOrEmpty(processPath) ? null : GetDefaultExtractDir(processPath);
+        if (!IsBundle || string.IsNullOrEmpty(extractDir))
+        {
+            var fallbackLayout = layoutDiscovery.DiscoverLayout();
+            return fallbackLayout is null
+                ? null
+                : new BundleLayoutLease(versionId: null, versionDirectory: null, fallbackLayout, lease: null);
+        }
+
+        var lockPath = Path.Combine(extractDir, ".aspire-bundle-lock");
+        using var fileLock = await FileLock.AcquireAsync(lockPath, cancellationToken).ConfigureAwait(false);
+
+        var activeVersion = ResolveActiveVersionDirectory(extractDir);
+        if (activeVersion is null)
+        {
+            logger.LogDebug("Could not resolve an active bundle version under {ExtractDir}.", extractDir);
+            return null;
+        }
+
+        BundleVersionLease? lease = null;
+        try
+        {
+            lease = BundleVersionLease.Acquire(activeVersion.Value.VersionDirectory, holderKind, commandName);
+            return new BundleLayoutLease(
+                activeVersion.Value.VersionId,
+                activeVersion.Value.VersionDirectory,
+                CreateVersionRootedLayout(activeVersion.Value.VersionDirectory),
+                lease);
+        }
+        catch
+        {
+            lease?.Dispose();
+            throw;
+        }
+    }
+
+    /// <inheritdoc/>
     public async Task<BundleExtractResult> ExtractAsync(string destinationPath, bool force = false, CancellationToken cancellationToken = default)
     {
         if (!IsBundle)
@@ -545,8 +587,8 @@ internal sealed class BundleService(
 
     /// <summary>
     /// Best-effort sweep of the <c>versions/</c> directory, removing anything other
-    /// than the active version plus any <c>.tmp.*</c>, <c>.bad.*</c>, <c>.old.*</c>
-    /// leftovers. Locked items are softly renamed so they can be reaped next run.
+    /// than the active version. Directories with active leases are left untouched
+    /// and retried by a later extraction.
     /// </summary>
     internal static void TryCleanupStaleVersions(string versionsRoot, string activeVersionId)
     {
@@ -565,22 +607,80 @@ internal sealed class BundleService(
                 continue;
             }
 
+            if (BundleVersionLease.HasActiveLease(entry))
+            {
+                continue;
+            }
+
             try
             {
                 Directory.Delete(entry, recursive: true);
             }
             catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
             {
-                // Still in use — rename so it is out of the way and will be reaped next run.
-                try
-                {
-                    Directory.Move(entry, $"{entry}.old.{Environment.TickCount64}");
-                }
-                catch
-                {
-                }
+                // If deletion fails after lease probing, leave the directory untouched.
+                // A later setup/update can retry without invalidating a potential reader.
             }
         }
+    }
+
+    private static (string VersionId, string VersionDirectory)? ResolveActiveVersionDirectory(string extractDir)
+    {
+        var bundlePath = Path.Combine(extractDir, BundleDiscovery.BundleDirectoryName);
+        if (ResolveReparsePointTarget(bundlePath, extractDir) is { } linkTarget &&
+            IsVersionedLayoutValid(linkTarget))
+        {
+            return (GetDirectoryName(linkTarget), linkTarget);
+        }
+
+        var existingVersion = ReadVersionMarker(extractDir);
+        if (!string.IsNullOrEmpty(existingVersion))
+        {
+            var versionId = ComputeVersionId(existingVersion);
+            var markerVersionDir = Path.Combine(extractDir, VersionsDirectoryName, versionId);
+            if (IsVersionedLayoutValid(markerVersionDir))
+            {
+                return (versionId, markerVersionDir);
+            }
+        }
+
+        return null;
+    }
+
+    private static string? ResolveReparsePointTarget(string linkPath, string layoutPath)
+    {
+        if (!ReparsePoint.IsReparsePoint(linkPath))
+        {
+            return null;
+        }
+
+        var target = ReparsePoint.GetTarget(linkPath);
+        if (string.IsNullOrEmpty(target))
+        {
+            return null;
+        }
+
+        return Path.GetFullPath(Path.IsPathRooted(target)
+            ? target
+            : Path.Combine(layoutPath, target));
+    }
+
+    private static string GetDirectoryName(string path)
+    {
+        return Path.GetFileName(path.TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar));
+    }
+
+    private static LayoutConfiguration CreateVersionRootedLayout(string versionDirectory)
+    {
+        return new LayoutConfiguration
+        {
+            LayoutPath = versionDirectory,
+            Components = new LayoutComponents
+            {
+                Dcp = BundleDiscovery.DcpDirectoryName,
+                Managed = BundleDiscovery.ManagedDirectoryName,
+            }
+        };
     }
 
     /// <summary>

--- a/src/Aspire.Cli/Bundles/BundleService.cs
+++ b/src/Aspire.Cli/Bundles/BundleService.cs
@@ -87,13 +87,6 @@ internal sealed class BundleService(
     }
 
     /// <inheritdoc/>
-    public async Task<LayoutConfiguration?> EnsureExtractedAndGetLayoutAsync(CancellationToken cancellationToken = default)
-    {
-        await EnsureExtractedAsync(cancellationToken).ConfigureAwait(false);
-        return layoutDiscovery.DiscoverLayout();
-    }
-
-    /// <inheritdoc/>
     public async Task<BundleLayoutLease?> EnsureExtractedAndAcquireLayoutAsync(string holderKind, string? commandName = null, CancellationToken cancellationToken = default)
     {
         var extractDir = GetBundleExtractDirForCurrentProcess();

--- a/src/Aspire.Cli/Bundles/BundleService.cs
+++ b/src/Aspire.Cli/Bundles/BundleService.cs
@@ -95,7 +95,7 @@ internal sealed class BundleService(
             var fallbackLayout = layoutDiscovery.DiscoverLayout();
             return fallbackLayout is null
                 ? null
-                : new BundleLayoutLease(versionId: null, versionDirectory: null, fallbackLayout, lease: null);
+                : new BundleLayoutLease(fallbackLayout, lease: null);
         }
 
         var lockPath = Path.Combine(extractDir, ".aspire-bundle-lock");
@@ -123,8 +123,6 @@ internal sealed class BundleService(
         {
             lease = BundleVersionLease.Acquire(activeVersion.Value.VersionDirectory, holderKind, commandName);
             return new BundleLayoutLease(
-                activeVersion.Value.VersionId,
-                activeVersion.Value.VersionDirectory,
                 CreateVersionRootedLayout(activeVersion.Value.VersionDirectory),
                 lease);
         }

--- a/src/Aspire.Cli/Bundles/IBundleService.cs
+++ b/src/Aspire.Cli/Bundles/IBundleService.cs
@@ -42,6 +42,8 @@ internal interface IBundleService
 
     /// <summary>
     /// Ensures the bundle is extracted and returns a version-rooted layout with a lease that prevents cleanup.
+    /// Extraction, active-version resolution, and lease acquisition happen under the same bundle lock
+    /// so cleanup cannot delete the selected version before the lease protects it.
     /// Callers that start bundle-owned processes should use this method and keep the returned lease alive
     /// until the child process has exited or acquired its own lease.
     /// </summary>

--- a/src/Aspire.Cli/Bundles/IBundleService.cs
+++ b/src/Aspire.Cli/Bundles/IBundleService.cs
@@ -41,6 +41,17 @@ internal interface IBundleService
     Task<LayoutConfiguration?> EnsureExtractedAndGetLayoutAsync(CancellationToken cancellationToken = default);
 
     /// <summary>
+    /// Ensures the bundle is extracted and returns a version-rooted layout with a lease that prevents cleanup.
+    /// Callers that start bundle-owned processes should use this method and keep the returned lease alive
+    /// until the child process has exited or acquired its own lease.
+    /// </summary>
+    /// <param name="holderKind">Diagnostic category for the lease holder.</param>
+    /// <param name="commandName">Optional command name for diagnostics.</param>
+    /// <param name="cancellationToken">The cancellation token.</param>
+    /// <returns>The leased layout, or <see langword="null"/> if no layout is found.</returns>
+    Task<BundleLayoutLease?> EnsureExtractedAndAcquireLayoutAsync(string holderKind, string? commandName = null, CancellationToken cancellationToken = default);
+
+    /// <summary>
     /// Determines the default extraction directory for the supplied CLI binary path
     /// by reading the <c>.aspire-install.json</c> sidecar (if any) next to the
     /// resolved binary and switching on its <c>source</c> field. The resulting

--- a/src/Aspire.Cli/Bundles/IBundleService.cs
+++ b/src/Aspire.Cli/Bundles/IBundleService.cs
@@ -1,8 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using Aspire.Cli.Layout;
-
 namespace Aspire.Cli.Bundles;
 
 /// <summary>
@@ -30,15 +28,6 @@ internal interface IBundleService
     /// <param name="cancellationToken">The cancellation token.</param>
     /// <returns>The result of the extraction attempt.</returns>
     Task<BundleExtractResult> ExtractAsync(string destinationPath, bool force = false, CancellationToken cancellationToken = default);
-
-    /// <summary>
-    /// Ensures the bundle is extracted and returns the discovered layout.
-    /// Combines <see cref="EnsureExtractedAsync"/> and layout discovery into a single call
-    /// so callers cannot forget to extract before discovering the layout.
-    /// </summary>
-    /// <param name="cancellationToken">The cancellation token.</param>
-    /// <returns>The discovered layout, or <see langword="null"/> if no layout is found.</returns>
-    Task<LayoutConfiguration?> EnsureExtractedAndGetLayoutAsync(CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Ensures the bundle is extracted and returns a version-rooted layout with a lease that prevents cleanup.

--- a/src/Aspire.Cli/Commands/DashboardRunCommand.cs
+++ b/src/Aspire.Cli/Commands/DashboardRunCommand.cs
@@ -84,7 +84,8 @@ internal sealed class DashboardRunCommand : BaseCommand
 
     protected override async Task<CommandResult> ExecuteAsync(ParseResult parseResult, CancellationToken cancellationToken)
     {
-        var layout = await _bundleService.EnsureExtractedAndGetLayoutAsync(cancellationToken).ConfigureAwait(false);
+        using var layoutLease = await _bundleService.EnsureExtractedAndAcquireLayoutAsync("cli", "dashboard", cancellationToken).ConfigureAwait(false);
+        var layout = layoutLease?.Layout;
         if (layout is null)
         {
             return CommandResult.Failure(CliExitCodes.DashboardFailure, DashboardCommandStrings.BundleLayoutNotFound);
@@ -109,6 +110,7 @@ internal sealed class DashboardRunCommand : BaseCommand
         // to avoid exposing them in process listings (e.g. ps, Task Manager).
         string? browserToken = null;
         var environmentVariables = new Dictionary<string, string>();
+        layoutLease?.AddEnvironment(environmentVariables);
         if (!allowAnonymous && !ConfigSettingHasValue(unmatchedTokens, ExecutionContext, KnownConfigNames.DashboardUnsecuredAllowAnonymous))
         {
             if (!ConfigSettingHasValue(unmatchedTokens, ExecutionContext, DashboardConfigNames.DashboardFrontendBrowserTokenName.EnvVarName))

--- a/src/Aspire.Cli/NuGet/BundleNuGetPackageCache.cs
+++ b/src/Aspire.Cli/NuGet/BundleNuGetPackageCache.cs
@@ -135,8 +135,9 @@ internal sealed class BundleNuGetPackageCache : INuGetPackageCache
         FileInfo? nugetConfigFile,
         CancellationToken cancellationToken)
     {
-        // Ensure the bundle is extracted and get the layout in a single call
-        var layout = await _bundleService.EnsureExtractedAndGetLayoutAsync(cancellationToken).ConfigureAwait(false);
+        // Ensure the bundle is extracted and lease the version before launching aspire-managed.
+        using var layoutLease = await _bundleService.EnsureExtractedAndAcquireLayoutAsync("cli", "nuget-search", cancellationToken).ConfigureAwait(false);
+        var layout = layoutLease?.Layout;
         if (layout is null)
         {
             throw new InvalidOperationException("Bundle layout not found. Cannot perform NuGet search in bundle mode.");
@@ -185,10 +186,14 @@ internal sealed class BundleNuGetPackageCache : INuGetPackageCache
         _logger.LogDebug("NuGet search args: {Args}", string.Join(" ", args));
         _logger.LogDebug("Working directory: {WorkingDir}", workingDirectory.FullName);
 
+        var environmentVariables = new Dictionary<string, string>();
+        layoutLease?.AddEnvironment(environmentVariables);
+
         var (exitCode, output, error) = await _layoutProcessRunner.RunAsync(
             managedPath,
             args,
             workingDirectory: workingDirectory.FullName,
+            environmentVariables: environmentVariables,
             ct: cancellationToken).ConfigureAwait(false);
 
         // Log stderr output (verbose info from NuGetHelper)

--- a/src/Aspire.Cli/NuGet/BundleNuGetService.cs
+++ b/src/Aspire.Cli/NuGet/BundleNuGetService.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Text.Json;
+using Aspire.Cli.Bundles;
 using Aspire.Cli.Configuration;
 using Aspire.Cli.Layout;
 using Aspire.Cli.Utils;
@@ -47,19 +48,22 @@ internal sealed class BundleNuGetService : INuGetService
     private readonly IFeatures _features;
     private readonly CliExecutionContext _executionContext;
     private readonly ILogger<BundleNuGetService> _logger;
+    private readonly IBundleService? _bundleService;
 
     public BundleNuGetService(
         ILayoutDiscovery layoutDiscovery,
         LayoutProcessRunner layoutProcessRunner,
         IFeatures features,
         CliExecutionContext executionContext,
-        ILogger<BundleNuGetService> logger)
+        ILogger<BundleNuGetService> logger,
+        IBundleService? bundleService = null)
     {
         _layoutDiscovery = layoutDiscovery;
         _layoutProcessRunner = layoutProcessRunner;
         _features = features;
         _executionContext = executionContext;
         _logger = logger;
+        _bundleService = bundleService;
     }
 
     public async Task<string> RestorePackagesAsync(
@@ -73,7 +77,10 @@ internal sealed class BundleNuGetService : INuGetService
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(workingDirectory);
 
-        var layout = _layoutDiscovery.DiscoverLayout();
+        using var layoutLease = _bundleService is null
+            ? null
+            : await _bundleService.EnsureExtractedAndAcquireLayoutAsync("cli", "nuget-restore", ct).ConfigureAwait(false);
+        var layout = layoutLease?.Layout ?? _layoutDiscovery.DiscoverLayout();
         if (layout is null)
         {
             throw new InvalidOperationException("Bundle layout not found. Cannot perform NuGet restore in bundle mode.");
@@ -168,6 +175,7 @@ internal sealed class BundleNuGetService : INuGetService
 
         var environmentVariables = new Dictionary<string, string>();
         NuGetSignatureVerificationEnabler.Apply(environmentVariables, _features, _executionContext);
+        layoutLease?.AddEnvironment(environmentVariables);
 
         var (exitCode, output, error) = await _layoutProcessRunner.RunAsync(
             managedPath,

--- a/src/Aspire.Cli/Processes/ProcessShutdownService.cs
+++ b/src/Aspire.Cli/Processes/ProcessShutdownService.cs
@@ -3,6 +3,7 @@
 
 using System.Globalization;
 using Aspire.Cli.Backchannel;
+using Aspire.Cli.Bundles;
 using Aspire.Cli.Layout;
 using Aspire.Shared;
 using Microsoft.Extensions.Logging;
@@ -14,6 +15,7 @@ namespace Aspire.Cli.Processes;
 /// </summary>
 internal sealed class ProcessShutdownService(
     ILayoutDiscovery layoutDiscovery,
+    IBundleService bundleService,
     LayoutProcessRunner layoutProcessRunner,
     CliExecutionContext executionContext,
     ILogger<ProcessShutdownService> logger,
@@ -156,7 +158,9 @@ internal sealed class ProcessShutdownService(
             return true;
         }
 
-        var dcpDirectory = layoutDiscovery.GetComponentPath(LayoutComponent.Dcp, executionContext.WorkingDirectory.FullName);
+        using var layoutLease = await bundleService.EnsureExtractedAndAcquireLayoutAsync("cli", "dcp-stop-process-tree", cancellationToken).ConfigureAwait(false);
+        var dcpDirectory = layoutLease?.Layout.GetDcpPath() ??
+            layoutDiscovery.GetComponentPath(LayoutComponent.Dcp, executionContext.WorkingDirectory.FullName);
         if (dcpDirectory is null)
         {
             logger.LogWarning("Could not find DCP in the Aspire layout.");

--- a/src/Aspire.Cli/Profiling/ProfileCaptureService.cs
+++ b/src/Aspire.Cli/Profiling/ProfileCaptureService.cs
@@ -60,9 +60,11 @@ internal sealed class ProfileCaptureService(
         ArgumentNullException.ThrowIfNull(options);
 
         var managedPath = ResolveManagedPathOverride(configuration);
+        BundleLayoutLease? layoutLease = null;
         if (managedPath is null)
         {
-            var layout = await bundleService.EnsureExtractedAndGetLayoutAsync(cancellationToken).ConfigureAwait(false);
+            layoutLease = await bundleService.EnsureExtractedAndAcquireLayoutAsync("cli", "profile-dashboard", cancellationToken).ConfigureAwait(false);
+            var layout = layoutLease?.Layout;
             managedPath = layout?.GetManagedPath();
         }
 
@@ -73,6 +75,7 @@ internal sealed class ProfileCaptureService(
 
         if (managedPath is null || !File.Exists(managedPath))
         {
+            layoutLease?.Dispose();
             throw new InvalidOperationException(DashboardCommandStrings.ManagedBinaryNotFound);
         }
 
@@ -96,17 +99,21 @@ internal sealed class ProfileCaptureService(
         IProcessExecution dashboardProcess;
         try
         {
+            var environmentVariables = CreateDashboardEnvironment();
+            layoutLease?.AddEnvironment(environmentVariables);
+
             // Launch aspire-managed directly instead of calling `aspire dashboard run`. Calling
             // back through the CLI being profiled would recursively apply --capture-profile and
             // make the collector part of the measurement.
             dashboardProcess = layoutProcessRunner.Start(
                 managedPath,
                 dashboardArgs,
-                environmentVariables: CreateDashboardEnvironment(),
+                environmentVariables: environmentVariables,
                 options: processOptions);
         }
         catch (Exception ex)
         {
+            layoutLease?.Dispose();
             throw new InvalidOperationException(string.Format(CultureInfo.CurrentCulture, DashboardCommandStrings.DashboardFailedToStart, ex.Message), ex);
         }
 
@@ -119,7 +126,8 @@ internal sealed class ProfileCaptureService(
             logger,
             s_profileDataTimeout,
             s_pollInterval,
-            ProfileDataQuietPolls);
+            ProfileDataQuietPolls,
+            layoutLease);
         try
         {
             await session.WaitForDashboardAsync(dashboardStartTimeout, pollInterval, cancellationToken).ConfigureAwait(false);
@@ -216,6 +224,7 @@ internal sealed class ProfileCaptureService(
         private readonly TimeSpan _profileDataTimeout;
         private readonly TimeSpan _profileDataPollInterval;
         private readonly int _profileDataQuietPolls;
+        private readonly BundleLayoutLease? _layoutLease;
 
         public ProfileCaptureSession(
             ProfileCaptureOptions options,
@@ -236,7 +245,8 @@ internal sealed class ProfileCaptureService(
             ILogger logger,
             TimeSpan profileDataTimeout,
             TimeSpan profileDataPollInterval,
-            int profileDataQuietPolls)
+            int profileDataQuietPolls,
+            BundleLayoutLease? layoutLease = null)
         {
             _options = options;
             _dashboardProcess = dashboardProcess;
@@ -248,6 +258,7 @@ internal sealed class ProfileCaptureService(
             _profileDataTimeout = profileDataTimeout;
             _profileDataPollInterval = profileDataPollInterval;
             _profileDataQuietPolls = profileDataQuietPolls;
+            _layoutLease = layoutLease;
         }
 
         public async Task WaitForDashboardAsync(TimeSpan timeout, TimeSpan pollInterval, CancellationToken cancellationToken)
@@ -367,6 +378,7 @@ internal sealed class ProfileCaptureService(
             finally
             {
                 _dashboardProcess.Dispose();
+                _layoutLease?.Dispose();
             }
         }
 

--- a/src/Aspire.Cli/Projects/AppHostServerProject.cs
+++ b/src/Aspire.Cli/Projects/AppHostServerProject.cs
@@ -3,6 +3,7 @@
 
 using Aspire.Cli.Bundles;
 using Aspire.Cli.DotNet;
+using Aspire.Cli.Layout;
 using Aspire.Cli.NuGet;
 using Aspire.Cli.Packaging;
 using Aspire.Cli.Utils;
@@ -56,6 +57,23 @@ internal sealed class AppHostServerProjectFactory(
         // Priority 3: Check if we have a bundle layout with a pre-built AppHost server
         if (layout is not null && layout.GetManagedPath() is string serverPath && File.Exists(serverPath))
         {
+            return CreatePrebuiltAppHostServer(appPath, socketPath, layout, layoutLease);
+        }
+
+        layoutLease?.Dispose();
+        throw new InvalidOperationException(
+            "No Aspire AppHost server is available. Ensure the Aspire CLI is installed " +
+            "with a valid bundle layout, or reinstall using 'aspire setup --force'.");
+    }
+
+    internal PrebuiltAppHostServer CreatePrebuiltAppHostServer(
+        string appPath,
+        string socketPath,
+        LayoutConfiguration layout,
+        BundleLayoutLease? layoutLease)
+    {
+        try
+        {
             return new PrebuiltAppHostServer(
                 appPath,
                 socketPath,
@@ -68,10 +86,10 @@ internal sealed class AppHostServerProjectFactory(
                 loggerFactory.CreateLogger<PrebuiltAppHostServer>(),
                 layoutLease);
         }
-
-        layoutLease?.Dispose();
-        throw new InvalidOperationException(
-            "No Aspire AppHost server is available. Ensure the Aspire CLI is installed " +
-            "with a valid bundle layout, or reinstall using 'aspire setup --force'.");
+        catch
+        {
+            layoutLease?.Dispose();
+            throw;
+        }
     }
 }

--- a/src/Aspire.Cli/Projects/AppHostServerProject.cs
+++ b/src/Aspire.Cli/Projects/AppHostServerProject.cs
@@ -50,7 +50,8 @@ internal sealed class AppHostServerProjectFactory(
         }
 
         // Priority 2: Ensure bundle is extracted and check for layout
-        var layout = await bundleService.EnsureExtractedAndGetLayoutAsync(cancellationToken);
+        var layoutLease = await bundleService.EnsureExtractedAndAcquireLayoutAsync("cli", "apphost-server", cancellationToken);
+        var layout = layoutLease?.Layout;
 
         // Priority 3: Check if we have a bundle layout with a pre-built AppHost server
         if (layout is not null && layout.GetManagedPath() is string serverPath && File.Exists(serverPath))
@@ -64,9 +65,11 @@ internal sealed class AppHostServerProjectFactory(
                 sdkInstaller,
                 packagingService,
                 executionContext,
-                loggerFactory.CreateLogger<PrebuiltAppHostServer>());
+                loggerFactory.CreateLogger<PrebuiltAppHostServer>(),
+                layoutLease);
         }
 
+        layoutLease?.Dispose();
         throw new InvalidOperationException(
             "No Aspire AppHost server is available. Ensure the Aspire CLI is installed " +
             "with a valid bundle layout, or reinstall using 'aspire setup --force'.");

--- a/src/Aspire.Cli/Projects/AppHostServerSession.cs
+++ b/src/Aspire.Cli/Projects/AppHostServerSession.cs
@@ -22,6 +22,7 @@ internal sealed class AppHostServerSession : IAppHostServerSession
     private readonly string _socketPath;
     private readonly ProfilingTelemetry.ActivityScope _activity;
     private readonly ProfilingTelemetry? _profilingTelemetry;
+    private readonly IDisposable? _projectLifetime;
     private IAppHostRpcClient? _rpcClient;
     private bool _disposed;
 
@@ -32,7 +33,8 @@ internal sealed class AppHostServerSession : IAppHostServerSession
         string authenticationToken,
         ILogger logger,
         ProfilingTelemetry.ActivityScope activity = default,
-        ProfilingTelemetry? profilingTelemetry = null)
+        ProfilingTelemetry? profilingTelemetry = null,
+        IDisposable? projectLifetime = null)
     {
         _serverProcess = serverProcess;
         _output = output;
@@ -41,6 +43,7 @@ internal sealed class AppHostServerSession : IAppHostServerSession
         _logger = logger;
         _activity = activity;
         _profilingTelemetry = profilingTelemetry;
+        _projectLifetime = projectLifetime;
     }
 
     /// <inheritdoc />
@@ -109,6 +112,7 @@ internal sealed class AppHostServerSession : IAppHostServerSession
         {
             activity.SetError(ex.Message);
             activity.Dispose();
+            (appHostServerProject as IDisposable)?.Dispose();
             throw;
         }
 
@@ -122,7 +126,8 @@ internal sealed class AppHostServerSession : IAppHostServerSession
             authenticationToken,
             logger,
             activity,
-            profilingTelemetry);
+            profilingTelemetry,
+            appHostServerProject as IDisposable);
     }
 
     /// <inheritdoc />
@@ -168,6 +173,7 @@ internal sealed class AppHostServerSession : IAppHostServerSession
         }
 
         _serverProcess.Dispose();
+        _projectLifetime?.Dispose();
         _activity.Dispose();
     }
 }

--- a/src/Aspire.Cli/Projects/AppHostServerSession.cs
+++ b/src/Aspire.Cli/Projects/AppHostServerSession.cs
@@ -209,9 +209,21 @@ internal sealed class AppHostServerSessionFactory : IAppHostServerSessionFactory
         var appHostServerProject = await _projectFactory.CreateAsync(appHostPath, cancellationToken);
 
         // Prepare the server (create files + build for dev mode, restore packages for prebuilt mode)
-        var prepareResult = await appHostServerProject.PrepareAsync(sdkVersion, integrations, cancellationToken);
+        AppHostServerPrepareResult prepareResult;
+        try
+        {
+            prepareResult = await appHostServerProject.PrepareAsync(sdkVersion, integrations, cancellationToken);
+        }
+        catch
+        {
+            (appHostServerProject as IDisposable)?.Dispose();
+            throw;
+        }
+
         if (!prepareResult.Success)
         {
+            (appHostServerProject as IDisposable)?.Dispose();
+
             return new AppHostServerSessionResult(
                 Success: false,
                 Session: null,

--- a/src/Aspire.Cli/Projects/DotNetAppHostProject.cs
+++ b/src/Aspire.Cli/Projects/DotNetAppHostProject.cs
@@ -288,10 +288,12 @@ internal sealed class DotNetAppHostProject : IAppHostProject
         }
 
         var canQueryCliBundleProperty = !isSingleFileAppHost || !context.NoBuild;
+        BundleLayoutLease? cliBundleLease = null;
         if (canQueryCliBundleProperty && await IsUsingCliBundleAsync(effectiveAppHostFile, cancellationToken))
         {
-            await ConfigureCliBundleEnvironmentAsync(env, cancellationToken);
+            cliBundleLease = await ConfigureCliBundleEnvironmentAsync(env, cancellationToken);
         }
+        using var cliBundleLeaseScope = cliBundleLease;
 
         // RunCommand may display captured AppHost output as soon as BuildCompletionSource is signaled.
         // Store the collector first so failures that occur immediately after preparation are not lost
@@ -677,10 +679,9 @@ internal sealed class DotNetAppHostProject : IAppHostProject
             }
         }
 
-        if (await IsUsingCliBundleAsync(effectiveAppHostFile, cancellationToken))
-        {
-            await ConfigureCliBundleEnvironmentAsync(env, cancellationToken);
-        }
+        using var cliBundleLease = await IsUsingCliBundleAsync(effectiveAppHostFile, cancellationToken)
+            ? await ConfigureCliBundleEnvironmentAsync(env, cancellationToken)
+            : null;
 
         // Build the apphost (unless --no-build is specified)
         if (!isSingleFileAppHost && !context.NoBuild)
@@ -877,13 +878,15 @@ internal sealed class DotNetAppHostProject : IAppHostProject
         return string.Equals(useCliBundleElement.GetString(), "true", StringComparison.OrdinalIgnoreCase);
     }
 
-    private async Task ConfigureCliBundleEnvironmentAsync(Dictionary<string, string> env, CancellationToken cancellationToken)
+    private async Task<BundleLayoutLease?> ConfigureCliBundleEnvironmentAsync(Dictionary<string, string> env, CancellationToken cancellationToken)
     {
-        var layout = await _bundleService.EnsureExtractedAndGetLayoutAsync(cancellationToken);
+        var layoutLease = await _bundleService.EnsureExtractedAndAcquireLayoutAsync("cli", "dotnet-apphost", cancellationToken);
+        var layout = layoutLease?.Layout;
         if (layout is null)
         {
+            layoutLease?.Dispose();
             _logger.LogDebug("AspireUseCliBundle is enabled, but the Aspire CLI bundle layout was not available from this CLI process.");
-            return;
+            return null;
         }
 
         if (!env.ContainsKey(BundleDiscovery.DcpPathEnvVar) && layout.GetDcpPath() is { } dcpPath)
@@ -895,6 +898,9 @@ internal sealed class DotNetAppHostProject : IAppHostProject
         {
             env[BundleDiscovery.DashboardPathEnvVar] = managedPath;
         }
+
+        layoutLease?.AddEnvironment(env);
+        return layoutLease;
     }
 
     /// <summary>

--- a/src/Aspire.Cli/Projects/PrebuiltAppHostServer.cs
+++ b/src/Aspire.Cli/Projects/PrebuiltAppHostServer.cs
@@ -963,10 +963,7 @@ internal sealed class PrebuiltAppHostServer : IAppHostServerProject, IDisposable
             }
         }
 
-        if (_layoutLease?.VersionDirectory is { } versionDirectory)
-        {
-            startInfo.Environment[BundleDiscovery.BundleVersionDirectoryEnvVar] = versionDirectory;
-        }
+        _layoutLease?.AddEnvironment(startInfo);
 
         if (debug)
         {

--- a/src/Aspire.Cli/Projects/PrebuiltAppHostServer.cs
+++ b/src/Aspire.Cli/Projects/PrebuiltAppHostServer.cs
@@ -7,6 +7,7 @@ using System.Security.Cryptography;
 using System.Text;
 using System.Text.Json;
 using System.Xml.Linq;
+using Aspire.Cli.Bundles;
 using Aspire.Cli.Configuration;
 using Aspire.Cli.DotNet;
 using Aspire.Cli.Layout;
@@ -24,7 +25,7 @@ namespace Aspire.Cli.Projects;
 /// This is used when running in bundle mode (without .NET SDK) to avoid
 /// dynamic project generation and building.
 /// </summary>
-internal sealed class PrebuiltAppHostServer : IAppHostServerProject
+internal sealed class PrebuiltAppHostServer : IAppHostServerProject, IDisposable
 {
     internal const string ClosureMetadataFileName = "closure-metadata.txt";
     internal const string ClosureSourcesFileName = "closure-sources.txt";
@@ -44,6 +45,7 @@ internal sealed class PrebuiltAppHostServer : IAppHostServerProject
     private readonly IPackagingService _packagingService;
     private readonly CliExecutionContext _executionContext;
     private readonly ILogger _logger;
+    private readonly BundleLayoutLease? _layoutLease;
     private readonly string _workingDirectory;
     private readonly string _projectReferencePrepareLockPath;
     private readonly AppHostServerProjectLayoutStore _projectLayoutStore;
@@ -65,6 +67,7 @@ internal sealed class PrebuiltAppHostServer : IAppHostServerProject
     /// <param name="packagingService">The packaging service for channel resolution.</param>
     /// <param name="executionContext">The CLI execution context providing identity channel information.</param>
     /// <param name="logger">The logger for diagnostic output.</param>
+    /// <param name="layoutLease">The active bundle layout lease, if this server is running from a versioned bundle.</param>
     public PrebuiltAppHostServer(
         string appPath,
         string socketPath,
@@ -74,7 +77,8 @@ internal sealed class PrebuiltAppHostServer : IAppHostServerProject
         IDotNetSdkInstaller sdkInstaller,
         IPackagingService packagingService,
         CliExecutionContext executionContext,
-        ILogger logger)
+        ILogger logger,
+        BundleLayoutLease? layoutLease = null)
     {
         _appDirectoryPath = Path.GetFullPath(appPath);
         _socketPath = socketPath;
@@ -85,6 +89,7 @@ internal sealed class PrebuiltAppHostServer : IAppHostServerProject
         _packagingService = packagingService;
         _executionContext = executionContext;
         _logger = logger;
+        _layoutLease = layoutLease;
 
         // Create a working directory for this app host session
         var pathHash = SHA256.HashData(Encoding.UTF8.GetBytes(_appDirectoryPath));
@@ -694,6 +699,11 @@ internal sealed class PrebuiltAppHostServer : IAppHostServerProject
             }
         }
 
+        if (_layoutLease?.VersionDirectory is { } versionDirectory)
+        {
+            startInfo.Environment[BundleDiscovery.BundleVersionDirectoryEnvVar] = versionDirectory;
+        }
+
         if (debug)
         {
             startInfo.Environment[KnownConfigNames.AspireLogLevel] = "Debug";
@@ -707,6 +717,12 @@ internal sealed class PrebuiltAppHostServer : IAppHostServerProject
 
     /// <inheritdoc />
     public string GetInstanceIdentifier() => _appDirectoryPath;
+
+    /// <inheritdoc />
+    public void Dispose()
+    {
+        _layoutLease?.Dispose();
+    }
 
     /// <summary>
     /// Reads the project reference assembly names written by the MSBuild target during build.

--- a/src/Aspire.Managed/Aspire.Managed.csproj
+++ b/src/Aspire.Managed/Aspire.Managed.csproj
@@ -48,6 +48,8 @@
   </ItemGroup>
 
   <ItemGroup>
+    <Compile Include="$(SharedDir)BundleDiscovery.cs" Link="Shared\BundleDiscovery.cs" />
+    <Compile Include="$(SharedDir)BundleVersionLease.cs" Link="Shared\BundleVersionLease.cs" />
     <Compile Include="$(SharedDir)IntegrationPackageProbeManifest.cs" Link="NuGet\IntegrationPackageProbeManifest.cs" />
   </ItemGroup>
 

--- a/src/Aspire.Managed/Program.cs
+++ b/src/Aspire.Managed/Program.cs
@@ -3,7 +3,21 @@
 
 using Aspire.Dashboard;
 using Aspire.Managed.NuGet.Commands;
+using Aspire.Shared;
 using System.CommandLine;
+
+BundleVersionLease? acquiredBundleLease;
+try
+{
+    acquiredBundleLease = BundleVersionLease.TryAcquireFromEnvironment("aspire-managed", args.FirstOrDefault());
+}
+catch (Exception ex) when (ex is IOException or UnauthorizedAccessException or DirectoryNotFoundException or ArgumentException or NotSupportedException)
+{
+    Console.Error.WriteLine($"Failed to acquire Aspire bundle lease: {ex.Message}");
+    return 1;
+}
+
+using var bundleLease = acquiredBundleLease;
 
 return args switch
 {

--- a/src/Shared/BundleDiscovery.cs
+++ b/src/Shared/BundleDiscovery.cs
@@ -4,6 +4,7 @@
 // This file is source-linked into multiple projects:
 // - Aspire.Hosting
 // - Aspire.Cli
+// - Aspire.Managed
 // Do not add project-specific dependencies.
 
 using System.Runtime.InteropServices;
@@ -40,6 +41,11 @@ internal static class BundleDiscovery
     /// Environment variable for overriding the aspire-managed path.
     /// </summary>
     public const string ManagedPathEnvVar = "ASPIRE_MANAGED_PATH";
+
+    /// <summary>
+    /// Environment variable containing the leased version directory for bundle-owned child processes.
+    /// </summary>
+    public const string BundleVersionDirectoryEnvVar = "ASPIRE_BUNDLE_VERSION_DIR";
 
     /// <summary>
     /// Environment variable to force SDK mode (skip bundle detection).

--- a/src/Shared/BundleVersionLease.cs
+++ b/src/Shared/BundleVersionLease.cs
@@ -69,7 +69,16 @@ internal sealed class BundleVersionLease : IDisposable
 
         try
         {
-            var metadata = CreateMetadata(fullVersionDirectory, holderKind, commandName);
+            var versionId = Path.GetFileName(fullVersionDirectory.TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar));
+            var metadata = new BundleVersionLeaseMetadata(
+                VersionId: versionId,
+                VersionDirectory: fullVersionDirectory,
+                ProcessId: Environment.ProcessId,
+                ProcessStartTimeUtcTicks: GetCurrentProcessStartTimeTicks(),
+                HolderKind: holderKind,
+                CommandName: commandName,
+                AcquiredUtc: DateTimeOffset.UtcNow);
+
             JsonSerializer.Serialize(stream, metadata, BundleVersionLeaseJsonSerializerContext.Default.BundleVersionLeaseMetadata);
             stream.Flush(flushToDisk: true);
 
@@ -206,21 +215,6 @@ internal sealed class BundleVersionLease : IDisposable
         {
             return 0;
         }
-    }
-
-    private static BundleVersionLeaseMetadata CreateMetadata(string versionDirectory, string holderKind, string? commandName)
-    {
-        var versionId = Path.GetFileName(versionDirectory.TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar));
-        var startTicks = GetCurrentProcessStartTimeTicks();
-
-        return new BundleVersionLeaseMetadata(
-            VersionId: versionId,
-            VersionDirectory: versionDirectory,
-            ProcessId: Environment.ProcessId,
-            ProcessStartTimeUtcTicks: startTicks,
-            HolderKind: holderKind,
-            CommandName: commandName,
-            AcquiredUtc: DateTimeOffset.UtcNow);
     }
 }
 

--- a/src/Shared/BundleVersionLease.cs
+++ b/src/Shared/BundleVersionLease.cs
@@ -1,0 +1,256 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+// This file is source-linked into multiple projects.
+// Do not add project-specific dependencies.
+
+using System.Diagnostics;
+using System.Globalization;
+using System.Text;
+
+namespace Aspire.Shared;
+
+/// <summary>
+/// Holds an exclusive file handle that marks a versioned CLI bundle directory as in use.
+/// </summary>
+internal sealed class BundleVersionLease : IDisposable
+{
+    /// <summary>
+    /// Directory name under a versioned bundle directory that contains lease files.
+    /// </summary>
+    public const string LeasesDirectoryName = ".leases";
+
+    private const string LeaseExtension = ".lease";
+    private readonly FileStream _stream;
+
+    private BundleVersionLease(string versionDirectory, string leasePath, FileStream stream)
+    {
+        VersionDirectory = versionDirectory;
+        LeasePath = leasePath;
+        _stream = stream;
+    }
+
+    /// <summary>
+    /// Gets the leased version directory.
+    /// </summary>
+    public string VersionDirectory { get; }
+
+    /// <summary>
+    /// Gets the lease metadata path.
+    /// </summary>
+    public string LeasePath { get; }
+
+    /// <summary>
+    /// Creates a lease for <paramref name="versionDirectory"/>.
+    /// </summary>
+    public static BundleVersionLease Acquire(string versionDirectory, string holderKind, string? commandName = null)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(versionDirectory);
+        ArgumentException.ThrowIfNullOrWhiteSpace(holderKind);
+
+        var fullVersionDirectory = Path.GetFullPath(versionDirectory);
+        if (!Directory.Exists(fullVersionDirectory))
+        {
+            throw new DirectoryNotFoundException($"Bundle version directory '{fullVersionDirectory}' does not exist.");
+        }
+
+        var leasesDirectory = Path.Combine(fullVersionDirectory, LeasesDirectoryName);
+        Directory.CreateDirectory(leasesDirectory);
+
+        var leasePath = Path.Combine(leasesDirectory, CreateLeaseFileName());
+        var stream = new FileStream(
+            leasePath,
+            FileMode.CreateNew,
+            FileAccess.ReadWrite,
+            FileShare.None,
+            bufferSize: 4096,
+            FileOptions.DeleteOnClose);
+
+        try
+        {
+            var metadata = CreateMetadataJson(fullVersionDirectory, holderKind, commandName);
+            var bytes = Encoding.UTF8.GetBytes(metadata);
+            stream.Write(bytes);
+            stream.Flush(flushToDisk: true);
+
+            return new BundleVersionLease(fullVersionDirectory, leasePath, stream);
+        }
+        catch
+        {
+            stream.Dispose();
+            throw;
+        }
+    }
+
+    /// <summary>
+    /// Acquires a lease from <see cref="BundleDiscovery.BundleVersionDirectoryEnvVar"/> when the environment variable is set.
+    /// </summary>
+    public static BundleVersionLease? TryAcquireFromEnvironment(string holderKind, string? commandName = null)
+    {
+        var versionDirectory = Environment.GetEnvironmentVariable(BundleDiscovery.BundleVersionDirectoryEnvVar);
+        if (string.IsNullOrWhiteSpace(versionDirectory))
+        {
+            return null;
+        }
+
+        return Acquire(versionDirectory, holderKind, commandName);
+    }
+
+    /// <summary>
+    /// Adds bundle lease handoff environment variables to a child process environment.
+    /// </summary>
+    public static void AddEnvironment(IDictionary<string, string> environmentVariables, string versionDirectory)
+    {
+        ArgumentNullException.ThrowIfNull(environmentVariables);
+        ArgumentException.ThrowIfNullOrWhiteSpace(versionDirectory);
+
+        environmentVariables[BundleDiscovery.BundleVersionDirectoryEnvVar] = Path.GetFullPath(versionDirectory);
+    }
+
+    /// <summary>
+    /// Returns <see langword="true"/> if <paramref name="versionDirectory"/> has any active leases.
+    /// Orphaned lease files are removed as they are discovered.
+    /// </summary>
+    public static bool HasActiveLease(string versionDirectory)
+    {
+        var leasesDirectory = Path.Combine(versionDirectory, LeasesDirectoryName);
+        if (!Directory.Exists(leasesDirectory))
+        {
+            return false;
+        }
+
+        foreach (var leasePath in EnumerateLeaseFiles(leasesDirectory))
+        {
+            if (!TryDeleteOrphanedLease(leasePath))
+            {
+                return true;
+            }
+        }
+
+        TryDeleteEmptyLeaseDirectory(leasesDirectory);
+        return false;
+    }
+
+    /// <inheritdoc/>
+    public void Dispose()
+    {
+        _stream.Dispose();
+    }
+
+    private static IEnumerable<string> EnumerateLeaseFiles(string leasesDirectory)
+    {
+        try
+        {
+            return Directory.EnumerateFiles(leasesDirectory, $"*{LeaseExtension}").ToArray();
+        }
+        catch (Exception ex) when (ex is DirectoryNotFoundException or IOException or UnauthorizedAccessException)
+        {
+            return [];
+        }
+    }
+
+    private static bool TryDeleteOrphanedLease(string leasePath)
+    {
+        try
+        {
+            using var stream = new FileStream(
+                leasePath,
+                FileMode.Open,
+                FileAccess.ReadWrite,
+                FileShare.None,
+                bufferSize: 1,
+                FileOptions.DeleteOnClose);
+            return true;
+        }
+        catch (FileNotFoundException)
+        {
+            return true;
+        }
+        catch (DirectoryNotFoundException)
+        {
+            return true;
+        }
+        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
+        {
+            return false;
+        }
+    }
+
+    private static void TryDeleteEmptyLeaseDirectory(string leasesDirectory)
+    {
+        try
+        {
+            Directory.Delete(leasesDirectory);
+        }
+        catch (Exception ex) when (ex is DirectoryNotFoundException or IOException or UnauthorizedAccessException)
+        {
+        }
+    }
+
+    private static string CreateLeaseFileName()
+    {
+        var startTicks = GetCurrentProcessStartTimeTicks();
+        return string.Create(
+            CultureInfo.InvariantCulture,
+            $"{Environment.ProcessId}-{startTicks}-{Guid.NewGuid():N}{LeaseExtension}");
+    }
+
+    private static long GetCurrentProcessStartTimeTicks()
+    {
+        try
+        {
+            using var process = Process.GetCurrentProcess();
+            return process.StartTime.ToUniversalTime().Ticks;
+        }
+        catch (Exception ex) when (ex is InvalidOperationException or NotSupportedException or System.ComponentModel.Win32Exception)
+        {
+            return 0;
+        }
+    }
+
+    private static string CreateMetadataJson(string versionDirectory, string holderKind, string? commandName)
+    {
+        var versionId = Path.GetFileName(versionDirectory.TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar));
+        var startTicks = GetCurrentProcessStartTimeTicks();
+        var acquired = DateTimeOffset.UtcNow.ToString("O", CultureInfo.InvariantCulture);
+
+        return $$"""
+            {
+              "versionId": "{{EscapeJson(versionId)}}",
+              "versionDirectory": "{{EscapeJson(versionDirectory)}}",
+              "processId": {{Environment.ProcessId}},
+              "processStartTimeUtcTicks": {{startTicks}},
+              "holderKind": "{{EscapeJson(holderKind)}}",
+              "commandName": "{{EscapeJson(commandName)}}",
+              "acquiredUtc": "{{acquired}}"
+            }
+            """;
+    }
+
+    private static string EscapeJson(string? value)
+    {
+        if (string.IsNullOrEmpty(value))
+        {
+            return string.Empty;
+        }
+
+        var builder = new StringBuilder(value.Length);
+        foreach (var ch in value)
+        {
+            _ = ch switch
+            {
+                '"' => builder.Append("\\\""),
+                '\\' => builder.Append("\\\\"),
+                '\b' => builder.Append("\\b"),
+                '\f' => builder.Append("\\f"),
+                '\n' => builder.Append("\\n"),
+                '\r' => builder.Append("\\r"),
+                '\t' => builder.Append("\\t"),
+                < ' ' => builder.Append(CultureInfo.InvariantCulture, $"\\u{(int)ch:x4}"),
+                _ => builder.Append(ch)
+            };
+        }
+
+        return builder.ToString();
+    }
+}

--- a/src/Shared/BundleVersionLease.cs
+++ b/src/Shared/BundleVersionLease.cs
@@ -24,12 +24,32 @@ internal sealed class BundleVersionLease : IDisposable
     private const string LeaseExtension = ".lease";
     private readonly FileStream _stream;
 
-    private BundleVersionLease(string versionDirectory, string leasePath, FileStream stream)
+    private BundleVersionLease(
+        string? versionId,
+        string versionDirectory,
+        string leasePath,
+        int processId,
+        long processStartTimeUtcTicks,
+        string holderKind,
+        string? commandName,
+        DateTimeOffset acquiredUtc,
+        FileStream stream)
     {
+        VersionId = versionId;
         VersionDirectory = versionDirectory;
         LeasePath = leasePath;
+        ProcessId = processId;
+        ProcessStartTimeUtcTicks = processStartTimeUtcTicks;
+        HolderKind = holderKind;
+        CommandName = commandName;
+        AcquiredUtc = acquiredUtc;
         _stream = stream;
     }
+
+    /// <summary>
+    /// Gets the leased version id.
+    /// </summary>
+    public string? VersionId { get; }
 
     /// <summary>
     /// Gets the leased version directory.
@@ -39,7 +59,33 @@ internal sealed class BundleVersionLease : IDisposable
     /// <summary>
     /// Gets the lease metadata path.
     /// </summary>
+    [JsonIgnore]
     public string LeasePath { get; }
+
+    /// <summary>
+    /// Gets the process id that acquired the lease.
+    /// </summary>
+    public int ProcessId { get; }
+
+    /// <summary>
+    /// Gets the UTC start time ticks for the process that acquired the lease.
+    /// </summary>
+    public long ProcessStartTimeUtcTicks { get; }
+
+    /// <summary>
+    /// Gets the kind of process holding the lease.
+    /// </summary>
+    public string HolderKind { get; }
+
+    /// <summary>
+    /// Gets the command name associated with the lease, if any.
+    /// </summary>
+    public string? CommandName { get; }
+
+    /// <summary>
+    /// Gets when the lease was acquired.
+    /// </summary>
+    public DateTimeOffset AcquiredUtc { get; }
 
     /// <summary>
     /// Creates a lease for <paramref name="versionDirectory"/>.
@@ -70,19 +116,21 @@ internal sealed class BundleVersionLease : IDisposable
         try
         {
             var versionId = Path.GetFileName(fullVersionDirectory.TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar));
-            var metadata = new BundleVersionLeaseMetadata(
-                VersionId: versionId,
-                VersionDirectory: fullVersionDirectory,
-                ProcessId: Environment.ProcessId,
-                ProcessStartTimeUtcTicks: GetCurrentProcessStartTimeTicks(),
-                HolderKind: holderKind,
-                CommandName: commandName,
-                AcquiredUtc: DateTimeOffset.UtcNow);
+            var lease = new BundleVersionLease(
+                versionId,
+                fullVersionDirectory,
+                leasePath,
+                Environment.ProcessId,
+                GetCurrentProcessStartTimeTicks(),
+                holderKind,
+                commandName,
+                DateTimeOffset.UtcNow,
+                stream);
 
-            JsonSerializer.Serialize(stream, metadata, BundleVersionLeaseJsonSerializerContext.Default.BundleVersionLeaseMetadata);
+            JsonSerializer.Serialize(stream, lease, BundleVersionLeaseJsonSerializerContext.Default.BundleVersionLease);
             stream.Flush(flushToDisk: true);
 
-            return new BundleVersionLease(fullVersionDirectory, leasePath, stream);
+            return lease;
         }
         catch
         {
@@ -115,6 +163,12 @@ internal sealed class BundleVersionLease : IDisposable
 
         environmentVariables[BundleDiscovery.BundleVersionDirectoryEnvVar] = Path.GetFullPath(versionDirectory);
     }
+
+    /// <summary>
+    /// Adds bundle lease handoff environment variables to a child process environment.
+    /// </summary>
+    public void AddEnvironment(IDictionary<string, string> environmentVariables)
+        => AddEnvironment(environmentVariables, VersionDirectory);
 
     /// <summary>
     /// Returns <see langword="true"/> if <paramref name="versionDirectory"/> has any active leases.
@@ -218,15 +272,6 @@ internal sealed class BundleVersionLease : IDisposable
     }
 }
 
-internal sealed record BundleVersionLeaseMetadata(
-    string? VersionId,
-    string VersionDirectory,
-    int ProcessId,
-    long ProcessStartTimeUtcTicks,
-    string HolderKind,
-    string? CommandName,
-    DateTimeOffset AcquiredUtc);
-
 [JsonSourceGenerationOptions(PropertyNamingPolicy = JsonKnownNamingPolicy.CamelCase, WriteIndented = true)]
-[JsonSerializable(typeof(BundleVersionLeaseMetadata))]
+[JsonSerializable(typeof(BundleVersionLease))]
 internal sealed partial class BundleVersionLeaseJsonSerializerContext : JsonSerializerContext;

--- a/src/Shared/BundleVersionLease.cs
+++ b/src/Shared/BundleVersionLease.cs
@@ -6,7 +6,8 @@
 
 using System.Diagnostics;
 using System.Globalization;
-using System.Text;
+using System.Text.Json;
+using System.Text.Json.Serialization;
 
 namespace Aspire.Shared;
 
@@ -68,9 +69,8 @@ internal sealed class BundleVersionLease : IDisposable
 
         try
         {
-            var metadata = CreateMetadataJson(fullVersionDirectory, holderKind, commandName);
-            var bytes = Encoding.UTF8.GetBytes(metadata);
-            stream.Write(bytes);
+            var metadata = CreateMetadata(fullVersionDirectory, holderKind, commandName);
+            JsonSerializer.Serialize(stream, metadata, BundleVersionLeaseJsonSerializerContext.Default.BundleVersionLeaseMetadata);
             stream.Flush(flushToDisk: true);
 
             return new BundleVersionLease(fullVersionDirectory, leasePath, stream);
@@ -208,49 +208,31 @@ internal sealed class BundleVersionLease : IDisposable
         }
     }
 
-    private static string CreateMetadataJson(string versionDirectory, string holderKind, string? commandName)
+    private static BundleVersionLeaseMetadata CreateMetadata(string versionDirectory, string holderKind, string? commandName)
     {
         var versionId = Path.GetFileName(versionDirectory.TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar));
         var startTicks = GetCurrentProcessStartTimeTicks();
-        var acquired = DateTimeOffset.UtcNow.ToString("O", CultureInfo.InvariantCulture);
 
-        return $$"""
-            {
-              "versionId": "{{EscapeJson(versionId)}}",
-              "versionDirectory": "{{EscapeJson(versionDirectory)}}",
-              "processId": {{Environment.ProcessId}},
-              "processStartTimeUtcTicks": {{startTicks}},
-              "holderKind": "{{EscapeJson(holderKind)}}",
-              "commandName": "{{EscapeJson(commandName)}}",
-              "acquiredUtc": "{{acquired}}"
-            }
-            """;
-    }
-
-    private static string EscapeJson(string? value)
-    {
-        if (string.IsNullOrEmpty(value))
-        {
-            return string.Empty;
-        }
-
-        var builder = new StringBuilder(value.Length);
-        foreach (var ch in value)
-        {
-            _ = ch switch
-            {
-                '"' => builder.Append("\\\""),
-                '\\' => builder.Append("\\\\"),
-                '\b' => builder.Append("\\b"),
-                '\f' => builder.Append("\\f"),
-                '\n' => builder.Append("\\n"),
-                '\r' => builder.Append("\\r"),
-                '\t' => builder.Append("\\t"),
-                < ' ' => builder.Append(CultureInfo.InvariantCulture, $"\\u{(int)ch:x4}"),
-                _ => builder.Append(ch)
-            };
-        }
-
-        return builder.ToString();
+        return new BundleVersionLeaseMetadata(
+            VersionId: versionId,
+            VersionDirectory: versionDirectory,
+            ProcessId: Environment.ProcessId,
+            ProcessStartTimeUtcTicks: startTicks,
+            HolderKind: holderKind,
+            CommandName: commandName,
+            AcquiredUtc: DateTimeOffset.UtcNow);
     }
 }
+
+internal sealed record BundleVersionLeaseMetadata(
+    string? VersionId,
+    string VersionDirectory,
+    int ProcessId,
+    long ProcessStartTimeUtcTicks,
+    string HolderKind,
+    string? CommandName,
+    DateTimeOffset AcquiredUtc);
+
+[JsonSourceGenerationOptions(PropertyNamingPolicy = JsonKnownNamingPolicy.CamelCase, WriteIndented = true)]
+[JsonSerializable(typeof(BundleVersionLeaseMetadata))]
+internal sealed partial class BundleVersionLeaseJsonSerializerContext : JsonSerializerContext;

--- a/tests/Aspire.Cli.Tests/BundleServiceIntegrationTests.cs
+++ b/tests/Aspire.Cli.Tests/BundleServiceIntegrationTests.cs
@@ -191,6 +191,95 @@ public class BundleServiceIntegrationTests(ITestOutputHelper outputHelper)
     }
 
     [Fact]
+    public async Task EnsureExtractedAndAcquireLayoutAsync_ReturnsVersionRootedLayoutAndSkipsLeasedCleanup()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        var layoutRoot = workspace.WorkspaceRoot.FullName;
+        var layoutDiscovery = new TestLayoutDiscovery(layoutRoot);
+
+        var v1BinaryPath = CreateFakeCliBinary(Path.Combine(layoutRoot, ".fake-bins"), "aspire-v1", "cli-v1");
+        var v2BinaryPath = CreateFakeCliBinary(Path.Combine(layoutRoot, ".fake-bins"), "aspire-v2", "cli-v2-longer");
+        File.SetLastWriteTimeUtc(v2BinaryPath, File.GetLastWriteTimeUtc(v1BinaryPath).AddHours(1));
+
+        var v1Service = CreateService(new TestBundlePayloadProvider(CreateFakeBundlePayload("v1")), layoutDiscovery, v1BinaryPath);
+        var result1 = await v1Service.ExtractAsync(layoutRoot, force: true);
+        Assert.Equal(BundleExtractResult.Extracted, result1);
+
+        var versionsDir = Path.Combine(layoutRoot, BundleService.VersionsDirectoryName);
+        var v1VersionDir = Assert.Single(Directory.GetDirectories(versionsDir));
+
+        try
+        {
+            using var layoutLease = await v1Service.EnsureExtractedAndAcquireLayoutAsync("test", "reader");
+            Assert.NotNull(layoutLease);
+            Assert.True(layoutLease.HasLease);
+
+            var managedPath = layoutLease.Layout.GetManagedPath();
+            Assert.NotNull(managedPath);
+
+            var comparison = OperatingSystem.IsWindows() ? StringComparison.OrdinalIgnoreCase : StringComparison.Ordinal;
+            Assert.StartsWith(
+                Path.GetFullPath(v1VersionDir),
+                Path.GetFullPath(managedPath!),
+                comparison);
+
+            var v2Service = CreateService(new TestBundlePayloadProvider(CreateFakeBundlePayload("v2")), layoutDiscovery, v2BinaryPath);
+            var result2 = await v2Service.ExtractAsync(layoutRoot, force: true);
+            Assert.Equal(BundleExtractResult.Extracted, result2);
+
+            Assert.True(Directory.Exists(v1VersionDir), "Leased stale version should not be deleted during upgrade cleanup.");
+            Assert.Equal(2, Directory.GetDirectories(versionsDir).Length);
+        }
+        finally
+        {
+            CleanupReparsePoints(layoutRoot);
+        }
+    }
+
+    [Fact]
+    public void TryCleanupStaleVersions_SkipsVersionWithActiveLease()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        var versionsDir = Path.Combine(workspace.WorkspaceRoot.FullName, BundleService.VersionsDirectoryName);
+        var staleVersionDir = Path.Combine(versionsDir, "stale-version");
+        Directory.CreateDirectory(staleVersionDir);
+
+        using var lease = BundleVersionLease.Acquire(staleVersionDir, "test", "cleanup");
+
+        BundleService.TryCleanupStaleVersions(versionsDir, activeVersionId: "active-version");
+
+        Assert.True(Directory.Exists(staleVersionDir));
+    }
+
+    [Fact]
+    public void TryCleanupStaleVersions_RemovesOrphanLeaseFilesBeforeDeletingVersion()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        var versionsDir = Path.Combine(workspace.WorkspaceRoot.FullName, BundleService.VersionsDirectoryName);
+        var staleVersionDir = Path.Combine(versionsDir, "stale-version");
+        var leasesDir = Path.Combine(staleVersionDir, BundleVersionLease.LeasesDirectoryName);
+        Directory.CreateDirectory(leasesDir);
+        File.WriteAllText(Path.Combine(leasesDir, "orphan.lease"), "{}");
+
+        BundleService.TryCleanupStaleVersions(versionsDir, activeVersionId: "active-version");
+
+        Assert.False(Directory.Exists(staleVersionDir));
+    }
+
+    [Fact]
+    public void BundleVersionLease_AllowsConcurrentReadersForSameVersion()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        var versionDir = workspace.CreateDirectory("version").FullName;
+
+        using var lease1 = BundleVersionLease.Acquire(versionDir, "test", "reader1");
+        using var lease2 = BundleVersionLease.Acquire(versionDir, "test", "reader2");
+
+        Assert.NotEqual(lease1.LeasePath, lease2.LeasePath);
+        Assert.True(BundleVersionLease.HasActiveLease(versionDir));
+    }
+
+    [Fact]
     public async Task EnsureExtractedAsync_DotnetToolStorePath_ExtractsToTargetFrameworkDirectory()
     {
         using var workspace = TemporaryWorkspace.Create(outputHelper);

--- a/tests/Aspire.Cli.Tests/Commands/AppHostLauncherTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/AppHostLauncherTests.cs
@@ -645,6 +645,7 @@ public class AppHostLauncherTests(ITestOutputHelper outputHelper)
             var fileLoggerProvider = new FileLoggerProvider(executionContext.LogFilePath, new TestStartupErrorWriter());
             var processShutdownService = new ProcessShutdownService(
                 new FixedLayoutDiscovery(),
+                new NullBundleService(),
                 new LayoutProcessRunner(new TestProcessExecutionFactory()),
                 executionContext,
                 NullLogger<ProcessShutdownService>.Instance,

--- a/tests/Aspire.Cli.Tests/Processes/ProcessShutdownServiceTests.cs
+++ b/tests/Aspire.Cli.Tests/Processes/ProcessShutdownServiceTests.cs
@@ -3,6 +3,7 @@
 
 using System.Diagnostics;
 using System.Globalization;
+using Aspire.Cli.Bundles;
 using Aspire.Cli.Layout;
 using Aspire.Cli.Processes;
 using Aspire.Cli.Tests.TestServices;
@@ -65,14 +66,47 @@ public class ProcessShutdownServiceTests(ITestOutputHelper outputHelper)
         };
         var signaler = CreateService(workspace, dcpDirectory.FullName, executionFactory);
 
-        var result = await signaler.TryStopProcessTreeWithDcpAsync(Environment.ProcessId, new DateTimeOffset(Process.GetCurrentProcess().StartTime), includeStartTime: false, CancellationToken.None);
+        var result = await signaler.TryStopProcessTreeWithDcpAsync(
+            Environment.ProcessId,
+            new DateTimeOffset(Process.GetCurrentProcess().StartTime),
+            includeStartTime: false,
+            CancellationToken.None);
 
         Assert.True(result);
         Assert.NotNull(capturedArguments);
         Assert.DoesNotContain("--process-start-time", capturedArguments);
     }
 
-    private static ProcessShutdownService CreateService(TemporaryWorkspace workspace, string dcpDirectory, TestProcessExecutionFactory executionFactory)
+    [Fact]
+    public async Task TryStopProcessTreeWithDcpAsync_UsesLeasedBundleDcpPathWhenAvailable()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        var mutableDcpDirectory = workspace.WorkspaceRoot.CreateSubdirectory("bundle").CreateSubdirectory("dcp");
+        File.WriteAllText(BundleDiscovery.GetDcpExecutablePath(mutableDcpDirectory.FullName), string.Empty);
+
+        var versionRoot = workspace.WorkspaceRoot.CreateSubdirectory("versions").CreateSubdirectory("active-version");
+        var leasedDcpDirectory = versionRoot.CreateSubdirectory("dcp");
+        var leasedDcpPath = BundleDiscovery.GetDcpExecutablePath(leasedDcpDirectory.FullName);
+        File.WriteAllText(leasedDcpPath, string.Empty);
+
+        var executionFactory = new TestProcessExecutionFactory();
+        var bundleService = new TestBundleService(isBundle: true)
+        {
+            Layout = new LayoutConfiguration { LayoutPath = versionRoot.FullName }
+        };
+        var signaler = CreateService(workspace, mutableDcpDirectory.FullName, executionFactory, bundleService);
+
+        var result = await signaler.TryStopProcessTreeWithDcpAsync(Environment.ProcessId, new DateTimeOffset(Process.GetCurrentProcess().StartTime), includeStartTime: false, CancellationToken.None);
+
+        Assert.True(result);
+        Assert.Equal(leasedDcpPath, executionFactory.LastFileName);
+    }
+
+    private static ProcessShutdownService CreateService(
+        TemporaryWorkspace workspace,
+        string dcpDirectory,
+        TestProcessExecutionFactory executionFactory,
+        IBundleService? bundleService = null)
     {
         var executionContext = new CliExecutionContext(
             workspace.WorkspaceRoot,
@@ -84,6 +118,7 @@ public class ProcessShutdownServiceTests(ITestOutputHelper outputHelper)
 
         return new ProcessShutdownService(
             new FixedLayoutDiscovery(dcpDirectory),
+            bundleService ?? new NullBundleService(),
             new LayoutProcessRunner(executionFactory),
             executionContext,
             NullLogger<ProcessShutdownService>.Instance,

--- a/tests/Aspire.Cli.Tests/Projects/AppHostServerSessionTests.cs
+++ b/tests/Aspire.Cli.Tests/Projects/AppHostServerSessionTests.cs
@@ -148,8 +148,6 @@ public class AppHostServerSessionTests(ITestOutputHelper outputHelper)
         var versionDirectory = workspace.CreateDirectory("version");
         var versionLease = BundleVersionLease.Acquire(versionDirectory.FullName, "test", "apphost-server");
         var layoutLease = new BundleLayoutLease(
-            versionId: "test-version",
-            versionDirectory: versionDirectory.FullName,
             new LayoutConfiguration(),
             versionLease);
         var factory = CreateAppHostServerProjectFactory();

--- a/tests/Aspire.Cli.Tests/Projects/AppHostServerSessionTests.cs
+++ b/tests/Aspire.Cli.Tests/Projects/AppHostServerSessionTests.cs
@@ -2,17 +2,24 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Diagnostics;
+using Aspire.Cli.Bundles;
 using Aspire.Cli.Configuration;
+using Aspire.Cli.Layout;
+using Aspire.Cli.NuGet;
 using Aspire.Cli.Projects;
 using Aspire.Cli.Telemetry;
+using Aspire.Cli.Tests.Mcp;
+using Aspire.Cli.Tests.TestServices;
+using Aspire.Cli.Tests.Utils;
 using Aspire.Cli.Utils;
 using Aspire.Hosting;
+using Aspire.Shared;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging.Abstractions;
 
 namespace Aspire.Cli.Tests.Projects;
 
-public class AppHostServerSessionTests
+public class AppHostServerSessionTests(ITestOutputHelper outputHelper)
 {
     [Fact]
     public async Task Start_DoesNotMutateCallerEnvironmentVariables()
@@ -104,6 +111,67 @@ public class AppHostServerSessionTests
         Assert.NotEqual(parentActivity.Id, receivedEnvironmentVariables[ProfilingTelemetry.EnvironmentVariables.TraceParent]);
     }
 
+    [Fact]
+    public async Task CreateAsync_DisposesProjectWhenPrepareFails()
+    {
+        var project = new FakeFailingAppHostServerProject(Directory.GetCurrentDirectory());
+        var projectFactory = new TestAppHostServerProjectFactory
+        {
+            CreateAsyncCallback = (_, _) => Task.FromResult<IAppHostServerProject>(project)
+        };
+        using var profilingTelemetry = new ProfilingTelemetry(CreateConfiguration());
+        var sessionFactory = new AppHostServerSessionFactory(
+            projectFactory,
+            NullLogger<AppHostServerSession>.Instance,
+            profilingTelemetry);
+
+        var result = await sessionFactory.CreateAsync(
+            project.AppDirectoryPath,
+            "13.4.0",
+            [],
+            launchSettingsEnvVars: null,
+            debug: false,
+            CancellationToken.None);
+
+        Assert.False(result.Success);
+        Assert.True(project.Disposed);
+    }
+
+    [Fact]
+    public void CreatePrebuiltAppHostServer_DisposesLayoutLeaseWhenConstructorFails()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        var appPath = workspace.CreateDirectory("apphost").FullName;
+        var integrationCachePathBlockedByFile = Path.Combine(workspace.WorkspaceRoot.FullName, ".aspire", "integrations");
+        File.WriteAllText(integrationCachePathBlockedByFile, string.Empty);
+
+        var versionDirectory = workspace.CreateDirectory("version");
+        var versionLease = BundleVersionLease.Acquire(versionDirectory.FullName, "test", "apphost-server");
+        var layoutLease = new BundleLayoutLease(
+            versionId: "test-version",
+            versionDirectory: versionDirectory.FullName,
+            new LayoutConfiguration(),
+            versionLease);
+        var factory = CreateAppHostServerProjectFactory();
+
+        Assert.True(BundleVersionLease.HasActiveLease(versionDirectory.FullName));
+
+        try
+        {
+            Assert.ThrowsAny<IOException>(() => factory.CreatePrebuiltAppHostServer(
+                appPath,
+                "test.sock",
+                new LayoutConfiguration(),
+                layoutLease));
+
+            Assert.False(BundleVersionLease.HasActiveLease(versionDirectory.FullName));
+        }
+        finally
+        {
+            layoutLease.Dispose();
+        }
+    }
+
     private static ActivityListener CreateActivityListener(string sourceName)
     {
         var listener = new ActivityListener
@@ -120,6 +188,26 @@ public class AppHostServerSessionTests
         return new ConfigurationBuilder()
             .AddInMemoryCollection(values.Select(value => new KeyValuePair<string, string?>(value.Key, value.Value)))
             .Build();
+    }
+
+    private static AppHostServerProjectFactory CreateAppHostServerProjectFactory()
+    {
+        var executionContext = TestExecutionContextFactory.CreateTestContext();
+        var nugetService = new BundleNuGetService(
+            new NullLayoutDiscovery(),
+            new LayoutProcessRunner(new TestProcessExecutionFactory()),
+            new TestFeatures(),
+            executionContext,
+            NullLogger<BundleNuGetService>.Instance);
+
+        return new AppHostServerProjectFactory(
+            new TestDotNetCliRunner(),
+            MockPackagingServiceFactory.Create(),
+            new NullBundleService(),
+            nugetService,
+            new TestDotNetSdkInstaller(),
+            executionContext,
+            NullLoggerFactory.Instance);
     }
 
     private sealed class RecordingAppHostServerProject : IAppHostServerProject

--- a/tests/Aspire.Cli.Tests/TestServices/FakeFailingAppHostServerProject.cs
+++ b/tests/Aspire.Cli.Tests/TestServices/FakeFailingAppHostServerProject.cs
@@ -15,9 +15,11 @@ namespace Aspire.Cli.Tests.TestServices;
 /// that exercise the channel/config write side-effects that happen BEFORE
 /// <c>AppHostServerProject.PrepareAsync</c>.
 /// </summary>
-internal sealed class FakeFailingAppHostServerProject(string appDirectoryPath) : IAppHostServerProject
+internal sealed class FakeFailingAppHostServerProject(string appDirectoryPath) : IAppHostServerProject, IDisposable
 {
     public string AppDirectoryPath { get; } = appDirectoryPath;
+
+    public bool Disposed { get; private set; }
 
     public string GetInstanceIdentifier() => AppDirectoryPath;
 
@@ -34,4 +36,9 @@ internal sealed class FakeFailingAppHostServerProject(string appDirectoryPath) :
         string[]? additionalArgs = null,
         bool debug = false) =>
         throw new NotSupportedException("Run should not be invoked when PrepareAsync fails.");
+
+    public void Dispose()
+    {
+        Disposed = true;
+    }
 }

--- a/tests/Aspire.Cli.Tests/Utils/CliTestHelper.cs
+++ b/tests/Aspire.Cli.Tests/Utils/CliTestHelper.cs
@@ -673,6 +673,9 @@ internal sealed class NullBundleService : IBundleService
     public Task<Layout.LayoutConfiguration?> EnsureExtractedAndGetLayoutAsync(CancellationToken cancellationToken = default)
         => Task.FromResult<Layout.LayoutConfiguration?>(null);
 
+    public Task<BundleLayoutLease?> EnsureExtractedAndAcquireLayoutAsync(string holderKind, string? commandName = null, CancellationToken cancellationToken = default)
+        => Task.FromResult<BundleLayoutLease?>(null);
+
     public string? GetDefaultExtractDir(string processPath) => null;
 }
 
@@ -702,6 +705,9 @@ internal sealed class TestBundleService(bool isBundle) : IBundleService
 
     public Task<Layout.LayoutConfiguration?> EnsureExtractedAndGetLayoutAsync(CancellationToken cancellationToken = default)
         => Task.FromResult(Layout);
+
+    public Task<BundleLayoutLease?> EnsureExtractedAndAcquireLayoutAsync(string holderKind, string? commandName = null, CancellationToken cancellationToken = default)
+        => Task.FromResult(Layout is null ? null : new BundleLayoutLease(versionId: null, versionDirectory: null, Layout, lease: null));
 
     public string? GetDefaultExtractDir(string processPath) => null;
 }

--- a/tests/Aspire.Cli.Tests/Utils/CliTestHelper.cs
+++ b/tests/Aspire.Cli.Tests/Utils/CliTestHelper.cs
@@ -670,9 +670,6 @@ internal sealed class NullBundleService : IBundleService
     public Task<BundleExtractResult> ExtractAsync(string destinationPath, bool force = false, CancellationToken cancellationToken = default)
         => Task.FromResult(BundleExtractResult.NoPayload);
 
-    public Task<Layout.LayoutConfiguration?> EnsureExtractedAndGetLayoutAsync(CancellationToken cancellationToken = default)
-        => Task.FromResult<Layout.LayoutConfiguration?>(null);
-
     public Task<BundleLayoutLease?> EnsureExtractedAndAcquireLayoutAsync(string holderKind, string? commandName = null, CancellationToken cancellationToken = default)
         => Task.FromResult<BundleLayoutLease?>(null);
 
@@ -702,9 +699,6 @@ internal sealed class TestBundleService(bool isBundle) : IBundleService
 
     public Task<BundleExtractResult> ExtractAsync(string destinationPath, bool force = false, CancellationToken cancellationToken = default)
         => Task.FromResult(isBundle ? BundleExtractResult.AlreadyUpToDate : BundleExtractResult.NoPayload);
-
-    public Task<Layout.LayoutConfiguration?> EnsureExtractedAndGetLayoutAsync(CancellationToken cancellationToken = default)
-        => Task.FromResult(Layout);
 
     public Task<BundleLayoutLease?> EnsureExtractedAndAcquireLayoutAsync(string holderKind, string? commandName = null, CancellationToken cancellationToken = default)
         => Task.FromResult(Layout is null ? null : new BundleLayoutLease(versionId: null, versionDirectory: null, Layout, lease: null));

--- a/tests/Aspire.Cli.Tests/Utils/CliTestHelper.cs
+++ b/tests/Aspire.Cli.Tests/Utils/CliTestHelper.cs
@@ -701,7 +701,7 @@ internal sealed class TestBundleService(bool isBundle) : IBundleService
         => Task.FromResult(isBundle ? BundleExtractResult.AlreadyUpToDate : BundleExtractResult.NoPayload);
 
     public Task<BundleLayoutLease?> EnsureExtractedAndAcquireLayoutAsync(string holderKind, string? commandName = null, CancellationToken cancellationToken = default)
-        => Task.FromResult(Layout is null ? null : new BundleLayoutLease(versionId: null, versionDirectory: null, Layout, lease: null));
+        => Task.FromResult(Layout is null ? null : new BundleLayoutLease(Layout, lease: null));
 
     public string? GetDefaultExtractDir(string processPath) => null;
 }


### PR DESCRIPTION
## Description

Fixes #16306

This prevents Aspire CLI bundle upgrades from deleting or invalidating a bundle version while another CLI/AppHost process is still using it. Before this change, upgraded CLIs could flip the `bundle` reparse point and clean up older `versions\<id>` directories while a concurrent process was about to launch `aspire-managed` or DCP from the previous bundle version.

The CLI now acquires per-version leases under `versions\<id>\.leases`, returns leased layouts rooted directly at `versions\<id>`, and makes cleanup skip versions with active lease files. Bundle-owned child processes receive `ASPIRE_BUNDLE_VERSION_DIR`, and `aspire-managed` self-leases on startup so long-running dashboard/server/NuGet helper processes keep their backing version alive after parent startup.

### Behavior by install/layout type

Bundled installs always extract into a versioned bundle layout before bundle-owned component paths are used. The install route only changes the extraction root:

- `winget`, `brew`, and `dotnet-tool` installs extract beside the CLI binary, then use `versions\<id>` plus the public `bundle\` pointer under that binary directory.
- `script` and `pr` installs extract under the install prefix parent of `bin\`, then use the same `versions\<id>` plus `bundle\` pointer shape there.

Layouts without a versioned bundle folder are treated as non-owned fallback layouts. That covers dev/SDK/external layouts where the running CLI has no embedded bundle payload. In those cases `EnsureExtractedAndAcquireLayoutAsync` falls back to normal layout discovery and returns an unleased layout because `BundleService` does not own or clean up those files, so there is no bundle cleanup race to protect.

### User-facing usage

No command syntax changes are required. Existing bundle flows such as setup/update, dashboard launch, NuGet restore/search, AppHost server startup, and `AspireUseCliBundle` now use stable version-rooted paths internally instead of launching through the mutable `bundle` pointer.

### Validation

- `.\restore.cmd`
- `dotnet build .\src\Aspire.Cli\Aspire.Cli.csproj --no-restore`
- `dotnet build .\src\Aspire.Managed\Aspire.Managed.csproj --no-restore`
- `dotnet test --project .\tests\Aspire.Cli.Tests\Aspire.Cli.Tests.csproj --no-launch-profile -- --filter-class "*.BundleServiceIntegrationTests" --filter-not-trait "quarantined=true" --filter-not-trait "outerloop=true"`
- `dotnet test --project .\tests\Aspire.Cli.Tests\Aspire.Cli.Tests.csproj --no-launch-profile -- --filter-class "*.BundleServiceIntegrationTests" --filter-class "*.DotNetAppHostProjectTests" --filter-class "*.BundleNuGetPackageCacheTests" --filter-class "*.BundleNuGetServiceTests" --filter-class "*.DashboardRunCommandTests" --filter-class "*.ProfileCaptureServiceTests" --filter-class "*.PrebuiltAppHostServerTests" --filter-not-trait "quarantined=true" --filter-not-trait "outerloop=true"`

Full `Aspire.Cli.Tests` was also run with quarantine/outerloop exclusions; it failed only in two unrelated git safecrlf tests (`fatal: LF would be replaced by CRLF in .gitignore`).

## Checklist

- Is this feature complete?
  - [ ] Yes. Ready to ship.
  - [x] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No