### PR TITLE
Add Rust AppHost scaffold regression coverage

### DIFF
--- a/src/Aspire.Hosting.CodeGeneration.Rust/RustLanguageSupport.cs
+++ b/src/Aspire.Hosting.CodeGeneration.Rust/RustLanguageSupport.cs
@@ -15,6 +15,7 @@ internal sealed class RustLanguageSupport : ILanguageSupport
     /// The language/runtime identifier for Rust.
     /// </summary>
     private const string LanguageId = "rust";
+    private const string AppHostFileName = "apphost.rs";
 
     /// <summary>
     /// The code generation target language. This maps to the ICodeGenerator.Language property.
@@ -22,7 +23,7 @@ internal sealed class RustLanguageSupport : ILanguageSupport
     private const string CodeGenTarget = "Rust";
 
     private const string LanguageDisplayName = "Rust";
-    private static readonly string[] s_detectionPatterns = ["apphost.rs"];
+    private static readonly string[] s_detectionPatterns = [AppHostFileName];
 
     /// <inheritdoc />
     public string Language => LanguageId;
@@ -68,8 +69,8 @@ internal sealed class RustLanguageSupport : ILanguageSupport
             lazy_static = "1.4"
             """;
 
-        // Create apphost.rs marker file for detection
-        files["apphost.rs"] = """
+        // Create the marker file the CLI uses to recognize Rust AppHosts.
+        files[AppHostFileName] = """
             // Aspire Rust AppHost marker file
             // This file is used to detect the project type.
             // The actual entry point is in src/main.rs.
@@ -105,7 +106,7 @@ internal sealed class RustLanguageSupport : ILanguageSupport
     /// <inheritdoc />
     public DetectionResult Detect(string directoryPath)
     {
-        var appHostPath = Path.Combine(directoryPath, "apphost.rs");
+        var appHostPath = Path.Combine(directoryPath, AppHostFileName);
         if (!File.Exists(appHostPath))
         {
             return DetectionResult.NotFound;
@@ -117,7 +118,7 @@ internal sealed class RustLanguageSupport : ILanguageSupport
             return DetectionResult.NotFound;
         }
 
-        return DetectionResult.Found(LanguageId, "apphost.rs");
+        return DetectionResult.Found(LanguageId, AppHostFileName);
     }
 
     /// <inheritdoc />

--- a/tests/Aspire.Hosting.CodeGeneration.Rust.Tests/Aspire.Hosting.CodeGeneration.Rust.Tests.csproj
+++ b/tests/Aspire.Hosting.CodeGeneration.Rust.Tests/Aspire.Hosting.CodeGeneration.Rust.Tests.csproj
@@ -17,6 +17,7 @@
 
   <ItemGroup>
     <Compile Include="$(TestsSharedDir)TestModuleInitializer.cs" Link="shared/TestModuleInitializer.cs" />
+    <Compile Include="$(TestsSharedDir)TempDirectory.cs" Link="shared/TempDirectory.cs" />
     <!-- Share test types with TypeScript tests -->
     <Compile Include="..\Aspire.Hosting.CodeGeneration.TypeScript.Tests\TestTypes\*.cs" Link="TestTypes\%(Filename)%(Extension)" />
   </ItemGroup>

--- a/tests/Aspire.Hosting.CodeGeneration.Rust.Tests/RustLanguageSupportTests.cs
+++ b/tests/Aspire.Hosting.CodeGeneration.Rust.Tests/RustLanguageSupportTests.cs
@@ -20,11 +20,12 @@ public class RustLanguageSupportTests
             ProjectName = "RustApp"
         });
 
-        Assert.Contains("src/main.rs", files.Keys);
-        Assert.Contains("Cargo.toml", files.Keys);
-        Assert.Contains("apphost.rs", files.Keys);
-        Assert.Contains("apphost.run.json", files.Keys);
-        Assert.DoesNotContain("apphost.ts", files.Keys);
+        Assert.Collection(
+            files.Keys.Order(StringComparer.Ordinal),
+            key => Assert.Equal("Cargo.toml", key),
+            key => Assert.Equal("apphost.rs", key),
+            key => Assert.Equal("apphost.run.json", key),
+            key => Assert.Equal("src/main.rs", key));
     }
 
     [Fact]

--- a/tests/Aspire.Hosting.CodeGeneration.Rust.Tests/RustLanguageSupportTests.cs
+++ b/tests/Aspire.Hosting.CodeGeneration.Rust.Tests/RustLanguageSupportTests.cs
@@ -1,0 +1,70 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Aspire.TypeSystem;
+
+namespace Aspire.Hosting.CodeGeneration.Rust.Tests;
+
+public class RustLanguageSupportTests
+{
+    private readonly RustLanguageSupport _languageSupport = new();
+
+    [Fact]
+    public void Scaffold_CreatesRustAppHostFilesOnly()
+    {
+        using var testDir = new TestTempDirectory();
+
+        var files = _languageSupport.Scaffold(new ScaffoldRequest
+        {
+            TargetPath = testDir.Path,
+            ProjectName = "RustApp"
+        });
+
+        Assert.Contains("src/main.rs", files.Keys);
+        Assert.Contains("Cargo.toml", files.Keys);
+        Assert.Contains("apphost.rs", files.Keys);
+        Assert.Contains("apphost.run.json", files.Keys);
+        Assert.DoesNotContain("apphost.ts", files.Keys);
+    }
+
+    [Fact]
+    public void Detect_ReturnsRustAppHostWhenMarkerAndCargoExist()
+    {
+        using var testDir = new TestTempDirectory();
+
+        File.WriteAllText(Path.Combine(testDir.Path, "apphost.rs"), "// marker");
+        File.WriteAllText(Path.Combine(testDir.Path, "Cargo.toml"), "[package]");
+
+        var result = _languageSupport.Detect(testDir.Path);
+
+        Assert.True(result.IsValid);
+        Assert.Equal("rust", result.Language);
+        Assert.Equal("apphost.rs", result.AppHostFile);
+    }
+
+    [Fact]
+    public void Detect_DoesNotTreatTypeScriptAppHostAsRust()
+    {
+        using var testDir = new TestTempDirectory();
+
+        File.WriteAllText(Path.Combine(testDir.Path, "apphost.ts"), "// typescript");
+        File.WriteAllText(Path.Combine(testDir.Path, "Cargo.toml"), "[package]");
+
+        var result = _languageSupport.Detect(testDir.Path);
+
+        Assert.False(result.IsValid);
+    }
+
+    [Fact]
+    public void GetRuntimeSpec_UsesCargoRun()
+    {
+        var runtimeSpec = _languageSupport.GetRuntimeSpec();
+
+        Assert.Equal("rust", runtimeSpec.Language);
+        Assert.Equal("Rust", runtimeSpec.DisplayName);
+        Assert.Equal("Rust", runtimeSpec.CodeGenLanguage);
+        Assert.Equal(["apphost.rs"], runtimeSpec.DetectionPatterns);
+        Assert.Equal("cargo", runtimeSpec.Execute.Command);
+        Assert.Equal(["run"], runtimeSpec.Execute.Args);
+    }
+}

--- a/tests/Aspire.Hosting.CodeGeneration.Rust.Tests/RustLanguageSupportTests.cs
+++ b/tests/Aspire.Hosting.CodeGeneration.Rust.Tests/RustLanguageSupportTests.cs
@@ -56,6 +56,18 @@ public class RustLanguageSupportTests
     }
 
     [Fact]
+    public void Detect_RequiresCargoManifest()
+    {
+        using var testDir = new TestTempDirectory();
+
+        File.WriteAllText(Path.Combine(testDir.Path, "apphost.rs"), "// marker");
+
+        var result = _languageSupport.Detect(testDir.Path);
+
+        Assert.False(result.IsValid);
+    }
+
+    [Fact]
     public void GetRuntimeSpec_UsesCargoRun()
     {
         var runtimeSpec = _languageSupport.GetRuntimeSpec();


### PR DESCRIPTION
## Description

I could not reproduce the reported extra `apphost.ts` with the current Rust empty AppHost paths. `aspire new aspire-rust-empty`, `aspire new aspire-empty --language rust`, and `aspire init --language rust` all scaffold only the Rust AppHost files.

This PR keeps that behavior from regressing by centralizing the Rust AppHost marker filename and adding focused Rust language-support coverage. The tests verify Rust scaffolding emits `apphost.rs` without `apphost.ts`, detection requires both `apphost.rs` and `Cargo.toml`, a TypeScript `apphost.ts` is not treated as a Rust AppHost, and the runtime spec remains `cargo run`.

Related: #16681

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No