### PR TITLE
Add structured filter dialog to TraceDetail page

### DIFF
--- a/src/Aspire.Dashboard/Components/Pages/StructuredLogs.razor.cs
+++ b/src/Aspire.Dashboard/Components/Pages/StructuredLogs.razor.cs
@@ -357,25 +357,14 @@ public partial class StructuredLogs : IComponentWithTelemetry, IPageWithSessionA
             await _contentLayout.CloseMobileToolbarAsync();
         }
 
-        var title = entry is not null ? FilterLoc[nameof(StructuredFiltering.DialogTitleEditFilter)] : FilterLoc[nameof(StructuredFiltering.DialogTitleAddFilter)];
-        var parameters = new DialogParameters
-        {
-            OnDialogResult = DialogService.CreateDialogCallback(this, HandleFilterDialog),
-            Title = title,
-            Alignment = HorizontalAlignment.Right,
-            PrimaryAction = null,
-            SecondaryAction = null,
-            Width = ViewportInformation.IsDesktop ? "450px" : "100%"
-        };
-        var data = new FilterDialogViewModel
-        {
-            Filter = entry,
-            PropertyKeys = TelemetryRepository.GetLogPropertyKeys(PageViewModel.SelectedResource.Id?.GetResourceKey()),
-            KnownKeys = KnownStructuredLogFields.AllFields,
-            GetFieldValues = TelemetryRepository.GetLogsFieldValues
-        };
-
-        await DialogService.ShowPanelAsync<FilterDialog>(data, parameters);
+        await FilterHelpers.OpenFilterAsync(
+            entry,
+            DialogService,
+            DialogService.CreateDialogCallback(this, HandleFilterDialog),
+            propertyKeys: TelemetryRepository.GetLogPropertyKeys(PageViewModel.SelectedResource.Id?.GetResourceKey()),
+            knownKeys: KnownStructuredLogFields.AllFields,
+            getFieldValues: TelemetryRepository.GetLogsFieldValues,
+            FilterLoc);
     }
 
     private async Task HandleFilterDialog(DialogResult result)
@@ -433,13 +422,13 @@ public partial class StructuredLogs : IComponentWithTelemetry, IPageWithSessionA
 
     private List<MenuButtonItem> GetFilterMenuItems()
     {
-        return this.GetFilterMenuItems(
+        return FilterHelpers.GetFilterMenuItems(
             ViewModel.Filters,
             ViewModel.ClearFilters,
             OpenFilterAsync,
+            afterChangeAsync: () => this.AfterViewModelChangedAsync(_contentLayout, waitToApplyMobileChange: false),
             FilterLoc,
-            DialogsLoc,
-            _contentLayout);
+            DialogsLoc);
     }
 
     protected override async Task OnAfterRenderAsync(bool firstRender)

--- a/src/Aspire.Dashboard/Components/Pages/TraceDetail.razor
+++ b/src/Aspire.Dashboard/Components/Pages/TraceDetail.razor
@@ -5,6 +5,8 @@
 @using System.Diagnostics
 @inject IStringLocalizer<AIAssistant> AIAssistantLoc
 @inject IStringLocalizer<AIPrompts> AIPromptsLoc
+@inject IStringLocalizer<StructuredFiltering> FilterLoc
+@inject IStringLocalizer<Dialogs> DialogsLoc
 
 <PageTitle>
     <ApplicationName
@@ -61,6 +63,25 @@
 
                             <DesktopToolbarDivider />
 
+                            @if (_filters.Count == 0)
+                            {
+                                <span slot="end">@FilterLoc[nameof(StructuredFiltering.NoFilters)]</span>
+                            }
+                            else
+                            {
+                                <div slot="end">
+                                    <FluentCounterBadge HorizontalPosition="70" Count="@(_filters.GetEnabledFilters().Count())" Appearance="Appearance.Accent">
+                                        <AspireMenuButton HideIcon="true" Text="@FilterLoc[nameof(StructuredFiltering.Filters)]" Items="@GetFilterMenuItems()" />
+                                    </FluentCounterBadge>
+                                </div>
+                            }
+
+                            <DesktopToolbarDivider />
+
+                            <FluentButton slot="end" Appearance="Appearance.Stealth" aria-label="@FilterLoc[nameof(StructuredFiltering.AddFilter)]" OnClick="() => OpenFilterAsync(null)"><FluentIcon Value="@(new Icons.Regular.Size20.Filter())" /></FluentButton>
+
+                            <DesktopToolbarDivider />
+
                             <AspireMenuButton ButtonAppearance="Appearance.Lightweight"
                                               Icon="@(new Icons.Regular.Size20.Options())"
                                               Items="@_traceActionsMenuItems"
@@ -80,6 +101,17 @@
                     <SpanTypeSelect @bind-SpanType="@_selectedSpanType"
                                     SpanTypes="@_spanTypes"
                                     HandleSelectedSpanTypeChangedAsync="@HandleSelectedSpanTypeChangedAsync" />
+                    @if (_filters.Count > 0)
+                    {
+                        <div slot="end">
+                            <FluentCounterBadge HorizontalPosition="70" Count="@(_filters.GetEnabledFilters().Count())" Appearance="Appearance.Accent">
+                                <AspireMenuButton HideIcon="true" Text="@FilterLoc[nameof(StructuredFiltering.Filters)]" Items="@GetFilterMenuItems()" />
+                            </FluentCounterBadge>
+                        </div>
+                    }
+                    <FluentButton slot="end" Appearance="Appearance.Stealth" aria-label="@FilterLoc[nameof(StructuredFiltering.AddFilter)]" OnClick="() => OpenFilterAsync(null)">
+                        <FluentIcon Class="align-text-bottom" Value="@(new Icons.Regular.Size20.Filter())" /> @FilterLoc[nameof(StructuredFiltering.AddFilter)]
+                    </FluentButton>
                     <AspireMenuButton ButtonAppearance="Appearance.Lightweight"
                                       Icon="@(new Icons.Regular.Size20.Options())"
                                       Items="@_traceActionsMenuItems"

--- a/src/Aspire.Dashboard/Components/Pages/TraceDetail.razor.cs
+++ b/src/Aspire.Dashboard/Components/Pages/TraceDetail.razor.cs
@@ -46,6 +46,7 @@ public partial class TraceDetail : ComponentBase, IComponentWithTelemetry, IDisp
     private AIContext? _aiContext;
     private IList<GridColumn> _gridColumns = null!;
     private string _filter = string.Empty;
+    private readonly List<FieldTelemetryFilter> _filters = [];
     private readonly List<MenuButtonItem> _traceActionsMenuItems = [];
     private AspirePageContentLayout? _layout;
     private List<SelectViewModel<SpanType>> _spanTypes = default!;
@@ -196,7 +197,7 @@ public partial class TraceDetail : ComponentBase, IComponentWithTelemetry, IDisp
                 continue;
             }
 
-            if (viewModel.MatchesFilter(_filter, _selectedSpanType.Id?.Filter, GetResourceName, out var matchedDescendents))
+            if (viewModel.MatchesFilter(_filter, _selectedSpanType.Id?.Filter, _filters, GetResourceName, out var matchedDescendents))
             {
                 visibleViewModels.Add(viewModel);
                 foreach (var descendent in matchedDescendents.Where(d => !d.IsHidden))
@@ -569,6 +570,187 @@ public partial class TraceDetail : ComponentBase, IComponentWithTelemetry, IDisp
 
                 return Task.CompletedTask;
             });
+    }
+
+    private async Task OpenFilterAsync(FieldTelemetryFilter? entry)
+    {
+        if (_layout is not null)
+        {
+            await _layout.CloseMobileToolbarAsync();
+        }
+
+        var title = entry is not null ? FilterLoc[nameof(StructuredFiltering.DialogTitleEditFilter)] : FilterLoc[nameof(StructuredFiltering.DialogTitleAddFilter)];
+        var parameters = new DialogParameters
+        {
+            OnDialogResult = DialogService.CreateDialogCallback(this, HandleFilterDialog),
+            Title = title,
+            Alignment = HorizontalAlignment.Right,
+            PrimaryAction = null,
+            SecondaryAction = null,
+            Width = "450px"
+        };
+        var data = new FilterDialogViewModel
+        {
+            Filter = entry,
+            PropertyKeys = GetTraceSpanPropertyKeys(),
+            KnownKeys = KnownTraceFields.AllFields,
+            GetFieldValues = GetTraceSpanFieldValues
+        };
+        await DialogService.ShowPanelAsync<FilterDialog>(data, parameters);
+    }
+
+    private async Task HandleFilterDialog(DialogResult result)
+    {
+        if (result.Data is FilterDialogResult filterResult && filterResult.Filter is FieldTelemetryFilter filter)
+        {
+            if (filterResult.Delete)
+            {
+                _filters.Remove(filter);
+            }
+            else if (filterResult.Add)
+            {
+                _filters.Add(filter);
+            }
+            else if (filterResult.Enable)
+            {
+                filter.Enabled = true;
+            }
+            else if (filterResult.Disable)
+            {
+                filter.Enabled = false;
+            }
+        }
+
+        await RefreshAfterFilterChangeAsync();
+    }
+
+    private async Task RefreshAfterFilterChangeAsync()
+    {
+        SelectedData = null;
+        await InvokeAsync(StateHasChanged);
+        await InvokeAsync(_dataGrid.SafeRefreshDataAsync);
+    }
+
+    // Computed fresh on each dialog open. A single trace typically has a small number of spans,
+    // so caching is unnecessary and avoids stale data if the trace is updated while the page is open.
+    private List<string> GetTraceSpanPropertyKeys()
+    {
+        if (_trace is null)
+        {
+            return [];
+        }
+
+        var keys = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        foreach (var span in _trace.Spans)
+        {
+            foreach (var attribute in span.Attributes)
+            {
+                keys.Add(attribute.Key);
+            }
+        }
+
+        return keys.OrderBy(k => k).ToList();
+    }
+
+    // Computed fresh on each dialog open for the same reason as GetTraceSpanPropertyKeys.
+    private Dictionary<string, int> GetTraceSpanFieldValues(string attributeName)
+    {
+        var attributeValues = new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase);
+
+        if (_trace is null)
+        {
+            return attributeValues;
+        }
+
+        foreach (var span in _trace.Spans)
+        {
+            var values = OtlpSpan.GetFieldValue(span, attributeName);
+            if (values.Value1 != null)
+            {
+                if (!attributeValues.TryGetValue(values.Value1, out var count))
+                {
+                    count = 0;
+                }
+                attributeValues[values.Value1] = count + 1;
+            }
+            if (values.Value2 != null)
+            {
+                if (!attributeValues.TryGetValue(values.Value2, out var count))
+                {
+                    count = 0;
+                }
+                attributeValues[values.Value2] = count + 1;
+            }
+        }
+
+        return attributeValues;
+    }
+
+    private List<MenuButtonItem> GetFilterMenuItems()
+    {
+        var filterMenuItems = new List<MenuButtonItem>();
+
+        foreach (var filter in _filters)
+        {
+            filterMenuItems.Add(new MenuButtonItem
+            {
+                OnClick = () => OpenFilterAsync(filter),
+                Text = filter.GetDisplayText(FilterLoc),
+                Icon = filter.Enabled ? new Icons.Regular.Size16.Play() : new Icons.Regular.Size16.Pause(),
+                Class = "filter-menu-item",
+            });
+        }
+
+        filterMenuItems.Add(new MenuButtonItem
+        {
+            IsDivider = true
+        });
+
+        if (_filters.GetEnabledFilters().Any())
+        {
+            filterMenuItems.Add(new MenuButtonItem
+            {
+                Text = DialogsLoc[nameof(Dashboard.Resources.Dialogs.FilterDialogDisableAll)],
+                Icon = new Icons.Regular.Size16.Pause(),
+                OnClick = async () =>
+                {
+                    foreach (var filter in _filters)
+                    {
+                        filter.Enabled = false;
+                    }
+                    await RefreshAfterFilterChangeAsync();
+                }
+            });
+        }
+        else
+        {
+            filterMenuItems.Add(new MenuButtonItem
+            {
+                Text = DialogsLoc[nameof(Dashboard.Resources.Dialogs.FilterDialogEnableAll)],
+                Icon = new Icons.Regular.Size16.Play(),
+                OnClick = async () =>
+                {
+                    foreach (var filter in _filters)
+                    {
+                        filter.Enabled = true;
+                    }
+                    await RefreshAfterFilterChangeAsync();
+                }
+            });
+        }
+
+        filterMenuItems.Add(new MenuButtonItem
+        {
+            Text = DialogsLoc[nameof(Dashboard.Resources.Dialogs.SettingsRemoveAllButtonText)],
+            Icon = new Icons.Regular.Size16.Delete(),
+            OnClick = async () =>
+            {
+                _filters.Clear();
+                await RefreshAfterFilterChangeAsync();
+            }
+        });
+
+        return filterMenuItems;
     }
 
     public void Dispose()

--- a/src/Aspire.Dashboard/Components/Pages/TraceDetail.razor.cs
+++ b/src/Aspire.Dashboard/Components/Pages/TraceDetail.razor.cs
@@ -579,24 +579,14 @@ public partial class TraceDetail : ComponentBase, IComponentWithTelemetry, IDisp
             await _layout.CloseMobileToolbarAsync();
         }
 
-        var title = entry is not null ? FilterLoc[nameof(StructuredFiltering.DialogTitleEditFilter)] : FilterLoc[nameof(StructuredFiltering.DialogTitleAddFilter)];
-        var parameters = new DialogParameters
-        {
-            OnDialogResult = DialogService.CreateDialogCallback(this, HandleFilterDialog),
-            Title = title,
-            Alignment = HorizontalAlignment.Right,
-            PrimaryAction = null,
-            SecondaryAction = null,
-            Width = "450px"
-        };
-        var data = new FilterDialogViewModel
-        {
-            Filter = entry,
-            PropertyKeys = GetTraceSpanPropertyKeys(),
-            KnownKeys = KnownTraceFields.AllFields,
-            GetFieldValues = GetTraceSpanFieldValues
-        };
-        await DialogService.ShowPanelAsync<FilterDialog>(data, parameters);
+        await FilterHelpers.OpenFilterAsync(
+            entry,
+            DialogService,
+            DialogService.CreateDialogCallback(this, HandleFilterDialog),
+            propertyKeys: GetTraceSpanPropertyKeys(),
+            knownKeys: KnownTraceFields.AllFields,
+            getFieldValues: GetTraceSpanFieldValues,
+            FilterLoc);
     }
 
     private async Task HandleFilterDialog(DialogResult result)
@@ -655,102 +645,23 @@ public partial class TraceDetail : ComponentBase, IComponentWithTelemetry, IDisp
     // Computed fresh on each dialog open for the same reason as GetTraceSpanPropertyKeys.
     private Dictionary<string, int> GetTraceSpanFieldValues(string attributeName)
     {
-        var attributeValues = new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase);
-
         if (_trace is null)
         {
-            return attributeValues;
+            return new Dictionary<string, int>(StringComparers.OtlpAttribute);
         }
 
-        foreach (var span in _trace.Spans)
-        {
-            var values = OtlpSpan.GetFieldValue(span, attributeName);
-            if (values.Value1 != null)
-            {
-                if (!attributeValues.TryGetValue(values.Value1, out var count))
-                {
-                    count = 0;
-                }
-                attributeValues[values.Value1] = count + 1;
-            }
-            if (values.Value2 != null)
-            {
-                if (!attributeValues.TryGetValue(values.Value2, out var count))
-                {
-                    count = 0;
-                }
-                attributeValues[values.Value2] = count + 1;
-            }
-        }
-
-        return attributeValues;
+        return OtlpSpan.GetFieldValuesFromTraces([_trace], attributeName);
     }
 
     private List<MenuButtonItem> GetFilterMenuItems()
     {
-        var filterMenuItems = new List<MenuButtonItem>();
-
-        foreach (var filter in _filters)
-        {
-            filterMenuItems.Add(new MenuButtonItem
-            {
-                OnClick = () => OpenFilterAsync(filter),
-                Text = filter.GetDisplayText(FilterLoc),
-                Icon = filter.Enabled ? new Icons.Regular.Size16.Play() : new Icons.Regular.Size16.Pause(),
-                Class = "filter-menu-item",
-            });
-        }
-
-        filterMenuItems.Add(new MenuButtonItem
-        {
-            IsDivider = true
-        });
-
-        if (_filters.GetEnabledFilters().Any())
-        {
-            filterMenuItems.Add(new MenuButtonItem
-            {
-                Text = DialogsLoc[nameof(Dashboard.Resources.Dialogs.FilterDialogDisableAll)],
-                Icon = new Icons.Regular.Size16.Pause(),
-                OnClick = async () =>
-                {
-                    foreach (var filter in _filters)
-                    {
-                        filter.Enabled = false;
-                    }
-                    await RefreshAfterFilterChangeAsync();
-                }
-            });
-        }
-        else
-        {
-            filterMenuItems.Add(new MenuButtonItem
-            {
-                Text = DialogsLoc[nameof(Dashboard.Resources.Dialogs.FilterDialogEnableAll)],
-                Icon = new Icons.Regular.Size16.Play(),
-                OnClick = async () =>
-                {
-                    foreach (var filter in _filters)
-                    {
-                        filter.Enabled = true;
-                    }
-                    await RefreshAfterFilterChangeAsync();
-                }
-            });
-        }
-
-        filterMenuItems.Add(new MenuButtonItem
-        {
-            Text = DialogsLoc[nameof(Dashboard.Resources.Dialogs.SettingsRemoveAllButtonText)],
-            Icon = new Icons.Regular.Size16.Delete(),
-            OnClick = async () =>
-            {
-                _filters.Clear();
-                await RefreshAfterFilterChangeAsync();
-            }
-        });
-
-        return filterMenuItems;
+        return FilterHelpers.GetFilterMenuItems(
+            _filters,
+            clearFilters: _filters.Clear,
+            openFilterAsync: OpenFilterAsync,
+            afterChangeAsync: RefreshAfterFilterChangeAsync,
+            filterLoc: FilterLoc,
+            dialogsLoc: DialogsLoc);
     }
 
     public void Dispose()

--- a/src/Aspire.Dashboard/Components/Pages/TraceDetail.razor.css
+++ b/src/Aspire.Dashboard/Components/Pages/TraceDetail.razor.css
@@ -205,6 +205,7 @@
 ::deep .trace-header-filters {
     grid-area: filters;
     display: flex;
+    align-items: center;
 }
 
 ::deep .span-button-container {

--- a/src/Aspire.Dashboard/Components/Pages/Traces.razor.cs
+++ b/src/Aspire.Dashboard/Components/Pages/Traces.razor.cs
@@ -362,24 +362,14 @@ public partial class Traces : IComponentWithTelemetry, IPageWithSessionAndUrlSta
             await _contentLayout.CloseMobileToolbarAsync();
         }
 
-        var title = entry is not null ? FilterLoc[nameof(StructuredFiltering.DialogTitleEditFilter)] : FilterLoc[nameof(StructuredFiltering.DialogTitleAddFilter)];
-        var parameters = new DialogParameters
-        {
-            OnDialogResult = DialogService.CreateDialogCallback(this, HandleFilterDialog),
-            Title = title,
-            Alignment = HorizontalAlignment.Right,
-            PrimaryAction = null,
-            SecondaryAction = null,
-            Width = "450px"
-        };
-        var data = new FilterDialogViewModel
-        {
-            Filter = entry,
-            PropertyKeys = TelemetryRepository.GetTracePropertyKeys(PageViewModel.SelectedResource.Id?.GetResourceKey()),
-            KnownKeys = KnownTraceFields.AllFields,
-            GetFieldValues = TelemetryRepository.GetTraceFieldValues
-        };
-        await DialogService.ShowPanelAsync<FilterDialog>(data, parameters);
+        await FilterHelpers.OpenFilterAsync(
+            entry,
+            DialogService,
+            DialogService.CreateDialogCallback(this, HandleFilterDialog),
+            propertyKeys: TelemetryRepository.GetTracePropertyKeys(PageViewModel.SelectedResource.Id?.GetResourceKey()),
+            knownKeys: KnownTraceFields.AllFields,
+            getFieldValues: TelemetryRepository.GetTraceFieldValues,
+            FilterLoc);
     }
 
     private async Task HandleFilterDialog(DialogResult result)
@@ -424,13 +414,13 @@ public partial class Traces : IComponentWithTelemetry, IPageWithSessionAndUrlSta
 
     private List<MenuButtonItem> GetFilterMenuItems()
     {
-        return this.GetFilterMenuItems(
+        return FilterHelpers.GetFilterMenuItems(
             TracesViewModel.Filters,
             clearFilters: TracesViewModel.ClearFilters,
             openFilterAsync: OpenFilterAsync,
+            afterChangeAsync: () => this.AfterViewModelChangedAsync(_contentLayout, waitToApplyMobileChange: false),
             filterLoc: FilterLoc,
-            dialogsLoc: DialogsLoc,
-            contentLayout: _contentLayout);
+            dialogsLoc: DialogsLoc);
     }
 
     private static bool HasGenAISpans(OtlpTrace trace)

--- a/src/Aspire.Dashboard/Model/Otlp/SpanWaterfallViewModel.cs
+++ b/src/Aspire.Dashboard/Model/Otlp/SpanWaterfallViewModel.cs
@@ -48,7 +48,7 @@ public sealed class SpanWaterfallViewModel
         return tooltip;
     }
 
-    public bool MatchesFilter(string filter, TelemetryFilter? typeFilter, Func<OtlpResourceView, string> getResourceName, [NotNullWhen(true)] out IEnumerable<SpanWaterfallViewModel>? matchedDescendents)
+    public bool MatchesFilter(string filter, TelemetryFilter? typeFilter, IReadOnlyList<FieldTelemetryFilter>? structuredFilters, Func<OtlpResourceView, string> getResourceName, [NotNullWhen(true)] out IEnumerable<SpanWaterfallViewModel>? matchedDescendents)
     {
         if (Filter(this))
         {
@@ -58,7 +58,7 @@ public sealed class SpanWaterfallViewModel
 
         foreach (var child in Children)
         {
-            if (child.MatchesFilter(filter, typeFilter, getResourceName, out var matchedChildDescendents))
+            if (child.MatchesFilter(filter, typeFilter, structuredFilters, getResourceName, out var matchedChildDescendents))
             {
                 matchedDescendents = [child, ..matchedChildDescendents];
                 return true;
@@ -76,6 +76,15 @@ public sealed class SpanWaterfallViewModel
                 {
                     return false;
                 }
+            }
+
+            // A span matches when it satisfies all enabled structured filters,
+            // mirroring TelemetryRepository.GetTraces which checks "a trace matches when
+            // one of its spans matches all filters."
+            if (structuredFilters is { Count: > 0 } &&
+                !structuredFilters.Where(f => f.Enabled).All(f => f.Apply(viewModel.Span)))
+            {
+                return false;
             }
 
             if (string.IsNullOrWhiteSpace(filter))

--- a/src/Aspire.Dashboard/Otlp/Model/OtlpSpan.cs
+++ b/src/Aspire.Dashboard/Otlp/Model/OtlpSpan.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Diagnostics;
+using System.Runtime.InteropServices;
 using Aspire.Dashboard.Extensions;
 using Aspire.Dashboard.Model.Otlp;
 using Grpc.Core;
@@ -240,6 +241,31 @@ public class OtlpSpan
             KnownTraceFields.NameField => span.Name,
             _ => span.Attributes.GetValue(field)
         };
+    }
+
+    public static Dictionary<string, int> GetFieldValuesFromTraces(IEnumerable<OtlpTrace> traces, string attributeName)
+    {
+        var attributeValues = new Dictionary<string, int>(StringComparers.OtlpAttribute);
+
+        foreach (var trace in traces)
+        {
+            foreach (var span in trace.Spans)
+            {
+                var values = GetFieldValue(span, attributeName);
+                if (values.Value1 is not null)
+                {
+                    ref var count = ref CollectionsMarshal.GetValueRefOrAddDefault(attributeValues, values.Value1, out _);
+                    count++;
+                }
+                if (values.Value2 is not null)
+                {
+                    ref var count = ref CollectionsMarshal.GetValueRefOrAddDefault(attributeValues, values.Value2, out _);
+                    count++;
+                }
+            }
+        }
+
+        return attributeValues;
     }
 
     public record struct FieldValues(string? Value1, string? Value2 = null)

--- a/src/Aspire.Dashboard/Otlp/Storage/TelemetryRepository.cs
+++ b/src/Aspire.Dashboard/Otlp/Storage/TelemetryRepository.cs
@@ -897,36 +897,14 @@ public sealed partial class TelemetryRepository : IDisposable
     {
         _tracesLock.EnterReadLock();
 
-        var attributesValues = new Dictionary<string, int>(StringComparers.OtlpAttribute);
-
         try
         {
-            foreach (var trace in _traces)
-            {
-                foreach (var span in trace.Spans)
-                {
-                    var values = OtlpSpan.GetFieldValue(span, attributeName);
-                    if (values.Value1 != null)
-                    {
-                        ref var count = ref CollectionsMarshal.GetValueRefOrAddDefault(attributesValues, values.Value1, out _);
-                        // Adds to dictionary if not present.
-                        count++;
-                    }
-                    if (values.Value2 != null)
-                    {
-                        ref var count = ref CollectionsMarshal.GetValueRefOrAddDefault(attributesValues, values.Value2, out _);
-                        // Adds to dictionary if not present.
-                        count++;
-                    }
-                }
-            }
+            return OtlpSpan.GetFieldValuesFromTraces(_traces, attributeName);
         }
         finally
         {
             _tracesLock.ExitReadLock();
         }
-
-        return attributesValues;
     }
 
     public Dictionary<string, int> GetLogsFieldValues(string attributeName)

--- a/src/Aspire.Dashboard/Utils/FilterHelpers.cs
+++ b/src/Aspire.Dashboard/Utils/FilterHelpers.cs
@@ -1,12 +1,13 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using Aspire.Dashboard.Components.Layout;
-using Aspire.Dashboard.Components.Pages;
+using Aspire.Dashboard.Components.Dialogs;
 using Aspire.Dashboard.Model;
 using Aspire.Dashboard.Model.Otlp;
 using Aspire.Dashboard.Resources;
+using Microsoft.AspNetCore.Components;
 using Microsoft.Extensions.Localization;
+using Microsoft.FluentUI.AspNetCore.Components;
 using Icons = Microsoft.FluentUI.AspNetCore.Components.Icons;
 
 namespace Aspire.Dashboard.Utils;
@@ -18,14 +19,13 @@ public static class FilterHelpers
         return filters.Where(filter => filter.Enabled);
     }
 
-    public static List<MenuButtonItem> GetFilterMenuItems<TView, TR>(
-        this IPageWithSessionAndUrlState<TView, TR> page,
+    public static List<MenuButtonItem> GetFilterMenuItems(
         IReadOnlyList<FieldTelemetryFilter> filters,
         Action clearFilters,
-        Func<FieldTelemetryFilter, Task> openFilterAsync,
+        Func<FieldTelemetryFilter?, Task> openFilterAsync,
+        Func<Task> afterChangeAsync,
         IStringLocalizer<StructuredFiltering> filterLoc,
-        IStringLocalizer<Dialogs> dialogsLoc,
-        AspirePageContentLayout? contentLayout) where TR : class
+        IStringLocalizer<Dialogs> dialogsLoc)
     {
         var filterMenuItems = new List<MenuButtonItem>();
 
@@ -58,7 +58,7 @@ public static class FilterHelpers
                         filter.Enabled = false;
                     }
 
-                    await page.AfterViewModelChangedAsync(contentLayout, waitToApplyMobileChange: false).ConfigureAwait(true);
+                    await afterChangeAsync().ConfigureAwait(true);
                 }
             });
         }
@@ -75,7 +75,7 @@ public static class FilterHelpers
                         filter.Enabled = true;
                     }
 
-                    await page.AfterViewModelChangedAsync(contentLayout, waitToApplyMobileChange: false).ConfigureAwait(true);
+                    await afterChangeAsync().ConfigureAwait(true);
                 }
             });
         }
@@ -87,10 +87,39 @@ public static class FilterHelpers
             OnClick = async () =>
             {
                 clearFilters();
-                await page.AfterViewModelChangedAsync(contentLayout, waitToApplyMobileChange: false).ConfigureAwait(true);
+                await afterChangeAsync().ConfigureAwait(true);
             }
         });
 
         return filterMenuItems;
+    }
+
+    public static async Task OpenFilterAsync(
+        FieldTelemetryFilter? entry,
+        DashboardDialogService dialogService,
+        EventCallback<DialogResult> onDialogResult,
+        List<string> propertyKeys,
+        List<string> knownKeys,
+        Func<string, Dictionary<string, int>> getFieldValues,
+        IStringLocalizer<StructuredFiltering> filterLoc)
+    {
+        var title = entry is not null ? filterLoc[nameof(StructuredFiltering.DialogTitleEditFilter)] : filterLoc[nameof(StructuredFiltering.DialogTitleAddFilter)];
+        var parameters = new DialogParameters
+        {
+            OnDialogResult = onDialogResult,
+            Title = title,
+            Alignment = HorizontalAlignment.Right,
+            PrimaryAction = null,
+            SecondaryAction = null,
+            Width = dialogService.IsDesktop ? "450px" : "100%"
+        };
+        var data = new FilterDialogViewModel
+        {
+            Filter = entry,
+            PropertyKeys = propertyKeys,
+            KnownKeys = knownKeys,
+            GetFieldValues = getFieldValues
+        };
+        await dialogService.ShowPanelAsync<FilterDialog>(data, parameters).ConfigureAwait(false);
     }
 }

--- a/tests/Aspire.Dashboard.Tests/Model/SpanWaterfallViewModelTests.cs
+++ b/tests/Aspire.Dashboard.Tests/Model/SpanWaterfallViewModelTests.cs
@@ -145,7 +145,7 @@ public sealed class SpanWaterfallViewModelTests
             new SpanWaterfallViewModel.TraceDetailState([], [], [])).First();
 
         // Act
-        var result = vm.MatchesFilter(filter, typeFilter: null, a => a.Resource.ResourceName, out _);
+        var result = vm.MatchesFilter(filter, typeFilter: null, structuredFilters: null, a => a.Resource.ResourceName, out _);
 
         // Assert
         Assert.Equal(expected, result);
@@ -205,7 +205,7 @@ public sealed class SpanWaterfallViewModelTests
             new SpanWaterfallViewModel.TraceDetailState([], [], [])).First();
 
         // Act 1
-        var result1 = vm.MatchesFilter(string.Empty, typeFilter: spanType.Id?.Filter, a => a.Resource.ResourceName, out _);
+        var result1 = vm.MatchesFilter(string.Empty, typeFilter: spanType.Id?.Filter, structuredFilters: null, a => a.Resource.ResourceName, out _);
 
         // Assert 1
         Assert.Equal(expected, result1);
@@ -214,7 +214,7 @@ public sealed class SpanWaterfallViewModelTests
         if (result1)
         {
             // Act 2
-            var result2 = vm.MatchesFilter(string.Empty, typeFilter: otherSpanType.Id?.Filter, a => a.Resource.ResourceName, out _);
+            var result2 = vm.MatchesFilter(string.Empty, typeFilter: otherSpanType.Id?.Filter, structuredFilters: null, a => a.Resource.ResourceName, out _);
 
             // Assert 2
             Assert.False(result2);
@@ -239,8 +239,8 @@ public sealed class SpanWaterfallViewModelTests
         var child = vms[1];
 
         // Act and assert
-        Assert.True(parent.MatchesFilter("child", typeFilter: null, a => a.Resource.ResourceName, out _));
-        Assert.True(child.MatchesFilter("child", typeFilter: null, a => a.Resource.ResourceName, out _));
+        Assert.True(parent.MatchesFilter("child", typeFilter: null, structuredFilters: null, a => a.Resource.ResourceName, out _));
+        Assert.True(child.MatchesFilter("child", typeFilter: null, structuredFilters: null, a => a.Resource.ResourceName, out _));
     }
 
     [Fact]
@@ -261,9 +261,171 @@ public sealed class SpanWaterfallViewModelTests
         var child = vms[1];
 
         // Act and assert
-        Assert.True(parent.MatchesFilter("parent", typeFilter: null, a => a.Resource.ResourceName, out var descendents));
+        Assert.True(parent.MatchesFilter("parent", typeFilter: null, structuredFilters: null, a => a.Resource.ResourceName, out var descendents));
         Assert.Equal("child", Assert.Single(descendents).Span.SpanId);
-        Assert.False(child.MatchesFilter("parent", typeFilter: null, a => a.Resource.ResourceName, out _));
+        Assert.False(child.MatchesFilter("parent", typeFilter: null, structuredFilters: null, a => a.Resource.ResourceName, out _));
+    }
+
+    [Theory]
+    [InlineData("http.method", FilterCondition.Equals, "GET", true)]  // Exact match
+    [InlineData("http.method", FilterCondition.Equals, "POST", false)]  // Wrong value
+    [InlineData("http.method", FilterCondition.Contains, "GE", true)]  // Partial match
+    [InlineData("http.method", FilterCondition.Contains, "DELETE", false)]  // Partial no match
+    [InlineData("http.method", FilterCondition.NotEqual, "POST", true)]  // Not equal passes
+    [InlineData("http.method", FilterCondition.NotEqual, "GET", false)]  // Not equal fails
+    [InlineData("http.method", FilterCondition.NotContains, "POS", true)]  // Not contains passes
+    [InlineData("http.method", FilterCondition.NotContains, "GE", false)]  // Not contains fails
+    [InlineData("nonexistent.attr", FilterCondition.Equals, "GET", false)]  // Field not present
+    public void MatchesFilter_StructuredFilter_SingleFilter_ReturnsExpected(string field, FilterCondition condition, string value, bool expected)
+    {
+        // Arrange
+        var context = new OtlpContext { Logger = NullLogger.Instance, Options = new() };
+        var app = new OtlpResource("app1", "instance", uninstrumentedPeer: false, context);
+        var trace = new OtlpTrace(new byte[] { 1, 2, 3 }, DateTime.MinValue);
+        var scope = TelemetryTestHelpers.CreateOtlpScope(context);
+
+        var attributes = new[]
+        {
+            new KeyValuePair<string, string>("http.method", "GET"),
+            new KeyValuePair<string, string>("http.status_code", "200")
+        };
+
+        var span = TelemetryTestHelpers.CreateOtlpSpan(
+            app, trace, scope, spanId: "1", parentSpanId: null,
+            startDate: new DateTime(2001, 1, 1, 1, 1, 2, DateTimeKind.Utc),
+            attributes: attributes,
+            statusCode: OtlpSpanStatusCode.Unset, statusMessage: null, kind: OtlpSpanKind.Client);
+        trace.AddSpan(span);
+
+        var vm = SpanWaterfallViewModel.Create(trace, [], new SpanWaterfallViewModel.TraceDetailState([], [], [])).First();
+
+        var filters = new List<FieldTelemetryFilter>
+        {
+            new() { Field = field, Condition = condition, Value = value }
+        };
+
+        // Act
+        var result = vm.MatchesFilter(string.Empty, typeFilter: null, structuredFilters: filters, a => a.Resource.ResourceName, out _);
+
+        // Assert
+        Assert.Equal(expected, result);
+    }
+
+    [Fact]
+    public void MatchesFilter_StructuredFilter_MultipleFilters_AllMustMatch()
+    {
+        // Arrange
+        var context = new OtlpContext { Logger = NullLogger.Instance, Options = new() };
+        var app = new OtlpResource("app1", "instance", uninstrumentedPeer: false, context);
+        var trace = new OtlpTrace(new byte[] { 1, 2, 3 }, DateTime.MinValue);
+        var scope = TelemetryTestHelpers.CreateOtlpScope(context);
+
+        var attributes = new[]
+        {
+            new KeyValuePair<string, string>("http.method", "GET"),
+            new KeyValuePair<string, string>("http.status_code", "200")
+        };
+
+        var span = TelemetryTestHelpers.CreateOtlpSpan(
+            app, trace, scope, spanId: "1", parentSpanId: null,
+            startDate: new DateTime(2001, 1, 1, 1, 1, 2, DateTimeKind.Utc),
+            attributes: attributes,
+            statusCode: OtlpSpanStatusCode.Unset, statusMessage: null, kind: OtlpSpanKind.Client);
+        trace.AddSpan(span);
+
+        var vm = SpanWaterfallViewModel.Create(trace, [], new SpanWaterfallViewModel.TraceDetailState([], [], [])).First();
+
+        // One filter matches, one doesn't — AND logic means the span shouldn't match.
+        var filters = new List<FieldTelemetryFilter>
+        {
+            new() { Field = "http.method", Condition = FilterCondition.Equals, Value = "GET" },
+            new() { Field = "http.status_code", Condition = FilterCondition.Equals, Value = "500" }
+        };
+
+        // Act
+        var result = vm.MatchesFilter(string.Empty, typeFilter: null, structuredFilters: filters, a => a.Resource.ResourceName, out _);
+
+        // Assert
+        Assert.False(result);
+    }
+
+    [Fact]
+    public void MatchesFilter_StructuredFilter_DisabledFilterIsIgnored()
+    {
+        // Arrange
+        var context = new OtlpContext { Logger = NullLogger.Instance, Options = new() };
+        var app = new OtlpResource("app1", "instance", uninstrumentedPeer: false, context);
+        var trace = new OtlpTrace(new byte[] { 1, 2, 3 }, DateTime.MinValue);
+        var scope = TelemetryTestHelpers.CreateOtlpScope(context);
+
+        var attributes = new[]
+        {
+            new KeyValuePair<string, string>("http.method", "GET")
+        };
+
+        var span = TelemetryTestHelpers.CreateOtlpSpan(
+            app, trace, scope, spanId: "1", parentSpanId: null,
+            startDate: new DateTime(2001, 1, 1, 1, 1, 2, DateTimeKind.Utc),
+            attributes: attributes,
+            statusCode: OtlpSpanStatusCode.Unset, statusMessage: null, kind: OtlpSpanKind.Client);
+        trace.AddSpan(span);
+
+        var vm = SpanWaterfallViewModel.Create(trace, [], new SpanWaterfallViewModel.TraceDetailState([], [], [])).First();
+
+        // Filter would exclude the span, but it's disabled.
+        var filters = new List<FieldTelemetryFilter>
+        {
+            new() { Field = "http.method", Condition = FilterCondition.Equals, Value = "POST", Enabled = false }
+        };
+
+        // Act
+        var result = vm.MatchesFilter(string.Empty, typeFilter: null, structuredFilters: filters, a => a.Resource.ResourceName, out _);
+
+        // Assert
+        Assert.True(result);
+    }
+
+    [Fact]
+    public void MatchesFilter_StructuredFilter_ParentMatchesWhenChildHasMatchingFilter()
+    {
+        // Arrange
+        var context = new OtlpContext { Logger = NullLogger.Instance, Options = new() };
+        var app = new OtlpResource("app1", "instance", uninstrumentedPeer: false, context);
+        var trace = new OtlpTrace(new byte[] { 1, 2, 3 }, DateTime.MinValue);
+        var scope = TelemetryTestHelpers.CreateOtlpScope(context);
+
+        var parentSpan = TelemetryTestHelpers.CreateOtlpSpan(
+            app, trace, scope, spanId: "parent", parentSpanId: null,
+            startDate: new DateTime(2001, 1, 1, 1, 1, 2, DateTimeKind.Utc),
+            attributes: [new KeyValuePair<string, string>("http.method", "GET")],
+            statusCode: OtlpSpanStatusCode.Unset, statusMessage: null, kind: OtlpSpanKind.Server);
+
+        var childSpan = TelemetryTestHelpers.CreateOtlpSpan(
+            app, trace, scope, spanId: "child", parentSpanId: "parent",
+            startDate: new DateTime(2001, 1, 1, 1, 1, 3, DateTimeKind.Utc),
+            attributes: [new KeyValuePair<string, string>("db.system", "postgresql")],
+            statusCode: OtlpSpanStatusCode.Unset, statusMessage: null, kind: OtlpSpanKind.Client);
+
+        trace.AddSpan(parentSpan);
+        trace.AddSpan(childSpan);
+
+        var vms = SpanWaterfallViewModel.Create(trace, [], new SpanWaterfallViewModel.TraceDetailState([], [], []));
+        var parent = vms[0];
+        var child = vms[1];
+
+        // Filter matches child but not parent — parent should still match via descendant logic.
+        var filters = new List<FieldTelemetryFilter>
+        {
+            new() { Field = "db.system", Condition = FilterCondition.Equals, Value = "postgresql" }
+        };
+
+        // Act
+        var parentResult = parent.MatchesFilter(string.Empty, typeFilter: null, structuredFilters: filters, a => a.Resource.ResourceName, out _);
+        var childResult = child.MatchesFilter(string.Empty, typeFilter: null, structuredFilters: filters, a => a.Resource.ResourceName, out _);
+
+        // Assert
+        Assert.True(parentResult);
+        Assert.True(childResult);
     }
 
     private sealed class EmptyDisposable : IDisposable


### PR DESCRIPTION
Fixes https://github.com/microsoft/aspire/issues/17123

Add a structured 'Add filter' dialog to the trace detail (waterfall) page, following the same pattern as the Traces list page. Filters apply per-span with AND logic, and parent spans remain visible when a descendant matches.

- Add filter UI markup (desktop and mobile) with badge counter
- Add MatchesFilter structured filter support in SpanWaterfallViewModel
- Add tests for structured filtering
- Fix toolbar alignment with align-items: center