### PR TITLE
Remove trailing periods after interpolated content in error strings

### DIFF
--- a/src/Aspire.Cli/Resources/InteractionServiceStrings.resx
+++ b/src/Aspire.Cli/Resources/InteractionServiceStrings.resx
@@ -207,10 +207,10 @@
     <value>The specified project file is not an Aspire AppHost project.</value>
   </data>
   <data name="ErrorConnectingToAppHost" xml:space="preserve">
-    <value>An error occurred while connecting to the AppHost. The AppHost possibly crashed before it was available: {0}.</value>
+    <value>An error occurred while connecting to the AppHost. The AppHost possibly crashed before it was available: {0}</value>
   </data>
   <data name="AppHostConnectionLost" xml:space="preserve">
-    <value>The connection to the AppHost was lost: {0}.</value>
+    <value>The connection to the AppHost was lost: {0}</value>
   </data>
   <data name="AppHostConnectionLostGeneric" xml:space="preserve">
     <value>The connection to the application was lost.</value>

--- a/src/Aspire.Cli/Resources/WaitCommandStrings.resx
+++ b/src/Aspire.Cli/Resources/WaitCommandStrings.resx
@@ -142,7 +142,7 @@
     <value>Resource '{0}' was not found.</value>
   </data>
   <data name="ResourceEnteredFailedState" xml:space="preserve">
-    <value>Resource '{0}' entered a failed state: {1}.</value>
+    <value>Resource '{0}' entered a failed state: {1}</value>
   </data>
   <data name="InvalidStatusValue" xml:space="preserve">
     <value>Invalid status value '{0}'. Valid values are: healthy, up, down.</value>

--- a/src/Aspire.Cli/Resources/xlf/InteractionServiceStrings.cs.xlf
+++ b/src/Aspire.Cli/Resources/xlf/InteractionServiceStrings.cs.xlf
@@ -3,7 +3,7 @@
   <file datatype="xml" source-language="en" target-language="cs" original="../InteractionServiceStrings.resx">
     <body>
       <trans-unit id="AppHostConnectionLost">
-        <source>The connection to the AppHost was lost: {0}.</source>
+        <source>The connection to the AppHost was lost: {0}</source>
         <target state="needs-review-translation">Připojení k hostiteli aplikace bylo ztraceno: {0}.</target>
         <note />
       </trans-unit>
@@ -73,7 +73,7 @@
         <note>Represents a type of link</note>
       </trans-unit>
       <trans-unit id="ErrorConnectingToAppHost">
-        <source>An error occurred while connecting to the AppHost. The AppHost possibly crashed before it was available: {0}.</source>
+        <source>An error occurred while connecting to the AppHost. The AppHost possibly crashed before it was available: {0}</source>
         <target state="needs-review-translation">Při připojování k hostiteli aplikací došlo k chybě. Pravděpodobně došlo k chybovému ukončení hostitele aplikací před tím, než byl k dispozici: {0}.</target>
         <note />
       </trans-unit>

--- a/src/Aspire.Cli/Resources/xlf/InteractionServiceStrings.de.xlf
+++ b/src/Aspire.Cli/Resources/xlf/InteractionServiceStrings.de.xlf
@@ -3,7 +3,7 @@
   <file datatype="xml" source-language="en" target-language="de" original="../InteractionServiceStrings.resx">
     <body>
       <trans-unit id="AppHostConnectionLost">
-        <source>The connection to the AppHost was lost: {0}.</source>
+        <source>The connection to the AppHost was lost: {0}</source>
         <target state="needs-review-translation">Die Verbindung mit dem App-Host wurde getrennt: {0}.</target>
         <note />
       </trans-unit>
@@ -73,7 +73,7 @@
         <note>Represents a type of link</note>
       </trans-unit>
       <trans-unit id="ErrorConnectingToAppHost">
-        <source>An error occurred while connecting to the AppHost. The AppHost possibly crashed before it was available: {0}.</source>
+        <source>An error occurred while connecting to the AppHost. The AppHost possibly crashed before it was available: {0}</source>
         <target state="needs-review-translation">Fehler beim Herstellen einer Verbindung mit dem App-Host. Der App-Host ist möglicherweise abgestürzt, bevor er verfügbar war: {0}.</target>
         <note />
       </trans-unit>

--- a/src/Aspire.Cli/Resources/xlf/InteractionServiceStrings.es.xlf
+++ b/src/Aspire.Cli/Resources/xlf/InteractionServiceStrings.es.xlf
@@ -3,7 +3,7 @@
   <file datatype="xml" source-language="en" target-language="es" original="../InteractionServiceStrings.resx">
     <body>
       <trans-unit id="AppHostConnectionLost">
-        <source>The connection to the AppHost was lost: {0}.</source>
+        <source>The connection to the AppHost was lost: {0}</source>
         <target state="needs-review-translation">Se perdió la conexión con el host de la aplicación: {0}.</target>
         <note />
       </trans-unit>
@@ -73,7 +73,7 @@
         <note>Represents a type of link</note>
       </trans-unit>
       <trans-unit id="ErrorConnectingToAppHost">
-        <source>An error occurred while connecting to the AppHost. The AppHost possibly crashed before it was available: {0}.</source>
+        <source>An error occurred while connecting to the AppHost. The AppHost possibly crashed before it was available: {0}</source>
         <target state="needs-review-translation">Se produjo un error al conectarse al host de aplicaciones. Es posible que el host de la aplicación se haya bloqueado antes de que estuviera disponible: {0}.</target>
         <note />
       </trans-unit>

--- a/src/Aspire.Cli/Resources/xlf/InteractionServiceStrings.fr.xlf
+++ b/src/Aspire.Cli/Resources/xlf/InteractionServiceStrings.fr.xlf
@@ -3,7 +3,7 @@
   <file datatype="xml" source-language="en" target-language="fr" original="../InteractionServiceStrings.resx">
     <body>
       <trans-unit id="AppHostConnectionLost">
-        <source>The connection to the AppHost was lost: {0}.</source>
+        <source>The connection to the AppHost was lost: {0}</source>
         <target state="needs-review-translation">La connexion à l’hôte de l’application a été perdue : {0}.</target>
         <note />
       </trans-unit>
@@ -73,7 +73,7 @@
         <note>Represents a type of link</note>
       </trans-unit>
       <trans-unit id="ErrorConnectingToAppHost">
-        <source>An error occurred while connecting to the AppHost. The AppHost possibly crashed before it was available: {0}.</source>
+        <source>An error occurred while connecting to the AppHost. The AppHost possibly crashed before it was available: {0}</source>
         <target state="needs-review-translation">Une erreur s’est produite lors de la connexion à l’hôte d’application. L’hôte d’application s’est peut-être bloqué avant qu’il ne soit disponible : {0}.</target>
         <note />
       </trans-unit>

--- a/src/Aspire.Cli/Resources/xlf/InteractionServiceStrings.it.xlf
+++ b/src/Aspire.Cli/Resources/xlf/InteractionServiceStrings.it.xlf
@@ -3,7 +3,7 @@
   <file datatype="xml" source-language="en" target-language="it" original="../InteractionServiceStrings.resx">
     <body>
       <trans-unit id="AppHostConnectionLost">
-        <source>The connection to the AppHost was lost: {0}.</source>
+        <source>The connection to the AppHost was lost: {0}</source>
         <target state="needs-review-translation">La connessione all'host dell'app è stata interrotta: {0}.</target>
         <note />
       </trans-unit>
@@ -73,7 +73,7 @@
         <note>Represents a type of link</note>
       </trans-unit>
       <trans-unit id="ErrorConnectingToAppHost">
-        <source>An error occurred while connecting to the AppHost. The AppHost possibly crashed before it was available: {0}.</source>
+        <source>An error occurred while connecting to the AppHost. The AppHost possibly crashed before it was available: {0}</source>
         <target state="needs-review-translation">Si è verificato un errore durante la connessione all'host delle app. È possibile che l'host delle app si sia arrestato in modo anomalo prima che fosse disponibile: {0}.</target>
         <note />
       </trans-unit>

--- a/src/Aspire.Cli/Resources/xlf/InteractionServiceStrings.ja.xlf
+++ b/src/Aspire.Cli/Resources/xlf/InteractionServiceStrings.ja.xlf
@@ -3,7 +3,7 @@
   <file datatype="xml" source-language="en" target-language="ja" original="../InteractionServiceStrings.resx">
     <body>
       <trans-unit id="AppHostConnectionLost">
-        <source>The connection to the AppHost was lost: {0}.</source>
+        <source>The connection to the AppHost was lost: {0}</source>
         <target state="needs-review-translation">アプリ ホストへの接続が失われました: {0}。</target>
         <note />
       </trans-unit>
@@ -73,7 +73,7 @@
         <note>Represents a type of link</note>
       </trans-unit>
       <trans-unit id="ErrorConnectingToAppHost">
-        <source>An error occurred while connecting to the AppHost. The AppHost possibly crashed before it was available: {0}.</source>
+        <source>An error occurred while connecting to the AppHost. The AppHost possibly crashed before it was available: {0}</source>
         <target state="needs-review-translation">アプリ ホスティング プロセスへの接続でエラーが発生しました。アプリ ホスティング プロセスが、利用可能になる前にクラッシュした可能性があります: {0}。</target>
         <note />
       </trans-unit>

--- a/src/Aspire.Cli/Resources/xlf/InteractionServiceStrings.ko.xlf
+++ b/src/Aspire.Cli/Resources/xlf/InteractionServiceStrings.ko.xlf
@@ -3,7 +3,7 @@
   <file datatype="xml" source-language="en" target-language="ko" original="../InteractionServiceStrings.resx">
     <body>
       <trans-unit id="AppHostConnectionLost">
-        <source>The connection to the AppHost was lost: {0}.</source>
+        <source>The connection to the AppHost was lost: {0}</source>
         <target state="needs-review-translation">앱 호스트에 대한 연결이 끊어졌습니다. {0}.</target>
         <note />
       </trans-unit>
@@ -73,7 +73,7 @@
         <note>Represents a type of link</note>
       </trans-unit>
       <trans-unit id="ErrorConnectingToAppHost">
-        <source>An error occurred while connecting to the AppHost. The AppHost possibly crashed before it was available: {0}.</source>
+        <source>An error occurred while connecting to the AppHost. The AppHost possibly crashed before it was available: {0}</source>
         <target state="needs-review-translation">앱 호스트에 연결하는 동안 오류가 발생했습니다. 앱 호스트가 사용 가능하기 전에 충돌했을 수 있음: {0}.</target>
         <note />
       </trans-unit>

--- a/src/Aspire.Cli/Resources/xlf/InteractionServiceStrings.pl.xlf
+++ b/src/Aspire.Cli/Resources/xlf/InteractionServiceStrings.pl.xlf
@@ -3,7 +3,7 @@
   <file datatype="xml" source-language="en" target-language="pl" original="../InteractionServiceStrings.resx">
     <body>
       <trans-unit id="AppHostConnectionLost">
-        <source>The connection to the AppHost was lost: {0}.</source>
+        <source>The connection to the AppHost was lost: {0}</source>
         <target state="needs-review-translation">Połączenie z hostem aplikacji zostało utracone: {0}.</target>
         <note />
       </trans-unit>
@@ -73,7 +73,7 @@
         <note>Represents a type of link</note>
       </trans-unit>
       <trans-unit id="ErrorConnectingToAppHost">
-        <source>An error occurred while connecting to the AppHost. The AppHost possibly crashed before it was available: {0}.</source>
+        <source>An error occurred while connecting to the AppHost. The AppHost possibly crashed before it was available: {0}</source>
         <target state="needs-review-translation">Wystąpił błąd podczas nawiązywania połączenia z hostem aplikacji. Host aplikacji prawdopodobnie uległ awarii, zanim był dostępny: {0}.</target>
         <note />
       </trans-unit>

--- a/src/Aspire.Cli/Resources/xlf/InteractionServiceStrings.pt-BR.xlf
+++ b/src/Aspire.Cli/Resources/xlf/InteractionServiceStrings.pt-BR.xlf
@@ -3,7 +3,7 @@
   <file datatype="xml" source-language="en" target-language="pt-BR" original="../InteractionServiceStrings.resx">
     <body>
       <trans-unit id="AppHostConnectionLost">
-        <source>The connection to the AppHost was lost: {0}.</source>
+        <source>The connection to the AppHost was lost: {0}</source>
         <target state="needs-review-translation">A conexão com o host do aplicativo foi perdida: {0}.</target>
         <note />
       </trans-unit>
@@ -73,7 +73,7 @@
         <note>Represents a type of link</note>
       </trans-unit>
       <trans-unit id="ErrorConnectingToAppHost">
-        <source>An error occurred while connecting to the AppHost. The AppHost possibly crashed before it was available: {0}.</source>
+        <source>An error occurred while connecting to the AppHost. The AppHost possibly crashed before it was available: {0}</source>
         <target state="needs-review-translation">Erro ao se conectar ao host de aplicativo. O host de aplicativo possivelmente falhou antes de estar disponível: {0}.</target>
         <note />
       </trans-unit>

--- a/src/Aspire.Cli/Resources/xlf/InteractionServiceStrings.ru.xlf
+++ b/src/Aspire.Cli/Resources/xlf/InteractionServiceStrings.ru.xlf
@@ -3,7 +3,7 @@
   <file datatype="xml" source-language="en" target-language="ru" original="../InteractionServiceStrings.resx">
     <body>
       <trans-unit id="AppHostConnectionLost">
-        <source>The connection to the AppHost was lost: {0}.</source>
+        <source>The connection to the AppHost was lost: {0}</source>
         <target state="needs-review-translation">Потеряно подключение к узлу приложения: {0}.</target>
         <note />
       </trans-unit>
@@ -73,7 +73,7 @@
         <note>Represents a type of link</note>
       </trans-unit>
       <trans-unit id="ErrorConnectingToAppHost">
-        <source>An error occurred while connecting to the AppHost. The AppHost possibly crashed before it was available: {0}.</source>
+        <source>An error occurred while connecting to the AppHost. The AppHost possibly crashed before it was available: {0}</source>
         <target state="needs-review-translation">При подключении к хосту приложений возникла ошибка. Возможно, хост приложения аварийно завершил работу до того, как стал доступен: {0}.</target>
         <note />
       </trans-unit>

--- a/src/Aspire.Cli/Resources/xlf/InteractionServiceStrings.tr.xlf
+++ b/src/Aspire.Cli/Resources/xlf/InteractionServiceStrings.tr.xlf
@@ -3,7 +3,7 @@
   <file datatype="xml" source-language="en" target-language="tr" original="../InteractionServiceStrings.resx">
     <body>
       <trans-unit id="AppHostConnectionLost">
-        <source>The connection to the AppHost was lost: {0}.</source>
+        <source>The connection to the AppHost was lost: {0}</source>
         <target state="needs-review-translation">Uygulama ana işleminin bağlantısı kesildi: {0}.</target>
         <note />
       </trans-unit>
@@ -73,7 +73,7 @@
         <note>Represents a type of link</note>
       </trans-unit>
       <trans-unit id="ErrorConnectingToAppHost">
-        <source>An error occurred while connecting to the AppHost. The AppHost possibly crashed before it was available: {0}.</source>
+        <source>An error occurred while connecting to the AppHost. The AppHost possibly crashed before it was available: {0}</source>
         <target state="needs-review-translation">Uygulama ana işlemiyle bağlantı kurulurken bir hata oluştu. Uygulama ana işlemi, kullanılabilir duruma gelmeden önce muhtemelen çöktü: {0}.</target>
         <note />
       </trans-unit>

--- a/src/Aspire.Cli/Resources/xlf/InteractionServiceStrings.zh-Hans.xlf
+++ b/src/Aspire.Cli/Resources/xlf/InteractionServiceStrings.zh-Hans.xlf
@@ -3,7 +3,7 @@
   <file datatype="xml" source-language="en" target-language="zh-Hans" original="../InteractionServiceStrings.resx">
     <body>
       <trans-unit id="AppHostConnectionLost">
-        <source>The connection to the AppHost was lost: {0}.</source>
+        <source>The connection to the AppHost was lost: {0}</source>
         <target state="needs-review-translation">与应用主机的连接已断开: {0}。</target>
         <note />
       </trans-unit>
@@ -73,7 +73,7 @@
         <note>Represents a type of link</note>
       </trans-unit>
       <trans-unit id="ErrorConnectingToAppHost">
-        <source>An error occurred while connecting to the AppHost. The AppHost possibly crashed before it was available: {0}.</source>
+        <source>An error occurred while connecting to the AppHost. The AppHost possibly crashed before it was available: {0}</source>
         <target state="needs-review-translation">连接到应用主机时出错。应用主机可能在可用之前发生故障: {0}。</target>
         <note />
       </trans-unit>

--- a/src/Aspire.Cli/Resources/xlf/InteractionServiceStrings.zh-Hant.xlf
+++ b/src/Aspire.Cli/Resources/xlf/InteractionServiceStrings.zh-Hant.xlf
@@ -3,7 +3,7 @@
   <file datatype="xml" source-language="en" target-language="zh-Hant" original="../InteractionServiceStrings.resx">
     <body>
       <trans-unit id="AppHostConnectionLost">
-        <source>The connection to the AppHost was lost: {0}.</source>
+        <source>The connection to the AppHost was lost: {0}</source>
         <target state="needs-review-translation">與應用程式主機的連線已中斷: {0}。</target>
         <note />
       </trans-unit>
@@ -73,7 +73,7 @@
         <note>Represents a type of link</note>
       </trans-unit>
       <trans-unit id="ErrorConnectingToAppHost">
-        <source>An error occurred while connecting to the AppHost. The AppHost possibly crashed before it was available: {0}.</source>
+        <source>An error occurred while connecting to the AppHost. The AppHost possibly crashed before it was available: {0}</source>
         <target state="needs-review-translation">連接到應用程式主機時發生錯誤。應用程式主機可能在可用之前當機: {0}。</target>
         <note />
       </trans-unit>

--- a/src/Aspire.Cli/Resources/xlf/WaitCommandStrings.cs.xlf
+++ b/src/Aspire.Cli/Resources/xlf/WaitCommandStrings.cs.xlf
@@ -18,8 +18,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ResourceEnteredFailedState">
-        <source>Resource '{0}' entered a failed state: {1}.</source>
-        <target state="translated">Prostředek {0} vstoupil do stavu selhání: {1}.</target>
+        <source>Resource '{0}' entered a failed state: {1}</source>
+        <target state="needs-review-translation">Prostředek {0} vstoupil do stavu selhání: {1}.</target>
         <note />
       </trans-unit>
       <trans-unit id="ResourceNotFound">

--- a/src/Aspire.Cli/Resources/xlf/WaitCommandStrings.de.xlf
+++ b/src/Aspire.Cli/Resources/xlf/WaitCommandStrings.de.xlf
@@ -18,8 +18,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ResourceEnteredFailedState">
-        <source>Resource '{0}' entered a failed state: {1}.</source>
-        <target state="translated">Die Ressource „{0}“ ist in einen Fehlerzustand geraten: {1}.</target>
+        <source>Resource '{0}' entered a failed state: {1}</source>
+        <target state="needs-review-translation">Die Ressource „{0}“ ist in einen Fehlerzustand geraten: {1}.</target>
         <note />
       </trans-unit>
       <trans-unit id="ResourceNotFound">

--- a/src/Aspire.Cli/Resources/xlf/WaitCommandStrings.es.xlf
+++ b/src/Aspire.Cli/Resources/xlf/WaitCommandStrings.es.xlf
@@ -18,8 +18,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ResourceEnteredFailedState">
-        <source>Resource '{0}' entered a failed state: {1}.</source>
-        <target state="translated">El recurso "{0}" entró en un estado de error: {1}.</target>
+        <source>Resource '{0}' entered a failed state: {1}</source>
+        <target state="needs-review-translation">El recurso "{0}" entró en un estado de error: {1}.</target>
         <note />
       </trans-unit>
       <trans-unit id="ResourceNotFound">

--- a/src/Aspire.Cli/Resources/xlf/WaitCommandStrings.fr.xlf
+++ b/src/Aspire.Cli/Resources/xlf/WaitCommandStrings.fr.xlf
@@ -18,8 +18,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ResourceEnteredFailedState">
-        <source>Resource '{0}' entered a failed state: {1}.</source>
-        <target state="translated">La ressource « {0} » est passée en état d’échec : {1}.</target>
+        <source>Resource '{0}' entered a failed state: {1}</source>
+        <target state="needs-review-translation">La ressource « {0} » est passée en état d’échec : {1}.</target>
         <note />
       </trans-unit>
       <trans-unit id="ResourceNotFound">

--- a/src/Aspire.Cli/Resources/xlf/WaitCommandStrings.it.xlf
+++ b/src/Aspire.Cli/Resources/xlf/WaitCommandStrings.it.xlf
@@ -18,8 +18,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ResourceEnteredFailedState">
-        <source>Resource '{0}' entered a failed state: {1}.</source>
-        <target state="translated">La risorsa '{0}' è entrata in stato di errore: {1}.</target>
+        <source>Resource '{0}' entered a failed state: {1}</source>
+        <target state="needs-review-translation">La risorsa '{0}' è entrata in stato di errore: {1}.</target>
         <note />
       </trans-unit>
       <trans-unit id="ResourceNotFound">

--- a/src/Aspire.Cli/Resources/xlf/WaitCommandStrings.ja.xlf
+++ b/src/Aspire.Cli/Resources/xlf/WaitCommandStrings.ja.xlf
@@ -18,8 +18,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ResourceEnteredFailedState">
-        <source>Resource '{0}' entered a failed state: {1}.</source>
-        <target state="translated">リソース '{0}' がエラー状態になりました: {1}。</target>
+        <source>Resource '{0}' entered a failed state: {1}</source>
+        <target state="needs-review-translation">リソース '{0}' がエラー状態になりました: {1}。</target>
         <note />
       </trans-unit>
       <trans-unit id="ResourceNotFound">

--- a/src/Aspire.Cli/Resources/xlf/WaitCommandStrings.ko.xlf
+++ b/src/Aspire.Cli/Resources/xlf/WaitCommandStrings.ko.xlf
@@ -18,8 +18,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ResourceEnteredFailedState">
-        <source>Resource '{0}' entered a failed state: {1}.</source>
-        <target state="translated">리소스 '{0}'이(가) 실패 상태로 전환되었습니다. {1}.</target>
+        <source>Resource '{0}' entered a failed state: {1}</source>
+        <target state="needs-review-translation">리소스 '{0}'이(가) 실패 상태로 전환되었습니다. {1}.</target>
         <note />
       </trans-unit>
       <trans-unit id="ResourceNotFound">

--- a/src/Aspire.Cli/Resources/xlf/WaitCommandStrings.pl.xlf
+++ b/src/Aspire.Cli/Resources/xlf/WaitCommandStrings.pl.xlf
@@ -18,8 +18,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ResourceEnteredFailedState">
-        <source>Resource '{0}' entered a failed state: {1}.</source>
-        <target state="translated">Zasób „{0}” przeszedł w stan błędu: {1}.</target>
+        <source>Resource '{0}' entered a failed state: {1}</source>
+        <target state="needs-review-translation">Zasób „{0}” przeszedł w stan błędu: {1}.</target>
         <note />
       </trans-unit>
       <trans-unit id="ResourceNotFound">

--- a/src/Aspire.Cli/Resources/xlf/WaitCommandStrings.pt-BR.xlf
+++ b/src/Aspire.Cli/Resources/xlf/WaitCommandStrings.pt-BR.xlf
@@ -18,8 +18,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ResourceEnteredFailedState">
-        <source>Resource '{0}' entered a failed state: {1}.</source>
-        <target state="translated">O recurso "{0}" entrou em um estado de falha: {1}.</target>
+        <source>Resource '{0}' entered a failed state: {1}</source>
+        <target state="needs-review-translation">O recurso "{0}" entrou em um estado de falha: {1}.</target>
         <note />
       </trans-unit>
       <trans-unit id="ResourceNotFound">

--- a/src/Aspire.Cli/Resources/xlf/WaitCommandStrings.ru.xlf
+++ b/src/Aspire.Cli/Resources/xlf/WaitCommandStrings.ru.xlf
@@ -18,8 +18,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ResourceEnteredFailedState">
-        <source>Resource '{0}' entered a failed state: {1}.</source>
-        <target state="translated">Ресурс "{0}" перешёл в состояние сбоя: {1}.</target>
+        <source>Resource '{0}' entered a failed state: {1}</source>
+        <target state="needs-review-translation">Ресурс "{0}" перешёл в состояние сбоя: {1}.</target>
         <note />
       </trans-unit>
       <trans-unit id="ResourceNotFound">

--- a/src/Aspire.Cli/Resources/xlf/WaitCommandStrings.tr.xlf
+++ b/src/Aspire.Cli/Resources/xlf/WaitCommandStrings.tr.xlf
@@ -18,8 +18,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ResourceEnteredFailedState">
-        <source>Resource '{0}' entered a failed state: {1}.</source>
-        <target state="translated">'{0}' kaynağı başarısız bir duruma girdi: {1}.</target>
+        <source>Resource '{0}' entered a failed state: {1}</source>
+        <target state="needs-review-translation">'{0}' kaynağı başarısız bir duruma girdi: {1}.</target>
         <note />
       </trans-unit>
       <trans-unit id="ResourceNotFound">

--- a/src/Aspire.Cli/Resources/xlf/WaitCommandStrings.zh-Hans.xlf
+++ b/src/Aspire.Cli/Resources/xlf/WaitCommandStrings.zh-Hans.xlf
@@ -18,8 +18,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ResourceEnteredFailedState">
-        <source>Resource '{0}' entered a failed state: {1}.</source>
-        <target state="translated">资源“{0}”进入失败状态: {1}。</target>
+        <source>Resource '{0}' entered a failed state: {1}</source>
+        <target state="needs-review-translation">资源“{0}”进入失败状态: {1}。</target>
         <note />
       </trans-unit>
       <trans-unit id="ResourceNotFound">

--- a/src/Aspire.Cli/Resources/xlf/WaitCommandStrings.zh-Hant.xlf
+++ b/src/Aspire.Cli/Resources/xlf/WaitCommandStrings.zh-Hant.xlf
@@ -18,8 +18,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ResourceEnteredFailedState">
-        <source>Resource '{0}' entered a failed state: {1}.</source>
-        <target state="translated">資源 '{0}' 已進入失敗狀態: {1}。</target>
+        <source>Resource '{0}' entered a failed state: {1}</source>
+        <target state="needs-review-translation">資源 '{0}' 已進入失敗狀態: {1}。</target>
         <note />
       </trans-unit>
       <trans-unit id="ResourceNotFound">

--- a/src/Aspire.Dashboard/Resources/Columns.resx
+++ b/src/Aspire.Dashboard/Resources/Columns.resx
@@ -165,7 +165,7 @@ For more information, see https://aka.ms/aspire/container-runtime-unhealthy.</va
     <value>Resource is waiting for dependencies.</value>
   </data>
   <data name="StateColumnResourceWaitingFor" xml:space="preserve">
-    <value>Waiting for dependencies: {0}.</value>
+    <value>Waiting for dependencies: {0}</value>
     <comment>{0} is a comma-separated list of dependency resource names.</comment>
   </data>
 </root>

--- a/src/Aspire.Dashboard/Resources/xlf/Columns.cs.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Columns.cs.xlf
@@ -50,8 +50,8 @@ Další informace najdete na https://aka.ms/dotnet/aspire/container-runtime-unhe
         <note />
       </trans-unit>
       <trans-unit id="StateColumnResourceWaitingFor">
-        <source>Waiting for dependencies: {0}.</source>
-        <target state="new">Waiting for dependencies: {0}.</target>
+        <source>Waiting for dependencies: {0}</source>
+        <target state="new">Waiting for dependencies: {0}</target>
         <note>{0} is a comma-separated list of dependency resource names.</note>
       </trans-unit>
       <trans-unit id="UnknownStateLabel">

--- a/src/Aspire.Dashboard/Resources/xlf/Columns.de.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Columns.de.xlf
@@ -50,8 +50,8 @@ Weitere Informationen finden Sie unter https://aka.ms/dotnet/aspire/container-ru
         <note />
       </trans-unit>
       <trans-unit id="StateColumnResourceWaitingFor">
-        <source>Waiting for dependencies: {0}.</source>
-        <target state="new">Waiting for dependencies: {0}.</target>
+        <source>Waiting for dependencies: {0}</source>
+        <target state="new">Waiting for dependencies: {0}</target>
         <note>{0} is a comma-separated list of dependency resource names.</note>
       </trans-unit>
       <trans-unit id="UnknownStateLabel">

--- a/src/Aspire.Dashboard/Resources/xlf/Columns.es.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Columns.es.xlf
@@ -50,8 +50,8 @@ Para obtener más información, consulte https://aka.ms/dotnet/aspire/container-
         <note />
       </trans-unit>
       <trans-unit id="StateColumnResourceWaitingFor">
-        <source>Waiting for dependencies: {0}.</source>
-        <target state="new">Waiting for dependencies: {0}.</target>
+        <source>Waiting for dependencies: {0}</source>
+        <target state="new">Waiting for dependencies: {0}</target>
         <note>{0} is a comma-separated list of dependency resource names.</note>
       </trans-unit>
       <trans-unit id="UnknownStateLabel">

--- a/src/Aspire.Dashboard/Resources/xlf/Columns.fr.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Columns.fr.xlf
@@ -50,8 +50,8 @@ Pour plus d’informations, consultez https://aka.ms/dotnet/aspire/container-run
         <note />
       </trans-unit>
       <trans-unit id="StateColumnResourceWaitingFor">
-        <source>Waiting for dependencies: {0}.</source>
-        <target state="new">Waiting for dependencies: {0}.</target>
+        <source>Waiting for dependencies: {0}</source>
+        <target state="new">Waiting for dependencies: {0}</target>
         <note>{0} is a comma-separated list of dependency resource names.</note>
       </trans-unit>
       <trans-unit id="UnknownStateLabel">

--- a/src/Aspire.Dashboard/Resources/xlf/Columns.it.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Columns.it.xlf
@@ -50,8 +50,8 @@ Per altre informazioni, vedere https://aka.ms/dotnet/aspire/container-runtime-un
         <note />
       </trans-unit>
       <trans-unit id="StateColumnResourceWaitingFor">
-        <source>Waiting for dependencies: {0}.</source>
-        <target state="new">Waiting for dependencies: {0}.</target>
+        <source>Waiting for dependencies: {0}</source>
+        <target state="new">Waiting for dependencies: {0}</target>
         <note>{0} is a comma-separated list of dependency resource names.</note>
       </trans-unit>
       <trans-unit id="UnknownStateLabel">

--- a/src/Aspire.Dashboard/Resources/xlf/Columns.ja.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Columns.ja.xlf
@@ -50,8 +50,8 @@ For more information, see https://aka.ms/aspire/container-runtime-unhealthy.</so
         <note />
       </trans-unit>
       <trans-unit id="StateColumnResourceWaitingFor">
-        <source>Waiting for dependencies: {0}.</source>
-        <target state="new">Waiting for dependencies: {0}.</target>
+        <source>Waiting for dependencies: {0}</source>
+        <target state="new">Waiting for dependencies: {0}</target>
         <note>{0} is a comma-separated list of dependency resource names.</note>
       </trans-unit>
       <trans-unit id="UnknownStateLabel">

--- a/src/Aspire.Dashboard/Resources/xlf/Columns.ko.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Columns.ko.xlf
@@ -50,8 +50,8 @@ For more information, see https://aka.ms/aspire/container-runtime-unhealthy.</so
         <note />
       </trans-unit>
       <trans-unit id="StateColumnResourceWaitingFor">
-        <source>Waiting for dependencies: {0}.</source>
-        <target state="new">Waiting for dependencies: {0}.</target>
+        <source>Waiting for dependencies: {0}</source>
+        <target state="new">Waiting for dependencies: {0}</target>
         <note>{0} is a comma-separated list of dependency resource names.</note>
       </trans-unit>
       <trans-unit id="UnknownStateLabel">

--- a/src/Aspire.Dashboard/Resources/xlf/Columns.pl.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Columns.pl.xlf
@@ -50,8 +50,8 @@ Aby uzyskać więcej informacji, zobacz https://aka.ms/dotnet/aspire/container-r
         <note />
       </trans-unit>
       <trans-unit id="StateColumnResourceWaitingFor">
-        <source>Waiting for dependencies: {0}.</source>
-        <target state="new">Waiting for dependencies: {0}.</target>
+        <source>Waiting for dependencies: {0}</source>
+        <target state="new">Waiting for dependencies: {0}</target>
         <note>{0} is a comma-separated list of dependency resource names.</note>
       </trans-unit>
       <trans-unit id="UnknownStateLabel">

--- a/src/Aspire.Dashboard/Resources/xlf/Columns.pt-BR.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Columns.pt-BR.xlf
@@ -50,8 +50,8 @@ Para obter mais informações, consulte https://aka.ms/dotnet/aspire/container-
         <note />
       </trans-unit>
       <trans-unit id="StateColumnResourceWaitingFor">
-        <source>Waiting for dependencies: {0}.</source>
-        <target state="new">Waiting for dependencies: {0}.</target>
+        <source>Waiting for dependencies: {0}</source>
+        <target state="new">Waiting for dependencies: {0}</target>
         <note>{0} is a comma-separated list of dependency resource names.</note>
       </trans-unit>
       <trans-unit id="UnknownStateLabel">

--- a/src/Aspire.Dashboard/Resources/xlf/Columns.ru.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Columns.ru.xlf
@@ -50,8 +50,8 @@ For more information, see https://aka.ms/aspire/container-runtime-unhealthy.</so
         <note />
       </trans-unit>
       <trans-unit id="StateColumnResourceWaitingFor">
-        <source>Waiting for dependencies: {0}.</source>
-        <target state="new">Waiting for dependencies: {0}.</target>
+        <source>Waiting for dependencies: {0}</source>
+        <target state="new">Waiting for dependencies: {0}</target>
         <note>{0} is a comma-separated list of dependency resource names.</note>
       </trans-unit>
       <trans-unit id="UnknownStateLabel">

--- a/src/Aspire.Dashboard/Resources/xlf/Columns.tr.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Columns.tr.xlf
@@ -50,8 +50,8 @@ Daha fazla bilgi için bkz. https://aka.ms/dotnet/aspire/container-runtime-unhea
         <note />
       </trans-unit>
       <trans-unit id="StateColumnResourceWaitingFor">
-        <source>Waiting for dependencies: {0}.</source>
-        <target state="new">Waiting for dependencies: {0}.</target>
+        <source>Waiting for dependencies: {0}</source>
+        <target state="new">Waiting for dependencies: {0}</target>
         <note>{0} is a comma-separated list of dependency resource names.</note>
       </trans-unit>
       <trans-unit id="UnknownStateLabel">

--- a/src/Aspire.Dashboard/Resources/xlf/Columns.zh-Hans.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Columns.zh-Hans.xlf
@@ -50,8 +50,8 @@ For more information, see https://aka.ms/aspire/container-runtime-unhealthy.</so
         <note />
       </trans-unit>
       <trans-unit id="StateColumnResourceWaitingFor">
-        <source>Waiting for dependencies: {0}.</source>
-        <target state="new">Waiting for dependencies: {0}.</target>
+        <source>Waiting for dependencies: {0}</source>
+        <target state="new">Waiting for dependencies: {0}</target>
         <note>{0} is a comma-separated list of dependency resource names.</note>
       </trans-unit>
       <trans-unit id="UnknownStateLabel">

--- a/src/Aspire.Dashboard/Resources/xlf/Columns.zh-Hant.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Columns.zh-Hant.xlf
@@ -50,8 +50,8 @@ For more information, see https://aka.ms/aspire/container-runtime-unhealthy.</so
         <note />
       </trans-unit>
       <trans-unit id="StateColumnResourceWaitingFor">
-        <source>Waiting for dependencies: {0}.</source>
-        <target state="new">Waiting for dependencies: {0}.</target>
+        <source>Waiting for dependencies: {0}</source>
+        <target state="new">Waiting for dependencies: {0}</target>
         <note>{0} is a comma-separated list of dependency resource names.</note>
       </trans-unit>
       <trans-unit id="UnknownStateLabel">


### PR DESCRIPTION
- Dashboard: 'Waiting for dependencies: {0}.' -> without period
- CLI InteractionServiceStrings: 'crashed before it was available: {0}.' -> without period
- CLI InteractionServiceStrings: 'connection to the AppHost was lost: {0}.' -> without period
- CLI WaitCommandStrings: 'entered a failed state: {1}.' -> without period

These four strings all follow the pattern ": {interpolated_value}." where the interpolated value is an error message or state description

Related to #17244 (item 3)
Related to #17277