### PR TITLE
Move error handling from Program.cs to BaseCommand SetAction delegate

### DIFF
--- a/src/Aspire.Cli/Commands/BaseCommand.cs
+++ b/src/Aspire.Cli/Commands/BaseCommand.cs
@@ -15,6 +15,8 @@ namespace Aspire.Cli.Commands;
 
 internal abstract class BaseCommand : Command
 {
+    private static readonly int[] s_suppressErrorLogsMessageExitCodes = [CliExitCodes.Cancelled, CliExitCodes.MissingRequiredArgument];
+
     protected virtual bool UpdateNotificationsEnabled { get; } = true;
 
     /// <summary>
@@ -60,6 +62,16 @@ internal abstract class BaseCommand : Command
                 // Error messages have already been displayed by the interaction service.
                 result = CommandResult.Failure(CliExitCodes.MissingRequiredArgument);
             }
+            catch (OperationCanceledException ex) when (cancellationToken.IsCancellationRequested || ex is ExtensionOperationCanceledException)
+            {
+                result = CommandResult.Cancelled();
+            }
+            catch (Exception ex)
+            {
+                var errorMessage = string.Format(CultureInfo.CurrentCulture, InteractionServiceStrings.UnexpectedErrorOccurred, ex.Message);
+                telemetry.RecordError(errorMessage, ex);
+                result = CommandResult.Failure(CliExitCodes.InvalidCommand, errorMessage);
+            }
 
             var isErrorExitCode = result.ExitCode != CliExitCodes.Success;
 
@@ -82,7 +94,7 @@ internal abstract class BaseCommand : Command
             // Display the CLI log file path on non-zero exit codes so the user knows
             // where to find diagnostic details. Suppress for user-input errors where
             // the log wouldn't contain useful context (e.g., missing required arguments).
-            if (isErrorExitCode && result.ExitCode != CliExitCodes.MissingRequiredArgument)
+            if (isErrorExitCode && !s_suppressErrorLogsMessageExitCodes.Contains(result.ExitCode))
             {
                 interactionService.DisplayMessage(
                     KnownEmojis.PageFacingUp,

--- a/src/Aspire.Cli/Program.cs
+++ b/src/Aspire.Cli/Program.cs
@@ -865,6 +865,15 @@ public class Program
                 // Log exit code for debugging
                 logger.LogInformation("Exit code: {ExitCode}", exitCode);
             }
+            catch (Exception ex)
+            {
+                // Should never get here because RootCommand's handler should catch all exceptions, but log just in case.
+                exitCode = CliExitCodes.InvalidCommand;
+
+                logger.LogError(ex, "An unexpected error occurred.");
+                telemetry.RecordError("An unexpected error occurred.", ex);
+                errorWriter.WriteLine(string.Format(CultureInfo.CurrentCulture, InteractionServiceStrings.UnexpectedErrorOccurred, ex.Message));
+            }
             finally
             {
                 mainActivity?.SetTag(TelemetryConstants.Tags.ProcessExitCode, exitCode);

--- a/src/Aspire.Cli/Program.cs
+++ b/src/Aspire.Cli/Program.cs
@@ -865,18 +865,6 @@ public class Program
                 // Log exit code for debugging
                 logger.LogInformation("Exit code: {ExitCode}", exitCode);
             }
-            catch (OperationCanceledException ex) when (cancellationManager.IsCancellationRequested || ex is ExtensionOperationCanceledException)
-            {
-                exitCode = CliExitCodes.Cancelled;
-            }
-            catch (Exception ex)
-            {
-                exitCode = CliExitCodes.InvalidCommand;
-
-                logger.LogError(ex, "An unexpected error occurred.");
-                telemetry.RecordError("An unexpected error occurred.", ex);
-                errorWriter.WriteLine(string.Format(CultureInfo.CurrentCulture, InteractionServiceStrings.UnexpectedErrorOccurred, ex.Message));
-            }
             finally
             {
                 mainActivity?.SetTag(TelemetryConstants.Tags.ProcessExitCode, exitCode);

--- a/tests/Aspire.Cli.Tests/Commands/BaseCommandTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/BaseCommandTests.cs
@@ -270,4 +270,39 @@ public class BaseCommandTests(ITestOutputHelper outputHelper)
         Assert.DoesNotContain(testInteractionService.DisplayedMessages,
             m => m.ConsoleOverride == ConsoleOutput.Error);
     }
+
+    [Fact]
+    public async Task BaseCommand_OnUnexpectedException_ReturnsInvalidCommandExitCode_AndDisplaysError()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        var testInteractionService = new TestInteractionService();
+        var backchannelMonitor = new TestAuxiliaryBackchannelMonitor
+        {
+            ScanAsyncCallback = _ => throw new InvalidOperationException("Something went wrong")
+        };
+
+        var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper, options =>
+        {
+            options.InteractionServiceFactory = _ => testInteractionService;
+            options.AuxiliaryBackchannelMonitorFactory = _ => backchannelMonitor;
+        });
+        using var provider = services.BuildServiceProvider();
+
+        var command = provider.GetRequiredService<RootCommand>();
+        var result = command.Parse("ps");
+
+        var exitCode = await result.InvokeAsync().DefaultTimeout();
+
+        Assert.Equal(CliExitCodes.InvalidCommand, exitCode);
+
+        // Verify error message was displayed
+        var expectedErrorMessage = string.Format(CultureInfo.CurrentCulture, InteractionServiceStrings.UnexpectedErrorOccurred, "Something went wrong");
+        Assert.Contains(expectedErrorMessage, testInteractionService.DisplayedErrors);
+
+        // Verify log file path was displayed on stderr
+        var executionContext = provider.GetRequiredService<CliExecutionContext>();
+        var expectedLogMessage = string.Format(CultureInfo.CurrentCulture, InteractionServiceStrings.SeeLogsAt, executionContext.LogFilePath);
+        var logMessage = Assert.Single(testInteractionService.DisplayedMessages, m => m.Message == expectedLogMessage);
+        Assert.Equal(ConsoleOutput.Error, logMessage.ConsoleOverride);
+    }
 }


### PR DESCRIPTION
## Description

Move the `OperationCanceledException` and generic `Exception` catch blocks from `Program.Main` into the `BaseCommand` try/catch around `ExecuteAsync`. This centralizes error handling so all commands benefit from consistent cancellation and unexpected error behavior.

## Changes

- **BaseCommand.cs**: Added catch blocks for `OperationCanceledException` (when cancelled or `ExtensionOperationCanceledException`) and generic `Exception` to the existing try/catch around `ExecuteAsync`. Also added `CliExitCodes.Cancelled` to the exit codes that suppress the "see logs at" message since log files don't contain useful context for user-initiated cancellations.
- **Program.cs**: Removed the now-redundant catch blocks from the outer try/catch in `Main`.

## Testing

Ran the full CLI test suite — 3345 passed, 3 failed (all pre-existing unrelated failures in `RemoteExecutor` tests), 12 skipped.