### PR TITLE
Surface silent integration-assembly load failures (#16729)

### DIFF
--- a/src/Aspire.Cli/Projects/PrebuiltAppHostServer.cs
+++ b/src/Aspire.Cli/Projects/PrebuiltAppHostServer.cs
@@ -856,7 +856,13 @@ internal sealed class PrebuiltAppHostServer : IAppHostServerProject
         {
             if (e.Data is not null)
             {
-                _logger.LogTrace("PrebuiltAppHostServer({ProcessId}) stdout: {Line}", process.Id, e.Data);
+                // Promoted from LogTrace to LogDebug so that apphost-server stdout reaches the
+                // CLI's on-disk log under the default file-logger filter (Debug). Previously
+                // these lines were dropped entirely, which made apphost-side warnings
+                // (for example, "LoaderExceptions" from the type-discovery path) invisible to
+                // anyone diagnosing a "no code generator found" / "no language support found"
+                // error. See https://github.com/microsoft/aspire/issues/16729.
+                _logger.LogDebug("PrebuiltAppHostServer({ProcessId}) stdout: {Line}", process.Id, e.Data);
                 outputCollector.AppendOutput(e.Data);
             }
         };
@@ -864,7 +870,11 @@ internal sealed class PrebuiltAppHostServer : IAppHostServerProject
         {
             if (e.Data is not null)
             {
-                _logger.LogTrace("PrebuiltAppHostServer({ProcessId}) stderr: {Line}", process.Id, e.Data);
+                // Promoted from LogTrace to LogInformation so that apphost-server stderr is
+                // visible at the default console log level (Information). Stderr is reserved
+                // for genuine problems in well-behaved server processes, so surfacing it
+                // by default is appropriate. See https://github.com/microsoft/aspire/issues/16729.
+                _logger.LogInformation("PrebuiltAppHostServer({ProcessId}) stderr: {Line}", process.Id, e.Data);
                 outputCollector.AppendError(e.Data);
             }
         };

--- a/src/Aspire.Hosting.RemoteHost/AssemblyLoader.cs
+++ b/src/Aspire.Hosting.RemoteHost/AssemblyLoader.cs
@@ -43,6 +43,8 @@ internal sealed class AssemblyLoader
             string.IsNullOrWhiteSpace(libsPath) ? "<none>" : libsPath,
             string.IsNullOrWhiteSpace(probeManifestPath) ? "<none>" : probeManifestPath);
 
+        WarnIfSharedAssemblyMismatch(libsPath, logger);
+
         _assemblies = new Lazy<IReadOnlyList<Assembly>>(
             () => LoadAssemblies(_assemblyNamesToLoad.Value, _loadContext, logger));
     }
@@ -167,6 +169,80 @@ internal sealed class AssemblyLoader
         }
 
         return assemblies;
+    }
+
+    /// <summary>
+    /// Warns when a shared assembly (one that <see cref="IntegrationLoadContext"/> intentionally
+    /// resolves through the default <see cref="AssemblyLoadContext"/>) exists in the integration
+    /// libs directory at a different identity than what the default context provides.
+    /// </summary>
+    /// <remarks>
+    /// This is a defense against a real failure mode: when the bundled <c>Aspire.TypeSystem</c>
+    /// (compiled into the apphost server's single-file executable) and the libs copy
+    /// (restored alongside <c>Aspire.Hosting.*.dll</c>) report different assembly versions or MVIDs,
+    /// integration assemblies that reference the libs copy will fail to bind their type
+    /// references through the default context. The resulting <see cref="ReflectionTypeLoadException"/>
+    /// would otherwise be swallowed silently and surface only as a downstream "no code generator
+    /// found" / "no language support found" error with no actionable diagnostic.
+    /// </remarks>
+    private static void WarnIfSharedAssemblyMismatch(string? integrationLibsPath, ILogger logger)
+    {
+        if (string.IsNullOrWhiteSpace(integrationLibsPath) || !Directory.Exists(integrationLibsPath))
+        {
+            return;
+        }
+
+        foreach (var sharedName in IntegrationLoadContext.GetSharedAssemblyNames())
+        {
+            var libsPath = Path.Combine(integrationLibsPath, sharedName + ".dll");
+            if (!File.Exists(libsPath))
+            {
+                continue;
+            }
+
+            AssemblyName? probedName;
+            try
+            {
+                probedName = AssemblyName.GetAssemblyName(libsPath);
+            }
+            catch (Exception ex)
+            {
+                logger.LogDebug(ex, "Could not read assembly identity from {Path}", libsPath);
+                continue;
+            }
+
+            var defaultAsm = AssemblyLoadContext.Default.Assemblies.FirstOrDefault(
+                assembly => string.Equals(assembly.GetName().Name, sharedName, StringComparison.OrdinalIgnoreCase));
+            if (defaultAsm is null)
+            {
+                logger.LogDebug("Default context does not currently provide '{AssemblyName}'", sharedName);
+                continue;
+            }
+
+            var defaultName = defaultAsm.GetName();
+            var defaultMvid = defaultAsm.ManifestModule.ModuleVersionId;
+
+            if (defaultName.Version != probedName.Version)
+            {
+                logger.LogWarning(
+                    "Shared assembly '{AssemblyName}' version mismatch: bundled={BundledVersion}, libs={LibsVersion} ({LibsPath}). " +
+                    "Integration assemblies referencing this assembly from the libs directory will fail to bind their type " +
+                    "references through the default load context, which causes integrations to be silently skipped during type discovery. " +
+                    "This typically indicates the apphost server bundle and the restored integration packages were produced by " +
+                    "different build configurations.",
+                    sharedName,
+                    defaultName.Version,
+                    probedName.Version,
+                    libsPath);
+                continue;
+            }
+
+            // Same version, but different MVID (compiled from different sources) is also a binary-incompatibility risk.
+            // We can't read the probed MVID without loading the assembly, which we deliberately don't do here.
+            // Logging the bundled MVID at Debug helps correlate with any subsequent ReflectionTypeLoadException.
+            logger.LogDebug("Shared assembly '{AssemblyName}' identity matches: Version={Version}, BundledMvid={Mvid}",
+                sharedName, defaultName.Version, defaultMvid);
+        }
     }
 
     private static Assembly LoadAssembly(IntegrationLoadContext loadContext, string name)

--- a/src/Aspire.Hosting.RemoteHost/CodeGeneration/CodeGenerationService.cs
+++ b/src/Aspire.Hosting.RemoteHost/CodeGeneration/CodeGenerationService.cs
@@ -232,7 +232,7 @@ internal sealed class CodeGenerationService
             var generator = _resolver.GetCodeGenerator(language);
             if (generator == null)
             {
-                throw new ArgumentException($"No code generator found for language: {language}");
+                throw new ArgumentException(BuildNoCodeGeneratorMessage(language));
             }
 
             var context = _atsContextFactory.GetContext();
@@ -253,6 +253,26 @@ internal sealed class CodeGenerationService
             _logger.LogError(ex, "<< generateCode({Language}) failed", language);
             throw;
         }
+    }
+
+    private string BuildNoCodeGeneratorMessage(string language)
+    {
+        var available = _resolver.GetSupportedLanguages()
+            .OrderBy(s => s, StringComparer.OrdinalIgnoreCase)
+            .ToArray();
+
+        if (available.Length == 0)
+        {
+            // No generators discovered at all is almost always a binary-mismatch / type-load
+            // failure (see CodeGeneratorResolver warnings). Point the user at the apphost
+            // server log so they can see the underlying LoaderExceptions.
+            return $"No code generator found for language: {language}. " +
+                   "No code generators were discovered in any loaded assembly. " +
+                   "This usually indicates a binary mismatch between the bundled apphost server and the integration assemblies on disk; " +
+                   "check the apphost server log for 'LoaderExceptions' Warnings.";
+        }
+
+        return $"No code generator found for language: {language}. Available languages: {string.Join(", ", available)}.";
     }
 }
 

--- a/src/Aspire.Hosting.RemoteHost/CodeGeneration/CodeGeneratorResolver.cs
+++ b/src/Aspire.Hosting.RemoteHost/CodeGeneration/CodeGeneratorResolver.cs
@@ -20,10 +20,20 @@ internal sealed class CodeGeneratorResolver
         IServiceProvider serviceProvider,
         AssemblyLoader assemblyLoader,
         ILogger<CodeGeneratorResolver> logger)
+        : this(serviceProvider, assemblyLoader.GetAssemblies, logger)
+    {
+    }
+
+    // Test-only seam: lets unit tests inject a synthetic assembly set without going
+    // through the AssemblyLoader (which is sealed and probes the file system).
+    internal CodeGeneratorResolver(
+        IServiceProvider serviceProvider,
+        Func<IReadOnlyList<Assembly>> assembliesProvider,
+        ILogger<CodeGeneratorResolver> logger)
     {
         _logger = logger;
         _generators = new Lazy<Dictionary<string, ICodeGenerator>>(
-            () => DiscoverGenerators(serviceProvider, assemblyLoader.GetAssemblies()));
+            () => DiscoverGenerators(serviceProvider, assembliesProvider()));
     }
 
     /// <summary>
@@ -37,6 +47,15 @@ internal sealed class CodeGeneratorResolver
         return generator;
     }
 
+    /// <summary>
+    /// Gets the languages of all discovered code generators.
+    /// </summary>
+    /// <returns>The set of supported language identifiers.</returns>
+    public IReadOnlyCollection<string> GetSupportedLanguages()
+    {
+        return _generators.Value.Keys.ToArray();
+    }
+
     private Dictionary<string, ICodeGenerator> DiscoverGenerators(
         IServiceProvider serviceProvider,
         IReadOnlyList<Assembly> assemblies)
@@ -46,17 +65,36 @@ internal sealed class CodeGeneratorResolver
         foreach (var assembly in assemblies)
         {
             Type[] types;
+            var assemblyName = assembly.GetName().Name;
+            var hadTypeLoadFailure = false;
             try
             {
                 types = assembly.GetTypes();
             }
             catch (ReflectionTypeLoadException ex)
             {
-                _logger.LogDebug(ex, "Some types in assembly '{AssemblyName}' could not be loaded", assembly.GetName().Name);
+                hadTypeLoadFailure = true;
+                // Surface loader binding failures at Warning level. These typically indicate
+                // a binary mismatch between the bundled runtime assemblies and the integration
+                // assemblies loaded from disk (for example, when Aspire.TypeSystem versions
+                // diverge). Including the LoaderExceptions in the log is essential for
+                // diagnosing these failures, which previously disappeared into Debug-level
+                // output that the apphost server never wrote to disk.
+                var loaderMessages = ex.LoaderExceptions is { Length: > 0 } loaders
+                    ? string.Join("; ", loaders.Where(e => e is not null).Select(e => e!.Message).Distinct())
+                    : "(no LoaderExceptions captured)";
+                _logger.LogWarning(
+                    ex,
+                    "Some types in assembly '{AssemblyName}' could not be loaded; {LoadedCount} of {TotalCount} types are available. LoaderExceptions: {LoaderExceptions}",
+                    assemblyName,
+                    ex.Types.Count(t => t is not null),
+                    ex.Types.Length,
+                    loaderMessages);
                 // Use the types that were successfully loaded
                 types = ex.Types.Where(t => t is not null).ToArray()!;
             }
 
+            var discoveredInAssembly = 0;
             foreach (var type in types)
             {
                 if (!type.IsAbstract &&
@@ -67,6 +105,7 @@ internal sealed class CodeGeneratorResolver
                     {
                         var generator = (ICodeGenerator)ActivatorUtilities.CreateInstance(serviceProvider, type);
                         generators[generator.Language] = generator;
+                        discoveredInAssembly++;
                         _logger.LogDebug("Discovered code generator: {TypeName} for language '{Language}'", type.Name, generator.Language);
                     }
                     catch (Exception ex)
@@ -75,8 +114,26 @@ internal sealed class CodeGeneratorResolver
                     }
                 }
             }
+
+            // If an assembly named like a code-generation contributor produced zero generators,
+            // that is almost certainly a silent type-load failure rather than an intentional
+            // design. Log a Warning so the user can see it.
+            if (discoveredInAssembly == 0 && LooksLikeCodeGeneratorAssembly(assemblyName))
+            {
+                _logger.LogWarning(
+                    "Assembly '{AssemblyName}' was loaded but did not contribute any {Interface} implementations. {Hint}",
+                    assemblyName,
+                    nameof(ICodeGenerator),
+                    hadTypeLoadFailure
+                        ? "This is likely caused by a binary mismatch between the bundled and probed assemblies (see preceding LoaderExceptions)."
+                        : "Verify the assembly contains a non-abstract type that implements " + typeof(ICodeGenerator).FullName + ".");
+            }
         }
 
         return generators;
     }
+
+    private static bool LooksLikeCodeGeneratorAssembly(string? assemblyName)
+        => assemblyName is not null
+           && assemblyName.StartsWith("Aspire.Hosting.CodeGeneration.", StringComparison.OrdinalIgnoreCase);
 }

--- a/src/Aspire.Hosting.RemoteHost/IntegrationLoadContext.cs
+++ b/src/Aspire.Hosting.RemoteHost/IntegrationLoadContext.cs
@@ -16,6 +16,12 @@ internal sealed class IntegrationLoadContext : AssemblyLoadContext
 {
     private const string SharedAssemblyName = "Aspire.TypeSystem";
 
+    /// <summary>
+    /// Gets the assembly names that this load context shares with the default
+    /// <see cref="AssemblyLoadContext"/> (resolution always defers to the default ALC).
+    /// </summary>
+    internal static IReadOnlyList<string> GetSharedAssemblyNames() => [SharedAssemblyName];
+
     private readonly string[] _probeDirectories;
     private readonly IntegrationPackageProbeManifest _packageProbeManifest;
     private readonly ILogger _logger;

--- a/src/Aspire.Hosting.RemoteHost/Language/LanguageService.cs
+++ b/src/Aspire.Hosting.RemoteHost/Language/LanguageService.cs
@@ -55,7 +55,7 @@ internal sealed class LanguageService
             var languageSupport = _resolver.GetLanguageSupport(language);
             if (languageSupport == null)
             {
-                throw new ArgumentException($"No language support found for: {language}");
+                throw new ArgumentException(BuildNoLanguageSupportMessage(language));
             }
 
             var request = new ScaffoldRequest
@@ -135,7 +135,7 @@ internal sealed class LanguageService
             var languageSupport = _resolver.GetLanguageSupport(language);
             if (languageSupport == null)
             {
-                throw new ArgumentException($"No language support found for: {language}");
+                throw new ArgumentException(BuildNoLanguageSupportMessage(language));
             }
 
             var spec = languageSupport.GetRuntimeSpec();
@@ -149,5 +149,26 @@ internal sealed class LanguageService
             _logger.LogError(ex, "<< getRuntimeSpec({Language}) failed", language);
             throw;
         }
+    }
+
+    private string BuildNoLanguageSupportMessage(string language)
+    {
+        var available = _resolver.GetAllLanguages()
+            .Select(l => l.Language)
+            .OrderBy(s => s, StringComparer.OrdinalIgnoreCase)
+            .ToArray();
+
+        if (available.Length == 0)
+        {
+            // No language support discovered at all is almost always a binary-mismatch /
+            // type-load failure (see LanguageSupportResolver warnings). Point the user at
+            // the apphost server log so they can see the underlying LoaderExceptions.
+            return $"No language support found for: {language}. " +
+                   "No language support implementations were discovered in any loaded assembly. " +
+                   "This usually indicates a binary mismatch between the bundled apphost server and the integration assemblies on disk; " +
+                   "check the apphost server log for 'LoaderExceptions' Warnings.";
+        }
+
+        return $"No language support found for: {language}. Available languages: {string.Join(", ", available)}.";
     }
 }

--- a/src/Aspire.Hosting.RemoteHost/Language/LanguageSupportResolver.cs
+++ b/src/Aspire.Hosting.RemoteHost/Language/LanguageSupportResolver.cs
@@ -20,10 +20,20 @@ internal sealed class LanguageSupportResolver
         IServiceProvider serviceProvider,
         AssemblyLoader assemblyLoader,
         ILogger<LanguageSupportResolver> logger)
+        : this(serviceProvider, assemblyLoader.GetAssemblies, logger)
+    {
+    }
+
+    // Test-only seam: lets unit tests inject a synthetic assembly set without going
+    // through the AssemblyLoader (which is sealed and probes the file system).
+    internal LanguageSupportResolver(
+        IServiceProvider serviceProvider,
+        Func<IReadOnlyList<Assembly>> assembliesProvider,
+        ILogger<LanguageSupportResolver> logger)
     {
         _logger = logger;
         _languages = new Lazy<Dictionary<string, ILanguageSupport>>(
-            () => DiscoverLanguages(serviceProvider, assemblyLoader.GetAssemblies()));
+            () => DiscoverLanguages(serviceProvider, assembliesProvider()));
     }
 
     /// <summary>
@@ -55,17 +65,36 @@ internal sealed class LanguageSupportResolver
         foreach (var assembly in assemblies)
         {
             Type[] types;
+            var assemblyName = assembly.GetName().Name;
+            var hadTypeLoadFailure = false;
             try
             {
                 types = assembly.GetTypes();
             }
             catch (ReflectionTypeLoadException ex)
             {
-                _logger.LogDebug(ex, "Some types in assembly '{AssemblyName}' could not be loaded", assembly.GetName().Name);
+                hadTypeLoadFailure = true;
+                // Surface loader binding failures at Warning level. These typically indicate
+                // a binary mismatch between the bundled runtime assemblies and the integration
+                // assemblies loaded from disk (for example, when Aspire.TypeSystem versions
+                // diverge). Including the LoaderExceptions in the log is essential for
+                // diagnosing these failures, which previously disappeared into Debug-level
+                // output that the apphost server never wrote to disk.
+                var loaderMessages = ex.LoaderExceptions is { Length: > 0 } loaders
+                    ? string.Join("; ", loaders.Where(e => e is not null).Select(e => e!.Message).Distinct())
+                    : "(no LoaderExceptions captured)";
+                _logger.LogWarning(
+                    ex,
+                    "Some types in assembly '{AssemblyName}' could not be loaded; {LoadedCount} of {TotalCount} types are available. LoaderExceptions: {LoaderExceptions}",
+                    assemblyName,
+                    ex.Types.Count(t => t is not null),
+                    ex.Types.Length,
+                    loaderMessages);
                 // Use the types that were successfully loaded
                 types = ex.Types.Where(t => t is not null).ToArray()!;
             }
 
+            var discoveredInAssembly = 0;
             foreach (var type in types)
             {
                 if (!type.IsAbstract &&
@@ -76,6 +105,7 @@ internal sealed class LanguageSupportResolver
                     {
                         var language = (ILanguageSupport)ActivatorUtilities.CreateInstance(serviceProvider, type);
                         languages[language.Language] = language;
+                        discoveredInAssembly++;
                         _logger.LogDebug("Discovered language support: {TypeName} for language '{Language}'", type.Name, language.Language);
                     }
                     catch (Exception ex)
@@ -84,8 +114,26 @@ internal sealed class LanguageSupportResolver
                     }
                 }
             }
+
+            // If an assembly named like a code-generation / language-support contributor
+            // produced zero implementations, that is almost certainly a silent type-load
+            // failure rather than an intentional design. Log a Warning so the user can see it.
+            if (discoveredInAssembly == 0 && LooksLikeLanguageSupportAssembly(assemblyName))
+            {
+                _logger.LogWarning(
+                    "Assembly '{AssemblyName}' was loaded but did not contribute any {Interface} implementations. {Hint}",
+                    assemblyName,
+                    nameof(ILanguageSupport),
+                    hadTypeLoadFailure
+                        ? "This is likely caused by a binary mismatch between the bundled and probed assemblies (see preceding LoaderExceptions)."
+                        : "Verify the assembly contains a non-abstract type that implements " + typeof(ILanguageSupport).FullName + ".");
+            }
         }
 
         return languages;
     }
+
+    private static bool LooksLikeLanguageSupportAssembly(string? assemblyName)
+        => assemblyName is not null
+           && assemblyName.StartsWith("Aspire.Hosting.CodeGeneration.", StringComparison.OrdinalIgnoreCase);
 }

--- a/tests/Aspire.Hosting.RemoteHost.Tests/RecordingLogger.cs
+++ b/tests/Aspire.Hosting.RemoteHost.Tests/RecordingLogger.cs
@@ -1,0 +1,33 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Collections.Concurrent;
+using Microsoft.Extensions.Logging;
+
+namespace Aspire.Hosting.RemoteHost.Tests;
+
+/// <summary>
+/// Minimal in-memory logger used by tests that need to inspect emitted log entries.
+/// Thread-safe; entries are appended in the order Log is called.
+/// </summary>
+internal sealed class RecordingLogger<T> : ILogger<T>
+{
+    public ConcurrentQueue<LogEntry> Entries { get; } = new();
+
+    public IDisposable BeginScope<TState>(TState state) where TState : notnull => NullScope.Instance;
+
+    public bool IsEnabled(LogLevel logLevel) => true;
+
+    public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception? exception, Func<TState, Exception?, string> formatter)
+    {
+        Entries.Enqueue(new LogEntry(logLevel, eventId, formatter(state, exception), exception));
+    }
+
+    internal sealed record LogEntry(LogLevel Level, EventId EventId, string Message, Exception? Exception);
+
+    private sealed class NullScope : IDisposable
+    {
+        public static readonly NullScope Instance = new();
+        public void Dispose() { }
+    }
+}

--- a/tests/Aspire.Hosting.RemoteHost.Tests/ResolverDiagnosticsTests.cs
+++ b/tests/Aspire.Hosting.RemoteHost.Tests/ResolverDiagnosticsTests.cs
@@ -1,0 +1,111 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Reflection;
+using Aspire.Hosting.RemoteHost.CodeGeneration;
+using Aspire.Hosting.RemoteHost.Language;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Xunit;
+
+namespace Aspire.Hosting.RemoteHost.Tests;
+
+/// <summary>
+/// Coverage for the diagnostics surfaced by the discovery resolvers when type loading fails or
+/// when a "code generation" assembly is loaded but contributes no implementations. These tests
+/// guard the user-facing fix for https://github.com/microsoft/aspire/issues/16729 — a previously
+/// silent ReflectionTypeLoadException that produced a downstream "no code generator found" /
+/// "no language support found" error with no actionable diagnostic.
+/// </summary>
+public class ResolverDiagnosticsTests
+{
+    [Fact]
+    public void CodeGeneratorResolver_LogsWarning_WhenAssemblyTypeLoadFails()
+    {
+        var logger = new RecordingLogger<CodeGeneratorResolver>();
+        var stub = new TypeLoadFailingAssembly("Aspire.Hosting.CodeGeneration.Synthetic");
+
+        using var services = new ServiceCollection().BuildServiceProvider();
+        var resolver = new CodeGeneratorResolver(services, () => (IReadOnlyList<Assembly>)[stub], logger);
+
+        Assert.Null(resolver.GetCodeGenerator("anything"));
+
+        var warning = logger.Entries.SingleOrDefault(e => e.Level == LogLevel.Warning && e.Message.Contains("could not be loaded"));
+        Assert.NotNull(warning);
+        Assert.Contains("LoaderExceptions", warning!.Message);
+        Assert.Contains(stub.GetName().Name!, warning.Message);
+        Assert.Contains("synthetic loader exception", warning.Message);
+    }
+
+    [Fact]
+    public void LanguageSupportResolver_LogsWarning_WhenAssemblyTypeLoadFails()
+    {
+        var logger = new RecordingLogger<LanguageSupportResolver>();
+        var stub = new TypeLoadFailingAssembly("Aspire.Hosting.CodeGeneration.Synthetic");
+
+        using var services = new ServiceCollection().BuildServiceProvider();
+        var resolver = new LanguageSupportResolver(services, () => (IReadOnlyList<Assembly>)[stub], logger);
+
+        Assert.Null(resolver.GetLanguageSupport("anything"));
+
+        var warning = logger.Entries.SingleOrDefault(e => e.Level == LogLevel.Warning && e.Message.Contains("could not be loaded"));
+        Assert.NotNull(warning);
+        Assert.Contains("LoaderExceptions", warning!.Message);
+        Assert.Contains(stub.GetName().Name!, warning.Message);
+        Assert.Contains("synthetic loader exception", warning.Message);
+    }
+
+    [Fact]
+    public void CodeGeneratorResolver_LogsWarning_WhenCodeGenerationAssemblyContributesNothing()
+    {
+        var logger = new RecordingLogger<CodeGeneratorResolver>();
+        // The marker name is what triggers the "did not contribute any" diagnostic.
+        var empty = new EmptyNamedAssembly("Aspire.Hosting.CodeGeneration.Synthetic");
+
+        using var services = new ServiceCollection().BuildServiceProvider();
+        var resolver = new CodeGeneratorResolver(services, () => (IReadOnlyList<Assembly>)[empty], logger);
+
+        Assert.Null(resolver.GetCodeGenerator("anything"));
+
+        var warning = logger.Entries.SingleOrDefault(e => e.Level == LogLevel.Warning && e.Message.Contains("did not contribute"));
+        Assert.NotNull(warning);
+        Assert.Contains("ICodeGenerator", warning!.Message);
+    }
+
+    [Fact]
+    public void CodeGeneratorResolver_DoesNotLogContributionWarning_ForArbitraryAssembly()
+    {
+        var logger = new RecordingLogger<CodeGeneratorResolver>();
+        var arbitrary = new EmptyNamedAssembly("My.Custom.Integration");
+
+        using var services = new ServiceCollection().BuildServiceProvider();
+        _ = new CodeGeneratorResolver(services, () => (IReadOnlyList<Assembly>)[arbitrary], logger).GetCodeGenerator("anything");
+
+        Assert.DoesNotContain(logger.Entries, e => e.Level == LogLevel.Warning && e.Message.Contains("did not contribute"));
+    }
+
+    private sealed class TypeLoadFailingAssembly : Assembly
+    {
+        private readonly AssemblyName _name;
+
+        public TypeLoadFailingAssembly(string name) => _name = new AssemblyName(name);
+
+        public override AssemblyName GetName() => _name;
+
+        public override Type[] GetTypes()
+            => throw new ReflectionTypeLoadException(
+                [null, typeof(string)],
+                [new FileLoadException("synthetic loader exception: simulated Aspire.TypeSystem mismatch")]);
+    }
+
+    private sealed class EmptyNamedAssembly : Assembly
+    {
+        private readonly AssemblyName _name;
+
+        public EmptyNamedAssembly(string name) => _name = new AssemblyName(name);
+
+        public override AssemblyName GetName() => _name;
+
+        public override Type[] GetTypes() => [typeof(string)];
+    }
+}

--- a/tests/Aspire.Hosting.RemoteHost.Tests/ServiceErrorMessageTests.cs
+++ b/tests/Aspire.Hosting.RemoteHost.Tests/ServiceErrorMessageTests.cs
@@ -1,0 +1,142 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Reflection;
+using Aspire.Hosting.RemoteHost.CodeGeneration;
+using Aspire.Hosting.RemoteHost.Diagnostics;
+using Aspire.Hosting.RemoteHost.Language;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+using Xunit;
+
+namespace Aspire.Hosting.RemoteHost.Tests;
+
+/// <summary>
+/// Verifies the user-facing error messages on the RPC-exposed services include actionable
+/// information instead of just "No language support found for: X". See
+/// https://github.com/microsoft/aspire/issues/16729 for the background.
+/// </summary>
+public class ServiceErrorMessageTests
+{
+    [Fact]
+    public void ScaffoldAppHost_UnknownLanguage_ListsAvailableLanguages()
+    {
+        var (langService, _) = CreateServices();
+
+        var ex = Assert.Throws<ArgumentException>(() => langService.ScaffoldAppHost("klingon", "/tmp/whatever"));
+
+        Assert.Contains("No language support found for: klingon", ex.Message);
+        Assert.Contains("Available languages:", ex.Message);
+        Assert.Contains("typescript/nodejs", ex.Message);
+    }
+
+    [Fact]
+    public void GenerateCode_UnknownLanguage_ListsAvailableLanguages()
+    {
+        var (_, codeService) = CreateServices();
+
+        var ex = Assert.Throws<ArgumentException>(() => codeService.GenerateCode("klingon"));
+
+        Assert.Contains("No code generator found for language: klingon", ex.Message);
+        Assert.Contains("Available languages:", ex.Message);
+        Assert.Contains("TypeScript", ex.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void ScaffoldAppHost_NoLanguagesDiscovered_PointsAtBundleMismatch()
+    {
+        var langService = CreateLanguageServiceWithEmptyResolver();
+
+        var ex = Assert.Throws<ArgumentException>(() => langService.ScaffoldAppHost("typescript/nodejs", "/tmp/whatever"));
+
+        Assert.Contains("No language support found for: typescript/nodejs", ex.Message);
+        Assert.Contains("LoaderExceptions", ex.Message);
+        Assert.Contains("binary mismatch", ex.Message);
+    }
+
+    [Fact]
+    public void GenerateCode_NoGeneratorsDiscovered_PointsAtBundleMismatch()
+    {
+        var codeService = CreateCodeGenerationServiceWithEmptyResolver();
+
+        var ex = Assert.Throws<ArgumentException>(() => codeService.GenerateCode("TypeScript"));
+
+        Assert.Contains("No code generator found for language: TypeScript", ex.Message);
+        Assert.Contains("LoaderExceptions", ex.Message);
+        Assert.Contains("binary mismatch", ex.Message);
+    }
+
+    private static (LanguageService Lang, CodeGenerationService Code) CreateServices()
+    {
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["AtsAssemblies:0"] = "Aspire.Hosting.CodeGeneration.Go",
+                ["AtsAssemblies:1"] = "Aspire.Hosting.CodeGeneration.Java",
+                ["AtsAssemblies:2"] = "Aspire.Hosting.CodeGeneration.Python",
+                ["AtsAssemblies:3"] = "Aspire.Hosting.CodeGeneration.Rust",
+                ["AtsAssemblies:4"] = "Aspire.Hosting.CodeGeneration.TypeScript"
+            })
+            .Build();
+
+        var telemetry = CreateTelemetry();
+        var loader = new AssemblyLoader(configuration, NullLogger<AssemblyLoader>.Instance, telemetry);
+        // Note: do NOT dispose the ServiceProvider here. The resolvers lazily instantiate
+        // language-support / code-generator types via ActivatorUtilities, which would fail
+        // if the provider had already been disposed.
+        var services = new ServiceCollection().BuildServiceProvider();
+
+        var langResolver = new LanguageSupportResolver(services, loader, NullLogger<LanguageSupportResolver>.Instance);
+        var codeResolver = new CodeGeneratorResolver(services, loader, NullLogger<CodeGeneratorResolver>.Instance);
+
+        var auth = CreateAuthenticatedState();
+
+        var atsContextFactory = new AtsContextFactory(loader, NullLogger<AtsContextFactory>.Instance, telemetry);
+
+        var lang = new LanguageService(auth, langResolver, NullLogger<LanguageService>.Instance, telemetry);
+        var code = new CodeGenerationService(auth, atsContextFactory, codeResolver, NullLogger<CodeGenerationService>.Instance, telemetry);
+        return (lang, code);
+    }
+
+    private static LanguageService CreateLanguageServiceWithEmptyResolver()
+    {
+        var services = new ServiceCollection().BuildServiceProvider();
+        // Use the test-only seam to inject an empty assembly list so the resolver hits the
+        // "no implementations discovered" branch deterministically, regardless of what
+        // AssemblyLoader probing finds in the test runtime directory.
+        var langResolver = new LanguageSupportResolver(
+            services,
+            Array.Empty<Assembly>,
+            NullLogger<LanguageSupportResolver>.Instance);
+
+        var auth = CreateAuthenticatedState();
+        return new LanguageService(auth, langResolver, NullLogger<LanguageService>.Instance, CreateTelemetry());
+    }
+
+    private static CodeGenerationService CreateCodeGenerationServiceWithEmptyResolver()
+    {
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>())
+            .Build();
+
+        var telemetry = CreateTelemetry();
+        var loader = new AssemblyLoader(configuration, NullLogger<AssemblyLoader>.Instance, telemetry);
+        var services = new ServiceCollection().BuildServiceProvider();
+        var codeResolver = new CodeGeneratorResolver(
+            services,
+            Array.Empty<Assembly>,
+            NullLogger<CodeGeneratorResolver>.Instance);
+
+        var auth = CreateAuthenticatedState();
+        var atsContextFactory = new AtsContextFactory(loader, NullLogger<AtsContextFactory>.Instance, telemetry);
+        return new CodeGenerationService(auth, atsContextFactory, codeResolver, NullLogger<CodeGenerationService>.Instance, telemetry);
+    }
+
+    // The default state is "authenticated" when no JsonRpcAuthToken is present in configuration.
+    private static JsonRpcAuthenticationState CreateAuthenticatedState()
+        => new(new ConfigurationBuilder().Build());
+
+    private static RemoteHostProfilingTelemetry CreateTelemetry()
+        => new(new ConfigurationBuilder().Build());
+}


### PR DESCRIPTION
## Description

When `aspire new` (or another integration-driven command) silently fails to find a code generator or language support — for any reason: build-pipeline version skew, a stale local NuGet cache, a transitive dependency mismatch, a partially populated probe directory, etc. — users see only this:

```
❌ An unexpected error occurred: No code generator found for language: TypeScript
❌ An unexpected error occurred: No language support found for: typescript/nodejs
```

The actual cause (e.g. a `ReflectionTypeLoadException` whose `LoaderExceptions` describe an `Aspire.TypeSystem` mismatch, or an integration assembly that was loaded but contributed zero discoverable types) is logged at `LogDebug`, which is below the file logger's default `Information` threshold and never reaches the on-disk log. Result: the user has no path to self-diagnose. Issue [#16729](https://github.com/microsoft/aspire/issues/16729) documents the symptom and the diagnostic-hardening direction the team agreed on after the originally-reported `13.3.0` reproduction turned out to be a local NuGet cache anomaly.

This is **diagnostic hardening only** — no change to runtime binding behavior. After this PR, a recurrence of the same shape of failure surfaces a clear log entry naming the offending assembly and either the `LoaderExceptions` text or the bundled-vs-libs version mismatch, and the user-facing error message itself lists the available languages or points at the apphost-server log + binary-mismatch scenario.

### What users see after this PR

CLI log (file, default Information threshold):

```
warn: Aspire.Hosting.RemoteHost.AssemblyLoader[0]
      Shared assembly 'Aspire.TypeSystem' version mismatch: bundled=13.4.0.0, libs=13.3.0.0 (…/libs/Aspire.TypeSystem.dll).
      Integration assemblies referencing this assembly from the libs directory will fail to bind their type references through
      the default load context, which causes integrations to be silently skipped during type discovery.
      This typically indicates the apphost server bundle and the restored integration packages were produced by different build configurations.

warn: Aspire.Hosting.RemoteHost.CodeGeneration.CodeGeneratorResolver[0]
      Some types in assembly 'Aspire.Hosting.CodeGeneration.TypeScript' could not be loaded; 142 of 158 types are available.
      LoaderExceptions: Could not load file or assembly 'Aspire.TypeSystem, Version=13.3.0.0…'

warn: Aspire.Hosting.RemoteHost.CodeGeneration.CodeGeneratorResolver[0]
      Assembly 'Aspire.Hosting.CodeGeneration.TypeScript' was loaded but did not contribute any ICodeGenerator implementations.
      This is likely caused by a binary mismatch between the bundled and probed assemblies (see preceding LoaderExceptions).
```

User-facing error from the RPC service when there are some languages discovered but not the requested one:

```
No language support found for: klingon. Available languages: go, java, python, rust, typescript/nodejs.
No code generator found for language: klingon. Available languages: Go, Java, Python, Rust, TypeScript.
```

User-facing error when **no** languages are discovered at all (the silent-failure case the issue is about):

```
No language support found for: typescript/nodejs. No language support implementations were discovered in any loaded assembly.
This usually indicates a binary mismatch between the bundled apphost server and the integration assemblies on disk;
check the apphost server log for 'LoaderExceptions' Warnings.
```

### Implementation summary

- `CodeGeneratorResolver` / `LanguageSupportResolver`: promote `ReflectionTypeLoadException` from `LogDebug` → `LogWarning` with flattened `LoaderExceptions` text. Add a per-assembly warning when an `Aspire.Hosting.CodeGeneration.*` assembly is loaded but contributes zero impls (almost always a silent type-load failure).
- `AssemblyLoader`: add `WarnIfSharedAssemblyMismatch`, invoked at construction time. Compares the default-ALC version of each shared assembly (currently just `Aspire.TypeSystem`) against the libs-on-disk version and logs a `Warning` on mismatch. This catches the case the version-unification logic in `IntegrationLoadContext.Load` can't help with — for the shared assembly, the load context unconditionally defers to the default ALC, so a probed/bundled mismatch never goes through version comparison.
- `LanguageService` / `CodeGenerationService`: replace bare `"No language support found for: X"` / `"No code generator found for language: X"` with a builder that lists available languages, or — when zero are discovered — explains the likely binary-mismatch cause and points at the apphost-server log.
- `PrebuiltAppHostServer`: promote spawned-process `stdout` from `LogTrace` → `LogDebug` and `stderr` from `LogTrace` → `LogInformation`, so warnings emitted by the apphost server actually reach the default file log.

### Internal-only API additions

- `CodeGeneratorResolver.GetSupportedLanguages()` — used by `CodeGenerationService` to list discovered languages in error messages.
- Internal test-only `Func<IReadOnlyList<Assembly>>` constructor on both resolvers, used by the new tests to inject synthetic assemblies without going through the file-system-probing `AssemblyLoader`.
- `IntegrationLoadContext.GetSharedAssemblyNames()` — single source of truth for "which assemblies does the integration ALC defer to default for", consumed by the new `WarnIfSharedAssemblyMismatch` in `AssemblyLoader`.

All resolvers, services, and the load context are themselves `internal sealed`. No public API surface is added.

### Validation

- `dotnet build src/Aspire.Hosting.RemoteHost/Aspire.Hosting.RemoteHost.csproj` — 0 warnings, 0 errors.
- `dotnet build src/Aspire.Cli/Aspire.Cli.csproj` — 0 warnings, 0 errors.
- `dotnet test --project tests/Aspire.Hosting.RemoteHost.Tests/Aspire.Hosting.RemoteHost.Tests.csproj -- --filter-not-trait "quarantined=true" --filter-not-trait "outerloop=true"` — **422 / 422 passed**, including 8 new tests:
  - `ResolverDiagnosticsTests` (4) — Warning logged on `ReflectionTypeLoadException` with `LoaderExceptions` text (both resolvers); zero-contributor warning fires for marker-named assemblies and does **not** fire for arbitrary ones.
  - `ServiceErrorMessageTests` (4) — `ScaffoldAppHost` and `GenerateCode` error messages list discovered languages in the "some available" case and point at the binary-mismatch / `LoaderExceptions` hint in the "zero discovered" case.

### Relationship to the closed PR

This supersedes the closed [#16733](https://github.com/microsoft/aspire/pull/16733). The diagnostic-hardening half is unchanged in intent and lands cleanly. The `AssemblyLoader` call site needed adjustment because `LoadAssemblies` no longer carries `integrationLibsPath`; the warning now runs from the constructor where `libsPath` is in scope. Test helpers updated for the current `AssemblyLoader` / `LanguageService` / `CodeGenerationService` constructor shapes (which all now also take `RemoteHostProfilingTelemetry`). The runtime binding fix the closed PR had originally explored is **not** included — the issue itself records that the originally-reported failure was a cache anomaly, not a binding regression.

Fixes #16729

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
