### PR TITLE
Add TypeScript package manager E2E coverage

### DIFF
--- a/tests/Aspire.Cli.EndToEnd.Tests/Helpers/TypeScriptAppHostToolchainTestHelpers.cs
+++ b/tests/Aspire.Cli.EndToEnd.Tests/Helpers/TypeScriptAppHostToolchainTestHelpers.cs
@@ -11,6 +11,9 @@ namespace Aspire.Cli.EndToEnd.Tests.Helpers;
 /// </summary>
 internal static class TypeScriptAppHostToolchainTestHelpers
 {
+    private const string YarnConfigurationFileName = ".yarnrc.yml";
+    private const string YarnNodeModulesConfiguration = "nodeLinker: node-modules";
+
     private static readonly JsonSerializerOptions s_packageJsonSerializerOptions = new()
     {
         WriteIndented = true
@@ -36,6 +39,7 @@ internal static class TypeScriptAppHostToolchainTestHelpers
 
         packageJson["packageManager"] = GetPackageManager(toolchain);
         File.WriteAllText(packageJsonPath, $"{packageJson.ToJsonString(s_packageJsonSerializerOptions)}{Environment.NewLine}");
+        ConfigureToolchainFiles(projectRoot, toolchain);
 
         if (!cleanInstallState)
         {
@@ -57,6 +61,44 @@ internal static class TypeScriptAppHostToolchainTestHelpers
             Directory.Delete(nodeModulesPath, recursive: true);
         }
     }
+
+    /// <summary>
+    /// Gets the restore/install command for a toolchain.
+    /// </summary>
+    internal static string GetInstallCommand(string toolchain) =>
+        $"{GetCommandName(toolchain)} install";
+
+    /// <summary>
+    /// Gets the no-emit type-check command for a toolchain.
+    /// </summary>
+    internal static string GetTypeCheckCommand(string toolchain, string tsConfigFileName) =>
+        NormalizeToolchain(toolchain) switch
+        {
+            "bun" => $"bun run tsc --noEmit -p {tsConfigFileName}",
+            "yarn" => $"yarn run tsc --noEmit -p {tsConfigFileName}",
+            "pnpm" => $"pnpm exec tsc --noEmit -p {tsConfigFileName}",
+            "npm" => $"npx --no-install tsc --noEmit -p {tsConfigFileName}",
+            _ => throw new ArgumentOutOfRangeException(nameof(toolchain), toolchain, "Unsupported TypeScript AppHost toolchain.")
+        };
+
+    /// <summary>
+    /// Gets the script runner command for a toolchain.
+    /// </summary>
+    internal static string GetRunScriptCommand(string toolchain, string scriptName) =>
+        $"{GetCommandName(toolchain)} run {scriptName}";
+
+    /// <summary>
+    /// Gets the primary lock file name a toolchain should produce after restore/install.
+    /// </summary>
+    internal static string GetLockFileName(string toolchain) =>
+        NormalizeToolchain(toolchain) switch
+        {
+            "bun" => "bun.lock",
+            "yarn" => "yarn.lock",
+            "pnpm" => "pnpm-lock.yaml",
+            "npm" => "package-lock.json",
+            _ => throw new ArgumentOutOfRangeException(nameof(toolchain), toolchain, "Unsupported TypeScript AppHost toolchain.")
+        };
 
     /// <summary>
     /// Gets the package manager metadata value for a toolchain.
@@ -100,6 +142,31 @@ internal static class TypeScriptAppHostToolchainTestHelpers
             "yarn" => "https://yarnpkg.com/getting-started/install",
             "pnpm" => "https://pnpm.io/installation",
             "npm" => "https://nodejs.org/en/download",
+            _ => throw new ArgumentOutOfRangeException(nameof(toolchain), toolchain, "Unsupported TypeScript AppHost toolchain.")
+        };
+
+    private static void ConfigureToolchainFiles(string projectRoot, string toolchain)
+    {
+        var yarnConfigPath = Path.Combine(projectRoot, YarnConfigurationFileName);
+        if (NormalizeToolchain(toolchain) == "yarn")
+        {
+            // Yarn 4 defaults to Plug'n'Play, but the generated AppHost/Vite workflows exercised
+            // here expect node_modules resolution across tsx, nodemon, and Vite.
+            File.WriteAllText(yarnConfigPath, $"{YarnNodeModulesConfiguration}{Environment.NewLine}");
+        }
+        else if (File.Exists(yarnConfigPath))
+        {
+            File.Delete(yarnConfigPath);
+        }
+    }
+
+    private static string GetCommandName(string toolchain) =>
+        NormalizeToolchain(toolchain) switch
+        {
+            "bun" => "bun",
+            "yarn" => "yarn",
+            "pnpm" => "pnpm",
+            "npm" => "npm",
             _ => throw new ArgumentOutOfRangeException(nameof(toolchain), toolchain, "Unsupported TypeScript AppHost toolchain.")
         };
 

--- a/tests/Aspire.Cli.EndToEnd.Tests/Helpers/TypeScriptAppHostToolchainTestHelpers.cs
+++ b/tests/Aspire.Cli.EndToEnd.Tests/Helpers/TypeScriptAppHostToolchainTestHelpers.cs
@@ -39,10 +39,10 @@ internal static class TypeScriptAppHostToolchainTestHelpers
 
         packageJson["packageManager"] = GetPackageManager(toolchain);
         File.WriteAllText(packageJsonPath, $"{packageJson.ToJsonString(s_packageJsonSerializerOptions)}{Environment.NewLine}");
-        ConfigureToolchainFiles(projectRoot, toolchain);
 
         if (!cleanInstallState)
         {
+            ConfigureToolchainFiles(projectRoot, toolchain);
             return;
         }
 
@@ -60,6 +60,8 @@ internal static class TypeScriptAppHostToolchainTestHelpers
         {
             Directory.Delete(nodeModulesPath, recursive: true);
         }
+
+        ConfigureToolchainFiles(projectRoot, toolchain);
     }
 
     /// <summary>
@@ -153,6 +155,14 @@ internal static class TypeScriptAppHostToolchainTestHelpers
             // Yarn 4 defaults to Plug'n'Play, but the generated AppHost/Vite workflows exercised
             // here expect node_modules resolution across tsx, nodemon, and Vite.
             File.WriteAllText(yarnConfigPath, $"{YarnNodeModulesConfiguration}{Environment.NewLine}");
+
+            var yarnLockPath = Path.Combine(projectRoot, "yarn.lock");
+            if (!File.Exists(yarnLockPath))
+            {
+                // Without a lockfile, Yarn walks up to the AppHost package.json and treats a nested
+                // Vite app as an unlisted workspace instead of an independent package.
+                File.WriteAllText(yarnLockPath, string.Empty);
+            }
         }
         else if (File.Exists(yarnConfigPath))
         {

--- a/tests/Aspire.Cli.EndToEnd.Tests/TypeScriptCodegenValidationTests.cs
+++ b/tests/Aspire.Cli.EndToEnd.Tests/TypeScriptCodegenValidationTests.cs
@@ -15,15 +15,16 @@ namespace Aspire.Cli.EndToEnd.Tests;
 /// </summary>
 public sealed class TypeScriptCodegenValidationTests(ITestOutputHelper output)
 {
-    public static TheoryData<string> AlternativeToolchains => new()
+    public static TheoryData<string> SupportedToolchains => new()
     {
+        "npm",
         "bun",
         "yarn",
         "pnpm"
     };
 
     [Theory]
-    [MemberData(nameof(AlternativeToolchains))]
+    [MemberData(nameof(SupportedToolchains))]
     [CaptureWorkspaceOnFailure]
     public async Task RestoreGeneratesSdkFiles_WithConfiguredToolchain(string toolchain)
     {
@@ -77,6 +78,19 @@ public sealed class TypeScriptCodegenValidationTests(ITestOutputHelper output)
         await auto.EnterAsync();
         await auto.WaitUntilTextAsync("SDK code restored successfully", timeout: TimeSpan.FromMinutes(3));
         await auto.WaitForSuccessPromptAsync(counter);
+
+        var lockFilePath = Path.Combine(
+            workspace.WorkspaceRoot.FullName,
+            TypeScriptAppHostToolchainTestHelpers.GetLockFileName(toolchain));
+        if (!File.Exists(lockFilePath))
+        {
+            throw new InvalidOperationException(
+                $"Expected {TypeScriptAppHostToolchainTestHelpers.GetDisplayName(toolchain)} restore to create '{lockFilePath}'.");
+        }
+
+        await auto.TypeAsync(TypeScriptAppHostToolchainTestHelpers.GetTypeCheckCommand(toolchain, "tsconfig.apphost.json"));
+        await auto.EnterAsync();
+        await auto.WaitForSuccessPromptFailFastAsync(counter, TimeSpan.FromMinutes(2));
 
         // Step 4: Verify generated SDK files exist.
         var modulesDir = Path.Combine(workspace.WorkspaceRoot.FullName, ".modules");

--- a/tests/Aspire.Cli.EndToEnd.Tests/TypeScriptPolyglotTests.cs
+++ b/tests/Aspire.Cli.EndToEnd.Tests/TypeScriptPolyglotTests.cs
@@ -16,15 +16,16 @@ namespace Aspire.Cli.EndToEnd.Tests;
 /// </summary>
 public sealed class TypeScriptPolyglotTests(ITestOutputHelper output)
 {
-    public static TheoryData<string> AlternativeToolchains => new()
+    public static TheoryData<string> SupportedToolchains => new()
     {
+        "npm",
         "bun",
         "yarn",
         "pnpm"
     };
 
     [Theory]
-    [MemberData(nameof(AlternativeToolchains))]
+    [MemberData(nameof(SupportedToolchains))]
     [CaptureWorkspaceOnFailure]
     public async Task CreateTypeScriptAppHostWithViteApp_UsesConfiguredToolchain(string toolchain)
     {
@@ -78,8 +79,11 @@ public sealed class TypeScriptPolyglotTests(ITestOutputHelper output)
         await auto.EnterAsync();
         await auto.WaitForSuccessPromptAsync(counter, TimeSpan.FromMinutes(2));
 
+        var viteProjectRoot = Path.Combine(workspace.WorkspaceRoot.FullName, "viteapp");
+        TypeScriptAppHostToolchainTestHelpers.SetPackageManager(viteProjectRoot, toolchain, cleanInstallState: true);
+
         // Step 3: Install Vite app dependencies
-        await auto.TypeAsync("cd viteapp && npm install && cd ..");
+        await auto.TypeAsync($"cd viteapp && {TypeScriptAppHostToolchainTestHelpers.GetInstallCommand(toolchain)} && cd ..");
         await auto.EnterAsync();
         await auto.WaitForSuccessPromptAsync(counter, TimeSpan.FromMinutes(2));
 
@@ -108,7 +112,31 @@ public sealed class TypeScriptPolyglotTests(ITestOutputHelper output)
 
         File.WriteAllText(appHostPath, newContent);
 
-        // Step 6: Run the apphost
+        // Step 6: Restore and type-check with the configured package manager before running.
+        await auto.TypeAsync("aspire restore");
+        await auto.EnterAsync();
+        await auto.WaitUntilTextAsync("SDK code restored successfully", timeout: TimeSpan.FromMinutes(3));
+        await auto.WaitForSuccessPromptAsync(counter);
+
+        var appHostLockFilePath = Path.Combine(
+            workspace.WorkspaceRoot.FullName,
+            TypeScriptAppHostToolchainTestHelpers.GetLockFileName(toolchain));
+        Assert.True(
+            File.Exists(appHostLockFilePath),
+            $"Expected {TypeScriptAppHostToolchainTestHelpers.GetDisplayName(toolchain)} restore to create '{appHostLockFilePath}'.");
+
+        var viteLockFilePath = Path.Combine(
+            viteProjectRoot,
+            TypeScriptAppHostToolchainTestHelpers.GetLockFileName(toolchain));
+        Assert.True(
+            File.Exists(viteLockFilePath),
+            $"Expected {TypeScriptAppHostToolchainTestHelpers.GetDisplayName(toolchain)} install to create '{viteLockFilePath}'.");
+
+        await auto.TypeAsync(TypeScriptAppHostToolchainTestHelpers.GetTypeCheckCommand(toolchain, "tsconfig.apphost.json"));
+        await auto.EnterAsync();
+        await auto.WaitForSuccessPromptFailFastAsync(counter, TimeSpan.FromMinutes(2));
+
+        // Step 7: Run the apphost
         await auto.TypeAsync("aspire run");
         await auto.EnterAsync();
         await auto.WaitUntilAsync(s =>
@@ -123,9 +151,70 @@ public sealed class TypeScriptPolyglotTests(ITestOutputHelper output)
             return s.ContainsText("Press CTRL+C to stop the AppHost and exit.");
         }, timeout: TimeSpan.FromMinutes(3), description: "Press CTRL+C message (aspire run started)");
 
-        // Step 7: Stop the apphost
+        // Step 8: Stop the apphost
         await auto.Ctrl().KeyAsync(Hex1bKey.C);
         await auto.WaitForSuccessPromptAsync(counter);
+        await auto.TypeAsync("exit");
+        await auto.EnterAsync();
+
+        await pendingRun;
+    }
+
+    [Theory]
+    [MemberData(nameof(SupportedToolchains))]
+    [CaptureWorkspaceOnFailure]
+    public async Task GeneratedAspireDevScript_StartsWatchMode_WithConfiguredToolchain(string toolchain)
+    {
+        var repoRoot = CliE2ETestHelpers.GetRepoRoot();
+        var strategy = CliInstallStrategy.Detect(output.WriteLine);
+        var workspace = TemporaryWorkspace.Create(output);
+        var localChannel = CliE2ETestHelpers.PrepareLocalChannel(repoRoot, strategy,
+            ["Aspire.Hosting.CodeGeneration.TypeScript."]);
+
+        var channelArgument = localChannel is not null ? " --channel local" : string.Empty;
+
+        using var terminal = CliE2ETestHelpers.CreateDockerTestTerminal(repoRoot, strategy, output, workspace: workspace);
+
+        var pendingRun = terminal.RunAsync(TestContext.Current.CancellationToken);
+
+        var counter = new SequenceCounter();
+        var auto = new Hex1bTerminalAutomator(terminal, defaultTimeout: TimeSpan.FromSeconds(500));
+
+        await auto.PrepareDockerEnvironmentAsync(counter, workspace);
+        await auto.InstallAspireCliAsync(strategy, counter);
+
+        await auto.TypeAsync($"aspire init --language typescript --non-interactive{channelArgument}");
+        await auto.EnterAsync();
+        await auto.WaitUntilTextAsync("Created apphost.ts", timeout: TimeSpan.FromMinutes(2));
+        await auto.DeclineAgentInitPromptAsync(counter);
+
+        TypeScriptAppHostToolchainTestHelpers.SetPackageManager(workspace.WorkspaceRoot.FullName, toolchain, cleanInstallState: true);
+
+        if (localChannel is not null)
+        {
+            CliE2ETestHelpers.WriteLocalChannelSettings(workspace.WorkspaceRoot.FullName, localChannel.SdkVersion);
+        }
+
+        await auto.TypeAsync(TypeScriptAppHostToolchainTestHelpers.GetInstallCommand(toolchain));
+        await auto.EnterAsync();
+        await auto.WaitForSuccessPromptAsync(counter, TimeSpan.FromMinutes(2));
+
+        var lockFilePath = Path.Combine(
+            workspace.WorkspaceRoot.FullName,
+            TypeScriptAppHostToolchainTestHelpers.GetLockFileName(toolchain));
+        Assert.True(
+            File.Exists(lockFilePath),
+            $"Expected {TypeScriptAppHostToolchainTestHelpers.GetDisplayName(toolchain)} install to create '{lockFilePath}'.");
+
+        await auto.TypeAsync(TypeScriptAppHostToolchainTestHelpers.GetRunScriptCommand(toolchain, "aspire:dev"));
+        await auto.EnterAsync();
+        await auto.WaitUntilAsync(
+            s => s.ContainsText("Watching for file changes."),
+            timeout: TimeSpan.FromMinutes(2),
+            description: $"{toolchain} watch mode to start");
+
+        await auto.Ctrl().KeyAsync(Hex1bKey.C);
+        await auto.WaitForAnyPromptAsync(counter);
         await auto.TypeAsync("exit");
         await auto.EnterAsync();
 


### PR DESCRIPTION
## Description

TypeScript AppHost package-manager support has resolver-level coverage, but the supported managers also need end-to-end coverage that proves restore, type-check, run, and watch-mode flows work through the real CLI harness.

This adds package-manager-aware E2E helpers and expands the TypeScript AppHost tests to exercise npm, pnpm, Yarn 4+, and Bun. The scenarios now assert manager-specific lock files are produced, use the selected manager for type-checking instead of falling back to npm, and cover the generated `aspire:dev` watch script. Yarn test workspaces write `nodeLinker: node-modules` because the generated AppHost and Vite workflows rely on node_modules resolution rather than Yarn Plug'n'Play.

Validation:
- `./dotnet.sh build tests/Aspire.Cli.EndToEnd.Tests/Aspire.Cli.EndToEnd.Tests.csproj /p:SkipNativeBuild=true /p:TreatWarningsAsErrors=false`
- `git diff --check`
- Docker-backed E2E execution was not run locally because the Docker daemon was unavailable in this session.

Fixes: #17033

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No