### PR TITLE
[DO NOT MERGE / DO NOT REVIEW] Validate stabilization is a single-line change on top of #15681

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -133,9 +133,13 @@ jobs:
         # Classes that touch IsPrerelease / channel detection / template version pinning /
         # update-notification logic. These are the code paths most likely to behave
         # differently when the CLI's own assembly version label is stable.
+        # --no-build / --no-restore: the previous step already built (with -p:SkipTestProjects=false)
+        # under StabilizePackageVersion=true. Running without these would re-evaluate the
+        # project graph with a different global-property fingerprint than step 1, defeating
+        # MSBuild incremental cache and risking subtle differences in what gets rebuilt.
         run: |
           ./dotnet.sh test --project tests/Aspire.Cli.Tests/Aspire.Cli.Tests.csproj \
-            --no-launch-profile \
+            --no-build --no-restore --no-launch-profile \
             -p:StabilizePackageVersion=true \
             -- \
             --filter-class "*.AssemblyMetadataChannelTests" \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -133,13 +133,17 @@ jobs:
         # Classes that touch IsPrerelease / channel detection / template version pinning /
         # update-notification logic. These are the code paths most likely to behave
         # differently when the CLI's own assembly version label is stable.
-        # --no-build / --no-restore: the previous step already built (with -p:SkipTestProjects=false)
-        # under StabilizePackageVersion=true. Running without these would re-evaluate the
-        # project graph with a different global-property fingerprint than step 1, defeating
-        # MSBuild incremental cache and risking subtle differences in what gets rebuilt.
+        # NOTE: we intentionally do NOT pass --no-build / --no-restore here. SDK 10's
+        # `dotnet test` driver needs to perform its own MSBuild evaluation pass to detect
+        # the Microsoft.Testing.Platform runner (which Aspire.Cli.Tests uses), and without
+        # restore that evaluation reports "All projects must use that test runner ... using
+        # VSTest test runner" and exits non-zero. The previous pack step's restore is keyed
+        # by a different global-property fingerprint and can't be reused. The cost of
+        # letting `dotnet test` re-restore here is small because nothing on disk actually
+        # changes — it's just an in-memory evaluation pass.
         run: |
           ./dotnet.sh test --project tests/Aspire.Cli.Tests/Aspire.Cli.Tests.csproj \
-            --no-build --no-restore --no-launch-profile \
+            --no-launch-profile \
             -p:StabilizePackageVersion=true \
             -- \
             --filter-class "*.AssemblyMetadataChannelTests" \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -134,8 +134,8 @@ jobs:
         # update-notification logic. These are the code paths most likely to behave
         # differently when the CLI's own assembly version label is stable.
         run: |
-          ./dotnet.sh test tests/Aspire.Cli.Tests/Aspire.Cli.Tests.csproj \
-            --no-build --no-launch-profile \
+          ./dotnet.sh test --project tests/Aspire.Cli.Tests/Aspire.Cli.Tests.csproj \
+            --no-launch-profile \
             -p:StabilizePackageVersion=true \
             -- \
             --filter-class "*.AssemblyMetadataChannelTests" \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,7 +58,7 @@ jobs:
             exit 1
           }
           $SHORT_SHA = $Env:PR_HEAD_SHA.Substring(0,8)
-          $VERSION_SUFFIX = "/p:VersionSuffix=pr.$($Env:PR_NUMBER).g$SHORT_SHA"
+          $VERSION_SUFFIX = "/p:VersionSuffix=pr.$($Env:PR_NUMBER).g$SHORT_SHA /p:DotNetFinalVersionKind=prerelease"
           Write-Host "Computed VERSION_SUFFIX_OVERRIDE=$VERSION_SUFFIX"
           "VERSION_SUFFIX_OVERRIDE=$VERSION_SUFFIX" | Out-File -FilePath $Env:GITHUB_OUTPUT -Append -Encoding utf8
 
@@ -75,12 +75,103 @@ jobs:
       versionOverrideArg: ${{ needs.prepare_for_ci.outputs.VERSION_SUFFIX_OVERRIDE }}
       extensionVersionOverride: ${{ needs.prepare_for_ci.outputs.EXTENSION_VERSION_OVERRIDE }}
 
+  # Stabilization gate (#15335 / PR #15681).
+  #
+  # PR CI runs unstable (DotNetFinalVersionKind=prerelease above) so that dogfood artifacts
+  # have unique versions and dynamic Helix versions line up cleanly. To compensate for the
+  # fact that we never normally exercise the "everything is stable" build shape on PRs, this
+  # job runs a parallel build with StabilizePackageVersion=true that:
+  #
+  #   1. Packs all shipping packages, which catches NU5104 (stable package depending on a
+  #      preview package whose csproj sets SuppressFinalPackageVersion=true). This is the
+  #      check that used to fire only on the official stabilization PR.
+  #   2. Runs the subset of Aspire.Cli.Tests classes that exercise version/channel/template
+  #      version pinning logic against the stably-built CLI assemblies. These are the code
+  #      paths most likely to behave differently when the CLI's own version label is stable.
+  #   3. Runs a small init+restore smoke script that exercises the full
+  #      `aspire init` -> `aspire restore` flow against the locally-built stable feed,
+  #      which is the scenario that has historically broken on stabilization branches.
+  #
+  # The job is gated to PRs only. Push CI (including push to release branches with
+  # StabilizePackageVersion=true) doesn't need this check because that *is* the stabilized
+  # build shape already.
+  stabilization_check:
+    name: Stabilization Check
+    runs-on: 8-core-ubuntu-latest
+    needs: [prepare_for_ci]
+    if: ${{ github.repository_owner == 'microsoft' && needs.prepare_for_ci.outputs.skip_workflow != 'true' }}
+    steps:
+      # The actual stabilization work only makes sense for pull_request events. On push
+      # (including push to release branches with StabilizePackageVersion=true) the build is
+      # already running in the shape this job is meant to validate, so there's nothing to
+      # add. We still let the job *run* on push so the GitHub Actions result is 'success'
+      # rather than 'skipped' — otherwise the `results:` job's `contains(needs.*.result,
+      # 'skipped')` check would fail every push to main / release/**.
+      - name: Skip on push events
+        if: ${{ github.event_name != 'pull_request' }}
+        run: echo "Stabilization Check only runs on pull_request events. Skipping (job remains success)."
+
+      - name: Checkout code
+        if: ${{ github.event_name == 'pull_request' }}
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Build + pack with StabilizePackageVersion=true
+        if: ${{ github.event_name == 'pull_request' }}
+        # SkipNativeBuild=true keeps this job fast (~5min): pack-time NU5104 detection
+        # doesn't need NativeAOT CLI binaries, and the moderate smoke below invokes the
+        # CLI via `dotnet run --project src/Aspire.Cli/Aspire.Cli.csproj`. See #15335 for
+        # the follow-up tracking a NativeAOT-publish variant of this job.
+        run: |
+          ./build.sh -restore -build -ci -pack \
+            -p:StabilizePackageVersion=true \
+            -p:SkipTestProjects=false \
+            -p:SkipPlaygroundProjects=true \
+            -p:SkipNativeBuild=true \
+            -p:InstallBrowsersForPlaywright=false
+
+      - name: Run version-sensitive Aspire.Cli.Tests classes under stabilization
+        if: ${{ github.event_name == 'pull_request' }}
+        # Classes that touch IsPrerelease / channel detection / template version pinning /
+        # update-notification logic. These are the code paths most likely to behave
+        # differently when the CLI's own assembly version label is stable.
+        run: |
+          ./dotnet.sh test tests/Aspire.Cli.Tests/Aspire.Cli.Tests.csproj \
+            --no-build --no-launch-profile \
+            -p:StabilizePackageVersion=true \
+            -- \
+            --filter-class "*.AssemblyMetadataChannelTests" \
+            --filter-class "*.IdentityChannelReaderTests" \
+            --filter-class "*.PackageChannelTests" \
+            --filter-class "*.PrebuiltAppHostServerChannelResolutionTests" \
+            --filter-class "*.DotNetBasedAppHostServerChannelResolutionTests" \
+            --filter-class "*.NewCommandChannelResolutionTests" \
+            --filter-class "*.ChannelReseedTests" \
+            --filter-class "*.VersionHelperTests" \
+            --filter-class "*.CliUpdateNotificationServiceTests" \
+            --filter-class "*.UpdateCommandTests" \
+            --filter-class "*.DotNetTemplateFactoryTests" \
+            --filter-not-trait "quarantined=true" \
+            --filter-not-trait "outerloop=true"
+
+      - name: aspire init + restore smoke against stable local feed
+        if: ${{ github.event_name == 'pull_request' }}
+        run: ./eng/scripts/stabilization-smoke-init-restore.sh
+
+      # Always upload logs, even if the build fails, to enable debugging
+      - name: Upload logs
+        if: ${{ always() && github.event_name == 'pull_request' }}
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
+        with:
+          name: stabilization_check_logs
+          path: artifacts/log
+          retention-days: 5
+
   # This job is used for branch protection. It fails if any of the dependent jobs failed
   results:
     if: ${{ always() && github.repository_owner == 'microsoft' }}
     runs-on: ubuntu-latest
     name: Final Results
-    needs: [prepare_for_ci, tests]
+    needs: [prepare_for_ci, tests, stabilization_check]
 
     steps:
       - name: Fail if any of the dependent jobs failed

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,7 +75,7 @@ jobs:
       versionOverrideArg: ${{ needs.prepare_for_ci.outputs.VERSION_SUFFIX_OVERRIDE }}
       extensionVersionOverride: ${{ needs.prepare_for_ci.outputs.EXTENSION_VERSION_OVERRIDE }}
 
-  # Stabilization gate (#15335 / PR #15681).
+  # Stabilization gate.
   #
   # PR CI runs unstable (DotNetFinalVersionKind=prerelease above) so that dogfood artifacts
   # have unique versions and dynamic Helix versions line up cleanly. To compensate for the
@@ -119,8 +119,7 @@ jobs:
         if: ${{ github.event_name == 'pull_request' }}
         # SkipNativeBuild=true keeps this job fast (~5min): pack-time NU5104 detection
         # doesn't need NativeAOT CLI binaries, and the moderate smoke below invokes the
-        # CLI via `dotnet run --project src/Aspire.Cli/Aspire.Cli.csproj`. See #15335 for
-        # the follow-up tracking a NativeAOT-publish variant of this job.
+        # CLI via `dotnet run --project src/Aspire.Cli/Aspire.Cli.csproj`.
         run: |
           ./build.sh -restore -build -ci -pack \
             -p:StabilizePackageVersion=true \

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -21,7 +21,7 @@
     <MicrosoftTestingPlatformVersion>2.2.1</MicrosoftTestingPlatformVersion>
     <MicrosoftNETTestSdkVersion>17.14.1</MicrosoftNETTestSdkVersion>
     <!-- Enable to remove prerelease label. -->
-    <StabilizePackageVersion Condition="'$(StabilizePackageVersion)' == ''">false</StabilizePackageVersion>
+    <StabilizePackageVersion Condition="'$(StabilizePackageVersion)' == ''">true</StabilizePackageVersion>
     <DotNetFinalVersionKind Condition="'$(StabilizePackageVersion)' == 'true'">release</DotNetFinalVersionKind>
   </PropertyGroup>
   <PropertyGroup>

--- a/eng/scripts/stabilization-smoke-init-restore.sh
+++ b/eng/scripts/stabilization-smoke-init-restore.sh
@@ -131,10 +131,10 @@ run_aspire() {
 
 # Stage a NuGet.config in the work dir BEFORE running `aspire new`. The CLI itself fetches
 # the templates package via NuGet, and the subsequent restore needs both Aspire.* (from local
-# stable) and non-Aspire transitives (from the public dotnet feeds). packageSourceMapping pins
-# Aspire.* to our feed so a missing/preview Aspire dep fails fast rather than silently falling
-# back to nuget.org. Mirrors the source-mapping pattern in tests/Shared/nuget-with-package-
-# source-mapping.config used by Helix.
+# stable) and any non-Aspire transitives. packageSourceMapping pins Aspire.* to our feed so
+# a missing/preview Aspire dep fails fast rather than silently falling back to nuget.org for
+# an older stable release. Everything else flows from nuget.org — matches what an end user
+# running `aspire new` would have configured by default.
 cat > "$WORK_DIR/NuGet.config" <<EOF
 <?xml version="1.0" encoding="utf-8"?>
 <configuration>
@@ -144,25 +144,13 @@ cat > "$WORK_DIR/NuGet.config" <<EOF
   <packageSources>
     <clear />
     <add key="local-stable" value="$LOCAL_FEED" />
-    <add key="dotnet-public" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public/nuget/v3/index.json" />
-    <add key="dotnet-eng" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-eng/nuget/v3/index.json" />
-    <add key="dotnet9" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet9/nuget/v3/index.json" />
-    <add key="dotnet10" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet10/nuget/v3/index.json" />
+    <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
   </packageSources>
   <packageSourceMapping>
     <packageSource key="local-stable">
       <package pattern="Aspire*" />
     </packageSource>
-    <packageSource key="dotnet-public">
-      <package pattern="*" />
-    </packageSource>
-    <packageSource key="dotnet-eng">
-      <package pattern="*" />
-    </packageSource>
-    <packageSource key="dotnet9">
-      <package pattern="*" />
-    </packageSource>
-    <packageSource key="dotnet10">
+    <packageSource key="nuget.org">
       <package pattern="*" />
     </packageSource>
   </packageSourceMapping>
@@ -171,7 +159,7 @@ cat > "$WORK_DIR/NuGet.config" <<EOF
   </disabledPackageSources>
 </configuration>
 EOF
-echo "  ✓ Source-mapped NuGet.config written (Aspire* -> local-stable; everything else -> public dotnet feeds)"
+echo "  ✓ Source-mapped NuGet.config written (Aspire* -> local-stable; everything else -> nuget.org)"
 
 PROJECT_NAME="MyAspireApp"
 echo ""
@@ -217,7 +205,7 @@ else
 fi
 
 echo ""
-echo "→ aspire restore (against local stable feed + public dotnet feeds for transitives)"
+echo "→ aspire restore (against local stable feed for Aspire packages, nuget.org for everything else)"
 (cd "$PROJECT_DIR" && run_aspire restore < /dev/null)
 
 echo ""

--- a/eng/scripts/stabilization-smoke-init-restore.sh
+++ b/eng/scripts/stabilization-smoke-init-restore.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
-# Stabilization smoke test: aspire init + aspire restore against the locally-built stable feed.
+# Stabilization smoke test: aspire new aspire-empty + aspire restore against the locally-built
+# stable Aspire feed.
 #
 # Purpose
 # -------
@@ -20,14 +21,20 @@
 #   - flip <SuppressFinalPackageVersion>true</...> on Aspire.Hosting.Foo (ship it as preview), or
 #   - request Foo.Lib to stabilize before our next stable release.
 #
-# This script (the smoke) handles the end-to-end consumer flow specifically:
-#   * That `aspire init` emits an SDK / package reference shape that actually resolves against
-#     the stable feed (catches template version-pinning regressions).
-#   * That `aspire restore` succeeds end-to-end against a feed that contains only the stable
-#     packages we'd ship — i.e. no silent fallback to nuget.org papering over a missing dep.
+# This script (the smoke) handles the end-to-end consumer flow specifically. It exercises:
+#   * Template integrity — that `aspire new aspire-empty` produces a buildable project shape
+#     using the stably-built Aspire.ProjectTemplates package.
+#   * Template version-pinning — that the SDK reference (Aspire.AppHost.Sdk) and PackageReferences
+#     emitted by the template resolve against the stable feed for Aspire.* packages.
+#   * Restore wiring — that `aspire restore` succeeds end-to-end for the generated project tree.
 #
-# The pack-time NU5104 check (which is the primary detector for the Foo.Lib scenario above) is
-# the previous step in the stabilization_check job in ci.yml — this script complements it by
+# Aspire.* packages MUST come from the local stable feed (so missing/preview-only Aspire packages
+# fail restore here, exactly as they would on a real stabilization branch). Non-Aspire deps
+# pulled in by the template (Microsoft.Extensions.*, OpenTelemetry.*, etc.) are routed to the
+# normal public dotnet feeds via packageSourceMapping — they're not the surface we're validating.
+#
+# The pack-time NU5104 check (the primary detector for the Foo.Lib scenario above) is the
+# previous step in the stabilization_check job in ci.yml — this script complements it by
 # exercising the user-visible CLI workflow against the same stably-built feed.
 #
 # Prerequisites
@@ -60,7 +67,7 @@ ASPIRE_CLI_PROJECT="$REPO_ROOT/src/Aspire.Cli/Aspire.Cli.csproj"
 # which is what we need on CI runners that don't have a system-wide .NET 10 SDK.
 DOTNET="$REPO_ROOT/dotnet.sh"
 
-echo "=== Stabilization smoke: aspire init + restore ==="
+echo "=== Stabilization smoke: aspire new aspire-empty + restore ==="
 echo "Repo root:     $REPO_ROOT"
 echo "Configuration: $CONFIGURATION"
 echo "Local feed:    $LOCAL_FEED"
@@ -71,7 +78,7 @@ if [ ! -d "$LOCAL_FEED" ]; then
     exit 1
 fi
 
-# Confirm the feed actually contains stabilized Aspire packages (i.e. e.g. Aspire.Hosting.13.X.0.nupkg
+# Confirm the feed actually contains stabilized Aspire packages (i.e. Aspire.Hosting.13.X.0.nupkg
 # without a -dev/-preview suffix). Otherwise this smoke would be checking the wrong shape.
 if ! ls "$LOCAL_FEED"/Aspire.Hosting.[0-9]*.[0-9]*.[0-9]*.nupkg > /dev/null 2>&1; then
     echo "❌ No stable Aspire.Hosting.*.nupkg in $LOCAL_FEED. Did pack run with StabilizePackageVersion=true?"
@@ -80,15 +87,22 @@ if ! ls "$LOCAL_FEED"/Aspire.Hosting.[0-9]*.[0-9]*.[0-9]*.nupkg > /dev/null 2>&1
     exit 1
 fi
 
+# Same expectation for the templates package — `aspire new` needs it installable from the feed.
+if ! ls "$LOCAL_FEED"/Aspire.ProjectTemplates.[0-9]*.[0-9]*.[0-9]*.nupkg > /dev/null 2>&1; then
+    echo "❌ No stable Aspire.ProjectTemplates.*.nupkg in $LOCAL_FEED."
+    echo "   Did pack run with StabilizePackageVersion=true (and without -p:SkipProjectTemplates)?"
+    exit 1
+fi
+
 WORK_DIR="$(mktemp -d -t aspire-stab-smoke-XXXXXXXX)"
 # Clean up on any exit; -f tolerates the dir being already gone if cleanup ran inside the script.
 trap 'rm -rf "$WORK_DIR"' EXIT
-echo "Work dir:    $WORK_DIR"
+echo "Work dir:      $WORK_DIR"
 
 # Build the CLI project up-front (under stabilization) so subsequent `dotnet run` invocations
 # from inside the temp dir don't trigger a build in the test working directory (which would
 # pull in the temp dir's NuGet.config and try to restore the CLI's own dependencies against
-# our locally-only feed).
+# our local-only feed).
 echo ""
 echo "→ Building Aspire.Cli (stabilized) for use as the smoke driver"
 (
@@ -115,45 +129,96 @@ run_aspire() {
     )
 }
 
-echo ""
-echo "→ aspire init --language csharp --suppress-agent-init"
-# --language csharp suppresses the language prompt.
-# --suppress-agent-init suppresses the agent-skill install prompt.
-# Together these make init non-interactive (the two prompts above are the only ones init
-# raises by default — see InitCommand.cs:97-105 and InitCommand.cs:162-165).
-# < /dev/null is belt-and-braces: if a new prompt is ever added without a corresponding
-# suppression flag we want this script to fail fast rather than hang the CI job.
-(cd "$WORK_DIR" && run_aspire init --language csharp --suppress-agent-init < /dev/null)
-
-# Verify init produced what we expect.
-for required in apphost.cs aspire.config.json; do
-    if [ ! -f "$WORK_DIR/$required" ]; then
-        echo "❌ aspire init did not create $required"
-        ls -la "$WORK_DIR"
-        exit 1
-    fi
-done
-echo "  ✓ apphost.cs and aspire.config.json present"
-
-# Replace whatever NuGet.config init wrote with one that points only at the local stable
-# feed. This makes the subsequent restore deterministic and offline-friendly:
-#   * If a stable Aspire package transitively requires a preview-only package, restore must
-#     fail here (not silently fall back to nuget.org).
-#   * Avoids depending on network availability inside the CI job.
+# Stage a NuGet.config in the work dir BEFORE running `aspire new`. The CLI itself fetches
+# the templates package via NuGet, and the subsequent restore needs both Aspire.* (from local
+# stable) and non-Aspire transitives (from the public dotnet feeds). packageSourceMapping pins
+# Aspire.* to our feed so a missing/preview Aspire dep fails fast rather than silently falling
+# back to nuget.org. Mirrors the source-mapping pattern in tests/Shared/nuget-with-package-
+# source-mapping.config used by Helix.
 cat > "$WORK_DIR/NuGet.config" <<EOF
 <?xml version="1.0" encoding="utf-8"?>
 <configuration>
+  <fallbackPackageFolders>
+    <clear />
+  </fallbackPackageFolders>
   <packageSources>
     <clear />
     <add key="local-stable" value="$LOCAL_FEED" />
+    <add key="dotnet-public" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public/nuget/v3/index.json" />
+    <add key="dotnet-eng" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-eng/nuget/v3/index.json" />
+    <add key="dotnet9" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet9/nuget/v3/index.json" />
+    <add key="dotnet10" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet10/nuget/v3/index.json" />
   </packageSources>
+  <packageSourceMapping>
+    <packageSource key="local-stable">
+      <package pattern="Aspire*" />
+    </packageSource>
+    <packageSource key="dotnet-public">
+      <package pattern="*" />
+    </packageSource>
+    <packageSource key="dotnet-eng">
+      <package pattern="*" />
+    </packageSource>
+    <packageSource key="dotnet9">
+      <package pattern="*" />
+    </packageSource>
+    <packageSource key="dotnet10">
+      <package pattern="*" />
+    </packageSource>
+  </packageSourceMapping>
+  <disabledPackageSources>
+    <clear />
+  </disabledPackageSources>
 </configuration>
 EOF
-echo "  ✓ NuGet.config overridden to local-stable feed only"
+echo "  ✓ Source-mapped NuGet.config written (Aspire* -> local-stable; everything else -> public dotnet feeds)"
+
+PROJECT_NAME="MyAspireApp"
+echo ""
+echo "→ aspire new aspire-empty --name $PROJECT_NAME --output $PROJECT_NAME --language csharp --suppress-agent-init --localhost-tld false"
+# Flags chosen to make the command fully non-interactive:
+#   --language csharp        suppresses the language prompt
+#   --suppress-agent-init    suppresses the "configure AI agent environments" prompt
+#   --localhost-tld false    suppresses the localhost-tld prompt
+# --source pins the templates-package fetch to our local-stable feed, so we test the templates
+# we just packed (not whatever's on nuget.org).
+# < /dev/null is belt-and-braces: if a new prompt is ever added without a corresponding
+# suppression flag we want this script to fail fast rather than hang the CI job.
+(
+    cd "$WORK_DIR"
+    run_aspire new aspire-empty \
+        --name "$PROJECT_NAME" \
+        --output "$PROJECT_NAME" \
+        --source "$LOCAL_FEED" \
+        --language csharp \
+        --suppress-agent-init \
+        --localhost-tld false \
+        < /dev/null
+)
+
+# Verify the template produced something. `aspire-empty` may resolve to either the
+# single-file AppHost shape (apphost.cs + aspire.config.json) or a project-based shape
+# (<Name>.AppHost.csproj + <Name>.ServiceDefaults.csproj), depending on the CLI's template
+# resolution. Accept either — both are valid AppHost layouts that aspire restore can drive.
+PROJECT_DIR="$WORK_DIR/$PROJECT_NAME"
+if [ ! -d "$PROJECT_DIR" ]; then
+    echo "❌ aspire new did not create the project directory $PROJECT_DIR"
+    exit 1
+fi
+if [ -f "$PROJECT_DIR/apphost.cs" ] && [ -f "$PROJECT_DIR/aspire.config.json" ]; then
+    echo "  ✓ Single-file AppHost detected (apphost.cs + aspire.config.json)"
+elif [ -f "$PROJECT_DIR/$PROJECT_NAME.AppHost/$PROJECT_NAME.AppHost.csproj" ]; then
+    echo "  ✓ Project-based AppHost detected ($PROJECT_NAME.AppHost.csproj)"
+else
+    echo "❌ aspire new produced an unrecognized layout in $PROJECT_DIR"
+    echo "   Contents (depth 3):"
+    find "$PROJECT_DIR" -maxdepth 3 -type f 2>/dev/null || true
+    exit 1
+fi
 
 echo ""
-echo "→ aspire restore (against local stable feed)"
-(cd "$WORK_DIR" && run_aspire restore < /dev/null)
+echo "→ aspire restore (against local stable feed + public dotnet feeds for transitives)"
+(cd "$PROJECT_DIR" && run_aspire restore < /dev/null)
 
 echo ""
-echo "✅ Stabilization smoke passed: aspire init + restore both succeeded against stable packages."
+echo "✅ Stabilization smoke passed: aspire new aspire-empty + restore both succeeded against stable packages."

--- a/eng/scripts/stabilization-smoke-init-restore.sh
+++ b/eng/scripts/stabilization-smoke-init-restore.sh
@@ -3,15 +3,32 @@
 #
 # Purpose
 # -------
-# This is a moderate-coverage smoke that lives outside the regular CI test path so it can
-# always exercise the "everything is stable" build shape, regardless of whether the rest of
-# the PR's CI is running on prerelease versions (which it is — see ci.yml). It catches:
+# Most regular PR CI runs unstable (DotNetFinalVersionKind=prerelease), which means a class of
+# bugs that only show up under "everything is stable" is invisible until the actual
+# stabilization PR. The canonical case:
 #
-#   * Restore-time failures for stable AppHosts referencing packages whose csproj sets
-#     SuppressFinalPackageVersion=true (the bucket of issues that historically forced past
-#     stabilization PRs to hand-skip whole test classes).
-#   * Template version-pinning regressions where `aspire init` emits an SDK or package
-#     reference that doesn't resolve against the stable feed.
+#   Suppose Aspire.Hosting.Foo (which is NOT marked <SuppressFinalPackageVersion>true</...>,
+#   so it ships as stable when we stabilize) adds a PackageReference to Foo.Lib, but Foo.Lib
+#   is still publishing preview versions only. Under a prerelease PR build, both Aspire.Hosting.Foo
+#   and Foo.Lib are prerelease and restore happily. The moment we flip StabilizePackageVersion
+#   on, Aspire.Hosting.Foo becomes stable while its transitive dep is still prerelease — and
+#   the build breaks (NU5104 at pack time, or restore failures downstream).
+#
+# Without a check like this one we only catch that class of regression at stabilization time,
+# usually within days of a release. With this check it surfaces on the PR that introduces the
+# preview dependency, so the integration author can decide up front whether to:
+#   - flip <SuppressFinalPackageVersion>true</...> on Aspire.Hosting.Foo (ship it as preview), or
+#   - request Foo.Lib to stabilize before our next stable release.
+#
+# This script (the smoke) handles the end-to-end consumer flow specifically:
+#   * That `aspire init` emits an SDK / package reference shape that actually resolves against
+#     the stable feed (catches template version-pinning regressions).
+#   * That `aspire restore` succeeds end-to-end against a feed that contains only the stable
+#     packages we'd ship — i.e. no silent fallback to nuget.org papering over a missing dep.
+#
+# The pack-time NU5104 check (which is the primary detector for the Foo.Lib scenario above) is
+# the previous step in the stabilization_check job in ci.yml — this script complements it by
+# exercising the user-visible CLI workflow against the same stably-built feed.
 #
 # Prerequisites
 # -------------

--- a/eng/scripts/stabilization-smoke-init-restore.sh
+++ b/eng/scripts/stabilization-smoke-init-restore.sh
@@ -42,12 +42,18 @@
 #   ./build.sh -pack -p:StabilizePackageVersion=true -p:SkipTestProjects=true \
 #              -p:SkipPlaygroundProjects=true -p:SkipNativeBuild=true
 #   ./eng/scripts/stabilization-smoke-init-restore.sh
+#
+# Override defaults via env vars when needed:
+#   STABILIZATION_SMOKE_CONFIGURATION  Build configuration the pack step used (default: Debug)
+#   STABILIZATION_SMOKE_FEED           Absolute path to the local NuGet feed
+#                                      (default: $REPO_ROOT/artifacts/packages/$CONFIG/Shipping)
 
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
-LOCAL_FEED="$REPO_ROOT/artifacts/packages/Debug/Shipping"
+CONFIGURATION="${STABILIZATION_SMOKE_CONFIGURATION:-Debug}"
+LOCAL_FEED="${STABILIZATION_SMOKE_FEED:-$REPO_ROOT/artifacts/packages/$CONFIGURATION/Shipping}"
 ASPIRE_CLI_PROJECT="$REPO_ROOT/src/Aspire.Cli/Aspire.Cli.csproj"
 # Use the repo-local SDK that restore.sh / build.sh install under .dotnet/. The wrapper script
 # also sets DOTNET_SKIP_FIRST_TIME_EXPERIENCE and resolves the SDK version from global.json,
@@ -55,8 +61,9 @@ ASPIRE_CLI_PROJECT="$REPO_ROOT/src/Aspire.Cli/Aspire.Cli.csproj"
 DOTNET="$REPO_ROOT/dotnet.sh"
 
 echo "=== Stabilization smoke: aspire init + restore ==="
-echo "Repo root:   $REPO_ROOT"
-echo "Local feed:  $LOCAL_FEED"
+echo "Repo root:     $REPO_ROOT"
+echo "Configuration: $CONFIGURATION"
+echo "Local feed:    $LOCAL_FEED"
 
 if [ ! -d "$LOCAL_FEED" ]; then
     echo "❌ Local feed not found at: $LOCAL_FEED"
@@ -87,7 +94,7 @@ echo "→ Building Aspire.Cli (stabilized) for use as the smoke driver"
 (
     cd "$REPO_ROOT"
     "$DOTNET" build "$ASPIRE_CLI_PROJECT" \
-        -c Debug \
+        -c "$CONFIGURATION" \
         -p:StabilizePackageVersion=true \
         --nologo -v quiet
 )
@@ -100,7 +107,7 @@ run_aspire() {
     (
         cd "$REPO_ROOT"
         "$DOTNET" run --project "$ASPIRE_CLI_PROJECT" \
-            -c Debug \
+            -c "$CONFIGURATION" \
             --no-build \
             --no-launch-profile \
             -p:StabilizePackageVersion=true \

--- a/eng/scripts/stabilization-smoke-init-restore.sh
+++ b/eng/scripts/stabilization-smoke-init-restore.sh
@@ -8,8 +8,8 @@
 # the PR's CI is running on prerelease versions (which it is — see ci.yml). It catches:
 #
 #   * Restore-time failures for stable AppHosts referencing packages whose csproj sets
-#     SuppressFinalPackageVersion=true (the bucket of issues that historically forced 13.1
-#     / 13.2 / 13.3 stabilization PRs to hand-skip whole test classes — see #15335).
+#     SuppressFinalPackageVersion=true (the bucket of issues that historically forced past
+#     stabilization PRs to hand-skip whole test classes).
 #   * Template version-pinning regressions where `aspire init` emits an SDK or package
 #     reference that doesn't resolve against the stable feed.
 #

--- a/eng/scripts/stabilization-smoke-init-restore.sh
+++ b/eng/scripts/stabilization-smoke-init-restore.sh
@@ -117,6 +117,13 @@ echo "→ Building Aspire.Cli (stabilized) for use as the smoke driver"
 # also prevents `dotnet run` from re-resolving NuGet against the temp-dir NuGet.config.
 # --no-launch-profile keeps src/Aspire.Cli/Properties/launchSettings.json out of the picture
 # so the CLI receives exactly the args we pass after `--`.
+# --non-interactive (a recursive root-level option, see Aspire.Cli/Commands/RootCommand.cs:
+# NonInteractiveOption with Recursive = true) is the canonical "I'm in CI, never prompt" flag.
+# It causes the CLI to fail fast on any prompt that doesn't have an explicit answer instead of
+# silently defaulting or hanging on stdin. The explicit suppression flags below (--language,
+# --suppress-agent-init, --localhost-tld) supply the actual *values* we want for the known
+# prompts; --non-interactive guards against any future prompt being added without a matching
+# suppression flag, and against ambient prompts like the certificate trust check.
 run_aspire() {
     (
         cd "$REPO_ROOT"
@@ -125,7 +132,7 @@ run_aspire() {
             --no-build \
             --no-launch-profile \
             -p:StabilizePackageVersion=true \
-            -- "$@"
+            -- --non-interactive "$@"
     )
 }
 

--- a/eng/scripts/stabilization-smoke-init-restore.sh
+++ b/eng/scripts/stabilization-smoke-init-restore.sh
@@ -24,9 +24,17 @@
 # This script (the smoke) handles the end-to-end consumer flow specifically. It exercises:
 #   * Template integrity — that `aspire new aspire-empty` produces a buildable project shape
 #     using the stably-built Aspire.ProjectTemplates package.
-#   * Template version-pinning — that the SDK reference (Aspire.AppHost.Sdk) and PackageReferences
-#     emitted by the template resolve against the stable feed for Aspire.* packages.
+#   * Template version-pinning — that the SDK reference (Aspire.AppHost.Sdk) and any
+#     PackageReferences emitted by the template resolve against the stable feed for
+#     Aspire.* packages.
 #   * Restore wiring — that `aspire restore` succeeds end-to-end for the generated project tree.
+#
+# Coverage NOTE: today `aspire new aspire-empty` resolves to a single-file `apphost.cs` shape
+# whose only NuGet dependency is `Aspire.AppHost.Sdk` (which transitively pulls
+# Aspire.Hosting.AppHost / Aspire.Hosting). So this smoke validates that the SDK reference path
+# is wired correctly through to the local stable feed — NOT that every Aspire integration
+# package restores. Per-integration NU5104 (stable depends on preview) detection comes from the
+# previous step in the stabilization_check job (the stabilized pack). The two are complementary.
 #
 # Aspire.* packages MUST come from the local stable feed (so missing/preview-only Aspire packages
 # fail restore here, exactly as they would on a real stabilization branch). Non-Aspire deps
@@ -78,11 +86,19 @@ if [ ! -d "$LOCAL_FEED" ]; then
     exit 1
 fi
 
-# Confirm the feed actually contains stabilized Aspire packages (i.e. Aspire.Hosting.13.X.0.nupkg
-# without a -dev/-preview suffix). Otherwise this smoke would be checking the wrong shape.
-if ! ls "$LOCAL_FEED"/Aspire.Hosting.[0-9]*.[0-9]*.[0-9]*.nupkg > /dev/null 2>&1; then
-    echo "❌ No stable Aspire.Hosting.*.nupkg in $LOCAL_FEED. Did pack run with StabilizePackageVersion=true?"
-    echo "   Found nupkgs:"
+# Confirm the feed actually contains stabilized Aspire packages — i.e. e.g. Aspire.Hosting.13.4.0.nupkg
+# with no -dev/-preview/-rc/-alpha/-beta suffix. Without this guard a local-repro run that forgot
+# to pass StabilizePackageVersion=true to the pack would sail past, and the smoke would silently
+# be validating a prerelease build instead of a stable one. (CI is safe regardless because the
+# prior pack step always passes the flag, but local-repro paths through this script need the check.)
+# bash globs treat `[0-9]*` as "one digit then any chars", so the glob alone would match
+# 13.4.0-dev.nupkg too. The grep -v filter is what enforces "no prerelease suffix."
+if ! ls "$LOCAL_FEED"/Aspire.Hosting.[0-9]*.[0-9]*.[0-9]*.nupkg 2>/dev/null \
+        | grep -vE -- '-(dev|preview|rc|alpha|beta|ci|pr)\.' \
+        | grep -q .; then
+    echo "❌ No stable (no -dev/-preview/-rc/-alpha/-beta) Aspire.Hosting.*.nupkg in $LOCAL_FEED."
+    echo "   Did pack run with StabilizePackageVersion=true?"
+    echo "   Aspire.Hosting nupkgs found:"
     ls "$LOCAL_FEED"/Aspire.Hosting.*.nupkg 2>/dev/null | head -5 || true
     exit 1
 fi
@@ -113,27 +129,30 @@ echo "→ Building Aspire.Cli (stabilized) for use as the smoke driver"
         --nologo -v quiet
 )
 
-# Helper: invoke the CLI from anywhere. We use --no-build because we just built above; this
-# also prevents `dotnet run` from re-resolving NuGet against the temp-dir NuGet.config.
-# --no-launch-profile keeps src/Aspire.Cli/Properties/launchSettings.json out of the picture
-# so the CLI receives exactly the args we pass after `--`.
-# --non-interactive (a recursive root-level option, see Aspire.Cli/Commands/RootCommand.cs:
-# NonInteractiveOption with Recursive = true) is the canonical "I'm in CI, never prompt" flag.
-# It causes the CLI to fail fast on any prompt that doesn't have an explicit answer instead of
-# silently defaulting or hanging on stdin. The explicit suppression flags below (--language,
-# --suppress-agent-init, --localhost-tld) supply the actual *values* we want for the known
-# prompts; --non-interactive guards against any future prompt being added without a matching
-# suppression flag, and against ambient prompts like the certificate trust check.
+# Helper: invoke the CLI via the repo-local SDK. Intentionally does NOT change directory —
+# the caller's CWD is what propagates to the spawned aspire process. That matters because:
+#   * aspire's --output (and other path-based) flags resolve relative paths against
+#     Environment.CurrentDirectory.
+#   * NuGet config-walk starts from CWD, so we want the temp-dir NuGet.config (with the
+#     Aspire* -> local-stable source mapping) to be the one found, not the repo's own
+#     NuGet.config which points at dnceng-internal feeds.
+# (`./dotnet.sh` resolves the local SDK via $scriptroot — independent of CWD — so we don't
+# need to be in $REPO_ROOT for the SDK lookup.)
+# --no-build because we just built above; --no-launch-profile keeps src/Aspire.Cli/Properties/
+# launchSettings.json from interfering with our explicit args. --non-interactive (a recursive
+# root-level option, see Aspire.Cli/Commands/RootCommand.cs: NonInteractiveOption with
+# Recursive = true) is the canonical "I'm in CI, never prompt" flag. The explicit suppression
+# flags below (--language, --suppress-agent-init, --localhost-tld) supply the actual *values*
+# we want for the known prompts; --non-interactive guards against any future prompt being
+# added without a matching suppression flag, and against ambient prompts like the certificate
+# trust check.
 run_aspire() {
-    (
-        cd "$REPO_ROOT"
-        "$DOTNET" run --project "$ASPIRE_CLI_PROJECT" \
-            -c "$CONFIGURATION" \
-            --no-build \
-            --no-launch-profile \
-            -p:StabilizePackageVersion=true \
-            -- --non-interactive "$@"
-    )
+    "$DOTNET" run --project "$ASPIRE_CLI_PROJECT" \
+        -c "$CONFIGURATION" \
+        --no-build \
+        --no-launch-profile \
+        -p:StabilizePackageVersion=true \
+        -- --non-interactive "$@"
 }
 
 # Stage a NuGet.config in the work dir BEFORE running `aspire new`. The CLI itself fetches
@@ -169,21 +188,24 @@ EOF
 echo "  ✓ Source-mapped NuGet.config written (Aspire* -> local-stable; everything else -> nuget.org)"
 
 PROJECT_NAME="MyAspireApp"
+# Absolute path so `--output` is unambiguous regardless of CWD.
+PROJECT_DIR="$WORK_DIR/$PROJECT_NAME"
 echo ""
-echo "→ aspire new aspire-empty --name $PROJECT_NAME --output $PROJECT_NAME --language csharp --suppress-agent-init --localhost-tld false"
-# Flags chosen to make the command fully non-interactive:
+echo "→ aspire new aspire-empty --name $PROJECT_NAME --output $PROJECT_DIR --language csharp --suppress-agent-init --localhost-tld false"
+# Flags chosen to make the command fully non-interactive (in addition to --non-interactive
+# baked into run_aspire):
 #   --language csharp        suppresses the language prompt
 #   --suppress-agent-init    suppresses the "configure AI agent environments" prompt
 #   --localhost-tld false    suppresses the localhost-tld prompt
 # --source pins the templates-package fetch to our local-stable feed, so we test the templates
 # we just packed (not whatever's on nuget.org).
-# < /dev/null is belt-and-braces: if a new prompt is ever added without a corresponding
-# suppression flag we want this script to fail fast rather than hang the CI job.
+# CWD is $WORK_DIR so the temp NuGet.config (with Aspire* source-mapped to local-stable) is
+# the one NuGet finds via its config walk.
 (
     cd "$WORK_DIR"
     run_aspire new aspire-empty \
         --name "$PROJECT_NAME" \
-        --output "$PROJECT_NAME" \
+        --output "$PROJECT_DIR" \
         --source "$LOCAL_FEED" \
         --language csharp \
         --suppress-agent-init \
@@ -195,7 +217,6 @@ echo "→ aspire new aspire-empty --name $PROJECT_NAME --output $PROJECT_NAME --
 # single-file AppHost shape (apphost.cs + aspire.config.json) or a project-based shape
 # (<Name>.AppHost.csproj + <Name>.ServiceDefaults.csproj), depending on the CLI's template
 # resolution. Accept either — both are valid AppHost layouts that aspire restore can drive.
-PROJECT_DIR="$WORK_DIR/$PROJECT_NAME"
 if [ ! -d "$PROJECT_DIR" ]; then
     echo "❌ aspire new did not create the project directory $PROJECT_DIR"
     exit 1
@@ -213,6 +234,8 @@ fi
 
 echo ""
 echo "→ aspire restore (against local stable feed for Aspire packages, nuget.org for everything else)"
+# Run from $PROJECT_DIR so aspire restore discovers aspire.config.json there AND so the
+# nearest NuGet.config (the one we wrote at $WORK_DIR) is the one used.
 (cd "$PROJECT_DIR" && run_aspire restore < /dev/null)
 
 echo ""

--- a/eng/scripts/stabilization-smoke-init-restore.sh
+++ b/eng/scripts/stabilization-smoke-init-restore.sh
@@ -1,0 +1,135 @@
+#!/usr/bin/env bash
+# Stabilization smoke test: aspire init + aspire restore against the locally-built stable feed.
+#
+# Purpose
+# -------
+# This is a moderate-coverage smoke that lives outside the regular CI test path so it can
+# always exercise the "everything is stable" build shape, regardless of whether the rest of
+# the PR's CI is running on prerelease versions (which it is — see ci.yml). It catches:
+#
+#   * Restore-time failures for stable AppHosts referencing packages whose csproj sets
+#     SuppressFinalPackageVersion=true (the bucket of issues that historically forced 13.1
+#     / 13.2 / 13.3 stabilization PRs to hand-skip whole test classes — see #15335).
+#   * Template version-pinning regressions where `aspire init` emits an SDK or package
+#     reference that doesn't resolve against the stable feed.
+#
+# Prerequisites
+# -------------
+# This script assumes a stabilized pack has already populated $REPO_ROOT/artifacts/packages
+# (the ci.yml stabilization_check job does this in the preceding step via
+# `./build.sh -pack /p:StabilizePackageVersion=true ...`). For local repro, run that build
+# first.
+#
+# Local repro
+# -----------
+#   ./build.sh -pack -p:StabilizePackageVersion=true -p:SkipTestProjects=true \
+#              -p:SkipPlaygroundProjects=true -p:SkipNativeBuild=true
+#   ./eng/scripts/stabilization-smoke-init-restore.sh
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+LOCAL_FEED="$REPO_ROOT/artifacts/packages/Debug/Shipping"
+ASPIRE_CLI_PROJECT="$REPO_ROOT/src/Aspire.Cli/Aspire.Cli.csproj"
+# Use the repo-local SDK that restore.sh / build.sh install under .dotnet/. The wrapper script
+# also sets DOTNET_SKIP_FIRST_TIME_EXPERIENCE and resolves the SDK version from global.json,
+# which is what we need on CI runners that don't have a system-wide .NET 10 SDK.
+DOTNET="$REPO_ROOT/dotnet.sh"
+
+echo "=== Stabilization smoke: aspire init + restore ==="
+echo "Repo root:   $REPO_ROOT"
+echo "Local feed:  $LOCAL_FEED"
+
+if [ ! -d "$LOCAL_FEED" ]; then
+    echo "❌ Local feed not found at: $LOCAL_FEED"
+    echo "   Run a stabilized pack first (see prerequisites at the top of this script)."
+    exit 1
+fi
+
+# Confirm the feed actually contains stabilized Aspire packages (i.e. e.g. Aspire.Hosting.13.X.0.nupkg
+# without a -dev/-preview suffix). Otherwise this smoke would be checking the wrong shape.
+if ! ls "$LOCAL_FEED"/Aspire.Hosting.[0-9]*.[0-9]*.[0-9]*.nupkg > /dev/null 2>&1; then
+    echo "❌ No stable Aspire.Hosting.*.nupkg in $LOCAL_FEED. Did pack run with StabilizePackageVersion=true?"
+    echo "   Found nupkgs:"
+    ls "$LOCAL_FEED"/Aspire.Hosting.*.nupkg 2>/dev/null | head -5 || true
+    exit 1
+fi
+
+WORK_DIR="$(mktemp -d -t aspire-stab-smoke-XXXXXXXX)"
+# Clean up on any exit; -f tolerates the dir being already gone if cleanup ran inside the script.
+trap 'rm -rf "$WORK_DIR"' EXIT
+echo "Work dir:    $WORK_DIR"
+
+# Build the CLI project up-front (under stabilization) so subsequent `dotnet run` invocations
+# from inside the temp dir don't trigger a build in the test working directory (which would
+# pull in the temp dir's NuGet.config and try to restore the CLI's own dependencies against
+# our locally-only feed).
+echo ""
+echo "→ Building Aspire.Cli (stabilized) for use as the smoke driver"
+(
+    cd "$REPO_ROOT"
+    "$DOTNET" build "$ASPIRE_CLI_PROJECT" \
+        -c Debug \
+        -p:StabilizePackageVersion=true \
+        --nologo -v quiet
+)
+
+# Helper: invoke the CLI from anywhere. We use --no-build because we just built above; this
+# also prevents `dotnet run` from re-resolving NuGet against the temp-dir NuGet.config.
+# --no-launch-profile keeps src/Aspire.Cli/Properties/launchSettings.json out of the picture
+# so the CLI receives exactly the args we pass after `--`.
+run_aspire() {
+    (
+        cd "$REPO_ROOT"
+        "$DOTNET" run --project "$ASPIRE_CLI_PROJECT" \
+            -c Debug \
+            --no-build \
+            --no-launch-profile \
+            -p:StabilizePackageVersion=true \
+            -- "$@"
+    )
+}
+
+echo ""
+echo "→ aspire init --language csharp --suppress-agent-init"
+# --language csharp suppresses the language prompt.
+# --suppress-agent-init suppresses the agent-skill install prompt.
+# Together these make init non-interactive (the two prompts above are the only ones init
+# raises by default — see InitCommand.cs:97-105 and InitCommand.cs:162-165).
+# < /dev/null is belt-and-braces: if a new prompt is ever added without a corresponding
+# suppression flag we want this script to fail fast rather than hang the CI job.
+(cd "$WORK_DIR" && run_aspire init --language csharp --suppress-agent-init < /dev/null)
+
+# Verify init produced what we expect.
+for required in apphost.cs aspire.config.json; do
+    if [ ! -f "$WORK_DIR/$required" ]; then
+        echo "❌ aspire init did not create $required"
+        ls -la "$WORK_DIR"
+        exit 1
+    fi
+done
+echo "  ✓ apphost.cs and aspire.config.json present"
+
+# Replace whatever NuGet.config init wrote with one that points only at the local stable
+# feed. This makes the subsequent restore deterministic and offline-friendly:
+#   * If a stable Aspire package transitively requires a preview-only package, restore must
+#     fail here (not silently fall back to nuget.org).
+#   * Avoids depending on network availability inside the CI job.
+cat > "$WORK_DIR/NuGet.config" <<EOF
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <packageSources>
+    <clear />
+    <add key="local-stable" value="$LOCAL_FEED" />
+  </packageSources>
+</configuration>
+EOF
+echo "  ✓ NuGet.config overridden to local-stable feed only"
+
+echo ""
+echo "→ aspire restore (against local stable feed)"
+(cd "$WORK_DIR" && run_aspire restore < /dev/null)
+
+echo ""
+echo "✅ Stabilization smoke passed: aspire init + restore both succeeded against stable packages."

--- a/src/Directory.Build.targets
+++ b/src/Directory.Build.targets
@@ -31,4 +31,13 @@
       <PackageName Include="$(PackageId)" Condition="'$(IsPackable)' == 'true'" WithPackageVersion="$(PackageVersion)" />
     </ItemGroup>
   </Target>
+
+  <!-- Used by Aspire.RepoTesting.targets to dynamically compute per-package versions for Helix testing.
+       Returns the PackageId and its computed PackageVersion for packable projects. The version is computed
+       per-project by the Arcade SDK, respecting SuppressFinalPackageVersion, StabilizePackageVersion, etc. -->
+  <Target Name="ReturnPackageVersion" Returns="@(_ReturnedPackageVersion)">
+    <ItemGroup>
+      <_ReturnedPackageVersion Include="$(PackageId)" Version="$(PackageVersion)" Condition="'$(IsPackable)' == 'true'" />
+    </ItemGroup>
+  </Target>
 </Project>

--- a/src/Directory.Build.targets
+++ b/src/Directory.Build.targets
@@ -34,7 +34,14 @@
 
   <!-- Used by Aspire.RepoTesting.targets to dynamically compute per-package versions for Helix testing.
        Returns the PackageId and its computed PackageVersion for packable projects. The version is computed
-       per-project by the Arcade SDK, respecting SuppressFinalPackageVersion, StabilizePackageVersion, etc. -->
+       per-project by the Arcade SDK, respecting SuppressFinalPackageVersion, StabilizePackageVersion, etc.
+
+       This target reads $(PackageVersion) declaratively (i.e. as a property whose value Arcade has already
+       set via property groups during evaluation, not via a prior target). That is correct as of the current
+       Arcade SDK. If a future Arcade bump moves PackageVersion computation into a target body, callers of
+       this target may observe the pre-target value; the Helix package-versions generation in
+       tests/Shared/RepoTesting/Aspire.RepoTesting.targets would then need an explicit dependency on whatever
+       target sets PackageVersion. -->
   <Target Name="ReturnPackageVersion" Returns="@(_ReturnedPackageVersion)">
     <ItemGroup>
       <_ReturnedPackageVersion Include="$(PackageId)" Version="$(PackageVersion)" Condition="'$(IsPackable)' == 'true'" />

--- a/tests/Shared/RepoTesting/Aspire.RepoTesting.targets
+++ b/tests/Shared/RepoTesting/Aspire.RepoTesting.targets
@@ -33,7 +33,7 @@
     `AspireProjectOrPackageReference` - maps to projects in `src/` or `src/Components/`
   -->
 
-  <Import Project="Sdk.props" Sdk="Aspire.AppHost.Sdk" Version="$(PackageVersion)" Condition="'$(IsAspireHost)' == 'true' and '$(RepoRoot)' == '' and '$(TestsRunningOutsideOfRepo)' == 'true'" />
+  <Import Project="Sdk.props" Sdk="Aspire.AppHost.Sdk" Version="$(AspireAppHostSdkVersion)" Condition="'$(IsAspireHost)' == 'true' and '$(RepoRoot)' == '' and '$(TestsRunningOutsideOfRepo)' == 'true'" />
 
   <PropertyGroup>
     <!-- copy by default only when archiving tests, and for test projects that support running out of repo -->
@@ -107,7 +107,33 @@
 
   <!-- Generate before the build so the projects can use this in a <None ..> item -->
   <Target Name="_GeneratePackagesVersionsProps" BeforeTargets="BeforeBuild" Condition="'$(DeployOutsideOfRepoSupportFiles)' == 'true' and '$(IsTestUtilityProject)' != 'true'">
-    <!-- Duplicate all the @(PackageVersion) items with the evaluated versions -->
+    <!-- Enumerate all src projects to get their per-package versions (respects SuppressFinalPackageVersion, etc.) -->
+    <ItemGroup>
+      <_SrcProjectsForVersions Include="$(RepoRoot)src\**\*.csproj"
+                               Exclude="$(RepoRoot)src\Aspire.ProjectTemplates\templates\**\*.csproj" />
+    </ItemGroup>
+
+    <MSBuild Projects="@(_SrcProjectsForVersions)"
+             Targets="ReturnPackageVersion"
+             BuildInParallel="true">
+      <Output TaskParameter="TargetOutputs" ItemName="_AspirePackageVersions" />
+    </MSBuild>
+
+    <!-- Format Aspire package versions as XML PackageVersion entries -->
+    <ItemGroup>
+      <_AspirePackageVersionXml Include="@(_AspirePackageVersions -> '&lt;PackageVersion Include=&quot;%(Identity)&quot; Version=&quot;%(Version)&quot; /&gt;')" />
+    </ItemGroup>
+
+    <!-- Extract the Aspire.AppHost.Sdk version for SDK imports in Aspire.RepoTesting.targets -->
+    <FindInList List="@(_AspirePackageVersions)" ItemSpecToFind="Aspire.AppHost.Sdk">
+      <Output TaskParameter="ItemFound" ItemName="_AppHostSdkItem" />
+    </FindInList>
+
+    <PropertyGroup>
+      <_AspireAppHostSdkVersion>%(_AppHostSdkItem.Version)</_AspireAppHostSdkVersion>
+    </PropertyGroup>
+
+    <!-- Duplicate all the @(PackageVersion) items (3rd-party packages) with the evaluated versions -->
     <ItemGroup>
       <_PackageVersionEvaluated Include="@(PackageVersion -> '&lt;PackageVersion Include=&quot;%(Identity)&quot; Version=&quot;%(Version)&quot; /&gt;')" />
 
@@ -126,12 +152,18 @@
       <Project>
         <PropertyGroup>
           <PackageVersion>$(PackageVersion)</PackageVersion>
+          <AspireAppHostSdkVersion>$(_AspireAppHostSdkVersion)</AspireAppHostSdkVersion>
 
           <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
         </PropertyGroup>
 
-        <ItemGroup>
+        <ItemGroup Label="3rd-party packages">
             @(_PackageVersionEvaluated, '
+            ')
+        </ItemGroup>
+
+        <ItemGroup Label="Aspire packages (dynamically computed)">
+            @(_AspirePackageVersionXml, '
             ')
         </ItemGroup>
 
@@ -165,6 +197,6 @@
     <AspireHostingSDKVersion>$(MajorVersion).$(MinorVersion).$(PatchVersion)</AspireHostingSDKVersion>
   </PropertyGroup>
 
-  <Import Project="Sdk.targets" Sdk="Aspire.AppHost.Sdk" Version="$(PackageVersion)" Condition="'$(IsAspireHost)' == 'true' and '$(RepoRoot)' == '' and '$(TestsRunningOutsideOfRepo)' == 'true'" />
+  <Import Project="Sdk.targets" Sdk="Aspire.AppHost.Sdk" Version="$(AspireAppHostSdkVersion)" Condition="'$(IsAspireHost)' == 'true' and '$(RepoRoot)' == '' and '$(TestsRunningOutsideOfRepo)' == 'true'" />
 
 </Project>

--- a/tests/Shared/RepoTesting/Aspire.RepoTesting.targets
+++ b/tests/Shared/RepoTesting/Aspire.RepoTesting.targets
@@ -141,6 +141,13 @@
       <_AspireAppHostSdkVersion>%(_AppHostSdkItem.Version)</_AspireAppHostSdkVersion>
     </PropertyGroup>
 
+    <!-- Hard-fail if Aspire.AppHost.Sdk wasn't enumerated. Without this check the generated
+         Directory.Packages.Versions.props would emit <AspireAppHostSdkVersion></AspireAppHostSdkVersion>
+         and the Helix consumer's <Import Sdk="Aspire.AppHost.Sdk" Version="" /> would later fail
+         with an opaque NuGet SDK-resolution error instead of pointing here. -->
+    <Error Condition="'$(_AspireAppHostSdkVersion)' == ''"
+           Text="ReturnPackageVersion did not yield Aspire.AppHost.Sdk in @(_AspirePackageVersions). Did src/Aspire.AppHost.Sdk/Aspire.AppHost.Sdk.csproj rename/un-pack, or was the project excluded from _SrcProjectsForVersions?" />
+
     <!-- Duplicate all the @(PackageVersion) items (3rd-party packages) with the evaluated versions -->
     <ItemGroup>
       <_PackageVersionEvaluated Include="@(PackageVersion -> '&lt;PackageVersion Include=&quot;%(Identity)&quot; Version=&quot;%(Version)&quot; /&gt;')" />

--- a/tests/Shared/RepoTesting/Aspire.RepoTesting.targets
+++ b/tests/Shared/RepoTesting/Aspire.RepoTesting.targets
@@ -33,6 +33,14 @@
     `AspireProjectOrPackageReference` - maps to projects in `src/` or `src/Components/`
   -->
 
+  <!--
+    $(AspireAppHostSdkVersion) is defined in the generated Directory.Packages.Versions.props
+    (produced by the _GeneratePackagesVersionsProps target below) and reaches this file via:
+      Directory.Packages.props -> Directory.Packages.Helix.props -> Directory.Packages.Versions.props
+    It is only set in the out-of-repo (Helix) consumer build — the same scope this Import is gated on
+    by Condition="...TestsRunningOutsideOfRepo == 'true'". For in-repo builds the SDK is resolved
+    through the in-repo ImportGroup further below, not this Import.
+  -->
   <Import Project="Sdk.props" Sdk="Aspire.AppHost.Sdk" Version="$(AspireAppHostSdkVersion)" Condition="'$(IsAspireHost)' == 'true' and '$(RepoRoot)' == '' and '$(TestsRunningOutsideOfRepo)' == 'true'" />
 
   <PropertyGroup>
@@ -197,6 +205,7 @@
     <AspireHostingSDKVersion>$(MajorVersion).$(MinorVersion).$(PatchVersion)</AspireHostingSDKVersion>
   </PropertyGroup>
 
+  <!-- See note on the matching Sdk.props Import at the top of this file for where $(AspireAppHostSdkVersion) comes from. -->
   <Import Project="Sdk.targets" Sdk="Aspire.AppHost.Sdk" Version="$(AspireAppHostSdkVersion)" Condition="'$(IsAspireHost)' == 'true' and '$(RepoRoot)' == '' and '$(TestsRunningOutsideOfRepo)' == 'true'" />
 
 </Project>

--- a/tests/Shared/RepoTesting/Directory.Packages.Helix.props
+++ b/tests/Shared/RepoTesting/Directory.Packages.Helix.props
@@ -1,84 +1,13 @@
 <Project>
   <Import Project="$(MSBuildThisFileDirectory)Directory.Packages.Versions.props" />
 
-  <ItemGroup Label="Aspire packages">
-    <PackageVersion Include="Aspire.Azure.AI.OpenAI" Version="$(PackageVersion)" />
-    <PackageVersion Include="Aspire.Azure.Data.Tables" Version="$(PackageVersion)" />
-    <PackageVersion Include="Aspire.Azure.Messaging.EventHubs" Version="$(PackageVersion)" />
-    <PackageVersion Include="Aspire.Azure.Messaging.ServiceBus" Version="$(PackageVersion)" />
-    <PackageVersion Include="Aspire.Azure.Messaging.WebPubSub" Version="$(PackageVersion)" />
-    <PackageVersion Include="Aspire.Azure.Search.Documents" Version="$(PackageVersion)" />
-    <PackageVersion Include="Aspire.Azure.Security.KeyVault" Version="$(PackageVersion)" />
-    <PackageVersion Include="Aspire.Azure.Storage.Blobs" Version="$(PackageVersion)" />
-    <PackageVersion Include="Aspire.Azure.Storage.Queues" Version="$(PackageVersion)" />
-    <PackageVersion Include="Aspire.Azure.Npgsql.EntityFrameworkCore.PostgreSQL" Version="$(PackageVersion)" />
-    <PackageVersion Include="Aspire.Confluent.Kafka" Version="$(PackageVersion)" />
-    <PackageVersion Include="Aspire.Hosting" Version="$(PackageVersion)" />
-    <PackageVersion Include="Aspire.Hosting.AppHost" Version="$(PackageVersion)" />
-    <PackageVersion Include="Aspire.Hosting.Azure" Version="$(PackageVersion)" />
-    <PackageVersion Include="Aspire.Hosting.Azure.AppConfiguration" Version="$(PackageVersion)" />
-    <PackageVersion Include="Aspire.Hosting.Azure.AppContainers" Version="$(PackageVersion)" />
-    <PackageVersion Include="Aspire.Hosting.Azure.ApplicationInsights" Version="$(PackageVersion)" />
-    <PackageVersion Include="Aspire.Hosting.Azure.CognitiveServices" Version="$(PackageVersion)" />
-    <PackageVersion Include="Aspire.Hosting.Azure.CosmosDB" Version="$(PackageVersion)" />
-    <PackageVersion Include="Aspire.Hosting.Azure.ContainerRegistry" Version="$(PackageVersion)" />
-    <PackageVersion Include="Aspire.Hosting.Azure.EventHubs" Version="$(PackageVersion)" />
-    <PackageVersion Include="Aspire.Hosting.Azure.Functions" Version="$(PackageVersion)" />
-    <PackageVersion Include="Aspire.Hosting.Azure.KeyVault" Version="$(PackageVersion)" />
-    <PackageVersion Include="Aspire.Hosting.Azure.OperationalInsights" Version="$(PackageVersion)" />
-    <PackageVersion Include="Aspire.Hosting.Azure.PostgreSQL" Version="$(PackageVersion)" />
-    <PackageVersion Include="Aspire.Hosting.Azure.Redis" Version="$(PackageVersion)" />
-    <PackageVersion Include="Aspire.Hosting.Azure.Search" Version="$(PackageVersion)" />
-    <PackageVersion Include="Aspire.Hosting.Azure.ServiceBus" Version="$(PackageVersion)" />
-    <PackageVersion Include="Aspire.Hosting.Azure.SignalR" Version="$(PackageVersion)" />
-    <PackageVersion Include="Aspire.Hosting.Azure.Sql" Version="$(PackageVersion)" />
-    <PackageVersion Include="Aspire.Hosting.Azure.Storage" Version="$(PackageVersion)" />
-    <PackageVersion Include="Aspire.Hosting.Azure.WebPubSub" Version="$(PackageVersion)" />
-    <PackageVersion Include="Aspire.Hosting.Docker" Version="$(PackageVersion)" />
-    <PackageVersion Include="Aspire.Hosting.Garnet" Version="$(PackageVersion)" />
-    <PackageVersion Include="Aspire.Hosting.Kafka" Version="$(PackageVersion)" />
-    <PackageVersion Include="Aspire.Hosting.Keycloak" Version="$(PackageVersion)" />
-    <PackageVersion Include="Aspire.Hosting.Milvus" Version="$(PackageVersion)" />
-    <PackageVersion Include="Aspire.Hosting.MongoDB" Version="$(PackageVersion)" />
-    <PackageVersion Include="Aspire.Hosting.MySql" Version="$(PackageVersion)" />
-    <PackageVersion Include="Aspire.Hosting.Nats" Version="$(PackageVersion)" />
-    <PackageVersion Include="Aspire.Hosting.JavaScript" Version="$(PackageVersion)" />
-    <PackageVersion Include="Aspire.Hosting.Oracle" Version="$(PackageVersion)" />
-    <PackageVersion Include="Aspire.Hosting.Orleans" Version="$(PackageVersion)" />
-    <PackageVersion Include="Aspire.Hosting.PostgreSQL" Version="$(PackageVersion)" />
-    <PackageVersion Include="Aspire.Hosting.Python" Version="$(PackageVersion)" />
-    <PackageVersion Include="Aspire.Hosting.Qdrant" Version="$(PackageVersion)" />
-    <PackageVersion Include="Aspire.Hosting.RabbitMQ" Version="$(PackageVersion)" />
-    <PackageVersion Include="Aspire.Hosting.Redis" Version="$(PackageVersion)" />
-    <PackageVersion Include="Aspire.AppHost.Sdk" Version="$(PackageVersion)" />
-    <PackageVersion Include="Aspire.Hosting.Seq" Version="$(PackageVersion)" />
-    <PackageVersion Include="Aspire.Hosting.SqlServer" Version="$(PackageVersion)" />
-    <PackageVersion Include="Aspire.Hosting.Testing" Version="$(PackageVersion)" />
-    <PackageVersion Include="Aspire.Hosting.Valkey" Version="$(PackageVersion)" />
-    <PackageVersion Include="Aspire.Hosting.Yarp" Version="$(PackageVersion)" />
-
-    <PackageVersion Include="Aspire.Keycloak.Authentication" Version="$(PackageVersion)" />
-    <PackageVersion Include="Aspire.Microsoft.Azure.Cosmos" Version="$(PackageVersion)" />
-    <PackageVersion Include="Aspire.Microsoft.Data.SqlClient" Version="$(PackageVersion)" />
-    <PackageVersion Include="Aspire.Microsoft.EntityFrameworkCore.Cosmos" Version="$(PackageVersion)" />
-    <PackageVersion Include="Aspire.Microsoft.EntityFrameworkCore.SqlServer" Version="$(PackageVersion)" />
-    <PackageVersion Include="Aspire.Milvus.Client" Version="$(PackageVersion)" />
-    <PackageVersion Include="Aspire.MongoDB.Driver" Version="$(PackageVersion)" />
-    <PackageVersion Include="Aspire.MongoDB.Driver.v2" Version="$(PackageVersion)" />
-    <PackageVersion Include="Aspire.MySqlConnector" Version="$(PackageVersion)" />
-    <PackageVersion Include="Aspire.NATS.Net" Version="$(PackageVersion)" />
-    <PackageVersion Include="Aspire.Npgsql" Version="$(PackageVersion)" />
-    <PackageVersion Include="Aspire.Npgsql.EntityFrameworkCore.PostgreSQL" Version="$(PackageVersion)" />
-    <PackageVersion Include="Aspire.Oracle.EntityFrameworkCore" Version="$(PackageVersion)" />
-    <PackageVersion Include="Aspire.Pomelo.EntityFrameworkCore.MySql" Version="$(PackageVersion)" />
-    <PackageVersion Include="Aspire.Qdrant.Client" Version="$(PackageVersion)" />
-    <PackageVersion Include="Aspire.RabbitMQ.Client" Version="$(PackageVersion)" />
-    <PackageVersion Include="Aspire.RabbitMQ.Client.v6" Version="$(PackageVersion)" />
-    <PackageVersion Include="Aspire.Seq" Version="$(PackageVersion)" />
-    <PackageVersion Include="Aspire.StackExchange.Redis" Version="$(PackageVersion)" />
-    <PackageVersion Include="Aspire.StackExchange.Redis.DistributedCaching" Version="$(PackageVersion)" />
-    <PackageVersion Include="Aspire.StackExchange.Redis.OutputCaching" Version="$(PackageVersion)" />
-  </ItemGroup>
+  <!--
+    Aspire package versions are dynamically computed and included in the generated
+    Directory.Packages.Versions.props file. They are produced by calling the ReturnPackageVersion
+    target on each packable src project, which returns the per-project PackageVersion computed by
+    the Arcade SDK (respecting SuppressFinalPackageVersion, StabilizePackageVersion, etc.).
+    See _GeneratePackagesVersionsProps target in Aspire.RepoTesting.targets for details.
+  -->
 
   <ItemGroup Label="For tests">
     <PackageVersion Include="mstest.testadapter" Version="$(MSTestTestAdapterVersion)" />


### PR DESCRIPTION
## 🚨 DO NOT MERGE — DO NOT REVIEW 🚨

This is a **throwaway validation PR**. It exists only to exercise CI for the changes proposed in #15681 by flipping the one knob that those changes claim should be the only knob needed when stabilizing a release.

- **Do not review this PR.** Review #15681 instead.
- **Do not merge this PR.** It will be closed without merging.
- **Do not comment** with code-style suggestions or design feedback — this PR's purpose is just to surface CI signal.

## What this PR does

Flips `StabilizePackageVersion` to `true` in `eng/Versions.props`. That is the *entire* diff (one line). The branch is stacked on top of #15681's `automate-helix-versions` branch — meaning this PR's diff against `main` is the union of #15681's changes + this one-line flip.

## What it is testing

#15681 introduces a mechanism that dynamically computes Helix test package versions, restores PR-time prerelease semantics under stabilization (via `DotNetFinalVersionKind=prerelease` for PR builds), and adds a `stabilization_check` CI job. The claim is:

> Going forward, stabilizing a release for 13.4 (and beyond) is a **single-line change** in `eng/Versions.props`. No more hand-editing of `Directory.Packages.Helix.props`, no more dropping the `compute_version_suffix` step from `ci.yml`, no more `[ActiveIssue]` tags on KubernetesDeploy tests, no more SKIP lists in the polyglot scripts.

This PR tests that claim by performing only the single-line flip and letting CI exercise:

1. **PR build verification** (the unstable / dogfood path): `DotNetFinalVersionKind=prerelease` should keep PR builds producing unique prerelease versions even with `StabilizePackageVersion=true` set globally, so dynamic Helix package versions still line up and dogfood install still verifies a unique build.
2. **`stabilization_check` job**: should still pass under the same global flag, validating that PR-time stable-pack + version-sensitive CLI smoke + `aspire init` + `aspire restore` against the stable feed all succeed without any of the historical workarounds.
3. **Helix tests** that previously broke on stabilization branches (the KubernetesDeploy E2E set, polyglot SDK validation) should now pass with no special-case skips, because PR-time builds remain prerelease.

If CI is green here, the claim in #15681 is validated empirically.

## What to do with this PR

Close it once CI has completed and the relevant signal has been observed. **Do not** merge.

Linked: #15681, #15335.
