### PR TITLE
Fix StripPrefix XML doc default value

### DIFF
--- a/src/Aspire.Hosting.JavaScript/PublishAsStaticWebsiteOptions.cs
+++ b/src/Aspire.Hosting.JavaScript/PublishAsStaticWebsiteOptions.cs
@@ -22,7 +22,7 @@ public class PublishAsStaticWebsiteOptions
     /// Gets or sets whether to remove the API path prefix before forwarding to the backend.
     /// For example, with <c>apiPath="/api"</c> and <c>StripPrefix=true</c>, a request to
     /// <c>/api/weatherforecast</c> is forwarded as <c>/weatherforecast</c>.
-    /// Defaults to <see langword="true"/>.
+    /// Defaults to <see langword="false"/>.
     /// </summary>
     public bool StripPrefix { get; set; }
 


### PR DESCRIPTION
## Description

The XML doc on `PublishAsStaticWebsiteOptions.StripPrefix` claims the property defaults to `true`, but:

- The property has no initializer, so `bool` defaults to `false`.
- The polyglot wrapper `PublishAsStaticWebsitePolyglot` declares `bool stripPrefix = false`.
- `AddViteAppTests` explicitly asserts the default is `false` (`"StripPrefix defaults to false"`).

This PR corrects the doc comment to match the actual behavior. No code/behavioral change.

## Checklist

- [x] Doc-only change in `src/Aspire.Hosting.JavaScript/PublishAsStaticWebsiteOptions.cs`
- [x] `Aspire.Hosting.JavaScript` builds clean

Found via a daily code-review pass over the Aspire codebase.