### PR TITLE
fix(cli): reject --source for file-based AppHost add

### DIFF
--- a/src/Aspire.Cli/Commands/AddCommand.cs
+++ b/src/Aspire.Cli/Commands/AddCommand.cs
@@ -83,6 +83,13 @@ internal sealed class AddCommand : BaseCommand
             // Get the appropriate project handler
             var project = _projectFactory.GetProject(effectiveAppHostProjectFile);
 
+            if (!string.IsNullOrEmpty(source) && IsFileBasedCSharpAppHost(effectiveAppHostProjectFile, project))
+            {
+                return CommandResult.Failure(
+                    CliExitCodes.FailedToAddPackage,
+                    string.Format(CultureInfo.CurrentCulture, AddCommandStrings.SourceOptionNotSupportedForFileBasedAppHost, effectiveAppHostProjectFile.FullName));
+            }
+
             // Check if the .NET SDK is available (only needed for .NET projects)
             if (project.LanguageId == KnownLanguageId.CSharp)
             {
@@ -341,6 +348,12 @@ internal sealed class AddCommand : BaseCommand
         }
 
         return await GetPackageByInteractiveFlow(workingDirectory, possiblePackages, preferredVersion, cancellationToken);
+    }
+
+    private static bool IsFileBasedCSharpAppHost(FileInfo appHostFile, IAppHostProject project)
+    {
+        return project.LanguageId == KnownLanguageId.CSharp
+            && appHostFile.Name.Equals("apphost.cs", StringComparison.OrdinalIgnoreCase);
     }
 
 }

--- a/src/Aspire.Cli/Resources/AddCommandStrings.Designer.cs
+++ b/src/Aspire.Cli/Resources/AddCommandStrings.Designer.cs
@@ -197,6 +197,14 @@ namespace Aspire.Cli.Resources {
             }
         }
 
+        public static string SourceOptionNotSupportedForFileBasedAppHost
+        {
+            get
+            {
+                return ResourceManager.GetString("SourceOptionNotSupportedForFileBasedAppHost", resourceCulture);
+            }
+        }
+
         public static string PackageAddedSuccessfully
         {
             get

--- a/src/Aspire.Cli/Resources/AddCommandStrings.resx
+++ b/src/Aspire.Cli/Resources/AddCommandStrings.resx
@@ -173,6 +173,10 @@
     <value>The package installation failed with exit code {0}.</value>
     <comment>{0} is a number</comment>
   </data>
+  <data name="SourceOptionNotSupportedForFileBasedAppHost" xml:space="preserve">
+    <value>The option '--source' cannot be used when adding an integration to file-based AppHost '{0}'. Register the feed in nuget.config for the AppHost directory, then run 'aspire add' without '--source'.</value>
+    <comment>{0} is the path to the file-based AppHost.</comment>
+  </data>
   <data name="PackageAddedSuccessfully" xml:space="preserve">
     <value>The package {0}::{1} was added successfully.</value>
     <comment>{0} is the package name, {1} is the version.</comment>

--- a/src/Aspire.Cli/Resources/xlf/AddCommandStrings.cs.xlf
+++ b/src/Aspire.Cli/Resources/xlf/AddCommandStrings.cs.xlf
@@ -142,6 +142,11 @@
         <target state="needs-review-translation">Zdroj NuGet, který se má použít pro integraci</target>
         <note />
       </trans-unit>
+      <trans-unit id="SourceOptionNotSupportedForFileBasedAppHost">
+        <source>The option '--source' cannot be used when adding an integration to file-based AppHost '{0}'. Register the feed in nuget.config for the AppHost directory, then run 'aspire add' without '--source'.</source>
+        <target state="new">The option '--source' cannot be used when adding an integration to file-based AppHost '{0}'. Register the feed in nuget.config for the AppHost directory, then run 'aspire add' without '--source'.</target>
+        <note>{0} is the path to the file-based AppHost.</note>
+      </trans-unit>
       <trans-unit id="SpecifiedVersionNotFoundForPackage">
         <source>The requested version '{1}' was not found for package '{0}'.</source>
         <target state="new">The requested version '{1}' was not found for package '{0}'.</target>

--- a/src/Aspire.Cli/Resources/xlf/AddCommandStrings.de.xlf
+++ b/src/Aspire.Cli/Resources/xlf/AddCommandStrings.de.xlf
@@ -142,6 +142,11 @@
         <target state="needs-review-translation">Die NuGet-Quelle, die für die Integration verwendet werden soll.</target>
         <note />
       </trans-unit>
+      <trans-unit id="SourceOptionNotSupportedForFileBasedAppHost">
+        <source>The option '--source' cannot be used when adding an integration to file-based AppHost '{0}'. Register the feed in nuget.config for the AppHost directory, then run 'aspire add' without '--source'.</source>
+        <target state="new">The option '--source' cannot be used when adding an integration to file-based AppHost '{0}'. Register the feed in nuget.config for the AppHost directory, then run 'aspire add' without '--source'.</target>
+        <note>{0} is the path to the file-based AppHost.</note>
+      </trans-unit>
       <trans-unit id="SpecifiedVersionNotFoundForPackage">
         <source>The requested version '{1}' was not found for package '{0}'.</source>
         <target state="new">The requested version '{1}' was not found for package '{0}'.</target>

--- a/src/Aspire.Cli/Resources/xlf/AddCommandStrings.es.xlf
+++ b/src/Aspire.Cli/Resources/xlf/AddCommandStrings.es.xlf
@@ -142,6 +142,11 @@
         <target state="needs-review-translation">El origen de NuGet que se utilizará para la integración.</target>
         <note />
       </trans-unit>
+      <trans-unit id="SourceOptionNotSupportedForFileBasedAppHost">
+        <source>The option '--source' cannot be used when adding an integration to file-based AppHost '{0}'. Register the feed in nuget.config for the AppHost directory, then run 'aspire add' without '--source'.</source>
+        <target state="new">The option '--source' cannot be used when adding an integration to file-based AppHost '{0}'. Register the feed in nuget.config for the AppHost directory, then run 'aspire add' without '--source'.</target>
+        <note>{0} is the path to the file-based AppHost.</note>
+      </trans-unit>
       <trans-unit id="SpecifiedVersionNotFoundForPackage">
         <source>The requested version '{1}' was not found for package '{0}'.</source>
         <target state="new">The requested version '{1}' was not found for package '{0}'.</target>

--- a/src/Aspire.Cli/Resources/xlf/AddCommandStrings.fr.xlf
+++ b/src/Aspire.Cli/Resources/xlf/AddCommandStrings.fr.xlf
@@ -142,6 +142,11 @@
         <target state="needs-review-translation">Source NuGet à utiliser pour l’intégration.</target>
         <note />
       </trans-unit>
+      <trans-unit id="SourceOptionNotSupportedForFileBasedAppHost">
+        <source>The option '--source' cannot be used when adding an integration to file-based AppHost '{0}'. Register the feed in nuget.config for the AppHost directory, then run 'aspire add' without '--source'.</source>
+        <target state="new">The option '--source' cannot be used when adding an integration to file-based AppHost '{0}'. Register the feed in nuget.config for the AppHost directory, then run 'aspire add' without '--source'.</target>
+        <note>{0} is the path to the file-based AppHost.</note>
+      </trans-unit>
       <trans-unit id="SpecifiedVersionNotFoundForPackage">
         <source>The requested version '{1}' was not found for package '{0}'.</source>
         <target state="new">The requested version '{1}' was not found for package '{0}'.</target>

--- a/src/Aspire.Cli/Resources/xlf/AddCommandStrings.it.xlf
+++ b/src/Aspire.Cli/Resources/xlf/AddCommandStrings.it.xlf
@@ -142,6 +142,11 @@
         <target state="needs-review-translation">Origine NuGet da usare per l'integrazione.</target>
         <note />
       </trans-unit>
+      <trans-unit id="SourceOptionNotSupportedForFileBasedAppHost">
+        <source>The option '--source' cannot be used when adding an integration to file-based AppHost '{0}'. Register the feed in nuget.config for the AppHost directory, then run 'aspire add' without '--source'.</source>
+        <target state="new">The option '--source' cannot be used when adding an integration to file-based AppHost '{0}'. Register the feed in nuget.config for the AppHost directory, then run 'aspire add' without '--source'.</target>
+        <note>{0} is the path to the file-based AppHost.</note>
+      </trans-unit>
       <trans-unit id="SpecifiedVersionNotFoundForPackage">
         <source>The requested version '{1}' was not found for package '{0}'.</source>
         <target state="new">The requested version '{1}' was not found for package '{0}'.</target>

--- a/src/Aspire.Cli/Resources/xlf/AddCommandStrings.ja.xlf
+++ b/src/Aspire.Cli/Resources/xlf/AddCommandStrings.ja.xlf
@@ -142,6 +142,11 @@
         <target state="needs-review-translation">統合に使用する NuGet ソース。</target>
         <note />
       </trans-unit>
+      <trans-unit id="SourceOptionNotSupportedForFileBasedAppHost">
+        <source>The option '--source' cannot be used when adding an integration to file-based AppHost '{0}'. Register the feed in nuget.config for the AppHost directory, then run 'aspire add' without '--source'.</source>
+        <target state="new">The option '--source' cannot be used when adding an integration to file-based AppHost '{0}'. Register the feed in nuget.config for the AppHost directory, then run 'aspire add' without '--source'.</target>
+        <note>{0} is the path to the file-based AppHost.</note>
+      </trans-unit>
       <trans-unit id="SpecifiedVersionNotFoundForPackage">
         <source>The requested version '{1}' was not found for package '{0}'.</source>
         <target state="new">The requested version '{1}' was not found for package '{0}'.</target>

--- a/src/Aspire.Cli/Resources/xlf/AddCommandStrings.ko.xlf
+++ b/src/Aspire.Cli/Resources/xlf/AddCommandStrings.ko.xlf
@@ -142,6 +142,11 @@
         <target state="needs-review-translation">통합에 사용할 NuGet 원본입니다.</target>
         <note />
       </trans-unit>
+      <trans-unit id="SourceOptionNotSupportedForFileBasedAppHost">
+        <source>The option '--source' cannot be used when adding an integration to file-based AppHost '{0}'. Register the feed in nuget.config for the AppHost directory, then run 'aspire add' without '--source'.</source>
+        <target state="new">The option '--source' cannot be used when adding an integration to file-based AppHost '{0}'. Register the feed in nuget.config for the AppHost directory, then run 'aspire add' without '--source'.</target>
+        <note>{0} is the path to the file-based AppHost.</note>
+      </trans-unit>
       <trans-unit id="SpecifiedVersionNotFoundForPackage">
         <source>The requested version '{1}' was not found for package '{0}'.</source>
         <target state="new">The requested version '{1}' was not found for package '{0}'.</target>

--- a/src/Aspire.Cli/Resources/xlf/AddCommandStrings.pl.xlf
+++ b/src/Aspire.Cli/Resources/xlf/AddCommandStrings.pl.xlf
@@ -142,6 +142,11 @@
         <target state="needs-review-translation">Źródło NuGet do użycia na potrzeby integracji.</target>
         <note />
       </trans-unit>
+      <trans-unit id="SourceOptionNotSupportedForFileBasedAppHost">
+        <source>The option '--source' cannot be used when adding an integration to file-based AppHost '{0}'. Register the feed in nuget.config for the AppHost directory, then run 'aspire add' without '--source'.</source>
+        <target state="new">The option '--source' cannot be used when adding an integration to file-based AppHost '{0}'. Register the feed in nuget.config for the AppHost directory, then run 'aspire add' without '--source'.</target>
+        <note>{0} is the path to the file-based AppHost.</note>
+      </trans-unit>
       <trans-unit id="SpecifiedVersionNotFoundForPackage">
         <source>The requested version '{1}' was not found for package '{0}'.</source>
         <target state="new">The requested version '{1}' was not found for package '{0}'.</target>

--- a/src/Aspire.Cli/Resources/xlf/AddCommandStrings.pt-BR.xlf
+++ b/src/Aspire.Cli/Resources/xlf/AddCommandStrings.pt-BR.xlf
@@ -142,6 +142,11 @@
         <target state="needs-review-translation">A fonte do NuGet a ser usada para a integração.</target>
         <note />
       </trans-unit>
+      <trans-unit id="SourceOptionNotSupportedForFileBasedAppHost">
+        <source>The option '--source' cannot be used when adding an integration to file-based AppHost '{0}'. Register the feed in nuget.config for the AppHost directory, then run 'aspire add' without '--source'.</source>
+        <target state="new">The option '--source' cannot be used when adding an integration to file-based AppHost '{0}'. Register the feed in nuget.config for the AppHost directory, then run 'aspire add' without '--source'.</target>
+        <note>{0} is the path to the file-based AppHost.</note>
+      </trans-unit>
       <trans-unit id="SpecifiedVersionNotFoundForPackage">
         <source>The requested version '{1}' was not found for package '{0}'.</source>
         <target state="new">The requested version '{1}' was not found for package '{0}'.</target>

--- a/src/Aspire.Cli/Resources/xlf/AddCommandStrings.ru.xlf
+++ b/src/Aspire.Cli/Resources/xlf/AddCommandStrings.ru.xlf
@@ -142,6 +142,11 @@
         <target state="needs-review-translation">Источник NuGet, который следует использовать для интеграции.</target>
         <note />
       </trans-unit>
+      <trans-unit id="SourceOptionNotSupportedForFileBasedAppHost">
+        <source>The option '--source' cannot be used when adding an integration to file-based AppHost '{0}'. Register the feed in nuget.config for the AppHost directory, then run 'aspire add' without '--source'.</source>
+        <target state="new">The option '--source' cannot be used when adding an integration to file-based AppHost '{0}'. Register the feed in nuget.config for the AppHost directory, then run 'aspire add' without '--source'.</target>
+        <note>{0} is the path to the file-based AppHost.</note>
+      </trans-unit>
       <trans-unit id="SpecifiedVersionNotFoundForPackage">
         <source>The requested version '{1}' was not found for package '{0}'.</source>
         <target state="new">The requested version '{1}' was not found for package '{0}'.</target>

--- a/src/Aspire.Cli/Resources/xlf/AddCommandStrings.tr.xlf
+++ b/src/Aspire.Cli/Resources/xlf/AddCommandStrings.tr.xlf
@@ -142,6 +142,11 @@
         <target state="needs-review-translation">Tümleştirme için kullanılacak NuGet kaynağı.</target>
         <note />
       </trans-unit>
+      <trans-unit id="SourceOptionNotSupportedForFileBasedAppHost">
+        <source>The option '--source' cannot be used when adding an integration to file-based AppHost '{0}'. Register the feed in nuget.config for the AppHost directory, then run 'aspire add' without '--source'.</source>
+        <target state="new">The option '--source' cannot be used when adding an integration to file-based AppHost '{0}'. Register the feed in nuget.config for the AppHost directory, then run 'aspire add' without '--source'.</target>
+        <note>{0} is the path to the file-based AppHost.</note>
+      </trans-unit>
       <trans-unit id="SpecifiedVersionNotFoundForPackage">
         <source>The requested version '{1}' was not found for package '{0}'.</source>
         <target state="new">The requested version '{1}' was not found for package '{0}'.</target>

--- a/src/Aspire.Cli/Resources/xlf/AddCommandStrings.zh-Hans.xlf
+++ b/src/Aspire.Cli/Resources/xlf/AddCommandStrings.zh-Hans.xlf
@@ -142,6 +142,11 @@
         <target state="needs-review-translation">用于集成的 NuGet 源。</target>
         <note />
       </trans-unit>
+      <trans-unit id="SourceOptionNotSupportedForFileBasedAppHost">
+        <source>The option '--source' cannot be used when adding an integration to file-based AppHost '{0}'. Register the feed in nuget.config for the AppHost directory, then run 'aspire add' without '--source'.</source>
+        <target state="new">The option '--source' cannot be used when adding an integration to file-based AppHost '{0}'. Register the feed in nuget.config for the AppHost directory, then run 'aspire add' without '--source'.</target>
+        <note>{0} is the path to the file-based AppHost.</note>
+      </trans-unit>
       <trans-unit id="SpecifiedVersionNotFoundForPackage">
         <source>The requested version '{1}' was not found for package '{0}'.</source>
         <target state="new">The requested version '{1}' was not found for package '{0}'.</target>

--- a/src/Aspire.Cli/Resources/xlf/AddCommandStrings.zh-Hant.xlf
+++ b/src/Aspire.Cli/Resources/xlf/AddCommandStrings.zh-Hant.xlf
@@ -142,6 +142,11 @@
         <target state="needs-review-translation">用於整合的 NuGet 來源。</target>
         <note />
       </trans-unit>
+      <trans-unit id="SourceOptionNotSupportedForFileBasedAppHost">
+        <source>The option '--source' cannot be used when adding an integration to file-based AppHost '{0}'. Register the feed in nuget.config for the AppHost directory, then run 'aspire add' without '--source'.</source>
+        <target state="new">The option '--source' cannot be used when adding an integration to file-based AppHost '{0}'. Register the feed in nuget.config for the AppHost directory, then run 'aspire add' without '--source'.</target>
+        <note>{0} is the path to the file-based AppHost.</note>
+      </trans-unit>
       <trans-unit id="SpecifiedVersionNotFoundForPackage">
         <source>The requested version '{1}' was not found for package '{0}'.</source>
         <target state="new">The requested version '{1}' was not found for package '{0}'.</target>

--- a/tests/Aspire.Cli.Tests/Commands/AddCommandTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/AddCommandTests.cs
@@ -2941,4 +2941,54 @@ public class AddCommandFuzzySearchTests(ITestOutputHelper outputHelper)
         // Verify that Azure AppContainers package was found and added through fuzzy matching
         Assert.Equal("Aspire.Hosting.Azure.AppContainers", addedPackage);
     }
+
+    [Fact]
+    public async Task AddCommandWithSourceFailsFastForFileBasedAppHost()
+    {
+        var searchedPackages = false;
+        var addedPackage = false;
+        var testInteractionService = new TestInteractionService();
+
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        var appHostFile = new FileInfo(Path.Combine(workspace.WorkspaceRoot.FullName, "apphost.cs"));
+        await File.WriteAllTextAsync(appHostFile.FullName, """
+            #:sdk Aspire.AppHost.Sdk@13.4.0
+            """);
+
+        var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper, options =>
+        {
+            options.InteractionServiceFactory = _ => testInteractionService;
+            options.DotNetCliRunnerFactory = _ =>
+            {
+                var runner = new TestDotNetCliRunner();
+                runner.SearchPackagesAsyncCallback = (_, _, _, _, _, _, _, _, _, _) =>
+                {
+                    searchedPackages = true;
+                    throw new InvalidOperationException("Should not search packages when --source is rejected for a file-based AppHost.");
+                };
+                runner.AddPackageAsyncCallback = (_, _, _, _, _, _, _) =>
+                {
+                    addedPackage = true;
+                    throw new InvalidOperationException("Should not add a package when --source is rejected for a file-based AppHost.");
+                };
+                return runner;
+            };
+        });
+        using var provider = services.BuildServiceProvider();
+
+        var command = provider.GetRequiredService<AddCommand>();
+        var result = command.Parse($"add redis --apphost \"{appHostFile.FullName}\" --source https://api.nuget.org/v3/index.json --version 13.4.0");
+
+        var exitCode = await result.InvokeAsync().DefaultTimeout();
+
+        Assert.Equal(CliExitCodes.FailedToAddPackage, exitCode);
+        Assert.False(searchedPackages);
+        Assert.False(addedPackage);
+        Assert.DoesNotContain(AddCommandStrings.SearchingForAspirePackages, testInteractionService.ShownStatuses);
+        Assert.Contains(testInteractionService.DisplayedErrors, error =>
+            error.Contains("'--source'", StringComparison.Ordinal) &&
+            error.Contains("file-based AppHost", StringComparison.Ordinal) &&
+            error.Contains(appHostFile.FullName, StringComparison.Ordinal) &&
+            error.Contains("nuget.config", StringComparison.Ordinal));
+    }
 }


### PR DESCRIPTION
## Description

`aspire add <integration> --source <feed>` failed on file-based C# AppHosts (`apphost.cs`) only after the CLI delegated to the .NET SDK:

```text
Cannot specify option '--source' when operating on a file-based app.
```

The same option works for project-based AppHosts, so the file-based path surfaced a lower-level SDK error plus Aspire's generic package installation failure after package discovery had already run.

This change makes Aspire CLI fail fast for `apphost.cs` when `--source` is specified. The new error names `--source`, names the file-based AppHost path, and tells the user to register the feed in `nuget.config` before rerunning `aspire add` without `--source`. Project-based AppHosts continue to pass `--source` through to `dotnet package add` unchanged.

### User-facing usage

File-based AppHosts now get an Aspire-owned error before package discovery or package installation starts:

```bash
aspire add redis --apphost ./apphost.cs --source ./packages --version 13.4.0
```

```text
The option '--source' cannot be used when adding an integration to file-based AppHost './apphost.cs'. Register the feed in nuget.config for the AppHost directory, then run 'aspire add' without '--source'.
```

### Validation

```bash
dotnet build tests/Aspire.Cli.Tests/Aspire.Cli.Tests.csproj /p:SkipNativeBuild=true

dotnet test --project tests/Aspire.Cli.Tests/Aspire.Cli.Tests.csproj --no-launch-profile -- \
  --filter-method "*.AddCommandWithSourceFailsFastForFileBasedAppHost" \
  --filter-method "*.AddPackageAsyncUsesPositionalArgumentForCsprojFile" \
  --filter-method "*.AddPackageAsyncWithSourceAndNoRestoreHasArgumentSourceAndNoRestore" \
  --filter-not-trait "quarantined=true" \
  --filter-not-trait "outerloop=true"
```

Fixes #17304

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
