### PR TITLE
Add install CLI link to AI Agents dialog descriptions

### DIFF
--- a/src/Aspire.Dashboard/Components/Dialogs/AIAgentsDialog.razor.cs
+++ b/src/Aspire.Dashboard/Components/Dialogs/AIAgentsDialog.razor.cs
@@ -32,10 +32,11 @@ public partial class AIAgentsDialog : IDialogContentComponent
 
     private const string AppHostLearnMoreUrl = "https://aka.ms/aspire/ai-agents-apphost";
     private const string StandaloneLearnMoreUrl = "https://aka.ms/aspire/dashboard-ai-standalone";
+    private const string InstallCliUrl = "https://aka.ms/aspire/install-cli";
 
     private string Description => DashboardClient.IsEnabled
-        ? string.Format(CultureInfo.CurrentCulture, Loc[nameof(DialogsLoc.AIAgentsDialogAppHostDescription)], AppHostLearnMoreUrl)
-        : string.Format(CultureInfo.CurrentCulture, Loc[nameof(DialogsLoc.AIAgentsDialogStandaloneDescription)], GetDashboardUrl(), StandaloneLearnMoreUrl);
+        ? string.Format(CultureInfo.CurrentCulture, Loc[nameof(DialogsLoc.AIAgentsDialogAppHostDescription)], AppHostLearnMoreUrl, InstallCliUrl)
+        : string.Format(CultureInfo.CurrentCulture, Loc[nameof(DialogsLoc.AIAgentsDialogStandaloneDescription)], GetDashboardUrl(), StandaloneLearnMoreUrl, InstallCliUrl);
 
     private string GetDashboardUrl()
     {

--- a/src/Aspire.Dashboard/Resources/Dialogs.resx
+++ b/src/Aspire.Dashboard/Resources/Dialogs.resx
@@ -537,7 +537,7 @@ First, [install the Aspire CLI]({1}) if you haven't already. Then use an Aspire 
 aspire agent init
 ```
 
-This configures Aspire skill files for your AI agent. The skill files tell the agent how to use Aspire CLI commands such as [`aspire logs`](https://aspire.dev/reference/cli/commands/aspire-logs/) and [`aspire otel traces`](https://aspire.dev/reference/cli/commands/aspire-otel-traces/).
+This configures skill files for your AI agent. The skill files tell the agent how to use Aspire CLI commands such as [`aspire logs`](https://aspire.dev/reference/cli/commands/aspire-logs/) and [`aspire otel traces`](https://aspire.dev/reference/cli/commands/aspire-otel-traces/).
 
 Once connected, agents can start your app, check resource health, fetch logs and traces, and more.
 

--- a/src/Aspire.Dashboard/Resources/Dialogs.resx
+++ b/src/Aspire.Dashboard/Resources/Dialogs.resx
@@ -531,13 +531,13 @@ For more information about using AI agents with the dashboard, such as setting u
 
 The structured logs, distributed traces, and resource status in this dashboard are available to AI agents via the Aspire CLI. This gives agents deep observability into your app, to help them diagnose issues and verify fixes.
 
-First, [install the Aspire CLI]({1}) if you haven't already. Then get started by running this command in your project:
+First, [install the Aspire CLI]({1}) if you haven't already. Then use an Aspire CLI command to initialize agent support in your project:
 
 ```bash
 aspire agent init
 ```
 
-This configures skill files for your AI assistant. The skill files tell the agent how to use Aspire CLI commands such as [`aspire logs`](https://aspire.dev/reference/cli/commands/aspire-logs/) and [`aspire otel traces`](https://aspire.dev/reference/cli/commands/aspire-otel-traces/).
+This configures Aspire skill files for your AI agent. The skill files tell the agent how to use Aspire CLI commands such as [`aspire logs`](https://aspire.dev/reference/cli/commands/aspire-logs/) and [`aspire otel traces`](https://aspire.dev/reference/cli/commands/aspire-otel-traces/).
 
 Once connected, agents can start your app, check resource health, fetch logs and traces, and more.
 

--- a/src/Aspire.Dashboard/Resources/Dialogs.resx
+++ b/src/Aspire.Dashboard/Resources/Dialogs.resx
@@ -512,7 +512,7 @@
 
 The structured logs and distributed traces in the dashboard are available to AI agents via the Aspire CLI. This gives agents deep observability into your app, to help them diagnose issues and verify fixes.
 
-Use Aspire CLI commands to get telemetry data in your terminal:
+First, [install the Aspire CLI]({2}) if you haven't already. Then use Aspire CLI commands to get telemetry data in your terminal:
 
 ```bash
 aspire otel logs --dashboard-url {0}
@@ -524,14 +524,14 @@ aspire otel logs --dashboard-url {0}
 - [`aspire export`](https://aspire.dev/reference/cli/commands/aspire-export/) — Export telemetry and resource data to a zip file
 
 For more information about using AI agents with the dashboard, such as setting up skills, see [Standalone dashboard and AI coding agents]({1}).</value>
-    <comment>{0} is the dashboard URL, {1} is the learn more URL</comment>
+    <comment>{0} is the dashboard URL, {1} is the learn more URL, {2} is the install CLI URL</comment>
   </data>
   <data name="AIAgentsDialogAppHostDescription" xml:space="preserve">
     <value>Build, debug, and profile apps using AI agents and Aspire 🚀
 
 The structured logs, distributed traces, and resource status in this dashboard are available to AI agents via the Aspire CLI. This gives agents deep observability into your app, to help them diagnose issues and verify fixes.
 
-Get started by running this command in your project:
+First, [install the Aspire CLI]({1}) if you haven't already. Then get started by running this command in your project:
 
 ```bash
 aspire agent init
@@ -542,5 +542,6 @@ This configures skill files for your AI assistant. The skill files tell the agen
 Once connected, agents can start your app, check resource health, fetch logs and traces, and more.
 
 For more information about using AI agents with Aspire, such as setting up skills, see [AI coding agents]({0}).</value>
+    <comment>{0} is the learn more URL, {1} is the install CLI URL</comment>
   </data>
 </root>

--- a/src/Aspire.Dashboard/Resources/xlf/Dialogs.cs.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Dialogs.cs.xlf
@@ -7,13 +7,13 @@
 
 The structured logs, distributed traces, and resource status in this dashboard are available to AI agents via the Aspire CLI. This gives agents deep observability into your app, to help them diagnose issues and verify fixes.
 
-First, [install the Aspire CLI]({1}) if you haven't already. Then get started by running this command in your project:
+First, [install the Aspire CLI]({1}) if you haven't already. Then use an Aspire CLI command to initialize agent support in your project:
 
 ```bash
 aspire agent init
 ```
 
-This configures skill files for your AI assistant. The skill files tell the agent how to use Aspire CLI commands such as [`aspire logs`](https://aspire.dev/reference/cli/commands/aspire-logs/) and [`aspire otel traces`](https://aspire.dev/reference/cli/commands/aspire-otel-traces/).
+This configures Aspire skill files for your AI agent. The skill files tell the agent how to use Aspire CLI commands such as [`aspire logs`](https://aspire.dev/reference/cli/commands/aspire-logs/) and [`aspire otel traces`](https://aspire.dev/reference/cli/commands/aspire-otel-traces/).
 
 Once connected, agents can start your app, check resource health, fetch logs and traces, and more.
 
@@ -22,13 +22,13 @@ For more information about using AI agents with Aspire, such as setting up skill
 
 The structured logs, distributed traces, and resource status in this dashboard are available to AI agents via the Aspire CLI. This gives agents deep observability into your app, to help them diagnose issues and verify fixes.
 
-First, [install the Aspire CLI]({1}) if you haven't already. Then get started by running this command in your project:
+First, [install the Aspire CLI]({1}) if you haven't already. Then use an Aspire CLI command to initialize agent support in your project:
 
 ```bash
 aspire agent init
 ```
 
-This configures skill files for your AI assistant. The skill files tell the agent how to use Aspire CLI commands such as [`aspire logs`](https://aspire.dev/reference/cli/commands/aspire-logs/) and [`aspire otel traces`](https://aspire.dev/reference/cli/commands/aspire-otel-traces/).
+This configures Aspire skill files for your AI agent. The skill files tell the agent how to use Aspire CLI commands such as [`aspire logs`](https://aspire.dev/reference/cli/commands/aspire-logs/) and [`aspire otel traces`](https://aspire.dev/reference/cli/commands/aspire-otel-traces/).
 
 Once connected, agents can start your app, check resource health, fetch logs and traces, and more.
 

--- a/src/Aspire.Dashboard/Resources/xlf/Dialogs.cs.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Dialogs.cs.xlf
@@ -7,7 +7,7 @@
 
 The structured logs, distributed traces, and resource status in this dashboard are available to AI agents via the Aspire CLI. This gives agents deep observability into your app, to help them diagnose issues and verify fixes.
 
-Get started by running this command in your project:
+First, [install the Aspire CLI]({1}) if you haven't already. Then get started by running this command in your project:
 
 ```bash
 aspire agent init
@@ -22,7 +22,7 @@ For more information about using AI agents with Aspire, such as setting up skill
 
 The structured logs, distributed traces, and resource status in this dashboard are available to AI agents via the Aspire CLI. This gives agents deep observability into your app, to help them diagnose issues and verify fixes.
 
-Get started by running this command in your project:
+First, [install the Aspire CLI]({1}) if you haven't already. Then get started by running this command in your project:
 
 ```bash
 aspire agent init
@@ -33,14 +33,14 @@ This configures skill files for your AI assistant. The skill files tell the agen
 Once connected, agents can start your app, check resource health, fetch logs and traces, and more.
 
 For more information about using AI agents with Aspire, such as setting up skills, see [AI coding agents]({0}).</target>
-        <note />
+        <note>{0} is the learn more URL, {1} is the install CLI URL</note>
       </trans-unit>
       <trans-unit id="AIAgentsDialogStandaloneDescription">
         <source>Build, debug, and profile apps using AI agents and Aspire 🚀
 
 The structured logs and distributed traces in the dashboard are available to AI agents via the Aspire CLI. This gives agents deep observability into your app, to help them diagnose issues and verify fixes.
 
-Use Aspire CLI commands to get telemetry data in your terminal:
+First, [install the Aspire CLI]({2}) if you haven't already. Then use Aspire CLI commands to get telemetry data in your terminal:
 
 ```bash
 aspire otel logs --dashboard-url {0}
@@ -56,7 +56,7 @@ For more information about using AI agents with the dashboard, such as setting u
 
 The structured logs and distributed traces in the dashboard are available to AI agents via the Aspire CLI. This gives agents deep observability into your app, to help them diagnose issues and verify fixes.
 
-Use Aspire CLI commands to get telemetry data in your terminal:
+First, [install the Aspire CLI]({2}) if you haven't already. Then use Aspire CLI commands to get telemetry data in your terminal:
 
 ```bash
 aspire otel logs --dashboard-url {0}
@@ -68,7 +68,7 @@ aspire otel logs --dashboard-url {0}
 - [`aspire export`](https://aspire.dev/reference/cli/commands/aspire-export/) — Export telemetry and resource data to a zip file
 
 For more information about using AI agents with the dashboard, such as setting up skills, see [Standalone dashboard and AI coding agents]({1}).</target>
-        <note>{0} is the dashboard URL, {1} is the learn more URL</note>
+        <note>{0} is the dashboard URL, {1} is the learn more URL, {2} is the install CLI URL</note>
       </trans-unit>
       <trans-unit id="AIAgentsDialogTitle">
         <source>AI agents</source>

--- a/src/Aspire.Dashboard/Resources/xlf/Dialogs.cs.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Dialogs.cs.xlf
@@ -13,7 +13,7 @@ First, [install the Aspire CLI]({1}) if you haven't already. Then use an Aspire 
 aspire agent init
 ```
 
-This configures Aspire skill files for your AI agent. The skill files tell the agent how to use Aspire CLI commands such as [`aspire logs`](https://aspire.dev/reference/cli/commands/aspire-logs/) and [`aspire otel traces`](https://aspire.dev/reference/cli/commands/aspire-otel-traces/).
+This configures skill files for your AI agent. The skill files tell the agent how to use Aspire CLI commands such as [`aspire logs`](https://aspire.dev/reference/cli/commands/aspire-logs/) and [`aspire otel traces`](https://aspire.dev/reference/cli/commands/aspire-otel-traces/).
 
 Once connected, agents can start your app, check resource health, fetch logs and traces, and more.
 
@@ -28,7 +28,7 @@ First, [install the Aspire CLI]({1}) if you haven't already. Then use an Aspire 
 aspire agent init
 ```
 
-This configures Aspire skill files for your AI agent. The skill files tell the agent how to use Aspire CLI commands such as [`aspire logs`](https://aspire.dev/reference/cli/commands/aspire-logs/) and [`aspire otel traces`](https://aspire.dev/reference/cli/commands/aspire-otel-traces/).
+This configures skill files for your AI agent. The skill files tell the agent how to use Aspire CLI commands such as [`aspire logs`](https://aspire.dev/reference/cli/commands/aspire-logs/) and [`aspire otel traces`](https://aspire.dev/reference/cli/commands/aspire-otel-traces/).
 
 Once connected, agents can start your app, check resource health, fetch logs and traces, and more.
 

--- a/src/Aspire.Dashboard/Resources/xlf/Dialogs.de.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Dialogs.de.xlf
@@ -7,13 +7,13 @@
 
 The structured logs, distributed traces, and resource status in this dashboard are available to AI agents via the Aspire CLI. This gives agents deep observability into your app, to help them diagnose issues and verify fixes.
 
-First, [install the Aspire CLI]({1}) if you haven't already. Then get started by running this command in your project:
+First, [install the Aspire CLI]({1}) if you haven't already. Then use an Aspire CLI command to initialize agent support in your project:
 
 ```bash
 aspire agent init
 ```
 
-This configures skill files for your AI assistant. The skill files tell the agent how to use Aspire CLI commands such as [`aspire logs`](https://aspire.dev/reference/cli/commands/aspire-logs/) and [`aspire otel traces`](https://aspire.dev/reference/cli/commands/aspire-otel-traces/).
+This configures Aspire skill files for your AI agent. The skill files tell the agent how to use Aspire CLI commands such as [`aspire logs`](https://aspire.dev/reference/cli/commands/aspire-logs/) and [`aspire otel traces`](https://aspire.dev/reference/cli/commands/aspire-otel-traces/).
 
 Once connected, agents can start your app, check resource health, fetch logs and traces, and more.
 
@@ -22,13 +22,13 @@ For more information about using AI agents with Aspire, such as setting up skill
 
 The structured logs, distributed traces, and resource status in this dashboard are available to AI agents via the Aspire CLI. This gives agents deep observability into your app, to help them diagnose issues and verify fixes.
 
-First, [install the Aspire CLI]({1}) if you haven't already. Then get started by running this command in your project:
+First, [install the Aspire CLI]({1}) if you haven't already. Then use an Aspire CLI command to initialize agent support in your project:
 
 ```bash
 aspire agent init
 ```
 
-This configures skill files for your AI assistant. The skill files tell the agent how to use Aspire CLI commands such as [`aspire logs`](https://aspire.dev/reference/cli/commands/aspire-logs/) and [`aspire otel traces`](https://aspire.dev/reference/cli/commands/aspire-otel-traces/).
+This configures Aspire skill files for your AI agent. The skill files tell the agent how to use Aspire CLI commands such as [`aspire logs`](https://aspire.dev/reference/cli/commands/aspire-logs/) and [`aspire otel traces`](https://aspire.dev/reference/cli/commands/aspire-otel-traces/).
 
 Once connected, agents can start your app, check resource health, fetch logs and traces, and more.
 

--- a/src/Aspire.Dashboard/Resources/xlf/Dialogs.de.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Dialogs.de.xlf
@@ -7,7 +7,7 @@
 
 The structured logs, distributed traces, and resource status in this dashboard are available to AI agents via the Aspire CLI. This gives agents deep observability into your app, to help them diagnose issues and verify fixes.
 
-Get started by running this command in your project:
+First, [install the Aspire CLI]({1}) if you haven't already. Then get started by running this command in your project:
 
 ```bash
 aspire agent init
@@ -22,7 +22,7 @@ For more information about using AI agents with Aspire, such as setting up skill
 
 The structured logs, distributed traces, and resource status in this dashboard are available to AI agents via the Aspire CLI. This gives agents deep observability into your app, to help them diagnose issues and verify fixes.
 
-Get started by running this command in your project:
+First, [install the Aspire CLI]({1}) if you haven't already. Then get started by running this command in your project:
 
 ```bash
 aspire agent init
@@ -33,14 +33,14 @@ This configures skill files for your AI assistant. The skill files tell the agen
 Once connected, agents can start your app, check resource health, fetch logs and traces, and more.
 
 For more information about using AI agents with Aspire, such as setting up skills, see [AI coding agents]({0}).</target>
-        <note />
+        <note>{0} is the learn more URL, {1} is the install CLI URL</note>
       </trans-unit>
       <trans-unit id="AIAgentsDialogStandaloneDescription">
         <source>Build, debug, and profile apps using AI agents and Aspire 🚀
 
 The structured logs and distributed traces in the dashboard are available to AI agents via the Aspire CLI. This gives agents deep observability into your app, to help them diagnose issues and verify fixes.
 
-Use Aspire CLI commands to get telemetry data in your terminal:
+First, [install the Aspire CLI]({2}) if you haven't already. Then use Aspire CLI commands to get telemetry data in your terminal:
 
 ```bash
 aspire otel logs --dashboard-url {0}
@@ -56,7 +56,7 @@ For more information about using AI agents with the dashboard, such as setting u
 
 The structured logs and distributed traces in the dashboard are available to AI agents via the Aspire CLI. This gives agents deep observability into your app, to help them diagnose issues and verify fixes.
 
-Use Aspire CLI commands to get telemetry data in your terminal:
+First, [install the Aspire CLI]({2}) if you haven't already. Then use Aspire CLI commands to get telemetry data in your terminal:
 
 ```bash
 aspire otel logs --dashboard-url {0}
@@ -68,7 +68,7 @@ aspire otel logs --dashboard-url {0}
 - [`aspire export`](https://aspire.dev/reference/cli/commands/aspire-export/) — Export telemetry and resource data to a zip file
 
 For more information about using AI agents with the dashboard, such as setting up skills, see [Standalone dashboard and AI coding agents]({1}).</target>
-        <note>{0} is the dashboard URL, {1} is the learn more URL</note>
+        <note>{0} is the dashboard URL, {1} is the learn more URL, {2} is the install CLI URL</note>
       </trans-unit>
       <trans-unit id="AIAgentsDialogTitle">
         <source>AI agents</source>

--- a/src/Aspire.Dashboard/Resources/xlf/Dialogs.de.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Dialogs.de.xlf
@@ -13,7 +13,7 @@ First, [install the Aspire CLI]({1}) if you haven't already. Then use an Aspire 
 aspire agent init
 ```
 
-This configures Aspire skill files for your AI agent. The skill files tell the agent how to use Aspire CLI commands such as [`aspire logs`](https://aspire.dev/reference/cli/commands/aspire-logs/) and [`aspire otel traces`](https://aspire.dev/reference/cli/commands/aspire-otel-traces/).
+This configures skill files for your AI agent. The skill files tell the agent how to use Aspire CLI commands such as [`aspire logs`](https://aspire.dev/reference/cli/commands/aspire-logs/) and [`aspire otel traces`](https://aspire.dev/reference/cli/commands/aspire-otel-traces/).
 
 Once connected, agents can start your app, check resource health, fetch logs and traces, and more.
 
@@ -28,7 +28,7 @@ First, [install the Aspire CLI]({1}) if you haven't already. Then use an Aspire 
 aspire agent init
 ```
 
-This configures Aspire skill files for your AI agent. The skill files tell the agent how to use Aspire CLI commands such as [`aspire logs`](https://aspire.dev/reference/cli/commands/aspire-logs/) and [`aspire otel traces`](https://aspire.dev/reference/cli/commands/aspire-otel-traces/).
+This configures skill files for your AI agent. The skill files tell the agent how to use Aspire CLI commands such as [`aspire logs`](https://aspire.dev/reference/cli/commands/aspire-logs/) and [`aspire otel traces`](https://aspire.dev/reference/cli/commands/aspire-otel-traces/).
 
 Once connected, agents can start your app, check resource health, fetch logs and traces, and more.
 

--- a/src/Aspire.Dashboard/Resources/xlf/Dialogs.es.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Dialogs.es.xlf
@@ -7,13 +7,13 @@
 
 The structured logs, distributed traces, and resource status in this dashboard are available to AI agents via the Aspire CLI. This gives agents deep observability into your app, to help them diagnose issues and verify fixes.
 
-First, [install the Aspire CLI]({1}) if you haven't already. Then get started by running this command in your project:
+First, [install the Aspire CLI]({1}) if you haven't already. Then use an Aspire CLI command to initialize agent support in your project:
 
 ```bash
 aspire agent init
 ```
 
-This configures skill files for your AI assistant. The skill files tell the agent how to use Aspire CLI commands such as [`aspire logs`](https://aspire.dev/reference/cli/commands/aspire-logs/) and [`aspire otel traces`](https://aspire.dev/reference/cli/commands/aspire-otel-traces/).
+This configures Aspire skill files for your AI agent. The skill files tell the agent how to use Aspire CLI commands such as [`aspire logs`](https://aspire.dev/reference/cli/commands/aspire-logs/) and [`aspire otel traces`](https://aspire.dev/reference/cli/commands/aspire-otel-traces/).
 
 Once connected, agents can start your app, check resource health, fetch logs and traces, and more.
 
@@ -22,13 +22,13 @@ For more information about using AI agents with Aspire, such as setting up skill
 
 The structured logs, distributed traces, and resource status in this dashboard are available to AI agents via the Aspire CLI. This gives agents deep observability into your app, to help them diagnose issues and verify fixes.
 
-First, [install the Aspire CLI]({1}) if you haven't already. Then get started by running this command in your project:
+First, [install the Aspire CLI]({1}) if you haven't already. Then use an Aspire CLI command to initialize agent support in your project:
 
 ```bash
 aspire agent init
 ```
 
-This configures skill files for your AI assistant. The skill files tell the agent how to use Aspire CLI commands such as [`aspire logs`](https://aspire.dev/reference/cli/commands/aspire-logs/) and [`aspire otel traces`](https://aspire.dev/reference/cli/commands/aspire-otel-traces/).
+This configures Aspire skill files for your AI agent. The skill files tell the agent how to use Aspire CLI commands such as [`aspire logs`](https://aspire.dev/reference/cli/commands/aspire-logs/) and [`aspire otel traces`](https://aspire.dev/reference/cli/commands/aspire-otel-traces/).
 
 Once connected, agents can start your app, check resource health, fetch logs and traces, and more.
 

--- a/src/Aspire.Dashboard/Resources/xlf/Dialogs.es.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Dialogs.es.xlf
@@ -7,7 +7,7 @@
 
 The structured logs, distributed traces, and resource status in this dashboard are available to AI agents via the Aspire CLI. This gives agents deep observability into your app, to help them diagnose issues and verify fixes.
 
-Get started by running this command in your project:
+First, [install the Aspire CLI]({1}) if you haven't already. Then get started by running this command in your project:
 
 ```bash
 aspire agent init
@@ -22,7 +22,7 @@ For more information about using AI agents with Aspire, such as setting up skill
 
 The structured logs, distributed traces, and resource status in this dashboard are available to AI agents via the Aspire CLI. This gives agents deep observability into your app, to help them diagnose issues and verify fixes.
 
-Get started by running this command in your project:
+First, [install the Aspire CLI]({1}) if you haven't already. Then get started by running this command in your project:
 
 ```bash
 aspire agent init
@@ -33,14 +33,14 @@ This configures skill files for your AI assistant. The skill files tell the agen
 Once connected, agents can start your app, check resource health, fetch logs and traces, and more.
 
 For more information about using AI agents with Aspire, such as setting up skills, see [AI coding agents]({0}).</target>
-        <note />
+        <note>{0} is the learn more URL, {1} is the install CLI URL</note>
       </trans-unit>
       <trans-unit id="AIAgentsDialogStandaloneDescription">
         <source>Build, debug, and profile apps using AI agents and Aspire 🚀
 
 The structured logs and distributed traces in the dashboard are available to AI agents via the Aspire CLI. This gives agents deep observability into your app, to help them diagnose issues and verify fixes.
 
-Use Aspire CLI commands to get telemetry data in your terminal:
+First, [install the Aspire CLI]({2}) if you haven't already. Then use Aspire CLI commands to get telemetry data in your terminal:
 
 ```bash
 aspire otel logs --dashboard-url {0}
@@ -56,7 +56,7 @@ For more information about using AI agents with the dashboard, such as setting u
 
 The structured logs and distributed traces in the dashboard are available to AI agents via the Aspire CLI. This gives agents deep observability into your app, to help them diagnose issues and verify fixes.
 
-Use Aspire CLI commands to get telemetry data in your terminal:
+First, [install the Aspire CLI]({2}) if you haven't already. Then use Aspire CLI commands to get telemetry data in your terminal:
 
 ```bash
 aspire otel logs --dashboard-url {0}
@@ -68,7 +68,7 @@ aspire otel logs --dashboard-url {0}
 - [`aspire export`](https://aspire.dev/reference/cli/commands/aspire-export/) — Export telemetry and resource data to a zip file
 
 For more information about using AI agents with the dashboard, such as setting up skills, see [Standalone dashboard and AI coding agents]({1}).</target>
-        <note>{0} is the dashboard URL, {1} is the learn more URL</note>
+        <note>{0} is the dashboard URL, {1} is the learn more URL, {2} is the install CLI URL</note>
       </trans-unit>
       <trans-unit id="AIAgentsDialogTitle">
         <source>AI agents</source>

--- a/src/Aspire.Dashboard/Resources/xlf/Dialogs.es.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Dialogs.es.xlf
@@ -13,7 +13,7 @@ First, [install the Aspire CLI]({1}) if you haven't already. Then use an Aspire 
 aspire agent init
 ```
 
-This configures Aspire skill files for your AI agent. The skill files tell the agent how to use Aspire CLI commands such as [`aspire logs`](https://aspire.dev/reference/cli/commands/aspire-logs/) and [`aspire otel traces`](https://aspire.dev/reference/cli/commands/aspire-otel-traces/).
+This configures skill files for your AI agent. The skill files tell the agent how to use Aspire CLI commands such as [`aspire logs`](https://aspire.dev/reference/cli/commands/aspire-logs/) and [`aspire otel traces`](https://aspire.dev/reference/cli/commands/aspire-otel-traces/).
 
 Once connected, agents can start your app, check resource health, fetch logs and traces, and more.
 
@@ -28,7 +28,7 @@ First, [install the Aspire CLI]({1}) if you haven't already. Then use an Aspire 
 aspire agent init
 ```
 
-This configures Aspire skill files for your AI agent. The skill files tell the agent how to use Aspire CLI commands such as [`aspire logs`](https://aspire.dev/reference/cli/commands/aspire-logs/) and [`aspire otel traces`](https://aspire.dev/reference/cli/commands/aspire-otel-traces/).
+This configures skill files for your AI agent. The skill files tell the agent how to use Aspire CLI commands such as [`aspire logs`](https://aspire.dev/reference/cli/commands/aspire-logs/) and [`aspire otel traces`](https://aspire.dev/reference/cli/commands/aspire-otel-traces/).
 
 Once connected, agents can start your app, check resource health, fetch logs and traces, and more.
 

--- a/src/Aspire.Dashboard/Resources/xlf/Dialogs.fr.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Dialogs.fr.xlf
@@ -7,13 +7,13 @@
 
 The structured logs, distributed traces, and resource status in this dashboard are available to AI agents via the Aspire CLI. This gives agents deep observability into your app, to help them diagnose issues and verify fixes.
 
-First, [install the Aspire CLI]({1}) if you haven't already. Then get started by running this command in your project:
+First, [install the Aspire CLI]({1}) if you haven't already. Then use an Aspire CLI command to initialize agent support in your project:
 
 ```bash
 aspire agent init
 ```
 
-This configures skill files for your AI assistant. The skill files tell the agent how to use Aspire CLI commands such as [`aspire logs`](https://aspire.dev/reference/cli/commands/aspire-logs/) and [`aspire otel traces`](https://aspire.dev/reference/cli/commands/aspire-otel-traces/).
+This configures Aspire skill files for your AI agent. The skill files tell the agent how to use Aspire CLI commands such as [`aspire logs`](https://aspire.dev/reference/cli/commands/aspire-logs/) and [`aspire otel traces`](https://aspire.dev/reference/cli/commands/aspire-otel-traces/).
 
 Once connected, agents can start your app, check resource health, fetch logs and traces, and more.
 
@@ -22,13 +22,13 @@ For more information about using AI agents with Aspire, such as setting up skill
 
 The structured logs, distributed traces, and resource status in this dashboard are available to AI agents via the Aspire CLI. This gives agents deep observability into your app, to help them diagnose issues and verify fixes.
 
-First, [install the Aspire CLI]({1}) if you haven't already. Then get started by running this command in your project:
+First, [install the Aspire CLI]({1}) if you haven't already. Then use an Aspire CLI command to initialize agent support in your project:
 
 ```bash
 aspire agent init
 ```
 
-This configures skill files for your AI assistant. The skill files tell the agent how to use Aspire CLI commands such as [`aspire logs`](https://aspire.dev/reference/cli/commands/aspire-logs/) and [`aspire otel traces`](https://aspire.dev/reference/cli/commands/aspire-otel-traces/).
+This configures Aspire skill files for your AI agent. The skill files tell the agent how to use Aspire CLI commands such as [`aspire logs`](https://aspire.dev/reference/cli/commands/aspire-logs/) and [`aspire otel traces`](https://aspire.dev/reference/cli/commands/aspire-otel-traces/).
 
 Once connected, agents can start your app, check resource health, fetch logs and traces, and more.
 

--- a/src/Aspire.Dashboard/Resources/xlf/Dialogs.fr.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Dialogs.fr.xlf
@@ -7,7 +7,7 @@
 
 The structured logs, distributed traces, and resource status in this dashboard are available to AI agents via the Aspire CLI. This gives agents deep observability into your app, to help them diagnose issues and verify fixes.
 
-Get started by running this command in your project:
+First, [install the Aspire CLI]({1}) if you haven't already. Then get started by running this command in your project:
 
 ```bash
 aspire agent init
@@ -22,7 +22,7 @@ For more information about using AI agents with Aspire, such as setting up skill
 
 The structured logs, distributed traces, and resource status in this dashboard are available to AI agents via the Aspire CLI. This gives agents deep observability into your app, to help them diagnose issues and verify fixes.
 
-Get started by running this command in your project:
+First, [install the Aspire CLI]({1}) if you haven't already. Then get started by running this command in your project:
 
 ```bash
 aspire agent init
@@ -33,14 +33,14 @@ This configures skill files for your AI assistant. The skill files tell the agen
 Once connected, agents can start your app, check resource health, fetch logs and traces, and more.
 
 For more information about using AI agents with Aspire, such as setting up skills, see [AI coding agents]({0}).</target>
-        <note />
+        <note>{0} is the learn more URL, {1} is the install CLI URL</note>
       </trans-unit>
       <trans-unit id="AIAgentsDialogStandaloneDescription">
         <source>Build, debug, and profile apps using AI agents and Aspire 🚀
 
 The structured logs and distributed traces in the dashboard are available to AI agents via the Aspire CLI. This gives agents deep observability into your app, to help them diagnose issues and verify fixes.
 
-Use Aspire CLI commands to get telemetry data in your terminal:
+First, [install the Aspire CLI]({2}) if you haven't already. Then use Aspire CLI commands to get telemetry data in your terminal:
 
 ```bash
 aspire otel logs --dashboard-url {0}
@@ -56,7 +56,7 @@ For more information about using AI agents with the dashboard, such as setting u
 
 The structured logs and distributed traces in the dashboard are available to AI agents via the Aspire CLI. This gives agents deep observability into your app, to help them diagnose issues and verify fixes.
 
-Use Aspire CLI commands to get telemetry data in your terminal:
+First, [install the Aspire CLI]({2}) if you haven't already. Then use Aspire CLI commands to get telemetry data in your terminal:
 
 ```bash
 aspire otel logs --dashboard-url {0}
@@ -68,7 +68,7 @@ aspire otel logs --dashboard-url {0}
 - [`aspire export`](https://aspire.dev/reference/cli/commands/aspire-export/) — Export telemetry and resource data to a zip file
 
 For more information about using AI agents with the dashboard, such as setting up skills, see [Standalone dashboard and AI coding agents]({1}).</target>
-        <note>{0} is the dashboard URL, {1} is the learn more URL</note>
+        <note>{0} is the dashboard URL, {1} is the learn more URL, {2} is the install CLI URL</note>
       </trans-unit>
       <trans-unit id="AIAgentsDialogTitle">
         <source>AI agents</source>

--- a/src/Aspire.Dashboard/Resources/xlf/Dialogs.fr.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Dialogs.fr.xlf
@@ -13,7 +13,7 @@ First, [install the Aspire CLI]({1}) if you haven't already. Then use an Aspire 
 aspire agent init
 ```
 
-This configures Aspire skill files for your AI agent. The skill files tell the agent how to use Aspire CLI commands such as [`aspire logs`](https://aspire.dev/reference/cli/commands/aspire-logs/) and [`aspire otel traces`](https://aspire.dev/reference/cli/commands/aspire-otel-traces/).
+This configures skill files for your AI agent. The skill files tell the agent how to use Aspire CLI commands such as [`aspire logs`](https://aspire.dev/reference/cli/commands/aspire-logs/) and [`aspire otel traces`](https://aspire.dev/reference/cli/commands/aspire-otel-traces/).
 
 Once connected, agents can start your app, check resource health, fetch logs and traces, and more.
 
@@ -28,7 +28,7 @@ First, [install the Aspire CLI]({1}) if you haven't already. Then use an Aspire 
 aspire agent init
 ```
 
-This configures Aspire skill files for your AI agent. The skill files tell the agent how to use Aspire CLI commands such as [`aspire logs`](https://aspire.dev/reference/cli/commands/aspire-logs/) and [`aspire otel traces`](https://aspire.dev/reference/cli/commands/aspire-otel-traces/).
+This configures skill files for your AI agent. The skill files tell the agent how to use Aspire CLI commands such as [`aspire logs`](https://aspire.dev/reference/cli/commands/aspire-logs/) and [`aspire otel traces`](https://aspire.dev/reference/cli/commands/aspire-otel-traces/).
 
 Once connected, agents can start your app, check resource health, fetch logs and traces, and more.
 

--- a/src/Aspire.Dashboard/Resources/xlf/Dialogs.it.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Dialogs.it.xlf
@@ -7,13 +7,13 @@
 
 The structured logs, distributed traces, and resource status in this dashboard are available to AI agents via the Aspire CLI. This gives agents deep observability into your app, to help them diagnose issues and verify fixes.
 
-First, [install the Aspire CLI]({1}) if you haven't already. Then get started by running this command in your project:
+First, [install the Aspire CLI]({1}) if you haven't already. Then use an Aspire CLI command to initialize agent support in your project:
 
 ```bash
 aspire agent init
 ```
 
-This configures skill files for your AI assistant. The skill files tell the agent how to use Aspire CLI commands such as [`aspire logs`](https://aspire.dev/reference/cli/commands/aspire-logs/) and [`aspire otel traces`](https://aspire.dev/reference/cli/commands/aspire-otel-traces/).
+This configures Aspire skill files for your AI agent. The skill files tell the agent how to use Aspire CLI commands such as [`aspire logs`](https://aspire.dev/reference/cli/commands/aspire-logs/) and [`aspire otel traces`](https://aspire.dev/reference/cli/commands/aspire-otel-traces/).
 
 Once connected, agents can start your app, check resource health, fetch logs and traces, and more.
 
@@ -22,13 +22,13 @@ For more information about using AI agents with Aspire, such as setting up skill
 
 The structured logs, distributed traces, and resource status in this dashboard are available to AI agents via the Aspire CLI. This gives agents deep observability into your app, to help them diagnose issues and verify fixes.
 
-First, [install the Aspire CLI]({1}) if you haven't already. Then get started by running this command in your project:
+First, [install the Aspire CLI]({1}) if you haven't already. Then use an Aspire CLI command to initialize agent support in your project:
 
 ```bash
 aspire agent init
 ```
 
-This configures skill files for your AI assistant. The skill files tell the agent how to use Aspire CLI commands such as [`aspire logs`](https://aspire.dev/reference/cli/commands/aspire-logs/) and [`aspire otel traces`](https://aspire.dev/reference/cli/commands/aspire-otel-traces/).
+This configures Aspire skill files for your AI agent. The skill files tell the agent how to use Aspire CLI commands such as [`aspire logs`](https://aspire.dev/reference/cli/commands/aspire-logs/) and [`aspire otel traces`](https://aspire.dev/reference/cli/commands/aspire-otel-traces/).
 
 Once connected, agents can start your app, check resource health, fetch logs and traces, and more.
 

--- a/src/Aspire.Dashboard/Resources/xlf/Dialogs.it.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Dialogs.it.xlf
@@ -7,7 +7,7 @@
 
 The structured logs, distributed traces, and resource status in this dashboard are available to AI agents via the Aspire CLI. This gives agents deep observability into your app, to help them diagnose issues and verify fixes.
 
-Get started by running this command in your project:
+First, [install the Aspire CLI]({1}) if you haven't already. Then get started by running this command in your project:
 
 ```bash
 aspire agent init
@@ -22,7 +22,7 @@ For more information about using AI agents with Aspire, such as setting up skill
 
 The structured logs, distributed traces, and resource status in this dashboard are available to AI agents via the Aspire CLI. This gives agents deep observability into your app, to help them diagnose issues and verify fixes.
 
-Get started by running this command in your project:
+First, [install the Aspire CLI]({1}) if you haven't already. Then get started by running this command in your project:
 
 ```bash
 aspire agent init
@@ -33,14 +33,14 @@ This configures skill files for your AI assistant. The skill files tell the agen
 Once connected, agents can start your app, check resource health, fetch logs and traces, and more.
 
 For more information about using AI agents with Aspire, such as setting up skills, see [AI coding agents]({0}).</target>
-        <note />
+        <note>{0} is the learn more URL, {1} is the install CLI URL</note>
       </trans-unit>
       <trans-unit id="AIAgentsDialogStandaloneDescription">
         <source>Build, debug, and profile apps using AI agents and Aspire 🚀
 
 The structured logs and distributed traces in the dashboard are available to AI agents via the Aspire CLI. This gives agents deep observability into your app, to help them diagnose issues and verify fixes.
 
-Use Aspire CLI commands to get telemetry data in your terminal:
+First, [install the Aspire CLI]({2}) if you haven't already. Then use Aspire CLI commands to get telemetry data in your terminal:
 
 ```bash
 aspire otel logs --dashboard-url {0}
@@ -56,7 +56,7 @@ For more information about using AI agents with the dashboard, such as setting u
 
 The structured logs and distributed traces in the dashboard are available to AI agents via the Aspire CLI. This gives agents deep observability into your app, to help them diagnose issues and verify fixes.
 
-Use Aspire CLI commands to get telemetry data in your terminal:
+First, [install the Aspire CLI]({2}) if you haven't already. Then use Aspire CLI commands to get telemetry data in your terminal:
 
 ```bash
 aspire otel logs --dashboard-url {0}
@@ -68,7 +68,7 @@ aspire otel logs --dashboard-url {0}
 - [`aspire export`](https://aspire.dev/reference/cli/commands/aspire-export/) — Export telemetry and resource data to a zip file
 
 For more information about using AI agents with the dashboard, such as setting up skills, see [Standalone dashboard and AI coding agents]({1}).</target>
-        <note>{0} is the dashboard URL, {1} is the learn more URL</note>
+        <note>{0} is the dashboard URL, {1} is the learn more URL, {2} is the install CLI URL</note>
       </trans-unit>
       <trans-unit id="AIAgentsDialogTitle">
         <source>AI agents</source>

--- a/src/Aspire.Dashboard/Resources/xlf/Dialogs.it.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Dialogs.it.xlf
@@ -13,7 +13,7 @@ First, [install the Aspire CLI]({1}) if you haven't already. Then use an Aspire 
 aspire agent init
 ```
 
-This configures Aspire skill files for your AI agent. The skill files tell the agent how to use Aspire CLI commands such as [`aspire logs`](https://aspire.dev/reference/cli/commands/aspire-logs/) and [`aspire otel traces`](https://aspire.dev/reference/cli/commands/aspire-otel-traces/).
+This configures skill files for your AI agent. The skill files tell the agent how to use Aspire CLI commands such as [`aspire logs`](https://aspire.dev/reference/cli/commands/aspire-logs/) and [`aspire otel traces`](https://aspire.dev/reference/cli/commands/aspire-otel-traces/).
 
 Once connected, agents can start your app, check resource health, fetch logs and traces, and more.
 
@@ -28,7 +28,7 @@ First, [install the Aspire CLI]({1}) if you haven't already. Then use an Aspire 
 aspire agent init
 ```
 
-This configures Aspire skill files for your AI agent. The skill files tell the agent how to use Aspire CLI commands such as [`aspire logs`](https://aspire.dev/reference/cli/commands/aspire-logs/) and [`aspire otel traces`](https://aspire.dev/reference/cli/commands/aspire-otel-traces/).
+This configures skill files for your AI agent. The skill files tell the agent how to use Aspire CLI commands such as [`aspire logs`](https://aspire.dev/reference/cli/commands/aspire-logs/) and [`aspire otel traces`](https://aspire.dev/reference/cli/commands/aspire-otel-traces/).
 
 Once connected, agents can start your app, check resource health, fetch logs and traces, and more.
 

--- a/src/Aspire.Dashboard/Resources/xlf/Dialogs.ja.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Dialogs.ja.xlf
@@ -7,13 +7,13 @@
 
 The structured logs, distributed traces, and resource status in this dashboard are available to AI agents via the Aspire CLI. This gives agents deep observability into your app, to help them diagnose issues and verify fixes.
 
-First, [install the Aspire CLI]({1}) if you haven't already. Then get started by running this command in your project:
+First, [install the Aspire CLI]({1}) if you haven't already. Then use an Aspire CLI command to initialize agent support in your project:
 
 ```bash
 aspire agent init
 ```
 
-This configures skill files for your AI assistant. The skill files tell the agent how to use Aspire CLI commands such as [`aspire logs`](https://aspire.dev/reference/cli/commands/aspire-logs/) and [`aspire otel traces`](https://aspire.dev/reference/cli/commands/aspire-otel-traces/).
+This configures Aspire skill files for your AI agent. The skill files tell the agent how to use Aspire CLI commands such as [`aspire logs`](https://aspire.dev/reference/cli/commands/aspire-logs/) and [`aspire otel traces`](https://aspire.dev/reference/cli/commands/aspire-otel-traces/).
 
 Once connected, agents can start your app, check resource health, fetch logs and traces, and more.
 
@@ -22,13 +22,13 @@ For more information about using AI agents with Aspire, such as setting up skill
 
 The structured logs, distributed traces, and resource status in this dashboard are available to AI agents via the Aspire CLI. This gives agents deep observability into your app, to help them diagnose issues and verify fixes.
 
-First, [install the Aspire CLI]({1}) if you haven't already. Then get started by running this command in your project:
+First, [install the Aspire CLI]({1}) if you haven't already. Then use an Aspire CLI command to initialize agent support in your project:
 
 ```bash
 aspire agent init
 ```
 
-This configures skill files for your AI assistant. The skill files tell the agent how to use Aspire CLI commands such as [`aspire logs`](https://aspire.dev/reference/cli/commands/aspire-logs/) and [`aspire otel traces`](https://aspire.dev/reference/cli/commands/aspire-otel-traces/).
+This configures Aspire skill files for your AI agent. The skill files tell the agent how to use Aspire CLI commands such as [`aspire logs`](https://aspire.dev/reference/cli/commands/aspire-logs/) and [`aspire otel traces`](https://aspire.dev/reference/cli/commands/aspire-otel-traces/).
 
 Once connected, agents can start your app, check resource health, fetch logs and traces, and more.
 

--- a/src/Aspire.Dashboard/Resources/xlf/Dialogs.ja.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Dialogs.ja.xlf
@@ -7,7 +7,7 @@
 
 The structured logs, distributed traces, and resource status in this dashboard are available to AI agents via the Aspire CLI. This gives agents deep observability into your app, to help them diagnose issues and verify fixes.
 
-Get started by running this command in your project:
+First, [install the Aspire CLI]({1}) if you haven't already. Then get started by running this command in your project:
 
 ```bash
 aspire agent init
@@ -22,7 +22,7 @@ For more information about using AI agents with Aspire, such as setting up skill
 
 The structured logs, distributed traces, and resource status in this dashboard are available to AI agents via the Aspire CLI. This gives agents deep observability into your app, to help them diagnose issues and verify fixes.
 
-Get started by running this command in your project:
+First, [install the Aspire CLI]({1}) if you haven't already. Then get started by running this command in your project:
 
 ```bash
 aspire agent init
@@ -33,14 +33,14 @@ This configures skill files for your AI assistant. The skill files tell the agen
 Once connected, agents can start your app, check resource health, fetch logs and traces, and more.
 
 For more information about using AI agents with Aspire, such as setting up skills, see [AI coding agents]({0}).</target>
-        <note />
+        <note>{0} is the learn more URL, {1} is the install CLI URL</note>
       </trans-unit>
       <trans-unit id="AIAgentsDialogStandaloneDescription">
         <source>Build, debug, and profile apps using AI agents and Aspire 🚀
 
 The structured logs and distributed traces in the dashboard are available to AI agents via the Aspire CLI. This gives agents deep observability into your app, to help them diagnose issues and verify fixes.
 
-Use Aspire CLI commands to get telemetry data in your terminal:
+First, [install the Aspire CLI]({2}) if you haven't already. Then use Aspire CLI commands to get telemetry data in your terminal:
 
 ```bash
 aspire otel logs --dashboard-url {0}
@@ -56,7 +56,7 @@ For more information about using AI agents with the dashboard, such as setting u
 
 The structured logs and distributed traces in the dashboard are available to AI agents via the Aspire CLI. This gives agents deep observability into your app, to help them diagnose issues and verify fixes.
 
-Use Aspire CLI commands to get telemetry data in your terminal:
+First, [install the Aspire CLI]({2}) if you haven't already. Then use Aspire CLI commands to get telemetry data in your terminal:
 
 ```bash
 aspire otel logs --dashboard-url {0}
@@ -68,7 +68,7 @@ aspire otel logs --dashboard-url {0}
 - [`aspire export`](https://aspire.dev/reference/cli/commands/aspire-export/) — Export telemetry and resource data to a zip file
 
 For more information about using AI agents with the dashboard, such as setting up skills, see [Standalone dashboard and AI coding agents]({1}).</target>
-        <note>{0} is the dashboard URL, {1} is the learn more URL</note>
+        <note>{0} is the dashboard URL, {1} is the learn more URL, {2} is the install CLI URL</note>
       </trans-unit>
       <trans-unit id="AIAgentsDialogTitle">
         <source>AI agents</source>

--- a/src/Aspire.Dashboard/Resources/xlf/Dialogs.ja.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Dialogs.ja.xlf
@@ -13,7 +13,7 @@ First, [install the Aspire CLI]({1}) if you haven't already. Then use an Aspire 
 aspire agent init
 ```
 
-This configures Aspire skill files for your AI agent. The skill files tell the agent how to use Aspire CLI commands such as [`aspire logs`](https://aspire.dev/reference/cli/commands/aspire-logs/) and [`aspire otel traces`](https://aspire.dev/reference/cli/commands/aspire-otel-traces/).
+This configures skill files for your AI agent. The skill files tell the agent how to use Aspire CLI commands such as [`aspire logs`](https://aspire.dev/reference/cli/commands/aspire-logs/) and [`aspire otel traces`](https://aspire.dev/reference/cli/commands/aspire-otel-traces/).
 
 Once connected, agents can start your app, check resource health, fetch logs and traces, and more.
 
@@ -28,7 +28,7 @@ First, [install the Aspire CLI]({1}) if you haven't already. Then use an Aspire 
 aspire agent init
 ```
 
-This configures Aspire skill files for your AI agent. The skill files tell the agent how to use Aspire CLI commands such as [`aspire logs`](https://aspire.dev/reference/cli/commands/aspire-logs/) and [`aspire otel traces`](https://aspire.dev/reference/cli/commands/aspire-otel-traces/).
+This configures skill files for your AI agent. The skill files tell the agent how to use Aspire CLI commands such as [`aspire logs`](https://aspire.dev/reference/cli/commands/aspire-logs/) and [`aspire otel traces`](https://aspire.dev/reference/cli/commands/aspire-otel-traces/).
 
 Once connected, agents can start your app, check resource health, fetch logs and traces, and more.
 

--- a/src/Aspire.Dashboard/Resources/xlf/Dialogs.ko.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Dialogs.ko.xlf
@@ -7,13 +7,13 @@
 
 The structured logs, distributed traces, and resource status in this dashboard are available to AI agents via the Aspire CLI. This gives agents deep observability into your app, to help them diagnose issues and verify fixes.
 
-First, [install the Aspire CLI]({1}) if you haven't already. Then get started by running this command in your project:
+First, [install the Aspire CLI]({1}) if you haven't already. Then use an Aspire CLI command to initialize agent support in your project:
 
 ```bash
 aspire agent init
 ```
 
-This configures skill files for your AI assistant. The skill files tell the agent how to use Aspire CLI commands such as [`aspire logs`](https://aspire.dev/reference/cli/commands/aspire-logs/) and [`aspire otel traces`](https://aspire.dev/reference/cli/commands/aspire-otel-traces/).
+This configures Aspire skill files for your AI agent. The skill files tell the agent how to use Aspire CLI commands such as [`aspire logs`](https://aspire.dev/reference/cli/commands/aspire-logs/) and [`aspire otel traces`](https://aspire.dev/reference/cli/commands/aspire-otel-traces/).
 
 Once connected, agents can start your app, check resource health, fetch logs and traces, and more.
 
@@ -22,13 +22,13 @@ For more information about using AI agents with Aspire, such as setting up skill
 
 The structured logs, distributed traces, and resource status in this dashboard are available to AI agents via the Aspire CLI. This gives agents deep observability into your app, to help them diagnose issues and verify fixes.
 
-First, [install the Aspire CLI]({1}) if you haven't already. Then get started by running this command in your project:
+First, [install the Aspire CLI]({1}) if you haven't already. Then use an Aspire CLI command to initialize agent support in your project:
 
 ```bash
 aspire agent init
 ```
 
-This configures skill files for your AI assistant. The skill files tell the agent how to use Aspire CLI commands such as [`aspire logs`](https://aspire.dev/reference/cli/commands/aspire-logs/) and [`aspire otel traces`](https://aspire.dev/reference/cli/commands/aspire-otel-traces/).
+This configures Aspire skill files for your AI agent. The skill files tell the agent how to use Aspire CLI commands such as [`aspire logs`](https://aspire.dev/reference/cli/commands/aspire-logs/) and [`aspire otel traces`](https://aspire.dev/reference/cli/commands/aspire-otel-traces/).
 
 Once connected, agents can start your app, check resource health, fetch logs and traces, and more.
 

--- a/src/Aspire.Dashboard/Resources/xlf/Dialogs.ko.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Dialogs.ko.xlf
@@ -7,7 +7,7 @@
 
 The structured logs, distributed traces, and resource status in this dashboard are available to AI agents via the Aspire CLI. This gives agents deep observability into your app, to help them diagnose issues and verify fixes.
 
-Get started by running this command in your project:
+First, [install the Aspire CLI]({1}) if you haven't already. Then get started by running this command in your project:
 
 ```bash
 aspire agent init
@@ -22,7 +22,7 @@ For more information about using AI agents with Aspire, such as setting up skill
 
 The structured logs, distributed traces, and resource status in this dashboard are available to AI agents via the Aspire CLI. This gives agents deep observability into your app, to help them diagnose issues and verify fixes.
 
-Get started by running this command in your project:
+First, [install the Aspire CLI]({1}) if you haven't already. Then get started by running this command in your project:
 
 ```bash
 aspire agent init
@@ -33,14 +33,14 @@ This configures skill files for your AI assistant. The skill files tell the agen
 Once connected, agents can start your app, check resource health, fetch logs and traces, and more.
 
 For more information about using AI agents with Aspire, such as setting up skills, see [AI coding agents]({0}).</target>
-        <note />
+        <note>{0} is the learn more URL, {1} is the install CLI URL</note>
       </trans-unit>
       <trans-unit id="AIAgentsDialogStandaloneDescription">
         <source>Build, debug, and profile apps using AI agents and Aspire 🚀
 
 The structured logs and distributed traces in the dashboard are available to AI agents via the Aspire CLI. This gives agents deep observability into your app, to help them diagnose issues and verify fixes.
 
-Use Aspire CLI commands to get telemetry data in your terminal:
+First, [install the Aspire CLI]({2}) if you haven't already. Then use Aspire CLI commands to get telemetry data in your terminal:
 
 ```bash
 aspire otel logs --dashboard-url {0}
@@ -56,7 +56,7 @@ For more information about using AI agents with the dashboard, such as setting u
 
 The structured logs and distributed traces in the dashboard are available to AI agents via the Aspire CLI. This gives agents deep observability into your app, to help them diagnose issues and verify fixes.
 
-Use Aspire CLI commands to get telemetry data in your terminal:
+First, [install the Aspire CLI]({2}) if you haven't already. Then use Aspire CLI commands to get telemetry data in your terminal:
 
 ```bash
 aspire otel logs --dashboard-url {0}
@@ -68,7 +68,7 @@ aspire otel logs --dashboard-url {0}
 - [`aspire export`](https://aspire.dev/reference/cli/commands/aspire-export/) — Export telemetry and resource data to a zip file
 
 For more information about using AI agents with the dashboard, such as setting up skills, see [Standalone dashboard and AI coding agents]({1}).</target>
-        <note>{0} is the dashboard URL, {1} is the learn more URL</note>
+        <note>{0} is the dashboard URL, {1} is the learn more URL, {2} is the install CLI URL</note>
       </trans-unit>
       <trans-unit id="AIAgentsDialogTitle">
         <source>AI agents</source>

--- a/src/Aspire.Dashboard/Resources/xlf/Dialogs.ko.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Dialogs.ko.xlf
@@ -13,7 +13,7 @@ First, [install the Aspire CLI]({1}) if you haven't already. Then use an Aspire 
 aspire agent init
 ```
 
-This configures Aspire skill files for your AI agent. The skill files tell the agent how to use Aspire CLI commands such as [`aspire logs`](https://aspire.dev/reference/cli/commands/aspire-logs/) and [`aspire otel traces`](https://aspire.dev/reference/cli/commands/aspire-otel-traces/).
+This configures skill files for your AI agent. The skill files tell the agent how to use Aspire CLI commands such as [`aspire logs`](https://aspire.dev/reference/cli/commands/aspire-logs/) and [`aspire otel traces`](https://aspire.dev/reference/cli/commands/aspire-otel-traces/).
 
 Once connected, agents can start your app, check resource health, fetch logs and traces, and more.
 
@@ -28,7 +28,7 @@ First, [install the Aspire CLI]({1}) if you haven't already. Then use an Aspire 
 aspire agent init
 ```
 
-This configures Aspire skill files for your AI agent. The skill files tell the agent how to use Aspire CLI commands such as [`aspire logs`](https://aspire.dev/reference/cli/commands/aspire-logs/) and [`aspire otel traces`](https://aspire.dev/reference/cli/commands/aspire-otel-traces/).
+This configures skill files for your AI agent. The skill files tell the agent how to use Aspire CLI commands such as [`aspire logs`](https://aspire.dev/reference/cli/commands/aspire-logs/) and [`aspire otel traces`](https://aspire.dev/reference/cli/commands/aspire-otel-traces/).
 
 Once connected, agents can start your app, check resource health, fetch logs and traces, and more.
 

--- a/src/Aspire.Dashboard/Resources/xlf/Dialogs.pl.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Dialogs.pl.xlf
@@ -7,13 +7,13 @@
 
 The structured logs, distributed traces, and resource status in this dashboard are available to AI agents via the Aspire CLI. This gives agents deep observability into your app, to help them diagnose issues and verify fixes.
 
-First, [install the Aspire CLI]({1}) if you haven't already. Then get started by running this command in your project:
+First, [install the Aspire CLI]({1}) if you haven't already. Then use an Aspire CLI command to initialize agent support in your project:
 
 ```bash
 aspire agent init
 ```
 
-This configures skill files for your AI assistant. The skill files tell the agent how to use Aspire CLI commands such as [`aspire logs`](https://aspire.dev/reference/cli/commands/aspire-logs/) and [`aspire otel traces`](https://aspire.dev/reference/cli/commands/aspire-otel-traces/).
+This configures Aspire skill files for your AI agent. The skill files tell the agent how to use Aspire CLI commands such as [`aspire logs`](https://aspire.dev/reference/cli/commands/aspire-logs/) and [`aspire otel traces`](https://aspire.dev/reference/cli/commands/aspire-otel-traces/).
 
 Once connected, agents can start your app, check resource health, fetch logs and traces, and more.
 
@@ -22,13 +22,13 @@ For more information about using AI agents with Aspire, such as setting up skill
 
 The structured logs, distributed traces, and resource status in this dashboard are available to AI agents via the Aspire CLI. This gives agents deep observability into your app, to help them diagnose issues and verify fixes.
 
-First, [install the Aspire CLI]({1}) if you haven't already. Then get started by running this command in your project:
+First, [install the Aspire CLI]({1}) if you haven't already. Then use an Aspire CLI command to initialize agent support in your project:
 
 ```bash
 aspire agent init
 ```
 
-This configures skill files for your AI assistant. The skill files tell the agent how to use Aspire CLI commands such as [`aspire logs`](https://aspire.dev/reference/cli/commands/aspire-logs/) and [`aspire otel traces`](https://aspire.dev/reference/cli/commands/aspire-otel-traces/).
+This configures Aspire skill files for your AI agent. The skill files tell the agent how to use Aspire CLI commands such as [`aspire logs`](https://aspire.dev/reference/cli/commands/aspire-logs/) and [`aspire otel traces`](https://aspire.dev/reference/cli/commands/aspire-otel-traces/).
 
 Once connected, agents can start your app, check resource health, fetch logs and traces, and more.
 

--- a/src/Aspire.Dashboard/Resources/xlf/Dialogs.pl.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Dialogs.pl.xlf
@@ -7,7 +7,7 @@
 
 The structured logs, distributed traces, and resource status in this dashboard are available to AI agents via the Aspire CLI. This gives agents deep observability into your app, to help them diagnose issues and verify fixes.
 
-Get started by running this command in your project:
+First, [install the Aspire CLI]({1}) if you haven't already. Then get started by running this command in your project:
 
 ```bash
 aspire agent init
@@ -22,7 +22,7 @@ For more information about using AI agents with Aspire, such as setting up skill
 
 The structured logs, distributed traces, and resource status in this dashboard are available to AI agents via the Aspire CLI. This gives agents deep observability into your app, to help them diagnose issues and verify fixes.
 
-Get started by running this command in your project:
+First, [install the Aspire CLI]({1}) if you haven't already. Then get started by running this command in your project:
 
 ```bash
 aspire agent init
@@ -33,14 +33,14 @@ This configures skill files for your AI assistant. The skill files tell the agen
 Once connected, agents can start your app, check resource health, fetch logs and traces, and more.
 
 For more information about using AI agents with Aspire, such as setting up skills, see [AI coding agents]({0}).</target>
-        <note />
+        <note>{0} is the learn more URL, {1} is the install CLI URL</note>
       </trans-unit>
       <trans-unit id="AIAgentsDialogStandaloneDescription">
         <source>Build, debug, and profile apps using AI agents and Aspire 🚀
 
 The structured logs and distributed traces in the dashboard are available to AI agents via the Aspire CLI. This gives agents deep observability into your app, to help them diagnose issues and verify fixes.
 
-Use Aspire CLI commands to get telemetry data in your terminal:
+First, [install the Aspire CLI]({2}) if you haven't already. Then use Aspire CLI commands to get telemetry data in your terminal:
 
 ```bash
 aspire otel logs --dashboard-url {0}
@@ -56,7 +56,7 @@ For more information about using AI agents with the dashboard, such as setting u
 
 The structured logs and distributed traces in the dashboard are available to AI agents via the Aspire CLI. This gives agents deep observability into your app, to help them diagnose issues and verify fixes.
 
-Use Aspire CLI commands to get telemetry data in your terminal:
+First, [install the Aspire CLI]({2}) if you haven't already. Then use Aspire CLI commands to get telemetry data in your terminal:
 
 ```bash
 aspire otel logs --dashboard-url {0}
@@ -68,7 +68,7 @@ aspire otel logs --dashboard-url {0}
 - [`aspire export`](https://aspire.dev/reference/cli/commands/aspire-export/) — Export telemetry and resource data to a zip file
 
 For more information about using AI agents with the dashboard, such as setting up skills, see [Standalone dashboard and AI coding agents]({1}).</target>
-        <note>{0} is the dashboard URL, {1} is the learn more URL</note>
+        <note>{0} is the dashboard URL, {1} is the learn more URL, {2} is the install CLI URL</note>
       </trans-unit>
       <trans-unit id="AIAgentsDialogTitle">
         <source>AI agents</source>

--- a/src/Aspire.Dashboard/Resources/xlf/Dialogs.pl.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Dialogs.pl.xlf
@@ -13,7 +13,7 @@ First, [install the Aspire CLI]({1}) if you haven't already. Then use an Aspire 
 aspire agent init
 ```
 
-This configures Aspire skill files for your AI agent. The skill files tell the agent how to use Aspire CLI commands such as [`aspire logs`](https://aspire.dev/reference/cli/commands/aspire-logs/) and [`aspire otel traces`](https://aspire.dev/reference/cli/commands/aspire-otel-traces/).
+This configures skill files for your AI agent. The skill files tell the agent how to use Aspire CLI commands such as [`aspire logs`](https://aspire.dev/reference/cli/commands/aspire-logs/) and [`aspire otel traces`](https://aspire.dev/reference/cli/commands/aspire-otel-traces/).
 
 Once connected, agents can start your app, check resource health, fetch logs and traces, and more.
 
@@ -28,7 +28,7 @@ First, [install the Aspire CLI]({1}) if you haven't already. Then use an Aspire 
 aspire agent init
 ```
 
-This configures Aspire skill files for your AI agent. The skill files tell the agent how to use Aspire CLI commands such as [`aspire logs`](https://aspire.dev/reference/cli/commands/aspire-logs/) and [`aspire otel traces`](https://aspire.dev/reference/cli/commands/aspire-otel-traces/).
+This configures skill files for your AI agent. The skill files tell the agent how to use Aspire CLI commands such as [`aspire logs`](https://aspire.dev/reference/cli/commands/aspire-logs/) and [`aspire otel traces`](https://aspire.dev/reference/cli/commands/aspire-otel-traces/).
 
 Once connected, agents can start your app, check resource health, fetch logs and traces, and more.
 

--- a/src/Aspire.Dashboard/Resources/xlf/Dialogs.pt-BR.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Dialogs.pt-BR.xlf
@@ -7,13 +7,13 @@
 
 The structured logs, distributed traces, and resource status in this dashboard are available to AI agents via the Aspire CLI. This gives agents deep observability into your app, to help them diagnose issues and verify fixes.
 
-First, [install the Aspire CLI]({1}) if you haven't already. Then get started by running this command in your project:
+First, [install the Aspire CLI]({1}) if you haven't already. Then use an Aspire CLI command to initialize agent support in your project:
 
 ```bash
 aspire agent init
 ```
 
-This configures skill files for your AI assistant. The skill files tell the agent how to use Aspire CLI commands such as [`aspire logs`](https://aspire.dev/reference/cli/commands/aspire-logs/) and [`aspire otel traces`](https://aspire.dev/reference/cli/commands/aspire-otel-traces/).
+This configures Aspire skill files for your AI agent. The skill files tell the agent how to use Aspire CLI commands such as [`aspire logs`](https://aspire.dev/reference/cli/commands/aspire-logs/) and [`aspire otel traces`](https://aspire.dev/reference/cli/commands/aspire-otel-traces/).
 
 Once connected, agents can start your app, check resource health, fetch logs and traces, and more.
 
@@ -22,13 +22,13 @@ For more information about using AI agents with Aspire, such as setting up skill
 
 The structured logs, distributed traces, and resource status in this dashboard are available to AI agents via the Aspire CLI. This gives agents deep observability into your app, to help them diagnose issues and verify fixes.
 
-First, [install the Aspire CLI]({1}) if you haven't already. Then get started by running this command in your project:
+First, [install the Aspire CLI]({1}) if you haven't already. Then use an Aspire CLI command to initialize agent support in your project:
 
 ```bash
 aspire agent init
 ```
 
-This configures skill files for your AI assistant. The skill files tell the agent how to use Aspire CLI commands such as [`aspire logs`](https://aspire.dev/reference/cli/commands/aspire-logs/) and [`aspire otel traces`](https://aspire.dev/reference/cli/commands/aspire-otel-traces/).
+This configures Aspire skill files for your AI agent. The skill files tell the agent how to use Aspire CLI commands such as [`aspire logs`](https://aspire.dev/reference/cli/commands/aspire-logs/) and [`aspire otel traces`](https://aspire.dev/reference/cli/commands/aspire-otel-traces/).
 
 Once connected, agents can start your app, check resource health, fetch logs and traces, and more.
 

--- a/src/Aspire.Dashboard/Resources/xlf/Dialogs.pt-BR.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Dialogs.pt-BR.xlf
@@ -7,7 +7,7 @@
 
 The structured logs, distributed traces, and resource status in this dashboard are available to AI agents via the Aspire CLI. This gives agents deep observability into your app, to help them diagnose issues and verify fixes.
 
-Get started by running this command in your project:
+First, [install the Aspire CLI]({1}) if you haven't already. Then get started by running this command in your project:
 
 ```bash
 aspire agent init
@@ -22,7 +22,7 @@ For more information about using AI agents with Aspire, such as setting up skill
 
 The structured logs, distributed traces, and resource status in this dashboard are available to AI agents via the Aspire CLI. This gives agents deep observability into your app, to help them diagnose issues and verify fixes.
 
-Get started by running this command in your project:
+First, [install the Aspire CLI]({1}) if you haven't already. Then get started by running this command in your project:
 
 ```bash
 aspire agent init
@@ -33,14 +33,14 @@ This configures skill files for your AI assistant. The skill files tell the agen
 Once connected, agents can start your app, check resource health, fetch logs and traces, and more.
 
 For more information about using AI agents with Aspire, such as setting up skills, see [AI coding agents]({0}).</target>
-        <note />
+        <note>{0} is the learn more URL, {1} is the install CLI URL</note>
       </trans-unit>
       <trans-unit id="AIAgentsDialogStandaloneDescription">
         <source>Build, debug, and profile apps using AI agents and Aspire 🚀
 
 The structured logs and distributed traces in the dashboard are available to AI agents via the Aspire CLI. This gives agents deep observability into your app, to help them diagnose issues and verify fixes.
 
-Use Aspire CLI commands to get telemetry data in your terminal:
+First, [install the Aspire CLI]({2}) if you haven't already. Then use Aspire CLI commands to get telemetry data in your terminal:
 
 ```bash
 aspire otel logs --dashboard-url {0}
@@ -56,7 +56,7 @@ For more information about using AI agents with the dashboard, such as setting u
 
 The structured logs and distributed traces in the dashboard are available to AI agents via the Aspire CLI. This gives agents deep observability into your app, to help them diagnose issues and verify fixes.
 
-Use Aspire CLI commands to get telemetry data in your terminal:
+First, [install the Aspire CLI]({2}) if you haven't already. Then use Aspire CLI commands to get telemetry data in your terminal:
 
 ```bash
 aspire otel logs --dashboard-url {0}
@@ -68,7 +68,7 @@ aspire otel logs --dashboard-url {0}
 - [`aspire export`](https://aspire.dev/reference/cli/commands/aspire-export/) — Export telemetry and resource data to a zip file
 
 For more information about using AI agents with the dashboard, such as setting up skills, see [Standalone dashboard and AI coding agents]({1}).</target>
-        <note>{0} is the dashboard URL, {1} is the learn more URL</note>
+        <note>{0} is the dashboard URL, {1} is the learn more URL, {2} is the install CLI URL</note>
       </trans-unit>
       <trans-unit id="AIAgentsDialogTitle">
         <source>AI agents</source>

--- a/src/Aspire.Dashboard/Resources/xlf/Dialogs.pt-BR.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Dialogs.pt-BR.xlf
@@ -13,7 +13,7 @@ First, [install the Aspire CLI]({1}) if you haven't already. Then use an Aspire 
 aspire agent init
 ```
 
-This configures Aspire skill files for your AI agent. The skill files tell the agent how to use Aspire CLI commands such as [`aspire logs`](https://aspire.dev/reference/cli/commands/aspire-logs/) and [`aspire otel traces`](https://aspire.dev/reference/cli/commands/aspire-otel-traces/).
+This configures skill files for your AI agent. The skill files tell the agent how to use Aspire CLI commands such as [`aspire logs`](https://aspire.dev/reference/cli/commands/aspire-logs/) and [`aspire otel traces`](https://aspire.dev/reference/cli/commands/aspire-otel-traces/).
 
 Once connected, agents can start your app, check resource health, fetch logs and traces, and more.
 
@@ -28,7 +28,7 @@ First, [install the Aspire CLI]({1}) if you haven't already. Then use an Aspire 
 aspire agent init
 ```
 
-This configures Aspire skill files for your AI agent. The skill files tell the agent how to use Aspire CLI commands such as [`aspire logs`](https://aspire.dev/reference/cli/commands/aspire-logs/) and [`aspire otel traces`](https://aspire.dev/reference/cli/commands/aspire-otel-traces/).
+This configures skill files for your AI agent. The skill files tell the agent how to use Aspire CLI commands such as [`aspire logs`](https://aspire.dev/reference/cli/commands/aspire-logs/) and [`aspire otel traces`](https://aspire.dev/reference/cli/commands/aspire-otel-traces/).
 
 Once connected, agents can start your app, check resource health, fetch logs and traces, and more.
 

--- a/src/Aspire.Dashboard/Resources/xlf/Dialogs.ru.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Dialogs.ru.xlf
@@ -7,13 +7,13 @@
 
 The structured logs, distributed traces, and resource status in this dashboard are available to AI agents via the Aspire CLI. This gives agents deep observability into your app, to help them diagnose issues and verify fixes.
 
-First, [install the Aspire CLI]({1}) if you haven't already. Then get started by running this command in your project:
+First, [install the Aspire CLI]({1}) if you haven't already. Then use an Aspire CLI command to initialize agent support in your project:
 
 ```bash
 aspire agent init
 ```
 
-This configures skill files for your AI assistant. The skill files tell the agent how to use Aspire CLI commands such as [`aspire logs`](https://aspire.dev/reference/cli/commands/aspire-logs/) and [`aspire otel traces`](https://aspire.dev/reference/cli/commands/aspire-otel-traces/).
+This configures Aspire skill files for your AI agent. The skill files tell the agent how to use Aspire CLI commands such as [`aspire logs`](https://aspire.dev/reference/cli/commands/aspire-logs/) and [`aspire otel traces`](https://aspire.dev/reference/cli/commands/aspire-otel-traces/).
 
 Once connected, agents can start your app, check resource health, fetch logs and traces, and more.
 
@@ -22,13 +22,13 @@ For more information about using AI agents with Aspire, such as setting up skill
 
 The structured logs, distributed traces, and resource status in this dashboard are available to AI agents via the Aspire CLI. This gives agents deep observability into your app, to help them diagnose issues and verify fixes.
 
-First, [install the Aspire CLI]({1}) if you haven't already. Then get started by running this command in your project:
+First, [install the Aspire CLI]({1}) if you haven't already. Then use an Aspire CLI command to initialize agent support in your project:
 
 ```bash
 aspire agent init
 ```
 
-This configures skill files for your AI assistant. The skill files tell the agent how to use Aspire CLI commands such as [`aspire logs`](https://aspire.dev/reference/cli/commands/aspire-logs/) and [`aspire otel traces`](https://aspire.dev/reference/cli/commands/aspire-otel-traces/).
+This configures Aspire skill files for your AI agent. The skill files tell the agent how to use Aspire CLI commands such as [`aspire logs`](https://aspire.dev/reference/cli/commands/aspire-logs/) and [`aspire otel traces`](https://aspire.dev/reference/cli/commands/aspire-otel-traces/).
 
 Once connected, agents can start your app, check resource health, fetch logs and traces, and more.
 

--- a/src/Aspire.Dashboard/Resources/xlf/Dialogs.ru.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Dialogs.ru.xlf
@@ -7,7 +7,7 @@
 
 The structured logs, distributed traces, and resource status in this dashboard are available to AI agents via the Aspire CLI. This gives agents deep observability into your app, to help them diagnose issues and verify fixes.
 
-Get started by running this command in your project:
+First, [install the Aspire CLI]({1}) if you haven't already. Then get started by running this command in your project:
 
 ```bash
 aspire agent init
@@ -22,7 +22,7 @@ For more information about using AI agents with Aspire, such as setting up skill
 
 The structured logs, distributed traces, and resource status in this dashboard are available to AI agents via the Aspire CLI. This gives agents deep observability into your app, to help them diagnose issues and verify fixes.
 
-Get started by running this command in your project:
+First, [install the Aspire CLI]({1}) if you haven't already. Then get started by running this command in your project:
 
 ```bash
 aspire agent init
@@ -33,14 +33,14 @@ This configures skill files for your AI assistant. The skill files tell the agen
 Once connected, agents can start your app, check resource health, fetch logs and traces, and more.
 
 For more information about using AI agents with Aspire, such as setting up skills, see [AI coding agents]({0}).</target>
-        <note />
+        <note>{0} is the learn more URL, {1} is the install CLI URL</note>
       </trans-unit>
       <trans-unit id="AIAgentsDialogStandaloneDescription">
         <source>Build, debug, and profile apps using AI agents and Aspire 🚀
 
 The structured logs and distributed traces in the dashboard are available to AI agents via the Aspire CLI. This gives agents deep observability into your app, to help them diagnose issues and verify fixes.
 
-Use Aspire CLI commands to get telemetry data in your terminal:
+First, [install the Aspire CLI]({2}) if you haven't already. Then use Aspire CLI commands to get telemetry data in your terminal:
 
 ```bash
 aspire otel logs --dashboard-url {0}
@@ -56,7 +56,7 @@ For more information about using AI agents with the dashboard, such as setting u
 
 The structured logs and distributed traces in the dashboard are available to AI agents via the Aspire CLI. This gives agents deep observability into your app, to help them diagnose issues and verify fixes.
 
-Use Aspire CLI commands to get telemetry data in your terminal:
+First, [install the Aspire CLI]({2}) if you haven't already. Then use Aspire CLI commands to get telemetry data in your terminal:
 
 ```bash
 aspire otel logs --dashboard-url {0}
@@ -68,7 +68,7 @@ aspire otel logs --dashboard-url {0}
 - [`aspire export`](https://aspire.dev/reference/cli/commands/aspire-export/) — Export telemetry and resource data to a zip file
 
 For more information about using AI agents with the dashboard, such as setting up skills, see [Standalone dashboard and AI coding agents]({1}).</target>
-        <note>{0} is the dashboard URL, {1} is the learn more URL</note>
+        <note>{0} is the dashboard URL, {1} is the learn more URL, {2} is the install CLI URL</note>
       </trans-unit>
       <trans-unit id="AIAgentsDialogTitle">
         <source>AI agents</source>

--- a/src/Aspire.Dashboard/Resources/xlf/Dialogs.ru.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Dialogs.ru.xlf
@@ -13,7 +13,7 @@ First, [install the Aspire CLI]({1}) if you haven't already. Then use an Aspire 
 aspire agent init
 ```
 
-This configures Aspire skill files for your AI agent. The skill files tell the agent how to use Aspire CLI commands such as [`aspire logs`](https://aspire.dev/reference/cli/commands/aspire-logs/) and [`aspire otel traces`](https://aspire.dev/reference/cli/commands/aspire-otel-traces/).
+This configures skill files for your AI agent. The skill files tell the agent how to use Aspire CLI commands such as [`aspire logs`](https://aspire.dev/reference/cli/commands/aspire-logs/) and [`aspire otel traces`](https://aspire.dev/reference/cli/commands/aspire-otel-traces/).
 
 Once connected, agents can start your app, check resource health, fetch logs and traces, and more.
 
@@ -28,7 +28,7 @@ First, [install the Aspire CLI]({1}) if you haven't already. Then use an Aspire 
 aspire agent init
 ```
 
-This configures Aspire skill files for your AI agent. The skill files tell the agent how to use Aspire CLI commands such as [`aspire logs`](https://aspire.dev/reference/cli/commands/aspire-logs/) and [`aspire otel traces`](https://aspire.dev/reference/cli/commands/aspire-otel-traces/).
+This configures skill files for your AI agent. The skill files tell the agent how to use Aspire CLI commands such as [`aspire logs`](https://aspire.dev/reference/cli/commands/aspire-logs/) and [`aspire otel traces`](https://aspire.dev/reference/cli/commands/aspire-otel-traces/).
 
 Once connected, agents can start your app, check resource health, fetch logs and traces, and more.
 

--- a/src/Aspire.Dashboard/Resources/xlf/Dialogs.tr.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Dialogs.tr.xlf
@@ -7,13 +7,13 @@
 
 The structured logs, distributed traces, and resource status in this dashboard are available to AI agents via the Aspire CLI. This gives agents deep observability into your app, to help them diagnose issues and verify fixes.
 
-First, [install the Aspire CLI]({1}) if you haven't already. Then get started by running this command in your project:
+First, [install the Aspire CLI]({1}) if you haven't already. Then use an Aspire CLI command to initialize agent support in your project:
 
 ```bash
 aspire agent init
 ```
 
-This configures skill files for your AI assistant. The skill files tell the agent how to use Aspire CLI commands such as [`aspire logs`](https://aspire.dev/reference/cli/commands/aspire-logs/) and [`aspire otel traces`](https://aspire.dev/reference/cli/commands/aspire-otel-traces/).
+This configures Aspire skill files for your AI agent. The skill files tell the agent how to use Aspire CLI commands such as [`aspire logs`](https://aspire.dev/reference/cli/commands/aspire-logs/) and [`aspire otel traces`](https://aspire.dev/reference/cli/commands/aspire-otel-traces/).
 
 Once connected, agents can start your app, check resource health, fetch logs and traces, and more.
 
@@ -22,13 +22,13 @@ For more information about using AI agents with Aspire, such as setting up skill
 
 The structured logs, distributed traces, and resource status in this dashboard are available to AI agents via the Aspire CLI. This gives agents deep observability into your app, to help them diagnose issues and verify fixes.
 
-First, [install the Aspire CLI]({1}) if you haven't already. Then get started by running this command in your project:
+First, [install the Aspire CLI]({1}) if you haven't already. Then use an Aspire CLI command to initialize agent support in your project:
 
 ```bash
 aspire agent init
 ```
 
-This configures skill files for your AI assistant. The skill files tell the agent how to use Aspire CLI commands such as [`aspire logs`](https://aspire.dev/reference/cli/commands/aspire-logs/) and [`aspire otel traces`](https://aspire.dev/reference/cli/commands/aspire-otel-traces/).
+This configures Aspire skill files for your AI agent. The skill files tell the agent how to use Aspire CLI commands such as [`aspire logs`](https://aspire.dev/reference/cli/commands/aspire-logs/) and [`aspire otel traces`](https://aspire.dev/reference/cli/commands/aspire-otel-traces/).
 
 Once connected, agents can start your app, check resource health, fetch logs and traces, and more.
 

--- a/src/Aspire.Dashboard/Resources/xlf/Dialogs.tr.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Dialogs.tr.xlf
@@ -7,7 +7,7 @@
 
 The structured logs, distributed traces, and resource status in this dashboard are available to AI agents via the Aspire CLI. This gives agents deep observability into your app, to help them diagnose issues and verify fixes.
 
-Get started by running this command in your project:
+First, [install the Aspire CLI]({1}) if you haven't already. Then get started by running this command in your project:
 
 ```bash
 aspire agent init
@@ -22,7 +22,7 @@ For more information about using AI agents with Aspire, such as setting up skill
 
 The structured logs, distributed traces, and resource status in this dashboard are available to AI agents via the Aspire CLI. This gives agents deep observability into your app, to help them diagnose issues and verify fixes.
 
-Get started by running this command in your project:
+First, [install the Aspire CLI]({1}) if you haven't already. Then get started by running this command in your project:
 
 ```bash
 aspire agent init
@@ -33,14 +33,14 @@ This configures skill files for your AI assistant. The skill files tell the agen
 Once connected, agents can start your app, check resource health, fetch logs and traces, and more.
 
 For more information about using AI agents with Aspire, such as setting up skills, see [AI coding agents]({0}).</target>
-        <note />
+        <note>{0} is the learn more URL, {1} is the install CLI URL</note>
       </trans-unit>
       <trans-unit id="AIAgentsDialogStandaloneDescription">
         <source>Build, debug, and profile apps using AI agents and Aspire 🚀
 
 The structured logs and distributed traces in the dashboard are available to AI agents via the Aspire CLI. This gives agents deep observability into your app, to help them diagnose issues and verify fixes.
 
-Use Aspire CLI commands to get telemetry data in your terminal:
+First, [install the Aspire CLI]({2}) if you haven't already. Then use Aspire CLI commands to get telemetry data in your terminal:
 
 ```bash
 aspire otel logs --dashboard-url {0}
@@ -56,7 +56,7 @@ For more information about using AI agents with the dashboard, such as setting u
 
 The structured logs and distributed traces in the dashboard are available to AI agents via the Aspire CLI. This gives agents deep observability into your app, to help them diagnose issues and verify fixes.
 
-Use Aspire CLI commands to get telemetry data in your terminal:
+First, [install the Aspire CLI]({2}) if you haven't already. Then use Aspire CLI commands to get telemetry data in your terminal:
 
 ```bash
 aspire otel logs --dashboard-url {0}
@@ -68,7 +68,7 @@ aspire otel logs --dashboard-url {0}
 - [`aspire export`](https://aspire.dev/reference/cli/commands/aspire-export/) — Export telemetry and resource data to a zip file
 
 For more information about using AI agents with the dashboard, such as setting up skills, see [Standalone dashboard and AI coding agents]({1}).</target>
-        <note>{0} is the dashboard URL, {1} is the learn more URL</note>
+        <note>{0} is the dashboard URL, {1} is the learn more URL, {2} is the install CLI URL</note>
       </trans-unit>
       <trans-unit id="AIAgentsDialogTitle">
         <source>AI agents</source>

--- a/src/Aspire.Dashboard/Resources/xlf/Dialogs.tr.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Dialogs.tr.xlf
@@ -13,7 +13,7 @@ First, [install the Aspire CLI]({1}) if you haven't already. Then use an Aspire 
 aspire agent init
 ```
 
-This configures Aspire skill files for your AI agent. The skill files tell the agent how to use Aspire CLI commands such as [`aspire logs`](https://aspire.dev/reference/cli/commands/aspire-logs/) and [`aspire otel traces`](https://aspire.dev/reference/cli/commands/aspire-otel-traces/).
+This configures skill files for your AI agent. The skill files tell the agent how to use Aspire CLI commands such as [`aspire logs`](https://aspire.dev/reference/cli/commands/aspire-logs/) and [`aspire otel traces`](https://aspire.dev/reference/cli/commands/aspire-otel-traces/).
 
 Once connected, agents can start your app, check resource health, fetch logs and traces, and more.
 
@@ -28,7 +28,7 @@ First, [install the Aspire CLI]({1}) if you haven't already. Then use an Aspire 
 aspire agent init
 ```
 
-This configures Aspire skill files for your AI agent. The skill files tell the agent how to use Aspire CLI commands such as [`aspire logs`](https://aspire.dev/reference/cli/commands/aspire-logs/) and [`aspire otel traces`](https://aspire.dev/reference/cli/commands/aspire-otel-traces/).
+This configures skill files for your AI agent. The skill files tell the agent how to use Aspire CLI commands such as [`aspire logs`](https://aspire.dev/reference/cli/commands/aspire-logs/) and [`aspire otel traces`](https://aspire.dev/reference/cli/commands/aspire-otel-traces/).
 
 Once connected, agents can start your app, check resource health, fetch logs and traces, and more.
 

--- a/src/Aspire.Dashboard/Resources/xlf/Dialogs.zh-Hans.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Dialogs.zh-Hans.xlf
@@ -7,13 +7,13 @@
 
 The structured logs, distributed traces, and resource status in this dashboard are available to AI agents via the Aspire CLI. This gives agents deep observability into your app, to help them diagnose issues and verify fixes.
 
-First, [install the Aspire CLI]({1}) if you haven't already. Then get started by running this command in your project:
+First, [install the Aspire CLI]({1}) if you haven't already. Then use an Aspire CLI command to initialize agent support in your project:
 
 ```bash
 aspire agent init
 ```
 
-This configures skill files for your AI assistant. The skill files tell the agent how to use Aspire CLI commands such as [`aspire logs`](https://aspire.dev/reference/cli/commands/aspire-logs/) and [`aspire otel traces`](https://aspire.dev/reference/cli/commands/aspire-otel-traces/).
+This configures Aspire skill files for your AI agent. The skill files tell the agent how to use Aspire CLI commands such as [`aspire logs`](https://aspire.dev/reference/cli/commands/aspire-logs/) and [`aspire otel traces`](https://aspire.dev/reference/cli/commands/aspire-otel-traces/).
 
 Once connected, agents can start your app, check resource health, fetch logs and traces, and more.
 
@@ -22,13 +22,13 @@ For more information about using AI agents with Aspire, such as setting up skill
 
 The structured logs, distributed traces, and resource status in this dashboard are available to AI agents via the Aspire CLI. This gives agents deep observability into your app, to help them diagnose issues and verify fixes.
 
-First, [install the Aspire CLI]({1}) if you haven't already. Then get started by running this command in your project:
+First, [install the Aspire CLI]({1}) if you haven't already. Then use an Aspire CLI command to initialize agent support in your project:
 
 ```bash
 aspire agent init
 ```
 
-This configures skill files for your AI assistant. The skill files tell the agent how to use Aspire CLI commands such as [`aspire logs`](https://aspire.dev/reference/cli/commands/aspire-logs/) and [`aspire otel traces`](https://aspire.dev/reference/cli/commands/aspire-otel-traces/).
+This configures Aspire skill files for your AI agent. The skill files tell the agent how to use Aspire CLI commands such as [`aspire logs`](https://aspire.dev/reference/cli/commands/aspire-logs/) and [`aspire otel traces`](https://aspire.dev/reference/cli/commands/aspire-otel-traces/).
 
 Once connected, agents can start your app, check resource health, fetch logs and traces, and more.
 

--- a/src/Aspire.Dashboard/Resources/xlf/Dialogs.zh-Hans.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Dialogs.zh-Hans.xlf
@@ -7,7 +7,7 @@
 
 The structured logs, distributed traces, and resource status in this dashboard are available to AI agents via the Aspire CLI. This gives agents deep observability into your app, to help them diagnose issues and verify fixes.
 
-Get started by running this command in your project:
+First, [install the Aspire CLI]({1}) if you haven't already. Then get started by running this command in your project:
 
 ```bash
 aspire agent init
@@ -22,7 +22,7 @@ For more information about using AI agents with Aspire, such as setting up skill
 
 The structured logs, distributed traces, and resource status in this dashboard are available to AI agents via the Aspire CLI. This gives agents deep observability into your app, to help them diagnose issues and verify fixes.
 
-Get started by running this command in your project:
+First, [install the Aspire CLI]({1}) if you haven't already. Then get started by running this command in your project:
 
 ```bash
 aspire agent init
@@ -33,14 +33,14 @@ This configures skill files for your AI assistant. The skill files tell the agen
 Once connected, agents can start your app, check resource health, fetch logs and traces, and more.
 
 For more information about using AI agents with Aspire, such as setting up skills, see [AI coding agents]({0}).</target>
-        <note />
+        <note>{0} is the learn more URL, {1} is the install CLI URL</note>
       </trans-unit>
       <trans-unit id="AIAgentsDialogStandaloneDescription">
         <source>Build, debug, and profile apps using AI agents and Aspire 🚀
 
 The structured logs and distributed traces in the dashboard are available to AI agents via the Aspire CLI. This gives agents deep observability into your app, to help them diagnose issues and verify fixes.
 
-Use Aspire CLI commands to get telemetry data in your terminal:
+First, [install the Aspire CLI]({2}) if you haven't already. Then use Aspire CLI commands to get telemetry data in your terminal:
 
 ```bash
 aspire otel logs --dashboard-url {0}
@@ -56,7 +56,7 @@ For more information about using AI agents with the dashboard, such as setting u
 
 The structured logs and distributed traces in the dashboard are available to AI agents via the Aspire CLI. This gives agents deep observability into your app, to help them diagnose issues and verify fixes.
 
-Use Aspire CLI commands to get telemetry data in your terminal:
+First, [install the Aspire CLI]({2}) if you haven't already. Then use Aspire CLI commands to get telemetry data in your terminal:
 
 ```bash
 aspire otel logs --dashboard-url {0}
@@ -68,7 +68,7 @@ aspire otel logs --dashboard-url {0}
 - [`aspire export`](https://aspire.dev/reference/cli/commands/aspire-export/) — Export telemetry and resource data to a zip file
 
 For more information about using AI agents with the dashboard, such as setting up skills, see [Standalone dashboard and AI coding agents]({1}).</target>
-        <note>{0} is the dashboard URL, {1} is the learn more URL</note>
+        <note>{0} is the dashboard URL, {1} is the learn more URL, {2} is the install CLI URL</note>
       </trans-unit>
       <trans-unit id="AIAgentsDialogTitle">
         <source>AI agents</source>

--- a/src/Aspire.Dashboard/Resources/xlf/Dialogs.zh-Hans.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Dialogs.zh-Hans.xlf
@@ -13,7 +13,7 @@ First, [install the Aspire CLI]({1}) if you haven't already. Then use an Aspire 
 aspire agent init
 ```
 
-This configures Aspire skill files for your AI agent. The skill files tell the agent how to use Aspire CLI commands such as [`aspire logs`](https://aspire.dev/reference/cli/commands/aspire-logs/) and [`aspire otel traces`](https://aspire.dev/reference/cli/commands/aspire-otel-traces/).
+This configures skill files for your AI agent. The skill files tell the agent how to use Aspire CLI commands such as [`aspire logs`](https://aspire.dev/reference/cli/commands/aspire-logs/) and [`aspire otel traces`](https://aspire.dev/reference/cli/commands/aspire-otel-traces/).
 
 Once connected, agents can start your app, check resource health, fetch logs and traces, and more.
 
@@ -28,7 +28,7 @@ First, [install the Aspire CLI]({1}) if you haven't already. Then use an Aspire 
 aspire agent init
 ```
 
-This configures Aspire skill files for your AI agent. The skill files tell the agent how to use Aspire CLI commands such as [`aspire logs`](https://aspire.dev/reference/cli/commands/aspire-logs/) and [`aspire otel traces`](https://aspire.dev/reference/cli/commands/aspire-otel-traces/).
+This configures skill files for your AI agent. The skill files tell the agent how to use Aspire CLI commands such as [`aspire logs`](https://aspire.dev/reference/cli/commands/aspire-logs/) and [`aspire otel traces`](https://aspire.dev/reference/cli/commands/aspire-otel-traces/).
 
 Once connected, agents can start your app, check resource health, fetch logs and traces, and more.
 

--- a/src/Aspire.Dashboard/Resources/xlf/Dialogs.zh-Hant.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Dialogs.zh-Hant.xlf
@@ -7,13 +7,13 @@
 
 The structured logs, distributed traces, and resource status in this dashboard are available to AI agents via the Aspire CLI. This gives agents deep observability into your app, to help them diagnose issues and verify fixes.
 
-First, [install the Aspire CLI]({1}) if you haven't already. Then get started by running this command in your project:
+First, [install the Aspire CLI]({1}) if you haven't already. Then use an Aspire CLI command to initialize agent support in your project:
 
 ```bash
 aspire agent init
 ```
 
-This configures skill files for your AI assistant. The skill files tell the agent how to use Aspire CLI commands such as [`aspire logs`](https://aspire.dev/reference/cli/commands/aspire-logs/) and [`aspire otel traces`](https://aspire.dev/reference/cli/commands/aspire-otel-traces/).
+This configures Aspire skill files for your AI agent. The skill files tell the agent how to use Aspire CLI commands such as [`aspire logs`](https://aspire.dev/reference/cli/commands/aspire-logs/) and [`aspire otel traces`](https://aspire.dev/reference/cli/commands/aspire-otel-traces/).
 
 Once connected, agents can start your app, check resource health, fetch logs and traces, and more.
 
@@ -22,13 +22,13 @@ For more information about using AI agents with Aspire, such as setting up skill
 
 The structured logs, distributed traces, and resource status in this dashboard are available to AI agents via the Aspire CLI. This gives agents deep observability into your app, to help them diagnose issues and verify fixes.
 
-First, [install the Aspire CLI]({1}) if you haven't already. Then get started by running this command in your project:
+First, [install the Aspire CLI]({1}) if you haven't already. Then use an Aspire CLI command to initialize agent support in your project:
 
 ```bash
 aspire agent init
 ```
 
-This configures skill files for your AI assistant. The skill files tell the agent how to use Aspire CLI commands such as [`aspire logs`](https://aspire.dev/reference/cli/commands/aspire-logs/) and [`aspire otel traces`](https://aspire.dev/reference/cli/commands/aspire-otel-traces/).
+This configures Aspire skill files for your AI agent. The skill files tell the agent how to use Aspire CLI commands such as [`aspire logs`](https://aspire.dev/reference/cli/commands/aspire-logs/) and [`aspire otel traces`](https://aspire.dev/reference/cli/commands/aspire-otel-traces/).
 
 Once connected, agents can start your app, check resource health, fetch logs and traces, and more.
 

--- a/src/Aspire.Dashboard/Resources/xlf/Dialogs.zh-Hant.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Dialogs.zh-Hant.xlf
@@ -7,7 +7,7 @@
 
 The structured logs, distributed traces, and resource status in this dashboard are available to AI agents via the Aspire CLI. This gives agents deep observability into your app, to help them diagnose issues and verify fixes.
 
-Get started by running this command in your project:
+First, [install the Aspire CLI]({1}) if you haven't already. Then get started by running this command in your project:
 
 ```bash
 aspire agent init
@@ -22,7 +22,7 @@ For more information about using AI agents with Aspire, such as setting up skill
 
 The structured logs, distributed traces, and resource status in this dashboard are available to AI agents via the Aspire CLI. This gives agents deep observability into your app, to help them diagnose issues and verify fixes.
 
-Get started by running this command in your project:
+First, [install the Aspire CLI]({1}) if you haven't already. Then get started by running this command in your project:
 
 ```bash
 aspire agent init
@@ -33,14 +33,14 @@ This configures skill files for your AI assistant. The skill files tell the agen
 Once connected, agents can start your app, check resource health, fetch logs and traces, and more.
 
 For more information about using AI agents with Aspire, such as setting up skills, see [AI coding agents]({0}).</target>
-        <note />
+        <note>{0} is the learn more URL, {1} is the install CLI URL</note>
       </trans-unit>
       <trans-unit id="AIAgentsDialogStandaloneDescription">
         <source>Build, debug, and profile apps using AI agents and Aspire 🚀
 
 The structured logs and distributed traces in the dashboard are available to AI agents via the Aspire CLI. This gives agents deep observability into your app, to help them diagnose issues and verify fixes.
 
-Use Aspire CLI commands to get telemetry data in your terminal:
+First, [install the Aspire CLI]({2}) if you haven't already. Then use Aspire CLI commands to get telemetry data in your terminal:
 
 ```bash
 aspire otel logs --dashboard-url {0}
@@ -56,7 +56,7 @@ For more information about using AI agents with the dashboard, such as setting u
 
 The structured logs and distributed traces in the dashboard are available to AI agents via the Aspire CLI. This gives agents deep observability into your app, to help them diagnose issues and verify fixes.
 
-Use Aspire CLI commands to get telemetry data in your terminal:
+First, [install the Aspire CLI]({2}) if you haven't already. Then use Aspire CLI commands to get telemetry data in your terminal:
 
 ```bash
 aspire otel logs --dashboard-url {0}
@@ -68,7 +68,7 @@ aspire otel logs --dashboard-url {0}
 - [`aspire export`](https://aspire.dev/reference/cli/commands/aspire-export/) — Export telemetry and resource data to a zip file
 
 For more information about using AI agents with the dashboard, such as setting up skills, see [Standalone dashboard and AI coding agents]({1}).</target>
-        <note>{0} is the dashboard URL, {1} is the learn more URL</note>
+        <note>{0} is the dashboard URL, {1} is the learn more URL, {2} is the install CLI URL</note>
       </trans-unit>
       <trans-unit id="AIAgentsDialogTitle">
         <source>AI agents</source>

--- a/src/Aspire.Dashboard/Resources/xlf/Dialogs.zh-Hant.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Dialogs.zh-Hant.xlf
@@ -13,7 +13,7 @@ First, [install the Aspire CLI]({1}) if you haven't already. Then use an Aspire 
 aspire agent init
 ```
 
-This configures Aspire skill files for your AI agent. The skill files tell the agent how to use Aspire CLI commands such as [`aspire logs`](https://aspire.dev/reference/cli/commands/aspire-logs/) and [`aspire otel traces`](https://aspire.dev/reference/cli/commands/aspire-otel-traces/).
+This configures skill files for your AI agent. The skill files tell the agent how to use Aspire CLI commands such as [`aspire logs`](https://aspire.dev/reference/cli/commands/aspire-logs/) and [`aspire otel traces`](https://aspire.dev/reference/cli/commands/aspire-otel-traces/).
 
 Once connected, agents can start your app, check resource health, fetch logs and traces, and more.
 
@@ -28,7 +28,7 @@ First, [install the Aspire CLI]({1}) if you haven't already. Then use an Aspire 
 aspire agent init
 ```
 
-This configures Aspire skill files for your AI agent. The skill files tell the agent how to use Aspire CLI commands such as [`aspire logs`](https://aspire.dev/reference/cli/commands/aspire-logs/) and [`aspire otel traces`](https://aspire.dev/reference/cli/commands/aspire-otel-traces/).
+This configures skill files for your AI agent. The skill files tell the agent how to use Aspire CLI commands such as [`aspire logs`](https://aspire.dev/reference/cli/commands/aspire-logs/) and [`aspire otel traces`](https://aspire.dev/reference/cli/commands/aspire-otel-traces/).
 
 Once connected, agents can start your app, check resource health, fetch logs and traces, and more.
 


### PR DESCRIPTION
## Description

Adds a link to the CLI installation page (https://aspire.dev/get-started/install-cli/) in both the AppHost and Standalone AI Agents dialog descriptions. The link appears before the instructions to run CLI commands, guiding users to install the CLI first.

## Changes

- Updated `AIAgentsDialogStandaloneDescription` to include "First, [install the Aspire CLI]({2}) if you haven't already." before the CLI usage instructions
- Updated `AIAgentsDialogAppHostDescription` to include "First, [install the Aspire CLI]({1}) if you haven't already." before the `aspire agent init` command
- Added `InstallCliUrl` constant and passed it to both `string.Format` calls
- Updated xlf translation files