### PR TITLE
Show empty state for console logs

### DIFF
--- a/src/Aspire.Dashboard/Components/Controls/LogViewer.razor
+++ b/src/Aspire.Dashboard/Components/Controls/LogViewer.razor
@@ -15,7 +15,7 @@
             @if (ShowNoLogsMessage && logEntries.EntriesCount == 0)
             {
                 <div class="console-empty-message" role="status" aria-live="polite">
-                    <FluentIcon Value="@(new Icons.Regular.Size16.SlideText())" />
+                    <FluentIcon Value="@(new Icons.Regular.Size24.SlideText())" />
                     <span>@Loc[nameof(ConsoleLogs.ConsoleLogsNoLogsFound)]</span>
                 </div>
             }

--- a/src/Aspire.Dashboard/Components/Controls/LogViewer.razor
+++ b/src/Aspire.Dashboard/Components/Controls/LogViewer.razor
@@ -12,6 +12,13 @@
     <div class="@GetLogContainerClass()" id="logContainer">
         @if (LogEntries is { } logEntries)
         {
+            @if (ShowNoLogsMessage && logEntries.EntriesCount == 0)
+            {
+                <div class="console-empty-message" role="status" aria-live="polite">
+                    <FluentIcon Value="@(new Icons.Regular.Size16.SlideText())" />
+                    <span>@Loc[nameof(ConsoleLogs.ConsoleLogsNoLogsFound)]</span>
+                </div>
+            }
             <Virtualize @ref="VirtualizeRef" ItemsProvider="@GetItems" ItemSize="20" OverscanCount="200" TItem="LogEntry">
                 @if (context.Pause is { } pause)
                 {

--- a/src/Aspire.Dashboard/Components/Controls/LogViewer.razor
+++ b/src/Aspire.Dashboard/Components/Controls/LogViewer.razor
@@ -15,7 +15,7 @@
             @if (ShowNoLogsMessage && logEntries.EntriesCount == 0)
             {
                 <div class="console-empty-message" role="status" aria-live="polite">
-                    <FluentIcon Value="@(new Icons.Regular.Size16.SlideText())" />
+                    <FluentIcon Value="@(new Icons.Regular.Size16.SlideText())" aria-hidden="true" />
                     <span>@Loc[nameof(ConsoleLogs.ConsoleLogsNoLogsFound)]</span>
                 </div>
             }

--- a/src/Aspire.Dashboard/Components/Controls/LogViewer.razor.cs
+++ b/src/Aspire.Dashboard/Components/Controls/LogViewer.razor.cs
@@ -46,6 +46,9 @@ public sealed partial class LogViewer
     [Parameter]
     public bool NoWrapLogs { get; set; }
 
+    [Parameter]
+    public bool ShowNoLogsMessage { get; set; }
+
     private Virtualize<LogEntry>? VirtualizeRef
     {
         get => field;

--- a/src/Aspire.Dashboard/Components/Controls/LogViewer.razor.css
+++ b/src/Aspire.Dashboard/Components/Controls/LogViewer.razor.css
@@ -28,14 +28,16 @@
 }
 
 ::deep .console-empty-message {
+    gap: 8px;
+    color: #fff;
+    user-select: none;
+    font-family: var(--body-font);
+    font-weight: 600;
+    padding: calc(var(--design-unit) * 5px);
     display: flex;
     align-items: center;
-    gap: 8px;
-    padding: 20px 24px;
-    color: var(--console-font-color);
-    cursor: default;
-    opacity: 0.72;
-    user-select: none;
+    height: auto !important;
+    justify-content: center;
 }
 
 ::deep .ansi-fg-black {

--- a/src/Aspire.Dashboard/Components/Controls/LogViewer.razor.css
+++ b/src/Aspire.Dashboard/Components/Controls/LogViewer.razor.css
@@ -27,6 +27,17 @@
     user-select: none;
 }
 
+::deep .console-empty-message {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    padding: 20px 24px;
+    color: var(--console-font-color);
+    cursor: default;
+    opacity: 0.72;
+    user-select: none;
+}
+
 ::deep .ansi-fg-black {
     color: var(--console-theme-black);
 }

--- a/src/Aspire.Dashboard/Components/Pages/ConsoleLogs.razor
+++ b/src/Aspire.Dashboard/Components/Pages/ConsoleLogs.razor
@@ -110,6 +110,7 @@
                 ShowTimestamp="@_showTimestamp"
                 IsTimestampUtc="@_isTimestampUtc"
                 NoWrapLogs="@_noWrapLogs"
+                ShowNoLogsMessage="@_showNoLogsMessage"
                 ShowResourcePrefix="@_isSubscribedToAll"/>
         </MainSection>
     </AspirePageContentLayout>

--- a/src/Aspire.Dashboard/Components/Pages/ConsoleLogs.razor.cs
+++ b/src/Aspire.Dashboard/Components/Pages/ConsoleLogs.razor.cs
@@ -27,6 +27,8 @@ namespace Aspire.Dashboard.Components.Pages;
 
 public sealed partial class ConsoleLogs : ComponentBase, IComponentWithTelemetry, IAsyncDisposable, IPageWithSessionAndUrlState<ConsoleLogs.ConsoleLogsViewModel, ConsoleLogs.ConsoleLogsPageState>
 {
+    private static readonly TimeSpan s_noLogsMessageDelay = TimeSpan.FromSeconds(1.5);
+
     [DebuggerDisplay("Resource = {Resource.Name}, IsCancellationRequested = {CancellationToken.IsCancellationRequested}")]
     private sealed class ConsoleLogsSubscription
     {
@@ -415,7 +417,7 @@ public sealed partial class ConsoleLogs : ComponentBase, IComponentWithTelemetry
         {
             _logEntries.Clear(keepActivePauseEntries: false);
         }
-        StopNoLogsMessageDelay();
+        ResetNoLogsMessage();
 
         await InvokeAsync(_logViewerRef.SafeRefreshDataAsync);
 
@@ -664,17 +666,15 @@ public sealed partial class ConsoleLogs : ComponentBase, IComponentWithTelemetry
 
     private void StartNoLogsMessageDelay()
     {
-        StopNoLogsMessageDelay();
+        ResetNoLogsMessage();
 
         _showNoLogsMessageCts = new();
         _ = ShowNoLogsMessageAfterDelayAsync(_showNoLogsMessageCts.Token);
     }
 
-    private void StopNoLogsMessageDelay()
+    private void ResetNoLogsMessage()
     {
         _showNoLogsMessageCts?.Cancel();
-        _showNoLogsMessageCts?.Dispose();
-        _showNoLogsMessageCts = null;
         _showNoLogsMessage = false;
     }
 
@@ -682,7 +682,7 @@ public sealed partial class ConsoleLogs : ComponentBase, IComponentWithTelemetry
     {
         try
         {
-            await Task.Delay(TimeSpan.FromSeconds(2), cancellationToken);
+            await Task.Delay(s_noLogsMessageDelay, cancellationToken);
         }
         catch (OperationCanceledException)
         {
@@ -1021,7 +1021,8 @@ public sealed partial class ConsoleLogs : ComponentBase, IComponentWithTelemetry
     public async ValueTask DisposeAsync()
     {
         _aiContext?.Dispose();
-        StopNoLogsMessageDelay();
+        ResetNoLogsMessage();
+        _showNoLogsMessageCts?.Dispose();
 
         _consoleLogsFiltersChangedSubscription?.Dispose();
 

--- a/src/Aspire.Dashboard/Components/Pages/ConsoleLogs.razor.cs
+++ b/src/Aspire.Dashboard/Components/Pages/ConsoleLogs.razor.cs
@@ -157,6 +157,7 @@ public sealed partial class ConsoleLogs : ComponentBase, IComponentWithTelemetry
     internal LogEntries _logEntries = null!;
     private readonly object _updateLogsLock = new object();
     private CancellationTokenSource? _showNoLogsMessageCts;
+    private Task? _showNoLogsMessageDelayTask;
     private AIContext? _aiContext;
     private LogViewer? _logViewerRef;
 
@@ -667,7 +668,7 @@ public sealed partial class ConsoleLogs : ComponentBase, IComponentWithTelemetry
         StopNoLogsMessageDelay();
 
         _showNoLogsMessageCts = new();
-        _ = ShowNoLogsMessageAfterDelayAsync(_showNoLogsMessageCts.Token);
+        _showNoLogsMessageDelayTask = ShowNoLogsMessageAfterDelayAsync(_showNoLogsMessageCts.Token);
     }
 
     private void StopNoLogsMessageDelay()
@@ -683,26 +684,37 @@ public sealed partial class ConsoleLogs : ComponentBase, IComponentWithTelemetry
         try
         {
             await Task.Delay(TimeSpan.FromSeconds(2), cancellationToken);
+
+            if (cancellationToken.IsCancellationRequested)
+            {
+                return;
+            }
+
+            await InvokeAsync(() =>
+            {
+                var hasNoLogEntries = false;
+                lock (_updateLogsLock)
+                {
+                    hasNoLogEntries = _logEntries.EntriesCount == 0;
+                }
+
+                if (!cancellationToken.IsCancellationRequested && hasNoLogEntries)
+                {
+                    _showNoLogsMessage = true;
+                    StateHasChanged();
+                }
+            });
         }
         catch (OperationCanceledException)
         {
-            return;
         }
-
-        await InvokeAsync(() =>
+        catch (Exception) when (cancellationToken.IsCancellationRequested)
         {
-            var hasNoLogEntries = false;
-            lock (_updateLogsLock)
-            {
-                hasNoLogEntries = _logEntries.EntriesCount == 0;
-            }
-
-            if (!cancellationToken.IsCancellationRequested && hasNoLogEntries)
-            {
-                _showNoLogsMessage = true;
-                StateHasChanged();
-            }
-        });
+        }
+        catch (Exception ex)
+        {
+            Logger.LogDebug(ex, "Failed to show the no logs message.");
+        }
     }
 
     private string GetResourceName(ResourceViewModel resource) => ResourceViewModel.GetResourceName(resource, _resourceByName);
@@ -1022,6 +1034,7 @@ public sealed partial class ConsoleLogs : ComponentBase, IComponentWithTelemetry
     {
         _aiContext?.Dispose();
         StopNoLogsMessageDelay();
+        await TaskHelpers.WaitIgnoreCancelAsync(_showNoLogsMessageDelayTask);
 
         _consoleLogsFiltersChangedSubscription?.Dispose();
 

--- a/src/Aspire.Dashboard/Components/Pages/ConsoleLogs.razor.cs
+++ b/src/Aspire.Dashboard/Components/Pages/ConsoleLogs.razor.cs
@@ -1026,7 +1026,7 @@ public sealed partial class ConsoleLogs : ComponentBase, IComponentWithTelemetry
     {
         _aiContext?.Dispose();
         ResetNoLogsMessage();
-        _showNoLogsMessageCts?.Dispose();
+        _showNoLogsMessageCts?.Cancel();
         await TaskHelpers.WaitIgnoreCancelAsync(_showNoLogsMessageDelayTask);
 
         _consoleLogsFiltersChangedSubscription?.Dispose();

--- a/src/Aspire.Dashboard/Components/Pages/ConsoleLogs.razor.cs
+++ b/src/Aspire.Dashboard/Components/Pages/ConsoleLogs.razor.cs
@@ -685,30 +685,22 @@ public sealed partial class ConsoleLogs : ComponentBase, IComponentWithTelemetry
         {
             await Task.Delay(s_noLogsMessageDelay, cancellationToken);
 
-            if (cancellationToken.IsCancellationRequested)
-            {
-                return;
-            }
-
             await InvokeAsync(() =>
             {
-                var hasNoLogEntries = false;
-                lock (_updateLogsLock)
+                if (!cancellationToken.IsCancellationRequested)
                 {
-                    hasNoLogEntries = _logEntries.EntriesCount == 0;
-                }
+                    var hasNoLogEntries = false;
+                    lock (_updateLogsLock)
+                    {
+                        hasNoLogEntries = _logEntries.EntriesCount == 0;
+                    }
 
-                if (!cancellationToken.IsCancellationRequested && hasNoLogEntries)
-                {
-                    _showNoLogsMessage = true;
+                    _showNoLogsMessage = hasNoLogEntries;
                     StateHasChanged();
                 }
             });
         }
         catch (OperationCanceledException)
-        {
-        }
-        catch (Exception) when (cancellationToken.IsCancellationRequested)
         {
         }
         catch (Exception ex)

--- a/src/Aspire.Dashboard/Components/Pages/ConsoleLogs.razor.cs
+++ b/src/Aspire.Dashboard/Components/Pages/ConsoleLogs.razor.cs
@@ -156,6 +156,7 @@ public sealed partial class ConsoleLogs : ComponentBase, IComponentWithTelemetry
     private bool _isSubscribedToAll;
     internal LogEntries _logEntries = null!;
     private readonly object _updateLogsLock = new object();
+    private CancellationTokenSource? _showNoLogsMessageCts;
     private AIContext? _aiContext;
     private LogViewer? _logViewerRef;
 
@@ -171,6 +172,7 @@ public sealed partial class ConsoleLogs : ComponentBase, IComponentWithTelemetry
     private bool _showTimestamp;
     private bool _isTimestampUtc;
     private bool _noWrapLogs;
+    private bool _showNoLogsMessage;
     public ConsoleLogsViewModel PageViewModel { get; set; } = null!;
     private IDisposable? _consoleLogsFiltersChangedSubscription;
 
@@ -308,6 +310,7 @@ public sealed partial class ConsoleLogs : ComponentBase, IComponentWithTelemetry
     {
         await foreach (var batch in _logEntryChannel.GetBatchesAsync(minReadInterval: TimeSpan.FromMilliseconds(100), cancellationToken: _resourceSubscriptionToken))
         {
+            var hasNewLogEntry = false;
             lock (_updateLogsLock)
             {
                 foreach (var (resourceName, logEntry, lineNumber) in batch)
@@ -334,10 +337,19 @@ public sealed partial class ConsoleLogs : ComponentBase, IComponentWithTelemetry
                     }
 
                     _logEntries.InsertSorted(logEntry);
+                    hasNewLogEntry = true;
                 }
             }
 
-            await InvokeAsync(_logViewerRef.SafeRefreshDataAsync);
+            await InvokeAsync(async () =>
+            {
+                if (hasNewLogEntry)
+                {
+                    _showNoLogsMessage = false;
+                }
+
+                await _logViewerRef.SafeRefreshDataAsync();
+            });
         }
     }
 
@@ -403,6 +415,7 @@ public sealed partial class ConsoleLogs : ComponentBase, IComponentWithTelemetry
         {
             _logEntries.Clear(keepActivePauseEntries: false);
         }
+        StopNoLogsMessageDelay();
 
         await InvokeAsync(_logViewerRef.SafeRefreshDataAsync);
 
@@ -421,6 +434,11 @@ public sealed partial class ConsoleLogs : ComponentBase, IComponentWithTelemetry
         else
         {
             Logger.LogDebug("Unexpected state. Unknown resource '{ResourceName}' selected.", selectedResourceName);
+        }
+
+        if (!_consoleLogsSubscriptions.IsEmpty)
+        {
+            StartNoLogsMessageDelay();
         }
     }
 
@@ -642,6 +660,49 @@ public sealed partial class ConsoleLogs : ComponentBase, IComponentWithTelemetry
         }
 
         return Task.CompletedTask;
+    }
+
+    private void StartNoLogsMessageDelay()
+    {
+        StopNoLogsMessageDelay();
+
+        _showNoLogsMessageCts = new();
+        _ = ShowNoLogsMessageAfterDelayAsync(_showNoLogsMessageCts.Token);
+    }
+
+    private void StopNoLogsMessageDelay()
+    {
+        _showNoLogsMessageCts?.Cancel();
+        _showNoLogsMessageCts?.Dispose();
+        _showNoLogsMessageCts = null;
+        _showNoLogsMessage = false;
+    }
+
+    private async Task ShowNoLogsMessageAfterDelayAsync(CancellationToken cancellationToken)
+    {
+        try
+        {
+            await Task.Delay(TimeSpan.FromSeconds(2), cancellationToken);
+        }
+        catch (OperationCanceledException)
+        {
+            return;
+        }
+
+        await InvokeAsync(() =>
+        {
+            var hasNoLogEntries = false;
+            lock (_updateLogsLock)
+            {
+                hasNoLogEntries = _logEntries.EntriesCount == 0;
+            }
+
+            if (!cancellationToken.IsCancellationRequested && hasNoLogEntries)
+            {
+                _showNoLogsMessage = true;
+                StateHasChanged();
+            }
+        });
     }
 
     private string GetResourceName(ResourceViewModel resource) => ResourceViewModel.GetResourceName(resource, _resourceByName);
@@ -960,6 +1021,7 @@ public sealed partial class ConsoleLogs : ComponentBase, IComponentWithTelemetry
     public async ValueTask DisposeAsync()
     {
         _aiContext?.Dispose();
+        StopNoLogsMessageDelay();
 
         _consoleLogsFiltersChangedSubscription?.Dispose();
 

--- a/src/Aspire.Dashboard/Resources/ConsoleLogs.Designer.cs
+++ b/src/Aspire.Dashboard/Resources/ConsoleLogs.Designer.cs
@@ -68,6 +68,12 @@ namespace Aspire.Dashboard.Resources {
                 return ResourceManager.GetString("ConsoleLogsLogsNotYetAvailable", resourceCulture);
             }
         }
+
+        public static string ConsoleLogsNoLogsFound {
+            get {
+                return ResourceManager.GetString("ConsoleLogsNoLogsFound", resourceCulture);
+            }
+        }
         
         public static string ConsoleLogsWatchingLogs {
             get {

--- a/src/Aspire.Dashboard/Resources/ConsoleLogs.resx
+++ b/src/Aspire.Dashboard/Resources/ConsoleLogs.resx
@@ -130,6 +130,9 @@
   <data name="ConsoleLogsLogsNotYetAvailable" xml:space="preserve">
     <value>Logs not yet available</value>
   </data>
+  <data name="ConsoleLogsNoLogsFound" xml:space="preserve">
+    <value>No logs found</value>
+  </data>
   <data name="ConsoleLogsWatchingLogs" xml:space="preserve">
     <value>Watching logs...</value>
   </data>

--- a/src/Aspire.Dashboard/Resources/xlf/ConsoleLogs.cs.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/ConsoleLogs.cs.xlf
@@ -27,6 +27,11 @@
         <target state="translated">Protokoly ještě nejsou k dispozici.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ConsoleLogsNoLogsFound">
+        <source>No logs found</source>
+        <target state="new">No logs found</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ConsoleLogsNoResourceSelected">
         <source>No resource selected</source>
         <target state="translated">Nevybrán žádný prostředek</target>

--- a/src/Aspire.Dashboard/Resources/xlf/ConsoleLogs.cs.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/ConsoleLogs.cs.xlf
@@ -29,7 +29,7 @@
       </trans-unit>
       <trans-unit id="ConsoleLogsNoLogsFound">
         <source>No logs found</source>
-        <target state="new">No logs found</target>
+        <target state="translated">Nenašly se žádné protokoly.</target>
         <note />
       </trans-unit>
       <trans-unit id="ConsoleLogsNoResourceSelected">

--- a/src/Aspire.Dashboard/Resources/xlf/ConsoleLogs.cs.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/ConsoleLogs.cs.xlf
@@ -29,7 +29,7 @@
       </trans-unit>
       <trans-unit id="ConsoleLogsNoLogsFound">
         <source>No logs found</source>
-        <target state="translated">Nenašly se žádné protokoly.</target>
+        <target state="new">No logs found</target>
         <note />
       </trans-unit>
       <trans-unit id="ConsoleLogsNoResourceSelected">

--- a/src/Aspire.Dashboard/Resources/xlf/ConsoleLogs.de.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/ConsoleLogs.de.xlf
@@ -27,6 +27,11 @@
         <target state="translated">Protokolle noch nicht verfügbar</target>
         <note />
       </trans-unit>
+      <trans-unit id="ConsoleLogsNoLogsFound">
+        <source>No logs found</source>
+        <target state="new">No logs found</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ConsoleLogsNoResourceSelected">
         <source>No resource selected</source>
         <target state="translated">Keine Ressource ausgewählt</target>

--- a/src/Aspire.Dashboard/Resources/xlf/ConsoleLogs.de.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/ConsoleLogs.de.xlf
@@ -29,7 +29,7 @@
       </trans-unit>
       <trans-unit id="ConsoleLogsNoLogsFound">
         <source>No logs found</source>
-        <target state="new">No logs found</target>
+        <target state="translated">Keine Protokolle gefunden.</target>
         <note />
       </trans-unit>
       <trans-unit id="ConsoleLogsNoResourceSelected">

--- a/src/Aspire.Dashboard/Resources/xlf/ConsoleLogs.de.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/ConsoleLogs.de.xlf
@@ -29,7 +29,7 @@
       </trans-unit>
       <trans-unit id="ConsoleLogsNoLogsFound">
         <source>No logs found</source>
-        <target state="translated">Keine Protokolle gefunden.</target>
+        <target state="new">No logs found</target>
         <note />
       </trans-unit>
       <trans-unit id="ConsoleLogsNoResourceSelected">

--- a/src/Aspire.Dashboard/Resources/xlf/ConsoleLogs.es.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/ConsoleLogs.es.xlf
@@ -27,6 +27,11 @@
         <target state="translated">Los registros aún no están disponibles</target>
         <note />
       </trans-unit>
+      <trans-unit id="ConsoleLogsNoLogsFound">
+        <source>No logs found</source>
+        <target state="new">No logs found</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ConsoleLogsNoResourceSelected">
         <source>No resource selected</source>
         <target state="translated">No hay ningún recurso seleccionado</target>

--- a/src/Aspire.Dashboard/Resources/xlf/ConsoleLogs.es.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/ConsoleLogs.es.xlf
@@ -29,7 +29,7 @@
       </trans-unit>
       <trans-unit id="ConsoleLogsNoLogsFound">
         <source>No logs found</source>
-        <target state="new">No logs found</target>
+        <target state="translated">No se encontraron registros</target>
         <note />
       </trans-unit>
       <trans-unit id="ConsoleLogsNoResourceSelected">

--- a/src/Aspire.Dashboard/Resources/xlf/ConsoleLogs.es.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/ConsoleLogs.es.xlf
@@ -29,7 +29,7 @@
       </trans-unit>
       <trans-unit id="ConsoleLogsNoLogsFound">
         <source>No logs found</source>
-        <target state="translated">No se encontraron registros</target>
+        <target state="new">No logs found</target>
         <note />
       </trans-unit>
       <trans-unit id="ConsoleLogsNoResourceSelected">

--- a/src/Aspire.Dashboard/Resources/xlf/ConsoleLogs.fr.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/ConsoleLogs.fr.xlf
@@ -27,6 +27,11 @@
         <target state="translated">Journaux non disponibles pour le moment</target>
         <note />
       </trans-unit>
+      <trans-unit id="ConsoleLogsNoLogsFound">
+        <source>No logs found</source>
+        <target state="new">No logs found</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ConsoleLogsNoResourceSelected">
         <source>No resource selected</source>
         <target state="translated">Aucune ressource sélectionnée</target>

--- a/src/Aspire.Dashboard/Resources/xlf/ConsoleLogs.fr.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/ConsoleLogs.fr.xlf
@@ -29,7 +29,7 @@
       </trans-unit>
       <trans-unit id="ConsoleLogsNoLogsFound">
         <source>No logs found</source>
-        <target state="new">No logs found</target>
+        <target state="translated">Journaux introuvables</target>
         <note />
       </trans-unit>
       <trans-unit id="ConsoleLogsNoResourceSelected">

--- a/src/Aspire.Dashboard/Resources/xlf/ConsoleLogs.fr.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/ConsoleLogs.fr.xlf
@@ -29,7 +29,7 @@
       </trans-unit>
       <trans-unit id="ConsoleLogsNoLogsFound">
         <source>No logs found</source>
-        <target state="translated">Journaux introuvables</target>
+        <target state="new">No logs found</target>
         <note />
       </trans-unit>
       <trans-unit id="ConsoleLogsNoResourceSelected">

--- a/src/Aspire.Dashboard/Resources/xlf/ConsoleLogs.it.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/ConsoleLogs.it.xlf
@@ -29,7 +29,7 @@
       </trans-unit>
       <trans-unit id="ConsoleLogsNoLogsFound">
         <source>No logs found</source>
-        <target state="new">No logs found</target>
+        <target state="translated">Nessun log trovato</target>
         <note />
       </trans-unit>
       <trans-unit id="ConsoleLogsNoResourceSelected">

--- a/src/Aspire.Dashboard/Resources/xlf/ConsoleLogs.it.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/ConsoleLogs.it.xlf
@@ -27,6 +27,11 @@
         <target state="translated">Log non ancora disponibili</target>
         <note />
       </trans-unit>
+      <trans-unit id="ConsoleLogsNoLogsFound">
+        <source>No logs found</source>
+        <target state="new">No logs found</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ConsoleLogsNoResourceSelected">
         <source>No resource selected</source>
         <target state="translated">Nessuna risorsa selezionata</target>

--- a/src/Aspire.Dashboard/Resources/xlf/ConsoleLogs.it.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/ConsoleLogs.it.xlf
@@ -29,7 +29,7 @@
       </trans-unit>
       <trans-unit id="ConsoleLogsNoLogsFound">
         <source>No logs found</source>
-        <target state="translated">Nessun log trovato</target>
+        <target state="new">No logs found</target>
         <note />
       </trans-unit>
       <trans-unit id="ConsoleLogsNoResourceSelected">

--- a/src/Aspire.Dashboard/Resources/xlf/ConsoleLogs.ja.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/ConsoleLogs.ja.xlf
@@ -27,6 +27,11 @@
         <target state="translated">ログはまだ使用できません</target>
         <note />
       </trans-unit>
+      <trans-unit id="ConsoleLogsNoLogsFound">
+        <source>No logs found</source>
+        <target state="new">No logs found</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ConsoleLogsNoResourceSelected">
         <source>No resource selected</source>
         <target state="translated">リソースが選択されていません</target>

--- a/src/Aspire.Dashboard/Resources/xlf/ConsoleLogs.ja.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/ConsoleLogs.ja.xlf
@@ -29,7 +29,7 @@
       </trans-unit>
       <trans-unit id="ConsoleLogsNoLogsFound">
         <source>No logs found</source>
-        <target state="new">No logs found</target>
+        <target state="translated">ログが見つかりません</target>
         <note />
       </trans-unit>
       <trans-unit id="ConsoleLogsNoResourceSelected">

--- a/src/Aspire.Dashboard/Resources/xlf/ConsoleLogs.ja.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/ConsoleLogs.ja.xlf
@@ -29,7 +29,7 @@
       </trans-unit>
       <trans-unit id="ConsoleLogsNoLogsFound">
         <source>No logs found</source>
-        <target state="translated">ログが見つかりません</target>
+        <target state="new">No logs found</target>
         <note />
       </trans-unit>
       <trans-unit id="ConsoleLogsNoResourceSelected">

--- a/src/Aspire.Dashboard/Resources/xlf/ConsoleLogs.ko.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/ConsoleLogs.ko.xlf
@@ -29,7 +29,7 @@
       </trans-unit>
       <trans-unit id="ConsoleLogsNoLogsFound">
         <source>No logs found</source>
-        <target state="new">No logs found</target>
+        <target state="translated">로그를 찾을 수 없음</target>
         <note />
       </trans-unit>
       <trans-unit id="ConsoleLogsNoResourceSelected">

--- a/src/Aspire.Dashboard/Resources/xlf/ConsoleLogs.ko.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/ConsoleLogs.ko.xlf
@@ -27,6 +27,11 @@
         <target state="translated">로그를 아직 사용할 수 없음</target>
         <note />
       </trans-unit>
+      <trans-unit id="ConsoleLogsNoLogsFound">
+        <source>No logs found</source>
+        <target state="new">No logs found</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ConsoleLogsNoResourceSelected">
         <source>No resource selected</source>
         <target state="translated">리소스를 선택하지 않음</target>

--- a/src/Aspire.Dashboard/Resources/xlf/ConsoleLogs.ko.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/ConsoleLogs.ko.xlf
@@ -29,7 +29,7 @@
       </trans-unit>
       <trans-unit id="ConsoleLogsNoLogsFound">
         <source>No logs found</source>
-        <target state="translated">로그를 찾을 수 없음</target>
+        <target state="new">No logs found</target>
         <note />
       </trans-unit>
       <trans-unit id="ConsoleLogsNoResourceSelected">

--- a/src/Aspire.Dashboard/Resources/xlf/ConsoleLogs.pl.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/ConsoleLogs.pl.xlf
@@ -29,7 +29,7 @@
       </trans-unit>
       <trans-unit id="ConsoleLogsNoLogsFound">
         <source>No logs found</source>
-        <target state="new">No logs found</target>
+        <target state="translated">Nie znaleziono dzienników</target>
         <note />
       </trans-unit>
       <trans-unit id="ConsoleLogsNoResourceSelected">

--- a/src/Aspire.Dashboard/Resources/xlf/ConsoleLogs.pl.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/ConsoleLogs.pl.xlf
@@ -27,6 +27,11 @@
         <target state="translated">Dzienniki nie są jeszcze dostępne</target>
         <note />
       </trans-unit>
+      <trans-unit id="ConsoleLogsNoLogsFound">
+        <source>No logs found</source>
+        <target state="new">No logs found</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ConsoleLogsNoResourceSelected">
         <source>No resource selected</source>
         <target state="translated">Nie wybrano zasobu</target>

--- a/src/Aspire.Dashboard/Resources/xlf/ConsoleLogs.pl.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/ConsoleLogs.pl.xlf
@@ -29,7 +29,7 @@
       </trans-unit>
       <trans-unit id="ConsoleLogsNoLogsFound">
         <source>No logs found</source>
-        <target state="translated">Nie znaleziono dzienników</target>
+        <target state="new">No logs found</target>
         <note />
       </trans-unit>
       <trans-unit id="ConsoleLogsNoResourceSelected">

--- a/src/Aspire.Dashboard/Resources/xlf/ConsoleLogs.pt-BR.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/ConsoleLogs.pt-BR.xlf
@@ -27,6 +27,11 @@
         <target state="translated">Logs ainda não disponíveis</target>
         <note />
       </trans-unit>
+      <trans-unit id="ConsoleLogsNoLogsFound">
+        <source>No logs found</source>
+        <target state="new">No logs found</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ConsoleLogsNoResourceSelected">
         <source>No resource selected</source>
         <target state="translated">Não há nenhum recurso selecionado</target>

--- a/src/Aspire.Dashboard/Resources/xlf/ConsoleLogs.pt-BR.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/ConsoleLogs.pt-BR.xlf
@@ -29,7 +29,7 @@
       </trans-unit>
       <trans-unit id="ConsoleLogsNoLogsFound">
         <source>No logs found</source>
-        <target state="new">No logs found</target>
+        <target state="translated">Nenhum log encontrado</target>
         <note />
       </trans-unit>
       <trans-unit id="ConsoleLogsNoResourceSelected">

--- a/src/Aspire.Dashboard/Resources/xlf/ConsoleLogs.pt-BR.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/ConsoleLogs.pt-BR.xlf
@@ -29,7 +29,7 @@
       </trans-unit>
       <trans-unit id="ConsoleLogsNoLogsFound">
         <source>No logs found</source>
-        <target state="translated">Nenhum log encontrado</target>
+        <target state="new">No logs found</target>
         <note />
       </trans-unit>
       <trans-unit id="ConsoleLogsNoResourceSelected">

--- a/src/Aspire.Dashboard/Resources/xlf/ConsoleLogs.ru.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/ConsoleLogs.ru.xlf
@@ -29,7 +29,7 @@
       </trans-unit>
       <trans-unit id="ConsoleLogsNoLogsFound">
         <source>No logs found</source>
-        <target state="new">No logs found</target>
+        <target state="translated">Журналы не найдены</target>
         <note />
       </trans-unit>
       <trans-unit id="ConsoleLogsNoResourceSelected">

--- a/src/Aspire.Dashboard/Resources/xlf/ConsoleLogs.ru.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/ConsoleLogs.ru.xlf
@@ -27,6 +27,11 @@
         <target state="translated">Журналы пока недоступны</target>
         <note />
       </trans-unit>
+      <trans-unit id="ConsoleLogsNoLogsFound">
+        <source>No logs found</source>
+        <target state="new">No logs found</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ConsoleLogsNoResourceSelected">
         <source>No resource selected</source>
         <target state="translated">Нет выбранных ресурсов</target>

--- a/src/Aspire.Dashboard/Resources/xlf/ConsoleLogs.ru.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/ConsoleLogs.ru.xlf
@@ -29,7 +29,7 @@
       </trans-unit>
       <trans-unit id="ConsoleLogsNoLogsFound">
         <source>No logs found</source>
-        <target state="translated">Журналы не найдены</target>
+        <target state="new">No logs found</target>
         <note />
       </trans-unit>
       <trans-unit id="ConsoleLogsNoResourceSelected">

--- a/src/Aspire.Dashboard/Resources/xlf/ConsoleLogs.tr.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/ConsoleLogs.tr.xlf
@@ -29,7 +29,7 @@
       </trans-unit>
       <trans-unit id="ConsoleLogsNoLogsFound">
         <source>No logs found</source>
-        <target state="new">No logs found</target>
+        <target state="translated">Günlük bulunamadı</target>
         <note />
       </trans-unit>
       <trans-unit id="ConsoleLogsNoResourceSelected">

--- a/src/Aspire.Dashboard/Resources/xlf/ConsoleLogs.tr.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/ConsoleLogs.tr.xlf
@@ -27,6 +27,11 @@
         <target state="translated">Günlükler henüz kullanılamıyor</target>
         <note />
       </trans-unit>
+      <trans-unit id="ConsoleLogsNoLogsFound">
+        <source>No logs found</source>
+        <target state="new">No logs found</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ConsoleLogsNoResourceSelected">
         <source>No resource selected</source>
         <target state="translated">Hiçbir kaynak seçilmedi</target>

--- a/src/Aspire.Dashboard/Resources/xlf/ConsoleLogs.tr.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/ConsoleLogs.tr.xlf
@@ -29,7 +29,7 @@
       </trans-unit>
       <trans-unit id="ConsoleLogsNoLogsFound">
         <source>No logs found</source>
-        <target state="translated">Günlük bulunamadı</target>
+        <target state="new">No logs found</target>
         <note />
       </trans-unit>
       <trans-unit id="ConsoleLogsNoResourceSelected">

--- a/src/Aspire.Dashboard/Resources/xlf/ConsoleLogs.zh-Hans.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/ConsoleLogs.zh-Hans.xlf
@@ -29,7 +29,7 @@
       </trans-unit>
       <trans-unit id="ConsoleLogsNoLogsFound">
         <source>No logs found</source>
-        <target state="new">No logs found</target>
+        <target state="translated">找不到日志</target>
         <note />
       </trans-unit>
       <trans-unit id="ConsoleLogsNoResourceSelected">

--- a/src/Aspire.Dashboard/Resources/xlf/ConsoleLogs.zh-Hans.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/ConsoleLogs.zh-Hans.xlf
@@ -27,6 +27,11 @@
         <target state="translated">日志尚不可用</target>
         <note />
       </trans-unit>
+      <trans-unit id="ConsoleLogsNoLogsFound">
+        <source>No logs found</source>
+        <target state="new">No logs found</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ConsoleLogsNoResourceSelected">
         <source>No resource selected</source>
         <target state="translated">未选择资源</target>

--- a/src/Aspire.Dashboard/Resources/xlf/ConsoleLogs.zh-Hans.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/ConsoleLogs.zh-Hans.xlf
@@ -29,7 +29,7 @@
       </trans-unit>
       <trans-unit id="ConsoleLogsNoLogsFound">
         <source>No logs found</source>
-        <target state="translated">找不到日志</target>
+        <target state="new">No logs found</target>
         <note />
       </trans-unit>
       <trans-unit id="ConsoleLogsNoResourceSelected">

--- a/src/Aspire.Dashboard/Resources/xlf/ConsoleLogs.zh-Hant.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/ConsoleLogs.zh-Hant.xlf
@@ -29,7 +29,7 @@
       </trans-unit>
       <trans-unit id="ConsoleLogsNoLogsFound">
         <source>No logs found</source>
-        <target state="new">No logs found</target>
+        <target state="translated">找不到記錄</target>
         <note />
       </trans-unit>
       <trans-unit id="ConsoleLogsNoResourceSelected">

--- a/src/Aspire.Dashboard/Resources/xlf/ConsoleLogs.zh-Hant.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/ConsoleLogs.zh-Hant.xlf
@@ -27,6 +27,11 @@
         <target state="translated">記錄尚不可用</target>
         <note />
       </trans-unit>
+      <trans-unit id="ConsoleLogsNoLogsFound">
+        <source>No logs found</source>
+        <target state="new">No logs found</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ConsoleLogsNoResourceSelected">
         <source>No resource selected</source>
         <target state="translated">未選取任何資源</target>

--- a/src/Aspire.Dashboard/Resources/xlf/ConsoleLogs.zh-Hant.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/ConsoleLogs.zh-Hant.xlf
@@ -29,7 +29,7 @@
       </trans-unit>
       <trans-unit id="ConsoleLogsNoLogsFound">
         <source>No logs found</source>
-        <target state="translated">找不到記錄</target>
+        <target state="new">No logs found</target>
         <note />
       </trans-unit>
       <trans-unit id="ConsoleLogsNoResourceSelected">


### PR DESCRIPTION
Closes #17336

## Summary
- Show a console empty state after a 2 second delay when a log subscription has no entries.
- Hide the empty state as soon as log entries arrive or the subscription changes.
- Add the localized No logs found resource across generated localization files.

## Impact
Users no longer see a blank console log pane for resources that have not emitted console output.

## Validation
- dotnet restore src\Aspire.Dashboard\Aspire.Dashboard.csproj
- dotnet build src\Aspire.Dashboard\Aspire.Dashboard.csproj --configuration Debug --no-restore passed with 0 warnings and 0 errors.
- Installed repo-local ASP.NET Core runtime 8.0.0 after the first test run reported the runtime was missing.
- .\dotnet.cmd test --project tests\Aspire.Dashboard.Tests\Aspire.Dashboard.Tests.csproj --configuration Debug --no-restore -- --filter-namespace Aspire.Dashboard.Tests.ConsoleLogsTests passed: 167 tests.
- git diff --check passed.