### PR TITLE
Fix internal build break: 'aspire-managed --help' in CLI archive verifier returns exit 1

### DIFF
--- a/eng/scripts/verify-cli-archive.ps1
+++ b/eng/scripts/verify-cli-archive.ps1
@@ -147,8 +147,13 @@ function Test-ExtractedBundleLayout {
 
     Write-Step "Extracted bundle layout contains AppHost server assets."
 
-    Write-Step "Running '$managedExecutablePath --help'..."
-    $managedOutput = & $managedExecutablePath --help 2>&1
+    # aspire-managed's top-level entry point is a hard dispatch on
+    # dashboard|server|nuget and returns 1 for anything else (including --help).
+    # Use a real subcommand whose System.CommandLine help path returns 0; this
+    # also exercises the NativeAOT-compiled CommandLine code path as part of
+    # the smoke check. See src/Aspire.Managed/Program.cs.
+    Write-Step "Running '$managedExecutablePath nuget --help'..."
+    $managedOutput = & $managedExecutablePath nuget --help 2>&1
     if ($LASTEXITCODE -ne 0) {
         throw "aspire-managed failed with exit code $LASTEXITCODE. Output: $managedOutput"
     }


### PR DESCRIPTION
The signed build+sign pipeline (`microsoft-aspire`, definition 1602) started failing on `main` in all three RIDs (osx-arm64, linux-x64, win-x64) right after #17274 merged. The new `🟣Verify CLI archive` step fails with:

```
❌ Verification failed: aspire-managed failed with exit code 1. Output: Usage: aspire-managed <dashboard|server|nuget> [args...]
```

See https://dev.azure.com/dnceng/internal/_build/results?buildId=2980569.

## Root cause

`eng/scripts/verify-cli-archive.ps1` smoke-tests the bundled server with `aspire-managed --help` and asserts exit 0. But `Aspire.Managed`'s entry point is a hard `args switch` on `dashboard|server|nuget`; anything else — including `--help` — falls through to `ShowUsage()`, which prints the usage banner to stderr and returns `1` (`src/Aspire.Managed/Program.cs:22-28,58-62`). So the assertion was guaranteed to fail against the real binary.

The bug was not caught pre-merge because the AzDO build+sign pipeline doesn't run on GitHub PRs (it's the post-merge signed pipeline), and the acquisition test added alongside the verifier uses a synthetic fake archive whose `aspire-managed` doesn't share the real binary's exit behavior.

## Fix

Invoke `aspire-managed nuget --help` instead. The `nuget` subcommand dispatches through `System.CommandLine`'s `RootCommand`, which adds `--help` automatically and returns 0 — so it both smoke-tests the NativeAOT-compiled CommandLine path and satisfies the verifier's exit-code assertion. The `Aspire.Managed` binary itself is unchanged.

## Surprises

None. No behavior change for users of the shipped CLI; only the post-merge verifier script changes.
