### PR TITLE
Add profiling spans for aspire add

### DIFF
--- a/src/Aspire.Cli/Commands/AddCommand.cs
+++ b/src/Aspire.Cli/Commands/AddCommand.cs
@@ -66,6 +66,28 @@ internal sealed class AddCommand : BaseCommand
         using var activity = Telemetry.StartDiagnosticActivity(this.Name);
 
         AddPackageContext? context = null;
+        ProfilingTelemetry.ActivityScope addActivity = default;
+
+        CommandResult AddCommandFailure(int exitCode, string? message = null)
+        {
+            addActivity.SetProcessExitCode(exitCode);
+            addActivity.SetError(message ?? $"Add command exited with code {exitCode}.");
+
+            return message is null
+                ? CommandResult.Failure(exitCode)
+                : CommandResult.Failure(exitCode, message);
+        }
+
+        CommandResult AddCommandFromExitCode(int exitCode)
+        {
+            addActivity.SetProcessExitCode(exitCode);
+            if (exitCode != CliExitCodes.Success)
+            {
+                addActivity.SetError($"Add command exited with code {exitCode}.");
+            }
+
+            return CommandResult.FromExitCode(exitCode);
+        }
 
         try
         {
@@ -73,7 +95,7 @@ internal sealed class AddCommand : BaseCommand
             var passedAppHostProjectFile = parseResult.GetValue(s_appHostOption);
             var version = parseResult.GetValue(s_versionOption);
             var source = parseResult.GetValue(s_sourceOption);
-            using var addActivity = _profilingTelemetry.StartAddCommand(integrationName, version, source, passedAppHostProjectFile);
+            addActivity = _profilingTelemetry.StartAddCommand(integrationName, version, source, passedAppHostProjectFile);
 
             AppHostProjectSearchResult searchResult;
             using (var findAppHostActivity = _profilingTelemetry.StartAddFindAppHost(passedAppHostProjectFile))
@@ -87,7 +109,7 @@ internal sealed class AddCommand : BaseCommand
 
             if (effectiveAppHostProjectFile is null)
             {
-                return CommandResult.Failure(CliExitCodes.FailedToFindProject);
+                return AddCommandFailure(CliExitCodes.FailedToFindProject);
             }
 
             // Get the appropriate project handler
@@ -99,7 +121,7 @@ internal sealed class AddCommand : BaseCommand
             {
                 if (!await SdkInstallHelper.EnsureSdkInstalledAsync(_sdkInstaller, InteractionService, Telemetry, cancellationToken: cancellationToken))
                 {
-                    return CommandResult.Failure(CliExitCodes.SdkNotInstalled);
+                    return AddCommandFailure(CliExitCodes.SdkNotInstalled);
                 }
             }
 
@@ -120,7 +142,7 @@ internal sealed class AddCommand : BaseCommand
             }
             if (configuredChannelExitCode is { } exitCode)
             {
-                return CommandResult.FromExitCode(exitCode);
+                return AddCommandFromExitCode(exitCode);
             }
 
             List<(NuGetPackage Package, PackageChannel Channel)> packagesWithChannels;
@@ -144,12 +166,15 @@ internal sealed class AddCommand : BaseCommand
 
             if (packagesWithShortName.Count == 0)
             {
-                return CommandResult.Failure(CliExitCodes.FailedToAddPackage, AddCommandStrings.NoPackagesFound);
+                return AddCommandFailure(CliExitCodes.FailedToAddPackage, AddCommandStrings.NoPackagesFound);
             }
 
             var filteredPackagesWithShortName = packagesWithShortName
                 .Where(p => p.FriendlyName == integrationName || p.Package.Id == integrationName)
                 .ToList();
+            var packageMatchKind = filteredPackagesWithShortName.Count > 0
+                ? ProfilingTelemetry.Values.AddPackageMatchKindExact
+                : ProfilingTelemetry.Values.AddPackageMatchKindNone;
 
             if (filteredPackagesWithShortName.Count == 0 && integrationName is not null && version is not null && !_hostEnvironment.SupportsInteractiveInput)
             {
@@ -165,22 +190,25 @@ internal sealed class AddCommand : BaseCommand
                 filteredPackagesWithShortName = IntegrationPackageSearchService.GetIntegrationSearchMatches(packagesWithShortName, integrationName)
                     .Select(x => (x.FriendlyName, x.Package, x.Channel))
                     .ToList();
+                packageMatchKind = filteredPackagesWithShortName.Count > 0
+                    ? ProfilingTelemetry.Values.AddPackageMatchKindFuzzy
+                    : ProfilingTelemetry.Values.AddPackageMatchKindNone;
             }
 
             // If we didn't match any, show a complete list. If we matched one, and its
             // an exact match, then we still prompt, but it will only prompt for
             // the version. If there is more than one match then we prompt.
             (string FriendlyName, NuGetPackage Package, PackageChannel Channel) selectedNuGetPackage;
+            selectedNuGetPackage = filteredPackagesWithShortName.Count switch
+            {
+                0 => await GetPackageByInteractiveFlowWithNoMatchesMessage(effectiveAppHostProjectFile.Directory!, packagesWithShortName, integrationName, version, cancellationToken),
+                1 when filteredPackagesWithShortName[0].Package.Version == version
+                    => filteredPackagesWithShortName[0],
+                _ => await GetPackageByInteractiveFlow(effectiveAppHostProjectFile.Directory!, filteredPackagesWithShortName, version, cancellationToken)
+            };
             using (var selectPackageActivity = _profilingTelemetry.StartAddSelectPackage(integrationName, version))
             {
-                selectPackageActivity.SetAddPackageMatchCount(filteredPackagesWithShortName.Count);
-                selectedNuGetPackage = filteredPackagesWithShortName.Count switch
-                {
-                    0 => await GetPackageByInteractiveFlowWithNoMatchesMessage(effectiveAppHostProjectFile.Directory!, packagesWithShortName, integrationName, version, cancellationToken),
-                    1 when filteredPackagesWithShortName[0].Package.Version == version
-                        => filteredPackagesWithShortName[0],
-                    _ => await GetPackageByInteractiveFlow(effectiveAppHostProjectFile.Directory!, filteredPackagesWithShortName, version, cancellationToken)
-                };
+                selectPackageActivity.SetAddPackageMatch(filteredPackagesWithShortName.Count, packageMatchKind);
                 selectPackageActivity.SetAddSelectedPackage(selectedNuGetPackage.Package.Id, selectedNuGetPackage.Package.Version, selectedNuGetPackage.Channel.Name);
                 addActivity.SetAddSelectedPackage(selectedNuGetPackage.Package.Id, selectedNuGetPackage.Package.Version, selectedNuGetPackage.Channel.Name);
             }
@@ -246,7 +274,7 @@ internal sealed class AddCommand : BaseCommand
             }
             else if (runningInstanceResult == RunningInstanceResult.StopFailed)
             {
-                return CommandResult.Failure(CliExitCodes.FailedToAddPackage, AddCommandStrings.UnableToStopRunningInstances);
+                return AddCommandFailure(CliExitCodes.FailedToAddPackage, AddCommandStrings.UnableToStopRunningInstances);
             }
 
             bool success;
@@ -269,14 +297,16 @@ internal sealed class AddCommand : BaseCommand
                 {
                     InteractionService.DisplayLines(outputCollector.GetLines());
                 }
-                return CommandResult.Failure(CliExitCodes.FailedToAddPackage, string.Format(CultureInfo.CurrentCulture, AddCommandStrings.PackageInstallationFailed, CliExitCodes.FailedToAddPackage));
+                return AddCommandFailure(CliExitCodes.FailedToAddPackage, string.Format(CultureInfo.CurrentCulture, AddCommandStrings.PackageInstallationFailed, CliExitCodes.FailedToAddPackage));
             }
 
             InteractionService.DisplaySuccess(string.Format(CultureInfo.CurrentCulture, AddCommandStrings.PackageAddedSuccessfully, selectedNuGetPackage.Package.Id, selectedNuGetPackage.Package.Version));
+            addActivity.SetProcessExitCode(CliExitCodes.Success);
             return CommandResult.Success();
         }
         catch (ProjectLocatorException ex)
         {
+            addActivity.SetError(ex);
             return HandleProjectLocatorException(ex, InteractionService, Telemetry);
         }
         catch (OperationCanceledException)
@@ -285,6 +315,8 @@ internal sealed class AddCommand : BaseCommand
         }
         catch (EmptyChoicesException ex)
         {
+            addActivity.SetProcessExitCode(CliExitCodes.FailedToAddPackage);
+            addActivity.SetError(ex.Message);
             Telemetry.RecordError(ex.Message, ex);
             return CommandResult.Failure(CliExitCodes.FailedToAddPackage, ex.Message);
         }
@@ -295,8 +327,14 @@ internal sealed class AddCommand : BaseCommand
                 InteractionService.DisplayLines(outputCollector.GetLines());
             }
             var errorMessage = string.Format(CultureInfo.CurrentCulture, AddCommandStrings.ErrorOccurredWhileAddingPackage, ex.Message);
+            addActivity.SetProcessExitCode(CliExitCodes.FailedToAddPackage);
+            addActivity.SetError(ex);
             Telemetry.RecordError(errorMessage, ex);
             return CommandResult.Failure(CliExitCodes.FailedToAddPackage, errorMessage);
+        }
+        finally
+        {
+            addActivity.Dispose();
         }
     }
 
@@ -319,15 +357,15 @@ internal sealed class AddCommand : BaseCommand
 
     private async Task<(string FriendlyName, NuGetPackage Package, PackageChannel Channel)> GetPackageByInteractiveFlow(DirectoryInfo workingDirectory, IEnumerable<(string FriendlyName, NuGetPackage Package, PackageChannel Channel)> possiblePackages, string? preferredVersion, CancellationToken cancellationToken)
     {
-        var distinctPackages = possiblePackages.DistinctBy(p => p.Package.Id);
+        var distinctPackages = possiblePackages.DistinctBy(p => p.Package.Id).ToArray();
 
         // If there is only one package, we can skip the prompt and just use it.
         // In non-interactive mode, auto-select the first package.
-        var selectedPackage = distinctPackages.Count() switch
+        var selectedPackage = distinctPackages.Length switch
         {
             1 => distinctPackages.First(),
             > 1 when !_hostEnvironment.SupportsInteractiveInput => distinctPackages.First(),
-            > 1 => await _prompter.PromptForIntegrationAsync(distinctPackages, cancellationToken),
+            > 1 => await PromptForIntegrationAsync(distinctPackages, cancellationToken),
             _ => throw new InvalidOperationException(AddCommandStrings.UnexpectedNumberOfPackagesFound)
         };
 
@@ -383,9 +421,21 @@ internal sealed class AddCommand : BaseCommand
         }
 
         // ... otherwise we had better prompt.
-        var version = await _prompter.PromptForIntegrationVersionAsync(orderedPackageVersions, cancellationToken);
+        var version = await PromptForIntegrationVersionAsync(orderedPackageVersions, cancellationToken);
 
         return version;
+    }
+
+    private async Task<(string FriendlyName, NuGetPackage Package, PackageChannel Channel)> PromptForIntegrationAsync(IEnumerable<(string FriendlyName, NuGetPackage Package, PackageChannel Channel)> packages, CancellationToken cancellationToken)
+    {
+        using var promptActivity = _profilingTelemetry.StartAddSelectPackagePrompt();
+        return await _prompter.PromptForIntegrationAsync(packages, cancellationToken);
+    }
+
+    private async Task<(string FriendlyName, NuGetPackage Package, PackageChannel Channel)> PromptForIntegrationVersionAsync(IEnumerable<(string FriendlyName, NuGetPackage Package, PackageChannel Channel)> packages, CancellationToken cancellationToken)
+    {
+        using var promptActivity = _profilingTelemetry.StartAddSelectPackagePrompt();
+        return await _prompter.PromptForIntegrationVersionAsync(packages, cancellationToken);
     }
 
     private async Task<(string FriendlyName, NuGetPackage Package, PackageChannel Channel)> GetPackageByInteractiveFlowWithNoMatchesMessage(DirectoryInfo workingDirectory, IEnumerable<(string FriendlyName, NuGetPackage Package, PackageChannel Channel)> possiblePackages, string? searchTerm, string? preferredVersion, CancellationToken cancellationToken)

--- a/src/Aspire.Cli/Commands/AddCommand.cs
+++ b/src/Aspire.Cli/Commands/AddCommand.cs
@@ -27,6 +27,7 @@ internal sealed class AddCommand : BaseCommand
     private readonly IDotNetSdkInstaller _sdkInstaller;
     private readonly ICliHostEnvironment _hostEnvironment;
     private readonly IAppHostProjectFactory _projectFactory;
+    private readonly ProfilingTelemetry _profilingTelemetry;
 
     private static readonly Argument<string> s_integrationArgument = new("integration")
     {
@@ -43,7 +44,7 @@ internal sealed class AddCommand : BaseCommand
         Description = AddCommandStrings.SourceArgumentDescription
     };
 
-    public AddCommand(IInteractionService interactionService, IProjectLocator projectLocator, IntegrationPackageSearchService integrationPackageSearchService, IAddCommandPrompter prompter, AspireCliTelemetry telemetry, IDotNetSdkInstaller sdkInstaller, IFeatures features, ICliUpdateNotifier updateNotifier, CliExecutionContext executionContext, ICliHostEnvironment hostEnvironment, IAppHostProjectFactory projectFactory)
+    public AddCommand(IInteractionService interactionService, IProjectLocator projectLocator, IntegrationPackageSearchService integrationPackageSearchService, IAddCommandPrompter prompter, AspireCliTelemetry telemetry, IDotNetSdkInstaller sdkInstaller, IFeatures features, ICliUpdateNotifier updateNotifier, CliExecutionContext executionContext, ICliHostEnvironment hostEnvironment, IAppHostProjectFactory projectFactory, ProfilingTelemetry profilingTelemetry)
         : base("add", AddCommandStrings.Description, features, updateNotifier, executionContext, interactionService, telemetry)
     {
         _projectLocator = projectLocator;
@@ -52,6 +53,7 @@ internal sealed class AddCommand : BaseCommand
         _sdkInstaller = sdkInstaller;
         _hostEnvironment = hostEnvironment;
         _projectFactory = projectFactory;
+        _profilingTelemetry = profilingTelemetry;
 
         Arguments.Add(s_integrationArgument);
         Options.Add(s_appHostOption);
@@ -71,8 +73,16 @@ internal sealed class AddCommand : BaseCommand
             var passedAppHostProjectFile = parseResult.GetValue(s_appHostOption);
             var version = parseResult.GetValue(s_versionOption);
             var source = parseResult.GetValue(s_sourceOption);
+            using var addActivity = _profilingTelemetry.StartAddCommand(integrationName, version, source, passedAppHostProjectFile);
 
-            var searchResult = await _projectLocator.UseOrFindAppHostProjectFileAsync(passedAppHostProjectFile, MultipleAppHostProjectsFoundBehavior.Prompt, createSettingsFile: true, cancellationToken);
+            AppHostProjectSearchResult searchResult;
+            using (var findAppHostActivity = _profilingTelemetry.StartAddFindAppHost(passedAppHostProjectFile))
+            {
+                searchResult = await _projectLocator.UseOrFindAppHostProjectFileAsync(passedAppHostProjectFile, MultipleAppHostProjectsFoundBehavior.Prompt, createSettingsFile: true, cancellationToken);
+                findAppHostActivity.SetAppHostCandidateCount(searchResult.AllProjectFileCandidates.Count);
+            }
+            addActivity.SetAppHostCandidateCount(searchResult.AllProjectFileCandidates.Count);
+
             var effectiveAppHostProjectFile = searchResult.SelectedProjectFile;
 
             if (effectiveAppHostProjectFile is null)
@@ -82,6 +92,7 @@ internal sealed class AddCommand : BaseCommand
 
             // Get the appropriate project handler
             var project = _projectFactory.GetProject(effectiveAppHostProjectFile);
+            addActivity.SetAppHostLanguage(project.LanguageId);
 
             // Check if the .NET SDK is available (only needed for .NET projects)
             if (project.LanguageId == KnownLanguageId.CSharp)
@@ -92,37 +103,60 @@ internal sealed class AddCommand : BaseCommand
                 }
             }
 
-            var (configuredChannel, configuredChannelExitCode) = _integrationPackageSearchService.GetConfiguredChannel(effectiveAppHostProjectFile, project);
+            string? configuredChannel;
+            int? configuredChannelExitCode;
+            using (var configuredChannelActivity = _profilingTelemetry.StartAddGetConfiguredChannel())
+            {
+                (configuredChannel, configuredChannelExitCode) = _integrationPackageSearchService.GetConfiguredChannel(effectiveAppHostProjectFile, project);
+                configuredChannelActivity.SetAddConfiguredChannel(configuredChannel);
+                if (configuredChannelExitCode is { } channelExitCode)
+                {
+                    configuredChannelActivity.SetProcessExitCode(channelExitCode);
+                    if (channelExitCode != CliExitCodes.Success)
+                    {
+                        configuredChannelActivity.SetError($"Configured channel lookup exited with code {channelExitCode}.");
+                    }
+                }
+            }
             if (configuredChannelExitCode is { } exitCode)
             {
                 return CommandResult.FromExitCode(exitCode);
             }
 
-            var packagesWithChannels = await InteractionService.ShowStatusAsync(
-                AddCommandStrings.SearchingForAspirePackages,
-                async () => await _integrationPackageSearchService.GetIntegrationPackagesWithChannelsAsync(effectiveAppHostProjectFile.Directory!, configuredChannel, cancellationToken));
+            List<(NuGetPackage Package, PackageChannel Channel)> packagesWithChannels;
+            using (var searchPackagesActivity = _profilingTelemetry.StartAddSearchPackages(configuredChannel))
+            {
+                var discoveredPackages = await InteractionService.ShowStatusAsync(
+                    AddCommandStrings.SearchingForAspirePackages,
+                    async () => await _integrationPackageSearchService.GetIntegrationPackagesWithChannelsAsync(effectiveAppHostProjectFile.Directory!, configuredChannel, cancellationToken));
+                packagesWithChannels = discoveredPackages as List<(NuGetPackage Package, PackageChannel Channel)> ?? discoveredPackages.ToList();
+                var packageCount = packagesWithChannels.Count;
+                searchPackagesActivity.SetAddPackageSearchResultCount(packageCount);
+                addActivity.SetAddPackageSearchResultCount(packageCount);
+            }
 
-            if (!packagesWithChannels.Any())
+            if (packagesWithChannels.Count == 0)
             {
                 throw new EmptyChoicesException(AddCommandStrings.NoIntegrationPackagesFound);
             }
 
-            var packagesWithShortName = packagesWithChannels.Select(IntegrationPackageSearchService.GenerateFriendlyName).OrderBy(p => p.FriendlyName, new CommunityToolkitFirstComparer());
+            var packagesWithShortName = packagesWithChannels.Select(IntegrationPackageSearchService.GenerateFriendlyName).OrderBy(p => p.FriendlyName, new CommunityToolkitFirstComparer()).ToList();
 
-            if (!packagesWithShortName.Any())
+            if (packagesWithShortName.Count == 0)
             {
                 return CommandResult.Failure(CliExitCodes.FailedToAddPackage, AddCommandStrings.NoPackagesFound);
             }
 
             var filteredPackagesWithShortName = packagesWithShortName
-                .Where(p => p.FriendlyName == integrationName || p.Package.Id == integrationName);
+                .Where(p => p.FriendlyName == integrationName || p.Package.Id == integrationName)
+                .ToList();
 
-            if (!filteredPackagesWithShortName.Any() && integrationName is not null && version is not null && !_hostEnvironment.SupportsInteractiveInput)
+            if (filteredPackagesWithShortName.Count == 0 && integrationName is not null && version is not null && !_hostEnvironment.SupportsInteractiveInput)
             {
                 throw new EmptyChoicesException(string.Format(CultureInfo.CurrentCulture, AddCommandStrings.SpecifiedVersionRequiresExactPackageMatch, integrationName));
             }
 
-            if (!filteredPackagesWithShortName.Any() && integrationName is not null)
+            if (filteredPackagesWithShortName.Count == 0 && integrationName is not null)
             {
                 // If we didn't get an exact match on the friendly name or the package ID
                 // then try a fuzzy search to create a broader filtered list.
@@ -136,13 +170,20 @@ internal sealed class AddCommand : BaseCommand
             // If we didn't match any, show a complete list. If we matched one, and its
             // an exact match, then we still prompt, but it will only prompt for
             // the version. If there is more than one match then we prompt.
-            var selectedNuGetPackage = filteredPackagesWithShortName.Count() switch
+            (string FriendlyName, NuGetPackage Package, PackageChannel Channel) selectedNuGetPackage;
+            using (var selectPackageActivity = _profilingTelemetry.StartAddSelectPackage(integrationName, version))
             {
-                0 => await GetPackageByInteractiveFlowWithNoMatchesMessage(effectiveAppHostProjectFile.Directory!, packagesWithShortName, integrationName, version, cancellationToken),
-                1 when filteredPackagesWithShortName.First().Package.Version == version
-                    => filteredPackagesWithShortName.First(),
-                _ => await GetPackageByInteractiveFlow(effectiveAppHostProjectFile.Directory!, filteredPackagesWithShortName, version, cancellationToken)
-            };
+                selectPackageActivity.SetAddPackageMatchCount(filteredPackagesWithShortName.Count);
+                selectedNuGetPackage = filteredPackagesWithShortName.Count switch
+                {
+                    0 => await GetPackageByInteractiveFlowWithNoMatchesMessage(effectiveAppHostProjectFile.Directory!, packagesWithShortName, integrationName, version, cancellationToken),
+                    1 when filteredPackagesWithShortName[0].Package.Version == version
+                        => filteredPackagesWithShortName[0],
+                    _ => await GetPackageByInteractiveFlow(effectiveAppHostProjectFile.Directory!, filteredPackagesWithShortName, version, cancellationToken)
+                };
+                selectPackageActivity.SetAddSelectedPackage(selectedNuGetPackage.Package.Id, selectedNuGetPackage.Package.Version, selectedNuGetPackage.Channel.Name);
+                addActivity.SetAddSelectedPackage(selectedNuGetPackage.Package.Id, selectedNuGetPackage.Package.Version, selectedNuGetPackage.Channel.Name);
+            }
 
             // When installing from a PR channel, ensure the project has access to
             // the PR hive as a NuGet source so `dotnet add package` can resolve the
@@ -189,10 +230,15 @@ internal sealed class AddCommand : BaseCommand
             // Stop any running AppHost instance before adding the package.
             // A running AppHost (especially in detach mode) locks project files,
             // which prevents 'dotnet add package' from modifying the project.
-            var runningInstanceResult = await project.FindAndStopRunningInstanceAsync(
-                effectiveAppHostProjectFile,
-                ExecutionContext.HomeDirectory,
-                cancellationToken);
+            RunningInstanceResult runningInstanceResult;
+            using (var stopRunningInstanceActivity = _profilingTelemetry.StartAddStopExistingInstance())
+            {
+                runningInstanceResult = await project.FindAndStopRunningInstanceAsync(
+                    effectiveAppHostProjectFile,
+                    ExecutionContext.HomeDirectory,
+                    cancellationToken);
+                stopRunningInstanceActivity.SetAppHostRunningInstanceResult(runningInstanceResult);
+            }
 
             if (runningInstanceResult == RunningInstanceResult.InstanceStopped)
             {
@@ -203,10 +249,19 @@ internal sealed class AddCommand : BaseCommand
                 return CommandResult.Failure(CliExitCodes.FailedToAddPackage, AddCommandStrings.UnableToStopRunningInstances);
             }
 
-            var success = await InteractionService.ShowStatusAsync(
-                AddCommandStrings.AddingAspireIntegration,
-                async () => await project.AddPackageAsync(context, cancellationToken)
-            );
+            bool success;
+            using (var addPackageActivity = _profilingTelemetry.StartAddPackage(context.PackageId, context.PackageVersion, context.Source))
+            {
+                success = await InteractionService.ShowStatusAsync(
+                    AddCommandStrings.AddingAspireIntegration,
+                    async () => await project.AddPackageAsync(context, cancellationToken)
+                );
+                addPackageActivity.SetAddPackageSuccess(success);
+                if (!success)
+                {
+                    addPackageActivity.SetError("Package installation failed.");
+                }
+            }
 
             if (!success)
             {

--- a/src/Aspire.Cli/Telemetry/ProfilingTelemetry.cs
+++ b/src/Aspire.Cli/Telemetry/ProfilingTelemetry.cs
@@ -52,6 +52,7 @@ internal sealed class ProfilingTelemetry(IConfiguration configuration) : IDispos
         public const string AddGetConfiguredChannel = "aspire/cli/add.get_configured_channel";
         public const string AddSearchPackages = "aspire/cli/add.search_packages";
         public const string AddSelectPackage = "aspire/cli/add.select_package";
+        public const string AddSelectPackagePrompt = "aspire/cli/add.select_package.prompt";
         public const string AddStopExistingInstance = "aspire/cli/add.stop_existing_instance";
         public const string AddPackage = "aspire/cli/add.package";
         public const string RunCommand = "aspire/cli/run";
@@ -175,6 +176,7 @@ internal sealed class ProfilingTelemetry(IConfiguration configuration) : IDispos
         public const string AddConfiguredChannel = "aspire.cli.add.configured_channel";
         public const string AddPackageSearchResultCount = "aspire.cli.add.package.search_result_count";
         public const string AddPackageMatchCount = "aspire.cli.add.package.match_count";
+        public const string AddPackageMatchKind = "aspire.cli.add.package.match_kind";
         public const string AddPackageId = "aspire.cli.add.package.id";
         public const string AddPackageVersion = "aspire.cli.add.package.version";
         public const string AddPackageChannel = "aspire.cli.add.package.channel";
@@ -240,6 +242,9 @@ internal sealed class ProfilingTelemetry(IConfiguration configuration) : IDispos
         public const string GuestCommandPhaseExecute = "execute";
         public const string GuestCommandPhaseWatchExecute = "watch_execute";
         public const string GuestCommandPhasePublishExecute = "publish_execute";
+        public const string AddPackageMatchKindExact = "exact";
+        public const string AddPackageMatchKindFuzzy = "fuzzy";
+        public const string AddPackageMatchKindNone = "none";
     }
 
     public bool IsEnabled => IsProfilingEnabled(configuration);
@@ -503,6 +508,11 @@ internal sealed class ProfilingTelemetry(IConfiguration configuration) : IDispos
         var activity = StartActivity(Activities.AddSelectPackage);
         activity.SetAddPackageSelectionRequest(integrationName, version);
         return activity;
+    }
+
+    internal ActivityScope StartAddSelectPackagePrompt()
+    {
+        return StartActivity(Activities.AddSelectPackagePrompt);
     }
 
     internal ActivityScope StartAddStopExistingInstance()
@@ -909,7 +919,11 @@ internal sealed class ProfilingTelemetry(IConfiguration configuration) : IDispos
             SetTag(Tags.AddVersionSpecified, !string.IsNullOrEmpty(version));
         }
 
-        public void SetAddPackageMatchCount(int count) => SetTag(Tags.AddPackageMatchCount, count);
+        public void SetAddPackageMatch(int count, string matchKind)
+        {
+            SetTag(Tags.AddPackageMatchCount, count);
+            SetTag(Tags.AddPackageMatchKind, matchKind);
+        }
 
         public void SetAddPackageSearchResultCount(int count) => SetTag(Tags.AddPackageSearchResultCount, count);
 

--- a/src/Aspire.Cli/Telemetry/ProfilingTelemetry.cs
+++ b/src/Aspire.Cli/Telemetry/ProfilingTelemetry.cs
@@ -47,6 +47,13 @@ internal sealed class ProfilingTelemetry(IConfiguration configuration) : IDispos
     {
         public const string Command = "aspire/cli/command";
         public const string Process = "aspire/cli/process";
+        public const string AddCommand = "aspire/cli/add";
+        public const string AddFindAppHost = "aspire/cli/add.find_apphost";
+        public const string AddGetConfiguredChannel = "aspire/cli/add.get_configured_channel";
+        public const string AddSearchPackages = "aspire/cli/add.search_packages";
+        public const string AddSelectPackage = "aspire/cli/add.select_package";
+        public const string AddStopExistingInstance = "aspire/cli/add.stop_existing_instance";
+        public const string AddPackage = "aspire/cli/add.package";
         public const string RunCommand = "aspire/cli/run";
         public const string LsCommand = "aspire/cli/ls";
         public const string LsFindAppHosts = "aspire/cli/ls.find_apphosts";
@@ -162,6 +169,16 @@ internal sealed class ProfilingTelemetry(IConfiguration configuration) : IDispos
         public const string LsOutputFormat = "aspire.cli.ls.output_format";
         public const string ProcessCommandArgs = "process.command_args";
         public const string ProcessCommandArgsCount = "process.command_args.count";
+        public const string AddIntegrationName = "aspire.cli.add.integration.name";
+        public const string AddVersionSpecified = "aspire.cli.add.version_specified";
+        public const string AddSourceSpecified = "aspire.cli.add.source_specified";
+        public const string AddConfiguredChannel = "aspire.cli.add.configured_channel";
+        public const string AddPackageSearchResultCount = "aspire.cli.add.package.search_result_count";
+        public const string AddPackageMatchCount = "aspire.cli.add.package.match_count";
+        public const string AddPackageId = "aspire.cli.add.package.id";
+        public const string AddPackageVersion = "aspire.cli.add.package.version";
+        public const string AddPackageChannel = "aspire.cli.add.package.channel";
+        public const string AddPackageSuccess = "aspire.cli.add.package.success";
     }
 
     /// <summary>
@@ -452,6 +469,52 @@ internal sealed class ProfilingTelemetry(IConfiguration configuration) : IDispos
     {
         var activity = StartActivity(Activities.RunAppHostFindAppHost);
         activity.SetAppHostProjectFileSpecified(passedAppHostProjectFile is not null);
+        return activity;
+    }
+
+    internal ActivityScope StartAddCommand(string? integrationName, string? version, string? source, FileInfo? passedAppHostProjectFile)
+    {
+        var activity = StartActivity(Activities.AddCommand, startWithRemoteParent: true);
+        activity.SetAddInvocation(integrationName, version, source, passedAppHostProjectFile);
+        return activity;
+    }
+
+    internal ActivityScope StartAddFindAppHost(FileInfo? passedAppHostProjectFile)
+    {
+        var activity = StartActivity(Activities.AddFindAppHost);
+        activity.SetAppHostProjectFileSpecified(passedAppHostProjectFile is not null);
+        return activity;
+    }
+
+    internal ActivityScope StartAddGetConfiguredChannel()
+    {
+        return StartActivity(Activities.AddGetConfiguredChannel);
+    }
+
+    internal ActivityScope StartAddSearchPackages(string? configuredChannel)
+    {
+        var activity = StartActivity(Activities.AddSearchPackages);
+        activity.SetAddConfiguredChannel(configuredChannel);
+        return activity;
+    }
+
+    internal ActivityScope StartAddSelectPackage(string? integrationName, string? version)
+    {
+        var activity = StartActivity(Activities.AddSelectPackage);
+        activity.SetAddPackageSelectionRequest(integrationName, version);
+        return activity;
+    }
+
+    internal ActivityScope StartAddStopExistingInstance()
+    {
+        return StartActivity(Activities.AddStopExistingInstance);
+    }
+
+    internal ActivityScope StartAddPackage(string packageId, string packageVersion, string? source)
+    {
+        var activity = StartActivity(Activities.AddPackage);
+        activity.SetAddPackage(packageId, packageVersion);
+        activity.SetAddSourceSpecified(!string.IsNullOrEmpty(source));
         return activity;
     }
 
@@ -823,6 +886,42 @@ internal sealed class ProfilingTelemetry(IConfiguration configuration) : IDispos
         public void SetAppHostBackchannelConnected(bool connected) => SetTag(Tags.AppHostBackchannelConnected, connected);
 
         public void SetAppHostBuildSuccess(bool buildSuccess) => SetTag(Tags.AppHostBuildSuccess, buildSuccess);
+
+        public void SetAddConfiguredChannel(string? configuredChannel) => SetTag(Tags.AddConfiguredChannel, configuredChannel);
+
+        public void SetAddInvocation(string? integrationName, string? version, string? source, FileInfo? passedAppHostProjectFile)
+        {
+            SetTag(Tags.AddIntegrationName, integrationName);
+            SetTag(Tags.AddVersionSpecified, !string.IsNullOrEmpty(version));
+            SetTag(Tags.AddSourceSpecified, !string.IsNullOrEmpty(source));
+            SetAppHostProjectFileSpecified(passedAppHostProjectFile is not null);
+        }
+
+        public void SetAddPackage(string packageId, string packageVersion)
+        {
+            SetTag(Tags.AddPackageId, packageId);
+            SetTag(Tags.AddPackageVersion, packageVersion);
+        }
+
+        public void SetAddPackageSelectionRequest(string? integrationName, string? version)
+        {
+            SetTag(Tags.AddIntegrationName, integrationName);
+            SetTag(Tags.AddVersionSpecified, !string.IsNullOrEmpty(version));
+        }
+
+        public void SetAddPackageMatchCount(int count) => SetTag(Tags.AddPackageMatchCount, count);
+
+        public void SetAddPackageSearchResultCount(int count) => SetTag(Tags.AddPackageSearchResultCount, count);
+
+        public void SetAddPackageSuccess(bool success) => SetTag(Tags.AddPackageSuccess, success);
+
+        public void SetAddSourceSpecified(bool sourceSpecified) => SetTag(Tags.AddSourceSpecified, sourceSpecified);
+
+        public void SetAddSelectedPackage(string packageId, string packageVersion, string channelName)
+        {
+            SetAddPackage(packageId, packageVersion);
+            SetTag(Tags.AddPackageChannel, channelName);
+        }
 
         public void SetAppHostBuildExitCode(int exitCode)
         {

--- a/tests/Aspire.Cli.Tests/Telemetry/ProfilingTelemetryTests.cs
+++ b/tests/Aspire.Cli.Tests/Telemetry/ProfilingTelemetryTests.cs
@@ -140,8 +140,12 @@ public class ProfilingTelemetryTests
 
             using (var selectPackageActivity = profilingTelemetry.StartAddSelectPackage("redis", "13.4.0"))
             {
-                selectPackageActivity.SetAddPackageMatchCount(1);
+                selectPackageActivity.SetAddPackageMatch(1, ProfilingTelemetry.Values.AddPackageMatchKindExact);
                 selectPackageActivity.SetAddSelectedPackage("Aspire.Hosting.Redis", "13.4.0", "daily");
+            }
+
+            using (profilingTelemetry.StartAddSelectPackagePrompt())
+            {
             }
 
             using (var stopRunningInstanceActivity = profilingTelemetry.StartAddStopExistingInstance())
@@ -199,9 +203,14 @@ public class ProfilingTelemetryTests
                 Assert.Equal("redis", selectPackageActivity.GetTagItem(ProfilingTelemetry.Tags.AddIntegrationName));
                 Assert.Equal(true, selectPackageActivity.GetTagItem(ProfilingTelemetry.Tags.AddVersionSpecified));
                 Assert.Equal(1, selectPackageActivity.GetTagItem(ProfilingTelemetry.Tags.AddPackageMatchCount));
+                Assert.Equal(ProfilingTelemetry.Values.AddPackageMatchKindExact, selectPackageActivity.GetTagItem(ProfilingTelemetry.Tags.AddPackageMatchKind));
                 Assert.Equal("Aspire.Hosting.Redis", selectPackageActivity.GetTagItem(ProfilingTelemetry.Tags.AddPackageId));
                 Assert.Equal("13.4.0", selectPackageActivity.GetTagItem(ProfilingTelemetry.Tags.AddPackageVersion));
                 Assert.Equal("daily", selectPackageActivity.GetTagItem(ProfilingTelemetry.Tags.AddPackageChannel));
+            },
+            promptActivity =>
+            {
+                Assert.Equal(ProfilingTelemetry.Activities.AddSelectPackagePrompt, promptActivity.OperationName);
             },
             stopRunningInstanceActivity =>
             {

--- a/tests/Aspire.Cli.Tests/Telemetry/ProfilingTelemetryTests.cs
+++ b/tests/Aspire.Cli.Tests/Telemetry/ProfilingTelemetryTests.cs
@@ -112,6 +112,119 @@ public class ProfilingTelemetryTests
     }
 
     [Fact]
+    public void StartAddCommand_CreatesAddSpecificSpans()
+    {
+        var startedActivities = new List<Activity>();
+        using var listener = CreateProfilingActivityListener(startedActivities.Add);
+        using var profilingTelemetry = new ProfilingTelemetry(CreateConfiguration(
+            (ProfilingTelemetry.EnvironmentVariables.Enabled, "true"),
+            (ProfilingTelemetry.EnvironmentVariables.SessionId, "session-1")));
+        var appHostProjectFile = new FileInfo(Path.Combine("AppHost", "AppHost.csproj"));
+
+        using (var addActivity = profilingTelemetry.StartAddCommand("redis", "13.4.0", "nuget-source", appHostProjectFile))
+        {
+            using (var findAppHostActivity = profilingTelemetry.StartAddFindAppHost(appHostProjectFile))
+            {
+                findAppHostActivity.SetAppHostCandidateCount(1);
+            }
+
+            using (var configuredChannelActivity = profilingTelemetry.StartAddGetConfiguredChannel())
+            {
+                configuredChannelActivity.SetAddConfiguredChannel("daily");
+            }
+
+            using (var searchPackagesActivity = profilingTelemetry.StartAddSearchPackages("daily"))
+            {
+                searchPackagesActivity.SetAddPackageSearchResultCount(42);
+            }
+
+            using (var selectPackageActivity = profilingTelemetry.StartAddSelectPackage("redis", "13.4.0"))
+            {
+                selectPackageActivity.SetAddPackageMatchCount(1);
+                selectPackageActivity.SetAddSelectedPackage("Aspire.Hosting.Redis", "13.4.0", "daily");
+            }
+
+            using (var stopRunningInstanceActivity = profilingTelemetry.StartAddStopExistingInstance())
+            {
+                stopRunningInstanceActivity.SetAppHostRunningInstanceResult("NoInstanceFound");
+            }
+
+            using (var addPackageActivity = profilingTelemetry.StartAddPackage("Aspire.Hosting.Redis", "13.4.0", "nuget-source"))
+            {
+                addPackageActivity.SetAddPackageSuccess(true);
+            }
+
+            addActivity.SetAppHostCandidateCount(1);
+            addActivity.SetAppHostLanguage("csharp");
+            addActivity.SetAddPackageSearchResultCount(42);
+            addActivity.SetAddSelectedPackage("Aspire.Hosting.Redis", "13.4.0", "daily");
+        }
+
+        Assert.Collection(
+            startedActivities,
+            addActivity =>
+            {
+                Assert.Equal(ProfilingTelemetry.Activities.AddCommand, addActivity.OperationName);
+                Assert.Equal("redis", addActivity.GetTagItem(ProfilingTelemetry.Tags.AddIntegrationName));
+                Assert.Equal(true, addActivity.GetTagItem(ProfilingTelemetry.Tags.AddVersionSpecified));
+                Assert.Equal(true, addActivity.GetTagItem(ProfilingTelemetry.Tags.AddSourceSpecified));
+                Assert.Equal(true, addActivity.GetTagItem(ProfilingTelemetry.Tags.AppHostProjectFileSpecified));
+                Assert.Equal(1, addActivity.GetTagItem(ProfilingTelemetry.Tags.AppHostCandidateCount));
+                Assert.Equal("csharp", addActivity.GetTagItem(ProfilingTelemetry.Tags.AppHostLanguage));
+                Assert.Equal(42, addActivity.GetTagItem(ProfilingTelemetry.Tags.AddPackageSearchResultCount));
+                Assert.Equal("Aspire.Hosting.Redis", addActivity.GetTagItem(ProfilingTelemetry.Tags.AddPackageId));
+                Assert.Equal("13.4.0", addActivity.GetTagItem(ProfilingTelemetry.Tags.AddPackageVersion));
+                Assert.Equal("daily", addActivity.GetTagItem(ProfilingTelemetry.Tags.AddPackageChannel));
+            },
+            findAppHostActivity =>
+            {
+                Assert.Equal(ProfilingTelemetry.Activities.AddFindAppHost, findAppHostActivity.OperationName);
+                Assert.Equal(true, findAppHostActivity.GetTagItem(ProfilingTelemetry.Tags.AppHostProjectFileSpecified));
+                Assert.Equal(1, findAppHostActivity.GetTagItem(ProfilingTelemetry.Tags.AppHostCandidateCount));
+            },
+            configuredChannelActivity =>
+            {
+                Assert.Equal(ProfilingTelemetry.Activities.AddGetConfiguredChannel, configuredChannelActivity.OperationName);
+                Assert.Equal("daily", configuredChannelActivity.GetTagItem(ProfilingTelemetry.Tags.AddConfiguredChannel));
+            },
+            searchPackagesActivity =>
+            {
+                Assert.Equal(ProfilingTelemetry.Activities.AddSearchPackages, searchPackagesActivity.OperationName);
+                Assert.Equal("daily", searchPackagesActivity.GetTagItem(ProfilingTelemetry.Tags.AddConfiguredChannel));
+                Assert.Equal(42, searchPackagesActivity.GetTagItem(ProfilingTelemetry.Tags.AddPackageSearchResultCount));
+            },
+            selectPackageActivity =>
+            {
+                Assert.Equal(ProfilingTelemetry.Activities.AddSelectPackage, selectPackageActivity.OperationName);
+                Assert.Equal("redis", selectPackageActivity.GetTagItem(ProfilingTelemetry.Tags.AddIntegrationName));
+                Assert.Equal(true, selectPackageActivity.GetTagItem(ProfilingTelemetry.Tags.AddVersionSpecified));
+                Assert.Equal(1, selectPackageActivity.GetTagItem(ProfilingTelemetry.Tags.AddPackageMatchCount));
+                Assert.Equal("Aspire.Hosting.Redis", selectPackageActivity.GetTagItem(ProfilingTelemetry.Tags.AddPackageId));
+                Assert.Equal("13.4.0", selectPackageActivity.GetTagItem(ProfilingTelemetry.Tags.AddPackageVersion));
+                Assert.Equal("daily", selectPackageActivity.GetTagItem(ProfilingTelemetry.Tags.AddPackageChannel));
+            },
+            stopRunningInstanceActivity =>
+            {
+                Assert.Equal(ProfilingTelemetry.Activities.AddStopExistingInstance, stopRunningInstanceActivity.OperationName);
+                Assert.Equal("NoInstanceFound", stopRunningInstanceActivity.GetTagItem(ProfilingTelemetry.Tags.AppHostRunningInstanceResult));
+            },
+            addPackageActivity =>
+            {
+                Assert.Equal(ProfilingTelemetry.Activities.AddPackage, addPackageActivity.OperationName);
+                Assert.Equal("Aspire.Hosting.Redis", addPackageActivity.GetTagItem(ProfilingTelemetry.Tags.AddPackageId));
+                Assert.Equal("13.4.0", addPackageActivity.GetTagItem(ProfilingTelemetry.Tags.AddPackageVersion));
+                Assert.Equal(true, addPackageActivity.GetTagItem(ProfilingTelemetry.Tags.AddSourceSpecified));
+                Assert.Equal(true, addPackageActivity.GetTagItem(ProfilingTelemetry.Tags.AddPackageSuccess));
+            });
+
+        Assert.All(startedActivities, activity =>
+        {
+            Assert.Equal("session-1", activity.GetTagItem(ProfilingTelemetry.Tags.ProfilingSessionId));
+            Assert.Equal("session-1", activity.GetBaggageItem(ProfilingTelemetry.Baggage.SessionId));
+        });
+    }
+
+    [Fact]
     public void ProfilingSpansReuseSessionFromAmbientActivityBaggage()
     {
         var startedActivities = new List<Activity>();


### PR DESCRIPTION
## Description

Instruments `aspire add` with profiling spans so that `--capture-profile` captures where add time is spent — package search, package selection, and installation — alongside the existing run/ls profiling.

### What changed

- New profiling spans in `ProfilingTelemetry`:
  - `aspire/cli/add` — root span for the whole add command
  - `aspire/cli/add.find_apphost` — AppHost project discovery
  - `aspire/cli/add.get_configured_channel` — NuGet channel lookup via msbuild
  - `aspire/cli/add.search_packages` — `dotnet package search` for Aspire integrations
  - `aspire/cli/add.select_package` — records match count/kind and selected package (dispatch only, no user think time)
  - `aspire/cli/add.select_package.prompt` — wraps interactive package/version prompts so user think time is filterable
  - `aspire/cli/add.stop_existing_instance` — stopping any running AppHost before add
  - `aspire/cli/add.package` — `dotnet package add` installation

- New tags: `aspire.cli.add.integration.name`, `version_specified`, `source_specified`, `configured_channel`, `package.search_result_count`, `package.match_count`, `package.match_kind` (`exact`/`fuzzy`/`none`), `package.id`, `package.version`, `package.channel`, `package.success`

- Root `aspire/cli/add` span is marked with error status and exit code on all graceful failure paths (not just thrown exceptions).

### User-facing usage

```bash
aspire add redis --version 9.5.0 --capture-profile --capture-profile-output add-redis.zip
```

Sample profile output (from `SimplePipelines.AppHost` playground):

```
aspire/cli/add               4.1s   package.id=Aspire.Hosting.Redis; package.version=9.5.0; search_result_count=120
  aspire/cli/add.find_apphost  453ms
  aspire/cli/add.search_packages  289ms  search_result_count=120
  aspire/cli/add.select_package     0.1ms  match_count=1; match_kind=exact
  aspire/cli/add.stop_existing_instance  3ms
  aspire/cli/add.package       3.0s   success=true
    process dotnet package add ...  3.0s
```

`dotnet package search` and `dotnet package add` each appear as child `process dotnet` spans so it's easy to see which subprocess dominates add time.

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
  - [x] No
