### PR TITLE
Advise `aspire certs trust` in polyglot HTTPS dev-cert errors

### DIFF
--- a/src/Aspire.Hosting.RemoteHost/Ats/PolyglotCapabilityInvocationException.cs
+++ b/src/Aspire.Hosting.RemoteHost/Ats/PolyglotCapabilityInvocationException.cs
@@ -514,6 +514,8 @@ internal static partial class PolyglotCapabilityErrorFormatter
             return message;
         }
 
+        message = RewritePolyglotUnfriendlyGuidance(message);
+
         if (!string.IsNullOrEmpty(polyglotMethodName) && !string.IsNullOrEmpty(clrMemberName))
         {
             message = Regex.Replace(
@@ -541,6 +543,40 @@ internal static partial class PolyglotCapabilityErrorFormatter
         message = ControlCharacterRegex().Replace(message, " ");
 
         return message.Trim();
+    }
+
+    // Rewrites guidance baked into framework exception messages so it makes sense for
+    // polyglot (non-.NET) app hosts that flow through this formatter. Native .NET app
+    // hosts never go through PolyglotCapabilityErrorFormatter, so their messages are
+    // unchanged.
+    //
+    // The Kestrel HTTPS dev-cert message has been stable across .NET versions and
+    // reads exactly:
+    //   "Unable to configure HTTPS endpoint. No server certificate was specified, and
+    //    the default developer certificate could not be found or is out of date. To
+    //    generate a developer certificate run 'dotnet dev-certs https'. To trust the
+    //    certificate (Windows and macOS only) run 'dotnet dev-certs https --trust'.
+    //    For more information on configuring HTTPS see
+    //    https://go.microsoft.com/fwlink/?linkid=848054."
+    // The advice to invoke `dotnet dev-certs` assumes a .NET SDK is on the PATH, which
+    // is not guaranteed for TypeScript / Node.js / Python app host users. Aspire ships
+    // `aspire certs trust`, which creates the dev cert when missing and trusts it in a
+    // single step, so we rewrite both sentences into one. See
+    // https://github.com/microsoft/aspire/issues/17273.
+    private static string RewritePolyglotUnfriendlyGuidance(string message)
+    {
+        const string KestrelDevCertGuidance =
+            "To generate a developer certificate run 'dotnet dev-certs https'. " +
+            "To trust the certificate (Windows and macOS only) run 'dotnet dev-certs https --trust'.";
+        const string AspireDevCertGuidance =
+            "To generate and trust a developer certificate run 'aspire certs trust'.";
+        const string KestrelHttpsFwlink = "https://go.microsoft.com/fwlink/?linkid=848054";
+        const string AspireHttpsDocs = "https://aspire.dev/docs/";
+
+        message = message.Replace(KestrelDevCertGuidance, AspireDevCertGuidance, StringComparison.Ordinal);
+        message = message.Replace(KestrelHttpsFwlink, AspireHttpsDocs, StringComparison.Ordinal);
+
+        return message;
     }
 
     [GeneratedRegex(@"\s{2,}")]

--- a/src/Aspire.Hosting.RemoteHost/Ats/PolyglotCapabilityInvocationException.cs
+++ b/src/Aspire.Hosting.RemoteHost/Ats/PolyglotCapabilityInvocationException.cs
@@ -550,34 +550,38 @@ internal static partial class PolyglotCapabilityErrorFormatter
     // hosts never go through PolyglotCapabilityErrorFormatter, so their messages are
     // unchanged.
     //
-    // The Kestrel HTTPS dev-cert message has been stable across .NET versions and
-    // reads exactly:
-    //   "Unable to configure HTTPS endpoint. No server certificate was specified, and
-    //    the default developer certificate could not be found or is out of date. To
-    //    generate a developer certificate run 'dotnet dev-certs https'. To trust the
-    //    certificate (Windows and macOS only) run 'dotnet dev-certs https --trust'.
-    //    For more information on configuring HTTPS see
-    //    https://go.microsoft.com/fwlink/?linkid=848054."
-    // The advice to invoke `dotnet dev-certs` assumes a .NET SDK is on the PATH, which
-    // is not guaranteed for TypeScript / Node.js / Python app host users. Aspire ships
-    // `aspire certs trust`, which creates the dev cert when missing and trusts it in a
-    // single step, so we rewrite both sentences into one. See
-    // https://github.com/microsoft/aspire/issues/17273.
+    // ASP.NET Core Kestrel surfaces the missing/untrusted HTTPS dev-cert state by
+    // throwing a plain InvalidOperationException with no HResult and no specific
+    // exception type, so the message is the only signal available. The text is
+    // sourced from the resx entry `NoCertSpecifiedNoDevelopmentCertificateFound` and
+    // is thrown unconditionally from `TlsConfigurationLoader.UseHttpsWithDefaults`:
+    //   https://github.com/dotnet/aspnetcore/blob/main/src/Servers/Kestrel/Core/src/CoreStrings.resx
+    //   https://github.com/dotnet/aspnetcore/blob/main/src/Servers/Kestrel/Core/src/TlsConfigurationLoader.cs
+    //
+    // The fwlink identifier `848054` has been the unique sentinel for this exact
+    // error since .NET Core 2.1 (it was added when the dev-cert tooling shipped) and
+    // does not appear in any other Kestrel error, so we anchor detection on it. The
+    // regex tolerates whitespace/line-ending variation between the two guidance
+    // sentences and the fwlink and rewrites the whole block in one shot.
+    //
+    // If a future framework release reworks the message such that the fwlink is no
+    // longer present, the rewrite degrades gracefully: the regex misses, the original
+    // (less friendly) text propagates unchanged, and no incorrect substitution occurs.
+    //
+    // See https://github.com/microsoft/aspire/issues/17273.
     private static string RewritePolyglotUnfriendlyGuidance(string message)
     {
-        const string KestrelDevCertGuidance =
-            "To generate a developer certificate run 'dotnet dev-certs https'. " +
-            "To trust the certificate (Windows and macOS only) run 'dotnet dev-certs https --trust'.";
-        const string AspireDevCertGuidance =
-            "To generate and trust a developer certificate run 'aspire certs trust'.";
-        const string KestrelHttpsFwlink = "https://go.microsoft.com/fwlink/?linkid=848054";
-        const string AspireHttpsDocs = "https://aspire.dev/docs/";
-
-        message = message.Replace(KestrelDevCertGuidance, AspireDevCertGuidance, StringComparison.Ordinal);
-        message = message.Replace(KestrelHttpsFwlink, AspireHttpsDocs, StringComparison.Ordinal);
-
-        return message;
+        return KestrelDevCertGuidanceRegex().Replace(
+            message,
+            "To generate and trust a developer certificate run 'aspire certs trust'. " +
+            "For more information on configuring HTTPS see https://aspire.dev/docs/.");
     }
+
+    [GeneratedRegex(
+        @"To generate a developer certificate run 'dotnet dev-certs https'\.\s+" +
+        @"To trust the certificate \(Windows and macOS only\) run 'dotnet dev-certs https --trust'\.\s+" +
+        @"For more information on configuring HTTPS see https://go\.microsoft\.com/fwlink/\?linkid=848054\.")]
+    private static partial Regex KestrelDevCertGuidanceRegex();
 
     [GeneratedRegex(@"\s{2,}")]
     private static partial Regex DoubleWhitespaceRegex();

--- a/src/Aspire.Hosting.RemoteHost/Ats/PolyglotCapabilityInvocationException.cs
+++ b/src/Aspire.Hosting.RemoteHost/Ats/PolyglotCapabilityInvocationException.cs
@@ -560,28 +560,33 @@ internal static partial class PolyglotCapabilityErrorFormatter
     //
     // The fwlink identifier `848054` has been the unique sentinel for this exact
     // error since .NET Core 2.1 (it was added when the dev-cert tooling shipped) and
-    // does not appear in any other Kestrel error, so we anchor detection on it. The
-    // regex tolerates whitespace/line-ending variation between the two guidance
-    // sentences and the fwlink and rewrites the whole block in one shot.
+    // does not appear in any other Kestrel error, so we use it as a single detection
+    // anchor and replace the entire message with our own polyglot-friendly text. This
+    // is more robust than search/replacing pieces of the original message because it
+    // doesn't depend on the exact wording of any sentence other than the fwlink itself.
     //
     // If a future framework release reworks the message such that the fwlink is no
-    // longer present, the rewrite degrades gracefully: the regex misses, the original
+    // longer present, the rewrite degrades gracefully: detection misses, the original
     // (less friendly) text propagates unchanged, and no incorrect substitution occurs.
     //
     // See https://github.com/microsoft/aspire/issues/17273.
+    private const string KestrelHttpsFwlinkSentinel = "https://go.microsoft.com/fwlink/?linkid=848054";
+
+    private const string AspirePolyglotDevCertMessage =
+        "Unable to configure HTTPS endpoint. No server certificate was specified, and the default " +
+        "developer certificate could not be found or is out of date. To generate and trust a developer " +
+        "certificate run 'aspire certs trust'. For more information on configuring HTTPS see " +
+        "https://aspire.dev/docs/.";
+
     private static string RewritePolyglotUnfriendlyGuidance(string message)
     {
-        return KestrelDevCertGuidanceRegex().Replace(
-            message,
-            "To generate and trust a developer certificate run 'aspire certs trust'. " +
-            "For more information on configuring HTTPS see https://aspire.dev/docs/.");
-    }
+        if (message.Contains(KestrelHttpsFwlinkSentinel, StringComparison.Ordinal))
+        {
+            return AspirePolyglotDevCertMessage;
+        }
 
-    [GeneratedRegex(
-        @"To generate a developer certificate run 'dotnet dev-certs https'\.\s+" +
-        @"To trust the certificate \(Windows and macOS only\) run 'dotnet dev-certs https --trust'\.\s+" +
-        @"For more information on configuring HTTPS see https://go\.microsoft\.com/fwlink/\?linkid=848054\.")]
-    private static partial Regex KestrelDevCertGuidanceRegex();
+        return message;
+    }
 
     [GeneratedRegex(@"\s{2,}")]
     private static partial Regex DoubleWhitespaceRegex();

--- a/tests/Aspire.Hosting.RemoteHost.Tests/CapabilityDispatcherTests.cs
+++ b/tests/Aspire.Hosting.RemoteHost.Tests/CapabilityDispatcherTests.cs
@@ -1878,6 +1878,39 @@ public class CapabilityDispatcherTests
         Assert.DoesNotContain("on resource", capabilityException.Message);
     }
 
+    // Regression test for https://github.com/microsoft/aspire/issues/17273 — TypeScript
+    // and other polyglot app host users may not have the .NET SDK available, so the
+    // Kestrel-generated `dotnet dev-certs` guidance is replaced with `aspire certs trust`
+    // and the fwlink is replaced with an aspire.dev docs link when surfacing through the
+    // polyglot capability layer.
+    [Fact]
+    public void PolyglotFormatter_CreateInternalError_RewritesKestrelDevCertGuidanceForPolyglotHosts()
+    {
+        var handles = new HandleRegistry();
+
+        const string KestrelMessage =
+            "Unable to configure HTTPS endpoint. No server certificate was specified, " +
+            "and the default developer certificate could not be found or is out of date. " +
+            "To generate a developer certificate run 'dotnet dev-certs https'. " +
+            "To trust the certificate (Windows and macOS only) run 'dotnet dev-certs https --trust'. " +
+            "For more information on configuring HTTPS see https://go.microsoft.com/fwlink/?linkid=848054.";
+
+        var ex = PolyglotCapabilityErrorFormatter.CreateInternalError(
+            "Aspire.Hosting/run",
+            "run",
+            "RunAsync",
+            args: null,
+            handles,
+            new InvalidOperationException(KestrelMessage));
+
+        var capabilityException = ex.ToCapabilityException();
+
+        Assert.DoesNotContain("dotnet dev-certs", capabilityException.Message);
+        Assert.DoesNotContain("go.microsoft.com/fwlink", capabilityException.Message);
+        Assert.Contains("aspire certs trust", capabilityException.Message);
+        Assert.Contains("https://aspire.dev/docs/", capabilityException.Message);
+    }
+
     [Fact]
     public void Invoke_StaticMethodTakingRawResource_UnwrapsBuilderHandle()
     {


### PR DESCRIPTION
## Description

When a TypeScript (or other polyglot) app host fails to start because the ASP.NET Core HTTPS developer certificate is missing or untrusted, Kestrel surfaces a message that tells users to run `dotnet dev-certs https` and `dotnet dev-certs https --trust`, and points them at `https://go.microsoft.com/fwlink/?linkid=848054`. That advice assumes the .NET SDK is on `PATH`, which is not guaranteed for Node.js / Python / etc. app host users, and the fwlink is not the right destination for Aspire docs.

This change rewrites the message on its way through the polyglot capability layer so polyglot users see Aspire CLI guidance instead:

> Unable to configure HTTPS endpoint. ... To generate and trust a developer certificate run `aspire certs trust`. For more information on configuring HTTPS see https://aspire.dev/docs/.

### Approach

`PolyglotCapabilityErrorFormatter.ScrubMessage` is the single chokepoint that all exception messages flow through on their way to polyglot (non-.NET) hosts. Native .NET app hosts never go through this code path, so their guidance is unchanged.

ASP.NET Core's Kestrel throws a plain `InvalidOperationException` from `TlsConfigurationLoader.UseHttpsWithDefaults` with no `HResult` and no specific exception type, so the message text is the only signal available. The fwlink ID `848054` has been the unique sentinel for this exact error since .NET Core 2.1 and does not appear in any other Kestrel error, so it is used purely as a detection sentinel; when it appears, the entire message is replaced with a single polyglot-friendly constant owned by us. This avoids any dependency on the exact wording of the surrounding sentences. If a future framework release ever removes the fwlink, the rewrite degrades gracefully: detection misses and the original message propagates unchanged.

Verified with the existing `PolyglotFormatter_*` tests plus a new regression test that pipes the exact Kestrel message through `CreateInternalError` and asserts the rewrite.

Fixes: #17273

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No