### PR TITLE
Fix WaitBehavior.StopOnResourceUnavailable hanging when resource does not exist in model

### DIFF
--- a/src/Aspire.Hosting/ApplicationModel/ResourceNotificationService.cs
+++ b/src/Aspire.Hosting/ApplicationModel/ResourceNotificationService.cs
@@ -238,18 +238,10 @@ public class ResourceNotificationService : IDisposable
     {
         _logger.LogDebug("Waiting for resource '{ResourceName}' to enter the '{State}' state.", resourceName, HealthStatus.Healthy);
 
-        if (waitBehavior == WaitBehavior.StopOnResourceUnavailable)
+        if (waitBehavior == WaitBehavior.StopOnResourceUnavailable && !TryGetCurrentState(resourceName, out _))
         {
-            // GetService (not GetRequiredService) intentionally — the obsolete constructor supplies a
-            // NullServiceProvider that returns null for all services. When the model is unavailable we
-            // skip the check rather than throwing, which preserves backward compatibility for callers
-            // using that deprecated path.
-            var appModel = _serviceProvider.GetService<DistributedApplicationModel>();
-            if (appModel is not null && !appModel.Resources.Any(r => string.Equals(r.Name, resourceName, StringComparisons.ResourceName)))
-            {
-                _logger.LogError("Stopped waiting for resource '{ResourceName}' to become healthy because it does not exist in the application model.", resourceName);
-                throw new DistributedApplicationException($"Stopped waiting for resource '{resourceName}' to become healthy because it does not exist in the application model.");
-            }
+            _logger.LogError("Stopped waiting for resource '{ResourceName}' to become healthy because it does not exist in the application model.", resourceName);
+            throw new DistributedApplicationException($"Stopped waiting for resource '{resourceName}' to become healthy because it does not exist in the application model.");
         }
 
         var resourceEvent = await WaitForResourceCoreAsync(

--- a/src/Aspire.Hosting/ApplicationModel/ResourceNotificationService.cs
+++ b/src/Aspire.Hosting/ApplicationModel/ResourceNotificationService.cs
@@ -237,6 +237,17 @@ public class ResourceNotificationService : IDisposable
     public async Task<ResourceEvent> WaitForResourceHealthyAsync(string resourceName, WaitBehavior waitBehavior, CancellationToken cancellationToken = default)
     {
         _logger.LogDebug("Waiting for resource '{ResourceName}' to enter the '{State}' state.", resourceName, HealthStatus.Healthy);
+
+        if (waitBehavior == WaitBehavior.StopOnResourceUnavailable)
+        {
+            var appModel = _serviceProvider.GetService<DistributedApplicationModel>();
+            if (appModel is not null && !appModel.Resources.Any(r => string.Equals(r.Name, resourceName, StringComparisons.ResourceName)))
+            {
+                _logger.LogError("Stopped waiting for resource '{ResourceName}' to become healthy because it does not exist in the application model.", resourceName);
+                throw new DistributedApplicationException($"Stopped waiting for resource '{resourceName}' to become healthy because it does not exist in the application model.");
+            }
+        }
+
         var resourceEvent = await WaitForResourceCoreAsync(
             resourceName,
             re => ShouldYieldHealthyWait(waitBehavior, re.Snapshot),

--- a/src/Aspire.Hosting/ApplicationModel/ResourceNotificationService.cs
+++ b/src/Aspire.Hosting/ApplicationModel/ResourceNotificationService.cs
@@ -240,6 +240,10 @@ public class ResourceNotificationService : IDisposable
 
         if (waitBehavior == WaitBehavior.StopOnResourceUnavailable)
         {
+            // GetService (not GetRequiredService) intentionally — the obsolete constructor supplies a
+            // NullServiceProvider that returns null for all services. When the model is unavailable we
+            // skip the check rather than throwing, which preserves backward compatibility for callers
+            // using that deprecated path.
             var appModel = _serviceProvider.GetService<DistributedApplicationModel>();
             if (appModel is not null && !appModel.Resources.Any(r => string.Equals(r.Name, resourceName, StringComparisons.ResourceName)))
             {

--- a/src/Aspire.Hosting/ApplicationModel/ResourceNotificationService.cs
+++ b/src/Aspire.Hosting/ApplicationModel/ResourceNotificationService.cs
@@ -240,8 +240,17 @@ public class ResourceNotificationService : IDisposable
 
         if (waitBehavior == WaitBehavior.StopOnResourceUnavailable && !TryGetCurrentState(resourceName, out _))
         {
-            _logger.LogError("Stopped waiting for resource '{ResourceName}' to become healthy because it does not exist in the application model.", resourceName);
-            throw new DistributedApplicationException($"Stopped waiting for resource '{resourceName}' to become healthy because it does not exist in the application model.");
+            // TryGetCurrentState returns false both when a resource doesn't exist and when it exists
+            // but hasn't published its first event yet. Check the app model to distinguish the two:
+            // only throw if the resource is definitively absent from the model. When the model is
+            // unavailable (e.g. the obsolete constructor path) we skip the check to preserve
+            // backward compatibility.
+            var appModel = _serviceProvider.GetService<DistributedApplicationModel>();
+            if (appModel is not null && !appModel.Resources.Any(r => string.Equals(r.Name, resourceName, StringComparisons.ResourceName)))
+            {
+                _logger.LogError("Stopped waiting for resource '{ResourceName}' to become healthy because it does not exist in the application model.", resourceName);
+                throw new DistributedApplicationException($"Stopped waiting for resource '{resourceName}' to become healthy because it does not exist in the application model.");
+            }
         }
 
         var resourceEvent = await WaitForResourceCoreAsync(

--- a/tests/Aspire.Hosting.Tests/ResourceNotificationTests.cs
+++ b/tests/Aspire.Hosting.Tests/ResourceNotificationTests.cs
@@ -1158,13 +1158,15 @@ public class ResourceNotificationTests
     {
         var notificationService = ResourceNotificationServiceTestHelpers.Create();
 
-        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+        using var cts = new CancellationTokenSource();
 
-        // With WaitOnResourceUnavailable the call should NOT throw immediately — it must wait
-        // until the token is cancelled, confirming the fast-fail path is not triggered.
+        // With WaitOnResourceUnavailable the fast-fail path must NOT trigger — the task should
+        // enter a waiting state rather than throwing DistributedApplicationException immediately.
+        var waitTask = notificationService.WaitForResourceHealthyAsync("does-not-exist", WaitBehavior.WaitOnResourceUnavailable, cts.Token);
+        Assert.False(waitTask.IsCompleted);
+
         cts.Cancel();
-        await Assert.ThrowsAsync<OperationCanceledException>(
-            () => notificationService.WaitForResourceHealthyAsync("does-not-exist", WaitBehavior.WaitOnResourceUnavailable, cts.Token));
+        await Assert.ThrowsAsync<OperationCanceledException>(() => waitTask);
     }
 
     private static async Task<bool> PublishAndGetIsHiddenAsync<T>(

--- a/tests/Aspire.Hosting.Tests/ResourceNotificationTests.cs
+++ b/tests/Aspire.Hosting.Tests/ResourceNotificationTests.cs
@@ -7,6 +7,7 @@ using Aspire.Hosting.Tests.Utils;
 using Microsoft.AspNetCore.InternalTesting;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Logging.Testing;
 using HealthStatus = Microsoft.Extensions.Diagnostics.HealthChecks.HealthStatus;
 
@@ -1144,7 +1145,13 @@ public class ResourceNotificationTests
     [Fact]
     public async Task WaitForResourceHealthyAsync_StopOnResourceUnavailable_ThrowsIfResourceNotInModel()
     {
-        var notificationService = ResourceNotificationServiceTestHelpers.Create();
+        var appModel = new DistributedApplicationModel([new CustomResource("existingResource")]);
+        var serviceProvider = new TestServiceProvider().AddService(appModel);
+        var notificationService = new ResourceNotificationService(
+            new NullLogger<ResourceNotificationService>(),
+            new TestHostApplicationLifetime(),
+            serviceProvider,
+            new ResourceLoggerService());
 
         var ex = await Assert.ThrowsAsync<DistributedApplicationException>(
             () => notificationService.WaitForResourceHealthyAsync("does-not-exist", WaitBehavior.StopOnResourceUnavailable));

--- a/tests/Aspire.Hosting.Tests/ResourceNotificationTests.cs
+++ b/tests/Aspire.Hosting.Tests/ResourceNotificationTests.cs
@@ -7,6 +7,7 @@ using Aspire.Hosting.Tests.Utils;
 using Microsoft.AspNetCore.InternalTesting;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Logging.Testing;
 using HealthStatus = Microsoft.Extensions.Diagnostics.HealthChecks.HealthStatus;
 
@@ -1139,6 +1140,49 @@ public class ResourceNotificationTests
         Assert.Contains(logRecords, log => log.Level == LogLevel.Debug && log.Message.Contains("Waiting for resource 'myResource' to enter the 'Healthy' state."));
         Assert.Contains(logRecords, log => log.Level == LogLevel.Debug && log.Message.Contains("Waiting for resource ready to execute for 'myResource'."));
         Assert.Contains(logRecords, log => log.Level == LogLevel.Debug && log.Message.Contains("Finished waiting for resource 'myResource'."));
+    }
+
+    [Fact]
+    public async Task WaitForResourceHealthyAsync_StopOnResourceUnavailable_ThrowsIfResourceNotInModel()
+    {
+        var existingResource = new CustomResource("existingResource");
+        var appModel = new DistributedApplicationModel([existingResource]);
+
+        var serviceProvider = new TestServiceProvider().AddService(appModel);
+        var notificationService = new ResourceNotificationService(
+            new NullLogger<ResourceNotificationService>(),
+            new TestHostApplicationLifetime(),
+            serviceProvider,
+            new ResourceLoggerService());
+
+        var ex = await Assert.ThrowsAsync<DistributedApplicationException>(
+            () => notificationService.WaitForResourceHealthyAsync("does-not-exist", WaitBehavior.StopOnResourceUnavailable));
+
+        Assert.Contains("does-not-exist", ex.Message);
+        Assert.Contains("does not exist in the application model", ex.Message);
+    }
+
+    [Fact]
+    public async Task WaitForResourceHealthyAsync_WaitOnResourceUnavailable_DoesNotThrowForNonexistentResource()
+    {
+        var existingResource = new CustomResource("existingResource");
+        var appModel = new DistributedApplicationModel([existingResource]);
+
+        var serviceProvider = new TestServiceProvider().AddService(appModel);
+        var notificationService = new ResourceNotificationService(
+            new NullLogger<ResourceNotificationService>(),
+            new TestHostApplicationLifetime(),
+            serviceProvider,
+            new ResourceLoggerService());
+
+        using var cts = new CancellationTokenSource(TimeSpan.FromMilliseconds(100));
+
+        // With WaitOnResourceUnavailable, the call should wait (not throw immediately), and only
+        // cancel when the token is triggered.
+        var ex = await Assert.ThrowsAsync<OperationCanceledException>(
+            () => notificationService.WaitForResourceHealthyAsync("does-not-exist", WaitBehavior.WaitOnResourceUnavailable, cts.Token));
+
+        Assert.IsNotType<DistributedApplicationException>(ex);
     }
 
     private static async Task<bool> PublishAndGetIsHiddenAsync<T>(

--- a/tests/Aspire.Hosting.Tests/ResourceNotificationTests.cs
+++ b/tests/Aspire.Hosting.Tests/ResourceNotificationTests.cs
@@ -1175,14 +1175,13 @@ public class ResourceNotificationTests
             serviceProvider,
             new ResourceLoggerService());
 
-        using var cts = new CancellationTokenSource(TimeSpan.FromMilliseconds(100));
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
 
-        // With WaitOnResourceUnavailable, the call should wait (not throw immediately), and only
-        // cancel when the token is triggered.
-        var ex = await Assert.ThrowsAsync<OperationCanceledException>(
+        // With WaitOnResourceUnavailable the call should NOT throw immediately — it must wait
+        // until the token is cancelled, confirming the fast-fail path is not triggered.
+        cts.Cancel();
+        await Assert.ThrowsAsync<OperationCanceledException>(
             () => notificationService.WaitForResourceHealthyAsync("does-not-exist", WaitBehavior.WaitOnResourceUnavailable, cts.Token));
-
-        Assert.IsNotType<DistributedApplicationException>(ex);
     }
 
     private static async Task<bool> PublishAndGetIsHiddenAsync<T>(

--- a/tests/Aspire.Hosting.Tests/ResourceNotificationTests.cs
+++ b/tests/Aspire.Hosting.Tests/ResourceNotificationTests.cs
@@ -7,7 +7,6 @@ using Aspire.Hosting.Tests.Utils;
 using Microsoft.AspNetCore.InternalTesting;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
-using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Logging.Testing;
 using HealthStatus = Microsoft.Extensions.Diagnostics.HealthChecks.HealthStatus;
 
@@ -1145,15 +1144,7 @@ public class ResourceNotificationTests
     [Fact]
     public async Task WaitForResourceHealthyAsync_StopOnResourceUnavailable_ThrowsIfResourceNotInModel()
     {
-        var existingResource = new CustomResource("existingResource");
-        var appModel = new DistributedApplicationModel([existingResource]);
-
-        var serviceProvider = new TestServiceProvider().AddService(appModel);
-        var notificationService = new ResourceNotificationService(
-            new NullLogger<ResourceNotificationService>(),
-            new TestHostApplicationLifetime(),
-            serviceProvider,
-            new ResourceLoggerService());
+        var notificationService = ResourceNotificationServiceTestHelpers.Create();
 
         var ex = await Assert.ThrowsAsync<DistributedApplicationException>(
             () => notificationService.WaitForResourceHealthyAsync("does-not-exist", WaitBehavior.StopOnResourceUnavailable));
@@ -1165,15 +1156,7 @@ public class ResourceNotificationTests
     [Fact]
     public async Task WaitForResourceHealthyAsync_WaitOnResourceUnavailable_DoesNotThrowForNonexistentResource()
     {
-        var existingResource = new CustomResource("existingResource");
-        var appModel = new DistributedApplicationModel([existingResource]);
-
-        var serviceProvider = new TestServiceProvider().AddService(appModel);
-        var notificationService = new ResourceNotificationService(
-            new NullLogger<ResourceNotificationService>(),
-            new TestHostApplicationLifetime(),
-            serviceProvider,
-            new ResourceLoggerService());
+        var notificationService = ResourceNotificationServiceTestHelpers.Create();
 
         using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
 


### PR DESCRIPTION
## Summary

Fixes #17267

When \`WaitForResourceHealthyAsync\` is called with \`WaitBehavior.StopOnResourceUnavailable\` for a resource name that is not registered in the application model, the internal watch loop never receives any matching events and hangs indefinitely.

**Fix:** Added an upfront check in \`WaitForResourceHealthyAsync\`. When \`StopOnResourceUnavailable\` is used:
- \`TryGetCurrentState\` is checked first — if the resource already has state, proceed normally (fast path)
- If \`TryGetCurrentState\` returns false (no state yet), \`DistributedApplicationModel\` is consulted to distinguish "resource missing from model" from "resource exists but hasn't published its first event yet"
- If the resource is absent from the model, \`DistributedApplicationException\` is thrown immediately
- If \`DistributedApplicationModel\` is unavailable (obsolete constructor path), the check is skipped to preserve backward compatibility

\`WaitBehavior.WaitOnResourceUnavailable\` is unaffected and continues to wait indefinitely as before.

## Test plan

- [x] \`WaitForResourceHealthyAsync_StopOnResourceUnavailable_ThrowsIfResourceNotInModel\` — verifies the fix: throws immediately with a clear message when the resource is not in the model
- [x] \`WaitForResourceHealthyAsync_WaitOnResourceUnavailable_DoesNotThrowForNonexistentResource\` — verifies the other behavior is untouched: \`WaitOnResourceUnavailable\` enters a waiting state and only exits via cancellation token