### PR TITLE
Add OTEL telemetry analysis commands

### DIFF
--- a/src/Aspire.Cli/Commands/TelemetryAnalysisCommandHelpers.cs
+++ b/src/Aspire.Cli/Commands/TelemetryAnalysisCommandHelpers.cs
@@ -1,0 +1,398 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.CommandLine;
+using System.Globalization;
+using System.Text.Encodings.Web;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using Aspire.Cli.Resources;
+using Aspire.Dashboard.Otlp.Model;
+using Aspire.Dashboard.Utils;
+using Aspire.Otlp.Serialization;
+using Aspire.Shared.ConsoleLogs;
+
+namespace Aspire.Cli.Commands;
+
+internal enum SpanStatsGroupBy
+{
+    Name,
+    Resource
+}
+
+internal sealed record TelemetryTraceInfo(
+    string TraceId,
+    string Name,
+    string ResourceName,
+    int SpanCount,
+    bool HasError,
+    TimeSpan Duration,
+    ulong? StartTimeUnixNano);
+
+internal sealed record TelemetrySummaryOutput(
+    int ResourceCount,
+    int TraceCount,
+    int SpanCount,
+    int ErrorTraceCount,
+    int ErrorSpanCount,
+    double AverageDurationMs,
+    double P50DurationMs,
+    double P95DurationMs,
+    double P99DurationMs,
+    double MaxDurationMs);
+
+internal sealed record TelemetrySlowTraceOutput(
+    string TraceId,
+    string Name,
+    string Resource,
+    int SpanCount,
+    bool HasError,
+    double DurationMs,
+    string? Timestamp,
+    string? DashboardUrl);
+
+internal sealed record TelemetryWallTimeOutput(
+    string TraceId,
+    string Name,
+    string Resource,
+    int SpanCount,
+    bool HasError,
+    double WallClockMs,
+    double SpanSumMs,
+    double CoveredMs,
+    double GapMs,
+    double OverlapMs,
+    double SpanSumToWallRatio,
+    string? Timestamp,
+    string? DashboardUrl);
+
+internal sealed record TelemetrySpanStatsOutput(
+    string Group,
+    int Count,
+    int ErrorCount,
+    double AverageDurationMs,
+    double P95DurationMs,
+    double MaxDurationMs,
+    double TotalDurationMs);
+
+[JsonSerializable(typeof(TelemetrySummaryOutput))]
+[JsonSerializable(typeof(TelemetrySlowTraceOutput[]))]
+[JsonSerializable(typeof(TelemetryWallTimeOutput[]))]
+[JsonSerializable(typeof(TelemetrySpanStatsOutput[]))]
+[JsonSourceGenerationOptions(
+    WriteIndented = true,
+    PropertyNamingPolicy = JsonKnownNamingPolicy.CamelCase,
+    DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull)]
+internal sealed partial class TelemetryAnalysisJsonContext : JsonSerializerContext
+{
+    private static TelemetryAnalysisJsonContext? s_relaxedEscaping;
+
+    public static TelemetryAnalysisJsonContext RelaxedEscaping => s_relaxedEscaping ??= new TelemetryAnalysisJsonContext(
+        new JsonSerializerOptions
+        {
+            Encoder = JavaScriptEncoder.UnsafeRelaxedJsonEscaping,
+            PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+            DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
+            WriteIndented = true
+        });
+}
+
+internal static class TelemetryAnalysisCommandHelpers
+{
+    internal static Option<FileInfo?> CreateFileOption() => new("--file")
+    {
+        Description = TelemetryCommandStrings.TelemetryArchiveOptionDescription
+    };
+
+    internal static Option<int> CreateTopOption(int defaultValue = 20) => new("--top")
+    {
+        Description = TelemetryCommandStrings.TopOptionDescription,
+        DefaultValueFactory = _ => defaultValue
+    };
+
+    internal static CommandResult? ValidateInputOptions(FileInfo? archiveFile, FileInfo? appHost, string? dashboardUrl, string? apiKey)
+    {
+        if (archiveFile is not null && (appHost is not null || dashboardUrl is not null || apiKey is not null))
+        {
+            return CommandResult.Failure(CliExitCodes.InvalidCommand, TelemetryCommandStrings.FileAndLiveOptionsExclusive);
+        }
+
+        return null;
+    }
+
+    internal static CommandResult? ValidateTop(int top)
+    {
+        if (top < 1)
+        {
+            return CommandResult.Failure(CliExitCodes.InvalidCommand, TelemetryCommandStrings.TopMustBePositive);
+        }
+
+        return null;
+    }
+
+    internal static TelemetryTraceInfo[] GetTraceInfos(TelemetryAnalysisData data)
+    {
+        var traces = SharedAIHelpers.GetTracesFromOtlpData(data.ResourceSpans);
+        return traces
+            .Where(t => !string.IsNullOrEmpty(t.TraceId))
+            .Select(t => CreateTraceInfo(t, data.AllResources))
+            .OrderBy(t => t.StartTimeUnixNano ?? 0)
+            .ToArray();
+    }
+
+    internal static TelemetrySummaryOutput CreateSummary(TelemetryAnalysisData data, TelemetryTraceInfo[] traceInfos)
+    {
+        var spans = SharedAIHelpers.GetSpanDtosFromOtlpData(data.ResourceSpans);
+        var traceDurations = traceInfos.Select(t => t.Duration).OrderBy(d => d).ToArray();
+
+        return new TelemetrySummaryOutput(
+            ResourceCount: data.AllResources.Count,
+            TraceCount: traceInfos.Length,
+            SpanCount: spans.Count,
+            ErrorTraceCount: traceInfos.Count(t => t.HasError),
+            ErrorSpanCount: spans.Count(s => IsError(s.Span)),
+            AverageDurationMs: ToMilliseconds(traceDurations.Length == 0 ? TimeSpan.Zero : TimeSpan.FromTicks((long)traceDurations.Average(d => d.Ticks))),
+            P50DurationMs: ToMilliseconds(GetPercentile(traceDurations, 50)),
+            P95DurationMs: ToMilliseconds(GetPercentile(traceDurations, 95)),
+            P99DurationMs: ToMilliseconds(GetPercentile(traceDurations, 99)),
+            MaxDurationMs: ToMilliseconds(traceDurations.Length == 0 ? TimeSpan.Zero : traceDurations[^1]));
+    }
+
+    internal static TelemetrySlowTraceOutput[] CreateSlowTraceOutputs(TelemetryAnalysisData data, IEnumerable<TelemetryTraceInfo> traceInfos)
+    {
+        return traceInfos.Select(t => new TelemetrySlowTraceOutput(
+            t.TraceId,
+            t.Name,
+            t.ResourceName,
+            t.SpanCount,
+            t.HasError,
+            ToMilliseconds(t.Duration),
+            FormatTimestamp(t.StartTimeUnixNano),
+            GetDashboardTraceUrl(data.DashboardUrl, t.TraceId))).ToArray();
+    }
+
+    internal static TelemetryWallTimeOutput[] CreateWallTimeOutputs(TelemetryAnalysisData data)
+    {
+        var traces = SharedAIHelpers.GetTracesFromOtlpData(data.ResourceSpans);
+        return traces
+            .Where(t => !string.IsNullOrEmpty(t.TraceId))
+            .Select(t => CreateWallTimeOutput(t, data.AllResources, data.DashboardUrl))
+            .OrderByDescending(t => t.WallClockMs)
+            .ThenByDescending(t => t.SpanSumMs)
+            .ThenBy(t => t.TraceId, StringComparer.Ordinal)
+            .ToArray();
+    }
+
+    internal static TelemetrySpanStatsOutput[] CreateSpanStats(TelemetryAnalysisData data, SpanStatsGroupBy groupBy)
+    {
+        var spans = SharedAIHelpers.GetSpanDtosFromOtlpData(data.ResourceSpans);
+        return spans
+            .GroupBy(s => GetSpanGroupKey(s, data.AllResources, groupBy), StringComparer.OrdinalIgnoreCase)
+            .Select(g => CreateSpanStatsOutput(g.Key, g.ToArray()))
+            .OrderByDescending(s => s.TotalDurationMs)
+            .ThenBy(s => s.Group, StringComparer.OrdinalIgnoreCase)
+            .ToArray();
+    }
+
+    internal static string FormatDuration(double milliseconds)
+    {
+        return TelemetryCommandHelpers.FormatDuration(TimeSpan.FromMilliseconds(milliseconds));
+    }
+
+    private static TelemetryTraceInfo CreateTraceInfo(OtlpTraceDto trace, IReadOnlyList<IOtlpResource> allResources)
+    {
+        var root = GetRootOrFirstSpan(trace);
+        var intervals = GetSpanIntervals(trace);
+        var duration = CalculateWallClockDuration(intervals);
+        var start = intervals.Length == 0 ? (ulong?)null : intervals[0].StartTimeUnixNano;
+
+        return new TelemetryTraceInfo(
+            trace.TraceId,
+            root?.Span.Name ?? "unknown",
+            root is null ? "unknown" : OtlpHelpers.GetResourceName(root.Resource, allResources),
+            trace.Spans.Count,
+            trace.Spans.Any(s => IsError(s.Span)),
+            duration,
+            start);
+    }
+
+    private static TelemetryWallTimeOutput CreateWallTimeOutput(OtlpTraceDto trace, IReadOnlyList<IOtlpResource> allResources, string? dashboardUrl)
+    {
+        var traceInfo = CreateTraceInfo(trace, allResources);
+        var intervals = GetSpanIntervals(trace);
+
+        // Treat each span as an absolute OTLP interval:
+        //   span A: start=0ms, end=100ms
+        //   span B: start=25ms, end=75ms
+        // The trace wall clock is the full envelope (100ms), covered time is the union of covered
+        // intervals (100ms), and span sum is each span duration added together (150ms).
+        // Gaps point at uncovered time inside the envelope; overlap points at nested or concurrent
+        // spans that make the span sum exceed covered elapsed time.
+        var wallClock = CalculateWallClockDuration(intervals);
+        var spanSum = CalculateSpanSumDuration(intervals);
+        var covered = CalculateCoveredDuration(intervals);
+        var gap = wallClock > covered ? wallClock - covered : TimeSpan.Zero;
+        var overlap = spanSum > covered ? spanSum - covered : TimeSpan.Zero;
+        var spanSumToWallRatio = wallClock > TimeSpan.Zero ? spanSum.TotalMilliseconds / wallClock.TotalMilliseconds : 0;
+
+        return new TelemetryWallTimeOutput(
+            traceInfo.TraceId,
+            traceInfo.Name,
+            traceInfo.ResourceName,
+            traceInfo.SpanCount,
+            traceInfo.HasError,
+            ToMilliseconds(wallClock),
+            ToMilliseconds(spanSum),
+            ToMilliseconds(covered),
+            ToMilliseconds(gap),
+            ToMilliseconds(overlap),
+            Math.Round(spanSumToWallRatio, 3),
+            FormatTimestamp(traceInfo.StartTimeUnixNano),
+            GetDashboardTraceUrl(dashboardUrl, traceInfo.TraceId));
+    }
+
+    private static OtlpSpanDto? GetRootOrFirstSpan(OtlpTraceDto trace)
+    {
+        var spanIds = trace.Spans
+            .Select(s => s.Span.SpanId)
+            .Where(id => !string.IsNullOrEmpty(id))
+            .ToHashSet(StringComparer.Ordinal);
+
+        return trace.Spans
+            .Where(s => string.IsNullOrEmpty(s.Span.ParentSpanId) || !spanIds.Contains(s.Span.ParentSpanId))
+            .OrderBy(s => s.Span.StartTimeUnixNano ?? ulong.MaxValue)
+            .FirstOrDefault()
+            ?? trace.Spans.OrderBy(s => s.Span.StartTimeUnixNano ?? ulong.MaxValue).FirstOrDefault();
+    }
+
+    private static TimeSpan CalculateWallClockDuration(SpanInterval[] intervals)
+    {
+        if (intervals.Length == 0)
+        {
+            return TimeSpan.Zero;
+        }
+
+        var start = intervals[0].StartTimeUnixNano;
+        var end = intervals.Max(i => i.EndTimeUnixNano);
+        return end >= start ? OtlpHelpers.NanosecondsToTimeSpan(end - start) : TimeSpan.Zero;
+    }
+
+    private static TimeSpan CalculateSpanSumDuration(SpanInterval[] intervals)
+    {
+        var ticks = 0L;
+        foreach (var interval in intervals)
+        {
+            ticks += OtlpHelpers.NanosecondsToTicks(interval.EndTimeUnixNano - interval.StartTimeUnixNano);
+        }
+
+        return TimeSpan.FromTicks(ticks);
+    }
+
+    private static TimeSpan CalculateCoveredDuration(SpanInterval[] intervals)
+    {
+        if (intervals.Length == 0)
+        {
+            return TimeSpan.Zero;
+        }
+
+        var coveredTicks = 0L;
+        var currentStart = intervals[0].StartTimeUnixNano;
+        var currentEnd = intervals[0].EndTimeUnixNano;
+
+        foreach (var interval in intervals.Skip(1))
+        {
+            if (interval.StartTimeUnixNano > currentEnd)
+            {
+                coveredTicks += OtlpHelpers.NanosecondsToTicks(currentEnd - currentStart);
+                currentStart = interval.StartTimeUnixNano;
+                currentEnd = interval.EndTimeUnixNano;
+                continue;
+            }
+
+            if (interval.EndTimeUnixNano > currentEnd)
+            {
+                currentEnd = interval.EndTimeUnixNano;
+            }
+        }
+
+        coveredTicks += OtlpHelpers.NanosecondsToTicks(currentEnd - currentStart);
+        return TimeSpan.FromTicks(coveredTicks);
+    }
+
+    private static SpanInterval[] GetSpanIntervals(OtlpTraceDto trace)
+    {
+        var intervals = new List<SpanInterval>();
+        foreach (var span in trace.Spans)
+        {
+            var start = span.Span.StartTimeUnixNano;
+            var end = span.Span.EndTimeUnixNano;
+            if (start.HasValue && end.HasValue && end.Value >= start.Value)
+            {
+                intervals.Add(new SpanInterval(start.Value, end.Value));
+            }
+        }
+
+        return intervals
+            .OrderBy(i => i.StartTimeUnixNano)
+            .ThenBy(i => i.EndTimeUnixNano)
+            .ToArray();
+    }
+
+    private static TelemetrySpanStatsOutput CreateSpanStatsOutput(string group, OtlpSpanDto[] spans)
+    {
+        var durations = spans
+            .Select(s => OtlpHelpers.CalculateDuration(s.Span.StartTimeUnixNano, s.Span.EndTimeUnixNano))
+            .OrderBy(d => d)
+            .ToArray();
+        var totalTicks = durations.Sum(d => d.Ticks);
+        var average = durations.Length == 0 ? TimeSpan.Zero : TimeSpan.FromTicks(totalTicks / durations.Length);
+
+        return new TelemetrySpanStatsOutput(
+            group,
+            spans.Length,
+            spans.Count(s => IsError(s.Span)),
+            ToMilliseconds(average),
+            ToMilliseconds(GetPercentile(durations, 95)),
+            ToMilliseconds(durations.Length == 0 ? TimeSpan.Zero : durations[^1]),
+            ToMilliseconds(TimeSpan.FromTicks(totalTicks)));
+    }
+
+    private static string GetSpanGroupKey(OtlpSpanDto span, IReadOnlyList<IOtlpResource> allResources, SpanStatsGroupBy groupBy)
+    {
+        return groupBy switch
+        {
+            SpanStatsGroupBy.Resource => OtlpHelpers.GetResourceName(span.Resource, allResources),
+            _ => string.IsNullOrEmpty(span.Span.Name) ? "unknown" : span.Span.Name
+        };
+    }
+
+    private static bool IsError(OtlpSpanJson span) => span.Status?.Code == 2;
+
+    private static TimeSpan GetPercentile(TimeSpan[] sortedDurations, int percentile)
+    {
+        if (sortedDurations.Length == 0)
+        {
+            return TimeSpan.Zero;
+        }
+
+        var index = (int)Math.Ceiling(percentile / 100d * sortedDurations.Length) - 1;
+        index = Math.Clamp(index, 0, sortedDurations.Length - 1);
+        return sortedDurations[index];
+    }
+
+    private static double ToMilliseconds(TimeSpan duration) => Math.Round(duration.TotalMilliseconds, 3);
+
+    private static string? FormatTimestamp(ulong? startTimeUnixNano)
+    {
+        return startTimeUnixNano.HasValue
+            ? OtlpHelpers.UnixNanoSecondsToDateTime(startTimeUnixNano.Value).ToString("O", CultureInfo.InvariantCulture)
+            : null;
+    }
+
+    private static string? GetDashboardTraceUrl(string? dashboardUrl, string traceId)
+    {
+        return dashboardUrl is null ? null : DashboardUrls.CombineUrl(dashboardUrl, DashboardUrls.TraceDetailUrl(traceId));
+    }
+
+    private readonly record struct SpanInterval(ulong StartTimeUnixNano, ulong EndTimeUnixNano);
+}

--- a/src/Aspire.Cli/Commands/TelemetryAnalysisDataSource.cs
+++ b/src/Aspire.Cli/Commands/TelemetryAnalysisDataSource.cs
@@ -1,0 +1,225 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Globalization;
+using System.IO.Compression;
+using System.Net.Http.Json;
+using System.Text.Json;
+using Aspire.Cli.Backchannel;
+using Aspire.Cli.Interaction;
+using Aspire.Cli.Projects;
+using Aspire.Cli.Resources;
+using Aspire.Dashboard.Otlp.Model;
+using Aspire.Dashboard.Utils;
+using Aspire.Otlp.Serialization;
+using Microsoft.Extensions.Logging;
+
+namespace Aspire.Cli.Commands;
+
+internal sealed record TelemetryAnalysisData(
+    OtlpResourceSpansJson[] ResourceSpans,
+    IReadOnlyList<IOtlpResource> AllResources,
+    string? DashboardUrl);
+
+internal sealed record TelemetryAnalysisDataResult(
+    bool Success,
+    TelemetryAnalysisData? Data,
+    int ExitCode,
+    string? ErrorMessage)
+{
+    public static TelemetryAnalysisDataResult Succeeded(TelemetryAnalysisData data) => new(true, data, CliExitCodes.Success, null);
+
+    public static TelemetryAnalysisDataResult Failed(int exitCode, string? errorMessage = null) => new(false, null, exitCode, errorMessage);
+}
+
+internal sealed class TelemetryAnalysisDataSource
+{
+    private readonly IInteractionService _interactionService;
+    private readonly AppHostConnectionResolver _connectionResolver;
+    private readonly IHttpClientFactory _httpClientFactory;
+    private readonly ILogger<TelemetryAnalysisDataSource> _logger;
+
+    public TelemetryAnalysisDataSource(
+        IAuxiliaryBackchannelMonitor backchannelMonitor,
+        IInteractionService interactionService,
+        IProjectLocator projectLocator,
+        CliExecutionContext executionContext,
+        IHttpClientFactory httpClientFactory,
+        ILogger<TelemetryAnalysisDataSource> logger)
+    {
+        _interactionService = interactionService;
+        _httpClientFactory = httpClientFactory;
+        _logger = logger;
+        _connectionResolver = new AppHostConnectionResolver(backchannelMonitor, interactionService, projectLocator, executionContext, logger);
+    }
+
+    public async Task<TelemetryAnalysisDataResult> GetTracesAsync(
+        FileInfo? projectFile,
+        string? dashboardUrl,
+        string? apiKey,
+        FileInfo? archiveFile,
+        string? resourceName,
+        CancellationToken cancellationToken)
+    {
+        if (archiveFile is not null)
+        {
+            return await GetArchivedTracesAsync(archiveFile, resourceName, cancellationToken).ConfigureAwait(false);
+        }
+
+        return await GetLiveTracesAsync(projectFile, dashboardUrl, apiKey, resourceName, cancellationToken).ConfigureAwait(false);
+    }
+
+    private async Task<TelemetryAnalysisDataResult> GetLiveTracesAsync(
+        FileInfo? projectFile,
+        string? dashboardUrl,
+        string? apiKey,
+        string? resourceName,
+        CancellationToken cancellationToken)
+    {
+        var dashboardApi = await TelemetryCommandHelpers.GetDashboardApiAsync(
+            _connectionResolver,
+            _interactionService,
+            _httpClientFactory,
+            _logger,
+            projectFile,
+            dashboardUrl,
+            apiKey,
+            requireDashboard: true,
+            cancellationToken).ConfigureAwait(false);
+
+        if (!dashboardApi.Success)
+        {
+            return TelemetryAnalysisDataResult.Failed(dashboardApi.ExitCode);
+        }
+
+        try
+        {
+            using var client = TelemetryCommandHelpers.CreateApiClient(_httpClientFactory, dashboardApi.ApiToken!);
+            var resources = await TelemetryCommandHelpers.GetAllResourcesAsync(client, dashboardApi.BaseUrl!, cancellationToken).ConfigureAwait(false);
+
+            if (!TelemetryCommandHelpers.TryResolveResourceNames(resourceName, resources, out var resolvedResources))
+            {
+                return TelemetryAnalysisDataResult.Failed(
+                    CliExitCodes.InvalidCommand,
+                    string.Format(CultureInfo.CurrentCulture, TelemetryCommandStrings.ResourceNotFound, resourceName));
+            }
+
+            var url = DashboardUrls.TelemetryTracesApiUrl(dashboardApi.BaseUrl!, resolvedResources, limit: TelemetryCommandHelpers.MaxTelemetryLimit);
+            var response = await client.GetAsync(url, cancellationToken).ConfigureAwait(false);
+            TelemetryCommandHelpers.EnsureTelemetryApiResponse(response);
+
+            var apiResponse = await response.Content.ReadFromJsonAsync(OtlpJsonSerializerContext.Default.TelemetryApiResponse, cancellationToken).ConfigureAwait(false);
+            var resourceSpans = apiResponse?.Data?.ResourceSpans ?? [];
+            var allResources = TelemetryCommandHelpers.ToOtlpResources(resources);
+
+            return TelemetryAnalysisDataResult.Succeeded(new TelemetryAnalysisData(resourceSpans, allResources, dashboardApi.DashboardUrl));
+        }
+        catch (HttpRequestException ex)
+        {
+            _logger.LogError(ex, "Failed to fetch traces for telemetry analysis");
+            var errorInfo = await TelemetryCommandHelpers.FormatTelemetryErrorAsync(ex, dashboardApi.BaseUrl!, dashboardUrl is not null, _httpClientFactory, _logger, cancellationToken).ConfigureAwait(false);
+            TelemetryCommandHelpers.DisplayTelemetryError(_interactionService, errorInfo);
+            return TelemetryAnalysisDataResult.Failed(CliExitCodes.DashboardFailure);
+        }
+    }
+
+    private async Task<TelemetryAnalysisDataResult> GetArchivedTracesAsync(
+        FileInfo archiveFile,
+        string? resourceName,
+        CancellationToken cancellationToken)
+    {
+        if (!archiveFile.Exists)
+        {
+            return TelemetryAnalysisDataResult.Failed(
+                CliExitCodes.InvalidCommand,
+                string.Format(CultureInfo.CurrentCulture, TelemetryCommandStrings.TelemetryArchiveNotFound, archiveFile.FullName));
+        }
+
+        try
+        {
+            using var fileStream = archiveFile.OpenRead();
+            using var archive = new ZipArchive(fileStream, ZipArchiveMode.Read, leaveOpen: false);
+
+            var resourceSpans = new List<OtlpResourceSpansJson>();
+            foreach (var entry in archive.Entries.Where(IsTraceEntry))
+            {
+                await using var entryStream = entry.Open();
+                var data = await JsonSerializer.DeserializeAsync(entryStream, OtlpJsonSerializerContext.Default.OtlpTelemetryDataJson, cancellationToken).ConfigureAwait(false);
+                if (data?.ResourceSpans is { Length: > 0 })
+                {
+                    resourceSpans.AddRange(data.ResourceSpans);
+                }
+            }
+
+            var allResources = GetAllResources(resourceSpans);
+            var selectedResourceSpans = resourceSpans.ToArray();
+            if (!string.IsNullOrEmpty(resourceName))
+            {
+                if (!TryFilterResourceSpans(resourceSpans, allResources, resourceName, out var filteredResourceSpans))
+                {
+                    return TelemetryAnalysisDataResult.Failed(
+                        CliExitCodes.InvalidCommand,
+                        string.Format(CultureInfo.CurrentCulture, TelemetryCommandStrings.ResourceNotFound, resourceName));
+                }
+
+                selectedResourceSpans = filteredResourceSpans;
+            }
+
+            return TelemetryAnalysisDataResult.Succeeded(new TelemetryAnalysisData(
+                selectedResourceSpans,
+                allResources,
+                DashboardUrl: null));
+        }
+        catch (Exception ex) when (ex is InvalidDataException or JsonException or IOException)
+        {
+            _logger.LogError(ex, "Failed to read telemetry archive {ArchiveFile}", archiveFile.FullName);
+            return TelemetryAnalysisDataResult.Failed(
+                CliExitCodes.InvalidCommand,
+                string.Format(CultureInfo.CurrentCulture, TelemetryCommandStrings.FailedToReadTelemetryArchive, archiveFile.FullName, ex.Message));
+        }
+    }
+
+    private static bool IsTraceEntry(ZipArchiveEntry entry)
+    {
+        return entry.FullName.StartsWith("traces/", StringComparison.OrdinalIgnoreCase) &&
+            entry.FullName.EndsWith(".json", StringComparison.OrdinalIgnoreCase) &&
+            entry.Length > 0;
+    }
+
+    private static IReadOnlyList<IOtlpResource> GetAllResources(IEnumerable<OtlpResourceSpansJson> resourceSpans)
+    {
+        return resourceSpans
+            .Select(rs => new SimpleOtlpResource(rs.Resource?.GetServiceName() ?? "unknown", rs.Resource?.GetServiceInstanceId()))
+            .Distinct()
+            .OrderBy(r => r.ResourceName, StringComparer.OrdinalIgnoreCase)
+            .ThenBy(r => r.InstanceId, StringComparer.OrdinalIgnoreCase)
+            .ToArray();
+    }
+
+    private static bool TryFilterResourceSpans(
+        IReadOnlyList<OtlpResourceSpansJson> resourceSpans,
+        IReadOnlyList<IOtlpResource> allResources,
+        string resourceName,
+        out OtlpResourceSpansJson[] filteredResourceSpans)
+    {
+        var matchingResources = allResources
+            .Where(r =>
+                string.Equals(r.ResourceName, resourceName, StringComparisons.ResourceName) ||
+                string.Equals(OtlpHelpers.GetResourceName(r, allResources), resourceName, StringComparisons.ResourceName))
+            .ToArray();
+
+        if (matchingResources.Length == 0)
+        {
+            filteredResourceSpans = [];
+            return false;
+        }
+
+        filteredResourceSpans = resourceSpans
+            .Where(rs => matchingResources.Any(r =>
+                string.Equals(r.ResourceName, rs.Resource?.GetServiceName() ?? "unknown", StringComparisons.ResourceName) &&
+                string.Equals(r.InstanceId, rs.Resource?.GetServiceInstanceId(), StringComparison.OrdinalIgnoreCase)))
+            .ToArray();
+
+        return true;
+    }
+}

--- a/src/Aspire.Cli/Commands/TelemetryCommand.cs
+++ b/src/Aspire.Cli/Commands/TelemetryCommand.cs
@@ -20,6 +20,10 @@ internal sealed class TelemetryCommand : ParentCommand
         TelemetryLogsCommand logsCommand,
         TelemetrySpansCommand spansCommand,
         TelemetryTracesCommand tracesCommand,
+        TelemetrySummaryCommand summaryCommand,
+        TelemetrySlowTracesCommand slowTracesCommand,
+        TelemetryWallTimeCommand wallTimeCommand,
+        TelemetrySpanStatsCommand spanStatsCommand,
         IInteractionService interactionService,
         IFeatures features,
         ICliUpdateNotifier updateNotifier,
@@ -30,9 +34,17 @@ internal sealed class TelemetryCommand : ParentCommand
         ArgumentNullException.ThrowIfNull(logsCommand);
         ArgumentNullException.ThrowIfNull(spansCommand);
         ArgumentNullException.ThrowIfNull(tracesCommand);
+        ArgumentNullException.ThrowIfNull(summaryCommand);
+        ArgumentNullException.ThrowIfNull(slowTracesCommand);
+        ArgumentNullException.ThrowIfNull(wallTimeCommand);
+        ArgumentNullException.ThrowIfNull(spanStatsCommand);
 
         Subcommands.Add(logsCommand);
         Subcommands.Add(spansCommand);
         Subcommands.Add(tracesCommand);
+        Subcommands.Add(summaryCommand);
+        Subcommands.Add(slowTracesCommand);
+        Subcommands.Add(wallTimeCommand);
+        Subcommands.Add(spanStatsCommand);
     }
 }

--- a/src/Aspire.Cli/Commands/TelemetrySlowTracesCommand.cs
+++ b/src/Aspire.Cli/Commands/TelemetrySlowTracesCommand.cs
@@ -1,0 +1,140 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.CommandLine;
+using System.Globalization;
+using System.Text.Json;
+using Aspire.Cli.Configuration;
+using Aspire.Cli.Interaction;
+using Aspire.Cli.Resources;
+using Aspire.Cli.Telemetry;
+using Aspire.Cli.Utils;
+using Aspire.Dashboard.Otlp.Model;
+using Microsoft.Extensions.Logging;
+using Spectre.Console;
+
+namespace Aspire.Cli.Commands;
+
+/// <summary>
+/// Command to show the slowest traces.
+/// </summary>
+internal sealed class TelemetrySlowTracesCommand : BaseCommand
+{
+    private readonly TelemetryAnalysisDataSource _dataSource;
+    private readonly ILogger<TelemetrySlowTracesCommand> _logger;
+
+    private static readonly Argument<string?> s_resourceArgument = TelemetryCommandHelpers.CreateResourceArgument();
+    private static readonly OptionWithLegacy<FileInfo?> s_appHostOption = TelemetryCommandHelpers.CreateAppHostOption();
+    private static readonly Option<OutputFormat> s_formatOption = TelemetryCommandHelpers.CreateFormatOption();
+    private static readonly Option<string?> s_dashboardUrlOption = TelemetryCommandHelpers.CreateDashboardUrlOption();
+    private static readonly Option<string?> s_apiKeyOption = TelemetryCommandHelpers.CreateApiKeyOption();
+    private static readonly Option<FileInfo?> s_fileOption = TelemetryAnalysisCommandHelpers.CreateFileOption();
+    private static readonly Option<int> s_topOption = TelemetryAnalysisCommandHelpers.CreateTopOption();
+
+    public TelemetrySlowTracesCommand(
+        TelemetryAnalysisDataSource dataSource,
+        IInteractionService interactionService,
+        IFeatures features,
+        ICliUpdateNotifier updateNotifier,
+        CliExecutionContext executionContext,
+        AspireCliTelemetry telemetry,
+        ILogger<TelemetrySlowTracesCommand> logger)
+        : base("top-traces", TelemetryCommandStrings.SlowTracesDescription, features, updateNotifier, executionContext, interactionService, telemetry)
+    {
+        _dataSource = dataSource;
+        _logger = logger;
+
+        Arguments.Add(s_resourceArgument);
+        Options.Add(s_appHostOption);
+        Options.Add(s_formatOption);
+        Options.Add(s_dashboardUrlOption);
+        Options.Add(s_apiKeyOption);
+        Options.Add(s_fileOption);
+        Options.Add(s_topOption);
+    }
+
+    protected override async Task<CommandResult> ExecuteAsync(ParseResult parseResult, CancellationToken cancellationToken)
+    {
+        using var activity = Telemetry.StartDiagnosticActivity(Name);
+
+        var resourceName = parseResult.GetValue(s_resourceArgument);
+        var appHost = parseResult.GetValue(s_appHostOption);
+        var format = parseResult.GetValue(s_formatOption);
+        var dashboardUrl = parseResult.GetValue(s_dashboardUrlOption);
+        var apiKey = parseResult.GetValue(s_apiKeyOption);
+        var file = parseResult.GetValue(s_fileOption);
+        var top = parseResult.GetValue(s_topOption);
+
+        if (TelemetryAnalysisCommandHelpers.ValidateInputOptions(file, appHost, dashboardUrl, apiKey) is { } validationResult)
+        {
+            return validationResult;
+        }
+        if (TelemetryAnalysisCommandHelpers.ValidateTop(top) is { } topValidationResult)
+        {
+            return topValidationResult;
+        }
+
+        var dataResult = await _dataSource.GetTracesAsync(appHost, dashboardUrl, apiKey, file, resourceName, cancellationToken).ConfigureAwait(false);
+        if (!dataResult.Success)
+        {
+            return CommandResult.Failure(dataResult.ExitCode, dataResult.ErrorMessage);
+        }
+
+        var data = dataResult.Data!;
+        var slowTraces = TelemetryAnalysisCommandHelpers.GetTraceInfos(data)
+            .OrderByDescending(t => t.Duration)
+            .Take(top)
+            .ToArray();
+        var output = TelemetryAnalysisCommandHelpers.CreateSlowTraceOutputs(data, slowTraces);
+
+        if (format == OutputFormat.Json)
+        {
+            var json = JsonSerializer.Serialize(output, TelemetryAnalysisJsonContext.RelaxedEscaping.TelemetrySlowTraceOutputArray);
+            InteractionService.DisplayRawText(json, ConsoleOutput.Standard);
+        }
+        else
+        {
+            DisplaySlowTraces(slowTraces, data.DashboardUrl);
+        }
+
+        _logger.LogDebug("Displayed {TraceCount} slow traces", slowTraces.Length);
+        return CommandResult.Success();
+    }
+
+    private void DisplaySlowTraces(TelemetryTraceInfo[] slowTraces, string? dashboardUrl)
+    {
+        if (slowTraces.Length == 0)
+        {
+            TelemetryCommandHelpers.DisplayNoData(InteractionService, "traces");
+            return;
+        }
+
+        var table = new Table();
+        table.AddBoldColumn(TelemetryCommandStrings.HeaderDuration);
+        table.AddBoldColumn(TelemetryCommandStrings.HeaderSpans);
+        table.AddBoldColumn(TelemetryCommandStrings.HeaderStatus);
+        table.AddBoldColumn(TelemetryCommandStrings.HeaderResource);
+        table.AddBoldColumn(TelemetryCommandStrings.HeaderName);
+        table.AddBoldColumn(TelemetryCommandStrings.HeaderTraceId);
+
+        foreach (var trace in slowTraces)
+        {
+            var status = trace.HasError ? "[red]ERR[/]" : "[green]OK[/]";
+            var traceId = TelemetryCommandHelpers.FormatTraceLink(
+                InteractionService,
+                dashboardUrl,
+                trace.TraceId,
+                OtlpHelpers.ToShortenedId(trace.TraceId));
+
+            table.AddRow(
+                TelemetryCommandHelpers.FormatDuration(trace.Duration),
+                trace.SpanCount.ToString(CultureInfo.InvariantCulture),
+                status,
+                trace.ResourceName.EscapeMarkup(),
+                trace.Name.EscapeMarkup(),
+                traceId);
+        }
+
+        InteractionService.DisplayRenderable(table);
+    }
+}

--- a/src/Aspire.Cli/Commands/TelemetrySpanStatsCommand.cs
+++ b/src/Aspire.Cli/Commands/TelemetrySpanStatsCommand.cs
@@ -1,0 +1,138 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.CommandLine;
+using System.Globalization;
+using System.Text.Json;
+using Aspire.Cli.Configuration;
+using Aspire.Cli.Interaction;
+using Aspire.Cli.Resources;
+using Aspire.Cli.Telemetry;
+using Aspire.Cli.Utils;
+using Microsoft.Extensions.Logging;
+using Spectre.Console;
+
+namespace Aspire.Cli.Commands;
+
+/// <summary>
+/// Command to aggregate span duration statistics.
+/// </summary>
+internal sealed class TelemetrySpanStatsCommand : BaseCommand
+{
+    private readonly TelemetryAnalysisDataSource _dataSource;
+    private readonly ILogger<TelemetrySpanStatsCommand> _logger;
+
+    private static readonly Argument<string?> s_resourceArgument = TelemetryCommandHelpers.CreateResourceArgument();
+    private static readonly OptionWithLegacy<FileInfo?> s_appHostOption = TelemetryCommandHelpers.CreateAppHostOption();
+    private static readonly Option<OutputFormat> s_formatOption = TelemetryCommandHelpers.CreateFormatOption();
+    private static readonly Option<string?> s_dashboardUrlOption = TelemetryCommandHelpers.CreateDashboardUrlOption();
+    private static readonly Option<string?> s_apiKeyOption = TelemetryCommandHelpers.CreateApiKeyOption();
+    private static readonly Option<FileInfo?> s_fileOption = TelemetryAnalysisCommandHelpers.CreateFileOption();
+    private static readonly Option<int> s_topOption = TelemetryAnalysisCommandHelpers.CreateTopOption();
+    private static readonly Option<SpanStatsGroupBy> s_groupByOption = new("--group-by")
+    {
+        Description = TelemetryCommandStrings.GroupByOptionDescription,
+        DefaultValueFactory = _ => SpanStatsGroupBy.Name
+    };
+
+    public TelemetrySpanStatsCommand(
+        TelemetryAnalysisDataSource dataSource,
+        IInteractionService interactionService,
+        IFeatures features,
+        ICliUpdateNotifier updateNotifier,
+        CliExecutionContext executionContext,
+        AspireCliTelemetry telemetry,
+        ILogger<TelemetrySpanStatsCommand> logger)
+        : base("span-stats", TelemetryCommandStrings.SpanStatsDescription, features, updateNotifier, executionContext, interactionService, telemetry)
+    {
+        _dataSource = dataSource;
+        _logger = logger;
+
+        Arguments.Add(s_resourceArgument);
+        Options.Add(s_appHostOption);
+        Options.Add(s_formatOption);
+        Options.Add(s_dashboardUrlOption);
+        Options.Add(s_apiKeyOption);
+        Options.Add(s_fileOption);
+        Options.Add(s_topOption);
+        Options.Add(s_groupByOption);
+    }
+
+    protected override async Task<CommandResult> ExecuteAsync(ParseResult parseResult, CancellationToken cancellationToken)
+    {
+        using var activity = Telemetry.StartDiagnosticActivity(Name);
+
+        var resourceName = parseResult.GetValue(s_resourceArgument);
+        var appHost = parseResult.GetValue(s_appHostOption);
+        var format = parseResult.GetValue(s_formatOption);
+        var dashboardUrl = parseResult.GetValue(s_dashboardUrlOption);
+        var apiKey = parseResult.GetValue(s_apiKeyOption);
+        var file = parseResult.GetValue(s_fileOption);
+        var top = parseResult.GetValue(s_topOption);
+        var groupBy = parseResult.GetValue(s_groupByOption);
+
+        if (TelemetryAnalysisCommandHelpers.ValidateInputOptions(file, appHost, dashboardUrl, apiKey) is { } validationResult)
+        {
+            return validationResult;
+        }
+        if (TelemetryAnalysisCommandHelpers.ValidateTop(top) is { } topValidationResult)
+        {
+            return topValidationResult;
+        }
+
+        var dataResult = await _dataSource.GetTracesAsync(appHost, dashboardUrl, apiKey, file, resourceName, cancellationToken).ConfigureAwait(false);
+        if (!dataResult.Success)
+        {
+            return CommandResult.Failure(dataResult.ExitCode, dataResult.ErrorMessage);
+        }
+
+        var spanStats = TelemetryAnalysisCommandHelpers.CreateSpanStats(dataResult.Data!, groupBy)
+            .Take(top)
+            .ToArray();
+
+        if (format == OutputFormat.Json)
+        {
+            var json = JsonSerializer.Serialize(spanStats, TelemetryAnalysisJsonContext.RelaxedEscaping.TelemetrySpanStatsOutputArray);
+            InteractionService.DisplayRawText(json, ConsoleOutput.Standard);
+        }
+        else
+        {
+            DisplaySpanStats(spanStats);
+        }
+
+        _logger.LogDebug("Displayed {SpanStatsCount} span statistic rows", spanStats.Length);
+        return CommandResult.Success();
+    }
+
+    private void DisplaySpanStats(TelemetrySpanStatsOutput[] spanStats)
+    {
+        if (spanStats.Length == 0)
+        {
+            TelemetryCommandHelpers.DisplayNoData(InteractionService, "spans");
+            return;
+        }
+
+        var table = new Table();
+        table.AddBoldColumn(TelemetryCommandStrings.HeaderGroup);
+        table.AddBoldColumn(TelemetryCommandStrings.HeaderCount);
+        table.AddBoldColumn(TelemetryCommandStrings.HeaderErrors);
+        table.AddBoldColumn(TelemetryCommandStrings.HeaderAverage);
+        table.AddBoldColumn(TelemetryCommandStrings.HeaderP95);
+        table.AddBoldColumn(TelemetryCommandStrings.HeaderMax);
+        table.AddBoldColumn(TelemetryCommandStrings.HeaderTotal);
+
+        foreach (var item in spanStats)
+        {
+            table.AddRow(
+                item.Group.EscapeMarkup(),
+                item.Count.ToString(CultureInfo.InvariantCulture),
+                item.ErrorCount.ToString(CultureInfo.InvariantCulture),
+                TelemetryAnalysisCommandHelpers.FormatDuration(item.AverageDurationMs),
+                TelemetryAnalysisCommandHelpers.FormatDuration(item.P95DurationMs),
+                TelemetryAnalysisCommandHelpers.FormatDuration(item.MaxDurationMs),
+                TelemetryAnalysisCommandHelpers.FormatDuration(item.TotalDurationMs));
+        }
+
+        InteractionService.DisplayRenderable(table);
+    }
+}

--- a/src/Aspire.Cli/Commands/TelemetrySummaryCommand.cs
+++ b/src/Aspire.Cli/Commands/TelemetrySummaryCommand.cs
@@ -1,0 +1,112 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.CommandLine;
+using System.Globalization;
+using System.Text.Json;
+using Aspire.Cli.Configuration;
+using Aspire.Cli.Interaction;
+using Aspire.Cli.Resources;
+using Aspire.Cli.Telemetry;
+using Aspire.Cli.Utils;
+using Microsoft.Extensions.Logging;
+using Spectre.Console;
+
+namespace Aspire.Cli.Commands;
+
+/// <summary>
+/// Command to summarize trace latency, span counts, and errors.
+/// </summary>
+internal sealed class TelemetrySummaryCommand : BaseCommand
+{
+    private readonly TelemetryAnalysisDataSource _dataSource;
+    private readonly ILogger<TelemetrySummaryCommand> _logger;
+
+    private static readonly Argument<string?> s_resourceArgument = TelemetryCommandHelpers.CreateResourceArgument();
+    private static readonly OptionWithLegacy<FileInfo?> s_appHostOption = TelemetryCommandHelpers.CreateAppHostOption();
+    private static readonly Option<OutputFormat> s_formatOption = TelemetryCommandHelpers.CreateFormatOption();
+    private static readonly Option<string?> s_dashboardUrlOption = TelemetryCommandHelpers.CreateDashboardUrlOption();
+    private static readonly Option<string?> s_apiKeyOption = TelemetryCommandHelpers.CreateApiKeyOption();
+    private static readonly Option<FileInfo?> s_fileOption = TelemetryAnalysisCommandHelpers.CreateFileOption();
+
+    public TelemetrySummaryCommand(
+        TelemetryAnalysisDataSource dataSource,
+        IInteractionService interactionService,
+        IFeatures features,
+        ICliUpdateNotifier updateNotifier,
+        CliExecutionContext executionContext,
+        AspireCliTelemetry telemetry,
+        ILogger<TelemetrySummaryCommand> logger)
+        : base("summary", TelemetryCommandStrings.SummaryDescription, features, updateNotifier, executionContext, interactionService, telemetry)
+    {
+        _dataSource = dataSource;
+        _logger = logger;
+
+        Arguments.Add(s_resourceArgument);
+        Options.Add(s_appHostOption);
+        Options.Add(s_formatOption);
+        Options.Add(s_dashboardUrlOption);
+        Options.Add(s_apiKeyOption);
+        Options.Add(s_fileOption);
+    }
+
+    protected override async Task<CommandResult> ExecuteAsync(ParseResult parseResult, CancellationToken cancellationToken)
+    {
+        using var activity = Telemetry.StartDiagnosticActivity(Name);
+
+        var resourceName = parseResult.GetValue(s_resourceArgument);
+        var appHost = parseResult.GetValue(s_appHostOption);
+        var format = parseResult.GetValue(s_formatOption);
+        var dashboardUrl = parseResult.GetValue(s_dashboardUrlOption);
+        var apiKey = parseResult.GetValue(s_apiKeyOption);
+        var file = parseResult.GetValue(s_fileOption);
+
+        if (TelemetryAnalysisCommandHelpers.ValidateInputOptions(file, appHost, dashboardUrl, apiKey) is { } validationResult)
+        {
+            return validationResult;
+        }
+
+        var dataResult = await _dataSource.GetTracesAsync(appHost, dashboardUrl, apiKey, file, resourceName, cancellationToken).ConfigureAwait(false);
+        if (!dataResult.Success)
+        {
+            return CommandResult.Failure(dataResult.ExitCode, dataResult.ErrorMessage);
+        }
+
+        var data = dataResult.Data!;
+        var traces = TelemetryAnalysisCommandHelpers.GetTraceInfos(data);
+        var summary = TelemetryAnalysisCommandHelpers.CreateSummary(data, traces);
+
+        if (format == OutputFormat.Json)
+        {
+            var json = JsonSerializer.Serialize(summary, TelemetryAnalysisJsonContext.RelaxedEscaping.TelemetrySummaryOutput);
+            InteractionService.DisplayRawText(json, ConsoleOutput.Standard);
+        }
+        else
+        {
+            DisplaySummary(summary);
+        }
+
+        _logger.LogDebug("Displayed telemetry summary for {TraceCount} traces", summary.TraceCount);
+        return CommandResult.Success();
+    }
+
+    private void DisplaySummary(TelemetrySummaryOutput summary)
+    {
+        var table = new Table();
+        table.AddBoldColumn(TelemetryCommandStrings.HeaderMetric);
+        table.AddBoldColumn(TelemetryCommandStrings.HeaderValue);
+
+        table.AddRow(TelemetryCommandStrings.MetricResources, summary.ResourceCount.ToString(CultureInfo.InvariantCulture));
+        table.AddRow(TelemetryCommandStrings.MetricTraces, summary.TraceCount.ToString(CultureInfo.InvariantCulture));
+        table.AddRow(TelemetryCommandStrings.MetricSpans, summary.SpanCount.ToString(CultureInfo.InvariantCulture));
+        table.AddRow(TelemetryCommandStrings.MetricErrorTraces, summary.ErrorTraceCount.ToString(CultureInfo.InvariantCulture));
+        table.AddRow(TelemetryCommandStrings.MetricErrorSpans, summary.ErrorSpanCount.ToString(CultureInfo.InvariantCulture));
+        table.AddRow(TelemetryCommandStrings.MetricAverageDuration, TelemetryAnalysisCommandHelpers.FormatDuration(summary.AverageDurationMs));
+        table.AddRow(TelemetryCommandStrings.MetricP50Duration, TelemetryAnalysisCommandHelpers.FormatDuration(summary.P50DurationMs));
+        table.AddRow(TelemetryCommandStrings.MetricP95Duration, TelemetryAnalysisCommandHelpers.FormatDuration(summary.P95DurationMs));
+        table.AddRow(TelemetryCommandStrings.MetricP99Duration, TelemetryAnalysisCommandHelpers.FormatDuration(summary.P99DurationMs));
+        table.AddRow(TelemetryCommandStrings.MetricMaxDuration, TelemetryAnalysisCommandHelpers.FormatDuration(summary.MaxDurationMs));
+
+        InteractionService.DisplayRenderable(table);
+    }
+}

--- a/src/Aspire.Cli/Commands/TelemetryWallTimeCommand.cs
+++ b/src/Aspire.Cli/Commands/TelemetryWallTimeCommand.cs
@@ -1,0 +1,153 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.CommandLine;
+using System.Globalization;
+using System.Text.Json;
+using Aspire.Cli.Configuration;
+using Aspire.Cli.Interaction;
+using Aspire.Cli.Resources;
+using Aspire.Cli.Telemetry;
+using Aspire.Cli.Utils;
+using Aspire.Dashboard.Otlp.Model;
+using Microsoft.Extensions.Logging;
+using Spectre.Console;
+
+namespace Aspire.Cli.Commands;
+
+/// <summary>
+/// Command to analyze trace wall-clock time, span coverage, and gaps.
+/// </summary>
+internal sealed class TelemetryWallTimeCommand : BaseCommand
+{
+    private readonly TelemetryAnalysisDataSource _dataSource;
+    private readonly ILogger<TelemetryWallTimeCommand> _logger;
+
+    private static readonly Argument<string?> s_resourceArgument = TelemetryCommandHelpers.CreateResourceArgument();
+    private static readonly OptionWithLegacy<FileInfo?> s_appHostOption = TelemetryCommandHelpers.CreateAppHostOption();
+    private static readonly Option<OutputFormat> s_formatOption = TelemetryCommandHelpers.CreateFormatOption();
+    private static readonly Option<string?> s_dashboardUrlOption = TelemetryCommandHelpers.CreateDashboardUrlOption();
+    private static readonly Option<string?> s_apiKeyOption = TelemetryCommandHelpers.CreateApiKeyOption();
+    private static readonly Option<FileInfo?> s_fileOption = TelemetryAnalysisCommandHelpers.CreateFileOption();
+    private static readonly Option<int> s_topOption = TelemetryAnalysisCommandHelpers.CreateTopOption();
+
+    public TelemetryWallTimeCommand(
+        TelemetryAnalysisDataSource dataSource,
+        IInteractionService interactionService,
+        IFeatures features,
+        ICliUpdateNotifier updateNotifier,
+        CliExecutionContext executionContext,
+        AspireCliTelemetry telemetry,
+        ILogger<TelemetryWallTimeCommand> logger)
+        : base("wall-time", TelemetryCommandStrings.WallTimeDescription, features, updateNotifier, executionContext, interactionService, telemetry)
+    {
+        _dataSource = dataSource;
+        _logger = logger;
+
+        Arguments.Add(s_resourceArgument);
+        Options.Add(s_appHostOption);
+        Options.Add(s_formatOption);
+        Options.Add(s_dashboardUrlOption);
+        Options.Add(s_apiKeyOption);
+        Options.Add(s_fileOption);
+        Options.Add(s_topOption);
+    }
+
+    protected override async Task<CommandResult> ExecuteAsync(ParseResult parseResult, CancellationToken cancellationToken)
+    {
+        using var activity = Telemetry.StartDiagnosticActivity(Name);
+
+        var resourceName = parseResult.GetValue(s_resourceArgument);
+        var appHost = parseResult.GetValue(s_appHostOption);
+        var format = parseResult.GetValue(s_formatOption);
+        var dashboardUrl = parseResult.GetValue(s_dashboardUrlOption);
+        var apiKey = parseResult.GetValue(s_apiKeyOption);
+        var file = parseResult.GetValue(s_fileOption);
+        var top = parseResult.GetValue(s_topOption);
+
+        if (TelemetryAnalysisCommandHelpers.ValidateInputOptions(file, appHost, dashboardUrl, apiKey) is { } validationResult)
+        {
+            return validationResult;
+        }
+        if (TelemetryAnalysisCommandHelpers.ValidateTop(top) is { } topValidationResult)
+        {
+            return topValidationResult;
+        }
+
+        var dataResult = await _dataSource.GetTracesAsync(appHost, dashboardUrl, apiKey, file, resourceName, cancellationToken).ConfigureAwait(false);
+        if (!dataResult.Success)
+        {
+            return CommandResult.Failure(dataResult.ExitCode, dataResult.ErrorMessage);
+        }
+
+        var data = dataResult.Data!;
+        var wallTime = TelemetryAnalysisCommandHelpers.CreateWallTimeOutputs(data)
+            .Take(top)
+            .ToArray();
+
+        if (format == OutputFormat.Json)
+        {
+            var json = JsonSerializer.Serialize(wallTime, TelemetryAnalysisJsonContext.RelaxedEscaping.TelemetryWallTimeOutputArray);
+            InteractionService.DisplayRawText(json, ConsoleOutput.Standard);
+        }
+        else
+        {
+            DisplayWallTime(wallTime, data.DashboardUrl);
+        }
+
+        _logger.LogDebug("Displayed {WallTimeCount} wall-clock trace rows", wallTime.Length);
+        return CommandResult.Success();
+    }
+
+    private void DisplayWallTime(TelemetryWallTimeOutput[] wallTime, string? dashboardUrl)
+    {
+        if (wallTime.Length == 0)
+        {
+            TelemetryCommandHelpers.DisplayNoData(InteractionService, "traces");
+            return;
+        }
+
+        var table = new Table();
+        table.AddBoldColumn(TelemetryCommandStrings.HeaderWallClock);
+        table.AddBoldColumn(TelemetryCommandStrings.HeaderSpanSum);
+        table.AddBoldColumn(TelemetryCommandStrings.HeaderCovered);
+        table.AddBoldColumn(TelemetryCommandStrings.HeaderGap);
+        table.AddBoldColumn(TelemetryCommandStrings.HeaderOverlap);
+        table.AddBoldColumn(TelemetryCommandStrings.HeaderRatio);
+        table.AddBoldColumn(TelemetryCommandStrings.HeaderSpans);
+        table.AddBoldColumn(TelemetryCommandStrings.HeaderStatus);
+        table.AddBoldColumn(TelemetryCommandStrings.HeaderResource);
+        table.AddBoldColumn(TelemetryCommandStrings.HeaderName);
+        table.AddBoldColumn(TelemetryCommandStrings.HeaderTraceId);
+
+        foreach (var trace in wallTime)
+        {
+            var status = trace.HasError ? "[red]ERR[/]" : "[green]OK[/]";
+            var traceId = TelemetryCommandHelpers.FormatTraceLink(
+                InteractionService,
+                dashboardUrl,
+                trace.TraceId,
+                OtlpHelpers.ToShortenedId(trace.TraceId));
+
+            table.AddRow(
+                TelemetryAnalysisCommandHelpers.FormatDuration(trace.WallClockMs),
+                TelemetryAnalysisCommandHelpers.FormatDuration(trace.SpanSumMs),
+                TelemetryAnalysisCommandHelpers.FormatDuration(trace.CoveredMs),
+                TelemetryAnalysisCommandHelpers.FormatDuration(trace.GapMs),
+                TelemetryAnalysisCommandHelpers.FormatDuration(trace.OverlapMs),
+                FormatRatio(trace.SpanSumToWallRatio),
+                trace.SpanCount.ToString(CultureInfo.InvariantCulture),
+                status,
+                trace.Resource.EscapeMarkup(),
+                trace.Name.EscapeMarkup(),
+                traceId);
+        }
+
+        InteractionService.DisplayRenderable(table);
+    }
+
+    private static string FormatRatio(double ratio)
+    {
+        return ratio.ToString("0.###", CultureInfo.InvariantCulture) + "x";
+    }
+}

--- a/src/Aspire.Cli/Program.cs
+++ b/src/Aspire.Cli/Program.cs
@@ -412,6 +412,7 @@ public class Program
         builder.Services.AddSingleton<IBundlePayloadProvider, EmbeddedBundlePayloadProvider>();
         builder.Services.AddSingleton<IBundleService, BundleService>();
         builder.Services.AddSingleton<ProfileCaptureService>();
+        builder.Services.AddTransient<TelemetryAnalysisDataSource>();
         builder.Services.AddSingleton<IAppHostServerProjectFactory, AppHostServerProjectFactory>();
         builder.Services.AddSingleton<ICliDownloader, CliDownloader>();
         builder.Services.AddSingleton<IFirstTimeUseNoticeSentinel>(_ => new FirstTimeUseNoticeSentinel(GetUsersAspirePath()));
@@ -538,6 +539,10 @@ public class Program
         builder.Services.AddTransient<TelemetryLogsCommand>();
         builder.Services.AddTransient<TelemetrySpansCommand>();
         builder.Services.AddTransient<TelemetryTracesCommand>();
+        builder.Services.AddTransient<TelemetrySummaryCommand>();
+        builder.Services.AddTransient<TelemetrySlowTracesCommand>();
+        builder.Services.AddTransient<TelemetryWallTimeCommand>();
+        builder.Services.AddTransient<TelemetrySpanStatsCommand>();
         builder.Services.AddTransient<ExportCommand>();
         builder.Services.AddTransient<ApiCommand>();
         builder.Services.AddTransient<ApiListCommand>();

--- a/src/Aspire.Cli/Resources/TelemetryCommandStrings.Designer.cs
+++ b/src/Aspire.Cli/Resources/TelemetryCommandStrings.Designer.cs
@@ -95,6 +95,30 @@ namespace Aspire.Cli.Resources {
                 return ResourceManager.GetString("TracesDescription", resourceCulture);
             }
         }
+
+        internal static string SummaryDescription {
+            get {
+                return ResourceManager.GetString("SummaryDescription", resourceCulture);
+            }
+        }
+
+        internal static string SlowTracesDescription {
+            get {
+                return ResourceManager.GetString("SlowTracesDescription", resourceCulture);
+            }
+        }
+
+        internal static string WallTimeDescription {
+            get {
+                return ResourceManager.GetString("WallTimeDescription", resourceCulture);
+            }
+        }
+
+        internal static string SpanStatsDescription {
+            get {
+                return ResourceManager.GetString("SpanStatsDescription", resourceCulture);
+            }
+        }
         
         /// <summary>
         ///   Looks up a localized string similar to Filter by resource name..
@@ -176,6 +200,24 @@ namespace Aspire.Cli.Resources {
                 return ResourceManager.GetString("SearchOptionDescription", resourceCulture);
             }
         }
+
+        internal static string TelemetryArchiveOptionDescription {
+            get {
+                return ResourceManager.GetString("TelemetryArchiveOptionDescription", resourceCulture);
+            }
+        }
+
+        internal static string TopOptionDescription {
+            get {
+                return ResourceManager.GetString("TopOptionDescription", resourceCulture);
+            }
+        }
+
+        internal static string GroupByOptionDescription {
+            get {
+                return ResourceManager.GetString("GroupByOptionDescription", resourceCulture);
+            }
+        }
         
         /// <summary>
         ///   Looks up a localized string similar to The --limit value must be a positive number..
@@ -183,6 +225,36 @@ namespace Aspire.Cli.Resources {
         internal static string LimitMustBePositive {
             get {
                 return ResourceManager.GetString("LimitMustBePositive", resourceCulture);
+            }
+        }
+
+        internal static string TopMustBePositive {
+            get {
+                return ResourceManager.GetString("TopMustBePositive", resourceCulture);
+            }
+        }
+
+        internal static string FileAndLiveOptionsExclusive {
+            get {
+                return ResourceManager.GetString("FileAndLiveOptionsExclusive", resourceCulture);
+            }
+        }
+
+        internal static string TelemetryArchiveNotFound {
+            get {
+                return ResourceManager.GetString("TelemetryArchiveNotFound", resourceCulture);
+            }
+        }
+
+        internal static string FailedToReadTelemetryArchive {
+            get {
+                return ResourceManager.GetString("FailedToReadTelemetryArchive", resourceCulture);
+            }
+        }
+
+        internal static string ResourceNotFound {
+            get {
+                return ResourceManager.GetString("ResourceNotFound", resourceCulture);
             }
         }
         
@@ -255,6 +327,168 @@ namespace Aspire.Cli.Resources {
         internal static string HeaderStatus {
             get {
                 return ResourceManager.GetString("HeaderStatus", resourceCulture);
+            }
+        }
+
+        internal static string HeaderMetric {
+            get {
+                return ResourceManager.GetString("HeaderMetric", resourceCulture);
+            }
+        }
+
+        internal static string HeaderValue {
+            get {
+                return ResourceManager.GetString("HeaderValue", resourceCulture);
+            }
+        }
+
+        internal static string HeaderTraceId {
+            get {
+                return ResourceManager.GetString("HeaderTraceId", resourceCulture);
+            }
+        }
+
+        internal static string HeaderResource {
+            get {
+                return ResourceManager.GetString("HeaderResource", resourceCulture);
+            }
+        }
+
+        internal static string HeaderGroup {
+            get {
+                return ResourceManager.GetString("HeaderGroup", resourceCulture);
+            }
+        }
+
+        internal static string HeaderCount {
+            get {
+                return ResourceManager.GetString("HeaderCount", resourceCulture);
+            }
+        }
+
+        internal static string HeaderErrors {
+            get {
+                return ResourceManager.GetString("HeaderErrors", resourceCulture);
+            }
+        }
+
+        internal static string HeaderAverage {
+            get {
+                return ResourceManager.GetString("HeaderAverage", resourceCulture);
+            }
+        }
+
+        internal static string HeaderP95 {
+            get {
+                return ResourceManager.GetString("HeaderP95", resourceCulture);
+            }
+        }
+
+        internal static string HeaderMax {
+            get {
+                return ResourceManager.GetString("HeaderMax", resourceCulture);
+            }
+        }
+
+        internal static string HeaderTotal {
+            get {
+                return ResourceManager.GetString("HeaderTotal", resourceCulture);
+            }
+        }
+
+        internal static string HeaderWallClock {
+            get {
+                return ResourceManager.GetString("HeaderWallClock", resourceCulture);
+            }
+        }
+
+        internal static string HeaderSpanSum {
+            get {
+                return ResourceManager.GetString("HeaderSpanSum", resourceCulture);
+            }
+        }
+
+        internal static string HeaderCovered {
+            get {
+                return ResourceManager.GetString("HeaderCovered", resourceCulture);
+            }
+        }
+
+        internal static string HeaderGap {
+            get {
+                return ResourceManager.GetString("HeaderGap", resourceCulture);
+            }
+        }
+
+        internal static string HeaderOverlap {
+            get {
+                return ResourceManager.GetString("HeaderOverlap", resourceCulture);
+            }
+        }
+
+        internal static string HeaderRatio {
+            get {
+                return ResourceManager.GetString("HeaderRatio", resourceCulture);
+            }
+        }
+
+        internal static string MetricResources {
+            get {
+                return ResourceManager.GetString("MetricResources", resourceCulture);
+            }
+        }
+
+        internal static string MetricTraces {
+            get {
+                return ResourceManager.GetString("MetricTraces", resourceCulture);
+            }
+        }
+
+        internal static string MetricSpans {
+            get {
+                return ResourceManager.GetString("MetricSpans", resourceCulture);
+            }
+        }
+
+        internal static string MetricErrorTraces {
+            get {
+                return ResourceManager.GetString("MetricErrorTraces", resourceCulture);
+            }
+        }
+
+        internal static string MetricErrorSpans {
+            get {
+                return ResourceManager.GetString("MetricErrorSpans", resourceCulture);
+            }
+        }
+
+        internal static string MetricAverageDuration {
+            get {
+                return ResourceManager.GetString("MetricAverageDuration", resourceCulture);
+            }
+        }
+
+        internal static string MetricP50Duration {
+            get {
+                return ResourceManager.GetString("MetricP50Duration", resourceCulture);
+            }
+        }
+
+        internal static string MetricP95Duration {
+            get {
+                return ResourceManager.GetString("MetricP95Duration", resourceCulture);
+            }
+        }
+
+        internal static string MetricP99Duration {
+            get {
+                return ResourceManager.GetString("MetricP99Duration", resourceCulture);
+            }
+        }
+
+        internal static string MetricMaxDuration {
+            get {
+                return ResourceManager.GetString("MetricMaxDuration", resourceCulture);
             }
         }
 

--- a/src/Aspire.Cli/Resources/TelemetryCommandStrings.resx
+++ b/src/Aspire.Cli/Resources/TelemetryCommandStrings.resx
@@ -129,6 +129,18 @@
   <data name="TracesDescription" xml:space="preserve">
     <value>View traces from the Dashboard telemetry API</value>
   </data>
+  <data name="SummaryDescription" xml:space="preserve">
+    <value>Summarize trace latency, span counts, and errors</value>
+  </data>
+  <data name="SlowTracesDescription" xml:space="preserve">
+    <value>Show top traces by wall-clock duration</value>
+  </data>
+  <data name="WallTimeDescription" xml:space="preserve">
+    <value>Analyze trace wall-clock time, span coverage, gaps, and overlap</value>
+  </data>
+  <data name="SpanStatsDescription" xml:space="preserve">
+    <value>Aggregate span duration statistics</value>
+  </data>
   <data name="ResourceArgumentDescription" xml:space="preserve">
     <value>Filter by resource name</value>
   </data>
@@ -156,8 +168,32 @@
   <data name="SearchOptionDescription" xml:space="preserve">
     <value>Full-text search across telemetry text fields, such as log messages, attribute values, names, source, and IDs</value>
   </data>
+  <data name="TelemetryArchiveOptionDescription" xml:space="preserve">
+    <value>Read telemetry from an Aspire export or profile archive instead of a running dashboard</value>
+  </data>
+  <data name="TopOptionDescription" xml:space="preserve">
+    <value>Maximum number of rows to display</value>
+  </data>
+  <data name="GroupByOptionDescription" xml:space="preserve">
+    <value>Group span statistics by Name or Resource</value>
+  </data>
   <data name="LimitMustBePositive" xml:space="preserve">
     <value>The --limit value must be a positive number.</value>
+  </data>
+  <data name="TopMustBePositive" xml:space="preserve">
+    <value>The --top value must be a positive number.</value>
+  </data>
+  <data name="FileAndLiveOptionsExclusive" xml:space="preserve">
+    <value>The --file option cannot be used with --dashboard-url, --api-key, or --apphost. Specify either an archive file or a live dashboard source.</value>
+  </data>
+  <data name="TelemetryArchiveNotFound" xml:space="preserve">
+    <value>Telemetry archive file '{0}' was not found.</value>
+  </data>
+  <data name="FailedToReadTelemetryArchive" xml:space="preserve">
+    <value>Failed to read telemetry archive '{0}': {1}</value>
+  </data>
+  <data name="ResourceNotFound" xml:space="preserve">
+    <value>Resource '{0}' not found.</value>
   </data>
   <data name="DashboardNotAvailable" xml:space="preserve">
     <value>Could not fetch telemetry data from the dashboard. The dashboard is not available.</value>
@@ -191,6 +227,87 @@
   </data>
   <data name="HeaderStatus" xml:space="preserve">
     <value>Status</value>
+  </data>
+  <data name="HeaderMetric" xml:space="preserve">
+    <value>Metric</value>
+  </data>
+  <data name="HeaderValue" xml:space="preserve">
+    <value>Value</value>
+  </data>
+  <data name="HeaderTraceId" xml:space="preserve">
+    <value>Trace ID</value>
+  </data>
+  <data name="HeaderResource" xml:space="preserve">
+    <value>Resource</value>
+  </data>
+  <data name="HeaderGroup" xml:space="preserve">
+    <value>Group</value>
+  </data>
+  <data name="HeaderCount" xml:space="preserve">
+    <value>Count</value>
+  </data>
+  <data name="HeaderErrors" xml:space="preserve">
+    <value>Errors</value>
+  </data>
+  <data name="HeaderAverage" xml:space="preserve">
+    <value>Avg</value>
+  </data>
+  <data name="HeaderP95" xml:space="preserve">
+    <value>P95</value>
+  </data>
+  <data name="HeaderMax" xml:space="preserve">
+    <value>Max</value>
+  </data>
+  <data name="HeaderTotal" xml:space="preserve">
+    <value>Total</value>
+  </data>
+  <data name="HeaderWallClock" xml:space="preserve">
+    <value>Wall</value>
+  </data>
+  <data name="HeaderSpanSum" xml:space="preserve">
+    <value>Span sum</value>
+  </data>
+  <data name="HeaderCovered" xml:space="preserve">
+    <value>Covered</value>
+  </data>
+  <data name="HeaderGap" xml:space="preserve">
+    <value>Gap</value>
+  </data>
+  <data name="HeaderOverlap" xml:space="preserve">
+    <value>Overlap</value>
+  </data>
+  <data name="HeaderRatio" xml:space="preserve">
+    <value>Ratio</value>
+  </data>
+  <data name="MetricResources" xml:space="preserve">
+    <value>Resources</value>
+  </data>
+  <data name="MetricTraces" xml:space="preserve">
+    <value>Traces</value>
+  </data>
+  <data name="MetricSpans" xml:space="preserve">
+    <value>Spans</value>
+  </data>
+  <data name="MetricErrorTraces" xml:space="preserve">
+    <value>Error traces</value>
+  </data>
+  <data name="MetricErrorSpans" xml:space="preserve">
+    <value>Error spans</value>
+  </data>
+  <data name="MetricAverageDuration" xml:space="preserve">
+    <value>Average duration</value>
+  </data>
+  <data name="MetricP50Duration" xml:space="preserve">
+    <value>P50 duration</value>
+  </data>
+  <data name="MetricP95Duration" xml:space="preserve">
+    <value>P95 duration</value>
+  </data>
+  <data name="MetricP99Duration" xml:space="preserve">
+    <value>P99 duration</value>
+  </data>
+  <data name="MetricMaxDuration" xml:space="preserve">
+    <value>Max duration</value>
   </data>
   <data name="DashboardUrlOptionDescription" xml:space="preserve">
     <value>Base URL of a standalone Aspire Dashboard (e.g. http://localhost:18888). Login URLs are also accepted and automatically normalized.</value>

--- a/src/Aspire.Cli/Resources/xlf/TelemetryCommandStrings.cs.xlf
+++ b/src/Aspire.Cli/Resources/xlf/TelemetryCommandStrings.cs.xlf
@@ -107,6 +107,16 @@
         <target state="translated">Nepodařilo se načíst telemetrii: {0}</target>
         <note />
       </trans-unit>
+      <trans-unit id="FailedToReadTelemetryArchive">
+        <source>Failed to read telemetry archive '{0}': {1}</source>
+        <target state="new">Failed to read telemetry archive '{0}': {1}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FileAndLiveOptionsExclusive">
+        <source>The --file option cannot be used with --dashboard-url, --api-key, or --apphost. Specify either an archive file or a live dashboard source.</source>
+        <target state="new">The --file option cannot be used with --dashboard-url, --api-key, or --apphost. Specify either an archive file or a live dashboard source.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="FollowOptionDescription">
         <source>Stream telemetry in real-time as it arrives</source>
         <target state="needs-review-translation">Umožňuje streamovat telemetrii v reálném čase, jakmile dorazí.</target>
@@ -117,9 +127,29 @@
         <target state="needs-review-translation">Výstupní formát (tabulka nebo JSON).</target>
         <note />
       </trans-unit>
+      <trans-unit id="GroupByOptionDescription">
+        <source>Group span statistics by Name or Resource</source>
+        <target state="new">Group span statistics by Name or Resource</target>
+        <note />
+      </trans-unit>
       <trans-unit id="HasErrorOptionDescription">
         <source>Filter by error status (true to show only errors, false to exclude errors)</source>
         <target state="needs-review-translation">Umožňuje filtrovat podle chybového stavu (true pro zobrazení pouze chyb, false pro vyloučení chyb).</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HeaderAverage">
+        <source>Avg</source>
+        <target state="new">Avg</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HeaderCount">
+        <source>Count</source>
+        <target state="new">Count</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HeaderCovered">
+        <source>Covered</source>
+        <target state="new">Covered</target>
         <note />
       </trans-unit>
       <trans-unit id="HeaderDuration">
@@ -127,9 +157,59 @@
         <target state="translated">Doba trvání</target>
         <note />
       </trans-unit>
+      <trans-unit id="HeaderErrors">
+        <source>Errors</source>
+        <target state="new">Errors</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HeaderGap">
+        <source>Gap</source>
+        <target state="new">Gap</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HeaderGroup">
+        <source>Group</source>
+        <target state="new">Group</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HeaderMax">
+        <source>Max</source>
+        <target state="new">Max</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HeaderMetric">
+        <source>Metric</source>
+        <target state="new">Metric</target>
+        <note />
+      </trans-unit>
       <trans-unit id="HeaderName">
         <source>Name</source>
         <target state="translated">Název</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HeaderOverlap">
+        <source>Overlap</source>
+        <target state="new">Overlap</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HeaderP95">
+        <source>P95</source>
+        <target state="new">P95</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HeaderRatio">
+        <source>Ratio</source>
+        <target state="new">Ratio</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HeaderResource">
+        <source>Resource</source>
+        <target state="new">Resource</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HeaderSpanSum">
+        <source>Span sum</source>
+        <target state="new">Span sum</target>
         <note />
       </trans-unit>
       <trans-unit id="HeaderSpans">
@@ -147,6 +227,26 @@
         <target state="translated">Časové razítko</target>
         <note />
       </trans-unit>
+      <trans-unit id="HeaderTotal">
+        <source>Total</source>
+        <target state="new">Total</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HeaderTraceId">
+        <source>Trace ID</source>
+        <target state="new">Trace ID</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HeaderValue">
+        <source>Value</source>
+        <target state="new">Value</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HeaderWallClock">
+        <source>Wall</source>
+        <target state="new">Wall</target>
+        <note />
+      </trans-unit>
       <trans-unit id="LimitMustBePositive">
         <source>The --limit value must be a positive number.</source>
         <target state="translated">Hodnota --tail musí být kladné číslo.</target>
@@ -162,9 +262,64 @@
         <target state="needs-review-translation">Umožňuje zobrazit strukturované protokoly z rozhraní API telemetrie řídicího panelu.</target>
         <note />
       </trans-unit>
+      <trans-unit id="MetricAverageDuration">
+        <source>Average duration</source>
+        <target state="new">Average duration</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MetricErrorSpans">
+        <source>Error spans</source>
+        <target state="new">Error spans</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MetricErrorTraces">
+        <source>Error traces</source>
+        <target state="new">Error traces</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MetricMaxDuration">
+        <source>Max duration</source>
+        <target state="new">Max duration</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MetricP50Duration">
+        <source>P50 duration</source>
+        <target state="new">P50 duration</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MetricP95Duration">
+        <source>P95 duration</source>
+        <target state="new">P95 duration</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MetricP99Duration">
+        <source>P99 duration</source>
+        <target state="new">P99 duration</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MetricResources">
+        <source>Resources</source>
+        <target state="new">Resources</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MetricSpans">
+        <source>Spans</source>
+        <target state="new">Spans</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MetricTraces">
+        <source>Traces</source>
+        <target state="new">Traces</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ResourceArgumentDescription">
         <source>Filter by resource name</source>
         <target state="needs-review-translation">Filtrovat podle názvu prostředku.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourceNotFound">
+        <source>Resource '{0}' not found.</source>
+        <target state="new">Resource '{0}' not found.</target>
         <note />
       </trans-unit>
       <trans-unit id="SearchOptionDescription">
@@ -182,9 +337,44 @@
         <target state="needs-review-translation">Umožňuje filtrovat protokoly podle minimální závažnosti (trasování, ladění, informace, upozornění, chyba, kritické).</target>
         <note />
       </trans-unit>
+      <trans-unit id="SlowTracesDescription">
+        <source>Show top traces by wall-clock duration</source>
+        <target state="new">Show top traces by wall-clock duration</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SpanStatsDescription">
+        <source>Aggregate span duration statistics</source>
+        <target state="new">Aggregate span duration statistics</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SpansDescription">
         <source>View spans from the Dashboard telemetry API</source>
         <target state="needs-review-translation">Umožňuje zobrazit rozsahy z rozhraní API telemetrie řídicího panelu.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SummaryDescription">
+        <source>Summarize trace latency, span counts, and errors</source>
+        <target state="new">Summarize trace latency, span counts, and errors</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TelemetryArchiveNotFound">
+        <source>Telemetry archive file '{0}' was not found.</source>
+        <target state="new">Telemetry archive file '{0}' was not found.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TelemetryArchiveOptionDescription">
+        <source>Read telemetry from an Aspire export or profile archive instead of a running dashboard</source>
+        <target state="new">Read telemetry from an Aspire export or profile archive instead of a running dashboard</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TopMustBePositive">
+        <source>The --top value must be a positive number.</source>
+        <target state="new">The --top value must be a positive number.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TopOptionDescription">
+        <source>Maximum number of rows to display</source>
+        <target state="new">Maximum number of rows to display</target>
         <note />
       </trans-unit>
       <trans-unit id="TraceIdArgumentDescription">
@@ -210,6 +400,11 @@
       <trans-unit id="UnexpectedContentType">
         <source>Dashboard API returned unexpected content type '{0}'. Expected JSON response.</source>
         <target state="new">Dashboard API returned unexpected content type '{0}'. Expected JSON response.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WallTimeDescription">
+        <source>Analyze trace wall-clock time, span coverage, gaps, and overlap</source>
+        <target state="new">Analyze trace wall-clock time, span coverage, gaps, and overlap</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Aspire.Cli/Resources/xlf/TelemetryCommandStrings.de.xlf
+++ b/src/Aspire.Cli/Resources/xlf/TelemetryCommandStrings.de.xlf
@@ -107,6 +107,16 @@
         <target state="translated">Fehler beim Abrufen der Telemetrie: {0}</target>
         <note />
       </trans-unit>
+      <trans-unit id="FailedToReadTelemetryArchive">
+        <source>Failed to read telemetry archive '{0}': {1}</source>
+        <target state="new">Failed to read telemetry archive '{0}': {1}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FileAndLiveOptionsExclusive">
+        <source>The --file option cannot be used with --dashboard-url, --api-key, or --apphost. Specify either an archive file or a live dashboard source.</source>
+        <target state="new">The --file option cannot be used with --dashboard-url, --api-key, or --apphost. Specify either an archive file or a live dashboard source.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="FollowOptionDescription">
         <source>Stream telemetry in real-time as it arrives</source>
         <target state="needs-review-translation">Streamen Sie Telemetriedaten in Echtzeit, sobald sie eintreffen.</target>
@@ -117,9 +127,29 @@
         <target state="needs-review-translation">Ausgabeformat (Tabelle oder JSON).</target>
         <note />
       </trans-unit>
+      <trans-unit id="GroupByOptionDescription">
+        <source>Group span statistics by Name or Resource</source>
+        <target state="new">Group span statistics by Name or Resource</target>
+        <note />
+      </trans-unit>
       <trans-unit id="HasErrorOptionDescription">
         <source>Filter by error status (true to show only errors, false to exclude errors)</source>
         <target state="needs-review-translation">Filtern Sie nach Fehlerstatus (true, um nur Fehler anzuzeigen; false, um Fehler auszuschließen).</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HeaderAverage">
+        <source>Avg</source>
+        <target state="new">Avg</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HeaderCount">
+        <source>Count</source>
+        <target state="new">Count</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HeaderCovered">
+        <source>Covered</source>
+        <target state="new">Covered</target>
         <note />
       </trans-unit>
       <trans-unit id="HeaderDuration">
@@ -127,9 +157,59 @@
         <target state="translated">Dauer</target>
         <note />
       </trans-unit>
+      <trans-unit id="HeaderErrors">
+        <source>Errors</source>
+        <target state="new">Errors</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HeaderGap">
+        <source>Gap</source>
+        <target state="new">Gap</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HeaderGroup">
+        <source>Group</source>
+        <target state="new">Group</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HeaderMax">
+        <source>Max</source>
+        <target state="new">Max</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HeaderMetric">
+        <source>Metric</source>
+        <target state="new">Metric</target>
+        <note />
+      </trans-unit>
       <trans-unit id="HeaderName">
         <source>Name</source>
         <target state="translated">Name</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HeaderOverlap">
+        <source>Overlap</source>
+        <target state="new">Overlap</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HeaderP95">
+        <source>P95</source>
+        <target state="new">P95</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HeaderRatio">
+        <source>Ratio</source>
+        <target state="new">Ratio</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HeaderResource">
+        <source>Resource</source>
+        <target state="new">Resource</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HeaderSpanSum">
+        <source>Span sum</source>
+        <target state="new">Span sum</target>
         <note />
       </trans-unit>
       <trans-unit id="HeaderSpans">
@@ -147,6 +227,26 @@
         <target state="translated">Zeitstempel</target>
         <note />
       </trans-unit>
+      <trans-unit id="HeaderTotal">
+        <source>Total</source>
+        <target state="new">Total</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HeaderTraceId">
+        <source>Trace ID</source>
+        <target state="new">Trace ID</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HeaderValue">
+        <source>Value</source>
+        <target state="new">Value</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HeaderWallClock">
+        <source>Wall</source>
+        <target state="new">Wall</target>
+        <note />
+      </trans-unit>
       <trans-unit id="LimitMustBePositive">
         <source>The --limit value must be a positive number.</source>
         <target state="translated">Der Wert für --limit muss eine positive Zahl sein.</target>
@@ -162,9 +262,64 @@
         <target state="needs-review-translation">Zeigen Sie strukturierte Protokolle aus der Dashboard-Telemetrie-API an.</target>
         <note />
       </trans-unit>
+      <trans-unit id="MetricAverageDuration">
+        <source>Average duration</source>
+        <target state="new">Average duration</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MetricErrorSpans">
+        <source>Error spans</source>
+        <target state="new">Error spans</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MetricErrorTraces">
+        <source>Error traces</source>
+        <target state="new">Error traces</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MetricMaxDuration">
+        <source>Max duration</source>
+        <target state="new">Max duration</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MetricP50Duration">
+        <source>P50 duration</source>
+        <target state="new">P50 duration</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MetricP95Duration">
+        <source>P95 duration</source>
+        <target state="new">P95 duration</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MetricP99Duration">
+        <source>P99 duration</source>
+        <target state="new">P99 duration</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MetricResources">
+        <source>Resources</source>
+        <target state="new">Resources</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MetricSpans">
+        <source>Spans</source>
+        <target state="new">Spans</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MetricTraces">
+        <source>Traces</source>
+        <target state="new">Traces</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ResourceArgumentDescription">
         <source>Filter by resource name</source>
         <target state="needs-review-translation">Filtern Sie nach Ressourcennamen.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourceNotFound">
+        <source>Resource '{0}' not found.</source>
+        <target state="new">Resource '{0}' not found.</target>
         <note />
       </trans-unit>
       <trans-unit id="SearchOptionDescription">
@@ -182,9 +337,44 @@
         <target state="needs-review-translation">Filtern Sie Protokolle nach minimaler Schwere (Trace, Debug, Information, Warnung, Fehler, Kritisch).</target>
         <note />
       </trans-unit>
+      <trans-unit id="SlowTracesDescription">
+        <source>Show top traces by wall-clock duration</source>
+        <target state="new">Show top traces by wall-clock duration</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SpanStatsDescription">
+        <source>Aggregate span duration statistics</source>
+        <target state="new">Aggregate span duration statistics</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SpansDescription">
         <source>View spans from the Dashboard telemetry API</source>
         <target state="needs-review-translation">Zeigen Sie Bereiche aus der Dashboard-Telemetrie-API an.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SummaryDescription">
+        <source>Summarize trace latency, span counts, and errors</source>
+        <target state="new">Summarize trace latency, span counts, and errors</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TelemetryArchiveNotFound">
+        <source>Telemetry archive file '{0}' was not found.</source>
+        <target state="new">Telemetry archive file '{0}' was not found.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TelemetryArchiveOptionDescription">
+        <source>Read telemetry from an Aspire export or profile archive instead of a running dashboard</source>
+        <target state="new">Read telemetry from an Aspire export or profile archive instead of a running dashboard</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TopMustBePositive">
+        <source>The --top value must be a positive number.</source>
+        <target state="new">The --top value must be a positive number.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TopOptionDescription">
+        <source>Maximum number of rows to display</source>
+        <target state="new">Maximum number of rows to display</target>
         <note />
       </trans-unit>
       <trans-unit id="TraceIdArgumentDescription">
@@ -210,6 +400,11 @@
       <trans-unit id="UnexpectedContentType">
         <source>Dashboard API returned unexpected content type '{0}'. Expected JSON response.</source>
         <target state="new">Dashboard API returned unexpected content type '{0}'. Expected JSON response.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WallTimeDescription">
+        <source>Analyze trace wall-clock time, span coverage, gaps, and overlap</source>
+        <target state="new">Analyze trace wall-clock time, span coverage, gaps, and overlap</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Aspire.Cli/Resources/xlf/TelemetryCommandStrings.es.xlf
+++ b/src/Aspire.Cli/Resources/xlf/TelemetryCommandStrings.es.xlf
@@ -107,6 +107,16 @@
         <target state="translated">Error al capturar la telemetría: {0}</target>
         <note />
       </trans-unit>
+      <trans-unit id="FailedToReadTelemetryArchive">
+        <source>Failed to read telemetry archive '{0}': {1}</source>
+        <target state="new">Failed to read telemetry archive '{0}': {1}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FileAndLiveOptionsExclusive">
+        <source>The --file option cannot be used with --dashboard-url, --api-key, or --apphost. Specify either an archive file or a live dashboard source.</source>
+        <target state="new">The --file option cannot be used with --dashboard-url, --api-key, or --apphost. Specify either an archive file or a live dashboard source.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="FollowOptionDescription">
         <source>Stream telemetry in real-time as it arrives</source>
         <target state="needs-review-translation">Transmitir datos de telemetría en tiempo real a medida que llegan.</target>
@@ -117,9 +127,29 @@
         <target state="needs-review-translation">Formato de salida (tabla o JSON).</target>
         <note />
       </trans-unit>
+      <trans-unit id="GroupByOptionDescription">
+        <source>Group span statistics by Name or Resource</source>
+        <target state="new">Group span statistics by Name or Resource</target>
+        <note />
+      </trans-unit>
       <trans-unit id="HasErrorOptionDescription">
         <source>Filter by error status (true to show only errors, false to exclude errors)</source>
         <target state="needs-review-translation">Filtrar por estado de error (true para mostrar solo los errores, false para excluir errores).</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HeaderAverage">
+        <source>Avg</source>
+        <target state="new">Avg</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HeaderCount">
+        <source>Count</source>
+        <target state="new">Count</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HeaderCovered">
+        <source>Covered</source>
+        <target state="new">Covered</target>
         <note />
       </trans-unit>
       <trans-unit id="HeaderDuration">
@@ -127,9 +157,59 @@
         <target state="translated">Duración</target>
         <note />
       </trans-unit>
+      <trans-unit id="HeaderErrors">
+        <source>Errors</source>
+        <target state="new">Errors</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HeaderGap">
+        <source>Gap</source>
+        <target state="new">Gap</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HeaderGroup">
+        <source>Group</source>
+        <target state="new">Group</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HeaderMax">
+        <source>Max</source>
+        <target state="new">Max</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HeaderMetric">
+        <source>Metric</source>
+        <target state="new">Metric</target>
+        <note />
+      </trans-unit>
       <trans-unit id="HeaderName">
         <source>Name</source>
         <target state="translated">Nombre</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HeaderOverlap">
+        <source>Overlap</source>
+        <target state="new">Overlap</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HeaderP95">
+        <source>P95</source>
+        <target state="new">P95</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HeaderRatio">
+        <source>Ratio</source>
+        <target state="new">Ratio</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HeaderResource">
+        <source>Resource</source>
+        <target state="new">Resource</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HeaderSpanSum">
+        <source>Span sum</source>
+        <target state="new">Span sum</target>
         <note />
       </trans-unit>
       <trans-unit id="HeaderSpans">
@@ -147,6 +227,26 @@
         <target state="translated">Marca de tiempo</target>
         <note />
       </trans-unit>
+      <trans-unit id="HeaderTotal">
+        <source>Total</source>
+        <target state="new">Total</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HeaderTraceId">
+        <source>Trace ID</source>
+        <target state="new">Trace ID</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HeaderValue">
+        <source>Value</source>
+        <target state="new">Value</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HeaderWallClock">
+        <source>Wall</source>
+        <target state="new">Wall</target>
+        <note />
+      </trans-unit>
       <trans-unit id="LimitMustBePositive">
         <source>The --limit value must be a positive number.</source>
         <target state="translated">El valor --limit debe ser un número positivo.</target>
@@ -162,9 +262,64 @@
         <target state="needs-review-translation">Ver los registros estructurados desde la API de telemetría del panel.</target>
         <note />
       </trans-unit>
+      <trans-unit id="MetricAverageDuration">
+        <source>Average duration</source>
+        <target state="new">Average duration</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MetricErrorSpans">
+        <source>Error spans</source>
+        <target state="new">Error spans</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MetricErrorTraces">
+        <source>Error traces</source>
+        <target state="new">Error traces</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MetricMaxDuration">
+        <source>Max duration</source>
+        <target state="new">Max duration</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MetricP50Duration">
+        <source>P50 duration</source>
+        <target state="new">P50 duration</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MetricP95Duration">
+        <source>P95 duration</source>
+        <target state="new">P95 duration</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MetricP99Duration">
+        <source>P99 duration</source>
+        <target state="new">P99 duration</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MetricResources">
+        <source>Resources</source>
+        <target state="new">Resources</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MetricSpans">
+        <source>Spans</source>
+        <target state="new">Spans</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MetricTraces">
+        <source>Traces</source>
+        <target state="new">Traces</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ResourceArgumentDescription">
         <source>Filter by resource name</source>
         <target state="needs-review-translation">Filtrar por nombre de recurso.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourceNotFound">
+        <source>Resource '{0}' not found.</source>
+        <target state="new">Resource '{0}' not found.</target>
         <note />
       </trans-unit>
       <trans-unit id="SearchOptionDescription">
@@ -182,9 +337,44 @@
         <target state="needs-review-translation">Filtrar los registros por gravedad mínima (Seguimiento, Depuración, Información, Advertencia, Error, Crítico).</target>
         <note />
       </trans-unit>
+      <trans-unit id="SlowTracesDescription">
+        <source>Show top traces by wall-clock duration</source>
+        <target state="new">Show top traces by wall-clock duration</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SpanStatsDescription">
+        <source>Aggregate span duration statistics</source>
+        <target state="new">Aggregate span duration statistics</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SpansDescription">
         <source>View spans from the Dashboard telemetry API</source>
         <target state="needs-review-translation">Ver intervalos de la API de telemetría del panel.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SummaryDescription">
+        <source>Summarize trace latency, span counts, and errors</source>
+        <target state="new">Summarize trace latency, span counts, and errors</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TelemetryArchiveNotFound">
+        <source>Telemetry archive file '{0}' was not found.</source>
+        <target state="new">Telemetry archive file '{0}' was not found.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TelemetryArchiveOptionDescription">
+        <source>Read telemetry from an Aspire export or profile archive instead of a running dashboard</source>
+        <target state="new">Read telemetry from an Aspire export or profile archive instead of a running dashboard</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TopMustBePositive">
+        <source>The --top value must be a positive number.</source>
+        <target state="new">The --top value must be a positive number.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TopOptionDescription">
+        <source>Maximum number of rows to display</source>
+        <target state="new">Maximum number of rows to display</target>
         <note />
       </trans-unit>
       <trans-unit id="TraceIdArgumentDescription">
@@ -210,6 +400,11 @@
       <trans-unit id="UnexpectedContentType">
         <source>Dashboard API returned unexpected content type '{0}'. Expected JSON response.</source>
         <target state="new">Dashboard API returned unexpected content type '{0}'. Expected JSON response.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WallTimeDescription">
+        <source>Analyze trace wall-clock time, span coverage, gaps, and overlap</source>
+        <target state="new">Analyze trace wall-clock time, span coverage, gaps, and overlap</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Aspire.Cli/Resources/xlf/TelemetryCommandStrings.fr.xlf
+++ b/src/Aspire.Cli/Resources/xlf/TelemetryCommandStrings.fr.xlf
@@ -107,6 +107,16 @@
         <target state="translated">Échec de la récupération de télémétrie : {0}</target>
         <note />
       </trans-unit>
+      <trans-unit id="FailedToReadTelemetryArchive">
+        <source>Failed to read telemetry archive '{0}': {1}</source>
+        <target state="new">Failed to read telemetry archive '{0}': {1}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FileAndLiveOptionsExclusive">
+        <source>The --file option cannot be used with --dashboard-url, --api-key, or --apphost. Specify either an archive file or a live dashboard source.</source>
+        <target state="new">The --file option cannot be used with --dashboard-url, --api-key, or --apphost. Specify either an archive file or a live dashboard source.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="FollowOptionDescription">
         <source>Stream telemetry in real-time as it arrives</source>
         <target state="needs-review-translation">Diffuser la télémétrie en temps réel dès son arrivée.</target>
@@ -117,9 +127,29 @@
         <target state="needs-review-translation">Format de sortie (Tableau ou JSON).</target>
         <note />
       </trans-unit>
+      <trans-unit id="GroupByOptionDescription">
+        <source>Group span statistics by Name or Resource</source>
+        <target state="new">Group span statistics by Name or Resource</target>
+        <note />
+      </trans-unit>
       <trans-unit id="HasErrorOptionDescription">
         <source>Filter by error status (true to show only errors, false to exclude errors)</source>
         <target state="needs-review-translation">Filtrer selon le statut d’erreur (true pour afficher uniquement les erreurs, false pour exclure les erreurs).</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HeaderAverage">
+        <source>Avg</source>
+        <target state="new">Avg</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HeaderCount">
+        <source>Count</source>
+        <target state="new">Count</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HeaderCovered">
+        <source>Covered</source>
+        <target state="new">Covered</target>
         <note />
       </trans-unit>
       <trans-unit id="HeaderDuration">
@@ -127,9 +157,59 @@
         <target state="translated">Durée</target>
         <note />
       </trans-unit>
+      <trans-unit id="HeaderErrors">
+        <source>Errors</source>
+        <target state="new">Errors</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HeaderGap">
+        <source>Gap</source>
+        <target state="new">Gap</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HeaderGroup">
+        <source>Group</source>
+        <target state="new">Group</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HeaderMax">
+        <source>Max</source>
+        <target state="new">Max</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HeaderMetric">
+        <source>Metric</source>
+        <target state="new">Metric</target>
+        <note />
+      </trans-unit>
       <trans-unit id="HeaderName">
         <source>Name</source>
         <target state="translated">Nom</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HeaderOverlap">
+        <source>Overlap</source>
+        <target state="new">Overlap</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HeaderP95">
+        <source>P95</source>
+        <target state="new">P95</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HeaderRatio">
+        <source>Ratio</source>
+        <target state="new">Ratio</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HeaderResource">
+        <source>Resource</source>
+        <target state="new">Resource</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HeaderSpanSum">
+        <source>Span sum</source>
+        <target state="new">Span sum</target>
         <note />
       </trans-unit>
       <trans-unit id="HeaderSpans">
@@ -147,6 +227,26 @@
         <target state="translated">Horodateur</target>
         <note />
       </trans-unit>
+      <trans-unit id="HeaderTotal">
+        <source>Total</source>
+        <target state="new">Total</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HeaderTraceId">
+        <source>Trace ID</source>
+        <target state="new">Trace ID</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HeaderValue">
+        <source>Value</source>
+        <target state="new">Value</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HeaderWallClock">
+        <source>Wall</source>
+        <target state="new">Wall</target>
+        <note />
+      </trans-unit>
       <trans-unit id="LimitMustBePositive">
         <source>The --limit value must be a positive number.</source>
         <target state="translated">La valeur --limit doit être un nombre positif.</target>
@@ -162,9 +262,64 @@
         <target state="needs-review-translation">Afficher les journaux structurés via l’API de télémétrie du tableau de bord.</target>
         <note />
       </trans-unit>
+      <trans-unit id="MetricAverageDuration">
+        <source>Average duration</source>
+        <target state="new">Average duration</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MetricErrorSpans">
+        <source>Error spans</source>
+        <target state="new">Error spans</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MetricErrorTraces">
+        <source>Error traces</source>
+        <target state="new">Error traces</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MetricMaxDuration">
+        <source>Max duration</source>
+        <target state="new">Max duration</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MetricP50Duration">
+        <source>P50 duration</source>
+        <target state="new">P50 duration</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MetricP95Duration">
+        <source>P95 duration</source>
+        <target state="new">P95 duration</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MetricP99Duration">
+        <source>P99 duration</source>
+        <target state="new">P99 duration</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MetricResources">
+        <source>Resources</source>
+        <target state="new">Resources</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MetricSpans">
+        <source>Spans</source>
+        <target state="new">Spans</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MetricTraces">
+        <source>Traces</source>
+        <target state="new">Traces</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ResourceArgumentDescription">
         <source>Filter by resource name</source>
         <target state="needs-review-translation">Filtrer par nom de ressource.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourceNotFound">
+        <source>Resource '{0}' not found.</source>
+        <target state="new">Resource '{0}' not found.</target>
         <note />
       </trans-unit>
       <trans-unit id="SearchOptionDescription">
@@ -182,9 +337,44 @@
         <target state="needs-review-translation">Filtrer les journaux selon la gravité minimale (Trace, Debug, Information, Warning, Error, Critical).</target>
         <note />
       </trans-unit>
+      <trans-unit id="SlowTracesDescription">
+        <source>Show top traces by wall-clock duration</source>
+        <target state="new">Show top traces by wall-clock duration</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SpanStatsDescription">
+        <source>Aggregate span duration statistics</source>
+        <target state="new">Aggregate span duration statistics</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SpansDescription">
         <source>View spans from the Dashboard telemetry API</source>
         <target state="needs-review-translation">Afficher les intervalles à partir de l’API de télémétrie du tableau de bord.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SummaryDescription">
+        <source>Summarize trace latency, span counts, and errors</source>
+        <target state="new">Summarize trace latency, span counts, and errors</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TelemetryArchiveNotFound">
+        <source>Telemetry archive file '{0}' was not found.</source>
+        <target state="new">Telemetry archive file '{0}' was not found.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TelemetryArchiveOptionDescription">
+        <source>Read telemetry from an Aspire export or profile archive instead of a running dashboard</source>
+        <target state="new">Read telemetry from an Aspire export or profile archive instead of a running dashboard</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TopMustBePositive">
+        <source>The --top value must be a positive number.</source>
+        <target state="new">The --top value must be a positive number.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TopOptionDescription">
+        <source>Maximum number of rows to display</source>
+        <target state="new">Maximum number of rows to display</target>
         <note />
       </trans-unit>
       <trans-unit id="TraceIdArgumentDescription">
@@ -210,6 +400,11 @@
       <trans-unit id="UnexpectedContentType">
         <source>Dashboard API returned unexpected content type '{0}'. Expected JSON response.</source>
         <target state="new">Dashboard API returned unexpected content type '{0}'. Expected JSON response.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WallTimeDescription">
+        <source>Analyze trace wall-clock time, span coverage, gaps, and overlap</source>
+        <target state="new">Analyze trace wall-clock time, span coverage, gaps, and overlap</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Aspire.Cli/Resources/xlf/TelemetryCommandStrings.it.xlf
+++ b/src/Aspire.Cli/Resources/xlf/TelemetryCommandStrings.it.xlf
@@ -107,6 +107,16 @@
         <target state="translated">Non è possibile recuperare i dati di telemetria: {0}</target>
         <note />
       </trans-unit>
+      <trans-unit id="FailedToReadTelemetryArchive">
+        <source>Failed to read telemetry archive '{0}': {1}</source>
+        <target state="new">Failed to read telemetry archive '{0}': {1}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FileAndLiveOptionsExclusive">
+        <source>The --file option cannot be used with --dashboard-url, --api-key, or --apphost. Specify either an archive file or a live dashboard source.</source>
+        <target state="new">The --file option cannot be used with --dashboard-url, --api-key, or --apphost. Specify either an archive file or a live dashboard source.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="FollowOptionDescription">
         <source>Stream telemetry in real-time as it arrives</source>
         <target state="needs-review-translation">Trasmetti i dati di telemetria in tempo reale non appena arrivano.</target>
@@ -117,9 +127,29 @@
         <target state="needs-review-translation">Formato di output (Tabella o JSON).</target>
         <note />
       </trans-unit>
+      <trans-unit id="GroupByOptionDescription">
+        <source>Group span statistics by Name or Resource</source>
+        <target state="new">Group span statistics by Name or Resource</target>
+        <note />
+      </trans-unit>
       <trans-unit id="HasErrorOptionDescription">
         <source>Filter by error status (true to show only errors, false to exclude errors)</source>
         <target state="needs-review-translation">Filtra per stato di errore (true per mostrare solo gli errori, false per escluderli).</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HeaderAverage">
+        <source>Avg</source>
+        <target state="new">Avg</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HeaderCount">
+        <source>Count</source>
+        <target state="new">Count</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HeaderCovered">
+        <source>Covered</source>
+        <target state="new">Covered</target>
         <note />
       </trans-unit>
       <trans-unit id="HeaderDuration">
@@ -127,9 +157,59 @@
         <target state="translated">Durata</target>
         <note />
       </trans-unit>
+      <trans-unit id="HeaderErrors">
+        <source>Errors</source>
+        <target state="new">Errors</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HeaderGap">
+        <source>Gap</source>
+        <target state="new">Gap</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HeaderGroup">
+        <source>Group</source>
+        <target state="new">Group</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HeaderMax">
+        <source>Max</source>
+        <target state="new">Max</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HeaderMetric">
+        <source>Metric</source>
+        <target state="new">Metric</target>
+        <note />
+      </trans-unit>
       <trans-unit id="HeaderName">
         <source>Name</source>
         <target state="translated">Nome</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HeaderOverlap">
+        <source>Overlap</source>
+        <target state="new">Overlap</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HeaderP95">
+        <source>P95</source>
+        <target state="new">P95</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HeaderRatio">
+        <source>Ratio</source>
+        <target state="new">Ratio</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HeaderResource">
+        <source>Resource</source>
+        <target state="new">Resource</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HeaderSpanSum">
+        <source>Span sum</source>
+        <target state="new">Span sum</target>
         <note />
       </trans-unit>
       <trans-unit id="HeaderSpans">
@@ -147,6 +227,26 @@
         <target state="translated">Timestamp</target>
         <note />
       </trans-unit>
+      <trans-unit id="HeaderTotal">
+        <source>Total</source>
+        <target state="new">Total</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HeaderTraceId">
+        <source>Trace ID</source>
+        <target state="new">Trace ID</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HeaderValue">
+        <source>Value</source>
+        <target state="new">Value</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HeaderWallClock">
+        <source>Wall</source>
+        <target state="new">Wall</target>
+        <note />
+      </trans-unit>
       <trans-unit id="LimitMustBePositive">
         <source>The --limit value must be a positive number.</source>
         <target state="translated">Il valore --limit deve essere un numero positivo.</target>
@@ -162,9 +262,64 @@
         <target state="needs-review-translation">Visualizza i log strutturati dall'API di telemetria del dashboard.</target>
         <note />
       </trans-unit>
+      <trans-unit id="MetricAverageDuration">
+        <source>Average duration</source>
+        <target state="new">Average duration</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MetricErrorSpans">
+        <source>Error spans</source>
+        <target state="new">Error spans</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MetricErrorTraces">
+        <source>Error traces</source>
+        <target state="new">Error traces</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MetricMaxDuration">
+        <source>Max duration</source>
+        <target state="new">Max duration</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MetricP50Duration">
+        <source>P50 duration</source>
+        <target state="new">P50 duration</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MetricP95Duration">
+        <source>P95 duration</source>
+        <target state="new">P95 duration</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MetricP99Duration">
+        <source>P99 duration</source>
+        <target state="new">P99 duration</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MetricResources">
+        <source>Resources</source>
+        <target state="new">Resources</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MetricSpans">
+        <source>Spans</source>
+        <target state="new">Spans</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MetricTraces">
+        <source>Traces</source>
+        <target state="new">Traces</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ResourceArgumentDescription">
         <source>Filter by resource name</source>
         <target state="needs-review-translation">Filtrare per nome della risorsa.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourceNotFound">
+        <source>Resource '{0}' not found.</source>
+        <target state="new">Resource '{0}' not found.</target>
         <note />
       </trans-unit>
       <trans-unit id="SearchOptionDescription">
@@ -182,9 +337,44 @@
         <target state="needs-review-translation">Filtra i log in base alla gravità minima (Traccia, Debug, Informazioni, Avviso, Errore, Critico).</target>
         <note />
       </trans-unit>
+      <trans-unit id="SlowTracesDescription">
+        <source>Show top traces by wall-clock duration</source>
+        <target state="new">Show top traces by wall-clock duration</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SpanStatsDescription">
+        <source>Aggregate span duration statistics</source>
+        <target state="new">Aggregate span duration statistics</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SpansDescription">
         <source>View spans from the Dashboard telemetry API</source>
         <target state="needs-review-translation">Visualizza gli span dall'API di telemetria del dashboard.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SummaryDescription">
+        <source>Summarize trace latency, span counts, and errors</source>
+        <target state="new">Summarize trace latency, span counts, and errors</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TelemetryArchiveNotFound">
+        <source>Telemetry archive file '{0}' was not found.</source>
+        <target state="new">Telemetry archive file '{0}' was not found.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TelemetryArchiveOptionDescription">
+        <source>Read telemetry from an Aspire export or profile archive instead of a running dashboard</source>
+        <target state="new">Read telemetry from an Aspire export or profile archive instead of a running dashboard</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TopMustBePositive">
+        <source>The --top value must be a positive number.</source>
+        <target state="new">The --top value must be a positive number.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TopOptionDescription">
+        <source>Maximum number of rows to display</source>
+        <target state="new">Maximum number of rows to display</target>
         <note />
       </trans-unit>
       <trans-unit id="TraceIdArgumentDescription">
@@ -210,6 +400,11 @@
       <trans-unit id="UnexpectedContentType">
         <source>Dashboard API returned unexpected content type '{0}'. Expected JSON response.</source>
         <target state="new">Dashboard API returned unexpected content type '{0}'. Expected JSON response.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WallTimeDescription">
+        <source>Analyze trace wall-clock time, span coverage, gaps, and overlap</source>
+        <target state="new">Analyze trace wall-clock time, span coverage, gaps, and overlap</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Aspire.Cli/Resources/xlf/TelemetryCommandStrings.ja.xlf
+++ b/src/Aspire.Cli/Resources/xlf/TelemetryCommandStrings.ja.xlf
@@ -107,6 +107,16 @@
         <target state="translated">テレメトリをフェッチできませんでした: {0}</target>
         <note />
       </trans-unit>
+      <trans-unit id="FailedToReadTelemetryArchive">
+        <source>Failed to read telemetry archive '{0}': {1}</source>
+        <target state="new">Failed to read telemetry archive '{0}': {1}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FileAndLiveOptionsExclusive">
+        <source>The --file option cannot be used with --dashboard-url, --api-key, or --apphost. Specify either an archive file or a live dashboard source.</source>
+        <target state="new">The --file option cannot be used with --dashboard-url, --api-key, or --apphost. Specify either an archive file or a live dashboard source.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="FollowOptionDescription">
         <source>Stream telemetry in real-time as it arrives</source>
         <target state="needs-review-translation">テレメトリが到着すると、リアルタイムでストリーミングします。</target>
@@ -117,9 +127,29 @@
         <target state="needs-review-translation">出力形式 (テーブルまたは JSON)。</target>
         <note />
       </trans-unit>
+      <trans-unit id="GroupByOptionDescription">
+        <source>Group span statistics by Name or Resource</source>
+        <target state="new">Group span statistics by Name or Resource</target>
+        <note />
+      </trans-unit>
       <trans-unit id="HasErrorOptionDescription">
         <source>Filter by error status (true to show only errors, false to exclude errors)</source>
         <target state="needs-review-translation">エラーの状態でフィルター処理します (エラーのみを表示する場合は true、エラーを除外するには false)。</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HeaderAverage">
+        <source>Avg</source>
+        <target state="new">Avg</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HeaderCount">
+        <source>Count</source>
+        <target state="new">Count</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HeaderCovered">
+        <source>Covered</source>
+        <target state="new">Covered</target>
         <note />
       </trans-unit>
       <trans-unit id="HeaderDuration">
@@ -127,9 +157,59 @@
         <target state="translated">期間</target>
         <note />
       </trans-unit>
+      <trans-unit id="HeaderErrors">
+        <source>Errors</source>
+        <target state="new">Errors</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HeaderGap">
+        <source>Gap</source>
+        <target state="new">Gap</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HeaderGroup">
+        <source>Group</source>
+        <target state="new">Group</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HeaderMax">
+        <source>Max</source>
+        <target state="new">Max</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HeaderMetric">
+        <source>Metric</source>
+        <target state="new">Metric</target>
+        <note />
+      </trans-unit>
       <trans-unit id="HeaderName">
         <source>Name</source>
         <target state="translated">名前</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HeaderOverlap">
+        <source>Overlap</source>
+        <target state="new">Overlap</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HeaderP95">
+        <source>P95</source>
+        <target state="new">P95</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HeaderRatio">
+        <source>Ratio</source>
+        <target state="new">Ratio</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HeaderResource">
+        <source>Resource</source>
+        <target state="new">Resource</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HeaderSpanSum">
+        <source>Span sum</source>
+        <target state="new">Span sum</target>
         <note />
       </trans-unit>
       <trans-unit id="HeaderSpans">
@@ -147,6 +227,26 @@
         <target state="translated">タイムスタンプ</target>
         <note />
       </trans-unit>
+      <trans-unit id="HeaderTotal">
+        <source>Total</source>
+        <target state="new">Total</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HeaderTraceId">
+        <source>Trace ID</source>
+        <target state="new">Trace ID</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HeaderValue">
+        <source>Value</source>
+        <target state="new">Value</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HeaderWallClock">
+        <source>Wall</source>
+        <target state="new">Wall</target>
+        <note />
+      </trans-unit>
       <trans-unit id="LimitMustBePositive">
         <source>The --limit value must be a positive number.</source>
         <target state="translated">--limit の値は正の数値である必要があります。</target>
@@ -162,9 +262,64 @@
         <target state="needs-review-translation">ダッシュボード テレメトリ API から構造化ログを表示します。</target>
         <note />
       </trans-unit>
+      <trans-unit id="MetricAverageDuration">
+        <source>Average duration</source>
+        <target state="new">Average duration</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MetricErrorSpans">
+        <source>Error spans</source>
+        <target state="new">Error spans</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MetricErrorTraces">
+        <source>Error traces</source>
+        <target state="new">Error traces</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MetricMaxDuration">
+        <source>Max duration</source>
+        <target state="new">Max duration</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MetricP50Duration">
+        <source>P50 duration</source>
+        <target state="new">P50 duration</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MetricP95Duration">
+        <source>P95 duration</source>
+        <target state="new">P95 duration</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MetricP99Duration">
+        <source>P99 duration</source>
+        <target state="new">P99 duration</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MetricResources">
+        <source>Resources</source>
+        <target state="new">Resources</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MetricSpans">
+        <source>Spans</source>
+        <target state="new">Spans</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MetricTraces">
+        <source>Traces</source>
+        <target state="new">Traces</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ResourceArgumentDescription">
         <source>Filter by resource name</source>
         <target state="needs-review-translation">リソース名でフィルター処理します。</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourceNotFound">
+        <source>Resource '{0}' not found.</source>
+        <target state="new">Resource '{0}' not found.</target>
         <note />
       </trans-unit>
       <trans-unit id="SearchOptionDescription">
@@ -182,9 +337,44 @@
         <target state="needs-review-translation">最小重大度 (トレース、デバッグ、情報、警告、エラー、重大) でログをフィルター処理します。</target>
         <note />
       </trans-unit>
+      <trans-unit id="SlowTracesDescription">
+        <source>Show top traces by wall-clock duration</source>
+        <target state="new">Show top traces by wall-clock duration</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SpanStatsDescription">
+        <source>Aggregate span duration statistics</source>
+        <target state="new">Aggregate span duration statistics</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SpansDescription">
         <source>View spans from the Dashboard telemetry API</source>
         <target state="needs-review-translation">ダッシュボード テレメトリ API からスパンを表示します。</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SummaryDescription">
+        <source>Summarize trace latency, span counts, and errors</source>
+        <target state="new">Summarize trace latency, span counts, and errors</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TelemetryArchiveNotFound">
+        <source>Telemetry archive file '{0}' was not found.</source>
+        <target state="new">Telemetry archive file '{0}' was not found.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TelemetryArchiveOptionDescription">
+        <source>Read telemetry from an Aspire export or profile archive instead of a running dashboard</source>
+        <target state="new">Read telemetry from an Aspire export or profile archive instead of a running dashboard</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TopMustBePositive">
+        <source>The --top value must be a positive number.</source>
+        <target state="new">The --top value must be a positive number.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TopOptionDescription">
+        <source>Maximum number of rows to display</source>
+        <target state="new">Maximum number of rows to display</target>
         <note />
       </trans-unit>
       <trans-unit id="TraceIdArgumentDescription">
@@ -210,6 +400,11 @@
       <trans-unit id="UnexpectedContentType">
         <source>Dashboard API returned unexpected content type '{0}'. Expected JSON response.</source>
         <target state="new">Dashboard API returned unexpected content type '{0}'. Expected JSON response.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WallTimeDescription">
+        <source>Analyze trace wall-clock time, span coverage, gaps, and overlap</source>
+        <target state="new">Analyze trace wall-clock time, span coverage, gaps, and overlap</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Aspire.Cli/Resources/xlf/TelemetryCommandStrings.ko.xlf
+++ b/src/Aspire.Cli/Resources/xlf/TelemetryCommandStrings.ko.xlf
@@ -107,6 +107,16 @@
         <target state="translated">원격 분석을 가져오지 못했습니다. {0}</target>
         <note />
       </trans-unit>
+      <trans-unit id="FailedToReadTelemetryArchive">
+        <source>Failed to read telemetry archive '{0}': {1}</source>
+        <target state="new">Failed to read telemetry archive '{0}': {1}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FileAndLiveOptionsExclusive">
+        <source>The --file option cannot be used with --dashboard-url, --api-key, or --apphost. Specify either an archive file or a live dashboard source.</source>
+        <target state="new">The --file option cannot be used with --dashboard-url, --api-key, or --apphost. Specify either an archive file or a live dashboard source.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="FollowOptionDescription">
         <source>Stream telemetry in real-time as it arrives</source>
         <target state="needs-review-translation">원격 분석 데이터를 실시간으로 스트림합니다.</target>
@@ -117,9 +127,29 @@
         <target state="needs-review-translation">출력 형식(테이블 또는 JSON)입니다.</target>
         <note />
       </trans-unit>
+      <trans-unit id="GroupByOptionDescription">
+        <source>Group span statistics by Name or Resource</source>
+        <target state="new">Group span statistics by Name or Resource</target>
+        <note />
+      </trans-unit>
       <trans-unit id="HasErrorOptionDescription">
         <source>Filter by error status (true to show only errors, false to exclude errors)</source>
         <target state="needs-review-translation">오류 상태로 필터링합니다(true면 오류만, false면 오류 제외).</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HeaderAverage">
+        <source>Avg</source>
+        <target state="new">Avg</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HeaderCount">
+        <source>Count</source>
+        <target state="new">Count</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HeaderCovered">
+        <source>Covered</source>
+        <target state="new">Covered</target>
         <note />
       </trans-unit>
       <trans-unit id="HeaderDuration">
@@ -127,9 +157,59 @@
         <target state="translated">기간</target>
         <note />
       </trans-unit>
+      <trans-unit id="HeaderErrors">
+        <source>Errors</source>
+        <target state="new">Errors</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HeaderGap">
+        <source>Gap</source>
+        <target state="new">Gap</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HeaderGroup">
+        <source>Group</source>
+        <target state="new">Group</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HeaderMax">
+        <source>Max</source>
+        <target state="new">Max</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HeaderMetric">
+        <source>Metric</source>
+        <target state="new">Metric</target>
+        <note />
+      </trans-unit>
       <trans-unit id="HeaderName">
         <source>Name</source>
         <target state="translated">이름</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HeaderOverlap">
+        <source>Overlap</source>
+        <target state="new">Overlap</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HeaderP95">
+        <source>P95</source>
+        <target state="new">P95</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HeaderRatio">
+        <source>Ratio</source>
+        <target state="new">Ratio</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HeaderResource">
+        <source>Resource</source>
+        <target state="new">Resource</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HeaderSpanSum">
+        <source>Span sum</source>
+        <target state="new">Span sum</target>
         <note />
       </trans-unit>
       <trans-unit id="HeaderSpans">
@@ -147,6 +227,26 @@
         <target state="translated">타임스탬프</target>
         <note />
       </trans-unit>
+      <trans-unit id="HeaderTotal">
+        <source>Total</source>
+        <target state="new">Total</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HeaderTraceId">
+        <source>Trace ID</source>
+        <target state="new">Trace ID</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HeaderValue">
+        <source>Value</source>
+        <target state="new">Value</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HeaderWallClock">
+        <source>Wall</source>
+        <target state="new">Wall</target>
+        <note />
+      </trans-unit>
       <trans-unit id="LimitMustBePositive">
         <source>The --limit value must be a positive number.</source>
         <target state="translated">--limit 값은 양수여야 합니다.</target>
@@ -162,9 +262,64 @@
         <target state="needs-review-translation">대시보드 원격 분석 API에서 구조화된 로그를 확인합니다.</target>
         <note />
       </trans-unit>
+      <trans-unit id="MetricAverageDuration">
+        <source>Average duration</source>
+        <target state="new">Average duration</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MetricErrorSpans">
+        <source>Error spans</source>
+        <target state="new">Error spans</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MetricErrorTraces">
+        <source>Error traces</source>
+        <target state="new">Error traces</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MetricMaxDuration">
+        <source>Max duration</source>
+        <target state="new">Max duration</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MetricP50Duration">
+        <source>P50 duration</source>
+        <target state="new">P50 duration</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MetricP95Duration">
+        <source>P95 duration</source>
+        <target state="new">P95 duration</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MetricP99Duration">
+        <source>P99 duration</source>
+        <target state="new">P99 duration</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MetricResources">
+        <source>Resources</source>
+        <target state="new">Resources</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MetricSpans">
+        <source>Spans</source>
+        <target state="new">Spans</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MetricTraces">
+        <source>Traces</source>
+        <target state="new">Traces</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ResourceArgumentDescription">
         <source>Filter by resource name</source>
         <target state="needs-review-translation">리소스 이름으로 필터링</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourceNotFound">
+        <source>Resource '{0}' not found.</source>
+        <target state="new">Resource '{0}' not found.</target>
         <note />
       </trans-unit>
       <trans-unit id="SearchOptionDescription">
@@ -182,9 +337,44 @@
         <target state="needs-review-translation">최소 심각도(Trace, Debug, Information, Warning, Error, Critical)로 로그를 필터링합니다.</target>
         <note />
       </trans-unit>
+      <trans-unit id="SlowTracesDescription">
+        <source>Show top traces by wall-clock duration</source>
+        <target state="new">Show top traces by wall-clock duration</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SpanStatsDescription">
+        <source>Aggregate span duration statistics</source>
+        <target state="new">Aggregate span duration statistics</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SpansDescription">
         <source>View spans from the Dashboard telemetry API</source>
         <target state="needs-review-translation">대시보드 원격 분석 API에서 범위를 확인합니다.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SummaryDescription">
+        <source>Summarize trace latency, span counts, and errors</source>
+        <target state="new">Summarize trace latency, span counts, and errors</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TelemetryArchiveNotFound">
+        <source>Telemetry archive file '{0}' was not found.</source>
+        <target state="new">Telemetry archive file '{0}' was not found.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TelemetryArchiveOptionDescription">
+        <source>Read telemetry from an Aspire export or profile archive instead of a running dashboard</source>
+        <target state="new">Read telemetry from an Aspire export or profile archive instead of a running dashboard</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TopMustBePositive">
+        <source>The --top value must be a positive number.</source>
+        <target state="new">The --top value must be a positive number.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TopOptionDescription">
+        <source>Maximum number of rows to display</source>
+        <target state="new">Maximum number of rows to display</target>
         <note />
       </trans-unit>
       <trans-unit id="TraceIdArgumentDescription">
@@ -210,6 +400,11 @@
       <trans-unit id="UnexpectedContentType">
         <source>Dashboard API returned unexpected content type '{0}'. Expected JSON response.</source>
         <target state="new">Dashboard API returned unexpected content type '{0}'. Expected JSON response.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WallTimeDescription">
+        <source>Analyze trace wall-clock time, span coverage, gaps, and overlap</source>
+        <target state="new">Analyze trace wall-clock time, span coverage, gaps, and overlap</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Aspire.Cli/Resources/xlf/TelemetryCommandStrings.pl.xlf
+++ b/src/Aspire.Cli/Resources/xlf/TelemetryCommandStrings.pl.xlf
@@ -107,6 +107,16 @@
         <target state="translated">Nie można pobrać telemetrii: {0}</target>
         <note />
       </trans-unit>
+      <trans-unit id="FailedToReadTelemetryArchive">
+        <source>Failed to read telemetry archive '{0}': {1}</source>
+        <target state="new">Failed to read telemetry archive '{0}': {1}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FileAndLiveOptionsExclusive">
+        <source>The --file option cannot be used with --dashboard-url, --api-key, or --apphost. Specify either an archive file or a live dashboard source.</source>
+        <target state="new">The --file option cannot be used with --dashboard-url, --api-key, or --apphost. Specify either an archive file or a live dashboard source.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="FollowOptionDescription">
         <source>Stream telemetry in real-time as it arrives</source>
         <target state="needs-review-translation">Strumieniuj telemetrię w czasie rzeczywistym, gdy tylko nadejdzie.</target>
@@ -117,9 +127,29 @@
         <target state="needs-review-translation">Format wyjściowy (tabela lub JSON).</target>
         <note />
       </trans-unit>
+      <trans-unit id="GroupByOptionDescription">
+        <source>Group span statistics by Name or Resource</source>
+        <target state="new">Group span statistics by Name or Resource</target>
+        <note />
+      </trans-unit>
       <trans-unit id="HasErrorOptionDescription">
         <source>Filter by error status (true to show only errors, false to exclude errors)</source>
         <target state="needs-review-translation">Filtruj według statusu błędu (wartość true, aby pokazać tylko błędy, false, aby je wykluczyć).</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HeaderAverage">
+        <source>Avg</source>
+        <target state="new">Avg</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HeaderCount">
+        <source>Count</source>
+        <target state="new">Count</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HeaderCovered">
+        <source>Covered</source>
+        <target state="new">Covered</target>
         <note />
       </trans-unit>
       <trans-unit id="HeaderDuration">
@@ -127,9 +157,59 @@
         <target state="translated">Czas trwania</target>
         <note />
       </trans-unit>
+      <trans-unit id="HeaderErrors">
+        <source>Errors</source>
+        <target state="new">Errors</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HeaderGap">
+        <source>Gap</source>
+        <target state="new">Gap</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HeaderGroup">
+        <source>Group</source>
+        <target state="new">Group</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HeaderMax">
+        <source>Max</source>
+        <target state="new">Max</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HeaderMetric">
+        <source>Metric</source>
+        <target state="new">Metric</target>
+        <note />
+      </trans-unit>
       <trans-unit id="HeaderName">
         <source>Name</source>
         <target state="translated">Nazwa</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HeaderOverlap">
+        <source>Overlap</source>
+        <target state="new">Overlap</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HeaderP95">
+        <source>P95</source>
+        <target state="new">P95</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HeaderRatio">
+        <source>Ratio</source>
+        <target state="new">Ratio</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HeaderResource">
+        <source>Resource</source>
+        <target state="new">Resource</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HeaderSpanSum">
+        <source>Span sum</source>
+        <target state="new">Span sum</target>
         <note />
       </trans-unit>
       <trans-unit id="HeaderSpans">
@@ -147,6 +227,26 @@
         <target state="translated">Znacznik czasu</target>
         <note />
       </trans-unit>
+      <trans-unit id="HeaderTotal">
+        <source>Total</source>
+        <target state="new">Total</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HeaderTraceId">
+        <source>Trace ID</source>
+        <target state="new">Trace ID</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HeaderValue">
+        <source>Value</source>
+        <target state="new">Value</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HeaderWallClock">
+        <source>Wall</source>
+        <target state="new">Wall</target>
+        <note />
+      </trans-unit>
       <trans-unit id="LimitMustBePositive">
         <source>The --limit value must be a positive number.</source>
         <target state="translated">Wartość --limit musi być liczbą dodatnią.</target>
@@ -162,9 +262,64 @@
         <target state="needs-review-translation">Wyświetl strukturalne logi z interfejsu API telemetrii pulpitu nawigacyjnego.</target>
         <note />
       </trans-unit>
+      <trans-unit id="MetricAverageDuration">
+        <source>Average duration</source>
+        <target state="new">Average duration</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MetricErrorSpans">
+        <source>Error spans</source>
+        <target state="new">Error spans</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MetricErrorTraces">
+        <source>Error traces</source>
+        <target state="new">Error traces</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MetricMaxDuration">
+        <source>Max duration</source>
+        <target state="new">Max duration</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MetricP50Duration">
+        <source>P50 duration</source>
+        <target state="new">P50 duration</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MetricP95Duration">
+        <source>P95 duration</source>
+        <target state="new">P95 duration</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MetricP99Duration">
+        <source>P99 duration</source>
+        <target state="new">P99 duration</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MetricResources">
+        <source>Resources</source>
+        <target state="new">Resources</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MetricSpans">
+        <source>Spans</source>
+        <target state="new">Spans</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MetricTraces">
+        <source>Traces</source>
+        <target state="new">Traces</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ResourceArgumentDescription">
         <source>Filter by resource name</source>
         <target state="needs-review-translation">Filtruj według nazwy zasobu.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourceNotFound">
+        <source>Resource '{0}' not found.</source>
+        <target state="new">Resource '{0}' not found.</target>
         <note />
       </trans-unit>
       <trans-unit id="SearchOptionDescription">
@@ -182,9 +337,44 @@
         <target state="needs-review-translation">Filtruj logi według minimalnego poziomu ważności (Śledzenie, Debugowanie, Informacja, Ostrzeżenie, Błąd, Krytyczne).</target>
         <note />
       </trans-unit>
+      <trans-unit id="SlowTracesDescription">
+        <source>Show top traces by wall-clock duration</source>
+        <target state="new">Show top traces by wall-clock duration</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SpanStatsDescription">
+        <source>Aggregate span duration statistics</source>
+        <target state="new">Aggregate span duration statistics</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SpansDescription">
         <source>View spans from the Dashboard telemetry API</source>
         <target state="needs-review-translation">Wyświetl zakresy z interfejsu API telemetrii pulpitu nawigacyjnego.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SummaryDescription">
+        <source>Summarize trace latency, span counts, and errors</source>
+        <target state="new">Summarize trace latency, span counts, and errors</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TelemetryArchiveNotFound">
+        <source>Telemetry archive file '{0}' was not found.</source>
+        <target state="new">Telemetry archive file '{0}' was not found.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TelemetryArchiveOptionDescription">
+        <source>Read telemetry from an Aspire export or profile archive instead of a running dashboard</source>
+        <target state="new">Read telemetry from an Aspire export or profile archive instead of a running dashboard</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TopMustBePositive">
+        <source>The --top value must be a positive number.</source>
+        <target state="new">The --top value must be a positive number.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TopOptionDescription">
+        <source>Maximum number of rows to display</source>
+        <target state="new">Maximum number of rows to display</target>
         <note />
       </trans-unit>
       <trans-unit id="TraceIdArgumentDescription">
@@ -210,6 +400,11 @@
       <trans-unit id="UnexpectedContentType">
         <source>Dashboard API returned unexpected content type '{0}'. Expected JSON response.</source>
         <target state="new">Dashboard API returned unexpected content type '{0}'. Expected JSON response.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WallTimeDescription">
+        <source>Analyze trace wall-clock time, span coverage, gaps, and overlap</source>
+        <target state="new">Analyze trace wall-clock time, span coverage, gaps, and overlap</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Aspire.Cli/Resources/xlf/TelemetryCommandStrings.pt-BR.xlf
+++ b/src/Aspire.Cli/Resources/xlf/TelemetryCommandStrings.pt-BR.xlf
@@ -107,6 +107,16 @@
         <target state="translated">Falha ao buscar telemetria: {0}</target>
         <note />
       </trans-unit>
+      <trans-unit id="FailedToReadTelemetryArchive">
+        <source>Failed to read telemetry archive '{0}': {1}</source>
+        <target state="new">Failed to read telemetry archive '{0}': {1}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FileAndLiveOptionsExclusive">
+        <source>The --file option cannot be used with --dashboard-url, --api-key, or --apphost. Specify either an archive file or a live dashboard source.</source>
+        <target state="new">The --file option cannot be used with --dashboard-url, --api-key, or --apphost. Specify either an archive file or a live dashboard source.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="FollowOptionDescription">
         <source>Stream telemetry in real-time as it arrives</source>
         <target state="needs-review-translation">Transmita telemetria em tempo real conforme ela chega.</target>
@@ -117,9 +127,29 @@
         <target state="needs-review-translation">Formato de saída (Tabela ou Json).</target>
         <note />
       </trans-unit>
+      <trans-unit id="GroupByOptionDescription">
+        <source>Group span statistics by Name or Resource</source>
+        <target state="new">Group span statistics by Name or Resource</target>
+        <note />
+      </trans-unit>
       <trans-unit id="HasErrorOptionDescription">
         <source>Filter by error status (true to show only errors, false to exclude errors)</source>
         <target state="needs-review-translation">Filtrar por status de erro (true para mostrar apenas erros, false para excluir erros).</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HeaderAverage">
+        <source>Avg</source>
+        <target state="new">Avg</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HeaderCount">
+        <source>Count</source>
+        <target state="new">Count</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HeaderCovered">
+        <source>Covered</source>
+        <target state="new">Covered</target>
         <note />
       </trans-unit>
       <trans-unit id="HeaderDuration">
@@ -127,9 +157,59 @@
         <target state="translated">Duração</target>
         <note />
       </trans-unit>
+      <trans-unit id="HeaderErrors">
+        <source>Errors</source>
+        <target state="new">Errors</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HeaderGap">
+        <source>Gap</source>
+        <target state="new">Gap</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HeaderGroup">
+        <source>Group</source>
+        <target state="new">Group</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HeaderMax">
+        <source>Max</source>
+        <target state="new">Max</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HeaderMetric">
+        <source>Metric</source>
+        <target state="new">Metric</target>
+        <note />
+      </trans-unit>
       <trans-unit id="HeaderName">
         <source>Name</source>
         <target state="translated">Nome</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HeaderOverlap">
+        <source>Overlap</source>
+        <target state="new">Overlap</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HeaderP95">
+        <source>P95</source>
+        <target state="new">P95</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HeaderRatio">
+        <source>Ratio</source>
+        <target state="new">Ratio</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HeaderResource">
+        <source>Resource</source>
+        <target state="new">Resource</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HeaderSpanSum">
+        <source>Span sum</source>
+        <target state="new">Span sum</target>
         <note />
       </trans-unit>
       <trans-unit id="HeaderSpans">
@@ -147,6 +227,26 @@
         <target state="translated">Timestamp</target>
         <note />
       </trans-unit>
+      <trans-unit id="HeaderTotal">
+        <source>Total</source>
+        <target state="new">Total</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HeaderTraceId">
+        <source>Trace ID</source>
+        <target state="new">Trace ID</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HeaderValue">
+        <source>Value</source>
+        <target state="new">Value</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HeaderWallClock">
+        <source>Wall</source>
+        <target state="new">Wall</target>
+        <note />
+      </trans-unit>
       <trans-unit id="LimitMustBePositive">
         <source>The --limit value must be a positive number.</source>
         <target state="translated">O valor --limit deve ser um número positivo.</target>
@@ -162,9 +262,64 @@
         <target state="needs-review-translation">Veja os logs estruturados da API de telemetria do Painel.</target>
         <note />
       </trans-unit>
+      <trans-unit id="MetricAverageDuration">
+        <source>Average duration</source>
+        <target state="new">Average duration</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MetricErrorSpans">
+        <source>Error spans</source>
+        <target state="new">Error spans</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MetricErrorTraces">
+        <source>Error traces</source>
+        <target state="new">Error traces</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MetricMaxDuration">
+        <source>Max duration</source>
+        <target state="new">Max duration</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MetricP50Duration">
+        <source>P50 duration</source>
+        <target state="new">P50 duration</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MetricP95Duration">
+        <source>P95 duration</source>
+        <target state="new">P95 duration</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MetricP99Duration">
+        <source>P99 duration</source>
+        <target state="new">P99 duration</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MetricResources">
+        <source>Resources</source>
+        <target state="new">Resources</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MetricSpans">
+        <source>Spans</source>
+        <target state="new">Spans</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MetricTraces">
+        <source>Traces</source>
+        <target state="new">Traces</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ResourceArgumentDescription">
         <source>Filter by resource name</source>
         <target state="needs-review-translation">Filtre por nome de recurso.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourceNotFound">
+        <source>Resource '{0}' not found.</source>
+        <target state="new">Resource '{0}' not found.</target>
         <note />
       </trans-unit>
       <trans-unit id="SearchOptionDescription">
@@ -182,9 +337,44 @@
         <target state="needs-review-translation">Filtre os logs por severidade mínima (Rastreamento, Depuração, Informações, Aviso, Erro, Crítico).</target>
         <note />
       </trans-unit>
+      <trans-unit id="SlowTracesDescription">
+        <source>Show top traces by wall-clock duration</source>
+        <target state="new">Show top traces by wall-clock duration</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SpanStatsDescription">
+        <source>Aggregate span duration statistics</source>
+        <target state="new">Aggregate span duration statistics</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SpansDescription">
         <source>View spans from the Dashboard telemetry API</source>
         <target state="needs-review-translation">Veja os spans da API de telemetria do Painel.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SummaryDescription">
+        <source>Summarize trace latency, span counts, and errors</source>
+        <target state="new">Summarize trace latency, span counts, and errors</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TelemetryArchiveNotFound">
+        <source>Telemetry archive file '{0}' was not found.</source>
+        <target state="new">Telemetry archive file '{0}' was not found.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TelemetryArchiveOptionDescription">
+        <source>Read telemetry from an Aspire export or profile archive instead of a running dashboard</source>
+        <target state="new">Read telemetry from an Aspire export or profile archive instead of a running dashboard</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TopMustBePositive">
+        <source>The --top value must be a positive number.</source>
+        <target state="new">The --top value must be a positive number.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TopOptionDescription">
+        <source>Maximum number of rows to display</source>
+        <target state="new">Maximum number of rows to display</target>
         <note />
       </trans-unit>
       <trans-unit id="TraceIdArgumentDescription">
@@ -210,6 +400,11 @@
       <trans-unit id="UnexpectedContentType">
         <source>Dashboard API returned unexpected content type '{0}'. Expected JSON response.</source>
         <target state="new">Dashboard API returned unexpected content type '{0}'. Expected JSON response.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WallTimeDescription">
+        <source>Analyze trace wall-clock time, span coverage, gaps, and overlap</source>
+        <target state="new">Analyze trace wall-clock time, span coverage, gaps, and overlap</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Aspire.Cli/Resources/xlf/TelemetryCommandStrings.ru.xlf
+++ b/src/Aspire.Cli/Resources/xlf/TelemetryCommandStrings.ru.xlf
@@ -107,6 +107,16 @@
         <target state="translated">Не удалось получить телеметрию: {0}</target>
         <note />
       </trans-unit>
+      <trans-unit id="FailedToReadTelemetryArchive">
+        <source>Failed to read telemetry archive '{0}': {1}</source>
+        <target state="new">Failed to read telemetry archive '{0}': {1}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FileAndLiveOptionsExclusive">
+        <source>The --file option cannot be used with --dashboard-url, --api-key, or --apphost. Specify either an archive file or a live dashboard source.</source>
+        <target state="new">The --file option cannot be used with --dashboard-url, --api-key, or --apphost. Specify either an archive file or a live dashboard source.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="FollowOptionDescription">
         <source>Stream telemetry in real-time as it arrives</source>
         <target state="needs-review-translation">Потоковая передача телеметрии в реальном времени по мере поступления.</target>
@@ -117,9 +127,29 @@
         <target state="needs-review-translation">Формат вывода (таблица или JSON).</target>
         <note />
       </trans-unit>
+      <trans-unit id="GroupByOptionDescription">
+        <source>Group span statistics by Name or Resource</source>
+        <target state="new">Group span statistics by Name or Resource</target>
+        <note />
+      </trans-unit>
       <trans-unit id="HasErrorOptionDescription">
         <source>Filter by error status (true to show only errors, false to exclude errors)</source>
         <target state="needs-review-translation">Фильтрация по состоянию ошибки (true — показывать только ошибки, false — исключать ошибки).</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HeaderAverage">
+        <source>Avg</source>
+        <target state="new">Avg</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HeaderCount">
+        <source>Count</source>
+        <target state="new">Count</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HeaderCovered">
+        <source>Covered</source>
+        <target state="new">Covered</target>
         <note />
       </trans-unit>
       <trans-unit id="HeaderDuration">
@@ -127,9 +157,59 @@
         <target state="translated">Продолжительность</target>
         <note />
       </trans-unit>
+      <trans-unit id="HeaderErrors">
+        <source>Errors</source>
+        <target state="new">Errors</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HeaderGap">
+        <source>Gap</source>
+        <target state="new">Gap</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HeaderGroup">
+        <source>Group</source>
+        <target state="new">Group</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HeaderMax">
+        <source>Max</source>
+        <target state="new">Max</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HeaderMetric">
+        <source>Metric</source>
+        <target state="new">Metric</target>
+        <note />
+      </trans-unit>
       <trans-unit id="HeaderName">
         <source>Name</source>
         <target state="translated">Имя</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HeaderOverlap">
+        <source>Overlap</source>
+        <target state="new">Overlap</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HeaderP95">
+        <source>P95</source>
+        <target state="new">P95</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HeaderRatio">
+        <source>Ratio</source>
+        <target state="new">Ratio</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HeaderResource">
+        <source>Resource</source>
+        <target state="new">Resource</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HeaderSpanSum">
+        <source>Span sum</source>
+        <target state="new">Span sum</target>
         <note />
       </trans-unit>
       <trans-unit id="HeaderSpans">
@@ -147,6 +227,26 @@
         <target state="translated">Метка времени</target>
         <note />
       </trans-unit>
+      <trans-unit id="HeaderTotal">
+        <source>Total</source>
+        <target state="new">Total</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HeaderTraceId">
+        <source>Trace ID</source>
+        <target state="new">Trace ID</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HeaderValue">
+        <source>Value</source>
+        <target state="new">Value</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HeaderWallClock">
+        <source>Wall</source>
+        <target state="new">Wall</target>
+        <note />
+      </trans-unit>
       <trans-unit id="LimitMustBePositive">
         <source>The --limit value must be a positive number.</source>
         <target state="translated">Значение --limit должно быть положительным числом.</target>
@@ -162,9 +262,64 @@
         <target state="needs-review-translation">Просмотр структурированных журналов через API телеметрии панели мониторинга.</target>
         <note />
       </trans-unit>
+      <trans-unit id="MetricAverageDuration">
+        <source>Average duration</source>
+        <target state="new">Average duration</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MetricErrorSpans">
+        <source>Error spans</source>
+        <target state="new">Error spans</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MetricErrorTraces">
+        <source>Error traces</source>
+        <target state="new">Error traces</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MetricMaxDuration">
+        <source>Max duration</source>
+        <target state="new">Max duration</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MetricP50Duration">
+        <source>P50 duration</source>
+        <target state="new">P50 duration</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MetricP95Duration">
+        <source>P95 duration</source>
+        <target state="new">P95 duration</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MetricP99Duration">
+        <source>P99 duration</source>
+        <target state="new">P99 duration</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MetricResources">
+        <source>Resources</source>
+        <target state="new">Resources</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MetricSpans">
+        <source>Spans</source>
+        <target state="new">Spans</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MetricTraces">
+        <source>Traces</source>
+        <target state="new">Traces</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ResourceArgumentDescription">
         <source>Filter by resource name</source>
         <target state="needs-review-translation">Фильтровать по имени ресурса.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourceNotFound">
+        <source>Resource '{0}' not found.</source>
+        <target state="new">Resource '{0}' not found.</target>
         <note />
       </trans-unit>
       <trans-unit id="SearchOptionDescription">
@@ -182,9 +337,44 @@
         <target state="needs-review-translation">Фильтрация журналов по минимальному уровню серьезности (трассировка, отладка, информация, предупреждение, ошибка, критическое).</target>
         <note />
       </trans-unit>
+      <trans-unit id="SlowTracesDescription">
+        <source>Show top traces by wall-clock duration</source>
+        <target state="new">Show top traces by wall-clock duration</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SpanStatsDescription">
+        <source>Aggregate span duration statistics</source>
+        <target state="new">Aggregate span duration statistics</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SpansDescription">
         <source>View spans from the Dashboard telemetry API</source>
         <target state="needs-review-translation">Просмотр диапазонов через API телеметрии панели мониторинга.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SummaryDescription">
+        <source>Summarize trace latency, span counts, and errors</source>
+        <target state="new">Summarize trace latency, span counts, and errors</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TelemetryArchiveNotFound">
+        <source>Telemetry archive file '{0}' was not found.</source>
+        <target state="new">Telemetry archive file '{0}' was not found.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TelemetryArchiveOptionDescription">
+        <source>Read telemetry from an Aspire export or profile archive instead of a running dashboard</source>
+        <target state="new">Read telemetry from an Aspire export or profile archive instead of a running dashboard</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TopMustBePositive">
+        <source>The --top value must be a positive number.</source>
+        <target state="new">The --top value must be a positive number.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TopOptionDescription">
+        <source>Maximum number of rows to display</source>
+        <target state="new">Maximum number of rows to display</target>
         <note />
       </trans-unit>
       <trans-unit id="TraceIdArgumentDescription">
@@ -210,6 +400,11 @@
       <trans-unit id="UnexpectedContentType">
         <source>Dashboard API returned unexpected content type '{0}'. Expected JSON response.</source>
         <target state="new">Dashboard API returned unexpected content type '{0}'. Expected JSON response.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WallTimeDescription">
+        <source>Analyze trace wall-clock time, span coverage, gaps, and overlap</source>
+        <target state="new">Analyze trace wall-clock time, span coverage, gaps, and overlap</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Aspire.Cli/Resources/xlf/TelemetryCommandStrings.tr.xlf
+++ b/src/Aspire.Cli/Resources/xlf/TelemetryCommandStrings.tr.xlf
@@ -107,6 +107,16 @@
         <target state="translated">Telemetri getirilemedi: {0}</target>
         <note />
       </trans-unit>
+      <trans-unit id="FailedToReadTelemetryArchive">
+        <source>Failed to read telemetry archive '{0}': {1}</source>
+        <target state="new">Failed to read telemetry archive '{0}': {1}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FileAndLiveOptionsExclusive">
+        <source>The --file option cannot be used with --dashboard-url, --api-key, or --apphost. Specify either an archive file or a live dashboard source.</source>
+        <target state="new">The --file option cannot be used with --dashboard-url, --api-key, or --apphost. Specify either an archive file or a live dashboard source.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="FollowOptionDescription">
         <source>Stream telemetry in real-time as it arrives</source>
         <target state="needs-review-translation">Telemetri geldikçe gerçek zamanlı olarak akışını yapın.</target>
@@ -117,9 +127,29 @@
         <target state="needs-review-translation">Çıktı biçimi (Tablo veya Json).</target>
         <note />
       </trans-unit>
+      <trans-unit id="GroupByOptionDescription">
+        <source>Group span statistics by Name or Resource</source>
+        <target state="new">Group span statistics by Name or Resource</target>
+        <note />
+      </trans-unit>
       <trans-unit id="HasErrorOptionDescription">
         <source>Filter by error status (true to show only errors, false to exclude errors)</source>
         <target state="needs-review-translation">Hata durumuna göre filtreleyin (yalnızca hataları göstermek için true, hataları hariç tutmak için false).</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HeaderAverage">
+        <source>Avg</source>
+        <target state="new">Avg</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HeaderCount">
+        <source>Count</source>
+        <target state="new">Count</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HeaderCovered">
+        <source>Covered</source>
+        <target state="new">Covered</target>
         <note />
       </trans-unit>
       <trans-unit id="HeaderDuration">
@@ -127,9 +157,59 @@
         <target state="translated">Süre</target>
         <note />
       </trans-unit>
+      <trans-unit id="HeaderErrors">
+        <source>Errors</source>
+        <target state="new">Errors</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HeaderGap">
+        <source>Gap</source>
+        <target state="new">Gap</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HeaderGroup">
+        <source>Group</source>
+        <target state="new">Group</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HeaderMax">
+        <source>Max</source>
+        <target state="new">Max</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HeaderMetric">
+        <source>Metric</source>
+        <target state="new">Metric</target>
+        <note />
+      </trans-unit>
       <trans-unit id="HeaderName">
         <source>Name</source>
         <target state="translated">Ad</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HeaderOverlap">
+        <source>Overlap</source>
+        <target state="new">Overlap</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HeaderP95">
+        <source>P95</source>
+        <target state="new">P95</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HeaderRatio">
+        <source>Ratio</source>
+        <target state="new">Ratio</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HeaderResource">
+        <source>Resource</source>
+        <target state="new">Resource</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HeaderSpanSum">
+        <source>Span sum</source>
+        <target state="new">Span sum</target>
         <note />
       </trans-unit>
       <trans-unit id="HeaderSpans">
@@ -147,6 +227,26 @@
         <target state="translated">Zaman damgası</target>
         <note />
       </trans-unit>
+      <trans-unit id="HeaderTotal">
+        <source>Total</source>
+        <target state="new">Total</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HeaderTraceId">
+        <source>Trace ID</source>
+        <target state="new">Trace ID</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HeaderValue">
+        <source>Value</source>
+        <target state="new">Value</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HeaderWallClock">
+        <source>Wall</source>
+        <target state="new">Wall</target>
+        <note />
+      </trans-unit>
       <trans-unit id="LimitMustBePositive">
         <source>The --limit value must be a positive number.</source>
         <target state="translated">--limit değeri, pozitif bir sayı olmalıdır.</target>
@@ -162,9 +262,64 @@
         <target state="needs-review-translation">Pano telemetri API'sinden yapılandırılmış günlükleri görüntüleyin.</target>
         <note />
       </trans-unit>
+      <trans-unit id="MetricAverageDuration">
+        <source>Average duration</source>
+        <target state="new">Average duration</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MetricErrorSpans">
+        <source>Error spans</source>
+        <target state="new">Error spans</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MetricErrorTraces">
+        <source>Error traces</source>
+        <target state="new">Error traces</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MetricMaxDuration">
+        <source>Max duration</source>
+        <target state="new">Max duration</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MetricP50Duration">
+        <source>P50 duration</source>
+        <target state="new">P50 duration</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MetricP95Duration">
+        <source>P95 duration</source>
+        <target state="new">P95 duration</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MetricP99Duration">
+        <source>P99 duration</source>
+        <target state="new">P99 duration</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MetricResources">
+        <source>Resources</source>
+        <target state="new">Resources</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MetricSpans">
+        <source>Spans</source>
+        <target state="new">Spans</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MetricTraces">
+        <source>Traces</source>
+        <target state="new">Traces</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ResourceArgumentDescription">
         <source>Filter by resource name</source>
         <target state="needs-review-translation">Kaynak adına göre filtreleyin.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourceNotFound">
+        <source>Resource '{0}' not found.</source>
+        <target state="new">Resource '{0}' not found.</target>
         <note />
       </trans-unit>
       <trans-unit id="SearchOptionDescription">
@@ -182,9 +337,44 @@
         <target state="needs-review-translation">Günlükleri en düşük önem derecesine göre filtreleyin (İzleme, Hata Ayıklama, Bilgi, Uyarı, Hata, Kritik).</target>
         <note />
       </trans-unit>
+      <trans-unit id="SlowTracesDescription">
+        <source>Show top traces by wall-clock duration</source>
+        <target state="new">Show top traces by wall-clock duration</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SpanStatsDescription">
+        <source>Aggregate span duration statistics</source>
+        <target state="new">Aggregate span duration statistics</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SpansDescription">
         <source>View spans from the Dashboard telemetry API</source>
         <target state="needs-review-translation">Pano telemetri API'sinden yayılmaları görüntüleyin.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SummaryDescription">
+        <source>Summarize trace latency, span counts, and errors</source>
+        <target state="new">Summarize trace latency, span counts, and errors</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TelemetryArchiveNotFound">
+        <source>Telemetry archive file '{0}' was not found.</source>
+        <target state="new">Telemetry archive file '{0}' was not found.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TelemetryArchiveOptionDescription">
+        <source>Read telemetry from an Aspire export or profile archive instead of a running dashboard</source>
+        <target state="new">Read telemetry from an Aspire export or profile archive instead of a running dashboard</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TopMustBePositive">
+        <source>The --top value must be a positive number.</source>
+        <target state="new">The --top value must be a positive number.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TopOptionDescription">
+        <source>Maximum number of rows to display</source>
+        <target state="new">Maximum number of rows to display</target>
         <note />
       </trans-unit>
       <trans-unit id="TraceIdArgumentDescription">
@@ -210,6 +400,11 @@
       <trans-unit id="UnexpectedContentType">
         <source>Dashboard API returned unexpected content type '{0}'. Expected JSON response.</source>
         <target state="new">Dashboard API returned unexpected content type '{0}'. Expected JSON response.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WallTimeDescription">
+        <source>Analyze trace wall-clock time, span coverage, gaps, and overlap</source>
+        <target state="new">Analyze trace wall-clock time, span coverage, gaps, and overlap</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Aspire.Cli/Resources/xlf/TelemetryCommandStrings.zh-Hans.xlf
+++ b/src/Aspire.Cli/Resources/xlf/TelemetryCommandStrings.zh-Hans.xlf
@@ -107,6 +107,16 @@
         <target state="translated">未能获取遥测数据: {0}</target>
         <note />
       </trans-unit>
+      <trans-unit id="FailedToReadTelemetryArchive">
+        <source>Failed to read telemetry archive '{0}': {1}</source>
+        <target state="new">Failed to read telemetry archive '{0}': {1}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FileAndLiveOptionsExclusive">
+        <source>The --file option cannot be used with --dashboard-url, --api-key, or --apphost. Specify either an archive file or a live dashboard source.</source>
+        <target state="new">The --file option cannot be used with --dashboard-url, --api-key, or --apphost. Specify either an archive file or a live dashboard source.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="FollowOptionDescription">
         <source>Stream telemetry in real-time as it arrives</source>
         <target state="needs-review-translation">在遥测数据到来时，将其实时流式传输。</target>
@@ -117,9 +127,29 @@
         <target state="needs-review-translation">输出格式(表格或 Json)。</target>
         <note />
       </trans-unit>
+      <trans-unit id="GroupByOptionDescription">
+        <source>Group span statistics by Name or Resource</source>
+        <target state="new">Group span statistics by Name or Resource</target>
+        <note />
+      </trans-unit>
       <trans-unit id="HasErrorOptionDescription">
         <source>Filter by error status (true to show only errors, false to exclude errors)</source>
         <target state="needs-review-translation">按错误状态筛选(true 表示仅显示错误，false 表示排除错误)。</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HeaderAverage">
+        <source>Avg</source>
+        <target state="new">Avg</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HeaderCount">
+        <source>Count</source>
+        <target state="new">Count</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HeaderCovered">
+        <source>Covered</source>
+        <target state="new">Covered</target>
         <note />
       </trans-unit>
       <trans-unit id="HeaderDuration">
@@ -127,9 +157,59 @@
         <target state="translated">持续时间</target>
         <note />
       </trans-unit>
+      <trans-unit id="HeaderErrors">
+        <source>Errors</source>
+        <target state="new">Errors</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HeaderGap">
+        <source>Gap</source>
+        <target state="new">Gap</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HeaderGroup">
+        <source>Group</source>
+        <target state="new">Group</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HeaderMax">
+        <source>Max</source>
+        <target state="new">Max</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HeaderMetric">
+        <source>Metric</source>
+        <target state="new">Metric</target>
+        <note />
+      </trans-unit>
       <trans-unit id="HeaderName">
         <source>Name</source>
         <target state="translated">名称</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HeaderOverlap">
+        <source>Overlap</source>
+        <target state="new">Overlap</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HeaderP95">
+        <source>P95</source>
+        <target state="new">P95</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HeaderRatio">
+        <source>Ratio</source>
+        <target state="new">Ratio</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HeaderResource">
+        <source>Resource</source>
+        <target state="new">Resource</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HeaderSpanSum">
+        <source>Span sum</source>
+        <target state="new">Span sum</target>
         <note />
       </trans-unit>
       <trans-unit id="HeaderSpans">
@@ -147,6 +227,26 @@
         <target state="translated">时间戳</target>
         <note />
       </trans-unit>
+      <trans-unit id="HeaderTotal">
+        <source>Total</source>
+        <target state="new">Total</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HeaderTraceId">
+        <source>Trace ID</source>
+        <target state="new">Trace ID</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HeaderValue">
+        <source>Value</source>
+        <target state="new">Value</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HeaderWallClock">
+        <source>Wall</source>
+        <target state="new">Wall</target>
+        <note />
+      </trans-unit>
       <trans-unit id="LimitMustBePositive">
         <source>The --limit value must be a positive number.</source>
         <target state="translated">--limit 值必须是正数。</target>
@@ -162,9 +262,64 @@
         <target state="needs-review-translation">查看仪表板遥测 API 中的结构化日志。</target>
         <note />
       </trans-unit>
+      <trans-unit id="MetricAverageDuration">
+        <source>Average duration</source>
+        <target state="new">Average duration</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MetricErrorSpans">
+        <source>Error spans</source>
+        <target state="new">Error spans</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MetricErrorTraces">
+        <source>Error traces</source>
+        <target state="new">Error traces</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MetricMaxDuration">
+        <source>Max duration</source>
+        <target state="new">Max duration</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MetricP50Duration">
+        <source>P50 duration</source>
+        <target state="new">P50 duration</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MetricP95Duration">
+        <source>P95 duration</source>
+        <target state="new">P95 duration</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MetricP99Duration">
+        <source>P99 duration</source>
+        <target state="new">P99 duration</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MetricResources">
+        <source>Resources</source>
+        <target state="new">Resources</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MetricSpans">
+        <source>Spans</source>
+        <target state="new">Spans</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MetricTraces">
+        <source>Traces</source>
+        <target state="new">Traces</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ResourceArgumentDescription">
         <source>Filter by resource name</source>
         <target state="needs-review-translation">按资源名称筛选。</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourceNotFound">
+        <source>Resource '{0}' not found.</source>
+        <target state="new">Resource '{0}' not found.</target>
         <note />
       </trans-unit>
       <trans-unit id="SearchOptionDescription">
@@ -182,9 +337,44 @@
         <target state="needs-review-translation">按最低严重级别(跟踪、调试、信息、警告、错误、严重)筛选日志。</target>
         <note />
       </trans-unit>
+      <trans-unit id="SlowTracesDescription">
+        <source>Show top traces by wall-clock duration</source>
+        <target state="new">Show top traces by wall-clock duration</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SpanStatsDescription">
+        <source>Aggregate span duration statistics</source>
+        <target state="new">Aggregate span duration statistics</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SpansDescription">
         <source>View spans from the Dashboard telemetry API</source>
         <target state="needs-review-translation">查看仪表板遥测 API 中的跨度。</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SummaryDescription">
+        <source>Summarize trace latency, span counts, and errors</source>
+        <target state="new">Summarize trace latency, span counts, and errors</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TelemetryArchiveNotFound">
+        <source>Telemetry archive file '{0}' was not found.</source>
+        <target state="new">Telemetry archive file '{0}' was not found.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TelemetryArchiveOptionDescription">
+        <source>Read telemetry from an Aspire export or profile archive instead of a running dashboard</source>
+        <target state="new">Read telemetry from an Aspire export or profile archive instead of a running dashboard</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TopMustBePositive">
+        <source>The --top value must be a positive number.</source>
+        <target state="new">The --top value must be a positive number.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TopOptionDescription">
+        <source>Maximum number of rows to display</source>
+        <target state="new">Maximum number of rows to display</target>
         <note />
       </trans-unit>
       <trans-unit id="TraceIdArgumentDescription">
@@ -210,6 +400,11 @@
       <trans-unit id="UnexpectedContentType">
         <source>Dashboard API returned unexpected content type '{0}'. Expected JSON response.</source>
         <target state="new">Dashboard API returned unexpected content type '{0}'. Expected JSON response.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WallTimeDescription">
+        <source>Analyze trace wall-clock time, span coverage, gaps, and overlap</source>
+        <target state="new">Analyze trace wall-clock time, span coverage, gaps, and overlap</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Aspire.Cli/Resources/xlf/TelemetryCommandStrings.zh-Hant.xlf
+++ b/src/Aspire.Cli/Resources/xlf/TelemetryCommandStrings.zh-Hant.xlf
@@ -107,6 +107,16 @@
         <target state="translated">無法擷取遙測: {0}</target>
         <note />
       </trans-unit>
+      <trans-unit id="FailedToReadTelemetryArchive">
+        <source>Failed to read telemetry archive '{0}': {1}</source>
+        <target state="new">Failed to read telemetry archive '{0}': {1}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FileAndLiveOptionsExclusive">
+        <source>The --file option cannot be used with --dashboard-url, --api-key, or --apphost. Specify either an archive file or a live dashboard source.</source>
+        <target state="new">The --file option cannot be used with --dashboard-url, --api-key, or --apphost. Specify either an archive file or a live dashboard source.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="FollowOptionDescription">
         <source>Stream telemetry in real-time as it arrives</source>
         <target state="needs-review-translation">在遙測抵達時即時串流遙測。</target>
@@ -117,9 +127,29 @@
         <target state="needs-review-translation">輸出格式 (資料表或 Json)。</target>
         <note />
       </trans-unit>
+      <trans-unit id="GroupByOptionDescription">
+        <source>Group span statistics by Name or Resource</source>
+        <target state="new">Group span statistics by Name or Resource</target>
+        <note />
+      </trans-unit>
       <trans-unit id="HasErrorOptionDescription">
         <source>Filter by error status (true to show only errors, false to exclude errors)</source>
         <target state="needs-review-translation">依錯誤狀態篩選 (true 以僅顯示錯誤，false 以排除錯誤)。</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HeaderAverage">
+        <source>Avg</source>
+        <target state="new">Avg</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HeaderCount">
+        <source>Count</source>
+        <target state="new">Count</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HeaderCovered">
+        <source>Covered</source>
+        <target state="new">Covered</target>
         <note />
       </trans-unit>
       <trans-unit id="HeaderDuration">
@@ -127,9 +157,59 @@
         <target state="translated">期間</target>
         <note />
       </trans-unit>
+      <trans-unit id="HeaderErrors">
+        <source>Errors</source>
+        <target state="new">Errors</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HeaderGap">
+        <source>Gap</source>
+        <target state="new">Gap</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HeaderGroup">
+        <source>Group</source>
+        <target state="new">Group</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HeaderMax">
+        <source>Max</source>
+        <target state="new">Max</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HeaderMetric">
+        <source>Metric</source>
+        <target state="new">Metric</target>
+        <note />
+      </trans-unit>
       <trans-unit id="HeaderName">
         <source>Name</source>
         <target state="translated">名稱</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HeaderOverlap">
+        <source>Overlap</source>
+        <target state="new">Overlap</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HeaderP95">
+        <source>P95</source>
+        <target state="new">P95</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HeaderRatio">
+        <source>Ratio</source>
+        <target state="new">Ratio</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HeaderResource">
+        <source>Resource</source>
+        <target state="new">Resource</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HeaderSpanSum">
+        <source>Span sum</source>
+        <target state="new">Span sum</target>
         <note />
       </trans-unit>
       <trans-unit id="HeaderSpans">
@@ -147,6 +227,26 @@
         <target state="translated">時間戳記</target>
         <note />
       </trans-unit>
+      <trans-unit id="HeaderTotal">
+        <source>Total</source>
+        <target state="new">Total</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HeaderTraceId">
+        <source>Trace ID</source>
+        <target state="new">Trace ID</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HeaderValue">
+        <source>Value</source>
+        <target state="new">Value</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HeaderWallClock">
+        <source>Wall</source>
+        <target state="new">Wall</target>
+        <note />
+      </trans-unit>
       <trans-unit id="LimitMustBePositive">
         <source>The --limit value must be a positive number.</source>
         <target state="translated">--limit 值必須是正數。</target>
@@ -162,9 +262,64 @@
         <target state="needs-review-translation">從儀表板遙測 API 檢視結構化記錄。</target>
         <note />
       </trans-unit>
+      <trans-unit id="MetricAverageDuration">
+        <source>Average duration</source>
+        <target state="new">Average duration</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MetricErrorSpans">
+        <source>Error spans</source>
+        <target state="new">Error spans</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MetricErrorTraces">
+        <source>Error traces</source>
+        <target state="new">Error traces</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MetricMaxDuration">
+        <source>Max duration</source>
+        <target state="new">Max duration</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MetricP50Duration">
+        <source>P50 duration</source>
+        <target state="new">P50 duration</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MetricP95Duration">
+        <source>P95 duration</source>
+        <target state="new">P95 duration</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MetricP99Duration">
+        <source>P99 duration</source>
+        <target state="new">P99 duration</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MetricResources">
+        <source>Resources</source>
+        <target state="new">Resources</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MetricSpans">
+        <source>Spans</source>
+        <target state="new">Spans</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MetricTraces">
+        <source>Traces</source>
+        <target state="new">Traces</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ResourceArgumentDescription">
         <source>Filter by resource name</source>
         <target state="needs-review-translation">依資源名稱篩選。</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourceNotFound">
+        <source>Resource '{0}' not found.</source>
+        <target state="new">Resource '{0}' not found.</target>
         <note />
       </trans-unit>
       <trans-unit id="SearchOptionDescription">
@@ -182,9 +337,44 @@
         <target state="needs-review-translation">依最低嚴重性篩選記錄 (追蹤、偵錯、資訊、警告、錯誤、重大)。</target>
         <note />
       </trans-unit>
+      <trans-unit id="SlowTracesDescription">
+        <source>Show top traces by wall-clock duration</source>
+        <target state="new">Show top traces by wall-clock duration</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SpanStatsDescription">
+        <source>Aggregate span duration statistics</source>
+        <target state="new">Aggregate span duration statistics</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SpansDescription">
         <source>View spans from the Dashboard telemetry API</source>
         <target state="needs-review-translation">從儀表板遙測 API 檢視範圍。</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SummaryDescription">
+        <source>Summarize trace latency, span counts, and errors</source>
+        <target state="new">Summarize trace latency, span counts, and errors</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TelemetryArchiveNotFound">
+        <source>Telemetry archive file '{0}' was not found.</source>
+        <target state="new">Telemetry archive file '{0}' was not found.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TelemetryArchiveOptionDescription">
+        <source>Read telemetry from an Aspire export or profile archive instead of a running dashboard</source>
+        <target state="new">Read telemetry from an Aspire export or profile archive instead of a running dashboard</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TopMustBePositive">
+        <source>The --top value must be a positive number.</source>
+        <target state="new">The --top value must be a positive number.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TopOptionDescription">
+        <source>Maximum number of rows to display</source>
+        <target state="new">Maximum number of rows to display</target>
         <note />
       </trans-unit>
       <trans-unit id="TraceIdArgumentDescription">
@@ -210,6 +400,11 @@
       <trans-unit id="UnexpectedContentType">
         <source>Dashboard API returned unexpected content type '{0}'. Expected JSON response.</source>
         <target state="new">Dashboard API returned unexpected content type '{0}'. Expected JSON response.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WallTimeDescription">
+        <source>Analyze trace wall-clock time, span coverage, gaps, and overlap</source>
+        <target state="new">Analyze trace wall-clock time, span coverage, gaps, and overlap</target>
         <note />
       </trans-unit>
     </body>

--- a/tests/Aspire.Cli.Tests/Commands/TelemetryAnalysisCommandTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/TelemetryAnalysisCommandTests.cs
@@ -1,0 +1,278 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.IO.Compression;
+using System.Net;
+using System.Text.Json;
+using Aspire.Cli.Commands;
+using Aspire.Cli.Interaction;
+using Aspire.Cli.Tests.TestServices;
+using Aspire.Cli.Tests.Utils;
+using Aspire.Otlp.Serialization;
+using Microsoft.AspNetCore.InternalTesting;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+
+namespace Aspire.Cli.Tests.Commands;
+
+public class TelemetryAnalysisCommandTests(ITestOutputHelper outputHelper)
+{
+    private static readonly DateTime s_testTime = TelemetryTestHelper.s_testTime;
+
+    [Fact]
+    public async Task TelemetrySummaryCommand_WithDashboardUrl_ReturnsJsonSummary()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        var interactionService = new TestInteractionService();
+        var responseJson = BuildTelemetryApiResponse(
+            CreateResourceSpans("frontend", null,
+                CreateSpan("trace1", "span1", "GET /frontend", 0, 100)),
+            CreateResourceSpans("backend", null,
+                CreateSpan("trace1", "span2", "GET /backend", 10, 60, parentSpanId: "span1"),
+                CreateSpan("trace2", "span3", "GET /error", 200, 250, hasError: true)));
+
+        using var provider = CreateDashboardProvider(workspace, interactionService, responseJson);
+        var command = provider.GetRequiredService<RootCommand>();
+        var result = command.Parse("otel summary --dashboard-url http://localhost:18888 --format json");
+
+        var exitCode = await result.InvokeAsync().DefaultTimeout();
+
+        Assert.Equal(CliExitCodes.Success, exitCode);
+        var (json, consoleOutput) = Assert.Single(interactionService.DisplayedRawText);
+        Assert.Equal(ConsoleOutput.Standard, consoleOutput);
+
+        using var document = JsonDocument.Parse(json);
+        var root = document.RootElement;
+        Assert.Equal(2, root.GetProperty("resourceCount").GetInt32());
+        Assert.Equal(2, root.GetProperty("traceCount").GetInt32());
+        Assert.Equal(3, root.GetProperty("spanCount").GetInt32());
+        Assert.Equal(1, root.GetProperty("errorTraceCount").GetInt32());
+        Assert.Equal(1, root.GetProperty("errorSpanCount").GetInt32());
+        Assert.Equal(75, root.GetProperty("averageDurationMs").GetDouble());
+        Assert.Equal(100, root.GetProperty("p95DurationMs").GetDouble());
+    }
+
+    [Fact]
+    public async Task TelemetrySlowTracesCommand_WithArchive_StitchesTraceAcrossResources()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        var interactionService = new TestInteractionService();
+        var archivePath = CreateTelemetryArchive(workspace,
+            ("traces/frontend.json", CreateTelemetryData(CreateResourceSpans("frontend", null,
+                CreateSpan("trace1", "span1", "GET /frontend", 0, 100)))),
+            ("traces/backend.json", CreateTelemetryData(CreateResourceSpans("backend", null,
+                CreateSpan("trace1", "span2", "GET /backend", 20, 80, parentSpanId: "span1")))));
+
+        using var provider = CreateArchiveProvider(workspace, interactionService);
+        var command = provider.GetRequiredService<RootCommand>();
+        var result = command.Parse($"otel top-traces --file \"{archivePath}\" --format json");
+
+        var exitCode = await result.InvokeAsync().DefaultTimeout();
+
+        Assert.Equal(CliExitCodes.Success, exitCode);
+        var (json, _) = Assert.Single(interactionService.DisplayedRawText);
+
+        using var document = JsonDocument.Parse(json);
+        var trace = Assert.Single(document.RootElement.EnumerateArray());
+        Assert.Equal("trace1", trace.GetProperty("traceId").GetString());
+        Assert.Equal("GET /frontend", trace.GetProperty("name").GetString());
+        Assert.Equal("frontend", trace.GetProperty("resource").GetString());
+        Assert.Equal(2, trace.GetProperty("spanCount").GetInt32());
+        Assert.Equal(100, trace.GetProperty("durationMs").GetDouble());
+    }
+
+    [Fact]
+    public async Task TelemetryWallTimeCommand_WithArchive_ReportsWallClockWorkAndGaps()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        var interactionService = new TestInteractionService();
+        var archivePath = CreateTelemetryArchive(workspace,
+            ("traces/frontend.json", CreateTelemetryData(CreateResourceSpans("frontend", null,
+                CreateSpan("trace-with-gap", "span1", "GET /frontend", 0, 40),
+                CreateSpan("trace-with-gap", "span2", "GET /database", 160, 200, parentSpanId: "span1"),
+                CreateSpan("trace-overlap", "span3", "GET /frontend", 0, 100)))),
+            ("traces/backend.json", CreateTelemetryData(CreateResourceSpans("backend", null,
+                CreateSpan("trace-overlap", "span4", "GET /backend", 20, 80, parentSpanId: "span3")))));
+
+        using var provider = CreateArchiveProvider(workspace, interactionService);
+        var command = provider.GetRequiredService<RootCommand>();
+        var result = command.Parse($"otel wall-time --file \"{archivePath}\" --format json --top 2");
+
+        var exitCode = await result.InvokeAsync().DefaultTimeout();
+
+        Assert.Equal(CliExitCodes.Success, exitCode);
+        var (json, _) = Assert.Single(interactionService.DisplayedRawText);
+
+        using var document = JsonDocument.Parse(json);
+        var rows = document.RootElement.EnumerateArray().ToArray();
+        Assert.Equal(2, rows.Length);
+
+        Assert.Equal("trace-with-gap", rows[0].GetProperty("traceId").GetString());
+        Assert.Equal(200, rows[0].GetProperty("wallClockMs").GetDouble());
+        Assert.Equal(80, rows[0].GetProperty("spanSumMs").GetDouble());
+        Assert.Equal(80, rows[0].GetProperty("coveredMs").GetDouble());
+        Assert.Equal(120, rows[0].GetProperty("gapMs").GetDouble());
+        Assert.Equal(0, rows[0].GetProperty("overlapMs").GetDouble());
+        Assert.Equal(0.4, rows[0].GetProperty("spanSumToWallRatio").GetDouble());
+
+        Assert.Equal("trace-overlap", rows[1].GetProperty("traceId").GetString());
+        Assert.Equal(100, rows[1].GetProperty("wallClockMs").GetDouble());
+        Assert.Equal(160, rows[1].GetProperty("spanSumMs").GetDouble());
+        Assert.Equal(100, rows[1].GetProperty("coveredMs").GetDouble());
+        Assert.Equal(0, rows[1].GetProperty("gapMs").GetDouble());
+        Assert.Equal(60, rows[1].GetProperty("overlapMs").GetDouble());
+        Assert.Equal(1.6, rows[1].GetProperty("spanSumToWallRatio").GetDouble());
+    }
+
+    [Fact]
+    public async Task TelemetrySpanStatsCommand_WithArchive_GroupsByResource()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        var interactionService = new TestInteractionService();
+        var archivePath = CreateTelemetryArchive(workspace,
+            ("traces/frontend.json", CreateTelemetryData(CreateResourceSpans("frontend", null,
+                CreateSpan("trace1", "span1", "GET /frontend", 0, 100)))),
+            ("traces/backend.json", CreateTelemetryData(CreateResourceSpans("backend", null,
+                CreateSpan("trace1", "span2", "GET /backend", 20, 80, parentSpanId: "span1")))));
+
+        using var provider = CreateArchiveProvider(workspace, interactionService);
+        var command = provider.GetRequiredService<RootCommand>();
+        var result = command.Parse($"otel span-stats --file \"{archivePath}\" --group-by resource --format json");
+
+        var exitCode = await result.InvokeAsync().DefaultTimeout();
+
+        Assert.Equal(CliExitCodes.Success, exitCode);
+        var (json, _) = Assert.Single(interactionService.DisplayedRawText);
+
+        using var document = JsonDocument.Parse(json);
+        var rows = document.RootElement.EnumerateArray().ToArray();
+        Assert.Equal(2, rows.Length);
+        Assert.Equal("frontend", rows[0].GetProperty("group").GetString());
+        Assert.Equal(100, rows[0].GetProperty("totalDurationMs").GetDouble());
+        Assert.Equal("backend", rows[1].GetProperty("group").GetString());
+        Assert.Equal(60, rows[1].GetProperty("totalDurationMs").GetDouble());
+    }
+
+    private ServiceProvider CreateDashboardProvider(TemporaryWorkspace workspace, TestInteractionService interactionService, string tracesJson)
+    {
+        var resources =
+            """
+            [
+              { "name": "backend" },
+              { "name": "frontend" }
+            ]
+            """;
+        var handler = new MockHttpMessageHandler(request =>
+        {
+            var url = request.RequestUri!.ToString();
+            if (url.Contains("/api/telemetry/resources", StringComparison.Ordinal))
+            {
+                return new HttpResponseMessage(HttpStatusCode.OK)
+                {
+                    Content = new StringContent(resources, System.Text.Encoding.UTF8, "application/json")
+                };
+            }
+
+            if (url.Contains("/api/telemetry/traces", StringComparison.Ordinal))
+            {
+                return new HttpResponseMessage(HttpStatusCode.OK)
+                {
+                    Content = new StringContent(tracesJson, System.Text.Encoding.UTF8, "application/json")
+                };
+            }
+
+            return new HttpResponseMessage(HttpStatusCode.NotFound);
+        });
+
+        var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper, options =>
+        {
+            options.InteractionServiceFactory = _ => interactionService;
+        });
+        services.AddSingleton(handler);
+        services.Replace(ServiceDescriptor.Singleton<IHttpClientFactory>(new MockHttpClientFactory(handler)));
+
+        return services.BuildServiceProvider();
+    }
+
+    private ServiceProvider CreateArchiveProvider(TemporaryWorkspace workspace, TestInteractionService interactionService)
+    {
+        var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper, options =>
+        {
+            options.InteractionServiceFactory = _ => interactionService;
+        });
+
+        return services.BuildServiceProvider();
+    }
+
+    private static string CreateTelemetryArchive(TemporaryWorkspace workspace, params (string EntryName, OtlpTelemetryDataJson Data)[] entries)
+    {
+        var path = Path.Combine(workspace.WorkspaceRoot.FullName, "telemetry.zip");
+        using var fileStream = File.Create(path);
+        using var archive = new ZipArchive(fileStream, ZipArchiveMode.Create);
+
+        foreach (var (entryName, data) in entries)
+        {
+            var entry = archive.CreateEntry(entryName);
+            using var entryStream = entry.Open();
+            JsonSerializer.Serialize(entryStream, data, OtlpJsonSerializerContext.Default.OtlpTelemetryDataJson);
+        }
+
+        return path;
+    }
+
+    private static string BuildTelemetryApiResponse(params OtlpResourceSpansJson[] resourceSpans)
+    {
+        var response = new TelemetryApiResponse
+        {
+            Data = CreateTelemetryData(resourceSpans),
+            TotalCount = resourceSpans.SelectMany(rs => rs.ScopeSpans ?? []).SelectMany(ss => ss.Spans ?? []).Select(s => s.TraceId).Distinct().Count(),
+            ReturnedCount = resourceSpans.Length
+        };
+
+        return JsonSerializer.Serialize(response, OtlpJsonSerializerContext.Default.TelemetryApiResponse);
+    }
+
+    private static OtlpTelemetryDataJson CreateTelemetryData(params OtlpResourceSpansJson[] resourceSpans)
+    {
+        return new OtlpTelemetryDataJson
+        {
+            ResourceSpans = resourceSpans
+        };
+    }
+
+    private static OtlpResourceSpansJson CreateResourceSpans(string serviceName, string? instanceId, params OtlpSpanJson[] spans)
+    {
+        return new OtlpResourceSpansJson
+        {
+            Resource = TelemetryTestHelper.CreateOtlpResource(serviceName, instanceId),
+            ScopeSpans =
+            [
+                new OtlpScopeSpansJson
+                {
+                    Spans = spans
+                }
+            ]
+        };
+    }
+
+    private static OtlpSpanJson CreateSpan(
+        string traceId,
+        string spanId,
+        string name,
+        int startMs,
+        int endMs,
+        bool hasError = false,
+        string? parentSpanId = null)
+    {
+        return new OtlpSpanJson
+        {
+            TraceId = traceId,
+            SpanId = spanId,
+            ParentSpanId = parentSpanId,
+            Name = name,
+            StartTimeUnixNano = TelemetryTestHelper.DateTimeToUnixNanoseconds(s_testTime.AddMilliseconds(startMs)),
+            EndTimeUnixNano = TelemetryTestHelper.DateTimeToUnixNanoseconds(s_testTime.AddMilliseconds(endMs)),
+            Status = new OtlpSpanStatusJson { Code = hasError ? 2 : 1 }
+        };
+    }
+}

--- a/tests/Aspire.Cli.Tests/Utils/CliTestHelper.cs
+++ b/tests/Aspire.Cli.Tests/Utils/CliTestHelper.cs
@@ -232,9 +232,14 @@ internal static class CliTestHelper
         services.AddTransient<AgentInitCommand>();
         services.AddSingleton<ResourceColorMap>();
         services.AddTransient<TelemetryCommand>();
+        services.AddTransient<TelemetryAnalysisDataSource>();
         services.AddTransient<TelemetryLogsCommand>();
         services.AddTransient<TelemetrySpansCommand>();
         services.AddTransient<TelemetryTracesCommand>();
+        services.AddTransient<TelemetrySummaryCommand>();
+        services.AddTransient<TelemetrySlowTracesCommand>();
+        services.AddTransient<TelemetryWallTimeCommand>();
+        services.AddTransient<TelemetrySpanStatsCommand>();
         services.AddTransient<ExportCommand>();
         services.AddTransient<ExtensionInternalCommand>();
         services.AddTransient<WaitCommand>();


### PR DESCRIPTION
## Description

Aspire already exposes raw OpenTelemetry logs, spans, and traces through the CLI, but quick performance investigations still require users to manually inspect telemetry or export data into another tool. This adds first-pass `aspire otel` analysis commands that answer common latency questions directly from either a live dashboard or a saved Aspire export/profile archive.

The new commands are:

```bash
aspire otel summary [resource] [--file telemetry.zip] [--format json]
aspire otel top-traces [resource] [--file telemetry.zip] [--top 20] [--format json]
aspire otel wall-time [resource] [--file telemetry.zip] [--top 20] [--format json]
aspire otel span-stats [resource] [--file telemetry.zip] [--group-by name|resource] [--top 20] [--format json]
```

They default to analyzing the live dashboard telemetry API and use `--file` to analyze exported telemetry offline. Archive analysis merges all `traces/*.json` entries before grouping by trace ID so traces that cross resources are analyzed as complete traces. `wall-time` reports trace wall-clock duration plus span interval coverage, gaps, overlap, and span-sum ratio without implying CPU utilization.

Command help:

```text
Commands:
  logs <resource>        View structured logs from the Dashboard telemetry API
  spans <resource>       View spans from the Dashboard telemetry API
  traces <resource>      View traces from the Dashboard telemetry API
  summary <resource>     Summarize trace latency, span counts, and errors
  top-traces <resource>  Show top traces by wall-clock duration
  wall-time <resource>   Analyze trace wall-clock time, span coverage, gaps, and overlap
  span-stats <resource>  Aggregate span duration statistics
```

Sample output from an archive:

```text
$ aspire otel summary --file telemetry.zip
┌──────────────────┬───────┐
│ Metric           │ Value │
├──────────────────┼───────┤
│ Resources        │ 2     │
│ Traces           │ 3     │
│ Spans            │ 4     │
│ Error traces     │ 1     │
│ Error spans      │ 1     │
│ Average duration │ 0.15s │
│ P50 duration     │ 0.15s │
│ P95 duration     │ 0.2s  │
│ P99 duration     │ 0.2s  │
│ Max duration     │ 0.2s  │
└──────────────────┴───────┘
```

```text
$ aspire otel top-traces --file telemetry.zip --top 3
┌──────────┬───────┬────────┬──────────┬────────────────┬──────────┐
│ Duration │ Spans │ Status │ Resource │ Name           │ Trace ID │
├──────────┼───────┼────────┼──────────┼────────────────┼──────────┤
│ 0.2s     │ 2     │ OK     │ frontend │ GET /checkout  │ aaaaaaa  │
│ 0.15s    │ 1     │ ERR    │ backend  │ GET /inventory │ ccccccc  │
│ 0.1s     │ 1     │ OK     │ frontend │ GET /products  │ bbbbbbb  │
└──────────┴───────┴────────┴──────────┴────────────────┴──────────┘
```

```text
$ aspire otel wall-time --file telemetry.zip --top 3
┌───────┬──────────┬─────────┬─────┬─────────┬───────┬───────┬────────┬──────────┬────────────────┬──────────┐
│ Wall  │ Span sum │ Covered │ Gap │ Overlap │ Ratio │ Spans │ Status │ Resource │ Name           │ Trace ID │
├───────┼──────────┼─────────┼─────┼─────────┼───────┼───────┼────────┼──────────┼────────────────┼──────────┤
│ 0.2s  │ 0.32s    │ 0.2s    │ 0μs │ 0.12s   │ 1.6x  │ 2     │ OK     │ frontend │ GET /checkout  │ aaaaaaa  │
│ 0.15s │ 0.15s    │ 0.15s   │ 0μs │ 0μs     │ 1x    │ 1     │ ERR    │ backend  │ GET /inventory │ ccccccc  │
│ 0.1s  │ 0.1s     │ 0.1s    │ 0μs │ 0μs     │ 1x    │ 1     │ OK     │ frontend │ GET /products  │ bbbbbbb  │
└───────┴──────────┴─────────┴─────┴─────────┴───────┴───────┴────────┴──────────┴────────────────┴──────────┘
```

```text
$ aspire otel span-stats --file telemetry.zip --group-by resource --top 3
┌──────────┬───────┬────────┬───────┬───────┬───────┬───────┐
│ Group    │ Count │ Errors │ Avg   │ P95   │ Max   │ Total │
├──────────┼───────┼────────┼───────┼───────┼───────┼───────┤
│ frontend │ 2     │ 0      │ 0.15s │ 0.2s  │ 0.2s  │ 0.3s  │
│ backend  │ 2     │ 1      │ 0.14s │ 0.15s │ 0.15s │ 0.27s │
└──────────┴───────┴────────┴───────┴───────┴───────┴───────┘
```

Validation:

- `dotnet build src/Aspire.Cli/Aspire.Cli.csproj /p:SkipNativeBuild=true --no-restore`
- `dotnet test --project tests/Aspire.Cli.Tests/Aspire.Cli.Tests.csproj --no-launch-profile -- --filter-class "*.TelemetryCommandTests" --filter-class "*.TelemetryAnalysisCommandTests" --filter-not-trait "quarantined=true" --filter-not-trait "outerloop=true"`
- Generated `otel --help` output for the new command names.

Fixes # (issue)

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No