### PR TITLE
Honor AsExisting() on AddAzureContainerAppEnvironment + add WithAcrPullIdentity

### DIFF
--- a/src/Aspire.Hosting.Azure.AppContainers/AzureContainerAppEnvironmentAcrPullIdentityAnnotation.cs
+++ b/src/Aspire.Hosting.Azure.AppContainers/AzureContainerAppEnvironmentAcrPullIdentityAnnotation.cs
@@ -1,0 +1,21 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Aspire.Hosting.ApplicationModel;
+
+namespace Aspire.Hosting.Azure;
+
+/// <summary>
+/// Indicates that an <see cref="AppContainers.AzureContainerAppEnvironmentResource"/> should use the supplied
+/// <see cref="AzureUserAssignedIdentityResource"/> as the identity that holds the <c>AcrPull</c> role on the
+/// configured container registry, instead of having Aspire create a new identity and a new <c>AcrPull</c>
+/// role assignment.
+/// </summary>
+/// <param name="identity">The user-assigned identity resource to use for the <c>AcrPull</c> role.</param>
+internal sealed class AzureContainerAppEnvironmentAcrPullIdentityAnnotation(AzureUserAssignedIdentityResource identity) : IResourceAnnotation
+{
+    /// <summary>
+    /// Gets the user-assigned identity resource that holds the <c>AcrPull</c> role.
+    /// </summary>
+    public AzureUserAssignedIdentityResource Identity { get; } = identity;
+}

--- a/src/Aspire.Hosting.Azure.AppContainers/AzureContainerAppExtensions.cs
+++ b/src/Aspire.Hosting.Azure.AppContainers/AzureContainerAppExtensions.cs
@@ -722,7 +722,7 @@ public static class AzureContainerAppExtensions
     /// </para>
     /// </remarks>
     /// <exception cref="ArgumentNullException">Thrown when <paramref name="builder"/> or <paramref name="identityBuilder"/> is <see langword="null"/>.</exception>
-    [AspireExport(Description = "Configures the container app environment to use a specific user-assigned managed identity for the AcrPull role on the container registry")]
+    [AspireExport]
     public static IResourceBuilder<AzureContainerAppEnvironmentResource> WithAcrPullIdentity(
         this IResourceBuilder<AzureContainerAppEnvironmentResource> builder,
         IResourceBuilder<AzureUserAssignedIdentityResource> identityBuilder)

--- a/src/Aspire.Hosting.Azure.AppContainers/AzureContainerAppExtensions.cs
+++ b/src/Aspire.Hosting.Azure.AppContainers/AzureContainerAppExtensions.cs
@@ -479,6 +479,15 @@ public static class AzureContainerAppExtensions
                 "WithDelegatedSubnet call or stop marking the environment as existing.");
         }
 
+        if (appEnvResource.HasAnnotationOfType<AzureLogAnalyticsWorkspaceReferenceAnnotation>())
+        {
+            throw new InvalidOperationException(
+                $"The Azure Container App Environment '{appEnvResource.Name}' is marked as existing but is also " +
+                "configured with a Log Analytics workspace via WithAzureLogAnalyticsWorkspace. The existing managed " +
+                "environment already owns its Log Analytics workspace and Aspire cannot reconfigure it. Remove the " +
+                "WithAzureLogAnalyticsWorkspace call or stop marking the environment as existing.");
+        }
+
         // This tells azd to avoid creating infrastructure.
         var userPrincipalId = new ProvisioningParameter(AzureBicepResource.KnownParameters.UserPrincipalId, typeof(string)) { Value = new BicepValue<string>(string.Empty) };
         infra.Add(userPrincipalId);

--- a/src/Aspire.Hosting.Azure.AppContainers/AzureContainerAppExtensions.cs
+++ b/src/Aspire.Hosting.Azure.AppContainers/AzureContainerAppExtensions.cs
@@ -725,10 +725,27 @@ public static class AzureContainerAppExtensions
     /// </para>
     /// <para>
     /// This is commonly combined with <c>AsExisting</c> on the environment and on the container registry to deploy
-    /// container apps into a pre-provisioned set of Azure resources without granting the deployment principal
-    /// permission to create new identities or role assignments. See
-    /// <see href="https://github.com/microsoft/aspire/issues/12977"/> for the scenario this addresses.
+    /// container apps into a pre-provisioned set of Azure resources without Aspire emitting any new identity or
+    /// role-assignment resources. See <see href="https://github.com/microsoft/aspire/issues/12977"/> for the
+    /// scenario this addresses.
     /// </para>
+    /// <para>
+    /// Only the combination of an existing environment, an existing container registry, and this method avoids
+    /// emitting any new identity or role-assignment resources in the env module. Other combinations still work but
+    /// will emit additional resources:
+    /// </para>
+    /// <list type="bullet">
+    ///   <item><description>
+    ///   If the environment is marked <c>AsExisting</c> but no identity is supplied here, Aspire still emits a new
+    ///   <c>UserAssignedIdentity</c> and an <c>AcrPull</c> role assignment on the configured registry.
+    ///   </description></item>
+    ///   <item><description>
+    ///   If this method is used but the container registry is not existing (either the Aspire-generated default
+    ///   registry or a user-added registry without <c>AsExisting</c>), the registry itself is still provisioned.
+    ///   To wire the supplied identity to that newly-created registry, chain
+    ///   <c>.WithRoleAssignments(acr, ContainerRegistryBuiltInRole.AcrPull)</c> on the identity.
+    ///   </description></item>
+    /// </list>
     /// </remarks>
     /// <exception cref="ArgumentNullException">Thrown when <paramref name="builder"/> or <paramref name="identityBuilder"/> is <see langword="null"/>.</exception>
     [AspireExport]

--- a/src/Aspire.Hosting.Azure.AppContainers/AzureContainerAppExtensions.cs
+++ b/src/Aspire.Hosting.Azure.AppContainers/AzureContainerAppExtensions.cs
@@ -107,6 +107,17 @@ public static class AzureContainerAppExtensions
         {
             var appEnvResource = (AzureContainerAppEnvironmentResource)infra.AspireResource;
 
+            // When the user has marked this environment as existing (via AsExisting / PublishAsExisting),
+            // we must not generate a brand-new managed environment + Log Analytics + Dashboard. Instead,
+            // emit a thin module that references the existing environment and still wires up the ACR pull
+            // identity that newly-deployed container apps in the env will need.
+            // See https://github.com/microsoft/aspire/issues/12977.
+            if (appEnvResource.IsExisting())
+            {
+                ConfigureExistingContainerAppEnvironmentInfrastructure(infra, appEnvResource);
+                return;
+            }
+
             // This tells azd to avoid creating infrastructure
             var userPrincipalId = new ProvisioningParameter(AzureBicepResource.KnownParameters.UserPrincipalId, typeof(string)) { Value = new BicepValue<string>(string.Empty) };
             infra.Add(userPrincipalId);
@@ -128,12 +139,27 @@ public static class AzureContainerAppExtensions
                 infra.Add(resourceToken);
             }
 
-            var identity = new UserAssignedIdentity(Infrastructure.NormalizeBicepIdentifier($"{appEnvResource.Name}_mi"))
-            {
-                Tags = tags
-            };
+            UserAssignedIdentity? newIdentity = null;
+            BicepValue<string> managedIdentityIdOutputValue;
 
-            infra.Add(identity);
+            if (appEnvResource.TryGetLastAnnotation<AzureContainerAppEnvironmentAcrPullIdentityAnnotation>(out var identityAnnotation))
+            {
+                // The user has supplied an existing identity (commonly via AddAzureUserAssignedIdentity +
+                // .WithRoleAssignments(acr, AcrPull)). Skip creating env_mi + the AcrPull role assignment
+                // here and have the env module read the identity id from a parameter wired to the identity
+                // module's "id" output.
+                managedIdentityIdOutputValue = identityAnnotation.Identity.Id.AsProvisioningParameter(infra);
+            }
+            else
+            {
+                newIdentity = new UserAssignedIdentity(Infrastructure.NormalizeBicepIdentifier($"{appEnvResource.Name}_mi"))
+                {
+                    Tags = tags
+                };
+
+                infra.Add(newIdentity);
+                managedIdentityIdOutputValue = newIdentity.Id.ToBicepExpression();
+            }
 
             AzureProvisioningResource? registry = null;
             if (appEnvResource.TryGetLastAnnotation<ContainerRegistryReferenceAnnotation>(out var registryReferenceAnnotation) &&
@@ -154,11 +180,14 @@ public static class AzureContainerAppExtensions
             var containerRegistry = (ContainerRegistryService)registry.AddAsExistingResource(infra);
             infra.Add(containerRegistry);
 
-            var pullRa = containerRegistry.CreateRoleAssignment(ContainerRegistryBuiltInRole.AcrPull, identity);
+            if (newIdentity is not null)
+            {
+                var pullRa = containerRegistry.CreateRoleAssignment(ContainerRegistryBuiltInRole.AcrPull, newIdentity);
 
-            // There's a bug in the CDK, see https://github.com/Azure/azure-sdk-for-net/issues/47265
-            pullRa.Name = BicepFunction.CreateGuid(containerRegistry.Id, identity.Id, pullRa.RoleDefinitionId);
-            infra.Add(pullRa);
+                // There's a bug in the CDK, see https://github.com/Azure/azure-sdk-for-net/issues/47265
+                pullRa.Name = BicepFunction.CreateGuid(containerRegistry.Id, newIdentity.Id, pullRa.RoleDefinitionId);
+                infra.Add(pullRa);
+            }
 
             OperationalInsightsWorkspace? laWorkspace = null;
             if (appEnvResource.TryGetLastAnnotation<AzureLogAnalyticsWorkspaceReferenceAnnotation>(out var logAnalyticsReferenceAnnotation) && logAnalyticsReferenceAnnotation.Workspace is AzureProvisioningResource workspace)
@@ -341,7 +370,7 @@ public static class AzureContainerAppExtensions
             {
                 Debug.Assert(resourceToken is not null);
 
-                identity.Name = BicepFunction.Interpolate($"mi-{resourceToken}");
+                newIdentity?.Name = BicepFunction.Interpolate($"mi-{resourceToken}");
                 containerRegistry.Name = new FunctionCallExpression(
                     new IdentifierExpression("replace"),
                     new InterpolatedStringExpression([
@@ -392,38 +421,7 @@ public static class AzureContainerAppExtensions
                 Value = laWorkspace.Id.ToBicepExpression()
             });
 
-            // Required by the IContaineRegistry interface
-            infra.Add(new ProvisioningOutput("AZURE_CONTAINER_REGISTRY_NAME", typeof(string))
-            {
-                Value = containerRegistry.Name.ToBicepExpression()
-            });
-
-            infra.Add(new ProvisioningOutput("AZURE_CONTAINER_REGISTRY_ENDPOINT", typeof(string))
-            {
-                Value = containerRegistry.LoginServer.ToBicepExpression()
-            });
-
-            // Required by the IAzureContainerRegistry interface
-            infra.Add(new ProvisioningOutput("AZURE_CONTAINER_REGISTRY_MANAGED_IDENTITY_ID", typeof(string))
-            {
-                Value = identity.Id.ToBicepExpression()
-            });
-
-            infra.Add(new ProvisioningOutput("AZURE_CONTAINER_APPS_ENVIRONMENT_NAME", typeof(string))
-            {
-                Value = containerAppEnvironment.Name.ToBicepExpression()
-            });
-
-            infra.Add(new ProvisioningOutput("AZURE_CONTAINER_APPS_ENVIRONMENT_ID", typeof(string))
-            {
-                Value = containerAppEnvironment.Id.ToBicepExpression()
-            });
-
-            // Required for azd to output the dashboard URL
-            infra.Add(new ProvisioningOutput("AZURE_CONTAINER_APPS_ENVIRONMENT_DEFAULT_DOMAIN", typeof(string))
-            {
-                Value = containerAppEnvironment.DefaultDomain.ToBicepExpression()
-            });
+            AddSharedContainerAppEnvironmentOutputs(infra, containerRegistry, containerAppEnvironment, managedIdentityIdOutputValue);
         });
 
         // Create the default container registry resource before creating the environment
@@ -439,6 +437,157 @@ public static class AzureContainerAppExtensions
             : builder.AddResource(containerAppEnvResource);
 
         return appEnvBuilder;
+    }
+
+    /// <summary>
+    /// Configures the Bicep infrastructure for an <see cref="AzureContainerAppEnvironmentResource"/> that has been
+    /// marked as existing (e.g. via <c>AsExisting</c> / <c>PublishAsExisting</c>). Only emits a reference to the
+    /// existing managed environment and the small set of supporting resources that newly-deployed container apps
+    /// need (an ACR-pull managed identity bound to the env's container registry).
+    /// </summary>
+    /// <remarks>
+    /// We deliberately skip:
+    /// <list type="bullet">
+    ///   <item><description>Creating a new <c>ContainerAppManagedEnvironment</c> — the existing one is referenced.</description></item>
+    ///   <item><description>Creating a new <c>OperationalInsightsWorkspace</c> — the existing env already has logging configured.</description></item>
+    ///   <item><description>Creating the Aspire Dashboard <c>dotNetComponent</c> — the existing env already owns its dashboard configuration.</description></item>
+    ///   <item><description>Storage accounts / file shares for container volumes and VNet configuration — these cannot be
+    ///   added to an env that already exists without mutating it. If the user attempts to combine these features with
+    ///   <c>AsExisting</c>, we throw a clear error.</description></item>
+    /// </list>
+    /// See https://github.com/microsoft/aspire/issues/12977 for the bug this addresses.
+    /// </remarks>
+    private static void ConfigureExistingContainerAppEnvironmentInfrastructure(
+        AzureResourceInfrastructure infra,
+        AzureContainerAppEnvironmentResource appEnvResource)
+    {
+        if (appEnvResource.VolumeNames.Count > 0)
+        {
+            throw new InvalidOperationException(
+                $"The Azure Container App Environment '{appEnvResource.Name}' is marked as existing but one or more " +
+                "container apps targeted to it declare volume mounts. Volumes require provisioning storage on the " +
+                "managed environment, which Aspire cannot do for an existing environment. Remove the volume mounts " +
+                "or stop marking the environment as existing.");
+        }
+
+        if (appEnvResource.HasAnnotationOfType<DelegatedSubnetAnnotation>())
+        {
+            throw new InvalidOperationException(
+                $"The Azure Container App Environment '{appEnvResource.Name}' is marked as existing but is also " +
+                "configured with a delegated subnet via WithDelegatedSubnet. VNet integration is a property of the " +
+                "managed environment itself and cannot be reconfigured on an existing environment. Remove the " +
+                "WithDelegatedSubnet call or stop marking the environment as existing.");
+        }
+
+        // This tells azd to avoid creating infrastructure.
+        var userPrincipalId = new ProvisioningParameter(AzureBicepResource.KnownParameters.UserPrincipalId, typeof(string)) { Value = new BicepValue<string>(string.Empty) };
+        infra.Add(userPrincipalId);
+
+        var tags = new ProvisioningParameter("tags", typeof(object))
+        {
+            Value = new BicepDictionary<string>()
+        };
+        infra.Add(tags);
+
+        // Reference the existing managed environment. AddAsExistingResource handles the
+        // FromExisting + ExistingAzureResourceAnnotation (name / resource group scope) wiring.
+        var containerAppEnvironment = (ContainerAppManagedEnvironment)appEnvResource.AddAsExistingResource(infra);
+
+        // Container apps still need an identity that can pull from the configured ACR. By default we
+        // create one here and add an AcrPull role assignment on the registry. When the user has supplied
+        // their own identity via WithAcrPullIdentity, we skip both — they own role assignments —
+        // and emit the supplied identity's id as AZURE_CONTAINER_REGISTRY_MANAGED_IDENTITY_ID.
+        UserAssignedIdentity? newIdentity = null;
+        BicepValue<string> managedIdentityIdOutputValue;
+
+        if (appEnvResource.TryGetLastAnnotation<AzureContainerAppEnvironmentAcrPullIdentityAnnotation>(out var identityAnnotation))
+        {
+            managedIdentityIdOutputValue = identityAnnotation.Identity.Id.AsProvisioningParameter(infra);
+        }
+        else
+        {
+            newIdentity = new UserAssignedIdentity(Infrastructure.NormalizeBicepIdentifier($"{appEnvResource.Name}_mi"))
+            {
+                Tags = tags
+            };
+            infra.Add(newIdentity);
+            managedIdentityIdOutputValue = newIdentity.Id.ToBicepExpression();
+        }
+
+        AzureProvisioningResource? registry = null;
+        if (appEnvResource.TryGetLastAnnotation<ContainerRegistryReferenceAnnotation>(out var registryReferenceAnnotation) &&
+            registryReferenceAnnotation.Registry is AzureProvisioningResource explicitRegistry)
+        {
+            registry = explicitRegistry;
+        }
+        else if (appEnvResource.DefaultContainerRegistry is not null)
+        {
+            registry = appEnvResource.DefaultContainerRegistry;
+        }
+
+        if (registry is null)
+        {
+            throw new InvalidOperationException($"No container registry associated with environment '{appEnvResource.Name}'. This should have been added automatically.");
+        }
+
+        var containerRegistry = (ContainerRegistryService)registry.AddAsExistingResource(infra);
+        infra.Add(containerRegistry);
+
+        if (newIdentity is not null)
+        {
+            var pullRa = containerRegistry.CreateRoleAssignment(ContainerRegistryBuiltInRole.AcrPull, newIdentity);
+            // There's a bug in the CDK, see https://github.com/Azure/azure-sdk-for-net/issues/47265
+            pullRa.Name = BicepFunction.CreateGuid(containerRegistry.Id, newIdentity.Id, pullRa.RoleDefinitionId);
+            infra.Add(pullRa);
+        }
+
+        AddSharedContainerAppEnvironmentOutputs(infra, containerRegistry, containerAppEnvironment, managedIdentityIdOutputValue);
+    }
+
+    /// <summary>
+    /// Emits the container-registry + container-app-environment outputs that downstream
+    /// resources (<c>BaseContainerAppContext</c>, <c>ContainerAppUrls</c>, etc.) consume.
+    /// Shared between the greenfield and existing-env infrastructure callbacks so both
+    /// paths produce the exact same set of well-known outputs.
+    /// </summary>
+    private static void AddSharedContainerAppEnvironmentOutputs(
+        AzureResourceInfrastructure infra,
+        ContainerRegistryService containerRegistry,
+        ContainerAppManagedEnvironment containerAppEnvironment,
+        BicepValue<string> managedIdentityIdOutputValue)
+    {
+        // Required by the IContainerRegistry interface
+        infra.Add(new ProvisioningOutput("AZURE_CONTAINER_REGISTRY_NAME", typeof(string))
+        {
+            Value = containerRegistry.Name.ToBicepExpression()
+        });
+
+        infra.Add(new ProvisioningOutput("AZURE_CONTAINER_REGISTRY_ENDPOINT", typeof(string))
+        {
+            Value = containerRegistry.LoginServer.ToBicepExpression()
+        });
+
+        // Required by the IAzureContainerRegistry interface
+        infra.Add(new ProvisioningOutput("AZURE_CONTAINER_REGISTRY_MANAGED_IDENTITY_ID", typeof(string))
+        {
+            Value = managedIdentityIdOutputValue
+        });
+
+        infra.Add(new ProvisioningOutput("AZURE_CONTAINER_APPS_ENVIRONMENT_NAME", typeof(string))
+        {
+            Value = containerAppEnvironment.Name.ToBicepExpression()
+        });
+
+        infra.Add(new ProvisioningOutput("AZURE_CONTAINER_APPS_ENVIRONMENT_ID", typeof(string))
+        {
+            Value = containerAppEnvironment.Id.ToBicepExpression()
+        });
+
+        // Required for azd to output the dashboard URL
+        infra.Add(new ProvisioningOutput("AZURE_CONTAINER_APPS_ENVIRONMENT_DEFAULT_DOMAIN", typeof(string))
+        {
+            Value = containerAppEnvironment.DefaultDomain.ToBicepExpression()
+        });
     }
 
     /// <summary>
@@ -542,6 +691,46 @@ public static class AzureContainerAppExtensions
 
         // Add a LogAnalyticsWorkspaceReferenceAnnotation to indicate that the resource is using a specific workspace
         builder.WithAnnotation(new AzureLogAnalyticsWorkspaceReferenceAnnotation(workspaceBuilder.Resource));
+
+        return builder;
+    }
+
+    /// <summary>
+    /// Configures the container app environment to use the supplied <see cref="AzureUserAssignedIdentityResource"/>
+    /// as the managed identity that container apps in the environment use to pull images from the configured
+    /// container registry (the <c>AcrPull</c> identity), instead of having Aspire create a new identity and a new
+    /// <c>AcrPull</c> role assignment.
+    /// </summary>
+    /// <param name="builder">The container app environment to configure.</param>
+    /// <param name="identityBuilder">
+    /// The resource builder for the user-assigned identity that should be used for image pulls. This identity is
+    /// only used for the <c>AcrPull</c> role; it is not assigned to individual container apps in the environment.
+    /// </param>
+    /// <returns>The <see cref="IResourceBuilder{T}"/> for chaining.</returns>
+    /// <remarks>
+    /// <para>
+    /// When this is set, Aspire will not create a new identity or an <c>AcrPull</c> role assignment for the
+    /// container registry. The caller is responsible for ensuring the supplied identity already has the required
+    /// <c>AcrPull</c> role assignment on the registry, for example by chaining
+    /// <c>.WithRoleAssignments(acr, ContainerRegistryBuiltInRole.AcrPull)</c> when adding the identity.
+    /// </para>
+    /// <para>
+    /// This is commonly combined with <c>AsExisting</c> on the environment and on the container registry to deploy
+    /// container apps into a pre-provisioned set of Azure resources without granting the deployment principal
+    /// permission to create new identities or role assignments. See
+    /// <see href="https://github.com/microsoft/aspire/issues/12977"/> for the scenario this addresses.
+    /// </para>
+    /// </remarks>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="builder"/> or <paramref name="identityBuilder"/> is <see langword="null"/>.</exception>
+    [AspireExport(Description = "Configures the container app environment to use a specific user-assigned managed identity for the AcrPull role on the container registry")]
+    public static IResourceBuilder<AzureContainerAppEnvironmentResource> WithAcrPullIdentity(
+        this IResourceBuilder<AzureContainerAppEnvironmentResource> builder,
+        IResourceBuilder<AzureUserAssignedIdentityResource> identityBuilder)
+    {
+        ArgumentNullException.ThrowIfNull(builder);
+        ArgumentNullException.ThrowIfNull(identityBuilder);
+
+        builder.WithAnnotation(new AzureContainerAppEnvironmentAcrPullIdentityAnnotation(identityBuilder.Resource));
 
         return builder;
     }

--- a/src/Aspire.Hosting.Azure.AppContainers/api/Aspire.Hosting.Azure.AppContainers.ats.txt
+++ b/src/Aspire.Hosting.Azure.AppContainers/api/Aspire.Hosting.Azure.AppContainers.ats.txt
@@ -12,6 +12,7 @@ Aspire.Hosting.Azure.AppContainers/publishAsScheduledAzureContainerAppJob(cronEx
 Aspire.Hosting.Azure.AppContainers/publishContainerAsAzureContainerApp(configure: callback) -> Aspire.Hosting/Aspire.Hosting.ApplicationModel.ContainerResource
 Aspire.Hosting.Azure.AppContainers/publishExecutableAsAzureContainerApp(configure: callback) -> Aspire.Hosting/Aspire.Hosting.ApplicationModel.ExecutableResource
 Aspire.Hosting.Azure.AppContainers/publishProjectAsAzureContainerApp(configure: callback) -> Aspire.Hosting/Aspire.Hosting.ApplicationModel.ProjectResource
+Aspire.Hosting.Azure.AppContainers/withAcrPullIdentity(identityBuilder: Aspire.Hosting.Azure/Aspire.Hosting.Azure.AzureUserAssignedIdentityResource) -> Aspire.Hosting.Azure.AppContainers/Aspire.Hosting.Azure.AppContainers.AzureContainerAppEnvironmentResource
 Aspire.Hosting.Azure.AppContainers/withAzdResourceNaming() -> Aspire.Hosting.Azure.AppContainers/Aspire.Hosting.Azure.AppContainers.AzureContainerAppEnvironmentResource
 Aspire.Hosting.Azure.AppContainers/withAzureLogAnalyticsWorkspace(workspaceBuilder: Aspire.Hosting.Azure.OperationalInsights/Aspire.Hosting.Azure.AzureLogAnalyticsWorkspaceResource) -> Aspire.Hosting.Azure.AppContainers/Aspire.Hosting.Azure.AppContainers.AzureContainerAppEnvironmentResource
 Aspire.Hosting.Azure.AppContainers/withCompactResourceNaming() -> Aspire.Hosting.Azure.AppContainers/Aspire.Hosting.Azure.AppContainers.AzureContainerAppEnvironmentResource

--- a/tests/Aspire.Hosting.Azure.Tests/AzureContainerAppEnvironmentExtensionsTests.cs
+++ b/tests/Aspire.Hosting.Azure.Tests/AzureContainerAppEnvironmentExtensionsTests.cs
@@ -305,6 +305,30 @@ public class AzureContainerAppEnvironmentExtensionsTests
     }
 
     [Fact]
+    public async Task AsExisting_ThrowsWhenCombinedWithAzureLogAnalyticsWorkspace()
+    {
+        using var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish);
+
+        var environmentName = builder.AddParameter("environmentName");
+
+        var logAnalyticsWorkspace = builder.AddAzureLogAnalyticsWorkspace("log");
+
+        var env = builder.AddAzureContainerAppEnvironment("env")
+            .AsExisting(environmentName, (IResourceBuilder<ParameterResource>?)null)
+            .WithAzureLogAnalyticsWorkspace(logAnalyticsWorkspace);
+
+        var ex = await Assert.ThrowsAsync<InvalidOperationException>(
+            () => AzureManifestUtils.GetManifestWithBicep(env.Resource));
+
+        Assert.Equal(
+            "The Azure Container App Environment 'env' is marked as existing but is also " +
+            "configured with a Log Analytics workspace via WithAzureLogAnalyticsWorkspace. The existing managed " +
+            "environment already owns its Log Analytics workspace and Aspire cannot reconfigure it. Remove the " +
+            "WithAzureLogAnalyticsWorkspace call or stop marking the environment as existing.",
+            ex.Message);
+    }
+
+    [Fact]
     public async Task WithAzureContainerRegistry_PublishSucceeds_WhenDefaultRegistryIsRedundant()
     {
         // Regression test for the publish-time error:

--- a/tests/Aspire.Hosting.Azure.Tests/AzureContainerAppEnvironmentExtensionsTests.cs
+++ b/tests/Aspire.Hosting.Azure.Tests/AzureContainerAppEnvironmentExtensionsTests.cs
@@ -154,6 +154,124 @@ public class AzureContainerAppEnvironmentExtensionsTests
     }
 
     [Fact]
+    public async Task AsExisting_PublishGeneratesThinModuleReferencingExistingEnvironment()
+    {
+        // Regression test for https://github.com/microsoft/aspire/issues/12977.
+        // When AsExisting is used on AddAzureContainerAppEnvironment, the published Bicep
+        // must reference the existing managed environment instead of generating a new one
+        // plus a new Log Analytics workspace and a new Aspire Dashboard component.
+        using var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish);
+
+        var environmentName = builder.AddParameter("environmentName");
+        var sharedResourceGroup = builder.AddParameter("sharedRg");
+
+        var env = builder.AddAzureContainerAppEnvironment("env")
+            .AsExisting(environmentName, sharedResourceGroup);
+
+        var (manifest, bicep) = await AzureManifestUtils.GetManifestWithBicep(env.Resource);
+
+        await Verify(bicep, extension: "bicep")
+            .AppendContentAsFile(manifest.ToString(), "json");
+    }
+
+    [Fact]
+    public async Task AsExisting_WithExplicitContainerRegistry_PublishGeneratesThinModule()
+    {
+        // When AsExisting is combined with an explicit AsExisting ACR (a common deployment
+        // scenario where everything is pre-provisioned), the resulting Bicep should not
+        // create either a new managed environment or a new container registry.
+        using var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish);
+
+        var environmentName = builder.AddParameter("environmentName");
+        var registryName = builder.AddParameter("registryName");
+        var sharedResourceGroup = builder.AddParameter("sharedRg");
+
+        var acr = builder.AddAzureContainerRegistry("acr")
+            .AsExisting(registryName, sharedResourceGroup);
+
+        var env = builder.AddAzureContainerAppEnvironment("env")
+            .AsExisting(environmentName, sharedResourceGroup)
+            .WithAzureContainerRegistry(acr);
+
+        var (manifest, bicep) = await AzureManifestUtils.GetManifestWithBicep(env.Resource);
+
+        await Verify(bicep, extension: "bicep")
+            .AppendContentAsFile(manifest.ToString(), "json");
+    }
+
+    [Fact]
+    public async Task WithAcrPullIdentity_PublishGeneratesEnvWithSuppliedIdentity()
+    {
+        // Greenfield environment, but the user has BYO'd a managed identity. The generated
+        // Bicep should NOT declare an env_mi resource or an AcrPull role assignment - the
+        // identity id should flow into the env module via a parameter and be emitted as
+        // AZURE_CONTAINER_REGISTRY_MANAGED_IDENTITY_ID.
+        using var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish);
+
+        var mi = builder.AddAzureUserAssignedIdentity("shared-mi");
+
+        var env = builder.AddAzureContainerAppEnvironment("env")
+            .WithAcrPullIdentity(mi);
+
+        var (manifest, bicep) = await AzureManifestUtils.GetManifestWithBicep(env.Resource);
+
+        await Verify(bicep, extension: "bicep")
+            .AppendContentAsFile(manifest.ToString(), "json");
+    }
+
+    [Fact]
+    public async Task WithAcrPullIdentity_AsExisting_PublishGeneratesThinModuleWithSuppliedIdentity()
+    {
+        // Full pre-provisioned scenario from https://github.com/microsoft/aspire/issues/12977:
+        // existing env + existing ACR + BYO identity that already has AcrPull on the ACR.
+        // The generated env module should reference existing resources only and contain
+        // neither a new identity nor a new role assignment.
+        using var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish);
+
+        var environmentName = builder.AddParameter("environmentName");
+        var registryName = builder.AddParameter("registryName");
+        var identityName = builder.AddParameter("identityName");
+        var sharedResourceGroup = builder.AddParameter("sharedRg");
+
+        var acr = builder.AddAzureContainerRegistry("acr")
+            .AsExisting(registryName, sharedResourceGroup);
+
+        var mi = builder.AddAzureUserAssignedIdentity("shared-mi")
+            .AsExisting(identityName, sharedResourceGroup);
+
+        var env = builder.AddAzureContainerAppEnvironment("env")
+            .AsExisting(environmentName, sharedResourceGroup)
+            .WithAzureContainerRegistry(acr)
+            .WithAcrPullIdentity(mi);
+
+        var (manifest, bicep) = await AzureManifestUtils.GetManifestWithBicep(env.Resource);
+
+        await Verify(bicep, extension: "bicep")
+            .AppendContentAsFile(manifest.ToString(), "json");
+    }
+
+    [Fact]
+    public async Task AsExisting_ThrowsWhenCombinedWithDelegatedSubnet()
+    {
+        using var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish);
+
+        var environmentName = builder.AddParameter("environmentName");
+
+        var vnet = builder.AddAzureVirtualNetwork("myvnet");
+        var subnet = vnet.AddSubnet("aca-subnet", "10.0.0.0/23");
+
+        var env = builder.AddAzureContainerAppEnvironment("env")
+            .AsExisting(environmentName, (IResourceBuilder<ParameterResource>?)null)
+            .WithDelegatedSubnet(subnet);
+
+        var ex = await Assert.ThrowsAsync<InvalidOperationException>(
+            () => AzureManifestUtils.GetManifestWithBicep(env.Resource));
+
+        Assert.Contains("existing", ex.Message, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("WithDelegatedSubnet", ex.Message);
+    }
+
+    [Fact]
     public async Task WithAzureContainerRegistry_PublishSucceeds_WhenDefaultRegistryIsRedundant()
     {
         // Regression test for the publish-time error:

--- a/tests/Aspire.Hosting.Azure.Tests/AzureContainerAppEnvironmentExtensionsTests.cs
+++ b/tests/Aspire.Hosting.Azure.Tests/AzureContainerAppEnvironmentExtensionsTests.cs
@@ -272,6 +272,39 @@ public class AzureContainerAppEnvironmentExtensionsTests
     }
 
     [Fact]
+    public async Task AsExisting_ThrowsWhenContainerAppDeclaresVolumeMount()
+    {
+        // When the env is marked as existing, Aspire cannot provision the storage
+        // account / file share that backs container app volume mounts (storage is
+        // attached to the managed env, which we don't own here). Asserts the
+        // configureInfrastructure callback throws a clear error in that case so the
+        // guard isn't silently dropped by future refactors.
+        using var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish);
+
+        var environmentName = builder.AddParameter("environmentName");
+
+        var env = builder.AddAzureContainerAppEnvironment("env")
+            .AsExisting(environmentName, (IResourceBuilder<ParameterResource>?)null);
+
+        builder.AddContainer("api", "myimage")
+               .WithVolume("data", "/var/data");
+
+        using var app = builder.Build();
+
+        await AzureManifestUtils.ExecuteBeforeStartHooksAsync(app, default);
+
+        var ex = await Assert.ThrowsAsync<InvalidOperationException>(
+            () => AzureManifestUtils.GetManifestWithBicep(env.Resource, skipPreparer: true));
+
+        Assert.Equal(
+            "The Azure Container App Environment 'env' is marked as existing but one or more " +
+            "container apps targeted to it declare volume mounts. Volumes require provisioning storage on the " +
+            "managed environment, which Aspire cannot do for an existing environment. Remove the volume mounts " +
+            "or stop marking the environment as existing.",
+            ex.Message);
+    }
+
+    [Fact]
     public async Task WithAzureContainerRegistry_PublishSucceeds_WhenDefaultRegistryIsRedundant()
     {
         // Regression test for the publish-time error:

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureContainerAppEnvironmentExtensionsTests.AsExisting_PublishGeneratesThinModuleReferencingExistingEnvironment.verified.bicep
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureContainerAppEnvironmentExtensionsTests.AsExisting_PublishGeneratesThinModuleReferencingExistingEnvironment.verified.bicep
@@ -1,0 +1,49 @@
+﻿@description('The location for the resource(s) to be deployed.')
+param location string = resourceGroup().location
+
+param userPrincipalId string = ''
+
+param tags object = { }
+
+param environmentName string
+
+param sharedRg string
+
+param env_acr_outputs_name string
+
+resource env 'Microsoft.App/managedEnvironments@2025-07-01' existing = {
+  name: environmentName
+  scope: resourceGroup(sharedRg)
+}
+
+resource env_mi 'Microsoft.ManagedIdentity/userAssignedIdentities@2024-11-30' = {
+  name: take('env_mi-${uniqueString(resourceGroup().id)}', 128)
+  location: location
+  tags: tags
+}
+
+resource env_acr 'Microsoft.ContainerRegistry/registries@2025-04-01' existing = {
+  name: env_acr_outputs_name
+}
+
+resource env_acr_env_mi_AcrPull 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
+  name: guid(env_acr.id, env_mi.id, subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '7f951dda-4ed3-4680-a7ca-43fe172d538d'))
+  properties: {
+    principalId: env_mi.properties.principalId
+    roleDefinitionId: subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '7f951dda-4ed3-4680-a7ca-43fe172d538d')
+    principalType: 'ServicePrincipal'
+  }
+  scope: env_acr
+}
+
+output AZURE_CONTAINER_REGISTRY_NAME string = env_acr.name
+
+output AZURE_CONTAINER_REGISTRY_ENDPOINT string = env_acr.properties.loginServer
+
+output AZURE_CONTAINER_REGISTRY_MANAGED_IDENTITY_ID string = env_mi.id
+
+output AZURE_CONTAINER_APPS_ENVIRONMENT_NAME string = env.name
+
+output AZURE_CONTAINER_APPS_ENVIRONMENT_ID string = env.id
+
+output AZURE_CONTAINER_APPS_ENVIRONMENT_DEFAULT_DOMAIN string = env.properties.defaultDomain

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureContainerAppEnvironmentExtensionsTests.AsExisting_PublishGeneratesThinModuleReferencingExistingEnvironment.verified.json
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureContainerAppEnvironmentExtensionsTests.AsExisting_PublishGeneratesThinModuleReferencingExistingEnvironment.verified.json
@@ -1,0 +1,10 @@
+﻿{
+  "type": "azure.bicep.v0",
+  "path": "env.module.bicep",
+  "params": {
+    "environmentName": "{environmentName.value}",
+    "sharedRg": "{sharedRg.value}",
+    "env_acr_outputs_name": "{env-acr.outputs.name}",
+    "userPrincipalId": ""
+  }
+}

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureContainerAppEnvironmentExtensionsTests.AsExisting_WithExplicitContainerRegistry_PublishGeneratesThinModule.verified.bicep
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureContainerAppEnvironmentExtensionsTests.AsExisting_WithExplicitContainerRegistry_PublishGeneratesThinModule.verified.bicep
@@ -1,0 +1,50 @@
+﻿@description('The location for the resource(s) to be deployed.')
+param location string = resourceGroup().location
+
+param userPrincipalId string = ''
+
+param tags object = { }
+
+param environmentName string
+
+param sharedRg string
+
+param registryName string
+
+resource env 'Microsoft.App/managedEnvironments@2025-07-01' existing = {
+  name: environmentName
+  scope: resourceGroup(sharedRg)
+}
+
+resource env_mi 'Microsoft.ManagedIdentity/userAssignedIdentities@2024-11-30' = {
+  name: take('env_mi-${uniqueString(resourceGroup().id)}', 128)
+  location: location
+  tags: tags
+}
+
+resource acr 'Microsoft.ContainerRegistry/registries@2025-04-01' existing = {
+  name: registryName
+  scope: resourceGroup(sharedRg)
+}
+
+resource acr_env_mi_AcrPull 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
+  name: guid(acr.id, env_mi.id, subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '7f951dda-4ed3-4680-a7ca-43fe172d538d'))
+  properties: {
+    principalId: env_mi.properties.principalId
+    roleDefinitionId: subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '7f951dda-4ed3-4680-a7ca-43fe172d538d')
+    principalType: 'ServicePrincipal'
+  }
+  scope: acr
+}
+
+output AZURE_CONTAINER_REGISTRY_NAME string = acr.name
+
+output AZURE_CONTAINER_REGISTRY_ENDPOINT string = acr.properties.loginServer
+
+output AZURE_CONTAINER_REGISTRY_MANAGED_IDENTITY_ID string = env_mi.id
+
+output AZURE_CONTAINER_APPS_ENVIRONMENT_NAME string = env.name
+
+output AZURE_CONTAINER_APPS_ENVIRONMENT_ID string = env.id
+
+output AZURE_CONTAINER_APPS_ENVIRONMENT_DEFAULT_DOMAIN string = env.properties.defaultDomain

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureContainerAppEnvironmentExtensionsTests.AsExisting_WithExplicitContainerRegistry_PublishGeneratesThinModule.verified.json
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureContainerAppEnvironmentExtensionsTests.AsExisting_WithExplicitContainerRegistry_PublishGeneratesThinModule.verified.json
@@ -1,0 +1,10 @@
+﻿{
+  "type": "azure.bicep.v0",
+  "path": "env.module.bicep",
+  "params": {
+    "environmentName": "{environmentName.value}",
+    "sharedRg": "{sharedRg.value}",
+    "registryName": "{registryName.value}",
+    "userPrincipalId": ""
+  }
+}

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureContainerAppEnvironmentExtensionsTests.WithAcrPullIdentity_AsExisting_PublishGeneratesThinModuleWithSuppliedIdentity.verified.bicep
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureContainerAppEnvironmentExtensionsTests.WithAcrPullIdentity_AsExisting_PublishGeneratesThinModuleWithSuppliedIdentity.verified.bicep
@@ -1,0 +1,36 @@
+﻿@description('The location for the resource(s) to be deployed.')
+param location string = resourceGroup().location
+
+param userPrincipalId string = ''
+
+param tags object = { }
+
+param environmentName string
+
+param sharedRg string
+
+param shared_mi_outputs_id string
+
+param registryName string
+
+resource env 'Microsoft.App/managedEnvironments@2025-07-01' existing = {
+  name: environmentName
+  scope: resourceGroup(sharedRg)
+}
+
+resource acr 'Microsoft.ContainerRegistry/registries@2025-04-01' existing = {
+  name: registryName
+  scope: resourceGroup(sharedRg)
+}
+
+output AZURE_CONTAINER_REGISTRY_NAME string = acr.name
+
+output AZURE_CONTAINER_REGISTRY_ENDPOINT string = acr.properties.loginServer
+
+output AZURE_CONTAINER_REGISTRY_MANAGED_IDENTITY_ID string = shared_mi_outputs_id
+
+output AZURE_CONTAINER_APPS_ENVIRONMENT_NAME string = env.name
+
+output AZURE_CONTAINER_APPS_ENVIRONMENT_ID string = env.id
+
+output AZURE_CONTAINER_APPS_ENVIRONMENT_DEFAULT_DOMAIN string = env.properties.defaultDomain

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureContainerAppEnvironmentExtensionsTests.WithAcrPullIdentity_AsExisting_PublishGeneratesThinModuleWithSuppliedIdentity.verified.json
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureContainerAppEnvironmentExtensionsTests.WithAcrPullIdentity_AsExisting_PublishGeneratesThinModuleWithSuppliedIdentity.verified.json
@@ -1,0 +1,11 @@
+﻿{
+  "type": "azure.bicep.v0",
+  "path": "env.module.bicep",
+  "params": {
+    "environmentName": "{environmentName.value}",
+    "sharedRg": "{sharedRg.value}",
+    "shared_mi_outputs_id": "{shared-mi.outputs.id}",
+    "registryName": "{registryName.value}",
+    "userPrincipalId": ""
+  }
+}

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureContainerAppEnvironmentExtensionsTests.WithAcrPullIdentity_PublishGeneratesEnvWithSuppliedIdentity.verified.bicep
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureContainerAppEnvironmentExtensionsTests.WithAcrPullIdentity_PublishGeneratesEnvWithSuppliedIdentity.verified.bicep
@@ -1,0 +1,70 @@
+﻿@description('The location for the resource(s) to be deployed.')
+param location string = resourceGroup().location
+
+param userPrincipalId string = ''
+
+param tags object = { }
+
+param shared_mi_outputs_id string
+
+param env_acr_outputs_name string
+
+resource env_acr 'Microsoft.ContainerRegistry/registries@2025-04-01' existing = {
+  name: env_acr_outputs_name
+}
+
+resource env_law 'Microsoft.OperationalInsights/workspaces@2025-02-01' = {
+  name: take('envlaw-${uniqueString(resourceGroup().id)}', 63)
+  location: location
+  properties: {
+    sku: {
+      name: 'PerGB2018'
+    }
+  }
+  tags: tags
+}
+
+resource env 'Microsoft.App/managedEnvironments@2025-07-01' = {
+  name: take('env${uniqueString(resourceGroup().id)}', 24)
+  location: location
+  properties: {
+    appLogsConfiguration: {
+      destination: 'log-analytics'
+      logAnalyticsConfiguration: {
+        customerId: env_law.properties.customerId
+        sharedKey: env_law.listKeys().primarySharedKey
+      }
+    }
+    workloadProfiles: [
+      {
+        name: 'consumption'
+        workloadProfileType: 'Consumption'
+      }
+    ]
+  }
+  tags: tags
+}
+
+resource aspireDashboard 'Microsoft.App/managedEnvironments/dotNetComponents@2025-10-02-preview' = {
+  name: 'aspire-dashboard'
+  properties: {
+    componentType: 'AspireDashboard'
+  }
+  parent: env
+}
+
+output AZURE_LOG_ANALYTICS_WORKSPACE_NAME string = env_law.name
+
+output AZURE_LOG_ANALYTICS_WORKSPACE_ID string = env_law.id
+
+output AZURE_CONTAINER_REGISTRY_NAME string = env_acr.name
+
+output AZURE_CONTAINER_REGISTRY_ENDPOINT string = env_acr.properties.loginServer
+
+output AZURE_CONTAINER_REGISTRY_MANAGED_IDENTITY_ID string = shared_mi_outputs_id
+
+output AZURE_CONTAINER_APPS_ENVIRONMENT_NAME string = env.name
+
+output AZURE_CONTAINER_APPS_ENVIRONMENT_ID string = env.id
+
+output AZURE_CONTAINER_APPS_ENVIRONMENT_DEFAULT_DOMAIN string = env.properties.defaultDomain

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureContainerAppEnvironmentExtensionsTests.WithAcrPullIdentity_PublishGeneratesEnvWithSuppliedIdentity.verified.json
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureContainerAppEnvironmentExtensionsTests.WithAcrPullIdentity_PublishGeneratesEnvWithSuppliedIdentity.verified.json
@@ -1,0 +1,9 @@
+﻿{
+  "type": "azure.bicep.v0",
+  "path": "env.module.bicep",
+  "params": {
+    "shared_mi_outputs_id": "{shared-mi.outputs.id}",
+    "env_acr_outputs_name": "{env-acr.outputs.name}",
+    "userPrincipalId": ""
+  }
+}


### PR DESCRIPTION
## Description

`AddAzureContainerAppEnvironment(...).AsExisting(...)` already marked the resource as existing for the model, but the publish-time `configureInfrastructure` callback still produced a brand-new managed environment, Log Analytics workspace, Aspire Dashboard component, storage account, and user-assigned identity. The generated Bicep tried to *create* the environment the user said already existed, which is the bug reported in #12977.

This PR makes the callback short-circuit when the environment is marked as existing and emit a thin module that only references the existing resources and produces the outputs the rest of the publish pipeline consumes (`AZURE_CONTAINER_APPS_ENVIRONMENT_NAME` / `_ID` / `_DEFAULT_DOMAIN` and `AZURE_CONTAINER_REGISTRY_NAME` / `_ENDPOINT` / `_MANAGED_IDENTITY_ID`). Volumes and `WithDelegatedSubnet` are explicitly rejected with a clear error when combined with `AsExisting`, since both require creating new infrastructure.

A common deployment scenario for #12977 also wants to BYO the managed identity that holds `AcrPull` on the container registry, so the deployment principal does not need permission to create new identities or role assignments. This PR adds a small follow-on API for that:

```csharp
var mi  = builder.AddAzureUserAssignedIdentity("shared-mi").AsExisting(...);
var acr = builder.AddAzureContainerRegistry("acr").AsExisting(...);

builder.AddAzureContainerAppEnvironment("env")
    .AsExisting(envName, sharedRg)
    .WithAzureContainerRegistry(acr)
    .WithAcrPullIdentity(mi);
```

When `WithAcrPullIdentity` is set, Aspire skips creating its own `env_mi` identity and the `AcrPull` role assignment, and wires the user's identity id through a Bicep parameter into `AZURE_CONTAINER_REGISTRY_MANAGED_IDENTITY_ID`. The caller is responsible for ensuring the supplied identity already has `AcrPull` on the registry. This works in both the greenfield and `AsExisting` paths.

Refactor note: the six shared registry + env outputs are now produced from a single `AddSharedContainerAppEnvironmentOutputs` helper so the new-vs-existing branches stay in lockstep.

Associated docs PR: https://github.com/microsoft/aspire.dev/pull/1045/

Fixes #12977
Fixes #9094

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [x] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [x] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [x] Yes
      - [ ] No
  - [ ] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No