### PR TITLE
Clarify Aspire update notification

### DIFF
--- a/src/Aspire.Cli/Commands/AppHostLauncher.cs
+++ b/src/Aspire.Cli/Commands/AppHostLauncher.cs
@@ -87,6 +87,7 @@ internal sealed class AppHostLauncher(
     /// <param name="additionalArgs">Additional unmatched args to forward.</param>
     /// <param name="stopAfterLaunchDelay">Optional delay after launch before stopping the AppHost.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
+    /// <param name="appHostSelected">Callback invoked when an AppHost project file has been selected.</param>
     /// <returns>A <see cref="CommandResult"/> indicating success or failure.</returns>
     public async Task<CommandResult> LaunchDetachedAsync(
         FileInfo? passedAppHostProjectFile,
@@ -97,7 +98,8 @@ internal sealed class AppHostLauncher(
         IEnumerable<string> globalArgs,
         IEnumerable<string> additionalArgs,
         TimeSpan? stopAfterLaunchDelay,
-        CancellationToken cancellationToken)
+        CancellationToken cancellationToken,
+        Action<FileInfo>? appHostSelected = null)
     {
         // In JSON mode or non-interactive mode, avoid interactive prompts.
         var multipleAppHostBehavior = format == OutputFormat.Json || !hostEnvironment.SupportsInteractiveInput
@@ -125,6 +127,8 @@ internal sealed class AppHostLauncher(
         {
             return CommandResult.Failure(CliExitCodes.FailedToFindProject);
         }
+
+        appHostSelected?.Invoke(effectiveAppHostFile);
 
         logger.LogDebug("Starting AppHost in background: {AppHostPath}", effectiveAppHostFile.FullName);
 

--- a/src/Aspire.Cli/Commands/BaseCommand.cs
+++ b/src/Aspire.Cli/Commands/BaseCommand.cs
@@ -18,6 +18,7 @@ internal abstract class BaseCommand : Command
     private static readonly int[] s_suppressErrorLogsMessageExitCodes = [CliExitCodes.Cancelled, CliExitCodes.MissingRequiredArgument];
 
     protected virtual bool UpdateNotificationsEnabled { get; } = true;
+    protected virtual bool IncludeAppHostUpdateCommandInUpdateNotification { get; }
 
     /// <summary>
     /// Gets the help group for this command.
@@ -118,7 +119,7 @@ internal abstract class BaseCommand : Command
             {
                 try
                 {
-                    updateNotifier.NotifyIfUpdateAvailable();
+                    updateNotifier.NotifyIfUpdateAvailable(IncludeAppHostUpdateCommandInUpdateNotification);
                 }
                 catch
                 {

--- a/src/Aspire.Cli/Commands/RunCommand.cs
+++ b/src/Aspire.Cli/Commands/RunCommand.cs
@@ -73,6 +73,7 @@ internal sealed class RunCommand : BaseCommand
     private readonly ICliHostEnvironment _hostEnvironment;
     private readonly ProfilingTelemetry _profilingTelemetry;
     private bool _isDetachMode;
+    private bool _hasAppHostContext;
 
     // Guest AppHosts can bring up the temporary server/backchannel and then fail immediately
     // afterward when the guest startup process hits a syntax or pre-execute error. Keep the
@@ -80,6 +81,7 @@ internal sealed class RunCommand : BaseCommand
     private static readonly TimeSpan s_detachedStartupStabilityWindow = TimeSpan.FromSeconds(2);
 
     protected override bool UpdateNotificationsEnabled => !_isDetachMode;
+    protected override bool IncludeAppHostUpdateCommandInUpdateNotification => _hasAppHostContext;
 
     private static readonly Option<bool> s_detachOption = new("--detach")
     {
@@ -132,6 +134,7 @@ internal sealed class RunCommand : BaseCommand
 
     protected override async Task<CommandResult> ExecuteAsync(ParseResult parseResult, CancellationToken cancellationToken)
     {
+        _hasAppHostContext = false;
         var passedAppHostProjectFile = parseResult.GetValue(AppHostLauncher.s_appHostOption);
         var detach = parseResult.GetValue(s_detachOption);
         _isDetachMode = detach;
@@ -220,6 +223,7 @@ internal sealed class RunCommand : BaseCommand
                 runActivity?.SetTag(TelemetryConstants.Tags.ErrorType, "project_not_found");
                 return CommandResult.Failure(CliExitCodes.FailedToFindProject);
             }
+            _hasAppHostContext = true;
 
             // Resolve the language for this file and get the appropriate handler
             var project = _projectFactory.TryGetProject(effectiveAppHostFile);

--- a/src/Aspire.Cli/Commands/StartCommand.cs
+++ b/src/Aspire.Cli/Commands/StartCommand.cs
@@ -20,6 +20,9 @@ internal sealed class StartCommand : BaseCommand
 
     private readonly AppHostLauncher _appHostLauncher;
     private readonly IConfiguration _configuration;
+    private bool _hasAppHostContext;
+
+    protected override bool IncludeAppHostUpdateCommandInUpdateNotification => _hasAppHostContext;
 
     private static readonly Option<bool> s_noBuildOption = new("--no-build")
     {
@@ -48,6 +51,7 @@ internal sealed class StartCommand : BaseCommand
 
     protected override async Task<CommandResult> ExecuteAsync(ParseResult parseResult, CancellationToken cancellationToken)
     {
+        _hasAppHostContext = false;
         var passedAppHostProjectFile = parseResult.GetValue(AppHostLauncher.s_appHostOption);
         var format = parseResult.GetValue(AppHostLauncher.s_formatOption);
         var isolated = parseResult.GetValue(AppHostLauncher.s_isolatedOption);
@@ -75,6 +79,7 @@ internal sealed class StartCommand : BaseCommand
             && ExtensionHelper.IsExtensionHost(InteractionService, out var extensionInteractionService, out _)
             && string.IsNullOrEmpty(_configuration[KnownConfigNames.ExtensionDebugSessionId]))
         {
+            _hasAppHostContext = passedAppHostProjectFile is not null;
             var startDebugSession = parseResult.GetValue(RootCommand.StartDebugSessionOption);
             var debugSessionArgs = new List<string>();
             if (isolated)
@@ -140,6 +145,7 @@ internal sealed class StartCommand : BaseCommand
             globalArgs,
             additionalArgs,
             stopAfterLaunchDelay,
-            cancellationToken);
+            cancellationToken,
+            _ => _hasAppHostContext = true);
     }
 }

--- a/src/Aspire.Cli/Interaction/ConsoleInteractionService.cs
+++ b/src/Aspire.Cli/Interaction/ConsoleInteractionService.cs
@@ -697,16 +697,18 @@ internal class ConsoleInteractionService : IInteractionService
     {
         // Write to stderr to avoid corrupting stdout when JSON output is used
         _errorConsole.WriteLine();
-        _errorConsole.MarkupLine(string.Format(CultureInfo.CurrentCulture, InteractionServiceStrings.NewCliVersionAvailable, newerVersion.EscapeMarkup()));
-
         if (includeAppHostUpdateCommand)
         {
-            _errorConsole.MarkupLine(string.Format(CultureInfo.CurrentCulture, InteractionServiceStrings.ToUpdateAppHostRunCommand, "aspire update"));
+            _errorConsole.MarkupLine(string.Format(CultureInfo.CurrentCulture, InteractionServiceStrings.NewCliVersionAvailableWithAppHostUpdateCommand, newerVersion.EscapeMarkup(), "aspire update"));
+        }
+        else
+        {
+            _errorConsole.MarkupLine(string.Format(CultureInfo.CurrentCulture, InteractionServiceStrings.NewCliVersionAvailable, newerVersion.EscapeMarkup()));
         }
 
         if (!string.IsNullOrEmpty(updateCommand))
         {
-            _errorConsole.MarkupLine(string.Format(CultureInfo.CurrentCulture, InteractionServiceStrings.ToUpdateCliRunCommand, updateCommand.EscapeMarkup()));
+            _errorConsole.MarkupLine(string.Format(CultureInfo.CurrentCulture, InteractionServiceStrings.ToUpdateCliUseCommand, updateCommand.EscapeMarkup()));
         }
 
         _errorConsole.MarkupLine(string.Format(CultureInfo.CurrentCulture, InteractionServiceStrings.MoreInfoNewCliVersion, MarkupHelpers.SafeLink(this, UpdateUrl)));

--- a/src/Aspire.Cli/Interaction/ConsoleInteractionService.cs
+++ b/src/Aspire.Cli/Interaction/ConsoleInteractionService.cs
@@ -693,12 +693,16 @@ internal class ConsoleInteractionService : IInteractionService
 
     private const string UpdateUrl = "https://aka.ms/aspire/update";
 
-    public void DisplayVersionUpdateNotification(string newerVersion, string? updateCommand = null)
+    public void DisplayVersionUpdateNotification(string newerVersion, string? updateCommand = null, bool includeAppHostUpdateCommand = false)
     {
         // Write to stderr to avoid corrupting stdout when JSON output is used
         _errorConsole.WriteLine();
         _errorConsole.MarkupLine(string.Format(CultureInfo.CurrentCulture, InteractionServiceStrings.NewCliVersionAvailable, newerVersion.EscapeMarkup()));
-        _errorConsole.MarkupLine(string.Format(CultureInfo.CurrentCulture, InteractionServiceStrings.ToUpdateAppHostRunCommand, "aspire update"));
+
+        if (includeAppHostUpdateCommand)
+        {
+            _errorConsole.MarkupLine(string.Format(CultureInfo.CurrentCulture, InteractionServiceStrings.ToUpdateAppHostRunCommand, "aspire update"));
+        }
 
         if (!string.IsNullOrEmpty(updateCommand))
         {

--- a/src/Aspire.Cli/Interaction/ConsoleInteractionService.cs
+++ b/src/Aspire.Cli/Interaction/ConsoleInteractionService.cs
@@ -698,10 +698,11 @@ internal class ConsoleInteractionService : IInteractionService
         // Write to stderr to avoid corrupting stdout when JSON output is used
         _errorConsole.WriteLine();
         _errorConsole.MarkupLine(string.Format(CultureInfo.CurrentCulture, InteractionServiceStrings.NewCliVersionAvailable, newerVersion.EscapeMarkup()));
+        _errorConsole.MarkupLine(string.Format(CultureInfo.CurrentCulture, InteractionServiceStrings.ToUpdateAppHostRunCommand, "aspire update"));
 
         if (!string.IsNullOrEmpty(updateCommand))
         {
-            _errorConsole.MarkupLine(string.Format(CultureInfo.CurrentCulture, InteractionServiceStrings.ToUpdateRunCommand, updateCommand.EscapeMarkup()));
+            _errorConsole.MarkupLine(string.Format(CultureInfo.CurrentCulture, InteractionServiceStrings.ToUpdateCliRunCommand, updateCommand.EscapeMarkup()));
         }
 
         _errorConsole.MarkupLine(string.Format(CultureInfo.CurrentCulture, InteractionServiceStrings.MoreInfoNewCliVersion, MarkupHelpers.SafeLink(this, UpdateUrl)));

--- a/src/Aspire.Cli/Interaction/ExtensionInteractionService.cs
+++ b/src/Aspire.Cli/Interaction/ExtensionInteractionService.cs
@@ -488,9 +488,9 @@ internal class ExtensionInteractionService : IExtensionInteractionService
         _consoleInteractionService.DisplayMarkupLine(markup);
     }
 
-    public void DisplayVersionUpdateNotification(string newerVersion, string? updateCommand = null)
+    public void DisplayVersionUpdateNotification(string newerVersion, string? updateCommand = null, bool includeAppHostUpdateCommand = false)
     {
-        _consoleInteractionService.DisplayVersionUpdateNotification(newerVersion, updateCommand);
+        _consoleInteractionService.DisplayVersionUpdateNotification(newerVersion, updateCommand, includeAppHostUpdateCommand);
     }
 
     public void DisplayRenderable(IRenderable renderable)

--- a/src/Aspire.Cli/Interaction/IInteractionService.cs
+++ b/src/Aspire.Cli/Interaction/IInteractionService.cs
@@ -54,7 +54,7 @@ internal interface IInteractionService
     /// </summary>
     bool SupportsLinks { get; }
 
-    void DisplayVersionUpdateNotification(string newerVersion, string? updateCommand = null);
+    void DisplayVersionUpdateNotification(string newerVersion, string? updateCommand = null, bool includeAppHostUpdateCommand = false);
     // The semantic type is stringly-typed because some values originate from backchannel payloads.
     // Use ConsoleLogTypes for CLI-defined values.
     void WriteConsoleLog(string message, int? lineNumber = null, string? type = null, bool isErrorMessage = false);

--- a/src/Aspire.Cli/Resources/InteractionServiceStrings.Designer.cs
+++ b/src/Aspire.Cli/Resources/InteractionServiceStrings.Designer.cs
@@ -457,11 +457,20 @@ namespace Aspire.Cli.Resources {
         }
 
         /// <summary>
-        ///   Looks up a localized string similar to [dim]To update, run: {0}[/].
+        ///   Looks up a localized string similar to [dim]To update this AppHost, run: {0}[/].
         /// </summary>
-        public static string ToUpdateRunCommand {
+        public static string ToUpdateAppHostRunCommand {
             get {
-                return ResourceManager.GetString("ToUpdateRunCommand", resourceCulture);
+                return ResourceManager.GetString("ToUpdateAppHostRunCommand", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to [dim]To update the Aspire CLI, run: {0}[/].
+        /// </summary>
+        public static string ToUpdateCliRunCommand {
+            get {
+                return ResourceManager.GetString("ToUpdateCliRunCommand", resourceCulture);
             }
         }
     }

--- a/src/Aspire.Cli/Resources/InteractionServiceStrings.Designer.cs
+++ b/src/Aspire.Cli/Resources/InteractionServiceStrings.Designer.cs
@@ -277,6 +277,15 @@ namespace Aspire.Cli.Resources {
         }
 
         /// <summary>
+        ///   Looks up a localized string similar to [yellow]A new version of Aspire is available: {0}[/] [dim](use {1} for this AppHost)[/].
+        /// </summary>
+        public static string NewCliVersionAvailableWithAppHostUpdateCommand {
+            get {
+                return ResourceManager.GetString("NewCliVersionAvailableWithAppHostUpdateCommand", resourceCulture);
+            }
+        }
+
+        /// <summary>
         ///   Looks up a localized string similar to No items available for selection: {0}.
         /// </summary>
         public static string NoItemsAvailableForSelection {
@@ -457,20 +466,11 @@ namespace Aspire.Cli.Resources {
         }
 
         /// <summary>
-        ///   Looks up a localized string similar to [dim]To update this AppHost, run: {0}[/].
+        ///   Looks up a localized string similar to [dim]To update the Aspire CLI, use: {0}[/].
         /// </summary>
-        public static string ToUpdateAppHostRunCommand {
+        public static string ToUpdateCliUseCommand {
             get {
-                return ResourceManager.GetString("ToUpdateAppHostRunCommand", resourceCulture);
-            }
-        }
-
-        /// <summary>
-        ///   Looks up a localized string similar to [dim]To update the Aspire CLI, run: {0}[/].
-        /// </summary>
-        public static string ToUpdateCliRunCommand {
-            get {
-                return ResourceManager.GetString("ToUpdateCliRunCommand", resourceCulture);
+                return ResourceManager.GetString("ToUpdateCliUseCommand", resourceCulture);
             }
         }
     }

--- a/src/Aspire.Cli/Resources/InteractionServiceStrings.resx
+++ b/src/Aspire.Cli/Resources/InteractionServiceStrings.resx
@@ -241,8 +241,12 @@
     <value>[dim]For more information, see: {0}[/]</value>
     <comment>Do not translate [dim]. Also leave [/] as-is. {0} is a pre-formatted link</comment>
   </data>
-  <data name="ToUpdateRunCommand" xml:space="preserve">
-    <value>[dim]To update, run: {0}[/]</value>
+  <data name="ToUpdateAppHostRunCommand" xml:space="preserve">
+    <value>[dim]To update this AppHost, run: {0}[/]</value>
+    <comment>Do not translate [dim]. Also leave [/] as-is. {0} is the command to run</comment>
+  </data>
+  <data name="ToUpdateCliRunCommand" xml:space="preserve">
+    <value>[dim]To update the Aspire CLI, run: {0}[/]</value>
     <comment>Do not translate [dim]. Also leave [/] as-is. {0} is the command to run</comment>
   </data>
   <data name="UnbuildableAppHostsDetected" xml:space="preserve">

--- a/src/Aspire.Cli/Resources/InteractionServiceStrings.resx
+++ b/src/Aspire.Cli/Resources/InteractionServiceStrings.resx
@@ -237,17 +237,17 @@
     <value>[yellow]A new version of Aspire is available: {0}[/]</value>
     <comment>Do not translate [yellow] and also leave [/] as-is. {0} is the version number</comment>
   </data>
+  <data name="NewCliVersionAvailableWithAppHostUpdateCommand" xml:space="preserve">
+    <value>[yellow]A new version of Aspire is available: {0}[/] [dim](use {1} for this AppHost)[/]</value>
+    <comment>Do not translate [yellow], [dim], or [/] as-is. {0} is the version number. {1} is the command to use</comment>
+  </data>
   <data name="MoreInfoNewCliVersion" xml:space="preserve">
     <value>[dim]For more information, see: {0}[/]</value>
     <comment>Do not translate [dim]. Also leave [/] as-is. {0} is a pre-formatted link</comment>
   </data>
-  <data name="ToUpdateAppHostRunCommand" xml:space="preserve">
-    <value>[dim]To update this AppHost, run: {0}[/]</value>
-    <comment>Do not translate [dim]. Also leave [/] as-is. {0} is the command to run</comment>
-  </data>
-  <data name="ToUpdateCliRunCommand" xml:space="preserve">
-    <value>[dim]To update the Aspire CLI, run: {0}[/]</value>
-    <comment>Do not translate [dim]. Also leave [/] as-is. {0} is the command to run</comment>
+  <data name="ToUpdateCliUseCommand" xml:space="preserve">
+    <value>[dim]To update the Aspire CLI, use: {0}[/]</value>
+    <comment>Do not translate [dim]. Also leave [/] as-is. {0} is the command to use</comment>
   </data>
   <data name="UnbuildableAppHostsDetected" xml:space="preserve">
     <value>No AppHosts were found (there may be AppHost project files with syntax errors/invalid SDK versions).</value>

--- a/src/Aspire.Cli/Resources/xlf/InteractionServiceStrings.cs.xlf
+++ b/src/Aspire.Cli/Resources/xlf/InteractionServiceStrings.cs.xlf
@@ -197,9 +197,14 @@
         <target state="translated">Zastavuje se Aspire.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ToUpdateRunCommand">
-        <source>[dim]To update, run: {0}[/]</source>
-        <target state="translated">[dim]Pro aktualizaci spusťte: {0}[/]</target>
+      <trans-unit id="ToUpdateAppHostRunCommand">
+        <source>[dim]To update this AppHost, run: {0}[/]</source>
+        <target state="new">[dim]To update this AppHost, run: {0}[/]</target>
+        <note>Do not translate [dim]. Also leave [/] as-is. {0} is the command to run</note>
+      </trans-unit>
+      <trans-unit id="ToUpdateCliRunCommand">
+        <source>[dim]To update the Aspire CLI, run: {0}[/]</source>
+        <target state="new">[dim]To update the Aspire CLI, run: {0}[/]</target>
         <note>Do not translate [dim]. Also leave [/] as-is. {0} is the command to run</note>
       </trans-unit>
       <trans-unit id="TrustingCertificates">

--- a/src/Aspire.Cli/Resources/xlf/InteractionServiceStrings.cs.xlf
+++ b/src/Aspire.Cli/Resources/xlf/InteractionServiceStrings.cs.xlf
@@ -97,6 +97,11 @@
         <target state="new">[yellow]A new version of Aspire is available: {0}[/]</target>
         <note>Do not translate [yellow] and also leave [/] as-is. {0} is the version number</note>
       </trans-unit>
+      <trans-unit id="NewCliVersionAvailableWithAppHostUpdateCommand">
+        <source>[yellow]A new version of Aspire is available: {0}[/] [dim](use {1} for this AppHost)[/]</source>
+        <target state="new">[yellow]A new version of Aspire is available: {0}[/] [dim](use {1} for this AppHost)[/]</target>
+        <note>Do not translate [yellow], [dim], or [/] as-is. {0} is the version number. {1} is the command to use</note>
+      </trans-unit>
       <trans-unit id="NoItemsAvailableForSelection">
         <source>No items available for selection: {0}</source>
         <target state="translated">Nejsou k dispozici žádné položky pro výběr: {0}</target>
@@ -197,15 +202,10 @@
         <target state="translated">Zastavuje se Aspire.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ToUpdateAppHostRunCommand">
-        <source>[dim]To update this AppHost, run: {0}[/]</source>
-        <target state="new">[dim]To update this AppHost, run: {0}[/]</target>
-        <note>Do not translate [dim]. Also leave [/] as-is. {0} is the command to run</note>
-      </trans-unit>
-      <trans-unit id="ToUpdateCliRunCommand">
-        <source>[dim]To update the Aspire CLI, run: {0}[/]</source>
-        <target state="new">[dim]To update the Aspire CLI, run: {0}[/]</target>
-        <note>Do not translate [dim]. Also leave [/] as-is. {0} is the command to run</note>
+      <trans-unit id="ToUpdateCliUseCommand">
+        <source>[dim]To update the Aspire CLI, use: {0}[/]</source>
+        <target state="new">[dim]To update the Aspire CLI, use: {0}[/]</target>
+        <note>Do not translate [dim]. Also leave [/] as-is. {0} is the command to use</note>
       </trans-unit>
       <trans-unit id="TrustingCertificates">
         <source>Trusting certificates...</source>

--- a/src/Aspire.Cli/Resources/xlf/InteractionServiceStrings.de.xlf
+++ b/src/Aspire.Cli/Resources/xlf/InteractionServiceStrings.de.xlf
@@ -97,6 +97,11 @@
         <target state="new">[yellow]A new version of Aspire is available: {0}[/]</target>
         <note>Do not translate [yellow] and also leave [/] as-is. {0} is the version number</note>
       </trans-unit>
+      <trans-unit id="NewCliVersionAvailableWithAppHostUpdateCommand">
+        <source>[yellow]A new version of Aspire is available: {0}[/] [dim](use {1} for this AppHost)[/]</source>
+        <target state="new">[yellow]A new version of Aspire is available: {0}[/] [dim](use {1} for this AppHost)[/]</target>
+        <note>Do not translate [yellow], [dim], or [/] as-is. {0} is the version number. {1} is the command to use</note>
+      </trans-unit>
       <trans-unit id="NoItemsAvailableForSelection">
         <source>No items available for selection: {0}</source>
         <target state="translated">Es sind keine Elemente zur Auswahl verfügbar: {0}</target>
@@ -197,15 +202,10 @@
         <target state="translated">Aspire wird beendet.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ToUpdateAppHostRunCommand">
-        <source>[dim]To update this AppHost, run: {0}[/]</source>
-        <target state="new">[dim]To update this AppHost, run: {0}[/]</target>
-        <note>Do not translate [dim]. Also leave [/] as-is. {0} is the command to run</note>
-      </trans-unit>
-      <trans-unit id="ToUpdateCliRunCommand">
-        <source>[dim]To update the Aspire CLI, run: {0}[/]</source>
-        <target state="new">[dim]To update the Aspire CLI, run: {0}[/]</target>
-        <note>Do not translate [dim]. Also leave [/] as-is. {0} is the command to run</note>
+      <trans-unit id="ToUpdateCliUseCommand">
+        <source>[dim]To update the Aspire CLI, use: {0}[/]</source>
+        <target state="new">[dim]To update the Aspire CLI, use: {0}[/]</target>
+        <note>Do not translate [dim]. Also leave [/] as-is. {0} is the command to use</note>
       </trans-unit>
       <trans-unit id="TrustingCertificates">
         <source>Trusting certificates...</source>

--- a/src/Aspire.Cli/Resources/xlf/InteractionServiceStrings.de.xlf
+++ b/src/Aspire.Cli/Resources/xlf/InteractionServiceStrings.de.xlf
@@ -197,9 +197,14 @@
         <target state="translated">Aspire wird beendet.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ToUpdateRunCommand">
-        <source>[dim]To update, run: {0}[/]</source>
-        <target state="translated">[dim]Zum Aktualisieren diesen Befehl ausführen: {0}[/]</target>
+      <trans-unit id="ToUpdateAppHostRunCommand">
+        <source>[dim]To update this AppHost, run: {0}[/]</source>
+        <target state="new">[dim]To update this AppHost, run: {0}[/]</target>
+        <note>Do not translate [dim]. Also leave [/] as-is. {0} is the command to run</note>
+      </trans-unit>
+      <trans-unit id="ToUpdateCliRunCommand">
+        <source>[dim]To update the Aspire CLI, run: {0}[/]</source>
+        <target state="new">[dim]To update the Aspire CLI, run: {0}[/]</target>
         <note>Do not translate [dim]. Also leave [/] as-is. {0} is the command to run</note>
       </trans-unit>
       <trans-unit id="TrustingCertificates">

--- a/src/Aspire.Cli/Resources/xlf/InteractionServiceStrings.es.xlf
+++ b/src/Aspire.Cli/Resources/xlf/InteractionServiceStrings.es.xlf
@@ -197,9 +197,14 @@
         <target state="translated">Deteniendo Aspire.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ToUpdateRunCommand">
-        <source>[dim]To update, run: {0}[/]</source>
-        <target state="translated">[dim]Para actualizar, ejecuta: {0}[/]</target>
+      <trans-unit id="ToUpdateAppHostRunCommand">
+        <source>[dim]To update this AppHost, run: {0}[/]</source>
+        <target state="new">[dim]To update this AppHost, run: {0}[/]</target>
+        <note>Do not translate [dim]. Also leave [/] as-is. {0} is the command to run</note>
+      </trans-unit>
+      <trans-unit id="ToUpdateCliRunCommand">
+        <source>[dim]To update the Aspire CLI, run: {0}[/]</source>
+        <target state="new">[dim]To update the Aspire CLI, run: {0}[/]</target>
         <note>Do not translate [dim]. Also leave [/] as-is. {0} is the command to run</note>
       </trans-unit>
       <trans-unit id="TrustingCertificates">

--- a/src/Aspire.Cli/Resources/xlf/InteractionServiceStrings.es.xlf
+++ b/src/Aspire.Cli/Resources/xlf/InteractionServiceStrings.es.xlf
@@ -97,6 +97,11 @@
         <target state="new">[yellow]A new version of Aspire is available: {0}[/]</target>
         <note>Do not translate [yellow] and also leave [/] as-is. {0} is the version number</note>
       </trans-unit>
+      <trans-unit id="NewCliVersionAvailableWithAppHostUpdateCommand">
+        <source>[yellow]A new version of Aspire is available: {0}[/] [dim](use {1} for this AppHost)[/]</source>
+        <target state="new">[yellow]A new version of Aspire is available: {0}[/] [dim](use {1} for this AppHost)[/]</target>
+        <note>Do not translate [yellow], [dim], or [/] as-is. {0} is the version number. {1} is the command to use</note>
+      </trans-unit>
       <trans-unit id="NoItemsAvailableForSelection">
         <source>No items available for selection: {0}</source>
         <target state="translated">No hay elementos disponibles para la selección: {0}</target>
@@ -197,15 +202,10 @@
         <target state="translated">Deteniendo Aspire.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ToUpdateAppHostRunCommand">
-        <source>[dim]To update this AppHost, run: {0}[/]</source>
-        <target state="new">[dim]To update this AppHost, run: {0}[/]</target>
-        <note>Do not translate [dim]. Also leave [/] as-is. {0} is the command to run</note>
-      </trans-unit>
-      <trans-unit id="ToUpdateCliRunCommand">
-        <source>[dim]To update the Aspire CLI, run: {0}[/]</source>
-        <target state="new">[dim]To update the Aspire CLI, run: {0}[/]</target>
-        <note>Do not translate [dim]. Also leave [/] as-is. {0} is the command to run</note>
+      <trans-unit id="ToUpdateCliUseCommand">
+        <source>[dim]To update the Aspire CLI, use: {0}[/]</source>
+        <target state="new">[dim]To update the Aspire CLI, use: {0}[/]</target>
+        <note>Do not translate [dim]. Also leave [/] as-is. {0} is the command to use</note>
       </trans-unit>
       <trans-unit id="TrustingCertificates">
         <source>Trusting certificates...</source>

--- a/src/Aspire.Cli/Resources/xlf/InteractionServiceStrings.fr.xlf
+++ b/src/Aspire.Cli/Resources/xlf/InteractionServiceStrings.fr.xlf
@@ -197,9 +197,14 @@
         <target state="translated">Arrêt d’Aspire.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ToUpdateRunCommand">
-        <source>[dim]To update, run: {0}[/]</source>
-        <target state="translated">[dim]Pour mettre à jour, exécutez : {0}[/]</target>
+      <trans-unit id="ToUpdateAppHostRunCommand">
+        <source>[dim]To update this AppHost, run: {0}[/]</source>
+        <target state="new">[dim]To update this AppHost, run: {0}[/]</target>
+        <note>Do not translate [dim]. Also leave [/] as-is. {0} is the command to run</note>
+      </trans-unit>
+      <trans-unit id="ToUpdateCliRunCommand">
+        <source>[dim]To update the Aspire CLI, run: {0}[/]</source>
+        <target state="new">[dim]To update the Aspire CLI, run: {0}[/]</target>
         <note>Do not translate [dim]. Also leave [/] as-is. {0} is the command to run</note>
       </trans-unit>
       <trans-unit id="TrustingCertificates">

--- a/src/Aspire.Cli/Resources/xlf/InteractionServiceStrings.fr.xlf
+++ b/src/Aspire.Cli/Resources/xlf/InteractionServiceStrings.fr.xlf
@@ -97,6 +97,11 @@
         <target state="new">[yellow]A new version of Aspire is available: {0}[/]</target>
         <note>Do not translate [yellow] and also leave [/] as-is. {0} is the version number</note>
       </trans-unit>
+      <trans-unit id="NewCliVersionAvailableWithAppHostUpdateCommand">
+        <source>[yellow]A new version of Aspire is available: {0}[/] [dim](use {1} for this AppHost)[/]</source>
+        <target state="new">[yellow]A new version of Aspire is available: {0}[/] [dim](use {1} for this AppHost)[/]</target>
+        <note>Do not translate [yellow], [dim], or [/] as-is. {0} is the version number. {1} is the command to use</note>
+      </trans-unit>
       <trans-unit id="NoItemsAvailableForSelection">
         <source>No items available for selection: {0}</source>
         <target state="translated">Aucun élément disponible pour la sélection : {0}</target>
@@ -197,15 +202,10 @@
         <target state="translated">Arrêt d’Aspire.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ToUpdateAppHostRunCommand">
-        <source>[dim]To update this AppHost, run: {0}[/]</source>
-        <target state="new">[dim]To update this AppHost, run: {0}[/]</target>
-        <note>Do not translate [dim]. Also leave [/] as-is. {0} is the command to run</note>
-      </trans-unit>
-      <trans-unit id="ToUpdateCliRunCommand">
-        <source>[dim]To update the Aspire CLI, run: {0}[/]</source>
-        <target state="new">[dim]To update the Aspire CLI, run: {0}[/]</target>
-        <note>Do not translate [dim]. Also leave [/] as-is. {0} is the command to run</note>
+      <trans-unit id="ToUpdateCliUseCommand">
+        <source>[dim]To update the Aspire CLI, use: {0}[/]</source>
+        <target state="new">[dim]To update the Aspire CLI, use: {0}[/]</target>
+        <note>Do not translate [dim]. Also leave [/] as-is. {0} is the command to use</note>
       </trans-unit>
       <trans-unit id="TrustingCertificates">
         <source>Trusting certificates...</source>

--- a/src/Aspire.Cli/Resources/xlf/InteractionServiceStrings.it.xlf
+++ b/src/Aspire.Cli/Resources/xlf/InteractionServiceStrings.it.xlf
@@ -97,6 +97,11 @@
         <target state="new">[yellow]A new version of Aspire is available: {0}[/]</target>
         <note>Do not translate [yellow] and also leave [/] as-is. {0} is the version number</note>
       </trans-unit>
+      <trans-unit id="NewCliVersionAvailableWithAppHostUpdateCommand">
+        <source>[yellow]A new version of Aspire is available: {0}[/] [dim](use {1} for this AppHost)[/]</source>
+        <target state="new">[yellow]A new version of Aspire is available: {0}[/] [dim](use {1} for this AppHost)[/]</target>
+        <note>Do not translate [yellow], [dim], or [/] as-is. {0} is the version number. {1} is the command to use</note>
+      </trans-unit>
       <trans-unit id="NoItemsAvailableForSelection">
         <source>No items available for selection: {0}</source>
         <target state="translated">Nessun elemento disponibile per la selezione: {0}</target>
@@ -197,15 +202,10 @@
         <target state="translated">Arresto di Aspire.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ToUpdateAppHostRunCommand">
-        <source>[dim]To update this AppHost, run: {0}[/]</source>
-        <target state="new">[dim]To update this AppHost, run: {0}[/]</target>
-        <note>Do not translate [dim]. Also leave [/] as-is. {0} is the command to run</note>
-      </trans-unit>
-      <trans-unit id="ToUpdateCliRunCommand">
-        <source>[dim]To update the Aspire CLI, run: {0}[/]</source>
-        <target state="new">[dim]To update the Aspire CLI, run: {0}[/]</target>
-        <note>Do not translate [dim]. Also leave [/] as-is. {0} is the command to run</note>
+      <trans-unit id="ToUpdateCliUseCommand">
+        <source>[dim]To update the Aspire CLI, use: {0}[/]</source>
+        <target state="new">[dim]To update the Aspire CLI, use: {0}[/]</target>
+        <note>Do not translate [dim]. Also leave [/] as-is. {0} is the command to use</note>
       </trans-unit>
       <trans-unit id="TrustingCertificates">
         <source>Trusting certificates...</source>

--- a/src/Aspire.Cli/Resources/xlf/InteractionServiceStrings.it.xlf
+++ b/src/Aspire.Cli/Resources/xlf/InteractionServiceStrings.it.xlf
@@ -197,9 +197,14 @@
         <target state="translated">Arresto di Aspire.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ToUpdateRunCommand">
-        <source>[dim]To update, run: {0}[/]</source>
-        <target state="translated">[dim]Per aggiornare, eseguire: {0}[/]</target>
+      <trans-unit id="ToUpdateAppHostRunCommand">
+        <source>[dim]To update this AppHost, run: {0}[/]</source>
+        <target state="new">[dim]To update this AppHost, run: {0}[/]</target>
+        <note>Do not translate [dim]. Also leave [/] as-is. {0} is the command to run</note>
+      </trans-unit>
+      <trans-unit id="ToUpdateCliRunCommand">
+        <source>[dim]To update the Aspire CLI, run: {0}[/]</source>
+        <target state="new">[dim]To update the Aspire CLI, run: {0}[/]</target>
         <note>Do not translate [dim]. Also leave [/] as-is. {0} is the command to run</note>
       </trans-unit>
       <trans-unit id="TrustingCertificates">

--- a/src/Aspire.Cli/Resources/xlf/InteractionServiceStrings.ja.xlf
+++ b/src/Aspire.Cli/Resources/xlf/InteractionServiceStrings.ja.xlf
@@ -97,6 +97,11 @@
         <target state="new">[yellow]A new version of Aspire is available: {0}[/]</target>
         <note>Do not translate [yellow] and also leave [/] as-is. {0} is the version number</note>
       </trans-unit>
+      <trans-unit id="NewCliVersionAvailableWithAppHostUpdateCommand">
+        <source>[yellow]A new version of Aspire is available: {0}[/] [dim](use {1} for this AppHost)[/]</source>
+        <target state="new">[yellow]A new version of Aspire is available: {0}[/] [dim](use {1} for this AppHost)[/]</target>
+        <note>Do not translate [yellow], [dim], or [/] as-is. {0} is the version number. {1} is the command to use</note>
+      </trans-unit>
       <trans-unit id="NoItemsAvailableForSelection">
         <source>No items available for selection: {0}</source>
         <target state="translated">選択できる項目がありません: {0}</target>
@@ -197,15 +202,10 @@
         <target state="translated">Aspire を停止しています。</target>
         <note />
       </trans-unit>
-      <trans-unit id="ToUpdateAppHostRunCommand">
-        <source>[dim]To update this AppHost, run: {0}[/]</source>
-        <target state="new">[dim]To update this AppHost, run: {0}[/]</target>
-        <note>Do not translate [dim]. Also leave [/] as-is. {0} is the command to run</note>
-      </trans-unit>
-      <trans-unit id="ToUpdateCliRunCommand">
-        <source>[dim]To update the Aspire CLI, run: {0}[/]</source>
-        <target state="new">[dim]To update the Aspire CLI, run: {0}[/]</target>
-        <note>Do not translate [dim]. Also leave [/] as-is. {0} is the command to run</note>
+      <trans-unit id="ToUpdateCliUseCommand">
+        <source>[dim]To update the Aspire CLI, use: {0}[/]</source>
+        <target state="new">[dim]To update the Aspire CLI, use: {0}[/]</target>
+        <note>Do not translate [dim]. Also leave [/] as-is. {0} is the command to use</note>
       </trans-unit>
       <trans-unit id="TrustingCertificates">
         <source>Trusting certificates...</source>

--- a/src/Aspire.Cli/Resources/xlf/InteractionServiceStrings.ja.xlf
+++ b/src/Aspire.Cli/Resources/xlf/InteractionServiceStrings.ja.xlf
@@ -197,9 +197,14 @@
         <target state="translated">Aspire を停止しています。</target>
         <note />
       </trans-unit>
-      <trans-unit id="ToUpdateRunCommand">
-        <source>[dim]To update, run: {0}[/]</source>
-        <target state="translated">[dim]更新するには、{0}[/] を実行します</target>
+      <trans-unit id="ToUpdateAppHostRunCommand">
+        <source>[dim]To update this AppHost, run: {0}[/]</source>
+        <target state="new">[dim]To update this AppHost, run: {0}[/]</target>
+        <note>Do not translate [dim]. Also leave [/] as-is. {0} is the command to run</note>
+      </trans-unit>
+      <trans-unit id="ToUpdateCliRunCommand">
+        <source>[dim]To update the Aspire CLI, run: {0}[/]</source>
+        <target state="new">[dim]To update the Aspire CLI, run: {0}[/]</target>
         <note>Do not translate [dim]. Also leave [/] as-is. {0} is the command to run</note>
       </trans-unit>
       <trans-unit id="TrustingCertificates">

--- a/src/Aspire.Cli/Resources/xlf/InteractionServiceStrings.ko.xlf
+++ b/src/Aspire.Cli/Resources/xlf/InteractionServiceStrings.ko.xlf
@@ -97,6 +97,11 @@
         <target state="new">[yellow]A new version of Aspire is available: {0}[/]</target>
         <note>Do not translate [yellow] and also leave [/] as-is. {0} is the version number</note>
       </trans-unit>
+      <trans-unit id="NewCliVersionAvailableWithAppHostUpdateCommand">
+        <source>[yellow]A new version of Aspire is available: {0}[/] [dim](use {1} for this AppHost)[/]</source>
+        <target state="new">[yellow]A new version of Aspire is available: {0}[/] [dim](use {1} for this AppHost)[/]</target>
+        <note>Do not translate [yellow], [dim], or [/] as-is. {0} is the version number. {1} is the command to use</note>
+      </trans-unit>
       <trans-unit id="NoItemsAvailableForSelection">
         <source>No items available for selection: {0}</source>
         <target state="translated">선택할 수 있는 항목 없음: {0}</target>
@@ -197,15 +202,10 @@
         <target state="translated">Aspire를 중지하는 중입니다.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ToUpdateAppHostRunCommand">
-        <source>[dim]To update this AppHost, run: {0}[/]</source>
-        <target state="new">[dim]To update this AppHost, run: {0}[/]</target>
-        <note>Do not translate [dim]. Also leave [/] as-is. {0} is the command to run</note>
-      </trans-unit>
-      <trans-unit id="ToUpdateCliRunCommand">
-        <source>[dim]To update the Aspire CLI, run: {0}[/]</source>
-        <target state="new">[dim]To update the Aspire CLI, run: {0}[/]</target>
-        <note>Do not translate [dim]. Also leave [/] as-is. {0} is the command to run</note>
+      <trans-unit id="ToUpdateCliUseCommand">
+        <source>[dim]To update the Aspire CLI, use: {0}[/]</source>
+        <target state="new">[dim]To update the Aspire CLI, use: {0}[/]</target>
+        <note>Do not translate [dim]. Also leave [/] as-is. {0} is the command to use</note>
       </trans-unit>
       <trans-unit id="TrustingCertificates">
         <source>Trusting certificates...</source>

--- a/src/Aspire.Cli/Resources/xlf/InteractionServiceStrings.ko.xlf
+++ b/src/Aspire.Cli/Resources/xlf/InteractionServiceStrings.ko.xlf
@@ -197,9 +197,14 @@
         <target state="translated">Aspire를 중지하는 중입니다.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ToUpdateRunCommand">
-        <source>[dim]To update, run: {0}[/]</source>
-        <target state="translated">[dim]업데이트하려면 다음 명령 실행: {0}[/]</target>
+      <trans-unit id="ToUpdateAppHostRunCommand">
+        <source>[dim]To update this AppHost, run: {0}[/]</source>
+        <target state="new">[dim]To update this AppHost, run: {0}[/]</target>
+        <note>Do not translate [dim]. Also leave [/] as-is. {0} is the command to run</note>
+      </trans-unit>
+      <trans-unit id="ToUpdateCliRunCommand">
+        <source>[dim]To update the Aspire CLI, run: {0}[/]</source>
+        <target state="new">[dim]To update the Aspire CLI, run: {0}[/]</target>
         <note>Do not translate [dim]. Also leave [/] as-is. {0} is the command to run</note>
       </trans-unit>
       <trans-unit id="TrustingCertificates">

--- a/src/Aspire.Cli/Resources/xlf/InteractionServiceStrings.pl.xlf
+++ b/src/Aspire.Cli/Resources/xlf/InteractionServiceStrings.pl.xlf
@@ -197,9 +197,14 @@
         <target state="translated">Zatrzymywanie platformy Aspire.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ToUpdateRunCommand">
-        <source>[dim]To update, run: {0}[/]</source>
-        <target state="translated">[dim]Aby zaktualizować, uruchom: {0}[/]</target>
+      <trans-unit id="ToUpdateAppHostRunCommand">
+        <source>[dim]To update this AppHost, run: {0}[/]</source>
+        <target state="new">[dim]To update this AppHost, run: {0}[/]</target>
+        <note>Do not translate [dim]. Also leave [/] as-is. {0} is the command to run</note>
+      </trans-unit>
+      <trans-unit id="ToUpdateCliRunCommand">
+        <source>[dim]To update the Aspire CLI, run: {0}[/]</source>
+        <target state="new">[dim]To update the Aspire CLI, run: {0}[/]</target>
         <note>Do not translate [dim]. Also leave [/] as-is. {0} is the command to run</note>
       </trans-unit>
       <trans-unit id="TrustingCertificates">

--- a/src/Aspire.Cli/Resources/xlf/InteractionServiceStrings.pl.xlf
+++ b/src/Aspire.Cli/Resources/xlf/InteractionServiceStrings.pl.xlf
@@ -97,6 +97,11 @@
         <target state="new">[yellow]A new version of Aspire is available: {0}[/]</target>
         <note>Do not translate [yellow] and also leave [/] as-is. {0} is the version number</note>
       </trans-unit>
+      <trans-unit id="NewCliVersionAvailableWithAppHostUpdateCommand">
+        <source>[yellow]A new version of Aspire is available: {0}[/] [dim](use {1} for this AppHost)[/]</source>
+        <target state="new">[yellow]A new version of Aspire is available: {0}[/] [dim](use {1} for this AppHost)[/]</target>
+        <note>Do not translate [yellow], [dim], or [/] as-is. {0} is the version number. {1} is the command to use</note>
+      </trans-unit>
       <trans-unit id="NoItemsAvailableForSelection">
         <source>No items available for selection: {0}</source>
         <target state="translated">Brak dostępnych elementów do wyboru: {0}</target>
@@ -197,15 +202,10 @@
         <target state="translated">Zatrzymywanie platformy Aspire.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ToUpdateAppHostRunCommand">
-        <source>[dim]To update this AppHost, run: {0}[/]</source>
-        <target state="new">[dim]To update this AppHost, run: {0}[/]</target>
-        <note>Do not translate [dim]. Also leave [/] as-is. {0} is the command to run</note>
-      </trans-unit>
-      <trans-unit id="ToUpdateCliRunCommand">
-        <source>[dim]To update the Aspire CLI, run: {0}[/]</source>
-        <target state="new">[dim]To update the Aspire CLI, run: {0}[/]</target>
-        <note>Do not translate [dim]. Also leave [/] as-is. {0} is the command to run</note>
+      <trans-unit id="ToUpdateCliUseCommand">
+        <source>[dim]To update the Aspire CLI, use: {0}[/]</source>
+        <target state="new">[dim]To update the Aspire CLI, use: {0}[/]</target>
+        <note>Do not translate [dim]. Also leave [/] as-is. {0} is the command to use</note>
       </trans-unit>
       <trans-unit id="TrustingCertificates">
         <source>Trusting certificates...</source>

--- a/src/Aspire.Cli/Resources/xlf/InteractionServiceStrings.pt-BR.xlf
+++ b/src/Aspire.Cli/Resources/xlf/InteractionServiceStrings.pt-BR.xlf
@@ -197,9 +197,14 @@
         <target state="translated">Interrompendo o Aspire.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ToUpdateRunCommand">
-        <source>[dim]To update, run: {0}[/]</source>
-        <target state="translated">[dim]Para atualizar, execute: {0}[/]</target>
+      <trans-unit id="ToUpdateAppHostRunCommand">
+        <source>[dim]To update this AppHost, run: {0}[/]</source>
+        <target state="new">[dim]To update this AppHost, run: {0}[/]</target>
+        <note>Do not translate [dim]. Also leave [/] as-is. {0} is the command to run</note>
+      </trans-unit>
+      <trans-unit id="ToUpdateCliRunCommand">
+        <source>[dim]To update the Aspire CLI, run: {0}[/]</source>
+        <target state="new">[dim]To update the Aspire CLI, run: {0}[/]</target>
         <note>Do not translate [dim]. Also leave [/] as-is. {0} is the command to run</note>
       </trans-unit>
       <trans-unit id="TrustingCertificates">

--- a/src/Aspire.Cli/Resources/xlf/InteractionServiceStrings.pt-BR.xlf
+++ b/src/Aspire.Cli/Resources/xlf/InteractionServiceStrings.pt-BR.xlf
@@ -97,6 +97,11 @@
         <target state="new">[yellow]A new version of Aspire is available: {0}[/]</target>
         <note>Do not translate [yellow] and also leave [/] as-is. {0} is the version number</note>
       </trans-unit>
+      <trans-unit id="NewCliVersionAvailableWithAppHostUpdateCommand">
+        <source>[yellow]A new version of Aspire is available: {0}[/] [dim](use {1} for this AppHost)[/]</source>
+        <target state="new">[yellow]A new version of Aspire is available: {0}[/] [dim](use {1} for this AppHost)[/]</target>
+        <note>Do not translate [yellow], [dim], or [/] as-is. {0} is the version number. {1} is the command to use</note>
+      </trans-unit>
       <trans-unit id="NoItemsAvailableForSelection">
         <source>No items available for selection: {0}</source>
         <target state="translated">Nenhum item disponível para seleção: {0}</target>
@@ -197,15 +202,10 @@
         <target state="translated">Interrompendo o Aspire.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ToUpdateAppHostRunCommand">
-        <source>[dim]To update this AppHost, run: {0}[/]</source>
-        <target state="new">[dim]To update this AppHost, run: {0}[/]</target>
-        <note>Do not translate [dim]. Also leave [/] as-is. {0} is the command to run</note>
-      </trans-unit>
-      <trans-unit id="ToUpdateCliRunCommand">
-        <source>[dim]To update the Aspire CLI, run: {0}[/]</source>
-        <target state="new">[dim]To update the Aspire CLI, run: {0}[/]</target>
-        <note>Do not translate [dim]. Also leave [/] as-is. {0} is the command to run</note>
+      <trans-unit id="ToUpdateCliUseCommand">
+        <source>[dim]To update the Aspire CLI, use: {0}[/]</source>
+        <target state="new">[dim]To update the Aspire CLI, use: {0}[/]</target>
+        <note>Do not translate [dim]. Also leave [/] as-is. {0} is the command to use</note>
       </trans-unit>
       <trans-unit id="TrustingCertificates">
         <source>Trusting certificates...</source>

--- a/src/Aspire.Cli/Resources/xlf/InteractionServiceStrings.ru.xlf
+++ b/src/Aspire.Cli/Resources/xlf/InteractionServiceStrings.ru.xlf
@@ -197,9 +197,14 @@
         <target state="translated">Производится остановка Aspire.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ToUpdateRunCommand">
-        <source>[dim]To update, run: {0}[/]</source>
-        <target state="translated">[dim]Для обновления выполните: {0}[/]</target>
+      <trans-unit id="ToUpdateAppHostRunCommand">
+        <source>[dim]To update this AppHost, run: {0}[/]</source>
+        <target state="new">[dim]To update this AppHost, run: {0}[/]</target>
+        <note>Do not translate [dim]. Also leave [/] as-is. {0} is the command to run</note>
+      </trans-unit>
+      <trans-unit id="ToUpdateCliRunCommand">
+        <source>[dim]To update the Aspire CLI, run: {0}[/]</source>
+        <target state="new">[dim]To update the Aspire CLI, run: {0}[/]</target>
         <note>Do not translate [dim]. Also leave [/] as-is. {0} is the command to run</note>
       </trans-unit>
       <trans-unit id="TrustingCertificates">

--- a/src/Aspire.Cli/Resources/xlf/InteractionServiceStrings.ru.xlf
+++ b/src/Aspire.Cli/Resources/xlf/InteractionServiceStrings.ru.xlf
@@ -97,6 +97,11 @@
         <target state="new">[yellow]A new version of Aspire is available: {0}[/]</target>
         <note>Do not translate [yellow] and also leave [/] as-is. {0} is the version number</note>
       </trans-unit>
+      <trans-unit id="NewCliVersionAvailableWithAppHostUpdateCommand">
+        <source>[yellow]A new version of Aspire is available: {0}[/] [dim](use {1} for this AppHost)[/]</source>
+        <target state="new">[yellow]A new version of Aspire is available: {0}[/] [dim](use {1} for this AppHost)[/]</target>
+        <note>Do not translate [yellow], [dim], or [/] as-is. {0} is the version number. {1} is the command to use</note>
+      </trans-unit>
       <trans-unit id="NoItemsAvailableForSelection">
         <source>No items available for selection: {0}</source>
         <target state="translated">Нет элементов, доступных для выбора: {0}</target>
@@ -197,15 +202,10 @@
         <target state="translated">Производится остановка Aspire.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ToUpdateAppHostRunCommand">
-        <source>[dim]To update this AppHost, run: {0}[/]</source>
-        <target state="new">[dim]To update this AppHost, run: {0}[/]</target>
-        <note>Do not translate [dim]. Also leave [/] as-is. {0} is the command to run</note>
-      </trans-unit>
-      <trans-unit id="ToUpdateCliRunCommand">
-        <source>[dim]To update the Aspire CLI, run: {0}[/]</source>
-        <target state="new">[dim]To update the Aspire CLI, run: {0}[/]</target>
-        <note>Do not translate [dim]. Also leave [/] as-is. {0} is the command to run</note>
+      <trans-unit id="ToUpdateCliUseCommand">
+        <source>[dim]To update the Aspire CLI, use: {0}[/]</source>
+        <target state="new">[dim]To update the Aspire CLI, use: {0}[/]</target>
+        <note>Do not translate [dim]. Also leave [/] as-is. {0} is the command to use</note>
       </trans-unit>
       <trans-unit id="TrustingCertificates">
         <source>Trusting certificates...</source>

--- a/src/Aspire.Cli/Resources/xlf/InteractionServiceStrings.tr.xlf
+++ b/src/Aspire.Cli/Resources/xlf/InteractionServiceStrings.tr.xlf
@@ -97,6 +97,11 @@
         <target state="new">[yellow]A new version of Aspire is available: {0}[/]</target>
         <note>Do not translate [yellow] and also leave [/] as-is. {0} is the version number</note>
       </trans-unit>
+      <trans-unit id="NewCliVersionAvailableWithAppHostUpdateCommand">
+        <source>[yellow]A new version of Aspire is available: {0}[/] [dim](use {1} for this AppHost)[/]</source>
+        <target state="new">[yellow]A new version of Aspire is available: {0}[/] [dim](use {1} for this AppHost)[/]</target>
+        <note>Do not translate [yellow], [dim], or [/] as-is. {0} is the version number. {1} is the command to use</note>
+      </trans-unit>
       <trans-unit id="NoItemsAvailableForSelection">
         <source>No items available for selection: {0}</source>
         <target state="translated">Seçim için herhangi bir öğe mevcut değil: {0}</target>
@@ -197,15 +202,10 @@
         <target state="translated">Aspire durduruluyor.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ToUpdateAppHostRunCommand">
-        <source>[dim]To update this AppHost, run: {0}[/]</source>
-        <target state="new">[dim]To update this AppHost, run: {0}[/]</target>
-        <note>Do not translate [dim]. Also leave [/] as-is. {0} is the command to run</note>
-      </trans-unit>
-      <trans-unit id="ToUpdateCliRunCommand">
-        <source>[dim]To update the Aspire CLI, run: {0}[/]</source>
-        <target state="new">[dim]To update the Aspire CLI, run: {0}[/]</target>
-        <note>Do not translate [dim]. Also leave [/] as-is. {0} is the command to run</note>
+      <trans-unit id="ToUpdateCliUseCommand">
+        <source>[dim]To update the Aspire CLI, use: {0}[/]</source>
+        <target state="new">[dim]To update the Aspire CLI, use: {0}[/]</target>
+        <note>Do not translate [dim]. Also leave [/] as-is. {0} is the command to use</note>
       </trans-unit>
       <trans-unit id="TrustingCertificates">
         <source>Trusting certificates...</source>

--- a/src/Aspire.Cli/Resources/xlf/InteractionServiceStrings.tr.xlf
+++ b/src/Aspire.Cli/Resources/xlf/InteractionServiceStrings.tr.xlf
@@ -197,9 +197,14 @@
         <target state="translated">Aspire durduruluyor.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ToUpdateRunCommand">
-        <source>[dim]To update, run: {0}[/]</source>
-        <target state="translated">[dim]Güncelleştirmek için çalıştırın: {0}[/]</target>
+      <trans-unit id="ToUpdateAppHostRunCommand">
+        <source>[dim]To update this AppHost, run: {0}[/]</source>
+        <target state="new">[dim]To update this AppHost, run: {0}[/]</target>
+        <note>Do not translate [dim]. Also leave [/] as-is. {0} is the command to run</note>
+      </trans-unit>
+      <trans-unit id="ToUpdateCliRunCommand">
+        <source>[dim]To update the Aspire CLI, run: {0}[/]</source>
+        <target state="new">[dim]To update the Aspire CLI, run: {0}[/]</target>
         <note>Do not translate [dim]. Also leave [/] as-is. {0} is the command to run</note>
       </trans-unit>
       <trans-unit id="TrustingCertificates">

--- a/src/Aspire.Cli/Resources/xlf/InteractionServiceStrings.zh-Hans.xlf
+++ b/src/Aspire.Cli/Resources/xlf/InteractionServiceStrings.zh-Hans.xlf
@@ -97,6 +97,11 @@
         <target state="new">[yellow]A new version of Aspire is available: {0}[/]</target>
         <note>Do not translate [yellow] and also leave [/] as-is. {0} is the version number</note>
       </trans-unit>
+      <trans-unit id="NewCliVersionAvailableWithAppHostUpdateCommand">
+        <source>[yellow]A new version of Aspire is available: {0}[/] [dim](use {1} for this AppHost)[/]</source>
+        <target state="new">[yellow]A new version of Aspire is available: {0}[/] [dim](use {1} for this AppHost)[/]</target>
+        <note>Do not translate [yellow], [dim], or [/] as-is. {0} is the version number. {1} is the command to use</note>
+      </trans-unit>
       <trans-unit id="NoItemsAvailableForSelection">
         <source>No items available for selection: {0}</source>
         <target state="translated">没有可供选择的项目: {0}</target>
@@ -197,15 +202,10 @@
         <target state="translated">正在停止 Aspire。</target>
         <note />
       </trans-unit>
-      <trans-unit id="ToUpdateAppHostRunCommand">
-        <source>[dim]To update this AppHost, run: {0}[/]</source>
-        <target state="new">[dim]To update this AppHost, run: {0}[/]</target>
-        <note>Do not translate [dim]. Also leave [/] as-is. {0} is the command to run</note>
-      </trans-unit>
-      <trans-unit id="ToUpdateCliRunCommand">
-        <source>[dim]To update the Aspire CLI, run: {0}[/]</source>
-        <target state="new">[dim]To update the Aspire CLI, run: {0}[/]</target>
-        <note>Do not translate [dim]. Also leave [/] as-is. {0} is the command to run</note>
+      <trans-unit id="ToUpdateCliUseCommand">
+        <source>[dim]To update the Aspire CLI, use: {0}[/]</source>
+        <target state="new">[dim]To update the Aspire CLI, use: {0}[/]</target>
+        <note>Do not translate [dim]. Also leave [/] as-is. {0} is the command to use</note>
       </trans-unit>
       <trans-unit id="TrustingCertificates">
         <source>Trusting certificates...</source>

--- a/src/Aspire.Cli/Resources/xlf/InteractionServiceStrings.zh-Hans.xlf
+++ b/src/Aspire.Cli/Resources/xlf/InteractionServiceStrings.zh-Hans.xlf
@@ -197,9 +197,14 @@
         <target state="translated">正在停止 Aspire。</target>
         <note />
       </trans-unit>
-      <trans-unit id="ToUpdateRunCommand">
-        <source>[dim]To update, run: {0}[/]</source>
-        <target state="translated">[dim]若要更新，请运行: {0}[/]</target>
+      <trans-unit id="ToUpdateAppHostRunCommand">
+        <source>[dim]To update this AppHost, run: {0}[/]</source>
+        <target state="new">[dim]To update this AppHost, run: {0}[/]</target>
+        <note>Do not translate [dim]. Also leave [/] as-is. {0} is the command to run</note>
+      </trans-unit>
+      <trans-unit id="ToUpdateCliRunCommand">
+        <source>[dim]To update the Aspire CLI, run: {0}[/]</source>
+        <target state="new">[dim]To update the Aspire CLI, run: {0}[/]</target>
         <note>Do not translate [dim]. Also leave [/] as-is. {0} is the command to run</note>
       </trans-unit>
       <trans-unit id="TrustingCertificates">

--- a/src/Aspire.Cli/Resources/xlf/InteractionServiceStrings.zh-Hant.xlf
+++ b/src/Aspire.Cli/Resources/xlf/InteractionServiceStrings.zh-Hant.xlf
@@ -97,6 +97,11 @@
         <target state="new">[yellow]A new version of Aspire is available: {0}[/]</target>
         <note>Do not translate [yellow] and also leave [/] as-is. {0} is the version number</note>
       </trans-unit>
+      <trans-unit id="NewCliVersionAvailableWithAppHostUpdateCommand">
+        <source>[yellow]A new version of Aspire is available: {0}[/] [dim](use {1} for this AppHost)[/]</source>
+        <target state="new">[yellow]A new version of Aspire is available: {0}[/] [dim](use {1} for this AppHost)[/]</target>
+        <note>Do not translate [yellow], [dim], or [/] as-is. {0} is the version number. {1} is the command to use</note>
+      </trans-unit>
       <trans-unit id="NoItemsAvailableForSelection">
         <source>No items available for selection: {0}</source>
         <target state="translated">沒有可供選取的項目: {0}</target>
@@ -197,15 +202,10 @@
         <target state="translated">正在停止 Aspire。</target>
         <note />
       </trans-unit>
-      <trans-unit id="ToUpdateAppHostRunCommand">
-        <source>[dim]To update this AppHost, run: {0}[/]</source>
-        <target state="new">[dim]To update this AppHost, run: {0}[/]</target>
-        <note>Do not translate [dim]. Also leave [/] as-is. {0} is the command to run</note>
-      </trans-unit>
-      <trans-unit id="ToUpdateCliRunCommand">
-        <source>[dim]To update the Aspire CLI, run: {0}[/]</source>
-        <target state="new">[dim]To update the Aspire CLI, run: {0}[/]</target>
-        <note>Do not translate [dim]. Also leave [/] as-is. {0} is the command to run</note>
+      <trans-unit id="ToUpdateCliUseCommand">
+        <source>[dim]To update the Aspire CLI, use: {0}[/]</source>
+        <target state="new">[dim]To update the Aspire CLI, use: {0}[/]</target>
+        <note>Do not translate [dim]. Also leave [/] as-is. {0} is the command to use</note>
       </trans-unit>
       <trans-unit id="TrustingCertificates">
         <source>Trusting certificates...</source>

--- a/src/Aspire.Cli/Resources/xlf/InteractionServiceStrings.zh-Hant.xlf
+++ b/src/Aspire.Cli/Resources/xlf/InteractionServiceStrings.zh-Hant.xlf
@@ -197,9 +197,14 @@
         <target state="translated">正在停止 Aspire。</target>
         <note />
       </trans-unit>
-      <trans-unit id="ToUpdateRunCommand">
-        <source>[dim]To update, run: {0}[/]</source>
-        <target state="translated">[dim]若要更新，請執行: {0}[/]</target>
+      <trans-unit id="ToUpdateAppHostRunCommand">
+        <source>[dim]To update this AppHost, run: {0}[/]</source>
+        <target state="new">[dim]To update this AppHost, run: {0}[/]</target>
+        <note>Do not translate [dim]. Also leave [/] as-is. {0} is the command to run</note>
+      </trans-unit>
+      <trans-unit id="ToUpdateCliRunCommand">
+        <source>[dim]To update the Aspire CLI, run: {0}[/]</source>
+        <target state="new">[dim]To update the Aspire CLI, run: {0}[/]</target>
         <note>Do not translate [dim]. Also leave [/] as-is. {0} is the command to run</note>
       </trans-unit>
       <trans-unit id="TrustingCertificates">

--- a/src/Aspire.Cli/Utils/CliUpdateNotifier.cs
+++ b/src/Aspire.Cli/Utils/CliUpdateNotifier.cs
@@ -116,7 +116,7 @@ internal class CliUpdateNotifier(
         }
 
         var newerVersion = PackageUpdateHelpers.GetNewerVersion(logger, currentVersion, _availablePackages);
-        var updateCommand = newerVersion is null ? null : DotNetToolDetection.GetDotNetToolUpdateCommand() ?? "aspire update";
+        var updateCommand = newerVersion is null ? null : DotNetToolDetection.GetDotNetToolUpdateCommand() ?? "aspire update --self";
         // Derive the lane the recommendation comes from so doctor can show
         // 'Latest version is X (channel: stable)' vs '(channel: prerelease)'.
         // GetNewerVersion picks between newestStable and newestPrerelease

--- a/src/Aspire.Cli/Utils/CliUpdateNotifier.cs
+++ b/src/Aspire.Cli/Utils/CliUpdateNotifier.cs
@@ -13,7 +13,7 @@ internal interface ICliUpdateNotifier
 {
     Task CheckForCliUpdatesAsync(DirectoryInfo workingDirectory, CancellationToken cancellationToken);
     Task<CliVersionStatus> GetVersionStatusAsync(DirectoryInfo workingDirectory, CancellationToken cancellationToken);
-    void NotifyIfUpdateAvailable();
+    void NotifyIfUpdateAvailable(bool includeAppHostUpdateCommand = false);
     bool IsUpdateAvailable();
 }
 
@@ -52,12 +52,12 @@ internal class CliUpdateNotifier(
         _availablePackages = await GetCliPackagesAsync(workingDirectory, cancellationToken);
     }
 
-    public void NotifyIfUpdateAvailable()
+    public void NotifyIfUpdateAvailable(bool includeAppHostUpdateCommand = false)
     {
         var status = GetCachedVersionStatus();
         if (status.LatestVersion is not null)
         {
-            interactionService.DisplayVersionUpdateNotification(status.LatestVersion, status.UpdateCommand);
+            interactionService.DisplayVersionUpdateNotification(status.LatestVersion, status.UpdateCommand, includeAppHostUpdateCommand);
         }
     }
 

--- a/tests/Aspire.Cli.Tests/Commands/BaseCommandTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/BaseCommandTests.cs
@@ -95,7 +95,7 @@ public class BaseCommandTests(ITestOutputHelper outputHelper)
         var testNotifier = new TestCliUpdateNotifier
         {
             IsUpdateAvailableCallback = () => true,
-            NotifyIfUpdateAvailableCallback = () => testInteractionService.DisplayVersionUpdateNotification("13.3.0-preview.1", "aspire update")
+            NotifyIfUpdateAvailableCallback = includeAppHostUpdateCommand => testInteractionService.DisplayVersionUpdateNotification("13.3.0-preview.1", "aspire update", includeAppHostUpdateCommand)
         };
         var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper, options =>
         {
@@ -109,6 +109,7 @@ public class BaseCommandTests(ITestOutputHelper outputHelper)
 
         await result.InvokeAsync().DefaultTimeout();
 
+        Assert.False(testNotifier.LastIncludeAppHostUpdateCommand);
         Assert.Equal(0, testInteractionService.DisplayEmptyLineCount);
     }
 

--- a/tests/Aspire.Cli.Tests/Commands/DoctorCommandTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/DoctorCommandTests.cs
@@ -78,7 +78,7 @@ public class DoctorCommandTests(ITestOutputHelper outputHelper)
             options.ErrorTextWriter = errorWriter;
             options.CliUpdateNotifierFactory = sp => new TestCliUpdateNotifier
             {
-                NotifyIfUpdateAvailableCallback = () =>
+                NotifyIfUpdateAvailableCallback = _ =>
                 {
                     notifierInvoked = true;
                     var interactionService = sp.GetRequiredService<IInteractionService>();

--- a/tests/Aspire.Cli.Tests/Commands/PublishCommandPromptingIntegrationTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/PublishCommandPromptingIntegrationTests.cs
@@ -962,7 +962,7 @@ internal sealed class TestConsoleInteractionServiceWithPromptTracking : IInterac
     public void DisplayMarkdown(string markdown, ConsoleOutput? consoleOverride = null, int? maxWidth = null) { }
     public void DisplayMarkupLine(string markup) { }
 
-    public void DisplayVersionUpdateNotification(string newerVersion, string? updateCommand = null) { }
+    public void DisplayVersionUpdateNotification(string newerVersion, string? updateCommand = null, bool includeAppHostUpdateCommand = false) { }
 
     public void DisplayRenderable(IRenderable renderable) { }
     public Task DisplayLiveAsync(IRenderable initialRenderable, Func<Action<IRenderable>, Task> callback) => callback(_ => { });

--- a/tests/Aspire.Cli.Tests/Commands/StartCommandTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/StartCommandTests.cs
@@ -231,6 +231,44 @@ public class StartCommandTests(ITestOutputHelper outputHelper)
     }
 
     [Fact]
+    public async Task StartCommand_WithSelectedAppHost_IncludesAppHostUpdateCommandInNotification()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        var appHostFile = CreateAppHostFile(workspace);
+        var updateNotifier = new TestCliUpdateNotifier();
+
+        var projectLocator = new TestProjectLocator
+        {
+            UseOrFindAppHostProjectFileWithBehaviorAsyncCallback = (_, _, _, _) =>
+                Task.FromResult(new AppHostProjectSearchResult(appHostFile, [appHostFile]))
+        };
+
+        var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper, options =>
+        {
+            options.ProjectLocatorFactory = _ => projectLocator;
+            options.CliUpdateNotifierFactory = _ => updateNotifier;
+            options.CliHostEnvironmentFactory = sp =>
+            {
+                var configuration = sp.GetRequiredService<IConfiguration>();
+                return new CliHostEnvironment(configuration, nonInteractive: true);
+            };
+        });
+
+        services.Replace(ServiceDescriptor.Singleton<IDetachedProcessLauncher>(new TestDetachedProcessLauncher(() => { })));
+        services.Replace(ServiceDescriptor.Singleton<TimeProvider>(new InstantTimeoutTimeProvider()));
+
+        using var provider = services.BuildServiceProvider();
+
+        var command = provider.GetRequiredService<RootCommand>();
+        var result = command.Parse($"start --apphost {appHostFile.FullName}");
+
+        var exitCode = await result.InvokeAsync().DefaultTimeout();
+
+        Assert.Equal(CliExitCodes.FailedToDotnetRunAppHost, exitCode);
+        Assert.True(updateNotifier.LastIncludeAppHostUpdateCommand);
+    }
+
+    [Fact]
     public async Task StartCommand_WhenRunningInExtensionWithoutDebugSession_StartsVsCodeRunSession()
     {
         using var workspace = TemporaryWorkspace.Create(outputHelper);

--- a/tests/Aspire.Cli.Tests/Commands/UpdateCommandTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/UpdateCommandTests.cs
@@ -2666,8 +2666,8 @@ internal sealed class CancellationTrackingInteractionService : IInteractionServi
         _innerService.DisplayCancellationMessage(consoleOverride);
     }
     public void DisplayEmptyLine() => _innerService.DisplayEmptyLine();
-    public void DisplayVersionUpdateNotification(string newerVersion, string? updateCommand = null) 
-        => _innerService.DisplayVersionUpdateNotification(newerVersion, updateCommand);
+    public void DisplayVersionUpdateNotification(string newerVersion, string? updateCommand = null, bool includeAppHostUpdateCommand = false) 
+        => _innerService.DisplayVersionUpdateNotification(newerVersion, updateCommand, includeAppHostUpdateCommand);
     public void WriteConsoleLog(string message, int? lineNumber = null, string? type = null, bool isErrorMessage = false) 
         => _innerService.WriteConsoleLog(message, lineNumber, type, isErrorMessage);
     public void DisplayRenderable(IRenderable renderable) => _innerService.DisplayRenderable(renderable);

--- a/tests/Aspire.Cli.Tests/Interaction/ConsoleInteractionServiceTests.cs
+++ b/tests/Aspire.Cli.Tests/Interaction/ConsoleInteractionServiceTests.cs
@@ -633,7 +633,7 @@ public class ConsoleInteractionServiceTests
 
         // Version strings are unlikely to have brackets, but the method should handle it
         var version = "13.2.0-preview [beta]";
-        var updateCommand = "aspire update --channel [stable]";
+        var updateCommand = "aspire update --self --channel [stable]";
 
         // Act - should not throw due to unescaped markup characters
         var exception = Record.Exception(() => interactionService.DisplayVersionUpdateNotification(version, updateCommand));
@@ -643,7 +643,9 @@ public class ConsoleInteractionServiceTests
         var outputString = output.ToString();
         Assert.Contains("A new version of Aspire is available:", outputString);
         Assert.Contains("13.2.0-preview [beta]", outputString);
-        Assert.Contains("aspire update --channel [stable]", outputString);
+        Assert.Contains("To update this AppHost, run: aspire update", outputString);
+        Assert.Contains("To update the Aspire CLI, run:", outputString);
+        Assert.Contains("aspire update --self --channel [stable]", outputString);
     }
 
     [Fact]

--- a/tests/Aspire.Cli.Tests/Interaction/ConsoleInteractionServiceTests.cs
+++ b/tests/Aspire.Cli.Tests/Interaction/ConsoleInteractionServiceTests.cs
@@ -643,8 +643,8 @@ public class ConsoleInteractionServiceTests
         var outputString = output.ToString();
         Assert.Contains("A new version of Aspire is available:", outputString);
         Assert.Contains("13.2.0-preview [beta]", outputString);
-        Assert.Contains("To update this AppHost, run: aspire update", outputString);
-        Assert.Contains("To update the Aspire CLI, run:", outputString);
+        Assert.Contains("for this AppHost", outputString);
+        Assert.Contains("To update the Aspire CLI, use:", outputString);
         Assert.Contains("aspire update --self --channel [stable]", outputString);
     }
 
@@ -664,8 +664,8 @@ public class ConsoleInteractionServiceTests
         interactionService.DisplayVersionUpdateNotification("13.2.0", "aspire update --self");
 
         var outputString = output.ToString();
-        Assert.Contains("To update the Aspire CLI, run: aspire update --self", outputString);
-        Assert.DoesNotContain("To update this AppHost, run:", outputString);
+        Assert.Contains("To update the Aspire CLI, use: aspire update --self", outputString);
+        Assert.DoesNotContain("for this AppHost", outputString);
     }
 
     [Fact]

--- a/tests/Aspire.Cli.Tests/Interaction/ConsoleInteractionServiceTests.cs
+++ b/tests/Aspire.Cli.Tests/Interaction/ConsoleInteractionServiceTests.cs
@@ -636,7 +636,7 @@ public class ConsoleInteractionServiceTests
         var updateCommand = "aspire update --self --channel [stable]";
 
         // Act - should not throw due to unescaped markup characters
-        var exception = Record.Exception(() => interactionService.DisplayVersionUpdateNotification(version, updateCommand));
+        var exception = Record.Exception(() => interactionService.DisplayVersionUpdateNotification(version, updateCommand, includeAppHostUpdateCommand: true));
 
         // Assert
         Assert.Null(exception);
@@ -646,6 +646,26 @@ public class ConsoleInteractionServiceTests
         Assert.Contains("To update this AppHost, run: aspire update", outputString);
         Assert.Contains("To update the Aspire CLI, run:", outputString);
         Assert.Contains("aspire update --self --channel [stable]", outputString);
+    }
+
+    [Fact]
+    public void DisplayVersionUpdateNotification_WithoutAppHostContext_DoesNotShowAppHostUpdateCommand()
+    {
+        var output = new StringBuilder();
+        var console = AnsiConsole.Create(new AnsiConsoleSettings
+        {
+            Ansi = AnsiSupport.No,
+            ColorSystem = ColorSystemSupport.NoColors,
+            Out = new AnsiConsoleOutput(new StringWriter(output))
+        });
+
+        var interactionService = CreateInteractionService(console);
+
+        interactionService.DisplayVersionUpdateNotification("13.2.0", "aspire update --self");
+
+        var outputString = output.ToString();
+        Assert.Contains("To update the Aspire CLI, run: aspire update --self", outputString);
+        Assert.DoesNotContain("To update this AppHost, run:", outputString);
     }
 
     [Fact]

--- a/tests/Aspire.Cli.Tests/Projects/ExtensionGuestLauncherTests.cs
+++ b/tests/Aspire.Cli.Tests/Projects/ExtensionGuestLauncherTests.cs
@@ -177,7 +177,7 @@ public class ExtensionGuestLauncherTests
         public void DisplayRawText(string text, ConsoleOutput? consoleOverride = null) => throw new NotImplementedException();
         public void DisplayMarkdown(string markdown, ConsoleOutput? consoleOverride = null, int? maxWidth = null) => throw new NotImplementedException();
         public void DisplayMarkupLine(string markup) => throw new NotImplementedException();
-        public void DisplayVersionUpdateNotification(string newerVersion, string? updateCommand = null) => throw new NotImplementedException();
+        public void DisplayVersionUpdateNotification(string newerVersion, string? updateCommand = null, bool includeAppHostUpdateCommand = false) => throw new NotImplementedException();
         public void DisplayRenderable(Spectre.Console.Rendering.IRenderable renderable) => throw new NotImplementedException();
         public Task DisplayLiveAsync(Spectre.Console.Rendering.IRenderable initialRenderable, Func<Action<Spectre.Console.Rendering.IRenderable>, Task> callback) => throw new NotImplementedException();
     }

--- a/tests/Aspire.Cli.Tests/Templating/DotNetTemplateFactoryTests.cs
+++ b/tests/Aspire.Cli.Tests/Templating/DotNetTemplateFactoryTests.cs
@@ -410,7 +410,7 @@ public class DotNetTemplateFactoryTests
         public void DisplayMarkupLine(string markup) { }
         public void DisplaySubtleMessage(string message, bool allowMarkup = false) { }
         public void DisplayEmptyLine() { }
-        public void DisplayVersionUpdateNotification(string message, string? updateCommand = null) { }
+        public void DisplayVersionUpdateNotification(string message, string? updateCommand = null, bool includeAppHostUpdateCommand = false) { }
         public void WriteConsoleLog(string message, int? resourceHashCode, string? resourceName, bool isError) { }
         public void DisplayRenderable(IRenderable renderable) { }
         public Task DisplayLiveAsync(IRenderable initialRenderable, Func<Action<IRenderable>, Task> callback) => callback(_ => { });

--- a/tests/Aspire.Cli.Tests/TestServices/TestCliUpdateNotifier.cs
+++ b/tests/Aspire.Cli.Tests/TestServices/TestCliUpdateNotifier.cs
@@ -15,7 +15,8 @@ internal sealed class TestCliUpdateNotifier : ICliUpdateNotifier
 
     public Func<DirectoryInfo, CancellationToken, Task>? CheckForCliUpdatesAsyncCallback { get; set; }
 
-    public Action? NotifyIfUpdateAvailableCallback { get; set; }
+    public Action<bool>? NotifyIfUpdateAvailableCallback { get; set; }
+    public bool LastIncludeAppHostUpdateCommand { get; private set; }
 
     public Task CheckForCliUpdatesAsync(DirectoryInfo workingDirectory, CancellationToken cancellationToken)
     {
@@ -34,10 +35,11 @@ internal sealed class TestCliUpdateNotifier : ICliUpdateNotifier
             : Task.FromResult(new CliVersionStatus("13.0.0", null, null));
     }
 
-    public void NotifyIfUpdateAvailable()
+    public void NotifyIfUpdateAvailable(bool includeAppHostUpdateCommand = false)
     {
         NotifyWasCalled = true;
-        NotifyIfUpdateAvailableCallback?.Invoke();
+        LastIncludeAppHostUpdateCommand = includeAppHostUpdateCommand;
+        NotifyIfUpdateAvailableCallback?.Invoke(includeAppHostUpdateCommand);
     }
 
     public bool IsUpdateAvailable()

--- a/tests/Aspire.Cli.Tests/TestServices/TestExtensionInteractionService.cs
+++ b/tests/Aspire.Cli.Tests/TestServices/TestExtensionInteractionService.cs
@@ -179,7 +179,7 @@ internal sealed class TestExtensionInteractionService(IServiceProvider servicePr
 
     public Action<string>? DisplayVersionUpdateNotificationCallback { get; set; }
 
-    public void DisplayVersionUpdateNotification(string newerVersion, string? updateCommand = null)
+    public void DisplayVersionUpdateNotification(string newerVersion, string? updateCommand = null, bool includeAppHostUpdateCommand = false)
     {
         DisplayVersionUpdateNotificationCallback?.Invoke(newerVersion);
     }

--- a/tests/Aspire.Cli.Tests/TestServices/TestInteractionService.cs
+++ b/tests/Aspire.Cli.Tests/TestServices/TestInteractionService.cs
@@ -28,6 +28,7 @@ internal sealed class TestInteractionService : IInteractionService
     public Action<string>? ShowDynamicStatusCallback { get; set; }
     public Action<string>? DisplayVersionUpdateNotificationCallback { get; set; }
     public string? LastVersionUpdateCommand { get; private set; }
+    public bool LastVersionUpdateIncludedAppHostCommand { get; private set; }
 
     /// <summary>
     /// Callback for capturing selection prompts in tests. Uses non-generic IEnumerable and object
@@ -329,9 +330,10 @@ internal sealed class TestInteractionService : IInteractionService
         DisplayConsoleWriteLineMessage?.Invoke(output);
     }
 
-    public void DisplayVersionUpdateNotification(string newerVersion, string? updateCommand = null)
+    public void DisplayVersionUpdateNotification(string newerVersion, string? updateCommand = null, bool includeAppHostUpdateCommand = false)
     {
         LastVersionUpdateCommand = updateCommand;
+        LastVersionUpdateIncludedAppHostCommand = includeAppHostUpdateCommand;
         DisplayVersionUpdateNotificationCallback?.Invoke(newerVersion);
     }
 

--- a/tests/Aspire.Cli.Tests/Utils/CliUpdateNotificationServiceTests.cs
+++ b/tests/Aspire.Cli.Tests/Utils/CliUpdateNotificationServiceTests.cs
@@ -291,7 +291,7 @@ public class CliUpdateNotificationServiceTests(ITestOutputHelper outputHelper)
     }
 
     [Fact]
-    public async Task NotifyIfUpdateAvailable_UsesAspireUpdateCommandForStandaloneArchivePath()
+    public async Task NotifyIfUpdateAvailable_UsesAspireUpdateSelfCommandForStandaloneArchivePath()
     {
         using var workspace = TemporaryWorkspace.Create(outputHelper);
         using var processPathScope = DotNetToolDetection.UseProcessPathForTesting("/home/test/.aspire/bin/aspire");
@@ -328,7 +328,7 @@ public class CliUpdateNotificationServiceTests(ITestOutputHelper outputHelper)
         notifier.NotifyIfUpdateAvailable();
 
         Assert.NotNull(interactionService);
-        Assert.Equal("aspire update", interactionService.LastVersionUpdateCommand);
+        Assert.Equal("aspire update --self", interactionService.LastVersionUpdateCommand);
     }
 
     [Fact]


### PR DESCRIPTION
﻿## Description

The shutdown update notification currently only says to run `aspire update`, which can make it unclear whether users are updating the AppHost or the CLI binary. This clarifies the notification so users see separate guidance for updating the AppHost and updating the Aspire CLI.

### User-facing usage

When an `aspire run` session ends and an Aspire update is available, the notification now distinguishes the commands:

```text
A new version of Aspire is available: 13.3.4
To update this AppHost, run: aspire update
To update the Aspire CLI, run: aspire update --self
For more information, see: https://aka.ms/aspire/update
```

The fallback standalone CLI update recommendation now uses `aspire update --self`, while dotnet tool installs still show their appropriate `dotnet tool update ...` command.

### Validation

- `./restore.cmd`
- `dotnet build /t:UpdateXlf ./src/Aspire.Cli/Aspire.Cli.csproj`
- `dotnet test --project ./tests/Aspire.Cli.Tests/Aspire.Cli.Tests.csproj --no-launch-profile -- --filter-class "*.ConsoleInteractionServiceTests" --filter-class "*.CliUpdateNotificationServiceTests" --filter-not-trait "quarantined=true" --filter-not-trait "outerloop=true"`

Fixes # (issue)

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
