### PR TITLE
Fix browser token auth over HTTP

### DIFF
--- a/src/Aspire.Dashboard/Authentication/AspireDashboardCookieManager.cs
+++ b/src/Aspire.Dashboard/Authentication/AspireDashboardCookieManager.cs
@@ -5,7 +5,7 @@ using Microsoft.AspNetCore.Authentication.Cookies;
 
 namespace Aspire.Dashboard.Authentication;
 
-internal sealed class BrowserTokenCookieManager(string httpCookieName) : ICookieManager
+internal sealed class AspireDashboardCookieManager(string httpCookieName) : ICookieManager
 {
     private readonly ChunkingCookieManager _inner = new();
 
@@ -31,7 +31,7 @@ internal sealed class BrowserTokenCookieManager(string httpCookieName) : ICookie
 
     private string GetCookieName(HttpContext context, string key)
     {
-        // Keep HTTP browser-token cookies separate from HTTPS cookies so browser-specific localhost cookie behavior
+        // Keep HTTP dashboard auth cookies separate from HTTPS cookies so browser-specific localhost cookie behavior
         // can't cause a stale HTTPS cookie to shadow a fresh HTTP sign-in.
         return context.Request.IsHttps ? key : httpCookieName;
     }

--- a/src/Aspire.Dashboard/Authentication/BrowserTokenCookieManager.cs
+++ b/src/Aspire.Dashboard/Authentication/BrowserTokenCookieManager.cs
@@ -22,6 +22,11 @@ internal sealed class BrowserTokenCookieManager(string httpCookieName) : ICookie
     public void DeleteCookie(HttpContext context, string key, CookieOptions options)
     {
         _inner.DeleteCookie(context, GetCookieName(context, key), options);
+
+        if (context.Request.IsHttps && key != httpCookieName)
+        {
+            _inner.DeleteCookie(context, httpCookieName, options);
+        }
     }
 
     private string GetCookieName(HttpContext context, string key)

--- a/src/Aspire.Dashboard/Authentication/BrowserTokenCookieManager.cs
+++ b/src/Aspire.Dashboard/Authentication/BrowserTokenCookieManager.cs
@@ -1,0 +1,33 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.AspNetCore.Authentication.Cookies;
+
+namespace Aspire.Dashboard.Authentication;
+
+internal sealed class BrowserTokenCookieManager(string httpCookieName) : ICookieManager
+{
+    private readonly ChunkingCookieManager _inner = new();
+
+    public string? GetRequestCookie(HttpContext context, string key)
+    {
+        return _inner.GetRequestCookie(context, GetCookieName(context, key));
+    }
+
+    public void AppendResponseCookie(HttpContext context, string key, string? value, CookieOptions options)
+    {
+        _inner.AppendResponseCookie(context, GetCookieName(context, key), value, options);
+    }
+
+    public void DeleteCookie(HttpContext context, string key, CookieOptions options)
+    {
+        _inner.DeleteCookie(context, GetCookieName(context, key), options);
+    }
+
+    private string GetCookieName(HttpContext context, string key)
+    {
+        // Keep HTTP browser-token cookies separate from HTTPS cookies so browser-specific localhost cookie behavior
+        // can't cause a stale HTTPS cookie to shadow a fresh HTTP sign-in.
+        return context.Request.IsHttps ? key : httpCookieName;
+    }
+}

--- a/src/Aspire.Dashboard/DashboardWebApplication.cs
+++ b/src/Aspire.Dashboard/DashboardWebApplication.cs
@@ -63,6 +63,7 @@ public sealed class DashboardWebApplication : IAsyncDisposable
     public const int ExitCodeAddressInUse = DashboardExitCodes.AddressInUse;
 
     private const string DashboardAuthCookieName = ".Aspire.Dashboard.Auth";
+    private const string DashboardHttpAuthCookieName = ".Aspire.Dashboard.Auth.Http";
     private const string DashboardAntiForgeryCookieName = ".Aspire.Dashboard.Antiforgery";
     private readonly WebApplication _app;
     private readonly ILogger<DashboardWebApplication> _logger;
@@ -857,6 +858,7 @@ public sealed class DashboardWebApplication : IAsyncDisposable
                         return Task.CompletedTask;
                     };
                     options.Cookie.Name = DashboardAuthCookieName;
+                    options.CookieManager = new BrowserTokenCookieManager(DashboardHttpAuthCookieName);
                 });
                 break;
             case FrontendAuthMode.Unsecured:

--- a/src/Aspire.Dashboard/DashboardWebApplication.cs
+++ b/src/Aspire.Dashboard/DashboardWebApplication.cs
@@ -800,6 +800,7 @@ public sealed class DashboardWebApplication : IAsyncDisposable
                 authentication.AddCookie(options =>
                 {
                     options.Cookie.Name = DashboardAuthCookieName;
+                    options.CookieManager = new AspireDashboardCookieManager(DashboardHttpAuthCookieName);
                 });
 
                 authentication.AddOpenIdConnect(options =>
@@ -859,7 +860,7 @@ public sealed class DashboardWebApplication : IAsyncDisposable
                         return Task.CompletedTask;
                     };
                     options.Cookie.Name = DashboardAuthCookieName;
-                    options.CookieManager = new BrowserTokenCookieManager(DashboardHttpAuthCookieName);
+                    options.CookieManager = new AspireDashboardCookieManager(DashboardHttpAuthCookieName);
                 });
                 break;
             case FrontendAuthMode.Unsecured:

--- a/src/Aspire.Dashboard/DashboardWebApplication.cs
+++ b/src/Aspire.Dashboard/DashboardWebApplication.cs
@@ -462,6 +462,13 @@ public sealed class DashboardWebApplication : IAsyncDisposable
             _app.UseCors();
         }
 
+        // Use Forwarded Headers middleware if configured. This must run before token validation because sign-in cookie
+        // behavior depends on the normalized request scheme.
+        if (builder.Configuration.GetBool(DashboardConfigNames.ForwardedHeaders.ConfigKey) ?? false)
+        {
+            _app.UseForwardedHeaders();
+        }
+
         _app.UseMiddleware<ValidateTokenMiddleware>();
 
         // Configure the HTTP request pipeline.
@@ -497,12 +504,6 @@ public sealed class DashboardWebApplication : IAsyncDisposable
                 }
             }
         });
-
-        // Use Forwarded Headers middleware if configured.
-        if (builder.Configuration.GetBool(DashboardConfigNames.ForwardedHeaders.ConfigKey) ?? false)
-        {
-            _app.UseForwardedHeaders();
-        }
 
         _app.UseAuthorization();
 

--- a/tests/Aspire.Dashboard.Tests/DashboardOptionsTests.cs
+++ b/tests/Aspire.Dashboard.Tests/DashboardOptionsTests.cs
@@ -5,7 +5,9 @@ using System.Security.Claims;
 using System.Text.Json;
 using Aspire.Dashboard.Configuration;
 using Aspire.Hosting;
+using Microsoft.AspNetCore.Authentication.Cookies;
 using Microsoft.AspNetCore.Authentication.OpenIdConnect;
+using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
@@ -325,6 +327,32 @@ public sealed class DashboardOptionsTests
         Assert.Equal(2, claimIdentity.Claims.Count());
         Assert.True(claimIdentity.HasClaim("role", "admin"));
         Assert.True(claimIdentity.HasClaim("role", "test"));
+    }
+
+    [Fact]
+    public async Task OpenIdConnectOptions_UsesDashboardCookieManager()
+    {
+        await using var app = new DashboardWebApplication(builder => builder.Configuration.AddInMemoryCollection(
+        [
+            new("ASPNETCORE_URLS", "http://localhost:8000/"),
+            new("ASPIRE_DASHBOARD_OTLP_ENDPOINT_URL", "http://localhost:4319/"),
+            new("Authentication:Schemes:OpenIdConnect:Authority", "https://id.aspire.dev/"),
+            new("Authentication:Schemes:OpenIdConnect:ClientId", "aspire-dashboard"),
+            new("Dashboard:Frontend:AuthMode", "OpenIdConnect")
+        ]));
+        var cookieOptions = app.Services.GetRequiredService<IOptionsMonitor<CookieAuthenticationOptions>>().Get(CookieAuthenticationDefaults.AuthenticationScheme);
+        Assert.Equal(".Aspire.Dashboard.Auth", cookieOptions.Cookie.Name);
+
+        var httpContext = new DefaultHttpContext();
+        cookieOptions.CookieManager.AppendResponseCookie(httpContext, cookieOptions.Cookie.Name!, "value", new CookieOptions());
+        var httpCookie = Assert.Single(httpContext.Response.Headers.SetCookie);
+        Assert.StartsWith(".Aspire.Dashboard.Auth.Http=", httpCookie, StringComparison.Ordinal);
+
+        var httpsContext = new DefaultHttpContext();
+        httpsContext.Request.Scheme = "https";
+        cookieOptions.CookieManager.AppendResponseCookie(httpsContext, cookieOptions.Cookie.Name!, "value", new CookieOptions());
+        var httpsCookie = Assert.Single(httpsContext.Response.Headers.SetCookie);
+        Assert.StartsWith(".Aspire.Dashboard.Auth=", httpsCookie, StringComparison.Ordinal);
     }
 
     [Fact]

--- a/tests/Aspire.Dashboard.Tests/Integration/FrontendBrowserTokenAuthTests.cs
+++ b/tests/Aspire.Dashboard.Tests/Integration/FrontendBrowserTokenAuthTests.cs
@@ -76,6 +76,124 @@ public class FrontendBrowserTokenAuthTests
     }
 
     [Fact]
+    public async Task Get_LoginPage_ValidToken_HttpEndpointAfterHttpsEndpoint_RedirectToApp()
+    {
+        var apiKey = "TestKey123!";
+        await using var app = IntegrationTestHelpers.CreateDashboardWebApplication(_testOutputHelper, config =>
+        {
+            config[DashboardConfigNames.DashboardFrontendUrlName.ConfigKey] = "https://127.0.0.1:0;http://127.0.0.1:0";
+            config[DashboardConfigNames.DashboardFrontendAuthModeName.ConfigKey] = FrontendAuthMode.BrowserToken.ToString();
+            config[DashboardConfigNames.DashboardFrontendBrowserTokenName.ConfigKey] = apiKey;
+        });
+        await app.StartAsync().DefaultTimeout();
+
+        var endpoints = app.FrontendEndPointsAccessor
+            .Select(accessor => accessor())
+            .ToList();
+        var httpsEndpoint = endpoints.Single(endpoint => endpoint.IsHttps);
+        var httpEndpoint = endpoints.Single(endpoint => !endpoint.IsHttps);
+
+        var cookieContainer = new CookieContainer();
+        using var handler = new HttpClientHandler
+        {
+            AllowAutoRedirect = true,
+            CookieContainer = cookieContainer,
+            ServerCertificateCustomValidationCallback = HttpClientHandler.DangerousAcceptAnyServerCertificateValidator,
+            UseCookies = true
+        };
+        using var client = new HttpClient(handler);
+
+        var httpsBaseAddress = new Uri(httpsEndpoint.GetResolvedAddress());
+        var httpBaseAddress = new Uri(httpEndpoint.GetResolvedAddress());
+
+        client.BaseAddress = httpsBaseAddress;
+        var response1 = await client.GetAsync(DashboardUrls.LoginUrl(returnUrl: DashboardUrls.TracesUrl(), token: apiKey)).DefaultTimeout();
+
+        Assert.Equal(HttpStatusCode.OK, response1.StatusCode);
+        Assert.Equal(DashboardUrls.TracesUrl(), response1.RequestMessage!.RequestUri!.PathAndQuery);
+
+        var response2 = await client.GetAsync(new Uri(httpBaseAddress, DashboardUrls.LoginUrl(returnUrl: DashboardUrls.TracesUrl(), token: apiKey))).DefaultTimeout();
+
+        Assert.Equal(HttpStatusCode.OK, response2.StatusCode);
+        Assert.Equal(DashboardUrls.TracesUrl(), response2.RequestMessage!.RequestUri!.PathAndQuery);
+
+        var response3 = await client.GetAsync(new Uri(httpBaseAddress, DashboardUrls.StructuredLogsUrl())).DefaultTimeout();
+
+        Assert.Equal(HttpStatusCode.OK, response3.StatusCode);
+        Assert.Equal(DashboardUrls.StructuredLogsUrl(), response3.RequestMessage!.RequestUri!.PathAndQuery);
+    }
+
+    [Fact]
+    public async Task Get_LoginPage_ValidToken_HttpEndpointWithHttpsEndpoint_UsesHttpSpecificCookie()
+    {
+        var apiKey = "TestKey123!";
+        await using var app = IntegrationTestHelpers.CreateDashboardWebApplication(_testOutputHelper, config =>
+        {
+            config[DashboardConfigNames.DashboardFrontendUrlName.ConfigKey] = "https://127.0.0.1:0;http://127.0.0.1:0";
+            config[DashboardConfigNames.DashboardFrontendAuthModeName.ConfigKey] = FrontendAuthMode.BrowserToken.ToString();
+            config[DashboardConfigNames.DashboardFrontendBrowserTokenName.ConfigKey] = apiKey;
+        });
+        await app.StartAsync().DefaultTimeout();
+
+        var endpoints = app.FrontendEndPointsAccessor
+            .Select(accessor => accessor())
+            .ToList();
+        var httpsEndpoint = endpoints.Single(endpoint => endpoint.IsHttps);
+        var httpEndpoint = endpoints.Single(endpoint => !endpoint.IsHttps);
+
+        using var handler = new HttpClientHandler
+        {
+            AllowAutoRedirect = false,
+            ServerCertificateCustomValidationCallback = HttpClientHandler.DangerousAcceptAnyServerCertificateValidator,
+            UseCookies = true
+        };
+        using var client = new HttpClient(handler);
+
+        var httpsResponse = await client.GetAsync(new Uri(new Uri(httpsEndpoint.GetResolvedAddress()), DashboardUrls.LoginUrl(returnUrl: DashboardUrls.TracesUrl(), token: apiKey))).DefaultTimeout();
+        var httpResponse = await client.GetAsync(new Uri(new Uri(httpEndpoint.GetResolvedAddress()), DashboardUrls.LoginUrl(returnUrl: DashboardUrls.TracesUrl(), token: apiKey))).DefaultTimeout();
+
+        Assert.Equal(HttpStatusCode.Redirect, httpsResponse.StatusCode);
+        Assert.Equal(HttpStatusCode.Redirect, httpResponse.StatusCode);
+
+        var httpsCookie = Assert.Single(httpsResponse.Headers.GetValues("Set-Cookie"), c => c.StartsWith(".Aspire.Dashboard.Auth=", StringComparison.Ordinal));
+        var httpCookie = Assert.Single(httpResponse.Headers.GetValues("Set-Cookie"), c => c.StartsWith(".Aspire.Dashboard.Auth.Http=", StringComparison.Ordinal));
+        Assert.Contains("; secure", httpsCookie, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("; secure", httpCookie, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public async Task Get_LoginPage_ValidToken_HttpEndpointWithHttpsEndpoint_RedirectToApp()
+    {
+        var apiKey = "TestKey123!";
+        await using var app = IntegrationTestHelpers.CreateDashboardWebApplication(_testOutputHelper, config =>
+        {
+            config[DashboardConfigNames.DashboardFrontendUrlName.ConfigKey] = "https://127.0.0.1:0;http://127.0.0.1:0";
+            config[DashboardConfigNames.DashboardFrontendAuthModeName.ConfigKey] = FrontendAuthMode.BrowserToken.ToString();
+            config[DashboardConfigNames.DashboardFrontendBrowserTokenName.ConfigKey] = apiKey;
+        });
+        await app.StartAsync().DefaultTimeout();
+
+        var httpEndpoint = app.FrontendEndPointsAccessor
+            .Select(accessor => accessor())
+            .Single(endpoint => !endpoint.IsHttps);
+
+        using var client = new HttpClient(new HttpClientHandler { AllowAutoRedirect = true, UseCookies = true })
+        {
+            BaseAddress = new Uri(httpEndpoint.GetResolvedAddress())
+        };
+
+        var response1 = await client.GetAsync(DashboardUrls.LoginUrl(returnUrl: DashboardUrls.TracesUrl(), token: apiKey)).DefaultTimeout();
+
+        Assert.Equal(HttpStatusCode.OK, response1.StatusCode);
+        Assert.Equal(DashboardUrls.TracesUrl(), response1.RequestMessage!.RequestUri!.PathAndQuery);
+
+        var response2 = await client.GetAsync(DashboardUrls.StructuredLogsUrl()).DefaultTimeout();
+
+        Assert.Equal(HttpStatusCode.OK, response2.StatusCode);
+        Assert.Equal(DashboardUrls.StructuredLogsUrl(), response2.RequestMessage!.RequestUri!.PathAndQuery);
+    }
+
+    [Fact]
     public async Task Get_LoginPage_ValidToken_OtlpHttpConnection_Denied()
     {
         // Arrange

--- a/tests/Aspire.Dashboard.Tests/Integration/FrontendBrowserTokenAuthTests.cs
+++ b/tests/Aspire.Dashboard.Tests/Integration/FrontendBrowserTokenAuthTests.cs
@@ -162,6 +162,46 @@ public class FrontendBrowserTokenAuthTests
     }
 
     [Fact]
+    public async Task Get_Signout_HttpsEndpointWithHttpAndHttpsCookies_DeletesBothCookies()
+    {
+        var apiKey = "TestKey123!";
+        await using var app = IntegrationTestHelpers.CreateDashboardWebApplication(_testOutputHelper, config =>
+        {
+            config[DashboardConfigNames.DashboardFrontendUrlName.ConfigKey] = "https://127.0.0.1:0;http://127.0.0.1:0";
+            config[DashboardConfigNames.DashboardFrontendAuthModeName.ConfigKey] = FrontendAuthMode.BrowserToken.ToString();
+            config[DashboardConfigNames.DashboardFrontendBrowserTokenName.ConfigKey] = apiKey;
+        });
+        await app.StartAsync().DefaultTimeout();
+
+        var endpoints = app.FrontendEndPointsAccessor
+            .Select(accessor => accessor())
+            .ToList();
+        var httpsEndpoint = endpoints.Single(endpoint => endpoint.IsHttps);
+        var httpEndpoint = endpoints.Single(endpoint => !endpoint.IsHttps);
+
+        using var handler = new HttpClientHandler
+        {
+            AllowAutoRedirect = false,
+            ServerCertificateCustomValidationCallback = HttpClientHandler.DangerousAcceptAnyServerCertificateValidator,
+            UseCookies = true
+        };
+        using var client = new HttpClient(handler);
+
+        var httpsBaseAddress = new Uri(httpsEndpoint.GetResolvedAddress());
+        var httpBaseAddress = new Uri(httpEndpoint.GetResolvedAddress());
+
+        await client.GetAsync(new Uri(httpsBaseAddress, DashboardUrls.LoginUrl(returnUrl: DashboardUrls.TracesUrl(), token: apiKey))).DefaultTimeout();
+        await client.GetAsync(new Uri(httpBaseAddress, DashboardUrls.LoginUrl(returnUrl: DashboardUrls.TracesUrl(), token: apiKey))).DefaultTimeout();
+
+        var signoutResponse = await client.GetAsync(new Uri(httpsBaseAddress, "/api/signout")).DefaultTimeout();
+
+        Assert.Equal(HttpStatusCode.Redirect, signoutResponse.StatusCode);
+        var deletedCookies = signoutResponse.Headers.GetValues("Set-Cookie").ToList();
+        Assert.Contains(deletedCookies, c => c.StartsWith(".Aspire.Dashboard.Auth=", StringComparison.Ordinal) && c.Contains("expires=Thu, 01 Jan 1970", StringComparison.OrdinalIgnoreCase));
+        Assert.Contains(deletedCookies, c => c.StartsWith(".Aspire.Dashboard.Auth.Http=", StringComparison.Ordinal) && c.Contains("expires=Thu, 01 Jan 1970", StringComparison.OrdinalIgnoreCase));
+    }
+
+    [Fact]
     public async Task Get_LoginPage_ValidToken_HttpEndpointWithHttpsEndpoint_RedirectToApp()
     {
         var apiKey = "TestKey123!";

--- a/tests/Aspire.Dashboard.Tests/Integration/FrontendBrowserTokenAuthTests.cs
+++ b/tests/Aspire.Dashboard.Tests/Integration/FrontendBrowserTokenAuthTests.cs
@@ -194,6 +194,38 @@ public class FrontendBrowserTokenAuthTests
     }
 
     [Fact]
+    public async Task Get_LoginPage_ValidToken_ForwardedHttps_UsesHttpsCookie()
+    {
+        var apiKey = "TestKey123!";
+        await using var app = IntegrationTestHelpers.CreateDashboardWebApplication(_testOutputHelper, config =>
+        {
+            config[DashboardConfigNames.ForwardedHeaders.ConfigKey] = bool.TrueString;
+            config[DashboardConfigNames.DashboardFrontendAuthModeName.ConfigKey] = FrontendAuthMode.BrowserToken.ToString();
+            config[DashboardConfigNames.DashboardFrontendBrowserTokenName.ConfigKey] = apiKey;
+        });
+        await app.StartAsync().DefaultTimeout();
+
+        using var handler = new HttpClientHandler
+        {
+            AllowAutoRedirect = false,
+            UseCookies = true
+        };
+        using var client = new HttpClient(handler)
+        {
+            BaseAddress = new Uri($"http://{app.FrontendSingleEndPointAccessor().EndPoint}")
+        };
+        client.DefaultRequestHeaders.Add("X-Forwarded-Proto", "https");
+        client.DefaultRequestHeaders.Add("X-Forwarded-Host", "localhost");
+
+        var response = await client.GetAsync(DashboardUrls.LoginUrl(returnUrl: DashboardUrls.TracesUrl(), token: apiKey)).DefaultTimeout();
+
+        Assert.Equal(HttpStatusCode.Redirect, response.StatusCode);
+
+        var cookie = Assert.Single(response.Headers.GetValues("Set-Cookie"), c => c.StartsWith(".Aspire.Dashboard.Auth=", StringComparison.Ordinal));
+        Assert.Contains("; secure", cookie, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
     public async Task Get_LoginPage_ValidToken_OtlpHttpConnection_Denied()
     {
         // Arrange

--- a/tests/Aspire.Dashboard.Tests/Integration/FrontendBrowserTokenAuthTests.cs
+++ b/tests/Aspire.Dashboard.Tests/Integration/FrontendBrowserTokenAuthTests.cs
@@ -197,8 +197,18 @@ public class FrontendBrowserTokenAuthTests
 
         Assert.Equal(HttpStatusCode.Redirect, signoutResponse.StatusCode);
         var deletedCookies = signoutResponse.Headers.GetValues("Set-Cookie").ToList();
-        Assert.Contains(deletedCookies, c => c.StartsWith(".Aspire.Dashboard.Auth=", StringComparison.Ordinal) && c.Contains("expires=Thu, 01 Jan 1970", StringComparison.OrdinalIgnoreCase));
-        Assert.Contains(deletedCookies, c => c.StartsWith(".Aspire.Dashboard.Auth.Http=", StringComparison.Ordinal) && c.Contains("expires=Thu, 01 Jan 1970", StringComparison.OrdinalIgnoreCase));
+        Assert.Collection(
+            deletedCookies,
+            c =>
+            {
+                Assert.StartsWith(".Aspire.Dashboard.Auth=", c, StringComparison.Ordinal);
+                Assert.Contains("expires=Thu, 01 Jan 1970", c, StringComparison.OrdinalIgnoreCase);
+            },
+            c =>
+            {
+                Assert.StartsWith(".Aspire.Dashboard.Auth.Http=", c, StringComparison.Ordinal);
+                Assert.Contains("expires=Thu, 01 Jan 1970", c, StringComparison.OrdinalIgnoreCase);
+            });
     }
 
     [Fact]

--- a/tests/Aspire.Dashboard.Tests/Integration/Playwright/BrowserTokenAuthenticationTests.cs
+++ b/tests/Aspire.Dashboard.Tests/Integration/Playwright/BrowserTokenAuthenticationTests.cs
@@ -1,6 +1,8 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Net;
+using System.Net.Sockets;
 using Aspire.TestUtilities;
 using Aspire.Dashboard.Configuration;
 using Aspire.Dashboard.Resources;
@@ -21,6 +23,23 @@ public class BrowserTokenAuthenticationTests : PlaywrightTestsBase<BrowserTokenA
         {
             Configuration[DashboardConfigNames.DashboardFrontendAuthModeName.ConfigKey] = nameof(FrontendAuthMode.BrowserToken);
             Configuration[DashboardConfigNames.DashboardFrontendBrowserTokenName.ConfigKey] = "VALID_TOKEN";
+        }
+    }
+
+    public sealed class BrowserTokenDashboardServerWithHttpAndHttpsFixture : DashboardServerFixture
+    {
+        public BrowserTokenDashboardServerWithHttpAndHttpsFixture()
+        {
+            Configuration[DashboardConfigNames.DashboardFrontendUrlName.ConfigKey] = $"https://localhost:{GetAvailablePort()};http://localhost:{GetAvailablePort()}";
+            Configuration[DashboardConfigNames.DashboardFrontendAuthModeName.ConfigKey] = nameof(FrontendAuthMode.BrowserToken);
+            Configuration[DashboardConfigNames.DashboardFrontendBrowserTokenName.ConfigKey] = "VALID_TOKEN";
+        }
+
+        private static int GetAvailablePort()
+        {
+            using var listener = new TcpListener(IPAddress.Loopback, 0);
+            listener.Start();
+            return ((IPEndPoint)listener.LocalEndpoint).Port;
         }
     }
 
@@ -121,5 +140,94 @@ public class BrowserTokenAuthenticationTests : PlaywrightTestsBase<BrowserTokenA
             // Assert
             Assert.Equal("submit-token", name);
         });
+    }
+}
+
+[RequiresFeature(TestFeature.Playwright)]
+public class BrowserTokenAuthenticationHttpAndHttpsTests : PlaywrightTestsBase<BrowserTokenAuthenticationTests.BrowserTokenDashboardServerWithHttpAndHttpsFixture>
+{
+    public BrowserTokenAuthenticationHttpAndHttpsTests(BrowserTokenAuthenticationTests.BrowserTokenDashboardServerWithHttpAndHttpsFixture dashboardServerFixture)
+        : base(dashboardServerFixture)
+    {
+    }
+
+    [Fact]
+    [OuterloopTest("Resource-intensive Playwright browser test")]
+    public async Task BrowserToken_QueryStringToken_HttpsThenHttp_WebKit_Success()
+    {
+        using var playwright = await Microsoft.Playwright.Playwright.CreateAsync();
+        await using var browser = await LaunchWebKitAsync(playwright);
+
+        await RunHttpsThenHttpAsync(browser);
+    }
+
+    private static async Task<IBrowser> LaunchWebKitAsync(IPlaywright playwright)
+    {
+        try
+        {
+            return await playwright.Webkit.LaunchAsync(new BrowserTypeLaunchOptions { Headless = true });
+        }
+        catch (PlaywrightException ex) when (IsWebKitBrowserUnavailable(ex))
+        {
+            Assert.Skip("Playwright WebKit is not available in this environment.");
+            throw;
+        }
+    }
+
+    private static bool IsWebKitBrowserUnavailable(PlaywrightException ex)
+    {
+        return ex.Message.Contains("Executable doesn't exist", StringComparison.Ordinal) ||
+            ex.Message.Contains("Host system is missing dependencies", StringComparison.Ordinal);
+    }
+
+    private async Task RunHttpsThenHttpAsync(IBrowser browser)
+    {
+        var endpoints = DashboardServerFixture.DashboardApp.FrontendEndPointsAccessor
+            .Select(accessor => accessor())
+            .ToList();
+        var httpsEndpoint = endpoints.Single(e => e.IsHttps);
+        var httpEndpoint = endpoints.Single(e => !e.IsHttps);
+
+        var httpsBaseUrl = httpsEndpoint.GetResolvedAddress(replaceIPAnyWithLocalhost: true);
+        var httpBaseUrl = httpEndpoint.GetResolvedAddress(replaceIPAnyWithLocalhost: true);
+
+        var context = await browser.NewContextAsync(new BrowserNewContextOptions
+        {
+            IgnoreHTTPSErrors = true
+        });
+        try
+        {
+            var page = await context.NewPageAsync();
+            try
+            {
+                await page.GotoAsync($"{httpsBaseUrl}/login?t=VALID_TOKEN").DefaultTimeout(TestConstants.LongTimeoutTimeSpan);
+                await Assertions
+                    .Expect(page.GetByText(MockDashboardClient.TestResource1.DisplayName))
+                    .ToBeVisibleAsync()
+                    .DefaultTimeout(TestConstants.LongTimeoutTimeSpan);
+
+                await page.GotoAsync($"{httpBaseUrl}/login?t=VALID_TOKEN").DefaultTimeout(TestConstants.LongTimeoutTimeSpan);
+                await Assertions
+                    .Expect(page.GetByText(MockDashboardClient.TestResource1.DisplayName))
+                    .ToBeVisibleAsync()
+                    .DefaultTimeout(TestConstants.LongTimeoutTimeSpan);
+
+                await page.GotoAsync($"{httpBaseUrl}/structuredlogs").DefaultTimeout(TestConstants.LongTimeoutTimeSpan);
+                Assert.Equal("/structuredlogs", new Uri(page.Url).AbsolutePath);
+                await Assertions
+                    .Expect(page.GetByRole(AriaRole.Button, new() { Name = "submit-token" }))
+                    .Not
+                    .ToBeVisibleAsync()
+                    .DefaultTimeout(TestConstants.LongTimeoutTimeSpan);
+            }
+            finally
+            {
+                await page.CloseAsync();
+            }
+        }
+        finally
+        {
+            await context.DisposeAsync();
+        }
     }
 }

--- a/tests/Aspire.Dashboard.Tests/Integration/Playwright/BrowserTokenAuthenticationTests.cs
+++ b/tests/Aspire.Dashboard.Tests/Integration/Playwright/BrowserTokenAuthenticationTests.cs
@@ -1,8 +1,6 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.Net;
-using System.Net.Sockets;
 using Aspire.TestUtilities;
 using Aspire.Dashboard.Configuration;
 using Aspire.Dashboard.Resources;
@@ -30,16 +28,9 @@ public class BrowserTokenAuthenticationTests : PlaywrightTestsBase<BrowserTokenA
     {
         public BrowserTokenDashboardServerWithHttpAndHttpsFixture()
         {
-            Configuration[DashboardConfigNames.DashboardFrontendUrlName.ConfigKey] = $"https://localhost:{GetAvailablePort()};http://localhost:{GetAvailablePort()}";
+            Configuration[DashboardConfigNames.DashboardFrontendUrlName.ConfigKey] = "https://localhost:0;http://localhost:0";
             Configuration[DashboardConfigNames.DashboardFrontendAuthModeName.ConfigKey] = nameof(FrontendAuthMode.BrowserToken);
             Configuration[DashboardConfigNames.DashboardFrontendBrowserTokenName.ConfigKey] = "VALID_TOKEN";
-        }
-
-        private static int GetAvailablePort()
-        {
-            using var listener = new TcpListener(IPAddress.Loopback, 0);
-            listener.Start();
-            return ((IPEndPoint)listener.LocalEndpoint).Port;
         }
     }
 


### PR DESCRIPTION
## Description

Fixes browser-token dashboard authentication when the dashboard frontend is reachable over both HTTPS and HTTP. Browsers can handle localhost cookies differently across schemes, so a Secure HTTPS auth cookie could shadow the HTTP sign-in flow. The dashboard now uses separate auth cookie names for HTTP and HTTPS requests, and applies the same cookie manager to OpenID Connect dashboard auth as well as browser-token auth.

This revives #16818, rebased onto the latest `upstream/main`, and addresses James's review comments by:

- Renaming the cookie manager to `AspireDashboardCookieManager` because it is used by both browser-token auth and OpenID Connect auth.
- Making the sign-out cookie deletion assertion use `Assert.Collection` so the expected two deleted cookies are explicit.
- Adding coverage that OpenID Connect auth uses scheme-specific dashboard auth cookies.

### User-facing usage

Dashboard users can expose both HTTPS and HTTP frontend endpoints and still authenticate consistently:

```json
{
  "Dashboard:Frontend:Url": "https://127.0.0.1:0;http://127.0.0.1:0",
  "Dashboard:Frontend:AuthMode": "BrowserToken"
}
```

HTTPS requests continue to use `.Aspire.Dashboard.Auth`, while HTTP requests use `.Aspire.Dashboard.Auth.Http`.

### Security considerations

This changes dashboard authentication cookie selection. The HTTPS cookie keeps the existing secure cookie name and behavior, while HTTP requests use a separate non-secure cookie name so browser scheme-specific cookie behavior cannot cause a stale HTTPS cookie to be used for an HTTP sign-in. No new listeners, secrets, or token formats are introduced.

Fixes #16067

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [x] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [x] No
  - [ ] No
