### PR TITLE
Show empty state for console logs

### DIFF
--- a/src/Aspire.Dashboard/Components/Controls/LogViewer.razor
+++ b/src/Aspire.Dashboard/Components/Controls/LogViewer.razor
@@ -92,6 +92,14 @@
                     </div>
                 }
             </Virtualize>
+
+            @if (_showEmptyLogsMessage && IsLogEntriesEmpty())
+            {
+                <div class="empty-log-message" role="status" aria-live="polite">
+                    <FluentIcon Value="@(new Icons.Regular.Size24.SlideText())" />
+                    <span>@Loc[nameof(ConsoleLogs.ConsoleLogsNoLogsFound)]</span>
+                </div>
+            }
         }
     </div>
 </div>

--- a/src/Aspire.Dashboard/Components/Controls/LogViewer.razor.cs
+++ b/src/Aspire.Dashboard/Components/Controls/LogViewer.razor.cs
@@ -17,10 +17,13 @@ namespace Aspire.Dashboard.Components;
 /// </summary>
 public sealed partial class LogViewer
 {
+    private static readonly TimeSpan s_emptyLogsMessageDelay = TimeSpan.FromSeconds(2);
     private static readonly MarkupString s_spaceMarkup = new MarkupString("&#32;");
 
     private LogEntries? _logEntries;
     private bool _logsChanged;
+    private bool _showEmptyLogsMessage;
+    private CancellationTokenSource? _emptyLogsMessageDelayCts;
 
     [Inject]
     public required BrowserTimeProvider TimeProvider { get; init; }
@@ -69,6 +72,7 @@ public sealed partial class LogViewer
         }
 
         await VirtualizeRef.RefreshDataAsync();
+        UpdateEmptyLogsMessageState();
         StateHasChanged();
     }
 
@@ -80,8 +84,10 @@ public sealed partial class LogViewer
 
             _logsChanged = true;
             _logEntries = LogEntries;
+            ResetEmptyLogsMessage();
         }
 
+        UpdateEmptyLogsMessageState();
         base.OnParametersSet();
     }
 
@@ -94,6 +100,67 @@ public sealed partial class LogViewer
         }
 
         return ValueTask.FromResult(new ItemsProviderResult<LogEntry>(entries.Skip(r.StartIndex).Take(r.Count), entries.Count));
+    }
+
+    private bool IsLogEntriesEmpty() => _logEntries?.EntriesCount == 0;
+
+    private void UpdateEmptyLogsMessageState()
+    {
+        if (IsLogEntriesEmpty())
+        {
+            StartEmptyLogsMessageDelay();
+        }
+        else
+        {
+            ResetEmptyLogsMessage();
+        }
+    }
+
+    private void StartEmptyLogsMessageDelay()
+    {
+        if (_showEmptyLogsMessage || _emptyLogsMessageDelayCts is not null)
+        {
+            return;
+        }
+
+        _emptyLogsMessageDelayCts = new CancellationTokenSource();
+        _ = ShowEmptyLogsMessageAfterDelayAsync(_emptyLogsMessageDelayCts);
+    }
+
+    private async Task ShowEmptyLogsMessageAfterDelayAsync(CancellationTokenSource delayCts)
+    {
+        try
+        {
+            await Task.Delay(s_emptyLogsMessageDelay, delayCts.Token);
+
+            await InvokeAsync(() =>
+            {
+                if (_emptyLogsMessageDelayCts == delayCts && IsLogEntriesEmpty())
+                {
+                    _showEmptyLogsMessage = true;
+                    StateHasChanged();
+                }
+            });
+        }
+        catch (OperationCanceledException)
+        {
+        }
+        finally
+        {
+            if (_emptyLogsMessageDelayCts == delayCts)
+            {
+                _emptyLogsMessageDelayCts = null;
+            }
+
+            delayCts.Dispose();
+        }
+    }
+
+    private void ResetEmptyLogsMessage()
+    {
+        _showEmptyLogsMessage = false;
+        _emptyLogsMessageDelayCts?.Cancel();
+        _emptyLogsMessageDelayCts = null;
     }
 
     protected override async Task OnAfterRenderAsync(bool firstRender)
@@ -137,6 +204,7 @@ public sealed partial class LogViewer
     {
         Logger.LogDebug("Disposing log viewer.");
 
+        ResetEmptyLogsMessage();
         DimensionManager.OnViewportInformationChanged -= OnBrowserResize;
         return ValueTask.CompletedTask;
     }

--- a/src/Aspire.Dashboard/Components/Controls/LogViewer.razor.css
+++ b/src/Aspire.Dashboard/Components/Controls/LogViewer.razor.css
@@ -147,3 +147,13 @@
     font-variation-settings: var(--type-ramp-minus-1-font-variations);
     user-select: none;
 }
+
+.empty-log-message {
+    align-items: center;
+    color: var(--console-font-color);
+    column-gap: 8px;
+    display: flex;
+    justify-content: center;
+    min-height: 160px;
+    opacity: 0.72;
+}

--- a/src/Aspire.Dashboard/Resources/ConsoleLogs.Designer.cs
+++ b/src/Aspire.Dashboard/Resources/ConsoleLogs.Designer.cs
@@ -68,6 +68,12 @@ namespace Aspire.Dashboard.Resources {
                 return ResourceManager.GetString("ConsoleLogsLogsNotYetAvailable", resourceCulture);
             }
         }
+
+        public static string ConsoleLogsNoLogsFound {
+            get {
+                return ResourceManager.GetString("ConsoleLogsNoLogsFound", resourceCulture);
+            }
+        }
         
         public static string ConsoleLogsWatchingLogs {
             get {

--- a/src/Aspire.Dashboard/Resources/ConsoleLogs.resx
+++ b/src/Aspire.Dashboard/Resources/ConsoleLogs.resx
@@ -130,6 +130,9 @@
   <data name="ConsoleLogsLogsNotYetAvailable" xml:space="preserve">
     <value>Logs not yet available</value>
   </data>
+  <data name="ConsoleLogsNoLogsFound" xml:space="preserve">
+    <value>No logs found</value>
+  </data>
   <data name="ConsoleLogsWatchingLogs" xml:space="preserve">
     <value>Watching logs...</value>
   </data>

--- a/src/Aspire.Dashboard/Resources/xlf/ConsoleLogs.cs.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/ConsoleLogs.cs.xlf
@@ -27,6 +27,11 @@
         <target state="translated">Protokoly ještě nejsou k dispozici.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ConsoleLogsNoLogsFound">
+        <source>No logs found</source>
+        <target state="new">No logs found</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ConsoleLogsNoResourceSelected">
         <source>No resource selected</source>
         <target state="translated">Nevybrán žádný prostředek</target>

--- a/src/Aspire.Dashboard/Resources/xlf/ConsoleLogs.de.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/ConsoleLogs.de.xlf
@@ -27,6 +27,11 @@
         <target state="translated">Protokolle noch nicht verfügbar</target>
         <note />
       </trans-unit>
+      <trans-unit id="ConsoleLogsNoLogsFound">
+        <source>No logs found</source>
+        <target state="new">No logs found</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ConsoleLogsNoResourceSelected">
         <source>No resource selected</source>
         <target state="translated">Keine Ressource ausgewählt</target>

--- a/src/Aspire.Dashboard/Resources/xlf/ConsoleLogs.es.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/ConsoleLogs.es.xlf
@@ -27,6 +27,11 @@
         <target state="translated">Los registros aún no están disponibles</target>
         <note />
       </trans-unit>
+      <trans-unit id="ConsoleLogsNoLogsFound">
+        <source>No logs found</source>
+        <target state="new">No logs found</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ConsoleLogsNoResourceSelected">
         <source>No resource selected</source>
         <target state="translated">No hay ningún recurso seleccionado</target>

--- a/src/Aspire.Dashboard/Resources/xlf/ConsoleLogs.fr.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/ConsoleLogs.fr.xlf
@@ -27,6 +27,11 @@
         <target state="translated">Journaux non disponibles pour le moment</target>
         <note />
       </trans-unit>
+      <trans-unit id="ConsoleLogsNoLogsFound">
+        <source>No logs found</source>
+        <target state="new">No logs found</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ConsoleLogsNoResourceSelected">
         <source>No resource selected</source>
         <target state="translated">Aucune ressource sélectionnée</target>

--- a/src/Aspire.Dashboard/Resources/xlf/ConsoleLogs.it.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/ConsoleLogs.it.xlf
@@ -27,6 +27,11 @@
         <target state="translated">Log non ancora disponibili</target>
         <note />
       </trans-unit>
+      <trans-unit id="ConsoleLogsNoLogsFound">
+        <source>No logs found</source>
+        <target state="new">No logs found</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ConsoleLogsNoResourceSelected">
         <source>No resource selected</source>
         <target state="translated">Nessuna risorsa selezionata</target>

--- a/src/Aspire.Dashboard/Resources/xlf/ConsoleLogs.ja.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/ConsoleLogs.ja.xlf
@@ -27,6 +27,11 @@
         <target state="translated">ログはまだ使用できません</target>
         <note />
       </trans-unit>
+      <trans-unit id="ConsoleLogsNoLogsFound">
+        <source>No logs found</source>
+        <target state="new">No logs found</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ConsoleLogsNoResourceSelected">
         <source>No resource selected</source>
         <target state="translated">リソースが選択されていません</target>

--- a/src/Aspire.Dashboard/Resources/xlf/ConsoleLogs.ko.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/ConsoleLogs.ko.xlf
@@ -27,6 +27,11 @@
         <target state="translated">로그를 아직 사용할 수 없음</target>
         <note />
       </trans-unit>
+      <trans-unit id="ConsoleLogsNoLogsFound">
+        <source>No logs found</source>
+        <target state="new">No logs found</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ConsoleLogsNoResourceSelected">
         <source>No resource selected</source>
         <target state="translated">리소스를 선택하지 않음</target>

--- a/src/Aspire.Dashboard/Resources/xlf/ConsoleLogs.pl.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/ConsoleLogs.pl.xlf
@@ -27,6 +27,11 @@
         <target state="translated">Dzienniki nie są jeszcze dostępne</target>
         <note />
       </trans-unit>
+      <trans-unit id="ConsoleLogsNoLogsFound">
+        <source>No logs found</source>
+        <target state="new">No logs found</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ConsoleLogsNoResourceSelected">
         <source>No resource selected</source>
         <target state="translated">Nie wybrano zasobu</target>

--- a/src/Aspire.Dashboard/Resources/xlf/ConsoleLogs.pt-BR.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/ConsoleLogs.pt-BR.xlf
@@ -27,6 +27,11 @@
         <target state="translated">Logs ainda não disponíveis</target>
         <note />
       </trans-unit>
+      <trans-unit id="ConsoleLogsNoLogsFound">
+        <source>No logs found</source>
+        <target state="new">No logs found</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ConsoleLogsNoResourceSelected">
         <source>No resource selected</source>
         <target state="translated">Não há nenhum recurso selecionado</target>

--- a/src/Aspire.Dashboard/Resources/xlf/ConsoleLogs.ru.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/ConsoleLogs.ru.xlf
@@ -27,6 +27,11 @@
         <target state="translated">Журналы пока недоступны</target>
         <note />
       </trans-unit>
+      <trans-unit id="ConsoleLogsNoLogsFound">
+        <source>No logs found</source>
+        <target state="new">No logs found</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ConsoleLogsNoResourceSelected">
         <source>No resource selected</source>
         <target state="translated">Нет выбранных ресурсов</target>

--- a/src/Aspire.Dashboard/Resources/xlf/ConsoleLogs.tr.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/ConsoleLogs.tr.xlf
@@ -27,6 +27,11 @@
         <target state="translated">Günlükler henüz kullanılamıyor</target>
         <note />
       </trans-unit>
+      <trans-unit id="ConsoleLogsNoLogsFound">
+        <source>No logs found</source>
+        <target state="new">No logs found</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ConsoleLogsNoResourceSelected">
         <source>No resource selected</source>
         <target state="translated">Hiçbir kaynak seçilmedi</target>

--- a/src/Aspire.Dashboard/Resources/xlf/ConsoleLogs.zh-Hans.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/ConsoleLogs.zh-Hans.xlf
@@ -27,6 +27,11 @@
         <target state="translated">日志尚不可用</target>
         <note />
       </trans-unit>
+      <trans-unit id="ConsoleLogsNoLogsFound">
+        <source>No logs found</source>
+        <target state="new">No logs found</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ConsoleLogsNoResourceSelected">
         <source>No resource selected</source>
         <target state="translated">未选择资源</target>

--- a/src/Aspire.Dashboard/Resources/xlf/ConsoleLogs.zh-Hant.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/ConsoleLogs.zh-Hant.xlf
@@ -27,6 +27,11 @@
         <target state="translated">記錄尚不可用</target>
         <note />
       </trans-unit>
+      <trans-unit id="ConsoleLogsNoLogsFound">
+        <source>No logs found</source>
+        <target state="new">No logs found</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ConsoleLogsNoResourceSelected">
         <source>No resource selected</source>
         <target state="translated">未選取任何資源</target>

--- a/tests/Aspire.Dashboard.Components.Tests/Pages/ConsoleLogsTests.cs
+++ b/tests/Aspire.Dashboard.Components.Tests/Pages/ConsoleLogsTests.cs
@@ -371,6 +371,52 @@ public partial class ConsoleLogsTests : DashboardTestContext
     }
 
     [Fact]
+    public async Task ResourceName_NoLogsAfterDelay_ShowsNoLogsFound()
+    {
+        // Arrange
+        var testResource = ModelTestHelpers.CreateResource(resourceName: "test-resource", state: KnownResourceState.Running);
+        var subscribedResourceNameTcs = new TaskCompletionSource<string>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var consoleLogsChannel = Channel.CreateUnbounded<IReadOnlyList<ResourceLogLine>>();
+        var resourceChannel = Channel.CreateUnbounded<IReadOnlyList<ResourceViewModelChange>>();
+        var dashboardClient = new TestDashboardClient(
+            isEnabled: true,
+            consoleLogsChannelProvider: name =>
+            {
+                subscribedResourceNameTcs.TrySetResult(name);
+                return consoleLogsChannel;
+            },
+            resourceChannelProvider: () => resourceChannel,
+            initialResources: [testResource]);
+
+        SetupConsoleLogsServices(dashboardClient);
+
+        var dimensionManager = Services.GetRequiredService<DimensionManager>();
+        var viewport = new ViewportInformation(IsDesktop: true, IsUltraLowHeight: false, IsUltraLowWidth: false);
+        dimensionManager.InvokeOnViewportInformationChanged(viewport);
+
+        // Act
+        var cut = RenderComponent<Components.Pages.ConsoleLogs>(builder =>
+        {
+            builder.Add(p => p.ResourceName, "test-resource");
+            builder.Add(p => p.ViewportInformation, viewport);
+        });
+
+        var instance = cut.Instance;
+        var loc = Services.GetRequiredService<IStringLocalizer<Resources.ConsoleLogs>>();
+
+        // Assert
+        cut.WaitForState(() => instance.PageViewModel.SelectedResource.Id?.InstanceId == testResource.Name);
+        cut.WaitForState(() => instance.PageViewModel.Status == loc[nameof(Resources.ConsoleLogs.ConsoleLogsWatchingLogs)]);
+
+        var subscribedResource = await subscribedResourceNameTcs.Task;
+        Assert.Equal("test-resource", subscribedResource);
+
+        cut.WaitForAssertion(
+            () => Assert.Contains(Resources.ConsoleLogs.ConsoleLogsNoLogsFound, cut.Markup),
+            TimeSpan.FromSeconds(5));
+    }
+
+    [Fact]
     public async Task ReadingLogs_ErrorDuringRead_SetStatusAndLog()
     {
         // Arrange


### PR DESCRIPTION
## Summary
- Shows a console log empty state after logs have had time to stream
- Adds a localized `No logs found` resource and translation placeholders
- Covers the empty state with a ConsoleLogs component test

Fixes #17336

## Tests
- `./dotnet.cmd test --project tests/Aspire.Dashboard.Components.Tests/Aspire.Dashboard.Components.Tests.csproj --no-restore -- --filter-class Aspire.Dashboard.Components.Tests.Pages.ConsoleLogsTests`