### PR TITLE
Run yarn install before extension launch tasks

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -18,6 +18,23 @@
 			},
 			"label": "npm: watch extension",
       "path": "extension",
+			"dependsOn": [
+				"yarn: install extension"
+			],
+			"dependsOrder": "sequence"
+		},
+		{
+			"label": "yarn: install extension",
+			"type": "shell",
+			"command": "npx --yes --package yarn@1.22.22 yarn install --frozen-lockfile --non-interactive",
+			"options": {
+				"cwd": "${workspaceFolder}/extension"
+			},
+			"problemMatcher": [],
+			"presentation": {
+				"reveal": "silent",
+				"group": "watchers"
+			}
 		},
 		{
 			"type": "npm",

--- a/extension/.vscode/tasks.json
+++ b/extension/.vscode/tasks.json
@@ -16,7 +16,24 @@
 				"kind": "build",
 				"isDefault": true
 			},
-			"label": "npm: watch extension"
+			"label": "npm: watch extension",
+			"dependsOn": [
+				"yarn: install extension"
+			],
+			"dependsOrder": "sequence"
+		},
+		{
+			"label": "yarn: install extension",
+			"type": "shell",
+			"command": "npx --yes --package yarn@1.22.22 yarn install --frozen-lockfile --non-interactive",
+			"options": {
+				"cwd": "${workspaceFolder}"
+			},
+			"problemMatcher": [],
+			"presentation": {
+				"reveal": "silent",
+				"group": "watchers"
+			}
 		},
 		{
 			"type": "npm",

--- a/src/Aspire.Cli/Commands/AddCommand.cs
+++ b/src/Aspire.Cli/Commands/AddCommand.cs
@@ -21,6 +21,8 @@ internal sealed class AddCommand : BaseCommand
 {
     internal override HelpGroup HelpGroup => HelpGroup.AppCommands;
 
+    protected override bool UpdateNotificationsEnabled => true;
+
     private readonly IProjectLocator _projectLocator;
     private readonly IntegrationPackageSearchService _integrationPackageSearchService;
     private readonly IAddCommandPrompter _prompter;

--- a/src/Aspire.Cli/Commands/AgentInitCommand.cs
+++ b/src/Aspire.Cli/Commands/AgentInitCommand.cs
@@ -85,8 +85,6 @@ internal sealed class AgentInitCommand : BaseCommand, IPackageMetaPrefetchingCom
             ConsoleInteractionService.NoneChoice)
     };
 
-    protected override bool UpdateNotificationsEnabled => false;
-
     /// <summary>
     /// Public entry point for executing the init command.
     /// This allows McpInitCommand to delegate to this implementation.

--- a/src/Aspire.Cli/Commands/AgentMcpCommand.cs
+++ b/src/Aspire.Cli/Commands/AgentMcpCommand.cs
@@ -85,8 +85,6 @@ internal sealed class AgentMcpCommand : BaseCommand
         Options.Add(s_apiKeyOption);
     }
 
-    protected override bool UpdateNotificationsEnabled => false;
-
     /// <summary>
     /// Public entry point for executing the MCP server command.
     /// This allows McpStartCommand to delegate to this implementation.

--- a/src/Aspire.Cli/Commands/ApiGetCommand.cs
+++ b/src/Aspire.Cli/Commands/ApiGetCommand.cs
@@ -54,8 +54,6 @@ internal sealed class ApiGetCommand : BaseCommand
         Options.Add(s_formatOption);
     }
 
-    protected override bool UpdateNotificationsEnabled => false;
-
     protected override async Task<CommandResult> ExecuteAsync(ParseResult parseResult, CancellationToken cancellationToken)
     {
         using var activity = Telemetry.StartDiagnosticActivity(Name);

--- a/src/Aspire.Cli/Commands/ApiListCommand.cs
+++ b/src/Aspire.Cli/Commands/ApiListCommand.cs
@@ -55,8 +55,6 @@ internal sealed class ApiListCommand : BaseCommand
         Options.Add(s_formatOption);
     }
 
-    protected override bool UpdateNotificationsEnabled => false;
-
     protected override async Task<CommandResult> ExecuteAsync(ParseResult parseResult, CancellationToken cancellationToken)
     {
         using var activity = Telemetry.StartDiagnosticActivity(Name);

--- a/src/Aspire.Cli/Commands/ApiSearchCommand.cs
+++ b/src/Aspire.Cli/Commands/ApiSearchCommand.cs
@@ -67,8 +67,6 @@ internal sealed class ApiSearchCommand : BaseCommand
         Options.Add(s_limitOption);
     }
 
-    protected override bool UpdateNotificationsEnabled => false;
-
     protected override async Task<CommandResult> ExecuteAsync(ParseResult parseResult, CancellationToken cancellationToken)
     {
         using var activity = Telemetry.StartDiagnosticActivity(Name);

--- a/src/Aspire.Cli/Commands/BaseCommand.cs
+++ b/src/Aspire.Cli/Commands/BaseCommand.cs
@@ -114,7 +114,7 @@ internal abstract class BaseCommand : Command
                 }
             }
 
-            if (UpdateNotificationsEnabled && features.IsFeatureEnabled(KnownFeatures.UpdateNotificationsEnabled, true))
+            if (UpdateNotificationsEnabled && !IsJsonFormatRequested(parseResult) && features.IsFeatureEnabled(KnownFeatures.UpdateNotificationsEnabled, true))
             {
                 try
                 {

--- a/src/Aspire.Cli/Commands/BaseCommand.cs
+++ b/src/Aspire.Cli/Commands/BaseCommand.cs
@@ -17,7 +17,7 @@ internal abstract class BaseCommand : Command
 {
     private static readonly int[] s_suppressErrorLogsMessageExitCodes = [CliExitCodes.Cancelled, CliExitCodes.MissingRequiredArgument];
 
-    protected virtual bool UpdateNotificationsEnabled { get; } = true;
+    protected virtual bool UpdateNotificationsEnabled { get; }
 
     /// <summary>
     /// Gets the help group for this command.

--- a/src/Aspire.Cli/Commands/CacheCommand.cs
+++ b/src/Aspire.Cli/Commands/CacheCommand.cs
@@ -30,8 +30,6 @@ internal sealed class CacheCommand : ParentCommand
         {
         }
 
-        protected override bool UpdateNotificationsEnabled => false;
-
         protected override Task<CommandResult> ExecuteAsync(ParseResult parseResult, CancellationToken cancellationToken)
         {
             try

--- a/src/Aspire.Cli/Commands/CertificatesCleanCommand.cs
+++ b/src/Aspire.Cli/Commands/CertificatesCleanCommand.cs
@@ -25,8 +25,6 @@ internal sealed class CertificatesCleanCommand : BaseCommand
         _certificateToolRunner = certificateToolRunner;
     }
 
-    protected override bool UpdateNotificationsEnabled => false;
-
     protected override Task<CommandResult> ExecuteAsync(ParseResult parseResult, CancellationToken cancellationToken)
     {
         InteractionService.DisplayMessage(KnownEmojis.Information, CertificatesCommandStrings.CleanProgress);

--- a/src/Aspire.Cli/Commands/CertificatesTrustCommand.cs
+++ b/src/Aspire.Cli/Commands/CertificatesTrustCommand.cs
@@ -25,8 +25,6 @@ internal sealed class CertificatesTrustCommand : BaseCommand
         _certificateService = certificateService;
     }
 
-    protected override bool UpdateNotificationsEnabled => false;
-
     protected override async Task<CommandResult> ExecuteAsync(ParseResult parseResult, CancellationToken cancellationToken)
     {
         InteractionService.DisplayMessage(KnownEmojis.Information, CertificatesCommandStrings.TrustProgress);

--- a/src/Aspire.Cli/Commands/ConfigCommand.cs
+++ b/src/Aspire.Cli/Commands/ConfigCommand.cs
@@ -41,8 +41,6 @@ internal sealed class ConfigCommand : BaseCommand
         Subcommands.Add(infoCommand);
     }
 
-    protected override bool UpdateNotificationsEnabled => false;
-
     protected override async Task<CommandResult> ExecuteAsync(ParseResult parseResult, CancellationToken cancellationToken)
     {
         if (_configuration[KnownConfigNames.ExtensionPromptEnabled] is not "true")
@@ -76,8 +74,6 @@ internal sealed class ConfigCommand : BaseCommand
         {
             Arguments.Add(s_keyArgument);
         }
-
-        protected override bool UpdateNotificationsEnabled => false;
 
         protected override async Task<CommandResult> ExecuteAsync(ParseResult parseResult, CancellationToken cancellationToken)
         {
@@ -135,8 +131,6 @@ internal sealed class ConfigCommand : BaseCommand
             Arguments.Add(s_valueArgument);
             Options.Add(s_globalOption);
         }
-
-        protected override bool UpdateNotificationsEnabled => false;
 
         protected override async Task<CommandResult> ExecuteAsync(ParseResult parseResult, CancellationToken cancellationToken)
         {
@@ -217,8 +211,6 @@ internal sealed class ConfigCommand : BaseCommand
         {
             Options.Add(s_allOption);
         }
-
-        protected override bool UpdateNotificationsEnabled => false;
 
         protected override async Task<CommandResult> ExecuteAsync(ParseResult parseResult, CancellationToken cancellationToken)
         {
@@ -376,8 +368,6 @@ internal sealed class ConfigCommand : BaseCommand
             Options.Add(s_globalOption);
         }
 
-        protected override bool UpdateNotificationsEnabled => false;
-
         protected override async Task<CommandResult> ExecuteAsync(ParseResult parseResult, CancellationToken cancellationToken)
         {
             var key = parseResult.GetValue(s_keyArgument);
@@ -460,8 +450,6 @@ internal sealed class ConfigCommand : BaseCommand
             };
             Options.Add(jsonOption);
         }
-
-        protected override bool UpdateNotificationsEnabled => false;
 
         protected override async Task<CommandResult> ExecuteAsync(ParseResult parseResult, CancellationToken cancellationToken)
         {

--- a/src/Aspire.Cli/Commands/DashboardRunCommand.cs
+++ b/src/Aspire.Cli/Commands/DashboardRunCommand.cs
@@ -25,6 +25,8 @@ internal sealed class DashboardRunCommand : BaseCommand
 {
     internal override HelpGroup HelpGroup => HelpGroup.Monitoring;
 
+    protected override bool UpdateNotificationsEnabled => true;
+
     private readonly IInteractionService _interactionService;
     private readonly IBundleService _bundleService;
     private readonly LayoutProcessRunner _layoutProcessRunner;

--- a/src/Aspire.Cli/Commands/DescribeCommand.cs
+++ b/src/Aspire.Cli/Commands/DescribeCommand.cs
@@ -77,6 +77,8 @@ internal sealed class DescribeCommand : BaseCommand
 {
     internal override HelpGroup HelpGroup => HelpGroup.Monitoring;
 
+    protected override bool UpdateNotificationsEnabled => true;
+
     private readonly IInteractionService _interactionService;
     private readonly AppHostConnectionResolver _connectionResolver;
     private readonly ResourceColorMap _resourceColorMap;

--- a/src/Aspire.Cli/Commands/DocsGetCommand.cs
+++ b/src/Aspire.Cli/Commands/DocsGetCommand.cs
@@ -55,8 +55,6 @@ internal sealed class DocsGetCommand : BaseCommand
         Options.Add(s_formatOption);
     }
 
-    protected override bool UpdateNotificationsEnabled => false;
-
     protected override async Task<CommandResult> ExecuteAsync(ParseResult parseResult, CancellationToken cancellationToken)
     {
         using var activity = Telemetry.StartDiagnosticActivity(Name);

--- a/src/Aspire.Cli/Commands/DocsListCommand.cs
+++ b/src/Aspire.Cli/Commands/DocsListCommand.cs
@@ -44,8 +44,6 @@ internal sealed class DocsListCommand : BaseCommand
         Options.Add(s_formatOption);
     }
 
-    protected override bool UpdateNotificationsEnabled => false;
-
     protected override async Task<CommandResult> ExecuteAsync(ParseResult parseResult, CancellationToken cancellationToken)
     {
         using var activity = Telemetry.StartDiagnosticActivity(Name);

--- a/src/Aspire.Cli/Commands/DocsSearchCommand.cs
+++ b/src/Aspire.Cli/Commands/DocsSearchCommand.cs
@@ -56,8 +56,6 @@ internal sealed class DocsSearchCommand : BaseCommand
         Options.Add(s_limitOption);
     }
 
-    protected override bool UpdateNotificationsEnabled => false;
-
     protected override async Task<CommandResult> ExecuteAsync(ParseResult parseResult, CancellationToken cancellationToken)
     {
         using var activity = Telemetry.StartDiagnosticActivity(Name);

--- a/src/Aspire.Cli/Commands/DoctorCommand.cs
+++ b/src/Aspire.Cli/Commands/DoctorCommand.cs
@@ -24,7 +24,6 @@ internal sealed class DoctorCommand : BaseCommand
     // BaseCommand-driven update banner would print a second, less-structured copy on
     // stderr — pure duplication, plus noise for JSON consumers. Matches the convention
     // already used by other --format json commands (ApiGet, ApiList, DocsSearch, DocsList).
-    protected override bool UpdateNotificationsEnabled => false;
 
     private readonly IEnvironmentChecker _environmentChecker;
     private readonly IInstallationDiscovery _installationDiscovery;

--- a/src/Aspire.Cli/Commands/ExportCommand.cs
+++ b/src/Aspire.Cli/Commands/ExportCommand.cs
@@ -26,6 +26,8 @@ internal sealed class ExportCommand : BaseCommand
 {
     internal override HelpGroup HelpGroup => HelpGroup.Monitoring;
 
+    protected override bool UpdateNotificationsEnabled => true;
+
     private readonly IInteractionService _interactionService;
     private readonly AppHostConnectionResolver _connectionResolver;
     private readonly ILogger<ExportCommand> _logger;

--- a/src/Aspire.Cli/Commands/ExtensionInternalCommand.cs
+++ b/src/Aspire.Cli/Commands/ExtensionInternalCommand.cs
@@ -35,8 +35,6 @@ internal sealed class ExtensionInternalCommand : BaseCommand
             _projectLocator = projectLocator;
         }
 
-        protected override bool UpdateNotificationsEnabled => false;
-
         protected override async Task<CommandResult> ExecuteAsync(ParseResult parseResult, CancellationToken cancellationToken)
         {
             try

--- a/src/Aspire.Cli/Commands/InitCommand.cs
+++ b/src/Aspire.Cli/Commands/InitCommand.cs
@@ -34,6 +34,8 @@ internal sealed class InitCommand : BaseCommand
 {
     internal override HelpGroup HelpGroup => HelpGroup.AppCommands;
 
+    protected override bool UpdateNotificationsEnabled => true;
+
     private readonly CliExecutionContext _executionContext;
     private readonly ILanguageService _languageService;
     private readonly ISolutionLocator _solutionLocator;

--- a/src/Aspire.Cli/Commands/IntegrationSearchCommand.cs
+++ b/src/Aspire.Cli/Commands/IntegrationSearchCommand.cs
@@ -42,8 +42,6 @@ internal abstract class IntegrationDiscoveryCommand : BaseCommand
         Options.Add(_formatOption);
     }
 
-    protected override bool UpdateNotificationsEnabled => false;
-
     protected abstract string? GetSearchTerm(ParseResult parseResult);
 
     protected override async Task<CommandResult> ExecuteAsync(ParseResult parseResult, CancellationToken cancellationToken)

--- a/src/Aspire.Cli/Commands/LogsCommand.cs
+++ b/src/Aspire.Cli/Commands/LogsCommand.cs
@@ -79,6 +79,8 @@ internal sealed class LogsCommand : BaseCommand
 {
     internal override HelpGroup HelpGroup => HelpGroup.Monitoring;
 
+    protected override bool UpdateNotificationsEnabled => true;
+
     private readonly IInteractionService _interactionService;
     private readonly ICliHostEnvironment _hostEnvironment;
     private readonly AppHostConnectionResolver _connectionResolver;

--- a/src/Aspire.Cli/Commands/LsCommand.cs
+++ b/src/Aspire.Cli/Commands/LsCommand.cs
@@ -18,6 +18,8 @@ internal sealed class LsCommand : BaseCommand
 {
     internal override HelpGroup HelpGroup => HelpGroup.AppCommands;
 
+    protected override bool UpdateNotificationsEnabled => true;
+
     private readonly IInteractionService _interactionService;
     private readonly IProjectLocator _projectLocator;
     private readonly CliExecutionContext _executionContext;

--- a/src/Aspire.Cli/Commands/McpInitCommand.cs
+++ b/src/Aspire.Cli/Commands/McpInitCommand.cs
@@ -58,8 +58,6 @@ internal sealed class McpInitCommand : BaseCommand, IPackageMetaPrefetchingComma
             telemetry);
     }
 
-    protected override bool UpdateNotificationsEnabled => false;
-
     protected override async Task<CommandResult> ExecuteAsync(ParseResult parseResult, CancellationToken cancellationToken)
     {
         // Display deprecation warning

--- a/src/Aspire.Cli/Commands/McpStartCommand.cs
+++ b/src/Aspire.Cli/Commands/McpStartCommand.cs
@@ -31,8 +31,6 @@ internal sealed class McpStartCommand : BaseCommand
         _agentMcpCommand = agentMcpCommand;
     }
 
-    protected override bool UpdateNotificationsEnabled => false;
-
     protected override async Task<CommandResult> ExecuteAsync(ParseResult parseResult, CancellationToken cancellationToken)
     {
         // Display deprecation warning to stderr (all MCP logging goes to stderr)

--- a/src/Aspire.Cli/Commands/NewCommand.cs
+++ b/src/Aspire.Cli/Commands/NewCommand.cs
@@ -24,6 +24,8 @@ internal sealed class NewCommand : BaseCommand, IPackageMetaPrefetchingCommand
 {
     internal override HelpGroup HelpGroup => HelpGroup.AppCommands;
 
+    protected override bool UpdateNotificationsEnabled => true;
+
     private readonly INewCommandPrompter _prompter;
     private readonly ITemplateProvider _templateProvider;
     private readonly ITemplate[] _templates;

--- a/src/Aspire.Cli/Commands/ParentCommand.cs
+++ b/src/Aspire.Cli/Commands/ParentCommand.cs
@@ -19,8 +19,6 @@ internal abstract class ParentCommand : BaseCommand
     {
     }
 
-    protected override bool UpdateNotificationsEnabled => false;
-
     protected sealed override Task<CommandResult> ExecuteAsync(ParseResult parseResult, CancellationToken cancellationToken)
     {
         return Task.FromResult(CommandResult.DisplayHelp());

--- a/src/Aspire.Cli/Commands/PipelineCommandBase.cs
+++ b/src/Aspire.Cli/Commands/PipelineCommandBase.cs
@@ -25,6 +25,8 @@ namespace Aspire.Cli.Commands;
 
 internal abstract class PipelineCommandBase : BaseCommand
 {
+    protected override bool UpdateNotificationsEnabled => true;
+
     private const string CustomChoiceValue = "__CUSTOM_CHOICE";
 
     protected readonly IDotNetCliRunner _runner;

--- a/src/Aspire.Cli/Commands/PsCommand.cs
+++ b/src/Aspire.Cli/Commands/PsCommand.cs
@@ -71,6 +71,8 @@ internal sealed class PsCommand : BaseCommand
 {
     internal override HelpGroup HelpGroup => HelpGroup.AppCommands;
 
+    protected override bool UpdateNotificationsEnabled => true;
+
     private readonly IInteractionService _interactionService;
     private readonly IAuxiliaryBackchannelMonitor _backchannelMonitor;
     private readonly ILogger<PsCommand> _logger;

--- a/src/Aspire.Cli/Commands/RenderCommand.cs
+++ b/src/Aspire.Cli/Commands/RenderCommand.cs
@@ -109,8 +109,6 @@ internal sealed class RenderCommand : BaseCommand
         Hidden = true;
     }
 
-    protected override bool UpdateNotificationsEnabled => false;
-
     protected override async Task<CommandResult> ExecuteAsync(ParseResult parseResult, CancellationToken cancellationToken)
     {
         if (parseResult.GetValue(s_listScenariosOption))

--- a/src/Aspire.Cli/Commands/ResourceCommand.cs
+++ b/src/Aspire.Cli/Commands/ResourceCommand.cs
@@ -23,6 +23,8 @@ internal sealed class ResourceCommand : BaseCommand
 {
     internal override HelpGroup HelpGroup => HelpGroup.ResourceManagement;
 
+    protected override bool UpdateNotificationsEnabled => true;
+
     private readonly IInteractionService _interactionService;
     private readonly IAuxiliaryBackchannelMonitor _backchannelMonitor;
     private readonly IProjectLocator _projectLocator;

--- a/src/Aspire.Cli/Commands/RestoreCommand.cs
+++ b/src/Aspire.Cli/Commands/RestoreCommand.cs
@@ -24,6 +24,8 @@ internal sealed class RestoreCommand : BaseCommand
 {
     internal override HelpGroup HelpGroup => HelpGroup.AppCommands;
 
+    protected override bool UpdateNotificationsEnabled => true;
+
     private readonly IProjectLocator _projectLocator;
     private readonly IAppHostProjectFactory _projectFactory;
     private readonly ILanguageDiscovery _languageDiscovery;

--- a/src/Aspire.Cli/Commands/Sdk/SdkDumpCommand.cs
+++ b/src/Aspire.Cli/Commands/Sdk/SdkDumpCommand.cs
@@ -36,8 +36,6 @@ internal sealed class SdkDumpCommand : BaseCommand
     private readonly IAppHostServerProjectFactory _appHostServerProjectFactory;
     private readonly ILogger<SdkDumpCommand> _logger;
 
-    protected override bool UpdateNotificationsEnabled => false;
-
     private static readonly Argument<string[]> s_integrationArgument = new("integrations")
     {
         Description = "Integrations to scan. Each can be a .csproj path or a NuGet package in PackageName@Version format. If not specified, dumps core Aspire.Hosting capabilities.",

--- a/src/Aspire.Cli/Commands/SetupCommand.cs
+++ b/src/Aspire.Cli/Commands/SetupCommand.cs
@@ -15,6 +15,8 @@ namespace Aspire.Cli.Commands;
 /// </summary>
 internal sealed class SetupCommand : BaseCommand
 {
+    protected override bool UpdateNotificationsEnabled => true;
+
     private readonly IBundleService _bundleService;
 
     private static readonly Option<string?> s_installPathOption = new("--install-path")

--- a/src/Aspire.Cli/Commands/StartCommand.cs
+++ b/src/Aspire.Cli/Commands/StartCommand.cs
@@ -18,6 +18,8 @@ internal sealed class StartCommand : BaseCommand
 {
     internal override HelpGroup HelpGroup => HelpGroup.AppCommands;
 
+    protected override bool UpdateNotificationsEnabled => true;
+
     private readonly AppHostLauncher _appHostLauncher;
     private readonly IConfiguration _configuration;
 

--- a/src/Aspire.Cli/Commands/StopCommand.cs
+++ b/src/Aspire.Cli/Commands/StopCommand.cs
@@ -19,6 +19,8 @@ internal sealed class StopCommand : BaseCommand
 {
     internal override HelpGroup HelpGroup => HelpGroup.AppCommands;
 
+    protected override bool UpdateNotificationsEnabled => true;
+
     private readonly IInteractionService _interactionService;
     private readonly AppHostConnectionResolver _connectionResolver;
     private readonly ILogger<StopCommand> _logger;

--- a/src/Aspire.Cli/Commands/UpdateCommand.cs
+++ b/src/Aspire.Cli/Commands/UpdateCommand.cs
@@ -105,8 +105,6 @@ internal sealed class UpdateCommand : BaseCommand
         Options.Add(_qualityOption);
     }
 
-    protected override bool UpdateNotificationsEnabled => false;
-
     private static string? GetDotNetToolUpdateCommand()
     {
         return DotNetToolDetection.GetDotNetToolUpdateCommand();

--- a/src/Aspire.Cli/Commands/WaitCommand.cs
+++ b/src/Aspire.Cli/Commands/WaitCommand.cs
@@ -18,6 +18,8 @@ internal sealed class WaitCommand : BaseCommand
 {
     internal override HelpGroup HelpGroup => HelpGroup.ResourceManagement;
 
+    protected override bool UpdateNotificationsEnabled => true;
+
     private readonly IInteractionService _interactionService;
     private readonly AppHostConnectionResolver _connectionResolver;
     private readonly ILogger<WaitCommand> _logger;

--- a/tests/Aspire.Cli.Tests/Commands/BaseCommandTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/BaseCommandTests.cs
@@ -112,6 +112,33 @@ public class BaseCommandTests(ITestOutputHelper outputHelper)
         Assert.Equal(0, testInteractionService.DisplayEmptyLineCount);
     }
 
+    [Theory]
+    [InlineData("ps --format json", false)]
+    [InlineData("ps", true)]
+    public async Task BaseCommand_UpdateNotification_RespectJsonFormat(string args, bool expectNotifyCalled)
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        var testInteractionService = new TestInteractionService();
+        var testNotifier = new TestCliUpdateNotifier
+        {
+            IsUpdateAvailableCallback = () => true,
+            NotifyIfUpdateAvailableCallback = () => testInteractionService.DisplayVersionUpdateNotification("13.3.0-preview.1", "aspire update")
+        };
+        var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper, options =>
+        {
+            options.InteractionServiceFactory = _ => testInteractionService;
+            options.CliUpdateNotifierFactory = _ => testNotifier;
+        });
+        using var provider = services.BuildServiceProvider();
+
+        var command = provider.GetRequiredService<RootCommand>();
+        var result = command.Parse(args);
+
+        await result.InvokeAsync().DefaultTimeout();
+
+        Assert.Equal(expectNotifyCalled, testNotifier.NotifyWasCalled);
+    }
+
     [Fact]
     public async Task BaseCommand_OnFailure_DisplaysLogFilePathOnStderr()
     {

--- a/tests/Aspire.Cli.Tests/Commands/BaseCommandTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/BaseCommandTests.cs
@@ -115,6 +115,7 @@ public class BaseCommandTests(ITestOutputHelper outputHelper)
     [Theory]
     [InlineData("ps --format json", false)]
     [InlineData("ps", true)]
+    [InlineData("docs", false)]
     public async Task BaseCommand_UpdateNotification_RespectJsonFormat(string args, bool expectNotifyCalled)
     {
         using var workspace = TemporaryWorkspace.Create(outputHelper);


### PR DESCRIPTION
## Description

Extension development launch configurations currently start the shared `npm: watch extension` prelaunch task directly. On a clean checkout, that can fail before the extension host starts because dependencies have not been installed yet.

This updates both root and extension-folder VS Code task definitions so `npm: watch extension` first runs a finite `yarn: install extension` task. The install task uses Yarn 1.22.22 with `--frozen-lockfile --non-interactive`, matching the checked-in Yarn v1 lockfile and avoiding lockfile updates as a launch side effect.

### User-facing usage

Developers can keep using the existing "Run Extension" launch configurations. VS Code now runs the dependency install prerequisite before starting webpack watch:

```jsonc
"preLaunchTask": "npm: watch extension"
```

The shared watch task handles the prerequisite through:

```jsonc
"dependsOn": [
  "yarn: install extension"
],
"dependsOrder": "sequence"
```

Validation:

- `cd extension && npx --yes --package yarn@1.22.22 yarn install --frozen-lockfile --non-interactive`
- `cd extension && npm run watch` reached webpack watch mode
- `git diff --check -- .vscode/tasks.json extension/.vscode/tasks.json`

Fixes # (issue)

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [x] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
