### PR TITLE
Default dashboard endpoints when config is missing

### DIFF
--- a/src/Aspire.Hosting/Dashboard/DashboardEventHandlers.cs
+++ b/src/Aspire.Hosting/Dashboard/DashboardEventHandlers.cs
@@ -358,21 +358,21 @@ internal sealed class DashboardEventHandlers(IConfiguration configuration,
             dashboardResource.Annotations.Remove(endpointAnnotation);
         }
 
-        // Add the dashboard endpoints as non-proxied
+        // Add the dashboard endpoints.
         var options = dashboardOptions.Value;
 
-        var dashboardUrls = options.DashboardUrl;
-        var otlpGrpcEndpointUrl = options.OtlpGrpcEndpointUrl;
-        var otlpHttpEndpointUrl = options.OtlpHttpEndpointUrl;
+        var dashboardUrls = NormalizeConfiguredUrl(options.DashboardUrl);
+        var otlpGrpcEndpointUrl = NormalizeConfiguredUrl(options.OtlpGrpcEndpointUrl);
+        var otlpHttpEndpointUrl = NormalizeConfiguredUrl(options.OtlpHttpEndpointUrl);
 
         eventing.Subscribe<ResourceReadyEvent>(dashboardResource, async (@event, cancellationToken) =>
         {
             var browserToken = options.DashboardToken;
 
-            // Get the actual allocated URL from the dashboard resource endpoint
             string? dashboardUrl = null;
+            var resourceWithEndpoints = @event.Resource as IResourceWithEndpoints;
 
-            if (@event.Resource is IResourceWithEndpoints resourceWithEndpoints)
+            if (resourceWithEndpoints is not null)
             {
                 // Try HTTPS first, then HTTP
                 var httpsEndpoint = resourceWithEndpoints.GetEndpoint("https");
@@ -400,35 +400,86 @@ internal sealed class DashboardEventHandlers(IConfiguration configuration,
 
             distributedApplicationLogger.LogInformation("Now listening on: {DashboardUrl}", dashboardUrl.TrimEnd('/'));
 
-            LoggingHelpers.WriteDashboardSummary(distributedApplicationLogger, dashboardUrl, otlpGrpcEndpointUrl, otlpHttpEndpointUrl, browserToken, isContainer: false);
+            LoggingHelpers.WriteDashboardSummary(
+                distributedApplicationLogger,
+                dashboardUrl,
+                otlpGrpcEndpointUrl,
+                otlpHttpEndpointUrl,
+                browserToken,
+                isContainer: false);
         });
 
-        foreach (var d in dashboardUrls?.Split(';', StringSplitOptions.RemoveEmptyEntries) ?? [])
+        if (string.IsNullOrWhiteSpace(dashboardUrls))
         {
-            var address = BindingAddress.Parse(d);
-
-            dashboardResource.Annotations.Add(new EndpointAnnotation(ProtocolType.Tcp, uriScheme: address.Scheme, port: address.Port, isProxied: true)
+            dashboardResource.Annotations.Add(CreateEndpoint("https"));
+            dashboardResource.Annotations.Add(CreateEndpoint("http"));
+        }
+        else
+        {
+            foreach (var d in dashboardUrls.Split(';', StringSplitOptions.RemoveEmptyEntries))
             {
-                TargetHost = address.Host
-            });
+                var address = BindingAddress.Parse(d);
+
+                dashboardResource.Annotations.Add(CreateEndpoint(address.Scheme, port: address.Port, targetHost: address.Host));
+            }
         }
 
-        if (otlpGrpcEndpointUrl != null)
+        if (otlpGrpcEndpointUrl is null && otlpHttpEndpointUrl is null)
         {
-            var address = BindingAddress.Parse(otlpGrpcEndpointUrl);
-            dashboardResource.Annotations.Add(new EndpointAnnotation(ProtocolType.Tcp, name: KnownEndpointNames.OtlpGrpcEndpointName, uriScheme: address.Scheme, port: address.Port, isProxied: true, transport: "http2")
+            dashboardResource.Annotations.Add(CreateEndpoint(KnownEndpointNames.OtlpGrpcEndpointName, uriScheme: GetDefaultOtlpScheme(dashboardUrls), transport: "http2"));
+        }
+        else
+        {
+            if (otlpGrpcEndpointUrl != null)
             {
-                TargetHost = address.Host
-            });
+                var address = BindingAddress.Parse(otlpGrpcEndpointUrl);
+                dashboardResource.Annotations.Add(CreateEndpoint(KnownEndpointNames.OtlpGrpcEndpointName, address.Scheme, port: address.Port, targetHost: address.Host, transport: "http2"));
+            }
+
+            if (otlpHttpEndpointUrl != null)
+            {
+                var address = BindingAddress.Parse(otlpHttpEndpointUrl);
+                dashboardResource.Annotations.Add(CreateEndpoint(KnownEndpointNames.OtlpHttpEndpointName, address.Scheme, port: address.Port, targetHost: address.Host));
+            }
+
         }
 
-        if (otlpHttpEndpointUrl != null)
+        static EndpointAnnotation CreateEndpoint(
+            string name,
+            string? uriScheme = null,
+            int? port = null,
+            string targetHost = "localhost",
+            string? transport = null)
         {
-            var address = BindingAddress.Parse(otlpHttpEndpointUrl);
-            dashboardResource.Annotations.Add(new EndpointAnnotation(ProtocolType.Tcp, name: KnownEndpointNames.OtlpHttpEndpointName, uriScheme: address.Scheme, port: address.Port, isProxied: true)
+            return new EndpointAnnotation(ProtocolType.Tcp, name: name, uriScheme: uriScheme ?? name, port: port, isProxied: true, transport: transport)
             {
-                TargetHost = address.Host
-            });
+                TargetHost = targetHost
+            };
+        }
+
+        static string? NormalizeConfiguredUrl(string? url) =>
+            string.IsNullOrWhiteSpace(url) ? null : url;
+
+        static string GetDefaultOtlpScheme(string? dashboardUrls)
+        {
+            if (string.IsNullOrWhiteSpace(dashboardUrls))
+            {
+                return "https";
+            }
+
+            var hasHttp = false;
+            foreach (var d in dashboardUrls.Split(';', StringSplitOptions.RemoveEmptyEntries))
+            {
+                var address = BindingAddress.Parse(d);
+                if (address.Scheme == "https")
+                {
+                    return "https";
+                }
+
+                hasHttp |= address.Scheme == "http";
+            }
+
+            return hasHttp ? "http" : "https";
         }
 
         // Determine whether any HTTPS endpoints are configured
@@ -527,11 +578,6 @@ internal sealed class DashboardEventHandlers(IConfiguration configuration,
         }
 
         var options = dashboardOptions.Value;
-
-        // Options should have been validated these should not be null
-
-        Debug.Assert(options.DashboardUrl is not null, "DashboardUrl should not be null");
-        Debug.Assert(options.OtlpGrpcEndpointUrl is not null || options.OtlpHttpEndpointUrl is not null, "OtlpGrpcEndpointUrl and OtlpHttpEndpointUrl should not both be null");
 
         var environment = options.AspNetCoreEnvironment;
         var browserToken = options.DashboardToken;

--- a/src/Aspire.Hosting/Dashboard/DashboardOptions.cs
+++ b/src/Aspire.Hosting/Dashboard/DashboardOptions.cs
@@ -45,18 +45,6 @@ internal class ValidateDashboardOptions : IValidateOptions<DashboardOptions>
 {
     public ValidateOptionsResult Validate(string? name, DashboardOptions options)
     {
-        var builder = new ValidateOptionsResultBuilder();
-
-        if (string.IsNullOrEmpty(options.DashboardUrl))
-        {
-            builder.AddError($"Failed to configure dashboard resource because {KnownConfigNames.AspNetCoreUrls} environment variable was not set.");
-        }
-
-        if (string.IsNullOrEmpty(options.OtlpGrpcEndpointUrl) && string.IsNullOrEmpty(options.OtlpHttpEndpointUrl))
-        {
-            builder.AddError($"Failed to configure dashboard resource because {KnownConfigNames.DashboardOtlpGrpcEndpointUrl} and {KnownConfigNames.DashboardOtlpHttpEndpointUrl} environment variables are not set. At least one OTLP endpoint must be provided.");
-        }
-
-        return builder.Build();
+        return ValidateOptionsResult.Success;
     }
 }

--- a/src/Aspire.Hosting/Dashboard/TransportOptionsValidator.cs
+++ b/src/Aspire.Hosting/Dashboard/TransportOptionsValidator.cs
@@ -21,30 +21,24 @@ internal class TransportOptionsValidator(IConfiguration configuration, Distribut
 
         // Validate ASPNETCORE_URLS
         var applicationUrls = configuration[KnownConfigNames.AspNetCoreUrls];
-        if (string.IsNullOrEmpty(applicationUrls))
+        if (!string.IsNullOrEmpty(applicationUrls))
         {
-            return ValidateOptionsResult.Fail($"AppHost does not have applicationUrl in launch profile, or {KnownConfigNames.AspNetCoreUrls} environment variable set.");
-        }
+            var firstApplicationUrl = applicationUrls.Split(";").First();
 
-        var firstApplicationUrl = applicationUrls.Split(";").First();
+            if (!TryParseBindingAddress(firstApplicationUrl, out var parsedFirstApplicationUrl))
+            {
+                return ValidateOptionsResult.Fail($"The 'applicationUrl' setting of the launch profile has value '{firstApplicationUrl}' which could not be parsed as a URI.");
+            }
 
-        if (!TryParseBindingAddress(firstApplicationUrl, out var parsedFirstApplicationUrl))
-        {
-            return ValidateOptionsResult.Fail($"The 'applicationUrl' setting of the launch profile has value '{firstApplicationUrl}' which could not be parsed as a URI.");
-        }
-
-        if (parsedFirstApplicationUrl.Scheme == "http")
-        {
-            return ValidateOptionsResult.Fail($"The 'applicationUrl' setting must be an https address unless the '{KnownConfigNames.AllowUnsecuredTransport}' environment variable is set to true. This configuration is commonly set in the launch profile. See https://aka.ms/aspire/allowunsecuredtransport for more details.");
+            if (parsedFirstApplicationUrl.Scheme == "http")
+            {
+                return ValidateOptionsResult.Fail($"The 'applicationUrl' setting must be an https address unless the '{KnownConfigNames.AllowUnsecuredTransport}' environment variable is set to true. This configuration is commonly set in the launch profile. See https://aka.ms/aspire/allowunsecuredtransport for more details.");
+            }
         }
 
         // Validate ASPIRE_DASHBOARD_OTLP_ENDPOINT_URL
         var dashboardOtlpGrpcEndpointUrl = configuration.GetString(KnownConfigNames.DashboardOtlpGrpcEndpointUrl, KnownConfigNames.Legacy.DashboardOtlpGrpcEndpointUrl);
         var dashboardOtlpHttpEndpointUrl = configuration.GetString(KnownConfigNames.DashboardOtlpHttpEndpointUrl, KnownConfigNames.Legacy.DashboardOtlpHttpEndpointUrl);
-        if (string.IsNullOrEmpty(dashboardOtlpGrpcEndpointUrl) && string.IsNullOrEmpty(dashboardOtlpHttpEndpointUrl))
-        {
-            return ValidateOptionsResult.Fail($"AppHost does not have the {KnownConfigNames.DashboardOtlpGrpcEndpointUrl} or {KnownConfigNames.DashboardOtlpHttpEndpointUrl} settings defined. At least one OTLP endpoint must be provided.");
-        }
 
         if (!TryValidateEndpointUrl(KnownConfigNames.DashboardOtlpGrpcEndpointUrl, dashboardOtlpGrpcEndpointUrl, out var resultGrpc))
         {
@@ -57,19 +51,17 @@ internal class TransportOptionsValidator(IConfiguration configuration, Distribut
 
         // Validate ASPIRE_DASHBOARD_RESOURCE_SERVER_ENDPOINT_URL
         var resourceServiceEndpointUrl = configuration.GetString(KnownConfigNames.ResourceServiceEndpointUrl, KnownConfigNames.Legacy.ResourceServiceEndpointUrl);
-        if (string.IsNullOrEmpty(resourceServiceEndpointUrl))
+        if (!string.IsNullOrEmpty(resourceServiceEndpointUrl))
         {
-            return ValidateOptionsResult.Fail($"AppHost does not have the {KnownConfigNames.ResourceServiceEndpointUrl} setting defined.");
-        }
+            if (!Uri.TryCreate(resourceServiceEndpointUrl, UriKind.Absolute, out var parsedResourceServiceEndpointUrl))
+            {
+                return ValidateOptionsResult.Fail($"The {KnownConfigNames.ResourceServiceEndpointUrl} setting with a value of '{resourceServiceEndpointUrl}' could not be parsed as a URI.");
+            }
 
-        if (!Uri.TryCreate(resourceServiceEndpointUrl, UriKind.Absolute, out var parsedResourceServiceEndpointUrl))
-        {
-            return ValidateOptionsResult.Fail($"The {KnownConfigNames.ResourceServiceEndpointUrl} setting with a value of '{resourceServiceEndpointUrl}' could not be parsed as a URI.");
-        }
-
-        if (parsedResourceServiceEndpointUrl.Scheme == "http")
-        {
-            return ValidateOptionsResult.Fail($"The '{KnownConfigNames.ResourceServiceEndpointUrl}' setting must be an https address unless the '{KnownConfigNames.AllowUnsecuredTransport}' environment variable is set to true. This configuration is commonly set in the launch profile. See https://aka.ms/aspire/allowunsecuredtransport for more details.");
+            if (parsedResourceServiceEndpointUrl.Scheme == "http")
+            {
+                return ValidateOptionsResult.Fail($"The '{KnownConfigNames.ResourceServiceEndpointUrl}' setting must be an https address unless the '{KnownConfigNames.AllowUnsecuredTransport}' environment variable is set to true. This configuration is commonly set in the launch profile. See https://aka.ms/aspire/allowunsecuredtransport for more details.");
+            }
         }
 
         return ValidateOptionsResult.Success;

--- a/tests/Aspire.Hosting.Tests/Dashboard/DashboardResourceTests.cs
+++ b/tests/Aspire.Hosting.Tests/Dashboard/DashboardResourceTests.cs
@@ -82,6 +82,152 @@ public class DashboardResourceTests(ITestOutputHelper testOutputHelper)
         );
     }
 
+    [Fact]
+    public async Task DashboardWithMissingEndpointConfigurationUsesDynamicDefaults()
+    {
+        using var builder = TestDistributedApplicationBuilder.Create(
+            options => options.DisableDashboard = false,
+            testOutputHelper: testOutputHelper);
+
+        builder.Services.AddSingleton<IDashboardEndpointProvider, MockDashboardEndpointProvider>();
+
+        builder.Configuration.Sources.Clear();
+        builder.Configuration.AddInMemoryCollection(new Dictionary<string, string?>());
+
+        using var app = builder.Build();
+
+        await app.ExecuteBeforeStartHooksAsync(default).DefaultTimeout();
+
+        var model = app.Services.GetRequiredService<DistributedApplicationModel>();
+        var dashboard = Assert.Single(model.Resources);
+
+        var endpoints = dashboard.Annotations.OfType<EndpointAnnotation>().ToDictionary(e => e.Name);
+        Assert.Null(endpoints["https"].Port);
+        Assert.Null(endpoints["http"].Port);
+        Assert.Null(endpoints[KnownEndpointNames.OtlpGrpcEndpointName].Port);
+        Assert.False(endpoints.ContainsKey(KnownEndpointNames.OtlpHttpEndpointName));
+
+        SetDashboardAllocatedEndpoints(dashboard, otlpGrpcPort: 5001, otlpHttpPort: 5002, httpPort: 5003, httpsPort: 5005);
+
+        var config = await EnvironmentVariableEvaluator.GetEnvironmentVariablesAsync(dashboard, DistributedApplicationOperation.Run, app.Services).DefaultTimeout();
+
+        Assert.Equal("https://localhost:5005;http://localhost:5003", config.Single(e => e.Key == KnownConfigNames.AspNetCoreUrls).Value);
+        Assert.Equal("https://localhost:5001", config.Single(e => e.Key == KnownConfigNames.DashboardOtlpGrpcEndpointUrl).Value);
+        Assert.Equal("http://localhost:5000", config.Single(e => e.Key == KnownConfigNames.ResourceServiceEndpointUrl).Value);
+
+        var configuration = app.Services.GetRequiredService<IConfiguration>();
+        Assert.Null(configuration[KnownConfigNames.AspNetCoreUrls]);
+        Assert.Null(configuration[KnownConfigNames.DashboardOtlpGrpcEndpointUrl]);
+        Assert.Null(configuration[KnownConfigNames.ResourceServiceEndpointUrl]);
+    }
+
+    [Fact]
+    public async Task DashboardWithEmptyEndpointConfigurationUsesDynamicDefaults()
+    {
+        using var builder = TestDistributedApplicationBuilder.Create(
+            options => options.DisableDashboard = false,
+            testOutputHelper: testOutputHelper);
+
+        builder.Services.AddSingleton<IDashboardEndpointProvider, MockDashboardEndpointProvider>();
+
+        builder.Configuration.Sources.Clear();
+        builder.Configuration.AddInMemoryCollection(new Dictionary<string, string?>
+        {
+            [KnownConfigNames.AspNetCoreUrls] = string.Empty,
+            [KnownConfigNames.DashboardOtlpGrpcEndpointUrl] = string.Empty,
+            [KnownConfigNames.DashboardOtlpHttpEndpointUrl] = string.Empty,
+            [KnownConfigNames.ResourceServiceEndpointUrl] = string.Empty
+        });
+
+        using var app = builder.Build();
+
+        await app.ExecuteBeforeStartHooksAsync(default).DefaultTimeout();
+
+        var model = app.Services.GetRequiredService<DistributedApplicationModel>();
+        var dashboard = Assert.Single(model.Resources);
+
+        var endpoints = dashboard.Annotations.OfType<EndpointAnnotation>().ToDictionary(e => e.Name);
+        Assert.Null(endpoints["https"].Port);
+        Assert.Null(endpoints["http"].Port);
+        Assert.Null(endpoints[KnownEndpointNames.OtlpGrpcEndpointName].Port);
+        Assert.False(endpoints.ContainsKey(KnownEndpointNames.OtlpHttpEndpointName));
+
+        SetDashboardAllocatedEndpoints(dashboard, otlpGrpcPort: 5001, otlpHttpPort: 5002, httpPort: 5003, httpsPort: 5005);
+
+        var config = await EnvironmentVariableEvaluator.GetEnvironmentVariablesAsync(dashboard, DistributedApplicationOperation.Run, app.Services).DefaultTimeout();
+
+        Assert.Equal("https://localhost:5005;http://localhost:5003", config.Single(e => e.Key == KnownConfigNames.AspNetCoreUrls).Value);
+        Assert.Equal("https://localhost:5001", config.Single(e => e.Key == KnownConfigNames.DashboardOtlpGrpcEndpointUrl).Value);
+        Assert.Equal("http://localhost:5000", config.Single(e => e.Key == KnownConfigNames.ResourceServiceEndpointUrl).Value);
+    }
+
+    [Fact]
+    public async Task DashboardWithPartialEndpointConfigurationDefaultsMissingOtlpEndpoint()
+    {
+        using var builder = TestDistributedApplicationBuilder.Create(
+            options => options.DisableDashboard = false,
+            testOutputHelper: testOutputHelper);
+
+        builder.Services.AddSingleton<IDashboardEndpointProvider, MockDashboardEndpointProvider>();
+
+        builder.Configuration.Sources.Clear();
+        builder.Configuration.AddInMemoryCollection(new Dictionary<string, string?>
+        {
+            [KnownConfigNames.AspNetCoreUrls] = "https://localhost:17123"
+        });
+
+        using var app = builder.Build();
+
+        await app.ExecuteBeforeStartHooksAsync(default).DefaultTimeout();
+
+        var model = app.Services.GetRequiredService<DistributedApplicationModel>();
+        var dashboard = Assert.Single(model.Resources);
+
+        var endpoints = dashboard.Annotations.OfType<EndpointAnnotation>().ToDictionary(e => e.Name);
+        Assert.Equal(17123, endpoints["https"].Port);
+        Assert.Null(endpoints[KnownEndpointNames.OtlpGrpcEndpointName].Port);
+
+        SetDashboardAllocatedEndpoints(dashboard, otlpGrpcPort: 5001, otlpHttpPort: 5002, httpPort: 5003, httpsPort: 5005);
+
+        var config = await EnvironmentVariableEvaluator.GetEnvironmentVariablesAsync(dashboard, DistributedApplicationOperation.Run, app.Services).DefaultTimeout();
+
+        Assert.Equal("https://localhost:5005", config.Single(e => e.Key == KnownConfigNames.AspNetCoreUrls).Value);
+        Assert.Equal("https://localhost:5001", config.Single(e => e.Key == KnownConfigNames.DashboardOtlpGrpcEndpointUrl).Value);
+    }
+
+    [Fact]
+    public async Task DashboardWithHttpOnlyEndpointConfigurationDefaultsMissingOtlpEndpointToHttp()
+    {
+        using var builder = TestDistributedApplicationBuilder.Create(
+            options => options.DisableDashboard = false,
+            testOutputHelper: testOutputHelper);
+
+        builder.Services.AddSingleton<IDashboardEndpointProvider, MockDashboardEndpointProvider>();
+
+        builder.Configuration.Sources.Clear();
+        builder.Configuration.AddInMemoryCollection(new Dictionary<string, string?>
+        {
+            [KnownConfigNames.AspNetCoreUrls] = "http://localhost:15123",
+            [KnownConfigNames.AllowUnsecuredTransport] = "true"
+        });
+
+        using var app = builder.Build();
+
+        await app.ExecuteBeforeStartHooksAsync(default).DefaultTimeout();
+
+        var model = app.Services.GetRequiredService<DistributedApplicationModel>();
+        var dashboard = Assert.Single(model.Resources);
+
+        var endpoints = dashboard.Annotations.OfType<EndpointAnnotation>().ToDictionary(e => e.Name);
+        Assert.Equal("http", endpoints[KnownEndpointNames.OtlpGrpcEndpointName].UriScheme);
+
+        SetDashboardAllocatedEndpoints(dashboard, otlpGrpcPort: 5001, otlpHttpPort: 5002, httpPort: 5003, httpsPort: 5005);
+
+        var config = await EnvironmentVariableEvaluator.GetEnvironmentVariablesAsync(dashboard, DistributedApplicationOperation.Run, app.Services).DefaultTimeout();
+
+        Assert.Equal("http://localhost:5001", config.Single(e => e.Key == KnownConfigNames.DashboardOtlpGrpcEndpointUrl).Value);
+    }
+
     [Theory]
     [InlineData(KnownConfigNames.DashboardOtlpGrpcEndpointUrl)]
     [InlineData(KnownConfigNames.Legacy.DashboardOtlpGrpcEndpointUrl)]

--- a/tests/Aspire.Hosting.Tests/Dashboard/TransportOptionsValidatorTests.cs
+++ b/tests/Aspire.Hosting.Tests/Dashboard/TransportOptionsValidatorTests.cs
@@ -103,7 +103,7 @@ public class TransportOptionsValidatorTests
     }
 
     [Fact]
-    public void ValidationFailsWithMissingUrl()
+    public void ValidationSucceedsWithMissingUrl()
     {
         var distributedApplicationOptions = new DistributedApplicationOptions();
         var executionContext = new DistributedApplicationExecutionContext(DistributedApplicationOperation.Run);
@@ -114,15 +114,11 @@ public class TransportOptionsValidatorTests
 
         var validator = new TransportOptionsValidator(config, executionContext, distributedApplicationOptions);
         var result = validator.Validate(null, options);
-        Assert.True(result.Failed);
-        Assert.Equal(
-            $"AppHost does not have applicationUrl in launch profile, or {KnownConfigNames.AspNetCoreUrls} environment variable set.",
-            result.FailureMessage
-            );
+        Assert.True(result.Succeeded, result.FailureMessage);
     }
 
     [Fact]
-    public void ValidationFailsWithStringEmptyUrl()
+    public void ValidationSucceedsWithStringEmptyUrl()
     {
         var distributedApplicationOptions = new DistributedApplicationOptions();
         var executionContext = new DistributedApplicationExecutionContext(DistributedApplicationOperation.Run);
@@ -134,17 +130,13 @@ public class TransportOptionsValidatorTests
 
         var validator = new TransportOptionsValidator(config, executionContext, distributedApplicationOptions);
         var result = validator.Validate(null, options);
-        Assert.True(result.Failed);
-        Assert.Equal(
-            $"AppHost does not have applicationUrl in launch profile, or {KnownConfigNames.AspNetCoreUrls} environment variable set.",
-            result.FailureMessage
-            );
+        Assert.True(result.Succeeded, result.FailureMessage);
     }
 
     [Theory]
     [InlineData(KnownConfigNames.ResourceServiceEndpointUrl)]
     [InlineData(KnownConfigNames.Legacy.ResourceServiceEndpointUrl)]
-    public void ValidationFailsWhenResourceUrlNotDefined(string resourceServiceEndpointUrlKey)
+    public void ValidationSucceedsWhenResourceUrlNotDefined(string resourceServiceEndpointUrlKey)
     {
         var distributedApplicationOptions = new DistributedApplicationOptions();
         var executionContext = new DistributedApplicationExecutionContext(DistributedApplicationOperation.Run);
@@ -158,17 +150,13 @@ public class TransportOptionsValidatorTests
 
         var validator = new TransportOptionsValidator(config, executionContext, distributedApplicationOptions);
         var result = validator.Validate(null, options);
-        Assert.True(result.Failed);
-        Assert.Equal(
-            $"AppHost does not have the {KnownConfigNames.ResourceServiceEndpointUrl} setting defined.",
-            result.FailureMessage
-            );
+        Assert.True(result.Succeeded, result.FailureMessage);
     }
 
     [Theory]
     [InlineData(KnownConfigNames.DashboardOtlpGrpcEndpointUrl)]
     [InlineData(KnownConfigNames.Legacy.DashboardOtlpGrpcEndpointUrl)]
-    public void ValidationFailsWhenOtlpUrlNotDefined(string dashboardOtlpGrpcEndpointUrlKey)
+    public void ValidationSucceedsWhenOtlpUrlNotDefined(string dashboardOtlpGrpcEndpointUrlKey)
     {
         var distributedApplicationOptions = new DistributedApplicationOptions();
         var executionContext = new DistributedApplicationExecutionContext(DistributedApplicationOperation.Run);
@@ -182,11 +170,7 @@ public class TransportOptionsValidatorTests
 
         var validator = new TransportOptionsValidator(config, executionContext, distributedApplicationOptions);
         var result = validator.Validate(null, options);
-        Assert.True(result.Failed);
-        Assert.Equal(
-            $"AppHost does not have the {KnownConfigNames.DashboardOtlpGrpcEndpointUrl} or {KnownConfigNames.DashboardOtlpHttpEndpointUrl} settings defined. At least one OTLP endpoint must be provided.",
-            result.FailureMessage
-            );
+        Assert.True(result.Succeeded, result.FailureMessage);
     }
 
     [Theory]


### PR DESCRIPTION
## Description

Fixes #9999

Aspire dashboard startup should not require `aspire.config.json` or launch profile environment variables to provide dashboard and OTLP endpoint URLs. Today, custom or incomplete profiles can fail validation before the dashboard has a chance to use runtime endpoint allocation.

This change lets missing dashboard URL, OTLP endpoint, and resource service endpoint configuration fall back to dynamic runtime defaults instead of mutating existing config files. Explicitly configured values are still validated, including malformed URLs and insecure HTTP values unless unsecured transport is allowed.

### User-facing usage

Users can run an AppHost even when the profile/config does not include dashboard endpoint environment variables such as:

```json
{
  "ASPNETCORE_URLS": "https://localhost:<port>;http://localhost:<port>",
  "ASPIRE_DASHBOARD_OTLP_ENDPOINT_URL": "https://localhost:<port>",
  "ASPIRE_DASHBOARD_RESOURCE_SERVER_ENDPOINT_URL": "https://localhost:<port>"
}
```

When those values are absent, Aspire Hosting now creates dashboard and OTLP endpoints dynamically and uses the allocated endpoint values for the dashboard environment at runtime.

Validation:
- `dotnet test --project tests/Aspire.Hosting.Tests/Aspire.Hosting.Tests.csproj --no-launch-profile -- --filter-class "*.DashboardResourceTests" --filter-not-trait "quarantined=true" --filter-not-trait "outerloop=true"`
- `dotnet test --project tests/Aspire.Hosting.Tests/Aspire.Hosting.Tests.csproj --no-launch-profile -- --filter-class "*.TransportOptionsValidatorTests" --filter-not-trait "quarantined=true" --filter-not-trait "outerloop=true"`
- `dotnet test --project tests/Aspire.Hosting.Tests/Aspire.Hosting.Tests.csproj --no-build --no-launch-profile -- --filter-class "*.DashboardResourceTests" --filter-class "*.TransportOptionsValidatorTests" --filter-class "*.DashboardOptionsTests" --filter-class "*.DashboardEventHandlersTests" --filter-class "*.WithOtlpExporterTests" --filter-not-trait "quarantined=true" --filter-not-trait "outerloop=true"`
- `dotnet build tests/Aspire.Hosting.Tests/Aspire.Hosting.Tests.csproj --no-restore /p:SkipNativeBuild=true`

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
