### PR TITLE
Use resource strings in PsCommand and LsCommand tests for stderr assertions

### DIFF
--- a/tests/Aspire.Cli.Tests/Commands/LsCommandTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/LsCommandTests.cs
@@ -138,10 +138,12 @@ public class LsCommandTests(ITestOutputHelper outputHelper)
     {
         using var workspace = TemporaryWorkspace.Create(outputHelper);
         var textWriter = new TestOutputTextWriter(outputHelper);
+        var errorWriter = new StringWriter();
 
         var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper, options =>
         {
             options.OutputTextWriter = textWriter;
+            options.ErrorTextWriter = errorWriter;
         });
         using var provider = services.BuildServiceProvider();
 
@@ -156,6 +158,85 @@ public class LsCommandTests(ITestOutputHelper outputHelper)
         using var document = JsonDocument.Parse(jsonOutput);
         Assert.Equal(JsonValueKind.Array, document.RootElement.ValueKind);
         Assert.Equal(0, document.RootElement.GetArrayLength());
+
+        // Stderr should not contain JSON data
+        var stderrText = errorWriter.ToString();
+        Assert.Equal("", stderrText);
+    }
+
+    [Fact]
+    public async Task LsCommand_JsonFormat_OnlyJsonOnStdout_StatusMessagesOnStderr()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        var textWriter = new TestOutputTextWriter(outputHelper);
+        var errorWriter = new StringWriter();
+        var appHostPath1 = Path.Combine(workspace.WorkspaceRoot.FullName, "App1", "App1.AppHost.csproj");
+        var appHostPath2 = Path.Combine(workspace.WorkspaceRoot.FullName, "App2", "App2.AppHost.csproj");
+        var projectLocator = new TestProjectLocator
+        {
+            FindAppHostProjectsAsyncCallback = (_, _, _) => Task.FromResult(new List<AppHostProjectCandidate>
+            {
+                new(new FileInfo(appHostPath1), KnownLanguageId.CSharp),
+                new(new FileInfo(appHostPath2), KnownLanguageId.TypeScript, AppHostProjectCandidateStatus.PossiblyUnbuildable)
+            })
+        };
+
+        var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper, options =>
+        {
+            options.OutputTextWriter = textWriter;
+            options.ErrorTextWriter = errorWriter;
+            options.ProjectLocatorFactory = _ => projectLocator;
+        });
+        using var provider = services.BuildServiceProvider();
+
+        var command = provider.GetRequiredService<RootCommand>();
+        var result = command.Parse("ls --format json");
+
+        var exitCode = await result.InvokeAsync().DefaultTimeout();
+
+        Assert.Equal(CliExitCodes.Success, exitCode);
+
+        // Stdout must contain only valid JSON (parseable without error)
+        var stdoutText = string.Join(string.Empty, textWriter.Logs);
+        using var document = JsonDocument.Parse(stdoutText);
+        Assert.Equal(JsonValueKind.Array, document.RootElement.ValueKind);
+        Assert.Equal(2, document.RootElement.GetArrayLength());
+
+        // Stderr should not contain JSON data
+        var stderrText = errorWriter.ToString();
+        Assert.Equal("", stderrText);
+    }
+
+    [Fact]
+    public async Task LsCommand_JsonFormat_NoResults_OnlyJsonOnStdout_StatusMessagesOnStderr()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        var textWriter = new TestOutputTextWriter(outputHelper);
+        var errorWriter = new StringWriter();
+
+        var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper, options =>
+        {
+            options.OutputTextWriter = textWriter;
+            options.ErrorTextWriter = errorWriter;
+        });
+        using var provider = services.BuildServiceProvider();
+
+        var command = provider.GetRequiredService<RootCommand>();
+        var result = command.Parse("ls --format json");
+
+        var exitCode = await result.InvokeAsync().DefaultTimeout();
+
+        Assert.Equal(CliExitCodes.Success, exitCode);
+
+        // Stdout must contain only valid JSON (empty array)
+        var stdoutText = string.Join(string.Empty, textWriter.Logs);
+        using var document = JsonDocument.Parse(stdoutText);
+        Assert.Equal(JsonValueKind.Array, document.RootElement.ValueKind);
+        Assert.Equal(0, document.RootElement.GetArrayLength());
+
+        // Stderr should not contain JSON data
+        var stderrText = errorWriter.ToString();
+        Assert.DoesNotContain("path", stderrText, StringComparison.Ordinal);
     }
 
     [Fact]

--- a/tests/Aspire.Cli.Tests/Commands/LsCommandTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/LsCommandTests.cs
@@ -236,7 +236,7 @@ public class LsCommandTests(ITestOutputHelper outputHelper)
 
         // Stderr should not contain JSON data
         var stderrText = errorWriter.ToString();
-        Assert.DoesNotContain("path", stderrText, StringComparison.Ordinal);
+        Assert.Equal("", stderrText);
     }
 
     [Fact]

--- a/tests/Aspire.Cli.Tests/Commands/PsCommandTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/PsCommandTests.cs
@@ -6,6 +6,7 @@ using System.Net.Sockets;
 using System.Text.Json;
 using Aspire.Cli.Backchannel;
 using Aspire.Cli.Commands;
+using Aspire.Cli.Resources;
 using Aspire.Cli.Tests.TestServices;
 using Aspire.Cli.Tests.Utils;
 using Microsoft.AspNetCore.InternalTesting;
@@ -473,6 +474,88 @@ public class PsCommandTests(ITestOutputHelper outputHelper)
         var document = JsonDocument.Parse(json);
         Assert.Equal(JsonValueKind.Array, document.RootElement.ValueKind);
         Assert.Equal(0, document.RootElement.GetArrayLength());
+    }
+
+    [Fact]
+    public async Task PsCommand_JsonFormat_OnlyJsonOnStdout_StatusMessagesOnStderr()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        var textWriter = new TestOutputTextWriter(outputHelper);
+        var errorWriter = new StringWriter();
+
+        var monitor = new TestAuxiliaryBackchannelMonitor();
+        var connection = new TestAppHostAuxiliaryBackchannel
+        {
+            IsInScope = true,
+            AppHostInfo = new AppHostInformation
+            {
+                AppHostPath = Path.Combine(workspace.WorkspaceRoot.FullName, "App1", "App1.AppHost.csproj"),
+                ProcessId = 1234,
+                CliProcessId = 5678
+            },
+            DashboardUrlsState = new DashboardUrlsState
+            {
+                BaseUrlWithLoginToken = "http://localhost:18888/login?t=abc123"
+            }
+        };
+        monitor.AddConnection("hash1", "socket.hash1", connection);
+
+        var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper, options =>
+        {
+            options.OutputTextWriter = textWriter;
+            options.ErrorTextWriter = errorWriter;
+            options.AuxiliaryBackchannelMonitorFactory = _ => monitor;
+        });
+        using var provider = services.BuildServiceProvider();
+
+        var command = provider.GetRequiredService<RootCommand>();
+        var result = command.Parse("ps --format json");
+
+        var exitCode = await result.InvokeAsync().DefaultTimeout();
+
+        Assert.Equal(CliExitCodes.Success, exitCode);
+
+        // Stdout must contain only valid JSON (parseable without error)
+        var stdoutText = string.Join(string.Empty, textWriter.Logs);
+        using var document = JsonDocument.Parse(stdoutText);
+        Assert.Equal(JsonValueKind.Array, document.RootElement.ValueKind);
+        Assert.Equal(1, document.RootElement.GetArrayLength());
+
+        // Status messages should be routed to stderr
+        var stderrText = errorWriter.ToString();
+        Assert.Contains(SharedCommandStrings.ScanningForRunningAppHosts, stderrText);
+    }
+
+    [Fact]
+    public async Task PsCommand_JsonFormat_NoResults_OnlyJsonOnStdout_StatusMessagesOnStderr()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        var textWriter = new TestOutputTextWriter(outputHelper);
+        var errorWriter = new StringWriter();
+
+        var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper, options =>
+        {
+            options.OutputTextWriter = textWriter;
+            options.ErrorTextWriter = errorWriter;
+        });
+        using var provider = services.BuildServiceProvider();
+
+        var command = provider.GetRequiredService<RootCommand>();
+        var result = command.Parse("ps --format json");
+
+        var exitCode = await result.InvokeAsync().DefaultTimeout();
+
+        Assert.Equal(CliExitCodes.Success, exitCode);
+
+        // Stdout must contain only valid JSON (empty array)
+        var stdoutText = string.Join(string.Empty, textWriter.Logs);
+        using var document = JsonDocument.Parse(stdoutText);
+        Assert.Equal(JsonValueKind.Array, document.RootElement.ValueKind);
+        Assert.Equal(0, document.RootElement.GetArrayLength());
+
+        // Status messages should be routed to stderr
+        var stderrText = errorWriter.ToString();
+        Assert.Contains(SharedCommandStrings.ScanningForRunningAppHosts, stderrText);
     }
 
     [Fact]


### PR DESCRIPTION
## Summary

Updates PsCommand and LsCommand tests to use `SharedCommandStrings.ScanningForRunningAppHosts` resource string instead of hardcoded `"Scanning"` when asserting stderr output. This makes the tests resilient to localization changes.

## Changes

- `PsCommandTests.cs`: Added `using Aspire.Cli.Resources` and replaced hardcoded string assertions with resource string references
- `LsCommandTests.cs`: Added new tests verifying stderr routing with resource string assertions