### PR TITLE
Restore Kestrel HTTP/2 config and remove health check from BasketService

### DIFF
--- a/playground/TestShop/BasketService/appsettings.json
+++ b/playground/TestShop/BasketService/appsettings.json
@@ -7,6 +7,11 @@
     }
   },
   "AllowedHosts": "*",
+  "Kestrel": {
+    "EndpointDefaults": {
+      "Protocols": "Http2"
+    }
+  },
   "Aspire": {
     "RabbitMQ": {
       "Client": {

--- a/playground/TestShop/TestShop.AppHost/AppHost.cs
+++ b/playground/TestShop/TestShop.AppHost/AppHost.cs
@@ -84,8 +84,7 @@ var basketService = builder.AddProject("basketservice", @"..\BasketService\Baske
                            .WithReference(basketCache)
                            .WaitFor(basketCache)
                            .WithReference(messaging)
-                           .WaitFor(messaging)
-                           .WithHttpHealthCheck("/health", endpointName: "http");
+                           .WaitFor(messaging);
 
 var frontend = builder.AddProject<Projects.MyFrontend>("frontend")
     .WithExternalHttpEndpoints()


### PR DESCRIPTION
The BasketService uses gRPC which requires HTTP/2. The Kestrel EndpointDefaults configuration ensures the service works correctly. Remove `WithHttpHealthCheck` since it conflicts with the HTTP/2-only protocol configuration.\n\nRelated: https://github.com/microsoft/aspire/pull/17089/files#r3285683573