### PR TITLE
Honor existing Azure App Service plans

### DIFF
--- a/src/Aspire.Hosting.Azure.AppContainers/AzureContainerAppEnvironmentResource.cs
+++ b/src/Aspire.Hosting.Azure.AppContainers/AzureContainerAppEnvironmentResource.cs
@@ -57,18 +57,23 @@ public class AzureContainerAppEnvironmentResource :
 
             steps.Add(prepareStep);
 
-            // Add print-dashboard-url step
-            var printDashboardUrlStep = new PipelineStep
+            if (EnableDashboard)
             {
-                Name = $"print-dashboard-url-{name}",
-                Description = $"Prints the deployment summary and dashboard URL for {name}.",
-                Action = ctx => PrintDashboardUrlAsync(ctx),
-                Tags = ["print-summary"],
-                DependsOnSteps = [AzureEnvironmentResource.ProvisionInfrastructureStepName],
-                RequiredBySteps = [WellKnownPipelineSteps.Deploy]
-            };
+                // The dashboard URL is only meaningful when the dashboard is provisioned.
+                // Avoid registering the summary step when WithDashboard(false) is used, otherwise
+                // we would emit a link to a dashboard that does not exist in the environment.
+                var printDashboardUrlStep = new PipelineStep
+                {
+                    Name = $"print-dashboard-url-{name}",
+                    Description = $"Prints the deployment summary and dashboard URL for {name}.",
+                    Action = ctx => PrintDashboardUrlAsync(ctx),
+                    Tags = ["print-summary"],
+                    DependsOnSteps = [AzureEnvironmentResource.ProvisionInfrastructureStepName],
+                    RequiredBySteps = [WellKnownPipelineSteps.Deploy]
+                };
 
-            steps.Add(printDashboardUrlStep);
+                steps.Add(printDashboardUrlStep);
+            }
 
             // Expand deployment target steps for all compute resources
             // This ensures the push/provision steps from deployment targets are included in the pipeline

--- a/src/Aspire.Hosting.Azure.AppContainers/AzureContainerAppExtensions.cs
+++ b/src/Aspire.Hosting.Azure.AppContainers/AzureContainerAppExtensions.cs
@@ -756,7 +756,7 @@ public static class AzureContainerAppExtensions
         ArgumentNullException.ThrowIfNull(builder);
         ArgumentNullException.ThrowIfNull(identityBuilder);
 
-        builder.WithAnnotation(new AzureContainerAppEnvironmentAcrPullIdentityAnnotation(identityBuilder.Resource), ResourceAnnotationMutationBehavior.Replace);
+        builder.WithAnnotation(new AzureContainerAppEnvironmentAcrPullIdentityAnnotation(identityBuilder.Resource));
 
         return builder;
     }

--- a/src/Aspire.Hosting.Azure.AppContainers/AzureContainerAppExtensions.cs
+++ b/src/Aspire.Hosting.Azure.AppContainers/AzureContainerAppExtensions.cs
@@ -756,7 +756,7 @@ public static class AzureContainerAppExtensions
         ArgumentNullException.ThrowIfNull(builder);
         ArgumentNullException.ThrowIfNull(identityBuilder);
 
-        builder.WithAnnotation(new AzureContainerAppEnvironmentAcrPullIdentityAnnotation(identityBuilder.Resource));
+        builder.WithAnnotation(new AzureContainerAppEnvironmentAcrPullIdentityAnnotation(identityBuilder.Resource), ResourceAnnotationMutationBehavior.Replace);
 
         return builder;
     }

--- a/src/Aspire.Hosting.Azure.AppService/AzureAppServiceEnvironmentAcrPullIdentityAnnotation.cs
+++ b/src/Aspire.Hosting.Azure.AppService/AzureAppServiceEnvironmentAcrPullIdentityAnnotation.cs
@@ -1,0 +1,21 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Aspire.Hosting.ApplicationModel;
+
+namespace Aspire.Hosting.Azure;
+
+/// <summary>
+/// Indicates that an <see cref="AzureAppServiceEnvironmentResource"/> should use the supplied
+/// <see cref="AzureUserAssignedIdentityResource"/> as the identity that holds the <c>AcrPull</c> role on the
+/// configured container registry, instead of having Aspire create a new identity and a new <c>AcrPull</c>
+/// role assignment.
+/// </summary>
+/// <param name="identity">The user-assigned identity resource to use for the <c>AcrPull</c> role.</param>
+internal sealed class AzureAppServiceEnvironmentAcrPullIdentityAnnotation(AzureUserAssignedIdentityResource identity) : IResourceAnnotation
+{
+    /// <summary>
+    /// Gets the user-assigned identity resource that holds the <c>AcrPull</c> role.
+    /// </summary>
+    public AzureUserAssignedIdentityResource Identity { get; } = identity;
+}

--- a/src/Aspire.Hosting.Azure.AppService/AzureAppServiceEnvironmentExtensions.cs
+++ b/src/Aspire.Hosting.Azure.AppService/AzureAppServiceEnvironmentExtensions.cs
@@ -107,12 +107,30 @@ public static partial class AzureAppServiceEnvironmentExtensions
 
             infra.Add(tags);
 
-            var identity = new UserAssignedIdentity($"{prefix}_mi")
-            {
-                Tags = tags
-            };
+            UserAssignedIdentity? newIdentity = null;
+            BicepValue<string> managedIdentityIdOutputValue;
+            BicepValue<string> managedIdentityClientIdOutputValue;
 
-            infra.Add(identity);
+            if (resource.TryGetLastAnnotation<AzureAppServiceEnvironmentAcrPullIdentityAnnotation>(out var identityAnnotation))
+            {
+                // The user has supplied an existing identity (commonly via AddAzureUserAssignedIdentity +
+                // .WithRoleAssignments(acr, AcrPull)). Skip creating env_mi + the AcrPull role assignment
+                // here and have the env module read the identity id/client id from parameters wired to the
+                // identity module's outputs.
+                managedIdentityIdOutputValue = identityAnnotation.Identity.Id.AsProvisioningParameter(infra);
+                managedIdentityClientIdOutputValue = identityAnnotation.Identity.ClientId.AsProvisioningParameter(infra);
+            }
+            else
+            {
+                newIdentity = new UserAssignedIdentity($"{prefix}_mi")
+                {
+                    Tags = tags
+                };
+
+                infra.Add(newIdentity);
+                managedIdentityIdOutputValue = newIdentity.Id.ToBicepExpression();
+                managedIdentityClientIdOutputValue = newIdentity.ClientId.ToBicepExpression();
+            }
 
             AzureProvisioningResource? registry = null;
             if (resource.TryGetLastAnnotation<ContainerRegistryReferenceAnnotation>(out var registryReferenceAnnotation) &&
@@ -133,26 +151,40 @@ public static partial class AzureAppServiceEnvironmentExtensions
             var containerRegistry = (ContainerRegistryService)registry.AddAsExistingResource(infra);
             infra.Add(containerRegistry);
 
-            var pullRa = containerRegistry.CreateRoleAssignment(ContainerRegistryBuiltInRole.AcrPull, identity);
-
-            // There's a bug in the CDK, see https://github.com/Azure/azure-sdk-for-net/issues/47265
-            pullRa.Name = BicepFunction.CreateGuid(containerRegistry.Id, identity.Id, pullRa.RoleDefinitionId);
-            infra.Add(pullRa);
-
-            var plan = new AppServicePlan($"{prefix}_asplan")
+            if (newIdentity is not null)
             {
-                Sku = new AppServiceSkuDescription
-                {
-                    Name = "P0V3",
-                    Tier = "Premium"
-                },
-                Kind = "Linux",
-                IsReserved = true,
-                // Enable perSiteScaling so each app service can scale independently
-                IsPerSiteScaling = true
-            };
+                var pullRa = containerRegistry.CreateRoleAssignment(ContainerRegistryBuiltInRole.AcrPull, newIdentity);
 
-            infra.Add(plan);
+                // There's a bug in the CDK, see https://github.com/Azure/azure-sdk-for-net/issues/47265
+                pullRa.Name = BicepFunction.CreateGuid(containerRegistry.Id, newIdentity.Id, pullRa.RoleDefinitionId);
+                infra.Add(pullRa);
+            }
+
+            AppServicePlan plan;
+            if (resource.IsExisting())
+            {
+                // The Aspire resource models the App Service Plan. When users mark it existing,
+                // keep provisioning the supporting app resources but reference the supplied plan
+                // instead of declaring a new Microsoft.Web/serverfarms resource.
+                plan = (AppServicePlan)resource.AddAsExistingResource(infra);
+            }
+            else
+            {
+                plan = new AppServicePlan($"{prefix}_asplan")
+                {
+                    Sku = new AppServiceSkuDescription
+                    {
+                        Name = "P0V3",
+                        Tier = "Premium"
+                    },
+                    Kind = "Linux",
+                    IsReserved = true,
+                    // Enable perSiteScaling so each app service can scale independently
+                    IsPerSiteScaling = true
+                };
+
+                infra.Add(plan);
+            }
 
             infra.Add(new ProvisioningOutput("name", typeof(string))
             {
@@ -182,18 +214,18 @@ public static partial class AzureAppServiceEnvironmentExtensions
 
             infra.Add(new ProvisioningOutput("AZURE_CONTAINER_REGISTRY_MANAGED_IDENTITY_ID", typeof(string))
             {
-                Value = identity.Id.ToBicepExpression()
+                Value = managedIdentityIdOutputValue
             });
 
             infra.Add(new ProvisioningOutput("AZURE_CONTAINER_REGISTRY_MANAGED_IDENTITY_CLIENT_ID", typeof(string))
             {
-                Value = identity.ClientId.ToBicepExpression()
+                Value = managedIdentityClientIdOutputValue
             });
 
             if (resource.EnableDashboard)
             {
                 // Add aspire dashboard website
-                var website = AzureAppServiceEnvironmentUtility.AddDashboard(infra, identity, plan.Id);
+                var website = AzureAppServiceEnvironmentUtility.AddDashboard(infra, managedIdentityClientIdOutputValue, plan.Id);
 
                 infra.Add(new ProvisioningOutput("AZURE_APP_SERVICE_DASHBOARD_URI", typeof(string))
                 {
@@ -434,6 +466,51 @@ public static partial class AzureAppServiceEnvironmentExtensions
         ArgumentException.ThrowIfNullOrWhiteSpace(deploymentSlot);
 
         builder.Resource.DeploymentSlot = deploymentSlot;
+        return builder;
+    }
+
+    /// <summary>
+    /// Configures the Azure App Service environment to use the supplied <see cref="AzureUserAssignedIdentityResource"/>
+    /// as the managed identity that App Service apps use to pull images from the configured container registry
+    /// (the <c>AcrPull</c> identity), instead of having Aspire create a new identity and a new <c>AcrPull</c>
+    /// role assignment.
+    /// </summary>
+    /// <param name="builder">The Azure App Service environment to configure.</param>
+    /// <param name="identityBuilder">
+    /// The resource builder for the user-assigned identity that should be used for image pulls. This identity is
+    /// only used for the <c>AcrPull</c> role; it is not assigned as the app service runtime identity.
+    /// </param>
+    /// <returns>The <see cref="IResourceBuilder{T}"/> for chaining.</returns>
+    /// <remarks>
+    /// <para>
+    /// When this is set, Aspire will not create a new identity or an <c>AcrPull</c> role assignment for the
+    /// container registry. The caller is responsible for ensuring the supplied identity already has the required
+    /// <c>AcrPull</c> role assignment on the registry, for example by chaining
+    /// <c>.WithRoleAssignments(acr, ContainerRegistryBuiltInRole.AcrPull)</c> when adding the identity.
+    /// </para>
+    /// <para>
+    /// This is commonly combined with <c>AsExisting</c> on the App Service environment (App Service Plan) and on
+    /// the container registry to deploy websites into a pre-provisioned set of Azure resources without Aspire
+    /// emitting any new ACR-pull identity or ACR-pull role-assignment resources.
+    /// </para>
+    /// <para>
+    /// If the Aspire dashboard is enabled, Aspire still provisions the dashboard website and its contributor
+    /// identity. Use <see cref="WithDashboard(IResourceBuilder{AzureAppServiceEnvironmentResource}, bool)"/> with
+    /// <see langword="false"/> when targeting a fully pre-provisioned App Service Plan that should not receive a
+    /// dashboard.
+    /// </para>
+    /// </remarks>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="builder"/> or <paramref name="identityBuilder"/> is <see langword="null"/>.</exception>
+    [AspireExport]
+    public static IResourceBuilder<AzureAppServiceEnvironmentResource> WithAcrPullIdentity(
+        this IResourceBuilder<AzureAppServiceEnvironmentResource> builder,
+        IResourceBuilder<AzureUserAssignedIdentityResource> identityBuilder)
+    {
+        ArgumentNullException.ThrowIfNull(builder);
+        ArgumentNullException.ThrowIfNull(identityBuilder);
+
+        builder.WithAnnotation(new AzureAppServiceEnvironmentAcrPullIdentityAnnotation(identityBuilder.Resource), ResourceAnnotationMutationBehavior.Replace);
+
         return builder;
     }
 

--- a/src/Aspire.Hosting.Azure.AppService/AzureAppServiceEnvironmentExtensions.cs
+++ b/src/Aspire.Hosting.Azure.AppService/AzureAppServiceEnvironmentExtensions.cs
@@ -491,8 +491,26 @@ public static partial class AzureAppServiceEnvironmentExtensions
     /// <para>
     /// This is commonly combined with <c>AsExisting</c> on the App Service environment (App Service Plan) and on
     /// the container registry to deploy websites into a pre-provisioned set of Azure resources without Aspire
-    /// emitting any new ACR-pull identity or ACR-pull role-assignment resources.
+    /// emitting any new ACR-pull identity or ACR-pull role-assignment resources. See
+    /// <see href="https://github.com/microsoft/aspire/issues/14382"/> for the scenario this addresses.
     /// </para>
+    /// <para>
+    /// Only the combination of an existing App Service Plan, an existing container registry, and this method
+    /// avoids emitting any new identity or role-assignment resources in the env module. Other combinations still
+    /// work but will emit additional resources:
+    /// </para>
+    /// <list type="bullet">
+    ///   <item><description>
+    ///   If the App Service Plan is marked <c>AsExisting</c> but no identity is supplied here, Aspire still emits
+    ///   a new <c>UserAssignedIdentity</c> and an <c>AcrPull</c> role assignment on the configured registry.
+    ///   </description></item>
+    ///   <item><description>
+    ///   If this method is used but the container registry is not existing (either the Aspire-generated default
+    ///   registry or a user-added registry without <c>AsExisting</c>), the registry itself is still provisioned.
+    ///   To wire the supplied identity to that newly-created registry, chain
+    ///   <c>.WithRoleAssignments(acr, ContainerRegistryBuiltInRole.AcrPull)</c> on the identity.
+    ///   </description></item>
+    /// </list>
     /// <para>
     /// If the Aspire dashboard is enabled, Aspire still provisions the dashboard website and its contributor
     /// identity. Use <see cref="WithDashboard(IResourceBuilder{AzureAppServiceEnvironmentResource}, bool)"/> with

--- a/src/Aspire.Hosting.Azure.AppService/AzureAppServiceEnvironmentExtensions.cs
+++ b/src/Aspire.Hosting.Azure.AppService/AzureAppServiceEnvironmentExtensions.cs
@@ -477,8 +477,8 @@ public static partial class AzureAppServiceEnvironmentExtensions
     /// </summary>
     /// <param name="builder">The Azure App Service environment to configure.</param>
     /// <param name="identityBuilder">
-    /// The resource builder for the user-assigned identity that should be used for image pulls. This identity is
-    /// only used for the <c>AcrPull</c> role; it is not assigned as the app service runtime identity.
+    /// The resource builder for the user-assigned identity that should be used for image pulls. The supplied
+    /// identity must already have the <c>AcrPull</c> role on the configured container registry.
     /// </param>
     /// <returns>The <see cref="IResourceBuilder{T}"/> for chaining.</returns>
     /// <remarks>
@@ -487,6 +487,13 @@ public static partial class AzureAppServiceEnvironmentExtensions
     /// container registry. The caller is responsible for ensuring the supplied identity already has the required
     /// <c>AcrPull</c> role assignment on the registry, for example by chaining
     /// <c>.WithRoleAssignments(acr, ContainerRegistryBuiltInRole.AcrPull)</c> when adding the identity.
+    /// </para>
+    /// <para>
+    /// Unlike the equivalent method on Azure Container Apps, App Service reuses this single identity for more than
+    /// just image pulls. The same identity is also attached to every generated App Service web app as a user-assigned
+    /// managed identity, and is used by the Aspire OTLP sidecar to authenticate telemetry to the Aspire dashboard
+    /// (it is added to the dashboard's <c>ALLOWED_MANAGED_IDENTITIES</c> and exposed to each app via the OTEL
+    /// client-id app setting). If you supply an existing identity here, it will take on all of these roles.
     /// </para>
     /// <para>
     /// This is commonly combined with <c>AsExisting</c> on the App Service environment (App Service Plan) and on
@@ -527,7 +534,7 @@ public static partial class AzureAppServiceEnvironmentExtensions
         ArgumentNullException.ThrowIfNull(builder);
         ArgumentNullException.ThrowIfNull(identityBuilder);
 
-        builder.WithAnnotation(new AzureAppServiceEnvironmentAcrPullIdentityAnnotation(identityBuilder.Resource), ResourceAnnotationMutationBehavior.Replace);
+        builder.WithAnnotation(new AzureAppServiceEnvironmentAcrPullIdentityAnnotation(identityBuilder.Resource));
 
         return builder;
     }

--- a/src/Aspire.Hosting.Azure.AppService/AzureAppServiceEnvironmentResource.cs
+++ b/src/Aspire.Hosting.Azure.AppService/AzureAppServiceEnvironmentResource.cs
@@ -71,18 +71,23 @@ public class AzureAppServiceEnvironmentResource :
 
             steps.Add(validateStep);
 
-            // Add print-dashboard-url step
-            var printDashboardUrlStep = new PipelineStep
+            if (EnableDashboard)
             {
-                Name = $"print-dashboard-url-{name}",
-                Description = $"Prints the deployment summary and dashboard URL for {name}.",
-                Action = ctx => PrintDashboardUrlAsync(ctx),
-                Tags = ["print-summary"],
-                DependsOnSteps = [AzureEnvironmentResource.ProvisionInfrastructureStepName],
-                RequiredBySteps = [WellKnownPipelineSteps.Deploy]
-            };
+                // The dashboard output is only emitted when the dashboard is provisioned.
+                // Avoid registering the summary step when WithDashboard(false) is used,
+                // otherwise deploy succeeds and then fails while trying to read a missing output.
+                var printDashboardUrlStep = new PipelineStep
+                {
+                    Name = $"print-dashboard-url-{name}",
+                    Description = $"Prints the deployment summary and dashboard URL for {name}.",
+                    Action = ctx => PrintDashboardUrlAsync(ctx),
+                    Tags = ["print-summary"],
+                    DependsOnSteps = [AzureEnvironmentResource.ProvisionInfrastructureStepName],
+                    RequiredBySteps = [WellKnownPipelineSteps.Deploy]
+                };
 
-            steps.Add(printDashboardUrlStep);
+                steps.Add(printDashboardUrlStep);
+            }
 
             // Expand deployment target steps for all compute resources
             // This ensures the push/provision steps from deployment targets are included in the pipeline

--- a/src/Aspire.Hosting.Azure.AppService/AzureAppServiceEnvironmentUtility.cs
+++ b/src/Aspire.Hosting.Azure.AppService/AzureAppServiceEnvironmentUtility.cs
@@ -22,13 +22,12 @@ internal static class AzureAppServiceEnvironmentUtility
     }
 
     public static WebSite AddDashboard(AzureResourceInfrastructure infra,
-        UserAssignedIdentity otelIdentity,
+        BicepValue<string> acrPullIdentityClientId,
         BicepValue<ResourceIdentifier> appServicePlanId)
     {
         // This ACR identity is used by the dashboard to authorize the telemetry data
         // coming from the dotnet web apps. This identity is being assigned to every web app
         // in the aspire project and can be safely reused for authorization in the dashboard. 
-        var otelClientId = otelIdentity.ClientId;
         var prefix = infra.AspireResource.Name;
         var contributorIdentity = new UserAssignedIdentity(Infrastructure.NormalizeBicepIdentifier($"{prefix}-contributor-mi"));
 
@@ -60,7 +59,7 @@ internal static class AzureAppServiceEnvironmentUtility
             SiteConfig = new SiteConfigProperties()
             {
                 LinuxFxVersion = "ASPIREDASHBOARD|1.0",
-                AcrUserManagedIdentityId = otelClientId,
+                AcrUserManagedIdentityId = acrPullIdentityClientId,
                 UseManagedIdentityCreds = true,
                 IsHttp20Enabled = true,
                 Http20ProxyFlag = 1,
@@ -93,7 +92,7 @@ internal static class AzureAppServiceEnvironmentUtility
         dashboard.SiteConfig.AppSettings.Add(new AppServiceNameValuePair { Name = "WEBSITE_START_SCM_WITH_PRELOAD", Value = "true" });
         // Appsettings related to managed identity for auth
         dashboard.SiteConfig.AppSettings.Add(new AppServiceNameValuePair { Name = "AZURE_CLIENT_ID", Value = contributorIdentity.ClientId });
-        dashboard.SiteConfig.AppSettings.Add(new AppServiceNameValuePair { Name = "ALLOWED_MANAGED_IDENTITIES", Value = otelClientId });
+        dashboard.SiteConfig.AppSettings.Add(new AppServiceNameValuePair { Name = "ALLOWED_MANAGED_IDENTITIES", Value = acrPullIdentityClientId });
         // Added appsetting to identify the resources in a specific aspire environment
         dashboard.SiteConfig.AppSettings.Add(new AppServiceNameValuePair { Name = "ASPIRE_ENVIRONMENT_NAME", Value = infra.AspireResource.Name });
 

--- a/src/Aspire.Hosting.Azure.AppService/AzureAppServiceEnvironmentUtility.cs
+++ b/src/Aspire.Hosting.Azure.AppService/AzureAppServiceEnvironmentUtility.cs
@@ -22,12 +22,16 @@ internal static class AzureAppServiceEnvironmentUtility
     }
 
     public static WebSite AddDashboard(AzureResourceInfrastructure infra,
-        BicepValue<string> acrPullIdentityClientId,
+        BicepValue<string> webAppIdentityClientId,
         BicepValue<ResourceIdentifier> appServicePlanId)
     {
-        // This ACR identity is used by the dashboard to authorize the telemetry data
-        // coming from the dotnet web apps. This identity is being assigned to every web app
-        // in the aspire project and can be safely reused for authorization in the dashboard. 
+        // The webAppIdentityClientId is the client id of the user-assigned identity that is attached
+        // to every web app in the aspire project. That identity serves two roles in the deployed
+        // environment, and both are wired up from this single client id:
+        //   1. ACR pull: it holds the AcrPull role on the container registry, and the dashboard
+        //      website itself reuses it via SiteConfig.AcrUserManagedIdentityId to pull its image.
+        //   2. Telemetry auth: it is the identity the web apps present when sending OTLP telemetry
+        //      to the dashboard, so the dashboard authorizes it via ALLOWED_MANAGED_IDENTITIES.
         var prefix = infra.AspireResource.Name;
         var contributorIdentity = new UserAssignedIdentity(Infrastructure.NormalizeBicepIdentifier($"{prefix}-contributor-mi"));
 
@@ -59,7 +63,7 @@ internal static class AzureAppServiceEnvironmentUtility
             SiteConfig = new SiteConfigProperties()
             {
                 LinuxFxVersion = "ASPIREDASHBOARD|1.0",
-                AcrUserManagedIdentityId = acrPullIdentityClientId,
+                AcrUserManagedIdentityId = webAppIdentityClientId,
                 UseManagedIdentityCreds = true,
                 IsHttp20Enabled = true,
                 Http20ProxyFlag = 1,
@@ -92,7 +96,7 @@ internal static class AzureAppServiceEnvironmentUtility
         dashboard.SiteConfig.AppSettings.Add(new AppServiceNameValuePair { Name = "WEBSITE_START_SCM_WITH_PRELOAD", Value = "true" });
         // Appsettings related to managed identity for auth
         dashboard.SiteConfig.AppSettings.Add(new AppServiceNameValuePair { Name = "AZURE_CLIENT_ID", Value = contributorIdentity.ClientId });
-        dashboard.SiteConfig.AppSettings.Add(new AppServiceNameValuePair { Name = "ALLOWED_MANAGED_IDENTITIES", Value = acrPullIdentityClientId });
+        dashboard.SiteConfig.AppSettings.Add(new AppServiceNameValuePair { Name = "ALLOWED_MANAGED_IDENTITIES", Value = webAppIdentityClientId });
         // Added appsetting to identify the resources in a specific aspire environment
         dashboard.SiteConfig.AppSettings.Add(new AppServiceNameValuePair { Name = "ASPIRE_ENVIRONMENT_NAME", Value = infra.AspireResource.Name });
 

--- a/src/Aspire.Hosting.Azure.AppService/api/Aspire.Hosting.Azure.AppService.ats.txt
+++ b/src/Aspire.Hosting.Azure.AppService/api/Aspire.Hosting.Azure.AppService.ats.txt
@@ -8,6 +8,7 @@ Aspire.Hosting.Azure.AppService/Aspire.Hosting.Azure.AzureAppServiceEnvironmentR
 Aspire.Hosting.Azure.AppService/addAzureAppServiceEnvironment(name: string) -> Aspire.Hosting.Azure.AppService/Aspire.Hosting.Azure.AzureAppServiceEnvironmentResource
 Aspire.Hosting.Azure.AppService/publishAsAzureAppServiceWebsite(configure?: callback, configureSlot?: callback) -> Aspire.Hosting/Aspire.Hosting.ApplicationModel.IComputeResource
 Aspire.Hosting.Azure.AppService/skipEnvironmentVariableNameChecks() -> Aspire.Hosting/Aspire.Hosting.ApplicationModel.IComputeResource
+Aspire.Hosting.Azure.AppService/withAcrPullIdentity(identityBuilder: Aspire.Hosting.Azure/Aspire.Hosting.Azure.AzureUserAssignedIdentityResource) -> Aspire.Hosting.Azure.AppService/Aspire.Hosting.Azure.AzureAppServiceEnvironmentResource
 Aspire.Hosting.Azure.AppService/withAzureApplicationInsights(applicationInsights?: string|Aspire.Hosting/Aspire.Hosting.ApplicationModel.ParameterResource|Aspire.Hosting.Azure.ApplicationInsights/Aspire.Hosting.Azure.AzureApplicationInsightsResource) -> Aspire.Hosting.Azure.AppService/Aspire.Hosting.Azure.AzureAppServiceEnvironmentResource
 Aspire.Hosting.Azure.AppService/withDashboard(enable?: boolean) -> Aspire.Hosting.Azure.AppService/Aspire.Hosting.Azure.AzureAppServiceEnvironmentResource
 Aspire.Hosting.Azure.AppService/withDeploymentSlot(deploymentSlot: string|Aspire.Hosting/Aspire.Hosting.ApplicationModel.ParameterResource) -> Aspire.Hosting.Azure.AppService/Aspire.Hosting.Azure.AzureAppServiceEnvironmentResource

--- a/tests/Aspire.Hosting.Azure.Tests/AzureAppServiceTests.cs
+++ b/tests/Aspire.Hosting.Azure.Tests/AzureAppServiceTests.cs
@@ -11,6 +11,7 @@ using Aspire.Hosting.Utils;
 using Aspire.TestUtilities;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
 using static Aspire.Hosting.Utils.AzureManifestUtils;
 
 namespace Aspire.Hosting.Azure.Tests;
@@ -345,7 +346,7 @@ public class AzureAppServiceTests(ITestOutputHelper testOutputHelper)
         var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish);
 
         var nameParameter = builder.AddParameter("appServicePlanName", "existing-plan-name");
-        var resourceGroupParameter = builder.AddParameter("resourceGroup", "existing-rg");
+        var resourceGroupParameter = builder.AddParameter("appServicePlanResourceGroup", "existing-rg");
 
         builder.AddAzureAppServiceEnvironment("env")
             .PublishAsExisting(nameParameter, resourceGroupParameter);
@@ -366,6 +367,139 @@ public class AzureAppServiceTests(ITestOutputHelper testOutputHelper)
 
         await Verify(manifest.ToString(), "json")
               .AppendContentAsFile(bicep, "bicep");
+    }
+
+    [Fact]
+    public async Task AzureAppServiceEnvironmentCanPublishExistingAppServicePlan()
+    {
+        using var tempDir = new TestTempDirectory();
+
+        var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish, tempDir.Path);
+
+        var nameParameter = builder.AddParameter("appServicePlanName", "existing-plan-name");
+        var resourceGroupParameter = builder.AddParameter("appServicePlanResourceGroup", "existing-rg");
+
+        builder.AddAzureAppServiceEnvironment("env")
+            .PublishAsExisting(nameParameter, resourceGroupParameter);
+
+        builder.AddProject<Project>("api", launchProfileName: null)
+            .WithHttpEndpoint()
+            .WithExternalHttpEndpoints();
+
+        using var app = builder.Build();
+
+        await app.RunAsync();
+
+        var mainBicepPath = Path.Combine(tempDir.Path, "main.bicep");
+        Assert.True(File.Exists(mainBicepPath), $"Expected publish to produce '{mainBicepPath}'.");
+        var mainBicep = await File.ReadAllTextAsync(mainBicepPath);
+
+        var envBicepPath = Path.Combine(tempDir.Path, "env", "env.bicep");
+        Assert.True(File.Exists(envBicepPath), $"Expected publish to produce '{envBicepPath}'.");
+        var envBicep = await File.ReadAllTextAsync(envBicepPath);
+
+        var apiBicepPath = Path.Combine(tempDir.Path, "api", "api.bicep");
+        Assert.True(File.Exists(apiBicepPath), $"Expected publish to produce '{apiBicepPath}'.");
+        var apiBicep = await File.ReadAllTextAsync(apiBicepPath);
+
+        await Verify(mainBicep, "bicep")
+            .AppendContentAsFile(envBicep, "bicep")
+            .AppendContentAsFile(apiBicep, "bicep");
+    }
+
+    [Fact]
+    public async Task AsExisting_WithExplicitContainerRegistry_PublishGeneratesEnvWithExistingPlanAndRegistry()
+    {
+        // Existing App Service Plan + existing ACR should reference both pre-provisioned resources.
+        // Without WithAcrPullIdentity, Aspire still emits a new identity and AcrPull role assignment
+        // for image pulls. Disable the dashboard so the snapshot focuses on plan/ACR behavior.
+        var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish);
+
+        var planName = builder.AddParameter("appServicePlanName");
+        var registryName = builder.AddParameter("registryName");
+        var sharedResourceGroup = builder.AddParameter("sharedRg");
+
+        var acr = builder.AddAzureContainerRegistry("acr")
+            .AsExisting(registryName, sharedResourceGroup);
+
+        var env = builder.AddAzureAppServiceEnvironment("env")
+            .AsExisting(planName, sharedResourceGroup)
+            .WithAzureContainerRegistry(acr)
+            .WithDashboard(false);
+
+        var (manifest, bicep) = await GetManifestWithBicep(env.Resource);
+
+        await Verify(bicep, extension: "bicep")
+            .AppendContentAsFile(manifest.ToString(), "json");
+    }
+
+    [Fact]
+    public async Task WithAcrPullIdentity_PublishGeneratesEnvWithSuppliedIdentity()
+    {
+        // Greenfield App Service Plan, but the user has BYO'd a managed identity. The generated
+        // Bicep should NOT declare an env_mi resource or an AcrPull role assignment - the
+        // identity id/client id should flow into the env module via parameters and be emitted as
+        // AZURE_CONTAINER_REGISTRY_MANAGED_IDENTITY_ID/CLIENT_ID.
+        var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish);
+
+        var mi = builder.AddAzureUserAssignedIdentity("shared-mi");
+
+        var env = builder.AddAzureAppServiceEnvironment("env")
+            .WithAcrPullIdentity(mi);
+
+        var (manifest, bicep) = await GetManifestWithBicep(env.Resource);
+
+        await Verify(bicep, extension: "bicep")
+            .AppendContentAsFile(manifest.ToString(), "json");
+    }
+
+    [Fact]
+    public async Task WithAcrPullIdentity_AsExisting_PublishGeneratesEnvWithSuppliedIdentity()
+    {
+        // Existing App Service Plan + existing ACR + BYO identity that already has AcrPull on the ACR.
+        // Disable the dashboard so the env module references the pre-provisioned resources without
+        // emitting a new ACR-pull identity, AcrPull role assignment, dashboard, or dashboard contributor identity.
+        var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish);
+
+        var planName = builder.AddParameter("appServicePlanName");
+        var registryName = builder.AddParameter("registryName");
+        var identityName = builder.AddParameter("identityName");
+        var sharedResourceGroup = builder.AddParameter("sharedRg");
+
+        var acr = builder.AddAzureContainerRegistry("acr")
+            .AsExisting(registryName, sharedResourceGroup);
+
+        var mi = builder.AddAzureUserAssignedIdentity("shared-mi")
+            .AsExisting(identityName, sharedResourceGroup);
+
+        var env = builder.AddAzureAppServiceEnvironment("env")
+            .AsExisting(planName, sharedResourceGroup)
+            .WithAzureContainerRegistry(acr)
+            .WithAcrPullIdentity(mi)
+            .WithDashboard(false);
+
+        var (manifest, bicep) = await GetManifestWithBicep(env.Resource);
+
+        await Verify(bicep, extension: "bicep")
+            .AppendContentAsFile(manifest.ToString(), "json");
+    }
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public async Task WithDashboardControlsDashboardUrlPrintStep(bool enableDashboard)
+    {
+        var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish);
+
+        var env = builder.AddAzureAppServiceEnvironment("env")
+            .WithDashboard(enableDashboard);
+
+        using var app = builder.Build();
+
+        var steps = await CreateStepsAsync(app, env.Resource);
+        var hasPrintDashboardUrlStep = steps.Any(s => s.Name == "print-dashboard-url-env");
+
+        Assert.Equal(enableDashboard, hasPrintDashboardUrlStep);
     }
 
     [Fact]
@@ -1096,6 +1230,28 @@ public class AzureAppServiceTests(ITestOutputHelper testOutputHelper)
 
     private static Task<(JsonNode ManifestNode, string BicepText)> GetManifestWithBicep(IResource resource) =>
         AzureManifestUtils.GetManifestWithBicep(resource, skipPreparer: true);
+
+    private static async Task<List<PipelineStep>> CreateStepsAsync(DistributedApplication app, AzureAppServiceEnvironmentResource resource)
+    {
+        var pipelineContext = new PipelineContext(
+            app.Services.GetRequiredService<DistributedApplicationModel>(),
+            new DistributedApplicationExecutionContext(DistributedApplicationOperation.Publish),
+            app.Services,
+            NullLogger.Instance,
+            CancellationToken.None);
+
+        var results = new List<PipelineStep>();
+        foreach (var annotation in resource.Annotations.OfType<PipelineStepAnnotation>())
+        {
+            results.AddRange(await annotation.CreateStepsAsync(new PipelineStepFactoryContext
+            {
+                PipelineContext = pipelineContext,
+                Resource = resource
+            }));
+        }
+
+        return results;
+    }
 
     private sealed class Project : IProjectMetadata
     {

--- a/tests/Aspire.Hosting.Azure.Tests/AzureContainerAppsTests.cs
+++ b/tests/Aspire.Hosting.Azure.Tests/AzureContainerAppsTests.cs
@@ -18,6 +18,7 @@ using Azure.Provisioning.KeyVault;
 using Azure.Provisioning.Primitives;
 using Azure.Provisioning.Storage;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
 using static Aspire.Hosting.Utils.AzureManifestUtils;
 
 namespace Aspire.Hosting.Azure.Tests;
@@ -2645,5 +2646,45 @@ public class AzureContainerAppsTests
 
         await Verify(manifest.ToString(), "json")
               .AppendContentAsFile(bicep, "bicep");
+    }
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public async Task WithDashboardControlsDashboardUrlPrintStep(bool enableDashboard)
+    {
+        var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish);
+
+        var env = builder.AddAzureContainerAppEnvironment("env")
+            .WithDashboard(enableDashboard);
+
+        using var app = builder.Build();
+
+        var steps = await CreateStepsAsync(app, env.Resource);
+        var hasPrintDashboardUrlStep = steps.Any(s => s.Name == "print-dashboard-url-env");
+
+        Assert.Equal(enableDashboard, hasPrintDashboardUrlStep);
+    }
+
+    private static async Task<List<PipelineStep>> CreateStepsAsync(DistributedApplication app, AzureContainerAppEnvironmentResource resource)
+    {
+        var pipelineContext = new PipelineContext(
+            app.Services.GetRequiredService<DistributedApplicationModel>(),
+            new DistributedApplicationExecutionContext(DistributedApplicationOperation.Publish),
+            app.Services,
+            NullLogger.Instance,
+            CancellationToken.None);
+
+        var results = new List<PipelineStep>();
+        foreach (var annotation in resource.Annotations.OfType<PipelineStepAnnotation>())
+        {
+            results.AddRange(await annotation.CreateStepsAsync(new PipelineStepFactoryContext
+            {
+                PipelineContext = pipelineContext,
+                Resource = resource
+            }));
+        }
+
+        return results;
     }
 }

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureAppServiceTests.AsExisting_WithExplicitContainerRegistry_PublishGeneratesEnvWithExistingPlanAndRegistry.verified.bicep
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureAppServiceTests.AsExisting_WithExplicitContainerRegistry_PublishGeneratesEnvWithExistingPlanAndRegistry.verified.bicep
@@ -1,0 +1,52 @@
+@description('The location for the resource(s) to be deployed.')
+param location string = resourceGroup().location
+
+param userPrincipalId string = ''
+
+param tags object = { }
+
+param registryName string
+
+param sharedRg string
+
+param appServicePlanName string
+
+resource env_mi 'Microsoft.ManagedIdentity/userAssignedIdentities@2024-11-30' = {
+  name: take('env_mi-${uniqueString(resourceGroup().id)}', 128)
+  location: location
+  tags: tags
+}
+
+resource acr 'Microsoft.ContainerRegistry/registries@2025-04-01' existing = {
+  name: registryName
+  scope: resourceGroup(sharedRg)
+}
+
+resource acr_env_mi_AcrPull 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
+  name: guid(acr.id, env_mi.id, subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '7f951dda-4ed3-4680-a7ca-43fe172d538d'))
+  properties: {
+    principalId: env_mi.properties.principalId
+    roleDefinitionId: subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '7f951dda-4ed3-4680-a7ca-43fe172d538d')
+    principalType: 'ServicePrincipal'
+  }
+  scope: acr
+}
+
+resource env 'Microsoft.Web/serverfarms@2025-03-01' existing = {
+  name: appServicePlanName
+  scope: resourceGroup(sharedRg)
+}
+
+output name string = env.name
+
+output planId string = env.id
+
+output webSiteSuffix string = uniqueString(resourceGroup().id)
+
+output AZURE_CONTAINER_REGISTRY_NAME string = acr.name
+
+output AZURE_CONTAINER_REGISTRY_ENDPOINT string = acr.properties.loginServer
+
+output AZURE_CONTAINER_REGISTRY_MANAGED_IDENTITY_ID string = env_mi.id
+
+output AZURE_CONTAINER_REGISTRY_MANAGED_IDENTITY_CLIENT_ID string = env_mi.properties.clientId

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureAppServiceTests.AsExisting_WithExplicitContainerRegistry_PublishGeneratesEnvWithExistingPlanAndRegistry.verified.json
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureAppServiceTests.AsExisting_WithExplicitContainerRegistry_PublishGeneratesEnvWithExistingPlanAndRegistry.verified.json
@@ -2,9 +2,9 @@
   "type": "azure.bicep.v0",
   "path": "env.module.bicep",
   "params": {
-    "env_acr_outputs_name": "{env-acr.outputs.name}",
+    "registryName": "{registryName.value}",
+    "sharedRg": "{sharedRg.value}",
     "appServicePlanName": "{appServicePlanName.value}",
-    "appServicePlanResourceGroup": "{appServicePlanResourceGroup.value}",
     "userPrincipalId": ""
   }
 }

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureAppServiceTests.AzureAppServiceEnvironmentCanPublishExistingAppServicePlan#00.verified.bicep
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureAppServiceTests.AzureAppServiceEnvironmentCanPublishExistingAppServicePlan#00.verified.bicep
@@ -1,0 +1,50 @@
+﻿targetScope = 'subscription'
+
+param resourceGroupName string
+
+param location string
+
+param principalId string
+
+param appServicePlanResourceGroup string
+
+param appServicePlanName string
+
+resource rg 'Microsoft.Resources/resourceGroups@2023-07-01' = {
+  name: resourceGroupName
+  location: location
+}
+
+module env_acr 'env-acr/env-acr.bicep' = {
+  name: 'env-acr'
+  scope: rg
+  params: {
+    location: location
+  }
+}
+
+module env 'env/env.bicep' = {
+  name: 'env'
+  scope: rg
+  params: {
+    location: location
+    env_acr_outputs_name: env_acr.outputs.name
+    appServicePlanName: appServicePlanName
+    appServicePlanResourceGroup: appServicePlanResourceGroup
+    userPrincipalId: principalId
+  }
+}
+
+output env_AZURE_CONTAINER_REGISTRY_ENDPOINT string = env.outputs.AZURE_CONTAINER_REGISTRY_ENDPOINT
+
+output env_planId string = env.outputs.planId
+
+output env_AZURE_CONTAINER_REGISTRY_MANAGED_IDENTITY_ID string = env.outputs.AZURE_CONTAINER_REGISTRY_MANAGED_IDENTITY_ID
+
+output env_AZURE_CONTAINER_REGISTRY_MANAGED_IDENTITY_CLIENT_ID string = env.outputs.AZURE_CONTAINER_REGISTRY_MANAGED_IDENTITY_CLIENT_ID
+
+output env_AZURE_APP_SERVICE_DASHBOARD_URI string = env.outputs.AZURE_APP_SERVICE_DASHBOARD_URI
+
+output env_AZURE_WEBSITE_CONTRIBUTOR_MANAGED_IDENTITY_ID string = env.outputs.AZURE_WEBSITE_CONTRIBUTOR_MANAGED_IDENTITY_ID
+
+output env_AZURE_WEBSITE_CONTRIBUTOR_MANAGED_IDENTITY_PRINCIPAL_ID string = env.outputs.AZURE_WEBSITE_CONTRIBUTOR_MANAGED_IDENTITY_PRINCIPAL_ID

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureAppServiceTests.AzureAppServiceEnvironmentCanPublishExistingAppServicePlan#01.verified.bicep
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureAppServiceTests.AzureAppServiceEnvironmentCanPublishExistingAppServicePlan#01.verified.bicep
@@ -1,4 +1,4 @@
-﻿@description('The location for the resource(s) to be deployed.')
+@description('The location for the resource(s) to be deployed.')
 param location string = resourceGroup().location
 
 param userPrincipalId string = ''

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureAppServiceTests.AzureAppServiceEnvironmentCanPublishExistingAppServicePlan#02.verified.bicep
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureAppServiceTests.AzureAppServiceEnvironmentCanPublishExistingAppServicePlan#02.verified.bicep
@@ -1,0 +1,118 @@
+@description('The location for the resource(s) to be deployed.')
+param location string = resourceGroup().location
+
+param env_outputs_azure_container_registry_endpoint string
+
+param env_outputs_planid string
+
+param env_outputs_azure_container_registry_managed_identity_id string
+
+param env_outputs_azure_container_registry_managed_identity_client_id string
+
+param api_containerimage string
+
+param api_containerport string
+
+param env_outputs_azure_app_service_dashboard_uri string
+
+param env_outputs_azure_website_contributor_managed_identity_id string
+
+param env_outputs_azure_website_contributor_managed_identity_principal_id string
+
+resource mainContainer 'Microsoft.Web/sites/sitecontainers@2025-03-01' = {
+  name: 'main'
+  properties: {
+    authType: 'UserAssigned'
+    image: api_containerimage
+    isMain: true
+    targetPort: api_containerport
+    userManagedIdentityClientId: env_outputs_azure_container_registry_managed_identity_client_id
+  }
+  parent: webapp
+}
+
+resource webapp 'Microsoft.Web/sites@2025-03-01' = {
+  name: take('${toLower('api')}-${uniqueString(resourceGroup().id)}', 60)
+  location: location
+  properties: {
+    serverFarmId: env_outputs_planid
+    siteConfig: {
+      numberOfWorkers: 30
+      linuxFxVersion: 'SITECONTAINERS'
+      acrUseManagedIdentityCreds: true
+      acrUserManagedIdentityID: env_outputs_azure_container_registry_managed_identity_client_id
+      appSettings: [
+        {
+          name: 'WEBSITES_PORT'
+          value: api_containerport
+        }
+        {
+          name: 'OTEL_DOTNET_EXPERIMENTAL_OTLP_RETRY'
+          value: 'in_memory'
+        }
+        {
+          name: 'ASPNETCORE_FORWARDEDHEADERS_ENABLED'
+          value: 'true'
+        }
+        {
+          name: 'HTTP_PORTS'
+          value: api_containerport
+        }
+        {
+          name: 'ASPIRE_ENVIRONMENT_NAME'
+          value: 'env'
+        }
+        {
+          name: 'OTEL_SERVICE_NAME'
+          value: 'api'
+        }
+        {
+          name: 'OTEL_EXPORTER_OTLP_PROTOCOL'
+          value: 'grpc'
+        }
+        {
+          name: 'OTEL_EXPORTER_OTLP_ENDPOINT'
+          value: 'http://localhost:6001'
+        }
+        {
+          name: 'WEBSITE_ENABLE_ASPIRE_OTEL_SIDECAR'
+          value: 'true'
+        }
+        {
+          name: 'OTEL_COLLECTOR_URL'
+          value: env_outputs_azure_app_service_dashboard_uri
+        }
+        {
+          name: 'OTEL_CLIENT_ID'
+          value: env_outputs_azure_container_registry_managed_identity_client_id
+        }
+      ]
+    }
+  }
+  identity: {
+    type: 'UserAssigned'
+    userAssignedIdentities: {
+      '${env_outputs_azure_container_registry_managed_identity_id}': { }
+    }
+  }
+}
+
+resource api_website_ra 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
+  name: guid(webapp.id, env_outputs_azure_website_contributor_managed_identity_id, subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'de139f84-1756-47ae-9be6-808fbbe84772'))
+  properties: {
+    principalId: env_outputs_azure_website_contributor_managed_identity_principal_id
+    roleDefinitionId: subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'de139f84-1756-47ae-9be6-808fbbe84772')
+    principalType: 'ServicePrincipal'
+  }
+  scope: webapp
+}
+
+resource slotConfigNames 'Microsoft.Web/sites/config@2025-03-01' = {
+  name: 'slotConfigNames'
+  properties: {
+    appSettingNames: [
+      'OTEL_SERVICE_NAME'
+    ]
+  }
+  parent: webapp
+}

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureAppServiceTests.WithAcrPullIdentity_AsExisting_PublishGeneratesEnvWithSuppliedIdentity.verified.bicep
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureAppServiceTests.WithAcrPullIdentity_AsExisting_PublishGeneratesEnvWithSuppliedIdentity.verified.bicep
@@ -1,0 +1,40 @@
+@description('The location for the resource(s) to be deployed.')
+param location string = resourceGroup().location
+
+param userPrincipalId string = ''
+
+param tags object = { }
+
+param shared_mi_outputs_id string
+
+param shared_mi_outputs_clientid string
+
+param registryName string
+
+param sharedRg string
+
+param appServicePlanName string
+
+resource acr 'Microsoft.ContainerRegistry/registries@2025-04-01' existing = {
+  name: registryName
+  scope: resourceGroup(sharedRg)
+}
+
+resource env 'Microsoft.Web/serverfarms@2025-03-01' existing = {
+  name: appServicePlanName
+  scope: resourceGroup(sharedRg)
+}
+
+output name string = env.name
+
+output planId string = env.id
+
+output webSiteSuffix string = uniqueString(resourceGroup().id)
+
+output AZURE_CONTAINER_REGISTRY_NAME string = acr.name
+
+output AZURE_CONTAINER_REGISTRY_ENDPOINT string = acr.properties.loginServer
+
+output AZURE_CONTAINER_REGISTRY_MANAGED_IDENTITY_ID string = shared_mi_outputs_id
+
+output AZURE_CONTAINER_REGISTRY_MANAGED_IDENTITY_CLIENT_ID string = shared_mi_outputs_clientid

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureAppServiceTests.WithAcrPullIdentity_AsExisting_PublishGeneratesEnvWithSuppliedIdentity.verified.json
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureAppServiceTests.WithAcrPullIdentity_AsExisting_PublishGeneratesEnvWithSuppliedIdentity.verified.json
@@ -1,0 +1,12 @@
+﻿{
+  "type": "azure.bicep.v0",
+  "path": "env.module.bicep",
+  "params": {
+    "shared_mi_outputs_id": "{shared-mi.outputs.id}",
+    "shared_mi_outputs_clientid": "{shared-mi.outputs.clientId}",
+    "registryName": "{registryName.value}",
+    "sharedRg": "{sharedRg.value}",
+    "appServicePlanName": "{appServicePlanName.value}",
+    "userPrincipalId": ""
+  }
+}

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureAppServiceTests.WithAcrPullIdentity_PublishGeneratesEnvWithSuppliedIdentity.verified.bicep
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureAppServiceTests.WithAcrPullIdentity_PublishGeneratesEnvWithSuppliedIdentity.verified.bicep
@@ -1,39 +1,32 @@
-﻿@description('The location for the resource(s) to be deployed.')
+@description('The location for the resource(s) to be deployed.')
 param location string = resourceGroup().location
 
 param userPrincipalId string = ''
 
 param tags object = { }
 
+param shared_mi_outputs_id string
+
+param shared_mi_outputs_clientid string
+
 param env_acr_outputs_name string
-
-param appServicePlanName string
-
-param appServicePlanResourceGroup string
-
-resource env_mi 'Microsoft.ManagedIdentity/userAssignedIdentities@2024-11-30' = {
-  name: take('env_mi-${uniqueString(resourceGroup().id)}', 128)
-  location: location
-  tags: tags
-}
 
 resource env_acr 'Microsoft.ContainerRegistry/registries@2025-04-01' existing = {
   name: env_acr_outputs_name
 }
 
-resource env_acr_env_mi_AcrPull 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
-  name: guid(env_acr.id, env_mi.id, subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '7f951dda-4ed3-4680-a7ca-43fe172d538d'))
+resource env_asplan 'Microsoft.Web/serverfarms@2025-03-01' = {
+  name: take('envasplan-${uniqueString(resourceGroup().id)}', 60)
+  location: location
   properties: {
-    principalId: env_mi.properties.principalId
-    roleDefinitionId: subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '7f951dda-4ed3-4680-a7ca-43fe172d538d')
-    principalType: 'ServicePrincipal'
+    perSiteScaling: true
+    reserved: true
   }
-  scope: env_acr
-}
-
-resource env 'Microsoft.Web/serverfarms@2025-03-01' existing = {
-  name: appServicePlanName
-  scope: resourceGroup(appServicePlanResourceGroup)
+  kind: 'Linux'
+  sku: {
+    name: 'P0V3'
+    tier: 'Premium'
+  }
 }
 
 resource env_contributor_mi 'Microsoft.ManagedIdentity/userAssignedIdentities@2024-11-30' = {
@@ -54,12 +47,12 @@ resource dashboard 'Microsoft.Web/sites@2025-03-01' = {
   name: take('${toLower('env')}-${toLower('aspiredashboard')}-${uniqueString(resourceGroup().id)}', 60)
   location: location
   properties: {
-    serverFarmId: env.id
+    serverFarmId: env_asplan.id
     siteConfig: {
       numberOfWorkers: 1
       linuxFxVersion: 'ASPIREDASHBOARD|1.0'
       acrUseManagedIdentityCreds: true
-      acrUserManagedIdentityID: env_mi.properties.clientId
+      acrUserManagedIdentityID: shared_mi_outputs_clientid
       appSettings: [
         {
           name: 'DASHBOARD__FRONTEND__AUTHMODE'
@@ -99,7 +92,7 @@ resource dashboard 'Microsoft.Web/sites@2025-03-01' = {
         }
         {
           name: 'ALLOWED_MANAGED_IDENTITIES'
-          value: env_mi.properties.clientId
+          value: shared_mi_outputs_clientid
         }
         {
           name: 'ASPIRE_ENVIRONMENT_NAME'
@@ -120,9 +113,9 @@ resource dashboard 'Microsoft.Web/sites@2025-03-01' = {
   kind: 'app,linux,aspiredashboard'
 }
 
-output name string = env.name
+output name string = env_asplan.name
 
-output planId string = env.id
+output planId string = env_asplan.id
 
 output webSiteSuffix string = uniqueString(resourceGroup().id)
 
@@ -130,9 +123,9 @@ output AZURE_CONTAINER_REGISTRY_NAME string = env_acr.name
 
 output AZURE_CONTAINER_REGISTRY_ENDPOINT string = env_acr.properties.loginServer
 
-output AZURE_CONTAINER_REGISTRY_MANAGED_IDENTITY_ID string = env_mi.id
+output AZURE_CONTAINER_REGISTRY_MANAGED_IDENTITY_ID string = shared_mi_outputs_id
 
-output AZURE_CONTAINER_REGISTRY_MANAGED_IDENTITY_CLIENT_ID string = env_mi.properties.clientId
+output AZURE_CONTAINER_REGISTRY_MANAGED_IDENTITY_CLIENT_ID string = shared_mi_outputs_clientid
 
 output AZURE_WEBSITE_CONTRIBUTOR_MANAGED_IDENTITY_ID string = env_contributor_mi.id
 

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureAppServiceTests.WithAcrPullIdentity_PublishGeneratesEnvWithSuppliedIdentity.verified.json
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureAppServiceTests.WithAcrPullIdentity_PublishGeneratesEnvWithSuppliedIdentity.verified.json
@@ -2,9 +2,9 @@
   "type": "azure.bicep.v0",
   "path": "env.module.bicep",
   "params": {
+    "shared_mi_outputs_id": "{shared-mi.outputs.id}",
+    "shared_mi_outputs_clientid": "{shared-mi.outputs.clientId}",
     "env_acr_outputs_name": "{env-acr.outputs.name}",
-    "appServicePlanName": "{appServicePlanName.value}",
-    "appServicePlanResourceGroup": "{appServicePlanResourceGroup.value}",
     "userPrincipalId": ""
   }
 }


### PR DESCRIPTION
## Description

Fixes #14382

Azure App Service deployments can now target an existing App Service Plan correctly. Previously, applying `AsExisting(...)` / `PublishAsExisting(...)` to `AzureAppServiceEnvironmentResource` did not carry through the full publish/deploy pipeline, so generated Bicep could still treat the App Service Plan as a resource to create. This change emits the App Service Plan as an existing `Microsoft.Web/serverfarms` resource while still allowing Aspire to create the website, dashboard, container registry, and supporting identities that are not marked as existing.

This also adds App Service parity for BYO ACR pull identities with `WithAcrPullIdentity(...)`, mirroring the Container Apps pattern where callers can provide the user-assigned identity used for container image pulls and own the required `AcrPull` role assignment. While testing the existing-plan flow, I also fixed the dashboard-disabled deploy path so Aspire does not try to print a dashboard URL when `.WithDashboard(false)` omits the dashboard output.

### User-facing usage

C# AppHost:

```csharp
var planName = builder.AddParameter("appServicePlanName");
var planResourceGroup = builder.AddParameter("appServicePlanResourceGroup");

builder.AddAzureAppServiceEnvironment("env")
    .AsExisting(planName, planResourceGroup);

builder.AddProject<Projects.Api>("api")
    .WithExternalHttpEndpoints();
```

TypeScript AppHost:

```typescript
const planName = await builder.addParameter('appServicePlanName');
const planResourceGroup = await builder.addParameter('appServicePlanResourceGroup');

await builder.addAzureAppServiceEnvironment('env')
    .asExisting(planName, { resourceGroup: planResourceGroup });

await builder.addProject('api', '../Api/Api.csproj')
    .withExternalHttpEndpoints();
```

BYO ACR pull identity:

```csharp
var acr = builder.AddAzureContainerRegistry("acr").AsExisting("myacr", "shared-rg");
var pullIdentity = builder.AddAzureUserAssignedIdentity("pull-identity")
    .AsExisting("my-pull-identity", "shared-rg");

pullIdentity.WithRoleAssignments(acr, ContainerRegistryBuiltInRole.AcrPull);

builder.AddAzureAppServiceEnvironment("env")
    .AsExisting(planName, planResourceGroup)
    .WithAzureContainerRegistry(acr)
    .WithAcrPullIdentity(pullIdentity);
```

Generated `env/env.bicep` now includes:

```bicep
resource env 'Microsoft.Web/serverfarms@2025-03-01' existing = {
  name: appServicePlanName
  scope: resourceGroup(appServicePlanResourceGroup)
}
```

### Security considerations

`WithAcrPullIdentity(...)` intentionally changes who owns the `AcrPull` role assignment. When a caller supplies an identity, Aspire does not create a new ACR pull identity or role assignment; the caller must ensure that identity already has the required `AcrPull` permission on the registry.

### Validation

- `dotnet test --project tests/Aspire.Hosting.Azure.Tests/Aspire.Hosting.Azure.Tests.csproj --no-launch-profile -- --filter-class "*.AzureAppServiceTests" --filter-not-trait "quarantined=true" --filter-not-trait "outerloop=true"`
- Live Azure App Service E2E against a manually-created Linux App Service Plan in `DavidPersonal`, including:
  - C# AppHost with `.WithDashboard(false)`
  - C# AppHost updated to default dashboard-enabled deployment
  - TypeScript AppHost with default dashboard-enabled deployment
  - Verified both API and dashboard sites used the pre-existing plan and the API returned `existing-plan-ok`

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [x] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [x] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [x] No
  - [ ] No
- Does the change make any security assumptions or guarantees?
  - [x] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [x] No
  - [ ] No
