### PR TITLE
Address remaining Blazor integration PR feedback

### DIFF
--- a/playground/BlazorHosted/BlazorHosted.ClientServiceDefaults/Extensions.cs
+++ b/playground/BlazorHosted/BlazorHosted.ClientServiceDefaults/Extensions.cs
@@ -35,7 +35,7 @@ public static class BlazorClientExtensions
     private static WebAssemblyHostBuilder ConfigureBlazorClientOpenTelemetry(this WebAssemblyHostBuilder builder)
     {
         // Without an OTLP path base, there's nowhere to export telemetry in WASM.
-        var otlpPathBase = builder.Configuration["ASPIRE_OTLP_PATH_BASE"];
+        var otlpPathBase = builder.Configuration["OTEL_EXPORTER_OTLP_ENDPOINT"];
         if (string.IsNullOrEmpty(otlpPathBase))
         {
             return builder;

--- a/playground/BlazorHosted/BlazorHosted.Server/Program.cs
+++ b/playground/BlazorHosted/BlazorHosted.Server/Program.cs
@@ -4,6 +4,30 @@ var builder = WebApplication.CreateBuilder(args);
 
 builder.AddServiceDefaults();
 
+// Filter out OTLP proxy traffic from tracing to prevent a feedback loop:
+// YARP forwards /_otlp/* requests to the dashboard, and without filtering,
+// those forwarding requests would themselves be traced and exported — creating
+// recursive telemetry entries in the dashboard.
+builder.Services.PostConfigure<OpenTelemetry.Instrumentation.AspNetCore.AspNetCoreTraceInstrumentationOptions>(options =>
+{
+    var previous = options.Filter;
+    options.Filter = context =>
+    {
+        var path = context.Request.Path.Value;
+        return (previous is null || previous(context))
+            && (path is null || !path.Contains("/_otlp/", StringComparison.Ordinal));
+    };
+});
+
+builder.Services.PostConfigure<OpenTelemetry.Instrumentation.Http.HttpClientTraceInstrumentationOptions>(options =>
+{
+    var previous = options.FilterHttpRequestMessage;
+    options.FilterHttpRequestMessage = request =>
+        (previous is null || previous(request))
+        && (request.RequestUri is null
+            || !request.RequestUri.AbsolutePath.StartsWith("/v1/", StringComparison.Ordinal));
+});
+
 builder.Services.AddRazorComponents()
     .AddInteractiveWebAssemblyComponents();
 

--- a/playground/BlazorHosted/README.md
+++ b/playground/BlazorHosted/README.md
@@ -1,6 +1,6 @@
 # BlazorHosted
 
-This sample demonstrates how to integrate a **hosted Blazor WebAssembly** application (Blazor Web App with Interactive WebAssembly render mode) with .NET Aspire, enabling full observability (logs, traces) and service discovery for both the server and the WASM client.
+This sample demonstrates how to integrate a **hosted Blazor WebAssembly** application (Blazor Web App with Interactive WebAssembly render mode) with Aspire, enabling full observability (logs, traces) and service discovery for both the server and the WASM client.
 
 ## Overview
 

--- a/playground/BlazorStandalone/BlazorStandalone.ClientServiceDefaults/Extensions.cs
+++ b/playground/BlazorStandalone/BlazorStandalone.ClientServiceDefaults/Extensions.cs
@@ -35,7 +35,7 @@ public static class BlazorClientExtensions
     private static WebAssemblyHostBuilder ConfigureBlazorClientOpenTelemetry(this WebAssemblyHostBuilder builder)
     {
         // Without an OTLP path base, there's nowhere to export telemetry in WASM.
-        var otlpPathBase = builder.Configuration["ASPIRE_OTLP_PATH_BASE"];
+        var otlpPathBase = builder.Configuration["OTEL_EXPORTER_OTLP_ENDPOINT"];
         if (string.IsNullOrEmpty(otlpPathBase))
         {
             return builder;

--- a/playground/BlazorStandalone/README.md
+++ b/playground/BlazorStandalone/README.md
@@ -1,6 +1,6 @@
 # BlazorStandalone
 
-This sample demonstrates how to integrate a **standalone Blazor WebAssembly** application with .NET Aspire, enabling full observability (logs, traces) and service discovery without requiring a hosted Blazor Server backend.
+This sample demonstrates how to integrate a **standalone Blazor WebAssembly** application with Aspire, enabling full observability (logs, traces) and service discovery without requiring a hosted Blazor Server backend.
 
 ## Overview
 

--- a/src/Aspire.Hosting.Blazor/Aspire.Hosting.Blazor.csproj
+++ b/src/Aspire.Hosting.Blazor/Aspire.Hosting.Blazor.csproj
@@ -11,7 +11,19 @@
   <PropertyGroup>
     <MinCodeCoverage>0</MinCodeCoverage>
     <EnablePackageValidation>false</EnablePackageValidation>
+    <!-- The minimum .NET version for Docker images used in the Blazor gateway publish pipeline.
+         Derived from the highest TFM in the repo (currently net10.0). The Gateway.cs file-based
+         app and the WASM client projects target this version, so published containers must use
+         matching SDK/runtime base images. -->
+    <BlazorGatewayDotNetImageTag>10.0</BlazorGatewayDotNetImageTag>
   </PropertyGroup>
+
+  <ItemGroup>
+    <AssemblyAttribute Include="System.Reflection.AssemblyMetadataAttribute">
+      <_Parameter1>BlazorGatewayDotNetImageTag</_Parameter1>
+      <_Parameter2>$(BlazorGatewayDotNetImageTag)</_Parameter2>
+    </AssemblyAttribute>
+  </ItemGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\Aspire.Hosting\Aspire.Hosting.csproj" />

--- a/src/Aspire.Hosting.Blazor/BlazorGatewayExtensions.cs
+++ b/src/Aspire.Hosting.Blazor/BlazorGatewayExtensions.cs
@@ -212,6 +212,20 @@ public static class BlazorGatewayExtensions
                 var gatewayEndpoint = httpsGatewayEndpoint ?? httpGatewayEndpoint
                     ?? throw new InvalidOperationException($"The gateway '{gateway.Resource.Name}' must define an HTTP or HTTPS endpoint.");
 
+                // Resolve the HTTP OTLP endpoint for WASM client proxying.
+                // WASM clients use HTTP/protobuf (not gRPC), so we need the HTTP endpoint.
+                // First try to resolve from the dashboard resource model (handles randomized ports
+                // and isolated mode). Fall back to configuration for cases where the dashboard
+                // resource isn't in the model (e.g. external dashboard).
+                var httpOtlpEndpointUrl = ResolveHttpOtlpEndpointUrl(context, gateway.ApplicationBuilder.Configuration);
+
+                if (httpOtlpEndpointUrl is null && registeredApps.Any(a => a.ProxyBlazorTelemetry))
+                {
+                    context.Logger.LogWarning(
+                        "OTLP telemetry proxying was requested but no dashboard HTTP endpoint could be resolved. " +
+                        "WASM client telemetry will not be forwarded.");
+                }
+
                 if (context.ExecutionContext.IsPublishMode)
                 {
                     ConfigurePublishEnvironment(context, registeredApps, gatewayEndpoint, httpGatewayEndpoint);
@@ -241,20 +255,6 @@ public static class BlazorGatewayExtensions
                 var mergedRuntimePath = Path.Combine(outputDir, "merged.staticwebassets.runtime.json");
                 await EndpointsManifestTransformer.MergeRuntimeManifestsAsync(manifests, mergedRuntimePath, context.Logger, context.CancellationToken).ConfigureAwait(false);
                 context.EnvironmentVariables["staticWebAssets"] = mergedRuntimePath;
-
-                // Resolve the HTTP OTLP endpoint for WASM client proxying.
-                // WASM clients use HTTP/protobuf (not gRPC), so we need the HTTP endpoint.
-                // First try to resolve from the dashboard resource model (handles randomized ports
-                // and isolated mode). Fall back to configuration for cases where the dashboard
-                // resource isn't in the model (e.g. external dashboard).
-                var httpOtlpEndpointUrl = ResolveHttpOtlpEndpointUrl(context, gateway.ApplicationBuilder.Configuration);
-
-                if (httpOtlpEndpointUrl is null && registeredApps.Any(a => a.ProxyBlazorTelemetry))
-                {
-                    context.Logger.LogWarning(
-                        "OTLP telemetry proxying was requested but no dashboard HTTP endpoint could be resolved. " +
-                        "WASM client telemetry will not be forwarded.");
-                }
 
                 GatewayConfigurationBuilder.EmitProxyConfiguration(context.EnvironmentVariables, registeredApps, gatewayEndpoint, httpGatewayEndpoint, httpOtlpEndpointUrl);
             });

--- a/src/Aspire.Hosting.Blazor/BlazorGatewayExtensions.cs
+++ b/src/Aspire.Hosting.Blazor/BlazorGatewayExtensions.cs
@@ -21,10 +21,6 @@ namespace Aspire.Hosting;
 [Experimental("ASPIREBLAZOR001", UrlFormat = "https://aka.ms/aspire/diagnostics/{0}")]
 public static class BlazorGatewayExtensions
 {
-    // Derive the .NET image tag from the runtime version of the app host process.
-    // The Gateway is a file-based app compiled with the same SDK, so the major.minor
-    // version of the running host matches the required SDK/ASP.NET base images.
-    // Pre-release runtimes (preview/RC) use suffixed tags like "10.0-preview" or "11.0-rc".
     private static readonly string s_dotNetImageTag = GetDotNetImageTag();
     private const string DotNetSdkImageRepo = "mcr.microsoft.com/dotnet/sdk";
     private const string DotNetAspNetImageRepo = "mcr.microsoft.com/dotnet/aspnet";
@@ -37,7 +33,7 @@ public static class BlazorGatewayExtensions
     [AspireExportIgnore(Reason = "Blazor gateway APIs are not yet stable for ATS export.")]
     public static IResourceBuilder<ProjectResource> AddBlazorGateway(
         this IDistributedApplicationBuilder builder,
-        string name)
+        [ResourceName] string name)
     {
         var gatewayPath = GetScriptPath("Gateway.cs");
         var gateway = builder.AddCSharpApp(name, gatewayPath)
@@ -84,7 +80,7 @@ public static class BlazorGatewayExtensions
     [AspireExportIgnore(Reason = "Open generic type parameter TProject is not ATS-compatible.")]
     public static IResourceBuilder<BlazorWasmAppResource> AddBlazorWasmProject<TProject>(
         this IDistributedApplicationBuilder builder,
-        string name)
+        [ResourceName] string name)
         where TProject : IProjectMetadata, new()
     {
         var metadata = new TProject();
@@ -109,7 +105,7 @@ public static class BlazorGatewayExtensions
     [AspireExportIgnore(Reason = "Blazor gateway APIs are not yet stable for ATS export.")]
     public static IResourceBuilder<BlazorWasmAppResource> AddBlazorWasmApp(
         this IDistributedApplicationBuilder builder,
-        string name,
+        [ResourceName] string name,
         string projectPath)
     {
         var resolvedPath = Path.GetFullPath(Path.Combine(builder.AppHostDirectory, projectPath));
@@ -201,8 +197,7 @@ public static class BlazorGatewayExtensions
         var annotation = GetOrAddGatewayAppsAnnotation(gateway.Resource);
 
         var gatewayOutputRoot = Path.Combine(
-            gateway.ApplicationBuilder.AppHostDirectory,
-            "obj", "Aspire.Hosting.Blazor", "gateways", gateway.Resource.Name);
+            GetBlazorStorePath(gateway.ApplicationBuilder), "gateways", gateway.Resource.Name);
 
         if (!annotation.IsInitialized)
         {
@@ -253,9 +248,15 @@ public static class BlazorGatewayExtensions
                 // and isolated mode). Fall back to configuration for cases where the dashboard
                 // resource isn't in the model (e.g. external dashboard).
                 var httpOtlpEndpointUrl = ResolveHttpOtlpEndpointUrl(context, gateway.ApplicationBuilder.Configuration);
-                var resourceLoggerService = context.ExecutionContext.ServiceProvider.GetRequiredService<ResourceLoggerService>();
 
-                GatewayConfigurationBuilder.EmitProxyConfiguration(context.EnvironmentVariables, registeredApps, gatewayEndpoint, httpGatewayEndpoint, httpOtlpEndpointUrl, resourceLoggerService);
+                if (httpOtlpEndpointUrl is null && registeredApps.Any(a => a.ProxyBlazorTelemetry))
+                {
+                    context.Logger.LogWarning(
+                        "OTLP telemetry proxying was requested but no dashboard HTTP endpoint could be resolved. " +
+                        "WASM client telemetry will not be forwarded.");
+                }
+
+                GatewayConfigurationBuilder.EmitProxyConfiguration(context.EnvironmentVariables, registeredApps, gatewayEndpoint, httpGatewayEndpoint, httpOtlpEndpointUrl);
             });
         }
 
@@ -413,14 +414,14 @@ public static class BlazorGatewayExtensions
         var relativeProjectPath = Path.GetRelativePath(
             project.SolutionRoot, wasmApp.Resource.ProjectPath).Replace('\\', '/');
 
-        // Copy the PrefixEndpoints.cs script into a project-local build folder so it's
-        // available inside the Docker build context without clobbering the solution root.
+        // Copy PrefixEndpoints.cs into .aspire/scripts/ within the solution root so it's
+        // included in the Docker build context.
         var scriptSource = GetScriptPath("PrefixEndpoints.cs");
-        var scriptRelativePath = Path.Combine(project.RelativeProjectPath, "obj", "Aspire.Hosting.Blazor", "PrefixEndpoints.cs")
-            .Replace('\\', '/');
-        var scriptDest = Path.Combine(project.SolutionRoot, scriptRelativePath.Replace('/', Path.DirectorySeparatorChar));
+        var scriptDest = Path.Combine(project.SolutionRoot, ".aspire", "scripts", "PrefixEndpoints.cs");
         Directory.CreateDirectory(Path.GetDirectoryName(scriptDest)!);
         File.Copy(scriptSource, scriptDest, overwrite: true);
+        var scriptRelativePath = Path.GetRelativePath(project.SolutionRoot, scriptDest)
+            .Replace('\\', '/');
 
         var companion = gateway.ApplicationBuilder.AddResource(
             new BlazorWasmPublishResource(publishResourceName))
@@ -464,6 +465,19 @@ public static class BlazorGatewayExtensions
         }
 
         return scriptPath;
+    }
+
+    private const string AspireStorePathKey = "Aspire:Store:Path";
+
+    /// <summary>
+    /// Gets the Blazor-specific store path under the Aspire store directory.
+    /// </summary>
+    private static string GetBlazorStorePath(IDistributedApplicationBuilder builder)
+    {
+        var storePath = builder.Configuration[AspireStorePathKey]
+            ?? builder.AppHostDirectory;
+
+        return Path.Combine(storePath, ".aspire", "blazor");
     }
 
     private static List<EndpointReferenceAnnotation> GetServiceDiscoveryReferences(IResource resource)
@@ -637,30 +651,58 @@ public static class BlazorGatewayExtensions
     }
 
     /// <summary>
-    /// Resolves the Docker image tag for the .NET SDK/ASP.NET base images.
-    /// Returns "Major.Minor" for stable releases (e.g. "10.0", "11.0"),
-    /// and appends "-preview" or "-rc" for pre-release runtimes to match the
-    /// MCR tag naming convention (e.g. "10.0-preview", "11.0-rc").
+    /// Resolves the Docker image tag for .NET base images. Uses the maximum of the build-time
+    /// stamped version and the actual runtime version, with pre-release suffix when applicable.
     /// </summary>
     private static string GetDotNetImageTag()
     {
-        var tag = $"{Environment.Version.Major}.{Environment.Version.Minor}";
+        var runtimeMajor = Environment.Version.Major;
+        var runtimeMinor = Environment.Version.Minor;
 
-        // The runtime's informational version contains the full pre-release label,
-        // e.g. "10.0.0-preview.7.25352.1+..." or "11.0.0-rc.1.25400.3+...".
-        // Stable/servicing builds use "10.0.6-servicing..." which we ignore.
-        var informationalVersion = (System.Reflection.AssemblyInformationalVersionAttribute?)
-            Attribute.GetCustomAttribute(typeof(object).Assembly, typeof(System.Reflection.AssemblyInformationalVersionAttribute));
+        var stampedMajor = runtimeMajor;
+        var stampedMinor = runtimeMinor;
 
-        if (informationalVersion is not null)
+        var stampedValue = typeof(BlazorGatewayExtensions).Assembly
+            .GetCustomAttributes(typeof(System.Reflection.AssemblyMetadataAttribute), inherit: false)
+            .OfType<System.Reflection.AssemblyMetadataAttribute>()
+            .FirstOrDefault(a => a.Key == "BlazorGatewayDotNetImageTag")
+            ?.Value;
+
+        if (!string.IsNullOrEmpty(stampedValue))
         {
-            if (informationalVersion.InformationalVersion.Contains("-preview", StringComparison.OrdinalIgnoreCase))
+            var parts = stampedValue.Split('.');
+            if (parts.Length >= 2
+                && int.TryParse(parts[0], out var sMajor)
+                && int.TryParse(parts[1], out var sMinor))
             {
-                tag += "-preview";
+                stampedMajor = sMajor;
+                stampedMinor = sMinor;
             }
-            else if (informationalVersion.InformationalVersion.Contains("-rc", StringComparison.OrdinalIgnoreCase))
+        }
+
+        var major = Math.Max(runtimeMajor, stampedMajor);
+        var minor = (major == runtimeMajor && major == stampedMajor)
+            ? Math.Max(runtimeMinor, stampedMinor)
+            : (major == runtimeMajor ? runtimeMinor : stampedMinor);
+
+        var tag = $"{major}.{minor}";
+
+        // Append pre-release suffix when the runtime version won and is pre-release.
+        if (major == runtimeMajor && minor == runtimeMinor)
+        {
+            var informationalVersion = (System.Reflection.AssemblyInformationalVersionAttribute?)
+                Attribute.GetCustomAttribute(typeof(object).Assembly, typeof(System.Reflection.AssemblyInformationalVersionAttribute));
+
+            if (informationalVersion is not null)
             {
-                tag += "-rc";
+                if (informationalVersion.InformationalVersion.Contains("-preview", StringComparison.OrdinalIgnoreCase))
+                {
+                    tag += "-preview";
+                }
+                else if (informationalVersion.InformationalVersion.Contains("-rc", StringComparison.OrdinalIgnoreCase))
+                {
+                    tag += "-rc";
+                }
             }
         }
 

--- a/src/Aspire.Hosting.Blazor/BlazorHostedExtensions.cs
+++ b/src/Aspire.Hosting.Blazor/BlazorHostedExtensions.cs
@@ -99,7 +99,6 @@ public static class BlazorHostedExtensions
                 annotation.Services,
                 annotation.ProxyBlazorTelemetry,
                 httpOtlpEndpointUrl,
-                context.Logger,
                 annotation.OtlpPrefix);
         });
     }

--- a/src/Aspire.Hosting.Blazor/BlazorHostedExtensions.cs
+++ b/src/Aspire.Hosting.Blazor/BlazorHostedExtensions.cs
@@ -3,6 +3,7 @@
 
 using System.Diagnostics.CodeAnalysis;
 using Aspire.Hosting.ApplicationModel;
+using Microsoft.Extensions.Logging;
 
 #pragma warning disable ASPIREATS001 // AspireExportIgnore is experimental
 
@@ -90,6 +91,13 @@ public static class BlazorHostedExtensions
             // Resolve the HTTP OTLP endpoint for WASM client proxying.
             // WASM clients use HTTP/protobuf (not gRPC), so we need the HTTP endpoint.
             var httpOtlpEndpointUrl = BlazorGatewayExtensions.ResolveHttpOtlpEndpointUrl(context, host.ApplicationBuilder.Configuration);
+
+            if (httpOtlpEndpointUrl is null && annotation.ProxyBlazorTelemetry)
+            {
+                context.Logger.LogWarning(
+                    "OTLP telemetry proxying was requested but no dashboard HTTP endpoint could be resolved. " +
+                    "WASM client telemetry will not be forwarded.");
+            }
 
             GatewayConfigurationBuilder.EmitHostedProxyConfiguration(
                 context.EnvironmentVariables,

--- a/src/Aspire.Hosting.Blazor/GatewayConfigurationBuilder.cs
+++ b/src/Aspire.Hosting.Blazor/GatewayConfigurationBuilder.cs
@@ -241,7 +241,7 @@ internal static class GatewayConfigurationBuilder
             // Send only the OTLP path so the WASM client resolves it against its own
             // page origin (HostEnvironment.BaseAddress). This avoids cross-origin issues
             // when the user navigates via HTTP but the gateway also exposes HTTPS.
-            environment["ASPIRE_OTLP_PATH_BASE"] = $"{pathBase}/{otlpPrefix}";
+            environment["OTEL_EXPORTER_OTLP_ENDPOINT"] = $"{pathBase}/{otlpPrefix}";
             environment["OTEL_EXPORTER_OTLP_PROTOCOL"] = "http/protobuf";
 
             // NOTE: OTEL_EXPORTER_OTLP_HEADERS is intentionally NOT sent to the WASM client.

--- a/src/Aspire.Hosting.Blazor/GatewayConfigurationBuilder.cs
+++ b/src/Aspire.Hosting.Blazor/GatewayConfigurationBuilder.cs
@@ -1,10 +1,10 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Text.Encodings.Web;
 using System.Text.Json;
+using System.Text.Json.Nodes;
 using Aspire.Hosting.ApplicationModel;
-using Microsoft.Extensions.Logging;
-using Microsoft.Extensions.Logging.Abstractions;
 
 namespace Aspire.Hosting;
 
@@ -23,8 +23,7 @@ internal static class GatewayConfigurationBuilder
         List<GatewayAppRegistration> apps,
         EndpointReference gatewayEndpoint,
         EndpointReference? httpGatewayEndpoint = null,
-        object? httpOtlpEndpoint = null,
-        ResourceLoggerService? resourceLoggerService = null)
+        object? httpOtlpEndpoint = null)
     {
         var addedClusters = new HashSet<string>();
         var httpClientEndpoint = httpGatewayEndpoint ?? (gatewayEndpoint.IsHttp ? gatewayEndpoint : null);
@@ -35,8 +34,6 @@ internal static class GatewayConfigurationBuilder
             var prefix = reg.PathPrefix;
             var envPrefix = $"ClientApps__{reg.Resource.Name}";
 
-            // Per-app client config: use an IValueProvider that resolves the gateway URL
-            // at startup and builds the final JSON response.
             // Flatten services: one HostedClientService per named endpoint so each gets
             // its own YARP cluster destination.
             var servicesList = new List<HostedClientService>();
@@ -56,8 +53,7 @@ internal static class GatewayConfigurationBuilder
             }
             var services = servicesList.ToArray();
 
-            env[$"{envPrefix}__ConfigResponse"] = new ClientConfigValueProvider(
-                gatewayEndpoint,
+            env[$"{envPrefix}__ConfigResponse"] = BuildConfigExpression(
                 httpClientEndpoint,
                 httpsClientEndpoint,
                 prefix,
@@ -65,7 +61,6 @@ internal static class GatewayConfigurationBuilder
                 services,
                 reg.ProxyBlazorTelemetry,
                 httpOtlpEndpoint,
-                resourceLoggerService?.GetLogger(reg.Resource) ?? NullLogger.Instance,
                 reg.OtlpPrefix);
 
             EmitYarpRoutes(env, prefix, reg.Resource.Name, services, reg.ProxyBlazorTelemetry, addedClusters,
@@ -90,14 +85,12 @@ internal static class GatewayConfigurationBuilder
         IReadOnlyList<HostedClientService> services,
         bool proxyBlazorTelemetry,
         object? httpOtlpEndpoint,
-        ILogger? logger = null,
         string otlpPrefix = DefaultOtlpPrefix)
     {
         var httpClientEndpoint = httpHostEndpoint ?? (hostEndpoint.IsHttp ? hostEndpoint : null);
         var httpsClientEndpoint = hostEndpoint.IsHttps ? hostEndpoint : null;
 
-        env["Client__ConfigResponse"] = new ClientConfigValueProvider(
-            hostEndpoint,
+        env["Client__ConfigResponse"] = BuildConfigExpression(
             httpClientEndpoint,
             httpsClientEndpoint,
             prefix: null,
@@ -105,7 +98,6 @@ internal static class GatewayConfigurationBuilder
             services,
             proxyBlazorTelemetry,
             httpOtlpEndpoint,
-            logger ?? NullLogger.Instance,
             otlpPrefix);
         env["Client__ConfigEndpointPath"] = "/_blazor/_configuration";
 
@@ -127,6 +119,12 @@ internal static class GatewayConfigurationBuilder
     /// Default URL path segment for proxying OTLP telemetry to the Aspire dashboard.
     /// </summary>
     internal const string DefaultOtlpPrefix = "_otlp";
+
+    private static readonly JsonSerializerOptions s_jsonOptions = new()
+    {
+        WriteIndented = false,
+        Encoder = JavaScriptEncoder.UnsafeRelaxedJsonEscaping
+    };
 
     private static void EmitYarpRoutes(
         IDictionary<string, object> env,
@@ -197,15 +195,19 @@ internal static class GatewayConfigurationBuilder
         }
     }
 
+    // All string values placed into the JSON are constructed by us: a brace-free token
+    // (__ORIGIN__) concatenated with URL path segments (e.g. "/app/_api/weatherapi").
+    // Because none of these values contain { or }, the only literal braces in the
+    // serialized output are structural JSON. This invariant makes the Replace("{","{{")
+    // step below correct — if a future change introduces braces in values, the
+    // string.Format template would break and tests would catch it immediately.
+    private const string OriginToken = "__ORIGIN__";
+
     /// <summary>
-    /// An IValueProvider that resolves an endpoint URL and builds the
-    /// Blazor WASM configuration JSON response. At run time, the URL is
-    /// resolved from the EndpointReference. At publish time, ValueExpression emits
-    /// the JSON with manifest expression placeholders for the deployer to resolve.
-    /// Used by both the standalone gateway and hosted Blazor models.
+    /// Builds the ConfigResponse JSON as a <see cref="ReferenceExpression"/>. In dev mode the
+    /// gateway origin resolves to the actual URL; in publish mode publishers emit a placeholder.
     /// </summary>
-    internal sealed class ClientConfigValueProvider(
-        EndpointReference primaryEndpoint,
+    internal static ReferenceExpression BuildConfigExpression(
         EndpointReference? httpEndpoint,
         EndpointReference? httpsEndpoint,
         string? prefix,
@@ -213,118 +215,74 @@ internal static class GatewayConfigurationBuilder
         IReadOnlyList<HostedClientService> services,
         bool proxyBlazorTelemetry,
         object? httpOtlpEndpoint,
-        ILogger logger,
-        string otlpPrefix = DefaultOtlpPrefix) : IValueProvider, IManifestExpressionProvider
+        string otlpPrefix = DefaultOtlpPrefix)
     {
-        string IManifestExpressionProvider.ValueExpression =>
-            BuildJson(
-                ((IManifestExpressionProvider)primaryEndpoint).ValueExpression,
-                ResolveEndpointExpression(httpEndpoint),
-                ResolveEndpointExpression(httpsEndpoint));
+        var pathBase = prefix != null ? $"/{prefix}" : "";
 
-        async ValueTask<string?> IValueProvider.GetValueAsync(CancellationToken cancellationToken)
-        {
-            LogOtlpWarningIfNeeded();
-            var primaryUrl = await primaryEndpoint.GetValueAsync(cancellationToken).ConfigureAwait(false);
-            var httpUrl = await ResolveEndpointAsync(httpEndpoint, cancellationToken).ConfigureAwait(false);
-            var httpsUrl = await ResolveEndpointAsync(httpsEndpoint, cancellationToken).ConfigureAwait(false);
-            return BuildJson(primaryUrl, httpUrl, httpsUrl);
-        }
+        var environment = new JsonObject();
 
-        async ValueTask<string?> IValueProvider.GetValueAsync(ValueProviderContext context, CancellationToken cancellationToken)
+        foreach (var svc in services)
         {
-            LogOtlpWarningIfNeeded();
-            var primaryUrl = await primaryEndpoint.GetValueAsync(context, cancellationToken).ConfigureAwait(false);
-            var httpUrl = await ResolveEndpointAsync(httpEndpoint, context, cancellationToken).ConfigureAwait(false);
-            var httpsUrl = await ResolveEndpointAsync(httpsEndpoint, context, cancellationToken).ConfigureAwait(false);
-            return BuildJson(primaryUrl, httpUrl, httpsUrl);
-        }
-
-        private void LogOtlpWarningIfNeeded()
-        {
-            if (proxyBlazorTelemetry && httpOtlpEndpoint is null)
+            if (httpsEndpoint is not null)
             {
-                logger.LogWarning(
-                    "OTLP telemetry proxying was requested but no dashboard HTTP endpoint could be resolved. " +
-                    "WASM client telemetry will not be forwarded.");
+                environment[$"services__{svc.ServiceName}__https__0"] = $"{OriginToken}{pathBase}/{svc.ApiPrefix}/{svc.ServiceName}";
+            }
+
+            if (httpEndpoint is not null)
+            {
+                environment[$"services__{svc.ServiceName}__http__0"] = $"{OriginToken}{pathBase}/{svc.ApiPrefix}/{svc.ServiceName}";
             }
         }
 
-        private static async ValueTask<string?> ResolveEndpointAsync(EndpointReference? endpoint, CancellationToken cancellationToken)
+        if (proxyBlazorTelemetry && httpOtlpEndpoint is not null)
         {
-            if (endpoint is null)
+            environment["OTEL_SERVICE_NAME"] = resourceName;
+
+            // Send only the OTLP path so the WASM client resolves it against its own
+            // page origin (HostEnvironment.BaseAddress). This avoids cross-origin issues
+            // when the user navigates via HTTP but the gateway also exposes HTTPS.
+            environment["ASPIRE_OTLP_PATH_BASE"] = $"{pathBase}/{otlpPrefix}";
+            environment["OTEL_EXPORTER_OTLP_PROTOCOL"] = "http/protobuf";
+
+            // NOTE: OTEL_EXPORTER_OTLP_HEADERS is intentionally NOT sent to the WASM client.
+            // The headers contain the dashboard OTLP API key, and this config is delivered
+            // to browser-visible JSON. The YARP proxy injects the headers server-side when
+            // forwarding telemetry to the dashboard.
+        }
+
+        var config = new JsonObject
+        {
+            ["webAssembly"] = new JsonObject
             {
-                return null;
+                ["environment"] = environment
             }
+        };
 
-            return await endpoint.GetValueAsync(cancellationToken).ConfigureAwait(false);
-        }
+        var json = config.ToJsonString(s_jsonOptions);
 
-        private static async ValueTask<string?> ResolveEndpointAsync(EndpointReference? endpoint, ValueProviderContext context, CancellationToken cancellationToken)
+        // The only literal { } in the output are structural JSON braces (we control
+        // all string values and they contain no braces). Escape them for string.Format,
+        // then swap the origin token for {0}.
+        var format = json
+            .Replace("{", "{{")
+            .Replace("}", "}}")
+            .Replace(OriginToken, "{0}");
+
+        var originEndpoint = httpsEndpoint ?? httpEndpoint
+            ?? throw new InvalidOperationException("At least one gateway endpoint (HTTP or HTTPS) must be provided.");
+
+        var originRef = new GatewayOriginReference(originEndpoint);
+        var builder = new ReferenceExpressionBuilder();
+        var segments = format.Split("{0}");
+        for (var i = 0; i < segments.Length; i++)
         {
-            if (endpoint is null)
+            if (i > 0)
             {
-                return null;
+                builder.AppendFormatted(originRef);
             }
-
-            return await endpoint.GetValueAsync(context, cancellationToken).ConfigureAwait(false);
+            builder.AppendLiteral(segments[i]);
         }
 
-        private static string? ResolveEndpointExpression(EndpointReference? endpoint)
-        {
-            return endpoint is IManifestExpressionProvider manifestExpressionProvider
-                ? manifestExpressionProvider.ValueExpression
-                : null;
-        }
-
-        private string BuildJson(string? primaryBaseUrl, string? httpBaseUrl, string? httpsBaseUrl)
-        {
-            var pathBase = prefix != null ? $"/{prefix}" : "";
-            var environment = new Dictionary<string, string>();
-            var normalizedPrimaryBaseUrl = NormalizeUrl(primaryBaseUrl);
-            var normalizedHttpBaseUrl = NormalizeUrl(httpBaseUrl ?? (primaryEndpoint.IsHttp ? normalizedPrimaryBaseUrl : null));
-            var normalizedHttpsBaseUrl = NormalizeUrl(httpsBaseUrl ?? (primaryEndpoint.IsHttps ? normalizedPrimaryBaseUrl : null));
-
-            foreach (var svc in services)
-            {
-                if (normalizedHttpsBaseUrl is not null)
-                {
-                    environment[$"services__{svc.ServiceName}__https__0"] = $"{normalizedHttpsBaseUrl}{pathBase}/{svc.ApiPrefix}/{svc.ServiceName}";
-                }
-
-                if (normalizedHttpBaseUrl is not null)
-                {
-                    environment[$"services__{svc.ServiceName}__http__0"] = $"{normalizedHttpBaseUrl}{pathBase}/{svc.ApiPrefix}/{svc.ServiceName}";
-                }
-            }
-
-            if (proxyBlazorTelemetry && httpOtlpEndpoint is not null)
-            {
-                environment["OTEL_SERVICE_NAME"] = resourceName;
-
-                // Send only the OTLP path so the WASM client resolves it against its own
-                // page origin (HostEnvironment.BaseAddress). This avoids cross-origin issues
-                // when the user navigates via HTTP but the gateway also exposes HTTPS.
-                environment["ASPIRE_OTLP_PATH_BASE"] = $"{pathBase}/{otlpPrefix}";
-                environment["OTEL_EXPORTER_OTLP_PROTOCOL"] = "http/protobuf";
-
-                // NOTE: OTEL_EXPORTER_OTLP_HEADERS is intentionally NOT sent to the WASM client.
-                // The headers contain the dashboard OTLP API key, and this config is delivered
-                // to browser-visible JSON. The YARP proxy injects the headers server-side when
-                // forwarding telemetry to the dashboard.
-            }
-
-            return JsonSerializer.Serialize(
-                new ClientConfiguration
-                {
-                    WebAssembly = new WebAssemblyConfiguration { Environment = environment }
-                },
-                ManifestJsonContext.Relaxed.ClientConfiguration);
-        }
-
-        private static string? NormalizeUrl(string? url)
-        {
-            return string.IsNullOrEmpty(url) ? null : url.TrimEnd('/');
-        }
+        return builder.Build();
     }
 }

--- a/src/Aspire.Hosting.Blazor/GatewayOriginReference.cs
+++ b/src/Aspire.Hosting.Blazor/GatewayOriginReference.cs
@@ -1,0 +1,21 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Aspire.Hosting.ApplicationModel;
+
+namespace Aspire.Hosting;
+
+/// <summary>
+/// Wraps a gateway <see cref="EndpointReference"/> so publishers can emit a deployer-configurable
+/// placeholder (e.g., <c>${GATEWAY_BINDINGS_HTTPS_URL}</c>) while dev mode resolves the actual URL.
+/// </summary>
+internal sealed class GatewayOriginReference(EndpointReference endpoint) : IValueProvider, IManifestExpressionProvider
+{
+    public string ValueExpression => $"{{{endpoint.Resource.Name}.bindings.{endpoint.EndpointName}.url}}";
+
+    public async ValueTask<string?> GetValueAsync(CancellationToken cancellationToken = default)
+    {
+        var url = await endpoint.GetValueAsync(cancellationToken).ConfigureAwait(false);
+        return url?.TrimEnd('/');
+    }
+}

--- a/src/Aspire.Hosting.Blazor/Manifests/EndpointsManifestTransformer.cs
+++ b/src/Aspire.Hosting.Blazor/Manifests/EndpointsManifestTransformer.cs
@@ -21,7 +21,8 @@ internal static class EndpointsManifestTransformer
     {
         var manifest = JsonSerializer.Deserialize(
             await File.ReadAllTextAsync(manifestPath, ct).ConfigureAwait(false),
-            ManifestJsonContext.Default.EndpointsManifest)!;
+            ManifestJsonContext.Default.EndpointsManifest)
+            ?? throw new InvalidOperationException($"Failed to deserialize endpoints manifest from '{manifestPath}'.");
 
         var fallbackEndpoints = new List<EndpointEntry>();
 
@@ -33,7 +34,7 @@ internal static class EndpointsManifestTransformer
             // We skip compressed variants (those with Content-Encoding selectors) because the
             // ContentEncodingNegotiationMatcherPolicy would otherwise prefer the catch-all over
             // literal routes (like _blazor/_configuration) that lack encoding metadata.
-            if (ep.Route == "index.html")
+            if (string.Equals(ep.Route, "index.html", StringComparison.OrdinalIgnoreCase))
             {
                 var hasContentEncoding = ep.Selectors?.Any(s => s.Name == "Content-Encoding") == true;
 

--- a/src/Aspire.Hosting.Blazor/Scripts/Gateway.cs.in
+++ b/src/Aspire.Hosting.Blazor/Scripts/Gateway.cs.in
@@ -79,7 +79,7 @@ foreach (var appConfig in appConfigs.Values)
 {
     if (!string.IsNullOrEmpty(appConfig.ConfigEndpointPath) && !string.IsNullOrEmpty(appConfig.ConfigResponse))
     {
-        app.MapGet(appConfig.ConfigEndpointPath, () => Results.Content(appConfig.ConfigResponse, "application/json"))
+        app.MapGet(appConfig.ConfigEndpointPath, () => Results.Content(appConfig.ConfigResponse!, "application/json"))
             .WithMetadata(new ContentEncodingMetadata("identity", 1.0));
     }
 

--- a/src/Aspire.Hosting.Blazor/Scripts/Gateway.cs.in
+++ b/src/Aspire.Hosting.Blazor/Scripts/Gateway.cs.in
@@ -150,9 +150,12 @@ static class ServiceDefaultsExtensions
                 tracing.AddSource(builder.Environment.ApplicationName)
                     .AddAspNetCoreInstrumentation(options =>
                         options.Filter = context =>
-                            !context.Request.Path.StartsWithSegments("/health")
-                            && !context.Request.Path.StartsWithSegments("/alive")
-                            && !IsStaticAssetOrOtlpRequest(context.Request.Path)
+                        {
+                            var path = context.Request.Path.Value;
+                            return !context.Request.Path.StartsWithSegments("/health")
+                                && !context.Request.Path.StartsWithSegments("/alive")
+                                && (path is null || !path.Contains("/_otlp/", StringComparison.Ordinal));
+                        }
                     )
                     .AddHttpClientInstrumentation(options =>
                         // Filter out the gateway's own OTLP export calls to the dashboard
@@ -170,15 +173,6 @@ static class ServiceDefaultsExtensions
         }
 
         return builder;
-    }
-
-    private static bool IsStaticAssetOrOtlpRequest(PathString path)
-    {
-        var pathValue = path.Value;
-        return pathValue is not null
-            && (pathValue.Contains("/_framework/", StringComparison.Ordinal)
-                || pathValue.Contains("/_content/", StringComparison.Ordinal)
-                || pathValue.Contains("/_otlp/", StringComparison.Ordinal));
     }
 
     public static TBuilder AddDefaultHealthChecks<TBuilder>(this TBuilder builder) where TBuilder : IHostApplicationBuilder

--- a/tests/Aspire.Hosting.Blazor.Tests/BlazorHostedExtensionsTests.cs
+++ b/tests/Aspire.Hosting.Blazor.Tests/BlazorHostedExtensionsTests.cs
@@ -4,6 +4,7 @@
 using Aspire.Hosting.ApplicationModel;
 using Aspire.Hosting.Utils;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Testing;
 
 namespace Aspire.Hosting.Blazor.Tests;
 
@@ -294,12 +295,12 @@ public class BlazorHostedExtensionsTests(ITestOutputHelper testOutputHelper)
             .ProxyBlazorTelemetry();
 
         var blazorApp = builder.Resources.Single(r => r.Name == "blazorapp");
-        var (_, logMessages) = await GetEnvironmentVariablesWithLogs(blazorApp, builder);
+        var (_, sink) = await GetEnvironmentVariablesWithLogs(blazorApp, builder);
 
-        Assert.Contains(logMessages, msg =>
+        Assert.Contains(sink.Writes, msg =>
             msg.LogLevel == LogLevel.Warning &&
-            msg.Message.Contains("OTLP telemetry proxying was requested") &&
-            msg.Message.Contains("WASM client telemetry will not be forwarded"));
+            msg.Message?.Contains("OTLP telemetry proxying was requested") == true &&
+            msg.Message?.Contains("WASM client telemetry will not be forwarded") == true);
     }
 
     [Fact]
@@ -313,11 +314,51 @@ public class BlazorHostedExtensionsTests(ITestOutputHelper testOutputHelper)
             .ProxyBlazorTelemetry();
 
         var blazorApp = builder.Resources.Single(r => r.Name == "blazorapp");
-        var (_, logMessages) = await GetEnvironmentVariablesWithLogs(blazorApp, builder);
+        var (_, sink) = await GetEnvironmentVariablesWithLogs(blazorApp, builder);
 
-        Assert.DoesNotContain(logMessages, msg =>
+        Assert.DoesNotContain(sink.Writes, msg =>
             msg.LogLevel == LogLevel.Warning &&
-            msg.Message.Contains("OTLP telemetry proxying was requested"));
+            msg.Message?.Contains("OTLP telemetry proxying was requested") == true);
+    }
+
+    [Fact]
+    public async Task WithBlazorClientApp_LogsWarning_WhenOtlpEndpointNotResolvable()
+    {
+        using var builder = TestDistributedApplicationBuilder.Create(testOutputHelper);
+
+        var gateway = builder.AddProject<TestProjectMetadata>("gateway")
+            .WithHttpEndpoint()
+            .WithHttpsEndpoint();
+
+        var wasmApp = builder.AddBlazorWasmApp("store", "Store/Store.csproj");
+        gateway.WithBlazorClientApp(wasmApp, proxyTelemetry: true);
+
+        var (_, sink) = await GetEnvironmentVariablesWithLogs(gateway.Resource, builder);
+
+        Assert.Contains(sink.Writes, msg =>
+            msg.LogLevel == LogLevel.Warning &&
+            msg.Message?.Contains("OTLP telemetry proxying was requested") == true &&
+            msg.Message?.Contains("WASM client telemetry will not be forwarded") == true);
+    }
+
+    [Fact]
+    public async Task WithBlazorClientApp_DoesNotLogWarning_WhenOtlpEndpointIsConfigured()
+    {
+        using var builder = TestDistributedApplicationBuilder.Create(testOutputHelper);
+        builder.Configuration["ASPIRE_DASHBOARD_OTLP_HTTP_ENDPOINT_URL"] = "http://localhost:4318";
+
+        var gateway = builder.AddProject<TestProjectMetadata>("gateway")
+            .WithHttpEndpoint()
+            .WithHttpsEndpoint();
+
+        var wasmApp = builder.AddBlazorWasmApp("store", "Store/Store.csproj");
+        gateway.WithBlazorClientApp(wasmApp, proxyTelemetry: true);
+
+        var (_, sink) = await GetEnvironmentVariablesWithLogs(gateway.Resource, builder);
+
+        Assert.DoesNotContain(sink.Writes, msg =>
+            msg.LogLevel == LogLevel.Warning &&
+            msg.Message?.Contains("OTLP telemetry proxying was requested") == true);
     }
 
     private static async Task<Dictionary<string, object>> GetEnvironmentVariables(
@@ -327,20 +368,21 @@ public class BlazorHostedExtensionsTests(ITestOutputHelper testOutputHelper)
         return env;
     }
 
-    private static async Task<(Dictionary<string, object> Env, List<LogMessage> Logs)> GetEnvironmentVariablesWithLogs(
+    private static async Task<(Dictionary<string, object> Env, TestSink Sink)> GetEnvironmentVariablesWithLogs(
         IResource resource, IDistributedApplicationBuilder builder)
     {
         var env = new Dictionary<string, object>();
-        var logs = new List<LogMessage>();
+        var sink = new TestSink();
+        var logger = new TestLogger(string.Empty, sink, enabled: true);
         var context = new EnvironmentCallbackContext(builder.ExecutionContext, resource, env)
         {
-            Logger = new ListLogger(logs)
+            Logger = logger
         };
         foreach (var callback in resource.Annotations.OfType<EnvironmentCallbackAnnotation>())
         {
             await callback.Callback(context).ConfigureAwait(false);
         }
-        return (env, logs);
+        return (env, sink);
     }
 
     private static string ResolveManifestExpression(object value)
@@ -357,19 +399,5 @@ public class BlazorHostedExtensionsTests(ITestOutputHelper testOutputHelper)
         public string ProjectPath => "TestProject/TestProject.csproj";
 
         public LaunchSettings LaunchSettings { get; } = new();
-    }
-
-    private sealed record LogMessage(LogLevel LogLevel, string Message);
-
-    private sealed class ListLogger(List<LogMessage> messages) : ILogger
-    {
-        public IDisposable? BeginScope<TState>(TState state) where TState : notnull => null;
-
-        public bool IsEnabled(LogLevel logLevel) => true;
-
-        public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception? exception, Func<TState, Exception?, string> formatter)
-        {
-            messages.Add(new LogMessage(logLevel, formatter(state, exception)));
-        }
     }
 }

--- a/tests/Aspire.Hosting.Blazor.Tests/BlazorHostedExtensionsTests.cs
+++ b/tests/Aspire.Hosting.Blazor.Tests/BlazorHostedExtensionsTests.cs
@@ -86,7 +86,7 @@ public class BlazorHostedExtensionsTests(ITestOutputHelper testOutputHelper)
         var configJson = ResolveManifestExpression(env["Client__ConfigResponse"]);
         Assert.Contains("OTEL_SERVICE_NAME", configJson);
         Assert.Contains("blazorapp", configJson);
-        Assert.Contains("ASPIRE_OTLP_PATH_BASE", configJson);
+        Assert.Contains("OTEL_EXPORTER_OTLP_ENDPOINT", configJson);
         Assert.Contains("/_otlp", configJson);
     }
 
@@ -115,7 +115,7 @@ public class BlazorHostedExtensionsTests(ITestOutputHelper testOutputHelper)
         // Config response includes both service URLs and OTLP
         var configJson = ResolveManifestExpression(env["Client__ConfigResponse"]);
         Assert.Contains("services__weatherapi__https__0", configJson);
-        Assert.Contains("ASPIRE_OTLP_PATH_BASE", configJson);
+        Assert.Contains("OTEL_EXPORTER_OTLP_ENDPOINT", configJson);
         Assert.Contains("OTEL_SERVICE_NAME", configJson);
     }
 
@@ -183,7 +183,7 @@ public class BlazorHostedExtensionsTests(ITestOutputHelper testOutputHelper)
         Assert.False(env.ContainsKey("ReverseProxy__Routes__route-otlp__ClusterId"));
 
         var configJson = ResolveManifestExpression(env["Client__ConfigResponse"]);
-        Assert.DoesNotContain("ASPIRE_OTLP_PATH_BASE", configJson);
+        Assert.DoesNotContain("OTEL_EXPORTER_OTLP_ENDPOINT", configJson);
     }
 
     [Fact]

--- a/tests/Aspire.Hosting.Blazor.Tests/BlazorHostedExtensionsTests.cs
+++ b/tests/Aspire.Hosting.Blazor.Tests/BlazorHostedExtensionsTests.cs
@@ -3,6 +3,7 @@
 
 using Aspire.Hosting.ApplicationModel;
 using Aspire.Hosting.Utils;
+using Microsoft.Extensions.Logging;
 
 namespace Aspire.Hosting.Blazor.Tests;
 
@@ -282,16 +283,64 @@ public class BlazorHostedExtensionsTests(ITestOutputHelper testOutputHelper)
         Assert.Contains("catalogapi", referencedNames);
     }
 
+    [Fact]
+    public async Task ProxyTelemetry_LogsWarning_WhenOtlpEndpointNotResolvable()
+    {
+        using var builder = TestDistributedApplicationBuilder.Create(testOutputHelper);
+        // Intentionally NOT setting ASPIRE_DASHBOARD_OTLP_HTTP_ENDPOINT_URL
+
+        builder.AddProject<TestProjectMetadata>("blazorapp")
+            .WithHttpsEndpoint()
+            .ProxyBlazorTelemetry();
+
+        var blazorApp = builder.Resources.Single(r => r.Name == "blazorapp");
+        var (_, logMessages) = await GetEnvironmentVariablesWithLogs(blazorApp, builder);
+
+        Assert.Contains(logMessages, msg =>
+            msg.LogLevel == LogLevel.Warning &&
+            msg.Message.Contains("OTLP telemetry proxying was requested") &&
+            msg.Message.Contains("WASM client telemetry will not be forwarded"));
+    }
+
+    [Fact]
+    public async Task ProxyTelemetry_DoesNotLogWarning_WhenOtlpEndpointIsConfigured()
+    {
+        using var builder = TestDistributedApplicationBuilder.Create(testOutputHelper);
+        builder.Configuration["ASPIRE_DASHBOARD_OTLP_HTTP_ENDPOINT_URL"] = "http://localhost:4318";
+
+        builder.AddProject<TestProjectMetadata>("blazorapp")
+            .WithHttpsEndpoint()
+            .ProxyBlazorTelemetry();
+
+        var blazorApp = builder.Resources.Single(r => r.Name == "blazorapp");
+        var (_, logMessages) = await GetEnvironmentVariablesWithLogs(blazorApp, builder);
+
+        Assert.DoesNotContain(logMessages, msg =>
+            msg.LogLevel == LogLevel.Warning &&
+            msg.Message.Contains("OTLP telemetry proxying was requested"));
+    }
+
     private static async Task<Dictionary<string, object>> GetEnvironmentVariables(
         IResource resource, IDistributedApplicationBuilder builder)
     {
+        var (env, _) = await GetEnvironmentVariablesWithLogs(resource, builder);
+        return env;
+    }
+
+    private static async Task<(Dictionary<string, object> Env, List<LogMessage> Logs)> GetEnvironmentVariablesWithLogs(
+        IResource resource, IDistributedApplicationBuilder builder)
+    {
         var env = new Dictionary<string, object>();
-        var context = new EnvironmentCallbackContext(builder.ExecutionContext, resource, env);
+        var logs = new List<LogMessage>();
+        var context = new EnvironmentCallbackContext(builder.ExecutionContext, resource, env)
+        {
+            Logger = new ListLogger(logs)
+        };
         foreach (var callback in resource.Annotations.OfType<EnvironmentCallbackAnnotation>())
         {
             await callback.Callback(context).ConfigureAwait(false);
         }
-        return env;
+        return (env, logs);
     }
 
     private static string ResolveManifestExpression(object value)
@@ -308,5 +357,19 @@ public class BlazorHostedExtensionsTests(ITestOutputHelper testOutputHelper)
         public string ProjectPath => "TestProject/TestProject.csproj";
 
         public LaunchSettings LaunchSettings { get; } = new();
+    }
+
+    private sealed record LogMessage(LogLevel LogLevel, string Message);
+
+    private sealed class ListLogger(List<LogMessage> messages) : ILogger
+    {
+        public IDisposable? BeginScope<TState>(TState state) where TState : notnull => null;
+
+        public bool IsEnabled(LogLevel logLevel) => true;
+
+        public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception? exception, Func<TState, Exception?, string> formatter)
+        {
+            messages.Add(new LogMessage(logLevel, formatter(state, exception)));
+        }
     }
 }

--- a/tests/Aspire.Hosting.Blazor.Tests/GatewayConfigurationBuilderTests.cs
+++ b/tests/Aspire.Hosting.Blazor.Tests/GatewayConfigurationBuilderTests.cs
@@ -323,7 +323,7 @@ public class GatewayConfigurationBuilderTests(ITestOutputHelper testOutputHelper
 
         var configResponse = (IManifestExpressionProvider)env["ClientApps__store__ConfigResponse"];
         var manifestExpression = configResponse.ValueExpression;
-        Assert.DoesNotContain("ASPIRE_OTLP_PATH_BASE", manifestExpression);
+        Assert.DoesNotContain("OTEL_EXPORTER_OTLP_ENDPOINT", manifestExpression);
     }
 
     [Fact]
@@ -462,7 +462,7 @@ public class GatewayConfigurationBuilderTests(ITestOutputHelper testOutputHelper
 
         // OTLP path base is emitted so the WASM client can resolve it against
         // the page's origin, avoiding cross-origin issues.
-        Assert.Contains("ASPIRE_OTLP_PATH_BASE", configJson);
+        Assert.Contains("OTEL_EXPORTER_OTLP_ENDPOINT", configJson);
         Assert.Contains("/_otlp", configJson);
 
         // Service discovery emits both schemes so the client can pick the right one.


### PR DESCRIPTION
## Summary

Addresses remaining unresolved review threads from #15691 and adds Docker Compose publish support for the Blazor gateway.

## PR Feedback Fixes

- Add `[ResourceName]` attribute to `AddBlazorGateway`, `AddBlazorWasmProject<T>`, and `AddBlazorWasmApp` name parameters
- Replace null-forgiving operator with explicit `?? throw` in `EndpointsManifestTransformer`
- Use `StringComparison.OrdinalIgnoreCase` for route comparison
- Fix '.NET Aspire' phrasing in playground README files
- Extract `"Aspire:Store:Path"` magic string to a const
- Re-add OTLP misconfiguration warning at call site (where logger is available)

## Docker Compose Publish Support

The `ClientConfigValueProvider` class (IValueProvider + IManifestExpressionProvider) is replaced with a static `BuildConfigExpression()` method that returns a `ReferenceExpression`. This makes the ConfigResponse environment variable natively understood by all publishers.

**How it works:**
1. Build JSON with a brace-free `__ORIGIN__` token in place of the gateway URL
2. Serialize with `UnsafeRelaxedJsonEscaping` (we control all values, no braces present)
3. Escape structural JSON braces (`{` -> `{{`) for `string.Format` safety
4. Replace `__ORIGIN__` with `{0}` to create the format string
5. Build a `ReferenceExpression` with `GatewayOriginReference` as the argument

**Result:**
- **Dev mode**: endpoint resolves to `https://localhost:PORT` — ConfigResponse contains absolute URLs
- **Docker Compose publish**: publisher emits `$${GATEWAY_BINDINGS_HTTPS_URL}` — deployer fills `.env`

New file: `GatewayOriginReference.cs` — lightweight IValueProvider + IManifestExpressionProvider that wraps an EndpointReference, trims trailing slashes, and emits manifest expressions for publishers.
