### PR TITLE
Use KnownConfigNames for resource service endpoint URL with legacy fallback

### DIFF
--- a/src/Aspire.Dashboard/ServiceClient/DashboardClient.cs
+++ b/src/Aspire.Dashboard/ServiceClient/DashboardClient.cs
@@ -31,7 +31,7 @@ namespace Aspire.Dashboard.ServiceClient;
 /// lives until the stream is closed.
 /// </para>
 /// <para>
-/// If the <c>DOTNET_RESOURCE_SERVICE_ENDPOINT_URL</c> environment variable is not specified, then there's
+/// If the <c>ASPIRE_RESOURCE_SERVICE_ENDPOINT_URL</c> environment variable is not specified, then there's
 /// no known endpoint to connect to, and this dashboard client will be disabled. Calls to
 /// <see cref="IDashboardClient.SubscribeResourcesAsync"/> and <see cref="IDashboardClient.SubscribeConsoleLogs"/>
 /// will throw if <see cref="IDashboardClient.IsEnabled"/> is <see langword="false"/>. Callers should

--- a/src/Aspire.Hosting/Dashboard/DashboardServiceHost.cs
+++ b/src/Aspire.Hosting/Dashboard/DashboardServiceHost.cs
@@ -25,16 +25,6 @@ namespace Aspire.Hosting.Dashboard;
 internal sealed class DashboardServiceHost : IHostedService
 {
     /// <summary>
-    /// Name of the environment variable that optionally specifies the resource service URL,
-    /// which the dashboard will connect to over gRPC.
-    /// </summary>
-    /// <remarks>
-    /// This is primarily intended for cases outside of the local developer environment.
-    /// If no value exists for this variable, a port is assigned dynamically.
-    /// </remarks>
-    private const string ResourceServiceUrlVariableName = "DOTNET_RESOURCE_SERVICE_ENDPOINT_URL";
-
-    /// <summary>
     /// Provides access to the URI at which the resource service endpoint is hosted.
     /// </summary>
     private readonly TaskCompletionSource<string> _resourceServiceUri = new();
@@ -135,7 +125,9 @@ internal sealed class DashboardServiceHost : IHostedService
         void ConfigureKestrel(KestrelServerOptions kestrelOptions)
         {
             // Inspect environment for the address to listen on.
-            var uri = configuration.GetUri(ResourceServiceUrlVariableName);
+            // Prefer the new config name, falling back to the legacy name.
+            var uri = configuration.GetUri(KnownConfigNames.ResourceServiceEndpointUrl)
+                ?? configuration.GetUri(KnownConfigNames.Legacy.ResourceServiceEndpointUrl);
             var allowUnsecuredTransport = configuration.GetBool(KnownConfigNames.AllowUnsecuredTransport) ?? false;
 
             var scheme = ResolveScheme(uri, allowUnsecuredTransport);
@@ -154,7 +146,7 @@ internal sealed class DashboardServiceHost : IHostedService
             }
             else
             {
-                throw new ArgumentException($"{ResourceServiceUrlVariableName} must contain a local loopback address.");
+                throw new ArgumentException($"{KnownConfigNames.ResourceServiceEndpointUrl} must contain a local loopback address.");
             }
 
             void ConfigureListen(ListenOptions options)
@@ -191,7 +183,7 @@ internal sealed class DashboardServiceHost : IHostedService
     /// </summary>
     /// <remarks>
     /// Intended to be used by the app model when launching the dashboard process, populating its
-    /// <c>DOTNET_RESOURCE_SERVICE_ENDPOINT_URL</c> environment variable with a single URI.
+    /// <c>ASPIRE_RESOURCE_SERVICE_ENDPOINT_URL</c> environment variable with a single URI.
     /// </remarks>
     public async Task<string> GetResourceServiceUriAsync(CancellationToken cancellationToken = default)
     {

--- a/tests/Aspire.Hosting.Tests/DistributedApplicationTests.cs
+++ b/tests/Aspire.Hosting.Tests/DistributedApplicationTests.cs
@@ -11,6 +11,7 @@ using System.Text.RegularExpressions;
 using System.Threading.Channels;
 using Aspire.Dashboard.Model;
 using Aspire.Hosting.Diagnostics;
+using Aspire.Hosting.Dashboard;
 using Aspire.TestUtilities;
 using Aspire.Hosting.Dcp;
 using Aspire.Hosting.Dcp.Model;
@@ -1430,6 +1431,33 @@ public class DistributedApplicationTests
         {
             Assert.NotNull(envVars);
             return Assert.Single(envVars, e => e.Name == name).Value;
+        }
+    }
+
+    [Fact]
+    public async Task StartAsync_ResourceServiceEndpointUrl_PassedToDashboardServiceHost()
+    {
+        const string testName = "dashboard-resource-service-endpoint-url";
+        var resourceServicePort = await Network.GetAvailablePortAsync();
+        var configuredResourceServiceUrl = $"http://localhost:{resourceServicePort}";
+        var args = new string[] {
+            $"{KnownConfigNames.ResourceServiceEndpointUrl}={configuredResourceServiceUrl}"
+        };
+        using var testProgram = CreateTestProgram(testName, args: args, disableDashboard: false);
+
+        await using var app = testProgram.Build();
+
+        var dashboardServiceHost = app.Services.GetRequiredService<DashboardServiceHost>();
+        await ((IHostedService)dashboardServiceHost).StartAsync(CancellationToken.None);
+
+        try
+        {
+            var resourceServiceUri = await dashboardServiceHost.GetResourceServiceUriAsync();
+            Assert.Equal(configuredResourceServiceUrl, resourceServiceUri.TrimEnd('/'));
+        }
+        finally
+        {
+            await ((IHostedService)dashboardServiceHost).StopAsync(CancellationToken.None);
         }
     }
 


### PR DESCRIPTION
## Summary

Remove the hardcoded `DOTNET_RESOURCE_SERVICE_ENDPOINT_URL` constant from `DashboardServiceHost` and use `KnownConfigNames.ResourceServiceEndpointUrl` (`ASPIRE_RESOURCE_SERVICE_ENDPOINT_URL`) with fallback to `KnownConfigNames.Legacy.ResourceServiceEndpointUrl` (`DOTNET_RESOURCE_SERVICE_ENDPOINT_URL`).

## Changes

- **DashboardServiceHost.cs**: Removed `ResourceServiceUrlVariableName` private const. Updated `ConfigureKestrel` to prefer the new config name and fall back to the legacy name, matching the pattern used elsewhere in the codebase.
- **DashboardClient.cs**: Updated XML doc comment to reference the new env var name.