### PR TITLE
Make ITokenCredentialProvider public

### DIFF
--- a/src/Aspire.Hosting.Azure.ContainerRegistry/AzureContainerRegistryHelpers.cs
+++ b/src/Aspire.Hosting.Azure.ContainerRegistry/AzureContainerRegistryHelpers.cs
@@ -7,7 +7,6 @@
 #pragma warning disable ASPIREAZURE001
 
 using Aspire.Hosting.ApplicationModel;
-using Aspire.Hosting.Azure.Provisioning.Internal;
 using Aspire.Hosting.Pipelines;
 using Microsoft.Extensions.DependencyInjection;
 

--- a/src/Aspire.Hosting.Azure/ITokenCredentialProvider.cs
+++ b/src/Aspire.Hosting.Azure/ITokenCredentialProvider.cs
@@ -1,0 +1,32 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Azure.Core;
+
+namespace Aspire.Hosting.Azure;
+
+/// <summary>
+/// Provides access to the <see cref="TokenCredential"/> that Aspire uses
+/// to authenticate against Azure when provisioning resources and calling Azure APIs.
+/// </summary>
+/// <remarks>
+/// <para>
+/// This service is registered as a singleton when Azure provisioning is enabled
+/// (e.g., by <c>AddAzureProvisioning</c>).
+/// </para>
+/// <para>
+/// Integrations and app host code can resolve this service from <see cref="System.IServiceProvider"/>
+/// to obtain a <see cref="TokenCredential"/> instance configured by Aspire's
+/// Azure provisioning options (for example, the configured tenant id and credential source).
+/// The concrete credential type returned by <see cref="TokenCredential"/> is an implementation
+/// detail and may change between releases; callers should treat the value as an opaque
+/// <see cref="TokenCredential"/>.
+/// </para>
+/// </remarks>
+public interface ITokenCredentialProvider
+{
+    /// <summary>
+    /// Gets the <see cref="TokenCredential"/> to use for Azure authentication.
+    /// </summary>
+    TokenCredential TokenCredential { get; }
+}

--- a/src/Aspire.Hosting.Azure/Provisioning/Internal/IProvisioningServices.cs
+++ b/src/Aspire.Hosting.Azure/Provisioning/Internal/IProvisioningServices.cs
@@ -244,14 +244,3 @@ internal interface IUserPrincipalProvider
     /// </summary>
     Task<UserPrincipal> GetUserPrincipalAsync(CancellationToken cancellationToken = default);
 }
-
-/// <summary>
-/// Provides access to Azure token credentials.
-/// </summary>
-internal interface ITokenCredentialProvider
-{
-    /// <summary>
-    /// Gets the token credential for Azure authentication.
-    /// </summary>
-    TokenCredential TokenCredential { get; }
-}

--- a/src/Aspire.Hosting.Foundry/PromptAgent/AzurePromptAgentResource.cs
+++ b/src/Aspire.Hosting.Foundry/PromptAgent/AzurePromptAgentResource.cs
@@ -6,7 +6,6 @@ using System.Collections.Immutable;
 using System.Globalization;
 using Aspire.Hosting.ApplicationModel;
 using Aspire.Hosting.Azure;
-using Aspire.Hosting.Azure.Provisioning.Internal;
 using Aspire.Hosting.Pipelines;
 using Aspire.Hosting.Publishing;
 using Azure.AI.Projects;

--- a/tests/Aspire.Hosting.Azure.Tests/TokenCredentialProviderTests.cs
+++ b/tests/Aspire.Hosting.Azure.Tests/TokenCredentialProviderTests.cs
@@ -1,0 +1,79 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Aspire.Hosting.Utils;
+using Azure.Core;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Aspire.Hosting.Azure.Tests;
+
+public class TokenCredentialProviderTests
+{
+    [Fact]
+    public void AddAzureProvisioning_RegistersITokenCredentialProvider()
+    {
+        using var builder = TestDistributedApplicationBuilder.Create();
+        builder.AddAzureProvisioning();
+
+        using var app = builder.Build();
+
+        var provider = app.Services.GetRequiredService<ITokenCredentialProvider>();
+
+        Assert.NotNull(provider);
+        Assert.NotNull(provider.TokenCredential);
+    }
+
+    [Fact]
+    public void AddAzureProvisioning_RegistersITokenCredentialProviderAsSingleton()
+    {
+        using var builder = TestDistributedApplicationBuilder.Create();
+        builder.AddAzureProvisioning();
+
+        using var app = builder.Build();
+
+        var first = app.Services.GetRequiredService<ITokenCredentialProvider>();
+        var second = app.Services.GetRequiredService<ITokenCredentialProvider>();
+
+        Assert.Same(first, second);
+        Assert.Same(first.TokenCredential, second.TokenCredential);
+    }
+
+    [Fact]
+    public void AddingAzureResource_RegistersITokenCredentialProvider()
+    {
+        // AddAzureProvisioning is invoked indirectly when an Azure resource is added.
+        using var builder = TestDistributedApplicationBuilder.Create();
+        builder.AddAzureInfrastructure("infra", _ => { });
+
+        using var app = builder.Build();
+
+        var provider = app.Services.GetRequiredService<ITokenCredentialProvider>();
+
+        Assert.NotNull(provider.TokenCredential);
+    }
+
+    [Fact]
+    public void ITokenCredentialProvider_CanBeReplacedWithCustomImplementation()
+    {
+        // External callers should be able to plug in their own credential by
+        // replacing the registered service with their own implementation.
+        var customCredential = new TestTokenCredential();
+        var customProvider = new CustomTokenCredentialProvider(customCredential);
+
+        using var builder = TestDistributedApplicationBuilder.Create();
+        builder.AddAzureProvisioning();
+        builder.Services.AddSingleton<ITokenCredentialProvider>(customProvider);
+
+        using var app = builder.Build();
+
+        var resolved = app.Services.GetRequiredService<ITokenCredentialProvider>();
+
+        Assert.Same(customProvider, resolved);
+        Assert.Same(customCredential, resolved.TokenCredential);
+    }
+
+    private sealed class CustomTokenCredentialProvider(TokenCredential credential) : ITokenCredentialProvider
+    {
+        public TokenCredential TokenCredential { get; } = credential;
+    }
+}


### PR DESCRIPTION
## Description

When integrations and app host code outside of `Aspire.Hosting.Azure` need to call Azure APIs, they need a `TokenCredential`. Internally, `Aspire.Hosting.Azure` already builds and caches one — configured by the user's Azure provisioning options (tenant id, credential source, etc.) and matched to the run/publish execution context — but the service that exposes it (`ITokenCredentialProvider`) is `internal`, so external callers couldn't reuse it. They had to construct their own credential and risk drifting from the credential Aspire itself uses.

This change makes `ITokenCredentialProvider` part of the public surface so external callers can resolve the same `TokenCredential` that Aspire uses for provisioning and Azure API calls.

### User-facing usage

Integrations and app host code can resolve the provider from DI in any context that has access to `IServiceProvider` and use the credential to talk to Azure:

```csharp
using Aspire.Hosting.Azure;
using Azure.Core;
using Microsoft.Extensions.DependencyInjection;

// e.g. inside a pipeline step, lifecycle hook, or custom resource:
var provider = serviceProvider.GetRequiredService<ITokenCredentialProvider>();
TokenCredential credential = provider.TokenCredential;

// Use the credential with any Azure SDK client.
var armClient = new ArmClient(credential);
```

The service is registered as a singleton by `AddAzureProvisioning`, which is also called indirectly by `AddAzureEnvironment` and the Azure resource extension methods — so anyone using Aspire's Azure hosting integrations already has it registered. Callers can also replace the registration with their own implementation if they want to plug in a custom credential.

### Implementation notes

- Moved `ITokenCredentialProvider` from `Aspire.Hosting.Azure.Provisioning.Internal` to `Aspire.Hosting.Azure` and changed the accessibility to `public`. Added `<remarks />` documentation noting the lifetime, configuration source, and that the concrete credential type is an implementation detail.
- `DefaultTokenCredentialProvider` (the implementation) stays `internal`.
- The other types in `Aspire.Hosting.Azure.Provisioning.Internal` remain internal.
- Removed now-unneeded `using Aspire.Hosting.Azure.Provisioning.Internal;` directives in `AzureContainerRegistryHelpers.cs` and `AzurePromptAgentResource.cs`.

### Validation

- Added `TokenCredentialProviderTests` with 4 tests:
  - `AddAzureProvisioning` registers `ITokenCredentialProvider` and yields a non-null `TokenCredential`.
  - The registration is a singleton (same instance on repeated resolution, and the same `TokenCredential`).
  - Adding an Azure resource (e.g. `AddAzureInfrastructure`) also registers the provider via the indirect `AddAzureProvisioning` path.
  - Callers can replace `ITokenCredentialProvider` with a custom implementation.
- All new tests pass; 15 related existing tests (`DefaultTokenCredentialProviderTests`, `DefaultUserPrincipalProviderTests`) still pass.
- Dependent projects (`Aspire.Hosting.Azure.ContainerRegistry`, `Aspire.Hosting.Foundry`) build cleanly with the moved interface.

Fixes # (issue)

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [x] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [x] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [x] Yes
      - [ ] No
  - [ ] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
