### PR TITLE
Add duration filter to traces page

### DIFF
--- a/src/Aspire.Dashboard/Components/Pages/TraceDetail.razor.cs
+++ b/src/Aspire.Dashboard/Components/Pages/TraceDetail.razor.cs
@@ -802,7 +802,7 @@ public partial class TraceDetail : ComponentBase, IComponentWithTelemetry, IDisp
             DialogService,
             DialogService.CreateDialogCallback(this, HandleFilterDialog),
             propertyKeys: GetTraceSpanPropertyKeys(),
-            knownKeys: [.. KnownTraceFields.AllFields, KnownTraceFields.DurationField],
+            knownKeys: KnownTraceFields.AllFields,
             getFieldValues: GetTraceSpanFieldValues,
             FilterLoc);
     }

--- a/src/Aspire.Dashboard/Model/Otlp/KnownTraceFields.cs
+++ b/src/Aspire.Dashboard/Model/Otlp/KnownTraceFields.cs
@@ -17,8 +17,6 @@ public static class KnownTraceFields
     public const string ParentIdField = "trace.parentid";
     public const string DestinationField = "trace.destination";
 
-    // Duration filtering is currently exposed by Trace Detail only. Do not include it
-    // here unless the Traces list also gets explicit trace-level duration semantics.
     public static readonly List<string> AllFields = [
         NameField,
         KindField,
@@ -26,6 +24,7 @@ public static class KnownTraceFields
         KnownResourceFields.ServiceNameField,
         TraceIdField,
         SpanIdField,
-        KnownSourceFields.NameField
+        KnownSourceFields.NameField,
+        DurationField
     ];
 }

--- a/src/Aspire.Dashboard/Model/Otlp/TelemetryFilter.cs
+++ b/src/Aspire.Dashboard/Model/Otlp/TelemetryFilter.cs
@@ -131,6 +131,24 @@ public class FieldTelemetryFilter : TelemetryFilter
         return func(fieldNumber, filterNumber);
     }
 
+    public bool HasNumericMatch(double fieldValue)
+    {
+        if (!double.TryParse(Value, NumberStyles.Float, CultureInfo.InvariantCulture, out var filterNumber) ||
+            !double.IsFinite(filterNumber) ||
+            !double.IsFinite(fieldValue))
+        {
+            return false;
+        }
+
+        if (Condition is not (FilterCondition.Equals or FilterCondition.GreaterThan or FilterCondition.LessThan or FilterCondition.GreaterThanOrEqual or FilterCondition.LessThanOrEqual or FilterCondition.NotEqual))
+        {
+            return false;
+        }
+
+        var func = ConditionToFuncNumber(Condition);
+        return func(fieldValue, filterNumber);
+    }
+
     public override IEnumerable<OtlpLogEntry> Apply(IEnumerable<OtlpLogEntry> input)
     {
         switch (Field)

--- a/src/Aspire.Dashboard/Model/Otlp/TelemetryFilterExtensions.cs
+++ b/src/Aspire.Dashboard/Model/Otlp/TelemetryFilterExtensions.cs
@@ -1,0 +1,13 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Aspire.Dashboard.Model.Otlp;
+
+public static class TelemetryFilterExtensions
+{
+    public static bool IsDurationFilter(this TelemetryFilter filter)
+        => filter is FieldTelemetryFilter { Field: KnownTraceFields.DurationField };
+
+    public static bool HasNumericMatch(this TelemetryFilter filter, double fieldValue)
+        => filter is FieldTelemetryFilter fieldFilter && fieldFilter.HasNumericMatch(fieldValue);
+}

--- a/src/Aspire.Dashboard/Model/Otlp/TelemetryFilterExtensions.cs
+++ b/src/Aspire.Dashboard/Model/Otlp/TelemetryFilterExtensions.cs
@@ -5,7 +5,7 @@ namespace Aspire.Dashboard.Model.Otlp;
 
 public static class TelemetryFilterExtensions
 {
-    public static bool IsDurationFilter(this TelemetryFilter filter)
+    public static bool IsTraceDurationFilter(this TelemetryFilter filter)
         => filter is FieldTelemetryFilter { Field: KnownTraceFields.DurationField };
 
     public static bool HasNumericMatch(this TelemetryFilter filter, double fieldValue)

--- a/src/Aspire.Dashboard/Otlp/Storage/TelemetryRepository.cs
+++ b/src/Aspire.Dashboard/Otlp/Storage/TelemetryRepository.cs
@@ -726,7 +726,7 @@ public sealed partial class TelemetryRepository : IDisposable
         // Duration filters apply to the trace's overall duration, not individual spans.
         foreach (var filter in filters)
         {
-            if (filter.IsDurationFilter() && !filter.HasNumericMatch(trace.Duration.TotalMilliseconds))
+            if (filter.IsTraceDurationFilter() && !filter.HasNumericMatch(trace.Duration.TotalMilliseconds))
             {
                 return false;
             }
@@ -738,7 +738,7 @@ public sealed partial class TelemetryRepository : IDisposable
             var match = true;
             foreach (var filter in filters)
             {
-                if (filter.IsDurationFilter())
+                if (filter.IsTraceDurationFilter())
                 {
                     continue;
                 }
@@ -801,7 +801,7 @@ public sealed partial class TelemetryRepository : IDisposable
     {
         public bool IsOptimized => OptimizedDurationFilter is not null || OptimizedStringFilter is not null;
 
-        public bool IsDurationFilter => OptimizedDurationFilter is not null || Filter.IsDurationFilter();
+        public bool IsDurationFilter => OptimizedDurationFilter is not null || Filter.IsTraceDurationFilter();
 
         public static TraceFilter Create(TelemetryFilter filter)
         {
@@ -835,7 +835,7 @@ public sealed partial class TelemetryRepository : IDisposable
                 return durationFilter.Apply(traceDurationMs);
             }
 
-            return Filter.IsDurationFilter() && Filter.HasNumericMatch(traceDurationMs);
+            return Filter.IsTraceDurationFilter() && Filter.HasNumericMatch(traceDurationMs);
         }
     }
 

--- a/src/Aspire.Dashboard/Otlp/Storage/TelemetryRepository.cs
+++ b/src/Aspire.Dashboard/Otlp/Storage/TelemetryRepository.cs
@@ -723,12 +723,26 @@ public sealed partial class TelemetryRepository : IDisposable
             return MatchesFilters(trace, optimizedFilters);
         }
 
-        // A trace matches when one of its spans matches all filters.
+        // Duration filters apply to the trace's overall duration, not individual spans.
+        foreach (var filter in filters)
+        {
+            if (filter.IsDurationFilter() && !filter.HasNumericMatch(trace.Duration.TotalMilliseconds))
+            {
+                return false;
+            }
+        }
+
+        // A trace matches when one of its spans matches all non-duration filters.
         foreach (var span in trace.Spans)
         {
             var match = true;
             foreach (var filter in filters)
             {
+                if (filter.IsDurationFilter())
+                {
+                    continue;
+                }
+
                 if (!filter.Apply(span))
                 {
                     match = false;
@@ -747,12 +761,26 @@ public sealed partial class TelemetryRepository : IDisposable
 
     private static bool MatchesFilters(OtlpTrace trace, List<TraceFilter> optimizedFilters)
     {
-        // A trace matches when one of its spans matches all filters.
+        // Duration filters apply to the trace's overall duration, not individual spans.
+        foreach (var filter in optimizedFilters)
+        {
+            if (filter.IsDurationFilter && !filter.ApplyDuration(trace.Duration.TotalMilliseconds))
+            {
+                return false;
+            }
+        }
+
+        // A trace matches when one of its spans matches all non-duration filters.
         foreach (var span in trace.Spans)
         {
             var match = true;
             foreach (var filter in optimizedFilters)
             {
+                if (filter.IsDurationFilter)
+                {
+                    continue;
+                }
+
                 if (!filter.Apply(span))
                 {
                     match = false;
@@ -773,6 +801,8 @@ public sealed partial class TelemetryRepository : IDisposable
     {
         public bool IsOptimized => OptimizedDurationFilter is not null || OptimizedStringFilter is not null;
 
+        public bool IsDurationFilter => OptimizedDurationFilter is not null || Filter.IsDurationFilter();
+
         public static TraceFilter Create(TelemetryFilter filter)
         {
             if (DurationFilter.TryCreate(filter, out var durationFilter))
@@ -790,17 +820,22 @@ public sealed partial class TelemetryRepository : IDisposable
 
         public bool Apply(OtlpSpan span)
         {
-            if (OptimizedDurationFilter is { } durationFilter)
-            {
-                return durationFilter.Apply(span.Duration.TotalMilliseconds);
-            }
-
             if (OptimizedStringFilter is { } stringFilter)
             {
                 return stringFilter.Apply(span);
             }
 
             return Filter.Apply(span);
+        }
+
+        public bool ApplyDuration(double traceDurationMs)
+        {
+            if (OptimizedDurationFilter is { } durationFilter)
+            {
+                return durationFilter.Apply(traceDurationMs);
+            }
+
+            return Filter.IsDurationFilter() && Filter.HasNumericMatch(traceDurationMs);
         }
     }
 

--- a/src/Aspire.Dashboard/Otlp/Storage/TelemetryRepository.cs
+++ b/src/Aspire.Dashboard/Otlp/Storage/TelemetryRepository.cs
@@ -835,7 +835,7 @@ public sealed partial class TelemetryRepository : IDisposable
                 return durationFilter.Apply(traceDurationMs);
             }
 
-            return Filter.IsTraceDurationFilter() && Filter.HasNumericMatch(traceDurationMs);
+            return Filter.HasNumericMatch(traceDurationMs);
         }
     }
 

--- a/tests/Aspire.Dashboard.Tests/TelemetryRepositoryTests/TraceTests.cs
+++ b/tests/Aspire.Dashboard.Tests/TelemetryRepositoryTests/TraceTests.cs
@@ -1361,6 +1361,68 @@ public class TraceTests
     }
 
     [Fact]
+    public void GetTraces_DurationFilter_AppliesTraceLevelDuration()
+    {
+        // Verifies that the duration filter uses the trace's overall duration (first span
+        // start to latest span end), not individual span durations. A trace with a 100ms
+        // root span containing a 5ms child span should match "> 50ms" (trace is 100ms)
+        // but NOT "< 10ms" (even though the child span is only 5ms).
+        var repository = CreateRepository();
+
+        var addContext = new AddContext();
+        repository.AddTraces(addContext, new RepeatedField<ResourceSpans>()
+        {
+            new ResourceSpans
+            {
+                Resource = CreateResource(name: "resource1", instanceId: "123"),
+                ScopeSpans =
+                {
+                    new ScopeSpans
+                    {
+                        Scope = CreateScope(),
+                        Spans =
+                        {
+                            // Root span: 100ms duration
+                            CreateSpan(traceId: "1", spanId: "1-1", startTime: s_testTime.AddMilliseconds(0), endTime: s_testTime.AddMilliseconds(100)),
+                            // Child span: 5ms duration (well under any "short" threshold)
+                            CreateSpan(traceId: "1", spanId: "1-2", startTime: s_testTime.AddMilliseconds(10), endTime: s_testTime.AddMilliseconds(15), parentSpanId: "1-1")
+                        }
+                    }
+                }
+            }
+        });
+
+        Assert.Equal(0, addContext.FailureCount);
+
+        var resourceKey = new ResourceKey("resource1", InstanceId: null);
+
+        // Duration filter "> 50ms" should match because trace duration is 100ms.
+        var traces = repository.GetTraces(new GetTracesRequest
+        {
+            ResourceKey = resourceKey,
+            FilterText = string.Empty,
+            StartIndex = 0,
+            Count = 10,
+            Filters = [new FieldTelemetryFilter { Field = KnownTraceFields.DurationField, Condition = FilterCondition.GreaterThan, Value = "50" }]
+        });
+
+        Assert.Single(traces.PagedResult.Items);
+
+        // Duration filter "< 10ms" should NOT match because trace duration is 100ms,
+        // even though the child span is only 5ms.
+        traces = repository.GetTraces(new GetTracesRequest
+        {
+            ResourceKey = resourceKey,
+            FilterText = string.Empty,
+            StartIndex = 0,
+            Count = 10,
+            Filters = [new FieldTelemetryFilter { Field = KnownTraceFields.DurationField, Condition = FilterCondition.LessThan, Value = "10" }]
+        });
+
+        Assert.Empty(traces.PagedResult.Items);
+    }
+
+    [Fact]
     public void GetTraces_NotEqualFilter_NonMatchingValue_ReturnsTrace()
     {
         // Arrange


### PR DESCRIPTION
Fixes #17376

Adds a duration filter to the Traces page so users can filter traces by their overall duration. The filter uses trace-level semantics (first span start → latest span end), unlike the Trace Detail page which filters individual spans.