### PR TITLE
[release/13.3] Replace `zap trash: "~/.aspire"` with canonical "no zap" comment in Homebrew cask

### DIFF
--- a/eng/homebrew/aspire.rb.template
+++ b/eng/homebrew/aspire.rb.template
@@ -17,5 +17,5 @@ cask "aspire" do
 
   binary "aspire"
 
-  zap trash: "~/.aspire"
+  # No zap stanza required
 end


### PR DESCRIPTION
The 13.3.x Homebrew cask has `zap trash: "~/.aspire"`. `~/.aspire` is the user's Aspire CLI home — shared with every other install route (the `get-aspire-cli` script, `dotnet tool install -g Aspire.Cli`, etc.). A user who runs `brew uninstall --zap aspire` silently wipes state used by all those parallel installs.

(Plain `brew uninstall --cask aspire` is unaffected — `zap` only runs under explicit `--zap`. So the blast radius is users who use `--zap` as a "clean uninstall" habit, but it's silent and unrecoverable when it does fire.)

The brew install writes no user-level state outside the Caskroom, so the right fix is the canonical comment documented by the [Homebrew Cask Cookbook](https://docs.brew.sh/Cask-Cookbook#stanza-zap):

```ruby
# No zap stanza required
```

Lands before the first 13.3.x cask is submitted to `Homebrew/homebrew-cask`, so no published cask carries the data-loss path. The full sidecar/co-located-bundle rework that moves brew-owned CLI state out of `~/.aspire` entirely is the 13.4 work in #16817; this is the minimum safe servicing patch for 13.3.x.
