### PR TITLE
Use canonical "no zap" comment instead of "zap trash: []" placeholder in Homebrew cask

### DIFF
--- a/eng/homebrew/aspire.rb.template
+++ b/eng/homebrew/aspire.rb.template
@@ -22,10 +22,5 @@ cask "aspire" do
     File.write("#{staged_path}/.aspire-install.json", %Q({"source":"brew"}\n))
   end
 
-  # Intentionally empty: `brew uninstall --zap aspire` should not remove
-  # `~/.aspire` because that directory is shared with non-Homebrew Aspire
-  # state (PR hives, dev certs, telemetry, runtime sockets, manually
-  # installed CLIs). An explicit empty `zap` silences the `missing-zap`
-  # audit warning and the corresponding upstream homebrew/cask PR label.
-  zap trash: []
+  # No zap stanza required
 end


### PR DESCRIPTION
The cask uses `zap trash: []` as a placeholder to silence the upstream `missing zap` triage label, since `~/.aspire` is shared with non-Homebrew install routes and must not be zapped on `brew uninstall --zap`.

The Homebrew Cask Cookbook documents the canonical pattern for casks with no user state to zap as a single comment:

```ruby
# No zap stanza required
```

The comment satisfies the same upstream missing-zap triage regex (matches `zap stanza required\n` against `zap .+\n`), is what 1,284+ merged casks use today (incl. CLI-binary casks like `aws-vault-binary` and `p4`), and matches the [homebrew-cask style guide rule](https://github.com/Homebrew/homebrew-cask/blob/HEAD/CONTRIBUTING.md) that the only comments permitted are ones explicitly defined in the Cookbook. Maintainer guidance in [Homebrew/homebrew-cask#264857](https://github.com/Homebrew/homebrew-cask/pull/264857) (pgen) steers cask authors away from placeholder zap content like `trash: []` toward this canonical form.

No behavior change: brew writes the sidecar inside `staged_path` (the Caskroom-managed directory), which Homebrew already cleans on regular uninstall, so the zap stanza was always a no-op.

Companion to the same change on `release/13.3` in #17395.
