### PR TITLE
Fix polyglot endpoint callback deadlocks

### DIFF
--- a/src/Aspire.Hosting.Integration.Analyzers/AspireExportAnalyzer.Diagnostics.cs
+++ b/src/Aspire.Hosting.Integration.Analyzers/AspireExportAnalyzer.Diagnostics.cs
@@ -105,7 +105,7 @@ internal partial class AspireExportAnalyzer
         internal static readonly DiagnosticDescriptor s_exportedSyncDelegateInvokedInline = new(
             id: ExportedSyncDelegateInvokedInlineId,
             title: "Exported synchronous callback should not be invoked inline",
-            messageFormat: "Exported builder method '{0}' directly invokes synchronous delegate parameter '{1}'. Defer the callback, expose an async delegate, or set RunSyncOnBackgroundThread = true to avoid polyglot deadlocks.",
+            messageFormat: "Exported builder method '{0}' directly or transitively invokes synchronous delegate parameter '{1}'. Defer the callback, expose an async delegate, or set RunSyncOnBackgroundThread = true to avoid polyglot deadlocks.",
             category: "Design",
             DiagnosticSeverity.Warning,
             isEnabledByDefault: true,

--- a/src/Aspire.Hosting.Integration.Analyzers/AspireExportAnalyzer.cs
+++ b/src/Aspire.Hosting.Integration.Analyzers/AspireExportAnalyzer.cs
@@ -172,6 +172,7 @@ internal partial class AspireExportAnalyzer : DiagnosticAnalyzer
         // Warn when exported builder methods invoke synchronous callback delegates inline. Deferred callbacks
         // that are stored for later execution are fine, and exports that opt into background-thread dispatch
         // are handled safely by the runtime.
+        var inlineDelegateInvocationCache = new ConcurrentDictionary<ISymbol, ImmutableHashSet<int>>(SymbolEqualityComparer.Default);
         context.RegisterOperationBlockStartAction(c =>
         {
             if (c.OwningSymbol is not IMethodSymbol method ||
@@ -197,7 +198,13 @@ internal partial class AspireExportAnalyzer : DiagnosticAnalyzer
 
             var reportedParameters = new ConcurrentDictionary<string, byte>(StringComparer.Ordinal);
             c.RegisterOperationAction(
-                oc => AnalyzeInlineSynchronousDelegateInvocation(oc, method, synchronousDelegateParameters, reportedParameters),
+                oc => AnalyzeInlineSynchronousDelegateInvocation(
+                    oc,
+                    context.Compilation.Assembly,
+                    method,
+                    synchronousDelegateParameters,
+                    reportedParameters,
+                    inlineDelegateInvocationCache),
                 OperationKind.Invocation);
         });
     }
@@ -868,35 +875,277 @@ internal partial class AspireExportAnalyzer : DiagnosticAnalyzer
 
     private static void AnalyzeInlineSynchronousDelegateInvocation(
         OperationAnalysisContext context,
+        IAssemblySymbol assembly,
         IMethodSymbol method,
         IReadOnlyDictionary<string, IParameterSymbol> synchronousDelegateParameters,
-        ConcurrentDictionary<string, byte> reportedParameters)
+        ConcurrentDictionary<string, byte> reportedParameters,
+        ConcurrentDictionary<ISymbol, ImmutableHashSet<int>> inlineDelegateInvocationCache)
     {
         var invocation = (IInvocationOperation)context.Operation;
 
-        if (invocation.TargetMethod.MethodKind != MethodKind.DelegateInvoke ||
-            invocation.Syntax is not InvocationExpressionSyntax invocationSyntax ||
+        if (invocation.Syntax is not InvocationExpressionSyntax invocationSyntax ||
             IsInsideNestedCallback(invocationSyntax))
         {
             return;
         }
 
-        var parameterName = GetInvokedDelegateParameterName(invocationSyntax);
-        if (parameterName is null || !synchronousDelegateParameters.TryGetValue(parameterName, out var parameter))
+        if (invocation.TargetMethod.MethodKind == MethodKind.DelegateInvoke)
         {
+            var parameterName = GetInvokedDelegateParameterName(invocationSyntax);
+            if (parameterName is null || !synchronousDelegateParameters.TryGetValue(parameterName, out var parameter))
+            {
+                return;
+            }
+
+            ReportInlineSynchronousDelegateInvocation(context, method, reportedParameters, invocationSyntax.GetLocation(), parameter);
             return;
         }
 
-        if (!reportedParameters.TryAdd(parameterName, default))
+        foreach (var argument in invocation.Arguments)
         {
-            return;
+            if (argument.Parameter is null ||
+                GetReferencedParameter(argument.Value) is not { } referencedParameter ||
+                !synchronousDelegateParameters.TryGetValue(referencedParameter.Name, out var callbackParameter))
+            {
+                continue;
+            }
+
+            var targetInvokedParameters = GetInlineInvokedDelegateParameterOrdinals(
+                invocation.TargetMethod,
+                assembly,
+                inlineDelegateInvocationCache,
+                new HashSet<ISymbol>(SymbolEqualityComparer.Default),
+                context.CancellationToken);
+
+            if (!targetInvokedParameters.Contains(argument.Parameter.Ordinal))
+            {
+                continue;
+            }
+
+            ReportInlineSynchronousDelegateInvocation(context, method, reportedParameters, invocationSyntax.GetLocation(), callbackParameter);
+        }
+    }
+
+    private static void ReportInlineSynchronousDelegateInvocation(
+        OperationAnalysisContext context,
+        IMethodSymbol method,
+        ConcurrentDictionary<string, byte> reportedParameters,
+        Location location,
+        IParameterSymbol parameter)
+    {
+        if (reportedParameters.TryAdd(parameter.Name, default))
+        {
+            context.ReportDiagnostic(Diagnostic.Create(
+                Diagnostics.s_exportedSyncDelegateInvokedInline,
+                location,
+                method.Name,
+                parameter.Name));
+        }
+    }
+
+    private static ImmutableHashSet<int> GetInlineInvokedDelegateParameterOrdinals(
+        IMethodSymbol method,
+        IAssemblySymbol assembly,
+        ConcurrentDictionary<ISymbol, ImmutableHashSet<int>> cache,
+        HashSet<ISymbol> visiting,
+        CancellationToken cancellationToken)
+    {
+        if (cache.TryGetValue(method, out var cached))
+        {
+            return cached;
         }
 
-        context.ReportDiagnostic(Diagnostic.Create(
-            Diagnostics.s_exportedSyncDelegateInvokedInline,
-            invocationSyntax.GetLocation(),
-            method.Name,
-            parameter.Name));
+        if (!SymbolEqualityComparer.Default.Equals(method.ContainingAssembly, assembly) ||
+            method.DeclaringSyntaxReferences.Length == 0 ||
+            !visiting.Add(method))
+        {
+            return ImmutableHashSet<int>.Empty;
+        }
+
+        try
+        {
+            var result = ComputeInlineInvokedDelegateParameterOrdinals(method, assembly, cache, visiting, cancellationToken);
+            cache.TryAdd(method, result);
+            return result;
+        }
+        finally
+        {
+            visiting.Remove(method);
+        }
+    }
+
+    private static ImmutableHashSet<int> ComputeInlineInvokedDelegateParameterOrdinals(
+        IMethodSymbol method,
+        IAssemblySymbol assembly,
+        ConcurrentDictionary<ISymbol, ImmutableHashSet<int>> cache,
+        HashSet<ISymbol> visiting,
+        CancellationToken cancellationToken)
+    {
+        var synchronousDelegateParameterOrdinals = method.Parameters
+            .Where(IsSynchronousDelegateParameter)
+            .Select(static p => p.Ordinal)
+            .ToImmutableHashSet();
+
+        if (synchronousDelegateParameterOrdinals.Count == 0)
+        {
+            return ImmutableHashSet<int>.Empty;
+        }
+
+        var syntax = method.DeclaringSyntaxReferences[0].GetSyntax(cancellationToken);
+        var result = ImmutableHashSet.CreateBuilder<int>();
+
+        foreach (var invocationSyntax in syntax.DescendantNodes().OfType<InvocationExpressionSyntax>())
+        {
+            if (IsInsideNestedCallback(invocationSyntax))
+            {
+                continue;
+            }
+
+            var parameterName = GetInvokedDelegateParameterName(invocationSyntax);
+            var parameter = parameterName is null
+                ? null
+                : method.Parameters.FirstOrDefault(p => p.Name == parameterName);
+            if (parameter is not null && synchronousDelegateParameterOrdinals.Contains(parameter.Ordinal))
+            {
+                result.Add(parameter.Ordinal);
+                continue;
+            }
+
+            foreach (var targetMethod in ResolveSameTypeMethodInvocations(method, invocationSyntax))
+            {
+                foreach (var argument in invocationSyntax.ArgumentList.Arguments)
+                {
+                    if (GetReferencedParameterName(argument.Expression) is not { } referencedParameterName)
+                    {
+                        continue;
+                    }
+
+                    var referencedParameter = method.Parameters.FirstOrDefault(p => p.Name == referencedParameterName);
+                    var targetParameterOrdinal = GetTargetParameterOrdinal(targetMethod, argument, invocationSyntax.ArgumentList);
+
+                    if (referencedParameter is null ||
+                        targetParameterOrdinal is null ||
+                        !synchronousDelegateParameterOrdinals.Contains(referencedParameter.Ordinal))
+                    {
+                        continue;
+                    }
+
+                    var targetInvokedParameters = GetInlineInvokedDelegateParameterOrdinals(
+                        targetMethod,
+                        assembly,
+                        cache,
+                        visiting,
+                        cancellationToken);
+
+                    if (targetInvokedParameters.Contains(targetParameterOrdinal.Value))
+                    {
+                        result.Add(referencedParameter.Ordinal);
+                    }
+                }
+            }
+        }
+
+        return result.ToImmutable();
+    }
+
+    private static IParameterSymbol? GetReferencedParameter(IOperation operation)
+    {
+        while (operation is IConversionOperation conversion)
+        {
+            operation = conversion.Operand;
+        }
+
+        return operation is IParameterReferenceOperation parameterReference
+            ? parameterReference.Parameter
+            : null;
+    }
+
+    private static IEnumerable<IMethodSymbol> ResolveSameTypeMethodInvocations(IMethodSymbol containingMethod, InvocationExpressionSyntax invocation)
+    {
+        // Analyzer rules prohibit fetching a SemanticModel for arbitrary helper syntax here, so helper
+        // summaries use the exact operation symbol at the export boundary and bounded syntax matching
+        // for subsequent calls inside the same helper type.
+        var methodName = invocation.Expression switch
+        {
+            IdentifierNameSyntax identifier => identifier.Identifier.ValueText,
+            MemberAccessExpressionSyntax memberAccess => memberAccess.Name.Identifier.ValueText,
+            _ => null
+        };
+
+        if (methodName is null || containingMethod.ContainingType is null)
+        {
+            yield break;
+        }
+
+        foreach (var member in containingMethod.ContainingType.GetMembers(methodName).OfType<IMethodSymbol>())
+        {
+            if (member.DeclaringSyntaxReferences.Length == 0 ||
+                !CouldAcceptArguments(member, invocation.ArgumentList))
+            {
+                continue;
+            }
+
+            yield return member;
+        }
+    }
+
+    private static bool CouldAcceptArguments(IMethodSymbol targetMethod, ArgumentListSyntax argumentList)
+    {
+        var positionalArgumentCount = 0;
+        foreach (var argument in argumentList.Arguments)
+        {
+            if (argument.NameColon is not null)
+            {
+                if (!targetMethod.Parameters.Any(p => p.Name == argument.NameColon.Name.Identifier.ValueText))
+                {
+                    return false;
+                }
+
+                continue;
+            }
+
+            positionalArgumentCount++;
+        }
+
+        if (positionalArgumentCount > targetMethod.Parameters.Length)
+        {
+            return false;
+        }
+
+        var suppliedNames = new HashSet<string>(argumentList.Arguments
+            .Where(static a => a.NameColon is not null)
+            .Select(static a => a.NameColon!.Name.Identifier.ValueText),
+            StringComparer.Ordinal);
+
+        return targetMethod.Parameters
+            .Where(static p => !p.IsOptional)
+            .All(p => p.Ordinal < positionalArgumentCount || suppliedNames.Contains(p.Name));
+    }
+
+    private static int? GetTargetParameterOrdinal(IMethodSymbol targetMethod, ArgumentSyntax argument, ArgumentListSyntax argumentList)
+    {
+        if (argument.NameColon is not null)
+        {
+            var parameter = targetMethod.Parameters.FirstOrDefault(p => p.Name == argument.NameColon.Name.Identifier.ValueText);
+            return parameter?.Ordinal;
+        }
+
+        var ordinal = argumentList.Arguments.IndexOf(argument);
+        return ordinal >= 0 && ordinal < targetMethod.Parameters.Length
+            ? ordinal
+            : null;
+    }
+
+    private static string? GetReferencedParameterName(ExpressionSyntax expression)
+    {
+        while (expression is ParenthesizedExpressionSyntax parenthesized)
+        {
+            expression = parenthesized.Expression;
+        }
+
+        return expression is IdentifierNameSyntax identifier
+            ? identifier.Identifier.ValueText
+            : null;
     }
 
     private static bool IsInsideNestedCallback(InvocationExpressionSyntax invocation)

--- a/src/Aspire.Hosting/ResourceBuilderExtensions.cs
+++ b/src/Aspire.Hosting/ResourceBuilderExtensions.cs
@@ -1495,7 +1495,7 @@ public static class ResourceBuilderExtensions
     /// <summary>
     /// Updates a named endpoint via callback
     /// </summary>
-    [AspireExport]
+    [AspireExport(RunSyncOnBackgroundThread = true)]
     internal static IResourceBuilder<T> WithEndpointCallback<T>(this IResourceBuilder<T> builder, [EndpointName] string endpointName, Action<EndpointUpdateContext> callback, bool createIfNotExists = true) where T : IResourceWithEndpoints
     {
         ArgumentNullException.ThrowIfNull(builder);
@@ -1508,7 +1508,7 @@ public static class ResourceBuilderExtensions
     /// <summary>
     /// Updates an HTTP endpoint via callback
     /// </summary>
-    [AspireExport]
+    [AspireExport(RunSyncOnBackgroundThread = true)]
     internal static IResourceBuilder<T> WithHttpEndpointCallback<T>(this IResourceBuilder<T> builder, Action<EndpointUpdateContext> callback, [EndpointName] string? name = null, bool createIfNotExists = true) where T : IResourceWithEndpoints
     {
         ArgumentNullException.ThrowIfNull(builder);
@@ -1520,7 +1520,7 @@ public static class ResourceBuilderExtensions
     /// <summary>
     /// Updates an HTTPS endpoint via callback
     /// </summary>
-    [AspireExport]
+    [AspireExport(RunSyncOnBackgroundThread = true)]
     internal static IResourceBuilder<T> WithHttpsEndpointCallback<T>(this IResourceBuilder<T> builder, Action<EndpointUpdateContext> callback, [EndpointName] string? name = null, bool createIfNotExists = true) where T : IResourceWithEndpoints
     {
         ArgumentNullException.ThrowIfNull(builder);

--- a/tests/Aspire.Hosting.Analyzers.Tests/AspireExportAnalyzerTests.cs
+++ b/tests/Aspire.Hosting.Analyzers.Tests/AspireExportAnalyzerTests.cs
@@ -441,6 +441,81 @@ public class AspireExportAnalyzerTests
     }
 
     [Fact]
+    public async Task ExportedBuilderMethod_PassesActionToHelperThatInvokesInline_ReportsASPIREEXPORT010()
+    {
+        var diagnostic = AspireExportAnalyzer.Diagnostics.s_exportedSyncDelegateInvokedInline;
+
+        var test = AnalyzerTest.Create<AspireExportAnalyzer>("""
+            using System;
+            using Aspire.Hosting;
+            using Aspire.Hosting.ApplicationModel;
+
+            var builder = DistributedApplication.CreateBuilder(args);
+
+            public sealed class TestResource(string name) : Resource(name);
+            public sealed class TestContext;
+
+            public static class TestExports
+            {
+                [AspireExport]
+                public static IResourceBuilder<TestResource> WithHelperCallback(this IResourceBuilder<TestResource> builder, Action<TestContext> callback)
+                {
+                    InvokeCallback(callback);
+                    return builder;
+                }
+
+                private static void InvokeCallback(Action<TestContext> callback)
+                {
+                    callback(new TestContext());
+                }
+            }
+            """,
+            [new DiagnosticResult(diagnostic).WithLocation(15, 9).WithArguments("WithHelperCallback", "callback")]);
+
+        await test.RunAsync();
+    }
+
+    [Fact]
+    public async Task ExportedBuilderMethod_PassesActionToTransitiveHelperThatInvokesInline_ReportsASPIREEXPORT010()
+    {
+        var diagnostic = AspireExportAnalyzer.Diagnostics.s_exportedSyncDelegateInvokedInline;
+
+        var test = AnalyzerTest.Create<AspireExportAnalyzer>("""
+            using System;
+            using Aspire.Hosting;
+            using Aspire.Hosting.ApplicationModel;
+
+            var builder = DistributedApplication.CreateBuilder(args);
+
+            public sealed class TestResource(string name) : Resource(name);
+            public sealed class TestContext;
+
+            public static class TestExports
+            {
+                [AspireExport]
+                public static IResourceBuilder<TestResource> WithTransitiveHelperCallback(this IResourceBuilder<TestResource> builder, Action<TestContext> callback)
+                {
+                    InvokeOuter(callback);
+                    return builder;
+                }
+
+                private static void InvokeOuter(Action<TestContext> callback)
+                {
+                    InvokeInner(callback);
+                }
+
+                private static void InvokeInner(Action<TestContext> callback)
+                {
+                    callback(new TestContext());
+                }
+            }
+            """,
+            [new DiagnosticResult(diagnostic).WithLocation(15, 9).WithArguments("WithTransitiveHelperCallback", "callback")]);
+
+        await test.RunAsync();
+    }
+
+    [Fact]
     public async Task ExportedBuilderMethod_PassesActionIntoDeferredLambda_NoDiagnostics()
     {
         var test = AnalyzerTest.Create<AspireExportAnalyzer>("""
@@ -464,6 +539,42 @@ public class AspireExportAnalyzerTests
                 public static IResourceBuilder<TestResource> WithDeferredCallback(this IResourceBuilder<TestResource> builder, Action<TestContext> callback)
                 {
                     return builder.WithAnnotation(new TestAnnotation(ctx => callback(ctx)));
+                }
+            }
+            """, []);
+
+        await test.RunAsync();
+    }
+
+    [Fact]
+    public async Task ExportedBuilderMethod_PassesActionToHelperThatDefersCallback_NoDiagnostics()
+    {
+        var test = AnalyzerTest.Create<AspireExportAnalyzer>("""
+            using System;
+            using Aspire.Hosting;
+            using Aspire.Hosting.ApplicationModel;
+
+            var builder = DistributedApplication.CreateBuilder(args);
+
+            public sealed class TestResource(string name) : Resource(name);
+            public sealed class TestContext;
+
+            public sealed class TestAnnotation : IResourceAnnotation
+            {
+                public TestAnnotation(Action<TestContext> callback) { }
+            }
+
+            public static class TestExports
+            {
+                [AspireExport]
+                public static IResourceBuilder<TestResource> WithDeferredHelperCallback(this IResourceBuilder<TestResource> builder, Action<TestContext> callback)
+                {
+                    return builder.WithAnnotation(CreateAnnotation(callback));
+                }
+
+                private static TestAnnotation CreateAnnotation(Action<TestContext> callback)
+                {
+                    return new TestAnnotation(ctx => callback(ctx));
                 }
             }
             """, []);
@@ -588,6 +699,38 @@ public class AspireExportAnalyzerTests
                 {
                     callback(new TestContext());
                     return builder;
+                }
+            }
+            """, []);
+
+        await test.RunAsync();
+    }
+
+    [Fact]
+    public async Task ExportedBuilderMethod_WithBackgroundThreadOptInAndTransitiveHelperInvocation_NoASPIREEXPORT010()
+    {
+        var test = AnalyzerTest.Create<AspireExportAnalyzer>("""
+            using System;
+            using Aspire.Hosting;
+            using Aspire.Hosting.ApplicationModel;
+
+            var builder = DistributedApplication.CreateBuilder(args);
+
+            public sealed class TestResource(string name) : Resource(name);
+            public sealed class TestContext;
+
+            public static class TestExports
+            {
+                [AspireExport(RunSyncOnBackgroundThread = true)]
+                public static IResourceBuilder<TestResource> WithHelperCallback(this IResourceBuilder<TestResource> builder, Action<TestContext> callback)
+                {
+                    InvokeCallback(callback);
+                    return builder;
+                }
+
+                private static void InvokeCallback(Action<TestContext> callback)
+                {
+                    callback(new TestContext());
                 }
             }
             """, []);

--- a/tests/Aspire.Hosting.RemoteHost.Tests/AtsCapabilityScannerTests.cs
+++ b/tests/Aspire.Hosting.RemoteHost.Tests/AtsCapabilityScannerTests.cs
@@ -549,6 +549,29 @@ public class AtsCapabilityScannerTests
     }
 
     [Fact]
+    public void ScanAssembly_EndpointCallbackExports_UseBackgroundThreadOptIn()
+    {
+        var hostingAssembly = typeof(DistributedApplication).Assembly;
+
+        var result = AtsCapabilityScanner.ScanAssembly(hostingAssembly);
+
+        var endpointCallbackIds = new[]
+        {
+            "/withEndpointCallback",
+            "/withHttpEndpointCallback",
+            "/withHttpsEndpointCallback"
+        };
+
+        foreach (var endpointCallbackId in endpointCallbackIds)
+        {
+            var capability = Assert.Single(result.Capabilities,
+                c => c.CapabilityId.EndsWith(endpointCallbackId, StringComparison.Ordinal));
+
+            Assert.True(capability.RunSyncOnBackgroundThread);
+        }
+    }
+
+    [Fact]
     public void ScanAssembly_ClassLevelBackgroundThreadOptIn_AppliesToExportedMethods()
     {
         var result = AtsCapabilityScanner.ScanAssembly(typeof(AtsCapabilityScannerTests).Assembly);

--- a/tests/Aspire.Hosting.RemoteHost.Tests/AtsCapabilityScannerTests.cs
+++ b/tests/Aspire.Hosting.RemoteHost.Tests/AtsCapabilityScannerTests.cs
@@ -549,29 +549,6 @@ public class AtsCapabilityScannerTests
     }
 
     [Fact]
-    public void ScanAssembly_EndpointCallbackExports_UseBackgroundThreadOptIn()
-    {
-        var hostingAssembly = typeof(DistributedApplication).Assembly;
-
-        var result = AtsCapabilityScanner.ScanAssembly(hostingAssembly);
-
-        var endpointCallbackIds = new[]
-        {
-            "/withEndpointCallback",
-            "/withHttpEndpointCallback",
-            "/withHttpsEndpointCallback"
-        };
-
-        foreach (var endpointCallbackId in endpointCallbackIds)
-        {
-            var capability = Assert.Single(result.Capabilities,
-                c => c.CapabilityId.EndsWith(endpointCallbackId, StringComparison.Ordinal));
-
-            Assert.True(capability.RunSyncOnBackgroundThread);
-        }
-    }
-
-    [Fact]
     public void ScanAssembly_ClassLevelBackgroundThreadOptIn_AppliesToExportedMethods()
     {
         var result = AtsCapabilityScanner.ScanAssembly(typeof(AtsCapabilityScannerTests).Assembly);


### PR DESCRIPTION
## Description

Polyglot AppHosts could deadlock when `withEndpointCallback`, `withHttpEndpointCallback`, or `withHttpsEndpointCallback` invoked a synchronous callback whose body made nested ATS/RPC mutations. This marks those endpoint callback exports with `RunSyncOnBackgroundThread = true` so the RPC loop can continue processing nested calls while the synchronous callback completes.

This also hardens `ASPIREEXPORT010` so future exported builder methods fail the build when they directly or transitively invoke synchronous callback parameters without the background-thread opt-in. The analyzer now covers bounded same-assembly helper chains while still allowing deferred callback storage patterns.

### User-facing usage

TypeScript AppHosts can mutate endpoint properties inside endpoint callbacks without hanging the polyglot bridge:

```typescript
await frontend.withHttpEndpointCallback(async (http) => {
    await http.isProxied.set(false);
});
```

### Validation

- `./dotnet.sh test --project tests/Aspire.Hosting.Analyzers.Tests/Aspire.Hosting.Analyzers.Tests.csproj --no-launch-profile -- --filter-class "*.AspireExportAnalyzerTests" --filter-not-trait "quarantined=true" --filter-not-trait "outerloop=true"`
- `./dotnet.sh test --project tests/Aspire.Hosting.RemoteHost.Tests/Aspire.Hosting.RemoteHost.Tests.csproj --no-launch-profile -- --filter-method "*.ScanAssembly_EndpointCallbackExports_UseBackgroundThreadOptIn" --filter-not-trait "quarantined=true" --filter-not-trait "outerloop=true"`
- `./dotnet.sh build src/Aspire.Hosting/Aspire.Hosting.csproj --no-restore`
- `./build.sh --build`

Fixes: #17391

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
