### PR TITLE
Support async chaining in TypeScript AppHosts

### DIFF
--- a/src/Aspire.Hosting.CodeGeneration.TypeScript/AtsTypeScriptCodeGenerator.cs
+++ b/src/Aspire.Hosting.CodeGeneration.TypeScript/AtsTypeScriptCodeGenerator.cs
@@ -1689,8 +1689,15 @@ internal sealed class AtsTypeScriptCodeGenerator : ICodeGenerator
 
         if (getter != null)
         {
-            var returnTypeName = MapTypeRefToTypeScript(getter.ReturnType);
-            WriteLine($"        get: () => Promise<{returnTypeName}>;");
+            if (TryGetPromiseWrapperType(getter.ReturnType, out var promiseInterfaceName, out _))
+            {
+                WriteLine($"        get: () => {promiseInterfaceName};");
+            }
+            else
+            {
+                var returnTypeName = MapTypeRefToTypeScript(getter.ReturnType);
+                WriteLine($"        get: () => Promise<{returnTypeName}>;");
+            }
         }
 
         if (setter != null)
@@ -1757,8 +1764,15 @@ internal sealed class AtsTypeScriptCodeGenerator : ICodeGenerator
             WriteCapabilityDocComment("    ", capability, requiredParams, hasOptionals ? "options" : null);
             if (hasNonBuilderReturn)
             {
-                var returnType = MapTypeRefToTypeScript(capability.ReturnType);
-                WriteLine($"    {capability.MethodName}({publicParamsString}): Promise<{returnType}>;");
+                if (TryGetPromiseWrapperType(capability.ReturnType, out var promiseInterfaceName, out _))
+                {
+                    WriteLine($"    {capability.MethodName}({publicParamsString}): {promiseInterfaceName};");
+                }
+                else
+                {
+                    var returnType = MapTypeRefToTypeScript(capability.ReturnType);
+                    WriteLine($"    {capability.MethodName}({publicParamsString}): Promise<{returnType}>;");
+                }
             }
             else
             {
@@ -1810,8 +1824,15 @@ internal sealed class AtsTypeScriptCodeGenerator : ICodeGenerator
             WriteCapabilityDocComment("    ", capability, requiredParams, hasOptionals ? "options" : null);
             if (hasNonBuilderReturn)
             {
-                var returnType = MapTypeRefToTypeScript(capability.ReturnType);
-                WriteLine($"    {capability.MethodName}({paramsString}): Promise<{returnType}>;");
+                if (TryGetPromiseWrapperType(capability.ReturnType, out var returnPromiseInterfaceName, out _))
+                {
+                    WriteLine($"    {capability.MethodName}({paramsString}): {returnPromiseInterfaceName};");
+                }
+                else
+                {
+                    var returnType = MapTypeRefToTypeScript(capability.ReturnType);
+                    WriteLine($"    {capability.MethodName}({paramsString}): Promise<{returnType}>;");
+                }
             }
             else
             {
@@ -1874,6 +1895,9 @@ internal sealed class AtsTypeScriptCodeGenerator : ICodeGenerator
         var hasMethods = standardMethods.Count > 0;
 
         var properties = GroupPropertiesByName(getters, setters);
+        var getterOnlyProperties = properties
+            .Where(p => IsGetterOnlyProperty(p.Getter, p.Setter))
+            .ToList();
         foreach (var prop in properties)
         {
             GenerateInterfaceProperty(prop.PropertyName, prop.Getter, prop.Setter);
@@ -1887,14 +1911,14 @@ internal sealed class AtsTypeScriptCodeGenerator : ICodeGenerator
         WriteLine("}");
         WriteLine();
 
-        if (!hasMethods)
+        if (!hasMethods && getterOnlyProperties.Count == 0)
         {
             return;
         }
 
         var promiseInterfaceName = GetPromiseInterfaceName(className);
         WriteLine($"export interface {promiseInterfaceName} extends PromiseLike<{interfaceName}> {{");
-        foreach (var prop in properties.Where(p => IsGetterOnlyProperty(p.Getter, p.Setter)))
+        foreach (var prop in getterOnlyProperties)
         {
             GenerateGetterOnlyPropertyPromiseSignature(prop.PropertyName, prop.Getter!);
         }
@@ -2041,6 +2065,46 @@ internal sealed class AtsTypeScriptCodeGenerator : ICodeGenerator
         var hasNonBuilderReturn = !returnsBuilder && capability.ReturnType != null;
         if (hasNonBuilderReturn)
         {
+            if (TryGetPromiseWrapperType(capability.ReturnType, out var returnPromiseInterfaceName, out var returnPromiseImplementationClassName))
+            {
+                var wrappedReturnTypeId = capability.ReturnType!.TypeId;
+                var wrappedReturnClassName = GetConcreteClassName(wrappedReturnTypeId);
+                var returnImplementationClassNameForWrapper = GetImplementationClassName(wrappedReturnClassName);
+                var returnHandleType = GetHandleTypeName(wrappedReturnTypeId);
+
+                WriteCapabilityDocComment("    ", capability, requiredParams, hasOptionals ? publicOptionsParamName : null);
+                Write($"    {methodName}(");
+                Write(publicParamsString);
+                WriteLine($"): {returnPromiseInterfaceName} {{");
+                WriteLine("        const promise = (async () => {");
+
+                foreach (var param in hasDirectOptionsParameter ? [] : optionalParams)
+                {
+                    var localParameterName = GetLocalParameterName(param);
+                    WriteLine($"            {(IsWidenedHandleType(param.Type) ? "let" : "const")} {localParameterName} = {publicOptionsParamName}?.{param.Name};");
+                }
+
+                var callbackParamsForPromiseWrapper = userParams.Where(p => p.IsCallback).ToList();
+                foreach (var callbackParam in callbackParamsForPromiseWrapper)
+                {
+                    GenerateCallbackRegistration(callbackParam, "            ");
+                }
+
+                GeneratePromiseResolution(userParams, "            ");
+                GenerateArgsObjectWithConditionals(targetParamName, requiredParams, optionalParams, useSafeOptionalLocalNames: true, indent: "            ");
+
+                WriteLine($"            const handle = await this._client.invokeCapability<{returnHandleType}>(");
+                WriteLine($"                '{capability.CapabilityId}',");
+                WriteLine("                rpcArgs");
+                WriteLine("            );");
+                WriteLine($"            return new {returnImplementationClassNameForWrapper}(handle, this._client);");
+                WriteLine("        })();");
+                WriteLine($"        return new {returnPromiseImplementationClassName}(promise, this._client);");
+                WriteLine("    }");
+                WriteLine();
+                return;
+            }
+
             // Generate a simple async method that returns the actual type
             var returnType = MapTypeRefToTypeScript(capability.ReturnType);
 
@@ -2446,6 +2510,19 @@ internal sealed class AtsTypeScriptCodeGenerator : ICodeGenerator
 
             if (hasNonBuilderReturn)
             {
+                if (TryGetPromiseWrapperType(capability.ReturnType, out var returnPromiseInterfaceName, out var returnPromiseImplementationClassName))
+                {
+                    Write($"    {methodName}(");
+                    Write(paramsString);
+                    WriteLine($"): {returnPromiseInterfaceName} {{");
+                    Write($"        return new {returnPromiseImplementationClassName}(this._promise.then(obj => obj.{methodName}(");
+                    Write(argsString);
+                    WriteLine(")), this._client);");
+                    WriteLine("    }");
+                    WriteLine();
+                    continue;
+                }
+
                 // For non-builder returns, call the public method directly
                 var returnType = MapTypeRefToTypeScript(capability.ReturnType);
                 Write($"    {methodName}(");
@@ -2956,7 +3033,7 @@ internal sealed class AtsTypeScriptCodeGenerator : ICodeGenerator
     /// <summary>
     /// Generates a type class (context type or wrapper type).
     /// Uses property-like objects for mutable properties and methods for getter-only properties.
-    /// For types with methods, also generates a Promise wrapper class for fluent chaining.
+    /// For types with generated async members, also generates a Promise wrapper class for fluent chaining.
     /// </summary>
     private void GenerateTypeClass(BuilderModel model)
     {
@@ -2989,6 +3066,9 @@ internal sealed class AtsTypeScriptCodeGenerator : ICodeGenerator
 
         // Group getters and setters by property name to create property members
         var properties = GroupPropertiesByName(getters, setters);
+        var getterOnlyProperties = properties
+            .Where(p => IsGetterOnlyProperty(p.Getter, p.Setter))
+            .ToList();
 
         // Generate property access members
         foreach (var prop in properties)
@@ -3020,8 +3100,8 @@ internal sealed class AtsTypeScriptCodeGenerator : ICodeGenerator
         WriteLine("}");
         WriteLine();
 
-        // Generate thenable wrapper class if this type has methods
-        if (hasMethods)
+        // Generate thenable wrapper class if this type has generated async members
+        if (hasMethods || getterOnlyProperties.Count > 0)
         {
             GenerateTypeClassThenableWrapper(model, allMethods);
         }
@@ -3294,13 +3374,29 @@ internal sealed class AtsTypeScriptCodeGenerator : ICodeGenerator
         var wrapperImplementationClassName = GetImplementationClassName(wrapperClassName);
 
         WriteLine($"    {propertyName} = {{");
-        WriteLine($"        get: async (): Promise<{wrapperClassName}> => {{");
-        WriteLine($"            const handle = await this._client.invokeCapability<{handleType}>(");
-        WriteLine($"                '{getter.CapabilityId}',");
-        WriteLine($"                {{ context: this._handle }}");
-        WriteLine("            );");
-        WriteLine($"            return new {wrapperImplementationClassName}(handle, this._client);");
-        WriteLine("        },");
+        if (TryGetPromiseWrapperType(getter.ReturnType, out var promiseInterfaceName, out var promiseImplementationClassName))
+        {
+            WriteLine($"        get: (): {promiseInterfaceName} => {{");
+            WriteLine("            const promise = (async () => {");
+            WriteLine($"                const handle = await this._client.invokeCapability<{handleType}>(");
+            WriteLine($"                    '{getter.CapabilityId}',");
+            WriteLine($"                    {{ context: this._handle }}");
+            WriteLine("                );");
+            WriteLine($"                return new {wrapperImplementationClassName}(handle, this._client);");
+            WriteLine("            })();");
+            WriteLine($"            return new {promiseImplementationClassName}(promise, this._client, false);");
+            WriteLine("        },");
+        }
+        else
+        {
+            WriteLine($"        get: async (): Promise<{wrapperClassName}> => {{");
+            WriteLine($"            const handle = await this._client.invokeCapability<{handleType}>(");
+            WriteLine($"                '{getter.CapabilityId}',");
+            WriteLine($"                {{ context: this._handle }}");
+            WriteLine("            );");
+            WriteLine($"            return new {wrapperImplementationClassName}(handle, this._client);");
+            WriteLine("        },");
+        }
 
         if (setter != null)
         {
@@ -3511,6 +3607,39 @@ internal sealed class AtsTypeScriptCodeGenerator : ICodeGenerator
             ? MapTypeRefToTypeScript(method.ReturnType)
             : "void";
 
+        if (TryGetPromiseWrapperType(method.ReturnType, out var returnPromiseInterfaceName, out var returnPromiseImplementationClassName))
+        {
+            var returnTypeId = method.ReturnType!.TypeId;
+            var returnClassName = GetConcreteClassName(returnTypeId);
+            var returnImplementationClassName = GetImplementationClassName(returnClassName);
+            var returnHandleType = GetHandleTypeName(returnTypeId);
+
+            WriteCapabilityDocComment("    ", method, requiredParams, hasOptionals ? publicOptionsParamName : null);
+            Write($"    {methodName}(");
+            Write(paramsString);
+            WriteLine($"): {returnPromiseInterfaceName} {{");
+            WriteLine("        const promise = (async () => {");
+
+            foreach (var param in hasDirectOptionsParameter ? [] : optionalParams)
+            {
+                var localParameterName = GetLocalParameterName(param);
+                WriteLine($"            {(IsWidenedHandleType(param.Type) ? "let" : "const")} {localParameterName} = {publicOptionsParamName}?.{param.Name};");
+            }
+
+            GenerateResolveAndBuildArgs(targetParamName, userParams, requiredParams, optionalParams, useSafeOptionalLocalNames: true, indent: "            ");
+
+            WriteLine($"            const handle = await this._client.invokeCapability<{returnHandleType}>(");
+            WriteLine($"                '{method.CapabilityId}',");
+            WriteLine("                rpcArgs");
+            WriteLine("            );");
+            WriteLine($"            return new {returnImplementationClassName}(handle, this._client);");
+            WriteLine("        })();");
+            WriteLine($"        return new {returnPromiseImplementationClassName}(promise, this._client);");
+            WriteLine("    }");
+            WriteLine();
+            return;
+        }
+
         // Generate async method
         WriteCapabilityDocComment("    ", method, requiredParams, hasOptionals ? publicOptionsParamName : null);
         Write($"    async {methodName}(");
@@ -3590,6 +3719,39 @@ internal sealed class AtsTypeScriptCodeGenerator : ICodeGenerator
 
         // Determine return type
         var returnType = MapTypeRefToTypeScript(capability.ReturnType);
+
+        if (TryGetPromiseWrapperType(capability.ReturnType, out var returnPromiseInterfaceName, out var returnPromiseImplementationClassName))
+        {
+            var returnTypeId = capability.ReturnType!.TypeId;
+            var returnClassName = GetConcreteClassName(returnTypeId);
+            var returnImplementationClassName = GetImplementationClassName(returnClassName);
+            var returnHandleType = GetHandleTypeName(returnTypeId);
+
+            WriteCapabilityDocComment("    ", capability, requiredParams, hasOptionals ? publicOptionsParamName : null);
+            Write($"    {methodName}(");
+            Write(paramsString);
+            WriteLine($"): {returnPromiseInterfaceName} {{");
+            WriteLine("        const promise = (async () => {");
+
+            foreach (var param in hasDirectOptionsParameter ? [] : optionalParams)
+            {
+                var localParameterName = GetLocalParameterName(param);
+                WriteLine($"            {(IsWidenedHandleType(param.Type) ? "let" : "const")} {localParameterName} = {publicOptionsParamName}?.{param.Name};");
+            }
+
+            GenerateResolveAndBuildArgs(firstParamName, userParams, requiredParams, optionalParams, useSafeOptionalLocalNames: true, indent: "            ");
+
+            WriteLine($"            const handle = await this._client.invokeCapability<{returnHandleType}>(");
+            WriteLine($"                '{capability.CapabilityId}',");
+            WriteLine("                rpcArgs");
+            WriteLine("            );");
+            WriteLine($"            return new {returnImplementationClassName}(handle, this._client);");
+            WriteLine("        })();");
+            WriteLine($"        return new {returnPromiseImplementationClassName}(promise, this._client);");
+            WriteLine("    }");
+            WriteLine();
+            return;
+        }
 
         // Generate async method
         WriteCapabilityDocComment("    ", capability, requiredParams, hasOptionals ? publicOptionsParamName : null);
@@ -4325,15 +4487,23 @@ internal sealed class AtsTypeScriptCodeGenerator : ICodeGenerator
     }
 
     /// <summary>
-    /// Determines if a type has chainable methods and should have a Promise wrapper.
-    /// Types with instance methods or wrapper methods get Promise wrappers.
+    /// Determines if a type has generated async members and should have a Promise wrapper.
+    /// Types with instance methods, wrapper methods, or getter-only properties get Promise wrappers.
     /// </summary>
     private static bool HasChainableMethods(BuilderModel model)
     {
-        // Check for instance methods (from ExposeMethods=true) or wrapper methods
-        return model.Capabilities.Any(c =>
+        var hasMethods = model.Capabilities.Any(c =>
             c.CapabilityKind == AtsCapabilityKind.InstanceMethod ||
             c.CapabilityKind == AtsCapabilityKind.Method);
+        if (hasMethods)
+        {
+            return true;
+        }
+
+        var getters = model.Capabilities.Where(c => c.CapabilityKind == AtsCapabilityKind.PropertyGetter).ToList();
+        var setters = model.Capabilities.Where(c => c.CapabilityKind == AtsCapabilityKind.PropertySetter).ToList();
+
+        return GroupPropertiesByName(getters, setters).Any(p => IsGetterOnlyProperty(p.Getter, p.Setter));
     }
 
     /// <summary>

--- a/tests/Aspire.Hosting.CodeGeneration.TypeScript.Tests/Snapshots/AtsGeneratedAspire.verified.ts
+++ b/tests/Aspire.Hosting.CodeGeneration.TypeScript.Tests/Snapshots/AtsGeneratedAspire.verified.ts
@@ -309,6 +309,13 @@ export interface TestCollectionContext {
     metadata(): Promise<AspireDict<string, string>>;
 }
 
+export interface TestCollectionContextPromise extends PromiseLike<TestCollectionContext> {
+    /** List property - should generate AspireList getter like Dictionary properties. */
+    items(): Promise<AspireList<string>>;
+    /** Dictionary property - already works with AspireDict getter. */
+    metadata(): Promise<AspireDict<string, string>>;
+}
+
 // ============================================================================
 // TestCollectionContextImpl
 // ============================================================================
@@ -344,6 +351,31 @@ class TestCollectionContextImpl implements TestCollectionContext {
             );
         }
         return this._metadata;
+    }
+
+}
+
+/**
+ * Thenable wrapper for TestCollectionContext that enables fluent chaining.
+ */
+class TestCollectionContextPromiseImpl implements TestCollectionContextPromise {
+    constructor(private _promise: Promise<TestCollectionContext>, private _client: AspireClientRpc, track = true) {
+        if (track) { _client.trackPromise(_promise); }
+    }
+
+    then<TResult1 = TestCollectionContext, TResult2 = never>(
+        onfulfilled?: ((value: TestCollectionContext) => TResult1 | PromiseLike<TResult1>) | null,
+        onrejected?: ((reason: unknown) => TResult2 | PromiseLike<TResult2>) | null
+    ): PromiseLike<TResult1 | TResult2> {
+        return this._promise.then(onfulfilled, onrejected);
+    }
+
+    items(): Promise<AspireList<string>> {
+        return this._promise.then(obj => obj.items());
+    }
+
+    metadata(): Promise<AspireDict<string, string>> {
+        return this._promise.then(obj => obj.metadata());
     }
 
 }
@@ -4029,5 +4061,4 @@ registerHandleWrapper('Aspire.Hosting.CodeGeneration.TypeScript.Tests/Aspire.Hos
 registerHandleWrapper('Aspire.Hosting/Aspire.Hosting.ApplicationModel.IResource', (handle, client) => new ResourceImpl(handle as IResourceHandle, client));
 registerHandleWrapper('Aspire.Hosting/Aspire.Hosting.ApplicationModel.IResourceWithConnectionString', (handle, client) => new ResourceWithConnectionStringImpl(handle as IResourceWithConnectionStringHandle, client));
 registerHandleWrapper('Aspire.Hosting/Aspire.Hosting.ApplicationModel.IResourceWithEnvironment', (handle, client) => new ResourceWithEnvironmentImpl(handle as IResourceWithEnvironmentHandle, client));
-
 

--- a/tests/Aspire.Hosting.CodeGeneration.TypeScript.Tests/Snapshots/TwoPassScanningGeneratedAspire.verified.ts
+++ b/tests/Aspire.Hosting.CodeGeneration.TypeScript.Tests/Snapshots/TwoPassScanningGeneratedAspire.verified.ts
@@ -1,4 +1,4 @@
-// aspire.mts - Capability-based Aspire SDK
+﻿// aspire.mts - Capability-based Aspire SDK
 // This SDK uses the ATS (Aspire Type System) capability API.
 // Capabilities are endpoints like 'Aspire.Hosting/createBuilder'.
 //
@@ -1542,6 +1542,13 @@ export interface AfterPublishEvent {
     model(): DistributedApplicationModelPromise;
 }
 
+export interface AfterPublishEventPromise extends PromiseLike<AfterPublishEvent> {
+    /** The `IServiceProvider` for the app host. */
+    services(): ServiceProviderPromise;
+    /** The `DistributedApplicationModel` instance. */
+    model(): DistributedApplicationModelPromise;
+}
+
 // ============================================================================
 // AfterPublishEventImpl
 // ============================================================================
@@ -1577,6 +1584,31 @@ class AfterPublishEventImpl implements AfterPublishEvent {
 
 }
 
+/**
+ * Thenable wrapper for AfterPublishEvent that enables fluent chaining.
+ */
+class AfterPublishEventPromiseImpl implements AfterPublishEventPromise {
+    constructor(private _promise: Promise<AfterPublishEvent>, private _client: AspireClientRpc, track = true) {
+        if (track) { _client.trackPromise(_promise); }
+    }
+
+    then<TResult1 = AfterPublishEvent, TResult2 = never>(
+        onfulfilled?: ((value: AfterPublishEvent) => TResult1 | PromiseLike<TResult1>) | null,
+        onrejected?: ((reason: unknown) => TResult2 | PromiseLike<TResult2>) | null
+    ): PromiseLike<TResult1 | TResult2> {
+        return this._promise.then(onfulfilled, onrejected);
+    }
+
+    services(): ServiceProviderPromise {
+        return new ServiceProviderPromiseImpl(this._promise.then(obj => obj.services()), this._client, false);
+    }
+
+    model(): DistributedApplicationModelPromise {
+        return new DistributedApplicationModelPromiseImpl(this._promise.then(obj => obj.model()), this._client, false);
+    }
+
+}
+
 // ============================================================================
 // AfterResourcesCreatedEvent
 // ============================================================================
@@ -1591,6 +1623,13 @@ class AfterPublishEventImpl implements AfterPublishEvent {
  */
 export interface AfterResourcesCreatedEvent {
     toJSON(): MarshalledHandle;
+    /** The `IServiceProvider` instance. */
+    services(): ServiceProviderPromise;
+    /** The `DistributedApplicationModel` instance. */
+    model(): DistributedApplicationModelPromise;
+}
+
+export interface AfterResourcesCreatedEventPromise extends PromiseLike<AfterResourcesCreatedEvent> {
     /** The `IServiceProvider` instance. */
     services(): ServiceProviderPromise;
     /** The `DistributedApplicationModel` instance. */
@@ -1639,6 +1678,31 @@ class AfterResourcesCreatedEventImpl implements AfterResourcesCreatedEvent {
 
 }
 
+/**
+ * Thenable wrapper for AfterResourcesCreatedEvent that enables fluent chaining.
+ */
+class AfterResourcesCreatedEventPromiseImpl implements AfterResourcesCreatedEventPromise {
+    constructor(private _promise: Promise<AfterResourcesCreatedEvent>, private _client: AspireClientRpc, track = true) {
+        if (track) { _client.trackPromise(_promise); }
+    }
+
+    then<TResult1 = AfterResourcesCreatedEvent, TResult2 = never>(
+        onfulfilled?: ((value: AfterResourcesCreatedEvent) => TResult1 | PromiseLike<TResult1>) | null,
+        onrejected?: ((reason: unknown) => TResult2 | PromiseLike<TResult2>) | null
+    ): PromiseLike<TResult1 | TResult2> {
+        return this._promise.then(onfulfilled, onrejected);
+    }
+
+    services(): ServiceProviderPromise {
+        return new ServiceProviderPromiseImpl(this._promise.then(obj => obj.services()), this._client, false);
+    }
+
+    model(): DistributedApplicationModelPromise {
+        return new DistributedApplicationModelPromiseImpl(this._promise.then(obj => obj.model()), this._client, false);
+    }
+
+}
+
 // ============================================================================
 // BeforePublishEvent
 // ============================================================================
@@ -1646,6 +1710,13 @@ class AfterResourcesCreatedEventImpl implements AfterResourcesCreatedEvent {
 /** This event is published before the distributed application is published. */
 export interface BeforePublishEvent {
     toJSON(): MarshalledHandle;
+    /** The `IServiceProvider` for the app host. */
+    services(): ServiceProviderPromise;
+    /** The `DistributedApplicationModel` instance. */
+    model(): DistributedApplicationModelPromise;
+}
+
+export interface BeforePublishEventPromise extends PromiseLike<BeforePublishEvent> {
     /** The `IServiceProvider` for the app host. */
     services(): ServiceProviderPromise;
     /** The `DistributedApplicationModel` instance. */
@@ -1687,6 +1758,31 @@ class BeforePublishEventImpl implements BeforePublishEvent {
 
 }
 
+/**
+ * Thenable wrapper for BeforePublishEvent that enables fluent chaining.
+ */
+class BeforePublishEventPromiseImpl implements BeforePublishEventPromise {
+    constructor(private _promise: Promise<BeforePublishEvent>, private _client: AspireClientRpc, track = true) {
+        if (track) { _client.trackPromise(_promise); }
+    }
+
+    then<TResult1 = BeforePublishEvent, TResult2 = never>(
+        onfulfilled?: ((value: BeforePublishEvent) => TResult1 | PromiseLike<TResult1>) | null,
+        onrejected?: ((reason: unknown) => TResult2 | PromiseLike<TResult2>) | null
+    ): PromiseLike<TResult1 | TResult2> {
+        return this._promise.then(onfulfilled, onrejected);
+    }
+
+    services(): ServiceProviderPromise {
+        return new ServiceProviderPromiseImpl(this._promise.then(obj => obj.services()), this._client, false);
+    }
+
+    model(): DistributedApplicationModelPromise {
+        return new DistributedApplicationModelPromiseImpl(this._promise.then(obj => obj.model()), this._client, false);
+    }
+
+}
+
 // ============================================================================
 // BeforeResourceStartedEvent
 // ============================================================================
@@ -1698,6 +1794,13 @@ class BeforePublishEventImpl implements BeforePublishEvent {
  */
 export interface BeforeResourceStartedEvent {
     toJSON(): MarshalledHandle;
+    /** Gets the Resource property */
+    resource(): ResourcePromise;
+    /** Gets the Services property */
+    services(): ServiceProviderPromise;
+}
+
+export interface BeforeResourceStartedEventPromise extends PromiseLike<BeforeResourceStartedEvent> {
     /** Gets the Resource property */
     resource(): ResourcePromise;
     /** Gets the Services property */
@@ -1743,6 +1846,31 @@ class BeforeResourceStartedEventImpl implements BeforeResourceStartedEvent {
 
 }
 
+/**
+ * Thenable wrapper for BeforeResourceStartedEvent that enables fluent chaining.
+ */
+class BeforeResourceStartedEventPromiseImpl implements BeforeResourceStartedEventPromise {
+    constructor(private _promise: Promise<BeforeResourceStartedEvent>, private _client: AspireClientRpc, track = true) {
+        if (track) { _client.trackPromise(_promise); }
+    }
+
+    then<TResult1 = BeforeResourceStartedEvent, TResult2 = never>(
+        onfulfilled?: ((value: BeforeResourceStartedEvent) => TResult1 | PromiseLike<TResult1>) | null,
+        onrejected?: ((reason: unknown) => TResult2 | PromiseLike<TResult2>) | null
+    ): PromiseLike<TResult1 | TResult2> {
+        return this._promise.then(onfulfilled, onrejected);
+    }
+
+    resource(): ResourcePromise {
+        return new ResourcePromiseImpl(this._promise.then(obj => obj.resource()), this._client, false);
+    }
+
+    services(): ServiceProviderPromise {
+        return new ServiceProviderPromiseImpl(this._promise.then(obj => obj.services()), this._client, false);
+    }
+
+}
+
 // ============================================================================
 // BeforeStartEvent
 // ============================================================================
@@ -1757,6 +1885,13 @@ class BeforeResourceStartedEventImpl implements BeforeResourceStartedEvent {
  */
 export interface BeforeStartEvent {
     toJSON(): MarshalledHandle;
+    /** The `IServiceProvider` instance. */
+    services(): ServiceProviderPromise;
+    /** The `DistributedApplicationModel` instance. */
+    model(): DistributedApplicationModelPromise;
+}
+
+export interface BeforeStartEventPromise extends PromiseLike<BeforeStartEvent> {
     /** The `IServiceProvider` instance. */
     services(): ServiceProviderPromise;
     /** The `DistributedApplicationModel` instance. */
@@ -1805,6 +1940,31 @@ class BeforeStartEventImpl implements BeforeStartEvent {
 
 }
 
+/**
+ * Thenable wrapper for BeforeStartEvent that enables fluent chaining.
+ */
+class BeforeStartEventPromiseImpl implements BeforeStartEventPromise {
+    constructor(private _promise: Promise<BeforeStartEvent>, private _client: AspireClientRpc, track = true) {
+        if (track) { _client.trackPromise(_promise); }
+    }
+
+    then<TResult1 = BeforeStartEvent, TResult2 = never>(
+        onfulfilled?: ((value: BeforeStartEvent) => TResult1 | PromiseLike<TResult1>) | null,
+        onrejected?: ((reason: unknown) => TResult2 | PromiseLike<TResult2>) | null
+    ): PromiseLike<TResult1 | TResult2> {
+        return this._promise.then(onfulfilled, onrejected);
+    }
+
+    services(): ServiceProviderPromise {
+        return new ServiceProviderPromiseImpl(this._promise.then(obj => obj.services()), this._client, false);
+    }
+
+    model(): DistributedApplicationModelPromise {
+        return new DistributedApplicationModelPromiseImpl(this._promise.then(obj => obj.model()), this._client, false);
+    }
+
+}
+
 // ============================================================================
 // CommandLineArgsCallbackContext
 // ============================================================================
@@ -1823,7 +1983,22 @@ export interface CommandLineArgsCallbackContext {
      */
     resource(): ResourcePromise;
     /** Gets the execution context associated with this callback. */
-    executionContext(): Promise<DistributedApplicationExecutionContext>;
+    executionContext(): DistributedApplicationExecutionContextPromise;
+}
+
+export interface CommandLineArgsCallbackContextPromise extends PromiseLike<CommandLineArgsCallbackContext> {
+    /** Gets the editor used to manipulate command-line arguments in polyglot callbacks. */
+    args(): CommandLineArgsEditorPromise;
+    /** Gets the logger facade used by polyglot callbacks. */
+    log(): LogFacadePromise;
+    /**
+     * The resource associated with this callback context.
+     *
+     * This will be set to the resource in all cases where Aspire invokes the callback.
+     */
+    resource(): ResourcePromise;
+    /** Gets the execution context associated with this callback. */
+    executionContext(): DistributedApplicationExecutionContextPromise;
 }
 
 // ============================================================================
@@ -1870,12 +2045,48 @@ class CommandLineArgsCallbackContextImpl implements CommandLineArgsCallbackConte
         return new ResourcePromiseImpl(promise, this._client, false);
     }
 
-    async executionContext(): Promise<DistributedApplicationExecutionContext> {
-        const handle = await this._client.invokeCapability<DistributedApplicationExecutionContextHandle>(
-            'Aspire.Hosting.ApplicationModel/CommandLineArgsCallbackContext.executionContext',
-            { context: this._handle }
-        );
-        return new DistributedApplicationExecutionContextImpl(handle, this._client);
+    executionContext(): DistributedApplicationExecutionContextPromise {
+        const promise = (async () => {
+            const handle = await this._client.invokeCapability<DistributedApplicationExecutionContextHandle>(
+                'Aspire.Hosting.ApplicationModel/CommandLineArgsCallbackContext.executionContext',
+                { context: this._handle }
+            );
+            return new DistributedApplicationExecutionContextImpl(handle, this._client);
+        })();
+        return new DistributedApplicationExecutionContextPromiseImpl(promise, this._client, false);
+    }
+
+}
+
+/**
+ * Thenable wrapper for CommandLineArgsCallbackContext that enables fluent chaining.
+ */
+class CommandLineArgsCallbackContextPromiseImpl implements CommandLineArgsCallbackContextPromise {
+    constructor(private _promise: Promise<CommandLineArgsCallbackContext>, private _client: AspireClientRpc, track = true) {
+        if (track) { _client.trackPromise(_promise); }
+    }
+
+    then<TResult1 = CommandLineArgsCallbackContext, TResult2 = never>(
+        onfulfilled?: ((value: CommandLineArgsCallbackContext) => TResult1 | PromiseLike<TResult1>) | null,
+        onrejected?: ((reason: unknown) => TResult2 | PromiseLike<TResult2>) | null
+    ): PromiseLike<TResult1 | TResult2> {
+        return this._promise.then(onfulfilled, onrejected);
+    }
+
+    args(): CommandLineArgsEditorPromise {
+        return new CommandLineArgsEditorPromiseImpl(this._promise.then(obj => obj.args()), this._client, false);
+    }
+
+    log(): LogFacadePromise {
+        return new LogFacadePromiseImpl(this._promise.then(obj => obj.log()), this._client, false);
+    }
+
+    resource(): ResourcePromise {
+        return new ResourcePromiseImpl(this._promise.then(obj => obj.resource()), this._client, false);
+    }
+
+    executionContext(): DistributedApplicationExecutionContextPromise {
+        return new DistributedApplicationExecutionContextPromiseImpl(this._promise.then(obj => obj.executionContext()), this._client, false);
     }
 
 }
@@ -1968,6 +2179,13 @@ export interface ConnectionStringAvailableEvent {
     services(): ServiceProviderPromise;
 }
 
+export interface ConnectionStringAvailableEventPromise extends PromiseLike<ConnectionStringAvailableEvent> {
+    /** Gets the Resource property */
+    resource(): ResourcePromise;
+    /** Gets the Services property */
+    services(): ServiceProviderPromise;
+}
+
 // ============================================================================
 // ConnectionStringAvailableEventImpl
 // ============================================================================
@@ -1999,6 +2217,31 @@ class ConnectionStringAvailableEventImpl implements ConnectionStringAvailableEve
             return new ServiceProviderImpl(handle, this._client);
         })();
         return new ServiceProviderPromiseImpl(promise, this._client, false);
+    }
+
+}
+
+/**
+ * Thenable wrapper for ConnectionStringAvailableEvent that enables fluent chaining.
+ */
+class ConnectionStringAvailableEventPromiseImpl implements ConnectionStringAvailableEventPromise {
+    constructor(private _promise: Promise<ConnectionStringAvailableEvent>, private _client: AspireClientRpc, track = true) {
+        if (track) { _client.trackPromise(_promise); }
+    }
+
+    then<TResult1 = ConnectionStringAvailableEvent, TResult2 = never>(
+        onfulfilled?: ((value: ConnectionStringAvailableEvent) => TResult1 | PromiseLike<TResult1>) | null,
+        onrejected?: ((reason: unknown) => TResult2 | PromiseLike<TResult2>) | null
+    ): PromiseLike<TResult1 | TResult2> {
+        return this._promise.then(onfulfilled, onrejected);
+    }
+
+    resource(): ResourcePromise {
+        return new ResourcePromiseImpl(this._promise.then(obj => obj.resource()), this._client, false);
+    }
+
+    services(): ServiceProviderPromise {
+        return new ServiceProviderPromiseImpl(this._promise.then(obj => obj.services()), this._client, false);
     }
 
 }
@@ -2094,6 +2337,15 @@ export interface ContainerImagePushOptionsCallbackContext {
     options(): Promise<ContainerImagePushOptions>;
 }
 
+export interface ContainerImagePushOptionsCallbackContextPromise extends PromiseLike<ContainerImagePushOptionsCallbackContext> {
+    /** Gets the resource being configured for container image push operations. */
+    resource(): ResourcePromise;
+    /** Gets the cancellation token to observe while configuring image push options. */
+    cancellationToken(): Promise<CancellationToken>;
+    /** Gets the container image push options that can be modified by the callback. */
+    options(): Promise<ContainerImagePushOptions>;
+}
+
 // ============================================================================
 // ContainerImagePushOptionsCallbackContextImpl
 // ============================================================================
@@ -2134,6 +2386,35 @@ class ContainerImagePushOptionsCallbackContextImpl implements ContainerImagePush
 
 }
 
+/**
+ * Thenable wrapper for ContainerImagePushOptionsCallbackContext that enables fluent chaining.
+ */
+class ContainerImagePushOptionsCallbackContextPromiseImpl implements ContainerImagePushOptionsCallbackContextPromise {
+    constructor(private _promise: Promise<ContainerImagePushOptionsCallbackContext>, private _client: AspireClientRpc, track = true) {
+        if (track) { _client.trackPromise(_promise); }
+    }
+
+    then<TResult1 = ContainerImagePushOptionsCallbackContext, TResult2 = never>(
+        onfulfilled?: ((value: ContainerImagePushOptionsCallbackContext) => TResult1 | PromiseLike<TResult1>) | null,
+        onrejected?: ((reason: unknown) => TResult2 | PromiseLike<TResult2>) | null
+    ): PromiseLike<TResult1 | TResult2> {
+        return this._promise.then(onfulfilled, onrejected);
+    }
+
+    resource(): ResourcePromise {
+        return new ResourcePromiseImpl(this._promise.then(obj => obj.resource()), this._client, false);
+    }
+
+    cancellationToken(): Promise<CancellationToken> {
+        return this._promise.then(obj => obj.cancellationToken());
+    }
+
+    options(): Promise<ContainerImagePushOptions> {
+        return this._promise.then(obj => obj.options());
+    }
+
+}
+
 // ============================================================================
 // ContainerImageReference
 // ============================================================================
@@ -2141,6 +2422,13 @@ class ContainerImagePushOptionsCallbackContextImpl implements ContainerImagePush
 /** Represents the fully‑qualified container image reference that should be deployed. */
 export interface ContainerImageReference {
     toJSON(): MarshalledHandle;
+    /** Gets the resource that this container image is associated with. */
+    resource(): ResourcePromise;
+    /** Gets the ValueExpression property */
+    valueExpression(): Promise<string>;
+}
+
+export interface ContainerImageReferencePromise extends PromiseLike<ContainerImageReference> {
     /** Gets the resource that this container image is associated with. */
     resource(): ResourcePromise;
     /** Gets the ValueExpression property */
@@ -2178,6 +2466,31 @@ class ContainerImageReferenceImpl implements ContainerImageReference {
 
 }
 
+/**
+ * Thenable wrapper for ContainerImageReference that enables fluent chaining.
+ */
+class ContainerImageReferencePromiseImpl implements ContainerImageReferencePromise {
+    constructor(private _promise: Promise<ContainerImageReference>, private _client: AspireClientRpc, track = true) {
+        if (track) { _client.trackPromise(_promise); }
+    }
+
+    then<TResult1 = ContainerImageReference, TResult2 = never>(
+        onfulfilled?: ((value: ContainerImageReference) => TResult1 | PromiseLike<TResult1>) | null,
+        onrejected?: ((reason: unknown) => TResult2 | PromiseLike<TResult2>) | null
+    ): PromiseLike<TResult1 | TResult2> {
+        return this._promise.then(onfulfilled, onrejected);
+    }
+
+    resource(): ResourcePromise {
+        return new ResourcePromiseImpl(this._promise.then(obj => obj.resource()), this._client, false);
+    }
+
+    valueExpression(): Promise<string> {
+        return this._promise.then(obj => obj.valueExpression());
+    }
+
+}
+
 // ============================================================================
 // ContainerMountAnnotation
 // ============================================================================
@@ -2185,6 +2498,17 @@ class ContainerImageReferenceImpl implements ContainerImageReference {
 /** Represents a mount annotation for a container resource. */
 export interface ContainerMountAnnotation {
     toJSON(): MarshalledHandle;
+    /** Gets the source of the bind mount or name if a volume. Can be `null` if the mount is an anonymous volume. */
+    source(): Promise<string | null>;
+    /** Gets the target of the mount. */
+    target(): Promise<string>;
+    /** Gets the type of the mount. */
+    type(): Promise<ContainerMountType>;
+    /** Gets a value indicating whether the volume mount is read-only. */
+    isReadOnly(): Promise<boolean>;
+}
+
+export interface ContainerMountAnnotationPromise extends PromiseLike<ContainerMountAnnotation> {
     /** Gets the source of the bind mount or name if a volume. Can be `null` if the mount is an anonymous volume. */
     source(): Promise<string | null>;
     /** Gets the target of the mount. */
@@ -2236,6 +2560,39 @@ class ContainerMountAnnotationImpl implements ContainerMountAnnotation {
 
 }
 
+/**
+ * Thenable wrapper for ContainerMountAnnotation that enables fluent chaining.
+ */
+class ContainerMountAnnotationPromiseImpl implements ContainerMountAnnotationPromise {
+    constructor(private _promise: Promise<ContainerMountAnnotation>, private _client: AspireClientRpc, track = true) {
+        if (track) { _client.trackPromise(_promise); }
+    }
+
+    then<TResult1 = ContainerMountAnnotation, TResult2 = never>(
+        onfulfilled?: ((value: ContainerMountAnnotation) => TResult1 | PromiseLike<TResult1>) | null,
+        onrejected?: ((reason: unknown) => TResult2 | PromiseLike<TResult2>) | null
+    ): PromiseLike<TResult1 | TResult2> {
+        return this._promise.then(onfulfilled, onrejected);
+    }
+
+    source(): Promise<string | null> {
+        return this._promise.then(obj => obj.source());
+    }
+
+    target(): Promise<string> {
+        return this._promise.then(obj => obj.target());
+    }
+
+    type(): Promise<ContainerMountType> {
+        return this._promise.then(obj => obj.type());
+    }
+
+    isReadOnly(): Promise<boolean> {
+        return this._promise.then(obj => obj.isReadOnly());
+    }
+
+}
+
 // ============================================================================
 // ContainerPortReference
 // ============================================================================
@@ -2243,6 +2600,13 @@ class ContainerMountAnnotationImpl implements ContainerMountAnnotation {
 /** Represents a TCP/UDP port that a container can expose. */
 export interface ContainerPortReference {
     toJSON(): MarshalledHandle;
+    /** Gets the resource that this container port is associated with. */
+    resource(): ResourcePromise;
+    /** Gets the ValueExpression property */
+    valueExpression(): Promise<string>;
+}
+
+export interface ContainerPortReferencePromise extends PromiseLike<ContainerPortReference> {
     /** Gets the resource that this container port is associated with. */
     resource(): ResourcePromise;
     /** Gets the ValueExpression property */
@@ -2276,6 +2640,31 @@ class ContainerPortReferenceImpl implements ContainerPortReference {
             'Aspire.Hosting.ApplicationModel/ContainerPortReference.valueExpression',
             { context: this._handle }
         );
+    }
+
+}
+
+/**
+ * Thenable wrapper for ContainerPortReference that enables fluent chaining.
+ */
+class ContainerPortReferencePromiseImpl implements ContainerPortReferencePromise {
+    constructor(private _promise: Promise<ContainerPortReference>, private _client: AspireClientRpc, track = true) {
+        if (track) { _client.trackPromise(_promise); }
+    }
+
+    then<TResult1 = ContainerPortReference, TResult2 = never>(
+        onfulfilled?: ((value: ContainerPortReference) => TResult1 | PromiseLike<TResult1>) | null,
+        onrejected?: ((reason: unknown) => TResult2 | PromiseLike<TResult2>) | null
+    ): PromiseLike<TResult1 | TResult2> {
+        return this._promise.then(onfulfilled, onrejected);
+    }
+
+    resource(): ResourcePromise {
+        return new ResourcePromiseImpl(this._promise.then(obj => obj.resource()), this._client, false);
+    }
+
+    valueExpression(): Promise<string> {
+        return this._promise.then(obj => obj.valueExpression());
     }
 
 }
@@ -2405,6 +2794,17 @@ export interface DistributedApplicationExecutionContext {
     isRunMode(): Promise<boolean>;
 }
 
+export interface DistributedApplicationExecutionContextPromise extends PromiseLike<DistributedApplicationExecutionContext> {
+    /** The operation currently being performed by the AppHost. */
+    operation(): Promise<DistributedApplicationOperation>;
+    /** The `IServiceProvider` for the AppHost. */
+    serviceProvider(): ServiceProviderPromise;
+    /** Returns true if the current operation is publishing. */
+    isPublishMode(): Promise<boolean>;
+    /** Returns true if the current operation is running. */
+    isRunMode(): Promise<boolean>;
+}
+
 // ============================================================================
 // DistributedApplicationExecutionContextImpl
 // ============================================================================
@@ -2461,6 +2861,39 @@ class DistributedApplicationExecutionContextImpl implements DistributedApplicati
             'Aspire.Hosting/DistributedApplicationExecutionContext.isRunMode',
             { context: this._handle }
         );
+    }
+
+}
+
+/**
+ * Thenable wrapper for DistributedApplicationExecutionContext that enables fluent chaining.
+ */
+class DistributedApplicationExecutionContextPromiseImpl implements DistributedApplicationExecutionContextPromise {
+    constructor(private _promise: Promise<DistributedApplicationExecutionContext>, private _client: AspireClientRpc, track = true) {
+        if (track) { _client.trackPromise(_promise); }
+    }
+
+    then<TResult1 = DistributedApplicationExecutionContext, TResult2 = never>(
+        onfulfilled?: ((value: DistributedApplicationExecutionContext) => TResult1 | PromiseLike<TResult1>) | null,
+        onrejected?: ((reason: unknown) => TResult2 | PromiseLike<TResult2>) | null
+    ): PromiseLike<TResult1 | TResult2> {
+        return this._promise.then(onfulfilled, onrejected);
+    }
+
+    operation(): Promise<DistributedApplicationOperation> {
+        return this._promise.then(obj => obj.operation());
+    }
+
+    serviceProvider(): ServiceProviderPromise {
+        return new ServiceProviderPromiseImpl(this._promise.then(obj => obj.serviceProvider()), this._client, false);
+    }
+
+    isPublishMode(): Promise<boolean> {
+        return this._promise.then(obj => obj.isPublishMode());
+    }
+
+    isRunMode(): Promise<boolean> {
+        return this._promise.then(obj => obj.isRunMode());
     }
 
 }
@@ -2731,6 +3164,17 @@ export interface DockerfileBuilderCallbackContext {
     cancellationToken(): Promise<CancellationToken>;
 }
 
+export interface DockerfileBuilderCallbackContextPromise extends PromiseLike<DockerfileBuilderCallbackContext> {
+    /** Gets the resource being built. */
+    resource(): ResourcePromise;
+    /** Gets the Dockerfile builder instance. */
+    builder(): DockerfileBuilderPromise;
+    /** Gets the service provider for dependency injection. */
+    services(): ServiceProviderPromise;
+    /** Gets the cancellation token to observe while waiting for the task to complete. */
+    cancellationToken(): Promise<CancellationToken>;
+}
+
 // ============================================================================
 // DockerfileBuilderCallbackContextImpl
 // ============================================================================
@@ -2781,6 +3225,39 @@ class DockerfileBuilderCallbackContextImpl implements DockerfileBuilderCallbackC
             { context: this._handle }
         );
         return CancellationToken.fromValue(result);
+    }
+
+}
+
+/**
+ * Thenable wrapper for DockerfileBuilderCallbackContext that enables fluent chaining.
+ */
+class DockerfileBuilderCallbackContextPromiseImpl implements DockerfileBuilderCallbackContextPromise {
+    constructor(private _promise: Promise<DockerfileBuilderCallbackContext>, private _client: AspireClientRpc, track = true) {
+        if (track) { _client.trackPromise(_promise); }
+    }
+
+    then<TResult1 = DockerfileBuilderCallbackContext, TResult2 = never>(
+        onfulfilled?: ((value: DockerfileBuilderCallbackContext) => TResult1 | PromiseLike<TResult1>) | null,
+        onrejected?: ((reason: unknown) => TResult2 | PromiseLike<TResult2>) | null
+    ): PromiseLike<TResult1 | TResult2> {
+        return this._promise.then(onfulfilled, onrejected);
+    }
+
+    resource(): ResourcePromise {
+        return new ResourcePromiseImpl(this._promise.then(obj => obj.resource()), this._client, false);
+    }
+
+    builder(): DockerfileBuilderPromise {
+        return new DockerfileBuilderPromiseImpl(this._promise.then(obj => obj.builder()), this._client, false);
+    }
+
+    services(): ServiceProviderPromise {
+        return new ServiceProviderPromiseImpl(this._promise.then(obj => obj.services()), this._client, false);
+    }
+
+    cancellationToken(): Promise<CancellationToken> {
+        return this._promise.then(obj => obj.cancellationToken());
     }
 
 }
@@ -3253,7 +3730,7 @@ export interface EndpointReference {
      * @param property The `EndpointProperty` enum value to use in the reference.
      * @returns An `EndpointReferenceExpression` representing the specified `EndpointProperty`.
      */
-    property(property: EndpointProperty): Promise<EndpointReferenceExpression>;
+    property(property: EndpointProperty): EndpointReferenceExpressionPromise;
     /**
      * Gets a conditional expression that resolves to the enabledValue when TLS is enabled on the endpoint, or to the disabledValue otherwise.
      *
@@ -3320,7 +3797,7 @@ export interface EndpointReferencePromise extends PromiseLike<EndpointReference>
      * @param property The `EndpointProperty` enum value to use in the reference.
      * @returns An `EndpointReferenceExpression` representing the specified `EndpointProperty`.
      */
-    property(property: EndpointProperty): Promise<EndpointReferenceExpression>;
+    property(property: EndpointProperty): EndpointReferenceExpressionPromise;
     /**
      * Gets a conditional expression that resolves to the enabledValue when TLS is enabled on the endpoint, or to the disabledValue otherwise.
      *
@@ -3470,17 +3947,23 @@ class EndpointReferenceImpl implements EndpointReference {
         );
     }
 
+    /** @internal */
+    async _propertyInternal(property: EndpointProperty): Promise<EndpointReferenceExpression> {
+        const rpcArgs: Record<string, unknown> = { context: this._handle, property };
+        const result = await this._client.invokeCapability<EndpointReferenceExpressionHandle>(
+            'Aspire.Hosting.ApplicationModel/EndpointReference.property',
+            rpcArgs
+        );
+        return new EndpointReferenceExpressionImpl(result, this._client);
+    }
+
     /**
      * Gets the specified property expression of the endpoint.
      * @param property The `EndpointProperty` enum value to use in the reference.
      * @returns An `EndpointReferenceExpression` representing the specified `EndpointProperty`.
      */
-    async property(property: EndpointProperty): Promise<EndpointReferenceExpression> {
-        const rpcArgs: Record<string, unknown> = { context: this._handle, property };
-        return await this._client.invokeCapability<EndpointReferenceExpression>(
-            'Aspire.Hosting.ApplicationModel/EndpointReference.property',
-            rpcArgs
-        );
+    property(property: EndpointProperty): EndpointReferenceExpressionPromise {
+        return new EndpointReferenceExpressionPromiseImpl(this._propertyInternal(property), this._client);
     }
 
     /**
@@ -3583,8 +4066,8 @@ class EndpointReferencePromiseImpl implements EndpointReferencePromise {
         return this._promise.then(obj => obj.getValueAsync(options));
     }
 
-    property(property: EndpointProperty): Promise<EndpointReferenceExpression> {
-        return this._promise.then(obj => obj.property(property));
+    property(property: EndpointProperty): EndpointReferenceExpressionPromise {
+        return new EndpointReferenceExpressionPromiseImpl(this._promise.then(obj => obj.property(property)), this._client);
     }
 
     getTlsValue(enabledValue: ReferenceExpression, disabledValue: ReferenceExpression): Promise<ReferenceExpression> {
@@ -3600,6 +4083,15 @@ class EndpointReferencePromiseImpl implements EndpointReferencePromise {
 /** Represents a property expression for an endpoint reference. */
 export interface EndpointReferenceExpression {
     toJSON(): MarshalledHandle;
+    /** Gets the `EndpointReference`. */
+    endpoint(): EndpointReferencePromise;
+    /** Gets the `EndpointProperty` for the property expression. */
+    property(): Promise<EndpointProperty>;
+    /** Gets the expression of the property of the endpoint. */
+    valueExpression(): Promise<string>;
+}
+
+export interface EndpointReferenceExpressionPromise extends PromiseLike<EndpointReferenceExpression> {
     /** Gets the `EndpointReference`. */
     endpoint(): EndpointReferencePromise;
     /** Gets the `EndpointProperty` for the property expression. */
@@ -3642,6 +4134,35 @@ class EndpointReferenceExpressionImpl implements EndpointReferenceExpression {
             'Aspire.Hosting.ApplicationModel/EndpointReferenceExpression.valueExpression',
             { context: this._handle }
         );
+    }
+
+}
+
+/**
+ * Thenable wrapper for EndpointReferenceExpression that enables fluent chaining.
+ */
+class EndpointReferenceExpressionPromiseImpl implements EndpointReferenceExpressionPromise {
+    constructor(private _promise: Promise<EndpointReferenceExpression>, private _client: AspireClientRpc, track = true) {
+        if (track) { _client.trackPromise(_promise); }
+    }
+
+    then<TResult1 = EndpointReferenceExpression, TResult2 = never>(
+        onfulfilled?: ((value: EndpointReferenceExpression) => TResult1 | PromiseLike<TResult1>) | null,
+        onrejected?: ((reason: unknown) => TResult2 | PromiseLike<TResult2>) | null
+    ): PromiseLike<TResult1 | TResult2> {
+        return this._promise.then(onfulfilled, onrejected);
+    }
+
+    endpoint(): EndpointReferencePromise {
+        return new EndpointReferencePromiseImpl(this._promise.then(obj => obj.endpoint()), this._client, false);
+    }
+
+    property(): Promise<EndpointProperty> {
+        return this._promise.then(obj => obj.property());
+    }
+
+    valueExpression(): Promise<string> {
+        return this._promise.then(obj => obj.valueExpression());
     }
 
 }
@@ -3705,6 +4226,11 @@ export interface EndpointUpdateContext {
         get: () => Promise<boolean>;
         set: (value: boolean) => Promise<void>;
     };
+}
+
+export interface EndpointUpdateContextPromise extends PromiseLike<EndpointUpdateContext> {
+    /** Gets the endpoint name. */
+    name(): Promise<string>;
 }
 
 // ============================================================================
@@ -3877,6 +4403,27 @@ class EndpointUpdateContextImpl implements EndpointUpdateContext {
 
 }
 
+/**
+ * Thenable wrapper for EndpointUpdateContext that enables fluent chaining.
+ */
+class EndpointUpdateContextPromiseImpl implements EndpointUpdateContextPromise {
+    constructor(private _promise: Promise<EndpointUpdateContext>, private _client: AspireClientRpc, track = true) {
+        if (track) { _client.trackPromise(_promise); }
+    }
+
+    then<TResult1 = EndpointUpdateContext, TResult2 = never>(
+        onfulfilled?: ((value: EndpointUpdateContext) => TResult1 | PromiseLike<TResult1>) | null,
+        onrejected?: ((reason: unknown) => TResult2 | PromiseLike<TResult2>) | null
+    ): PromiseLike<TResult1 | TResult2> {
+        return this._promise.then(onfulfilled, onrejected);
+    }
+
+    name(): Promise<string> {
+        return this._promise.then(obj => obj.name());
+    }
+
+}
+
 // ============================================================================
 // EnvironmentCallbackContext
 // ============================================================================
@@ -3895,7 +4442,22 @@ export interface EnvironmentCallbackContext {
      */
     resource(): ResourcePromise;
     /** Gets the execution context associated with this invocation of the AppHost. */
-    executionContext(): Promise<DistributedApplicationExecutionContext>;
+    executionContext(): DistributedApplicationExecutionContextPromise;
+}
+
+export interface EnvironmentCallbackContextPromise extends PromiseLike<EnvironmentCallbackContext> {
+    /** Gets the editor used to set environment variables in polyglot callbacks. */
+    environment(): EnvironmentEditorPromise;
+    /** Gets the logger facade used by polyglot callbacks. */
+    log(): LogFacadePromise;
+    /**
+     * The resource associated with this callback context.
+     *
+     * This will be set to the resource in all cases where Aspire invokes the callback.
+     */
+    resource(): ResourcePromise;
+    /** Gets the execution context associated with this invocation of the AppHost. */
+    executionContext(): DistributedApplicationExecutionContextPromise;
 }
 
 // ============================================================================
@@ -3942,12 +4504,48 @@ class EnvironmentCallbackContextImpl implements EnvironmentCallbackContext {
         return new ResourcePromiseImpl(promise, this._client, false);
     }
 
-    async executionContext(): Promise<DistributedApplicationExecutionContext> {
-        const handle = await this._client.invokeCapability<DistributedApplicationExecutionContextHandle>(
-            'Aspire.Hosting.ApplicationModel/EnvironmentCallbackContext.executionContext',
-            { context: this._handle }
-        );
-        return new DistributedApplicationExecutionContextImpl(handle, this._client);
+    executionContext(): DistributedApplicationExecutionContextPromise {
+        const promise = (async () => {
+            const handle = await this._client.invokeCapability<DistributedApplicationExecutionContextHandle>(
+                'Aspire.Hosting.ApplicationModel/EnvironmentCallbackContext.executionContext',
+                { context: this._handle }
+            );
+            return new DistributedApplicationExecutionContextImpl(handle, this._client);
+        })();
+        return new DistributedApplicationExecutionContextPromiseImpl(promise, this._client, false);
+    }
+
+}
+
+/**
+ * Thenable wrapper for EnvironmentCallbackContext that enables fluent chaining.
+ */
+class EnvironmentCallbackContextPromiseImpl implements EnvironmentCallbackContextPromise {
+    constructor(private _promise: Promise<EnvironmentCallbackContext>, private _client: AspireClientRpc, track = true) {
+        if (track) { _client.trackPromise(_promise); }
+    }
+
+    then<TResult1 = EnvironmentCallbackContext, TResult2 = never>(
+        onfulfilled?: ((value: EnvironmentCallbackContext) => TResult1 | PromiseLike<TResult1>) | null,
+        onrejected?: ((reason: unknown) => TResult2 | PromiseLike<TResult2>) | null
+    ): PromiseLike<TResult1 | TResult2> {
+        return this._promise.then(onfulfilled, onrejected);
+    }
+
+    environment(): EnvironmentEditorPromise {
+        return new EnvironmentEditorPromiseImpl(this._promise.then(obj => obj.environment()), this._client, false);
+    }
+
+    log(): LogFacadePromise {
+        return new LogFacadePromiseImpl(this._promise.then(obj => obj.log()), this._client, false);
+    }
+
+    resource(): ResourcePromise {
+        return new ResourcePromiseImpl(this._promise.then(obj => obj.resource()), this._client, false);
+    }
+
+    executionContext(): DistributedApplicationExecutionContextPromise {
+        return new DistributedApplicationExecutionContextPromiseImpl(this._promise.then(obj => obj.executionContext()), this._client, false);
     }
 
 }
@@ -4038,7 +4636,7 @@ class EnvironmentEditorPromiseImpl implements EnvironmentEditorPromise {
 export interface EventingSubscriberRegistrationContext {
     toJSON(): MarshalledHandle;
     /** The execution context for the AppHost invocation. */
-    executionContext(): Promise<DistributedApplicationExecutionContext>;
+    executionContext(): DistributedApplicationExecutionContextPromise;
     /** The cancellation token associated with the subscriber registration. */
     cancellationToken(): Promise<CancellationToken>;
     /**
@@ -4069,7 +4667,7 @@ export interface EventingSubscriberRegistrationContext {
 
 export interface EventingSubscriberRegistrationContextPromise extends PromiseLike<EventingSubscriberRegistrationContext> {
     /** The execution context for the AppHost invocation. */
-    executionContext(): Promise<DistributedApplicationExecutionContext>;
+    executionContext(): DistributedApplicationExecutionContextPromise;
     /** The cancellation token associated with the subscriber registration. */
     cancellationToken(): Promise<CancellationToken>;
     /**
@@ -4109,12 +4707,15 @@ class EventingSubscriberRegistrationContextImpl implements EventingSubscriberReg
     /** Serialize for JSON-RPC transport */
     toJSON(): MarshalledHandle { return this._handle.toJSON(); }
 
-    async executionContext(): Promise<DistributedApplicationExecutionContext> {
-        const handle = await this._client.invokeCapability<DistributedApplicationExecutionContextHandle>(
-            'Aspire.Hosting.Ats/EventingSubscriberRegistrationContext.executionContext',
-            { context: this._handle }
-        );
-        return new DistributedApplicationExecutionContextImpl(handle, this._client);
+    executionContext(): DistributedApplicationExecutionContextPromise {
+        const promise = (async () => {
+            const handle = await this._client.invokeCapability<DistributedApplicationExecutionContextHandle>(
+                'Aspire.Hosting.Ats/EventingSubscriberRegistrationContext.executionContext',
+                { context: this._handle }
+            );
+            return new DistributedApplicationExecutionContextImpl(handle, this._client);
+        })();
+        return new DistributedApplicationExecutionContextPromiseImpl(promise, this._client, false);
     }
 
     async cancellationToken(): Promise<CancellationToken> {
@@ -4214,8 +4815,8 @@ class EventingSubscriberRegistrationContextPromiseImpl implements EventingSubscr
         return this._promise.then(onfulfilled, onrejected);
     }
 
-    executionContext(): Promise<DistributedApplicationExecutionContext> {
-        return this._promise.then(obj => obj.executionContext());
+    executionContext(): DistributedApplicationExecutionContextPromise {
+        return new DistributedApplicationExecutionContextPromiseImpl(this._promise.then(obj => obj.executionContext()), this._client, false);
     }
 
     cancellationToken(): Promise<CancellationToken> {
@@ -4247,6 +4848,23 @@ class EventingSubscriberRegistrationContextPromiseImpl implements EventingSubscr
 /** Context for {@link ResourceCommandAnnotation.ExecuteCommand}. */
 export interface ExecuteCommandContext {
     toJSON(): MarshalledHandle;
+    /** The resource name. */
+    resourceName(): Promise<string>;
+    /** The cancellation token. */
+    cancellationToken(): Promise<CancellationToken>;
+    /** The logger for the resource. */
+    logger(): LoggerPromise;
+    /**
+     * Gets the invocation arguments supplied by the client when the command is executed.
+     *
+     * The collection contains the arguments described by `Arguments` with their
+     * submitted values populated. CLI positional arguments are mapped by declaration order. Dashboard, MCP, and other
+     * named-payload clients are mapped by `Name`.
+     */
+    arguments(): Promise<InteractionInputCollection>;
+}
+
+export interface ExecuteCommandContextPromise extends PromiseLike<ExecuteCommandContext> {
     /** The resource name. */
     resourceName(): Promise<string>;
     /** The cancellation token. */
@@ -4309,6 +4927,39 @@ class ExecuteCommandContextImpl implements ExecuteCommandContext {
 
 }
 
+/**
+ * Thenable wrapper for ExecuteCommandContext that enables fluent chaining.
+ */
+class ExecuteCommandContextPromiseImpl implements ExecuteCommandContextPromise {
+    constructor(private _promise: Promise<ExecuteCommandContext>, private _client: AspireClientRpc, track = true) {
+        if (track) { _client.trackPromise(_promise); }
+    }
+
+    then<TResult1 = ExecuteCommandContext, TResult2 = never>(
+        onfulfilled?: ((value: ExecuteCommandContext) => TResult1 | PromiseLike<TResult1>) | null,
+        onrejected?: ((reason: unknown) => TResult2 | PromiseLike<TResult2>) | null
+    ): PromiseLike<TResult1 | TResult2> {
+        return this._promise.then(onfulfilled, onrejected);
+    }
+
+    resourceName(): Promise<string> {
+        return this._promise.then(obj => obj.resourceName());
+    }
+
+    cancellationToken(): Promise<CancellationToken> {
+        return this._promise.then(obj => obj.cancellationToken());
+    }
+
+    logger(): LoggerPromise {
+        return new LoggerPromiseImpl(this._promise.then(obj => obj.logger()), this._client, false);
+    }
+
+    arguments(): Promise<InteractionInputCollection> {
+        return this._promise.then(obj => obj.arguments());
+    }
+
+}
+
 // ============================================================================
 // InitializeResourceEvent
 // ============================================================================
@@ -4321,6 +4972,19 @@ class ExecuteCommandContextImpl implements ExecuteCommandContext {
  */
 export interface InitializeResourceEvent {
     toJSON(): MarshalledHandle;
+    /** Gets the Resource property */
+    resource(): ResourcePromise;
+    /** The `IDistributedApplicationEventing` service for the app host. */
+    eventing(): DistributedApplicationEventingPromise;
+    /** An instance of `ILogger` that can be used to log messages for the resource. */
+    logger(): LoggerPromise;
+    /** The `ResourceNotificationService` for the app host. */
+    notifications(): ResourceNotificationServicePromise;
+    /** The `IServiceProvider` for the app host. */
+    services(): ServiceProviderPromise;
+}
+
+export interface InitializeResourceEventPromise extends PromiseLike<InitializeResourceEvent> {
     /** Gets the Resource property */
     resource(): ResourcePromise;
     /** The `IDistributedApplicationEventing` service for the app host. */
@@ -4402,6 +5066,43 @@ class InitializeResourceEventImpl implements InitializeResourceEvent {
             return new ServiceProviderImpl(handle, this._client);
         })();
         return new ServiceProviderPromiseImpl(promise, this._client, false);
+    }
+
+}
+
+/**
+ * Thenable wrapper for InitializeResourceEvent that enables fluent chaining.
+ */
+class InitializeResourceEventPromiseImpl implements InitializeResourceEventPromise {
+    constructor(private _promise: Promise<InitializeResourceEvent>, private _client: AspireClientRpc, track = true) {
+        if (track) { _client.trackPromise(_promise); }
+    }
+
+    then<TResult1 = InitializeResourceEvent, TResult2 = never>(
+        onfulfilled?: ((value: InitializeResourceEvent) => TResult1 | PromiseLike<TResult1>) | null,
+        onrejected?: ((reason: unknown) => TResult2 | PromiseLike<TResult2>) | null
+    ): PromiseLike<TResult1 | TResult2> {
+        return this._promise.then(onfulfilled, onrejected);
+    }
+
+    resource(): ResourcePromise {
+        return new ResourcePromiseImpl(this._promise.then(obj => obj.resource()), this._client, false);
+    }
+
+    eventing(): DistributedApplicationEventingPromise {
+        return new DistributedApplicationEventingPromiseImpl(this._promise.then(obj => obj.eventing()), this._client, false);
+    }
+
+    logger(): LoggerPromise {
+        return new LoggerPromiseImpl(this._promise.then(obj => obj.logger()), this._client, false);
+    }
+
+    notifications(): ResourceNotificationServicePromise {
+        return new ResourceNotificationServicePromiseImpl(this._promise.then(obj => obj.notifications()), this._client, false);
+    }
+
+    services(): ServiceProviderPromise {
+        return new ServiceProviderPromiseImpl(this._promise.then(obj => obj.services()), this._client, false);
     }
 
 }
@@ -4803,7 +5504,7 @@ export interface PipelineContext {
     /** Gets the distributed application model to be deployed. */
     model(): DistributedApplicationModelPromise;
     /** Gets the execution context for the distributed application. */
-    executionContext(): Promise<DistributedApplicationExecutionContext>;
+    executionContext(): DistributedApplicationExecutionContextPromise;
     /** Gets the service provider for dependency resolution. */
     services(): ServiceProviderPromise;
     /** Gets the logger for pipeline operations. */
@@ -4813,6 +5514,24 @@ export interface PipelineContext {
         get: () => Promise<CancellationToken>;
         set: (value: AbortSignal | CancellationToken) => Promise<void>;
     };
+    /**
+     * Gets the pipeline summary that steps can add information to. The summary will be displayed to users after pipeline execution completes.
+     *
+     * Pipeline steps can add key-value pairs to the summary to provide useful information
+     * about the pipeline execution, such as deployment targets, resource names, URLs, etc.
+     */
+    summary(): PipelineSummaryPromise;
+}
+
+export interface PipelineContextPromise extends PromiseLike<PipelineContext> {
+    /** Gets the distributed application model to be deployed. */
+    model(): DistributedApplicationModelPromise;
+    /** Gets the execution context for the distributed application. */
+    executionContext(): DistributedApplicationExecutionContextPromise;
+    /** Gets the service provider for dependency resolution. */
+    services(): ServiceProviderPromise;
+    /** Gets the logger for pipeline operations. */
+    logger(): LoggerPromise;
     /**
      * Gets the pipeline summary that steps can add information to. The summary will be displayed to users after pipeline execution completes.
      *
@@ -4844,12 +5563,15 @@ class PipelineContextImpl implements PipelineContext {
         return new DistributedApplicationModelPromiseImpl(promise, this._client, false);
     }
 
-    async executionContext(): Promise<DistributedApplicationExecutionContext> {
-        const handle = await this._client.invokeCapability<DistributedApplicationExecutionContextHandle>(
-            'Aspire.Hosting.Pipelines/PipelineContext.executionContext',
-            { context: this._handle }
-        );
-        return new DistributedApplicationExecutionContextImpl(handle, this._client);
+    executionContext(): DistributedApplicationExecutionContextPromise {
+        const promise = (async () => {
+            const handle = await this._client.invokeCapability<DistributedApplicationExecutionContextHandle>(
+                'Aspire.Hosting.Pipelines/PipelineContext.executionContext',
+                { context: this._handle }
+            );
+            return new DistributedApplicationExecutionContextImpl(handle, this._client);
+        })();
+        return new DistributedApplicationExecutionContextPromiseImpl(promise, this._client, false);
     }
 
     services(): ServiceProviderPromise {
@@ -4899,6 +5621,43 @@ class PipelineContextImpl implements PipelineContext {
             return new PipelineSummaryImpl(handle, this._client);
         })();
         return new PipelineSummaryPromiseImpl(promise, this._client, false);
+    }
+
+}
+
+/**
+ * Thenable wrapper for PipelineContext that enables fluent chaining.
+ */
+class PipelineContextPromiseImpl implements PipelineContextPromise {
+    constructor(private _promise: Promise<PipelineContext>, private _client: AspireClientRpc, track = true) {
+        if (track) { _client.trackPromise(_promise); }
+    }
+
+    then<TResult1 = PipelineContext, TResult2 = never>(
+        onfulfilled?: ((value: PipelineContext) => TResult1 | PromiseLike<TResult1>) | null,
+        onrejected?: ((reason: unknown) => TResult2 | PromiseLike<TResult2>) | null
+    ): PromiseLike<TResult1 | TResult2> {
+        return this._promise.then(onfulfilled, onrejected);
+    }
+
+    model(): DistributedApplicationModelPromise {
+        return new DistributedApplicationModelPromiseImpl(this._promise.then(obj => obj.model()), this._client, false);
+    }
+
+    executionContext(): DistributedApplicationExecutionContextPromise {
+        return new DistributedApplicationExecutionContextPromiseImpl(this._promise.then(obj => obj.executionContext()), this._client, false);
+    }
+
+    services(): ServiceProviderPromise {
+        return new ServiceProviderPromiseImpl(this._promise.then(obj => obj.services()), this._client, false);
+    }
+
+    logger(): LoggerPromise {
+        return new LoggerPromiseImpl(this._promise.then(obj => obj.logger()), this._client, false);
+    }
+
+    summary(): PipelineSummaryPromise {
+        return new PipelineSummaryPromiseImpl(this._promise.then(obj => obj.summary()), this._client, false);
     }
 
 }
@@ -5254,13 +6013,37 @@ class PipelineStepPromiseImpl implements PipelineStepPromise {
 export interface PipelineStepContext {
     toJSON(): MarshalledHandle;
     /** Gets the pipeline context shared across all steps. */
-    pipelineContext(): Promise<PipelineContext>;
+    pipelineContext(): PipelineContextPromise;
     /** Gets the publishing step associated with this specific step execution. */
     reportingStep(): ReportingStepPromise;
     /** Gets the distributed application model to be deployed. */
     model(): DistributedApplicationModelPromise;
     /** Gets the execution context for the distributed application. */
-    executionContext(): Promise<DistributedApplicationExecutionContext>;
+    executionContext(): DistributedApplicationExecutionContextPromise;
+    /** Gets the service provider for dependency resolution. */
+    services(): ServiceProviderPromise;
+    /** Gets the logger for pipeline operations that writes to both the pipeline logger and the step logger. */
+    logger(): LoggerPromise;
+    /** Gets the cancellation token for the pipeline operation. */
+    cancellationToken(): Promise<CancellationToken>;
+    /**
+     * Gets the pipeline summary that steps can add information to. The summary will be displayed to users after pipeline execution completes.
+     *
+     * Pipeline steps can add key-value pairs to the summary to provide useful information
+     * about the pipeline execution, such as deployment targets, resource names, URLs, etc.
+     */
+    summary(): PipelineSummaryPromise;
+}
+
+export interface PipelineStepContextPromise extends PromiseLike<PipelineStepContext> {
+    /** Gets the pipeline context shared across all steps. */
+    pipelineContext(): PipelineContextPromise;
+    /** Gets the publishing step associated with this specific step execution. */
+    reportingStep(): ReportingStepPromise;
+    /** Gets the distributed application model to be deployed. */
+    model(): DistributedApplicationModelPromise;
+    /** Gets the execution context for the distributed application. */
+    executionContext(): DistributedApplicationExecutionContextPromise;
     /** Gets the service provider for dependency resolution. */
     services(): ServiceProviderPromise;
     /** Gets the logger for pipeline operations that writes to both the pipeline logger and the step logger. */
@@ -5292,12 +6075,15 @@ class PipelineStepContextImpl implements PipelineStepContext {
     /** Serialize for JSON-RPC transport */
     toJSON(): MarshalledHandle { return this._handle.toJSON(); }
 
-    async pipelineContext(): Promise<PipelineContext> {
-        const handle = await this._client.invokeCapability<PipelineContextHandle>(
-            'Aspire.Hosting.Pipelines/PipelineStepContext.pipelineContext',
-            { context: this._handle }
-        );
-        return new PipelineContextImpl(handle, this._client);
+    pipelineContext(): PipelineContextPromise {
+        const promise = (async () => {
+            const handle = await this._client.invokeCapability<PipelineContextHandle>(
+                'Aspire.Hosting.Pipelines/PipelineStepContext.pipelineContext',
+                { context: this._handle }
+            );
+            return new PipelineContextImpl(handle, this._client);
+        })();
+        return new PipelineContextPromiseImpl(promise, this._client, false);
     }
 
     reportingStep(): ReportingStepPromise {
@@ -5322,12 +6108,15 @@ class PipelineStepContextImpl implements PipelineStepContext {
         return new DistributedApplicationModelPromiseImpl(promise, this._client, false);
     }
 
-    async executionContext(): Promise<DistributedApplicationExecutionContext> {
-        const handle = await this._client.invokeCapability<DistributedApplicationExecutionContextHandle>(
-            'Aspire.Hosting.Pipelines/PipelineStepContext.executionContext',
-            { context: this._handle }
-        );
-        return new DistributedApplicationExecutionContextImpl(handle, this._client);
+    executionContext(): DistributedApplicationExecutionContextPromise {
+        const promise = (async () => {
+            const handle = await this._client.invokeCapability<DistributedApplicationExecutionContextHandle>(
+                'Aspire.Hosting.Pipelines/PipelineStepContext.executionContext',
+                { context: this._handle }
+            );
+            return new DistributedApplicationExecutionContextImpl(handle, this._client);
+        })();
+        return new DistributedApplicationExecutionContextPromiseImpl(promise, this._client, false);
     }
 
     services(): ServiceProviderPromise {
@@ -5373,6 +6162,55 @@ class PipelineStepContextImpl implements PipelineStepContext {
 
 }
 
+/**
+ * Thenable wrapper for PipelineStepContext that enables fluent chaining.
+ */
+class PipelineStepContextPromiseImpl implements PipelineStepContextPromise {
+    constructor(private _promise: Promise<PipelineStepContext>, private _client: AspireClientRpc, track = true) {
+        if (track) { _client.trackPromise(_promise); }
+    }
+
+    then<TResult1 = PipelineStepContext, TResult2 = never>(
+        onfulfilled?: ((value: PipelineStepContext) => TResult1 | PromiseLike<TResult1>) | null,
+        onrejected?: ((reason: unknown) => TResult2 | PromiseLike<TResult2>) | null
+    ): PromiseLike<TResult1 | TResult2> {
+        return this._promise.then(onfulfilled, onrejected);
+    }
+
+    pipelineContext(): PipelineContextPromise {
+        return new PipelineContextPromiseImpl(this._promise.then(obj => obj.pipelineContext()), this._client, false);
+    }
+
+    reportingStep(): ReportingStepPromise {
+        return new ReportingStepPromiseImpl(this._promise.then(obj => obj.reportingStep()), this._client, false);
+    }
+
+    model(): DistributedApplicationModelPromise {
+        return new DistributedApplicationModelPromiseImpl(this._promise.then(obj => obj.model()), this._client, false);
+    }
+
+    executionContext(): DistributedApplicationExecutionContextPromise {
+        return new DistributedApplicationExecutionContextPromiseImpl(this._promise.then(obj => obj.executionContext()), this._client, false);
+    }
+
+    services(): ServiceProviderPromise {
+        return new ServiceProviderPromiseImpl(this._promise.then(obj => obj.services()), this._client, false);
+    }
+
+    logger(): LoggerPromise {
+        return new LoggerPromiseImpl(this._promise.then(obj => obj.logger()), this._client, false);
+    }
+
+    cancellationToken(): Promise<CancellationToken> {
+        return this._promise.then(obj => obj.cancellationToken());
+    }
+
+    summary(): PipelineSummaryPromise {
+        return new PipelineSummaryPromiseImpl(this._promise.then(obj => obj.summary()), this._client, false);
+    }
+
+}
+
 // ============================================================================
 // PipelineStepFactoryContext
 // ============================================================================
@@ -5381,7 +6219,14 @@ class PipelineStepContextImpl implements PipelineStepContext {
 export interface PipelineStepFactoryContext {
     toJSON(): MarshalledHandle;
     /** Gets the pipeline context that has the model and other properties. */
-    pipelineContext(): Promise<PipelineContext>;
+    pipelineContext(): PipelineContextPromise;
+    /** Gets the resource that this factory is associated with. */
+    resource(): ResourcePromise;
+}
+
+export interface PipelineStepFactoryContextPromise extends PromiseLike<PipelineStepFactoryContext> {
+    /** Gets the pipeline context that has the model and other properties. */
+    pipelineContext(): PipelineContextPromise;
     /** Gets the resource that this factory is associated with. */
     resource(): ResourcePromise;
 }
@@ -5397,12 +6242,15 @@ class PipelineStepFactoryContextImpl implements PipelineStepFactoryContext {
     /** Serialize for JSON-RPC transport */
     toJSON(): MarshalledHandle { return this._handle.toJSON(); }
 
-    async pipelineContext(): Promise<PipelineContext> {
-        const handle = await this._client.invokeCapability<PipelineContextHandle>(
-            'Aspire.Hosting.Pipelines/PipelineStepFactoryContext.pipelineContext',
-            { context: this._handle }
-        );
-        return new PipelineContextImpl(handle, this._client);
+    pipelineContext(): PipelineContextPromise {
+        const promise = (async () => {
+            const handle = await this._client.invokeCapability<PipelineContextHandle>(
+                'Aspire.Hosting.Pipelines/PipelineStepFactoryContext.pipelineContext',
+                { context: this._handle }
+            );
+            return new PipelineContextImpl(handle, this._client);
+        })();
+        return new PipelineContextPromiseImpl(promise, this._client, false);
     }
 
     resource(): ResourcePromise {
@@ -5414,6 +6262,31 @@ class PipelineStepFactoryContextImpl implements PipelineStepFactoryContext {
             return new ResourceImpl(handle, this._client);
         })();
         return new ResourcePromiseImpl(promise, this._client, false);
+    }
+
+}
+
+/**
+ * Thenable wrapper for PipelineStepFactoryContext that enables fluent chaining.
+ */
+class PipelineStepFactoryContextPromiseImpl implements PipelineStepFactoryContextPromise {
+    constructor(private _promise: Promise<PipelineStepFactoryContext>, private _client: AspireClientRpc, track = true) {
+        if (track) { _client.trackPromise(_promise); }
+    }
+
+    then<TResult1 = PipelineStepFactoryContext, TResult2 = never>(
+        onfulfilled?: ((value: PipelineStepFactoryContext) => TResult1 | PromiseLike<TResult1>) | null,
+        onrejected?: ((reason: unknown) => TResult2 | PromiseLike<TResult2>) | null
+    ): PromiseLike<TResult1 | TResult2> {
+        return this._promise.then(onfulfilled, onrejected);
+    }
+
+    pipelineContext(): PipelineContextPromise {
+        return new PipelineContextPromiseImpl(this._promise.then(obj => obj.pipelineContext()), this._client, false);
+    }
+
+    resource(): ResourcePromise {
+        return new ResourcePromiseImpl(this._promise.then(obj => obj.resource()), this._client, false);
     }
 
 }
@@ -5913,6 +6786,13 @@ export interface ResourceEndpointsAllocatedEvent {
     services(): ServiceProviderPromise;
 }
 
+export interface ResourceEndpointsAllocatedEventPromise extends PromiseLike<ResourceEndpointsAllocatedEvent> {
+    /** Gets the Resource property */
+    resource(): ResourcePromise;
+    /** Gets the Services property */
+    services(): ServiceProviderPromise;
+}
+
 // ============================================================================
 // ResourceEndpointsAllocatedEventImpl
 // ============================================================================
@@ -5948,6 +6828,31 @@ class ResourceEndpointsAllocatedEventImpl implements ResourceEndpointsAllocatedE
             return new ServiceProviderImpl(handle, this._client);
         })();
         return new ServiceProviderPromiseImpl(promise, this._client, false);
+    }
+
+}
+
+/**
+ * Thenable wrapper for ResourceEndpointsAllocatedEvent that enables fluent chaining.
+ */
+class ResourceEndpointsAllocatedEventPromiseImpl implements ResourceEndpointsAllocatedEventPromise {
+    constructor(private _promise: Promise<ResourceEndpointsAllocatedEvent>, private _client: AspireClientRpc, track = true) {
+        if (track) { _client.trackPromise(_promise); }
+    }
+
+    then<TResult1 = ResourceEndpointsAllocatedEvent, TResult2 = never>(
+        onfulfilled?: ((value: ResourceEndpointsAllocatedEvent) => TResult1 | PromiseLike<TResult1>) | null,
+        onrejected?: ((reason: unknown) => TResult2 | PromiseLike<TResult2>) | null
+    ): PromiseLike<TResult1 | TResult2> {
+        return this._promise.then(onfulfilled, onrejected);
+    }
+
+    resource(): ResourcePromise {
+        return new ResourcePromiseImpl(this._promise.then(obj => obj.resource()), this._client, false);
+    }
+
+    services(): ServiceProviderPromise {
+        return new ServiceProviderPromiseImpl(this._promise.then(obj => obj.services()), this._client, false);
     }
 
 }
@@ -6246,6 +7151,13 @@ export interface ResourceReadyEvent {
     services(): ServiceProviderPromise;
 }
 
+export interface ResourceReadyEventPromise extends PromiseLike<ResourceReadyEvent> {
+    /** The resource that is in a healthy state. */
+    resource(): ResourcePromise;
+    /** Gets the Services property */
+    services(): ServiceProviderPromise;
+}
+
 // ============================================================================
 // ResourceReadyEventImpl
 // ============================================================================
@@ -6285,6 +7197,31 @@ class ResourceReadyEventImpl implements ResourceReadyEvent {
 
 }
 
+/**
+ * Thenable wrapper for ResourceReadyEvent that enables fluent chaining.
+ */
+class ResourceReadyEventPromiseImpl implements ResourceReadyEventPromise {
+    constructor(private _promise: Promise<ResourceReadyEvent>, private _client: AspireClientRpc, track = true) {
+        if (track) { _client.trackPromise(_promise); }
+    }
+
+    then<TResult1 = ResourceReadyEvent, TResult2 = never>(
+        onfulfilled?: ((value: ResourceReadyEvent) => TResult1 | PromiseLike<TResult1>) | null,
+        onrejected?: ((reason: unknown) => TResult2 | PromiseLike<TResult2>) | null
+    ): PromiseLike<TResult1 | TResult2> {
+        return this._promise.then(onfulfilled, onrejected);
+    }
+
+    resource(): ResourcePromise {
+        return new ResourcePromiseImpl(this._promise.then(obj => obj.resource()), this._client, false);
+    }
+
+    services(): ServiceProviderPromise {
+        return new ServiceProviderPromiseImpl(this._promise.then(obj => obj.services()), this._client, false);
+    }
+
+}
+
 // ============================================================================
 // ResourceStoppedEvent
 // ============================================================================
@@ -6296,6 +7233,13 @@ class ResourceReadyEventImpl implements ResourceReadyEvent {
  */
 export interface ResourceStoppedEvent {
     toJSON(): MarshalledHandle;
+    /** Gets the Resource property */
+    resource(): ResourcePromise;
+    /** Gets the Services property */
+    services(): ServiceProviderPromise;
+}
+
+export interface ResourceStoppedEventPromise extends PromiseLike<ResourceStoppedEvent> {
     /** Gets the Resource property */
     resource(): ResourcePromise;
     /** Gets the Services property */
@@ -6341,6 +7285,31 @@ class ResourceStoppedEventImpl implements ResourceStoppedEvent {
 
 }
 
+/**
+ * Thenable wrapper for ResourceStoppedEvent that enables fluent chaining.
+ */
+class ResourceStoppedEventPromiseImpl implements ResourceStoppedEventPromise {
+    constructor(private _promise: Promise<ResourceStoppedEvent>, private _client: AspireClientRpc, track = true) {
+        if (track) { _client.trackPromise(_promise); }
+    }
+
+    then<TResult1 = ResourceStoppedEvent, TResult2 = never>(
+        onfulfilled?: ((value: ResourceStoppedEvent) => TResult1 | PromiseLike<TResult1>) | null,
+        onrejected?: ((reason: unknown) => TResult2 | PromiseLike<TResult2>) | null
+    ): PromiseLike<TResult1 | TResult2> {
+        return this._promise.then(onfulfilled, onrejected);
+    }
+
+    resource(): ResourcePromise {
+        return new ResourcePromiseImpl(this._promise.then(obj => obj.resource()), this._client, false);
+    }
+
+    services(): ServiceProviderPromise {
+        return new ServiceProviderPromiseImpl(this._promise.then(obj => obj.services()), this._client, false);
+    }
+
+}
+
 // ============================================================================
 // ResourceUrlsCallbackContext
 // ============================================================================
@@ -6355,7 +7324,7 @@ export interface ResourceUrlsCallbackContext {
     /** Gets the logger facade used by polyglot callbacks. */
     log(): LogFacadePromise;
     /** Gets the execution context associated with this invocation of the AppHost. */
-    executionContext(): Promise<DistributedApplicationExecutionContext>;
+    executionContext(): DistributedApplicationExecutionContextPromise;
     /**
      * Gets an endpoint reference from the associated resource
      * @param name The name of the endpoint.
@@ -6371,7 +7340,7 @@ export interface ResourceUrlsCallbackContextPromise extends PromiseLike<Resource
     /** Gets the logger facade used by polyglot callbacks. */
     log(): LogFacadePromise;
     /** Gets the execution context associated with this invocation of the AppHost. */
-    executionContext(): Promise<DistributedApplicationExecutionContext>;
+    executionContext(): DistributedApplicationExecutionContextPromise;
     /**
      * Gets an endpoint reference from the associated resource
      * @param name The name of the endpoint.
@@ -6423,12 +7392,15 @@ class ResourceUrlsCallbackContextImpl implements ResourceUrlsCallbackContext {
         return new LogFacadePromiseImpl(promise, this._client, false);
     }
 
-    async executionContext(): Promise<DistributedApplicationExecutionContext> {
-        const handle = await this._client.invokeCapability<DistributedApplicationExecutionContextHandle>(
-            'Aspire.Hosting.ApplicationModel/ResourceUrlsCallbackContext.executionContext',
-            { context: this._handle }
-        );
-        return new DistributedApplicationExecutionContextImpl(handle, this._client);
+    executionContext(): DistributedApplicationExecutionContextPromise {
+        const promise = (async () => {
+            const handle = await this._client.invokeCapability<DistributedApplicationExecutionContextHandle>(
+                'Aspire.Hosting.ApplicationModel/ResourceUrlsCallbackContext.executionContext',
+                { context: this._handle }
+            );
+            return new DistributedApplicationExecutionContextImpl(handle, this._client);
+        })();
+        return new DistributedApplicationExecutionContextPromiseImpl(promise, this._client, false);
     }
 
     /** @internal */
@@ -6478,8 +7450,8 @@ class ResourceUrlsCallbackContextPromiseImpl implements ResourceUrlsCallbackCont
         return new LogFacadePromiseImpl(this._promise.then(obj => obj.log()), this._client, false);
     }
 
-    executionContext(): Promise<DistributedApplicationExecutionContext> {
-        return this._promise.then(obj => obj.executionContext());
+    executionContext(): DistributedApplicationExecutionContextPromise {
+        return new DistributedApplicationExecutionContextPromiseImpl(this._promise.then(obj => obj.executionContext()), this._client, false);
     }
 
     getEndpoint(name: string): EndpointReferencePromise {
@@ -6496,7 +7468,7 @@ class ResourceUrlsCallbackContextPromiseImpl implements ResourceUrlsCallbackCont
 export interface ResourceUrlsEditor {
     toJSON(): MarshalledHandle;
     /** Gets the execution context associated with this editor. */
-    executionContext(): Promise<DistributedApplicationExecutionContext>;
+    executionContext(): DistributedApplicationExecutionContextPromise;
     /**
      * Adds a displayed URL.
      * @param url The URL to add, specified as a string or reference expression.
@@ -6514,7 +7486,7 @@ export interface ResourceUrlsEditor {
 
 export interface ResourceUrlsEditorPromise extends PromiseLike<ResourceUrlsEditor> {
     /** Gets the execution context associated with this editor. */
-    executionContext(): Promise<DistributedApplicationExecutionContext>;
+    executionContext(): DistributedApplicationExecutionContextPromise;
     /**
      * Adds a displayed URL.
      * @param url The URL to add, specified as a string or reference expression.
@@ -6541,12 +7513,15 @@ class ResourceUrlsEditorImpl implements ResourceUrlsEditor {
     /** Serialize for JSON-RPC transport */
     toJSON(): MarshalledHandle { return this._handle.toJSON(); }
 
-    async executionContext(): Promise<DistributedApplicationExecutionContext> {
-        const handle = await this._client.invokeCapability<DistributedApplicationExecutionContextHandle>(
-            'Aspire.Hosting.ApplicationModel/ResourceUrlsEditor.executionContext',
-            { context: this._handle }
-        );
-        return new DistributedApplicationExecutionContextImpl(handle, this._client);
+    executionContext(): DistributedApplicationExecutionContextPromise {
+        const promise = (async () => {
+            const handle = await this._client.invokeCapability<DistributedApplicationExecutionContextHandle>(
+                'Aspire.Hosting.ApplicationModel/ResourceUrlsEditor.executionContext',
+                { context: this._handle }
+            );
+            return new DistributedApplicationExecutionContextImpl(handle, this._client);
+        })();
+        return new DistributedApplicationExecutionContextPromiseImpl(promise, this._client, false);
     }
 
     /** @internal */
@@ -6610,8 +7585,8 @@ class ResourceUrlsEditorPromiseImpl implements ResourceUrlsEditorPromise {
         return this._promise.then(onfulfilled, onrejected);
     }
 
-    executionContext(): Promise<DistributedApplicationExecutionContext> {
-        return this._promise.then(obj => obj.executionContext());
+    executionContext(): DistributedApplicationExecutionContextPromise {
+        return new DistributedApplicationExecutionContextPromiseImpl(this._promise.then(obj => obj.executionContext()), this._client, false);
     }
 
     add(url: string | ReferenceExpression, options?: AddOptions): ResourceUrlsEditorPromise {
@@ -6720,6 +7695,13 @@ export interface TestCollectionContext {
     metadata(): Promise<AspireDict<string, string>>;
 }
 
+export interface TestCollectionContextPromise extends PromiseLike<TestCollectionContext> {
+    /** List property - should generate AspireList getter like Dictionary properties. */
+    items(): Promise<AspireList<string>>;
+    /** Dictionary property - already works with AspireDict getter. */
+    metadata(): Promise<AspireDict<string, string>>;
+}
+
 // ============================================================================
 // TestCollectionContextImpl
 // ============================================================================
@@ -6755,6 +7737,31 @@ class TestCollectionContextImpl implements TestCollectionContext {
             );
         }
         return this._metadata;
+    }
+
+}
+
+/**
+ * Thenable wrapper for TestCollectionContext that enables fluent chaining.
+ */
+class TestCollectionContextPromiseImpl implements TestCollectionContextPromise {
+    constructor(private _promise: Promise<TestCollectionContext>, private _client: AspireClientRpc, track = true) {
+        if (track) { _client.trackPromise(_promise); }
+    }
+
+    then<TResult1 = TestCollectionContext, TResult2 = never>(
+        onfulfilled?: ((value: TestCollectionContext) => TResult1 | PromiseLike<TResult1>) | null,
+        onrejected?: ((reason: unknown) => TResult2 | PromiseLike<TResult2>) | null
+    ): PromiseLike<TResult1 | TResult2> {
+        return this._promise.then(onfulfilled, onrejected);
+    }
+
+    items(): Promise<AspireList<string>> {
+        return this._promise.then(obj => obj.items());
+    }
+
+    metadata(): Promise<AspireDict<string, string>> {
+        return this._promise.then(obj => obj.metadata());
     }
 
 }
@@ -7042,6 +8049,11 @@ export interface UpdateCommandStateContext {
     resourceSnapshot(): Promise<UpdateCommandStateResourceSnapshot>;
 }
 
+export interface UpdateCommandStateContextPromise extends PromiseLike<UpdateCommandStateContext> {
+    /** Gets the resource snapshot data available to polyglot command state callbacks. */
+    resourceSnapshot(): Promise<UpdateCommandStateResourceSnapshot>;
+}
+
 // ============================================================================
 // UpdateCommandStateContextImpl
 // ============================================================================
@@ -7058,6 +8070,27 @@ class UpdateCommandStateContextImpl implements UpdateCommandStateContext {
             'Aspire.Hosting.ApplicationModel/UpdateCommandStateContext.resourceSnapshot',
             { context: this._handle }
         );
+    }
+
+}
+
+/**
+ * Thenable wrapper for UpdateCommandStateContext that enables fluent chaining.
+ */
+class UpdateCommandStateContextPromiseImpl implements UpdateCommandStateContextPromise {
+    constructor(private _promise: Promise<UpdateCommandStateContext>, private _client: AspireClientRpc, track = true) {
+        if (track) { _client.trackPromise(_promise); }
+    }
+
+    then<TResult1 = UpdateCommandStateContext, TResult2 = never>(
+        onfulfilled?: ((value: UpdateCommandStateContext) => TResult1 | PromiseLike<TResult1>) | null,
+        onrejected?: ((reason: unknown) => TResult2 | PromiseLike<TResult2>) | null
+    ): PromiseLike<TResult1 | TResult2> {
+        return this._promise.then(onfulfilled, onrejected);
+    }
+
+    resourceSnapshot(): Promise<UpdateCommandStateResourceSnapshot> {
+        return this._promise.then(obj => obj.resourceSnapshot());
     }
 
 }
@@ -7186,7 +8219,7 @@ export interface Configuration {
      * @param key The configuration key.
      * @returns The configuration section handle.
      */
-    getSection(key: string): Promise<ConfigurationSection>;
+    getSection(key: string): ConfigurationSectionPromise;
     /**
      * Gets the child sections of a configuration handle.
      * @returns The child sections.
@@ -7218,7 +8251,7 @@ export interface ConfigurationPromise extends PromiseLike<Configuration> {
      * @param key The configuration key.
      * @returns The configuration section handle.
      */
-    getSection(key: string): Promise<ConfigurationSection>;
+    getSection(key: string): ConfigurationSectionPromise;
     /**
      * Gets the child sections of a configuration handle.
      * @returns The child sections.
@@ -7269,17 +8302,23 @@ class ConfigurationImpl implements Configuration {
         );
     }
 
+    /** @internal */
+    async _getSectionInternal(key: string): Promise<ConfigurationSection> {
+        const rpcArgs: Record<string, unknown> = { configuration: this._handle, key };
+        const result = await this._client.invokeCapability<IConfigurationSectionHandle>(
+            'Aspire.Hosting/getSection',
+            rpcArgs
+        );
+        return new ConfigurationSectionImpl(result, this._client);
+    }
+
     /**
      * Gets a configuration section by key.
      * @param key The configuration key.
      * @returns The configuration section handle.
      */
-    async getSection(key: string): Promise<ConfigurationSection> {
-        const rpcArgs: Record<string, unknown> = { configuration: this._handle, key };
-        return await this._client.invokeCapability<ConfigurationSection>(
-            'Aspire.Hosting/getSection',
-            rpcArgs
-        );
+    getSection(key: string): ConfigurationSectionPromise {
+        return new ConfigurationSectionPromiseImpl(this._getSectionInternal(key), this._client);
     }
 
     /**
@@ -7332,8 +8371,8 @@ class ConfigurationPromiseImpl implements ConfigurationPromise {
         return this._promise.then(obj => obj.getConnectionString(name));
     }
 
-    getSection(key: string): Promise<ConfigurationSection> {
-        return this._promise.then(obj => obj.getSection(key));
+    getSection(key: string): ConfigurationSectionPromise {
+        return new ConfigurationSectionPromiseImpl(this._promise.then(obj => obj.getSection(key)), this._client);
     }
 
     getChildren(): Promise<ConfigurationSection[]> {
@@ -7361,6 +8400,13 @@ export interface ConfigurationSection {
         get: () => Promise<string | null>;
         set: (value: string | null) => Promise<void>;
     };
+}
+
+export interface ConfigurationSectionPromise extends PromiseLike<ConfigurationSection> {
+    /** Gets the Key property */
+    key(): Promise<string>;
+    /** Gets the Path property */
+    path(): Promise<string>;
 }
 
 // ============================================================================
@@ -7405,6 +8451,31 @@ class ConfigurationSectionImpl implements ConfigurationSection {
 
 }
 
+/**
+ * Thenable wrapper for ConfigurationSection that enables fluent chaining.
+ */
+class ConfigurationSectionPromiseImpl implements ConfigurationSectionPromise {
+    constructor(private _promise: Promise<ConfigurationSection>, private _client: AspireClientRpc, track = true) {
+        if (track) { _client.trackPromise(_promise); }
+    }
+
+    then<TResult1 = ConfigurationSection, TResult2 = never>(
+        onfulfilled?: ((value: ConfigurationSection) => TResult1 | PromiseLike<TResult1>) | null,
+        onrejected?: ((reason: unknown) => TResult2 | PromiseLike<TResult2>) | null
+    ): PromiseLike<TResult1 | TResult2> {
+        return this._promise.then(onfulfilled, onrejected);
+    }
+
+    key(): Promise<string> {
+        return this._promise.then(obj => obj.key());
+    }
+
+    path(): Promise<string> {
+        return this._promise.then(obj => obj.path());
+    }
+
+}
+
 // ============================================================================
 // DistributedApplicationBuilder
 // ============================================================================
@@ -7424,7 +8495,7 @@ export interface DistributedApplicationBuilder {
      * Use this property to determine whether the app host is running locally or publishing
      * deployment artifacts, and adjust the application model accordingly.
      */
-    executionContext(): Promise<DistributedApplicationExecutionContext>;
+    executionContext(): DistributedApplicationExecutionContextPromise;
     /**
      * Gets the deployment pipeline for this distributed application.
      *
@@ -7626,7 +8697,7 @@ export interface DistributedApplicationBuilderPromise extends PromiseLike<Distri
      * Use this property to determine whether the app host is running locally or publishing
      * deployment artifacts, and adjust the application model accordingly.
      */
-    executionContext(): Promise<DistributedApplicationExecutionContext>;
+    executionContext(): DistributedApplicationExecutionContextPromise;
     /**
      * Gets the deployment pipeline for this distributed application.
      *
@@ -7855,12 +8926,15 @@ class DistributedApplicationBuilderImpl implements DistributedApplicationBuilder
         return new DistributedApplicationEventingPromiseImpl(promise, this._client, false);
     }
 
-    async executionContext(): Promise<DistributedApplicationExecutionContext> {
-        const handle = await this._client.invokeCapability<DistributedApplicationExecutionContextHandle>(
-            'Aspire.Hosting/IDistributedApplicationBuilder.executionContext',
-            { context: this._handle }
-        );
-        return new DistributedApplicationExecutionContextImpl(handle, this._client);
+    executionContext(): DistributedApplicationExecutionContextPromise {
+        const promise = (async () => {
+            const handle = await this._client.invokeCapability<DistributedApplicationExecutionContextHandle>(
+                'Aspire.Hosting/IDistributedApplicationBuilder.executionContext',
+                { context: this._handle }
+            );
+            return new DistributedApplicationExecutionContextImpl(handle, this._client);
+        })();
+        return new DistributedApplicationExecutionContextPromiseImpl(promise, this._client, false);
     }
 
     pipeline(): DistributedApplicationPipelinePromise {
@@ -8430,8 +9504,8 @@ class DistributedApplicationBuilderPromiseImpl implements DistributedApplication
         return new DistributedApplicationEventingPromiseImpl(this._promise.then(obj => obj.eventing()), this._client, false);
     }
 
-    executionContext(): Promise<DistributedApplicationExecutionContext> {
-        return this._promise.then(obj => obj.executionContext());
+    executionContext(): DistributedApplicationExecutionContextPromise {
+        return new DistributedApplicationExecutionContextPromiseImpl(this._promise.then(obj => obj.executionContext()), this._client, false);
     }
 
     pipeline(): DistributedApplicationPipelinePromise {
@@ -10699,7 +11773,7 @@ export interface ContainerRegistryResource {
      * Creates an execution configuration builder for the specified resource.
      * @returns The execution configuration builder.
      */
-    createExecutionConfiguration(): Promise<ExecutionConfigurationBuilder>;
+    createExecutionConfiguration(): ExecutionConfigurationBuilderPromise;
     /**
      * Adds an optional string parameter
      * @param options Additional options.
@@ -10977,7 +12051,7 @@ export interface ContainerRegistryResourcePromise extends PromiseLike<ContainerR
      * Creates an execution configuration builder for the specified resource.
      * @returns The execution configuration builder.
      */
-    createExecutionConfiguration(): Promise<ExecutionConfigurationBuilder>;
+    createExecutionConfiguration(): ExecutionConfigurationBuilderPromise;
     /**
      * Adds an optional string parameter
      * @param options Additional options.
@@ -11726,12 +12800,16 @@ class ContainerRegistryResourceImpl extends ResourceBuilderBase<ContainerRegistr
      * Creates an execution configuration builder for the specified resource.
      * @returns The execution configuration builder.
      */
-    async createExecutionConfiguration(): Promise<ExecutionConfigurationBuilder> {
-        const rpcArgs: Record<string, unknown> = { resource: this._handle };
-        return await this._client.invokeCapability<ExecutionConfigurationBuilder>(
-            'Aspire.Hosting/createExecutionConfiguration',
-            rpcArgs
-        );
+    createExecutionConfiguration(): ExecutionConfigurationBuilderPromise {
+        const promise = (async () => {
+            const rpcArgs: Record<string, unknown> = { resource: this._handle };
+            const handle = await this._client.invokeCapability<IExecutionConfigurationBuilderHandle>(
+                'Aspire.Hosting/createExecutionConfiguration',
+                rpcArgs
+            );
+            return new ExecutionConfigurationBuilderImpl(handle, this._client);
+        })();
+        return new ExecutionConfigurationBuilderPromiseImpl(promise, this._client);
     }
 
     /** @internal */
@@ -12246,8 +13324,8 @@ class ContainerRegistryResourcePromiseImpl implements ContainerRegistryResourceP
         return new ContainerRegistryResourcePromiseImpl(this._promise.then(obj => obj.onResourceReady(callback)), this._client);
     }
 
-    createExecutionConfiguration(): Promise<ExecutionConfigurationBuilder> {
-        return this._promise.then(obj => obj.createExecutionConfiguration());
+    createExecutionConfiguration(): ExecutionConfigurationBuilderPromise {
+        return new ExecutionConfigurationBuilderPromiseImpl(this._promise.then(obj => obj.createExecutionConfiguration()), this._client);
     }
 
     withOptionalString(options?: WithOptionalStringOptions): ContainerRegistryResourcePromise {
@@ -12668,7 +13746,7 @@ export interface ContainerResource {
      * @param name The name of the endpoint.
      * @returns An `EndpointReference` that can be used to resolve the address of the endpoint after resource allocation has occurred.
      */
-    getEndpoint(name: string): Promise<EndpointReference>;
+    getEndpoint(name: string): EndpointReferencePromise;
     /**
      * Configures a resource to mark all endpoints' transport as HTTP/2. This is useful for HTTP/2 services that need prior knowledge.
      * @returns The resource builder.
@@ -12984,7 +14062,7 @@ export interface ContainerResource {
      * Creates an execution configuration builder for the specified resource.
      * @returns The execution configuration builder.
      */
-    createExecutionConfiguration(): Promise<ExecutionConfigurationBuilder>;
+    createExecutionConfiguration(): ExecutionConfigurationBuilderPromise;
     /**
      * Adds an optional string parameter
      * @param options Additional options.
@@ -13369,7 +14447,7 @@ export interface ContainerResourcePromise extends PromiseLike<ContainerResource>
      * @param name The name of the endpoint.
      * @returns An `EndpointReference` that can be used to resolve the address of the endpoint after resource allocation has occurred.
      */
-    getEndpoint(name: string): Promise<EndpointReference>;
+    getEndpoint(name: string): EndpointReferencePromise;
     /**
      * Configures a resource to mark all endpoints' transport as HTTP/2. This is useful for HTTP/2 services that need prior knowledge.
      * @returns The resource builder.
@@ -13685,7 +14763,7 @@ export interface ContainerResourcePromise extends PromiseLike<ContainerResource>
      * Creates an execution configuration builder for the specified resource.
      * @returns The execution configuration builder.
      */
-    createExecutionConfiguration(): Promise<ExecutionConfigurationBuilder>;
+    createExecutionConfiguration(): ExecutionConfigurationBuilderPromise;
     /**
      * Adds an optional string parameter
      * @param options Additional options.
@@ -14728,12 +15806,16 @@ class ContainerResourceImpl extends ResourceBuilderBase<ContainerResourceHandle>
      * @param name The name of the endpoint.
      * @returns An `EndpointReference` that can be used to resolve the address of the endpoint after resource allocation has occurred.
      */
-    async getEndpoint(name: string): Promise<EndpointReference> {
-        const rpcArgs: Record<string, unknown> = { builder: this._handle, name };
-        return await this._client.invokeCapability<EndpointReference>(
-            'Aspire.Hosting/getEndpoint',
-            rpcArgs
-        );
+    getEndpoint(name: string): EndpointReferencePromise {
+        const promise = (async () => {
+            const rpcArgs: Record<string, unknown> = { builder: this._handle, name };
+            const handle = await this._client.invokeCapability<EndpointReferenceHandle>(
+                'Aspire.Hosting/getEndpoint',
+                rpcArgs
+            );
+            return new EndpointReferenceImpl(handle, this._client);
+        })();
+        return new EndpointReferencePromiseImpl(promise, this._client);
     }
 
     /** @internal */
@@ -15684,12 +16766,16 @@ class ContainerResourceImpl extends ResourceBuilderBase<ContainerResourceHandle>
      * Creates an execution configuration builder for the specified resource.
      * @returns The execution configuration builder.
      */
-    async createExecutionConfiguration(): Promise<ExecutionConfigurationBuilder> {
-        const rpcArgs: Record<string, unknown> = { resource: this._handle };
-        return await this._client.invokeCapability<ExecutionConfigurationBuilder>(
-            'Aspire.Hosting/createExecutionConfiguration',
-            rpcArgs
-        );
+    createExecutionConfiguration(): ExecutionConfigurationBuilderPromise {
+        const promise = (async () => {
+            const rpcArgs: Record<string, unknown> = { resource: this._handle };
+            const handle = await this._client.invokeCapability<IExecutionConfigurationBuilderHandle>(
+                'Aspire.Hosting/createExecutionConfiguration',
+                rpcArgs
+            );
+            return new ExecutionConfigurationBuilderImpl(handle, this._client);
+        })();
+        return new ExecutionConfigurationBuilderPromiseImpl(promise, this._client);
     }
 
     /** @internal */
@@ -16283,8 +17369,8 @@ class ContainerResourcePromiseImpl implements ContainerResourcePromise {
         return new ContainerResourcePromiseImpl(this._promise.then(obj => obj.withExternalHttpEndpoints()), this._client);
     }
 
-    getEndpoint(name: string): Promise<EndpointReference> {
-        return this._promise.then(obj => obj.getEndpoint(name));
+    getEndpoint(name: string): EndpointReferencePromise {
+        return new EndpointReferencePromiseImpl(this._promise.then(obj => obj.getEndpoint(name)), this._client);
     }
 
     asHttp2Service(): ContainerResourcePromise {
@@ -16447,8 +17533,8 @@ class ContainerResourcePromiseImpl implements ContainerResourcePromise {
         return new ContainerResourcePromiseImpl(this._promise.then(obj => obj.onResourceReady(callback)), this._client);
     }
 
-    createExecutionConfiguration(): Promise<ExecutionConfigurationBuilder> {
-        return this._promise.then(obj => obj.createExecutionConfiguration());
+    createExecutionConfiguration(): ExecutionConfigurationBuilderPromise {
+        return new ExecutionConfigurationBuilderPromiseImpl(this._promise.then(obj => obj.createExecutionConfiguration()), this._client);
     }
 
     withOptionalString(options?: WithOptionalStringOptions): ContainerResourcePromise {
@@ -16745,7 +17831,7 @@ export interface CSharpAppResource {
      * @param name The name of the endpoint.
      * @returns An `EndpointReference` that can be used to resolve the address of the endpoint after resource allocation has occurred.
      */
-    getEndpoint(name: string): Promise<EndpointReference>;
+    getEndpoint(name: string): EndpointReferencePromise;
     /**
      * Configures a resource to mark all endpoints' transport as HTTP/2. This is useful for HTTP/2 services that need prior knowledge.
      * @returns The resource builder.
@@ -17053,7 +18139,7 @@ export interface CSharpAppResource {
      * Creates an execution configuration builder for the specified resource.
      * @returns The execution configuration builder.
      */
-    createExecutionConfiguration(): Promise<ExecutionConfigurationBuilder>;
+    createExecutionConfiguration(): ExecutionConfigurationBuilderPromise;
     /**
      * Adds an optional string parameter
      * @param options Additional options.
@@ -17307,7 +18393,7 @@ export interface CSharpAppResourcePromise extends PromiseLike<CSharpAppResource>
      * @param name The name of the endpoint.
      * @returns An `EndpointReference` that can be used to resolve the address of the endpoint after resource allocation has occurred.
      */
-    getEndpoint(name: string): Promise<EndpointReference>;
+    getEndpoint(name: string): EndpointReferencePromise;
     /**
      * Configures a resource to mark all endpoints' transport as HTTP/2. This is useful for HTTP/2 services that need prior knowledge.
      * @returns The resource builder.
@@ -17615,7 +18701,7 @@ export interface CSharpAppResourcePromise extends PromiseLike<CSharpAppResource>
      * Creates an execution configuration builder for the specified resource.
      * @returns The execution configuration builder.
      */
-    createExecutionConfiguration(): Promise<ExecutionConfigurationBuilder>;
+    createExecutionConfiguration(): ExecutionConfigurationBuilderPromise;
     /**
      * Adds an optional string parameter
      * @param options Additional options.
@@ -18315,12 +19401,16 @@ class CSharpAppResourceImpl extends ResourceBuilderBase<CSharpAppResourceHandle>
      * @param name The name of the endpoint.
      * @returns An `EndpointReference` that can be used to resolve the address of the endpoint after resource allocation has occurred.
      */
-    async getEndpoint(name: string): Promise<EndpointReference> {
-        const rpcArgs: Record<string, unknown> = { builder: this._handle, name };
-        return await this._client.invokeCapability<EndpointReference>(
-            'Aspire.Hosting/getEndpoint',
-            rpcArgs
-        );
+    getEndpoint(name: string): EndpointReferencePromise {
+        const promise = (async () => {
+            const rpcArgs: Record<string, unknown> = { builder: this._handle, name };
+            const handle = await this._client.invokeCapability<EndpointReferenceHandle>(
+                'Aspire.Hosting/getEndpoint',
+                rpcArgs
+            );
+            return new EndpointReferenceImpl(handle, this._client);
+        })();
+        return new EndpointReferencePromiseImpl(promise, this._client);
     }
 
     /** @internal */
@@ -19260,12 +20350,16 @@ class CSharpAppResourceImpl extends ResourceBuilderBase<CSharpAppResourceHandle>
      * Creates an execution configuration builder for the specified resource.
      * @returns The execution configuration builder.
      */
-    async createExecutionConfiguration(): Promise<ExecutionConfigurationBuilder> {
-        const rpcArgs: Record<string, unknown> = { resource: this._handle };
-        return await this._client.invokeCapability<ExecutionConfigurationBuilder>(
-            'Aspire.Hosting/createExecutionConfiguration',
-            rpcArgs
-        );
+    createExecutionConfiguration(): ExecutionConfigurationBuilderPromise {
+        const promise = (async () => {
+            const rpcArgs: Record<string, unknown> = { resource: this._handle };
+            const handle = await this._client.invokeCapability<IExecutionConfigurationBuilderHandle>(
+                'Aspire.Hosting/createExecutionConfiguration',
+                rpcArgs
+            );
+            return new ExecutionConfigurationBuilderImpl(handle, this._client);
+        })();
+        return new ExecutionConfigurationBuilderPromiseImpl(promise, this._client);
     }
 
     /** @internal */
@@ -19799,8 +20893,8 @@ class CSharpAppResourcePromiseImpl implements CSharpAppResourcePromise {
         return new CSharpAppResourcePromiseImpl(this._promise.then(obj => obj.withExternalHttpEndpoints()), this._client);
     }
 
-    getEndpoint(name: string): Promise<EndpointReference> {
-        return this._promise.then(obj => obj.getEndpoint(name));
+    getEndpoint(name: string): EndpointReferencePromise {
+        return new EndpointReferencePromiseImpl(this._promise.then(obj => obj.getEndpoint(name)), this._client);
     }
 
     asHttp2Service(): CSharpAppResourcePromise {
@@ -19963,8 +21057,8 @@ class CSharpAppResourcePromiseImpl implements CSharpAppResourcePromise {
         return new CSharpAppResourcePromiseImpl(this._promise.then(obj => obj.onResourceReady(callback)), this._client);
     }
 
-    createExecutionConfiguration(): Promise<ExecutionConfigurationBuilder> {
-        return this._promise.then(obj => obj.createExecutionConfiguration());
+    createExecutionConfiguration(): ExecutionConfigurationBuilderPromise {
+        return new ExecutionConfigurationBuilderPromiseImpl(this._promise.then(obj => obj.createExecutionConfiguration()), this._client);
     }
 
     withOptionalString(options?: WithOptionalStringOptions): CSharpAppResourcePromise {
@@ -20295,7 +21389,7 @@ export interface DotnetToolResource {
      * @param name The name of the endpoint.
      * @returns An `EndpointReference` that can be used to resolve the address of the endpoint after resource allocation has occurred.
      */
-    getEndpoint(name: string): Promise<EndpointReference>;
+    getEndpoint(name: string): EndpointReferencePromise;
     /**
      * Configures a resource to mark all endpoints' transport as HTTP/2. This is useful for HTTP/2 services that need prior knowledge.
      * @returns The resource builder.
@@ -20597,7 +21691,7 @@ export interface DotnetToolResource {
      * Creates an execution configuration builder for the specified resource.
      * @returns The execution configuration builder.
      */
-    createExecutionConfiguration(): Promise<ExecutionConfigurationBuilder>;
+    createExecutionConfiguration(): ExecutionConfigurationBuilderPromise;
     /**
      * Adds an optional string parameter
      * @param options Additional options.
@@ -20885,7 +21979,7 @@ export interface DotnetToolResourcePromise extends PromiseLike<DotnetToolResourc
      * @param name The name of the endpoint.
      * @returns An `EndpointReference` that can be used to resolve the address of the endpoint after resource allocation has occurred.
      */
-    getEndpoint(name: string): Promise<EndpointReference>;
+    getEndpoint(name: string): EndpointReferencePromise;
     /**
      * Configures a resource to mark all endpoints' transport as HTTP/2. This is useful for HTTP/2 services that need prior knowledge.
      * @returns The resource builder.
@@ -21187,7 +22281,7 @@ export interface DotnetToolResourcePromise extends PromiseLike<DotnetToolResourc
      * Creates an execution configuration builder for the specified resource.
      * @returns The execution configuration builder.
      */
-    createExecutionConfiguration(): Promise<ExecutionConfigurationBuilder>;
+    createExecutionConfiguration(): ExecutionConfigurationBuilderPromise;
     /**
      * Adds an optional string parameter
      * @param options Additional options.
@@ -21997,12 +23091,16 @@ class DotnetToolResourceImpl extends ResourceBuilderBase<DotnetToolResourceHandl
      * @param name The name of the endpoint.
      * @returns An `EndpointReference` that can be used to resolve the address of the endpoint after resource allocation has occurred.
      */
-    async getEndpoint(name: string): Promise<EndpointReference> {
-        const rpcArgs: Record<string, unknown> = { builder: this._handle, name };
-        return await this._client.invokeCapability<EndpointReference>(
-            'Aspire.Hosting/getEndpoint',
-            rpcArgs
-        );
+    getEndpoint(name: string): EndpointReferencePromise {
+        const promise = (async () => {
+            const rpcArgs: Record<string, unknown> = { builder: this._handle, name };
+            const handle = await this._client.invokeCapability<EndpointReferenceHandle>(
+                'Aspire.Hosting/getEndpoint',
+                rpcArgs
+            );
+            return new EndpointReferenceImpl(handle, this._client);
+        })();
+        return new EndpointReferencePromiseImpl(promise, this._client);
     }
 
     /** @internal */
@@ -22922,12 +24020,16 @@ class DotnetToolResourceImpl extends ResourceBuilderBase<DotnetToolResourceHandl
      * Creates an execution configuration builder for the specified resource.
      * @returns The execution configuration builder.
      */
-    async createExecutionConfiguration(): Promise<ExecutionConfigurationBuilder> {
-        const rpcArgs: Record<string, unknown> = { resource: this._handle };
-        return await this._client.invokeCapability<ExecutionConfigurationBuilder>(
-            'Aspire.Hosting/createExecutionConfiguration',
-            rpcArgs
-        );
+    createExecutionConfiguration(): ExecutionConfigurationBuilderPromise {
+        const promise = (async () => {
+            const rpcArgs: Record<string, unknown> = { resource: this._handle };
+            const handle = await this._client.invokeCapability<IExecutionConfigurationBuilderHandle>(
+                'Aspire.Hosting/createExecutionConfiguration',
+                rpcArgs
+            );
+            return new ExecutionConfigurationBuilderImpl(handle, this._client);
+        })();
+        return new ExecutionConfigurationBuilderPromiseImpl(promise, this._client);
     }
 
     /** @internal */
@@ -23485,8 +24587,8 @@ class DotnetToolResourcePromiseImpl implements DotnetToolResourcePromise {
         return new DotnetToolResourcePromiseImpl(this._promise.then(obj => obj.withExternalHttpEndpoints()), this._client);
     }
 
-    getEndpoint(name: string): Promise<EndpointReference> {
-        return this._promise.then(obj => obj.getEndpoint(name));
+    getEndpoint(name: string): EndpointReferencePromise {
+        return new EndpointReferencePromiseImpl(this._promise.then(obj => obj.getEndpoint(name)), this._client);
     }
 
     asHttp2Service(): DotnetToolResourcePromise {
@@ -23645,8 +24747,8 @@ class DotnetToolResourcePromiseImpl implements DotnetToolResourcePromise {
         return new DotnetToolResourcePromiseImpl(this._promise.then(obj => obj.onResourceReady(callback)), this._client);
     }
 
-    createExecutionConfiguration(): Promise<ExecutionConfigurationBuilder> {
-        return this._promise.then(obj => obj.createExecutionConfiguration());
+    createExecutionConfiguration(): ExecutionConfigurationBuilderPromise {
+        return new ExecutionConfigurationBuilderPromiseImpl(this._promise.then(obj => obj.createExecutionConfiguration()), this._client);
     }
 
     withOptionalString(options?: WithOptionalStringOptions): DotnetToolResourcePromise {
@@ -23951,7 +25053,7 @@ export interface ExecutableResource {
      * @param name The name of the endpoint.
      * @returns An `EndpointReference` that can be used to resolve the address of the endpoint after resource allocation has occurred.
      */
-    getEndpoint(name: string): Promise<EndpointReference>;
+    getEndpoint(name: string): EndpointReferencePromise;
     /**
      * Configures a resource to mark all endpoints' transport as HTTP/2. This is useful for HTTP/2 services that need prior knowledge.
      * @returns The resource builder.
@@ -24253,7 +25355,7 @@ export interface ExecutableResource {
      * Creates an execution configuration builder for the specified resource.
      * @returns The execution configuration builder.
      */
-    createExecutionConfiguration(): Promise<ExecutionConfigurationBuilder>;
+    createExecutionConfiguration(): ExecutionConfigurationBuilderPromise;
     /**
      * Adds an optional string parameter
      * @param options Additional options.
@@ -24508,7 +25610,7 @@ export interface ExecutableResourcePromise extends PromiseLike<ExecutableResourc
      * @param name The name of the endpoint.
      * @returns An `EndpointReference` that can be used to resolve the address of the endpoint after resource allocation has occurred.
      */
-    getEndpoint(name: string): Promise<EndpointReference>;
+    getEndpoint(name: string): EndpointReferencePromise;
     /**
      * Configures a resource to mark all endpoints' transport as HTTP/2. This is useful for HTTP/2 services that need prior knowledge.
      * @returns The resource builder.
@@ -24810,7 +25912,7 @@ export interface ExecutableResourcePromise extends PromiseLike<ExecutableResourc
      * Creates an execution configuration builder for the specified resource.
      * @returns The execution configuration builder.
      */
-    createExecutionConfiguration(): Promise<ExecutionConfigurationBuilder>;
+    createExecutionConfiguration(): ExecutionConfigurationBuilderPromise;
     /**
      * Adds an optional string parameter
      * @param options Additional options.
@@ -25516,12 +26618,16 @@ class ExecutableResourceImpl extends ResourceBuilderBase<ExecutableResourceHandl
      * @param name The name of the endpoint.
      * @returns An `EndpointReference` that can be used to resolve the address of the endpoint after resource allocation has occurred.
      */
-    async getEndpoint(name: string): Promise<EndpointReference> {
-        const rpcArgs: Record<string, unknown> = { builder: this._handle, name };
-        return await this._client.invokeCapability<EndpointReference>(
-            'Aspire.Hosting/getEndpoint',
-            rpcArgs
-        );
+    getEndpoint(name: string): EndpointReferencePromise {
+        const promise = (async () => {
+            const rpcArgs: Record<string, unknown> = { builder: this._handle, name };
+            const handle = await this._client.invokeCapability<EndpointReferenceHandle>(
+                'Aspire.Hosting/getEndpoint',
+                rpcArgs
+            );
+            return new EndpointReferenceImpl(handle, this._client);
+        })();
+        return new EndpointReferencePromiseImpl(promise, this._client);
     }
 
     /** @internal */
@@ -26441,12 +27547,16 @@ class ExecutableResourceImpl extends ResourceBuilderBase<ExecutableResourceHandl
      * Creates an execution configuration builder for the specified resource.
      * @returns The execution configuration builder.
      */
-    async createExecutionConfiguration(): Promise<ExecutionConfigurationBuilder> {
-        const rpcArgs: Record<string, unknown> = { resource: this._handle };
-        return await this._client.invokeCapability<ExecutionConfigurationBuilder>(
-            'Aspire.Hosting/createExecutionConfiguration',
-            rpcArgs
-        );
+    createExecutionConfiguration(): ExecutionConfigurationBuilderPromise {
+        const promise = (async () => {
+            const rpcArgs: Record<string, unknown> = { resource: this._handle };
+            const handle = await this._client.invokeCapability<IExecutionConfigurationBuilderHandle>(
+                'Aspire.Hosting/createExecutionConfiguration',
+                rpcArgs
+            );
+            return new ExecutionConfigurationBuilderImpl(handle, this._client);
+        })();
+        return new ExecutionConfigurationBuilderPromiseImpl(promise, this._client);
     }
 
     /** @internal */
@@ -26980,8 +28090,8 @@ class ExecutableResourcePromiseImpl implements ExecutableResourcePromise {
         return new ExecutableResourcePromiseImpl(this._promise.then(obj => obj.withExternalHttpEndpoints()), this._client);
     }
 
-    getEndpoint(name: string): Promise<EndpointReference> {
-        return this._promise.then(obj => obj.getEndpoint(name));
+    getEndpoint(name: string): EndpointReferencePromise {
+        return new EndpointReferencePromiseImpl(this._promise.then(obj => obj.getEndpoint(name)), this._client);
     }
 
     asHttp2Service(): ExecutableResourcePromise {
@@ -27140,8 +28250,8 @@ class ExecutableResourcePromiseImpl implements ExecutableResourcePromise {
         return new ExecutableResourcePromiseImpl(this._promise.then(obj => obj.onResourceReady(callback)), this._client);
     }
 
-    createExecutionConfiguration(): Promise<ExecutionConfigurationBuilder> {
-        return this._promise.then(obj => obj.createExecutionConfiguration());
+    createExecutionConfiguration(): ExecutionConfigurationBuilderPromise {
+        return new ExecutionConfigurationBuilderPromiseImpl(this._promise.then(obj => obj.createExecutionConfiguration()), this._client);
     }
 
     withOptionalString(options?: WithOptionalStringOptions): ExecutableResourcePromise {
@@ -27471,7 +28581,7 @@ export interface ExternalServiceResource {
      * Creates an execution configuration builder for the specified resource.
      * @returns The execution configuration builder.
      */
-    createExecutionConfiguration(): Promise<ExecutionConfigurationBuilder>;
+    createExecutionConfiguration(): ExecutionConfigurationBuilderPromise;
     /**
      * Adds an optional string parameter
      * @param options Additional options.
@@ -27754,7 +28864,7 @@ export interface ExternalServiceResourcePromise extends PromiseLike<ExternalServ
      * Creates an execution configuration builder for the specified resource.
      * @returns The execution configuration builder.
      */
-    createExecutionConfiguration(): Promise<ExecutionConfigurationBuilder>;
+    createExecutionConfiguration(): ExecutionConfigurationBuilderPromise;
     /**
      * Adds an optional string parameter
      * @param options Additional options.
@@ -28527,12 +29637,16 @@ class ExternalServiceResourceImpl extends ResourceBuilderBase<ExternalServiceRes
      * Creates an execution configuration builder for the specified resource.
      * @returns The execution configuration builder.
      */
-    async createExecutionConfiguration(): Promise<ExecutionConfigurationBuilder> {
-        const rpcArgs: Record<string, unknown> = { resource: this._handle };
-        return await this._client.invokeCapability<ExecutionConfigurationBuilder>(
-            'Aspire.Hosting/createExecutionConfiguration',
-            rpcArgs
-        );
+    createExecutionConfiguration(): ExecutionConfigurationBuilderPromise {
+        const promise = (async () => {
+            const rpcArgs: Record<string, unknown> = { resource: this._handle };
+            const handle = await this._client.invokeCapability<IExecutionConfigurationBuilderHandle>(
+                'Aspire.Hosting/createExecutionConfiguration',
+                rpcArgs
+            );
+            return new ExecutionConfigurationBuilderImpl(handle, this._client);
+        })();
+        return new ExecutionConfigurationBuilderPromiseImpl(promise, this._client);
     }
 
     /** @internal */
@@ -29051,8 +30165,8 @@ class ExternalServiceResourcePromiseImpl implements ExternalServiceResourcePromi
         return new ExternalServiceResourcePromiseImpl(this._promise.then(obj => obj.onResourceReady(callback)), this._client);
     }
 
-    createExecutionConfiguration(): Promise<ExecutionConfigurationBuilder> {
-        return this._promise.then(obj => obj.createExecutionConfiguration());
+    createExecutionConfiguration(): ExecutionConfigurationBuilderPromise {
+        return new ExecutionConfigurationBuilderPromiseImpl(this._promise.then(obj => obj.createExecutionConfiguration()), this._client);
     }
 
     withOptionalString(options?: WithOptionalStringOptions): ExternalServiceResourcePromise {
@@ -29383,7 +30497,7 @@ export interface ParameterResource {
      * Creates an execution configuration builder for the specified resource.
      * @returns The execution configuration builder.
      */
-    createExecutionConfiguration(): Promise<ExecutionConfigurationBuilder>;
+    createExecutionConfiguration(): ExecutionConfigurationBuilderPromise;
     /**
      * Adds an optional string parameter
      * @param options Additional options.
@@ -29674,7 +30788,7 @@ export interface ParameterResourcePromise extends PromiseLike<ParameterResource>
      * Creates an execution configuration builder for the specified resource.
      * @returns The execution configuration builder.
      */
-    createExecutionConfiguration(): Promise<ExecutionConfigurationBuilder>;
+    createExecutionConfiguration(): ExecutionConfigurationBuilderPromise;
     /**
      * Adds an optional string parameter
      * @param options Additional options.
@@ -30465,12 +31579,16 @@ class ParameterResourceImpl extends ResourceBuilderBase<ParameterResourceHandle>
      * Creates an execution configuration builder for the specified resource.
      * @returns The execution configuration builder.
      */
-    async createExecutionConfiguration(): Promise<ExecutionConfigurationBuilder> {
-        const rpcArgs: Record<string, unknown> = { resource: this._handle };
-        return await this._client.invokeCapability<ExecutionConfigurationBuilder>(
-            'Aspire.Hosting/createExecutionConfiguration',
-            rpcArgs
-        );
+    createExecutionConfiguration(): ExecutionConfigurationBuilderPromise {
+        const promise = (async () => {
+            const rpcArgs: Record<string, unknown> = { resource: this._handle };
+            const handle = await this._client.invokeCapability<IExecutionConfigurationBuilderHandle>(
+                'Aspire.Hosting/createExecutionConfiguration',
+                rpcArgs
+            );
+            return new ExecutionConfigurationBuilderImpl(handle, this._client);
+        })();
+        return new ExecutionConfigurationBuilderPromiseImpl(promise, this._client);
     }
 
     /** @internal */
@@ -30993,8 +32111,8 @@ class ParameterResourcePromiseImpl implements ParameterResourcePromise {
         return new ParameterResourcePromiseImpl(this._promise.then(obj => obj.onResourceReady(callback)), this._client);
     }
 
-    createExecutionConfiguration(): Promise<ExecutionConfigurationBuilder> {
-        return this._promise.then(obj => obj.createExecutionConfiguration());
+    createExecutionConfiguration(): ExecutionConfigurationBuilderPromise {
+        return new ExecutionConfigurationBuilderPromiseImpl(this._promise.then(obj => obj.createExecutionConfiguration()), this._client);
     }
 
     withOptionalString(options?: WithOptionalStringOptions): ParameterResourcePromise {
@@ -31284,7 +32402,7 @@ export interface ProjectResource {
      * @param name The name of the endpoint.
      * @returns An `EndpointReference` that can be used to resolve the address of the endpoint after resource allocation has occurred.
      */
-    getEndpoint(name: string): Promise<EndpointReference>;
+    getEndpoint(name: string): EndpointReferencePromise;
     /**
      * Configures a resource to mark all endpoints' transport as HTTP/2. This is useful for HTTP/2 services that need prior knowledge.
      * @returns The resource builder.
@@ -31592,7 +32710,7 @@ export interface ProjectResource {
      * Creates an execution configuration builder for the specified resource.
      * @returns The execution configuration builder.
      */
-    createExecutionConfiguration(): Promise<ExecutionConfigurationBuilder>;
+    createExecutionConfiguration(): ExecutionConfigurationBuilderPromise;
     /**
      * Adds an optional string parameter
      * @param options Additional options.
@@ -31846,7 +32964,7 @@ export interface ProjectResourcePromise extends PromiseLike<ProjectResource> {
      * @param name The name of the endpoint.
      * @returns An `EndpointReference` that can be used to resolve the address of the endpoint after resource allocation has occurred.
      */
-    getEndpoint(name: string): Promise<EndpointReference>;
+    getEndpoint(name: string): EndpointReferencePromise;
     /**
      * Configures a resource to mark all endpoints' transport as HTTP/2. This is useful for HTTP/2 services that need prior knowledge.
      * @returns The resource builder.
@@ -32154,7 +33272,7 @@ export interface ProjectResourcePromise extends PromiseLike<ProjectResource> {
      * Creates an execution configuration builder for the specified resource.
      * @returns The execution configuration builder.
      */
-    createExecutionConfiguration(): Promise<ExecutionConfigurationBuilder>;
+    createExecutionConfiguration(): ExecutionConfigurationBuilderPromise;
     /**
      * Adds an optional string parameter
      * @param options Additional options.
@@ -32855,12 +33973,16 @@ class ProjectResourceImpl extends ResourceBuilderBase<ProjectResourceHandle> imp
      * @param name The name of the endpoint.
      * @returns An `EndpointReference` that can be used to resolve the address of the endpoint after resource allocation has occurred.
      */
-    async getEndpoint(name: string): Promise<EndpointReference> {
-        const rpcArgs: Record<string, unknown> = { builder: this._handle, name };
-        return await this._client.invokeCapability<EndpointReference>(
-            'Aspire.Hosting/getEndpoint',
-            rpcArgs
-        );
+    getEndpoint(name: string): EndpointReferencePromise {
+        const promise = (async () => {
+            const rpcArgs: Record<string, unknown> = { builder: this._handle, name };
+            const handle = await this._client.invokeCapability<EndpointReferenceHandle>(
+                'Aspire.Hosting/getEndpoint',
+                rpcArgs
+            );
+            return new EndpointReferenceImpl(handle, this._client);
+        })();
+        return new EndpointReferencePromiseImpl(promise, this._client);
     }
 
     /** @internal */
@@ -33800,12 +34922,16 @@ class ProjectResourceImpl extends ResourceBuilderBase<ProjectResourceHandle> imp
      * Creates an execution configuration builder for the specified resource.
      * @returns The execution configuration builder.
      */
-    async createExecutionConfiguration(): Promise<ExecutionConfigurationBuilder> {
-        const rpcArgs: Record<string, unknown> = { resource: this._handle };
-        return await this._client.invokeCapability<ExecutionConfigurationBuilder>(
-            'Aspire.Hosting/createExecutionConfiguration',
-            rpcArgs
-        );
+    createExecutionConfiguration(): ExecutionConfigurationBuilderPromise {
+        const promise = (async () => {
+            const rpcArgs: Record<string, unknown> = { resource: this._handle };
+            const handle = await this._client.invokeCapability<IExecutionConfigurationBuilderHandle>(
+                'Aspire.Hosting/createExecutionConfiguration',
+                rpcArgs
+            );
+            return new ExecutionConfigurationBuilderImpl(handle, this._client);
+        })();
+        return new ExecutionConfigurationBuilderPromiseImpl(promise, this._client);
     }
 
     /** @internal */
@@ -34339,8 +35465,8 @@ class ProjectResourcePromiseImpl implements ProjectResourcePromise {
         return new ProjectResourcePromiseImpl(this._promise.then(obj => obj.withExternalHttpEndpoints()), this._client);
     }
 
-    getEndpoint(name: string): Promise<EndpointReference> {
-        return this._promise.then(obj => obj.getEndpoint(name));
+    getEndpoint(name: string): EndpointReferencePromise {
+        return new EndpointReferencePromiseImpl(this._promise.then(obj => obj.getEndpoint(name)), this._client);
     }
 
     asHttp2Service(): ProjectResourcePromise {
@@ -34503,8 +35629,8 @@ class ProjectResourcePromiseImpl implements ProjectResourcePromise {
         return new ProjectResourcePromiseImpl(this._promise.then(obj => obj.onResourceReady(callback)), this._client);
     }
 
-    createExecutionConfiguration(): Promise<ExecutionConfigurationBuilder> {
-        return this._promise.then(obj => obj.createExecutionConfiguration());
+    createExecutionConfiguration(): ExecutionConfigurationBuilderPromise {
+        return new ExecutionConfigurationBuilderPromiseImpl(this._promise.then(obj => obj.createExecutionConfiguration()), this._client);
     }
 
     withOptionalString(options?: WithOptionalStringOptions): ProjectResourcePromise {
@@ -34932,7 +36058,7 @@ export interface TestDatabaseResource {
      * @param name The name of the endpoint.
      * @returns An `EndpointReference` that can be used to resolve the address of the endpoint after resource allocation has occurred.
      */
-    getEndpoint(name: string): Promise<EndpointReference>;
+    getEndpoint(name: string): EndpointReferencePromise;
     /**
      * Configures a resource to mark all endpoints' transport as HTTP/2. This is useful for HTTP/2 services that need prior knowledge.
      * @returns The resource builder.
@@ -35248,7 +36374,7 @@ export interface TestDatabaseResource {
      * Creates an execution configuration builder for the specified resource.
      * @returns The execution configuration builder.
      */
-    createExecutionConfiguration(): Promise<ExecutionConfigurationBuilder>;
+    createExecutionConfiguration(): ExecutionConfigurationBuilderPromise;
     /**
      * Adds an optional string parameter
      * @param options Additional options.
@@ -35633,7 +36759,7 @@ export interface TestDatabaseResourcePromise extends PromiseLike<TestDatabaseRes
      * @param name The name of the endpoint.
      * @returns An `EndpointReference` that can be used to resolve the address of the endpoint after resource allocation has occurred.
      */
-    getEndpoint(name: string): Promise<EndpointReference>;
+    getEndpoint(name: string): EndpointReferencePromise;
     /**
      * Configures a resource to mark all endpoints' transport as HTTP/2. This is useful for HTTP/2 services that need prior knowledge.
      * @returns The resource builder.
@@ -35949,7 +37075,7 @@ export interface TestDatabaseResourcePromise extends PromiseLike<TestDatabaseRes
      * Creates an execution configuration builder for the specified resource.
      * @returns The execution configuration builder.
      */
-    createExecutionConfiguration(): Promise<ExecutionConfigurationBuilder>;
+    createExecutionConfiguration(): ExecutionConfigurationBuilderPromise;
     /**
      * Adds an optional string parameter
      * @param options Additional options.
@@ -36991,12 +38117,16 @@ class TestDatabaseResourceImpl extends ResourceBuilderBase<TestDatabaseResourceH
      * @param name The name of the endpoint.
      * @returns An `EndpointReference` that can be used to resolve the address of the endpoint after resource allocation has occurred.
      */
-    async getEndpoint(name: string): Promise<EndpointReference> {
-        const rpcArgs: Record<string, unknown> = { builder: this._handle, name };
-        return await this._client.invokeCapability<EndpointReference>(
-            'Aspire.Hosting/getEndpoint',
-            rpcArgs
-        );
+    getEndpoint(name: string): EndpointReferencePromise {
+        const promise = (async () => {
+            const rpcArgs: Record<string, unknown> = { builder: this._handle, name };
+            const handle = await this._client.invokeCapability<EndpointReferenceHandle>(
+                'Aspire.Hosting/getEndpoint',
+                rpcArgs
+            );
+            return new EndpointReferenceImpl(handle, this._client);
+        })();
+        return new EndpointReferencePromiseImpl(promise, this._client);
     }
 
     /** @internal */
@@ -37947,12 +39077,16 @@ class TestDatabaseResourceImpl extends ResourceBuilderBase<TestDatabaseResourceH
      * Creates an execution configuration builder for the specified resource.
      * @returns The execution configuration builder.
      */
-    async createExecutionConfiguration(): Promise<ExecutionConfigurationBuilder> {
-        const rpcArgs: Record<string, unknown> = { resource: this._handle };
-        return await this._client.invokeCapability<ExecutionConfigurationBuilder>(
-            'Aspire.Hosting/createExecutionConfiguration',
-            rpcArgs
-        );
+    createExecutionConfiguration(): ExecutionConfigurationBuilderPromise {
+        const promise = (async () => {
+            const rpcArgs: Record<string, unknown> = { resource: this._handle };
+            const handle = await this._client.invokeCapability<IExecutionConfigurationBuilderHandle>(
+                'Aspire.Hosting/createExecutionConfiguration',
+                rpcArgs
+            );
+            return new ExecutionConfigurationBuilderImpl(handle, this._client);
+        })();
+        return new ExecutionConfigurationBuilderPromiseImpl(promise, this._client);
     }
 
     /** @internal */
@@ -38546,8 +39680,8 @@ class TestDatabaseResourcePromiseImpl implements TestDatabaseResourcePromise {
         return new TestDatabaseResourcePromiseImpl(this._promise.then(obj => obj.withExternalHttpEndpoints()), this._client);
     }
 
-    getEndpoint(name: string): Promise<EndpointReference> {
-        return this._promise.then(obj => obj.getEndpoint(name));
+    getEndpoint(name: string): EndpointReferencePromise {
+        return new EndpointReferencePromiseImpl(this._promise.then(obj => obj.getEndpoint(name)), this._client);
     }
 
     asHttp2Service(): TestDatabaseResourcePromise {
@@ -38710,8 +39844,8 @@ class TestDatabaseResourcePromiseImpl implements TestDatabaseResourcePromise {
         return new TestDatabaseResourcePromiseImpl(this._promise.then(obj => obj.onResourceReady(callback)), this._client);
     }
 
-    createExecutionConfiguration(): Promise<ExecutionConfigurationBuilder> {
-        return this._promise.then(obj => obj.createExecutionConfiguration());
+    createExecutionConfiguration(): ExecutionConfigurationBuilderPromise {
+        return new ExecutionConfigurationBuilderPromiseImpl(this._promise.then(obj => obj.createExecutionConfiguration()), this._client);
     }
 
     withOptionalString(options?: WithOptionalStringOptions): TestDatabaseResourcePromise {
@@ -39155,7 +40289,7 @@ export interface TestRedisResource {
      * @param name The name of the endpoint.
      * @returns An `EndpointReference` that can be used to resolve the address of the endpoint after resource allocation has occurred.
      */
-    getEndpoint(name: string): Promise<EndpointReference>;
+    getEndpoint(name: string): EndpointReferencePromise;
     /**
      * Configures a resource to mark all endpoints' transport as HTTP/2. This is useful for HTTP/2 services that need prior knowledge.
      * @returns The resource builder.
@@ -39477,7 +40611,7 @@ export interface TestRedisResource {
      * Creates an execution configuration builder for the specified resource.
      * @returns The execution configuration builder.
      */
-    createExecutionConfiguration(): Promise<ExecutionConfigurationBuilder>;
+    createExecutionConfiguration(): ExecutionConfigurationBuilderPromise;
     /**
      * Adds a child database to a test Redis resource
      *
@@ -39920,7 +41054,7 @@ export interface TestRedisResourcePromise extends PromiseLike<TestRedisResource>
      * @param name The name of the endpoint.
      * @returns An `EndpointReference` that can be used to resolve the address of the endpoint after resource allocation has occurred.
      */
-    getEndpoint(name: string): Promise<EndpointReference>;
+    getEndpoint(name: string): EndpointReferencePromise;
     /**
      * Configures a resource to mark all endpoints' transport as HTTP/2. This is useful for HTTP/2 services that need prior knowledge.
      * @returns The resource builder.
@@ -40242,7 +41376,7 @@ export interface TestRedisResourcePromise extends PromiseLike<TestRedisResource>
      * Creates an execution configuration builder for the specified resource.
      * @returns The execution configuration builder.
      */
-    createExecutionConfiguration(): Promise<ExecutionConfigurationBuilder>;
+    createExecutionConfiguration(): ExecutionConfigurationBuilderPromise;
     /**
      * Adds a child database to a test Redis resource
      *
@@ -41362,12 +42496,16 @@ class TestRedisResourceImpl extends ResourceBuilderBase<TestRedisResourceHandle>
      * @param name The name of the endpoint.
      * @returns An `EndpointReference` that can be used to resolve the address of the endpoint after resource allocation has occurred.
      */
-    async getEndpoint(name: string): Promise<EndpointReference> {
-        const rpcArgs: Record<string, unknown> = { builder: this._handle, name };
-        return await this._client.invokeCapability<EndpointReference>(
-            'Aspire.Hosting/getEndpoint',
-            rpcArgs
-        );
+    getEndpoint(name: string): EndpointReferencePromise {
+        const promise = (async () => {
+            const rpcArgs: Record<string, unknown> = { builder: this._handle, name };
+            const handle = await this._client.invokeCapability<EndpointReferenceHandle>(
+                'Aspire.Hosting/getEndpoint',
+                rpcArgs
+            );
+            return new EndpointReferenceImpl(handle, this._client);
+        })();
+        return new EndpointReferencePromiseImpl(promise, this._client);
     }
 
     /** @internal */
@@ -42342,12 +43480,16 @@ class TestRedisResourceImpl extends ResourceBuilderBase<TestRedisResourceHandle>
      * Creates an execution configuration builder for the specified resource.
      * @returns The execution configuration builder.
      */
-    async createExecutionConfiguration(): Promise<ExecutionConfigurationBuilder> {
-        const rpcArgs: Record<string, unknown> = { resource: this._handle };
-        return await this._client.invokeCapability<ExecutionConfigurationBuilder>(
-            'Aspire.Hosting/createExecutionConfiguration',
-            rpcArgs
-        );
+    createExecutionConfiguration(): ExecutionConfigurationBuilderPromise {
+        const promise = (async () => {
+            const rpcArgs: Record<string, unknown> = { resource: this._handle };
+            const handle = await this._client.invokeCapability<IExecutionConfigurationBuilderHandle>(
+                'Aspire.Hosting/createExecutionConfiguration',
+                rpcArgs
+            );
+            return new ExecutionConfigurationBuilderImpl(handle, this._client);
+        })();
+        return new ExecutionConfigurationBuilderPromiseImpl(promise, this._client);
     }
 
     /** @internal */
@@ -43136,8 +44278,8 @@ class TestRedisResourcePromiseImpl implements TestRedisResourcePromise {
         return new TestRedisResourcePromiseImpl(this._promise.then(obj => obj.withExternalHttpEndpoints()), this._client);
     }
 
-    getEndpoint(name: string): Promise<EndpointReference> {
-        return this._promise.then(obj => obj.getEndpoint(name));
+    getEndpoint(name: string): EndpointReferencePromise {
+        return new EndpointReferencePromiseImpl(this._promise.then(obj => obj.getEndpoint(name)), this._client);
     }
 
     asHttp2Service(): TestRedisResourcePromise {
@@ -43304,8 +44446,8 @@ class TestRedisResourcePromiseImpl implements TestRedisResourcePromise {
         return new TestRedisResourcePromiseImpl(this._promise.then(obj => obj.onResourceReady(callback)), this._client);
     }
 
-    createExecutionConfiguration(): Promise<ExecutionConfigurationBuilder> {
-        return this._promise.then(obj => obj.createExecutionConfiguration());
+    createExecutionConfiguration(): ExecutionConfigurationBuilderPromise {
+        return new ExecutionConfigurationBuilderPromiseImpl(this._promise.then(obj => obj.createExecutionConfiguration()), this._client);
     }
 
     addTestChildDatabase(name: string, options?: AddTestChildDatabaseOptions): TestDatabaseResourcePromise {
@@ -43781,7 +44923,7 @@ export interface TestVaultResource {
      * @param name The name of the endpoint.
      * @returns An `EndpointReference` that can be used to resolve the address of the endpoint after resource allocation has occurred.
      */
-    getEndpoint(name: string): Promise<EndpointReference>;
+    getEndpoint(name: string): EndpointReferencePromise;
     /**
      * Configures a resource to mark all endpoints' transport as HTTP/2. This is useful for HTTP/2 services that need prior knowledge.
      * @returns The resource builder.
@@ -44097,7 +45239,7 @@ export interface TestVaultResource {
      * Creates an execution configuration builder for the specified resource.
      * @returns The execution configuration builder.
      */
-    createExecutionConfiguration(): Promise<ExecutionConfigurationBuilder>;
+    createExecutionConfiguration(): ExecutionConfigurationBuilderPromise;
     /**
      * Adds an optional string parameter
      * @param options Additional options.
@@ -44484,7 +45626,7 @@ export interface TestVaultResourcePromise extends PromiseLike<TestVaultResource>
      * @param name The name of the endpoint.
      * @returns An `EndpointReference` that can be used to resolve the address of the endpoint after resource allocation has occurred.
      */
-    getEndpoint(name: string): Promise<EndpointReference>;
+    getEndpoint(name: string): EndpointReferencePromise;
     /**
      * Configures a resource to mark all endpoints' transport as HTTP/2. This is useful for HTTP/2 services that need prior knowledge.
      * @returns The resource builder.
@@ -44800,7 +45942,7 @@ export interface TestVaultResourcePromise extends PromiseLike<TestVaultResource>
      * Creates an execution configuration builder for the specified resource.
      * @returns The execution configuration builder.
      */
-    createExecutionConfiguration(): Promise<ExecutionConfigurationBuilder>;
+    createExecutionConfiguration(): ExecutionConfigurationBuilderPromise;
     /**
      * Adds an optional string parameter
      * @param options Additional options.
@@ -45844,12 +46986,16 @@ class TestVaultResourceImpl extends ResourceBuilderBase<TestVaultResourceHandle>
      * @param name The name of the endpoint.
      * @returns An `EndpointReference` that can be used to resolve the address of the endpoint after resource allocation has occurred.
      */
-    async getEndpoint(name: string): Promise<EndpointReference> {
-        const rpcArgs: Record<string, unknown> = { builder: this._handle, name };
-        return await this._client.invokeCapability<EndpointReference>(
-            'Aspire.Hosting/getEndpoint',
-            rpcArgs
-        );
+    getEndpoint(name: string): EndpointReferencePromise {
+        const promise = (async () => {
+            const rpcArgs: Record<string, unknown> = { builder: this._handle, name };
+            const handle = await this._client.invokeCapability<EndpointReferenceHandle>(
+                'Aspire.Hosting/getEndpoint',
+                rpcArgs
+            );
+            return new EndpointReferenceImpl(handle, this._client);
+        })();
+        return new EndpointReferencePromiseImpl(promise, this._client);
     }
 
     /** @internal */
@@ -46800,12 +47946,16 @@ class TestVaultResourceImpl extends ResourceBuilderBase<TestVaultResourceHandle>
      * Creates an execution configuration builder for the specified resource.
      * @returns The execution configuration builder.
      */
-    async createExecutionConfiguration(): Promise<ExecutionConfigurationBuilder> {
-        const rpcArgs: Record<string, unknown> = { resource: this._handle };
-        return await this._client.invokeCapability<ExecutionConfigurationBuilder>(
-            'Aspire.Hosting/createExecutionConfiguration',
-            rpcArgs
-        );
+    createExecutionConfiguration(): ExecutionConfigurationBuilderPromise {
+        const promise = (async () => {
+            const rpcArgs: Record<string, unknown> = { resource: this._handle };
+            const handle = await this._client.invokeCapability<IExecutionConfigurationBuilderHandle>(
+                'Aspire.Hosting/createExecutionConfiguration',
+                rpcArgs
+            );
+            return new ExecutionConfigurationBuilderImpl(handle, this._client);
+        })();
+        return new ExecutionConfigurationBuilderPromiseImpl(promise, this._client);
     }
 
     /** @internal */
@@ -47414,8 +48564,8 @@ class TestVaultResourcePromiseImpl implements TestVaultResourcePromise {
         return new TestVaultResourcePromiseImpl(this._promise.then(obj => obj.withExternalHttpEndpoints()), this._client);
     }
 
-    getEndpoint(name: string): Promise<EndpointReference> {
-        return this._promise.then(obj => obj.getEndpoint(name));
+    getEndpoint(name: string): EndpointReferencePromise {
+        return new EndpointReferencePromiseImpl(this._promise.then(obj => obj.getEndpoint(name)), this._client);
     }
 
     asHttp2Service(): TestVaultResourcePromise {
@@ -47578,8 +48728,8 @@ class TestVaultResourcePromiseImpl implements TestVaultResourcePromise {
         return new TestVaultResourcePromiseImpl(this._promise.then(obj => obj.onResourceReady(callback)), this._client);
     }
 
-    createExecutionConfiguration(): Promise<ExecutionConfigurationBuilder> {
-        return this._promise.then(obj => obj.createExecutionConfiguration());
+    createExecutionConfiguration(): ExecutionConfigurationBuilderPromise {
+        return new ExecutionConfigurationBuilderPromiseImpl(this._promise.then(obj => obj.createExecutionConfiguration()), this._client);
     }
 
     withOptionalString(options?: WithOptionalStringOptions): TestVaultResourcePromise {
@@ -48228,7 +49378,7 @@ export interface Resource {
      * Creates an execution configuration builder for the specified resource.
      * @returns The execution configuration builder.
      */
-    createExecutionConfiguration(): Promise<ExecutionConfigurationBuilder>;
+    createExecutionConfiguration(): ExecutionConfigurationBuilderPromise;
     /**
      * Adds an optional string parameter
      * @param options Additional options.
@@ -48506,7 +49656,7 @@ export interface ResourcePromise extends PromiseLike<Resource> {
      * Creates an execution configuration builder for the specified resource.
      * @returns The execution configuration builder.
      */
-    createExecutionConfiguration(): Promise<ExecutionConfigurationBuilder>;
+    createExecutionConfiguration(): ExecutionConfigurationBuilderPromise;
     /**
      * Adds an optional string parameter
      * @param options Additional options.
@@ -49256,12 +50406,16 @@ class ResourceImpl extends ResourceBuilderBase<IResourceHandle> implements Resou
      * Creates an execution configuration builder for the specified resource.
      * @returns The execution configuration builder.
      */
-    async createExecutionConfiguration(): Promise<ExecutionConfigurationBuilder> {
-        const rpcArgs: Record<string, unknown> = { resource: this._handle };
-        return await this._client.invokeCapability<ExecutionConfigurationBuilder>(
-            'Aspire.Hosting/createExecutionConfiguration',
-            rpcArgs
-        );
+    createExecutionConfiguration(): ExecutionConfigurationBuilderPromise {
+        const promise = (async () => {
+            const rpcArgs: Record<string, unknown> = { resource: this._handle };
+            const handle = await this._client.invokeCapability<IExecutionConfigurationBuilderHandle>(
+                'Aspire.Hosting/createExecutionConfiguration',
+                rpcArgs
+            );
+            return new ExecutionConfigurationBuilderImpl(handle, this._client);
+        })();
+        return new ExecutionConfigurationBuilderPromiseImpl(promise, this._client);
     }
 
     /** @internal */
@@ -49776,8 +50930,8 @@ class ResourcePromiseImpl implements ResourcePromise {
         return new ResourcePromiseImpl(this._promise.then(obj => obj.onResourceReady(callback)), this._client);
     }
 
-    createExecutionConfiguration(): Promise<ExecutionConfigurationBuilder> {
-        return this._promise.then(obj => obj.createExecutionConfiguration());
+    createExecutionConfiguration(): ExecutionConfigurationBuilderPromise {
+        return new ExecutionConfigurationBuilderPromiseImpl(this._promise.then(obj => obj.createExecutionConfiguration()), this._client);
     }
 
     withOptionalString(options?: WithOptionalStringOptions): ResourcePromise {
@@ -50377,7 +51531,7 @@ export interface ResourceWithEndpoints {
      * @param name The name of the endpoint.
      * @returns An `EndpointReference` that can be used to resolve the address of the endpoint after resource allocation has occurred.
      */
-    getEndpoint(name: string): Promise<EndpointReference>;
+    getEndpoint(name: string): EndpointReferencePromise;
     /**
      * Configures a resource to mark all endpoints' transport as HTTP/2. This is useful for HTTP/2 services that need prior knowledge.
      * @returns The resource builder.
@@ -50477,7 +51631,7 @@ export interface ResourceWithEndpointsPromise extends PromiseLike<ResourceWithEn
      * @param name The name of the endpoint.
      * @returns An `EndpointReference` that can be used to resolve the address of the endpoint after resource allocation has occurred.
      */
-    getEndpoint(name: string): Promise<EndpointReference>;
+    getEndpoint(name: string): EndpointReferencePromise;
     /**
      * Configures a resource to mark all endpoints' transport as HTTP/2. This is useful for HTTP/2 services that need prior knowledge.
      * @returns The resource builder.
@@ -50768,12 +51922,16 @@ class ResourceWithEndpointsImpl extends ResourceBuilderBase<IResourceWithEndpoin
      * @param name The name of the endpoint.
      * @returns An `EndpointReference` that can be used to resolve the address of the endpoint after resource allocation has occurred.
      */
-    async getEndpoint(name: string): Promise<EndpointReference> {
-        const rpcArgs: Record<string, unknown> = { builder: this._handle, name };
-        return await this._client.invokeCapability<EndpointReference>(
-            'Aspire.Hosting/getEndpoint',
-            rpcArgs
-        );
+    getEndpoint(name: string): EndpointReferencePromise {
+        const promise = (async () => {
+            const rpcArgs: Record<string, unknown> = { builder: this._handle, name };
+            const handle = await this._client.invokeCapability<EndpointReferenceHandle>(
+                'Aspire.Hosting/getEndpoint',
+                rpcArgs
+            );
+            return new EndpointReferenceImpl(handle, this._client);
+        })();
+        return new EndpointReferencePromiseImpl(promise, this._client);
     }
 
     /** @internal */
@@ -50949,8 +52107,8 @@ class ResourceWithEndpointsPromiseImpl implements ResourceWithEndpointsPromise {
         return new ResourceWithEndpointsPromiseImpl(this._promise.then(obj => obj.withExternalHttpEndpoints()), this._client);
     }
 
-    getEndpoint(name: string): Promise<EndpointReference> {
-        return this._promise.then(obj => obj.getEndpoint(name));
+    getEndpoint(name: string): EndpointReferencePromise {
+        return new EndpointReferencePromiseImpl(this._promise.then(obj => obj.getEndpoint(name)), this._client);
     }
 
     asHttp2Service(): ResourceWithEndpointsPromise {

--- a/tests/PolyglotAppHosts/Aspire.Hosting/TypeScript/apphost.mts
+++ b/tests/PolyglotAppHosts/Aspire.Hosting/TypeScript/apphost.mts
@@ -144,8 +144,8 @@ await dockerContainer.withHttpEndpointCallback(async (updateContext) => {
 }, { name: "http", createIfNotExists: false });
 const endpoint = await dockerContainer.getEndpoint("http");
 const expr = refExpr`Host=${endpoint}`;
-const endpointHost = await endpoint.property(EndpointProperty.Host);
-const endpointPort = await endpoint.property(EndpointProperty.Port);
+const endpointHost = await dockerContainer.getEndpoint("http").property(EndpointProperty.Host);
+const endpointPort = await dockerContainer.getEndpoint("http").property(EndpointProperty.Port);
 const endpointUrl = refExpr`http://${endpointHost}:${endpointPort}`;
 
 const builtConnectionString = await builder.addConnectionString("customcs", { environmentVariableNameOrExpression: expr });
@@ -218,8 +218,7 @@ await container.withEnvironmentCallback(async (context) => {
     const environment = await context.environment();
     const environmentLog = await context.log();
     const _environmentResource = await context.resource();
-    const environmentExecutionContext = await context.executionContext();
-    const _environmentIsRunMode: boolean = await environmentExecutionContext.isRunMode();
+    const _environmentIsRunMode: boolean = await context.executionContext().isRunMode();
     await environmentLog.warning("Environment callback logger");
     await environment.set("MY_CALLBACK_ENDPOINT", endpoint);
 });
@@ -228,8 +227,7 @@ await container.withArgsCallback(async (context) => {
     const args = await context.args();
     const argsLog = await context.log();
     const _argsResource = await context.resource();
-    const argsExecutionContext = await context.executionContext();
-    const _argsIsRunMode: boolean = await argsExecutionContext.isRunMode();
+    const _argsIsRunMode: boolean = await context.executionContext().isRunMode();
     await argsLog.error("Args callback logger");
     await args.add("--validation-callback");
     await args.add(expr);
@@ -238,12 +236,13 @@ await container.withArgsCallback(async (context) => {
 await container.withUrls(async (context) => {
     const _urlsResource = await context.resource();
     const urlsLog = await context.log();
-    const urlsExecutionContext = await context.executionContext();
-    const _urlsIsRunMode: boolean = await urlsExecutionContext.isRunMode();
+    const _urlsIsRunMode: boolean = await context.executionContext().isRunMode();
     const callbackEndpoint = await context.getEndpoint("http");
+    const callbackEndpointHost = await context.getEndpoint("http").property(EndpointProperty.Host);
     const urls = await context.urls();
     await urlsLog.debug("URLs callback logger");
     await urls.add(refExpr`https://${callbackEndpoint}`);
+    await urls.add(refExpr`https://${callbackEndpointHost}`);
     await urls.addForEndpoint(callbackEndpoint, "/details", { displayText: "Details" });
 });
 
@@ -350,8 +349,7 @@ await container.withPipelineStepFactory("custom-build-step", async (stepContext)
     await pipelineSummary.add("PipelineContext", "Validated");
     await pipelineSummary.addMarkdown("PipelineMarkdown", "**Validated**");
 
-    const executionContext = await stepContext.executionContext();
-    const _isPublishMode: boolean = await executionContext.isPublishMode();
+    const _isPublishMode: boolean = await stepContext.executionContext().isPublishMode();
     const stepServices = await stepContext.services();
     const stepLogger = await stepContext.logger();
     await stepLogger.logInformation("Pipeline step context logger");
@@ -415,11 +413,10 @@ await container.withPipelineConfiguration(async (configContext) => {
 // ===================================================================
 
 const _appHostDirectory: string = await builder.appHostDirectory();
-const hostEnvironment = await builder.environment();
-const _isDevelopment: boolean = await hostEnvironment.isDevelopment();
-const _isProduction: boolean = await hostEnvironment.isProduction();
-const _isStaging: boolean = await hostEnvironment.isStaging();
-const _isSpecificEnvironment: boolean = await hostEnvironment.isEnvironment("Development");
+const _isDevelopment: boolean = await builder.environment().isDevelopment();
+const _isProduction: boolean = await builder.environment().isProduction();
+const _isStaging: boolean = await builder.environment().isStaging();
+const _isSpecificEnvironment: boolean = await builder.environment().isEnvironment("Development");
 
 const builderConfiguration = await builder.getConfiguration();
 const _configValue: string = await builderConfiguration.getConfigValue("MyConfig:Key");
@@ -428,14 +425,13 @@ const _configSection = await builderConfiguration.getSection("MyConfig");
 const _configChildren = await builderConfiguration.getChildren();
 const _configExists: boolean = await builderConfiguration.exists("MyConfig:Key");
 
-const builderExecutionContext = await builder.executionContext();
+const builderExecutionContext = builder.executionContext();
 const executionContextServiceProvider = await builderExecutionContext.serviceProvider();
 const _distributedApplicationModelFromExecutionContext = await executionContextServiceProvider.getDistributedApplicationModel();
 const resourceCommandService = await executionContextServiceProvider.getResourceCommandService();
 
 await builder.addEventingSubscriber(async (registrationContext) => {
-    const subscriberExecutionContext = await registrationContext.executionContext();
-    const _subscriberIsRunMode: boolean = await subscriberExecutionContext.isRunMode();
+    const _subscriberIsRunMode: boolean = await registrationContext.executionContext().isRunMode();
     const _subscriberCancellationToken = await registrationContext.cancellationToken();
 
     await registrationContext.onBeforeStart(async (beforeStartEvent) => {
@@ -708,7 +704,8 @@ await container.withCommand("noop", "Noop", async () => {
     },
 });
 await container.withCommand("echo", "Echo", async (ctx) => {
-    const commandArguments = await (await ctx.arguments()).toArray();
+    const commandInputs = await ctx.arguments();
+    const commandArguments = await commandInputs.toArray();
 
     return { success: commandArguments[0]?.value === "hello" };
 }, {


### PR DESCRIPTION
## Description

TypeScript AppHost APIs already support fluent chaining for builder methods like `builder.addContainer(...).withReference(...)`, but generated async methods that returned other generated wrapper types still required callers to split the chain or use a double await. This updates TypeScript code generation so any generated async method returning a chainable wrapper type exposes the same thenable surface.

The generator now emits promise wrapper return types for wrapper-returning generated async methods and getter-style generated async members, including callback/context APIs. The TypeScript validation AppHost covers the intended syntax instead of asserting generated code shape directly.

### User-facing usage

TypeScript AppHosts can now chain through generated async methods with a single await:

```typescript
const isDevelopment = await builder.environment().isDevelopment();
const isRunMode = await context.executionContext().isRunMode();
const endpointHost = await container.getEndpoint("http").property(EndpointProperty.Host);
```

Fixes # (issue)

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No