### PR TITLE
fix(extension): re-pin lockfile tarballs to dotnet-public-npm mirror

### DIFF
--- a/extension/.npmrc
+++ b/extension/.npmrc
@@ -1,2 +1,1 @@
 registry=https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/
-replace-registry-host=never

--- a/extension/package-lock.json
+++ b/extension/package-lock.json
@@ -7994,7 +7994,7 @@
     },
     "node_modules/node-gyp-build": {
       "version": "4.8.4",
-      "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.8.4.tgz",
+      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/node-gyp-build/-/node-gyp-build-4.8.4.tgz",
       "integrity": "sha512-LA4ZjwlnUblHVgq0oBF3Jl/6h/Nvs5fzBLwdEF4nuxnFdsfajde4WfxtJr3CaiH+F6ewcIB/q4jQ4UzPyid+CQ==",
       "license": "MIT",
       "bin": {
@@ -8873,7 +8873,7 @@
     },
     "node_modules/postcss": {
       "version": "8.5.10",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.10.tgz",
+      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/postcss/-/postcss-8.5.10.tgz",
       "integrity": "sha512-pMMHxBOZKFU6HgAZ4eyGnwXF/EvPGGqUr0MnZ5+99485wwW41kW91A4LOGxSHhgugZmSChL5AlElNdwlNgcnLQ==",
       "dev": true,
       "funding": [
@@ -10761,7 +10761,7 @@
     },
     "node_modules/tree-sitter-c-sharp": {
       "version": "0.23.5",
-      "resolved": "https://registry.npmjs.org/tree-sitter-c-sharp/-/tree-sitter-c-sharp-0.23.5.tgz",
+      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/tree-sitter-c-sharp/-/tree-sitter-c-sharp-0.23.5.tgz",
       "integrity": "sha512-xJGOeXPMmld0nES5+080N/06yY6LQi+KWGWV4LfZaZe6srJPtUtfhIbRSN7EZN6IaauzW28v6W4QHFwmeUW6HQ==",
       "hasInstallScript": true,
       "license": "MIT",
@@ -10780,7 +10780,7 @@
     },
     "node_modules/tree-sitter-c-sharp/node_modules/node-addon-api": {
       "version": "8.7.0",
-      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-8.7.0.tgz",
+      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/node-addon-api/-/node-addon-api-8.7.0.tgz",
       "integrity": "sha512-9MdFxmkKaOYVTV+XVRG8ArDwwQ77XIgIPyKASB1k3JPq3M8fGQQQE3YpMOrKm6g//Ktx8ivZr8xo1Qmtqub+GA==",
       "license": "MIT",
       "engines": {
@@ -11209,7 +11209,7 @@
     },
     "node_modules/uuid": {
       "version": "14.0.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-14.0.0.tgz",
+      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/uuid/-/uuid-14.0.0.tgz",
       "integrity": "sha512-Qo+uWgilfSmAhXCMav1uYFynlQO7fMFiMVZsQqZRMIXp0O7rR7qjkj+cPvBHLgBqi960QCoo/PH2/6ZtVqKvrg==",
       "dev": true,
       "funding": [
@@ -11507,7 +11507,7 @@
     },
     "node_modules/web-tree-sitter": {
       "version": "0.26.9",
-      "resolved": "https://registry.npmjs.org/web-tree-sitter/-/web-tree-sitter-0.26.9.tgz",
+      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/web-tree-sitter/-/web-tree-sitter-0.26.9.tgz",
       "integrity": "sha512-YJwSHANl6XFgeEjB8nitgj0qZYt5gkIesJ4w2srS2wcLB4GUa4xcOkM0YaMsU6WNR53YVIkDSY7Ej4pf3IXtCA==",
       "license": "MIT"
     },

--- a/extension/yarn.lock
+++ b/extension/yarn.lock
@@ -4072,7 +4072,7 @@ node-addon-api@^4.3.0:
 
 node-addon-api@^8.2.2:
   version "8.7.0"
-  resolved "https://registry.npmjs.org/node-addon-api/-/node-addon-api-8.7.0.tgz"
+  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/node-addon-api/-/node-addon-api-8.7.0.tgz"
   integrity sha512-9MdFxmkKaOYVTV+XVRG8ArDwwQ77XIgIPyKASB1k3JPq3M8fGQQQE3YpMOrKm6g//Ktx8ivZr8xo1Qmtqub+GA==
 
 node-forge@1.4.0:
@@ -4082,7 +4082,7 @@ node-forge@1.4.0:
 
 node-gyp-build@^4.8.4:
   version "4.8.4"
-  resolved "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.8.4.tgz"
+  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/node-gyp-build/-/node-gyp-build-4.8.4.tgz"
   integrity sha512-LA4ZjwlnUblHVgq0oBF3Jl/6h/Nvs5fzBLwdEF4nuxnFdsfajde4WfxtJr3CaiH+F6ewcIB/q4jQ4UzPyid+CQ==
 
 node-html-markdown@^1.3.0:
@@ -5471,7 +5471,7 @@ toidentifier@~1.0.1:
 
 tree-sitter-c-sharp@0.23.5:
   version "0.23.5"
-  resolved "https://registry.npmjs.org/tree-sitter-c-sharp/-/tree-sitter-c-sharp-0.23.5.tgz"
+  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/tree-sitter-c-sharp/-/tree-sitter-c-sharp-0.23.5.tgz"
   integrity sha512-xJGOeXPMmld0nES5+080N/06yY6LQi+KWGWV4LfZaZe6srJPtUtfhIbRSN7EZN6IaauzW28v6W4QHFwmeUW6HQ==
   dependencies:
     node-addon-api "^8.2.2"
@@ -5862,7 +5862,7 @@ watchpack@^2.5.1:
 
 web-tree-sitter@0.26.9:
   version "0.26.9"
-  resolved "https://registry.npmjs.org/web-tree-sitter/-/web-tree-sitter-0.26.9.tgz"
+  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/web-tree-sitter/-/web-tree-sitter-0.26.9.tgz"
   integrity sha512-YJwSHANl6XFgeEjB8nitgj0qZYt5gkIesJ4w2srS2wcLB4GUa4xcOkM0YaMsU6WNR53YVIkDSY7Ej4pf3IXtCA==
 
 web-tree-sitter@^0.20.8:


### PR DESCRIPTION
The internal `microsoft-aspire` pipeline has been red on `main` since build `20260521.18` (~06:20 UTC May 22). The `win_x64` job fails when MSBuild invokes `yarn install` from `extension/Extension.proj`:

```
extension\Extension.proj(39,5): error MSB3073: The command "yarn install" exited with code 1.
```

```
yarn install v1.22.22
[1/4] Resolving packages...
[2/4] Fetching packages...
error Error: connect EACCES 192.0.2.14:443
```

## Root cause

PR #17361 added `tree-sitter-c-sharp@0.23.5` and `web-tree-sitter@0.26.9` (plus the transitive `node-addon-api@^8.2.2` and `node-gyp-build@^4.8.4`) and the resulting `extension/yarn.lock` entries `resolved` against `https://registry.npmjs.org/...` instead of the internal `dotnet-public-npm` mirror. The same PR added `replace-registry-host=never` to `extension/.npmrc`, which tells Yarn not to rewrite the hosts at install time. The internal build agent can only reach the mirror, so the install fails at TCP connect on the sinkholed address.

`extension/package-lock.json` has the same problem — six bad URLs total: the four new ones, plus `postcss@8.5.10` and `uuid@14.0.0` which PR #16507 was meant to fix but only updated in `yarn.lock`. PR CI's `npm install` has been silently pulling them from `registry.npmjs.org` because GitHub runners have unrestricted egress.

## The fix

- Drop `replace-registry-host=never` from `extension/.npmrc`.
- Rewrite the six `resolved` URLs across `extension/yarn.lock` and `extension/package-lock.json` to the `dotnet-public-npm` mirror. The feed proxies upstream npmjs.org, so tarball bytes and integrity hashes are unchanged; the `npmAuthenticate@0` step in `eng/pipelines/azure-pipelines.yml` will lazily pull-and-cache the new packages on the first authenticated install — same mechanism #16507 relied on.

## Surprises

`extension/package-lock.json` has been broken since #16489 (~Sep 2025) without detection. A follow-up will add a lockfile-host lint to catch this on PR CI.

Fixes #17399
