### PR TITLE
Add VS Code Go debugging support

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -16,6 +16,20 @@
 			"cwd": "${workspaceFolder}/extension"
 		},
 		{
+			"name": "Run Extension (Go debugging playground)",
+			"type": "extensionHost",
+			"request": "launch",
+			"args": [
+				"--extensionDevelopmentPath=${workspaceFolder}/extension",
+				"${workspaceFolder}/playground/GoDebugging"
+			],
+			"outFiles": [
+				"${workspaceFolder}/extension/dist/**/*.js"
+			],
+			"preLaunchTask": "tasks: watch extension",
+			"cwd": "${workspaceFolder}/extension"
+		},
+		{
 			"name": "Run Extension (cli stop on entry)",
 			"type": "extensionHost",
 			"request": "launch",

--- a/extension/package.nls.json
+++ b/extension/package.nls.json
@@ -105,6 +105,8 @@
   "aspire-vscode.strings.yesLabel": "Yes",
   "aspire-vscode.strings.noLabel": "No",
   "aspire-vscode.strings.invalidLaunchConfiguration": "Invalid launch configuration for {0}.",
+  "aspire-vscode.strings.goDisplayName": "Go: {0}",
+  "aspire-vscode.strings.goLabel": "Go",
   "aspire-vscode.strings.noAppHostInWorkspace": "No AppHost found in the Aspire settings file.",
   "aspire-vscode.strings.dashboard": "Dashboard",
   "aspire-vscode.strings.codespaces": "Codespaces",

--- a/extension/src/capabilities.ts
+++ b/extension/src/capabilities.ts
@@ -13,6 +13,8 @@ export type Capability =
     | 'ms-dotnettools.csharp' // Older AppHost versions used this extension identifier instead of project
     | 'python' // Support for running Python projects
     | 'ms-python.python' // Older AppHost versions used this extension identifier instead of python
+    | 'go' // Support for running Go projects
+    | 'golang.go' // Older AppHost versions used this extension identifier instead of go
     | 'node' // Support for running Node.js projects
     | 'browser' // Support for browser debugging (built-in to VS Code via js-debug)
     | 'azure-functions'; // Support for running Azure Functions projects
@@ -34,6 +36,10 @@ export function isCsharpInstalled() {
 
 export function isPythonInstalled() {
     return isExtensionInstalled("ms-python.python");
+}
+
+export function isGoInstalled() {
+    return isExtensionInstalled("golang.go");
 }
 
 export function isAzureFunctionsExtensionInstalled() {
@@ -67,6 +73,11 @@ export function getSupportedCapabilities(): Capabilities {
     if (isPythonInstalled()) {
         capabilities.push("python");
         capabilities.push("ms-python.python");
+    }
+
+    if (isGoInstalled()) {
+        capabilities.push("go");
+        capabilities.push("golang.go");
     }
 
     if (isNodeInstalled()) {

--- a/extension/src/dcp/types.ts
+++ b/extension/src/dcp/types.ts
@@ -45,6 +45,17 @@ export function isPythonLaunchConfiguration(obj: any): obj is PythonLaunchConfig
     return obj && obj.type === 'python';
 }
 
+export interface GoLaunchConfiguration extends ExecutableLaunchConfiguration {
+    type: "go";
+    program?: string;
+    working_directory?: string;
+    build_flags?: string;
+}
+
+export function isGoLaunchConfiguration(obj: any): obj is GoLaunchConfiguration {
+    return obj && obj.type === 'go';
+}
+
 export interface NodeLaunchConfiguration extends ExecutableLaunchConfiguration {
     type: "node"; // Provided by VS Code's built-in js-debug, no extension needed
     script_path?: string;

--- a/extension/src/debugger/debuggerExtensions.ts
+++ b/extension/src/debugger/debuggerExtensions.ts
@@ -4,11 +4,12 @@ import { debugProject, runProject } from "../loc/strings";
 import { mergeEnvs } from "../utils/environment";
 import { extensionLogOutputChannel } from "../utils/logging";
 import { projectDebuggerExtension } from "./languages/dotnet";
-import { isAzureFunctionsExtensionInstalled, isCsharpInstalled, isPythonInstalled } from '../capabilities';
+import { isAzureFunctionsExtensionInstalled, isCsharpInstalled, isGoInstalled, isPythonInstalled } from '../capabilities';
 import { pythonDebuggerExtension } from "./languages/python";
 import { nodeDebuggerExtension } from "./languages/node";
 import { browserDebuggerExtension } from "./languages/browser";
 import { azureFunctionsDebuggerExtension } from "./languages/azureFunctions";
+import { goDebuggerExtension } from "./languages/go";
 import { isDirectory } from "../utils/io";
 
 // Represents a resource-specific debugger extension for when the default session configuration is not sufficient to launch the resource.
@@ -80,9 +81,12 @@ export function getResourceDebuggerExtensions(): ResourceDebuggerExtension[] {
         extensions.push(pythonDebuggerExtension);
     }
 
+    if (isGoInstalled()) {
+        extensions.push(goDebuggerExtension);
+    }
+
     extensions.push(nodeDebuggerExtension);
     extensions.push(browserDebuggerExtension);
 
     return extensions;
 }
-

--- a/extension/src/debugger/languages/go.ts
+++ b/extension/src/debugger/languages/go.ts
@@ -1,0 +1,56 @@
+import * as vscode from 'vscode';
+import { AspireResourceExtendedDebugConfiguration, ExecutableLaunchConfiguration, isGoLaunchConfiguration } from "../../dcp/types";
+import { goDisplayName, goLabel, invalidLaunchConfiguration } from "../../loc/strings";
+import { extensionLogOutputChannel } from "../../utils/logging";
+import { ResourceDebuggerExtension } from "../debuggerExtensions";
+
+function getProjectFile(launchConfig: ExecutableLaunchConfiguration): string {
+    if (isGoLaunchConfiguration(launchConfig)) {
+        return launchConfig.program || launchConfig.working_directory || '';
+    }
+
+    throw new Error(invalidLaunchConfiguration(JSON.stringify(launchConfig)));
+}
+
+export const goDebuggerExtension: ResourceDebuggerExtension = {
+    resourceType: 'go',
+    debugAdapter: 'go',
+    extensionId: 'golang.go',
+    getDisplayName: (launchConfiguration: ExecutableLaunchConfiguration) => {
+        if (isGoLaunchConfiguration(launchConfiguration)) {
+            const displayPath = launchConfiguration.program || launchConfiguration.working_directory || '';
+            return displayPath ? goDisplayName(vscode.workspace.asRelativePath(displayPath)) : goLabel;
+        }
+
+        return goLabel;
+    },
+    getSupportedFileTypes: () => ['.go'],
+    getProjectFile: (launchConfig) => getProjectFile(launchConfig),
+    createDebugSessionConfigurationCallback: async (launchConfig, args, _env, launchOptions, debugConfiguration: AspireResourceExtendedDebugConfiguration): Promise<void> => {
+        if (!isGoLaunchConfiguration(launchConfig)) {
+            extensionLogOutputChannel.info(`The resource type was not go for ${JSON.stringify(launchConfig)}`);
+            throw new Error(invalidLaunchConfiguration(JSON.stringify(launchConfig)));
+        }
+
+        debugConfiguration.type = 'go';
+        debugConfiguration.request = 'launch';
+        debugConfiguration.mode = 'debug';
+        debugConfiguration.debugAdapter = 'dlv-dap';
+        debugConfiguration.noDebug = !launchOptions.debug;
+
+        const program = launchConfig.program || launchConfig.working_directory;
+        if (program) {
+            debugConfiguration.program = program;
+        }
+
+        if (launchConfig.working_directory) {
+            debugConfiguration.cwd = launchConfig.working_directory;
+        }
+
+        if (launchConfig.build_flags) {
+            debugConfiguration.buildFlags = launchConfig.build_flags;
+        }
+
+        debugConfiguration.args = args ?? [];
+    }
+};

--- a/extension/src/loc/strings.ts
+++ b/extension/src/loc/strings.ts
@@ -88,6 +88,8 @@ export const errorGettingConfigInfo = (error: any) => vscode.l10n.t('Error getti
 export const invalidLaunchConfiguration = (projectPath: string) => vscode.l10n.t('Invalid launch configuration for {0}.', projectPath);
 export const browserDisplayName = (url: string) => vscode.l10n.t('Browser: {0}', url);
 export const browserLabel = vscode.l10n.t('Browser');
+export const goDisplayName = (program: string) => vscode.l10n.t('Go: {0}', program);
+export const goLabel = vscode.l10n.t('Go');
 export const dontShowAgainLabel = vscode.l10n.t("Don't Show Again");
 export const doYouWantToSetDefaultApphost = (appHost: string) => vscode.l10n.t('Do you want to set {0} as the default AppHost for this workspace?', appHost);
 export const doYouWantToSelectDefaultApphost = vscode.l10n.t('Do you want to select the default AppHost for this workspace?');

--- a/extension/src/test/goDebugger.test.ts
+++ b/extension/src/test/goDebugger.test.ts
@@ -1,0 +1,100 @@
+import * as assert from 'assert';
+import * as sinon from 'sinon';
+import * as vscode from 'vscode';
+import { getSupportedCapabilities } from '../capabilities';
+import { AspireDebugSession } from '../debugger/AspireDebugSession';
+import { getResourceDebuggerExtensions } from '../debugger/debuggerExtensions';
+import { goDebuggerExtension } from '../debugger/languages/go';
+import { AspireResourceExtendedDebugConfiguration, GoLaunchConfiguration } from '../dcp/types';
+
+suite('Go Debugger Extension Tests', () => {
+    const fakeAspireDebugSession = {} as AspireDebugSession;
+
+    teardown(() => sinon.restore());
+
+    test('advertises Go support when the Go extension is installed', () => {
+        sinon.stub(vscode.extensions, 'getExtension').callsFake((extensionId: string) => {
+            return extensionId === 'golang.go' ? { id: extensionId } as vscode.Extension<unknown> : undefined;
+        });
+
+        const capabilities = getSupportedCapabilities();
+        assert.ok(capabilities.includes('go'));
+        assert.ok(capabilities.includes('golang.go'));
+        assert.ok(getResourceDebuggerExtensions().some(extension => extension.resourceType === 'go'));
+    });
+
+    test('configures VS Code Go debugger with dlv-dap', async () => {
+        const launchConfig: GoLaunchConfiguration = {
+            type: 'go',
+            program: '/workspace/api/cmd/server',
+            working_directory: '/workspace/api',
+            build_flags: "-tags='integration' -gcflags='all=-N -l'"
+        };
+        const debugConfig = createDebugConfig();
+
+        await goDebuggerExtension.createDebugSessionConfigurationCallback!(
+            launchConfig,
+            ['--listen', ':8080'],
+            [],
+            { debug: true, runId: '1', debugSessionId: '1', isApphost: false, debugSession: fakeAspireDebugSession },
+            debugConfig);
+
+        assert.strictEqual(debugConfig.type, 'go');
+        assert.strictEqual(debugConfig.request, 'launch');
+        assert.strictEqual(debugConfig.mode, 'debug');
+        assert.strictEqual(debugConfig.debugAdapter, 'dlv-dap');
+        assert.strictEqual(debugConfig.program, '/workspace/api/cmd/server');
+        assert.strictEqual(debugConfig.cwd, '/workspace/api');
+        assert.strictEqual(debugConfig.buildFlags, "-tags='integration' -gcflags='all=-N -l'");
+        assert.deepStrictEqual(debugConfig.args, ['--listen', ':8080']);
+        assert.strictEqual(debugConfig.noDebug, false);
+    });
+
+    test('sets noDebug when launch option disables debugging', async () => {
+        const launchConfig: GoLaunchConfiguration = {
+            type: 'go',
+            program: '/workspace/api',
+            working_directory: '/workspace/api'
+        };
+        const debugConfig = createDebugConfig();
+
+        await goDebuggerExtension.createDebugSessionConfigurationCallback!(
+            launchConfig,
+            [],
+            [],
+            { debug: false, runId: '1', debugSessionId: '1', isApphost: false, debugSession: fakeAspireDebugSession },
+            debugConfig);
+
+        assert.strictEqual(debugConfig.noDebug, true);
+    });
+
+    test('uses working directory as program when program is absent', async () => {
+        const launchConfig: GoLaunchConfiguration = {
+            type: 'go',
+            working_directory: '/workspace/api'
+        };
+        const debugConfig = createDebugConfig();
+
+        await goDebuggerExtension.createDebugSessionConfigurationCallback!(
+            launchConfig,
+            [],
+            [],
+            { debug: true, runId: '1', debugSessionId: '1', isApphost: false, debugSession: fakeAspireDebugSession },
+            debugConfig);
+
+        assert.strictEqual(debugConfig.program, '/workspace/api');
+        assert.strictEqual(debugConfig.cwd, '/workspace/api');
+    });
+});
+
+function createDebugConfig(): AspireResourceExtendedDebugConfiguration {
+    return {
+        runId: '1',
+        debugSessionId: '1',
+        type: 'go',
+        name: 'Go',
+        request: 'launch',
+        program: '/workspace/api',
+        args: []
+    };
+}

--- a/playground/GoDebugging/.vscode/extensions.json
+++ b/playground/GoDebugging/.vscode/extensions.json
@@ -1,0 +1,6 @@
+{
+  "recommendations": [
+    "microsoft-aspire.aspire-vscode",
+    "golang.go"
+  ]
+}

--- a/playground/GoDebugging/.vscode/launch.json
+++ b/playground/GoDebugging/.vscode/launch.json
@@ -1,0 +1,11 @@
+{
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "name": "Debug Go Debugging AppHost",
+      "type": "aspire",
+      "request": "launch",
+      "program": "${workspaceFolder}/GoDebugging.AppHost/GoDebugging.AppHost.csproj"
+    }
+  ]
+}

--- a/playground/GoDebugging/GoDebugging.AppHost/GoDebugging.AppHost.csproj
+++ b/playground/GoDebugging/GoDebugging.AppHost/GoDebugging.AppHost.csproj
@@ -1,0 +1,17 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>$(DefaultTargetFramework)</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsAspireHost>true</IsAspireHost>
+    <UserSecretsId>5f2f9a51-df01-40a9-857c-927070ccdf6b</UserSecretsId>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <AspireProjectOrPackageReference Include="Aspire.Hosting.AppHost" />
+    <AspireProjectOrPackageReference Include="Aspire.Hosting.Go" />
+  </ItemGroup>
+
+</Project>

--- a/playground/GoDebugging/GoDebugging.AppHost/Program.cs
+++ b/playground/GoDebugging/GoDebugging.AppHost/Program.cs
@@ -1,0 +1,10 @@
+#pragma warning disable ASPIREGO001
+
+var builder = DistributedApplication.CreateBuilder(args);
+
+builder.AddGoApp("api", "../api", buildTags: ["playground"])
+       .WithAppArgs("--message", "hello-from-aspire")
+       .WithHttpEndpoint(env: "PORT")
+       .WithExternalHttpEndpoints();
+
+builder.Build().Run();

--- a/playground/GoDebugging/GoDebugging.AppHost/Properties/launchSettings.json
+++ b/playground/GoDebugging/GoDebugging.AppHost/Properties/launchSettings.json
@@ -1,0 +1,12 @@
+{
+  "profiles": {
+    "https": {
+      "commandName": "Project",
+      "applicationUrl": "https://localhost:17110;http://localhost:15110",
+      "environmentVariables": {
+        "ASPIRE_DASHBOARD_OTLP_ENDPOINT_URL": "https://localhost:21110",
+        "ASPIRE_RESOURCE_SERVICE_ENDPOINT_URL": "https://localhost:22110"
+      }
+    }
+  }
+}

--- a/playground/GoDebugging/README.md
+++ b/playground/GoDebugging/README.md
@@ -1,0 +1,11 @@
+# Go Debugging Playground
+
+This playground is for manually testing Aspire's VS Code Go debugger integration.
+
+1. Open the Aspire repo in VS Code.
+2. Start the `Run Extension (Go debugging playground)` launch configuration.
+3. In the Extension Development Host, install the recommended Go extension if prompted.
+4. Start the `Debug Go Debugging AppHost` launch configuration.
+5. Set a breakpoint in `api/main.go`.
+
+The AppHost references the local `Aspire.Hosting.Go` project so it exercises the current repo changes. The Go API uses the `playground` build tag and receives `--message hello-from-aspire` as app args, which verifies that the Aspire launch configuration passes `buildFlags` to VS Code and strips Go tool arguments from the debugged program args.

--- a/playground/GoDebugging/api/go.mod
+++ b/playground/GoDebugging/api/go.mod
@@ -1,0 +1,3 @@
+module goapphost/api
+
+go 1.26

--- a/playground/GoDebugging/api/main.go
+++ b/playground/GoDebugging/api/main.go
@@ -1,0 +1,72 @@
+//go:build playground
+
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"flag"
+	"log"
+	"net/http"
+	"os"
+	"os/signal"
+	"strings"
+	"syscall"
+	"time"
+)
+
+func main() {
+	message := flag.String("message", "hello", "message returned by the API")
+	flag.Parse()
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		response := map[string]any{
+			"message": *message,
+			"args":    os.Args[1:],
+			"time":    time.Now().Format(time.RFC3339),
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		if err := json.NewEncoder(w).Encode(response); err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+		}
+	})
+
+	server := &http.Server{
+		Addr:              listenAddress(),
+		Handler:           mux,
+		ReadHeaderTimeout: 5 * time.Second,
+	}
+
+	go func() {
+		log.Printf("api listening on %s", server.Addr)
+		if err := server.ListenAndServe(); err != nil && !errors.Is(err, http.ErrServerClosed) {
+			log.Fatalf("listen: %v", err)
+		}
+	}()
+
+	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	defer stop()
+
+	<-ctx.Done()
+	shutdownCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	_ = server.Shutdown(shutdownCtx)
+}
+
+func listenAddress() string {
+	if port := os.Getenv("PORT"); port != "" {
+		return ":" + port
+	}
+
+	if urls := os.Getenv("ASPNETCORE_URLS"); urls != "" {
+		first := strings.Split(urls, ";")[0]
+		if index := strings.LastIndex(first, ":"); index != -1 {
+			return first[index:]
+		}
+	}
+
+	return ":8080"
+}

--- a/src/Aspire.Hosting.Go/GoHostingExtensions.cs
+++ b/src/Aspire.Hosting.Go/GoHostingExtensions.cs
@@ -643,6 +643,15 @@ public static class GoHostingExtensions
     {
         ArgumentNullException.ThrowIfNull(builder);
 
+        // WithDelveServer changes the resource into a headless Delve process that IDEs attach to
+        // manually. Leaving the VS Code launch annotation in place would make DCP hand execution to
+        // the IDE instead of starting that Delve server.
+        var debuggingAnnotation = builder.Resource.Annotations.OfType<SupportsDebuggingAnnotation>().FirstOrDefault();
+        if (debuggingAnnotation is not null)
+        {
+            builder.Resource.Annotations.Remove(debuggingAnnotation);
+        }
+
         // Switch the underlying executable from "go" to "dlv" using Replace so that
         // calling WithDelveServer more than once is idempotent.
         return builder
@@ -659,17 +668,58 @@ public static class GoHostingExtensions
     {
         ArgumentNullException.ThrowIfNull(builder);
 
-        var workingDirectory = Path.GetFullPath(builder.Resource.WorkingDirectory);
+        var resource = builder.Resource;
 
         return builder.WithDebugSupport(
-            mode => new GoLaunchConfiguration
+            mode =>
             {
-                Program = workingDirectory,
-                Mode = mode,
-                WorkingDirectory = workingDirectory
+                // Resolve annotations when DCP creates the launch configuration so later
+                // resource mutations such as WithWorkingDirectory(...) are reflected.
+                var workingDirectory = Path.GetFullPath(resource.WorkingDirectory);
+                var packagePath = resource.TryGetLastAnnotation<GoPackagePathAnnotation>(out var packagePathAnnotation)
+                    ? packagePathAnnotation.PackagePath
+                    : ".";
+                var buildFlags = BuildFlagsString(resource);
+
+                return new GoLaunchConfiguration
+                {
+                    Program = Path.GetFullPath(packagePath, workingDirectory),
+                    Mode = mode,
+                    WorkingDirectory = workingDirectory,
+                    BuildFlags = buildFlags.Length > 0 ? buildFlags : null
+                };
             },
-            "go");
+            "go",
+            static ctx =>
+            {
+                // The executable resource normally starts as:
+                //   go run [-race] [-tags=...] [-ldflags=...] [-gcflags=...] <pkg> [app args]
+                // In IDE mode VS Code's Go debugger owns the tool/build/package portion via
+                // program/buildFlags, so only the user program arguments should remain.
+                if (ctx.Args is not [string runCommand, ..] || runCommand != "run")
+                {
+                    return;
+                }
+
+                ctx.Args.RemoveAt(0);
+
+                while (ctx.Args is [string arg, ..] && IsGoRunBuildFlag(arg))
+                {
+                    ctx.Args.RemoveAt(0);
+                }
+
+                if (ctx.Args.Count > 0)
+                {
+                    ctx.Args.RemoveAt(0);
+                }
+            });
     }
+
+    private static bool IsGoRunBuildFlag(string arg) =>
+        arg == "-race" ||
+        arg.StartsWith("-tags=", StringComparison.Ordinal) ||
+        arg.StartsWith("-ldflags=", StringComparison.Ordinal) ||
+        arg.StartsWith("-gcflags=", StringComparison.Ordinal);
 
     /// <summary>
     /// Builds the <c>go build</c> command for the generated Dockerfile, propagating any

--- a/src/Aspire.Hosting.Go/GoLaunchConfiguration.cs
+++ b/src/Aspire.Hosting.Go/GoLaunchConfiguration.cs
@@ -17,4 +17,12 @@ internal sealed class GoLaunchConfiguration() : ExecutableLaunchConfiguration("g
 
     [JsonPropertyName("working_directory")]
     public string WorkingDirectory { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Build flags passed to Delve when VS Code launches the Go debugger.
+    /// Corresponds to the <c>buildFlags</c> field in VS Code's Go launch configuration.
+    /// </summary>
+    [JsonPropertyName("build_flags")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? BuildFlags { get; set; }
 }

--- a/tests/Aspire.Hosting.Go.Tests/AddGoAppTests.cs
+++ b/tests/Aspire.Hosting.Go.Tests/AddGoAppTests.cs
@@ -6,7 +6,10 @@
 #pragma warning disable ASPIRECOMMAND001
 
 using Aspire.Hosting.ApplicationModel;
+using Aspire.Hosting.Dcp.Model;
+using Aspire.Hosting.Tests.Utils;
 using Aspire.Hosting.Utils;
+using System.Text.Json;
 
 namespace Aspire.Hosting.Go.Tests;
 
@@ -353,6 +356,120 @@ public class AddGoAppTests
             }
             """;
         Assert.Equal(expected, manifest.ToString());
+    }
+
+    [Fact]
+    public void WithDelveServer_RemovesVSCodeDebuggingAnnotation()
+    {
+        using var builder = TestDistributedApplicationBuilder.Create().WithResourceCleanUp(true);
+
+        var app = builder.AddGoApp("api", AppContext.BaseDirectory)
+            .WithDelveServer(port: 2345);
+
+        Assert.DoesNotContain(app.Resource.Annotations, annotation => annotation is SupportsDebuggingAnnotation);
+    }
+
+    // ---- VS Code debugging --------------------------------------------------
+
+    [Fact]
+    public void WithVSCodeDebugging_PopulatesGoLaunchConfiguration()
+    {
+        using var builder = TestDistributedApplicationBuilder.Create().WithResourceCleanUp(true);
+        using var sourceDir = new TestTempDirectory();
+        var packageDirectory = Path.Combine(sourceDir.Path, "cmd", "server");
+
+        var app = builder.AddGoApp("api", sourceDir.Path,
+            packagePath: "./cmd/server",
+            buildTags: ["integration"],
+            gcFlags: "all=-N -l",
+            raceDetector: true);
+
+        var launchConfig = InvokeLaunchConfigurationAnnotator(app.Resource);
+
+        Assert.Equal("go", launchConfig.Type);
+        Assert.Equal(ExecutableLaunchMode.Debug, launchConfig.Mode);
+        Assert.Equal(packageDirectory, launchConfig.Program);
+        Assert.Equal(sourceDir.Path, launchConfig.WorkingDirectory);
+        Assert.Equal("-race -tags='integration' -gcflags='all=-N -l'", launchConfig.BuildFlags);
+    }
+
+    [Fact]
+    public void WithVSCodeDebugging_OmitsBuildFlagsWhenNoneConfigured()
+    {
+        using var builder = TestDistributedApplicationBuilder.Create().WithResourceCleanUp(true);
+        using var sourceDir = new TestTempDirectory();
+
+        var app = builder.AddGoApp("api", sourceDir.Path);
+
+        var launchConfig = InvokeLaunchConfigurationAnnotator(app.Resource);
+
+        Assert.Null(launchConfig.BuildFlags);
+    }
+
+    [Fact]
+    public async Task WithVSCodeDebugging_RemovesGoToolArguments()
+    {
+        using var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Run);
+        using var sourceDir = new TestTempDirectory();
+
+        var runSessionInfo = new RunSessionInfo
+        {
+            ProtocolsSupported = ["test"],
+            SupportedLaunchConfigurations = ["go"]
+        };
+
+        builder.Configuration["DEBUG_SESSION_INFO"] = JsonSerializer.Serialize(runSessionInfo);
+        builder.Configuration["DEBUG_SESSION_PORT"] = "5678";
+
+        var app = builder.AddGoApp("api", sourceDir.Path,
+                packagePath: "./cmd/server",
+                buildTags: ["integration"],
+                ldFlags: "-X main.version=1.0.0",
+                gcFlags: "all=-N -l",
+                raceDetector: true)
+            .WithAppArgs("--config", "prod.yaml");
+
+        var application = builder.Build();
+
+        var commandArguments = await ArgumentEvaluator.GetArgumentListAsync(app.Resource, application.Services);
+
+        Assert.Collection(commandArguments,
+            arg => Assert.Equal("--config", arg),
+            arg => Assert.Equal("prod.yaml", arg));
+    }
+
+    [Fact]
+    public async Task WithVSCodeDebugging_DoesNotRemoveGoToolArguments_WhenGoLaunchConfigurationUnsupported()
+    {
+        using var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Run);
+        using var sourceDir = new TestTempDirectory();
+
+        var runSessionInfo = new RunSessionInfo
+        {
+            ProtocolsSupported = ["test"],
+            SupportedLaunchConfigurations = ["python"]
+        };
+
+        builder.Configuration["DEBUG_SESSION_INFO"] = JsonSerializer.Serialize(runSessionInfo);
+        builder.Configuration["DEBUG_SESSION_PORT"] = "5678";
+
+        var app = builder.AddGoApp("api", sourceDir.Path,
+                packagePath: "./cmd/server",
+                buildTags: ["integration"],
+                raceDetector: true)
+            .WithAppArgs("--config", "prod.yaml");
+
+        var application = builder.Build();
+
+        var commandArguments = await ArgumentEvaluator.GetArgumentListAsync(app.Resource, application.Services);
+
+        Assert.Collection(commandArguments,
+            arg => Assert.Equal("run", arg),
+            arg => Assert.Equal("-race", arg),
+            arg => Assert.Equal("-tags=integration", arg),
+            arg => Assert.Equal("./cmd/server", arg),
+            arg => Assert.Equal("--config", arg),
+            arg => Assert.Equal("prod.yaml", arg));
     }
 
     // ---- Manifest: WithDelveServer with build flags -----------------------
@@ -880,6 +997,19 @@ public class AddGoAppTests
         var content = await File.ReadAllTextAsync(Path.Combine(outputDir.Path, "api.Dockerfile"));
 
         await Verify(content);
+    }
+
+    private static GoLaunchConfiguration InvokeLaunchConfigurationAnnotator(IResource resource)
+    {
+        Assert.True(resource.TryGetLastAnnotation<SupportsDebuggingAnnotation>(out var supportsDebugging));
+
+        var exe = Executable.Create("test", "go");
+        supportsDebugging.LaunchConfigurationAnnotator(exe, ExecutableLaunchMode.Debug);
+
+        Assert.True(exe.TryGetAnnotationAsObjectList<GoLaunchConfiguration>(
+            Executable.LaunchConfigurationsAnnotation,
+            out var launchConfigs));
+        return Assert.Single(launchConfigs);
     }
 
     private sealed class GoFilesContainer(string name, string command, string workingDirectory)


### PR DESCRIPTION
## Description

This adds native VS Code debugging support for Aspire Go resources. Previously the Go integration could start a headless Delve server with `WithDelveServer`, but that path was process-owned and required an IDE attach workflow. With this change, the AppHost can emit Go launch metadata and the VS Code extension maps it to the `golang.go` debugger using `dlv-dap`.

Implementation summary:

- Adds Go debugger capability detection for `golang.go` in the VS Code extension.
- Maps Aspire Go launch configurations to VS Code Go debug configurations, including `program`, `cwd`, `args`, and Delve `buildFlags`.
- Emits Go launch metadata from `Aspire.Hosting.Go` and strips Go tool/build arguments in IDE debug mode so only app args reach the debugged program.
- Keeps `WithDelveServer` as the explicit process-owned headless Delve path by removing the IDE debug support annotation when Delve owns the resource command.
- Adds a Go debugging playground for manual VS Code validation.

### User-facing usage

Go resources can be debugged from the Aspire VS Code extension when the Go extension is installed:

```csharp
#pragma warning disable ASPIREGO001

var builder = DistributedApplication.CreateBuilder(args);

builder.AddGoApp("api", "../api", buildTags: ["playground"])
       .WithAppArgs("--message", "hello-from-aspire")
       .WithHttpEndpoint(env: "PORT")
       .WithExternalHttpEndpoints();

builder.Build().Run();
```

The playground can be used to verify the full VS Code flow:

1. Start `Run Extension (Go debugging playground)` from the Aspire repo.
2. In the Extension Development Host, start `Debug Go Debugging AppHost`.
3. Set a breakpoint in `playground/GoDebugging/api/main.go`.

The Go API uses the `playground` build tag and receives `--message hello-from-aspire` as app args. This verifies that Aspire passes Delve build flags to VS Code while stripping Go tool arguments from the debugged program args.

Fixes # (issue)

## Validation

- `npm run compile-tests`
- `npm run lint`
- `npm run unit-test -- --grep "Go Debugger"`
- `go test -tags playground ./...`
- `MSBUILDTERMINALLOGGER=false dotnet build playground/GoDebugging/GoDebugging.AppHost/GoDebugging.AppHost.csproj -m:1 -nr:false -p:BuildInParallel=false -p:UseSharedCompilation=false -v:minimal`
- `MSBUILDTERMINALLOGGER=false dotnet build tests/Aspire.Hosting.Go.Tests/Aspire.Hosting.Go.Tests.csproj --no-restore -m:1 -nr:false -p:BuildInParallel=false -p:UseSharedCompilation=false -v:minimal`
- `dotnet artifacts/bin/Aspire.Hosting.Go.Tests/Debug/net8.0/Aspire.Hosting.Go.Tests.dll --filter-method "*.WithDelveServer_RemovesVSCodeDebuggingAnnotation" --filter-method "*.WithVSCodeDebugging_PopulatesGoLaunchConfiguration" --filter-method "*.WithVSCodeDebugging_OmitsBuildFlagsWhenNoneConfigured" --filter-method "*.WithVSCodeDebugging_RemovesGoToolArguments" --filter-method "*.WithVSCodeDebugging_DoesNotRemoveGoToolArguments_WhenGoLaunchConfigurationUnsupported" --filter-not-trait "quarantined=true" --filter-not-trait "outerloop=true" --timeout 30s --output Detailed`
- Manual VS Code Extension Development Host verification of the Go debugging playground, including breakpoint/debug launch behavior.

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
