### PR TITLE
Fix Spectre cursor crash in CLI activity spinner

### DIFF
--- a/src/Aspire.Cli/Utils/ConsoleActivityLogger.cs
+++ b/src/Aspire.Cli/Utils/ConsoleActivityLogger.cs
@@ -118,7 +118,10 @@ internal sealed class ConsoleActivityLogger
         _spinning = true;
         _spinnerTask = Task.Run(async () =>
         {
-            _console.Cursor.Hide();
+            lock (_lock)
+            {
+                _console.Cursor.Hide();
+            }
 
             try
             {
@@ -126,9 +129,19 @@ internal sealed class ConsoleActivityLogger
                 {
                     var spinChar = _spinnerChars[_spinnerIndex % _spinnerChars.Length];
 
-                    // Write then move back so nothing can write between these events (hopefully)
-                    _console.Write(spinChar.ToString());
-                    _console.Cursor.MoveLeft();
+                    // Take the same lock used by WriteLine so the spinner write and the
+                    // corresponding MoveLeft are atomic relative to other console output.
+                    // Without this, a concurrent WriteLine could land between the Write
+                    // and the MoveLeft, leaving the cursor at column 0; Spectre's legacy
+                    // cursor backend (used whenever ANSI is disabled) then evaluates
+                    // `Console.CursorLeft -= 1`, which throws
+                    // "value must be greater than or equal to zero and less than the
+                    // console's buffer size in that dimension. (Parameter 'left')".
+                    lock (_lock)
+                    {
+                        _console.Write(spinChar.ToString());
+                        SafeMoveCursorLeft();
+                    }
 
                     _spinnerIndex++;
                     await Task.Delay(120).ConfigureAwait(false);
@@ -136,12 +149,35 @@ internal sealed class ConsoleActivityLogger
             }
             finally
             {
-                // Clear spinner character
-                _console.Write(" ");
-                _console.Cursor.MoveLeft();
-                _console.Cursor.Show();
+                lock (_lock)
+                {
+                    // Clear spinner character
+                    _console.Write(" ");
+                    SafeMoveCursorLeft();
+                    _console.Cursor.Show();
+                }
             }
         });
+    }
+
+    private void SafeMoveCursorLeft()
+    {
+        try
+        {
+            _console.Cursor.MoveLeft();
+        }
+        catch (ArgumentOutOfRangeException)
+        {
+            // Spectre's legacy cursor backend does not clamp negative coordinates, so
+            // moving left from column 0 (e.g. when the just-written spinner char wrapped
+            // to a new line, or the cursor was already at column 0) throws. Swallow it;
+            // the only consequence is a stray spinner glyph, never a crash.
+        }
+        catch (IOException)
+        {
+            // Cursor manipulation can fail on redirected/non-tty outputs. Spinner output
+            // is purely cosmetic, so there is nothing meaningful to do here.
+        }
     }
 
     public async Task StopSpinnerAsync()

--- a/src/Aspire.Cli/Utils/ConsoleActivityLogger.cs
+++ b/src/Aspire.Cli/Utils/ConsoleActivityLogger.cs
@@ -120,7 +120,7 @@ internal sealed class ConsoleActivityLogger
         {
             lock (_lock)
             {
-                _console.Cursor.Hide();
+                SafeSetCursorVisible(visible: false);
             }
 
             try
@@ -154,7 +154,7 @@ internal sealed class ConsoleActivityLogger
                     // Clear spinner character
                     _console.Write(" ");
                     SafeMoveCursorLeft();
-                    _console.Cursor.Show();
+                    SafeSetCursorVisible(visible: true);
                 }
             }
         });
@@ -177,6 +177,35 @@ internal sealed class ConsoleActivityLogger
         {
             // Cursor manipulation can fail on redirected/non-tty outputs. Spinner output
             // is purely cosmetic, so there is nothing meaningful to do here.
+        }
+    }
+
+    private void SafeSetCursorVisible(bool visible)
+    {
+        try
+        {
+            if (visible)
+            {
+                _console.Cursor.Show();
+            }
+            else
+            {
+                _console.Cursor.Hide();
+            }
+        }
+        catch (IOException)
+        {
+            // Spectre's legacy cursor backend implements Show/Hide as
+            // `System.Console.CursorVisible = X`, which throws IOException when stdout
+            // is redirected or attached to a non-tty. The spinner is purely cosmetic,
+            // so a missing show/hide is not worth crashing the command (especially in
+            // the `finally` block, where an exception would also fault the spinner task
+            // and surface from StopSpinnerAsync).
+        }
+        catch (PlatformNotSupportedException)
+        {
+            // Some platforms (notably non-Windows for the setter) do not support
+            // Console.CursorVisible. Same rationale as above: cosmetic, ignore.
         }
     }
 

--- a/tests/Aspire.Cli.Tests/Utils/ConsoleActivityLoggerTests.cs
+++ b/tests/Aspire.Cli.Tests/Utils/ConsoleActivityLoggerTests.cs
@@ -6,6 +6,7 @@ using Aspire.Cli.Backchannel;
 using Aspire.Cli.Resources;
 using Aspire.Cli.Utils;
 using Spectre.Console;
+using Spectre.Console.Rendering;
 
 namespace Aspire.Cli.Tests.Utils;
 
@@ -447,5 +448,127 @@ public class ConsoleActivityLoggerTests
         var result = output.ToString();
         Assert.Contains("[DBG]", result);
         Assert.Contains("ef-tool-start", result);
+    }
+
+    [Fact]
+    public async Task Spinner_DoesNotPropagate_CursorMoveLeftFailureFromLegacyBackend()
+    {
+        // Regression test for the crash:
+        //   "The value must be greater than or equal to zero and less than the
+        //    console's buffer size in that dimension. (Parameter 'left')"
+        // which surfaced from `aspire publish` when the spinner's MoveLeft raced
+        // with concurrent WriteLine output and the cursor was at column 0.
+        // Spectre's LegacyConsoleCursor (used whenever ANSI is disabled) does
+        // an unguarded `Console.CursorLeft -= 1` that throws in that case.
+        // The spinner must tolerate that failure rather than faulting the task.
+        var output = new StringBuilder();
+        var inner = AnsiConsole.Create(new AnsiConsoleSettings
+        {
+            Ansi = AnsiSupport.No,
+            ColorSystem = ColorSystemSupport.NoColors,
+            Out = new AnsiConsoleOutput(new StringWriter(output)),
+            Enrichment = new ProfileEnrichment { UseDefaultEnrichers = false },
+        });
+        var console = new ThrowingCursorConsole(inner);
+        var logger = new ConsoleActivityLogger(console, TestHelpers.CreateInteractiveHostEnvironment(), forceColor: false);
+
+        logger.StartSpinner();
+        // Allow several spinner ticks (each ~120ms) to exercise MoveLeft repeatedly.
+        await Task.Delay(400);
+
+        // StopSpinnerAsync awaits the spinner task, so any unhandled exception
+        // inside the loop or the finally block would be observed and rethrown here.
+        await logger.StopSpinnerAsync();
+
+        Assert.True(console.MoveLeftCallCount > 0, "Expected the spinner to attempt at least one MoveLeft.");
+    }
+
+    [Fact]
+    public async Task Spinner_DoesNotCrash_WhenWriteLineRunsConcurrently()
+    {
+        // Belt-and-braces test that the spinner's draw and the activity WriteLine
+        // calls do not produce an unhandled exception when interleaved on a console
+        // whose cursor uses the legacy (non-ANSI) backend semantics.
+        var output = new StringBuilder();
+        var inner = AnsiConsole.Create(new AnsiConsoleSettings
+        {
+            Ansi = AnsiSupport.No,
+            ColorSystem = ColorSystemSupport.NoColors,
+            Out = new AnsiConsoleOutput(new StringWriter(output)),
+            Enrichment = new ProfileEnrichment { UseDefaultEnrichers = false },
+        });
+        var console = new ThrowingCursorConsole(inner);
+        var logger = new ConsoleActivityLogger(console, TestHelpers.CreateInteractiveHostEnvironment(), forceColor: false);
+
+        logger.StartSpinner();
+
+        // Hammer WriteLine from multiple threads while the spinner is ticking.
+        var writers = Enumerable.Range(0, 4).Select(threadIndex => Task.Run(() =>
+        {
+            for (var i = 0; i < 50; i++)
+            {
+                logger.Progress($"step-{threadIndex}", $"working {i}");
+            }
+        })).ToArray();
+
+        await Task.WhenAll(writers);
+        await logger.StopSpinnerAsync();
+    }
+
+    // Wraps a real IAnsiConsole but substitutes an IAnsiConsoleCursor whose Move(Left, _)
+    // always throws ArgumentOutOfRangeException, mimicking Spectre's LegacyConsoleCursor
+    // when System.Console.CursorLeft would be driven negative.
+    private sealed class ThrowingCursorConsole : IAnsiConsole
+    {
+        private readonly IAnsiConsole _inner;
+        private readonly ThrowingCursor _cursor = new();
+
+        public ThrowingCursorConsole(IAnsiConsole inner)
+        {
+            _inner = inner;
+        }
+
+        public int MoveLeftCallCount => _cursor.MoveLeftCallCount;
+
+        public Profile Profile => _inner.Profile;
+        public IAnsiConsoleCursor Cursor => _cursor;
+        public IAnsiConsoleInput Input => _inner.Input;
+        public IExclusivityMode ExclusivityMode => _inner.ExclusivityMode;
+        public RenderPipeline Pipeline => _inner.Pipeline;
+
+        public void Clear(bool home) => _inner.Clear(home);
+        public void Write(IRenderable renderable) => _inner.Write(renderable);
+        public void WriteAnsi(Action<AnsiWriter> action) => _inner.WriteAnsi(action);
+    }
+
+    private sealed class ThrowingCursor : IAnsiConsoleCursor
+    {
+        private int _moveLeftCallCount;
+
+        public int MoveLeftCallCount => _moveLeftCallCount;
+
+        public void Show(bool show)
+        {
+        }
+
+        public void Move(CursorDirection direction, int steps)
+        {
+            if (direction == CursorDirection.Left)
+            {
+                Interlocked.Increment(ref _moveLeftCallCount);
+                // Simulate the worst-case legacy backend behavior: every MoveLeft fails
+                // as if Console.CursorLeft were already 0. The production code must
+                // swallow this so the spinner task does not fault. We intentionally use
+                // the same "left" parameter name that System.Console.SetCursorPosition
+                // throws with, to mirror the real-world exception users see.
+#pragma warning disable CA2208 // Instantiate argument exceptions correctly
+                throw new ArgumentOutOfRangeException("left", -1, "Simulated legacy cursor failure.");
+#pragma warning restore CA2208
+            }
+        }
+
+        public void SetPosition(int column, int line)
+        {
+        }
     }
 }

--- a/tests/Aspire.Cli.Tests/Utils/ConsoleActivityLoggerTests.cs
+++ b/tests/Aspire.Cli.Tests/Utils/ConsoleActivityLoggerTests.cs
@@ -481,6 +481,7 @@ public class ConsoleActivityLoggerTests
         await logger.StopSpinnerAsync();
 
         Assert.True(console.MoveLeftCallCount > 0, "Expected the spinner to attempt at least one MoveLeft.");
+        Assert.True(console.ShowHideCallCount >= 2, "Expected the spinner to attempt both Hide (at start) and Show (in finally).");
     }
 
     [Fact]
@@ -529,6 +530,7 @@ public class ConsoleActivityLoggerTests
         }
 
         public int MoveLeftCallCount => _cursor.MoveLeftCallCount;
+        public int ShowHideCallCount => _cursor.ShowHideCallCount;
 
         public Profile Profile => _inner.Profile;
         public IAnsiConsoleCursor Cursor => _cursor;
@@ -546,9 +548,15 @@ public class ConsoleActivityLoggerTests
         private int _moveLeftCallCount;
 
         public int MoveLeftCallCount => _moveLeftCallCount;
+        public int ShowHideCallCount { get; private set; }
 
         public void Show(bool show)
         {
+            ShowHideCallCount++;
+            // Simulate Spectre's LegacyConsoleCursor.Show, which sets
+            // System.Console.CursorVisible and can throw IOException when stdout is
+            // redirected or attached to a non-tty.
+            throw new IOException("Simulated legacy cursor visibility failure.");
         }
 
         public void Move(CursorDirection direction, int steps)

--- a/tests/Aspire.Cli.Tests/Utils/ConsoleActivityLoggerTests.cs
+++ b/tests/Aspire.Cli.Tests/Utils/ConsoleActivityLoggerTests.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Diagnostics;
 using System.Text;
 using Aspire.Cli.Backchannel;
 using Aspire.Cli.Resources;
@@ -473,8 +474,15 @@ public class ConsoleActivityLoggerTests
         var logger = new ConsoleActivityLogger(console, TestHelpers.CreateInteractiveHostEnvironment(), forceColor: false);
 
         logger.StartSpinner();
-        // Allow several spinner ticks (each ~120ms) to exercise MoveLeft repeatedly.
-        await Task.Delay(400);
+
+        // Poll for the spinner to actually run rather than waiting a fixed wall-clock
+        // duration. Under thread-pool starvation the spinner task may not get scheduled
+        // for a while, so a fixed Task.Delay would be timing-dependent and flaky.
+        var sw = Stopwatch.StartNew();
+        while (console.MoveLeftCallCount == 0 && sw.Elapsed < TimeSpan.FromSeconds(10))
+        {
+            await Task.Delay(50);
+        }
 
         // StopSpinnerAsync awaits the spinner task, so any unhandled exception
         // inside the loop or the finally block would be observed and rethrown here.


### PR DESCRIPTION
## Description

Running `aspire publish` (reported against a TypeScript AppHost on the daily build) could crash with:

```
❌ An unexpected error occurred: The value must be greater than or equal to zero and less than
the console's buffer size in that dimension. (Parameter 'left')
Actual value was -1.
```

Root cause is a race in `ConsoleActivityLogger`. The spinner task wrote a glyph and then called `_console.Cursor.MoveLeft()` *without* holding the `_lock` that guards `WriteLine`. When publish-pipeline output interleaved between the `Write` and the `MoveLeft`, the cursor could land at column 0. Spectre's `LegacyConsoleCursor` (used whenever ANSI is disabled) then runs an unguarded `Console.CursorLeft -= 1`, which throws the error above.

The fix takes `_lock` around both the per-tick spinner draw and the cleanup in the `finally` block so they are atomic relative to `WriteLine`, and adds a defensive `SafeMoveCursorLeft` helper that swallows `ArgumentOutOfRangeException`/`IOException` from cursor manipulation (covers the rare case where the spinner glyph wraps to a new line, or stdout is redirected). The spinner is purely cosmetic, so dropping a move under those conditions is preferable to crashing the command.

Fixes # (issue)

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [x] No
- Did you add public API?
  - [ ] Yes
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
  - [x] No