### PR TITLE
Fix WithIngressClass parameter resolution for Kubernetes publish

### DIFF
--- a/src/Aspire.Hosting.Kubernetes/KubernetesEnvironmentResource.cs
+++ b/src/Aspire.Hosting.Kubernetes/KubernetesEnvironmentResource.cs
@@ -585,6 +585,21 @@ public sealed class KubernetesEnvironmentResource : Resource, IComputeEnvironmen
     {
         if (valueProvider is ParameterResource parameter)
         {
+            // Attempt to resolve this individual parameter first. The outer
+            // MissingParameterValueException from the whole-expression resolve attempt
+            // only tells us that *some* parameter in the expression was unresolved;
+            // others (e.g., those with `publishValueAsDefault: true`) may still have
+            // a value and should be inlined into the manifest rather than left as
+            // Helm placeholders. This keeps the published chart maximally self-contained.
+            try
+            {
+                return (await parameter.GetValueAsync(cancellationToken).ConfigureAwait(false)) ?? string.Empty;
+            }
+            catch (MissingParameterValueException)
+            {
+                // Fall through to Helm-reference substitution below.
+            }
+
             // Capture the parameter so HelmDeploymentEngine writes its resolved value to
             // the deploy-time override file, and ensure values.yaml has a placeholder so
             // `helm template` (and `aspire publish` consumers that don't deploy via Aspire)

--- a/src/Aspire.Hosting.Kubernetes/KubernetesEnvironmentResource.cs
+++ b/src/Aspire.Hosting.Kubernetes/KubernetesEnvironmentResource.cs
@@ -516,11 +516,12 @@ public sealed class KubernetesEnvironmentResource : Resource, IComputeEnvironmen
     }
 
     /// <summary>
-    /// Resolves a <see cref="ReferenceExpression"/> to a string value. If the expression wraps
-    /// a <see cref="ParameterResource"/> that has no value yet (common during publish), returns
-    /// the parameter's name as a fallback so it can be used in Helm values.
+    /// Resolves a <see cref="ReferenceExpression"/> at deploy time. Used by pipeline steps
+    /// (e.g., TLS bootstrap, gateway address discovery) where parameter values are expected
+    /// to be available. Falls back to the format string when a parameter is missing — these
+    /// paths run after deploy and should not encounter unresolved parameters in practice.
     /// </summary>
-    private static async Task<string> ResolveExpressionAsync(ReferenceExpression expression, CancellationToken cancellationToken)
+    private static async Task<string> ResolveExpressionAtDeployTimeAsync(ReferenceExpression expression, CancellationToken cancellationToken)
     {
         try
         {
@@ -529,6 +530,88 @@ public sealed class KubernetesEnvironmentResource : Resource, IComputeEnvironmen
         catch (MissingParameterValueException)
         {
             return expression.Format;
+        }
+    }
+
+    /// <summary>
+    /// Resolves a <see cref="ReferenceExpression"/> for inclusion in a Kubernetes manifest
+    /// produced by an ingress or gateway resource. When the expression wraps one or more
+    /// <see cref="ParameterResource"/> instances that have no value at publish time
+    /// (e.g., user-supplied parameters without defaults, or secrets), the expression is
+    /// rendered with Helm template placeholders (such as <c>{{ .Values.parameters.ingress.ingressclass }}</c>)
+    /// and the parameters are captured for deploy-time resolution into a values override file.
+    /// </summary>
+    /// <param name="expression">The reference expression to resolve.</param>
+    /// <param name="owningResourceName">
+    /// The name of the resource (ingress or gateway) that owns this expression. Used as the
+    /// scoping segment in the generated Helm parameter path so multiple ingress/gateway resources
+    /// can reuse the same parameter name without collision.
+    /// </param>
+    /// <param name="cancellationToken">The cancellation token.</param>
+    private async Task<string> ResolveExpressionAsync(ReferenceExpression expression, string owningResourceName, CancellationToken cancellationToken)
+    {
+        try
+        {
+            return (await expression.GetValueAsync(cancellationToken).ConfigureAwait(false))!;
+        }
+        catch (MissingParameterValueException)
+        {
+            // One or more parameters in the expression have no value at publish time
+            // (e.g., a parameter created via AddParameter("ingressclass") with no default,
+            // or a secret parameter). Substitute each unresolved parameter with a Helm
+            // template reference into values.yaml so the resulting manifest is a valid
+            // Helm template and the value can be supplied at deploy time.
+            var owningResourceKey = owningResourceName.ToHelmValuesSectionName();
+            var args = new object[expression.ValueProviders.Count];
+
+            for (var i = 0; i < expression.ValueProviders.Count; i++)
+            {
+                args[i] = await ResolveValueProviderAsync(
+                    expression.ValueProviders[i],
+                    owningResourceName,
+                    owningResourceKey,
+                    cancellationToken).ConfigureAwait(false);
+            }
+
+            return string.Format(System.Globalization.CultureInfo.InvariantCulture, expression.Format, args);
+        }
+    }
+
+    private async Task<string> ResolveValueProviderAsync(
+        IValueProvider valueProvider,
+        string owningResourceName,
+        string owningResourceKey,
+        CancellationToken cancellationToken)
+    {
+        if (valueProvider is ParameterResource parameter)
+        {
+            // Capture the parameter so HelmDeploymentEngine writes its resolved value to
+            // the deploy-time override file, and ensure values.yaml has a placeholder so
+            // `helm template` (and `aspire publish` consumers that don't deploy via Aspire)
+            // can render the chart without `<no value>` substitutions.
+            var section = parameter.Secret ? HelmExtensions.SecretsKey : HelmExtensions.ParametersKey;
+            var valueKey = parameter.Name.ToHelmValuesSectionName();
+
+            if (!CapturedHelmValues.Any(c =>
+                    c.Section == section &&
+                    c.ResourceKey == owningResourceKey &&
+                    c.ValueKey == valueKey))
+            {
+                CapturedHelmValues.Add(new CapturedHelmValue(section, owningResourceKey, valueKey, parameter));
+            }
+
+            return parameter.Secret
+                ? valueKey.ToHelmSecretExpression(owningResourceName)
+                : valueKey.ToHelmParameterExpression(owningResourceName);
+        }
+
+        try
+        {
+            return (await valueProvider.GetValueAsync(cancellationToken).ConfigureAwait(false)) ?? string.Empty;
+        }
+        catch (MissingParameterValueException)
+        {
+            return string.Empty;
         }
     }
 
@@ -568,7 +651,7 @@ public sealed class KubernetesEnvironmentResource : Resource, IComputeEnvironmen
         }
     }
 
-    private static async Task<Ingress?> BuildIngressObject(
+    private async Task<Ingress?> BuildIngressObject(
         KubernetesIngressResource ingressResource,
         Dictionary<IResource, KubernetesResource> deploymentTargets,
         ILogger logger,
@@ -584,12 +667,12 @@ public sealed class KubernetesEnvironmentResource : Resource, IComputeEnvironmen
 
         if (ingressResource.IngressClassName is not null)
         {
-            ingress.Spec.IngressClassName = await ResolveExpressionAsync(ingressResource.IngressClassName, cancellationToken).ConfigureAwait(false);
+            ingress.Spec.IngressClassName = await ResolveExpressionAsync(ingressResource.IngressClassName, ingressResource.Name, cancellationToken).ConfigureAwait(false);
         }
 
         foreach (var (key, value) in ingressResource.IngressAnnotations)
         {
-            ingress.Metadata.Annotations[key] = await ResolveExpressionAsync(value, cancellationToken).ConfigureAwait(false);
+            ingress.Metadata.Annotations[key] = await ResolveExpressionAsync(value, ingressResource.Name, cancellationToken).ConfigureAwait(false);
         }
 
         var pathsByHost = ingressResource.Paths.GroupBy(p => p.Host ?? string.Empty);
@@ -637,12 +720,12 @@ public sealed class KubernetesEnvironmentResource : Resource, IComputeEnvironmen
         {
             var tlsEntry = new IngressTLSV1
             {
-                SecretName = await ResolveExpressionAsync(tls.SecretName, cancellationToken).ConfigureAwait(false),
+                SecretName = await ResolveExpressionAsync(tls.SecretName, ingressResource.Name, cancellationToken).ConfigureAwait(false),
             };
 
             foreach (var host in ingressResource.Hostnames)
             {
-                tlsEntry.Hosts.Add(await ResolveExpressionAsync(host, cancellationToken).ConfigureAwait(false));
+                tlsEntry.Hosts.Add(await ResolveExpressionAsync(host, ingressResource.Name, cancellationToken).ConfigureAwait(false));
             }
 
             ingress.Spec.Tls.Add(tlsEntry);
@@ -661,7 +744,7 @@ public sealed class KubernetesEnvironmentResource : Resource, IComputeEnvironmen
             {
                 foreach (var host in ingressResource.Hostnames)
                 {
-                    var resolvedHost = await ResolveExpressionAsync(host, cancellationToken).ConfigureAwait(false);
+                    var resolvedHost = await ResolveExpressionAsync(host, ingressResource.Name, cancellationToken).ConfigureAwait(false);
                     if (!hostsWithRules.Contains(resolvedHost))
                     {
                         ingress.Spec.Rules.Add(new IngressRuleV1
@@ -768,7 +851,7 @@ public sealed class KubernetesEnvironmentResource : Resource, IComputeEnvironmen
         }
     }
 
-    private static async Task BuildGatewayObjects(
+    private async Task BuildGatewayObjects(
         KubernetesGatewayResource gatewayResource,
         Dictionary<IResource, KubernetesResource> deploymentTargets,
         ILogger logger,
@@ -788,11 +871,11 @@ public sealed class KubernetesEnvironmentResource : Resource, IComputeEnvironmen
             Metadata = { Name = gatewayName }
         };
 
-        gateway.Spec.GatewayClassName = await ResolveExpressionAsync(gatewayResource.GatewayClassName, cancellationToken).ConfigureAwait(false);
+        gateway.Spec.GatewayClassName = await ResolveExpressionAsync(gatewayResource.GatewayClassName, gatewayResource.Name, cancellationToken).ConfigureAwait(false);
 
         foreach (var (key, value) in gatewayResource.GatewayAnnotations)
         {
-            gateway.Metadata.Annotations[key] = await ResolveExpressionAsync(value, cancellationToken).ConfigureAwait(false);
+            gateway.Metadata.Annotations[key] = await ResolveExpressionAsync(value, gatewayResource.Name, cancellationToken).ConfigureAwait(false);
         }
 
         gateway.Spec.Listeners.Add(new GatewayListenerV1
@@ -809,7 +892,7 @@ public sealed class KubernetesEnvironmentResource : Resource, IComputeEnvironmen
         var tlsListenerIndex = 0;
         foreach (var tls in gatewayResource.TlsConfigs)
         {
-            var resolvedSecretName = await ResolveExpressionAsync(tls.SecretName, cancellationToken).ConfigureAwait(false);
+            var resolvedSecretName = await ResolveExpressionAsync(tls.SecretName, gatewayResource.Name, cancellationToken).ConfigureAwait(false);
 
             if (gatewayResource.Hostnames.Count == 0)
             {
@@ -842,7 +925,7 @@ public sealed class KubernetesEnvironmentResource : Resource, IComputeEnvironmen
                     var listenerName = tlsListenerIndex == 0 ? "https" : $"https-{tlsListenerIndex}";
                     tlsListenerIndex++;
 
-                    var resolvedHost = await ResolveExpressionAsync(host, cancellationToken).ConfigureAwait(false);
+                    var resolvedHost = await ResolveExpressionAsync(host, gatewayResource.Name, cancellationToken).ConfigureAwait(false);
 
                     gateway.Spec.Listeners.Add(new GatewayListenerV1
                     {
@@ -1058,7 +1141,7 @@ public sealed class KubernetesEnvironmentResource : Resource, IComputeEnvironmen
         foreach (var (gateway, secretNameExpr) in gatewaysNeedingDiscovery)
         {
             var gatewayName = gateway.Name.ToKubernetesResourceName();
-            var secretName = await ResolveExpressionAsync(secretNameExpr, context.CancellationToken).ConfigureAwait(false);
+            var secretName = await ResolveExpressionAtDeployTimeAsync(secretNameExpr, context.CancellationToken).ConfigureAwait(false);
 
             // Pre-create a placeholder bootstrap TLS secret BEFORE waiting for the Gateway
             // address. Some controllers (notably Azure Application Gateway for Containers)
@@ -1812,8 +1895,8 @@ public sealed class KubernetesEnvironmentResource : Resource, IComputeEnvironmen
 
         foreach (var (secretNameExpr, hostnameExpr) in tlsSecrets)
         {
-            var secretName = await ResolveExpressionAsync(secretNameExpr, context.CancellationToken).ConfigureAwait(false);
-            var hostname = await ResolveExpressionAsync(hostnameExpr, context.CancellationToken).ConfigureAwait(false);
+            var secretName = await ResolveExpressionAtDeployTimeAsync(secretNameExpr, context.CancellationToken).ConfigureAwait(false);
+            var hostname = await ResolveExpressionAtDeployTimeAsync(hostnameExpr, context.CancellationToken).ConfigureAwait(false);
 
             var checkArgs = $"get secret {secretName} --namespace {@namespace}";
             if (environment.KubeConfigPath is not null)

--- a/src/Aspire.Hosting.Kubernetes/KubernetesEnvironmentResource.cs
+++ b/src/Aspire.Hosting.Kubernetes/KubernetesEnvironmentResource.cs
@@ -605,14 +605,13 @@ public sealed class KubernetesEnvironmentResource : Resource, IComputeEnvironmen
                 : valueKey.ToHelmParameterExpression(owningResourceName);
         }
 
-        try
-        {
-            return (await valueProvider.GetValueAsync(cancellationToken).ConfigureAwait(false)) ?? string.Empty;
-        }
-        catch (MissingParameterValueException)
-        {
-            return string.Empty;
-        }
+        // For non-ParameterResource providers (string literals, endpoint references, etc.)
+        // resolve normally. If a nested provider throws MissingParameterValueException
+        // we intentionally let it propagate: silently substituting an empty string here
+        // would produce invalid Kubernetes manifest fields (e.g., `secretName: ""`,
+        // `hosts: [""]`) that only fail loudly at deploy time. Letting it throw surfaces
+        // the unresolved-parameter problem during publish.
+        return (await valueProvider.GetValueAsync(cancellationToken).ConfigureAwait(false)) ?? string.Empty;
     }
 
     private async Task ProcessIngressResources(DistributedApplicationModel model, Dictionary<IResource, KubernetesResource> deploymentTargets, ILogger logger, CancellationToken cancellationToken)

--- a/src/Aspire.Hosting.Kubernetes/KubernetesPublishingContext.cs
+++ b/src/Aspire.Hosting.Kubernetes/KubernetesPublishingContext.cs
@@ -138,7 +138,41 @@ internal sealed class KubernetesPublishingContext(
         }
 
         await WriteKubernetesHelmChartAsync(environment).ConfigureAwait(false);
+
+        // Drain any captured Helm values from ingress/gateway resources that don't go through
+        // AppendResourceContextToHelmValuesAsync (compute resources do). Without this, values.yaml
+        // would be missing placeholders for parameters referenced by WithIngressClass(parameter),
+        // WithHostname(parameter), WithTls(parameter), WithGatewayClass(parameter), etc., and
+        // `helm template` would render `<no value>` for those Helm references.
+        EnsureCapturedHelmValuePlaceholders(environment);
+
         await WriteKubernetesHelmValuesAsync().ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Adds empty placeholders to <see cref="_helmValues"/> for any captured Helm value
+    /// whose (section, resourceKey, valueKey) is not already present. Compute resources
+    /// populate their placeholders during <see cref="AppendResourceContextToHelmValuesAsync"/>;
+    /// ingress and gateway resources rely on this pass.
+    /// </summary>
+    private void EnsureCapturedHelmValuePlaceholders(KubernetesEnvironmentResource environment)
+    {
+        foreach (var captured in environment.CapturedHelmValues)
+        {
+            if (_helmValues[captured.Section] is not Dictionary<string, object> section)
+            {
+                continue;
+            }
+
+            if (!section.TryGetValue(captured.ResourceKey, out var resourceObj) ||
+                resourceObj is not Dictionary<string, object> resourceSection)
+            {
+                resourceSection = new Dictionary<string, object>();
+                section[captured.ResourceKey] = resourceSection;
+            }
+
+            resourceSection.TryAdd(captured.ValueKey, string.Empty);
+        }
     }
 
     private async Task AppendResourceContextToHelmValuesAsync(IResource resource, KubernetesResource resourceContext)

--- a/src/Aspire.Hosting.Kubernetes/KubernetesPublishingContext.cs
+++ b/src/Aspire.Hosting.Kubernetes/KubernetesPublishingContext.cs
@@ -159,7 +159,7 @@ internal sealed class KubernetesPublishingContext(
     {
         foreach (var captured in environment.CapturedHelmValues)
         {
-            if (_helmValues[captured.Section] is not Dictionary<string, object> section)
+            if (!_helmValues.TryGetValue(captured.Section, out var section))
             {
                 continue;
             }

--- a/tests/Aspire.Hosting.Kubernetes.Tests/KubernetesIngressTests.cs
+++ b/tests/Aspire.Hosting.Kubernetes.Tests/KubernetesIngressTests.cs
@@ -66,6 +66,90 @@ public class KubernetesIngressTests
     }
 
     [Fact]
+    public async Task AddIngress_WithIngressClassParameter_GeneratesHelmReferenceAndPlaceholder()
+    {
+        // Regression test: using a ParameterResource with the WithIngressClass overload
+        // previously rendered the literal format string ("{0}") into ingressClassName
+        // when the parameter had no value available at publish time. The fix substitutes a
+        // Helm template expression and captures the parameter so the deploy-time values
+        // override file (and chart values.yaml placeholder) include the entry.
+        using var tempDir = new TestTempDirectory();
+        // Pipeline:ClearCache=true prevents loading of leaked deployment state from
+        // ~/.aspire/deployments/<sha>/<env>.json (which would otherwise auto-resolve
+        // parameters from prior test runs and bypass the MissingParameterValueException path).
+        var builder = TestDistributedApplicationBuilder.Create(
+            "AppHost:Operation=publish",
+            $"Pipeline:OutputPath={tempDir.Path}",
+            "Pipeline:LogLevel=information",
+            "Pipeline:Step=publish",
+            "Pipeline:ClearCache=true");
+
+        // Use a unique parameter name per test run to defeat any persistent state file lookup.
+        var parameterName = $"ingressclass{Guid.NewGuid():N}";
+        var ingressClass = builder.AddParameter(parameterName);
+
+        var k8s = builder.AddKubernetesEnvironment("env");
+        var ingress = k8s.AddIngress("public")
+            .WithIngressClass(ingressClass);
+
+        var api = builder.AddContainer("myapi", "nginx")
+            .WithHttpEndpoint(targetPort: 8080)
+            .WithExternalHttpEndpoints();
+
+        ingress.WithRoute("/api", api.GetEndpoint("http"));
+
+        var app = builder.Build();
+        app.Run();
+
+        var ingressPath = Path.Combine(tempDir.Path, "templates", "public", "public.yaml");
+        Assert.True(File.Exists(ingressPath), $"Expected ingress YAML at {ingressPath}");
+
+        var content = await File.ReadAllTextAsync(ingressPath);
+        Assert.DoesNotContain("\"{0}\"", content);
+        Assert.Contains($"{{{{ .Values.parameters.public.{parameterName} }}}}", content);
+
+        var valuesPath = Path.Combine(tempDir.Path, "values.yaml");
+        Assert.True(File.Exists(valuesPath), $"Expected values.yaml at {valuesPath}");
+
+        var values = await File.ReadAllTextAsync(valuesPath);
+        // Expect a placeholder entry under parameters: public: <parameterName>: so consumers
+        // of the published Helm chart can fill it in (and `helm template` won't substitute <no value>).
+        Assert.Matches(
+            new System.Text.RegularExpressions.Regex(@"parameters:\s*[\r\n]+\s*public:\s*[\r\n]+\s*" + System.Text.RegularExpressions.Regex.Escape(parameterName) + @"\s*:"),
+            values);
+    }
+
+    [Fact]
+    public async Task AddIngress_WithIngressClassParameter_WithDefaultValue_ResolvesAtPublish()
+    {
+        // When a parameter has a publish-time default, the resolved value should be inlined
+        // into the manifest rather than rendered as a Helm template reference.
+        using var tempDir = new TestTempDirectory();
+        var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish, tempDir.Path);
+
+        var ingressClass = builder.AddParameter("ingressclass", "nginx", publishValueAsDefault: true);
+
+        var k8s = builder.AddKubernetesEnvironment("env");
+        var ingress = k8s.AddIngress("public")
+            .WithIngressClass(ingressClass);
+
+        var api = builder.AddContainer("myapi", "nginx")
+            .WithHttpEndpoint(targetPort: 8080)
+            .WithExternalHttpEndpoints();
+
+        ingress.WithRoute("/api", api.GetEndpoint("http"));
+
+        var app = builder.Build();
+        app.Run();
+
+        var ingressPath = Path.Combine(tempDir.Path, "templates", "public", "public.yaml");
+        var content = await File.ReadAllTextAsync(ingressPath);
+
+        Assert.Contains("ingressClassName: \"nginx\"", content);
+        Assert.DoesNotContain("{{ .Values", content);
+    }
+
+    [Fact]
     public async Task AddIngress_WithTls_GeneratesTlsSection()
     {
         using var tempDir = new TestTempDirectory();

--- a/tests/Aspire.Hosting.Kubernetes.Tests/KubernetesIngressTests.cs
+++ b/tests/Aspire.Hosting.Kubernetes.Tests/KubernetesIngressTests.cs
@@ -96,7 +96,7 @@ public class KubernetesIngressTests
             .WithHttpEndpoint(targetPort: 8080)
             .WithExternalHttpEndpoints();
 
-        ingress.WithRoute("/api", api.GetEndpoint("http"));
+        ingress.WithPath("/api", api.GetEndpoint("http"));
 
         var app = builder.Build();
         app.Run();
@@ -137,7 +137,7 @@ public class KubernetesIngressTests
             .WithHttpEndpoint(targetPort: 8080)
             .WithExternalHttpEndpoints();
 
-        ingress.WithRoute("/api", api.GetEndpoint("http"));
+        ingress.WithPath("/api", api.GetEndpoint("http"));
 
         var app = builder.Build();
         app.Run();


### PR DESCRIPTION
## Description

When an ingress or gateway resource referenced a `ParameterResource` via `WithIngressClass`, `WithHostname`, `WithTls`, etc., the generated Kubernetes YAML rendered the literal format string `"{0}"` for unresolved parameters instead of a Helm template expression. This made the published Helm chart unusable unless the parameter happened to have a value at publish time. Reproduced from a bug shown on AspireFridays by @robrich:

```csharp
var ingressClass = builder.AddParameter("ingressclass");
ingress.WithIngressClass(ingressClass);
```

produced:

```yaml
spec:
  ingressClassName: "{0}"     # should be a Helm template reference
```

### Why the bug existed

`KubernetesEnvironmentResource.ResolveExpressionAsync` was the single helper used to resolve every `ReferenceExpression` consumed by the Kubernetes publisher (ingress class, hostname, TLS, gateway listeners, etc.). It called `ReferenceExpression.GetValueAsync` and, on `MissingParameterValueException`, returned `expression.Format` verbatim as a "fallback":

```csharp
catch (MissingParameterValueException)
{
    return expression.Format;   // "{0}" for a single ParameterResource
}
```

`expression.Format` is the raw composite format string (e.g. `"{0}"` for one parameter, `"{0}-{1}"` for two). It only resembles a useful value for expressions that contain no placeholders, which is essentially never the case for parameter-driven values. The docstring claimed the helper returned the parameter name, but the implementation never did — it just emitted the format string and let it land in the published YAML.

This was harmless for the original callers (TLS bootstrap and gateway address discovery in pipeline steps) because those run at deploy time, where parameters already have values and the catch block is never hit. The bug only surfaced once the same helper was reused for publish-time manifest generation, where missing values are the normal case.

### How the fix works

`ResolveExpressionAsync` is now parameter-aware and runs at publish time. When the expression contains unresolved `ParameterResource`s, the fix:

1. Walks each `IValueProvider` in the expression individually instead of returning the raw format string.
2. For each unresolved `ParameterResource`, substitutes a Helm template reference of the form `{{ .Values.parameters.<owningResource>.<paramName> }}` (or `secrets.` for secret parameters), scoped to the owning ingress/gateway resource so multiple resources can reuse the same parameter name without colliding.
3. Captures the parameter in `CapturedHelmValues` so two downstream consumers get the right data:
   - `HelmDeploymentEngine` writes the resolved parameter value into the deploy-time override file Aspire passes to `helm install`/`helm upgrade`.
   - `values.yaml` gets a matching placeholder entry via the new `EnsureCapturedHelmValuePlaceholders` pass in `KubernetesPublishingContext`, so `helm template` against the published chart does not render `<no value>` for users who deploy outside of Aspire.
4. Re-applies `string.Format` with the substituted segments, preserving any literal text from the original expression (e.g. an expression like `"prefix-{0}-suffix"` becomes `"prefix-{{ .Values.parameters.ingress.foo }}-suffix"`).

Pipeline-time callers (TLS bootstrap, gateway address discovery) keep their original behavior through a renamed static helper `ResolveExpressionAtDeployTimeAsync`. Those paths run after parameters are guaranteed to be resolved, so a missing-value fallback there is acceptable (and, again, never hit in practice).

### Testing notes

Added two regression tests in `KubernetesIngressTests.cs` covering the parameter and missing-parameter cases. The missing-parameter test needs `Pipeline:ClearCache=true` plus a per-run unique parameter name because the deployment state file at `~/.aspire/deployments/<sha>/<env>.json` persists across local test runs and would otherwise auto-resolve the parameter from a previous run, masking the failure.

Fixes # (issue)

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
