### PR TITLE
Fix for Aspire.Deployment.EndToEnd.Tests.FrontDoorDeploymentTests.DeployReactTemplateWithFrontDoor

### DIFF
--- a/tests/Aspire.Deployment.EndToEnd.Tests/FrontDoorDeploymentTests.cs
+++ b/tests/Aspire.Deployment.EndToEnd.Tests/FrontDoorDeploymentTests.cs
@@ -91,30 +91,21 @@ public sealed class FrontDoorDeploymentTests(ITestOutputHelper output)
             await auto.EnterAsync();
             await auto.WaitForSuccessPromptAsync(counter);
 
-            // Step 5: Add Azure Container Apps and Front Door hosting packages
+            // Step 5: Add Azure Container Apps and Front Door hosting packages.
+            // Use WaitForAspireAddCompletionAsync because `aspire add` only prompts for a
+            // version when multiple candidates are found; when the package is resolved from
+            // the local bundle (the typical CI case) the command installs directly with no
+            // prompt, so a hard-coded WaitUntilText for the legacy "(based on NuGet.config)"
+            // prompt times out. The helper covers both code paths.
             output.WriteLine("Step 5: Adding Azure Container Apps hosting package...");
             await auto.TypeAsync("aspire add Aspire.Hosting.Azure.AppContainers");
             await auto.EnterAsync();
-
-            if (DeploymentE2ETestHelpers.IsRunningInCI)
-            {
-                await auto.WaitUntilTextAsync("(based on NuGet.config)", timeout: TimeSpan.FromSeconds(60));
-                await auto.EnterAsync();
-            }
-
-            await auto.WaitForSuccessPromptAsync(counter, TimeSpan.FromSeconds(180));
+            await auto.WaitForAspireAddCompletionAsync(counter, TimeSpan.FromMinutes(3));
 
             output.WriteLine("Step 5b: Adding Azure Front Door hosting package...");
             await auto.TypeAsync("aspire add Aspire.Hosting.Azure.FrontDoor");
             await auto.EnterAsync();
-
-            if (DeploymentE2ETestHelpers.IsRunningInCI)
-            {
-                await auto.WaitUntilTextAsync("(based on NuGet.config)", timeout: TimeSpan.FromSeconds(60));
-                await auto.EnterAsync();
-            }
-
-            await auto.WaitForSuccessPromptAsync(counter, TimeSpan.FromSeconds(180));
+            await auto.WaitForAspireAddCompletionAsync(counter, TimeSpan.FromMinutes(3));
 
             // Step 6: Modify AppHost.cs to add Azure Container App Environment and Front Door
             var projectDir = Path.Combine(workspace.WorkspaceRoot.FullName, projectName);


### PR DESCRIPTION
> ⚠️ **This PR was created automatically by a workflow analyzing Deployment E2E test failures on `main`.** It is intentionally opened as a draft so a human can review the fix before merging.

## Fix for `Aspire.Deployment.EndToEnd.Tests.FrontDoorDeploymentTests.DeployReactTemplateWithFrontDoor`

Fixes #17426

### Problem

The test consistently fails on every nightly Deployment E2E run with:

```
Hex1b.Automation.WaitUntilTimeoutException : WaitUntil timed out after 00:01:00
    waiting for: text "(based on NuGet.config)" to appear
```

The 60-second `WaitUntilText("(based on NuGet.config)")` after the first
`aspire add Aspire.Hosting.Azure.AppContainers` times out. The recorded
terminal for the failing run shows that `aspire add` installs the package
directly without any version-selection prompt:

```
⠲ Adding Aspire hosting integration...
✅ The package Aspire.Hosting.Azure.AppContainers::13.4.0-dev was added successfully.
[6 OK] $
```

### Root Cause

When `aspire add` resolves a single candidate from the local bundle (the
typical CI case), it skips the legacy "(based on NuGet.config)" version-selection prompt and installs directly. The test's hard-coded wait for that
prompt is therefore brittle.

### Fix

Replace the explicit `WaitUntilTextAsync(...)` + `EnterAsync()` pair with
`WaitForAspireAddCompletionAsync`, which already handles both prompted and
prompt-less code paths and is the same helper used by the other deployment
E2E tests (e.g. the AKS cert-manager test).

### Verification

CI on this PR will run the standard build. After CI is green, the
`/deployment-test` command will be triggered to re-run the affected
deployment E2E test against Azure and confirm the fix.
