### PR TITLE
Fix for Aspire.Deployment.EndToEnd.Tests.AksAzureKubernetesEnvironmentCertManagerTypeScriptDeploymentTests.DeployTypeScriptApiWithCertManagerToAzureKubernetesEnvironment

### DIFF
--- a/tests/Aspire.Deployment.EndToEnd.Tests/AksAzureKubernetesEnvironmentCertManagerTypeScriptDeploymentTests.cs
+++ b/tests/Aspire.Deployment.EndToEnd.Tests/AksAzureKubernetesEnvironmentCertManagerTypeScriptDeploymentTests.cs
@@ -12,7 +12,7 @@ namespace Aspire.Deployment.EndToEnd.Tests;
 /// TypeScript-AppHost variant of the AKS cert-manager E2E test. Mirrors
 /// <see cref="AksAzureKubernetesEnvironmentCertManagerDeploymentTests"/> but uses the
 /// TypeScript Express/React starter (<c>aspire new</c> --&gt; <c>Starter App (Express/React, TypeScript AppHost)</c>)
-/// and patches <c>apphost.ts</c> to wire <c>addAzureKubernetesEnvironment</c> +
+/// and patches <c>apphost.mts</c> to wire <c>addAzureKubernetesEnvironment</c> +
 /// <c>addCertManager</c> + <c>addIssuer().withLetsEncryptProductionParam(acmeEmail).withHttp01Solver()</c>
 /// + <c>gateway.withGatewayTlsIssuer(letsEncrypt)</c> around the Express API.
 ///
@@ -117,7 +117,7 @@ public sealed class AksAzureKubernetesEnvironmentCertManagerTypeScriptDeployment
                 await auto.WaitForSuccessPromptAsync(counter, TimeSpan.FromSeconds(180));
             }
 
-            // Patch apphost.ts. The Express/React starter creates an Express API at ./api
+            // Patch apphost.mts. The Express/React starter creates an Express API at ./api
             // exposing an HTTP endpoint, plus a Vite frontend bundled in for publish. We
             // replace the trailing `await builder.build().run();` with the AKS + cert-manager
             // wiring that puts the API behind a Gateway with TLS issued by Let's Encrypt production.
@@ -129,9 +129,12 @@ public sealed class AksAzureKubernetesEnvironmentCertManagerTypeScriptDeployment
             //   addGateway / withLoadBalancer / withRoute / withGatewayTlsIssuer
             //   publishAsKubernetesService / addManifest
             var projectDir = Path.Combine(workspace.WorkspaceRoot.FullName, projectName);
-            var appHostFilePath = Path.Combine(projectDir, "apphost.ts");
+            // The TypeScript starter template emits apphost.mts (since PR #16984); the
+            // earlier apphost.ts name is gone. CliTemplateFactory.TypeScriptStarterTemplate
+            // looks for Path.Combine(outputPath, "apphost.mts").
+            var appHostFilePath = Path.Combine(projectDir, "apphost.mts");
 
-            output.WriteLine($"Step 6: Modifying apphost.ts at: {appHostFilePath}");
+            output.WriteLine($"Step 6: Modifying apphost.mts at: {appHostFilePath}");
 
             var content = File.ReadAllText(appHostFilePath);
 
@@ -190,7 +193,7 @@ await builder.build().run();
 
             content = content.Replace(buildRunPattern, replacement);
             File.WriteAllText(appHostFilePath, content);
-            output.WriteLine("Modified apphost.ts with addCertManager + addIssuer + withGatewayTlsIssuer");
+            output.WriteLine("Modified apphost.mts with addCertManager + addIssuer + withGatewayTlsIssuer");
 
             output.WriteLine("Step 7: Setting deployment environment variables...");
             await auto.TypeAsync(


### PR DESCRIPTION
> ⚠️ **This PR was created automatically by a workflow analyzing Deployment E2E test failures on `main`.** It is intentionally opened as a draft so a human can review the fix before merging.

## Fix for `Aspire.Deployment.EndToEnd.Tests.AksAzureKubernetesEnvironmentCertManagerTypeScriptDeploymentTests.DeployTypeScriptApiWithCertManagerToAzureKubernetesEnvironment`

Fixes #17427

### Problem

The test fails immediately after creating the TypeScript Express/React starter
project with:

```
System.IO.FileNotFoundException : Could not find file
    '/tmp/Aspire.Cli.Tests/TemporaryWorkspaces/<guid>/AksCertManagerTs/apphost.ts'.
```

### Root Cause

Since PR #16984 ("Use mts for TypeScript AppHosts") the TypeScript starter
template emits `apphost.mts` instead of `apphost.ts` (see
[`CliTemplateFactory.TypeScriptStarterTemplate.cs#L75`](https://github.com/microsoft/aspire/blob/main/src/Aspire.Cli/Templating/CliTemplateFactory.TypeScriptStarterTemplate.cs#L75)).
The test still hard-codes the old `apphost.ts` name, so `File.ReadAllText`
fails right after project creation.

### Fix

Update the test's file reference (and the surrounding XML doc / log strings)
from `apphost.ts` to `apphost.mts`.

### Verification

CI on this PR will run the standard build. After CI is green, the
`/deployment-test` command will be triggered to re-run the affected
deployment E2E test against Azure and confirm the fix.
