### PR TITLE
Fix for Aspire.Deployment.EndToEnd.Tests.TypeScriptAzureContainerAppJobDeploymentTests.DeployTypeScriptContainerAppJobsToAzureContainerApps

### DIFF
--- a/tests/Aspire.Deployment.EndToEnd.Tests/TypeScriptAzureContainerAppJobDeploymentTests.cs
+++ b/tests/Aspire.Deployment.EndToEnd.Tests/TypeScriptAzureContainerAppJobDeploymentTests.cs
@@ -119,7 +119,11 @@ public sealed class TypeScriptAzureContainerAppJobDeploymentTests(ITestOutputHel
 
     private static void WriteContainerAppJobsAppHost(TemporaryWorkspace workspace)
     {
-        File.WriteAllText(Path.Combine(workspace.WorkspaceRoot.FullName, "apphost.ts"), """
+        // `aspire init --language typescript` creates apphost.mts (since PR #16984), not
+        // apphost.ts. Overwrite that file with the test's custom AppHost; otherwise
+        // `aspire deploy` runs against the empty default apphost.mts and no Azure
+        // resources get provisioned.
+        File.WriteAllText(Path.Combine(workspace.WorkspaceRoot.FullName, "apphost.mts"), """
             import { createBuilder } from './.aspire/modules/aspire.js';
 
             const builder = await createBuilder();


### PR DESCRIPTION
> ⚠️ **This PR was created automatically by a workflow analyzing Deployment E2E test failures on `main`.** It is intentionally opened as a draft so a human can review the fix before merging.

## Fix for `Aspire.Deployment.EndToEnd.Tests.TypeScriptAzureContainerAppJobDeploymentTests.DeployTypeScriptContainerAppJobsToAzureContainerApps`

Fixes #17428

### Problem

The test fails when its verification step looks up Azure Container App jobs:

```
WaitUntil("success prompt [9 OK] $ (fail-fast on error)") — FAILED after 5:00
```

The terminal recording shows `aspire deploy` completes in **97 ms** with
`4/4 steps succeeded` and zero actual resources provisioned, then:

```
Resource group: e2e-ts-aca-jobs-<runid>-1
Resource group not found
[ERR:1] $
```

### Root Cause

Since PR #16984 ("Use mts for TypeScript AppHosts"),
`aspire init --language typescript` creates `apphost.mts`, not `apphost.ts`.
The test was writing its custom AppHost content to `apphost.ts`, which is
ignored. `aspire deploy` ran against the empty default `apphost.mts`,
provisioned nothing, and the verification step failed because the resource
group was never created.

### Fix

Write the custom AppHost content to `apphost.mts`, overwriting the
init-generated empty file so it is actually deployed.

### Verification

CI on this PR will run the standard build. After CI is green, the
`/deployment-test` command will be triggered to re-run the affected
deployment E2E test against Azure and confirm the fix.
