### PR TITLE
Fix for Aspire.Deployment.EndToEnd.Tests.TypeScriptJavaScriptHostingDeploymentTests.DeployTypeScriptStaticWebsiteWithNodeApiToAzureContainerApps

### DIFF
--- a/tests/Aspire.Deployment.EndToEnd.Tests/AksAzureKubernetesEnvironmentCertManagerTypeScriptDeploymentTests.cs
+++ b/tests/Aspire.Deployment.EndToEnd.Tests/AksAzureKubernetesEnvironmentCertManagerTypeScriptDeploymentTests.cs
@@ -12,13 +12,13 @@ namespace Aspire.Deployment.EndToEnd.Tests;
 /// TypeScript-AppHost variant of the AKS cert-manager E2E test. Mirrors
 /// <see cref="AksAzureKubernetesEnvironmentCertManagerDeploymentTests"/> but uses the
 /// TypeScript Express/React starter (<c>aspire new</c> --&gt; <c>Starter App (Express/React, TypeScript AppHost)</c>)
-/// and patches <c>apphost.ts</c> to wire <c>addAzureKubernetesEnvironment</c> +
+/// and patches <c>apphost.mts</c> to wire <c>addAzureKubernetesEnvironment</c> +
 /// <c>addCertManager</c> + <c>addIssuer().withLetsEncryptProductionParam(acmeEmail).withHttp01Solver()</c>
 /// + <c>gateway.withGatewayTlsIssuer(letsEncrypt)</c> around the Express API.
 ///
 /// Proves that the cert-manager API surface generated for TypeScript via <c>[AspireExport]</c>
 /// works end-to-end against a real AKS cluster (this complements the polyglot type-check
-/// validation in <c>tests/PolyglotAppHosts/Aspire.Hosting.Kubernetes/TypeScript/apphost.ts</c>).
+/// validation in <c>tests/PolyglotAppHosts/Aspire.Hosting.Kubernetes/TypeScript/apphost.mts</c>).
 ///
 /// Uses Let's Encrypt <em>production</em> so the served cert chains to a publicly-trusted root
 /// (mirrors a realistic deployment). Production is rate-limited (50 certs / registered
@@ -117,7 +117,7 @@ public sealed class AksAzureKubernetesEnvironmentCertManagerTypeScriptDeployment
                 await auto.WaitForSuccessPromptAsync(counter, TimeSpan.FromSeconds(180));
             }
 
-            // Patch apphost.ts. The Express/React starter creates an Express API at ./api
+            // Patch apphost.mts. The Express/React starter creates an Express API at ./api
             // exposing an HTTP endpoint, plus a Vite frontend bundled in for publish. We
             // replace the trailing `await builder.build().run();` with the AKS + cert-manager
             // wiring that puts the API behind a Gateway with TLS issued by Let's Encrypt production.
@@ -129,9 +129,11 @@ public sealed class AksAzureKubernetesEnvironmentCertManagerTypeScriptDeployment
             //   addGateway / withLoadBalancer / withRoute / withGatewayTlsIssuer
             //   publishAsKubernetesService / addManifest
             var projectDir = Path.Combine(workspace.WorkspaceRoot.FullName, projectName);
-            var appHostFilePath = Path.Combine(projectDir, "apphost.ts");
+            // The TypeScript starter templates (including Express/React) emit apphost.mts
+            // since PR #16984. Reading apphost.ts here would fail with FileNotFoundException.
+            var appHostFilePath = Path.Combine(projectDir, "apphost.mts");
 
-            output.WriteLine($"Step 6: Modifying apphost.ts at: {appHostFilePath}");
+            output.WriteLine($"Step 6: Modifying apphost.mts at: {appHostFilePath}");
 
             var content = File.ReadAllText(appHostFilePath);
 
@@ -190,7 +192,7 @@ await builder.build().run();
 
             content = content.Replace(buildRunPattern, replacement);
             File.WriteAllText(appHostFilePath, content);
-            output.WriteLine("Modified apphost.ts with addCertManager + addIssuer + withGatewayTlsIssuer");
+            output.WriteLine("Modified apphost.mts with addCertManager + addIssuer + withGatewayTlsIssuer");
 
             output.WriteLine("Step 7: Setting deployment environment variables...");
             await auto.TypeAsync(

--- a/tests/Aspire.Deployment.EndToEnd.Tests/TypeScriptAzureContainerAppJobDeploymentTests.cs
+++ b/tests/Aspire.Deployment.EndToEnd.Tests/TypeScriptAzureContainerAppJobDeploymentTests.cs
@@ -119,7 +119,11 @@ public sealed class TypeScriptAzureContainerAppJobDeploymentTests(ITestOutputHel
 
     private static void WriteContainerAppJobsAppHost(TemporaryWorkspace workspace)
     {
-        File.WriteAllText(Path.Combine(workspace.WorkspaceRoot.FullName, "apphost.ts"), """
+        // `aspire init --language typescript` creates apphost.mts (since PR #16984), not
+        // apphost.ts. Overwrite that file with the test's custom AppHost; otherwise
+        // `aspire deploy` runs against the empty default apphost.mts and no Azure
+        // resources get provisioned.
+        File.WriteAllText(Path.Combine(workspace.WorkspaceRoot.FullName, "apphost.mts"), """
             import { createBuilder } from './.aspire/modules/aspire.js';
 
             const builder = await createBuilder();

--- a/tests/Aspire.Deployment.EndToEnd.Tests/TypeScriptAzureContainerAppJobDeploymentTests.cs
+++ b/tests/Aspire.Deployment.EndToEnd.Tests/TypeScriptAzureContainerAppJobDeploymentTests.cs
@@ -122,9 +122,10 @@ public sealed class TypeScriptAzureContainerAppJobDeploymentTests(ITestOutputHel
         // `aspire init --language typescript` creates apphost.mts (since PR #16984), not
         // apphost.ts. Overwrite that file with the test's custom AppHost; otherwise
         // `aspire deploy` runs against the empty default apphost.mts and no Azure
-        // resources get provisioned.
+        // resources get provisioned. The mts variant imports the generated SDK as
+        // `aspire.mjs` (not `aspire.js`, which is the legacy apphost.ts shape).
         File.WriteAllText(Path.Combine(workspace.WorkspaceRoot.FullName, "apphost.mts"), """
-            import { createBuilder } from './.aspire/modules/aspire.js';
+            import { createBuilder } from './.aspire/modules/aspire.mjs';
 
             const builder = await createBuilder();
 

--- a/tests/Aspire.Deployment.EndToEnd.Tests/TypeScriptJavaScriptHostingDeploymentTests.cs
+++ b/tests/Aspire.Deployment.EndToEnd.Tests/TypeScriptJavaScriptHostingDeploymentTests.cs
@@ -161,7 +161,11 @@ public sealed class TypeScriptJavaScriptHostingDeploymentTests(ITestOutputHelper
             </html>
             """);
 
-        File.WriteAllText(Path.Combine(workspace.WorkspaceRoot.FullName, "apphost.ts"), """
+        // `aspire init --language typescript` creates apphost.mts (since PR #16984), not
+        // apphost.ts. Overwrite that file with the test's custom AppHost; otherwise
+        // `aspire deploy` runs against the empty default apphost.mts and no Azure
+        // resources get provisioned.
+        File.WriteAllText(Path.Combine(workspace.WorkspaceRoot.FullName, "apphost.mts"), """
             import { createBuilder } from './.aspire/modules/aspire.js';
 
             const builder = await createBuilder();

--- a/tests/Aspire.Deployment.EndToEnd.Tests/TypeScriptJavaScriptHostingDeploymentTests.cs
+++ b/tests/Aspire.Deployment.EndToEnd.Tests/TypeScriptJavaScriptHostingDeploymentTests.cs
@@ -164,9 +164,10 @@ public sealed class TypeScriptJavaScriptHostingDeploymentTests(ITestOutputHelper
         // `aspire init --language typescript` creates apphost.mts (since PR #16984), not
         // apphost.ts. Overwrite that file with the test's custom AppHost; otherwise
         // `aspire deploy` runs against the empty default apphost.mts and no Azure
-        // resources get provisioned.
+        // resources get provisioned. The mts variant imports the generated SDK as
+        // `aspire.mjs` (not `aspire.js`, which is the legacy apphost.ts shape).
         File.WriteAllText(Path.Combine(workspace.WorkspaceRoot.FullName, "apphost.mts"), """
-            import { createBuilder } from './.aspire/modules/aspire.js';
+            import { createBuilder } from './.aspire/modules/aspire.mjs';
 
             const builder = await createBuilder();
 


### PR DESCRIPTION
> ⚠️ **This PR was created automatically by a workflow analyzing Deployment E2E test failures on `main`.** It is intentionally opened as a draft so a human can review the fix before merging.

## Fix for `Aspire.Deployment.EndToEnd.Tests.TypeScriptJavaScriptHostingDeploymentTests.DeployTypeScriptStaticWebsiteWithNodeApiToAzureContainerApps`

Fixes #17429

### Problem

The test fails with:

```
System.InvalidOperationException : Command failed with non-zero exit code
    (detected ERR prompt at sequence 10).
```

The terminal recording shows `aspire deploy` completes in **97 ms** with
`4/4 steps succeeded` and zero actual resources provisioned, then:

```
ERROR: (ResourceGroupNotFound) Resource group 'e2e-ts-js-hosting-<runid>-1' could not be found.
[ERR:1] $
```

### Root Cause

Since PR #16984 ("Use mts for TypeScript AppHosts"),
`aspire init --language typescript` creates `apphost.mts`, not `apphost.ts`.
The test was writing its custom AppHost content to `apphost.ts`, which is
ignored. `aspire deploy` ran against the empty default `apphost.mts`,
provisioned nothing, and the verification step failed because the resource
group was never created.

### Fix

Write the custom AppHost content to `apphost.mts`, overwriting the
init-generated empty file so it is actually deployed.

### Verification

CI on this PR will run the standard build. After CI is green, the
`/deployment-test` command will be triggered to re-run the affected
deployment E2E test against Azure and confirm the fix.
