### PR TITLE
Fix banner crash when stdout is redirected

### DIFF
--- a/src/Aspire.Cli/Program.cs
+++ b/src/Aspire.Cli/Program.cs
@@ -672,8 +672,10 @@ public class Program
 
         var hostEnvironment = serviceProvider.GetRequiredService<ICliHostEnvironment>();
 
-        // Show banner if explicitly requested OR on first run (unless suppressed by noLogo or non-interactive output)
-        if (showBanner || (isFirstRun && !noLogo && hostEnvironment.SupportsInteractiveOutput))
+        // Show banner if explicitly requested OR on first run (unless suppressed by noLogo or non-interactive output).
+        // Always require interactive output support — the animated banner uses Spectre.Console's Live display
+        // which manipulates the cursor and fails when console handles are invalid (e.g., stdout is redirected).
+        if ((showBanner || (isFirstRun && !noLogo)) && hostEnvironment.SupportsInteractiveOutput)
         {
             var bannerService = serviceProvider.GetRequiredService<IBannerService>();
             await bannerService.DisplayBannerAsync(cancellationToken);

--- a/src/Aspire.Cli/Program.cs
+++ b/src/Aspire.Cli/Program.cs
@@ -672,7 +672,7 @@ public class Program
 
         var hostEnvironment = serviceProvider.GetRequiredService<ICliHostEnvironment>();
 
-        // Show banner if explicitly requested OR on first run (unless suppressed by noLogo or non-interactive output).
+        // Show banner if explicitly requested OR on first run (unless suppressed by noLogo).
         // Always require interactive output support — the animated banner uses Spectre.Console's Live display
         // which manipulates the cursor and fails when console handles are invalid (e.g., stdout is redirected).
         if ((showBanner || (isFirstRun && !noLogo)) && hostEnvironment.SupportsInteractiveOutput)

--- a/tests/Aspire.Cli.Tests/Commands/RootCommandTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/RootCommandTests.cs
@@ -246,6 +246,7 @@ public class RootCommandTests(ITestOutputHelper outputHelper)
             options.ErrorTextWriter = errorWriter;
             options.FirstTimeUseNoticeSentinelFactory = _ => sentinel;
             options.BannerServiceFactory = _ => bannerService;
+            options.CliHostEnvironmentFactory = _ => TestHelpers.CreateInteractiveHostEnvironment();
         });
         using var provider = services.BuildServiceProvider();
 
@@ -266,6 +267,7 @@ public class RootCommandTests(ITestOutputHelper outputHelper)
         var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper, options =>
         {
             options.BannerServiceFactory = _ => bannerService;
+            options.CliHostEnvironmentFactory = _ => TestHelpers.CreateInteractiveHostEnvironment();
         });
         using var provider = services.BuildServiceProvider();
 
@@ -300,6 +302,7 @@ public class RootCommandTests(ITestOutputHelper outputHelper)
             options.ErrorTextWriter = errorWriter;
             options.FirstTimeUseNoticeSentinelFactory = _ => sentinel;
             options.BannerServiceFactory = _ => bannerService;
+            options.CliHostEnvironmentFactory = _ => TestHelpers.CreateInteractiveHostEnvironment();
         });
         using var provider = services.BuildServiceProvider();
 
@@ -432,8 +435,11 @@ public class RootCommandTests(ITestOutputHelper outputHelper)
     }
 
     [Fact]
-    public async Task Banner_DisplayedWithExplicitBannerFlag_InNonInteractiveEnvironment()
+    public async Task Banner_NotDisplayedWithExplicitBannerFlag_InNonInteractiveEnvironment()
     {
+        // Even when --banner is explicitly passed, the banner should NOT display in a
+        // non-interactive environment because Spectre.Console's Live display requires
+        // valid console handles (e.g., stdout must not be redirected).
         using var workspace = TemporaryWorkspace.Create(outputHelper);
         var sentinel = new TestFirstTimeUseNoticeSentinel { SentinelExists = true }; // Not first run
         var bannerService = new TestBannerService();
@@ -448,7 +454,7 @@ public class RootCommandTests(ITestOutputHelper outputHelper)
 
         await Program.DisplayFirstTimeUseNoticeIfNeededAsync(provider, [CommonOptionNames.Banner]);
 
-        Assert.True(bannerService.WasBannerDisplayed);
+        Assert.False(bannerService.WasBannerDisplayed);
     }
 
     [Fact]


### PR DESCRIPTION
## Description

When `--banner` was explicitly passed and stdout was redirected (e.g., `aspire --version --banner > test.txt`), the CLI crashed with `System.IO.IOException: The handle is invalid` because Spectre.Console's `Live` display tried to set `Console.CursorVisible` on an invalid handle.

The root cause was that the `showBanner` flag bypassed the `SupportsInteractiveOutput` check in the OR condition. The fix ensures `SupportsInteractiveOutput` is always required for the animated banner, even when explicitly requested via `--banner`.

Fixes https://github.com/microsoft/aspire/issues/17410

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
  - [x] No