### PR TITLE
Handle partial Linux certificate trust in CI

### DIFF
--- a/src/Aspire.Cli/Certificates/CertificateService.cs
+++ b/src/Aspire.Cli/Certificates/CertificateService.cs
@@ -47,15 +47,18 @@ internal sealed class CertificateService(
     ICertificateToolRunner certificateToolRunner,
     IInteractionService interactionService,
     AspireCliTelemetry telemetry,
-    ICliHostEnvironment hostEnvironment) : ICertificateService
+    ICliHostEnvironment hostEnvironment,
+    Func<bool>? isLinux = null) : ICertificateService
 {
     private const string SslCertDirEnvVar = "SSL_CERT_DIR";
+    private readonly Func<bool> _isLinux = isLinux ?? OperatingSystem.IsLinux;
 
     public async Task<EnsureCertificatesTrustedResult> EnsureCertificatesTrustedAsync(CancellationToken cancellationToken)
     {
         using var activity = telemetry.StartDiagnosticActivity(kind: ActivityKind.Client);
 
         var environmentVariables = new Dictionary<string, string>();
+        var isLinux = _isLinux();
 
         // In non-interactive environments on macOS and Windows we can't successfully
         // prompt for trust (macOS Keychain password, Windows trust dialog) and we also
@@ -63,7 +66,7 @@ internal sealed class CertificateService(
         // Skip the trust attempt but still check the current state so we can warn when
         // the environment does not already have a trusted certificate. Linux trust is
         // non-interactive so it's safe to run the full flow there.
-        var canPerformTrust = hostEnvironment.SupportsInteractiveInput || OperatingSystem.IsLinux();
+        var canPerformTrust = hostEnvironment.SupportsInteractiveInput || isLinux;
 
         if (!canPerformTrust)
         {
@@ -77,7 +80,7 @@ internal sealed class CertificateService(
                 interactionService.DisplayMessage(KnownEmojis.Warning, ErrorStrings.CertificatesNotTrustedNonInteractive);
             }
 
-            if (preCheck.IsPartiallyTrusted && OperatingSystem.IsLinux())
+            if (preCheck.IsPartiallyTrusted && isLinux)
             {
                 ConfigureSslCertDir(environmentVariables);
             }
@@ -107,15 +110,20 @@ internal sealed class CertificateService(
         }
 
         var postTrustCheck = certificateToolRunner.CheckHttpCertificate();
-        if (postTrustCheck.IsPartiallyTrusted && OperatingSystem.IsLinux())
+        if (postTrustCheck.IsPartiallyTrusted && isLinux)
         {
             ConfigureSslCertDir(environmentVariables);
         }
 
+        var partialTrustAccepted = !hostEnvironment.SupportsInteractiveInput
+            && isLinux
+            && trustResultCode == EnsureCertificateResult.PartiallyFailedToTrustTheCertificate
+            && postTrustCheck.IsPartiallyTrusted;
+
         return new EnsureCertificatesTrustedResult
         {
             EnvironmentVariables = environmentVariables,
-            Success = CertificateHelpers.IsSuccessfulTrustResult(trustResultCode),
+            Success = CertificateHelpers.IsSuccessfulTrustResult(trustResultCode) || partialTrustAccepted,
             WasCancelled = trustResultCode == EnsureCertificateResult.UserCancelledTrustStep,
             ResultCode = trustResultCode
         };

--- a/src/Aspire.Cli/Commands/CertificatesTrustCommand.cs
+++ b/src/Aspire.Cli/Commands/CertificatesTrustCommand.cs
@@ -9,6 +9,7 @@ using Aspire.Cli.Interaction;
 using Aspire.Cli.Resources;
 using Aspire.Cli.Telemetry;
 using Aspire.Cli.Utils;
+using Microsoft.AspNetCore.Certificates.Generation;
 
 namespace Aspire.Cli.Commands;
 
@@ -33,7 +34,15 @@ internal sealed class CertificatesTrustCommand : BaseCommand
 
         if (result.Success)
         {
-            InteractionService.DisplaySuccess(CertificatesCommandStrings.TrustSuccess);
+            if (result.ResultCode == EnsureCertificateResult.PartiallyFailedToTrustTheCertificate)
+            {
+                InteractionService.DisplayMessage(KnownEmojis.Warning, CertificatesCommandStrings.TrustPartialSuccess);
+            }
+            else
+            {
+                InteractionService.DisplaySuccess(CertificatesCommandStrings.TrustSuccess);
+            }
+
             return CommandResult.Success();
         }
 

--- a/src/Aspire.Cli/Resources/CertificatesCommandStrings.Designer.cs
+++ b/src/Aspire.Cli/Resources/CertificatesCommandStrings.Designer.cs
@@ -156,6 +156,15 @@ namespace Aspire.Cli.Resources {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to HTTPS development certificate was partially trusted. Continuing because partial trust is usable for CLI HTTPS diagnostics on Linux; browser trust may still be incomplete..
+        /// </summary>
+        internal static string TrustPartialSuccess {
+            get {
+                return ResourceManager.GetString("TrustPartialSuccess", resourceCulture);
+            }
+        }
+
+        /// <summary>
         ///   Looks up a localized string similar to Trusting development certificate (may require elevated permissions)....
         /// </summary>
         internal static string TrustProgress {

--- a/src/Aspire.Cli/Resources/CertificatesCommandStrings.resx
+++ b/src/Aspire.Cli/Resources/CertificatesCommandStrings.resx
@@ -101,4 +101,7 @@
     <value>Certificate trust operation returned: {0}</value>
     <comment>{0} is the EnsureCertificateResult value</comment>
   </data>
+  <data name="TrustPartialSuccess" xml:space="preserve">
+    <value>HTTPS development certificate was partially trusted. Continuing because partial trust is usable for CLI HTTPS diagnostics on Linux; browser trust may still be incomplete.</value>
+  </data>
 </root>

--- a/src/Aspire.Cli/Resources/xlf/CertificatesCommandStrings.cs.xlf
+++ b/src/Aspire.Cli/Resources/xlf/CertificatesCommandStrings.cs.xlf
@@ -57,6 +57,11 @@
         <target state="new">Certificate trust operation returned: {0}</target>
         <note>{0} is the EnsureCertificateResult value</note>
       </trans-unit>
+      <trans-unit id="TrustPartialSuccess">
+        <source>HTTPS development certificate was partially trusted. Continuing because partial trust is usable for CLI HTTPS diagnostics on Linux; browser trust may still be incomplete.</source>
+        <target state="new">HTTPS development certificate was partially trusted. Continuing because partial trust is usable for CLI HTTPS diagnostics on Linux; browser trust may still be incomplete.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="TrustProgress">
         <source>Trusting development certificate (may require elevated permissions)...</source>
         <target state="new">Trusting development certificate (may require elevated permissions)...</target>

--- a/src/Aspire.Cli/Resources/xlf/CertificatesCommandStrings.de.xlf
+++ b/src/Aspire.Cli/Resources/xlf/CertificatesCommandStrings.de.xlf
@@ -57,6 +57,11 @@
         <target state="new">Certificate trust operation returned: {0}</target>
         <note>{0} is the EnsureCertificateResult value</note>
       </trans-unit>
+      <trans-unit id="TrustPartialSuccess">
+        <source>HTTPS development certificate was partially trusted. Continuing because partial trust is usable for CLI HTTPS diagnostics on Linux; browser trust may still be incomplete.</source>
+        <target state="new">HTTPS development certificate was partially trusted. Continuing because partial trust is usable for CLI HTTPS diagnostics on Linux; browser trust may still be incomplete.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="TrustProgress">
         <source>Trusting development certificate (may require elevated permissions)...</source>
         <target state="new">Trusting development certificate (may require elevated permissions)...</target>

--- a/src/Aspire.Cli/Resources/xlf/CertificatesCommandStrings.es.xlf
+++ b/src/Aspire.Cli/Resources/xlf/CertificatesCommandStrings.es.xlf
@@ -57,6 +57,11 @@
         <target state="new">Certificate trust operation returned: {0}</target>
         <note>{0} is the EnsureCertificateResult value</note>
       </trans-unit>
+      <trans-unit id="TrustPartialSuccess">
+        <source>HTTPS development certificate was partially trusted. Continuing because partial trust is usable for CLI HTTPS diagnostics on Linux; browser trust may still be incomplete.</source>
+        <target state="new">HTTPS development certificate was partially trusted. Continuing because partial trust is usable for CLI HTTPS diagnostics on Linux; browser trust may still be incomplete.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="TrustProgress">
         <source>Trusting development certificate (may require elevated permissions)...</source>
         <target state="new">Trusting development certificate (may require elevated permissions)...</target>

--- a/src/Aspire.Cli/Resources/xlf/CertificatesCommandStrings.fr.xlf
+++ b/src/Aspire.Cli/Resources/xlf/CertificatesCommandStrings.fr.xlf
@@ -57,6 +57,11 @@
         <target state="new">Certificate trust operation returned: {0}</target>
         <note>{0} is the EnsureCertificateResult value</note>
       </trans-unit>
+      <trans-unit id="TrustPartialSuccess">
+        <source>HTTPS development certificate was partially trusted. Continuing because partial trust is usable for CLI HTTPS diagnostics on Linux; browser trust may still be incomplete.</source>
+        <target state="new">HTTPS development certificate was partially trusted. Continuing because partial trust is usable for CLI HTTPS diagnostics on Linux; browser trust may still be incomplete.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="TrustProgress">
         <source>Trusting development certificate (may require elevated permissions)...</source>
         <target state="new">Trusting development certificate (may require elevated permissions)...</target>

--- a/src/Aspire.Cli/Resources/xlf/CertificatesCommandStrings.it.xlf
+++ b/src/Aspire.Cli/Resources/xlf/CertificatesCommandStrings.it.xlf
@@ -57,6 +57,11 @@
         <target state="new">Certificate trust operation returned: {0}</target>
         <note>{0} is the EnsureCertificateResult value</note>
       </trans-unit>
+      <trans-unit id="TrustPartialSuccess">
+        <source>HTTPS development certificate was partially trusted. Continuing because partial trust is usable for CLI HTTPS diagnostics on Linux; browser trust may still be incomplete.</source>
+        <target state="new">HTTPS development certificate was partially trusted. Continuing because partial trust is usable for CLI HTTPS diagnostics on Linux; browser trust may still be incomplete.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="TrustProgress">
         <source>Trusting development certificate (may require elevated permissions)...</source>
         <target state="new">Trusting development certificate (may require elevated permissions)...</target>

--- a/src/Aspire.Cli/Resources/xlf/CertificatesCommandStrings.ja.xlf
+++ b/src/Aspire.Cli/Resources/xlf/CertificatesCommandStrings.ja.xlf
@@ -57,6 +57,11 @@
         <target state="new">Certificate trust operation returned: {0}</target>
         <note>{0} is the EnsureCertificateResult value</note>
       </trans-unit>
+      <trans-unit id="TrustPartialSuccess">
+        <source>HTTPS development certificate was partially trusted. Continuing because partial trust is usable for CLI HTTPS diagnostics on Linux; browser trust may still be incomplete.</source>
+        <target state="new">HTTPS development certificate was partially trusted. Continuing because partial trust is usable for CLI HTTPS diagnostics on Linux; browser trust may still be incomplete.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="TrustProgress">
         <source>Trusting development certificate (may require elevated permissions)...</source>
         <target state="new">Trusting development certificate (may require elevated permissions)...</target>

--- a/src/Aspire.Cli/Resources/xlf/CertificatesCommandStrings.ko.xlf
+++ b/src/Aspire.Cli/Resources/xlf/CertificatesCommandStrings.ko.xlf
@@ -57,6 +57,11 @@
         <target state="new">Certificate trust operation returned: {0}</target>
         <note>{0} is the EnsureCertificateResult value</note>
       </trans-unit>
+      <trans-unit id="TrustPartialSuccess">
+        <source>HTTPS development certificate was partially trusted. Continuing because partial trust is usable for CLI HTTPS diagnostics on Linux; browser trust may still be incomplete.</source>
+        <target state="new">HTTPS development certificate was partially trusted. Continuing because partial trust is usable for CLI HTTPS diagnostics on Linux; browser trust may still be incomplete.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="TrustProgress">
         <source>Trusting development certificate (may require elevated permissions)...</source>
         <target state="new">Trusting development certificate (may require elevated permissions)...</target>

--- a/src/Aspire.Cli/Resources/xlf/CertificatesCommandStrings.pl.xlf
+++ b/src/Aspire.Cli/Resources/xlf/CertificatesCommandStrings.pl.xlf
@@ -57,6 +57,11 @@
         <target state="new">Certificate trust operation returned: {0}</target>
         <note>{0} is the EnsureCertificateResult value</note>
       </trans-unit>
+      <trans-unit id="TrustPartialSuccess">
+        <source>HTTPS development certificate was partially trusted. Continuing because partial trust is usable for CLI HTTPS diagnostics on Linux; browser trust may still be incomplete.</source>
+        <target state="new">HTTPS development certificate was partially trusted. Continuing because partial trust is usable for CLI HTTPS diagnostics on Linux; browser trust may still be incomplete.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="TrustProgress">
         <source>Trusting development certificate (may require elevated permissions)...</source>
         <target state="new">Trusting development certificate (may require elevated permissions)...</target>

--- a/src/Aspire.Cli/Resources/xlf/CertificatesCommandStrings.pt-BR.xlf
+++ b/src/Aspire.Cli/Resources/xlf/CertificatesCommandStrings.pt-BR.xlf
@@ -57,6 +57,11 @@
         <target state="new">Certificate trust operation returned: {0}</target>
         <note>{0} is the EnsureCertificateResult value</note>
       </trans-unit>
+      <trans-unit id="TrustPartialSuccess">
+        <source>HTTPS development certificate was partially trusted. Continuing because partial trust is usable for CLI HTTPS diagnostics on Linux; browser trust may still be incomplete.</source>
+        <target state="new">HTTPS development certificate was partially trusted. Continuing because partial trust is usable for CLI HTTPS diagnostics on Linux; browser trust may still be incomplete.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="TrustProgress">
         <source>Trusting development certificate (may require elevated permissions)...</source>
         <target state="new">Trusting development certificate (may require elevated permissions)...</target>

--- a/src/Aspire.Cli/Resources/xlf/CertificatesCommandStrings.ru.xlf
+++ b/src/Aspire.Cli/Resources/xlf/CertificatesCommandStrings.ru.xlf
@@ -57,6 +57,11 @@
         <target state="new">Certificate trust operation returned: {0}</target>
         <note>{0} is the EnsureCertificateResult value</note>
       </trans-unit>
+      <trans-unit id="TrustPartialSuccess">
+        <source>HTTPS development certificate was partially trusted. Continuing because partial trust is usable for CLI HTTPS diagnostics on Linux; browser trust may still be incomplete.</source>
+        <target state="new">HTTPS development certificate was partially trusted. Continuing because partial trust is usable for CLI HTTPS diagnostics on Linux; browser trust may still be incomplete.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="TrustProgress">
         <source>Trusting development certificate (may require elevated permissions)...</source>
         <target state="new">Trusting development certificate (may require elevated permissions)...</target>

--- a/src/Aspire.Cli/Resources/xlf/CertificatesCommandStrings.tr.xlf
+++ b/src/Aspire.Cli/Resources/xlf/CertificatesCommandStrings.tr.xlf
@@ -57,6 +57,11 @@
         <target state="new">Certificate trust operation returned: {0}</target>
         <note>{0} is the EnsureCertificateResult value</note>
       </trans-unit>
+      <trans-unit id="TrustPartialSuccess">
+        <source>HTTPS development certificate was partially trusted. Continuing because partial trust is usable for CLI HTTPS diagnostics on Linux; browser trust may still be incomplete.</source>
+        <target state="new">HTTPS development certificate was partially trusted. Continuing because partial trust is usable for CLI HTTPS diagnostics on Linux; browser trust may still be incomplete.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="TrustProgress">
         <source>Trusting development certificate (may require elevated permissions)...</source>
         <target state="new">Trusting development certificate (may require elevated permissions)...</target>

--- a/src/Aspire.Cli/Resources/xlf/CertificatesCommandStrings.zh-Hans.xlf
+++ b/src/Aspire.Cli/Resources/xlf/CertificatesCommandStrings.zh-Hans.xlf
@@ -57,6 +57,11 @@
         <target state="new">Certificate trust operation returned: {0}</target>
         <note>{0} is the EnsureCertificateResult value</note>
       </trans-unit>
+      <trans-unit id="TrustPartialSuccess">
+        <source>HTTPS development certificate was partially trusted. Continuing because partial trust is usable for CLI HTTPS diagnostics on Linux; browser trust may still be incomplete.</source>
+        <target state="new">HTTPS development certificate was partially trusted. Continuing because partial trust is usable for CLI HTTPS diagnostics on Linux; browser trust may still be incomplete.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="TrustProgress">
         <source>Trusting development certificate (may require elevated permissions)...</source>
         <target state="new">Trusting development certificate (may require elevated permissions)...</target>

--- a/src/Aspire.Cli/Resources/xlf/CertificatesCommandStrings.zh-Hant.xlf
+++ b/src/Aspire.Cli/Resources/xlf/CertificatesCommandStrings.zh-Hant.xlf
@@ -57,6 +57,11 @@
         <target state="new">Certificate trust operation returned: {0}</target>
         <note>{0} is the EnsureCertificateResult value</note>
       </trans-unit>
+      <trans-unit id="TrustPartialSuccess">
+        <source>HTTPS development certificate was partially trusted. Continuing because partial trust is usable for CLI HTTPS diagnostics on Linux; browser trust may still be incomplete.</source>
+        <target state="new">HTTPS development certificate was partially trusted. Continuing because partial trust is usable for CLI HTTPS diagnostics on Linux; browser trust may still be incomplete.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="TrustProgress">
         <source>Trusting development certificate (may require elevated permissions)...</source>
         <target state="new">Trusting development certificate (may require elevated permissions)...</target>

--- a/tests/Aspire.Cli.Tests/Certificates/CertificateServiceTests.cs
+++ b/tests/Aspire.Cli.Tests/Certificates/CertificateServiceTests.cs
@@ -94,8 +94,7 @@ public class CertificateServiceTests(ITestOutputHelper outputHelper)
         Assert.False(result.Success);
         Assert.False(result.WasCancelled);
         Assert.Equal(EnsureCertificateResult.PartiallyFailedToTrustTheCertificate, result.ResultCode);
-        Assert.True(result.EnvironmentVariables.ContainsKey("SSL_CERT_DIR"));
-        Assert.Contains(".aspnet/dev-certs/trust", result.EnvironmentVariables["SSL_CERT_DIR"]);
+        AssertSslCertDirContainsDevCertsTrustPath(result.EnvironmentVariables);
     }
 
     [Fact]
@@ -122,8 +121,7 @@ public class CertificateServiceTests(ITestOutputHelper outputHelper)
         Assert.True(result.Success);
         Assert.False(result.WasCancelled);
         Assert.Equal(EnsureCertificateResult.PartiallyFailedToTrustTheCertificate, result.ResultCode);
-        Assert.True(result.EnvironmentVariables.ContainsKey("SSL_CERT_DIR"));
-        Assert.Contains(".aspnet/dev-certs/trust", result.EnvironmentVariables["SSL_CERT_DIR"]);
+        AssertSslCertDirContainsDevCertsTrustPath(result.EnvironmentVariables);
     }
 
     [Fact]
@@ -386,5 +384,11 @@ public class CertificateServiceTests(ITestOutputHelper outputHelper)
                 }
             ]
         };
+    }
+
+    private static void AssertSslCertDirContainsDevCertsTrustPath(IDictionary<string, string> environmentVariables)
+    {
+        Assert.True(environmentVariables.ContainsKey("SSL_CERT_DIR"));
+        Assert.Contains(CertificateHelpers.GetDevCertsTrustPath(), environmentVariables["SSL_CERT_DIR"].Split(Path.PathSeparator));
     }
 }

--- a/tests/Aspire.Cli.Tests/Certificates/CertificateServiceTests.cs
+++ b/tests/Aspire.Cli.Tests/Certificates/CertificateServiceTests.cs
@@ -3,6 +3,7 @@
 
 using Aspire.Cli.Certificates;
 using Aspire.Cli.Interaction;
+using Aspire.Cli.Telemetry;
 using Aspire.Cli.Tests.TestServices;
 using Aspire.Cli.Tests.Utils;
 using Aspire.Cli.Utils;
@@ -70,13 +71,8 @@ public class CertificateServiceTests(ITestOutputHelper outputHelper)
     }
 
     [Fact]
-    public async Task EnsureCertificatesTrustedAsync_WithPartiallyTrustedCert_RunsTrustAndSetsSslCertDirOnLinux()
+    public async Task EnsureCertificatesTrustedAsync_WithPartiallyTrustedCert_ReturnsFailureForInteractiveLinux()
     {
-        if (!OperatingSystem.IsLinux())
-        {
-            return;
-        }
-
         using var workspace = TemporaryWorkspace.Create(outputHelper);
         var trustCalled = false;
 
@@ -88,7 +84,7 @@ public class CertificateServiceTests(ITestOutputHelper outputHelper)
                 return EnsureCertificateResult.PartiallyFailedToTrustTheCertificate;
             },
             CheckHttpCertificateCallback = () => CreateTrustResult(CertificateManager.TrustLevel.Partial)
-        });
+        }, nonInteractive: false, isLinux: () => true);
 
         var cs = sp.GetRequiredService<ICertificateService>();
 
@@ -96,6 +92,34 @@ public class CertificateServiceTests(ITestOutputHelper outputHelper)
 
         Assert.True(trustCalled);
         Assert.False(result.Success);
+        Assert.False(result.WasCancelled);
+        Assert.Equal(EnsureCertificateResult.PartiallyFailedToTrustTheCertificate, result.ResultCode);
+        Assert.True(result.EnvironmentVariables.ContainsKey("SSL_CERT_DIR"));
+        Assert.Contains(".aspnet/dev-certs/trust", result.EnvironmentVariables["SSL_CERT_DIR"]);
+    }
+
+    [Fact]
+    public async Task EnsureCertificatesTrustedAsync_WithPartiallyTrustedCert_ReturnsSuccessForNonInteractiveLinux()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        var trustCalled = false;
+
+        using var sp = CreateServiceProvider(workspace, new TestCertificateToolRunner
+        {
+            TrustHttpCertificateCallback = () =>
+            {
+                trustCalled = true;
+                return EnsureCertificateResult.PartiallyFailedToTrustTheCertificate;
+            },
+            CheckHttpCertificateCallback = () => CreateTrustResult(CertificateManager.TrustLevel.Partial)
+        }, nonInteractive: true, isLinux: () => true);
+
+        var cs = sp.GetRequiredService<ICertificateService>();
+
+        var result = await cs.EnsureCertificatesTrustedAsync(TestContext.Current.CancellationToken).DefaultTimeout();
+
+        Assert.True(trustCalled);
+        Assert.True(result.Success);
         Assert.False(result.WasCancelled);
         Assert.Equal(EnsureCertificateResult.PartiallyFailedToTrustTheCertificate, result.ResultCode);
         Assert.True(result.EnvironmentVariables.ContainsKey("SSL_CERT_DIR"));
@@ -273,8 +297,6 @@ public class CertificateServiceTests(ITestOutputHelper outputHelper)
     [Fact]
     public async Task EnsureCertificatesTrustedAsync_NonInteractive_ProceedsOnLinux()
     {
-        Assert.SkipUnless(OperatingSystem.IsLinux(), "Linux-only: non-interactive trust is supported on Linux.");
-
         using var workspace = TemporaryWorkspace.Create(outputHelper);
         var trustCalled = false;
 
@@ -296,6 +318,13 @@ public class CertificateServiceTests(ITestOutputHelper outputHelper)
                 var configuration = sp.GetRequiredService<IConfiguration>();
                 return new CliHostEnvironment(configuration, nonInteractive: true);
             };
+            options.CertificateServiceFactory = sp =>
+            {
+                var interactiveService = sp.GetRequiredService<IInteractionService>();
+                var telemetry = sp.GetRequiredService<AspireCliTelemetry>();
+                var hostEnvironment = sp.GetRequiredService<ICliHostEnvironment>();
+                return new CertificateService(toolRunner, interactiveService, telemetry, hostEnvironment, isLinux: () => true);
+            };
         });
 
         using var sp = services.BuildServiceProvider();
@@ -307,7 +336,7 @@ public class CertificateServiceTests(ITestOutputHelper outputHelper)
         Assert.True(result.Success);
     }
 
-    private ServiceProvider CreateServiceProvider(TemporaryWorkspace workspace, TestCertificateToolRunner toolRunner)
+    private ServiceProvider CreateServiceProvider(TemporaryWorkspace workspace, TestCertificateToolRunner toolRunner, bool nonInteractive = false, Func<bool>? isLinux = null)
     {
         var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper, options =>
         {
@@ -315,7 +344,14 @@ public class CertificateServiceTests(ITestOutputHelper outputHelper)
             options.CliHostEnvironmentFactory = sp =>
             {
                 var configuration = sp.GetRequiredService<IConfiguration>();
-                return new CliHostEnvironment(configuration, nonInteractive: false);
+                return new CliHostEnvironment(configuration, nonInteractive);
+            };
+            options.CertificateServiceFactory = sp =>
+            {
+                var interactiveService = sp.GetRequiredService<IInteractionService>();
+                var telemetry = sp.GetRequiredService<AspireCliTelemetry>();
+                var hostEnvironment = sp.GetRequiredService<ICliHostEnvironment>();
+                return new CertificateService(toolRunner, interactiveService, telemetry, hostEnvironment, isLinux);
             };
         });
 

--- a/tests/Aspire.Cli.Tests/Commands/CertificatesCommandTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/CertificatesCommandTests.cs
@@ -1,8 +1,14 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using Aspire.Cli.Certificates;
+using Aspire.Cli.Telemetry;
+using Aspire.Cli.Tests.TestServices;
 using Aspire.Cli.Tests.Utils;
+using Aspire.Cli.Utils;
+using Microsoft.AspNetCore.Certificates.Generation;
 using Microsoft.AspNetCore.InternalTesting;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 
 namespace Aspire.Cli.Tests.Commands;
@@ -52,5 +58,59 @@ public class CertificatesCommandTests(ITestOutputHelper outputHelper)
         var exitCode = await result.InvokeAsync().DefaultTimeout();
 
         Assert.Equal(CliExitCodes.Success, exitCode);
+    }
+
+    [Fact]
+    public async Task CertificatesCommand_TrustSubcommand_ReturnsSuccessForNonInteractiveLinuxPartialTrust()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        var interactionService = new TestInteractionService();
+        var toolRunner = new TestCertificateToolRunner
+        {
+            TrustHttpCertificateCallback = () => EnsureCertificateResult.PartiallyFailedToTrustTheCertificate,
+            CheckHttpCertificateCallback = () => new CertificateTrustResult
+            {
+                HasCertificates = true,
+                TrustLevel = CertificateManager.TrustLevel.Partial,
+                Certificates =
+                [
+                    new DevCertInfo
+                    {
+                        Version = 5,
+                        TrustLevel = CertificateManager.TrustLevel.Partial,
+                        IsHttpsDevelopmentCertificate = true,
+                        ValidityNotBefore = DateTimeOffset.Now.AddDays(-1),
+                        ValidityNotAfter = DateTimeOffset.Now.AddDays(365)
+                    }
+                ]
+            }
+        };
+
+        var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper, options =>
+        {
+            options.InteractionServiceFactory = _ => interactionService;
+            options.CertificateToolRunnerFactory = _ => toolRunner;
+            options.CliHostEnvironmentFactory = sp =>
+            {
+                var configuration = sp.GetRequiredService<IConfiguration>();
+                return new CliHostEnvironment(configuration, nonInteractive: true);
+            };
+            options.CertificateServiceFactory = sp =>
+            {
+                var telemetry = sp.GetRequiredService<AspireCliTelemetry>();
+                var hostEnvironment = sp.GetRequiredService<ICliHostEnvironment>();
+                return new CertificateService(toolRunner, interactionService, telemetry, hostEnvironment, isLinux: () => true);
+            };
+        });
+        using var provider = services.BuildServiceProvider();
+
+        var command = provider.GetRequiredService<Aspire.Cli.Commands.RootCommand>();
+        var result = command.Parse("certs trust --non-interactive");
+
+        var exitCode = await result.InvokeAsync().DefaultTimeout();
+
+        Assert.Equal(CliExitCodes.Success, exitCode);
+        Assert.Contains(interactionService.DisplayedMessages, m => m.Message.Contains("partially trusted", StringComparison.OrdinalIgnoreCase));
+        Assert.Empty(interactionService.DisplayedSuccess);
     }
 }


### PR DESCRIPTION
## Description

On non-interactive Linux CI runners, `aspire certs trust --non-interactive` can successfully install the development certificate for OpenSSL while still reporting `PartiallyFailedToTrustTheCertificate` because browser/NSS trust could not be completed. That partial state is useful for CLI diagnostics and AppHost HTTPS checks, but the command previously returned a hard failure.

This change treats partial trust as success only for non-interactive Linux runs, and only after the post-trust check confirms the certificate is actually partially trusted. Interactive Linux runs and real trust failures still fail. The command now prints a warning explaining that CLI HTTPS diagnostics can continue while browser trust may remain incomplete.

### User-facing usage

```bash
aspire certs trust --non-interactive
```

Partial Linux trust now exits successfully with guidance:

```text
Developer certificates may not be fully trusted (trust exit code was: PartiallyFailedToTrustTheCertificate).
HTTPS development certificate was partially trusted. Continuing because partial trust is usable for CLI HTTPS diagnostics on Linux; browser trust may still be incomplete.
EXIT:0
```

`aspire doctor` still reports the partial trust state and guidance to set `SSL_CERT_DIR`; it does not hide that browser/user trust may be incomplete.

### Security considerations

This change affects certificate trust command success semantics. It does not skip the trust operation or convert full trust failures into success. The success path is limited to non-interactive Linux and requires the post-trust certificate check to report `TrustLevel.Partial`, preserving failure behavior for untrusted certificates and interactive runs.

Validation:

- `dotnet test --project tests/Aspire.Cli.Tests/Aspire.Cli.Tests.csproj --no-launch-profile -- --filter-class "*.CertificateServiceTests" --filter-class "*.CertificatesCommandTests" --filter-not-trait "quarantined=true" --filter-not-trait "outerloop=true"`
- Container smoke test with a Linux x64 published CLI and NSS DB present: `aspire certs trust --non-interactive` returned `EXIT:0` with the new partial-trust warning.

Fixes # (issue)

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [x] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [x] No
  - [ ] No