### PR TITLE
Support DCP dev cert TLS files

### DIFF
--- a/src/Aspire.Hosting/Dcp/DcpHost.cs
+++ b/src/Aspire.Hosting/Dcp/DcpHost.cs
@@ -406,7 +406,8 @@ internal sealed class DcpHost
         {
             Mode = FileMode.Create,
             Access = FileAccess.Write,
-            Share = FileShare.Read
+            Share = FileShare.Read,
+            Options = FileOptions.Asynchronous
         };
 
         if (!OperatingSystem.IsWindows())

--- a/src/Aspire.Hosting/Dcp/DcpHost.cs
+++ b/src/Aspire.Hosting/Dcp/DcpHost.cs
@@ -237,11 +237,20 @@ internal sealed class DcpHost
             return;
         }
 
-        var (certificatePath, keyPath) = await DeveloperCertificateService.GetCertificateFilePathsAsync(
+        var (certificatePath, keyPath, cachedThumbprint) = await DeveloperCertificateService.GetCachedCertificateFilePathsAsync(
             certificate,
             password: null,
             cancellationToken).ConfigureAwait(false);
 
+        if (certificatePath is null || keyPath is null || cachedThumbprint is null)
+        {
+            _logger.LogWarning("Failed to cache the developer certificate files. DCP will use its default certificate.");
+            _dcpTlsCertThumbprint = null;
+            activity.SetDcpTlsCertificateResult(ProfilingTelemetry.Values.DcpTlsCertificateResultNoCertificate);
+            return;
+        }
+
+        _dcpTlsCertThumbprint = cachedThumbprint;
         _dcpTlsCertFile = certificatePath;
         _dcpTlsKeyFile = keyPath;
         activity.SetDcpTlsCertificateResult(

--- a/src/Aspire.Hosting/Dcp/DcpHost.cs
+++ b/src/Aspire.Hosting/Dcp/DcpHost.cs
@@ -5,10 +5,12 @@ using System.Buffers;
 using System.Collections;
 using System.IO.Pipelines;
 using System.Net.Sockets;
+using System.Security.Cryptography;
 using System.Security.Cryptography.X509Certificates;
 using System.Text;
 using Aspire.Dashboard.Utils;
 using Aspire.Hosting.ApplicationModel;
+using Aspire.Hosting.Diagnostics;
 using Aspire.Hosting.Dcp.Process;
 using Aspire.Hosting.Resources;
 using Aspire.Shared;
@@ -38,6 +40,8 @@ internal sealed class DcpHost
     private readonly IConfiguration _configuration;
     private readonly CancellationTokenSource _shutdownCts = new();
     private string? _dcpTlsCertThumbprint;
+    private string? _dcpTlsCertFile;
+    private string? _dcpTlsKeyFile;
     private Task? _logProcessorTask;
 
     // These environment variables should never be inherited by DCP from the app host.
@@ -176,27 +180,24 @@ internal sealed class DcpHost
             }
     }
 
-    internal Task PrepareDcpTlsCertificateAsync(CancellationToken cancellationToken)
+    internal async Task PrepareDcpTlsCertificateAsync(CancellationToken cancellationToken)
     {
         cancellationToken.ThrowIfCancellationRequested();
 
         // Using the ASP.NET dev cert for DCP TLS is opt-in; by default DCP uses its own ephemeral certificate.
         if (!_configuration.GetBool(KnownConfigNames.DcpDeveloperCertificate, defaultValue: false))
         {
-            return Task.CompletedTask;
+            return;
         }
 
-        if (!OperatingSystem.IsWindows())
-        {
-            _logger.LogWarning("Developer certificate thumbprint configuration is only supported on Windows. DCP will use its default certificate.");
-            return Task.CompletedTask;
-        }
+        using var activity = ProfilingTelemetry.StartDcpPrepareTlsCertificate(_configuration);
 
         // Check if we have a trusted developer certificate with a private key available
         var certificates = _developerCertificateService.Certificates;
         if (certificates.Count == 0)
         {
-            return Task.CompletedTask;
+            activity.SetDcpTlsCertificateResult(ProfilingTelemetry.Values.DcpTlsCertificateResultNoCertificate);
+            return;
         }
 
         // Use the first (latest/best) certificate that has a private key
@@ -212,20 +213,77 @@ internal sealed class DcpHost
 
         if (certificate is null)
         {
-            return Task.CompletedTask;
+            activity.SetDcpTlsCertificateResult(ProfilingTelemetry.Values.DcpTlsCertificateResultNoPrivateKeyCertificate);
+            return;
         }
 
         var thumbprint = certificate.Thumbprint;
         if (string.IsNullOrWhiteSpace(thumbprint))
         {
             _logger.LogWarning("Failed to read the developer certificate thumbprint. DCP will use its default certificate.");
-            return Task.CompletedTask;
+            activity.SetDcpTlsCertificateResult(ProfilingTelemetry.Values.DcpTlsCertificateResultMissingThumbprint);
+            return;
         }
 
         _dcpTlsCertThumbprint = thumbprint;
-        _logger.LogDebug("Prepared DCP TLS certificate thumbprint {Thumbprint}.", thumbprint);
 
-        return Task.CompletedTask;
+        if (OperatingSystem.IsWindows())
+        {
+            activity.SetDcpTlsCertificateResult(
+                ProfilingTelemetry.Values.DcpTlsCertificateResultPrepared,
+                ProfilingTelemetry.Values.DcpTlsCertificateModeThumbprint,
+                prepared: true);
+            _logger.LogDebug("Prepared DCP TLS certificate thumbprint {Thumbprint}.", thumbprint);
+            return;
+        }
+
+        var (keyPem, _) = await DeveloperCertificateService.GetKeyMaterialAsync(
+            certificate,
+            password: null,
+            needKeyPem: true,
+            needPfx: false,
+            cancellationToken).ConfigureAwait(false);
+
+        if (keyPem is null || keyPem.Length == 0)
+        {
+            _logger.LogWarning("Failed to export the developer certificate private key. DCP will use its default certificate.");
+            _dcpTlsCertThumbprint = null;
+            activity.SetDcpTlsCertificateResult(ProfilingTelemetry.Values.DcpTlsCertificateResultKeyExportFailed);
+            return;
+        }
+
+        try
+        {
+            var certificateDirectory = Path.Combine(_locations.DcpSessionDir, "tls");
+            Directory.CreateDirectory(certificateDirectory, UnixFileMode.UserExecute | UnixFileMode.UserWrite | UnixFileMode.UserRead);
+
+            var certificatePath = Path.Combine(certificateDirectory, "dcp-tls.crt");
+            var keyPath = Path.Combine(certificateDirectory, "dcp-tls.key");
+
+            await WriteFileWithUserOnlyPermissionsAsync(certificatePath, Encoding.UTF8.GetBytes(certificate.ExportCertificatePem()), cancellationToken).ConfigureAwait(false);
+
+            var keyBytes = Encoding.UTF8.GetBytes(keyPem);
+            try
+            {
+                await WriteFileWithUserOnlyPermissionsAsync(keyPath, keyBytes, cancellationToken).ConfigureAwait(false);
+            }
+            finally
+            {
+                CryptographicOperations.ZeroMemory(keyBytes);
+            }
+
+            _dcpTlsCertFile = certificatePath;
+            _dcpTlsKeyFile = keyPath;
+            activity.SetDcpTlsCertificateResult(
+                ProfilingTelemetry.Values.DcpTlsCertificateResultPrepared,
+                ProfilingTelemetry.Values.DcpTlsCertificateModeFiles,
+                prepared: true);
+            _logger.LogDebug("Prepared DCP TLS certificate files for thumbprint {Thumbprint}.", thumbprint);
+        }
+        finally
+        {
+            Array.Clear(keyPem);
+        }
     }
 
     public async Task StopAsync()
@@ -278,6 +336,11 @@ internal sealed class DcpHost
         if (!string.IsNullOrWhiteSpace(_dcpTlsCertThumbprint))
         {
             arguments += $" --tls-cert-thumbprint \"{_dcpTlsCertThumbprint}\"";
+        }
+
+        if (!string.IsNullOrWhiteSpace(_dcpTlsCertFile) && !string.IsNullOrWhiteSpace(_dcpTlsKeyFile))
+        {
+            arguments += $" --tls-cert-file \"{_dcpTlsCertFile}\" --tls-key-file \"{_dcpTlsKeyFile}\"";
         }
 
         var dcpProcessSpec = new ProcessSpec(dcpExePath)
@@ -334,6 +397,25 @@ internal sealed class DcpHost
         }
 
         return dcpProcessSpec;
+    }
+
+    private static async Task WriteFileWithUserOnlyPermissionsAsync(string path, ReadOnlyMemory<byte> contents, CancellationToken cancellationToken)
+    {
+        var options = new FileStreamOptions
+        {
+            Mode = FileMode.Create,
+            Access = FileAccess.Write,
+            Share = FileShare.Read
+        };
+
+        if (!OperatingSystem.IsWindows())
+        {
+            options.UnixCreateMode = UnixFileMode.UserRead | UnixFileMode.UserWrite;
+        }
+
+        using var stream = new FileStream(path, options);
+
+        await stream.WriteAsync(contents, cancellationToken).ConfigureAwait(false);
     }
 
     private void SetDcpProfilingEnvironment(IDictionary<string, string> environmentVariables)

--- a/src/Aspire.Hosting/Dcp/DcpHost.cs
+++ b/src/Aspire.Hosting/Dcp/DcpHost.cs
@@ -5,7 +5,6 @@ using System.Buffers;
 using System.Collections;
 using System.IO.Pipelines;
 using System.Net.Sockets;
-using System.Security.Cryptography;
 using System.Security.Cryptography.X509Certificates;
 using System.Text;
 using Aspire.Dashboard.Utils;
@@ -238,53 +237,18 @@ internal sealed class DcpHost
             return;
         }
 
-        var (keyPem, _) = await DeveloperCertificateService.GetKeyMaterialAsync(
+        var (certificatePath, keyPath) = await DeveloperCertificateService.GetCertificateFilePathsAsync(
             certificate,
             password: null,
-            needKeyPem: true,
-            needPfx: false,
             cancellationToken).ConfigureAwait(false);
 
-        if (keyPem is null || keyPem.Length == 0)
-        {
-            _logger.LogWarning("Failed to export the developer certificate private key. DCP will use its default certificate.");
-            _dcpTlsCertThumbprint = null;
-            activity.SetDcpTlsCertificateResult(ProfilingTelemetry.Values.DcpTlsCertificateResultKeyExportFailed);
-            return;
-        }
-
-        try
-        {
-            var certificateDirectory = Path.Combine(_locations.DcpSessionDir, "tls");
-            Directory.CreateDirectory(certificateDirectory, UnixFileMode.UserExecute | UnixFileMode.UserWrite | UnixFileMode.UserRead);
-
-            var certificatePath = Path.Combine(certificateDirectory, "dcp-tls.crt");
-            var keyPath = Path.Combine(certificateDirectory, "dcp-tls.key");
-
-            await WriteFileWithUserOnlyPermissionsAsync(certificatePath, Encoding.UTF8.GetBytes(certificate.ExportCertificatePem()), cancellationToken).ConfigureAwait(false);
-
-            var keyBytes = Encoding.UTF8.GetBytes(keyPem);
-            try
-            {
-                await WriteFileWithUserOnlyPermissionsAsync(keyPath, keyBytes, cancellationToken).ConfigureAwait(false);
-            }
-            finally
-            {
-                CryptographicOperations.ZeroMemory(keyBytes);
-            }
-
-            _dcpTlsCertFile = certificatePath;
-            _dcpTlsKeyFile = keyPath;
-            activity.SetDcpTlsCertificateResult(
-                ProfilingTelemetry.Values.DcpTlsCertificateResultPrepared,
-                ProfilingTelemetry.Values.DcpTlsCertificateModeFiles,
-                prepared: true);
-            _logger.LogDebug("Prepared DCP TLS certificate files for thumbprint {Thumbprint}.", thumbprint);
-        }
-        finally
-        {
-            Array.Clear(keyPem);
-        }
+        _dcpTlsCertFile = certificatePath;
+        _dcpTlsKeyFile = keyPath;
+        activity.SetDcpTlsCertificateResult(
+            ProfilingTelemetry.Values.DcpTlsCertificateResultPrepared,
+            ProfilingTelemetry.Values.DcpTlsCertificateModeFiles,
+            prepared: true);
+        _logger.LogDebug("Prepared DCP TLS certificate files for thumbprint {Thumbprint}.", thumbprint);
     }
 
     public async Task StopAsync()
@@ -398,26 +362,6 @@ internal sealed class DcpHost
         }
 
         return dcpProcessSpec;
-    }
-
-    private static async Task WriteFileWithUserOnlyPermissionsAsync(string path, ReadOnlyMemory<byte> contents, CancellationToken cancellationToken)
-    {
-        var options = new FileStreamOptions
-        {
-            Mode = FileMode.Create,
-            Access = FileAccess.Write,
-            Share = FileShare.Read,
-            Options = FileOptions.Asynchronous
-        };
-
-        if (!OperatingSystem.IsWindows())
-        {
-            options.UnixCreateMode = UnixFileMode.UserRead | UnixFileMode.UserWrite;
-        }
-
-        using var stream = new FileStream(path, options);
-
-        await stream.WriteAsync(contents, cancellationToken).ConfigureAwait(false);
     }
 
     private void SetDcpProfilingEnvironment(IDictionary<string, string> environmentVariables)

--- a/src/Aspire.Hosting/Dcp/DcpHost.cs
+++ b/src/Aspire.Hosting/Dcp/DcpHost.cs
@@ -184,8 +184,9 @@ internal sealed class DcpHost
     {
         cancellationToken.ThrowIfCancellationRequested();
 
-        // Using the ASP.NET dev cert for DCP TLS is opt-in; by default DCP uses its own ephemeral certificate.
-        if (!_configuration.GetBool(KnownConfigNames.DcpDeveloperCertificate, defaultValue: false))
+        // DCP uses the ASP.NET dev cert for TLS by default. The environment variable remains
+        // available as an opt-out if users need DCP's ephemeral certificate behavior.
+        if (!_configuration.GetBool(KnownConfigNames.DcpDeveloperCertificate, defaultValue: true))
         {
             return;
         }

--- a/src/Aspire.Hosting/DeveloperCertificateService.cs
+++ b/src/Aspire.Hosting/DeveloperCertificateService.cs
@@ -229,44 +229,16 @@ internal class DeveloperCertificateService : IDeveloperCertificateService
             return ExportFromPrivateKey(certificate, password, needKeyPem, needPfx);
         }
 
-        // For dev certs we prefer reading from cache to avoid repeated keychain access prompts
-        var lookup = GetKeyMaterialCacheLookup(certificate, password);
-
+        // For dev certs we prefer reading from cache to avoid repeated keychain access prompts.
         // Ensure only one thread at a time is resolving certificates to avoid concurrent cache misses
         // all trying to update the cache at the same time.
         await s_certificateCacheSemaphore.WaitAsync(cancellationToken).ConfigureAwait(false);
         try
         {
-            var pfxFileName = Path.Join(s_userDevCertificateLocation, $"{lookup}.pfx");
-            var keyFileName = Path.Join(s_userDevCertificateLocation, $"{lookup}.key");
-
-            // Try to read cached files. On cache hit, return the raw bytes directly
-            // without loading them into X509Certificate2 (which would import the key into
-            // the macOS keychain on net8.0).
-            var cachedPfx = TryReadCacheFile(pfxFileName);
-            var cachedKey = TryReadCacheFile(keyFileName);
-
-            if (cachedPfx is not null && cachedKey is not null)
-            {
-                return (
-                    needKeyPem ? Encoding.UTF8.GetString(cachedKey).ToCharArray() : null,
-                    needPfx ? cachedPfx : null);
-            }
-
-            // Fall back to accessing the private key directly (triggers a keychain prompt on macOS).
-            // Always produce both formats for caching, even if the caller only needs one.
-            var result = ExportFromPrivateKey(certificate, password, needKeyPem: true, needPfx: true);
-
-            await WriteCacheFilesAsync(
-                certificateFileName: null,
-                certificatePem: null,
-                pfxFileName,
-                result.pfxBytes,
-                keyFileName,
-                result.keyPem,
-                cancellationToken).ConfigureAwait(false);
-
-            return (needKeyPem ? result.keyPem : null, needPfx ? result.pfxBytes : null);
+            var cached = EnsureCachedKeyMaterial(certificate, password);
+            return (
+                needKeyPem ? Encoding.UTF8.GetString(cached.keyBytes).ToCharArray() : null,
+                needPfx ? cached.pfxBytes : null);
         }
         finally
         {
@@ -275,58 +247,91 @@ internal class DeveloperCertificateService : IDeveloperCertificateService
     }
 
     /// <summary>
-    /// Returns cached PEM certificate and key file paths for the specified developer certificate.
+    /// Ensures the public certificate (.crt), PFX (.pfx) and PEM private key (.key) cache files
+    /// exist for the specified ASP.NET Core developer certificate and returns the paths along with
+    /// the certificate thumbprint. Returns <c>(null, null, null)</c> if the supplied certificate is
+    /// not a developer certificate, has no thumbprint, or the cache files could not be produced.
     /// </summary>
-    /// <param name="certificate">The developer certificate to cache file material for.</param>
-    /// <param name="password">The password for the private key, or <c>null</c> for unencrypted export.</param>
-    /// <param name="cancellationToken">A token that can be used to cancel the operation.</param>
-    /// <returns>Cached PEM certificate and key file paths.</returns>
-    internal static async Task<(string certificateFilePath, string keyFilePath)> GetCertificateFilePathsAsync(
+    internal static async Task<(string? certificateFilePath, string? keyFilePath, string? thumbprint)> GetCachedCertificateFilePathsAsync(
         X509Certificate2 certificate,
         string? password,
         CancellationToken cancellationToken)
     {
-        var lookup = GetKeyMaterialCacheLookup(certificate, password);
-        var certificateFileName = Path.Join(s_userDevCertificateLocation, $"{lookup}.crt");
-        var keyFileName = Path.Join(s_userDevCertificateLocation, $"{lookup}.key");
+        if (!certificate.IsAspNetCoreDevelopmentCertificate() || string.IsNullOrWhiteSpace(certificate.Thumbprint))
+        {
+            return (null, null, null);
+        }
 
-        var (keyPem, _) = await GetKeyMaterialAsync(
-            certificate,
-            password,
-            needKeyPem: true,
-            needPfx: false,
-            cancellationToken).ConfigureAwait(false);
+        string certificateFileName;
+        string keyFileName;
 
+        await s_certificateCacheSemaphore.WaitAsync(cancellationToken).ConfigureAwait(false);
         try
         {
-            if (keyPem is null)
-            {
-                throw new InvalidOperationException("Failed to export the developer certificate private key.");
-            }
-
-            await WriteCacheFilesAsync(
-                certificateFileName,
-                Encoding.UTF8.GetBytes(certificate.ExportCertificatePem()),
-                pfxFileName: null,
-                pfxBytes: null,
-                keyFileName,
-                keyPem,
-                cancellationToken).ConfigureAwait(false);
+            var cached = EnsureCachedKeyMaterial(certificate, password);
+            certificateFileName = cached.certFileName;
+            keyFileName = cached.keyFileName;
         }
         finally
         {
-            if (keyPem is not null)
-            {
-                Array.Clear(keyPem);
-            }
+            s_certificateCacheSemaphore.Release();
         }
 
-        if (TryReadCacheFile(certificateFileName) is null || TryReadCacheFile(keyFileName) is null)
+        return File.Exists(certificateFileName) && File.Exists(keyFileName)
+            ? (certificateFileName, keyFileName, certificate.Thumbprint)
+            : (null, null, null);
+    }
+
+    /// <summary>
+    /// Ensures the public certificate (.crt), PFX (.pfx) and PEM private key (.key) cache files
+    /// exist for the specified certificate, returning their paths along with the cached PFX/key
+    /// byte contents. On cache miss the private key is accessed once (which may trigger a keychain
+    /// prompt on macOS) to export both private-key formats; on cache hit the bytes are read
+    /// directly from disk to avoid importing the PFX into the macOS keychain via
+    /// <see cref="X509Certificate2"/>. The public .crt file is written whenever it is missing,
+    /// since it can be produced without accessing the private key.
+    /// </summary>
+    /// <remarks>The caller must hold <see cref="s_certificateCacheSemaphore"/>.</remarks>
+    private static (string certFileName, string pfxFileName, string keyFileName, byte[] pfxBytes, byte[] keyBytes) EnsureCachedKeyMaterial(
+        X509Certificate2 certificate, string? password)
+    {
+        var lookup = GetKeyMaterialCacheLookup(certificate, password);
+        var certFileName = Path.Join(s_userDevCertificateLocation, $"{lookup}.crt");
+        var pfxFileName = Path.Join(s_userDevCertificateLocation, $"{lookup}.pfx");
+        var keyFileName = Path.Join(s_userDevCertificateLocation, $"{lookup}.key");
+
+        var cachedPfx = TryReadCacheFile(pfxFileName);
+        var cachedKey = TryReadCacheFile(keyFileName);
+
+        byte[] pfxBytes;
+        byte[] keyBytes;
+
+        if (cachedPfx is not null && cachedKey is not null)
         {
-            throw new IOException($"Failed to cache developer certificate files in '{s_userDevCertificateLocation}'.");
+            pfxBytes = cachedPfx;
+            keyBytes = cachedKey;
+        }
+        else
+        {
+            // Fall back to accessing the private key directly (triggers a keychain prompt on macOS).
+            // Always produce both formats for caching, even if the caller only needs one.
+            var result = ExportFromPrivateKey(certificate, password, needKeyPem: true, needPfx: true);
+            pfxBytes = result.pfxBytes!;
+            keyBytes = Encoding.UTF8.GetBytes(result.keyPem!);
+            Array.Clear(result.keyPem!);
+
+            WriteCacheFiles(certFileName, certificate, pfxFileName, pfxBytes, keyFileName, keyBytes);
         }
 
-        return (certificateFileName, keyFileName);
+        // The public certificate cache file can be produced without touching the private key,
+        // so refresh it whenever it is missing (including on cache hits from older caches that
+        // pre-date this file).
+        if (!File.Exists(certFileName))
+        {
+            WriteCacheFiles(certFileName, certificate, pfxFileName: null, pfxBytes: null, keyFileName: null, keyBytes: null);
+        }
+
+        return (certFileName, pfxFileName, keyFileName, pfxBytes, keyBytes);
     }
 
     private static string GetKeyMaterialCacheLookup(X509Certificate2 certificate, string? password)
@@ -420,16 +425,17 @@ internal class DeveloperCertificateService : IDeveloperCertificateService
     }
 
     /// <summary>
-    /// Writes certificate, PFX, and PEM key cache files. Best-effort; failures are silently ignored.
+    /// Writes the public certificate (.crt), PFX (.pfx) and PEM private key (.key) cache files.
+    /// Any of the file-name / payload pairs may be null to skip writing that file. Best-effort;
+    /// failures are silently ignored.
     /// </summary>
-    private static async Task WriteCacheFilesAsync(
-        string? certificateFileName,
-        byte[]? certificatePem,
+    private static void WriteCacheFiles(
+        string certFileName,
+        X509Certificate2 certificate,
         string? pfxFileName,
         byte[]? pfxBytes,
         string? keyFileName,
-        char[]? keyPem,
-        CancellationToken cancellationToken)
+        byte[]? keyBytes)
     {
         try
         {
@@ -442,56 +448,21 @@ internal class DeveloperCertificateService : IDeveloperCertificateService
                 Directory.CreateDirectory(s_userDevCertificateLocation, UnixFileMode.UserExecute | UnixFileMode.UserWrite | UnixFileMode.UserRead);
             }
 
-            if (certificateFileName is not null && certificatePem is not null)
-            {
-                await WriteCacheFileAsync(certificateFileName, certificatePem, cancellationToken).ConfigureAwait(false);
-            }
+            File.WriteAllText(certFileName, certificate.ExportCertificatePem());
 
             if (pfxFileName is not null && pfxBytes is not null)
             {
-                await WriteCacheFileAsync(pfxFileName, pfxBytes, cancellationToken).ConfigureAwait(false);
+                File.WriteAllBytes(pfxFileName, pfxBytes);
             }
 
-            if (keyFileName is not null && keyPem is not null)
+            if (keyFileName is not null && keyBytes is not null)
             {
-                var keyBytes = Encoding.UTF8.GetBytes(keyPem);
-                try
-                {
-                    await WriteCacheFileAsync(keyFileName, keyBytes, cancellationToken).ConfigureAwait(false);
-                }
-                finally
-                {
-                    CryptographicOperations.ZeroMemory(keyBytes);
-                }
+                File.WriteAllBytes(keyFileName, keyBytes);
             }
-        }
-        catch (OperationCanceledException)
-        {
-            throw;
         }
         catch
         {
             // Best-effort caching operation.
         }
-    }
-
-    private static async Task WriteCacheFileAsync(string path, ReadOnlyMemory<byte> contents, CancellationToken cancellationToken)
-    {
-        var options = new FileStreamOptions
-        {
-            Mode = FileMode.Create,
-            Access = FileAccess.Write,
-            Share = FileShare.Read,
-            Options = FileOptions.Asynchronous
-        };
-
-        if (!OperatingSystem.IsWindows())
-        {
-            options.UnixCreateMode = UnixFileMode.UserRead | UnixFileMode.UserWrite;
-        }
-
-        using var stream = new FileStream(path, options);
-
-        await stream.WriteAsync(contents, cancellationToken).ConfigureAwait(false);
     }
 }

--- a/src/Aspire.Hosting/DeveloperCertificateService.cs
+++ b/src/Aspire.Hosting/DeveloperCertificateService.cs
@@ -230,13 +230,7 @@ internal class DeveloperCertificateService : IDeveloperCertificateService
         }
 
         // For dev certs we prefer reading from cache to avoid repeated keychain access prompts
-        var lookup = certificate.Thumbprint;
-        if (password is not null)
-        {
-            lookup += $"-{password}";
-        }
-
-        lookup = Convert.ToHexString(SHA256.HashData(Encoding.UTF8.GetBytes(lookup)));
+        var lookup = GetKeyMaterialCacheLookup(certificate, password);
 
         // Ensure only one thread at a time is resolving certificates to avoid concurrent cache misses
         // all trying to update the cache at the same time.
@@ -263,7 +257,14 @@ internal class DeveloperCertificateService : IDeveloperCertificateService
             // Always produce both formats for caching, even if the caller only needs one.
             var result = ExportFromPrivateKey(certificate, password, needKeyPem: true, needPfx: true);
 
-            WriteCacheFiles(pfxFileName, result.pfxBytes, keyFileName, result.keyPem);
+            await WriteCacheFilesAsync(
+                certificateFileName: null,
+                certificatePem: null,
+                pfxFileName,
+                result.pfxBytes,
+                keyFileName,
+                result.keyPem,
+                cancellationToken).ConfigureAwait(false);
 
             return (needKeyPem ? result.keyPem : null, needPfx ? result.pfxBytes : null);
         }
@@ -271,6 +272,72 @@ internal class DeveloperCertificateService : IDeveloperCertificateService
         {
             s_certificateCacheSemaphore.Release();
         }
+    }
+
+    /// <summary>
+    /// Returns cached PEM certificate and key file paths for the specified developer certificate.
+    /// </summary>
+    /// <param name="certificate">The developer certificate to cache file material for.</param>
+    /// <param name="password">The password for the private key, or <c>null</c> for unencrypted export.</param>
+    /// <param name="cancellationToken">A token that can be used to cancel the operation.</param>
+    /// <returns>Cached PEM certificate and key file paths.</returns>
+    internal static async Task<(string certificateFilePath, string keyFilePath)> GetCertificateFilePathsAsync(
+        X509Certificate2 certificate,
+        string? password,
+        CancellationToken cancellationToken)
+    {
+        var lookup = GetKeyMaterialCacheLookup(certificate, password);
+        var certificateFileName = Path.Join(s_userDevCertificateLocation, $"{lookup}.crt");
+        var keyFileName = Path.Join(s_userDevCertificateLocation, $"{lookup}.key");
+
+        var (keyPem, _) = await GetKeyMaterialAsync(
+            certificate,
+            password,
+            needKeyPem: true,
+            needPfx: false,
+            cancellationToken).ConfigureAwait(false);
+
+        try
+        {
+            if (keyPem is null)
+            {
+                throw new InvalidOperationException("Failed to export the developer certificate private key.");
+            }
+
+            await WriteCacheFilesAsync(
+                certificateFileName,
+                Encoding.UTF8.GetBytes(certificate.ExportCertificatePem()),
+                pfxFileName: null,
+                pfxBytes: null,
+                keyFileName,
+                keyPem,
+                cancellationToken).ConfigureAwait(false);
+        }
+        finally
+        {
+            if (keyPem is not null)
+            {
+                Array.Clear(keyPem);
+            }
+        }
+
+        if (TryReadCacheFile(certificateFileName) is null || TryReadCacheFile(keyFileName) is null)
+        {
+            throw new IOException($"Failed to cache developer certificate files in '{s_userDevCertificateLocation}'.");
+        }
+
+        return (certificateFileName, keyFileName);
+    }
+
+    private static string GetKeyMaterialCacheLookup(X509Certificate2 certificate, string? password)
+    {
+        var lookup = certificate.Thumbprint;
+        if (password is not null)
+        {
+            lookup += $"-{password}";
+        }
+
+        return Convert.ToHexString(SHA256.HashData(Encoding.UTF8.GetBytes(lookup)));
     }
 
     /// <summary>
@@ -353,9 +420,16 @@ internal class DeveloperCertificateService : IDeveloperCertificateService
     }
 
     /// <summary>
-    /// Writes PFX and PEM key cache files. Best-effort; failures are silently ignored.
+    /// Writes certificate, PFX, and PEM key cache files. Best-effort; failures are silently ignored.
     /// </summary>
-    private static void WriteCacheFiles(string pfxFileName, byte[]? pfxBytes, string keyFileName, char[]? keyPem)
+    private static async Task WriteCacheFilesAsync(
+        string? certificateFileName,
+        byte[]? certificatePem,
+        string? pfxFileName,
+        byte[]? pfxBytes,
+        string? keyFileName,
+        char[]? keyPem,
+        CancellationToken cancellationToken)
     {
         try
         {
@@ -368,19 +442,56 @@ internal class DeveloperCertificateService : IDeveloperCertificateService
                 Directory.CreateDirectory(s_userDevCertificateLocation, UnixFileMode.UserExecute | UnixFileMode.UserWrite | UnixFileMode.UserRead);
             }
 
-            if (pfxBytes is not null)
+            if (certificateFileName is not null && certificatePem is not null)
             {
-                File.WriteAllBytes(pfxFileName, pfxBytes);
+                await WriteCacheFileAsync(certificateFileName, certificatePem, cancellationToken).ConfigureAwait(false);
             }
 
-            if (keyPem is not null)
+            if (pfxFileName is not null && pfxBytes is not null)
             {
-                File.WriteAllBytes(keyFileName, Encoding.UTF8.GetBytes(keyPem));
+                await WriteCacheFileAsync(pfxFileName, pfxBytes, cancellationToken).ConfigureAwait(false);
             }
+
+            if (keyFileName is not null && keyPem is not null)
+            {
+                var keyBytes = Encoding.UTF8.GetBytes(keyPem);
+                try
+                {
+                    await WriteCacheFileAsync(keyFileName, keyBytes, cancellationToken).ConfigureAwait(false);
+                }
+                finally
+                {
+                    CryptographicOperations.ZeroMemory(keyBytes);
+                }
+            }
+        }
+        catch (OperationCanceledException)
+        {
+            throw;
         }
         catch
         {
             // Best-effort caching operation.
         }
+    }
+
+    private static async Task WriteCacheFileAsync(string path, ReadOnlyMemory<byte> contents, CancellationToken cancellationToken)
+    {
+        var options = new FileStreamOptions
+        {
+            Mode = FileMode.Create,
+            Access = FileAccess.Write,
+            Share = FileShare.Read,
+            Options = FileOptions.Asynchronous
+        };
+
+        if (!OperatingSystem.IsWindows())
+        {
+            options.UnixCreateMode = UnixFileMode.UserRead | UnixFileMode.UserWrite;
+        }
+
+        using var stream = new FileStream(path, options);
+
+        await stream.WriteAsync(contents, cancellationToken).ConfigureAwait(false);
     }
 }

--- a/src/Aspire.Hosting/Diagnostics/ProfilingTelemetry.cs
+++ b/src/Aspire.Hosting/Diagnostics/ProfilingTelemetry.cs
@@ -22,6 +22,7 @@ internal sealed class ProfilingTelemetry(IConfiguration configuration)
         // Activity names describe AppHost/DCP orchestration work. Keep names stable
         // because profiling exports are queried across CLI and AppHost versions.
         public const string DcpRunApplication = "aspire.hosting.dcp.run_application";
+        public const string DcpPrepareTlsCertificate = "aspire.hosting.dcp.prepare_tls_certificate";
         public const string AppHostProcessStartup = "aspire.hosting.apphost.process_startup";
         public const string AppHostStart = "aspire.hosting.apphost.start";
         public const string AppHostBeforeStart = "aspire.hosting.apphost.before_start";
@@ -110,6 +111,10 @@ internal sealed class ProfilingTelemetry(IConfiguration configuration)
         public const string DcpKubernetesClientWaitMilliseconds = "aspire.dcp.kubernetes_client.wait_ms";
         public const string DcpKubernetesClientAlreadyInitialized = "aspire.dcp.kubernetes_client_already_initialized";
         public const string DcpKubernetesClientInitialized = "aspire.dcp.kubernetes_client.initialized";
+        public const string DcpTlsDeveloperCertificateEnabled = "aspire.dcp.tls.developer_certificate.enabled";
+        public const string DcpTlsCertificateMode = "aspire.dcp.tls.certificate.mode";
+        public const string DcpTlsCertificatePrepared = "aspire.dcp.tls.certificate.prepared";
+        public const string DcpTlsCertificateResult = "aspire.dcp.tls.certificate.result";
         public const string BackchannelSocketPath = "aspire.hosting.backchannel.socket.path";
         public const string PreviousResourceState = "aspire.resource.previous_state";
         public const string PreviousResourceHealthStatus = "aspire.resource.previous_health_status";
@@ -170,6 +175,13 @@ internal sealed class ProfilingTelemetry(IConfiguration configuration)
         public const string DashboardUrlSourceNone = "none";
         public const string DashboardUrlSourceResource = "resource";
         public const string DashboardUrlSourceConfiguration = "configuration";
+        public const string DcpTlsCertificateModeFiles = "files";
+        public const string DcpTlsCertificateModeThumbprint = "thumbprint";
+        public const string DcpTlsCertificateResultKeyExportFailed = "key_export_failed";
+        public const string DcpTlsCertificateResultMissingThumbprint = "missing_thumbprint";
+        public const string DcpTlsCertificateResultNoCertificate = "no_certificate";
+        public const string DcpTlsCertificateResultNoPrivateKeyCertificate = "no_private_key_certificate";
+        public const string DcpTlsCertificateResultPrepared = "prepared";
     }
 
     internal static class Annotations
@@ -251,6 +263,13 @@ internal sealed class ProfilingTelemetry(IConfiguration configuration)
     {
         var activity = StartActivity(configuration, Activities.DcpRunApplication);
         activity.SetResourceCount(resourceCount);
+        return activity;
+    }
+
+    public static ActivityScope StartDcpPrepareTlsCertificate(IConfiguration? configuration)
+    {
+        var activity = StartActivity(configuration, Activities.DcpPrepareTlsCertificate);
+        activity.SetDcpTlsDeveloperCertificateEnabled(true);
         return activity;
     }
 
@@ -884,6 +903,19 @@ internal sealed class ProfilingTelemetry(IConfiguration configuration)
         {
             SetTag(Tags.DcpApiOperation, operationType.ToString());
             SetTag(Tags.DcpResourceKind, resourceType);
+        }
+
+        public void SetDcpTlsDeveloperCertificateEnabled(bool enabled) => SetTag(Tags.DcpTlsDeveloperCertificateEnabled, enabled);
+
+        public void SetDcpTlsCertificateResult(string result, string? mode = null, bool prepared = false)
+        {
+            SetTag(Tags.DcpTlsCertificateResult, result);
+            SetTag(Tags.DcpTlsCertificatePrepared, prepared);
+
+            if (!string.IsNullOrEmpty(mode))
+            {
+                SetTag(Tags.DcpTlsCertificateMode, mode);
+            }
         }
 
         public void SetAppHostEntryPoint(string entryPoint) => SetTag(Tags.AppHostEntryPoint, entryPoint);

--- a/src/Aspire.Hosting/Diagnostics/ProfilingTelemetry.cs
+++ b/src/Aspire.Hosting/Diagnostics/ProfilingTelemetry.cs
@@ -177,7 +177,6 @@ internal sealed class ProfilingTelemetry(IConfiguration configuration)
         public const string DashboardUrlSourceConfiguration = "configuration";
         public const string DcpTlsCertificateModeFiles = "files";
         public const string DcpTlsCertificateModeThumbprint = "thumbprint";
-        public const string DcpTlsCertificateResultKeyExportFailed = "key_export_failed";
         public const string DcpTlsCertificateResultMissingThumbprint = "missing_thumbprint";
         public const string DcpTlsCertificateResultNoCertificate = "no_certificate";
         public const string DcpTlsCertificateResultNoPrivateKeyCertificate = "no_private_key_certificate";

--- a/tests/Aspire.Hosting.Tests/Dcp/DcpHostNotificationTests.cs
+++ b/tests/Aspire.Hosting.Tests/Dcp/DcpHostNotificationTests.cs
@@ -724,6 +724,7 @@ public sealed class DcpHostNotificationTests
 
         using var rsa = RSA.Create(2048);
         var request = new CertificateRequest(subject, rsa, HashAlgorithmName.SHA256, RSASignaturePadding.Pkcs1);
+        request.CertificateExtensions.Add(new X509Extension("1.3.6.1.4.1.311.84.1.1", [0], critical: false));
         using var certificate = request.CreateSelfSigned(DateTimeOffset.UtcNow.AddDays(-1), DateTimeOffset.UtcNow.AddDays(30));
 
         return X509CertificateLoader.LoadPkcs12(certificate.Export(X509ContentType.Pfx), password: null, X509KeyStorageFlags.Exportable);

--- a/tests/Aspire.Hosting.Tests/Dcp/DcpHostNotificationTests.cs
+++ b/tests/Aspire.Hosting.Tests/Dcp/DcpHostNotificationTests.cs
@@ -1,10 +1,14 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Collections.Concurrent;
+using System.Diagnostics;
 using System.Globalization;
 using System.Net.Sockets;
+using System.Security.Cryptography;
 using System.Security.Cryptography.X509Certificates;
 using Aspire.Hosting.Dcp;
+using Aspire.Hosting.Diagnostics;
 using Aspire.Hosting.Resources;
 using Aspire.Hosting.Tests.Utils;
 using Microsoft.AspNetCore.InternalTesting;
@@ -474,19 +478,22 @@ public sealed class DcpHostNotificationTests
 
         // Assert
         Assert.DoesNotContain("--tls-cert-thumbprint", processSpec.Arguments);
+        Assert.DoesNotContain("--tls-cert-file", processSpec.Arguments);
+        Assert.DoesNotContain("--tls-key-file", processSpec.Arguments);
     }
 
     [Fact]
     public async Task CreateDcpProcessSpec_WithTlsCertThumbprint_IncludesThumbprintArgument()
     {
-        Assert.SkipUnless(OperatingSystem.IsWindows(), "Developer certificate thumbprint is only supported on Windows.");
-
         // Arrange
-        using var certificate = CreateUntrustedCertificate();
+        var activities = new ConcurrentBag<Activity>();
+        using var listener = CreateActivityListener(ProfilingTelemetry.ActivitySourceName, activities.Add);
+        using var certificate = CreateExportableCertificate();
         var configuration = new ConfigurationBuilder()
             .AddInMemoryCollection(new Dictionary<string, string?>
             {
-                [KnownConfigNames.DcpDeveloperCertificate] = "true"
+                [KnownConfigNames.DcpDeveloperCertificate] = "true",
+                [KnownConfigNames.ProfilingEnabled] = "true"
             })
             .Build();
         var dcpHost = CreateDcpHostForProcessSpecTests(
@@ -501,6 +508,26 @@ public sealed class DcpHostNotificationTests
 
         // Assert
         Assert.Contains($"--tls-cert-thumbprint \"{certificate.Thumbprint}\"", processSpec.Arguments);
+        var certificateActivity = Assert.Single(activities, activity => activity.OperationName == ProfilingTelemetry.Activities.DcpPrepareTlsCertificate);
+        Assert.Equal(true, certificateActivity.GetTagItem(ProfilingTelemetry.Tags.DcpTlsDeveloperCertificateEnabled));
+        Assert.Equal(ProfilingTelemetry.Values.DcpTlsCertificateResultPrepared, certificateActivity.GetTagItem(ProfilingTelemetry.Tags.DcpTlsCertificateResult));
+        Assert.Equal(true, certificateActivity.GetTagItem(ProfilingTelemetry.Tags.DcpTlsCertificatePrepared));
+
+        if (OperatingSystem.IsWindows())
+        {
+            Assert.DoesNotContain("--tls-cert-file", processSpec.Arguments);
+            Assert.DoesNotContain("--tls-key-file", processSpec.Arguments);
+            Assert.Equal(ProfilingTelemetry.Values.DcpTlsCertificateModeThumbprint, certificateActivity.GetTagItem(ProfilingTelemetry.Tags.DcpTlsCertificateMode));
+        }
+        else
+        {
+            var certificatePath = GetQuotedArgumentValue(processSpec.Arguments, "--tls-cert-file");
+            var keyPath = GetQuotedArgumentValue(processSpec.Arguments, "--tls-key-file");
+
+            Assert.Equal(certificate.ExportCertificatePem(), File.ReadAllText(certificatePath));
+            Assert.Contains("PRIVATE KEY", File.ReadAllText(keyPath));
+            Assert.Equal(ProfilingTelemetry.Values.DcpTlsCertificateModeFiles, certificateActivity.GetTagItem(ProfilingTelemetry.Tags.DcpTlsCertificateMode));
+        }
     }
 
     [Fact]
@@ -519,6 +546,8 @@ public sealed class DcpHostNotificationTests
 
         // Assert - thumbprint should not appear because config is not enabled
         Assert.DoesNotContain("--tls-cert-thumbprint", processSpec.Arguments);
+        Assert.DoesNotContain("--tls-cert-file", processSpec.Arguments);
+        Assert.DoesNotContain("--tls-key-file", processSpec.Arguments);
     }
 
     [Fact]
@@ -683,6 +712,47 @@ public sealed class DcpHostNotificationTests
         }
 
         throw new FileNotFoundException("Could not locate test certificate file 'testCert.pfx' in expected locations.");
+    }
+
+    private static X509Certificate2 CreateExportableCertificate()
+    {
+        var subject = new X500DistinguishedName($"CN=aspire-test-{Guid.NewGuid():N}");
+
+        using var rsa = RSA.Create(2048);
+        var request = new CertificateRequest(subject, rsa, HashAlgorithmName.SHA256, RSASignaturePadding.Pkcs1);
+        using var certificate = request.CreateSelfSigned(DateTimeOffset.UtcNow.AddDays(-1), DateTimeOffset.UtcNow.AddDays(30));
+
+        return X509CertificateLoader.LoadPkcs12(certificate.Export(X509ContentType.Pfx), password: null, X509KeyStorageFlags.Exportable);
+    }
+
+    private static string GetQuotedArgumentValue(string? arguments, string option)
+    {
+        if (arguments is null)
+        {
+            throw new InvalidOperationException("Expected process arguments to be set.");
+        }
+
+        var prefix = $"{option} \"";
+        var start = arguments.IndexOf(prefix, StringComparison.Ordinal);
+        Assert.NotEqual(-1, start);
+        start += prefix.Length;
+
+        var end = arguments.IndexOf('"', start);
+        Assert.NotEqual(-1, end);
+
+        return arguments[start..end];
+    }
+
+    private static ActivityListener CreateActivityListener(string sourceName, Action<Activity> activityStopped)
+    {
+        var listener = new ActivityListener
+        {
+            ShouldListenTo = source => source.Name == sourceName,
+            Sample = (ref ActivityCreationOptions<ActivityContext> _) => ActivitySamplingResult.AllDataAndRecorded,
+            ActivityStopped = activityStopped
+        };
+        ActivitySource.AddActivityListener(listener);
+        return listener;
     }
 
     [Fact]

--- a/tests/Aspire.Hosting.Tests/Dcp/DcpHostNotificationTests.cs
+++ b/tests/Aspire.Hosting.Tests/Dcp/DcpHostNotificationTests.cs
@@ -483,16 +483,14 @@ public sealed class DcpHostNotificationTests
     }
 
     [Fact]
-    public async Task CreateDcpProcessSpec_WithTlsCertThumbprint_IncludesThumbprintArgument()
+    public async Task CreateDcpProcessSpec_WithDcpDeveloperCertificateDefault_IncludesDeveloperCertificateArguments()
     {
-        // Arrange
         var activities = new ConcurrentBag<Activity>();
         using var listener = CreateActivityListener(ProfilingTelemetry.ActivitySourceName, activities.Add);
         using var certificate = CreateExportableCertificate();
         var configuration = new ConfigurationBuilder()
             .AddInMemoryCollection(new Dictionary<string, string?>
             {
-                [KnownConfigNames.DcpDeveloperCertificate] = "true",
                 [KnownConfigNames.ProfilingEnabled] = "true"
             })
             .Build();
@@ -533,10 +531,16 @@ public sealed class DcpHostNotificationTests
     [Fact]
     public async Task CreateDcpProcessSpec_WithDcpDeveloperCertificateDisabled_DoesNotIncludeThumbprintArgument()
     {
-        // Arrange - config not set, so PrepareDcpTlsCertificateAsync should not set the thumbprint
         using var certificate = CreateUntrustedCertificate();
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                [KnownConfigNames.DcpDeveloperCertificate] = "false"
+            })
+            .Build();
         var dcpHost = CreateDcpHostForProcessSpecTests(
-            developerCertificateService: new TestDeveloperCertificateService([certificate], false, false, false));
+            developerCertificateService: new TestDeveloperCertificateService([certificate], false, false, false),
+            configuration: configuration);
         var locations = CreateTestLocations();
 
         await dcpHost.PrepareDcpTlsCertificateAsync(CancellationToken.None);
@@ -544,7 +548,7 @@ public sealed class DcpHostNotificationTests
         // Act
         var processSpec = dcpHost.CreateDcpProcessSpec(locations);
 
-        // Assert - thumbprint should not appear because config is not enabled
+        // Assert - thumbprint should not appear because config is explicitly disabled
         Assert.DoesNotContain("--tls-cert-thumbprint", processSpec.Arguments);
         Assert.DoesNotContain("--tls-cert-file", processSpec.Arguments);
         Assert.DoesNotContain("--tls-key-file", processSpec.Arguments);


### PR DESCRIPTION
## Description

DCP recently added support for TLS certificate files, which lets Aspire use the existing ASP.NET Core developer certificate beyond the current Windows-only thumbprint path. This change makes that developer-certificate path the default for DCP TLS, while preserving `ASPIRE_DCP_USE_DEVELOPER_CERTIFICATE=false` as an opt-out for users who need DCP's default ephemeral certificate behavior.

By default, Aspire now keeps the Windows behavior of passing `--tls-cert-thumbprint`. On macOS and Linux, Aspire asks the existing developer certificate service for cached certificate and key file paths, then starts DCP with `--tls-cert-file`, `--tls-key-file`, and `--tls-cert-thumbprint` so DCP can verify the loaded certificate.

Startup profiling also records a dedicated `aspire.hosting.dcp.prepare_tls_certificate` activity when this code path is active. The span tags capture whether the developer certificate path was enabled, the preparation result, whether a certificate was prepared, and the certificate mode (`thumbprint` or `files`) so we can measure the performance impact of this path.

### User-facing usage

This behavior is enabled by default. Users can opt out with the existing environment variable:

```bash
ASPIRE_DCP_USE_DEVELOPER_CERTIFICATE=false
```

### Security considerations

This change uses the existing developer certificate cache for exported certificate and private key material on macOS and Linux. The cache is under the user's profile and the cached files are written with user-only Unix permissions. Security review should confirm the file location and permissions are appropriate for the default developer certificate scenario and explicit opt-out behavior.

Validation:

```bash
dotnet test --project tests/Aspire.Hosting.Tests/Aspire.Hosting.Tests.csproj --no-launch-profile -- --filter-class "*.DcpHostNotificationTests" --filter-not-trait "quarantined=true" --filter-not-trait "outerloop=true"
```

Fixes # (issue)

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [x] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [x] No
  - [ ] No