### PR TITLE
Serialize CLI host tests to fix sample_rate race (#17450)

### DIFF
--- a/tests/Aspire.Cli.Tests/Telemetry/TelemetryConfigurationTests.cs
+++ b/tests/Aspire.Cli.Tests/Telemetry/TelemetryConfigurationTests.cs
@@ -17,6 +17,23 @@ namespace Aspire.Cli.Tests.Telemetry;
 
 public class TelemetryConfigurationTests
 {
+    // The Aspire.Cli.Tests assembly opts out of Azure Monitor telemetry by default
+    // (see TestTelemetryDefaults). Tests that need the Azure Monitor branch override
+    // the env-var-derived opt-out by passing this in their in-memory configuration —
+    // AddInMemoryCollection is added AFTER AddEnvironmentVariables in
+    // Program.BuildApplicationAsync, so the in-memory value wins.
+    private static readonly KeyValuePair<string, string?> s_telemetryOptInOverride =
+        new(AspireCliTelemetry.TelemetryOptOutConfigKey, "false");
+
+    private static Dictionary<string, string?> WithTelemetryOptIn(Dictionary<string, string?>? config = null)
+    {
+        var result = config is null
+            ? new Dictionary<string, string?>()
+            : new Dictionary<string, string?>(config);
+        result[s_telemetryOptInOverride.Key] = s_telemetryOptInOverride.Value;
+        return result;
+    }
+
     private static async Task<IHost> BuildHostAsync(Dictionary<string, string?>? config = null)
     {
         var loggingOptions = Program.ParseLoggingOptions([]);
@@ -30,9 +47,11 @@ public class TelemetryConfigurationTests
     [Fact]
     public async Task AzureMonitor_Enabled_ByDefault()
     {
-        // The Application Insights connection string is now hardcoded, so Azure Monitor
-        // should be enabled by default when telemetry is not opted out
-        using var host = await BuildHostAsync();
+        // The Application Insights connection string is hardcoded, so Azure Monitor
+        // should be enabled when telemetry is not opted out. The test process opts out
+        // by default (see TestTelemetryDefaults); we explicitly opt back in here to
+        // exercise the Azure Monitor branch.
+        using var host = await BuildHostAsync(WithTelemetryOptIn());
 
         var telemetryManager = host.Services.GetService<TelemetryManager>();
         Assert.NotNull(telemetryManager);
@@ -59,10 +78,10 @@ public class TelemetryConfigurationTests
     [Fact]
     public async Task OtlpExporter_WithoutProfiling_EnablesOnlyDebugDiagnostics_WhenEndpointProvided()
     {
-        var config = new Dictionary<string, string?>
+        var config = WithTelemetryOptIn(new Dictionary<string, string?>
         {
             [AspireCliTelemetry.OtlpExporterEndpointConfigKey] = "http://localhost:4317"
-        };
+        });
 
         using var host = await BuildHostAsync(config);
 
@@ -122,11 +141,11 @@ public class TelemetryConfigurationTests
     [Fact]
     public async Task OtlpExporter_WithProfiling_KeepsReportedTelemetryAndProfilingSeparate()
     {
-        var config = new Dictionary<string, string?>
+        var config = WithTelemetryOptIn(new Dictionary<string, string?>
         {
             [AspireCliTelemetry.OtlpExporterEndpointConfigKey] = "http://localhost:4317",
             [Aspire.Hosting.KnownConfigNames.ProfilingEnabled] = "true"
-        };
+        });
 
         using var host = await BuildHostAsync(config);
 

--- a/tests/Aspire.Cli.Tests/TestTelemetryDefaults.cs
+++ b/tests/Aspire.Cli.Tests/TestTelemetryDefaults.cs
@@ -1,0 +1,33 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Runtime.CompilerServices;
+using Aspire.Cli.Telemetry;
+
+namespace Aspire.Cli.Tests;
+
+/// <summary>
+/// Opts the CLI out of Azure Monitor telemetry for the entire <c>Aspire.Cli.Tests</c>
+/// process. Tests that need to exercise the Azure Monitor branch override this via the
+/// in-memory configuration passed to <see cref="Aspire.Cli.Program.BuildApplicationAsync"/>,
+/// which is layered on top of <c>AddEnvironmentVariables()</c> and therefore wins.
+///
+/// Why opt out by default in tests: see https://github.com/microsoft/aspire/issues/17450.
+/// Azure Monitor's default <c>RateLimitedSampler</c> emits a <c>microsoft.sample_rate</c>
+/// attribute via <c>ActivityCreationOptions.SamplingTags.Add</c> (no <c>TryAdd</c>). When
+/// xUnit v3 runs test classes in parallel and more than one <c>TelemetryManager</c>
+/// builds a TracerProvider in the same process, two listeners are registered on the
+/// <c>Aspire.Cli.Reported</c> ActivitySource and both samplers fire on the same shared
+/// <c>ActivityCreationOptions</c>, so the second <c>Add</c> throws
+/// <c>InvalidOperationException("The collection already contains item with same key 'microsoft.sample_rate'")</c>.
+/// Defaulting the test process to opted-out keeps Azure Monitor out of the pipeline
+/// except in the focused tests that explicitly need it.
+/// </summary>
+internal static class TestTelemetryDefaults
+{
+    [ModuleInitializer]
+    internal static void OptOutByDefault()
+    {
+        Environment.SetEnvironmentVariable(AspireCliTelemetry.TelemetryOptOutConfigKey, "true");
+    }
+}


### PR DESCRIPTION
## Description

Fixes #17450.

`Aspire.Cli.Tests.CliSmokeTests.MainReturnsExpectedExitCode(args: [], expectedExitCode: 1)` intermittently failed in CI with:

```
System.InvalidOperationException : "The collection already contains item with same key 'microsoft.sample_rate'"
   at System.Diagnostics.ActivityTagsCollection.Add(String key, Object value)
   at OpenTelemetry.Trace.TracerProviderSdk.ComputeActivitySamplingResult(...)
   at System.Diagnostics.ActivitySource.CreateActivity(...)
   at Aspire.Cli.Telemetry.AspireCliTelemetry.StartReportedActivity(...)
```

### Root cause

`Azure.Monitor.OpenTelemetry.Exporter` uses `RateLimitedSampler` by default, which (once its adaptive state has matured for ~200ms after construction) returns a `SamplingResult` containing a `microsoft.sample_rate` attribute. OpenTelemetry's `TracerProviderSdk.ComputeActivitySamplingResult` writes those attributes into `ActivityCreationOptions.SamplingTags` via a hard `Add(key, value)` (no `TryAdd`). `ActivitySource.CreateActivity` reuses the **same** `ActivityCreationOptions` instance across every registered listener, so when two listeners on the `Aspire.Cli.Reported` source both run samplers that emit `microsoft.sample_rate`, the second `Add` throws.

Aspire CLI production code only ever has one live `TelemetryManager` (registered as a DI singleton), so the duplicate-tag race is impossible at runtime. xUnit v3 runs test classes in parallel by default, however, which allows two in-process host-building tests to overlap: when one of them calls `StartReportedActivity`, both listeners fire and the second `Add` throws.

### Fix

Opt the entire `Aspire.Cli.Tests` process out of Azure Monitor by default, and re-enable it only for the handful of tests that actually need to assert on Azure Monitor configuration.

- New `tests/Aspire.Cli.Tests/TestTelemetryDefaults.cs` uses `[ModuleInitializer]` to set `ASPIRE_CLI_TELEMETRY_OPTOUT=true` for the test process before any test method runs. With opt-out enabled, `TelemetryManager` does not register an Azure Monitor `TracerProvider`, so no Azure Monitor listener ever attaches to the `Aspire.Cli.Reported` source from test code.
- `TelemetryConfigurationTests` adds a small `WithTelemetryOptIn(...)` helper that injects `"ASPIRE_CLI_TELEMETRY_OPTOUT": "false"` into the in-memory configuration. `Program.BuildApplicationAsync` reads environment variables before in-memory values, so in-memory wins. The three tests that exercise Azure Monitor (`AzureMonitor_Enabled_ByDefault`, `OtlpExporter_WithoutProfiling_EnablesOnlyDebugDiagnostics_WhenEndpointProvided`, `OtlpExporter_WithProfiling_KeepsReportedTelemetryAndProfilingSeparate`) opt back in via this helper. Because all Azure Monitor `TracerProvider` creations are now confined to a single class and xUnit runs methods within a class serially, the duplicate-`Add` race cannot happen.

No production code changes. No test collections, no parallelization toggles. The opt-out lives entirely outside test class code so it cannot be accidentally bypassed by adding new test classes that build a CLI host in-process.

### Why not a product-side fix

The defect is fundamentally an OpenTelemetry/Azure Monitor interaction: any sampler that writes attributes into `SamplingTags` will collide when more than one listener is attached to the same `ActivitySource`. A product-side workaround would either (a) discard the Azure Monitor default sampler and lose rate-limiting + the `sample_rate` metric, or (b) wrap the sampler chain to dedupe attributes - both worse trade-offs than disabling Azure Monitor in the test process where it provides no value anyway.

### Verification

- Reproduced the exact CI stack trace locally by constructing two `TelemetryManager` instances with Azure Monitor enabled, waiting 300ms for the samplers' adaptive state to mature, and calling `StartReportedActivity`. This confirmed the root cause; the repro test was removed before commit (no upstream issue to track, and a `[ActiveIssue]`-skipped repro added more noise than value).
- Full `tests/Aspire.Cli.Tests` suite locally: 3,660 / 3,681 pass (21 skipped on this platform), 0 failures.
- `MainReturnsExpectedExitCode` across 5 stress runs locally: all green.
- `TelemetryConfigurationTests` (all 3 Azure Monitor tests): pass with the opt-in helper.

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
  - [x] No
