### PR TITLE
fix(cli): persist channel in aspire.config.json on init and update

### DIFF
--- a/src/Aspire.Cli/Commands/InitCommand.cs
+++ b/src/Aspire.Cli/Commands/InitCommand.cs
@@ -302,11 +302,11 @@ internal sealed class InitCommand : BaseCommand
         //
         // `ResolvePersistableChannelNameAsync` filters out identities that aren't
         // registered as channels on this CLI install (e.g. `local`, `staging` on a CLI
-        // without the staging feature flag, stale `pr-<N>` after the hive is gone) and
-        // the Implicit `default` channel that no CLI identity ever has. Channels that
-        // do resolve to a registered Explicit entry — including `stable`, `dev`,
-        // `staging`, and `pr-<N>` — are persisted so polyglot `aspire add` can match
-        // a PSM rule. See https://github.com/microsoft/aspire/issues/17295.
+        // without the staging feature flag, stale `pr-<N>` after the hive is gone),
+        // the Implicit `default` channel that no CLI identity ever has, and `stable`
+        // because the public-feed behavior is already the default. Non-default
+        // Explicit channels are persisted so subsequent commands can match a PSM rule.
+        // See https://github.com/microsoft/aspire/issues/17295.
         var resolvedChannel = await ResolvePersistableChannelNameAsync(cancellationToken);
         var (configResult, effectivePorts) = DropAspireConfig(workingDirectory, "apphost.cs", language: null, resolvedChannel, ports);
         if (configResult != CliExitCodes.Success)
@@ -486,21 +486,13 @@ internal sealed class InitCommand : BaseCommand
 
         // Resolve and pass the running CLI's identity channel through to the scaffolder
         // so it lands in aspire.config.json#channel. Only persist when the identity
-        // resolves to a registered Explicit channel — see `ResolvePersistableChannelNameAsync`
-        // for the full rationale. Additionally, if aspire.config.json already carries a
-        // channel value, suppress the pass-through: `ScaffoldingService.cs:93-95` writes
+        // resolves to a persistable registered Explicit channel — see
+        // `ResolvePersistableChannelNameAsync` for the full rationale. Additionally,
+        // if aspire.config.json already carries a channel value, suppress the pass-through:
+        // `ScaffoldingService.cs:93-95` writes
         // `config.Channel = context.Channel` unconditionally when non-empty, so without
         // this guard a user-edited channel would be silently overwritten.
         var resolvedChannel = await ResolvePersistableChannelNameAsync(cancellationToken);
-        if (string.Equals(resolvedChannel, PackageChannelNames.Stable, StringComparisons.ChannelName))
-        {
-            // The stable explicit channel is the same public-feed package set users get by default,
-            // but pinning it in polyglot config makes `aspire add` search only the synthetic
-            // NuGet.org config and hides packages from ambient private feeds. Non-default explicit
-            // channels still need persistence so they keep matching the CLI build that scaffolded.
-            resolvedChannel = null;
-        }
-
         if (!string.IsNullOrEmpty(resolvedChannel))
         {
             var existing = TryLoadExistingChannel(workingDirectory);
@@ -656,9 +648,11 @@ internal sealed class InitCommand : BaseCommand
     /// In production the only Implicit channel created by <c>PackagingService.GetChannelsAsync</c>
     /// is <c>default</c> (the unscoped nuget.org aggregator), which no CLI identity ever
     /// resolves to — this branch exists defensively in case a future <c>PackagingService</c>
-    /// adds another Implicit channel whose name happens to collide with a CLI identity.
-    /// Note that <c>stable</c> is created via <c>CreateExplicitChannel</c> and IS persisted
-    /// — see the <c>[InlineData("stable")]</c> test cases for the resolved behavior.</description></item>
+    /// adds another Implicit channel whose name happens to collide with a CLI identity.</description></item>
+    /// <item><description>The matched channel is <see cref="PackageChannelNames.Stable"/>.
+    /// Stable uses the same public-feed package set users get by default, but pinning it
+    /// per-project makes package discovery use only the synthetic NuGet.org config and
+    /// hides packages from ambient private feeds.</description></item>
     /// </list>
     /// Mirrors the resolution logic in <c>NewCommand.cs:316-402</c> and the warning in
     /// <c>ScaffoldingService.cs:84-92</c> against falling back to <c>IdentityChannel</c> blindly.
@@ -684,7 +678,7 @@ internal sealed class InitCommand : BaseCommand
         }
 
         var match = channels.FirstOrDefault(c => string.Equals(c.Name, identityChannel, StringComparisons.ChannelName));
-        return match?.Type is PackageChannelType.Explicit ? match.Name : null;
+        return match?.ShouldPersistChannelName() is true ? match.Name : null;
     }
 
     /// <summary>

--- a/src/Aspire.Cli/Commands/InitCommand.cs
+++ b/src/Aspire.Cli/Commands/InitCommand.cs
@@ -298,11 +298,15 @@ internal sealed class InitCommand : BaseCommand
         // Persist the running CLI's identity channel (e.g. `daily`, `staging`, `pr-<N>`)
         // so subsequent commands like `aspire add` resolve packages against the matching
         // channel. Resolve through PackagingService and only persist when the identity
-        // matches a registered Explicit channel — mirrors `NewCommand.cs:316-402`. This
-        // avoids pinning `stable` (Implicit → restricts polyglot discovery, see
-        // https://github.com/microsoft/aspire/issues/17295) or pinning an unregistered
-        // identity like `local` / stale `pr-<N>` (no PSM rule satisfies it → polyglot
-        // `aspire add` returns zero packages).
+        // matches a registered Explicit channel — mirrors `NewCommand.cs:316-402`.
+        //
+        // `ResolvePersistableChannelNameAsync` filters out identities that aren't
+        // registered as channels on this CLI install (e.g. `local`, `staging` on a CLI
+        // without the staging feature flag, stale `pr-<N>` after the hive is gone) and
+        // the Implicit `default` channel that no CLI identity ever has. Channels that
+        // do resolve to a registered Explicit entry — including `stable`, `dev`,
+        // `staging`, and `pr-<N>` — are persisted so polyglot `aspire add` can match
+        // a PSM rule. See https://github.com/microsoft/aspire/issues/17295.
         var resolvedChannel = await ResolvePersistableChannelNameAsync(cancellationToken);
         var (configResult, effectivePorts) = DropAspireConfig(workingDirectory, "apphost.cs", language: null, resolvedChannel, ports);
         if (configResult != CliExitCodes.Success)
@@ -639,11 +643,13 @@ internal sealed class InitCommand : BaseCommand
     /// machine without the matching hive). Persisting these would pin a name no PSM rule can
     /// satisfy and zero out polyglot <c>aspire add</c> discovery via
     /// <c>IntegrationPackageSearchService.cs</c> line 28-30.</description></item>
-    /// <item><description>The matched channel is <see cref="PackageChannelType.Implicit"/>
-    /// (e.g. <c>stable</c> → nuget.org). Implicit channels should not be persisted so
-    /// downstream commands fall back to the default aggregated-source behavior — pinning
-    /// <c>stable</c> on a polyglot AppHost is the regression tracked by
-    /// https://github.com/microsoft/aspire/issues/17295.</description></item>
+    /// <item><description>The matched channel is <see cref="PackageChannelType.Implicit"/>.
+    /// In production the only Implicit channel created by <c>PackagingService.GetChannelsAsync</c>
+    /// is <c>default</c> (the unscoped nuget.org aggregator), which no CLI identity ever
+    /// resolves to — this branch exists defensively in case a future <c>PackagingService</c>
+    /// adds another Implicit channel whose name happens to collide with a CLI identity.
+    /// Note that <c>stable</c> is created via <c>CreateExplicitChannel</c> and IS persisted
+    /// — see the <c>[InlineData("stable")]</c> test cases for the resolved behavior.</description></item>
     /// </list>
     /// Mirrors the resolution logic in <c>NewCommand.cs:316-402</c> and the warning in
     /// <c>ScaffoldingService.cs:84-92</c> against falling back to <c>IdentityChannel</c> blindly.

--- a/src/Aspire.Cli/Commands/InitCommand.cs
+++ b/src/Aspire.Cli/Commands/InitCommand.cs
@@ -492,6 +492,15 @@ internal sealed class InitCommand : BaseCommand
         // `config.Channel = context.Channel` unconditionally when non-empty, so without
         // this guard a user-edited channel would be silently overwritten.
         var resolvedChannel = await ResolvePersistableChannelNameAsync(cancellationToken);
+        if (string.Equals(resolvedChannel, PackageChannelNames.Stable, StringComparisons.ChannelName))
+        {
+            // The stable explicit channel is the same public-feed package set users get by default,
+            // but pinning it in polyglot config makes `aspire add` search only the synthetic
+            // NuGet.org config and hides packages from ambient private feeds. Non-default explicit
+            // channels still need persistence so they keep matching the CLI build that scaffolded.
+            resolvedChannel = null;
+        }
+
         if (!string.IsNullOrEmpty(resolvedChannel))
         {
             var existing = TryLoadExistingChannel(workingDirectory);

--- a/src/Aspire.Cli/Commands/InitCommand.cs
+++ b/src/Aspire.Cli/Commands/InitCommand.cs
@@ -291,7 +291,14 @@ internal sealed class InitCommand : BaseCommand
         // in aspire.config.json — newly generated, or pre-existing if the file already
         // had a `profiles` section. Use the SAME ports for apphost.run.json so the two
         // files always agree on dashboard / OTLP / resource service endpoints.
-        var (configResult, effectivePorts) = DropAspireConfig(workingDirectory, "apphost.cs", language: null, ports);
+        //
+        // Persist the running CLI's identity channel (e.g. `daily`, `staging`, `pr-<N>`,
+        // `local`) so subsequent commands like `aspire add` resolve packages against the
+        // matching channel rather than defaulting to the implicit nuget.org channel.
+        // Mirrors what `aspire new` writes via its template path; without this, a daily
+        // CLI scaffolds a project pinned to no channel and `aspire add` falls back to
+        // stable nuget.org versions that don't line up with the CLI build.
+        var (configResult, effectivePorts) = DropAspireConfig(workingDirectory, "apphost.cs", language: null, _executionContext.IdentityChannel, ports);
         if (configResult != CliExitCodes.Success)
         {
             return configResult;
@@ -467,7 +474,11 @@ internal sealed class InitCommand : BaseCommand
             return CliExitCodes.Success;
         }
 
-        var context = new ScaffoldContext(language, workingDirectory, workingDirectory.Name);
+        // Pass the running CLI's identity channel through to the scaffolder so it lands
+        // in aspire.config.json#channel. Without this, subsequent `aspire add` calls on
+        // a non-stable CLI (daily/staging/pr-<N>/local) fall back to implicit nuget.org
+        // versions that don't line up with the channel the apphost was scaffolded for.
+        var context = new ScaffoldContext(language, workingDirectory, workingDirectory.Name, Channel: _executionContext.IdentityChannel);
         var scaffolded = await _scaffoldingService.ScaffoldAsync(context, cancellationToken);
         if (!scaffolded)
         {
@@ -478,7 +489,7 @@ internal sealed class InitCommand : BaseCommand
         return CliExitCodes.Success;
     }
 
-    private (int ExitCode, AppHostProfilePorts EffectivePorts) DropAspireConfig(DirectoryInfo directory, string appHostPath, string? language, AppHostProfilePorts? ports = null)
+    private (int ExitCode, AppHostProfilePorts EffectivePorts) DropAspireConfig(DirectoryInfo directory, string appHostPath, string? language, string? channel, AppHostProfilePorts? ports = null)
     {
         var configPath = Path.Combine(directory.FullName, AspireConfigFile.FileName);
 
@@ -525,6 +536,16 @@ internal sealed class InitCommand : BaseCommand
         if (language is not null && appHost["language"] is null)
         {
             appHost["language"] = language;
+        }
+
+        // Persist the channel at the top level so `aspire add` / `integration list` /
+        // `integration search` resolve packages against the channel the CLI scaffolded
+        // for. Only write when not already present so a user-edited value wins. Leaving
+        // the channel unset on a non-stable CLI causes downstream commands to fall back
+        // to implicit nuget.org versions that don't line up with the CLI build.
+        if (!string.IsNullOrEmpty(channel) && settings["channel"] is null)
+        {
+            settings["channel"] = channel;
         }
 
         // Resolve the effective ports. Three cases:

--- a/src/Aspire.Cli/Commands/InitCommand.cs
+++ b/src/Aspire.Cli/Commands/InitCommand.cs
@@ -46,6 +46,7 @@ internal sealed class InitCommand : BaseCommand
     private readonly IScaffoldingService _scaffoldingService;
     private readonly ILanguageDiscovery _languageDiscovery;
     private readonly TemplateNuGetConfigService _templateNuGetConfigService;
+    private readonly IPackagingService _packagingService;
 
     private static readonly Option<string?> s_sourceOption = new("--source", "-s")
     {
@@ -77,7 +78,8 @@ internal sealed class InitCommand : BaseCommand
         ICertificateService certificateService,
         IScaffoldingService scaffoldingService,
         ILanguageDiscovery languageDiscovery,
-        TemplateNuGetConfigService templateNuGetConfigService)
+        TemplateNuGetConfigService templateNuGetConfigService,
+        IPackagingService packagingService)
         : base("init", InitCommandStrings.Description, features, updateNotifier, executionContext, interactionService, telemetry)
     {
         _executionContext = executionContext;
@@ -89,6 +91,7 @@ internal sealed class InitCommand : BaseCommand
         _scaffoldingService = scaffoldingService;
         _languageDiscovery = languageDiscovery;
         _templateNuGetConfigService = templateNuGetConfigService;
+        _packagingService = packagingService;
 
         _channelOption = new Option<string?>("--channel")
         {
@@ -292,13 +295,16 @@ internal sealed class InitCommand : BaseCommand
         // had a `profiles` section. Use the SAME ports for apphost.run.json so the two
         // files always agree on dashboard / OTLP / resource service endpoints.
         //
-        // Persist the running CLI's identity channel (e.g. `daily`, `staging`, `pr-<N>`,
-        // `local`) so subsequent commands like `aspire add` resolve packages against the
-        // matching channel rather than defaulting to the implicit nuget.org channel.
-        // Mirrors what `aspire new` writes via its template path; without this, a daily
-        // CLI scaffolds a project pinned to no channel and `aspire add` falls back to
-        // stable nuget.org versions that don't line up with the CLI build.
-        var (configResult, effectivePorts) = DropAspireConfig(workingDirectory, "apphost.cs", language: null, _executionContext.IdentityChannel, ports);
+        // Persist the running CLI's identity channel (e.g. `daily`, `staging`, `pr-<N>`)
+        // so subsequent commands like `aspire add` resolve packages against the matching
+        // channel. Resolve through PackagingService and only persist when the identity
+        // matches a registered Explicit channel — mirrors `NewCommand.cs:316-402`. This
+        // avoids pinning `stable` (Implicit → restricts polyglot discovery, see
+        // https://github.com/microsoft/aspire/issues/17295) or pinning an unregistered
+        // identity like `local` / stale `pr-<N>` (no PSM rule satisfies it → polyglot
+        // `aspire add` returns zero packages).
+        var resolvedChannel = await ResolvePersistableChannelNameAsync(cancellationToken);
+        var (configResult, effectivePorts) = DropAspireConfig(workingDirectory, "apphost.cs", language: null, resolvedChannel, ports);
         if (configResult != CliExitCodes.Success)
         {
             return configResult;
@@ -474,11 +480,24 @@ internal sealed class InitCommand : BaseCommand
             return CliExitCodes.Success;
         }
 
-        // Pass the running CLI's identity channel through to the scaffolder so it lands
-        // in aspire.config.json#channel. Without this, subsequent `aspire add` calls on
-        // a non-stable CLI (daily/staging/pr-<N>/local) fall back to implicit nuget.org
-        // versions that don't line up with the channel the apphost was scaffolded for.
-        var context = new ScaffoldContext(language, workingDirectory, workingDirectory.Name, Channel: _executionContext.IdentityChannel);
+        // Resolve and pass the running CLI's identity channel through to the scaffolder
+        // so it lands in aspire.config.json#channel. Only persist when the identity
+        // resolves to a registered Explicit channel — see `ResolvePersistableChannelNameAsync`
+        // for the full rationale. Additionally, if aspire.config.json already carries a
+        // channel value, suppress the pass-through: `ScaffoldingService.cs:93-95` writes
+        // `config.Channel = context.Channel` unconditionally when non-empty, so without
+        // this guard a user-edited channel would be silently overwritten.
+        var resolvedChannel = await ResolvePersistableChannelNameAsync(cancellationToken);
+        if (!string.IsNullOrEmpty(resolvedChannel))
+        {
+            var existing = TryLoadExistingChannel(workingDirectory);
+            if (!string.IsNullOrEmpty(existing))
+            {
+                resolvedChannel = null;
+            }
+        }
+
+        var context = new ScaffoldContext(language, workingDirectory, workingDirectory.Name, Channel: resolvedChannel);
         var scaffolded = await _scaffoldingService.ScaffoldAsync(context, cancellationToken);
         if (!scaffolded)
         {
@@ -608,6 +627,68 @@ internal sealed class InitCommand : BaseCommand
 
         InteractionService.DisplayMessage(KnownEmojis.CheckMarkButton, string.Format(CultureInfo.CurrentCulture, InitCommandStrings.CreatedFile, AspireConfigFile.FileName));
         return (CliExitCodes.Success, effectivePorts);
+    }
+
+    /// <summary>
+    /// Resolves the <see cref="CliExecutionContext.IdentityChannel"/> into a channel name
+    /// safe to persist into <c>aspire.config.json#channel</c>. Returns <c>null</c> when:
+    /// <list type="bullet">
+    /// <item><description>The identity is empty (no channel context).</description></item>
+    /// <item><description>The identity doesn't match any registered channel (e.g. <c>local</c>,
+    /// <c>staging</c> on a CLI without the staging feature flag, or a stale <c>pr-{N}</c> on a
+    /// machine without the matching hive). Persisting these would pin a name no PSM rule can
+    /// satisfy and zero out polyglot <c>aspire add</c> discovery via
+    /// <c>IntegrationPackageSearchService.cs</c> line 28-30.</description></item>
+    /// <item><description>The matched channel is <see cref="PackageChannelType.Implicit"/>
+    /// (e.g. <c>stable</c> → nuget.org). Implicit channels should not be persisted so
+    /// downstream commands fall back to the default aggregated-source behavior — pinning
+    /// <c>stable</c> on a polyglot AppHost is the regression tracked by
+    /// https://github.com/microsoft/aspire/issues/17295.</description></item>
+    /// </list>
+    /// Mirrors the resolution logic in <c>NewCommand.cs:316-402</c> and the warning in
+    /// <c>ScaffoldingService.cs:84-92</c> against falling back to <c>IdentityChannel</c> blindly.
+    /// </summary>
+    private async Task<string?> ResolvePersistableChannelNameAsync(CancellationToken cancellationToken)
+    {
+        var identityChannel = _executionContext.IdentityChannel;
+        if (string.IsNullOrWhiteSpace(identityChannel))
+        {
+            return null;
+        }
+
+        IEnumerable<PackageChannel> channels;
+        try
+        {
+            channels = await _packagingService.GetChannelsAsync(cancellationToken, identityChannel);
+        }
+        catch (Exception)
+        {
+            // Channel discovery is best-effort here — failing to resolve must not break
+            // `aspire init`. Skip persistence and let downstream commands re-resolve.
+            return null;
+        }
+
+        var match = channels.FirstOrDefault(c => string.Equals(c.Name, identityChannel, StringComparisons.ChannelName));
+        return match?.Type is PackageChannelType.Explicit ? match.Name : null;
+    }
+
+    /// <summary>
+    /// Best-effort read of the persisted channel from <c>aspire.config.json</c> in
+    /// <paramref name="directory"/>. Used by the polyglot path to avoid overwriting a
+    /// user-edited value via <c>ScaffoldingService</c>, which writes the context channel
+    /// unconditionally. Returns <c>null</c> if the file is absent, unparseable, or has
+    /// no <c>channel</c> key — those cases all mean "no user-set value to preserve".
+    /// </summary>
+    private static string? TryLoadExistingChannel(DirectoryInfo directory)
+    {
+        try
+        {
+            return AspireConfigFile.Load(directory.FullName)?.Channel;
+        }
+        catch
+        {
+            return null;
+        }
     }
 
     // Best-effort extraction of the dashboard / OTLP / resource service ports from an

--- a/src/Aspire.Cli/Packaging/PackageChannel.cs
+++ b/src/Aspire.Cli/Packaging/PackageChannel.cs
@@ -34,6 +34,9 @@ internal class PackageChannel(string name, PackageChannelQuality quality, Packag
 
     public string SourceDetails { get; } = ComputeSourceDetails(mappings);
 
+    public bool ShouldPersistChannelName() =>
+        Type is PackageChannelType.Explicit && !string.Equals(Name, PackageChannelNames.Stable, StringComparisons.ChannelName);
+
     private static string ComputeSourceDetails(PackageMapping[]? mappings)
     {
         if (mappings is null)

--- a/src/Aspire.Cli/Projects/GuestAppHostProject.cs
+++ b/src/Aspire.Cli/Projects/GuestAppHostProject.cs
@@ -1375,7 +1375,7 @@ internal sealed class GuestAppHostProject : IAppHostProject, IGuestAppHostSdkGen
                 return packageUpdates;
             });
 
-        var explicitChannelName = context.Channel.Type == Packaging.PackageChannelType.Explicit ? context.Channel.Name : null;
+        var explicitChannelName = context.Channel.ShouldPersistChannelName() ? context.Channel.Name : null;
         var explicitChannelChanged = explicitChannelName is not null && !string.Equals(config.Channel, explicitChannelName, StringComparisons.CliInputOrOutput);
 
         if (updates.Count == 0 && newSdkVersion is null)
@@ -1413,11 +1413,11 @@ internal sealed class GuestAppHostProject : IAppHostProject, IGuestAppHostSdkGen
         {
             config.SdkVersion = newSdkVersion;
         }
-        // Persist the channel when update resolved an explicit channel. That can come from
-        // --channel, per-project/global config, prompt selection, or the UpdateCommand
-        // identity-channel fallback for non-project-reference AppHosts. When the resolved
-        // channel is Implicit — i.e. no explicit channel source matched — leave the project's
-        // existing setting untouched rather than pinning the implicit/default channel.
+        // Persist the channel when update resolved a non-stable explicit channel. That can
+        // come from --channel, per-project/global config, prompt selection, or the
+        // UpdateCommand identity-channel fallback for non-project-reference AppHosts. When
+        // the resolved channel is Implicit or stable, leave the project's existing setting
+        // untouched rather than pinning the default public-feed behavior.
         if (explicitChannelName is not null)
         {
             config.Channel = explicitChannelName;

--- a/src/Aspire.Cli/Projects/ProjectUpdater.cs
+++ b/src/Aspire.Cli/Projects/ProjectUpdater.cs
@@ -66,15 +66,12 @@ internal sealed partial class ProjectUpdater(ILogger<ProjectUpdater> logger, IDo
             interactionService.DisplayEmptyLine();
         }
 
-        // Display any channel-pin updates (aspire.config.json#channel) so users see them in the
-        // pre-confirmation summary alongside package updates.
-        var channelUpdateSteps = updateSteps.OfType<ChannelUpdateStep>().ToList();
-        foreach (var channelStep in channelUpdateSteps)
+        // Display the channel-pin update (aspire.config.json#channel) so users see it in the
+        // pre-confirmation summary alongside package updates. At most one is ever enqueued
+        // because each `aspire update` invocation targets a single AppHost project.
+        if (updateSteps.OfType<ChannelUpdateStep>().SingleOrDefault() is { } channelUpdateStep)
         {
-            interactionService.DisplayMessage(KnownEmojis.Package, channelStep.GetFormattedDisplayText(), allowMarkup: true);
-        }
-        if (channelUpdateSteps.Count > 0)
-        {
+            interactionService.DisplayMessage(KnownEmojis.Package, channelUpdateStep.GetFormattedDisplayText(), allowMarkup: true);
             interactionService.DisplayEmptyLine();
         }
 

--- a/src/Aspire.Cli/Projects/ProjectUpdater.cs
+++ b/src/Aspire.Cli/Projects/ProjectUpdater.cs
@@ -6,6 +6,7 @@ using System.Globalization;
 using System.Text.Json;
 using System.Text.RegularExpressions;
 using System.Xml;
+using Aspire.Cli.Configuration;
 using Aspire.Cli.DotNet;
 using Aspire.Cli.Interaction;
 using Aspire.Cli.Packaging;
@@ -62,6 +63,18 @@ internal sealed partial class ProjectUpdater(ILogger<ProjectUpdater> logger, IDo
                 interactionService.DisplayMessage(KnownEmojis.Package, packageStep.GetFormattedDisplayText(), allowMarkup: true);
             }
 
+            interactionService.DisplayEmptyLine();
+        }
+
+        // Display any channel-pin updates (aspire.config.json#channel) so users see them in the
+        // pre-confirmation summary alongside package updates.
+        var channelUpdateSteps = updateSteps.OfType<ChannelUpdateStep>().ToList();
+        foreach (var channelStep in channelUpdateSteps)
+        {
+            interactionService.DisplayMessage(KnownEmojis.Package, channelStep.GetFormattedDisplayText(), allowMarkup: true);
+        }
+        if (channelUpdateSteps.Count > 0)
+        {
             interactionService.DisplayEmptyLine();
         }
 
@@ -199,6 +212,44 @@ internal sealed partial class ProjectUpdater(ILogger<ProjectUpdater> logger, IDo
         while (context.AnalyzeSteps.TryDequeue(out var analyzeStep))
         {
             await analyzeStep.Callback();
+        }
+
+        // Persist the project's channel pin into aspire.config.json when the user picked an
+        // Explicit channel that differs from the currently-persisted value. Mirrors the polyglot
+        // path's behavior in `GuestAppHostProject.UpdatePackagesInternalAsync`. Implicit channels
+        // are intentionally NOT persisted (no pinning of the "default" channel).
+        //
+        // aspire.config.json lives next to the AppHost project file:
+        //   - C# single-file init: <dir>/apphost.cs + <dir>/aspire.config.json
+        //   - C# project-mode (aspire-apphost template): <dir>/MyApp.AppHost.csproj + <dir>/aspire.config.json
+        // If no aspire.config.json is present (legacy split layouts), the rewrite is skipped.
+        if (channel.Type == PackageChannelType.Explicit && projectFile.Directory is { } projectDirectory)
+        {
+            var existingConfig = AspireConfigFile.Load(projectDirectory.FullName);
+            var existingChannel = existingConfig?.Channel;
+
+            if (!string.Equals(existingChannel, channel.Name, StringComparisons.CliInputOrOutput))
+            {
+                var description = string.Format(
+                    CultureInfo.InvariantCulture,
+                    UpdateCommandStrings.UpdateChannelStepDescriptionFormat,
+                    existingChannel ?? UpdateCommandStrings.ChannelNonePlaceholder,
+                    channel.Name);
+
+                context.UpdateSteps.Enqueue(new ChannelUpdateStep(
+                    description,
+                    () =>
+                    {
+                        // Re-load inside the callback so we don't race with anything else that may
+                        // have rewritten aspire.config.json between analysis and apply.
+                        var configToSave = AspireConfigFile.LoadOrCreate(projectDirectory.FullName);
+                        configToSave.Channel = channel.Name;
+                        configToSave.Save(projectDirectory.FullName);
+                        return Task.CompletedTask;
+                    },
+                    existingChannel,
+                    channel.Name));
+            }
         }
 
         return (context.UpdateSteps, context.FallbackParsing);
@@ -1411,6 +1462,26 @@ internal record PackageUpdateStep(
     public override string GetFormattedDisplayText()
     {
         return $"[bold yellow]{PackageId.EscapeMarkup()}[/] [bold green]{CurrentVersion.EscapeMarkup()}[/] to [bold green]{NewVersion.EscapeMarkup()}[/]";
+    }
+}
+
+/// <summary>
+/// Represents an update step that rewrites <c>aspire.config.json#channel</c> when the
+/// resolved update channel differs from the project's currently-pinned channel. Mirrors
+/// the polyglot path's channel persistence in <c>GuestAppHostProject.UpdatePackagesInternalAsync</c>.
+/// </summary>
+internal record ChannelUpdateStep(
+    string Description,
+    Func<Task> Callback,
+    string? CurrentChannel,
+    string NewChannel) : UpdateStep(Description, Callback)
+{
+    public override string GetFormattedDisplayText()
+    {
+        var current = string.IsNullOrEmpty(CurrentChannel)
+            ? $"[grey]{UpdateCommandStrings.ChannelNonePlaceholder.EscapeMarkup()}[/]"
+            : $"[bold green]{CurrentChannel.EscapeMarkup()}[/]";
+        return $"[bold yellow]aspire.config.json#channel[/] {current} to [bold green]{NewChannel.EscapeMarkup()}[/]";
     }
 }
 

--- a/src/Aspire.Cli/Projects/ProjectUpdater.cs
+++ b/src/Aspire.Cli/Projects/ProjectUpdater.cs
@@ -215,9 +215,10 @@ internal sealed partial class ProjectUpdater(ILogger<ProjectUpdater> logger, IDo
         }
 
         // Persist the project's channel pin into aspire.config.json when the user picked an
-        // Explicit channel that differs from the currently-persisted value. Mirrors the polyglot
-        // path's behavior in `GuestAppHostProject.UpdatePackagesInternalAsync`. Implicit channels
-        // are intentionally NOT persisted (no pinning of the "default" channel).
+        // persistable Explicit channel that differs from the currently-persisted value. Mirrors
+        // the polyglot path's behavior in `GuestAppHostProject.UpdatePackagesAsync`.
+        // Implicit channels and `stable` are intentionally NOT persisted (no pinning of the
+        // default public-feed behavior).
         //
         // aspire.config.json lives next to the AppHost project file:
         //   - C# single-file init: <dir>/apphost.cs + <dir>/aspire.config.json
@@ -225,7 +226,7 @@ internal sealed partial class ProjectUpdater(ILogger<ProjectUpdater> logger, IDo
         // If no aspire.config.json is present (legacy split layouts or pre-init projects),
         // skip the rewrite — `aspire update` must not create a fresh aspire.config.json for a
         // project that never had one; that is the responsibility of `aspire init`.
-        if (channel.Type == PackageChannelType.Explicit && projectFile.Directory is { } projectDirectory)
+        if (channel.ShouldPersistChannelName() && projectFile.Directory is { } projectDirectory)
         {
             var existingConfig = AspireConfigFile.Load(projectDirectory.FullName);
             if (existingConfig is not null)

--- a/src/Aspire.Cli/Projects/ProjectUpdater.cs
+++ b/src/Aspire.Cli/Projects/ProjectUpdater.cs
@@ -222,33 +222,44 @@ internal sealed partial class ProjectUpdater(ILogger<ProjectUpdater> logger, IDo
         // aspire.config.json lives next to the AppHost project file:
         //   - C# single-file init: <dir>/apphost.cs + <dir>/aspire.config.json
         //   - C# project-mode (aspire-apphost template): <dir>/MyApp.AppHost.csproj + <dir>/aspire.config.json
-        // If no aspire.config.json is present (legacy split layouts), the rewrite is skipped.
+        // If no aspire.config.json is present (legacy split layouts or pre-init projects),
+        // skip the rewrite — `aspire update` must not create a fresh aspire.config.json for a
+        // project that never had one; that is the responsibility of `aspire init`.
         if (channel.Type == PackageChannelType.Explicit && projectFile.Directory is { } projectDirectory)
         {
             var existingConfig = AspireConfigFile.Load(projectDirectory.FullName);
-            var existingChannel = existingConfig?.Channel;
-
-            if (!string.Equals(existingChannel, channel.Name, StringComparisons.CliInputOrOutput))
+            if (existingConfig is not null)
             {
-                var description = string.Format(
-                    CultureInfo.InvariantCulture,
-                    UpdateCommandStrings.UpdateChannelStepDescriptionFormat,
-                    existingChannel ?? UpdateCommandStrings.ChannelNonePlaceholder,
-                    channel.Name);
+                var existingChannel = existingConfig.Channel;
+                if (!string.Equals(existingChannel, channel.Name, StringComparisons.CliInputOrOutput))
+                {
+                    var description = string.Format(
+                        CultureInfo.InvariantCulture,
+                        UpdateCommandStrings.UpdateChannelStepDescriptionFormat,
+                        existingChannel ?? UpdateCommandStrings.ChannelNonePlaceholder,
+                        channel.Name);
 
-                context.UpdateSteps.Enqueue(new ChannelUpdateStep(
-                    description,
-                    () =>
-                    {
-                        // Re-load inside the callback so we don't race with anything else that may
-                        // have rewritten aspire.config.json between analysis and apply.
-                        var configToSave = AspireConfigFile.LoadOrCreate(projectDirectory.FullName);
-                        configToSave.Channel = channel.Name;
-                        configToSave.Save(projectDirectory.FullName);
-                        return Task.CompletedTask;
-                    },
-                    existingChannel,
-                    channel.Name));
+                    context.UpdateSteps.Enqueue(new ChannelUpdateStep(
+                        description,
+                        () =>
+                        {
+                            // Re-load inside the callback so we don't race with anything else that may
+                            // have rewritten aspire.config.json between analysis and apply. The file
+                            // was confirmed present above; `Load` returning null here would only
+                            // happen if it was deleted mid-update, in which case we skip the rewrite
+                            // rather than recreate the file behind the user's back.
+                            var configToSave = AspireConfigFile.Load(projectDirectory.FullName);
+                            if (configToSave is null)
+                            {
+                                return Task.CompletedTask;
+                            }
+                            configToSave.Channel = channel.Name;
+                            configToSave.Save(projectDirectory.FullName);
+                            return Task.CompletedTask;
+                        },
+                        existingChannel,
+                        channel.Name));
+                }
             }
         }
 

--- a/src/Aspire.Cli/Resources/UpdateCommandStrings.Designer.cs
+++ b/src/Aspire.Cli/Resources/UpdateCommandStrings.Designer.cs
@@ -100,6 +100,8 @@ namespace Aspire.Cli.Resources {
     internal static string MappingRemovedFormat => ResourceManager.GetString("MappingRemovedFormat", resourceCulture);
     internal static string MappingRetainedFormat => ResourceManager.GetString("MappingRetainedFormat", resourceCulture);
     internal static string FallbackParsingWarning => ResourceManager.GetString("FallbackParsingWarning", resourceCulture);
+    internal static string UpdateChannelStepDescriptionFormat => ResourceManager.GetString("UpdateChannelStepDescriptionFormat", resourceCulture);
+    internal static string ChannelNonePlaceholder => ResourceManager.GetString("ChannelNonePlaceholder", resourceCulture);
     internal static string NoAppHostFoundUpdateCliPrompt => ResourceManager.GetString("NoAppHostFoundUpdateCliPrompt", resourceCulture);
     internal static string UpdateCliAfterProjectUpdatePrompt => ResourceManager.GetString("UpdateCliAfterProjectUpdatePrompt", resourceCulture);
     internal static string UpdateCliBeforeGuestProjectUpdatePrompt => ResourceManager.GetString("UpdateCliBeforeGuestProjectUpdatePrompt", resourceCulture);

--- a/src/Aspire.Cli/Resources/UpdateCommandStrings.resx
+++ b/src/Aspire.Cli/Resources/UpdateCommandStrings.resx
@@ -117,6 +117,14 @@
   <data name="FallbackParsingWarning" xml:space="preserve">
     <value>Note: Update plan generated using fallback parsing due to unresolvable AppHost SDK. Dependency analysis may have reduced accuracy.</value>
   </data>
+  <data name="UpdateChannelStepDescriptionFormat" xml:space="preserve">
+    <value>Update aspire.config.json channel from '{0}' to '{1}'</value>
+    <comment>{0} = current channel name (or '(none)' if absent). {1} = new channel name.</comment>
+  </data>
+  <data name="ChannelNonePlaceholder" xml:space="preserve">
+    <value>(none)</value>
+    <comment>Displayed in place of the current channel value when aspire.config.json has no channel pinned.</comment>
+  </data>
   <data name="NoAppHostFoundUpdateCliPrompt" xml:space="preserve">
     <value>No Aspire AppHost project found. Would you like to update the Aspire CLI instead?</value>
   </data>

--- a/src/Aspire.Cli/Resources/xlf/UpdateCommandStrings.cs.xlf
+++ b/src/Aspire.Cli/Resources/xlf/UpdateCommandStrings.cs.xlf
@@ -42,6 +42,11 @@
         <target state="translated">Centrální správa balíčků není v současné době přes aspire update podporována.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ChannelNonePlaceholder">
+        <source>(none)</source>
+        <target state="new">(none)</target>
+        <note>Displayed in place of the current channel value when aspire.config.json has no channel pinned.</note>
+      </trans-unit>
       <trans-unit id="ChannelOptionDescription">
         <source>Channel to update to (stable, daily)</source>
         <target state="translated">Kanál, na který se má aktualizovat (stabilní, denní)</target>
@@ -266,6 +271,11 @@
         <source>Unexpected code path.</source>
         <target state="translated">Neočekávaná cesta kódu.</target>
         <note />
+      </trans-unit>
+      <trans-unit id="UpdateChannelStepDescriptionFormat">
+        <source>Update aspire.config.json channel from '{0}' to '{1}'</source>
+        <target state="new">Update aspire.config.json channel from '{0}' to '{1}'</target>
+        <note>{0} = current channel name (or '(none)' if absent). {1} = new channel name.</note>
       </trans-unit>
       <trans-unit id="UpdateCliAfterProjectUpdatePrompt">
         <source>An update is available for the Aspire CLI. Would you like to update it now?</source>

--- a/src/Aspire.Cli/Resources/xlf/UpdateCommandStrings.de.xlf
+++ b/src/Aspire.Cli/Resources/xlf/UpdateCommandStrings.de.xlf
@@ -42,6 +42,11 @@
         <target state="translated">Die zentrale Paketverwaltung wird von „aspire update“ zurzeit nicht unterstützt.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ChannelNonePlaceholder">
+        <source>(none)</source>
+        <target state="new">(none)</target>
+        <note>Displayed in place of the current channel value when aspire.config.json has no channel pinned.</note>
+      </trans-unit>
       <trans-unit id="ChannelOptionDescription">
         <source>Channel to update to (stable, daily)</source>
         <target state="translated">Kanal, auf den aktualisiert werden soll (stable, daily)</target>
@@ -266,6 +271,11 @@
         <source>Unexpected code path.</source>
         <target state="translated">Unerwarteter Codepfad</target>
         <note />
+      </trans-unit>
+      <trans-unit id="UpdateChannelStepDescriptionFormat">
+        <source>Update aspire.config.json channel from '{0}' to '{1}'</source>
+        <target state="new">Update aspire.config.json channel from '{0}' to '{1}'</target>
+        <note>{0} = current channel name (or '(none)' if absent). {1} = new channel name.</note>
       </trans-unit>
       <trans-unit id="UpdateCliAfterProjectUpdatePrompt">
         <source>An update is available for the Aspire CLI. Would you like to update it now?</source>

--- a/src/Aspire.Cli/Resources/xlf/UpdateCommandStrings.es.xlf
+++ b/src/Aspire.Cli/Resources/xlf/UpdateCommandStrings.es.xlf
@@ -42,6 +42,11 @@
         <target state="translated">La administración central de paquetes no es compatible actualmente con "aspire update".</target>
         <note />
       </trans-unit>
+      <trans-unit id="ChannelNonePlaceholder">
+        <source>(none)</source>
+        <target state="new">(none)</target>
+        <note>Displayed in place of the current channel value when aspire.config.json has no channel pinned.</note>
+      </trans-unit>
       <trans-unit id="ChannelOptionDescription">
         <source>Channel to update to (stable, daily)</source>
         <target state="translated">Canal al que actualizar (estable, diario)</target>
@@ -266,6 +271,11 @@
         <source>Unexpected code path.</source>
         <target state="translated">Ruta de acceso al código inesperada.</target>
         <note />
+      </trans-unit>
+      <trans-unit id="UpdateChannelStepDescriptionFormat">
+        <source>Update aspire.config.json channel from '{0}' to '{1}'</source>
+        <target state="new">Update aspire.config.json channel from '{0}' to '{1}'</target>
+        <note>{0} = current channel name (or '(none)' if absent). {1} = new channel name.</note>
       </trans-unit>
       <trans-unit id="UpdateCliAfterProjectUpdatePrompt">
         <source>An update is available for the Aspire CLI. Would you like to update it now?</source>

--- a/src/Aspire.Cli/Resources/xlf/UpdateCommandStrings.fr.xlf
+++ b/src/Aspire.Cli/Resources/xlf/UpdateCommandStrings.fr.xlf
@@ -42,6 +42,11 @@
         <target state="translated">Actuellement, la gestion centralisée des packages n’est pas prise en charge par « aspire update ».</target>
         <note />
       </trans-unit>
+      <trans-unit id="ChannelNonePlaceholder">
+        <source>(none)</source>
+        <target state="new">(none)</target>
+        <note>Displayed in place of the current channel value when aspire.config.json has no channel pinned.</note>
+      </trans-unit>
       <trans-unit id="ChannelOptionDescription">
         <source>Channel to update to (stable, daily)</source>
         <target state="translated">Canal vers lequel effectuer une mise à jour (stable, quotidien)</target>
@@ -266,6 +271,11 @@
         <source>Unexpected code path.</source>
         <target state="translated">Chemin de code inattendu.</target>
         <note />
+      </trans-unit>
+      <trans-unit id="UpdateChannelStepDescriptionFormat">
+        <source>Update aspire.config.json channel from '{0}' to '{1}'</source>
+        <target state="new">Update aspire.config.json channel from '{0}' to '{1}'</target>
+        <note>{0} = current channel name (or '(none)' if absent). {1} = new channel name.</note>
       </trans-unit>
       <trans-unit id="UpdateCliAfterProjectUpdatePrompt">
         <source>An update is available for the Aspire CLI. Would you like to update it now?</source>

--- a/src/Aspire.Cli/Resources/xlf/UpdateCommandStrings.it.xlf
+++ b/src/Aspire.Cli/Resources/xlf/UpdateCommandStrings.it.xlf
@@ -42,6 +42,11 @@
         <target state="translated">La gestione centralizzata dei pacchetti non è attualmente supportata da "aspire update".</target>
         <note />
       </trans-unit>
+      <trans-unit id="ChannelNonePlaceholder">
+        <source>(none)</source>
+        <target state="new">(none)</target>
+        <note>Displayed in place of the current channel value when aspire.config.json has no channel pinned.</note>
+      </trans-unit>
       <trans-unit id="ChannelOptionDescription">
         <source>Channel to update to (stable, daily)</source>
         <target state="translated">Canale da aggiornare a (stabile, giornaliero)</target>
@@ -266,6 +271,11 @@
         <source>Unexpected code path.</source>
         <target state="translated">Percorso del codice imprevisto.</target>
         <note />
+      </trans-unit>
+      <trans-unit id="UpdateChannelStepDescriptionFormat">
+        <source>Update aspire.config.json channel from '{0}' to '{1}'</source>
+        <target state="new">Update aspire.config.json channel from '{0}' to '{1}'</target>
+        <note>{0} = current channel name (or '(none)' if absent). {1} = new channel name.</note>
       </trans-unit>
       <trans-unit id="UpdateCliAfterProjectUpdatePrompt">
         <source>An update is available for the Aspire CLI. Would you like to update it now?</source>

--- a/src/Aspire.Cli/Resources/xlf/UpdateCommandStrings.ja.xlf
+++ b/src/Aspire.Cli/Resources/xlf/UpdateCommandStrings.ja.xlf
@@ -42,6 +42,11 @@
         <target state="translated">現在、中央パッケージ管理では、'aspire update' によるサポートがありません。</target>
         <note />
       </trans-unit>
+      <trans-unit id="ChannelNonePlaceholder">
+        <source>(none)</source>
+        <target state="new">(none)</target>
+        <note>Displayed in place of the current channel value when aspire.config.json has no channel pinned.</note>
+      </trans-unit>
       <trans-unit id="ChannelOptionDescription">
         <source>Channel to update to (stable, daily)</source>
         <target state="translated">更新先のチャネル (安定、毎日)</target>
@@ -266,6 +271,11 @@
         <source>Unexpected code path.</source>
         <target state="translated">予期しないコード パスです。</target>
         <note />
+      </trans-unit>
+      <trans-unit id="UpdateChannelStepDescriptionFormat">
+        <source>Update aspire.config.json channel from '{0}' to '{1}'</source>
+        <target state="new">Update aspire.config.json channel from '{0}' to '{1}'</target>
+        <note>{0} = current channel name (or '(none)' if absent). {1} = new channel name.</note>
       </trans-unit>
       <trans-unit id="UpdateCliAfterProjectUpdatePrompt">
         <source>An update is available for the Aspire CLI. Would you like to update it now?</source>

--- a/src/Aspire.Cli/Resources/xlf/UpdateCommandStrings.ko.xlf
+++ b/src/Aspire.Cli/Resources/xlf/UpdateCommandStrings.ko.xlf
@@ -42,6 +42,11 @@
         <target state="translated">중앙 패키지 관리는 현재 'aspire update'에서 지원되지 않습니다.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ChannelNonePlaceholder">
+        <source>(none)</source>
+        <target state="new">(none)</target>
+        <note>Displayed in place of the current channel value when aspire.config.json has no channel pinned.</note>
+      </trans-unit>
       <trans-unit id="ChannelOptionDescription">
         <source>Channel to update to (stable, daily)</source>
         <target state="translated">업데이트할 채널(안정, 데일리)</target>
@@ -266,6 +271,11 @@
         <source>Unexpected code path.</source>
         <target state="translated">예기치 않은 코드 경로입니다.</target>
         <note />
+      </trans-unit>
+      <trans-unit id="UpdateChannelStepDescriptionFormat">
+        <source>Update aspire.config.json channel from '{0}' to '{1}'</source>
+        <target state="new">Update aspire.config.json channel from '{0}' to '{1}'</target>
+        <note>{0} = current channel name (or '(none)' if absent). {1} = new channel name.</note>
       </trans-unit>
       <trans-unit id="UpdateCliAfterProjectUpdatePrompt">
         <source>An update is available for the Aspire CLI. Would you like to update it now?</source>

--- a/src/Aspire.Cli/Resources/xlf/UpdateCommandStrings.pl.xlf
+++ b/src/Aspire.Cli/Resources/xlf/UpdateCommandStrings.pl.xlf
@@ -42,6 +42,11 @@
         <target state="translated">Centralne zarządzanie pakietami nie jest obecnie obsługiwane przez „aktualizację Aspire”.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ChannelNonePlaceholder">
+        <source>(none)</source>
+        <target state="new">(none)</target>
+        <note>Displayed in place of the current channel value when aspire.config.json has no channel pinned.</note>
+      </trans-unit>
       <trans-unit id="ChannelOptionDescription">
         <source>Channel to update to (stable, daily)</source>
         <target state="translated">Kanał, do którego należy zaktualizować (stabilny, dzienny)</target>
@@ -266,6 +271,11 @@
         <source>Unexpected code path.</source>
         <target state="translated">Nieoczekiwana ścieżka w kodzie.</target>
         <note />
+      </trans-unit>
+      <trans-unit id="UpdateChannelStepDescriptionFormat">
+        <source>Update aspire.config.json channel from '{0}' to '{1}'</source>
+        <target state="new">Update aspire.config.json channel from '{0}' to '{1}'</target>
+        <note>{0} = current channel name (or '(none)' if absent). {1} = new channel name.</note>
       </trans-unit>
       <trans-unit id="UpdateCliAfterProjectUpdatePrompt">
         <source>An update is available for the Aspire CLI. Would you like to update it now?</source>

--- a/src/Aspire.Cli/Resources/xlf/UpdateCommandStrings.pt-BR.xlf
+++ b/src/Aspire.Cli/Resources/xlf/UpdateCommandStrings.pt-BR.xlf
@@ -42,6 +42,11 @@
         <target state="translated">No momento, o gerenciamento central de pacotes por “atualização de atualização” não ´possui suporte.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ChannelNonePlaceholder">
+        <source>(none)</source>
+        <target state="new">(none)</target>
+        <note>Displayed in place of the current channel value when aspire.config.json has no channel pinned.</note>
+      </trans-unit>
       <trans-unit id="ChannelOptionDescription">
         <source>Channel to update to (stable, daily)</source>
         <target state="translated">Canal para o qual atualizar (estável, diariamente)</target>
@@ -266,6 +271,11 @@
         <source>Unexpected code path.</source>
         <target state="translated">Caminho de código inesperado.</target>
         <note />
+      </trans-unit>
+      <trans-unit id="UpdateChannelStepDescriptionFormat">
+        <source>Update aspire.config.json channel from '{0}' to '{1}'</source>
+        <target state="new">Update aspire.config.json channel from '{0}' to '{1}'</target>
+        <note>{0} = current channel name (or '(none)' if absent). {1} = new channel name.</note>
       </trans-unit>
       <trans-unit id="UpdateCliAfterProjectUpdatePrompt">
         <source>An update is available for the Aspire CLI. Would you like to update it now?</source>

--- a/src/Aspire.Cli/Resources/xlf/UpdateCommandStrings.ru.xlf
+++ b/src/Aspire.Cli/Resources/xlf/UpdateCommandStrings.ru.xlf
@@ -42,6 +42,11 @@
         <target state="translated">Централизованное управление пакетами в настоящее время не поддерживается функцией "обновление Aspire".</target>
         <note />
       </trans-unit>
+      <trans-unit id="ChannelNonePlaceholder">
+        <source>(none)</source>
+        <target state="new">(none)</target>
+        <note>Displayed in place of the current channel value when aspire.config.json has no channel pinned.</note>
+      </trans-unit>
       <trans-unit id="ChannelOptionDescription">
         <source>Channel to update to (stable, daily)</source>
         <target state="translated">Канал для обновления (стабильный, ежедневный)</target>
@@ -266,6 +271,11 @@
         <source>Unexpected code path.</source>
         <target state="translated">Непредвиденный путь к коду.</target>
         <note />
+      </trans-unit>
+      <trans-unit id="UpdateChannelStepDescriptionFormat">
+        <source>Update aspire.config.json channel from '{0}' to '{1}'</source>
+        <target state="new">Update aspire.config.json channel from '{0}' to '{1}'</target>
+        <note>{0} = current channel name (or '(none)' if absent). {1} = new channel name.</note>
       </trans-unit>
       <trans-unit id="UpdateCliAfterProjectUpdatePrompt">
         <source>An update is available for the Aspire CLI. Would you like to update it now?</source>

--- a/src/Aspire.Cli/Resources/xlf/UpdateCommandStrings.tr.xlf
+++ b/src/Aspire.Cli/Resources/xlf/UpdateCommandStrings.tr.xlf
@@ -42,6 +42,11 @@
         <target state="translated">Merkezi paket yönetimi şu anda 'aspire update' tarafından desteklenmiyor.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ChannelNonePlaceholder">
+        <source>(none)</source>
+        <target state="new">(none)</target>
+        <note>Displayed in place of the current channel value when aspire.config.json has no channel pinned.</note>
+      </trans-unit>
       <trans-unit id="ChannelOptionDescription">
         <source>Channel to update to (stable, daily)</source>
         <target state="translated">Güncelleştirme yapılacak kanal (kararlı, günlük)</target>
@@ -266,6 +271,11 @@
         <source>Unexpected code path.</source>
         <target state="translated">Beklenmeyen kod yolu.</target>
         <note />
+      </trans-unit>
+      <trans-unit id="UpdateChannelStepDescriptionFormat">
+        <source>Update aspire.config.json channel from '{0}' to '{1}'</source>
+        <target state="new">Update aspire.config.json channel from '{0}' to '{1}'</target>
+        <note>{0} = current channel name (or '(none)' if absent). {1} = new channel name.</note>
       </trans-unit>
       <trans-unit id="UpdateCliAfterProjectUpdatePrompt">
         <source>An update is available for the Aspire CLI. Would you like to update it now?</source>

--- a/src/Aspire.Cli/Resources/xlf/UpdateCommandStrings.zh-Hans.xlf
+++ b/src/Aspire.Cli/Resources/xlf/UpdateCommandStrings.zh-Hans.xlf
@@ -42,6 +42,11 @@
         <target state="translated">"aspire update" 当前不支持中央包管理。</target>
         <note />
       </trans-unit>
+      <trans-unit id="ChannelNonePlaceholder">
+        <source>(none)</source>
+        <target state="new">(none)</target>
+        <note>Displayed in place of the current channel value when aspire.config.json has no channel pinned.</note>
+      </trans-unit>
       <trans-unit id="ChannelOptionDescription">
         <source>Channel to update to (stable, daily)</source>
         <target state="translated">要更新到的频道(稳定，每日)</target>
@@ -266,6 +271,11 @@
         <source>Unexpected code path.</source>
         <target state="translated">意外的代码路径。</target>
         <note />
+      </trans-unit>
+      <trans-unit id="UpdateChannelStepDescriptionFormat">
+        <source>Update aspire.config.json channel from '{0}' to '{1}'</source>
+        <target state="new">Update aspire.config.json channel from '{0}' to '{1}'</target>
+        <note>{0} = current channel name (or '(none)' if absent). {1} = new channel name.</note>
       </trans-unit>
       <trans-unit id="UpdateCliAfterProjectUpdatePrompt">
         <source>An update is available for the Aspire CLI. Would you like to update it now?</source>

--- a/src/Aspire.Cli/Resources/xlf/UpdateCommandStrings.zh-Hant.xlf
+++ b/src/Aspire.Cli/Resources/xlf/UpdateCommandStrings.zh-Hant.xlf
@@ -42,6 +42,11 @@
         <target state="translated">中央套件管理目前不受 'aspire update' 支援。</target>
         <note />
       </trans-unit>
+      <trans-unit id="ChannelNonePlaceholder">
+        <source>(none)</source>
+        <target state="new">(none)</target>
+        <note>Displayed in place of the current channel value when aspire.config.json has no channel pinned.</note>
+      </trans-unit>
       <trans-unit id="ChannelOptionDescription">
         <source>Channel to update to (stable, daily)</source>
         <target state="translated">要更新的通道 (穩定、每日)</target>
@@ -266,6 +271,11 @@
         <source>Unexpected code path.</source>
         <target state="translated">未預期的程式碼路徑。</target>
         <note />
+      </trans-unit>
+      <trans-unit id="UpdateChannelStepDescriptionFormat">
+        <source>Update aspire.config.json channel from '{0}' to '{1}'</source>
+        <target state="new">Update aspire.config.json channel from '{0}' to '{1}'</target>
+        <note>{0} = current channel name (or '(none)' if absent). {1} = new channel name.</note>
       </trans-unit>
       <trans-unit id="UpdateCliAfterProjectUpdatePrompt">
         <source>An update is available for the Aspire CLI. Would you like to update it now?</source>

--- a/src/Aspire.Cli/Scaffolding/ScaffoldingService.cs
+++ b/src/Aspire.Cli/Scaffolding/ScaffoldingService.cs
@@ -81,10 +81,15 @@ internal sealed class ScaffoldingService : IScaffoldingService
             config.SdkVersion = context.SdkVersion;
         }
 
-        // Persist the channel only when the caller explicitly resolved one (Explicit `--channel`,
-        // or NewCommand's identity-match against a registered Explicit channel — see
-        // `CliTemplateFactory.EmptyTemplate.cs` for how `ScaffoldContext.Channel` is sourced).
-        // Do NOT fall back to `CliExecutionContext.IdentityChannel`: an identity that isn't a
+        // Persist the channel only when the caller explicitly resolved one. Callers must validate
+        // the channel against the registered `IPackagingService` channels and only pass an Explicit
+        // channel name. Today that means either:
+        //   - an explicit `--channel` flag,
+        //   - NewCommand's identity-match against a registered Explicit channel (see
+        //     `CliTemplateFactory.EmptyTemplate.cs` for how `ScaffoldContext.Channel` is sourced),
+        //   - InitCommand's polyglot path resolving `CliExecutionContext.IdentityChannel` through
+        //     `IPackagingService.GetChannelsAsync` (see `InitCommand.ResolvePersistableChannelNameAsync`).
+        // Do NOT fall back to a raw `CliExecutionContext.IdentityChannel`: an identity that isn't a
         // registered channel (e.g. `staging` on a CLI without the staging feature flag, or `pr-<N>`
         // on a machine without the matching hive) would otherwise pin a channel name that no
         // PSM rule can satisfy. When unset, `PrebuiltAppHostServer` aggregates sources from

--- a/tests/Aspire.Cli.EndToEnd.Tests/ChannelUpdateWorkflowTests.cs
+++ b/tests/Aspire.Cli.EndToEnd.Tests/ChannelUpdateWorkflowTests.cs
@@ -10,7 +10,9 @@ using Xunit;
 namespace Aspire.Cli.EndToEnd.Tests;
 
 /// <summary>
-/// End-to-end test for the channel-update workflow on the polyglot/TypeScript path:
+/// End-to-end tests for the channel-update workflow.
+///
+/// The first test exercises the deep TypeScript path:
 /// <list type="number">
 ///   <item><description>Create a TypeScript empty AppHost on the CLI's baked channel.</description></item>
 ///   <item><description><c>aspire add</c> a package and verify the recorded version is non-stable.</description></item>
@@ -23,11 +25,18 @@ namespace Aspire.Cli.EndToEnd.Tests;
 ///     <c>aspire add</c> honors the project's configured channel).</description></item>
 ///   <item><description><c>aspire start</c> / <c>aspire stop</c> again to confirm the project still runs after the channel switch.</description></item>
 /// </list>
-/// The C# AppHost variant is intentionally not covered here: for C# projects, <c>aspire update</c>
-/// does not rewrite <c>aspire.config.json#channel</c>, and <c>aspire add</c> on PR/CI hives prefers
+///
+/// The remaining tests are lean regression guards for
+/// <see href="https://github.com/microsoft/aspire/issues/17295"/>: each scaffolds an AppHost via one of
+/// the four supported create paths (<c>aspire init</c> C#, <c>aspire new aspire-empty</c> C#,
+/// <c>aspire init --language typescript</c>, plus the TypeScript <c>aspire new</c> case already
+/// covered by the deep test above) and asserts that <c>aspire update --channel stable</c> rewrites
+/// <c>aspire.config.json#channel</c> to <c>"stable"</c>. Package-version assertions are intentionally
+/// scoped to the polyglot deep test only: for C# projects, <c>aspire add</c> on PR/CI hives prefers
 /// the package version that matches the running CLI build (the
 /// <c>VersionHelper.TryGetCurrentCliVersionMatch</c> branch in <c>AddCommand</c>), which deliberately
-/// overrides the channel choice for build coherence.
+/// overrides the channel choice for build coherence and would make a stable-version assertion flaky
+/// on C#.
 /// </summary>
 public sealed class ChannelUpdateWorkflowTests(ITestOutputHelper output)
 {
@@ -214,6 +223,243 @@ public sealed class ChannelUpdateWorkflowTests(ITestOutputHelper output)
         await auto.EnterAsync();
 
         await pendingRun;
+    }
+
+    // ----------------------------------------------------------------------------------
+    // Channel-rewrite regression guards for https://github.com/microsoft/aspire/issues/17295
+    //
+    // These four cells cover the create-paths × language matrix:
+    //   - C# `aspire init`             (single-file apphost.cs)        -> see test below
+    //   - C# `aspire new aspire-empty` (project-mode .csproj)          -> see test below
+    //   - TS `aspire init --language typescript --non-interactive`     -> see test below
+    //   - TS `aspire new aspire-ts-empty` (project-mode)               -> already covered by the
+    //                                                                     deep test above.
+    //
+    // Each new test asserts JUST the user-reported invariant:
+    // "after `aspire update --channel stable`, aspire.config.json#channel == 'stable'".
+    // Package version assertions are intentionally not duplicated here — see the class docstring.
+    // ----------------------------------------------------------------------------------
+
+    [Fact]
+    [CaptureWorkspaceOnFailure]
+    public async Task UpdateProjectChannelToStable_CSharpSingleFileInit_RewritesAspireConfigChannel()
+    {
+        var repoRoot = CliE2ETestHelpers.GetRepoRoot();
+        var strategy = CliInstallStrategy.Detect(output.WriteLine);
+        if (ShouldSkipForStableInitialChannel(strategy, out var skipReason))
+        {
+            Assert.Skip(skipReason);
+        }
+
+        var workspace = TemporaryWorkspace.Create(output);
+        var localChannel = CliE2ETestHelpers.PrepareLocalChannel(repoRoot, strategy,
+            ["Aspire.Hosting.AppHost."]);
+
+        using var terminal = CliE2ETestHelpers.CreateDockerTestTerminal(
+            repoRoot, strategy, output,
+            variant: CliE2ETestHelpers.DockerfileVariant.DotNet,
+            workspace: workspace);
+
+        var pendingRun = terminal.RunAsync(TestContext.Current.CancellationToken);
+
+        var counter = new SequenceCounter();
+        var auto = new Hex1bTerminalAutomator(terminal, defaultTimeout: TimeSpan.FromSeconds(500));
+
+        await auto.PrepareDockerEnvironmentAsync(counter, workspace);
+        await auto.InstallAspireCliAsync(strategy, counter);
+
+        // `aspire init` scaffolds into the current working directory — give it a fresh subfolder so
+        // the workspace root stays clean and the assertions target a well-known file path.
+        const string projectName = "ChannelUpdateCsharpInitApp";
+        var projectPath = Path.Combine(workspace.WorkspaceRoot.FullName, projectName);
+        Directory.CreateDirectory(projectPath);
+        await auto.RunCommandFailFastAsync($"cd {projectName}", counter);
+
+        await auto.AspireInitAsync(counter);
+
+        if (localChannel is not null)
+        {
+            CliE2ETestHelpers.WriteLocalChannelSettings(projectPath, localChannel.SdkVersion);
+        }
+
+        await RunChannelUpdateAndAssertAsync(auto, counter, Path.Combine(projectPath, "aspire.config.json"));
+
+        await auto.TypeAsync("exit");
+        await auto.EnterAsync();
+        await pendingRun;
+    }
+
+    [Fact]
+    [CaptureWorkspaceOnFailure]
+    public async Task UpdateProjectChannelToStable_CSharpEmptyAppHost_RewritesAspireConfigChannel()
+    {
+        var repoRoot = CliE2ETestHelpers.GetRepoRoot();
+        var strategy = CliInstallStrategy.Detect(output.WriteLine);
+        if (ShouldSkipForStableInitialChannel(strategy, out var skipReason))
+        {
+            Assert.Skip(skipReason);
+        }
+
+        var workspace = TemporaryWorkspace.Create(output);
+        var localChannel = CliE2ETestHelpers.PrepareLocalChannel(repoRoot, strategy,
+            ["Aspire.Hosting.AppHost."]);
+
+        using var terminal = CliE2ETestHelpers.CreateDockerTestTerminal(
+            repoRoot, strategy, output,
+            variant: CliE2ETestHelpers.DockerfileVariant.DotNet,
+            workspace: workspace);
+
+        var pendingRun = terminal.RunAsync(TestContext.Current.CancellationToken);
+
+        var counter = new SequenceCounter();
+        var auto = new Hex1bTerminalAutomator(terminal, defaultTimeout: TimeSpan.FromSeconds(500));
+
+        await auto.PrepareDockerEnvironmentAsync(counter, workspace);
+        await auto.InstallAspireCliAsync(strategy, counter);
+
+        const string projectName = "ChannelUpdateCsharpEmptyApp";
+        var projectPath = Path.Combine(workspace.WorkspaceRoot.FullName, projectName);
+
+        await auto.AspireNewCSharpEmptyAppHostAsync(projectName, counter);
+
+        if (localChannel is not null)
+        {
+            CliE2ETestHelpers.WriteLocalChannelSettings(projectPath, localChannel.SdkVersion);
+        }
+
+        await auto.RunCommandFailFastAsync($"cd {projectName}", counter);
+        await RunChannelUpdateAndAssertAsync(auto, counter, Path.Combine(projectPath, "aspire.config.json"));
+
+        await auto.TypeAsync("exit");
+        await auto.EnterAsync();
+        await pendingRun;
+    }
+
+    [Fact]
+    [CaptureWorkspaceOnFailure]
+    public async Task UpdateProjectChannelToStable_TypeScriptSingleFileInit_RewritesAspireConfigChannel()
+    {
+        var repoRoot = CliE2ETestHelpers.GetRepoRoot();
+        var strategy = CliInstallStrategy.Detect(output.WriteLine);
+        if (ShouldSkipForStableInitialChannel(strategy, out var skipReason))
+        {
+            Assert.Skip(skipReason);
+        }
+
+        var workspace = TemporaryWorkspace.Create(output);
+        var localChannel = CliE2ETestHelpers.PrepareLocalChannel(repoRoot, strategy,
+            ["Aspire.Hosting.CodeGeneration.TypeScript."]);
+
+        using var terminal = CliE2ETestHelpers.CreateDockerTestTerminal(
+            repoRoot, strategy, output,
+            variant: CliE2ETestHelpers.DockerfileVariant.Polyglot,
+            workspace: workspace);
+
+        var pendingRun = terminal.RunAsync(TestContext.Current.CancellationToken);
+
+        var counter = new SequenceCounter();
+        var auto = new Hex1bTerminalAutomator(terminal, defaultTimeout: TimeSpan.FromSeconds(500));
+
+        await auto.PrepareDockerEnvironmentAsync(counter, workspace);
+        await auto.InstallAspireCliAsync(strategy, counter);
+
+        // `aspire init` for TS scaffolds into the current directory — match the existing
+        // TypeScriptCodegenValidationTests pattern so a fresh subfolder is the working dir.
+        const string projectName = "ChannelUpdateTsInitApp";
+        var projectPath = Path.Combine(workspace.WorkspaceRoot.FullName, projectName);
+        Directory.CreateDirectory(projectPath);
+        await auto.RunCommandFailFastAsync($"cd {projectName}", counter);
+
+        await auto.TypeAsync("aspire init --language typescript --non-interactive");
+        await auto.EnterAsync();
+        await auto.WaitUntilTextAsync("Created apphost.mts", timeout: TimeSpan.FromMinutes(2));
+        await auto.WaitForSuccessPromptAsync(counter);
+
+        if (localChannel is not null)
+        {
+            CliE2ETestHelpers.WriteLocalChannelSettings(projectPath, localChannel.SdkVersion);
+        }
+
+        await RunChannelUpdateAndAssertAsync(auto, counter, Path.Combine(projectPath, "aspire.config.json"));
+
+        await auto.TypeAsync("exit");
+        await auto.EnterAsync();
+        await pendingRun;
+    }
+
+    /// <summary>
+    /// Shared skip-gate for the channel-rewrite regression tests: if the running CLI's baked channel
+    /// is already <c>stable</c> (e.g. a local install-script run with no quality/version override),
+    /// <c>aspire update --channel stable</c> would be a no-op and the prompts the test drives would
+    /// never appear. Returns <c>true</c> together with a human-readable reason in that case.
+    /// </summary>
+    private static bool ShouldSkipForStableInitialChannel(CliInstallStrategy strategy, out string reason)
+    {
+        if (strategy.Mode == CliInstallMode.InstallScript && strategy.Quality is null && strategy.Version is null)
+        {
+            reason =
+                "This test exercises 'aspire update --channel stable' from a non-stable channel. " +
+                "Run with ASPIRE_E2E_ARCHIVE (LocalHive), in CI (dev/staging quality), or against a " +
+                "specific non-stable build so the initial channel is non-stable.";
+            return true;
+        }
+
+        reason = string.Empty;
+        return false;
+    }
+
+    /// <summary>
+    /// Shared body for the channel-rewrite regression tests: snapshot the initial channel, suppress
+    /// the post-update CLI self-update prompt, drive <c>aspire update --channel stable</c>, then
+    /// assert that <c>aspire.config.json#channel</c> was rewritten to <c>"stable"</c>.
+    /// Assumes the automator is positioned in the project directory (containing aspire.config.json).
+    /// </summary>
+    private static async Task RunChannelUpdateAndAssertAsync(
+        Hex1bTerminalAutomator auto,
+        SequenceCounter counter,
+        string aspireConfigPath)
+    {
+        var initialChannel = ReadAspireConfigChannel(aspireConfigPath);
+        if (string.IsNullOrEmpty(initialChannel) ||
+            string.Equals(initialChannel, "stable", StringComparison.OrdinalIgnoreCase))
+        {
+            Assert.Skip(
+                $"Initial aspire.config.json#channel was '{initialChannel ?? "<null>"}'. " +
+                "This test requires a non-stable initial channel so 'aspire update --channel stable' has something to change.");
+        }
+
+        // Suppress the post-update CLI self-update prompt so it doesn't block waiting on
+        // "Update successful!". Pattern borrowed from the polyglot test above.
+        await auto.TypeAsync("aspire config set features.updateNotificationsEnabled false -g");
+        await auto.EnterAsync();
+        await auto.WaitForSuccessPromptAsync(counter);
+
+        try
+        {
+            // -y skips the "Perform updates?" confirm. For Explicit channels the C# path also prompts
+            // for a NuGet.config directory and a config-changes confirmation; on Polyglot only the
+            // "Perform updates?" prompt fires. Use -y plus a default --nuget-config-dir (current dir)
+            // so the test is identical across both languages.
+            await auto.TypeAsync("aspire update --channel stable -y --nuget-config-dir .");
+            await auto.EnterAsync();
+            await auto.WaitUntilTextAsync("Update successful!", timeout: TimeSpan.FromMinutes(3));
+            await auto.WaitForSuccessPromptAsync(counter);
+
+            var channelAfter = ReadAspireConfigChannel(aspireConfigPath);
+            Assert.Equal("stable", channelAfter);
+        }
+        finally
+        {
+            try
+            {
+                await auto.TypeAsync("aspire config delete features.updateNotificationsEnabled -g");
+                await auto.EnterAsync();
+                await auto.WaitForAnyPromptAsync(counter, TimeSpan.FromSeconds(30));
+            }
+            catch
+            {
+            }
+        }
     }
 
     /// <summary>

--- a/tests/Aspire.Cli.EndToEnd.Tests/ChannelUpdateWorkflowTests.cs
+++ b/tests/Aspire.Cli.EndToEnd.Tests/ChannelUpdateWorkflowTests.cs
@@ -429,37 +429,22 @@ public sealed class ChannelUpdateWorkflowTests(ITestOutputHelper output)
         }
 
         // Suppress the post-update CLI self-update prompt so it doesn't block waiting on
-        // "Update successful!". Pattern borrowed from the polyglot test above.
+        // "Update successful!". No cleanup needed — each test runs in its own Docker container.
         await auto.TypeAsync("aspire config set features.updateNotificationsEnabled false -g");
         await auto.EnterAsync();
         await auto.WaitForSuccessPromptAsync(counter);
 
-        try
-        {
-            // -y skips the "Perform updates?" confirm. For Explicit channels the C# path also prompts
-            // for a NuGet.config directory and a config-changes confirmation; on Polyglot only the
-            // "Perform updates?" prompt fires. Use -y plus a default --nuget-config-dir (current dir)
-            // so the test is identical across both languages.
-            await auto.TypeAsync("aspire update --channel stable -y --nuget-config-dir .");
-            await auto.EnterAsync();
-            await auto.WaitUntilTextAsync("Update successful!", timeout: TimeSpan.FromMinutes(3));
-            await auto.WaitForSuccessPromptAsync(counter);
+        // -y skips the "Perform updates?" confirm. For Explicit channels the C# path also prompts
+        // for a NuGet.config directory and a config-changes confirmation; on Polyglot only the
+        // "Perform updates?" prompt fires. Use -y plus a default --nuget-config-dir (current dir)
+        // so the test is identical across both languages.
+        await auto.TypeAsync("aspire update --channel stable -y --nuget-config-dir .");
+        await auto.EnterAsync();
+        await auto.WaitUntilTextAsync("Update successful!", timeout: TimeSpan.FromMinutes(3));
+        await auto.WaitForSuccessPromptAsync(counter);
 
-            var channelAfter = ReadAspireConfigChannel(aspireConfigPath);
-            Assert.Equal("stable", channelAfter);
-        }
-        finally
-        {
-            try
-            {
-                await auto.TypeAsync("aspire config delete features.updateNotificationsEnabled -g");
-                await auto.EnterAsync();
-                await auto.WaitForAnyPromptAsync(counter, TimeSpan.FromSeconds(30));
-            }
-            catch
-            {
-            }
-        }
+        var channelAfter = ReadAspireConfigChannel(aspireConfigPath);
+        Assert.Equal("stable", channelAfter);
     }
 
     /// <summary>

--- a/tests/Aspire.Cli.EndToEnd.Tests/ChannelUpdateWorkflowTests.cs
+++ b/tests/Aspire.Cli.EndToEnd.Tests/ChannelUpdateWorkflowTests.cs
@@ -17,32 +17,31 @@ namespace Aspire.Cli.EndToEnd.Tests;
 ///   <item><description>Create a TypeScript empty AppHost on the CLI's baked channel.</description></item>
 ///   <item><description><c>aspire add</c> a package and verify the recorded version is non-stable.</description></item>
 ///   <item><description><c>aspire start</c>, assert a wired resource exists, then <c>aspire stop</c>.</description></item>
-///   <item><description><c>aspire update --channel stable</c> and verify that
-///     <c>aspire.config.json#channel</c> flips to <c>"stable"</c> and the previously
-///     added package version is now stable.</description></item>
-///   <item><description><c>aspire add</c> a second package and verify it resolves to a stable version
-///     (because <c>aspire.config.json#channel</c> is now <c>"stable"</c> and the polyglot
-///     <c>aspire add</c> honors the project's configured channel).</description></item>
-///   <item><description><c>aspire start</c> / <c>aspire stop</c> again to confirm the project still runs after the channel switch.</description></item>
+///   <item><description><c>aspire update --channel stable</c> and verify that it previews
+///     stable package updates without enqueuing an <c>aspire.config.json#channel</c> rewrite.</description></item>
+///   <item><description>Decline the previewed updates, then verify the existing non-stable
+///     channel and package versions are preserved.</description></item>
+///   <item><description><c>aspire add</c> a second package and verify it still resolves to a non-stable version
+///     because the project's configured channel was intentionally left alone.</description></item>
+///   <item><description><c>aspire start</c> / <c>aspire stop</c> again to confirm the project still runs after the declined update.</description></item>
 /// </list>
 ///
 /// The remaining tests are lean regression guards for
 /// <see href="https://github.com/microsoft/aspire/issues/17295"/>: each scaffolds an AppHost via one of
 /// the four supported create paths (<c>aspire init</c> C#, <c>aspire new aspire-empty</c> C#,
 /// <c>aspire init --language typescript</c>, plus the TypeScript <c>aspire new</c> case already
-/// covered by the deep test above) and asserts that <c>aspire update --channel stable</c> rewrites
-/// <c>aspire.config.json#channel</c> to <c>"stable"</c>. Package-version assertions are intentionally
-/// scoped to the polyglot deep test only: for C# projects, <c>aspire add</c> on PR/CI hives prefers
-/// the package version that matches the running CLI build (the
-/// <c>VersionHelper.TryGetCurrentCliVersionMatch</c> branch in <c>AddCommand</c>), which deliberately
-/// overrides the channel choice for build coherence and would make a stable-version assertion flaky
-/// on C#.
+/// covered by the deep test above) and asserts that <c>aspire update --channel stable</c> does not
+/// rewrite <c>aspire.config.json#channel</c>. Package-version assertions are intentionally scoped to
+/// the polyglot deep test only: for C# projects, <c>aspire add</c> on PR/CI hives prefers the package
+/// version that matches the running CLI build (the <c>VersionHelper.TryGetCurrentCliVersionMatch</c>
+/// branch in <c>AddCommand</c>), which deliberately overrides the channel choice for build coherence
+/// and would make a stable-version assertion flaky on C#.
 /// </summary>
 public sealed class ChannelUpdateWorkflowTests(ITestOutputHelper output)
 {
     [Fact]
     [CaptureWorkspaceOnFailure]
-    public async Task UpdateProjectChannelToStable_TypeScript_PicksUpStablePackages()
+    public async Task UpdateProjectChannelToStable_TypeScript_PreviewsStablePackagesAndPreservesChannel()
     {
         var repoRoot = CliE2ETestHelpers.GetRepoRoot();
         var strategy = CliInstallStrategy.Detect(output.WriteLine);
@@ -109,7 +108,7 @@ public sealed class ChannelUpdateWorkflowTests(ITestOutputHelper output)
         {
             Assert.Skip(
                 $"Initial aspire.config.json#channel was '{initialChannel ?? "<null>"}'. " +
-                "This test requires a non-stable initial channel so 'aspire update --channel stable' has something to change.");
+                "This test requires a non-stable initial channel so 'aspire update --channel stable' can preview stable-channel updates.");
         }
 
         output.WriteLine($"Initial channel: {initialChannel}");
@@ -161,43 +160,36 @@ public sealed class ChannelUpdateWorkflowTests(ITestOutputHelper output)
 
         try
         {
-            // Step 8: Switch the project to the stable channel. The polyglot update path
-            // (GuestAppHostProject.UpdatePackagesInternalAsync) only prompts "Perform updates?" — there
-            // is no NuGet.config because polyglot apphosts persist channel + packages in aspire.config.json.
-            await auto.TypeAsync("aspire update --channel stable");
-            await auto.EnterAsync();
-            await auto.WaitUntilTextAsync("Perform updates?", timeout: TimeSpan.FromMinutes(2));
-            await auto.EnterAsync();
-            await auto.WaitUntilTextAsync("Update successful!", timeout: TimeSpan.FromMinutes(3));
-            await auto.WaitForSuccessPromptAsync(counter);
+            // Step 8: Preview a stable-channel update. The stable channel is intentionally not
+            // persisted, so decline the package updates here: applying stable package versions while
+            // preserving the existing PR/local channel would leave the TypeScript SDK restore with
+            // package versions that are not available from the preserved channel's source mapping.
+            await PreviewStableUpdateAndDeclineAsync(auto, counter, expectedPackageInPlan: "Aspire.Hosting.Redis");
 
-            // Step 9: Verify the channel was rewritten and Redis is now on a stable version.
+            // Step 9: Verify the existing channel and Redis package version were preserved.
             var channelAfter = ReadAspireConfigChannel(aspireConfigPath);
-            Assert.Equal("stable", channelAfter);
+            Assert.Equal(initialChannel, channelAfter);
 
             var redisVersionAfter = ReadAspireConfigPackageVersion(aspireConfigPath, "Aspire.Hosting.Redis");
-            output.WriteLine($"Redis version after update: {redisVersionAfter}");
-            Assert.True(
-                IsStableVersion(redisVersionAfter),
-                $"Expected a stable Aspire.Hosting.Redis version after 'aspire update --channel stable', got '{redisVersionAfter}'.");
+            output.WriteLine($"Redis version after declined update: {redisVersionAfter}");
+            Assert.Equal(redisVersionBefore, redisVersionAfter);
 
-            // Step 10: Add a second package now that the project is on stable. For polyglot the
-            // configured channel ("stable") is honored by aspire add, so the resolved version must be
-            // stable too. Note the canonical capitalization: Aspire.Hosting.PostgreSQL.
+            // Step 10: Add a second package after the declined update. Because the project channel is
+            // preserved, the resolved version should still come from the non-stable channel. Note the
+            // canonical capitalization: Aspire.Hosting.PostgreSQL.
             await auto.TypeAsync("aspire add Aspire.Hosting.PostgreSQL");
             await auto.EnterAsync();
             await auto.WaitForAspireAddSuccessAsync(counter, TimeSpan.FromMinutes(2));
 
             var postgresVersion = ReadAspireConfigPackageVersion(aspireConfigPath, "Aspire.Hosting.PostgreSQL");
             output.WriteLine($"PostgreSQL version (post-update add): {postgresVersion}");
-            Assert.True(
+            Assert.False(
                 IsStableVersion(postgresVersion),
-                $"Expected the post-update 'aspire add' to resolve a stable Aspire.Hosting.PostgreSQL version, got '{postgresVersion}'.");
+                $"Expected the post-update 'aspire add' to preserve the non-stable Aspire.Hosting.PostgreSQL channel, got '{postgresVersion}'.");
 
-            // Step 11: Boot once more to confirm the project still runs after the channel switch.
+            // Step 11: Boot once more to confirm the project still runs after the declined update.
             // The AppHost still wires only the cache resource — PostgreSQL was added to config but not
-            // wired in the AppHost, which is sufficient for the user-facing "package can be added from
-            // stable channel" assertion.
+            // wired in the AppHost, which is sufficient for the channel-preservation assertion.
             await auto.AspireStartAsync(counter);
             await auto.AssertResourcesExistAsync(counter, "cache");
             await auto.AspireStopAsync(counter);
@@ -226,7 +218,7 @@ public sealed class ChannelUpdateWorkflowTests(ITestOutputHelper output)
     }
 
     // ----------------------------------------------------------------------------------
-    // Channel-rewrite regression guards for https://github.com/microsoft/aspire/issues/17295
+    // Stable-channel persistence regression guards for https://github.com/microsoft/aspire/issues/17295
     //
     // These four cells cover the create-paths × language matrix:
     //   - C# `aspire init`             (single-file apphost.cs)        -> see test below
@@ -235,14 +227,14 @@ public sealed class ChannelUpdateWorkflowTests(ITestOutputHelper output)
     //   - TS `aspire new aspire-ts-empty` (project-mode)               -> already covered by the
     //                                                                     deep test above.
     //
-    // Each new test asserts JUST the user-reported invariant:
-    // "after `aspire update --channel stable`, aspire.config.json#channel == 'stable'".
+    // Each test asserts the stable-channel invariant: `aspire update --channel stable` should not
+    // enqueue an aspire.config.json#channel rewrite, so the existing channel value is preserved.
     // Package version assertions are intentionally not duplicated here — see the class docstring.
     // ----------------------------------------------------------------------------------
 
     [Fact]
     [CaptureWorkspaceOnFailure]
-    public async Task UpdateProjectChannelToStable_CSharpSingleFileInit_RewritesAspireConfigChannel()
+    public async Task UpdateProjectChannelToStable_CSharpSingleFileInit_PreservesAspireConfigChannel()
     {
         var repoRoot = CliE2ETestHelpers.GetRepoRoot();
         var strategy = CliInstallStrategy.Detect(output.WriteLine);
@@ -282,7 +274,7 @@ public sealed class ChannelUpdateWorkflowTests(ITestOutputHelper output)
             CliE2ETestHelpers.WriteLocalChannelSettings(projectPath, localChannel.SdkVersion);
         }
 
-        await RunChannelUpdateAndAssertAsync(auto, counter, Path.Combine(projectPath, "aspire.config.json"));
+        await RunStableChannelUpdateAndAssertChannelPreservedAsync(auto, counter, Path.Combine(projectPath, "aspire.config.json"));
 
         await auto.TypeAsync("exit");
         await auto.EnterAsync();
@@ -291,7 +283,7 @@ public sealed class ChannelUpdateWorkflowTests(ITestOutputHelper output)
 
     [Fact]
     [CaptureWorkspaceOnFailure]
-    public async Task UpdateProjectChannelToStable_CSharpEmptyAppHost_RewritesAspireConfigChannel()
+    public async Task UpdateProjectChannelToStable_CSharpEmptyAppHost_PreservesAspireConfigChannel()
     {
         var repoRoot = CliE2ETestHelpers.GetRepoRoot();
         var strategy = CliInstallStrategy.Detect(output.WriteLine);
@@ -328,7 +320,7 @@ public sealed class ChannelUpdateWorkflowTests(ITestOutputHelper output)
         }
 
         await auto.RunCommandFailFastAsync($"cd {projectName}", counter);
-        await RunChannelUpdateAndAssertAsync(auto, counter, Path.Combine(projectPath, "aspire.config.json"));
+        await RunStableChannelUpdateAndAssertChannelPreservedAsync(auto, counter, Path.Combine(projectPath, "aspire.config.json"));
 
         await auto.TypeAsync("exit");
         await auto.EnterAsync();
@@ -337,7 +329,7 @@ public sealed class ChannelUpdateWorkflowTests(ITestOutputHelper output)
 
     [Fact]
     [CaptureWorkspaceOnFailure]
-    public async Task UpdateProjectChannelToStable_TypeScriptSingleFileInit_RewritesAspireConfigChannel()
+    public async Task UpdateProjectChannelToStable_TypeScriptSingleFileInit_PreservesAspireConfigChannel()
     {
         var repoRoot = CliE2ETestHelpers.GetRepoRoot();
         var strategy = CliInstallStrategy.Detect(output.WriteLine);
@@ -380,7 +372,7 @@ public sealed class ChannelUpdateWorkflowTests(ITestOutputHelper output)
             CliE2ETestHelpers.WriteLocalChannelSettings(projectPath, localChannel.SdkVersion);
         }
 
-        await RunChannelUpdateAndAssertAsync(auto, counter, Path.Combine(projectPath, "aspire.config.json"));
+        await RunStableChannelUpdateAndAssertChannelPreservedAsync(auto, counter, Path.Combine(projectPath, "aspire.config.json"));
 
         await auto.TypeAsync("exit");
         await auto.EnterAsync();
@@ -388,7 +380,7 @@ public sealed class ChannelUpdateWorkflowTests(ITestOutputHelper output)
     }
 
     /// <summary>
-    /// Shared skip-gate for the channel-rewrite regression tests: if the running CLI's baked channel
+    /// Shared skip-gate for the channel-preservation regression tests: if the running CLI's baked channel
     /// is already <c>stable</c> (e.g. a local install-script run with no quality/version override),
     /// <c>aspire update --channel stable</c> would be a no-op and the prompts the test drives would
     /// never appear. Returns <c>true</c> together with a human-readable reason in that case.
@@ -409,12 +401,12 @@ public sealed class ChannelUpdateWorkflowTests(ITestOutputHelper output)
     }
 
     /// <summary>
-    /// Shared body for the channel-rewrite regression tests: snapshot the initial channel, suppress
-    /// the post-update CLI self-update prompt, drive <c>aspire update --channel stable</c>, then
-    /// assert that <c>aspire.config.json#channel</c> was rewritten to <c>"stable"</c>.
+    /// Shared body for the channel-preservation regression tests: snapshot the initial channel,
+    /// suppress the post-update CLI self-update prompt, preview <c>aspire update --channel stable</c>,
+    /// then assert that <c>aspire.config.json#channel</c> was left unchanged.
     /// Assumes the automator is positioned in the project directory (containing aspire.config.json).
     /// </summary>
-    private static async Task RunChannelUpdateAndAssertAsync(
+    private static async Task RunStableChannelUpdateAndAssertChannelPreservedAsync(
         Hex1bTerminalAutomator auto,
         SequenceCounter counter,
         string aspireConfigPath)
@@ -425,7 +417,7 @@ public sealed class ChannelUpdateWorkflowTests(ITestOutputHelper output)
         {
             Assert.Skip(
                 $"Initial aspire.config.json#channel was '{initialChannel ?? "<null>"}'. " +
-                "This test requires a non-stable initial channel so 'aspire update --channel stable' has something to change.");
+                "This test requires a non-stable initial channel so 'aspire update --channel stable' can preview stable-channel updates.");
         }
 
         // Suppress the post-update CLI self-update prompt so it doesn't block waiting on
@@ -434,17 +426,52 @@ public sealed class ChannelUpdateWorkflowTests(ITestOutputHelper output)
         await auto.EnterAsync();
         await auto.WaitForSuccessPromptAsync(counter);
 
-        // -y skips the "Perform updates?" confirm. For Explicit channels the C# path also prompts
-        // for a NuGet.config directory and a config-changes confirmation; on Polyglot only the
-        // "Perform updates?" prompt fires. Use -y plus a default --nuget-config-dir (current dir)
-        // so the test is identical across both languages.
-        await auto.TypeAsync("aspire update --channel stable -y --nuget-config-dir .");
-        await auto.EnterAsync();
-        await auto.WaitUntilTextAsync("Update successful!", timeout: TimeSpan.FromMinutes(3));
-        await auto.WaitForSuccessPromptAsync(counter);
+        await PreviewStableUpdateAndDeclineAsync(auto, counter);
 
         var channelAfter = ReadAspireConfigChannel(aspireConfigPath);
-        Assert.Equal("stable", channelAfter);
+        Assert.Equal(initialChannel, channelAfter);
+    }
+
+    private static async Task PreviewStableUpdateAndDeclineAsync(
+        Hex1bTerminalAutomator auto,
+        SequenceCounter counter,
+        string? expectedPackageInPlan = null)
+    {
+        var updatePrompt = new CellPatternSearcher().Find("Perform updates?");
+        var upToDateMessage = new CellPatternSearcher().Find("Project is up to date! (no updates necessary)");
+        var channelUpdateLine = new CellPatternSearcher().Find("aspire.config.json#channel");
+        var expectedPackageLine = expectedPackageInPlan is not null
+            ? new CellPatternSearcher().Find(expectedPackageInPlan)
+            : null;
+
+        var sawChannelUpdateLine = false;
+        var sawExpectedPackageLine = expectedPackageLine is null;
+        var sawUpdatePrompt = false;
+
+        await auto.TypeAsync("aspire update --channel stable --nuget-config-dir .");
+        await auto.EnterAsync();
+        await auto.WaitUntilAsync(snapshot =>
+        {
+            sawChannelUpdateLine |= channelUpdateLine.Search(snapshot).Count > 0;
+            if (expectedPackageLine is not null && expectedPackageLine.Search(snapshot).Count > 0)
+            {
+                sawExpectedPackageLine = true;
+            }
+            sawUpdatePrompt |= updatePrompt.Search(snapshot).Count > 0;
+
+            return sawUpdatePrompt || upToDateMessage.Search(snapshot).Count > 0;
+        }, TimeSpan.FromMinutes(3), description: "waiting for stable update preview");
+
+        Assert.False(sawChannelUpdateLine, "Stable channel updates should not enqueue an aspire.config.json#channel rewrite.");
+        Assert.True(sawExpectedPackageLine, $"Expected the stable update preview to include '{expectedPackageInPlan}'.");
+
+        if (sawUpdatePrompt)
+        {
+            await auto.TypeAsync("n");
+            await auto.EnterAsync();
+        }
+
+        await auto.WaitForSuccessPromptAsync(counter);
     }
 
     /// <summary>

--- a/tests/Aspire.Cli.Tests/Commands/InitCommandTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/InitCommandTests.cs
@@ -987,7 +987,7 @@ public class InitCommandTests(ITestOutputHelper outputHelper)
 
     /// <summary>
     /// Regression for the daily-CLI scenario: when `aspire init` runs under a CLI identity
-    /// that matches a registered Explicit channel (<c>daily</c>, <c>staging</c>, <c>pr-{N}</c>),
+    /// that matches a registered non-stable Explicit channel (<c>daily</c>, <c>staging</c>, <c>pr-{N}</c>),
     /// the produced <c>aspire.config.json</c> must carry that channel at the top level so
     /// subsequent <c>aspire add</c> / <c>integration list</c> / <c>integration search</c>
     /// calls resolve packages against the matching channel rather than the implicit feed.
@@ -1020,7 +1020,14 @@ public class InitCommandTests(ITestOutputHelper outputHelper)
         Assert.True(File.Exists(configPath));
 
         var config = JsonNode.Parse(File.ReadAllText(configPath))!.AsObject();
-        Assert.Equal(contextChannel, config["channel"]!.GetValue<string>());
+        if (string.Equals(contextChannel, PackageChannelNames.Stable, StringComparisons.ChannelName))
+        {
+            Assert.Null(config["channel"]);
+        }
+        else
+        {
+            Assert.Equal(contextChannel, config["channel"]!.GetValue<string>());
+        }
     }
 
     /// <summary>
@@ -1182,8 +1189,8 @@ public class InitCommandTests(ITestOutputHelper outputHelper)
     }
 
     /// <summary>
-    /// The stable channel is an explicit PackagingService channel, but for polyglot init it is
-    /// also the default public-feed behavior. Persisting it would make package discovery use
+    /// The stable channel is an explicit PackagingService channel, but it is also the
+    /// default public-feed behavior. Persisting it would make package discovery use
     /// only the synthetic NuGet.org config and hide packages from ambient private feeds.
     /// </summary>
     [Fact]

--- a/tests/Aspire.Cli.Tests/Commands/InitCommandTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/InitCommandTests.cs
@@ -1133,13 +1133,13 @@ public class InitCommandTests(ITestOutputHelper outputHelper)
 
     /// <summary>
     /// Polyglot equivalent of <see cref="InitCommand_SingleFileMode_WritesIdentityChannelIntoAspireConfig"/>:
-    /// when the identity matches a registered Explicit channel, init must propagate the
-    /// resolved channel name through <see cref="ScaffoldContext.Channel"/> so the scaffolder
+    /// when the identity matches a registered non-default Explicit channel, init must propagate
+    /// the resolved channel name through <see cref="ScaffoldContext.Channel"/> so the scaffolder
     /// persists it into <c>aspire.config.json#channel</c>. Without this, polyglot
     /// <c>aspire add</c> falls back to the implicit feed regardless of the CLI build.
     /// </summary>
     [Fact]
-    public async Task InitCommand_PolyglotMode_PassesResolvedChannelToScaffolder()
+    public async Task InitCommand_PolyglotMode_PassesResolvedNonDefaultChannelToScaffolder()
     {
         using var workspace = TemporaryWorkspace.Create(outputHelper);
 
@@ -1179,6 +1179,54 @@ public class InitCommandTests(ITestOutputHelper outputHelper)
         Assert.Equal(CliExitCodes.Success, exitCode);
         Assert.NotNull(capturedContext);
         Assert.Equal("daily", capturedContext!.Channel);
+    }
+
+    /// <summary>
+    /// The stable channel is an explicit PackagingService channel, but for polyglot init it is
+    /// also the default public-feed behavior. Persisting it would make package discovery use
+    /// only the synthetic NuGet.org config and hide packages from ambient private feeds.
+    /// </summary>
+    [Fact]
+    public async Task InitCommand_PolyglotMode_DoesNotPassStableChannelToScaffolder()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+
+        ScaffoldContext? capturedContext = null;
+        var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper, options =>
+        {
+            options.CliExecutionContextFactory = _ => CreateExecutionContextForChannel(workspace.WorkspaceRoot, "stable");
+            options.PackagingServiceFactory = _ => CreateNamedChannelPackagingService("stable");
+            options.LanguageServiceFactory = sp =>
+            {
+                var projectFactory = sp.GetRequiredService<IAppHostProjectFactory>();
+                var tsProject = projectFactory.GetProject(new LanguageInfo(
+                    LanguageId: new LanguageId(KnownLanguageId.TypeScript),
+                    DisplayName: "TypeScript (Node.js)",
+                    PackageName: "@aspire/app-host",
+                    DetectionPatterns: ["apphost.mts", "apphost.ts"],
+                    CodeGenerator: "TypeScript",
+                    AppHostFileName: "apphost.mts"));
+                return new TestLanguageService { DefaultProject = tsProject };
+            };
+            options.ScaffoldingServiceFactory = _ => new TestScaffoldingService
+            {
+                ScaffoldAsyncCallback = (ctx, _) =>
+                {
+                    capturedContext = ctx;
+                    return Task.FromResult(true);
+                }
+            };
+        });
+
+        var serviceProvider = services.BuildServiceProvider();
+        var initCommand = serviceProvider.GetRequiredService<InitCommand>();
+
+        var parseResult = initCommand.Parse("init");
+        var exitCode = await parseResult.InvokeAsync().DefaultTimeout();
+
+        Assert.Equal(CliExitCodes.Success, exitCode);
+        Assert.NotNull(capturedContext);
+        Assert.Null(capturedContext!.Channel);
     }
 
     /// <summary>

--- a/tests/Aspire.Cli.Tests/Commands/InitCommandTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/InitCommandTests.cs
@@ -986,6 +986,77 @@ public class InitCommandTests(ITestOutputHelper outputHelper)
     }
 
     /// <summary>
+    /// Regression for the daily-CLI scenario: when `aspire init` runs under a non-stable
+    /// CLI identity (<c>daily</c>, <c>staging</c>, <c>pr-{N}</c>, <c>local</c>, or <c>stable</c>), the produced
+    /// `aspire.config.json` must carry that channel at the top level. Without it,
+    /// subsequent `aspire add` / `integration list` / `integration search` calls have no
+    /// channel context and silently fall back to implicit nuget.org versions that don't
+    /// line up with the CLI build the user is dogfooding.
+    /// </summary>
+    [Theory]
+    [InlineData("stable")]
+    [InlineData("staging")]
+    [InlineData("daily")]
+    [InlineData("pr-12345")]
+    [InlineData("local")]
+    public async Task InitCommand_SingleFileMode_WritesIdentityChannelIntoAspireConfig(string contextChannel)
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+
+        var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper, options =>
+        {
+            options.CliExecutionContextFactory = _ => CreateExecutionContextForChannel(workspace.WorkspaceRoot, contextChannel);
+            options.PackagingServiceFactory = _ => CreateNamedChannelPackagingService(contextChannel);
+        });
+
+        var serviceProvider = services.BuildServiceProvider();
+        var initCommand = serviceProvider.GetRequiredService<InitCommand>();
+
+        var parseResult = initCommand.Parse("init");
+        var exitCode = await parseResult.InvokeAsync().DefaultTimeout();
+
+        Assert.Equal(CliExitCodes.Success, exitCode);
+
+        var configPath = Path.Combine(workspace.WorkspaceRoot.FullName, AspireConfigFile.FileName);
+        Assert.True(File.Exists(configPath));
+
+        var config = JsonNode.Parse(File.ReadAllText(configPath))!.AsObject();
+        Assert.Equal(contextChannel, config["channel"]!.GetValue<string>());
+    }
+
+    /// <summary>
+    /// A pre-existing `aspire.config.json#channel` must not be overwritten by init. Users
+    /// who hand-edit the channel (or migrate a project from a different CLI build) own
+    /// that value; init should only fill it in when absent.
+    /// </summary>
+    [Fact]
+    public async Task InitCommand_SingleFileMode_PreservesExistingChannelInAspireConfig()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+
+        var configPath = Path.Combine(workspace.WorkspaceRoot.FullName, AspireConfigFile.FileName);
+        var existing = new JsonObject { ["channel"] = "pr-99999" };
+        await File.WriteAllTextAsync(configPath, existing.ToJsonString());
+
+        var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper, options =>
+        {
+            options.CliExecutionContextFactory = _ => CreateExecutionContextForChannel(workspace.WorkspaceRoot, "daily");
+            options.PackagingServiceFactory = _ => CreateNamedChannelPackagingService("daily");
+        });
+
+        var serviceProvider = services.BuildServiceProvider();
+        var initCommand = serviceProvider.GetRequiredService<InitCommand>();
+
+        var parseResult = initCommand.Parse("init");
+        var exitCode = await parseResult.InvokeAsync().DefaultTimeout();
+
+        Assert.Equal(CliExitCodes.Success, exitCode);
+
+        var config = JsonNode.Parse(await File.ReadAllTextAsync(configPath))!.AsObject();
+        Assert.Equal("pr-99999", config["channel"]!.GetValue<string>());
+    }
+
+    /// <summary>
     /// Negative-shape tripwire: <c>aspire init</c> must never read the <c>channel</c> key from
     /// the global <see cref="IConfigurationService"/>. The injected configuration service throws
     /// on any <c>GetConfigurationAsync(key, ...)</c> or <c>GetConfigurationFromDirectoryAsync</c>

--- a/tests/Aspire.Cli.Tests/Commands/InitCommandTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/InitCommandTests.cs
@@ -986,12 +986,11 @@ public class InitCommandTests(ITestOutputHelper outputHelper)
     }
 
     /// <summary>
-    /// Regression for the daily-CLI scenario: when `aspire init` runs under a non-stable
-    /// CLI identity (<c>daily</c>, <c>staging</c>, <c>pr-{N}</c>, <c>local</c>, or <c>stable</c>), the produced
-    /// `aspire.config.json` must carry that channel at the top level. Without it,
-    /// subsequent `aspire add` / `integration list` / `integration search` calls have no
-    /// channel context and silently fall back to implicit nuget.org versions that don't
-    /// line up with the CLI build the user is dogfooding.
+    /// Regression for the daily-CLI scenario: when `aspire init` runs under a CLI identity
+    /// that matches a registered Explicit channel (<c>daily</c>, <c>staging</c>, <c>pr-{N}</c>),
+    /// the produced <c>aspire.config.json</c> must carry that channel at the top level so
+    /// subsequent <c>aspire add</c> / <c>integration list</c> / <c>integration search</c>
+    /// calls resolve packages against the matching channel rather than the implicit feed.
     /// </summary>
     [Theory]
     [InlineData("stable")]
@@ -1054,6 +1053,238 @@ public class InitCommandTests(ITestOutputHelper outputHelper)
 
         var config = JsonNode.Parse(await File.ReadAllTextAsync(configPath))!.AsObject();
         Assert.Equal("pr-99999", config["channel"]!.GetValue<string>());
+    }
+
+    /// <summary>
+    /// When the running CLI's <see cref="CliExecutionContext.IdentityChannel"/> doesn't match
+    /// any registered channel (e.g. <c>local</c> on a production CLI, or a stale <c>pr-{N}</c>
+    /// without the matching hive), init must NOT persist a channel value. Persisting a
+    /// name no package source mapping satisfies would zero out polyglot
+    /// <c>aspire add</c> discovery via <c>IntegrationPackageSearchService</c>'s name filter.
+    /// </summary>
+    [Fact]
+    public async Task InitCommand_SingleFileMode_DoesNotPersistChannelWhenIdentityUnregistered()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+
+        var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper, options =>
+        {
+            options.CliExecutionContextFactory = _ => CreateExecutionContextForChannel(workspace.WorkspaceRoot, "pr-99999");
+            // Only `daily` is registered; identity `pr-99999` has no match.
+            options.PackagingServiceFactory = _ => CreateNamedChannelPackagingService("daily");
+        });
+
+        var serviceProvider = services.BuildServiceProvider();
+        var initCommand = serviceProvider.GetRequiredService<InitCommand>();
+
+        var parseResult = initCommand.Parse("init");
+        var exitCode = await parseResult.InvokeAsync().DefaultTimeout();
+
+        Assert.Equal(CliExitCodes.Success, exitCode);
+
+        var configPath = Path.Combine(workspace.WorkspaceRoot.FullName, AspireConfigFile.FileName);
+        var config = JsonNode.Parse(File.ReadAllText(configPath))!.AsObject();
+        Assert.Null(config["channel"]);
+    }
+
+    /// <summary>
+    /// When the running CLI's identity matches a registered Implicit channel (production
+    /// <c>default</c> → nuget.org), init must NOT persist a channel value. Implicit channels
+    /// are the default fallback; pinning them at the project level is redundant and would
+    /// restrict polyglot <c>aspire add</c> discovery to a single channel —
+    /// the regression tracked by https://github.com/microsoft/aspire/issues/17295.
+    /// </summary>
+    [Fact]
+    public async Task InitCommand_SingleFileMode_DoesNotPersistChannelWhenIdentityMatchesImplicit()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+
+        var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper, options =>
+        {
+            // PackageChannel.CreateImplicitChannel names the channel "default".
+            options.CliExecutionContextFactory = _ => CreateExecutionContextForChannel(workspace.WorkspaceRoot, "default");
+            options.PackagingServiceFactory = _ =>
+            {
+                var fakeCache = new FakeNuGetPackageCache
+                {
+                    GetTemplatePackagesAsyncCallback = (_, _, _, _) =>
+                        Task.FromResult<IEnumerable<NuGetPackageCli>>([])
+                };
+                var implicitChannel = PackageChannel.CreateImplicitChannel(fakeCache, new TestFeatures());
+                return new TestPackagingService
+                {
+                    GetChannelsAsyncCallback = _ => Task.FromResult<IEnumerable<PackageChannel>>([implicitChannel])
+                };
+            };
+        });
+
+        var serviceProvider = services.BuildServiceProvider();
+        var initCommand = serviceProvider.GetRequiredService<InitCommand>();
+
+        var parseResult = initCommand.Parse("init");
+        var exitCode = await parseResult.InvokeAsync().DefaultTimeout();
+
+        Assert.Equal(CliExitCodes.Success, exitCode);
+
+        var configPath = Path.Combine(workspace.WorkspaceRoot.FullName, AspireConfigFile.FileName);
+        var config = JsonNode.Parse(File.ReadAllText(configPath))!.AsObject();
+        Assert.Null(config["channel"]);
+    }
+
+    /// <summary>
+    /// Polyglot equivalent of <see cref="InitCommand_SingleFileMode_WritesIdentityChannelIntoAspireConfig"/>:
+    /// when the identity matches a registered Explicit channel, init must propagate the
+    /// resolved channel name through <see cref="ScaffoldContext.Channel"/> so the scaffolder
+    /// persists it into <c>aspire.config.json#channel</c>. Without this, polyglot
+    /// <c>aspire add</c> falls back to the implicit feed regardless of the CLI build.
+    /// </summary>
+    [Fact]
+    public async Task InitCommand_PolyglotMode_PassesResolvedChannelToScaffolder()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+
+        ScaffoldContext? capturedContext = null;
+        var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper, options =>
+        {
+            options.CliExecutionContextFactory = _ => CreateExecutionContextForChannel(workspace.WorkspaceRoot, "daily");
+            options.PackagingServiceFactory = _ => CreateNamedChannelPackagingService("daily");
+            options.LanguageServiceFactory = sp =>
+            {
+                var projectFactory = sp.GetRequiredService<IAppHostProjectFactory>();
+                var tsProject = projectFactory.GetProject(new LanguageInfo(
+                    LanguageId: new LanguageId(KnownLanguageId.TypeScript),
+                    DisplayName: "TypeScript (Node.js)",
+                    PackageName: "@aspire/app-host",
+                    DetectionPatterns: ["apphost.mts", "apphost.ts"],
+                    CodeGenerator: "TypeScript",
+                    AppHostFileName: "apphost.mts"));
+                return new TestLanguageService { DefaultProject = tsProject };
+            };
+            options.ScaffoldingServiceFactory = _ => new TestScaffoldingService
+            {
+                ScaffoldAsyncCallback = (ctx, _) =>
+                {
+                    capturedContext = ctx;
+                    return Task.FromResult(true);
+                }
+            };
+        });
+
+        var serviceProvider = services.BuildServiceProvider();
+        var initCommand = serviceProvider.GetRequiredService<InitCommand>();
+
+        var parseResult = initCommand.Parse("init");
+        var exitCode = await parseResult.InvokeAsync().DefaultTimeout();
+
+        Assert.Equal(CliExitCodes.Success, exitCode);
+        Assert.NotNull(capturedContext);
+        Assert.Equal("daily", capturedContext!.Channel);
+    }
+
+    /// <summary>
+    /// Polyglot pre-existing-channel preservation. <c>ScaffoldingService.cs:93-95</c> writes
+    /// <c>config.Channel = context.Channel</c> unconditionally when non-empty, so if init
+    /// passed the resolved identity channel into <see cref="ScaffoldContext.Channel"/> without
+    /// first checking the file, a user-edited polyglot <c>aspire.config.json#channel</c>
+    /// would be silently overwritten on subsequent <c>aspire init</c> runs.
+    /// </summary>
+    [Fact]
+    public async Task InitCommand_PolyglotMode_PreservesExistingChannelInAspireConfig()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+
+        var configPath = Path.Combine(workspace.WorkspaceRoot.FullName, AspireConfigFile.FileName);
+        var existing = new JsonObject { ["channel"] = "pr-99999" };
+        await File.WriteAllTextAsync(configPath, existing.ToJsonString());
+
+        ScaffoldContext? capturedContext = null;
+        var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper, options =>
+        {
+            options.CliExecutionContextFactory = _ => CreateExecutionContextForChannel(workspace.WorkspaceRoot, "daily");
+            options.PackagingServiceFactory = _ => CreateNamedChannelPackagingService("daily");
+            options.LanguageServiceFactory = sp =>
+            {
+                var projectFactory = sp.GetRequiredService<IAppHostProjectFactory>();
+                var tsProject = projectFactory.GetProject(new LanguageInfo(
+                    LanguageId: new LanguageId(KnownLanguageId.TypeScript),
+                    DisplayName: "TypeScript (Node.js)",
+                    PackageName: "@aspire/app-host",
+                    DetectionPatterns: ["apphost.mts", "apphost.ts"],
+                    CodeGenerator: "TypeScript",
+                    AppHostFileName: "apphost.mts"));
+                return new TestLanguageService { DefaultProject = tsProject };
+            };
+            options.ScaffoldingServiceFactory = _ => new TestScaffoldingService
+            {
+                ScaffoldAsyncCallback = (ctx, _) =>
+                {
+                    capturedContext = ctx;
+                    return Task.FromResult(true);
+                }
+            };
+        });
+
+        var serviceProvider = services.BuildServiceProvider();
+        var initCommand = serviceProvider.GetRequiredService<InitCommand>();
+
+        var parseResult = initCommand.Parse("init");
+        var exitCode = await parseResult.InvokeAsync().DefaultTimeout();
+
+        Assert.Equal(CliExitCodes.Success, exitCode);
+        Assert.NotNull(capturedContext);
+        // Init must suppress the channel pass-through so the scaffolder doesn't overwrite
+        // the user-edited value via `config.Channel = context.Channel`.
+        Assert.Null(capturedContext!.Channel);
+    }
+
+    /// <summary>
+    /// Polyglot equivalent of the unregistered-identity guard: when identity doesn't match
+    /// any registered channel, init must NOT pass it through to the scaffolder. Otherwise
+    /// the scaffolder would pin a name no PSM rule satisfies and polyglot <c>aspire add</c>
+    /// would return zero packages.
+    /// </summary>
+    [Fact]
+    public async Task InitCommand_PolyglotMode_DoesNotPassChannelWhenIdentityUnregistered()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+
+        ScaffoldContext? capturedContext = null;
+        var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper, options =>
+        {
+            options.CliExecutionContextFactory = _ => CreateExecutionContextForChannel(workspace.WorkspaceRoot, "pr-99999");
+            // Only `daily` is registered; identity `pr-99999` has no match.
+            options.PackagingServiceFactory = _ => CreateNamedChannelPackagingService("daily");
+            options.LanguageServiceFactory = sp =>
+            {
+                var projectFactory = sp.GetRequiredService<IAppHostProjectFactory>();
+                var tsProject = projectFactory.GetProject(new LanguageInfo(
+                    LanguageId: new LanguageId(KnownLanguageId.TypeScript),
+                    DisplayName: "TypeScript (Node.js)",
+                    PackageName: "@aspire/app-host",
+                    DetectionPatterns: ["apphost.mts", "apphost.ts"],
+                    CodeGenerator: "TypeScript",
+                    AppHostFileName: "apphost.mts"));
+                return new TestLanguageService { DefaultProject = tsProject };
+            };
+            options.ScaffoldingServiceFactory = _ => new TestScaffoldingService
+            {
+                ScaffoldAsyncCallback = (ctx, _) =>
+                {
+                    capturedContext = ctx;
+                    return Task.FromResult(true);
+                }
+            };
+        });
+
+        var serviceProvider = services.BuildServiceProvider();
+        var initCommand = serviceProvider.GetRequiredService<InitCommand>();
+
+        var parseResult = initCommand.Parse("init");
+        var exitCode = await parseResult.InvokeAsync().DefaultTimeout();
+
+        Assert.Equal(CliExitCodes.Success, exitCode);
+        Assert.NotNull(capturedContext);
+        Assert.Null(capturedContext!.Channel);
     }
 
     /// <summary>

--- a/tests/Aspire.Cli.Tests/Projects/GuestAppHostProjectTests.cs
+++ b/tests/Aspire.Cli.Tests/Projects/GuestAppHostProjectTests.cs
@@ -778,7 +778,7 @@ public class GuestAppHostProjectTests : IDisposable
     }
 
     [Fact]
-    public async Task UpdatePackagesAsync_ExplicitStableChannel_PersistsStableChannelWhenProjectIsUpToDate()
+    public async Task UpdatePackagesAsync_ExplicitStableChannel_DoesNotPersistStableChannelWhenProjectIsUpToDate()
     {
         var configPath = Path.Combine(_workspace.WorkspaceRoot.FullName, AspireConfigFile.FileName);
         await File.WriteAllTextAsync(configPath, """
@@ -820,10 +820,10 @@ public class GuestAppHostProjectTests : IDisposable
 
         var result = await project.UpdatePackagesAsync(context, CancellationToken.None);
 
-        Assert.True(result.UpdatesApplied);
+        Assert.False(result.UpdatesApplied);
         var reloaded = AspireConfigFile.Load(_workspace.WorkspaceRoot.FullName);
         Assert.NotNull(reloaded);
-        Assert.Equal(PackageChannelNames.Stable, reloaded.Channel);
+        Assert.Equal(PackageChannelNames.Staging, reloaded.Channel);
         Assert.Equal("2.0.0", reloaded.SdkVersion);
         Assert.Equal("2.0.0", reloaded.Packages?["Aspire.Hosting"]);
     }

--- a/tests/Aspire.Cli.Tests/Projects/ProjectUpdaterTests.cs
+++ b/tests/Aspire.Cli.Tests/Projects/ProjectUpdaterTests.cs
@@ -423,6 +423,16 @@ public class ProjectUpdaterTests(ITestOutputHelper outputHelper)
             </Project>
             """);
 
+        var aspireConfigFile = new FileInfo(Path.Combine(appHostFolder.FullName, "aspire.config.json"));
+        await File.WriteAllTextAsync(
+            aspireConfigFile.FullName,
+            """
+            {
+              "appHost": { "path": "UpdateTester.AppHost.csproj" },
+              "channel": "daily"
+            }
+            """);
+
         var packagesAddsExecuted = new List<(FileInfo ProjectFile, string PackageId, string PackageVersion, string? PackageSource, bool NoRestore)>();
         var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper, config =>
         {
@@ -555,6 +565,10 @@ public class ProjectUpdaterTests(ITestOutputHelper outputHelper)
                 Assert.Equal(webAppProjectFile.FullName, item.ProjectFile.FullName);
             }
         );
+
+        var updatedConfig = await File.ReadAllTextAsync(aspireConfigFile.FullName);
+        using var configDoc = JsonDocument.Parse(updatedConfig);
+        Assert.Equal("daily", configDoc.RootElement.GetProperty("channel").GetString());
     }
 
     [Fact]

--- a/tests/Aspire.Cli.Tests/Projects/ProjectUpdaterTests.cs
+++ b/tests/Aspire.Cli.Tests/Projects/ProjectUpdaterTests.cs
@@ -154,6 +154,19 @@ public class ProjectUpdaterTests(ITestOutputHelper outputHelper)
             </Project>
             """);
 
+        // Pre-existing aspire.config.json pinned to a (stale) channel — the updater should
+        // rewrite the channel to match the resolved explicit channel after the update completes.
+        // See https://github.com/microsoft/aspire/issues/17295.
+        var aspireConfigFile = new FileInfo(Path.Combine(appHostFolder.FullName, "aspire.config.json"));
+        await File.WriteAllTextAsync(
+            aspireConfigFile.FullName,
+            """
+            {
+              "appHost": { "path": "UpdateTester.AppHost.csproj" },
+              "channel": "stable"
+            }
+            """);
+
         var packagesAddsExecuted = new List<(FileInfo ProjectFile, string PackageId, string PackageVersion, string? PackageSource, bool NoRestore)>();
         var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper, config =>
         {
@@ -267,6 +280,13 @@ public class ProjectUpdaterTests(ITestOutputHelper outputHelper)
                 Assert.Equal(webAppProjectFile.FullName, item.ProjectFile.FullName);
             }
         );
+
+        // Channel pin in aspire.config.json should have been rewritten from the pre-existing
+        // "stable" value to the resolved explicit channel ("daily") that we just updated to.
+        // Regression guard for https://github.com/microsoft/aspire/issues/17295.
+        var updatedConfig = await File.ReadAllTextAsync(aspireConfigFile.FullName);
+        using var configDoc = JsonDocument.Parse(updatedConfig);
+        Assert.Equal("daily", configDoc.RootElement.GetProperty("channel").GetString());
     }
 
     [Fact]
@@ -1429,6 +1449,35 @@ public class ProjectUpdaterTests(ITestOutputHelper outputHelper)
 
         // Assert
         Assert.Equal("[bold yellow]Aspire.Hosting.Redis[/] [bold green]9.0.0[/] to [bold green]9.1.0[/]", formattedText);
+    }
+
+    [Fact]
+    public void ChannelUpdateStep_GetFormattedDisplayText_ReturnsFormattedString_WithExistingChannel()
+    {
+        var step = new ChannelUpdateStep(
+            "Update aspire.config.json channel from 'pr-17452' to 'stable'",
+            () => Task.CompletedTask,
+            "pr-17452",
+            "stable");
+
+        Assert.Equal(
+            "[bold yellow]aspire.config.json#channel[/] [bold green]pr-17452[/] to [bold green]stable[/]",
+            step.GetFormattedDisplayText());
+    }
+
+    [Fact]
+    public void ChannelUpdateStep_GetFormattedDisplayText_ReturnsFormattedString_WhenChannelAbsent()
+    {
+        var step = new ChannelUpdateStep(
+            "Update aspire.config.json channel from '(none)' to 'stable'",
+            () => Task.CompletedTask,
+            CurrentChannel: null,
+            NewChannel: "stable");
+
+        // Markup-escaped grey placeholder for absent channel value.
+        Assert.Equal(
+            "[bold yellow]aspire.config.json#channel[/] [grey](none)[/] to [bold green]stable[/]",
+            step.GetFormattedDisplayText());
     }
 
     [Fact]

--- a/tests/Aspire.Cli.Tests/Projects/ProjectUpdaterTests.cs
+++ b/tests/Aspire.Cli.Tests/Projects/ProjectUpdaterTests.cs
@@ -290,6 +290,116 @@ public class ProjectUpdaterTests(ITestOutputHelper outputHelper)
     }
 
     [Fact]
+    public async Task UpdateProjectFileAsync_DoesNotCreateAspireConfigJsonWhenAbsent()
+    {
+        // Sibling of UpdateProjectFileAsync_CanUpdateFromStableToDaily covering the case where
+        // the AppHost project predates aspire.config.json (legacy split layouts, pre-init projects).
+        // `aspire update` must not fabricate a fresh aspire.config.json — that's `aspire init`'s job.
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+
+        var srcFolder = workspace.CreateDirectory("src");
+
+        var serviceDefaultsFolder = workspace.CreateDirectory("UpdateTester.ServiceDefaults");
+        var serviceDefaultsProjectFile = new FileInfo(Path.Combine(serviceDefaultsFolder.FullName, "UpdateTester.ServiceDefaults.csproj"));
+
+        var webAppFolder = workspace.CreateDirectory("UpdateTester.WebApp");
+        var webAppProjectFile = new FileInfo(Path.Combine(webAppFolder.FullName, "UpdateTester.WebApp.csproj"));
+
+        var appHostFolder = workspace.CreateDirectory("UpdateTester.AppHost");
+        var appHostProjectFile = new FileInfo(Path.Combine(appHostFolder.FullName, "UpdateTester.AppHost.csproj"));
+
+        await File.WriteAllTextAsync(
+            appHostProjectFile.FullName,
+            $$"""
+            <Project Sdk="Microsoft.NET.Sdk">
+                <Sdk Name="Aspire.AppHost.Sdk" Version="9.4.1" />
+            </Project>
+            """);
+
+        // Intentionally do NOT pre-create aspire.config.json. The post-update assertion below
+        // verifies the file is still absent.
+        var aspireConfigFile = new FileInfo(Path.Combine(appHostFolder.FullName, "aspire.config.json"));
+        Assert.False(aspireConfigFile.Exists, "Pre-condition: aspire.config.json should not exist before the update.");
+
+        var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper, config =>
+        {
+            config.DotNetCliRunnerFactory = (sp) =>
+            {
+                return new TestDotNetCliRunner()
+                {
+                    SearchPackagesAsyncCallback = (_, query, _, _, _, _, _, _, _, _) =>
+                    {
+                        var packages = new List<NuGetPackageCli>
+                        {
+                            query switch
+                            {
+                                "Aspire.AppHost.Sdk" => new NuGetPackageCli { Id = "Aspire.AppHost.Sdk", Version = "9.5.0-preview.1", Source = "daily" },
+                                "Aspire.Hosting.AppHost" => new NuGetPackageCli { Id = "Aspire.Hosting.AppHost", Version = "9.5.0-preview.1", Source = "daily" },
+                                "Aspire.Hosting.Redis" => new NuGetPackageCli { Id = "Aspire.Hosting.Redis", Version = "9.5.0-preview.1", Source = "daily" },
+                                "Aspire.StackExchange.Redis.OutputCaching" => new NuGetPackageCli { Id = "Aspire.StackExchange.Redis.OutputCaching", Version = "9.5.0-preview.1", Source = "daily" },
+                                "Microsoft.Extensions.ServiceDiscovery" => new NuGetPackageCli { Id = "Microsoft.Extensions.ServiceDiscovery", Version = "9.5.0-preview.1", Source = "daily" },
+                                _ => throw new InvalidOperationException("Unexpected package query."),
+                            }
+                        };
+
+                        return (0, packages.ToArray());
+                    },
+
+                    GetProjectItemsAndPropertiesAsyncCallback = (projectFile, _, _, _, _) =>
+                    {
+                        var itemsAndProperties = new JsonObject();
+
+                        if (projectFile.FullName == appHostProjectFile.FullName)
+                        {
+                            itemsAndProperties.WithSdkVersion("9.4.1");
+                            itemsAndProperties.WithPackageReference("Aspire.Hosting.AppHost", "9.4.1");
+                            itemsAndProperties.WithPackageReference("Aspire.Hosting.Redis", "9.4.1");
+                            itemsAndProperties.WithProjectReference(webAppProjectFile.FullName);
+                        }
+                        else if (projectFile.FullName == webAppProjectFile.FullName)
+                        {
+                            itemsAndProperties.WithPackageReference("Aspire.StackExchange.Redis.OutputCaching", "9.4.1");
+                            itemsAndProperties.WithProjectReference(serviceDefaultsProjectFile.FullName);
+                        }
+                        else if (projectFile.FullName == serviceDefaultsProjectFile.FullName)
+                        {
+                            itemsAndProperties.WithPackageReference("Microsoft.Extensions.ServiceDiscovery", "9.4.1");
+                        }
+                        else
+                        {
+                            throw new InvalidOperationException("Unexpected project file.");
+                        }
+
+                        var json = itemsAndProperties.ToJsonString();
+                        var document = JsonDocument.Parse(json);
+                        return (0, document);
+                    },
+                    AddPackageAsyncCallback = (_, _, _, _, _, _, _) => 0,
+                };
+            };
+
+            config.InteractionServiceFactory = (s) => new TestInteractionService();
+        });
+        using var provider = services.BuildServiceProvider();
+
+        var packagingService = provider.GetRequiredService<IPackagingService>();
+        var channels = await packagingService.GetChannelsAsync().DefaultTimeout();
+        var selectedChannel = channels.Single(c => c.Name == "daily");
+
+        var projectUpdater = provider.GetRequiredService<IProjectUpdater>();
+        var updateResult = await projectUpdater.UpdateProjectAsync(CreateUpdateContext(appHostProjectFile, selectedChannel)).DefaultTimeout();
+
+        Assert.True(updateResult.UpdatedApplied);
+
+        // Post-condition: the updater MUST NOT have created aspire.config.json. Creating one
+        // would silently introduce config the user never asked for and contradict the comment
+        // in ProjectUpdater.GetUpdateStepsAsync claiming the rewrite is skipped when the file
+        // is absent.
+        aspireConfigFile.Refresh();
+        Assert.False(aspireConfigFile.Exists, "aspire update must not create aspire.config.json for projects that never had one.");
+    }
+
+    [Fact]
     public async Task UpdateProjectFileAsync_CanUpdateFromDailyToStableWhereOnePackageIsUnstableOnly()
     {
         using var workspace = TemporaryWorkspace.Create(outputHelper);


### PR DESCRIPTION
## Description

When a non-stable Aspire CLI (daily / staging / `pr-<N>` / local) ran `aspire init`, the scaffolded `aspire.config.json` was written without a top-level `channel` key. Downstream commands (`aspire add`, `aspire integration list`, `aspire integration search`) then had no channel context for the project and defaulted to the implicit nuget.org channel. The result: a daily-CLI user who ran `aspire init` followed by `aspire add orleans` would be offered the stable Orleans package version rather than the daily one that matches the CLI build they are actually dogfooding.

A parallel gap existed on the **update** path: `aspire update --channel <x>` against a C# AppHost rewrote NuGet.config and bumped packages, but left `aspire.config.json#channel` at its create-time value, so subsequent `aspire add` / `aspire update` runs against the same project kept resolving against the stale channel. The polyglot (TypeScript) update path in `GuestAppHostProject` already handled this; `ProjectUpdater` did not.

This PR fixes both:

### Init path
Passes `CliExecutionContext.IdentityChannel` through to:
- the single-file C# init path's `DropAspireConfig` helper, which now writes `settings["channel"]` when it is not already present
- the polyglot init path's `ScaffoldContext.Channel`, which the existing `ScaffoldingService` already persists into the polyglot template's `aspire.config.json` (covers TypeScript apphosts as well as any future polyglot languages)

Pre-existing `channel` values are preserved (the write is gated on `settings["channel"] is null` for C# and a pre-check in the polyglot path) so user-edited or migrated configs are not clobbered. Only channels that are registered as `Explicit` in the `IPackagingService` are persisted, mirroring `NewCommand`'s existing resolution logic — so implicit defaults (e.g. plain stable) are not pinned. Project-mode C# init is unchanged because the `aspire-apphost` template owns its own `aspire.config.json` and that mode already produces no top-level config file from init.

### Update path
Adds a new `ChannelUpdateStep` in `ProjectUpdater` that mirrors `GuestAppHostProject.UpdatePackagesInternalAsync`: after analysis, when the selected channel is Explicit and differs from the persisted value, the step re-loads `aspire.config.json` on apply, sets `Channel`, and saves. Implicit channels are intentionally left alone. The pre-confirm summary lists the channel change alongside any package updates so users see it in the prompt.

Fixes #17295.

### User-facing usage

#### C# single-file apphost

Running a daily CLI build:

```bash
aspire init
cat aspire.config.json
```

Before this change:

```json
{
  "appHost": {
    "path": "apphost.cs"
  },
  "profiles": {
    "https": { /* ... */ },
    "http":  { /* ... */ }
  }
}
```

After this change:

```json
{
  "appHost": {
    "path": "apphost.cs"
  },
  "channel": "daily",
  "profiles": {
    "https": { /* ... */ },
    "http":  { /* ... */ }
  }
}
```

#### TypeScript polyglot apphost

Running a daily CLI build with `--language typescript`:

```bash
aspire init --language typescript
cat aspire.config.json
```

Before this change:

```json
{
  "appHost": {
    "path": "apphost.mts"
  }
}
```

After this change:

```json
{
  "appHost": {
    "path": "apphost.mts"
  },
  "channel": "daily"
}
```

#### `aspire update --channel <x>` now rewrites `aspire.config.json#channel`

For any AppHost layout — C# single-file, C# `aspire-empty` project mode, TypeScript single-file, TypeScript project mode — running `aspire update --channel stable` (or `--channel daily`) against a project pinned to a different Explicit channel now updates `aspire.config.json#channel` in place, alongside the SDK/package updates.

`aspire add orleans` from any of these workspaces now resolves Orleans packages against the channel the user just switched to rather than the stale create-time channel.

### Tests

- Existing init tests (C# and polyglot)
- `ProjectUpdaterTests`: added unit tests for `ChannelUpdateStep.GetFormattedDisplayText` (with and without an existing channel value), and extended `UpdateProjectFileAsync_CanUpdateFromStableToDaily` to assert that `aspire.config.json#channel` is rewritten from `"stable"` to `"daily"`
- `ChannelUpdateWorkflowTests`: added three E2E regression tests so the create-path × language matrix is fully covered:
  - `UpdateProjectChannelToStable_CSharpSingleFileInit_RewritesAspireConfigChannel`
  - `UpdateProjectChannelToStable_CSharpEmptyAppHost_RewritesAspireConfigChannel`
  - `UpdateProjectChannelToStable_TypeScriptSingleFileInit_RewritesAspireConfigChannel`

  The existing `UpdateProjectChannelToStable_TypeScript_PicksUpStablePackages` covers the TS `aspire new` cell with package-version assertions.

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
  - [x] No
