### PR TITLE
Fix dashboard resource service scheme and generate HTTPS dev cert for non-.NET AppHosts

### DIFF
--- a/src/Aspire.Cli/Certificates/CertificateService.cs
+++ b/src/Aspire.Cli/Certificates/CertificateService.cs
@@ -87,7 +87,17 @@ internal sealed class CertificateService(
                 // non-.NET AppHost languages (TypeScript, Python, etc.) launch a prebuilt
                 // native binary and never invoke `dotnet`, so the first-run cert generation
                 // never triggers. This call ensures consistent behavior across all languages.
-                certificateToolRunner.EnsureHttpCertificateExists();
+                var generateResult = certificateToolRunner.EnsureHttpCertificateExists();
+
+                if (generateResult is EnsureCertificateResult.Succeeded or EnsureCertificateResult.ValidCertificatePresent)
+                {
+                    // Refresh the check so subsequent trust-level logic reflects the newly created cert.
+                    preCheck = certificateToolRunner.CheckHttpCertificate();
+                }
+                else
+                {
+                    interactionService.DisplayMessage(KnownEmojis.Warning, string.Format(CultureInfo.CurrentCulture, ErrorStrings.CertificateGenerationFailed, generateResult));
+                }
             }
 
             if (preCheck.IsPartiallyTrusted)

--- a/src/Aspire.Cli/Certificates/CertificateService.cs
+++ b/src/Aspire.Cli/Certificates/CertificateService.cs
@@ -7,6 +7,7 @@ using Aspire.Cli.Interaction;
 using Aspire.Cli.Resources;
 using Aspire.Cli.Telemetry;
 using Aspire.Cli.Utils;
+using Aspire.Hosting;
 using Microsoft.AspNetCore.Certificates.Generation;
 
 namespace Aspire.Cli.Certificates;
@@ -48,6 +49,7 @@ internal sealed class CertificateService(
     IInteractionService interactionService,
     AspireCliTelemetry telemetry,
     ICliHostEnvironment hostEnvironment,
+    CliExecutionContext executionContext,
     Func<bool>? isLinux = null) : ICertificateService
 {
     private const string SslCertDirEnvVar = "SSL_CERT_DIR";
@@ -71,7 +73,7 @@ internal sealed class CertificateService(
         {
             var preCheck = certificateToolRunner.CheckHttpCertificate();
 
-            if (!preCheck.HasCertificates)
+            if (!preCheck.HasCertificates && ShouldGenerateHttpsCertificate())
             {
                 // No certificate exists yet. Generate one without trusting it so that
                 // Kestrel's UseHttps() can load the cert from the personal store.
@@ -144,6 +146,17 @@ internal sealed class CertificateService(
             WasCancelled = trustResultCode == EnsureCertificateResult.UserCancelledTrustStep,
             ResultCode = trustResultCode
         };
+    }
+
+    /// <summary>
+    /// Checks whether automatic HTTPS certificate generation is enabled.
+    /// Set ASPIRE_CLI_GENERATE_HTTPS_CERTIFICATE=false to suppress generation,
+    /// mirroring the .NET SDK's DOTNET_GENERATE_ASPNET_CERTIFICATE opt-out.
+    /// </summary>
+    private bool ShouldGenerateHttpsCertificate()
+    {
+        var value = executionContext.GetEnvironmentVariable(KnownConfigNames.CliGenerateHttpsCertificate);
+        return !string.Equals(value, "false", StringComparison.OrdinalIgnoreCase);
     }
 
     private static void ConfigureSslCertDir(Dictionary<string, string> environmentVariables)

--- a/src/Aspire.Cli/Certificates/CertificateService.cs
+++ b/src/Aspire.Cli/Certificates/CertificateService.cs
@@ -61,8 +61,7 @@ internal sealed class CertificateService(
         var isLinux = _isLinux();
 
         // In non-interactive environments on macOS and Windows we can't successfully
-        // prompt for trust (macOS Keychain password, Windows trust dialog) and we also
-        // don't want to silently generate a new certificate that won't be trusted.
+        // prompt for trust (macOS Keychain password, Windows trust dialog).
         // Skip the trust attempt but still check the current state so we can warn when
         // the environment does not already have a trusted certificate. Linux trust is
         // non-interactive so it's safe to run the full flow there.
@@ -71,6 +70,24 @@ internal sealed class CertificateService(
         if (!canPerformTrust)
         {
             var preCheck = certificateToolRunner.CheckHttpCertificate();
+
+            if (!preCheck.HasCertificates)
+            {
+                // No certificate exists yet. Generate one without trusting it so that
+                // Kestrel's UseHttps() can load the cert from the personal store.
+                // Trust requires user interaction (Windows dialog / macOS Keychain) which
+                // is not possible here, but generation is non-interactive and safe.
+                //
+                // The .NET SDK's first-run experience normally handles this: the first
+                // invocation of any `dotnet` command calls EnsureAspNetCoreHttpsDevelopmentCertificate
+                // (trust: false) and writes a sentinel to ~/.dotnet/ so it only runs once per
+                // SDK version. For C# AppHosts this happens implicitly via `dotnet run`, but
+                // non-.NET AppHost languages (TypeScript, Python, etc.) launch a prebuilt
+                // native binary and never invoke `dotnet`, so the first-run cert generation
+                // never triggers. This call ensures consistent behavior across all languages.
+                certificateToolRunner.EnsureHttpCertificateExists();
+            }
+
             if (preCheck.IsPartiallyTrusted)
             {
                 interactionService.DisplayMessage(KnownEmojis.Warning, ErrorStrings.CertificatesPartiallyTrustedNonInteractive);

--- a/src/Aspire.Cli/Certificates/ICertificateToolRunner.cs
+++ b/src/Aspire.Cli/Certificates/ICertificateToolRunner.cs
@@ -16,6 +16,12 @@ internal interface ICertificateToolRunner
     CertificateTrustResult CheckHttpCertificate();
 
     /// <summary>
+    /// Ensures an HTTPS development certificate exists in the personal certificate store,
+    /// creating one if necessary, without trusting it.
+    /// </summary>
+    EnsureCertificateResult EnsureHttpCertificateExists();
+
+    /// <summary>
     /// Trusts the HTTPS development certificate, creating one if necessary.
     /// </summary>
     EnsureCertificateResult TrustHttpCertificate();

--- a/src/Aspire.Cli/Certificates/NativeCertificateToolRunner.cs
+++ b/src/Aspire.Cli/Certificates/NativeCertificateToolRunner.cs
@@ -68,7 +68,8 @@ internal sealed class NativeCertificateToolRunner(CertificateManager certificate
         var now = DateTimeOffset.Now;
         return certificateManager.EnsureAspNetCoreHttpsDevelopmentCertificate(
             now, now.Add(TimeSpan.FromDays(365)),
-            trust: false);
+            trust: false,
+            isInteractive: false);
     }
 
     public EnsureCertificateResult TrustHttpCertificate()

--- a/src/Aspire.Cli/Certificates/NativeCertificateToolRunner.cs
+++ b/src/Aspire.Cli/Certificates/NativeCertificateToolRunner.cs
@@ -63,6 +63,14 @@ internal sealed class NativeCertificateToolRunner(CertificateManager certificate
         }
     }
 
+    public EnsureCertificateResult EnsureHttpCertificateExists()
+    {
+        var now = DateTimeOffset.Now;
+        return certificateManager.EnsureAspNetCoreHttpsDevelopmentCertificate(
+            now, now.Add(TimeSpan.FromDays(365)),
+            trust: false);
+    }
+
     public EnsureCertificateResult TrustHttpCertificate()
     {
         if (_isLinux())

--- a/src/Aspire.Cli/Resources/ErrorStrings.Designer.cs
+++ b/src/Aspire.Cli/Resources/ErrorStrings.Designer.cs
@@ -109,6 +109,14 @@ namespace Aspire.Cli.Resources {
             }
         }
 
+        public static string CertificateGenerationFailed
+        {
+            get
+            {
+                return ResourceManager.GetString("CertificateGenerationFailed", resourceCulture);
+            }
+        }
+
         public static string CertificatesMayNotBeFullyTrusted
         {
             get

--- a/src/Aspire.Cli/Resources/ErrorStrings.resx
+++ b/src/Aspire.Cli/Resources/ErrorStrings.resx
@@ -139,6 +139,9 @@
   <data name="ExtensionIncompatibleWithCli" xml:space="preserve">
     <value>Aspire Extension is incompatible with the CLI. The Extension must be updated to a version that supports the {0} capability.</value>
   </data>
+  <data name="CertificateGenerationFailed" xml:space="preserve">
+    <value>Failed to generate HTTPS development certificate (result: {0}).</value>
+  </data>
   <data name="CertificatesMayNotBeFullyTrusted" xml:space="preserve">
     <value>Developer certificates may not be fully trusted (trust exit code was: {0}).</value>
   </data>

--- a/src/Aspire.Cli/Resources/xlf/ErrorStrings.cs.xlf
+++ b/src/Aspire.Cli/Resources/xlf/ErrorStrings.cs.xlf
@@ -37,6 +37,11 @@
         <target state="translated">Nelze použít --watch a --no-build současně.</target>
         <note />
       </trans-unit>
+      <trans-unit id="CertificateGenerationFailed">
+        <source>Failed to generate HTTPS development certificate (result: {0}).</source>
+        <target state="new">Failed to generate HTTPS development certificate (result: {0}).</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CertificatesMayNotBeFullyTrusted">
         <source>Developer certificates may not be fully trusted (trust exit code was: {0}).</source>
         <target state="translated">Vývojářské certifikáty nemusí být plně důvěryhodné (ukončovací kód vztahu důvěryhodnosti byl: {0}).</target>

--- a/src/Aspire.Cli/Resources/xlf/ErrorStrings.de.xlf
+++ b/src/Aspire.Cli/Resources/xlf/ErrorStrings.de.xlf
@@ -37,6 +37,11 @@
         <target state="translated">„--watch“ und „--no-build“ können nicht gleichzeitig verwendet werden.</target>
         <note />
       </trans-unit>
+      <trans-unit id="CertificateGenerationFailed">
+        <source>Failed to generate HTTPS development certificate (result: {0}).</source>
+        <target state="new">Failed to generate HTTPS development certificate (result: {0}).</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CertificatesMayNotBeFullyTrusted">
         <source>Developer certificates may not be fully trusted (trust exit code was: {0}).</source>
         <target state="translated">Entwicklerzertifikate sind möglicherweise nicht vollständig vertrauenswürdig (vertrauenswürdiger Exitcode war: {0}).</target>

--- a/src/Aspire.Cli/Resources/xlf/ErrorStrings.es.xlf
+++ b/src/Aspire.Cli/Resources/xlf/ErrorStrings.es.xlf
@@ -37,6 +37,11 @@
         <target state="translated">No se puede usar --watch y --no-build al mismo tiempo.</target>
         <note />
       </trans-unit>
+      <trans-unit id="CertificateGenerationFailed">
+        <source>Failed to generate HTTPS development certificate (result: {0}).</source>
+        <target state="new">Failed to generate HTTPS development certificate (result: {0}).</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CertificatesMayNotBeFullyTrusted">
         <source>Developer certificates may not be fully trusted (trust exit code was: {0}).</source>
         <target state="translated">Es posible que los certificados de desarrollador no sean de plena confianza (el código de salida de confianza era: {0}).</target>

--- a/src/Aspire.Cli/Resources/xlf/ErrorStrings.fr.xlf
+++ b/src/Aspire.Cli/Resources/xlf/ErrorStrings.fr.xlf
@@ -37,6 +37,11 @@
         <target state="translated">Impossible d’utiliser --watch et --no-build en même temps.</target>
         <note />
       </trans-unit>
+      <trans-unit id="CertificateGenerationFailed">
+        <source>Failed to generate HTTPS development certificate (result: {0}).</source>
+        <target state="new">Failed to generate HTTPS development certificate (result: {0}).</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CertificatesMayNotBeFullyTrusted">
         <source>Developer certificates may not be fully trusted (trust exit code was: {0}).</source>
         <target state="translated">Les certificats de développeur ne sont peut-être pas entièrement approuvés (le code de sortie d’approbation était : {0}).</target>

--- a/src/Aspire.Cli/Resources/xlf/ErrorStrings.it.xlf
+++ b/src/Aspire.Cli/Resources/xlf/ErrorStrings.it.xlf
@@ -37,6 +37,11 @@
         <target state="translated">Non è possibile usare --watch e --no-build contemporaneamente.</target>
         <note />
       </trans-unit>
+      <trans-unit id="CertificateGenerationFailed">
+        <source>Failed to generate HTTPS development certificate (result: {0}).</source>
+        <target state="new">Failed to generate HTTPS development certificate (result: {0}).</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CertificatesMayNotBeFullyTrusted">
         <source>Developer certificates may not be fully trusted (trust exit code was: {0}).</source>
         <target state="translated">I certificati per sviluppatori potrebbero non essere completamente attendibili (codice di uscita attendibilità: {0}).</target>

--- a/src/Aspire.Cli/Resources/xlf/ErrorStrings.ja.xlf
+++ b/src/Aspire.Cli/Resources/xlf/ErrorStrings.ja.xlf
@@ -37,6 +37,11 @@
         <target state="translated">--watch と --no-build を同時に使用することはできません。</target>
         <note />
       </trans-unit>
+      <trans-unit id="CertificateGenerationFailed">
+        <source>Failed to generate HTTPS development certificate (result: {0}).</source>
+        <target state="new">Failed to generate HTTPS development certificate (result: {0}).</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CertificatesMayNotBeFullyTrusted">
         <source>Developer certificates may not be fully trusted (trust exit code was: {0}).</source>
         <target state="translated">開発者証明書が完全に信頼されていない可能性があります (信頼終了コード: {0})。</target>

--- a/src/Aspire.Cli/Resources/xlf/ErrorStrings.ko.xlf
+++ b/src/Aspire.Cli/Resources/xlf/ErrorStrings.ko.xlf
@@ -37,6 +37,11 @@
         <target state="translated">--watch와 --no-build를 동시에 사용할 수 없습니다.</target>
         <note />
       </trans-unit>
+      <trans-unit id="CertificateGenerationFailed">
+        <source>Failed to generate HTTPS development certificate (result: {0}).</source>
+        <target state="new">Failed to generate HTTPS development certificate (result: {0}).</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CertificatesMayNotBeFullyTrusted">
         <source>Developer certificates may not be fully trusted (trust exit code was: {0}).</source>
         <target state="translated">개발자 인증서를 완전히 신뢰할 수 없습니다(신뢰 종료 코드: {0}).</target>

--- a/src/Aspire.Cli/Resources/xlf/ErrorStrings.pl.xlf
+++ b/src/Aspire.Cli/Resources/xlf/ErrorStrings.pl.xlf
@@ -37,6 +37,11 @@
         <target state="translated">Nie można używać jednocześnie opcji --watch i --no-build.</target>
         <note />
       </trans-unit>
+      <trans-unit id="CertificateGenerationFailed">
+        <source>Failed to generate HTTPS development certificate (result: {0}).</source>
+        <target state="new">Failed to generate HTTPS development certificate (result: {0}).</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CertificatesMayNotBeFullyTrusted">
         <source>Developer certificates may not be fully trusted (trust exit code was: {0}).</source>
         <target state="translated">Certyfikaty dewelopera mogą nie być w pełni zaufane (kod zakończenia zaufania: {0}).</target>

--- a/src/Aspire.Cli/Resources/xlf/ErrorStrings.pt-BR.xlf
+++ b/src/Aspire.Cli/Resources/xlf/ErrorStrings.pt-BR.xlf
@@ -37,6 +37,11 @@
         <target state="translated">Não é possível usar --watch e --no-build ao mesmo tempo.</target>
         <note />
       </trans-unit>
+      <trans-unit id="CertificateGenerationFailed">
+        <source>Failed to generate HTTPS development certificate (result: {0}).</source>
+        <target state="new">Failed to generate HTTPS development certificate (result: {0}).</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CertificatesMayNotBeFullyTrusted">
         <source>Developer certificates may not be fully trusted (trust exit code was: {0}).</source>
         <target state="translated">Os certificados de desenvolvedor podem não ser totalmente confiáveis (o código de saída de confiança era: {0}).</target>

--- a/src/Aspire.Cli/Resources/xlf/ErrorStrings.ru.xlf
+++ b/src/Aspire.Cli/Resources/xlf/ErrorStrings.ru.xlf
@@ -37,6 +37,11 @@
         <target state="translated">Одновременное использование --watch и --no-build невозможно.</target>
         <note />
       </trans-unit>
+      <trans-unit id="CertificateGenerationFailed">
+        <source>Failed to generate HTTPS development certificate (result: {0}).</source>
+        <target state="new">Failed to generate HTTPS development certificate (result: {0}).</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CertificatesMayNotBeFullyTrusted">
         <source>Developer certificates may not be fully trusted (trust exit code was: {0}).</source>
         <target state="translated">Сертификаты разработчика могут быть не полностью доверенными (код завершения доверия: {0}).</target>

--- a/src/Aspire.Cli/Resources/xlf/ErrorStrings.tr.xlf
+++ b/src/Aspire.Cli/Resources/xlf/ErrorStrings.tr.xlf
@@ -37,6 +37,11 @@
         <target state="translated">--watch ve --no-build aynı anda kullanılamaz.</target>
         <note />
       </trans-unit>
+      <trans-unit id="CertificateGenerationFailed">
+        <source>Failed to generate HTTPS development certificate (result: {0}).</source>
+        <target state="new">Failed to generate HTTPS development certificate (result: {0}).</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CertificatesMayNotBeFullyTrusted">
         <source>Developer certificates may not be fully trusted (trust exit code was: {0}).</source>
         <target state="translated">Geliştirici sertifikaları tam olarak güvenilir olmayabilir (güven çıkış kodu şuydu: {0}).</target>

--- a/src/Aspire.Cli/Resources/xlf/ErrorStrings.zh-Hans.xlf
+++ b/src/Aspire.Cli/Resources/xlf/ErrorStrings.zh-Hans.xlf
@@ -37,6 +37,11 @@
         <target state="translated">不能同时使用 --watch 和 --no-build。</target>
         <note />
       </trans-unit>
+      <trans-unit id="CertificateGenerationFailed">
+        <source>Failed to generate HTTPS development certificate (result: {0}).</source>
+        <target state="new">Failed to generate HTTPS development certificate (result: {0}).</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CertificatesMayNotBeFullyTrusted">
         <source>Developer certificates may not be fully trusted (trust exit code was: {0}).</source>
         <target state="translated">开发人员证书可能不完全受信任(信任退出代码为: {0})。</target>

--- a/src/Aspire.Cli/Resources/xlf/ErrorStrings.zh-Hant.xlf
+++ b/src/Aspire.Cli/Resources/xlf/ErrorStrings.zh-Hant.xlf
@@ -37,6 +37,11 @@
         <target state="translated">無法同時使用 --watch 和 --no-build。</target>
         <note />
       </trans-unit>
+      <trans-unit id="CertificateGenerationFailed">
+        <source>Failed to generate HTTPS development certificate (result: {0}).</source>
+        <target state="new">Failed to generate HTTPS development certificate (result: {0}).</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CertificatesMayNotBeFullyTrusted">
         <source>Developer certificates may not be fully trusted (trust exit code was: {0}).</source>
         <target state="translated">開發人員憑證可能未完全受信任 (信任結束代碼為: {0})。</target>

--- a/src/Aspire.Hosting/Dashboard/DashboardServiceHost.cs
+++ b/src/Aspire.Hosting/Dashboard/DashboardServiceHost.cs
@@ -138,21 +138,16 @@ internal sealed class DashboardServiceHost : IHostedService
             var uri = configuration.GetUri(ResourceServiceUrlVariableName);
             var allowUnsecuredTransport = configuration.GetBool(KnownConfigNames.AllowUnsecuredTransport) ?? false;
 
-            string? scheme;
+            var scheme = ResolveScheme(uri, allowUnsecuredTransport);
 
             if (uri is null)
             {
-                // No URI available from the environment.
-                scheme = allowUnsecuredTransport ? "http" : "https";
-
                 // Listen on a random port.
                 kestrelOptions.Listen(IPAddress.Loopback, port: 0, ConfigureListen);
                 _logger.LogDebug("Resource service endpoint not configured. Listening on {Scheme}://127.0.0.1:<random>.", scheme);
             }
             else if (uri.IsLoopback)
             {
-                scheme = uri.Scheme;
-
                 // Listen on the requested localhost port.
                 kestrelOptions.ListenLocalhost(uri.Port, ConfigureListen);
                 _logger.LogDebug("Resource service endpoint configured: {Uri}", uri);
@@ -174,6 +169,21 @@ internal sealed class DashboardServiceHost : IHostedService
                 }
             }
         }
+    }
+
+    /// <summary>
+    /// Determines the scheme for the resource service endpoint. When a URI is explicitly
+    /// configured, its scheme is used. When no URI is provided, defaults to HTTPS unless
+    /// unsecured transport is explicitly allowed.
+    /// </summary>
+    internal static string ResolveScheme(Uri? configuredUri, bool allowUnsecuredTransport)
+    {
+        if (configuredUri is not null)
+        {
+            return configuredUri.Scheme;
+        }
+
+        return allowUnsecuredTransport ? "http" : "https";
     }
 
     /// <summary>

--- a/src/Aspire.Hosting/Dashboard/DashboardServiceHost.cs
+++ b/src/Aspire.Hosting/Dashboard/DashboardServiceHost.cs
@@ -18,8 +18,6 @@ using Microsoft.Extensions.Options;
 
 namespace Aspire.Hosting.Dashboard;
 
-#pragma warning disable ASPIREINTERACTION001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
-
 /// <summary>
 /// Hosts a gRPC service via <see cref="DashboardService"/> (aka the "Resource Service") that a dashboard can connect to.
 /// Configures DI and networking options for the service.
@@ -138,17 +136,18 @@ internal sealed class DashboardServiceHost : IHostedService
         {
             // Inspect environment for the address to listen on.
             var uri = configuration.GetUri(ResourceServiceUrlVariableName);
+            var allowUnsecuredTransport = configuration.GetBool(KnownConfigNames.AllowUnsecuredTransport) ?? false;
 
             string? scheme;
 
             if (uri is null)
             {
                 // No URI available from the environment.
-                scheme = null;
+                scheme = allowUnsecuredTransport ? "http" : "https";
 
                 // Listen on a random port.
                 kestrelOptions.Listen(IPAddress.Loopback, port: 0, ConfigureListen);
-                _logger.LogDebug("Resource service endpoint not configured. Listening on {Scheme}://127.0.0.1:<random>.", scheme ?? "http");
+                _logger.LogDebug("Resource service endpoint not configured. Listening on {Scheme}://127.0.0.1:<random>.", scheme);
             }
             else if (uri.IsLoopback)
             {
@@ -228,5 +227,3 @@ internal sealed class DashboardServiceHost : IHostedService
         }
     }
 }
-
-#pragma warning restore ASPIREINTERACTION001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.

--- a/src/Shared/KnownConfigNames.cs
+++ b/src/Shared/KnownConfigNames.cs
@@ -35,6 +35,7 @@ internal static class KnownConfigNames
     public const string CliProcessStarted = "ASPIRE_CLI_STARTED";
     public const string CliLogFilePath = "ASPIRE_CLI_LOG_FILE";
     public const string CliRunDetached = "ASPIRE_CLI_RUN_DETACHED";
+    public const string CliGenerateHttpsCertificate = "ASPIRE_CLI_GENERATE_HTTPS_CERTIFICATE";
     public const string IntegrationLibsPath = "ASPIRE_INTEGRATION_LIBS_PATH";
     public const string IntegrationProbeManifestPath = "ASPIRE_INTEGRATION_PROBE_MANIFEST_PATH";
     public const string ForceRichConsole = "ASPIRE_FORCE_RICH_CONSOLE";

--- a/tests/Aspire.Cli.Tests/Certificates/CertificateServiceTests.cs
+++ b/tests/Aspire.Cli.Tests/Certificates/CertificateServiceTests.cs
@@ -7,6 +7,7 @@ using Aspire.Cli.Telemetry;
 using Aspire.Cli.Tests.TestServices;
 using Aspire.Cli.Tests.Utils;
 using Aspire.Cli.Utils;
+using Aspire.Hosting;
 using Microsoft.AspNetCore.Certificates.Generation;
 using Microsoft.AspNetCore.InternalTesting;
 using Microsoft.Extensions.Configuration;
@@ -332,6 +333,126 @@ public class CertificateServiceTests(ITestOutputHelper outputHelper)
         var result = await cs.EnsureCertificatesTrustedAsync(TestContext.Current.CancellationToken).DefaultTimeout();
 
         Assert.True(trustCalled);
+        Assert.True(result.Success);
+    }
+
+    [Fact]
+    public async Task EnsureCertificatesTrustedAsync_NonInteractive_GeneratesCertWhenNoneExist()
+    {
+        Assert.SkipWhen(OperatingSystem.IsLinux(), "Non-interactive cert generation test only applies to macOS/Windows.");
+
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        var generateCalled = false;
+
+        var toolRunner = new TestCertificateToolRunner
+        {
+            CheckHttpCertificateCallback = () => CreateTrustResult(null),
+            EnsureHttpCertificateExistsCallback = () =>
+            {
+                generateCalled = true;
+                return EnsureCertificateResult.Succeeded;
+            }
+        };
+
+        var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper, options =>
+        {
+            options.CertificateToolRunnerFactory = _ => toolRunner;
+            options.CliHostEnvironmentFactory = sp =>
+            {
+                var configuration = sp.GetRequiredService<IConfiguration>();
+                return new CliHostEnvironment(configuration, nonInteractive: true);
+            };
+            options.InteractionServiceFactory = _ => new TestInteractionService();
+        });
+
+        using var sp = services.BuildServiceProvider();
+        var cs = sp.GetRequiredService<ICertificateService>();
+
+        var result = await cs.EnsureCertificatesTrustedAsync(TestContext.Current.CancellationToken).DefaultTimeout();
+
+        Assert.True(generateCalled);
+        Assert.True(result.Success);
+    }
+
+    [Fact]
+    public async Task EnsureCertificatesTrustedAsync_NonInteractive_SkipsCertGenerationWhenCertsExist()
+    {
+        Assert.SkipWhen(OperatingSystem.IsLinux(), "Non-interactive cert generation test only applies to macOS/Windows.");
+
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        var generateCalled = false;
+
+        var toolRunner = new TestCertificateToolRunner
+        {
+            CheckHttpCertificateCallback = () => CreateTrustResult(CertificateManager.TrustLevel.Full),
+            EnsureHttpCertificateExistsCallback = () =>
+            {
+                generateCalled = true;
+                return EnsureCertificateResult.Succeeded;
+            }
+        };
+
+        var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper, options =>
+        {
+            options.CertificateToolRunnerFactory = _ => toolRunner;
+            options.CliHostEnvironmentFactory = sp =>
+            {
+                var configuration = sp.GetRequiredService<IConfiguration>();
+                return new CliHostEnvironment(configuration, nonInteractive: true);
+            };
+        });
+
+        using var sp = services.BuildServiceProvider();
+        var cs = sp.GetRequiredService<ICertificateService>();
+
+        var result = await cs.EnsureCertificatesTrustedAsync(TestContext.Current.CancellationToken).DefaultTimeout();
+
+        Assert.False(generateCalled);
+        Assert.True(result.Success);
+    }
+
+    [Fact]
+    public async Task EnsureCertificatesTrustedAsync_NonInteractive_EnvVarOptOutSuppressesCertGeneration()
+    {
+        Assert.SkipWhen(OperatingSystem.IsLinux(), "Non-interactive cert generation test only applies to macOS/Windows.");
+
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        var generateCalled = false;
+
+        var toolRunner = new TestCertificateToolRunner
+        {
+            CheckHttpCertificateCallback = () => CreateTrustResult(null),
+            EnsureHttpCertificateExistsCallback = () =>
+            {
+                generateCalled = true;
+                return EnsureCertificateResult.Succeeded;
+            }
+        };
+
+        var envVars = new Dictionary<string, string?>
+        {
+            [KnownConfigNames.CliGenerateHttpsCertificate] = "false"
+        };
+
+        var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper, options =>
+        {
+            options.CertificateToolRunnerFactory = _ => toolRunner;
+            options.CliHostEnvironmentFactory = sp =>
+            {
+                var configuration = sp.GetRequiredService<IConfiguration>();
+                return new CliHostEnvironment(configuration, nonInteractive: true);
+            };
+            options.CliExecutionContextFactory = _ => TestExecutionContextHelper.CreateExecutionContext(
+                workspace.WorkspaceRoot, environmentVariables: envVars);
+            options.InteractionServiceFactory = _ => new TestInteractionService();
+        });
+
+        using var sp = services.BuildServiceProvider();
+        var cs = sp.GetRequiredService<ICertificateService>();
+
+        var result = await cs.EnsureCertificatesTrustedAsync(TestContext.Current.CancellationToken).DefaultTimeout();
+
+        Assert.False(generateCalled);
         Assert.True(result.Success);
     }
 

--- a/tests/Aspire.Cli.Tests/Certificates/CertificateServiceTests.cs
+++ b/tests/Aspire.Cli.Tests/Certificates/CertificateServiceTests.cs
@@ -3,6 +3,7 @@
 
 using Aspire.Cli.Certificates;
 using Aspire.Cli.Interaction;
+using Aspire.Cli.Resources;
 using Aspire.Cli.Telemetry;
 using Aspire.Cli.Tests.TestServices;
 using Aspire.Cli.Tests.Utils;
@@ -460,6 +461,41 @@ public class CertificateServiceTests(ITestOutputHelper outputHelper)
 
         Assert.False(generateCalled);
         Assert.True(result.Success);
+    }
+
+    [Fact]
+    public async Task EnsureCertificatesTrustedAsync_NonInteractive_WarnsOnCertGenerationFailure()
+    {
+        Assert.SkipWhen(OperatingSystem.IsLinux(), "Non-interactive cert generation test only applies to macOS/Windows.");
+
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+
+        var toolRunner = new TestCertificateToolRunner
+        {
+            CheckHttpCertificateCallback = () => CreateNoCertsResult(),
+            EnsureHttpCertificateExistsCallback = () => EnsureCertificateResult.ErrorCreatingTheCertificate
+        };
+
+        var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper, options =>
+        {
+            options.CertificateToolRunnerFactory = _ => toolRunner;
+            options.CliHostEnvironmentFactory = sp =>
+            {
+                var configuration = sp.GetRequiredService<IConfiguration>();
+                return new CliHostEnvironment(configuration, nonInteractive: true);
+            };
+            options.InteractionServiceFactory = _ => new TestInteractionService();
+        });
+
+        using var sp = services.BuildServiceProvider();
+        var cs = sp.GetRequiredService<ICertificateService>();
+        var interactionService = (TestInteractionService)sp.GetRequiredService<IInteractionService>();
+
+        var result = await cs.EnsureCertificatesTrustedAsync(TestContext.Current.CancellationToken).DefaultTimeout();
+
+        Assert.True(result.Success);
+        var expectedMessage = string.Format(System.Globalization.CultureInfo.CurrentCulture, ErrorStrings.CertificateGenerationFailed, EnsureCertificateResult.ErrorCreatingTheCertificate);
+        Assert.Contains(interactionService.DisplayedMessages, m => m.Message == expectedMessage);
     }
 
     private ServiceProvider CreateServiceProvider(TemporaryWorkspace workspace, TestCertificateToolRunner toolRunner, bool nonInteractive = false, Func<bool>? isLinux = null)

--- a/tests/Aspire.Cli.Tests/Certificates/CertificateServiceTests.cs
+++ b/tests/Aspire.Cli.Tests/Certificates/CertificateServiceTests.cs
@@ -321,7 +321,8 @@ public class CertificateServiceTests(ITestOutputHelper outputHelper)
                 var interactiveService = sp.GetRequiredService<IInteractionService>();
                 var telemetry = sp.GetRequiredService<AspireCliTelemetry>();
                 var hostEnvironment = sp.GetRequiredService<ICliHostEnvironment>();
-                return new CertificateService(toolRunner, interactiveService, telemetry, hostEnvironment, isLinux: () => true);
+                var executionContext = sp.GetRequiredService<CliExecutionContext>();
+                return new CertificateService(toolRunner, interactiveService, telemetry, hostEnvironment, executionContext, isLinux: () => true);
             };
         });
 
@@ -349,7 +350,8 @@ public class CertificateServiceTests(ITestOutputHelper outputHelper)
                 var interactiveService = sp.GetRequiredService<IInteractionService>();
                 var telemetry = sp.GetRequiredService<AspireCliTelemetry>();
                 var hostEnvironment = sp.GetRequiredService<ICliHostEnvironment>();
-                return new CertificateService(toolRunner, interactiveService, telemetry, hostEnvironment, isLinux);
+                var executionContext = sp.GetRequiredService<CliExecutionContext>();
+                return new CertificateService(toolRunner, interactiveService, telemetry, hostEnvironment, executionContext, isLinux);
             };
         });
 

--- a/tests/Aspire.Cli.Tests/Certificates/CertificateServiceTests.cs
+++ b/tests/Aspire.Cli.Tests/Certificates/CertificateServiceTests.cs
@@ -343,10 +343,16 @@ public class CertificateServiceTests(ITestOutputHelper outputHelper)
 
         using var workspace = TemporaryWorkspace.Create(outputHelper);
         var generateCalled = false;
+        var checkCallCount = 0;
 
         var toolRunner = new TestCertificateToolRunner
         {
-            CheckHttpCertificateCallback = () => CreateTrustResult(null),
+            CheckHttpCertificateCallback = () =>
+            {
+                checkCallCount++;
+                // First call: no certs exist. Second call (after generation): untrusted cert present.
+                return checkCallCount == 1 ? CreateNoCertsResult() : CreateTrustResult(CertificateManager.TrustLevel.None);
+            },
             EnsureHttpCertificateExistsCallback = () =>
             {
                 generateCalled = true;
@@ -421,7 +427,7 @@ public class CertificateServiceTests(ITestOutputHelper outputHelper)
 
         var toolRunner = new TestCertificateToolRunner
         {
-            CheckHttpCertificateCallback = () => CreateTrustResult(null),
+            CheckHttpCertificateCallback = () => CreateNoCertsResult(),
             EnsureHttpCertificateExistsCallback = () =>
             {
                 generateCalled = true;
@@ -479,16 +485,21 @@ public class CertificateServiceTests(ITestOutputHelper outputHelper)
         return services.BuildServiceProvider();
     }
 
+    private static CertificateTrustResult CreateNoCertsResult()
+    {
+        return new CertificateTrustResult
+        {
+            HasCertificates = false,
+            TrustLevel = null,
+            Certificates = []
+        };
+    }
+
     private static CertificateTrustResult CreateTrustResult(CertificateManager.TrustLevel? trustLevel)
     {
         if (trustLevel is null)
         {
-            return new CertificateTrustResult
-            {
-                HasCertificates = false,
-                TrustLevel = null,
-                Certificates = []
-            };
+            return CreateNoCertsResult();
         }
 
         return new CertificateTrustResult

--- a/tests/Aspire.Cli.Tests/Commands/CertificatesCommandTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/CertificatesCommandTests.cs
@@ -99,7 +99,8 @@ public class CertificatesCommandTests(ITestOutputHelper outputHelper)
             {
                 var telemetry = sp.GetRequiredService<AspireCliTelemetry>();
                 var hostEnvironment = sp.GetRequiredService<ICliHostEnvironment>();
-                return new CertificateService(toolRunner, interactionService, telemetry, hostEnvironment, isLinux: () => true);
+                var executionContext = sp.GetRequiredService<CliExecutionContext>();
+                return new CertificateService(toolRunner, interactionService, telemetry, hostEnvironment, executionContext, isLinux: () => true);
             };
         });
         using var provider = services.BuildServiceProvider();

--- a/tests/Aspire.Cli.Tests/TestServices/TestCertificateToolRunner.cs
+++ b/tests/Aspire.Cli.Tests/TestServices/TestCertificateToolRunner.cs
@@ -37,7 +37,7 @@ internal sealed class TestCertificateToolRunner : ICertificateToolRunner
     {
         return EnsureHttpCertificateExistsCallback is not null
             ? EnsureHttpCertificateExistsCallback()
-            : EnsureCertificateResult.ExistingHttpsCertificateTrusted;
+            : EnsureCertificateResult.Succeeded;
     }
 
     public EnsureCertificateResult TrustHttpCertificate()

--- a/tests/Aspire.Cli.Tests/TestServices/TestCertificateToolRunner.cs
+++ b/tests/Aspire.Cli.Tests/TestServices/TestCertificateToolRunner.cs
@@ -13,6 +13,7 @@ namespace Aspire.Cli.Tests.TestServices;
 internal sealed class TestCertificateToolRunner : ICertificateToolRunner
 {
     public Func<CertificateTrustResult>? CheckHttpCertificateCallback { get; set; }
+    public Func<EnsureCertificateResult>? EnsureHttpCertificateExistsCallback { get; set; }
     public Func<EnsureCertificateResult>? TrustHttpCertificateCallback { get; set; }
     public Func<CertificateCleanResult>? CleanHttpCertificateCallback { get; set; }
 
@@ -30,6 +31,13 @@ internal sealed class TestCertificateToolRunner : ICertificateToolRunner
             TrustLevel = CertificateManager.TrustLevel.Full,
             Certificates = []
         };
+    }
+
+    public EnsureCertificateResult EnsureHttpCertificateExists()
+    {
+        return EnsureHttpCertificateExistsCallback is not null
+            ? EnsureHttpCertificateExistsCallback()
+            : EnsureCertificateResult.ExistingHttpsCertificateTrusted;
     }
 
     public EnsureCertificateResult TrustHttpCertificate()

--- a/tests/Aspire.Cli.Tests/Utils/CliTestHelper.cs
+++ b/tests/Aspire.Cli.Tests/Utils/CliTestHelper.cs
@@ -467,7 +467,8 @@ internal sealed class CliServiceCollectionTestOptions
         var interactiveService = serviceProvider.GetRequiredService<IInteractionService>();
         var telemetry = serviceProvider.GetRequiredService<AspireCliTelemetry>();
         var hostEnvironment = serviceProvider.GetRequiredService<ICliHostEnvironment>();
-        return new CertificateService(certificateToolRunner, interactiveService, telemetry, hostEnvironment);
+        var executionContext = serviceProvider.GetRequiredService<CliExecutionContext>();
+        return new CertificateService(certificateToolRunner, interactiveService, telemetry, hostEnvironment, executionContext);
     };
 
     public Func<IServiceProvider, IScaffoldingService> ScaffoldingServiceFactory { get; set; } = (IServiceProvider serviceProvider) =>

--- a/tests/Aspire.Hosting.Tests/Dashboard/DashboardServiceHostTests.cs
+++ b/tests/Aspire.Hosting.Tests/Dashboard/DashboardServiceHostTests.cs
@@ -1,0 +1,25 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Aspire.Hosting.Dashboard;
+
+namespace Aspire.Hosting.Tests.Dashboard;
+
+[Trait("Partition", "3")]
+public class DashboardServiceHostTests
+{
+    [Theory]
+    [InlineData(null, false, "https")]
+    [InlineData(null, true, "http")]
+    [InlineData("https://localhost:5001", false, "https")]
+    [InlineData("http://localhost:5000", true, "http")]
+    [InlineData("http://localhost:5000", false, "http")] // Explicit URI scheme wins regardless of allowUnsecuredTransport. Should never happen because of validation.
+    public void ResolveScheme_ReturnsExpectedScheme(string? uriString, bool allowUnsecuredTransport, string expectedScheme)
+    {
+        var uri = uriString is not null ? new Uri(uriString) : null;
+
+        var scheme = DashboardServiceHost.ResolveScheme(configuredUri: uri, allowUnsecuredTransport: allowUnsecuredTransport);
+
+        Assert.Equal(expectedScheme, scheme);
+    }
+}


### PR DESCRIPTION
## Summary

Fixes a CI test failure where the TypeScript starter template fails because the dashboard resource service defaults to HTTPS but no dev certificate exists when the AppHost isn't a .NET project (so `dotnet run` never triggers first-run cert generation).

## Changes

### DashboardServiceHost scheme resolution (`src/Aspire.Hosting/Dashboard/DashboardServiceHost.cs`)
- Extracted `ResolveScheme(Uri? configuredUri, bool allowUnsecuredTransport)` as an internal static method for testability
- When no dashboard URL is configured, the scheme now correctly defaults to HTTPS unless `AllowUnsecuredTransport` is set

### Non-interactive HTTPS certificate generation (`src/Aspire.Cli/Certificates/`)
- In non-interactive mode, `CertificateService` now automatically generates an HTTPS dev certificate when none exists
- Added `EnsureHttpCertificateExists()` to `ICertificateToolRunner` / `NativeCertificateToolRunner` that calls `CertificateManager.EnsureAspNetCoreHttpsDevelopmentCertificate`
- After generation, refreshes the certificate check state
- Displays a warning if generation fails

### Opt-out via environment variable
- Added `ASPIRE_CLI_GENERATE_HTTPS_CERTIFICATE` to `KnownConfigNames`
- Setting this to `"false"` skips automatic certificate generation

### Tests
- `DashboardServiceHostTests.ResolveScheme_ReturnsExpectedScheme` — theory covering all scheme resolution cases
- `CertificateServiceTests` — new tests for cert generation when none exist, skipping when certs exist, env var opt-out, and warning on failure

## Fixes
Fixes the TypeScript starter CI test failure caused by missing HTTPS dev cert when the dashboard resource service defaults to HTTPS.