### PR TITLE
Fix `stop --all` to return success when no app hosts are running

### DIFF
--- a/src/Aspire.Cli/Commands/StopCommand.cs
+++ b/src/Aspire.Cli/Commands/StopCommand.cs
@@ -160,8 +160,8 @@ internal sealed class StopCommand : BaseCommand
 
         if (allConnections.Length == 0)
         {
-            _interactionService.DisplayError(SharedCommandStrings.AppHostNotRunning);
-            return CliExitCodes.FailedToFindProject;
+            _interactionService.DisplayMessage(KnownEmojis.Information, SharedCommandStrings.AppHostNotRunning);
+            return CliExitCodes.Success;
         }
 
         _logger.LogDebug("Found {Count} running AppHost(s) to stop", allConnections.Length);

--- a/tests/Aspire.Cli.Tests/Commands/StopCommandTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/StopCommandTests.cs
@@ -290,6 +290,33 @@ public class StopCommandTests(ITestOutputHelper outputHelper)
         Assert.All(stopAppHostActivities, activity => Assert.Equal(CliExitCodes.Success, activity.GetTagItem(TelemetryConstants.Tags.ProcessExitCode)));
     }
 
+    [Theory]
+    [InlineData("stop")]
+    [InlineData("stop --all")]
+    public async Task StopCommand_NoRunningAppHosts_ReturnsSuccess(string commandLine)
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        var interactionService = new TestInteractionService();
+        var monitor = new TestAuxiliaryBackchannelMonitor();
+
+        var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper, options =>
+        {
+            options.InteractionServiceFactory = _ => interactionService;
+            options.AuxiliaryBackchannelMonitorFactory = _ => monitor;
+            options.CliHostEnvironmentFactory = _ => TestHelpers.CreateInteractiveHostEnvironment();
+        });
+        using var provider = services.BuildServiceProvider();
+
+        var command = provider.GetRequiredService<RootCommand>();
+        var result = command.Parse(commandLine);
+
+        var exitCode = await result.InvokeAsync().DefaultTimeout();
+
+        Assert.Equal(CliExitCodes.Success, exitCode);
+        var displayedMessage = Assert.Single(interactionService.DisplayedMessages);
+        Assert.Equal(SharedCommandStrings.AppHostNotRunning, displayedMessage.Message);
+    }
+
     private static TestAppHostAuxiliaryBackchannel CreateConnection(string appHostPath, int processId, bool isInScope = true)
     {
         return new TestAppHostAuxiliaryBackchannel


### PR DESCRIPTION
## Description

Make `aspire stop --all` return exit code 0 (Success) with an informational message when no app hosts are running, consistent with the interactive `aspire stop` behavior.

Previously, `--all` returned exit code 7 (FailedToFindProject) and displayed an error, while the interactive path returned Success with an info message. This inconsistency made scripting scenarios fail unnecessarily.

## Changes

- **`src/Aspire.Cli/Commands/StopCommand.cs`**: Changed `StopAllAppHostsAsync` to use `DisplayMessage` with `KnownEmojis.Information` and return `CliExitCodes.Success` when no connections are found (instead of `DisplayError` + `FailedToFindProject`).
- **`tests/Aspire.Cli.Tests/Commands/StopCommandTests.cs`**: Added a parameterized `[Theory]` test covering both the interactive `stop` and `stop --all` paths to verify they return success with the expected informational message.

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
  - [x] No