### PR TITLE
Support arbitrary IValueProvider sources in Docker Compose .env file generation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -263,6 +263,7 @@ kill <pid>
 * Do not use Directory.SetCurrentDirectory in tests as it can cause side effects when tests execute concurrently.
 * Prefer using shared test service implementations (e.g., project-level `TestServices/` or `Helpers/` directories, or the cross-project `tests/Shared/` folder) rather than creating private implementation classes within individual test files. Reusing existing test fakes and helpers keeps tests consistent, reduces duplication, and makes maintenance easier. Do not create private test classes when a shared one already exists or can be extended.
 * MTP diagnostic args (hang dump, crash dump, exit code handling) are defined in `eng/Testing.props` via `MtpBaseArgs`. Do not hardcode these args in workflow YAML. See [docs/ci/mtp-args-pipeline.md](docs/ci/mtp-args-pipeline.md) for details.
+* Use `Verify` (snapshot testing) for generated artifacts (files, serialized output, structured text). Prefer `await Verify(value, "ext")` over `Assert.Contains` / `Assert.DoesNotContain` / `Assert.Equal` on the same value. Run the test once to generate the `.received.` file, review it, then rename it to `.verified.` to accept it.
 
 ## Running tests
 

--- a/src/Aspire.Hosting.Docker/DockerComposeEnvironmentResource.cs
+++ b/src/Aspire.Hosting.Docker/DockerComposeEnvironmentResource.cs
@@ -515,14 +515,16 @@ public class DockerComposeEnvironmentResource : Resource, IComputeEnvironmentRes
             var envVar = entry.Value;
             var defaultValue = envVar.DefaultValue;
 
-            if (defaultValue is null && envVar.Source is ParameterResource parameter)
+            // Only resolve from the parameter if no static default is already set;
+            // a caller that provides an explicit default intends to skip parameter resolution.
+            if (envVar.Source is ParameterResource parameter)
             {
-                defaultValue = await parameter.GetValueAsync(context.CancellationToken).ConfigureAwait(false);
+                defaultValue ??= await parameter.GetValueAsync(context.CancellationToken).ConfigureAwait(false);
             }
-
-            if (envVar.Source is ContainerImageReference cir)
+            else if (envVar.Source is IValueProvider vp)
             {
-                defaultValue = await ((IValueProvider)cir).GetValueAsync(context.CancellationToken).ConfigureAwait(false);
+                // IValueProvider sources are always resolved dynamically — a static default is never used.
+                defaultValue = await vp.GetValueAsync(context.CancellationToken).ConfigureAwait(false);
             }
 
             envFile.Add(entry.Key, defaultValue, envVar.Description, onlyIfMissing: false);

--- a/tests/Aspire.Hosting.Docker.Tests/DockerComposePublisherTests.cs
+++ b/tests/Aspire.Hosting.Docker.Tests/DockerComposePublisherTests.cs
@@ -3,6 +3,7 @@
 
 #pragma warning disable ASPIREPIPELINES003
 
+using System.Text.RegularExpressions;
 using Aspire.Hosting.ApplicationModel;
 using Aspire.Hosting.Docker.Resources.ComposeNodes;
 using Aspire.Hosting.Publishing;
@@ -768,10 +769,9 @@ public class DockerComposePublisherTests(ITestOutputHelper outputHelper)
         // The compose file uses the user-specified container env var name; the .env file uses the
         // name derived from the provider's ValueExpression. Docker Compose interpolates between them.
         var composeContent = await File.ReadAllTextAsync(Path.Combine(tempDir.Path, "docker-compose.yaml"));
-        Assert.Contains("MY_VAR: \"${TEST_CONDITION}\"", composeContent);
-
         var envFileContent = await File.ReadAllTextAsync(Path.Combine(tempDir.Path, ".env.Production"));
-        Assert.Contains("TEST_CONDITION=resolved-value", envFileContent);
+        await Verify(composeContent, "yaml")
+            .AppendContentAsFile(envFileContent, "env");
     }
 
     [Fact]
@@ -802,8 +802,7 @@ public class DockerComposePublisherTests(ITestOutputHelper outputHelper)
         app.Run();
 
         var envFileContent = await File.ReadAllTextAsync(Path.Combine(tempDir.Path, ".env.Production"));
-        Assert.Contains("MYPARAM=static-override", envFileContent);
-        Assert.DoesNotContain("MYPARAM=dynamic-value", envFileContent);
+        await Verify(envFileContent, "env");
     }
 
     [Fact]
@@ -827,8 +826,9 @@ public class DockerComposePublisherTests(ITestOutputHelper outputHelper)
         app.Run();
 
         var envFileContent = await File.ReadAllTextAsync(Path.Combine(tempDir.Path, ".env.Production"));
-        Assert.Contains("PROJECT1_IMAGE=", envFileContent);
-        Assert.DoesNotContain("PROJECT1_IMAGE=project1:latest", envFileContent);
+        await Verify(envFileContent, "env")
+            // The image tag includes the current time (e.g. "aspire-deploy-20260525182406"); scrub it so the snapshot is stable across runs.
+            .ScrubLinesWithReplace(line => Regex.Replace(line, @"aspire-deploy-\d{14}", "aspire-deploy-TIMESTAMP"));
     }
 
     [Fact]
@@ -972,8 +972,8 @@ public class DockerComposePublisherTests(ITestOutputHelper outputHelper)
             .ConfigureEnvFile(envVars =>
             {
                 // Find and remove the auto-generated bind mount placeholder for yarp
-                var keysToRemove = envVars.Where(kv => 
-                    kv.Value.Resource?.Name == "yarp" && 
+                var keysToRemove = envVars.Where(kv =>
+                    kv.Value.Resource?.Name == "yarp" &&
                     kv.Value.Source is ContainerMountAnnotation).Select(kv => kv.Key).ToList();
 
                 foreach (var key in keysToRemove)

--- a/tests/Aspire.Hosting.Docker.Tests/DockerComposePublisherTests.cs
+++ b/tests/Aspire.Hosting.Docker.Tests/DockerComposePublisherTests.cs
@@ -775,6 +775,63 @@ public class DockerComposePublisherTests(ITestOutputHelper outputHelper)
     }
 
     [Fact]
+    public async Task PrepareStep_SkipsParameterResolutionWhenStaticDefaultIsSet()
+    {
+        using var tempDir = new TestTempDirectory();
+
+        var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish, tempDir.Path, step: "prepare-docker-compose");
+        builder.Services.AddSingleton<IResourceContainerImageManager, MockImageBuilder>();
+
+        var environment = builder.AddDockerComposeEnvironment("docker-compose");
+
+        var param = builder.AddParameter("myparam", "dynamic-value");
+
+        builder.AddContainer("testapp", "testimage")
+            .WithEnvironment("MY_PARAM", param);
+
+        // Set a static default before PrepareAsync runs; parameter resolution should be skipped.
+        environment.ConfigureEnvFile(vars =>
+        {
+            if (vars.TryGetValue("MYPARAM", out var envVar))
+            {
+                envVar.DefaultValue = "static-override";
+            }
+        });
+
+        var app = builder.Build();
+        app.Run();
+
+        var envFileContent = await File.ReadAllTextAsync(Path.Combine(tempDir.Path, ".env.Production"));
+        Assert.Contains("MYPARAM=static-override", envFileContent);
+        Assert.DoesNotContain("MYPARAM=dynamic-value", envFileContent);
+    }
+
+    [Fact]
+    public async Task PrepareStep_ResolvesContainerImageReferenceViaIValueProvider()
+    {
+        using var tempDir = new TestTempDirectory();
+
+        var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish, tempDir.Path, step: "prepare-docker-compose");
+        builder.Services.AddSingleton<IResourceContainerImageManager, MockImageBuilder>();
+
+        builder.AddDockerComposeEnvironment("docker-compose");
+
+        // ProjectResource triggers AsContainerImagePlaceholder, which creates a CapturedEnvironmentVariable
+        // with Source=ContainerImageReference and DefaultValue="project1:latest".
+        // PrepareAsync should call GetValueAsync() via the IValueProvider branch; with no registry
+        // configured in the test, GetValueAsync() returns null and the entry is written empty —
+        // not "project1:latest". If the IValueProvider branch were skipped, the static default would appear.
+        builder.AddProject<TestProjectWithLaunchSettings>("project1");
+
+        var app = builder.Build();
+        app.Run();
+
+        var envFileContent = await File.ReadAllTextAsync(Path.Combine(tempDir.Path, ".env.Production"));
+        Assert.Contains("PROJECT1_IMAGE=", envFileContent);
+        Assert.DoesNotContain("PROJECT1_IMAGE=project1:latest", envFileContent);
+    }
+
+    [Fact]
     public async Task PublishAsync_BindMounts_ReplacedWithEnvironmentPlaceholders()
     {
         using var tempDir = new TestTempDirectory();

--- a/tests/Aspire.Hosting.Docker.Tests/DockerComposePublisherTests.cs
+++ b/tests/Aspire.Hosting.Docker.Tests/DockerComposePublisherTests.cs
@@ -747,6 +747,34 @@ public class DockerComposePublisherTests(ITestOutputHelper outputHelper)
     }
 
     [Fact]
+    public async Task PrepareStep_ResolvesArbitraryIValueProviderSource()
+    {
+        using var tempDir = new TestTempDirectory();
+
+        var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish, tempDir.Path, step: "prepare-docker-compose");
+        builder.Services.AddSingleton<IResourceContainerImageManager, MockImageBuilder>();
+
+        builder.AddDockerComposeEnvironment("docker-compose");
+
+        builder.AddContainer("testapp", "testimage")
+            .WithEnvironment(context =>
+            {
+                context.EnvironmentVariables["MY_VAR"] = new TestConditionProvider("resolved-value");
+            });
+
+        var app = builder.Build();
+        app.Run();
+
+        // The compose file uses the user-specified container env var name; the .env file uses the
+        // name derived from the provider's ValueExpression. Docker Compose interpolates between them.
+        var composeContent = await File.ReadAllTextAsync(Path.Combine(tempDir.Path, "docker-compose.yaml"));
+        Assert.Contains("MY_VAR: \"${TEST_CONDITION}\"", composeContent);
+
+        var envFileContent = await File.ReadAllTextAsync(Path.Combine(tempDir.Path, ".env.Production"));
+        Assert.Contains("TEST_CONDITION=resolved-value", envFileContent);
+    }
+
+    [Fact]
     public async Task PublishAsync_BindMounts_ReplacedWithEnvironmentPlaceholders()
     {
         using var tempDir = new TestTempDirectory();

--- a/tests/Aspire.Hosting.Docker.Tests/Snapshots/DockerComposePublisherTests.PrepareStep_ResolvesArbitraryIValueProviderSource.verified.env
+++ b/tests/Aspire.Hosting.Docker.Tests/Snapshots/DockerComposePublisherTests.PrepareStep_ResolvesArbitraryIValueProviderSource.verified.env
@@ -1,0 +1,2 @@
+﻿TEST_CONDITION=resolved-value
+

--- a/tests/Aspire.Hosting.Docker.Tests/Snapshots/DockerComposePublisherTests.PrepareStep_ResolvesArbitraryIValueProviderSource.verified.yaml
+++ b/tests/Aspire.Hosting.Docker.Tests/Snapshots/DockerComposePublisherTests.PrepareStep_ResolvesArbitraryIValueProviderSource.verified.yaml
@@ -1,0 +1,20 @@
+﻿services:
+  docker-compose-dashboard:
+    image: "mcr.microsoft.com/dotnet/nightly/aspire-dashboard:latest"
+    ports:
+      - "18888"
+    expose:
+      - "18889"
+      - "18890"
+    networks:
+      - "aspire"
+    restart: "always"
+  testapp:
+    image: "testimage:latest"
+    environment:
+      MY_VAR: "${TEST_CONDITION}"
+    networks:
+      - "aspire"
+networks:
+  aspire:
+    driver: "bridge"

--- a/tests/Aspire.Hosting.Docker.Tests/Snapshots/DockerComposePublisherTests.PrepareStep_ResolvesContainerImageReferenceViaIValueProvider.verified.env
+++ b/tests/Aspire.Hosting.Docker.Tests/Snapshots/DockerComposePublisherTests.PrepareStep_ResolvesContainerImageReferenceViaIValueProvider.verified.env
@@ -1,0 +1,6 @@
+﻿# Container image name for project1
+PROJECT1_IMAGE=project1:aspire-deploy-TIMESTAMP
+
+# Default container port for project1
+PROJECT1_PORT=8080
+

--- a/tests/Aspire.Hosting.Docker.Tests/Snapshots/DockerComposePublisherTests.PrepareStep_SkipsParameterResolutionWhenStaticDefaultIsSet.verified.env
+++ b/tests/Aspire.Hosting.Docker.Tests/Snapshots/DockerComposePublisherTests.PrepareStep_SkipsParameterResolutionWhenStaticDefaultIsSet.verified.env
@@ -1,0 +1,3 @@
+﻿# Parameter myparam
+MYPARAM=static-override
+


### PR DESCRIPTION
## Description

When generating the `.env` file adjacent to the Docker Compose file, `DockerComposeEnvironmentResource.PrepareAsync` resolved values for two specific source types: `ParameterResource` and `ContainerImageReference`. Any other type that implements `IValueProvider` — including custom resource types defined in external repos — was silently ignored, leaving the env var with whatever static default was set (or blank).

This change collapses the `ContainerImageReference`-specific branch into a generic `IValueProvider` branch, and adds a comment explaining the asymmetric treatment of `ParameterResource`.

```diff
-            if (defaultValue is null && envVar.Source is ParameterResource parameter)
+            // Only resolve from the parameter if no static default is already set;
+            // a caller that provides an explicit default intends to skip parameter resolution.
+            if (envVar.Source is ParameterResource parameter)
             {
-                defaultValue = await parameter.GetValueAsync(context.CancellationToken).ConfigureAwait(false);
+                defaultValue ??= await parameter.GetValueAsync(context.CancellationToken).ConfigureAwait(false);
             }
-
-            if (envVar.Source is ContainerImageReference cir)
+            else if (envVar.Source is IValueProvider vp)
             {
-                defaultValue = await ((IValueProvider)cir).GetValueAsync(context.CancellationToken).ConfigureAwait(false);
+                // IValueProvider sources are always resolved dynamically — a static default is never used.
+                defaultValue = await vp.GetValueAsync(context.CancellationToken).ConfigureAwait(false);
             }
```

`ContainerImageReference` already implements `IValueProvider`, so it is handled by the new branch without any change in behavior. `ParameterResource` is kept as a separate leading branch because it skips resolution when a static default is already set — the `else` ensures it cannot fall through to the `IValueProvider` branch.

### Alternatives considered

**Keep `ContainerImageReference` explicit and add an `IValueProvider` fallback as a third branch**
The natural first approach is to leave the two existing branches untouched and append a catch-all:

```diff
             if (envVar.Source is ContainerImageReference cir)
             {
                 defaultValue = await ((IValueProvider)cir).GetValueAsync(context.CancellationToken).ConfigureAwait(false);
             }
+            else if (envVar.Source is IValueProvider vp)
+            {
+                defaultValue = await vp.GetValueAsync(context.CancellationToken).ConfigureAwait(false);
+            }
```

This works, but the `ContainerImageReference` branch becomes dead weight — it does the same thing the fallback would do, and requires a comment explaining why the `else` is there to prevent double-resolution. Collapsing it into the fallback is strictly simpler.

**Collapse both branches into a single `IValueProvider` check**
Removing the `ParameterResource` branch entirely would produce the shortest code, but it loses the `??=` guard: the parameter would always be resolved even when a static default is already set. That is a behavioral regression for existing callers.

```diff
-            if (envVar.Source is ParameterResource parameter)
-            {
-                defaultValue ??= await parameter.GetValueAsync(context.CancellationToken).ConfigureAwait(false);
-            }
-            else if (envVar.Source is IValueProvider vp)
+            if (envVar.Source is IValueProvider vp)
             {
                 defaultValue = await vp.GetValueAsync(context.CancellationToken).ConfigureAwait(false);
             }
```

**Change `Source` from `object?` to `IValueProvider?`**
A type-safe property would eliminate the runtime pattern-matching entirely, but `ContainerMountAnnotation` and `ContainerPortReference` are also valid `Source` values and do not implement `IValueProvider`. Moving them to a separate property would be a public API break with no benefit over the current fix.

```diff
-    [AspireUnion(typeof(ParameterResource), typeof(ContainerMountAnnotation), typeof(ContainerImageReference), typeof(ContainerPortReference))]
-    public object? Source { get; set; }
+    [AspireUnion(typeof(ParameterResource), typeof(ContainerImageReference))]
+    public IValueProvider? Source { get; set; }
```

**Make `ConfigureEnvFile` async**
The `ConfigureEnvFile` callback is synchronous, so callers cannot await their own value resolution. Changing its type would let any caller handle arbitrary sources asynchronously — but this pushes resolution responsibility out of the framework and onto every caller, and is a breaking change to the internal API.

```diff
-internal Action<IDictionary<string, CapturedEnvironmentVariable>>? ConfigureEnvFile { get; set; }
+internal Func<IDictionary<string, CapturedEnvironmentVariable>, CancellationToken, Task>? ConfigureEnvFile { get; set; }
```

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [x] No
- Did you add public API?
  - [ ] Yes
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
  - [x] No