### PR TITLE
Eliminate Unknown CLI E2E test results in PR comment

### DIFF
--- a/tests/Aspire.Cli.EndToEnd.Tests/Helpers/CliE2ETestHelpers.cs
+++ b/tests/Aspire.Cli.EndToEnd.Tests/Helpers/CliE2ETestHelpers.cs
@@ -94,6 +94,13 @@ internal static class CliE2ETestHelpers
     }
 
     /// <summary>
+    /// Resolves the test method name for naming a recording file. See
+    /// <see cref="Hex1bTestHelpers.ResolveTestMethodName"/> for the full rationale.
+    /// </summary>
+    private static string ResolveTestMethodName(string callerMemberName)
+        => Hex1bTestHelpers.ResolveTestMethodName(callerMemberName);
+
+    /// <summary>
     /// Creates a headless Hex1b terminal configured for E2E testing with asciinema recording.
     /// Uses default dimensions of 160x48 unless overridden.
     /// </summary>
@@ -103,7 +110,14 @@ internal static class CliE2ETestHelpers
     /// <returns>A configured <see cref="Hex1bTerminal"/> instance. Caller is responsible for disposal.</returns>
     internal static Hex1bTerminal CreateTestTerminal(int width = 160, int height = 48, [CallerMemberName] string testName = "")
     {
-        var recordingPath = GetTestResultsRecordingPath(testName);
+        // Prefer the xUnit-reported test method name so that when a [Fact]/[Theory]
+        // delegates into a private helper (e.g. *Core methods), the .cast file is
+        // still named after the public test the TRX records an outcome for. Without
+        // this, `[CallerMemberName]` captures the helper, the recording filename has
+        // no matching TRX entry, and the recording-comment workflow tags the test as
+        // "Unknown".
+        var resolvedTestName = ResolveTestMethodName(testName);
+        var recordingPath = GetTestResultsRecordingPath(resolvedTestName);
         RegisterCaptureFile("recording.cast", recordingPath);
         return Hex1bTerminal.CreateBuilder()
             .WithHeadless()
@@ -162,6 +176,9 @@ internal static class CliE2ETestHelpers
         int height = 48,
         [CallerMemberName] string testName = "")
     {
+        // See CreateTestTerminal above for why we prefer the xUnit-reported test
+        // method name over `[CallerMemberName]`.
+        testName = ResolveTestMethodName(testName);
         var recordingPath = GetTestResultsRecordingPath(testName);
         RegisterCaptureFile("recording.cast", recordingPath);
         var dockerfilePath = GetDockerfilePath(repoRoot, variant);
@@ -334,6 +351,9 @@ internal static class CliE2ETestHelpers
         int height = 48,
         [CallerMemberName] string testName = "")
     {
+        // See CreateTestTerminal above for why we prefer the xUnit-reported test
+        // method name over `[CallerMemberName]`.
+        testName = ResolveTestMethodName(testName);
         var recordingPath = GetTestResultsRecordingPath(testName);
         RegisterCaptureFile("recording.cast", recordingPath);
 

--- a/tests/Shared/Hex1bTestHelpers.cs
+++ b/tests/Shared/Hex1bTestHelpers.cs
@@ -89,6 +89,13 @@ internal static class Hex1bTestHelpers
         int height = 48,
         [CallerMemberName] string testName = "")
     {
+        // Prefer the xUnit-reported test method name so that when a [Fact]/[Theory]
+        // delegates into a private helper (e.g. *Core methods), the .cast file is
+        // still named after the public test the TRX records an outcome for. The CLI
+        // E2E recording-comment workflow joins .cast files to TRX outcomes by name;
+        // when the helper name leaks in via `[CallerMemberName]`, no TRX entry
+        // matches and the test ends up tagged "Unknown" on every PR.
+        testName = ResolveTestMethodName(testName);
         var recordingPath = GetTestResultsRecordingPath(testName, localSubDir);
 
         var builder = Hex1bTerminal.CreateBuilder()
@@ -126,6 +133,20 @@ internal static class Hex1bTestHelpers
 
         Directory.CreateDirectory(recordingsDir);
         return Path.Combine(recordingsDir, $"{testName}.cast");
+    }
+
+    /// <summary>
+    /// Resolves the test method name for naming a recording file. Prefers the xUnit-reported
+    /// <c>TestContext.Current.TestCase.TestMethodName</c> when running inside a live test
+    /// context, so a recording created from inside a private helper still gets named after
+    /// the public <c>[Fact]</c>/<c>[Theory]</c> that the TRX records an outcome for. Falls
+    /// back to the <see cref="CallerMemberNameAttribute"/>-supplied name when no test context
+    /// is available.
+    /// </summary>
+    internal static string ResolveTestMethodName(string callerMemberName)
+    {
+        var fromXunit = Xunit.TestContext.Current?.TestCase?.TestMethodName;
+        return !string.IsNullOrEmpty(fromXunit) ? fromXunit : callerMemberName;
     }
 
     /// <summary>


### PR DESCRIPTION
## Eliminate Unknown CLI E2E test results

Across recent PRs (#17474, #17463, #17249, …) the recording-comment bot consistently tagged the **same five tests** as Unknown (❔):

```
❓ CLI E2E Tests unknown — 96 passed, 0 failed, 5 unknown
```

| Test (from cast filename) | Shape |
|---|---|
| `AgentMcpListStructuredLogsFromStarterAppCore` | private `*Core` helper called by 3 public `[Fact]`s |
| `DashboardRunWithAgentMcpCore` | private `*Core` helper called by 2 public `[Fact]`s |
| `DashboardRunWithOtelTracesReturnsNoTracesCore` | private `*Core` helper called by 2 public `[Fact]`s |
| `AspireInitWithSolutionFileGeneratesAppHostThatBuildsAgainstChannelHive` | `[Theory]` with `InlineData("Test.sln")` / `("Test.slnx")` |
| (5th, same pattern) | — |

## Root causes (two independent bugs)

### Bug 1 — `[CallerMemberName]` captures the helper, not the public test

`CliE2ETestHelpers.CreateTestTerminal` / `CreateDockerTestTerminal` / `CreatePodmanDockerTestTerminal` (and the shared `Hex1bTestHelpers.CreateTestTerminal`) name the `.cast` file using `[CallerMemberName]`. When a `[Fact]` is a thin wrapper delegating into a private helper:

```csharp
[Fact]
public Task DashboardRunWithAgentMcpListTracesReturnsNoTraces()
    => DashboardRunWithAgentMcpCore(...);

private async Task DashboardRunWithAgentMcpCore(...) {
    using var terminal = CliE2ETestHelpers.CreateDockerTestTerminal(...); // CallerMemberName = "DashboardRunWithAgentMcpCore"
}
```

… the cast file ends up named after the helper. The TRX has no entry for `DashboardRunWithAgentMcpCore`, so the workflow's `jq -r '.[$name] // "Unknown"'` falls through to Unknown.

### Bug 2 — jq `bare_method` splits on `.` inside theory parameters

The workflow's `bare_method` runs in the wrong order:

```jq
def bare_method(name):
  (name | split(".") | last) | sub("\\(.*$"; "");
```

For `...Hive(solutionFileName: "Test.sln")`, `split(".")` chops *inside the quoted param* and `last` returns `sln")`, not the method name. Verified locally:

```bash
$ echo '...Test.sln")"... ' | jq '<old bare_method>'
{ "sln\")": "Passed" }
```

Hits every theory whose parameters contain `.` (URLs, file extensions, version strings).

## Fixes in this PR

| # | Fix | Pushed? |
|---|---|---|
| 1 | `CreateTestTerminal` family + shared helper: prefer `TestContext.Current?.TestCase?.TestMethodName` over `[CallerMemberName]`, fall back when no test context is active. | ✅ commit `9dfee9a2c` |
| 2 | `cli-e2e-recording-comment.yml`: swap order in `bare_method` (strip params first, then split on `.`) | ⏳ patch below — needs `workflow` scope |
| 3 | `cli-e2e-recording-comment.yml`: emit a `::warning::` annotation listing any unmatched recordings so future regressions show up in the workflow log itself | ⏳ same patch |

Both Bug 1 and Bug 2 are needed to clear all five Unknowns: Bug 1 fixes the `*Core` helpers (4 tests), Bug 2 fixes the dotted-theory case (`AspireInit…ChannelHive`).

## Workflow fix patch (apply with `workflow` scope)

Copilot's OAuth token doesn't have `workflow` scope, so the workflow change has to be applied by a maintainer. Save the block below to `workflow-fix.patch` and run `git am workflow-fix.patch`, or just edit the YAML by hand:

<details>
<summary>Patch for <code>.github/workflows/cli-e2e-recording-comment.yml</code></summary>

```patch
From 8ed659e806273845ddee8d3aec6849cdf77d0695 Mon Sep 17 00:00:00 2001
From: Mitch Denny <midenn@microsoft.com>
Date: Tue, 26 May 2026 13:03:02 +1000
Subject: [PATCH] Fix Unknown CLI E2E results from jq splitting theory params
 on '.'
MIME-Version: 1.0
Content-Type: text/plain; charset=UTF-8
Content-Transfer-Encoding: 8bit

Resolves bug #2 of the two root causes that left CLI E2E recordings
tagged as Unknown in the PR recording-comment.

The 'bare_method' jq function used to match TRX testNames against .cast
recording filenames split on '.' before stripping the theory parameter
suffix:

    def bare_method(name):
      (name | split(".") | last) | sub("\\(.*$"; "");

For a TRX testName like
    Aspire.Cli.EndToEnd.Tests.CSharpProjectModeInitTests.AspireInitWithSolutionFileGeneratesAppHostThatBuildsAgainstChannelHive(solutionFileName: "Test.sln")

split(".") chops inside the quoted parameter and 'last' returns
'sln")', not the method name. So the bare-name key in the lookup map
becomes 'sln")' / 'slnx")' instead of the actual test method name,
and the .cast file matches neither — Unknown. This is the same pattern
for any [Theory] parameter that contains a '.' (URLs, file extensions,
version strings).

Fix: strip the '(<params>)' suffix first, then split on '.'.

Also adds a defensive ::warning:: annotation when any .cast file fails
to match a TRX outcome, so a future regression of the matching logic is
visible in the recording-comment workflow's own log instead of only
showing up as a degraded count in the PR comment that few people read
the workflow logs for.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
---
 .../workflows/cli-e2e-recording-comment.yml   | 25 ++++++++++++++++++-
 1 file changed, 24 insertions(+), 1 deletion(-)

diff --git a/.github/workflows/cli-e2e-recording-comment.yml b/.github/workflows/cli-e2e-recording-comment.yml
index 5c76728b0..9abd81e2c 100644
--- a/.github/workflows/cli-e2e-recording-comment.yml
+++ b/.github/workflows/cli-e2e-recording-comment.yml
@@ -195,8 +195,15 @@ jobs:
                   # parameter data stripped) so a .cast file named after the
                   # CallerMemberName matches a TRX entry like
                   # "Namespace.Class.Method(toolchain: "pnpm")".
+                  #
+                  # IMPORTANT: strip the "(<params>)" suffix BEFORE splitting on
+                  # ".". Theory parameters frequently contain "." (URLs, file
+                  # extensions like "Test.sln", version strings). If split runs
+                  # first, `last` returns garbage like `sln")` instead of the
+                  # actual method name and the test reports as "Unknown" on every
+                  # PR. See https://github.com/microsoft/aspire/pull/17484.
                   def bare_method(name):
-                    (name | split(".") | last) | sub("\\(.*$"; "");
+                    (name | sub("\\(.*$"; "")) | split(".") | last;
                   def fqn_no_params(name):
                     name | sub("\\(.*$"; "");
                   def merge(map; key; outcome):
@@ -276,6 +283,7 @@ jobs:
             # Arrays to track failed test recordings separately
             FAILED_TESTS_BODY=""
             TABLE_BODY=""
+            UNKNOWN_FILENAMES=""
 
             for castfile in "$RECORDINGS_DIR"/*.cast; do
               if [ -f "$castfile" ]; then
@@ -307,6 +315,12 @@ jobs:
                   STATUS_EMOJI="❔"
                   LINK_LABEL="❔ ▶️ View recording"
                   TEST_UNKNOWN_COUNT=$((TEST_UNKNOWN_COUNT + 1))
+                  # Track the filename so we can emit a workflow warning below.
+                  # "Unknown" almost always means the recording name didn't match any TRX
+                  # entry (e.g. recording named after a private helper rather than the
+                  # public [Fact]). Surfacing it here makes the regression obvious in the
+                  # workflow logs instead of only in the PR comment.
+                  UNKNOWN_FILENAMES="${UNKNOWN_FILENAMES} ${safe_filename}"
                 fi
 
                 # Upload to asciinema with retry logic for transient failures
@@ -351,6 +365,15 @@ jobs:
 
             echo "Uploaded $UPLOAD_COUNT recordings, $FAIL_COUNT upload failures, $TEST_PASS_COUNT passed, $TEST_FAIL_COUNT failed, $TEST_UNKNOWN_COUNT unknown"
 
+            # Emit a workflow annotation for unmatched recordings so the regression
+            # surfaces in the GitHub Actions UI of this workflow run, not only in the
+            # eventual PR comment. The PR comment summarises by count, which is easy
+            # to overlook; a `::warning::` annotation is hard to miss when triaging
+            # the recording-comment workflow itself.
+            if [ "$TEST_UNKNOWN_COUNT" -gt 0 ]; then
+              echo "::warning title=CLI E2E recordings without a matching TRX outcome::${TEST_UNKNOWN_COUNT} recording(s) could not be matched to a test result and will be tagged 'Unknown' in the PR comment.${UNKNOWN_FILENAMES} See https://github.com/microsoft/aspire/blob/main/.github/workflows/cli-e2e-recording-comment.yml for the matching logic."
+            fi
+
             # Build the summary line in the same style as the deployment E2E comment:
             # "<emoji> **CLI E2E Tests <status>** — X passed, Y failed[, Z unknown]"
             # Status reflects test outcomes; recording-upload failures are a secondary concern
-- 
2.50.1 (Apple Git-155)
```

</details>

## Verification

- Both `Aspire.Cli.EndToEnd.Tests` and `Aspire.Deployment.EndToEnd.Tests` build clean against the C# changes.
- The new jq `bare_method` was tested locally against a synthetic TRX containing the failing theory shape and a normal test:

  ```
  {
    "AspireInitWithSolutionFileGeneratesAppHostThatBuildsAgainstChannelHive": "Failed",
    "SimpleSmokeTest": "Passed"
  }
  ```

  (Verified that "Failed" wins over "Passed" across theory rows via the existing `merge` rule.)

## Out of scope

One `.cast` file per theory case: today `[Theory]` invocations share a single recording path and the last case wins. Worth doing eventually but orthogonal to making the matching correct.
