### PR TITLE
test(cli): quarantine ResourceCommand_FailsWhenInteractionServiceIsRequired (#17485)

### DIFF
--- a/tests/Aspire.Cli.EndToEnd.Tests/ResourceCommandTests.cs
+++ b/tests/Aspire.Cli.EndToEnd.Tests/ResourceCommandTests.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using Aspire.Cli.EndToEnd.Tests.Helpers;
@@ -6,6 +6,7 @@ using Aspire.Cli.Resources;
 using Aspire.Cli.Tests.Utils;
 using Hex1b.Automation;
 using Xunit;
+using Aspire.TestUtilities;
 
 namespace Aspire.Cli.EndToEnd.Tests;
 
@@ -145,6 +146,7 @@ public sealed class ResourceCommandTests(ITestOutputHelper output)
 
     [Fact]
     [CaptureWorkspaceOnFailure]
+    [QuarantinedTest("https://github.com/microsoft/aspire/issues/17485")]
     public async Task ResourceCommand_FailsWhenInteractionServiceIsRequired()
     {
         var repoRoot = CliE2ETestHelpers.GetRepoRoot();


### PR DESCRIPTION
## Description

Quarantines `Aspire.Cli.EndToEnd.Tests.ResourceCommandTests.ResourceCommand_FailsWhenInteractionServiceIsRequired` while we investigate the underlying shutdown-timing issue tracked by #17485.

### Why now

The test was observed flaking on PR #17452 ([run 26425521402](https://github.com/microsoft/aspire/actions/runs/26425521402)) — attempts 1 and 3 failed, attempt 2 passed — even though that PR only touches CLI init/channel/scaffolding code paths and has no plausible causal link to `aspire stop`, `ProcessShutdownService`, the auxiliary backchannel, or DCP container shutdown.

### What's actually broken

The Hex1b automator times out on `WaitUntilText(" stopped successfully.")`, but the cast file shows `aspire stop` actively prints:

```
⠳ Stopping apphost.cs...
❌ Failed to stop apphost.cs.
📄 See logs at /root/.aspire/logs/cli_<id>.log
🔍 See AppHost logs at /root/.aspire/logs/cli_<id>_detach-child_<id>.log
```

after spinning for ~60s. At the moment of failure, the post-step `docker container ls` in the same CI job shows the redis container still running:

```
CONTAINER ID   IMAGE          STATUS         NAMES
5aa9f3938387   redis:latest   Up 7 seconds   cache-xuhbbbzq
```

`ProcessShutdownService.StopProcessesAsync` (10s graceful → force-kill → monitor) is exhausting its budget while DCP is still tearing down the container under Docker-in-Docker contention on `ubuntu-latest`. Issue #17485 captures the suspected root cause and the speculative follow-up of extending the shutdown monitor window for DCP-managed-container scenarios.

### Change

Adds `[QuarantinedTest("https://github.com/microsoft/aspire/issues/17485")]` to the single affected test method via `tools/QuarantineTools`. No production code changes.

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [x] No
- Did you add public API?
  - [ ] Yes
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
  - [x] No

---

Addresses #17485. Related PR where the failure was observed: #17452.
