### PR TITLE
fix: always offload to background thread when RunSyncOnBackgroundThread=true in CapabilityDispatcher

### DIFF
--- a/src/Aspire.Hosting.RemoteHost/Ats/CapabilityDispatcher.cs
+++ b/src/Aspire.Hosting.RemoteHost/Ats/CapabilityDispatcher.cs
@@ -619,7 +619,19 @@ internal sealed class CapabilityDispatcher
 
     private static async Task<object?> InvokeMethodAsync(MethodInfo method, object? target, object?[] methodArgs, bool runSyncOnBackgroundThread)
     {
-        if (runSyncOnBackgroundThread && !IsAsyncReturnType(method.ReturnType))
+        // When runSyncOnBackgroundThread is true, we must move to a background thread regardless of
+        // whether the method is sync or async. The caller (typically DistributedApplication.RunAsync)
+        // may be executing on the NonConcurrentSynchronizationContext (StreamJsonRpc's single-item
+        // dispatch queue). Any synchronous work done before the first real 'await' — including
+        // BeforeStartEvent subscribers and lazy IOptions.Configure callbacks — runs on that context.
+        // If any of that work invokes an ATS proxy for a TypeScript async callback, the proxy calls
+        // .GetAwaiter().GetResult(), which blocks the context while awaiting responses that are
+        // themselves queued on the same blocked context → deadlock.
+        //
+        // Previously this guard only applied to sync-return methods (!IsAsyncReturnType), leaving
+        // async-return methods like RunAsync unprotected. Removing the guard ensures the synchronous
+        // startup code of those methods also runs off the sync context.
+        if (runSyncOnBackgroundThread)
         {
             return await Task.Run(() => InvokeMethodCore(method, target, methodArgs)).ConfigureAwait(false);
         }


### PR DESCRIPTION
﻿## Summary

Fixes #17487

When `runSyncOnBackgroundThread = true`, `InvokeMethodAsync` previously only used `Task.Run` for synchronous-returning methods (`!IsAsyncReturnType`). This left async-returning methods — most importantly `DistributedApplication.RunAsync` — executing their synchronous startup code directly on StreamJsonRpc's `NonConcurrentSynchronizationContext`.

Any `BeforeStartEvent` subscriber that invoked an ATS proxy for a TypeScript `async` callback (directly or via a lazy `IOptions.Configure` callback) would deadlock:

- The ATS proxy calls `.GetAwaiter().GetResult()` on the TypeScript call
- That call needs to queue a response on the `NonConcurrentSynchronizationContext`
- That context is blocked waiting for `.GetResult()` → deadlock

The symptom is `aspire start` / `aspire run` hanging silently for 60 seconds then timing out with no useful error output.

## Change

Remove the `!IsAsyncReturnType` guard so `runSyncOnBackgroundThread = true` always moves execution to a background thread, regardless of the method's return type:

```csharp
// Before
if (runSyncOnBackgroundThread && !IsAsyncReturnType(method.ReturnType))

// After
if (runSyncOnBackgroundThread)
```

## How was this discovered

Via [kjldev/aspirec4](https://github.com/kjldev/aspirec4), a community library that auto-generates LikeC4 architecture diagrams from the Aspire resource graph. Its TypeScript AppHost sample passes an `async` configure callback to `AddAspireC4`. That callback was being invoked inside a lazy `IOptions.Configure` registration triggered during `RunAsync`, causing the deadlock. A `dotnet-dump` of the hung `aspire-managed.exe` produced the call stack in the linked issue.
