### PR TITLE
Use emoji instead of codicons for health status in resource tooltips

### DIFF
--- a/extension/src/views/AspireAppHostTreeProvider.ts
+++ b/extension/src/views/AspireAppHostTreeProvider.ts
@@ -315,7 +315,14 @@ function buildResourceTooltip(resource: ResourceJson): vscode.MarkdownString {
         if (reports) {
             const entries = Object.entries(reports).sort(([a], [b]) => a.localeCompare(b));
             for (const [name, report] of entries) {
-                const icon = report.status === HealthStatus.Healthy ? '$(pass)' : report.status === HealthStatus.Degraded ? '$(warning)' : '$(error)';
+                let icon = '❓';
+                if (report.status === HealthStatus.Healthy) {
+                    icon = '✅';
+                } else if (report.status === HealthStatus.Degraded) {
+                    icon = '⚠️';
+                } else if (report.status === HealthStatus.Unhealthy) {
+                    icon = '❌';
+                }
                 md.appendMarkdown(`${icon} ${name}: ${report.status ?? 'Unknown'}${report.description ? ` - ${report.description}` : ''}\n\n`);
             }
         }


### PR DESCRIPTION
## Problem

Resource tooltips in the tree view display health check status using VS Code codicon references (`$(pass)`, `$(warning)`, `$(error)`), but these render as **literal text** in `MarkdownString` tooltips instead of icons.

### Before

<!-- Drag-drop screenshot here showing $(pass) literal text in tooltip -->
The tooltip shows raw text like `$(pass) apiservice_https_/health_200_check: Healthy`

<img width="724" height="596" alt="image" src="https://github.com/user-attachments/assets/41ae6a1c-50ea-49f3-a8dd-a885cd33ca99" />

### After

Health checks now display with emoji:
- ✅ Healthy
- ⚠️ Degraded  
- ❌ Unhealthy
- ❓ Unknown

<img width="505" height="449" alt="image" src="https://github.com/user-attachments/assets/a2901dc0-2be8-4692-b194-de0e52b64907" />

I used emoji because they have color. A VS Code icon would be the same color as text and not as noticable.

## Changes

- Replaced codicon references with emoji in `buildResourceTooltip()` in `AspireAppHostTreeProvider.ts`
- Added explicit handling for unknown health status (grey question mark)