### PR TITLE
Fix Azure role assignment preparation idempotency

### DIFF
--- a/src/Aspire.Hosting.Azure/AzureResourcePreparer.cs
+++ b/src/Aspire.Hosting.Azure/AzureResourcePreparer.cs
@@ -212,8 +212,7 @@ internal sealed class AzureResourcePreparer(
 
                         foreach (var roleAssignmentResource in roleAssignmentResources)
                         {
-                            appModel.Resources.Add(roleAssignmentResource);
-                            prerequisiteResources.Add(roleAssignmentResource);
+                            prerequisiteResources.Add(AddOrGetRoleAssignmentResource(appModel, roleAssignmentResource));
                         }
                     }
                 }
@@ -221,10 +220,7 @@ internal sealed class AzureResourcePreparer(
                 // Add prerequisite infrastructure resources on the compute resource.
                 // Deployment infrastructure subscribers will transfer these to deployment target References
                 // so AzureBicepResource dependency wiring can apply provision ordering.
-                if (prerequisiteResources.Count > 0)
-                {
-                    resource.Annotations.Add(new DeploymentPrerequisitesAnnotation(prerequisiteResources));
-                }
+                AddDeploymentPrerequisitesAnnotation(resource, prerequisiteResources);
             }
 
             if (executionContext.IsRunMode)
@@ -393,11 +389,55 @@ internal sealed class AzureResourcePreparer(
         {
             var roleAssignmentResource = CreateGlobalRoleAssignmentsResource(azureResource, roles);
 
+            roleAssignmentResource = AddOrGetRoleAssignmentResource(appModel, roleAssignmentResource);
+
+            if (!azureResource.Annotations.OfType<RoleAssignmentResourceAnnotation>().Any(a => a.RolesResource == roleAssignmentResource))
+            {
+                azureResource.Annotations.Add(new RoleAssignmentResourceAnnotation(roleAssignmentResource));
+            }
+
+            if (!roleAssignmentResource.Annotations.OfType<ResourceRelationshipAnnotation>().Any(a => a.Resource == azureResource && a.Type == KnownRelationshipTypes.Parent))
+            {
+                roleAssignmentResource.Annotations.Add(new ResourceRelationshipAnnotation(azureResource, KnownRelationshipTypes.Parent));
+            }
+        }
+    }
+
+    private static AzureRoleAssignmentResource AddOrGetRoleAssignmentResource(DistributedApplicationModel appModel, AzureRoleAssignmentResource roleAssignmentResource)
+    {
+        if (!appModel.Resources.TryGetByName(roleAssignmentResource.Name, out var existingResource))
+        {
             appModel.Resources.Add(roleAssignmentResource);
+            return roleAssignmentResource;
+        }
 
-            azureResource.Annotations.Add(new RoleAssignmentResourceAnnotation(roleAssignmentResource));
+        if (existingResource is AzureRoleAssignmentResource existingRoleAssignmentResource &&
+            existingRoleAssignmentResource.TargetAzureResource == roleAssignmentResource.TargetAzureResource &&
+            existingRoleAssignmentResource.OwnerResource == roleAssignmentResource.OwnerResource &&
+            existingRoleAssignmentResource.IdentityResource == roleAssignmentResource.IdentityResource)
+        {
+            return existingRoleAssignmentResource;
+        }
 
-            roleAssignmentResource.Annotations.Add(new ResourceRelationshipAnnotation(azureResource, KnownRelationshipTypes.Parent));
+        appModel.Resources.Add(roleAssignmentResource);
+        return roleAssignmentResource;
+    }
+
+    private static void AddDeploymentPrerequisitesAnnotation(IResource resource, HashSet<AzureBicepResource> prerequisiteResources)
+    {
+        if (prerequisiteResources.Count == 0)
+        {
+            return;
+        }
+
+        if (resource.TryGetAnnotationsOfType<DeploymentPrerequisitesAnnotation>(out var existingAnnotations))
+        {
+            prerequisiteResources.ExceptWith(existingAnnotations.SelectMany(a => a.Resources));
+        }
+
+        if (prerequisiteResources.Count > 0)
+        {
+            resource.Annotations.Add(new DeploymentPrerequisitesAnnotation(prerequisiteResources));
         }
     }
 

--- a/tests/Aspire.Deployment.EndToEnd.Tests/AzureStorageDeploymentTests.cs
+++ b/tests/Aspire.Deployment.EndToEnd.Tests/AzureStorageDeploymentTests.cs
@@ -28,6 +28,17 @@ public sealed class AzureStorageDeploymentTests(ITestOutputHelper output)
         await DeployAzureStorageResourceCore(cancellationToken);
     }
 
+    [Fact]
+    public async Task DeployStarterWithSharedAzureStorageReferences()
+    {
+        using var cts = new CancellationTokenSource(s_testTimeout);
+        using var linkedCts = CancellationTokenSource.CreateLinkedTokenSource(
+            cts.Token, TestContext.Current.CancellationToken);
+        var cancellationToken = linkedCts.Token;
+
+        await DeployStarterWithSharedAzureStorageReferencesCore(cancellationToken);
+    }
+
     private async Task DeployAzureStorageResourceCore(CancellationToken cancellationToken)
     {
         // Validate prerequisites
@@ -178,6 +189,165 @@ builder.Build().Run();
         finally
         {
             // Always attempt to clean up the resource group
+            output.WriteLine($"Cleaning up resource group: {resourceGroupName}");
+            await CleanupResourceGroupAsync(resourceGroupName);
+        }
+    }
+
+    private async Task DeployStarterWithSharedAzureStorageReferencesCore(CancellationToken cancellationToken)
+    {
+        var subscriptionId = AzureAuthenticationHelpers.TryGetSubscriptionId();
+        if (string.IsNullOrEmpty(subscriptionId))
+        {
+            Assert.Skip("Azure subscription not configured. Set ASPIRE_DEPLOYMENT_TEST_SUBSCRIPTION.");
+        }
+
+        if (!AzureAuthenticationHelpers.IsAzureAuthAvailable())
+        {
+            if (DeploymentE2ETestHelpers.IsRunningInCI)
+            {
+                Assert.Fail("Azure authentication not available in CI. Check OIDC configuration.");
+            }
+            else
+            {
+                Assert.Skip("Azure authentication not available. Run 'az login' to authenticate.");
+            }
+        }
+
+        var workspace = TemporaryWorkspace.Create(output);
+        var startTime = DateTime.UtcNow;
+        var resourceGroupName = DeploymentE2ETestHelpers.GenerateResourceGroupName("storage-shared");
+        var projectName = "StorageShared";
+
+        output.WriteLine($"Test: {nameof(DeployStarterWithSharedAzureStorageReferences)}");
+        output.WriteLine($"Project Name: {projectName}");
+        output.WriteLine($"Resource Group: {resourceGroupName}");
+        output.WriteLine($"Subscription: {subscriptionId[..8]}...");
+        output.WriteLine($"Workspace: {workspace.WorkspaceRoot.FullName}");
+
+        try
+        {
+            using var terminal = DeploymentE2ETestHelpers.CreateTestTerminal();
+            var pendingRun = terminal.RunAsync(cancellationToken);
+
+            var counter = new SequenceCounter();
+            var auto = new Hex1bTerminalAutomator(terminal, defaultTimeout: TimeSpan.FromSeconds(500));
+
+            output.WriteLine("Step 1: Preparing environment...");
+            await auto.PrepareEnvironmentAsync(workspace, counter);
+
+            await auto.InstallCurrentBuildAspireCliAsync(counter, output);
+
+            output.WriteLine("Step 3: Creating starter project...");
+            await auto.AspireNewAsync(projectName, counter, useRedisCache: false);
+
+            output.WriteLine("Step 4: Navigating to project directory...");
+            await auto.TypeAsync($"cd {projectName}");
+            await auto.EnterAsync();
+            await auto.WaitForSuccessPromptAsync(counter);
+
+            output.WriteLine("Step 5a: Adding Azure Container Apps hosting package...");
+            await auto.TypeAsync("aspire add Aspire.Hosting.Azure.AppContainers");
+            await auto.EnterAsync();
+            await auto.WaitForAspireAddCompletionAsync(counter);
+
+            output.WriteLine("Step 5b: Adding Azure Storage hosting package...");
+            await auto.TypeAsync("aspire add Aspire.Hosting.Azure.Storage");
+            await auto.EnterAsync();
+            await auto.WaitForAspireAddCompletionAsync(counter);
+
+            var projectDir = Path.Combine(workspace.WorkspaceRoot.FullName, projectName);
+            var appHostDir = Path.Combine(projectDir, $"{projectName}.AppHost");
+            var appHostFilePath = Path.Combine(appHostDir, "AppHost.cs");
+
+            output.WriteLine($"Looking for AppHost.cs at: {appHostFilePath}");
+
+            var content = File.ReadAllText(appHostFilePath);
+
+            content = content.Replace(
+                "var builder = DistributedApplication.CreateBuilder(args);",
+                """
+var builder = DistributedApplication.CreateBuilder(args);
+
+var storage = builder.AddAzureStorage("storage");
+var blobs = storage.AddBlobs("blobs");
+""");
+
+            content = content.Replace(
+                $"var apiService = builder.AddProject<Projects.{projectName}_ApiService>(\"apiservice\")",
+                $"var apiService = builder.AddProject<Projects.{projectName}_ApiService>(\"apiservice\")\n    .WithReference(blobs)");
+
+            content = content.Replace(
+                ".WithReference(apiService)",
+                """
+.WithReference(apiService)
+    .WithReference(blobs)
+""");
+
+            var buildRunPattern = "builder.Build().Run();";
+            var replacement = """
+// Add Azure Container App Environment for managed identity support
+builder.AddAzureContainerAppEnvironment("infra");
+
+builder.Build().Run();
+""";
+
+            content = content.Replace(buildRunPattern, replacement);
+            File.WriteAllText(appHostFilePath, content);
+
+            output.WriteLine($"Modified AppHost.cs with shared Azure Storage references at: {appHostFilePath}");
+            output.WriteLine($"New content:\n{content}");
+
+            output.WriteLine("Step 6: Navigating to AppHost directory...");
+            await auto.TypeAsync($"cd {projectName}.AppHost");
+            await auto.EnterAsync();
+            await auto.WaitForSuccessPromptAsync(counter);
+
+            await auto.TypeAsync($"unset ASPIRE_PLAYGROUND && export AZURE__LOCATION=westus3 && export AZURE__RESOURCEGROUP={resourceGroupName}");
+            await auto.EnterAsync();
+            await auto.WaitForSuccessPromptAsync(counter);
+
+            output.WriteLine("Step 7: Starting Azure deployment...");
+            await auto.TypeAsync("aspire deploy --clear-cache");
+            await auto.EnterAsync();
+            await auto.WaitForPipelineSuccessAsync(timeout: TimeSpan.FromMinutes(25));
+            await auto.WaitForSuccessPromptAsync(counter, TimeSpan.FromMinutes(2));
+
+            output.WriteLine("Step 8: Verifying Azure Storage account...");
+            await auto.TypeAsync($"az storage account list -g \"{resourceGroupName}\" --query \"[].name\" -o tsv");
+            await auto.EnterAsync();
+            await auto.WaitForSuccessPromptAsync(counter, TimeSpan.FromSeconds(30));
+
+            output.WriteLine("Step 9: Destroying Azure deployment...");
+            await auto.AspireDestroyAsync(counter);
+
+            await auto.TypeAsync("exit");
+            await auto.EnterAsync();
+
+            await pendingRun;
+
+            var duration = DateTime.UtcNow - startTime;
+            output.WriteLine($"Deployment completed in {duration}");
+
+            DeploymentReporter.ReportDeploymentSuccess(
+                nameof(DeployStarterWithSharedAzureStorageReferences),
+                resourceGroupName,
+                new Dictionary<string, string>(),
+                duration);
+        }
+        catch (Exception ex)
+        {
+            output.WriteLine($"Test failed: {ex.Message}");
+
+            DeploymentReporter.ReportDeploymentFailure(
+                nameof(DeployStarterWithSharedAzureStorageReferences),
+                resourceGroupName,
+                ex.Message);
+
+            throw;
+        }
+        finally
+        {
             output.WriteLine($"Cleaning up resource group: {resourceGroupName}");
             await CleanupResourceGroupAsync(resourceGroupName);
         }

--- a/tests/Aspire.Hosting.Azure.Tests/AzureResourcePreparerTests.cs
+++ b/tests/Aspire.Hosting.Azure.Tests/AzureResourcePreparerTests.cs
@@ -8,6 +8,7 @@ using Aspire.Hosting.ApplicationModel;
 using Aspire.Hosting.Pipelines;
 using Aspire.Hosting.Utils;
 using Azure.Provisioning.KeyVault;
+using Azure.Provisioning.SignalR;
 using Azure.Provisioning.Storage;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
@@ -297,6 +298,90 @@ public class AzureResourcePreparerTests
             app.Services.GetRequiredService<DistributedApplicationModel>().Resources.OfType<AzureRoleAssignmentResource>(),
             resource => resource.TargetAzureResource == storage.Resource);
         Assert.Same(api.Resource, storageRoleAssignment.OwnerResource);
+    }
+
+    [Fact]
+    public async Task RoleAssignmentsAreNotDuplicatedWhenBeforeStartRunsBeforePublishPipeline()
+    {
+        const string inspectRoleAssignmentsStepName = "inspect-signalr-role-assignments";
+
+        using var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish, step: inspectRoleAssignmentsStepName);
+        builder.AddAzureContainerAppEnvironment("env");
+
+        var signalR = builder.AddAzureSignalR("signalr");
+
+        var serviceA = builder.AddProject<Project>("service-a", launchProfileName: null)
+            .WithReference(signalR)
+            .WithRoleAssignments(signalR, SignalRBuiltInRole.SignalRContributor);
+
+        var serviceB = builder.AddProject<Project>("service-b", launchProfileName: null)
+            .WithReference(signalR)
+            .WithRoleAssignments(signalR, SignalRBuiltInRole.SignalRContributor);
+
+        List<AzureRoleAssignmentResource>? signalRRoleAssignments = null;
+        builder.Pipeline.AddStep(
+            inspectRoleAssignmentsStepName,
+            context =>
+            {
+                signalRRoleAssignments =
+                    [.. context.Model.Resources
+                        .OfType<AzureRoleAssignmentResource>()
+                        .Where(resource => resource.TargetAzureResource == signalR.Resource)
+                        .OrderBy(resource => resource.Name, StringComparer.Ordinal)];
+
+                return Task.CompletedTask;
+            },
+            dependsOn: WellKnownPipelineSteps.BeforeStart);
+
+        using var app = builder.Build();
+        await app.RunAsync().WaitAsync(TimeSpan.FromSeconds(30));
+
+        Assert.NotNull(signalRRoleAssignments);
+        Assert.Collection(signalRRoleAssignments,
+            resource =>
+            {
+                Assert.Equal("service-a-roles-signalr", resource.Name);
+                Assert.Same(signalR.Resource, resource.TargetAzureResource);
+                Assert.Same(serviceA.Resource, resource.OwnerResource);
+            },
+            resource =>
+            {
+                Assert.Equal("service-b-roles-signalr", resource.Name);
+                Assert.Same(signalR.Resource, resource.TargetAzureResource);
+                Assert.Same(serviceB.Resource, resource.OwnerResource);
+            });
+
+        var model = app.Services.GetRequiredService<DistributedApplicationModel>();
+        Assert.Collection(
+            model.Resources
+                .OfType<ProjectResource>()
+                .OrderBy(resource => resource.Name, StringComparer.Ordinal),
+            resource => Assert.Single(resource.Annotations.OfType<DeploymentPrerequisitesAnnotation>()),
+            resource => Assert.Single(resource.Annotations.OfType<DeploymentPrerequisitesAnnotation>()));
+    }
+
+    [Fact]
+    public async Task GlobalRoleAssignmentsAreNotDuplicatedWhenBeforeStartRunsTwice()
+    {
+        using var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Run);
+
+        var storage = builder.AddAzureStorage("storage");
+        var blobs = storage.AddBlobs("blobs");
+
+        builder.AddProject<Project>("api", launchProfileName: null)
+            .WithReference(blobs);
+
+        using var app = builder.Build();
+        var model = app.Services.GetRequiredService<DistributedApplicationModel>();
+
+        await ExecuteBeforeStartHooksAsync(app, default);
+        await ExecuteBeforeStartHooksAsync(app, default);
+
+        var storageRoles = Assert.Single(model.Resources.OfType<AzureRoleAssignmentResource>(), resource => resource.Name == "storage-roles");
+        Assert.Same(storage.Resource, storageRoles.TargetAzureResource);
+        Assert.Null(storageRoles.OwnerResource);
+        Assert.Single(storage.Resource.Annotations.OfType<RoleAssignmentResourceAnnotation>());
+        Assert.Single(storageRoles.Annotations.OfType<ResourceRelationshipAnnotation>());
     }
 
     [Fact]


### PR DESCRIPTION
## Description

Azure resource preparation can run during the BeforeStart pipeline and again when publish or deploy executes against the same application model. In 13.3, that caused shared Azure resources such as Storage or SignalR to fail with duplicate role-assignment resources when multiple projects referenced the same target.

This makes role-assignment preparation idempotent by reusing equivalent existing `AzureRoleAssignmentResource` instances and avoiding duplicate deployment prerequisite and relationship annotations. Name collisions that point at a different target, owner, or identity still fail instead of being silently reused.

Fixes #17493

Validation:

- Reproduced the duplicate-resource failure by temporarily reverting the source fix and running the new publish-lifecycle regression test.
- `dotnet test --project tests\Aspire.Hosting.Azure.Tests\Aspire.Hosting.Azure.Tests.csproj --no-launch-profile -- --filter-class "*.AzureResourcePreparerTests" --filter-not-trait "quarantined=true" --filter-not-trait "outerloop=true"`
- `dotnet build tests\Aspire.Deployment.EndToEnd.Tests\Aspire.Deployment.EndToEnd.Tests.csproj --no-restore`

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No