### PR TITLE
Expose Foundry inference endpoint env var

### DIFF
--- a/playground/FoundryAgents/app/main.py
+++ b/playground/FoundryAgents/app/main.py
@@ -48,12 +48,8 @@ async def get_forecast() -> str:
 
 def main():
     """Main function to run the agent as a web server."""
-    project_endpoint = os.environ.get("PROJ_MYPROJECT_URI") or os.environ.get("ConnectionStrings__projmyproject", "")
+    project_endpoint = os.environ.get("PROJMYPROJECT_URI")
     deployment_name = os.environ.get("CHAT_MODELNAME", "chat")
-
-    # Parse endpoint from connection string format if needed (Endpoint=https://...)
-    if project_endpoint.startswith("Endpoint="):
-        project_endpoint = project_endpoint.split("Endpoint=", 1)[1].split(";")[0]
 
     client = FoundryChatClient(
         project_endpoint=project_endpoint,

--- a/playground/FoundryAgents/app/main.py
+++ b/playground/FoundryAgents/app/main.py
@@ -51,15 +51,7 @@ def get_project_endpoint() -> str:
     if project_endpoint:
         return project_endpoint
 
-    connection_string = os.environ.get("ConnectionStrings__projmyproject", "")
-    # Aspire connection strings use key/value pairs such as:
-    #   Endpoint=https://<account>.services.ai.azure.com/api/projects/<project>;...
-    for segment in connection_string.split(";"):
-        key, separator, value = segment.partition("=")
-        if separator and key == "Endpoint" and value:
-            return value
-
-    raise RuntimeError("PROJMYPROJECT_URI or ConnectionStrings__projmyproject with an Endpoint value is required.")
+    raise RuntimeError("PROJMYPROJECT_URI is required.")
 
 
 def main():

--- a/playground/FoundryAgents/app/main.py
+++ b/playground/FoundryAgents/app/main.py
@@ -46,9 +46,25 @@ async def get_forecast() -> str:
         return json.dumps({"error": str(e)})
 
 
+def get_project_endpoint() -> str:
+    project_endpoint = os.environ.get("PROJMYPROJECT_URI")
+    if project_endpoint:
+        return project_endpoint
+
+    connection_string = os.environ.get("ConnectionStrings__projmyproject", "")
+    # Aspire connection strings use key/value pairs such as:
+    #   Endpoint=https://<account>.services.ai.azure.com/api/projects/<project>;...
+    for segment in connection_string.split(";"):
+        key, separator, value = segment.partition("=")
+        if separator and key == "Endpoint" and value:
+            return value
+
+    raise RuntimeError("PROJMYPROJECT_URI or ConnectionStrings__projmyproject with an Endpoint value is required.")
+
+
 def main():
     """Main function to run the agent as a web server."""
-    project_endpoint = os.environ.get("PROJMYPROJECT_URI")
+    project_endpoint = get_project_endpoint()
     deployment_name = os.environ.get("CHAT_MODELNAME", "chat")
 
     client = FoundryChatClient(

--- a/playground/FoundryAgents/app/main.py
+++ b/playground/FoundryAgents/app/main.py
@@ -46,17 +46,9 @@ async def get_forecast() -> str:
         return json.dumps({"error": str(e)})
 
 
-def get_project_endpoint() -> str:
-    project_endpoint = os.environ.get("PROJMYPROJECT_URI")
-    if project_endpoint:
-        return project_endpoint
-
-    raise RuntimeError("PROJMYPROJECT_URI is required.")
-
-
 def main():
     """Main function to run the agent as a web server."""
-    project_endpoint = get_project_endpoint()
+    project_endpoint = os.environ["PROJMYPROJECT_URI"]
     deployment_name = os.environ.get("CHAT_MODELNAME", "chat")
 
     client = FoundryChatClient(

--- a/src/Aspire.Hosting.Foundry/FoundryResource.cs
+++ b/src/Aspire.Hosting.Foundry/FoundryResource.cs
@@ -127,7 +127,7 @@ public class FoundryResource(string name, Action<AzureResourceInfrastructure> co
     {
         yield return new("Uri", UriExpression);
 
-        yield return new("AI_INFERENCE_URI", IsEmulator ? UriExpression : ReferenceExpression.Create($"{AIFoundryApiEndpoint}models"));
+        yield return new("AIInferenceUri", IsEmulator ? UriExpression : ReferenceExpression.Create($"{AIFoundryApiEndpoint}models"));
 
         if (IsEmulator)
         {

--- a/src/Aspire.Hosting.Foundry/FoundryResource.cs
+++ b/src/Aspire.Hosting.Foundry/FoundryResource.cs
@@ -127,6 +127,11 @@ public class FoundryResource(string name, Action<AzureResourceInfrastructure> co
     {
         yield return new("Uri", UriExpression);
 
+        if (!IsEmulator)
+        {
+            yield return new("EndpointAIInference", ReferenceExpression.Create($"{AIFoundryApiEndpoint}models"));
+        }
+
         if (IsEmulator)
         {
             yield return new("Key", ReferenceExpression.Create($"{ApiKey}"));

--- a/src/Aspire.Hosting.Foundry/FoundryResource.cs
+++ b/src/Aspire.Hosting.Foundry/FoundryResource.cs
@@ -127,10 +127,7 @@ public class FoundryResource(string name, Action<AzureResourceInfrastructure> co
     {
         yield return new("Uri", UriExpression);
 
-        if (!IsEmulator)
-        {
-            yield return new("EndpointAIInference", ReferenceExpression.Create($"{AIFoundryApiEndpoint}models"));
-        }
+        yield return new("AI_INFERENCE_URI", IsEmulator ? UriExpression : ReferenceExpression.Create($"{AIFoundryApiEndpoint}models"));
 
         if (IsEmulator)
         {

--- a/src/Aspire.Hosting.Foundry/README.md
+++ b/src/Aspire.Hosting.Foundry/README.md
@@ -102,6 +102,7 @@ The Microsoft Foundry resource exposes the following connection properties:
 | Property Name | Description |
 |---------------|-------------|
 | `Uri` | The endpoint URI for the Microsoft Foundry resource, with the format `https://<resource_name>.services.ai.azure.com/` or the emulator service URI when running Foundry Local (e.g., `http://127.0.0.1:61799/v1`) |
+| `EndpointAIInference` | The AI inference endpoint URI when targeting Azure, with the format `https://<resource_name>.services.ai.azure.com/models` |
 | `Key` | The API key when using Foundry Local |
 
 ### Microsoft Foundry deployment

--- a/src/Aspire.Hosting.Foundry/README.md
+++ b/src/Aspire.Hosting.Foundry/README.md
@@ -102,7 +102,7 @@ The Microsoft Foundry resource exposes the following connection properties:
 | Property Name | Description |
 |---------------|-------------|
 | `Uri` | The endpoint URI for the Microsoft Foundry resource, with the format `https://<resource_name>.services.ai.azure.com/` or the emulator service URI when running Foundry Local (e.g., `http://127.0.0.1:61799/v1`) |
-| `AI_INFERENCE_URI` | The AI inference endpoint URI, with the format `https://<resource_name>.services.ai.azure.com/models` when targeting Azure or the emulator service URI when running Foundry Local (e.g., `http://127.0.0.1:61799/v1`) |
+| `AIInferenceUri` | The AI inference endpoint URI, with the format `https://<resource_name>.services.ai.azure.com/models` when targeting Azure or the emulator service URI when running Foundry Local (e.g., `http://127.0.0.1:61799/v1`) |
 | `Key` | The API key when using Foundry Local |
 
 ### Microsoft Foundry deployment

--- a/src/Aspire.Hosting.Foundry/README.md
+++ b/src/Aspire.Hosting.Foundry/README.md
@@ -105,6 +105,8 @@ The Microsoft Foundry resource exposes the following connection properties:
 | `AIInferenceUri` | The AI inference endpoint URI, with the format `https://<resource_name>.services.ai.azure.com/models` when targeting Azure or the emulator service URI when running Foundry Local (e.g., `http://127.0.0.1:61799/v1`) |
 | `Key` | The API key when using Foundry Local |
 
+See [Migrate from Azure AI Inference to Azure OpenAI in Azure AI Foundry Models](https://learn.microsoft.com/azure/foundry/how-to/model-inference-to-openai-migration?tabs=openai) for guidance on which URI to use based on the SDK used by your application.
+
 ### Microsoft Foundry deployment
 
 The Microsoft Foundry deployment resource inherits all properties from its parent Microsoft Foundry resource and adds:

--- a/src/Aspire.Hosting.Foundry/README.md
+++ b/src/Aspire.Hosting.Foundry/README.md
@@ -102,7 +102,7 @@ The Microsoft Foundry resource exposes the following connection properties:
 | Property Name | Description |
 |---------------|-------------|
 | `Uri` | The endpoint URI for the Microsoft Foundry resource, with the format `https://<resource_name>.services.ai.azure.com/` or the emulator service URI when running Foundry Local (e.g., `http://127.0.0.1:61799/v1`) |
-| `EndpointAIInference` | The AI inference endpoint URI when targeting Azure, with the format `https://<resource_name>.services.ai.azure.com/models` |
+| `AI_INFERENCE_URI` | The AI inference endpoint URI, with the format `https://<resource_name>.services.ai.azure.com/models` when targeting Azure or the emulator service URI when running Foundry Local (e.g., `http://127.0.0.1:61799/v1`) |
 | `Key` | The API key when using Foundry Local |
 
 ### Microsoft Foundry deployment

--- a/tests/Aspire.Hosting.Azure.Tests/FoundryConnectionPropertiesTests.cs
+++ b/tests/Aspire.Hosting.Azure.Tests/FoundryConnectionPropertiesTests.cs
@@ -25,7 +25,7 @@ public class FoundryConnectionPropertiesTests
             },
             property =>
             {
-                Assert.Equal("AI_INFERENCE_URI", property.Key);
+                Assert.Equal("AIInferenceUri", property.Key);
                 Assert.Equal("{aifoundry.outputs.aiFoundryApiEndpoint}models", property.Value.ValueExpression);
             });
     }
@@ -51,7 +51,7 @@ public class FoundryConnectionPropertiesTests
             },
             property =>
             {
-                Assert.Equal("AI_INFERENCE_URI", property.Key);
+                Assert.Equal("AIInferenceUri", property.Key);
                 Assert.Equal("http://localhost:8080/", property.Value.ValueExpression);
             },
             property =>

--- a/tests/Aspire.Hosting.Azure.Tests/FoundryConnectionPropertiesTests.cs
+++ b/tests/Aspire.Hosting.Azure.Tests/FoundryConnectionPropertiesTests.cs
@@ -22,6 +22,11 @@ public class FoundryConnectionPropertiesTests
             {
                 Assert.Equal("Uri", property.Key);
                 Assert.Equal("{aifoundry.outputs.aiFoundryApiEndpoint}", property.Value.ValueExpression);
+            },
+            property =>
+            {
+                Assert.Equal("EndpointAIInference", property.Key);
+                Assert.Equal("{aifoundry.outputs.aiFoundryApiEndpoint}models", property.Value.ValueExpression);
             });
     }
 

--- a/tests/Aspire.Hosting.Azure.Tests/FoundryConnectionPropertiesTests.cs
+++ b/tests/Aspire.Hosting.Azure.Tests/FoundryConnectionPropertiesTests.cs
@@ -25,7 +25,7 @@ public class FoundryConnectionPropertiesTests
             },
             property =>
             {
-                Assert.Equal("EndpointAIInference", property.Key);
+                Assert.Equal("AI_INFERENCE_URI", property.Key);
                 Assert.Equal("{aifoundry.outputs.aiFoundryApiEndpoint}models", property.Value.ValueExpression);
             });
     }
@@ -47,6 +47,11 @@ public class FoundryConnectionPropertiesTests
             property =>
             {
                 Assert.Equal("Uri", property.Key);
+                Assert.Equal("http://localhost:8080/", property.Value.ValueExpression);
+            },
+            property =>
+            {
+                Assert.Equal("AI_INFERENCE_URI", property.Key);
                 Assert.Equal("http://localhost:8080/", property.Value.ValueExpression);
             },
             property =>

--- a/tests/Aspire.Hosting.Azure.Tests/FoundryDeploymentConnectionPropertiesTests.cs
+++ b/tests/Aspire.Hosting.Azure.Tests/FoundryDeploymentConnectionPropertiesTests.cs
@@ -32,6 +32,11 @@ public class FoundryDeploymentConnectionPropertiesTests
             },
             property =>
             {
+                Assert.Equal("AI_INFERENCE_URI", property.Key);
+                Assert.Equal("http://localhost:8080/", property.Value.ValueExpression);
+            },
+            property =>
+            {
                 Assert.Equal("Key", property.Key);
                 Assert.Equal("OPENAI_KEY", property.Value.ValueExpression);
             },
@@ -70,7 +75,7 @@ public class FoundryDeploymentConnectionPropertiesTests
             },
             property =>
             {
-                Assert.Equal("EndpointAIInference", property.Key);
+                Assert.Equal("AI_INFERENCE_URI", property.Key);
                 Assert.Equal("{aifoundry.outputs.aiFoundryApiEndpoint}models", property.Value.ValueExpression);
             },
             property =>

--- a/tests/Aspire.Hosting.Azure.Tests/FoundryDeploymentConnectionPropertiesTests.cs
+++ b/tests/Aspire.Hosting.Azure.Tests/FoundryDeploymentConnectionPropertiesTests.cs
@@ -32,7 +32,7 @@ public class FoundryDeploymentConnectionPropertiesTests
             },
             property =>
             {
-                Assert.Equal("AI_INFERENCE_URI", property.Key);
+                Assert.Equal("AIInferenceUri", property.Key);
                 Assert.Equal("http://localhost:8080/", property.Value.ValueExpression);
             },
             property =>
@@ -75,7 +75,7 @@ public class FoundryDeploymentConnectionPropertiesTests
             },
             property =>
             {
-                Assert.Equal("AI_INFERENCE_URI", property.Key);
+                Assert.Equal("AIInferenceUri", property.Key);
                 Assert.Equal("{aifoundry.outputs.aiFoundryApiEndpoint}models", property.Value.ValueExpression);
             },
             property =>

--- a/tests/Aspire.Hosting.Azure.Tests/FoundryDeploymentConnectionPropertiesTests.cs
+++ b/tests/Aspire.Hosting.Azure.Tests/FoundryDeploymentConnectionPropertiesTests.cs
@@ -70,6 +70,11 @@ public class FoundryDeploymentConnectionPropertiesTests
             },
             property =>
             {
+                Assert.Equal("EndpointAIInference", property.Key);
+                Assert.Equal("{aifoundry.outputs.aiFoundryApiEndpoint}models", property.Value.ValueExpression);
+            },
+            property =>
+            {
                 Assert.Equal("ModelName", property.Key);
                 // Should be FoundryModel.Microsoft.Phi4.Format but assigned dynamically
                 Assert.Equal("chat", property.Value.ValueExpression);

--- a/tests/Aspire.Hosting.Foundry.Tests/ProjectWithReferenceTests.cs
+++ b/tests/Aspire.Hosting.Foundry.Tests/ProjectWithReferenceTests.cs
@@ -88,6 +88,6 @@ public class ProjectWithReferenceTests
         Assert.Contains(envVars, kvp =>
             kvp.Key == "CHAT_URI");
         Assert.Contains(envVars, kvp =>
-            kvp.Key == "CHAT_AI_INFERENCE_URI" && kvp.Value == "{test-account.outputs.aiFoundryApiEndpoint}models");
+            kvp.Key == "CHAT_AIINFERENCEURI" && kvp.Value == "{test-account.outputs.aiFoundryApiEndpoint}models");
     }
 }

--- a/tests/Aspire.Hosting.Foundry.Tests/ProjectWithReferenceTests.cs
+++ b/tests/Aspire.Hosting.Foundry.Tests/ProjectWithReferenceTests.cs
@@ -88,6 +88,6 @@ public class ProjectWithReferenceTests
         Assert.Contains(envVars, kvp =>
             kvp.Key == "CHAT_URI");
         Assert.Contains(envVars, kvp =>
-            kvp.Key == "CHAT_ENDPOINTAIINFERENCE" && kvp.Value == "{test-account.outputs.aiFoundryApiEndpoint}models");
+            kvp.Key == "CHAT_AI_INFERENCE_URI" && kvp.Value == "{test-account.outputs.aiFoundryApiEndpoint}models");
     }
 }

--- a/tests/Aspire.Hosting.Foundry.Tests/ProjectWithReferenceTests.cs
+++ b/tests/Aspire.Hosting.Foundry.Tests/ProjectWithReferenceTests.cs
@@ -87,5 +87,7 @@ public class ProjectWithReferenceTests
             kvp.Key == "CHAT_VERSION" && kvp.Value == "1");
         Assert.Contains(envVars, kvp =>
             kvp.Key == "CHAT_URI");
+        Assert.Contains(envVars, kvp =>
+            kvp.Key == "CHAT_ENDPOINTAIINFERENCE" && kvp.Value == "{test-account.outputs.aiFoundryApiEndpoint}models");
     }
 }


### PR DESCRIPTION
## Description

Foundry deployment references currently expose the base Foundry URI and model metadata as individual environment variables, but non-.NET consumers still have to parse the composite connection string to get the AI inference endpoint. This adds `EndpointAIInference` as an individual connection property so consumers can use the inference endpoint directly.

### User-facing usage

When a non-.NET app references a Foundry deployment:

```csharp
var foundry = builder.AddFoundry("foundry");
var chat = foundry.AddDeployment("chat", "gpt-4.1", "2025-04-14", "OpenAI");

builder.AddPythonApp("app", "../app", "main.py")
    .WithReference(chat);
```

Aspire now injects `CHAT_ENDPOINTAIINFERENCE` alongside the existing `CHAT_URI`, `CHAT_MODELNAME`, `CHAT_VERSION`, and `CHAT_FORMAT` variables. The FoundryAgents Python playground also resolves the project endpoint from the individual project URI env var and only parses the connection string as a fallback.

Validation:
- `Aspire.Hosting.Azure.Tests`: `FoundryConnectionPropertiesTests`, `FoundryDeploymentConnectionPropertiesTests`
- `Aspire.Hosting.Foundry.Tests`: `ProjectWithReferenceTests`
- `python3 -m py_compile playground/FoundryAgents/app/main.py`

Fixes #16280

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
