### PR TITLE
Default CLI bundle extraction to Aspire home for sidecar-less installs

### DIFF
--- a/docs/specs/bundle.md
+++ b/docs/specs/bundle.md
@@ -297,6 +297,7 @@ The parent directory check supports the installed layout where the CLI binary li
 | `ASPIRE_DCP_PATH` | DCP binaries location | `/opt/aspire/dcp` |
 | `ASPIRE_DASHBOARD_PATH` | Path used by Aspire.Hosting to locate the dashboard binary (now points to `aspire-managed`) | `/opt/aspire/managed/aspire-managed` |
 | `ASPIRE_MANAGED_PATH` | CLI-only path for the `aspire-managed` binary | `/opt/aspire/managed/aspire-managed` |
+| `ASPIRE_HOME` | Default Aspire state root and fallback bundle extraction root when no install-route sidecar selects an install-owned location | `/home/user/.aspire` |
 | `ASPIRE_INTEGRATION_LIBS_PATH` | Path to copied project-reference integration DLLs for aspire-server assembly resolution | `/home/user/myapp/.aspire/integrations/apphosts/app-hash/project-layouts/items/fingerprint/libs` |
 | `ASPIRE_INTEGRATION_PROBE_MANIFEST_PATH` | Path to the NuGet package probe manifest for package-backed integration assemblies | `/home/user/myapp/.aspire/integrations/package-restore/hash/integration-package-probe-manifest.json` |
 | `ASPIRE_USE_GLOBAL_DOTNET` | Force SDK mode | `true` |

--- a/docs/specs/install-routes.md
+++ b/docs/specs/install-routes.md
@@ -29,13 +29,13 @@ portable installs, the Aspire home used for hives and local state.
 
 - `winget` / `brew` / `dotnet-tool` → `binaryDir` (flat: bundle extracts beside the binary).
 - `script` / `pr` / `localhive` → `Path.GetDirectoryName(binaryDir)` (bin layout: bundle extracts as a sibling of `bin/`).
-- missing, unreadable, malformed, or unknown `source` sidecar → parent-of-binary, matching the legacy heuristic for pre-sidecar installs.
+- missing, unreadable, malformed, or unknown `source` sidecar → default Aspire home (`ASPIRE_HOME` when set, otherwise `$HOME/.aspire`).
 
 `CliPathHelper.GetAspireHomeDirectory` maps sidecar-owned portable installs to
 their install prefix so hives, caches, logs, and SDK state stay with the
 install. `script` and `localhive` use the parent of `bin`; `pr` uses the parent
 of `dogfood/pr-<N>/bin`. Package-manager installs and sidecar-less binaries keep
-the default user-profile Aspire home.
+the default Aspire home (`ASPIRE_HOME` when set, otherwise `$HOME/.aspire`).
 
 ## Per-route authorship
 
@@ -67,7 +67,7 @@ Two mechanical checks guard the contract:
 
 ## Reader-side invariants (runtime)
 
-`BundleService.ComputeDefaultExtractDir` is the single point of truth for layout selection. It performs no path-shape detection: layout is a pure function of the sidecar `source` value (or the fallback when the sidecar is absent, unreadable, malformed, or has an unknown `source`). Unknown `source` values fall back to parent-of-binary for typed bundle layout handling. Coverage lives in `tests/Aspire.Cli.Tests/Bundles/BundleServiceCrossRouteExtractionTests.cs` as a theory over (source × prefix-shape) rows, including the cross-route case where a `brew` sidecar lands under a script-style prefix.
+`BundleService.ComputeDefaultExtractDir` is the single point of truth for layout selection. It performs no path-shape detection: layout is a pure function of the sidecar `source` value (or the fallback when the sidecar is absent, unreadable, malformed, or has an unknown `source`). Unknown `source` values fall back to the default Aspire home so unrecognized installs do not try to write next to the CLI binary. Coverage lives in `tests/Aspire.Cli.Tests/Bundles/BundleServiceCrossRouteExtractionTests.cs` as a theory over (source × prefix-shape) rows, including the cross-route case where a `brew` sidecar lands under a script-style prefix.
 
 `CliPathHelper.GetAspireHomeDirectory` is the single point of truth for Aspire-home selection. It reads the same sidecar but only changes home for Aspire-owned portable routes (`script`, `pr`, and `localhive`); package-manager routes use the user-profile home because their install roots are package-manager-owned. Coverage lives in `tests/Aspire.Cli.Tests/Utils/CliPathHelperTests.cs`.
 

--- a/src/Aspire.Cli/Bundles/BundleService.cs
+++ b/src/Aspire.Cli/Bundles/BundleService.cs
@@ -418,7 +418,10 @@ internal sealed class BundleService(
             InstallSourceExtensions.ScriptWire
                 or InstallSourceExtensions.PrWire
                 or InstallSourceExtensions.LocalHiveWire => Path.GetDirectoryName(binaryDir) ?? binaryDir,
-            _ => Path.GetDirectoryName(binaryDir) ?? binaryDir,
+            // Sidecar-less binaries can be installed in arbitrary locations, including
+            // read-only package stores. Default to user-owned Aspire home unless a
+            // route-specific sidecar explicitly opts in to colocated extraction.
+            _ => CliPathHelper.GetDefaultAspireHomeDirectory(),
         };
     }
 

--- a/src/Aspire.Cli/Bundles/IBundleService.cs
+++ b/src/Aspire.Cli/Bundles/IBundleService.cs
@@ -54,9 +54,8 @@ internal interface IBundleService
     /// <item><description>Packager-managed sources (<c>source=winget</c> /
     /// <c>source=brew</c> / <c>source=dotnet-tool</c>): the directory containing the
     /// binary (symlinks resolved first).</description></item>
-    /// <item><description>No sidecar / unmanaged installs: the parent of the binary's
-    /// directory, preserving the historical <c>~/.aspire/bin/aspire → ~/.aspire/</c>
-    /// heuristic.</description></item>
+    /// <item><description>No sidecar / unmanaged installs: the default Aspire home
+    /// directory (<c>ASPIRE_HOME</c> when set, otherwise <c>~/.aspire</c>).</description></item>
     /// </list>
     /// </summary>
     /// <param name="processPath">An absolute path to the CLI binary.</param>

--- a/src/Aspire.Cli/Layout/LayoutDiscovery.cs
+++ b/src/Aspire.Cli/Layout/LayoutDiscovery.cs
@@ -71,8 +71,45 @@ public sealed class LayoutDiscovery : ILayoutDiscovery
             return LogEnvironmentOverrides(relativeLayout);
         }
 
+        // 3. Try the Aspire home directory. This is the auto-extract destination
+        // for sidecar-less installs (e.g. CLI binaries in read-only locations
+        // like a Nix store), so the bundle the CLI just extracted has to be
+        // discoverable here too — otherwise post-extract validation fails and
+        // every command that depends on the bundle reports extraction failed.
+        // Keep this as the last probe so colocated installs (winget, brew,
+        // dotnet-tool, script, pr, localhive) are never shadowed by a stale
+        // home-directory layout.
+        var aspireHomeLayout = TryDiscoverAspireHomeLayout();
+        if (aspireHomeLayout is not null)
+        {
+            _logger.LogDebug("Discovered layout in Aspire home: {Path}", aspireHomeLayout.LayoutPath);
+            return LogEnvironmentOverrides(aspireHomeLayout);
+        }
+
         _logger.LogDebug("No bundle layout discovered");
         return null;
+    }
+
+    private LayoutConfiguration? TryDiscoverAspireHomeLayout()
+    {
+        string aspireHome;
+        try
+        {
+            aspireHome = CliPathHelper.GetDefaultAspireHomeDirectory();
+        }
+        catch (Exception ex) when (ex is ArgumentException or PathTooLongException or NotSupportedException)
+        {
+            _logger.LogDebug(ex, "TryDiscoverAspireHomeLayout: could not resolve Aspire home directory");
+            return null;
+        }
+
+        if (string.IsNullOrEmpty(aspireHome) || !Directory.Exists(aspireHome))
+        {
+            return null;
+        }
+
+        _logger.LogDebug("TryDiscoverAspireHomeLayout: Checking Aspire home {Path}...", aspireHome);
+        return TryInferLayout(aspireHome);
     }
 
     public string? GetComponentPath(LayoutComponent component, string? projectDirectory = null)

--- a/src/Aspire.Cli/Utils/CliPathHelper.cs
+++ b/src/Aspire.Cli/Utils/CliPathHelper.cs
@@ -9,12 +9,26 @@ namespace Aspire.Cli.Utils;
 
 internal static class CliPathHelper
 {
+    internal const string AspireHomeEnvironmentVariable = "ASPIRE_HOME";
+
     internal static string GetAspireHomeDirectory(string? processPath = null, ILogger? logger = null)
     {
         var effectiveProcessPath = processPath ?? Environment.ProcessPath;
 
         return TryGetAspireHomeDirectoryFromInstallRoute(effectiveProcessPath, logger)
-            ?? Path.Combine(GetUserProfileDirectory(), ".aspire");
+            ?? GetDefaultAspireHomeDirectory();
+    }
+
+    internal static string GetDefaultAspireHomeDirectory()
+        => GetDefaultAspireHomeDirectory(
+            Environment.GetEnvironmentVariable(AspireHomeEnvironmentVariable),
+            GetUserProfileDirectory());
+
+    internal static string GetDefaultAspireHomeDirectory(string? configuredAspireHome, string userProfileDirectory)
+    {
+        return string.IsNullOrWhiteSpace(configuredAspireHome)
+            ? Path.Combine(userProfileDirectory, ".aspire")
+            : configuredAspireHome;
     }
 
     internal static string? TryGetAspireHomeDirectoryFromInstallRoute(string? processPath, ILogger? logger = null)

--- a/tests/Aspire.Cli.Tests/BundleServiceComputeDefaultExtractDirTests.cs
+++ b/tests/Aspire.Cli.Tests/BundleServiceComputeDefaultExtractDirTests.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using Aspire.Cli.Bundles;
+using Aspire.Cli.Utils;
 
 namespace Aspire.Cli.Tests;
 
@@ -150,15 +151,13 @@ public class BundleServiceComputeDefaultExtractDirTests
     }
 
     [Fact]
-    public void ComputeDefaultExtractDir_UnmanagedFallback_PreservesLegacyParentOfBinaryDirHeuristic()
+    public void ComputeDefaultExtractDir_UnmanagedFallback_UsesDefaultAspireHome()
     {
-        // No sidecar anywhere → fall back to "parent of binary's directory" so
-        // installs that pre-date the sidecar continue to see the historical
-        // ~/.aspire/bin/aspire → ~/.aspire/ mapping. Without this backwards-compat
-        // path, existing CLI installs would silently move their extraction target
-        // on upgrade and re-extract into the binary's own dir.
+        // No sidecar anywhere means no install route opted in to writing next to
+        // the binary, so the fallback must be user-owned Aspire home rather than
+        // an arbitrary binary parent that may be read-only.
         using var temp = new TestTempDirectory();
-        var prefixDir = Path.Combine(temp.Path, ".aspire");
+        var prefixDir = Path.Combine(temp.Path, "nix", "store", "aspire");
         var binDir = Path.Combine(prefixDir, "bin");
         Directory.CreateDirectory(binDir);
 
@@ -168,7 +167,8 @@ public class BundleServiceComputeDefaultExtractDirTests
 
         var result = BundleService.ComputeDefaultExtractDir(binaryPath);
 
-        Assert.Equal(prefixDir, result);
+        Assert.Equal(CliPathHelper.GetDefaultAspireHomeDirectory(), result);
+        Assert.NotEqual(prefixDir, result);
     }
 
     [Fact]

--- a/tests/Aspire.Cli.Tests/BundleServiceIntegrationTests.cs
+++ b/tests/Aspire.Cli.Tests/BundleServiceIntegrationTests.cs
@@ -197,9 +197,15 @@ public class BundleServiceIntegrationTests(ITestOutputHelper outputHelper)
         var layoutRoot = workspace.WorkspaceRoot.FullName;
         var layoutDiscovery = new TestLayoutDiscovery(layoutRoot);
 
-        var v1BinaryPath = CreateFakeCliBinary(Path.Combine(layoutRoot, ".fake-bins"), "aspire-v1", "cli-v1");
-        var v2BinaryPath = CreateFakeCliBinary(Path.Combine(layoutRoot, ".fake-bins"), "aspire-v2", "cli-v2-longer");
+        var binDir = Path.Combine(layoutRoot, ".fake-bins");
+        var v1BinaryPath = CreateFakeCliBinary(binDir, "aspire-v1", "cli-v1");
+        var v2BinaryPath = CreateFakeCliBinary(binDir, "aspire-v2", "cli-v2-longer");
         File.SetLastWriteTimeUtc(v2BinaryPath, File.GetLastWriteTimeUtc(v1BinaryPath).AddHours(1));
+
+        // Drop a script sidecar so EnsureExtractedAndAcquireLayoutAsync resolves the
+        // process-driven extract directory to the parent of the binary directory
+        // (layoutRoot) rather than the default Aspire home.
+        File.WriteAllText(Path.Combine(binDir, ".aspire-install.json"), "{\"source\":\"script\"}");
 
         var v1Service = CreateService(new TestBundlePayloadProvider(CreateFakeBundlePayload("v1")), layoutDiscovery, v1BinaryPath);
         var result1 = await v1Service.ExtractAsync(layoutRoot, force: true);
@@ -280,10 +286,14 @@ public class BundleServiceIntegrationTests(ITestOutputHelper outputHelper)
     }
 
     [Fact]
-    public async Task EnsureExtractedAsync_DotnetToolStorePath_ExtractsToTargetFrameworkDirectory()
+    public async Task EnsureExtractedAsync_DotnetToolStorePath_ExtractsToRidDirectory()
     {
         using var workspace = TemporaryWorkspace.Create(outputHelper);
-        var layoutRoot = Path.Combine(
+        // RID-specific dotnet-tool layout: the native binary lives in the
+        // RID-scoped directory inside the tool store. The sidecar declares
+        // source=dotnet-tool so extraction stays at that same RID directory
+        // (binaryDir) rather than falling back to Aspire home.
+        var ridDir = Path.Combine(
             workspace.WorkspaceRoot.FullName,
             ".dotnet",
             "tools",
@@ -293,22 +303,24 @@ public class BundleServiceIntegrationTests(ITestOutputHelper outputHelper)
             "aspire.cli.linux-x64",
             "9.4.0",
             "tools",
-            "net10.0");
+            "net10.0",
+            "linux-x64");
         var processPath = CreateFakeCliBinary(
-            Path.Combine(layoutRoot, "linux-x64"),
+            ridDir,
             BundleDiscovery.GetExecutableFileName("aspire"),
             "native-aot-cli");
+        File.WriteAllText(Path.Combine(ridDir, ".aspire-install.json"), "{\"source\":\"dotnet-tool\"}");
         var payload = CreateFakeBundlePayload();
         var provider = new TestBundlePayloadProvider(payload);
-        var layoutDiscovery = new TestLayoutDiscovery(layoutRoot);
+        var layoutDiscovery = new TestLayoutDiscovery(ridDir);
         var service = CreateService(provider, layoutDiscovery, processPath);
 
         await service.EnsureExtractedAsync();
 
-        var bundleLink = Path.Combine(layoutRoot, BundleDiscovery.BundleDirectoryName);
+        var bundleLink = Path.Combine(ridDir, BundleDiscovery.BundleDirectoryName);
         try
         {
-            Assert.True(ReparsePoint.IsReparsePoint(bundleLink), "bundle/ should be a reparse point under the tool TFM directory");
+            Assert.True(ReparsePoint.IsReparsePoint(bundleLink), "bundle/ should be a reparse point under the tool RID directory");
 
             var managedExe = Path.Combine(bundleLink,
                 BundleDiscovery.ManagedDirectoryName,
@@ -317,7 +329,7 @@ public class BundleServiceIntegrationTests(ITestOutputHelper outputHelper)
         }
         finally
         {
-            CleanupReparsePoints(layoutRoot);
+            CleanupReparsePoints(ridDir);
         }
     }
 

--- a/tests/Aspire.Cli.Tests/BundleServiceIntegrationTests.cs
+++ b/tests/Aspire.Cli.Tests/BundleServiceIntegrationTests.cs
@@ -5,6 +5,7 @@ using System.Formats.Tar;
 using System.IO.Compression;
 using Aspire.Cli.Bundles;
 using Aspire.Cli.Layout;
+using Aspire.Cli.Tests.Acquisition;
 using Aspire.Cli.Tests.TestServices;
 using Aspire.Cli.Tests.Utils;
 using Aspire.Cli.Utils;
@@ -13,6 +14,11 @@ using Microsoft.Extensions.Logging.Abstractions;
 
 namespace Aspire.Cli.Tests;
 
+// EnsureExtractedAndAcquireLayoutAsync_SidecarlessInstall_ExtractsToAspireHomeAndAcquiresLayout
+// mutates the process-wide ASPIRE_HOME variable. xUnit runs test classes in parallel by default,
+// so join EnvVarMutatingTestCollection to serialize with other suites that read ASPIRE_HOME via
+// CliPathHelper.GetDefaultAspireHomeDirectory.
+[Collection(EnvVarMutatingTestCollection.Name)]
 public class BundleServiceIntegrationTests(ITestOutputHelper outputHelper)
 {
     /// <summary>
@@ -330,6 +336,95 @@ public class BundleServiceIntegrationTests(ITestOutputHelper outputHelper)
         finally
         {
             CleanupReparsePoints(ridDir);
+        }
+    }
+
+    [Fact]
+    public async Task EnsureExtractedAndAcquireLayoutAsync_SidecarlessInstall_ExtractsToAspireHomeAndAcquiresLayout()
+    {
+        // End-to-end coverage for the sidecar-less install scenario fixed by this PR:
+        //   1. ComputeDefaultExtractDir routes a no-sidecar CLI to $ASPIRE_HOME instead of
+        //      Path.GetDirectoryName(binaryDir) so binaries in read-only locations (e.g.
+        //      Nix stores) can still extract their bundle.
+        //   2. The real LayoutDiscovery's Aspire-home probe finds the freshly extracted
+        //      layout even though the CLI binary is outside the bundle hierarchy.
+        // Individual pieces are covered by ComputeDefaultExtractDir tests and
+        // LayoutDiscovery_FallsBackToAspireHomeWhenLayoutIsNotRelativeToCli; this test
+        // locks in the combined behavior end-to-end through EnsureExtractedAndAcquireLayoutAsync.
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+
+        // CLI lives in a directory unrelated to any layout, with no .aspire-install.json
+        // sidecar. This simulates an installation in an arbitrary location such as a
+        // package-manager-controlled, read-only prefix.
+        var binaryDir = Path.Combine(workspace.WorkspaceRoot.FullName, "opt", "aspire-readonly", "bin");
+        var processPath = CreateFakeCliBinary(
+            binaryDir,
+            BundleDiscovery.GetExecutableFileName("aspire"),
+            "sidecarless-cli");
+
+        var aspireHome = Path.Combine(workspace.WorkspaceRoot.FullName, "home", ".aspire");
+        Directory.CreateDirectory(aspireHome);
+
+        var payload = CreateFakeBundlePayload();
+        var provider = new TestBundlePayloadProvider(payload);
+
+        // Use the real LayoutDiscovery (not TestLayoutDiscovery) so the post-extract
+        // probe must actually find the freshly extracted bundle via the Aspire-home
+        // fallback. Relative-to-CLI discovery must fail (binary lives outside any
+        // layout) for the home probe to be exercised.
+        var layoutDiscovery = new LayoutDiscovery(NullLogger<LayoutDiscovery>.Instance)
+        {
+            ProcessPathOverride = processPath
+        };
+        var service = CreateService(provider, layoutDiscovery, processPath);
+
+        var originalAspireHome = Environment.GetEnvironmentVariable(CliPathHelper.AspireHomeEnvironmentVariable);
+        try
+        {
+            Environment.SetEnvironmentVariable(CliPathHelper.AspireHomeEnvironmentVariable, aspireHome);
+
+            using var layoutLease = await service.EnsureExtractedAndAcquireLayoutAsync("test", "sidecarless-flow");
+
+            Assert.NotNull(layoutLease);
+            Assert.True(layoutLease!.HasLease);
+
+            // Bundle should have been extracted under $ASPIRE_HOME (not next to the CLI binary).
+            var bundleLink = Path.Combine(aspireHome, BundleDiscovery.BundleDirectoryName);
+            Assert.True(ReparsePoint.IsReparsePoint(bundleLink),
+                $"bundle/ should be a reparse point under $ASPIRE_HOME ({aspireHome})");
+
+            var managedExe = Path.Combine(bundleLink,
+                BundleDiscovery.ManagedDirectoryName,
+                BundleDiscovery.GetExecutableFileName(BundleDiscovery.ManagedExecutableName));
+            Assert.True(File.Exists(managedExe), $"managed exe should exist at {managedExe}");
+
+            // No stray extraction should have leaked next to the CLI binary itself.
+            Assert.False(
+                Directory.Exists(Path.Combine(binaryDir, BundleDiscovery.BundleDirectoryName)),
+                "bundle/ must not be created next to the sidecar-less CLI binary.");
+            Assert.False(
+                Directory.Exists(Path.Combine(Path.GetDirectoryName(binaryDir)!, BundleDiscovery.BundleDirectoryName)),
+                "bundle/ must not be created in the parent of the sidecar-less binary directory.");
+
+            // The resolved layout must point into the active version directory under $ASPIRE_HOME,
+            // proving the post-extract discovery succeeded via the Aspire-home probe rather than a
+            // cached lookup.
+            var versionsDir = Path.Combine(aspireHome, BundleService.VersionsDirectoryName);
+            var activeVersionDir = Assert.Single(Directory.GetDirectories(versionsDir));
+
+            var managedPath = layoutLease.Layout.GetManagedPath();
+            Assert.NotNull(managedPath);
+
+            var comparison = OperatingSystem.IsWindows() ? StringComparison.OrdinalIgnoreCase : StringComparison.Ordinal;
+            Assert.StartsWith(
+                Path.GetFullPath(activeVersionDir),
+                Path.GetFullPath(managedPath!),
+                comparison);
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable(CliPathHelper.AspireHomeEnvironmentVariable, originalAspireHome);
+            CleanupReparsePoints(aspireHome);
         }
     }
 

--- a/tests/Aspire.Cli.Tests/BundleServiceTests.cs
+++ b/tests/Aspire.Cli.Tests/BundleServiceTests.cs
@@ -3,6 +3,7 @@
 
 using Aspire.Cli.Bundles;
 using Aspire.Cli.Tests.Utils;
+using Aspire.Cli.Utils;
 using Aspire.Shared;
 
 namespace Aspire.Cli.Tests;
@@ -43,20 +44,22 @@ public class BundleServiceTests(ITestOutputHelper outputHelper)
     }
 
     [Fact]
-    public void ComputeDefaultExtractDir_NoSidecar_ReturnsParentOfBinaryDirectory()
+    public void ComputeDefaultExtractDir_NoSidecar_ReturnsDefaultAspireHomeDirectory()
     {
-        // Legacy no-sidecar fallback: a sidecar-less install still walks one level up
-        // from the binary's directory to preserve the historical
-        // ~/.aspire/bin/aspire → ~/.aspire/ mapping that pre-dates the sidecar.
+        // Sidecar-less installs do not prove the binary's directory is user-writable.
+        // Use Aspire home so arbitrary install locations such as read-only package
+        // stores can still extract the embedded bundle.
+        var expected = CliPathHelper.GetDefaultAspireHomeDirectory();
+
         if (OperatingSystem.IsWindows())
         {
             var result = BundleService.ComputeDefaultExtractDir(@"C:\Users\test\.aspire\bin\aspire.exe");
-            Assert.Equal(@"C:\Users\test\.aspire", result);
+            Assert.Equal(expected, result);
         }
         else
         {
             var result = BundleService.ComputeDefaultExtractDir("/home/test/.aspire/bin/aspire");
-            Assert.Equal("/home/test/.aspire", result);
+            Assert.Equal(expected, result);
         }
     }
 

--- a/tests/Aspire.Cli.Tests/Bundles/BundleServiceCrossRouteExtractionTests.cs
+++ b/tests/Aspire.Cli.Tests/Bundles/BundleServiceCrossRouteExtractionTests.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using Aspire.Cli.Bundles;
+using Aspire.Cli.Utils;
 
 namespace Aspire.Cli.Tests.Bundles;
 
@@ -12,10 +13,12 @@ namespace Aspire.Cli.Tests.Bundles;
 /// <c>source</c> field — and nothing else — to decide between
 /// <c>binaryDir</c> (winget / brew / dotnet-tool) and the parent of
 /// <c>binaryDir</c> (script / pr / localhive). Missing, invalid, or unknown sidecars fall
-/// through to the parent-of-binary heuristic.
+/// through to the default Aspire home.
 /// </summary>
 public class BundleServiceCrossRouteExtractionTests
 {
+    private const string DefaultAspireHome = "<default-aspire-home>";
+
     // The inline-data paths use forward slashes for source-readability; the test
     // method converts them to platform-native separators before constructing
     // absolute paths under the temp root.
@@ -48,13 +51,13 @@ public class BundleServiceCrossRouteExtractionTests
     //    script maps to parent-of-binary, so the result is one level above the
     //    cask version dir. Not a real install pattern; locks in determinism.
     [InlineData("script", "Caskroom/aspire/13.2.0/aspire", "Caskroom/aspire")]
-    // 9) No sidecar at all: fallback heuristic = parent of binaryDir.
-    [InlineData(null, ".aspire/bin/aspire", ".aspire")]
+    // 9) No sidecar at all: fallback to default Aspire home.
+    [InlineData(null, ".aspire/bin/aspire", DefaultAspireHome)]
     // 10) Sidecar with invalid JSON: parser throws, treated as no sidecar.
-    [InlineData("__invalid__", ".aspire/bin/aspire", ".aspire")]
+    [InlineData("__invalid__", ".aspire/bin/aspire", DefaultAspireHome)]
     // 11) Sidecar with an unknown source value: switch default arm, same as
-    //     missing sidecar — parent-of-binary.
-    [InlineData("github-actions", ".aspire/bin/aspire", ".aspire")]
+    //     missing sidecar — default Aspire home.
+    [InlineData("github-actions", ".aspire/bin/aspire", DefaultAspireHome)]
     public void ComputeDefaultExtractDir_RouteAndPrefixCombinations_ProduceExpectedExtractDir(
         string? sourceField,
         string relativeProcessPath,
@@ -79,7 +82,9 @@ public class BundleServiceCrossRouteExtractionTests
                 File.WriteAllText(sidecarPath, content);
             }
 
-            var expected = Path.Combine(root, ToNativePath(relativeExpectedExtractDir));
+            var expected = relativeExpectedExtractDir == DefaultAspireHome
+                ? CliPathHelper.GetDefaultAspireHomeDirectory()
+                : Path.Combine(root, ToNativePath(relativeExpectedExtractDir));
 
             var actual = BundleService.ComputeDefaultExtractDir(processPath);
 

--- a/tests/Aspire.Cli.Tests/Layout/LayoutDiscoveryReparsePointTests.cs
+++ b/tests/Aspire.Cli.Tests/Layout/LayoutDiscoveryReparsePointTests.cs
@@ -164,6 +164,53 @@ public class LayoutDiscoveryReparsePointTests(ITestOutputHelper outputHelper)
         }
     }
 
+    [Fact]
+    public void DiscoverLayout_PrefersRelativeLayoutOverAspireHomeLayout()
+    {
+        // The Aspire-home probe is the last fallback in DiscoverLayout so that
+        // package-managed or sidecar-owned installs (winget/brew/dotnet-tool/script/
+        // pr/localhive) — which already colocate the bundle next to or above the
+        // CLI binary — are never shadowed by a stale or differently-versioned
+        // layout left over in $HOME/.aspire from an earlier sidecar-less run.
+        // This regression test pins that ordering: when both layouts exist, the
+        // relative-to-CLI layout wins.
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+
+        // Colocated (relative) layout: CLI in {layoutRoot}/bin/aspire with the
+        // bundle as a sibling of bin/.
+        var relativeLayoutRoot = Path.Combine(workspace.WorkspaceRoot.FullName, "colocated");
+        var binDir = Path.Combine(relativeLayoutRoot, "bin");
+        Directory.CreateDirectory(binDir);
+        var binaryPath = Path.Combine(binDir, OperatingSystem.IsWindows() ? "aspire.exe" : "aspire");
+        File.WriteAllText(binaryPath, "stub");
+        CreateValidBundleLayout(relativeLayoutRoot);
+
+        // Competing $ASPIRE_HOME layout: also valid but should not be selected.
+        var aspireHome = Path.Combine(workspace.WorkspaceRoot.FullName, "home", ".aspire");
+        CreateValidBundleLayout(aspireHome);
+
+        var originalAspireHome = Environment.GetEnvironmentVariable(CliPathHelper.AspireHomeEnvironmentVariable);
+        try
+        {
+            Environment.SetEnvironmentVariable(CliPathHelper.AspireHomeEnvironmentVariable, aspireHome);
+
+            var discovery = new LayoutDiscovery(NullLogger<LayoutDiscovery>.Instance)
+            {
+                ProcessPathOverride = binaryPath
+            };
+
+            var layout = discovery.DiscoverLayout();
+
+            Assert.NotNull(layout);
+            Assert.Equal(relativeLayoutRoot, layout!.LayoutPath);
+            Assert.NotEqual(aspireHome, layout.LayoutPath);
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable(CliPathHelper.AspireHomeEnvironmentVariable, originalAspireHome);
+        }
+    }
+
     private static void CreateValidBundleLayout(string layoutRoot)
     {
         var bundleDir = Path.Combine(layoutRoot, BundleDiscovery.BundleDirectoryName);

--- a/tests/Aspire.Cli.Tests/Layout/LayoutDiscoveryReparsePointTests.cs
+++ b/tests/Aspire.Cli.Tests/Layout/LayoutDiscoveryReparsePointTests.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using Aspire.Cli.Layout;
+using Aspire.Cli.Tests.Acquisition;
 using Aspire.Cli.Tests.Utils;
 using Aspire.Cli.Utils;
 using Aspire.Shared;
@@ -14,6 +15,15 @@ namespace Aspire.Cli.Tests.LayoutTests;
 /// whose <c>bundle/</c> entry is a reparse point pointing at a versioned subdirectory
 /// (the new on-disk shape introduced for transactional installs).
 /// </summary>
+/// <remarks>
+/// The Aspire-home fallback test mutates the process-wide <c>ASPIRE_HOME</c> environment
+/// variable, which is also read by <see cref="CliPathHelper.GetDefaultAspireHomeDirectory()"/>
+/// and indirectly by <c>BundleService.ComputeDefaultExtractDir</c>. xUnit runs test classes
+/// in parallel by default, so without joining <see cref="EnvVarMutatingTestCollection"/> a
+/// concurrent reader in another suite could observe the temporary override and assert against
+/// the wrong path. Disabling parallelization across the mutating tests prevents that race.
+/// </remarks>
+[Collection(EnvVarMutatingTestCollection.Name)]
 public class LayoutDiscoveryReparsePointTests(ITestOutputHelper outputHelper)
 {
     [Fact]

--- a/tests/Aspire.Cli.Tests/Layout/LayoutDiscoveryReparsePointTests.cs
+++ b/tests/Aspire.Cli.Tests/Layout/LayoutDiscoveryReparsePointTests.cs
@@ -117,6 +117,43 @@ public class LayoutDiscoveryReparsePointTests(ITestOutputHelper outputHelper)
         }
     }
 
+    [Fact]
+    public void DiscoverLayout_FallsBackToAspireHomeWhenLayoutIsNotRelativeToCli()
+    {
+        // Simulates a sidecar-less install where the CLI binary lives somewhere
+        // unrelated to the extracted bundle (e.g. a Nix store / read-only path)
+        // and the bundle is extracted to $ASPIRE_HOME.
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+
+        var binaryDir = Path.Combine(workspace.WorkspaceRoot.FullName, "opt", "aspire", "bin");
+        Directory.CreateDirectory(binaryDir);
+        var binaryPath = Path.Combine(binaryDir, OperatingSystem.IsWindows() ? "aspire.exe" : "aspire");
+        File.WriteAllText(binaryPath, "stub");
+
+        var aspireHome = Path.Combine(workspace.WorkspaceRoot.FullName, "home", ".aspire");
+        CreateValidBundleLayout(aspireHome);
+
+        var originalAspireHome = Environment.GetEnvironmentVariable(CliPathHelper.AspireHomeEnvironmentVariable);
+        try
+        {
+            Environment.SetEnvironmentVariable(CliPathHelper.AspireHomeEnvironmentVariable, aspireHome);
+
+            var discovery = new LayoutDiscovery(NullLogger<LayoutDiscovery>.Instance)
+            {
+                ProcessPathOverride = binaryPath
+            };
+
+            var layout = discovery.DiscoverLayout();
+
+            Assert.NotNull(layout);
+            Assert.Equal(aspireHome, layout!.LayoutPath);
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable(CliPathHelper.AspireHomeEnvironmentVariable, originalAspireHome);
+        }
+    }
+
     private static void CreateValidBundleLayout(string layoutRoot)
     {
         var bundleDir = Path.Combine(layoutRoot, BundleDiscovery.BundleDirectoryName);

--- a/tests/Aspire.Cli.Tests/Utils/CliPathHelperTests.cs
+++ b/tests/Aspire.Cli.Tests/Utils/CliPathHelperTests.cs
@@ -109,6 +109,25 @@ public class CliPathHelperTests(ITestOutputHelper outputHelper)
     }
 
     [Fact]
+    public void GetDefaultAspireHomeDirectory_UsesConfiguredAspireHome()
+    {
+        var result = CliPathHelper.GetDefaultAspireHomeDirectory("/custom/aspire-home", "/home/user");
+
+        Assert.Equal("/custom/aspire-home", result);
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void GetDefaultAspireHomeDirectory_WithoutConfiguredAspireHome_UsesUserProfile(string? configuredAspireHome)
+    {
+        var result = CliPathHelper.GetDefaultAspireHomeDirectory(configuredAspireHome, "/home/user");
+
+        Assert.Equal(Path.Combine("/home/user", ".aspire"), result);
+    }
+
+    [Fact]
     public void ResolveSymlinkOrOriginalPath_NonLink_ReturnsOriginalPath()
     {
         const string path = "relative/path/aspire";


### PR DESCRIPTION
## Description

CLI installs in read-only or non-user-writable locations (e.g., a Nix store, system-managed prefixes) currently fail bundle extraction because the sidecar-less fallback in `BundleService.ComputeDefaultExtractDir` resolves to the parent of the binary directory. That heuristic only makes sense for the script-style layout (`~/.aspire/bin/aspire`) and was never safe as a universal default.

This change makes the unmanaged fallback resolve to the user-owned Aspire home directory instead: `$ASPIRE_HOME` when set, otherwise `~/.aspire`. Package-manager and known sidecar routes (winget, brew, dotnet-tool, script, pr, localhive) keep their existing colocated / parent-of-binary behavior, so any install that ships an `.aspire-install.json` still extracts inside the directory the packager owns. Only the "no sidecar / unknown source" arm of the switch is affected.

A new `CliPathHelper.GetDefaultAspireHomeDirectory()` is the single source of truth for that path so the bundle fallback and the existing `GetAspireHomeDirectory()` agree on `ASPIRE_HOME` semantics.

### Notable test updates

- The dotnet-tool integration test (`EnsureExtractedAsync_DotnetToolStorePath_*`) previously relied on the legacy parent-of-binary fallback. It now drops a `source=dotnet-tool` sidecar and asserts extraction at the RID directory, matching the real dotnet-tool contract. Renamed to `...ExtractsToRidDirectory`.
- `EnsureExtractedAndAcquireLayoutAsync_ReturnsVersionRootedLayoutAndSkipsLeasedCleanup` now drops a `source=script` sidecar so the process-driven extract directory still resolves to the test workspace root rather than the real `$HOME/.aspire`.

Fixes #17253

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No