### PR TITLE
Fix TypeScript AppHost deadlock for async callbacks

### DIFF
--- a/src/Aspire.Hosting.RemoteHost/Ats/CapabilityDispatcher.cs
+++ b/src/Aspire.Hosting.RemoteHost/Ats/CapabilityDispatcher.cs
@@ -622,7 +622,7 @@ internal sealed class CapabilityDispatcher
         if (runInvocationOnBackgroundThread)
         {
             // Async-returning exports can execute substantial synchronous setup before returning
-            // their Task. Run that invocation path off the JSON-RPC synchronization context so
+            // their Task or ValueTask. Run that invocation path off the JSON-RPC synchronization context so
             // sync-over-async callback proxies can still receive nested RPC responses.
             return await Task.Run(() => InvokeMethodCore(method, target, methodArgs)).ConfigureAwait(false);
         }

--- a/src/Aspire.Hosting.RemoteHost/Ats/CapabilityDispatcher.cs
+++ b/src/Aspire.Hosting.RemoteHost/Ats/CapabilityDispatcher.cs
@@ -617,24 +617,17 @@ internal sealed class CapabilityDispatcher
         return InvokeAsync(capabilityId, args).GetAwaiter().GetResult();
     }
 
-    private static async Task<object?> InvokeMethodAsync(MethodInfo method, object? target, object?[] methodArgs, bool runSyncOnBackgroundThread)
+    private static async Task<object?> InvokeMethodAsync(MethodInfo method, object? target, object?[] methodArgs, bool runInvocationOnBackgroundThread)
     {
-        if (runSyncOnBackgroundThread && !IsAsyncReturnType(method.ReturnType))
+        if (runInvocationOnBackgroundThread)
         {
+            // Async-returning exports can execute substantial synchronous setup before returning
+            // their Task. Run that invocation path off the JSON-RPC synchronization context so
+            // sync-over-async callback proxies can still receive nested RPC responses.
             return await Task.Run(() => InvokeMethodCore(method, target, methodArgs)).ConfigureAwait(false);
         }
 
         return InvokeMethodCore(method, target, methodArgs);
-    }
-
-    private static bool IsAsyncReturnType(Type returnType)
-    {
-        if (typeof(Task).IsAssignableFrom(returnType) || returnType == typeof(ValueTask))
-        {
-            return true;
-        }
-
-        return returnType.IsGenericType && returnType.GetGenericTypeDefinition() == typeof(ValueTask<>);
     }
 
     private static async Task<object?> UnwrapAsyncResultAsync(object? result, Type returnType)

--- a/src/Aspire.Hosting/Ats/AspireExportAttribute.cs
+++ b/src/Aspire.Hosting/Ats/AspireExportAttribute.cs
@@ -229,9 +229,9 @@ public sealed class AspireExportAttribute : Attribute
     /// complete.
     /// </para>
     /// <para>
-    /// For async exports, this applies to the synchronous invocation path that returns the <see cref="Task"/> or
-    /// <see cref="Task{TResult}"/>. This is important when the async method performs startup work or invokes callbacks
-    /// before its first asynchronous yield.
+    /// For async exports, this applies to the synchronous invocation path that returns the <see cref="Task"/>,
+    /// <see cref="Task{TResult}"/>, <see cref="ValueTask"/>, or <see cref="ValueTask{TResult}"/>. This is important
+    /// when the async method performs startup work or invokes callbacks before its first asynchronous yield.
     /// </para>
     /// <para>
     /// When applied to a type, this setting also applies to exported members discovered from that type unless an individual

--- a/src/Aspire.Hosting/Ats/AspireExportAttribute.cs
+++ b/src/Aspire.Hosting/Ats/AspireExportAttribute.cs
@@ -219,18 +219,19 @@ public sealed class AspireExportAttribute : Attribute
     public bool ExposeMethods { get; set; }
 
     /// <summary>
-    /// Gets or sets whether synchronous exported methods should be invoked on a background thread by the ATS dispatcher.
+    /// Gets or sets whether the exported method invocation should run on a background thread by the ATS dispatcher.
     /// </summary>
     /// <remarks>
     /// <para>
-    /// Set this to <see langword="true"/> for synchronous exports that may invoke synchronous callback delegates which in turn
+    /// Set this to <see langword="true"/> for exports that may invoke synchronous callback delegates which in turn
     /// re-enter the remote host through ATS. Running the export on a background thread allows the JSON-RPC request loop to
-    /// continue processing nested callback and capability invocations while the synchronous method waits for the callback to
+    /// continue processing nested callback and capability invocations while the method waits for the callback to
     /// complete.
     /// </para>
     /// <para>
-    /// This setting only affects synchronous exported methods. Async exports that already return <see cref="Task"/> or
-    /// <see cref="Task{TResult}"/> are awaited normally and do not use this option.
+    /// For async exports, this applies to the synchronous invocation path that returns the <see cref="Task"/> or
+    /// <see cref="Task{TResult}"/>. This is important when the async method performs startup work or invokes callbacks
+    /// before its first asynchronous yield.
     /// </para>
     /// <para>
     /// When applied to a type, this setting also applies to exported members discovered from that type unless an individual

--- a/src/Aspire.TypeSystem/AtsCapabilityInfo.cs
+++ b/src/Aspire.TypeSystem/AtsCapabilityInfo.cs
@@ -356,7 +356,7 @@ public sealed class AtsCapabilityInfo
     public string? SourceLocation { get; init; }
 
     /// <summary>
-    /// Gets or sets whether synchronous invocations of this capability should run on a background thread.
+    /// Gets or sets whether this capability's invocation should run on a background thread.
     /// </summary>
     public bool RunSyncOnBackgroundThread { get; init; }
 }

--- a/src/Aspire.TypeSystem/AttributeDataReader.cs
+++ b/src/Aspire.TypeSystem/AttributeDataReader.cs
@@ -379,7 +379,7 @@ public sealed class AspireExportData
     public bool ExposeMethods { get; init; }
 
     /// <summary>
-    /// Gets whether synchronous exported methods should be invoked on a background thread by the ATS dispatcher.
+    /// Gets whether exported method invocations should run on a background thread by the ATS dispatcher.
     /// </summary>
     public bool RunSyncOnBackgroundThread { get; init; }
 }

--- a/tests/Aspire.Hosting.RemoteHost.Tests/CapabilityDispatcherTests.cs
+++ b/tests/Aspire.Hosting.RemoteHost.Tests/CapabilityDispatcherTests.cs
@@ -734,7 +734,32 @@ public class CapabilityDispatcherTests
     }
 
     [Fact]
-    public void Invoke_ValueTaskCapabilityWithBackgroundThreadOptIn_RunsInline()
+    public void Invoke_TaskCapabilityWithBackgroundThreadOptIn_RunsOnBackgroundThread()
+    {
+        var dispatcher = CreateDispatcher(typeof(TestCapabilitiesWithBackgroundThreadDispatch).Assembly);
+        var callerThreadId = Environment.CurrentManagedThreadId;
+
+        var result = dispatcher.Invoke("Aspire.Hosting.RemoteHost.Tests/taskBackgroundThreadProbe", null);
+
+        Assert.NotNull(result);
+        Assert.NotEqual(callerThreadId, result.GetValue<int>());
+    }
+
+    [Fact]
+    public void Invoke_NonGenericTaskCapabilityWithBackgroundThreadOptIn_RunsOnBackgroundThread()
+    {
+        var dispatcher = CreateDispatcher(typeof(TestCapabilitiesWithBackgroundThreadDispatch).Assembly);
+        var callerThreadId = Environment.CurrentManagedThreadId;
+
+        TestCapabilitiesWithBackgroundThreadDispatch.ResetLastObservedThreadId();
+
+        dispatcher.Invoke("Aspire.Hosting.RemoteHost.Tests/nonGenericTaskBackgroundThreadProbe", null);
+
+        Assert.NotEqual(callerThreadId, TestCapabilitiesWithBackgroundThreadDispatch.LastObservedThreadId);
+    }
+
+    [Fact]
+    public void Invoke_ValueTaskCapabilityWithBackgroundThreadOptIn_RunsOnBackgroundThread()
     {
         var dispatcher = CreateDispatcher(typeof(TestCapabilitiesWithBackgroundThreadDispatch).Assembly);
         var callerThreadId = Environment.CurrentManagedThreadId;
@@ -742,11 +767,11 @@ public class CapabilityDispatcherTests
         var result = dispatcher.Invoke("Aspire.Hosting.RemoteHost.Tests/valueTaskBackgroundThreadProbe", null);
 
         Assert.NotNull(result);
-        Assert.Equal(callerThreadId, result.GetValue<int>());
+        Assert.NotEqual(callerThreadId, result.GetValue<int>());
     }
 
     [Fact]
-    public void Invoke_NonGenericValueTaskCapabilityWithBackgroundThreadOptIn_RunsInline()
+    public void Invoke_NonGenericValueTaskCapabilityWithBackgroundThreadOptIn_RunsOnBackgroundThread()
     {
         var dispatcher = CreateDispatcher(typeof(TestCapabilitiesWithBackgroundThreadDispatch).Assembly);
         var callerThreadId = Environment.CurrentManagedThreadId;
@@ -755,7 +780,56 @@ public class CapabilityDispatcherTests
 
         dispatcher.Invoke("Aspire.Hosting.RemoteHost.Tests/nonGenericValueTaskBackgroundThreadProbe", null);
 
-        Assert.Equal(callerThreadId, TestCapabilitiesWithBackgroundThreadDispatch.LastObservedThreadId);
+        Assert.NotEqual(callerThreadId, TestCapabilitiesWithBackgroundThreadDispatch.LastObservedThreadId);
+    }
+
+    [Fact]
+    public void Invoke_AsyncReturningCapabilityWithBackgroundThreadOptIn_InvokesSyncCallbackOnBackgroundThread()
+    {
+        var handles = new HandleRegistry();
+        var invoker = new TestCallbackInvoker();
+        var (marshaller, callbackFactory) = CreateTestMarshallerWithCallbacks(handles, invoker);
+        using var _ = callbackFactory;
+        var dispatcher = new CapabilityDispatcher(handles, marshaller, [typeof(TestCapabilitiesWithBackgroundThreadDispatch).Assembly]);
+        var callerThreadId = Environment.CurrentManagedThreadId;
+
+        TestCapabilitiesWithBackgroundThreadDispatch.ResetLastObservedThreadId();
+
+        dispatcher.Invoke(
+            "Aspire.Hosting.RemoteHost.Tests/invokeSyncCallbackFromAsyncBackgroundThreadProbe",
+            new JsonObject { ["callback"] = "background-callback" });
+
+        Assert.NotEqual(callerThreadId, TestCapabilitiesWithBackgroundThreadDispatch.LastObservedThreadId);
+        Assert.Single(invoker.Invocations);
+        Assert.Equal("background-callback", invoker.Invocations[0].CallbackId);
+    }
+
+    [Fact]
+    public void Invoke_AsyncReturningCapabilityWithBackgroundThreadOptIn_DoesNotRunSyncCallbackOnCallerSynchronizationContext()
+    {
+        var handles = new HandleRegistry();
+        var invoker = new TestSynchronizationContextCallbackInvoker();
+        var (marshaller, callbackFactory) = CreateTestMarshallerWithCallbacks(handles, invoker);
+        using var _ = callbackFactory;
+        var dispatcher = new CapabilityDispatcher(handles, marshaller, [typeof(TestCapabilitiesWithBackgroundThreadDispatch).Assembly]);
+        var callerSynchronizationContext = new SynchronizationContext();
+        var originalSynchronizationContext = SynchronizationContext.Current;
+
+        try
+        {
+            SynchronizationContext.SetSynchronizationContext(callerSynchronizationContext);
+
+            dispatcher.Invoke(
+                "Aspire.Hosting.RemoteHost.Tests/invokeSyncCallbackFromAsyncBackgroundThreadProbe",
+                new JsonObject { ["callback"] = "background-callback" });
+        }
+        finally
+        {
+            SynchronizationContext.SetSynchronizationContext(originalSynchronizationContext);
+        }
+
+        Assert.Single(invoker.Invocations);
+        Assert.NotSame(callerSynchronizationContext, invoker.LastObservedSynchronizationContext);
     }
 
     [Fact]
@@ -1962,6 +2036,32 @@ public class CapabilityDispatcherTests
 }
 
 /// <summary>
+/// Captures the synchronization context observed by callback invocation.
+/// </summary>
+internal sealed class TestSynchronizationContextCallbackInvoker : ICallbackInvoker
+{
+    public List<(string CallbackId, JsonNode? Args)> Invocations { get; } = [];
+    public SynchronizationContext? LastObservedSynchronizationContext { get; private set; }
+    public bool IsConnected => true;
+
+    public Task<TResult> InvokeAsync<TResult>(string callbackId, JsonNode? args, CancellationToken cancellationToken = default)
+    {
+        LastObservedSynchronizationContext = SynchronizationContext.Current;
+        Invocations.Add((callbackId, args));
+
+        return Task.FromResult(default(TResult)!);
+    }
+
+    public Task InvokeAsync(string callbackId, JsonNode? args, CancellationToken cancellationToken = default)
+    {
+        LastObservedSynchronizationContext = SynchronizationContext.Current;
+        Invocations.Add((callbackId, args));
+
+        return Task.CompletedTask;
+    }
+}
+
+/// <summary>
 /// Test capabilities for scanning.
 /// </summary>
 internal static class TestCapabilities
@@ -2224,6 +2324,21 @@ internal static class TestCapabilitiesWithBackgroundThreadDispatch
         return Environment.CurrentManagedThreadId;
     }
 
+    /// <ats-summary>Captures the current thread for Task&lt;T&gt; invocation</ats-summary>
+    [AspireExport(RunSyncOnBackgroundThread = true)]
+    public static Task<int> TaskBackgroundThreadProbe()
+    {
+        return Task.FromResult(Environment.CurrentManagedThreadId);
+    }
+
+    /// <ats-summary>Captures the current thread for Task invocation</ats-summary>
+    [AspireExport(RunSyncOnBackgroundThread = true)]
+    public static Task NonGenericTaskBackgroundThreadProbe()
+    {
+        LastObservedThreadId = Environment.CurrentManagedThreadId;
+        return Task.CompletedTask;
+    }
+
     /// <ats-summary>Captures the current thread for ValueTask&lt;T&gt; invocation</ats-summary>
     [AspireExport(RunSyncOnBackgroundThread = true)]
     public static ValueTask<int> ValueTaskBackgroundThreadProbe()
@@ -2237,6 +2352,16 @@ internal static class TestCapabilitiesWithBackgroundThreadDispatch
     {
         LastObservedThreadId = Environment.CurrentManagedThreadId;
         return ValueTask.CompletedTask;
+    }
+
+    /// <ats-summary>Synchronously invokes a callback from a Task-returning capability</ats-summary>
+    [AspireExport(RunSyncOnBackgroundThread = true)]
+    public static Task InvokeSyncCallbackFromAsyncBackgroundThreadProbe(Func<Task> callback)
+    {
+        LastObservedThreadId = Environment.CurrentManagedThreadId;
+        callback().GetAwaiter().GetResult();
+
+        return Task.CompletedTask;
     }
 }
 


### PR DESCRIPTION
## Description

Fixes #17487

TypeScript AppHosts could hang during `aspire start`/`aspire run` when an ATS export marked with `RunSyncOnBackgroundThread = true` returned `Task`/`ValueTask` and synchronously invoked an async TypeScript callback during startup. The dispatcher previously skipped the background-thread path for async-returning exports, so the synchronous invocation path could still run on StreamJsonRpc's non-concurrent synchronization context and block nested callback responses.

This updates ATS capability dispatch so `RunSyncOnBackgroundThread` applies to the reflected method invocation regardless of whether the export returns synchronously, `Task`, or `ValueTask`. Async results are still unwrapped through the existing path after invocation. The XML docs now clarify that the option covers the synchronous invocation path of async exports, especially work that happens before the first asynchronous yield.

### User-facing usage

TypeScript AppHosts can use integrations that opt into `RunSyncOnBackgroundThread` with async configure callbacks that are invoked during startup without deadlocking the AppHost server startup.

Validation:

```text
dotnet test --project tests\Aspire.Hosting.RemoteHost.Tests\Aspire.Hosting.RemoteHost.Tests.csproj --no-launch-profile -- --filter-not-trait "quarantined=true" --filter-not-trait "outerloop=true"
```

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
