### PR TITLE
Expand TypeScript brownfield workspace validation

### DIFF
--- a/src/Aspire.Cli/Scaffolding/PackageJsonMerger.cs
+++ b/src/Aspire.Cli/Scaffolding/PackageJsonMerger.cs
@@ -41,7 +41,8 @@ internal static class PackageJsonMerger
     /// <summary>
     /// Merges scaffold-generated package.json content with existing content.
     /// Preserves all existing properties and scripts. Scaffold scripts that conflict
-    /// with existing names are added under the <c>aspire:</c> prefix. Non-conflicting
+    /// with existing names are added under the <c>aspire:</c> prefix. Existing scripts,
+    /// including <c>aspire:</c>-prefixed scripts, are preserved. Non-conflicting
     /// <c>aspire:X</c> scripts get a convenience alias <c>X</c> pointing to
     /// <c>{toolchain} run aspire:X</c>.
     /// </summary>
@@ -140,7 +141,7 @@ internal static class PackageJsonMerger
     /// <remarks>
     /// For each scaffold script:
     /// <list type="bullet">
-    /// <item>Already <c>aspire:</c> prefixed → always added/updated</item>
+    /// <item>Already <c>aspire:</c> prefixed → added only when missing</item>
     /// <item>Not prefixed, conflicts with existing → added as <c>aspire:{name}</c></item>
     /// <item>Not prefixed, no conflict → added with the original name</item>
     /// </list>
@@ -158,8 +159,7 @@ internal static class PackageJsonMerger
 
             if (name.StartsWith(AspirePrefix, StringComparison.Ordinal))
             {
-                // Already prefixed — always set it
-                existingScripts[name] = command;
+                existingScripts[name] ??= command;
             }
             else if (existingScripts[name] is not null)
             {

--- a/src/Aspire.Cli/Scaffolding/ScaffoldingService.cs
+++ b/src/Aspire.Cli/Scaffolding/ScaffoldingService.cs
@@ -290,13 +290,28 @@ internal sealed class ScaffoldingService : IScaffoldingService
         var scripts = EnsureJsonObject(packageJson, "scripts");
         var toolchain = TypeScriptAppHostToolchainResolver.Resolve(rootDirectory, _logger);
         var relativeAppHostDirectory = PathNormalizer.NormalizePathForStorage(Path.GetRelativePath(rootDirectory.FullName, appHostDirectory.FullName));
+        var preservedScriptNames = AddRootTypeScriptAppHostDelegateScripts(scripts, toolchain, relativeAppHostDirectory);
 
-        scripts["aspire:start"] = CreateRootDelegateScript(toolchain, relativeAppHostDirectory, "aspire:start");
-        scripts["aspire:build"] = CreateRootDelegateScript(toolchain, relativeAppHostDirectory, "aspire:build");
-        scripts["aspire:dev"] = CreateRootDelegateScript(toolchain, relativeAppHostDirectory, "aspire:dev");
+        if (preservedScriptNames.Count > 0)
+        {
+            _interactionService.DisplayMessage(
+                KnownEmojis.Warning,
+                $"Preserved existing package.json script(s) {string.Join(", ", preservedScriptNames)}. Run the AppHost directly from {relativeAppHostDirectory} or remove the existing script(s) and rerun 'aspire init' to regenerate the root delegates.");
+        }
 
         var serializedPackageJson = SerializePackageJson(packageJson, existingContent);
         await File.WriteAllTextAsync(packageJsonPath, serializedPackageJson, cancellationToken);
+    }
+
+    internal static IReadOnlyList<string> AddRootTypeScriptAppHostDelegateScripts(JsonObject scripts, TypeScriptAppHostToolchain toolchain, string relativeAppHostDirectory)
+    {
+        List<string>? preservedScriptNames = null;
+
+        AddRootTypeScriptAppHostDelegateScript(scripts, toolchain, relativeAppHostDirectory, "aspire:start", ref preservedScriptNames);
+        AddRootTypeScriptAppHostDelegateScript(scripts, toolchain, relativeAppHostDirectory, "aspire:build", ref preservedScriptNames);
+        AddRootTypeScriptAppHostDelegateScript(scripts, toolchain, relativeAppHostDirectory, "aspire:dev", ref preservedScriptNames);
+
+        return preservedScriptNames ?? [];
     }
 
     internal static string SerializePackageJson(JsonObject packageJson, string existingContent)
@@ -351,6 +366,26 @@ internal sealed class ScaffoldingService : IScaffoldingService
             TypeScriptAppHostToolchain.Bun => $"bun --cwd {relativeAppHostDirectory} run {scriptName}",
             _ => throw new ArgumentOutOfRangeException(nameof(toolchain), toolchain, null)
         };
+    }
+
+    private static void AddRootTypeScriptAppHostDelegateScript(JsonObject scripts, TypeScriptAppHostToolchain toolchain, string relativeAppHostDirectory, string scriptName, ref List<string>? preservedScriptNames)
+    {
+        var delegateScript = CreateRootDelegateScript(toolchain, relativeAppHostDirectory, scriptName);
+        if (scripts[scriptName] is JsonValue existingScriptValue &&
+            existingScriptValue.TryGetValue<string>(out var existingScript) &&
+            string.Equals(existingScript, delegateScript, StringComparison.Ordinal))
+        {
+            return;
+        }
+
+        if (scripts[scriptName] is not null)
+        {
+            preservedScriptNames ??= [];
+            preservedScriptNames.Add(scriptName);
+            return;
+        }
+
+        scripts[scriptName] = delegateScript;
     }
 
     private async Task<int> InstallDependenciesAsync(

--- a/src/Aspire.Cli/Scaffolding/ScaffoldingService.cs
+++ b/src/Aspire.Cli/Scaffolding/ScaffoldingService.cs
@@ -288,9 +288,8 @@ internal sealed class ScaffoldingService : IScaffoldingService
         }
 
         var scripts = EnsureJsonObject(packageJson, "scripts");
-        var toolchain = TypeScriptAppHostToolchainResolver.Resolve(rootDirectory, _logger);
         var relativeAppHostDirectory = PathNormalizer.NormalizePathForStorage(Path.GetRelativePath(rootDirectory.FullName, appHostDirectory.FullName));
-        var preservedScriptNames = AddRootTypeScriptAppHostDelegateScripts(scripts, toolchain, relativeAppHostDirectory);
+        var preservedScriptNames = AddRootTypeScriptAppHostDelegateScripts(scripts, appHostDirectory, relativeAppHostDirectory, _logger);
 
         if (preservedScriptNames.Count > 0)
         {
@@ -312,6 +311,12 @@ internal sealed class ScaffoldingService : IScaffoldingService
         AddRootTypeScriptAppHostDelegateScript(scripts, toolchain, relativeAppHostDirectory, "aspire:dev", ref preservedScriptNames);
 
         return preservedScriptNames ?? [];
+    }
+
+    internal static IReadOnlyList<string> AddRootTypeScriptAppHostDelegateScripts(JsonObject scripts, DirectoryInfo appHostDirectory, string relativeAppHostDirectory, ILogger? logger)
+    {
+        var toolchain = TypeScriptAppHostToolchainResolver.Resolve(appHostDirectory, logger);
+        return AddRootTypeScriptAppHostDelegateScripts(scripts, toolchain, relativeAppHostDirectory);
     }
 
     internal static string SerializePackageJson(JsonObject packageJson, string existingContent)

--- a/tests/Aspire.Cli.EndToEnd.Tests/TypeScriptPolyglotTests.cs
+++ b/tests/Aspire.Cli.EndToEnd.Tests/TypeScriptPolyglotTests.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Text.Json;
 using System.Text.Json.Nodes;
 using Aspire.Cli.EndToEnd.Tests.Helpers;
 using Aspire.Cli.Tests.Utils;
@@ -160,6 +161,100 @@ public sealed class TypeScriptPolyglotTests(ITestOutputHelper output)
         await pendingRun;
     }
 
+    [Fact]
+    [CaptureWorkspaceOnFailure]
+    public async Task CreateTypeScriptAppHostWithViteApp_AllowsGuestAppPackageManagerToDiffer()
+    {
+        const string appHostToolchain = "pnpm";
+        const string guestToolchain = "npm";
+
+        var repoRoot = CliE2ETestHelpers.GetRepoRoot();
+        var strategy = CliInstallStrategy.Detect(output.WriteLine);
+        var workspace = TemporaryWorkspace.Create(output);
+        var localChannel = CliE2ETestHelpers.PrepareLocalChannel(repoRoot, strategy,
+            ["Aspire.Hosting.CodeGeneration.TypeScript.", "Aspire.Hosting.JavaScript."]);
+        var channelArgument = localChannel is not null ? " --channel local" : string.Empty;
+
+        using var terminal = CliE2ETestHelpers.CreateDockerTestTerminal(repoRoot, strategy, output, variant: CliE2ETestHelpers.DockerfileVariant.Polyglot, mountDockerSocket: true, workspace: workspace);
+
+        var pendingRun = terminal.RunAsync(TestContext.Current.CancellationToken);
+
+        var counter = new SequenceCounter();
+        var auto = new Hex1bTerminalAutomator(terminal, defaultTimeout: TimeSpan.FromSeconds(500));
+
+        await auto.PrepareDockerEnvironmentAsync(counter, workspace);
+        await auto.InstallAspireCliAsync(strategy, counter);
+
+        await auto.TypeAsync($"aspire init --language typescript --non-interactive{channelArgument}");
+        await auto.EnterAsync();
+        await auto.WaitUntilTextAsync("Created apphost.mts", timeout: TimeSpan.FromMinutes(2));
+        await auto.DeclineAgentInitPromptAsync(counter);
+
+        TypeScriptAppHostToolchainTestHelpers.SetPackageManager(workspace.WorkspaceRoot.FullName, appHostToolchain, cleanInstallState: true);
+
+        if (localChannel is not null)
+        {
+            CliE2ETestHelpers.WriteLocalChannelSettings(workspace.WorkspaceRoot.FullName, localChannel.SdkVersion);
+        }
+
+        await auto.TypeAsync("npm create -y vite@latest viteapp -- --template vanilla-ts --no-interactive");
+        await auto.EnterAsync();
+        await auto.WaitForSuccessPromptAsync(counter, TimeSpan.FromMinutes(2));
+
+        var viteProjectRoot = Path.Combine(workspace.WorkspaceRoot.FullName, "viteapp");
+        TypeScriptAppHostToolchainTestHelpers.SetPackageManager(viteProjectRoot, guestToolchain, cleanInstallState: true);
+
+        await auto.TypeAsync($"cd viteapp && {TypeScriptAppHostToolchainTestHelpers.GetInstallCommand(guestToolchain)} && cd ..");
+        await auto.EnterAsync();
+        await auto.WaitForSuccessPromptAsync(counter, TimeSpan.FromMinutes(2));
+
+        await auto.TypeAsync("aspire add Aspire.Hosting.JavaScript");
+        await auto.EnterAsync();
+        await auto.WaitForAspireAddSuccessAsync(counter, TimeSpan.FromMinutes(2));
+
+        var appHostPath = Path.Combine(workspace.WorkspaceRoot.FullName, "apphost.mts");
+        File.WriteAllText(appHostPath, """
+            // Aspire TypeScript AppHost
+            // For more information, see: https://aspire.dev
+
+            import { createBuilder } from './.aspire/modules/aspire.mjs';
+
+            const builder = await createBuilder();
+
+            await builder.addViteApp("viteapp", "./viteapp");
+
+            await builder.build().run();
+            """);
+
+        await auto.TypeAsync("aspire restore");
+        await auto.EnterAsync();
+        await auto.WaitUntilTextAsync("SDK code restored successfully", timeout: TimeSpan.FromMinutes(3));
+        await auto.WaitForSuccessPromptAsync(counter);
+
+        var appHostLockFilePath = Path.Combine(
+            workspace.WorkspaceRoot.FullName,
+            TypeScriptAppHostToolchainTestHelpers.GetLockFileName(appHostToolchain));
+        Assert.True(
+            File.Exists(appHostLockFilePath),
+            $"Expected {TypeScriptAppHostToolchainTestHelpers.GetDisplayName(appHostToolchain)} restore to create '{appHostLockFilePath}'.");
+
+        var guestLockFilePath = Path.Combine(
+            viteProjectRoot,
+            TypeScriptAppHostToolchainTestHelpers.GetLockFileName(guestToolchain));
+        Assert.True(
+            File.Exists(guestLockFilePath),
+            $"Expected {TypeScriptAppHostToolchainTestHelpers.GetDisplayName(guestToolchain)} install to create '{guestLockFilePath}'.");
+
+        await auto.TypeAsync(TypeScriptAppHostToolchainTestHelpers.GetTypeCheckCommand(appHostToolchain, "tsconfig.apphost.json"));
+        await auto.EnterAsync();
+        await auto.WaitForSuccessPromptFailFastAsync(counter, TimeSpan.FromMinutes(2));
+
+        await auto.TypeAsync("exit");
+        await auto.EnterAsync();
+
+        await pendingRun;
+    }
+
     [Theory]
     [MemberData(nameof(SupportedToolchains))]
     [CaptureWorkspaceOnFailure]
@@ -222,7 +317,7 @@ public sealed class TypeScriptPolyglotTests(ITestOutputHelper output)
     }
 
     [Fact]
-    public async Task InitTypeScriptAppHost_AugmentsExistingViteRepoAtRoot()
+    public async Task InitTypeScriptAppHost_AugmentsExistingViteRepoInWorkspaceSubdirectory()
     {
         var repoRoot = CliE2ETestHelpers.GetRepoRoot();
         var strategy = CliInstallStrategy.Detect(output.WriteLine);
@@ -254,8 +349,20 @@ public sealed class TypeScriptPolyglotTests(ITestOutputHelper output)
         await auto.InstallAspireCliAsync(strategy, counter);
         await auto.EnablePolyglotSupportAsync(counter);
 
+        File.WriteAllText(
+            Path.Combine(workspace.WorkspaceRoot.FullName, "package.json"),
+            """
+            {
+              "name": "workspace-root",
+              "private": true,
+              "workspaces": [
+                "packages/*"
+              ]
+            }
+            """);
+
         // Create brownfield Vite project
-        await auto.TypeAsync("mkdir brownfield && cd brownfield");
+        await auto.TypeAsync("mkdir -p packages/brownfield && cd packages/brownfield");
         await auto.EnterAsync();
         await auto.WaitForSuccessPromptAsync(counter);
 
@@ -264,7 +371,7 @@ public sealed class TypeScriptPolyglotTests(ITestOutputHelper output)
         await auto.WaitForSuccessPromptAsync(counter, TimeSpan.FromMinutes(2));
 
         // Capture original package.json scripts and tsconfig before aspire init
-        var projectRoot = Path.Combine(workspace.WorkspaceRoot.FullName, "brownfield");
+        var projectRoot = Path.Combine(workspace.WorkspaceRoot.FullName, "packages", "brownfield");
         var packageJson = JsonNode.Parse(File.ReadAllText(Path.Combine(projectRoot, "package.json")))!.AsObject();
         var scripts = packageJson["scripts"]!.AsObject();
         originalDevScript = scripts["dev"]?.GetValue<string>();
@@ -272,6 +379,8 @@ public sealed class TypeScriptPolyglotTests(ITestOutputHelper output)
         originalPreviewScript = scripts["preview"]?.GetValue<string>();
         originalPackageType = packageJson["type"]?.GetValue<string>();
         originalTsConfig = File.ReadAllText(Path.Combine(projectRoot, "tsconfig.json"));
+        scripts["aspire:start"] = "custom-apphost-start";
+        File.WriteAllText(Path.Combine(projectRoot, "package.json"), packageJson.ToJsonString(new JsonSerializerOptions { WriteIndented = true }));
 
         // LocalHive strategy only: PrepareLocalChannel returned a real channel,
         // so write the per-project aspire.config.json to point at the in-repo
@@ -300,7 +409,7 @@ public sealed class TypeScriptPolyglotTests(ITestOutputHelper output)
         Assert.Equal(originalDevScript, scripts["dev"]?.GetValue<string>());
         Assert.Equal(originalBuildScript, scripts["build"]?.GetValue<string>());
         Assert.Equal(originalPreviewScript, scripts["preview"]?.GetValue<string>());
-        Assert.Equal("npm --prefix aspire-apphost run aspire:start", scripts["aspire:start"]?.GetValue<string>());
+        Assert.Equal("custom-apphost-start", scripts["aspire:start"]?.GetValue<string>());
         Assert.Equal("npm --prefix aspire-apphost run aspire:build", scripts["aspire:build"]?.GetValue<string>());
         Assert.Equal("npm --prefix aspire-apphost run aspire:dev", scripts["aspire:dev"]?.GetValue<string>());
         Assert.Equal(originalPackageType, packageJson["type"]?.GetValue<string>());

--- a/tests/Aspire.Cli.Tests/Projects/TypeScriptAppHostToolchainResolverTests.cs
+++ b/tests/Aspire.Cli.Tests/Projects/TypeScriptAppHostToolchainResolverTests.cs
@@ -173,6 +173,37 @@ public sealed class TypeScriptAppHostToolchainResolverTests(ITestOutputHelper ou
     }
 
     [Fact]
+    public void Resolve_WhenAppHostAndParentDefineDifferentToolchains_ReturnsAppHostToolchain()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+
+        var appHostDirectory = workspace.WorkspaceRoot.CreateSubdirectory("apps").CreateSubdirectory("apphost");
+        File.WriteAllText(Path.Combine(appHostDirectory.Parent!.FullName, "package.json"), "{ \"packageManager\": \"pnpm@10.12.1\" }");
+        File.WriteAllText(Path.Combine(appHostDirectory.FullName, "package.json"), "{ \"packageManager\": \"bun@1.2.0\" }");
+
+        var resolution = TypeScriptAppHostToolchainResolver.ResolveWithReason(appHostDirectory);
+
+        Assert.Equal(TypeScriptAppHostToolchain.Bun, resolution.Toolchain);
+        Assert.Equal($"packageManager 'bun@1.2.0' found in {Path.Combine(appHostDirectory.FullName, "package.json")}", resolution.Reason);
+    }
+
+    [Fact]
+    public void Resolve_WhenAppHostLockFileAndParentPackageManagerDiffer_ReturnsAppHostLockFileToolchain()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+
+        var appHostDirectory = workspace.WorkspaceRoot.CreateSubdirectory("apps").CreateSubdirectory("apphost");
+        File.WriteAllText(Path.Combine(appHostDirectory.Parent!.FullName, "package.json"), "{ \"packageManager\": \"yarn@4.14.1\" }");
+        File.WriteAllText(Path.Combine(appHostDirectory.FullName, "package.json"), "{ \"name\": \"apphost\" }");
+        File.WriteAllText(Path.Combine(appHostDirectory.FullName, "pnpm-lock.yaml"), "lockfileVersion: '9.0'");
+
+        var resolution = TypeScriptAppHostToolchainResolver.ResolveWithReason(appHostDirectory);
+
+        Assert.Equal(TypeScriptAppHostToolchain.Pnpm, resolution.Toolchain);
+        Assert.Equal($"pnpm-lock.yaml found in {appHostDirectory.FullName}", resolution.Reason);
+    }
+
+    [Fact]
     public void Resolve_WhenGrandparentDirectoryDefinesToolchain_ReturnsNpm()
     {
         using var workspace = TemporaryWorkspace.Create(outputHelper);

--- a/tests/Aspire.Cli.Tests/Scaffolding/PackageJsonMergerTests.cs
+++ b/tests/Aspire.Cli.Tests/Scaffolding/PackageJsonMergerTests.cs
@@ -100,14 +100,15 @@ public class PackageJsonMergerTests
     }
 
     [Fact]
-    public void PrefixedScripts_AlwaysAdded()
+    public void PrefixedScripts_PreserveExistingValues()
     {
         var existing = """
             {
               "name": "my-app",
               "scripts": {
                 "dev": "vite",
-                "build": "vite build"
+                "build": "vite build",
+                "aspire:start": "custom start"
               }
             }
             """;
@@ -130,8 +131,8 @@ public class PackageJsonMergerTests
         Assert.Equal("vite", scripts["dev"]?.GetValue<string>());
         Assert.Equal("vite build", scripts["build"]?.GetValue<string>());
 
-        // All aspire: scripts added
-        Assert.Equal("aspire run", scripts["aspire:start"]?.GetValue<string>());
+        // Existing aspire: scripts are preserved; missing ones are added
+        Assert.Equal("custom start", scripts["aspire:start"]?.GetValue<string>());
         Assert.Equal("tsc -p tsconfig.apphost.json", scripts["aspire:build"]?.GetValue<string>());
         Assert.Equal("tsc --watch -p tsconfig.apphost.json", scripts["aspire:dev"]?.GetValue<string>());
         Assert.Equal("eslint apphost.ts", scripts["aspire:lint"]?.GetValue<string>());

--- a/tests/Aspire.Cli.Tests/Scaffolding/ScaffoldingServiceTests.cs
+++ b/tests/Aspire.Cli.Tests/Scaffolding/ScaffoldingServiceTests.cs
@@ -130,6 +130,35 @@ public class ScaffoldingServiceTests
     }
 
     [Fact]
+    public void AddRootTypeScriptAppHostDelegateScripts_UsesAppHostToolchain()
+    {
+        var rootDirectory = Directory.CreateTempSubdirectory();
+
+        try
+        {
+            var appHostDirectory = Directory.CreateDirectory(Path.Combine(rootDirectory.FullName, ScaffoldingService.BrownfieldTypeScriptAppHostDirectoryName));
+            File.WriteAllText(Path.Combine(rootDirectory.FullName, "package.json"), "{ \"packageManager\": \"npm@10.0.0\" }");
+            File.WriteAllText(Path.Combine(appHostDirectory.FullName, "package.json"), "{ \"packageManager\": \"pnpm@10.0.0\" }");
+            var scripts = new JsonObject();
+
+            var preservedScriptNames = ScaffoldingService.AddRootTypeScriptAppHostDelegateScripts(
+                scripts,
+                appHostDirectory,
+                ScaffoldingService.BrownfieldTypeScriptAppHostDirectoryName,
+                logger: null);
+
+            Assert.Empty(preservedScriptNames);
+            Assert.Equal("pnpm --dir aspire-apphost run aspire:start", scripts["aspire:start"]?.GetValue<string>());
+            Assert.Equal("pnpm --dir aspire-apphost run aspire:build", scripts["aspire:build"]?.GetValue<string>());
+            Assert.Equal("pnpm --dir aspire-apphost run aspire:dev", scripts["aspire:dev"]?.GetValue<string>());
+        }
+        finally
+        {
+            rootDirectory.Delete(recursive: true);
+        }
+    }
+
+    [Fact]
     public void AddRootTypeScriptAppHostDelegateScripts_PreservesExistingAspireScripts()
     {
         var scripts = JsonNode.Parse("""

--- a/tests/Aspire.Cli.Tests/Scaffolding/ScaffoldingServiceTests.cs
+++ b/tests/Aspire.Cli.Tests/Scaffolding/ScaffoldingServiceTests.cs
@@ -113,6 +113,44 @@ public class ScaffoldingServiceTests
     }
 
     [Fact]
+    public void AddRootTypeScriptAppHostDelegateScripts_AddsMissingScriptsWithSelectedToolchain()
+    {
+        var scripts = JsonNode.Parse("""{ "test": "vitest" }""")!.AsObject();
+
+        var preservedScriptNames = ScaffoldingService.AddRootTypeScriptAppHostDelegateScripts(
+            scripts,
+            TypeScriptAppHostToolchain.Pnpm,
+            "apps/web/aspire-apphost");
+
+        Assert.Empty(preservedScriptNames);
+        Assert.Equal("vitest", scripts["test"]?.GetValue<string>());
+        Assert.Equal("pnpm --dir apps/web/aspire-apphost run aspire:start", scripts["aspire:start"]?.GetValue<string>());
+        Assert.Equal("pnpm --dir apps/web/aspire-apphost run aspire:build", scripts["aspire:build"]?.GetValue<string>());
+        Assert.Equal("pnpm --dir apps/web/aspire-apphost run aspire:dev", scripts["aspire:dev"]?.GetValue<string>());
+    }
+
+    [Fact]
+    public void AddRootTypeScriptAppHostDelegateScripts_PreservesExistingAspireScripts()
+    {
+        var scripts = JsonNode.Parse("""
+            {
+              "aspire:start": "custom-start",
+              "aspire:build": "npm --prefix aspire-apphost run aspire:build"
+            }
+            """)!.AsObject();
+
+        var preservedScriptNames = ScaffoldingService.AddRootTypeScriptAppHostDelegateScripts(
+            scripts,
+            TypeScriptAppHostToolchain.Npm,
+            "aspire-apphost");
+
+        Assert.Equal(["aspire:start"], preservedScriptNames);
+        Assert.Equal("custom-start", scripts["aspire:start"]?.GetValue<string>());
+        Assert.Equal("npm --prefix aspire-apphost run aspire:build", scripts["aspire:build"]?.GetValue<string>());
+        Assert.Equal("npm --prefix aspire-apphost run aspire:dev", scripts["aspire:dev"]?.GetValue<string>());
+    }
+
+    [Fact]
     public void GetScaffoldedAppHostRelativePath_UsesActualScaffoldedFile_WhenDefaultFileNameDiffers()
     {
         var rootDirectory = Directory.CreateTempSubdirectory();


### PR DESCRIPTION
## Description

TypeScript brownfield AppHosts need to work in realistic workspace layouts without taking over scripts that users already own. This change preserves existing root `aspire:*` scripts during TypeScript brownfield init, adds missing AppHost delegate scripts only when safe, and warns when a delegate script was intentionally left untouched.

It also locks down the package-manager boundary for TypeScript AppHosts: AppHost package-manager markers take precedence inside the AppHost package, while guest apps can keep their own package manager and lockfile. The new coverage exercises workspace-subdirectory brownfield init, script preservation, and mixed AppHost/guest package-manager scenarios.

### User-facing usage

In a brownfield TypeScript app under a workspace subdirectory, users can run:

```bash
aspire init --language typescript --non-interactive
```

The generated AppHost stays under `aspire-apphost`, existing app scripts such as `dev`, `build`, `preview`, and existing `aspire:start` values are preserved, and missing root delegates such as `aspire:build` and `aspire:dev` are added to call the nested AppHost package.

Fixes: #17036

Validation:
- `./restore.sh`
- `git diff --check`
- `dotnet test --project tests/Aspire.Cli.Tests/Aspire.Cli.Tests.csproj --no-launch-profile -- --filter-class "*.ScaffoldingServiceTests" --filter-class "*.PackageJsonMergerTests" --filter-class "*.TypeScriptAppHostToolchainResolverTests" --filter-not-trait "quarantined=true" --filter-not-trait "outerloop=true"`
- Targeted TypeScript E2E tests were attempted locally, but this environment installed GA CLI `13.3.5` instead of the workspace build and failed on older `apphost.ts` output before exercising this branch.

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No