### PR TITLE
Bump Microsoft.AI.Foundry.Local 0.3.0 -> 1.1.0 (needs API migration)

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -108,7 +108,7 @@
     <PackageVersion Include="KubernetesClient" Version="19.0.2" />
     <PackageVersion Include="JsonPatch.Net" Version="3.3.0" />
     <PackageVersion Include="Markdig" Version="1.2.0" />
-    <PackageVersion Include="Microsoft.AI.Foundry.Local" Version="0.3.0" />
+    <PackageVersion Include="Microsoft.AI.Foundry.Local" Version="1.1.0" />
     <PackageVersion Include="Microsoft.Agents.AI.OpenAI" Version="1.5.0" />
     <PackageVersion Include="Microsoft.Data.SqlClient" Version="7.0.1" />
     <PackageVersion Include="Microsoft.FluentUI.AspNetCore.Components" Version="4.14.1" />


### PR DESCRIPTION
> [!NOTE]
> **Draft — does not build.** Posting this PR to coordinate the migration work. Splitting it out of #17056 so the rest of the deferred dep bumps can land.

## What's here

A single one-line bump in `Directory.Packages.props`:

```diff
- <PackageVersion Include="Microsoft.AI.Foundry.Local" Version="0.3.0" />
+ <PackageVersion Include="Microsoft.AI.Foundry.Local" Version="1.1.0" />
```

## Why this needs a focused PR

`Microsoft.AI.Foundry.Local 1.1.0` is a **complete API redesign**, not an additive release. The whole `FoundryLocalManager` pattern changes:

| Old (0.3.0) | New (1.1.0) |
|---|---|
| Injected instance (`FoundryLocalManager` via DI) | Static singleton (`FoundryLocalManager.Instance`, `CreateAsync`) |
| `manager.IsServiceRunning` (sync property) | (new health pattern, TBD) |
| `manager.StartServiceAsync(ct)` | `StartWebServiceAsync` with `Urls` property |
| `manager.Endpoint` (property) | `Urls[0]` (after web service start) |
| `manager.ApiKey` | (unclear in new API) |
| `manager.ListLoadedModelsAsync(ct)` | navigate via `GetCatalogAsync()` → `Catalog.GetModelAsync()` |
| `manager.DownloadModelWithProgressAsync(model, ct)` | `model.DownloadAsync()` |
| `manager.LoadModelAsync(modelId, ct)` | `model.LoadAsync()` |

## Files that need migrating

- `src/Aspire.Hosting.Foundry/FoundryLocalHealthCheck.cs` — `manager.IsServiceRunning`
- `src/Aspire.Hosting.Foundry/LocalModelHealthCheck.cs` — `manager.ListLoadedModelsAsync`
- `src/Aspire.Hosting.Foundry/FoundryExtensions.cs` — `ApiKey`, `StartServiceAsync`, `Endpoint`, `DownloadModelWithProgressAsync`, `LoadModelAsync` (8 call sites)
- DI registration in `AddFoundryLocal` will likely change (singleton vs scoped, no longer registering the manager as a service)
- Lifecycle/disposal — `FoundryLocalManager` is now `IDisposable` with explicit `CreateAsync`/`Dispose` and singleton ownership

## Why I'm not just doing it

The migration is large enough to deserve product judgement (DI shape, lifecycle, behavior in the AppHost) rather than a mechanical port. Tagging @tommasodotNET and @sebastienros — you've been closest to the Foundry hosting code recently; can you take a look at how you'd like to adapt this?

The latest SDK README is helpful here: https://www.nuget.org/packages/Microsoft.AI.Foundry.Local/1.1.0

## Related

- #17056 — the parent dep-bump PR; this bump was deferred from there so the rest can ship.
