### PR TITLE
Bump StreamJsonRpc 2.22.23 -> 2.24.92 (needs Roslyn 4.14 analyzer workaround)

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -133,7 +133,7 @@
     <PackageVersion Include="StackExchange.Redis" Version="2.13.1" />
     <PackageVersion Include="System.IO.Hashing" Version="10.0.8" />
     <PackageVersion Include="Yarp.ReverseProxy" Version="2.3.0" />
-    <PackageVersion Include="StreamJsonRpc" Version="2.22.23" />
+    <PackageVersion Include="StreamJsonRpc" Version="2.24.92" />
     <PackageVersion Include="Semver" Version="3.0.0" />
     <PackageVersion Include="Sigstore" Version="0.5.0" />
     <PackageVersion Include="Tuf" Version="0.5.0" />


### PR DESCRIPTION
> [!NOTE]
> **Draft — will fail Templates CI.** Posting this PR to coordinate the migration. Splitting it out of #17056 so the rest of the deferred dep bumps can land.

## What's here

A single one-line bump in `Directory.Packages.props`:

```diff
- <PackageVersion Include="StreamJsonRpc" Version="2.22.23" />
+ <PackageVersion Include="StreamJsonRpc" Version="2.24.92" />
```

## Why this needs a focused PR

`StreamJsonRpc 2.24.x` ships a Roslyn analyzer assembly (`StreamJsonRpc.Analyzers.dll`) compiled against **Roslyn 4.14.0**. The Templates tests build generated AppHost projects using the **.NET 8 SDK** (Roslyn 4.11.0). When the .NET 8 csc loads the StreamJsonRpc analyzer it fails with:

```
CSC : error CS9057: The analyzer assembly '.../streamjsonrpc/2.24.92/analyzers/cs/StreamJsonRpc.Analyzers.dll'
references version '4.14.0.0' of the compiler, which is newer than the currently running version '4.11.0.0'.
```

All 16 Templates CI jobs fail with this error.

## Options to investigate

1. **Suppress the analyzer in generated AppHost templates** — add `<PackageReference ... ExcludeAssets="analyzers" />` (or equivalent) to the templated project so the analyzer never loads under the legacy .NET 8 csc. This keeps the runtime/library bump but skips the build-time analyzer where the SDK is too old.
2. **Wait for a StreamJsonRpc release that downgrades or splits the analyzer** — unlikely in the short term; the analyzer is intentionally targeting newer Roslyn.
3. **Stop building templated apps with the .NET 8 SDK** — would require revisiting the Templates test matrix; significant scope.
4. **Pin a version of StreamJsonRpc that pre-dates the 4.14 analyzer requirement** — possibly 2.24.0-2.24.83 if any exist; the analyzer was introduced somewhere in the 2.24.x line.

Tagging @karolz-ms, @danegsta, @davidfowl — you've been closest to the DCP/StreamJsonRpc integration; could you pick the right path? Happy to do the implementation once we've agreed.

## Related

- #17056 — the parent dep-bump PR; this bump was deferred from there so the rest can ship.
- #17514 — sibling deferred bump (Microsoft.AI.Foundry.Local).

## Affected CI jobs (all Templates)

- Templates-MSTest_NewUpAndBuildSupportProjectTemplatesTests (ubuntu, windows)
- Templates-NUnit_NewUpAndBuildSupportProjectTemplatesTests (ubuntu, windows)
- Templates-NewUpAndBuildStandaloneTemplateTests (ubuntu, windows)
- Templates-XUnit_Default_NewUpAndBuildSupportProjectTemplatesTests (ubuntu, windows)
- Templates-XUnit_NewUpAndBuildSupportProjectTemplatesTests (ubuntu, windows)
- Templates-XUnit_V2_NewUpAndBuildSupportProjectTemplatesTests (ubuntu, windows)
- Templates-XUnit_V3MTP_NewUpAndBuildSupportProjectTemplatesTests (ubuntu, windows)
- Templates-XUnit_V3_NewUpAndBuildSupportProjectTemplatesTests (ubuntu, windows)
