### PR TITLE
fix(acquisition): use GitHub releases for stable CLI versions

### DIFF
--- a/eng/scripts/get-aspire-cli.ps1
+++ b/eng/scripts/get-aspire-cli.ps1
@@ -56,6 +56,7 @@ $Script:Config = @{
         "release" = "https://aka.ms/dotnet/9/aspire/ga/daily"
         "versioned" = "https://ci.dot.net/public/aspire"
         "versioned-checksums" = "https://ci.dot.net/public-checksums/aspire"
+        "github-releases" = "https://github.com/microsoft/aspire/releases/download"
     }
 }
 
@@ -1039,6 +1040,32 @@ function Get-AspireExtensionUrl {
     }
 }
 
+function Test-StableVersion {
+    [CmdletBinding()]
+    [OutputType([bool])]
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$Version
+    )
+
+    return $Version -match '^v?\d+\.\d+\.\d+$'
+}
+
+function ConvertTo-StableVersion {
+    [CmdletBinding()]
+    [OutputType([string])]
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$Version
+    )
+
+    if ($Version.StartsWith('v', [System.StringComparison]::OrdinalIgnoreCase)) {
+        return $Version.Substring(1)
+    }
+
+    return $Version
+}
+
 # Enhanced URL construction function with configuration-based URLs
 function Get-AspireCliUrl {
     [CmdletBinding()]
@@ -1080,7 +1107,20 @@ function Get-AspireCliUrl {
         }
     }
     else {
-        # When version is set, use ci.dot.net URL
+        if (Test-StableVersion -Version $Version) {
+            $stableVersion = ConvertTo-StableVersion -Version $Version
+            $archiveFilename = "aspire-cli-$RuntimeIdentifier-$stableVersion.$Extension"
+            $checksumFilename = "$archiveFilename.sha512"
+            $baseUrl = $Script:Config.BaseUrls["github-releases"]
+
+            return [PSCustomObject]@{
+                ArchiveUrl = "$baseUrl/v$stableVersion/$archiveFilename"
+                ArchiveFilename = $archiveFilename
+                ChecksumUrl = "$baseUrl/v$stableVersion/$checksumFilename"
+                ChecksumFilename = $checksumFilename
+            }
+        }
+
         $archiveFilename = "aspire-cli-$RuntimeIdentifier-$Version.$Extension"
         $checksumFilename = "$archiveFilename.sha512"
 

--- a/eng/scripts/get-aspire-cli.sh
+++ b/eng/scripts/get-aspire-cli.sh
@@ -323,7 +323,10 @@ validate_content_type() {
         #
         #   HTTP/2 200
         #   content-type: application/octet-stream
-        # GitHub release assets use this shape, so only validate the final response.
+        # GitHub documents release asset downloads as either 200 OK or 302 Found.
+        # The 302 is an HTML redirect page, but the final 200 response is the
+        # archive/checksum, so validate only that block.
+        # See: https://docs.github.com/rest/releases/assets#get-a-release-asset
         local final_headers
         final_headers=$(printf "%s\n" "$headers" | awk '
             /^HTTP(\/| )[0-9]/ {

--- a/eng/scripts/get-aspire-cli.sh
+++ b/eng/scripts/get-aspire-cli.sh
@@ -317,8 +317,28 @@ validate_content_type() {
     # Get headers via HEAD request
     local headers
     if headers=$(secure_curl "$url" /dev/null 60 "$USER_AGENT" 3 "HEAD" 2>&1); then
+        # curl --location --head returns a header block for each redirect, for example:
+        #   HTTP/2 302
+        #   content-type: text/html; charset=utf-8
+        #
+        #   HTTP/2 200
+        #   content-type: application/octet-stream
+        # GitHub release assets use this shape, so only validate the final response.
+        local final_headers
+        final_headers=$(printf "%s\n" "$headers" | awk '
+            /^HTTP(\/| )[0-9]/ {
+                block = $0 "\n"
+                next
+            }
+            {
+                block = block $0 "\n"
+            }
+            END {
+                printf "%s", block
+            }')
+
         # Check if response suggests HTML content (error page)
-        if echo "$headers" | grep -qi "content-type:.*text/html"; then
+        if echo "$final_headers" | grep -qi "content-type:.*text/html"; then
             say_error "Server returned HTML content instead of expected file. Make sure the URL is correct: $url"
             return 1
         fi
@@ -734,6 +754,18 @@ construct_aspire_extension_url() {
     fi
 }
 
+is_stable_version() {
+    local version="$1"
+
+    [[ "$version" =~ ^[vV]?[0-9]+\.[0-9]+\.[0-9]+$ ]]
+}
+
+normalize_stable_version() {
+    local version="$1"
+
+    printf "%s" "${version#[vV]}"
+}
+
 # Function to construct the base URL for the Aspire CLI download
 construct_aspire_cli_url() {
     local version="$1"
@@ -769,7 +801,13 @@ construct_aspire_cli_url() {
 
         printf "${base_url}/aspire-cli-${rid}.${extension}"
     else
-        # When version is set, use ci.dot.net URL
+        if is_stable_version "$version"; then
+            local normalized_version
+            normalized_version=$(normalize_stable_version "$version")
+            base_url="https://github.com/microsoft/aspire/releases/download/v${normalized_version}"
+            printf "${base_url}/aspire-cli-${rid}-${normalized_version}.${extension}"
+            return 0
+        fi
 
         if [[ "$checksum" == "true" ]]; then
             # For checksum URLs, use the public-checksums URL

--- a/eng/scripts/get-aspire-cli.sh
+++ b/eng/scripts/get-aspire-cli.sh
@@ -816,7 +816,7 @@ construct_aspire_cli_url() {
             # For checksum URLs, use the public-checksums URL
             base_url="https://ci.dot.net/public-checksums/aspire"
         else
-            base_url="https://ci.dot.net/public/aspire/"
+            base_url="https://ci.dot.net/public/aspire"
         fi
 
         printf "${base_url}/${version}/aspire-cli-${rid}-${version}.${extension}"

--- a/tests/Aspire.Acquisition.Tests/Scripts/ReleaseScriptFunctionTests.cs
+++ b/tests/Aspire.Acquisition.Tests/Scripts/ReleaseScriptFunctionTests.cs
@@ -137,11 +137,13 @@ public class ReleaseScriptFunctionTests(ITestOutputHelper testOutput)
         Assert.Equal(expectedUrl, result.Output.Trim());
     }
 
-    [Fact]
-    public async Task ConstructAspireCliUrl_WithPrereleaseVersion_ReturnsCiDotNetUrl()
+    [Theory]
+    [InlineData("13.3.0-dev")]
+    [InlineData("13.3.0-preview.1.25366.3")]
+    [InlineData("13.3.0-local")]
+    public async Task ConstructAspireCliUrl_WithPrereleaseVersion_ReturnsCiDotNetUrl(string version)
     {
         using var env = new TestEnvironment();
-        var version = "13.2.0-preview.1.25366.3";
         using var cmd = new ScriptFunctionCommand(
             s_releaseScript,
             $"construct_aspire_cli_url '{version}' 'release' 'linux-x64' 'tar.gz'",
@@ -157,11 +159,13 @@ public class ReleaseScriptFunctionTests(ITestOutputHelper testOutput)
         Assert.Contains("linux-x64", url);
     }
 
-    [Fact]
-    public async Task ConstructAspireCliUrl_WithPrereleaseVersionAndChecksum_ReturnsCiDotNetChecksumUrl()
+    [Theory]
+    [InlineData("13.3.0-dev")]
+    [InlineData("13.3.0-preview.1.25366.3")]
+    [InlineData("13.3.0-local")]
+    public async Task ConstructAspireCliUrl_WithPrereleaseVersionAndChecksum_ReturnsCiDotNetChecksumUrl(string version)
     {
         using var env = new TestEnvironment();
-        var version = "13.2.0-preview.1.25366.3";
         using var cmd = new ScriptFunctionCommand(
             s_releaseScript,
             $"construct_aspire_cli_url '{version}' 'release' 'linux-x64' 'tar.gz' 'true'",

--- a/tests/Aspire.Acquisition.Tests/Scripts/ReleaseScriptFunctionTests.cs
+++ b/tests/Aspire.Acquisition.Tests/Scripts/ReleaseScriptFunctionTests.cs
@@ -153,10 +153,7 @@ public class ReleaseScriptFunctionTests(ITestOutputHelper testOutput)
         var result = await cmd.ExecuteAsync();
 
         result.EnsureSuccessful();
-        var url = result.Output.Trim();
-        Assert.Contains("ci.dot.net/public/aspire", url);
-        Assert.Contains(version, url);
-        Assert.Contains("linux-x64", url);
+        Assert.Equal($"https://ci.dot.net/public/aspire/{version}/aspire-cli-linux-x64-{version}.tar.gz", result.Output.Trim());
     }
 
     [Theory]

--- a/tests/Aspire.Acquisition.Tests/Scripts/ReleaseScriptFunctionTests.cs
+++ b/tests/Aspire.Acquisition.Tests/Scripts/ReleaseScriptFunctionTests.cs
@@ -99,8 +99,46 @@ public class ReleaseScriptFunctionTests(ITestOutputHelper testOutput)
         Assert.Equal(expectedUrl, result.Output.Trim());
     }
 
+    [Theory]
+    [InlineData("13.3.5", "linux-x64", "tar.gz", "https://github.com/microsoft/aspire/releases/download/v13.3.5/aspire-cli-linux-x64-13.3.5.tar.gz")]
+    [InlineData("v13.3.5", "win-x64", "zip", "https://github.com/microsoft/aspire/releases/download/v13.3.5/aspire-cli-win-x64-13.3.5.zip")]
+    public async Task ConstructAspireCliUrl_WithStableVersion_ReturnsGitHubReleaseUrl(
+        string version, string rid, string ext, string expectedUrl)
+    {
+        using var env = new TestEnvironment();
+        using var cmd = new ScriptFunctionCommand(
+            s_releaseScript,
+            $"construct_aspire_cli_url '{version}' 'release' '{rid}' '{ext}'",
+            env,
+            _testOutput);
+
+        var result = await cmd.ExecuteAsync();
+
+        result.EnsureSuccessful();
+        Assert.Equal(expectedUrl, result.Output.Trim());
+    }
+
+    [Theory]
+    [InlineData("13.3.5", "linux-x64", "tar.gz", "https://github.com/microsoft/aspire/releases/download/v13.3.5/aspire-cli-linux-x64-13.3.5.tar.gz.sha512")]
+    [InlineData("v13.3.5", "win-x64", "zip", "https://github.com/microsoft/aspire/releases/download/v13.3.5/aspire-cli-win-x64-13.3.5.zip.sha512")]
+    public async Task ConstructAspireCliUrl_WithStableVersionAndChecksum_ReturnsGitHubReleaseChecksumUrl(
+        string version, string rid, string ext, string expectedUrl)
+    {
+        using var env = new TestEnvironment();
+        using var cmd = new ScriptFunctionCommand(
+            s_releaseScript,
+            $"construct_aspire_cli_url '{version}' 'release' '{rid}' '{ext}' 'true'",
+            env,
+            _testOutput);
+
+        var result = await cmd.ExecuteAsync();
+
+        result.EnsureSuccessful();
+        Assert.Equal(expectedUrl, result.Output.Trim());
+    }
+
     [Fact]
-    public async Task ConstructAspireCliUrl_WithVersion_ReturnsCiDotNetUrl()
+    public async Task ConstructAspireCliUrl_WithPrereleaseVersion_ReturnsCiDotNetUrl()
     {
         using var env = new TestEnvironment();
         var version = "13.2.0-preview.1.25366.3";
@@ -120,7 +158,7 @@ public class ReleaseScriptFunctionTests(ITestOutputHelper testOutput)
     }
 
     [Fact]
-    public async Task ConstructAspireCliUrl_WithVersionAndChecksum_ReturnsChecksumUrl()
+    public async Task ConstructAspireCliUrl_WithPrereleaseVersionAndChecksum_ReturnsCiDotNetChecksumUrl()
     {
         using var env = new TestEnvironment();
         var version = "13.2.0-preview.1.25366.3";
@@ -180,6 +218,36 @@ public class ReleaseScriptFunctionTests(ITestOutputHelper testOutput)
         Assert.DoesNotContain("dotnet", descriptor, StringComparison.OrdinalIgnoreCase);
         Assert.DoesNotContain("ga/daily", descriptor, StringComparison.OrdinalIgnoreCase);
         Assert.DoesNotContain("rc/daily", descriptor, StringComparison.OrdinalIgnoreCase);
+    }
+
+    #endregion
+
+    #region validate_content_type
+
+    [Fact]
+    public async Task ValidateContentType_GitHubReleaseRedirectWithHtmlIntermediateResponse_Succeeds()
+    {
+        using var env = new TestEnvironment();
+        using var cmd = new ScriptFunctionCommand(
+            s_releaseScript,
+            """
+            secure_curl() {
+                cat <<'HEADERS'
+            HTTP/2 302
+            content-type: text/html; charset=utf-8
+
+            HTTP/2 200
+            content-type: application/octet-stream
+            HEADERS
+            }
+            validate_content_type 'https://github.com/microsoft/aspire/releases/download/v13.3.5/aspire-cli-linux-x64-13.3.5.tar.gz'
+            """,
+            env,
+            _testOutput);
+
+        var result = await cmd.ExecuteAsync();
+
+        result.EnsureSuccessful();
     }
 
     #endregion

--- a/tests/Aspire.Acquisition.Tests/Scripts/ReleaseScriptPSFunctionTests.cs
+++ b/tests/Aspire.Acquisition.Tests/Scripts/ReleaseScriptPSFunctionTests.cs
@@ -137,11 +137,13 @@ public class ReleaseScriptPSFunctionTests(ITestOutputHelper testOutput)
         Assert.Equal(expectedUrl, result.Output.Trim());
     }
 
-    [Fact]
-    public async Task GetAspireCliUrl_WithPrereleaseVersion_ReturnsCiDotNetUrl()
+    [Theory]
+    [InlineData("13.3.0-dev")]
+    [InlineData("13.3.0-preview.1.25366.3")]
+    [InlineData("13.3.0-local")]
+    public async Task GetAspireCliUrl_WithPrereleaseVersion_ReturnsCiDotNetUrl(string version)
     {
         using var env = new TestEnvironment();
-        var version = "13.2.0-preview.1.25366.3";
         using var cmd = new ScriptFunctionCommand(
             s_releaseScript,
             $"(Get-AspireCliUrl -Version '{version}' -Quality 'release' -RuntimeIdentifier 'linux-x64' -Extension 'tar.gz').ArchiveUrl",
@@ -154,11 +156,13 @@ public class ReleaseScriptPSFunctionTests(ITestOutputHelper testOutput)
         Assert.Equal($"https://ci.dot.net/public/aspire/{version}/aspire-cli-linux-x64-{version}.tar.gz", result.Output.Trim());
     }
 
-    [Fact]
-    public async Task GetAspireCliUrl_WithPrereleaseVersionChecksum_ReturnsCiDotNetChecksumUrl()
+    [Theory]
+    [InlineData("13.3.0-dev")]
+    [InlineData("13.3.0-preview.1.25366.3")]
+    [InlineData("13.3.0-local")]
+    public async Task GetAspireCliUrl_WithPrereleaseVersionChecksum_ReturnsCiDotNetChecksumUrl(string version)
     {
         using var env = new TestEnvironment();
-        var version = "13.2.0-preview.1.25366.3";
         using var cmd = new ScriptFunctionCommand(
             s_releaseScript,
             $"(Get-AspireCliUrl -Version '{version}' -Quality 'release' -RuntimeIdentifier 'linux-x64' -Extension 'tar.gz').ChecksumUrl",

--- a/tests/Aspire.Acquisition.Tests/Scripts/ReleaseScriptPSFunctionTests.cs
+++ b/tests/Aspire.Acquisition.Tests/Scripts/ReleaseScriptPSFunctionTests.cs
@@ -99,8 +99,46 @@ public class ReleaseScriptPSFunctionTests(ITestOutputHelper testOutput)
         Assert.Equal(expectedUrl, result.Output.Trim());
     }
 
+    [Theory]
+    [InlineData("13.3.5", "linux-x64", "tar.gz", "https://github.com/microsoft/aspire/releases/download/v13.3.5/aspire-cli-linux-x64-13.3.5.tar.gz")]
+    [InlineData("v13.3.5", "win-x64", "zip", "https://github.com/microsoft/aspire/releases/download/v13.3.5/aspire-cli-win-x64-13.3.5.zip")]
+    public async Task GetAspireCliUrl_WithStableVersion_ReturnsGitHubReleaseUrl(
+        string version, string rid, string ext, string expectedUrl)
+    {
+        using var env = new TestEnvironment();
+        using var cmd = new ScriptFunctionCommand(
+            s_releaseScript,
+            $"(Get-AspireCliUrl -Version '{version}' -Quality 'release' -RuntimeIdentifier '{rid}' -Extension '{ext}').ArchiveUrl",
+            env,
+            _testOutput);
+
+        var result = await cmd.ExecuteAsync();
+
+        result.EnsureSuccessful();
+        Assert.Equal(expectedUrl, result.Output.Trim());
+    }
+
+    [Theory]
+    [InlineData("13.3.5", "linux-x64", "tar.gz", "https://github.com/microsoft/aspire/releases/download/v13.3.5/aspire-cli-linux-x64-13.3.5.tar.gz.sha512")]
+    [InlineData("v13.3.5", "win-x64", "zip", "https://github.com/microsoft/aspire/releases/download/v13.3.5/aspire-cli-win-x64-13.3.5.zip.sha512")]
+    public async Task GetAspireCliUrl_WithStableVersionChecksum_ReturnsGitHubReleaseChecksumUrl(
+        string version, string rid, string ext, string expectedUrl)
+    {
+        using var env = new TestEnvironment();
+        using var cmd = new ScriptFunctionCommand(
+            s_releaseScript,
+            $"(Get-AspireCliUrl -Version '{version}' -Quality 'release' -RuntimeIdentifier '{rid}' -Extension '{ext}').ChecksumUrl",
+            env,
+            _testOutput);
+
+        var result = await cmd.ExecuteAsync();
+
+        result.EnsureSuccessful();
+        Assert.Equal(expectedUrl, result.Output.Trim());
+    }
+
     [Fact]
-    public async Task GetAspireCliUrl_WithVersion_ReturnsCiDotNetUrl()
+    public async Task GetAspireCliUrl_WithPrereleaseVersion_ReturnsCiDotNetUrl()
     {
         using var env = new TestEnvironment();
         var version = "13.2.0-preview.1.25366.3";
@@ -113,14 +151,11 @@ public class ReleaseScriptPSFunctionTests(ITestOutputHelper testOutput)
         var result = await cmd.ExecuteAsync();
 
         result.EnsureSuccessful();
-        var url = result.Output.Trim();
-        Assert.Contains("ci.dot.net/public/aspire", url);
-        Assert.Contains(version, url);
-        Assert.Contains("linux-x64", url);
+        Assert.Equal($"https://ci.dot.net/public/aspire/{version}/aspire-cli-linux-x64-{version}.tar.gz", result.Output.Trim());
     }
 
     [Fact]
-    public async Task GetAspireCliUrl_WithVersionChecksum_ReturnsChecksumUrl()
+    public async Task GetAspireCliUrl_WithPrereleaseVersionChecksum_ReturnsCiDotNetChecksumUrl()
     {
         using var env = new TestEnvironment();
         var version = "13.2.0-preview.1.25366.3";
@@ -133,10 +168,7 @@ public class ReleaseScriptPSFunctionTests(ITestOutputHelper testOutput)
         var result = await cmd.ExecuteAsync();
 
         result.EnsureSuccessful();
-        var url = result.Output.Trim();
-        Assert.Contains("ci.dot.net/public-checksums/aspire", url);
-        Assert.Contains(version, url);
-        Assert.EndsWith(".sha512", url);
+        Assert.Equal($"https://ci.dot.net/public-checksums/aspire/{version}/aspire-cli-linux-x64-{version}.tar.gz.sha512", result.Output.Trim());
     }
 
     [Fact]


### PR DESCRIPTION
## Description

Stable exact-version installs through `get-aspire-cli` failed because the scripts routed every `--version` value through `ci.dot.net`, where stable short-version directories are not available:

```text
https://ci.dot.net/public/aspire/13.1.0/aspire-cli-linux-x64-13.1.0.tar.gz -> 404
```

The script path treated stable releases and prerelease/dev builds the same. Stable CLI release assets are published on GitHub under `v{version}` tags, while suffixed versions such as `13.3.0-dev`, `13.3.0-preview...`, and `13.3.0-local` still need the existing `ci.dot.net` layout.

This updates the bash and PowerShell release scripts to detect plain stable semver versions, normalize an optional `v` prefix, and download the CLI archive/checksum from GitHub release assets. Prerelease and other suffixed versions continue using `ci.dot.net`.

GitHub release asset downloads can return an intermediate `302` before the final archive response, so the bash pre-download content-type check now validates only the final `curl --location --head` response block instead of rejecting the redirect page as HTML.

Fixes #15937

## Checklist

- [x] Tests added/updated
- [ ] Docs added/updated
