### PR TITLE
Improve agent init skill install output

### DIFF
--- a/src/Aspire.Cli/Commands/AgentInitCommand.cs
+++ b/src/Aspire.Cli/Commands/AgentInitCommand.cs
@@ -311,6 +311,8 @@ internal sealed class AgentInitCommand : BaseCommand, IPackageMetaPrefetchingCom
             }
         }
 
+        var installedSkills = new List<InstalledSkillSummaryItem>();
+
         foreach (var location in selectedLocations)
         {
             context.AddSkillBaseDirectory(location.RelativeSkillDirectory);
@@ -328,26 +330,38 @@ internal sealed class AgentInitCommand : BaseCommand, IPackageMetaPrefetchingCom
                     continue;
                 }
 
-                hasErrors |= !await InstallSkillAsync(
+                var installResult = await InstallSkillAsync(
                     workspaceRoot,
                     location.RelativeSkillDirectory,
                     skill,
                     aspireSkillsBundle,
                     isUserLevel: false,
                     cancellationToken);
+                hasErrors |= !installResult.Succeeded;
+                if (installResult.UpdatedSkill is not null)
+                {
+                    installedSkills.Add(installResult.UpdatedSkill);
+                }
 
                 if (location.IncludeUserLevel)
                 {
-                    hasErrors |= !await InstallSkillAsync(
+                    installResult = await InstallSkillAsync(
                         ExecutionContext.HomeDirectory,
                         location.RelativeSkillDirectory,
                         skill,
                         aspireSkillsBundle,
                         isUserLevel: true,
                         cancellationToken);
+                    hasErrors |= !installResult.Succeeded;
+                    if (installResult.UpdatedSkill is not null)
+                    {
+                        installedSkills.Add(installResult.UpdatedSkill);
+                    }
                 }
             }
         }
+
+        DisplayInstalledSkillsSummary(installedSkills);
 
         // --- Phase 4: Handle Playwright CLI (installs binary + mirrors skill files to registered directories) ---
         var selectedSkillDirs = selectedLocations.Select(l => l.RelativeSkillDirectory).ToHashSet(StringComparer.OrdinalIgnoreCase);
@@ -424,8 +438,8 @@ internal sealed class AgentInitCommand : BaseCommand, IPackageMetaPrefetchingCom
     /// <summary>
     /// Installs the files for a skill at the specified location, creating or updating them as needed.
     /// </summary>
-    /// <returns><c>true</c> if successful, <c>false</c> if an error occurred.</returns>
-    private async Task<bool> InstallSkillAsync(
+    /// <returns>The install result, including the skill/location pair when files were updated.</returns>
+    private async Task<SkillInstallResult> InstallSkillAsync(
         DirectoryInfo rootDirectory,
         string relativeSkillDirectory,
         SkillDefinition skill,
@@ -465,23 +479,60 @@ internal sealed class AgentInitCommand : BaseCommand, IPackageMetaPrefetchingCom
 
             if (!anyFileUpdated)
             {
-                return true;
+                return new(Succeeded: true, UpdatedSkill: null);
             }
 
-            var displayRelativeSkillPath = relativeSkillPath
-                .Replace(Path.DirectorySeparatorChar, '/')
-                .Replace(Path.AltDirectorySeparatorChar, '/');
-            var displayPath = isUserLevel ? $"~/{displayRelativeSkillPath}" : displayRelativeSkillPath;
-            _interactionService.DisplayMessage(KnownEmojis.Robot,
-                string.Format(CultureInfo.CurrentCulture, AgentCommandStrings.InitCommand_InstalledSkill, skill.Name, displayPath));
-            return true;
+            var displayLocation = GetDisplaySkillDirectory(relativeSkillDirectory, isUserLevel);
+            return new(Succeeded: true, new InstalledSkillSummaryItem(skill.Name, displayLocation));
         }
         catch (Exception ex) when (ex is IOException or UnauthorizedAccessException or InvalidOperationException)
         {
             _interactionService.DisplayError(
                 string.Format(CultureInfo.CurrentCulture, AgentCommandStrings.InitCommand_FailedToInstallSkill, skill.Name, fullSkillDirectoryPath, ex.Message));
-            return false;
+            return new(Succeeded: false, UpdatedSkill: null);
         }
+    }
+
+    private void DisplayInstalledSkillsSummary(IReadOnlyList<InstalledSkillSummaryItem> installedSkills)
+    {
+        if (installedSkills.Count == 0)
+        {
+            return;
+        }
+
+        var skillNames = string.Join(", ", GetUniqueValues(installedSkills.Select(static installedSkill => installedSkill.SkillName)));
+        var locations = string.Join(", ", GetUniqueValues(installedSkills.Select(static installedSkill => installedSkill.DisplayLocation)));
+        var message = string.Join(Environment.NewLine,
+            AgentCommandStrings.InitCommand_InstalledSkillsSummary,
+            $"  {string.Format(CultureInfo.CurrentCulture, AgentCommandStrings.InitCommand_InstalledSkillsSummarySkills, skillNames)}",
+            $"  {string.Format(CultureInfo.CurrentCulture, AgentCommandStrings.InitCommand_InstalledSkillsSummaryLocations, locations)}");
+
+        _interactionService.DisplayMessage(KnownEmojis.Robot, message);
+    }
+
+    private static IReadOnlyList<string> GetUniqueValues(IEnumerable<string> values)
+    {
+        var uniqueValues = new List<string>();
+        var seenValues = new HashSet<string>(StringComparer.Ordinal);
+
+        foreach (var value in values)
+        {
+            if (seenValues.Add(value))
+            {
+                uniqueValues.Add(value);
+            }
+        }
+
+        return uniqueValues;
+    }
+
+    private static string GetDisplaySkillDirectory(string relativeSkillDirectory, bool isUserLevel)
+    {
+        var displayRelativeSkillDirectory = relativeSkillDirectory
+            .Replace(Path.DirectorySeparatorChar, '/')
+            .Replace(Path.AltDirectorySeparatorChar, '/');
+
+        return isUserLevel ? $"~/{displayRelativeSkillDirectory}" : displayRelativeSkillDirectory;
     }
 
     private static async Task<IReadOnlyList<SkillAssetFile>> GetSkillFilesAsync(SkillDefinition skill, AspireSkillsBundle? aspireSkillsBundle, CancellationToken cancellationToken)
@@ -509,6 +560,10 @@ internal sealed class AgentInitCommand : BaseCommand, IPackageMetaPrefetchingCom
         Strict,
         BestEffort
     }
+
+    private sealed record InstalledSkillSummaryItem(string SkillName, string DisplayLocation);
+
+    private readonly record struct SkillInstallResult(bool Succeeded, InstalledSkillSummaryItem? UpdatedSkill);
 }
 
 internal readonly record struct AgentInitExecutionResult(

--- a/src/Aspire.Cli/Resources/AgentCommandStrings.Designer.cs
+++ b/src/Aspire.Cli/Resources/AgentCommandStrings.Designer.cs
@@ -205,11 +205,29 @@ namespace Aspire.Cli.Resources {
         }
 
         /// <summary>
-        ///   Looks up a localized string similar to Installed {0} skill ({1})..
+        ///   Looks up a localized string similar to Installed Aspire agent skills:.
         /// </summary>
-        internal static string InitCommand_InstalledSkill {
+        internal static string InitCommand_InstalledSkillsSummary {
             get {
-                return ResourceManager.GetString("InitCommand_InstalledSkill", resourceCulture);
+                return ResourceManager.GetString("InitCommand_InstalledSkillsSummary", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Skills: {0}.
+        /// </summary>
+        internal static string InitCommand_InstalledSkillsSummarySkills {
+            get {
+                return ResourceManager.GetString("InitCommand_InstalledSkillsSummarySkills", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Locations: {0}.
+        /// </summary>
+        internal static string InitCommand_InstalledSkillsSummaryLocations {
+            get {
+                return ResourceManager.GetString("InitCommand_InstalledSkillsSummaryLocations", resourceCulture);
             }
         }
 

--- a/src/Aspire.Cli/Resources/AgentCommandStrings.resx
+++ b/src/Aspire.Cli/Resources/AgentCommandStrings.resx
@@ -108,8 +108,14 @@
   <data name="InitCommand_PlaywrightCliSkipped" xml:space="preserve">
     <value>Playwright CLI requires npm, which was not found on PATH. Skipping installation.</value>
   </data>
-  <data name="InitCommand_InstalledSkill" xml:space="preserve">
-    <value>Installed {0} skill ({1}).</value>
+  <data name="InitCommand_InstalledSkillsSummary" xml:space="preserve">
+    <value>Installed Aspire agent skills:</value>
+  </data>
+  <data name="InitCommand_InstalledSkillsSummarySkills" xml:space="preserve">
+    <value>Skills: {0}</value>
+  </data>
+  <data name="InitCommand_InstalledSkillsSummaryLocations" xml:space="preserve">
+    <value>Locations: {0}</value>
   </data>
   <data name="InitCommand_FailedToInstallSkill" xml:space="preserve">
     <value>Failed to install {0} skill at {1}: {2}</value>

--- a/src/Aspire.Cli/Resources/xlf/AgentCommandStrings.cs.xlf
+++ b/src/Aspire.Cli/Resources/xlf/AgentCommandStrings.cs.xlf
@@ -57,9 +57,19 @@
         <target state="new">Installed Playwright CLI.</target>
         <note />
       </trans-unit>
-      <trans-unit id="InitCommand_InstalledSkill">
-        <source>Installed {0} skill ({1}).</source>
-        <target state="new">Installed {0} skill ({1}).</target>
+      <trans-unit id="InitCommand_InstalledSkillsSummary">
+        <source>Installed Aspire agent skills:</source>
+        <target state="new">Installed Aspire agent skills:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InitCommand_InstalledSkillsSummaryLocations">
+        <source>Locations: {0}</source>
+        <target state="new">Locations: {0}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InitCommand_InstalledSkillsSummarySkills">
+        <source>Skills: {0}</source>
+        <target state="new">Skills: {0}</target>
         <note />
       </trans-unit>
       <trans-unit id="InitCommand_PlaywrightCliSkipped">

--- a/src/Aspire.Cli/Resources/xlf/AgentCommandStrings.de.xlf
+++ b/src/Aspire.Cli/Resources/xlf/AgentCommandStrings.de.xlf
@@ -57,9 +57,19 @@
         <target state="new">Installed Playwright CLI.</target>
         <note />
       </trans-unit>
-      <trans-unit id="InitCommand_InstalledSkill">
-        <source>Installed {0} skill ({1}).</source>
-        <target state="new">Installed {0} skill ({1}).</target>
+      <trans-unit id="InitCommand_InstalledSkillsSummary">
+        <source>Installed Aspire agent skills:</source>
+        <target state="new">Installed Aspire agent skills:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InitCommand_InstalledSkillsSummaryLocations">
+        <source>Locations: {0}</source>
+        <target state="new">Locations: {0}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InitCommand_InstalledSkillsSummarySkills">
+        <source>Skills: {0}</source>
+        <target state="new">Skills: {0}</target>
         <note />
       </trans-unit>
       <trans-unit id="InitCommand_PlaywrightCliSkipped">

--- a/src/Aspire.Cli/Resources/xlf/AgentCommandStrings.es.xlf
+++ b/src/Aspire.Cli/Resources/xlf/AgentCommandStrings.es.xlf
@@ -57,9 +57,19 @@
         <target state="new">Installed Playwright CLI.</target>
         <note />
       </trans-unit>
-      <trans-unit id="InitCommand_InstalledSkill">
-        <source>Installed {0} skill ({1}).</source>
-        <target state="new">Installed {0} skill ({1}).</target>
+      <trans-unit id="InitCommand_InstalledSkillsSummary">
+        <source>Installed Aspire agent skills:</source>
+        <target state="new">Installed Aspire agent skills:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InitCommand_InstalledSkillsSummaryLocations">
+        <source>Locations: {0}</source>
+        <target state="new">Locations: {0}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InitCommand_InstalledSkillsSummarySkills">
+        <source>Skills: {0}</source>
+        <target state="new">Skills: {0}</target>
         <note />
       </trans-unit>
       <trans-unit id="InitCommand_PlaywrightCliSkipped">

--- a/src/Aspire.Cli/Resources/xlf/AgentCommandStrings.fr.xlf
+++ b/src/Aspire.Cli/Resources/xlf/AgentCommandStrings.fr.xlf
@@ -57,9 +57,19 @@
         <target state="new">Installed Playwright CLI.</target>
         <note />
       </trans-unit>
-      <trans-unit id="InitCommand_InstalledSkill">
-        <source>Installed {0} skill ({1}).</source>
-        <target state="new">Installed {0} skill ({1}).</target>
+      <trans-unit id="InitCommand_InstalledSkillsSummary">
+        <source>Installed Aspire agent skills:</source>
+        <target state="new">Installed Aspire agent skills:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InitCommand_InstalledSkillsSummaryLocations">
+        <source>Locations: {0}</source>
+        <target state="new">Locations: {0}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InitCommand_InstalledSkillsSummarySkills">
+        <source>Skills: {0}</source>
+        <target state="new">Skills: {0}</target>
         <note />
       </trans-unit>
       <trans-unit id="InitCommand_PlaywrightCliSkipped">

--- a/src/Aspire.Cli/Resources/xlf/AgentCommandStrings.it.xlf
+++ b/src/Aspire.Cli/Resources/xlf/AgentCommandStrings.it.xlf
@@ -57,9 +57,19 @@
         <target state="new">Installed Playwright CLI.</target>
         <note />
       </trans-unit>
-      <trans-unit id="InitCommand_InstalledSkill">
-        <source>Installed {0} skill ({1}).</source>
-        <target state="new">Installed {0} skill ({1}).</target>
+      <trans-unit id="InitCommand_InstalledSkillsSummary">
+        <source>Installed Aspire agent skills:</source>
+        <target state="new">Installed Aspire agent skills:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InitCommand_InstalledSkillsSummaryLocations">
+        <source>Locations: {0}</source>
+        <target state="new">Locations: {0}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InitCommand_InstalledSkillsSummarySkills">
+        <source>Skills: {0}</source>
+        <target state="new">Skills: {0}</target>
         <note />
       </trans-unit>
       <trans-unit id="InitCommand_PlaywrightCliSkipped">

--- a/src/Aspire.Cli/Resources/xlf/AgentCommandStrings.ja.xlf
+++ b/src/Aspire.Cli/Resources/xlf/AgentCommandStrings.ja.xlf
@@ -57,9 +57,19 @@
         <target state="new">Installed Playwright CLI.</target>
         <note />
       </trans-unit>
-      <trans-unit id="InitCommand_InstalledSkill">
-        <source>Installed {0} skill ({1}).</source>
-        <target state="new">Installed {0} skill ({1}).</target>
+      <trans-unit id="InitCommand_InstalledSkillsSummary">
+        <source>Installed Aspire agent skills:</source>
+        <target state="new">Installed Aspire agent skills:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InitCommand_InstalledSkillsSummaryLocations">
+        <source>Locations: {0}</source>
+        <target state="new">Locations: {0}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InitCommand_InstalledSkillsSummarySkills">
+        <source>Skills: {0}</source>
+        <target state="new">Skills: {0}</target>
         <note />
       </trans-unit>
       <trans-unit id="InitCommand_PlaywrightCliSkipped">

--- a/src/Aspire.Cli/Resources/xlf/AgentCommandStrings.ko.xlf
+++ b/src/Aspire.Cli/Resources/xlf/AgentCommandStrings.ko.xlf
@@ -57,9 +57,19 @@
         <target state="new">Installed Playwright CLI.</target>
         <note />
       </trans-unit>
-      <trans-unit id="InitCommand_InstalledSkill">
-        <source>Installed {0} skill ({1}).</source>
-        <target state="new">Installed {0} skill ({1}).</target>
+      <trans-unit id="InitCommand_InstalledSkillsSummary">
+        <source>Installed Aspire agent skills:</source>
+        <target state="new">Installed Aspire agent skills:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InitCommand_InstalledSkillsSummaryLocations">
+        <source>Locations: {0}</source>
+        <target state="new">Locations: {0}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InitCommand_InstalledSkillsSummarySkills">
+        <source>Skills: {0}</source>
+        <target state="new">Skills: {0}</target>
         <note />
       </trans-unit>
       <trans-unit id="InitCommand_PlaywrightCliSkipped">

--- a/src/Aspire.Cli/Resources/xlf/AgentCommandStrings.pl.xlf
+++ b/src/Aspire.Cli/Resources/xlf/AgentCommandStrings.pl.xlf
@@ -57,9 +57,19 @@
         <target state="new">Installed Playwright CLI.</target>
         <note />
       </trans-unit>
-      <trans-unit id="InitCommand_InstalledSkill">
-        <source>Installed {0} skill ({1}).</source>
-        <target state="new">Installed {0} skill ({1}).</target>
+      <trans-unit id="InitCommand_InstalledSkillsSummary">
+        <source>Installed Aspire agent skills:</source>
+        <target state="new">Installed Aspire agent skills:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InitCommand_InstalledSkillsSummaryLocations">
+        <source>Locations: {0}</source>
+        <target state="new">Locations: {0}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InitCommand_InstalledSkillsSummarySkills">
+        <source>Skills: {0}</source>
+        <target state="new">Skills: {0}</target>
         <note />
       </trans-unit>
       <trans-unit id="InitCommand_PlaywrightCliSkipped">

--- a/src/Aspire.Cli/Resources/xlf/AgentCommandStrings.pt-BR.xlf
+++ b/src/Aspire.Cli/Resources/xlf/AgentCommandStrings.pt-BR.xlf
@@ -57,9 +57,19 @@
         <target state="new">Installed Playwright CLI.</target>
         <note />
       </trans-unit>
-      <trans-unit id="InitCommand_InstalledSkill">
-        <source>Installed {0} skill ({1}).</source>
-        <target state="new">Installed {0} skill ({1}).</target>
+      <trans-unit id="InitCommand_InstalledSkillsSummary">
+        <source>Installed Aspire agent skills:</source>
+        <target state="new">Installed Aspire agent skills:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InitCommand_InstalledSkillsSummaryLocations">
+        <source>Locations: {0}</source>
+        <target state="new">Locations: {0}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InitCommand_InstalledSkillsSummarySkills">
+        <source>Skills: {0}</source>
+        <target state="new">Skills: {0}</target>
         <note />
       </trans-unit>
       <trans-unit id="InitCommand_PlaywrightCliSkipped">

--- a/src/Aspire.Cli/Resources/xlf/AgentCommandStrings.ru.xlf
+++ b/src/Aspire.Cli/Resources/xlf/AgentCommandStrings.ru.xlf
@@ -57,9 +57,19 @@
         <target state="new">Installed Playwright CLI.</target>
         <note />
       </trans-unit>
-      <trans-unit id="InitCommand_InstalledSkill">
-        <source>Installed {0} skill ({1}).</source>
-        <target state="new">Installed {0} skill ({1}).</target>
+      <trans-unit id="InitCommand_InstalledSkillsSummary">
+        <source>Installed Aspire agent skills:</source>
+        <target state="new">Installed Aspire agent skills:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InitCommand_InstalledSkillsSummaryLocations">
+        <source>Locations: {0}</source>
+        <target state="new">Locations: {0}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InitCommand_InstalledSkillsSummarySkills">
+        <source>Skills: {0}</source>
+        <target state="new">Skills: {0}</target>
         <note />
       </trans-unit>
       <trans-unit id="InitCommand_PlaywrightCliSkipped">

--- a/src/Aspire.Cli/Resources/xlf/AgentCommandStrings.tr.xlf
+++ b/src/Aspire.Cli/Resources/xlf/AgentCommandStrings.tr.xlf
@@ -57,9 +57,19 @@
         <target state="new">Installed Playwright CLI.</target>
         <note />
       </trans-unit>
-      <trans-unit id="InitCommand_InstalledSkill">
-        <source>Installed {0} skill ({1}).</source>
-        <target state="new">Installed {0} skill ({1}).</target>
+      <trans-unit id="InitCommand_InstalledSkillsSummary">
+        <source>Installed Aspire agent skills:</source>
+        <target state="new">Installed Aspire agent skills:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InitCommand_InstalledSkillsSummaryLocations">
+        <source>Locations: {0}</source>
+        <target state="new">Locations: {0}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InitCommand_InstalledSkillsSummarySkills">
+        <source>Skills: {0}</source>
+        <target state="new">Skills: {0}</target>
         <note />
       </trans-unit>
       <trans-unit id="InitCommand_PlaywrightCliSkipped">

--- a/src/Aspire.Cli/Resources/xlf/AgentCommandStrings.zh-Hans.xlf
+++ b/src/Aspire.Cli/Resources/xlf/AgentCommandStrings.zh-Hans.xlf
@@ -57,9 +57,19 @@
         <target state="new">Installed Playwright CLI.</target>
         <note />
       </trans-unit>
-      <trans-unit id="InitCommand_InstalledSkill">
-        <source>Installed {0} skill ({1}).</source>
-        <target state="new">Installed {0} skill ({1}).</target>
+      <trans-unit id="InitCommand_InstalledSkillsSummary">
+        <source>Installed Aspire agent skills:</source>
+        <target state="new">Installed Aspire agent skills:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InitCommand_InstalledSkillsSummaryLocations">
+        <source>Locations: {0}</source>
+        <target state="new">Locations: {0}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InitCommand_InstalledSkillsSummarySkills">
+        <source>Skills: {0}</source>
+        <target state="new">Skills: {0}</target>
         <note />
       </trans-unit>
       <trans-unit id="InitCommand_PlaywrightCliSkipped">

--- a/src/Aspire.Cli/Resources/xlf/AgentCommandStrings.zh-Hant.xlf
+++ b/src/Aspire.Cli/Resources/xlf/AgentCommandStrings.zh-Hant.xlf
@@ -57,9 +57,19 @@
         <target state="new">Installed Playwright CLI.</target>
         <note />
       </trans-unit>
-      <trans-unit id="InitCommand_InstalledSkill">
-        <source>Installed {0} skill ({1}).</source>
-        <target state="new">Installed {0} skill ({1}).</target>
+      <trans-unit id="InitCommand_InstalledSkillsSummary">
+        <source>Installed Aspire agent skills:</source>
+        <target state="new">Installed Aspire agent skills:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InitCommand_InstalledSkillsSummaryLocations">
+        <source>Locations: {0}</source>
+        <target state="new">Locations: {0}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InitCommand_InstalledSkillsSummarySkills">
+        <source>Skills: {0}</source>
+        <target state="new">Skills: {0}</target>
         <note />
       </trans-unit>
       <trans-unit id="InitCommand_PlaywrightCliSkipped">

--- a/tests/Aspire.Cli.Tests/Commands/AgentInitCommandTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/AgentInitCommandTests.cs
@@ -17,7 +17,7 @@ namespace Aspire.Cli.Tests.Commands;
 public class AgentInitCommandTests(ITestOutputHelper outputHelper)
 {
     [Fact]
-    public async Task AgentInitCommand_UsesNormalizedDisplayPath_WhenInstallingUserLevelSkill()
+    public async Task AgentInitCommand_SummarizesNormalizedDisplayPath_WhenInstallingUserLevelSkill()
     {
         using var workspace = TemporaryWorkspace.Create(outputHelper);
         var homeDirectory = workspace.CreateDirectory("fake-home");
@@ -44,13 +44,60 @@ public class AgentInitCommandTests(ITestOutputHelper outputHelper)
         var exitCode = await result.InvokeAsync().DefaultTimeout();
 
         Assert.Equal(0, exitCode);
+        var expectedSummary = string.Join(Environment.NewLine,
+            AgentCommandStrings.InitCommand_InstalledSkillsSummary,
+            $"  {string.Format(CultureInfo.CurrentCulture, AgentCommandStrings.InitCommand_InstalledSkillsSummarySkills, SkillDefinition.Aspire.Name)}",
+            $"  {string.Format(CultureInfo.CurrentCulture, AgentCommandStrings.InitCommand_InstalledSkillsSummaryLocations, ".agents/skills, ~/.agents/skills")}");
+
         Assert.Contains(
             interactionService.DisplayedMessages,
-            displayedMessage => displayedMessage.Message == string.Format(
+            displayedMessage => displayedMessage.Emoji.Equals(KnownEmojis.Robot) && displayedMessage.Message == expectedSummary);
+        Assert.DoesNotContain(
+            interactionService.DisplayedMessages,
+            displayedMessage => displayedMessage.Message.Contains("Installed aspire skill", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public async Task AgentInitCommand_SummarizesDefaultSkillsOnce()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        var homeDirectory = workspace.CreateDirectory("fake-home");
+        var interactionService = new TestInteractionService();
+        interactionService.SetupStringPromptResponse(workspace.WorkspaceRoot.FullName);
+        interactionService.PromptForSelectionsCallback = (_, choices, _, _) => choices.Cast<object>()
+            .Where(choice => choice switch
+            {
+                SkillLocation location => location == SkillLocation.Standard,
+                SkillDefinition skill => skill.IsDefault,
+                _ => false
+            })
+            .ToList();
+        var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper, options =>
+        {
+            options.InteractionServiceFactory = _ => interactionService;
+            options.CliExecutionContextFactory = _ => CreateExecutionContext(workspace.WorkspaceRoot, homeDirectory);
+        });
+
+        using var provider = services.BuildServiceProvider();
+        var command = provider.GetRequiredService<RootCommand>();
+        var result = command.Parse("agent init");
+
+        var exitCode = await result.InvokeAsync().DefaultTimeout();
+
+        Assert.Equal(0, exitCode);
+
+        var expectedSummary = string.Join(Environment.NewLine,
+            AgentCommandStrings.InitCommand_InstalledSkillsSummary,
+            $"  {string.Format(
                 CultureInfo.CurrentCulture,
-                AgentCommandStrings.InitCommand_InstalledSkill,
-                SkillDefinition.Aspire.Name,
-                "~/.agents/skills/aspire"));
+                AgentCommandStrings.InitCommand_InstalledSkillsSummarySkills,
+                string.Join(", ", SkillDefinition.All.Where(static skill => skill.IsDefault).Select(static skill => skill.Name)))}",
+            $"  {string.Format(CultureInfo.CurrentCulture, AgentCommandStrings.InitCommand_InstalledSkillsSummaryLocations, ".agents/skills, ~/.agents/skills")}");
+        var message = Assert.Single(interactionService.DisplayedMessages, displayedMessage => displayedMessage.Emoji.Equals(KnownEmojis.Robot));
+        Assert.Equal(expectedSummary, message.Message);
+        Assert.DoesNotContain(
+            interactionService.DisplayedMessages,
+            displayedMessage => displayedMessage.Message.Contains("Installed aspire skill", StringComparison.Ordinal));
     }
 
     [Fact]


### PR DESCRIPTION
## Description

Improves the `aspire agent init` skill installation output so the useful data is easy to scan. The command now collects updated skill/location pairs and prints one compact summary instead of repeating one success line for every skill at every install target.

Before:

```text
🤖 Installed aspire skill (.agents/skills/aspire).
🤖 Installed aspire skill (~/.agents/skills/aspire).
🤖 Installed aspireify skill (.agents/skills/aspireify).
🤖 Installed aspireify skill (~/.agents/skills/aspireify).
🤖 Installed aspire-deployment skill (.agents/skills/aspire-deployment).
🤖 Installed aspire-deployment skill (~/.agents/skills/aspire-deployment).
```

After:

```text
🤖 Installed Aspire agent skills:
     Skills: aspire, aspireify, aspire-deployment
     Locations: .agents/skills, ~/.agents/skills
✅ Agent environment configuration complete.
```

Detailed failure messages still include the exact skill path that failed, and no-op installs stay quiet except for the existing final success message.

### User-facing usage

Running `aspire agent init` with selected skills now summarizes the result:

```powershell
dotnet run --project src\Aspire.Cli\Aspire.Cli.csproj -- agent init --workspace-root <workspace> --skill-locations claudecode --skills aspire,aspireify,aspire-deployment
```

Observed local output:

```text
🤖 Installed Aspire agent skills:
     Skills: aspire, aspireify, aspire-deployment
     Locations: .claude/skills
✅ Agent environment configuration complete.
```

Validation:

- `dotnet build /t:UpdateXlf src\Aspire.Cli\Aspire.Cli.csproj`
- `dotnet test --project tests\Aspire.Cli.Tests\Aspire.Cli.Tests.csproj --no-launch-profile -- --filter-class "*.AgentInitCommandTests" --filter-not-trait "quarantined=true" --filter-not-trait "outerloop=true"`
- `dotnet run --project src\Aspire.Cli\Aspire.Cli.csproj -- agent init --workspace-root <temp-workspace> --skill-locations claudecode --skills aspire,aspireify,aspire-deployment`

Follow-up validation after PR CI publishes an Aspire CLI artifact: download the artifact and run `aspire new aspire-ts-starter -n aspire-app -o aspire-app`, answer `y` to AI setup, and select the defaults.

Fixes # (issue)

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
