### PR TITLE
[release/13.4] Stabilizing builds in preparation for 13.4 release

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -21,7 +21,7 @@
     <MicrosoftTestingPlatformVersion>2.2.1</MicrosoftTestingPlatformVersion>
     <MicrosoftNETTestSdkVersion>17.14.1</MicrosoftNETTestSdkVersion>
     <!-- Enable to remove prerelease label. -->
-    <StabilizePackageVersion Condition="'$(StabilizePackageVersion)' == ''">false</StabilizePackageVersion>
+    <StabilizePackageVersion Condition="'$(StabilizePackageVersion)' == ''">true</StabilizePackageVersion>
     <DotNetFinalVersionKind Condition="'$(StabilizePackageVersion)' == 'true'">release</DotNetFinalVersionKind>
   </PropertyGroup>
   <PropertyGroup>


### PR DESCRIPTION
Flip `StabilizePackageVersion` default to `true` in `eng/Versions.props` so the release/13.4 branch produces stable package versions.

## Background

Previously (see [#16566](https://github.com/microsoft/aspire/pull/16566) for release/13.3) stabilization required a sweep of changes: flipping the property, removing the PR-build version-suffix step, pinning the AppHost SDK in `RepoTesting.targets`, pinning every stabilizable Aspire package in `Directory.Packages.Helix.props`, and tweaking polyglot validation scripts to skip preview-only AppHosts.

PR [#15681](https://github.com/microsoft/aspire/pull/15681) (`Automate version stabilization: dynamically compute package versions for Helix testing`) collapses all of that into a single knob ΓÇö this PR is just that one-line flip.

## Validation

Built locally with the official-build configuration and stabilization on:

```
build.cmd -restore -build -pack -ci /p:SkipNativeBuild=true /p:OfficialBuildId=20260101.99
```

Result: `Build succeeded.` ΓÇö 0 warnings, 0 errors. 119 `.nupkg` files produced; stabilizable packages ship as `13.4.0` (e.g. `Aspire.Hosting.13.4.0.nupkg`, `Aspire.AppHost.Sdk.13.4.0.nupkg`), while packages that explicitly opt out via `SuppressFinalPackageVersion=true` (the preview hosting integrations) correctly remain at `13.4.0-preview.1.26051.99`.