### PR TITLE
Fix Aspire skills attestation build type

### DIFF
--- a/src/Aspire.Cli/Agents/AspireSkills/AspireSkillsInstaller.cs
+++ b/src/Aspire.Cli/Agents/AspireSkills/AspireSkillsInstaller.cs
@@ -31,7 +31,7 @@ internal sealed class AspireSkillsInstaller(
     internal const string GitHubRepository = "microsoft/aspire-skills";
     internal const string ExpectedSourceRepository = $"https://github.com/{GitHubRepository}";
     internal const string ExpectedWorkflowPath = ".github/workflows/publish.yml";
-    internal const string ExpectedBuildType = "https://slsa-framework.github.io/github-actions-buildtypes/workflow/v1";
+    internal const string ExpectedBuildType = "https://actions.github.io/buildtypes/workflow/v1";
     internal const string DisablePackageValidationKey = "disableAspireSkillsPackageValidation";
     internal const string VersionOverrideKey = "aspireSkillsVersion";
     internal const string MaxCacheAgeKey = "AspireSkillsMaxCacheAgeSeconds";

--- a/tests/Aspire.Cli.Tests/Agents/AspireSkillsInstallerTests.cs
+++ b/tests/Aspire.Cli.Tests/Agents/AspireSkillsInstallerTests.cs
@@ -19,6 +19,8 @@ namespace Aspire.Cli.Tests.Agents;
 
 public class AspireSkillsInstallerTests
 {
+    private const string GitHubReleaseAssetBuildType = "https://actions.github.io/buildtypes/workflow/v1";
+
     [Fact]
     public async Task InstallAsync_WhenValidBundleIsCached_UsesCacheWithoutNetwork()
     {
@@ -120,6 +122,11 @@ public class AspireSkillsInstallerTests
             Assert.Equal(AspireSkillsInstallStatus.Installed, result.Status);
             Assert.NotNull(result.Bundle);
             Assert.True(attestationVerifier.VerifyCalled);
+            Assert.Equal(AspireSkillsInstaller.GitHubRepository, attestationVerifier.Repository);
+            Assert.Equal(AspireSkillsInstaller.ExpectedSourceRepository, attestationVerifier.ExpectedSourceRepository);
+            Assert.Equal(AspireSkillsInstaller.ExpectedWorkflowPath, attestationVerifier.ExpectedWorkflowPath);
+            Assert.Equal(GitHubReleaseAssetBuildType, attestationVerifier.ExpectedBuildType);
+            Assert.Equal(AspireSkillsInstaller.Version, attestationVerifier.ExpectedVersion);
             Assert.NotNull(releaseRequestUri);
             Assert.NotNull(assetRequestUri);
             Assert.Contains("/microsoft/aspire-skills/releases/tags/v0.0.1", releaseRequestUri.AbsolutePath);
@@ -298,6 +305,16 @@ public class AspireSkillsInstallerTests
     {
         public bool VerifyCalled { get; private set; }
 
+        public string? Repository { get; private set; }
+
+        public string? ExpectedSourceRepository { get; private set; }
+
+        public string? ExpectedWorkflowPath { get; private set; }
+
+        public string? ExpectedBuildType { get; private set; }
+
+        public string? ExpectedVersion { get; private set; }
+
         public ProvenanceVerificationResult Result { get; init; } = new()
         {
             Outcome = ProvenanceVerificationOutcome.Verified,
@@ -314,6 +331,12 @@ public class AspireSkillsInstallerTests
             CancellationToken cancellationToken)
         {
             VerifyCalled = true;
+            Repository = repository;
+            ExpectedSourceRepository = expectedSourceRepository;
+            ExpectedWorkflowPath = expectedWorkflowPath;
+            ExpectedBuildType = expectedBuildType;
+            ExpectedVersion = expectedVersion;
+
             return Task.FromResult(Result);
         }
     }

--- a/tests/Aspire.Cli.Tests/Agents/SigstoreNpmProvenanceCheckerTests.cs
+++ b/tests/Aspire.Cli.Tests/Agents/SigstoreNpmProvenanceCheckerTests.cs
@@ -9,6 +9,8 @@ namespace Aspire.Cli.Tests.Agents;
 
 public class SigstoreNpmProvenanceCheckerTests
 {
+    private const string GitHubReleaseAssetBuildType = "https://actions.github.io/buildtypes/workflow/v1";
+
     #region ExtractSlsaBundleJson Tests
 
     [Fact]
@@ -257,6 +259,59 @@ public class SigstoreNpmProvenanceCheckerTests
             refInfo => refInfo.Kind == "tags");
 
         Assert.Equal(ProvenanceVerificationOutcome.Verified, result.Outcome);
+    }
+
+    [Fact]
+    public void VerifyProvenanceFields_WithGitHubReleaseAssetBuildType_ReturnsVerified()
+    {
+        var provenance = new NpmProvenanceData
+        {
+            SourceRepository = "https://github.com/microsoft/aspire-skills",
+            WorkflowPath = ".github/workflows/publish.yml",
+            BuildType = GitHubReleaseAssetBuildType,
+            WorkflowRef = "refs/tags/v0.0.1",
+            BuilderId = "https://github.com/microsoft/aspire-skills/.github/workflows/publish.yml@refs/tags/v0.0.1"
+        };
+
+        var result = SigstoreNpmProvenanceChecker.VerifyProvenanceFields(
+            provenance,
+            "https://github.com/microsoft/aspire-skills",
+            ".github/workflows/publish.yml",
+            GitHubReleaseAssetBuildType,
+            refInfo => string.Equals(refInfo.Kind, "tags", StringComparison.Ordinal) &&
+                       string.Equals(refInfo.Name, "v0.0.1", StringComparison.Ordinal));
+
+        Assert.Equal(ProvenanceVerificationOutcome.Verified, result.Outcome);
+    }
+
+    [Theory]
+    [InlineData("https://github.com/evil/aspire-skills", ".github/workflows/publish.yml", "refs/tags/v0.0.1", nameof(ProvenanceVerificationOutcome.SourceRepositoryMismatch))]
+    [InlineData("https://github.com/microsoft/aspire-skills", ".github/workflows/evil.yml", "refs/tags/v0.0.1", nameof(ProvenanceVerificationOutcome.WorkflowMismatch))]
+    [InlineData("https://github.com/microsoft/aspire-skills", ".github/workflows/publish.yml", "refs/heads/main", nameof(ProvenanceVerificationOutcome.WorkflowRefMismatch))]
+    public void VerifyProvenanceFields_WithGitHubReleaseAssetBuildType_RejectsUnexpectedProvenance(
+        string sourceRepository,
+        string workflowPath,
+        string workflowRef,
+        string expectedOutcome)
+    {
+        var provenance = new NpmProvenanceData
+        {
+            SourceRepository = sourceRepository,
+            WorkflowPath = workflowPath,
+            BuildType = GitHubReleaseAssetBuildType,
+            WorkflowRef = workflowRef,
+            BuilderId = "https://github.com/microsoft/aspire-skills/.github/workflows/publish.yml@refs/tags/v0.0.1"
+        };
+
+        var result = SigstoreNpmProvenanceChecker.VerifyProvenanceFields(
+            provenance,
+            "https://github.com/microsoft/aspire-skills",
+            ".github/workflows/publish.yml",
+            GitHubReleaseAssetBuildType,
+            refInfo => string.Equals(refInfo.Kind, "tags", StringComparison.Ordinal) &&
+                       string.Equals(refInfo.Name, "v0.0.1", StringComparison.Ordinal));
+
+        Assert.Equal(Enum.Parse<ProvenanceVerificationOutcome>(expectedOutcome), result.Outcome);
     }
 
     [Fact]


### PR DESCRIPTION
## Description

`aspire agent init --skills aspire,aspireify,aspire-deployment` failed to install the released `microsoft/aspire-skills` v0.0.1 bundle because the Aspire skills release-asset provenance verifier expected the stale SLSA GitHub Actions build type URL. GitHub release asset attestations produced by `actions/attest-build-provenance@v3` now report `https://actions.github.io/buildtypes/workflow/v1`.

This updates the Aspire skills installer to require the actual GitHub release-asset build type while preserving the existing source repository, workflow path, and tag ref validation. The generic provenance verifier tests now cover the GitHub release-asset build type and verify mismatched repo/workflow/ref values are still rejected.

### User-facing usage

Users can initialize the externally bundled Aspire skills from the signed GitHub release asset:

```bash
aspire agent init --skills aspire,aspireify,aspire-deployment
```

### Security considerations

This changes the expected provenance `buildType` for Aspire skills GitHub release assets to GitHub's current workflow build type. It does not disable attestation verification or broaden source repository, workflow path, or tag ref checks.

Validation:

```text
.\restore.cmd
dotnet test --project tests\Aspire.Cli.Tests\Aspire.Cli.Tests.csproj --no-launch-profile -- --filter-class "*.AspireSkillsInstallerTests" --filter-class "*.SigstoreNpmProvenanceCheckerTests" --filter-not-trait "quarantined=true" --filter-not-trait "outerloop=true"
```

Fixes # (issue)

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [x] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [x] No
  - [ ] No
