### PR TITLE
Fix 13.4 staging CLI dropping nuget.config without Aspire package source mapping

### DIFF
--- a/eng/pipelines/azure-pipelines.yml
+++ b/eng/pipelines/azure-pipelines.yml
@@ -8,6 +8,24 @@ parameters:
     displayName: 'Publish as Pre-Release'
     type: boolean
     default: false
+  # Operator-controlled override for the AspireCliChannel baked into native CLI
+  # binaries by build_sign_native.yml. The default 'auto' lets the pipeline pick
+  # stable / staging / daily / pr-<N> from Build.Reason and Build.SourceBranch
+  # (where release/* and internal/release/* branches always resolve to 'staging'
+  # so stabilizing dogfood builds aren't mis-baked as 'stable' — see
+  # https://github.com/microsoft/aspire/issues/17527). Set this to 'stable' when
+  # kicking off the official GA ship build from a release/* branch so the
+  # distributed binary identifies as stable and `aspire init` writes a
+  # nuget.org-only nuget.config matching the promoted package set.
+  - name: aspireCliChannelOverride
+    displayName: 'Aspire CLI channel override (auto = derive from branch; set to stable for the GA ship build)'
+    type: string
+    default: 'auto'
+    values:
+      - auto
+      - stable
+      - staging
+      - daily
 
 trigger:
   batch: true
@@ -167,6 +185,7 @@ extends:
             - osx-x64
           codeSign: true
           teamName: $(_TeamName)
+          aspireCliChannelOverride: ${{ parameters.aspireCliChannelOverride }}
           extraBuildArgs: >-
             /p:Configuration=$(_BuildConfig)
             $(_SignArgs)
@@ -182,6 +201,7 @@ extends:
           # no need to sign ELF binaries on linux
           codeSign: false
           teamName: $(_TeamName)
+          aspireCliChannelOverride: ${{ parameters.aspireCliChannelOverride }}
           extraBuildArgs: >-
             /p:Configuration=$(_BuildConfig)
             $(_OfficialBuildIdArgs)
@@ -194,6 +214,7 @@ extends:
             - win-arm64
           codeSign: true
           teamName: $(_TeamName)
+          aspireCliChannelOverride: ${{ parameters.aspireCliChannelOverride }}
           extraBuildArgs: >-
             /p:Configuration=$(_BuildConfig)
             $(_SignArgs)

--- a/eng/pipelines/templates/build_sign_native.yml
+++ b/eng/pipelines/templates/build_sign_native.yml
@@ -105,10 +105,21 @@ jobs:
                 # Bake the resolved hive label directly into AspireCliChannel. The CLI
                 # consumes this verbatim and avoids the legacy "pr" + parsed-PrNumber join.
                 $channel = "pr-$prNumber"
+              } elseif ($sourceBranch -match '^refs/heads/(release|internal/release)/') {
+                # Release/internal-release branches always produce staging artifacts —
+                # they are published to the staging feed for dogfooding and only later
+                # promoted to nuget.org. This must be checked BEFORE the
+                # `versionKind == release` arm, because a release-branch build also sets
+                # StabilizePackageVersion=true (→ DotNetFinalVersionKind=release) once
+                # we are stabilizing for ship. Without this ordering, the stabilized
+                # staging build would bake AspireCliChannel=stable and `aspire init`
+                # would drop a nuget.config with no staging feed mapping, causing
+                # `aspire add` to resolve Aspire.* packages from nuget.org (older
+                # versions) or fail to resolve the +sha-pinned Aspire.AppHost.Sdk.
+                # See https://github.com/microsoft/aspire/issues/17527.
+                $channel = 'staging'
               } elseif ($versionKind -eq 'release') {
                 $channel = 'stable'
-              } elseif ($sourceBranch -match '^refs/heads/(release|internal/release)/') {
-                $channel = 'staging'
               } else {
                 # main and any other branch fall through to daily
                 $channel = 'daily'

--- a/eng/pipelines/templates/build_sign_native.yml
+++ b/eng/pipelines/templates/build_sign_native.yml
@@ -6,6 +6,19 @@ parameters:
   extraBuildArgs: ''
   codeSign: false
   teamName: ''
+  # Optional override for AspireCliChannel. Accepted values: 'auto' (default;
+  # let computeCliChannel below pick stable/staging/daily/pr-<N> from Build.Reason
+  # and Build.SourceBranch), 'stable', 'staging', 'daily'. Set this to 'stable'
+  # when running the official ship pipeline so the GA CLI binary is baked with
+  # AspireCliChannel=stable (and aspire init then writes a nuget.org-only
+  # nuget.config, which is correct because the packages have been promoted to
+  # nuget.org). For routine stabilizing builds from a release/* branch — which
+  # also set DotNetFinalVersionKind=release — leave this on 'auto' so the
+  # channel falls through to 'staging' and aspire init writes a nuget.config
+  # that maps Aspire.* to the staging feed. See
+  # https://github.com/microsoft/aspire/issues/17527 for the bug that made this
+  # override necessary.
+  aspireCliChannelOverride: 'auto'
 
 jobs:
 
@@ -84,15 +97,32 @@ jobs:
               $reason = '$(Build.Reason)'
               $sourceBranch = '$(Build.SourceBranch)'
               $prNumber = '$(System.PullRequest.PullRequestNumber)'
+              # Template-time substitution: the value is the resolved
+              # aspireCliChannelOverride parameter literal, never a runtime
+              # variable. Quoting protects an empty/default value.
+              $override = '${{ parameters.aspireCliChannelOverride }}'
               Write-Host "Build.Reason: '$reason'"
               Write-Host "Build.SourceBranch: '$sourceBranch'"
               Write-Host "System.PullRequest.PullRequestNumber: '$prNumber'"
+              Write-Host "aspireCliChannelOverride: '$override'"
 
               $versionKind = & "$(Build.SourcesDirectory)/$(dotnetScript)" msbuild "$(Build.SourcesDirectory)/eng/Versions.props" -getProperty:DotNetFinalVersionKind
               $versionKind = $versionKind.Trim()
               Write-Host "DotNetFinalVersionKind: '$versionKind'"
 
-              if ($reason -eq 'PullRequest') {
+              if ($override -and $override -ne 'auto') {
+                # Operator override path. Validate against the same accepted set
+                # that IdentityChannelReader.IsValidChannel enforces at CLI startup
+                # so a typo here fails the pipeline step rather than producing a
+                # binary that refuses to boot. pr-<N> is intentionally excluded
+                # from the override set — PR builds always come from the
+                # PullRequest reason arm below.
+                if ($override -notin @('stable', 'staging', 'daily')) {
+                  throw "aspireCliChannelOverride='$override' is not one of: auto, stable, staging, daily."
+                }
+                $channel = $override
+              }
+              elseif ($reason -eq 'PullRequest') {
                 # Defense in depth: validate digit-only PR number rather than just
                 # non-emptiness. If the agent ever returns the literal macro string
                 # (e.g. '$(System.PullRequest.PullRequestNumber)' unresolved) this

--- a/eng/pipelines/templates/build_sign_native.yml
+++ b/eng/pipelines/templates/build_sign_native.yml
@@ -120,7 +120,7 @@ jobs:
                 if ($override -notin @('stable', 'staging', 'daily')) {
                   throw "aspireCliChannelOverride='$override' is not one of: auto, stable, staging, daily."
                 }
-                $channel = $override
+                $channel = $override.ToLowerInvariant()
               }
               elseif ($reason -eq 'PullRequest') {
                 # Defense in depth: validate digit-only PR number rather than just

--- a/src/Aspire.Cli/Packaging/PackagingService.cs
+++ b/src/Aspire.Cli/Packaging/PackagingService.cs
@@ -50,6 +50,11 @@ internal class PackagingService : IPackagingService
     private readonly IConfiguration _configuration;
     private readonly ILogger<PackagingService> _logger;
     private readonly Func<string?> _processPathProvider;
+    // Predicate used by staging-channel synthesis to decide whether the running CLI is built
+    // from a stable-shaped version (no semver prerelease tag). Defaults to inspecting the
+    // current Aspire.Cli assembly's InformationalVersion; tests inject a deterministic value
+    // because the version baked into the test-host assembly varies by build configuration.
+    private readonly Func<bool> _isStableShapedCliVersion;
 
     // Cached result of the staging-channel availability check. The inputs (CLI identity,
     // overrideStagingFeed, StagingChannelEnabled feature) are effectively static for the
@@ -64,7 +69,8 @@ internal class PackagingService : IPackagingService
         IFeatures features,
         IConfiguration configuration,
         ILogger<PackagingService> logger,
-        Func<string?>? processPathProvider = null)
+        Func<string?>? processPathProvider = null,
+        Func<bool>? isStableShapedCliVersion = null)
     {
         _executionContext = executionContext;
         _nuGetPackageCache = nuGetPackageCache;
@@ -72,6 +78,7 @@ internal class PackagingService : IPackagingService
         _configuration = configuration;
         _logger = logger;
         _processPathProvider = processPathProvider ?? (() => Environment.ProcessPath);
+        _isStableShapedCliVersion = isStableShapedCliVersion ?? IsStableShapedCliVersionFromAssembly;
         _stagingUnavailableReasonCache = new Lazy<string?>(ComputeStagingChannelUnavailableReason);
     }
 
@@ -133,7 +140,46 @@ internal class PackagingService : IPackagingService
         var stagingFeatureEnabled = _features.IsFeatureEnabled(KnownFeatures.StagingChannelEnabled, false);
         if (stagingFeatureEnabled || stagingChannelConfigured || stagingChannelRequested || stagingIdentityChannel)
         {
-            var defaultQuality = stagingChannelConfigured || stagingChannelRequested || stagingIdentityChannel ? PackageChannelQuality.Both : PackageChannelQuality.Stable;
+            // Default quality selection rules (per staging entry point):
+            //   - Explicit user opt-in (`stagingChannelConfigured`, `stagingChannelRequested`): Both.
+            //     The user picked staging deliberately; they get the broadest matching window.
+            //   - `stagingFeatureEnabled` only (no other staging signal): Stable. Preserves the
+            //     pre-existing behavior of the staging feature flag.
+            //   - `stagingIdentityChannel` (the running CLI itself self-identifies as staging):
+            //     depends on the CLI build's version shape.
+            //       * Stable-shaped (e.g. "13.4.0", produced during release stabilization when
+            //         StabilizePackageVersion=true) → Stable. The shared dotnet9 daily feed only
+            //         carries prerelease-tagged 13.4.0-preview.* builds, so defaulting to Both
+            //         would route Aspire.* to dotnet9 and fail to resolve the just-shipped
+            //         stable-shaped packages — the bug from
+            //         https://github.com/microsoft/aspire/issues/17527. Routing to Stable selects
+            //         the SHA-derived darc-pub-microsoft-aspire-<hash> feed, where the
+            //         stabilizing build's packages actually live.
+            //       * Prerelease-shaped (e.g. "13.4.0-preview.1.123") → Both. SHA-specific darc
+            //         feeds are only created for stable release-branch builds, so prerelease CLIs
+            //         must use the shared daily feed; the historical Both default is correct.
+            PackageChannelQuality defaultQuality;
+            if (stagingIdentityChannel)
+            {
+                // When the running CLI's identity itself is staging, the synthesized channel's
+                // quality MUST follow the CLI build's version shape regardless of how synthesis
+                // was triggered. `init` and many other commands pass requestedChannelName=staging
+                // when identity is staging, so checking `stagingChannelRequested` first would
+                // short-circuit this path and re-introduce the #17527 misroute on stabilizing
+                // builds.
+                defaultQuality = _isStableShapedCliVersion()
+                    ? PackageChannelQuality.Stable
+                    : PackageChannelQuality.Both;
+            }
+            else if (stagingChannelConfigured || stagingChannelRequested)
+            {
+                defaultQuality = PackageChannelQuality.Both;
+            }
+            else
+            {
+                defaultQuality = PackageChannelQuality.Stable;
+            }
+
             var stagingChannel = CreateStagingChannel(defaultQuality);
             if (stagingChannel is not null)
             {
@@ -214,6 +260,23 @@ internal class PackagingService : IPackagingService
 
         var packagesDirectory = new DirectoryInfo(Path.Combine(installPrefix.FullName, "hives", identityChannel, "packages"));
         return packagesDirectory.Exists ? packagesDirectory : null;
+    }
+
+    // Returns true when the running CLI's version is stable-shaped (no semver prerelease tag).
+    // Used by the staging-channel synthesis to route stabilizing builds to the SHA-derived darc
+    // feed instead of the shared dotnet9 daily feed. Falls back to false on any error so we
+    // preserve the historical Both/shared-feed behavior rather than silently misrouting.
+    private static bool IsStableShapedCliVersionFromAssembly()
+    {
+        try
+        {
+            var version = VersionHelper.GetDefaultSdkVersion();
+            return !string.IsNullOrEmpty(version) && !version.Contains('-');
+        }
+        catch
+        {
+            return false;
+        }
     }
 
     private PackageChannel? CreateStagingChannel(PackageChannelQuality defaultQuality)

--- a/tests/Aspire.Cli.Tests/Packaging/PackagingServiceTests.cs
+++ b/tests/Aspire.Cli.Tests/Packaging/PackagingServiceTests.cs
@@ -65,7 +65,7 @@ public class PackagingServiceTests(ITestOutputHelper outputHelper)
                 [PackagingService.OverrideStagingFeedConfigKey] = "https://example.com/nuget/v3/index.json"
             })
             .Build();
-        var packagingService = new PackagingService(executionContext, new FakeNuGetPackageCache(), new TestFeatures(), configuration, NullLogger<PackagingService>.Instance);
+        var packagingService = new PackagingService(executionContext, new FakeNuGetPackageCache(), new TestFeatures(), configuration, NullLogger<PackagingService>.Instance, isStableShapedCliVersion: () => false);
 
         var channels = await packagingService.GetChannelsAsync().DefaultTimeout();
 
@@ -80,6 +80,35 @@ public class PackagingServiceTests(ITestOutputHelper outputHelper)
 
         var stagingChannel = channels.First(c => c.Name == PackageChannelNames.Staging);
         Assert.Equal(PackageChannelQuality.Both, stagingChannel.Quality);
+    }
+
+    [Fact]
+    public async Task GetChannelsAsync_WhenIdentityChannelIsStagingOnStableShapedCli_DefaultsToStableQuality()
+    {
+        // Regression test for https://github.com/microsoft/aspire/issues/17527: during release
+        // stabilization the staging CLI ships with a stable-shaped version (e.g. "13.4.0"). The
+        // shared dotnet9 daily feed only carries prerelease-tagged 13.4.0-preview.* packages,
+        // so a stabilizing staging CLI must route Aspire.* to the SHA-derived darc-pub-aspire-<hash>
+        // feed instead — which requires defaulting the synthesized staging channel quality to
+        // Stable (so useSharedFeed in CreateStagingChannel resolves false).
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        var tempDir = workspace.WorkspaceRoot;
+        var hivesDir = new DirectoryInfo(Path.Combine(tempDir.FullName, ".aspire", "hives"));
+        var cacheDir = new DirectoryInfo(Path.Combine(tempDir.FullName, ".aspire", "cache"));
+        var executionContext = new CliExecutionContext(tempDir, hivesDir, cacheDir, new DirectoryInfo(Path.Combine(Path.GetTempPath(), "aspire-test-runtimes")), new DirectoryInfo(Path.Combine(Path.GetTempPath(), "aspire-test-logs")), "test.log", identityChannel: PackageChannelNames.Staging);
+
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                [PackagingService.OverrideStagingFeedConfigKey] = "https://example.com/nuget/v3/index.json"
+            })
+            .Build();
+        var packagingService = new PackagingService(executionContext, new FakeNuGetPackageCache(), new TestFeatures(), configuration, NullLogger<PackagingService>.Instance, isStableShapedCliVersion: () => true);
+
+        var channels = await packagingService.GetChannelsAsync().DefaultTimeout();
+
+        var stagingChannel = channels.First(c => c.Name == PackageChannelNames.Staging);
+        Assert.Equal(PackageChannelQuality.Stable, stagingChannel.Quality);
     }
 
     [Fact]

--- a/tests/Aspire.Cli.Tests/Utils/CliTestHelper.cs
+++ b/tests/Aspire.Cli.Tests/Utils/CliTestHelper.cs
@@ -576,7 +576,14 @@ internal sealed class CliServiceCollectionTestOptions
         var nuGetPackageCache = serviceProvider.GetRequiredService<INuGetPackageCache>();
         var features = serviceProvider.GetRequiredService<IFeatures>();
         var configuration = serviceProvider.GetRequiredService<IConfiguration>();
-        return new PackagingService(executionContext, nuGetPackageCache, features, configuration, NullLogger<PackagingService>.Instance);
+        // Force prerelease-shaped CLI version semantics in tests so PackagingService's
+        // identity-staging quality default does not depend on whether the test-host assembly
+        // was produced under StabilizePackageVersion=true. Without this, tests that rely on
+        // the shared-daily routing for `staging` identity (quality=Both → useSharedFeed=true)
+        // would fail under the stabilization-check job which builds with a stable-shaped
+        // version (no '-' suffix) baked in. Tests that specifically exercise the stable-shape
+        // branch construct PackagingService directly with isStableShapedCliVersion: () => true.
+        return new PackagingService(executionContext, nuGetPackageCache, features, configuration, NullLogger<PackagingService>.Instance, isStableShapedCliVersion: () => false);
     };
 
     public Func<IServiceProvider, IDiskCache> DiskCacheFactory { get; set; } = (IServiceProvider serviceProvider) => new NullDiskCache();


### PR DESCRIPTION
Fixes #17527.

The 13.4 staging CLI ships claiming `channel: stable`, which makes `aspire init` drop a `nuget.config` that points only at nuget.org — so `aspire add yarp` resolves the prior stable (`13.3.5`), or fails to find the stabilizing `Aspire.AppHost.Sdk@13.4.0+0f5144527…`.

## Three coordinated fixes

### 1. `eng/pipelines/templates/build_sign_native.yml` — reorder the channel-detect cascade

The auto-detect previously checked `versionKind -eq 'release'` **before** the release-branch regex. `StabilizePackageVersion=true` (every release-branch stabilizing build) sets `DotNetFinalVersionKind=release`, so the staging build was baked as `AspireCliChannel=stable`. Reordering so the release-branch regex runs first makes stabilizing release-branch builds resolve to `staging` correctly.

### 2. `eng/pipelines/azure-pipelines.yml` — `aspireCliChannelOverride` runtime parameter

Reordering (1) means release-branch builds no longer auto-resolve to `stable`. The actual GA ship build still needs to bake `stable`, so a runtime parameter (`auto` | `stable` | `staging` | `daily`, default `auto`) lets the operator pick the channel explicitly at queue time. `auto` falls through to the auto-detect cascade.

### 3. `src/Aspire.Cli/Packaging/PackagingService.cs` — version-shape-driven default quality

Even with fixes (1) + (2), the staging-channel synthesis was routing Aspire.* to the shared dnceng/dotnet9 daily feed instead of the SHA-derived `darc-pub-microsoft-aspire-<hash>` feed where stabilizing packages actually live. Root cause: `stagingIdentityChannel` defaulted quality to `Both`, making `useSharedFeed=true`. dotnet9 only carries `13.4.0-preview.1.*`, not stable-shaped `13.4.0`.

Fix: when the CLI's identity is `staging`, derive the default quality from the CLI build's version shape:
- **Stable-shaped** (no semver prerelease tag) → `Stable` → SHA-derived darc feed (works for stabilizing builds).
- **Prerelease-shaped** → `Both` → shared dotnet9 (historical behavior; SHA feeds only exist for stable builds).

The identity branch runs before the requested/configured branches in the if/else because `init` calls `GetChannelsAsync(requestedChannelName: "staging")` when identity is staging — short-circuiting there would re-introduce the bug. The version-shape predicate is injected via constructor for deterministic unit-test coverage.

## Validation

End-to-end validated with a locally-built NAOT `aspire` binary:

```
./dotnet.sh publish src/Aspire.Cli/Aspire.Cli.csproj -c Release -r osx-arm64 /p:AspireCliChannel=staging
aspire config set -g overrideStagingFeed https://pkgs.dev.azure.com/dnceng/public/_packaging/darc-pub-microsoft-aspire-0f514452/nuget/v3/index.json
aspire init --language csharp --non-interactive
aspire add yarp --non-interactive    # → Aspire.Hosting.Yarp::13.4.0 ✅
```

Resolved staging channel: `feed=…darc-pub-microsoft-aspire-0f514452…, quality=Stable, pinnedVersion=(none)`.

`PackagingServiceTests` (50/50) pass.

## Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/aspire/pull/17528)
