### PR TITLE
Update contribution guide

### DIFF
--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -106,8 +106,9 @@ The Aspire repository also includes custom Copilot skills that team members and 
 
 - [`code-review`](/.github/skills/code-review/SKILL.md) reviews a PR for high-confidence problems only, such as bugs, security issues, correctness errors, performance regressions, missing boundary error handling, concurrency or resource issues, flaky test patterns, and repository convention violations. It avoids style nits and duplicate review comments.
 - [`pr-testing`](/.github/skills/pr-testing/SKILL.md) installs the Aspire CLI and packages from a PR's dogfood build, verifies the installed CLI matches the PR head commit, analyzes changed areas, proposes targeted happy-path and negative test scenarios, runs the selected scenarios locally or in the repo container runner, captures evidence, and can produce a PR testing report.
+- [`cli-e2e-testing`](/.github/skills/cli-e2e-testing/SKILL.md) guides Aspire CLI end-to-end test authoring and debugging with Hex1b terminal automation. It covers test structure, local `localhive` archive workflows, Docker-based execution, install modes, prompt detection, and asciinema recordings for failures.
 
-Other repo skills can help with specialized work, but these two are the main skills the Aspire team uses to evaluate PR quality and dogfoodability.
+Other repo skills can help with specialized work, but these are the main skills the Aspire team uses to evaluate PR quality, dogfoodability, and CLI end-to-end coverage.
 
 ## Development environments
 

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -15,7 +15,7 @@ These instructions will get you ready to contribute to this project. If you just
   - [Running tests](#running-tests)
   - [Quarantined and outerloop tests](#quarantined-and-outerloop-tests)
   - [Testing pull request changes](#testing-pull-request-changes)
-- [Contributing with AI assistance](#contributing-with-ai-assistance)
+- [Coding Agents](#coding-agents)
   - [`code-review`](#code-review)
   - [`pr-testing`](#pr-testing)
   - [`cli-e2e-testing`](#cli-e2e-testing)
@@ -102,7 +102,7 @@ dotnet test --no-launch-profile -- \
 
 To test changes from a specific pull request locally, see [dogfooding-pull-requests.md](/docs/dogfooding-pull-requests.md) for instructions on installing Aspire CLI and NuGet packages built by that PR's CI run.
 
-## Contributing with AI assistance
+## Coding Agents
 
 Aspire uses GitHub Copilot automatic code review on pull requests. We expect Copilot review comments to be reviewed and addressed before merging, either by making the requested change or by explaining why a suggested change is not needed.
 

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -4,36 +4,49 @@ These instructions will get you ready to contribute to this project. If you just
 
 ## Contents
 
-- [Prepare the machine](#prepare-the-machine)
-- [Build the repo](#build-the-repo)
-- [Using the `dotnet` CLI](#using-the-dotnet-cli)
-- [Run TestShop](#run-testshop)
-- [Using VS Code](#using-vs-code)
-- [Building the VS Code extension](#building-the-vs-code-extension)
-- [Using Visual Studio](#using-visual-studio)
-- [Native build](#native-build)
-- [View Dashboard](#view-dashboard)
-- [Localization](#localization)
+- [Getting set up](#getting-set-up)
+  - [Prepare the machine](#prepare-the-machine)
+  - [Using the `dotnet` CLI](#using-the-dotnet-cli)
+  - [Build the repo](#build-the-repo)
+- [Verify your setup](#verify-your-setup)
+  - [Run TestShop](#run-testshop)
+  - [View Dashboard](#view-dashboard)
 - [Testing](#testing)
+  - [Running tests](#running-tests)
+  - [Quarantined and outerloop tests](#quarantined-and-outerloop-tests)
+  - [Testing pull request changes](#testing-pull-request-changes)
 - [Contributing with AI assistance](#contributing-with-ai-assistance)
-- [Integrations](#integrations)
-- [Generating local NuGet packages](#generating-local-nuget-packages)
-- [Creating a local Aspire build with `localhive`](#creating-a-local-aspire-build-with-localhive)
+- [Development environments](#development-environments)
+  - [Using VS Code](#using-vs-code)
+  - [Building the VS Code extension](#building-the-vs-code-extension)
+  - [Using Visual Studio](#using-visual-studio)
+- [Area-specific guidance](#area-specific-guidance)
+  - [Localization](#localization)
+  - [Integrations](#integrations)
+  - [Native build](#native-build)
+- [Trying your changes locally](#trying-your-changes-locally)
+  - [Generating local NuGet packages](#generating-local-nuget-packages)
+  - [Creating a local Aspire build with `localhive`](#creating-a-local-aspire-build-with-localhive)
 - [Tips and known issues](#tips-and-known-issues)
+  - [Package validation](#package-validation)
 
-## Prepare the machine
+## Getting set up
+
+### Prepare the machine
 
 See [machine-requirements.md](/docs/machine-requirements.md).
 
-## Build the repo
-
-First run `./restore.sh` (macOS and Linux) or `.\restore.cmd` (Windows) to install the repo-local .NET SDK. Then build with `./build.sh` (macOS and Linux) or `.\build.cmd` (Windows).
-
-## Using the `dotnet` CLI
+### Using the `dotnet` CLI
 
 After restore, `dotnet` commands run from this repo use the repo-local SDK because `global.json` includes `.dotnet` in the SDK search path. Use `./dotnet.sh` on Unix or `.\dotnet.cmd` on Windows when you need to force the repo-local SDK explicitly.
 
-## Run TestShop
+### Build the repo
+
+First run `./restore.sh` (macOS and Linux) or `.\restore.cmd` (Windows) to install the repo-local .NET SDK. Then build with `./build.sh` (macOS and Linux) or `.\build.cmd` (Windows).
+
+## Verify your setup
+
+### Run TestShop
 
 This will confirm that you're all set up.
 
@@ -50,11 +63,59 @@ Or, if you are using Visual Studio:
 2. Set the Startup Project to be the `AppHost` project (it's under `\playground\TestShop`). Make sure the launch profile is set to "http".
 3. <kbd>F5</kbd> to debug, or <kbd>Ctrl+F5</kbd> to launch without debugging.
 
-## Using VS Code
+### View Dashboard
+
+When you start the sample app in Visual Studio, it will automatically open your browser to show the dashboard.
+
+Otherwise if you are using the command line, when you have the Aspire app running, open the dashboard URL in your browser. The URL is shown in the app's console output like this: `Now listening on: http://localhost:15888`. You can change the default URL in the launchSettings.json file in the AppHost project.
+
+## Testing
+
+### Running tests
+
+To run tests, use the build script:
+
+```bash
+./build.sh --test  # Linux/macOS
+.\build.cmd --test # Windows
+```
+
+### Quarantined and outerloop tests
+
+Flaky tests may be marked as quarantined to prevent them from blocking CI while being investigated and fixed. See [quarantined-tests.md](/docs/quarantined-tests.md) for more information on working with quarantined tests.
+
+Long-running or resource-intensive tests may be marked as outerloop. See [outerloop-tests.md](/docs/outerloop-tests.md) for more information.
+
+When running tests locally or in automated environments, use the test filters to exclude known flaky and outerloop tests:
+
+```bash
+dotnet test --no-launch-profile -- \
+  --filter-not-trait "quarantined=true" \
+  --filter-not-trait "outerloop=true"
+```
+
+### Testing pull request changes
+
+To test changes from a specific pull request locally, see [dogfooding-pull-requests.md](/docs/dogfooding-pull-requests.md) for instructions on installing Aspire CLI and NuGet packages built by that PR's CI run.
+
+## Contributing with AI assistance
+
+Aspire uses GitHub Copilot automatic code review on pull requests. We expect Copilot review comments to be reviewed and addressed before merging, either by making the requested change or by explaining why a suggested change is not needed.
+
+The Aspire repository also includes custom Copilot skills that team members and automation may run on PRs, even when the PR author is not using an AI coding agent. Contributors can get a head start by running the key skills before requesting review:
+
+- [`code-review`](/.github/skills/code-review/SKILL.md) reviews a PR for high-confidence problems only, such as bugs, security issues, correctness errors, performance regressions, missing boundary error handling, concurrency or resource issues, flaky test patterns, and repository convention violations. It avoids style nits and duplicate review comments.
+- [`pr-testing`](/.github/skills/pr-testing/SKILL.md) installs the Aspire CLI and packages from a PR's dogfood build, verifies the installed CLI matches the PR head commit, analyzes changed areas, proposes targeted happy-path and negative test scenarios, runs the selected scenarios locally or in the repo container runner, captures evidence, and can produce a PR testing report.
+
+Other repo skills can help with specialized work, but these two are the main skills the Aspire team uses to evaluate PR quality and dogfoodability.
+
+## Development environments
+
+### Using VS Code
 
 Make sure you [build the repo](#build-the-repo) from command line at least once. Then use `./start-code.sh` (macOS and Linux) or `.\start-code.cmd` to start VS Code.
 
-## Building the VS Code extension
+### Building the VS Code extension
 
 The Aspire VS Code extension lives under `extension/`. To build the extension through the repo build, make sure Node.js, yarn, and `vsce` are on your PATH, then run:
 
@@ -75,25 +136,13 @@ yarn compile
 
 Use `yarn watch` while editing TypeScript. When adding or changing user-facing extension text, keep the strings localized in both `extension/package.nls.json` and `extension/src/loc/strings.ts`. For VSIX signing and release packaging details, see [extension-signing.md](/docs/extension-signing.md).
 
-## Using Visual Studio
+### Using Visual Studio
 
 Make sure you [build the repo](#build-the-repo) from command line at least once using `.\build.cmd` (Windows). Then use `.\startvs.cmd` to start Visual Studio with the correct environment setup.
 
-## Native build
+## Area-specific guidance
 
-The default build includes native builds for `Aspire.Cli` which produces Native AOT binaries for some platforms. These projects are in `eng/clipack/Aspire.Cli.*`.
-
-By default it builds the CLI native project for the current Runtime Identifier. Specific RIDs can be specified by setting `$(TargetRids)` to a colon separated list like `/p:TargetRids=osx-x64:osx-arm64`.
-
-Native build can be disabled with `/p:SkipNativeBuild=true`. To build only the native bits, use `/p:SkipManagedBuild=true`.
-
-## View Dashboard
-
-When you start the sample app in Visual Studio, it will automatically open your browser to show the dashboard.
-
-Otherwise if you are using the command line, when you have the Aspire app running, open the dashboard URL in your browser. The URL is shown in the app's console output like this: `Now listening on: http://localhost:15888`. You can change the default URL in the launchSettings.json file in the AppHost project.
-
-## Localization
+### Localization
 
 If you are contributing to Aspire.Dashboard, please ensure that all strings are localized. If necessary,
 create a new resx file under `src/Aspire.Dashboard/Resources`. To reference a string, ensure the `IStringLocalizer` for the resx file is
@@ -110,51 +159,21 @@ until `OnInitialized`.
 
 The `*.Designer.cs` files are checked in with the matching `*.resx` files. If you add, remove, or rename resources, update the matching designer file too. If the project has an `xlf` directory, run `dotnet build /t:UpdateXlf <path-to-project.csproj>` to update localization files instead of editing `*.xlf` files manually.
 
-## Testing
-
-### Running Tests
-
-To run tests, use the build script:
-
-```bash
-./build.sh --test  # Linux/macOS
-.\build.cmd --test # Windows
-```
-
-### Quarantined Tests
-
-Flaky tests may be marked as quarantined to prevent them from blocking CI while being investigated and fixed. See [quarantined-tests.md](/docs/quarantined-tests.md) for more information on working with quarantined tests.
-
-Long-running or resource-intensive tests may be marked as outerloop. See [outerloop-tests.md](/docs/outerloop-tests.md) for more information.
-
-When running tests locally or in automated environments, use the test filters to exclude known flaky and outerloop tests:
-
-```bash
-dotnet test --no-launch-profile -- \
-  --filter-not-trait "quarantined=true" \
-  --filter-not-trait "outerloop=true"
-```
-
-### Testing Pull Request Changes
-
-To test changes from a specific pull request locally, see [dogfooding-pull-requests.md](/docs/dogfooding-pull-requests.md) for instructions on installing Aspire CLI and NuGet packages built by that PR's CI run.
-
-## Contributing with AI assistance
-
-Aspire uses GitHub Copilot automatic code review on pull requests. We expect Copilot review comments to be reviewed and addressed before merging, either by making the requested change or by explaining why a suggested change is not needed.
-
-The Aspire repository also includes custom Copilot skills that team members and automation may run on PRs, even when the PR author is not using an AI coding agent. Contributors can get a head start by running the key skills before requesting review:
-
-- [`code-review`](/.github/skills/code-review/SKILL.md) reviews a PR for high-confidence problems only, such as bugs, security issues, correctness errors, performance regressions, missing boundary error handling, concurrency or resource issues, flaky test patterns, and repository convention violations. It avoids style nits and duplicate review comments.
-- [`pr-testing`](/.github/skills/pr-testing/SKILL.md) installs the Aspire CLI and packages from a PR's dogfood build, verifies the installed CLI matches the PR head commit, analyzes changed areas, proposes targeted happy-path and negative test scenarios, runs the selected scenarios locally or in the repo container runner, captures evidence, and can produce a PR testing report.
-
-Other repo skills can help with specialized work, but these two are the main skills the Aspire team uses to evaluate PR quality and dogfoodability.
-
-## Integrations
+### Integrations
 
 Please check the [Aspire integrations contribution guidelines](/src/Components/README.md) if you intend to make contributions to a new or existing Aspire integration.
 
-## Generating local NuGet packages
+### Native build
+
+The default build includes native builds for `Aspire.Cli` which produces Native AOT binaries for some platforms. These projects are in `eng/clipack/Aspire.Cli.*`.
+
+By default it builds the CLI native project for the current Runtime Identifier. Specific RIDs can be specified by setting `$(TargetRids)` to a colon separated list like `/p:TargetRids=osx-x64:osx-arm64`.
+
+Native build can be disabled with `/p:SkipNativeBuild=true`. To build only the native bits, use `/p:SkipManagedBuild=true`.
+
+## Trying your changes locally
+
+### Generating local NuGet packages
 
 If you only need package outputs, it can be useful to generate the NuGet packages in a local folder and use it as a package source from a separate Aspire-based project or solution. If you want to validate a complete locally-built Aspire product, including the CLI, templates, package hive, and bundle payload, use [`localhive`](#creating-a-local-aspire-build-with-localhive) instead.
 
@@ -173,7 +192,7 @@ Or edit the `NuGet.config` file and add this line to the `<packageSources>` list
 <add key="aspire-dev" value="my_aspire_folder/artifacts/packages/Debug/Shipping" />
 ```
 
-## Creating a local Aspire build with `localhive`
+### Creating a local Aspire build with `localhive`
 
 Use `localhive` when you want a fully usable Aspire product from your local source tree, not just a folder of NuGet packages. The script builds and packs the Aspire packages, creates an Aspire hive, builds the bundle payload, and installs a locally-built Aspire CLI. The CLI then discovers the hive as a channel, so commands like `aspire new`, `aspire add`, and `aspire init` use the packages produced by your custom build.
 

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -121,7 +121,7 @@ The Aspire VS Code extension lives under `extension/`. To build the extension th
 
 ```bash
 ./build.sh --build-extension  # macOS/Linux
-.\build.cmd --build-extension # Windows
+.\build.cmd /p:BuildExtension=true # Windows
 ```
 
 This runs the `extension/Extension.proj` build, installs extension dependencies with the checked-in `yarn.lock`, compiles the extension, and creates the VSIX artifacts under `artifacts/packages/Debug/vscode`.

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -16,6 +16,10 @@ These instructions will get you ready to contribute to this project. If you just
   - [Quarantined and outerloop tests](#quarantined-and-outerloop-tests)
   - [Testing pull request changes](#testing-pull-request-changes)
 - [Contributing with AI assistance](#contributing-with-ai-assistance)
+  - [`code-review`](#code-review)
+  - [`pr-testing`](#pr-testing)
+  - [`cli-e2e-testing`](#cli-e2e-testing)
+  - [`ci-test-failures`](#ci-test-failures)
 - [Development environments](#development-environments)
   - [Using VS Code](#using-vs-code)
   - [Building the VS Code extension](#building-the-vs-code-extension)
@@ -104,11 +108,23 @@ Aspire uses GitHub Copilot automatic code review on pull requests. We expect Cop
 
 The Aspire repository also includes custom Copilot skills that team members and automation may run on PRs, even when the PR author is not using an AI coding agent. Contributors can get a head start by running the key skills before requesting review:
 
-- [`code-review`](/.github/skills/code-review/SKILL.md) reviews a PR for high-confidence problems only, such as bugs, security issues, correctness errors, performance regressions, missing boundary error handling, concurrency or resource issues, flaky test patterns, and repository convention violations. It avoids style nits and duplicate review comments.
-- [`pr-testing`](/.github/skills/pr-testing/SKILL.md) installs the Aspire CLI and packages from a PR's dogfood build, verifies the installed CLI matches the PR head commit, analyzes changed areas, proposes targeted happy-path and negative test scenarios, runs the selected scenarios locally or in the repo container runner, captures evidence, and can produce a PR testing report.
-- [`cli-e2e-testing`](/.github/skills/cli-e2e-testing/SKILL.md) guides Aspire CLI end-to-end test authoring and debugging with Hex1b terminal automation. It covers test structure, local `localhive` archive workflows, Docker-based execution, install modes, prompt detection, and asciinema recordings for failures.
+### [`code-review`](/.github/skills/code-review/SKILL.md)
 
-Other repo skills can help with specialized work, but these are the main skills the Aspire team uses to evaluate PR quality, dogfoodability, and CLI end-to-end coverage.
+Reviews a PR for high-confidence problems only, such as bugs, security issues, correctness errors, performance regressions, missing boundary error handling, concurrency or resource issues, flaky test patterns, and repository convention violations. It avoids style nits and duplicate review comments.
+
+### [`pr-testing`](/.github/skills/pr-testing/SKILL.md)
+
+Installs the Aspire CLI and packages from a PR's dogfood build, verifies the installed CLI matches the PR head commit, analyzes changed areas, proposes targeted happy-path and negative test scenarios, runs the selected scenarios locally or in the repo container runner, captures evidence, and can produce a PR testing report.
+
+### [`cli-e2e-testing`](/.github/skills/cli-e2e-testing/SKILL.md)
+
+Guides Aspire CLI end-to-end test authoring and debugging with Hex1b terminal automation. It covers test structure, local `localhive` archive workflows, Docker-based execution, install modes, prompt detection, and asciinema recordings for failures.
+
+### [`ci-test-failures`](/.github/skills/ci-test-failures/SKILL.md)
+
+Guides GitHub Actions test-failure diagnosis. It covers downloading failed job logs and artifacts, extracting failed tests from runs, investigating failures without filing issues, and creating or updating failing-test issues with the repo tooling.
+
+Other repo skills can help with specialized work, but these are the main skills the Aspire team uses to evaluate PR quality, dogfoodability, CLI end-to-end coverage, and CI test failures.
 
 ## Development environments
 

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -22,12 +22,12 @@ These instructions will get you ready to contribute to this project. If you just
   - [`ci-test-failures`](#ci-test-failures)
 - [Development environments](#development-environments)
   - [Using VS Code](#using-vs-code)
-  - [Building the VS Code extension](#building-the-vs-code-extension)
-  - [Using Visual Studio](#using-visual-studio)
-- [Area-specific guidance](#area-specific-guidance)
-  - [Localization](#localization)
-  - [Integrations](#integrations)
-  - [Native build](#native-build)
+    - [Using Visual Studio](#using-visual-studio)
+  - [Area-specific guidance](#area-specific-guidance)
+    - [Localization](#localization)
+    - [Integrations](#integrations)
+    - [Native build](#native-build)
+    - [Building the VS Code extension](#building-the-vs-code-extension)
 - [Trying your changes locally](#trying-your-changes-locally)
   - [Generating local NuGet packages](#generating-local-nuget-packages)
   - [Creating a local Aspire build with `localhive`](#creating-a-local-aspire-build-with-localhive)
@@ -132,27 +132,6 @@ Other repo skills can help with specialized work, but these are the main skills 
 
 Make sure you [build the repo](#build-the-repo) from command line at least once. Then use `./start-code.sh` (macOS and Linux) or `.\start-code.cmd` to start VS Code.
 
-### Building the VS Code extension
-
-The Aspire VS Code extension lives under `extension/`. To build the extension through the repo build, make sure Node.js, yarn, and `vsce` are on your PATH, then run:
-
-```bash
-./build.sh --build-extension  # macOS/Linux
-.\build.cmd /p:BuildExtension=true # Windows
-```
-
-This runs the `extension/Extension.proj` build, installs extension dependencies with the checked-in `yarn.lock`, compiles the extension, and creates the VSIX artifacts under `artifacts/packages/Debug/vscode`.
-
-For extension inner-loop development, you can work directly in the extension folder:
-
-```bash
-cd extension
-yarn install --frozen-lockfile --non-interactive
-yarn compile
-```
-
-Use `yarn watch` while editing TypeScript. When adding or changing user-facing extension text, keep the strings localized in both `extension/package.nls.json` and `extension/src/loc/strings.ts`. For VSIX signing and release packaging details, see [extension-signing.md](/docs/extension-signing.md).
-
 ### Using Visual Studio
 
 Make sure you [build the repo](#build-the-repo) from command line at least once using `.\build.cmd` (Windows). Then use `.\startvs.cmd` to start Visual Studio with the correct environment setup.
@@ -187,6 +166,27 @@ The default build includes native builds for `Aspire.Cli` which produces Native 
 By default it builds the CLI native project for the current Runtime Identifier. Specific RIDs can be specified by setting `$(TargetRids)` to a colon separated list like `/p:TargetRids=osx-x64:osx-arm64`.
 
 Native build can be disabled with `/p:SkipNativeBuild=true`. To build only the native bits, use `/p:SkipManagedBuild=true`.
+
+### Building the VS Code extension
+
+The Aspire VS Code extension lives under `extension/`. To build the extension through the repo build, make sure Node.js, yarn, and `vsce` are on your PATH, then run:
+
+```bash
+./build.sh --build-extension  # macOS/Linux
+.\build.cmd /p:BuildExtension=true # Windows
+```
+
+This runs the `extension/Extension.proj` build, installs extension dependencies with the checked-in `yarn.lock`, compiles the extension, and creates the VSIX artifacts under `artifacts/packages/Debug/vscode`.
+
+For extension inner-loop development, you can work directly in the extension folder:
+
+```bash
+cd extension
+yarn install --frozen-lockfile --non-interactive
+yarn compile
+```
+
+Use `yarn watch` while editing TypeScript. When adding or changing user-facing extension text, keep the strings localized in both `extension/package.nls.json` and `extension/src/loc/strings.ts`. For VSIX signing and release packaging details, see [extension-signing.md](/docs/extension-signing.md).
 
 ## Trying your changes locally
 

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -2,16 +2,36 @@
 
 These instructions will get you ready to contribute to this project. If you just want to use Aspire, see [using-latest-daily.md](/docs/using-latest-daily.md).
 
+## Contents
+
+- [Prepare the machine](#prepare-the-machine)
+- [Build the repo](#build-the-repo)
+- [Using the `dotnet` CLI](#using-the-dotnet-cli)
+- [Run TestShop](#run-testshop)
+- [Using VS Code](#using-vs-code)
+- [Building the VS Code extension](#building-the-vs-code-extension)
+- [Using Visual Studio](#using-visual-studio)
+- [Native build](#native-build)
+- [View Dashboard](#view-dashboard)
+- [Localization](#localization)
+- [Testing](#testing)
+- [Contributing with AI assistance](#contributing-with-ai-assistance)
+- [Integrations](#integrations)
+- [Generating local NuGet packages](#generating-local-nuget-packages)
+- [Creating a local Aspire build with `localhive`](#creating-a-local-aspire-build-with-localhive)
+- [Tips and known issues](#tips-and-known-issues)
+
 ## Prepare the machine
 
 See [machine-requirements.md](/docs/machine-requirements.md).
+
 ## Build the repo
 
-`./build.sh` (macOS and Linux) or `.\build.cmd` (Windows)
+First run `./restore.sh` (macOS and Linux) or `.\restore.cmd` (Windows) to install the repo-local .NET SDK. Then build with `./build.sh` (macOS and Linux) or `.\build.cmd` (Windows).
 
 ## Using the `dotnet` CLI
 
-In building and testing, never use the global `dotnet` copy. Use `./dotnet.sh` on Unix, `.\dotnet.cmd` on Windows.
+After restore, `dotnet` commands run from this repo use the repo-local SDK because `global.json` includes `.dotnet` in the SDK search path. Use `./dotnet.sh` on Unix or `.\dotnet.cmd` on Windows when you need to force the repo-local SDK explicitly.
 
 ## Run TestShop
 
@@ -20,7 +40,6 @@ This will confirm that you're all set up.
 In your shell or in VS Code:
 
 ```shell
-# Replace "dotnet" with "./dotnet.sh" or ".\dotnet.cmd", as appropriate
 dotnet restore playground/TestShop/TestShop.AppHost/TestShop.AppHost.csproj
 dotnet run --project playground/TestShop/TestShop.AppHost/TestShop.AppHost.csproj
 ```
@@ -28,12 +47,33 @@ dotnet run --project playground/TestShop/TestShop.AppHost/TestShop.AppHost.cspro
 Or, if you are using Visual Studio:
 
 1. Open `Aspire.slnx`
-1. Set the Startup Project to be the `AppHost` project (it's under `\playground\TestShop`). Make sure the launch profile is set to "http".
-1. <kbd>F5</kbd> to debug, or <kbd>Ctrl+F5</kbd> to launch without debugging.
+2. Set the Startup Project to be the `AppHost` project (it's under `\playground\TestShop`). Make sure the launch profile is set to "http".
+3. <kbd>F5</kbd> to debug, or <kbd>Ctrl+F5</kbd> to launch without debugging.
 
 ## Using VS Code
 
 Make sure you [build the repo](#build-the-repo) from command line at least once. Then use `./start-code.sh` (macOS and Linux) or `.\start-code.cmd` to start VS Code.
+
+## Building the VS Code extension
+
+The Aspire VS Code extension lives under `extension/`. To build the extension through the repo build, make sure Node.js, yarn, and `vsce` are on your PATH, then run:
+
+```bash
+./build.sh --build-extension  # macOS/Linux
+.\build.cmd --build-extension # Windows
+```
+
+This runs the `extension/Extension.proj` build, installs extension dependencies with the checked-in `yarn.lock`, compiles the extension, and creates the VSIX artifacts under `artifacts/packages/Debug/vscode`.
+
+For extension inner-loop development, you can work directly in the extension folder:
+
+```bash
+cd extension
+yarn install --frozen-lockfile --non-interactive
+yarn compile
+```
+
+Use `yarn watch` while editing TypeScript. When adding or changing user-facing extension text, keep the strings localized in both `extension/package.nls.json` and `extension/src/loc/strings.ts`. For VSIX signing and release packaging details, see [extension-signing.md](/docs/extension-signing.md).
 
 ## Using Visual Studio
 
@@ -43,9 +83,9 @@ Make sure you [build the repo](#build-the-repo) from command line at least once 
 
 The default build includes native builds for `Aspire.Cli` which produces Native AOT binaries for some platforms. These projects are in `eng/clipack/Aspire.Cli.*`.
 
-By default it builds the cli native project for the current Runtime Identifier. A specific RIDs can be specified too by setting `$(TargetRids)` to a colon separated list like `/p:TargetRids=osx-x64:osx-arm64`.
+By default it builds the CLI native project for the current Runtime Identifier. Specific RIDs can be specified by setting `$(TargetRids)` to a colon separated list like `/p:TargetRids=osx-x64:osx-arm64`.
 
-Native build can be disabled with `/p:SkipNativeBuild=true`. And to only the native bits use `/p:SkipManagedBuild=true`.
+Native build can be disabled with `/p:SkipNativeBuild=true`. To build only the native bits, use `/p:SkipManagedBuild=true`.
 
 ## View Dashboard
 
@@ -56,7 +96,7 @@ Otherwise if you are using the command line, when you have the Aspire app runnin
 ## Localization
 
 If you are contributing to Aspire.Dashboard, please ensure that all strings are localized. If necessary,
-create a new resx file under `Aspire.Dashboard\Resources`. To reference a string, ensure the `IStringLocalizer` for the resx file is
+create a new resx file under `src/Aspire.Dashboard/Resources`. To reference a string, ensure the `IStringLocalizer` for the resx file is
 injected. An example is below:
 
 ```xml
@@ -68,6 +108,8 @@ injected. An example is below:
 Note that injection doesn't happen until a component's `OnInitialized`, so if you are referencing a string from codebehind, you must wait to do that
 until `OnInitialized`.
 
+The `*.Designer.cs` files are checked in with the matching `*.resx` files. If you add, remove, or rename resources, update the matching designer file too. If the project has an `xlf` directory, run `dotnet build /t:UpdateXlf <path-to-project.csproj>` to update localization files instead of editing `*.xlf` files manually.
+
 ## Testing
 
 ### Running Tests
@@ -76,40 +118,52 @@ To run tests, use the build script:
 
 ```bash
 ./build.sh --test  # Linux/macOS
-./build.cmd -test # Windows
+.\build.cmd --test # Windows
 ```
 
 ### Quarantined Tests
 
 Flaky tests may be marked as quarantined to prevent them from blocking CI while being investigated and fixed. See [quarantined-tests.md](/docs/quarantined-tests.md) for more information on working with quarantined tests.
 
-When running tests locally or in automated environments, use the quarantine filter to exclude known flaky tests:
+Long-running or resource-intensive tests may be marked as outerloop. See [outerloop-tests.md](/docs/outerloop-tests.md) for more information.
+
+When running tests locally or in automated environments, use the test filters to exclude known flaky and outerloop tests:
 
 ```bash
-# Replace "dotnet" with "./dotnet.sh" or ".\dotnet.cmd", as appropriate
-dotnet test --filter-not-trait "quarantined=true"
+dotnet test --no-launch-profile -- \
+  --filter-not-trait "quarantined=true" \
+  --filter-not-trait "outerloop=true"
 ```
 
 ### Testing Pull Request Changes
 
 To test changes from a specific pull request locally, see [dogfooding-pull-requests.md](/docs/dogfooding-pull-requests.md) for instructions on installing Aspire CLI and NuGet packages built by that PR's CI run.
 
-## Integrations (Formerly Components)
+## Contributing with AI assistance
+
+Aspire uses GitHub Copilot automatic code review on pull requests. We expect Copilot review comments to be reviewed and addressed before merging, either by making the requested change or by explaining why a suggested change is not needed.
+
+The Aspire repository also includes custom Copilot skills that team members and automation may run on PRs, even when the PR author is not using an AI coding agent. Contributors can get a head start by running the key skills before requesting review:
+
+- [`code-review`](/.github/skills/code-review/SKILL.md) reviews a PR for high-confidence problems only, such as bugs, security issues, correctness errors, performance regressions, missing boundary error handling, concurrency or resource issues, flaky test patterns, and repository convention violations. It avoids style nits and duplicate review comments.
+- [`pr-testing`](/.github/skills/pr-testing/SKILL.md) installs the Aspire CLI and packages from a PR's dogfood build, verifies the installed CLI matches the PR head commit, analyzes changed areas, proposes targeted happy-path and negative test scenarios, runs the selected scenarios locally or in the repo container runner, captures evidence, and can produce a PR testing report.
+
+Other repo skills can help with specialized work, but these two are the main skills the Aspire team uses to evaluate PR quality and dogfoodability.
+
+## Integrations
 
 Please check the [Aspire integrations contribution guidelines](/src/Components/README.md) if you intend to make contributions to a new or existing Aspire integration.
 
 ## Generating local NuGet packages
 
-If you want to try local changes on a separate Aspire based project or solution it can be useful to generate the NuGet packages
-in a local folder and use it as a package source.
+If you only need package outputs, it can be useful to generate the NuGet packages in a local folder and use it as a package source from a separate Aspire-based project or solution. If you want to validate a complete locally-built Aspire product, including the CLI, templates, package hive, and bundle payload, use [`localhive`](#creating-a-local-aspire-build-with-localhive) instead.
 
 To do so simply execute:
-`./build.sh -pack` (macOS and Linux) or `.\build.cmd -pack` (Windows)
+`./build.sh --pack` (macOS and Linux) or `.\build.cmd --pack` (Windows)
 
 This will generate all the packages in the folder `./artifacts/packages/Debug/Shipping`. At this point from your solution folder run:
 
 ```shell
-# Replace "dotnet" with "./dotnet.sh" or ".\dotnet.cmd", as appropriate
 dotnet nuget add source my_aspire_folder/artifacts/packages/Debug/Shipping
 ```
 
@@ -118,6 +172,40 @@ Or edit the `NuGet.config` file and add this line to the `<packageSources>` list
 ```xml
 <add key="aspire-dev" value="my_aspire_folder/artifacts/packages/Debug/Shipping" />
 ```
+
+## Creating a local Aspire build with `localhive`
+
+Use `localhive` when you want a fully usable Aspire product from your local source tree, not just a folder of NuGet packages. The script builds and packs the Aspire packages, creates an Aspire hive, builds the bundle payload, and installs a locally-built Aspire CLI. The CLI then discovers the hive as a channel, so commands like `aspire new`, `aspire add`, and `aspire init` use the packages produced by your custom build.
+
+Prefer using an explicit output directory so your custom build stays isolated and does not overwrite the default Aspire install under `$HOME/.aspire`:
+
+```bash
+./localhive.sh -c Release -n my-feature -o ./artifacts/localhive/my-feature
+export PATH="$PWD/artifacts/localhive/my-feature/bin:$PATH"
+aspire --version
+```
+
+On Windows:
+
+```powershell
+.\localhive.ps1 -c Release -n my-feature -o .\artifacts\localhive\my-feature
+$env:PATH = "$(Resolve-Path .\artifacts\localhive\my-feature\bin);$env:PATH"
+aspire --version
+```
+
+To create a standalone portable build that can be copied to another machine, add a target RID and the archive flag:
+
+```bash
+./localhive.sh -c Release -n my-feature -o ./artifacts/localhive/linux-x64 -r linux-x64 --archive
+```
+
+On Windows:
+
+```powershell
+.\localhive.ps1 -c Release -n my-feature -o .\artifacts\localhive\win-x64 -r win-x64 -Archive
+```
+
+The archive contains the CLI, local package hive, and bundle payload needed for that build. After extracting it on the target machine, run the `aspire` binary from the extracted `bin` directory.
 
 ## Tips and known issues
 
@@ -132,7 +220,7 @@ See the [tips and known issues](/docs/tips-and-known-issues.md) page.
 When creating a new integration, package validation will automatically try to download a previous version of the package to ensure you didn't break compat. As a result you might get the following build error:
 
 ```shell
-error NU1101: Unable to find package [NEW PACKAGE NAME]. No packages exist with this id in source(s): dotnet-eng, dotnet-public, dotnet9, dotnet9-transport. PackageSourceMapping is enabled, the following source(s) were not considered: dotnet-libraries.
+error NU1101: Unable to find package [NEW PACKAGE NAME]. No packages exist with this id in source(s): dotnet-eng, dotnet-public, dotnet9, dotnet10, dotnet9-transport. PackageSourceMapping is enabled, the following source(s) were not considered: dotnet-libraries.
 ```
 
 To prevent this the new package needs this line to be added to the `.csproj`:

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -22,12 +22,12 @@ These instructions will get you ready to contribute to this project. If you just
   - [`ci-test-failures`](#ci-test-failures)
 - [Development environments](#development-environments)
   - [Using VS Code](#using-vs-code)
-    - [Using Visual Studio](#using-visual-studio)
-  - [Area-specific guidance](#area-specific-guidance)
-    - [Localization](#localization)
-    - [Integrations](#integrations)
-    - [Native build](#native-build)
-    - [Building the VS Code extension](#building-the-vs-code-extension)
+  - [Using Visual Studio](#using-visual-studio)
+- [Area-specific guidance](#area-specific-guidance)
+  - [Localization](#localization)
+  - [Integrations](#integrations)
+  - [Native build](#native-build)
+  - [Building the VS Code extension](#building-the-vs-code-extension)
 - [Trying your changes locally](#trying-your-changes-locally)
   - [Generating local NuGet packages](#generating-local-nuget-packages)
   - [Creating a local Aspire build with `localhive`](#creating-a-local-aspire-build-with-localhive)
@@ -107,6 +107,9 @@ To test changes from a specific pull request locally, see [dogfooding-pull-reque
 Aspire uses GitHub Copilot automatic code review on pull requests. We expect Copilot review comments to be reviewed and addressed before merging, either by making the requested change or by explaining why a suggested change is not needed.
 
 The Aspire repository also includes custom Copilot skills that team members and automation may run on PRs, even when the PR author is not using an AI coding agent. Contributors can get a head start by running the key skills before requesting review:
+
+> [!NOTE]
+> AI-based code review and end-to-end testing can help find issues earlier, but they are not a replacement for human review and manual testing. Contributors are still responsible for understanding their changes and verifying the scenarios they affect.
 
 ### [`code-review`](/.github/skills/code-review/SKILL.md)
 


### PR DESCRIPTION
## Description

This updates the contribution guide so contributors have current setup, testing, extension, local build, and AI-assisted contribution guidance in one place.

Summary:
- Adds a table of contents for the guide.
- Updates restore and local .NET SDK guidance to match the current `global.json` behavior.
- Documents how to build and iterate on the VS Code extension, including localization expectations.
- Clarifies Dashboard localization, test filters for quarantined and outerloop tests, and package-only validation.
- Adds guidance for using `localhive` to create an isolated, fully usable local Aspire build without overwriting the default install.
- Adds AI-assisted contribution expectations for Copilot automatic reviews and the key `code-review` and `pr-testing` skills.
- Refreshes stale build, package, and feed examples.

Validation: docs-only change; checked the markdown diff for formatting issues.

Fixes # (issue)

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [x] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No