### PR TITLE
Friendly error for 'aspire do --list-steps' without a step

### DIFF
--- a/src/Aspire.Cli/Commands/DoCommand.cs
+++ b/src/Aspire.Cli/Commands/DoCommand.cs
@@ -35,9 +35,24 @@ internal sealed class DoCommand : PipelineCommandBase
         {
             var step = result.GetValue(_stepArgument);
             var listSteps = result.GetValue(s_listStepsOption);
-            if (string.IsNullOrEmpty(step) && !listSteps && !ExtensionHelper.IsExtensionHost(interactionService, out _, out _))
+            if (string.IsNullOrEmpty(step) && !ExtensionHelper.IsExtensionHost(interactionService, out _, out _))
             {
-                result.AddError("The 'step' argument is required when not using --list-steps.");
+                if (listSteps)
+                {
+                    // `aspire do --list-steps` with no step has no meaningful scope: the listing for
+                    // `do` is always relative to a target step. Surface a friendly error pointing at
+                    // concrete well-known step names rather than launching the AppHost and crashing
+                    // mid-pipeline (see https://github.com/microsoft/aspire/issues/17526).
+                    result.AddError(string.Format(
+                        System.Globalization.CultureInfo.CurrentCulture,
+                        DoCommandStrings.ListStepsRequiresStep,
+                        "deploy",
+                        "publish"));
+                }
+                else
+                {
+                    result.AddError(DoCommandStrings.StepArgumentRequired);
+                }
             }
         });
     }

--- a/src/Aspire.Cli/Commands/DoCommand.cs
+++ b/src/Aspire.Cli/Commands/DoCommand.cs
@@ -21,6 +21,30 @@ internal sealed class DoCommand : PipelineCommandBase
 
     private readonly Argument<string> _stepArgument;
 
+    // Mirror of Aspire.Hosting.Pipelines.WellKnownPipelineSteps used only for the friendly
+    // validation message when `aspire do --list-steps` is invoked without a step. The CLI
+    // does not reference Aspire.Hosting, so this list is hand-maintained; keep in sync with
+    // src/Aspire.Hosting/Pipelines/WellKnownPipelineSteps.cs. Sorted alphabetically so the
+    // rendered error is easy to scan.
+    private static readonly string[] s_wellKnownStepNames =
+    [
+        "before-start",
+        "build",
+        "build-prereq",
+        "check-container-runtime",
+        "deploy",
+        "deploy-prereq",
+        "destroy",
+        "destroy-prereq",
+        "diagnostics",
+        "process-parameters",
+        "publish",
+        "publish-prereq",
+        "push",
+        "push-prereq",
+        "validate-compute-environments"
+    ];
+
     public DoCommand(IDotNetCliRunner runner, IInteractionService interactionService, IProjectLocator projectLocator, AspireCliTelemetry telemetry, IFeatures features, ICliUpdateNotifier updateNotifier, CliExecutionContext executionContext, ICliHostEnvironment hostEnvironment, IAppHostProjectFactory projectFactory, IConfiguration configuration, ILogger<DoCommand> logger, IAnsiConsole ansiConsole)
         : base("do", DoCommandStrings.Description, runner, interactionService, projectLocator, telemetry, features, updateNotifier, executionContext, hostEnvironment, projectFactory, configuration, logger, ansiConsole)
     {
@@ -46,8 +70,7 @@ internal sealed class DoCommand : PipelineCommandBase
                     result.AddError(string.Format(
                         System.Globalization.CultureInfo.CurrentCulture,
                         DoCommandStrings.ListStepsRequiresStep,
-                        "deploy",
-                        "publish"));
+                        string.Join(", ", s_wellKnownStepNames)));
                 }
                 else
                 {

--- a/src/Aspire.Cli/Commands/DoCommand.cs
+++ b/src/Aspire.Cli/Commands/DoCommand.cs
@@ -35,20 +35,29 @@ internal sealed class DoCommand : PipelineCommandBase
         {
             var step = result.GetValue(_stepArgument);
             var listSteps = result.GetValue(s_listStepsOption);
-            if (string.IsNullOrEmpty(step) && !ExtensionHelper.IsExtensionHost(interactionService, out _, out _))
+            if (!string.IsNullOrEmpty(step))
             {
-                if (listSteps)
-                {
-                    // `aspire do --list-steps` with no step has no meaningful scope: the listing for
-                    // `do` is always relative to a target step. Surface a friendly error pointing at
-                    // common starting steps and the docs rather than launching the AppHost and
-                    // crashing mid-pipeline (see https://github.com/microsoft/aspire/issues/17526).
-                    result.AddError(DoCommandStrings.ListStepsRequiresStep);
-                }
-                else
-                {
-                    result.AddError(DoCommandStrings.StepArgumentRequired);
-                }
+                return;
+            }
+
+            if (listSteps)
+            {
+                // `aspire do --list-steps` with no step has no meaningful scope: the listing for
+                // `do` is always relative to a target step. Surface a friendly error pointing at
+                // common starting steps and the docs rather than launching the AppHost and
+                // crashing mid-pipeline (see https://github.com/microsoft/aspire/issues/17526).
+                // This applies in the extension host too because `--list-steps` does not flow
+                // through the interactive step prompt in GetRunArgumentsAsync, so without this
+                // error the extension would still hit the original crash path.
+                result.AddError(DoCommandStrings.ListStepsRequiresStep);
+                return;
+            }
+
+            // For a plain `aspire do` invocation, the extension host prompts the user for a step
+            // later in GetRunArgumentsAsync, so don't add a validation error there.
+            if (!ExtensionHelper.IsExtensionHost(interactionService, out _, out _))
+            {
+                result.AddError(DoCommandStrings.StepArgumentRequired);
             }
         });
     }

--- a/src/Aspire.Cli/Commands/DoCommand.cs
+++ b/src/Aspire.Cli/Commands/DoCommand.cs
@@ -21,30 +21,6 @@ internal sealed class DoCommand : PipelineCommandBase
 
     private readonly Argument<string> _stepArgument;
 
-    // Mirror of Aspire.Hosting.Pipelines.WellKnownPipelineSteps used only for the friendly
-    // validation message when `aspire do --list-steps` is invoked without a step. The CLI
-    // does not reference Aspire.Hosting, so this list is hand-maintained; keep in sync with
-    // src/Aspire.Hosting/Pipelines/WellKnownPipelineSteps.cs. Sorted alphabetically so the
-    // rendered error is easy to scan.
-    private static readonly string[] s_wellKnownStepNames =
-    [
-        "before-start",
-        "build",
-        "build-prereq",
-        "check-container-runtime",
-        "deploy",
-        "deploy-prereq",
-        "destroy",
-        "destroy-prereq",
-        "diagnostics",
-        "process-parameters",
-        "publish",
-        "publish-prereq",
-        "push",
-        "push-prereq",
-        "validate-compute-environments"
-    ];
-
     public DoCommand(IDotNetCliRunner runner, IInteractionService interactionService, IProjectLocator projectLocator, AspireCliTelemetry telemetry, IFeatures features, ICliUpdateNotifier updateNotifier, CliExecutionContext executionContext, ICliHostEnvironment hostEnvironment, IAppHostProjectFactory projectFactory, IConfiguration configuration, ILogger<DoCommand> logger, IAnsiConsole ansiConsole)
         : base("do", DoCommandStrings.Description, runner, interactionService, projectLocator, telemetry, features, updateNotifier, executionContext, hostEnvironment, projectFactory, configuration, logger, ansiConsole)
     {
@@ -65,12 +41,9 @@ internal sealed class DoCommand : PipelineCommandBase
                 {
                     // `aspire do --list-steps` with no step has no meaningful scope: the listing for
                     // `do` is always relative to a target step. Surface a friendly error pointing at
-                    // concrete well-known step names rather than launching the AppHost and crashing
-                    // mid-pipeline (see https://github.com/microsoft/aspire/issues/17526).
-                    result.AddError(string.Format(
-                        System.Globalization.CultureInfo.CurrentCulture,
-                        DoCommandStrings.ListStepsRequiresStep,
-                        string.Join(", ", s_wellKnownStepNames)));
+                    // common starting steps and the docs rather than launching the AppHost and
+                    // crashing mid-pipeline (see https://github.com/microsoft/aspire/issues/17526).
+                    result.AddError(DoCommandStrings.ListStepsRequiresStep);
                 }
                 else
                 {

--- a/src/Aspire.Cli/Resources/DoCommandStrings.Designer.cs
+++ b/src/Aspire.Cli/Resources/DoCommandStrings.Designer.cs
@@ -122,5 +122,23 @@ namespace Aspire.Cli.Resources {
                 return ResourceManager.GetString("StepArgumentDescription", resourceCulture);
             }
         }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The &apos;step&apos; argument is required..
+        /// </summary>
+        public static string StepArgumentRequired {
+            get {
+                return ResourceManager.GetString("StepArgumentRequired", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The &apos;step&apos; argument is required when using --list-steps. Specify the step you want to inspect, for example: &apos;aspire do {0} --list-steps&apos; or &apos;aspire do {1} --list-steps&apos;..
+        /// </summary>
+        public static string ListStepsRequiresStep {
+            get {
+                return ResourceManager.GetString("ListStepsRequiresStep", resourceCulture);
+            }
+        }
     }
 }

--- a/src/Aspire.Cli/Resources/DoCommandStrings.Designer.cs
+++ b/src/Aspire.Cli/Resources/DoCommandStrings.Designer.cs
@@ -133,7 +133,7 @@ namespace Aspire.Cli.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to The &apos;step&apos; argument is required when using --list-steps. Specify the step you want to inspect, for example: &apos;aspire do {0} --list-steps&apos; or &apos;aspire do {1} --list-steps&apos;..
+        ///   Looks up a localized string similar to The &apos;step&apos; argument is required when using --list-steps. Example: &apos;aspire do deploy --list-steps&apos;. Well-known step names include: {0}..
         /// </summary>
         public static string ListStepsRequiresStep {
             get {

--- a/src/Aspire.Cli/Resources/DoCommandStrings.Designer.cs
+++ b/src/Aspire.Cli/Resources/DoCommandStrings.Designer.cs
@@ -133,7 +133,7 @@ namespace Aspire.Cli.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to The &apos;step&apos; argument is required when using --list-steps. Example: &apos;aspire do deploy --list-steps&apos;. Well-known step names include: {0}..
+        ///   Looks up a localized string similar to The &apos;step&apos; argument is required when using --list-steps. Example: &apos;aspire do deploy --list-steps&apos;. Common starting steps are &apos;build&apos;, &apos;publish&apos; and &apos;deploy&apos;. See https://aspire.dev/reference/cli/commands/aspire-do/ for the full list of pipeline steps..
         /// </summary>
         public static string ListStepsRequiresStep {
             get {

--- a/src/Aspire.Cli/Resources/DoCommandStrings.resx
+++ b/src/Aspire.Cli/Resources/DoCommandStrings.resx
@@ -142,7 +142,6 @@
     <value>The 'step' argument is required.</value>
   </data>
   <data name="ListStepsRequiresStep" xml:space="preserve">
-    <value>The 'step' argument is required when using --list-steps. Example: 'aspire do deploy --list-steps'. Well-known step names include: {0}.</value>
-    <comment>{0} is a comma-separated list of well-known pipeline step names.</comment>
+    <value>The 'step' argument is required when using --list-steps. Example: 'aspire do deploy --list-steps'. Common starting steps are 'build', 'publish' and 'deploy'. See https://aspire.dev/reference/cli/commands/aspire-do/ for the full list of pipeline steps.</value>
   </data>
 </root>

--- a/src/Aspire.Cli/Resources/DoCommandStrings.resx
+++ b/src/Aspire.Cli/Resources/DoCommandStrings.resx
@@ -138,4 +138,11 @@
   <data name="StepArgumentDescription" xml:space="preserve">
     <value>The name of the step to execute</value>
   </data>
+  <data name="StepArgumentRequired" xml:space="preserve">
+    <value>The 'step' argument is required.</value>
+  </data>
+  <data name="ListStepsRequiresStep" xml:space="preserve">
+    <value>The 'step' argument is required when using --list-steps. Specify the step you want to inspect, for example: 'aspire do {0} --list-steps' or 'aspire do {1} --list-steps'.</value>
+    <comment>{0} and {1} are well-known pipeline step names such as 'deploy' and 'publish'.</comment>
+  </data>
 </root>

--- a/src/Aspire.Cli/Resources/DoCommandStrings.resx
+++ b/src/Aspire.Cli/Resources/DoCommandStrings.resx
@@ -142,7 +142,7 @@
     <value>The 'step' argument is required.</value>
   </data>
   <data name="ListStepsRequiresStep" xml:space="preserve">
-    <value>The 'step' argument is required when using --list-steps. Specify the step you want to inspect, for example: 'aspire do {0} --list-steps' or 'aspire do {1} --list-steps'.</value>
-    <comment>{0} and {1} are well-known pipeline step names such as 'deploy' and 'publish'.</comment>
+    <value>The 'step' argument is required when using --list-steps. Example: 'aspire do deploy --list-steps'. Well-known step names include: {0}.</value>
+    <comment>{0} is a comma-separated list of well-known pipeline step names.</comment>
   </data>
 </root>

--- a/src/Aspire.Cli/Resources/xlf/DoCommandStrings.cs.xlf
+++ b/src/Aspire.Cli/Resources/xlf/DoCommandStrings.cs.xlf
@@ -13,9 +13,9 @@
         <note />
       </trans-unit>
       <trans-unit id="ListStepsRequiresStep">
-        <source>The 'step' argument is required when using --list-steps. Example: 'aspire do deploy --list-steps'. Well-known step names include: {0}.</source>
-        <target state="new">The 'step' argument is required when using --list-steps. Example: 'aspire do deploy --list-steps'. Well-known step names include: {0}.</target>
-        <note>{0} is a comma-separated list of well-known pipeline step names.</note>
+        <source>The 'step' argument is required when using --list-steps. Example: 'aspire do deploy --list-steps'. Common starting steps are 'build', 'publish' and 'deploy'. See https://aspire.dev/reference/cli/commands/aspire-do/ for the full list of pipeline steps.</source>
+        <target state="new">The 'step' argument is required when using --list-steps. Example: 'aspire do deploy --list-steps'. Common starting steps are 'build', 'publish' and 'deploy'. See https://aspire.dev/reference/cli/commands/aspire-do/ for the full list of pipeline steps.</target>
+        <note />
       </trans-unit>
       <trans-unit id="OperationCanceled">
         <source>The operation was canceled.</source>

--- a/src/Aspire.Cli/Resources/xlf/DoCommandStrings.cs.xlf
+++ b/src/Aspire.Cli/Resources/xlf/DoCommandStrings.cs.xlf
@@ -13,9 +13,9 @@
         <note />
       </trans-unit>
       <trans-unit id="ListStepsRequiresStep">
-        <source>The 'step' argument is required when using --list-steps. Specify the step you want to inspect, for example: 'aspire do {0} --list-steps' or 'aspire do {1} --list-steps'.</source>
-        <target state="new">The 'step' argument is required when using --list-steps. Specify the step you want to inspect, for example: 'aspire do {0} --list-steps' or 'aspire do {1} --list-steps'.</target>
-        <note>{0} and {1} are well-known pipeline step names such as 'deploy' and 'publish'.</note>
+        <source>The 'step' argument is required when using --list-steps. Example: 'aspire do deploy --list-steps'. Well-known step names include: {0}.</source>
+        <target state="new">The 'step' argument is required when using --list-steps. Example: 'aspire do deploy --list-steps'. Well-known step names include: {0}.</target>
+        <note>{0} is a comma-separated list of well-known pipeline step names.</note>
       </trans-unit>
       <trans-unit id="OperationCanceled">
         <source>The operation was canceled.</source>

--- a/src/Aspire.Cli/Resources/xlf/DoCommandStrings.cs.xlf
+++ b/src/Aspire.Cli/Resources/xlf/DoCommandStrings.cs.xlf
@@ -12,6 +12,11 @@
         <target state="translated">Provádí se kanál...</target>
         <note />
       </trans-unit>
+      <trans-unit id="ListStepsRequiresStep">
+        <source>The 'step' argument is required when using --list-steps. Specify the step you want to inspect, for example: 'aspire do {0} --list-steps' or 'aspire do {1} --list-steps'.</source>
+        <target state="new">The 'step' argument is required when using --list-steps. Specify the step you want to inspect, for example: 'aspire do {0} --list-steps' or 'aspire do {1} --list-steps'.</target>
+        <note>{0} and {1} are well-known pipeline step names such as 'deploy' and 'publish'.</note>
+      </trans-unit>
       <trans-unit id="OperationCanceled">
         <source>The operation was canceled.</source>
         <target state="translated">Operace byla zrušena.</target>
@@ -35,6 +40,11 @@
       <trans-unit id="StepArgumentDescription">
         <source>The name of the step to execute</source>
         <target state="needs-review-translation">Název kroku, který se má provést</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StepArgumentRequired">
+        <source>The 'step' argument is required.</source>
+        <target state="new">The 'step' argument is required.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Aspire.Cli/Resources/xlf/DoCommandStrings.de.xlf
+++ b/src/Aspire.Cli/Resources/xlf/DoCommandStrings.de.xlf
@@ -13,9 +13,9 @@
         <note />
       </trans-unit>
       <trans-unit id="ListStepsRequiresStep">
-        <source>The 'step' argument is required when using --list-steps. Example: 'aspire do deploy --list-steps'. Well-known step names include: {0}.</source>
-        <target state="new">The 'step' argument is required when using --list-steps. Example: 'aspire do deploy --list-steps'. Well-known step names include: {0}.</target>
-        <note>{0} is a comma-separated list of well-known pipeline step names.</note>
+        <source>The 'step' argument is required when using --list-steps. Example: 'aspire do deploy --list-steps'. Common starting steps are 'build', 'publish' and 'deploy'. See https://aspire.dev/reference/cli/commands/aspire-do/ for the full list of pipeline steps.</source>
+        <target state="new">The 'step' argument is required when using --list-steps. Example: 'aspire do deploy --list-steps'. Common starting steps are 'build', 'publish' and 'deploy'. See https://aspire.dev/reference/cli/commands/aspire-do/ for the full list of pipeline steps.</target>
+        <note />
       </trans-unit>
       <trans-unit id="OperationCanceled">
         <source>The operation was canceled.</source>

--- a/src/Aspire.Cli/Resources/xlf/DoCommandStrings.de.xlf
+++ b/src/Aspire.Cli/Resources/xlf/DoCommandStrings.de.xlf
@@ -13,9 +13,9 @@
         <note />
       </trans-unit>
       <trans-unit id="ListStepsRequiresStep">
-        <source>The 'step' argument is required when using --list-steps. Specify the step you want to inspect, for example: 'aspire do {0} --list-steps' or 'aspire do {1} --list-steps'.</source>
-        <target state="new">The 'step' argument is required when using --list-steps. Specify the step you want to inspect, for example: 'aspire do {0} --list-steps' or 'aspire do {1} --list-steps'.</target>
-        <note>{0} and {1} are well-known pipeline step names such as 'deploy' and 'publish'.</note>
+        <source>The 'step' argument is required when using --list-steps. Example: 'aspire do deploy --list-steps'. Well-known step names include: {0}.</source>
+        <target state="new">The 'step' argument is required when using --list-steps. Example: 'aspire do deploy --list-steps'. Well-known step names include: {0}.</target>
+        <note>{0} is a comma-separated list of well-known pipeline step names.</note>
       </trans-unit>
       <trans-unit id="OperationCanceled">
         <source>The operation was canceled.</source>

--- a/src/Aspire.Cli/Resources/xlf/DoCommandStrings.de.xlf
+++ b/src/Aspire.Cli/Resources/xlf/DoCommandStrings.de.xlf
@@ -12,6 +12,11 @@
         <target state="translated">Pipeline wird ausgeführt …</target>
         <note />
       </trans-unit>
+      <trans-unit id="ListStepsRequiresStep">
+        <source>The 'step' argument is required when using --list-steps. Specify the step you want to inspect, for example: 'aspire do {0} --list-steps' or 'aspire do {1} --list-steps'.</source>
+        <target state="new">The 'step' argument is required when using --list-steps. Specify the step you want to inspect, for example: 'aspire do {0} --list-steps' or 'aspire do {1} --list-steps'.</target>
+        <note>{0} and {1} are well-known pipeline step names such as 'deploy' and 'publish'.</note>
+      </trans-unit>
       <trans-unit id="OperationCanceled">
         <source>The operation was canceled.</source>
         <target state="translated">Der Vorgang wurde abgebrochen.</target>
@@ -35,6 +40,11 @@
       <trans-unit id="StepArgumentDescription">
         <source>The name of the step to execute</source>
         <target state="needs-review-translation">Der Name des auszuführenden Schritts.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StepArgumentRequired">
+        <source>The 'step' argument is required.</source>
+        <target state="new">The 'step' argument is required.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Aspire.Cli/Resources/xlf/DoCommandStrings.es.xlf
+++ b/src/Aspire.Cli/Resources/xlf/DoCommandStrings.es.xlf
@@ -12,6 +12,11 @@
         <target state="translated">Ejecutando canalización...</target>
         <note />
       </trans-unit>
+      <trans-unit id="ListStepsRequiresStep">
+        <source>The 'step' argument is required when using --list-steps. Specify the step you want to inspect, for example: 'aspire do {0} --list-steps' or 'aspire do {1} --list-steps'.</source>
+        <target state="new">The 'step' argument is required when using --list-steps. Specify the step you want to inspect, for example: 'aspire do {0} --list-steps' or 'aspire do {1} --list-steps'.</target>
+        <note>{0} and {1} are well-known pipeline step names such as 'deploy' and 'publish'.</note>
+      </trans-unit>
       <trans-unit id="OperationCanceled">
         <source>The operation was canceled.</source>
         <target state="translated">Operación cancelada.</target>
@@ -35,6 +40,11 @@
       <trans-unit id="StepArgumentDescription">
         <source>The name of the step to execute</source>
         <target state="needs-review-translation">Nombre del paso que se va a ejecutar.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StepArgumentRequired">
+        <source>The 'step' argument is required.</source>
+        <target state="new">The 'step' argument is required.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Aspire.Cli/Resources/xlf/DoCommandStrings.es.xlf
+++ b/src/Aspire.Cli/Resources/xlf/DoCommandStrings.es.xlf
@@ -13,9 +13,9 @@
         <note />
       </trans-unit>
       <trans-unit id="ListStepsRequiresStep">
-        <source>The 'step' argument is required when using --list-steps. Example: 'aspire do deploy --list-steps'. Well-known step names include: {0}.</source>
-        <target state="new">The 'step' argument is required when using --list-steps. Example: 'aspire do deploy --list-steps'. Well-known step names include: {0}.</target>
-        <note>{0} is a comma-separated list of well-known pipeline step names.</note>
+        <source>The 'step' argument is required when using --list-steps. Example: 'aspire do deploy --list-steps'. Common starting steps are 'build', 'publish' and 'deploy'. See https://aspire.dev/reference/cli/commands/aspire-do/ for the full list of pipeline steps.</source>
+        <target state="new">The 'step' argument is required when using --list-steps. Example: 'aspire do deploy --list-steps'. Common starting steps are 'build', 'publish' and 'deploy'. See https://aspire.dev/reference/cli/commands/aspire-do/ for the full list of pipeline steps.</target>
+        <note />
       </trans-unit>
       <trans-unit id="OperationCanceled">
         <source>The operation was canceled.</source>

--- a/src/Aspire.Cli/Resources/xlf/DoCommandStrings.es.xlf
+++ b/src/Aspire.Cli/Resources/xlf/DoCommandStrings.es.xlf
@@ -13,9 +13,9 @@
         <note />
       </trans-unit>
       <trans-unit id="ListStepsRequiresStep">
-        <source>The 'step' argument is required when using --list-steps. Specify the step you want to inspect, for example: 'aspire do {0} --list-steps' or 'aspire do {1} --list-steps'.</source>
-        <target state="new">The 'step' argument is required when using --list-steps. Specify the step you want to inspect, for example: 'aspire do {0} --list-steps' or 'aspire do {1} --list-steps'.</target>
-        <note>{0} and {1} are well-known pipeline step names such as 'deploy' and 'publish'.</note>
+        <source>The 'step' argument is required when using --list-steps. Example: 'aspire do deploy --list-steps'. Well-known step names include: {0}.</source>
+        <target state="new">The 'step' argument is required when using --list-steps. Example: 'aspire do deploy --list-steps'. Well-known step names include: {0}.</target>
+        <note>{0} is a comma-separated list of well-known pipeline step names.</note>
       </trans-unit>
       <trans-unit id="OperationCanceled">
         <source>The operation was canceled.</source>

--- a/src/Aspire.Cli/Resources/xlf/DoCommandStrings.fr.xlf
+++ b/src/Aspire.Cli/Resources/xlf/DoCommandStrings.fr.xlf
@@ -12,6 +12,11 @@
         <target state="translated">Exécution du pipeline...</target>
         <note />
       </trans-unit>
+      <trans-unit id="ListStepsRequiresStep">
+        <source>The 'step' argument is required when using --list-steps. Specify the step you want to inspect, for example: 'aspire do {0} --list-steps' or 'aspire do {1} --list-steps'.</source>
+        <target state="new">The 'step' argument is required when using --list-steps. Specify the step you want to inspect, for example: 'aspire do {0} --list-steps' or 'aspire do {1} --list-steps'.</target>
+        <note>{0} and {1} are well-known pipeline step names such as 'deploy' and 'publish'.</note>
+      </trans-unit>
       <trans-unit id="OperationCanceled">
         <source>The operation was canceled.</source>
         <target state="translated">L'opération a été annulée.</target>
@@ -35,6 +40,11 @@
       <trans-unit id="StepArgumentDescription">
         <source>The name of the step to execute</source>
         <target state="needs-review-translation">Nom de l’étape à exécuter.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StepArgumentRequired">
+        <source>The 'step' argument is required.</source>
+        <target state="new">The 'step' argument is required.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Aspire.Cli/Resources/xlf/DoCommandStrings.fr.xlf
+++ b/src/Aspire.Cli/Resources/xlf/DoCommandStrings.fr.xlf
@@ -13,9 +13,9 @@
         <note />
       </trans-unit>
       <trans-unit id="ListStepsRequiresStep">
-        <source>The 'step' argument is required when using --list-steps. Example: 'aspire do deploy --list-steps'. Well-known step names include: {0}.</source>
-        <target state="new">The 'step' argument is required when using --list-steps. Example: 'aspire do deploy --list-steps'. Well-known step names include: {0}.</target>
-        <note>{0} is a comma-separated list of well-known pipeline step names.</note>
+        <source>The 'step' argument is required when using --list-steps. Example: 'aspire do deploy --list-steps'. Common starting steps are 'build', 'publish' and 'deploy'. See https://aspire.dev/reference/cli/commands/aspire-do/ for the full list of pipeline steps.</source>
+        <target state="new">The 'step' argument is required when using --list-steps. Example: 'aspire do deploy --list-steps'. Common starting steps are 'build', 'publish' and 'deploy'. See https://aspire.dev/reference/cli/commands/aspire-do/ for the full list of pipeline steps.</target>
+        <note />
       </trans-unit>
       <trans-unit id="OperationCanceled">
         <source>The operation was canceled.</source>

--- a/src/Aspire.Cli/Resources/xlf/DoCommandStrings.fr.xlf
+++ b/src/Aspire.Cli/Resources/xlf/DoCommandStrings.fr.xlf
@@ -13,9 +13,9 @@
         <note />
       </trans-unit>
       <trans-unit id="ListStepsRequiresStep">
-        <source>The 'step' argument is required when using --list-steps. Specify the step you want to inspect, for example: 'aspire do {0} --list-steps' or 'aspire do {1} --list-steps'.</source>
-        <target state="new">The 'step' argument is required when using --list-steps. Specify the step you want to inspect, for example: 'aspire do {0} --list-steps' or 'aspire do {1} --list-steps'.</target>
-        <note>{0} and {1} are well-known pipeline step names such as 'deploy' and 'publish'.</note>
+        <source>The 'step' argument is required when using --list-steps. Example: 'aspire do deploy --list-steps'. Well-known step names include: {0}.</source>
+        <target state="new">The 'step' argument is required when using --list-steps. Example: 'aspire do deploy --list-steps'. Well-known step names include: {0}.</target>
+        <note>{0} is a comma-separated list of well-known pipeline step names.</note>
       </trans-unit>
       <trans-unit id="OperationCanceled">
         <source>The operation was canceled.</source>

--- a/src/Aspire.Cli/Resources/xlf/DoCommandStrings.it.xlf
+++ b/src/Aspire.Cli/Resources/xlf/DoCommandStrings.it.xlf
@@ -12,6 +12,11 @@
         <target state="translated">Esecuzione della pipeline in corso...</target>
         <note />
       </trans-unit>
+      <trans-unit id="ListStepsRequiresStep">
+        <source>The 'step' argument is required when using --list-steps. Specify the step you want to inspect, for example: 'aspire do {0} --list-steps' or 'aspire do {1} --list-steps'.</source>
+        <target state="new">The 'step' argument is required when using --list-steps. Specify the step you want to inspect, for example: 'aspire do {0} --list-steps' or 'aspire do {1} --list-steps'.</target>
+        <note>{0} and {1} are well-known pipeline step names such as 'deploy' and 'publish'.</note>
+      </trans-unit>
       <trans-unit id="OperationCanceled">
         <source>The operation was canceled.</source>
         <target state="translated">L'operazione è stata annullata.</target>
@@ -35,6 +40,11 @@
       <trans-unit id="StepArgumentDescription">
         <source>The name of the step to execute</source>
         <target state="needs-review-translation">Nome del passaggio da eseguire.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StepArgumentRequired">
+        <source>The 'step' argument is required.</source>
+        <target state="new">The 'step' argument is required.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Aspire.Cli/Resources/xlf/DoCommandStrings.it.xlf
+++ b/src/Aspire.Cli/Resources/xlf/DoCommandStrings.it.xlf
@@ -13,9 +13,9 @@
         <note />
       </trans-unit>
       <trans-unit id="ListStepsRequiresStep">
-        <source>The 'step' argument is required when using --list-steps. Example: 'aspire do deploy --list-steps'. Well-known step names include: {0}.</source>
-        <target state="new">The 'step' argument is required when using --list-steps. Example: 'aspire do deploy --list-steps'. Well-known step names include: {0}.</target>
-        <note>{0} is a comma-separated list of well-known pipeline step names.</note>
+        <source>The 'step' argument is required when using --list-steps. Example: 'aspire do deploy --list-steps'. Common starting steps are 'build', 'publish' and 'deploy'. See https://aspire.dev/reference/cli/commands/aspire-do/ for the full list of pipeline steps.</source>
+        <target state="new">The 'step' argument is required when using --list-steps. Example: 'aspire do deploy --list-steps'. Common starting steps are 'build', 'publish' and 'deploy'. See https://aspire.dev/reference/cli/commands/aspire-do/ for the full list of pipeline steps.</target>
+        <note />
       </trans-unit>
       <trans-unit id="OperationCanceled">
         <source>The operation was canceled.</source>

--- a/src/Aspire.Cli/Resources/xlf/DoCommandStrings.it.xlf
+++ b/src/Aspire.Cli/Resources/xlf/DoCommandStrings.it.xlf
@@ -13,9 +13,9 @@
         <note />
       </trans-unit>
       <trans-unit id="ListStepsRequiresStep">
-        <source>The 'step' argument is required when using --list-steps. Specify the step you want to inspect, for example: 'aspire do {0} --list-steps' or 'aspire do {1} --list-steps'.</source>
-        <target state="new">The 'step' argument is required when using --list-steps. Specify the step you want to inspect, for example: 'aspire do {0} --list-steps' or 'aspire do {1} --list-steps'.</target>
-        <note>{0} and {1} are well-known pipeline step names such as 'deploy' and 'publish'.</note>
+        <source>The 'step' argument is required when using --list-steps. Example: 'aspire do deploy --list-steps'. Well-known step names include: {0}.</source>
+        <target state="new">The 'step' argument is required when using --list-steps. Example: 'aspire do deploy --list-steps'. Well-known step names include: {0}.</target>
+        <note>{0} is a comma-separated list of well-known pipeline step names.</note>
       </trans-unit>
       <trans-unit id="OperationCanceled">
         <source>The operation was canceled.</source>

--- a/src/Aspire.Cli/Resources/xlf/DoCommandStrings.ja.xlf
+++ b/src/Aspire.Cli/Resources/xlf/DoCommandStrings.ja.xlf
@@ -13,9 +13,9 @@
         <note />
       </trans-unit>
       <trans-unit id="ListStepsRequiresStep">
-        <source>The 'step' argument is required when using --list-steps. Example: 'aspire do deploy --list-steps'. Well-known step names include: {0}.</source>
-        <target state="new">The 'step' argument is required when using --list-steps. Example: 'aspire do deploy --list-steps'. Well-known step names include: {0}.</target>
-        <note>{0} is a comma-separated list of well-known pipeline step names.</note>
+        <source>The 'step' argument is required when using --list-steps. Example: 'aspire do deploy --list-steps'. Common starting steps are 'build', 'publish' and 'deploy'. See https://aspire.dev/reference/cli/commands/aspire-do/ for the full list of pipeline steps.</source>
+        <target state="new">The 'step' argument is required when using --list-steps. Example: 'aspire do deploy --list-steps'. Common starting steps are 'build', 'publish' and 'deploy'. See https://aspire.dev/reference/cli/commands/aspire-do/ for the full list of pipeline steps.</target>
+        <note />
       </trans-unit>
       <trans-unit id="OperationCanceled">
         <source>The operation was canceled.</source>

--- a/src/Aspire.Cli/Resources/xlf/DoCommandStrings.ja.xlf
+++ b/src/Aspire.Cli/Resources/xlf/DoCommandStrings.ja.xlf
@@ -13,9 +13,9 @@
         <note />
       </trans-unit>
       <trans-unit id="ListStepsRequiresStep">
-        <source>The 'step' argument is required when using --list-steps. Specify the step you want to inspect, for example: 'aspire do {0} --list-steps' or 'aspire do {1} --list-steps'.</source>
-        <target state="new">The 'step' argument is required when using --list-steps. Specify the step you want to inspect, for example: 'aspire do {0} --list-steps' or 'aspire do {1} --list-steps'.</target>
-        <note>{0} and {1} are well-known pipeline step names such as 'deploy' and 'publish'.</note>
+        <source>The 'step' argument is required when using --list-steps. Example: 'aspire do deploy --list-steps'. Well-known step names include: {0}.</source>
+        <target state="new">The 'step' argument is required when using --list-steps. Example: 'aspire do deploy --list-steps'. Well-known step names include: {0}.</target>
+        <note>{0} is a comma-separated list of well-known pipeline step names.</note>
       </trans-unit>
       <trans-unit id="OperationCanceled">
         <source>The operation was canceled.</source>

--- a/src/Aspire.Cli/Resources/xlf/DoCommandStrings.ja.xlf
+++ b/src/Aspire.Cli/Resources/xlf/DoCommandStrings.ja.xlf
@@ -12,6 +12,11 @@
         <target state="translated">パイプラインを実行しています...</target>
         <note />
       </trans-unit>
+      <trans-unit id="ListStepsRequiresStep">
+        <source>The 'step' argument is required when using --list-steps. Specify the step you want to inspect, for example: 'aspire do {0} --list-steps' or 'aspire do {1} --list-steps'.</source>
+        <target state="new">The 'step' argument is required when using --list-steps. Specify the step you want to inspect, for example: 'aspire do {0} --list-steps' or 'aspire do {1} --list-steps'.</target>
+        <note>{0} and {1} are well-known pipeline step names such as 'deploy' and 'publish'.</note>
+      </trans-unit>
       <trans-unit id="OperationCanceled">
         <source>The operation was canceled.</source>
         <target state="translated">操作は取り消されました。</target>
@@ -35,6 +40,11 @@
       <trans-unit id="StepArgumentDescription">
         <source>The name of the step to execute</source>
         <target state="needs-review-translation">実行するステップの名前です。</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StepArgumentRequired">
+        <source>The 'step' argument is required.</source>
+        <target state="new">The 'step' argument is required.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Aspire.Cli/Resources/xlf/DoCommandStrings.ko.xlf
+++ b/src/Aspire.Cli/Resources/xlf/DoCommandStrings.ko.xlf
@@ -13,9 +13,9 @@
         <note />
       </trans-unit>
       <trans-unit id="ListStepsRequiresStep">
-        <source>The 'step' argument is required when using --list-steps. Example: 'aspire do deploy --list-steps'. Well-known step names include: {0}.</source>
-        <target state="new">The 'step' argument is required when using --list-steps. Example: 'aspire do deploy --list-steps'. Well-known step names include: {0}.</target>
-        <note>{0} is a comma-separated list of well-known pipeline step names.</note>
+        <source>The 'step' argument is required when using --list-steps. Example: 'aspire do deploy --list-steps'. Common starting steps are 'build', 'publish' and 'deploy'. See https://aspire.dev/reference/cli/commands/aspire-do/ for the full list of pipeline steps.</source>
+        <target state="new">The 'step' argument is required when using --list-steps. Example: 'aspire do deploy --list-steps'. Common starting steps are 'build', 'publish' and 'deploy'. See https://aspire.dev/reference/cli/commands/aspire-do/ for the full list of pipeline steps.</target>
+        <note />
       </trans-unit>
       <trans-unit id="OperationCanceled">
         <source>The operation was canceled.</source>

--- a/src/Aspire.Cli/Resources/xlf/DoCommandStrings.ko.xlf
+++ b/src/Aspire.Cli/Resources/xlf/DoCommandStrings.ko.xlf
@@ -13,9 +13,9 @@
         <note />
       </trans-unit>
       <trans-unit id="ListStepsRequiresStep">
-        <source>The 'step' argument is required when using --list-steps. Specify the step you want to inspect, for example: 'aspire do {0} --list-steps' or 'aspire do {1} --list-steps'.</source>
-        <target state="new">The 'step' argument is required when using --list-steps. Specify the step you want to inspect, for example: 'aspire do {0} --list-steps' or 'aspire do {1} --list-steps'.</target>
-        <note>{0} and {1} are well-known pipeline step names such as 'deploy' and 'publish'.</note>
+        <source>The 'step' argument is required when using --list-steps. Example: 'aspire do deploy --list-steps'. Well-known step names include: {0}.</source>
+        <target state="new">The 'step' argument is required when using --list-steps. Example: 'aspire do deploy --list-steps'. Well-known step names include: {0}.</target>
+        <note>{0} is a comma-separated list of well-known pipeline step names.</note>
       </trans-unit>
       <trans-unit id="OperationCanceled">
         <source>The operation was canceled.</source>

--- a/src/Aspire.Cli/Resources/xlf/DoCommandStrings.ko.xlf
+++ b/src/Aspire.Cli/Resources/xlf/DoCommandStrings.ko.xlf
@@ -12,6 +12,11 @@
         <target state="translated">파이프라인을 실행하는 중...</target>
         <note />
       </trans-unit>
+      <trans-unit id="ListStepsRequiresStep">
+        <source>The 'step' argument is required when using --list-steps. Specify the step you want to inspect, for example: 'aspire do {0} --list-steps' or 'aspire do {1} --list-steps'.</source>
+        <target state="new">The 'step' argument is required when using --list-steps. Specify the step you want to inspect, for example: 'aspire do {0} --list-steps' or 'aspire do {1} --list-steps'.</target>
+        <note>{0} and {1} are well-known pipeline step names such as 'deploy' and 'publish'.</note>
+      </trans-unit>
       <trans-unit id="OperationCanceled">
         <source>The operation was canceled.</source>
         <target state="translated">작업이 취소되었습니다.</target>
@@ -35,6 +40,11 @@
       <trans-unit id="StepArgumentDescription">
         <source>The name of the step to execute</source>
         <target state="needs-review-translation">실행할 단계의 이름입니다.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StepArgumentRequired">
+        <source>The 'step' argument is required.</source>
+        <target state="new">The 'step' argument is required.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Aspire.Cli/Resources/xlf/DoCommandStrings.pl.xlf
+++ b/src/Aspire.Cli/Resources/xlf/DoCommandStrings.pl.xlf
@@ -13,9 +13,9 @@
         <note />
       </trans-unit>
       <trans-unit id="ListStepsRequiresStep">
-        <source>The 'step' argument is required when using --list-steps. Example: 'aspire do deploy --list-steps'. Well-known step names include: {0}.</source>
-        <target state="new">The 'step' argument is required when using --list-steps. Example: 'aspire do deploy --list-steps'. Well-known step names include: {0}.</target>
-        <note>{0} is a comma-separated list of well-known pipeline step names.</note>
+        <source>The 'step' argument is required when using --list-steps. Example: 'aspire do deploy --list-steps'. Common starting steps are 'build', 'publish' and 'deploy'. See https://aspire.dev/reference/cli/commands/aspire-do/ for the full list of pipeline steps.</source>
+        <target state="new">The 'step' argument is required when using --list-steps. Example: 'aspire do deploy --list-steps'. Common starting steps are 'build', 'publish' and 'deploy'. See https://aspire.dev/reference/cli/commands/aspire-do/ for the full list of pipeline steps.</target>
+        <note />
       </trans-unit>
       <trans-unit id="OperationCanceled">
         <source>The operation was canceled.</source>

--- a/src/Aspire.Cli/Resources/xlf/DoCommandStrings.pl.xlf
+++ b/src/Aspire.Cli/Resources/xlf/DoCommandStrings.pl.xlf
@@ -13,9 +13,9 @@
         <note />
       </trans-unit>
       <trans-unit id="ListStepsRequiresStep">
-        <source>The 'step' argument is required when using --list-steps. Specify the step you want to inspect, for example: 'aspire do {0} --list-steps' or 'aspire do {1} --list-steps'.</source>
-        <target state="new">The 'step' argument is required when using --list-steps. Specify the step you want to inspect, for example: 'aspire do {0} --list-steps' or 'aspire do {1} --list-steps'.</target>
-        <note>{0} and {1} are well-known pipeline step names such as 'deploy' and 'publish'.</note>
+        <source>The 'step' argument is required when using --list-steps. Example: 'aspire do deploy --list-steps'. Well-known step names include: {0}.</source>
+        <target state="new">The 'step' argument is required when using --list-steps. Example: 'aspire do deploy --list-steps'. Well-known step names include: {0}.</target>
+        <note>{0} is a comma-separated list of well-known pipeline step names.</note>
       </trans-unit>
       <trans-unit id="OperationCanceled">
         <source>The operation was canceled.</source>

--- a/src/Aspire.Cli/Resources/xlf/DoCommandStrings.pl.xlf
+++ b/src/Aspire.Cli/Resources/xlf/DoCommandStrings.pl.xlf
@@ -12,6 +12,11 @@
         <target state="translated">Wykonywanie potoku...</target>
         <note />
       </trans-unit>
+      <trans-unit id="ListStepsRequiresStep">
+        <source>The 'step' argument is required when using --list-steps. Specify the step you want to inspect, for example: 'aspire do {0} --list-steps' or 'aspire do {1} --list-steps'.</source>
+        <target state="new">The 'step' argument is required when using --list-steps. Specify the step you want to inspect, for example: 'aspire do {0} --list-steps' or 'aspire do {1} --list-steps'.</target>
+        <note>{0} and {1} are well-known pipeline step names such as 'deploy' and 'publish'.</note>
+      </trans-unit>
       <trans-unit id="OperationCanceled">
         <source>The operation was canceled.</source>
         <target state="translated">Operacja została anulowana.</target>
@@ -35,6 +40,11 @@
       <trans-unit id="StepArgumentDescription">
         <source>The name of the step to execute</source>
         <target state="needs-review-translation">Nazwa kroku do wykonania.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StepArgumentRequired">
+        <source>The 'step' argument is required.</source>
+        <target state="new">The 'step' argument is required.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Aspire.Cli/Resources/xlf/DoCommandStrings.pt-BR.xlf
+++ b/src/Aspire.Cli/Resources/xlf/DoCommandStrings.pt-BR.xlf
@@ -13,9 +13,9 @@
         <note />
       </trans-unit>
       <trans-unit id="ListStepsRequiresStep">
-        <source>The 'step' argument is required when using --list-steps. Example: 'aspire do deploy --list-steps'. Well-known step names include: {0}.</source>
-        <target state="new">The 'step' argument is required when using --list-steps. Example: 'aspire do deploy --list-steps'. Well-known step names include: {0}.</target>
-        <note>{0} is a comma-separated list of well-known pipeline step names.</note>
+        <source>The 'step' argument is required when using --list-steps. Example: 'aspire do deploy --list-steps'. Common starting steps are 'build', 'publish' and 'deploy'. See https://aspire.dev/reference/cli/commands/aspire-do/ for the full list of pipeline steps.</source>
+        <target state="new">The 'step' argument is required when using --list-steps. Example: 'aspire do deploy --list-steps'. Common starting steps are 'build', 'publish' and 'deploy'. See https://aspire.dev/reference/cli/commands/aspire-do/ for the full list of pipeline steps.</target>
+        <note />
       </trans-unit>
       <trans-unit id="OperationCanceled">
         <source>The operation was canceled.</source>

--- a/src/Aspire.Cli/Resources/xlf/DoCommandStrings.pt-BR.xlf
+++ b/src/Aspire.Cli/Resources/xlf/DoCommandStrings.pt-BR.xlf
@@ -13,9 +13,9 @@
         <note />
       </trans-unit>
       <trans-unit id="ListStepsRequiresStep">
-        <source>The 'step' argument is required when using --list-steps. Specify the step you want to inspect, for example: 'aspire do {0} --list-steps' or 'aspire do {1} --list-steps'.</source>
-        <target state="new">The 'step' argument is required when using --list-steps. Specify the step you want to inspect, for example: 'aspire do {0} --list-steps' or 'aspire do {1} --list-steps'.</target>
-        <note>{0} and {1} are well-known pipeline step names such as 'deploy' and 'publish'.</note>
+        <source>The 'step' argument is required when using --list-steps. Example: 'aspire do deploy --list-steps'. Well-known step names include: {0}.</source>
+        <target state="new">The 'step' argument is required when using --list-steps. Example: 'aspire do deploy --list-steps'. Well-known step names include: {0}.</target>
+        <note>{0} is a comma-separated list of well-known pipeline step names.</note>
       </trans-unit>
       <trans-unit id="OperationCanceled">
         <source>The operation was canceled.</source>

--- a/src/Aspire.Cli/Resources/xlf/DoCommandStrings.pt-BR.xlf
+++ b/src/Aspire.Cli/Resources/xlf/DoCommandStrings.pt-BR.xlf
@@ -12,6 +12,11 @@
         <target state="translated">Executando pipeline...</target>
         <note />
       </trans-unit>
+      <trans-unit id="ListStepsRequiresStep">
+        <source>The 'step' argument is required when using --list-steps. Specify the step you want to inspect, for example: 'aspire do {0} --list-steps' or 'aspire do {1} --list-steps'.</source>
+        <target state="new">The 'step' argument is required when using --list-steps. Specify the step you want to inspect, for example: 'aspire do {0} --list-steps' or 'aspire do {1} --list-steps'.</target>
+        <note>{0} and {1} are well-known pipeline step names such as 'deploy' and 'publish'.</note>
+      </trans-unit>
       <trans-unit id="OperationCanceled">
         <source>The operation was canceled.</source>
         <target state="translated">A operação foi cancelada.</target>
@@ -35,6 +40,11 @@
       <trans-unit id="StepArgumentDescription">
         <source>The name of the step to execute</source>
         <target state="needs-review-translation">O nome da etapa a ser executada.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StepArgumentRequired">
+        <source>The 'step' argument is required.</source>
+        <target state="new">The 'step' argument is required.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Aspire.Cli/Resources/xlf/DoCommandStrings.ru.xlf
+++ b/src/Aspire.Cli/Resources/xlf/DoCommandStrings.ru.xlf
@@ -12,6 +12,11 @@
         <target state="translated">Выполнение конвейера...</target>
         <note />
       </trans-unit>
+      <trans-unit id="ListStepsRequiresStep">
+        <source>The 'step' argument is required when using --list-steps. Specify the step you want to inspect, for example: 'aspire do {0} --list-steps' or 'aspire do {1} --list-steps'.</source>
+        <target state="new">The 'step' argument is required when using --list-steps. Specify the step you want to inspect, for example: 'aspire do {0} --list-steps' or 'aspire do {1} --list-steps'.</target>
+        <note>{0} and {1} are well-known pipeline step names such as 'deploy' and 'publish'.</note>
+      </trans-unit>
       <trans-unit id="OperationCanceled">
         <source>The operation was canceled.</source>
         <target state="translated">Операция была отменена.</target>
@@ -35,6 +40,11 @@
       <trans-unit id="StepArgumentDescription">
         <source>The name of the step to execute</source>
         <target state="needs-review-translation">Имя выполняемого шага.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StepArgumentRequired">
+        <source>The 'step' argument is required.</source>
+        <target state="new">The 'step' argument is required.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Aspire.Cli/Resources/xlf/DoCommandStrings.ru.xlf
+++ b/src/Aspire.Cli/Resources/xlf/DoCommandStrings.ru.xlf
@@ -13,9 +13,9 @@
         <note />
       </trans-unit>
       <trans-unit id="ListStepsRequiresStep">
-        <source>The 'step' argument is required when using --list-steps. Example: 'aspire do deploy --list-steps'. Well-known step names include: {0}.</source>
-        <target state="new">The 'step' argument is required when using --list-steps. Example: 'aspire do deploy --list-steps'. Well-known step names include: {0}.</target>
-        <note>{0} is a comma-separated list of well-known pipeline step names.</note>
+        <source>The 'step' argument is required when using --list-steps. Example: 'aspire do deploy --list-steps'. Common starting steps are 'build', 'publish' and 'deploy'. See https://aspire.dev/reference/cli/commands/aspire-do/ for the full list of pipeline steps.</source>
+        <target state="new">The 'step' argument is required when using --list-steps. Example: 'aspire do deploy --list-steps'. Common starting steps are 'build', 'publish' and 'deploy'. See https://aspire.dev/reference/cli/commands/aspire-do/ for the full list of pipeline steps.</target>
+        <note />
       </trans-unit>
       <trans-unit id="OperationCanceled">
         <source>The operation was canceled.</source>

--- a/src/Aspire.Cli/Resources/xlf/DoCommandStrings.ru.xlf
+++ b/src/Aspire.Cli/Resources/xlf/DoCommandStrings.ru.xlf
@@ -13,9 +13,9 @@
         <note />
       </trans-unit>
       <trans-unit id="ListStepsRequiresStep">
-        <source>The 'step' argument is required when using --list-steps. Specify the step you want to inspect, for example: 'aspire do {0} --list-steps' or 'aspire do {1} --list-steps'.</source>
-        <target state="new">The 'step' argument is required when using --list-steps. Specify the step you want to inspect, for example: 'aspire do {0} --list-steps' or 'aspire do {1} --list-steps'.</target>
-        <note>{0} and {1} are well-known pipeline step names such as 'deploy' and 'publish'.</note>
+        <source>The 'step' argument is required when using --list-steps. Example: 'aspire do deploy --list-steps'. Well-known step names include: {0}.</source>
+        <target state="new">The 'step' argument is required when using --list-steps. Example: 'aspire do deploy --list-steps'. Well-known step names include: {0}.</target>
+        <note>{0} is a comma-separated list of well-known pipeline step names.</note>
       </trans-unit>
       <trans-unit id="OperationCanceled">
         <source>The operation was canceled.</source>

--- a/src/Aspire.Cli/Resources/xlf/DoCommandStrings.tr.xlf
+++ b/src/Aspire.Cli/Resources/xlf/DoCommandStrings.tr.xlf
@@ -12,6 +12,11 @@
         <target state="translated">İşlem hattı yürütülüyor...</target>
         <note />
       </trans-unit>
+      <trans-unit id="ListStepsRequiresStep">
+        <source>The 'step' argument is required when using --list-steps. Specify the step you want to inspect, for example: 'aspire do {0} --list-steps' or 'aspire do {1} --list-steps'.</source>
+        <target state="new">The 'step' argument is required when using --list-steps. Specify the step you want to inspect, for example: 'aspire do {0} --list-steps' or 'aspire do {1} --list-steps'.</target>
+        <note>{0} and {1} are well-known pipeline step names such as 'deploy' and 'publish'.</note>
+      </trans-unit>
       <trans-unit id="OperationCanceled">
         <source>The operation was canceled.</source>
         <target state="translated">İşlem iptal edildi.</target>
@@ -35,6 +40,11 @@
       <trans-unit id="StepArgumentDescription">
         <source>The name of the step to execute</source>
         <target state="needs-review-translation">Yürütülecek adımın adı.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StepArgumentRequired">
+        <source>The 'step' argument is required.</source>
+        <target state="new">The 'step' argument is required.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Aspire.Cli/Resources/xlf/DoCommandStrings.tr.xlf
+++ b/src/Aspire.Cli/Resources/xlf/DoCommandStrings.tr.xlf
@@ -13,9 +13,9 @@
         <note />
       </trans-unit>
       <trans-unit id="ListStepsRequiresStep">
-        <source>The 'step' argument is required when using --list-steps. Example: 'aspire do deploy --list-steps'. Well-known step names include: {0}.</source>
-        <target state="new">The 'step' argument is required when using --list-steps. Example: 'aspire do deploy --list-steps'. Well-known step names include: {0}.</target>
-        <note>{0} is a comma-separated list of well-known pipeline step names.</note>
+        <source>The 'step' argument is required when using --list-steps. Example: 'aspire do deploy --list-steps'. Common starting steps are 'build', 'publish' and 'deploy'. See https://aspire.dev/reference/cli/commands/aspire-do/ for the full list of pipeline steps.</source>
+        <target state="new">The 'step' argument is required when using --list-steps. Example: 'aspire do deploy --list-steps'. Common starting steps are 'build', 'publish' and 'deploy'. See https://aspire.dev/reference/cli/commands/aspire-do/ for the full list of pipeline steps.</target>
+        <note />
       </trans-unit>
       <trans-unit id="OperationCanceled">
         <source>The operation was canceled.</source>

--- a/src/Aspire.Cli/Resources/xlf/DoCommandStrings.tr.xlf
+++ b/src/Aspire.Cli/Resources/xlf/DoCommandStrings.tr.xlf
@@ -13,9 +13,9 @@
         <note />
       </trans-unit>
       <trans-unit id="ListStepsRequiresStep">
-        <source>The 'step' argument is required when using --list-steps. Specify the step you want to inspect, for example: 'aspire do {0} --list-steps' or 'aspire do {1} --list-steps'.</source>
-        <target state="new">The 'step' argument is required when using --list-steps. Specify the step you want to inspect, for example: 'aspire do {0} --list-steps' or 'aspire do {1} --list-steps'.</target>
-        <note>{0} and {1} are well-known pipeline step names such as 'deploy' and 'publish'.</note>
+        <source>The 'step' argument is required when using --list-steps. Example: 'aspire do deploy --list-steps'. Well-known step names include: {0}.</source>
+        <target state="new">The 'step' argument is required when using --list-steps. Example: 'aspire do deploy --list-steps'. Well-known step names include: {0}.</target>
+        <note>{0} is a comma-separated list of well-known pipeline step names.</note>
       </trans-unit>
       <trans-unit id="OperationCanceled">
         <source>The operation was canceled.</source>

--- a/src/Aspire.Cli/Resources/xlf/DoCommandStrings.zh-Hans.xlf
+++ b/src/Aspire.Cli/Resources/xlf/DoCommandStrings.zh-Hans.xlf
@@ -12,6 +12,11 @@
         <target state="translated">正在执行管道...</target>
         <note />
       </trans-unit>
+      <trans-unit id="ListStepsRequiresStep">
+        <source>The 'step' argument is required when using --list-steps. Specify the step you want to inspect, for example: 'aspire do {0} --list-steps' or 'aspire do {1} --list-steps'.</source>
+        <target state="new">The 'step' argument is required when using --list-steps. Specify the step you want to inspect, for example: 'aspire do {0} --list-steps' or 'aspire do {1} --list-steps'.</target>
+        <note>{0} and {1} are well-known pipeline step names such as 'deploy' and 'publish'.</note>
+      </trans-unit>
       <trans-unit id="OperationCanceled">
         <source>The operation was canceled.</source>
         <target state="translated">该操作已取消。</target>
@@ -35,6 +40,11 @@
       <trans-unit id="StepArgumentDescription">
         <source>The name of the step to execute</source>
         <target state="needs-review-translation">要执行的步骤名称。</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StepArgumentRequired">
+        <source>The 'step' argument is required.</source>
+        <target state="new">The 'step' argument is required.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Aspire.Cli/Resources/xlf/DoCommandStrings.zh-Hans.xlf
+++ b/src/Aspire.Cli/Resources/xlf/DoCommandStrings.zh-Hans.xlf
@@ -13,9 +13,9 @@
         <note />
       </trans-unit>
       <trans-unit id="ListStepsRequiresStep">
-        <source>The 'step' argument is required when using --list-steps. Example: 'aspire do deploy --list-steps'. Well-known step names include: {0}.</source>
-        <target state="new">The 'step' argument is required when using --list-steps. Example: 'aspire do deploy --list-steps'. Well-known step names include: {0}.</target>
-        <note>{0} is a comma-separated list of well-known pipeline step names.</note>
+        <source>The 'step' argument is required when using --list-steps. Example: 'aspire do deploy --list-steps'. Common starting steps are 'build', 'publish' and 'deploy'. See https://aspire.dev/reference/cli/commands/aspire-do/ for the full list of pipeline steps.</source>
+        <target state="new">The 'step' argument is required when using --list-steps. Example: 'aspire do deploy --list-steps'. Common starting steps are 'build', 'publish' and 'deploy'. See https://aspire.dev/reference/cli/commands/aspire-do/ for the full list of pipeline steps.</target>
+        <note />
       </trans-unit>
       <trans-unit id="OperationCanceled">
         <source>The operation was canceled.</source>

--- a/src/Aspire.Cli/Resources/xlf/DoCommandStrings.zh-Hans.xlf
+++ b/src/Aspire.Cli/Resources/xlf/DoCommandStrings.zh-Hans.xlf
@@ -13,9 +13,9 @@
         <note />
       </trans-unit>
       <trans-unit id="ListStepsRequiresStep">
-        <source>The 'step' argument is required when using --list-steps. Specify the step you want to inspect, for example: 'aspire do {0} --list-steps' or 'aspire do {1} --list-steps'.</source>
-        <target state="new">The 'step' argument is required when using --list-steps. Specify the step you want to inspect, for example: 'aspire do {0} --list-steps' or 'aspire do {1} --list-steps'.</target>
-        <note>{0} and {1} are well-known pipeline step names such as 'deploy' and 'publish'.</note>
+        <source>The 'step' argument is required when using --list-steps. Example: 'aspire do deploy --list-steps'. Well-known step names include: {0}.</source>
+        <target state="new">The 'step' argument is required when using --list-steps. Example: 'aspire do deploy --list-steps'. Well-known step names include: {0}.</target>
+        <note>{0} is a comma-separated list of well-known pipeline step names.</note>
       </trans-unit>
       <trans-unit id="OperationCanceled">
         <source>The operation was canceled.</source>

--- a/src/Aspire.Cli/Resources/xlf/DoCommandStrings.zh-Hant.xlf
+++ b/src/Aspire.Cli/Resources/xlf/DoCommandStrings.zh-Hant.xlf
@@ -12,6 +12,11 @@
         <target state="translated">正在執行管線...</target>
         <note />
       </trans-unit>
+      <trans-unit id="ListStepsRequiresStep">
+        <source>The 'step' argument is required when using --list-steps. Specify the step you want to inspect, for example: 'aspire do {0} --list-steps' or 'aspire do {1} --list-steps'.</source>
+        <target state="new">The 'step' argument is required when using --list-steps. Specify the step you want to inspect, for example: 'aspire do {0} --list-steps' or 'aspire do {1} --list-steps'.</target>
+        <note>{0} and {1} are well-known pipeline step names such as 'deploy' and 'publish'.</note>
+      </trans-unit>
       <trans-unit id="OperationCanceled">
         <source>The operation was canceled.</source>
         <target state="translated">已取消作業。</target>
@@ -35,6 +40,11 @@
       <trans-unit id="StepArgumentDescription">
         <source>The name of the step to execute</source>
         <target state="needs-review-translation">要執行的步驟名稱。</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StepArgumentRequired">
+        <source>The 'step' argument is required.</source>
+        <target state="new">The 'step' argument is required.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Aspire.Cli/Resources/xlf/DoCommandStrings.zh-Hant.xlf
+++ b/src/Aspire.Cli/Resources/xlf/DoCommandStrings.zh-Hant.xlf
@@ -13,9 +13,9 @@
         <note />
       </trans-unit>
       <trans-unit id="ListStepsRequiresStep">
-        <source>The 'step' argument is required when using --list-steps. Example: 'aspire do deploy --list-steps'. Well-known step names include: {0}.</source>
-        <target state="new">The 'step' argument is required when using --list-steps. Example: 'aspire do deploy --list-steps'. Well-known step names include: {0}.</target>
-        <note>{0} is a comma-separated list of well-known pipeline step names.</note>
+        <source>The 'step' argument is required when using --list-steps. Example: 'aspire do deploy --list-steps'. Common starting steps are 'build', 'publish' and 'deploy'. See https://aspire.dev/reference/cli/commands/aspire-do/ for the full list of pipeline steps.</source>
+        <target state="new">The 'step' argument is required when using --list-steps. Example: 'aspire do deploy --list-steps'. Common starting steps are 'build', 'publish' and 'deploy'. See https://aspire.dev/reference/cli/commands/aspire-do/ for the full list of pipeline steps.</target>
+        <note />
       </trans-unit>
       <trans-unit id="OperationCanceled">
         <source>The operation was canceled.</source>

--- a/src/Aspire.Cli/Resources/xlf/DoCommandStrings.zh-Hant.xlf
+++ b/src/Aspire.Cli/Resources/xlf/DoCommandStrings.zh-Hant.xlf
@@ -13,9 +13,9 @@
         <note />
       </trans-unit>
       <trans-unit id="ListStepsRequiresStep">
-        <source>The 'step' argument is required when using --list-steps. Specify the step you want to inspect, for example: 'aspire do {0} --list-steps' or 'aspire do {1} --list-steps'.</source>
-        <target state="new">The 'step' argument is required when using --list-steps. Specify the step you want to inspect, for example: 'aspire do {0} --list-steps' or 'aspire do {1} --list-steps'.</target>
-        <note>{0} and {1} are well-known pipeline step names such as 'deploy' and 'publish'.</note>
+        <source>The 'step' argument is required when using --list-steps. Example: 'aspire do deploy --list-steps'. Well-known step names include: {0}.</source>
+        <target state="new">The 'step' argument is required when using --list-steps. Example: 'aspire do deploy --list-steps'. Well-known step names include: {0}.</target>
+        <note>{0} is a comma-separated list of well-known pipeline step names.</note>
       </trans-unit>
       <trans-unit id="OperationCanceled">
         <source>The operation was canceled.</source>

--- a/tests/Aspire.Cli.EndToEnd.Tests/ListStepsTests.cs
+++ b/tests/Aspire.Cli.EndToEnd.Tests/ListStepsTests.cs
@@ -56,8 +56,12 @@ public sealed class ListStepsTests(ITestOutputHelper output)
                 throw new InvalidOperationException(
                     "aspire do --list-steps regressed: pipeline executed and crashed instead of surfacing the friendly validation error.");
             }
-            return s.ContainsText("aspire do deploy --list-steps")
-                && s.ContainsText("aspire.dev/reference/cli/commands/aspire-do");
+            // Match short fragments that are unlikely to straddle a wrap boundary in a narrow
+            // terminal. The full error message is a single long sentence, so asserting on the
+            // raw URL (or any 30+ char run) is flaky because the screen buffer inserts wrap
+            // newlines that defeat ContainsText's literal substring match.
+            return s.ContainsText("required when using --list-steps")
+                && s.ContainsText("aspire.dev/");
         }, timeout: TimeSpan.FromMinutes(2),
             description: "waiting for friendly error with example and docs link");
 

--- a/tests/Aspire.Cli.EndToEnd.Tests/ListStepsTests.cs
+++ b/tests/Aspire.Cli.EndToEnd.Tests/ListStepsTests.cs
@@ -57,9 +57,9 @@ public sealed class ListStepsTests(ITestOutputHelper output)
                     "aspire do --list-steps regressed: pipeline executed and crashed instead of surfacing the friendly validation error.");
             }
             return s.ContainsText("aspire do deploy --list-steps")
-                && s.ContainsText("Well-known step names include:");
+                && s.ContainsText("aspire.dev/reference/cli/commands/aspire-do");
         }, timeout: TimeSpan.FromMinutes(2),
-            description: "waiting for friendly error listing well-known steps and an example");
+            description: "waiting for friendly error with example and docs link");
 
         // The validation error returns a non-zero exit code, but the shell prompt should come back.
         await auto.WaitForAnyPromptAsync(counter);

--- a/tests/Aspire.Cli.EndToEnd.Tests/ListStepsTests.cs
+++ b/tests/Aspire.Cli.EndToEnd.Tests/ListStepsTests.cs
@@ -9,13 +9,15 @@ using Xunit;
 namespace Aspire.Cli.EndToEnd.Tests;
 
 /// <summary>
-/// End-to-end tests for the aspire do --list-steps feature.
-/// Verifies that the CLI can list pipeline steps without executing them.
+/// End-to-end tests for the --list-steps feature on the aspire do, publish, and deploy commands.
+/// Verifies that the CLI can list pipeline steps without executing them, and that
+/// invalid combinations (such as `aspire do --list-steps` without a step argument)
+/// surface a friendly error instead of crashing.
 /// </summary>
 public sealed class ListStepsTests(ITestOutputHelper output)
 {
     [Fact]
-    public async Task DoListStepsShowsPipelineSteps()
+    public async Task DoPublishAndDeployListStepsWork()
     {
         var repoRoot = CliE2ETestHelpers.GetRepoRoot();
         var strategy = CliInstallStrategy.Detect(output.WriteLine);
@@ -40,17 +42,53 @@ public sealed class ListStepsTests(ITestOutputHelper output)
         await auto.EnterAsync();
         await auto.WaitForSuccessPromptAsync(counter);
 
-        // Run aspire do deploy --list-steps
-        await auto.TypeAsync("aspire do deploy --list-steps");
+        // 1. Regression for https://github.com/microsoft/aspire/issues/17526:
+        //    `aspire do --list-steps` with no step argument should surface a friendly error
+        //    pointing at concrete examples rather than crashing with
+        //    'Sequence contains more than one matching element'.
+        await auto.TypeAsync("aspire do --list-steps");
         await auto.EnterAsync();
 
-        // Wait for the output to contain step information
-        // The output should contain numbered steps with dependencies
+        await auto.WaitUntilAsync(s =>
+        {
+            if (s.ContainsText("Sequence contains more than one matching element"))
+            {
+                throw new InvalidOperationException(
+                    "aspire do --list-steps regressed: pipeline executed and crashed instead of surfacing the friendly validation error.");
+            }
+            return s.ContainsText("aspire do deploy --list-steps")
+                && s.ContainsText("aspire do publish --list-steps");
+        }, timeout: TimeSpan.FromMinutes(2),
+            description: "waiting for friendly error suggesting concrete aspire do <step> --list-steps examples");
+
+        // The validation error returns a non-zero exit code, but the shell prompt should come back.
+        await auto.WaitForAnyPromptAsync(counter);
+
+        // 2. `aspire do <step> --list-steps` lists pipeline steps for that step.
+        await auto.TypeAsync("aspire do deploy --list-steps");
+        await auto.EnterAsync();
         await auto.WaitUntilAsync(s =>
             s.ContainsText("Depends on:") || s.ContainsText("No dependencies"),
             timeout: TimeSpan.FromMinutes(3),
-            description: "waiting for --list-steps output with step dependency information");
+            description: "waiting for aspire do deploy --list-steps output");
+        await auto.WaitForSuccessPromptAsync(counter);
 
+        // 3. `aspire publish --list-steps` lists steps for the publish target.
+        await auto.TypeAsync("aspire publish --list-steps");
+        await auto.EnterAsync();
+        await auto.WaitUntilAsync(s =>
+            s.ContainsText("Depends on:") || s.ContainsText("No dependencies"),
+            timeout: TimeSpan.FromMinutes(3),
+            description: "waiting for aspire publish --list-steps output");
+        await auto.WaitForSuccessPromptAsync(counter);
+
+        // 4. `aspire deploy --list-steps` lists steps for the deploy target.
+        await auto.TypeAsync("aspire deploy --list-steps");
+        await auto.EnterAsync();
+        await auto.WaitUntilAsync(s =>
+            s.ContainsText("Depends on:") || s.ContainsText("No dependencies"),
+            timeout: TimeSpan.FromMinutes(3),
+            description: "waiting for aspire deploy --list-steps output");
         await auto.WaitForSuccessPromptAsync(counter);
 
         // Exit the terminal

--- a/tests/Aspire.Cli.EndToEnd.Tests/ListStepsTests.cs
+++ b/tests/Aspire.Cli.EndToEnd.Tests/ListStepsTests.cs
@@ -57,9 +57,9 @@ public sealed class ListStepsTests(ITestOutputHelper output)
                     "aspire do --list-steps regressed: pipeline executed and crashed instead of surfacing the friendly validation error.");
             }
             return s.ContainsText("aspire do deploy --list-steps")
-                && s.ContainsText("aspire do publish --list-steps");
+                && s.ContainsText("Well-known step names include:");
         }, timeout: TimeSpan.FromMinutes(2),
-            description: "waiting for friendly error suggesting concrete aspire do <step> --list-steps examples");
+            description: "waiting for friendly error listing well-known steps and an example");
 
         // The validation error returns a non-zero exit code, but the shell prompt should come back.
         await auto.WaitForAnyPromptAsync(counter);

--- a/tests/Aspire.Cli.Tests/Commands/DoCommandTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/DoCommandTests.cs
@@ -325,14 +325,36 @@ public class DoCommandTests(ITestOutputHelper outputHelper)
         using var provider = services.BuildServiceProvider();
         var command = provider.GetRequiredService<RootCommand>();
 
-        // Act - no step argument needed with --list-steps
-        var result = command.Parse("do --list-steps");
+        // Act - step argument is required, even with --list-steps
+        var result = command.Parse("do deploy --list-steps");
         var exitCode = await result.InvokeAsync().DefaultTimeout();
 
         // Assert
         Assert.Equal(0, exitCode);
         Assert.True(getPipelineStepsCalled.Task.IsCompleted, "GetPipelineStepsAsync should have been called");
         Assert.True(requestStopCalled.Task.IsCompleted, "RequestStopAsync should have been called");
+    }
+
+    [Fact]
+    public async Task DoCommandWithListStepsAndNoStepArgumentShowsFriendlyError()
+    {
+        // Regression for https://github.com/microsoft/aspire/issues/17526:
+        // `aspire do --list-steps` with no step argument used to launch the AppHost
+        // and crash mid-pipeline. It should now fail validation with a friendly
+        // error pointing at concrete examples.
+        using var tempRepo = TemporaryWorkspace.Create(outputHelper);
+
+        var services = CliTestHelper.CreateServiceCollection(tempRepo, outputHelper);
+        using var provider = services.BuildServiceProvider();
+        var command = provider.GetRequiredService<RootCommand>();
+
+        var result = command.Parse("do --list-steps");
+
+        Assert.NotEmpty(result.Errors);
+        var combined = string.Join("\n", result.Errors.Select(e => e.Message));
+        Assert.Contains("--list-steps", combined);
+        Assert.Contains("aspire do deploy --list-steps", combined);
+        Assert.Contains("aspire do publish --list-steps", combined);
     }
 
     [Fact]
@@ -431,7 +453,7 @@ public class DoCommandTests(ITestOutputHelper outputHelper)
         using var provider = services.BuildServiceProvider();
         var command = provider.GetRequiredService<RootCommand>();
 
-        var result = command.Parse("do --list-steps");
+        var result = command.Parse("do deploy --list-steps");
         var exitCode = await result.InvokeAsync().DefaultTimeout();
 
         // Assert - pipeline should NOT have been executed
@@ -489,7 +511,7 @@ public class DoCommandTests(ITestOutputHelper outputHelper)
         using var provider = services.BuildServiceProvider();
         var command = provider.GetRequiredService<RootCommand>();
 
-        var result = command.Parse("do --list-steps");
+        var result = command.Parse("do deploy --list-steps");
         var exitCode = await result.InvokeAsync().DefaultTimeout();
 
         Assert.Equal(0, exitCode);

--- a/tests/Aspire.Cli.Tests/Commands/DoCommandTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/DoCommandTests.cs
@@ -7,6 +7,7 @@ using Aspire.Cli.Tests.TestServices;
 using Aspire.Cli.Backchannel;
 using Microsoft.Extensions.DependencyInjection;
 using Aspire.Cli.Utils;
+using Aspire.Hosting;
 using Microsoft.AspNetCore.InternalTesting;
 
 namespace Aspire.Cli.Tests.Commands;
@@ -356,6 +357,35 @@ public class DoCommandTests(ITestOutputHelper outputHelper)
         Assert.Contains("aspire do deploy --list-steps", combined);
         Assert.Contains("build", combined);
         Assert.Contains("publish", combined);
+        Assert.Contains("https://aspire.dev/reference/cli/commands/aspire-do/", combined);
+    }
+
+    [Fact]
+    public async Task DoCommandWithListStepsAndNoStepArgumentInExtensionHostShowsFriendlyError()
+    {
+        // The extension host bypasses the plain `aspire do` step requirement because
+        // GetRunArgumentsAsync prompts the user interactively. But `--list-steps` does
+        // not flow through that prompt, so without the validator firing the extension
+        // would still hit the original crash from https://github.com/microsoft/aspire/issues/17526.
+        using var tempRepo = TemporaryWorkspace.Create(outputHelper);
+
+        var services = CliTestHelper.CreateServiceCollection(tempRepo, outputHelper, options =>
+        {
+            options.ExtensionBackchannelFactory = _ => new TestExtensionBackchannel();
+            options.InteractionServiceFactory = sp => new TestExtensionInteractionService(sp);
+            options.ConfigurationCallback += config =>
+            {
+                config[KnownConfigNames.ExtensionDebugSessionId] = "test-session-id";
+            };
+        });
+        using var provider = services.BuildServiceProvider();
+        var command = provider.GetRequiredService<RootCommand>();
+
+        var result = command.Parse("do --list-steps");
+
+        Assert.NotEmpty(result.Errors);
+        var combined = string.Join("\n", result.Errors.Select(e => e.Message));
+        Assert.Contains("--list-steps", combined);
         Assert.Contains("https://aspire.dev/reference/cli/commands/aspire-do/", combined);
     }
 

--- a/tests/Aspire.Cli.Tests/Commands/DoCommandTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/DoCommandTests.cs
@@ -354,7 +354,11 @@ public class DoCommandTests(ITestOutputHelper outputHelper)
         var combined = string.Join("\n", result.Errors.Select(e => e.Message));
         Assert.Contains("--list-steps", combined);
         Assert.Contains("aspire do deploy --list-steps", combined);
-        Assert.Contains("aspire do publish --list-steps", combined);
+        // The error lists well-known step names; spot-check a few from different
+        // categories (publish/deploy/build/destroy) to confirm the list is rendered.
+        Assert.Contains("publish", combined);
+        Assert.Contains("build", combined);
+        Assert.Contains("destroy", combined);
     }
 
     [Fact]

--- a/tests/Aspire.Cli.Tests/Commands/DoCommandTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/DoCommandTests.cs
@@ -354,11 +354,9 @@ public class DoCommandTests(ITestOutputHelper outputHelper)
         var combined = string.Join("\n", result.Errors.Select(e => e.Message));
         Assert.Contains("--list-steps", combined);
         Assert.Contains("aspire do deploy --list-steps", combined);
-        // The error lists well-known step names; spot-check a few from different
-        // categories (publish/deploy/build/destroy) to confirm the list is rendered.
-        Assert.Contains("publish", combined);
         Assert.Contains("build", combined);
-        Assert.Contains("destroy", combined);
+        Assert.Contains("publish", combined);
+        Assert.Contains("https://aspire.dev/reference/cli/commands/aspire-do/", combined);
     }
 
     [Fact]


### PR DESCRIPTION
## Description

`aspire do` is always step-targeted, so `--list-steps` with no step has no meaningful scope. The validator previously allowed `aspire do --list-steps` to run, which launched the AppHost and raced ahead executing the full pipeline before the CLI could fetch steps and stop it. That race surfaced as `InvalidOperationException: Sequence contains more than one matching element` from `AzurePublishingContext` (#17526).

This change tightens the `DoCommand` validator to always require the `step` argument (outside the extension host, which prompts interactively). When the user specifies `--list-steps` without a step, the CLI now emits a friendly, localized error pointing at concrete examples drawn from the well-known step names:

> The 'step' argument is required when using --list-steps. Specify the step you want to inspect, for example: 'aspire do deploy --list-steps' or 'aspire do publish --list-steps'.

`aspire publish --list-steps` and `aspire deploy --list-steps` are unchanged - they already pass a fixed `--step` and continue to work.

Scope was kept intentionally narrow: no changes to `PipelineOptions` / `PipelineExecutor` / AppHost. The underlying "more than one matching element" condition in `ResourceExtensions.GetDeploymentTargetAnnotation` is a separate latent bug that only surfaced because the pipeline ran when it shouldn't have.

### Files of note

- `src/Aspire.Cli/Commands/DoCommand.cs` - tightened validator with branch-specific friendly message.
- `src/Aspire.Cli/Resources/DoCommandStrings.resx` + `Designer.cs` - new `StepArgumentRequired` and `ListStepsRequiresStep` entries (and the previously inlined English error promoted to a resource).
- `src/Aspire.Cli/Resources/xlf/DoCommandStrings.*.xlf` - refreshed via `dotnet build /t:UpdateXlf` (translation pipeline owns the actual translations).
- `tests/Aspire.Cli.Tests/Commands/DoCommandTests.cs` - new `DoCommandWithListStepsAndNoStepArgumentShowsFriendlyError` regression test; three existing list-steps tests updated to pass a step.
- `tests/Aspire.Cli.EndToEnd.Tests/ListStepsTests.cs` - single Docker-backed E2E now exercises `aspire do --list-steps` (asserts the friendly error and explicitly fails if the `Sequence contains more than one matching element` crash returns), plus `aspire do deploy --list-steps`, `aspire publish --list-steps`, and `aspire deploy --list-steps` against a freshly created starter app.

Fixes: #17526

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No