### PR TITLE
Update --search option description with aka.ms link and field filter details

### DIFF
--- a/src/Aspire.Cli/Resources/LogsCommandStrings.resx
+++ b/src/Aspire.Cli/Resources/LogsCommandStrings.resx
@@ -163,6 +163,6 @@
     <value>No logs found.</value>
   </data>
   <data name="SearchOptionDescription" xml:space="preserve">
-    <value>Full-text search to filter log content</value>
+    <value>Full-text search to filter log content. See https://aka.ms/aspire/cli-search for more details</value>
   </data>
 </root>

--- a/src/Aspire.Cli/Resources/TelemetryCommandStrings.resx
+++ b/src/Aspire.Cli/Resources/TelemetryCommandStrings.resx
@@ -154,7 +154,7 @@
     <value>Filter by error status (true to show only errors, false to exclude errors)</value>
   </data>
   <data name="SearchOptionDescription" xml:space="preserve">
-    <value>Full-text search across telemetry text fields, such as log messages, attribute values, names, source, and IDs</value>
+    <value>Search and filter telemetry fields such as log messages, attribute values, names, source, and IDs. Supports full-text search and field filters. See https://aka.ms/aspire/cli-search for more details</value>
   </data>
   <data name="LimitMustBePositive" xml:space="preserve">
     <value>The --limit value must be a positive number.</value>

--- a/src/Aspire.Cli/Resources/xlf/LogsCommandStrings.cs.xlf
+++ b/src/Aspire.Cli/Resources/xlf/LogsCommandStrings.cs.xlf
@@ -48,8 +48,8 @@
         <note />
       </trans-unit>
       <trans-unit id="SearchOptionDescription">
-        <source>Search and filter log content fields such as messages, categories, and attribute values. Supports full-text search and field filters. See https://aka.ms/aspire/cli-search for more details</source>
-        <target state="new">Search and filter log content fields such as messages, categories, and attribute values. Supports full-text search and field filters. See https://aka.ms/aspire/cli-search for more details</target>
+        <source>Full-text search to filter log content. See https://aka.ms/aspire/cli-search for more details</source>
+        <target state="new">Full-text search to filter log content. See https://aka.ms/aspire/cli-search for more details</target>
         <note />
       </trans-unit>
       <trans-unit id="SelectAppHostAction">

--- a/src/Aspire.Cli/Resources/xlf/LogsCommandStrings.cs.xlf
+++ b/src/Aspire.Cli/Resources/xlf/LogsCommandStrings.cs.xlf
@@ -48,8 +48,8 @@
         <note />
       </trans-unit>
       <trans-unit id="SearchOptionDescription">
-        <source>Full-text search to filter log content</source>
-        <target state="new">Full-text search to filter log content</target>
+        <source>Search and filter log content fields such as messages, categories, and attribute values. Supports full-text search and field filters. See https://aka.ms/aspire/cli-search for more details</source>
+        <target state="new">Search and filter log content fields such as messages, categories, and attribute values. Supports full-text search and field filters. See https://aka.ms/aspire/cli-search for more details</target>
         <note />
       </trans-unit>
       <trans-unit id="SelectAppHostAction">

--- a/src/Aspire.Cli/Resources/xlf/LogsCommandStrings.de.xlf
+++ b/src/Aspire.Cli/Resources/xlf/LogsCommandStrings.de.xlf
@@ -48,8 +48,8 @@
         <note />
       </trans-unit>
       <trans-unit id="SearchOptionDescription">
-        <source>Search and filter log content fields such as messages, categories, and attribute values. Supports full-text search and field filters. See https://aka.ms/aspire/cli-search for more details</source>
-        <target state="new">Search and filter log content fields such as messages, categories, and attribute values. Supports full-text search and field filters. See https://aka.ms/aspire/cli-search for more details</target>
+        <source>Full-text search to filter log content. See https://aka.ms/aspire/cli-search for more details</source>
+        <target state="new">Full-text search to filter log content. See https://aka.ms/aspire/cli-search for more details</target>
         <note />
       </trans-unit>
       <trans-unit id="SelectAppHostAction">

--- a/src/Aspire.Cli/Resources/xlf/LogsCommandStrings.de.xlf
+++ b/src/Aspire.Cli/Resources/xlf/LogsCommandStrings.de.xlf
@@ -48,8 +48,8 @@
         <note />
       </trans-unit>
       <trans-unit id="SearchOptionDescription">
-        <source>Full-text search to filter log content</source>
-        <target state="new">Full-text search to filter log content</target>
+        <source>Search and filter log content fields such as messages, categories, and attribute values. Supports full-text search and field filters. See https://aka.ms/aspire/cli-search for more details</source>
+        <target state="new">Search and filter log content fields such as messages, categories, and attribute values. Supports full-text search and field filters. See https://aka.ms/aspire/cli-search for more details</target>
         <note />
       </trans-unit>
       <trans-unit id="SelectAppHostAction">

--- a/src/Aspire.Cli/Resources/xlf/LogsCommandStrings.es.xlf
+++ b/src/Aspire.Cli/Resources/xlf/LogsCommandStrings.es.xlf
@@ -48,8 +48,8 @@
         <note />
       </trans-unit>
       <trans-unit id="SearchOptionDescription">
-        <source>Search and filter log content fields such as messages, categories, and attribute values. Supports full-text search and field filters. See https://aka.ms/aspire/cli-search for more details</source>
-        <target state="new">Search and filter log content fields such as messages, categories, and attribute values. Supports full-text search and field filters. See https://aka.ms/aspire/cli-search for more details</target>
+        <source>Full-text search to filter log content. See https://aka.ms/aspire/cli-search for more details</source>
+        <target state="new">Full-text search to filter log content. See https://aka.ms/aspire/cli-search for more details</target>
         <note />
       </trans-unit>
       <trans-unit id="SelectAppHostAction">

--- a/src/Aspire.Cli/Resources/xlf/LogsCommandStrings.es.xlf
+++ b/src/Aspire.Cli/Resources/xlf/LogsCommandStrings.es.xlf
@@ -48,8 +48,8 @@
         <note />
       </trans-unit>
       <trans-unit id="SearchOptionDescription">
-        <source>Full-text search to filter log content</source>
-        <target state="new">Full-text search to filter log content</target>
+        <source>Search and filter log content fields such as messages, categories, and attribute values. Supports full-text search and field filters. See https://aka.ms/aspire/cli-search for more details</source>
+        <target state="new">Search and filter log content fields such as messages, categories, and attribute values. Supports full-text search and field filters. See https://aka.ms/aspire/cli-search for more details</target>
         <note />
       </trans-unit>
       <trans-unit id="SelectAppHostAction">

--- a/src/Aspire.Cli/Resources/xlf/LogsCommandStrings.fr.xlf
+++ b/src/Aspire.Cli/Resources/xlf/LogsCommandStrings.fr.xlf
@@ -48,8 +48,8 @@
         <note />
       </trans-unit>
       <trans-unit id="SearchOptionDescription">
-        <source>Search and filter log content fields such as messages, categories, and attribute values. Supports full-text search and field filters. See https://aka.ms/aspire/cli-search for more details</source>
-        <target state="new">Search and filter log content fields such as messages, categories, and attribute values. Supports full-text search and field filters. See https://aka.ms/aspire/cli-search for more details</target>
+        <source>Full-text search to filter log content. See https://aka.ms/aspire/cli-search for more details</source>
+        <target state="new">Full-text search to filter log content. See https://aka.ms/aspire/cli-search for more details</target>
         <note />
       </trans-unit>
       <trans-unit id="SelectAppHostAction">

--- a/src/Aspire.Cli/Resources/xlf/LogsCommandStrings.fr.xlf
+++ b/src/Aspire.Cli/Resources/xlf/LogsCommandStrings.fr.xlf
@@ -48,8 +48,8 @@
         <note />
       </trans-unit>
       <trans-unit id="SearchOptionDescription">
-        <source>Full-text search to filter log content</source>
-        <target state="new">Full-text search to filter log content</target>
+        <source>Search and filter log content fields such as messages, categories, and attribute values. Supports full-text search and field filters. See https://aka.ms/aspire/cli-search for more details</source>
+        <target state="new">Search and filter log content fields such as messages, categories, and attribute values. Supports full-text search and field filters. See https://aka.ms/aspire/cli-search for more details</target>
         <note />
       </trans-unit>
       <trans-unit id="SelectAppHostAction">

--- a/src/Aspire.Cli/Resources/xlf/LogsCommandStrings.it.xlf
+++ b/src/Aspire.Cli/Resources/xlf/LogsCommandStrings.it.xlf
@@ -48,8 +48,8 @@
         <note />
       </trans-unit>
       <trans-unit id="SearchOptionDescription">
-        <source>Search and filter log content fields such as messages, categories, and attribute values. Supports full-text search and field filters. See https://aka.ms/aspire/cli-search for more details</source>
-        <target state="new">Search and filter log content fields such as messages, categories, and attribute values. Supports full-text search and field filters. See https://aka.ms/aspire/cli-search for more details</target>
+        <source>Full-text search to filter log content. See https://aka.ms/aspire/cli-search for more details</source>
+        <target state="new">Full-text search to filter log content. See https://aka.ms/aspire/cli-search for more details</target>
         <note />
       </trans-unit>
       <trans-unit id="SelectAppHostAction">

--- a/src/Aspire.Cli/Resources/xlf/LogsCommandStrings.it.xlf
+++ b/src/Aspire.Cli/Resources/xlf/LogsCommandStrings.it.xlf
@@ -48,8 +48,8 @@
         <note />
       </trans-unit>
       <trans-unit id="SearchOptionDescription">
-        <source>Full-text search to filter log content</source>
-        <target state="new">Full-text search to filter log content</target>
+        <source>Search and filter log content fields such as messages, categories, and attribute values. Supports full-text search and field filters. See https://aka.ms/aspire/cli-search for more details</source>
+        <target state="new">Search and filter log content fields such as messages, categories, and attribute values. Supports full-text search and field filters. See https://aka.ms/aspire/cli-search for more details</target>
         <note />
       </trans-unit>
       <trans-unit id="SelectAppHostAction">

--- a/src/Aspire.Cli/Resources/xlf/LogsCommandStrings.ja.xlf
+++ b/src/Aspire.Cli/Resources/xlf/LogsCommandStrings.ja.xlf
@@ -48,8 +48,8 @@
         <note />
       </trans-unit>
       <trans-unit id="SearchOptionDescription">
-        <source>Search and filter log content fields such as messages, categories, and attribute values. Supports full-text search and field filters. See https://aka.ms/aspire/cli-search for more details</source>
-        <target state="new">Search and filter log content fields such as messages, categories, and attribute values. Supports full-text search and field filters. See https://aka.ms/aspire/cli-search for more details</target>
+        <source>Full-text search to filter log content. See https://aka.ms/aspire/cli-search for more details</source>
+        <target state="new">Full-text search to filter log content. See https://aka.ms/aspire/cli-search for more details</target>
         <note />
       </trans-unit>
       <trans-unit id="SelectAppHostAction">

--- a/src/Aspire.Cli/Resources/xlf/LogsCommandStrings.ja.xlf
+++ b/src/Aspire.Cli/Resources/xlf/LogsCommandStrings.ja.xlf
@@ -48,8 +48,8 @@
         <note />
       </trans-unit>
       <trans-unit id="SearchOptionDescription">
-        <source>Full-text search to filter log content</source>
-        <target state="new">Full-text search to filter log content</target>
+        <source>Search and filter log content fields such as messages, categories, and attribute values. Supports full-text search and field filters. See https://aka.ms/aspire/cli-search for more details</source>
+        <target state="new">Search and filter log content fields such as messages, categories, and attribute values. Supports full-text search and field filters. See https://aka.ms/aspire/cli-search for more details</target>
         <note />
       </trans-unit>
       <trans-unit id="SelectAppHostAction">

--- a/src/Aspire.Cli/Resources/xlf/LogsCommandStrings.ko.xlf
+++ b/src/Aspire.Cli/Resources/xlf/LogsCommandStrings.ko.xlf
@@ -48,8 +48,8 @@
         <note />
       </trans-unit>
       <trans-unit id="SearchOptionDescription">
-        <source>Search and filter log content fields such as messages, categories, and attribute values. Supports full-text search and field filters. See https://aka.ms/aspire/cli-search for more details</source>
-        <target state="new">Search and filter log content fields such as messages, categories, and attribute values. Supports full-text search and field filters. See https://aka.ms/aspire/cli-search for more details</target>
+        <source>Full-text search to filter log content. See https://aka.ms/aspire/cli-search for more details</source>
+        <target state="new">Full-text search to filter log content. See https://aka.ms/aspire/cli-search for more details</target>
         <note />
       </trans-unit>
       <trans-unit id="SelectAppHostAction">

--- a/src/Aspire.Cli/Resources/xlf/LogsCommandStrings.ko.xlf
+++ b/src/Aspire.Cli/Resources/xlf/LogsCommandStrings.ko.xlf
@@ -48,8 +48,8 @@
         <note />
       </trans-unit>
       <trans-unit id="SearchOptionDescription">
-        <source>Full-text search to filter log content</source>
-        <target state="new">Full-text search to filter log content</target>
+        <source>Search and filter log content fields such as messages, categories, and attribute values. Supports full-text search and field filters. See https://aka.ms/aspire/cli-search for more details</source>
+        <target state="new">Search and filter log content fields such as messages, categories, and attribute values. Supports full-text search and field filters. See https://aka.ms/aspire/cli-search for more details</target>
         <note />
       </trans-unit>
       <trans-unit id="SelectAppHostAction">

--- a/src/Aspire.Cli/Resources/xlf/LogsCommandStrings.pl.xlf
+++ b/src/Aspire.Cli/Resources/xlf/LogsCommandStrings.pl.xlf
@@ -48,8 +48,8 @@
         <note />
       </trans-unit>
       <trans-unit id="SearchOptionDescription">
-        <source>Search and filter log content fields such as messages, categories, and attribute values. Supports full-text search and field filters. See https://aka.ms/aspire/cli-search for more details</source>
-        <target state="new">Search and filter log content fields such as messages, categories, and attribute values. Supports full-text search and field filters. See https://aka.ms/aspire/cli-search for more details</target>
+        <source>Full-text search to filter log content. See https://aka.ms/aspire/cli-search for more details</source>
+        <target state="new">Full-text search to filter log content. See https://aka.ms/aspire/cli-search for more details</target>
         <note />
       </trans-unit>
       <trans-unit id="SelectAppHostAction">

--- a/src/Aspire.Cli/Resources/xlf/LogsCommandStrings.pl.xlf
+++ b/src/Aspire.Cli/Resources/xlf/LogsCommandStrings.pl.xlf
@@ -48,8 +48,8 @@
         <note />
       </trans-unit>
       <trans-unit id="SearchOptionDescription">
-        <source>Full-text search to filter log content</source>
-        <target state="new">Full-text search to filter log content</target>
+        <source>Search and filter log content fields such as messages, categories, and attribute values. Supports full-text search and field filters. See https://aka.ms/aspire/cli-search for more details</source>
+        <target state="new">Search and filter log content fields such as messages, categories, and attribute values. Supports full-text search and field filters. See https://aka.ms/aspire/cli-search for more details</target>
         <note />
       </trans-unit>
       <trans-unit id="SelectAppHostAction">

--- a/src/Aspire.Cli/Resources/xlf/LogsCommandStrings.pt-BR.xlf
+++ b/src/Aspire.Cli/Resources/xlf/LogsCommandStrings.pt-BR.xlf
@@ -48,8 +48,8 @@
         <note />
       </trans-unit>
       <trans-unit id="SearchOptionDescription">
-        <source>Search and filter log content fields such as messages, categories, and attribute values. Supports full-text search and field filters. See https://aka.ms/aspire/cli-search for more details</source>
-        <target state="new">Search and filter log content fields such as messages, categories, and attribute values. Supports full-text search and field filters. See https://aka.ms/aspire/cli-search for more details</target>
+        <source>Full-text search to filter log content. See https://aka.ms/aspire/cli-search for more details</source>
+        <target state="new">Full-text search to filter log content. See https://aka.ms/aspire/cli-search for more details</target>
         <note />
       </trans-unit>
       <trans-unit id="SelectAppHostAction">

--- a/src/Aspire.Cli/Resources/xlf/LogsCommandStrings.pt-BR.xlf
+++ b/src/Aspire.Cli/Resources/xlf/LogsCommandStrings.pt-BR.xlf
@@ -48,8 +48,8 @@
         <note />
       </trans-unit>
       <trans-unit id="SearchOptionDescription">
-        <source>Full-text search to filter log content</source>
-        <target state="new">Full-text search to filter log content</target>
+        <source>Search and filter log content fields such as messages, categories, and attribute values. Supports full-text search and field filters. See https://aka.ms/aspire/cli-search for more details</source>
+        <target state="new">Search and filter log content fields such as messages, categories, and attribute values. Supports full-text search and field filters. See https://aka.ms/aspire/cli-search for more details</target>
         <note />
       </trans-unit>
       <trans-unit id="SelectAppHostAction">

--- a/src/Aspire.Cli/Resources/xlf/LogsCommandStrings.ru.xlf
+++ b/src/Aspire.Cli/Resources/xlf/LogsCommandStrings.ru.xlf
@@ -48,8 +48,8 @@
         <note />
       </trans-unit>
       <trans-unit id="SearchOptionDescription">
-        <source>Search and filter log content fields such as messages, categories, and attribute values. Supports full-text search and field filters. See https://aka.ms/aspire/cli-search for more details</source>
-        <target state="new">Search and filter log content fields such as messages, categories, and attribute values. Supports full-text search and field filters. See https://aka.ms/aspire/cli-search for more details</target>
+        <source>Full-text search to filter log content. See https://aka.ms/aspire/cli-search for more details</source>
+        <target state="new">Full-text search to filter log content. See https://aka.ms/aspire/cli-search for more details</target>
         <note />
       </trans-unit>
       <trans-unit id="SelectAppHostAction">

--- a/src/Aspire.Cli/Resources/xlf/LogsCommandStrings.ru.xlf
+++ b/src/Aspire.Cli/Resources/xlf/LogsCommandStrings.ru.xlf
@@ -48,8 +48,8 @@
         <note />
       </trans-unit>
       <trans-unit id="SearchOptionDescription">
-        <source>Full-text search to filter log content</source>
-        <target state="new">Full-text search to filter log content</target>
+        <source>Search and filter log content fields such as messages, categories, and attribute values. Supports full-text search and field filters. See https://aka.ms/aspire/cli-search for more details</source>
+        <target state="new">Search and filter log content fields such as messages, categories, and attribute values. Supports full-text search and field filters. See https://aka.ms/aspire/cli-search for more details</target>
         <note />
       </trans-unit>
       <trans-unit id="SelectAppHostAction">

--- a/src/Aspire.Cli/Resources/xlf/LogsCommandStrings.tr.xlf
+++ b/src/Aspire.Cli/Resources/xlf/LogsCommandStrings.tr.xlf
@@ -48,8 +48,8 @@
         <note />
       </trans-unit>
       <trans-unit id="SearchOptionDescription">
-        <source>Search and filter log content fields such as messages, categories, and attribute values. Supports full-text search and field filters. See https://aka.ms/aspire/cli-search for more details</source>
-        <target state="new">Search and filter log content fields such as messages, categories, and attribute values. Supports full-text search and field filters. See https://aka.ms/aspire/cli-search for more details</target>
+        <source>Full-text search to filter log content. See https://aka.ms/aspire/cli-search for more details</source>
+        <target state="new">Full-text search to filter log content. See https://aka.ms/aspire/cli-search for more details</target>
         <note />
       </trans-unit>
       <trans-unit id="SelectAppHostAction">

--- a/src/Aspire.Cli/Resources/xlf/LogsCommandStrings.tr.xlf
+++ b/src/Aspire.Cli/Resources/xlf/LogsCommandStrings.tr.xlf
@@ -48,8 +48,8 @@
         <note />
       </trans-unit>
       <trans-unit id="SearchOptionDescription">
-        <source>Full-text search to filter log content</source>
-        <target state="new">Full-text search to filter log content</target>
+        <source>Search and filter log content fields such as messages, categories, and attribute values. Supports full-text search and field filters. See https://aka.ms/aspire/cli-search for more details</source>
+        <target state="new">Search and filter log content fields such as messages, categories, and attribute values. Supports full-text search and field filters. See https://aka.ms/aspire/cli-search for more details</target>
         <note />
       </trans-unit>
       <trans-unit id="SelectAppHostAction">

--- a/src/Aspire.Cli/Resources/xlf/LogsCommandStrings.zh-Hans.xlf
+++ b/src/Aspire.Cli/Resources/xlf/LogsCommandStrings.zh-Hans.xlf
@@ -48,8 +48,8 @@
         <note />
       </trans-unit>
       <trans-unit id="SearchOptionDescription">
-        <source>Search and filter log content fields such as messages, categories, and attribute values. Supports full-text search and field filters. See https://aka.ms/aspire/cli-search for more details</source>
-        <target state="new">Search and filter log content fields such as messages, categories, and attribute values. Supports full-text search and field filters. See https://aka.ms/aspire/cli-search for more details</target>
+        <source>Full-text search to filter log content. See https://aka.ms/aspire/cli-search for more details</source>
+        <target state="new">Full-text search to filter log content. See https://aka.ms/aspire/cli-search for more details</target>
         <note />
       </trans-unit>
       <trans-unit id="SelectAppHostAction">

--- a/src/Aspire.Cli/Resources/xlf/LogsCommandStrings.zh-Hans.xlf
+++ b/src/Aspire.Cli/Resources/xlf/LogsCommandStrings.zh-Hans.xlf
@@ -48,8 +48,8 @@
         <note />
       </trans-unit>
       <trans-unit id="SearchOptionDescription">
-        <source>Full-text search to filter log content</source>
-        <target state="new">Full-text search to filter log content</target>
+        <source>Search and filter log content fields such as messages, categories, and attribute values. Supports full-text search and field filters. See https://aka.ms/aspire/cli-search for more details</source>
+        <target state="new">Search and filter log content fields such as messages, categories, and attribute values. Supports full-text search and field filters. See https://aka.ms/aspire/cli-search for more details</target>
         <note />
       </trans-unit>
       <trans-unit id="SelectAppHostAction">

--- a/src/Aspire.Cli/Resources/xlf/LogsCommandStrings.zh-Hant.xlf
+++ b/src/Aspire.Cli/Resources/xlf/LogsCommandStrings.zh-Hant.xlf
@@ -48,8 +48,8 @@
         <note />
       </trans-unit>
       <trans-unit id="SearchOptionDescription">
-        <source>Search and filter log content fields such as messages, categories, and attribute values. Supports full-text search and field filters. See https://aka.ms/aspire/cli-search for more details</source>
-        <target state="new">Search and filter log content fields such as messages, categories, and attribute values. Supports full-text search and field filters. See https://aka.ms/aspire/cli-search for more details</target>
+        <source>Full-text search to filter log content. See https://aka.ms/aspire/cli-search for more details</source>
+        <target state="new">Full-text search to filter log content. See https://aka.ms/aspire/cli-search for more details</target>
         <note />
       </trans-unit>
       <trans-unit id="SelectAppHostAction">

--- a/src/Aspire.Cli/Resources/xlf/LogsCommandStrings.zh-Hant.xlf
+++ b/src/Aspire.Cli/Resources/xlf/LogsCommandStrings.zh-Hant.xlf
@@ -48,8 +48,8 @@
         <note />
       </trans-unit>
       <trans-unit id="SearchOptionDescription">
-        <source>Full-text search to filter log content</source>
-        <target state="new">Full-text search to filter log content</target>
+        <source>Search and filter log content fields such as messages, categories, and attribute values. Supports full-text search and field filters. See https://aka.ms/aspire/cli-search for more details</source>
+        <target state="new">Search and filter log content fields such as messages, categories, and attribute values. Supports full-text search and field filters. See https://aka.ms/aspire/cli-search for more details</target>
         <note />
       </trans-unit>
       <trans-unit id="SelectAppHostAction">

--- a/src/Aspire.Cli/Resources/xlf/TelemetryCommandStrings.cs.xlf
+++ b/src/Aspire.Cli/Resources/xlf/TelemetryCommandStrings.cs.xlf
@@ -168,8 +168,8 @@
         <note />
       </trans-unit>
       <trans-unit id="SearchOptionDescription">
-        <source>Full-text search across telemetry text fields, such as log messages, attribute values, names, source, and IDs</source>
-        <target state="new">Full-text search across telemetry text fields, such as log messages, attribute values, names, source, and IDs</target>
+        <source>Search and filter telemetry fields such as log messages, attribute values, names, source, and IDs. Supports full-text search and field filters. See https://aka.ms/aspire/cli-search for more details</source>
+        <target state="new">Search and filter telemetry fields such as log messages, attribute values, names, source, and IDs. Supports full-text search and field filters. See https://aka.ms/aspire/cli-search for more details</target>
         <note />
       </trans-unit>
       <trans-unit id="SelectAppHostAction">

--- a/src/Aspire.Cli/Resources/xlf/TelemetryCommandStrings.de.xlf
+++ b/src/Aspire.Cli/Resources/xlf/TelemetryCommandStrings.de.xlf
@@ -168,8 +168,8 @@
         <note />
       </trans-unit>
       <trans-unit id="SearchOptionDescription">
-        <source>Full-text search across telemetry text fields, such as log messages, attribute values, names, source, and IDs</source>
-        <target state="new">Full-text search across telemetry text fields, such as log messages, attribute values, names, source, and IDs</target>
+        <source>Search and filter telemetry fields such as log messages, attribute values, names, source, and IDs. Supports full-text search and field filters. See https://aka.ms/aspire/cli-search for more details</source>
+        <target state="new">Search and filter telemetry fields such as log messages, attribute values, names, source, and IDs. Supports full-text search and field filters. See https://aka.ms/aspire/cli-search for more details</target>
         <note />
       </trans-unit>
       <trans-unit id="SelectAppHostAction">

--- a/src/Aspire.Cli/Resources/xlf/TelemetryCommandStrings.es.xlf
+++ b/src/Aspire.Cli/Resources/xlf/TelemetryCommandStrings.es.xlf
@@ -168,8 +168,8 @@
         <note />
       </trans-unit>
       <trans-unit id="SearchOptionDescription">
-        <source>Full-text search across telemetry text fields, such as log messages, attribute values, names, source, and IDs</source>
-        <target state="new">Full-text search across telemetry text fields, such as log messages, attribute values, names, source, and IDs</target>
+        <source>Search and filter telemetry fields such as log messages, attribute values, names, source, and IDs. Supports full-text search and field filters. See https://aka.ms/aspire/cli-search for more details</source>
+        <target state="new">Search and filter telemetry fields such as log messages, attribute values, names, source, and IDs. Supports full-text search and field filters. See https://aka.ms/aspire/cli-search for more details</target>
         <note />
       </trans-unit>
       <trans-unit id="SelectAppHostAction">

--- a/src/Aspire.Cli/Resources/xlf/TelemetryCommandStrings.fr.xlf
+++ b/src/Aspire.Cli/Resources/xlf/TelemetryCommandStrings.fr.xlf
@@ -168,8 +168,8 @@
         <note />
       </trans-unit>
       <trans-unit id="SearchOptionDescription">
-        <source>Full-text search across telemetry text fields, such as log messages, attribute values, names, source, and IDs</source>
-        <target state="new">Full-text search across telemetry text fields, such as log messages, attribute values, names, source, and IDs</target>
+        <source>Search and filter telemetry fields such as log messages, attribute values, names, source, and IDs. Supports full-text search and field filters. See https://aka.ms/aspire/cli-search for more details</source>
+        <target state="new">Search and filter telemetry fields such as log messages, attribute values, names, source, and IDs. Supports full-text search and field filters. See https://aka.ms/aspire/cli-search for more details</target>
         <note />
       </trans-unit>
       <trans-unit id="SelectAppHostAction">

--- a/src/Aspire.Cli/Resources/xlf/TelemetryCommandStrings.it.xlf
+++ b/src/Aspire.Cli/Resources/xlf/TelemetryCommandStrings.it.xlf
@@ -168,8 +168,8 @@
         <note />
       </trans-unit>
       <trans-unit id="SearchOptionDescription">
-        <source>Full-text search across telemetry text fields, such as log messages, attribute values, names, source, and IDs</source>
-        <target state="new">Full-text search across telemetry text fields, such as log messages, attribute values, names, source, and IDs</target>
+        <source>Search and filter telemetry fields such as log messages, attribute values, names, source, and IDs. Supports full-text search and field filters. See https://aka.ms/aspire/cli-search for more details</source>
+        <target state="new">Search and filter telemetry fields such as log messages, attribute values, names, source, and IDs. Supports full-text search and field filters. See https://aka.ms/aspire/cli-search for more details</target>
         <note />
       </trans-unit>
       <trans-unit id="SelectAppHostAction">

--- a/src/Aspire.Cli/Resources/xlf/TelemetryCommandStrings.ja.xlf
+++ b/src/Aspire.Cli/Resources/xlf/TelemetryCommandStrings.ja.xlf
@@ -168,8 +168,8 @@
         <note />
       </trans-unit>
       <trans-unit id="SearchOptionDescription">
-        <source>Full-text search across telemetry text fields, such as log messages, attribute values, names, source, and IDs</source>
-        <target state="new">Full-text search across telemetry text fields, such as log messages, attribute values, names, source, and IDs</target>
+        <source>Search and filter telemetry fields such as log messages, attribute values, names, source, and IDs. Supports full-text search and field filters. See https://aka.ms/aspire/cli-search for more details</source>
+        <target state="new">Search and filter telemetry fields such as log messages, attribute values, names, source, and IDs. Supports full-text search and field filters. See https://aka.ms/aspire/cli-search for more details</target>
         <note />
       </trans-unit>
       <trans-unit id="SelectAppHostAction">

--- a/src/Aspire.Cli/Resources/xlf/TelemetryCommandStrings.ko.xlf
+++ b/src/Aspire.Cli/Resources/xlf/TelemetryCommandStrings.ko.xlf
@@ -168,8 +168,8 @@
         <note />
       </trans-unit>
       <trans-unit id="SearchOptionDescription">
-        <source>Full-text search across telemetry text fields, such as log messages, attribute values, names, source, and IDs</source>
-        <target state="new">Full-text search across telemetry text fields, such as log messages, attribute values, names, source, and IDs</target>
+        <source>Search and filter telemetry fields such as log messages, attribute values, names, source, and IDs. Supports full-text search and field filters. See https://aka.ms/aspire/cli-search for more details</source>
+        <target state="new">Search and filter telemetry fields such as log messages, attribute values, names, source, and IDs. Supports full-text search and field filters. See https://aka.ms/aspire/cli-search for more details</target>
         <note />
       </trans-unit>
       <trans-unit id="SelectAppHostAction">

--- a/src/Aspire.Cli/Resources/xlf/TelemetryCommandStrings.pl.xlf
+++ b/src/Aspire.Cli/Resources/xlf/TelemetryCommandStrings.pl.xlf
@@ -168,8 +168,8 @@
         <note />
       </trans-unit>
       <trans-unit id="SearchOptionDescription">
-        <source>Full-text search across telemetry text fields, such as log messages, attribute values, names, source, and IDs</source>
-        <target state="new">Full-text search across telemetry text fields, such as log messages, attribute values, names, source, and IDs</target>
+        <source>Search and filter telemetry fields such as log messages, attribute values, names, source, and IDs. Supports full-text search and field filters. See https://aka.ms/aspire/cli-search for more details</source>
+        <target state="new">Search and filter telemetry fields such as log messages, attribute values, names, source, and IDs. Supports full-text search and field filters. See https://aka.ms/aspire/cli-search for more details</target>
         <note />
       </trans-unit>
       <trans-unit id="SelectAppHostAction">

--- a/src/Aspire.Cli/Resources/xlf/TelemetryCommandStrings.pt-BR.xlf
+++ b/src/Aspire.Cli/Resources/xlf/TelemetryCommandStrings.pt-BR.xlf
@@ -168,8 +168,8 @@
         <note />
       </trans-unit>
       <trans-unit id="SearchOptionDescription">
-        <source>Full-text search across telemetry text fields, such as log messages, attribute values, names, source, and IDs</source>
-        <target state="new">Full-text search across telemetry text fields, such as log messages, attribute values, names, source, and IDs</target>
+        <source>Search and filter telemetry fields such as log messages, attribute values, names, source, and IDs. Supports full-text search and field filters. See https://aka.ms/aspire/cli-search for more details</source>
+        <target state="new">Search and filter telemetry fields such as log messages, attribute values, names, source, and IDs. Supports full-text search and field filters. See https://aka.ms/aspire/cli-search for more details</target>
         <note />
       </trans-unit>
       <trans-unit id="SelectAppHostAction">

--- a/src/Aspire.Cli/Resources/xlf/TelemetryCommandStrings.ru.xlf
+++ b/src/Aspire.Cli/Resources/xlf/TelemetryCommandStrings.ru.xlf
@@ -168,8 +168,8 @@
         <note />
       </trans-unit>
       <trans-unit id="SearchOptionDescription">
-        <source>Full-text search across telemetry text fields, such as log messages, attribute values, names, source, and IDs</source>
-        <target state="new">Full-text search across telemetry text fields, such as log messages, attribute values, names, source, and IDs</target>
+        <source>Search and filter telemetry fields such as log messages, attribute values, names, source, and IDs. Supports full-text search and field filters. See https://aka.ms/aspire/cli-search for more details</source>
+        <target state="new">Search and filter telemetry fields such as log messages, attribute values, names, source, and IDs. Supports full-text search and field filters. See https://aka.ms/aspire/cli-search for more details</target>
         <note />
       </trans-unit>
       <trans-unit id="SelectAppHostAction">

--- a/src/Aspire.Cli/Resources/xlf/TelemetryCommandStrings.tr.xlf
+++ b/src/Aspire.Cli/Resources/xlf/TelemetryCommandStrings.tr.xlf
@@ -168,8 +168,8 @@
         <note />
       </trans-unit>
       <trans-unit id="SearchOptionDescription">
-        <source>Full-text search across telemetry text fields, such as log messages, attribute values, names, source, and IDs</source>
-        <target state="new">Full-text search across telemetry text fields, such as log messages, attribute values, names, source, and IDs</target>
+        <source>Search and filter telemetry fields such as log messages, attribute values, names, source, and IDs. Supports full-text search and field filters. See https://aka.ms/aspire/cli-search for more details</source>
+        <target state="new">Search and filter telemetry fields such as log messages, attribute values, names, source, and IDs. Supports full-text search and field filters. See https://aka.ms/aspire/cli-search for more details</target>
         <note />
       </trans-unit>
       <trans-unit id="SelectAppHostAction">

--- a/src/Aspire.Cli/Resources/xlf/TelemetryCommandStrings.zh-Hans.xlf
+++ b/src/Aspire.Cli/Resources/xlf/TelemetryCommandStrings.zh-Hans.xlf
@@ -168,8 +168,8 @@
         <note />
       </trans-unit>
       <trans-unit id="SearchOptionDescription">
-        <source>Full-text search across telemetry text fields, such as log messages, attribute values, names, source, and IDs</source>
-        <target state="new">Full-text search across telemetry text fields, such as log messages, attribute values, names, source, and IDs</target>
+        <source>Search and filter telemetry fields such as log messages, attribute values, names, source, and IDs. Supports full-text search and field filters. See https://aka.ms/aspire/cli-search for more details</source>
+        <target state="new">Search and filter telemetry fields such as log messages, attribute values, names, source, and IDs. Supports full-text search and field filters. See https://aka.ms/aspire/cli-search for more details</target>
         <note />
       </trans-unit>
       <trans-unit id="SelectAppHostAction">

--- a/src/Aspire.Cli/Resources/xlf/TelemetryCommandStrings.zh-Hant.xlf
+++ b/src/Aspire.Cli/Resources/xlf/TelemetryCommandStrings.zh-Hant.xlf
@@ -168,8 +168,8 @@
         <note />
       </trans-unit>
       <trans-unit id="SearchOptionDescription">
-        <source>Full-text search across telemetry text fields, such as log messages, attribute values, names, source, and IDs</source>
-        <target state="new">Full-text search across telemetry text fields, such as log messages, attribute values, names, source, and IDs</target>
+        <source>Search and filter telemetry fields such as log messages, attribute values, names, source, and IDs. Supports full-text search and field filters. See https://aka.ms/aspire/cli-search for more details</source>
+        <target state="new">Search and filter telemetry fields such as log messages, attribute values, names, source, and IDs. Supports full-text search and field filters. See https://aka.ms/aspire/cli-search for more details</target>
         <note />
       </trans-unit>
       <trans-unit id="SelectAppHostAction">


### PR DESCRIPTION
## Description

Updates the `--search` option description in the CLI to clarify that it supports full-text search and field filters, and adds a link to `https://aka.ms/aspire/cli-search` for more details.

The aka.ms link will be created separately to point to the relevant documentation.

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [x] No
- Did you add public API?
  - [ ] Yes
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
  - [x] No
