### PR TITLE
Localize Aspire skills metadata errors

### DIFF
--- a/src/Aspire.Cli/Agents/AspireSkills/AspireSkillsInstaller.cs
+++ b/src/Aspire.Cli/Agents/AspireSkills/AspireSkillsInstaller.cs
@@ -195,7 +195,10 @@ internal sealed class AspireSkillsInstaller(
 
         if (ValidateEmbeddedMetadata(metadata) is { } metadataError)
         {
-            return AcquisitionResult.Failed($"Embedded Aspire skills bundle metadata is invalid: {metadataError}");
+            return AcquisitionResult.Failed(string.Format(
+                CultureInfo.CurrentCulture,
+                AgentCommandStrings.AspireSkillsInstaller_InvalidMetadata,
+                metadataError));
         }
 
         if (!string.Equals(metadata.Version, version, StringComparison.OrdinalIgnoreCase))
@@ -256,27 +259,31 @@ internal sealed class AspireSkillsInstaller(
     {
         if (string.IsNullOrWhiteSpace(metadata.Version))
         {
-            return "Embedded Aspire skills metadata must specify a version.";
+            return AgentCommandStrings.AspireSkillsInstaller_MissingMetadataVersion;
         }
 
         if (!string.Equals(metadata.Repository, GitHubRepository, StringComparison.OrdinalIgnoreCase))
         {
-            return string.Format(CultureInfo.InvariantCulture, "Embedded Aspire skills metadata repository '{0}' does not match expected repository '{1}'.", metadata.Repository, GitHubRepository);
+            return string.Format(
+                CultureInfo.CurrentCulture,
+                AgentCommandStrings.AspireSkillsInstaller_MetadataRepositoryMismatch,
+                metadata.Repository,
+                GitHubRepository);
         }
 
         if (string.IsNullOrWhiteSpace(metadata.Tag))
         {
-            return "Embedded Aspire skills metadata must specify a GitHub release tag.";
+            return AgentCommandStrings.AspireSkillsInstaller_MissingMetadataTag;
         }
 
         if (string.IsNullOrWhiteSpace(metadata.AssetName))
         {
-            return "Embedded Aspire skills metadata must specify a release asset name.";
+            return AgentCommandStrings.AspireSkillsInstaller_MissingMetadataAssetName;
         }
 
         if (string.IsNullOrWhiteSpace(metadata.Sha256))
         {
-            return "Embedded Aspire skills metadata must specify the release asset SHA-256 hash.";
+            return AgentCommandStrings.AspireSkillsInstaller_MissingMetadataSha256;
         }
 
         return null;
@@ -294,8 +301,8 @@ internal sealed class AspireSkillsInstaller(
         if (!string.Equals(expectedHash, actualHash, StringComparison.OrdinalIgnoreCase))
         {
             throw new InvalidOperationException(string.Format(
-                CultureInfo.InvariantCulture,
-                "Embedded Aspire skills archive failed SHA-256 verification. Expected '{0}', got '{1}'.",
+                CultureInfo.CurrentCulture,
+                AgentCommandStrings.AspireSkillsInstaller_ArchiveHashVerificationFailed,
                 expectedHash,
                 actualHash));
         }

--- a/src/Aspire.Cli/Resources/AgentCommandStrings.Designer.cs
+++ b/src/Aspire.Cli/Resources/AgentCommandStrings.Designer.cs
@@ -394,6 +394,69 @@ namespace Aspire.Cli.Resources {
         }
 
         /// <summary>
+        ///   Looks up a localized string similar to Embedded Aspire skills bundle metadata is invalid: {0}.
+        /// </summary>
+        internal static string AspireSkillsInstaller_InvalidMetadata {
+            get {
+                return ResourceManager.GetString("AspireSkillsInstaller_InvalidMetadata", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Embedded Aspire skills metadata must specify a version..
+        /// </summary>
+        internal static string AspireSkillsInstaller_MissingMetadataVersion {
+            get {
+                return ResourceManager.GetString("AspireSkillsInstaller_MissingMetadataVersion", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Embedded Aspire skills metadata repository '{0}' does not match expected repository '{1}'..
+        /// </summary>
+        internal static string AspireSkillsInstaller_MetadataRepositoryMismatch {
+            get {
+                return ResourceManager.GetString("AspireSkillsInstaller_MetadataRepositoryMismatch", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Embedded Aspire skills metadata must specify a GitHub release tag..
+        /// </summary>
+        internal static string AspireSkillsInstaller_MissingMetadataTag {
+            get {
+                return ResourceManager.GetString("AspireSkillsInstaller_MissingMetadataTag", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Embedded Aspire skills metadata must specify a release asset name..
+        /// </summary>
+        internal static string AspireSkillsInstaller_MissingMetadataAssetName {
+            get {
+                return ResourceManager.GetString("AspireSkillsInstaller_MissingMetadataAssetName", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Embedded Aspire skills metadata must specify the release asset SHA-256 hash..
+        /// </summary>
+        internal static string AspireSkillsInstaller_MissingMetadataSha256 {
+            get {
+                return ResourceManager.GetString("AspireSkillsInstaller_MissingMetadataSha256", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Embedded Aspire skills archive failed SHA-256 verification. Expected '{0}', got '{1}'..
+        /// </summary>
+        internal static string AspireSkillsInstaller_ArchiveHashVerificationFailed {
+            get {
+                return ResourceManager.GetString("AspireSkillsInstaller_ArchiveHashVerificationFailed", resourceCulture);
+            }
+        }
+
+        /// <summary>
         ///   Looks up a localized string similar to Installing Playwright CLI....
         /// </summary>
         internal static string PlaywrightCliInstaller_InstallingStatus {

--- a/src/Aspire.Cli/Resources/AgentCommandStrings.resx
+++ b/src/Aspire.Cli/Resources/AgentCommandStrings.resx
@@ -171,6 +171,27 @@
   <data name="AspireSkillsInstaller_InvalidBundle" xml:space="preserve">
     <value>The Aspire skills bundle is invalid: {0}</value>
   </data>
+  <data name="AspireSkillsInstaller_InvalidMetadata" xml:space="preserve">
+    <value>Embedded Aspire skills bundle metadata is invalid: {0}</value>
+  </data>
+  <data name="AspireSkillsInstaller_MissingMetadataVersion" xml:space="preserve">
+    <value>Embedded Aspire skills metadata must specify a version.</value>
+  </data>
+  <data name="AspireSkillsInstaller_MetadataRepositoryMismatch" xml:space="preserve">
+    <value>Embedded Aspire skills metadata repository '{0}' does not match expected repository '{1}'.</value>
+  </data>
+  <data name="AspireSkillsInstaller_MissingMetadataTag" xml:space="preserve">
+    <value>Embedded Aspire skills metadata must specify a GitHub release tag.</value>
+  </data>
+  <data name="AspireSkillsInstaller_MissingMetadataAssetName" xml:space="preserve">
+    <value>Embedded Aspire skills metadata must specify a release asset name.</value>
+  </data>
+  <data name="AspireSkillsInstaller_MissingMetadataSha256" xml:space="preserve">
+    <value>Embedded Aspire skills metadata must specify the release asset SHA-256 hash.</value>
+  </data>
+  <data name="AspireSkillsInstaller_ArchiveHashVerificationFailed" xml:space="preserve">
+    <value>Embedded Aspire skills archive failed SHA-256 verification. Expected '{0}', got '{1}'.</value>
+  </data>
   <data name="PlaywrightCliInstaller_InstallingStatus" xml:space="preserve">
     <value>Installing Playwright CLI...</value>
   </data>

--- a/src/Aspire.Cli/Resources/xlf/AgentCommandStrings.cs.xlf
+++ b/src/Aspire.Cli/Resources/xlf/AgentCommandStrings.cs.xlf
@@ -2,9 +2,44 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="cs" original="../AgentCommandStrings.resx">
     <body>
+      <trans-unit id="AspireSkillsInstaller_ArchiveHashVerificationFailed">
+        <source>Embedded Aspire skills archive failed SHA-256 verification. Expected '{0}', got '{1}'.</source>
+        <target state="new">Embedded Aspire skills archive failed SHA-256 verification. Expected '{0}', got '{1}'.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="AspireSkillsInstaller_GitHubUnavailable">
         <source>Aspire skills could not be downloaded from the verified GitHub release asset, and no valid cached or embedded bundle is available.</source>
         <target state="new">Aspire skills could not be downloaded from the verified GitHub release asset, and no valid cached or embedded bundle is available.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AspireSkillsInstaller_InvalidMetadata">
+        <source>Embedded Aspire skills bundle metadata is invalid: {0}</source>
+        <target state="new">Embedded Aspire skills bundle metadata is invalid: {0}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AspireSkillsInstaller_MetadataRepositoryMismatch">
+        <source>Embedded Aspire skills metadata repository '{0}' does not match expected repository '{1}'.</source>
+        <target state="new">Embedded Aspire skills metadata repository '{0}' does not match expected repository '{1}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AspireSkillsInstaller_MissingMetadataAssetName">
+        <source>Embedded Aspire skills metadata must specify a release asset name.</source>
+        <target state="new">Embedded Aspire skills metadata must specify a release asset name.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AspireSkillsInstaller_MissingMetadataSha256">
+        <source>Embedded Aspire skills metadata must specify the release asset SHA-256 hash.</source>
+        <target state="new">Embedded Aspire skills metadata must specify the release asset SHA-256 hash.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AspireSkillsInstaller_MissingMetadataTag">
+        <source>Embedded Aspire skills metadata must specify a GitHub release tag.</source>
+        <target state="new">Embedded Aspire skills metadata must specify a GitHub release tag.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AspireSkillsInstaller_MissingMetadataVersion">
+        <source>Embedded Aspire skills metadata must specify a version.</source>
+        <target state="new">Embedded Aspire skills metadata must specify a version.</target>
         <note />
       </trans-unit>
       <trans-unit id="ConfigUpdatesSelectPrompt">

--- a/src/Aspire.Cli/Resources/xlf/AgentCommandStrings.de.xlf
+++ b/src/Aspire.Cli/Resources/xlf/AgentCommandStrings.de.xlf
@@ -2,9 +2,44 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="de" original="../AgentCommandStrings.resx">
     <body>
+      <trans-unit id="AspireSkillsInstaller_ArchiveHashVerificationFailed">
+        <source>Embedded Aspire skills archive failed SHA-256 verification. Expected '{0}', got '{1}'.</source>
+        <target state="new">Embedded Aspire skills archive failed SHA-256 verification. Expected '{0}', got '{1}'.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="AspireSkillsInstaller_GitHubUnavailable">
         <source>Aspire skills could not be downloaded from the verified GitHub release asset, and no valid cached or embedded bundle is available.</source>
         <target state="new">Aspire skills could not be downloaded from the verified GitHub release asset, and no valid cached or embedded bundle is available.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AspireSkillsInstaller_InvalidMetadata">
+        <source>Embedded Aspire skills bundle metadata is invalid: {0}</source>
+        <target state="new">Embedded Aspire skills bundle metadata is invalid: {0}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AspireSkillsInstaller_MetadataRepositoryMismatch">
+        <source>Embedded Aspire skills metadata repository '{0}' does not match expected repository '{1}'.</source>
+        <target state="new">Embedded Aspire skills metadata repository '{0}' does not match expected repository '{1}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AspireSkillsInstaller_MissingMetadataAssetName">
+        <source>Embedded Aspire skills metadata must specify a release asset name.</source>
+        <target state="new">Embedded Aspire skills metadata must specify a release asset name.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AspireSkillsInstaller_MissingMetadataSha256">
+        <source>Embedded Aspire skills metadata must specify the release asset SHA-256 hash.</source>
+        <target state="new">Embedded Aspire skills metadata must specify the release asset SHA-256 hash.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AspireSkillsInstaller_MissingMetadataTag">
+        <source>Embedded Aspire skills metadata must specify a GitHub release tag.</source>
+        <target state="new">Embedded Aspire skills metadata must specify a GitHub release tag.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AspireSkillsInstaller_MissingMetadataVersion">
+        <source>Embedded Aspire skills metadata must specify a version.</source>
+        <target state="new">Embedded Aspire skills metadata must specify a version.</target>
         <note />
       </trans-unit>
       <trans-unit id="ConfigUpdatesSelectPrompt">

--- a/src/Aspire.Cli/Resources/xlf/AgentCommandStrings.es.xlf
+++ b/src/Aspire.Cli/Resources/xlf/AgentCommandStrings.es.xlf
@@ -2,9 +2,44 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="es" original="../AgentCommandStrings.resx">
     <body>
+      <trans-unit id="AspireSkillsInstaller_ArchiveHashVerificationFailed">
+        <source>Embedded Aspire skills archive failed SHA-256 verification. Expected '{0}', got '{1}'.</source>
+        <target state="new">Embedded Aspire skills archive failed SHA-256 verification. Expected '{0}', got '{1}'.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="AspireSkillsInstaller_GitHubUnavailable">
         <source>Aspire skills could not be downloaded from the verified GitHub release asset, and no valid cached or embedded bundle is available.</source>
         <target state="new">Aspire skills could not be downloaded from the verified GitHub release asset, and no valid cached or embedded bundle is available.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AspireSkillsInstaller_InvalidMetadata">
+        <source>Embedded Aspire skills bundle metadata is invalid: {0}</source>
+        <target state="new">Embedded Aspire skills bundle metadata is invalid: {0}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AspireSkillsInstaller_MetadataRepositoryMismatch">
+        <source>Embedded Aspire skills metadata repository '{0}' does not match expected repository '{1}'.</source>
+        <target state="new">Embedded Aspire skills metadata repository '{0}' does not match expected repository '{1}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AspireSkillsInstaller_MissingMetadataAssetName">
+        <source>Embedded Aspire skills metadata must specify a release asset name.</source>
+        <target state="new">Embedded Aspire skills metadata must specify a release asset name.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AspireSkillsInstaller_MissingMetadataSha256">
+        <source>Embedded Aspire skills metadata must specify the release asset SHA-256 hash.</source>
+        <target state="new">Embedded Aspire skills metadata must specify the release asset SHA-256 hash.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AspireSkillsInstaller_MissingMetadataTag">
+        <source>Embedded Aspire skills metadata must specify a GitHub release tag.</source>
+        <target state="new">Embedded Aspire skills metadata must specify a GitHub release tag.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AspireSkillsInstaller_MissingMetadataVersion">
+        <source>Embedded Aspire skills metadata must specify a version.</source>
+        <target state="new">Embedded Aspire skills metadata must specify a version.</target>
         <note />
       </trans-unit>
       <trans-unit id="ConfigUpdatesSelectPrompt">

--- a/src/Aspire.Cli/Resources/xlf/AgentCommandStrings.fr.xlf
+++ b/src/Aspire.Cli/Resources/xlf/AgentCommandStrings.fr.xlf
@@ -2,9 +2,44 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="fr" original="../AgentCommandStrings.resx">
     <body>
+      <trans-unit id="AspireSkillsInstaller_ArchiveHashVerificationFailed">
+        <source>Embedded Aspire skills archive failed SHA-256 verification. Expected '{0}', got '{1}'.</source>
+        <target state="new">Embedded Aspire skills archive failed SHA-256 verification. Expected '{0}', got '{1}'.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="AspireSkillsInstaller_GitHubUnavailable">
         <source>Aspire skills could not be downloaded from the verified GitHub release asset, and no valid cached or embedded bundle is available.</source>
         <target state="new">Aspire skills could not be downloaded from the verified GitHub release asset, and no valid cached or embedded bundle is available.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AspireSkillsInstaller_InvalidMetadata">
+        <source>Embedded Aspire skills bundle metadata is invalid: {0}</source>
+        <target state="new">Embedded Aspire skills bundle metadata is invalid: {0}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AspireSkillsInstaller_MetadataRepositoryMismatch">
+        <source>Embedded Aspire skills metadata repository '{0}' does not match expected repository '{1}'.</source>
+        <target state="new">Embedded Aspire skills metadata repository '{0}' does not match expected repository '{1}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AspireSkillsInstaller_MissingMetadataAssetName">
+        <source>Embedded Aspire skills metadata must specify a release asset name.</source>
+        <target state="new">Embedded Aspire skills metadata must specify a release asset name.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AspireSkillsInstaller_MissingMetadataSha256">
+        <source>Embedded Aspire skills metadata must specify the release asset SHA-256 hash.</source>
+        <target state="new">Embedded Aspire skills metadata must specify the release asset SHA-256 hash.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AspireSkillsInstaller_MissingMetadataTag">
+        <source>Embedded Aspire skills metadata must specify a GitHub release tag.</source>
+        <target state="new">Embedded Aspire skills metadata must specify a GitHub release tag.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AspireSkillsInstaller_MissingMetadataVersion">
+        <source>Embedded Aspire skills metadata must specify a version.</source>
+        <target state="new">Embedded Aspire skills metadata must specify a version.</target>
         <note />
       </trans-unit>
       <trans-unit id="ConfigUpdatesSelectPrompt">

--- a/src/Aspire.Cli/Resources/xlf/AgentCommandStrings.it.xlf
+++ b/src/Aspire.Cli/Resources/xlf/AgentCommandStrings.it.xlf
@@ -2,9 +2,44 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="it" original="../AgentCommandStrings.resx">
     <body>
+      <trans-unit id="AspireSkillsInstaller_ArchiveHashVerificationFailed">
+        <source>Embedded Aspire skills archive failed SHA-256 verification. Expected '{0}', got '{1}'.</source>
+        <target state="new">Embedded Aspire skills archive failed SHA-256 verification. Expected '{0}', got '{1}'.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="AspireSkillsInstaller_GitHubUnavailable">
         <source>Aspire skills could not be downloaded from the verified GitHub release asset, and no valid cached or embedded bundle is available.</source>
         <target state="new">Aspire skills could not be downloaded from the verified GitHub release asset, and no valid cached or embedded bundle is available.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AspireSkillsInstaller_InvalidMetadata">
+        <source>Embedded Aspire skills bundle metadata is invalid: {0}</source>
+        <target state="new">Embedded Aspire skills bundle metadata is invalid: {0}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AspireSkillsInstaller_MetadataRepositoryMismatch">
+        <source>Embedded Aspire skills metadata repository '{0}' does not match expected repository '{1}'.</source>
+        <target state="new">Embedded Aspire skills metadata repository '{0}' does not match expected repository '{1}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AspireSkillsInstaller_MissingMetadataAssetName">
+        <source>Embedded Aspire skills metadata must specify a release asset name.</source>
+        <target state="new">Embedded Aspire skills metadata must specify a release asset name.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AspireSkillsInstaller_MissingMetadataSha256">
+        <source>Embedded Aspire skills metadata must specify the release asset SHA-256 hash.</source>
+        <target state="new">Embedded Aspire skills metadata must specify the release asset SHA-256 hash.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AspireSkillsInstaller_MissingMetadataTag">
+        <source>Embedded Aspire skills metadata must specify a GitHub release tag.</source>
+        <target state="new">Embedded Aspire skills metadata must specify a GitHub release tag.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AspireSkillsInstaller_MissingMetadataVersion">
+        <source>Embedded Aspire skills metadata must specify a version.</source>
+        <target state="new">Embedded Aspire skills metadata must specify a version.</target>
         <note />
       </trans-unit>
       <trans-unit id="ConfigUpdatesSelectPrompt">

--- a/src/Aspire.Cli/Resources/xlf/AgentCommandStrings.ja.xlf
+++ b/src/Aspire.Cli/Resources/xlf/AgentCommandStrings.ja.xlf
@@ -2,9 +2,44 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="ja" original="../AgentCommandStrings.resx">
     <body>
+      <trans-unit id="AspireSkillsInstaller_ArchiveHashVerificationFailed">
+        <source>Embedded Aspire skills archive failed SHA-256 verification. Expected '{0}', got '{1}'.</source>
+        <target state="new">Embedded Aspire skills archive failed SHA-256 verification. Expected '{0}', got '{1}'.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="AspireSkillsInstaller_GitHubUnavailable">
         <source>Aspire skills could not be downloaded from the verified GitHub release asset, and no valid cached or embedded bundle is available.</source>
         <target state="new">Aspire skills could not be downloaded from the verified GitHub release asset, and no valid cached or embedded bundle is available.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AspireSkillsInstaller_InvalidMetadata">
+        <source>Embedded Aspire skills bundle metadata is invalid: {0}</source>
+        <target state="new">Embedded Aspire skills bundle metadata is invalid: {0}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AspireSkillsInstaller_MetadataRepositoryMismatch">
+        <source>Embedded Aspire skills metadata repository '{0}' does not match expected repository '{1}'.</source>
+        <target state="new">Embedded Aspire skills metadata repository '{0}' does not match expected repository '{1}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AspireSkillsInstaller_MissingMetadataAssetName">
+        <source>Embedded Aspire skills metadata must specify a release asset name.</source>
+        <target state="new">Embedded Aspire skills metadata must specify a release asset name.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AspireSkillsInstaller_MissingMetadataSha256">
+        <source>Embedded Aspire skills metadata must specify the release asset SHA-256 hash.</source>
+        <target state="new">Embedded Aspire skills metadata must specify the release asset SHA-256 hash.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AspireSkillsInstaller_MissingMetadataTag">
+        <source>Embedded Aspire skills metadata must specify a GitHub release tag.</source>
+        <target state="new">Embedded Aspire skills metadata must specify a GitHub release tag.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AspireSkillsInstaller_MissingMetadataVersion">
+        <source>Embedded Aspire skills metadata must specify a version.</source>
+        <target state="new">Embedded Aspire skills metadata must specify a version.</target>
         <note />
       </trans-unit>
       <trans-unit id="ConfigUpdatesSelectPrompt">

--- a/src/Aspire.Cli/Resources/xlf/AgentCommandStrings.ko.xlf
+++ b/src/Aspire.Cli/Resources/xlf/AgentCommandStrings.ko.xlf
@@ -2,9 +2,44 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="ko" original="../AgentCommandStrings.resx">
     <body>
+      <trans-unit id="AspireSkillsInstaller_ArchiveHashVerificationFailed">
+        <source>Embedded Aspire skills archive failed SHA-256 verification. Expected '{0}', got '{1}'.</source>
+        <target state="new">Embedded Aspire skills archive failed SHA-256 verification. Expected '{0}', got '{1}'.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="AspireSkillsInstaller_GitHubUnavailable">
         <source>Aspire skills could not be downloaded from the verified GitHub release asset, and no valid cached or embedded bundle is available.</source>
         <target state="new">Aspire skills could not be downloaded from the verified GitHub release asset, and no valid cached or embedded bundle is available.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AspireSkillsInstaller_InvalidMetadata">
+        <source>Embedded Aspire skills bundle metadata is invalid: {0}</source>
+        <target state="new">Embedded Aspire skills bundle metadata is invalid: {0}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AspireSkillsInstaller_MetadataRepositoryMismatch">
+        <source>Embedded Aspire skills metadata repository '{0}' does not match expected repository '{1}'.</source>
+        <target state="new">Embedded Aspire skills metadata repository '{0}' does not match expected repository '{1}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AspireSkillsInstaller_MissingMetadataAssetName">
+        <source>Embedded Aspire skills metadata must specify a release asset name.</source>
+        <target state="new">Embedded Aspire skills metadata must specify a release asset name.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AspireSkillsInstaller_MissingMetadataSha256">
+        <source>Embedded Aspire skills metadata must specify the release asset SHA-256 hash.</source>
+        <target state="new">Embedded Aspire skills metadata must specify the release asset SHA-256 hash.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AspireSkillsInstaller_MissingMetadataTag">
+        <source>Embedded Aspire skills metadata must specify a GitHub release tag.</source>
+        <target state="new">Embedded Aspire skills metadata must specify a GitHub release tag.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AspireSkillsInstaller_MissingMetadataVersion">
+        <source>Embedded Aspire skills metadata must specify a version.</source>
+        <target state="new">Embedded Aspire skills metadata must specify a version.</target>
         <note />
       </trans-unit>
       <trans-unit id="ConfigUpdatesSelectPrompt">

--- a/src/Aspire.Cli/Resources/xlf/AgentCommandStrings.pl.xlf
+++ b/src/Aspire.Cli/Resources/xlf/AgentCommandStrings.pl.xlf
@@ -2,9 +2,44 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="pl" original="../AgentCommandStrings.resx">
     <body>
+      <trans-unit id="AspireSkillsInstaller_ArchiveHashVerificationFailed">
+        <source>Embedded Aspire skills archive failed SHA-256 verification. Expected '{0}', got '{1}'.</source>
+        <target state="new">Embedded Aspire skills archive failed SHA-256 verification. Expected '{0}', got '{1}'.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="AspireSkillsInstaller_GitHubUnavailable">
         <source>Aspire skills could not be downloaded from the verified GitHub release asset, and no valid cached or embedded bundle is available.</source>
         <target state="new">Aspire skills could not be downloaded from the verified GitHub release asset, and no valid cached or embedded bundle is available.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AspireSkillsInstaller_InvalidMetadata">
+        <source>Embedded Aspire skills bundle metadata is invalid: {0}</source>
+        <target state="new">Embedded Aspire skills bundle metadata is invalid: {0}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AspireSkillsInstaller_MetadataRepositoryMismatch">
+        <source>Embedded Aspire skills metadata repository '{0}' does not match expected repository '{1}'.</source>
+        <target state="new">Embedded Aspire skills metadata repository '{0}' does not match expected repository '{1}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AspireSkillsInstaller_MissingMetadataAssetName">
+        <source>Embedded Aspire skills metadata must specify a release asset name.</source>
+        <target state="new">Embedded Aspire skills metadata must specify a release asset name.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AspireSkillsInstaller_MissingMetadataSha256">
+        <source>Embedded Aspire skills metadata must specify the release asset SHA-256 hash.</source>
+        <target state="new">Embedded Aspire skills metadata must specify the release asset SHA-256 hash.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AspireSkillsInstaller_MissingMetadataTag">
+        <source>Embedded Aspire skills metadata must specify a GitHub release tag.</source>
+        <target state="new">Embedded Aspire skills metadata must specify a GitHub release tag.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AspireSkillsInstaller_MissingMetadataVersion">
+        <source>Embedded Aspire skills metadata must specify a version.</source>
+        <target state="new">Embedded Aspire skills metadata must specify a version.</target>
         <note />
       </trans-unit>
       <trans-unit id="ConfigUpdatesSelectPrompt">

--- a/src/Aspire.Cli/Resources/xlf/AgentCommandStrings.pt-BR.xlf
+++ b/src/Aspire.Cli/Resources/xlf/AgentCommandStrings.pt-BR.xlf
@@ -2,9 +2,44 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="pt-BR" original="../AgentCommandStrings.resx">
     <body>
+      <trans-unit id="AspireSkillsInstaller_ArchiveHashVerificationFailed">
+        <source>Embedded Aspire skills archive failed SHA-256 verification. Expected '{0}', got '{1}'.</source>
+        <target state="new">Embedded Aspire skills archive failed SHA-256 verification. Expected '{0}', got '{1}'.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="AspireSkillsInstaller_GitHubUnavailable">
         <source>Aspire skills could not be downloaded from the verified GitHub release asset, and no valid cached or embedded bundle is available.</source>
         <target state="new">Aspire skills could not be downloaded from the verified GitHub release asset, and no valid cached or embedded bundle is available.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AspireSkillsInstaller_InvalidMetadata">
+        <source>Embedded Aspire skills bundle metadata is invalid: {0}</source>
+        <target state="new">Embedded Aspire skills bundle metadata is invalid: {0}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AspireSkillsInstaller_MetadataRepositoryMismatch">
+        <source>Embedded Aspire skills metadata repository '{0}' does not match expected repository '{1}'.</source>
+        <target state="new">Embedded Aspire skills metadata repository '{0}' does not match expected repository '{1}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AspireSkillsInstaller_MissingMetadataAssetName">
+        <source>Embedded Aspire skills metadata must specify a release asset name.</source>
+        <target state="new">Embedded Aspire skills metadata must specify a release asset name.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AspireSkillsInstaller_MissingMetadataSha256">
+        <source>Embedded Aspire skills metadata must specify the release asset SHA-256 hash.</source>
+        <target state="new">Embedded Aspire skills metadata must specify the release asset SHA-256 hash.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AspireSkillsInstaller_MissingMetadataTag">
+        <source>Embedded Aspire skills metadata must specify a GitHub release tag.</source>
+        <target state="new">Embedded Aspire skills metadata must specify a GitHub release tag.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AspireSkillsInstaller_MissingMetadataVersion">
+        <source>Embedded Aspire skills metadata must specify a version.</source>
+        <target state="new">Embedded Aspire skills metadata must specify a version.</target>
         <note />
       </trans-unit>
       <trans-unit id="ConfigUpdatesSelectPrompt">

--- a/src/Aspire.Cli/Resources/xlf/AgentCommandStrings.ru.xlf
+++ b/src/Aspire.Cli/Resources/xlf/AgentCommandStrings.ru.xlf
@@ -2,9 +2,44 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="ru" original="../AgentCommandStrings.resx">
     <body>
+      <trans-unit id="AspireSkillsInstaller_ArchiveHashVerificationFailed">
+        <source>Embedded Aspire skills archive failed SHA-256 verification. Expected '{0}', got '{1}'.</source>
+        <target state="new">Embedded Aspire skills archive failed SHA-256 verification. Expected '{0}', got '{1}'.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="AspireSkillsInstaller_GitHubUnavailable">
         <source>Aspire skills could not be downloaded from the verified GitHub release asset, and no valid cached or embedded bundle is available.</source>
         <target state="new">Aspire skills could not be downloaded from the verified GitHub release asset, and no valid cached or embedded bundle is available.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AspireSkillsInstaller_InvalidMetadata">
+        <source>Embedded Aspire skills bundle metadata is invalid: {0}</source>
+        <target state="new">Embedded Aspire skills bundle metadata is invalid: {0}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AspireSkillsInstaller_MetadataRepositoryMismatch">
+        <source>Embedded Aspire skills metadata repository '{0}' does not match expected repository '{1}'.</source>
+        <target state="new">Embedded Aspire skills metadata repository '{0}' does not match expected repository '{1}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AspireSkillsInstaller_MissingMetadataAssetName">
+        <source>Embedded Aspire skills metadata must specify a release asset name.</source>
+        <target state="new">Embedded Aspire skills metadata must specify a release asset name.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AspireSkillsInstaller_MissingMetadataSha256">
+        <source>Embedded Aspire skills metadata must specify the release asset SHA-256 hash.</source>
+        <target state="new">Embedded Aspire skills metadata must specify the release asset SHA-256 hash.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AspireSkillsInstaller_MissingMetadataTag">
+        <source>Embedded Aspire skills metadata must specify a GitHub release tag.</source>
+        <target state="new">Embedded Aspire skills metadata must specify a GitHub release tag.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AspireSkillsInstaller_MissingMetadataVersion">
+        <source>Embedded Aspire skills metadata must specify a version.</source>
+        <target state="new">Embedded Aspire skills metadata must specify a version.</target>
         <note />
       </trans-unit>
       <trans-unit id="ConfigUpdatesSelectPrompt">

--- a/src/Aspire.Cli/Resources/xlf/AgentCommandStrings.tr.xlf
+++ b/src/Aspire.Cli/Resources/xlf/AgentCommandStrings.tr.xlf
@@ -2,9 +2,44 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="tr" original="../AgentCommandStrings.resx">
     <body>
+      <trans-unit id="AspireSkillsInstaller_ArchiveHashVerificationFailed">
+        <source>Embedded Aspire skills archive failed SHA-256 verification. Expected '{0}', got '{1}'.</source>
+        <target state="new">Embedded Aspire skills archive failed SHA-256 verification. Expected '{0}', got '{1}'.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="AspireSkillsInstaller_GitHubUnavailable">
         <source>Aspire skills could not be downloaded from the verified GitHub release asset, and no valid cached or embedded bundle is available.</source>
         <target state="new">Aspire skills could not be downloaded from the verified GitHub release asset, and no valid cached or embedded bundle is available.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AspireSkillsInstaller_InvalidMetadata">
+        <source>Embedded Aspire skills bundle metadata is invalid: {0}</source>
+        <target state="new">Embedded Aspire skills bundle metadata is invalid: {0}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AspireSkillsInstaller_MetadataRepositoryMismatch">
+        <source>Embedded Aspire skills metadata repository '{0}' does not match expected repository '{1}'.</source>
+        <target state="new">Embedded Aspire skills metadata repository '{0}' does not match expected repository '{1}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AspireSkillsInstaller_MissingMetadataAssetName">
+        <source>Embedded Aspire skills metadata must specify a release asset name.</source>
+        <target state="new">Embedded Aspire skills metadata must specify a release asset name.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AspireSkillsInstaller_MissingMetadataSha256">
+        <source>Embedded Aspire skills metadata must specify the release asset SHA-256 hash.</source>
+        <target state="new">Embedded Aspire skills metadata must specify the release asset SHA-256 hash.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AspireSkillsInstaller_MissingMetadataTag">
+        <source>Embedded Aspire skills metadata must specify a GitHub release tag.</source>
+        <target state="new">Embedded Aspire skills metadata must specify a GitHub release tag.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AspireSkillsInstaller_MissingMetadataVersion">
+        <source>Embedded Aspire skills metadata must specify a version.</source>
+        <target state="new">Embedded Aspire skills metadata must specify a version.</target>
         <note />
       </trans-unit>
       <trans-unit id="ConfigUpdatesSelectPrompt">

--- a/src/Aspire.Cli/Resources/xlf/AgentCommandStrings.zh-Hans.xlf
+++ b/src/Aspire.Cli/Resources/xlf/AgentCommandStrings.zh-Hans.xlf
@@ -2,9 +2,44 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="zh-Hans" original="../AgentCommandStrings.resx">
     <body>
+      <trans-unit id="AspireSkillsInstaller_ArchiveHashVerificationFailed">
+        <source>Embedded Aspire skills archive failed SHA-256 verification. Expected '{0}', got '{1}'.</source>
+        <target state="new">Embedded Aspire skills archive failed SHA-256 verification. Expected '{0}', got '{1}'.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="AspireSkillsInstaller_GitHubUnavailable">
         <source>Aspire skills could not be downloaded from the verified GitHub release asset, and no valid cached or embedded bundle is available.</source>
         <target state="new">Aspire skills could not be downloaded from the verified GitHub release asset, and no valid cached or embedded bundle is available.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AspireSkillsInstaller_InvalidMetadata">
+        <source>Embedded Aspire skills bundle metadata is invalid: {0}</source>
+        <target state="new">Embedded Aspire skills bundle metadata is invalid: {0}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AspireSkillsInstaller_MetadataRepositoryMismatch">
+        <source>Embedded Aspire skills metadata repository '{0}' does not match expected repository '{1}'.</source>
+        <target state="new">Embedded Aspire skills metadata repository '{0}' does not match expected repository '{1}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AspireSkillsInstaller_MissingMetadataAssetName">
+        <source>Embedded Aspire skills metadata must specify a release asset name.</source>
+        <target state="new">Embedded Aspire skills metadata must specify a release asset name.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AspireSkillsInstaller_MissingMetadataSha256">
+        <source>Embedded Aspire skills metadata must specify the release asset SHA-256 hash.</source>
+        <target state="new">Embedded Aspire skills metadata must specify the release asset SHA-256 hash.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AspireSkillsInstaller_MissingMetadataTag">
+        <source>Embedded Aspire skills metadata must specify a GitHub release tag.</source>
+        <target state="new">Embedded Aspire skills metadata must specify a GitHub release tag.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AspireSkillsInstaller_MissingMetadataVersion">
+        <source>Embedded Aspire skills metadata must specify a version.</source>
+        <target state="new">Embedded Aspire skills metadata must specify a version.</target>
         <note />
       </trans-unit>
       <trans-unit id="ConfigUpdatesSelectPrompt">

--- a/src/Aspire.Cli/Resources/xlf/AgentCommandStrings.zh-Hant.xlf
+++ b/src/Aspire.Cli/Resources/xlf/AgentCommandStrings.zh-Hant.xlf
@@ -2,9 +2,44 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="zh-Hant" original="../AgentCommandStrings.resx">
     <body>
+      <trans-unit id="AspireSkillsInstaller_ArchiveHashVerificationFailed">
+        <source>Embedded Aspire skills archive failed SHA-256 verification. Expected '{0}', got '{1}'.</source>
+        <target state="new">Embedded Aspire skills archive failed SHA-256 verification. Expected '{0}', got '{1}'.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="AspireSkillsInstaller_GitHubUnavailable">
         <source>Aspire skills could not be downloaded from the verified GitHub release asset, and no valid cached or embedded bundle is available.</source>
         <target state="new">Aspire skills could not be downloaded from the verified GitHub release asset, and no valid cached or embedded bundle is available.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AspireSkillsInstaller_InvalidMetadata">
+        <source>Embedded Aspire skills bundle metadata is invalid: {0}</source>
+        <target state="new">Embedded Aspire skills bundle metadata is invalid: {0}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AspireSkillsInstaller_MetadataRepositoryMismatch">
+        <source>Embedded Aspire skills metadata repository '{0}' does not match expected repository '{1}'.</source>
+        <target state="new">Embedded Aspire skills metadata repository '{0}' does not match expected repository '{1}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AspireSkillsInstaller_MissingMetadataAssetName">
+        <source>Embedded Aspire skills metadata must specify a release asset name.</source>
+        <target state="new">Embedded Aspire skills metadata must specify a release asset name.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AspireSkillsInstaller_MissingMetadataSha256">
+        <source>Embedded Aspire skills metadata must specify the release asset SHA-256 hash.</source>
+        <target state="new">Embedded Aspire skills metadata must specify the release asset SHA-256 hash.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AspireSkillsInstaller_MissingMetadataTag">
+        <source>Embedded Aspire skills metadata must specify a GitHub release tag.</source>
+        <target state="new">Embedded Aspire skills metadata must specify a GitHub release tag.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AspireSkillsInstaller_MissingMetadataVersion">
+        <source>Embedded Aspire skills metadata must specify a version.</source>
+        <target state="new">Embedded Aspire skills metadata must specify a version.</target>
         <note />
       </trans-unit>
       <trans-unit id="ConfigUpdatesSelectPrompt">


### PR DESCRIPTION
## Description

Localizes the embedded Aspire skills bundle metadata validation failures discussed in https://github.com/microsoft/aspire/pull/17537#discussion_r3311758464. The hard-coded metadata and archive verification messages now flow through `AgentCommandStrings`, and `UpdateXlf` added the corresponding entries for the CLI localization files.

Validation:

```text
dotnet test --project .\tests\Aspire.Cli.Tests\Aspire.Cli.Tests.csproj --no-launch-profile -- --filter-class "*.AspireSkillsInstallerTests" --filter-not-trait "quarantined=true" --filter-not-trait "outerloop=true"
```

Fixes # (issue)

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [x] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
