### PR TITLE
Fix Postgres health checks with Postgres 18

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -121,6 +121,7 @@
     <PackageVersion Include="MySqlConnector.Logging.Microsoft.Extensions.Logging" Version="2.1.0" />
     <PackageVersion Include="NATS.Net" Version="2.8.0" />
     <PackageVersion Include="NCrontab.Signed" Version="3.4.0" />
+    <PackageVersion Include="Npgsql" Version="10.0.2" />
     <PackageVersion Include="Npgsql.DependencyInjection" Version="10.0.2" />
     <PackageVersion Include="OpenAI" Version="2.10.0" />
     <PackageVersion Include="Oracle.ManagedDataAccess.OpenTelemetry" Version="23.26.200" />

--- a/src/Aspire.Hosting.PostgreSQL/Aspire.Hosting.PostgreSQL.csproj
+++ b/src/Aspire.Hosting.PostgreSQL/Aspire.Hosting.PostgreSQL.csproj
@@ -14,6 +14,7 @@
 
   <ItemGroup>
     <PackageReference Include="AspNetCore.HealthChecks.NpgSql" />
+    <PackageReference Include="Npgsql" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Summary

- add an explicit `Npgsql` dependency to `Aspire.Hosting.PostgreSQL`
- centrally pin `Npgsql` to `10.0.2`, matching the existing `Npgsql.DependencyInjection` version
- ensure the built-in Postgres healthcheck no longer resolves to `Npgsql` 8.0.3 when using the default `postgres:18.3` image

## Details

`Aspire.Hosting.PostgreSQL` registers its server healthcheck through `AspNetCore.HealthChecks.NpgSql` 9.0.0. Without a direct `Npgsql` dependency, that package resolves `Npgsql` 8.0.3.

After the default Postgres image moved from `postgres:17.6` to `postgres:18.3`, the `Npgsql` 8.0.3 healthcheck can time out even while the container is running and accepting connections. When `postgres_check` never becomes healthy, the Postgres `ResourceReadyEvent` is not published, so the `AddDatabase(...)` creation hook does not run and child database resources can remain missing/unhealthy.

Local repro evidence against `postgres:18.3`:

- direct `Npgsql` 8.0.3 connection timed out
- `AspNetCore.HealthChecks.NpgSql` 9.0.0 with transitive `Npgsql` 8.0.3 reported unhealthy
- direct `Npgsql` 9.0.5 / 10.0.1 connections succeeded
- `AspNetCore.HealthChecks.NpgSql` 9.0.0 with explicit newer `Npgsql` reported healthy

## Testing

```text
dotnet test --project tests/Aspire.Hosting.PostgreSQL.Tests/Aspire.Hosting.PostgreSQL.Tests.csproj -- --filter-method "*PostgresFunctionalTests.VerifyPostgresResource" --filter-method "*PostgresFunctionalTests.AddDatabaseCreatesDatabaseResiliently"
```

Passed: total 2, failed 0, succeeded 2