### PR TITLE
Close guest process stdin to avoid TTY hang on macOS

### DIFF
--- a/src/Aspire.Cli/Npm/NpmRunner.cs
+++ b/src/Aspire.Cli/Npm/NpmRunner.cs
@@ -276,6 +276,11 @@ internal sealed class NpmRunner(ILogger<NpmRunner> logger, ProfilingTelemetry pr
     {
         var startInfo = new ProcessStartInfo
         {
+            // Redirect stdin so the child npm process (and any lifecycle scripts it invokes)
+            // does not inherit the CLI's TTY. The caller closes stdin immediately after Start()
+            // so any read surfaces as EOF instead of hanging waiting on the terminal. NpmRunner
+            // is intended to be fully non-interactive. See https://github.com/microsoft/aspire/issues/16791.
+            RedirectStandardInput = true,
             RedirectStandardOutput = true,
             RedirectStandardError = true,
             UseShellExecute = false,
@@ -357,6 +362,17 @@ internal sealed class NpmRunner(ILogger<NpmRunner> logger, ProfilingTelemetry pr
             using var process = new Process { StartInfo = startInfo };
             using var activity = profilingTelemetry.StartNpmCommand(npmPath, args, workingDirectory);
             process.Start();
+            // Close stdin so any npm lifecycle script that tries to read terminal input
+            // sees EOF instead of blocking on the inherited TTY. See ProcessGuestLauncher
+            // and https://github.com/microsoft/aspire/issues/16791.
+            try
+            {
+                process.StandardInput.Close();
+            }
+            catch (IOException)
+            {
+                // The child may have already closed its stdin; ignore.
+            }
             activity.SetProcessId(process.Id);
 
             var outputTask = process.StandardOutput.ReadToEndAsync(cancellationToken);

--- a/src/Aspire.Cli/Npm/NpmRunner.cs
+++ b/src/Aspire.Cli/Npm/NpmRunner.cs
@@ -203,6 +203,11 @@ internal sealed class NpmRunner(IEnvironment environment, ILogger<NpmRunner> log
     {
         var startInfo = new ProcessStartInfo
         {
+            // Redirect stdin so the child npm process (and any lifecycle scripts it invokes)
+            // does not inherit the CLI's TTY. The caller closes stdin immediately after Start()
+            // so any read surfaces as EOF instead of hanging waiting on the terminal. NpmRunner
+            // is intended to be fully non-interactive. See https://github.com/microsoft/aspire/issues/16791.
+            RedirectStandardInput = true,
             RedirectStandardOutput = true,
             RedirectStandardError = true,
             UseShellExecute = false,
@@ -284,6 +289,17 @@ internal sealed class NpmRunner(IEnvironment environment, ILogger<NpmRunner> log
             using var process = new Process { StartInfo = startInfo };
             using var activity = profilingTelemetry.StartNpmCommand(npmPath, args, workingDirectory);
             process.Start();
+            // Close stdin so any npm lifecycle script that tries to read terminal input
+            // sees EOF instead of blocking on the inherited TTY. See ProcessGuestLauncher
+            // and https://github.com/microsoft/aspire/issues/16791.
+            try
+            {
+                process.StandardInput.Close();
+            }
+            catch (IOException)
+            {
+                // The child may have already closed its stdin; ignore.
+            }
             activity.SetProcessId(process.Id);
 
             var outputTask = process.StandardOutput.ReadToEndAsync(cancellationToken);

--- a/src/Aspire.Cli/Processes/IsolatedProcess.cs
+++ b/src/Aspire.Cli/Processes/IsolatedProcess.cs
@@ -332,7 +332,7 @@ internal sealed partial class IsolatedProcess : IAsyncDisposable
             }
             else
             {
-                startedProcess = StartRedirected(_startInfo, redirectStandardInput: !_startInfo.IsolateConsole);
+                startedProcess = StartRedirected(_startInfo);
             }
 
             InitializeStartedProcess(startedProcess);
@@ -361,14 +361,7 @@ internal sealed partial class IsolatedProcess : IAsyncDisposable
     /// Cross-platform redirected spawn: a thin <see cref="Process.Start(ProcessStartInfo)"/> wrapper.
     /// </summary>
     /// <param name="startInfo">Process launch parameters.</param>
-    /// <param name="redirectStandardInput">
-    /// <see langword="true"/> wires stdin to an empty redirected pipe (the non-isolated shape every
-    /// other CLI subprocess uses). <see langword="false"/> lets the child inherit the CLI's stdin
-    /// (the isolated-Unix shape).
-    /// </param>
-    private static StartedProcess StartRedirected(
-        IsolatedProcessStartInfo startInfo,
-        bool redirectStandardInput)
+    private static StartedProcess StartRedirected(IsolatedProcessStartInfo startInfo)
     {
         var psi = new ProcessStartInfo
         {
@@ -378,7 +371,10 @@ internal sealed partial class IsolatedProcess : IAsyncDisposable
             CreateNoWindow = true,
             RedirectStandardOutput = true,
             RedirectStandardError = true,
-            RedirectStandardInput = redirectStandardInput,
+            // Guest processes never consume input from the CLI. Redirect and close stdin so tools
+            // such as package-manager lifecycle scripts observe EOF instead of inheriting the TTY
+            // and blocking indefinitely. See https://github.com/microsoft/aspire/issues/16791.
+            RedirectStandardInput = true,
             // Pin encodings so process output decoding is stable regardless of the ambient
             // Console.OutputEncoding (e.g. on container hosts that leave it set to ASCII).
             StandardOutputEncoding = new UTF8Encoding(encoderShouldEmitUTF8Identifier: false, throwOnInvalidBytes: false),
@@ -398,6 +394,8 @@ internal sealed partial class IsolatedProcess : IAsyncDisposable
 
         var process = Process.Start(psi)
             ?? throw new InvalidOperationException($"Failed to start child process: {startInfo.FileName}");
+
+        process.StandardInput.Close();
 
         return new StartedProcess(
             process,

--- a/src/Aspire.Cli/Projects/DotNetBasedAppHostServerProject.cs
+++ b/src/Aspire.Cli/Projects/DotNetBasedAppHostServerProject.cs
@@ -518,10 +518,23 @@ internal sealed class DotNetBasedAppHostServerProject : IAppHostServerProject
             _logger.LogDebug("Enabling debug logging for AppHostServer");
         }
 
+        startInfo.RedirectStandardInput = true;
         startInfo.RedirectStandardOutput = true;
         startInfo.RedirectStandardError = true;
 
         var process = Process.Start(startInfo)!;
+        // Close the redirected stdin pipe immediately so the AppHost server process — and any
+        // child/library it loads — observes EOF rather than blocking on the parent CLI's TTY
+        // if it ever reads from stdin. The CLI communicates with the server over a Unix socket
+        // (REMOTE_APP_HOST_SOCKET_PATH), not stdin. See https://github.com/microsoft/aspire/issues/16791.
+        try
+        {
+            process.StandardInput.Close();
+        }
+        catch (IOException)
+        {
+            // The child may have already closed its stdin; ignore.
+        }
 
         var outputCollector = new OutputCollector();
         process.OutputDataReceived += (sender, e) =>

--- a/src/Aspire.Cli/Projects/DotNetBasedAppHostServerProject.cs
+++ b/src/Aspire.Cli/Projects/DotNetBasedAppHostServerProject.cs
@@ -547,6 +547,7 @@ internal sealed class DotNetBasedAppHostServerProject : IAppHostServerProject
             _logger.LogDebug("Enabling debug logging for AppHostServer");
         }
 
+        startInfo.RedirectStandardInput = true;
         startInfo.RedirectStandardOutput = true;
         startInfo.RedirectStandardError = true;
 

--- a/src/Aspire.Cli/Projects/PrebuiltAppHostServer.cs
+++ b/src/Aspire.Cli/Projects/PrebuiltAppHostServer.cs
@@ -918,6 +918,18 @@ internal sealed class PrebuiltAppHostServer : IAppHostServerProject, IDisposable
         var startInfo = CreateStartInfo(hostPid, environmentVariables, additionalArgs, debug);
 
         var process = Process.Start(startInfo)!;
+        // Close the redirected stdin pipe immediately so the AppHost server process — and any
+        // child/library it loads — observes EOF rather than blocking on the parent CLI's TTY
+        // if it ever reads from stdin. The CLI communicates with the server over a Unix socket
+        // (REMOTE_APP_HOST_SOCKET_PATH), not stdin. See https://github.com/microsoft/aspire/issues/16791.
+        try
+        {
+            process.StandardInput.Close();
+        }
+        catch (IOException)
+        {
+            // The child may have already closed its stdin; ignore.
+        }
 
         var outputCollector = new OutputCollector();
         process.OutputDataReceived += (_, e) =>
@@ -1043,6 +1055,7 @@ internal sealed class PrebuiltAppHostServer : IAppHostServerProject, IDisposable
             startInfo.Environment[KnownConfigNames.AspireLogLevel] = "Debug";
         }
 
+        startInfo.RedirectStandardInput = true;
         startInfo.RedirectStandardOutput = true;
         startInfo.RedirectStandardError = true;
 

--- a/src/Aspire.Cli/Projects/PrebuiltAppHostServer.cs
+++ b/src/Aspire.Cli/Projects/PrebuiltAppHostServer.cs
@@ -1080,6 +1080,7 @@ internal sealed class PrebuiltAppHostServer : IAppHostServerProject, IDisposable
             startInfo.Environment[KnownConfigNames.AspireLogLevel] = "Debug";
         }
 
+        startInfo.RedirectStandardInput = true;
         startInfo.RedirectStandardOutput = true;
         startInfo.RedirectStandardError = true;
 

--- a/src/Aspire.Cli/Projects/ProcessGuestLauncher.cs
+++ b/src/Aspire.Cli/Projects/ProcessGuestLauncher.cs
@@ -57,6 +57,13 @@ internal sealed class ProcessGuestLauncher : IGuestProcessLauncher
         {
             FileName = resolvedCommandPath,
             WorkingDirectory = workingDirectory.FullName,
+            // Redirect stdin so the child does not inherit the CLI's TTY. Without this, on macOS/Linux
+            // any child (e.g. `npm install` postinstall scripts, husky, package-manager permission
+            // prompts) that reads from stdin will block forever waiting on the terminal, making
+            // `aspire new`/`init`/`add`/`restore` appear to stall with no output. We close stdin
+            // immediately after Start() below so a reader sees EOF instead of hanging.
+            // See https://github.com/microsoft/aspire/issues/16791.
+            RedirectStandardInput = true,
             RedirectStandardOutput = true,
             RedirectStandardError = true,
             UseShellExecute = false,
@@ -124,6 +131,17 @@ internal sealed class ProcessGuestLauncher : IGuestProcessLauncher
         AddEvent(activity, ProfilingTelemetry.Events.GuestProcessStart);
         process.Start();
         _logger.LogDebug("{Language} guest process {ProcessId} started: {Command}", _language, process.Id, resolvedCommandPath);
+        // Close the redirected stdin pipe immediately so any read attempt in the child surfaces
+        // as EOF rather than blocking on an empty pipe. We never write to the guest process
+        // stdin, so this is safe.
+        try
+        {
+            process.StandardInput.Close();
+        }
+        catch (IOException)
+        {
+            // The child may have already closed its stdin; ignore.
+        }
         activity?.SetTag(TelemetryConstants.Tags.ProcessPid, process.Id);
         AddEvent(activity, ProfilingTelemetry.Events.GuestProcessStarted, TelemetryConstants.Tags.ProcessPid, process.Id);
         if (afterLaunchAsync is not null)

--- a/tests/Aspire.Cli.EndToEnd.Tests/Helpers/CliE2EAutomatorHelpers.cs
+++ b/tests/Aspire.Cli.EndToEnd.Tests/Helpers/CliE2EAutomatorHelpers.cs
@@ -879,7 +879,7 @@ internal static class CliE2EAutomatorHelpers
     /// Stops a running Aspire AppHost with <c>aspire stop</c>.
     /// </summary>
     /// <remarks>
-    /// Uses <see cref="Hex1bAutomatorTestHelpers.WaitForSuccessPromptFailFastAsync"/> so that a
+    /// Uses <see cref="Hex1bAutomatorTestHelpers.WaitForSuccessPromptAsync"/> so that a
     /// non-zero exit from <c>aspire stop</c> (for example the documented <c>FailedToDotnetRunAppHost</c>
     /// flake in https://github.com/microsoft/aspire/issues/16643) surfaces immediately with a
     /// useful diagnostic rather than the default 500-second wait for the success prompt. <c>aspire stop</c>
@@ -892,7 +892,7 @@ internal static class CliE2EAutomatorHelpers
     {
         await auto.TypeAsync("aspire stop");
         await auto.EnterAsync();
-        await auto.WaitForSuccessPromptFailFastAsync(counter);
+        await auto.WaitForSuccessPromptAsync(counter);
     }
 
     /// <summary>

--- a/tests/Aspire.Cli.EndToEnd.Tests/Helpers/CliE2EAutomatorHelpers.cs
+++ b/tests/Aspire.Cli.EndToEnd.Tests/Helpers/CliE2EAutomatorHelpers.cs
@@ -878,13 +878,21 @@ internal static class CliE2EAutomatorHelpers
     /// <summary>
     /// Stops a running Aspire AppHost with <c>aspire stop</c>.
     /// </summary>
+    /// <remarks>
+    /// Uses <see cref="Hex1bAutomatorTestHelpers.WaitForSuccessPromptFailFastAsync"/> so that a
+    /// non-zero exit from <c>aspire stop</c> (for example the documented <c>FailedToDotnetRunAppHost</c>
+    /// flake in https://github.com/microsoft/aspire/issues/16643) surfaces immediately with a
+    /// useful diagnostic rather than the default 500-second wait for the success prompt. <c>aspire stop</c>
+    /// is invoked at the end of E2E tests on the happy path; any error result is a real failure to
+    /// surface, not something the test should silently sit on.
+    /// </remarks>
     internal static async Task AspireStopAsync(
         this Hex1bTerminalAutomator auto,
         SequenceCounter counter)
     {
         await auto.TypeAsync("aspire stop");
         await auto.EnterAsync();
-        await auto.WaitForSuccessPromptAsync(counter);
+        await auto.WaitForSuccessPromptFailFastAsync(counter);
     }
 
     /// <summary>

--- a/tests/Aspire.Cli.EndToEnd.Tests/Helpers/CliE2EAutomatorHelpers.cs
+++ b/tests/Aspire.Cli.EndToEnd.Tests/Helpers/CliE2EAutomatorHelpers.cs
@@ -929,7 +929,7 @@ internal static class CliE2EAutomatorHelpers
     /// Stops a running Aspire AppHost with <c>aspire stop</c>.
     /// </summary>
     /// <remarks>
-    /// Uses <see cref="Hex1bAutomatorTestHelpers.WaitForSuccessPromptFailFastAsync"/> so that a
+    /// Uses <see cref="Hex1bAutomatorTestHelpers.WaitForSuccessPromptAsync"/> so that a
     /// non-zero exit from <c>aspire stop</c> (for example the documented <c>FailedToDotnetRunAppHost</c>
     /// flake in https://github.com/microsoft/aspire/issues/16643) surfaces immediately with a
     /// useful diagnostic rather than the default 500-second wait for the success prompt. <c>aspire stop</c>
@@ -944,7 +944,7 @@ internal static class CliE2EAutomatorHelpers
         var apphostFlag = apphost is not null ? $" --apphost {AspireCliShellCommandHelpers.QuoteBashArg(apphost)}" : "";
         await auto.TypeAsync($"aspire stop{apphostFlag}");
         await auto.EnterAsync();
-        await auto.WaitForSuccessPromptFailFastAsync(counter);
+        await auto.WaitForSuccessPromptAsync(counter);
     }
 
     /// <summary>

--- a/tests/Aspire.Cli.EndToEnd.Tests/Helpers/CliE2EAutomatorHelpers.cs
+++ b/tests/Aspire.Cli.EndToEnd.Tests/Helpers/CliE2EAutomatorHelpers.cs
@@ -928,6 +928,14 @@ internal static class CliE2EAutomatorHelpers
     /// <summary>
     /// Stops a running Aspire AppHost with <c>aspire stop</c>.
     /// </summary>
+    /// <remarks>
+    /// Uses <see cref="Hex1bAutomatorTestHelpers.WaitForSuccessPromptFailFastAsync"/> so that a
+    /// non-zero exit from <c>aspire stop</c> (for example the documented <c>FailedToDotnetRunAppHost</c>
+    /// flake in https://github.com/microsoft/aspire/issues/16643) surfaces immediately with a
+    /// useful diagnostic rather than the default 500-second wait for the success prompt. <c>aspire stop</c>
+    /// is invoked at the end of E2E tests on the happy path; any error result is a real failure to
+    /// surface, not something the test should silently sit on.
+    /// </remarks>
     internal static async Task AspireStopAsync(
         this Hex1bTerminalAutomator auto,
         SequenceCounter counter,
@@ -936,7 +944,7 @@ internal static class CliE2EAutomatorHelpers
         var apphostFlag = apphost is not null ? $" --apphost {AspireCliShellCommandHelpers.QuoteBashArg(apphost)}" : "";
         await auto.TypeAsync($"aspire stop{apphostFlag}");
         await auto.EnterAsync();
-        await auto.WaitForSuccessPromptAsync(counter);
+        await auto.WaitForSuccessPromptFailFastAsync(counter);
     }
 
     /// <summary>

--- a/tests/Aspire.Cli.Tests/Npm/NpmRunnerTests.cs
+++ b/tests/Aspire.Cli.Tests/Npm/NpmRunnerTests.cs
@@ -13,6 +13,7 @@ public class NpmRunnerTests
     {
         var startInfo = NpmRunner.CreateNpmProcessStartInfo("/usr/bin/npm", ["view", "express", "version"], "/tmp/workdir");
 
+        Assert.True(startInfo.RedirectStandardInput);
         Assert.True(startInfo.RedirectStandardOutput);
         Assert.True(startInfo.RedirectStandardError);
         Assert.False(startInfo.UseShellExecute);

--- a/tests/Aspire.Cli.Tests/Npm/NpmRunnerTests.cs
+++ b/tests/Aspire.Cli.Tests/Npm/NpmRunnerTests.cs
@@ -33,6 +33,7 @@ public class NpmRunnerTests
     {
         var startInfo = NpmRunner.CreateNpmProcessStartInfo("/usr/bin/npm", ["view", "express", "version"], "/tmp/workdir", new TestEnvironment());
 
+        Assert.True(startInfo.RedirectStandardInput);
         Assert.True(startInfo.RedirectStandardOutput);
         Assert.True(startInfo.RedirectStandardError);
         Assert.False(startInfo.UseShellExecute);

--- a/tests/Aspire.Cli.Tests/Projects/GuestRuntimeTests.cs
+++ b/tests/Aspire.Cli.Tests/Projects/GuestRuntimeTests.cs
@@ -706,6 +706,53 @@ public class GuestRuntimeTests(ITestOutputHelper outputHelper)
     }
 
     [Fact]
+    public async Task ProcessGuestLauncher_ClosesChildStdinSoReadsObserveEof()
+    {
+        // Regression coverage for https://github.com/microsoft/aspire/issues/16791.
+        // Before this fix, ProcessGuestLauncher did not redirect/close stdin, so a child
+        // process (e.g. `npm install` postinstall scripts on macOS) inherited the parent
+        // CLI's TTY and any stdin read blocked forever - making `aspire new` for the
+        // TypeScript starter appear to stall.
+        var launcher = new ProcessGuestLauncher(
+            "test",
+            _loggerFactory.CreateLogger<ProcessGuestLauncher>());
+
+        string command;
+        string[] args;
+        if (OperatingSystem.IsWindows())
+        {
+            // `set /p` reads a line from stdin. With redirected+closed stdin it sees EOF and
+            // exits immediately. With an inherited or open-empty stdin it would block.
+            command = "cmd.exe";
+            args = ["/c", "set /p line=<nul & echo eof"];
+        }
+        else
+        {
+            // `read` returns non-zero on EOF; the script prints `eof` and exits.
+            command = "sh";
+            args = ["-c", "if read line; then echo got-input; else echo eof; fi"];
+        }
+
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+        var stopwatch = Stopwatch.StartNew();
+
+        var (exitCode, output) = await launcher.LaunchAsync(
+            command,
+            args,
+            new DirectoryInfo(Path.GetTempPath()),
+            new Dictionary<string, string>(),
+            cts.Token);
+
+        stopwatch.Stop();
+
+        Assert.False(cts.IsCancellationRequested,
+            $"Child process did not exit on its own within 10s - stdin may not have been closed. Elapsed: {stopwatch.Elapsed}.");
+        Assert.Equal(0, exitCode);
+        var lines = output?.GetLines().Select(l => l.Line).ToArray() ?? [];
+        Assert.Contains(lines, l => l.Contains("eof", StringComparison.OrdinalIgnoreCase));
+    }
+
+    [Fact]
     public async Task ProcessGuestLauncher_KillsProcessAndReturnsOnCancellation()
     {
         // Regression coverage for the AppHost system teardown path: when the AppHost server's

--- a/tests/Aspire.Cli.Tests/Projects/GuestRuntimeTests.cs
+++ b/tests/Aspire.Cli.Tests/Projects/GuestRuntimeTests.cs
@@ -717,14 +717,16 @@ public class GuestRuntimeTests(ITestOutputHelper outputHelper)
             "test",
             _loggerFactory.CreateLogger<ProcessGuestLauncher>());
 
+        using var tempDirectory = new TestTempDirectory();
+
         string command;
         string[] args;
         if (OperatingSystem.IsWindows())
         {
-            // `set /p` reads a line from stdin. With redirected+closed stdin it sees EOF and
-            // exits immediately. With an inherited or open-empty stdin it would block.
+            // `set /p` reads from process stdin. Do not add a local `<nul` redirection here:
+            // that would make the command observe EOF even if ProcessGuestLauncher regressed.
             command = "cmd.exe";
-            args = ["/c", "set /p line=<nul & echo eof"];
+            args = ["/c", "set /p line= & if defined line (echo got-input) else (echo eof)"];
         }
         else
         {
@@ -739,7 +741,7 @@ public class GuestRuntimeTests(ITestOutputHelper outputHelper)
         var (exitCode, output) = await launcher.LaunchAsync(
             command,
             args,
-            new DirectoryInfo(Path.GetTempPath()),
+            new DirectoryInfo(tempDirectory.Path),
             new Dictionary<string, string>(),
             cts.Token);
 
@@ -750,6 +752,7 @@ public class GuestRuntimeTests(ITestOutputHelper outputHelper)
         Assert.Equal(0, exitCode);
         var lines = output?.GetLines().Select(l => l.Line).ToArray() ?? [];
         Assert.Contains(lines, l => l.Contains("eof", StringComparison.OrdinalIgnoreCase));
+        Assert.DoesNotContain(lines, l => l.Contains("got-input", StringComparison.OrdinalIgnoreCase));
     }
 
     [Fact]

--- a/tests/Aspire.Cli.Tests/Projects/GuestRuntimeTests.cs
+++ b/tests/Aspire.Cli.Tests/Projects/GuestRuntimeTests.cs
@@ -823,6 +823,53 @@ public class GuestRuntimeTests(ITestOutputHelper outputHelper)
     }
 
     [Fact]
+    public async Task ProcessGuestLauncher_ClosesChildStdinSoReadsObserveEof()
+    {
+        // Regression coverage for https://github.com/microsoft/aspire/issues/16791.
+        // Before this fix, ProcessGuestLauncher did not redirect/close stdin, so a child
+        // process (e.g. `npm install` postinstall scripts on macOS) inherited the parent
+        // CLI's TTY and any stdin read blocked forever - making `aspire new` for the
+        // TypeScript starter appear to stall.
+        var launcher = new ProcessGuestLauncher(
+            "test",
+            _loggerFactory.CreateLogger<ProcessGuestLauncher>());
+
+        string command;
+        string[] args;
+        if (OperatingSystem.IsWindows())
+        {
+            // `set /p` reads a line from stdin. With redirected+closed stdin it sees EOF and
+            // exits immediately. With an inherited or open-empty stdin it would block.
+            command = "cmd.exe";
+            args = ["/c", "set /p line=<nul & echo eof"];
+        }
+        else
+        {
+            // `read` returns non-zero on EOF; the script prints `eof` and exits.
+            command = "sh";
+            args = ["-c", "if read line; then echo got-input; else echo eof; fi"];
+        }
+
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+        var stopwatch = Stopwatch.StartNew();
+
+        var (exitCode, output) = await launcher.LaunchAsync(
+            command,
+            args,
+            new DirectoryInfo(Path.GetTempPath()),
+            new Dictionary<string, string>(),
+            cts.Token);
+
+        stopwatch.Stop();
+
+        Assert.False(cts.IsCancellationRequested,
+            $"Child process did not exit on its own within 10s - stdin may not have been closed. Elapsed: {stopwatch.Elapsed}.");
+        Assert.Equal(0, exitCode);
+        var lines = output?.GetLines().Select(l => l.Line).ToArray() ?? [];
+        Assert.Contains(lines, l => l.Contains("eof", StringComparison.OrdinalIgnoreCase));
+    }
+
+    [Fact]
     public async Task ProcessGuestLauncher_KillsProcessAndReturnsOnCancellation()
     {
         // Regression coverage for the AppHost system teardown path: when the AppHost server's

--- a/tests/Aspire.Cli.Tests/Projects/GuestRuntimeTests.cs
+++ b/tests/Aspire.Cli.Tests/Projects/GuestRuntimeTests.cs
@@ -826,50 +826,56 @@ public class GuestRuntimeTests(ITestOutputHelper outputHelper)
     public async Task ProcessGuestLauncher_ClosesChildStdinSoReadsObserveEof()
     {
         // Regression coverage for https://github.com/microsoft/aspire/issues/16791.
-        // Before this fix, ProcessGuestLauncher did not redirect/close stdin, so a child
-        // process (e.g. `npm install` postinstall scripts on macOS) inherited the parent
-        // CLI's TTY and any stdin read blocked forever - making `aspire new` for the
-        // TypeScript starter appear to stall.
-        var launcher = new ProcessGuestLauncher(
-            "test",
-            _loggerFactory.CreateLogger<ProcessGuestLauncher>());
+        // Before this fix, the shared process launcher allowed isolated Unix guest processes
+        // to inherit the parent CLI's TTY, so a child process (e.g. `npm install` postinstall
+        // scripts on macOS) could block forever while reading stdin and make `aspire new` for
+        // the TypeScript starter appear to stall.
+        var launcher = CreateLauncher();
 
-        using var tempDirectory = new TestTempDirectory();
-
-        string command;
-        string[] args;
-        if (OperatingSystem.IsWindows())
+        var tempDirectory = Directory.CreateTempSubdirectory("aspire-guest-stdin-");
+        try
         {
-            // `set /p` reads from process stdin. Do not add a local `<nul` redirection here:
-            // that would make the command observe EOF even if ProcessGuestLauncher regressed.
-            command = "cmd.exe";
-            args = ["/c", "set /p line= & if defined line (echo got-input) else (echo eof)"];
+            string command;
+            string[] args;
+            if (OperatingSystem.IsWindows())
+            {
+                // `set /p` reads from process stdin. Do not add a local `<nul` redirection here:
+                // that would make the command observe EOF even if ProcessGuestLauncher regressed.
+                command = "cmd.exe";
+                args = ["/c", "set /p line= & if defined line (echo got-input) else (echo eof)"];
+            }
+            else
+            {
+                // `read` returns non-zero on EOF; the script prints `eof` and exits.
+                command = "sh";
+                args = ["-c", "if read line; then echo got-input; else echo eof; fi"];
+            }
+
+            using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+            var stopwatch = Stopwatch.StartNew();
+
+            var (exitCode, output) = await launcher.LaunchAsync(
+                command,
+                args,
+                tempDirectory,
+                new Dictionary<string, string>(),
+                afterLaunchAsync: null,
+                options: null,
+                cancellationToken: cts.Token);
+
+            stopwatch.Stop();
+
+            Assert.False(cts.IsCancellationRequested,
+                $"Child process did not exit on its own within 10s - stdin may not have been closed. Elapsed: {stopwatch.Elapsed}.");
+            Assert.Equal(0, exitCode);
+            var lines = output?.GetLines().Select(l => l.Line).ToArray() ?? [];
+            Assert.Contains(lines, l => l.Contains("eof", StringComparison.OrdinalIgnoreCase));
+            Assert.DoesNotContain(lines, l => l.Contains("got-input", StringComparison.OrdinalIgnoreCase));
         }
-        else
+        finally
         {
-            // `read` returns non-zero on EOF; the script prints `eof` and exits.
-            command = "sh";
-            args = ["-c", "if read line; then echo got-input; else echo eof; fi"];
+            tempDirectory.Delete(recursive: true);
         }
-
-        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
-        var stopwatch = Stopwatch.StartNew();
-
-        var (exitCode, output) = await launcher.LaunchAsync(
-            command,
-            args,
-            new DirectoryInfo(tempDirectory.Path),
-            new Dictionary<string, string>(),
-            cts.Token);
-
-        stopwatch.Stop();
-
-        Assert.False(cts.IsCancellationRequested,
-            $"Child process did not exit on its own within 10s - stdin may not have been closed. Elapsed: {stopwatch.Elapsed}.");
-        Assert.Equal(0, exitCode);
-        var lines = output?.GetLines().Select(l => l.Line).ToArray() ?? [];
-        Assert.Contains(lines, l => l.Contains("eof", StringComparison.OrdinalIgnoreCase));
-        Assert.DoesNotContain(lines, l => l.Contains("got-input", StringComparison.OrdinalIgnoreCase));
     }
 
     [Fact]

--- a/tests/Aspire.Cli.Tests/Projects/GuestRuntimeTests.cs
+++ b/tests/Aspire.Cli.Tests/Projects/GuestRuntimeTests.cs
@@ -834,14 +834,16 @@ public class GuestRuntimeTests(ITestOutputHelper outputHelper)
             "test",
             _loggerFactory.CreateLogger<ProcessGuestLauncher>());
 
+        using var tempDirectory = new TestTempDirectory();
+
         string command;
         string[] args;
         if (OperatingSystem.IsWindows())
         {
-            // `set /p` reads a line from stdin. With redirected+closed stdin it sees EOF and
-            // exits immediately. With an inherited or open-empty stdin it would block.
+            // `set /p` reads from process stdin. Do not add a local `<nul` redirection here:
+            // that would make the command observe EOF even if ProcessGuestLauncher regressed.
             command = "cmd.exe";
-            args = ["/c", "set /p line=<nul & echo eof"];
+            args = ["/c", "set /p line= & if defined line (echo got-input) else (echo eof)"];
         }
         else
         {
@@ -856,7 +858,7 @@ public class GuestRuntimeTests(ITestOutputHelper outputHelper)
         var (exitCode, output) = await launcher.LaunchAsync(
             command,
             args,
-            new DirectoryInfo(Path.GetTempPath()),
+            new DirectoryInfo(tempDirectory.Path),
             new Dictionary<string, string>(),
             cts.Token);
 
@@ -867,6 +869,7 @@ public class GuestRuntimeTests(ITestOutputHelper outputHelper)
         Assert.Equal(0, exitCode);
         var lines = output?.GetLines().Select(l => l.Line).ToArray() ?? [];
         Assert.Contains(lines, l => l.Contains("eof", StringComparison.OrdinalIgnoreCase));
+        Assert.DoesNotContain(lines, l => l.Contains("got-input", StringComparison.OrdinalIgnoreCase));
     }
 
     [Fact]


### PR DESCRIPTION
# Description

`aspire new` for the TypeScript starter (and `aspire init`/`add`/`restore`) hangs silently on macOS, producing no further output at ~0% CPU. Issue #16791 documents the symptom and a working `< /dev/null` workaround, which is strong evidence that some spawned child inherits the parent CLI's TTY and blocks on a stdin read.

## Root cause

Several subprocess launch paths in `Aspire.Cli` set `RedirectStandardOutput`/`Error = true` and `UseShellExecute = false`, but **leave stdin inheriting the parent TTY**. On macOS/Linux any read from stdin in those children then blocks forever:

| Launch path | Used for |
|---|---|
| `ProcessGuestLauncher` | `npm`/`pnpm`/`yarn`/`bun` install (and the guest AppHost itself) |
| `NpmRunner` | `npm view` / `pack` / `audit signatures` / `install -g` |
| `DotNetBasedAppHostServerProject.Run` | Dev/source-based AppHost **server** process |
| `PrebuiltAppHostServer.CreateStartInfo` | Shipped AppHost **server** process |

The TypeScript starter flow exercises all of these via `BuildAndGenerateSdkAsync`: prepare → start AppHost server → RPC codegen → `npm install`. By contrast, `dotnet new install` already goes through `ProcessExecutionFactory`, which sets `RedirectStandardInput = true` — that's why C#-only template scaffolding doesn't hit this.

## Fix

In each of the four launch paths above:

1. Set `RedirectStandardInput = true` on the `ProcessStartInfo`.
2. Immediately after `process.Start()`, call `process.StandardInput.Close()` (wrapped in `try/catch (IOException)`) so any child read surfaces as EOF instead of blocking on the inherited TTY.

The CLI controls these processes via Ctrl+C / backchannel cancellation and Unix-socket IPC (`REMOTE_APP_HOST_SOCKET_PATH`), never via stdin, so closing the pipe is safe.

## Tests

Added `ProcessGuestLauncher_ClosesChildStdinSoReadsObserveEof` in `GuestRuntimeTests`. It launches a short shell snippet that reads stdin and asserts the launcher returns within 10s with the child reporting EOF. Without the fix the test would block on the inherited TTY (or be killed by the 10s CTS).

All `GuestRuntimeTests`, `AppHostServerProjectTests`, `AppHostServerSessionTests`, and `NpmRunnerTests` pass locally (49 succeeded, 4 Windows-only skipped).

Fixes #16791
