### PR TITLE
Prefer current CLI template version for aspire new

### DIFF
--- a/src/Aspire.Cli/Commands/NewCommand.cs
+++ b/src/Aspire.Cli/Commands/NewCommand.cs
@@ -177,6 +177,34 @@ internal sealed class NewCommand : BaseCommand, IPackageMetaPrefetchingCommand
         return selected.LanguageId;
     }
 
+    private static NuGetPackage? TryGetCurrentCliTemplateVersionPackage(PackageChannel selectedChannel, NuGetPackage[] packages, bool hasPrHives)
+    {
+        if (VersionHelper.TryGetCurrentCliVersionMatch(
+            packages,
+            p => p.Version,
+            out var cliVersionPackage,
+            channelName: selectedChannel.Name,
+            hasPrHives: hasPrHives))
+        {
+            return cliVersionPackage;
+        }
+
+        if (packages.Length > 0 &&
+            selectedChannel.Type is PackageChannelType.Explicit &&
+            !VersionHelper.IsLocalBuildChannel(selectedChannel.Name))
+        {
+            // Prerelease channels can filter out the shipped stable package even when the feed can restore it.
+            return new NuGetPackage
+            {
+                Id = TemplateNuGetConfigService.TemplatesPackageName,
+                Version = VersionHelper.GetDefaultSdkVersion(),
+                Source = selectedChannel.SourceDetails
+            };
+        }
+
+        return null;
+    }
+
     private async Task<(bool Success, string? LanguageId)> ResolveSelectedLanguageAsync(ITemplate template, ParseResult parseResult, CancellationToken cancellationToken)
     {
         var explicitLanguageId = ParseExplicitLanguageId(parseResult);
@@ -379,14 +407,7 @@ internal sealed class NewCommand : BaseCommand, IPackageMetaPrefetchingCommand
                         .ToArray();
                     var hasPrHives = ExecutionContext.GetHiveCount() > 0;
 
-                    NuGetPackage? package = VersionHelper.TryGetCurrentCliVersionMatch(
-                        packages,
-                        p => p.Version,
-                        out var cliVersionPackage,
-                        channelName: selectedChannel.Name,
-                        hasPrHives: hasPrHives)
-                        ? cliVersionPackage
-                        : null;
+                    var package = TryGetCurrentCliTemplateVersionPackage(selectedChannel, packages, hasPrHives);
 
                     package ??= packages
                         .OrderByDescending(p => Semver.SemVersion.Parse(p.Version, Semver.SemVersionStyles.Strict), Semver.SemVersion.PrecedenceComparer)

--- a/src/Aspire.Cli/Packaging/PackageChannel.cs
+++ b/src/Aspire.Cli/Packaging/PackageChannel.cs
@@ -85,12 +85,15 @@ internal class PackageChannel(string name, PackageChannelQuality quality, Packag
             .DistinctBy(p => $"{p.Id}-{p.Version}");
 
         // When doing a `dotnet package search` the results may include stable packages even when searching for
-        // prerelease packages. This filters out this noise.
+        // prerelease packages. Keep the current CLI/SDK version so shipped CLIs can resolve their
+        // matching template package from daily/staging feeds, then filter out the remaining noise.
+        var currentCliVersion = VersionHelper.GetDefaultSdkVersion();
         var filteredPackages = packages.Where(p => new { SemVer = SemVersion.Parse(p.Version), Quality = Quality } switch
         {
             { Quality: PackageChannelQuality.Both } => true,
             { Quality: PackageChannelQuality.Stable, SemVer: { IsPrerelease: false } } => true,
             { Quality: PackageChannelQuality.Prerelease, SemVer: { IsPrerelease: true } } => true,
+            { Quality: PackageChannelQuality.Prerelease, SemVer: { IsPrerelease: false } } when string.Equals(p.Version, currentCliVersion, StringComparison.OrdinalIgnoreCase) => true,
             _ => false
         });
 

--- a/src/Aspire.Cli/Utils/VersionHelper.cs
+++ b/src/Aspire.Cli/Utils/VersionHelper.cs
@@ -24,7 +24,7 @@ internal static class VersionHelper
     }
 
     /// <summary>
-    /// Finds the candidate that exactly matches the current CLI/SDK version when running against local build channels or hives.
+    /// Finds the candidate that exactly matches the current CLI/SDK version when a channel has already been selected or local hives are present.
     /// </summary>
     public static bool TryGetCurrentCliVersionMatch<T>(
         IEnumerable<T> candidates,
@@ -36,7 +36,7 @@ internal static class VersionHelper
         ArgumentNullException.ThrowIfNull(candidates);
         ArgumentNullException.ThrowIfNull(versionSelector);
 
-        if (!hasPrHives && !IsLocalBuildChannel(channelName))
+        if (!hasPrHives && string.IsNullOrWhiteSpace(channelName))
         {
             match = default;
             return false;

--- a/tests/Aspire.Cli.Tests/Commands/NewCommandChannelResolutionTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/NewCommandChannelResolutionTests.cs
@@ -116,12 +116,9 @@ public class NewCommandChannelResolutionTests(ITestOutputHelper outputHelper)
     /// <summary>
     /// Channel-resolution contract: when the running CLI's identity is a non-local channel
     /// (daily / staging / stable) and no <c>--channel</c> is passed, <c>aspire new</c> must
-    /// resolve the template version from the channel whose name matches the identity — not
-    /// from the Implicit (nuget.org) channel. Without this, a daily/staging CLI silently
-    /// resolves a stable nuget.org template while the per-project channel pin (written by
-    /// the template factories) still points at the channel-specific feed — yielding an
-    /// inconsistent project that <c>aspire restore</c> rejects with "Unable to find a stable
-    /// package".
+    /// resolve the channel whose name matches the identity — not the Implicit (nuget.org)
+    /// channel — while still pinning the template version to the current CLI/SDK version.
+    /// The bundled server and restored Aspire packages must stay on the same version.
     /// </summary>
     [Theory]
     [InlineData(PackageChannelNames.Daily, "13.4.0-preview.1.99999.1")]
@@ -133,8 +130,20 @@ public class NewCommandChannelResolutionTests(ITestOutputHelper outputHelper)
             channelOptionArg: null,
             identityChannelVersion: identityChannelVersion);
 
-        Assert.Equal(identityChannelVersion, captured.Version);
+        Assert.Equal(VersionHelper.GetDefaultSdkVersion(), captured.Version);
         Assert.Equal(identityChannel, captured.Channel);
+    }
+
+    [Fact]
+    public async Task NewCommand_NoChannelArg_DailyChannelWithoutExactCliVersion_PinsTemplateToCurrentCliVersion()
+    {
+        var captured = await CaptureTemplateInputsAsync(
+            identityChannel: PackageChannelNames.Daily,
+            channelOptionArg: null,
+            identityChannelVersion: "13.5.0-preview.1.99999.1");
+
+        Assert.Equal(VersionHelper.GetDefaultSdkVersion(), captured.Version);
+        Assert.Equal(PackageChannelNames.Daily, captured.Channel);
     }
 
     /// <summary>
@@ -180,8 +189,8 @@ public class NewCommandChannelResolutionTests(ITestOutputHelper outputHelper)
     /// <summary>
     /// Issue #17121 regression guard: a staging-identity CLI should have a registered
     /// staging channel from <c>PackagingService.GetChannelsAsync</c>, so <c>aspire new</c>
-    /// resolves templates from staging instead of falling back to the Implicit NuGet.org
-    /// channel.
+    /// resolves the channel from staging instead of falling back to the Implicit NuGet.org
+    /// channel, while keeping the template version pinned to the current CLI.
     /// </summary>
     [Fact]
     public async Task NewCommand_NoChannelArg_StagingIdentityWithStagingChannelRegistered_ResolvesTemplateFromStaging()
@@ -191,14 +200,15 @@ public class NewCommandChannelResolutionTests(ITestOutputHelper outputHelper)
             channelOptionArg: null,
             identityChannelVersion: "13.4.0-rc.1.99999.1");
 
-        Assert.Equal("13.4.0-rc.1.99999.1", captured.Version);
+        Assert.Equal(VersionHelper.GetDefaultSdkVersion(), captured.Version);
         Assert.Equal(PackageChannelNames.Staging, captured.Channel);
     }
 
     /// <summary>
     /// Explicit <c>--channel</c> must always override the running CLI's identity channel —
     /// so a developer on a daily CLI can still scaffold a stable-channel project for
-    /// reproduction or migration testing.
+    /// reproduction or migration testing. The template version still stays pinned to the
+    /// current CLI so restored Aspire packages match the bundled server.
     /// </summary>
     [Fact]
     public async Task NewCommand_ExplicitChannelArg_OverridesIdentityChannel()
@@ -208,7 +218,7 @@ public class NewCommandChannelResolutionTests(ITestOutputHelper outputHelper)
             channelOptionArg: PackageChannelNames.Stable,
             identityChannelVersion: "13.4.0-preview.1.99999.1");
 
-        Assert.Equal("13.5.0", captured.Version); // stable channel version
+        Assert.Equal(VersionHelper.GetDefaultSdkVersion(), captured.Version);
         Assert.Equal(PackageChannelNames.Stable, captured.Channel);
     }
 

--- a/tests/Aspire.Cli.Tests/Commands/NewCommandChannelResolutionTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/NewCommandChannelResolutionTests.cs
@@ -8,6 +8,7 @@ using Aspire.Cli.Projects;
 using Aspire.Cli.Templating;
 using Aspire.Cli.Tests.TestServices;
 using Aspire.Cli.Tests.Utils;
+using Aspire.Cli.Utils;
 using Microsoft.AspNetCore.InternalTesting;
 using Microsoft.Extensions.DependencyInjection;
 using NuGetPackage = Aspire.Shared.NuGetPackageCli;
@@ -212,6 +213,27 @@ public class NewCommandChannelResolutionTests(ITestOutputHelper outputHelper)
     }
 
     /// <summary>
+    /// A shipped CLI must prefer its own SDK/template version from an explicitly selected
+    /// non-local channel instead of floating to a newer daily/staging package from the same feed.
+    /// </summary>
+    [Theory]
+    [InlineData(PackageChannelNames.Daily)]
+    [InlineData(PackageChannelNames.Staging)]
+    public async Task NewCommand_ExplicitPrereleaseChannel_PrefersCurrentCliVersionWhenAvailable(string channelName)
+    {
+        var cliVersion = VersionHelper.GetDefaultSdkVersion();
+
+        var captured = await CaptureTemplateInputsAsync(
+            identityChannel: channelName,
+            channelOptionArg: channelName,
+            identityChannelVersion: cliVersion,
+            identityChannelVersions: ["99.0.0-preview.1", cliVersion]);
+
+        Assert.Equal(cliVersion, captured.Version);
+        Assert.Equal(channelName, captured.Channel);
+    }
+
+    /// <summary>
     /// Invokes <see cref="NewCommand"/> with a fake CLI-runtime template that captures the
     /// <see cref="TemplateInputs"/> handed to it. This is the contract surface the four
     /// shipping CLI templates (TS/Python/Go starter + empty AppHost) all read from. Its
@@ -228,7 +250,8 @@ public class NewCommandChannelResolutionTests(ITestOutputHelper outputHelper)
     private async Task<CapturedTemplateInputs> CaptureTemplateInputsAsync(
         string identityChannel,
         string? channelOptionArg,
-        string? identityChannelVersion)
+        string? identityChannelVersion,
+        IEnumerable<string>? identityChannelVersions = null)
     {
         using var workspace = TemporaryWorkspace.Create(outputHelper);
 
@@ -260,7 +283,7 @@ public class NewCommandChannelResolutionTests(ITestOutputHelper outputHelper)
 
             options.TemplateProviderFactory = _ => new SingleTemplateProvider(fakeTemplate);
 
-            options.PackagingServiceFactory = _ => BuildPackagingService(identityChannel, identityChannelVersion);
+            options.PackagingServiceFactory = _ => BuildPackagingService(identityChannel, identityChannelVersion, identityChannelVersions);
         });
 
         using var serviceProvider = services.BuildServiceProvider();
@@ -280,8 +303,14 @@ public class NewCommandChannelResolutionTests(ITestOutputHelper outputHelper)
     /// pr-* explicit channels), but with deterministic per-channel template versions so
     /// tests can identify which channel won resolution.
     /// </summary>
-    private static IPackagingService BuildPackagingService(string identityChannel, string? identityChannelVersion)
+    private static IPackagingService BuildPackagingService(
+        string identityChannel,
+        string? identityChannelVersion,
+        IEnumerable<string>? identityChannelVersions)
     {
+        var identityVersions = identityChannelVersions?.ToArray()
+            ?? (identityChannelVersion is null ? [] : [identityChannelVersion]);
+
         // Implicit channel always returns the stable token so a "fell-through to Implicit"
         // outcome is distinguishable from an identity-channel pickup.
         var implicitCache = new FakeNuGetPackageCache
@@ -313,7 +342,7 @@ public class NewCommandChannelResolutionTests(ITestOutputHelper outputHelper)
         // Register a non-stable explicit channel matching the identity, when the test
         // scenario calls for it. Deliberately omitted in the "identity not registered"
         // case so fallback to Implicit can be observed.
-        var isDailyOrStaging = identityChannelVersion is not null &&
+        var isDailyOrStaging = identityVersions.Length > 0 &&
             !string.Equals(identityChannel, PackageChannelNames.Stable, StringComparison.OrdinalIgnoreCase) &&
             !identityChannel.StartsWith("pr-", StringComparison.OrdinalIgnoreCase);
         if (isDailyOrStaging)
@@ -322,7 +351,7 @@ public class NewCommandChannelResolutionTests(ITestOutputHelper outputHelper)
             {
                 GetTemplatePackagesAsyncCallback = (_, _, _, _) =>
                     Task.FromResult<IEnumerable<NuGetPackage>>(
-                        [new NuGetPackage { Id = "Aspire.ProjectTemplates", Source = "nuget", Version = identityChannelVersion! }])
+                        identityVersions.Select(version => new NuGetPackage { Id = "Aspire.ProjectTemplates", Source = "nuget", Version = version }))
             };
             channels.Add(PackageChannel.CreateExplicitChannel(
                 identityChannel,

--- a/tests/Aspire.Cli.Tests/Commands/NewCommandTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/NewCommandTests.cs
@@ -1609,7 +1609,7 @@ public class NewCommandTests(ITestOutputHelper outputHelper)
 
         var exitCode = await result.InvokeAsync().DefaultTimeout();
         Assert.Equal(CliExitCodes.Success, exitCode);
-        Assert.Equal("9.2.0", scaffoldSdkVersion);
+        Assert.Equal(VersionHelper.GetDefaultSdkVersion(), scaffoldSdkVersion);
         Assert.Equal("stable", scaffoldChannel);
     }
 
@@ -1810,7 +1810,7 @@ public class NewCommandTests(ITestOutputHelper outputHelper)
         Assert.Equal(CliExitCodes.Success, exitCode);
         Assert.True(buildAndGenerateCalled);
         Assert.Equal("daily", channelSeenByProject);
-        Assert.Equal("9.2.0", sdkVersionSeenByProject);
+        Assert.Equal(VersionHelper.GetDefaultSdkVersion(), sdkVersionSeenByProject);
         Assert.True(File.Exists(Path.Combine(workspace.WorkspaceRoot.FullName, "output", LanguageInfo.GeneratedFolderName, "aspire.mts")));
     }
 

--- a/tests/Aspire.Cli.Tests/Utils/VersionHelperTests.cs
+++ b/tests/Aspire.Cli.Tests/Utils/VersionHelperTests.cs
@@ -29,6 +29,71 @@ public class VersionHelperTests
     }
 
     [Theory]
+    [InlineData("daily")]
+    [InlineData("staging")]
+    [InlineData("stable")]
+    public void TryGetCurrentCliVersionMatch_WithNamedChannel_ReturnsCurrentCliVersion(string channelName)
+    {
+        var cliVersion = VersionHelper.GetDefaultSdkVersion();
+        var candidates = new[]
+        {
+            "99.0.0",
+            cliVersion,
+        };
+
+        var result = VersionHelper.TryGetCurrentCliVersionMatch(
+            candidates,
+            version => version,
+            out var match,
+            channelName: channelName,
+            hasPrHives: false);
+
+        Assert.True(result);
+        Assert.Equal(cliVersion, match);
+    }
+
+    [Fact]
+    public void TryGetCurrentCliVersionMatch_WithNamedChannelAndNoExactMatch_ReturnsFalse()
+    {
+        var candidates = new[]
+        {
+            "99.0.0",
+            "98.0.0",
+        };
+
+        var result = VersionHelper.TryGetCurrentCliVersionMatch(
+            candidates,
+            version => version,
+            out var match,
+            channelName: "daily",
+            hasPrHives: false);
+
+        Assert.False(result);
+        Assert.Null(match);
+    }
+
+    [Fact]
+    public void TryGetCurrentCliVersionMatch_WithNoChannelAndNoPrHives_ReturnsFalse()
+    {
+        var cliVersion = VersionHelper.GetDefaultSdkVersion();
+        var candidates = new[]
+        {
+            "99.0.0",
+            cliVersion,
+        };
+
+        var result = VersionHelper.TryGetCurrentCliVersionMatch(
+            candidates,
+            version => version,
+            out var match,
+            channelName: null,
+            hasPrHives: false);
+
+        Assert.False(result);
+        Assert.Null(match);
+    }
+
+    [Theory]
     [InlineData("pr-16820", true)]
     [InlineData("run-25422767716", true)]
     [InlineData("local", true)]


### PR DESCRIPTION
## Description

Fixes a release/13.4 `aspire new` version selection issue where a shipped 13.4 CLI using an explicit channel such as `--channel daily` could float to the newest `Aspire.ProjectTemplates` package from that channel, for example a 13.5 preview. That caused the bundled 13.4 AppHost server to restore/load 13.5 TypeScript codegen dependencies and fail with `Aspire.TypeSystem, Version=13.5.0.0` loader errors followed by `No language support found for: typescript/nodejs`.

The fix keeps CLI-runtime templates pinned to the current bundled CLI/SDK version after a channel is selected. If the channel search returns the exact current version, that package is selected. If prerelease channel search filters out the shipped stable-shaped version, `aspire new` still passes the current CLI/SDK version through so restore uses packages that match the bundled server. Local/PR hive behavior remains on the existing exact-match path.

### User-facing usage

A shipped 13.4 CLI now keeps generated TypeScript AppHosts on 13.4 instead of resolving newer daily packages:

```bash
aspire new aspire-ts-empty -n ExplicitTsEmptyFull -o ExplicitTsEmptyFull --channel daily --non-interactive
```

## Tests

- `dotnet test --project tests/Aspire.Cli.Tests/Aspire.Cli.Tests.csproj --no-restore -- --filter-class Aspire.Cli.Tests.Commands.NewCommandChannelResolutionTests --filter-class Aspire.Cli.Tests.Commands.NewCommandTests --filter-class Aspire.Cli.Tests.Utils.VersionHelperTests --no-progress`
- `dotnet test --project tests/Aspire.Cli.Tests/Aspire.Cli.Tests.csproj --no-restore -- --no-progress`

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
