### PR TITLE
infra: publish Aspire CLI native AOT symbols (Win + Linux + macOS) to MSDL

### DIFF
--- a/docs/ci/cli-native-symbols.md
+++ b/docs/ci/cli-native-symbols.md
@@ -1,0 +1,184 @@
+# Validating Aspire CLI Native AOT Symbols
+
+The Aspire CLI ships as a NativeAOT executable. Its `.pdb` (Windows), `.dbg` (Linux), and `.dwarf` (macOS) symbol files are published to MSDL by the internal pipeline so that `dotnet-symbol --symbols` against a shipped `aspire` binary downloads the symbol file a debugger needs to resolve stack frames during crash triage.
+
+See [`docs/ci/native-cli-packaging.md`](native-cli-packaging.md) for the build/sign side. This doc covers the **symbol** side: how the symbol artifacts reach MSDL, and how to verify locally that what arrives is paired with the right binary and actually useful for symbolication.
+
+## Pipeline architecture
+
+How CLI NativeAOT debug symbols reach MSDL/SymWeb.
+
+### Where ILC writes symbols
+
+For every `PublishAot=true` build, ILC emits the symbol artifact next to the binary at `artifacts/bin/Aspire.Cli/<config>/<tfm>/<rid>/native/`:
+
+| Platform | Artifact | How it's produced |
+|---|---|---|
+| Windows | `aspire.pdb` | ILC linker output |
+| Linux | `aspire.dbg` sidecar | `StripSymbols=true` (the default) splits debug info via `objcopy --only-keep-debug` + `--add-gnu-debuglink` |
+| macOS | `aspire.dSYM/` bundle | `dsymutil` against the Mach-O |
+
+These paths are governed by `Microsoft.NETCore.Native.targets` in the `Microsoft.DotNet.ILCompiler` package (`NativeOutputPath`, `NativeSymbolExt`). If they move, the staging paths in `eng/clipack/Common.projitems` go stale.
+
+### macOS: only the inner DWARF is shipped, not the `.dSYM` bundle
+
+ILC produces a `.dSYM` directory bundle whose payload is a Mach-O file with DWARF debug sections at `<binary>.dSYM/Contents/Resources/DWARF/<binary>`. The pipeline extracts just that inner file and ships it as `<binary>.dwarf`, mirroring dotnet/runtime's `dsymutil --flat` output (the form `SymbolUploadHelper`'s extension allowlist accepts).
+
+The `.dSYM` bundle directory itself isn't shipped: it has no extension to match the allowlist, and Apple-native automatic symbolication via Spotlight UUID indexing (which would benefit from the bundle form) is the open work tracked by [dotnet/runtime#88286](https://github.com/dotnet/runtime/issues/88286).
+
+### Two arcade publishing routes (one for Windows, one for Linux+macOS)
+
+Symbols flow through one of two distinct arcade publishing routes, depending on the target platform's symbol format:
+
+* **Windows `.pdb`** — loose-file path via `FilesToPublishToSymbolServer` in `eng/Publishing.props`. Arcade's `PrepLoosePdbsForPublish` hard-filters to `.pdb`/`.dll` only, so this path is Windows-only.
+
+* **Linux `.dbg` / macOS `.dwarf`** — packed into a NuGet symbol package (`.symbols.nupkg`) by `eng/clipack/Aspire.Cli.NativeSymbols.proj` (invoked from `eng/clipack/Common.projitems`'s `_PackNativeAotSymbols` target on the per-RID build agent) and routed via arcade's `_ExistingSymbolPackage` filter to the Symbols asset category. `SymbolUploadHelper` opens the `.symbols.nupkg` with raw `ZipFile.Open` (not NuGet OPC), filters entries by an extension allowlist that includes `.dbg`/`.dwarf`/`.so`/`.dylib`, then runs `symbol.exe adddirectory` on the extracted contents.
+
+The split isn't aesthetic — arcade's loose-pdb path doesn't accept ELF/Mach-O sidecars, and the `.symbols.nupkg` path predates the loose-pdb path. The `.symbols.nupkg` itself is a real NuGet symbol package: NuGet's `PackTask`, driven by `eng/clipack/Aspire.Cli.NativeSymbols.proj`, uses the `TfmSpecificDebugSymbolsFile` hook + `AllowedOutputExtensionsInSymbolsPackageBuildOutputFolder` allowlist to route the platform-specific debug-info file into the `.symbols.nupkg` only (not the empty companion main `.nupkg`, which is discarded). See [dotnet/runtime's `runtime.native.System.IO.Ports`](https://github.com/dotnet/runtime/blob/main/src/libraries/System.IO.Ports/pkg/runtime.native.System.IO.Ports.props) for the prior-art pattern.
+
+### Per-RID coverage gate
+
+`eng/Publishing.props`'s `_PublishBlobItems` target enforces — alongside its existing checks for archives, RID-specific tool packages, and npm packages — that every RID with an `eng/clipack/Aspire.Cli.<rid>.csproj` has a matching symbol artifact: an `aspire.pdb` under `artifacts/native-symbols/<config>/native_symbols_<rid>/` for `win-*` RIDs, and an `Aspire.Cli.<rid>.<version>.symbols.nupkg` in `Shipping/` for `linux-*`/`osx-*` RIDs. The expected RID set comes from the same `_ExpectedCliRids` item the other checks use, so there is one source of truth and no parallel list to drift.
+
+### Symbol-server keys
+
+`symstore`'s SSQP keys are computed from the file's intrinsic build-id (ELF `.note.gnu.build-id` on Linux, Mach-O `LC_UUID` on macOS, CodeView GUID+Age in PE on Windows), *not* from the in-package path or filename:
+
+| Platform | SSQP key form |
+|---|---|
+| Windows | `aspire.pdb/<GUID><Age>/aspire.pdb` |
+| Linux | `_.debug/elf-buildid-sym-<id>/_.debug` |
+| macOS | `_.dwarf/mach-uuid-sym-<uuid>/_.dwarf` |
+
+`dotnet-symbol` computes the same key from the shipped binary at lookup time, which is how a customer's stack-trace symbolication finds the right symbol file. See [dotnet/symstore SSQP_Key_Conventions](https://github.com/dotnet/symstore/blob/main/docs/specs/SSQP_Key_Conventions.md) for the canonical spec.
+
+### Upstream references
+
+When debugging a "`dotnet-symbol` returns nothing" report, or planning an arcade SDK / .NET SDK / Xcode bump, these are the upstream sources that drive the contracts above:
+
+* **dotnet/runtime** — uses this same `.dbg`/`.dwarf` symbol-package path for CoreCLR and libraries native symbols:
+  - [`eng/liveBuilds.targets`](https://github.com/dotnet/runtime/blob/main/eng/liveBuilds.targets#L122-L141) — CoreCLR `RuntimeFiles` includes `*.pdb;*.dbg;*.dwarf`
+  - [`eng/native/functions.cmake`](https://github.com/dotnet/runtime/blob/main/eng/native/functions.cmake#L362-L431) — defaults `dsymutil --flat` for macOS, producing flat `.dwarf` instead of `.dSYM` bundles
+  - [`Microsoft.DotNet.ILCompiler.pkgproj`](https://github.com/dotnet/runtime/blob/main/src/installer/pkg/projects/Microsoft.DotNet.ILCompiler/Microsoft.DotNet.ILCompiler.pkgproj#L54-L63) — excludes `.dbg`/`.dwarf`/`.dSYM` from the ILC package because they flow through the symbol package
+* **dotnet/arcade** — the `SymbolUploadHelper.cs` plumbing:
+  - [extension allowlist](https://github.com/dotnet/arcade/blob/main/src/Microsoft.DotNet.Internal.SymbolHelper/SymbolUploadHelper.cs#L37) — `.dbg`/`.dwarf`/`.so`/`.dylib` entries kept
+  - [`AddPackageToRequest`](https://github.com/dotnet/arcade/blob/main/src/Microsoft.DotNet.Internal.SymbolHelper/SymbolUploadHelper.cs#L273) — raw `ZipFile.Open` extraction
+* **dotnet/symstore** — symbol-server lookup side:
+  - [SSQP key conventions](https://github.com/dotnet/symstore/blob/main/docs/specs/SSQP_Key_Conventions.md)
+  - `Microsoft.SymbolStore.KeyGenerators` (one per format: `PortableFileKeyGenerator`, `ELFFileKeyGenerator`, `MachOKeyGenerator`)
+
+## Local validation
+
+`eng/scripts/validate-cli-symbols.ps1` is the on-demand validation tool. It does not run in CI.
+
+Pipeline success — even a green MSDL upload — does not prove that the right symbol file was paired with the right binary, that its bytes survived packaging intact, or that those bytes can actually resolve a stack frame. MSDL will happily accept mismatched, malformed, or unresolvable bytes; it just stores them. The first time anyone discovers the problem is the next crash triage attempt, which can be months after ship, and the symbols for already-shipped builds are unrecoverable. The script exists to catch all three failure modes locally before they ship.
+
+For script usage / parameters / examples, see the comment-based help:
+
+```pwsh
+Get-Help eng/scripts/validate-cli-symbols.ps1 -Detailed
+```
+
+### What it verifies
+
+The script reproduces the full symbol round-trip locally without uploading anything to MSDL. Three checks per RID, ordered loosest to strictest:
+
+| Check | What it proves | If it fails, suspect |
+|---|---|---|
+| **A.** Identifier symmetry | Binary intrinsic ID (PDB GUID+Age / ELF BuildID / Mach-O LC_UUID) matches the symbol file's ID. | A pipeline that paired up the wrong binary with the wrong symbol file — e.g., a staging step copying from the wrong `bin/<rid>/native/` location. |
+| **B.** `dotnet-symbol` round-trip | A real `dotnet-symbol` invocation against a local HTTP symstore (rooted at the SSQP-keyed directory) downloads a byte-identical copy of the symbol file. | SSQP key derivation drifting from what `dotnet-symbol` computes from the binary — most often because `Microsoft.SymbolStore`'s per-format key generator changed, or because the symbol file's intrinsic ID isn't what we think it is. |
+| **C.** Resolver-readable content | Platform symbolicator (`atos` / `addr2line` / `llvm-symbolizer`) can actually resolve the binary's entry-point VA using the file Check B downloaded. | Symbol file bytes are well-formed at the container level (zip, ELF note, Mach-O LC) but the debug-info inside is malformed — e.g., macOS flat-DWARF extraction produced a Mach-O with a corrupt `__DWARF` segment, or our `aspire.dwarf` rename lost something Apple's tools care about. **Check C is the only thing in the whole stack that proves the bytes are actually useful for symbolication.** |
+
+The `.symbols.nupkg` pack/extract round-trip is not separately checked: NuGet's `PackTask` owns the format and arcade reads what the SDK writes, so the script's contract stops at the symbol file inside.
+
+### When to run
+
+#### Required before merging
+
+Run the script (typically on the host RID is enough; full matrix if the change is cross-platform) before merging any of:
+
+* Changes to `eng/clipack/Common.projitems` (`_PackNativeAotSymbols` target) or `eng/clipack/Aspire.Cli.NativeSymbols.proj` that affect what gets staged from `artifacts/bin/Aspire.Cli/.../native/` or how the `.symbols.nupkg` is packed.
+* Changes to `eng/pipelines/templates/build_sign_native.yml` that affect the `native_symbols_<rid>` artifact publish (publish path, artifact name).
+* Changes to `eng/Publishing.props` that touch `FilesToPublishToSymbolServer`, the `_ExpectedCliRids` derivation, or the per-RID symbol-coverage gate (the `_Missing{Pdb,SymbolPackage}Rids` checks).
+* Changes to the Windows `build` job in `azure-pipelines.yml` / `azure-pipelines-unofficial.yml` that affect the `**/aspire.pdb` or `**/Aspire.Cli.*.symbols.nupkg` download/staging steps.
+* Changes to `src/Aspire.Cli/Aspire.Cli.csproj` involving `PublishAot`, `CopyOutputSymbolsToPublishDirectory`, or other symbol-affecting properties.
+
+#### Recommended
+
+* **Arcade SDK version bumps** — `_ExistingSymbolPackage` filter, `SymbolUploadHelper`, `PrepLoosePdbsForPublish`, and `GatherPublishItems` have all evolved across arcade versions. A bump can silently re-route symbol artifacts to a different asset category, or skip them entirely.
+* **.NET SDK / runtime upgrades** — `Microsoft.NETCore.Native.targets` is the source of truth for where ILC emits symbols (`NativeOutputPath`, `NativeSymbolExt`). If those move, our staging paths in `eng/clipack/Common.projitems` go stale.
+* **Xcode upgrades on the macOS native job** — `dsymutil`'s default output mode and the `aspire.dSYM/Contents/Resources/DWARF/<name>` layout have moved before. Our flat-DWARF extraction depends on both.
+* **Adding a new RID** to the AOT build matrix. The script's per-RID detection paths and SSQP key derivation need to cover the new RID before the pipeline does.
+* **Investigating a real-world "`dotnet-symbol` returns nothing" report against the Aspire CLI** — run the script against the same RID / configuration / build to localize the failure to A, B, or C before suspecting MSDL.
+
+#### When *not* to run
+
+* PR doesn't touch any of the files listed above and isn't a SDK / arcade / Xcode bump → skip. Running the script for unrelated changes wastes cycles and doesn't catch anything.
+
+### How to run
+
+Quick reference (full docs via `Get-Help`):
+
+```pwsh
+# Validate on the host RID, build first
+pwsh eng/scripts/validate-cli-symbols.ps1
+
+# Re-use an existing build (faster iteration during triage)
+pwsh eng/scripts/validate-cli-symbols.ps1 -SkipBuild
+
+# Cross-RID (must have publishable artifacts for the target RID)
+pwsh eng/scripts/validate-cli-symbols.ps1 -Rid linux-arm64
+```
+
+Exit code is `0` if every executed check passed, `1` if any failed. **Skipped checks (missing tooling) do not fail the script** — the script never blocks on absent platform tools, only on actual mismatches.
+
+### How to interpret results
+
+Each check reports one of:
+
+* **PASS** — check ran and the invariant held.
+* **SKIP** — check did not run; a warning explains why (most commonly a missing platform tool). The skip message is the diagnostic; re-running with the missing tool installed will produce a real PASS/FAIL.
+* **N/A** — check is not meaningful for this RID by design (e.g., Check A's PDB-side ID comparison is skipped on Windows when `llvm-pdbutil` isn't installed).
+* **FAIL** — check ran and the invariant was violated. Triage using the *suspect* column in the table above.
+
+For triage, the checks are layered: each one assumes the previous one passed. If Check A fails, B/C will likely also fail because they all depend on the binary↔symbol pairing being correct. Always fix the lowest-numbered failure first; later failures often resolve themselves once it's fixed.
+
+A useful baseline to keep in mind for a clean run on each RID:
+
+| RID | A | B | C | Notes |
+|---|---|---|---|---|
+| `osx-arm64` / `osx-x64` | PASS | PASS | PASS | Needs Xcode CLT for `atos` / `dwarfdump` / `otool` |
+| `linux-x64` / `linux-arm64` / `linux-musl-x64` | PASS | PASS | PASS | Needs binutils for `addr2line` / `readelf` |
+| `win-x64` / `win-arm64` | PASS *(SKIP w/o LLVM)* | PASS | PASS *(SKIP w/o LLVM)* | Without LLVM, A and C skip but B runs via `PEReader`; this is the common author-machine state. |
+
+Anything outside this baseline — especially a FAIL anywhere, or a SKIP for a check that should have been PASS on a configured machine — should be triaged before merging.
+
+### What the script covers vs. what it skips
+
+The script mirrors the production data flow described in [Pipeline architecture](#pipeline-architecture) without uploading. Each production step maps to one of the checks:
+
+| Production step | Script equivalent |
+|---|---|
+| `eng/clipack/Aspire.Cli.NativeSymbols.proj` packs `.symbols.nupkg` (Linux/macOS) | Not separately checked — NuGet `PackTask` owns the format; arcade reads the same format the SDK writes. |
+| Arcade's `_ExistingSymbolPackage` filter routes to Symbols asset | Implicit — the script's symbol file is the same one the pipeline ships |
+| `SymbolUploadHelper.AddPackageToRequest` + `symbol.exe adddirectory` index by SSQP key | Check B's local symstore directory + `dotnet-symbol` lookup |
+| Customer / triage runs `dotnet-symbol --symbols aspire` against MSDL | Check B against the local symstore (same protocol, same `dotnet-symbol` invocation) |
+| Customer / triage runs `atos` / `addr2line` / `llvm-symbolizer` against the downloaded file | Check C, against the same downloaded file |
+
+The script does *not* exercise: arcade's BAR registration, MSDL's ingestion, or the network path. Those are covered by the AzDO build itself. The script covers everything between "build outputs exist" and "a customer can symbolicate" — which is the part with no other automated coverage.
+
+### Maintaining the script
+
+The script's per-platform implementations of ID extraction and SSQP key derivation are encoded against the upstream sources documented in [Pipeline architecture](#pipeline-architecture). When you change the script — or when an upstream arcade SDK / .NET SDK / Xcode bump touches symbol handling — cross-check those sources.
+
+The script intentionally has no test coverage; the `Microsoft.SymbolStore` library is the reference implementation. If the script and `Microsoft.SymbolStore` disagree on an SSQP key, trust `Microsoft.SymbolStore` and fix the script.
+
+### When to retire this script
+
+The script is intentionally a one-shot tool, not a CI check. Running it on every PR would catch nothing for the ~95% of PRs that don't touch symbol-affecting files; the [When to run](#when-to-run) discipline is what makes that work.
+
+Retire it when at least one of:
+
+* Aspire CLI grows post-build test coverage that exercises stack-trace symbolication on the shipped native binary.
+* The symbol-publishing path has shipped through 2+ stable releases without regression, *and* at least one real-world MSDL crash-triage per RID has succeeded.
+* Arcade adds end-to-end symbol-resolve verification to its publish path.

--- a/eng/Publishing.props
+++ b/eng/Publishing.props
@@ -114,12 +114,69 @@
       <_CliPointerNpmPackages Include="@(_CliNpmPackagesToPublish)" Exclude="@(_CliRidSpecificNpmPackageFilesWithRid)" />
     </ItemGroup>
 
+    <ItemGroup Label="Validation of CLI native AOT symbols">
+      <!-- Windows: loose aspire.pdb per RID, downloaded from native_symbols_<rid>
+           build artifacts by eng/pipelines/templates/download_native_symbols.yml
+           into artifacts/native-symbols/<config>/native_symbols_<rid_underscored>/
+           aspire.pdb. The same glob feeds FilesToPublishToSymbolServer above
+           (loose-PDB path to MSDL). -->
+      <_WindowsExpectedSymbolRids Include="@(_ExpectedCliRids)"
+                                  Condition="$([System.String]::new('%(Identity)').StartsWith('win-'))" />
+
+      <_LooseSymbolPdbFiles Include="$(ArtifactsDir)native-symbols\$(Configuration)\**\aspire.pdb" />
+      <_LooseSymbolPdbFilesWithRid Include="@(_LooseSymbolPdbFiles)">
+        <!-- Reverse the hyphen→underscore substitution that build_sign_native.yml
+             applies to artifact names to recover the RID. -->
+        <ExtractedRid>$([System.Text.RegularExpressions.Regex]::Match('%(Identity)', 'native_symbols_([^/\\]+)').Groups[1].Value.Replace('_', '-'))</ExtractedRid>
+      </_LooseSymbolPdbFilesWithRid>
+
+      <_MissingPdbRids Include="@(_WindowsExpectedSymbolRids)" Exclude="@(_LooseSymbolPdbFilesWithRid -> '%(ExtractedRid)')" />
+      <_UnexpectedPdbRids Include="@(_LooseSymbolPdbFilesWithRid -> '%(ExtractedRid)')" Exclude="@(_WindowsExpectedSymbolRids)" />
+
+      <!-- Linux + macOS: Aspire.Cli.<rid>.<version>.symbols.nupkg in Shipping
+           (alongside the per-RID Aspire.Cli.<rid>.<version>.nupkg). Routed to
+           MSDL by arcade's _ExistingSymbolPackage filter -> SymbolUploadHelper. -->
+      <_NonWindowsExpectedSymbolRids Include="@(_ExpectedCliRids)"
+                                     Condition="!$([System.String]::new('%(Identity)').StartsWith('win-'))" />
+
+      <_NativeSymbolPackages Include="$(ArtifactsShippingPackagesDir)**\Aspire.Cli.*.symbols.nupkg" />
+      <_NativeSymbolPackagesWithRid Include="@(_NativeSymbolPackages)">
+        <!-- Same shape as Aspire.Cli.<rid>.<version>.nupkg used by
+             _CliRidSpecificToolPackageFilesWithRid above. -->
+        <ExtractedRid>$([System.Text.RegularExpressions.Regex]::Match('%(_NativeSymbolPackages.FileName)', '^Aspire\.Cli\.(.*?)\.\d+.*').Groups[1].Value)</ExtractedRid>
+      </_NativeSymbolPackagesWithRid>
+
+      <_MissingSymbolPackageRids Include="@(_NonWindowsExpectedSymbolRids)" Exclude="@(_NativeSymbolPackagesWithRid -> '%(ExtractedRid)')" />
+      <_UnexpectedSymbolPackageRids Include="@(_NativeSymbolPackagesWithRid -> '%(ExtractedRid)')" Exclude="@(_NonWindowsExpectedSymbolRids)" />
+    </ItemGroup>
+
+    <!-- Defensive: surface a clear failure if any ExtractedRid metadata is
+         empty (the per-item RID-extraction regex did not match the filename).
+         Without this, an unmatched item flows an empty entry into the
+         _MissingXRids list ('' doesn't match any expected RID), so the build
+         still fails — but with a confusing "all expected RIDs missing"
+         message instead of "we couldn't parse these filenames." -->
+    <ItemGroup>
+      <_FilesWithUnparseableRid Include="@(_ArchiveFilesWithRid)" Condition="'%(ExtractedRid)' == ''" />
+      <_FilesWithUnparseableRid Include="@(_CliRidSpecificToolPackageFilesWithRid)" Condition="'%(ExtractedRid)' == ''" />
+      <_FilesWithUnparseableRid Include="@(_CliRidSpecificNpmPackageFilesWithRid)" Condition="'%(ExtractedRid)' == ''" />
+      <_FilesWithUnparseableRid Include="@(_LooseSymbolPdbFilesWithRid)" Condition="'%(ExtractedRid)' == ''" />
+      <_FilesWithUnparseableRid Include="@(_NativeSymbolPackagesWithRid)" Condition="'%(ExtractedRid)' == ''" />
+    </ItemGroup>
+
+    <Error Condition="@(_FilesWithUnparseableRid->Count()) > 0"
+           Text="Could not extract RID from one or more artifact filenames (regex did not match). Files: @(_FilesWithUnparseableRid, ', '). This indicates an artifact-naming contract drift; check the RID-extraction regexes in this file against the actual filenames under artifacts/." />
+
     <Warning Condition="@(_UnexpectedArchiveRids->Count()) > 0" Text="Found unexpected CLI archives for @(_UnexpectedArchiveRids, ',') . These are all the cli archives found - @(_ArchiveFiles, ', ')" />
     <Warning Condition="@(_UnexpectedCliPackageRids->Count()) > 0" Text="Found unexpected Aspire.Cli RID-specific packages for @(_UnexpectedCliPackageRids, ',') . These are all the CLI tool packages found - @(_CliToolPackagesToPublish, ', ')" />
     <Warning Condition="@(_UnexpectedCliNpmPackageRids->Count()) > 0" Text="Found unexpected Aspire CLI npm RID-specific packages for @(_UnexpectedCliNpmPackageRids, ',') . These are all the CLI npm packages found - @(_CliNpmPackagesToPublish, ', ')" />
+    <Warning Condition="@(_UnexpectedPdbRids->Count()) > 0" Text="Found unexpected Aspire.Cli native AOT pdbs for @(_UnexpectedPdbRids, ', '). These are all the pdbs found - @(_LooseSymbolPdbFiles, ', ')" />
+    <Warning Condition="@(_UnexpectedSymbolPackageRids->Count()) > 0" Text="Found unexpected Aspire.Cli native AOT symbol packages for @(_UnexpectedSymbolPackageRids, ', '). These are all the symbol packages found - @(_NativeSymbolPackages, ', ')" />
     <Error Condition="@(_MissingArchiveRids->Count()) > 0" Text="Missing CLI archive(s) for runtime identifiers: @(_MissingArchiveRids, ', '). These are all the cli archives found - @(_ArchiveFiles, ', ')" />
     <Error Condition="@(_MissingCliPackageRids->Count()) > 0" Text="Missing Aspire.Cli RID-specific package(s) for runtime identifiers: @(_MissingCliPackageRids, ', '). These are all the CLI tool packages found - @(_CliToolPackagesToPublish, ', ')" />
     <Error Condition="@(_MissingCliNpmPackageRids->Count()) > 0" Text="Missing Aspire CLI npm RID-specific package(s) for runtime identifiers: @(_MissingCliNpmPackageRids, ', '). These are all the CLI npm packages found - @(_CliNpmPackagesToPublish, ', ')" />
+    <Error Condition="@(_MissingPdbRids->Count()) > 0" Text="Missing Aspire.Cli native AOT pdb(s) for runtime identifiers: @(_MissingPdbRids, ', '). These are all the pdbs found - @(_LooseSymbolPdbFiles, ', '). The pdbs are downloaded by eng/pipelines/templates/download_native_symbols.yml from native_symbols_&lt;rid&gt; build artifacts published by eng/pipelines/templates/build_sign_native.yml; see docs/ci/cli-native-symbols.md." />
+    <Error Condition="@(_MissingSymbolPackageRids->Count()) > 0" Text="Missing Aspire.Cli native AOT symbol package(s) for runtime identifiers: @(_MissingSymbolPackageRids, ', '). These are all the symbol packages found - @(_NativeSymbolPackages, ', '). The packages are staged into Shipping by eng/pipelines/templates/download_native_symbols.yml from native_symbols_&lt;rid&gt; build artifacts published by eng/pipelines/templates/build_sign_native.yml; see docs/ci/cli-native-symbols.md." />
     <Error Condition="@(_CliPointerToolPackages->Count()) != 1" Text="Expected exactly one Aspire.Cli pointer package but found @(_CliPointerToolPackages->Count()). Files: @(_CliPointerToolPackages, ', ')" />
     <Error Condition="@(_CliPointerNpmPackages->Count()) != 1" Text="Expected exactly one Aspire CLI npm pointer package but found @(_CliPointerNpmPackages->Count()). Files: @(_CliPointerNpmPackages, ', ')" />
 

--- a/eng/Publishing.props
+++ b/eng/Publishing.props
@@ -6,6 +6,17 @@
       <AutoGenerateSymbolPackages>false</AutoGenerateSymbolPackages>
    </PropertyGroup>
 
+  <!-- CLI NativeAOT debug symbols ship to MSDL through two arcade publishing routes:
+       loose-file FilesToPublishToSymbolServer for Windows .pdb (the glob
+       below), and .symbols.nupkg for Linux .dbg / macOS .dwarf (produced by
+       eng/clipack/Aspire.Cli.NativeSymbols.proj on the per-RID build agent
+       and staged into Shipping by
+       eng/pipelines/templates/download_native_symbols.yml on the publish
+       agent). See docs/ci/cli-native-symbols.md#pipeline-architecture. -->
+  <ItemGroup>
+    <FilesToPublishToSymbolServer Include="$(ArtifactsDir)native-symbols\$(Configuration)\**\aspire.pdb" />
+  </ItemGroup>
+
   <PropertyGroup>
     <_UploadPathRoot>aspire</_UploadPathRoot>
     <!-- Already-signed native archives (macOS/Linux) are downloaded to a separate directory

--- a/eng/clipack/Aspire.Cli.NativeSymbols.proj
+++ b/eng/clipack/Aspire.Cli.NativeSymbols.proj
@@ -1,0 +1,139 @@
+<!--
+  Per-RID NativeAOT symbol-package producer for the Aspire CLI on
+  Linux/macOS. Modelled on dotnet/runtime's runtime.native.* pattern:
+  https://github.com/dotnet/runtime/blob/main/src/libraries/System.IO.Ports/pkg/runtime.native.System.IO.Ports.props
+
+  Invoked from eng/clipack/Common.projitems' _PackNativeAotSymbols
+  target, once per CliRuntime, with these properties:
+    RuntimeIdentifier        e.g. linux-x64, osx-arm64
+    SymbolFilePath           absolute path to the .dbg (Linux) or
+                             .dwarf (macOS) payload — pre-renamed by the
+                             caller so the filename's extension matches
+                             SymbolsSuffix (NuGet's allow-list routes on
+                             extension, see below)
+    SymbolsSuffix            .dbg or .dwarf
+    PackageOutputPath        scratch dir to write Pack outputs into
+    BaseIntermediateOutputPath  per-RID obj dir to avoid clobbering the
+                                outer clipack project's obj when both
+                                live under eng/clipack/
+
+  Produces, into PackageOutputPath:
+    Aspire.Cli.<rid>.<version>.symbols.nupkg
+      tools/<tfm>/<rid>/aspire.<dbg|dwarf>
+    Aspire.Cli.<rid>.<version>.nupkg  (empty companion; the caller
+                                       discards it — it would otherwise
+                                       collide with the per-RID tool
+                                       nupkg of the same id+version
+                                       produced by clipack's
+                                       _PackRidSpecificDotnetTool)
+
+  How the .dbg/.dwarf is routed into the .symbols.nupkg and not the
+  main nupkg: NuGet's TfmSpecificDebugSymbolsFile hook gates entries
+  by extension against AllowedOutputExtensionsIn{Symbols,}PackageBuildOutputFolder.
+  The default main-package allowlist (.dll;.exe;.winmd;.json;.pri;.xml)
+  excludes .dbg/.dwarf, so appending SymbolsSuffix to the symbols-package
+  allowlist below routes the native symbol file only into the symbols
+  container.
+
+  Why .symbols.nupkg and not .snupkg: arcade matches symbol packages
+  via the _ExistingSymbolPackage item — a literal EndsWith('.symbols.nupkg')
+  filter — so .snupkg is not picked up by the MSDL publishing path.
+-->
+<Project Sdk="Microsoft.Build.NoTargets">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+
+    <IsPackable>true</IsPackable>
+    <PackageId>Aspire.Cli.$(RuntimeIdentifier)</PackageId>
+    <Authors>Microsoft</Authors>
+    <Description>Native AOT debug symbols for the Aspire CLI on $(RuntimeIdentifier).</Description>
+
+    <!-- The TfmSpecificDebugSymbolsInPackage hook chain only fires under
+         pack when IncludeBuildOutput is true (Pack.targets
+         _WalkEachTargetPerFramework gate). -->
+    <IncludeBuildOutput>true</IncludeBuildOutput>
+    <IncludeSymbols>true</IncludeSymbols>
+    <SymbolPackageFormat>symbols.nupkg</SymbolPackageFormat>
+
+    <AllowedOutputExtensionsInSymbolsPackageBuildOutputFolder>$(SymbolsSuffix)</AllowedOutputExtensionsInSymbolsPackageBuildOutputFolder>
+
+    <TargetsForTfmSpecificDebugSymbolsInPackage>
+      $(TargetsForTfmSpecificDebugSymbolsInPackage);_AddAspireCliNativeSymbol
+    </TargetsForTfmSpecificDebugSymbolsInPackage>
+
+    <!-- The companion main .nupkg has no lib/ assets by design — only
+         the .symbols.nupkg sibling is the shipping artifact. NU5128
+         warns on empty packages; the caller discards the empty companion. -->
+    <NoWarn>$(NoWarn);NU5128</NoWarn>
+    <SuppressDependenciesWhenPacking>true</SuppressDependenciesWhenPacking>
+  </PropertyGroup>
+
+  <Target Name="_ValidateAspireCliNativeSymbolsInputs" BeforeTargets="Pack">
+    <Error Condition="'$(RuntimeIdentifier)' == ''"
+           Text="RuntimeIdentifier must be set when packing Aspire.Cli native symbols." />
+    <Error Condition="'$(SymbolFilePath)' == ''"
+           Text="SymbolFilePath must be set when packing Aspire.Cli native symbols." />
+    <Error Condition="'$(SymbolsSuffix)' == ''"
+           Text="SymbolsSuffix must be set when packing Aspire.Cli native symbols (.dbg or .dwarf)." />
+    <Error Condition="!Exists('$(SymbolFilePath)')"
+           Text="Symbol file not found at '$(SymbolFilePath)'." />
+  </Target>
+
+  <!--
+    Inject the native symbol file into TfmSpecificDebugSymbolsFile.
+
+    TargetPath uses a rooted ('/tools/...') value so NuGet's
+    Path.Combine("lib/$(TargetFramework)", TargetPath) collapses to the
+    rooted value (Path.Combine treats a rooted second segment as
+    absolute). NuGet strips the leading slash when emitting the zip
+    entry, producing 'tools/<tfm>/<rid>/aspire.<dbg|dwarf>' inside
+    the package — matching the layout of the per-RID Aspire.Cli.<rid>
+    tool nupkg counterpart, so triage tooling can reason about either
+    container interchangeably. See https://github.com/NuGet/Home/issues/10860
+    for the leading-slash idiom.
+  -->
+  <Target Name="_AddAspireCliNativeSymbol">
+    <ItemGroup>
+      <TfmSpecificDebugSymbolsFile Include="$(SymbolFilePath)"
+                                   TargetPath="/tools/$(TargetFramework)/$(RuntimeIdentifier)"
+                                   TargetFramework="$(TargetFramework)" />
+    </ItemGroup>
+  </Target>
+
+  <!--
+    Assert the packed .symbols.nupkg actually contains the symbol payload
+    at the expected internal path. NuGet routes TfmSpecificDebugSymbolsFile
+    entries by extension via AllowedOutputExtensionsInSymbolsPackageBuildOutputFolder;
+    if any part of that chain regresses (SDK bump removes the hook, the
+    SymbolsSuffix-vs-allowlist wiring drifts, the leading-slash TargetPath
+    idiom from NuGet/Home#10860 stops collapsing), pack will succeed but
+    the symbol payload will land somewhere else — or be dropped entirely —
+    and MSDL upload will silently ship a package SymbolUploadHelper can't
+    use. Validating after Pack catches that on every clipack build, vs.
+    discovering it post-ship on the next crash-triage attempt.
+
+    Runs Linux/macOS only — this proj is never invoked on Windows
+    (Common.projitems' _PackNativeAotSymbols guards on !$(CliRuntime.StartsWith('win-'))).
+  -->
+  <Target Name="_ValidatePackedSymbols" AfterTargets="Pack">
+    <ItemGroup>
+      <_PackedSymbolsForValidation Include="$(PackageOutputPath)Aspire.Cli.$(RuntimeIdentifier).*.symbols.nupkg" />
+    </ItemGroup>
+
+    <Error Condition="@(_PackedSymbolsForValidation->Count()) != 1"
+           Text="Pack produced @(_PackedSymbolsForValidation->Count()) Aspire.Cli.$(RuntimeIdentifier).*.symbols.nupkg files in '$(PackageOutputPath)'; expected exactly one. Files: @(_PackedSymbolsForValidation, ', ')" />
+
+    <PropertyGroup>
+      <_ExpectedZipEntry>tools/$(TargetFramework)/$(RuntimeIdentifier)/aspire$(SymbolsSuffix)</_ExpectedZipEntry>
+    </PropertyGroup>
+
+    <Exec Command="unzip -l &quot;@(_PackedSymbolsForValidation)&quot;" ConsoleToMSBuild="true">
+      <Output TaskParameter="ConsoleOutput" PropertyName="_ZipListing" />
+    </Exec>
+
+    <Error Condition="!$([System.String]::Copy('$(_ZipListing)').Contains('$(_ExpectedZipEntry)'))"
+           Text="Packed Aspire.Cli.$(RuntimeIdentifier).*.symbols.nupkg is missing the expected entry '$(_ExpectedZipEntry)'. NuGet's TfmSpecificDebugSymbolsFile / AllowedOutputExtensionsInSymbolsPackageBuildOutputFolder routing may have regressed. unzip -l output:%0A$(_ZipListing)" />
+  </Target>
+
+</Project>

--- a/eng/clipack/Common.projitems
+++ b/eng/clipack/Common.projitems
@@ -262,6 +262,160 @@
              RemoveProperties="OutputPath;TargetFramework" />
   </Target>
 
+  <!--
+    Native AOT symbol staging.
+
+    After PackDotnetTool runs (on the per-RID build agent), stage the
+    native AOT debug-info payload so the publishing pipeline can ship
+    it to MSDL/SymWeb. Two routing paths, split into two targets keyed
+    on the RID family so neither carries inner conditions for the
+    other family:
+
+      * Windows (.pdb)  copied loose into native-symbols-staging/<rid>/.
+                        Arcade's FilesToPublishToSymbolServer glob in
+                        eng/Publishing.props picks it up on the publish
+                        agent and ships it via the loose-PDB path
+                        (PrepLoosePdbsForPublish).
+
+      * Linux/macOS     Aspire.Cli.NativeSymbols.proj produces a
+        (.dbg/.dwarf)   real Aspire.Cli.<rid>.<version>.symbols.nupkg
+                        containing tools/<tfm>/<rid>/aspire.<dbg|dwarf>
+                        and we promote it into native-symbols-staging/<rid>/.
+                        Arcade matches it via the _ExistingSymbolPackage
+                        item (Microsoft.DotNet.Arcade.Sdk's Publish.proj
+                        EndsWith('.symbols.nupkg') filter) and routes it
+                        to SymbolUploadHelper for MSDL ingestion.
+
+    AfterTargets=PackDotnetTool runs both targets on the same per-RID
+    build agent that produced the ILC native output, so the canonical
+    $(ArtifactsBinDir)Aspire.Cli/... layout exists and $(CliRuntime) /
+    $(Version) are fully resolved.
+
+    See docs/ci/cli-native-symbols.md for the operating doctrine.
+  -->
+
+  <!-- Shared paths used by both _PackNativeAotSymbolsWindows and
+       _PackNativeAotSymbolsUnix. Always read from the Release output
+       dir: _PublishProject above pins Configuration=Release on the AOT
+       publish regardless of the outer build's $(Configuration) (Debug
+       AOT trips https://github.com/protocolbuffers/protobuf/issues/21824).
+       Mirroring that pin here keeps a local `build.sh -c Debug -pack`
+       from failing the Exists() guards in the targets below with a
+       misleading "ILC output layout may have moved" message when the
+       artifacts are actually under Release/. -->
+  <PropertyGroup Condition="'$(CliRuntime)' != ''">
+    <_NativeOutputDir>$([MSBuild]::NormalizeDirectory($(ArtifactsBinDir), 'Aspire.Cli', 'Release', '$(TargetFramework)', '$(CliRuntime)', 'native'))</_NativeOutputDir>
+    <_NativeSymbolsStagingDir>$([MSBuild]::NormalizeDirectory($(ArtifactsDir), 'native-symbols-staging', '$(CliRuntime)'))</_NativeSymbolsStagingDir>
+  </PropertyGroup>
+
+  <Target Name="_PackNativeAotSymbolsWindows"
+          AfterTargets="PackDotnetTool"
+          Condition="'$(CliRuntime)' != '' and $(CliRuntime.StartsWith('win-'))">
+    <PropertyGroup>
+      <_AspireNativePdbPath>$([MSBuild]::NormalizePath($(_NativeOutputDir), 'aspire.pdb'))</_AspireNativePdbPath>
+    </PropertyGroup>
+
+    <MakeDir Directories="$(_NativeSymbolsStagingDir)" />
+
+    <Error Condition="!Exists('$(_AspireNativePdbPath)')"
+           Text="Expected native AOT pdb not found at '$(_AspireNativePdbPath)' for $(CliRuntime). ILC output layout may have moved; check Microsoft.NETCore.Native.targets (NativeOutputPath / NativeSymbolExt) and docs/ci/cli-native-symbols.md." />
+
+    <Copy SourceFiles="$(_AspireNativePdbPath)"
+          DestinationFiles="$([MSBuild]::NormalizePath($(_NativeSymbolsStagingDir), 'aspire.pdb'))" />
+
+    <Message Importance="High"
+             Text="Staged native AOT pdb for $(CliRuntime) -&gt; $(_NativeSymbolsStagingDir)aspire.pdb" />
+  </Target>
+
+  <Target Name="_PackNativeAotSymbolsUnix"
+          AfterTargets="PackDotnetTool"
+          Condition="'$(CliRuntime)' != '' and !$(CliRuntime.StartsWith('win-'))">
+    <PropertyGroup>
+      <_NativeSymbolsScratchDir>$([MSBuild]::NormalizeDirectory($(IntermediateOutputPath), 'native-symbols-pack'))</_NativeSymbolsScratchDir>
+
+      <!--
+        Linux:  ILC's default StripSymbols=true splits debug info into
+                the .dbg sidecar via objcopy (only-keep-debug +
+                add-gnu-debuglink). File is already named aspire.dbg.
+
+        macOS:  ILC produces a .dSYM bundle whose payload is a Mach-O
+                file with DWARF sections at Contents/Resources/DWARF/<name>.
+                We ship just that flat Mach-O as aspire.dwarf, mirroring
+                dotnet/runtime's flat-output dsymutil mode
+                (eng/native/functions.cmake). The inner file is named
+                `aspire` (no extension); NuGet's extension allowlist
+                routes by extension, so we stage a renamed copy as
+                aspire.dwarf before passing the path to the pack helper.
+                symstore's MachOFileKeyGenerator reads LC_UUID from the
+                file content to compute the SSQP key
+                _.dwarf/mach-uuid-sym-<uuid>/_.dwarf — independent of
+                filename. The .dSYM bundle directory itself isn't
+                shipped; see dotnet/runtime#88286 for the long-term
+                .dSYM bundle distribution work.
+      -->
+      <_SymbolsSuffix Condition="$(CliRuntime.StartsWith('linux-'))">.dbg</_SymbolsSuffix>
+      <_SymbolsSuffix Condition="$(CliRuntime.StartsWith('osx-'))">.dwarf</_SymbolsSuffix>
+
+      <_RawSymbolPath Condition="$(CliRuntime.StartsWith('linux-'))">$([MSBuild]::NormalizePath($(_NativeOutputDir), 'aspire.dbg'))</_RawSymbolPath>
+      <_RawSymbolPath Condition="$(CliRuntime.StartsWith('osx-'))">$([MSBuild]::NormalizePath($(_NativeOutputDir), 'aspire.dSYM', 'Contents', 'Resources', 'DWARF', 'aspire'))</_RawSymbolPath>
+
+      <_StagedSymbolPath>$([MSBuild]::NormalizePath($(_NativeSymbolsScratchDir), 'aspire$(_SymbolsSuffix)'))</_StagedSymbolPath>
+    </PropertyGroup>
+
+    <MakeDir Directories="$(_NativeSymbolsStagingDir)" />
+
+    <Error Condition="!Exists('$(_RawSymbolPath)')"
+           Text="Expected native AOT debug-info payload not found at '$(_RawSymbolPath)' for $(CliRuntime). ILC output layout may have moved; check Microsoft.NETCore.Native.targets and docs/ci/cli-native-symbols.md." />
+
+    <MakeDir Directories="$(_NativeSymbolsScratchDir)" />
+    <Copy SourceFiles="$(_RawSymbolPath)"
+          DestinationFiles="$(_StagedSymbolPath)" />
+
+    <ItemGroup>
+      <_NativeSymbolsPackProperties Include="Configuration=$(Configuration)" />
+      <_NativeSymbolsPackProperties Include="ContinuousIntegrationBuild=$(ContinuousIntegrationBuild)" />
+      <_NativeSymbolsPackProperties Condition="'$(VersionSuffix)' != ''" Include="VersionSuffix=$(VersionSuffix)" />
+      <_NativeSymbolsPackProperties Condition="'$(OfficialBuildId)' != ''" Include="OfficialBuildId=$(OfficialBuildId)" />
+      <_NativeSymbolsPackProperties Include="RuntimeIdentifier=$(CliRuntime)" />
+      <_NativeSymbolsPackProperties Include="SymbolFilePath=$(_StagedSymbolPath)" />
+      <_NativeSymbolsPackProperties Include="SymbolsSuffix=$(_SymbolsSuffix)" />
+      <_NativeSymbolsPackProperties Include="PackageOutputPath=$(_NativeSymbolsScratchDir)" />
+      <!-- Isolate the helper's obj/ from the outer per-RID clipack
+           project's obj/, which sits at the same path
+           (eng/clipack/obj/Release/<tfm>/) because both projects live
+           in eng/clipack/ and share TargetFramework. -->
+      <_NativeSymbolsPackProperties Include="BaseIntermediateOutputPath=$([MSBuild]::NormalizeDirectory($(IntermediateOutputPath), 'native-symbols-helper-obj'))" />
+    </ItemGroup>
+
+    <MSBuild Projects="$(RepoRoot)eng\clipack\Aspire.Cli.NativeSymbols.proj"
+             Targets="Restore"
+             Properties="@(_NativeSymbolsPackProperties)"
+             RemoveProperties="OutputPath;TargetFramework" />
+
+    <MSBuild Projects="$(RepoRoot)eng\clipack\Aspire.Cli.NativeSymbols.proj"
+             Targets="Pack"
+             Properties="@(_NativeSymbolsPackProperties)"
+             RemoveProperties="OutputPath;TargetFramework" />
+
+    <!-- Promote only the .symbols.nupkg into the staging dir. The empty
+         companion Aspire.Cli.<rid>.<version>.nupkg from NuGet's
+         IncludeSymbols pack is intentionally discarded — it would
+         collide with the per-RID tool nupkg of the same id+version
+         produced by _PackRidSpecificDotnetTool. -->
+    <ItemGroup>
+      <_PackedSymbolsNupkg Include="$(_NativeSymbolsScratchDir)Aspire.Cli.$(CliRuntime).*.symbols.nupkg" />
+    </ItemGroup>
+
+    <Error Condition="@(_PackedSymbolsNupkg-&gt;Count()) != 1"
+           Text="Expected exactly one Aspire.Cli.$(CliRuntime).*.symbols.nupkg in '$(_NativeSymbolsScratchDir)' but found @(_PackedSymbolsNupkg-&gt;Count()). Files: @(_PackedSymbolsNupkg, ', ')" />
+
+    <Copy SourceFiles="@(_PackedSymbolsNupkg)"
+          DestinationFolder="$(_NativeSymbolsStagingDir)" />
+
+    <Message Importance="High"
+             Text="Staged native AOT symbols package for $(CliRuntime) -&gt; $(_NativeSymbolsStagingDir)%(_PackedSymbolsNupkg.Filename)%(_PackedSymbolsNupkg.Extension)" />
+  </Target>
+
   <Target Name="PackNpmPackage"
           DependsOnTargets="_InitializeDotnetToolPackProperties;_ExtractNativeBinaryFromArchive">
     <Message Importance="High"

--- a/eng/clipack/Common.projitems
+++ b/eng/clipack/Common.projitems
@@ -286,10 +286,18 @@
                         EndsWith('.symbols.nupkg') filter) and routes it
                         to SymbolUploadHelper for MSDL ingestion.
 
-    AfterTargets=PackDotnetTool runs both targets on the same per-RID
-    build agent that produced the ILC native output, so the canonical
-    $(ArtifactsBinDir)Aspire.Cli/... layout exists and $(CliRuntime) /
-    $(Version) are fully resolved.
+    AfterTargets=PackDotnetTool runs both targets after the per-RID tool
+    nupkg has been packed, so $(CliRuntime) / $(Version) are fully resolved.
+
+    Both targets gate on Exists($(_NativeOutputDir)aspire[.exe]) — the
+    publish binary itself — so they silently no-op in flows that invoke
+    PackDotnetTool without first running PublishToDisk (notably
+    eng/AfterSigning.targets' _PackCliDotnetToolAfterPack on
+    build-packages.yml runners, where the archive is consumed via
+    _ExtractNativeBinaryFromArchive but the ILC native output isn't
+    regenerated locally). When the publish binary IS present, the Errors
+    inside each target catch the real "ILC ran but the symbol file isn't
+    where we expect" failure mode.
 
     See docs/ci/cli-native-symbols.md for the operating doctrine.
   -->
@@ -310,7 +318,7 @@
 
   <Target Name="_PackNativeAotSymbolsWindows"
           AfterTargets="PackDotnetTool"
-          Condition="'$(CliRuntime)' != '' and $(CliRuntime.StartsWith('win-'))">
+          Condition="'$(CliRuntime)' != '' and $(CliRuntime.StartsWith('win-')) and Exists('$(_NativeOutputDir)aspire.exe')">
     <PropertyGroup>
       <_AspireNativePdbPath>$([MSBuild]::NormalizePath($(_NativeOutputDir), 'aspire.pdb'))</_AspireNativePdbPath>
     </PropertyGroup>
@@ -329,7 +337,7 @@
 
   <Target Name="_PackNativeAotSymbolsUnix"
           AfterTargets="PackDotnetTool"
-          Condition="'$(CliRuntime)' != '' and !$(CliRuntime.StartsWith('win-'))">
+          Condition="'$(CliRuntime)' != '' and !$(CliRuntime.StartsWith('win-')) and Exists('$(_NativeOutputDir)aspire')">
     <PropertyGroup>
       <_NativeSymbolsScratchDir>$([MSBuild]::NormalizeDirectory($(IntermediateOutputPath), 'native-symbols-pack'))</_NativeSymbolsScratchDir>
 

--- a/eng/pipelines/azure-pipelines-unofficial.yml
+++ b/eng/pipelines/azure-pipelines-unofficial.yml
@@ -177,8 +177,14 @@ extends:
                 inputs:
                   itemPattern: |
                     **/Aspire.Cli*.nupkg
+                    !**/Aspire.Cli*.symbols.nupkg
                     **/microsoft-aspire-cli*.tgz
                   targetPath: '$(Build.SourcesDirectory)/artifacts/native-cli-packages/$(_BuildConfig)'
+
+              # Pull the native AOT symbols staged by build_sign_native so arcade can
+              # route them on to MSDL/SymWeb during the `-publish` step below. See
+              # docs/ci/cli-native-symbols.md for the full architecture.
+              - template: /eng/pipelines/templates/download_native_symbols.yml@self
 
               - pwsh: |
                   $ErrorActionPreference = 'Stop'

--- a/eng/pipelines/azure-pipelines.yml
+++ b/eng/pipelines/azure-pipelines.yml
@@ -271,8 +271,14 @@ extends:
                 inputs:
                   itemPattern: |
                     **/Aspire.Cli*.nupkg
+                    !**/Aspire.Cli*.symbols.nupkg
                     **/microsoft-aspire-cli*.tgz
                   targetPath: '$(Build.SourcesDirectory)/artifacts/native-cli-packages/$(_BuildConfig)'
+
+              # Pull the native AOT symbols staged by build_sign_native so arcade can
+              # route them on to MSDL/SymWeb during the `-publish` step below. See
+              # docs/ci/cli-native-symbols.md for the full architecture.
+              - template: /eng/pipelines/templates/download_native_symbols.yml@self
 
               - pwsh: |
                   $ErrorActionPreference = 'Stop'

--- a/eng/pipelines/templates/build_sign_native.yml
+++ b/eng/pipelines/templates/build_sign_native.yml
@@ -321,6 +321,20 @@ jobs:
                 ASPIRE_CLI_TELEMETRY_OPTOUT: 'true'
                 DOTNET_CLI_TELEMETRY_OPTOUT: 'true'
 
+          # Native AOT debug symbols (aspire.pdb on Windows,
+          # Aspire.Cli.<rid>.<version>.symbols.nupkg on Linux/macOS) are
+          # produced as first-class MSBuild outputs by the per-RID clipack
+          # project (eng/clipack/Common.projitems _PackNativeAotSymbols
+          # target + eng/clipack/Aspire.Cli.NativeSymbols.proj helper).
+          # They land in $(Build.SourcesDirectory)/artifacts/native-symbols-staging/<rid>/
+          # before this step runs. See docs/ci/cli-native-symbols.md.
+          - task: 1ES.PublishBuildArtifacts@1
+            displayName: 🟣Publish native symbols (${{ targetRid }})
+            condition: always()
+            inputs:
+              PathtoPublish: '$(Build.SourcesDirectory)/artifacts/native-symbols-staging/${{ targetRid }}'
+              ArtifactName: native_symbols_${{ replace(targetRid, '-', '_') }}
+
           - task: 1ES.PublishBuildArtifacts@1
             displayName: 🟣Publish Artifacts
             condition: always()

--- a/eng/pipelines/templates/download_native_symbols.yml
+++ b/eng/pipelines/templates/download_native_symbols.yml
@@ -1,0 +1,58 @@
+parameters: []
+
+# Steps to pull the native AOT symbols produced by the per-RID clipack build
+# (eng/clipack/Common.projitems' _PackNativeAotSymbols target +
+# eng/clipack/Aspire.Cli.NativeSymbols.proj helper) and published as
+# native_symbols_<rid> artifacts by build_sign_native.yml, then route them on
+# to arcade's -publish step (uploaded to MSDL/SymWeb downstream). Two payloads
+# share the native_symbols_<rid> artifacts:
+#   * Windows: loose aspire.pdb → kept under artifacts/native-symbols/ for
+#     FilesToPublishToSymbolServer (eng/Publishing.props loose-pdb glob).
+#   * Linux + macOS: Aspire.Cli.<rid>.<version>.symbols.nupkg containing
+#     aspire.dbg (Linux) or aspire.dwarf (macOS) → moved into
+#     packages/<config>/Shipping by the staging step below so arcade's
+#     _ExistingSymbolPackage filter classifies it as a Symbols asset and
+#     routes it to SymbolUploadHelper, which indexes the symbol payload via
+#     symbol.exe adddirectory.
+# The artifact-name prefix preserves distinct relative paths per RID, which
+# keeps the loose-pdb path's RelativePDBPath keys unique on the symbol server.
+#
+# Per-RID coverage (a pdb for every win-* RID, a .symbols.nupkg for every
+# linux-*/osx-* RID) is enforced in eng/Publishing.props alongside the
+# existing archive/tool/npm package coverage checks, deriving the expected
+# RID set from eng/clipack/Aspire.Cli.*.csproj filenames so there is one
+# source of truth.
+#
+# See docs/ci/cli-native-symbols.md for the full operating doctrine, including
+# the local validation script and the failure modes this pipeline protects
+# against.
+steps:
+  - task: DownloadPipelineArtifact@2
+    displayName: 🟣Download Native Symbols
+    inputs:
+      itemPattern: |
+        native_symbols_*/aspire.pdb
+      targetPath: '$(Build.SourcesDirectory)/artifacts/native-symbols/$(_BuildConfig)'
+
+  - task: DownloadPipelineArtifact@2
+    displayName: 🟣Download Native Symbol Packages
+    inputs:
+      itemPattern: |
+        native_symbols_*/Aspire.Cli.*.symbols.nupkg
+      targetPath: '$(Build.SourcesDirectory)/artifacts/native-symbol-pkgs/$(_BuildConfig)'
+
+  # Flatten downloaded *.symbols.nupkg files into Shipping. Arcade's
+  # GeneratePackageVersionsFromManifest target globs $(ArtifactsShippingPackagesDir)/**
+  # for .nupkg / .symbols.nupkg files, so they only need to live somewhere under
+  # Shipping for the manifest to pick them up.
+  - pwsh: |
+      $ErrorActionPreference = 'Stop'
+      $shipDir = '$(Build.SourcesDirectory)/artifacts/packages/$(_BuildConfig)/Shipping'
+      New-Item -ItemType Directory -Force -Path $shipDir | Out-Null
+      $pkgs = @(Get-ChildItem -Path '$(Build.SourcesDirectory)/artifacts/native-symbol-pkgs/$(_BuildConfig)' -Filter '*.symbols.nupkg' -File -Recurse -ErrorAction SilentlyContinue)
+      foreach ($p in $pkgs) {
+        Copy-Item -LiteralPath $p.FullName -Destination (Join-Path $shipDir $p.Name) -Force
+        Write-Host "Staged $($p.Name) -> $shipDir"
+      }
+      Write-Host "Total native symbol packages staged: $($pkgs.Count)"
+    displayName: 🟣Stage native symbol packages

--- a/eng/scripts/validate-cli-symbols.ps1
+++ b/eng/scripts/validate-cli-symbols.ps1
@@ -1,0 +1,801 @@
+<#
+.SYNOPSIS
+  Validates that the Aspire CLI's NativeAOT symbol artifacts produce a
+  working symbol-server round-trip, without uploading anything to MSDL.
+
+.DESCRIPTION
+  Three checks, ordered loosest-to-strictest:
+
+    A. Identifier symmetry   — the binary's intrinsic ID (PDB GUID/age,
+       ELF BuildID, Mach-O LC_UUID) matches the symbol file's. If this
+       holds, symstore's per-format key generator will compute the same
+       SSQP key from either side, which is the only thing the symbol
+       server's lookup depends on.
+
+    B. dotnet-symbol round-trip — set up a local HTTP server rooted at a
+       symstore directory laid out per the SSQP convention, place the
+       packaged symbol at the computed path, and run dotnet-symbol
+       against the binary. This exercises the exact lookup code path
+       that customers hit against MSDL.
+
+    C. Symbol resolution from downloaded file — resolve the binary's
+       entry-point virtual address against the symbol file Check B just
+       downloaded. Proves the file contains usable debug info, not just
+       bytes that happen to pass an SSQP round-trip. (Check B alone
+       would be satisfied by, e.g., a same-sized file of zeros that
+       carried the correct build-id.)
+
+  Prerequisites:
+    - pwsh 7+ (ships Start-ThreadJob, used to host a local HTTP symbol
+      server in-process for Check B)
+    - dotnet SDK 10 (the script will use the repo-local SDK via
+      dotnet.cmd / dotnet.sh when present)
+    - Platform-specific ID extractors (for Check A):
+        macOS:   dwarfdump (Xcode CLT)
+        Linux:   readelf (binutils)
+        Windows: System.Reflection.PortableExecutable.PEReader (from the
+                 .NET runtime — always available) extracts the binary's
+                 CodeView GUID+Age. The PDB-side ID uses llvm-pdbutil
+                 when present; if absent, Check A's symmetry comparison
+                 skips but Check B still runs end-to-end against the
+                 binary-side ID (which is what dotnet-symbol queries).
+    - Platform-specific symbolicators (for Check C):
+        macOS:   atos + otool (Xcode CLT)
+        Linux:   addr2line (binutils)
+        Windows: llvm-symbolizer (LLVM). Entry-point VA extraction uses
+                 System.Reflection.PortableExecutable.PEReader (from the
+                 .NET runtime — always available); llvm-readobj is only a
+                 secondary fallback. Check C skips with a warning if its
+                 resolver is missing; the script never fails just because
+                 platform tooling is absent.
+    - dotnet-symbol global tool (the script installs it if absent)
+
+.PARAMETER RepoRoot
+  Repository root. Defaults to two levels above the script's directory
+  (i.e., the standard eng/scripts/ → repo root resolution).
+
+.PARAMETER Configuration
+  Build configuration. Default: Release.
+
+.PARAMETER Rid
+  Target runtime identifier. Defaults to the host's win-x64/win-arm64/
+  linux-x64/linux-arm64/osx-x64/osx-arm64.
+
+.PARAMETER TargetFramework
+  Target framework moniker for the Aspire CLI build. Default: net10.0.
+  Used to compute the bin path under artifacts/bin/Aspire.Cli/<Configuration>/
+  <TargetFramework>/<Rid>/native/.
+
+.PARAMETER SkipBuild
+  Reuse an existing build under artifacts/bin/Aspire.Cli/<Configuration>/
+  <TargetFramework>/<Rid>/native/ instead of running dotnet publish.
+
+.EXAMPLE
+  # Validate on the host RID, build first
+  pwsh eng/scripts/validate-cli-symbols.ps1
+
+.EXAMPLE
+  # Validate using a build that already exists
+  pwsh eng/scripts/validate-cli-symbols.ps1 -SkipBuild
+
+.EXAMPLE
+  # Validate a non-host RID (e.g. linux-arm64 from x64)
+  pwsh eng/scripts/validate-cli-symbols.ps1 -Rid linux-arm64
+
+.NOTES
+  Exit code: 0 if every executed check passes, 1 if any check fails.
+  Skipped checks (missing tooling) don't fail the script.
+
+  This script is intentionally a one-shot local-validation tool, not a
+  CI test. CI exercises the same pipeline shape via the AzDO internal
+  build (build_sign_native → native_symbols_<rid> artifacts → Windows
+  build job staging → arcade publish to MSDL).
+
+  For when to run, how to triage a failed check, and the relationship
+  to the production pipeline, see docs/ci/cli-native-symbols.md.
+
+.LINK
+  docs/ci/cli-native-symbols.md
+#>
+
+[CmdletBinding()]
+param(
+  [string]$RepoRoot = "$PSScriptRoot/../..",
+  [string]$Configuration = 'Release',
+  [string]$Rid,
+  [string]$TargetFramework = 'net10.0',
+  [switch]$SkipBuild
+)
+
+$ErrorActionPreference = 'Stop'
+
+# Resolve absolute repo root
+$RepoRoot = (Resolve-Path $RepoRoot -ErrorAction SilentlyContinue)?.Path
+if (-not $RepoRoot -or -not (Test-Path "$RepoRoot/global.json")) {
+  $RepoRoot = $PWD.Path
+  if (-not (Test-Path "$RepoRoot/global.json")) {
+    Write-Host "##[error]Run from repo root or pass -RepoRoot. Could not find global.json at $RepoRoot" -ForegroundColor Red
+    exit 1
+  }
+}
+
+# Detect host RID
+if (-not $Rid) {
+  $arch = if ([System.Runtime.InteropServices.RuntimeInformation]::OSArchitecture -eq 'Arm64') { 'arm64' } else { 'x64' }
+  if ($IsWindows) { $Rid = "win-$arch" }
+  elseif ($IsMacOS) { $Rid = "osx-$arch" }
+  elseif ($IsLinux) { $Rid = "linux-$arch" }
+  else { throw 'Unsupported host OS' }
+}
+
+$results = [ordered]@{}
+
+Write-Host "=== Aspire CLI symbol validation ===" -ForegroundColor Cyan
+Write-Host "RepoRoot:        $RepoRoot"
+Write-Host "Configuration:   $Configuration"
+Write-Host "TargetFramework: $TargetFramework"
+Write-Host "Rid:             $Rid"
+Write-Host ""
+
+# 1. Build (or assume built)
+$binDir = Join-Path $RepoRoot "artifacts/bin/Aspire.Cli/$Configuration/$TargetFramework/$Rid/native"
+$binary = if ($Rid.StartsWith('win-')) { Join-Path $binDir 'aspire.exe' } else { Join-Path $binDir 'aspire' }
+
+if ($SkipBuild) {
+  if (-not (Test-Path $binary)) {
+    Write-Host "##[error]-SkipBuild specified but binary not found at $binary" -ForegroundColor Red
+    exit 1
+  }
+} else {
+  Write-Host "--- Building Aspire.Cli (-r $Rid -p:PublishAot=true) ---" -ForegroundColor Yellow
+  $dotnetCmd = if ($IsWindows) { "$RepoRoot/dotnet.cmd" } else { "$RepoRoot/dotnet.sh" }
+  if (-not (Test-Path $dotnetCmd)) {
+    # Fall back to system dotnet if the repo wrapper isn't there yet
+    $dotnetCmd = 'dotnet'
+  }
+  & $dotnetCmd publish "$RepoRoot/src/Aspire.Cli/Aspire.Cli.csproj" -c $Configuration -r $Rid --self-contained -p:PublishAot=true -p:ContinuousIntegrationBuild=false 2>&1 | Tee-Object -Variable buildLog | Out-Null
+  if ($LASTEXITCODE -ne 0) {
+    Write-Host "##[error]Build failed:" -ForegroundColor Red
+    $buildLog | Select-Object -Last 30 | ForEach-Object { Write-Host $_ }
+    exit 1
+  }
+  Write-Host "Build OK"
+  Write-Host ""
+}
+
+if (-not (Test-Path $binary)) {
+  throw "Binary missing after build at $binary"
+}
+
+# 2. Locate the symbol-file artifact ILC produced.
+$stagingDir = Join-Path $RepoRoot "artifacts/validate-symbols/$Rid"
+if (Test-Path $stagingDir) { Remove-Item -Recurse -Force $stagingDir }
+New-Item -ItemType Directory -Force -Path $stagingDir | Out-Null
+
+if ($Rid.StartsWith('win-')) {
+  # Windows: loose .pdb path (no .symbols.nupkg, since arcade ships these via FilesToPublishToSymbolServer)
+  $srcSymbol = Join-Path $binDir 'aspire.pdb'
+  $stagedSymbol = Join-Path $stagingDir 'aspire.pdb'
+  if (-not (Test-Path $srcSymbol)) { throw "Expected $srcSymbol" }
+  Copy-Item $srcSymbol $stagedSymbol -Force
+  Write-Host "Windows PDB: $stagedSymbol"
+}
+elseif ($Rid.StartsWith('linux-')) {
+  $srcSymbol = Join-Path $binDir 'aspire.dbg'
+  if (-not (Test-Path $srcSymbol)) { throw "Expected $srcSymbol" }
+  $stagedSymbol = Join-Path $stagingDir 'aspire.dbg'
+  Copy-Item $srcSymbol $stagedSymbol -Force
+  Write-Host "Linux .dbg: $stagedSymbol"
+}
+elseif ($Rid.StartsWith('osx-')) {
+  $srcSymbol = Join-Path $binDir 'aspire.dSYM/Contents/Resources/DWARF/aspire'
+  if (-not (Test-Path $srcSymbol)) { throw "Expected $srcSymbol" }
+  $stagedSymbol = Join-Path $stagingDir 'aspire.dwarf'
+  Copy-Item $srcSymbol $stagedSymbol -Force
+  Write-Host "macOS .dwarf (extracted from .dSYM/Contents/Resources/DWARF/): $stagedSymbol"
+}
+else { throw "Unsupported RID: $Rid" }
+Write-Host ""
+
+# .symbols.nupkg pack/extract round-trip used to be Check B here; it was
+# retired when eng/clipack/Aspire.Cli.NativeSymbols.proj took over packing
+# from the YAML PowerShell heredoc. NuGet's PackTask now owns the format,
+# so symmetry against arcade's _ExistingSymbolPackage / SymbolUploadHelper
+# is no longer the script's contract to prove.
+
+# === Check A: identifier symmetry ===
+Write-Host "--- Check A: identifier symmetry ---" -ForegroundColor Yellow
+$idBinary = $null
+$idSymbol = $null
+$idKind = ''
+# Tracks "tool was found and invoked but failed or produced no match" so the
+# SKIP-vs-FAIL gate at the end can distinguish missing optional tooling
+# (legitimate SKIP) from a genuine extractor failure (FAIL). The script's
+# "fail loudly when our own infra breaks" intent depends on this — silently
+# downgrading an unexpected tool failure to SKIP would let a real
+# binary↔symbol regression exit 0 unnoticed (the failure mode cycle-1 C3
+# already fixed for the dotnet-symbol install path).
+$extractorIssues = @()
+
+if ($Rid.StartsWith('osx-')) {
+  $idKind = 'Mach-O UUID'
+  $dwarfdump = Get-Command dwarfdump -ErrorAction SilentlyContinue
+  if ($dwarfdump) {
+    foreach ($pair in @(@{ File = $binary; Var = 'idBinary'; Label = 'binary' },
+                        @{ File = $stagedSymbol; Var = 'idSymbol'; Label = 'symbol' })) {
+      $cmdOut = & dwarfdump --uuid $pair.File 2>&1
+      $exit = $LASTEXITCODE
+      $first = ($cmdOut | Select-Object -First 1) -as [string]
+      if ($exit -ne 0) {
+        $extractorIssues += "dwarfdump --uuid failed on $($pair.Label) (exit $exit): $($cmdOut -join '; ')"
+      } elseif (-not ($first -match '^UUID: ')) {
+        $extractorIssues += "dwarfdump --uuid produced no 'UUID: ' line for $($pair.Label) (output: $first)"
+      } else {
+        $id = $first -replace '^UUID: ', '' -replace ' .*$', '' -replace '-', ''
+        Set-Variable -Name $pair.Var -Value $id.ToLowerInvariant()
+      }
+    }
+  } else {
+    Write-Host "  (dwarfdump not available — Check A's ID extraction skipped; install Xcode Command Line Tools)"
+  }
+}
+elseif ($Rid.StartsWith('linux-')) {
+  $idKind = 'ELF BuildID'
+  $readelf = Get-Command readelf -ErrorAction SilentlyContinue
+  if ($readelf) {
+    foreach ($pair in @(@{ File = $binary; Var = 'idBinary'; Label = 'binary' },
+                        @{ File = $stagedSymbol; Var = 'idSymbol'; Label = 'symbol' })) {
+      $cmdOut = & readelf -n $pair.File 2>&1
+      $exit = $LASTEXITCODE
+      $m = $cmdOut | Select-String -Pattern 'Build ID:\s+([0-9a-f]+)' | Select-Object -First 1
+      if ($exit -ne 0) {
+        $extractorIssues += "readelf -n failed on $($pair.Label) (exit $exit): $($cmdOut -join '; ')"
+      } elseif (-not $m) {
+        $extractorIssues += "readelf -n produced no 'Build ID' line for $($pair.Label) — note section may be missing"
+      } else {
+        Set-Variable -Name $pair.Var -Value $m.Matches.Groups[1].Value
+      }
+    }
+  } else {
+    Write-Host "  (readelf not available — Check A's ID extraction skipped; install binutils)"
+  }
+}
+elseif ($Rid.StartsWith('win-')) {
+  $idKind = 'PDB GUID+Age'
+
+  # Binary-side: use System.Reflection.PortableExecutable.PEReader, which
+  # ships with .NET 10 runtime / pwsh 7+. The CodeView debug directory
+  # entry in the PE carries the GUID+Age that the symbol server uses to
+  # key the .pdb — and crucially, this is the ID dotnet-symbol computes
+  # from the binary to drive its lookup. Doing this without an external
+  # tool is important because Check B below depends on having $idBinary
+  # even when LLVM isn't installed. We still try llvm-readobj as a
+  # secondary fallback in case PEReader can't read the CodeView record.
+  $peReaderError = $null
+  try {
+    $stream = [System.IO.File]::OpenRead($binary)
+    try {
+      $peReader = [System.Reflection.PortableExecutable.PEReader]::new($stream)
+      try {
+        foreach ($entry in $peReader.ReadDebugDirectory()) {
+          if ($entry.Type -eq [System.Reflection.PortableExecutable.DebugDirectoryEntryType]::CodeView) {
+            $cv = $peReader.ReadCodeViewDebugDirectoryData($entry)
+            $guid = $cv.Guid.ToString('N').ToLowerInvariant()
+            $age  = [Convert]::ToString($cv.Age, 16).ToLowerInvariant()
+            $idBinary = "$guid$age"
+            break
+          }
+        }
+      } finally { $peReader.Dispose() }
+    } finally { $stream.Dispose() }
+  } catch {
+    # PEReader is always available, so a hard exception here is unexpected.
+    # Defer marking as FAIL until we see whether the llvm-readobj fallback
+    # recovers — if it does, we got the ID and the exception was harmless.
+    $peReaderError = $_.Exception.Message
+    Write-Host "  (PEReader CodeView extraction failed: $peReaderError — will try llvm-readobj fallback)"
+  }
+
+  if (-not $idBinary) {
+    # PEReader didn't yield a CodeView entry — fall back to llvm-readobj.
+    $llvmReadobj = Get-Command llvm-readobj -ErrorAction SilentlyContinue
+    if ($llvmReadobj) {
+      $cv = & llvm-readobj --codeview $binary 2>&1
+      $cvExit = $LASTEXITCODE
+      $cvGuid = ($cv | Select-String -Pattern 'PDB70Signature:\s+\{?([0-9A-Fa-f-]+)\}?' | Select-Object -First 1)
+      $cvAge  = ($cv | Select-String -Pattern 'Age:\s+(\d+)' | Select-Object -First 1)
+      if ($cvExit -ne 0) {
+        $extractorIssues += "llvm-readobj --codeview failed on binary (exit $cvExit): $($cv -join '; ')"
+      } elseif (-not ($cvGuid -and $cvAge)) {
+        $extractorIssues += "llvm-readobj --codeview ran cleanly on binary but did not produce PDB70Signature+Age"
+      } else {
+        $g = $cvGuid.Matches.Groups[1].Value -replace '-', ''
+        $a = [int]$cvAge.Matches.Groups[1].Value
+        $idBinary = "$($g.ToLowerInvariant())$([Convert]::ToString($a,16).ToLowerInvariant())"
+      }
+    } elseif ($peReaderError) {
+      # No fallback installed AND PEReader threw — the binary-side ID is
+      # genuinely unavailable due to extractor failure (not missing tooling).
+      $extractorIssues += "PEReader CodeView extraction failed ($peReaderError) and llvm-readobj fallback is not installed"
+    } else {
+      # PEReader ran cleanly (no exception) but produced no CodeView entry,
+      # and there is no fallback installed to second-source the result.
+      # For a NativeAOT-built Windows aspire.exe this is a real artifact
+      # failure — the toolchain always emits a CodeView debug directory
+      # pointing at the .pdb sibling — and silently falling through to
+      # SKIP would let a regression that produces a binary without an
+      # SSQP key exit 0 unnoticed. Same shape, same fix as the
+      # readelf/dwarfdump "ran cleanly but did not produce expected
+      # output" issues above.
+      $extractorIssues += "PEReader found no CodeView debug directory in binary — a NativeAOT-built Windows aspire.exe is expected to have one; the symbol-server lookup key cannot be derived from the binary without it"
+    }
+  }
+
+  # PDB-side: requires llvm-pdbutil. If absent, Check A's symmetry
+  # comparison can't run, but Check B will still proceed using $idBinary
+  # (which is what dotnet-symbol computes from the binary to key its
+  # request).
+  $llvmPdbutil = Get-Command llvm-pdbutil -ErrorAction SilentlyContinue
+  if ($llvmPdbutil) {
+    $pdbSummary = & llvm-pdbutil dump --summary $stagedSymbol 2>&1
+    $pdbExit = $LASTEXITCODE
+    $guidLine = $pdbSummary | Select-String -Pattern 'GUID:\s+\{([0-9A-F-]+)\}' | Select-Object -First 1
+    $ageLine  = $pdbSummary | Select-String -Pattern 'Age:\s+(\d+)' | Select-Object -First 1
+    if ($pdbExit -ne 0) {
+      $extractorIssues += "llvm-pdbutil dump --summary failed on symbol (exit $pdbExit): $($pdbSummary -join '; ')"
+    } elseif (-not ($guidLine -and $ageLine)) {
+      $extractorIssues += "llvm-pdbutil dump --summary ran cleanly on symbol but did not produce GUID+Age"
+    } else {
+      $guid = $guidLine.Matches.Groups[1].Value -replace '-', ''
+      $age  = [int]$ageLine.Matches.Groups[1].Value
+      $idSymbol = "$($guid.ToLowerInvariant())$([Convert]::ToString($age,16).ToLowerInvariant())"
+    }
+  } else {
+    if ($idBinary) {
+      Write-Host "  (llvm-pdbutil not available — PDB-side ID skipped; Check A's symmetry comparison will skip, but Check B will use the binary's CodeView ID: $idBinary)"
+    } else {
+      Write-Host "  (llvm-pdbutil not available and PEReader did not yield CodeView — both Check A and Check B will skip)"
+    }
+  }
+}
+
+if ($idBinary -and $idSymbol) {
+  Write-Host "  $idKind from binary: $idBinary"
+  Write-Host "  $idKind from symbol: $idSymbol"
+  if ($idBinary -eq $idSymbol) {
+    Write-Host "  ✅ A PASS: identifiers match" -ForegroundColor Green
+    $results['A'] = $true
+  } else {
+    Write-Host "  ❌ A FAIL: identifier mismatch — symbol won't be findable from binary" -ForegroundColor Red
+    $results['A'] = $false
+  }
+} elseif ($extractorIssues.Count -gt 0) {
+  Write-Host "  ❌ A FAIL: extractor was present but did not produce a usable ID:" -ForegroundColor Red
+  foreach ($issue in $extractorIssues) { Write-Host "    - $issue" -ForegroundColor Red }
+  $results['A'] = $false
+} else {
+  Write-Host "  ⏭ A SKIP: missing tooling for ID extraction"
+  $results['A'] = $null
+}
+Write-Host ""
+
+# === Check B: dotnet-symbol round-trip via local file:// store ===
+Write-Host "--- Check B: dotnet-symbol round-trip via local symstore ---" -ForegroundColor Yellow
+
+# Ensure dotnet-symbol is installed. We attempt install when the tool is
+# absent, but distinguish "install attempted and failed" (Check B FAIL — the
+# script can't validate what it set out to validate) from "tool genuinely
+# absent and install was not attempted" (Check B SKIP — consistent with the
+# rest of the script's missing-prereq policy). Without that distinction, an
+# install failure (feed outage, auth, SDK mismatch) silently looks like a
+# clean SKIP and the script exits 0.
+#
+# Append ~/.dotnet/tools to PATH BEFORE the first Get-Command so an
+# already-installed tool whose install dir isn't on PATH is discovered
+# without going through `dotnet tool install -g`. That install would exit
+# 1 with "Tool 'dotnet-symbol' is already installed", which the
+# installFailed gate below would otherwise classify as a real install
+# failure even though the tool is fully usable.
+$env:PATH = "$env:PATH" + [System.IO.Path]::PathSeparator + (Join-Path $HOME '.dotnet/tools')
+$dotnetSymbol = Get-Command dotnet-symbol -ErrorAction SilentlyContinue
+$installFailed = $false
+$installLog = $null
+if (-not $dotnetSymbol) {
+  Write-Host "  Installing dotnet-symbol globally..."
+  $installLog = & dotnet tool install -g dotnet-symbol 2>&1
+  $installExit = $LASTEXITCODE
+  $dotnetSymbol = Get-Command dotnet-symbol -ErrorAction SilentlyContinue
+  if ($installExit -ne 0 -or -not $dotnetSymbol) {
+    $installFailed = $true
+  }
+}
+
+if ($installFailed) {
+  if ($installExit -ne 0) {
+    Write-Host "  ❌ B FAIL: dotnet tool install -g dotnet-symbol failed (exit $installExit). Output:" -ForegroundColor Red
+  } else {
+    Write-Host "  ❌ B FAIL: dotnet tool install -g dotnet-symbol reported success but the tool is still not on PATH after install. Output:" -ForegroundColor Red
+  }
+  $installLog | ForEach-Object { Write-Host "    $_" }
+  $results['B'] = $false
+} elseif (-not $dotnetSymbol) {
+  Write-Host "  ⏭ B SKIP: dotnet-symbol not available" -ForegroundColor Yellow
+  $results['B'] = $null
+} else {
+  $store = Join-Path $stagingDir 'local-symstore'
+  # Compute SSQP key + place symbol file at expected path. The key is computed
+  # from the binary's intrinsic ID — that's what dotnet-symbol extracts at
+  # lookup time. Prefer the symbol-side ID when available (covers the Check A
+  # symmetry case end-to-end), fall back to the binary-side ID otherwise so
+  # Check B still exercises the full round-trip even when only one side of
+  # Check A could be extracted (e.g. Windows without llvm-pdbutil).
+  $keyId = if ($idSymbol) { $idSymbol } elseif ($idBinary) { $idBinary } else { $null }
+  $keyPath = $null
+  if ($Rid.StartsWith('osx-') -and $keyId) {
+    $keyPath = "_.dwarf/mach-uuid-sym-$keyId/_.dwarf"
+  } elseif ($Rid.StartsWith('linux-') -and $keyId) {
+    $keyPath = "_.debug/elf-buildid-sym-$keyId/_.debug"
+  } elseif ($Rid.StartsWith('win-') -and $keyId) {
+    $keyPath = "aspire.pdb/$keyId/aspire.pdb"
+  }
+
+  if ($keyPath) {
+    $target = Join-Path $store $keyPath
+    New-Item -ItemType Directory -Force -Path (Split-Path $target -Parent) | Out-Null
+    # Place the staged symbol at the SSQP-derived path so dotnet-symbol's
+    # lookup finds it. On Windows we use the loose .pdb staged earlier; on
+    # Linux/macOS we use the staged .dbg/.dwarf. $stagedSymbol covers both.
+    Copy-Item $stagedSymbol $target -Force
+    Write-Host "  Placed symbol at: $keyPath"
+
+    $out = Join-Path $stagingDir 'dotnet-symbol-out'
+    if (Test-Path $out) { Remove-Item -Recurse -Force $out }
+    New-Item -ItemType Directory -Force -Path $out | Out-Null
+
+    # dotnet-symbol only accepts http(s) server paths — not file:// — so spin
+    # up a tiny HTTP server rooted at our local symstore. We use
+    # System.Net.HttpListener (cross-platform, built into .NET) in a
+    # Start-ThreadJob rather than shelling out to `python -m http.server`
+    # for two reasons:
+    #
+    #   1. No external dependency. Earlier versions used python3 which is
+    #      missing on stock Windows; `python.exe` resolves to the Microsoft
+    #      Store stub on a clean Windows 10/11 box, which exits silently
+    #      when invoked non-interactively. That left the script with a
+    #      "server" that never bound the port and Check B failing with
+    #      ConnectionRefused.
+    #
+    #   2. Actual readiness check. The old code just slept 2s and hoped;
+    #      we now poll the listener until it serves a request (or time out).
+    #
+    # The HttpListener is constructed and Start()ed in the main thread so
+    # we own its lifetime; the thread-job only consumes contexts off it.
+    # Calling $listener.Close() from the main thread is the *only* way to
+    # unblock the job's HttpListenerContext.GetContext() call (it's a
+    # blocking unmanaged call that Stop-Job/cancellation tokens can't
+    # interrupt).
+    $port = 18080 + (Get-Random -Maximum 999)
+    $listener = [System.Net.HttpListener]::new()
+    $listener.Prefixes.Add("http://127.0.0.1:$port/")
+    $listener.Start()
+    $serverJob = Start-ThreadJob -ScriptBlock {
+      param($listener, $root)
+      while ($listener.IsListening) {
+        try {
+          $ctx = $listener.GetContext()
+          $relPath = $ctx.Request.Url.AbsolutePath.TrimStart('/').Replace('/', [System.IO.Path]::DirectorySeparatorChar)
+          $filePath = Join-Path $root $relPath
+          if (Test-Path -LiteralPath $filePath -PathType Leaf) {
+            $bytes = [System.IO.File]::ReadAllBytes($filePath)
+            $ctx.Response.ContentLength64 = $bytes.Length
+            $ctx.Response.OutputStream.Write($bytes, 0, $bytes.Length)
+          } else {
+            $ctx.Response.StatusCode = 404
+          }
+          $ctx.Response.Close()
+        } catch {
+          # listener closed from the main thread — exit the loop
+          break
+        }
+      }
+    } -ArgumentList $listener, $store
+
+    # Poll until the listener answers (any HTTP response — including the
+    # expected 404 for /__ping__ — proves it's bound and serving).
+    $serverReady = $false
+    for ($i = 0; $i -lt 30; $i++) {
+      try {
+        Invoke-WebRequest -Uri "http://127.0.0.1:$port/__ping__" -TimeoutSec 1 -UseBasicParsing -ErrorAction Stop | Out-Null
+        $serverReady = $true; break
+      } catch {
+        if ($_.Exception.Response -and $_.Exception.Response.StatusCode -eq [System.Net.HttpStatusCode]::NotFound) {
+          $serverReady = $true; break
+        }
+        Start-Sleep -Milliseconds 200
+      }
+    }
+
+    if (-not $serverReady) {
+      # The HttpListener.Start() above succeeded, so this is the validator's
+      # own in-process server failing to serve — not a missing prereq. Fail
+      # the check loudly (results['B']=$false) instead of skipping; a SKIP
+      # here would mask a real validator infrastructure failure as a clean
+      # run.
+      Write-Host "  ❌ B FAIL: local HTTP symstore did not become ready within 6s" -ForegroundColor Red
+      $results['B'] = $false
+      try { $listener.Close() } catch { }
+      Stop-Job $serverJob -ErrorAction SilentlyContinue | Out-Null
+      Remove-Job $serverJob -Force -ErrorAction SilentlyContinue | Out-Null
+    } else {
+      try {
+        $serverUrl = "http://127.0.0.1:$port"
+        Write-Host "  Local HTTP symstore: $serverUrl  (Job $($serverJob.Id))"
+        Write-Host "  Running: dotnet-symbol --symbols $binary --server-path $serverUrl -o $out"
+        & dotnet-symbol --symbols $binary --server-path $serverUrl -o $out -d 2>&1 | Tee-Object -Variable dsLog | Out-Null
+        $dsExit = $LASTEXITCODE
+        if ($dsExit -ne 0) {
+          Write-Host "  ❌ B FAIL: dotnet-symbol exited $dsExit" -ForegroundColor Red
+          $dsLog | ForEach-Object { Write-Host "    $_" }
+          $results['B'] = $false
+        } else {
+          $downloaded = @(Get-ChildItem -Path $out -Recurse -File)
+          if ($downloaded.Count -eq 0) {
+            Write-Host "  ❌ B FAIL: dotnet-symbol succeeded but no file was downloaded" -ForegroundColor Red
+            $dsLog | ForEach-Object { Write-Host "    $_" }
+            $results['B'] = $false
+          } else {
+            $downloadedHash = (Get-FileHash $downloaded[0].FullName -Algorithm SHA256).Hash
+            $sourceHash = (Get-FileHash $stagedSymbol -Algorithm SHA256).Hash
+            Write-Host "  Downloaded:    $($downloaded[0].FullName) ($($downloaded[0].Length) bytes)"
+            Write-Host "  Source SHA-256:     $sourceHash"
+            Write-Host "  Downloaded SHA-256: $downloadedHash"
+            if ($downloadedHash -eq $sourceHash) {
+              Write-Host "  ✅ B PASS: dotnet-symbol retrieved byte-identical symbol via local HTTP symstore" -ForegroundColor Green
+              $results['B'] = $true
+            } else {
+              Write-Host "  ❌ B FAIL: downloaded file differs from source" -ForegroundColor Red
+              $results['B'] = $false
+            }
+          }
+        }
+      } finally {
+        try { $listener.Close() } catch { }
+        Stop-Job $serverJob -ErrorAction SilentlyContinue | Out-Null
+        Remove-Job $serverJob -Force -ErrorAction SilentlyContinue | Out-Null
+      }
+    }
+  } else {
+    Write-Host "  ⏭ B SKIP: could not compute SSQP key (no identifier from Check A)" -ForegroundColor Yellow
+    $results['B'] = $null
+  }
+}
+Write-Host ""
+
+# === Check C: symbol resolution from the downloaded file ===
+# Check B only proves "the symbol-server protocol delivers byte-identical
+# bytes for the right key". A same-sized file of zeros carrying the right
+# build-id would pass it. Check C points the platform's native symbolicator
+# at the file Check B just downloaded and asks it to resolve the binary's
+# entry-point virtual address — proving the bytes are actually a usable
+# debug-info container.
+Write-Host "--- Check C: symbol resolution from downloaded file ---" -ForegroundColor Yellow
+
+if ($results['B'] -ne $true) {
+  Write-Host "  ⏭ C SKIP: Check B did not pass; nothing to resolve against" -ForegroundColor Yellow
+  $results['C'] = $null
+} else {
+  $downloadedSymbol = (Get-ChildItem -Path $out -Recurse -File | Select-Object -First 1).FullName
+
+  # 1. Extract the binary's entry-point VA per format.
+  $entryVa = $null
+  $textBaseHex = $null  # Mach-O only — atos needs the segment load address
+  # Tracks "extractor was present but did not yield a usable VA" so the
+  # SKIP-vs-FAIL gate below distinguishes missing optional tooling from a
+  # real extraction failure. Mirrors the Check A pattern above.
+  $entryExtractorIssues = @()
+
+  if ($Rid.StartsWith('osx-')) {
+    # Mach-O LC_MAIN.entryoff is a __TEXT-segment-relative offset; the VA is
+    # (__TEXT vmaddr) + entryoff. Example output we parse:
+    #   Load command N
+    #         cmd LC_SEGMENT_64
+    #     ...
+    #         segname __TEXT
+    #      vmaddr 0x0000000100000000
+    #   Load command M
+    #         cmd LC_MAIN
+    #     entryoff 364504
+    $otoolCmd = Get-Command otool -ErrorAction SilentlyContinue
+    if ($otoolCmd) {
+      $otool = & otool -l $binary 2>&1
+      $otoolExit = $LASTEXITCODE
+      if ($otoolExit -ne 0) {
+        $entryExtractorIssues += "otool -l failed on binary (exit $otoolExit): $($otool -join '; ')"
+      } else {
+        $inText = $false
+        $textBase = 0
+        foreach ($line in $otool) {
+          if ($line -match 'segname __TEXT')  { $inText = $true; continue }
+          if ($inText -and $line -match 'vmaddr (0x[0-9a-fA-F]+)') {
+            $textBase = [Convert]::ToInt64($matches[1], 16)
+            break
+          }
+        }
+        $entryMatch = $otool | Select-String -Pattern 'entryoff (\d+)' | Select-Object -First 1
+        if ($textBase -and $entryMatch) {
+          $entryOff = [int]$entryMatch.Matches.Groups[1].Value
+          $entryVa = $textBase + $entryOff
+          $textBaseHex = '0x{0:x}' -f $textBase
+        } else {
+          $entryExtractorIssues += "otool -l ran cleanly on binary but did not produce both __TEXT vmaddr and LC_MAIN entryoff"
+        }
+      }
+    } else {
+      Write-Host "  (otool not available — Check C's entry-point VA extraction skipped; install Xcode Command Line Tools)"
+    }
+  }
+  elseif ($Rid.StartsWith('linux-')) {
+    # ELF entry point lives in the file header — readelf -h emits one line:
+    #   Entry point address:               0x4e300
+    $readelfCmd = Get-Command readelf -ErrorAction SilentlyContinue
+    if ($readelfCmd) {
+      $hdr = & readelf -h $binary 2>&1
+      $hdrExit = $LASTEXITCODE
+      $m = $hdr | Select-String -Pattern 'Entry point address:\s+(0x[0-9a-fA-F]+)' | Select-Object -First 1
+      if ($hdrExit -ne 0) {
+        $entryExtractorIssues += "readelf -h failed on binary (exit $hdrExit): $($hdr -join '; ')"
+      } elseif (-not $m) {
+        $entryExtractorIssues += "readelf -h ran cleanly on binary but did not produce an 'Entry point address' line"
+      } else {
+        $entryVa = [Convert]::ToInt64($m.Matches.Groups[1].Value, 16)
+      }
+    } else {
+      Write-Host "  (readelf not available — Check C's entry-point VA extraction skipped; install binutils)"
+    }
+  }
+  elseif ($Rid.StartsWith('win-')) {
+    # PE entry-point VA = ImageBase + AddressOfEntryPoint, both fields of
+    # the PE optional header. Use System.Reflection.PortableExecutable.PEReader
+    # (ships with the .NET runtime, no LLVM required) for parity with the
+    # binary-side ID extraction in Check A. Fall back to llvm-readobj if
+    # PEReader can't read the headers for some reason.
+    $peReaderError = $null
+    try {
+      $stream = [System.IO.File]::OpenRead($binary)
+      try {
+        $peReader = [System.Reflection.PortableExecutable.PEReader]::new($stream)
+        try {
+          $peHdr = $peReader.PEHeaders.PEHeader
+          if ($peHdr) {
+            $entryVa = [int64]$peHdr.ImageBase + [int64]$peHdr.AddressOfEntryPoint
+          }
+        } finally { $peReader.Dispose() }
+      } finally { $stream.Dispose() }
+    } catch {
+      # Defer marking FAIL until we see whether the llvm-readobj fallback
+      # recovers (same pattern as Check A).
+      $peReaderError = $_.Exception.Message
+      Write-Host "  (PEReader entry-point extraction failed: $peReaderError — will try llvm-readobj fallback)"
+    }
+
+    if (-not $entryVa) {
+      $llvmReadobj = Get-Command llvm-readobj -ErrorAction SilentlyContinue
+      if ($llvmReadobj) {
+        # llvm-readobj --file-headers output shape:
+        #   ImageBase:           0x140000000
+        #   AddressOfEntryPoint: 0x12345
+        $hdrs = & llvm-readobj --file-headers $binary 2>&1
+        $hdrsExit = $LASTEXITCODE
+        $aepM = $hdrs | Select-String -Pattern 'AddressOfEntryPoint:\s+(0x[0-9a-fA-F]+)' | Select-Object -First 1
+        $ibM  = $hdrs | Select-String -Pattern 'ImageBase:\s+(0x[0-9a-fA-F]+)' | Select-Object -First 1
+        if ($hdrsExit -ne 0) {
+          $entryExtractorIssues += "llvm-readobj --file-headers failed on binary (exit $hdrsExit): $($hdrs -join '; ')"
+        } elseif (-not ($aepM -and $ibM)) {
+          $entryExtractorIssues += "llvm-readobj --file-headers ran cleanly on binary but did not produce ImageBase+AddressOfEntryPoint"
+        } else {
+          $aep = [Convert]::ToInt64($aepM.Matches.Groups[1].Value, 16)
+          $ib  = [Convert]::ToInt64($ibM.Matches.Groups[1].Value, 16)
+          $entryVa = $aep + $ib
+        }
+      } elseif ($peReaderError) {
+        $entryExtractorIssues += "PEReader entry-point extraction failed ($peReaderError) and llvm-readobj fallback is not installed"
+      } else {
+        # PEReader ran cleanly (no exception) but produced no entry-point
+        # VA, and there is no fallback installed. For any valid PE binary
+        # this means PEHeaders.PEHeader was null — i.e. the file isn't a
+        # parseable PE, which is a real artifact failure for a Windows
+        # aspire.exe. Same reasoning as the Check A PEReader-no-CodeView
+        # case above.
+        $entryExtractorIssues += "PEReader read no PE optional header from binary — the file is not a parseable PE, so entry-point VA cannot be derived"
+      }
+    }
+  }
+
+  if (-not $entryVa) {
+    if ($entryExtractorIssues.Count -gt 0) {
+      Write-Host "  ❌ C FAIL: entry-point extractor was present but did not produce a usable VA:" -ForegroundColor Red
+      foreach ($issue in $entryExtractorIssues) { Write-Host "    - $issue" -ForegroundColor Red }
+      $results['C'] = $false
+    } else {
+      Write-Host "  ⏭ C SKIP: could not determine binary entry-point VA" -ForegroundColor Yellow
+      $results['C'] = $null
+    }
+  } else {
+    $entryVaHex = '0x{0:x}' -f $entryVa
+    Write-Host "  Binary entry-point VA: $entryVaHex"
+
+    # 2. Resolve the address against the downloaded symbol file.
+    $symResult = $null
+    $resolverTool = $null
+    if ($Rid.StartsWith('osx-')) {
+      $atos = Get-Command atos -ErrorAction SilentlyContinue
+      if ($atos) {
+        $resolverTool = 'atos'
+        # atos resolves an address against a Mach-O symbol container; -l
+        # supplies the load address (here the __TEXT vmaddr, since the file
+        # isn't actually mapped). Output shape: "main (in aspire.dwarf) (main.cpp:228)"
+        $symResult = (& atos -o $downloadedSymbol -l $textBaseHex $entryVaHex 2>$null | Select-Object -First 1)
+      }
+    }
+    elseif ($Rid.StartsWith('linux-')) {
+      $a2l = Get-Command addr2line -ErrorAction SilentlyContinue
+      if ($a2l) {
+        $resolverTool = 'addr2line'
+        # addr2line -f prints the function name on line 1 and file:line on
+        # line 2; -C demangles. We only assert on the function name.
+        # Output shape: "_start\n??:?" or "main\nmain.c:42"
+        $symResult = (& addr2line -e $downloadedSymbol -f -C $entryVaHex 2>$null | Select-Object -First 1)
+      }
+    }
+    elseif ($Rid.StartsWith('win-')) {
+      $llvm = Get-Command llvm-symbolizer -ErrorAction SilentlyContinue
+      if ($llvm) {
+        $resolverTool = 'llvm-symbolizer'
+        # llvm-symbolizer reads the PE's CodeView record to locate the PDB,
+        # which defaults to the .pdb path embedded at link time. Stage the
+        # downloaded .pdb adjacent to a copy of the binary so resolution
+        # uses the file dotnet-symbol actually delivered (not whatever PDB
+        # might be sitting next to the original build output).
+        $resolveDir = Join-Path $stagingDir 'resolve-test'
+        New-Item -ItemType Directory -Force -Path $resolveDir | Out-Null
+        $binCopy = Join-Path $resolveDir 'aspire.exe'
+        $pdbCopy = Join-Path $resolveDir 'aspire.pdb'
+        Copy-Item $binary $binCopy -Force
+        Copy-Item $downloadedSymbol $pdbCopy -Force
+        # Output shape: "wmain\nC:\path\to\main.cpp:228:0"
+        $symResult = (& llvm-symbolizer --obj=$binCopy $entryVaHex 2>$null | Select-Object -First 1)
+      }
+    }
+
+    if (-not $resolverTool) {
+      Write-Host "  ⏭ C SKIP: no symbolicator available for $Rid" -ForegroundColor Yellow
+      $results['C'] = $null
+    }
+    elseif (-not $symResult `
+        -or $symResult -match '^\s*\?\?\s*$' `
+        -or $symResult -match '^\s*0x[0-9a-fA-F]+\s*$') {
+      # Empty, "??" (addr2line "unknown"), or a hex address echoed back
+      # (llvm-symbolizer's "no debug info" output) all indicate the symbol
+      # file failed to resolve — meaning it doesn't actually contain usable
+      # debug info for this address.
+      Write-Host "  ❌ C FAIL: $resolverTool could not resolve $entryVaHex; got: '$symResult'" -ForegroundColor Red
+      $results['C'] = $false
+    } else {
+      Write-Host "  Resolved via ${resolverTool}: $entryVaHex → $symResult"
+      Write-Host "  ✅ C PASS: downloaded symbol contains usable debug info" -ForegroundColor Green
+      $results['C'] = $true
+    }
+  }
+}
+Write-Host ""
+
+# Summary
+Write-Host "=== Summary for $Rid ===" -ForegroundColor Cyan
+$exitCode = 0
+foreach ($k in $results.Keys) {
+  $v = $results[$k]
+  $glyph = if ($v -eq $true) { '✅' } elseif ($v -eq $false) { '❌' } else { '⏭' }
+  Write-Host "  $glyph Check $k"
+  if ($v -eq $false) { $exitCode = 1 }
+}
+exit $exitCode

--- a/eng/scripts/validate-cli-symbols.ps1
+++ b/eng/scripts/validate-cli-symbols.ps1
@@ -379,7 +379,9 @@ if ($idBinary -and $idSymbol) {
 }
 Write-Host ""
 
-# === Check B: dotnet-symbol round-trip via local file:// store ===
+# === Check B: dotnet-symbol round-trip via local symstore ===
+# Served over a loopback HttpListener, not a file:// URI — dotnet-symbol's
+# server-path parser only accepts http(s) (see HttpListener block below).
 Write-Host "--- Check B: dotnet-symbol round-trip via local symstore ---" -ForegroundColor Yellow
 
 # Ensure dotnet-symbol is installed. We attempt install when the tool is


### PR DESCRIPTION
**Aspire CLI ships as a NativeAOT binary but its native debug symbols never reached MSDL/SymWeb.** `dotnet symbol` against a shipped `aspire` returned nothing on any of Windows / Linux / macOS, so customer crash reports and our own triage couldn't symbolicate CLI stack traces.

```
$ dotnet symbol --symbols aspire.exe -o ./syms
Downloading from https://msdl.microsoft.com/download/symbols/
ERROR: Not Found
```

## Root cause

ILC emits a per-platform symbol artifact next to the binary on every NativeAOT build (`aspire.pdb` / `aspire.dbg` / `aspire.dSYM`), but nothing in our pipeline routed those into arcade's publish step. The infrastructure was wired up; it just had no file to upload.

## The fix

Two arcade publishing routes, one per platform family:

- **Windows `.pdb`** — loose-file path via `FilesToPublishToSymbolServer` (arcade's loose-PDB path is `.pdb`/`.dll`-only).
- **Linux `.dbg` / macOS `.dwarf`** — packed into `Aspire.Cli.<rid>.<version>.symbols.nupkg` via NuGet's `TfmSpecificDebugSymbolsFile` hook, routed through arcade's `_ExistingSymbolPackage` → `SymbolUploadHelper`.

Per-RID coverage gate in `eng/Publishing.props` asserts one symbol artifact per expected RID at publish time. `eng/scripts/validate-cli-symbols.ps1` reproduces the full round-trip locally (identifier symmetry → `dotnet-symbol` download → resolver-readable content) — manual, not in CI.

**See [`docs/ci/cli-native-symbols.md`](docs/ci/cli-native-symbols.md) for the operating doctrine** — ILC output paths, the macOS flat-DWARF vs `.dSYM` tradeoff, SSQP key forms per platform, and the upstream contracts (dotnet/runtime, dotnet/arcade, dotnet/symstore) this depends on.

## Call-outs

- **Cannot be PR-validated through GitHub Actions.** `azure-pipelines-public.yml` does not run `build_sign_native`. Verification: internal AzDO build [2992798](https://dev.azure.com/dnceng/internal/_build/results?buildId=2992798), which exercises the full `build_sign_native` matrix across all 7 RIDs (Win x64/arm64, Linux x64/arm64/musl-x64, macOS x64/arm64) producing `native_symbols_<rid>` artifacts for arcade's Publish Assets stage.
- **macOS ships the flat DWARF, not the `.dSYM` bundle.** Server-mediated `dotnet-symbol` symbolication (the primary CLI crash-triage flow) only needs the flat form; Apple-native automatic symbolication via Spotlight is the open work tracked by [dotnet/runtime#88286](https://github.com/dotnet/runtime/issues/88286).
- **`AutoGenerateSymbolPackages` stays `false`.** That property is about managed-PDB → `.symbols.nupkg` wrapping for NuGet packages, independent of the native symbol publishing here.
