### PR TITLE
Add aspire new diagnostic logging

### DIFF
--- a/src/Aspire.Cli/Commands/NewCommand.cs
+++ b/src/Aspire.Cli/Commands/NewCommand.cs
@@ -15,6 +15,7 @@ using Aspire.Cli.Telemetry;
 using Aspire.Cli.Templating;
 using Aspire.Cli.Utils;
 using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging;
 using Spectre.Console;
 using NuGetPackage = Aspire.Shared.NuGetPackageCli;
 
@@ -33,6 +34,7 @@ internal sealed class NewCommand : BaseCommand, IPackageMetaPrefetchingCommand
     private readonly IPackagingService _packagingService;
     private readonly AgentInitCommand _agentInitCommand;
     private readonly ICliHostEnvironment _hostEnvironment;
+    private readonly ILogger<NewCommand> _logger;
 
     internal static readonly Option<string?> s_nameOption = new("--name", "-n")
     {
@@ -85,7 +87,8 @@ internal sealed class NewCommand : BaseCommand, IPackageMetaPrefetchingCommand
         IPackagingService packagingService,
         AgentInitCommand agentInitCommand,
         ICliHostEnvironment hostEnvironment,
-        IConfiguration configuration)
+        IConfiguration configuration,
+        ILogger<NewCommand> logger)
         : base("new", NewCommandStrings.Description, features, updateNotifier, executionContext, interactionService, telemetry)
     {
         _prompter = prompter;
@@ -94,6 +97,7 @@ internal sealed class NewCommand : BaseCommand, IPackageMetaPrefetchingCommand
         _packagingService = packagingService;
         _agentInitCommand = agentInitCommand;
         _hostEnvironment = hostEnvironment;
+        _logger = logger;
 
         Options.Add(s_nameOption);
         Options.Add(s_outputOption);
@@ -177,7 +181,7 @@ internal sealed class NewCommand : BaseCommand, IPackageMetaPrefetchingCommand
         return selected.LanguageId;
     }
 
-    private static NuGetPackage? TryGetCurrentCliTemplateVersionPackage(PackageChannel selectedChannel, NuGetPackage[] packages, bool hasPrHives)
+    private static TemplateVersionSelection? TryGetCurrentCliTemplateVersionPackage(PackageChannel selectedChannel, NuGetPackage[] packages, bool hasPrHives)
     {
         if (VersionHelper.TryGetCurrentCliVersionMatch(
             packages,
@@ -186,7 +190,7 @@ internal sealed class NewCommand : BaseCommand, IPackageMetaPrefetchingCommand
             channelName: selectedChannel.Name,
             hasPrHives: hasPrHives))
         {
-            return cliVersionPackage;
+            return new TemplateVersionSelection(cliVersionPackage, "exact current CLI match");
         }
 
         if (packages.Length > 0 &&
@@ -194,12 +198,12 @@ internal sealed class NewCommand : BaseCommand, IPackageMetaPrefetchingCommand
             !VersionHelper.IsLocalBuildChannel(selectedChannel.Name))
         {
             // Prerelease channels can filter out the shipped stable package even when the feed can restore it.
-            return new NuGetPackage
+            return new TemplateVersionSelection(new NuGetPackage
             {
                 Id = TemplateNuGetConfigService.TemplatesPackageName,
                 Version = VersionHelper.GetDefaultSdkVersion(),
                 Source = selectedChannel.SourceDetails
-            };
+            }, "current CLI pin");
         }
 
         return null;
@@ -334,6 +338,8 @@ internal sealed class NewCommand : BaseCommand, IPackageMetaPrefetchingCommand
         public string? ErrorMessage { get; init; }
     }
 
+    private sealed record TemplateVersionSelection(NuGetPackage Package, string Reason);
+
     private async Task<ResolveTemplateVersionResult> ResolveCliTemplateVersionAsync(ParseResult parseResult, CancellationToken cancellationToken)
     {
         return await InteractionService.ShowStatusAsync(
@@ -372,6 +378,13 @@ internal sealed class NewCommand : BaseCommand, IPackageMetaPrefetchingCommand
                         ?? channels.FirstOrDefault()
                     : channels.FirstOrDefault(c => string.Equals(c.Name, configuredChannelName, StringComparisons.ChannelName));
 
+                _logger.LogDebug(
+                    "Resolving Aspire project template package. RequestedChannel: {RequestedChannel}, IdentityChannel: {IdentityChannel}, SelectedChannel: {SelectedChannel}, AvailableChannels: {AvailableChannels}",
+                    configuredChannelName,
+                    ExecutionContext.IdentityChannel,
+                    selectedChannel?.Name,
+                    string.Join(", ", channels.Select(static c => $"{c.Name} ({c.Type})")));
+
                 if (selectedChannel is null)
                 {
                     string errorMessage;
@@ -407,11 +420,19 @@ internal sealed class NewCommand : BaseCommand, IPackageMetaPrefetchingCommand
                         .ToArray();
                     var hasPrHives = ExecutionContext.GetHiveCount() > 0;
 
-                    var package = TryGetCurrentCliTemplateVersionPackage(selectedChannel, packages, hasPrHives);
+                    LogTemplatePackageCandidates(selectedChannel, packages);
 
-                    package ??= packages
-                        .OrderByDescending(p => Semver.SemVersion.Parse(p.Version, Semver.SemVersionStyles.Strict), Semver.SemVersion.PrecedenceComparer)
-                        .FirstOrDefault();
+                    var selection = TryGetCurrentCliTemplateVersionPackage(selectedChannel, packages, hasPrHives);
+                    var package = selection?.Package;
+                    var selectionReason = selection?.Reason;
+
+                    if (package is null)
+                    {
+                        package = packages
+                            .OrderByDescending(p => Semver.SemVersion.Parse(p.Version, Semver.SemVersionStyles.Strict), Semver.SemVersion.PrecedenceComparer)
+                            .FirstOrDefault();
+                        selectionReason = "latest fallback";
+                    }
 
                     if (package is null)
                     {
@@ -422,6 +443,13 @@ internal sealed class NewCommand : BaseCommand, IPackageMetaPrefetchingCommand
                     // (stable/nuget.org) should not be written so aspire add uses its default behavior.
                     var channelName = selectedChannel.Type is PackageChannelType.Explicit ? selectedChannel.Name : null;
 
+                    _logger.LogInformation(
+                        "Selected Aspire project template package {TemplatePackageVersion} from channel {ChannelName} ({ChannelType}). Reason: {SelectionReason}",
+                        package.Version,
+                        selectedChannel.Name,
+                        selectedChannel.Type,
+                        selectionReason);
+
                     return new ResolveTemplateVersionResult { Version = package.Version, ChannelName = channelName };
                 }
                 catch (NuGetPackageCacheException ex)
@@ -429,6 +457,25 @@ internal sealed class NewCommand : BaseCommand, IPackageMetaPrefetchingCommand
                     return new ResolveTemplateVersionResult { ErrorMessage = ex.Message };
                 }
             });
+    }
+
+    private void LogTemplatePackageCandidates(PackageChannel selectedChannel, IReadOnlyList<NuGetPackage> packages)
+    {
+        if (!_logger.IsEnabled(LogLevel.Debug))
+        {
+            return;
+        }
+
+        var preview = packages
+            .OrderByDescending(p => Semver.SemVersion.Parse(p.Version, Semver.SemVersionStyles.Strict), Semver.SemVersion.PrecedenceComparer)
+            .Take(5)
+            .Select(static p => $"{p.Version} ({PackageSourceRedactor.RedactForDisplay(p.Source)})");
+        _logger.LogDebug(
+            "Template package resolution found {CandidateCount} candidate package(s) in channel {ChannelName}. Preview: {CandidatePreview}{AdditionalCandidateCount}",
+            packages.Count,
+            selectedChannel.Name,
+            string.Join(", ", preview),
+            packages.Count > 5 ? $" (+{packages.Count - 5} more)" : string.Empty);
     }
 
     protected override async Task<CommandResult> ExecuteAsync(ParseResult parseResult, CancellationToken cancellationToken)

--- a/src/Aspire.Cli/NuGet/BundleNuGetService.cs
+++ b/src/Aspire.Cli/NuGet/BundleNuGetService.cs
@@ -117,6 +117,7 @@ internal sealed class BundleNuGetService : INuGetService
         if (File.Exists(manifestPath) && TryValidatePackageManifest(manifestPath, _logger))
         {
             _logger.LogDebug("Using cached package manifest at {Path}", manifestPath);
+            AppHostPackageDiagnostics.LogRestoredPackageVersionsFromAssetsFile(_logger, assetsPath, manifestPath);
             return manifestPath;
         }
 
@@ -251,6 +252,7 @@ internal sealed class BundleNuGetService : INuGetService
         }
 
         _logger.LogDebug("Package manifest created at {Path}", manifestPath);
+        AppHostPackageDiagnostics.LogRestoredPackageVersionsFromAssetsFile(_logger, assetsPath, manifestPath);
         return manifestPath;
     }
 

--- a/src/Aspire.Cli/Projects/AppHostRpcClient.cs
+++ b/src/Aspire.Cli/Projects/AppHostRpcClient.cs
@@ -1,12 +1,15 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Diagnostics;
 using System.IO.Pipes;
 using System.Net.Sockets;
 using System.Text.Json;
 using Aspire.Cli.Backchannel;
 using Aspire.Cli.Telemetry;
+using Aspire.Cli.Utils;
 using Aspire.TypeSystem;
+using Microsoft.Extensions.Logging;
 using StreamJsonRpc;
 
 namespace Aspire.Cli.Projects;
@@ -20,16 +23,19 @@ internal sealed class AppHostRpcClient : IAppHostRpcClient
     // The backchannel listener registers handlers without a connection name, so this value
     // is purely for grouping client-side spans/metrics in the trace.
     private const string ConnectionName = "remotehost";
+    private static readonly TimeSpan s_slowOperationWarningThreshold = TimeSpan.FromSeconds(5);
 
     private readonly Stream _stream;
     private readonly JsonRpc _jsonRpc;
     private readonly ProfilingTelemetry? _profilingTelemetry;
+    private readonly ILogger? _logger;
 
-    private AppHostRpcClient(Stream stream, JsonRpc jsonRpc, ProfilingTelemetry? profilingTelemetry)
+    private AppHostRpcClient(Stream stream, JsonRpc jsonRpc, ProfilingTelemetry? profilingTelemetry, ILogger? logger)
     {
         _stream = stream;
         _jsonRpc = jsonRpc;
         _profilingTelemetry = profilingTelemetry;
+        _logger = logger;
     }
 
     /// <summary>
@@ -39,11 +45,26 @@ internal sealed class AppHostRpcClient : IAppHostRpcClient
         string socketPath,
         string authenticationToken,
         ProfilingTelemetry? profilingTelemetry,
-        CancellationToken cancellationToken)
+        CancellationToken cancellationToken,
+        ILogger? logger = null)
     {
         ArgumentException.ThrowIfNullOrEmpty(authenticationToken);
 
-        var stream = await ConnectToServerAsync(socketPath, cancellationToken);
+        var connectionStopwatch = Stopwatch.StartNew();
+        logger?.LogDebug("Connecting to AppHost RPC transport. SocketPath: {SocketPath}", socketPath);
+
+        var stream = await DiagnosticLogging.WaitWithSlowWarningAsync(
+            ConnectToServerAsync(socketPath, cancellationToken, logger),
+            s_slowOperationWarningThreshold,
+            () => logger?.LogWarning(
+                "Still waiting to connect to AppHost RPC transport after {ElapsedSeconds} seconds. SocketPath: {SocketPath}",
+                s_slowOperationWarningThreshold.TotalSeconds,
+                socketPath)).ConfigureAwait(false);
+        logger?.LogDebug(
+            "Connected to AppHost RPC transport after {ElapsedMilliseconds} ms. SocketPath: {SocketPath}",
+            connectionStopwatch.ElapsedMilliseconds,
+            socketPath);
+
         JsonRpc? jsonRpc = null;
 
         try
@@ -56,21 +77,36 @@ internal sealed class AppHostRpcClient : IAppHostRpcClient
             };
             jsonRpc.StartListening();
 
-            var authenticated = await jsonRpc.InvokeWithProfilingAsync<bool>(
-                profilingTelemetry,
-                ConnectionName,
-                "authenticate",
-                [authenticationToken],
-                cancellationToken).ConfigureAwait(false);
+            var authenticationStopwatch = Stopwatch.StartNew();
+            logger?.LogDebug("Authenticating AppHost RPC connection. SocketPath: {SocketPath}", socketPath);
+
+            var authenticated = await DiagnosticLogging.WaitWithSlowWarningAsync(
+                jsonRpc.InvokeWithProfilingAsync<bool>(
+                    profilingTelemetry,
+                    ConnectionName,
+                    "authenticate",
+                    [authenticationToken],
+                    cancellationToken),
+                s_slowOperationWarningThreshold,
+                () => logger?.LogWarning(
+                    "Still waiting for AppHost RPC authentication after {ElapsedSeconds} seconds. SocketPath: {SocketPath}",
+                    s_slowOperationWarningThreshold.TotalSeconds,
+                    socketPath)).ConfigureAwait(false);
             if (!authenticated)
             {
                 throw new InvalidOperationException("Failed to authenticate to the AppHost server.");
             }
 
-            return new AppHostRpcClient(stream, jsonRpc, profilingTelemetry);
+            logger?.LogDebug(
+                "Authenticated AppHost RPC connection after {ElapsedMilliseconds} ms. SocketPath: {SocketPath}",
+                authenticationStopwatch.ElapsedMilliseconds,
+                socketPath);
+
+            return new AppHostRpcClient(stream, jsonRpc, profilingTelemetry, logger);
         }
-        catch
+        catch (Exception ex)
         {
+            logger?.LogDebug(ex, "Failed to connect or authenticate AppHost RPC connection. SocketPath: {SocketPath}", socketPath);
             jsonRpc?.Dispose();
             await stream.DisposeAsync();
             throw;
@@ -111,11 +147,11 @@ internal sealed class AppHostRpcClient : IAppHostRpcClient
 
     /// <inheritdoc />
     public Task<T> InvokeAsync<T>(string methodName, object?[] parameters, CancellationToken cancellationToken)
-        => _jsonRpc.InvokeWithProfilingAsync<T>(_profilingTelemetry, ConnectionName, methodName, parameters, cancellationToken);
+        => InvokeRpcWithDiagnosticsAsync<T>(methodName, parameters, cancellationToken);
 
     /// <inheritdoc />
     public Task InvokeAsync(string methodName, object?[] parameters, CancellationToken cancellationToken)
-        => _jsonRpc.InvokeWithProfilingAsync(_profilingTelemetry, ConnectionName, methodName, parameters, cancellationToken);
+        => InvokeRpcWithDiagnosticsAsync(methodName, parameters, cancellationToken);
 
     /// <summary>
     /// Invokes a code-generation RPC method and rethrows structured load/type failures as
@@ -126,7 +162,7 @@ internal sealed class AppHostRpcClient : IAppHostRpcClient
     {
         try
         {
-            return await _jsonRpc.InvokeWithProfilingAsync<T>(_profilingTelemetry, ConnectionName, methodName, parameters, cancellationToken).ConfigureAwait(false);
+            return await InvokeRpcWithDiagnosticsAsync<T>(methodName, parameters, cancellationToken).ConfigureAwait(false);
         }
         catch (RemoteInvocationException ex) when (ex.ErrorCode == AppHostCodeGenerationErrorCodes.IncompatibleAspireSdk)
         {
@@ -138,6 +174,46 @@ internal sealed class AppHostRpcClient : IAppHostRpcClient
 
             throw new AppHostCodeGenerationException(ex.Message, diagnostic, ex);
         }
+    }
+
+    private async Task<T> InvokeRpcWithDiagnosticsAsync<T>(string methodName, object?[] parameters, CancellationToken cancellationToken)
+    {
+        var stopwatch = Stopwatch.StartNew();
+        _logger?.LogDebug("Invoking AppHost RPC method {MethodName}.", methodName);
+
+        var result = await DiagnosticLogging.WaitWithSlowWarningAsync(
+            _jsonRpc.InvokeWithProfilingAsync<T>(_profilingTelemetry, ConnectionName, methodName, parameters, cancellationToken),
+            s_slowOperationWarningThreshold,
+            () => _logger?.LogWarning(
+                "Still waiting for AppHost RPC method {MethodName} after {ElapsedSeconds} seconds.",
+                methodName,
+                s_slowOperationWarningThreshold.TotalSeconds)).ConfigureAwait(false);
+
+        _logger?.LogDebug(
+            "Completed AppHost RPC method {MethodName} after {ElapsedMilliseconds} ms.",
+            methodName,
+            stopwatch.ElapsedMilliseconds);
+
+        return result;
+    }
+
+    private async Task InvokeRpcWithDiagnosticsAsync(string methodName, object?[] parameters, CancellationToken cancellationToken)
+    {
+        var stopwatch = Stopwatch.StartNew();
+        _logger?.LogDebug("Invoking AppHost RPC method {MethodName}.", methodName);
+
+        await DiagnosticLogging.WaitWithSlowWarningAsync(
+            _jsonRpc.InvokeWithProfilingAsync(_profilingTelemetry, ConnectionName, methodName, parameters, cancellationToken),
+            s_slowOperationWarningThreshold,
+            () => _logger?.LogWarning(
+                "Still waiting for AppHost RPC method {MethodName} after {ElapsedSeconds} seconds.",
+                methodName,
+                s_slowOperationWarningThreshold.TotalSeconds)).ConfigureAwait(false);
+
+        _logger?.LogDebug(
+            "Completed AppHost RPC method {MethodName} after {ElapsedMilliseconds} ms.",
+            methodName,
+            stopwatch.ElapsedMilliseconds);
     }
 
     /// <summary>
@@ -178,7 +254,7 @@ internal sealed class AppHostRpcClient : IAppHostRpcClient
     /// <summary>
     /// Connects to the RPC server using platform-appropriate transport.
     /// </summary>
-    private static async Task<Stream> ConnectToServerAsync(string socketPath, CancellationToken cancellationToken)
+    private static async Task<Stream> ConnectToServerAsync(string socketPath, CancellationToken cancellationToken, ILogger? logger)
     {
         var startTime = DateTimeOffset.UtcNow;
         const int ConnectionTimeoutSeconds = 30;
@@ -193,6 +269,7 @@ internal sealed class AppHostRpcClient : IAppHostRpcClient
                     try
                     {
                         await pipeClient.ConnectAsync(cancellationToken).ConfigureAwait(false);
+                        logger?.LogDebug("Connected to AppHost RPC named pipe. SocketPath: {SocketPath}", socketPath);
                         return pipeClient;
                     }
                     catch (TimeoutException)
@@ -205,6 +282,7 @@ internal sealed class AppHostRpcClient : IAppHostRpcClient
                     }
                 }
 
+                logger?.LogWarning("Timed out connecting to AppHost RPC named pipe after {ConnectionTimeoutSeconds} seconds. SocketPath: {SocketPath}", ConnectionTimeoutSeconds, socketPath);
                 throw new InvalidOperationException($"Failed to connect to RPC server at {socketPath}");
             }
             catch
@@ -225,6 +303,7 @@ internal sealed class AppHostRpcClient : IAppHostRpcClient
                     try
                     {
                         await socket.ConnectAsync(endpoint, cancellationToken).ConfigureAwait(false);
+                        logger?.LogDebug("Connected to AppHost RPC Unix domain socket. SocketPath: {SocketPath}", socketPath);
                         return new NetworkStream(socket, ownsSocket: true);
                     }
                     catch (SocketException)
@@ -233,6 +312,7 @@ internal sealed class AppHostRpcClient : IAppHostRpcClient
                     }
                 }
 
+                logger?.LogWarning("Timed out connecting to AppHost RPC Unix domain socket after {ConnectionTimeoutSeconds} seconds. SocketPath: {SocketPath}", ConnectionTimeoutSeconds, socketPath);
                 throw new InvalidOperationException($"Failed to connect to RPC server at {socketPath}");
             }
             catch
@@ -249,9 +329,16 @@ internal sealed class AppHostRpcClient : IAppHostRpcClient
 /// </summary>
 internal sealed class AppHostRpcClientFactory : IAppHostRpcClientFactory
 {
+    private readonly ILogger<AppHostRpcClient> _logger;
+
+    public AppHostRpcClientFactory(ILogger<AppHostRpcClient> logger)
+    {
+        _logger = logger;
+    }
+
     /// <inheritdoc />
     public async Task<IAppHostRpcClient> ConnectAsync(string socketPath, string authenticationToken, CancellationToken cancellationToken)
     {
-        return await AppHostRpcClient.ConnectAsync(socketPath, authenticationToken, profilingTelemetry: null, cancellationToken).ConfigureAwait(false);
+        return await AppHostRpcClient.ConnectAsync(socketPath, authenticationToken, profilingTelemetry: null, cancellationToken, _logger).ConfigureAwait(false);
     }
 }

--- a/src/Aspire.Cli/Projects/AppHostServerSession.cs
+++ b/src/Aspire.Cli/Projects/AppHostServerSession.cs
@@ -15,6 +15,8 @@ namespace Aspire.Cli.Projects;
 /// </summary>
 internal sealed class AppHostServerSession : IAppHostServerSession
 {
+    private static readonly TimeSpan s_slowOperationWarningThreshold = TimeSpan.FromSeconds(5);
+
     private readonly string _authenticationToken;
     private readonly ILogger _logger;
     private readonly Process _serverProcess;
@@ -103,6 +105,11 @@ internal sealed class AppHostServerSession : IAppHostServerSession
         OutputCollector serverOutput;
         try
         {
+            logger.LogDebug(
+                "Starting AppHost server process for {AppHostServerProjectType}. CliProcessId: {CliProcessId}",
+                appHostServerProject.GetType().Name,
+                currentPid);
+
             (socketPath, serverProcess, serverOutput) = appHostServerProject.Run(
                 currentPid,
                 serverEnvironmentVariables,
@@ -118,6 +125,10 @@ internal sealed class AppHostServerSession : IAppHostServerSession
 
         activity.SetProcessId(serverProcess.Id);
         activity.SetProcessInvocation(serverProcess.StartInfo.FileName, serverProcess.StartInfo.ArgumentList);
+        logger.LogDebug(
+            "Started AppHost server process {ProcessId}. SocketPath: {SocketPath}",
+            serverProcess.Id,
+            socketPath);
 
         return new AppHostServerSession(
             serverProcess,
@@ -135,7 +146,31 @@ internal sealed class AppHostServerSession : IAppHostServerSession
     {
         ObjectDisposedException.ThrowIf(_disposed, nameof(AppHostServerSession));
 
-        return _rpcClient ??= await AppHostRpcClient.ConnectAsync(_socketPath, _authenticationToken, _profilingTelemetry, cancellationToken);
+        if (_rpcClient is not null)
+        {
+            return _rpcClient;
+        }
+
+        _logger.LogDebug(
+            "Creating AppHost RPC client for process {ProcessId}. SocketPath: {SocketPath}",
+            _serverProcess.Id,
+            _socketPath);
+
+        _rpcClient = await DiagnosticLogging.WaitWithSlowWarningAsync(
+            AppHostRpcClient.ConnectAsync(_socketPath, _authenticationToken, _profilingTelemetry, cancellationToken, _logger),
+            s_slowOperationWarningThreshold,
+            () => _logger.LogWarning(
+                "Still waiting to create AppHost RPC client for process {ProcessId} after {ElapsedSeconds} seconds. SocketPath: {SocketPath}",
+                _serverProcess.Id,
+                s_slowOperationWarningThreshold.TotalSeconds,
+                _socketPath));
+
+        _logger.LogDebug(
+            "Created AppHost RPC client for process {ProcessId}. SocketPath: {SocketPath}",
+            _serverProcess.Id,
+            _socketPath);
+
+        return _rpcClient;
     }
 
     /// <inheritdoc />
@@ -207,18 +242,38 @@ internal sealed class AppHostServerSessionFactory : IAppHostServerSessionFactory
         CancellationToken cancellationToken)
     {
         var appHostServerProject = await _projectFactory.CreateAsync(appHostPath, cancellationToken);
+        var integrationList = integrations.ToList();
+        _logger.LogDebug(
+            "Preparing AppHost server project {AppHostServerProjectType}. AppHostPath: {AppHostPath}, SdkVersion: {SdkVersion}, IntegrationCount: {IntegrationCount}",
+            appHostServerProject.GetType().Name,
+            appHostPath,
+            sdkVersion,
+            integrationList.Count);
 
         // Prepare the server (create files + build for dev mode, restore packages for prebuilt mode)
         AppHostServerPrepareResult prepareResult;
         try
         {
-            prepareResult = await appHostServerProject.PrepareAsync(sdkVersion, integrations, cancellationToken: cancellationToken);
+            prepareResult = await DiagnosticLogging.WaitWithSlowWarningAsync(
+                appHostServerProject.PrepareAsync(sdkVersion, integrationList, cancellationToken: cancellationToken),
+                TimeSpan.FromSeconds(30),
+                () => _logger.LogWarning(
+                    "Still preparing AppHost server project {AppHostServerProjectType} after 30 seconds. AppHostPath: {AppHostPath}",
+                    appHostServerProject.GetType().Name,
+                    appHostPath));
         }
         catch
         {
             (appHostServerProject as IDisposable)?.Dispose();
             throw;
         }
+
+        _logger.LogDebug(
+            "Prepared AppHost server project {AppHostServerProjectType}. Success: {Success}, ChannelName: {ChannelName}, NeedsCodeGeneration: {NeedsCodeGeneration}",
+            appHostServerProject.GetType().Name,
+            prepareResult.Success,
+            prepareResult.ChannelName,
+            prepareResult.NeedsCodeGeneration);
 
         if (!prepareResult.Success)
         {

--- a/src/Aspire.Cli/Projects/DotNetBasedAppHostServerProject.cs
+++ b/src/Aspire.Cli/Projects/DotNetBasedAppHostServerProject.cs
@@ -432,6 +432,10 @@ internal sealed class DotNetBasedAppHostServerProject : IAppHostServerProject
         };
 
         var exitCode = await _dotNetCliRunner.BuildAsync(projectFile, noRestore: false, options, cancellationToken);
+        AppHostPackageDiagnostics.LogRestoredPackageVersionsFromAssetsFile(
+            _logger,
+            Path.Combine(_projectModelPath, "obj", "project.assets.json"),
+            manifestPath: null);
 
         return (exitCode == 0, outputCollector);
     }
@@ -445,6 +449,11 @@ internal sealed class DotNetBasedAppHostServerProject : IAppHostServerProject
         CancellationToken cancellationToken = default)
     {
         var (_, channelName) = await CreateProjectFilesAsync(integrations, requestedChannel, packageSourceOverride, cancellationToken);
+        _logger.LogDebug(
+            "Preparing in-repo AppHost server project. ProjectFile: {ProjectFile}, ChannelName: {ChannelName}, PackageReferences: {PackageReferences}",
+            GetProjectFilePath(),
+            channelName,
+            AppHostPackageDiagnostics.FormatTrackedPackageVersions(integrations.Where(static i => i.IsPackageReference).Select(static i => (i.Name, i.Version))));
         var (buildSuccess, buildOutput) = await BuildAsync(cancellationToken);
 
         if (!buildSuccess)

--- a/src/Aspire.Cli/Projects/PrebuiltAppHostServer.cs
+++ b/src/Aspire.Cli/Projects/PrebuiltAppHostServer.cs
@@ -157,6 +157,13 @@ internal sealed class PrebuiltAppHostServer : IAppHostServerProject, IDisposable
                 effectivePackageSourceOverride = await ResolveLocalPackageSourceOverrideAsync(requestedChannel, cancellationToken).ConfigureAwait(false);
             }
 
+            _logger.LogDebug(
+                "Preparing prebuilt AppHost server. RequestedChannel: {RequestedChannel}, PackageSourceOverride: {PackageSourceOverride}, PackageReferences: {PackageReferences}, ProjectReferenceCount: {ProjectReferenceCount}",
+                requestedChannel,
+                string.IsNullOrWhiteSpace(effectivePackageSourceOverride) ? null : PackageSourceRedactor.RedactForDisplay(effectivePackageSourceOverride),
+                AppHostPackageDiagnostics.FormatTrackedPackageVersions(packageRefs.Select(static p => (p.Name, p.Version))),
+                projectRefs.Count);
+
             if (projectRefs.Count > 0)
             {
                 // Project references require .NET SDK — verify it's available
@@ -187,6 +194,11 @@ internal sealed class PrebuiltAppHostServer : IAppHostServerProject, IDisposable
                         cancellationToken).ConfigureAwait(false);
                 }
 
+                _logger.LogDebug(
+                    "Prepared prebuilt AppHost project-reference closure. ManifestPath: {ManifestPath}, Packages: {PackageVersions}",
+                    _integrationProbeManifestPath,
+                    AppHostPackageDiagnostics.FormatTrackedPackageVersions(closureManifest.Entries.Select(static e => (e.PackageId ?? string.Empty, e.PackageVersion))));
+
                 _selectedProjectLayout = await _projectLayoutStore.GetOrCreateAsync(closureManifest, cancellationToken).ConfigureAwait(false);
                 if (_selectedProjectLayout is not null)
                 {
@@ -202,6 +214,10 @@ internal sealed class PrebuiltAppHostServer : IAppHostServerProject, IDisposable
                     // NuGet-only — use the bundled NuGet service (no SDK required)
                     _integrationProbeManifestPath = await RestoreNuGetPackagesAsync(
                         packageRefs, requestedChannel, effectivePackageSourceOverride, cancellationToken);
+                    _logger.LogDebug(
+                        "Prepared prebuilt AppHost package-reference closure. ManifestPath: {ManifestPath}, RequestedPackages: {PackageVersions}",
+                        _integrationProbeManifestPath,
+                        AppHostPackageDiagnostics.FormatTrackedPackageVersions(packageRefs.Select(static p => (p.Name, p.Version))));
                 }
 
                 var appSettingsContent = CreateAppSettingsContent(packageRefs, []);

--- a/src/Aspire.Cli/Templating/TemplateNuGetConfigService.cs
+++ b/src/Aspire.Cli/Templating/TemplateNuGetConfigService.cs
@@ -7,6 +7,7 @@ using Aspire.Cli.Exceptions;
 using Aspire.Cli.Interaction;
 using Aspire.Cli.Packaging;
 using Aspire.Cli.Utils;
+using Microsoft.Extensions.Logging;
 using NuGetPackage = Aspire.Shared.NuGetPackageCli;
 
 namespace Aspire.Cli.Templating;
@@ -20,7 +21,8 @@ internal sealed class TemplateNuGetConfigService(
     CliExecutionContext executionContext,
     IPackagingService packagingService,
     ITemplateVersionPrompter templateVersionPrompter,
-    ICliHostEnvironment hostEnvironment)
+    ICliHostEnvironment hostEnvironment,
+    ILogger<TemplateNuGetConfigService> logger)
 {
     /// <summary>
     /// The name of the NuGet package that ships the Aspire project templates.
@@ -204,6 +206,12 @@ internal sealed class TemplateNuGetConfigService(
     /// <exception cref="EmptyChoicesException">Thrown when no template package versions are available across the considered channels.</exception>
     public async Task<TemplatePackageSelection> ResolveTemplatePackageAsync(TemplatePackageQuery query, CancellationToken cancellationToken)
     {
+        logger.LogDebug(
+            "Resolving Aspire project template package. RequestedChannel: {RequestedChannel}, VersionOverride: {VersionOverride}, IncludePrHives: {IncludePrHives}",
+            query.RequestedChannel,
+            query.VersionOverride,
+            query.IncludePrHives);
+
         var allChannels = await packagingService.GetChannelsAsync(cancellationToken, query.RequestedChannel);
 
         // Honor PR hives only when the caller opts in. Init suppresses this so a developer
@@ -233,12 +241,18 @@ internal sealed class TemplateNuGetConfigService(
                 : allChannels.Where(c => c.Type is PackageChannelType.Implicit);
         }
 
+        var selectedChannels = channels.ToArray();
+        logger.LogDebug(
+            "Template package resolution will search {ChannelCount} channel(s): {Channels}",
+            selectedChannels.Length,
+            string.Join(", ", selectedChannels.Select(static c => $"{c.Name} ({c.Type})")));
+
         var packagesFromChannels = await interactionService.ShowStatusAsync(Resources.TemplatingStrings.SearchingForAvailableTemplateVersions, async () =>
         {
             var results = new List<(NuGetPackage Package, PackageChannel Channel)>();
             var resultsLock = new object();
 
-            await Parallel.ForEachAsync(channels, cancellationToken, async (channel, ct) =>
+            await Parallel.ForEachAsync(selectedChannels, cancellationToken, async (channel, ct) =>
             {
                 var templatePackages = await channel.GetTemplatePackagesAsync(executionContext.WorkingDirectory, ct);
                 lock (resultsLock)
@@ -255,15 +269,25 @@ internal sealed class TemplateNuGetConfigService(
             throw new EmptyChoicesException(Resources.TemplatingStrings.NoTemplateVersionsFound);
         }
 
-        var orderedPackagesFromChannels = packagesFromChannels.OrderByDescending(p => Semver.SemVersion.Parse(p.Package.Version), Semver.SemVersion.PrecedenceComparer);
+        var orderedPackagesFromChannels = packagesFromChannels
+            .OrderByDescending(p => Semver.SemVersion.Parse(p.Package.Version), Semver.SemVersion.PrecedenceComparer)
+            .ToArray();
+
+        LogTemplateCandidates(orderedPackagesFromChannels);
 
         if (query.VersionOverride is { } version)
         {
             var explicitMatch = orderedPackagesFromChannels.FirstOrDefault(p => p.Package.Version == version);
             if (explicitMatch.Package is not null)
             {
+                LogTemplateSelection(explicitMatch, "explicit-version-override");
                 return new TemplatePackageSelection(explicitMatch.Package, explicitMatch.Channel);
             }
+
+            logger.LogDebug(
+                "Requested template version override '{VersionOverride}' was not found among {CandidateCount} candidate package(s); continuing with normal selection.",
+                version,
+                orderedPackagesFromChannels.Length);
         }
 
         if (VersionHelper.TryGetCurrentCliVersionMatch(
@@ -273,6 +297,7 @@ internal sealed class TemplateNuGetConfigService(
             channelName: query.RequestedChannel,
             hasPrHives: hasPrHives))
         {
+            LogTemplateSelection(cliVersionMatch, "current-cli-version-match");
             return new TemplatePackageSelection(cliVersionMatch.Package, cliVersionMatch.Channel);
         }
 
@@ -282,6 +307,7 @@ internal sealed class TemplateNuGetConfigService(
         if (!string.IsNullOrEmpty(query.RequestedChannel))
         {
             var first = orderedPackagesFromChannels.First();
+            LogTemplateSelection(first, "requested-channel-highest");
             return new TemplatePackageSelection(first.Package, first.Channel);
         }
 
@@ -289,11 +315,40 @@ internal sealed class TemplateNuGetConfigService(
         if (!hostEnvironment.SupportsInteractiveInput)
         {
             var first = orderedPackagesFromChannels.First();
+            LogTemplateSelection(first, "non-interactive-highest");
             return new TemplatePackageSelection(first.Package, first.Channel);
         }
 
         var prompted = await templateVersionPrompter.PromptForTemplatesVersionAsync(orderedPackagesFromChannels, cancellationToken);
+        LogTemplateSelection(prompted, "user-prompted");
         return new TemplatePackageSelection(prompted.Package, prompted.Channel);
+    }
+
+    private void LogTemplateCandidates(IReadOnlyList<(NuGetPackage Package, PackageChannel Channel)> candidates)
+    {
+        if (!logger.IsEnabled(LogLevel.Debug))
+        {
+            return;
+        }
+
+        var preview = candidates
+            .Take(5)
+            .Select(static c => $"{c.Package.Version} from {c.Channel.Name} ({c.Channel.Type}, {PackageSourceRedactor.RedactForDisplay(c.Package.Source)})");
+        logger.LogDebug(
+            "Template package resolution found {CandidateCount} candidate package(s). Preview: {CandidatePreview}{AdditionalCandidateCount}",
+            candidates.Count,
+            string.Join(", ", preview),
+            candidates.Count > 5 ? $" (+{candidates.Count - 5} more)" : string.Empty);
+    }
+
+    private void LogTemplateSelection((NuGetPackage Package, PackageChannel Channel) selection, string reason)
+    {
+        logger.LogInformation(
+            "Selected Aspire project template package {TemplatePackageVersion} from channel {ChannelName} ({ChannelType}). Reason: {SelectionReason}",
+            selection.Package.Version,
+            selection.Channel.Name,
+            selection.Channel.Type,
+            reason);
     }
 
     private static bool HasInstalledLocalBuildPackageSource(PackageChannel channel)

--- a/src/Aspire.Cli/Utils/AppHostPackageDiagnostics.cs
+++ b/src/Aspire.Cli/Utils/AppHostPackageDiagnostics.cs
@@ -1,0 +1,106 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Text.Json;
+using Microsoft.Extensions.Logging;
+
+namespace Aspire.Cli.Utils;
+
+/// <summary>
+/// Helpers for logging AppHost package versions that affect guest-language code generation.
+/// </summary>
+internal static class AppHostPackageDiagnostics
+{
+    private static readonly string[] s_trackedPackageIds =
+    [
+        "Aspire.Hosting",
+        "Aspire.Hosting.CodeGeneration.TypeScript",
+        "Aspire.TypeSystem"
+    ];
+
+    public static string FormatTrackedPackageVersions(IEnumerable<(string Id, string? Version)> packages)
+    {
+        var packageVersions = packages
+            .GroupBy(static p => p.Id, StringComparer.OrdinalIgnoreCase)
+            .ToDictionary(static g => g.Key, static g => g.First().Version, StringComparer.OrdinalIgnoreCase);
+
+        return string.Join(", ", s_trackedPackageIds.Select(id =>
+            $"{id}={GetDisplayVersion(packageVersions.GetValueOrDefault(id))}"));
+    }
+
+    public static void LogRestoredPackageVersionsFromAssetsFile(ILogger logger, string assetsPath, string? manifestPath)
+    {
+        if (!logger.IsEnabled(LogLevel.Debug))
+        {
+            return;
+        }
+
+        try
+        {
+            if (!File.Exists(assetsPath))
+            {
+                logger.LogDebug(
+                    "AppHost package diagnostics skipped because assets file was not found. AssetsPath: {AssetsPath}, ManifestPath: {ManifestPath}",
+                    assetsPath,
+                    manifestPath);
+                return;
+            }
+
+            var versions = ReadPackageVersionsFromAssetsFile(assetsPath);
+            logger.LogDebug(
+                "Restored AppHost package versions. ManifestPath: {ManifestPath}, Packages: {PackageVersions}",
+                manifestPath,
+                FormatTrackedPackageVersions(versions));
+        }
+        catch (Exception ex) when (ex is JsonException or IOException or UnauthorizedAccessException)
+        {
+            logger.LogDebug(
+                ex,
+                "Failed to read AppHost package versions from assets file. AssetsPath: {AssetsPath}, ManifestPath: {ManifestPath}",
+                assetsPath,
+                manifestPath);
+        }
+    }
+
+    private static IReadOnlyList<(string Id, string? Version)> ReadPackageVersionsFromAssetsFile(string assetsPath)
+    {
+        using var stream = File.OpenRead(assetsPath);
+        using var document = JsonDocument.Parse(stream);
+        if (!document.RootElement.TryGetProperty("libraries", out var libraries))
+        {
+            return [];
+        }
+
+        var versions = new List<(string Id, string? Version)>();
+        foreach (var library in libraries.EnumerateObject())
+        {
+            if (!library.Value.TryGetProperty("type", out var typeElement) ||
+                !string.Equals(typeElement.GetString(), "package", StringComparison.OrdinalIgnoreCase) ||
+                TryParseLibraryName(library.Name) is not { } package)
+            {
+                continue;
+            }
+
+            if (s_trackedPackageIds.Contains(package.Id, StringComparer.OrdinalIgnoreCase))
+            {
+                versions.Add(package);
+            }
+        }
+
+        return versions;
+    }
+
+    private static (string Id, string Version)? TryParseLibraryName(string libraryName)
+    {
+        var separatorIndex = libraryName.IndexOf('/');
+        if (separatorIndex <= 0 || separatorIndex == libraryName.Length - 1)
+        {
+            return null;
+        }
+
+        return (libraryName[..separatorIndex], libraryName[(separatorIndex + 1)..]);
+    }
+
+    private static string GetDisplayVersion(string? version) =>
+        string.IsNullOrWhiteSpace(version) ? "<not restored>" : version;
+}

--- a/src/Aspire.Cli/Utils/DiagnosticLogging.cs
+++ b/src/Aspire.Cli/Utils/DiagnosticLogging.cs
@@ -1,0 +1,48 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Aspire.Cli.Utils;
+
+/// <summary>
+/// Helpers for adding diagnostic wait warnings without changing task behavior.
+/// </summary>
+internal static class DiagnosticLogging
+{
+    public static async Task<T> WaitWithSlowWarningAsync<T>(Task<T> task, TimeSpan threshold, Action logWarning)
+    {
+        ArgumentNullException.ThrowIfNull(task);
+        ArgumentNullException.ThrowIfNull(logWarning);
+
+        using var delayCancellation = new CancellationTokenSource();
+        var delayTask = Task.Delay(threshold, delayCancellation.Token);
+        if (await Task.WhenAny(task, delayTask).ConfigureAwait(false) == delayTask && !task.IsCompleted)
+        {
+            logWarning();
+        }
+        else
+        {
+            delayCancellation.Cancel();
+        }
+
+        return await task.ConfigureAwait(false);
+    }
+
+    public static async Task WaitWithSlowWarningAsync(Task task, TimeSpan threshold, Action logWarning)
+    {
+        ArgumentNullException.ThrowIfNull(task);
+        ArgumentNullException.ThrowIfNull(logWarning);
+
+        using var delayCancellation = new CancellationTokenSource();
+        var delayTask = Task.Delay(threshold, delayCancellation.Token);
+        if (await Task.WhenAny(task, delayTask).ConfigureAwait(false) == delayTask && !task.IsCompleted)
+        {
+            logWarning();
+        }
+        else
+        {
+            delayCancellation.Cancel();
+        }
+
+        await task.ConfigureAwait(false);
+    }
+}

--- a/src/Aspire.Hosting.RemoteHost/JsonRpcServer.cs
+++ b/src/Aspire.Hosting.RemoteHost/JsonRpcServer.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Diagnostics;
 using System.IO.Pipes;
 using System.Net.Sockets;
 using System.Runtime.Versioning;
@@ -111,7 +112,7 @@ internal sealed class JsonRpcServer : BackgroundService
                 listenActivity.AddJsonRpcServerListening();
                 await pipeServer.WaitForConnectionAsync(cancellationToken).ConfigureAwait(false);
 
-                _logger.LogDebug("Client connected");
+                _logger.LogDebug("Accepted JsonRpc client connection on named pipe {SocketPath}", _socketPath);
                 var activeClientCount = Interlocked.Increment(ref _activeClientCount);
                 listenActivity.AddJsonRpcClientConnected(activeClientCount);
 
@@ -172,7 +173,7 @@ internal sealed class JsonRpcServer : BackgroundService
 
                 var clientSocket = await _listenSocket.AcceptAsync(cancellationToken).ConfigureAwait(false);
 
-                _logger.LogDebug("Client connected");
+                _logger.LogDebug("Accepted JsonRpc client connection on Unix domain socket {SocketPath}", _socketPath);
                 var activeClientCount = Interlocked.Increment(ref _activeClientCount);
                 listenActivity.AddJsonRpcClientConnected(activeClientCount);
 
@@ -199,11 +200,12 @@ internal sealed class JsonRpcServer : BackgroundService
     {
         var clientId = Guid.NewGuid().ToString("N")[..8]; // Short client identifier
         var disconnectReason = "unknown";
+        var connectionStopwatch = Stopwatch.StartNew();
         using var activity = _profilingTelemetry.StartJsonRpcConnection();
 
         // Create a DI scope for this client connection
         // All scoped services (HandleRegistry, RemoteAppHostService, etc.) are per-client
-        _logger.LogDebug("Creating DI scope for client {ClientId}", clientId);
+        _logger.LogDebug("Accepted JsonRpc client stream {ClientId}; creating DI scope", clientId);
         var scope = _scopeFactory.CreateAsyncScope();
         await using var _ = scope.ConfigureAwait(false);
 
@@ -228,13 +230,14 @@ internal sealed class JsonRpcServer : BackgroundService
             // Add the shared LanguageService as an additional target for language support methods
             jsonRpc.AddLocalRpcTarget(languageService);
 
+            _logger.LogDebug("Starting JsonRpc listener for client {ClientId}", clientId);
             jsonRpc.StartListening();
             activity.AddJsonRpcListening();
 
             // Enable bidirectional communication - allow .NET to call back to TypeScript
             clientService.SetClientConnection(jsonRpc);
 
-            _logger.LogDebug("JsonRpc connection established for client {ClientId} (bidirectional)", clientId);
+            _logger.LogDebug("JsonRpc listener established for client {ClientId} (bidirectional)", clientId);
 
             // Wait for the connection to be closed by the client, an error, or cancellation
             using var registration = cancellationToken.Register(() =>
@@ -292,7 +295,11 @@ internal sealed class JsonRpcServer : BackgroundService
                 }
             }
 
-            _logger.LogDebug("Connection cleanup completed for client {ClientId}", clientId);
+            _logger.LogDebug(
+                "Connection cleanup completed for client {ClientId}. DisconnectReason: {DisconnectReason}, ElapsedMilliseconds: {ElapsedMilliseconds}",
+                clientId,
+                disconnectReason,
+                connectionStopwatch.ElapsedMilliseconds);
             activity.AddJsonRpcConnectionClosed(disconnectReason);
 
             // Decrement active client count

--- a/tests/Aspire.Cli.Tests/Templating/DotNetTemplateFactoryTests.cs
+++ b/tests/Aspire.Cli.Tests/Templating/DotNetTemplateFactoryTests.cs
@@ -16,6 +16,7 @@ using Aspire.Cli.Tests.TestServices;
 using Aspire.Cli.Tests.Utils;
 using Aspire.Cli.Utils;
 using Aspire.Shared;
+using Microsoft.Extensions.Logging.Abstractions;
 using Spectre.Console;
 using Spectre.Console.Rendering;
 
@@ -351,7 +352,13 @@ public class DotNetTemplateFactoryTests
         sdkInstaller ??= new TestDotNetSdkInstaller();
         var telemetry = TestTelemetryHelper.CreateInitializedTelemetry();
         var hostEnvironment = new FakeCliHostEnvironment(nonInteractive);
-        var templateNuGetConfigService = new TemplateNuGetConfigService(interactionService, executionContext, packagingService, prompter, hostEnvironment);
+        var templateNuGetConfigService = new TemplateNuGetConfigService(
+            interactionService,
+            executionContext,
+            packagingService,
+            prompter,
+            hostEnvironment,
+            NullLogger<TemplateNuGetConfigService>.Instance);
 
         return new DotNetTemplateFactory(
             interactionService,

--- a/tests/Aspire.Cli.Tests/Templating/TemplateNuGetConfigServiceTests.cs
+++ b/tests/Aspire.Cli.Tests/Templating/TemplateNuGetConfigServiceTests.cs
@@ -7,6 +7,7 @@ using Aspire.Cli.Tests.Mcp;
 using Aspire.Cli.Tests.TestServices;
 using Aspire.Cli.Tests.Utils;
 using Aspire.Cli.Utils;
+using Microsoft.Extensions.Logging.Abstractions;
 using System.Xml.Linq;
 
 namespace Aspire.Cli.Tests.Templating;
@@ -453,7 +454,8 @@ public class TemplateNuGetConfigServiceTests(ITestOutputHelper outputHelper)
             executionContext ?? TestExecutionContextFactory.CreateTestContext(),
             packagingService ?? MockPackagingServiceFactory.Create(),
             new StubTemplateVersionPrompter(),
-            new StubCliHostEnvironment());
+            new StubCliHostEnvironment(),
+            NullLogger<TemplateNuGetConfigService>.Instance);
     }
 
     private sealed class StubTemplateVersionPrompter : Aspire.Cli.Commands.ITemplateVersionPrompter


### PR DESCRIPTION
## Description

Adds diagnostic logging for the `aspire new` TypeScript AppHost creation path so future hangs or version-skew failures can be localized from debug logs instead of stopping at "Starting JsonRpc server on Unix domain socket".

The logs now show:

- Template package candidate counts/previews, selected version, channel, and reason (`exact current CLI match`, `current CLI pin`, or `latest fallback`).
- AppHost package restore diagnostics for `Aspire.Hosting`, `Aspire.Hosting.CodeGeneration.TypeScript`, and `Aspire.TypeSystem`, including the probe manifest path.
- AppHost server process/socket lifecycle, RPC transport connection, authentication, and RPC method elapsed time/slow-wait warnings.
- Remote host JsonRpc connection accept/listen/cleanup diagnostics.

Manual diagnosis with the instrumented CLI showed the current fixed `release/13.4` path selects template/package version `13.4.0` for `--channel daily` via `current CLI pin`, restores matching `13.4.0` AppHost packages, connects/authenticates successfully, and completes `scaffoldAppHost` in 8 ms. A temporary local revert of the current-CLI pinning fallback selected `13.5.0-preview.1.26277.15` from daily via `latest fallback`, restored `Aspire.Hosting`, `Aspire.Hosting.CodeGeneration.TypeScript`, and `Aspire.TypeSystem` `13.5.0-preview.1.26277.15`, then still connected/authenticated successfully and completed `scaffoldAppHost` in 10 ms and `generateCode` in 65 ms. Forced pre-fix style runs with `--version 13.5.0-preview.1.26277.12` and `.15` produced the same successful RPC-boundary result in the current environment, so the earlier hang is not reproducing here.

Fixes # (issue)

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No