### PR TITLE
Add job and artifacts links to CLI E2E recording comment table

### DIFF
--- a/.github/workflows/cli-e2e-recording-comment.yml
+++ b/.github/workflows/cli-e2e-recording-comment.yml
@@ -123,6 +123,30 @@ jobs:
 
             console.log(`Found ${cliE2eArtifacts.length} CLI E2E recording artifacts`);
 
+            // Build metadata mapping testShortName to artifact IDs for recordings and logs.
+            // Recording artifacts: cli-e2e-recordings-{testShortName}
+            // Logs artifacts: logs-{testShortName}-{os}
+            const artifactMeta = {};
+            for (const artifact of cliE2eArtifacts) {
+              const testShortName = artifact.name.replace('cli-e2e-recordings-', '');
+              artifactMeta[testShortName] = {
+                recordingArtifactId: artifact.id,
+                logsArtifactId: null
+              };
+            }
+
+            // Find matching logs artifacts for each testShortName
+            const logsArtifacts = allArtifacts.filter(a => a.name.startsWith('logs-'));
+            for (const [testShortName, meta] of Object.entries(artifactMeta)) {
+              const match = logsArtifacts.find(a => a.name.startsWith(`logs-${testShortName}-`));
+              if (match) {
+                meta.logsArtifactId = match.id;
+              }
+            }
+
+            fs.writeFileSync('artifact_meta.json', JSON.stringify(artifactMeta, null, 2));
+            console.log('Artifact metadata:', JSON.stringify(artifactMeta, null, 2));
+
             // Create recordings directory
             const recordingsDir = 'recordings';
             fs.mkdirSync(recordingsDir, { recursive: true });
@@ -152,17 +176,30 @@ jobs:
           mkdir -p cast_files
           mkdir -p trx_files
 
+          # Track which .cast file came from which testShortName so we can link
+          # to the correct job and artifacts in the PR comment.
+          declare -A CAST_TO_SHORT_NAME
+
           for zipfile in recordings/*.zip; do
             if [ -f "$zipfile" ]; then
               echo "Extracting $zipfile..."
-              unzip -o "$zipfile" -d "recordings/extracted_$(basename "$zipfile" .zip)" || true
+              # Artifact zip name: cli-e2e-recordings-{testShortName}.zip
+              ARTIFACT_NAME=$(basename "$zipfile" .zip)
+              TEST_SHORT_NAME="${ARTIFACT_NAME#cli-e2e-recordings-}"
+              EXTRACT_DIR="recordings/extracted_${ARTIFACT_NAME}"
+              unzip -o "$zipfile" -d "$EXTRACT_DIR" || true
+
+              # Copy .cast files and record their source testShortName
+              find "$EXTRACT_DIR" -name "*.cast" | while read -r castfile; do
+                CAST_BASENAME=$(basename "$castfile")
+                cp "$castfile" "cast_files/$CAST_BASENAME"
+                echo "${CAST_BASENAME%.cast}=${TEST_SHORT_NAME}" >> cast_source_map.txt
+              done
+
+              # Copy .trx files
+              find "$EXTRACT_DIR" -name "*.trx" -exec cp {} trx_files/ \; 2>/dev/null || true
             fi
           done
-
-          # Find and copy all .cast files
-          find recordings -name "*.cast" -exec cp {} cast_files/ \; 2>/dev/null || true
-          # Find and copy all .trx files (test results)
-          find recordings -name "*.trx" -exec cp {} trx_files/ \; 2>/dev/null || true
 
           echo "Found recordings:"
           ls -la cast_files/ || echo "No .cast files found"
@@ -230,6 +267,59 @@ jobs:
             echo "has_outcomes=false" >> "$GITHUB_OUTPUT"
           fi
 
+      - name: Look up job information for CI run
+        if: steps.run-info.outputs.skip != 'true' && hashFiles('cast_files/*.cast') != ''
+        id: job-info
+        continue-on-error: true
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea  # v7.0.1
+        with:
+          script: |
+            const fs = require('fs');
+            const runId = ${{ steps.run-info.outputs.run_id }};
+
+            // List all jobs for the workflow run
+            const jobs = await github.paginate(
+              github.rest.actions.listJobsForWorkflowRun,
+              {
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                run_id: runId,
+                per_page: 100
+              }
+            );
+
+            console.log(`Found ${jobs.length} jobs for run ${runId}`);
+
+            // Build a map from testShortName to job HTML URL.
+            // Job names follow the pattern: "{testShortName} ({os})" or
+            // "Tests / {testShortName} / {testShortName} ({os})"
+            // We match any job whose name contains the testShortName.
+            const castSourceMap = {};
+            if (fs.existsSync('cast_source_map.txt')) {
+              const lines = fs.readFileSync('cast_source_map.txt', 'utf8').trim().split('\n');
+              for (const line of lines) {
+                const [castName, shortName] = line.split('=');
+                if (castName && shortName) {
+                  castSourceMap[castName] = shortName;
+                }
+              }
+            }
+
+            // Get unique testShortNames
+            const shortNames = [...new Set(Object.values(castSourceMap))];
+            const jobMap = {};
+
+            for (const shortName of shortNames) {
+              // Find a job whose name contains the testShortName
+              const job = jobs.find(j => j.name.includes(shortName));
+              if (job) {
+                jobMap[shortName] = { url: job.html_url, id: job.id };
+              }
+            }
+
+            fs.writeFileSync('job_map.json', JSON.stringify(jobMap, null, 2));
+            console.log('Job map:', JSON.stringify(jobMap, null, 2));
+
       - name: Upload recordings and post comment
         if: steps.run-info.outputs.skip != 'true'
         env:
@@ -258,6 +348,19 @@ jobs:
               echo "No test outcomes available, will show recordings without pass/fail status"
               echo '{}' > test_outcomes.json
             fi
+
+            # Load cast-to-testShortName mapping, job URLs, and artifact metadata
+            # so we can link each recording to its CI job and downloadable artifacts.
+            declare -A CAST_SOURCE_MAP
+            if [ -f "cast_source_map.txt" ]; then
+              while IFS='=' read -r cast_name short_name; do
+                CAST_SOURCE_MAP["$cast_name"]="$short_name"
+              done < cast_source_map.txt
+            fi
+
+            # Ensure job_map.json and artifact_meta.json exist (may be absent if steps were skipped)
+            [ -f "job_map.json" ] || echo '{}' > job_map.json
+            [ -f "artifact_meta.json" ] || echo '{}' > artifact_meta.json
 
             # Unique marker to identify CLI E2E recording comments
             COMMENT_MARKER="<!-- cli-e2e-recordings -->"
@@ -324,27 +427,53 @@ jobs:
                   fi
                 done
 
+                # Resolve job URL and artifacts URL for this recording's test run.
+                # The cast_source_map maps .cast filename -> testShortName, which keys
+                # into job_map.json (testShortName -> job HTML URL) and
+                # artifact_meta.json (testShortName -> {recordingArtifactId, logsArtifactId}).
+                TEST_SHORT_NAME="${CAST_SOURCE_MAP[$filename]:-}"
+                JOB_URL=""
+                JOB_ID=""
+                ARTIFACTS_URL=""
+                if [ -n "$TEST_SHORT_NAME" ]; then
+                  JOB_URL=$(jq -r --arg name "$TEST_SHORT_NAME" '.[$name].url // ""' job_map.json)
+                  JOB_ID=$(jq -r --arg name "$TEST_SHORT_NAME" '.[$name].id // ""' job_map.json)
+                  LOGS_ARTIFACT_ID=$(jq -r --arg name "$TEST_SHORT_NAME" '.[$name].logsArtifactId // ""' artifact_meta.json)
+                  if [ -n "$LOGS_ARTIFACT_ID" ] && [ "$LOGS_ARTIFACT_ID" != "null" ]; then
+                    ARTIFACTS_URL="https://github.com/${GITHUB_REPOSITORY}/actions/runs/${RUN_ID}/artifacts/${LOGS_ARTIFACT_ID}"
+                  fi
+                fi
+
+                # Build the job and artifacts link cells for the table
+                JOB_CELL=""
+                if [ -n "$JOB_URL" ]; then
+                  JOB_CELL="[#${JOB_ID}](${JOB_URL})"
+                else
+                  JOB_CELL="—"
+                fi
+                ARTIFACTS_CELL=""
+                if [ -n "$ARTIFACTS_URL" ]; then
+                  ARTIFACTS_CELL="[Logs](${ARTIFACTS_URL})"
+                else
+                  ARTIFACTS_CELL="—"
+                fi
+
+                # Build the table row once; append to both tables as needed.
                 if [ -n "$ASCIINEMA_URL" ]; then
-                  TABLE_BODY="${TABLE_BODY}
-          | ${STATUS_EMOJI} | ${safe_filename} | [${LINK_LABEL}](${ASCIINEMA_URL}) |"
+                  ROW="| ${STATUS_EMOJI} | ${safe_filename} | [${LINK_LABEL}](${ASCIINEMA_URL}) | ${JOB_CELL} | ${ARTIFACTS_CELL} |"
                   echo "Uploaded: $ASCIINEMA_URL"
                   UPLOAD_COUNT=$((UPLOAD_COUNT + 1))
-
-                  # Track failed tests for the prominent section
-                  if [ "$TEST_OUTCOME" = "Failed" ]; then
-                    FAILED_TESTS_BODY="${FAILED_TESTS_BODY}
-          - ❌ **${safe_filename}** — [${LINK_LABEL}](${ASCIINEMA_URL})"
-                  fi
                 else
-                  TABLE_BODY="${TABLE_BODY}
-          | ${STATUS_EMOJI} | ${safe_filename} | ⚠️ Upload failed |"
+                  ROW="| ${STATUS_EMOJI} | ${safe_filename} | ⚠️ Upload failed | ${JOB_CELL} | ${ARTIFACTS_CELL} |"
                   echo "Failed to upload $castfile after $MAX_UPLOAD_RETRIES attempts"
                   FAIL_COUNT=$((FAIL_COUNT + 1))
+                fi
 
-                  if [ "$TEST_OUTCOME" = "Failed" ]; then
-                    FAILED_TESTS_BODY="${FAILED_TESTS_BODY}
-          - ❌ **${safe_filename}** — ⚠️ Recording upload failed"
-                  fi
+                TABLE_BODY="${TABLE_BODY}
+          ${ROW}"
+                if [ "$TEST_OUTCOME" = "Failed" ]; then
+                  FAILED_TESTS_BODY="${FAILED_TESTS_BODY}
+          ${ROW}"
                 fi
               fi
             done
@@ -394,8 +523,10 @@ jobs:
             FAILED_SECTION=""
             if [ -n "$FAILED_TESTS_BODY" ]; then
               FAILED_SECTION="
-          ### Failed Tests
-          ${FAILED_TESTS_BODY}
+          ### ❌ Failed Tests
+
+          | Status | Test | Recording | Job | Artifacts |
+          |--------|------|-----------|-----|-----------|${FAILED_TESTS_BODY}
           "
             fi
 
@@ -405,8 +536,8 @@ jobs:
           <details>
           <summary>View all recordings</summary>
 
-          | Status | Test | Recording |
-          |--------|------|-----------|${TABLE_BODY}
+          | Status | Test | Recording | Job | Artifacts |
+          |--------|------|-----------|-----|-----------|${TABLE_BODY}
 
           ---
           <sub>📹 Recordings uploaded automatically from [CI run #${RUN_ID}](https://github.com/${GITHUB_REPOSITORY}/actions/runs/${RUN_ID})</sub>

--- a/.github/workflows/cli-e2e-recording-comment.yml
+++ b/.github/workflows/cli-e2e-recording-comment.yml
@@ -276,49 +276,67 @@ jobs:
           script: |
             const fs = require('fs');
             const runId = ${{ steps.run-info.outputs.run_id }};
-
-            // List all jobs for the workflow run
-            const jobs = await github.paginate(
-              github.rest.actions.listJobsForWorkflowRun,
-              {
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                run_id: runId,
-                per_page: 100
-              }
-            );
-
-            console.log(`Found ${jobs.length} jobs for run ${runId}`);
-
-            // Build a map from testShortName to job HTML URL.
-            // Job names follow the pattern: "{testShortName} ({os})" or
-            // "Tests / {testShortName} / {testShortName} ({os})"
-            // We match any job whose name contains the testShortName.
-            const castSourceMap = {};
-            if (fs.existsSync('cast_source_map.txt')) {
-              const lines = fs.readFileSync('cast_source_map.txt', 'utf8').trim().split('\n');
-              for (const line of lines) {
-                const [castName, shortName] = line.split('=');
-                if (castName && shortName) {
-                  castSourceMap[castName] = shortName;
-                }
-              }
-            }
-
-            // Get unique testShortNames
-            const shortNames = [...new Set(Object.values(castSourceMap))];
             const jobMap = {};
 
-            for (const shortName of shortNames) {
-              // Find a job whose name contains the testShortName
-              const job = jobs.find(j => j.name.includes(shortName));
-              if (job) {
-                jobMap[shortName] = { url: job.html_url, id: job.id };
-              }
-            }
+            try {
+              // List all jobs for the workflow run
+              const jobs = await github.paginate(
+                github.rest.actions.listJobsForWorkflowRun,
+                {
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  run_id: runId,
+                  per_page: 100
+                }
+              );
 
-            fs.writeFileSync('job_map.json', JSON.stringify(jobMap, null, 2));
-            console.log('Job map:', JSON.stringify(jobMap, null, 2));
+              console.log(`Found ${jobs.length} jobs for run ${runId}`);
+
+              // Diagnostic: log first few job names and count any with null/undefined name
+              const nullNameCount = jobs.filter(j => !j.name).length;
+              if (nullNameCount > 0) {
+                console.log(`WARNING: ${nullNameCount} job(s) have null/undefined name`);
+              }
+              const sampleNames = jobs.slice(0, 5).map(j => j.name ?? '<null>');
+              console.log(`Sample job names: ${JSON.stringify(sampleNames)}`);
+
+              // Build a map from testShortName to job HTML URL.
+              // Job names follow the pattern: "{testShortName} ({os})" or
+              // "Tests / {testShortName} / {testShortName} ({os})"
+              // We match any job whose name contains the testShortName.
+              const castSourceMap = {};
+              if (fs.existsSync('cast_source_map.txt')) {
+                const lines = fs.readFileSync('cast_source_map.txt', 'utf8').trim().split('\n');
+                for (const line of lines) {
+                  const [castName, shortName] = line.split('=');
+                  if (castName && shortName) {
+                    castSourceMap[castName] = shortName;
+                  }
+                }
+              }
+
+              // Get unique testShortNames
+              const shortNames = [...new Set(Object.values(castSourceMap))];
+              console.log(`Looking up jobs for ${shortNames.length} short name(s): ${JSON.stringify(shortNames)}`);
+
+              for (const shortName of shortNames) {
+                // Find a job whose name contains the testShortName (null-safe)
+                const job = jobs.find(j => j.name && j.name.includes(shortName));
+                if (job) {
+                  jobMap[shortName] = { url: job.html_url, id: job.id };
+                } else {
+                  console.log(`No job found for shortName: ${shortName}`);
+                }
+              }
+
+              console.log(`Matched ${Object.keys(jobMap).length}/${shortNames.length} short names to jobs`);
+            } catch (error) {
+              core.error(`Failed to look up job information: ${error.message}`);
+              console.log(error.stack);
+            } finally {
+              fs.writeFileSync('job_map.json', JSON.stringify(jobMap, null, 2));
+              console.log('Job map:', JSON.stringify(jobMap, null, 2));
+            }
 
       - name: Upload recordings and post comment
         if: steps.run-info.outputs.skip != 'true'

--- a/.github/workflows/cli-e2e-recording-comment.yml
+++ b/.github/workflows/cli-e2e-recording-comment.yml
@@ -293,53 +293,36 @@ jobs:
               }
 
               const shortNames = [...new Set(Object.values(castSourceMap))];
-              const unmatchedNames = new Set(shortNames);
               console.log(`Looking up jobs for ${shortNames.length} short name(s): ${JSON.stringify(shortNames)}`);
 
-              // Fetch jobs page by page instead of using github.paginate, which fails
-              // with HTTP 500 on large runs (300+ jobs). Use per_page=50 because the
-              // GitHub API returns 502 "Server Error" with per_page=100 when runs have
-              // many jobs (the response payload exceeds an internal size limit).
-              const perPage = 50;
-              let page = 1;
-              const maxPages = 20;
-              while (unmatchedNames.size > 0 && page <= maxPages) {
-                let jobs;
-                try {
-                  const response = await github.rest.actions.listJobsForWorkflowRun({
-                    owner: context.repo.owner,
-                    repo: context.repo.repo,
-                    run_id: runId,
-                    per_page: perPage,
-                    page: page
-                  });
-                  jobs = response.data.jobs;
-                } catch (pageError) {
-                  console.log(`Page ${page} failed: ${pageError.message} — skipping`);
-                  page++;
-                  continue;
+              // Use per_page=50 because the GitHub API returns 502 "Server Error"
+              // with per_page=100 when runs have many jobs (300+). The response
+              // payload exceeds an internal size limit at larger page sizes.
+              const allJobs = await github.paginate(
+                github.rest.actions.listJobsForWorkflowRun,
+                {
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  run_id: runId,
+                  per_page: 50
                 }
+              );
 
-                console.log(`Page ${page}: ${jobs.length} jobs`);
-                if (jobs.length === 0) break;
+              console.log(`Fetched ${allJobs.length} jobs total`);
 
-                for (const job of jobs) {
-                  if (!job.name) continue;
-                  for (const shortName of unmatchedNames) {
-                    if (job.name.includes(shortName)) {
-                      jobMap[shortName] = { url: job.html_url, id: job.id };
-                      unmatchedNames.delete(shortName);
-                    }
+              for (const job of allJobs) {
+                if (!job.name) continue;
+                for (const shortName of shortNames) {
+                  if (job.name.includes(shortName)) {
+                    jobMap[shortName] = { url: job.html_url, id: job.id };
                   }
                 }
-
-                if (jobs.length < perPage) break;
-                page++;
               }
 
               console.log(`Matched ${Object.keys(jobMap).length}/${shortNames.length} short names to jobs`);
-              if (unmatchedNames.size > 0) {
-                console.log(`Unmatched: ${JSON.stringify([...unmatchedNames])}`);
+              const unmatched = shortNames.filter(n => !jobMap[n]);
+              if (unmatched.length > 0) {
+                console.log(`Unmatched: ${JSON.stringify(unmatched)}`);
               }
             } catch (error) {
               core.error(`Failed to look up job information: ${error.message}`);

--- a/.github/workflows/cli-e2e-recording-comment.yml
+++ b/.github/workflows/cli-e2e-recording-comment.yml
@@ -428,15 +428,15 @@ jobs:
                 TEST_OUTCOME=$(jq -r --arg name "$filename" '.[$name] // "Unknown"' test_outcomes.json)
                 if [ "$TEST_OUTCOME" = "Passed" ]; then
                   STATUS_EMOJI="✅"
-                  LINK_LABEL="✅ ▶️ View recording"
+                  LINK_LABEL="Recording"
                   TEST_PASS_COUNT=$((TEST_PASS_COUNT + 1))
                 elif [ "$TEST_OUTCOME" = "Failed" ]; then
                   STATUS_EMOJI="❌"
-                  LINK_LABEL="❌ ▶️ View failure recording"
+                  LINK_LABEL="Recording"
                   TEST_FAIL_COUNT=$((TEST_FAIL_COUNT + 1))
                 else
                   STATUS_EMOJI="❔"
-                  LINK_LABEL="❔ ▶️ View recording"
+                  LINK_LABEL="Recording"
                   TEST_UNKNOWN_COUNT=$((TEST_UNKNOWN_COUNT + 1))
                 fi
 

--- a/.github/workflows/cli-e2e-recording-comment.yml
+++ b/.github/workflows/cli-e2e-recording-comment.yml
@@ -297,11 +297,12 @@ jobs:
               console.log(`Looking up jobs for ${shortNames.length} short name(s): ${JSON.stringify(shortNames)}`);
 
               // Fetch jobs page by page instead of using github.paginate, which fails
-              // with HTTP 500 on large runs (300+ jobs). Manual pagination lets us:
-              // - Handle per-page errors gracefully (skip that page, keep partial results)
-              // - Stop early once all needed jobs are found
+              // with HTTP 500 on large runs (300+ jobs). Use per_page=50 because the
+              // GitHub API returns 502 "Server Error" with per_page=100 when runs have
+              // many jobs (the response payload exceeds an internal size limit).
+              const perPage = 50;
               let page = 1;
-              const maxPages = 10;
+              const maxPages = 20;
               while (unmatchedNames.size > 0 && page <= maxPages) {
                 let jobs;
                 try {
@@ -309,7 +310,7 @@ jobs:
                     owner: context.repo.owner,
                     repo: context.repo.repo,
                     run_id: runId,
-                    per_page: 100,
+                    per_page: perPage,
                     page: page
                   });
                   jobs = response.data.jobs;
@@ -332,7 +333,7 @@ jobs:
                   }
                 }
 
-                if (jobs.length < 100) break;
+                if (jobs.length < perPage) break;
                 page++;
               }
 

--- a/.github/workflows/cli-e2e-recording-comment.yml
+++ b/.github/workflows/cli-e2e-recording-comment.yml
@@ -280,31 +280,7 @@ jobs:
             const jobMap = {};
 
             try {
-              // List all jobs for the workflow run
-              const jobs = await github.paginate(
-                github.rest.actions.listJobsForWorkflowRun,
-                {
-                  owner: context.repo.owner,
-                  repo: context.repo.repo,
-                  run_id: runId,
-                  per_page: 100
-                }
-              );
-
-              console.log(`Found ${jobs.length} jobs for run ${runId}`);
-
-              // Diagnostic: log first few job names and count any with null/undefined name
-              const nullNameCount = jobs.filter(j => !j.name).length;
-              if (nullNameCount > 0) {
-                console.log(`WARNING: ${nullNameCount} job(s) have null/undefined name`);
-              }
-              const sampleNames = jobs.slice(0, 5).map(j => j.name ?? '<null>');
-              console.log(`Sample job names: ${JSON.stringify(sampleNames)}`);
-
-              // Build a map from testShortName to job HTML URL.
-              // Job names follow the pattern: "{testShortName} ({os})" or
-              // "Tests / {testShortName} / {testShortName} ({os})"
-              // We match any job whose name contains the testShortName.
+              // Read short names first so we can stop pagination early once all are found
               const castSourceMap = {};
               if (fs.existsSync('cast_source_map.txt')) {
                 const lines = fs.readFileSync('cast_source_map.txt', 'utf8').trim().split('\n');
@@ -316,21 +292,54 @@ jobs:
                 }
               }
 
-              // Get unique testShortNames
               const shortNames = [...new Set(Object.values(castSourceMap))];
+              const unmatchedNames = new Set(shortNames);
               console.log(`Looking up jobs for ${shortNames.length} short name(s): ${JSON.stringify(shortNames)}`);
 
-              for (const shortName of shortNames) {
-                // Find a job whose name contains the testShortName (null-safe)
-                const job = jobs.find(j => j.name && j.name.includes(shortName));
-                if (job) {
-                  jobMap[shortName] = { url: job.html_url, id: job.id };
-                } else {
-                  console.log(`No job found for shortName: ${shortName}`);
+              // Fetch jobs page by page instead of using github.paginate, which fails
+              // with HTTP 500 on large runs (300+ jobs). Manual pagination lets us:
+              // - Handle per-page errors gracefully (skip that page, keep partial results)
+              // - Stop early once all needed jobs are found
+              let page = 1;
+              const maxPages = 10;
+              while (unmatchedNames.size > 0 && page <= maxPages) {
+                let jobs;
+                try {
+                  const response = await github.rest.actions.listJobsForWorkflowRun({
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
+                    run_id: runId,
+                    per_page: 100,
+                    page: page
+                  });
+                  jobs = response.data.jobs;
+                } catch (pageError) {
+                  console.log(`Page ${page} failed: ${pageError.message} — skipping`);
+                  page++;
+                  continue;
                 }
+
+                console.log(`Page ${page}: ${jobs.length} jobs`);
+                if (jobs.length === 0) break;
+
+                for (const job of jobs) {
+                  if (!job.name) continue;
+                  for (const shortName of unmatchedNames) {
+                    if (job.name.includes(shortName)) {
+                      jobMap[shortName] = { url: job.html_url, id: job.id };
+                      unmatchedNames.delete(shortName);
+                    }
+                  }
+                }
+
+                if (jobs.length < 100) break;
+                page++;
               }
 
               console.log(`Matched ${Object.keys(jobMap).length}/${shortNames.length} short names to jobs`);
+              if (unmatchedNames.size > 0) {
+                console.log(`Unmatched: ${JSON.stringify([...unmatchedNames])}`);
+              }
             } catch (error) {
               core.error(`Failed to look up job information: ${error.message}`);
               console.log(error.stack);

--- a/.github/workflows/cli-e2e-recording-comment.yml
+++ b/.github/workflows/cli-e2e-recording-comment.yml
@@ -273,6 +273,7 @@ jobs:
         continue-on-error: true
         uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea  # v7.0.1
         with:
+          retries: 3
           script: |
             const fs = require('fs');
             const runId = ${{ steps.run-info.outputs.run_id }};


### PR DESCRIPTION
## Description

Improves the CLI E2E recording PR comment to make it easier to access diagnostics from the recording summary.

### Changes

- **Failed Tests section** is now a table (same format as the full recordings table), filtered to failed tests only
- **New "Job" column** links directly to the GitHub Actions job with a unique `#<job_id>` identifier
- **New "Artifacts" column** links to the downloadable test logs artifact for each test run
- **New "Look up job information" step** queries the GitHub Actions jobs API to resolve per-test job URLs
- **Artifact metadata** saved during download to map each test to its logs artifact
- **cast_source_map.txt** tracks which `.cast` file came from which `testShortName` for correct linking
- Table rows are built once and appended to both the failed tests table and the full table

### Example output

When tests fail:

> ❌ **CLI E2E Tests failed** — 3 passed, 1 failed (commit `abc1234`)
> ### ❌ Failed Tests
> | Status | Test | Recording | Job | Artifacts |
> |--------|------|-----------|-----|-----------|
> | ❌ | SomeTest | [❌ ▶️ View failure recording](url) | [#12345](url) | [Logs](url) |

