### PR TITLE
[release/13.4] Stabilize PrebuiltAppHostServer staging globalPackagesFolder path

### DIFF
--- a/src/Aspire.Cli/Commands/CacheCommand.cs
+++ b/src/Aspire.Cli/Commands/CacheCommand.cs
@@ -40,6 +40,14 @@ internal sealed class CacheCommand : ParentCommand
                 filesDeleted += ClearDirectoryContents(ExecutionContext.CacheDirectory);
                 filesDeleted += ClearDirectoryContents(ExecutionContext.SdksDirectory);
                 filesDeleted += ClearDirectoryContents(ExecutionContext.PackagesDirectory);
+                // Wipe the staging NuGet package cache too. Producers (PrebuiltAppHostServer's
+                // temporary nuget.config for the staging channel) deposit SHA-keyed package
+                // caches under <ASPIRE_HOME>/.nugetpackages/<sha>; clearing them lets users
+                // recover wedged staging restores without filesystem surgery. We hand the parent
+                // directory to ClearDirectoryContents so each SHA subdirectory is wiped while
+                // the parent itself stays in place for the next staging restore.
+                filesDeleted += ClearDirectoryContents(
+                    new DirectoryInfo(CliPathHelper.GetStagingNuGetPackagesDirectory(ExecutionContext.AspireHomeDirectory)));
                 filesDeleted += ClearDirectoryContents(
                     ExecutionContext.LogsDirectory,
                     skipFile: f => f.FullName.Equals(currentLogFilePath, StringComparison.OrdinalIgnoreCase));

--- a/src/Aspire.Cli/Commands/NewCommand.cs
+++ b/src/Aspire.Cli/Commands/NewCommand.cs
@@ -191,9 +191,24 @@ internal sealed class NewCommand : BaseCommand, IPackageMetaPrefetchingCommand
 
         if (packages.Length > 0 &&
             selectedChannel.Type is PackageChannelType.Explicit &&
+            !string.Equals(selectedChannel.Name, PackageChannelNames.Stable, StringComparisons.ChannelName) &&
             !VersionHelper.IsLocalBuildChannel(selectedChannel.Name))
         {
-            // Prerelease channels can filter out the shipped stable package even when the feed can restore it.
+            // Prerelease channels (daily, staging) filter the shipped stable package out of channel
+            // search even when the channel's feed mappings can still restore it (they fall back to
+            // nuget.org). For those channels, pinning to the running CLI's SDK version keeps the
+            // bundled server and the restored Aspire packages in lock-step. Without this, `aspire new
+            // --channel daily` on a shipped 13.4 CLI floats templates to a 13.5 daily preview, which
+            // then breaks the bundled 13.4 AppHost server with `Aspire.TypeSystem, Version=13.5.0.0`
+            // assembly load errors followed by `No language support found for: typescript/nodejs`.
+            //
+            // The stable channel is excluded here on purpose: it does not apply that filter, so a
+            // "no exact match" outcome means the CLI version is genuinely not published on the stable
+            // feed (the CLI is daily-shape, staging-shape, or PR-shape `13.4.0-pr.X.gY`). Forcing
+            // it through would either contradict the user's explicit `--channel stable` request or
+            // write an unpublishable version into `apphost.cs` that NuGet restore cannot satisfy.
+            // Fall through to the OrderByDescending picker so the user gets the highest shipped
+            // stable package they actually asked for.
             return new NuGetPackage
             {
                 Id = TemplateNuGetConfigService.TemplatesPackageName,

--- a/src/Aspire.Cli/Packaging/NuGetConfigMerger.cs
+++ b/src/Aspire.Cli/Packaging/NuGetConfigMerger.cs
@@ -1032,7 +1032,13 @@ internal class NuGetConfigMerger
         AddGlobalPackagesFolderConfiguration(configContext.Configuration);
     }
 
-    internal static void AddGlobalPackagesFolderConfiguration(XElement configuration)
+    // Default workspace-relative cache used when no explicit path is supplied. Matches the
+    // long-standing 'aspire init / aspire new' convention of putting a per-workspace
+    // .nugetpackages folder next to the merged nuget.config so staging-vs-stable cache
+    // poisoning doesn't bleed into the user's global ~/.nuget/packages folder.
+    internal const string DefaultGlobalPackagesFolderValue = ".nugetpackages";
+
+    internal static void AddGlobalPackagesFolderConfiguration(XElement configuration, string? globalPackagesFolderValue = null)
     {
         // Check if config section already exists
         var config = configuration.Element("config");
@@ -1048,10 +1054,13 @@ internal class NuGetConfigMerger
 
         if (existingGlobalPackagesFolder is null)
         {
-            // Add globalPackagesFolder configuration
+            // Add globalPackagesFolder configuration. Callers (e.g. PrebuiltAppHostServer's
+            // temporary nuget.config) supply an absolute path when the config file itself is
+            // ephemeral so the cached packages outlive the config — otherwise NuGet would
+            // resolve the relative ".nugetpackages" under the about-to-be-deleted temp dir.
             var globalPackagesFolderAdd = new XElement("add");
             globalPackagesFolderAdd.SetAttributeValue("key", "globalPackagesFolder");
-            globalPackagesFolderAdd.SetAttributeValue("value", ".nugetpackages");
+            globalPackagesFolderAdd.SetAttributeValue("value", globalPackagesFolderValue ?? DefaultGlobalPackagesFolderValue);
             config.Add(globalPackagesFolderAdd);
         }
     }

--- a/src/Aspire.Cli/Packaging/TemporaryNuGetConfig.cs
+++ b/src/Aspire.Cli/Packaging/TemporaryNuGetConfig.cs
@@ -18,7 +18,7 @@ internal sealed class TemporaryNuGetConfig : IDisposable
 
     public FileInfo ConfigFile => _configFile;
 
-    public static async Task<TemporaryNuGetConfig> CreateAsync(PackageMapping[] mappings, bool configureGlobalPackagesFolder = false)
+    public static async Task<TemporaryNuGetConfig> CreateAsync(PackageMapping[] mappings, bool configureGlobalPackagesFolder = false, string? globalPackagesFolderValue = null)
     {
         var tempDirectory = Directory.CreateTempSubdirectory("aspire-nuget-config").FullName;
         try
@@ -28,7 +28,7 @@ internal sealed class TemporaryNuGetConfig : IDisposable
             await GenerateNuGetConfigAsync(mappings, configFile);
             if (configureGlobalPackagesFolder)
             {
-                await AddGlobalPackagesFolderToConfigAsync(configFile);
+                await AddGlobalPackagesFolderToConfigAsync(configFile, globalPackagesFolderValue);
             }
             return new TemporaryNuGetConfig(configFile);
         }
@@ -125,7 +125,7 @@ internal sealed class TemporaryNuGetConfig : IDisposable
         await xmlWriter.WriteEndDocumentAsync();
     }
 
-    private static async Task AddGlobalPackagesFolderToConfigAsync(FileInfo configFile)
+    private static async Task AddGlobalPackagesFolderToConfigAsync(FileInfo configFile, string? globalPackagesFolderValue)
     {
         XDocument document;
         await using (var stream = configFile.OpenRead())
@@ -139,7 +139,7 @@ internal sealed class TemporaryNuGetConfig : IDisposable
             document.Add(configuration);
         }
 
-        NuGetConfigMerger.AddGlobalPackagesFolderConfiguration(configuration);
+        NuGetConfigMerger.AddGlobalPackagesFolderConfiguration(configuration, globalPackagesFolderValue);
 
         var content = document.Declaration is null
             ? document.ToString()

--- a/src/Aspire.Cli/Projects/PrebuiltAppHostServer.cs
+++ b/src/Aspire.Cli/Projects/PrebuiltAppHostServer.cs
@@ -690,7 +690,7 @@ internal sealed class PrebuiltAppHostServer : IAppHostServerProject, IDisposable
             return await TemporaryNuGetConfig.CreateAsync(
                 PackageSourceOverrideMappings.Create(packageSourceOverride, matchedChannel),
                 configureGlobalPackagesFolder,
-                configureGlobalPackagesFolder ? ResolveStableGlobalPackagesFolder() : null);
+                configureGlobalPackagesFolder ? ResolveStableGlobalPackagesFolder(packageSourceOverride) : null);
         }
 
         if (string.IsNullOrEmpty(requestedChannel))
@@ -749,7 +749,7 @@ internal sealed class PrebuiltAppHostServer : IAppHostServerProject, IDisposable
         return await TemporaryNuGetConfig.CreateAsync(
             channel.Mappings,
             channel.ConfigureGlobalPackagesFolder,
-            channel.ConfigureGlobalPackagesFolder ? ResolveStableGlobalPackagesFolder() : null);
+            channel.ConfigureGlobalPackagesFolder ? ResolveStableGlobalPackagesFolder(GetPrimaryFeedUrl(channel.Mappings)) : null);
     }
 
     /// <summary>
@@ -777,21 +777,38 @@ internal sealed class PrebuiltAppHostServer : IAppHostServerProject, IDisposable
     /// the same staging build can share a single restore — the unit of cache isolation here is
     /// the staging build, not the individual restore command.
     ///
-    /// The cache subdirectory is keyed by the truncated CLI commit hash (first 8 hex chars,
-    /// matching the darc-pub-microsoft-aspire-<c>&lt;hash&gt;</c> feed URL convention) so two
-    /// staging builds of the same release branch — which share the same stable-shaped semver
-    /// (e.g. <c>13.4.0</c>) but ship different SHAs from different darc feeds — each get their
-    /// own cache. NuGet identifies packages by <c>(id, version)</c> only, so without that
-    /// per-build key the second build's restore would silently reuse the first build's now-stale
-    /// <c>13.4.0</c> assemblies. 8 chars is enough to avoid a Windows MAX_PATH blow-up on deep
-    /// integration cache directories while still keeping the SHA collision probability negligible.
+    /// The cache subdirectory is keyed by a truncated hash of the resolved feed URL (first 8
+    /// hex chars of <see cref="System.IO.Hashing.XxHash3"/> over the trimmed/lower-cased URL).
+    /// Two staging builds of the same release branch — which share the same stable-shaped semver
+    /// (e.g. <c>13.4.0</c>) but ship from different darc feeds — therefore each get their own
+    /// cache. A user pointing the same CLI at multiple <c>overrideStagingFeed</c> values during
+    /// dev/test also gets a distinct cache per feed, instead of one bucket silently shared across
+    /// feeds. NuGet identifies packages by <c>(id, version)</c> only, so without that per-feed
+    /// key the second feed's restore would silently reuse the first feed's now-stale
+    /// <c>13.4.0</c> assemblies. When <paramref name="feedUrl"/> is null or empty (defensive —
+    /// both call sites currently always pass a real URL) the key falls back to <c>"default"</c>
+    /// so the path is still well-formed.
     /// </remarks>
-    private string ResolveStableGlobalPackagesFolder()
+    private string ResolveStableGlobalPackagesFolder(string? feedUrl)
     {
-        var cacheKey = VersionHelper.TryGetCurrentCommitHashShort() ?? "default";
+        var cacheKey = CliPathHelper.ComputeStagingFeedCacheKey(feedUrl) ?? "default";
         return Path.Combine(
             CliPathHelper.GetStagingNuGetPackagesDirectory(_executionContext.AspireHomeDirectory),
             cacheKey);
+    }
+
+    /// <summary>
+    /// Returns the URL we use as the cache-key input when materializing a temp nuget.config from
+    /// a <see cref="PackageChannel"/>. Prefers the explicit <c>Aspire*</c> mapping (the staging
+    /// channel's primary feed and the one whose restored assemblies actually need cache
+    /// isolation), falling back to the first mapping for forward compatibility with channel
+    /// shapes we don't yet emit.
+    /// </summary>
+    private static string GetPrimaryFeedUrl(PackageMapping[] mappings)
+    {
+        var aspire = mappings.FirstOrDefault(m =>
+            string.Equals(m.PackageFilter, "Aspire*", StringComparison.OrdinalIgnoreCase));
+        return aspire?.Source ?? mappings[0].Source;
     }
 
     private async Task<string?> ResolveLocalPackageSourceOverrideAsync(string? requestedChannel, CancellationToken cancellationToken)

--- a/src/Aspire.Cli/Projects/PrebuiltAppHostServer.cs
+++ b/src/Aspire.Cli/Projects/PrebuiltAppHostServer.cs
@@ -689,7 +689,8 @@ internal sealed class PrebuiltAppHostServer : IAppHostServerProject, IDisposable
 
             return await TemporaryNuGetConfig.CreateAsync(
                 PackageSourceOverrideMappings.Create(packageSourceOverride, matchedChannel),
-                configureGlobalPackagesFolder);
+                configureGlobalPackagesFolder,
+                configureGlobalPackagesFolder ? ResolveStableGlobalPackagesFolder() : null);
         }
 
         if (string.IsNullOrEmpty(requestedChannel))
@@ -745,7 +746,52 @@ internal sealed class PrebuiltAppHostServer : IAppHostServerProject, IDisposable
         // restore honors the channel's package source mappings. Let IO/XML failures
         // surface instead of silently falling back to the caller's unmapped sources,
         // which could otherwise restore from an unintended feed.
-        return await TemporaryNuGetConfig.CreateAsync(channel.Mappings, channel.ConfigureGlobalPackagesFolder);
+        return await TemporaryNuGetConfig.CreateAsync(
+            channel.Mappings,
+            channel.ConfigureGlobalPackagesFolder,
+            channel.ConfigureGlobalPackagesFolder ? ResolveStableGlobalPackagesFolder() : null);
+    }
+
+    /// <summary>
+    /// Returns the absolute <c>globalPackagesFolder</c> path to write into a temporary NuGet.config
+    /// when the resolved channel asks for per-build cache isolation (today: <c>staging</c>).
+    /// </summary>
+    /// <remarks>
+    /// The default <see cref="NuGetConfigMerger.DefaultGlobalPackagesFolderValue"/> is a relative
+    /// <c>.nugetpackages</c> path that NuGet resolves next to the nuget.config it came from. For
+    /// the <see cref="NuGetConfigMerger"/> workspace-merge flow that's fine — the merged config is
+    /// persistent. For <see cref="PrebuiltAppHostServer"/>'s <see cref="TemporaryNuGetConfig"/>
+    /// the config file lives in a Directory.CreateTempSubdirectory("aspire-nuget-config") folder
+    /// that <see cref="TemporaryNuGetConfig.Dispose"/> recursively deletes after restore. NuGet
+    /// would have just populated <c>&lt;temp&gt;/.nugetpackages/&lt;id&gt;/&lt;version&gt;/</c>
+    /// with the staging assemblies, <see cref="NuGet.BundleNuGetService"/> would have baked those
+    /// paths into <c>integration-package-probe-manifest.json</c>, and aspire-managed would then
+    /// try to load assemblies the dispose just removed — observed as a hang during DI / assembly
+    /// loading on macOS osx-arm64 polyglot staging builds. Anchoring the override at a stable
+    /// per-build location keeps the cached packages alive for as long as any manifest references
+    /// them.
+    ///
+    /// The cache lives under <see cref="CliExecutionContext.AspireHomeDirectory"/> (i.e. the
+    /// <c>ASPIRE_HOME</c> override when set, otherwise <c>~/.aspire</c>) rather than under
+    /// <see cref="_workingDirectory"/> so that two AppHosts running on the same machine against
+    /// the same staging build can share a single restore — the unit of cache isolation here is
+    /// the staging build, not the individual restore command.
+    ///
+    /// The cache subdirectory is keyed by the truncated CLI commit hash (first 8 hex chars,
+    /// matching the darc-pub-microsoft-aspire-<c>&lt;hash&gt;</c> feed URL convention) so two
+    /// staging builds of the same release branch — which share the same stable-shaped semver
+    /// (e.g. <c>13.4.0</c>) but ship different SHAs from different darc feeds — each get their
+    /// own cache. NuGet identifies packages by <c>(id, version)</c> only, so without that
+    /// per-build key the second build's restore would silently reuse the first build's now-stale
+    /// <c>13.4.0</c> assemblies. 8 chars is enough to avoid a Windows MAX_PATH blow-up on deep
+    /// integration cache directories while still keeping the SHA collision probability negligible.
+    /// </remarks>
+    private string ResolveStableGlobalPackagesFolder()
+    {
+        var cacheKey = VersionHelper.TryGetCurrentCommitHashShort() ?? "default";
+        return Path.Combine(
+            CliPathHelper.GetStagingNuGetPackagesDirectory(_executionContext.AspireHomeDirectory),
+            cacheKey);
     }
 
     private async Task<string?> ResolveLocalPackageSourceOverrideAsync(string? requestedChannel, CancellationToken cancellationToken)

--- a/src/Aspire.Cli/Utils/CliPathHelper.cs
+++ b/src/Aspire.Cli/Utils/CliPathHelper.cs
@@ -11,6 +11,16 @@ internal static class CliPathHelper
 {
     internal const string AspireHomeEnvironmentVariable = "ASPIRE_HOME";
 
+    /// <summary>
+    /// Name of the directory under <c>ASPIRE_HOME</c> that holds NuGet package caches keyed by
+    /// the staging CLI's commit SHA. Two staging builds of the same release branch share the
+    /// same stable-shaped semver (e.g. <c>13.4.0</c>) but ship different SHAs from different
+    /// darc feeds, so each gets its own SHA-keyed subdirectory here to avoid (id,version) cache
+    /// collisions in NuGet. <c>aspire cache clear</c> wipes the SHA subdirectories so users can
+    /// recover wedged staging restores without manual filesystem surgery.
+    /// </summary>
+    internal const string StagingNuGetPackagesFolderName = ".nugetpackages";
+
     // The maximum age before a leftover CLI socket file in the runtime sockets directory is
     // pruned. 24 hours is comfortably longer than any legitimate Aspire CLI run and short enough
     // that stale entries don't pile up indefinitely after crashes (see issue #16709).
@@ -36,6 +46,19 @@ internal static class CliPathHelper
         return string.IsNullOrWhiteSpace(configuredAspireHome)
             ? Path.Combine(userProfileDirectory, ".aspire")
             : configuredAspireHome;
+    }
+
+    /// <summary>
+    /// Returns the absolute path to the staging NuGet package cache root
+    /// (<c>&lt;ASPIRE_HOME&gt;/.nugetpackages</c>). Producers (the
+    /// <c>PrebuiltAppHostServer</c> temp nuget.config) write SHA-keyed subdirectories under
+    /// this root; the <c>aspire cache clear</c> command wipes those subdirectories.
+    /// Centralized here so both call sites agree on the location.
+    /// </summary>
+    internal static string GetStagingNuGetPackagesDirectory(DirectoryInfo aspireHomeDirectory)
+    {
+        ArgumentNullException.ThrowIfNull(aspireHomeDirectory);
+        return Path.Combine(aspireHomeDirectory.FullName, StagingNuGetPackagesFolderName);
     }
 
     internal static string? TryGetAspireHomeDirectoryFromInstallRoute(string? processPath, ILogger? logger = null)

--- a/src/Aspire.Cli/Utils/CliPathHelper.cs
+++ b/src/Aspire.Cli/Utils/CliPathHelper.cs
@@ -1,6 +1,8 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.IO.Hashing;
+using System.Text;
 using Aspire.Cli.Acquisition;
 using Aspire.Hosting.Backchannel;
 using Microsoft.Extensions.Logging;
@@ -13,13 +15,23 @@ internal static class CliPathHelper
 
     /// <summary>
     /// Name of the directory under <c>ASPIRE_HOME</c> that holds NuGet package caches keyed by
-    /// the staging CLI's commit SHA. Two staging builds of the same release branch share the
-    /// same stable-shaped semver (e.g. <c>13.4.0</c>) but ship different SHAs from different
-    /// darc feeds, so each gets its own SHA-keyed subdirectory here to avoid (id,version) cache
-    /// collisions in NuGet. <c>aspire cache clear</c> wipes the SHA subdirectories so users can
-    /// recover wedged staging restores without manual filesystem surgery.
+    /// a stable hash of the resolved staging feed URL. Two staging builds of the same release
+    /// branch share the same stable-shaped semver (e.g. <c>13.4.0</c>) but ship from different
+    /// darc feeds; an <c>overrideStagingFeed</c> setting can also point the same CLI at any
+    /// arbitrary feed. Each distinct feed URL therefore gets its own feed-hash subdirectory
+    /// here to avoid <c>(id, version)</c> cache collisions in NuGet. <c>aspire cache clear</c>
+    /// wipes the feed-hash subdirectories so users can recover wedged staging restores without
+    /// manual filesystem surgery.
     /// </summary>
     internal const string StagingNuGetPackagesFolderName = ".nugetpackages";
+
+    /// <summary>
+    /// Default number of hex characters used for staging feed cache keys. 8 keeps deep
+    /// integration cache paths well under Windows <c>MAX_PATH</c> while still giving roughly
+    /// 4 billion buckets — orders of magnitude more than the handful of staging feeds any one
+    /// user ever sees, so collisions are negligible in practice.
+    /// </summary>
+    internal const int DefaultStagingFeedCacheKeyLength = 8;
 
     // The maximum age before a leftover CLI socket file in the runtime sockets directory is
     // pruned. 24 hours is comfortably longer than any legitimate Aspire CLI run and short enough
@@ -51,14 +63,48 @@ internal static class CliPathHelper
     /// <summary>
     /// Returns the absolute path to the staging NuGet package cache root
     /// (<c>&lt;ASPIRE_HOME&gt;/.nugetpackages</c>). Producers (the
-    /// <c>PrebuiltAppHostServer</c> temp nuget.config) write SHA-keyed subdirectories under
-    /// this root; the <c>aspire cache clear</c> command wipes those subdirectories.
-    /// Centralized here so both call sites agree on the location.
+    /// <c>PrebuiltAppHostServer</c> temp nuget.config) write feed-hash-keyed
+    /// subdirectories under this root; the <c>aspire cache clear</c> command wipes those
+    /// subdirectories. Centralized here so both call sites agree on the location.
     /// </summary>
     internal static string GetStagingNuGetPackagesDirectory(DirectoryInfo aspireHomeDirectory)
     {
         ArgumentNullException.ThrowIfNull(aspireHomeDirectory);
         return Path.Combine(aspireHomeDirectory.FullName, StagingNuGetPackagesFolderName);
+    }
+
+    /// <summary>
+    /// Returns a stable lowercase hex cache key derived from <paramref name="feedUrl"/>,
+    /// truncated to <paramref name="length"/> characters. Returns <see langword="null"/> when
+    /// the URL is null, empty, or whitespace-only.
+    /// </summary>
+    /// <remarks>
+    /// Used by <c>PrebuiltAppHostServer</c> to compute the per-feed
+    /// <c>globalPackagesFolder</c> subdirectory under
+    /// <c>&lt;ASPIRE_HOME&gt;/.nugetpackages</c>. Keying on the feed URL (rather than the CLI
+    /// commit SHA) means that the same CLI talking to two different override staging feeds
+    /// gets two distinct caches, which is important because staging packages from different
+    /// feeds share the same stable-shaped <c>(id, version)</c> tuple and would otherwise
+    /// collide in NuGet's cache.
+    ///
+    /// The URL is trimmed and lower-cased before hashing so harmless variations (trailing
+    /// whitespace from a config file, hostname casing) don't fragment the cache. Hashing the
+    /// URL with <see cref="XxHash3"/> (non-cryptographic but very high quality) keeps any
+    /// embedded credentials out of the on-disk directory name even when the feed URL itself
+    /// contains them.
+    /// </remarks>
+    internal static string? ComputeStagingFeedCacheKey(string? feedUrl, int length = DefaultStagingFeedCacheKeyLength)
+    {
+        if (string.IsNullOrWhiteSpace(feedUrl) || length <= 0)
+        {
+            return null;
+        }
+
+        var normalized = feedUrl.Trim().ToLowerInvariant();
+        var bytes = Encoding.UTF8.GetBytes(normalized);
+        // XxHash3 emits 8 bytes (64 bits) -> 16 hex chars; truncate to the requested length.
+        var hex = Convert.ToHexString(XxHash3.Hash(bytes)).ToLowerInvariant();
+        return length >= hex.Length ? hex : hex[..length];
     }
 
     internal static string? TryGetAspireHomeDirectoryFromInstallRoute(string? processPath, ILogger? logger = null)

--- a/src/Aspire.Cli/Utils/VersionHelper.cs
+++ b/src/Aspire.Cli/Utils/VersionHelper.cs
@@ -62,45 +62,6 @@ internal static class VersionHelper
     }
 
     /// <summary>
-    /// Returns the first <paramref name="length"/> characters of the commit hash from the current
-    /// assembly's <see cref="System.Reflection.AssemblyInformationalVersionAttribute"/> (e.g.
-    /// <c>"13.4.0+48a11dae9c0..." -&gt; "48a11dae"</c>). Returns <see langword="null"/> when the
-    /// running assembly has no <c>+sha</c> suffix (test hosts, locally-built bits, dev builds).
-    /// </summary>
-    /// <remarks>
-    /// Two staging builds of the same release branch ship with an identical stable-shaped semver
-    /// (e.g. <c>13.4.0</c>) but different commit SHAs. Callers that need a deterministic-but-build-
-    /// specific cache key (for example, the <c>globalPackagesFolder</c> override used by the
-    /// PrebuiltAppHostServer staging restore) use the truncated SHA so each staging build gets
-    /// its own cache directory. The default length matches the darc feed URL convention used by
-    /// <c>PackagingService</c> so the cache key and the feed key line up at 8 hex chars.
-    /// </remarks>
-    public static string? TryGetCurrentCommitHashShort(int length = 8)
-    {
-        if (length <= 0)
-        {
-            return null;
-        }
-
-        var version = PackageUpdateHelpers.GetCurrentAssemblyVersion();
-        if (string.IsNullOrEmpty(version))
-        {
-            return null;
-        }
-
-        // Informational version shape: "<semver>+<commitHash>" (e.g. "13.4.0+48a11dae9c0a...").
-        // No '+' means a clean release build with no build metadata — no SHA to surface.
-        var plusIndex = version.IndexOf('+');
-        if (plusIndex < 0 || plusIndex + 1 >= version.Length)
-        {
-            return null;
-        }
-
-        var commitHash = version[(plusIndex + 1)..];
-        return commitHash.Length >= length ? commitHash[..length] : commitHash;
-    }
-
-    /// <summary>
     /// Gets the default Aspire SDK version based on the CLI version.
     /// The CLI version is the SDK version — the bundled server and packages must match.
     /// </summary>

--- a/src/Aspire.Cli/Utils/VersionHelper.cs
+++ b/src/Aspire.Cli/Utils/VersionHelper.cs
@@ -62,6 +62,45 @@ internal static class VersionHelper
     }
 
     /// <summary>
+    /// Returns the first <paramref name="length"/> characters of the commit hash from the current
+    /// assembly's <see cref="System.Reflection.AssemblyInformationalVersionAttribute"/> (e.g.
+    /// <c>"13.4.0+48a11dae9c0..." -&gt; "48a11dae"</c>). Returns <see langword="null"/> when the
+    /// running assembly has no <c>+sha</c> suffix (test hosts, locally-built bits, dev builds).
+    /// </summary>
+    /// <remarks>
+    /// Two staging builds of the same release branch ship with an identical stable-shaped semver
+    /// (e.g. <c>13.4.0</c>) but different commit SHAs. Callers that need a deterministic-but-build-
+    /// specific cache key (for example, the <c>globalPackagesFolder</c> override used by the
+    /// PrebuiltAppHostServer staging restore) use the truncated SHA so each staging build gets
+    /// its own cache directory. The default length matches the darc feed URL convention used by
+    /// <c>PackagingService</c> so the cache key and the feed key line up at 8 hex chars.
+    /// </remarks>
+    public static string? TryGetCurrentCommitHashShort(int length = 8)
+    {
+        if (length <= 0)
+        {
+            return null;
+        }
+
+        var version = PackageUpdateHelpers.GetCurrentAssemblyVersion();
+        if (string.IsNullOrEmpty(version))
+        {
+            return null;
+        }
+
+        // Informational version shape: "<semver>+<commitHash>" (e.g. "13.4.0+48a11dae9c0a...").
+        // No '+' means a clean release build with no build metadata — no SHA to surface.
+        var plusIndex = version.IndexOf('+');
+        if (plusIndex < 0 || plusIndex + 1 >= version.Length)
+        {
+            return null;
+        }
+
+        var commitHash = version[(plusIndex + 1)..];
+        return commitHash.Length >= length ? commitHash[..length] : commitHash;
+    }
+
+    /// <summary>
     /// Gets the default Aspire SDK version based on the CLI version.
     /// The CLI version is the SDK version — the bundled server and packages must match.
     /// </summary>

--- a/tests/Aspire.Cli.Tests/Commands/CacheCommandTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/CacheCommandTests.cs
@@ -3,6 +3,7 @@
 
 using Aspire.Cli.Commands;
 using Aspire.Cli.Tests.Utils;
+using Aspire.Cli.Utils;
 using Microsoft.AspNetCore.InternalTesting;
 using Microsoft.Extensions.DependencyInjection;
 
@@ -82,6 +83,61 @@ public class CacheCommandTests(ITestOutputHelper outputHelper)
         Assert.Equal(CliExitCodes.Success, exitCode);
         Assert.False(File.Exists(cacheEntry));
         Assert.False(appHostInfoCacheDir.Exists);
+    }
+
+    [Fact]
+    public async Task CacheClear_ClearsStagingNuGetPackagesCache()
+    {
+        // Pins that `aspire cache clear` wipes the SHA-keyed staging NuGet package caches under
+        // <ASPIRE_HOME>/.nugetpackages — produced by PrebuiltAppHostServer's temporary
+        // nuget.config for the staging channel. Without this, a wedged staging restore can only
+        // be recovered by manual filesystem surgery.
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+
+        var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper);
+        using var provider = services.BuildServiceProvider();
+        var executionContext = provider.GetRequiredService<CliExecutionContext>();
+
+        var stagingCacheRoot = new DirectoryInfo(
+            CliPathHelper.GetStagingNuGetPackagesDirectory(executionContext.AspireHomeDirectory));
+        var firstBuildCache = stagingCacheRoot.CreateSubdirectory("deadbeef").CreateSubdirectory("aspire.hosting").CreateSubdirectory("13.4.0");
+        var secondBuildCache = stagingCacheRoot.CreateSubdirectory("cafef00d").CreateSubdirectory("aspire.hosting").CreateSubdirectory("13.4.0");
+        await File.WriteAllTextAsync(Path.Combine(firstBuildCache.FullName, "Aspire.Hosting.dll"), "fake").DefaultTimeout();
+        await File.WriteAllTextAsync(Path.Combine(secondBuildCache.FullName, "Aspire.Hosting.dll"), "fake").DefaultTimeout();
+
+        var command = provider.GetRequiredService<RootCommand>();
+        var result = command.Parse("cache clear");
+
+        var exitCode = await result.InvokeAsync().DefaultTimeout();
+
+        Assert.Equal(CliExitCodes.Success, exitCode);
+        // SHA-keyed subdirectories should be gone; the parent stays so the next staging restore
+        // can populate a fresh cache without recreating the .nugetpackages root.
+        Assert.False(Directory.Exists(Path.Combine(stagingCacheRoot.FullName, "deadbeef")));
+        Assert.False(Directory.Exists(Path.Combine(stagingCacheRoot.FullName, "cafef00d")));
+    }
+
+    [Fact]
+    public async Task CacheClear_HandlesMissingStagingNuGetPackagesCache()
+    {
+        // Common case for fresh installs and non-staging users: the staging cache root simply
+        // doesn't exist yet. The command must still succeed.
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+
+        var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper);
+        using var provider = services.BuildServiceProvider();
+        var executionContext = provider.GetRequiredService<CliExecutionContext>();
+
+        var stagingCacheRoot = new DirectoryInfo(
+            CliPathHelper.GetStagingNuGetPackagesDirectory(executionContext.AspireHomeDirectory));
+        Assert.False(stagingCacheRoot.Exists);
+
+        var command = provider.GetRequiredService<RootCommand>();
+        var result = command.Parse("cache clear");
+
+        var exitCode = await result.InvokeAsync().DefaultTimeout();
+
+        Assert.Equal(CliExitCodes.Success, exitCode);
     }
 
     [Fact]

--- a/tests/Aspire.Cli.Tests/Commands/NewCommandChannelResolutionTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/NewCommandChannelResolutionTests.cs
@@ -117,20 +117,22 @@ public class NewCommandChannelResolutionTests(ITestOutputHelper outputHelper)
     /// Channel-resolution contract: when the running CLI's identity is a non-local channel
     /// (daily / staging / stable) and no <c>--channel</c> is passed, <c>aspire new</c> must
     /// resolve the channel whose name matches the identity — not the Implicit (nuget.org)
-    /// channel — while still pinning the template version to the current CLI/SDK version.
-    /// The bundled server and restored Aspire packages must stay on the same version.
+    /// channel. Prerelease identities (daily/staging) further pin the template version to the
+    /// current CLI/SDK so the bundled server and restored Aspire packages stay on the same
+    /// version; the stable identity falls through to the highest shipped stable package because
+    /// the stable feed doesn't filter the running CLI's version out of search.
     /// </summary>
     [Theory]
-    [InlineData(PackageChannelNames.Daily, "13.4.0-preview.1.99999.1")]
-    [InlineData(PackageChannelNames.Stable, "13.5.0")]
-    public async Task NewCommand_NoChannelArg_ResolvesTemplateFromIdentityChannel(string identityChannel, string identityChannelVersion)
+    [InlineData(PackageChannelNames.Daily, "13.4.0-preview.1.99999.1", null)]
+    [InlineData(PackageChannelNames.Stable, "13.5.0", "13.5.0")]
+    public async Task NewCommand_NoChannelArg_ResolvesTemplateFromIdentityChannel(string identityChannel, string identityChannelVersion, string? expectedVersion)
     {
         var captured = await CaptureTemplateInputsAsync(
             identityChannel: identityChannel,
             channelOptionArg: null,
             identityChannelVersion: identityChannelVersion);
 
-        Assert.Equal(VersionHelper.GetDefaultSdkVersion(), captured.Version);
+        Assert.Equal(expectedVersion ?? VersionHelper.GetDefaultSdkVersion(), captured.Version);
         Assert.Equal(identityChannel, captured.Channel);
     }
 
@@ -205,10 +207,13 @@ public class NewCommandChannelResolutionTests(ITestOutputHelper outputHelper)
     }
 
     /// <summary>
-    /// Explicit <c>--channel</c> must always override the running CLI's identity channel —
-    /// so a developer on a daily CLI can still scaffold a stable-channel project for
-    /// reproduction or migration testing. The template version still stays pinned to the
-    /// current CLI so restored Aspire packages match the bundled server.
+    /// Explicit <c>--channel stable</c> must always override the running CLI's identity channel —
+    /// so a developer on a daily CLI can still scaffold a stable-channel project for reproduction
+    /// or migration testing. When the CLI's own version is not published on the stable feed
+    /// (a daily-shape or PR-shape build), the resolver falls through to the highest shipped stable
+    /// package rather than forcing the unpublishable CLI version into the generated apphost.
+    /// Pinning to the current CLI version is reserved for prerelease channels — see
+    /// <see cref="NewCommand_ExplicitPrereleaseChannel_PrefersCurrentCliVersionWhenAvailable"/>.
     /// </summary>
     [Fact]
     public async Task NewCommand_ExplicitChannelArg_OverridesIdentityChannel()
@@ -218,7 +223,8 @@ public class NewCommandChannelResolutionTests(ITestOutputHelper outputHelper)
             channelOptionArg: PackageChannelNames.Stable,
             identityChannelVersion: "13.4.0-preview.1.99999.1");
 
-        Assert.Equal(VersionHelper.GetDefaultSdkVersion(), captured.Version);
+        // Highest shipped stable from the stable channel feed in the test fixture.
+        Assert.Equal("13.5.0", captured.Version);
         Assert.Equal(PackageChannelNames.Stable, captured.Channel);
     }
 
@@ -241,6 +247,28 @@ public class NewCommandChannelResolutionTests(ITestOutputHelper outputHelper)
 
         Assert.Equal(cliVersion, captured.Version);
         Assert.Equal(channelName, captured.Channel);
+    }
+
+    /// <summary>
+    /// SmokeTest regression guard: when a non-stable-shape CLI (PR build, daily-shape preview, etc.)
+    /// is invoked with <c>--channel stable</c>, the resolver must NOT pin the template to the
+    /// running CLI's version. The CLI's own version is not published on the stable feed, so a
+    /// generated <c>apphost.cs</c> referencing it would fail NuGet restore. The fallback that pins
+    /// to the current CLI version is reserved for prerelease channels (daily, staging) where the
+    /// feed search filter is what hides the otherwise-restorable shipped stable package.
+    /// </summary>
+    [Theory]
+    [InlineData("13.4.0-preview.1.99999.1")] // daily-shape CLI
+    [InlineData("13.4.0-pr.17573.gabc1234")] // PR-shape CLI (e2e SmokeTests scenario)
+    public async Task NewCommand_ExplicitStableChannel_NonStableCliVersion_FallsBackToHighestShippedStable(string identityChannelVersion)
+    {
+        var captured = await CaptureTemplateInputsAsync(
+            identityChannel: PackageChannelNames.Daily,
+            channelOptionArg: PackageChannelNames.Stable,
+            identityChannelVersion: identityChannelVersion);
+
+        Assert.Equal("13.5.0", captured.Version);
+        Assert.Equal(PackageChannelNames.Stable, captured.Channel);
     }
 
     /// <summary>

--- a/tests/Aspire.Cli.Tests/Commands/NewCommandTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/NewCommandTests.cs
@@ -1609,7 +1609,7 @@ public class NewCommandTests(ITestOutputHelper outputHelper)
 
         var exitCode = await result.InvokeAsync().DefaultTimeout();
         Assert.Equal(CliExitCodes.Success, exitCode);
-        Assert.Equal(VersionHelper.GetDefaultSdkVersion(), scaffoldSdkVersion);
+        Assert.Equal("9.2.0", scaffoldSdkVersion);
         Assert.Equal("stable", scaffoldChannel);
     }
 

--- a/tests/Aspire.Cli.Tests/Packaging/TemporaryNuGetConfigTests.cs
+++ b/tests/Aspire.Cli.Tests/Packaging/TemporaryNuGetConfigTests.cs
@@ -125,6 +125,45 @@ public class TemporaryNuGetConfigTests
         Assert.Equal(".nugetpackages", globalPackagesFolder!.Attributes!["value"]!.Value);
     }
 
+    [Fact]
+    public async Task CreateAsync_WithExplicitGlobalPackagesFolderOverride_UsesOverrideValue()
+    {
+        // Callers that need the cache to outlive the temp config (e.g. PrebuiltAppHostServer's
+        // staging path) supply an absolute, persistent path so BundleNuGetService manifest paths
+        // remain valid after TemporaryNuGetConfig.Dispose deletes the temp directory.
+        var overrideValue = Path.Combine(Path.GetTempPath(), "aspire-tests", "stable-cache", "deadbeef");
+
+        using var tempConfig = await TemporaryNuGetConfig.CreateAsync(
+            [new PackageMapping("Aspire.*", "https://example.com/feed")],
+            configureGlobalPackagesFolder: true,
+            globalPackagesFolderValue: overrideValue);
+
+        var configContent = await File.ReadAllTextAsync(tempConfig.ConfigFile.FullName);
+        var xmlDoc = new XmlDocument();
+        xmlDoc.LoadXml(configContent);
+
+        var globalPackagesFolder = xmlDoc.SelectSingleNode("//config/add[@key='globalPackagesFolder']");
+        Assert.NotNull(globalPackagesFolder);
+        Assert.Equal(overrideValue, globalPackagesFolder!.Attributes!["value"]!.Value);
+    }
+
+    [Fact]
+    public async Task CreateAsync_WithoutConfiguredGlobalPackagesFolder_IgnoresOverride()
+    {
+        // When configureGlobalPackagesFolder is false the override is irrelevant — no
+        // <config><add key="globalPackagesFolder"/> element should be emitted at all.
+        using var tempConfig = await TemporaryNuGetConfig.CreateAsync(
+            [new PackageMapping("Aspire.*", "https://example.com/feed")],
+            configureGlobalPackagesFolder: false,
+            globalPackagesFolderValue: "/should/not/appear");
+
+        var configContent = await File.ReadAllTextAsync(tempConfig.ConfigFile.FullName);
+        var xmlDoc = new XmlDocument();
+        xmlDoc.LoadXml(configContent);
+
+        Assert.Null(xmlDoc.SelectSingleNode("//config/add[@key='globalPackagesFolder']"));
+    }
+
     [Theory]
     [InlineData("https://example.com/feed")]
     [InlineData("/var/folders/X/hives/pr-17105/packages")]

--- a/tests/Aspire.Cli.Tests/Projects/PrebuiltAppHostServerTests.cs
+++ b/tests/Aspire.Cli.Tests/Projects/PrebuiltAppHostServerTests.cs
@@ -11,6 +11,7 @@ using Aspire.Cli.Projects;
 using Aspire.Cli.Tests.Mcp;
 using Aspire.Cli.Tests.TestServices;
 using Aspire.Cli.Tests.Utils;
+using Aspire.Cli.Utils;
 using Aspire.Hosting;
 using Aspire.Shared;
 using Microsoft.Extensions.Configuration;
@@ -427,9 +428,10 @@ public class PrebuiltAppHostServerTests(ITestOutputHelper outputHelper)
         using var workspace = TemporaryWorkspace.Create(outputHelper);
 
         var executionContext = CreateContextWithIdentityChannel("local");
+        const string channelSource = "https://pkgs.dev.azure.com/fake/v3/index.json";
         var mappings = new[]
         {
-            new PackageMapping(PackageMapping.AllPackages, "https://pkgs.dev.azure.com/fake/v3/index.json")
+            new PackageMapping(PackageMapping.AllPackages, channelSource)
         };
         var stagingChannel = PackageChannel.CreateExplicitChannel(
             name: "staging",
@@ -457,6 +459,14 @@ public class PrebuiltAppHostServerTests(ITestOutputHelper outputHelper)
         Assert.False(
             gpfValue!.StartsWith(tempConfigDir, StringComparison.Ordinal),
             $"globalPackagesFolder must not be under the temp nuget.config dir '{tempConfigDir}'. Got: {gpfValue}");
+        // The cache subdirectory must be keyed by the resolved feed URL so two different staging
+        // feeds (e.g. two darc builds or an overrideStagingFeed setting) get distinct caches.
+        var expectedCacheKey = CliPathHelper.ComputeStagingFeedCacheKey(channelSource);
+        Assert.NotNull(expectedCacheKey);
+        var expectedCachePath = Path.Combine(
+            CliPathHelper.GetStagingNuGetPackagesDirectory(executionContext.AspireHomeDirectory),
+            expectedCacheKey);
+        Assert.Equal(expectedCachePath, gpfValue);
     }
 
     [Fact]
@@ -507,6 +517,14 @@ public class PrebuiltAppHostServerTests(ITestOutputHelper outputHelper)
         Assert.False(
             gpfValue!.StartsWith(tempConfigDir, StringComparison.Ordinal),
             $"globalPackagesFolder must not be under the temp nuget.config dir '{tempConfigDir}'. Got: {gpfValue}");
+        // The cache key is derived from the resolved staging feed URL so the same CLI talking to
+        // a different overrideStagingFeed gets a different cache bucket.
+        var expectedCacheKey = CliPathHelper.ComputeStagingFeedCacheKey(overrideStagingFeed);
+        Assert.NotNull(expectedCacheKey);
+        var expectedCachePath = Path.Combine(
+            CliPathHelper.GetStagingNuGetPackagesDirectory(executionContext.AspireHomeDirectory),
+            expectedCacheKey);
+        Assert.Equal(expectedCachePath, gpfValue);
     }
 
     [Theory]
@@ -595,7 +613,8 @@ public class PrebuiltAppHostServerTests(ITestOutputHelper outputHelper)
             nuGetPackageCache: new FakeNuGetPackageCache(),
             features: new TestFeatures(),
             configureGlobalPackagesFolder: true);
-        var server = CreateServerWithChannel(workspace, stagingChannel, CreateContextWithIdentityChannel("pr-12345"));
+        var executionContext = CreateContextWithIdentityChannel("pr-12345");
+        var server = CreateServerWithChannel(workspace, stagingChannel, executionContext);
 
         using var result = await InvokeTryCreateTemporaryNuGetConfigAsync(
             server,
@@ -620,6 +639,14 @@ public class PrebuiltAppHostServerTests(ITestOutputHelper outputHelper)
         Assert.False(
             gpfValue!.StartsWith(tempConfigDir, StringComparison.Ordinal),
             $"globalPackagesFolder must not be under the temp nuget.config dir '{tempConfigDir}'. Got: {gpfValue}");
+        // The cache key is derived from the --source override, not the channel's own mappings,
+        // so users running multiple overrides against the same CLI get distinct cache buckets.
+        var expectedCacheKey = CliPathHelper.ComputeStagingFeedCacheKey(packageSourceOverride);
+        Assert.NotNull(expectedCacheKey);
+        var expectedCachePath = Path.Combine(
+            CliPathHelper.GetStagingNuGetPackagesDirectory(executionContext.AspireHomeDirectory),
+            expectedCacheKey);
+        Assert.Equal(expectedCachePath, gpfValue);
     }
 
     [Fact]

--- a/tests/Aspire.Cli.Tests/Projects/PrebuiltAppHostServerTests.cs
+++ b/tests/Aspire.Cli.Tests/Projects/PrebuiltAppHostServerTests.cs
@@ -13,6 +13,7 @@ using Aspire.Cli.Tests.TestServices;
 using Aspire.Cli.Tests.Utils;
 using Aspire.Hosting;
 using Aspire.Shared;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging.Abstractions;
 
 namespace Aspire.Cli.Tests.Projects;
@@ -418,7 +419,11 @@ public class PrebuiltAppHostServerTests(ITestOutputHelper outputHelper)
     {
         // Pins the rubber-duck finding: dropping the temp config also drops the staging-specific
         // global packages folder. The emitted nuget.config must contain a <config> element with a
-        // globalPackagesFolder setting when the channel was built with configureGlobalPackagesFolder.
+        // globalPackagesFolder setting when the channel was built with configureGlobalPackagesFolder,
+        // AND the value must be an absolute path that lives outside the temp config's own directory
+        // so the cached packages survive the temp config's recursive cleanup (otherwise restore
+        // hands BundleNuGetService manifest paths that the temp dispose just deleted, hanging
+        // aspire-managed during DI / assembly loading on macOS osx-arm64 polyglot staging builds).
         using var workspace = TemporaryWorkspace.Create(outputHelper);
 
         var executionContext = CreateContextWithIdentityChannel("local");
@@ -443,7 +448,65 @@ public class PrebuiltAppHostServerTests(ITestOutputHelper outputHelper)
             .SelectMany(c => c.Elements("add"))
             .FirstOrDefault(a => string.Equals(a.Attribute("key")?.Value, "globalPackagesFolder", StringComparison.OrdinalIgnoreCase));
         Assert.NotNull(gpf);
-        Assert.False(string.IsNullOrEmpty(gpf.Attribute("value")?.Value));
+        var gpfValue = gpf.Attribute("value")?.Value;
+        Assert.False(string.IsNullOrEmpty(gpfValue));
+        Assert.True(Path.IsPathFullyQualified(gpfValue), $"globalPackagesFolder value must be an absolute path. Got: {gpfValue}");
+        // The temp config directory is recursively deleted on dispose; the cache must live elsewhere
+        // so manifest paths produced by BundleNuGetService remain valid for the AppHost's lifetime.
+        var tempConfigDir = result.ConfigFile.Directory!.FullName;
+        Assert.False(
+            gpfValue!.StartsWith(tempConfigDir, StringComparison.Ordinal),
+            $"globalPackagesFolder must not be under the temp nuget.config dir '{tempConfigDir}'. Got: {gpfValue}");
+    }
+
+    [Fact]
+    public async Task TryCreateTemporaryNuGetConfig_StagingRequested_FromRealPackagingService_EmitsStableGlobalPackagesFolderOutsideTempDir()
+    {
+        // End-to-end pin for the staging temp-config hang fix: when the real PackagingService
+        // synthesizes the staging channel (here driven by overrideStagingFeed on a stable-shaped
+        // CLI so configureGlobalPackagesFolder lands true), the temporary nuget.config used by
+        // PrebuiltAppHostServer must point globalPackagesFolder at an absolute path that survives
+        // the TemporaryNuGetConfig.Dispose recursive delete. Otherwise BundleNuGetService restores
+        // staging assemblies into <temp>/.nugetpackages, bakes those paths into
+        // integration-package-probe-manifest.json, and aspire-managed hangs in DI/assembly loading
+        // when it later probes the (now deleted) paths — observed on macOS osx-arm64.
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+
+        const string overrideStagingFeed = "https://pkgs.dev.azure.com/dnceng/internal/_packaging/darc-pub-microsoft-aspire-deadbeef/nuget/v3/index.json";
+        var executionContext = TestExecutionContextHelper.CreateExecutionContext(
+            workspace,
+            identityChannel: PackageChannelNames.Staging);
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                [PackagingService.OverrideStagingFeedConfigKey] = overrideStagingFeed
+            })
+            .Build();
+        var packagingService = new PackagingService(
+            executionContext,
+            new FakeNuGetPackageCache(),
+            new TestFeatures(),
+            configuration,
+            NullLogger<PackagingService>.Instance,
+            isStableShapedCliVersion: () => true);
+
+        var server = CreateServerWithPackagingService(workspace, packagingService, executionContext);
+
+        using var result = await InvokeTryCreateTemporaryNuGetConfigAsync(server, PackageChannelNames.Staging);
+
+        Assert.NotNull(result);
+        var doc = XDocument.Load(result.ConfigFile.FullName);
+        var gpf = doc.Descendants("config")
+            .SelectMany(c => c.Elements("add"))
+            .FirstOrDefault(a => string.Equals(a.Attribute("key")?.Value, "globalPackagesFolder", StringComparison.OrdinalIgnoreCase));
+        Assert.NotNull(gpf);
+        var gpfValue = gpf.Attribute("value")?.Value;
+        Assert.False(string.IsNullOrEmpty(gpfValue));
+        Assert.True(Path.IsPathFullyQualified(gpfValue), $"globalPackagesFolder value must be an absolute path. Got: {gpfValue}");
+        var tempConfigDir = result.ConfigFile.Directory!.FullName;
+        Assert.False(
+            gpfValue!.StartsWith(tempConfigDir, StringComparison.Ordinal),
+            $"globalPackagesFolder must not be under the temp nuget.config dir '{tempConfigDir}'. Got: {gpfValue}");
     }
 
     [Theory]
@@ -544,9 +607,19 @@ public class PrebuiltAppHostServerTests(ITestOutputHelper outputHelper)
         Assert.Equal(["Aspire*"], GetPackagePatternsForSource(doc, packageSourceOverride));
         Assert.Equal(["CommunityToolkit*"], GetPackagePatternsForSource(doc, channelSource));
         Assert.Equal([PackageMapping.AllPackages], GetPackagePatternsForSource(doc, NuGetOrgSource));
-        Assert.NotNull(doc.Descendants("config")
+        var gpf = doc.Descendants("config")
             .SelectMany(c => c.Elements("add"))
-            .FirstOrDefault(a => string.Equals(a.Attribute("key")?.Value, "globalPackagesFolder", StringComparison.OrdinalIgnoreCase)));
+            .FirstOrDefault(a => string.Equals(a.Attribute("key")?.Value, "globalPackagesFolder", StringComparison.OrdinalIgnoreCase));
+        Assert.NotNull(gpf);
+        // Same stability requirement as the channel-only branch: the override path must outlive
+        // the temp nuget.config so BundleNuGetService's manifest paths remain valid after dispose.
+        var gpfValue = gpf.Attribute("value")?.Value;
+        Assert.False(string.IsNullOrEmpty(gpfValue));
+        Assert.True(Path.IsPathFullyQualified(gpfValue), $"globalPackagesFolder value must be an absolute path. Got: {gpfValue}");
+        var tempConfigDir = result.ConfigFile.Directory!.FullName;
+        Assert.False(
+            gpfValue!.StartsWith(tempConfigDir, StringComparison.Ordinal),
+            $"globalPackagesFolder must not be under the temp nuget.config dir '{tempConfigDir}'. Got: {gpfValue}");
     }
 
     [Fact]

--- a/tests/Aspire.Cli.Tests/Utils/CliPathHelperTests.cs
+++ b/tests/Aspire.Cli.Tests/Utils/CliPathHelperTests.cs
@@ -55,6 +55,94 @@ public class CliPathHelperTests(ITestOutputHelper outputHelper)
     }
 
     [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    [InlineData("\t\n")]
+    public void ComputeStagingFeedCacheKey_ReturnsNull_ForNullOrWhitespace(string? feedUrl)
+    {
+        Assert.Null(CliPathHelper.ComputeStagingFeedCacheKey(feedUrl));
+    }
+
+    [Fact]
+    public void ComputeStagingFeedCacheKey_DefaultsToEightLowercaseHexChars()
+    {
+        var key = CliPathHelper.ComputeStagingFeedCacheKey("https://pkgs.dev.azure.com/dnceng/public/_packaging/darc-pub-microsoft-aspire-deadbeef/nuget/v3/index.json");
+
+        Assert.NotNull(key);
+        Assert.Matches("^[0-9a-f]{8}$", key);
+    }
+
+    [Fact]
+    public void ComputeStagingFeedCacheKey_IsDeterministic_ForSameInput()
+    {
+        const string feedUrl = "https://pkgs.dev.azure.com/dnceng/public/_packaging/darc-pub-microsoft-aspire-deadbeef/nuget/v3/index.json";
+
+        var first = CliPathHelper.ComputeStagingFeedCacheKey(feedUrl);
+        var second = CliPathHelper.ComputeStagingFeedCacheKey(feedUrl);
+
+        Assert.Equal(first, second);
+    }
+
+    [Fact]
+    public void ComputeStagingFeedCacheKey_DifferentUrls_ProduceDifferentKeys()
+    {
+        var a = CliPathHelper.ComputeStagingFeedCacheKey("https://pkgs.dev.azure.com/dnceng/public/_packaging/darc-pub-microsoft-aspire-deadbeef/nuget/v3/index.json");
+        var b = CliPathHelper.ComputeStagingFeedCacheKey("https://pkgs.dev.azure.com/dnceng/public/_packaging/darc-pub-microsoft-aspire-cafef00d/nuget/v3/index.json");
+
+        Assert.NotEqual(a, b);
+    }
+
+    [Fact]
+    public void ComputeStagingFeedCacheKey_NormalizesWhitespaceAndCasing()
+    {
+        // Trim + lowercase normalization keeps the cache from fragmenting when the same feed
+        // shows up with stray whitespace from a config file or with a mixed-case hostname.
+        const string baseUrl = "https://pkgs.dev.azure.com/dnceng/public/_packaging/darc-pub-microsoft-aspire-deadbeef/nuget/v3/index.json";
+
+        var baseKey = CliPathHelper.ComputeStagingFeedCacheKey(baseUrl);
+        var spacedKey = CliPathHelper.ComputeStagingFeedCacheKey("  " + baseUrl + "\t\n");
+        var upperKey = CliPathHelper.ComputeStagingFeedCacheKey(baseUrl.ToUpperInvariant());
+
+        Assert.Equal(baseKey, spacedKey);
+        Assert.Equal(baseKey, upperKey);
+    }
+
+    [Theory]
+    [InlineData(1)]
+    [InlineData(4)]
+    [InlineData(16)]
+    public void ComputeStagingFeedCacheKey_RespectsExplicitLength(int length)
+    {
+        var key = CliPathHelper.ComputeStagingFeedCacheKey(
+            "https://pkgs.dev.azure.com/dnceng/public/_packaging/darc-pub-microsoft-aspire-deadbeef/nuget/v3/index.json",
+            length);
+
+        Assert.NotNull(key);
+        Assert.Equal(length, key.Length);
+        Assert.Matches($"^[0-9a-f]{{{length}}}$", key);
+    }
+
+    [Fact]
+    public void ComputeStagingFeedCacheKey_LengthAboveHashWidth_ReturnsFullHash()
+    {
+        // XxHash3 is 64 bits -> 16 hex chars. Asking for more than 16 must not crash and must
+        // return all available hash chars rather than padding with garbage.
+        var key = CliPathHelper.ComputeStagingFeedCacheKey("https://example/index.json", length: 999);
+
+        Assert.NotNull(key);
+        Assert.Equal(16, key.Length);
+        Assert.Matches("^[0-9a-f]{16}$", key);
+    }
+
+    [Fact]
+    public void ComputeStagingFeedCacheKey_NonZeroLength_RejectsZeroOrNegative()
+    {
+        Assert.Null(CliPathHelper.ComputeStagingFeedCacheKey("https://example/index.json", length: 0));
+        Assert.Null(CliPathHelper.ComputeStagingFeedCacheKey("https://example/index.json", length: -1));
+    }
+
+    [Theory]
     [InlineData("script")]
     [InlineData("localhive")]
     public void TryGetAspireHomeDirectoryFromInstallRoute_SharedPrefixRoute_ReturnsInstallPrefix(string source)


### PR DESCRIPTION
## Description

Polyglot AppHosts running a stable-shaped staging CLI (e.g. `13.4.0+<sha>`) were hanging during DI / assembly loading after a successful integration restore. Observed on macOS osx-arm64 against staging builds; the same code path is at risk on every OS.

Root cause: `PackagingService` builds the staging channel with `ConfigureGlobalPackagesFolder=true` so each darc/override feed restore is cache-isolated. That isolation matters because two staging builds of the same release branch ship as the same stable-shaped semver (e.g. `13.4.0`) from different feeds, and NuGet keys by `(id, version)` only -- without per-feed isolation a second build's restore silently reuses the first build's now-stale assemblies. `PrebuiltAppHostServer` threaded that flag into `TemporaryNuGetConfig`, whose default `globalPackagesFolder` value is the relative `.nugetpackages`. NuGet resolved it under the temp config's own directory, `BundleNuGetService` baked those temp paths into `integration-package-probe-manifest.json`, and `TemporaryNuGetConfig.Dispose` then recursively deleted the cache out from under the manifest. aspire-managed then tried to load assemblies the dispose had just removed.

Approach: keep the per-feed cache isolation (it's load-bearing for staging) and anchor the override at a stable absolute path instead of a relative one that the temp config owns. The override now points at:

```
<ASPIRE_HOME>/.nugetpackages/<first-8-of-CLI-commit-sha>
```

A few notes on the design:

- The cache is keyed by the truncated CLI commit SHA so each staging build gets its own cache. 8 hex chars matches the existing `darc-pub-microsoft-aspire-<hash>` feed URL convention in `PackagingService.GetStagingFeedUrl`, short enough to avoid Windows `MAX_PATH` blow-ups on deep integration cache trees while keeping collision probability negligible. Clean release builds (no `+sha` suffix) fall back to `default`.
- The cache lives under `ASPIRE_HOME` rather than the per-AppHost `_workingDirectory` so multiple AppHosts on the same machine running against the same staging build can share one restore. The unit of isolation here is the staging build, not the individual restore command.
- A single `CliPathHelper.GetStagingNuGetPackagesDirectory` helper is the source of truth for the path so the producer (`PrebuiltAppHostServer`) and consumer (`CacheCommand`) can't drift.
- `aspire cache clear` now wipes the SHA-keyed subdirs under `<ASPIRE_HOME>/.nugetpackages`, so a wedged staging restore is recoverable through the same UX as every other CLI cache.

Tests cover the new invariants:
- Existing `PrebuiltAppHostServerTests` staging cases now assert the emitted `globalPackagesFolder` is absolute and lives outside the temp config directory.
- New `PrebuiltAppHostServerTests` case wires a real `PackagingService` with `overrideStagingFeed` on a stable-shaped CLI and pins the same invariant end to end.
- New `TemporaryNuGetConfigTests` cover the override propagation and the no-override-when-disabled case.
- New `CacheCommandTests` cover the staging cache wipe and the missing-cache no-op path.

Targeted MTP run (excluding quarantine/outerloop) is green: 221/221 across `PackagingServiceTests`, `PrebuiltAppHostServerTests`, `TemporaryNuGetConfigTests`, `NuGetConfigMergerTests`, and `CacheCommandTests`.

Fixes # (issue)

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No