### PR TITLE
Fix TypeScript AppHost async callback deadlock

### DIFF
--- a/src/Aspire.Hosting/DistributedApplication.cs
+++ b/src/Aspire.Hosting/DistributedApplication.cs
@@ -516,7 +516,7 @@ public class DistributedApplication : IHost, IAsyncDisposable
     /// in refer to <see cref="DistributedApplicationExecutionContext" />.
     /// </para>
     /// </remarks>
-    [AspireExport("run")]
+    [AspireExport("run", RunSyncOnBackgroundThread = true)]
     public virtual async Task RunAsync(CancellationToken cancellationToken = default)
     {
         ProfilingTelemetry.EnsureInitialized(_host.Services);

--- a/tests/Aspire.Cli.EndToEnd.Tests/TypeScriptEmptyAppHostTemplateTests.cs
+++ b/tests/Aspire.Cli.EndToEnd.Tests/TypeScriptEmptyAppHostTemplateTests.cs
@@ -1,6 +1,8 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Text.Json;
+using System.Text.Json.Nodes;
 using Aspire.Cli.EndToEnd.Tests.Helpers;
 using Aspire.Cli.Tests.Utils;
 using Hex1b.Automation;
@@ -53,5 +55,159 @@ public sealed class TypeScriptEmptyAppHostTemplateTests(ITestOutputHelper output
         await auto.EnterAsync();
 
         await pendingRun;
+    }
+
+    [Fact]
+    [CaptureWorkspaceOnFailure]
+    public async Task TypeScriptAppHostRunDoesNotDeadlockWhenLazyOptionsInvokeAsyncCallback()
+    {
+        var repoRoot = CliE2ETestHelpers.GetRepoRoot();
+        var strategy = CliInstallStrategy.Detect(output.WriteLine);
+        var workspace = TemporaryWorkspace.Create(output);
+
+        using var terminal = CliE2ETestHelpers.CreateDockerTestTerminal(repoRoot, strategy, output, mountDockerSocket: true, workspace: workspace);
+
+        var pendingRun = terminal.RunAsync(TestContext.Current.CancellationToken);
+
+        var counter = new SequenceCounter();
+        var auto = new Hex1bTerminalAutomator(terminal, defaultTimeout: TimeSpan.FromSeconds(500));
+        var testBodyFailed = false;
+
+        try
+        {
+            await auto.PrepareDockerEnvironmentAsync(counter, workspace, enableDcpDiagnostics: true);
+            await auto.InstallAspireCliAsync(strategy, counter);
+
+            await auto.AspireNewTypeScriptEmptyAppHostAsync("TsDeadlockRepro", counter);
+
+            var appDirectory = Path.Combine(workspace.WorkspaceRoot.FullName, "TsDeadlockRepro");
+            WriteDeadlockReproFiles(appDirectory);
+
+            await auto.RunCommandFailFastAsync("cd TsDeadlockRepro", counter);
+            await auto.RunCommandFailFastAsync("aspire restore --non-interactive", counter, TimeSpan.FromMinutes(3));
+            await auto.RunCommandFailFastAsync("npm run build", counter, TimeSpan.FromMinutes(2));
+
+            await auto.AspireStartAsync(counter, startTimeout: TimeSpan.FromMinutes(2));
+            await auto.AspireStopAsync(counter);
+        }
+        catch
+        {
+            testBodyFailed = true;
+            throw;
+        }
+        finally
+        {
+            try
+            {
+                await auto.CaptureAspireDiagnosticsAsync(counter, workspace);
+            }
+            catch { } // Best effort
+
+            try
+            {
+                await auto.TypeAsync("exit");
+                await auto.EnterAsync();
+                await pendingRun;
+            }
+            catch
+            {
+                if (!testBodyFailed)
+                {
+                    throw;
+                }
+            }
+        }
+    }
+
+    private static void WriteDeadlockReproFiles(string appDirectory)
+    {
+        var sdkVersion = GetSdkVersion(appDirectory);
+        var extensionDirectory = Directory.CreateDirectory(Path.Combine(appDirectory, "DeadlockExtension"));
+
+        File.WriteAllText(Path.Combine(extensionDirectory.FullName, "DeadlockExtension.csproj"), $$"""
+            <Project Sdk="Microsoft.NET.Sdk">
+              <PropertyGroup>
+                <TargetFramework>net10.0</TargetFramework>
+                <ImplicitUsings>enable</ImplicitUsings>
+                <Nullable>enable</Nullable>
+                <NoWarn>$(NoWarn);ASPIREATS001</NoWarn>
+              </PropertyGroup>
+
+              <ItemGroup>
+                <PackageReference Include="Aspire.Hosting" Version="{{sdkVersion}}" />
+              </ItemGroup>
+            </Project>
+            """);
+
+        File.WriteAllText(Path.Combine(extensionDirectory.FullName, "DeadlockExtensions.cs"), """
+            using Aspire.Hosting;
+            using Aspire.Hosting.ApplicationModel;
+            using Microsoft.Extensions.DependencyInjection;
+            using Microsoft.Extensions.Options;
+
+            namespace DeadlockExtension;
+
+            public static class DeadlockExtensions
+            {
+                [AspireExport(RunSyncOnBackgroundThread = true)]
+                public static IDistributedApplicationBuilder AddLazyOptionsDeadlockRepro(
+                    this IDistributedApplicationBuilder builder,
+                    Action<DeadlockOptions>? configure = null)
+                {
+                    builder.Services.AddOptions<DeadlockOptions>()
+                        .Configure(options => configure?.Invoke(options));
+
+                    builder.Eventing.Subscribe<BeforeStartEvent>((@event, _) =>
+                    {
+                        var options = @event.Services.GetRequiredService<IOptions<DeadlockOptions>>().Value;
+                        if (options.SomeProperty is not "value-from-typescript")
+                        {
+                            throw new InvalidOperationException($"Expected TypeScript callback to set SomeProperty, but got '{options.SomeProperty ?? "<null>"}'.");
+                        }
+
+                        return Task.CompletedTask;
+                    });
+
+                    return builder;
+                }
+            }
+
+            [AspireExport(ExposeProperties = true)]
+            public sealed class DeadlockOptions
+            {
+                public string? SomeProperty { get; set; }
+            }
+            """);
+
+        File.WriteAllText(Path.Combine(appDirectory, "apphost.mts"), """
+            import { createBuilder } from './.aspire/modules/aspire.mjs';
+
+            const builder = await createBuilder();
+
+            await builder.addLazyOptionsDeadlockRepro({
+                configure: async (options) => {
+                    await options.someProperty.set("value-from-typescript");
+                }
+            });
+
+            await builder.build().run();
+            """);
+
+        var configPath = Path.Combine(appDirectory, "aspire.config.json");
+        var config = JsonNode.Parse(File.ReadAllText(configPath))?.AsObject()
+            ?? throw new InvalidOperationException($"Unable to read {configPath}.");
+        config["packages"] = new JsonObject
+        {
+            ["DeadlockExtension"] = "DeadlockExtension/DeadlockExtension.csproj"
+        };
+        File.WriteAllText(configPath, config.ToJsonString(new JsonSerializerOptions { WriteIndented = true }));
+    }
+
+    private static string GetSdkVersion(string appDirectory)
+    {
+        var configPath = Path.Combine(appDirectory, "aspire.config.json");
+        using var doc = JsonDocument.Parse(File.ReadAllText(configPath));
+        return doc.RootElement.GetProperty("sdk").GetProperty("version").GetString()
+            ?? throw new InvalidOperationException("Expected aspire.config.json to contain sdk.version.");
     }
 }


### PR DESCRIPTION
## Description

Fixes #17487.
Follow-up to #17508.

TypeScript AppHosts could still deadlock during `await builder.build().run()` when an async TypeScript callback was stored in lazy `IOptions.Configure` and invoked during `BeforeStartEvent`. PR #17508 fixed the dispatcher behavior for exports that already opt into `RunSyncOnBackgroundThread`, but the actual `Aspire.Hosting/run` capability was not opted in, so the real AppHost startup path could still run on StreamJsonRpc's non-concurrent synchronization context.

This changes `DistributedApplication.RunAsync` to export `Aspire.Hosting/run` with `RunSyncOnBackgroundThread = true`, keeping the synchronous startup portion of `RunAsync` off the JSON-RPC synchronization context. Existing TypeScript AppHosts can keep using:

```typescript
await builder.build().run();
```

The PR also adds a CLI E2E regression that recreates the exact failure shape:

1. Creates a TypeScript empty AppHost.
2. Adds a local ATS extension whose exported method is marked `RunSyncOnBackgroundThread = true`.
3. Stores the TypeScript async configure callback inside lazy `IOptions.Configure`.
4. Resolves those options from `BeforeStartEvent`.
5. Verifies `aspire start` succeeds instead of timing out while waiting for the AppHost server.

Validation:

- `.\restore.cmd`
- `dotnet build tests\Aspire.Cli.EndToEnd.Tests\Aspire.Cli.EndToEnd.Tests.csproj /p:SkipNativeBuild=true`
- Built a local Windows hive from this branch with `.\localhive.ps1 -r win-x64 -Archive`.
- Manually ran the exact TypeScript lazy-options repro against that hive: `aspire restore`, `npm run build`, `aspire start --format Json`, and `aspire stop`. `aspire start` returned successfully in ~15s instead of timing out after 60s.

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
