### PR TITLE
Improve dashboard summary log formatting

### DIFF
--- a/src/Shared/LoggingHelpers.cs
+++ b/src/Shared/LoggingHelpers.cs
@@ -44,37 +44,41 @@ internal static class LoggingHelpers
             .Append("Aspire Dashboard").Append('\n')
             .Append('\n');
 
+        // The default .NET console logger indents the first line 6 characters because of the level.
+        // This prefix aligns the URLs under the dashboard title and makes them easier to read.
+        // In other logging layouts the prefix is just extra spaces, but it doesn't cause any real issues.
+        var prefix = "      ";
+
         if (dashboardAuthority is not null)
         {
-            templateBuilder.Append("Dashboard:    {DashboardUrl}").Append('\n');
+            templateBuilder.Append(prefix).Append("- Dashboard:  {DashboardUrl}").Append('\n');
             parameters.Add(dashboardAuthority);
         }
 
         if (loginUrl is not null)
         {
-            templateBuilder.Append("Login URL:    {LoginUrl}").Append('\n');
+            templateBuilder.Append(prefix).Append("- Login URL:  {LoginUrl}").Append('\n');
             parameters.Add(loginUrl);
         }
 
         if (otlpGrpcAuthority is not null)
         {
-            templateBuilder.Append("OTLP/gRPC:    {OtlpGrpcUrl}").Append('\n');
+            templateBuilder.Append(prefix).Append("- OTLP/gRPC:  {OtlpGrpcUrl}").Append('\n');
             parameters.Add(otlpGrpcAuthority);
         }
 
         if (otlpHttpAuthority is not null)
         {
-            templateBuilder.Append("OTLP/HTTP:    {OtlpHttpUrl}").Append('\n');
+            templateBuilder.Append(prefix).Append("- OTLP/HTTP:  {OtlpHttpUrl}").Append('\n');
             parameters.Add(otlpHttpAuthority);
         }
 
+        logger.LogInformation(templateBuilder.ToString(), parameters.ToArray());
+
         if (isContainer)
         {
-            templateBuilder.Append('\n');
-            templateBuilder.Append("URLs may need changes depending on how network access to the container is configured.").Append('\n');
+            logger.LogInformation("Dashboard is running in a container. Access the dashboard from the host using port forwarding.");
         }
-
-        logger.LogInformation(templateBuilder.ToString(), parameters.ToArray());
     }
 
     [Conditional("DEBUG")]

--- a/tests/Aspire.Dashboard.Tests/Integration/FrontendBrowserTokenAuthTests.cs
+++ b/tests/Aspire.Dashboard.Tests/Integration/FrontendBrowserTokenAuthTests.cs
@@ -464,9 +464,8 @@ public class FrontendBrowserTokenAuthTests
         // Assert
         var l = testSink.Writes.Where(w => w.LoggerName == typeof(DashboardWebApplication).FullName).ToList();
 
-        // The container message is now part of the summary log message.
-        var summaryLog = l.Single(w => ((string?)LogTestHelpers.GetValue(w, "{OriginalFormat}"))?.StartsWith("Aspire Dashboard") == true);
-        var containerMessage = "URLs may need changes depending on how network access to the container is configured.";
-        Assert.Contains(containerMessage, summaryLog.Message);
+        // The container message is a separate log entry from the summary.
+        var containerLog = l.Single(w => w.Message == "Dashboard is running in a container. Access the dashboard from the host using port forwarding.");
+        Assert.NotNull(containerLog);
     }
 }

--- a/tests/Aspire.Dashboard.Tests/LoggingHelpersTests.cs
+++ b/tests/Aspire.Dashboard.Tests/LoggingHelpersTests.cs
@@ -31,10 +31,10 @@ public class LoggingHelpersTests
         Assert.Collection(lines,
             line => Assert.Equal("Aspire Dashboard", line),
             line => Assert.Equal(string.Empty, line),
-            line => Assert.Equal("Dashboard:    http://localhost:18888", line),
-            line => Assert.Equal("Login URL:    http://localhost:18888/login?t=abc123", line),
-            line => Assert.Equal("OTLP/gRPC:    http://localhost:18889", line),
-            line => Assert.Equal("OTLP/HTTP:    http://localhost:18890", line),
+            line => Assert.Equal("      - Dashboard:  http://localhost:18888", line),
+            line => Assert.Equal("      - Login URL:  http://localhost:18888/login?t=abc123", line),
+            line => Assert.Equal("      - OTLP/gRPC:  http://localhost:18889", line),
+            line => Assert.Equal("      - OTLP/HTTP:  http://localhost:18890", line),
             line => Assert.Equal(string.Empty, line));
 
         Assert.Equal("http://localhost:18888", LogTestHelpers.GetValue(write, "DashboardUrl"));
@@ -64,9 +64,9 @@ public class LoggingHelpersTests
         Assert.Collection(lines,
             line => Assert.Equal("Aspire Dashboard", line),
             line => Assert.Equal(string.Empty, line),
-            line => Assert.Equal("Dashboard:    http://localhost:18888", line),
-            line => Assert.Equal("OTLP/gRPC:    http://localhost:18889", line),
-            line => Assert.Equal("OTLP/HTTP:    http://localhost:18890", line),
+            line => Assert.Equal("      - Dashboard:  http://localhost:18888", line),
+            line => Assert.Equal("      - OTLP/gRPC:  http://localhost:18889", line),
+            line => Assert.Equal("      - OTLP/HTTP:  http://localhost:18890", line),
             line => Assert.Equal(string.Empty, line));
 
         Assert.Null(LogTestHelpers.GetValue(write, "LoginUrl"));
@@ -88,8 +88,8 @@ public class LoggingHelpersTests
         Assert.Collection(lines,
             line => Assert.Equal("Aspire Dashboard", line),
             line => Assert.Equal(string.Empty, line),
-            line => Assert.Equal("OTLP/gRPC:    http://localhost:18889", line),
-            line => Assert.Equal("OTLP/HTTP:    http://localhost:18890", line),
+            line => Assert.Equal("      - OTLP/gRPC:  http://localhost:18889", line),
+            line => Assert.Equal("      - OTLP/HTTP:  http://localhost:18890", line),
             line => Assert.Equal(string.Empty, line));
     }
 
@@ -114,8 +114,8 @@ public class LoggingHelpersTests
         Assert.Collection(lines,
             line => Assert.Equal("Aspire Dashboard", line),
             line => Assert.Equal(string.Empty, line),
-            line => Assert.Equal("OTLP/gRPC:    http://localhost:18889", line),
-            line => Assert.Equal("OTLP/HTTP:    http://localhost:18890", line),
+            line => Assert.Equal("      - OTLP/gRPC:  http://localhost:18889", line),
+            line => Assert.Equal("      - OTLP/HTTP:  http://localhost:18890", line),
             line => Assert.Equal(string.Empty, line));
 
         Assert.Null(LogTestHelpers.GetValue(write, "DashboardUrl"));
@@ -176,8 +176,8 @@ public class LoggingHelpersTests
         Assert.Collection(lines,
             line => Assert.Equal("Aspire Dashboard", line),
             line => Assert.Equal(string.Empty, line),
-            line => Assert.Equal("Dashboard:    http://localhost:18888", line),
-            line => Assert.Equal("Login URL:    http://localhost:18888/login?t=abc123", line),
+            line => Assert.Equal("      - Dashboard:  http://localhost:18888", line),
+            line => Assert.Equal("      - Login URL:  http://localhost:18888/login?t=abc123", line),
             line => Assert.Equal(string.Empty, line));
 
         Assert.Null(LogTestHelpers.GetValue(write, "OtlpGrpcUrl"));
@@ -198,11 +198,9 @@ public class LoggingHelpersTests
             token: "abc123",
             isContainer: true);
 
-        var write = Assert.Single(sink.Writes);
-        Assert.NotNull(write.Message);
-        var containerMessage = "URLs may need changes depending on how network access to the container is configured.";
-
-        Assert.Contains(containerMessage, write.Message);
+        Assert.Equal(2, sink.Writes.Count);
+        var containerWrite = sink.Writes.Skip(1).First();
+        Assert.Equal("Dashboard is running in a container. Access the dashboard from the host using port forwarding.", containerWrite.Message);
     }
 
     private static string[] GetMessageLines(string message)


### PR DESCRIPTION
## Description

Improves the dashboard summary log output by making URL lines easier to scan and separating the container warning into its own log entry.

- Adds indented bullet formatting (`"      - "` prefix) for dashboard and OTLP URL lines to align with .NET console logger indentation
- Emits the container access guidance as a separate `LogInformation` call instead of appending it to the summary template
- Updates `LoggingHelpersTests` expectations for the new summary format
- Updates `FrontendBrowserTokenAuthTests.LogOutput_InContainer_LoginLinkContainerMessage` to assert the new standalone container log message

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No