### PR TITLE
Forward-port #17528 + #17564 + #17573 from release/13.4 to main + DotNet template identity-channel fix

### DIFF
--- a/eng/pipelines/azure-pipelines.yml
+++ b/eng/pipelines/azure-pipelines.yml
@@ -8,6 +8,24 @@ parameters:
     displayName: 'Publish as Pre-Release'
     type: boolean
     default: false
+  # Operator-controlled override for the AspireCliChannel baked into native CLI
+  # binaries by build_sign_native.yml. The default 'auto' lets the pipeline pick
+  # stable / staging / daily / pr-<N> from Build.Reason and Build.SourceBranch
+  # (where release/* and internal/release/* branches always resolve to 'staging'
+  # so stabilizing dogfood builds aren't mis-baked as 'stable' — see
+  # https://github.com/microsoft/aspire/issues/17527). Set this to 'stable' when
+  # kicking off the official GA ship build from a release/* branch so the
+  # distributed binary identifies as stable and `aspire init` writes a
+  # nuget.org-only nuget.config matching the promoted package set.
+  - name: aspireCliChannelOverride
+    displayName: 'Aspire CLI channel override (auto = derive from branch; set to stable for the GA ship build)'
+    type: string
+    default: 'auto'
+    values:
+      - auto
+      - stable
+      - staging
+      - daily
 
 trigger:
   batch: true
@@ -167,6 +185,7 @@ extends:
             - osx-x64
           codeSign: true
           teamName: $(_TeamName)
+          aspireCliChannelOverride: ${{ parameters.aspireCliChannelOverride }}
           extraBuildArgs: >-
             /p:Configuration=$(_BuildConfig)
             $(_SignArgs)
@@ -182,6 +201,7 @@ extends:
           # no need to sign ELF binaries on linux
           codeSign: false
           teamName: $(_TeamName)
+          aspireCliChannelOverride: ${{ parameters.aspireCliChannelOverride }}
           extraBuildArgs: >-
             /p:Configuration=$(_BuildConfig)
             $(_OfficialBuildIdArgs)
@@ -194,6 +214,7 @@ extends:
             - win-arm64
           codeSign: true
           teamName: $(_TeamName)
+          aspireCliChannelOverride: ${{ parameters.aspireCliChannelOverride }}
           extraBuildArgs: >-
             /p:Configuration=$(_BuildConfig)
             $(_SignArgs)

--- a/eng/pipelines/templates/build_sign_native.yml
+++ b/eng/pipelines/templates/build_sign_native.yml
@@ -6,6 +6,19 @@ parameters:
   extraBuildArgs: ''
   codeSign: false
   teamName: ''
+  # Optional override for AspireCliChannel. Accepted values: 'auto' (default;
+  # let computeCliChannel below pick stable/staging/daily/pr-<N> from Build.Reason
+  # and Build.SourceBranch), 'stable', 'staging', 'daily'. Set this to 'stable'
+  # when running the official ship pipeline so the GA CLI binary is baked with
+  # AspireCliChannel=stable (and aspire init then writes a nuget.org-only
+  # nuget.config, which is correct because the packages have been promoted to
+  # nuget.org). For routine stabilizing builds from a release/* branch — which
+  # also set DotNetFinalVersionKind=release — leave this on 'auto' so the
+  # channel falls through to 'staging' and aspire init writes a nuget.config
+  # that maps Aspire.* to the staging feed. See
+  # https://github.com/microsoft/aspire/issues/17527 for the bug that made this
+  # override necessary.
+  aspireCliChannelOverride: 'auto'
 
 jobs:
 
@@ -84,15 +97,32 @@ jobs:
               $reason = '$(Build.Reason)'
               $sourceBranch = '$(Build.SourceBranch)'
               $prNumber = '$(System.PullRequest.PullRequestNumber)'
+              # Template-time substitution: the value is the resolved
+              # aspireCliChannelOverride parameter literal, never a runtime
+              # variable. Quoting protects an empty/default value.
+              $override = '${{ parameters.aspireCliChannelOverride }}'
               Write-Host "Build.Reason: '$reason'"
               Write-Host "Build.SourceBranch: '$sourceBranch'"
               Write-Host "System.PullRequest.PullRequestNumber: '$prNumber'"
+              Write-Host "aspireCliChannelOverride: '$override'"
 
               $versionKind = & "$(Build.SourcesDirectory)/$(dotnetScript)" msbuild "$(Build.SourcesDirectory)/eng/Versions.props" -getProperty:DotNetFinalVersionKind
               $versionKind = $versionKind.Trim()
               Write-Host "DotNetFinalVersionKind: '$versionKind'"
 
-              if ($reason -eq 'PullRequest') {
+              if ($override -and $override -ne 'auto') {
+                # Operator override path. Validate against the same accepted set
+                # that IdentityChannelReader.IsValidChannel enforces at CLI startup
+                # so a typo here fails the pipeline step rather than producing a
+                # binary that refuses to boot. pr-<N> is intentionally excluded
+                # from the override set — PR builds always come from the
+                # PullRequest reason arm below.
+                if ($override -notin @('stable', 'staging', 'daily')) {
+                  throw "aspireCliChannelOverride='$override' is not one of: auto, stable, staging, daily."
+                }
+                $channel = $override.ToLowerInvariant()
+              }
+              elseif ($reason -eq 'PullRequest') {
                 # Defense in depth: validate digit-only PR number rather than just
                 # non-emptiness. If the agent ever returns the literal macro string
                 # (e.g. '$(System.PullRequest.PullRequestNumber)' unresolved) this
@@ -105,10 +135,21 @@ jobs:
                 # Bake the resolved hive label directly into AspireCliChannel. The CLI
                 # consumes this verbatim and avoids the legacy "pr" + parsed-PrNumber join.
                 $channel = "pr-$prNumber"
+              } elseif ($sourceBranch -match '^refs/heads/(release|internal/release)/') {
+                # Release/internal-release branches always produce staging artifacts —
+                # they are published to the staging feed for dogfooding and only later
+                # promoted to nuget.org. This must be checked BEFORE the
+                # `versionKind == release` arm, because a release-branch build also sets
+                # StabilizePackageVersion=true (→ DotNetFinalVersionKind=release) once
+                # we are stabilizing for ship. Without this ordering, the stabilized
+                # staging build would bake AspireCliChannel=stable and `aspire init`
+                # would drop a nuget.config with no staging feed mapping, causing
+                # `aspire add` to resolve Aspire.* packages from nuget.org (older
+                # versions) or fail to resolve the +sha-pinned Aspire.AppHost.Sdk.
+                # See https://github.com/microsoft/aspire/issues/17527.
+                $channel = 'staging'
               } elseif ($versionKind -eq 'release') {
                 $channel = 'stable'
-              } elseif ($sourceBranch -match '^refs/heads/(release|internal/release)/') {
-                $channel = 'staging'
               } else {
                 # main and any other branch fall through to daily
                 $channel = 'daily'

--- a/src/Aspire.Cli/Commands/CacheCommand.cs
+++ b/src/Aspire.Cli/Commands/CacheCommand.cs
@@ -40,6 +40,14 @@ internal sealed class CacheCommand : ParentCommand
                 filesDeleted += ClearDirectoryContents(ExecutionContext.CacheDirectory);
                 filesDeleted += ClearDirectoryContents(ExecutionContext.SdksDirectory);
                 filesDeleted += ClearDirectoryContents(ExecutionContext.PackagesDirectory);
+                // Wipe the staging NuGet package cache too. Producers (PrebuiltAppHostServer's
+                // temporary nuget.config for the staging channel) deposit SHA-keyed package
+                // caches under <ASPIRE_HOME>/.nugetpackages/<sha>; clearing them lets users
+                // recover wedged staging restores without filesystem surgery. We hand the parent
+                // directory to ClearDirectoryContents so each SHA subdirectory is wiped while
+                // the parent itself stays in place for the next staging restore.
+                filesDeleted += ClearDirectoryContents(
+                    new DirectoryInfo(CliPathHelper.GetStagingNuGetPackagesDirectory(ExecutionContext.AspireHomeDirectory)));
                 filesDeleted += ClearDirectoryContents(
                     ExecutionContext.LogsDirectory,
                     skipFile: f => f.FullName.Equals(currentLogFilePath, StringComparison.OrdinalIgnoreCase));

--- a/src/Aspire.Cli/Commands/NewCommand.cs
+++ b/src/Aspire.Cli/Commands/NewCommand.cs
@@ -177,6 +177,34 @@ internal sealed class NewCommand : BaseCommand, IPackageMetaPrefetchingCommand
         return selected.LanguageId;
     }
 
+    private static NuGetPackage? TryGetCurrentCliTemplateVersionPackage(PackageChannel selectedChannel, NuGetPackage[] packages, bool hasPrHives)
+    {
+        if (VersionHelper.TryGetCurrentCliVersionMatch(
+            packages,
+            p => p.Version,
+            out var cliVersionPackage,
+            channelName: selectedChannel.Name,
+            hasPrHives: hasPrHives))
+        {
+            return cliVersionPackage;
+        }
+
+        if (packages.Length > 0 &&
+            selectedChannel.Type is PackageChannelType.Explicit &&
+            !VersionHelper.IsLocalBuildChannel(selectedChannel.Name))
+        {
+            // Prerelease channels can filter out the shipped stable package even when the feed can restore it.
+            return new NuGetPackage
+            {
+                Id = TemplateNuGetConfigService.TemplatesPackageName,
+                Version = VersionHelper.GetDefaultSdkVersion(),
+                Source = selectedChannel.SourceDetails
+            };
+        }
+
+        return null;
+    }
+
     private async Task<(bool Success, string? LanguageId)> ResolveSelectedLanguageAsync(ITemplate template, ParseResult parseResult, CancellationToken cancellationToken)
     {
         var explicitLanguageId = ParseExplicitLanguageId(parseResult);
@@ -379,14 +407,7 @@ internal sealed class NewCommand : BaseCommand, IPackageMetaPrefetchingCommand
                         .ToArray();
                     var hasPrHives = ExecutionContext.GetHiveCount() > 0;
 
-                    NuGetPackage? package = VersionHelper.TryGetCurrentCliVersionMatch(
-                        packages,
-                        p => p.Version,
-                        out var cliVersionPackage,
-                        channelName: selectedChannel.Name,
-                        hasPrHives: hasPrHives)
-                        ? cliVersionPackage
-                        : null;
+                    var package = TryGetCurrentCliTemplateVersionPackage(selectedChannel, packages, hasPrHives);
 
                     package ??= packages
                         .OrderByDescending(p => Semver.SemVersion.Parse(p.Version, Semver.SemVersionStyles.Strict), Semver.SemVersion.PrecedenceComparer)

--- a/src/Aspire.Cli/Commands/NewCommand.cs
+++ b/src/Aspire.Cli/Commands/NewCommand.cs
@@ -191,9 +191,24 @@ internal sealed class NewCommand : BaseCommand, IPackageMetaPrefetchingCommand
 
         if (packages.Length > 0 &&
             selectedChannel.Type is PackageChannelType.Explicit &&
+            !string.Equals(selectedChannel.Name, PackageChannelNames.Stable, StringComparisons.ChannelName) &&
             !VersionHelper.IsLocalBuildChannel(selectedChannel.Name))
         {
-            // Prerelease channels can filter out the shipped stable package even when the feed can restore it.
+            // Prerelease channels (daily, staging) filter the shipped stable package out of channel
+            // search even when the channel's feed mappings can still restore it (they fall back to
+            // nuget.org). For those channels, pinning to the running CLI's SDK version keeps the
+            // bundled server and the restored Aspire packages in lock-step. Without this, `aspire new
+            // --channel daily` on a shipped 13.4 CLI floats templates to a 13.5 daily preview, which
+            // then breaks the bundled 13.4 AppHost server with `Aspire.TypeSystem, Version=13.5.0.0`
+            // assembly load errors followed by `No language support found for: typescript/nodejs`.
+            //
+            // The stable channel is excluded here on purpose: it does not apply that filter, so a
+            // "no exact match" outcome means the CLI version is genuinely not published on the stable
+            // feed (the CLI is daily-shape, staging-shape, or PR-shape `13.4.0-pr.X.gY`). Forcing
+            // it through would either contradict the user's explicit `--channel stable` request or
+            // write an unpublishable version into `apphost.cs` that NuGet restore cannot satisfy.
+            // Fall through to the OrderByDescending picker so the user gets the highest shipped
+            // stable package they actually asked for.
             return new NuGetPackage
             {
                 Id = TemplateNuGetConfigService.TemplatesPackageName,

--- a/src/Aspire.Cli/Packaging/NuGetConfigMerger.cs
+++ b/src/Aspire.Cli/Packaging/NuGetConfigMerger.cs
@@ -1032,7 +1032,13 @@ internal class NuGetConfigMerger
         AddGlobalPackagesFolderConfiguration(configContext.Configuration);
     }
 
-    internal static void AddGlobalPackagesFolderConfiguration(XElement configuration)
+    // Default workspace-relative cache used when no explicit path is supplied. Matches the
+    // long-standing 'aspire init / aspire new' convention of putting a per-workspace
+    // .nugetpackages folder next to the merged nuget.config so staging-vs-stable cache
+    // poisoning doesn't bleed into the user's global ~/.nuget/packages folder.
+    internal const string DefaultGlobalPackagesFolderValue = ".nugetpackages";
+
+    internal static void AddGlobalPackagesFolderConfiguration(XElement configuration, string? globalPackagesFolderValue = null)
     {
         // Check if config section already exists
         var config = configuration.Element("config");
@@ -1048,10 +1054,13 @@ internal class NuGetConfigMerger
 
         if (existingGlobalPackagesFolder is null)
         {
-            // Add globalPackagesFolder configuration
+            // Add globalPackagesFolder configuration. Callers (e.g. PrebuiltAppHostServer's
+            // temporary nuget.config) supply an absolute path when the config file itself is
+            // ephemeral so the cached packages outlive the config — otherwise NuGet would
+            // resolve the relative ".nugetpackages" under the about-to-be-deleted temp dir.
             var globalPackagesFolderAdd = new XElement("add");
             globalPackagesFolderAdd.SetAttributeValue("key", "globalPackagesFolder");
-            globalPackagesFolderAdd.SetAttributeValue("value", ".nugetpackages");
+            globalPackagesFolderAdd.SetAttributeValue("value", globalPackagesFolderValue ?? DefaultGlobalPackagesFolderValue);
             config.Add(globalPackagesFolderAdd);
         }
     }

--- a/src/Aspire.Cli/Packaging/PackageChannel.cs
+++ b/src/Aspire.Cli/Packaging/PackageChannel.cs
@@ -85,12 +85,15 @@ internal class PackageChannel(string name, PackageChannelQuality quality, Packag
             .DistinctBy(p => $"{p.Id}-{p.Version}");
 
         // When doing a `dotnet package search` the results may include stable packages even when searching for
-        // prerelease packages. This filters out this noise.
+        // prerelease packages. Keep the current CLI/SDK version so shipped CLIs can resolve their
+        // matching template package from daily/staging feeds, then filter out the remaining noise.
+        var currentCliVersion = VersionHelper.GetDefaultSdkVersion();
         var filteredPackages = packages.Where(p => new { SemVer = SemVersion.Parse(p.Version), Quality = Quality } switch
         {
             { Quality: PackageChannelQuality.Both } => true,
             { Quality: PackageChannelQuality.Stable, SemVer: { IsPrerelease: false } } => true,
             { Quality: PackageChannelQuality.Prerelease, SemVer: { IsPrerelease: true } } => true,
+            { Quality: PackageChannelQuality.Prerelease, SemVer: { IsPrerelease: false } } when string.Equals(p.Version, currentCliVersion, StringComparison.OrdinalIgnoreCase) => true,
             _ => false
         });
 

--- a/src/Aspire.Cli/Packaging/PackagingService.cs
+++ b/src/Aspire.Cli/Packaging/PackagingService.cs
@@ -50,6 +50,11 @@ internal class PackagingService : IPackagingService
     private readonly IConfiguration _configuration;
     private readonly ILogger<PackagingService> _logger;
     private readonly Func<string?> _processPathProvider;
+    // Predicate used by staging-channel synthesis to decide whether the running CLI is built
+    // from a stable-shaped version (no semver prerelease tag). Defaults to inspecting the
+    // current Aspire.Cli assembly's InformationalVersion; tests inject a deterministic value
+    // because the version baked into the test-host assembly varies by build configuration.
+    private readonly Func<bool> _isStableShapedCliVersion;
 
     // Cached result of the staging-channel availability check. The inputs (CLI identity,
     // overrideStagingFeed, StagingChannelEnabled feature) are effectively static for the
@@ -64,7 +69,8 @@ internal class PackagingService : IPackagingService
         IFeatures features,
         IConfiguration configuration,
         ILogger<PackagingService> logger,
-        Func<string?>? processPathProvider = null)
+        Func<string?>? processPathProvider = null,
+        Func<bool>? isStableShapedCliVersion = null)
     {
         _executionContext = executionContext;
         _nuGetPackageCache = nuGetPackageCache;
@@ -72,6 +78,7 @@ internal class PackagingService : IPackagingService
         _configuration = configuration;
         _logger = logger;
         _processPathProvider = processPathProvider ?? (() => Environment.ProcessPath);
+        _isStableShapedCliVersion = isStableShapedCliVersion ?? IsStableShapedCliVersionFromAssembly;
         _stagingUnavailableReasonCache = new Lazy<string?>(ComputeStagingChannelUnavailableReason);
     }
 
@@ -133,7 +140,46 @@ internal class PackagingService : IPackagingService
         var stagingFeatureEnabled = _features.IsFeatureEnabled(KnownFeatures.StagingChannelEnabled, false);
         if (stagingFeatureEnabled || stagingChannelConfigured || stagingChannelRequested || stagingIdentityChannel)
         {
-            var defaultQuality = stagingChannelConfigured || stagingChannelRequested || stagingIdentityChannel ? PackageChannelQuality.Both : PackageChannelQuality.Stable;
+            // Default quality selection rules (per staging entry point):
+            //   - Explicit user opt-in (`stagingChannelConfigured`, `stagingChannelRequested`): Both.
+            //     The user picked staging deliberately; they get the broadest matching window.
+            //   - `stagingFeatureEnabled` only (no other staging signal): Stable. Preserves the
+            //     pre-existing behavior of the staging feature flag.
+            //   - `stagingIdentityChannel` (the running CLI itself self-identifies as staging):
+            //     depends on the CLI build's version shape.
+            //       * Stable-shaped (e.g. "13.4.0", produced during release stabilization when
+            //         StabilizePackageVersion=true) → Stable. The shared dotnet9 daily feed only
+            //         carries prerelease-tagged 13.4.0-preview.* builds, so defaulting to Both
+            //         would route Aspire.* to dotnet9 and fail to resolve the just-shipped
+            //         stable-shaped packages — the bug from
+            //         https://github.com/microsoft/aspire/issues/17527. Routing to Stable selects
+            //         the SHA-derived darc-pub-microsoft-aspire-<hash> feed, where the
+            //         stabilizing build's packages actually live.
+            //       * Prerelease-shaped (e.g. "13.4.0-preview.1.123") → Both. SHA-specific darc
+            //         feeds are only created for stable release-branch builds, so prerelease CLIs
+            //         must use the shared daily feed; the historical Both default is correct.
+            PackageChannelQuality defaultQuality;
+            if (stagingIdentityChannel)
+            {
+                // When the running CLI's identity itself is staging, the synthesized channel's
+                // quality MUST follow the CLI build's version shape regardless of how synthesis
+                // was triggered. `init` and many other commands pass requestedChannelName=staging
+                // when identity is staging, so checking `stagingChannelRequested` first would
+                // short-circuit this path and re-introduce the #17527 misroute on stabilizing
+                // builds.
+                defaultQuality = _isStableShapedCliVersion()
+                    ? PackageChannelQuality.Stable
+                    : PackageChannelQuality.Both;
+            }
+            else if (stagingChannelConfigured || stagingChannelRequested)
+            {
+                defaultQuality = PackageChannelQuality.Both;
+            }
+            else
+            {
+                defaultQuality = PackageChannelQuality.Stable;
+            }
+
             var stagingChannel = CreateStagingChannel(defaultQuality);
             if (stagingChannel is not null)
             {
@@ -214,6 +260,23 @@ internal class PackagingService : IPackagingService
 
         var packagesDirectory = new DirectoryInfo(Path.Combine(installPrefix.FullName, "hives", identityChannel, "packages"));
         return packagesDirectory.Exists ? packagesDirectory : null;
+    }
+
+    // Returns true when the running CLI's version is stable-shaped (no semver prerelease tag).
+    // Used by the staging-channel synthesis to route stabilizing builds to the SHA-derived darc
+    // feed instead of the shared dotnet9 daily feed. Falls back to false on any error so we
+    // preserve the historical Both/shared-feed behavior rather than silently misrouting.
+    private static bool IsStableShapedCliVersionFromAssembly()
+    {
+        try
+        {
+            var version = VersionHelper.GetDefaultSdkVersion();
+            return !string.IsNullOrEmpty(version) && !version.Contains('-');
+        }
+        catch
+        {
+            return false;
+        }
     }
 
     private PackageChannel? CreateStagingChannel(PackageChannelQuality defaultQuality)

--- a/src/Aspire.Cli/Packaging/TemporaryNuGetConfig.cs
+++ b/src/Aspire.Cli/Packaging/TemporaryNuGetConfig.cs
@@ -18,7 +18,7 @@ internal sealed class TemporaryNuGetConfig : IDisposable
 
     public FileInfo ConfigFile => _configFile;
 
-    public static async Task<TemporaryNuGetConfig> CreateAsync(PackageMapping[] mappings, bool configureGlobalPackagesFolder = false)
+    public static async Task<TemporaryNuGetConfig> CreateAsync(PackageMapping[] mappings, bool configureGlobalPackagesFolder = false, string? globalPackagesFolderValue = null)
     {
         var tempDirectory = Directory.CreateTempSubdirectory("aspire-nuget-config").FullName;
         try
@@ -28,7 +28,7 @@ internal sealed class TemporaryNuGetConfig : IDisposable
             await GenerateNuGetConfigAsync(mappings, configFile);
             if (configureGlobalPackagesFolder)
             {
-                await AddGlobalPackagesFolderToConfigAsync(configFile);
+                await AddGlobalPackagesFolderToConfigAsync(configFile, globalPackagesFolderValue);
             }
             return new TemporaryNuGetConfig(configFile);
         }
@@ -125,7 +125,7 @@ internal sealed class TemporaryNuGetConfig : IDisposable
         await xmlWriter.WriteEndDocumentAsync();
     }
 
-    private static async Task AddGlobalPackagesFolderToConfigAsync(FileInfo configFile)
+    private static async Task AddGlobalPackagesFolderToConfigAsync(FileInfo configFile, string? globalPackagesFolderValue)
     {
         XDocument document;
         await using (var stream = configFile.OpenRead())
@@ -139,7 +139,7 @@ internal sealed class TemporaryNuGetConfig : IDisposable
             document.Add(configuration);
         }
 
-        NuGetConfigMerger.AddGlobalPackagesFolderConfiguration(configuration);
+        NuGetConfigMerger.AddGlobalPackagesFolderConfiguration(configuration, globalPackagesFolderValue);
 
         var content = document.Declaration is null
             ? document.ToString()

--- a/src/Aspire.Cli/Projects/PrebuiltAppHostServer.cs
+++ b/src/Aspire.Cli/Projects/PrebuiltAppHostServer.cs
@@ -689,7 +689,8 @@ internal sealed class PrebuiltAppHostServer : IAppHostServerProject, IDisposable
 
             return await TemporaryNuGetConfig.CreateAsync(
                 PackageSourceOverrideMappings.Create(packageSourceOverride, matchedChannel),
-                configureGlobalPackagesFolder);
+                configureGlobalPackagesFolder,
+                configureGlobalPackagesFolder ? ResolveStableGlobalPackagesFolder(packageSourceOverride) : null);
         }
 
         if (string.IsNullOrEmpty(requestedChannel))
@@ -745,7 +746,69 @@ internal sealed class PrebuiltAppHostServer : IAppHostServerProject, IDisposable
         // restore honors the channel's package source mappings. Let IO/XML failures
         // surface instead of silently falling back to the caller's unmapped sources,
         // which could otherwise restore from an unintended feed.
-        return await TemporaryNuGetConfig.CreateAsync(channel.Mappings, channel.ConfigureGlobalPackagesFolder);
+        return await TemporaryNuGetConfig.CreateAsync(
+            channel.Mappings,
+            channel.ConfigureGlobalPackagesFolder,
+            channel.ConfigureGlobalPackagesFolder ? ResolveStableGlobalPackagesFolder(GetPrimaryFeedUrl(channel.Mappings)) : null);
+    }
+
+    /// <summary>
+    /// Returns the absolute <c>globalPackagesFolder</c> path to write into a temporary NuGet.config
+    /// when the resolved channel asks for per-build cache isolation (today: <c>staging</c>).
+    /// </summary>
+    /// <remarks>
+    /// The default <see cref="NuGetConfigMerger.DefaultGlobalPackagesFolderValue"/> is a relative
+    /// <c>.nugetpackages</c> path that NuGet resolves next to the nuget.config it came from. For
+    /// the <see cref="NuGetConfigMerger"/> workspace-merge flow that's fine — the merged config is
+    /// persistent. For <see cref="PrebuiltAppHostServer"/>'s <see cref="TemporaryNuGetConfig"/>
+    /// the config file lives in a Directory.CreateTempSubdirectory("aspire-nuget-config") folder
+    /// that <see cref="TemporaryNuGetConfig.Dispose"/> recursively deletes after restore. NuGet
+    /// would have just populated <c>&lt;temp&gt;/.nugetpackages/&lt;id&gt;/&lt;version&gt;/</c>
+    /// with the staging assemblies, <see cref="NuGet.BundleNuGetService"/> would have baked those
+    /// paths into <c>integration-package-probe-manifest.json</c>, and aspire-managed would then
+    /// try to load assemblies the dispose just removed — observed as a hang during DI / assembly
+    /// loading on macOS osx-arm64 polyglot staging builds. Anchoring the override at a stable
+    /// per-build location keeps the cached packages alive for as long as any manifest references
+    /// them.
+    ///
+    /// The cache lives under <see cref="CliExecutionContext.AspireHomeDirectory"/> (i.e. the
+    /// <c>ASPIRE_HOME</c> override when set, otherwise <c>~/.aspire</c>) rather than under
+    /// <see cref="_workingDirectory"/> so that two AppHosts running on the same machine against
+    /// the same staging build can share a single restore — the unit of cache isolation here is
+    /// the staging build, not the individual restore command.
+    ///
+    /// The cache subdirectory is keyed by a truncated hash of the resolved feed URL (first 8
+    /// hex chars of <see cref="System.IO.Hashing.XxHash3"/> over the trimmed/lower-cased URL).
+    /// Two staging builds of the same release branch — which share the same stable-shaped semver
+    /// (e.g. <c>13.4.0</c>) but ship from different darc feeds — therefore each get their own
+    /// cache. A user pointing the same CLI at multiple <c>overrideStagingFeed</c> values during
+    /// dev/test also gets a distinct cache per feed, instead of one bucket silently shared across
+    /// feeds. NuGet identifies packages by <c>(id, version)</c> only, so without that per-feed
+    /// key the second feed's restore would silently reuse the first feed's now-stale
+    /// <c>13.4.0</c> assemblies. When <paramref name="feedUrl"/> is null or empty (defensive —
+    /// both call sites currently always pass a real URL) the key falls back to <c>"default"</c>
+    /// so the path is still well-formed.
+    /// </remarks>
+    private string ResolveStableGlobalPackagesFolder(string? feedUrl)
+    {
+        var cacheKey = CliPathHelper.ComputeStagingFeedCacheKey(feedUrl) ?? "default";
+        return Path.Combine(
+            CliPathHelper.GetStagingNuGetPackagesDirectory(_executionContext.AspireHomeDirectory),
+            cacheKey);
+    }
+
+    /// <summary>
+    /// Returns the URL we use as the cache-key input when materializing a temp nuget.config from
+    /// a <see cref="PackageChannel"/>. Prefers the explicit <c>Aspire*</c> mapping (the staging
+    /// channel's primary feed and the one whose restored assemblies actually need cache
+    /// isolation), falling back to the first mapping for forward compatibility with channel
+    /// shapes we don't yet emit.
+    /// </summary>
+    private static string GetPrimaryFeedUrl(PackageMapping[] mappings)
+    {
+        var aspire = mappings.FirstOrDefault(m =>
+            string.Equals(m.PackageFilter, "Aspire*", StringComparison.OrdinalIgnoreCase));
+        return aspire?.Source ?? mappings[0].Source;
     }
 
     private async Task<string?> ResolveLocalPackageSourceOverrideAsync(string? requestedChannel, CancellationToken cancellationToken)

--- a/src/Aspire.Cli/Templating/TemplateNuGetConfigService.cs
+++ b/src/Aspire.Cli/Templating/TemplateNuGetConfigService.cs
@@ -224,13 +224,44 @@ internal sealed class TemplateNuGetConfigService(
                     $"{string.Join(", ", allChannels.Select(c => c.Name))}");
             channels = [matchingChannel];
         }
+        else if (hasPrHives)
+        {
+            // If there are hives (PR build directories), include all channels so a
+            // PR-installed CLI can find its matching local-hive templates.
+            channels = allChannels;
+        }
         else
         {
-            // If there are hives (PR build directories), include all channels.
-            // Otherwise, only use the implicit/default channel to avoid prompting.
-            channels = hasPrHives
-                ? allChannels
-                : allChannels.Where(c => c.Type is PackageChannelType.Implicit);
+            // Prefer the channel whose name matches the running CLI's identity
+            // (CliExecutionContext.IdentityChannel — stable, staging, daily, local,
+            // or pr-<N>). This keeps DotNet templates (C# Blazor / aspire-starter)
+            // lock-stepped with the CLI a developer just installed: a daily 13.5
+            // CLI resolves Aspire.ProjectTemplates from the daily feed, not from
+            // whatever stable version happens to be live on nuget.org.
+            //
+            // Without this, `TemplateNuGetConfigService` only queried the Implicit
+            // (nuget.org) channel when neither --channel was passed nor PR hives
+            // existed, so a clean ~/.aspire on a daily CLI silently resolved the
+            // shipped stable Aspire.ProjectTemplates (e.g. 13.3.5) while the daily
+            // 13.5.0-preview.1.* package on the dotnet9 feed was never seen. See
+            // https://github.com/microsoft/aspire/issues/17596 for the full repro.
+            //
+            // ResolveCliTemplateVersionAsync (NewCommand.cs) already does the same
+            // identity-channel preference for CLI-runtime templates; this brings
+            // DotNet templates in line. The Implicit fallback preserves the prior
+            // behavior when the identity channel isn't a registered channel (e.g.
+            // a "local" CLI without a corresponding local-build hive).
+            PackageChannel? identityChannelMatch = null;
+            if (!string.IsNullOrWhiteSpace(executionContext.IdentityChannel))
+            {
+                identityChannelMatch = allChannels.FirstOrDefault(c =>
+                    string.Equals(c.Name, executionContext.IdentityChannel, StringComparison.OrdinalIgnoreCase));
+            }
+
+            var implicitChannel = allChannels.FirstOrDefault(c => c.Type is PackageChannelType.Implicit);
+            channels = identityChannelMatch is not null
+                ? [identityChannelMatch]
+                : implicitChannel is not null ? [implicitChannel] : [];
         }
 
         var packagesFromChannels = await interactionService.ShowStatusAsync(Resources.TemplatingStrings.SearchingForAvailableTemplateVersions, async () =>

--- a/src/Aspire.Cli/Utils/CliPathHelper.cs
+++ b/src/Aspire.Cli/Utils/CliPathHelper.cs
@@ -1,6 +1,8 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.IO.Hashing;
+using System.Text;
 using Aspire.Cli.Acquisition;
 using Aspire.Hosting.Backchannel;
 using Microsoft.Extensions.Logging;
@@ -10,6 +12,26 @@ namespace Aspire.Cli.Utils;
 internal static class CliPathHelper
 {
     internal const string AspireHomeEnvironmentVariable = "ASPIRE_HOME";
+
+    /// <summary>
+    /// Name of the directory under <c>ASPIRE_HOME</c> that holds NuGet package caches keyed by
+    /// a stable hash of the resolved staging feed URL. Two staging builds of the same release
+    /// branch share the same stable-shaped semver (e.g. <c>13.4.0</c>) but ship from different
+    /// darc feeds; an <c>overrideStagingFeed</c> setting can also point the same CLI at any
+    /// arbitrary feed. Each distinct feed URL therefore gets its own feed-hash subdirectory
+    /// here to avoid <c>(id, version)</c> cache collisions in NuGet. <c>aspire cache clear</c>
+    /// wipes the feed-hash subdirectories so users can recover wedged staging restores without
+    /// manual filesystem surgery.
+    /// </summary>
+    internal const string StagingNuGetPackagesFolderName = ".nugetpackages";
+
+    /// <summary>
+    /// Default number of hex characters used for staging feed cache keys. 8 keeps deep
+    /// integration cache paths well under Windows <c>MAX_PATH</c> while still giving roughly
+    /// 4 billion buckets — orders of magnitude more than the handful of staging feeds any one
+    /// user ever sees, so collisions are negligible in practice.
+    /// </summary>
+    internal const int DefaultStagingFeedCacheKeyLength = 8;
 
     // The maximum age before a leftover CLI socket file in the runtime sockets directory is
     // pruned. 24 hours is comfortably longer than any legitimate Aspire CLI run and short enough
@@ -36,6 +58,53 @@ internal static class CliPathHelper
         return string.IsNullOrWhiteSpace(configuredAspireHome)
             ? Path.Combine(userProfileDirectory, ".aspire")
             : configuredAspireHome;
+    }
+
+    /// <summary>
+    /// Returns the absolute path to the staging NuGet package cache root
+    /// (<c>&lt;ASPIRE_HOME&gt;/.nugetpackages</c>). Producers (the
+    /// <c>PrebuiltAppHostServer</c> temp nuget.config) write feed-hash-keyed
+    /// subdirectories under this root; the <c>aspire cache clear</c> command wipes those
+    /// subdirectories. Centralized here so both call sites agree on the location.
+    /// </summary>
+    internal static string GetStagingNuGetPackagesDirectory(DirectoryInfo aspireHomeDirectory)
+    {
+        ArgumentNullException.ThrowIfNull(aspireHomeDirectory);
+        return Path.Combine(aspireHomeDirectory.FullName, StagingNuGetPackagesFolderName);
+    }
+
+    /// <summary>
+    /// Returns a stable lowercase hex cache key derived from <paramref name="feedUrl"/>,
+    /// truncated to <paramref name="length"/> characters. Returns <see langword="null"/> when
+    /// the URL is null, empty, or whitespace-only.
+    /// </summary>
+    /// <remarks>
+    /// Used by <c>PrebuiltAppHostServer</c> to compute the per-feed
+    /// <c>globalPackagesFolder</c> subdirectory under
+    /// <c>&lt;ASPIRE_HOME&gt;/.nugetpackages</c>. Keying on the feed URL (rather than the CLI
+    /// commit SHA) means that the same CLI talking to two different override staging feeds
+    /// gets two distinct caches, which is important because staging packages from different
+    /// feeds share the same stable-shaped <c>(id, version)</c> tuple and would otherwise
+    /// collide in NuGet's cache.
+    ///
+    /// The URL is trimmed and lower-cased before hashing so harmless variations (trailing
+    /// whitespace from a config file, hostname casing) don't fragment the cache. Hashing the
+    /// URL with <see cref="XxHash3"/> (non-cryptographic but very high quality) keeps any
+    /// embedded credentials out of the on-disk directory name even when the feed URL itself
+    /// contains them.
+    /// </remarks>
+    internal static string? ComputeStagingFeedCacheKey(string? feedUrl, int length = DefaultStagingFeedCacheKeyLength)
+    {
+        if (string.IsNullOrWhiteSpace(feedUrl) || length <= 0)
+        {
+            return null;
+        }
+
+        var normalized = feedUrl.Trim().ToLowerInvariant();
+        var bytes = Encoding.UTF8.GetBytes(normalized);
+        // XxHash3 emits 8 bytes (64 bits) -> 16 hex chars; truncate to the requested length.
+        var hex = Convert.ToHexString(XxHash3.Hash(bytes)).ToLowerInvariant();
+        return length >= hex.Length ? hex : hex[..length];
     }
 
     internal static string? TryGetAspireHomeDirectoryFromInstallRoute(string? processPath, ILogger? logger = null)

--- a/src/Aspire.Cli/Utils/VersionHelper.cs
+++ b/src/Aspire.Cli/Utils/VersionHelper.cs
@@ -24,7 +24,7 @@ internal static class VersionHelper
     }
 
     /// <summary>
-    /// Finds the candidate that exactly matches the current CLI/SDK version when running against local build channels or hives.
+    /// Finds the candidate that exactly matches the current CLI/SDK version when a channel has already been selected or local hives are present.
     /// </summary>
     public static bool TryGetCurrentCliVersionMatch<T>(
         IEnumerable<T> candidates,
@@ -36,7 +36,7 @@ internal static class VersionHelper
         ArgumentNullException.ThrowIfNull(candidates);
         ArgumentNullException.ThrowIfNull(versionSelector);
 
-        if (!hasPrHives && !IsLocalBuildChannel(channelName))
+        if (!hasPrHives && string.IsNullOrWhiteSpace(channelName))
         {
             match = default;
             return false;

--- a/tests/Aspire.Cli.Tests/Commands/CacheCommandTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/CacheCommandTests.cs
@@ -3,6 +3,7 @@
 
 using Aspire.Cli.Commands;
 using Aspire.Cli.Tests.Utils;
+using Aspire.Cli.Utils;
 using Microsoft.AspNetCore.InternalTesting;
 using Microsoft.Extensions.DependencyInjection;
 
@@ -82,6 +83,61 @@ public class CacheCommandTests(ITestOutputHelper outputHelper)
         Assert.Equal(CliExitCodes.Success, exitCode);
         Assert.False(File.Exists(cacheEntry));
         Assert.False(appHostInfoCacheDir.Exists);
+    }
+
+    [Fact]
+    public async Task CacheClear_ClearsStagingNuGetPackagesCache()
+    {
+        // Pins that `aspire cache clear` wipes the SHA-keyed staging NuGet package caches under
+        // <ASPIRE_HOME>/.nugetpackages — produced by PrebuiltAppHostServer's temporary
+        // nuget.config for the staging channel. Without this, a wedged staging restore can only
+        // be recovered by manual filesystem surgery.
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+
+        var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper);
+        using var provider = services.BuildServiceProvider();
+        var executionContext = provider.GetRequiredService<CliExecutionContext>();
+
+        var stagingCacheRoot = new DirectoryInfo(
+            CliPathHelper.GetStagingNuGetPackagesDirectory(executionContext.AspireHomeDirectory));
+        var firstBuildCache = stagingCacheRoot.CreateSubdirectory("deadbeef").CreateSubdirectory("aspire.hosting").CreateSubdirectory("13.4.0");
+        var secondBuildCache = stagingCacheRoot.CreateSubdirectory("cafef00d").CreateSubdirectory("aspire.hosting").CreateSubdirectory("13.4.0");
+        await File.WriteAllTextAsync(Path.Combine(firstBuildCache.FullName, "Aspire.Hosting.dll"), "fake").DefaultTimeout();
+        await File.WriteAllTextAsync(Path.Combine(secondBuildCache.FullName, "Aspire.Hosting.dll"), "fake").DefaultTimeout();
+
+        var command = provider.GetRequiredService<RootCommand>();
+        var result = command.Parse("cache clear");
+
+        var exitCode = await result.InvokeAsync().DefaultTimeout();
+
+        Assert.Equal(CliExitCodes.Success, exitCode);
+        // SHA-keyed subdirectories should be gone; the parent stays so the next staging restore
+        // can populate a fresh cache without recreating the .nugetpackages root.
+        Assert.False(Directory.Exists(Path.Combine(stagingCacheRoot.FullName, "deadbeef")));
+        Assert.False(Directory.Exists(Path.Combine(stagingCacheRoot.FullName, "cafef00d")));
+    }
+
+    [Fact]
+    public async Task CacheClear_HandlesMissingStagingNuGetPackagesCache()
+    {
+        // Common case for fresh installs and non-staging users: the staging cache root simply
+        // doesn't exist yet. The command must still succeed.
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+
+        var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper);
+        using var provider = services.BuildServiceProvider();
+        var executionContext = provider.GetRequiredService<CliExecutionContext>();
+
+        var stagingCacheRoot = new DirectoryInfo(
+            CliPathHelper.GetStagingNuGetPackagesDirectory(executionContext.AspireHomeDirectory));
+        Assert.False(stagingCacheRoot.Exists);
+
+        var command = provider.GetRequiredService<RootCommand>();
+        var result = command.Parse("cache clear");
+
+        var exitCode = await result.InvokeAsync().DefaultTimeout();
+
+        Assert.Equal(CliExitCodes.Success, exitCode);
     }
 
     [Fact]

--- a/tests/Aspire.Cli.Tests/Commands/NewCommandChannelResolutionTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/NewCommandChannelResolutionTests.cs
@@ -8,6 +8,7 @@ using Aspire.Cli.Projects;
 using Aspire.Cli.Templating;
 using Aspire.Cli.Tests.TestServices;
 using Aspire.Cli.Tests.Utils;
+using Aspire.Cli.Utils;
 using Microsoft.AspNetCore.InternalTesting;
 using Microsoft.Extensions.DependencyInjection;
 using NuGetPackage = Aspire.Shared.NuGetPackageCli;
@@ -115,12 +116,9 @@ public class NewCommandChannelResolutionTests(ITestOutputHelper outputHelper)
     /// <summary>
     /// Channel-resolution contract: when the running CLI's identity is a non-local channel
     /// (daily / staging / stable) and no <c>--channel</c> is passed, <c>aspire new</c> must
-    /// resolve the template version from the channel whose name matches the identity — not
-    /// from the Implicit (nuget.org) channel. Without this, a daily/staging CLI silently
-    /// resolves a stable nuget.org template while the per-project channel pin (written by
-    /// the template factories) still points at the channel-specific feed — yielding an
-    /// inconsistent project that <c>aspire restore</c> rejects with "Unable to find a stable
-    /// package".
+    /// resolve the channel whose name matches the identity — not the Implicit (nuget.org)
+    /// channel — while still pinning the template version to the current CLI/SDK version.
+    /// The bundled server and restored Aspire packages must stay on the same version.
     /// </summary>
     [Theory]
     [InlineData(PackageChannelNames.Daily, "13.4.0-preview.1.99999.1")]
@@ -132,8 +130,20 @@ public class NewCommandChannelResolutionTests(ITestOutputHelper outputHelper)
             channelOptionArg: null,
             identityChannelVersion: identityChannelVersion);
 
-        Assert.Equal(identityChannelVersion, captured.Version);
+        Assert.Equal(VersionHelper.GetDefaultSdkVersion(), captured.Version);
         Assert.Equal(identityChannel, captured.Channel);
+    }
+
+    [Fact]
+    public async Task NewCommand_NoChannelArg_DailyChannelWithoutExactCliVersion_PinsTemplateToCurrentCliVersion()
+    {
+        var captured = await CaptureTemplateInputsAsync(
+            identityChannel: PackageChannelNames.Daily,
+            channelOptionArg: null,
+            identityChannelVersion: "13.5.0-preview.1.99999.1");
+
+        Assert.Equal(VersionHelper.GetDefaultSdkVersion(), captured.Version);
+        Assert.Equal(PackageChannelNames.Daily, captured.Channel);
     }
 
     /// <summary>
@@ -179,8 +189,8 @@ public class NewCommandChannelResolutionTests(ITestOutputHelper outputHelper)
     /// <summary>
     /// Issue #17121 regression guard: a staging-identity CLI should have a registered
     /// staging channel from <c>PackagingService.GetChannelsAsync</c>, so <c>aspire new</c>
-    /// resolves templates from staging instead of falling back to the Implicit NuGet.org
-    /// channel.
+    /// resolves the channel from staging instead of falling back to the Implicit NuGet.org
+    /// channel, while keeping the template version pinned to the current CLI.
     /// </summary>
     [Fact]
     public async Task NewCommand_NoChannelArg_StagingIdentityWithStagingChannelRegistered_ResolvesTemplateFromStaging()
@@ -190,14 +200,15 @@ public class NewCommandChannelResolutionTests(ITestOutputHelper outputHelper)
             channelOptionArg: null,
             identityChannelVersion: "13.4.0-rc.1.99999.1");
 
-        Assert.Equal("13.4.0-rc.1.99999.1", captured.Version);
+        Assert.Equal(VersionHelper.GetDefaultSdkVersion(), captured.Version);
         Assert.Equal(PackageChannelNames.Staging, captured.Channel);
     }
 
     /// <summary>
     /// Explicit <c>--channel</c> must always override the running CLI's identity channel —
     /// so a developer on a daily CLI can still scaffold a stable-channel project for
-    /// reproduction or migration testing.
+    /// reproduction or migration testing. The template version still stays pinned to the
+    /// current CLI so restored Aspire packages match the bundled server.
     /// </summary>
     [Fact]
     public async Task NewCommand_ExplicitChannelArg_OverridesIdentityChannel()
@@ -207,8 +218,29 @@ public class NewCommandChannelResolutionTests(ITestOutputHelper outputHelper)
             channelOptionArg: PackageChannelNames.Stable,
             identityChannelVersion: "13.4.0-preview.1.99999.1");
 
-        Assert.Equal("13.5.0", captured.Version); // stable channel version
+        Assert.Equal(VersionHelper.GetDefaultSdkVersion(), captured.Version);
         Assert.Equal(PackageChannelNames.Stable, captured.Channel);
+    }
+
+    /// <summary>
+    /// A shipped CLI must prefer its own SDK/template version from an explicitly selected
+    /// non-local channel instead of floating to a newer daily/staging package from the same feed.
+    /// </summary>
+    [Theory]
+    [InlineData(PackageChannelNames.Daily)]
+    [InlineData(PackageChannelNames.Staging)]
+    public async Task NewCommand_ExplicitPrereleaseChannel_PrefersCurrentCliVersionWhenAvailable(string channelName)
+    {
+        var cliVersion = VersionHelper.GetDefaultSdkVersion();
+
+        var captured = await CaptureTemplateInputsAsync(
+            identityChannel: channelName,
+            channelOptionArg: channelName,
+            identityChannelVersion: cliVersion,
+            identityChannelVersions: ["99.0.0-preview.1", cliVersion]);
+
+        Assert.Equal(cliVersion, captured.Version);
+        Assert.Equal(channelName, captured.Channel);
     }
 
     /// <summary>
@@ -228,7 +260,8 @@ public class NewCommandChannelResolutionTests(ITestOutputHelper outputHelper)
     private async Task<CapturedTemplateInputs> CaptureTemplateInputsAsync(
         string identityChannel,
         string? channelOptionArg,
-        string? identityChannelVersion)
+        string? identityChannelVersion,
+        IEnumerable<string>? identityChannelVersions = null)
     {
         using var workspace = TemporaryWorkspace.Create(outputHelper);
 
@@ -260,7 +293,7 @@ public class NewCommandChannelResolutionTests(ITestOutputHelper outputHelper)
 
             options.TemplateProviderFactory = _ => new SingleTemplateProvider(fakeTemplate);
 
-            options.PackagingServiceFactory = _ => BuildPackagingService(identityChannel, identityChannelVersion);
+            options.PackagingServiceFactory = _ => BuildPackagingService(identityChannel, identityChannelVersion, identityChannelVersions);
         });
 
         using var serviceProvider = services.BuildServiceProvider();
@@ -280,8 +313,14 @@ public class NewCommandChannelResolutionTests(ITestOutputHelper outputHelper)
     /// pr-* explicit channels), but with deterministic per-channel template versions so
     /// tests can identify which channel won resolution.
     /// </summary>
-    private static IPackagingService BuildPackagingService(string identityChannel, string? identityChannelVersion)
+    private static IPackagingService BuildPackagingService(
+        string identityChannel,
+        string? identityChannelVersion,
+        IEnumerable<string>? identityChannelVersions)
     {
+        var identityVersions = identityChannelVersions?.ToArray()
+            ?? (identityChannelVersion is null ? [] : [identityChannelVersion]);
+
         // Implicit channel always returns the stable token so a "fell-through to Implicit"
         // outcome is distinguishable from an identity-channel pickup.
         var implicitCache = new FakeNuGetPackageCache
@@ -313,7 +352,7 @@ public class NewCommandChannelResolutionTests(ITestOutputHelper outputHelper)
         // Register a non-stable explicit channel matching the identity, when the test
         // scenario calls for it. Deliberately omitted in the "identity not registered"
         // case so fallback to Implicit can be observed.
-        var isDailyOrStaging = identityChannelVersion is not null &&
+        var isDailyOrStaging = identityVersions.Length > 0 &&
             !string.Equals(identityChannel, PackageChannelNames.Stable, StringComparison.OrdinalIgnoreCase) &&
             !identityChannel.StartsWith("pr-", StringComparison.OrdinalIgnoreCase);
         if (isDailyOrStaging)
@@ -322,7 +361,7 @@ public class NewCommandChannelResolutionTests(ITestOutputHelper outputHelper)
             {
                 GetTemplatePackagesAsyncCallback = (_, _, _, _) =>
                     Task.FromResult<IEnumerable<NuGetPackage>>(
-                        [new NuGetPackage { Id = "Aspire.ProjectTemplates", Source = "nuget", Version = identityChannelVersion! }])
+                        identityVersions.Select(version => new NuGetPackage { Id = "Aspire.ProjectTemplates", Source = "nuget", Version = version }))
             };
             channels.Add(PackageChannel.CreateExplicitChannel(
                 identityChannel,

--- a/tests/Aspire.Cli.Tests/Commands/NewCommandChannelResolutionTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/NewCommandChannelResolutionTests.cs
@@ -117,20 +117,22 @@ public class NewCommandChannelResolutionTests(ITestOutputHelper outputHelper)
     /// Channel-resolution contract: when the running CLI's identity is a non-local channel
     /// (daily / staging / stable) and no <c>--channel</c> is passed, <c>aspire new</c> must
     /// resolve the channel whose name matches the identity — not the Implicit (nuget.org)
-    /// channel — while still pinning the template version to the current CLI/SDK version.
-    /// The bundled server and restored Aspire packages must stay on the same version.
+    /// channel. Prerelease identities (daily/staging) further pin the template version to the
+    /// current CLI/SDK so the bundled server and restored Aspire packages stay on the same
+    /// version; the stable identity falls through to the highest shipped stable package because
+    /// the stable feed doesn't filter the running CLI's version out of search.
     /// </summary>
     [Theory]
-    [InlineData(PackageChannelNames.Daily, "13.4.0-preview.1.99999.1")]
-    [InlineData(PackageChannelNames.Stable, "13.5.0")]
-    public async Task NewCommand_NoChannelArg_ResolvesTemplateFromIdentityChannel(string identityChannel, string identityChannelVersion)
+    [InlineData(PackageChannelNames.Daily, "13.4.0-preview.1.99999.1", null)]
+    [InlineData(PackageChannelNames.Stable, "13.5.0", "13.5.0")]
+    public async Task NewCommand_NoChannelArg_ResolvesTemplateFromIdentityChannel(string identityChannel, string identityChannelVersion, string? expectedVersion)
     {
         var captured = await CaptureTemplateInputsAsync(
             identityChannel: identityChannel,
             channelOptionArg: null,
             identityChannelVersion: identityChannelVersion);
 
-        Assert.Equal(VersionHelper.GetDefaultSdkVersion(), captured.Version);
+        Assert.Equal(expectedVersion ?? VersionHelper.GetDefaultSdkVersion(), captured.Version);
         Assert.Equal(identityChannel, captured.Channel);
     }
 
@@ -205,10 +207,13 @@ public class NewCommandChannelResolutionTests(ITestOutputHelper outputHelper)
     }
 
     /// <summary>
-    /// Explicit <c>--channel</c> must always override the running CLI's identity channel —
-    /// so a developer on a daily CLI can still scaffold a stable-channel project for
-    /// reproduction or migration testing. The template version still stays pinned to the
-    /// current CLI so restored Aspire packages match the bundled server.
+    /// Explicit <c>--channel stable</c> must always override the running CLI's identity channel —
+    /// so a developer on a daily CLI can still scaffold a stable-channel project for reproduction
+    /// or migration testing. When the CLI's own version is not published on the stable feed
+    /// (a daily-shape or PR-shape build), the resolver falls through to the highest shipped stable
+    /// package rather than forcing the unpublishable CLI version into the generated apphost.
+    /// Pinning to the current CLI version is reserved for prerelease channels — see
+    /// <see cref="NewCommand_ExplicitPrereleaseChannel_PrefersCurrentCliVersionWhenAvailable"/>.
     /// </summary>
     [Fact]
     public async Task NewCommand_ExplicitChannelArg_OverridesIdentityChannel()
@@ -218,7 +223,8 @@ public class NewCommandChannelResolutionTests(ITestOutputHelper outputHelper)
             channelOptionArg: PackageChannelNames.Stable,
             identityChannelVersion: "13.4.0-preview.1.99999.1");
 
-        Assert.Equal(VersionHelper.GetDefaultSdkVersion(), captured.Version);
+        // Highest shipped stable from the stable channel feed in the test fixture.
+        Assert.Equal("13.5.0", captured.Version);
         Assert.Equal(PackageChannelNames.Stable, captured.Channel);
     }
 
@@ -241,6 +247,28 @@ public class NewCommandChannelResolutionTests(ITestOutputHelper outputHelper)
 
         Assert.Equal(cliVersion, captured.Version);
         Assert.Equal(channelName, captured.Channel);
+    }
+
+    /// <summary>
+    /// SmokeTest regression guard: when a non-stable-shape CLI (PR build, daily-shape preview, etc.)
+    /// is invoked with <c>--channel stable</c>, the resolver must NOT pin the template to the
+    /// running CLI's version. The CLI's own version is not published on the stable feed, so a
+    /// generated <c>apphost.cs</c> referencing it would fail NuGet restore. The fallback that pins
+    /// to the current CLI version is reserved for prerelease channels (daily, staging) where the
+    /// feed search filter is what hides the otherwise-restorable shipped stable package.
+    /// </summary>
+    [Theory]
+    [InlineData("13.4.0-preview.1.99999.1")] // daily-shape CLI
+    [InlineData("13.4.0-pr.17573.gabc1234")] // PR-shape CLI (e2e SmokeTests scenario)
+    public async Task NewCommand_ExplicitStableChannel_NonStableCliVersion_FallsBackToHighestShippedStable(string identityChannelVersion)
+    {
+        var captured = await CaptureTemplateInputsAsync(
+            identityChannel: PackageChannelNames.Daily,
+            channelOptionArg: PackageChannelNames.Stable,
+            identityChannelVersion: identityChannelVersion);
+
+        Assert.Equal("13.5.0", captured.Version);
+        Assert.Equal(PackageChannelNames.Stable, captured.Channel);
     }
 
     /// <summary>

--- a/tests/Aspire.Cli.Tests/Commands/NewCommandTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/NewCommandTests.cs
@@ -1609,7 +1609,7 @@ public class NewCommandTests(ITestOutputHelper outputHelper)
 
         var exitCode = await result.InvokeAsync().DefaultTimeout();
         Assert.Equal(CliExitCodes.Success, exitCode);
-        Assert.Equal("9.2.0", scaffoldSdkVersion);
+        Assert.Equal(VersionHelper.GetDefaultSdkVersion(), scaffoldSdkVersion);
         Assert.Equal("stable", scaffoldChannel);
     }
 
@@ -1810,7 +1810,7 @@ public class NewCommandTests(ITestOutputHelper outputHelper)
         Assert.Equal(CliExitCodes.Success, exitCode);
         Assert.True(buildAndGenerateCalled);
         Assert.Equal("daily", channelSeenByProject);
-        Assert.Equal("9.2.0", sdkVersionSeenByProject);
+        Assert.Equal(VersionHelper.GetDefaultSdkVersion(), sdkVersionSeenByProject);
         Assert.True(File.Exists(Path.Combine(workspace.WorkspaceRoot.FullName, "output", LanguageInfo.GeneratedFolderName, "aspire.mts")));
     }
 

--- a/tests/Aspire.Cli.Tests/Commands/NewCommandTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/NewCommandTests.cs
@@ -1609,7 +1609,7 @@ public class NewCommandTests(ITestOutputHelper outputHelper)
 
         var exitCode = await result.InvokeAsync().DefaultTimeout();
         Assert.Equal(CliExitCodes.Success, exitCode);
-        Assert.Equal(VersionHelper.GetDefaultSdkVersion(), scaffoldSdkVersion);
+        Assert.Equal("9.2.0", scaffoldSdkVersion);
         Assert.Equal("stable", scaffoldChannel);
     }
 

--- a/tests/Aspire.Cli.Tests/Packaging/PackagingServiceTests.cs
+++ b/tests/Aspire.Cli.Tests/Packaging/PackagingServiceTests.cs
@@ -65,7 +65,7 @@ public class PackagingServiceTests(ITestOutputHelper outputHelper)
                 [PackagingService.OverrideStagingFeedConfigKey] = "https://example.com/nuget/v3/index.json"
             })
             .Build();
-        var packagingService = new PackagingService(executionContext, new FakeNuGetPackageCache(), new TestFeatures(), configuration, NullLogger<PackagingService>.Instance);
+        var packagingService = new PackagingService(executionContext, new FakeNuGetPackageCache(), new TestFeatures(), configuration, NullLogger<PackagingService>.Instance, isStableShapedCliVersion: () => false);
 
         var channels = await packagingService.GetChannelsAsync().DefaultTimeout();
 
@@ -80,6 +80,35 @@ public class PackagingServiceTests(ITestOutputHelper outputHelper)
 
         var stagingChannel = channels.First(c => c.Name == PackageChannelNames.Staging);
         Assert.Equal(PackageChannelQuality.Both, stagingChannel.Quality);
+    }
+
+    [Fact]
+    public async Task GetChannelsAsync_WhenIdentityChannelIsStagingOnStableShapedCli_DefaultsToStableQuality()
+    {
+        // Regression test for https://github.com/microsoft/aspire/issues/17527: during release
+        // stabilization the staging CLI ships with a stable-shaped version (e.g. "13.4.0"). The
+        // shared dotnet9 daily feed only carries prerelease-tagged 13.4.0-preview.* packages,
+        // so a stabilizing staging CLI must route Aspire.* to the SHA-derived darc-pub-aspire-<hash>
+        // feed instead — which requires defaulting the synthesized staging channel quality to
+        // Stable (so useSharedFeed in CreateStagingChannel resolves false).
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        var tempDir = workspace.WorkspaceRoot;
+        var hivesDir = new DirectoryInfo(Path.Combine(tempDir.FullName, ".aspire", "hives"));
+        var cacheDir = new DirectoryInfo(Path.Combine(tempDir.FullName, ".aspire", "cache"));
+        var executionContext = new CliExecutionContext(tempDir, hivesDir, cacheDir, new DirectoryInfo(Path.Combine(Path.GetTempPath(), "aspire-test-runtimes")), new DirectoryInfo(Path.Combine(Path.GetTempPath(), "aspire-test-logs")), "test.log", identityChannel: PackageChannelNames.Staging);
+
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                [PackagingService.OverrideStagingFeedConfigKey] = "https://example.com/nuget/v3/index.json"
+            })
+            .Build();
+        var packagingService = new PackagingService(executionContext, new FakeNuGetPackageCache(), new TestFeatures(), configuration, NullLogger<PackagingService>.Instance, isStableShapedCliVersion: () => true);
+
+        var channels = await packagingService.GetChannelsAsync().DefaultTimeout();
+
+        var stagingChannel = channels.First(c => c.Name == PackageChannelNames.Staging);
+        Assert.Equal(PackageChannelQuality.Stable, stagingChannel.Quality);
     }
 
     [Fact]

--- a/tests/Aspire.Cli.Tests/Packaging/TemporaryNuGetConfigTests.cs
+++ b/tests/Aspire.Cli.Tests/Packaging/TemporaryNuGetConfigTests.cs
@@ -125,6 +125,45 @@ public class TemporaryNuGetConfigTests
         Assert.Equal(".nugetpackages", globalPackagesFolder!.Attributes!["value"]!.Value);
     }
 
+    [Fact]
+    public async Task CreateAsync_WithExplicitGlobalPackagesFolderOverride_UsesOverrideValue()
+    {
+        // Callers that need the cache to outlive the temp config (e.g. PrebuiltAppHostServer's
+        // staging path) supply an absolute, persistent path so BundleNuGetService manifest paths
+        // remain valid after TemporaryNuGetConfig.Dispose deletes the temp directory.
+        var overrideValue = Path.Combine(Path.GetTempPath(), "aspire-tests", "stable-cache", "deadbeef");
+
+        using var tempConfig = await TemporaryNuGetConfig.CreateAsync(
+            [new PackageMapping("Aspire.*", "https://example.com/feed")],
+            configureGlobalPackagesFolder: true,
+            globalPackagesFolderValue: overrideValue);
+
+        var configContent = await File.ReadAllTextAsync(tempConfig.ConfigFile.FullName);
+        var xmlDoc = new XmlDocument();
+        xmlDoc.LoadXml(configContent);
+
+        var globalPackagesFolder = xmlDoc.SelectSingleNode("//config/add[@key='globalPackagesFolder']");
+        Assert.NotNull(globalPackagesFolder);
+        Assert.Equal(overrideValue, globalPackagesFolder!.Attributes!["value"]!.Value);
+    }
+
+    [Fact]
+    public async Task CreateAsync_WithoutConfiguredGlobalPackagesFolder_IgnoresOverride()
+    {
+        // When configureGlobalPackagesFolder is false the override is irrelevant — no
+        // <config><add key="globalPackagesFolder"/> element should be emitted at all.
+        using var tempConfig = await TemporaryNuGetConfig.CreateAsync(
+            [new PackageMapping("Aspire.*", "https://example.com/feed")],
+            configureGlobalPackagesFolder: false,
+            globalPackagesFolderValue: "/should/not/appear");
+
+        var configContent = await File.ReadAllTextAsync(tempConfig.ConfigFile.FullName);
+        var xmlDoc = new XmlDocument();
+        xmlDoc.LoadXml(configContent);
+
+        Assert.Null(xmlDoc.SelectSingleNode("//config/add[@key='globalPackagesFolder']"));
+    }
+
     [Theory]
     [InlineData("https://example.com/feed")]
     [InlineData("/var/folders/X/hives/pr-17105/packages")]

--- a/tests/Aspire.Cli.Tests/Projects/PrebuiltAppHostServerTests.cs
+++ b/tests/Aspire.Cli.Tests/Projects/PrebuiltAppHostServerTests.cs
@@ -11,8 +11,10 @@ using Aspire.Cli.Projects;
 using Aspire.Cli.Tests.Mcp;
 using Aspire.Cli.Tests.TestServices;
 using Aspire.Cli.Tests.Utils;
+using Aspire.Cli.Utils;
 using Aspire.Hosting;
 using Aspire.Shared;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging.Abstractions;
 
 namespace Aspire.Cli.Tests.Projects;
@@ -418,13 +420,18 @@ public class PrebuiltAppHostServerTests(ITestOutputHelper outputHelper)
     {
         // Pins the rubber-duck finding: dropping the temp config also drops the staging-specific
         // global packages folder. The emitted nuget.config must contain a <config> element with a
-        // globalPackagesFolder setting when the channel was built with configureGlobalPackagesFolder.
+        // globalPackagesFolder setting when the channel was built with configureGlobalPackagesFolder,
+        // AND the value must be an absolute path that lives outside the temp config's own directory
+        // so the cached packages survive the temp config's recursive cleanup (otherwise restore
+        // hands BundleNuGetService manifest paths that the temp dispose just deleted, hanging
+        // aspire-managed during DI / assembly loading on macOS osx-arm64 polyglot staging builds).
         using var workspace = TemporaryWorkspace.Create(outputHelper);
 
         var executionContext = CreateContextWithIdentityChannel("local");
+        const string channelSource = "https://pkgs.dev.azure.com/fake/v3/index.json";
         var mappings = new[]
         {
-            new PackageMapping(PackageMapping.AllPackages, "https://pkgs.dev.azure.com/fake/v3/index.json")
+            new PackageMapping(PackageMapping.AllPackages, channelSource)
         };
         var stagingChannel = PackageChannel.CreateExplicitChannel(
             name: "staging",
@@ -443,7 +450,81 @@ public class PrebuiltAppHostServerTests(ITestOutputHelper outputHelper)
             .SelectMany(c => c.Elements("add"))
             .FirstOrDefault(a => string.Equals(a.Attribute("key")?.Value, "globalPackagesFolder", StringComparison.OrdinalIgnoreCase));
         Assert.NotNull(gpf);
-        Assert.False(string.IsNullOrEmpty(gpf.Attribute("value")?.Value));
+        var gpfValue = gpf.Attribute("value")?.Value;
+        Assert.False(string.IsNullOrEmpty(gpfValue));
+        Assert.True(Path.IsPathFullyQualified(gpfValue), $"globalPackagesFolder value must be an absolute path. Got: {gpfValue}");
+        // The temp config directory is recursively deleted on dispose; the cache must live elsewhere
+        // so manifest paths produced by BundleNuGetService remain valid for the AppHost's lifetime.
+        var tempConfigDir = result.ConfigFile.Directory!.FullName;
+        Assert.False(
+            gpfValue!.StartsWith(tempConfigDir, StringComparison.Ordinal),
+            $"globalPackagesFolder must not be under the temp nuget.config dir '{tempConfigDir}'. Got: {gpfValue}");
+        // The cache subdirectory must be keyed by the resolved feed URL so two different staging
+        // feeds (e.g. two darc builds or an overrideStagingFeed setting) get distinct caches.
+        var expectedCacheKey = CliPathHelper.ComputeStagingFeedCacheKey(channelSource);
+        Assert.NotNull(expectedCacheKey);
+        var expectedCachePath = Path.Combine(
+            CliPathHelper.GetStagingNuGetPackagesDirectory(executionContext.AspireHomeDirectory),
+            expectedCacheKey);
+        Assert.Equal(expectedCachePath, gpfValue);
+    }
+
+    [Fact]
+    public async Task TryCreateTemporaryNuGetConfig_StagingRequested_FromRealPackagingService_EmitsStableGlobalPackagesFolderOutsideTempDir()
+    {
+        // End-to-end pin for the staging temp-config hang fix: when the real PackagingService
+        // synthesizes the staging channel (here driven by overrideStagingFeed on a stable-shaped
+        // CLI so configureGlobalPackagesFolder lands true), the temporary nuget.config used by
+        // PrebuiltAppHostServer must point globalPackagesFolder at an absolute path that survives
+        // the TemporaryNuGetConfig.Dispose recursive delete. Otherwise BundleNuGetService restores
+        // staging assemblies into <temp>/.nugetpackages, bakes those paths into
+        // integration-package-probe-manifest.json, and aspire-managed hangs in DI/assembly loading
+        // when it later probes the (now deleted) paths — observed on macOS osx-arm64.
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+
+        const string overrideStagingFeed = "https://pkgs.dev.azure.com/dnceng/internal/_packaging/darc-pub-microsoft-aspire-deadbeef/nuget/v3/index.json";
+        var executionContext = TestExecutionContextHelper.CreateExecutionContext(
+            workspace,
+            identityChannel: PackageChannelNames.Staging);
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                [PackagingService.OverrideStagingFeedConfigKey] = overrideStagingFeed
+            })
+            .Build();
+        var packagingService = new PackagingService(
+            executionContext,
+            new FakeNuGetPackageCache(),
+            new TestFeatures(),
+            configuration,
+            NullLogger<PackagingService>.Instance,
+            isStableShapedCliVersion: () => true);
+
+        var server = CreateServerWithPackagingService(workspace, packagingService, executionContext);
+
+        using var result = await InvokeTryCreateTemporaryNuGetConfigAsync(server, PackageChannelNames.Staging);
+
+        Assert.NotNull(result);
+        var doc = XDocument.Load(result.ConfigFile.FullName);
+        var gpf = doc.Descendants("config")
+            .SelectMany(c => c.Elements("add"))
+            .FirstOrDefault(a => string.Equals(a.Attribute("key")?.Value, "globalPackagesFolder", StringComparison.OrdinalIgnoreCase));
+        Assert.NotNull(gpf);
+        var gpfValue = gpf.Attribute("value")?.Value;
+        Assert.False(string.IsNullOrEmpty(gpfValue));
+        Assert.True(Path.IsPathFullyQualified(gpfValue), $"globalPackagesFolder value must be an absolute path. Got: {gpfValue}");
+        var tempConfigDir = result.ConfigFile.Directory!.FullName;
+        Assert.False(
+            gpfValue!.StartsWith(tempConfigDir, StringComparison.Ordinal),
+            $"globalPackagesFolder must not be under the temp nuget.config dir '{tempConfigDir}'. Got: {gpfValue}");
+        // The cache key is derived from the resolved staging feed URL so the same CLI talking to
+        // a different overrideStagingFeed gets a different cache bucket.
+        var expectedCacheKey = CliPathHelper.ComputeStagingFeedCacheKey(overrideStagingFeed);
+        Assert.NotNull(expectedCacheKey);
+        var expectedCachePath = Path.Combine(
+            CliPathHelper.GetStagingNuGetPackagesDirectory(executionContext.AspireHomeDirectory),
+            expectedCacheKey);
+        Assert.Equal(expectedCachePath, gpfValue);
     }
 
     [Theory]
@@ -532,7 +613,8 @@ public class PrebuiltAppHostServerTests(ITestOutputHelper outputHelper)
             nuGetPackageCache: new FakeNuGetPackageCache(),
             features: new TestFeatures(),
             configureGlobalPackagesFolder: true);
-        var server = CreateServerWithChannel(workspace, stagingChannel, CreateContextWithIdentityChannel("pr-12345"));
+        var executionContext = CreateContextWithIdentityChannel("pr-12345");
+        var server = CreateServerWithChannel(workspace, stagingChannel, executionContext);
 
         using var result = await InvokeTryCreateTemporaryNuGetConfigAsync(
             server,
@@ -544,9 +626,27 @@ public class PrebuiltAppHostServerTests(ITestOutputHelper outputHelper)
         Assert.Equal(["Aspire*"], GetPackagePatternsForSource(doc, packageSourceOverride));
         Assert.Equal(["CommunityToolkit*"], GetPackagePatternsForSource(doc, channelSource));
         Assert.Equal([PackageMapping.AllPackages], GetPackagePatternsForSource(doc, NuGetOrgSource));
-        Assert.NotNull(doc.Descendants("config")
+        var gpf = doc.Descendants("config")
             .SelectMany(c => c.Elements("add"))
-            .FirstOrDefault(a => string.Equals(a.Attribute("key")?.Value, "globalPackagesFolder", StringComparison.OrdinalIgnoreCase)));
+            .FirstOrDefault(a => string.Equals(a.Attribute("key")?.Value, "globalPackagesFolder", StringComparison.OrdinalIgnoreCase));
+        Assert.NotNull(gpf);
+        // Same stability requirement as the channel-only branch: the override path must outlive
+        // the temp nuget.config so BundleNuGetService's manifest paths remain valid after dispose.
+        var gpfValue = gpf.Attribute("value")?.Value;
+        Assert.False(string.IsNullOrEmpty(gpfValue));
+        Assert.True(Path.IsPathFullyQualified(gpfValue), $"globalPackagesFolder value must be an absolute path. Got: {gpfValue}");
+        var tempConfigDir = result.ConfigFile.Directory!.FullName;
+        Assert.False(
+            gpfValue!.StartsWith(tempConfigDir, StringComparison.Ordinal),
+            $"globalPackagesFolder must not be under the temp nuget.config dir '{tempConfigDir}'. Got: {gpfValue}");
+        // The cache key is derived from the --source override, not the channel's own mappings,
+        // so users running multiple overrides against the same CLI get distinct cache buckets.
+        var expectedCacheKey = CliPathHelper.ComputeStagingFeedCacheKey(packageSourceOverride);
+        Assert.NotNull(expectedCacheKey);
+        var expectedCachePath = Path.Combine(
+            CliPathHelper.GetStagingNuGetPackagesDirectory(executionContext.AspireHomeDirectory),
+            expectedCacheKey);
+        Assert.Equal(expectedCachePath, gpfValue);
     }
 
     [Fact]

--- a/tests/Aspire.Cli.Tests/Templating/TemplateNuGetConfigServiceTests.cs
+++ b/tests/Aspire.Cli.Tests/Templating/TemplateNuGetConfigServiceTests.cs
@@ -212,11 +212,15 @@ public class TemplateNuGetConfigServiceTests(ITestOutputHelper outputHelper)
     }
 
     [Fact]
-    public async Task ResolveTemplatePackageAsync_NullRequestedChannel_UsesImplicitChannelOnly()
+    public async Task ResolveTemplatePackageAsync_NullRequestedChannel_NoIdentityChannelMatch_UsesImplicitChannelOnly()
     {
-        // No explicit RequestedChannel: the resolver picks the implicit channel only.
-        // We exercise the production codepath with a tracking packaging service so the
-        // assertion is that the resolver completes (no exception is thrown by
+        // No explicit RequestedChannel and the identity channel ("local") does not match any
+        // registered Explicit channel: the resolver falls back to the implicit channel only.
+        // This is the preserved-behavior path from before
+        // https://github.com/microsoft/aspire/issues/17596 — a "local" CLI without a matching
+        // local-build hive must not silently route DotNet templates through a stable feed
+        // it doesn't recognize. We exercise the production codepath with a tracking packaging
+        // service so the assertion is that the resolver completes (no exception is thrown by
         // an unexpected channel-lookup path) and only the implicit channel is in play.
         var requestedChannels = new List<PackageChannelType>();
         var packagingService = new TestPackagingService
@@ -245,6 +249,63 @@ public class TemplateNuGetConfigServiceTests(ITestOutputHelper outputHelper)
         // surfaces (not ChannelNotFoundException from a different lookup path).
         await Assert.ThrowsAsync<Aspire.Cli.Interaction.EmptyChoicesException>(
             async () => await service.ResolveTemplatePackageAsync(query, CancellationToken.None));
+    }
+
+    [Fact]
+    public async Task ResolveTemplatePackageAsync_NullRequestedChannel_PrefersIdentityChannelMatch()
+    {
+        // Regression test for https://github.com/microsoft/aspire/issues/17596: a daily CLI
+        // running `aspire new` for a DotNet template (e.g. C# Blazor) with no --channel flag
+        // and an empty ~/.aspire must resolve Aspire.ProjectTemplates from the daily channel,
+        // not from the implicit nuget.org channel. Previously this path restricted the search
+        // to the implicit channel only, so the latest shipped stable (e.g. 13.3.5) would mask
+        // the daily prerelease (e.g. 13.5.0-preview.1.*) that the matching CLI needs.
+        var packagingService = new TestPackagingService
+        {
+            GetChannelsAsyncCallback = _ =>
+            {
+                var implicitCh = PackageChannel.CreateImplicitChannel(new FakeNuGetPackageCache
+                {
+                    GetTemplatePackagesAsyncCallback = (_, _, _, _) => Task.FromResult<IEnumerable<Aspire.Shared.NuGetPackageCli>>(
+                    [
+                        new Aspire.Shared.NuGetPackageCli { Id = TemplateNuGetConfigService.TemplatesPackageName, Version = "13.3.5", Source = "nuget.org" }
+                    ])
+                }, new TestFeatures());
+                var dailyCh = PackageChannel.CreateExplicitChannel(
+                    "daily",
+                    PackageChannelQuality.Prerelease,
+                    [new PackageMapping("Aspire*", "daily-src")],
+                    new FakeNuGetPackageCache
+                    {
+                        GetTemplatePackagesAsyncCallback = (_, _, _, _) => Task.FromResult<IEnumerable<Aspire.Shared.NuGetPackageCli>>(
+                        [
+                            new Aspire.Shared.NuGetPackageCli { Id = TemplateNuGetConfigService.TemplatesPackageName, Version = "13.5.0-preview.1.26277.21", Source = "daily-src" }
+                        ])
+                    },
+                    features: new TestFeatures());
+                return Task.FromResult<IEnumerable<PackageChannel>>([implicitCh, dailyCh]);
+            }
+        };
+
+        var executionContext = TestExecutionContextHelper.CreateExecutionContext(
+            rootDirectory: new DirectoryInfo(Path.GetTempPath()),
+            identityChannel: "daily");
+
+        var service = CreateService(packagingService: packagingService, executionContext: executionContext);
+
+        var query = new TemplatePackageQuery(
+            RequestedChannel: null,
+            VersionOverride: null,
+            SourceOverride: null,
+            IncludePrHives: false);
+
+        var selection = await service.ResolveTemplatePackageAsync(query, CancellationToken.None);
+
+        // The daily channel must be selected (matches identity) and its prerelease package
+        // returned — not the stable 13.3.5 from the implicit channel.
+        Assert.Equal("daily", selection.Channel.Name);
+        Assert.Equal(PackageChannelType.Explicit, selection.Channel.Type);
+        Assert.Equal("13.5.0-preview.1.26277.21", selection.Package.Version);
     }
 
     [Fact]

--- a/tests/Aspire.Cli.Tests/Utils/CliPathHelperTests.cs
+++ b/tests/Aspire.Cli.Tests/Utils/CliPathHelperTests.cs
@@ -55,6 +55,94 @@ public class CliPathHelperTests(ITestOutputHelper outputHelper)
     }
 
     [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    [InlineData("\t\n")]
+    public void ComputeStagingFeedCacheKey_ReturnsNull_ForNullOrWhitespace(string? feedUrl)
+    {
+        Assert.Null(CliPathHelper.ComputeStagingFeedCacheKey(feedUrl));
+    }
+
+    [Fact]
+    public void ComputeStagingFeedCacheKey_DefaultsToEightLowercaseHexChars()
+    {
+        var key = CliPathHelper.ComputeStagingFeedCacheKey("https://pkgs.dev.azure.com/dnceng/public/_packaging/darc-pub-microsoft-aspire-deadbeef/nuget/v3/index.json");
+
+        Assert.NotNull(key);
+        Assert.Matches("^[0-9a-f]{8}$", key);
+    }
+
+    [Fact]
+    public void ComputeStagingFeedCacheKey_IsDeterministic_ForSameInput()
+    {
+        const string feedUrl = "https://pkgs.dev.azure.com/dnceng/public/_packaging/darc-pub-microsoft-aspire-deadbeef/nuget/v3/index.json";
+
+        var first = CliPathHelper.ComputeStagingFeedCacheKey(feedUrl);
+        var second = CliPathHelper.ComputeStagingFeedCacheKey(feedUrl);
+
+        Assert.Equal(first, second);
+    }
+
+    [Fact]
+    public void ComputeStagingFeedCacheKey_DifferentUrls_ProduceDifferentKeys()
+    {
+        var a = CliPathHelper.ComputeStagingFeedCacheKey("https://pkgs.dev.azure.com/dnceng/public/_packaging/darc-pub-microsoft-aspire-deadbeef/nuget/v3/index.json");
+        var b = CliPathHelper.ComputeStagingFeedCacheKey("https://pkgs.dev.azure.com/dnceng/public/_packaging/darc-pub-microsoft-aspire-cafef00d/nuget/v3/index.json");
+
+        Assert.NotEqual(a, b);
+    }
+
+    [Fact]
+    public void ComputeStagingFeedCacheKey_NormalizesWhitespaceAndCasing()
+    {
+        // Trim + lowercase normalization keeps the cache from fragmenting when the same feed
+        // shows up with stray whitespace from a config file or with a mixed-case hostname.
+        const string baseUrl = "https://pkgs.dev.azure.com/dnceng/public/_packaging/darc-pub-microsoft-aspire-deadbeef/nuget/v3/index.json";
+
+        var baseKey = CliPathHelper.ComputeStagingFeedCacheKey(baseUrl);
+        var spacedKey = CliPathHelper.ComputeStagingFeedCacheKey("  " + baseUrl + "\t\n");
+        var upperKey = CliPathHelper.ComputeStagingFeedCacheKey(baseUrl.ToUpperInvariant());
+
+        Assert.Equal(baseKey, spacedKey);
+        Assert.Equal(baseKey, upperKey);
+    }
+
+    [Theory]
+    [InlineData(1)]
+    [InlineData(4)]
+    [InlineData(16)]
+    public void ComputeStagingFeedCacheKey_RespectsExplicitLength(int length)
+    {
+        var key = CliPathHelper.ComputeStagingFeedCacheKey(
+            "https://pkgs.dev.azure.com/dnceng/public/_packaging/darc-pub-microsoft-aspire-deadbeef/nuget/v3/index.json",
+            length);
+
+        Assert.NotNull(key);
+        Assert.Equal(length, key.Length);
+        Assert.Matches($"^[0-9a-f]{{{length}}}$", key);
+    }
+
+    [Fact]
+    public void ComputeStagingFeedCacheKey_LengthAboveHashWidth_ReturnsFullHash()
+    {
+        // XxHash3 is 64 bits -> 16 hex chars. Asking for more than 16 must not crash and must
+        // return all available hash chars rather than padding with garbage.
+        var key = CliPathHelper.ComputeStagingFeedCacheKey("https://example/index.json", length: 999);
+
+        Assert.NotNull(key);
+        Assert.Equal(16, key.Length);
+        Assert.Matches("^[0-9a-f]{16}$", key);
+    }
+
+    [Fact]
+    public void ComputeStagingFeedCacheKey_NonZeroLength_RejectsZeroOrNegative()
+    {
+        Assert.Null(CliPathHelper.ComputeStagingFeedCacheKey("https://example/index.json", length: 0));
+        Assert.Null(CliPathHelper.ComputeStagingFeedCacheKey("https://example/index.json", length: -1));
+    }
+
+    [Theory]
     [InlineData("script")]
     [InlineData("localhive")]
     public void TryGetAspireHomeDirectoryFromInstallRoute_SharedPrefixRoute_ReturnsInstallPrefix(string source)

--- a/tests/Aspire.Cli.Tests/Utils/CliTestHelper.cs
+++ b/tests/Aspire.Cli.Tests/Utils/CliTestHelper.cs
@@ -576,7 +576,14 @@ internal sealed class CliServiceCollectionTestOptions
         var nuGetPackageCache = serviceProvider.GetRequiredService<INuGetPackageCache>();
         var features = serviceProvider.GetRequiredService<IFeatures>();
         var configuration = serviceProvider.GetRequiredService<IConfiguration>();
-        return new PackagingService(executionContext, nuGetPackageCache, features, configuration, NullLogger<PackagingService>.Instance);
+        // Force prerelease-shaped CLI version semantics in tests so PackagingService's
+        // identity-staging quality default does not depend on whether the test-host assembly
+        // was produced under StabilizePackageVersion=true. Without this, tests that rely on
+        // the shared-daily routing for `staging` identity (quality=Both → useSharedFeed=true)
+        // would fail under the stabilization-check job which builds with a stable-shaped
+        // version (no '-' suffix) baked in. Tests that specifically exercise the stable-shape
+        // branch construct PackagingService directly with isStableShapedCliVersion: () => true.
+        return new PackagingService(executionContext, nuGetPackageCache, features, configuration, NullLogger<PackagingService>.Instance, isStableShapedCliVersion: () => false);
     };
 
     public Func<IServiceProvider, IDiskCache> DiskCacheFactory { get; set; } = (IServiceProvider serviceProvider) => new NullDiskCache();

--- a/tests/Aspire.Cli.Tests/Utils/VersionHelperTests.cs
+++ b/tests/Aspire.Cli.Tests/Utils/VersionHelperTests.cs
@@ -29,6 +29,71 @@ public class VersionHelperTests
     }
 
     [Theory]
+    [InlineData("daily")]
+    [InlineData("staging")]
+    [InlineData("stable")]
+    public void TryGetCurrentCliVersionMatch_WithNamedChannel_ReturnsCurrentCliVersion(string channelName)
+    {
+        var cliVersion = VersionHelper.GetDefaultSdkVersion();
+        var candidates = new[]
+        {
+            "99.0.0",
+            cliVersion,
+        };
+
+        var result = VersionHelper.TryGetCurrentCliVersionMatch(
+            candidates,
+            version => version,
+            out var match,
+            channelName: channelName,
+            hasPrHives: false);
+
+        Assert.True(result);
+        Assert.Equal(cliVersion, match);
+    }
+
+    [Fact]
+    public void TryGetCurrentCliVersionMatch_WithNamedChannelAndNoExactMatch_ReturnsFalse()
+    {
+        var candidates = new[]
+        {
+            "99.0.0",
+            "98.0.0",
+        };
+
+        var result = VersionHelper.TryGetCurrentCliVersionMatch(
+            candidates,
+            version => version,
+            out var match,
+            channelName: "daily",
+            hasPrHives: false);
+
+        Assert.False(result);
+        Assert.Null(match);
+    }
+
+    [Fact]
+    public void TryGetCurrentCliVersionMatch_WithNoChannelAndNoPrHives_ReturnsFalse()
+    {
+        var cliVersion = VersionHelper.GetDefaultSdkVersion();
+        var candidates = new[]
+        {
+            "99.0.0",
+            cliVersion,
+        };
+
+        var result = VersionHelper.TryGetCurrentCliVersionMatch(
+            candidates,
+            version => version,
+            out var match,
+            channelName: null,
+            hasPrHives: false);
+
+        Assert.False(result);
+        Assert.Null(match);
+    }
+
+    [Theory]
     [InlineData("pr-16820", true)]
     [InlineData("run-25422767716", true)]
     [InlineData("local", true)]


### PR DESCRIPTION
Forward-ports two CLI fixes from `release/13.4` to `main`.

Fixes #17596.

## What's cherry-picked

| Commit | Original PR | Author | Summary |
| --- | --- | --- | --- |
| `3f0998a` | [#17564](https://github.com/microsoft/aspire/pull/17564) | @sebastienros | Prefer current CLI template version for `aspire new` |
| `5d0da8b` | [#17573](https://github.com/microsoft/aspire/pull/17573) | @danegsta | Stabilize `PrebuiltAppHostServer` staging `globalPackagesFolder` path |

Both PRs are already merged on `release/13.4` and need to land on `main` so daily builds get the same fixes.

## Why this matters (#17564)

See #17596 for the full investigation. Short version:

On a clean `~/.aspire`, `aspire new` with a daily-build CLI from `main` and a DotNet template (C# Blazor / `aspire-starter`) was resolving `Aspire.ProjectTemplates 13.3.5` from nuget.org instead of the expected `13.5.0-preview.1.*` from the `dotnet9` daily feed. Root cause: [`TemplateNuGetConfigService.ResolveTemplatePackageAsync`](https://github.com/microsoft/aspire/blob/main/src/Aspire.Cli/Templating/TemplateNuGetConfigService.cs#L213-L234) restricts the channel search to the Implicit (nuget.org) channel when neither `--channel` is supplied nor PR hives exist on disk. Folks with stale `~/.aspire/hives/*` from past PR installs never saw this — clearing `~/.aspire` exposes it.

PR #17564 adds `NewCommand.TryGetCurrentCliTemplateVersionPackage`, which synthesizes a `Aspire.ProjectTemplates` package pinned to the CLI's own SDK version for non-stable Explicit channels (daily/staging). A daily 13.5 CLI now lock-steps to 13.5 daily templates regardless of what nuget.org ships.

## Why this matters (#17573)

`PackagingService` creates the staging channel with `ConfigureGlobalPackagesFolder=true` so each darc/override feed restore lands in an isolated cache (two staging builds of the same release branch ship as `13.4.0` but from different feeds, and NuGet keys by `(id,version)` only). `PrebuiltAppHostServer` was wiring that flag into a `TemporaryNuGetConfig` whose relative `.nugetpackages` default resolved under the temp config's own directory; `BundleNuGetService` baked those temp paths into `integration-package-probe-manifest.json`, and `TemporaryNuGetConfig.Dispose` then recursively deleted the cache out from under the manifest. On macOS osx-arm64 polyglot staging builds this surfaced as a hang during DI / assembly loading in `aspire-managed`.

The fix anchors the override at a stable absolute path: `<ASPIRE_HOME>/.nugetpackages/<first-8-of-CLI-commit-sha>`, matching the existing `darc-pub-microsoft-aspire-<hash>` feed URL convention in `PackagingService.GetStagingFeedUrl`.

## Validation

Cherry-picks applied cleanly (no conflicts). Both PRs already passed CI on `release/13.4`. Will rely on this PR's CI run to confirm the forward-port compiles and tests pass on top of current `main`.

cc @radical @davidfowl @joperezr @sebastienros @danegsta
