### PR TITLE
Remove ATS experimental markers

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -39,8 +39,7 @@
     <!-- Issue: https://github.com/microsoft/aspire/issues/10175 -->
     <!-- NU1510: The project does not reference any target framework and will not be restored. -->
     <!-- TODO: Re-enable and remove this. -->
-    <!-- ASPIREATS001: Aspire Type System APIs are experimental -->
-    <NoWarn>$(NoWarn);xUnit1051;NU1510;ASPIREATS001</NoWarn>
+    <NoWarn>$(NoWarn);xUnit1051;NU1510</NoWarn>
   </PropertyGroup>
 
   <!-- OS/Architecture properties for local development resources -->

--- a/src/Aspire.Hosting.Blazor/BlazorGatewayExtensions.cs
+++ b/src/Aspire.Hosting.Blazor/BlazorGatewayExtensions.cs
@@ -11,7 +11,6 @@ using Microsoft.Extensions.Logging;
 
 #pragma warning disable ASPIREDOCKERFILEBUILDER001 // DockerfileBuilder is experimental
 #pragma warning disable ASPIRECSHARPAPPS001 // AddCSharpApp is experimental
-#pragma warning disable ASPIREATS001 // AspireExportIgnore is experimental
 
 namespace Aspire.Hosting;
 

--- a/src/Aspire.Hosting.Blazor/BlazorHostedExtensions.cs
+++ b/src/Aspire.Hosting.Blazor/BlazorHostedExtensions.cs
@@ -5,8 +5,6 @@ using System.Diagnostics.CodeAnalysis;
 using Aspire.Hosting.ApplicationModel;
 using Microsoft.Extensions.Logging;
 
-#pragma warning disable ASPIREATS001 // AspireExportIgnore is experimental
-
 namespace Aspire.Hosting;
 
 /// <summary>

--- a/src/Aspire.Hosting.Blazor/Resources/BlazorWasmAppResource.cs
+++ b/src/Aspire.Hosting.Blazor/Resources/BlazorWasmAppResource.cs
@@ -1,8 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-#pragma warning disable ASPIREATS001 // AspireExport is experimental
-
 using System.Diagnostics.CodeAnalysis;
 using Aspire.Hosting.ApplicationModel;
 

--- a/src/Aspire.Hosting.CodeGeneration.Go/AssemblyInfo.cs
+++ b/src/Aspire.Hosting.CodeGeneration.Go/AssemblyInfo.cs
@@ -1,6 +1,0 @@
-// Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MIT license.
-
-using System.Diagnostics.CodeAnalysis;
-
-[assembly: Experimental("ASPIREATS001", UrlFormat = "https://aka.ms/aspire/diagnostics/{0}")]

--- a/src/Aspire.Hosting.CodeGeneration.Java/AssemblyInfo.cs
+++ b/src/Aspire.Hosting.CodeGeneration.Java/AssemblyInfo.cs
@@ -1,6 +1,0 @@
-// Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MIT license.
-
-using System.Diagnostics.CodeAnalysis;
-
-[assembly: Experimental("ASPIREATS001", UrlFormat = "https://aka.ms/aspire/diagnostics/{0}")]

--- a/src/Aspire.Hosting.CodeGeneration.Python/AssemblyInfo.cs
+++ b/src/Aspire.Hosting.CodeGeneration.Python/AssemblyInfo.cs
@@ -1,6 +1,0 @@
-// Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MIT license.
-
-using System.Diagnostics.CodeAnalysis;
-
-[assembly: Experimental("ASPIREATS001", UrlFormat = "https://aka.ms/aspire/diagnostics/{0}")]

--- a/src/Aspire.Hosting.CodeGeneration.Rust/AssemblyInfo.cs
+++ b/src/Aspire.Hosting.CodeGeneration.Rust/AssemblyInfo.cs
@@ -1,6 +1,0 @@
-// Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MIT license.
-
-using System.Diagnostics.CodeAnalysis;
-
-[assembly: Experimental("ASPIREATS001", UrlFormat = "https://aka.ms/aspire/diagnostics/{0}")]

--- a/src/Aspire.Hosting.CodeGeneration.TypeScript/AssemblyInfo.cs
+++ b/src/Aspire.Hosting.CodeGeneration.TypeScript/AssemblyInfo.cs
@@ -1,6 +1,0 @@
-// Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MIT license.
-
-using System.Diagnostics.CodeAnalysis;
-
-[assembly: Experimental("ASPIREATS001", UrlFormat = "https://aka.ms/aspire/diagnostics/{0}")]

--- a/src/Aspire.Hosting.Integration.Analyzers/Aspire.Hosting.Integration.Analyzers.csproj
+++ b/src/Aspire.Hosting.Integration.Analyzers/Aspire.Hosting.Integration.Analyzers.csproj
@@ -13,7 +13,7 @@
     <SuppressFinalPackageVersion>true</SuppressFinalPackageVersion>
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <PackageTags>aspire hosting analyzers ats polyglot integration</PackageTags>
-    <Description>Experimental analyzers for Aspire hosting integration authors.</Description>
+    <Description>Analyzers for Aspire hosting integration authors.</Description>
     <LangVersion>12.0</LangVersion>
     <!--
       Analyzer projects don't need XML docs

--- a/src/Aspire.Hosting.Integration.Analyzers/README.md
+++ b/src/Aspire.Hosting.Integration.Analyzers/README.md
@@ -1,12 +1,12 @@
 # Aspire.Hosting.Integration.Analyzers package
 
-Provides experimental Roslyn analyzers for Aspire hosting integration authors building ATS and polyglot-friendly extensions outside the Aspire repo.
+Provides Roslyn analyzers for Aspire hosting integration authors building ATS and polyglot-friendly extensions outside the Aspire repo.
 
 ## Getting started
 
 ### Install the package
 
-In your integration project, install the experimental analyzer package with [NuGet](https://www.nuget.org):
+In your integration project, install the analyzer package with [NuGet](https://www.nuget.org):
 
 ```dotnetcli
 dotnet add package Aspire.Hosting.Integration.Analyzers --prerelease

--- a/src/Aspire.Hosting/ApplicationModel/IResourceWithCustomWithReference.cs
+++ b/src/Aspire.Hosting/ApplicationModel/IResourceWithCustomWithReference.cs
@@ -1,8 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.Diagnostics.CodeAnalysis;
-
 namespace Aspire.Hosting.ApplicationModel;
 
 /// <summary>
@@ -14,7 +12,6 @@ namespace Aspire.Hosting.ApplicationModel;
 /// to route references to resource-specific logic at runtime. Implementations may
 /// customize dispatch based on either the source or destination resource type.
 /// </remarks>
-[Experimental("ASPIREATS001")]
 public interface IResourceWithCustomWithReference<TSelf> : IResource
     where TSelf : IResource, IResourceWithCustomWithReference<TSelf>
 {

--- a/src/Aspire.Hosting/Ats/AspireDtoAttribute.cs
+++ b/src/Aspire.Hosting/Ats/AspireDtoAttribute.cs
@@ -1,8 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.Diagnostics.CodeAnalysis;
-
 namespace Aspire.Hosting;
 
 /// <summary>
@@ -27,7 +25,6 @@ namespace Aspire.Hosting;
 /// </para>
 /// </remarks>
 [AttributeUsage(AttributeTargets.Class | AttributeTargets.Struct, Inherited = false, AllowMultiple = false)]
-[Experimental("ASPIREATS001")]
 public sealed class AspireDtoAttribute : Attribute
 {
     /// <summary>

--- a/src/Aspire.Hosting/Ats/AspireExportAttribute.cs
+++ b/src/Aspire.Hosting/Ats/AspireExportAttribute.cs
@@ -1,8 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.Diagnostics.CodeAnalysis;
-
 namespace Aspire.Hosting;
 
 /// <summary>
@@ -86,7 +84,6 @@ namespace Aspire.Hosting;
     AttributeTargets.Method | AttributeTargets.Class | AttributeTargets.Interface | AttributeTargets.Assembly | AttributeTargets.Property,
     Inherited = false,
     AllowMultiple = true)]
-[Experimental("ASPIREATS001")]
 public sealed class AspireExportAttribute : Attribute
 {
     /// <summary>

--- a/src/Aspire.Hosting/Ats/AspireExportIgnoreAttribute.cs
+++ b/src/Aspire.Hosting/Ats/AspireExportIgnoreAttribute.cs
@@ -1,8 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.Diagnostics.CodeAnalysis;
-
 namespace Aspire.Hosting;
 
 /// <summary>
@@ -40,7 +38,6 @@ namespace Aspire.Hosting;
     AttributeTargets.Class | AttributeTargets.Property | AttributeTargets.Method,
     Inherited = false,
     AllowMultiple = false)]
-[Experimental("ASPIREATS001")]
 public sealed class AspireExportIgnoreAttribute : Attribute
 {
     /// <summary>

--- a/src/Aspire.Hosting/Ats/AspireUnionAttribute.cs
+++ b/src/Aspire.Hosting/Ats/AspireUnionAttribute.cs
@@ -1,8 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.Diagnostics.CodeAnalysis;
-
 namespace Aspire.Hosting;
 
 /// <summary>
@@ -36,7 +34,6 @@ namespace Aspire.Hosting;
 /// </para>
 /// </remarks>
 [AttributeUsage(AttributeTargets.Parameter | AttributeTargets.Property, AllowMultiple = false)]
-[Experimental("ASPIREATS001")]
 public sealed class AspireUnionAttribute : Attribute
 {
     /// <summary>

--- a/src/Aspire.Hosting/Ats/AspireValueAttribute.cs
+++ b/src/Aspire.Hosting/Ats/AspireValueAttribute.cs
@@ -1,8 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.Diagnostics.CodeAnalysis;
-
 namespace Aspire.Hosting;
 
 /// <summary>
@@ -25,7 +23,6 @@ namespace Aspire.Hosting;
 /// </remarks>
 /// <param name="catalogName">The root name of the generated value catalog.</param>
 [AttributeUsage(AttributeTargets.Field | AttributeTargets.Property, Inherited = false, AllowMultiple = false)]
-[Experimental("ASPIREATS001")]
 public sealed class AspireValueAttribute(string catalogName) : Attribute
 {
     /// <summary>

--- a/src/Aspire.Hosting/Ats/ThirdPartyAtsAttributes.md
+++ b/src/Aspire.Hosting/Ats/ThirdPartyAtsAttributes.md
@@ -4,7 +4,7 @@ The ATS capability scanner discovers attributes by their **full type name**, not
 
 ## Use the official analyzer package
 
-If your integration project already references `Aspire.Hosting`, you can add the experimental `Aspire.Hosting.Integration.Analyzers` package to get the same authoring diagnostics used by in-repo Aspire integrations:
+If your integration project already references `Aspire.Hosting`, you can add the `Aspire.Hosting.Integration.Analyzers` package to get the same authoring diagnostics used by in-repo Aspire integrations:
 
 ```xml
 <ItemGroup>

--- a/src/Aspire.TypeSystem/AssemblyInfo.cs
+++ b/src/Aspire.TypeSystem/AssemblyInfo.cs
@@ -1,6 +1,0 @@
-// Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MIT license.
-
-using System.Diagnostics.CodeAnalysis;
-
-[assembly: Experimental("ASPIREATS001", UrlFormat = "https://aka.ms/aspire/diagnostics/{0}")]

--- a/tests/Aspire.Cli.EndToEnd.Tests/ProjectReferenceTests.cs
+++ b/tests/Aspire.Cli.EndToEnd.Tests/ProjectReferenceTests.cs
@@ -59,7 +59,6 @@ public sealed class ProjectReferenceTests(ITestOutputHelper output)
                 <Project Sdk="Microsoft.NET.Sdk">
                   <PropertyGroup>
                     <TargetFramework>net10.0</TargetFramework>
-                    <NoWarn>$(NoWarn);ASPIREATS001</NoWarn>
                   </PropertyGroup>
                   <ItemGroup>
                     <PackageReference Include="Aspire.Hosting" Version="{{sdkVersion}}" />

--- a/tests/Aspire.Hosting.Analyzers.Tests/AnalyzerTest.cs
+++ b/tests/Aspire.Hosting.Analyzers.Tests/AnalyzerTest.cs
@@ -3,7 +3,6 @@
 
 using System.Reflection;
 using System.Runtime.Versioning;
-using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp.Testing;
 using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.Testing;
@@ -27,20 +26,7 @@ internal static class AnalyzerTest
                 // This is required to allow the use of top-level statements in the test source.
                 OutputKind = Microsoft.CodeAnalysis.OutputKind.ConsoleApplication
             },
-            ReferenceAssemblies = GetReferenceAssemblies(includeAspireHostingReference),
-            // Suppress ASPIREATS001 (experimental API) warnings in test code
-            SolutionTransforms =
-            {
-                (solution, projectId) =>
-                {
-                    var project = solution.GetProject(projectId)!;
-                    var compilationOptions = project.CompilationOptions!;
-                    var specificDiagnosticOptions = compilationOptions.SpecificDiagnosticOptions
-                        .Add("ASPIREATS001", ReportDiagnostic.Suppress);
-                    compilationOptions = compilationOptions.WithSpecificDiagnosticOptions(specificDiagnosticOptions);
-                    return solution.WithProjectCompilationOptions(projectId, compilationOptions);
-                }
-            }
+            ReferenceAssemblies = GetReferenceAssemblies(includeAspireHostingReference)
         };
         test.ExpectedDiagnostics.AddRange(expectedDiagnostics);
         return test;


### PR DESCRIPTION
## Description

TypeScript/polyglot support is GA for 13.4, so consumers should no longer need to suppress `ASPIREATS001` when using ATS/polyglot authoring attributes.

This removes the `ASPIREATS001` experimental markers from the ATS attributes, type-system/codegen assemblies, and the custom `WithReference` contract. It also cleans up now-obsolete suppressions in repo build settings, Blazor sources, analyzer tests, the CLI E2E project-reference template, and related analyzer documentation/metadata.

Validation:
- `./restore.sh`
- `MSBUILDTERMINALLOGGER=false ./build.sh --build /p:SkipNativeBuild=true`
- `dotnet test --project tests/Aspire.Hosting.Analyzers.Tests/Aspire.Hosting.Analyzers.Tests.csproj --no-launch-profile -- --filter-not-trait "quarantined=true" --filter-not-trait "outerloop=true"`
- `dotnet build src/Aspire.Hosting.Integration.Analyzers/Aspire.Hosting.Integration.Analyzers.csproj --no-restore`

Fixes: #17586

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
