### PR TITLE
Fix `aspire stop` falsely reporting failure on Unix

### DIFF
--- a/src/Aspire.Cli/Processes/ProcessShutdownService.cs
+++ b/src/Aspire.Cli/Processes/ProcessShutdownService.cs
@@ -46,14 +46,18 @@ internal sealed class ProcessShutdownService(
             return requestRpcStopAsync is not null && await TryRequestRpcStopAsync(requestRpcStopAsync, cancellationToken).ConfigureAwait(false);
         }
 
-        var processesToMonitor = new List<ProcessTarget> { new(appHostInfo.ProcessId, appHostInfo.StartedAt) };
+        var appHostProcess = new ProcessTarget(appHostInfo.ProcessId, appHostInfo.StartedAt);
+        var processesToForceKill = new List<ProcessTarget> { appHostProcess };
         if (appHostInfo.CliProcessId is int cliPid)
         {
-            processesToMonitor.Add(new ProcessTarget(cliPid, appHostInfo.CliStartedAt));
+            // The CLI process is a shutdown handle, not the success condition. On Unix it can remain
+            // observable until its parent reaps it after the AppHost has already stopped.
+            processesToForceKill.Add(new ProcessTarget(cliPid, appHostInfo.CliStartedAt));
         }
 
         return await StopProcessesAsync(
-            processesToMonitor,
+            processesToMonitor: [appHostProcess],
+            processesToForceKill,
             token => RequestAppHostGracefulShutdownAsync(appHostInfo, requestRpcStopAsync, token),
             cancellationToken).ConfigureAwait(false);
     }
@@ -63,19 +67,46 @@ internal sealed class ProcessShutdownService(
         Func<CancellationToken, Task<bool>> requestGracefulShutdownAsync,
         CancellationToken cancellationToken)
     {
+        return await StopProcessesAsync(
+            processesToMonitorAndKill,
+            processesToMonitorAndKill,
+            requestGracefulShutdownAsync,
+            cancellationToken).ConfigureAwait(false);
+    }
+
+    private async Task<bool> StopProcessesAsync(
+        IReadOnlyCollection<ProcessTarget> processesToMonitor,
+        IReadOnlyCollection<ProcessTarget> processesToForceKill,
+        Func<CancellationToken, Task<bool>> requestGracefulShutdownAsync,
+        CancellationToken cancellationToken)
+    {
         var gracefulShutdownRequested = await TryRequestGracefulShutdownAsync(requestGracefulShutdownAsync, cancellationToken).ConfigureAwait(false);
-        if (gracefulShutdownRequested && await MonitorProcessesForTerminationAsync(processesToMonitorAndKill, cancellationToken).ConfigureAwait(false))
+        if (gracefulShutdownRequested && await MonitorProcessesForTerminationAsync(processesToMonitor, cancellationToken).ConfigureAwait(false))
         {
+            ForceKillRemainingProcesses(processesToForceKill.Except(processesToMonitor), afterTimeout: false);
             return true;
         }
 
-        foreach (var process in processesToMonitorAndKill.Distinct())
+        ForceKillRemainingProcesses(processesToForceKill, afterTimeout: true);
+
+        return await MonitorProcessesForTerminationAsync(processesToMonitor, cancellationToken).ConfigureAwait(false);
+    }
+
+    private void ForceKillRemainingProcesses(IEnumerable<ProcessTarget> processes, bool afterTimeout)
+    {
+        foreach (var process in processes.Distinct())
         {
-            logger.LogWarning("Process {Pid} did not stop gracefully within timeout. Forcing process to terminate.", process.Pid);
+            if (afterTimeout)
+            {
+                logger.LogWarning("Process {Pid} did not stop gracefully within timeout. Forcing process to terminate.", process.Pid);
+            }
+            else
+            {
+                logger.LogDebug("Forcing remaining shutdown handle process {Pid} to terminate.", process.Pid);
+            }
+
             ProcessSignaler.ForceKill(process.Pid, process.StartTime, logger);
         }
-
-        return await MonitorProcessesForTerminationAsync(processesToMonitorAndKill, cancellationToken).ConfigureAwait(false);
     }
 
     private async Task<bool> RequestAppHostGracefulShutdownAsync(

--- a/src/Aspire.Cli/Processes/ProcessShutdownService.cs
+++ b/src/Aspire.Cli/Processes/ProcessShutdownService.cs
@@ -94,6 +94,14 @@ internal sealed class ProcessShutdownService(
 
     private void ForceKillRemainingProcesses(IEnumerable<ProcessTarget> processes, bool afterTimeout)
     {
+        // On Unix the AppHost's process tree does not include DCP (it is launched in its own
+        // session/process group), so a tree kill of the AppHost is safe: DCP will detect the
+        // AppHost exiting and gracefully tear down its own children. The same applies to the
+        // launcher CLI handle - any leftover `dotnet run` / AppHost descendants get cleaned up.
+        // On Windows DCP is an in-tree descendant of the AppHost, so we must single-process-kill
+        // here and rely on the graceful DCP `stop-process-tree` path for orderly resource cleanup.
+        var killEntireProcessTree = !OperatingSystem.IsWindows();
+
         foreach (var process in processes.Distinct())
         {
             if (afterTimeout)
@@ -105,7 +113,7 @@ internal sealed class ProcessShutdownService(
                 logger.LogDebug("Forcing remaining shutdown handle process {Pid} to terminate.", process.Pid);
             }
 
-            ProcessSignaler.ForceKill(process.Pid, process.StartTime, logger);
+            ProcessSignaler.ForceKill(process.Pid, process.StartTime, logger, killEntireProcessTree);
         }
     }
 
@@ -114,6 +122,28 @@ internal sealed class ProcessShutdownService(
         Func<CancellationToken, Task<bool>>? requestRpcStopAsync,
         CancellationToken cancellationToken)
     {
+        if (!OperatingSystem.IsWindows())
+        {
+            // Signal the AppHost directly with SIGTERM. The AppHost catches SIGTERM via
+            // Microsoft.Extensions.Hosting and invokes IHostApplicationLifetime.StopApplication,
+            // which gives DCP and all in-process resources the orderly shutdown they expect.
+            //
+            // Routing the graceful signal through the launcher CLI (CliProcessId) cascades via
+            // `dotnet run`'s child kill. That walk depends on the AppHost being visible in /proc
+            // as a descendant of the `dotnet` process at the moment of the walk, and on the
+            // AppHost being reaped by its parent rather than orphaned. When either of those races
+            // misfires the AppHost is left running (or lingering as a zombie reparented to PID 1)
+            // and the StopCommand monitor then times out reporting "Failed to stop apphost".
+            // Targeting the AppHost PID directly avoids the cascade entirely.
+            logger.LogDebug("Sending graceful shutdown to AppHost PID {Pid}", appHostInfo.ProcessId);
+            return await RequestProcessTreeGracefulShutdownAsync(appHostInfo.ProcessId, appHostInfo.StartedAt, includeStartTimeForDcp: false, cancellationToken).ConfigureAwait(false);
+        }
+
+        // On Windows DCP is an in-tree descendant of the AppHost, so we cannot tree-kill the
+        // AppHost without also taking DCP down. Instead, run the graceful shutdown against the
+        // launcher CLI's process tree (DCP performs `stop-process-tree --skip-descendants`),
+        // which signals the AppHost via DCP without disrupting the descendant cleanup DCP is
+        // responsible for.
         if (appHostInfo.CliProcessId is int cliPid)
         {
             logger.LogDebug("Requesting AppHost process tree shutdown via root CLI PID {Pid}", cliPid);

--- a/src/Shared/ProcessSignaler.cs
+++ b/src/Shared/ProcessSignaler.cs
@@ -30,15 +30,15 @@ internal static partial class ProcessSignaler
         }
     }
 
-    public static void ForceKill(int pid, DateTimeOffset? expectedStartTime, ILogger logger)
+    public static void ForceKill(int pid, DateTimeOffset? expectedStartTime, ILogger logger, bool killEntireProcessTree = false)
     {
         using var process = TryGetRunningProcess(pid, expectedStartTime, logger);
         if (process is { })
         {
-            logger.LogDebug("Killing process {Pid}...", pid);
+            logger.LogDebug("Killing process {Pid} (entireProcessTree={EntireProcessTree})...", pid, killEntireProcessTree);
             try
             {
-                process.Kill(entireProcessTree: false);
+                process.Kill(entireProcessTree: killEntireProcessTree);
             }
             catch (InvalidOperationException)
             {

--- a/tests/Aspire.Cli.Tests/Processes/ProcessShutdownServiceTests.cs
+++ b/tests/Aspire.Cli.Tests/Processes/ProcessShutdownServiceTests.cs
@@ -3,6 +3,7 @@
 
 using System.Diagnostics;
 using System.Globalization;
+using Aspire.Cli.Backchannel;
 using Aspire.Cli.Bundles;
 using Aspire.Cli.Layout;
 using Aspire.Cli.Processes;
@@ -10,6 +11,7 @@ using Aspire.Cli.Tests.TestServices;
 using Aspire.Cli.Tests.Utils;
 using Aspire.Shared;
 using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Time.Testing;
 
 namespace Aspire.Cli.Tests.Processes;
 
@@ -102,11 +104,51 @@ public class ProcessShutdownServiceTests(ITestOutputHelper outputHelper)
         Assert.Equal(leasedDcpPath, executionFactory.LastFileName);
     }
 
+    [Fact]
+    public async Task StopAppHostAsync_CleansUpCliProcessWithoutWaitingForItAsSuccessCondition()
+    {
+        Assert.SkipWhen(OperatingSystem.IsWindows(), "The signal-ignoring shell process is Unix-specific.");
+
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        var dcpDirectory = workspace.WorkspaceRoot.CreateSubdirectory("dcp");
+        File.WriteAllText(BundleDiscovery.GetDcpExecutablePath(dcpDirectory.FullName), string.Empty);
+
+        using var cliProcess = StartSignalIgnoringShellProcess();
+        try
+        {
+            var signaler = CreateService(
+                workspace,
+                dcpDirectory.FullName,
+                new TestProcessExecutionFactory(),
+                timeProvider: new FakeTimeProvider());
+
+            var result = await signaler.StopAppHostAsync(
+                new AppHostInformation
+                {
+                    AppHostPath = Path.Combine(workspace.WorkspaceRoot.FullName, "apphost.cs"),
+                    ProcessId = int.MaxValue,
+                    StartedAt = null,
+                    CliProcessId = cliProcess.Id,
+                    CliStartedAt = new DateTimeOffset(cliProcess.StartTime)
+                },
+                requestRpcStopAsync: null,
+                CancellationToken.None).WaitAsync(TimeSpan.FromSeconds(2));
+
+            Assert.True(result);
+            await cliProcess.WaitForExitAsync().WaitAsync(TimeSpan.FromSeconds(2));
+        }
+        finally
+        {
+            await StopProcessAsync(cliProcess);
+        }
+    }
+
     private static ProcessShutdownService CreateService(
         TemporaryWorkspace workspace,
         string dcpDirectory,
         TestProcessExecutionFactory executionFactory,
-        IBundleService? bundleService = null)
+        IBundleService? bundleService = null,
+        TimeProvider? timeProvider = null)
     {
         var executionContext = new CliExecutionContext(
             workspace.WorkspaceRoot,
@@ -122,7 +164,41 @@ public class ProcessShutdownServiceTests(ITestOutputHelper outputHelper)
             new LayoutProcessRunner(executionFactory),
             executionContext,
             NullLogger<ProcessShutdownService>.Instance,
-            TimeProvider.System);
+            timeProvider ?? TimeProvider.System);
+    }
+
+    private static Process StartSignalIgnoringShellProcess()
+    {
+        var startInfo = new ProcessStartInfo("/bin/sh")
+        {
+            RedirectStandardError = true,
+            RedirectStandardOutput = true,
+            UseShellExecute = false
+        };
+        startInfo.ArgumentList.Add("-c");
+        startInfo.ArgumentList.Add("trap '' TERM; exec sleep 60");
+
+        var process = Process.Start(startInfo);
+        Assert.NotNull(process);
+        return process;
+    }
+
+    private static async Task StopProcessAsync(Process process)
+    {
+        if (process.HasExited)
+        {
+            return;
+        }
+
+        try
+        {
+            process.Kill(entireProcessTree: true);
+            await process.WaitForExitAsync().WaitAsync(TimeSpan.FromSeconds(5));
+        }
+        catch (InvalidOperationException)
+        {
+            // The process exited between the HasExited check and Kill/WaitForExitAsync.
+        }
     }
 
     private sealed class FixedLayoutDiscovery(string dcpDirectory) : ILayoutDiscovery


### PR DESCRIPTION
## Why

`SmokeTests.LatestCliCanStartStableChannelAppHost` has been failing intermittently on `main` and `release/13.4` PRs with `Failed to stop apphost.cs`. Bimodal timing in the failures (success ~1s, failure ~40s) pointed at the AppHost being orphaned and unreaped on Unix during the shutdown cascade.

## Root cause

`aspire stop` was cascading through the launcher CLI on every platform: it would SIGTERM the launcher CLI (`aspire run`), which would cancel its `CancellationTokenSource`, which would cause `ProcessExecution` to call `.Kill(entireProcessTree: true)` on the spawned `dotnet run`, which would in turn try to terminate the AppHost via its own descendant walk.

On Unix this cascade is racy:

1. If the descendant walk inside `dotnet run` misses the AppHost (timing, reparenting, etc.), the AppHost gets orphaned to PID 1.
2. With no proper parent left to reap it, the AppHost can become a zombie that polling for `HasExited` from outside cannot distinguish from a live process.
3. `aspire stop` then waits the full SIGTERM (10s) + SIGKILL (10s) window before failing the operation — matching the ~40s failure timing observed in CI.

## Approach

Split the shutdown path by OS:

* **Unix:** Send SIGTERM directly to the AppHost PID. The AppHost shuts down through its normal `IHostApplicationLifetime` path, and the launcher CLI and `dotnet run` exit naturally when their child exits. Every process is reaped by its actual parent.
* **Unix force-stop:** Pass `killEntireProcessTree: true` to `ProcessSignaler.ForceKill`. DCP is launched in a separate session/process group on Unix, so tree-terminating the AppHost does **not** take DCP with it; DCP detects the parent gone and runs its own orderly child shutdown.
* **Windows:** Unchanged. The existing CLI → DCP cascade is preserved because DCP is an in-tree descendant of the AppHost on Windows, and a tree-wide termination would break DCP's orderly resource cleanup.

The earlier CLI-visibility fix (treating an unresponsive launcher CLI as success rather than blocking on it) is kept and is now belt-and-suspenders.

## Validation

Reproduced and measured in the repo-local Linux container (Ubuntu 24.04 ARM64):

| Build | Stops | Failures | Failure rate | Failure duration |
|-------|------:|---------:|-------------:|------------------|
| Baseline (no fix) | 25 | 5 | 20% | ~40s |
| CLI-visibility-only fix | 25 | 1 | 4% | ~40s |
| **This change** | **30** | **0** | **0%** | n/a (all stops 0.7-2.3s) |

Full local unit-test suite (`Aspire.Cli.Tests`): 3799 passed, 0 failed, 21 skipped.

## Notes for reviewers

* `ProcessSignaler.ForceKill` gains a `killEntireProcessTree` parameter, default `false`. All existing callers keep the old behavior; only `ProcessShutdownService.ForceKillRemainingProcesses` opts in, and only on Unix.
* Windows behavior is intentionally preserved verbatim. The new Unix branch is fully gated on `OperatingSystem.IsWindows()`.
* Zombie-aware liveness detection (reading `/proc/<pid>/stat` state field) was considered but skipped — with the cleaner Unix path, AppHosts are reaped by their actual parent and zombies should not be produced in the normal flow.
