### PR TITLE
[release/13.4] Remove Corepack from extension build scripts

### DIFF
--- a/extension/Extension.proj
+++ b/extension/Extension.proj
@@ -31,13 +31,13 @@
     <!-- Override package.json version if ExtensionVersionOverride is set, saving original first -->
     <Copy SourceFiles="$(_PackageJsonPath)" DestinationFiles="$(_PackageJsonPath).bak"
           Condition="'$(ExtensionVersionOverride)' != ''" />
-    <Exec Command="corepack yarn@1.22.22 version --new-version &quot;$(ExtensionVersionOverride)&quot; --no-git-tag-version"
+    <Exec Command="yarn version --new-version &quot;$(ExtensionVersionOverride)&quot; --no-git-tag-version"
           Condition="'$(ExtensionVersionOverride)' != ''"
           WorkingDirectory="$(ExtensionSrcDir)" />
 
     <!-- Install dependencies and compile -->
-    <Exec Command="corepack yarn@1.22.22 install --frozen-lockfile --non-interactive" WorkingDirectory="$(ExtensionSrcDir)" IgnoreStandardErrorWarningFormat="true" />
-    <Exec Command="corepack yarn@1.22.22 compile" WorkingDirectory="$(ExtensionSrcDir)" IgnoreStandardErrorWarningFormat="true" />
+    <Exec Command="yarn install --frozen-lockfile --non-interactive" WorkingDirectory="$(ExtensionSrcDir)" IgnoreStandardErrorWarningFormat="true" />
+    <Exec Command="yarn compile" WorkingDirectory="$(ExtensionSrcDir)" IgnoreStandardErrorWarningFormat="true" />
 
     <!-- Make extension directory -->
     <MakeDir Directories="$(_VscodeOutputDir)" />
@@ -88,12 +88,12 @@
   </Target>
 
   <Target Name="CheckYarnInstalled">
-    <Exec Command="corepack yarn@1.22.22 --version" ContinueOnError="true" ConsoleToMSBuild="true" IgnoreStandardErrorWarningFormat="true">
+    <Exec Command="yarn --version" ContinueOnError="true" ConsoleToMSBuild="true" IgnoreStandardErrorWarningFormat="true">
       <Output TaskParameter="ExitCode" PropertyName="YarnExitCode" />
       <Output TaskParameter="ConsoleOutput" PropertyName="YarnVersion" />
     </Exec>
 
-    <Error Condition="'$(YarnExitCode)' != '0'" Text="Corepack is not installed or cannot run Yarn Classic. To build the extension, install a Node.js version that includes Corepack." />
+    <Error Condition="'$(YarnExitCode)' != '0'" Text="yarn is not installed or not available in PATH. To build the extension, install yarn: https://yarnpkg.com/getting-started/install" />
 
     <Message Importance="high" Text="yarn version: $(YarnVersion)" />
   </Target>

--- a/extension/build.ps1
+++ b/extension/build.ps1
@@ -10,9 +10,10 @@ if (-not (Get-Command node -ErrorAction SilentlyContinue)) {
     exit 1
 }
 
-# Check for Corepack so the build uses the Yarn Classic version that matches extension/yarn.lock.
-if (-not (Get-Command corepack -ErrorAction SilentlyContinue)) {
-    Write-Error "Error: Corepack is not installed. Please install a Node.js version that includes Corepack."
+# Check for yarn
+if (-not (Get-Command yarn -ErrorAction SilentlyContinue)) {
+    Write-Error "Error: yarn is not installed. Please install yarn first."
+    Write-Host "You can install yarn by running: npm install -g yarn"
     exit 1
 }
 
@@ -40,7 +41,7 @@ Set-Location $PSScriptRoot
 
 Write-Host ""
 Write-Host "Running yarn install..."
-corepack yarn@1.22.22 install --frozen-lockfile --non-interactive
+yarn install --frozen-lockfile --non-interactive
 
 if ($LASTEXITCODE -ne 0) {
     Write-Error "yarn install failed with exit code $LASTEXITCODE"
@@ -49,7 +50,7 @@ if ($LASTEXITCODE -ne 0) {
 
 Write-Host ""
 Write-Host "Running yarn compile..."
-corepack yarn@1.22.22 compile
+yarn compile
 
 if ($LASTEXITCODE -ne 0) {
     Write-Error "yarn compile failed with exit code $LASTEXITCODE"

--- a/extension/build.sh
+++ b/extension/build.sh
@@ -9,9 +9,10 @@ if ! command -v node &> /dev/null; then
     exit 1
 fi
 
-# Check for Corepack so the build uses the Yarn Classic version that matches extension/yarn.lock.
-if ! command -v corepack &> /dev/null; then
-    echo "Error: Corepack is not installed. Please install a Node.js version that includes Corepack."
+# Check for yarn
+if ! command -v yarn &> /dev/null; then
+    echo "Error: yarn is not installed. Please install yarn first."
+    echo "You can install yarn by running: npm install -g yarn"
     exit 1
 fi
 
@@ -37,11 +38,11 @@ cd "$SCRIPT_DIR"
 
 echo ""
 echo "Running yarn install..."
-corepack yarn@1.22.22 install --frozen-lockfile --non-interactive
+yarn install --frozen-lockfile --non-interactive
 
 echo ""
 echo "Running yarn compile..."
-corepack yarn@1.22.22 compile
+yarn compile
 
 echo ""
 echo "Building Aspire CLI..."


### PR DESCRIPTION
## Description

Reverts the Corepack-specific Yarn invocation from the 13.4 branch VS Code extension build scripts.

Internal Azure Pipelines builds run with network isolation, and `corepack yarn@1.22.22` attempts to download Yarn from the public Yarn registry before the extension's `.yarnrc` package registry configuration is used. That public download is blocked in internal builds. For 13.4, use the lower-risk fix of invoking the configured `yarn` executable directly again while preserving the Yarn-only/frozen-lockfile restore path.

Validation:

- `git diff --check`
- Parsed `extension\Extension.proj` as XML
- Confirmed no `corepack` references remain in the targeted extension build files

Fixes # (issue)

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [x] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
