### PR TITLE
Accept dev localhost resource service URLs

### DIFF
--- a/src/Aspire.Hosting/Dashboard/DashboardServiceHost.cs
+++ b/src/Aspire.Hosting/Dashboard/DashboardServiceHost.cs
@@ -138,7 +138,7 @@ internal sealed class DashboardServiceHost : IHostedService
                 kestrelOptions.Listen(IPAddress.Loopback, port: 0, ConfigureListen);
                 _logger.LogDebug("Resource service endpoint not configured. Listening on {Scheme}://127.0.0.1:<random>.", scheme);
             }
-            else if (uri.IsLoopback)
+            else if (IsLocalResourceServiceEndpoint(uri))
             {
                 // Listen on the requested localhost port.
                 kestrelOptions.ListenLocalhost(uri.Port, ConfigureListen);
@@ -176,6 +176,28 @@ internal sealed class DashboardServiceHost : IHostedService
         }
 
         return allowUnsecuredTransport ? "http" : "https";
+    }
+
+    /// <summary>
+    /// Determines whether the resource service endpoint is scoped to the local machine.
+    /// </summary>
+    internal static bool IsLocalResourceServiceEndpoint(Uri uri)
+    {
+        if (uri.IsLoopback)
+        {
+            return true;
+        }
+
+        var host = uri.Host.EndsWith(".", StringComparison.Ordinal)
+            ? uri.Host[..^1]
+            : uri.Host;
+
+        // RFC 6761 reserves "localhost." and names under it for loopback resolution:
+        // https://www.rfc-editor.org/rfc/rfc6761#section-6.3. Uri.IsLoopback only
+        // recognizes "localhost" itself, but Aspire-generated polyglot AppHosts can use
+        // scoped names like "myapp.dev.localhost".
+        return string.Equals(host, KnownHostNames.Localhost, StringComparison.OrdinalIgnoreCase)
+            || host.EndsWith(".localhost", StringComparison.OrdinalIgnoreCase);
     }
 
     /// <summary>

--- a/src/Aspire.Hosting/Dashboard/DashboardServiceHost.cs
+++ b/src/Aspire.Hosting/Dashboard/DashboardServiceHost.cs
@@ -192,12 +192,7 @@ internal sealed class DashboardServiceHost : IHostedService
             ? uri.Host[..^1]
             : uri.Host;
 
-        // RFC 6761 reserves "localhost." and names under it for loopback resolution:
-        // https://www.rfc-editor.org/rfc/rfc6761#section-6.3. Uri.IsLoopback only
-        // recognizes "localhost" itself, but Aspire-generated polyglot AppHosts can use
-        // scoped names like "myapp.dev.localhost".
-        return string.Equals(host, KnownHostNames.Localhost, StringComparison.OrdinalIgnoreCase)
-            || host.EndsWith(".localhost", StringComparison.OrdinalIgnoreCase);
+        return EndpointHostHelpers.IsLocalhostOrLocalhostTld(host);
     }
 
     /// <summary>

--- a/tests/Aspire.Cli.EndToEnd.Tests/SmokeTests.cs
+++ b/tests/Aspire.Cli.EndToEnd.Tests/SmokeTests.cs
@@ -85,8 +85,8 @@ public sealed class SmokeTests(ITestOutputHelper output)
         const string projectName = "PolyglotDevLocalhost";
         await auto.AspireNewAsync(projectName, counter, template: AspireTemplate.ExpressReact, useDevLocalhost: true);
 
-        await auto.RunCommandFailFastAsync($"cd {projectName}", counter);
-        await auto.RunCommandFailFastAsync("grep -F 'ASPIRE_RESOURCE_SERVICE_ENDPOINT_URL' aspire.config.json && grep -F 'polyglotdevlocalhost.dev.localhost' aspire.config.json", counter);
+        await auto.RunCommandAsync($"cd {projectName}", counter);
+        await auto.RunCommandAsync("grep -F 'ASPIRE_RESOURCE_SERVICE_ENDPOINT_URL' aspire.config.json && grep -F 'polyglotdevlocalhost.dev.localhost' aspire.config.json", counter);
 
         await auto.TypeAsync("aspire run");
         await auto.EnterAsync();

--- a/tests/Aspire.Cli.EndToEnd.Tests/SmokeTests.cs
+++ b/tests/Aspire.Cli.EndToEnd.Tests/SmokeTests.cs
@@ -66,6 +66,48 @@ public sealed class SmokeTests(ITestOutputHelper output)
 
     [CaptureWorkspaceOnFailure]
     [Fact]
+    public async Task CreateAndRunPolyglotAppHostWithDevLocalhostUrls()
+    {
+        var repoRoot = CliE2ETestHelpers.GetRepoRoot();
+        var strategy = CliInstallStrategy.Detect(output.WriteLine);
+
+        var workspace = TemporaryWorkspace.Create(output);
+
+        using var terminal = CliE2ETestHelpers.CreateDockerTestTerminal(repoRoot, strategy, output, mountDockerSocket: true, workspace: workspace);
+
+        var counter = new SequenceCounter();
+        var auto = new Hex1bTerminalAutomator(terminal, defaultTimeout: TimeSpan.FromSeconds(500));
+        await using var terminalRun = CliE2ETestHelpers.StartRun(terminal, workspace, auto, counter, output, TestContext.Current.CancellationToken);
+
+        await auto.PrepareDockerEnvironmentAsync(counter, workspace);
+        await auto.InstallAspireCliAsync(strategy, counter);
+
+        const string projectName = "PolyglotDevLocalhost";
+        await auto.AspireNewAsync(projectName, counter, template: AspireTemplate.ExpressReact, useDevLocalhost: true);
+
+        await auto.RunCommandFailFastAsync($"cd {projectName}", counter);
+        await auto.RunCommandFailFastAsync("grep -F 'ASPIRE_RESOURCE_SERVICE_ENDPOINT_URL' aspire.config.json && grep -F 'polyglotdevlocalhost.dev.localhost' aspire.config.json", counter);
+
+        await auto.TypeAsync("aspire run");
+        await auto.EnterAsync();
+
+        await auto.WaitUntilAsync(s =>
+        {
+            if (s.ContainsText("Capability Error") ||
+                s.ContainsText("ASPIRE_RESOURCE_SERVICE_ENDPOINT_URL must contain a local loopback address"))
+            {
+                throw new InvalidOperationException("Polyglot AppHost failed to start with a *.dev.localhost resource service endpoint.");
+            }
+
+            return s.ContainsText("Press CTRL+C to stop the AppHost and exit.");
+        }, timeout: TimeSpan.FromMinutes(3), description: "Press CTRL+C message for polyglot AppHost with *.dev.localhost URLs");
+
+        await auto.Ctrl().KeyAsync(Hex1bKey.C);
+        await auto.WaitForSuccessPromptAsync(counter);
+    }
+
+    [CaptureWorkspaceOnFailure]
+    [Fact]
     public async Task LatestCliCanStartStableChannelAppHost()
     {
         var repoRoot = CliE2ETestHelpers.GetRepoRoot();

--- a/tests/Aspire.Hosting.Tests/Dashboard/DashboardServiceHostTests.cs
+++ b/tests/Aspire.Hosting.Tests/Dashboard/DashboardServiceHostTests.cs
@@ -22,4 +22,21 @@ public class DashboardServiceHostTests
 
         Assert.Equal(expectedScheme, scheme);
     }
+
+    [Theory]
+    [InlineData("https://localhost:5001", true)]
+    [InlineData("https://localhost.:5001", true)]
+    [InlineData("https://127.0.0.1:5001", true)]
+    [InlineData("https://[::1]:5001", true)]
+    [InlineData("https://myapp.dev.localhost:5001", true)]
+    [InlineData("https://myapp.dev.localhost.:5001", true)]
+    [InlineData("https://example.com:5001", false)]
+    [InlineData("https://localhost.example.com:5001", false)]
+    [InlineData("https://example-localhost:5001", false)]
+    public void IsLocalResourceServiceEndpoint_ReturnsExpectedResult(string uriString, bool expectedResult)
+    {
+        var result = DashboardServiceHost.IsLocalResourceServiceEndpoint(new Uri(uriString));
+
+        Assert.Equal(expectedResult, result);
+    }
 }


### PR DESCRIPTION
## Description

`aspire run` fails for polyglot AppHosts scaffolded with `*.dev.localhost` URLs because the AppHost resource service endpoint validation only accepted `Uri.IsLoopback`, which does not recognize RFC-reserved localhost subdomains.

This updates the resource service endpoint check to treat `localhost`, loopback IPs, and `.localhost` subdomains as local while still rejecting arbitrary DNS names and lookalikes. Kestrel continues to bind the resource service with `ListenLocalhost`, so this relaxes configuration validation without exposing a new network listener.

### User-facing usage

Users can scaffold and run a polyglot AppHost with `*.dev.localhost` URLs:

```bash
aspire new
# Select Starter App (Express/React, TypeScript AppHost)
# Choose Use *.dev.localhost URLs
aspire run
```

### Security considerations

This change relies on RFC 6761's reservation of `localhost` and names below it for loopback use. The resource service still binds with `ListenLocalhost`, and non-`.localhost` hostnames remain rejected.

Validation:

- `dotnet build tests/Aspire.Cli.EndToEnd.Tests/Aspire.Cli.EndToEnd.Tests.csproj`
- `dotnet test --project tests/Aspire.Hosting.Tests/Aspire.Hosting.Tests.csproj --no-launch-profile -- --filter-class "*.DashboardServiceHostTests" --filter-not-trait "quarantined=true" --filter-not-trait "outerloop=true"`
- `./localhive.sh -o /tmp/aspire-e2e-devlocalhost -r linux-arm64 --archive`
- `ASPIRE_E2E_ARCHIVE=/tmp/aspire-e2e-devlocalhost.tar.gz dotnet test --project tests/Aspire.Cli.EndToEnd.Tests/Aspire.Cli.EndToEnd.Tests.csproj --no-launch-profile -- --filter-method "*.CreateAndRunPolyglotAppHostWithDevLocalhostUrls" --filter-not-trait "quarantined=true" --filter-not-trait "outerloop=true"`

Fixes # (issue)

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [x] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [x] No
  - [ ] No