### PR TITLE
Fix guest AppHost Ctrl+C shutdown

### DIFF
--- a/src/Aspire.Cli/Commands/RunCommand.cs
+++ b/src/Aspire.Cli/Commands/RunCommand.cs
@@ -78,11 +78,10 @@ internal sealed class RunCommand : BaseCommand
     private const int MaxDisplayedAppHostStartupOutputLines = 80;
 
     // Startup cancellation waits for the AppHost run task to complete after it asks
-    // ProcessShutdownService to stop processes. That service can spend one full timeout
-    // waiting for graceful shutdown and another after force-kill fallback.
+    // ProcessShutdownService to stop the guest and server processes. Each stop can spend
+    // one run timeout waiting for graceful shutdown and another after force-kill fallback.
     private static readonly TimeSpan s_appHostStartupCancellationTimeout =
-        ProcessShutdownService.ProcessTerminationTimeout +
-        ProcessShutdownService.ProcessTerminationTimeout +
+        TimeSpan.FromTicks(ProcessShutdownService.RunProcessTerminationTimeout.Ticks * 4) +
         TimeSpan.FromSeconds(1);
 
     // Guest AppHosts can bring up the temporary server/backchannel and then fail immediately

--- a/src/Aspire.Cli/Commands/RunCommand.cs
+++ b/src/Aspire.Cli/Commands/RunCommand.cs
@@ -12,7 +12,6 @@ using Aspire.Cli.Configuration;
 using Aspire.Cli.Diagnostics;
 using Aspire.Cli.DotNet;
 using Aspire.Cli.Interaction;
-using Aspire.Cli.Processes;
 using Aspire.Cli.Profiling;
 using Aspire.Cli.Projects;
 using Aspire.Cli.Resources;
@@ -77,11 +76,14 @@ internal sealed class RunCommand : BaseCommand
     private bool _isDetachMode;
     private const int MaxDisplayedAppHostStartupOutputLines = 80;
 
-    // Startup cancellation waits for the AppHost run task to complete after it asks
-    // ProcessShutdownService to stop the guest and server processes. Each stop can spend
-    // one run timeout waiting for graceful shutdown and another after force-kill fallback.
+    private static readonly TimeSpan s_runProcessTerminationTimeout = TimeSpan.FromSeconds(3);
+    private static readonly TimeSpan s_runProcessShutdownTimeout =
+        TimeSpan.FromTicks(s_runProcessTerminationTimeout.Ticks * 2) + TimeSpan.FromSeconds(1);
+
+    // Startup cancellation waits for the AppHost run task to complete after it stops the
+    // directly-owned guest and server processes. Each stop gets its own run shutdown budget.
     private static readonly TimeSpan s_appHostStartupCancellationTimeout =
-        TimeSpan.FromTicks(ProcessShutdownService.RunProcessShutdownTimeout.Ticks * 2);
+        TimeSpan.FromTicks(s_runProcessShutdownTimeout.Ticks * 2);
 
     // Guest AppHosts can bring up the temporary server/backchannel and then fail immediately
     // afterward when the guest startup process hits a syntax, pre-execute, or model validation
@@ -283,6 +285,8 @@ internal sealed class RunCommand : BaseCommand
                 WorkingDirectory = ExecutionContext.WorkingDirectory,
                 BuildCompletionSource = buildCompletionSource,
                 BackchannelCompletionSource = backchannelCompletionSource,
+                ProcessTerminationTimeout = s_runProcessTerminationTimeout,
+                ProcessShutdownTimeout = s_runProcessShutdownTimeout,
             };
             ProfilingTelemetry.AddCurrentContextToEnvironment(context.EnvironmentVariables);
             if (captureProfile)

--- a/src/Aspire.Cli/Commands/RunCommand.cs
+++ b/src/Aspire.Cli/Commands/RunCommand.cs
@@ -12,6 +12,7 @@ using Aspire.Cli.Configuration;
 using Aspire.Cli.Diagnostics;
 using Aspire.Cli.DotNet;
 using Aspire.Cli.Interaction;
+using Aspire.Cli.Processes;
 using Aspire.Cli.Profiling;
 using Aspire.Cli.Projects;
 using Aspire.Cli.Resources;
@@ -76,7 +77,13 @@ internal sealed class RunCommand : BaseCommand
     private bool _isDetachMode;
     private const int MaxDisplayedAppHostStartupOutputLines = 80;
 
-    private static readonly TimeSpan s_appHostStartupCancellationTimeout = TimeSpan.FromSeconds(5);
+    // Startup cancellation waits for the AppHost run task to complete after it asks
+    // ProcessShutdownService to stop processes. That service can spend one full timeout
+    // waiting for graceful shutdown and another after force-kill fallback.
+    private static readonly TimeSpan s_appHostStartupCancellationTimeout =
+        ProcessShutdownService.ProcessTerminationTimeout +
+        ProcessShutdownService.ProcessTerminationTimeout +
+        TimeSpan.FromSeconds(1);
 
     // Guest AppHosts can bring up the temporary server/backchannel and then fail immediately
     // afterward when the guest startup process hits a syntax, pre-execute, or model validation

--- a/src/Aspire.Cli/Commands/RunCommand.cs
+++ b/src/Aspire.Cli/Commands/RunCommand.cs
@@ -81,8 +81,7 @@ internal sealed class RunCommand : BaseCommand
     // ProcessShutdownService to stop the guest and server processes. Each stop can spend
     // one run timeout waiting for graceful shutdown and another after force-kill fallback.
     private static readonly TimeSpan s_appHostStartupCancellationTimeout =
-        TimeSpan.FromTicks(ProcessShutdownService.RunProcessTerminationTimeout.Ticks * 4) +
-        TimeSpan.FromSeconds(1);
+        TimeSpan.FromTicks(ProcessShutdownService.RunProcessShutdownTimeout.Ticks * 2);
 
     // Guest AppHosts can bring up the temporary server/backchannel and then fail immediately
     // afterward when the guest startup process hits a syntax, pre-execute, or model validation

--- a/src/Aspire.Cli/Processes/ProcessShutdownService.cs
+++ b/src/Aspire.Cli/Processes/ProcessShutdownService.cs
@@ -22,9 +22,12 @@ internal sealed class ProcessShutdownService(
     TimeProvider timeProvider)
 {
     private static readonly TimeSpan s_processTerminationTimeout = TimeSpan.FromSeconds(10);
+    private static readonly TimeSpan s_runProcessTerminationTimeout = TimeSpan.FromSeconds(3);
     private static readonly TimeSpan s_processTerminationPollInterval = TimeSpan.FromMilliseconds(250);
 
     internal static TimeSpan ProcessTerminationTimeout => s_processTerminationTimeout;
+
+    internal static TimeSpan RunProcessTerminationTimeout => s_runProcessTerminationTimeout;
 
     public Task<bool> StopProcessTreeAsync(
         int pid,
@@ -37,6 +40,7 @@ internal sealed class ProcessShutdownService(
             startTime,
             includeStartTimeForDcp,
             forceKillEntireProcessTree: !OperatingSystem.IsWindows(),
+            processTerminationTimeout: s_processTerminationTimeout,
             cancellationToken);
     }
 
@@ -47,11 +51,29 @@ internal sealed class ProcessShutdownService(
         bool forceKillEntireProcessTree,
         CancellationToken cancellationToken)
     {
+        return StopProcessTreeAsync(
+            pid,
+            startTime,
+            includeStartTimeForDcp,
+            forceKillEntireProcessTree,
+            processTerminationTimeout: s_processTerminationTimeout,
+            cancellationToken);
+    }
+
+    public Task<bool> StopProcessTreeAsync(
+        int pid,
+        DateTimeOffset? startTime,
+        bool includeStartTimeForDcp,
+        bool forceKillEntireProcessTree,
+        TimeSpan processTerminationTimeout,
+        CancellationToken cancellationToken)
+    {
         return StopProcessesAsync(
             [new ProcessTarget(pid, startTime)],
             [new ProcessTarget(pid, startTime)],
             token => RequestProcessTreeGracefulShutdownAsync(pid, startTime, includeStartTimeForDcp, token),
             forceKillEntireProcessTree,
+            processTerminationTimeout,
             cancellationToken);
     }
 
@@ -61,11 +83,27 @@ internal sealed class ProcessShutdownService(
         bool forceKillEntireProcessTree,
         CancellationToken cancellationToken)
     {
+        return StopProcessGroupAsync(
+            pid,
+            startTime,
+            forceKillEntireProcessTree,
+            processTerminationTimeout: s_processTerminationTimeout,
+            cancellationToken);
+    }
+
+    public Task<bool> StopProcessGroupAsync(
+        int pid,
+        DateTimeOffset? startTime,
+        bool forceKillEntireProcessTree,
+        TimeSpan processTerminationTimeout,
+        CancellationToken cancellationToken)
+    {
         return StopProcessesAsync(
             [new ProcessTarget(pid, startTime)],
             [new ProcessTarget(pid, startTime)],
             token => RequestProcessGroupGracefulShutdownAsync(pid, startTime, token),
             forceKillEntireProcessTree,
+            processTerminationTimeout,
             cancellationToken);
     }
 
@@ -93,6 +131,7 @@ internal sealed class ProcessShutdownService(
             processesToForceKill,
             token => RequestAppHostGracefulShutdownAsync(appHostInfo, requestRpcStopAsync, token),
             forceKillEntireProcessTree: !OperatingSystem.IsWindows(),
+            processTerminationTimeout: s_processTerminationTimeout,
             cancellationToken).ConfigureAwait(false);
     }
 
@@ -106,6 +145,7 @@ internal sealed class ProcessShutdownService(
             processesToMonitorAndKill,
             requestGracefulShutdownAsync,
             forceKillEntireProcessTree: !OperatingSystem.IsWindows(),
+            processTerminationTimeout: s_processTerminationTimeout,
             cancellationToken).ConfigureAwait(false);
     }
 
@@ -114,10 +154,11 @@ internal sealed class ProcessShutdownService(
         IReadOnlyCollection<ProcessTarget> processesToForceKill,
         Func<CancellationToken, Task<bool>> requestGracefulShutdownAsync,
         bool forceKillEntireProcessTree,
+        TimeSpan processTerminationTimeout,
         CancellationToken cancellationToken)
     {
         var gracefulShutdownRequested = await TryRequestGracefulShutdownAsync(requestGracefulShutdownAsync, cancellationToken).ConfigureAwait(false);
-        if (gracefulShutdownRequested && await MonitorProcessesForTerminationAsync(processesToMonitor, cancellationToken).ConfigureAwait(false))
+        if (gracefulShutdownRequested && await MonitorProcessesForTerminationAsync(processesToMonitor, processTerminationTimeout, cancellationToken).ConfigureAwait(false))
         {
             ForceKillRemainingProcesses(processesToForceKill.Except(processesToMonitor), afterTimeout: false, killEntireProcessTree: forceKillEntireProcessTree);
             return true;
@@ -125,7 +166,7 @@ internal sealed class ProcessShutdownService(
 
         ForceKillRemainingProcesses(processesToForceKill, afterTimeout: true, killEntireProcessTree: forceKillEntireProcessTree);
 
-        return await MonitorProcessesForTerminationAsync(processesToMonitor, cancellationToken).ConfigureAwait(false);
+        return await MonitorProcessesForTerminationAsync(processesToMonitor, processTerminationTimeout, cancellationToken).ConfigureAwait(false);
     }
 
     private void ForceKillRemainingProcesses(IEnumerable<ProcessTarget> processes, bool afterTimeout, bool killEntireProcessTree)
@@ -313,10 +354,13 @@ internal sealed class ProcessShutdownService(
         return true;
     }
 
-    private async Task<bool> MonitorProcessesForTerminationAsync(IReadOnlyCollection<ProcessTarget> processes, CancellationToken cancellationToken)
+    private async Task<bool> MonitorProcessesForTerminationAsync(
+        IReadOnlyCollection<ProcessTarget> processes,
+        TimeSpan processTerminationTimeout,
+        CancellationToken cancellationToken)
     {
         var startTime = timeProvider.GetUtcNow();
-        while (timeProvider.GetUtcNow() - startTime < ProcessTerminationTimeout)
+        while (timeProvider.GetUtcNow() - startTime < processTerminationTimeout)
         {
             if (processes.All(IsProcessStopped))
             {

--- a/src/Aspire.Cli/Processes/ProcessShutdownService.cs
+++ b/src/Aspire.Cli/Processes/ProcessShutdownService.cs
@@ -24,6 +24,8 @@ internal sealed class ProcessShutdownService(
     private static readonly TimeSpan s_processTerminationTimeout = TimeSpan.FromSeconds(10);
     private static readonly TimeSpan s_processTerminationPollInterval = TimeSpan.FromMilliseconds(250);
 
+    internal static TimeSpan ProcessTerminationTimeout => s_processTerminationTimeout;
+
     public Task<bool> StopProcessTreeAsync(
         int pid,
         DateTimeOffset? startTime,
@@ -314,7 +316,7 @@ internal sealed class ProcessShutdownService(
     private async Task<bool> MonitorProcessesForTerminationAsync(IReadOnlyCollection<ProcessTarget> processes, CancellationToken cancellationToken)
     {
         var startTime = timeProvider.GetUtcNow();
-        while (timeProvider.GetUtcNow() - startTime < s_processTerminationTimeout)
+        while (timeProvider.GetUtcNow() - startTime < ProcessTerminationTimeout)
         {
             if (processes.All(IsProcessStopped))
             {

--- a/src/Aspire.Cli/Processes/ProcessShutdownService.cs
+++ b/src/Aspire.Cli/Processes/ProcessShutdownService.cs
@@ -22,15 +22,9 @@ internal sealed class ProcessShutdownService(
     TimeProvider timeProvider)
 {
     private static readonly TimeSpan s_processTerminationTimeout = TimeSpan.FromSeconds(10);
-    private static readonly TimeSpan s_runProcessTerminationTimeout = TimeSpan.FromSeconds(3);
     private static readonly TimeSpan s_processTerminationPollInterval = TimeSpan.FromMilliseconds(250);
 
-    internal static TimeSpan ProcessTerminationTimeout => s_processTerminationTimeout;
-
-    internal static TimeSpan RunProcessTerminationTimeout => s_runProcessTerminationTimeout;
-
-    internal static TimeSpan RunProcessShutdownTimeout =>
-        TimeSpan.FromTicks(s_runProcessTerminationTimeout.Ticks * 2) + TimeSpan.FromSeconds(1);
+    internal static TimeSpan DefaultProcessTerminationTimeout => s_processTerminationTimeout;
 
     public Task<bool> StopProcessTreeAsync(
         int pid,

--- a/src/Aspire.Cli/Processes/ProcessShutdownService.cs
+++ b/src/Aspire.Cli/Processes/ProcessShutdownService.cs
@@ -29,6 +29,9 @@ internal sealed class ProcessShutdownService(
 
     internal static TimeSpan RunProcessTerminationTimeout => s_runProcessTerminationTimeout;
 
+    internal static TimeSpan RunProcessShutdownTimeout =>
+        TimeSpan.FromTicks(s_runProcessTerminationTimeout.Ticks * 2) + TimeSpan.FromSeconds(1);
+
     public Task<bool> StopProcessTreeAsync(
         int pid,
         DateTimeOffset? startTime,

--- a/src/Aspire.Cli/Processes/ProcessShutdownService.cs
+++ b/src/Aspire.Cli/Processes/ProcessShutdownService.cs
@@ -30,9 +30,40 @@ internal sealed class ProcessShutdownService(
         bool includeStartTimeForDcp,
         CancellationToken cancellationToken)
     {
+        return StopProcessTreeAsync(
+            pid,
+            startTime,
+            includeStartTimeForDcp,
+            forceKillEntireProcessTree: !OperatingSystem.IsWindows(),
+            cancellationToken);
+    }
+
+    public Task<bool> StopProcessTreeAsync(
+        int pid,
+        DateTimeOffset? startTime,
+        bool includeStartTimeForDcp,
+        bool forceKillEntireProcessTree,
+        CancellationToken cancellationToken)
+    {
         return StopProcessesAsync(
             [new ProcessTarget(pid, startTime)],
+            [new ProcessTarget(pid, startTime)],
             token => RequestProcessTreeGracefulShutdownAsync(pid, startTime, includeStartTimeForDcp, token),
+            forceKillEntireProcessTree,
+            cancellationToken);
+    }
+
+    public Task<bool> StopProcessGroupAsync(
+        int pid,
+        DateTimeOffset? startTime,
+        bool forceKillEntireProcessTree,
+        CancellationToken cancellationToken)
+    {
+        return StopProcessesAsync(
+            [new ProcessTarget(pid, startTime)],
+            [new ProcessTarget(pid, startTime)],
+            token => RequestProcessGroupGracefulShutdownAsync(pid, startTime, token),
+            forceKillEntireProcessTree,
             cancellationToken);
     }
 
@@ -59,6 +90,7 @@ internal sealed class ProcessShutdownService(
             processesToMonitor: [appHostProcess],
             processesToForceKill,
             token => RequestAppHostGracefulShutdownAsync(appHostInfo, requestRpcStopAsync, token),
+            forceKillEntireProcessTree: !OperatingSystem.IsWindows(),
             cancellationToken).ConfigureAwait(false);
     }
 
@@ -71,6 +103,7 @@ internal sealed class ProcessShutdownService(
             processesToMonitorAndKill,
             processesToMonitorAndKill,
             requestGracefulShutdownAsync,
+            forceKillEntireProcessTree: !OperatingSystem.IsWindows(),
             cancellationToken).ConfigureAwait(false);
     }
 
@@ -78,30 +111,23 @@ internal sealed class ProcessShutdownService(
         IReadOnlyCollection<ProcessTarget> processesToMonitor,
         IReadOnlyCollection<ProcessTarget> processesToForceKill,
         Func<CancellationToken, Task<bool>> requestGracefulShutdownAsync,
+        bool forceKillEntireProcessTree,
         CancellationToken cancellationToken)
     {
         var gracefulShutdownRequested = await TryRequestGracefulShutdownAsync(requestGracefulShutdownAsync, cancellationToken).ConfigureAwait(false);
         if (gracefulShutdownRequested && await MonitorProcessesForTerminationAsync(processesToMonitor, cancellationToken).ConfigureAwait(false))
         {
-            ForceKillRemainingProcesses(processesToForceKill.Except(processesToMonitor), afterTimeout: false);
+            ForceKillRemainingProcesses(processesToForceKill.Except(processesToMonitor), afterTimeout: false, killEntireProcessTree: forceKillEntireProcessTree);
             return true;
         }
 
-        ForceKillRemainingProcesses(processesToForceKill, afterTimeout: true);
+        ForceKillRemainingProcesses(processesToForceKill, afterTimeout: true, killEntireProcessTree: forceKillEntireProcessTree);
 
         return await MonitorProcessesForTerminationAsync(processesToMonitor, cancellationToken).ConfigureAwait(false);
     }
 
-    private void ForceKillRemainingProcesses(IEnumerable<ProcessTarget> processes, bool afterTimeout)
+    private void ForceKillRemainingProcesses(IEnumerable<ProcessTarget> processes, bool afterTimeout, bool killEntireProcessTree)
     {
-        // On Unix the AppHost's process tree does not include DCP (it is launched in its own
-        // session/process group), so a tree kill of the AppHost is safe: DCP will detect the
-        // AppHost exiting and gracefully tear down its own children. The same applies to the
-        // launcher CLI handle - any leftover `dotnet run` / AppHost descendants get cleaned up.
-        // On Windows DCP is an in-tree descendant of the AppHost, so we must single-process-kill
-        // here and rely on the graceful DCP `stop-process-tree` path for orderly resource cleanup.
-        var killEntireProcessTree = !OperatingSystem.IsWindows();
-
         foreach (var process in processes.Distinct())
         {
             if (afterTimeout)
@@ -209,6 +235,16 @@ internal sealed class ProcessShutdownService(
         logger.LogDebug("Sending stop signal to process {Pid}", pid);
         ProcessSignaler.RequestGracefulShutdown(pid, startTime, logger);
         return true;
+    }
+
+    private Task<bool> RequestProcessGroupGracefulShutdownAsync(
+        int pid,
+        DateTimeOffset? startTime,
+        CancellationToken cancellationToken)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        ProcessSignaler.RequestGracefulShutdownForProcessGroup(pid, startTime, logger);
+        return Task.FromResult(true);
     }
 
     internal async Task<bool> TryStopProcessTreeWithDcpAsync(int pid, DateTimeOffset? startTime, bool includeStartTime, CancellationToken cancellationToken)

--- a/src/Aspire.Cli/Projects/AppHostProjectContext.cs
+++ b/src/Aspire.Cli/Projects/AppHostProjectContext.cs
@@ -87,6 +87,16 @@ internal sealed class AppHostProjectContext
     public required DirectoryInfo WorkingDirectory { get; init; }
 
     /// <summary>
+    /// Gets the per-process termination monitoring timeout for AppHost-owned child processes.
+    /// </summary>
+    public TimeSpan? ProcessTerminationTimeout { get; init; }
+
+    /// <summary>
+    /// Gets the total shutdown coordination timeout for AppHost-owned child processes.
+    /// </summary>
+    public TimeSpan? ProcessShutdownTimeout { get; init; }
+
+    /// <summary>
     /// Gets or sets the output collector for capturing stdout/stderr.
     /// Project implementations populate this during execution.
     /// Commands can access it for error display.

--- a/src/Aspire.Cli/Projects/AppHostServerSession.cs
+++ b/src/Aspire.Cli/Projects/AppHostServerSession.cs
@@ -172,6 +172,7 @@ internal sealed class AppHostServerSession : IAppHostServerSession
                         _serverProcess.Id,
                         serverProcessStartTime,
                         forceKillEntireProcessTree: !OperatingSystem.IsWindows(),
+                        processTerminationTimeout: ProcessShutdownService.RunProcessTerminationTimeout,
                         CancellationToken.None).ConfigureAwait(false);
                 }
                 else

--- a/src/Aspire.Cli/Projects/AppHostServerSession.cs
+++ b/src/Aspire.Cli/Projects/AppHostServerSession.cs
@@ -166,11 +166,18 @@ internal sealed class AppHostServerSession : IAppHostServerSession
             var stopped = false;
             if (_processShutdownService is not null)
             {
-                stopped = await _processShutdownService.StopProcessGroupAsync(
-                    _serverProcess.Id,
-                    TryGetServerProcessStartTime(),
-                    forceKillEntireProcessTree: !OperatingSystem.IsWindows(),
-                    CancellationToken.None).ConfigureAwait(false);
+                if (TryGetServerProcessStartTime(out var serverProcessStartTime))
+                {
+                    stopped = await _processShutdownService.StopProcessGroupAsync(
+                        _serverProcess.Id,
+                        serverProcessStartTime,
+                        forceKillEntireProcessTree: !OperatingSystem.IsWindows(),
+                        CancellationToken.None).ConfigureAwait(false);
+                }
+                else
+                {
+                    stopped = true;
+                }
             }
 
             if (!stopped && !_serverProcess.HasExited)
@@ -197,16 +204,18 @@ internal sealed class AppHostServerSession : IAppHostServerSession
         _activity.Dispose();
     }
 
-    private DateTimeOffset? TryGetServerProcessStartTime()
+    private bool TryGetServerProcessStartTime(out DateTimeOffset? startTime)
     {
         try
         {
-            return new DateTimeOffset(_serverProcess.StartTime);
+            startTime = new DateTimeOffset(_serverProcess.StartTime);
+            return true;
         }
         catch (InvalidOperationException)
         {
             // The process exited between the HasExited check and shutdown coordination.
-            return null;
+            startTime = null;
+            return false;
         }
     }
 }

--- a/src/Aspire.Cli/Projects/AppHostServerSession.cs
+++ b/src/Aspire.Cli/Projects/AppHostServerSession.cs
@@ -25,6 +25,8 @@ internal sealed class AppHostServerSession : IAppHostServerSession
     private readonly ProfilingTelemetry? _profilingTelemetry;
     private readonly IDisposable? _projectLifetime;
     private readonly ProcessShutdownService? _processShutdownService;
+    private readonly TimeSpan? _processTerminationTimeout;
+    private readonly TimeSpan? _processShutdownTimeout;
     private IAppHostRpcClient? _rpcClient;
     private bool _disposed;
 
@@ -37,7 +39,9 @@ internal sealed class AppHostServerSession : IAppHostServerSession
         ProfilingTelemetry.ActivityScope activity = default,
         ProfilingTelemetry? profilingTelemetry = null,
         IDisposable? projectLifetime = null,
-        ProcessShutdownService? processShutdownService = null)
+        ProcessShutdownService? processShutdownService = null,
+        TimeSpan? processTerminationTimeout = null,
+        TimeSpan? processShutdownTimeout = null)
     {
         _serverProcess = serverProcess;
         _output = output;
@@ -48,6 +52,8 @@ internal sealed class AppHostServerSession : IAppHostServerSession
         _profilingTelemetry = profilingTelemetry;
         _projectLifetime = projectLifetime;
         _processShutdownService = processShutdownService;
+        _processTerminationTimeout = processTerminationTimeout;
+        _processShutdownTimeout = processShutdownTimeout;
     }
 
     /// <inheritdoc />
@@ -73,6 +79,8 @@ internal sealed class AppHostServerSession : IAppHostServerSession
     /// <param name="logger">The logger to use for lifecycle diagnostics.</param>
     /// <param name="profilingTelemetry">Optional profiling telemetry for the server process lifetime.</param>
     /// <param name="processShutdownService">Optional shared process shutdown coordinator.</param>
+    /// <param name="processTerminationTimeout">Optional per-process termination monitoring timeout.</param>
+    /// <param name="processShutdownTimeout">Optional total shutdown coordination timeout.</param>
     /// <returns>The started AppHost server session.</returns>
     internal static AppHostServerSession Start(
         IAppHostServerProject appHostServerProject,
@@ -80,7 +88,9 @@ internal sealed class AppHostServerSession : IAppHostServerSession
         bool debug,
         ILogger logger,
         ProfilingTelemetry? profilingTelemetry = null,
-        ProcessShutdownService? processShutdownService = null)
+        ProcessShutdownService? processShutdownService = null,
+        TimeSpan? processTerminationTimeout = null,
+        TimeSpan? processShutdownTimeout = null)
     {
         var currentPid = Environment.ProcessId;
         var serverEnvironmentVariables = environmentVariables is null
@@ -134,7 +144,9 @@ internal sealed class AppHostServerSession : IAppHostServerSession
             activity,
             profilingTelemetry,
             appHostServerProject as IDisposable,
-            processShutdownService);
+            processShutdownService,
+            processTerminationTimeout,
+            processShutdownTimeout);
     }
 
     /// <inheritdoc />
@@ -168,14 +180,17 @@ internal sealed class AppHostServerSession : IAppHostServerSession
             {
                 if (TryGetServerProcessStartTime(out var serverProcessStartTime))
                 {
-                    using var shutdownCts = new CancellationTokenSource(ProcessShutdownService.RunProcessShutdownTimeout);
+                    var processTerminationTimeout = _processTerminationTimeout ?? ProcessShutdownService.DefaultProcessTerminationTimeout;
+                    var processShutdownTimeout = _processShutdownTimeout ?? GetProcessShutdownTimeout(processTerminationTimeout);
+                    using var shutdownCts = new CancellationTokenSource(processShutdownTimeout);
                     try
                     {
+                        _logger.LogInformation("Requesting shutdown of AppHost server process {ProcessId}", _serverProcess.Id);
                         stopped = await _processShutdownService.StopProcessGroupAsync(
                             _serverProcess.Id,
                             serverProcessStartTime,
                             forceKillEntireProcessTree: !OperatingSystem.IsWindows(),
-                            processTerminationTimeout: ProcessShutdownService.RunProcessTerminationTimeout,
+                            processTerminationTimeout,
                             shutdownCts.Token).ConfigureAwait(false);
                     }
                     catch (OperationCanceledException) when (shutdownCts.IsCancellationRequested)
@@ -193,7 +208,9 @@ internal sealed class AppHostServerSession : IAppHostServerSession
             {
                 try
                 {
-                    _serverProcess.Kill(entireProcessTree: !OperatingSystem.IsWindows());
+                    var killEntireProcessTree = !OperatingSystem.IsWindows();
+                    _logger.LogInformation("Killing AppHost server process {ProcessId} (entireProcessTree={EntireProcessTree})", _serverProcess.Id, killEntireProcessTree);
+                    _serverProcess.Kill(entireProcessTree: killEntireProcessTree);
                     _activity.SetError("AppHost server process was terminated during session disposal.");
                 }
                 catch (Exception ex)
@@ -201,6 +218,7 @@ internal sealed class AppHostServerSession : IAppHostServerSession
                     _logger.LogDebug(ex, "Error killing AppHost server process");
                 }
             }
+
         }
 
         if (_serverProcess.HasExited)
@@ -227,6 +245,9 @@ internal sealed class AppHostServerSession : IAppHostServerSession
             return false;
         }
     }
+
+    private static TimeSpan GetProcessShutdownTimeout(TimeSpan processTerminationTimeout)
+        => TimeSpan.FromTicks(processTerminationTimeout.Ticks * 2) + TimeSpan.FromSeconds(1);
 }
 
 /// <summary>

--- a/src/Aspire.Cli/Projects/AppHostServerSession.cs
+++ b/src/Aspire.Cli/Projects/AppHostServerSession.cs
@@ -168,12 +168,20 @@ internal sealed class AppHostServerSession : IAppHostServerSession
             {
                 if (TryGetServerProcessStartTime(out var serverProcessStartTime))
                 {
-                    stopped = await _processShutdownService.StopProcessGroupAsync(
-                        _serverProcess.Id,
-                        serverProcessStartTime,
-                        forceKillEntireProcessTree: !OperatingSystem.IsWindows(),
-                        processTerminationTimeout: ProcessShutdownService.RunProcessTerminationTimeout,
-                        CancellationToken.None).ConfigureAwait(false);
+                    using var shutdownCts = new CancellationTokenSource(ProcessShutdownService.RunProcessShutdownTimeout);
+                    try
+                    {
+                        stopped = await _processShutdownService.StopProcessGroupAsync(
+                            _serverProcess.Id,
+                            serverProcessStartTime,
+                            forceKillEntireProcessTree: !OperatingSystem.IsWindows(),
+                            processTerminationTimeout: ProcessShutdownService.RunProcessTerminationTimeout,
+                            shutdownCts.Token).ConfigureAwait(false);
+                    }
+                    catch (OperationCanceledException) when (shutdownCts.IsCancellationRequested)
+                    {
+                        _logger.LogWarning("Timed out waiting for AppHost server process {ProcessId} shutdown.", _serverProcess.Id);
+                    }
                 }
                 else
                 {

--- a/src/Aspire.Cli/Projects/AppHostServerSession.cs
+++ b/src/Aspire.Cli/Projects/AppHostServerSession.cs
@@ -3,6 +3,7 @@
 
 using System.Diagnostics;
 using Aspire.Cli.Configuration;
+using Aspire.Cli.Processes;
 using Aspire.Cli.Telemetry;
 using Aspire.Cli.Utils;
 using Aspire.Hosting;
@@ -23,6 +24,7 @@ internal sealed class AppHostServerSession : IAppHostServerSession
     private readonly ProfilingTelemetry.ActivityScope _activity;
     private readonly ProfilingTelemetry? _profilingTelemetry;
     private readonly IDisposable? _projectLifetime;
+    private readonly ProcessShutdownService? _processShutdownService;
     private IAppHostRpcClient? _rpcClient;
     private bool _disposed;
 
@@ -34,7 +36,8 @@ internal sealed class AppHostServerSession : IAppHostServerSession
         ILogger logger,
         ProfilingTelemetry.ActivityScope activity = default,
         ProfilingTelemetry? profilingTelemetry = null,
-        IDisposable? projectLifetime = null)
+        IDisposable? projectLifetime = null,
+        ProcessShutdownService? processShutdownService = null)
     {
         _serverProcess = serverProcess;
         _output = output;
@@ -44,6 +47,7 @@ internal sealed class AppHostServerSession : IAppHostServerSession
         _activity = activity;
         _profilingTelemetry = profilingTelemetry;
         _projectLifetime = projectLifetime;
+        _processShutdownService = processShutdownService;
     }
 
     /// <inheritdoc />
@@ -68,13 +72,15 @@ internal sealed class AppHostServerSession : IAppHostServerSession
     /// <param name="debug">Whether to enable debug logging for the server.</param>
     /// <param name="logger">The logger to use for lifecycle diagnostics.</param>
     /// <param name="profilingTelemetry">Optional profiling telemetry for the server process lifetime.</param>
+    /// <param name="processShutdownService">Optional shared process shutdown coordinator.</param>
     /// <returns>The started AppHost server session.</returns>
     internal static AppHostServerSession Start(
         IAppHostServerProject appHostServerProject,
         Dictionary<string, string>? environmentVariables,
         bool debug,
         ILogger logger,
-        ProfilingTelemetry? profilingTelemetry = null)
+        ProfilingTelemetry? profilingTelemetry = null,
+        ProcessShutdownService? processShutdownService = null)
     {
         var currentPid = Environment.ProcessId;
         var serverEnvironmentVariables = environmentVariables is null
@@ -127,7 +133,8 @@ internal sealed class AppHostServerSession : IAppHostServerSession
             logger,
             activity,
             profilingTelemetry,
-            appHostServerProject as IDisposable);
+            appHostServerProject as IDisposable,
+            processShutdownService);
     }
 
     /// <inheritdoc />
@@ -156,14 +163,27 @@ internal sealed class AppHostServerSession : IAppHostServerSession
 
         if (!_serverProcess.HasExited)
         {
-            try
+            var stopped = false;
+            if (_processShutdownService is not null)
             {
-                _serverProcess.Kill(entireProcessTree: true);
-                _activity.SetError("AppHost server process was terminated during session disposal.");
+                stopped = await _processShutdownService.StopProcessGroupAsync(
+                    _serverProcess.Id,
+                    TryGetServerProcessStartTime(),
+                    forceKillEntireProcessTree: !OperatingSystem.IsWindows(),
+                    CancellationToken.None).ConfigureAwait(false);
             }
-            catch (Exception ex)
+
+            if (!stopped && !_serverProcess.HasExited)
             {
-                _logger.LogDebug(ex, "Error killing AppHost server process");
+                try
+                {
+                    _serverProcess.Kill(entireProcessTree: !OperatingSystem.IsWindows());
+                    _activity.SetError("AppHost server process was terminated during session disposal.");
+                }
+                catch (Exception ex)
+                {
+                    _logger.LogDebug(ex, "Error killing AppHost server process");
+                }
             }
         }
 
@@ -175,6 +195,19 @@ internal sealed class AppHostServerSession : IAppHostServerSession
         _serverProcess.Dispose();
         _projectLifetime?.Dispose();
         _activity.Dispose();
+    }
+
+    private DateTimeOffset? TryGetServerProcessStartTime()
+    {
+        try
+        {
+            return new DateTimeOffset(_serverProcess.StartTime);
+        }
+        catch (InvalidOperationException)
+        {
+            // The process exited between the HasExited check and shutdown coordination.
+            return null;
+        }
     }
 }
 

--- a/src/Aspire.Cli/Projects/DotNetBasedAppHostServerProject.cs
+++ b/src/Aspire.Cli/Projects/DotNetBasedAppHostServerProject.cs
@@ -482,11 +482,7 @@ internal sealed class DotNetBasedAppHostServerProject : IAppHostServerProject
             WindowStyle = ProcessWindowStyle.Minimized,
             UseShellExecute = false,
             CreateNoWindow = true
-        };
-        if (OperatingSystem.IsWindows())
-        {
-            startInfo.CreateNewProcessGroup = true;
-        }
+        }.CreateNewProcessGroupOnWindows();
 
         startInfo.ArgumentList.Add("exec");
         startInfo.ArgumentList.Add(assemblyPath);

--- a/src/Aspire.Cli/Projects/DotNetBasedAppHostServerProject.cs
+++ b/src/Aspire.Cli/Projects/DotNetBasedAppHostServerProject.cs
@@ -483,6 +483,11 @@ internal sealed class DotNetBasedAppHostServerProject : IAppHostServerProject
             UseShellExecute = false,
             CreateNoWindow = true
         };
+        if (OperatingSystem.IsWindows())
+        {
+            startInfo.CreateNewProcessGroup = true;
+        }
+
         startInfo.ArgumentList.Add("exec");
         startInfo.ArgumentList.Add(assemblyPath);
 

--- a/src/Aspire.Cli/Projects/ExtensionGuestLauncher.cs
+++ b/src/Aspire.Cli/Projects/ExtensionGuestLauncher.cs
@@ -34,6 +34,8 @@ internal sealed class ExtensionGuestLauncher : IGuestProcessLauncher
         DirectoryInfo workingDirectory,
         IDictionary<string, string> environmentVariables,
         CancellationToken cancellationToken,
+        TimeSpan? processTerminationTimeout = null,
+        TimeSpan? processShutdownTimeout = null,
         Func<Task>? afterLaunchAsync = null)
     {
         // Prepend the runtime command (e.g., "npx") as the first argument so the

--- a/src/Aspire.Cli/Projects/GuestAppHostProject.cs
+++ b/src/Aspire.Cli/Projects/GuestAppHostProject.cs
@@ -434,7 +434,9 @@ internal sealed class GuestAppHostProject : IAppHostProject, IGuestAppHostSdkGen
                     context.Debug,
                     _logger,
                     _profilingTelemetry,
-                    _processShutdownService);
+                    _processShutdownService,
+                    context.ProcessTerminationTimeout,
+                    context.ProcessShutdownTimeout);
                 try
                 {
                     // Give the server a moment to start
@@ -608,7 +610,7 @@ internal sealed class GuestAppHostProject : IAppHostProject, IGuestAppHostSdkGen
                 // appHostSystemCts is linked to cancellationToken) tears down the guest process. The
                 // launcher will kill the guest's process tree when this token cancels.
                 (guestExitCode, guestOutput) = await ExecuteGuestAppHostAsync(
-                    appHostFile, directory, environmentVariables, enableHotReload, rpcClient, launcher, StartBackchannelConnectionAfterGuestAppHostLaunchesAsync, appHostSystemToken);
+                    appHostFile, directory, environmentVariables, enableHotReload, rpcClient, launcher, StartBackchannelConnectionAfterGuestAppHostLaunchesAsync, context.ProcessTerminationTimeout, context.ProcessShutdownTimeout, appHostSystemToken);
             }
 
             // If the user cancelled (Ctrl+C), surface that as cancellation instead of a "guest failed"
@@ -1885,6 +1887,8 @@ internal sealed class GuestAppHostProject : IAppHostProject, IGuestAppHostSdkGen
         IAppHostRpcClient rpcClient,
         IGuestProcessLauncher launcher,
         Func<Task>? afterAppHostLaunchedAsync,
+        TimeSpan? processTerminationTimeout,
+        TimeSpan? processShutdownTimeout,
         CancellationToken cancellationToken)
     {
         await EnsureRuntimeCreatedAsync(directory, rpcClient, cancellationToken);
@@ -1895,7 +1899,16 @@ internal sealed class GuestAppHostProject : IAppHostProject, IGuestAppHostSdkGen
             return (CliExitCodes.FailedToDotnetRunAppHost, new OutputCollector());
         }
 
-        return await _guestRuntime.RunAsync(appHostFile, directory, environmentVariables, watchMode, launcher, cancellationToken, afterAppHostLaunchedAsync: afterAppHostLaunchedAsync);
+        return await _guestRuntime.RunAsync(
+            appHostFile,
+            directory,
+            environmentVariables,
+            watchMode,
+            launcher,
+            cancellationToken,
+            processTerminationTimeout,
+            processShutdownTimeout,
+            afterAppHostLaunchedAsync: afterAppHostLaunchedAsync);
     }
 
     /// <summary>

--- a/src/Aspire.Cli/Projects/GuestAppHostProject.cs
+++ b/src/Aspire.Cli/Projects/GuestAppHostProject.cs
@@ -11,6 +11,7 @@ using Aspire.Cli.Diagnostics;
 using Aspire.Cli.DotNet;
 using Aspire.Cli.Interaction;
 using Aspire.Cli.Packaging;
+using Aspire.Cli.Processes;
 using Aspire.Cli.Resources;
 using Aspire.Cli.Telemetry;
 using Aspire.Cli.Utils;
@@ -47,6 +48,7 @@ internal sealed class GuestAppHostProject : IAppHostProject, IGuestAppHostSdkGen
     private readonly TimeProvider _timeProvider;
     private readonly RunningInstanceManager _runningInstanceManager;
     private readonly ProfilingTelemetry _profilingTelemetry;
+    private readonly ProcessShutdownService _processShutdownService;
 
     // Language is always resolved via constructor
     private readonly LanguageInfo _resolvedLanguage;
@@ -67,6 +69,7 @@ internal sealed class GuestAppHostProject : IAppHostProject, IGuestAppHostSdkGen
         ILogger<GuestAppHostProject> logger,
         FileLoggerProvider fileLoggerProvider,
         ProfilingTelemetry profilingTelemetry,
+        ProcessShutdownService processShutdownService,
         TimeProvider? timeProvider = null)
     {
         _resolvedLanguage = language;
@@ -83,6 +86,7 @@ internal sealed class GuestAppHostProject : IAppHostProject, IGuestAppHostSdkGen
         _logger = logger;
         _fileLoggerProvider = fileLoggerProvider;
         _profilingTelemetry = profilingTelemetry;
+        _processShutdownService = processShutdownService;
         _timeProvider = timeProvider ?? TimeProvider.System;
         _runningInstanceManager = new RunningInstanceManager(_logger, _interactionService, _timeProvider);
     }
@@ -272,7 +276,8 @@ internal sealed class GuestAppHostProject : IAppHostProject, IGuestAppHostSdkGen
             environmentVariables: null,
             debug: false,
             _logger,
-            _profilingTelemetry);
+            _profilingTelemetry,
+            _processShutdownService);
 
         // Step 3: Connect to server
         var rpcClient = await serverSession.GetRpcClientAsync(cancellationToken);
@@ -428,7 +433,8 @@ internal sealed class GuestAppHostProject : IAppHostProject, IGuestAppHostSdkGen
                     launchSettingsEnvVars,
                     context.Debug,
                     _logger,
-                    _profilingTelemetry);
+                    _profilingTelemetry,
+                    _processShutdownService);
                 try
                 {
                     // Give the server a moment to start
@@ -1008,7 +1014,8 @@ internal sealed class GuestAppHostProject : IAppHostProject, IGuestAppHostSdkGen
                     launchSettingsEnvVars,
                     context.Debug,
                     _logger,
-                    _profilingTelemetry);
+                    _profilingTelemetry,
+                    _processShutdownService);
 
                 // Start connecting to the backchannel (fire-and-forget) so the caller is unblocked
                 // as soon as the server is reachable; the post-start work below races alongside it.
@@ -1799,7 +1806,7 @@ internal sealed class GuestAppHostProject : IAppHostProject, IGuestAppHostSdkGen
                 runtimeSpec = TypeScriptAppHostToolchainResolver.ApplyToRuntimeSpec(runtimeSpec, toolchain);
             }
 
-            _guestRuntime = new GuestRuntime(runtimeSpec, _logger, _fileLoggerProvider, profilingTelemetry: _profilingTelemetry);
+            _guestRuntime = new GuestRuntime(runtimeSpec, _logger, _fileLoggerProvider, profilingTelemetry: _profilingTelemetry, processShutdownService: _processShutdownService);
 
             _logger.LogDebug("Created GuestRuntime for {RuntimeDisplayName}: Execute={Command} {Args}",
                 runtimeSpec.DisplayName,

--- a/src/Aspire.Cli/Projects/GuestRuntime.cs
+++ b/src/Aspire.Cli/Projects/GuestRuntime.cs
@@ -154,6 +154,8 @@ internal sealed class GuestRuntime
     /// <param name="watchMode">Whether to run in watch mode for hot reload.</param>
     /// <param name="launcher">Strategy for launching the process.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
+    /// <param name="processTerminationTimeout">Optional per-process termination monitoring timeout.</param>
+    /// <param name="processShutdownTimeout">Optional total shutdown coordination timeout.</param>
     /// <param name="afterAppHostLaunchedAsync">Callback invoked after the AppHost execute command has launched.</param>
     /// <returns>A tuple of the exit code and captured output (null when launched via extension).</returns>
     public async Task<(int ExitCode, OutputCollector? Output)> RunAsync(
@@ -163,6 +165,8 @@ internal sealed class GuestRuntime
         bool watchMode,
         IGuestProcessLauncher launcher,
         CancellationToken cancellationToken,
+        TimeSpan? processTerminationTimeout = null,
+        TimeSpan? processShutdownTimeout = null,
         Func<Task>? afterAppHostLaunchedAsync = null)
     {
         var useWatchCommand = watchMode && _spec.WatchExecute is not null;
@@ -183,7 +187,18 @@ internal sealed class GuestRuntime
         var phase = useWatchCommand
             ? ProfilingTelemetry.Values.GuestCommandPhaseWatchExecute
             : ProfilingTelemetry.Values.GuestCommandPhaseExecute;
-        return await ExecuteCommandAsync(commandSpec, appHostFile, directory, environmentVariables, null, phase, launcher, cancellationToken, afterLaunchAsync: afterAppHostLaunchedAsync);
+        return await ExecuteCommandAsync(
+            commandSpec,
+            appHostFile,
+            directory,
+            environmentVariables,
+            null,
+            phase,
+            launcher,
+            cancellationToken,
+            processTerminationTimeout,
+            processShutdownTimeout,
+            afterLaunchAsync: afterAppHostLaunchedAsync);
     }
 
     /// <summary>
@@ -262,6 +277,8 @@ internal sealed class GuestRuntime
         string phase,
         IGuestProcessLauncher launcher,
         CancellationToken cancellationToken,
+        TimeSpan? processTerminationTimeout = null,
+        TimeSpan? processShutdownTimeout = null,
         Func<Task>? afterLaunchAsync = null)
     {
         var args = ReplacePlaceholders(commandSpec.Args, appHostFile, directory, additionalArgs);
@@ -272,7 +289,15 @@ internal sealed class GuestRuntime
         using var activity = _profilingTelemetry is null
             ? default
             : _profilingTelemetry.StartGuestExecuteCommand(_spec.Language, _spec.DisplayName, commandSpec.Command, args, directory, phase);
-        var (exitCode, output) = await launcher.LaunchAsync(commandSpec.Command, args, directory, mergedEnvironment, cancellationToken, afterLaunchAsync: afterLaunchAsync);
+        var (exitCode, output) = await launcher.LaunchAsync(
+            commandSpec.Command,
+            args,
+            directory,
+            mergedEnvironment,
+            cancellationToken,
+            processTerminationTimeout,
+            processShutdownTimeout,
+            afterLaunchAsync);
         activity.SetProcessExitCode(exitCode);
         if (exitCode != 0)
         {

--- a/src/Aspire.Cli/Projects/GuestRuntime.cs
+++ b/src/Aspire.Cli/Projects/GuestRuntime.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using Aspire.Cli.Diagnostics;
+using Aspire.Cli.Processes;
 using Aspire.Cli.Telemetry;
 using Aspire.Cli.Utils;
 using Aspire.TypeSystem;
@@ -20,6 +21,7 @@ internal sealed class GuestRuntime
     private readonly FileLoggerProvider? _fileLoggerProvider;
     private readonly Func<string, string?> _commandResolver;
     private readonly ProfilingTelemetry? _profilingTelemetry;
+    private readonly ProcessShutdownService? _processShutdownService;
 
     /// <summary>
     /// Creates a new GuestRuntime for the given runtime specification.
@@ -29,13 +31,21 @@ internal sealed class GuestRuntime
     /// <param name="fileLoggerProvider">Optional file logger for writing output to disk.</param>
     /// <param name="commandResolver">Optional command resolver used to locate executables on PATH.</param>
     /// <param name="profilingTelemetry">Optional profiling telemetry for child-process diagnostics.</param>
-    public GuestRuntime(RuntimeSpec spec, ILogger logger, FileLoggerProvider? fileLoggerProvider = null, Func<string, string?>? commandResolver = null, ProfilingTelemetry? profilingTelemetry = null)
+    /// <param name="processShutdownService">Optional shared process shutdown coordinator.</param>
+    public GuestRuntime(
+        RuntimeSpec spec,
+        ILogger logger,
+        FileLoggerProvider? fileLoggerProvider = null,
+        Func<string, string?>? commandResolver = null,
+        ProfilingTelemetry? profilingTelemetry = null,
+        ProcessShutdownService? processShutdownService = null)
     {
         _spec = spec;
         _logger = logger;
         _fileLoggerProvider = fileLoggerProvider;
         _commandResolver = commandResolver ?? PathLookupHelper.FindFullPathFromPath;
         _profilingTelemetry = profilingTelemetry;
+        _processShutdownService = processShutdownService;
     }
 
     /// <summary>
@@ -313,7 +323,7 @@ internal sealed class GuestRuntime
     /// <summary>
     /// Creates the default process-based launcher for this runtime.
     /// </summary>
-    public ProcessGuestLauncher CreateDefaultLauncher() => new(_spec.Language, _logger, _fileLoggerProvider, _commandResolver);
+    public ProcessGuestLauncher CreateDefaultLauncher() => new(_spec.Language, _logger, _fileLoggerProvider, _commandResolver, _processShutdownService);
 
     /// <summary>
     /// Replaces placeholders in command arguments with actual values.

--- a/src/Aspire.Cli/Projects/IGuestProcessLauncher.cs
+++ b/src/Aspire.Cli/Projects/IGuestProcessLauncher.cs
@@ -19,5 +19,7 @@ internal interface IGuestProcessLauncher
         DirectoryInfo workingDirectory,
         IDictionary<string, string> environmentVariables,
         CancellationToken cancellationToken,
+        TimeSpan? processTerminationTimeout = null,
+        TimeSpan? processShutdownTimeout = null,
         Func<Task>? afterLaunchAsync = null);
 }

--- a/src/Aspire.Cli/Projects/PrebuiltAppHostServer.cs
+++ b/src/Aspire.Cli/Projects/PrebuiltAppHostServer.cs
@@ -905,11 +905,7 @@ internal sealed class PrebuiltAppHostServer : IAppHostServerProject, IDisposable
             WindowStyle = ProcessWindowStyle.Minimized,
             UseShellExecute = false,
             CreateNoWindow = true
-        };
-        if (OperatingSystem.IsWindows())
-        {
-            startInfo.CreateNewProcessGroup = true;
-        }
+        }.CreateNewProcessGroupOnWindows();
 
         // Insert "server" subcommand, then remaining args
         startInfo.ArgumentList.Add("server");

--- a/src/Aspire.Cli/Projects/PrebuiltAppHostServer.cs
+++ b/src/Aspire.Cli/Projects/PrebuiltAppHostServer.cs
@@ -906,6 +906,10 @@ internal sealed class PrebuiltAppHostServer : IAppHostServerProject, IDisposable
             UseShellExecute = false,
             CreateNoWindow = true
         };
+        if (OperatingSystem.IsWindows())
+        {
+            startInfo.CreateNewProcessGroup = true;
+        }
 
         // Insert "server" subcommand, then remaining args
         startInfo.ArgumentList.Add("server");

--- a/src/Aspire.Cli/Projects/ProcessGuestLauncher.cs
+++ b/src/Aspire.Cli/Projects/ProcessGuestLauncher.cs
@@ -176,6 +176,7 @@ internal sealed class ProcessGuestLauncher : IGuestProcessLauncher
                             process.Id,
                             processStartedAt,
                             forceKillEntireProcessTree: true,
+                            processTerminationTimeout: ProcessShutdownService.RunProcessTerminationTimeout,
                             CancellationToken.None).ConfigureAwait(false);
                     }
                     else

--- a/src/Aspire.Cli/Projects/ProcessGuestLauncher.cs
+++ b/src/Aspire.Cli/Projects/ProcessGuestLauncher.cs
@@ -135,7 +135,6 @@ internal sealed class ProcessGuestLauncher : IGuestProcessLauncher
 
         AddEvent(activity, ProfilingTelemetry.Events.GuestProcessStart);
         process.Start();
-        var processStartedAt = new DateTimeOffset(process.StartTime);
         _logger.LogDebug("{Language} guest process {ProcessId} started: {Command}", _language, process.Id, resolvedCommandPath);
         activity?.SetTag(TelemetryConstants.Tags.ProcessPid, process.Id);
         AddEvent(activity, ProfilingTelemetry.Events.GuestProcessStarted, TelemetryConstants.Tags.ProcessPid, process.Id);
@@ -172,12 +171,22 @@ internal sealed class ProcessGuestLauncher : IGuestProcessLauncher
             // the redirected output streams have time to drain.
             if (!process.HasExited)
             {
-                var stopped = _processShutdownService is not null &&
-                    await _processShutdownService.StopProcessGroupAsync(
-                        process.Id,
-                        processStartedAt,
-                        forceKillEntireProcessTree: true,
-                        CancellationToken.None).ConfigureAwait(false);
+                var stopped = false;
+                if (_processShutdownService is not null)
+                {
+                    if (TryGetProcessStartTime(process, out var processStartedAt))
+                    {
+                        stopped = await _processShutdownService.StopProcessGroupAsync(
+                            process.Id,
+                            processStartedAt,
+                            forceKillEntireProcessTree: true,
+                            CancellationToken.None).ConfigureAwait(false);
+                    }
+                    else
+                    {
+                        stopped = true;
+                    }
+                }
 
                 if (!stopped && !process.HasExited)
                 {
@@ -218,6 +227,21 @@ internal sealed class ProcessGuestLauncher : IGuestProcessLauncher
         }
 
         return (process.ExitCode, outputCollector);
+    }
+
+    private static bool TryGetProcessStartTime(Process process, out DateTimeOffset? startTime)
+    {
+        try
+        {
+            startTime = new DateTimeOffset(process.StartTime);
+            return true;
+        }
+        catch (InvalidOperationException)
+        {
+            // The process exited between the HasExited check and shutdown coordination.
+            startTime = null;
+            return false;
+        }
     }
 
     private static Activity? GetCurrentProfilingActivity()

--- a/src/Aspire.Cli/Projects/ProcessGuestLauncher.cs
+++ b/src/Aspire.Cli/Projects/ProcessGuestLauncher.cs
@@ -69,11 +69,7 @@ internal sealed class ProcessGuestLauncher : IGuestProcessLauncher
             RedirectStandardError = true,
             UseShellExecute = false,
             CreateNoWindow = true
-        };
-        if (OperatingSystem.IsWindows())
-        {
-            startInfo.CreateNewProcessGroup = true;
-        }
+        }.CreateNewProcessGroupOnWindows();
 
         foreach (var arg in args)
         {

--- a/src/Aspire.Cli/Projects/ProcessGuestLauncher.cs
+++ b/src/Aspire.Cli/Projects/ProcessGuestLauncher.cs
@@ -41,6 +41,8 @@ internal sealed class ProcessGuestLauncher : IGuestProcessLauncher
         DirectoryInfo workingDirectory,
         IDictionary<string, string> environmentVariables,
         CancellationToken cancellationToken,
+        TimeSpan? processTerminationTimeout = null,
+        TimeSpan? processShutdownTimeout = null,
         Func<Task>? afterLaunchAsync = null)
     {
         var activity = GetCurrentProfilingActivity();
@@ -172,14 +174,16 @@ internal sealed class ProcessGuestLauncher : IGuestProcessLauncher
                 {
                     if (TryGetProcessStartTime(process, out var processStartedAt))
                     {
-                        using var shutdownCts = new CancellationTokenSource(ProcessShutdownService.RunProcessShutdownTimeout);
+                        var effectiveProcessTerminationTimeout = processTerminationTimeout ?? ProcessShutdownService.DefaultProcessTerminationTimeout;
+                        var effectiveProcessShutdownTimeout = processShutdownTimeout ?? GetProcessShutdownTimeout(effectiveProcessTerminationTimeout);
+                        using var shutdownCts = new CancellationTokenSource(effectiveProcessShutdownTimeout);
                         try
                         {
                             stopped = await _processShutdownService.StopProcessGroupAsync(
                                 process.Id,
                                 processStartedAt,
                                 forceKillEntireProcessTree: true,
-                                processTerminationTimeout: ProcessShutdownService.RunProcessTerminationTimeout,
+                                effectiveProcessTerminationTimeout,
                                 shutdownCts.Token).ConfigureAwait(false);
                         }
                         catch (OperationCanceledException) when (shutdownCts.IsCancellationRequested)
@@ -212,7 +216,7 @@ internal sealed class ProcessGuestLauncher : IGuestProcessLauncher
             }
 
             _logger.LogDebug("Waiting for {Language} guest process {ProcessId} to exit after kill", _language, process.Id);
-            using var finalExitCts = new CancellationTokenSource(ProcessShutdownService.RunProcessTerminationTimeout);
+            using var finalExitCts = new CancellationTokenSource(processTerminationTimeout ?? ProcessShutdownService.DefaultProcessTerminationTimeout);
             try
             {
                 await process.WaitForExitAsync(finalExitCts.Token).ConfigureAwait(false);
@@ -257,6 +261,9 @@ internal sealed class ProcessGuestLauncher : IGuestProcessLauncher
             return false;
         }
     }
+
+    private static TimeSpan GetProcessShutdownTimeout(TimeSpan processTerminationTimeout)
+        => TimeSpan.FromTicks(processTerminationTimeout.Ticks * 2) + TimeSpan.FromSeconds(1);
 
     private static Activity? GetCurrentProfilingActivity()
     {

--- a/src/Aspire.Cli/Projects/ProcessGuestLauncher.cs
+++ b/src/Aspire.Cli/Projects/ProcessGuestLauncher.cs
@@ -3,6 +3,7 @@
 
 using System.Diagnostics;
 using Aspire.Cli.Diagnostics;
+using Aspire.Cli.Processes;
 using Aspire.Cli.Telemetry;
 using Aspire.Cli.Utils;
 using Microsoft.Extensions.Logging;
@@ -18,13 +19,20 @@ internal sealed class ProcessGuestLauncher : IGuestProcessLauncher
     private readonly ILogger _logger;
     private readonly FileLoggerProvider? _fileLoggerProvider;
     private readonly Func<string, string?> _commandResolver;
+    private readonly ProcessShutdownService? _processShutdownService;
 
-    public ProcessGuestLauncher(string language, ILogger logger, FileLoggerProvider? fileLoggerProvider = null, Func<string, string?>? commandResolver = null)
+    public ProcessGuestLauncher(
+        string language,
+        ILogger logger,
+        FileLoggerProvider? fileLoggerProvider = null,
+        Func<string, string?>? commandResolver = null,
+        ProcessShutdownService? processShutdownService = null)
     {
         _language = language;
         _logger = logger;
         _fileLoggerProvider = fileLoggerProvider;
         _commandResolver = commandResolver ?? PathLookupHelper.FindFullPathFromPath;
+        _processShutdownService = processShutdownService;
     }
 
     public async Task<(int ExitCode, OutputCollector? Output)> LaunchAsync(
@@ -62,6 +70,10 @@ internal sealed class ProcessGuestLauncher : IGuestProcessLauncher
             UseShellExecute = false,
             CreateNoWindow = true
         };
+        if (OperatingSystem.IsWindows())
+        {
+            startInfo.CreateNewProcessGroup = true;
+        }
 
         foreach (var arg in args)
         {
@@ -123,6 +135,7 @@ internal sealed class ProcessGuestLauncher : IGuestProcessLauncher
 
         AddEvent(activity, ProfilingTelemetry.Events.GuestProcessStart);
         process.Start();
+        var processStartedAt = new DateTimeOffset(process.StartTime);
         activity?.SetTag(TelemetryConstants.Tags.ProcessPid, process.Id);
         AddEvent(activity, ProfilingTelemetry.Events.GuestProcessStarted, TelemetryConstants.Tags.ProcessPid, process.Id);
         if (afterLaunchAsync is not null)
@@ -141,9 +154,10 @@ internal sealed class ProcessGuestLauncher : IGuestProcessLauncher
         {
             // The guest process is the AppHost's primary process for this language. When the caller
             // cancels - either because the user pressed Ctrl+C or because a fatal startup condition
-            // (e.g. the AppHost server backchannel timed out) escalated into a teardown - we must kill
-            // the process tree, otherwise the AppHost stays alive after the CLI returns and the run
-            // appears to hang from the user's perspective.
+            // (e.g. the AppHost server backchannel timed out) escalated into a teardown - use the
+            // same graceful-then-force shutdown flow as AppHostLauncher. The command cancellation
+            // token is already canceled here, so using it for the process-exit wait would race the
+            // graceful shutdown and immediately force-kill the guest AppHost.
             //
             // We don't rethrow the OperationCanceledException because the caller in GuestAppHostProject
             // uses the returned exit code to distinguish user cancellation from internal teardown
@@ -152,13 +166,23 @@ internal sealed class ProcessGuestLauncher : IGuestProcessLauncher
             // the redirected output streams have time to drain.
             if (!process.HasExited)
             {
-                try
+                var stopped = _processShutdownService is not null &&
+                    await _processShutdownService.StopProcessGroupAsync(
+                        process.Id,
+                        processStartedAt,
+                        forceKillEntireProcessTree: true,
+                        CancellationToken.None).ConfigureAwait(false);
+
+                if (!stopped && !process.HasExited)
                 {
-                    process.Kill(entireProcessTree: true);
-                }
-                catch (Exception killEx)
-                {
-                    _logger.LogDebug(killEx, "Failed to kill guest process {ProcessId} after cancellation", process.Id);
+                    try
+                    {
+                        process.Kill(entireProcessTree: true);
+                    }
+                    catch (Exception killEx)
+                    {
+                        _logger.LogDebug(killEx, "Failed to kill guest process {ProcessId} after cancellation", process.Id);
+                    }
                 }
             }
 

--- a/src/Aspire.Cli/Projects/ProcessGuestLauncher.cs
+++ b/src/Aspire.Cli/Projects/ProcessGuestLauncher.cs
@@ -163,8 +163,8 @@ internal sealed class ProcessGuestLauncher : IGuestProcessLauncher
             // We don't rethrow the OperationCanceledException because the caller in GuestAppHostProject
             // uses the returned exit code to distinguish user cancellation from internal teardown
             // (e.g. surfacing captured output when the guest was killed because the AppHost system
-            // failed). Wait without honoring cancellation so the OS reports the final exit code and
-            // the redirected output streams have time to drain.
+            // failed). Use fresh timeout tokens instead of the already-canceled command token so
+            // shutdown gets its budget without turning into an unbounded wait.
             if (!process.HasExited)
             {
                 var stopped = false;
@@ -172,12 +172,20 @@ internal sealed class ProcessGuestLauncher : IGuestProcessLauncher
                 {
                     if (TryGetProcessStartTime(process, out var processStartedAt))
                     {
-                        stopped = await _processShutdownService.StopProcessGroupAsync(
-                            process.Id,
-                            processStartedAt,
-                            forceKillEntireProcessTree: true,
-                            processTerminationTimeout: ProcessShutdownService.RunProcessTerminationTimeout,
-                            CancellationToken.None).ConfigureAwait(false);
+                        using var shutdownCts = new CancellationTokenSource(ProcessShutdownService.RunProcessShutdownTimeout);
+                        try
+                        {
+                            stopped = await _processShutdownService.StopProcessGroupAsync(
+                                process.Id,
+                                processStartedAt,
+                                forceKillEntireProcessTree: true,
+                                processTerminationTimeout: ProcessShutdownService.RunProcessTerminationTimeout,
+                                shutdownCts.Token).ConfigureAwait(false);
+                        }
+                        catch (OperationCanceledException) when (shutdownCts.IsCancellationRequested)
+                        {
+                            _logger.LogWarning("Timed out waiting for {Language} guest process {ProcessId} shutdown.", _language, process.Id);
+                        }
                     }
                     else
                     {
@@ -204,13 +212,22 @@ internal sealed class ProcessGuestLauncher : IGuestProcessLauncher
             }
 
             _logger.LogDebug("Waiting for {Language} guest process {ProcessId} to exit after kill", _language, process.Id);
-            await process.WaitForExitAsync(CancellationToken.None).ConfigureAwait(false);
+            using var finalExitCts = new CancellationTokenSource(ProcessShutdownService.RunProcessTerminationTimeout);
+            try
+            {
+                await process.WaitForExitAsync(finalExitCts.Token).ConfigureAwait(false);
+            }
+            catch (OperationCanceledException) when (finalExitCts.IsCancellationRequested)
+            {
+                _logger.LogWarning("Timed out waiting for {Language} guest process {ProcessId} to exit after shutdown.", _language, process.Id);
+            }
         }
 
-        _logger.LogDebug("{Language} guest process {ProcessId} exited with code {ExitCode}", _language, process.Id, process.ExitCode);
+        var exitCode = process.HasExited ? process.ExitCode : -1;
+        _logger.LogDebug("{Language} guest process {ProcessId} exited with code {ExitCode}", _language, process.Id, exitCode);
 
-        activity?.SetTag(TelemetryConstants.Tags.ProcessExitCode, process.ExitCode);
-        AddEvent(activity, ProfilingTelemetry.Events.GuestProcessExited, TelemetryConstants.Tags.ProcessExitCode, process.ExitCode);
+        activity?.SetTag(TelemetryConstants.Tags.ProcessExitCode, exitCode);
+        AddEvent(activity, ProfilingTelemetry.Events.GuestProcessExited, TelemetryConstants.Tags.ProcessExitCode, exitCode);
 
         // Wait for the redirected streams to finish draining so no trailing lines are lost.
         // Pass a fresh token rather than the outer cancellation token: when WaitForExitAsync
@@ -223,7 +240,7 @@ internal sealed class ProcessGuestLauncher : IGuestProcessLauncher
             _logger.LogWarning("{Language}({ProcessId}): Timed out waiting for output streams to drain after process exit", _language, process.Id);
         }
 
-        return (process.ExitCode, outputCollector);
+        return (exitCode, outputCollector);
     }
 
     private static bool TryGetProcessStartTime(Process process, out DateTimeOffset? startTime)

--- a/src/Aspire.Cli/Utils/ProcessStartInfoExtensions.cs
+++ b/src/Aspire.Cli/Utils/ProcessStartInfoExtensions.cs
@@ -1,0 +1,22 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Diagnostics;
+
+namespace Aspire.Cli.Utils;
+
+internal static class ProcessStartInfoExtensions
+{
+    public static ProcessStartInfo CreateNewProcessGroupOnWindows(this ProcessStartInfo startInfo)
+    {
+        if (OperatingSystem.IsWindows())
+        {
+            // Windows can only target CTRL_BREAK_EVENT at a child process group when the child is
+            // started with CREATE_NEW_PROCESS_GROUP. Ctrl+C is not usable for that case, so Aspire
+            // creates groups for guest AppHosts and AppHost servers that it needs to stop gracefully.
+            startInfo.CreateNewProcessGroup = true;
+        }
+
+        return startInfo;
+    }
+}

--- a/src/Shared/ProcessSignaler.cs
+++ b/src/Shared/ProcessSignaler.cs
@@ -32,12 +32,6 @@ internal static partial class ProcessSignaler
 
     public static void RequestGracefulShutdownForProcessGroup(int pid, DateTimeOffset? expectedStartTime, ILogger logger)
     {
-        using var process = TryGetRunningProcess(pid, expectedStartTime, logger);
-        if (process is null)
-        {
-            return; // Process is not running or does not match the expected start time
-        }
-
         logger.LogDebug("Requesting graceful shutdown of process group {Pid}...", pid);
 
         if (OperatingSystem.IsWindows())
@@ -46,6 +40,12 @@ internal static partial class ProcessSignaler
         }
         else
         {
+            using var process = TryGetRunningProcess(pid, expectedStartTime, logger);
+            if (process is null)
+            {
+                return; // Process is not running or does not match the expected start time
+            }
+
             RequestGracefulShutdownUnix(pid, logger);
         }
     }

--- a/src/Shared/ProcessSignaler.cs
+++ b/src/Shared/ProcessSignaler.cs
@@ -121,7 +121,7 @@ internal static partial class ProcessSignaler
         var result = GenerateConsoleCtrlEvent(CtrlBreakEvent, (uint)pid);
         if (!result)
         {
-            int error = Marshal.GetLastWin32Error();
+            var error = Marshal.GetLastWin32Error();
             // Best effort.
             logger.LogWarning("Could not gracefully stop Aspire application host process group {Pid}; the error code from signal send operation was {ErrorCode}", pid, error);
         }

--- a/src/Shared/ProcessSignaler.cs
+++ b/src/Shared/ProcessSignaler.cs
@@ -30,6 +30,26 @@ internal static partial class ProcessSignaler
         }
     }
 
+    public static void RequestGracefulShutdownForProcessGroup(int pid, DateTimeOffset? expectedStartTime, ILogger logger)
+    {
+        using var process = TryGetRunningProcess(pid, expectedStartTime, logger);
+        if (process is null)
+        {
+            return; // Process is not running or does not match the expected start time
+        }
+
+        logger.LogDebug("Requesting graceful shutdown of process group {Pid}...", pid);
+
+        if (OperatingSystem.IsWindows())
+        {
+            RequestGracefulShutdownWindowsProcessGroup(pid, logger);
+        }
+        else
+        {
+            RequestGracefulShutdownUnix(pid, logger);
+        }
+    }
+
     public static void ForceKill(int pid, DateTimeOffset? expectedStartTime, ILogger logger, bool killEntireProcessTree = false)
     {
         using var process = TryGetRunningProcess(pid, expectedStartTime, logger);
@@ -91,6 +111,21 @@ internal static partial class ProcessSignaler
     }
 
     private const int SigTerm = 15;
+    // Use CTRL_BREAK_EVENT for Windows process-group shutdown. Ctrl+C is not suitable here because
+    // Windows disables Ctrl+C delivery for processes launched with CREATE_NEW_PROCESS_GROUP.
+    // See https://learn.microsoft.com/windows/console/generateconsolectrlevent.
+    private const uint CtrlBreakEvent = 1;
+
+    private static void RequestGracefulShutdownWindowsProcessGroup(int pid, ILogger logger)
+    {
+        var result = GenerateConsoleCtrlEvent(CtrlBreakEvent, (uint)pid);
+        if (!result)
+        {
+            int error = Marshal.GetLastWin32Error();
+            // Best effort.
+            logger.LogWarning("Could not gracefully stop Aspire application host process group {Pid}; the error code from signal send operation was {ErrorCode}", pid, error);
+        }
+    }
 
     private static void RequestGracefulShutdownUnix(int pid, ILogger logger)
     {
@@ -107,4 +142,8 @@ internal static partial class ProcessSignaler
     // See https://developers.redhat.com/blog/2019/03/25/using-net-pinvoke-for-linux-system-functions
     [LibraryImport("libc", SetLastError = true, EntryPoint = "kill")]
     private static partial int kill(int pid, int sig);
+
+    [LibraryImport("kernel32.dll", SetLastError = true)]
+    [return: MarshalAs(UnmanagedType.Bool)]
+    private static partial bool GenerateConsoleCtrlEvent(uint dwCtrlEvent, uint dwProcessGroupId);
 }

--- a/tests/Aspire.Cli.Tests/Processes/ProcessShutdownServiceTests.cs
+++ b/tests/Aspire.Cli.Tests/Processes/ProcessShutdownServiceTests.cs
@@ -18,6 +18,43 @@ namespace Aspire.Cli.Tests.Processes;
 public class ProcessShutdownServiceTests(ITestOutputHelper outputHelper)
 {
     [Fact]
+    public async Task TryGetRunningProcess_MatchesGuestAppHostStyleChildStartTime()
+    {
+        using var process = StartLongRunningProcess();
+        try
+        {
+            var startTime = new DateTimeOffset(process.StartTime);
+
+            using var resolvedProcess = ProcessSignaler.TryGetRunningProcess(process.Id, startTime, NullLogger.Instance);
+
+            Assert.NotNull(resolvedProcess);
+            Assert.Equal(process.Id, resolvedProcess.Id);
+        }
+        finally
+        {
+            await StopProcessAsync(process);
+        }
+    }
+
+    [Fact]
+    public async Task TryGetRunningProcess_RejectsMismatchedStartTime()
+    {
+        using var process = StartLongRunningProcess();
+        try
+        {
+            var wrongStartTime = new DateTimeOffset(process.StartTime).AddMinutes(-5);
+
+            using var resolvedProcess = ProcessSignaler.TryGetRunningProcess(process.Id, wrongStartTime, NullLogger.Instance);
+
+            Assert.Null(resolvedProcess);
+        }
+        finally
+        {
+            await StopProcessAsync(process);
+        }
+    }
+
+    [Fact]
     public async Task TryStopProcessTreeWithDcpAsync_UsesDcpStopProcessTreeArguments()
     {
         using var workspace = TemporaryWorkspace.Create(outputHelper);
@@ -177,6 +214,20 @@ public class ProcessShutdownServiceTests(ITestOutputHelper outputHelper)
         };
         startInfo.ArgumentList.Add("-c");
         startInfo.ArgumentList.Add("trap '' TERM; exec sleep 60");
+
+        var process = Process.Start(startInfo);
+        Assert.NotNull(process);
+        return process;
+    }
+
+    private static Process StartLongRunningProcess()
+    {
+        var startInfo = OperatingSystem.IsWindows()
+            ? new ProcessStartInfo("cmd.exe", "/c ping -n 60 127.0.0.1 > nul")
+            : new ProcessStartInfo("/bin/sh", "-c 'sleep 60'");
+        startInfo.RedirectStandardError = true;
+        startInfo.RedirectStandardOutput = true;
+        startInfo.UseShellExecute = false;
 
         var process = Process.Start(startInfo);
         Assert.NotNull(process);

--- a/tests/Aspire.Cli.Tests/Projects/GuestAppHostProjectTests.cs
+++ b/tests/Aspire.Cli.Tests/Projects/GuestAppHostProjectTests.cs
@@ -4,7 +4,9 @@
 using Aspire.Cli.Configuration;
 using Aspire.Cli.Diagnostics;
 using Aspire.Cli.Interaction;
+using Aspire.Cli.Layout;
 using Aspire.Cli.Packaging;
+using Aspire.Cli.Processes;
 using Aspire.Cli.Projects;
 using Aspire.Cli.Telemetry;
 using Aspire.Cli.Tests.TestServices;
@@ -935,7 +937,14 @@ public class GuestAppHostProjectTests : IDisposable
             executionContext: executionContext,
             logger: NullLogger<GuestAppHostProject>.Instance,
             fileLoggerProvider: new FileLoggerProvider(logFilePath, new TestStartupErrorWriter()),
-            profilingTelemetry: _profilingTelemetry);
+            profilingTelemetry: _profilingTelemetry,
+            processShutdownService: new ProcessShutdownService(
+                new NullLayoutDiscovery(),
+                new NullBundleService(),
+                new LayoutProcessRunner(new TestProcessExecutionFactory()),
+                executionContext,
+                NullLogger<ProcessShutdownService>.Instance,
+                TimeProvider.System));
     }
 
 }

--- a/tests/Aspire.Cli.Tests/Projects/GuestRuntimeTests.cs
+++ b/tests/Aspire.Cli.Tests/Projects/GuestRuntimeTests.cs
@@ -886,6 +886,8 @@ public class GuestRuntimeTests(ITestOutputHelper outputHelper)
             DirectoryInfo workingDirectory,
             IDictionary<string, string> environmentVariables,
             CancellationToken cancellationToken,
+            TimeSpan? processTerminationTimeout = null,
+            TimeSpan? processShutdownTimeout = null,
             Func<Task>? afterLaunchAsync = null)
         {
             Calls.Add((command, args));

--- a/tests/Aspire.Cli.Tests/Projects/ProcessGuestLauncherTests.cs
+++ b/tests/Aspire.Cli.Tests/Projects/ProcessGuestLauncherTests.cs
@@ -13,6 +13,8 @@ namespace Aspire.Cli.Tests.Projects;
 
 public class ProcessGuestLauncherTests(ITestOutputHelper outputHelper)
 {
+    private static readonly TimeSpan s_processStartupTimeout = TimeSpan.FromSeconds(30);
+
     [Fact]
     [SkipOnPlatform(TestPlatforms.Windows, "This verifies the Unix SIGTERM graceful shutdown path.")]
     public async Task LaunchAsync_CancellationUsesUnixGracefulShutdownBeforeForceKill()
@@ -119,7 +121,7 @@ public class ProcessGuestLauncherTests(ITestOutputHelper outputHelper)
 
     private static async Task WaitForFileAsync(string path)
     {
-        using var timeout = new CancellationTokenSource(TimeSpan.FromSeconds(2));
+        using var timeout = new CancellationTokenSource(s_processStartupTimeout);
         while (!File.Exists(path))
         {
             await Task.Delay(TimeSpan.FromMilliseconds(20), timeout.Token);

--- a/tests/Aspire.Cli.Tests/Projects/ProcessGuestLauncherTests.cs
+++ b/tests/Aspire.Cli.Tests/Projects/ProcessGuestLauncherTests.cs
@@ -1,0 +1,140 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Aspire.Cli.Layout;
+using Aspire.Cli.Processes;
+using Aspire.Cli.Projects;
+using Aspire.Cli.Tests.TestServices;
+using Aspire.Cli.Tests.Utils;
+using Aspire.Shared;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace Aspire.Cli.Tests.Projects;
+
+public class ProcessGuestLauncherTests(ITestOutputHelper outputHelper)
+{
+    [Fact]
+    [SkipOnPlatform(TestPlatforms.Windows, "This verifies the Unix SIGTERM graceful shutdown path.")]
+    public async Task LaunchAsync_CancellationUsesUnixGracefulShutdownBeforeForceKill()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        var readyFile = Path.Combine(workspace.WorkspaceRoot.FullName, "ready.txt");
+        var launcher = new ProcessGuestLauncher(
+            "test",
+            NullLogger.Instance,
+            commandResolver: command => command == "/bin/sh" ? command : null,
+            processShutdownService: CreateProcessShutdownService(workspace));
+        using var cancellationTokenSource = new CancellationTokenSource();
+
+        var (exitCode, _) = await launcher.LaunchAsync(
+            "/bin/sh",
+            [
+                "-c",
+                "trap 'exit 0' TERM; printf ready > \"$1\"; while :; do sleep 0.1; done",
+                "ignored",
+                readyFile
+            ],
+            workspace.WorkspaceRoot,
+            new Dictionary<string, string>(),
+            cancellationTokenSource.Token,
+            afterLaunchAsync: async () =>
+            {
+                await WaitForFileAsync(readyFile);
+                await cancellationTokenSource.CancelAsync();
+            }).WaitAsync(TimeSpan.FromSeconds(5));
+
+        Assert.Equal(0, exitCode);
+    }
+
+    [Fact]
+    [SkipOnPlatform(TestPlatforms.Linux | TestPlatforms.OSX | TestPlatforms.FreeBSD, "This verifies Windows CTRL_BREAK_EVENT process-group shutdown.")]
+    public async Task LaunchAsync_CancellationUsesWindowsCtrlBreakBeforeForceKill()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        var scriptsDirectory = workspace.CreateDirectory("scripts");
+        var outputDirectory = workspace.CreateDirectory("output");
+        var scriptPath = Path.Combine(scriptsDirectory.FullName, "ctrl-break.ps1");
+        var readyFile = Path.Combine(outputDirectory.FullName, "ready.txt");
+        var breakFile = Path.Combine(outputDirectory.FullName, "break.txt");
+        await File.WriteAllTextAsync(
+            scriptPath,
+            """
+            param(
+                [string] $ReadyPath,
+                [string] $BreakPath
+            )
+
+            $receivedBreak = [System.Threading.ManualResetEventSlim]::new($false)
+            [Console]::CancelKeyPress += {
+                param($Sender, $EventArgs)
+                if ($EventArgs.SpecialKey -eq [ConsoleSpecialKey]::ControlBreak) {
+                    $EventArgs.Cancel = $true
+                    Set-Content -Path $BreakPath -Value 'break'
+                    $receivedBreak.Set()
+                }
+            }
+
+            Set-Content -Path $ReadyPath -Value 'ready'
+            if ($receivedBreak.Wait([TimeSpan]::FromSeconds(30))) {
+                exit 0
+            }
+
+            exit 2
+            """);
+        var launcher = new ProcessGuestLauncher(
+            "test",
+            NullLogger.Instance,
+            processShutdownService: CreateProcessShutdownService(workspace));
+        using var cancellationTokenSource = new CancellationTokenSource();
+
+        var (exitCode, _) = await launcher.LaunchAsync(
+            "powershell.exe",
+            ["-NoProfile", "-ExecutionPolicy", "Bypass", "-File", scriptPath, readyFile, breakFile],
+            workspace.WorkspaceRoot,
+            new Dictionary<string, string>(),
+            cancellationTokenSource.Token,
+            afterLaunchAsync: async () =>
+            {
+                await WaitForFileAsync(readyFile);
+                await cancellationTokenSource.CancelAsync();
+            }).WaitAsync(TimeSpan.FromSeconds(20));
+
+        Assert.Equal(0, exitCode);
+        Assert.True(File.Exists(breakFile));
+    }
+
+    private static ProcessShutdownService CreateProcessShutdownService(TemporaryWorkspace workspace)
+    {
+        var dcpDirectory = workspace.WorkspaceRoot.CreateSubdirectory("dcp");
+        File.WriteAllText(BundleDiscovery.GetDcpExecutablePath(dcpDirectory.FullName), string.Empty);
+
+        return new ProcessShutdownService(
+            new FixedLayoutDiscovery(dcpDirectory.FullName),
+            new NullBundleService(),
+            new LayoutProcessRunner(new TestProcessExecutionFactory()),
+            workspace.CreateExecutionContext(),
+            NullLogger<ProcessShutdownService>.Instance,
+            TimeProvider.System);
+    }
+
+    private static async Task WaitForFileAsync(string path)
+    {
+        using var timeout = new CancellationTokenSource(TimeSpan.FromSeconds(2));
+        while (!File.Exists(path))
+        {
+            await Task.Delay(TimeSpan.FromMilliseconds(20), timeout.Token);
+        }
+    }
+
+    private sealed class FixedLayoutDiscovery(string dcpDirectory) : ILayoutDiscovery
+    {
+        public LayoutConfiguration? DiscoverLayout(string? projectDirectory = null) => null;
+
+        public string? GetComponentPath(LayoutComponent component, string? projectDirectory = null)
+        {
+            return component == LayoutComponent.Dcp ? dcpDirectory : null;
+        }
+
+        public bool IsBundleModeAvailable(string? projectDirectory = null) => true;
+    }
+}


### PR DESCRIPTION
## Description

`aspire run` could race graceful shutdown for guest AppHosts: cancellation stopped the CLI wait immediately and the guest launcher could force-kill the guest process tree before the process handled Ctrl+C/Ctrl+Break. On Windows, the AppHost server also needs different fallback behavior from the guest because DCP is in the server process tree and should not be killed by server fallback cleanup.

This change launches guest AppHost processes and AppHost servers in Windows process groups, adds a `ProcessShutdownService` process-group shutdown path that sends `CTRL_BREAK_EVENT`, and routes guest/server cancellation through the shared graceful-then-force shutdown flow. Guest fallback still kills the whole process tree. Server fallback kills the whole tree on Unix, but only the target server process on Windows so in-tree DCP can keep handling cleanup.

### User-facing behavior

Pressing Ctrl+C during `aspire run` for guest AppHosts now gives the guest and AppHost server a graceful shutdown window before force termination, aligning the run path with the existing shutdown coordinator behavior.

Validation:

- `dotnet test --project tests/Aspire.Cli.Tests/Aspire.Cli.Tests.csproj --no-launch-profile -- --filter-class "*.ProcessGuestLauncherTests" --filter-class "*.ProcessShutdownServiceTests" --filter-class "*.AppHostServerSessionTests" --filter-not-trait "quarantined=true" --filter-not-trait "outerloop=true"`

Fixes # (issue)

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No