### PR TITLE
[release/13.4] Remove 'aspire new aspire-starter' step from CLI archive verifier

### DIFF
--- a/eng/scripts/verify-cli-archive.ps1
+++ b/eng/scripts/verify-cli-archive.ps1
@@ -8,8 +8,7 @@
     2. Extracts the CLI archive to a temp location
     3. Verifies the archive shape contains the native CLI payload and no install-route sidecar
     4. Runs 'aspire --version' to validate the binary executes
-    5. Runs 'aspire new aspire-starter' to test C# starter creation
-    6. Cleans up temp directories
+    5. Cleans up temp directories
 
 .PARAMETER ArchivePath
     Path to the CLI archive (.zip or .tar.gz)
@@ -115,29 +114,6 @@ function Test-ArchiveSidecar {
         throw "$ridFamily-* archive '$ArchiveFileName' must not contain '.aspire-install.json' (per-RID archives are shared across install routes; each route authors its own sidecar after extraction). Found: $($strayPaths -join ', ')"
     }
     Write-Step "$ridFamily-* archive correctly omits the install-route sidecar."
-}
-
-function Test-CSharpStarterProject {
-    param(
-        [Parameter(Mandatory = $true)][string]$AspireBin,
-        [Parameter(Mandatory = $true)][string]$ProjectRoot
-    )
-
-    Write-Step "Running 'aspire new aspire-starter --name VerifyApp --output $ProjectRoot --non-interactive --nologo --suppress-agent-init'..."
-    & $AspireBin new aspire-starter --name VerifyApp --output $ProjectRoot --non-interactive --nologo --suppress-agent-init 2>&1 | Write-Host
-    if ($LASTEXITCODE -ne 0) {
-        Write-Err "'aspire new aspire-starter' failed with exit code $LASTEXITCODE"
-        exit 1
-    }
-
-    $appHostDir = Join-Path $ProjectRoot "VerifyApp.AppHost"
-    if (-not (Test-Path $appHostDir)) {
-        Write-Err "Expected project directory 'VerifyApp.AppHost' not found after 'aspire new aspire-starter'"
-        Get-ChildItem $ProjectRoot | Format-Table
-        exit 1
-    }
-
-    Write-Ok "'aspire new aspire-starter' created project successfully"
 }
 
 $userHome = Get-UserHome
@@ -248,16 +224,20 @@ try {
     Write-Host "  Version: $versionOutput"
     Write-Ok "'aspire --version' succeeded"
 
-    # Step 4: Create starter project with aspire new. The C# starter exercises
-    # template engine + bundle self-extraction without requiring a NuGet restore.
-    # The TypeScript starter check (#17274) is intentionally not invoked here:
-    # its packager-managed AppHost bootstrap triggers a NuGet restore whose
-    # transitive deps resolve to api.nuget.org, which the 1ES signed-build agent
-    # has no egress to. Re-adding it requires either an internal NuGet mirror
-    # config or skipping the auto-restore. Tracked in #17345.
-    $csharpProjectDir = Join-Path $verifyTmpDir "VerifyApp"
-    New-Item -ItemType Directory -Path $csharpProjectDir -Force | Out-Null
-    Test-CSharpStarterProject -AspireBin $aspireBin -ProjectRoot $csharpProjectDir
+    # Note: 'aspire new aspire-starter' was previously invoked here to exercise the
+    # template engine + bundle self-extraction path. It has been removed because the
+    # template lookup is not actually offline — it queries NuGet feeds via
+    # TemplateNuGetConfigService.ResolveTemplatePackageAsync. The step only ever
+    # succeeded on release branches because builds were mis-baked with
+    # AspireCliChannel=stable, which routed the lookup to nuget.org and found a
+    # previously-shipped Aspire.ProjectTemplates version. Once #17528 corrected the
+    # release-branch builds to bake AspireCliChannel=staging, the implicit identity
+    # channel switched to a staging feed that is not reachable from the 1ES signed-
+    # build agent, and the step started failing with "No template versions were
+    # found." This mirrors the prior removal of the TypeScript starter check
+    # (#17274 / tracked in #17345) for the same egress reason. Re-adding meaningful
+    # starter coverage in the signed-build verifier requires either an internal
+    # NuGet mirror or a no-network template path.
 
     Write-Host ""
     Write-Host "=========================================="

--- a/tests/Aspire.Acquisition.Tests/Scripts/VerifyCliArchivePowerShellTests.cs
+++ b/tests/Aspire.Acquisition.Tests/Scripts/VerifyCliArchivePowerShellTests.cs
@@ -32,7 +32,6 @@ public class VerifyCliArchivePowerShellTests(ITestOutputHelper testOutput)
 
         result.EnsureSuccessful();
         Assert.Contains("aspire mock v1.0", result.Output);
-        Assert.Contains("'aspire new aspire-starter' created project successfully", result.Output);
         Assert.Contains("linux-* archive correctly omits the install-route sidecar", result.Output);
         Assert.Contains("All verification checks passed", result.Output);
     }


### PR DESCRIPTION
## Description

The signed-build CLI archive verifier (`eng/scripts/verify-cli-archive.ps1`) was running `aspire new aspire-starter` after extracting the archive. Its docstring claimed this exercised "template engine + bundle self-extraction without requiring a NuGet restore" — but that claim is wrong. `aspire new` resolves template versions via `TemplateNuGetConfigService.ResolveTemplatePackageAsync`, which always queries a NuGet feed.

### Why it used to work

On release branches, this step only ever passed by accident. Pre-#17528, release-branch builds were mis-baked with `AspireCliChannel=stable`. With a `stable` identity channel, `NewCommand.ResolveCliTemplateVersionAsync` routes the lookup to nuget.org (the `stable` channel maps `*` → `nuget.org`), where a previously-shipped `Aspire.ProjectTemplates` version was always available. So the verifier appeared to succeed, but it was actually depending on:

1. nuget.org being reachable from the build agent.
2. A stable Aspire.ProjectTemplates version having already been published to nuget.org.

### Why it now fails

#17528 corrected release-branch builds to bake `AspireCliChannel=staging` (so dogfood drops aren't mis-identified as stable). With a `staging` identity channel, the implicit selection in `NewCommand` (see `ResolveCliTemplateVersionAsync`, NewCommand.cs:333-345) now picks the staging channel, which maps `Aspire*` to a SHA-specific darc-pub feed (or the shared daily feed). That feed is not reachable from the 1ES signed-build agent, so the lookup returns nothing and the verifier fails with:

```
❌ No template versions were found. Please check your internet connection or NuGet source configuration.
```

This is the same egress reason the TypeScript starter check was already removed for in #17274 (tracked in #17345).

### Change

- Drop the `Test-CSharpStarterProject` invocation and helper from `eng/scripts/verify-cli-archive.ps1`, with a comment explaining the rationale.
- Drop the matching assertion in `VerifyCliArchivePowerShellTests.cs`.
- Leave the fake `aspire new` handler in `FakeArchiveHelper` alone — it's harmless mock code and avoids unnecessary diff churn.

The verifier still covers archive layout (sidecar contract for per-RID archives), CLI extraction, and `aspire --version` execution. Re-adding meaningful starter coverage in the signed-build verifier requires either an internal NuGet mirror configured on the agent or a no-network template path.

Fixes the internal AzDO build break introduced by #17528.

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes (existing `VerifyCliArchive_AcceptsCleanPerRidArchive` adjusted; sidecar tests unaffected).
- Did you add public API?
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [x] No
