### PR TITLE
[release/13.4] Restore dotnet watch dashboard auto-launch signal

### DIFF
--- a/src/Shared/LoggingHelpers.cs
+++ b/src/Shared/LoggingHelpers.cs
@@ -37,6 +37,12 @@ internal static class LoggingHelpers
             ? $"{dashboardAuthority}/login?t={token}"
             : null;
 
+        if (loginUrl is not null)
+        {
+            // dotnet watch looks for this exact log message to launch the dashboard. Do not change it.
+            logger.LogInformation("Login to the dashboard at {LoginUrl}", loginUrl);
+        }
+
         var templateBuilder = new StringBuilder();
         var parameters = new List<object?>();
 

--- a/tests/Aspire.Dashboard.Tests/Integration/FrontendBrowserTokenAuthTests.cs
+++ b/tests/Aspire.Dashboard.Tests/Integration/FrontendBrowserTokenAuthTests.cs
@@ -406,6 +406,15 @@ public class FrontendBrowserTokenAuthTests
             },
             w =>
             {
+                Assert.Equal("Login to the dashboard at {LoginUrl}", LogTestHelpers.GetValue(w, "{OriginalFormat}"));
+
+                var loginUrl = (string)LogTestHelpers.GetValue(w, "LoginUrl")!;
+                var uri = new Uri(loginUrl, UriKind.Absolute);
+                var queryString = HttpUtility.ParseQueryString(uri.Query);
+                Assert.NotNull(queryString["t"]);
+            },
+            w =>
+            {
                 Assert.StartsWith("Aspire Dashboard", (string)LogTestHelpers.GetValue(w, "{OriginalFormat}")!);
 
                 var loginUrl = (string)LogTestHelpers.GetValue(w, "LoginUrl")!;

--- a/tests/Aspire.Dashboard.Tests/LoggingHelpersTests.cs
+++ b/tests/Aspire.Dashboard.Tests/LoggingHelpersTests.cs
@@ -23,7 +23,15 @@ public class LoggingHelpersTests
             "http://localhost:18890",
             "abc123");
 
-        var write = Assert.Single(sink.Writes);
+        Assert.Equal(2, sink.Writes.Count);
+
+        var loginWrite = sink.Writes.ElementAt(0);
+        Assert.Equal(LogLevel.Information, loginWrite.LogLevel);
+        Assert.Equal("Login to the dashboard at http://localhost:18888/login?t=abc123", loginWrite.Message);
+        Assert.Equal("Login to the dashboard at {LoginUrl}", LogTestHelpers.GetValue(loginWrite, "{OriginalFormat}"));
+        Assert.Equal("http://localhost:18888/login?t=abc123", LogTestHelpers.GetValue(loginWrite, "LoginUrl"));
+
+        var write = sink.Writes.ElementAt(1);
         Assert.Equal(LogLevel.Information, write.LogLevel);
         Assert.NotNull(write.Message);
         var lines = GetMessageLines(write.Message!);
@@ -169,7 +177,9 @@ public class LoggingHelpersTests
             otlpHttpUrl: null,
             token: "abc123");
 
-        var write = Assert.Single(sink.Writes);
+        Assert.Equal(2, sink.Writes.Count);
+
+        var write = sink.Writes.ElementAt(1);
         Assert.NotNull(write.Message);
         var lines = GetMessageLines(write.Message!);
 
@@ -198,11 +208,13 @@ public class LoggingHelpersTests
             token: "abc123",
             isContainer: true);
 
-        var write = Assert.Single(sink.Writes);
-        Assert.NotNull(write.Message);
+        Assert.Equal(2, sink.Writes.Count);
+
+        var containerWrite = sink.Writes.ElementAt(1);
+        Assert.NotNull(containerWrite.Message);
         var containerMessage = "URLs may need changes depending on how network access to the container is configured.";
 
-        Assert.Contains(containerMessage, write.Message);
+        Assert.Contains(containerMessage, containerWrite.Message);
     }
 
     private static string[] GetMessageLines(string message)

--- a/tests/Aspire.Hosting.Tests/Dashboard/DashboardEventHandlersTests.cs
+++ b/tests/Aspire.Hosting.Tests/Dashboard/DashboardEventHandlersTests.cs
@@ -271,6 +271,12 @@ public class DashboardEventHandlersTests(ITestOutputHelper testOutputHelper)
         Assert.Equal(allocatedPort, uri.Port);
         Assert.Equal(expectedScheme, uri.Scheme);
 
+        var loginLog = testSink.Writes.FirstOrDefault(l =>
+            LogTestHelpers.GetValue(l, "{OriginalFormat}")?.ToString() == "Login to the dashboard at {LoginUrl}");
+
+        Assert.NotNull(loginLog);
+        Assert.Equal($"{expectedScheme}://{expectedHost}:{allocatedPort}/login?t=test-token", LogTestHelpers.GetValue(loginLog, "LoginUrl"));
+
         var summaryLog = testSink.Writes.FirstOrDefault(l =>
             LogTestHelpers.GetValue(l, "{OriginalFormat}")?.ToString()?.Contains("OTLP/gRPC:") == true);
 


### PR DESCRIPTION
Backport of #17610 to release/13.4

/cc @JamesNK

## Customer Impact

dotnet watch cannot automatically open the dashboard browser when running an Aspire 13.4 AppHost. This is a regression from 13.3 — the legacy login log line that dotnet watch depends on to detect when the AppHost is serving HTTP traffic was removed in the new dashboard summary refactoring.

Fixes #17591

## Testing

Unit tests added/updated covering the shared dashboard logging helper, the dashboard browser token auth integration test, and the AppHost dashboard-ready event handler. All tests pass on the release/13.4 branch.

## Risk

Very low. Adds a single additional LogInformation call before the existing dashboard summary output. No behavioral change to any other code path.

## Regression?

Yes — regressed in 13.4 when the dashboard summary output was refactored and the legacy login line was dropped.
