### PR TITLE
Update OpenTelemetry.Instrumentation.ConfluentKafka files to version 0.1.0-alpha.7

### DIFF
--- a/src/Vendoring/OpenTelemetry.Instrumentation.ConfluentKafka/ConfluentKafkaCommon.cs
+++ b/src/Vendoring/OpenTelemetry.Instrumentation.ConfluentKafka/ConfluentKafkaCommon.cs
@@ -15,12 +15,29 @@ internal static class ConfluentKafkaCommon
     internal const string KafkaMessagingSystem = "kafka";
     internal const string PublishOperationName = "publish";
 
+#pragma warning disable IDE0370 // Suppression is unnecessary
     internal const string InstrumentationName = "OpenTelemetry.Instrumentation.ConfluentKafka";
+#pragma warning restore IDE0370 // Suppression is unnecessary
     internal static readonly string InstrumentationVersion = new Version(0, 1, 0, 0).ToString();
     internal static readonly ActivitySource ActivitySource = new(InstrumentationName, InstrumentationVersion);
     internal static readonly Meter Meter = new(InstrumentationName, InstrumentationVersion);
-    internal static readonly Counter<long> ReceiveMessagesCounter = Meter.CreateCounter<long>(SemanticConventions.MetricMessagingReceiveMessages);
-    internal static readonly Histogram<double> ReceiveDurationHistogram = Meter.CreateHistogram<double>(SemanticConventions.MetricMessagingReceiveDuration);
-    internal static readonly Counter<long> PublishMessagesCounter = Meter.CreateCounter<long>(SemanticConventions.MetricMessagingPublishMessages);
-    internal static readonly Histogram<double> PublishDurationHistogram = Meter.CreateHistogram<double>(SemanticConventions.MetricMessagingPublishDuration);
+    internal static readonly Counter<long> ReceiveMessagesCounter = Meter.CreateCounter<long>(
+        SemanticConventions.MetricMessagingReceiveMessages,
+        description: "Measures the number of received messages.");
+
+    internal static readonly Histogram<double> ReceiveDurationHistogram = Meter.CreateHistogram(
+        SemanticConventions.MetricMessagingReceiveDuration,
+        unit: "s",
+        description: "Measures the duration of receive operation.",
+        advice: new InstrumentAdvice<double> { HistogramBucketBoundaries = [0.005, 0.01, 0.025, 0.05, 0.075, 0.1, 0.25, 0.5, 0.75, 1, 2.5, 5, 7.5, 10] });
+
+    internal static readonly Counter<long> PublishMessagesCounter = Meter.CreateCounter<long>(
+        SemanticConventions.MetricMessagingPublishMessages,
+        description: "Measures the number of published messages.");
+
+    internal static readonly Histogram<double> PublishDurationHistogram = Meter.CreateHistogram(
+        SemanticConventions.MetricMessagingPublishDuration,
+        unit: "s",
+        description: "Measures the duration of publish operation.",
+        advice: new InstrumentAdvice<double> { HistogramBucketBoundaries = [0.005, 0.01, 0.025, 0.05, 0.075, 0.1, 0.25, 0.5, 0.75, 1, 2.5, 5, 7.5, 10] });
 }

--- a/src/Vendoring/OpenTelemetry.Instrumentation.ConfluentKafka/InstrumentedConsumer.cs
+++ b/src/Vendoring/OpenTelemetry.Instrumentation.ConfluentKafka/InstrumentedConsumer.cs
@@ -34,23 +34,17 @@ internal class InstrumentedConsumer<TKey, TValue> : IConsumer<TKey, TValue>
     public string? GroupId { get; internal set; }
 
     public void Dispose()
-    {
-        this.consumer.Dispose();
-    }
+        => this.consumer.Dispose();
 
     public int AddBrokers(string brokers)
-    {
-        return this.consumer.AddBrokers(brokers);
-    }
+        => this.consumer.AddBrokers(brokers);
 
     public void SetSaslCredentials(string username, string password)
-    {
-        this.consumer.SetSaslCredentials(username, password);
-    }
+        => this.consumer.SetSaslCredentials(username, password);
 
     public ConsumeResult<TKey, TValue>? Consume(int millisecondsTimeout)
     {
-        DateTimeOffset start = DateTimeOffset.UtcNow;
+        var start = DateTimeOffset.UtcNow;
         ConsumeResult<TKey, TValue>? result = null;
         ConsumeResult consumeResult = default;
         string? errorType = null;
@@ -67,9 +61,9 @@ internal class InstrumentedConsumer<TKey, TValue> : IConsumer<TKey, TValue>
         }
         finally
         {
-            DateTimeOffset end = DateTimeOffset.UtcNow;
-            if (result is { IsPartitionEOF: false })
+            if (ShouldInstrument(result, errorType))
             {
+                var end = DateTimeOffset.UtcNow;
                 this.InstrumentConsumption(start, end, consumeResult, errorType);
             }
         }
@@ -77,7 +71,7 @@ internal class InstrumentedConsumer<TKey, TValue> : IConsumer<TKey, TValue>
 
     public ConsumeResult<TKey, TValue>? Consume(CancellationToken cancellationToken = default)
     {
-        DateTimeOffset start = DateTimeOffset.UtcNow;
+        var start = DateTimeOffset.UtcNow;
         ConsumeResult<TKey, TValue>? result = null;
         ConsumeResult consumeResult = default;
         string? errorType = null;
@@ -94,9 +88,9 @@ internal class InstrumentedConsumer<TKey, TValue> : IConsumer<TKey, TValue>
         }
         finally
         {
-            DateTimeOffset end = DateTimeOffset.UtcNow;
-            if (result is { IsPartitionEOF: false })
+            if (ShouldInstrument(result, errorType))
             {
+                var end = DateTimeOffset.UtcNow;
                 this.InstrumentConsumption(start, end, consumeResult, errorType);
             }
         }
@@ -104,7 +98,7 @@ internal class InstrumentedConsumer<TKey, TValue> : IConsumer<TKey, TValue>
 
     public ConsumeResult<TKey, TValue>? Consume(TimeSpan timeout)
     {
-        DateTimeOffset start = DateTimeOffset.UtcNow;
+        var start = DateTimeOffset.UtcNow;
         ConsumeResult<TKey, TValue>? result = null;
         ConsumeResult consumeResult = default;
         string? errorType = null;
@@ -121,143 +115,94 @@ internal class InstrumentedConsumer<TKey, TValue> : IConsumer<TKey, TValue>
         }
         finally
         {
-            DateTimeOffset end = DateTimeOffset.UtcNow;
-            if (result is { IsPartitionEOF: false })
+            if (ShouldInstrument(result, errorType))
             {
+                var end = DateTimeOffset.UtcNow;
                 this.InstrumentConsumption(start, end, consumeResult, errorType);
             }
         }
     }
 
     public void Subscribe(IEnumerable<string> topics)
-    {
-        this.consumer.Subscribe(topics);
-    }
+        => this.consumer.Subscribe(topics);
 
     public void Subscribe(string topic)
-    {
-        this.consumer.Subscribe(topic);
-    }
+        => this.consumer.Subscribe(topic);
 
     public void Unsubscribe()
-    {
-        this.consumer.Unsubscribe();
-    }
+        => this.consumer.Unsubscribe();
 
     public void Assign(TopicPartition partition)
-    {
-        this.consumer.Assign(partition);
-    }
+        => this.consumer.Assign(partition);
 
     public void Assign(TopicPartitionOffset partition)
-    {
-        this.consumer.Assign(partition);
-    }
+        => this.consumer.Assign(partition);
 
     public void Assign(IEnumerable<TopicPartitionOffset> partitions)
-    {
-        this.consumer.Assign(partitions);
-    }
+        => this.consumer.Assign(partitions);
 
     public void Assign(IEnumerable<TopicPartition> partitions)
-    {
-        this.consumer.Assign(partitions);
-    }
+        => this.consumer.Assign(partitions);
 
     public void IncrementalAssign(IEnumerable<TopicPartitionOffset> partitions)
-    {
-        this.consumer.IncrementalAssign(partitions);
-    }
+        => this.consumer.IncrementalAssign(partitions);
 
     public void IncrementalAssign(IEnumerable<TopicPartition> partitions)
-    {
-        this.consumer.IncrementalAssign(partitions);
-    }
+        => this.consumer.IncrementalAssign(partitions);
 
     public void IncrementalUnassign(IEnumerable<TopicPartition> partitions)
-    {
-        this.consumer.IncrementalUnassign(partitions);
-    }
+        => this.consumer.IncrementalUnassign(partitions);
 
-    public void Unassign()
-    {
-        this.consumer.Unassign();
-    }
+    public void Unassign() => this.consumer.Unassign();
 
     public void StoreOffset(ConsumeResult<TKey, TValue> result)
-    {
-        this.consumer.StoreOffset(result);
-    }
+        => this.consumer.StoreOffset(result);
 
     public void StoreOffset(TopicPartitionOffset offset)
-    {
-        this.consumer.StoreOffset(offset);
-    }
+        => this.consumer.StoreOffset(offset);
 
     public List<TopicPartitionOffset> Commit()
-    {
-        return this.consumer.Commit();
-    }
+        => this.consumer.Commit();
 
     public void Commit(IEnumerable<TopicPartitionOffset> offsets)
-    {
-        this.consumer.Commit(offsets);
-    }
+        => this.consumer.Commit(offsets);
 
     public void Commit(ConsumeResult<TKey, TValue> result)
-    {
-        this.consumer.Commit(result);
-    }
+        => this.consumer.Commit(result);
 
     public void Seek(TopicPartitionOffset tpo)
-    {
-        this.consumer.Seek(tpo);
-    }
+        => this.consumer.Seek(tpo);
 
     public void Pause(IEnumerable<TopicPartition> partitions)
-    {
-        this.consumer.Pause(partitions);
-    }
+        => this.consumer.Pause(partitions);
 
     public void Resume(IEnumerable<TopicPartition> partitions)
-    {
-        this.consumer.Resume(partitions);
-    }
+        => this.consumer.Resume(partitions);
 
     public List<TopicPartitionOffset> Committed(TimeSpan timeout)
-    {
-        return this.consumer.Committed(timeout);
-    }
+        => this.consumer.Committed(timeout);
 
     public List<TopicPartitionOffset> Committed(IEnumerable<TopicPartition> partitions, TimeSpan timeout)
-    {
-        return this.consumer.Committed(partitions, timeout);
-    }
+        => this.consumer.Committed(partitions, timeout);
 
     public Offset Position(TopicPartition partition)
-    {
-        return this.consumer.Position(partition);
-    }
+        => this.consumer.Position(partition);
 
     public List<TopicPartitionOffset> OffsetsForTimes(IEnumerable<TopicPartitionTimestamp> timestampsToSearch, TimeSpan timeout)
-    {
-        return this.consumer.OffsetsForTimes(timestampsToSearch, timeout);
-    }
+        => this.consumer.OffsetsForTimes(timestampsToSearch, timeout);
 
     public WatermarkOffsets GetWatermarkOffsets(TopicPartition topicPartition)
-    {
-        return this.consumer.GetWatermarkOffsets(topicPartition);
-    }
+        => this.consumer.GetWatermarkOffsets(topicPartition);
 
     public WatermarkOffsets QueryWatermarkOffsets(TopicPartition topicPartition, TimeSpan timeout)
-    {
-        return this.consumer.QueryWatermarkOffsets(topicPartition, timeout);
-    }
+        => this.consumer.QueryWatermarkOffsets(topicPartition, timeout);
 
     public void Close()
-    {
-        this.consumer.Close();
-    }
+        => this.consumer.Close();
+
+    private static bool ShouldInstrument(ConsumeResult<TKey, TValue>? result, string? errorType) =>
+        result is { IsPartitionEOF: false } ||
+        (result is null && errorType is not null);
 
     private static string FormatConsumeException(ConsumeException consumeException) =>
         $"ConsumeException: {consumeException.Error}";
@@ -276,7 +221,7 @@ internal class InstrumentedConsumer<TKey, TValue> : IConsumer<TKey, TValue>
         _ => (new ConsumeResult(exception.ConsumerRecord.TopicPartitionOffset, exception.ConsumerRecord.Message.Headers, exception.ConsumerRecord.Message.Key), FormatConsumeException(exception)),
     };
 
-    private static void GetTags(string topic, out TagList tags, int? partition = null, string? errorType = null)
+    private static void GetTags(string? topic, out TagList tags, int? partition = null, string? errorType = null)
     {
         tags = new TagList()
         {
@@ -286,10 +231,15 @@ internal class InstrumentedConsumer<TKey, TValue> : IConsumer<TKey, TValue>
             new KeyValuePair<string, object?>(
                 SemanticConventions.AttributeMessagingSystem,
                 ConfluentKafkaCommon.KafkaMessagingSystem),
-            new KeyValuePair<string, object?>(
-                SemanticConventions.AttributeMessagingDestinationName,
-                topic),
         };
+
+        if (topic is not null)
+        {
+            tags.Add(
+                new KeyValuePair<string, object?>(
+                    SemanticConventions.AttributeMessagingDestinationName,
+                    topic));
+        }
 
         if (partition is not null)
         {
@@ -308,9 +258,9 @@ internal class InstrumentedConsumer<TKey, TValue> : IConsumer<TKey, TValue>
         }
     }
 
-    private static void RecordReceive(TopicPartition topicPartition, TimeSpan duration, string? errorType = null)
+    private static void RecordReceive(TopicPartition? topicPartition, TimeSpan duration, string? errorType = null)
     {
-        GetTags(topicPartition.Topic, out var tags, partition: topicPartition.Partition, errorType);
+        GetTags(topicPartition?.Topic, out var tags, partition: topicPartition?.Partition, errorType);
 
         ConfluentKafkaCommon.ReceiveMessagesCounter.Add(1, in tags);
         ConfluentKafkaCommon.ReceiveDurationHistogram.Record(duration.TotalSeconds, in tags);
@@ -320,11 +270,11 @@ internal class InstrumentedConsumer<TKey, TValue> : IConsumer<TKey, TValue>
     {
         if (this.options.Traces)
         {
-            PropagationContext propagationContext = consumeResult.Headers != null
+            var propagationContext = consumeResult.Headers != null
                 ? OpenTelemetryConsumeResultExtensions.ExtractPropagationContext(consumeResult.Headers)
                 : default;
 
-            using Activity? activity = this.StartReceiveActivity(propagationContext, startTime, consumeResult.TopicPartitionOffset, consumeResult.Key);
+            using var activity = this.StartReceiveActivity(propagationContext, startTime, consumeResult.TopicPartitionOffset, consumeResult.Key);
             if (activity != null)
             {
                 if (errorType != null)
@@ -342,22 +292,24 @@ internal class InstrumentedConsumer<TKey, TValue> : IConsumer<TKey, TValue>
 
         if (this.options.Metrics)
         {
-            TimeSpan duration = endTime - startTime;
-            RecordReceive(consumeResult.TopicPartitionOffset!.TopicPartition, duration, errorType);
+            var duration = endTime - startTime;
+            RecordReceive(consumeResult.TopicPartitionOffset?.TopicPartition, duration, errorType);
         }
     }
 
     private Activity? StartReceiveActivity(PropagationContext propagationContext, DateTimeOffset start, TopicPartitionOffset? topicPartitionOffset, object? key)
     {
+#pragma warning disable IDE0370 // Suppression is unnecessary
         var spanName = string.IsNullOrEmpty(topicPartitionOffset?.Topic)
             ? ConfluentKafkaCommon.ReceiveOperationName
             : string.Concat(topicPartitionOffset!.Topic, " ", ConfluentKafkaCommon.ReceiveOperationName);
+#pragma warning restore IDE0370 // Suppression is unnecessary
 
         ActivityLink[] activityLinks = propagationContext.ActivityContext.IsValid()
-            ? new[] { new ActivityLink(propagationContext.ActivityContext) }
-            : Array.Empty<ActivityLink>();
+            ? [new ActivityLink(propagationContext.ActivityContext)]
+            : [];
 
-        Activity? activity = ConfluentKafkaCommon.ActivitySource.StartActivity(spanName, kind: ActivityKind.Consumer, links: activityLinks, startTime: start, parentContext: default);
+        var activity = ConfluentKafkaCommon.ActivitySource.StartActivity(spanName, kind: ActivityKind.Consumer, links: activityLinks, startTime: start, parentContext: default);
         if (activity?.IsAllDataRequested == true)
         {
             activity.SetTag(SemanticConventions.AttributeMessagingSystem, ConfluentKafkaCommon.KafkaMessagingSystem);

--- a/src/Vendoring/OpenTelemetry.Instrumentation.ConfluentKafka/InstrumentedConsumerBuilder.cs
+++ b/src/Vendoring/OpenTelemetry.Instrumentation.ConfluentKafka/InstrumentedConsumerBuilder.cs
@@ -41,10 +41,12 @@ internal sealed class InstrumentedConsumerBuilder<TKey, TValue> : ConsumerBuilde
     /// <returns>an <see cref="IProducer{TKey,TValue}"/>.</returns>
     public override IConsumer<TKey, TValue> Build()
     {
-        ConsumerConfig config = (ConsumerConfig)this.Config;
+        var config = (ConsumerConfig)this.Config;
 
-        var consumer = new InstrumentedConsumer<TKey, TValue>(base.Build(), this.options);
-        consumer.GroupId = config.GroupId;
+        var consumer = new InstrumentedConsumer<TKey, TValue>(base.Build(), this.options)
+        {
+            GroupId = config.GroupId,
+        };
 
         return consumer;
     }

--- a/src/Vendoring/OpenTelemetry.Instrumentation.ConfluentKafka/InstrumentedProducer.cs
+++ b/src/Vendoring/OpenTelemetry.Instrumentation.ConfluentKafka/InstrumentedProducer.cs
@@ -42,8 +42,8 @@ internal sealed class InstrumentedProducer<TKey, TValue> : IProducer<TKey, TValu
         Message<TKey, TValue> message,
         CancellationToken cancellationToken = default)
     {
-        DateTimeOffset start = DateTimeOffset.UtcNow;
-        using Activity? activity = this.StartPublishActivity(start, topic, message);
+        var start = DateTimeOffset.UtcNow;
+        using var activity = this.StartPublishActivity(start, topic, message);
         if (activity != null)
         {
             this.InjectActivity(activity, message);
@@ -71,9 +71,9 @@ internal sealed class InstrumentedProducer<TKey, TValue> : IProducer<TKey, TValu
         }
         finally
         {
-            DateTimeOffset end = DateTimeOffset.UtcNow;
+            var end = DateTimeOffset.UtcNow;
             activity?.SetEndTime(end.UtcDateTime);
-            TimeSpan duration = end - start;
+            var duration = end - start;
 
             if (this.options.Metrics)
             {
@@ -89,8 +89,8 @@ internal sealed class InstrumentedProducer<TKey, TValue> : IProducer<TKey, TValu
         Message<TKey, TValue> message,
         CancellationToken cancellationToken = default)
     {
-        DateTimeOffset start = DateTimeOffset.UtcNow;
-        using Activity? activity = this.StartPublishActivity(start, topicPartition.Topic, message, topicPartition.Partition);
+        var start = DateTimeOffset.UtcNow;
+        using var activity = this.StartPublishActivity(start, topicPartition.Topic, message, topicPartition.Partition);
         if (activity != null)
         {
             this.InjectActivity(activity, message);
@@ -118,9 +118,9 @@ internal sealed class InstrumentedProducer<TKey, TValue> : IProducer<TKey, TValu
         }
         finally
         {
-            DateTimeOffset end = DateTimeOffset.UtcNow;
+            var end = DateTimeOffset.UtcNow;
             activity?.SetEndTime(end.UtcDateTime);
-            TimeSpan duration = end - start;
+            var duration = end - start;
 
             if (this.options.Metrics)
             {
@@ -133,8 +133,8 @@ internal sealed class InstrumentedProducer<TKey, TValue> : IProducer<TKey, TValu
 
     public void Produce(string topic, Message<TKey, TValue> message, Action<DeliveryReport<TKey, TValue>>? deliveryHandler = null)
     {
-        DateTimeOffset start = DateTimeOffset.UtcNow;
-        using Activity? activity = this.StartPublishActivity(start, topic, message);
+        var start = DateTimeOffset.UtcNow;
+        using var activity = this.StartPublishActivity(start, topic, message);
         if (activity != null)
         {
             this.InjectActivity(activity, message);
@@ -161,9 +161,9 @@ internal sealed class InstrumentedProducer<TKey, TValue> : IProducer<TKey, TValu
         }
         finally
         {
-            DateTimeOffset end = DateTimeOffset.UtcNow;
+            var end = DateTimeOffset.UtcNow;
             activity?.SetEndTime(end.UtcDateTime);
-            TimeSpan duration = end - start;
+            var duration = end - start;
 
             if (this.options.Metrics)
             {
@@ -174,8 +174,8 @@ internal sealed class InstrumentedProducer<TKey, TValue> : IProducer<TKey, TValu
 
     public void Produce(TopicPartition topicPartition, Message<TKey, TValue> message, Action<DeliveryReport<TKey, TValue>>? deliveryHandler = null)
     {
-        DateTimeOffset start = DateTimeOffset.UtcNow;
-        using Activity? activity = this.StartPublishActivity(start, topicPartition.Topic, message, topicPartition.Partition);
+        var start = DateTimeOffset.UtcNow;
+        using var activity = this.StartPublishActivity(start, topicPartition.Topic, message, topicPartition.Partition);
         if (activity != null)
         {
             this.InjectActivity(activity, message);
@@ -202,9 +202,9 @@ internal sealed class InstrumentedProducer<TKey, TValue> : IProducer<TKey, TValu
         }
         finally
         {
-            DateTimeOffset end = DateTimeOffset.UtcNow;
+            var end = DateTimeOffset.UtcNow;
             activity?.SetEndTime(end.UtcDateTime);
-            TimeSpan duration = end - start;
+            var duration = end - start;
 
             if (this.options.Metrics)
             {
@@ -364,7 +364,7 @@ internal sealed class InstrumentedProducer<TKey, TValue> : IProducer<TKey, TValu
 
     private void InjectTraceContext(Message<TKey, TValue> message, string key, string value)
     {
-        message.Headers ??= new Headers();
+        message.Headers ??= [];
         message.Headers.Add(key, Encoding.UTF8.GetBytes(value));
     }
 }

--- a/src/Vendoring/OpenTelemetry.Instrumentation.ConfluentKafka/OpenTelemetryConsumeResultExtensions.cs
+++ b/src/Vendoring/OpenTelemetry.Instrumentation.ConfluentKafka/OpenTelemetryConsumeResultExtensions.cs
@@ -27,13 +27,13 @@ internal static class OpenTelemetryConsumeResultExtensions
         this ConsumeResult<TKey, TValue> consumeResult,
         out PropagationContext propagationContext)
     {
-#if NETFRAMEWORK
+#if NET
+        ArgumentNullException.ThrowIfNull(consumeResult);
+#else
         if (consumeResult == null)
         {
             throw new ArgumentNullException(nameof(consumeResult));
         }
-#else
-        ArgumentNullException.ThrowIfNull(consumeResult);
 #endif
 
         try
@@ -75,13 +75,13 @@ internal static class OpenTelemetryConsumeResultExtensions
         OpenTelemetryConsumeAndProcessMessageHandler<TKey, TValue> handler,
         CancellationToken cancellationToken)
     {
-#if NETFRAMEWORK
+#if NET
+        ArgumentNullException.ThrowIfNull(consumer);
+#else
         if (consumer == null)
         {
             throw new ArgumentNullException(nameof(consumer));
         }
-#else
-        ArgumentNullException.ThrowIfNull(consumer);
 #endif
 
         if (consumer is not InstrumentedConsumer<TKey, TValue> instrumentedConsumer)
@@ -89,13 +89,13 @@ internal static class OpenTelemetryConsumeResultExtensions
             throw new ArgumentException("Invalid consumer type.", nameof(consumer));
         }
 
-#if NETFRAMEWORK
-        if (handler is null)
+#if NET
+        ArgumentNullException.ThrowIfNull(handler);
+#else
+        if (handler == null)
         {
             throw new ArgumentNullException(nameof(handler));
         }
-#else
-        ArgumentNullException.ThrowIfNull(handler);
 #endif
 
         var consumeResult = instrumentedConsumer.Consume(cancellationToken);
@@ -105,25 +105,7 @@ internal static class OpenTelemetryConsumeResultExtensions
             return consumeResult;
         }
 
-        Activity? processActivity = null;
-        if (TryExtractPropagationContext(consumeResult, out var propagationContext))
-        {
-            processActivity = StartProcessActivity(
-                propagationContext,
-                consumeResult.TopicPartitionOffset,
-                consumeResult.Message.Key,
-                instrumentedConsumer.Name,
-                instrumentedConsumer.GroupId!);
-        }
-        else
-        {
-            processActivity = StartProcessActivity(
-                default,
-                consumeResult.TopicPartitionOffset,
-                consumeResult.Message.Key,
-                instrumentedConsumer.Name,
-                instrumentedConsumer.GroupId!);
-        }
+        var processActivity = StartProcessActivity(TryExtractPropagationContext(consumeResult, out var propagationContext) ? propagationContext : default, consumeResult.TopicPartitionOffset, consumeResult.Message.Key, instrumentedConsumer.Name, instrumentedConsumer.GroupId!);
 
         try
         {
@@ -133,6 +115,7 @@ internal static class OpenTelemetryConsumeResultExtensions
         {
             processActivity?.SetStatus(ActivityStatusCode.Error);
             processActivity?.SetTag(SemanticConventions.AttributeErrorType, ex.GetType().FullName);
+            throw;
         }
         finally
         {
@@ -147,15 +130,17 @@ internal static class OpenTelemetryConsumeResultExtensions
 
     private static Activity? StartProcessActivity<TKey>(PropagationContext propagationContext, TopicPartitionOffset? topicPartitionOffset, TKey? key, string clientId, string groupId)
     {
+#pragma warning disable IDE0370 // Suppression is unnecessary
         var spanName = string.IsNullOrEmpty(topicPartitionOffset?.Topic)
             ? ConfluentKafkaCommon.ProcessOperationName
             : string.Concat(topicPartitionOffset!.Topic, " ", ConfluentKafkaCommon.ProcessOperationName);
+#pragma warning restore IDE0370 // Suppression is unnecessary
 
         ActivityLink[] activityLinks = propagationContext != default && propagationContext.ActivityContext.IsValid()
-            ? new[] { new ActivityLink(propagationContext.ActivityContext) }
-            : Array.Empty<ActivityLink>();
+            ? [new ActivityLink(propagationContext.ActivityContext)]
+            : [];
 
-        Activity? activity = ConfluentKafkaCommon.ActivitySource.StartActivity(spanName, kind: ActivityKind.Consumer, links: activityLinks, parentContext: default);
+        var activity = ConfluentKafkaCommon.ActivitySource.StartActivity(spanName, kind: ActivityKind.Consumer, links: activityLinks, parentContext: default);
         if (activity?.IsAllDataRequested == true)
         {
             activity.SetTag(SemanticConventions.AttributeMessagingSystem, ConfluentKafkaCommon.KafkaMessagingSystem);

--- a/src/Vendoring/OpenTelemetry.Instrumentation.ConfluentKafka/Shared/Guard.cs
+++ b/src/Vendoring/OpenTelemetry.Instrumentation.ConfluentKafka/Shared/Guard.cs
@@ -1,8 +1,6 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-#nullable enable
-
 // Note: For some targets this file will contain more than one type/namespace.
 #pragma warning disable IDE0161 // Convert to file-scoped namespace
 
@@ -14,6 +12,7 @@ using System.Runtime.CompilerServices;
 #pragma warning disable SA1402 // File may only contain a single type
 #pragma warning disable SA1403 // File may only contain a single namespace
 #pragma warning disable SA1649 // File name should match first type name
+#pragma warning disable IDE0022 // Use expression body for method
 
 #if !NET
 namespace System.Runtime.CompilerServices
@@ -59,12 +58,16 @@ namespace OpenTelemetry.Internal
         /// <param name="paramName">The parameter name to use in the thrown exception.</param>
         [DebuggerHidden]
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static void ThrowIfNull([NotNull] object? value, [CallerArgumentExpression("value")] string? paramName = null)
+        public static void ThrowIfNull([NotNull] object? value, [CallerArgumentExpression(nameof(value))] string? paramName = null)
         {
+#if NET
+            ArgumentNullException.ThrowIfNull(value, paramName);
+#else
             if (value is null)
             {
                 throw new ArgumentNullException(paramName, "Must not be null");
             }
+#endif
         }
 
         /// <summary>
@@ -74,13 +77,17 @@ namespace OpenTelemetry.Internal
         /// <param name="paramName">The parameter name to use in the thrown exception.</param>
         [DebuggerHidden]
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static void ThrowIfNullOrEmpty([NotNull] string? value, [CallerArgumentExpression("value")] string? paramName = null)
+        public static void ThrowIfNullOrEmpty([NotNull] string? value, [CallerArgumentExpression(nameof(value))] string? paramName = null)
 #pragma warning disable CS8777 // Parameter must have a non-null value when exiting.
         {
+#if NET
+            ArgumentException.ThrowIfNullOrEmpty(value, paramName);
+#else
             if (string.IsNullOrEmpty(value))
             {
                 throw new ArgumentException("Must not be null or empty", paramName);
             }
+#endif
         }
 #pragma warning restore CS8777 // Parameter must have a non-null value when exiting.
 
@@ -91,13 +98,17 @@ namespace OpenTelemetry.Internal
         /// <param name="paramName">The parameter name to use in the thrown exception.</param>
         [DebuggerHidden]
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static void ThrowIfNullOrWhitespace([NotNull] string? value, [CallerArgumentExpression("value")] string? paramName = null)
+        public static void ThrowIfNullOrWhitespace([NotNull] string? value, [CallerArgumentExpression(nameof(value))] string? paramName = null)
 #pragma warning disable CS8777 // Parameter must have a non-null value when exiting.
         {
+#if NET
+            ArgumentException.ThrowIfNullOrWhiteSpace(value, paramName);
+#else
             if (string.IsNullOrWhiteSpace(value))
             {
                 throw new ArgumentException("Must not be null or whitespace", paramName);
             }
+#endif
         }
 #pragma warning restore CS8777 // Parameter must have a non-null value when exiting.
 
@@ -109,11 +120,31 @@ namespace OpenTelemetry.Internal
         /// <param name="paramName">The parameter name to use in the thrown exception.</param>
         [DebuggerHidden]
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static void ThrowIfZero(int value, string message = "Must not be zero", [CallerArgumentExpression("value")] string? paramName = null)
+        public static void ThrowIfZero(int value, string message = "Must not be zero", [CallerArgumentExpression(nameof(value))] string? paramName = null)
         {
+#if NET
+            ArgumentOutOfRangeException.ThrowIfZero(value, paramName);
+#else
             if (value == 0)
             {
                 throw new ArgumentException(message, paramName);
+            }
+#endif
+        }
+
+        /// <summary>
+        /// Throw an exception if the value is negative.
+        /// </summary>
+        /// <param name="value">The value to check.</param>
+        /// <param name="message">The message to use in the thrown exception.</param>
+        /// <param name="paramName">The parameter name to use in the thrown exception.</param>
+        [DebuggerHidden]
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static void ThrowIfNegative(int value, string message = "Must not be negative", [CallerArgumentExpression(nameof(value))] string? paramName = null)
+        {
+            if (value < 0)
+            {
+                throw new ArgumentOutOfRangeException(paramName, message);
             }
         }
 
@@ -124,7 +155,7 @@ namespace OpenTelemetry.Internal
         /// <param name="paramName">The parameter name to use in the thrown exception.</param>
         [DebuggerHidden]
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static void ThrowIfInvalidTimeout(int value, [CallerArgumentExpression("value")] string? paramName = null)
+        public static void ThrowIfInvalidTimeout(int value, [CallerArgumentExpression(nameof(value))] string? paramName = null)
         {
             ThrowIfOutOfRange(value, paramName, min: Timeout.Infinite, message: $"Must be non-negative or '{nameof(Timeout)}.{nameof(Timeout.Infinite)}'");
         }
@@ -141,7 +172,7 @@ namespace OpenTelemetry.Internal
         /// <param name="message">An optional custom message to use in the thrown exception.</param>
         [DebuggerHidden]
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static void ThrowIfOutOfRange(int value, [CallerArgumentExpression("value")] string? paramName = null, int min = int.MinValue, int max = int.MaxValue, string? minName = null, string? maxName = null, string? message = null)
+        public static void ThrowIfOutOfRange(int value, [CallerArgumentExpression(nameof(value))] string? paramName = null, int min = int.MinValue, int max = int.MaxValue, string? minName = null, string? maxName = null, string? message = null)
         {
             Range(value, paramName, min, max, minName, maxName, message);
         }
@@ -158,7 +189,7 @@ namespace OpenTelemetry.Internal
         /// <param name="message">An optional custom message to use in the thrown exception.</param>
         [DebuggerHidden]
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static void ThrowIfOutOfRange(double value, [CallerArgumentExpression("value")] string? paramName = null, double min = double.MinValue, double max = double.MaxValue, string? minName = null, string? maxName = null, string? message = null)
+        public static void ThrowIfOutOfRange(double value, [CallerArgumentExpression(nameof(value))] string? paramName = null, double min = double.MinValue, double max = double.MaxValue, string? minName = null, string? maxName = null, string? message = null)
         {
             Range(value, paramName, min, max, minName, maxName, message);
         }
@@ -172,14 +203,11 @@ namespace OpenTelemetry.Internal
         /// <returns>The value casted to the specified type.</returns>
         [DebuggerHidden]
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static T ThrowIfNotOfType<T>([NotNull] object? value, [CallerArgumentExpression("value")] string? paramName = null)
+        public static T ThrowIfNotOfType<T>([NotNull] object? value, [CallerArgumentExpression(nameof(value))] string? paramName = null)
         {
-            if (value is not T result)
-            {
-                throw new InvalidCastException($"Cannot cast '{paramName}' from '{value?.GetType().ToString() ?? "null"}' to '{typeof(T)}'");
-            }
-
-            return result;
+            return value is not T result
+                ? throw new InvalidCastException($"Cannot cast '{paramName}' from '{value?.GetType().ToString() ?? "null"}' to '{typeof(T)}'")
+                : result;
         }
 
         [DebuggerHidden]

--- a/src/Vendoring/OpenTelemetry.Instrumentation.ConfluentKafka/Shared/Guard.cs
+++ b/src/Vendoring/OpenTelemetry.Instrumentation.ConfluentKafka/Shared/Guard.cs
@@ -1,6 +1,8 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
+#nullable enable
+
 // Note: For some targets this file will contain more than one type/namespace.
 #pragma warning disable IDE0161 // Convert to file-scoped namespace
 

--- a/src/Vendoring/OpenTelemetry.Instrumentation.ConfluentKafka/Shared/PropertyFetcher.cs
+++ b/src/Vendoring/OpenTelemetry.Instrumentation.ConfluentKafka/Shared/PropertyFetcher.cs
@@ -5,11 +5,7 @@
 // Usages of the non-AOT-compatible version can be moved over to this one when they need to support AOT/trimming.
 // Copied from https://github.com/open-telemetry/opentelemetry-dotnet/blob/86a6ba0b7f7ed1f5e84e5a6610e640989cd3ae9f/src/Shared/DiagnosticSourceInstrumentation/PropertyFetcher.cs#L30
 
-#nullable enable
-
-#if NETSTANDARD2_1_0_OR_GREATER || NET
 using System.Diagnostics.CodeAnalysis;
-#endif
 using System.Reflection;
 
 namespace OpenTelemetry.Instrumentation;
@@ -40,6 +36,19 @@ internal sealed class PropertyFetcher<T>
         : 1 + this.innerFetcher.NumberOfInnerFetchers;
 
     /// <summary>
+    /// Fetch the property from the object.
+    /// </summary>
+    /// <param name="obj">Object to be fetched.</param>
+    /// <returns>Fetched value.</returns>
+#if NET
+    [RequiresUnreferencedCode(TrimCompatibilityMessage)]
+#endif
+    public T Fetch(object? obj)
+        => !this.TryFetch(obj, out var value)
+            ? throw new ArgumentException("Supplied object was null or did not match the expected type.", nameof(obj))
+            : value;
+
+    /// <summary>
     /// Try to fetch the property from the object.
     /// </summary>
     /// <param name="obj">Object to be fetched.</param>
@@ -49,19 +58,12 @@ internal sealed class PropertyFetcher<T>
     [RequiresUnreferencedCode(TrimCompatibilityMessage)]
 #endif
     public bool TryFetch(
-#if NETSTANDARD2_1_0_OR_GREATER || NET
-        [NotNullWhen(true)]
-#endif
         object? obj,
+        [NotNullWhen(true)]
         out T? value)
     {
-        var innerFetcher = this.innerFetcher;
-        if (innerFetcher is null)
-        {
-            return TryFetchRare(obj, this.propertyName, ref this.innerFetcher, out value);
-        }
-
-        return innerFetcher.TryFetch(obj, out value);
+        var localInnerFetcher = this.innerFetcher;
+        return localInnerFetcher is null ? TryFetchRare(obj, this.propertyName, ref this.innerFetcher, out value) : localInnerFetcher.TryFetch(obj, out value);
     }
 
 #if NET
@@ -109,26 +111,14 @@ internal sealed class PropertyFetcher<T>
                     return null;
                 }
 
-                var declaringType = propertyInfo.DeclaringType;
-                if (declaringType!.IsValueType)
-                {
-                    throw new NotSupportedException(
-                        $"Type: {declaringType.FullName} is a value type. PropertyFetcher can only operate on reference payload types.");
-                }
+#pragma warning disable IDE0370 // Suppression is unnecessary
+                var declaringType = propertyInfo.DeclaringType!;
+#pragma warning restore IDE0370 // Suppression is unnecessary
 
-                if (declaringType == typeof(object))
-                {
-                    // TODO: REMOVE this if branch when .NET 7 is out of support.
-                    // This branch is never executed and is only needed for .NET 7 AOT-compiler at trimming stage; i.e.,
-                    // this is not needed in .NET 8, because the compiler is improved and call into MakeGenericMethod will be AOT-compatible.
-                    // It is used to force the AOT compiler to create an instantiation of the method with a reference type.
-                    // The code for that instantiation can then be reused at runtime to create instantiation over any other reference.
-                    return CreateInstantiated<object>(propertyInfo);
-                }
-                else
-                {
-                    return DynamicInstantiationHelper(declaringType, propertyInfo);
-                }
+                return declaringType.IsValueType
+                    ? throw new NotSupportedException(
+                        $"Type: {declaringType.FullName} is a value type. PropertyFetcher can only operate on reference payload types.")
+                    : DynamicInstantiationHelper(declaringType, propertyInfo);
 
                 // Separated as a local function to be able to target the suppression to just this call.
                 // IL3050 was generated here because of the call to MakeGenericType, which is problematic in AOT if one of the type parameters is a value type;
@@ -139,10 +129,12 @@ internal sealed class PropertyFetcher<T>
 #endif
                 static PropertyFetch? DynamicInstantiationHelper(Type declaringType, PropertyInfo propertyInfo)
                 {
+#pragma warning disable IDE0370 // Suppression is unnecessary
                     return (PropertyFetch?)typeof(PropertyFetch)
                         .GetMethod(nameof(CreateInstantiated), BindingFlags.NonPublic | BindingFlags.Static)!
                         .MakeGenericMethod(declaringType) // This is validated in the earlier call chain to be a reference type.
-                        .Invoke(null, new object[] { propertyInfo })!;
+                        .Invoke(null, [propertyInfo]);
+#pragma warning restore IDE0370 // Suppression is unnecessary
                 }
             }
         }
@@ -174,7 +166,7 @@ internal sealed class PropertyFetcher<T>
         //    The declared object type is guaranteed to be a reference type (throw on value type.) Thus, MakeGenericMethod is AOT compatible.
         private static PropertyFetchInstantiated<TDeclaredObject> CreateInstantiated<TDeclaredObject>(PropertyInfo propertyInfo)
             where TDeclaredObject : class
-            => new PropertyFetchInstantiated<TDeclaredObject>(propertyInfo);
+            => new(propertyInfo);
 
 #if NET
         [RequiresUnreferencedCode(TrimCompatibilityMessage)]
@@ -189,7 +181,11 @@ internal sealed class PropertyFetcher<T>
             public PropertyFetchInstantiated(PropertyInfo property)
             {
                 this.propertyName = property.Name;
-                this.propertyFetch = (Func<TDeclaredObject, T>)property.GetMethod!.CreateDelegate(typeof(Func<TDeclaredObject, T>));
+#if NET
+                this.propertyFetch = property.GetMethod!.CreateDelegate<Func<TDeclaredObject, T>>();
+#else
+                this.propertyFetch = (Func<TDeclaredObject, T>)property.GetMethod.CreateDelegate(typeof(Func<TDeclaredObject, T>));
+#endif
             }
 
             public override int NumberOfInnerFetchers => this.innerFetcher == null
@@ -210,12 +206,7 @@ internal sealed class PropertyFetcher<T>
                 }
 
                 var innerFetcher = this.innerFetcher;
-                if (innerFetcher is null)
-                {
-                    return TryFetchRare(obj, this.propertyName, ref this.innerFetcher, out value);
-                }
-
-                return innerFetcher.TryFetch(obj, out value);
+                return innerFetcher is null ? TryFetchRare(obj, this.propertyName, ref this.innerFetcher, out value) : innerFetcher.TryFetch(obj, out value);
             }
         }
     }

--- a/src/Vendoring/OpenTelemetry.Instrumentation.ConfluentKafka/Shared/PropertyFetcher.cs
+++ b/src/Vendoring/OpenTelemetry.Instrumentation.ConfluentKafka/Shared/PropertyFetcher.cs
@@ -5,6 +5,8 @@
 // Usages of the non-AOT-compatible version can be moved over to this one when they need to support AOT/trimming.
 // Copied from https://github.com/open-telemetry/opentelemetry-dotnet/blob/86a6ba0b7f7ed1f5e84e5a6610e640989cd3ae9f/src/Shared/DiagnosticSourceInstrumentation/PropertyFetcher.cs#L30
 
+#nullable enable
+
 using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
 

--- a/src/Vendoring/OpenTelemetry.Instrumentation.ConfluentKafka/Shared/SemanticConventions.cs
+++ b/src/Vendoring/OpenTelemetry.Instrumentation.ConfluentKafka/Shared/SemanticConventions.cs
@@ -11,7 +11,7 @@ internal static class SemanticConventions
 {
     // The set of constants matches the specification as of this commit.
     // https://github.com/open-telemetry/opentelemetry-specification/tree/main/specification/trace/semantic_conventions
-    // https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/semantic_conventions/exceptions.md
+    // https://github.com/open-telemetry/semantic-conventions/blob/main/docs/exceptions/exceptions-spans.md
 #pragma warning disable CS1591 // Missing XML comment for publicly visible type or member
     public const string AttributeNetTransport = "net.transport";
     public const string AttributeNetPeerIp = "net.peer.ip";
@@ -24,8 +24,6 @@ internal static class SemanticConventions
     public const string AttributeEnduserId = "enduser.id";
     public const string AttributeEnduserRole = "enduser.role";
     public const string AttributeEnduserScope = "enduser.scope";
-
-    public const string AttributePeerService = "peer.service";
 
     public const string AttributeHttpMethod = "http.method";
     public const string AttributeHttpUrl = "http.url";
@@ -44,13 +42,13 @@ internal static class SemanticConventions
     public const string AttributeHttpResponseContentLength = "http.response_content_length";
     public const string AttributeHttpResponseContentLengthUncompressed = "http.response_content_length_uncompressed";
 
-    public const string AttributeDbSystem = "db.system";
     public const string AttributeDbConnectionString = "db.connection_string";
     public const string AttributeDbUser = "db.user";
     public const string AttributeDbMsSqlInstanceName = "db.mssql.instance_name";
     public const string AttributeDbJdbcDriverClassName = "db.jdbc.driver_classname";
     public const string AttributeDbName = "db.name";
     public const string AttributeDbStatement = "db.statement";
+    public const string AttributeDbSystem = "db.system";
     public const string AttributeDbOperation = "db.operation";
     public const string AttributeDbInstance = "db.instance";
     public const string AttributeDbCassandraKeyspace = "db.cassandra.keyspace";
@@ -62,6 +60,7 @@ internal static class SemanticConventions
     public const string AttributeRpcService = "rpc.service";
     public const string AttributeRpcMethod = "rpc.method";
     public const string AttributeRpcGrpcStatusCode = "rpc.grpc.status_code";
+    public const string AttributeRpcResponseStatusCode = "rpc.response.status_code";
 
     public const string AttributeMessageType = "message.type";
     public const string AttributeMessageId = "message.id";
@@ -117,6 +116,11 @@ internal static class SemanticConventions
     public const string AttributeServerPort = "server.port"; // replaces: "net.host.port" (AttributeNetHostPort)
     public const string AttributeUserAgentOriginal = "user_agent.original"; // replaces: http.user_agent (AttributeHttpUserAgent)
 
+    // v1.23.0 Database spans
+    // https://github.com/open-telemetry/semantic-conventions/blob/release/v1.23.x/docs/database/database-spans.md
+    public const string AttributeNetworkPeerAddress = "network.peer.address"; // replaces: "net.peer.ip" (AttributeNetPeerIp)
+    public const string AttributeNetworkPeerPort = "network.peer.port"; // replaces: "net.peer.port" (AttributeNetPeerPort)
+
     // v1.24.0 Messaging spans
     // https://github.com/open-telemetry/semantic-conventions/blob/v1.24.0/docs/messaging/messaging-spans.md
     public const string AttributeMessagingClientId = "messaging.client_id";
@@ -135,6 +139,22 @@ internal static class SemanticConventions
     public const string AttributeMessagingKafkaDestinationPartition = "messaging.kafka.destination.partition";
     public const string AttributeMessagingKafkaMessageKey = "messaging.kafka.message.key";
     public const string AttributeMessagingKafkaMessageOffset = "messaging.kafka.message.offset";
+
+    // v1.36.0 database conventions:
+    // https://github.com/open-telemetry/semantic-conventions/tree/v1.36.0/docs/database
+    public const string AttributeDbCollectionName = "db.collection.name";
+    public const string AttributeDbOperationName = "db.operation.name";
+    public const string AttributeDbSystemName = "db.system.name";
+    public const string AttributeDbNamespace = "db.namespace";
+    public const string AttributeDbResponseStatusCode = "db.response.status_code";
+    public const string AttributeDbOperationBatchSize = "db.operation.batch.size";
+    public const string AttributeDbQuerySummary = "db.query.summary";
+    public const string AttributeDbQueryText = "db.query.text";
+    public const string AttributeDbStoredProcedureName = "db.stored_procedure.name";
+
+    // v1.40.0 RPC spans
+    // https://github.com/open-telemetry/semantic-conventions/blob/v1.40.0/docs/rpc/rpc-spans.md
+    public const string AttributeRpcSystemName = "rpc.system.name";
 
 #pragma warning restore CS1591 // Missing XML comment for publicly visible type or member
 }

--- a/src/Vendoring/README.md
+++ b/src/Vendoring/README.md
@@ -5,7 +5,7 @@
 ```console
 git clone https://github.com/open-telemetry/opentelemetry-dotnet-contrib.git
 git fetch --tags
-git checkout tags/Instrumentation.ConfluentKafka-0.1.0-alpha.2
+git checkout tags/Instrumentation.ConfluentKafka-0.1.0-alpha.7
 ```
 
 ### Instructions


### PR DESCRIPTION


## Description

These PR includes changes for updating the `OpenTelemetry.Instrumentation.ConfluentKafka` files from version `0.1.0-alpha.2` to the latest version `0.1.0-alpha.7` following the instructions in https://github.com/microsoft/aspire/blob/main/src/Vendoring/README.md.

The new version of `OpenTelemetry.Instrumentation.ConfluentKafka` fixes a bug wherein `messaging.receive.messages` and `messaging.receive.duration` metrics are not emitted when a ConsumeException is encountered while consuming events.

These changes are required to be done in `microsoft/aspire` because it duplicates the `OpenTelemetry.Instrumentation.ConfluentKafka` on the vendoring folder.

Fixes #17655

## Checklist

- Is this feature complete?
  - [X] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [X] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [X] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [X] No
