### PR TITLE
[release/13.4] Update Foundry hosted agent builder APIs

### DIFF
--- a/playground/FoundryAgentEnterprise/FoundryAgentEnterprise.AppHost/AppHost.cs
+++ b/playground/FoundryAgentEnterprise/FoundryAgentEnterprise.AppHost/AppHost.cs
@@ -26,6 +26,7 @@ var app = builder.AddUvicornApp("app", "./app", "main:app")
     .WithReference(project)
     .WithReference(deployment)
     .WaitFor(deployment)
+    .AsHostedAgent()
     .WithComputeEnvironment(project, (opts) =>
     {
         opts.Description = "Foundry Agent Basic Example";

--- a/playground/FoundryAgentEnterprise/FoundryAgentEnterprise.AppHost/AppHost.cs
+++ b/playground/FoundryAgentEnterprise/FoundryAgentEnterprise.AppHost/AppHost.cs
@@ -23,11 +23,9 @@ var app = builder.AddUvicornApp("app", "./app", "main:app")
     .WithHttpEndpoint()
     .WithExternalHttpEndpoints()
     .WithHttpHealthCheck("/health")
-    .WithReference(project)
     .WithReference(deployment)
     .WaitFor(deployment)
-    .AsHostedAgent()
-    .WithComputeEnvironment(project, (opts) =>
+    .AsHostedAgent(project, (opts) =>
     {
         opts.Description = "Foundry Agent Basic Example";
         opts.Metadata["managed-by"] = "aspire-foundry";

--- a/playground/FoundryAgents/FoundryAgents.AppHost/AppHost.cs
+++ b/playground/FoundryAgents/FoundryAgents.AppHost/AppHost.cs
@@ -44,11 +44,13 @@ var codeInterpreter = project.AddCodeInterpreterTool("code-interp");
 builder.AddPythonApp("weather-hosted-agent", "../app", "main.py")
     .WithUv()
     .WithReference(project).WithReference(chat).WaitFor(chat)
+    .AsHostedAgent()
     .WithComputeEnvironment(project);
 
 builder.AddProject<Projects.DotNetHostedAgent>("proj-dotnet-hosted-agent")
     .WithHttpEndpoint(targetPort: 9000)
     .WithReference(project).WithReference(chat).WaitFor(chat)
+    .AsHostedAgent()
     .WithComputeEnvironment(project);
 
 // --- Prompt Agents ---

--- a/playground/FoundryAgents/FoundryAgents.AppHost/AppHost.cs
+++ b/playground/FoundryAgents/FoundryAgents.AppHost/AppHost.cs
@@ -43,15 +43,13 @@ var codeInterpreter = project.AddCodeInterpreterTool("code-interp");
 
 builder.AddPythonApp("weather-hosted-agent", "../app", "main.py")
     .WithUv()
-    .WithReference(project).WithReference(chat).WaitFor(chat)
-    .AsHostedAgent()
-    .WithComputeEnvironment(project);
+    .WithReference(chat).WaitFor(chat)
+    .AsHostedAgent(project);
 
 builder.AddProject<Projects.DotNetHostedAgent>("proj-dotnet-hosted-agent")
     .WithHttpEndpoint(targetPort: 9000)
-    .WithReference(project).WithReference(chat).WaitFor(chat)
-    .AsHostedAgent()
-    .WithComputeEnvironment(project);
+    .WithReference(chat).WaitFor(chat)
+    .AsHostedAgent(project);
 
 // --- Prompt Agents ---
 

--- a/src/Aspire.Hosting.Foundry/FoundryExtensions.cs
+++ b/src/Aspire.Hosting.Foundry/FoundryExtensions.cs
@@ -41,6 +41,7 @@ public static class FoundryExtensions
 
         var resource = new FoundryResource(name, ConfigureInfrastructure);
         return builder.AddResource(resource)
+            .WithIconName("AgentsAdd")
             .WithDefaultRoleAssignments(CognitiveServicesBuiltInRole.GetBuiltInRoleName,
                 CognitiveServicesBuiltInRole.CognitiveServicesUser, CognitiveServicesBuiltInRole.CognitiveServicesOpenAIUser);
     }
@@ -77,7 +78,7 @@ public static class FoundryExtensions
             deploymentBuilder.AsLocalDeployment(deployment);
         }
 
-        return deploymentBuilder;
+        return deploymentBuilder.WithIconName("BoxMultiple");
     }
 
     /// <summary>

--- a/src/Aspire.Hosting.Foundry/HostedAgent/HostedAgentBuilderExtension.cs
+++ b/src/Aspire.Hosting.Foundry/HostedAgent/HostedAgentBuilderExtension.cs
@@ -36,7 +36,7 @@ public static class HostedAgentResourceBuilderExtensions
     /// </code>
     /// </example>
     /// <ats-returns>The resource builder.</ats-returns>
-    [AspireExportIgnore(Reason = "Subset of the full AsHostedAgent overload which is exported.")]
+    [AspireExportIgnore(Reason = "Subset of the full AsHostedAgent(project) overload which is exported.")]
     public static IResourceBuilder<T> AsHostedAgent<T>(this IResourceBuilder<T> builder)
         where T : IResourceWithEndpoints, IResourceWithEnvironment, IComputeResource
     {
@@ -44,18 +44,48 @@ public static class HostedAgentResourceBuilderExtensions
     }
 
     /// <summary>
-    /// Configures the resource to run and publish as a hosted agent in Microsoft Foundry.
+    /// Configures the resource to run and publish as a hosted agent in Microsoft Foundry, targeting the specified Foundry project.
     /// </summary>
     /// <typeparam name="T">The type of resource being configured.</typeparam>
     /// <param name="builder">The resource builder for the compute resource.</param>
-    /// <param name="project">Optional Microsoft Foundry project resource used for both run and publish mode configuration.</param>
-    /// <param name="configure">A callback to configure hosted agent deployment options in publish mode.</param>
+    /// <param name="project">The Microsoft Foundry project resource used for both run and publish mode configuration.</param>
+    /// <param name="options">Optional hosted agent deployment options applied in publish mode.</param>
     /// <returns>A reference to the <see cref="IResourceBuilder{T}"/> for chaining.</returns>
+    /// <example>
+    /// <code lang="csharp">
+    /// var agent = builder.AddProject&lt;Projects.AgentService&gt;("agent")
+    ///     .AsHostedAgent(project, new HostedAgentOptions { Cpu = 1, Memory = 2 });
+    /// </code>
+    /// </example>
+    /// <ats-returns>The resource builder.</ats-returns>
     [AspireExport("asHostedAgentExecutable", MethodName = "asHostedAgent")]
     public static IResourceBuilder<T> AsHostedAgent<T>(
         this IResourceBuilder<T> builder,
-        IResourceBuilder<AzureCognitiveServicesProjectResource>? project = null,
-        Action<HostedAgentConfiguration>? configure = null)
+        IResourceBuilder<AzureCognitiveServicesProjectResource> project,
+        HostedAgentOptions? options = null)
+        where T : IResourceWithEndpoints, IResourceWithEnvironment, IComputeResource
+    {
+        ArgumentNullException.ThrowIfNull(project);
+
+        Action<HostedAgentConfiguration>? configure = options is null ? null : options.ApplyTo;
+        return AsHostedAgent(builder, project: project, configure: configure);
+    }
+
+    /// <summary>
+    /// Configures the resource to run and publish as a hosted agent in Microsoft Foundry, with full programmatic
+    /// access to the underlying <see cref="HostedAgentConfiguration"/> (including Azure SDK-specific options
+    /// such as tools and content filters).
+    /// </summary>
+    /// <typeparam name="T">The type of resource being configured.</typeparam>
+    /// <param name="builder">The resource builder for the compute resource.</param>
+    /// <param name="project">Optional Microsoft Foundry project resource used for both run and publish mode configuration. When <see langword="null"/>, an existing Foundry project in the model is reused or a new project is created in publish mode.</param>
+    /// <param name="configure">A callback to configure hosted agent deployment options in publish mode.</param>
+    /// <returns>A reference to the <see cref="IResourceBuilder{T}"/> for chaining.</returns>
+    [AspireExportIgnore(Reason = "Action callback shape is awkward for polyglot hosts; the HostedAgentOptions overload is exported instead.")]
+    public static IResourceBuilder<T> AsHostedAgent<T>(
+        this IResourceBuilder<T> builder,
+        IResourceBuilder<AzureCognitiveServicesProjectResource>? project,
+        Action<HostedAgentConfiguration>? configure)
         where T : IResourceWithEndpoints, IResourceWithEnvironment, IComputeResource
     {
         ArgumentNullException.ThrowIfNull(builder);
@@ -79,7 +109,9 @@ public static class HostedAgentResourceBuilderExtensions
     }
 
     /// <summary>
-    /// Configures the resource to run and publish as a hosted agent in Microsoft Foundry.
+    /// Configures the resource to run and publish as a hosted agent in Microsoft Foundry, with full programmatic
+    /// access to the underlying <see cref="HostedAgentConfiguration"/>. The Foundry project is resolved automatically
+    /// in publish mode.
     /// </summary>
     /// <typeparam name="T">The type of resource being configured.</typeparam>
     /// <param name="builder">The resource builder for the compute resource.</param>

--- a/src/Aspire.Hosting.Foundry/HostedAgent/HostedAgentBuilderExtension.cs
+++ b/src/Aspire.Hosting.Foundry/HostedAgent/HostedAgentBuilderExtension.cs
@@ -43,17 +43,22 @@ public static class HostedAgentResourceBuilderExtensions
         return AsHostedAgent(builder, project: null, configure: null);
     }
 
+    // The internal AsHostedAgentForExport overload below is the polyglot-exported version of AsHostedAgent.
+    // The method name differs from AsHostedAgent to avoid C# overload ambiguity with the Action-based
+    // overload; the polyglot-facing name is set back to "asHostedAgent" via [AspireExport(MethodName)].
+    // .NET callers should keep using the Action<HostedAgentConfiguration> overload above, which exposes
+    // the full HostedAgentConfiguration surface (tools, content filters, container protocol versions, etc.).
+
     /// <summary>
     /// Configures the resource to run and publish as a hosted agent in Microsoft Foundry, targeting the specified Foundry project.
     /// </summary>
-    /// <remarks>
-    /// This overload exists for the polyglot SDK surfaces (TypeScript, Go, Java, Python) generated via
-    /// <see cref="AspireExportAttribute"/>. .NET callers should use the
-    /// <see cref="AsHostedAgent{T}(IResourceBuilder{T}, IResourceBuilder{AzureCognitiveServicesProjectResource}?, Action{HostedAgentConfiguration}?)"/>
-    /// overload, which exposes the full <see cref="HostedAgentConfiguration"/> surface.
-    /// The method name differs from <c>AsHostedAgent</c> to avoid C# overload ambiguity with the <c>Action</c>-based
-    /// overload; the polyglot-facing name is set back to <c>asHostedAgent</c> via <see cref="AspireExportAttribute.MethodName"/>.
-    /// </remarks>
+    /// <typeparam name="T">The type of resource being configured.</typeparam>
+    /// <param name="builder">The resource builder for the compute resource.</param>
+    /// <param name="project">The Microsoft Foundry project the hosted agent is deployed into.</param>
+    /// <param name="options">Optional hosted agent deployment options (description, CPU, memory, metadata, environment variables) applied in publish mode.</param>
+    /// <returns>A reference to the <see cref="IResourceBuilder{T}"/> for chaining.</returns>
+    /// <ats-returns>The resource builder.</ats-returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="builder"/> or <paramref name="project"/> is <see langword="null"/>.</exception>
     [AspireExport("asHostedAgentExecutable", MethodName = "asHostedAgent")]
     internal static IResourceBuilder<T> AsHostedAgentForExport<T>(
         this IResourceBuilder<T> builder,

--- a/src/Aspire.Hosting.Foundry/HostedAgent/HostedAgentBuilderExtension.cs
+++ b/src/Aspire.Hosting.Foundry/HostedAgent/HostedAgentBuilderExtension.cs
@@ -15,152 +15,6 @@ namespace Aspire.Hosting;
 /// </summary>
 public static class HostedAgentResourceBuilderExtensions
 {
-
-    /// <summary>
-    /// Configures the resource to be deployed as a hosted agent in Microsoft Foundry.
-    /// </summary>
-    /// <typeparam name="T">The type of resource being configured.</typeparam>
-    /// <param name="builder">The resource builder for the compute resource.</param>
-    /// <param name="configure">A callback to configure the hosted agent deployment.</param>
-    /// <returns>A reference to the <see cref="IResourceBuilder{T}"/> for chaining.</returns>
-    /// <remarks>
-    /// This method applies in publish mode. Use <see cref="AsHostedAgent{T}(IResourceBuilder{T})"/>
-    /// to configure the resource with local run-mode hosted agent endpoints, dashboard commands,
-    /// and OpenTelemetry settings.
-    /// </remarks>
-    [AspireExportIgnore(Reason = "Subset of the full WithComputeEnvironment overload which is exported.")]
-    public static IResourceBuilder<T> WithComputeEnvironment<T>(
-        this IResourceBuilder<T> builder, Action<HostedAgentConfiguration> configure)
-        where T : IResourceWithEndpoints, IResourceWithEnvironment, IComputeResource
-    {
-        return WithComputeEnvironment(builder, project: null, configure: configure);
-    }
-
-    /// <summary>
-    /// Configures the resource to be deployed as a hosted agent in Microsoft Foundry.
-    /// </summary>
-    /// <typeparam name="T">The type of resource being configured.</typeparam>
-    /// <param name="builder">The resource builder for the compute resource.</param>
-    /// <param name="project">The Microsoft Foundry project resource to deploy the hosted agent to.</param>
-    /// <param name="configure">A callback to configure the hosted agent deployment.</param>
-    /// <returns>A reference to the <see cref="IResourceBuilder{T}"/> for chaining.</returns>
-    /// <remarks>
-    /// <para>
-    /// If <paramref name="project"/> is not provided, this method attempts to find an existing Microsoft Foundry
-    /// project resource in the application model. If none exists, a new project resource and parent account resource
-    /// are created automatically.
-    /// </para>
-    /// <para>
-    /// This method applies in publish mode. Use <see cref="AsHostedAgent{T}(IResourceBuilder{T})"/>
-    /// to configure the resource with local run-mode hosted agent endpoints, dashboard commands,
-    /// and OpenTelemetry settings.
-    /// </para>
-    /// </remarks>
-    [AspireExport("withComputeEnvironmentExecutable", MethodName = "withComputeEnvironment")]
-    public static IResourceBuilder<T> WithComputeEnvironment<T>(
-        this IResourceBuilder<T> builder, IResourceBuilder<AzureCognitiveServicesProjectResource>? project = null, Action<HostedAgentConfiguration>? configure = null)
-        where T : IResourceWithEndpoints, IResourceWithEnvironment, IComputeResource
-    {
-        if (builder.ApplicationBuilder.ExecutionContext.IsPublishMode)
-        {
-            /*
-             * Much of the logic here is similar to ExecutableResourceBuilderExtensions.PublishAsDockerFile().
-             *
-             * That is, in Publish mode, we swap the original resource with a hosted agent resource.
-             */
-            ArgumentNullException.ThrowIfNull(builder);
-
-            var resource = builder.Resource;
-
-            AzureCognitiveServicesProjectResource? projResource;
-            if (project is not null)
-            {
-                projResource = project.Resource;
-            }
-            else
-            {
-                projResource = builder.ApplicationBuilder.Resources.OfType<AzureCognitiveServicesProjectResource>().FirstOrDefault();
-                if (projResource is null)
-                {
-                    project = builder.ApplicationBuilder
-                        .AddFoundry($"{resource.Name}-proj-foundry")
-                        .AddProject($"{resource.Name}-proj");
-                    projResource = project.Resource;
-                }
-                else
-                {
-                    project = builder.ApplicationBuilder.CreateResourceBuilder(projResource);
-                }
-            }
-
-            ResourceBuilderExtensions.WithComputeEnvironment(builder, project!);
-
-            // Hosted Agent resource name
-            var agentName = $"{resource.Name}-ha";
-            if (builder.ApplicationBuilder.TryCreateResourceBuilder<AzureHostedAgentResource>(agentName, out var rb))
-            {
-                // We already have a hosted agent for this resource
-                if (configure is not null)
-                {
-                    rb.Resource.Configure = configure;
-                }
-                return builder;
-            }
-            // Get the corresponding ContainerResource for ExecutableResources. Usually this is swapped in at publish time for ExecutableResources.
-            IResource target;
-            if (resource is ContainerResource containerResource)
-            {
-                target = containerResource;
-            }
-            else if (builder.ApplicationBuilder.TryCreateResourceBuilder<ContainerResource>(resource.Name, out var crb))
-            {
-                target = crb.Resource;
-            }
-            else
-            {
-                // Ensure we have a container resource to deploy.
-                // ExecutableResource needs PublishAsDockerFile()
-                // to convert them into container resources at this stage.
-                if (resource is ExecutableResource)
-                {
-                    builder.ApplicationBuilder.CreateResourceBuilder((ExecutableResource)(object)resource).PublishAsDockerFile();
-
-                    if (builder.ApplicationBuilder.TryCreateResourceBuilder(resource.Name, out crb))
-                    {
-                        target = crb.Resource;
-                    }
-                    else
-                    {
-                        throw new InvalidOperationException($"Unable to create hosted agent for resource '{resource.Name}' because it could not be converted to a container resource.");
-                    }
-                }
-                else if (resource is not ProjectResource)
-                {
-                    throw new InvalidOperationException($"Unable to create hosted agent for resource '{resource.Name}' because it is not a container, executable, or project resource.");
-                }
-                else
-                {
-                    target = resource;
-                }
-            }
-
-            // Create a separate agent resource to host the deployment
-            var agent = new AzureHostedAgentResource(agentName, target, configure);
-
-            // Ensure image gets pushed properly
-            target.Annotations.Add(new DeploymentTargetAnnotation(agent)
-            {
-                ComputeEnvironment = projResource,
-                ContainerRegistry = projResource.ContainerRegistry
-            });
-
-            builder.ApplicationBuilder.AddResource(agent)
-                .WithReferenceRelationship(target)
-                .WithReference(project);
-        }
-        return builder;
-    }
-
     /// <summary>
     /// Configures the resource to run locally as a Microsoft Foundry hosted agent.
     /// </summary>
@@ -180,127 +34,273 @@ public static class HostedAgentResourceBuilderExtensions
     /// </code>
     /// </example>
     /// <ats-returns>The resource builder.</ats-returns>
-    [AspireExport]
+    [AspireExportIgnore(Reason = "Subset of the full AsHostedAgent overload which is exported.")]
     public static IResourceBuilder<T> AsHostedAgent<T>(this IResourceBuilder<T> builder)
         where T : IResourceWithEndpoints, IResourceWithEnvironment, IComputeResource
     {
+        return AsHostedAgent(builder, project: null, configure: null);
+    }
+
+    /// <summary>
+    /// Configures the resource to run and publish as a hosted agent in Microsoft Foundry.
+    /// </summary>
+    /// <typeparam name="T">The type of resource being configured.</typeparam>
+    /// <param name="builder">The resource builder for the compute resource.</param>
+    /// <param name="project">Optional Microsoft Foundry project resource used for both run and publish mode configuration.</param>
+    /// <param name="configure">A callback to configure hosted agent deployment options in publish mode.</param>
+    /// <returns>A reference to the <see cref="IResourceBuilder{T}"/> for chaining.</returns>
+    [AspireExport("asHostedAgentExecutable", MethodName = "asHostedAgent")]
+    public static IResourceBuilder<T> AsHostedAgent<T>(
+        this IResourceBuilder<T> builder,
+        IResourceBuilder<AzureCognitiveServicesProjectResource>? project = null,
+        Action<HostedAgentConfiguration>? configure = null)
+        where T : IResourceWithEndpoints, IResourceWithEnvironment, IComputeResource
+    {
+        ArgumentNullException.ThrowIfNull(builder);
+
         if (builder.ApplicationBuilder.ExecutionContext.IsRunMode)
         {
-            // Preserve any target port already configured on an existing "http" endpoint;
-            // fall back to the default MAF agent port (8088) when none is set.
-            var existingHttpEndpoint = builder.Resource.Annotations.OfType<EndpointAnnotation>().FirstOrDefault(e => e.Name == "http");
-            var targetPort = existingHttpEndpoint?.TargetPort ?? 8088;
+            ConfigureRunMode(builder);
 
-            builder
-                .WithHttpEndpoint(name: "http", env: "DEFAULT_AD_PORT", targetPort: targetPort, isProxied: true)
-                .WithUrls((ctx) =>
-                {
-                    var http = ctx.Urls.FirstOrDefault(u => u.Endpoint?.EndpointName == "http" || u.Endpoint?.EndpointName == "https");
-                    if (http is null)
-                    {
-                        return;
-                    }
-                    http.DisplayText = "Responses Endpoint";
-                    http.Url = new UriBuilder(http.Url)
-                    {
-                        Path = "/responses"
-                    }.ToString();
-                })
-                .WithHttpCommand(
-                    path: "/responses",
-                    displayName: "Send Message",
-                    endpointName: "http",
-                    commandOptions: new()
-                    {
-                        Method = HttpMethod.Post,
-                        IconName = "Agents",
-                        IconVariant = IconVariant.Regular,
-                        IsHighlighted = true,
-                        PrepareRequest = async ctx =>
-                        {
-                            var interactionService = ctx.ServiceProvider.GetRequiredService<IInteractionService>();
-                            var result = await interactionService.PromptInputAsync(
-                                title: "Responses API",
-                                message: "Enter a message to send to the agent.",
-                                inputLabel: "Message",
-                                placeHolder: "I would like to know the weather today.",
-                                cancellationToken: ctx.CancellationToken
-                            ).ConfigureAwait(true);
-                            if (result.Canceled || string.IsNullOrWhiteSpace(result.Data.Value))
-                            {
-                                ctx.HttpClient.CancelPendingRequests();
-                                throw new OperationCanceledException("User canceled the input prompt.");
-                            }
-                            var request = ctx.Request;
-                            var input = result.Data.Value;
-                            request.Content = new StringContent(new JsonObject() { ["input"] = input }.ToString(), System.Text.Encoding.UTF8, "application/json");
-                        },
-                        GetCommandResult = async ctx =>
-                        {
-                            ctx.CancellationToken.ThrowIfCancellationRequested();
-                            try
-                            {
-                                var response = await ctx.Response
-                                    .EnsureSuccessStatusCode()
-                                    .Content
-                                    .ReadFromJsonAsync<JsonObject>(cancellationToken: ctx.CancellationToken)
-                                    .ConfigureAwait(true);
-                                var formattedResponse = $"```\n{JsonSerializer.Serialize(response, new JsonSerializerOptions { WriteIndented = true })}\n```";
-                                var interactionService = ctx.ServiceProvider.GetRequiredService<IInteractionService>();
-                                await interactionService.PromptMessageBoxAsync(
-                                    title: "Agent Response",
-                                    message: formattedResponse,
-                                    options: new()
-                                    {
-                                        Intent = MessageIntent.Success,
-                                        EnableMessageMarkdown = true,
-                                        PrimaryButtonText = "Thanks!"
-                                    },
-                                    cancellationToken: ctx.CancellationToken
-                                ).ConfigureAwait(true);
-                                return new() { Success = true };
-                            }
-                            catch (Exception ex)
-                            {
-                                var interactionService = ctx.ServiceProvider.GetRequiredService<IInteractionService>();
-                                await interactionService.PromptMessageBoxAsync(
-                                    title: "Error",
-                                    message: $"An error occurred while processing the agent's response: {ex.Message}",
-                                    options: new()
-                                    {
-                                        Intent = MessageIntent.Error,
-                                        PrimaryButtonText = "OK"
-                                    },
-                                    cancellationToken: ctx.CancellationToken
-                                ).ConfigureAwait(true);
-                                Console.Error.Write($"Error processing agent response: {ex}");
-                                return new() { Success = false };
-                            }
-                        },
-                    }
-                )
-                .WithOtlpExporter()
-                .WithEnvironment((ctx) =>
-                {
-                    ctx.EnvironmentVariables.Add("OTEL_INSTRUMENTATION_OPENAI_AGENTS_ENABLED", "true");
-                    ctx.EnvironmentVariables.Add("OTEL_INSTRUMENTATION_OPENAI_AGENTS_CAPTURE_CONTENT", "true");
-                    ctx.EnvironmentVariables.Add("OTEL_INSTRUMENTATION_OPENAI_AGENTS_CAPTURE_METRICS", "true");
-                    ctx.EnvironmentVariables.Add("OTEL_GENAI_CAPTURE_MESSAGES", "true");
-                    ctx.EnvironmentVariables.Add("OTEL_GENAI_CAPTURE_SYSTEM_INSTRUCTIONS", "true");
-                    ctx.EnvironmentVariables.Add("OTEL_GENAI_CAPTURE_TOOL_DEFINITIONS", "true");
-                    ctx.EnvironmentVariables.Add("OTEL_GENAI_EMIT_OPERATION_DETAILS", "true");
-                    ctx.EnvironmentVariables.Add("OTEL_GENAI_AGENT_NAME", ctx.Resource.Name);
-                    ctx.EnvironmentVariables.Add("OTEL_GENAI_AGENT_ID", ctx.Resource.Name);
-                    var endpointVar = ctx.EnvironmentVariables.FirstOrDefault((item) => item.Key == "OTEL_EXPORTER_OTLP_ENDPOINT");
-                    if (endpointVar.Equals(default(KeyValuePair<string, string>)))
-                    {
-                        return;
-                    }
-                    // The Microsoft Foundry agentserver SDK expects the exporter to be at OTEL_EXPORTER_ENDPOINT instead.
-                    ctx.EnvironmentVariables["OTEL_EXPORTER_ENDPOINT"] = endpointVar.Value;
-                });
+            if (project is not null)
+            {
+                AddProjectReferenceForRunMode(builder, project);
+            }
+
+            return builder;
         }
 
+        var publishProject = project ?? ResolveProjectBuilderForPublish(builder);
+        ConfigurePublishMode(builder, publishProject, configure);
+
         return builder;
+    }
+
+    /// <summary>
+    /// Configures the resource to run and publish as a hosted agent in Microsoft Foundry.
+    /// </summary>
+    /// <typeparam name="T">The type of resource being configured.</typeparam>
+    /// <param name="builder">The resource builder for the compute resource.</param>
+    /// <param name="configure">A callback to configure hosted agent deployment options in publish mode.</param>
+    /// <returns>A reference to the <see cref="IResourceBuilder{T}"/> for chaining.</returns>
+    [AspireExportIgnore(Reason = "Subset of the full AsHostedAgent overload.")]
+    public static IResourceBuilder<T> AsHostedAgent<T>(
+        this IResourceBuilder<T> builder,
+        Action<HostedAgentConfiguration> configure)
+        where T : IResourceWithEndpoints, IResourceWithEnvironment, IComputeResource
+    {
+        ArgumentNullException.ThrowIfNull(configure);
+        return AsHostedAgent(builder, project: null, configure: configure);
+    }
+
+    private static void AddProjectReferenceForRunMode<T>(
+        IResourceBuilder<T> builder,
+        IResourceBuilder<AzureCognitiveServicesProjectResource> project)
+        where T : IResourceWithEndpoints, IResourceWithEnvironment, IComputeResource
+    {
+        builder.WithReference(project);
+
+        // The default ACR is required for publish-time image push, but in run mode it adds noise to the dashboard.
+        // When a hosted agent references a Foundry project for local execution, remove the default registry resource.
+        if (project.Resource.DefaultContainerRegistry is { } defaultRegistry)
+        {
+            builder.ApplicationBuilder.Resources.Remove(defaultRegistry);
+            project.Resource.DefaultContainerRegistry = null;
+        }
+    }
+
+    private static IResourceBuilder<AzureCognitiveServicesProjectResource> ResolveProjectBuilderForPublish<T>(IResourceBuilder<T> builder)
+        where T : IResourceWithEndpoints, IResourceWithEnvironment, IComputeResource
+    {
+        if (builder.ApplicationBuilder.Resources.OfType<AzureCognitiveServicesProjectResource>().FirstOrDefault() is { } existingProject)
+        {
+            return builder.ApplicationBuilder.CreateResourceBuilder(existingProject);
+        }
+
+        return builder.ApplicationBuilder
+            .AddFoundry($"{builder.Resource.Name}-proj-foundry")
+            .AddProject($"{builder.Resource.Name}-proj");
+    }
+
+    private static void ConfigureRunMode<T>(IResourceBuilder<T> builder)
+        where T : IResourceWithEndpoints, IResourceWithEnvironment, IComputeResource
+    {
+        // Preserve any target port already configured on an existing "http" endpoint;
+        // fall back to the default MAF agent port (8088) when none is set.
+        var existingHttpEndpoint = builder.Resource.Annotations.OfType<EndpointAnnotation>().FirstOrDefault(e => e.Name == "http");
+        var targetPort = existingHttpEndpoint?.TargetPort ?? 8088;
+
+        builder
+            .WithIconName("Agents")
+            .WithHttpEndpoint(name: "http", env: "DEFAULT_AD_PORT", targetPort: targetPort, isProxied: true)
+            .WithUrls((ctx) =>
+            {
+                var http = ctx.Urls.FirstOrDefault(u => u.Endpoint?.EndpointName == "http" || u.Endpoint?.EndpointName == "https");
+                if (http is null)
+                {
+                    return;
+                }
+                http.DisplayText = "Responses Endpoint";
+                http.Url = new UriBuilder(http.Url)
+                {
+                    Path = "/responses"
+                }.ToString();
+            })
+            .WithHttpCommand(
+                path: "/responses",
+                displayName: "Send Message",
+                endpointName: "http",
+                commandOptions: new()
+                {
+                    Method = HttpMethod.Post,
+                    IconName = "ChatSparkle",
+                    IconVariant = IconVariant.Regular,
+                    IsHighlighted = true,
+                    PrepareRequest = async ctx =>
+                    {
+                        var interactionService = ctx.ServiceProvider.GetRequiredService<IInteractionService>();
+                        var result = await interactionService.PromptInputAsync(
+                            title: "Responses API",
+                            message: "Enter a message to send to the agent.",
+                            inputLabel: "Message",
+                            placeHolder: "I would like to know the weather today.",
+                            cancellationToken: ctx.CancellationToken
+                        ).ConfigureAwait(true);
+                        if (result.Canceled || string.IsNullOrWhiteSpace(result.Data.Value))
+                        {
+                            ctx.HttpClient.CancelPendingRequests();
+                            throw new OperationCanceledException("User canceled the input prompt.");
+                        }
+                        var request = ctx.Request;
+                        var input = result.Data.Value;
+                        request.Content = new StringContent(new JsonObject() { ["input"] = input }.ToString(), System.Text.Encoding.UTF8, "application/json");
+                    },
+                    GetCommandResult = async ctx =>
+                    {
+                        ctx.CancellationToken.ThrowIfCancellationRequested();
+
+                        var response = ctx.Response;
+                        if (!response.IsSuccessStatusCode)
+                        {
+                            var errorPayload = await response.Content.ReadAsStringAsync(ctx.CancellationToken).ConfigureAwait(true);
+                            return CommandResults.Failure(
+                                $"Agent request failed with status code {(int)response.StatusCode} ({response.StatusCode}).",
+                                errorPayload,
+                                CommandResultFormat.Text);
+                        }
+
+                        var responseJson = await response.Content.ReadFromJsonAsync<JsonObject>(cancellationToken: ctx.CancellationToken).ConfigureAwait(true);
+                        if (responseJson is null)
+                        {
+                            return CommandResults.Failure("Agent returned an empty response.");
+                        }
+
+                        var formattedResponse = JsonSerializer.Serialize(responseJson, new JsonSerializerOptions { WriteIndented = true });
+                        return CommandResults.Success(
+                            message: "Agent response received.",
+                            result: formattedResponse,
+                            resultFormat: CommandResultFormat.Json,
+                            displayImmediately: true);
+                    },
+                }
+            )
+            .WithOtlpExporter()
+            .WithEnvironment((ctx) =>
+            {
+                ctx.EnvironmentVariables.Add("OTEL_INSTRUMENTATION_OPENAI_AGENTS_ENABLED", "true");
+                ctx.EnvironmentVariables.Add("OTEL_INSTRUMENTATION_OPENAI_AGENTS_CAPTURE_CONTENT", "true");
+                ctx.EnvironmentVariables.Add("OTEL_INSTRUMENTATION_OPENAI_AGENTS_CAPTURE_METRICS", "true");
+                ctx.EnvironmentVariables.Add("OTEL_GENAI_CAPTURE_MESSAGES", "true");
+                ctx.EnvironmentVariables.Add("OTEL_GENAI_CAPTURE_SYSTEM_INSTRUCTIONS", "true");
+                ctx.EnvironmentVariables.Add("OTEL_GENAI_CAPTURE_TOOL_DEFINITIONS", "true");
+                ctx.EnvironmentVariables.Add("OTEL_GENAI_EMIT_OPERATION_DETAILS", "true");
+                ctx.EnvironmentVariables.Add("OTEL_GENAI_AGENT_NAME", ctx.Resource.Name);
+                ctx.EnvironmentVariables.Add("OTEL_GENAI_AGENT_ID", ctx.Resource.Name);
+                var endpointVar = ctx.EnvironmentVariables.FirstOrDefault((item) => item.Key == "OTEL_EXPORTER_OTLP_ENDPOINT");
+                if (endpointVar.Equals(default(KeyValuePair<string, string>)))
+                {
+                    return;
+                }
+                // The Microsoft Foundry agentserver SDK expects the exporter to be at OTEL_EXPORTER_ENDPOINT instead.
+                ctx.EnvironmentVariables["OTEL_EXPORTER_ENDPOINT"] = endpointVar.Value;
+            });
+    }
+
+    private static void ConfigurePublishMode<T>(
+        IResourceBuilder<T> builder,
+        IResourceBuilder<AzureCognitiveServicesProjectResource> project,
+        Action<HostedAgentConfiguration>? configure)
+        where T : IResourceWithEndpoints, IResourceWithEnvironment, IComputeResource
+    {
+        /*
+         * Much of the logic here is similar to ExecutableResourceBuilderExtensions.PublishAsDockerFile().
+         *
+         * That is, in Publish mode, we swap the original resource with a hosted agent resource.
+         */
+        var resource = builder.Resource;
+        var projectResource = project.Resource;
+
+        ResourceBuilderExtensions.WithComputeEnvironment(builder, project);
+
+        // Hosted Agent resource name
+        var agentName = $"{resource.Name}-ha";
+        if (builder.ApplicationBuilder.TryCreateResourceBuilder<AzureHostedAgentResource>(agentName, out var existingHostedAgent))
+        {
+            // We already have a hosted agent for this resource
+            if (configure is not null)
+            {
+                existingHostedAgent.Resource.Configure = configure;
+            }
+            return;
+        }
+
+        // Get the corresponding ContainerResource for ExecutableResources. Usually this is swapped in at publish time for ExecutableResources.
+        IResource target;
+        if (resource is ContainerResource containerResource)
+        {
+            target = containerResource;
+        }
+        else if (builder.ApplicationBuilder.TryCreateResourceBuilder<ContainerResource>(resource.Name, out var containerResourceBuilder))
+        {
+            target = containerResourceBuilder.Resource;
+        }
+        else if (resource is ExecutableResource executableResource)
+        {
+            // Ensure we have a container resource to deploy.
+            // ExecutableResource needs PublishAsDockerFile() to convert it into a container resource at this stage.
+            builder.ApplicationBuilder.CreateResourceBuilder(executableResource).PublishAsDockerFile();
+
+            if (builder.ApplicationBuilder.TryCreateResourceBuilder(resource.Name, out containerResourceBuilder))
+            {
+                target = containerResourceBuilder.Resource;
+            }
+            else
+            {
+                throw new InvalidOperationException($"Unable to create hosted agent for resource '{resource.Name}' because it could not be converted to a container resource.");
+            }
+        }
+        else if (resource is ProjectResource)
+        {
+            target = resource;
+        }
+        else
+        {
+            throw new InvalidOperationException($"Unable to create hosted agent for resource '{resource.Name}' because it is not a container, executable, or project resource.");
+        }
+
+        // Create a separate agent resource to host the deployment.
+        var hostedAgent = new AzureHostedAgentResource(agentName, target, configure);
+
+        // Ensure image gets pushed properly.
+        target.Annotations.Add(new DeploymentTargetAnnotation(hostedAgent)
+        {
+            ComputeEnvironment = projectResource,
+            ContainerRegistry = projectResource.ContainerRegistry
+        });
+
+        builder.ApplicationBuilder.AddResource(hostedAgent)
+            .WithIconName("Agents")
+            .WithReferenceRelationship(target)
+            .WithReference(project);
     }
 }

--- a/src/Aspire.Hosting.Foundry/HostedAgent/HostedAgentBuilderExtension.cs
+++ b/src/Aspire.Hosting.Foundry/HostedAgent/HostedAgentBuilderExtension.cs
@@ -53,20 +53,120 @@ public static class HostedAgentResourceBuilderExtensions
         this IResourceBuilder<T> builder, IResourceBuilder<AzureCognitiveServicesProjectResource>? project = null, Action<HostedAgentConfiguration>? configure = null)
         where T : IResourceWithEndpoints, IResourceWithEnvironment, IComputeResource
     {
-        /*
-         * Much of the logic here is similar to ExecutableResourceBuilderExtensions.PublishAsDockerFile().
-         *
-         * That is, in Publish mode, we swap the original resource with a hosted agent resource.
-         */
-        ArgumentNullException.ThrowIfNull(builder);
+        if (builder.ApplicationBuilder.ExecutionContext.IsPublishMode)
+        {
+            /*
+             * Much of the logic here is similar to ExecutableResourceBuilderExtensions.PublishAsDockerFile().
+             *
+             * That is, in Publish mode, we swap the original resource with a hosted agent resource.
+             */
+            ArgumentNullException.ThrowIfNull(builder);
 
-        var resource = builder.Resource;
+            var resource = builder.Resource;
 
+            AzureCognitiveServicesProjectResource? projResource;
+            if (project is not null)
+            {
+                projResource = project.Resource;
+            }
+            else
+            {
+                projResource = builder.ApplicationBuilder.Resources.OfType<AzureCognitiveServicesProjectResource>().FirstOrDefault();
+                if (projResource is null)
+                {
+                    project = builder.ApplicationBuilder
+                        .AddFoundry($"{resource.Name}-proj-foundry")
+                        .AddProject($"{resource.Name}-proj");
+                    projResource = project.Resource;
+                }
+                else
+                {
+                    project = builder.ApplicationBuilder.CreateResourceBuilder(projResource);
+                }
+            }
+
+            ResourceBuilderExtensions.WithComputeEnvironment(builder, project!);
+
+            // Hosted Agent resource name
+            var agentName = $"{resource.Name}-ha";
+            if (builder.ApplicationBuilder.TryCreateResourceBuilder<AzureHostedAgentResource>(agentName, out var rb))
+            {
+                // We already have a hosted agent for this resource
+                if (configure is not null)
+                {
+                    rb.Resource.Configure = configure;
+                }
+                return builder;
+            }
+            // Get the corresponding ContainerResource for ExecutableResources. Usually this is swapped in at publish time for ExecutableResources.
+            IResource target;
+            if (resource is ContainerResource containerResource)
+            {
+                target = containerResource;
+            }
+            else if (builder.ApplicationBuilder.TryCreateResourceBuilder<ContainerResource>(resource.Name, out var crb))
+            {
+                target = crb.Resource;
+            }
+            else
+            {
+                // Ensure we have a container resource to deploy.
+                // ExecutableResource needs PublishAsDockerFile()
+                // to convert them into container resources at this stage.
+                if (resource is ExecutableResource)
+                {
+                    builder.ApplicationBuilder.CreateResourceBuilder((ExecutableResource)(object)resource).PublishAsDockerFile();
+
+                    if (builder.ApplicationBuilder.TryCreateResourceBuilder(resource.Name, out crb))
+                    {
+                        target = crb.Resource;
+                    }
+                    else
+                    {
+                        throw new InvalidOperationException($"Unable to create hosted agent for resource '{resource.Name}' because it could not be converted to a container resource.");
+                    }
+                }
+                else if (resource is not ProjectResource)
+                {
+                    throw new InvalidOperationException($"Unable to create hosted agent for resource '{resource.Name}' because it is not a container, executable, or project resource.");
+                }
+                else
+                {
+                    target = resource;
+                }
+            }
+
+            // Create a separate agent resource to host the deployment
+            var agent = new AzureHostedAgentResource(agentName, target, configure);
+
+            // Ensure image gets pushed properly
+            target.Annotations.Add(new DeploymentTargetAnnotation(agent)
+            {
+                ComputeEnvironment = projResource,
+                ContainerRegistry = projResource.ContainerRegistry
+            });
+
+            builder.ApplicationBuilder.AddResource(agent)
+                .WithReferenceRelationship(target)
+                .WithReference(project);
+        }
+        return builder;
+    }
+
+    /// <summary>
+    /// Configures a resource to be hosted as an Azure Hosted Agent.
+    /// </summary>
+    /// <typeparam name="T">The type of resource being configured.</typeparam>
+    /// <param name="builder">The resource builder.</param>
+    /// <returns>The resource builder for chaining.</returns>
+    [AspireExport]
+    public static IResourceBuilder<T> AsHostedAgent<T>(this IResourceBuilder<T> builder) where T : IResourceWithEndpoints, IResourceWithEnvironment, IComputeResource
+    {
         if (builder.ApplicationBuilder.ExecutionContext.IsRunMode)
         {
             // Preserve any target port already configured on an existing "http" endpoint;
             // fall back to the default MAF agent port (8088) when none is set.
-            var existingHttpEndpoint = resource.Annotations.OfType<EndpointAnnotation>().FirstOrDefault(e => e.Name == "http");
+            var existingHttpEndpoint = builder.Resource.Annotations.OfType<EndpointAnnotation>().FirstOrDefault(e => e.Name == "http");
             var targetPort = existingHttpEndpoint?.TargetPort ?? 8088;
 
             builder
@@ -83,28 +183,28 @@ public static class HostedAgentResourceBuilderExtensions
                     {
                         Path = "/responses"
                     }.ToString();
-                    ctx.Urls.Add(new()
-                    {
-                        DisplayText = "Liveness probe",
-                        Url = new UriBuilder(http.Url)
-                        {
-                            Path = "/liveness"
-                        }.ToString(),
-                        Endpoint = http.Endpoint,
-                        DisplayLocation = UrlDisplayLocation.DetailsOnly
-                    });
-                    ctx.Urls.Add(new()
-                    {
-                        DisplayText = "Readiness probe",
-                        Url = new UriBuilder(http.Url)
-                        {
-                            Path = "/readiness"
-                        }.ToString(),
-                        Endpoint = http.Endpoint,
-                        DisplayLocation = UrlDisplayLocation.DetailsOnly
-                    });
+                    // ctx.Urls.Add(new()
+                    // {
+                    //     DisplayText = "Liveness probe",
+                    //     Url = new UriBuilder(http.Url)
+                    //     {
+                    //         Path = "/liveness"
+                    //     }.ToString(),
+                    //     Endpoint = http.Endpoint,
+                    //     DisplayLocation = UrlDisplayLocation.DetailsOnly
+                    // });
+                    // ctx.Urls.Add(new()
+                    // {
+                    //     DisplayText = "Readiness probe",
+                    //     Url = new UriBuilder(http.Url)
+                    //     {
+                    //         Path = "/readiness"
+                    //     }.ToString(),
+                    //     Endpoint = http.Endpoint,
+                    //     DisplayLocation = UrlDisplayLocation.DetailsOnly
+                    // });
                 })
-                .WithHttpHealthCheck("/liveness")
+                // .WithHttpHealthCheck("/liveness")
                 .WithHttpCommand(
                     path: "/responses",
                     displayName: "Send Message",
@@ -198,93 +298,7 @@ public static class HostedAgentResourceBuilderExtensions
                     // The Microsoft Foundry agentserver SDK expects the exporter to be at OTEL_EXPORTER_ENDPOINT instead.
                     ctx.EnvironmentVariables["OTEL_EXPORTER_ENDPOINT"] = endpointVar.Value;
                 });
-            return builder;
         }
-        AzureCognitiveServicesProjectResource? projResource;
-        if (project is not null)
-        {
-            projResource = project.Resource;
-        }
-        else
-        {
-            projResource = builder.ApplicationBuilder.Resources.OfType<AzureCognitiveServicesProjectResource>().FirstOrDefault();
-            if (projResource is null)
-            {
-                project = builder.ApplicationBuilder
-                    .AddFoundry($"{resource.Name}-proj-foundry")
-                    .AddProject($"{resource.Name}-proj");
-                projResource = project.Resource;
-            }
-            else
-            {
-                project = builder.ApplicationBuilder.CreateResourceBuilder(projResource);
-            }
-        }
-
-        ResourceBuilderExtensions.WithComputeEnvironment(builder, project!);
-
-        // Hosted Agent resource name
-        var agentName = $"{resource.Name}-ha";
-        if (builder.ApplicationBuilder.TryCreateResourceBuilder<AzureHostedAgentResource>(agentName, out var rb))
-        {
-            // We already have a hosted agent for this resource
-            if (configure is not null)
-            {
-                rb.Resource.Configure = configure;
-            }
-            return builder;
-        }
-        // Get the corresponding ContainerResource for ExecutableResources. Usually this is swapped in at publish time for ExecutableResources.
-        IResource target;
-        if (resource is ContainerResource containerResource)
-        {
-            target = containerResource;
-        }
-        else if (builder.ApplicationBuilder.TryCreateResourceBuilder<ContainerResource>(resource.Name, out var crb))
-        {
-            target = crb.Resource;
-        }
-        else
-        {
-            // Ensure we have a container resource to deploy.
-            // ExecutableResource needs PublishAsDockerFile()
-            // to convert them into container resources at this stage.
-            if (resource is ExecutableResource)
-            {
-                builder.ApplicationBuilder.CreateResourceBuilder((ExecutableResource)(object)resource).PublishAsDockerFile();
-
-                if (builder.ApplicationBuilder.TryCreateResourceBuilder(resource.Name, out crb))
-                {
-                    target = crb.Resource;
-                }
-                else
-                {
-                    throw new InvalidOperationException($"Unable to create hosted agent for resource '{resource.Name}' because it could not be converted to a container resource.");
-                }
-            }
-            else if (resource is not ProjectResource)
-            {
-                throw new InvalidOperationException($"Unable to create hosted agent for resource '{resource.Name}' because it is not a container, executable, or project resource.");
-            }
-            else
-            {
-                target = resource;
-            }
-        }
-
-        // Create a separate agent resource to host the deployment
-        var agent = new AzureHostedAgentResource(agentName, target, configure);
-
-        // Ensure image gets pushed properly
-        target.Annotations.Add(new DeploymentTargetAnnotation(agent)
-        {
-            ComputeEnvironment = projResource,
-            ContainerRegistry = projResource.ContainerRegistry
-        });
-
-        builder.ApplicationBuilder.AddResource(agent)
-            .WithReferenceRelationship(target)
-            .WithReference(project);
 
         return builder;
     }

--- a/src/Aspire.Hosting.Foundry/HostedAgent/HostedAgentBuilderExtension.cs
+++ b/src/Aspire.Hosting.Foundry/HostedAgent/HostedAgentBuilderExtension.cs
@@ -205,28 +205,7 @@ public static class HostedAgentResourceBuilderExtensions
                     {
                         Path = "/responses"
                     }.ToString();
-                    // ctx.Urls.Add(new()
-                    // {
-                    //     DisplayText = "Liveness probe",
-                    //     Url = new UriBuilder(http.Url)
-                    //     {
-                    //         Path = "/liveness"
-                    //     }.ToString(),
-                    //     Endpoint = http.Endpoint,
-                    //     DisplayLocation = UrlDisplayLocation.DetailsOnly
-                    // });
-                    // ctx.Urls.Add(new()
-                    // {
-                    //     DisplayText = "Readiness probe",
-                    //     Url = new UriBuilder(http.Url)
-                    //     {
-                    //         Path = "/readiness"
-                    //     }.ToString(),
-                    //     Endpoint = http.Endpoint,
-                    //     DisplayLocation = UrlDisplayLocation.DetailsOnly
-                    // });
                 })
-                // .WithHttpHealthCheck("/liveness")
                 .WithHttpCommand(
                     path: "/responses",
                     displayName: "Send Message",

--- a/src/Aspire.Hosting.Foundry/HostedAgent/HostedAgentBuilderExtension.cs
+++ b/src/Aspire.Hosting.Foundry/HostedAgent/HostedAgentBuilderExtension.cs
@@ -240,6 +240,11 @@ public static class HostedAgentResourceBuilderExtensions
         var resource = builder.Resource;
         var projectResource = project.Resource;
 
+        if (!projectResource.HasAnnotationOfType<RequiresHostedAgentRegistryAnnotation>())
+        {
+            projectResource.Annotations.Add(new RequiresHostedAgentRegistryAnnotation());
+        }
+
         ResourceBuilderExtensions.WithComputeEnvironment(builder, project);
 
         // Hosted Agent resource name

--- a/src/Aspire.Hosting.Foundry/HostedAgent/HostedAgentBuilderExtension.cs
+++ b/src/Aspire.Hosting.Foundry/HostedAgent/HostedAgentBuilderExtension.cs
@@ -46,20 +46,16 @@ public static class HostedAgentResourceBuilderExtensions
     /// <summary>
     /// Configures the resource to run and publish as a hosted agent in Microsoft Foundry, targeting the specified Foundry project.
     /// </summary>
-    /// <typeparam name="T">The type of resource being configured.</typeparam>
-    /// <param name="builder">The resource builder for the compute resource.</param>
-    /// <param name="project">The Microsoft Foundry project resource used for both run and publish mode configuration.</param>
-    /// <param name="options">Optional hosted agent deployment options applied in publish mode.</param>
-    /// <returns>A reference to the <see cref="IResourceBuilder{T}"/> for chaining.</returns>
-    /// <example>
-    /// <code lang="csharp">
-    /// var agent = builder.AddProject&lt;Projects.AgentService&gt;("agent")
-    ///     .AsHostedAgent(project, new HostedAgentOptions { Cpu = 1, Memory = 2 });
-    /// </code>
-    /// </example>
-    /// <ats-returns>The resource builder.</ats-returns>
+    /// <remarks>
+    /// This overload exists for the polyglot SDK surfaces (TypeScript, Go, Java, Python) generated via
+    /// <see cref="AspireExportAttribute"/>. .NET callers should use the
+    /// <see cref="AsHostedAgent{T}(IResourceBuilder{T}, IResourceBuilder{AzureCognitiveServicesProjectResource}?, Action{HostedAgentConfiguration}?)"/>
+    /// overload, which exposes the full <see cref="HostedAgentConfiguration"/> surface.
+    /// The method name differs from <c>AsHostedAgent</c> to avoid C# overload ambiguity with the <c>Action</c>-based
+    /// overload; the polyglot-facing name is set back to <c>asHostedAgent</c> via <see cref="AspireExportAttribute.MethodName"/>.
+    /// </remarks>
     [AspireExport("asHostedAgentExecutable", MethodName = "asHostedAgent")]
-    public static IResourceBuilder<T> AsHostedAgent<T>(
+    internal static IResourceBuilder<T> AsHostedAgentForExport<T>(
         this IResourceBuilder<T> builder,
         IResourceBuilder<AzureCognitiveServicesProjectResource> project,
         HostedAgentOptions? options = null)
@@ -85,7 +81,7 @@ public static class HostedAgentResourceBuilderExtensions
     public static IResourceBuilder<T> AsHostedAgent<T>(
         this IResourceBuilder<T> builder,
         IResourceBuilder<AzureCognitiveServicesProjectResource>? project,
-        Action<HostedAgentConfiguration>? configure)
+        Action<HostedAgentConfiguration>? configure = null)
         where T : IResourceWithEndpoints, IResourceWithEnvironment, IComputeResource
     {
         ArgumentNullException.ThrowIfNull(builder);

--- a/src/Aspire.Hosting.Foundry/HostedAgent/HostedAgentBuilderExtension.cs
+++ b/src/Aspire.Hosting.Foundry/HostedAgent/HostedAgentBuilderExtension.cs
@@ -15,6 +15,8 @@ namespace Aspire.Hosting;
 /// </summary>
 public static class HostedAgentResourceBuilderExtensions
 {
+    private static readonly JsonSerializerOptions s_indentedJsonOptions = new() { WriteIndented = true };
+
     /// <summary>
     /// Configures the resource to run locally as a Microsoft Foundry hosted agent.
     /// </summary>
@@ -195,7 +197,7 @@ public static class HostedAgentResourceBuilderExtensions
                             return CommandResults.Failure("Agent returned an empty response.");
                         }
 
-                        var formattedResponse = JsonSerializer.Serialize(responseJson, new JsonSerializerOptions { WriteIndented = true });
+                        var formattedResponse = JsonSerializer.Serialize(responseJson, s_indentedJsonOptions);
                         return CommandResults.Success(
                             message: "Agent response received.",
                             result: formattedResponse,

--- a/src/Aspire.Hosting.Foundry/HostedAgent/HostedAgentBuilderExtension.cs
+++ b/src/Aspire.Hosting.Foundry/HostedAgent/HostedAgentBuilderExtension.cs
@@ -17,16 +17,16 @@ public static class HostedAgentResourceBuilderExtensions
 {
 
     /// <summary>
-    /// Configures the resource to run as a hosted agent in Microsoft Foundry.
-    ///
-    /// If a project resource is not provided, the method will attempt to find an existing
-    /// Microsoft Foundry project resource in the application model. If none exists,
-    /// a new project resource (and its parent account resource) will be created automatically.
+    /// Configures the resource to be deployed as a hosted agent in Microsoft Foundry.
     /// </summary>
+    /// <typeparam name="T">The type of resource being configured.</typeparam>
+    /// <param name="builder">The resource builder for the compute resource.</param>
+    /// <param name="configure">A callback to configure the hosted agent deployment.</param>
+    /// <returns>A reference to the <see cref="IResourceBuilder{T}"/> for chaining.</returns>
     /// <remarks>
-    /// In run mode, this configures the resource with hosted agent endpoints, health checks,
-    /// and OpenTelemetry settings. In publish mode, the resource is deployed as a hosted agent
-    /// in Microsoft Foundry.
+    /// This method applies in publish mode. Use <see cref="AsHostedAgent{T}(IResourceBuilder{T})"/>
+    /// to configure the resource with local run-mode hosted agent endpoints, dashboard commands,
+    /// and OpenTelemetry settings.
     /// </remarks>
     [AspireExportIgnore(Reason = "Subset of the full WithComputeEnvironment overload which is exported.")]
     public static IResourceBuilder<T> WithComputeEnvironment<T>(
@@ -37,16 +37,24 @@ public static class HostedAgentResourceBuilderExtensions
     }
 
     /// <summary>
-    /// Configures the resource to run as a hosted agent in Microsoft Foundry.
-    ///
-    /// If a project resource is not provided, the method will attempt to find an existing
-    /// Microsoft Foundry project resource in the application model. If none exists,
-    /// a new project resource (and its parent account resource) will be created automatically.
+    /// Configures the resource to be deployed as a hosted agent in Microsoft Foundry.
     /// </summary>
+    /// <typeparam name="T">The type of resource being configured.</typeparam>
+    /// <param name="builder">The resource builder for the compute resource.</param>
+    /// <param name="project">The Microsoft Foundry project resource to deploy the hosted agent to.</param>
+    /// <param name="configure">A callback to configure the hosted agent deployment.</param>
+    /// <returns>A reference to the <see cref="IResourceBuilder{T}"/> for chaining.</returns>
     /// <remarks>
-    /// In run mode, this configures the resource with hosted agent endpoints, health checks,
-    /// and OpenTelemetry settings. In publish mode, the resource is deployed as a hosted agent
-    /// in Microsoft Foundry.
+    /// <para>
+    /// If <paramref name="project"/> is not provided, this method attempts to find an existing Microsoft Foundry
+    /// project resource in the application model. If none exists, a new project resource and parent account resource
+    /// are created automatically.
+    /// </para>
+    /// <para>
+    /// This method applies in publish mode. Use <see cref="AsHostedAgent{T}(IResourceBuilder{T})"/>
+    /// to configure the resource with local run-mode hosted agent endpoints, dashboard commands,
+    /// and OpenTelemetry settings.
+    /// </para>
     /// </remarks>
     [AspireExport("withComputeEnvironmentExecutable", MethodName = "withComputeEnvironment")]
     public static IResourceBuilder<T> WithComputeEnvironment<T>(
@@ -154,13 +162,27 @@ public static class HostedAgentResourceBuilderExtensions
     }
 
     /// <summary>
-    /// Configures a resource to be hosted as an Azure Hosted Agent.
+    /// Configures the resource to run locally as a Microsoft Foundry hosted agent.
     /// </summary>
+    /// <ats-summary>Configures the resource to run locally as a Microsoft Foundry hosted agent.</ats-summary>
     /// <typeparam name="T">The type of resource being configured.</typeparam>
-    /// <param name="builder">The resource builder.</param>
-    /// <returns>The resource builder for chaining.</returns>
+    /// <param name="builder">The resource builder for the compute resource.</param>
+    /// <returns>A reference to the <see cref="IResourceBuilder{T}"/> for chaining.</returns>
+    /// <remarks>
+    /// This method applies in run mode. It configures the resource with the hosted agent responses endpoint,
+    /// a dashboard command for sending messages to the agent, and OpenTelemetry environment variables expected
+    /// by the Microsoft Foundry agent server SDK.
+    /// </remarks>
+    /// <example>
+    /// <code lang="csharp">
+    /// var agent = builder.AddProject&lt;Projects.AgentService&gt;("agent")
+    ///     .AsHostedAgent();
+    /// </code>
+    /// </example>
+    /// <ats-returns>The resource builder.</ats-returns>
     [AspireExport]
-    public static IResourceBuilder<T> AsHostedAgent<T>(this IResourceBuilder<T> builder) where T : IResourceWithEndpoints, IResourceWithEnvironment, IComputeResource
+    public static IResourceBuilder<T> AsHostedAgent<T>(this IResourceBuilder<T> builder)
+        where T : IResourceWithEndpoints, IResourceWithEnvironment, IComputeResource
     {
         if (builder.ApplicationBuilder.ExecutionContext.IsRunMode)
         {

--- a/src/Aspire.Hosting.Foundry/HostedAgent/HostedAgentOptions.cs
+++ b/src/Aspire.Hosting.Foundry/HostedAgent/HostedAgentOptions.cs
@@ -3,42 +3,45 @@
 
 namespace Aspire.Hosting.Foundry;
 
+// HostedAgentOptions exposes the subset of HostedAgentConfiguration that is meaningful to non-.NET
+// app hosts. .NET callers should use the AsHostedAgent overload that takes Action<HostedAgentConfiguration>
+// to access the full configuration surface (tools, content filters, container protocol versions, etc.).
+
 /// <summary>
-/// Polyglot-friendly options for configuring a hosted agent.
+/// Options that control how a compute resource is deployed as a Microsoft Foundry hosted agent.
+/// All properties are optional; unset properties fall back to the Foundry hosted agent defaults.
 /// </summary>
-/// <remarks>
-/// This DTO exposes the subset of <see cref="HostedAgentConfiguration"/> that is meaningful
-/// to non-.NET app hosts. .NET callers can use the
-/// <see cref="HostedAgentResourceBuilderExtensions.AsHostedAgent{T}(ApplicationModel.IResourceBuilder{T}, ApplicationModel.IResourceBuilder{AzureCognitiveServicesProjectResource}, System.Action{HostedAgentConfiguration})"/>
-/// overload to access the full configuration surface (tools, content filters, container protocol versions, etc.).
-/// </remarks>
 [AspireExport(ExposeProperties = true)]
 internal sealed class HostedAgentOptions
 {
     /// <summary>
-    /// The description of the hosted agent. When not set, the default from <see cref="HostedAgentConfiguration"/> is used.
+    /// Human-readable description of the hosted agent surfaced in the Microsoft Foundry portal.
+    /// When not set, the hosted agent default description is used.
     /// </summary>
     public string? Description { get; set; }
 
     /// <summary>
-    /// CPU allocation for each hosted agent instance, in vCPU cores. Must be between 0.5 and 3.5 in increments of 0.25.
-    /// When not set, the default from <see cref="HostedAgentConfiguration"/> is used.
+    /// CPU allocation for each hosted agent instance, in vCPU cores. Must be between 0.5 and 3.5
+    /// in increments of 0.25. When not set, the hosted agent default CPU allocation is used.
     /// </summary>
     public decimal? Cpu { get; set; }
 
     /// <summary>
-    /// Memory allocation for each hosted agent instance, in GiB. Must be between 1 and 7 in increments of 0.5
-    /// and equal to twice the CPU value. When not set, the default from <see cref="HostedAgentConfiguration"/> is used.
+    /// Memory allocation for each hosted agent instance, in GiB. Must be between 1 and 7 in
+    /// increments of 0.5 and equal to twice the CPU value. When not set, the hosted agent
+    /// default memory allocation is used.
     /// </summary>
     public decimal? Memory { get; set; }
 
     /// <summary>
-    /// Additional metadata to merge into the hosted agent definition. Existing entries with the same key are overwritten.
+    /// Additional metadata key/value pairs to attach to the hosted agent definition.
+    /// Entries with the same key as an existing metadata entry overwrite it.
     /// </summary>
     public IDictionary<string, string> Metadata { get; init; } = new Dictionary<string, string>();
 
     /// <summary>
-    /// Environment variables to set on the hosted agent container. Existing entries with the same key are overwritten.
+    /// Environment variables to set on the hosted agent container at runtime.
+    /// Entries with the same key as an existing environment variable overwrite it.
     /// </summary>
     public IDictionary<string, string> EnvironmentVariables { get; init; } = new Dictionary<string, string>();
 

--- a/src/Aspire.Hosting.Foundry/HostedAgent/HostedAgentOptions.cs
+++ b/src/Aspire.Hosting.Foundry/HostedAgent/HostedAgentOptions.cs
@@ -1,0 +1,74 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Aspire.Hosting.Foundry;
+
+/// <summary>
+/// Polyglot-friendly options for configuring a hosted agent.
+/// </summary>
+/// <remarks>
+/// This DTO exposes the subset of <see cref="HostedAgentConfiguration"/> that is meaningful
+/// to non-.NET app hosts. .NET callers can use the
+/// <see cref="HostedAgentResourceBuilderExtensions.AsHostedAgent{T}(ApplicationModel.IResourceBuilder{T}, ApplicationModel.IResourceBuilder{AzureCognitiveServicesProjectResource}, System.Action{HostedAgentConfiguration})"/>
+/// overload to access the full configuration surface (tools, content filters, container protocol versions, etc.).
+/// </remarks>
+[AspireExport(ExposeProperties = true)]
+public sealed class HostedAgentOptions
+{
+    /// <summary>
+    /// The description of the hosted agent. When not set, the default from <see cref="HostedAgentConfiguration"/> is used.
+    /// </summary>
+    public string? Description { get; set; }
+
+    /// <summary>
+    /// CPU allocation for each hosted agent instance, in vCPU cores. Must be between 0.5 and 3.5 in increments of 0.25.
+    /// When not set, the default from <see cref="HostedAgentConfiguration"/> is used.
+    /// </summary>
+    public decimal? Cpu { get; set; }
+
+    /// <summary>
+    /// Memory allocation for each hosted agent instance, in GiB. Must be between 1 and 7 in increments of 0.5
+    /// and equal to twice the CPU value. When not set, the default from <see cref="HostedAgentConfiguration"/> is used.
+    /// </summary>
+    public decimal? Memory { get; set; }
+
+    /// <summary>
+    /// Additional metadata to merge into the hosted agent definition. Existing entries with the same key are overwritten.
+    /// </summary>
+    public IDictionary<string, string> Metadata { get; init; } = new Dictionary<string, string>();
+
+    /// <summary>
+    /// Environment variables to set on the hosted agent container. Existing entries with the same key are overwritten.
+    /// </summary>
+    public IDictionary<string, string> EnvironmentVariables { get; init; } = new Dictionary<string, string>();
+
+    internal void ApplyTo(HostedAgentConfiguration configuration)
+    {
+        if (Description is not null)
+        {
+            configuration.Description = Description;
+        }
+
+        // Cpu and Memory have a coupled invariant on HostedAgentConfiguration (Memory = Cpu * 2 with validation).
+        // Apply Cpu first so a subsequent Memory assignment can still override the derived value.
+        if (Cpu is { } cpu)
+        {
+            configuration.Cpu = cpu;
+        }
+
+        if (Memory is { } memory)
+        {
+            configuration.Memory = memory;
+        }
+
+        foreach (var kvp in Metadata)
+        {
+            configuration.Metadata[kvp.Key] = kvp.Value;
+        }
+
+        foreach (var kvp in EnvironmentVariables)
+        {
+            configuration.EnvironmentVariables[kvp.Key] = kvp.Value;
+        }
+    }
+}

--- a/src/Aspire.Hosting.Foundry/HostedAgent/HostedAgentOptions.cs
+++ b/src/Aspire.Hosting.Foundry/HostedAgent/HostedAgentOptions.cs
@@ -13,7 +13,7 @@ namespace Aspire.Hosting.Foundry;
 /// overload to access the full configuration surface (tools, content filters, container protocol versions, etc.).
 /// </remarks>
 [AspireExport(ExposeProperties = true)]
-public sealed class HostedAgentOptions
+internal sealed class HostedAgentOptions
 {
     /// <summary>
     /// The description of the hosted agent. When not set, the default from <see cref="HostedAgentConfiguration"/> is used.

--- a/src/Aspire.Hosting.Foundry/HostedAgent/HostedAgentOptions.cs
+++ b/src/Aspire.Hosting.Foundry/HostedAgent/HostedAgentOptions.cs
@@ -11,7 +11,7 @@ namespace Aspire.Hosting.Foundry;
 /// Options that control how a compute resource is deployed as a Microsoft Foundry hosted agent.
 /// All properties are optional; unset properties fall back to the Foundry hosted agent defaults.
 /// </summary>
-[AspireExport(ExposeProperties = true)]
+[AspireDto]
 internal sealed class HostedAgentOptions
 {
     /// <summary>

--- a/src/Aspire.Hosting.Foundry/Project/ProjectBuilderExtension.cs
+++ b/src/Aspire.Hosting.Foundry/Project/ProjectBuilderExtension.cs
@@ -50,7 +50,11 @@ public static class AzureCognitiveServicesProjectExtensions
         builder.ApplicationBuilder.Services.Configure<AzureProvisioningOptions>(o => o.SupportsTargetedRoleAssignments = true);
 
         var project = builder.ApplicationBuilder.AddResource(new AzureCognitiveServicesProjectResource(name, ConfigureInfrastructure, builder.Resource));
-        project.Resource.DefaultContainerRegistry = CreateDefaultRegistry(builder.ApplicationBuilder, $"{name}-acr");
+        if (builder.ApplicationBuilder.ExecutionContext.IsPublishMode)
+        {
+            project.Resource.DefaultContainerRegistry = CreateDefaultRegistry(builder.ApplicationBuilder, $"{name}-acr");
+        }
+
         return project;
     }
 

--- a/src/Aspire.Hosting.Foundry/Project/ProjectBuilderExtension.cs
+++ b/src/Aspire.Hosting.Foundry/Project/ProjectBuilderExtension.cs
@@ -324,6 +324,12 @@ public static class AzureCognitiveServicesProjectExtensions
         return builder.ApplicationBuilder.CreateResourceBuilder(builder.Resource.Parent).AddDeployment(name, modelName, modelVersion, format);
     }
 
+    private static bool RequiresContainerRegistryProvisioning(AzureCognitiveServicesProjectResource project)
+    {
+        return project.HasAnnotationOfType<RequiresHostedAgentRegistryAnnotation>()
+            || project.HasAnnotationOfType<ContainerRegistryReferenceAnnotation>();
+    }
+
     internal static void ConfigureInfrastructure(AzureResourceInfrastructure infra)
     {
         var prefix = infra.AspireResource.Name;
@@ -411,44 +417,47 @@ public static class AzureCognitiveServicesProjectExtensions
         /*
          * Container registry for hosted agents
          *
-         * TODO: only provision if we need to create a Hosted Agent
+         * Only provision registry dependencies when the project will publish a hosted agent
+         * or when the user has explicitly supplied a registry override.
          */
+        if (RequiresContainerRegistryProvisioning(aspireResource))
+        {
+            AzureProvisioningResource? registry = null;
+            if (aspireResource.TryGetLastAnnotation<ContainerRegistryReferenceAnnotation>(out var registryReferenceAnnotation) && registryReferenceAnnotation.Registry is AzureProvisioningResource r)
+            {
+                registry = r;
+            }
+            else if (aspireResource.DefaultContainerRegistry is not null)
+            {
+                registry = aspireResource.DefaultContainerRegistry;
+            }
+            else
+            {
+                throw new InvalidOperationException($"No container registry configured for Azure Cognitive Services project resource '{aspireResource.Name}'. A container registry is required to publish hosted agents.");
+            }
 
-        AzureProvisioningResource? registry = null;
-        if (aspireResource.TryGetLastAnnotation<ContainerRegistryReferenceAnnotation>(out var registryReferenceAnnotation) && registryReferenceAnnotation.Registry is AzureProvisioningResource r)
-        {
-            registry = r;
-        }
-        else if (aspireResource.DefaultContainerRegistry is not null)
-        {
-            registry = aspireResource.DefaultContainerRegistry;
-        }
-        else
-        {
-            throw new InvalidOperationException($"No container registry configured for Azure Cognitive Services project resource '{aspireResource.Name}'. A container registry is required to publish and run hosted agents.");
-        }
-        var containerRegistry = (ContainerRegistryService)registry.AddAsExistingResource(infra);
-        // Why do we need this?
-        infra.Add(containerRegistry);
+            var containerRegistry = (ContainerRegistryService)registry.AddAsExistingResource(infra);
+            infra.Add(containerRegistry);
 
-        // Project needs this to pull hosted agent images and run them
-        var pullRa = containerRegistry.CreateRoleAssignment(ContainerRegistryBuiltInRole.AcrPull, RoleManagementPrincipalType.ServicePrincipal, projectPrincipalId);
-        // There's a bug in the CDK, see https://github.com/Azure/azure-sdk-for-net/issues/47265
-        pullRa.Name = BicepFunction.CreateGuid(containerRegistry.Id, project.Id, pullRa.RoleDefinitionId);
-        infra.Add(pullRa);
-        infra.Add(containerRegistry);
-        infra.Add(new ProvisioningOutput("AZURE_CONTAINER_REGISTRY_ENDPOINT", typeof(string))
-        {
-            Value = containerRegistry.LoginServer
-        });
-        infra.Add(new ProvisioningOutput("AZURE_CONTAINER_REGISTRY_NAME", typeof(string))
-        {
-            Value = containerRegistry.Name
-        });
-        infra.Add(new ProvisioningOutput("AZURE_CONTAINER_REGISTRY_MANAGED_IDENTITY_ID", typeof(string))
-        {
-            Value = projectPrincipalId
-        });
+            // Project needs this to pull hosted agent images during hosted-agent deployment.
+            var pullRa = containerRegistry.CreateRoleAssignment(ContainerRegistryBuiltInRole.AcrPull, RoleManagementPrincipalType.ServicePrincipal, projectPrincipalId);
+            // There's a bug in the CDK, see https://github.com/Azure/azure-sdk-for-net/issues/47265
+            pullRa.Name = BicepFunction.CreateGuid(containerRegistry.Id, project.Id, pullRa.RoleDefinitionId);
+            infra.Add(pullRa);
+            infra.Add(containerRegistry);
+            infra.Add(new ProvisioningOutput("AZURE_CONTAINER_REGISTRY_ENDPOINT", typeof(string))
+            {
+                Value = containerRegistry.LoginServer
+            });
+            infra.Add(new ProvisioningOutput("AZURE_CONTAINER_REGISTRY_NAME", typeof(string))
+            {
+                Value = containerRegistry.Name
+            });
+            infra.Add(new ProvisioningOutput("AZURE_CONTAINER_REGISTRY_MANAGED_IDENTITY_ID", typeof(string))
+            {
+                Value = projectPrincipalId
+            });
+        }
 
         // Implicit dependencies for capability hosts
         List<ProvisionableResource> capHostDeps = [];

--- a/src/Aspire.Hosting.Foundry/Project/ProjectResource.cs
+++ b/src/Aspire.Hosting.Foundry/Project/ProjectResource.cs
@@ -49,8 +49,9 @@ public class AzureCognitiveServicesProjectResource :
                 Description = $"Prepares Microsoft Foundry project {name} for deployment.",
                 Action = context =>
                 {
-                    if (this.HasAnnotationOfType<ContainerRegistryReferenceAnnotation>() &&
-                        DefaultContainerRegistry is not null)
+                    if (DefaultContainerRegistry is not null &&
+                        (this.HasAnnotationOfType<ContainerRegistryReferenceAnnotation>() ||
+                         !this.HasAnnotationOfType<RequiresHostedAgentRegistryAnnotation>()))
                     {
                         context.Model.Resources.Remove(DefaultContainerRegistry);
                         DefaultContainerRegistry = null;
@@ -246,6 +247,13 @@ public class AzureCognitiveServicesProjectResource :
             return false;
         }
     }
+}
+
+/// <summary>
+/// Marks a Foundry project as needing container registry provisioning for hosted agent deployment.
+/// </summary>
+internal sealed class RequiresHostedAgentRegistryAnnotation : IResourceAnnotation
+{
 }
 
 /// <summary>

--- a/src/Aspire.Hosting.Foundry/PromptAgent/PromptAgentBuilderExtensions.cs
+++ b/src/Aspire.Hosting.Foundry/PromptAgent/PromptAgentBuilderExtensions.cs
@@ -70,6 +70,7 @@ public static class PromptAgentBuilderExtensions
         var agent = new AzurePromptAgentResource(name, model.Resource.DeploymentName, project.Resource, instructions);
 
         var agentBuilder = project.ApplicationBuilder.AddResource(agent)
+            .WithIconName("Agents")
             .WithReferenceRelationship(project)
             .WithReference(project);
 

--- a/src/Aspire.Hosting.Foundry/PromptAgent/PromptAgentBuilderExtensions.cs
+++ b/src/Aspire.Hosting.Foundry/PromptAgent/PromptAgentBuilderExtensions.cs
@@ -104,7 +104,7 @@ public static class PromptAgentBuilderExtensions
             },
             commandOptions: new()
             {
-                IconName = "Agents",
+                IconName = "ChatSparkle",
                 IconVariant = IconVariant.Regular,
                 IsHighlighted = true,
                 Arguments =

--- a/src/Aspire.Hosting.Foundry/README.md
+++ b/src/Aspire.Hosting.Foundry/README.md
@@ -163,7 +163,7 @@ var foundry = builder.AddFoundry("foundry");
 var project = foundry.AddProject("my-project");
 
 builder.AddPythonApp("agent", "./app", "main:app")
-       .WithComputeEnvironment(project);
+       .AsHostedAgent(project);
 ```
 
 In run mode, the agent runs locally with health check endpoints and OpenTelemetry instrumentation. In publish mode, the agent is deployed as a hosted agent in Microsoft Foundry.

--- a/src/Aspire.Hosting.Foundry/api/Aspire.Hosting.Foundry.ats.txt
+++ b/src/Aspire.Hosting.Foundry/api/Aspire.Hosting.Foundry.ats.txt
@@ -293,6 +293,8 @@ Aspire.Hosting.Foundry/HostedAgentConfiguration.metadata(context: Aspire.Hosting
 Aspire.Hosting.Foundry/HostedAgentConfiguration.setCpu(context: Aspire.Hosting.Foundry/Aspire.Hosting.Foundry.HostedAgentConfiguration, value: number) -> Aspire.Hosting.Foundry/Aspire.Hosting.Foundry.HostedAgentConfiguration
 Aspire.Hosting.Foundry/HostedAgentConfiguration.setDescription(context: Aspire.Hosting.Foundry/Aspire.Hosting.Foundry.HostedAgentConfiguration, value: string) -> Aspire.Hosting.Foundry/Aspire.Hosting.Foundry.HostedAgentConfiguration
 Aspire.Hosting.Foundry/HostedAgentConfiguration.setMemory(context: Aspire.Hosting.Foundry/Aspire.Hosting.Foundry.HostedAgentConfiguration, value: number) -> Aspire.Hosting.Foundry/Aspire.Hosting.Foundry.HostedAgentConfiguration
+Aspire.Hosting.Foundry/asHostedAgent() -> Aspire.Hosting/Aspire.Hosting.ApplicationModel.IResourceWithEndpoints
+Aspire.Hosting.Foundry/withComputeEnvironmentExecutable(project?: Aspire.Hosting.Foundry/Aspire.Hosting.Foundry.AzureCognitiveServicesProjectResource, configure?: callback) -> Aspire.Hosting/Aspire.Hosting.ApplicationModel.IResourceWithEndpoints
 Aspire.Hosting.Foundry/runAsFoundryLocal() -> Aspire.Hosting.Foundry/Aspire.Hosting.Foundry.FoundryResource
 Aspire.Hosting.Foundry/withAppInsights(appInsights: Aspire.Hosting.Azure.ApplicationInsights/Aspire.Hosting.Azure.AzureApplicationInsightsResource) -> Aspire.Hosting.Foundry/Aspire.Hosting.Foundry.AzureCognitiveServicesProjectResource
 Aspire.Hosting.Foundry/withBingReference(bingReference: Aspire.Hosting.Foundry/Aspire.Hosting.Foundry.BingGroundingConnectionResource|string|Aspire.Hosting/Aspire.Hosting.ApplicationModel.ParameterResource) -> Aspire.Hosting.Foundry/Aspire.Hosting.Foundry.BingGroundingToolResource

--- a/src/Aspire.Hosting.Foundry/api/Aspire.Hosting.Foundry.ats.txt
+++ b/src/Aspire.Hosting.Foundry/api/Aspire.Hosting.Foundry.ats.txt
@@ -27,6 +27,12 @@ Aspire.Hosting.Foundry/Aspire.Hosting.Foundry.FoundryModel # Describes a model t
   Format: string # The format or provider of the model (e.g., OpenAI, Microsoft, xAi, Deepseek).
   Name: string # The name of the model.
   Version: string # The version of the model.
+Aspire.Hosting.Foundry/Aspire.Hosting.Foundry.HostedAgentOptions # Options that control how a compute resource is deployed as a Microsoft Foundry hosted agent. All properties are optional; unset properties fall back to the Foundry hosted agent defaults.
+  Cpu?: number # CPU allocation for each hosted agent instance, in vCPU cores. Must be between 0.5 and 3.5 in increments of 0.25. When not set, the hosted agent default CPU allocation is used.
+  Description: string # Human-readable description of the hosted agent surfaced in the Microsoft Foundry portal. When not set, the hosted agent default description is used.
+  EnvironmentVariables?: Aspire.Hosting/Dict<string,string> # Environment variables to set on the hosted agent container at runtime. Entries with the same key as an existing environment variable overwrite it.
+  Memory?: number # Memory allocation for each hosted agent instance, in GiB. Must be between 1 and 7 in increments of 0.5 and equal to twice the CPU value. When not set, the hosted agent default memory allocation is used.
+  Metadata?: Aspire.Hosting/Dict<string,string> # Additional metadata key/value pairs to attach to the hosted agent definition. Entries with the same key as an existing metadata entry overwrite it.
 
 # Enum Types
 enum:Aspire.Hosting.FoundryRole = CognitiveServicesOpenAIContributor | CognitiveServicesOpenAIUser | CognitiveServicesUser
@@ -262,6 +268,7 @@ Aspire.Hosting.Foundry/addSearchConnection(search: Aspire.Hosting.Azure.Search/A
 Aspire.Hosting.Foundry/addSharePointTool(name: string, projectConnectionIds: string[]) -> Aspire.Hosting.Foundry/Aspire.Hosting.Foundry.SharePointToolResource
 Aspire.Hosting.Foundry/addStorageConnection(storage: Aspire.Hosting.Azure.Storage/Aspire.Hosting.Azure.AzureStorageResource) -> Aspire.Hosting.Foundry/Aspire.Hosting.Foundry.AzureCognitiveServicesProjectConnectionResource
 Aspire.Hosting.Foundry/addWebSearchTool(name: string) -> Aspire.Hosting.Foundry/Aspire.Hosting.Foundry.WebSearchToolResource
+Aspire.Hosting.Foundry/asHostedAgentExecutable(project: Aspire.Hosting.Foundry/Aspire.Hosting.Foundry.AzureCognitiveServicesProjectResource, options?: Aspire.Hosting.Foundry/Aspire.Hosting.Foundry.HostedAgentOptions) -> Aspire.Hosting/Aspire.Hosting.ApplicationModel.IResourceWithEndpoints
 Aspire.Hosting.Foundry/AzurePromptAgentResource.connectionStringExpression(context: Aspire.Hosting.Foundry/Aspire.Hosting.Foundry.AzurePromptAgentResource) -> Aspire.Hosting/Aspire.Hosting.ApplicationModel.ReferenceExpression
 Aspire.Hosting.Foundry/AzurePromptAgentResource.description(context: Aspire.Hosting.Foundry/Aspire.Hosting.Foundry.AzurePromptAgentResource) -> string
 Aspire.Hosting.Foundry/AzurePromptAgentResource.instructions(context: Aspire.Hosting.Foundry/Aspire.Hosting.Foundry.AzurePromptAgentResource) -> string
@@ -293,13 +300,10 @@ Aspire.Hosting.Foundry/HostedAgentConfiguration.metadata(context: Aspire.Hosting
 Aspire.Hosting.Foundry/HostedAgentConfiguration.setCpu(context: Aspire.Hosting.Foundry/Aspire.Hosting.Foundry.HostedAgentConfiguration, value: number) -> Aspire.Hosting.Foundry/Aspire.Hosting.Foundry.HostedAgentConfiguration
 Aspire.Hosting.Foundry/HostedAgentConfiguration.setDescription(context: Aspire.Hosting.Foundry/Aspire.Hosting.Foundry.HostedAgentConfiguration, value: string) -> Aspire.Hosting.Foundry/Aspire.Hosting.Foundry.HostedAgentConfiguration
 Aspire.Hosting.Foundry/HostedAgentConfiguration.setMemory(context: Aspire.Hosting.Foundry/Aspire.Hosting.Foundry.HostedAgentConfiguration, value: number) -> Aspire.Hosting.Foundry/Aspire.Hosting.Foundry.HostedAgentConfiguration
-Aspire.Hosting.Foundry/asHostedAgent() -> Aspire.Hosting/Aspire.Hosting.ApplicationModel.IResourceWithEndpoints
-Aspire.Hosting.Foundry/withComputeEnvironmentExecutable(project?: Aspire.Hosting.Foundry/Aspire.Hosting.Foundry.AzureCognitiveServicesProjectResource, configure?: callback) -> Aspire.Hosting/Aspire.Hosting.ApplicationModel.IResourceWithEndpoints
 Aspire.Hosting.Foundry/runAsFoundryLocal() -> Aspire.Hosting.Foundry/Aspire.Hosting.Foundry.FoundryResource
 Aspire.Hosting.Foundry/withAppInsights(appInsights: Aspire.Hosting.Azure.ApplicationInsights/Aspire.Hosting.Azure.AzureApplicationInsightsResource) -> Aspire.Hosting.Foundry/Aspire.Hosting.Foundry.AzureCognitiveServicesProjectResource
 Aspire.Hosting.Foundry/withBingReference(bingReference: Aspire.Hosting.Foundry/Aspire.Hosting.Foundry.BingGroundingConnectionResource|string|Aspire.Hosting/Aspire.Hosting.ApplicationModel.ParameterResource) -> Aspire.Hosting.Foundry/Aspire.Hosting.Foundry.BingGroundingToolResource
 Aspire.Hosting.Foundry/withCapabilityHost(resource: Aspire.Hosting.Azure.CosmosDB/Aspire.Hosting.AzureCosmosDBResource|Aspire.Hosting.Azure.Storage/Aspire.Hosting.Azure.AzureStorageResource|Aspire.Hosting.Azure.Search/Aspire.Hosting.Azure.AzureSearchResource|Aspire.Hosting.Foundry/Aspire.Hosting.Foundry.FoundryResource) -> Aspire.Hosting.Foundry/Aspire.Hosting.Foundry.AzureCognitiveServicesProjectResource
-Aspire.Hosting.Foundry/withComputeEnvironmentExecutable(project?: Aspire.Hosting.Foundry/Aspire.Hosting.Foundry.AzureCognitiveServicesProjectResource, configure?: callback) -> Aspire.Hosting/Aspire.Hosting.ApplicationModel.IResourceWithEndpoints
 Aspire.Hosting.Foundry/withFoundryDeploymentProperties(configure: callback) -> Aspire.Hosting.Foundry/Aspire.Hosting.Foundry.FoundryDeploymentResource
 Aspire.Hosting.Foundry/withFoundryRoleAssignments(target: Aspire.Hosting.Foundry/Aspire.Hosting.Foundry.FoundryResource, roles: enum:Aspire.Hosting.FoundryRole[]) -> Aspire.Hosting/Aspire.Hosting.ApplicationModel.IResource
 Aspire.Hosting.Foundry/withKeyVault(keyVault: Aspire.Hosting.Azure.KeyVault/Aspire.Hosting.Azure.AzureKeyVaultResource) -> Aspire.Hosting.Foundry/Aspire.Hosting.Foundry.AzureCognitiveServicesProjectResource

--- a/src/Aspire.Hosting.Foundry/api/Aspire.Hosting.Foundry.cs
+++ b/src/Aspire.Hosting.Foundry/api/Aspire.Hosting.Foundry.cs
@@ -96,6 +96,10 @@ namespace Aspire.Hosting
 
     public static partial class HostedAgentResourceBuilderExtensions
     {
+        [AspireExport]
+        public static ApplicationModel.IResourceBuilder<T> AsHostedAgent<T>(this ApplicationModel.IResourceBuilder<T> builder)
+            where T : ApplicationModel.IResourceWithEndpoints, ApplicationModel.IResourceWithEnvironment, ApplicationModel.IComputeResource { throw null; }
+
         [AspireExport("withComputeEnvironmentExecutable", MethodName = "withComputeEnvironment")]
         public static ApplicationModel.IResourceBuilder<T> WithComputeEnvironment<T>(this ApplicationModel.IResourceBuilder<T> builder, ApplicationModel.IResourceBuilder<Foundry.AzureCognitiveServicesProjectResource>? project = null, System.Action<Foundry.HostedAgentConfiguration>? configure = null)
             where T : ApplicationModel.IResourceWithEndpoints, ApplicationModel.IResourceWithEnvironment, ApplicationModel.IComputeResource { throw null; }

--- a/src/Aspire.Hosting.Foundry/api/Aspire.Hosting.Foundry.cs
+++ b/src/Aspire.Hosting.Foundry/api/Aspire.Hosting.Foundry.cs
@@ -10,31 +10,31 @@ namespace Aspire.Hosting
 {
     public static partial class AzureCognitiveServicesProjectConnectionsBuilderExtensions
     {
-        [AspireExport("addBingGroundingConnectionFromParameter", Description = "Adds a Grounding with Bing Search connection to a Microsoft Foundry project using a parameter.")]
+        [AspireExport("addBingGroundingConnectionFromParameter")]
         public static ApplicationModel.IResourceBuilder<Foundry.BingGroundingConnectionResource> AddBingGroundingConnection(this ApplicationModel.IResourceBuilder<Foundry.AzureCognitiveServicesProjectResource> builder, string name, ApplicationModel.IResourceBuilder<ApplicationModel.ParameterResource> bingResourceId) { throw null; }
 
-        [AspireExport(Description = "Adds a Grounding with Bing Search connection to a Microsoft Foundry project.")]
+        [AspireExport]
         public static ApplicationModel.IResourceBuilder<Foundry.BingGroundingConnectionResource> AddBingGroundingConnection(this ApplicationModel.IResourceBuilder<Foundry.AzureCognitiveServicesProjectResource> builder, string name, string bingResourceId) { throw null; }
 
-        [AspireExport("addContainerRegistryConnection", Description = "Adds an Azure Container Registry connection to a Microsoft Foundry project.")]
+        [AspireExport("addContainerRegistryConnection")]
         public static ApplicationModel.IResourceBuilder<Foundry.AzureCognitiveServicesProjectConnectionResource> AddConnection(this ApplicationModel.IResourceBuilder<Foundry.AzureCognitiveServicesProjectResource> builder, ApplicationModel.IResourceBuilder<Azure.AzureContainerRegistryResource> registry) { throw null; }
 
-        [AspireExport("addKeyVaultConnection", Description = "Adds an Azure Key Vault connection to a Microsoft Foundry project.")]
+        [AspireExport("addKeyVaultConnection")]
         public static ApplicationModel.IResourceBuilder<Foundry.AzureCognitiveServicesProjectConnectionResource> AddConnection(this ApplicationModel.IResourceBuilder<Foundry.AzureCognitiveServicesProjectResource> builder, ApplicationModel.IResourceBuilder<Azure.AzureKeyVaultResource> keyVault) { throw null; }
 
-        [AspireExport("addSearchConnection", Description = "Adds an Azure AI Search connection to a Microsoft Foundry project.")]
+        [AspireExport("addSearchConnection")]
         public static ApplicationModel.IResourceBuilder<Foundry.AzureCognitiveServicesProjectConnectionResource> AddConnection(this ApplicationModel.IResourceBuilder<Foundry.AzureCognitiveServicesProjectResource> builder, ApplicationModel.IResourceBuilder<Azure.AzureSearchResource> search) { throw null; }
 
-        [AspireExport("addStorageConnection", Description = "Adds an Azure Storage connection to a Microsoft Foundry project.")]
+        [AspireExport("addStorageConnection")]
         public static ApplicationModel.IResourceBuilder<Foundry.AzureCognitiveServicesProjectConnectionResource> AddConnection(this ApplicationModel.IResourceBuilder<Foundry.AzureCognitiveServicesProjectResource> builder, ApplicationModel.IResourceBuilder<Azure.AzureStorageResource> storage) { throw null; }
 
-        [AspireExport("addCosmosConnection", Description = "Adds an Azure Cosmos DB connection to a Microsoft Foundry project.")]
+        [AspireExport("addCosmosConnection")]
         public static ApplicationModel.IResourceBuilder<Foundry.AzureCognitiveServicesProjectConnectionResource> AddConnection(this ApplicationModel.IResourceBuilder<Foundry.AzureCognitiveServicesProjectResource> builder, ApplicationModel.IResourceBuilder<AzureCosmosDBResource> db) { throw null; }
 
         [AspireExportIgnore(Reason = "Raw AzureContainerRegistryResource parameters are not ATS-compatible. Use the resource-builder overload instead.")]
         public static ApplicationModel.IResourceBuilder<Foundry.AzureCognitiveServicesProjectConnectionResource> AddConnection(this ApplicationModel.IResourceBuilder<Foundry.AzureCognitiveServicesProjectResource> builder, Azure.AzureContainerRegistryResource registry) { throw null; }
 
-        [AspireExport("addSearchConnectionFromResource", Description = "Adds an Azure AI Search connection to a Microsoft Foundry project.")]
+        [AspireExportIgnore(Reason = "Raw AzureSearchResource parameters are not ATS-compatible. Use the resource-builder overload instead.")]
         public static ApplicationModel.IResourceBuilder<Foundry.AzureCognitiveServicesProjectConnectionResource> AddConnection(this ApplicationModel.IResourceBuilder<Foundry.AzureCognitiveServicesProjectResource> builder, Azure.AzureSearchResource search) { throw null; }
 
         [AspireExportIgnore(Reason = "Raw AzureStorageResource parameters are not ATS-compatible. Use the resource-builder overload instead.")]
@@ -58,13 +58,13 @@ namespace Aspire.Hosting
         [AspireExportIgnore(Reason = "Polyglot app hosts use the internal addModelDeployment dispatcher export.")]
         public static ApplicationModel.IResourceBuilder<Foundry.FoundryDeploymentResource> AddModelDeployment(this ApplicationModel.IResourceBuilder<Foundry.AzureCognitiveServicesProjectResource> builder, string name, string modelName, string modelVersion, string format) { throw null; }
 
-        [AspireExport(Description = "Adds a Microsoft Foundry project resource to a Microsoft Foundry resource.")]
+        [AspireExport]
         public static ApplicationModel.IResourceBuilder<Foundry.AzureCognitiveServicesProjectResource> AddProject(this ApplicationModel.IResourceBuilder<Foundry.FoundryResource> builder, string name) { throw null; }
 
-        [AspireExport(Description = "Associates an Azure Application Insights resource with a Microsoft Foundry project.")]
+        [AspireExport]
         public static ApplicationModel.IResourceBuilder<Foundry.AzureCognitiveServicesProjectResource> WithAppInsights(this ApplicationModel.IResourceBuilder<Foundry.AzureCognitiveServicesProjectResource> builder, ApplicationModel.IResourceBuilder<Azure.AzureApplicationInsightsResource> appInsights) { throw null; }
 
-        [AspireExport(Description = "Associates an Azure Key Vault resource with a Microsoft Foundry project.")]
+        [AspireExport]
         public static ApplicationModel.IResourceBuilder<Foundry.AzureCognitiveServicesProjectResource> WithKeyVault(this ApplicationModel.IResourceBuilder<Foundry.AzureCognitiveServicesProjectResource> builder, ApplicationModel.IResourceBuilder<Azure.AzureKeyVaultResource> keyVault) { throw null; }
 
         [AspireExportIgnore(Reason = "The standard WithReference export already covers this polyglot scenario.")]
@@ -80,13 +80,13 @@ namespace Aspire.Hosting
         [AspireExportIgnore(Reason = "Polyglot app hosts use the internal addDeployment dispatcher export.")]
         public static ApplicationModel.IResourceBuilder<Foundry.FoundryDeploymentResource> AddDeployment(this ApplicationModel.IResourceBuilder<Foundry.FoundryResource> builder, string name, string modelName, string modelVersion, string format) { throw null; }
 
-        [AspireExport(Description = "Adds a Microsoft Foundry resource to the distributed application model.")]
+        [AspireExport]
         public static ApplicationModel.IResourceBuilder<Foundry.FoundryResource> AddFoundry(this IDistributedApplicationBuilder builder, string name) { throw null; }
 
-        [AspireExport(Description = "Configures the Microsoft Foundry resource to run by using Foundry Local.")]
+        [AspireExport]
         public static ApplicationModel.IResourceBuilder<Foundry.FoundryResource> RunAsFoundryLocal(this ApplicationModel.IResourceBuilder<Foundry.FoundryResource> builder) { throw null; }
 
-        [AspireExport("withFoundryDeploymentProperties", MethodName = "withProperties", Description = "Configures properties of a Microsoft Foundry deployment resource.", RunSyncOnBackgroundThread = true)]
+        [AspireExport("withFoundryDeploymentProperties", MethodName = "withProperties", RunSyncOnBackgroundThread = true)]
         public static ApplicationModel.IResourceBuilder<Foundry.FoundryDeploymentResource> WithProperties(this ApplicationModel.IResourceBuilder<Foundry.FoundryDeploymentResource> builder, System.Action<Foundry.FoundryDeploymentResource> configure) { throw null; }
 
         [AspireExportIgnore(Reason = "CognitiveServicesBuiltInRole is an Azure.Provisioning type not compatible with ATS. Use the FoundryRole-based overload instead.")]
@@ -96,64 +96,64 @@ namespace Aspire.Hosting
 
     public static partial class HostedAgentResourceBuilderExtensions
     {
-        [AspireExport]
+        [AspireExportIgnore(Reason = "Action callback shape is awkward for polyglot hosts; the HostedAgentOptions overload is exported instead.")]
+        public static ApplicationModel.IResourceBuilder<T> AsHostedAgent<T>(this ApplicationModel.IResourceBuilder<T> builder, ApplicationModel.IResourceBuilder<Foundry.AzureCognitiveServicesProjectResource>? project, System.Action<Foundry.HostedAgentConfiguration>? configure = null)
+            where T : ApplicationModel.IResourceWithEndpoints, ApplicationModel.IResourceWithEnvironment, ApplicationModel.IComputeResource { throw null; }
+
+        [AspireExportIgnore(Reason = "Subset of the full AsHostedAgent overload.")]
+        public static ApplicationModel.IResourceBuilder<T> AsHostedAgent<T>(this ApplicationModel.IResourceBuilder<T> builder, System.Action<Foundry.HostedAgentConfiguration> configure)
+            where T : ApplicationModel.IResourceWithEndpoints, ApplicationModel.IResourceWithEnvironment, ApplicationModel.IComputeResource { throw null; }
+
+        [AspireExportIgnore(Reason = "Subset of the full AsHostedAgent(project) overload which is exported.")]
         public static ApplicationModel.IResourceBuilder<T> AsHostedAgent<T>(this ApplicationModel.IResourceBuilder<T> builder)
-            where T : ApplicationModel.IResourceWithEndpoints, ApplicationModel.IResourceWithEnvironment, ApplicationModel.IComputeResource { throw null; }
-
-        [AspireExport("withComputeEnvironmentExecutable", MethodName = "withComputeEnvironment")]
-        public static ApplicationModel.IResourceBuilder<T> WithComputeEnvironment<T>(this ApplicationModel.IResourceBuilder<T> builder, ApplicationModel.IResourceBuilder<Foundry.AzureCognitiveServicesProjectResource>? project = null, System.Action<Foundry.HostedAgentConfiguration>? configure = null)
-            where T : ApplicationModel.IResourceWithEndpoints, ApplicationModel.IResourceWithEnvironment, ApplicationModel.IComputeResource { throw null; }
-
-        [AspireExportIgnore(Reason = "Subset of the full WithComputeEnvironment overload which is exported.")]
-        public static ApplicationModel.IResourceBuilder<T> WithComputeEnvironment<T>(this ApplicationModel.IResourceBuilder<T> builder, System.Action<Foundry.HostedAgentConfiguration> configure)
             where T : ApplicationModel.IResourceWithEndpoints, ApplicationModel.IResourceWithEnvironment, ApplicationModel.IComputeResource { throw null; }
     }
 
     public static partial class PromptAgentBuilderExtensions
     {
-        [AspireExport(Description = "Adds an Azure AI Search tool to a Microsoft Foundry project.")]
+        [AspireExport]
         public static ApplicationModel.IResourceBuilder<Foundry.AzureAISearchToolResource> AddAISearchTool(this ApplicationModel.IResourceBuilder<Foundry.AzureCognitiveServicesProjectResource> project, string name, string? indexName = null) { throw null; }
 
         [AspireExportIgnore(Reason = "BinaryData parameter is not ATS-compatible. Use the string overload instead.")]
         public static ApplicationModel.IResourceBuilder<Foundry.AzureFunctionToolResource> AddAzureFunctionTool(this ApplicationModel.IResourceBuilder<Foundry.AzureCognitiveServicesProjectResource> project, string name, string functionName, string description, System.BinaryData parameters, string inputQueueEndpoint, string inputQueueName, string outputQueueEndpoint, string outputQueueName) { throw null; }
 
-        [AspireExport(Description = "Adds an Azure Function tool to a Microsoft Foundry project.")]
+        [AspireExport]
         public static ApplicationModel.IResourceBuilder<Foundry.AzureFunctionToolResource> AddAzureFunctionTool(this ApplicationModel.IResourceBuilder<Foundry.AzureCognitiveServicesProjectResource> project, string name, string functionName, string description, string parametersJson, string inputQueueEndpoint, string inputQueueName, string outputQueueEndpoint, string outputQueueName) { throw null; }
 
-        [AspireExport(Description = "Adds a Bing Grounding tool to a Microsoft Foundry project.")]
+        [AspireExport]
         public static ApplicationModel.IResourceBuilder<Foundry.BingGroundingToolResource> AddBingGroundingTool(this ApplicationModel.IResourceBuilder<Foundry.AzureCognitiveServicesProjectResource> project, string name) { throw null; }
 
-        [AspireExport(Description = "Adds a Code Interpreter tool to a Microsoft Foundry project.")]
+        [AspireExport]
         public static ApplicationModel.IResourceBuilder<Foundry.CodeInterpreterToolResource> AddCodeInterpreterTool(this ApplicationModel.IResourceBuilder<Foundry.AzureCognitiveServicesProjectResource> project, string name) { throw null; }
 
-        [AspireExport(Description = "Adds a Computer Use tool to a Microsoft Foundry project.")]
+        [AspireExport]
         public static ApplicationModel.IResourceBuilder<Foundry.ComputerToolResource> AddComputerUseTool(this ApplicationModel.IResourceBuilder<Foundry.AzureCognitiveServicesProjectResource> project, string name, int displayWidth = 1024, int displayHeight = 768, string environment = "browser") { throw null; }
 
-        [AspireExport(Description = "Adds a Microsoft Fabric data agent tool to a Microsoft Foundry project.")]
+        [AspireExport]
         public static ApplicationModel.IResourceBuilder<Foundry.FabricToolResource> AddFabricTool(this ApplicationModel.IResourceBuilder<Foundry.AzureCognitiveServicesProjectResource> project, string name, params string[] projectConnectionIds) { throw null; }
 
-        [AspireExport(Description = "Adds a File Search tool to a Microsoft Foundry project.")]
+        [AspireExport]
         public static ApplicationModel.IResourceBuilder<Foundry.FileSearchToolResource> AddFileSearchTool(this ApplicationModel.IResourceBuilder<Foundry.AzureCognitiveServicesProjectResource> project, string name, params string[] vectorStoreIds) { throw null; }
 
         [AspireExportIgnore(Reason = "BinaryData parameter is not ATS-compatible. Use the string overload instead.")]
         public static ApplicationModel.IResourceBuilder<Foundry.FunctionToolResource> AddFunctionTool(this ApplicationModel.IResourceBuilder<Foundry.AzureCognitiveServicesProjectResource> project, string name, string functionName, System.BinaryData parameters, string? description = null, bool? strictModeEnabled = null) { throw null; }
 
-        [AspireExport(Description = "Adds an Image Generation tool to a Microsoft Foundry project.")]
+        [AspireExport]
         public static ApplicationModel.IResourceBuilder<Foundry.ImageGenerationToolResource> AddImageGenerationTool(this ApplicationModel.IResourceBuilder<Foundry.AzureCognitiveServicesProjectResource> project, string name) { throw null; }
 
-        [AspireExport(Description = "Adds a prompt agent to a Microsoft Foundry project.")]
+        [AspireExport]
         public static ApplicationModel.IResourceBuilder<Foundry.AzurePromptAgentResource> AddPromptAgent(this ApplicationModel.IResourceBuilder<Foundry.AzureCognitiveServicesProjectResource> project, string name, ApplicationModel.IResourceBuilder<Foundry.FoundryDeploymentResource> model, string? instructions = null) { throw null; }
 
-        [AspireExport(Description = "Adds a SharePoint grounding tool to a Microsoft Foundry project.")]
+        [AspireExport]
         public static ApplicationModel.IResourceBuilder<Foundry.SharePointToolResource> AddSharePointTool(this ApplicationModel.IResourceBuilder<Foundry.AzureCognitiveServicesProjectResource> project, string name, params string[] projectConnectionIds) { throw null; }
 
-        [AspireExport(Description = "Adds a Web Search tool to a Microsoft Foundry project.")]
+        [AspireExport]
         public static ApplicationModel.IResourceBuilder<Foundry.WebSearchToolResource> AddWebSearchTool(this ApplicationModel.IResourceBuilder<Foundry.AzureCognitiveServicesProjectResource> project, string name) { throw null; }
 
         [AspireExportIgnore(Reason = "IFoundryTool is not ATS-compatible.")]
         public static ApplicationModel.IResourceBuilder<Foundry.AzurePromptAgentResource> WithCustomTool(this ApplicationModel.IResourceBuilder<Foundry.AzurePromptAgentResource> builder, Foundry.IFoundryTool tool) { throw null; }
 
-        [AspireExport(Description = "Links an Azure AI Search tool to a backing search resource.")]
+        [AspireExport]
         public static ApplicationModel.IResourceBuilder<Foundry.AzureAISearchToolResource> WithReference(this ApplicationModel.IResourceBuilder<Foundry.AzureAISearchToolResource> tool, ApplicationModel.IResourceBuilder<Azure.AzureSearchResource> search) { throw null; }
 
         [AspireExportIgnore(Reason = "Covered by the internal AspireUnion overload.")]
@@ -165,7 +165,7 @@ namespace Aspire.Hosting
         [AspireExportIgnore(Reason = "Covered by the internal AspireUnion overload.")]
         public static ApplicationModel.IResourceBuilder<Foundry.BingGroundingToolResource> WithReference(this ApplicationModel.IResourceBuilder<Foundry.BingGroundingToolResource> tool, string bingResourceId) { throw null; }
 
-        [AspireExport(Description = "Adds a tool to a prompt agent.")]
+        [AspireExport]
         public static ApplicationModel.IResourceBuilder<Foundry.AzurePromptAgentResource> WithTool(this ApplicationModel.IResourceBuilder<Foundry.AzurePromptAgentResource> agent, ApplicationModel.IResourceBuilder<Foundry.FoundryToolResource> tool) { throw null; }
     }
 }
@@ -439,14 +439,6 @@ namespace Aspire.Hosting.Foundry
 
         public required string Version { get { throw null; } init { } }
 
-        public static partial class AI21Labs
-        {
-            [AspireValue("FoundryModels")]
-            public static readonly FoundryModel AI21Jamba15Large;
-            [AspireValue("FoundryModels")]
-            public static readonly FoundryModel AI21Jamba15Mini;
-        }
-
         public static partial class Anthropic
         {
             [AspireValue("FoundryModels")]
@@ -484,11 +476,7 @@ namespace Aspire.Hosting.Foundry
             [AspireValue("FoundryModels")]
             public static readonly FoundryModel CohereCommandA;
             [AspireValue("FoundryModels")]
-            public static readonly FoundryModel CohereCommandR;
-            [AspireValue("FoundryModels")]
             public static readonly FoundryModel CohereCommandR082024;
-            [AspireValue("FoundryModels")]
-            public static readonly FoundryModel CohereCommandRPlus;
             [AspireValue("FoundryModels")]
             public static readonly FoundryModel CohereCommandRPlus082024;
             [AspireValue("FoundryModels")]
@@ -521,11 +509,13 @@ namespace Aspire.Hosting.Foundry
             [AspireValue("FoundryModels")]
             public static readonly FoundryModel DeepSeekV30324;
             [AspireValue("FoundryModels")]
-            public static readonly FoundryModel DeepSeekV31;
-            [AspireValue("FoundryModels")]
             public static readonly FoundryModel DeepSeekV32;
             [AspireValue("FoundryModels")]
             public static readonly FoundryModel DeepSeekV32Speciale;
+            [AspireValue("FoundryModels")]
+            public static readonly FoundryModel DeepSeekV4Flash;
+            [AspireValue("FoundryModels")]
+            public static readonly FoundryModel DeepSeekV4Pro;
         }
 
         public static partial class Local
@@ -541,7 +531,13 @@ namespace Aspire.Hosting.Foundry
             [AspireValue("FoundryModels")]
             public static readonly FoundryModel Mistral7bV02;
             [AspireValue("FoundryModels")]
+            public static readonly FoundryModel MistralNemo12bInstruct;
+            [AspireValue("FoundryModels")]
             public static readonly FoundryModel NemotronSpeechStreamingEn06b;
+            [AspireValue("FoundryModels")]
+            public static readonly FoundryModel NemotronSpeechStreamingEs06b;
+            [AspireValue("FoundryModels")]
+            public static readonly FoundryModel Olmo37bInstruct;
             [AspireValue("FoundryModels")]
             public static readonly FoundryModel Phi35Mini;
             [AspireValue("FoundryModels")]
@@ -586,6 +582,8 @@ namespace Aspire.Hosting.Foundry
             [AspireValue("FoundryModels")]
             public static readonly FoundryModel Qwen352b;
             [AspireValue("FoundryModels")]
+            public static readonly FoundryModel Qwen352bText;
+            [AspireValue("FoundryModels")]
             public static readonly FoundryModel Qwen354b;
             [AspireValue("FoundryModels")]
             public static readonly FoundryModel Qwen359b;
@@ -601,6 +599,8 @@ namespace Aspire.Hosting.Foundry
             public static readonly FoundryModel Qwen3Vl4bInstruct;
             [AspireValue("FoundryModels")]
             public static readonly FoundryModel Qwen3Vl8bInstruct;
+            [AspireValue("FoundryModels")]
+            public static readonly FoundryModel Smollm33b;
         }
 
         public static partial class Meta
@@ -610,21 +610,13 @@ namespace Aspire.Hosting.Foundry
             [AspireValue("FoundryModels")]
             public static readonly FoundryModel Llama3290BVisionInstruct;
             [AspireValue("FoundryModels")]
-            public static readonly FoundryModel Llama3370BInstruct;
-            [AspireValue("FoundryModels")]
             public static readonly FoundryModel Llama4Maverick17B128EInstructFP8;
             [AspireValue("FoundryModels")]
             public static readonly FoundryModel Llama4Scout17B16EInstruct;
             [AspireValue("FoundryModels")]
             public static readonly FoundryModel MetaLlama31405BInstruct;
             [AspireValue("FoundryModels")]
-            public static readonly FoundryModel MetaLlama3170BInstruct;
-            [AspireValue("FoundryModels")]
             public static readonly FoundryModel MetaLlama318BInstruct;
-            [AspireValue("FoundryModels")]
-            public static readonly FoundryModel MetaLlama370BInstruct;
-            [AspireValue("FoundryModels")]
-            public static readonly FoundryModel MetaLlama38BInstruct;
         }
 
         public static partial class Microsoft
@@ -650,7 +642,11 @@ namespace Aspire.Hosting.Foundry
             [AspireValue("FoundryModels")]
             public static readonly FoundryModel AzureLanguageConversationalPiiRedaction;
             [AspireValue("FoundryModels")]
+            public static readonly FoundryModel AzureLanguageDocumentPiiRedaction;
+            [AspireValue("FoundryModels")]
             public static readonly FoundryModel AzureLanguageLanguageDetection;
+            [AspireValue("FoundryModels")]
+            public static readonly FoundryModel AzureLanguageTextAnalyticsForHealth;
             [AspireValue("FoundryModels")]
             public static readonly FoundryModel AzureLanguageTextPiiRedaction;
             [AspireValue("FoundryModels")]
@@ -697,6 +693,8 @@ namespace Aspire.Hosting.Foundry
             [AspireValue("FoundryModels")]
             public static readonly FoundryModel Phi3Small8kInstruct;
             [AspireValue("FoundryModels")]
+            public static readonly FoundryModel Phi3Vision128kInstruct;
+            [AspireValue("FoundryModels")]
             public static readonly FoundryModel Phi4;
             [AspireValue("FoundryModels")]
             public static readonly FoundryModel Phi4MiniInstruct;
@@ -722,17 +720,9 @@ namespace Aspire.Hosting.Foundry
             [AspireValue("FoundryModels")]
             public static readonly FoundryModel MistralDocumentAi2512;
             [AspireValue("FoundryModels")]
-            public static readonly FoundryModel MistralLarge2407;
-            [AspireValue("FoundryModels")]
-            public static readonly FoundryModel MistralLarge2411;
-            [AspireValue("FoundryModels")]
             public static readonly FoundryModel MistralLarge3;
             [AspireValue("FoundryModels")]
             public static readonly FoundryModel MistralMedium2505;
-            [AspireValue("FoundryModels")]
-            public static readonly FoundryModel MistralNemo;
-            [AspireValue("FoundryModels")]
-            public static readonly FoundryModel MistralSmall;
             [AspireValue("FoundryModels")]
             public static readonly FoundryModel MistralSmall2503;
         }
@@ -834,6 +824,8 @@ namespace Aspire.Hosting.Foundry
             [AspireValue("FoundryModels")]
             public static readonly FoundryModel GptAudioMini;
             [AspireValue("FoundryModels")]
+            public static readonly FoundryModel GptChatLatest;
+            [AspireValue("FoundryModels")]
             public static readonly FoundryModel GptImage1;
             [AspireValue("FoundryModels")]
             public static readonly FoundryModel GptImage15;
@@ -844,13 +836,17 @@ namespace Aspire.Hosting.Foundry
             [AspireValue("FoundryModels")]
             public static readonly FoundryModel GptOss120b;
             [AspireValue("FoundryModels")]
-            public static readonly FoundryModel GptOss20b;
-            [AspireValue("FoundryModels")]
             public static readonly FoundryModel GptRealtime;
             [AspireValue("FoundryModels")]
             public static readonly FoundryModel GptRealtime15;
             [AspireValue("FoundryModels")]
+            public static readonly FoundryModel GptRealtime2;
+            [AspireValue("FoundryModels")]
             public static readonly FoundryModel GptRealtimeMini;
+            [AspireValue("FoundryModels")]
+            public static readonly FoundryModel GptRealtimeTranslate;
+            [AspireValue("FoundryModels")]
+            public static readonly FoundryModel GptRealtimeWhisper;
             [AspireValue("FoundryModels")]
             public static readonly FoundryModel O1;
             [AspireValue("FoundryModels")]
@@ -896,10 +892,6 @@ namespace Aspire.Hosting.Foundry
         public static partial class XAI
         {
             [AspireValue("FoundryModels")]
-            public static readonly FoundryModel Grok3;
-            [AspireValue("FoundryModels")]
-            public static readonly FoundryModel Grok3Mini;
-            [AspireValue("FoundryModels")]
             public static readonly FoundryModel Grok4;
             [AspireValue("FoundryModels")]
             public static readonly FoundryModel Grok41FastNonReasoning;
@@ -909,6 +901,8 @@ namespace Aspire.Hosting.Foundry
             public static readonly FoundryModel Grok420NonReasoning;
             [AspireValue("FoundryModels")]
             public static readonly FoundryModel Grok420Reasoning;
+            [AspireValue("FoundryModels")]
+            public static readonly FoundryModel Grok43;
             [AspireValue("FoundryModels")]
             public static readonly FoundryModel Grok4FastNonReasoning;
             [AspireValue("FoundryModels")]
@@ -1011,8 +1005,6 @@ namespace Aspire.Hosting.Foundry
 
         [AspireExportIgnore(Reason = "Azure SDK-specific type not usable from polyglot hosts.")]
         public System.Collections.Generic.IList<global::Azure.AI.Projects.Agents.ProjectsAgentTool> Tools { get { throw null; } init { } }
-
-        public global::Azure.AI.Projects.Agents.ProjectsAgentVersionCreationOptions ToProjectsAgentVersionCreationOptions() { throw null; }
     }
 
     public partial interface IFoundryTool

--- a/tests/Aspire.Deployment.EndToEnd.Tests/FoundryHostedAgentDeploymentTests.cs
+++ b/tests/Aspire.Deployment.EndToEnd.Tests/FoundryHostedAgentDeploymentTests.cs
@@ -210,8 +210,7 @@ public sealed class FoundryHostedAgentDeploymentTests(ITestOutputHelper output)
 
                 builder.AddProject<Projects.DotNetHostedAgent>("dotnet-hosted-agent")
                     .WithReference(chat).WaitFor(chat)
-                    .AsHostedAgent()
-                    .WithComputeEnvironment(foundryProject);
+                    .AsHostedAgent(foundryProject);
 
                 builder.Build().Run();
                 """);

--- a/tests/Aspire.Deployment.EndToEnd.Tests/FoundryHostedAgentDeploymentTests.cs
+++ b/tests/Aspire.Deployment.EndToEnd.Tests/FoundryHostedAgentDeploymentTests.cs
@@ -210,6 +210,7 @@ public sealed class FoundryHostedAgentDeploymentTests(ITestOutputHelper output)
 
                 builder.AddProject<Projects.DotNetHostedAgent>("dotnet-hosted-agent")
                     .WithReference(chat).WaitFor(chat)
+                    .AsHostedAgent()
                     .WithComputeEnvironment(foundryProject);
 
                 builder.Build().Run();

--- a/tests/Aspire.Hosting.Azure.Tests/AzureDeployerTests.cs
+++ b/tests/Aspire.Hosting.Azure.Tests/AzureDeployerTests.cs
@@ -1284,7 +1284,7 @@ public class AzureDeployerTests(ITestOutputHelper testOutputHelper)
         var acaEnv = builder.AddAzureContainerAppEnvironment("aca-env");
 
         builder.AddProject<Project>("agent", launchProfileName: null)
-            .WithComputeEnvironment(foundryProject);
+            .AsHostedAgent(foundryProject);
 
         builder.AddProject<Project>("api", launchProfileName: null)
             .WithExternalHttpEndpoints()

--- a/tests/Aspire.Hosting.Azure.Tests/FoundryExtensionsTests.cs
+++ b/tests/Aspire.Hosting.Azure.Tests/FoundryExtensionsTests.cs
@@ -195,17 +195,16 @@ public class FoundryExtensionsTests
     }
 
     [Fact]
-    public void AddProject_AddsDefaultContainerRegistryInRunMode()
+    public void AddProject_DoesNotAddDefaultContainerRegistryInRunMode()
     {
         using var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Run);
 
         var project = builder.AddFoundry("myAIFoundry")
             .AddProject("my-project");
 
-        var registry = Assert.Single(builder.Resources.OfType<AzureContainerRegistryResource>());
-
-        Assert.Equal("my-project-acr", registry.Name);
-        Assert.Same(registry, project.Resource.ContainerRegistry);
+        Assert.DoesNotContain(builder.Resources, r => r.Name == "my-project-acr");
+        Assert.Empty(builder.Resources.OfType<AzureContainerRegistryResource>());
+        Assert.Null(project.Resource.ContainerRegistry);
     }
 
     [Fact]

--- a/tests/Aspire.Hosting.Azure.Tests/FoundryExtensionsTests.cs
+++ b/tests/Aspire.Hosting.Azure.Tests/FoundryExtensionsTests.cs
@@ -295,7 +295,7 @@ public class FoundryExtensionsTests
         var advisorAgent = builder.AddProject<Project>("advisoragent", launchProfileName: null)
             .WithReference(weatherAgent)
             .WaitFor(weatherAgent)
-            .WithComputeEnvironment(project);
+            .AsHostedAgent(project);
 
         using var app = builder.Build();
         await AzureManifestUtils.ExecuteBeforeStartHooksAsync(app, default);
@@ -326,7 +326,7 @@ public class FoundryExtensionsTests
             .AddProject("my-project");
 
         var advisorAgent = builder.AddProject<Project>("advisor-agent", launchProfileName: null)
-            .WithComputeEnvironment(project);
+            .AsHostedAgent(project);
 
         using var app = builder.Build();
         await AzureManifestUtils.ExecuteBeforeStartHooksAsync(app, default);
@@ -363,7 +363,7 @@ public class FoundryExtensionsTests
             {
                 context.EnvironmentVariables["WEATHER_HEALTH_URL"] = ReferenceExpression.Create($"{weatherAgent.GetEndpoint("http")}/health");
             })
-            .WithComputeEnvironment(project);
+            .AsHostedAgent(project);
 
         using var app = builder.Build();
         await AzureManifestUtils.ExecuteBeforeStartHooksAsync(app, default);
@@ -403,7 +403,7 @@ public class FoundryExtensionsTests
             {
                 context.EnvironmentVariables["WEATHER_HOST_AND_PORT"] = weatherAgent.GetEndpoint("http").Property(EndpointProperty.HostAndPort);
             })
-            .WithComputeEnvironment(project);
+            .AsHostedAgent(project);
 
         using var app = builder.Build();
         await AzureManifestUtils.ExecuteBeforeStartHooksAsync(app, default);
@@ -442,7 +442,7 @@ public class FoundryExtensionsTests
             .WithReference(weatherAgent)
             .WaitFor(weatherAgent);
 
-        advisorAgent.WithComputeEnvironment(project);
+        advisorAgent.AsHostedAgent(project);
 
         using var app = builder.Build();
         await AzureManifestUtils.ExecuteBeforeStartHooksAsync(app, default);
@@ -469,4 +469,3 @@ public class FoundryExtensionsTests
     }
 
 }
-

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/FoundryExtensionsTests.AddProject_GeneratesEndpointFromParentFoundryApiEndpoint.verified.bicep
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/FoundryExtensionsTests.AddProject_GeneratesEndpointFromParentFoundryApiEndpoint.verified.bicep
@@ -7,8 +7,6 @@ param userPrincipalId string = ''
 
 param foundry_outputs_name string
 
-param project_acr_outputs_name string
-
 resource foundry 'Microsoft.CognitiveServices/accounts@2025-09-01' existing = {
   name: foundry_outputs_name
 }
@@ -26,20 +24,6 @@ resource project 'Microsoft.CognitiveServices/accounts/projects@2025-09-01' = {
     'aspire-resource-name': 'project'
   }
   parent: foundry
-}
-
-resource project_acr 'Microsoft.ContainerRegistry/registries@2025-04-01' existing = {
-  name: project_acr_outputs_name
-}
-
-resource project_acr_AcrPull 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
-  name: guid(project_acr.id, project.id, subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '7f951dda-4ed3-4680-a7ca-43fe172d538d'))
-  properties: {
-    principalId: project.identity.principalId
-    roleDefinitionId: subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '7f951dda-4ed3-4680-a7ca-43fe172d538d')
-    principalType: 'ServicePrincipal'
-  }
-  scope: project_acr
 }
 
 resource project_ai 'Microsoft.Insights/components@2020-02-02' = {
@@ -88,11 +72,5 @@ output name string = '${foundry_outputs_name}/project'
 output endpoint string = project.properties.endpoints['AI Foundry API']
 
 output principalId string = project.identity.principalId
-
-output AZURE_CONTAINER_REGISTRY_ENDPOINT string = project_acr.properties.loginServer
-
-output AZURE_CONTAINER_REGISTRY_NAME string = project_acr_outputs_name
-
-output AZURE_CONTAINER_REGISTRY_MANAGED_IDENTITY_ID string = project.identity.principalId
 
 output APPLICATION_INSIGHTS_CONNECTION_STRING string = project_ai.properties.ConnectionString

--- a/tests/Aspire.Hosting.Foundry.Tests/HostedAgentExtensionTests.cs
+++ b/tests/Aspire.Hosting.Foundry.Tests/HostedAgentExtensionTests.cs
@@ -72,13 +72,13 @@ public class HostedAgentExtensionTests
         var resource = builder.Resources.Single(r => r.Name == "agent");
         var command = Assert.Single(resource.Annotations.OfType<ResourceCommandAnnotation>());
         Assert.Equal("Send Message", command.DisplayName);
-        Assert.Equal("Agents", command.IconName);
+        Assert.Equal("ChatSparkle", command.IconName);
         Assert.Equal(IconVariant.Regular, command.IconVariant);
         Assert.True(command.IsHighlighted);
     }
 
     [Fact]
-    public void WithComputeEnvironment_InPublishMode_DoesNotValidateRegion()
+    public void AsHostedAgent_InPublishMode_DoesNotValidateRegion()
     {
         using var builder = TestDistributedApplicationBuilder.Create(
             DistributedApplicationOperation.Publish);
@@ -89,13 +89,13 @@ public class HostedAgentExtensionTests
             .AddProject("my-project");
 
         var app = builder.AddPythonApp("agent", "./app.py", "main:app")
-            .WithComputeEnvironment(project);
+            .AsHostedAgent(project);
 
         Assert.NotNull(app);
     }
 
     [Fact]
-    public void WithComputeEnvironment_InPublishMode_AcceptsValidRegion()
+    public void AsHostedAgent_InPublishMode_AcceptsValidRegion()
     {
         using var builder = TestDistributedApplicationBuilder.Create(
             DistributedApplicationOperation.Publish);
@@ -106,33 +106,33 @@ public class HostedAgentExtensionTests
             .AddProject("my-project");
 
         var app = builder.AddPythonApp("agent", "./app.py", "main:app")
-            .WithComputeEnvironment(project);
+            .AsHostedAgent(project);
 
         Assert.NotNull(app);
     }
 
     [Fact]
-    public void WithComputeEnvironment_NoRegionConfig_DoesNotThrow()
+    public void AsHostedAgent_NoRegionConfig_DoesNotThrow()
     {
         using var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish);
         var project = builder.AddFoundry("account")
             .AddProject("my-project");
 
         var app = builder.AddPythonApp("agent", "./app.py", "main:app")
-            .WithComputeEnvironment(project);
+            .AsHostedAgent(project);
 
         Assert.NotNull(app);
     }
 
     [Fact]
-    public void WithComputeEnvironment_InPublishMode_CreatesHostedAgentResource()
+    public void AsHostedAgent_InPublishMode_CreatesHostedAgentResource()
     {
         using var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish);
         var project = builder.AddFoundry("account")
             .AddProject("my-project");
 
         builder.AddPythonApp("agent", "./app.py", "main:app")
-            .WithComputeEnvironment(project);
+            .AsHostedAgent(project);
 
         builder.Build();
 
@@ -142,17 +142,48 @@ public class HostedAgentExtensionTests
     }
 
     [Fact]
-    public void WithComputeEnvironment_WithoutProject_CreatesDefaultProject()
+    public void AsHostedAgent_WithoutProject_CreatesDefaultProject()
     {
         using var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish);
 
         builder.AddPythonApp("agent", "./app.py", "main:app")
-            .WithComputeEnvironment();
+            .AsHostedAgent();
 
         builder.Build();
 
         var project = builder.Resources.OfType<AzureCognitiveServicesProjectResource>().SingleOrDefault();
         Assert.NotNull(project);
+    }
+
+    [Fact]
+    public void AsHostedAgent_InRunMode_WithProject_AddsProjectDependency()
+    {
+        using var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Run);
+        var project = builder.AddFoundry("account")
+            .AddProject("my-project");
+
+        var app = builder.AddPythonApp("agent", "./app.py", "main:app")
+            .AsHostedAgent(project);
+
+        builder.Build();
+
+        Assert.Contains(app.Resource.Annotations.OfType<WaitAnnotation>(), w => ReferenceEquals(w.Resource, project.Resource));
+    }
+
+    [Fact]
+    public void AsHostedAgent_InRunMode_WithProject_RemovesDefaultContainerRegistryResource()
+    {
+        using var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Run);
+        var project = builder.AddFoundry("account")
+            .AddProject("my-project");
+
+        builder.AddPythonApp("agent", "./app.py", "main:app")
+            .AsHostedAgent(project);
+
+        builder.Build();
+
+        Assert.Null(project.Resource.DefaultContainerRegistry);
+        Assert.DoesNotContain(builder.Resources, r => r.Name == "my-project-acr");
     }
 
     [Fact]

--- a/tests/Aspire.Hosting.Foundry.Tests/HostedAgentExtensionTests.cs
+++ b/tests/Aspire.Hosting.Foundry.Tests/HostedAgentExtensionTests.cs
@@ -159,7 +159,7 @@ public class HostedAgentExtensionTests
         };
 
         builder.AddPythonApp("agent", "./app.py", "main:app")
-            .AsHostedAgent(project, options);
+            .AsHostedAgentForExport(project, options);
 
         builder.Build();
 
@@ -183,7 +183,7 @@ public class HostedAgentExtensionTests
             .AddProject("my-project");
 
         builder.AddPythonApp("agent", "./app.py", "main:app")
-            .AsHostedAgent(project, options: null);
+            .AsHostedAgentForExport(project, options: null);
 
         builder.Build();
 
@@ -197,7 +197,7 @@ public class HostedAgentExtensionTests
         using var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish);
         var app = builder.AddPythonApp("agent", "./app.py", "main:app");
 
-        Assert.Throws<ArgumentNullException>(() => app.AsHostedAgent(project: null!));
+        Assert.Throws<ArgumentNullException>(() => app.AsHostedAgentForExport(project: null!));
     }
 
     [Fact]

--- a/tests/Aspire.Hosting.Foundry.Tests/HostedAgentExtensionTests.cs
+++ b/tests/Aspire.Hosting.Foundry.Tests/HostedAgentExtensionTests.cs
@@ -172,7 +172,7 @@ public class HostedAgentExtensionTests
     }
 
     [Fact]
-    public void AsHostedAgent_InRunMode_WithProject_RemovesDefaultContainerRegistryResource()
+    public void AsHostedAgent_InRunMode_WithProject_DoesNotCreateDefaultContainerRegistryResource()
     {
         using var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Run);
         var project = builder.AddFoundry("account")

--- a/tests/Aspire.Hosting.Foundry.Tests/HostedAgentExtensionTests.cs
+++ b/tests/Aspire.Hosting.Foundry.Tests/HostedAgentExtensionTests.cs
@@ -12,14 +12,12 @@ namespace Aspire.Hosting.Foundry.Tests;
 public class HostedAgentExtensionTests
 {
     [Fact]
-    public void WithComputeEnvironment_InRunMode_AddsHttpEndpoint()
+    public void AsHostedAgent_InRunMode_AddsHttpEndpoint()
     {
         using var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Run);
-        var project = builder.AddFoundry("account")
-            .AddProject("my-project");
 
         var app = builder.AddPythonApp("agent", "./app.py", "main:app")
-            .WithComputeEnvironment(project);
+            .AsHostedAgent();
 
         builder.Build();
 
@@ -29,15 +27,13 @@ public class HostedAgentExtensionTests
     }
 
     [Fact]
-    public void WithComputeEnvironment_InRunMode_PreservesExistingHttpEndpointTargetPort()
+    public void AsHostedAgent_InRunMode_PreservesExistingHttpEndpointTargetPort()
     {
         using var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Run);
-        var project = builder.AddFoundry("account")
-            .AddProject("my-project");
 
         var app = builder.AddPythonApp("agent", "./app.py", "main:app")
             .WithHttpEndpoint(targetPort: 5000)
-            .WithComputeEnvironment(project);
+            .AsHostedAgent();
 
         builder.Build();
 
@@ -49,14 +45,12 @@ public class HostedAgentExtensionTests
     }
 
     [Fact]
-    public void WithComputeEnvironment_InRunMode_DoesNotHardCodePort()
+    public void AsHostedAgent_InRunMode_DoesNotHardCodePort()
     {
         using var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Run);
-        var project = builder.AddFoundry("account")
-            .AddProject("my-project");
 
         var app = builder.AddPythonApp("agent", "./app.py", "main:app")
-            .WithComputeEnvironment(project);
+            .AsHostedAgent();
 
         builder.Build();
 
@@ -66,21 +60,21 @@ public class HostedAgentExtensionTests
     }
 
     [Fact]
-    public void WithComputeEnvironment_InRunMode_ConfiguresHealthCheck()
+    public void AsHostedAgent_InRunMode_ConfiguresSendMessageCommand()
     {
         using var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Run);
-        var project = builder.AddFoundry("account")
-            .AddProject("my-project");
 
         builder.AddPythonApp("agent", "./app.py", "main:app")
-            .WithComputeEnvironment(project);
+            .AsHostedAgent();
 
         builder.Build();
 
-        // The resource should have a health check annotation from WithHttpHealthCheck
         var resource = builder.Resources.Single(r => r.Name == "agent");
-        var healthAnnotation = resource.Annotations.OfType<HealthCheckAnnotation>().FirstOrDefault();
-        Assert.NotNull(healthAnnotation);
+        var command = Assert.Single(resource.Annotations.OfType<ResourceCommandAnnotation>());
+        Assert.Equal("Send Message", command.DisplayName);
+        Assert.Equal("Agents", command.IconName);
+        Assert.Equal(IconVariant.Regular, command.IconVariant);
+        Assert.True(command.IsHighlighted);
     }
 
     [Fact]

--- a/tests/Aspire.Hosting.Foundry.Tests/HostedAgentExtensionTests.cs
+++ b/tests/Aspire.Hosting.Foundry.Tests/HostedAgentExtensionTests.cs
@@ -3,6 +3,7 @@
 
 #pragma warning disable ASPIRECOMPUTE003 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
 
+using System.Runtime.CompilerServices;
 using Aspire.Hosting.ApplicationModel;
 using Aspire.Hosting.Utils;
 using Microsoft.Extensions.DependencyInjection;
@@ -187,6 +188,21 @@ public class HostedAgentExtensionTests
     }
 
     [Fact]
+    public async Task AsHostedAgent_InRunMode_WithProject_ExecutesBeforeStartHooksWithoutContainerRegistry()
+    {
+        using var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Run);
+        var project = builder.AddFoundry("account")
+            .AddProject("my-project");
+
+        builder.AddPythonApp("agent", "./app.py", "main:app")
+            .AsHostedAgent(project);
+
+        using var app = builder.Build();
+
+        await ExecuteBeforeStartHooksAsync(app, default);
+    }
+
+    [Fact]
     public async Task FoundryProject_DefaultRegistryDoesNotAddGlobalRegistryTargets()
     {
         using var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish);
@@ -205,4 +221,7 @@ public class HostedAgentExtensionTests
         var registryTarget = Assert.Single(registryTargets);
         Assert.Same(registry.Resource, registryTarget.Registry);
     }
+
+    [UnsafeAccessor(UnsafeAccessorKind.Method, Name = "ExecuteBeforeStartHooksAsync")]
+    private static extern Task ExecuteBeforeStartHooksAsync(DistributedApplication app, CancellationToken cancellationToken);
 }

--- a/tests/Aspire.Hosting.Foundry.Tests/HostedAgentExtensionTests.cs
+++ b/tests/Aspire.Hosting.Foundry.Tests/HostedAgentExtensionTests.cs
@@ -143,6 +143,64 @@ public class HostedAgentExtensionTests
     }
 
     [Fact]
+    public void AsHostedAgent_WithOptions_AppliesAllPropertiesToConfiguration()
+    {
+        using var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish);
+        var project = builder.AddFoundry("account")
+            .AddProject("my-project");
+
+        var options = new HostedAgentOptions
+        {
+            Description = "test description",
+            Cpu = 1m,
+            Memory = 2m,
+            Metadata = { ["scenario"] = "unit-test" },
+            EnvironmentVariables = { ["MY_VAR"] = "my-value" }
+        };
+
+        builder.AddPythonApp("agent", "./app.py", "main:app")
+            .AsHostedAgent(project, options);
+
+        builder.Build();
+
+        var hostedAgent = Assert.Single(builder.Resources.OfType<AzureHostedAgentResource>());
+
+        var configuration = new HostedAgentConfiguration("test-image");
+        hostedAgent.Configure!(configuration);
+
+        Assert.Equal("test description", configuration.Description);
+        Assert.Equal(1m, configuration.Cpu);
+        Assert.Equal(2m, configuration.Memory);
+        Assert.Equal("unit-test", configuration.Metadata["scenario"]);
+        Assert.Equal("my-value", configuration.EnvironmentVariables["MY_VAR"]);
+    }
+
+    [Fact]
+    public void AsHostedAgent_WithNullOptions_DoesNotSetConfigureCallback()
+    {
+        using var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish);
+        var project = builder.AddFoundry("account")
+            .AddProject("my-project");
+
+        builder.AddPythonApp("agent", "./app.py", "main:app")
+            .AsHostedAgent(project, options: null);
+
+        builder.Build();
+
+        var hostedAgent = Assert.Single(builder.Resources.OfType<AzureHostedAgentResource>());
+        Assert.Null(hostedAgent.Configure);
+    }
+
+    [Fact]
+    public void AsHostedAgent_WithNullProject_Throws()
+    {
+        using var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish);
+        var app = builder.AddPythonApp("agent", "./app.py", "main:app");
+
+        Assert.Throws<ArgumentNullException>(() => app.AsHostedAgent(project: null!));
+    }
+
+    [Fact]
     public void AsHostedAgent_WithoutProject_CreatesDefaultProject()
     {
         using var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish);

--- a/tests/Aspire.Hosting.Foundry.Tests/ProjectResourceTests.cs
+++ b/tests/Aspire.Hosting.Foundry.Tests/ProjectResourceTests.cs
@@ -90,6 +90,27 @@ public class ProjectResourceTests
     }
 
     [Fact]
+    public async Task AddProject_WithoutHostedAgents_RemovesDefaultContainerRegistryDuringBeforeStart()
+    {
+        using var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish);
+
+        var project = builder.AddFoundry("account")
+            .AddProject("my-project");
+
+        var defaultRegistry = project.Resource.DefaultContainerRegistry;
+        Assert.NotNull(defaultRegistry);
+        Assert.Contains(defaultRegistry, builder.Resources);
+
+        using var app = builder.Build();
+        await ExecuteBeforeStartHooksAsync(app, default);
+
+        var model = app.Services.GetRequiredService<DistributedApplicationModel>();
+        var registries = model.Resources.OfType<AzureContainerRegistryResource>().ToList();
+        Assert.DoesNotContain(defaultRegistry, registries);
+        Assert.Null(project.Resource.DefaultContainerRegistry);
+    }
+
+    [Fact]
     public void ConnectionStringExpression_HasCorrectFormat()
     {
         using var builder = TestDistributedApplicationBuilder.Create();

--- a/tests/Aspire.Hosting.Foundry.Tests/ProjectResourceTests.cs
+++ b/tests/Aspire.Hosting.Foundry.Tests/ProjectResourceTests.cs
@@ -37,17 +37,17 @@ public class ProjectResourceTests
     }
 
     [Fact]
-    public void AddProject_InRunMode_ModelsDefaultContainerRegistry()
+    public void AddProject_InRunMode_DoesNotCreateDefaultContainerRegistry()
     {
         using var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Run);
 
         var project = builder.AddFoundry("account")
             .AddProject("my-project");
 
-        var registry = Assert.Single(builder.Resources.OfType<AzureContainerRegistryResource>());
-        Assert.Equal("my-project-acr", registry.Name);
-        Assert.Same(project.Resource.DefaultContainerRegistry, registry);
-        Assert.Same(project.Resource.DefaultContainerRegistry, project.Resource.ContainerRegistry);
+        Assert.DoesNotContain(builder.Resources, r => r.Name == "my-project-acr");
+        Assert.Empty(builder.Resources.OfType<AzureContainerRegistryResource>());
+        Assert.Null(project.Resource.DefaultContainerRegistry);
+        Assert.Null(project.Resource.ContainerRegistry);
     }
 
     [Fact]

--- a/tests/Aspire.Hosting.Foundry.Tests/PromptAgentTests.cs
+++ b/tests/Aspire.Hosting.Foundry.Tests/PromptAgentTests.cs
@@ -56,6 +56,26 @@ public class PromptAgentTests
     }
 
     [Fact]
+    public void AddPromptAgent_ConfiguresSendMessageCommand()
+    {
+        using var builder = TestDistributedApplicationBuilder.Create();
+        var project = builder.AddFoundry("account")
+            .AddProject("my-project");
+        var model = project.AddModelDeployment("gpt41", FoundryModel.OpenAI.Gpt41);
+
+        project.AddPromptAgent("my-agent", model);
+
+        builder.Build();
+
+        var resource = builder.Resources.Single(r => r.Name == "my-agent");
+        var command = Assert.Single(resource.Annotations.OfType<ResourceCommandAnnotation>());
+        Assert.Equal("Send Message", command.DisplayName);
+        Assert.Equal("ChatSparkle", command.IconName);
+        Assert.Equal(IconVariant.Regular, command.IconVariant);
+        Assert.True(command.IsHighlighted);
+    }
+
+    [Fact]
     public void AddPromptAgent_WithNullName_Throws()
     {
         using var builder = TestDistributedApplicationBuilder.Create();

--- a/tests/PolyglotAppHosts/Aspire.Hosting.Foundry/Go/apphost.go
+++ b/tests/PolyglotAppHosts/Aspire.Hosting.Foundry/Go/apphost.go
@@ -119,14 +119,15 @@ server.listen(port, '127.0.0.1');
 `,
 		})
 
-	hostedAgent.AsHostedAgent(&aspire.AsHostedAgentOptions{
-		Project: &project,
-		Configure: func(cfg aspire.HostedAgentConfiguration) {
-			cfg.SetDescription("Validation hosted agent")
-			cfg.SetCpu(1)
-			cfg.SetMemory(2)
-			_ = cfg.Metadata().Set("scenario", "validation")
-			_ = cfg.EnvironmentVariables().Set("VALIDATION_MODE", "true")
+	hostedAgent.AsHostedAgent(project, &aspire.HostedAgentOptions{
+		Description: aspire.StringPtr("Validation hosted agent"),
+		Cpu:         aspire.Float64Ptr(1),
+		Memory:      aspire.Float64Ptr(2),
+		Metadata: map[string]string{
+			"scenario": "validation",
+		},
+		EnvironmentVariables: map[string]string{
+			"VALIDATION_MODE": "true",
 		},
 	})
 

--- a/tests/PolyglotAppHosts/Aspire.Hosting.Foundry/Go/apphost.go
+++ b/tests/PolyglotAppHosts/Aspire.Hosting.Foundry/Go/apphost.go
@@ -119,8 +119,7 @@ server.listen(port, '127.0.0.1');
 `,
 		})
 
-	hostedAgent.AsHostedAgent()
-	hostedAgent.WithComputeEnvironment(&aspire.WithComputeEnvironmentOptions{
+	hostedAgent.AsHostedAgent(&aspire.AsHostedAgentOptions{
 		Project: &project,
 		Configure: func(cfg aspire.HostedAgentConfiguration) {
 			cfg.SetDescription("Validation hosted agent")

--- a/tests/PolyglotAppHosts/Aspire.Hosting.Foundry/Go/apphost.go
+++ b/tests/PolyglotAppHosts/Aspire.Hosting.Foundry/Go/apphost.go
@@ -119,6 +119,7 @@ server.listen(port, '127.0.0.1');
 `,
 		})
 
+	hostedAgent.AsHostedAgent()
 	hostedAgent.WithComputeEnvironment(&aspire.WithComputeEnvironmentOptions{
 		Project: &project,
 		Configure: func(cfg aspire.HostedAgentConfiguration) {

--- a/tests/PolyglotAppHosts/Aspire.Hosting.Foundry/Go/apphost.go
+++ b/tests/PolyglotAppHosts/Aspire.Hosting.Foundry/Go/apphost.go
@@ -119,15 +119,17 @@ server.listen(port, '127.0.0.1');
 `,
 		})
 
-	hostedAgent.AsHostedAgent(project, &aspire.HostedAgentOptions{
-		Description: aspire.StringPtr("Validation hosted agent"),
-		Cpu:         aspire.Float64Ptr(1),
-		Memory:      aspire.Float64Ptr(2),
-		Metadata: map[string]string{
-			"scenario": "validation",
-		},
-		EnvironmentVariables: map[string]string{
-			"VALIDATION_MODE": "true",
+	hostedAgent.AsHostedAgent(project, &aspire.AsHostedAgentOptions{
+		Options: &aspire.HostedAgentOptions{
+			Description: "Validation hosted agent",
+			Cpu:         aspire.Float64Ptr(1),
+			Memory:      aspire.Float64Ptr(2),
+			Metadata: map[string]string{
+				"scenario": "validation",
+			},
+			EnvironmentVariables: map[string]string{
+				"VALIDATION_MODE": "true",
+			},
 		},
 	})
 

--- a/tests/PolyglotAppHosts/Aspire.Hosting.Foundry/Java/AppHost.java
+++ b/tests/PolyglotAppHosts/Aspire.Hosting.Foundry/Java/AppHost.java
@@ -106,6 +106,7 @@ server.listen(port, '127.0.0.1');
 """
             });
 
+        hostedAgent.asHostedAgent();
         hostedAgent.withComputeEnvironment(new WithComputeEnvironmentOptions()
             .project(project)
             .configure((configuration) -> {

--- a/tests/PolyglotAppHosts/Aspire.Hosting.Foundry/Java/AppHost.java
+++ b/tests/PolyglotAppHosts/Aspire.Hosting.Foundry/Java/AppHost.java
@@ -106,8 +106,7 @@ server.listen(port, '127.0.0.1');
 """
             });
 
-        hostedAgent.asHostedAgent();
-        hostedAgent.withComputeEnvironment(new WithComputeEnvironmentOptions()
+        hostedAgent.asHostedAgent(new AsHostedAgentOptions()
             .project(project)
             .configure((configuration) -> {
                 configuration.setDescription("Validation hosted agent");

--- a/tests/PolyglotAppHosts/Aspire.Hosting.Foundry/Java/AppHost.java
+++ b/tests/PolyglotAppHosts/Aspire.Hosting.Foundry/Java/AppHost.java
@@ -109,8 +109,8 @@ server.listen(port, '127.0.0.1');
 
         var hostedAgentOptions = new HostedAgentOptions();
         hostedAgentOptions.setDescription("Validation hosted agent");
-        hostedAgentOptions.setCpu(1);
-        hostedAgentOptions.setMemory(2);
+        hostedAgentOptions.setCpu(1.0);
+        hostedAgentOptions.setMemory(2.0);
         hostedAgentOptions.setMetadata(Map.of("scenario", "validation"));
         hostedAgentOptions.setEnvironmentVariables(Map.of("VALIDATION_MODE", "true"));
         hostedAgent.asHostedAgent(project, hostedAgentOptions);

--- a/tests/PolyglotAppHosts/Aspire.Hosting.Foundry/Java/AppHost.java
+++ b/tests/PolyglotAppHosts/Aspire.Hosting.Foundry/Java/AppHost.java
@@ -1,4 +1,5 @@
 import aspire.*;
+import java.util.Map;
 
 void main() throws Exception {
         var builder = DistributedApplication.CreateBuilder();
@@ -106,15 +107,12 @@ server.listen(port, '127.0.0.1');
 """
             });
 
-        hostedAgent.asHostedAgent(new AsHostedAgentOptions()
-            .project(project)
-            .configure((configuration) -> {
-                configuration.setDescription("Validation hosted agent");
-                configuration.setCpu(1);
-                configuration.setMemory(2);
-                configuration.metadata().put("scenario", "validation");
-                configuration.environmentVariables().put("VALIDATION_MODE", "true");
-            }));
+        hostedAgent.asHostedAgent(project, new HostedAgentOptions()
+            .description("Validation hosted agent")
+            .cpu(1)
+            .memory(2)
+            .metadata(Map.of("scenario", "validation"))
+            .environmentVariables(Map.of("VALIDATION_MODE", "true")));
 
         var api = builder.addContainer("api", "nginx");
         foundry.withContainerRegistryRoleAssignments(registry, new AzureContainerRegistryRole[] {

--- a/tests/PolyglotAppHosts/Aspire.Hosting.Foundry/Java/AppHost.java
+++ b/tests/PolyglotAppHosts/Aspire.Hosting.Foundry/Java/AppHost.java
@@ -107,12 +107,13 @@ server.listen(port, '127.0.0.1');
 """
             });
 
-        hostedAgent.asHostedAgent(project, new HostedAgentOptions()
-            .description("Validation hosted agent")
-            .cpu(1)
-            .memory(2)
-            .metadata(Map.of("scenario", "validation"))
-            .environmentVariables(Map.of("VALIDATION_MODE", "true")));
+        var hostedAgentOptions = new HostedAgentOptions();
+        hostedAgentOptions.setDescription("Validation hosted agent");
+        hostedAgentOptions.setCpu(1);
+        hostedAgentOptions.setMemory(2);
+        hostedAgentOptions.setMetadata(Map.of("scenario", "validation"));
+        hostedAgentOptions.setEnvironmentVariables(Map.of("VALIDATION_MODE", "true"));
+        hostedAgent.asHostedAgent(project, hostedAgentOptions);
 
         var api = builder.addContainer("api", "nginx");
         foundry.withContainerRegistryRoleAssignments(registry, new AzureContainerRegistryRole[] {

--- a/tests/PolyglotAppHosts/Aspire.Hosting.Foundry/Python/apphost.py
+++ b/tests/PolyglotAppHosts/Aspire.Hosting.Foundry/Python/apphost.py
@@ -123,7 +123,7 @@ server.listen(port, '127.0.0.1');
 """
         ])
 
-    hosted_agent.with_compute_environment(project=project)
+    hosted_agent.as_hosted_agent(project=project)
 
     api = builder.add_container("api", "nginx")
     foundry.with_container_registry_role_assignments(registry)

--- a/tests/PolyglotAppHosts/Aspire.Hosting.Foundry/TypeScript/apphost.mts
+++ b/tests/PolyglotAppHosts/Aspire.Hosting.Foundry/TypeScript/apphost.mts
@@ -110,8 +110,7 @@ server.listen(port, '127.0.0.1');
 `
     ]);
 
-await hostedAgent.asHostedAgent();
-await hostedAgent.withComputeEnvironment({
+await hostedAgent.asHostedAgent({
     project,
     configure: async (configuration) => {
         await configuration.description.set('Validation hosted agent');

--- a/tests/PolyglotAppHosts/Aspire.Hosting.Foundry/TypeScript/apphost.mts
+++ b/tests/PolyglotAppHosts/Aspire.Hosting.Foundry/TypeScript/apphost.mts
@@ -110,6 +110,7 @@ server.listen(port, '127.0.0.1');
 `
     ]);
 
+await hostedAgent.asHostedAgent();
 await hostedAgent.withComputeEnvironment({
     project,
     configure: async (configuration) => {

--- a/tests/PolyglotAppHosts/Aspire.Hosting.Foundry/TypeScript/apphost.mts
+++ b/tests/PolyglotAppHosts/Aspire.Hosting.Foundry/TypeScript/apphost.mts
@@ -110,17 +110,12 @@ server.listen(port, '127.0.0.1');
 `
     ]);
 
-await hostedAgent.asHostedAgent({
-    project,
-    configure: async (configuration) => {
-        await configuration.description.set('Validation hosted agent');
-        await configuration.cpu.set(1);
-        await configuration.memory.set(2);
-        const metadata = await configuration.metadata();
-        await metadata.set('scenario', 'validation');
-        const environmentVariables = await configuration.environmentVariables();
-        await environmentVariables.set('VALIDATION_MODE', 'true');
-    }
+await hostedAgent.asHostedAgent(project, {
+    description: 'Validation hosted agent',
+    cpu: 1,
+    memory: 2,
+    metadata: { scenario: 'validation' },
+    environmentVariables: { VALIDATION_MODE: 'true' }
 });
 
 const api = await builder.addContainer('api', 'nginx');

--- a/tests/PolyglotAppHosts/Aspire.Hosting.Foundry/TypeScript/apphost.mts
+++ b/tests/PolyglotAppHosts/Aspire.Hosting.Foundry/TypeScript/apphost.mts
@@ -111,11 +111,13 @@ server.listen(port, '127.0.0.1');
     ]);
 
 await hostedAgent.asHostedAgent(project, {
-    description: 'Validation hosted agent',
-    cpu: 1,
-    memory: 2,
-    metadata: { scenario: 'validation' },
-    environmentVariables: { VALIDATION_MODE: 'true' }
+    options: {
+        description: 'Validation hosted agent',
+        cpu: 1,
+        memory: 2,
+        metadata: { scenario: 'validation' },
+        environmentVariables: { VALIDATION_MODE: 'true' }
+    }
 });
 
 const api = await builder.addContainer('api', 'nginx');

--- a/tests/PolyglotAppHosts/Aspire.Hosting.Foundry/TypeScript/apphost.mts
+++ b/tests/PolyglotAppHosts/Aspire.Hosting.Foundry/TypeScript/apphost.mts
@@ -111,13 +111,11 @@ server.listen(port, '127.0.0.1');
     ]);
 
 await hostedAgent.asHostedAgent(project, {
-    options: {
-        description: 'Validation hosted agent',
-        cpu: 1,
-        memory: 2,
-        metadata: { scenario: 'validation' },
-        environmentVariables: { VALIDATION_MODE: 'true' }
-    }
+    description: 'Validation hosted agent',
+    cpu: 1,
+    memory: 2,
+    metadata: { scenario: 'validation' },
+    environmentVariables: { VALIDATION_MODE: 'true' }
 });
 
 const api = await builder.addContainer('api', 'nginx');


### PR DESCRIPTION
Backport of #17545 to release/13.4

/cc @tommasodotNET

## Customer Impact

Customers using Aspire Foundry hosted agents get the updated project-first API and correct hosted-agent deployment configuration behavior. Local run mode no longer creates an unnecessary default Azure Container Registry resource.

## Testing

- `Aspire.Hosting.Foundry.Tests`: 92/92 passing on the release/13.4 backport branch.
- Source PR updated Foundry Azure/deployment/polyglot coverage and generated baselines.

## Risk

Low. The changes are localized to `Aspire.Hosting.Foundry` hosted-agent/project APIs and generated polyglot/API baselines, but they do affect public/generated API surface.

## Regression?

No.
