### PR TITLE
Handle process inspection race during shutdown

### DIFF
--- a/src/Shared/ProcessSignaler.cs
+++ b/src/Shared/ProcessSignaler.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.ComponentModel;
 using System.Diagnostics;
 using System.Runtime.InteropServices;
 using Microsoft.Extensions.Logging;
@@ -49,20 +50,31 @@ internal static partial class ProcessSignaler
 
     public static Process? TryGetRunningProcess(int pid, DateTimeOffset? expectedStartTime, ILogger logger)
     {
+        Process? process = null;
         try
         {
-            var process = Process.GetProcessById(pid);
-            if (expectedStartTime is not null && !AreClose(expectedStartTime, process.StartTime))
-            {
-                logger.LogDebug("Process {Pid} start time {ProcessStartTime} does not match expected start time {ExpectedStartTime}", pid, process.StartTime, expectedStartTime);
-                process.Dispose();
-                return null; // Do not return processes that do not match the expected start time
-            }
-
+            process = Process.GetProcessById(pid);
             if (process.HasExited)
             {
                 process.Dispose();
                 return null;
+            }
+
+            if (expectedStartTime is not null)
+            {
+                var processStartTime = process.StartTime;
+                if (!AreClose(expectedStartTime, processStartTime))
+                {
+                    logger.LogDebug("Process {Pid} start time {ProcessStartTime} does not match expected start time {ExpectedStartTime}", pid, processStartTime, expectedStartTime);
+                    process.Dispose();
+                    return null; // Do not return processes that do not match the expected start time
+                }
+
+                if (process.HasExited)
+                {
+                    process.Dispose();
+                    return null;
+                }
             }
 
             return process;
@@ -70,11 +82,23 @@ internal static partial class ProcessSignaler
         catch (ArgumentException)
         {
             // Process doesn't exist - already terminated.
+            process?.Dispose();
             return null;
         }
         catch (InvalidOperationException)
         {
             // Process has already exited.
+            process?.Dispose();
+            return null;
+        }
+        catch (Win32Exception ex)
+        {
+            // Process inspection can race with process exit. On macOS, StartTime can throw:
+            //   Win32Exception (3): Unable to retrieve the specified information about the process or thread. It may have exited or may be privileged.
+            // If we cannot inspect the process enough to prove it is the expected target, do
+            // not signal or kill it.
+            logger.LogDebug(ex, "Could not inspect process {Pid}. Treating it as not running.", pid);
+            process?.Dispose();
             return null;
         }
     }


### PR DESCRIPTION
## Description

`aspire stop --all` can monitor AppHost termination after an AppHost has already exited. On macOS, reading `Process.StartTime` during that race can throw `Win32Exception`, which previously bubbled out of `ProcessShutdownService` and failed the stop command even though shutdown had completed.

This updates `ProcessSignaler.TryGetRunningProcess` to treat `Win32Exception` during process inspection the same way it treats missing or already-exited processes: dispose the process handle, log at debug level, and return `null` so callers do not signal or kill a process they cannot safely validate.

Validation: `dotnet test --project tests/Aspire.Cli.Tests/Aspire.Cli.Tests.csproj --no-launch-profile -- --filter-class "*.ProcessShutdownServiceTests" --filter-not-trait "quarantined=true" --filter-not-trait "outerloop=true"`

Fixes #17662

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [x] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No