### PR TITLE
Reference Foundry project from hosted agent target

### DIFF
--- a/src/Aspire.Hosting.Foundry/HostedAgent/HostedAgentBuilderExtension.cs
+++ b/src/Aspire.Hosting.Foundry/HostedAgent/HostedAgentBuilderExtension.cs
@@ -144,6 +144,20 @@ public static class HostedAgentResourceBuilderExtensions
         }
     }
 
+    private static void AddProjectReferenceForPublishMode(
+        IDistributedApplicationBuilder applicationBuilder,
+        IResource target,
+        IResourceBuilder<AzureCognitiveServicesProjectResource> project)
+    {
+        if (target is not IResourceWithEnvironment targetWithEnvironment)
+        {
+            throw new InvalidOperationException($"Unable to reference Foundry project from resource '{target.Name}' because it does not support environment variables.");
+        }
+
+        applicationBuilder.CreateResourceBuilder(targetWithEnvironment)
+            .WithReference(project);
+    }
+
     private static IResourceBuilder<AzureCognitiveServicesProjectResource> ResolveProjectBuilderForPublish<T>(IResourceBuilder<T> builder)
         where T : IResourceWithEndpoints, IResourceWithEnvironment, IComputeResource
     {
@@ -308,7 +322,8 @@ public static class HostedAgentResourceBuilderExtensions
         {
             // Ensure we have a container resource to deploy.
             // ExecutableResource needs PublishAsDockerFile() to convert it into a container resource at this stage.
-            builder.ApplicationBuilder.CreateResourceBuilder(executableResource).PublishAsDockerFile();
+            builder.ApplicationBuilder.CreateResourceBuilder(executableResource)
+                .PublishAsDockerFile();
 
             if (builder.ApplicationBuilder.TryCreateResourceBuilder(resource.Name, out containerResourceBuilder))
             {
@@ -328,6 +343,8 @@ public static class HostedAgentResourceBuilderExtensions
             throw new InvalidOperationException($"Unable to create hosted agent for resource '{resource.Name}' because it is not a container, executable, or project resource.");
         }
 
+        AddProjectReferenceForPublishMode(builder.ApplicationBuilder, target, project);
+
         // Create a separate agent resource to host the deployment.
         var hostedAgent = new AzureHostedAgentResource(agentName, target, configure);
 
@@ -340,7 +357,6 @@ public static class HostedAgentResourceBuilderExtensions
 
         builder.ApplicationBuilder.AddResource(hostedAgent)
             .WithIconName("Agents")
-            .WithReferenceRelationship(target)
-            .WithReference(project);
+            .WithReferenceRelationship(target);
     }
 }

--- a/src/Aspire.Hosting.Foundry/HostedAgent/HostedAgentBuilderExtension.cs
+++ b/src/Aspire.Hosting.Foundry/HostedAgent/HostedAgentBuilderExtension.cs
@@ -144,20 +144,6 @@ public static class HostedAgentResourceBuilderExtensions
         }
     }
 
-    private static void AddProjectReferenceForPublishMode(
-        IDistributedApplicationBuilder applicationBuilder,
-        IResource target,
-        IResourceBuilder<AzureCognitiveServicesProjectResource> project)
-    {
-        if (target is not IResourceWithEnvironment targetWithEnvironment)
-        {
-            throw new InvalidOperationException($"Unable to reference Foundry project from resource '{target.Name}' because it does not support environment variables.");
-        }
-
-        applicationBuilder.CreateResourceBuilder(targetWithEnvironment)
-            .WithReference(project);
-    }
-
     private static IResourceBuilder<AzureCognitiveServicesProjectResource> ResolveProjectBuilderForPublish<T>(IResourceBuilder<T> builder)
         where T : IResourceWithEndpoints, IResourceWithEnvironment, IComputeResource
     {
@@ -309,7 +295,7 @@ public static class HostedAgentResourceBuilderExtensions
         }
 
         // Get the corresponding ContainerResource for ExecutableResources. Usually this is swapped in at publish time for ExecutableResources.
-        IResource target;
+        IResourceWithEnvironment target;
         if (resource is ContainerResource containerResource)
         {
             target = containerResource;
@@ -343,7 +329,10 @@ public static class HostedAgentResourceBuilderExtensions
             throw new InvalidOperationException($"Unable to create hosted agent for resource '{resource.Name}' because it is not a container, executable, or project resource.");
         }
 
-        AddProjectReferenceForPublishMode(builder.ApplicationBuilder, target, project);
+        // The hosted agent wrapper is not the deployed workload. Apply the Foundry
+        // reference to the target so its connection annotations flow into the deployment.
+        builder.ApplicationBuilder.CreateResourceBuilder(target)
+            .WithReference(project);
 
         // Create a separate agent resource to host the deployment.
         var hostedAgent = new AzureHostedAgentResource(agentName, target, configure);

--- a/tests/Aspire.Hosting.Azure.Tests/FoundryExtensionsTests.cs
+++ b/tests/Aspire.Hosting.Azure.Tests/FoundryExtensionsTests.cs
@@ -468,6 +468,9 @@ public class FoundryExtensionsTests
 
     private static void SetFoundryProjectOutputs(AzureCognitiveServicesProjectResource project)
     {
+        // These tests call the deployment-time environment resolver directly. In a real publish,
+        // provisioning populates the Foundry project Bicep outputs before references are resolved.
+        // Seed the outputs here so BicepOutputReference.GetValueAsync does not wait for provisioning.
         project.Outputs["endpoint"] = "https://account.services.ai.azure.com/api/projects/my-project";
         project.Outputs["APPLICATION_INSIGHTS_CONNECTION_STRING"] = "";
         project.ProvisioningTaskCompletionSource?.TrySetResult();

--- a/tests/Aspire.Hosting.Azure.Tests/FoundryExtensionsTests.cs
+++ b/tests/Aspire.Hosting.Azure.Tests/FoundryExtensionsTests.cs
@@ -304,6 +304,7 @@ public class FoundryExtensionsTests
         var environment = Assert.Single(model.Resources.OfType<AzureContainerAppEnvironmentResource>());
         environment.Outputs["AZURE_CONTAINER_APPS_ENVIRONMENT_DEFAULT_DOMAIN"] = "example.azurecontainerapps.io";
         environment.ProvisioningTaskCompletionSource?.TrySetResult();
+        SetFoundryProjectOutputs(project.Resource);
 
         using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
         var environmentVariables = await AzureHostedAgentResource.GetResolvedEnvironmentVariablesAsync(
@@ -332,6 +333,7 @@ public class FoundryExtensionsTests
 
         var model = app.Services.GetRequiredService<DistributedApplicationModel>();
         var hostedAgent = Assert.Single(model.Resources.OfType<AzureHostedAgentResource>());
+        SetFoundryProjectOutputs(project.Resource);
 
         using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
         var environmentVariables = await AzureHostedAgentResource.GetResolvedEnvironmentVariablesAsync(
@@ -372,6 +374,7 @@ public class FoundryExtensionsTests
         var environment = Assert.Single(model.Resources.OfType<AzureContainerAppEnvironmentResource>());
         environment.Outputs["AZURE_CONTAINER_APPS_ENVIRONMENT_DEFAULT_DOMAIN"] = "example.azurecontainerapps.io";
         environment.ProvisioningTaskCompletionSource?.TrySetResult();
+        SetFoundryProjectOutputs(project.Resource);
 
         using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
         var environmentVariables = await AzureHostedAgentResource.GetResolvedEnvironmentVariablesAsync(
@@ -412,6 +415,7 @@ public class FoundryExtensionsTests
         var environment = Assert.Single(model.Resources.OfType<AzureContainerAppEnvironmentResource>());
         environment.Outputs["AZURE_CONTAINER_APPS_ENVIRONMENT_DEFAULT_DOMAIN"] = "example.azurecontainerapps.io";
         environment.ProvisioningTaskCompletionSource?.TrySetResult();
+        SetFoundryProjectOutputs(project.Resource);
 
         using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
         var environmentVariables = await AzureHostedAgentResource.GetResolvedEnvironmentVariablesAsync(
@@ -460,6 +464,13 @@ public class FoundryExtensionsTests
         Assert.Contains("Foundry hosted agent 'advisor-agent-ha'", ex.Message);
         Assert.Contains("Endpoint 'http' on resource 'weather-agent' cannot be used", ex.Message);
         Assert.Contains("internal", ex.Message);
+    }
+
+    private static void SetFoundryProjectOutputs(AzureCognitiveServicesProjectResource project)
+    {
+        project.Outputs["endpoint"] = "https://account.services.ai.azure.com/api/projects/my-project";
+        project.Outputs["APPLICATION_INSIGHTS_CONNECTION_STRING"] = "";
+        project.ProvisioningTaskCompletionSource?.TrySetResult();
     }
 
     private sealed class Project : IProjectMetadata

--- a/tests/Aspire.Hosting.Foundry.Tests/HostedAgentExtensionTests.cs
+++ b/tests/Aspire.Hosting.Foundry.Tests/HostedAgentExtensionTests.cs
@@ -143,6 +143,29 @@ public class HostedAgentExtensionTests
     }
 
     [Fact]
+    public void AsHostedAgent_InPublishMode_AddsProjectReferenceToDeploymentTarget()
+    {
+        using var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish);
+        var project = builder.AddFoundry("account")
+            .AddProject("my-project");
+
+        builder.AddProject<Project>("agent", launchProfileName: null)
+            .AsHostedAgent(project);
+
+        builder.Build();
+
+        var hostedAgent = Assert.Single(builder.Resources.OfType<AzureHostedAgentResource>());
+
+        Assert.True(hostedAgent.Target.TryGetAnnotationsOfType<ResourceRelationshipAnnotation>(out var relationships));
+        Assert.Contains(relationships, r =>
+            r.Type == "Reference" &&
+            ReferenceEquals(r.Resource, project.Resource));
+        Assert.DoesNotContain(hostedAgent.Annotations.OfType<ResourceRelationshipAnnotation>(), r =>
+            r.Type == "Reference" &&
+            ReferenceEquals(r.Resource, project.Resource));
+    }
+
+    [Fact]
     public void AsHostedAgent_WithOptions_AppliesAllPropertiesToConfiguration()
     {
         using var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish);
@@ -282,4 +305,9 @@ public class HostedAgentExtensionTests
 
     [UnsafeAccessor(UnsafeAccessorKind.Method, Name = "ExecuteBeforeStartHooksAsync")]
     private static extern Task ExecuteBeforeStartHooksAsync(DistributedApplication app, CancellationToken cancellationToken);
+
+    private sealed class Project : IProjectMetadata
+    {
+        public string ProjectPath => "project";
+    }
 }

--- a/tests/Aspire.Hosting.Foundry.Tests/HostedAgentExtensionTests.cs
+++ b/tests/Aspire.Hosting.Foundry.Tests/HostedAgentExtensionTests.cs
@@ -5,6 +5,7 @@
 
 using System.Runtime.CompilerServices;
 using Aspire.Hosting.ApplicationModel;
+using Aspire.Hosting.Tests.Utils;
 using Aspire.Hosting.Utils;
 using Microsoft.Extensions.DependencyInjection;
 
@@ -143,7 +144,7 @@ public class HostedAgentExtensionTests
     }
 
     [Fact]
-    public void AsHostedAgent_InPublishMode_AddsProjectReferenceToDeploymentTarget()
+    public async Task AsHostedAgent_InPublishMode_AddsProjectReferenceToDeploymentTarget()
     {
         using var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish);
         var project = builder.AddFoundry("account")
@@ -160,6 +161,16 @@ public class HostedAgentExtensionTests
         Assert.Contains(relationships, r =>
             r.Type == "Reference" &&
             ReferenceEquals(r.Resource, project.Resource));
+
+        var envVars = await EnvironmentVariableEvaluator.GetEnvironmentVariablesAsync(
+            hostedAgent.Target, DistributedApplicationOperation.Publish, TestServiceProvider.Instance);
+
+        Assert.Contains(envVars, kvp =>
+            kvp.Key == "ConnectionStrings__my-project" &&
+            kvp.Value == "{my-project.connectionString}");
+        Assert.Contains(envVars, kvp =>
+            kvp.Key == "MY_PROJECT_CONNECTIONSTRING" &&
+            kvp.Value == "Endpoint={my-project.outputs.endpoint}");
         Assert.DoesNotContain(hostedAgent.Annotations.OfType<ResourceRelationshipAnnotation>(), r =>
             r.Type == "Reference" &&
             ReferenceEquals(r.Resource, project.Resource));


### PR DESCRIPTION
## Description

Publish-mode hosted agents now attach the Microsoft Foundry project reference to the actual deployment target resource after the target is resolved, instead of attaching it to the hosted-agent wrapper resource. This ensures the generated or existing container target has the Foundry project connection environment annotations before container build/deployment processing consumes the target resource.

This keeps run-mode behavior unchanged and preserves the hosted-agent wrapper's reference relationship to the deployment target. A regression test verifies the Foundry project reference is on `AzureHostedAgentResource.Target` and not only on the hosted-agent resource.

Validation:

```bash
./restore.sh
dotnet test --project tests/Aspire.Hosting.Foundry.Tests/Aspire.Hosting.Foundry.Tests.csproj --no-launch-profile -- --filter-not-trait "quarantined=true" --filter-not-trait "outerloop=true"
```

Fixes # (issue)

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
