### PR TITLE
[release/13.4] Mark Aspire.Hosting.Blazor as preview

### DIFF
--- a/src/Aspire.Hosting.Blazor/Aspire.Hosting.Blazor.csproj
+++ b/src/Aspire.Hosting.Blazor/Aspire.Hosting.Blazor.csproj
@@ -6,10 +6,6 @@
     <PackageTags>aspire integration hosting blazor webassembly gateway</PackageTags>
     <Description>Blazor WebAssembly hosting support for Aspire.</Description>
     <NoWarn>$(NoWarn);ASPIREBLAZOR001</NoWarn>
-    <!-- Ship as preview in 13.4.x. The stable 13.4.0 layout placed gateway scripts only under
-         buildTransitive/, which breaks the TypeScript AppHost flow that resolves Gateway.cs from
-         lib/. Keep the package preview-shaped until the packaging/loader issue is fully fixed.
-         Tracked by https://github.com/microsoft/aspire/issues/17685. -->
     <SuppressFinalPackageVersion>true</SuppressFinalPackageVersion>
   </PropertyGroup>
 

--- a/src/Aspire.Hosting.Blazor/Aspire.Hosting.Blazor.csproj
+++ b/src/Aspire.Hosting.Blazor/Aspire.Hosting.Blazor.csproj
@@ -6,6 +6,11 @@
     <PackageTags>aspire integration hosting blazor webassembly gateway</PackageTags>
     <Description>Blazor WebAssembly hosting support for Aspire.</Description>
     <NoWarn>$(NoWarn);ASPIREBLAZOR001</NoWarn>
+    <!-- Ship as preview in 13.4.x. The stable 13.4.0 layout placed gateway scripts only under
+         buildTransitive/, which breaks the TypeScript AppHost flow that resolves Gateway.cs from
+         lib/. Keep the package preview-shaped until the packaging/loader issue is fully fixed.
+         Tracked by https://github.com/microsoft/aspire/issues/17685. -->
+    <SuppressFinalPackageVersion>true</SuppressFinalPackageVersion>
   </PropertyGroup>
 
   <PropertyGroup>


### PR DESCRIPTION
Fixes [#17685](https://github.com/microsoft/aspire/issues/17685).

## Summary

The 13.4.0 stable build of `Aspire.Hosting.Blazor` ships the gateway scripts only under `buildTransitive/net8.0/Scripts/`, while the TypeScript polyglot AppHost loader resolves `Gateway.cs` from `lib/net8.0/Scripts/`. As a result, `aspire run` against a TS AppHost that calls `addBlazorGateway` fails out of the box with:

```
Capability Error: Could not invoke 'addBlazorGateway': Gateway.cs not found at
   'C:\Nuget\aspire.hosting.blazor\13.4.0\lib\net8.0\Scripts\Gateway.cs'.
```

To prevent users from picking up the broken stable package on 13.4.x while the packaging/loader fix is being worked, this PR sets `<SuppressFinalPackageVersion>true</SuppressFinalPackageVersion>` on the `Aspire.Hosting.Blazor` project so the built package stays preview-shaped on this release branch.

## Change

- `src/Aspire.Hosting.Blazor/Aspire.Hosting.Blazor.csproj`: add `SuppressFinalPackageVersion=true` with a comment pointing at [#17685](https://github.com/microsoft/aspire/issues/17685).

No code/behavioral changes — only the package version shape is affected.