### PR TITLE
Display resource commands in VS Code extension tree view

### DIFF
--- a/extension/package.json
+++ b/extension/package.json
@@ -315,6 +315,12 @@
         "icon": "$(terminal)"
       },
       {
+        "command": "aspire-vscode.executeResourceCommandItem",
+        "title": "%command.executeResourceCommandItem%",
+        "category": "Aspire",
+        "icon": "$(terminal)"
+      },
+      {
         "command": "aspire-vscode.copyEndpointUrl",
         "title": "%command.copyEndpointUrl%",
         "category": "Aspire",
@@ -511,6 +517,10 @@
           "when": "false"
         },
         {
+          "command": "aspire-vscode.executeResourceCommandItem",
+          "when": "false"
+        },
+        {
           "command": "aspire-vscode.codeLensDebugPipelineStep",
           "when": "false"
         },
@@ -640,6 +650,11 @@
         {
           "command": "aspire-vscode.executeResourceCommand",
           "when": "view == aspire-vscode.runningAppHosts && viewItem =~ /^resource(:|$)/",
+          "group": "2_actions@4"
+        },
+        {
+          "command": "aspire-vscode.executeResourceCommandItem",
+          "when": "view == aspire-vscode.runningAppHosts && viewItem == resourceCommand:enabled",
           "group": "2_actions@4"
         },
         {

--- a/extension/package.nls.json
+++ b/extension/package.nls.json
@@ -156,6 +156,7 @@
   "command.restartResource": "Restart",
   "command.viewResourceLogs": "View logs",
   "command.executeResourceCommand": "Execute resource command",
+  "command.executeResourceCommandItem": "Execute command",
   "command.copyEndpointUrl": "Copy URL",
   "command.openInExternalBrowser": "Open in browser",
   "command.openInIntegratedBrowser": "Open in VS Code",

--- a/extension/src/extension.ts
+++ b/extension/src/extension.ts
@@ -119,6 +119,7 @@ export async function activate(context: vscode.ExtensionContext) {
   const restartResourceRegistration = vscode.commands.registerCommand('aspire-vscode.restartResource', (element) => appHostTreeProvider.restartResource(element));
   const viewResourceLogsRegistration = vscode.commands.registerCommand('aspire-vscode.viewResourceLogs', (element) => appHostTreeProvider.viewResourceLogs(element));
   const executeResourceCommandRegistration = vscode.commands.registerCommand('aspire-vscode.executeResourceCommand', (element) => appHostTreeProvider.executeResourceCommand(element));
+  const executeResourceCommandItemRegistration = vscode.commands.registerCommand('aspire-vscode.executeResourceCommandItem', (element) => appHostTreeProvider.executeResourceCommandItem(element));
   const copyEndpointUrlRegistration = vscode.commands.registerCommand('aspire-vscode.copyEndpointUrl', (element) => appHostTreeProvider.copyEndpointUrl(element));
   const openInExternalBrowserRegistration = vscode.commands.registerCommand('aspire-vscode.openInExternalBrowser', (element) => appHostTreeProvider.openInExternalBrowser(element));
   const openInIntegratedBrowserRegistration = vscode.commands.registerCommand('aspire-vscode.openInIntegratedBrowser', (element) => appHostTreeProvider.openInIntegratedBrowser(element));
@@ -136,7 +137,7 @@ export async function activate(context: vscode.ExtensionContext) {
   // Activate the data repository. Workspace describe watching and global polling begin when the panel is visible.
   dataRepository.activate();
 
-  context.subscriptions.push(appHostTreeView, refreshRunningAppHostsRegistration, switchToGlobalViewRegistration, switchToWorkspaceViewRegistration, openDashboardRegistration, openAppHostSourceRegistration, stopAppHostRegistration, stopResourceRegistration, startResourceRegistration, restartResourceRegistration, viewResourceLogsRegistration, executeResourceCommandRegistration, copyEndpointUrlRegistration, openInExternalBrowserRegistration, openInIntegratedBrowserRegistration, copyResourceNameRegistration, copyAppHostPathRegistration, viewAppHostSourceRegistration, viewAppHostLogFileRegistration, copyLogFilePathRegistration, expandAllRegistration, { dispose: () => { appHostTreeProvider.dispose(); dataRepository.dispose(); } });
+  context.subscriptions.push(appHostTreeView, refreshRunningAppHostsRegistration, switchToGlobalViewRegistration, switchToWorkspaceViewRegistration, openDashboardRegistration, openAppHostSourceRegistration, stopAppHostRegistration, stopResourceRegistration, startResourceRegistration, restartResourceRegistration, viewResourceLogsRegistration, executeResourceCommandRegistration, executeResourceCommandItemRegistration, copyEndpointUrlRegistration, openInExternalBrowserRegistration, openInIntegratedBrowserRegistration, copyResourceNameRegistration, copyAppHostPathRegistration, viewAppHostSourceRegistration, viewAppHostLogFileRegistration, copyLogFilePathRegistration, expandAllRegistration, { dispose: () => { appHostTreeProvider.dispose(); dataRepository.dispose(); } });
 
   // CodeLens provider — shows Debug on pipeline steps, resource state on resources
   const codeLensProvider = new AspireCodeLensProvider(appHostTreeProvider, dataRepository);

--- a/extension/src/loc/strings.ts
+++ b/extension/src/loc/strings.ts
@@ -60,6 +60,7 @@ export const aspireDescribeMinimumVersion = '13.2.0';
 export const aspireCliDescribeNotSupported = (version: string) => vscode.l10n.t('Workspace resources require Aspire CLI {0} or newer. Update the Aspire CLI and refresh the Aspire panel.', version);
 export const appHostDescribeMayNotBeSupported = (version: string) => vscode.l10n.t('No workspace resources were returned. Workspace resources require the AppHost to reference Aspire.Hosting {0} or newer.', version);
 export const resourcesGroupLabel = vscode.l10n.t('Resources');
+export const commandsLabel = vscode.l10n.t('Commands');
 export const noCommandsAvailable = vscode.l10n.t('No commands available for this resource.');
 export const selectCommandPlaceholder = vscode.l10n.t('Select a command to execute');
 export const resourceCommandArgumentsTitle = (command: string) => vscode.l10n.t('Run {0}', command);

--- a/extension/src/views/AppHostDataRepository.ts
+++ b/extension/src/views/AppHostDataRepository.ts
@@ -18,6 +18,7 @@ export interface ResourceCommandJson {
     displayName?: string | null;
     description: string | null;
     visibility?: string | null;
+    state?: string | null;
     argumentInputs?: ResourceCommandArgumentInputJson[] | null;
 }
 

--- a/extension/src/views/AspireAppHostTreeProvider.ts
+++ b/extension/src/views/AspireAppHostTreeProvider.ts
@@ -25,6 +25,7 @@ import {
     resourceDescriptionHealth,
     resourceDescriptionExitCode,
     logFileLabel,
+    commandsLabel,
 } from '../loc/strings';
 import { isLinkableUrl } from '../utils/urlSchemes';
 import {
@@ -34,11 +35,12 @@ import {
     ResourceJson,
     ViewMode,
     shortenPaths,
+    ResourceCommandJson,
 } from './AppHostDataRepository';
 import { collectResourceCommandArguments, ResourceCommandArgumentValue } from './ResourceCommandArguments';
 import { createResourceCommandArgumentLoader } from './ResourceCommandArgumentsLoader';
 
-type TreeElement = AppHostItem | EndpointUrlItem | ResourcesGroupItem | ResourceItem | WorkspaceResourcesItem | HealthChecksGroupItem | HealthCheckItem | LogFileItem;
+type TreeElement = AppHostItem | EndpointUrlItem | ResourcesGroupItem | ResourceItem | WorkspaceResourcesItem | HealthChecksGroupItem | HealthCheckItem | LogFileItem | CommandsGroupItem | ResourceCommandItem;
 
 function sortResources(resources: ResourceJson[]): ResourceJson[] {
     return [...resources].sort((a, b) => {
@@ -177,6 +179,45 @@ class HealthCheckItem extends vscode.TreeItem {
             this.tooltip = description;
         }
         this.contextValue = 'healthCheck';
+    }
+}
+
+class CommandsGroupItem extends vscode.TreeItem {
+    constructor(public readonly resource: ResourceJson, public readonly resourceItem: ResourceItem, parentId: string) {
+        super(commandsLabel, vscode.TreeItemCollapsibleState.Collapsed);
+        this.id = `${parentId}:commands`;
+        this.iconPath = new vscode.ThemeIcon('terminal');
+        this.contextValue = 'commandsGroup';
+    }
+}
+
+class ResourceCommandItem extends vscode.TreeItem {
+    constructor(
+        public readonly commandName: string,
+        public readonly commandJson: ResourceCommandJson,
+        public readonly resourceItem: ResourceItem,
+        parentId: string
+    ) {
+        const label = commandJson.displayName ?? commandName;
+        super(label, vscode.TreeItemCollapsibleState.None);
+        this.id = `${parentId}:command:${commandName}`;
+        this.tooltip = commandJson.description ?? undefined;
+
+        const isEnabled = commandJson.state !== 'Disabled';
+
+        if (isEnabled) {
+            this.iconPath = new vscode.ThemeIcon('run');
+            this.contextValue = 'resourceCommand:enabled';
+            this.command = {
+                command: 'aspire-vscode.executeResourceCommandItem',
+                title: label,
+                arguments: [this]
+            };
+        } else {
+            this.iconPath = new vscode.ThemeIcon('run', new vscode.ThemeColor('disabledForeground'));
+            this.description = vscode.l10n.t('(disabled)');
+            this.contextValue = 'resourceCommand:disabled';
+        }
     }
 }
 
@@ -588,6 +629,10 @@ export class AspireAppHostTreeProvider implements vscode.TreeDataProvider<TreeEl
             return this._getHealthCheckChildren(element);
         }
 
+        if (element instanceof CommandsGroupItem) {
+            return this._getCommandChildren(element);
+        }
+
         return [];
     }
 
@@ -636,6 +681,9 @@ export class AspireAppHostTreeProvider implements vscode.TreeDataProvider<TreeEl
         if (element instanceof HealthChecksGroupItem) {
             return this._getHealthCheckChildren(element);
         }
+        if (element instanceof CommandsGroupItem) {
+            return this._getCommandChildren(element);
+        }
 
         return [];
     }
@@ -657,7 +705,22 @@ export class AspireAppHostTreeProvider implements vscode.TreeDataProvider<TreeEl
             items.push(new HealthChecksGroupItem(element.resource, element.id!));
         }
 
+        const commands = element.resource.commands;
+        if (commands && Object.keys(commands).length > 0) {
+            items.push(new CommandsGroupItem(element.resource, element, element.id!));
+        }
+
         return items;
+    }
+
+    private _getCommandChildren(element: CommandsGroupItem): TreeElement[] {
+        const commands = element.resource.commands;
+        if (!commands) {
+            return [];
+        }
+        return Object.entries(commands)
+            .sort(([a], [b]) => a.localeCompare(b))
+            .map(([name, cmd]) => new ResourceCommandItem(name, cmd, element.resourceItem, element.id!));
     }
 
     private _getHealthCheckChildren(element: HealthChecksGroupItem): TreeElement[] {
@@ -815,6 +878,22 @@ export class AspireAppHostTreeProvider implements vscode.TreeDataProvider<TreeEl
         }
 
         this._runResourceCommand(element, `"${selected.label}"`, commandArguments.args, commandArguments.containsSecret);
+    }
+
+    async executeResourceCommandItem(element: ResourceCommandItem): Promise<void> {
+        const commandName = element.commandName;
+        const command = element.commandJson;
+        const resourceItem = element.resourceItem;
+
+        const commandArguments = await collectResourceCommandArguments(commandName, command, {
+            secretWarningState: this._secretWarningState,
+            loadDynamicArguments: values => this._loadResourceCommandArguments(resourceItem, commandName, values),
+        });
+        if (commandArguments === undefined) {
+            return;
+        }
+
+        this._runResourceCommand(resourceItem, `"${commandName}"`, commandArguments.args, commandArguments.containsSecret);
     }
 
     async copyAppHostPath(element: AppHostItem): Promise<void> {

--- a/src/Aspire.Cli/Backchannel/ResourceSnapshotMapper.cs
+++ b/src/Aspire.Cli/Backchannel/ResourceSnapshotMapper.cs
@@ -106,9 +106,9 @@ internal static class ResourceSnapshotMapper
             }
         }
 
-        // Only include enabled commands
+        // Include enabled and disabled commands (exclude hidden/unsupported visibility)
         var commands = snapshot.Commands
-            .Where(IsCommandAvailableToApi)
+            .Where(c => IsCommandVisibleToApi(c.Visibility))
             .OrderBy(c => c.Name)
             .ToDistinctDictionary(
                 c => c.Name,
@@ -117,6 +117,7 @@ internal static class ResourceSnapshotMapper
                     DisplayName = string.IsNullOrWhiteSpace(c.DisplayName) ? null : c.DisplayName.Trim(),
                     Description = c.Description,
                     Visibility = IsDefaultCommandVisibility(c.Visibility) ? null : c.Visibility,
+                    State = c.State,
                     ArgumentInputs = c.ArgumentInputs.Length > 0
                         ? c.ArgumentInputs.Select(MapCommandArgumentInput).ToArray()
                         : null

--- a/src/Shared/Model/Serialization/ResourceJson.cs
+++ b/src/Shared/Model/Serialization/ResourceJson.cs
@@ -237,6 +237,12 @@ internal sealed class ResourceCommandJson
     public string? Visibility { get; set; }
 
     /// <summary>
+    /// The state of the command (e.g., "Enabled", "Disabled").
+    /// </summary>
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? State { get; set; }
+
+    /// <summary>
     /// The ordered inputs that describe the invocation arguments accepted by the command.
     /// </summary>
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]

--- a/tests/Aspire.Cli.Tests/Backchannel/ResourceSnapshotMapperTests.cs
+++ b/tests/Aspire.Cli.Tests/Backchannel/ResourceSnapshotMapperTests.cs
@@ -93,11 +93,13 @@ public class ResourceSnapshotMapperTests
         Assert.Single(result.Urls!);
         Assert.Equal("http://localhost:5000", result.Urls![0].Url);
 
-        // Only enabled commands should be included
-        var command = Assert.Single(result.Commands!);
-        Assert.Equal("stop", command.Key);
-        Assert.Equal(KnownCommandVisibility.Api, command.Value.Visibility);
-        var argumentInput = Assert.Single(command.Value.ArgumentInputs!);
+        // Enabled and disabled commands with API visibility should be included
+        Assert.Equal(2, result.Commands!.Count);
+
+        var stopCommand = result.Commands["stop"];
+        Assert.Equal("Enabled", stopCommand.State);
+        Assert.Equal(KnownCommandVisibility.Api, stopCommand.Visibility);
+        var argumentInput = Assert.Single(stopCommand.ArgumentInputs!);
         Assert.Equal("selector", argumentInput.Name);
         Assert.Equal("Selector", argumentInput.Label);
         Assert.Equal("CSS selector to click.", argumentInput.Description);
@@ -112,6 +114,10 @@ public class ResourceSnapshotMapperTests
         Assert.NotNull(argumentInput.DynamicLoading);
         Assert.True(argumentInput.DynamicLoading.AlwaysLoadOnStart);
         Assert.Equal("browser", Assert.Single(argumentInput.DynamicLoading.DependsOnInputs!));
+
+        var startCommand = result.Commands["start"];
+        Assert.Equal("Disabled", startCommand.State);
+        Assert.Null(startCommand.Visibility);
 
         // Only IsFromSpec environment variables should be included
         Assert.Single(result.Environment!);


### PR DESCRIPTION
Add support for displaying resource commands (both enabled and disabled) as child items under each resource in the Aspire extension tree view.

Changes:
- Backend: Add State property to ResourceCommandJson and map all API-visible commands including disabled ones in ResourceSnapshotMapper
- Extension: Register executeResourceCommandItem command and add CommandsGroupItem/ResourceCommandItem tree elements
- Tests: Update ResourceSnapshotMapperTests to verify both enabled and disabled commands are included

## Description

Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes # (issue)

## Checklist

- Is this feature complete?
  - [ ] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [ ] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [ ] No
