### PR TITLE
Update generate-api-diffs workflow to target release/13.4

### DIFF
--- a/.github/workflows/generate-api-diffs.yml
+++ b/.github/workflows/generate-api-diffs.yml
@@ -16,7 +16,7 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
-          ref: release/13.3
+          ref: release/13.4
 
       - name: Restore and build
         run: |
@@ -40,7 +40,7 @@ jobs:
         with:
           token: ${{ steps.app-token.outputs.token }}
           branch: update-api-diffs
-          base: release/13.3
+          base: release/13.4
           labels: |
             NO-MERGE
           title: "[Automated] Update API Surface Area"


### PR DESCRIPTION
The `generate-api-diffs` workflow was still hardcoded to `release/13.3` (the previous release), so the daily run hasn't produced any meaningful diff against the current release branch since #16602 was merged.

Update both the checkout `ref` and the PR `base` to `release/13.4`.

## Verification
- `release/13.4` branch exists.
- `net8.0` is still the `DefaultTargetFramework` on `release/13.4`, so the `-f net8.0` build step does not need a change.

## Follow-up worth considering
This workflow has to be hand-edited every release. We could parameterize the target branch (workflow input + repo variable, or dynamic discovery of the latest `release/*` branch) so it's not missed next time. Happy to do that in a follow-up PR if you want.