### PR TITLE
Fix TypeScript deadlock repro E2E test

### DIFF
--- a/tests/Aspire.Cli.EndToEnd.Tests/TypeScriptEmptyAppHostTemplateTests.cs
+++ b/tests/Aspire.Cli.EndToEnd.Tests/TypeScriptEmptyAppHostTemplateTests.cs
@@ -59,57 +59,24 @@ public sealed class TypeScriptEmptyAppHostTemplateTests(ITestOutputHelper output
         var workspace = TemporaryWorkspace.Create(output);
 
         using var terminal = CliE2ETestHelpers.CreateDockerTestTerminal(repoRoot, strategy, output, mountDockerSocket: true, workspace: workspace);
-
-        var pendingRun = terminal.RunAsync(TestContext.Current.CancellationToken);
-
         var counter = new SequenceCounter();
         var auto = new Hex1bTerminalAutomator(terminal, defaultTimeout: TimeSpan.FromSeconds(500));
-        var testBodyFailed = false;
+        await using var terminalRun = CliE2ETestHelpers.StartRun(terminal, workspace, auto, counter, output, TestContext.Current.CancellationToken);
 
-        try
-        {
-            await auto.PrepareDockerEnvironmentAsync(counter, workspace, enableDcpDiagnostics: true);
-            await auto.InstallAspireCliAsync(strategy, counter);
+        await auto.PrepareDockerEnvironmentAsync(counter, workspace, enableDcpDiagnostics: true);
+        await auto.InstallAspireCliAsync(strategy, counter);
 
-            await auto.AspireNewTypeScriptEmptyAppHostAsync("TsDeadlockRepro", counter);
+        await auto.AspireNewTypeScriptEmptyAppHostAsync("TsDeadlockRepro", counter);
 
-            var appDirectory = Path.Combine(workspace.WorkspaceRoot.FullName, "TsDeadlockRepro");
-            WriteDeadlockReproFiles(appDirectory);
+        var appDirectory = Path.Combine(workspace.WorkspaceRoot.FullName, "TsDeadlockRepro");
+        WriteDeadlockReproFiles(appDirectory);
 
-            await auto.RunCommandFailFastAsync("cd TsDeadlockRepro", counter);
-            await auto.RunCommandFailFastAsync("aspire restore --non-interactive", counter, TimeSpan.FromMinutes(3));
-            await auto.RunCommandFailFastAsync("npm run build", counter, TimeSpan.FromMinutes(2));
+        await auto.RunCommandAsync("cd TsDeadlockRepro", counter);
+        await auto.RunCommandAsync("aspire restore --non-interactive", counter, TimeSpan.FromMinutes(3));
+        await auto.RunCommandAsync("npm run build", counter, TimeSpan.FromMinutes(2));
 
-            await auto.AspireStartAsync(counter, startTimeout: TimeSpan.FromMinutes(2));
-            await auto.AspireStopAsync(counter);
-        }
-        catch
-        {
-            testBodyFailed = true;
-            throw;
-        }
-        finally
-        {
-            try
-            {
-                await auto.CaptureAspireDiagnosticsAsync(counter, workspace);
-            }
-            catch { } // Best effort
-
-            try
-            {
-                await auto.TypeAsync("exit");
-                await auto.EnterAsync();
-                await pendingRun;
-            }
-            catch
-            {
-                if (!testBodyFailed)
-                {
-                    throw;
-                }
-            }
-        }
+        await auto.AspireStartAsync(counter, startTimeout: TimeSpan.FromMinutes(2));
+        await auto.AspireStopAsync(counter);
     }
 
     private static void WriteDeadlockReproFiles(string appDirectory)


### PR DESCRIPTION
## Summary

Refactors `TypeScriptAppHostRunDoesNotDeadlockWhenLazyOptionsInvokeAsyncCallback` (added in #17575) to use the `TerminalRun` pattern via `CliE2ETestHelpers.StartRun`, replacing the manual `pendingRun` / `testBodyFailed` / try-catch-finally cleanup block.

## Changes

- Replaced manual `terminal.RunAsync` + try/catch/finally with `await using var terminalRun = CliE2ETestHelpers.StartRun(...)` which handles diagnostics capture, terminal exit, and awaiting the run automatically via `DisposeAsync`.
- Replaced `RunCommandFailFastAsync` (which doesn't exist) with `RunCommandAsync` to fix compilation.
- Test logic is unchanged — only the lifecycle/cleanup boilerplate is removed.

This makes the test consistent with all other CLI E2E tests in the project.

Fixes https://github.com/microsoft/aspire/issues/17684