### PR TITLE
Fix CLI E2E command helper calls

### DIFF
--- a/tests/Aspire.Cli.EndToEnd.Tests/TypeScriptEmptyAppHostTemplateTests.cs
+++ b/tests/Aspire.Cli.EndToEnd.Tests/TypeScriptEmptyAppHostTemplateTests.cs
@@ -76,9 +76,9 @@ public sealed class TypeScriptEmptyAppHostTemplateTests(ITestOutputHelper output
             var appDirectory = Path.Combine(workspace.WorkspaceRoot.FullName, "TsDeadlockRepro");
             WriteDeadlockReproFiles(appDirectory);
 
-            await auto.RunCommandFailFastAsync("cd TsDeadlockRepro", counter);
-            await auto.RunCommandFailFastAsync("aspire restore --non-interactive", counter, TimeSpan.FromMinutes(3));
-            await auto.RunCommandFailFastAsync("npm run build", counter, TimeSpan.FromMinutes(2));
+            await auto.RunCommandAsync("cd TsDeadlockRepro", counter);
+            await auto.RunCommandAsync("aspire restore --non-interactive", counter, TimeSpan.FromMinutes(3));
+            await auto.RunCommandAsync("npm run build", counter, TimeSpan.FromMinutes(2));
 
             await auto.AspireStartAsync(counter, startTimeout: TimeSpan.FromMinutes(2));
             await auto.AspireStopAsync(counter);


### PR DESCRIPTION
## Description

`TypeScriptAppHostRunDoesNotDeadlockWhenLazyOptionsInvokeAsyncCallback` was calling `RunCommandFailFastAsync`, which does not exist and caused the CLI E2E test project to fail at build time. This replaces those calls with `RunCommandAsync`, the existing helper that already waits for `WaitForSuccessPromptAsync` and fails fast when an error prompt appears.

Validation:
- `./restore.sh`
- `MSBUILDTERMINALLOGGER=false dotnet build tests/Aspire.Cli.EndToEnd.Tests/Aspire.Cli.EndToEnd.Tests.csproj --no-restore /p:SkipNativeBuild=true`

Fixes # (issue)

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [x] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No