### PR TITLE
Add == and != operators to numeric filter dropdown

### DIFF
--- a/src/Aspire.Dashboard/Components/Dialogs/FilterDialog.razor.cs
+++ b/src/Aspire.Dashboard/Components/Dialogs/FilterDialog.razor.cs
@@ -48,6 +48,8 @@ public partial class FilterDialog
 
         _numericFilterConditions =
         [
+            CreateFilterSelectViewModel(FilterCondition.Equals),
+            CreateFilterSelectViewModel(FilterCondition.NotEqual),
             CreateFilterSelectViewModel(FilterCondition.GreaterThanOrEqual),
             CreateFilterSelectViewModel(FilterCondition.GreaterThan),
             CreateFilterSelectViewModel(FilterCondition.LessThanOrEqual),

--- a/tests/Aspire.Dashboard.Components.Tests/Dialogs/FilterDialogTests.cs
+++ b/tests/Aspire.Dashboard.Components.Tests/Dialogs/FilterDialogTests.cs
@@ -33,6 +33,8 @@ public class FilterDialogTests : DashboardTestContext
 
         var conditionSelect = Assert.Single(cut.FindComponents<FluentSelect<SelectViewModel<FilterCondition>>>());
         Assert.Collection(conditionSelect.Instance.Items!,
+            item => Assert.Equal(FilterCondition.Equals, item.Id),
+            item => Assert.Equal(FilterCondition.NotEqual, item.Id),
             item => Assert.Equal(FilterCondition.GreaterThanOrEqual, item.Id),
             item => Assert.Equal(FilterCondition.GreaterThan, item.Id),
             item => Assert.Equal(FilterCondition.LessThanOrEqual, item.Id),


### PR DESCRIPTION
The Dashboard's FilterDialog was missing Equals and NotEqual conditions in the numeric filter dropdown (used for Duration filtering). The backend already supported these conditions in both TelemetryRepository.DurationFilter and TraceDetail.DurationFilter, but the UI never offered them.

Fixes #17692

Traces:
<img width="2465" height="761" alt="image" src="https://github.com/user-attachments/assets/33e340fc-707a-4f46-b3ed-fa43df7efb1d" />

Trace detail:
<img width="2446" height="728" alt="image" src="https://github.com/user-attachments/assets/5603dde0-ca10-431b-a467-e2cb96166931" />

