### PR TITLE
Spec: Custom Resource Lifecycle Model

### DIFF
--- a/docs/specs/appmodel.md
+++ b/docs/specs/appmodel.md
@@ -68,9 +68,9 @@ graph LR
 - [API Patterns](#api-patterns)
 - [Custom Resource Lifecycle Model](#custom-resource-lifecycle-model)
   - [ResourceContext](#resourcecontext)
-  - [The OnLifecycle hook](#the-onlifecycle-hook)
+  - [The OnInitializeResource overload](#the-oninitializeresource-overload)
   - [Builder Helpers](#builder-helpers)
-  - [What the Framework Handles Around OnLifecycle](#what-the-framework-handles-around-onlifecycle)
+  - [What the Framework Handles Around OnInitializeResource](#what-the-framework-handles-around-oninitializeresource)
   - [Patterns](#patterns)
   - [Start/Stop/Restart Routing](#startstoprestart-routing)
   - [Targeted Snapshot Updates](#targeted-snapshot-updates)
@@ -1184,7 +1184,7 @@ Custom resources that don't derive from built-in types (Container, Project, Exec
 The custom resource lifecycle model has two ideas, applied consistently:
 
 1. **Targeted updates** — each producer (DCP, orchestrator, user code) updates only its slice of the resource snapshot, never clobbering other producers' data.
-2. **One lifecycle hook, framework-managed ceremony** — authors implement a single `OnLifecycle` hook. The framework fires lifecycle events, sets timestamps, wires Start/Stop/Restart commands, and handles cleanup around it. The author owns whatever logic runs inside.
+2. **One lifecycle hook, framework-managed ceremony** — authors implement a single `OnInitializeResource` overload. The framework fires lifecycle events, sets timestamps, wires Start/Stop/Restart commands, and handles cleanup around it. The author owns whatever logic runs inside.
 
 See [`docs/specs/custom-resource-lifecycle.md`](custom-resource-lifecycle.md) for the full proposal including layering, migration, and open questions.
 
@@ -1232,20 +1232,27 @@ public class ResourceContext
 }
 ```
 
-### The OnLifecycle hook
+### The OnInitializeResource overload
 
-A custom resource that wants to participate in the dashboard lifecycle implements **one** hook:
+`OnInitializeResource` already exists with a callback that receives an `InitializeResourceEvent` and requires the author to manage everything (events, state, timestamps, the loop). This proposal adds a **new overload** that takes a `ResourceContext` instead — when this overload is used, the framework owns the surrounding ceremony.
 
 ```csharp
-public static IResourceBuilder<T> OnLifecycle<T>(
+// Existing overload (unchanged) — author owns everything.
+public static IResourceBuilder<T> OnInitializeResource<T>(
+    this IResourceBuilder<T> builder,
+    Func<T, InitializeResourceEvent, CancellationToken, Task> callback)
+    where T : IResource;
+
+// New overload — framework owns ceremony around the callback.
+public static IResourceBuilder<T> OnInitializeResource<T>(
     this IResourceBuilder<T> builder,
     Func<ResourceContext, CancellationToken, Task> lifecycle)
     where T : IResource;
 ```
 
-The framework calls the callback when the resource should start (auto-start at app startup, or in response to a Start/Restart command). The cancellation token is cancelled when the resource should stop. The callback observes the token and returns promptly.
+The framework calls the new overload's callback when the resource should start (auto-start at app startup, or in response to a Start/Restart command). The cancellation token is cancelled when the resource should stop. The callback observes the token and returns promptly.
 
-There is no separate `WithInterval`, `BoundTo`, `RunAsync`, or `OnStarted` primitive. Whatever pattern the resource needs — a periodic loop, an event subscription, a streaming consumer, a one-shot probe — is just code inside the callback. Convenience extensions (`WithInterval`, etc.) can be layered on top, but they expand to ordinary `OnLifecycle` bodies and aren't part of the framework contract.
+There is no separate `WithInterval`, `BoundTo`, `RunAsync`, or `OnStarted` primitive. Whatever pattern the resource needs — a periodic loop, an event subscription, a streaming consumer, a one-shot probe — is just code inside the callback. Convenience extensions (`WithInterval`, etc.) can be layered on top, but they expand to ordinary `OnInitializeResource` bodies and aren't part of the framework contract.
 
 ### Builder helpers
 
@@ -1260,7 +1267,7 @@ builder.AddResource(myResource)
 // WithInitialState remains for backward compatibility but is [Obsolete(false)].
 ```
 
-### What the framework handles around OnLifecycle
+### What the framework handles around OnInitializeResource
 
 | Concern | Framework behavior |
 |---------|-------------------|
@@ -1281,14 +1288,14 @@ Resources that don't have a meaningful runtime lifecycle (e.g. `ParameterResourc
 
 ### Patterns
 
-All four common patterns are just different bodies of the same `OnLifecycle` hook.
+All four common patterns are just different bodies of the same `OnInitializeResource` overload.
 
 #### Periodic (TalkingClock)
 
 ```csharp
 builder.AddResource(new TalkingClockResource("clock"))
     .WithResourceType("TalkingClock")
-    .OnLifecycle(async (ctx, ct) =>
+    .OnInitializeResource(async (ctx, ct) =>
     {
         await ctx.SetStateAsync(KnownResourceStates.Running, ct);
         long tick = 0;
@@ -1307,7 +1314,7 @@ builder.AddResource(new TalkingClockResource("clock"))
 When a resource's lifecycle follows another resource, the author waits for the source resource's state inside the callback. No new primitive needed:
 
 ```csharp
-portBuilder.OnLifecycle(async (ctx, ct) =>
+portBuilder.OnInitializeResource(async (ctx, ct) =>
 {
     await ctx.Notifications.WaitForResourceHealthyAsync(tunnel.Resource.Name, ct);
 
@@ -1325,7 +1332,7 @@ portBuilder.OnLifecycle(async (ctx, ct) =>
 
 ```csharp
 builder.AddResource(new KafkaMonitorResource("kafka-monitor"))
-    .OnLifecycle(async (ctx, ct) =>
+    .OnInitializeResource(async (ctx, ct) =>
     {
         var consumer = new KafkaConsumer(ctx.Get<KafkaConfig>().BootstrapServers);
         ctx.Track(consumer);
@@ -1344,7 +1351,7 @@ builder.AddResource(new KafkaMonitorResource("kafka-monitor"))
 builder.AddResource(new ExternalApiResource("payments-api"))
     .WithResourceType("ExternalAPI")
     .WithUrl("https://api.payments.com", "API")
-    .OnLifecycle(async (ctx, ct) =>
+    .OnInitializeResource(async (ctx, ct) =>
     {
         var client = new HttpClient();
         ctx.Track(client);
@@ -1361,8 +1368,8 @@ For ongoing health, use `WithHealthCheck` rather than overloading `State` with `
 
 Today, Start/Stop/Restart commands route directly to DCP and don't work for custom resources. With the lifecycle model, the orchestrator gains a custom resource path:
 
-- **Stop**: cancels the resource's `CancellationTokenSource`; the `OnLifecycle` callback observes cancellation and returns; the framework disposes tracked disposables and sets the terminal state.
-- **Start**: creates a new CTS and re-invokes the `OnLifecycle` callback; framework fires `BeforeResourceStartedEvent`, sets `Starting`, sets `StartTimeStamp`.
+- **Stop**: cancels the resource's `CancellationTokenSource`; the `OnInitializeResource` callback observes cancellation and returns; the framework disposes tracked disposables and sets the terminal state.
+- **Start**: creates a new CTS and re-invokes the `OnInitializeResource` callback; framework fires `BeforeResourceStartedEvent`, sets `Starting`, sets `StartTimeStamp`.
 - **Restart**: stop, then start.
 
 ### Targeted snapshot updates
@@ -1617,13 +1624,13 @@ public static class TalkingClockExtensions
         var clockResource = new TalkingClockResource(name, tickHandResource, tockHandResource);
 
         // The framework handles: lifecycle events, timestamps,
-        // Start/Stop/Restart commands, and WaitFor support around OnLifecycle.
+        // Start/Stop/Restart commands, and WaitFor support around OnInitializeResource.
         var clockBuilder = builder.AddResource(clockResource)
             .ExcludeFromManifest()
             .WithUrl("https://www.speaking-clock.com/", "Speaking Clock")
             .WithResourceType("TalkingClock")
             .WithProperty(CustomResourceKnownProperties.Source, "Talking Clock")
-            .OnLifecycle(async (ctx, ct) =>
+            .OnInitializeResource(async (ctx, ct) =>
             {
                 await ctx.SetStateAsync(KnownResourceStates.Running, ct);
                 long tick = 0;
@@ -1638,7 +1645,7 @@ public static class TalkingClockExtensions
             });
 
         // Child resources follow the parent clock's lifecycle by waiting on it
-        // inside their own OnLifecycle hook.
+        // inside their own OnInitializeResource overload.
         AddHandResource(tickHandResource, "tick");
         AddHandResource(tockHandResource, "tock");
 
@@ -1650,7 +1657,7 @@ public static class TalkingClockExtensions
                 .WithParentRelationship(clockBuilder)
                 .WithResourceType("ClockHand")
                 .WithProperty(CustomResourceKnownProperties.Source, "Talking Clock")
-                .OnLifecycle(async (ctx, ct) =>
+                .OnInitializeResource(async (ctx, ct) =>
                 {
                     await ctx.Notifications.WaitForResourceHealthyAsync(clockResource.Name, ct);
 

--- a/docs/specs/appmodel.md
+++ b/docs/specs/appmodel.md
@@ -1204,6 +1204,12 @@ public class ResourceContext
     /// The host service provider.
     public IServiceProvider Services { get; }
 
+    /// The resource notification service. Exposed directly for convenience.
+    public ResourceNotificationService Notifications { get; }
+
+    /// The distributed application eventing service. Exposed directly for convenience.
+    public IDistributedApplicationEventing Eventing { get; }
+
     /// Updates the resource state shown in the dashboard.
     public Task SetStateAsync(ResourceStateSnapshot state, CancellationToken ct = default);
     public Task SetStateAsync(string state, CancellationToken ct = default);
@@ -1303,16 +1309,14 @@ When a resource's lifecycle follows another resource, the author waits for the s
 ```csharp
 portBuilder.OnLifecycle(async (ctx, ct) =>
 {
-    var notifications = ctx.Services.GetRequiredService<ResourceNotificationService>();
-
-    await notifications.WaitForResourceHealthyAsync(tunnel.Resource.Name, ct);
+    await ctx.Notifications.WaitForResourceHealthyAsync(tunnel.Resource.Name, ct);
 
     // Port-specific setup...
     await ctx.SetStateAsync(KnownResourceStates.Running, ct);
 
     // Wait for parent to stop, then return. If the parent restarts,
     // the framework's restart logic re-invokes this callback.
-    await notifications.WaitForResourceAsync(tunnel.Resource.Name,
+    await ctx.Notifications.WaitForResourceAsync(tunnel.Resource.Name,
         [KnownResourceStates.Finished, KnownResourceStates.Exited], ct);
 });
 ```
@@ -1648,8 +1652,7 @@ public static class TalkingClockExtensions
                 .WithProperty(CustomResourceKnownProperties.Source, "Talking Clock")
                 .OnLifecycle(async (ctx, ct) =>
                 {
-                    var notifications = ctx.Services.GetRequiredService<ResourceNotificationService>();
-                    await notifications.WaitForResourceHealthyAsync(clockResource.Name, ct);
+                    await ctx.Notifications.WaitForResourceHealthyAsync(clockResource.Name, ct);
 
                     await ctx.SetStateAsync(KnownResourceStates.Running, ct);
                     long tick = 0;

--- a/docs/specs/appmodel.md
+++ b/docs/specs/appmodel.md
@@ -68,11 +68,10 @@ graph LR
 - [API Patterns](#api-patterns)
 - [Custom Resource Lifecycle Model](#custom-resource-lifecycle-model)
   - [ResourceContext](#resourcecontext)
-  - [Lifecycle Primitives](#lifecycle-primitives)
+  - [The OnLifecycle hook](#the-onlifecycle-hook)
   - [Builder Helpers](#builder-helpers)
-  - [What the Framework Handles Automatically](#what-the-framework-handles-automatically)
-  - [Composition Rules](#composition-rules)
-  - [Error Handling](#error-handling-1)
+  - [What the Framework Handles Around OnLifecycle](#what-the-framework-handles-around-onlifecycle)
+  - [Patterns](#patterns)
   - [Start/Stop/Restart Routing](#startstoprestart-routing)
   - [Targeted Snapshot Updates](#targeted-snapshot-updates)
 - [Full Examples](#full-examples)
@@ -1182,15 +1181,16 @@ public virtual void WriteToManifest(ManifestPublishingContext context)
 
 Custom resources that don't derive from built-in types (Container, Project, Executable) need a way to participate in the Aspire lifecycle — appearing in the dashboard, reporting state, exposing URLs, and supporting Start/Stop/Restart commands — without manually wiring all the plumbing that built-in resources get for free.
 
-The custom resource lifecycle model is built on three principles inspired by UI frameworks:
+The custom resource lifecycle model has two ideas, applied consistently:
 
-1. **Targeted updates** — each producer updates only its slice of the resource snapshot, never clobbering other producers' data.
-2. **Framework-owned lifecycle** — the framework manages the state machine, fires events, sets timestamps, and wires commands.
-3. **Reactive triggers** — resource authors declare *what drives their resource* (a timer, another resource, a stream) and provide callbacks. The framework manages when those callbacks fire.
+1. **Targeted updates** — each producer (DCP, orchestrator, user code) updates only its slice of the resource snapshot, never clobbering other producers' data.
+2. **One lifecycle hook, framework-managed ceremony** — authors implement a single `OnLifecycle` hook. The framework fires lifecycle events, sets timestamps, wires Start/Stop/Restart commands, and handles cleanup around it. The author owns whatever logic runs inside.
+
+See [`docs/specs/custom-resource-lifecycle.md`](custom-resource-lifecycle.md) for the full proposal including layering, migration, and open questions.
 
 ### ResourceContext
 
-`ResourceContext` is the primary API surface for custom resource authors to update dashboard state. It provides targeted methods for each aspect of the resource snapshot.
+`ResourceContext` is the primary API surface for custom resource authors to update dashboard state. It provides targeted methods for each aspect of the resource snapshot — no more `with` expressions over `CustomResourceSnapshot`.
 
 ```csharp
 public class ResourceContext
@@ -1205,17 +1205,17 @@ public class ResourceContext
     public IServiceProvider Services { get; }
 
     /// Updates the resource state shown in the dashboard.
-    public Task SetStateAsync(ResourceStateSnapshot state);
-    public Task SetStateAsync(string state);
+    public Task SetStateAsync(ResourceStateSnapshot state, CancellationToken ct = default);
+    public Task SetStateAsync(string state, CancellationToken ct = default);
 
     /// Sets a property shown in the resource details panel.
-    public Task SetPropertyAsync(string name, object? value, bool isSensitive = false);
+    public Task SetPropertyAsync(string name, object? value, bool isSensitive = false, CancellationToken ct = default);
 
     /// Adds or updates a URL shown in the dashboard.
-    public Task AddUrlAsync(UrlSnapshot url);
+    public Task AddUrlAsync(UrlSnapshot url, CancellationToken ct = default);
 
     /// Removes a URL by name.
-    public Task RemoveUrlAsync(string urlName);
+    public Task RemoveUrlAsync(string urlName, CancellationToken ct = default);
 
     /// Tracks a disposable that will be disposed when the resource stops.
     public void Track(IAsyncDisposable disposable);
@@ -1226,145 +1226,139 @@ public class ResourceContext
 }
 ```
 
-### Lifecycle primitives
+### The OnLifecycle hook
 
-Every custom resource is driven by one of four things:
-
-| Driver | Primitive | When to use |
-|--------|-----------|-------------|
-| Time | `WithInterval(period, onTick)` | Periodic polling, status refresh |
-| Another resource | `BoundTo(source)` | Port follows tunnel, sidecar follows container |
-| External stream | `RunAsync(execute)` | Streaming connections, subprocess management |
-| One-shot | `OnStarted(callback)` | Setup-and-done resources, external services |
-
-All four share the same `ResourceContext` for state updates.
-
-#### `WithInterval` — framework-owned timer
-
-The framework starts the timer when the resource starts and stops it on stop. No `while` loop needed.
+A custom resource that wants to participate in the dashboard lifecycle implements **one** hook:
 
 ```csharp
-builder.AddResource(new TalkingClockResource("clock"))
-    .WithResourceType("TalkingClock")
-    .WithProperty(CustomResourceKnownProperties.Source, "Talking Clock")
-    .WithInterval(TimeSpan.FromSeconds(1), async (ctx, tick) =>
-    {
-        await ctx.SetStateAsync(tick % 2 == 0
-            ? new ResourceStateSnapshot("Tick", KnownResourceStateStyles.Success)
-            : new ResourceStateSnapshot("Tock", KnownResourceStateStyles.Success));
-    });
+public static IResourceBuilder<T> OnLifecycle<T>(
+    this IResourceBuilder<T> builder,
+    Func<ResourceContext, CancellationToken, Task> lifecycle)
+    where T : IResource;
 ```
 
-#### `BoundTo` — lifecycle follows another resource
+The framework calls the callback when the resource should start (auto-start at app startup, or in response to a Start/Restart command). The cancellation token is cancelled when the resource should stop. The callback observes the token and returns promptly.
 
-Binds this resource's lifecycle to another. The framework automatically starts this resource when the source becomes ready, stops it when the source stops, and restarts it when the source restarts.
-
-```csharp
-// A tunnel port whose lifecycle follows the parent tunnel.
-portBuilder
-    .BoundTo(tunnelBuilder)
-    .OnStarted(async ctx =>
-    {
-        // Framework already fired BeforeResourceStartedEvent, set Starting, set timestamps.
-        // Just do the port-specific setup:
-        var port = (DevTunnelPortResource)ctx.Resource;
-        port.TunnelEndpointAnnotation.AllocatedEndpoint =
-            new(port.TunnelEndpointAnnotation, tunnelPortUri.Host, 443);
-        // Framework auto-resolves URLs from annotations.
-    });
-    // On source stop: framework sets Stopped, StopTimeStamp,
-    // marks URLs inactive, fires ResourceStoppedEvent.
-```
-
-#### `RunAsync` — escape hatch for streaming/subprocess patterns
-
-The author owns the loop. The framework still handles lifecycle, commands, events, and timestamps.
-
-```csharp
-builder.AddResource(new KafkaMonitorResource("kafka-monitor"))
-    .WithResourceType("KafkaMonitor")
-    .RunAsync(async (ctx, stoppingToken) =>
-    {
-        var consumer = new KafkaConsumer(ctx.Get<KafkaConfig>().BootstrapServers);
-        ctx.Track(consumer);
-        await foreach (var msg in consumer.ConsumeAsync(stoppingToken))
-        {
-            await ctx.SetPropertyAsync("last-offset", msg.Offset);
-        }
-    });
-```
-
-#### `OnStarted` / `OnStopping` — one-shot setup and cleanup
-
-```csharp
-builder.AddResource(new ExternalApiResource("payments-api"))
-    .WithResourceType("ExternalAPI")
-    .WithUrl("https://api.payments.com", "API")
-    .OnStarted(async ctx =>
-    {
-        var client = new HttpClient();
-        ctx.Track(client);
-        var response = await client.GetAsync("https://api.payments.com/health");
-        await ctx.SetStateAsync(response.IsSuccessStatusCode ? "Healthy" : "Degraded");
-    });
-```
+There is no separate `WithInterval`, `BoundTo`, `RunAsync`, or `OnStarted` primitive. Whatever pattern the resource needs — a periodic loop, an event subscription, a streaming consumer, a one-shot probe — is just code inside the callback. Convenience extensions (`WithInterval`, etc.) can be layered on top, but they expand to ordinary `OnLifecycle` bodies and aren't part of the framework contract.
 
 ### Builder helpers
 
 Registration-time helpers that replace the need to construct a full `CustomResourceSnapshot`:
 
 ```csharp
-/// Sets the resource type shown in the dashboard Type column.
 builder.AddResource(myResource)
     .WithResourceType("MyResourceType")
     .WithProperty(CustomResourceKnownProperties.Source, "my-source")
     .WithProperty("Version", "1.0");
 
-// WithInitialState remains for backward compatibility but is no longer recommended.
+// WithInitialState remains for backward compatibility but is [Obsolete(false)].
 ```
 
-### What the framework handles automatically
+### What the framework handles around OnLifecycle
 
-For all lifecycle primitives, the framework provides:
+| Concern | Framework behavior |
+|---------|-------------------|
+| Registration | Sets `CreationTimeStamp` and initial `State = NotStarted`. |
+| Start | Fires `BeforeResourceStartedEvent`, transitions to `Starting`, sets `StartTimeStamp`, then invokes the callback. |
+| Stop / Restart commands | Wires Start/Stop/Restart dashboard commands. Stop cancels the token; Restart does stop-then-start. |
+| URL resolution | Auto-resolves `ResourceUrlAnnotation`s into `UrlSnapshot`s on start. |
+| URL active state | Marks URLs active on start, inactive on stop. |
+| `WaitFor` support | Works automatically because `BeforeResourceStartedEvent` fires at the right time. |
+| Normal return | If the author hasn't already set a terminal state, framework sets `State = Finished`, `StopTimeStamp`, fires `ResourceStoppedEvent`. |
+| Cancellation | Same as normal return, plus the framework swallows `OperationCanceledException` from the cancellation token. |
+| Exception | State → `FailedToStart` if `Running` was never reached, else `Exited`. Either way, `StopTimeStamp` is set and `ResourceStoppedEvent` fires. Resource remains restartable. |
+| Cleanup | Disposables tracked via `ctx.Track(...)` are disposed in reverse order after the callback returns or throws. |
 
-| Concern | What the framework does |
-|---------|------------------------|
-| State machine | Manages NotStarted → Starting → Running → Stopping → Stopped transitions |
-| Timestamps | Sets `CreationTimeStamp` at registration, `StartTimeStamp` on start, `StopTimeStamp` on stop |
-| Lifecycle events | Fires `BeforeResourceStartedEvent` before callbacks; `ResourceStoppedEvent` on stop |
-| Dashboard commands | Wires Start/Stop/Restart commands automatically |
-| URL resolution | Auto-resolves `ResourceUrlAnnotation`s into `UrlSnapshot`s |
-| URL active state | Marks URLs inactive on stop, active on start |
-| `WaitFor` support | Works automatically because `BeforeResourceStartedEvent` fires at the right time |
-| Error handling | Callback throws → state = FailedToStart, logged, restartable from dashboard |
-| Cleanup | All tracked disposables (`ctx.Track(...)`) are disposed on stop |
+The author is responsible for transitioning to `Running` (or another live state) when their resource is actually ready, because only the author knows when that is.
 
-### Composition rules
+Resources that don't have a meaningful runtime lifecycle (e.g. `ParameterResource`) implement `IResourceWithoutLifecycle`. They are skipped by the framework's start/stop machinery and don't get Start/Stop/Restart commands.
 
-| Combination | Behavior |
-|-------------|----------|
-| Multiple `WithInterval` | All timers run independently |
-| `WithInterval` + `OnStarted` | `OnStarted` fires first, then timers start |
-| `BoundTo` + `OnStarted` | `OnStarted` fires when the source becomes ready |
-| `RunAsync` | Exclusive — cannot combine with `WithInterval` or `BoundTo` |
-| Multiple `OnStarted` | All fire in registration order |
-| Multiple `OnStopping` | All fire in reverse registration order |
+### Patterns
 
-### Error handling
+All four common patterns are just different bodies of the same `OnLifecycle` hook.
 
-| Scenario | Behavior |
-|----------|----------|
-| `OnStarted` throws | State → FailedToStart, error logged, restartable |
-| `WithInterval` tick throws | Error logged, tick skipped, timer continues |
-| `RunAsync` throws (not `OperationCanceledException`) | State → FailedToStart, error logged, restartable |
-| `OnStopping` throws | Error logged, stop proceeds anyway |
+#### Periodic (TalkingClock)
+
+```csharp
+builder.AddResource(new TalkingClockResource("clock"))
+    .WithResourceType("TalkingClock")
+    .OnLifecycle(async (ctx, ct) =>
+    {
+        await ctx.SetStateAsync(KnownResourceStates.Running, ct);
+        long tick = 0;
+        while (!ct.IsCancellationRequested)
+        {
+            await ctx.SetStateAsync(tick++ % 2 == 0
+                ? new ResourceStateSnapshot("Tick", KnownResourceStateStyles.Success)
+                : new ResourceStateSnapshot("Tock", KnownResourceStateStyles.Success), ct);
+            await Task.Delay(TimeSpan.FromSeconds(1), ct);
+        }
+    });
+```
+
+#### Bound to another resource (DevTunnelPort)
+
+When a resource's lifecycle follows another resource, the author waits for the source resource's state inside the callback. No new primitive needed:
+
+```csharp
+portBuilder.OnLifecycle(async (ctx, ct) =>
+{
+    var notifications = ctx.Services.GetRequiredService<ResourceNotificationService>();
+
+    await notifications.WaitForResourceHealthyAsync(tunnel.Resource.Name, ct);
+
+    // Port-specific setup...
+    await ctx.SetStateAsync(KnownResourceStates.Running, ct);
+
+    // Wait for parent to stop, then return. If the parent restarts,
+    // the framework's restart logic re-invokes this callback.
+    await notifications.WaitForResourceAsync(tunnel.Resource.Name,
+        [KnownResourceStates.Finished, KnownResourceStates.Exited], ct);
+});
+```
+
+#### Streaming / long-running loop (Kafka monitor)
+
+```csharp
+builder.AddResource(new KafkaMonitorResource("kafka-monitor"))
+    .OnLifecycle(async (ctx, ct) =>
+    {
+        var consumer = new KafkaConsumer(ctx.Get<KafkaConfig>().BootstrapServers);
+        ctx.Track(consumer);
+
+        await ctx.SetStateAsync(KnownResourceStates.Running, ct);
+        await foreach (var msg in consumer.ConsumeAsync(ct))
+        {
+            await ctx.SetPropertyAsync("last-offset", msg.Offset, ct: ct);
+        }
+    });
+```
+
+#### One-shot setup (external service)
+
+```csharp
+builder.AddResource(new ExternalApiResource("payments-api"))
+    .WithResourceType("ExternalAPI")
+    .WithUrl("https://api.payments.com", "API")
+    .OnLifecycle(async (ctx, ct) =>
+    {
+        var client = new HttpClient();
+        ctx.Track(client);
+        await client.GetAsync("https://api.payments.com/health", ct);
+
+        await ctx.SetStateAsync(KnownResourceStates.Running, ct);
+        await Task.Delay(Timeout.Infinite, ct);  // stay alive until shutdown
+    });
+```
+
+For ongoing health, use `WithHealthCheck` rather than overloading `State` with `Healthy`/`Degraded`.
 
 ### Start/Stop/Restart routing
 
 Today, Start/Stop/Restart commands route directly to DCP and don't work for custom resources. With the lifecycle model, the orchestrator gains a custom resource path:
 
-- **Stop**: cancels the resource's `CancellationTokenSource` → intervals stop, `RunAsync` token cancelled, `BoundTo` unsubscribes, `OnStopping` fires → framework sets Stopped state.
-- **Start**: creates new CTS, invokes lifecycle callbacks → framework sets Starting → Running.
+- **Stop**: cancels the resource's `CancellationTokenSource`; the `OnLifecycle` callback observes cancellation and returns; the framework disposes tracked disposables and sets the terminal state.
+- **Start**: creates a new CTS and re-invokes the `OnLifecycle` callback; framework fires `BeforeResourceStartedEvent`, sets `Starting`, sets `StartTimeStamp`.
 - **Restart**: stop, then start.
 
 ### Targeted snapshot updates
@@ -1382,6 +1376,7 @@ await ctx.AddUrlAsync(new UrlSnapshot("my-link", "http://example.com", false));
 ```
 
 This eliminates the "snapshot clobbering" problem where DCP's `ResourceSnapshotBuilder.ToSnapshot` would replace entire collections (`Urls`, `EnvironmentVariables`, `Volumes`, `Relationships`) on every watch event, silently discarding user-added data.
+
 
 ---
 
@@ -1617,23 +1612,29 @@ public static class TalkingClockExtensions
         var tockHandResource = new ClockHandResource(name + "-tock-hand");
         var clockResource = new TalkingClockResource(name, tickHandResource, tockHandResource);
 
-        // The framework handles: state machine, timestamps, lifecycle events,
-        // Start/Stop/Restart commands, and WaitFor support.
+        // The framework handles: lifecycle events, timestamps,
+        // Start/Stop/Restart commands, and WaitFor support around OnLifecycle.
         var clockBuilder = builder.AddResource(clockResource)
             .ExcludeFromManifest()
             .WithUrl("https://www.speaking-clock.com/", "Speaking Clock")
             .WithResourceType("TalkingClock")
             .WithProperty(CustomResourceKnownProperties.Source, "Talking Clock")
-            .WithInterval(TimeSpan.FromSeconds(1), async (ctx, tick) =>
+            .OnLifecycle(async (ctx, ct) =>
             {
-                ctx.Logger.LogInformation("The time is {time}", DateTime.UtcNow);
-
-                await ctx.SetStateAsync(tick % 2 == 0
-                    ? new ResourceStateSnapshot("Tick", KnownResourceStateStyles.Success)
-                    : new ResourceStateSnapshot("Tock", KnownResourceStateStyles.Success));
+                await ctx.SetStateAsync(KnownResourceStates.Running, ct);
+                long tick = 0;
+                while (!ct.IsCancellationRequested)
+                {
+                    ctx.Logger.LogInformation("The time is {time}", DateTime.UtcNow);
+                    await ctx.SetStateAsync(tick++ % 2 == 0
+                        ? new ResourceStateSnapshot("Tick", KnownResourceStateStyles.Success)
+                        : new ResourceStateSnapshot("Tock", KnownResourceStateStyles.Success), ct);
+                    await Task.Delay(TimeSpan.FromSeconds(1), ct);
+                }
             });
 
-        // Child resources bind their lifecycle to the parent clock.
+        // Child resources follow the parent clock's lifecycle by waiting on it
+        // inside their own OnLifecycle hook.
         AddHandResource(tickHandResource, "tick");
         AddHandResource(tockHandResource, "tock");
 
@@ -1645,15 +1646,22 @@ public static class TalkingClockExtensions
                 .WithParentRelationship(clockBuilder)
                 .WithResourceType("ClockHand")
                 .WithProperty(CustomResourceKnownProperties.Source, "Talking Clock")
-                .BoundTo(clockBuilder)
-                .WithInterval(TimeSpan.FromSeconds(1), async (ctx, tick) =>
+                .OnLifecycle(async (ctx, ct) =>
                 {
-                    // Alternate on/off in sync with the clock,
-                    // offset by whether this is the tick or tock hand.
-                    var isOn = label == "tick" ? tick % 2 == 0 : tick % 2 != 0;
-                    await ctx.SetStateAsync(isOn
-                        ? new ResourceStateSnapshot("On", KnownResourceStateStyles.Success)
-                        : new ResourceStateSnapshot("Off", KnownResourceStateStyles.Info));
+                    var notifications = ctx.Services.GetRequiredService<ResourceNotificationService>();
+                    await notifications.WaitForResourceHealthyAsync(clockResource.Name, ct);
+
+                    await ctx.SetStateAsync(KnownResourceStates.Running, ct);
+                    long tick = 0;
+                    while (!ct.IsCancellationRequested)
+                    {
+                        var isOn = label == "tick" ? tick % 2 == 0 : tick % 2 != 0;
+                        await ctx.SetStateAsync(isOn
+                            ? new ResourceStateSnapshot("On", KnownResourceStateStyles.Success)
+                            : new ResourceStateSnapshot("Off", KnownResourceStateStyles.Info), ct);
+                        await Task.Delay(TimeSpan.FromSeconds(1), ct);
+                        tick++;
+                    }
                 });
         }
     }

--- a/docs/specs/appmodel.md
+++ b/docs/specs/appmodel.md
@@ -73,6 +73,7 @@ graph LR
   - [What the Framework Handles Around OnInitializeResource](#what-the-framework-handles-around-oninitializeresource)
   - [Patterns](#patterns)
   - [Start/Stop/Restart Routing](#startstoprestart-routing)
+  - [Endpoints and DCP Interop](#endpoints-and-dcp-interop)
   - [Targeted Snapshot Updates](#targeted-snapshot-updates)
 - [Full Examples](#full-examples)
   - [Example: Derived Container Resource (Redis)](#example-derived-container-resource-redis)
@@ -1371,6 +1372,35 @@ Today, Start/Stop/Restart commands route directly to DCP and don't work for cust
 - **Stop**: cancels the resource's `CancellationTokenSource`; the `OnInitializeResource` callback observes cancellation and returns; the framework disposes tracked disposables and sets the terminal state.
 - **Start**: creates a new CTS and re-invokes the `OnInitializeResource` callback; framework fires `BeforeResourceStartedEvent`, sets `Starting`, sets `StartTimeStamp`.
 - **Restart**: stop, then start.
+
+### Endpoints and DCP interop
+
+Custom resources participate in endpoint allocation and service discovery on equal footing with DCP-managed resources, and can interact with DCP-managed resources without special wiring.
+
+**Endpoints on custom resources.** `WithEndpoint(...)` works the same as it does for containers and projects. The orchestrator allocates ports for any `EndpointAnnotation` whose `Port` is unset before `OnInitializeResource` runs, so `resource.GetEndpoint("name")` returns an endpoint with `AllocatedEndpoint` populated. `EndpointReference`, `WithReference(...)`, and service discovery export work unchanged. `ResourceEndpointsAllocatedEvent` fires after allocation and before the lifecycle callback.
+
+```csharp
+builder.AddResource(new InMemoryHttpResource("web"))
+    .WithEndpoint(name: "http", scheme: "http")
+    .OnInitializeResource(async (ctx, ct) =>
+    {
+        var endpoint = ((InMemoryHttpResource)ctx.Resource).GetEndpoint("http");
+
+        await using var server = WebApplication.Create();
+        server.Urls.Add(endpoint.Url);
+        await server.StartAsync(ct);
+        ctx.Track(server);
+
+        await ctx.SetStateAsync(KnownResourceStates.Running, ct);
+        await Task.Delay(Timeout.Infinite, ct);
+    });
+```
+
+**Waiting on, and reading from, DCP resources.** `ctx.Notifications.WaitForResourceHealthyAsync(name, ct)` works against any resource. `EndpointReference` resolves to live host/port values regardless of whether the source is a container, a project, or a custom resource.
+
+**Extending a DCP resource's snapshot.** Calling `ctx.AddUrlAsync` / `ctx.SetPropertyAsync` on a DCP-managed resource lands in the `"user"` source and survives DCP's snapshot refreshes (Layer 1 prevents clobbering). Scalar fields (`State`, `ExitCode`, timestamps) remain owned by DCP; explicit user writes via `ctx.SetStateAsync` route to a user-override slot that takes precedence only when set.
+
+**Bound-lifecycle resources.** Resources whose lifecycle tracks a parent (such as a `DevTunnelPortResource` that follows a `DevTunnelResource`) use `WithRestartOnSourceRestart(parentBuilder)` so the framework re-invokes the callback when the parent transitions back to a healthy state after stopping. Combined with `WaitForResourceAsync` calls inside the callback, this expresses the bound pattern without subscribing to events by hand.
 
 ### Targeted snapshot updates
 

--- a/docs/specs/appmodel.md
+++ b/docs/specs/appmodel.md
@@ -66,6 +66,15 @@ graph LR
 - [Endpoint Primitives](#endpoint-primitives)
 - [Context-Based Endpoint Resolution](#context-based-endpoint-resolution)
 - [API Patterns](#api-patterns)
+- [Custom Resource Lifecycle Model](#custom-resource-lifecycle-model)
+  - [ResourceContext](#resourcecontext)
+  - [Lifecycle Primitives](#lifecycle-primitives)
+  - [Builder Helpers](#builder-helpers)
+  - [What the Framework Handles Automatically](#what-the-framework-handles-automatically)
+  - [Composition Rules](#composition-rules)
+  - [Error Handling](#error-handling-1)
+  - [Start/Stop/Restart Routing](#startstoprestart-routing)
+  - [Targeted Snapshot Updates](#targeted-snapshot-updates)
 - [Full Examples](#full-examples)
   - [Example: Derived Container Resource (Redis)](#example-derived-container-resource-redis)
   - [Example: Custom Resource - Talking Clock](#example-custom-resource---talking-clock)
@@ -1169,6 +1178,213 @@ public virtual void WriteToManifest(ManifestPublishingContext context)
 
 ---
 
+## Custom Resource Lifecycle Model
+
+Custom resources that don't derive from built-in types (Container, Project, Executable) need a way to participate in the Aspire lifecycle — appearing in the dashboard, reporting state, exposing URLs, and supporting Start/Stop/Restart commands — without manually wiring all the plumbing that built-in resources get for free.
+
+The custom resource lifecycle model is built on three principles inspired by UI frameworks:
+
+1. **Targeted updates** — each producer updates only its slice of the resource snapshot, never clobbering other producers' data.
+2. **Framework-owned lifecycle** — the framework manages the state machine, fires events, sets timestamps, and wires commands.
+3. **Reactive triggers** — resource authors declare *what drives their resource* (a timer, another resource, a stream) and provide callbacks. The framework manages when those callbacks fire.
+
+### ResourceContext
+
+`ResourceContext` is the primary API surface for custom resource authors to update dashboard state. It provides targeted methods for each aspect of the resource snapshot.
+
+```csharp
+public class ResourceContext
+{
+    /// The resource this context is associated with.
+    public IResource Resource { get; }
+
+    /// A logger scoped to this resource.
+    public ILogger Logger { get; }
+
+    /// The host service provider.
+    public IServiceProvider Services { get; }
+
+    /// Updates the resource state shown in the dashboard.
+    public Task SetStateAsync(ResourceStateSnapshot state);
+    public Task SetStateAsync(string state);
+
+    /// Sets a property shown in the resource details panel.
+    public Task SetPropertyAsync(string name, object? value, bool isSensitive = false);
+
+    /// Adds or updates a URL shown in the dashboard.
+    public Task AddUrlAsync(UrlSnapshot url);
+
+    /// Removes a URL by name.
+    public Task RemoveUrlAsync(string urlName);
+
+    /// Tracks a disposable that will be disposed when the resource stops.
+    public void Track(IAsyncDisposable disposable);
+    public void Track(IDisposable disposable);
+
+    /// Retrieves a previously tracked object by type.
+    public T Get<T>() where T : class;
+}
+```
+
+### Lifecycle primitives
+
+Every custom resource is driven by one of four things:
+
+| Driver | Primitive | When to use |
+|--------|-----------|-------------|
+| Time | `WithInterval(period, onTick)` | Periodic polling, status refresh |
+| Another resource | `BoundTo(source)` | Port follows tunnel, sidecar follows container |
+| External stream | `RunAsync(execute)` | Streaming connections, subprocess management |
+| One-shot | `OnStarted(callback)` | Setup-and-done resources, external services |
+
+All four share the same `ResourceContext` for state updates.
+
+#### `WithInterval` — framework-owned timer
+
+The framework starts the timer when the resource starts and stops it on stop. No `while` loop needed.
+
+```csharp
+builder.AddResource(new TalkingClockResource("clock"))
+    .WithResourceType("TalkingClock")
+    .WithProperty(CustomResourceKnownProperties.Source, "Talking Clock")
+    .WithInterval(TimeSpan.FromSeconds(1), async (ctx, tick) =>
+    {
+        await ctx.SetStateAsync(tick % 2 == 0
+            ? new ResourceStateSnapshot("Tick", KnownResourceStateStyles.Success)
+            : new ResourceStateSnapshot("Tock", KnownResourceStateStyles.Success));
+    });
+```
+
+#### `BoundTo` — lifecycle follows another resource
+
+Binds this resource's lifecycle to another. The framework automatically starts this resource when the source becomes ready, stops it when the source stops, and restarts it when the source restarts.
+
+```csharp
+// A tunnel port whose lifecycle follows the parent tunnel.
+portBuilder
+    .BoundTo(tunnelBuilder)
+    .OnStarted(async ctx =>
+    {
+        // Framework already fired BeforeResourceStartedEvent, set Starting, set timestamps.
+        // Just do the port-specific setup:
+        var port = (DevTunnelPortResource)ctx.Resource;
+        port.TunnelEndpointAnnotation.AllocatedEndpoint =
+            new(port.TunnelEndpointAnnotation, tunnelPortUri.Host, 443);
+        // Framework auto-resolves URLs from annotations.
+    });
+    // On source stop: framework sets Stopped, StopTimeStamp,
+    // marks URLs inactive, fires ResourceStoppedEvent.
+```
+
+#### `RunAsync` — escape hatch for streaming/subprocess patterns
+
+The author owns the loop. The framework still handles lifecycle, commands, events, and timestamps.
+
+```csharp
+builder.AddResource(new KafkaMonitorResource("kafka-monitor"))
+    .WithResourceType("KafkaMonitor")
+    .RunAsync(async (ctx, stoppingToken) =>
+    {
+        var consumer = new KafkaConsumer(ctx.Get<KafkaConfig>().BootstrapServers);
+        ctx.Track(consumer);
+        await foreach (var msg in consumer.ConsumeAsync(stoppingToken))
+        {
+            await ctx.SetPropertyAsync("last-offset", msg.Offset);
+        }
+    });
+```
+
+#### `OnStarted` / `OnStopping` — one-shot setup and cleanup
+
+```csharp
+builder.AddResource(new ExternalApiResource("payments-api"))
+    .WithResourceType("ExternalAPI")
+    .WithUrl("https://api.payments.com", "API")
+    .OnStarted(async ctx =>
+    {
+        var client = new HttpClient();
+        ctx.Track(client);
+        var response = await client.GetAsync("https://api.payments.com/health");
+        await ctx.SetStateAsync(response.IsSuccessStatusCode ? "Healthy" : "Degraded");
+    });
+```
+
+### Builder helpers
+
+Registration-time helpers that replace the need to construct a full `CustomResourceSnapshot`:
+
+```csharp
+/// Sets the resource type shown in the dashboard Type column.
+builder.AddResource(myResource)
+    .WithResourceType("MyResourceType")
+    .WithProperty(CustomResourceKnownProperties.Source, "my-source")
+    .WithProperty("Version", "1.0");
+
+// WithInitialState remains for backward compatibility but is no longer recommended.
+```
+
+### What the framework handles automatically
+
+For all lifecycle primitives, the framework provides:
+
+| Concern | What the framework does |
+|---------|------------------------|
+| State machine | Manages NotStarted → Starting → Running → Stopping → Stopped transitions |
+| Timestamps | Sets `CreationTimeStamp` at registration, `StartTimeStamp` on start, `StopTimeStamp` on stop |
+| Lifecycle events | Fires `BeforeResourceStartedEvent` before callbacks; `ResourceStoppedEvent` on stop |
+| Dashboard commands | Wires Start/Stop/Restart commands automatically |
+| URL resolution | Auto-resolves `ResourceUrlAnnotation`s into `UrlSnapshot`s |
+| URL active state | Marks URLs inactive on stop, active on start |
+| `WaitFor` support | Works automatically because `BeforeResourceStartedEvent` fires at the right time |
+| Error handling | Callback throws → state = FailedToStart, logged, restartable from dashboard |
+| Cleanup | All tracked disposables (`ctx.Track(...)`) are disposed on stop |
+
+### Composition rules
+
+| Combination | Behavior |
+|-------------|----------|
+| Multiple `WithInterval` | All timers run independently |
+| `WithInterval` + `OnStarted` | `OnStarted` fires first, then timers start |
+| `BoundTo` + `OnStarted` | `OnStarted` fires when the source becomes ready |
+| `RunAsync` | Exclusive — cannot combine with `WithInterval` or `BoundTo` |
+| Multiple `OnStarted` | All fire in registration order |
+| Multiple `OnStopping` | All fire in reverse registration order |
+
+### Error handling
+
+| Scenario | Behavior |
+|----------|----------|
+| `OnStarted` throws | State → FailedToStart, error logged, restartable |
+| `WithInterval` tick throws | Error logged, tick skipped, timer continues |
+| `RunAsync` throws (not `OperationCanceledException`) | State → FailedToStart, error logged, restartable |
+| `OnStopping` throws | Error logged, stop proceeds anyway |
+
+### Start/Stop/Restart routing
+
+Today, Start/Stop/Restart commands route directly to DCP and don't work for custom resources. With the lifecycle model, the orchestrator gains a custom resource path:
+
+- **Stop**: cancels the resource's `CancellationTokenSource` → intervals stop, `RunAsync` token cancelled, `BoundTo` unsubscribes, `OnStopping` fires → framework sets Stopped state.
+- **Start**: creates new CTS, invokes lifecycle callbacks → framework sets Starting → Running.
+- **Restart**: stop, then start.
+
+### Targeted snapshot updates
+
+Each producer (DCP, orchestrator, user code) updates only its own slice of the resource snapshot. The notification service tracks items per source and merges all sources into the final snapshot:
+
+```csharp
+// DCP updates its URLs without touching user URLs:
+notifications.PublishUrlsAsync(resource, "dcp", dcpUrls);
+
+// User code adds URLs without being clobbered by DCP:
+await ctx.AddUrlAsync(new UrlSnapshot("my-link", "http://example.com", false));
+
+// Both sets of URLs appear in the dashboard.
+```
+
+This eliminates the "snapshot clobbering" problem where DCP's `ResourceSnapshotBuilder.ToSnapshot` would replace entire collections (`Urls`, `EnvironmentVariables`, `Volumes`, `Relationships`) on every watch event, silently discarding user-added data.
+
+---
+
 ## Full Examples
 
 This section contains complete, runnable examples demonstrating key concepts.
@@ -1375,12 +1591,78 @@ public class RedisResource(string name)
 
 ### Example: Custom Resource - Talking Clock
 
-This example demonstrates creating a completely custom resource (`TalkingClockResource`) that doesn't derive from built-in types. It shows:
-- Defining a simple resource class.
-- Implementing a custom lifecycle hook (`TalkingClockLifecycleHook`) to manage the resource's behavior (starting, logging, state updates).
-- Using `ResourceLoggerService` for per-resource logging.
-- Using `ResourceNotificationService` to publish state updates.
-- Creating an `AddTalkingClock` extension method to register the resource and its lifecycle hook.
+This example demonstrates creating a completely custom resource (`TalkingClockResource`) that doesn't derive from built-in types.
+
+#### Using the lifecycle model (recommended)
+
+With the [Custom Resource Lifecycle Model](#custom-resource-lifecycle-model), the framework handles state transitions, events, timestamps, and commands automatically. The author focuses on the resource-specific behavior.
+
+```csharp
+// Define the custom resource type — a data container.
+public sealed class TalkingClockResource(string name, ClockHandResource tickHand, ClockHandResource tockHand) : Resource(name)
+{
+    public ClockHandResource TickHand { get; } = tickHand;
+    public ClockHandResource TockHand { get; } = tockHand;
+}
+
+public sealed class ClockHandResource(string name) : Resource(name);
+
+public static class TalkingClockExtensions
+{
+    public static IResourceBuilder<TalkingClockResource> AddTalkingClock(
+        this IDistributedApplicationBuilder builder,
+        string name)
+    {
+        var tickHandResource = new ClockHandResource(name + "-tick-hand");
+        var tockHandResource = new ClockHandResource(name + "-tock-hand");
+        var clockResource = new TalkingClockResource(name, tickHandResource, tockHandResource);
+
+        // The framework handles: state machine, timestamps, lifecycle events,
+        // Start/Stop/Restart commands, and WaitFor support.
+        var clockBuilder = builder.AddResource(clockResource)
+            .ExcludeFromManifest()
+            .WithUrl("https://www.speaking-clock.com/", "Speaking Clock")
+            .WithResourceType("TalkingClock")
+            .WithProperty(CustomResourceKnownProperties.Source, "Talking Clock")
+            .WithInterval(TimeSpan.FromSeconds(1), async (ctx, tick) =>
+            {
+                ctx.Logger.LogInformation("The time is {time}", DateTime.UtcNow);
+
+                await ctx.SetStateAsync(tick % 2 == 0
+                    ? new ResourceStateSnapshot("Tick", KnownResourceStateStyles.Success)
+                    : new ResourceStateSnapshot("Tock", KnownResourceStateStyles.Success));
+            });
+
+        // Child resources bind their lifecycle to the parent clock.
+        AddHandResource(tickHandResource, "tick");
+        AddHandResource(tockHandResource, "tock");
+
+        return clockBuilder;
+
+        void AddHandResource(ClockHandResource clockHand, string label)
+        {
+            builder.AddResource(clockHand)
+                .WithParentRelationship(clockBuilder)
+                .WithResourceType("ClockHand")
+                .WithProperty(CustomResourceKnownProperties.Source, "Talking Clock")
+                .BoundTo(clockBuilder)
+                .WithInterval(TimeSpan.FromSeconds(1), async (ctx, tick) =>
+                {
+                    // Alternate on/off in sync with the clock,
+                    // offset by whether this is the tick or tock hand.
+                    var isOn = label == "tick" ? tick % 2 == 0 : tick % 2 != 0;
+                    await ctx.SetStateAsync(isOn
+                        ? new ResourceStateSnapshot("On", KnownResourceStateStyles.Success)
+                        : new ResourceStateSnapshot("Off", KnownResourceStateStyles.Info));
+                });
+        }
+    }
+}
+```
+
+#### Using the low-level API (current)
+
+The existing low-level API (`WithInitialState` + `OnInitializeResource`) is still available for backward compatibility and for cases that need full control over the lifecycle. This approach requires manually managing state transitions, events, timestamps, and the execution loop.
 
 ```csharp
 // Define the custom resource type. It inherits from the base Aspire 'Resource' class.

--- a/docs/specs/custom-resource-lifecycle.md
+++ b/docs/specs/custom-resource-lifecycle.md
@@ -41,7 +41,7 @@ This proposal keeps a single, consistent level of abstraction. There is **one** 
 
 1. **Targeted updates, not wholesale replacement.** Each producer (DCP, orchestrator, user code) updates only its slice of the resource snapshot. Producers cannot clobber each other.
 
-2. **One lifecycle hook, framework-managed ceremony.** A single `OnLifecycle(async (ctx, ct) => ...)` hook. The framework fires lifecycle events, sets timestamps, and wires Start/Stop/Restart commands around it. The author writes whatever logic they need inside it — a loop, an event subscription, a one-shot call.
+2. **One overload, framework-managed ceremony.** A new `OnInitializeResource(async (ctx, ct) => ...)` overload that takes a `ResourceContext` instead of an `InitializeResourceEvent`. The framework fires lifecycle events, sets timestamps, and wires Start/Stop/Restart commands around it. The author writes whatever logic they need inside it — a loop, an event subscription, a one-shot call.
 
 3. **A focused context, not a snapshot constructor.** A new `ResourceContext` exposes targeted methods (`SetStateAsync`, `SetPropertyAsync`, `AddUrlAsync`) so authors update just the fields they care about, never reconstruct a whole snapshot.
 
@@ -241,13 +241,20 @@ public static IResourceBuilder<T> WithCommand<T>(
 
 This is purely additive; existing `WithCommand` overloads continue to work.
 
-## Layer 3: One lifecycle hook, framework-managed ceremony
+## Layer 3: New `OnInitializeResource` overload, framework-managed ceremony
 
-### The single primitive: `OnLifecycle`
+### A new overload alongside the existing `OnInitializeResource`
 
-A custom resource that wants to participate in the dashboard lifecycle implements one hook:
+`OnInitializeResource` already exists today, but its callback receives an `InitializeResourceEvent` and the author owns every piece of ceremony (firing events, setting state, managing timestamps, owning the loop). This proposal adds a **second overload** that takes a `ResourceContext` instead — when this overload is used, the framework owns the surrounding ceremony.
 
 ```csharp
+// Existing overload (unchanged) — author owns everything.
+public static IResourceBuilder<T> OnInitializeResource<T>(
+    this IResourceBuilder<T> builder,
+    Func<T, InitializeResourceEvent, CancellationToken, Task> callback)
+    where T : IResource;
+
+// New overload — framework owns ceremony around the callback.
 /// <summary>
 /// Registers the lifecycle body for this resource. The framework owns the surrounding
 /// ceremony (lifecycle events, timestamps, command wiring, cleanup of tracked
@@ -262,15 +269,17 @@ A custom resource that wants to participate in the dashboard lifecycle implement
 /// or <see cref="KnownResourceStates.Exited"/> (if it did) and exposes the failure
 /// in the dashboard.
 /// </remarks>
-public static IResourceBuilder<T> OnLifecycle<T>(
+public static IResourceBuilder<T> OnInitializeResource<T>(
     this IResourceBuilder<T> builder,
     Func<ResourceContext, CancellationToken, Task> lifecycle)
     where T : IResource;
 ```
 
-That's the entire third layer.
+The signature carries the contract: if your callback takes a `ResourceContext`, the framework wraps it with ceremony. If it takes the legacy `InitializeResourceEvent`, you're responsible for everything (matching today's behavior, kept for back-compat).
 
-### What the framework handles around `OnLifecycle`
+That's the entire third layer — no new method name, just a new shape for an existing hook.
+
+### What the framework handles around `OnInitializeResource`
 
 | Concern | Framework behavior |
 |---------|-------------------|
@@ -289,11 +298,11 @@ The author is responsible for transitioning to `Running` (or another live state)
 
 ### Resources that opt out of lifecycle
 
-A resource that doesn't implement `IResourceWithLifetime` (or implements a marker like `IResourceWithoutLifecycle`) is skipped by the framework's start/stop machinery, doesn't get Start/Stop/Restart commands, and its `OnLifecycle` registration (if any) is treated as a no-op. This covers things like `ParameterResource` and other configuration-style resources that don't have a meaningful runtime lifecycle.
+A resource that doesn't implement `IResourceWithLifetime` (or implements a marker like `IResourceWithoutLifecycle`) is skipped by the framework's start/stop machinery, doesn't get Start/Stop/Restart commands, and its `OnInitializeResource` registration (if any) is treated as a no-op. This covers things like `ParameterResource` and other configuration-style resources that don't have a meaningful runtime lifecycle.
 
 ### Examples
 
-These are the four common patterns. They all use the same `OnLifecycle` hook; the body varies.
+These are the four common patterns. They all use the same `OnInitializeResource` overload; the body varies.
 
 #### Periodic (replaces TalkingClock today)
 
@@ -303,7 +312,7 @@ builder.AddResource(new TalkingClockResource("clock"))
     .WithResourceType("TalkingClock")
     .WithProperty(CustomResourceKnownProperties.Source, "Talking Clock")
     .WithUrl("https://www.speaking-clock.com/", "Speaking Clock")
-    .OnLifecycle(async (ctx, ct) =>
+    .OnInitializeResource(async (ctx, ct) =>
     {
         await ctx.SetStateAsync(KnownResourceStates.Running, ct);
         long tick = 0;
@@ -324,7 +333,7 @@ Compare to the [current TalkingClock implementation](../../playground/CustomReso
 When a resource's lifecycle follows another resource, the author waits for the source resource's state directly using existing notification APIs. No new primitive needed:
 
 ```csharp
-portBuilder.OnLifecycle(async (ctx, ct) =>
+portBuilder.OnInitializeResource(async (ctx, ct) =>
 {
     // Wait for the parent tunnel to be ready.
     await ctx.Notifications.WaitForResourceHealthyAsync(tunnel.Resource.Name, ct);
@@ -354,7 +363,7 @@ This replaces ~130 lines of manual ceremony in the current `DevTunnelPortResourc
 ```csharp
 builder.AddResource(new KafkaMonitorResource("kafka-monitor"))
     .WithResourceType("KafkaMonitor")
-    .OnLifecycle(async (ctx, ct) =>
+    .OnInitializeResource(async (ctx, ct) =>
     {
         var consumer = new KafkaConsumer(ctx.Get<KafkaConfig>().BootstrapServers);
         ctx.Track(consumer); // disposed by the framework on stop
@@ -375,7 +384,7 @@ builder.AddResource(new KafkaMonitorResource("kafka-monitor"))
 builder.AddResource(new ExternalApiResource("payments-api"))
     .WithResourceType("ExternalAPI")
     .WithUrl("https://api.payments.com", "API")
-    .OnLifecycle(async (ctx, ct) =>
+    .OnInitializeResource(async (ctx, ct) =>
     {
         var client = new HttpClient();
         ctx.Track(client);
@@ -392,16 +401,16 @@ builder.AddResource(new ExternalApiResource("payments-api"))
 
 (Continuous health is best expressed with `WithHealthCheck`, not with the `State` field. The dashboard renders a separate health badge for this.)
 
-### Optional helpers (built on `OnLifecycle`)
+### Optional helpers (built on `OnInitializeResource`)
 
-The most common patterns above can be packaged as extension methods that build on `OnLifecycle`. These are convenience helpers, not new primitives — they expand to ordinary `OnLifecycle` bodies and live in any namespace the consumer prefers.
+The most common patterns above can be packaged as extension methods that build on `OnInitializeResource`. These are convenience helpers, not new primitives — they expand to ordinary `OnInitializeResource` bodies and live in any namespace the consumer prefers.
 
 ```csharp
 public static class ResourceLifecycleExtensions
 {
     /// <summary>
     /// Convenience: runs <paramref name="onTick"/> on a fixed interval until the
-    /// resource is stopped. Equivalent to writing a while loop inside OnLifecycle.
+    /// resource is stopped. Equivalent to writing a while loop inside OnInitializeResource.
     /// </summary>
     public static IResourceBuilder<T> WithInterval<T>(
         this IResourceBuilder<T> builder,
@@ -409,7 +418,7 @@ public static class ResourceLifecycleExtensions
         Func<ResourceContext, long, CancellationToken, Task> onTick)
         where T : IResource
     {
-        return builder.OnLifecycle(async (ctx, ct) =>
+        return builder.OnInitializeResource(async (ctx, ct) =>
         {
             await ctx.SetStateAsync(KnownResourceStates.Running, ct);
             long tick = 0;
@@ -423,9 +432,9 @@ public static class ResourceLifecycleExtensions
 }
 ```
 
-Authors who like the helper can use it. Authors who want full control use `OnLifecycle` directly. There is exactly one primitive in the public API; everything else is layered on top.
+Authors who like the helper can use it. Authors who want full control use `OnInitializeResource` directly. There is exactly one primitive in the public API; everything else is layered on top.
 
-### What `OnLifecycle` does **not** prescribe
+### What `OnInitializeResource` does **not** prescribe
 
 To avoid the design debates around composing multiple lifecycle primitives, this proposal deliberately makes these the author's responsibility:
 
@@ -448,14 +457,14 @@ Dashboard "Stop" click
     → orchestrator.StopResourceAsync(name)
       → If DCP resource → _dcpExecutor.StopResourceAsync (existing path)
       → If custom resource → cancel the resource's CancellationTokenSource
-        → OnLifecycle callback observes cancellation, returns
+        → OnInitializeResource callback observes cancellation, returns
         → Framework: disposes tracked disposables, sets terminal state,
           sets StopTimeStamp, fires ResourceStoppedEvent
 
 Dashboard "Start" click
   → orchestrator.StartResourceAsync(name)
     → If DCP resource → _dcpExecutor.StartResourceAsync (existing path)
-    → If custom resource → create new CTS, re-invoke OnLifecycle callback
+    → If custom resource → create new CTS, re-invoke OnInitializeResource callback
       → Framework: fires BeforeResourceStartedEvent, sets Starting,
         sets StartTimeStamp, invokes callback
 ```
@@ -505,7 +514,7 @@ export interface UrlSnapshot {
 }
 ```
 
-### `ResourceContext` and `onLifecycle`
+### `ResourceContext` and `onInitializeResource`
 
 ```typescript
 export interface ResourceContext {
@@ -525,7 +534,7 @@ export interface ResourceContext {
 // On any resource builder:
 .withResourceType(resourceType: string)
 .withProperty(name: string, value: unknown, options?: PublishPropertyOptions)
-.onLifecycle(lifecycle: (ctx: ResourceContext, stopSignal: AbortSignal) => Promise<void>)
+.onInitializeResource(lifecycle: (ctx: ResourceContext, stopSignal: AbortSignal) => Promise<void>)
 ```
 
 ### TypeScript example
@@ -534,7 +543,7 @@ export interface ResourceContext {
 const clock = await builder.addResource("clock")
     .withResourceType("TalkingClock")
     .withProperty("aspire.resource.source", "Talking Clock")
-    .onLifecycle(async (ctx, stop) => {
+    .onInitializeResource(async (ctx, stop) => {
         await ctx.setState("Running");
         let tick = 0;
         while (!stop.aborted) {
@@ -579,7 +588,7 @@ builder.AddResource(myResource)
 builder.AddResource(myResource)
     .WithResourceType("MyResource")
     .WithProperty("Source", "my-source")
-    .OnLifecycle(async (ctx, ct) =>
+    .OnInitializeResource(async (ctx, ct) =>
     {
         await ctx.SetStateAsync(KnownResourceStates.Running, ct);
         while (!ct.IsCancellationRequested)
@@ -594,7 +603,7 @@ The reductions: no manual snapshot construction, no manual event firing, no manu
 
 ### From `OnResourceReady` / `OnResourceStopped` (bound lifecycle)
 
-See the DevTunnelPort example above. The pattern is to put the wait-for-parent logic inside `OnLifecycle` using `WaitForResourceAsync` / `WaitForResourceHealthyAsync`, instead of subscribing to events on the parent.
+See the DevTunnelPort example above. The pattern is to put the wait-for-parent logic inside `OnInitializeResource` using `WaitForResourceAsync` / `WaitForResourceHealthyAsync`, instead of subscribing to events on the parent.
 
 ## Implementation phases
 
@@ -602,14 +611,14 @@ See the DevTunnelPort example above. The pattern is to put the wait-for-parent l
 |-------|-------|-------------|
 | **1. Source-scoped slices** | Internal plumbing: per-source collection tracking in `ResourceNotificationService`, `PublishSlicedUpdateAsync` for DCP, refactor `ResourceSnapshotBuilder` and `ApplicationOrchestrator`. Fixes #13647. | None |
 | **2. `ResourceContext` + public API** | New `ResourceContext` class, targeted public methods on `ResourceNotificationService`, builder helpers (`WithResourceType`, `WithProperty`), `CreationTimeStamp` auto-default, `WithCommand` overload that accepts `ResourceContext`. | Phase 1 |
-| **3. `OnLifecycle` hook** | Framework-owned ceremony (events, timestamps, command wiring, cleanup), Start/Stop/Restart routing for custom resources, opt-out via `IResourceWithoutLifecycle`. | Phase 2 |
-| **4. TypeScript parity** | Code-gen changes to emit new methods on `ResourceNotificationService`, builders, and the `onLifecycle` hook. | Phase 3 |
+| **3. `OnInitializeResource` overload** | Framework-owned ceremony (events, timestamps, command wiring, cleanup), Start/Stop/Restart routing for custom resources, opt-out via `IResourceWithoutLifecycle`. | Phase 2 |
+| **4. TypeScript parity** | Code-gen changes to emit new methods on `ResourceNotificationService`, builders, and the `onInitializeResource` hook. | Phase 3 |
 
 Each phase is independently shippable and useful. Phase 1 alone fixes the clobbering bug. Phase 2 alone meaningfully improves authoring. Phase 3 closes the loop on Start/Stop/Restart commands and event firing for custom resources.
 
 ## Open questions
 
-1. **Naming.** `OnLifecycle` vs `WithLifecycle` vs `OnRun` vs `WithBody`? `ResourceContext` vs `ResourceUpdater` vs `ResourceController`? Naming TBD pending API review.
+1. **Naming.** The proposal reuses `OnInitializeResource` as the hook name with a new overload. Alternative: introduce a distinct name (`OnLifecycle`, `WithLifecycle`, `OnRun`) to make the framework-managed behavior more obvious from the callsite, at the cost of having two parallel hook concepts. `ResourceContext` itself could also be `ResourceUpdater` / `ResourceController`. TBD pending API review.
 
 2. **Framework state on author-thrown exceptions.** When the callback throws after `Running` was reached, should the framework expose the exception as an `ExitCode`-like value, or just log it? Recommendation: log plus a synthetic non-zero exit code so the dashboard renders the resource with error styling.
 

--- a/docs/specs/custom-resource-lifecycle.md
+++ b/docs/specs/custom-resource-lifecycle.md
@@ -1,0 +1,647 @@
+# Custom Resource Lifecycle Model
+
+> **Status**: Proposal
+> **Issues**: [#13647](https://github.com/microsoft/aspire/issues/13647), [#10365](https://github.com/microsoft/aspire/issues/10365)
+> **Audience**: Aspire contributors, integration authors, and advanced users building custom resources.
+
+## Motivation
+
+Custom resources in Aspire today require significant boilerplate. Authors must manually:
+
+- Construct a full `CustomResourceSnapshot` object with `WithInitialState`
+- Write and manage a `while` loop inside `OnInitializeResource`
+- Fire lifecycle events (`BeforeResourceStartedEvent`, `ResourceEndpointsAllocatedEvent`) by hand
+- Set timestamps (`CreationTimeStamp`, `StartTimeStamp`, `StopTimeStamp`) explicitly
+- Wire Start/Stop/Restart dashboard commands (which today only work for DCP-backed resources)
+- Work around snapshot clobbering — DCP's `ResourceSnapshotBuilder.ToSnapshot` overwrites `Urls`, `EnvironmentVariables`, `Volumes`, `Relationships`, and some `Properties` on every watch event, silently discarding anything the user added via `PublishUpdateAsync`
+
+This makes custom resources hard to author, error-prone, and fragile. The snapshot clobbering issue (#13647) means users cannot reliably add dynamic URLs or properties to DCP-managed resources.
+
+### The problem in one example
+
+```csharp
+// User adds a custom URL to a container.
+// It appears briefly, then vanishes when DCP refreshes.
+builder.AddContainer("nginx", "nginx")
+    .OnBeforeResourceStarted(async (res, evt, ct) =>
+    {
+        await evt.Services.GetRequiredService<ResourceNotificationService>()
+            .PublishUpdateAsync(res, x => x with
+            {
+                Urls = [.. x.Urls, new("Hello World", "http://localhost/", false)]
+            });
+    });
+```
+
+The "Hello World" URL disappears because `ResourceSnapshotBuilder.ToSnapshot` replaces the entire `Urls` collection with freshly computed DCP-sourced URLs on every state transition.
+
+## Design principles
+
+This proposal is modeled after UI frameworks:
+
+1. **Targeted updates, not wholesale replacement.** Like a UI framework where each component updates its own state without clobbering siblings, each producer (DCP, orchestrator, user code) updates only its slice of the resource snapshot.
+
+2. **Framework owns the lifecycle loop.** Like a UI framework that calls your render/update function rather than you writing a `while` loop, the Aspire framework manages the resource state machine and calls your callbacks at the right time.
+
+3. **Reactive triggers, not imperative loops.** Resource authors declare *what drives their resource* (a timer, another resource's events, an external stream) and provide callbacks. The framework manages when those callbacks fire, including start, stop, and restart.
+
+## Architecture
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│              ResourceNotificationService                    │
+│    (merges slices from all producers into one snapshot)     │
+│                                                             │
+│  ┌────────┐  ┌────────┐  ┌────────┐  ┌────────┐           │
+│  │ State  │  │  URLs  │  │  Props │  │  Env   │  ...       │
+│  │ slice  │  │ slice  │  │ slice  │  │ slice  │            │
+│  └───▲────┘  └───▲────┘  └───▲────┘  └───▲────┘           │
+│      │           │           │           │                  │
+└──────┼───────────┼───────────┼───────────┼──────────────────┘
+       │           │           │           │
+  ┌────┴──┐  ┌────┴──┐   ┌────┴──┐  ┌────┴──┐
+  │  DCP  │  │Orchest│   │ User  │  │ User  │
+  │watcher│  │rator  │   │ code  │  │ code  │
+  └───────┘  └───────┘   └───────┘  └───────┘
+```
+
+Each producer calls targeted update methods that only affect its own slice. The notification service merges all slices into the final `CustomResourceSnapshot` that flows to the dashboard.
+
+## Layer 1: Source-scoped snapshot updates
+
+### Problem
+
+`ResourceSnapshotBuilder.ToSnapshot` does `previous with { Urls = urls, EnvironmentVariables = env, ... }`, replacing every collection wholesale. Any URL, env var, or property added by user code via `PublishUpdateAsync` is silently lost.
+
+### Solution
+
+The notification service tracks collection items **per source**. Each producer identifies itself when updating a collection. The service stores items grouped by source and merges all sources into the rendered snapshot.
+
+```csharp
+// Internal API — used by DCP and the orchestrator:
+notifications.PublishUrlsAsync(resource, "dcp", dcpUrls);
+notifications.PublishEnvironmentAsync(resource, "dcp", dcpEnvVars);
+notifications.PublishPropertiesAsync(resource, "dcp", dcpProperties);
+
+// User code continues to use PublishUpdateAsync.
+// Collection writes are routed to the "user" source internally.
+await notifications.PublishUpdateAsync(resource, s => s with
+{
+    Urls = [.. s.Urls, new("Hello World", "http://localhost/", false)]
+});
+// The "Hello World" URL is stored in the "user" source.
+// DCP updates only replace the "dcp" source — user URLs are untouched.
+```
+
+When DCP calls `PublishUrlsAsync(resource, "dcp", newUrls)`:
+1. All previous URLs from source `"dcp"` are replaced with `newUrls`.
+2. URLs from source `"user"` and `"orchestrator"` are untouched.
+3. The merged snapshot contains URLs from all sources.
+
+### Atomicity
+
+DCP needs to update state + URLs + env + properties in one atomic operation to avoid intermediate states visible to the dashboard. A batch API handles this:
+
+```csharp
+// Internal: atomic multi-slice update
+notifications.PublishSlicedUpdateAsync(resource, "dcp", batch =>
+{
+    batch.State = dcpState;
+    batch.Urls = dcpUrls;
+    batch.EnvironmentVariables = dcpEnv;
+    batch.Properties = dcpProperties;
+    batch.Volumes = dcpVolumes;
+    batch.Relationships = dcpRelationships;
+});
+```
+
+### Backward compatibility
+
+`PublishUpdateAsync(resource, Func<CustomResourceSnapshot, CustomResourceSnapshot>)` continues to work exactly as today for scalar fields (`State`, `ExitCode`, timestamps). For collection fields, writes are routed to the `"user"` source. This means existing code that appends to `Urls` via `s => s with { Urls = [..s.Urls, myUrl] }` correctly adds to the user slice without affecting DCP-owned URLs.
+
+## Layer 2: `ResourceContext` and targeted public API
+
+### `ResourceContext`
+
+A new class that provides the state-update surface for resource authors. It's the "component API" — the thing you use to tell the dashboard what to show.
+
+```csharp
+public class ResourceContext
+{
+    /// <summary>The resource this context is associated with.</summary>
+    public IResource Resource { get; }
+
+    /// <summary>A logger scoped to this resource.</summary>
+    public ILogger Logger { get; }
+
+    /// <summary>The host service provider.</summary>
+    public IServiceProvider Services { get; }
+
+    /// <summary>Updates the resource state shown in the dashboard.</summary>
+    public Task SetStateAsync(ResourceStateSnapshot state);
+
+    /// <summary>Updates the resource state shown in the dashboard.</summary>
+    public Task SetStateAsync(string state);
+
+    /// <summary>Sets a property shown in the resource details panel.</summary>
+    public Task SetPropertyAsync(string name, object? value, bool isSensitive = false);
+
+    /// <summary>Adds or updates a URL shown in the dashboard.</summary>
+    public Task AddUrlAsync(UrlSnapshot url);
+
+    /// <summary>Removes a URL by name.</summary>
+    public Task RemoveUrlAsync(string urlName);
+
+    /// <summary>
+    /// Tracks a disposable that will be disposed when the resource stops.
+    /// Use this for connections, clients, or other resources with cleanup.
+    /// </summary>
+    public void Track(IAsyncDisposable disposable);
+
+    /// <summary>Tracks a disposable that will be disposed when the resource stops.</summary>
+    public void Track(IDisposable disposable);
+
+    /// <summary>Retrieves a previously tracked object by type.</summary>
+    public T Get<T>() where T : class;
+}
+```
+
+### Targeted methods on `ResourceNotificationService`
+
+In addition to the existing `PublishUpdateAsync`, new public methods for targeted updates:
+
+```csharp
+public class ResourceNotificationService
+{
+    // Existing (kept):
+    public Task PublishUpdateAsync(IResource resource,
+        Func<CustomResourceSnapshot, CustomResourceSnapshot> stateFactory);
+
+    // New:
+    public Task PublishStateAsync(IResource resource, ResourceStateSnapshot state);
+    public Task PublishStateAsync(IResource resource, string state);
+    public Task PublishPropertyAsync(IResource resource,
+        string name, object? value, bool isSensitive = false);
+    public Task PublishUrlAsync(IResource resource, UrlSnapshot url);
+    public Task RemoveUrlAsync(IResource resource, string urlName);
+}
+```
+
+### Builder extensions
+
+```csharp
+/// <summary>Sets the resource type shown in the dashboard Type column.</summary>
+public static IResourceBuilder<T> WithResourceType<T>(
+    this IResourceBuilder<T> builder, string resourceType)
+    where T : IResource;
+
+/// <summary>Adds a property visible in the dashboard resource details.</summary>
+public static IResourceBuilder<T> WithProperty<T>(
+    this IResourceBuilder<T> builder,
+    string name, object? value, bool isSensitive = false)
+    where T : IResource;
+```
+
+These are additive — `WithInitialState` remains for backward compatibility but is no longer the recommended way to set resource type and properties.
+
+## Layer 3: Framework-owned lifecycle
+
+### The four lifecycle primitives
+
+Every custom resource is driven by one of four things. The framework provides a primitive for each:
+
+| Driver | Primitive | When to use |
+|--------|-----------|-------------|
+| Time | `WithInterval(period, onTick)` | Periodic polling, status refresh |
+| Another resource | `BoundTo(source)` | Port follows tunnel, sidecar follows container |
+| External stream | `RunAsync(execute)` | Streaming connections, subprocess management |
+| One-shot | `OnStarted(callback)` | Setup-and-done resources, external services |
+
+All four share the same `ResourceContext` for state updates, and all four get automatic lifecycle management.
+
+### `WithInterval` — framework-owned timer
+
+```csharp
+/// <summary>
+/// Registers a periodic callback. The framework starts the timer when the resource starts
+/// and stops it when the resource stops. No while loop needed.
+/// </summary>
+public static IResourceBuilder<T> WithInterval<T>(
+    this IResourceBuilder<T> builder,
+    TimeSpan period,
+    Func<ResourceContext, long, Task> onTick)
+    where T : IResource;
+```
+
+**Example — TalkingClock:**
+
+```csharp
+builder.AddResource(new TalkingClockResource("clock"))
+    .ExcludeFromManifest()
+    .WithResourceType("TalkingClock")
+    .WithProperty(CustomResourceKnownProperties.Source, "Talking Clock")
+    .WithUrl("https://www.speaking-clock.com/", "Speaking Clock")
+    .WithInterval(TimeSpan.FromSeconds(1), async (ctx, tick) =>
+    {
+        await ctx.SetStateAsync(tick % 2 == 0
+            ? new ResourceStateSnapshot("Tick", KnownResourceStateStyles.Success)
+            : new ResourceStateSnapshot("Tock", KnownResourceStateStyles.Success));
+    });
+```
+
+Compare to the [current TalkingClock implementation](../../playground/CustomResources/CustomResources.AppHost/TalkingClockResource.cs) which requires ~30 lines, manual `BeforeResourceStartedEvent` firing, manual timestamps, manual `while` loop, and manual `PublishUpdateAsync` calls.
+
+### `BoundTo` — lifecycle follows another resource
+
+```csharp
+/// <summary>
+/// Binds this resource's lifecycle to another resource. The framework automatically:
+/// - Starts this resource when the source becomes ready
+/// - Stops this resource when the source stops
+/// - Restarts this resource when the source restarts
+/// - Fires all lifecycle events (BeforeResourceStartedEvent, etc.)
+/// - Manages timestamps and URL active/inactive state
+/// </summary>
+public static IResourceBuilder<T> BoundTo<T, TSource>(
+    this IResourceBuilder<T> builder,
+    IResourceBuilder<TSource> source)
+    where T : IResource
+    where TSource : IResource;
+```
+
+**Example — DevTunnelPort:**
+
+```csharp
+// Today: ~130 lines across OnResourceReady + OnResourceStopped handlers
+// that manually fire events, set state, allocate endpoints, toggle URL
+// activity, manage timestamps, and publish ResourceStoppedEvent.
+
+// Proposed:
+portBuilder
+    .BoundTo(tunnelBuilder)
+    .OnStarted(async ctx =>
+    {
+        // Framework already: fired BeforeResourceStartedEvent,
+        // set Starting, set StartTimeStamp.
+        // Do only the port-specific work:
+        var port = (DevTunnelPortResource)ctx.Resource;
+        var tunnelPort = port.LastKnownStatus!;
+        port.TunnelEndpointAnnotation.AllocatedEndpoint =
+            new(port.TunnelEndpointAnnotation, tunnelPort.PortUri!.Host, 443);
+        // Framework auto-resolves URLs from annotations
+    });
+    // On tunnel stop: framework sets Stopped, StopTimeStamp,
+    // marks URLs inactive, fires ResourceStoppedEvent.
+```
+
+#### What `BoundTo` does automatically
+
+1. **Subscribes to source `ResourceReadyEvent`** → starts this resource
+2. **Subscribes to source `ResourceStoppedEvent`** → stops this resource
+3. **Handles source restart** → stops this resource, then re-starts when source is ready again
+4. **Wires Start/Stop/Restart commands** — but Start is gated on source being ready
+5. **Fires all lifecycle events** (`BeforeResourceStartedEvent`, `ResourceEndpointsAllocatedEvent`, `ResourceStoppedEvent`)
+6. **Manages timestamps** (`StartTimeStamp`, `StopTimeStamp`)
+7. **Toggles URL active state** — URLs marked inactive on stop, active on start
+
+### `RunAsync` — author-owned loop (escape hatch)
+
+```csharp
+/// <summary>
+/// Registers an async function that runs while the resource is started.
+/// The stoppingToken is cancelled when the resource should stop.
+/// Use this for streaming connections, subprocess management, or any case
+/// where the resource needs a long-running loop.
+/// </summary>
+public static IResourceBuilder<T> RunAsync<T>(
+    this IResourceBuilder<T> builder,
+    Func<ResourceContext, CancellationToken, Task> execute)
+    where T : IResource;
+```
+
+**Example — Kafka monitor:**
+
+```csharp
+builder.AddResource(new KafkaMonitorResource("kafka-monitor"))
+    .WithResourceType("KafkaMonitor")
+    .RunAsync(async (ctx, stoppingToken) =>
+    {
+        var consumer = new KafkaConsumer(ctx.Get<KafkaConfig>().BootstrapServers);
+        ctx.Track(consumer);
+
+        await foreach (var msg in consumer.ConsumeAsync(stoppingToken))
+        {
+            await ctx.SetPropertyAsync("last-offset", msg.Offset);
+            await ctx.SetPropertyAsync("last-timestamp", msg.Timestamp);
+        }
+    });
+```
+
+### `OnStarted` / `OnStopping` — one-shot setup and cleanup
+
+```csharp
+/// <summary>
+/// Registers a callback that runs once when the resource starts.
+/// Use this for setup that doesn't require a long-running loop.
+/// </summary>
+public static IResourceBuilder<T> OnStarted<T>(
+    this IResourceBuilder<T> builder,
+    Func<ResourceContext, Task> onStarted)
+    where T : IResource;
+
+/// <summary>
+/// Registers a callback that runs when the resource is stopping.
+/// Use this for cleanup.
+/// </summary>
+public static IResourceBuilder<T> OnStopping<T>(
+    this IResourceBuilder<T> builder,
+    Func<ResourceContext, Task> onStopping)
+    where T : IResource;
+```
+
+**Example — external service:**
+
+```csharp
+builder.AddResource(new ExternalApiResource("payments-api"))
+    .WithResourceType("ExternalAPI")
+    .WithUrl("https://api.payments.com", "API")
+    .OnStarted(async ctx =>
+    {
+        var client = new HttpClient();
+        ctx.Track(client);
+        var response = await client.GetAsync("https://api.payments.com/health");
+        await ctx.SetStateAsync(response.IsSuccessStatusCode ? "Healthy" : "Degraded");
+    });
+```
+
+### What the framework handles automatically
+
+For all four primitives, the framework provides:
+
+| Concern | What the framework does |
+|---------|------------------------|
+| **State machine** | Manages NotStarted → Starting → Running → Stopping → Stopped transitions |
+| **Timestamps** | Sets `CreationTimeStamp` at registration, `StartTimeStamp` on start, `StopTimeStamp` on stop |
+| **Lifecycle events** | Fires `BeforeResourceStartedEvent` before calling callbacks; fires `ResourceStoppedEvent` on stop |
+| **Dashboard commands** | Wires Start/Stop/Restart commands automatically |
+| **URL resolution** | Auto-resolves `ResourceUrlAnnotation`s into `UrlSnapshot`s |
+| **URL active state** | Marks URLs inactive on stop, active on start |
+| **`WaitFor` support** | Works automatically because `BeforeResourceStartedEvent` fires at the right time |
+| **Error handling** | If a callback throws (not `OperationCanceledException`), state → FailedToStart, logged, restartable from dashboard |
+| **Cleanup** | All tracked disposables (`ctx.Track(...)`) are disposed on stop |
+
+### Start/Stop/Restart routing for custom resources
+
+Today, `ApplicationOrchestrator.StartResourceAsync` and `StopResourceAsync` route directly to `_dcpExecutor`, which only knows about DCP-managed resources. Custom resources get nothing.
+
+With this proposal, the orchestrator gains a custom resource lifecycle path:
+
+```
+Dashboard "Stop" click
+  → CommandsConfigurationExtensions
+    → orchestrator.StopResourceAsync(name)
+      → If DCP resource → _dcpExecutor.StopResourceAsync (existing path)
+      → If custom resource → cancel the resource's CancellationTokenSource
+        → WithInterval: timer stopped
+        → BoundTo: unbind from source events
+        → RunAsync: stoppingToken cancelled, await completion
+        → OnStopping: called
+        → Framework: state = Stopped, StopTimeStamp set, URLs inactive
+
+Dashboard "Start" click
+  → orchestrator.StartResourceAsync(name)
+    → If DCP resource → _dcpExecutor.StartResourceAsync (existing path)
+    → If custom resource → create new CTS, invoke lifecycle callbacks
+      → BoundTo: re-subscribe, but gate on source being ready
+      → Framework: state = Starting → Running
+```
+
+## TypeScript API
+
+The TypeScript API mirrors the C# API through the polyglot code-generation system.
+
+### `ResourceNotificationService`
+
+```typescript
+export interface ResourceNotificationService {
+    // Existing:
+    publishResourceUpdate(resource: Awaitable<Resource>,
+        options?: PublishResourceUpdateOptions): ResourceNotificationServicePromise;
+
+    // New:
+    publishState(resource: Awaitable<Resource>,
+        state: string,
+        options?: PublishStateOptions): ResourceNotificationServicePromise;
+
+    publishProperty(resource: Awaitable<Resource>,
+        name: string, value: unknown,
+        options?: PublishPropertyOptions): ResourceNotificationServicePromise;
+
+    publishUrl(resource: Awaitable<Resource>,
+        url: UrlSnapshot): ResourceNotificationServicePromise;
+
+    removeUrl(resource: Awaitable<Resource>,
+        urlName: string): ResourceNotificationServicePromise;
+}
+
+export interface PublishStateOptions {
+    stateStyle?: string;
+}
+
+export interface PublishPropertyOptions {
+    isSensitive?: boolean;
+}
+
+export interface UrlSnapshot {
+    name?: string;
+    url: string;
+    isInternal?: boolean;
+}
+```
+
+### `InitializeResourceEvent`
+
+```typescript
+export interface InitializeResourceEvent {
+    // Existing:
+    resource(): Promise<Resource>;
+    eventing(): Promise<IDistributedApplicationEventing>;
+    logger(): Promise<ILogger>;
+    notifications(): Promise<ResourceNotificationService>;
+    services(): Promise<IServiceProvider>;
+
+    // New:
+    setStarted(): Promise<void>;
+    setState(state: string, options?: PublishStateOptions): Promise<void>;
+    setProperty(name: string, value: unknown,
+        options?: PublishPropertyOptions): Promise<void>;
+    addUrl(url: UrlSnapshot): Promise<void>;
+}
+```
+
+### Builder extensions
+
+```typescript
+// On any resource builder:
+.withResourceType(resourceType: string)
+.withProperty(name: string, value: unknown, options?: PublishPropertyOptions)
+.withInterval(periodMs: number,
+    onTick: (ctx: ResourceContext, tick: number) => Promise<void>)
+.boundTo(source: Awaitable<Resource>)
+.onStarted(callback: (ctx: ResourceContext) => Promise<void>)
+.onStopping(callback: (ctx: ResourceContext) => Promise<void>)
+.run(execute: (ctx: ResourceContext, stoppingToken: AbortSignal) => Promise<void>)
+```
+
+### TypeScript example
+
+```typescript
+// TalkingClock
+const clock = await builder.addResource("clock")
+    .withResourceType("TalkingClock")
+    .withProperty("aspire.resource.source", "Talking Clock")
+    .withInterval(1000, async (ctx, tick) => {
+        await ctx.setState(tick % 2 === 0 ? "Tick" : "Tock",
+            { stateStyle: "success" });
+    });
+
+// Bound lifecycle
+const port = await builder.addResource("tunnel-port")
+    .withResourceType("DevTunnelPort")
+    .boundTo(tunnel)
+    .onStarted(async (ctx) => {
+        await ctx.addUrl({ name: "tunnel", url: tunnelPortUrl });
+    });
+```
+
+## Composition rules
+
+The lifecycle primitives compose as follows:
+
+| Combination | Behavior |
+|-------------|----------|
+| Multiple `WithInterval` | All timers run independently |
+| `WithInterval` + `OnStarted` | `OnStarted` fires first, then timers start |
+| `WithInterval` + `OnStopping` | Timers stop first, then `OnStopping` fires |
+| `BoundTo` + `OnStarted` | `OnStarted` fires when the source becomes ready |
+| `BoundTo` + `OnStopping` | `OnStopping` fires when the source stops |
+| `RunAsync` | Exclusive — cannot combine with `WithInterval` or `BoundTo` (it IS the lifecycle) |
+| `RunAsync` + `OnStopping` | `OnStopping` fires after `RunAsync` returns |
+| Multiple `OnStarted` | All fire in registration order |
+| Multiple `OnStopping` | All fire in reverse registration order |
+
+## Error handling
+
+| Scenario | Behavior |
+|----------|----------|
+| `OnStarted` throws | State → `FailedToStart`, error logged. Restartable from dashboard. |
+| `WithInterval` tick throws | Error logged, tick skipped. Timer continues. After N consecutive failures (configurable), state → `Unhealthy`. |
+| `RunAsync` throws (not `OperationCanceledException`) | State → `FailedToStart`, error logged. Restartable from dashboard. |
+| `RunAsync` catches `OperationCanceledException` | Normal stop. State → `Stopped`. |
+| `OnStopping` throws | Error logged. Stop proceeds — resource still transitions to Stopped. |
+
+## Migration guide
+
+### From `WithInitialState` + `OnInitializeResource`
+
+```csharp
+// Before:
+builder.AddResource(myResource)
+    .WithInitialState(new CustomResourceSnapshot
+    {
+        ResourceType = "MyResource",
+        CreationTimeStamp = DateTime.UtcNow,
+        State = KnownResourceStates.NotStarted,
+        Properties = [new("Source", "my-source")]
+    })
+    .OnInitializeResource(async (resource, @event, token) =>
+    {
+        await @event.Eventing.PublishAsync(
+            new BeforeResourceStartedEvent(resource, @event.Services), token);
+        await @event.Notifications.PublishUpdateAsync(resource, s => s with
+        {
+            StartTimeStamp = DateTime.UtcNow,
+            State = KnownResourceStates.Running
+        });
+        while (!token.IsCancellationRequested)
+        {
+            // ... work ...
+            await Task.Delay(interval, token);
+        }
+    });
+
+// After:
+builder.AddResource(myResource)
+    .WithResourceType("MyResource")
+    .WithProperty("Source", "my-source")
+    .WithInterval(interval, async (ctx, tick) =>
+    {
+        // ... work ...
+    });
+```
+
+### From `OnResourceReady` / `OnResourceStopped` (bound lifecycle)
+
+```csharp
+// Before:
+parentBuilder.OnResourceReady(async (parent, e, ct) =>
+{
+    var notifications = e.Services.GetRequiredService<ResourceNotificationService>();
+    var eventing = e.Services.GetRequiredService<IDistributedApplicationEventing>();
+    await eventing.PublishAsync<BeforeResourceStartedEvent>(
+        new(childResource, e.Services), EventDispatchBehavior.NonBlockingSequential, ct);
+    await notifications.PublishUpdateAsync(childResource, s => s with
+    {
+        State = KnownResourceStates.Starting,
+        StartTimeStamp = DateTime.UtcNow
+    });
+    // ... setup ...
+    await notifications.PublishUpdateAsync(childResource, s => s with
+    {
+        State = KnownResourceStates.Running
+    });
+});
+parentBuilder.OnResourceStopped(async (parent, e, ct) =>
+{
+    var notifications = e.Services.GetRequiredService<ResourceNotificationService>();
+    await notifications.PublishUpdateAsync(childResource, s => s with
+    {
+        State = KnownResourceStates.Finished,
+        StopTimeStamp = DateTime.UtcNow,
+        Urls = [.. s.Urls.Select(u => u with { IsInactive = true })]
+    });
+});
+
+// After:
+childBuilder
+    .BoundTo(parentBuilder)
+    .OnStarted(async ctx =>
+    {
+        // ... setup (just the custom part) ...
+    });
+```
+
+## Implementation phases
+
+| Phase | Scope | Dependencies |
+|-------|-------|-------------|
+| **1. Source-scoped slices** | Internal plumbing: per-source collection tracking in `ResourceNotificationService`, `PublishSlicedUpdateAsync` for DCP, refactor `ResourceSnapshotBuilder` and `ApplicationOrchestrator`. Fixes #13647. | None |
+| **2. `ResourceContext` + public API** | New `ResourceContext` class, targeted public methods on `ResourceNotificationService`, builder helpers (`WithResourceType`, `WithProperty`), `CreationTimeStamp` auto-default. Improves #10365 ergonomics. | Phase 1 |
+| **3. Lifecycle host + triggers** | `WithInterval`, `BoundTo`, `OnStarted`, `OnStopping`, `RunAsync`. Framework state machine, auto-events, auto-commands, Start/Stop routing for custom resources. | Phase 2 |
+| **4. TypeScript parity** | Code-gen changes to emit new methods on `ResourceNotificationService`, `InitializeResourceEvent`, and resource builders. | Phase 3 |
+
+Each phase is independently shippable and useful. Phase 1 alone fixes the clobbering bug. Phase 2 alone improves ergonomics. Phase 3 eliminates boilerplate.
+
+## Open questions
+
+1. **`RunAsync` exclusivity.** Should `RunAsync` be mutually exclusive with `WithInterval` and `BoundTo`, or should they compose? Recommendation: exclusive — `RunAsync` IS the lifecycle, and combining it with a timer or binding creates ambiguity about who owns the state machine.
+
+2. **`WithInterval` error threshold.** How many consecutive tick failures before the resource is marked unhealthy? A configurable default (e.g., 3) with an override parameter seems right.
+
+3. **`BoundTo` vs `WaitFor`.** `BoundTo(source)` means "my lifecycle follows the source." `WaitFor(source)` means "don't start me until the source is ready, but I have my own lifecycle." These are distinct and both useful. `BoundTo` implies `WaitFor`, but `WaitFor` does not imply `BoundTo`.
+
+4. **`PublishUpdateAsync` collection semantics.** When existing code does `s => s with { Urls = [myUrl] }`, should this replace only the `"user"` source's URLs (breaking: user loses all other URLs from `s.Urls` they might have appended), or set the full merged collection (non-breaking but clobbers DCP URLs)? Recommendation: write to `"user"` source only, and log a warning when collection fields are set via the legacy API to guide migration.
+
+5. **`ResourceContext` lifetime on restart.** On restart, should a fresh `ResourceContext` be created (all tracked disposables disposed, fresh state)? Recommendation: yes — restart is a full stop + start cycle.
+
+6. **Naming.** `BoundTo` vs `FollowLifecycle` vs `DependsOn`? `RunAsync` vs `WithLifecycle` vs `ExecuteAsync`? `OnStarted` vs `OnStart`? Naming TBD pending API review.

--- a/docs/specs/custom-resource-lifecycle.md
+++ b/docs/specs/custom-resource-lifecycle.md
@@ -471,6 +471,161 @@ Dashboard "Start" click
 
 Resources that implement `IResourceWithoutLifecycle` (or otherwise opt out) are skipped — they do not appear in Start/Stop/Restart command lists.
 
+## Layer 4: Endpoints and DCP interop
+
+Custom resources need to do two things that the layers above don't cover:
+1. **Expose endpoints** that other resources (DCP-managed or not) can resolve through `EndpointReference` and service discovery.
+2. **Interact with DCP-managed resources** — wait for them, reference their endpoints, and (in some cases) extend their snapshot.
+
+### Endpoints on custom resources
+
+Today, only DCP allocates ports. A custom resource that wants to expose an HTTP server has no way to participate in the endpoint allocation pipeline that fills in `AllocatedEndpoint`, and `EndpointReference` against it returns nothing usable.
+
+The proposal: the orchestrator gains an endpoint allocator that runs for **any** resource with `EndpointAnnotation`s, not just DCP resources. For custom resources, the allocator runs as part of the framework ceremony **before** `OnInitializeResource` is invoked.
+
+```csharp
+// Same WithEndpoint API as today.
+builder.AddResource(new InMemoryHttpResource("web"))
+    .WithEndpoint(port: null, targetPort: null, name: "http", scheme: "http")
+    .WithEndpoint(port: null, targetPort: null, name: "https", scheme: "https")
+    .OnInitializeResource(async (ctx, ct) =>
+    {
+        // Endpoints are already allocated by the time the callback runs.
+        var resource = (InMemoryHttpResource)ctx.Resource;
+        var http  = resource.GetEndpoint("http");   // AllocatedEndpoint is populated
+        var https = resource.GetEndpoint("https");
+
+        await using var server = WebApplication.Create();
+        server.Urls.Add(http.Url);
+        server.Urls.Add(https.Url);
+        await server.StartAsync(ct);
+        ctx.Track(server);
+
+        await ctx.SetStateAsync(KnownResourceStates.Running, ct);
+        await Task.Delay(Timeout.Infinite, ct);
+    });
+```
+
+What the framework provides automatically for custom-resource endpoints:
+
+| Concern | Behavior |
+|---------|----------|
+| Port allocation | Walks `EndpointAnnotation`s; for any with `Port == null`, picks an available port from a configurable range (default same as DCP's). |
+| `AllocatedEndpoint` | Populated on each `EndpointAnnotation` before `OnInitializeResource` runs. |
+| `EndpointReference` resolution | Works against the custom resource exactly as it does for a container. |
+| Service discovery export | `WithReference(custom)` exports the allocated endpoints into the consumer's config. |
+| `ResourceEndpointsAllocatedEvent` | Fires after allocation, before `OnInitializeResource`. |
+| Dashboard URLs | Endpoints surface in the dashboard URL list automatically — no `WithUrl` needed for endpoint-derived URLs. |
+| Restart | On Restart, ports are reallocated (or the previously-allocated port is reused if still free). |
+
+Resources that want to opt out of automatic allocation (because they manage their own port assignment) implement `IResourceWithoutAutomaticEndpointAllocation` or pass `WithEndpoint(allocateAutomatically: false, ...)`.
+
+This same allocator path is what `DevTunnelPortResource` would use today instead of hand-constructing `AllocatedEndpoint` inside its callback.
+
+### Interacting with DCP-managed resources
+
+Custom resources frequently need to coordinate with Containers, Projects, and Executables — wait for them to be ready, read their endpoints, or extend their snapshot. The proposal addresses each pattern explicitly.
+
+#### 1. Waiting on a DCP resource
+
+`WaitForResourceHealthyAsync` / `WaitForResourceAsync` on `ctx.Notifications` work uniformly across DCP and custom resources. No new API needed.
+
+```csharp
+.OnInitializeResource(async (ctx, ct) =>
+{
+    await ctx.Notifications.WaitForResourceHealthyAsync("postgres", ct);
+    // ... do work that depends on postgres being ready ...
+});
+```
+
+#### 2. Reading a DCP resource's endpoints
+
+`EndpointReference` is already the right primitive — it works whether the source resource is a container, project, or custom resource:
+
+```csharp
+var dbEndpoint = postgresBuilder.GetEndpoint("tcp");
+
+builder.AddResource(new MigratorResource("migrator"))
+    .OnInitializeResource(async (ctx, ct) =>
+    {
+        await ctx.Notifications.WaitForResourceHealthyAsync(postgresBuilder.Resource.Name, ct);
+
+        // EndpointReference resolves to the actual host/port at runtime.
+        var migrator = new SqlMigrator($"Host={dbEndpoint.Host};Port={dbEndpoint.Port};...");
+        await migrator.RunAsync(ct);
+
+        await ctx.SetStateAsync(KnownResourceStates.Finished, ct);
+    });
+```
+
+#### 3. Extending a DCP resource's snapshot
+
+Adding URLs or properties to an existing DCP resource works because of Layer 1 (source-scoped slices). The user updates land in the `"user"` source and merge with DCP's updates:
+
+```csharp
+builder.AddContainer("nginx", "nginx")
+    .OnInitializeResource(async (ctx, ct) =>
+    {
+        // Adds a URL to a DCP-managed container. The framework keeps it across
+        // DCP refreshes because user-scoped slices are never overwritten by DCP.
+        await ctx.AddUrlAsync(new UrlSnapshot("Docs", "https://nginx.org/", false), ct);
+        await ctx.SetPropertyAsync("origin", "internal-mirror", ct: ct);
+    });
+```
+
+Note: `OnInitializeResource` on a DCP-managed resource doesn't replace DCP's lifecycle — DCP still owns the container's process, state machine, and primary URL set. The user callback runs alongside DCP's management to add user-scoped data. The callback's cancellation token is tied to the DCP resource's lifecycle so it stops when the container stops.
+
+#### 4. Scalar state conflicts on shared resources
+
+URLs, properties, env vars, volumes, and relationships are **collections** — multi-source merging is well-defined.
+
+`State`, `ExitCode`, and timestamps are **scalars** — they have one authoritative owner per resource:
+
+| Resource kind | Owner of scalar state |
+|---|---|
+| DCP-managed (Container/Project/Executable) | DCP |
+| Custom resource using the new `OnInitializeResource` overload | The framework lifecycle host |
+| Custom resource using the legacy `OnInitializeResource` overload | The author |
+
+User attempts to set scalar state via `ctx.SetStateAsync` on a DCP-owned resource go to a **user-override slot** that takes precedence only when explicitly set. This preserves the existing escape hatch (`PublishUpdateAsync(c, s => s with { State = "Custom" })` still works) while making the precedence rules explicit.
+
+### Bound-lifecycle resources (DevTunnelPort): re-start on source restart
+
+The bound-lifecycle case (a custom resource whose lifetime tracks a DCP-managed parent) requires special wiring beyond what the bare lifecycle hook provides. Without help, the author's callback returns when the parent stops, the framework marks the child `Finished`, and nothing re-invokes the callback when the parent restarts.
+
+The framework supplies a single annotation that wires this for the author:
+
+```csharp
+/// <summary>
+/// Causes the framework to re-invoke this resource's OnInitializeResource callback
+/// whenever <paramref name="source"/> transitions back to a healthy state after stopping.
+/// Combined with WaitForResourceAsync calls in the callback, this implements the
+/// bound-lifecycle pattern (e.g. DevTunnelPort following its parent tunnel).
+/// </summary>
+public static IResourceBuilder<T> WithRestartOnSourceRestart<T, TSource>(
+    this IResourceBuilder<T> builder,
+    IResourceBuilder<TSource> source)
+    where T : IResource
+    where TSource : IResource;
+```
+
+With this, the DevTunnelPort example becomes self-restarting:
+
+```csharp
+portBuilder
+    .WithRestartOnSourceRestart(tunnelBuilder)
+    .OnInitializeResource(async (ctx, ct) =>
+    {
+        await ctx.Notifications.WaitForResourceHealthyAsync(tunnel.Resource.Name, ct);
+        // ... setup ...
+        await ctx.SetStateAsync(KnownResourceStates.Running, ct);
+        await ctx.Notifications.WaitForResourceAsync(tunnel.Resource.Name,
+            [KnownResourceStates.Finished, KnownResourceStates.Exited], ct);
+    });
+```
+
+This is the only annotation needed to bridge "manual wait-for-state in the callback" and "framework knows to re-invoke on parent restart." It's strictly additive; resources that don't need this behavior don't use it.
+
 ## TypeScript API
 
 The TypeScript API mirrors the C# API through the polyglot code-generation system.
@@ -626,8 +781,10 @@ Each phase is independently shippable and useful. Phase 1 alone fixes the clobbe
 
 4. **`ResourceContext` lifetime on restart.** On restart, should a fresh `ResourceContext` be created (all tracked disposables disposed, fresh state)? Recommendation: yes — restart is a full stop + start cycle.
 
-5. **Endpoint integration.** Custom resources that expose endpoints (e.g., a user-defined HTTP server resource — see [#16640](https://github.com/microsoft/aspire/issues/16640)) need a way to declare ports that are then surfaced through service discovery and `EndpointReference`. This is adjacent to lifecycle but not covered by this proposal; it's tracked separately.
+5. **Endpoint allocator extraction.** Layer 4 requires factoring the port-allocation logic out of DCP so the orchestrator can drive it for custom resources too. The DCP code path keeps using the extracted allocator unchanged; custom resources call it before `OnInitializeResource`. Scope is contained but the refactor touches DCP — TBD whether to ship Layer 4 in the same PR as Layers 1-3 or as an immediate follow-up.
 
-6. **`ExecutionConfigurationBuilder` integration.** Custom resources that produce a process (env vars + arguments) currently need bespoke coordination (see [#14954](https://github.com/microsoft/aspire/issues/14954)). `IResourceWithArguments` / `IResourceWithEnvironment` interop with `ResourceContext` is a follow-up, not part of this proposal.
+6. **Scalar state on shared resources.** Layer 4 introduces a "user-override slot" for scalar fields (`State`, `ExitCode`) on DCP-managed resources so user callbacks can override DCP's value. Alternative: reject user scalar writes on DCP resources outright (more predictable, more breaking). Recommendation: user-override with logging, matching today's behavior.
 
-7. **Health checks vs `State`.** Continuous health-like signals (`Healthy` / `Degraded`) should be expressed with `WithHealthCheck`, not by overloading the `State` field. This is documentation/guidance, not a code change in this spec.
+7. **`ExecutionConfigurationBuilder` integration.** Custom resources that produce a process (env vars + arguments) currently need bespoke coordination (see [#14954](https://github.com/microsoft/aspire/issues/14954)). `IResourceWithArguments` / `IResourceWithEnvironment` interop with `ResourceContext` is a follow-up, not part of this proposal.
+
+8. **Health checks vs `State`.** Continuous health-like signals (`Healthy` / `Degraded`) should be expressed with `WithHealthCheck`, not by overloading the `State` field. This is documentation/guidance, not a code change in this spec.

--- a/docs/specs/custom-resource-lifecycle.md
+++ b/docs/specs/custom-resource-lifecycle.md
@@ -37,13 +37,13 @@ The "Hello World" URL disappears because `ResourceSnapshotBuilder.ToSnapshot` re
 
 ## Design principles
 
-This proposal is modeled after UI frameworks:
+This proposal keeps a single, consistent level of abstraction. There is **one** lifecycle pattern for custom resources, plus targeted helpers that remove the most painful boilerplate. The framework takes ownership of the ceremony around lifecycle (events, timestamps, commands, state-machine wrap-up) but the author still owns the body of the lifecycle method.
 
-1. **Targeted updates, not wholesale replacement.** Like a UI framework where each component updates its own state without clobbering siblings, each producer (DCP, orchestrator, user code) updates only its slice of the resource snapshot.
+1. **Targeted updates, not wholesale replacement.** Each producer (DCP, orchestrator, user code) updates only its slice of the resource snapshot. Producers cannot clobber each other.
 
-2. **Framework owns the lifecycle loop.** Like a UI framework that calls your render/update function rather than you writing a `while` loop, the Aspire framework manages the resource state machine and calls your callbacks at the right time.
+2. **One lifecycle hook, framework-managed ceremony.** A single `OnLifecycle(async (ctx, ct) => ...)` hook. The framework fires lifecycle events, sets timestamps, and wires Start/Stop/Restart commands around it. The author writes whatever logic they need inside it — a loop, an event subscription, a one-shot call.
 
-3. **Reactive triggers, not imperative loops.** Resource authors declare *what drives their resource* (a timer, another resource's events, an external stream) and provide callbacks. The framework manages when those callbacks fire, including start, stop, and restart.
+3. **A focused context, not a snapshot constructor.** A new `ResourceContext` exposes targeted methods (`SetStateAsync`, `SetPropertyAsync`, `AddUrlAsync`) so authors update just the fields they care about, never reconstruct a whole snapshot.
 
 ## Architecture
 
@@ -52,14 +52,14 @@ This proposal is modeled after UI frameworks:
 │              ResourceNotificationService                    │
 │    (merges slices from all producers into one snapshot)     │
 │                                                             │
-│  ┌────────┐  ┌────────┐  ┌────────┐  ┌────────┐           │
-│  │ State  │  │  URLs  │  │  Props │  │  Env   │  ...       │
-│  │ slice  │  │ slice  │  │ slice  │  │ slice  │            │
-│  └───▲────┘  └───▲────┘  └───▲────┘  └───▲────┘           │
+│  ┌────────┐  ┌────────┐  ┌────────┐  ┌────────┐             │
+│  │ State  │  │  URLs  │  │  Props │  │  Env   │  ...        │
+│  │ slice  │  │ slice  │  │ slice  │  │ slice  │             │
+│  └───▲────┘  └───▲────┘  └───▲────┘  └───▲────┘             │
 │      │           │           │           │                  │
 └──────┼───────────┼───────────┼───────────┼──────────────────┘
        │           │           │           │
-  ┌────┴──┐  ┌────┴──┐   ┌────┴──┐  ┌────┴──┐
+  ┌────┴──┐  ┌─────┴─┐   ┌─────┴─┐  ┌──────┴┐
   │  DCP  │  │Orchest│   │ User  │  │ User  │
   │watcher│  │rator  │   │ code  │  │ code  │
   └───────┘  └───────┘   └───────┘  └───────┘
@@ -119,11 +119,13 @@ notifications.PublishSlicedUpdateAsync(resource, "dcp", batch =>
 
 `PublishUpdateAsync(resource, Func<CustomResourceSnapshot, CustomResourceSnapshot>)` continues to work exactly as today for scalar fields (`State`, `ExitCode`, timestamps). For collection fields, writes are routed to the `"user"` source. This means existing code that appends to `Urls` via `s => s with { Urls = [..s.Urls, myUrl] }` correctly adds to the user slice without affecting DCP-owned URLs.
 
+Layer 1 is independently shippable and fixes #13647 on its own. Nothing else in this spec depends on the layers above also shipping.
+
 ## Layer 2: `ResourceContext` and targeted public API
 
 ### `ResourceContext`
 
-A new class that provides the state-update surface for resource authors. It's the "component API" — the thing you use to tell the dashboard what to show.
+A new class that provides the state-update surface for resource authors. Instead of constructing whole `CustomResourceSnapshot` records, authors use targeted setters.
 
 ```csharp
 public class ResourceContext
@@ -138,23 +140,28 @@ public class ResourceContext
     public IServiceProvider Services { get; }
 
     /// <summary>Updates the resource state shown in the dashboard.</summary>
-    public Task SetStateAsync(ResourceStateSnapshot state);
+    public Task SetStateAsync(ResourceStateSnapshot state, CancellationToken ct = default);
 
-    /// <summary>Updates the resource state shown in the dashboard.</summary>
-    public Task SetStateAsync(string state);
+    /// <summary>
+    /// Updates the resource state. The string should typically be a value from
+    /// <see cref="KnownResourceStates"/> so the dashboard renders consistent styling
+    /// and behavior. Custom values are allowed but rendered as plain text.
+    /// </summary>
+    public Task SetStateAsync(string state, CancellationToken ct = default);
 
     /// <summary>Sets a property shown in the resource details panel.</summary>
-    public Task SetPropertyAsync(string name, object? value, bool isSensitive = false);
+    public Task SetPropertyAsync(string name, object? value, bool isSensitive = false, CancellationToken ct = default);
 
     /// <summary>Adds or updates a URL shown in the dashboard.</summary>
-    public Task AddUrlAsync(UrlSnapshot url);
+    public Task AddUrlAsync(UrlSnapshot url, CancellationToken ct = default);
 
     /// <summary>Removes a URL by name.</summary>
-    public Task RemoveUrlAsync(string urlName);
+    public Task RemoveUrlAsync(string urlName, CancellationToken ct = default);
 
     /// <summary>
     /// Tracks a disposable that will be disposed when the resource stops.
-    /// Use this for connections, clients, or other resources with cleanup.
+    /// Use this for connections, clients, or other resources with cleanup
+    /// instead of writing try/finally blocks around your loop.
     /// </summary>
     public void Track(IAsyncDisposable disposable);
 
@@ -168,7 +175,7 @@ public class ResourceContext
 
 ### Targeted methods on `ResourceNotificationService`
 
-In addition to the existing `PublishUpdateAsync`, new public methods for targeted updates:
+In addition to the existing `PublishUpdateAsync`, new public methods for targeted updates so callers who don't have a `ResourceContext` (event handlers, custom commands, lifecycle hooks) can still update single fields:
 
 ```csharp
 public class ResourceNotificationService
@@ -189,6 +196,8 @@ public class ResourceNotificationService
 
 ### Builder extensions
 
+Registration-time helpers that replace the need to construct a full `CustomResourceSnapshot`:
+
 ```csharp
 /// <summary>Sets the resource type shown in the dashboard Type column.</summary>
 public static IResourceBuilder<T> WithResourceType<T>(
@@ -202,38 +211,79 @@ public static IResourceBuilder<T> WithProperty<T>(
     where T : IResource;
 ```
 
-These are additive — `WithInitialState` remains for backward compatibility but is no longer the recommended way to set resource type and properties.
+These are additive — `WithInitialState` remains for backward compatibility but is marked `[Obsolete(error: false)]` to steer new code toward the helpers.
 
-## Layer 3: Framework-owned lifecycle
+### Custom commands also receive a `ResourceContext`
 
-### The four lifecycle primitives
-
-Every custom resource is driven by one of four things. The framework provides a primitive for each:
-
-| Driver | Primitive | When to use |
-|--------|-----------|-------------|
-| Time | `WithInterval(period, onTick)` | Periodic polling, status refresh |
-| Another resource | `BoundTo(source)` | Port follows tunnel, sidecar follows container |
-| External stream | `RunAsync(execute)` | Streaming connections, subprocess management |
-| One-shot | `OnStarted(callback)` | Setup-and-done resources, external services |
-
-All four share the same `ResourceContext` for state updates, and all four get automatic lifecycle management.
-
-### `WithInterval` — framework-owned timer
+To address the most common reason authors reach for `ResourceNotificationService` from a custom command, the `WithCommand` callback signature is extended to provide a `ResourceContext`:
 
 ```csharp
-/// <summary>
-/// Registers a periodic callback. The framework starts the timer when the resource starts
-/// and stops it when the resource stops. No while loop needed.
-/// </summary>
-public static IResourceBuilder<T> WithInterval<T>(
+public static IResourceBuilder<T> WithCommand<T>(
     this IResourceBuilder<T> builder,
-    TimeSpan period,
-    Func<ResourceContext, long, Task> onTick)
+    string name,
+    string displayName,
+    Func<ResourceContext, ExecuteCommandContext, Task<ExecuteCommandResult>> executeCommand,
+    /* existing parameters */)
     where T : IResource;
 ```
 
-**Example — TalkingClock:**
+This is purely additive; existing `WithCommand` overloads continue to work.
+
+## Layer 3: One lifecycle hook, framework-managed ceremony
+
+### The single primitive: `OnLifecycle`
+
+A custom resource that wants to participate in the dashboard lifecycle implements one hook:
+
+```csharp
+/// <summary>
+/// Registers the lifecycle body for this resource. The framework owns the surrounding
+/// ceremony (lifecycle events, timestamps, command wiring, cleanup of tracked
+/// disposables). The author owns whatever happens inside the callback.
+/// </summary>
+/// <remarks>
+/// The framework calls the callback when the resource should start (auto-start at
+/// app startup, or in response to a Start/Restart command). The cancellation token
+/// is cancelled when the resource should stop. The callback should observe the token
+/// and return promptly. If the callback throws, the framework transitions the resource
+/// to <see cref="KnownResourceStates.FailedToStart"/> (if it never reached Running)
+/// or <see cref="KnownResourceStates.Exited"/> (if it did) and exposes the failure
+/// in the dashboard.
+/// </remarks>
+public static IResourceBuilder<T> OnLifecycle<T>(
+    this IResourceBuilder<T> builder,
+    Func<ResourceContext, CancellationToken, Task> lifecycle)
+    where T : IResource;
+```
+
+That's the entire third layer.
+
+### What the framework handles around `OnLifecycle`
+
+| Concern | Framework behavior |
+|---------|-------------------|
+| **Registration** | Sets `CreationTimeStamp` and initial `State = NotStarted`. |
+| **Start** | Fires `BeforeResourceStartedEvent`, transitions to `Starting`, sets `StartTimeStamp`, then invokes the callback with a fresh `CancellationToken`. |
+| **Stop / Restart commands** | Wires Start/Stop/Restart dashboard commands. Stop cancels the token; Restart does stop-then-start. |
+| **URL resolution** | Auto-resolves `ResourceUrlAnnotation`s into `UrlSnapshot`s on start. |
+| **URL active state** | Marks URLs active on start, inactive on stop. |
+| **`WaitFor` support** | Works automatically because `BeforeResourceStartedEvent` fires at the right time. |
+| **Normal return** | If the author hasn't already set a terminal state (`Finished`, `Exited`, etc.), the framework sets `State = Finished`, `StopTimeStamp`. Fires `ResourceStoppedEvent`. |
+| **Cancellation** | Same as normal return, plus the framework swallows `OperationCanceledException` thrown by the token. |
+| **Exception** | If the author has not yet transitioned to `Running`, state → `FailedToStart`. Otherwise state → `Exited` with the exception logged. Either way, `StopTimeStamp` is set and `ResourceStoppedEvent` fires. The resource remains restartable. |
+| **Cleanup** | All disposables tracked via `ctx.Track(...)` are disposed in reverse registration order after the callback returns or throws, before the resource transitions to its terminal state. |
+
+The author is responsible for transitioning to `Running` (or another live state) when their resource is actually ready, because only the author knows when that is. The framework cannot guess.
+
+### Resources that opt out of lifecycle
+
+A resource that doesn't implement `IResourceWithLifetime` (or implements a marker like `IResourceWithoutLifecycle`) is skipped by the framework's start/stop machinery, doesn't get Start/Stop/Restart commands, and its `OnLifecycle` registration (if any) is treated as a no-op. This covers things like `ParameterResource` and other configuration-style resources that don't have a meaningful runtime lifecycle.
+
+### Examples
+
+These are the four common patterns. They all use the same `OnLifecycle` hook; the body varies.
+
+#### Periodic (replaces TalkingClock today)
 
 ```csharp
 builder.AddResource(new TalkingClockResource("clock"))
@@ -241,156 +291,142 @@ builder.AddResource(new TalkingClockResource("clock"))
     .WithResourceType("TalkingClock")
     .WithProperty(CustomResourceKnownProperties.Source, "Talking Clock")
     .WithUrl("https://www.speaking-clock.com/", "Speaking Clock")
-    .WithInterval(TimeSpan.FromSeconds(1), async (ctx, tick) =>
+    .OnLifecycle(async (ctx, ct) =>
     {
-        await ctx.SetStateAsync(tick % 2 == 0
-            ? new ResourceStateSnapshot("Tick", KnownResourceStateStyles.Success)
-            : new ResourceStateSnapshot("Tock", KnownResourceStateStyles.Success));
-    });
-```
-
-Compare to the [current TalkingClock implementation](../../playground/CustomResources/CustomResources.AppHost/TalkingClockResource.cs) which requires ~30 lines, manual `BeforeResourceStartedEvent` firing, manual timestamps, manual `while` loop, and manual `PublishUpdateAsync` calls.
-
-### `BoundTo` — lifecycle follows another resource
-
-```csharp
-/// <summary>
-/// Binds this resource's lifecycle to another resource. The framework automatically:
-/// - Starts this resource when the source becomes ready
-/// - Stops this resource when the source stops
-/// - Restarts this resource when the source restarts
-/// - Fires all lifecycle events (BeforeResourceStartedEvent, etc.)
-/// - Manages timestamps and URL active/inactive state
-/// </summary>
-public static IResourceBuilder<T> BoundTo<T, TSource>(
-    this IResourceBuilder<T> builder,
-    IResourceBuilder<TSource> source)
-    where T : IResource
-    where TSource : IResource;
-```
-
-**Example — DevTunnelPort:**
-
-```csharp
-// Today: ~130 lines across OnResourceReady + OnResourceStopped handlers
-// that manually fire events, set state, allocate endpoints, toggle URL
-// activity, manage timestamps, and publish ResourceStoppedEvent.
-
-// Proposed:
-portBuilder
-    .BoundTo(tunnelBuilder)
-    .OnStarted(async ctx =>
-    {
-        // Framework already: fired BeforeResourceStartedEvent,
-        // set Starting, set StartTimeStamp.
-        // Do only the port-specific work:
-        var port = (DevTunnelPortResource)ctx.Resource;
-        var tunnelPort = port.LastKnownStatus!;
-        port.TunnelEndpointAnnotation.AllocatedEndpoint =
-            new(port.TunnelEndpointAnnotation, tunnelPort.PortUri!.Host, 443);
-        // Framework auto-resolves URLs from annotations
-    });
-    // On tunnel stop: framework sets Stopped, StopTimeStamp,
-    // marks URLs inactive, fires ResourceStoppedEvent.
-```
-
-#### What `BoundTo` does automatically
-
-1. **Subscribes to source `ResourceReadyEvent`** → starts this resource
-2. **Subscribes to source `ResourceStoppedEvent`** → stops this resource
-3. **Handles source restart** → stops this resource, then re-starts when source is ready again
-4. **Wires Start/Stop/Restart commands** — but Start is gated on source being ready
-5. **Fires all lifecycle events** (`BeforeResourceStartedEvent`, `ResourceEndpointsAllocatedEvent`, `ResourceStoppedEvent`)
-6. **Manages timestamps** (`StartTimeStamp`, `StopTimeStamp`)
-7. **Toggles URL active state** — URLs marked inactive on stop, active on start
-
-### `RunAsync` — author-owned loop (escape hatch)
-
-```csharp
-/// <summary>
-/// Registers an async function that runs while the resource is started.
-/// The stoppingToken is cancelled when the resource should stop.
-/// Use this for streaming connections, subprocess management, or any case
-/// where the resource needs a long-running loop.
-/// </summary>
-public static IResourceBuilder<T> RunAsync<T>(
-    this IResourceBuilder<T> builder,
-    Func<ResourceContext, CancellationToken, Task> execute)
-    where T : IResource;
-```
-
-**Example — Kafka monitor:**
-
-```csharp
-builder.AddResource(new KafkaMonitorResource("kafka-monitor"))
-    .WithResourceType("KafkaMonitor")
-    .RunAsync(async (ctx, stoppingToken) =>
-    {
-        var consumer = new KafkaConsumer(ctx.Get<KafkaConfig>().BootstrapServers);
-        ctx.Track(consumer);
-
-        await foreach (var msg in consumer.ConsumeAsync(stoppingToken))
+        await ctx.SetStateAsync(KnownResourceStates.Running, ct);
+        long tick = 0;
+        while (!ct.IsCancellationRequested)
         {
-            await ctx.SetPropertyAsync("last-offset", msg.Offset);
-            await ctx.SetPropertyAsync("last-timestamp", msg.Timestamp);
+            await ctx.SetStateAsync(tick++ % 2 == 0
+                ? new ResourceStateSnapshot("Tick", KnownResourceStateStyles.Success)
+                : new ResourceStateSnapshot("Tock", KnownResourceStateStyles.Success), ct);
+            await Task.Delay(TimeSpan.FromSeconds(1), ct);
         }
     });
 ```
 
-### `OnStarted` / `OnStopping` — one-shot setup and cleanup
+Compare to the [current TalkingClock implementation](../../playground/CustomResources/CustomResources.AppHost/TalkingClockResource.cs): ~30 lines, manual `BeforeResourceStartedEvent` firing, manual timestamps, manual snapshot construction. The above is ~12 lines and the framework handles the rest.
+
+#### Bound to another resource (replaces DevTunnelPort manual subscriptions)
+
+When a resource's lifecycle follows another resource, the author waits for the source resource's state directly using existing notification APIs. No new primitive needed:
 
 ```csharp
-/// <summary>
-/// Registers a callback that runs once when the resource starts.
-/// Use this for setup that doesn't require a long-running loop.
-/// </summary>
-public static IResourceBuilder<T> OnStarted<T>(
-    this IResourceBuilder<T> builder,
-    Func<ResourceContext, Task> onStarted)
-    where T : IResource;
+portBuilder.OnLifecycle(async (ctx, ct) =>
+{
+    var notifications = ctx.Services.GetRequiredService<ResourceNotificationService>();
 
-/// <summary>
-/// Registers a callback that runs when the resource is stopping.
-/// Use this for cleanup.
-/// </summary>
-public static IResourceBuilder<T> OnStopping<T>(
-    this IResourceBuilder<T> builder,
-    Func<ResourceContext, Task> onStopping)
-    where T : IResource;
+    // Wait for the parent tunnel to be ready.
+    await notifications.WaitForResourceHealthyAsync(tunnel.Resource.Name, ct);
+
+    // Do the port-specific setup.
+    var port = (DevTunnelPortResource)ctx.Resource;
+    var tunnelPort = port.LastKnownStatus!;
+    port.TunnelEndpointAnnotation.AllocatedEndpoint =
+        new(port.TunnelEndpointAnnotation, tunnelPort.PortUri!.Host, 443);
+
+    await ctx.SetStateAsync(KnownResourceStates.Running, ct);
+
+    // Wait for the parent tunnel to stop, then return so the framework can
+    // tear us down. If the parent restarts, the framework's restart logic
+    // will re-invoke this callback.
+    await notifications.WaitForResourceAsync(
+        tunnel.Resource.Name,
+        [KnownResourceStates.Finished, KnownResourceStates.Exited, KnownResourceStates.FailedToStart],
+        ct);
+});
 ```
 
-**Example — external service:**
+This replaces ~130 lines of manual ceremony in the current `DevTunnelPortResource` (`OnResourceReady` + `OnResourceStopped` handlers that manually fire events, set state, allocate endpoints, toggle URL activity, manage timestamps, publish `ResourceStoppedEvent`).
+
+#### Streaming / long-running loop (Kafka monitor)
+
+```csharp
+builder.AddResource(new KafkaMonitorResource("kafka-monitor"))
+    .WithResourceType("KafkaMonitor")
+    .OnLifecycle(async (ctx, ct) =>
+    {
+        var consumer = new KafkaConsumer(ctx.Get<KafkaConfig>().BootstrapServers);
+        ctx.Track(consumer); // disposed by the framework on stop
+
+        await ctx.SetStateAsync(KnownResourceStates.Running, ct);
+
+        await foreach (var msg in consumer.ConsumeAsync(ct))
+        {
+            await ctx.SetPropertyAsync("last-offset", msg.Offset, ct: ct);
+            await ctx.SetPropertyAsync("last-timestamp", msg.Timestamp, ct: ct);
+        }
+    });
+```
+
+#### One-shot setup (external service health probe)
 
 ```csharp
 builder.AddResource(new ExternalApiResource("payments-api"))
     .WithResourceType("ExternalAPI")
     .WithUrl("https://api.payments.com", "API")
-    .OnStarted(async ctx =>
+    .OnLifecycle(async (ctx, ct) =>
     {
         var client = new HttpClient();
         ctx.Track(client);
-        var response = await client.GetAsync("https://api.payments.com/health");
-        await ctx.SetStateAsync(response.IsSuccessStatusCode ? "Healthy" : "Degraded");
+
+        var response = await client.GetAsync("https://api.payments.com/health", ct);
+        response.EnsureSuccessStatusCode();
+
+        await ctx.SetStateAsync(KnownResourceStates.Running, ct);
+
+        // Stay alive until shutdown. Health is reported via a separate health check.
+        await Task.Delay(Timeout.Infinite, ct);
     });
 ```
 
-### What the framework handles automatically
+(Continuous health is best expressed with `WithHealthCheck`, not with the `State` field. The dashboard renders a separate health badge for this.)
 
-For all four primitives, the framework provides:
+### Optional helpers (built on `OnLifecycle`)
 
-| Concern | What the framework does |
-|---------|------------------------|
-| **State machine** | Manages NotStarted → Starting → Running → Stopping → Stopped transitions |
-| **Timestamps** | Sets `CreationTimeStamp` at registration, `StartTimeStamp` on start, `StopTimeStamp` on stop |
-| **Lifecycle events** | Fires `BeforeResourceStartedEvent` before calling callbacks; fires `ResourceStoppedEvent` on stop |
-| **Dashboard commands** | Wires Start/Stop/Restart commands automatically |
-| **URL resolution** | Auto-resolves `ResourceUrlAnnotation`s into `UrlSnapshot`s |
-| **URL active state** | Marks URLs inactive on stop, active on start |
-| **`WaitFor` support** | Works automatically because `BeforeResourceStartedEvent` fires at the right time |
-| **Error handling** | If a callback throws (not `OperationCanceledException`), state → FailedToStart, logged, restartable from dashboard |
-| **Cleanup** | All tracked disposables (`ctx.Track(...)`) are disposed on stop |
+The most common patterns above can be packaged as extension methods that build on `OnLifecycle`. These are convenience helpers, not new primitives — they expand to ordinary `OnLifecycle` bodies and live in any namespace the consumer prefers.
 
-### Start/Stop/Restart routing for custom resources
+```csharp
+public static class ResourceLifecycleExtensions
+{
+    /// <summary>
+    /// Convenience: runs <paramref name="onTick"/> on a fixed interval until the
+    /// resource is stopped. Equivalent to writing a while loop inside OnLifecycle.
+    /// </summary>
+    public static IResourceBuilder<T> WithInterval<T>(
+        this IResourceBuilder<T> builder,
+        TimeSpan period,
+        Func<ResourceContext, long, CancellationToken, Task> onTick)
+        where T : IResource
+    {
+        return builder.OnLifecycle(async (ctx, ct) =>
+        {
+            await ctx.SetStateAsync(KnownResourceStates.Running, ct);
+            long tick = 0;
+            while (!ct.IsCancellationRequested)
+            {
+                await onTick(ctx, tick++, ct);
+                await Task.Delay(period, ct);
+            }
+        });
+    }
+}
+```
+
+Authors who like the helper can use it. Authors who want full control use `OnLifecycle` directly. There is exactly one primitive in the public API; everything else is layered on top.
+
+### What `OnLifecycle` does **not** prescribe
+
+To avoid the design debates around composing multiple lifecycle primitives, this proposal deliberately makes these the author's responsibility:
+
+- Whether to use a timer, an event subscription, a stream, or a one-shot call.
+- When to transition to `Running`.
+- Whether failures are `Exited` or `FailedToStart` (the framework picks based on whether `Running` was reached — see the table above — but the author can override by calling `SetStateAsync` explicitly before throwing or returning).
+- What happens if multiple background activities run inside the callback (compose them with `Task.WhenAll` or `Task.WhenAny` — the framework just sees one Task).
+
+This keeps the framework contract small and predictable, and avoids needing rules for "what if I combine `WithInterval` with `OnStarted` with `RunAsync`."
+
+## Start/Stop/Restart routing for custom resources
 
 Today, `ApplicationOrchestrator.StartResourceAsync` and `StopResourceAsync` route directly to `_dcpExecutor`, which only knows about DCP-managed resources. Custom resources get nothing.
 
@@ -402,19 +438,19 @@ Dashboard "Stop" click
     → orchestrator.StopResourceAsync(name)
       → If DCP resource → _dcpExecutor.StopResourceAsync (existing path)
       → If custom resource → cancel the resource's CancellationTokenSource
-        → WithInterval: timer stopped
-        → BoundTo: unbind from source events
-        → RunAsync: stoppingToken cancelled, await completion
-        → OnStopping: called
-        → Framework: state = Stopped, StopTimeStamp set, URLs inactive
+        → OnLifecycle callback observes cancellation, returns
+        → Framework: disposes tracked disposables, sets terminal state,
+          sets StopTimeStamp, fires ResourceStoppedEvent
 
 Dashboard "Start" click
   → orchestrator.StartResourceAsync(name)
     → If DCP resource → _dcpExecutor.StartResourceAsync (existing path)
-    → If custom resource → create new CTS, invoke lifecycle callbacks
-      → BoundTo: re-subscribe, but gate on source being ready
-      → Framework: state = Starting → Running
+    → If custom resource → create new CTS, re-invoke OnLifecycle callback
+      → Framework: fires BeforeResourceStartedEvent, sets Starting,
+        sets StartTimeStamp, invokes callback
 ```
+
+Resources that implement `IResourceWithoutLifecycle` (or otherwise opt out) are skipped — they do not appear in Start/Stop/Restart command lists.
 
 ## TypeScript API
 
@@ -459,86 +495,45 @@ export interface UrlSnapshot {
 }
 ```
 
-### `InitializeResourceEvent`
+### `ResourceContext` and `onLifecycle`
 
 ```typescript
-export interface InitializeResourceEvent {
-    // Existing:
+export interface ResourceContext {
     resource(): Promise<Resource>;
-    eventing(): Promise<IDistributedApplicationEventing>;
-    logger(): Promise<ILogger>;
-    notifications(): Promise<ResourceNotificationService>;
     services(): Promise<IServiceProvider>;
+    logger(): Promise<ILogger>;
 
-    // New:
-    setStarted(): Promise<void>;
     setState(state: string, options?: PublishStateOptions): Promise<void>;
-    setProperty(name: string, value: unknown,
-        options?: PublishPropertyOptions): Promise<void>;
+    setProperty(name: string, value: unknown, options?: PublishPropertyOptions): Promise<void>;
     addUrl(url: UrlSnapshot): Promise<void>;
+    removeUrl(urlName: string): Promise<void>;
+
+    track(disposable: AsyncDisposable | Disposable): void;
+    get<T>(): T;
 }
-```
 
-### Builder extensions
-
-```typescript
 // On any resource builder:
 .withResourceType(resourceType: string)
 .withProperty(name: string, value: unknown, options?: PublishPropertyOptions)
-.withInterval(periodMs: number,
-    onTick: (ctx: ResourceContext, tick: number) => Promise<void>)
-.boundTo(source: Awaitable<Resource>)
-.onStarted(callback: (ctx: ResourceContext) => Promise<void>)
-.onStopping(callback: (ctx: ResourceContext) => Promise<void>)
-.run(execute: (ctx: ResourceContext, stoppingToken: AbortSignal) => Promise<void>)
+.onLifecycle(lifecycle: (ctx: ResourceContext, stopSignal: AbortSignal) => Promise<void>)
 ```
 
 ### TypeScript example
 
 ```typescript
-// TalkingClock
 const clock = await builder.addResource("clock")
     .withResourceType("TalkingClock")
     .withProperty("aspire.resource.source", "Talking Clock")
-    .withInterval(1000, async (ctx, tick) => {
-        await ctx.setState(tick % 2 === 0 ? "Tick" : "Tock",
-            { stateStyle: "success" });
-    });
-
-// Bound lifecycle
-const port = await builder.addResource("tunnel-port")
-    .withResourceType("DevTunnelPort")
-    .boundTo(tunnel)
-    .onStarted(async (ctx) => {
-        await ctx.addUrl({ name: "tunnel", url: tunnelPortUrl });
+    .onLifecycle(async (ctx, stop) => {
+        await ctx.setState("Running");
+        let tick = 0;
+        while (!stop.aborted) {
+            await ctx.setState(tick++ % 2 === 0 ? "Tick" : "Tock",
+                { stateStyle: "success" });
+            await delay(1000, stop);
+        }
     });
 ```
-
-## Composition rules
-
-The lifecycle primitives compose as follows:
-
-| Combination | Behavior |
-|-------------|----------|
-| Multiple `WithInterval` | All timers run independently |
-| `WithInterval` + `OnStarted` | `OnStarted` fires first, then timers start |
-| `WithInterval` + `OnStopping` | Timers stop first, then `OnStopping` fires |
-| `BoundTo` + `OnStarted` | `OnStarted` fires when the source becomes ready |
-| `BoundTo` + `OnStopping` | `OnStopping` fires when the source stops |
-| `RunAsync` | Exclusive — cannot combine with `WithInterval` or `BoundTo` (it IS the lifecycle) |
-| `RunAsync` + `OnStopping` | `OnStopping` fires after `RunAsync` returns |
-| Multiple `OnStarted` | All fire in registration order |
-| Multiple `OnStopping` | All fire in reverse registration order |
-
-## Error handling
-
-| Scenario | Behavior |
-|----------|----------|
-| `OnStarted` throws | State → `FailedToStart`, error logged. Restartable from dashboard. |
-| `WithInterval` tick throws | Error logged, tick skipped. Timer continues. After N consecutive failures (configurable), state → `Unhealthy`. |
-| `RunAsync` throws (not `OperationCanceledException`) | State → `FailedToStart`, error logged. Restartable from dashboard. |
-| `RunAsync` catches `OperationCanceledException` | Normal stop. State → `Stopped`. |
-| `OnStopping` throws | Error logged. Stop proceeds — resource still transitions to Stopped. |
 
 ## Migration guide
 
@@ -574,74 +569,46 @@ builder.AddResource(myResource)
 builder.AddResource(myResource)
     .WithResourceType("MyResource")
     .WithProperty("Source", "my-source")
-    .WithInterval(interval, async (ctx, tick) =>
+    .OnLifecycle(async (ctx, ct) =>
     {
-        // ... work ...
+        await ctx.SetStateAsync(KnownResourceStates.Running, ct);
+        while (!ct.IsCancellationRequested)
+        {
+            // ... work ...
+            await Task.Delay(interval, ct);
+        }
     });
 ```
+
+The reductions: no manual snapshot construction, no manual event firing, no manual timestamp management, and Start/Stop/Restart commands work from the dashboard without additional wiring.
 
 ### From `OnResourceReady` / `OnResourceStopped` (bound lifecycle)
 
-```csharp
-// Before:
-parentBuilder.OnResourceReady(async (parent, e, ct) =>
-{
-    var notifications = e.Services.GetRequiredService<ResourceNotificationService>();
-    var eventing = e.Services.GetRequiredService<IDistributedApplicationEventing>();
-    await eventing.PublishAsync<BeforeResourceStartedEvent>(
-        new(childResource, e.Services), EventDispatchBehavior.NonBlockingSequential, ct);
-    await notifications.PublishUpdateAsync(childResource, s => s with
-    {
-        State = KnownResourceStates.Starting,
-        StartTimeStamp = DateTime.UtcNow
-    });
-    // ... setup ...
-    await notifications.PublishUpdateAsync(childResource, s => s with
-    {
-        State = KnownResourceStates.Running
-    });
-});
-parentBuilder.OnResourceStopped(async (parent, e, ct) =>
-{
-    var notifications = e.Services.GetRequiredService<ResourceNotificationService>();
-    await notifications.PublishUpdateAsync(childResource, s => s with
-    {
-        State = KnownResourceStates.Finished,
-        StopTimeStamp = DateTime.UtcNow,
-        Urls = [.. s.Urls.Select(u => u with { IsInactive = true })]
-    });
-});
-
-// After:
-childBuilder
-    .BoundTo(parentBuilder)
-    .OnStarted(async ctx =>
-    {
-        // ... setup (just the custom part) ...
-    });
-```
+See the DevTunnelPort example above. The pattern is to put the wait-for-parent logic inside `OnLifecycle` using `WaitForResourceAsync` / `WaitForResourceHealthyAsync`, instead of subscribing to events on the parent.
 
 ## Implementation phases
 
 | Phase | Scope | Dependencies |
 |-------|-------|-------------|
 | **1. Source-scoped slices** | Internal plumbing: per-source collection tracking in `ResourceNotificationService`, `PublishSlicedUpdateAsync` for DCP, refactor `ResourceSnapshotBuilder` and `ApplicationOrchestrator`. Fixes #13647. | None |
-| **2. `ResourceContext` + public API** | New `ResourceContext` class, targeted public methods on `ResourceNotificationService`, builder helpers (`WithResourceType`, `WithProperty`), `CreationTimeStamp` auto-default. Improves #10365 ergonomics. | Phase 1 |
-| **3. Lifecycle host + triggers** | `WithInterval`, `BoundTo`, `OnStarted`, `OnStopping`, `RunAsync`. Framework state machine, auto-events, auto-commands, Start/Stop routing for custom resources. | Phase 2 |
-| **4. TypeScript parity** | Code-gen changes to emit new methods on `ResourceNotificationService`, `InitializeResourceEvent`, and resource builders. | Phase 3 |
+| **2. `ResourceContext` + public API** | New `ResourceContext` class, targeted public methods on `ResourceNotificationService`, builder helpers (`WithResourceType`, `WithProperty`), `CreationTimeStamp` auto-default, `WithCommand` overload that accepts `ResourceContext`. | Phase 1 |
+| **3. `OnLifecycle` hook** | Framework-owned ceremony (events, timestamps, command wiring, cleanup), Start/Stop/Restart routing for custom resources, opt-out via `IResourceWithoutLifecycle`. | Phase 2 |
+| **4. TypeScript parity** | Code-gen changes to emit new methods on `ResourceNotificationService`, builders, and the `onLifecycle` hook. | Phase 3 |
 
-Each phase is independently shippable and useful. Phase 1 alone fixes the clobbering bug. Phase 2 alone improves ergonomics. Phase 3 eliminates boilerplate.
+Each phase is independently shippable and useful. Phase 1 alone fixes the clobbering bug. Phase 2 alone meaningfully improves authoring. Phase 3 closes the loop on Start/Stop/Restart commands and event firing for custom resources.
 
 ## Open questions
 
-1. **`RunAsync` exclusivity.** Should `RunAsync` be mutually exclusive with `WithInterval` and `BoundTo`, or should they compose? Recommendation: exclusive — `RunAsync` IS the lifecycle, and combining it with a timer or binding creates ambiguity about who owns the state machine.
+1. **Naming.** `OnLifecycle` vs `WithLifecycle` vs `OnRun` vs `WithBody`? `ResourceContext` vs `ResourceUpdater` vs `ResourceController`? Naming TBD pending API review.
 
-2. **`WithInterval` error threshold.** How many consecutive tick failures before the resource is marked unhealthy? A configurable default (e.g., 3) with an override parameter seems right.
+2. **Framework state on author-thrown exceptions.** When the callback throws after `Running` was reached, should the framework expose the exception as an `ExitCode`-like value, or just log it? Recommendation: log plus a synthetic non-zero exit code so the dashboard renders the resource with error styling.
 
-3. **`BoundTo` vs `WaitFor`.** `BoundTo(source)` means "my lifecycle follows the source." `WaitFor(source)` means "don't start me until the source is ready, but I have my own lifecycle." These are distinct and both useful. `BoundTo` implies `WaitFor`, but `WaitFor` does not imply `BoundTo`.
+3. **`PublishUpdateAsync` collection semantics.** When existing code does `s => s with { Urls = [myUrl] }`, should this replace only the `"user"` source's URLs (breaking: user loses all other URLs from `s.Urls` they might have appended), or set the full merged collection (non-breaking but clobbers DCP URLs)? Recommendation: write to `"user"` source only, and log a warning when collection fields are set via the legacy API to guide migration.
 
-4. **`PublishUpdateAsync` collection semantics.** When existing code does `s => s with { Urls = [myUrl] }`, should this replace only the `"user"` source's URLs (breaking: user loses all other URLs from `s.Urls` they might have appended), or set the full merged collection (non-breaking but clobbers DCP URLs)? Recommendation: write to `"user"` source only, and log a warning when collection fields are set via the legacy API to guide migration.
+4. **`ResourceContext` lifetime on restart.** On restart, should a fresh `ResourceContext` be created (all tracked disposables disposed, fresh state)? Recommendation: yes — restart is a full stop + start cycle.
 
-5. **`ResourceContext` lifetime on restart.** On restart, should a fresh `ResourceContext` be created (all tracked disposables disposed, fresh state)? Recommendation: yes — restart is a full stop + start cycle.
+5. **Endpoint integration.** Custom resources that expose endpoints (e.g., a user-defined HTTP server resource — see [#16640](https://github.com/microsoft/aspire/issues/16640)) need a way to declare ports that are then surfaced through service discovery and `EndpointReference`. This is adjacent to lifecycle but not covered by this proposal; it's tracked separately.
 
-6. **Naming.** `BoundTo` vs `FollowLifecycle` vs `DependsOn`? `RunAsync` vs `WithLifecycle` vs `ExecuteAsync`? `OnStarted` vs `OnStart`? Naming TBD pending API review.
+6. **`ExecutionConfigurationBuilder` integration.** Custom resources that produce a process (env vars + arguments) currently need bespoke coordination (see [#14954](https://github.com/microsoft/aspire/issues/14954)). `IResourceWithArguments` / `IResourceWithEnvironment` interop with `ResourceContext` is a follow-up, not part of this proposal.
+
+7. **Health checks vs `State`.** Continuous health-like signals (`Healthy` / `Degraded`) should be expressed with `WithHealthCheck`, not by overloading the `State` field. This is documentation/guidance, not a code change in this spec.

--- a/docs/specs/custom-resource-lifecycle.md
+++ b/docs/specs/custom-resource-lifecycle.md
@@ -139,6 +139,18 @@ public class ResourceContext
     /// <summary>The host service provider.</summary>
     public IServiceProvider Services { get; }
 
+    /// <summary>
+    /// The resource notification service. Exposed directly for convenience so authors
+    /// don't have to resolve it from <see cref="Services"/> for common operations like
+    /// <c>WaitForResourceAsync</c> / <c>WaitForResourceHealthyAsync</c>.
+    /// </summary>
+    public ResourceNotificationService Notifications { get; }
+
+    /// <summary>
+    /// The distributed application eventing service. Exposed directly for convenience.
+    /// </summary>
+    public IDistributedApplicationEventing Eventing { get; }
+
     /// <summary>Updates the resource state shown in the dashboard.</summary>
     public Task SetStateAsync(ResourceStateSnapshot state, CancellationToken ct = default);
 
@@ -314,10 +326,8 @@ When a resource's lifecycle follows another resource, the author waits for the s
 ```csharp
 portBuilder.OnLifecycle(async (ctx, ct) =>
 {
-    var notifications = ctx.Services.GetRequiredService<ResourceNotificationService>();
-
     // Wait for the parent tunnel to be ready.
-    await notifications.WaitForResourceHealthyAsync(tunnel.Resource.Name, ct);
+    await ctx.Notifications.WaitForResourceHealthyAsync(tunnel.Resource.Name, ct);
 
     // Do the port-specific setup.
     var port = (DevTunnelPortResource)ctx.Resource;
@@ -330,7 +340,7 @@ portBuilder.OnLifecycle(async (ctx, ct) =>
     // Wait for the parent tunnel to stop, then return so the framework can
     // tear us down. If the parent restarts, the framework's restart logic
     // will re-invoke this callback.
-    await notifications.WaitForResourceAsync(
+    await ctx.Notifications.WaitForResourceAsync(
         tunnel.Resource.Name,
         [KnownResourceStates.Finished, KnownResourceStates.Exited, KnownResourceStates.FailedToStart],
         ct);


### PR DESCRIPTION
## Description

Proposes a reactive lifecycle model for custom resources, modeled after UI frameworks, that addresses two long-standing problems:

- **#13647** — `ResourceSnapshotBuilder` overwrites user-published state (URLs, env vars, properties, volumes, relationships) on every DCP watch event.
- **#10365** — Custom resource authoring requires extensive boilerplate: manual snapshot construction, manual lifecycle event firing, manual timestamp management, and hand-written `while` loops.

The proposal is structured in three layers, each independently shippable:

1. **Source-scoped snapshot slices.** The notification service tracks collection items per producer (DCP, orchestrator, user). Each producer updates only its slice. Fixes #13647 without breaking `PublishUpdateAsync` compatibility.

2. **`ResourceContext` + targeted public API.** A new context type provides `SetStateAsync`, `SetPropertyAsync`, `AddUrlAsync` instead of constructing whole snapshots. New builder helpers (`WithResourceType`, `WithProperty`) replace the verbose `WithInitialState`.

3. **Framework-owned lifecycle.** Four primitives covering all custom resource patterns:
   - `WithInterval(period, onTick)` — framework owns the timer loop
   - `BoundTo(source)` — lifecycle follows another resource (e.g. `DevTunnelPortResource` following its parent tunnel)
   - `RunAsync(execute)` — escape hatch for streaming/subprocess cases
   - `OnStarted` / `OnStopping` — one-shot setup and cleanup

   The framework handles state transitions, timestamps, lifecycle events, Start/Stop/Restart command wiring, URL active-state toggling, and error handling.

Concrete impact: the existing TalkingClock example shrinks from ~30 lines of manual ceremony to ~6 lines. The DevTunnelPort lifecycle handlers shrink from ~130 lines to ~10. A 4th phase adds TypeScript parity through the polyglot code-gen system.

## Files

- `docs/specs/custom-resource-lifecycle.md` — new standalone spec with full API surface, composition rules, error handling, migration guide, implementation phases, and open questions.
- `docs/specs/appmodel.md` — new "Custom Resource Lifecycle Model" section integrated into the existing app model spec, with the TalkingClock example rewritten to show both the new and legacy APIs side by side.

Documentation only. No code changes. Posting as draft for design review.

## Checklist

- Is this feature complete?
  - [ ] Yes. Ready to ship.
  - [x] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [x] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to `aspire.dev` issue:
      - [New issue](https://github.com/microsoft/aspire.dev/issues/new)
  - [x] No