### PR TITLE
fix(cli): restore implicit-channel discovery + guard non-interactive fuzzy auto-pick (#17724, #17725)

### DIFF
--- a/src/Aspire.Cli/Commands/AddCommand.cs
+++ b/src/Aspire.Cli/Commands/AddCommand.cs
@@ -178,9 +178,17 @@ internal sealed class AddCommand : BaseCommand
                 ? ProfilingTelemetry.Values.AddPackageMatchKindExact
                 : ProfilingTelemetry.Values.AddPackageMatchKindNone;
 
-            if (filteredPackagesWithShortName.Count == 0 && integrationName is not null && version is not null && !_hostEnvironment.SupportsInteractiveInput)
+            // Non-interactive mode never falls back to fuzzy search: in interactive mode the user picks
+            // from the fuzzy candidates, but a script/CI invocation would otherwise silently auto-select
+            // distinctPackages.First() in GetPackageByInteractiveFlow and install the wrong package
+            // (https://github.com/microsoft/aspire/issues/17724). Refusing with an actionable error
+            // forces the caller to supply an exact package id or friendly name.
+            if (filteredPackagesWithShortName.Count == 0 && integrationName is not null && !_hostEnvironment.SupportsInteractiveInput)
             {
-                throw new EmptyChoicesException(string.Format(CultureInfo.CurrentCulture, AddCommandStrings.SpecifiedVersionRequiresExactPackageMatch, integrationName));
+                var message = version is not null
+                    ? string.Format(CultureInfo.CurrentCulture, AddCommandStrings.SpecifiedVersionRequiresExactPackageMatch, integrationName)
+                    : string.Format(CultureInfo.CurrentCulture, AddCommandStrings.NonInteractiveRequiresExactPackageMatch, integrationName);
+                throw new EmptyChoicesException(message);
             }
 
             if (filteredPackagesWithShortName.Count == 0 && integrationName is not null)

--- a/src/Aspire.Cli/Commands/AddCommand.cs
+++ b/src/Aspire.Cli/Commands/AddCommand.cs
@@ -205,16 +205,33 @@ internal sealed class AddCommand : BaseCommand
                     : ProfilingTelemetry.Values.AddPackageMatchKindNone;
             }
 
-            // If we didn't match any, show a complete list. If we matched one, and its
+            // If the user supplied a partial/fuzzy search term, keep the package prompt even when
+            // the fallback only found one candidate; otherwise `aspire add kube` can silently add
+            // the lone fuzzy match without asking the interactive user to confirm it.
+            var promptForSingleFuzzyPackage = packageMatchKind == ProfilingTelemetry.Values.AddPackageMatchKindFuzzy;
+
+            // If we didn't match any, show a complete list. If we matched one, and it's
             // an exact match, then we still prompt, but it will only prompt for
             // the version. If there is more than one match then we prompt.
             (string FriendlyName, NuGetPackage Package, PackageChannel Channel) selectedNuGetPackage;
             selectedNuGetPackage = filteredPackagesWithShortName.Count switch
             {
-                0 => await GetPackageByInteractiveFlowWithNoMatchesMessage(effectiveAppHostProjectFile.Directory!, packagesWithShortName, integrationName, version, cancellationToken),
-                1 when filteredPackagesWithShortName[0].Package.Version == version
+                0 => await GetPackageByInteractiveFlowWithNoMatchesMessage(
+                    effectiveAppHostProjectFile.Directory!,
+                    packagesWithShortName,
+                    integrationName,
+                    version,
+                    cancellationToken,
+                    promptForSinglePackage: integrationName is not null),
+                1 when packageMatchKind == ProfilingTelemetry.Values.AddPackageMatchKindExact
+                    && filteredPackagesWithShortName[0].Package.Version == version
                     => filteredPackagesWithShortName[0],
-                _ => await GetPackageByInteractiveFlow(effectiveAppHostProjectFile.Directory!, filteredPackagesWithShortName, version, cancellationToken)
+                _ => await GetPackageByInteractiveFlow(
+                    effectiveAppHostProjectFile.Directory!,
+                    filteredPackagesWithShortName,
+                    version,
+                    cancellationToken,
+                    promptForSingleFuzzyPackage)
             };
             using (var selectPackageActivity = _profilingTelemetry.StartAddSelectPackage(integrationName, version))
             {
@@ -365,14 +382,21 @@ internal sealed class AddCommand : BaseCommand
         return versions;
     }
 
-    private async Task<(string FriendlyName, NuGetPackage Package, PackageChannel Channel)> GetPackageByInteractiveFlow(DirectoryInfo workingDirectory, IEnumerable<(string FriendlyName, NuGetPackage Package, PackageChannel Channel)> possiblePackages, string? preferredVersion, CancellationToken cancellationToken)
+    private async Task<(string FriendlyName, NuGetPackage Package, PackageChannel Channel)> GetPackageByInteractiveFlow(
+        DirectoryInfo workingDirectory,
+        IEnumerable<(string FriendlyName, NuGetPackage Package, PackageChannel Channel)> possiblePackages,
+        string? preferredVersion,
+        CancellationToken cancellationToken,
+        bool promptForSinglePackage = false)
     {
         var distinctPackages = possiblePackages.DistinctBy(p => p.Package.Id).ToArray();
 
-        // If there is only one package, we can skip the prompt and just use it.
+        // Exact matches can skip the package prompt when one package remains. Fuzzy/no-match
+        // fallbacks opt into prompting so interactive users confirm the candidate first.
         // In non-interactive mode, auto-select the first package.
         var selectedPackage = distinctPackages.Length switch
         {
+            1 when promptForSinglePackage && _hostEnvironment.SupportsInteractiveInput => await PromptForIntegrationAsync(distinctPackages, cancellationToken),
             1 => distinctPackages.First(),
             > 1 when !_hostEnvironment.SupportsInteractiveInput => distinctPackages.First(),
             > 1 => await PromptForIntegrationAsync(distinctPackages, cancellationToken),
@@ -448,14 +472,20 @@ internal sealed class AddCommand : BaseCommand
         return await _prompter.PromptForIntegrationVersionAsync(packages, cancellationToken);
     }
 
-    private async Task<(string FriendlyName, NuGetPackage Package, PackageChannel Channel)> GetPackageByInteractiveFlowWithNoMatchesMessage(DirectoryInfo workingDirectory, IEnumerable<(string FriendlyName, NuGetPackage Package, PackageChannel Channel)> possiblePackages, string? searchTerm, string? preferredVersion, CancellationToken cancellationToken)
+    private async Task<(string FriendlyName, NuGetPackage Package, PackageChannel Channel)> GetPackageByInteractiveFlowWithNoMatchesMessage(
+        DirectoryInfo workingDirectory,
+        IEnumerable<(string FriendlyName, NuGetPackage Package, PackageChannel Channel)> possiblePackages,
+        string? searchTerm,
+        string? preferredVersion,
+        CancellationToken cancellationToken,
+        bool promptForSinglePackage = false)
     {
         if (searchTerm is not null)
         {
             InteractionService.DisplaySubtleMessage(string.Format(CultureInfo.CurrentCulture, AddCommandStrings.NoPackagesMatchedSearchTerm, searchTerm));
         }
 
-        return await GetPackageByInteractiveFlow(workingDirectory, possiblePackages, preferredVersion, cancellationToken);
+        return await GetPackageByInteractiveFlow(workingDirectory, possiblePackages, preferredVersion, cancellationToken, promptForSinglePackage);
     }
 
 }

--- a/src/Aspire.Cli/Commands/IntegrationPackageSearchService.cs
+++ b/src/Aspire.Cli/Commands/IntegrationPackageSearchService.cs
@@ -23,15 +23,19 @@ internal sealed class IntegrationPackageSearchService(
 
     public async Task<IEnumerable<(NuGetPackage Package, PackageChannel Channel)>> GetIntegrationPackagesWithChannelsAsync(DirectoryInfo workingDirectory, string? configuredChannel, CancellationToken cancellationToken)
     {
+        // `configuredChannel` (from a polyglot apphost's aspire.config.json) is forwarded
+        // ONLY as `requestedChannelName` so PackagingService can synthesize the staging
+        // channel for out-of-tree apphosts whose directory wasn't picked up by
+        // ConfigurationHelper.RegisterSettingsFiles. It must NOT narrow the post-retrieval
+        // channel set: doing so was the root cause of https://github.com/microsoft/aspire/issues/17724
+        // and https://github.com/microsoft/aspire/issues/17725, because a TS apphost pinned to a
+        // `Quality.Stable` channel ended up with only prerelease=false queries and prerelease-only
+        // packages (e.g. Aspire.Hosting.Foundry) became invisible. The filter pipeline downstream
+        // of this method is now identical for C# and TS apphosts.
         var allChannels = await packagingService.GetChannelsAsync(cancellationToken, configuredChannel);
 
-        if (!string.IsNullOrEmpty(configuredChannel))
-        {
-            allChannels = allChannels.Where(c => string.Equals(c.Name, configuredChannel, StringComparison.OrdinalIgnoreCase));
-        }
-
         var hasHives = executionContext.GetHiveCount() > 0;
-        var channels = hasHives || !string.IsNullOrEmpty(configuredChannel)
+        var channels = hasHives
             ? allChannels
             : allChannels.Where(c => c.Type is PackageChannelType.Implicit);
 

--- a/src/Aspire.Cli/Commands/IntegrationPackageSearchService.cs
+++ b/src/Aspire.Cli/Commands/IntegrationPackageSearchService.cs
@@ -24,18 +24,25 @@ internal sealed class IntegrationPackageSearchService(
     public async Task<IEnumerable<(NuGetPackage Package, PackageChannel Channel)>> GetIntegrationPackagesWithChannelsAsync(DirectoryInfo workingDirectory, string? configuredChannel, CancellationToken cancellationToken)
     {
         // `configuredChannel` (from a polyglot apphost's aspire.config.json) is forwarded
-        // ONLY as `requestedChannelName` so PackagingService can synthesize the staging
-        // channel for out-of-tree apphosts whose directory wasn't picked up by
-        // ConfigurationHelper.RegisterSettingsFiles. It must NOT narrow the post-retrieval
-        // channel set: doing so was the root cause of https://github.com/microsoft/aspire/issues/17724
-        // and https://github.com/microsoft/aspire/issues/17725, because a TS apphost pinned to a
-        // `Quality.Stable` channel ended up with only prerelease=false queries and prerelease-only
-        // packages (e.g. Aspire.Hosting.Foundry) became invisible. The filter pipeline downstream
-        // of this method is now identical for C# and TS apphosts.
+        // as `requestedChannelName` so PackagingService can synthesize the staging channel
+        // for out-of-tree apphosts whose directory wasn't picked up by
+        // ConfigurationHelper.RegisterSettingsFiles.
         var allChannels = await packagingService.GetChannelsAsync(cancellationToken, configuredChannel);
 
+        // Channels included in the search:
+        //   * Implicit channel: always.
+        //   * Explicit channels (stable, daily, staging, custom): when PR hives exist OR the
+        //     apphost has pinned an explicit channel via aspire.config.json.
+        //
+        // What this method MUST NOT do is narrow the explicit channel set to just the pinned
+        // channel. That was the root cause of https://github.com/microsoft/aspire/issues/17724
+        // and https://github.com/microsoft/aspire/issues/17725: a TS apphost pinned to a
+        // Quality.Stable channel ended up with prerelease=false queries everywhere and
+        // prerelease-only packages (e.g. Aspire.Hosting.Foundry) became invisible. The implicit
+        // channel (Quality.Both) must always participate so prerelease packages are reachable
+        // even when the explicit pin is Stable-quality.
         var hasHives = executionContext.GetHiveCount() > 0;
-        var channels = hasHives
+        var channels = hasHives || !string.IsNullOrEmpty(configuredChannel)
             ? allChannels
             : allChannels.Where(c => c.Type is PackageChannelType.Implicit);
 

--- a/src/Aspire.Cli/Resources/AddCommandStrings.Designer.cs
+++ b/src/Aspire.Cli/Resources/AddCommandStrings.Designer.cs
@@ -309,6 +309,14 @@ namespace Aspire.Cli.Resources {
             }
         }
 
+        public static string NonInteractiveRequiresExactPackageMatch
+        {
+            get
+            {
+                return ResourceManager.GetString("NonInteractiveRequiresExactPackageMatch", resourceCulture);
+            }
+        }
+
         public static string UsePrereleasePackages
         {
             get

--- a/src/Aspire.Cli/Resources/AddCommandStrings.resx
+++ b/src/Aspire.Cli/Resources/AddCommandStrings.resx
@@ -223,6 +223,10 @@
     <value>When --version is specified in non-interactive mode, the integration name must exactly match a package or friendly name. No exact match was found for '{0}'.</value>
     <comment>{0} is the integration name provided by the user.</comment>
   </data>
+  <data name="NonInteractiveRequiresExactPackageMatch" xml:space="preserve">
+    <value>No exact match was found for '{0}'. In non-interactive mode the integration name must exactly match a package id or friendly name; fuzzy fallback is disabled to prevent silently selecting the wrong package.</value>
+    <comment>{0} is the integration name provided by the user.</comment>
+  </data>
   <data name="UsePrereleasePackages" xml:space="preserve">
     <value>Use pre-release packages</value>
   </data>

--- a/src/Aspire.Cli/Resources/xlf/AddCommandStrings.cs.xlf
+++ b/src/Aspire.Cli/Resources/xlf/AddCommandStrings.cs.xlf
@@ -102,6 +102,11 @@
         <target state="translated">Vašemu hledaného termínu {0} neodpovídají žádné balíčky. Zobrazují se všechny dostupné balíčky.</target>
         <note>{0} is the search term provided by the user.</note>
       </trans-unit>
+      <trans-unit id="NonInteractiveRequiresExactPackageMatch">
+        <source>No exact match was found for '{0}'. In non-interactive mode the integration name must exactly match a package id or friendly name; fuzzy fallback is disabled to prevent silently selecting the wrong package.</source>
+        <target state="new">No exact match was found for '{0}'. In non-interactive mode the integration name must exactly match a package id or friendly name; fuzzy fallback is disabled to prevent silently selecting the wrong package.</target>
+        <note>{0} is the integration name provided by the user.</note>
+      </trans-unit>
       <trans-unit id="PackageAddedSuccessfully">
         <source>The package {0}::{1} was added successfully.</source>
         <target state="translated">Balíček {0}::{1} byl úspěšně přidán.</target>

--- a/src/Aspire.Cli/Resources/xlf/AddCommandStrings.de.xlf
+++ b/src/Aspire.Cli/Resources/xlf/AddCommandStrings.de.xlf
@@ -102,6 +102,11 @@
         <target state="translated">Es stimmten keine Pakete mit Ihrem Suchbegriff „{0}“ überein. Alle verfügbaren Pakete werden angezeigt.</target>
         <note>{0} is the search term provided by the user.</note>
       </trans-unit>
+      <trans-unit id="NonInteractiveRequiresExactPackageMatch">
+        <source>No exact match was found for '{0}'. In non-interactive mode the integration name must exactly match a package id or friendly name; fuzzy fallback is disabled to prevent silently selecting the wrong package.</source>
+        <target state="new">No exact match was found for '{0}'. In non-interactive mode the integration name must exactly match a package id or friendly name; fuzzy fallback is disabled to prevent silently selecting the wrong package.</target>
+        <note>{0} is the integration name provided by the user.</note>
+      </trans-unit>
       <trans-unit id="PackageAddedSuccessfully">
         <source>The package {0}::{1} was added successfully.</source>
         <target state="translated">Das Paket {0}::{1} wurde erfolgreich hinzugefügt.</target>

--- a/src/Aspire.Cli/Resources/xlf/AddCommandStrings.es.xlf
+++ b/src/Aspire.Cli/Resources/xlf/AddCommandStrings.es.xlf
@@ -102,6 +102,11 @@
         <target state="translated">No se encontraron paquetes que coincidan con el término de búsqueda "{0}". Mostrando todos los paquetes disponibles.</target>
         <note>{0} is the search term provided by the user.</note>
       </trans-unit>
+      <trans-unit id="NonInteractiveRequiresExactPackageMatch">
+        <source>No exact match was found for '{0}'. In non-interactive mode the integration name must exactly match a package id or friendly name; fuzzy fallback is disabled to prevent silently selecting the wrong package.</source>
+        <target state="new">No exact match was found for '{0}'. In non-interactive mode the integration name must exactly match a package id or friendly name; fuzzy fallback is disabled to prevent silently selecting the wrong package.</target>
+        <note>{0} is the integration name provided by the user.</note>
+      </trans-unit>
       <trans-unit id="PackageAddedSuccessfully">
         <source>The package {0}::{1} was added successfully.</source>
         <target state="translated">El paquete {0}::{1} se agregó correctamente.</target>

--- a/src/Aspire.Cli/Resources/xlf/AddCommandStrings.fr.xlf
+++ b/src/Aspire.Cli/Resources/xlf/AddCommandStrings.fr.xlf
@@ -102,6 +102,11 @@
         <target state="translated">Aucun package ne correspond à votre terme de recherche « {0} ». Affichage de tous les packages disponibles.</target>
         <note>{0} is the search term provided by the user.</note>
       </trans-unit>
+      <trans-unit id="NonInteractiveRequiresExactPackageMatch">
+        <source>No exact match was found for '{0}'. In non-interactive mode the integration name must exactly match a package id or friendly name; fuzzy fallback is disabled to prevent silently selecting the wrong package.</source>
+        <target state="new">No exact match was found for '{0}'. In non-interactive mode the integration name must exactly match a package id or friendly name; fuzzy fallback is disabled to prevent silently selecting the wrong package.</target>
+        <note>{0} is the integration name provided by the user.</note>
+      </trans-unit>
       <trans-unit id="PackageAddedSuccessfully">
         <source>The package {0}::{1} was added successfully.</source>
         <target state="translated">Le package {0}::{1} a été ajouté avec succès.</target>

--- a/src/Aspire.Cli/Resources/xlf/AddCommandStrings.it.xlf
+++ b/src/Aspire.Cli/Resources/xlf/AddCommandStrings.it.xlf
@@ -102,6 +102,11 @@
         <target state="translated">Nessun pacchetto corrisponde al termine di ricerca '{0}'. Visualizzazione di tutti i pacchetti disponibili.</target>
         <note>{0} is the search term provided by the user.</note>
       </trans-unit>
+      <trans-unit id="NonInteractiveRequiresExactPackageMatch">
+        <source>No exact match was found for '{0}'. In non-interactive mode the integration name must exactly match a package id or friendly name; fuzzy fallback is disabled to prevent silently selecting the wrong package.</source>
+        <target state="new">No exact match was found for '{0}'. In non-interactive mode the integration name must exactly match a package id or friendly name; fuzzy fallback is disabled to prevent silently selecting the wrong package.</target>
+        <note>{0} is the integration name provided by the user.</note>
+      </trans-unit>
       <trans-unit id="PackageAddedSuccessfully">
         <source>The package {0}::{1} was added successfully.</source>
         <target state="translated">Caricamento del pacchetto {0}::{1} completato.</target>

--- a/src/Aspire.Cli/Resources/xlf/AddCommandStrings.ja.xlf
+++ b/src/Aspire.Cli/Resources/xlf/AddCommandStrings.ja.xlf
@@ -102,6 +102,11 @@
         <target state="translated">検索語句 '{0}' に一致するパッケージはありません。使用可能なすべてのパッケージを表示しています。</target>
         <note>{0} is the search term provided by the user.</note>
       </trans-unit>
+      <trans-unit id="NonInteractiveRequiresExactPackageMatch">
+        <source>No exact match was found for '{0}'. In non-interactive mode the integration name must exactly match a package id or friendly name; fuzzy fallback is disabled to prevent silently selecting the wrong package.</source>
+        <target state="new">No exact match was found for '{0}'. In non-interactive mode the integration name must exactly match a package id or friendly name; fuzzy fallback is disabled to prevent silently selecting the wrong package.</target>
+        <note>{0} is the integration name provided by the user.</note>
+      </trans-unit>
       <trans-unit id="PackageAddedSuccessfully">
         <source>The package {0}::{1} was added successfully.</source>
         <target state="translated">パッケージ {0}::{1} が正常に追加されました。</target>

--- a/src/Aspire.Cli/Resources/xlf/AddCommandStrings.ko.xlf
+++ b/src/Aspire.Cli/Resources/xlf/AddCommandStrings.ko.xlf
@@ -102,6 +102,11 @@
         <target state="translated">검색어 '{0}'와(과) 일치하는 패키지가 없습니다. 사용 가능한 모든 패키지를 표시합니다.</target>
         <note>{0} is the search term provided by the user.</note>
       </trans-unit>
+      <trans-unit id="NonInteractiveRequiresExactPackageMatch">
+        <source>No exact match was found for '{0}'. In non-interactive mode the integration name must exactly match a package id or friendly name; fuzzy fallback is disabled to prevent silently selecting the wrong package.</source>
+        <target state="new">No exact match was found for '{0}'. In non-interactive mode the integration name must exactly match a package id or friendly name; fuzzy fallback is disabled to prevent silently selecting the wrong package.</target>
+        <note>{0} is the integration name provided by the user.</note>
+      </trans-unit>
       <trans-unit id="PackageAddedSuccessfully">
         <source>The package {0}::{1} was added successfully.</source>
         <target state="translated">패키지 {0}::{1}을(를) 추가했습니다.</target>

--- a/src/Aspire.Cli/Resources/xlf/AddCommandStrings.pl.xlf
+++ b/src/Aspire.Cli/Resources/xlf/AddCommandStrings.pl.xlf
@@ -102,6 +102,11 @@
         <target state="translated">Żadne pakiety nie pasują do wyszukiwanego terminu „{0}”. Wyświetlanie wszystkich dostępnych pakietów.</target>
         <note>{0} is the search term provided by the user.</note>
       </trans-unit>
+      <trans-unit id="NonInteractiveRequiresExactPackageMatch">
+        <source>No exact match was found for '{0}'. In non-interactive mode the integration name must exactly match a package id or friendly name; fuzzy fallback is disabled to prevent silently selecting the wrong package.</source>
+        <target state="new">No exact match was found for '{0}'. In non-interactive mode the integration name must exactly match a package id or friendly name; fuzzy fallback is disabled to prevent silently selecting the wrong package.</target>
+        <note>{0} is the integration name provided by the user.</note>
+      </trans-unit>
       <trans-unit id="PackageAddedSuccessfully">
         <source>The package {0}::{1} was added successfully.</source>
         <target state="translated">Pakiet {0}::{1} został pomyślnie dodany.</target>

--- a/src/Aspire.Cli/Resources/xlf/AddCommandStrings.pt-BR.xlf
+++ b/src/Aspire.Cli/Resources/xlf/AddCommandStrings.pt-BR.xlf
@@ -102,6 +102,11 @@
         <target state="translated">Nenhum pacote correspondeu ao termo de pesquisa '{0}'. Mostrando todos os pacotes disponíveis.</target>
         <note>{0} is the search term provided by the user.</note>
       </trans-unit>
+      <trans-unit id="NonInteractiveRequiresExactPackageMatch">
+        <source>No exact match was found for '{0}'. In non-interactive mode the integration name must exactly match a package id or friendly name; fuzzy fallback is disabled to prevent silently selecting the wrong package.</source>
+        <target state="new">No exact match was found for '{0}'. In non-interactive mode the integration name must exactly match a package id or friendly name; fuzzy fallback is disabled to prevent silently selecting the wrong package.</target>
+        <note>{0} is the integration name provided by the user.</note>
+      </trans-unit>
       <trans-unit id="PackageAddedSuccessfully">
         <source>The package {0}::{1} was added successfully.</source>
         <target state="translated">O pacote {0}::{1} foi adicionado com êxito.</target>

--- a/src/Aspire.Cli/Resources/xlf/AddCommandStrings.ru.xlf
+++ b/src/Aspire.Cli/Resources/xlf/AddCommandStrings.ru.xlf
@@ -102,6 +102,11 @@
         <target state="translated">Не найдено пакетов, соответствующих вашему запросу "{0}". Показаны все доступные пакеты.</target>
         <note>{0} is the search term provided by the user.</note>
       </trans-unit>
+      <trans-unit id="NonInteractiveRequiresExactPackageMatch">
+        <source>No exact match was found for '{0}'. In non-interactive mode the integration name must exactly match a package id or friendly name; fuzzy fallback is disabled to prevent silently selecting the wrong package.</source>
+        <target state="new">No exact match was found for '{0}'. In non-interactive mode the integration name must exactly match a package id or friendly name; fuzzy fallback is disabled to prevent silently selecting the wrong package.</target>
+        <note>{0} is the integration name provided by the user.</note>
+      </trans-unit>
       <trans-unit id="PackageAddedSuccessfully">
         <source>The package {0}::{1} was added successfully.</source>
         <target state="translated">Пакет {0}::{1} загружен успешно.</target>

--- a/src/Aspire.Cli/Resources/xlf/AddCommandStrings.tr.xlf
+++ b/src/Aspire.Cli/Resources/xlf/AddCommandStrings.tr.xlf
@@ -102,6 +102,11 @@
         <target state="translated">'{0}' arama teriminizle eşleşen herhangi bir paket bulunamadı. Kullanılabilir tüm paketler gösteriliyor.</target>
         <note>{0} is the search term provided by the user.</note>
       </trans-unit>
+      <trans-unit id="NonInteractiveRequiresExactPackageMatch">
+        <source>No exact match was found for '{0}'. In non-interactive mode the integration name must exactly match a package id or friendly name; fuzzy fallback is disabled to prevent silently selecting the wrong package.</source>
+        <target state="new">No exact match was found for '{0}'. In non-interactive mode the integration name must exactly match a package id or friendly name; fuzzy fallback is disabled to prevent silently selecting the wrong package.</target>
+        <note>{0} is the integration name provided by the user.</note>
+      </trans-unit>
       <trans-unit id="PackageAddedSuccessfully">
         <source>The package {0}::{1} was added successfully.</source>
         <target state="translated">{0}::{1} paketi başarıyla eklendi.</target>

--- a/src/Aspire.Cli/Resources/xlf/AddCommandStrings.zh-Hans.xlf
+++ b/src/Aspire.Cli/Resources/xlf/AddCommandStrings.zh-Hans.xlf
@@ -102,6 +102,11 @@
         <target state="translated">没有与搜索词“{0}”匹配的包。正在显示所有可用包。</target>
         <note>{0} is the search term provided by the user.</note>
       </trans-unit>
+      <trans-unit id="NonInteractiveRequiresExactPackageMatch">
+        <source>No exact match was found for '{0}'. In non-interactive mode the integration name must exactly match a package id or friendly name; fuzzy fallback is disabled to prevent silently selecting the wrong package.</source>
+        <target state="new">No exact match was found for '{0}'. In non-interactive mode the integration name must exactly match a package id or friendly name; fuzzy fallback is disabled to prevent silently selecting the wrong package.</target>
+        <note>{0} is the integration name provided by the user.</note>
+      </trans-unit>
       <trans-unit id="PackageAddedSuccessfully">
         <source>The package {0}::{1} was added successfully.</source>
         <target state="translated">已成功添加包 {0}::{1}。</target>

--- a/src/Aspire.Cli/Resources/xlf/AddCommandStrings.zh-Hant.xlf
+++ b/src/Aspire.Cli/Resources/xlf/AddCommandStrings.zh-Hant.xlf
@@ -102,6 +102,11 @@
         <target state="translated">沒有任何套件符合您搜尋的字詞 '{0}'。顯示所有可用的套件。</target>
         <note>{0} is the search term provided by the user.</note>
       </trans-unit>
+      <trans-unit id="NonInteractiveRequiresExactPackageMatch">
+        <source>No exact match was found for '{0}'. In non-interactive mode the integration name must exactly match a package id or friendly name; fuzzy fallback is disabled to prevent silently selecting the wrong package.</source>
+        <target state="new">No exact match was found for '{0}'. In non-interactive mode the integration name must exactly match a package id or friendly name; fuzzy fallback is disabled to prevent silently selecting the wrong package.</target>
+        <note>{0} is the integration name provided by the user.</note>
+      </trans-unit>
       <trans-unit id="PackageAddedSuccessfully">
         <source>The package {0}::{1} was added successfully.</source>
         <target state="translated">已成功新增套件 {0}::{1}。</target>

--- a/tests/Aspire.Cli.Tests/Commands/AddCommandTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/AddCommandTests.cs
@@ -354,8 +354,25 @@ public class AddCommandTests(ITestOutputHelper outputHelper)
     }
 
     [Fact]
-    public async Task IntegrationSearchCommandFormatJsonWithAppHostUsesConfiguredChannel()
+    public async Task IntegrationSearchCommandFormatJsonWithTypeScriptAppHostPinnedToChannelAlsoSearchesImplicitChannel()
     {
+        // Regression for https://github.com/microsoft/aspire/issues/17724 + https://github.com/microsoft/aspire/issues/17725.
+        //
+        // Layer 1 (latent bug, born 2026-01-13 in PR #13705): IntegrationPackageSearchService used to
+        //   narrow the channel set to whatever `configuredChannel` resolved to whenever the apphost was
+        //   non-C#. This dropped the implicit channel and any other channels from discovery.
+        // Layer 2 (PR #17452, 2026-05-26): `aspire init` started writing `"channel": "<identity>"` into
+        //   the scaffolded aspire.config.json for polyglot apphosts. This activated the Layer 1 bug for
+        //   every newly-initialized TS apphost in 13.4.
+        //
+        // Fix: IntegrationPackageSearchService no longer narrows; the configured channel is forwarded
+        //   only as a synthesis trigger to PackagingService.GetChannelsAsync. The full channel set
+        //   (implicit + pinned channel + any hives) is now searched, matching C# behavior.
+        //
+        // This test pins the TS apphost to the "daily" channel via aspire.config.json. Pre-fix only the
+        // daily channel was searched and Redis 2.0.0 (daily) was the only result. Post-fix the implicit
+        // channel is also searched, and SelectPreferredIntegrationPackage prefers the implicit channel
+        // when versions collide on Id, so Redis 1.0.0 (implicit) wins the dedupe.
         var rawJson = string.Empty;
         var testInteractionService = new TestInteractionService
         {
@@ -401,14 +418,19 @@ public class AddCommandTests(ITestOutputHelper outputHelper)
 
         Assert.Equal(CliExitCodes.Success, exitCode);
 
+        // Implicit channel result wins the dedupe (SelectPreferredIntegrationPackage prefers implicit).
+        // The important regression signal is that the implicit channel is SEARCHED at all post-fix.
         var integration = Assert.Single(ReadIntegrationResults(rawJson));
         Assert.Equal("Aspire.Hosting.Redis", integration.Package);
-        Assert.Equal("2.0.0", integration.Version);
+        Assert.Equal("1.0.0", integration.Version);
     }
 
     [Fact]
-    public async Task IntegrationSearchCommandFormatJsonWithAppHostUsesConfiguredStagingChannelUnderStableCli()
+    public async Task IntegrationSearchCommandFormatJsonWithTypeScriptAppHostPinnedToStagingChannelAlsoSearchesImplicitChannel()
     {
+        // See companion test above for the full Layer 1 / Layer 2 regression story.
+        // This variant covers the staging-channel pin: a stable-shaped CLI dogfooder whose apphost
+        // was init'd by PR #17452 and now has `"channel": "staging"` written into aspire.config.json.
         var rawJson = string.Empty;
         var testInteractionService = new TestInteractionService
         {
@@ -457,7 +479,154 @@ public class AddCommandTests(ITestOutputHelper outputHelper)
 
         var integration = Assert.Single(ReadIntegrationResults(rawJson));
         Assert.Equal("Aspire.Hosting.Redis", integration.Package);
-        Assert.Equal("2.0.0", integration.Version);
+        Assert.Equal("1.0.0", integration.Version);
+    }
+
+    [Fact]
+    public async Task IntegrationSearchCommandFormatJsonWithTypeScriptAppHostPinnedToStableChannelStillSurfacesPrereleaseOnlyPackages()
+    {
+        // Regression for https://github.com/microsoft/aspire/issues/17725 specifically.
+        //
+        // Aspire.Hosting.Foundry has never shipped a stable version — it only exists as prerelease.
+        // Pre-fix, a TS apphost with `"channel": "stable"` in aspire.config.json got narrowed to the
+        // stable channel only. That channel is Quality.Stable, so only `prerelease: false` queries
+        // were issued, and Foundry never appeared in the result set. Users dogfooding the staging CLI
+        // (which writes `"channel": "stable"` for a stable-shaped build) could not discover Foundry.
+        //
+        // Post-fix the implicit channel (Quality.Both) is also searched, which DOES issue
+        // `prerelease: true` queries, and Foundry surfaces.
+        //
+        // The fake here respects the `prerelease` arg passed to GetIntegrationPackagesAsync so the
+        // stable channel sees Redis only, while the implicit channel sees Redis + Foundry. The
+        // existence of Foundry in the result is the regression signal.
+        var rawJson = string.Empty;
+        var testInteractionService = new TestInteractionService
+        {
+            DisplayRawTextCallback = text => rawJson = text
+        };
+
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        var appHostFile = new FileInfo(Path.Combine(workspace.WorkspaceRoot.FullName, "apphost.ts"));
+        File.WriteAllText(appHostFile.FullName, string.Empty);
+        File.WriteAllText(Path.Combine(workspace.WorkspaceRoot.FullName, AspireConfigFile.FileName), """
+            {
+              "channel": "stable"
+            }
+            """);
+
+        // Implicit channel: Quality.Both. Returns Redis when prerelease=false, Redis+Foundry when prerelease=true.
+        var implicitCache = new FakeNuGetPackageCache
+        {
+            GetIntegrationPackagesAsyncCallback = (_, prerelease, _, _) => Task.FromResult<IEnumerable<NuGetPackage>>(
+                prerelease
+                    ? [CreatePackage("Aspire.Hosting.Redis", "1.0.0"), CreatePackage("Aspire.Hosting.Foundry", "1.0.0-preview.1")]
+                    : [CreatePackage("Aspire.Hosting.Redis", "1.0.0")])
+        };
+        // Stable channel: Quality.Stable. PackageChannel only issues prerelease=false queries against it,
+        // so Foundry (prerelease-only) never appears regardless of what the cache could return.
+        var stableCache = new FakeNuGetPackageCache
+        {
+            GetIntegrationPackagesAsyncCallback = (_, _, _, _) => Task.FromResult<IEnumerable<NuGetPackage>>([CreatePackage("Aspire.Hosting.Redis", "1.0.0")])
+        };
+
+        var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper, options =>
+        {
+            options.CliExecutionContextFactory = _ => CreateExecutionContext(workspace, PackageChannelNames.Stable);
+            options.InteractionServiceFactory = _ => testInteractionService;
+            options.PackagingServiceFactory = _ => new TestPackagingService
+            {
+                GetChannelsAsyncCallback = _ => Task.FromResult<IEnumerable<PackageChannel>>([
+                    PackageChannel.CreateImplicitChannel(implicitCache, new TestFeatures()),
+                    PackageChannel.CreateExplicitChannel(PackageChannelNames.Stable, PackageChannelQuality.Stable, [new PackageMapping("Aspire*", "stable")], stableCache, new TestFeatures())
+                ])
+            };
+        });
+        services.AddSingleton<IAppHostProjectFactory>(new TestTypeScriptStarterProjectFactory((_, _, _) => Task.FromResult(true)));
+        using var provider = services.BuildServiceProvider();
+
+        var command = provider.GetRequiredService<RootCommand>();
+        var result = command.Parse($"integration search foundry --apphost \"{appHostFile.FullName}\" --format json");
+
+        var exitCode = await result.InvokeAsync().DefaultTimeout();
+
+        Assert.Equal(CliExitCodes.Success, exitCode);
+
+        var integration = Assert.Single(ReadIntegrationResults(rawJson));
+        Assert.Equal("Aspire.Hosting.Foundry", integration.Package);
+        Assert.Equal("1.0.0-preview.1", integration.Version);
+    }
+
+    [Theory]
+    [InlineData(null)]        // No persisted channel — control case
+    [InlineData("\"daily\"")] // Persisted channel — the case where #17452 + Layer-1 narrowing collided
+    public async Task IntegrationSearchCommandTypeScriptAppHostProducesSameResultRegardlessOfPersistedChannel(string? configFileChannelJson)
+    {
+        // Durable regression guard for the Layer-1 narrowing bug.
+        //
+        // Pre-fix: aspire.config.json with `"channel"` set caused IntegrationPackageSearchService to
+        //   narrow the channel set to that single channel, so the with-channel arm of this theory
+        //   would have returned ONLY the daily channel's Redis (2.0.0) while the without-channel arm
+        //   returned BOTH channels (implicit + daily, dedupe wins on implicit → 1.0.0).
+        // Post-fix: both arms search the full channel set; both produce Redis 1.0.0.
+        //
+        // This is the structural guarantee that #17452's `"channel"` persistence has zero effect on
+        // discovery filtering — it now only acts as a synthesis trigger to PackagingService.
+        // If anyone re-introduces narrowing on `configuredChannel`, this test fires on the
+        // with-channel arm.
+        var rawJson = string.Empty;
+        var testInteractionService = new TestInteractionService
+        {
+            DisplayRawTextCallback = text => rawJson = text
+        };
+
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        var appHostFile = new FileInfo(Path.Combine(workspace.WorkspaceRoot.FullName, "apphost.ts"));
+        File.WriteAllText(appHostFile.FullName, string.Empty);
+        if (configFileChannelJson is not null)
+        {
+            File.WriteAllText(Path.Combine(workspace.WorkspaceRoot.FullName, AspireConfigFile.FileName), $$"""
+                {
+                  "channel": {{configFileChannelJson}}
+                }
+                """);
+        }
+
+        var implicitCache = new FakeNuGetPackageCache
+        {
+            GetIntegrationPackagesAsyncCallback = (_, _, _, _) => Task.FromResult<IEnumerable<NuGetPackage>>([CreatePackage("Aspire.Hosting.Redis", "1.0.0")])
+        };
+        var dailyCache = new FakeNuGetPackageCache
+        {
+            GetIntegrationPackagesAsyncCallback = (_, _, _, _) => Task.FromResult<IEnumerable<NuGetPackage>>([CreatePackage("Aspire.Hosting.Redis", "2.0.0")])
+        };
+
+        var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper, options =>
+        {
+            options.InteractionServiceFactory = _ => testInteractionService;
+            options.PackagingServiceFactory = _ => new TestPackagingService
+            {
+                GetChannelsAsyncCallback = _ => Task.FromResult<IEnumerable<PackageChannel>>([
+                    PackageChannel.CreateImplicitChannel(implicitCache, new TestFeatures()),
+                    PackageChannel.CreateExplicitChannel("daily", PackageChannelQuality.Both, [new PackageMapping("Aspire*", "daily")], dailyCache, new TestFeatures())
+                ])
+            };
+        });
+        services.AddSingleton<IAppHostProjectFactory>(new TestTypeScriptStarterProjectFactory((_, _, _) => Task.FromResult(true)));
+        using var provider = services.BuildServiceProvider();
+
+        var command = provider.GetRequiredService<RootCommand>();
+        var result = command.Parse($"integration search redis --apphost \"{appHostFile.FullName}\" --format json");
+
+        var exitCode = await result.InvokeAsync().DefaultTimeout();
+
+        Assert.Equal(CliExitCodes.Success, exitCode);
+
+        var integration = Assert.Single(ReadIntegrationResults(rawJson));
+        Assert.Equal("Aspire.Hosting.Redis", integration.Package);
+        // Implicit channel is preferred by SelectPreferredIntegrationPackage when an integration
+        // appears in both implicit and explicit channels. Both theory arms must agree on 1.0.0,
+        // proving persisted-channel value no longer narrows discovery.
+        Assert.Equal("1.0.0", integration.Version);
     }
 
     [Fact]
@@ -2286,6 +2455,12 @@ public class AddCommandFuzzySearchTests(ITestOutputHelper outputHelper)
                 return prompter;
             };
 
+            // Fuzzy fallback only fires in interactive mode after the Layer-3 fix for #17724.
+            // The default test host environment is non-interactive (mirroring CI), so opt this
+            // fixture into the interactive path explicitly: the test asserts that an interactive
+            // user can still discover PostgreSQL by typing "postgre".
+            options.CliHostEnvironmentFactory = _ => TestHelpers.CreateInteractiveHostEnvironment();
+
             options.ProjectLocatorFactory = _ => new TestProjectLocator();
 
             options.DotNetCliRunnerFactory = (sp) =>
@@ -2339,6 +2514,126 @@ public class AddCommandFuzzySearchTests(ITestOutputHelper outputHelper)
         Assert.Equal(0, exitCode);
         // Verify that PostgreSQL package was added through fuzzy matching
         Assert.Equal("Aspire.Hosting.PostgreSQL", addedPackage);
+    }
+
+    [Fact]
+    public async Task AddCommand_NonInteractive_NoExactMatchWithoutVersion_FailsInsteadOfFuzzyAutoPick_Regression17724()
+    {
+        // Regression for https://github.com/microsoft/aspire/issues/17724.
+        //
+        // Pre-fix: `aspire add kube --non-interactive` had no exact match for "kube" (none of the
+        //   packages are literally named "kube"), so AddCommand fell back to fuzzy search. The fuzzy
+        //   candidate list was then passed to GetPackageByInteractiveFlow, which in non-interactive
+        //   mode auto-selected `distinctPackages.First()` (AddCommand.cs:368-369) and silently added
+        //   the wrong package. In the user's report this was Aspire.Hosting.Azure because the
+        //   companion Layer-1 bug (#17725 / IntegrationPackageSearchService narrowing) had filtered
+        //   prerelease packages out, leaving Azure as the only fuzzy candidate.
+        //
+        // Fix: AddCommand now refuses to fall back to fuzzy search whenever the host is non-interactive
+        //   and no exact match was found, regardless of whether --version was supplied. The error
+        //   surfaces the new NonInteractiveRequiresExactPackageMatch resource so the user/script
+        //   knows to supply the full package id or friendly name.
+        //
+        // This test uses the simpler C# project flow (TestDotNetCliRunner stub) because the bug is
+        // in AddCommand's non-interactive handling, not in package discovery — the discovery path is
+        // covered by the cross-language parity test above. The Aspire.Hosting.Azure and
+        // Aspire.Hosting.Kubernetes packages both fuzzy-match "kube"; pre-fix the first one
+        // (Aspire.Hosting.Azure, alphabetical) would have been silently picked.
+        var addPackageWasCalled = false;
+        var testInteractionService = new TestInteractionService();
+
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper, options =>
+        {
+            options.CliHostEnvironmentFactory = _ => TestHelpers.CreateNonInteractiveHostEnvironment();
+            options.InteractionServiceFactory = _ => testInteractionService;
+            options.ProjectLocatorFactory = _ => new TestProjectLocator();
+
+            options.DotNetCliRunnerFactory = (sp) =>
+            {
+                var runner = new TestDotNetCliRunner();
+                runner.SearchPackagesAsyncCallback = (dir, query, exactMatch, prerelease, take, skip, nugetSource, useCache, options, cancellationToken) =>
+                {
+                    return (
+                        0,
+                        new NuGetPackage[]
+                        {
+                            new() { Id = "Aspire.Hosting.Azure", Source = "nuget", Version = "9.2.0" },
+                            new() { Id = "Aspire.Hosting.Kubernetes", Source = "nuget", Version = "9.2.0" }
+                        });
+                };
+
+                runner.AddPackageAsyncCallback = (projectFilePath, packageName, packageVersion, nugetSource, noRestore, options, cancellationToken) =>
+                {
+                    addPackageWasCalled = true;
+                    return 0;
+                };
+
+                return runner;
+            };
+        });
+        using var provider = services.BuildServiceProvider();
+
+        var command = provider.GetRequiredService<AddCommand>();
+        var result = command.Parse("add kube");
+
+        var exitCode = await result.InvokeAsync().DefaultTimeout();
+
+        Assert.Equal(CliExitCodes.FailedToAddPackage, exitCode);
+        Assert.False(addPackageWasCalled, "AddPackageAsync must not be called when there is no exact match in non-interactive mode.");
+        Assert.Contains(string.Format(AddCommandStrings.NonInteractiveRequiresExactPackageMatch, "kube"), testInteractionService.DisplayedErrors);
+    }
+
+    [Fact]
+    public async Task AddCommand_NonInteractive_ExactMatchWithoutVersion_StillSucceeds()
+    {
+        // Companion regression guard for #17724: ensures the new non-interactive guard ONLY fires
+        // when there is no exact match. An exact match by package id (or friendly name) must still
+        // install successfully — this is the documented happy path for CI/scripted usage.
+        var addedPackage = string.Empty;
+        var testInteractionService = new TestInteractionService();
+
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper, options =>
+        {
+            options.CliHostEnvironmentFactory = _ => TestHelpers.CreateNonInteractiveHostEnvironment();
+            options.InteractionServiceFactory = _ => testInteractionService;
+            options.ProjectLocatorFactory = _ => new TestProjectLocator();
+
+            options.DotNetCliRunnerFactory = (sp) =>
+            {
+                var runner = new TestDotNetCliRunner();
+                runner.SearchPackagesAsyncCallback = (dir, query, exactMatch, prerelease, take, skip, nugetSource, useCache, options, cancellationToken) =>
+                {
+                    return (
+                        0,
+                        new NuGetPackage[]
+                        {
+                            new() { Id = "Aspire.Hosting.Azure", Source = "nuget", Version = "9.2.0" },
+                            new() { Id = "Aspire.Hosting.Kubernetes", Source = "nuget", Version = "9.2.0" }
+                        });
+                };
+
+                runner.AddPackageAsyncCallback = (projectFilePath, packageName, packageVersion, nugetSource, noRestore, options, cancellationToken) =>
+                {
+                    addedPackage = packageName;
+                    return 0;
+                };
+
+                return runner;
+            };
+        });
+        using var provider = services.BuildServiceProvider();
+
+        var command = provider.GetRequiredService<AddCommand>();
+        // "kubernetes" is the friendly name (Aspire.Hosting.Kubernetes → friendlyName "kubernetes"),
+        // so this is an exact match and must succeed.
+        var result = command.Parse("add kubernetes");
+
+        var exitCode = await result.InvokeAsync().DefaultTimeout();
+
+        Assert.Equal(0, exitCode);
+        Assert.Equal("Aspire.Hosting.Kubernetes", addedPackage);
     }
 
     [Fact]
@@ -2886,6 +3181,10 @@ public class AddCommandFuzzySearchTests(ITestOutputHelper outputHelper)
                 var interactionService = sp.GetRequiredService<IInteractionService>();
                 return new TestAddCommandPrompter(interactionService);
             };
+
+            // Fuzzy fallback only fires in interactive mode after the Layer-3 fix for #17724;
+            // see companion comment on AddCommand_WithStartsWith_FindsMatchUsingFuzzySearch.
+            options.CliHostEnvironmentFactory = _ => TestHelpers.CreateInteractiveHostEnvironment();
 
             options.ProjectLocatorFactory = _ => new TestProjectLocator();
 

--- a/tests/Aspire.Cli.Tests/Commands/AddCommandTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/AddCommandTests.cs
@@ -365,14 +365,18 @@ public class AddCommandTests(ITestOutputHelper outputHelper)
         //   the scaffolded aspire.config.json for polyglot apphosts. This activated the Layer 1 bug for
         //   every newly-initialized TS apphost in 13.4.
         //
-        // Fix: IntegrationPackageSearchService no longer narrows; the configured channel is forwarded
-        //   only as a synthesis trigger to PackagingService.GetChannelsAsync. The full channel set
-        //   (implicit + pinned channel + any hives) is now searched, matching C# behavior.
+        // Fix: IntegrationPackageSearchService no longer narrows. The full channel set (implicit +
+        //   pinned channel + any hives) is searched.
         //
         // This test pins the TS apphost to the "daily" channel via aspire.config.json. Pre-fix only the
         // daily channel was searched and Redis 2.0.0 (daily) was the only result. Post-fix the implicit
-        // channel is also searched, and SelectPreferredIntegrationPackage prefers the implicit channel
+        // channel is ALSO searched, and SelectPreferredIntegrationPackage prefers the implicit channel
         // when versions collide on Id, so Redis 1.0.0 (implicit) wins the dedupe.
+        //
+        // The structural guarantee asserted below — both `implicitHits` AND `dailyHits` being > 0 — is
+        // what defends against a regression that drops either channel from the search. Asserting only
+        // on the resulting Redis version is insufficient because implicit-only and daily-only searches
+        // both happen to produce a single result.
         var rawJson = string.Empty;
         var testInteractionService = new TestInteractionService
         {
@@ -388,13 +392,25 @@ public class AddCommandTests(ITestOutputHelper outputHelper)
             }
             """);
 
+        // Track per-channel invocation. IntegrationPackageSearchService walks channels via
+        // Parallel.ForEachAsync, so callbacks may run concurrently; Interlocked guards that.
+        var implicitHits = 0;
+        var dailyHits = 0;
         var implicitCache = new FakeNuGetPackageCache
         {
-            GetIntegrationPackagesAsyncCallback = (_, _, _, _) => Task.FromResult<IEnumerable<NuGetPackage>>([CreatePackage("Aspire.Hosting.Redis", "1.0.0")])
+            GetIntegrationPackagesAsyncCallback = (_, _, _, _) =>
+            {
+                Interlocked.Increment(ref implicitHits);
+                return Task.FromResult<IEnumerable<NuGetPackage>>([CreatePackage("Aspire.Hosting.Redis", "1.0.0")]);
+            }
         };
         var dailyCache = new FakeNuGetPackageCache
         {
-            GetIntegrationPackagesAsyncCallback = (_, _, _, _) => Task.FromResult<IEnumerable<NuGetPackage>>([CreatePackage("Aspire.Hosting.Redis", "2.0.0")])
+            GetIntegrationPackagesAsyncCallback = (_, _, _, _) =>
+            {
+                Interlocked.Increment(ref dailyHits);
+                return Task.FromResult<IEnumerable<NuGetPackage>>([CreatePackage("Aspire.Hosting.Redis", "2.0.0")]);
+            }
         };
 
         var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper, options =>
@@ -418,8 +434,11 @@ public class AddCommandTests(ITestOutputHelper outputHelper)
 
         Assert.Equal(CliExitCodes.Success, exitCode);
 
+        // Structural regression signal: BOTH channels must have been searched.
+        Assert.True(implicitHits > 0, "Implicit channel was not queried — discovery is dropping it.");
+        Assert.True(dailyHits > 0, "Daily channel was not queried — pinned channel is being dropped from discovery.");
+
         // Implicit channel result wins the dedupe (SelectPreferredIntegrationPackage prefers implicit).
-        // The important regression signal is that the implicit channel is SEARCHED at all post-fix.
         var integration = Assert.Single(ReadIntegrationResults(rawJson));
         Assert.Equal("Aspire.Hosting.Redis", integration.Package);
         Assert.Equal("1.0.0", integration.Version);
@@ -446,13 +465,23 @@ public class AddCommandTests(ITestOutputHelper outputHelper)
             }
             """);
 
+        var implicitHits = 0;
+        var stagingHits = 0;
         var implicitCache = new FakeNuGetPackageCache
         {
-            GetIntegrationPackagesAsyncCallback = (_, _, _, _) => Task.FromResult<IEnumerable<NuGetPackage>>([CreatePackage("Aspire.Hosting.Redis", "1.0.0")])
+            GetIntegrationPackagesAsyncCallback = (_, _, _, _) =>
+            {
+                Interlocked.Increment(ref implicitHits);
+                return Task.FromResult<IEnumerable<NuGetPackage>>([CreatePackage("Aspire.Hosting.Redis", "1.0.0")]);
+            }
         };
         var stagingCache = new FakeNuGetPackageCache
         {
-            GetIntegrationPackagesAsyncCallback = (_, _, _, _) => Task.FromResult<IEnumerable<NuGetPackage>>([CreatePackage("Aspire.Hosting.Redis", "2.0.0")])
+            GetIntegrationPackagesAsyncCallback = (_, _, _, _) =>
+            {
+                Interlocked.Increment(ref stagingHits);
+                return Task.FromResult<IEnumerable<NuGetPackage>>([CreatePackage("Aspire.Hosting.Redis", "2.0.0")]);
+            }
         };
 
         var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper, options =>
@@ -476,6 +505,9 @@ public class AddCommandTests(ITestOutputHelper outputHelper)
         var exitCode = await result.InvokeAsync().DefaultTimeout();
 
         Assert.Equal(CliExitCodes.Success, exitCode);
+
+        Assert.True(implicitHits > 0, "Implicit channel was not queried — discovery is dropping it.");
+        Assert.True(stagingHits > 0, "Staging channel was not queried — pinned channel is being dropped from discovery.");
 
         var integration = Assert.Single(ReadIntegrationResults(rawJson));
         Assert.Equal("Aspire.Hosting.Redis", integration.Package);
@@ -515,18 +547,28 @@ public class AddCommandTests(ITestOutputHelper outputHelper)
             """);
 
         // Implicit channel: Quality.Both. Returns Redis when prerelease=false, Redis+Foundry when prerelease=true.
+        var implicitHits = 0;
         var implicitCache = new FakeNuGetPackageCache
         {
-            GetIntegrationPackagesAsyncCallback = (_, prerelease, _, _) => Task.FromResult<IEnumerable<NuGetPackage>>(
-                prerelease
-                    ? [CreatePackage("Aspire.Hosting.Redis", "1.0.0"), CreatePackage("Aspire.Hosting.Foundry", "1.0.0-preview.1")]
-                    : [CreatePackage("Aspire.Hosting.Redis", "1.0.0")])
+            GetIntegrationPackagesAsyncCallback = (_, prerelease, _, _) =>
+            {
+                Interlocked.Increment(ref implicitHits);
+                return Task.FromResult<IEnumerable<NuGetPackage>>(
+                    prerelease
+                        ? [CreatePackage("Aspire.Hosting.Redis", "1.0.0"), CreatePackage("Aspire.Hosting.Foundry", "1.0.0-preview.1")]
+                        : [CreatePackage("Aspire.Hosting.Redis", "1.0.0")]);
+            }
         };
         // Stable channel: Quality.Stable. PackageChannel only issues prerelease=false queries against it,
         // so Foundry (prerelease-only) never appears regardless of what the cache could return.
+        var stableHits = 0;
         var stableCache = new FakeNuGetPackageCache
         {
-            GetIntegrationPackagesAsyncCallback = (_, _, _, _) => Task.FromResult<IEnumerable<NuGetPackage>>([CreatePackage("Aspire.Hosting.Redis", "1.0.0")])
+            GetIntegrationPackagesAsyncCallback = (_, _, _, _) =>
+            {
+                Interlocked.Increment(ref stableHits);
+                return Task.FromResult<IEnumerable<NuGetPackage>>([CreatePackage("Aspire.Hosting.Redis", "1.0.0")]);
+            }
         };
 
         var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper, options =>
@@ -551,28 +593,38 @@ public class AddCommandTests(ITestOutputHelper outputHelper)
 
         Assert.Equal(CliExitCodes.Success, exitCode);
 
+        // Both channels must be queried. The implicit channel is what surfaces Foundry (via
+        // prerelease=true), but the stable channel must also be searched so users who pinned to
+        // it don't lose stable-only packages.
+        Assert.True(implicitHits > 0, "Implicit channel was not queried — Foundry would not be discoverable.");
+        Assert.True(stableHits > 0, "Stable channel was not queried — pinned channel is being dropped from discovery.");
+
         var integration = Assert.Single(ReadIntegrationResults(rawJson));
         Assert.Equal("Aspire.Hosting.Foundry", integration.Package);
         Assert.Equal("1.0.0-preview.1", integration.Version);
     }
 
     [Theory]
-    [InlineData(null)]        // No persisted channel — control case
-    [InlineData("\"daily\"")] // Persisted channel — the case where #17452 + Layer-1 narrowing collided
-    public async Task IntegrationSearchCommandTypeScriptAppHostProducesSameResultRegardlessOfPersistedChannel(string? configFileChannelJson)
+    [InlineData(null, false)]        // No persisted channel — only implicit is searched, daily is excluded.
+    [InlineData("\"daily\"", true)]  // Persisted channel — implicit AND daily are searched.
+    public async Task IntegrationSearchCommandTypeScriptAppHostPersistedChannelExpandsDiscoveryWithoutChangingPreferredResult(string? configFileChannelJson, bool expectExplicitChannelHit)
     {
-        // Durable regression guard for the Layer-1 narrowing bug.
+        // Durable regression guard against re-introducing the Layer-1 narrowing bug.
         //
         // Pre-fix: aspire.config.json with `"channel"` set caused IntegrationPackageSearchService to
-        //   narrow the channel set to that single channel, so the with-channel arm of this theory
-        //   would have returned ONLY the daily channel's Redis (2.0.0) while the without-channel arm
-        //   returned BOTH channels (implicit + daily, dedupe wins on implicit → 1.0.0).
-        // Post-fix: both arms search the full channel set; both produce Redis 1.0.0.
+        //   narrow the channel set to that single channel, so the with-channel arm would have returned
+        //   ONLY the daily channel's Redis (2.0.0) while the without-channel arm returned Redis 1.0.0.
+        // Post-fix two things hold simultaneously:
+        //   (a) Both arms yield the SAME preferred Redis to the user (1.0.0, the implicit channel
+        //       wins via SelectPreferredIntegrationPackage) — because the pin no longer overrides
+        //       what the user sees as the top-ranked result.
+        //   (b) The with-channel arm ALSO queries the pinned (daily) channel; the without-channel arm
+        //       does not — because the explicit channel set is gated on `hasHives || !empty(configuredChannel)`.
         //
-        // This is the structural guarantee that #17452's `"channel"` persistence has zero effect on
-        // discovery filtering — it now only acts as a synthesis trigger to PackagingService.
-        // If anyone re-introduces narrowing on `configuredChannel`, this test fires on the
-        // with-channel arm.
+        // Both halves matter. (a) alone would pass for an implementation that incorrectly narrowed
+        // to implicit-only when a channel was pinned (a different regression than the original bug
+        // but still wrong — it would mean users who pin to `daily` lose access to packages that only
+        // exist on the daily feed). (b) is the new structural guarantee on top of (a).
         var rawJson = string.Empty;
         var testInteractionService = new TestInteractionService
         {
@@ -591,13 +643,23 @@ public class AddCommandTests(ITestOutputHelper outputHelper)
                 """);
         }
 
+        var implicitHits = 0;
+        var dailyHits = 0;
         var implicitCache = new FakeNuGetPackageCache
         {
-            GetIntegrationPackagesAsyncCallback = (_, _, _, _) => Task.FromResult<IEnumerable<NuGetPackage>>([CreatePackage("Aspire.Hosting.Redis", "1.0.0")])
+            GetIntegrationPackagesAsyncCallback = (_, _, _, _) =>
+            {
+                Interlocked.Increment(ref implicitHits);
+                return Task.FromResult<IEnumerable<NuGetPackage>>([CreatePackage("Aspire.Hosting.Redis", "1.0.0")]);
+            }
         };
         var dailyCache = new FakeNuGetPackageCache
         {
-            GetIntegrationPackagesAsyncCallback = (_, _, _, _) => Task.FromResult<IEnumerable<NuGetPackage>>([CreatePackage("Aspire.Hosting.Redis", "2.0.0")])
+            GetIntegrationPackagesAsyncCallback = (_, _, _, _) =>
+            {
+                Interlocked.Increment(ref dailyHits);
+                return Task.FromResult<IEnumerable<NuGetPackage>>([CreatePackage("Aspire.Hosting.Redis", "2.0.0")]);
+            }
         };
 
         var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper, options =>
@@ -621,12 +683,21 @@ public class AddCommandTests(ITestOutputHelper outputHelper)
 
         Assert.Equal(CliExitCodes.Success, exitCode);
 
+        // (a) User-visible result is identical across arms: implicit Redis 1.0.0 wins.
         var integration = Assert.Single(ReadIntegrationResults(rawJson));
         Assert.Equal("Aspire.Hosting.Redis", integration.Package);
-        // Implicit channel is preferred by SelectPreferredIntegrationPackage when an integration
-        // appears in both implicit and explicit channels. Both theory arms must agree on 1.0.0,
-        // proving persisted-channel value no longer narrows discovery.
         Assert.Equal("1.0.0", integration.Version);
+
+        // (b) Per-channel search invocation differs based on whether a channel was pinned.
+        Assert.True(implicitHits > 0, "Implicit channel must always be searched.");
+        if (expectExplicitChannelHit)
+        {
+            Assert.True(dailyHits > 0, "With-channel arm: pinned 'daily' channel must also be searched.");
+        }
+        else
+        {
+            Assert.Equal(0, dailyHits);
+        }
     }
 
     [Fact]

--- a/tests/Aspire.Cli.Tests/Commands/AddCommandTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/AddCommandTests.cs
@@ -605,8 +605,13 @@ public class AddCommandTests(ITestOutputHelper outputHelper)
     }
 
     [Theory]
-    [InlineData(null, false)]        // No persisted channel — only implicit is searched, daily is excluded.
-    [InlineData("\"daily\"", true)]  // Persisted channel — implicit AND daily are searched.
+    [InlineData(null, false)]          // No persisted channel — only implicit is searched, the explicit channel is excluded.
+    [InlineData("\"daily\"", true)]    // Persisted daily channel — implicit AND daily are searched.
+    [InlineData("\"staging\"", true)]  // Persisted staging channel — implicit AND staging are searched. Proves the gate is channel-name-opaque,
+                                       // so the post-fix behavior verified for "daily" applies equally to a staging-stamped release where
+                                       // `aspire new` would write `"channel": "staging"` into the polyglot apphost's aspire.config.json.
+                                       // (See IntegrationPackageSearchService.GetIntegrationPackagesWithChannelsAsync: the gate is
+                                       //  `hasHives || !string.IsNullOrEmpty(configuredChannel)` — it never inspects the channel name.)
     public async Task IntegrationSearchCommandTypeScriptAppHostPersistedChannelExpandsDiscoveryWithoutChangingPreferredResult(string? configFileChannelJson, bool expectExplicitChannelHit)
     {
         // Durable regression guard against re-introducing the Layer-1 narrowing bug.
@@ -692,7 +697,12 @@ public class AddCommandTests(ITestOutputHelper outputHelper)
         Assert.True(implicitHits > 0, "Implicit channel must always be searched.");
         if (expectExplicitChannelHit)
         {
-            Assert.True(dailyHits > 0, "With-channel arm: pinned 'daily' channel must also be searched.");
+            // The explicit (daily) channel registered in the fake PackagingService gets searched
+            // regardless of what channel NAME the apphost pinned (the gate is channel-name-opaque —
+            // it only checks `!string.IsNullOrEmpty(configuredChannel)`). That's how a real CLI
+            // built with `AspireCliChannel=staging` (writing `"channel": "staging"` into apphosts
+            // via `aspire new`) will exercise the same gate path as a CLI that pinned `"daily"`.
+            Assert.True(dailyHits > 0, $"With-channel arm: explicit channel must also be searched when apphost pin is non-empty (configured: {configFileChannelJson}).");
         }
         else
         {
@@ -792,6 +802,100 @@ public class AddCommandTests(ITestOutputHelper outputHelper)
         var integration = Assert.Single(ReadIntegrationResults(rawJson));
         Assert.Equal("Aspire.Hosting.Redis", integration.Package);
         Assert.Equal("1.0.0", integration.Version);
+    }
+
+    [Fact]
+    public async Task IntegrationSearchCommandStagingStampedCliWithPinnedStagingApphostQueriesBothImplicitAndStagingChannelsAndSurfacesPrereleaseOnlyPackages()
+    {
+        // High-confidence shipping-shape regression guard for #17724 and #17725.
+        //
+        // This test simulates EXACTLY what a real CLI built and shipped as staging will do when
+        // the user runs `aspire add <name>` against a polyglot apphost that `aspire new` created:
+        //
+        //   * The CLI binary is stamped `AspireCliChannel=staging` -> `IdentityChannel == "staging"`.
+        //     This triggers the real PackagingService.GetChannelsAsync to synthesize a real staging
+        //     channel alongside implicit + stable (no fake TestPackagingService is used here).
+        //   * `aspire new` writes `"channel": "staging"` into aspire.config.json (see
+        //     CliTemplateFactory.TypeScriptStarterTemplate). We mirror that here.
+        //   * There are NO PR hives. This is a real shipped install, not a dogfood/PR build.
+        //
+        // Pre-fix (the regression introduced before 13.4): the gate narrowed the search to ONLY the
+        // pinned staging channel. Implicit was excluded. Prerelease-only integrations (e.g.,
+        // Aspire.Hosting.Foundry) were invisible because the only feed queried was the staging
+        // feed, which doesn't surface them. The `aspire add kubernetes` regression had the same
+        // root cause: kubernetes was reachable via implicit (nuget.org) but invisible under the
+        // narrowed staging-only search.
+        //
+        // Post-fix invariants verified here:
+        //   (i)  BOTH implicit AND the synthesized staging channel are queried (cache call count
+        //        is >= 2). Pre-fix this would have been exactly 1.
+        //   (ii) A prerelease-only package returned by the cache only when prerelease=true (which
+        //        is what Quality.Both channels request) is reachable to the user.
+        var rawJson = string.Empty;
+        var testInteractionService = new TestInteractionService
+        {
+            DisplayRawTextCallback = text => rawJson = text
+        };
+
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        var appHostFile = new FileInfo(Path.Combine(workspace.WorkspaceRoot.FullName, "apphost.ts"));
+        File.WriteAllText(appHostFile.FullName, string.Empty);
+        File.WriteAllText(Path.Combine(workspace.WorkspaceRoot.FullName, AspireConfigFile.FileName), """
+            {
+              "channel": "staging"
+            }
+            """);
+
+        var totalCacheCalls = 0;
+        var prereleaseRequested = 0;
+        var cache = new FakeNuGetPackageCache
+        {
+            GetIntegrationPackagesAsyncCallback = (_, prerelease, _, _) =>
+            {
+                Interlocked.Increment(ref totalCacheCalls);
+                if (prerelease)
+                {
+                    Interlocked.Increment(ref prereleaseRequested);
+                    return Task.FromResult<IEnumerable<NuGetPackage>>([CreatePackage("Aspire.Hosting.Foundry", "13.4.0-rc.1")]);
+                }
+                return Task.FromResult<IEnumerable<NuGetPackage>>([]);
+            }
+        };
+
+        var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper, options =>
+        {
+            // Stamp the running CLI as the staging release identity. The real PackagingService
+            // (left un-overridden here) reads this from CliExecutionContext.IdentityChannel and
+            // synthesizes the staging channel automatically (see PackagingService.GetChannelsAsync
+            // -> stagingIdentityChannel branch).
+            options.CliExecutionContextFactory = _ => CreateExecutionContext(workspace, PackageChannelNames.Staging);
+            options.InteractionServiceFactory = _ => testInteractionService;
+            options.NuGetPackageCacheFactory = _ => cache;
+        });
+        services.AddSingleton<IAppHostProjectFactory>(new TestTypeScriptStarterProjectFactory((_, _, _) => Task.FromResult(true)));
+        using var provider = services.BuildServiceProvider();
+
+        var command = provider.GetRequiredService<RootCommand>();
+        var result = command.Parse($"integration search foundry --apphost \"{appHostFile.FullName}\" --format json");
+
+        var exitCode = await result.InvokeAsync().DefaultTimeout();
+
+        Assert.Equal(CliExitCodes.Success, exitCode);
+
+        // (ii) The prerelease-only package is reachable to the user.
+        var integration = Assert.Single(ReadIntegrationResults(rawJson));
+        Assert.Equal("Aspire.Hosting.Foundry", integration.Package);
+        Assert.Equal("13.4.0-rc.1", integration.Version);
+
+        // (i) Both implicit AND staging were queried. Pre-fix narrowing would have produced exactly 1 call.
+        // Real PackagingService.GetChannelsAsync under IdentityChannel=Staging returns at least
+        // [implicit, stable, staging]; the IPSS gate now lets all of them through (hasHives=false,
+        // configuredChannel="staging" -> not empty -> gate evaluates true). At minimum the implicit
+        // and staging channels must have run, so we require >= 2 calls. Using `>= 2` rather than
+        // `== N` keeps the test robust to PackagingService adding additional explicit channels
+        // (e.g., stable) without weakening the regression guard.
+        Assert.True(totalCacheCalls >= 2, $"Expected >= 2 cache calls (both implicit and staging channels), got {totalCacheCalls}. Pre-fix narrowing would have produced 1 call.");
+        Assert.True(prereleaseRequested >= 1, $"Expected at least one channel to request prerelease=true (Quality.Both channels do); got {prereleaseRequested}.");
     }
 
     [Fact]

--- a/tests/Aspire.Cli.Tests/Commands/AddCommandTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/AddCommandTests.cs
@@ -1467,6 +1467,76 @@ public class AddCommandTests(ITestOutputHelper outputHelper)
         Assert.All(exactMatchQueries, query => Assert.Equal("Aspire.Hosting.Redis", query));
     }
 
+    [Theory]
+    [InlineData("redis")]
+    [InlineData("Aspire.Hosting.Redis")]
+    public async Task AddCommandInteractiveDoesNotPromptForIntegrationWhenExactMatchIsFound(string integrationName)
+    {
+        var promptedForIntegration = false;
+        var promptedForVersion = false;
+        var selectedPackageName = string.Empty;
+        var selectedPackageVersion = string.Empty;
+
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper, options =>
+        {
+            options.CliHostEnvironmentFactory = _ => TestHelpers.CreateInteractiveHostEnvironment();
+            options.AddCommandPrompterFactory = (sp) =>
+            {
+                var interactionService = sp.GetRequiredService<IInteractionService>();
+                var prompter = new TestAddCommandPrompter(interactionService);
+                prompter.PromptForIntegrationCallback = (packages) =>
+                {
+                    promptedForIntegration = true;
+                    throw new InvalidOperationException("Should not have been prompted for integration selection.");
+                };
+                prompter.PromptForIntegrationVersionCallback = (packages) =>
+                {
+                    promptedForVersion = true;
+                    return packages.Single(package => package.Package.Version == "13.2.0");
+                };
+
+                return prompter;
+            };
+
+            options.ProjectLocatorFactory = _ => new TestProjectLocator();
+
+            options.DotNetCliRunnerFactory = (sp) =>
+            {
+                var runner = new TestDotNetCliRunner();
+                runner.SearchPackagesAsyncCallback = (dir, query, exactMatch, prerelease, take, skip, nugetSource, useCache, invocationOptions, cancellationToken) =>
+                {
+                    return (0, [
+                        new NuGetPackage { Id = "Aspire.Hosting.Redis", Source = "nuget", Version = "13.3.0" },
+                        new NuGetPackage { Id = "Aspire.Hosting.Redis", Source = "nuget", Version = "13.2.0" }
+                    ]);
+                };
+
+                runner.AddPackageAsyncCallback = (projectFilePath, packageName, packageVersion, nugetSource, noRestore, invocationOptions, cancellationToken) =>
+                {
+                    selectedPackageName = packageName;
+                    selectedPackageVersion = packageVersion;
+                    return 0;
+                };
+
+                return runner;
+            };
+        });
+
+        using var provider = services.BuildServiceProvider();
+
+        var command = provider.GetRequiredService<AddCommand>();
+        var result = command.Parse($"add {integrationName}");
+
+        var exitCode = await result.InvokeAsync().DefaultTimeout();
+
+        Assert.Equal(0, exitCode);
+        Assert.False(promptedForIntegration);
+        Assert.True(promptedForVersion);
+        Assert.Equal("Aspire.Hosting.Redis", selectedPackageName);
+        Assert.Equal("13.2.0", selectedPackageVersion);
+    }
+
     [Fact]
     public async Task AddCommandSearchesEachPackageIdOnceWhenExactMatchFallsBackAcrossSharedChannel()
     {
@@ -2809,6 +2879,131 @@ public class AddCommandFuzzySearchTests(ITestOutputHelper outputHelper)
 
         Assert.Equal(0, exitCode);
         Assert.Equal("Aspire.Hosting.Kubernetes", addedPackage);
+    }
+
+    [Fact]
+    public async Task AddCommand_Interactive_SingleFuzzyMatchPromptsBeforeAdding_Regression17724()
+    {
+        var promptedPackages = new List<(string FriendlyName, NuGetPackage Package, PackageChannel Channel)>();
+        var addedPackage = string.Empty;
+
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper, options =>
+        {
+            options.CliHostEnvironmentFactory = _ => TestHelpers.CreateInteractiveHostEnvironment();
+            options.AddCommandPrompterFactory = (sp) =>
+            {
+                var interactionService = sp.GetRequiredService<IInteractionService>();
+                var prompter = new TestAddCommandPrompter(interactionService);
+                prompter.PromptForIntegrationCallback = (packages) =>
+                {
+                    promptedPackages.AddRange(packages);
+                    return packages.Single();
+                };
+
+                return prompter;
+            };
+            options.ProjectLocatorFactory = _ => new TestProjectLocator();
+
+            options.DotNetCliRunnerFactory = (sp) =>
+            {
+                var runner = new TestDotNetCliRunner();
+                runner.SearchPackagesAsyncCallback = (dir, query, exactMatch, prerelease, take, skip, nugetSource, useCache, options, cancellationToken) =>
+                {
+                    return (
+                        0,
+                        new NuGetPackage[]
+                        {
+                            new() { Id = "Aspire.Hosting.Azure", Source = "nuget", Version = "9.2.0" }
+                        });
+                };
+
+                runner.AddPackageAsyncCallback = (projectFilePath, packageName, packageVersion, nugetSource, noRestore, options, cancellationToken) =>
+                {
+                    addedPackage = packageName;
+                    return 0;
+                };
+
+                return runner;
+            };
+        });
+        using var provider = services.BuildServiceProvider();
+
+        var command = provider.GetRequiredService<AddCommand>();
+        var result = command.Parse("add kube");
+
+        var exitCode = await result.InvokeAsync().DefaultTimeout();
+
+        var promptedPackage = Assert.Single(promptedPackages);
+        Assert.Equal(0, exitCode);
+        Assert.Equal("Aspire.Hosting.Azure", promptedPackage.Package.Id);
+        Assert.Equal("Aspire.Hosting.Azure", addedPackage);
+    }
+
+    [Fact]
+    public async Task AddCommand_Interactive_NoFuzzyMatchSinglePackagePromptsBeforeAdding()
+    {
+        var promptedPackages = new List<(string FriendlyName, NuGetPackage Package, PackageChannel Channel)>();
+        var displayedSubtleMessage = string.Empty;
+        var addedPackage = string.Empty;
+        var testInteractionService = new TestInteractionService
+        {
+            DisplaySubtleMessageCallback = message => displayedSubtleMessage = message
+        };
+
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper, options =>
+        {
+            options.CliHostEnvironmentFactory = _ => TestHelpers.CreateInteractiveHostEnvironment();
+            options.InteractionServiceFactory = _ => testInteractionService;
+            options.AddCommandPrompterFactory = (sp) =>
+            {
+                var interactionService = sp.GetRequiredService<IInteractionService>();
+                var prompter = new TestAddCommandPrompter(interactionService);
+                prompter.PromptForIntegrationCallback = (packages) =>
+                {
+                    promptedPackages.AddRange(packages);
+                    return packages.Single();
+                };
+
+                return prompter;
+            };
+            options.ProjectLocatorFactory = _ => new TestProjectLocator();
+
+            options.DotNetCliRunnerFactory = (sp) =>
+            {
+                var runner = new TestDotNetCliRunner();
+                runner.SearchPackagesAsyncCallback = (dir, query, exactMatch, prerelease, take, skip, nugetSource, useCache, options, cancellationToken) =>
+                {
+                    return (
+                        0,
+                        new NuGetPackage[]
+                        {
+                            new() { Id = "Aspire.Hosting.Redis", Source = "nuget", Version = "9.2.0" }
+                        });
+                };
+
+                runner.AddPackageAsyncCallback = (projectFilePath, packageName, packageVersion, nugetSource, noRestore, options, cancellationToken) =>
+                {
+                    addedPackage = packageName;
+                    return 0;
+                };
+
+                return runner;
+            };
+        });
+        using var provider = services.BuildServiceProvider();
+
+        var command = provider.GetRequiredService<AddCommand>();
+        var result = command.Parse("add zzzzzzzzzz");
+
+        var exitCode = await result.InvokeAsync().DefaultTimeout();
+
+        var promptedPackage = Assert.Single(promptedPackages);
+        Assert.Equal(0, exitCode);
+        Assert.Equal(string.Format(AddCommandStrings.NoPackagesMatchedSearchTerm, "zzzzzzzzzz"), displayedSubtleMessage);
+        Assert.Equal("Aspire.Hosting.Redis", promptedPackage.Package.Id);
+        Assert.Equal("Aspire.Hosting.Redis", addedPackage);
     }
 
     [Fact]


### PR DESCRIPTION
Fixes #17724. Fixes #17725.

## What changed

This PR addresses two release/13.4 blockers that share a root cause.

### Root cause — how we got here (three layers)

The user-facing symptom is **"13.4 hides Kubernetes / Foundry on `aspire add`, 13.3.5 didn't"**. That's a regression. But the *code* responsible for hiding them is identical in both versions — what changed is what populates the input that activates that code.

| Layer | Where | When | What |
|---|---|---|---|
| **Layer 1** — latent bug | `IntegrationPackageSearchService.GetIntegrationPackagesWithChannelsAsync` narrows the channel set to `configuredChannel` when non-empty | Born 2026-01-13, PR #13705 (polyglot apphost intro) | C# short-circuits to `null`; non-C# reads `aspire.config.json` `"channel"` → narrows. If the resolved channel is `Quality.Stable`, prerelease packages disappear. |
| **Layer 2** — activator | `aspire init` started writing `"channel": "<IdentityChannel>"` into scaffolded `aspire.config.json` for both single-file C# and polyglot apphosts | 2026-05-26, PR #17452 | Every 13.4-init'd apphost now has `"channel"` populated, activating Layer 1 for polyglot apphosts. C# remains immune via the short-circuit, but only by accident. |
| **Layer 3** — fallback auto-selection | `AddCommand` treated a single fallback candidate as unambiguous | Pre-existing | With Layers 1 + 2 active, `aspire add kube --non-interactive` on a TS apphost can silently install `Aspire.Hosting.Azure`. In interactive mode, `aspire add kube` can also skip package confirmation whenever fuzzy/no-match fallback collapses to one candidate. |

13.3.5 users were immune because no path was writing `"channel"` into `aspire.config.json` — the Layer-1 narrowing existed but never had input. PR #17452 was the activator that woke the dormant bug for everyone on 13.4.

### Fix #17725 — `IntegrationPackageSearchService` no longer narrows

Deleted the `configuredChannel` narrowing block. The post-retrieval channel set is now:

```csharp
var channels = hasHives || !string.IsNullOrEmpty(configuredChannel)
    ? allChannels
    : allChannels.Where(c => c.Type is PackageChannelType.Implicit);
```

Result:

- **TS apphost with `"channel"` pinned** (the #17725 case): implicit channel + the pinned channel + any hives. Pre-fix only the pinned channel was searched, so prerelease-only packages (e.g. `Aspire.Hosting.Foundry`) vanished when pinned to `Quality.Stable`. Post-fix the implicit channel (`Quality.Both`) participates, so prerelease packages remain reachable, AND the pinned channel still contributes its feed-specific packages.
- **TS apphost without `"channel"`**: implicit channel only (matches C# default).
- **C# apphost**: unchanged. `GetConfiguredChannel` already short-circuits to null for C#, so the gate behavior is identical to before.

The `configuredChannel` value is still forwarded to `PackagingService.GetChannelsAsync` as `requestedChannelName` so out-of-tree apphost staging-channel synthesis (the feature PR #17452 was actually trying to enable) keeps working.

### Fix #17724 — exact-match guard and interactive confirmation

`AddCommand` now tracks whether the candidate set came from exact matching, fuzzy fallback, or the no-match fallback.

- **Non-interactive**: `aspire add <name>` fails fast when `<name>` does not exactly match a friendly name or package ID, instead of silently auto-picking a fuzzy candidate. Callers must supply an exact package ID or friendly name (for example, `aspire add kubernetes` rather than `aspire add kube`).
- **Interactive**: exact matches still skip the package-selection prompt, but fuzzy fallback and no-match fallback now ask for confirmation even when the candidate set contains exactly one package. That covers the interactive `aspire add kube` case from #17724.

This is intentionally orthogonal to Fix #17725 — even if discovery returned every relevant package, silently auto-picking a fuzzy match in a script is wrong, and silently adding a single interactive fuzzy/no-match fallback candidate is too surprising.

## Intentional behavior changes (for release notes)

1. **Polyglot apphosts with `"channel"` set in `aspire.config.json`** previously saw packages from only the pinned channel. They now see packages from the implicit channel **and** the pinned channel. `NuGetPackage.Source` carries the originating feed through to install, so feed routing on install is preserved.
2. **`aspire add <fuzzy-name>` in non-interactive mode** now fails fast instead of silently picking a fuzzy match. Use an exact package ID or friendly name.
3. **`aspire add <fuzzy-name>` in interactive mode** now prompts before adding when the result came from fuzzy/no-match fallback, even if only one candidate remains. Exact friendly-name/package-ID matches still do not show the package-selection prompt.

## Tests

Added/updated in `tests/Aspire.Cli.Tests/Commands/AddCommandTests.cs`. All discovery tests use per-channel invocation counters (`Interlocked.Increment` inside the cache callback) so that "channel X was searched" is asserted directly rather than inferred from dedupe outcomes.

- **`IntegrationSearchCommandFormatJsonWithTypeScriptAppHostPinnedToStableChannelStillSurfacesPrereleaseOnlyPackages`** — primary regression test for #17725. Asserts Foundry surfaces AND both the implicit and stable channels are queried.
- **`IntegrationSearchCommandTypeScriptAppHostPersistedChannelExpandsDiscoveryWithoutChangingPreferredResult`** — `[Theory]` with two arms. Asserts (a) the user-visible top result is identical with/without `"channel"` pinned, AND (b) per-channel invocation counters: implicit-only when no pin, implicit + daily when pinned. Fails fast if anyone re-introduces narrowing OR drops the pinned channel.
- **`IntegrationSearchCommandFormatJsonWithTypeScriptAppHostPinnedToChannelAlsoSearchesImplicitChannel`** + **`...PinnedToStagingChannelAlsoSearchesImplicitChannel`** — assert both channels are queried (counter-backed) and implicit wins the dedupe.
- **`AddCommand_NonInteractive_NoExactMatchWithoutVersion_FailsInsteadOfFuzzyAutoPick_Regression17724`** — non-interactive `add kube` fails instead of fuzzy auto-picking, and `AddPackageAsync` is not called.
- **`AddCommand_NonInteractive_ExactMatchWithoutVersion_StillSucceeds`** — companion happy-path guard for exact friendly-name matching in non-interactive mode.
- **`AddCommand_Interactive_SingleFuzzyMatchPromptsBeforeAdding_Regression17724`** — interactive `add kube` prompts before adding when fuzzy fallback returns a single candidate.
- **`AddCommandInteractiveDoesNotPromptForIntegrationWhenExactMatchIsFound`** — exact interactive matches skip the package-selection prompt for both friendly names and package IDs.
- **`AddCommand_Interactive_NoFuzzyMatchSinglePackagePromptsBeforeAdding`** — interactive no-match fallback also prompts before adding when only one candidate remains.

Two pre-existing `AddCommandFuzzySearchTests` (`AddCommand_WithStartsWith_FindsMatchUsingFuzzySearch`, `AddCommand_WithTypo_FindsMatchUsingFuzzySearch`) were implicitly testing the buggy auto-pick behavior under the default non-interactive test host. They've been updated to opt into an interactive host environment so they assert the documented interactive-fuzzy-prompt behavior.

Latest targeted validation passed for the `AddCommandTests` and `AddCommandFuzzySearchTests` classes.

## Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/aspire/pull/17728)