### PR TITLE
Allow 'write' permission to dispatch the VS Code extension release workflow

### DIFF
--- a/.github/workflows/extension-release.yml
+++ b/.github/workflows/extension-release.yml
@@ -60,9 +60,14 @@ jobs:
           PERMISSION=$(gh api "repos/${REPOSITORY}/collaborators/${ACTOR}/permission" --jq '.permission')
           echo "User permission level: ${PERMISSION}"
 
-          if [[ "$PERMISSION" != "admin" && "$PERMISSION" != "maintain" ]]; then
+          # `write` is the highest permission level granted to contributors on
+          # microsoft/aspire — nobody holds `maintain`/`admin`, so gating on those
+          # alone would make this workflow undispatchable by anyone. Accept `write`
+          # and above, matching the repo's other contributor-gated workflows
+          # (.github/workflows/apply-test-attributes.yml, backport.yml).
+          if [[ "$PERMISSION" != "admin" && "$PERMISSION" != "maintain" && "$PERMISSION" != "write" ]]; then
             echo "❌ ERROR: User ${ACTOR} does not have sufficient permissions."
-            echo "Required: 'admin' or 'maintain' permission level."
+            echo "Required: 'write', 'maintain', or 'admin' permission level."
             echo "Current: '${PERMISSION}'"
             exit 1
           fi


### PR DESCRIPTION
## Problem

The `extension-release.yml` authorization gate (added in #15766) required `admin` or `maintain` permission:

```bash
if [[ "$PERMISSION" != "admin" && "$PERMISSION" != "maintain" ]]; then
  echo "ERROR: User ${ACTOR} does not have sufficient permissions."
  exit 1
fi
```

But on `microsoft/aspire` **nobody holds `maintain`/`admin`** — `write` is the highest level granted to contributors. As written, the workflow is **undispatchable by anyone**. A real dispatch fails at step 1:

```
User permission level: write
ERROR: User adamint does not have sufficient permissions.
Required: 'admin' or 'maintain'.  Current: 'write'
```

(Observed live: run 26692032713 — failed at the authorization step, no branch/PR created.)

## Fix

Accept `write` and above, matching the repo's other **human-dispatched** contributor-gated workflows — `apply-test-attributes.yml` and `backport.yml` both allow `['admin', 'write']`.

## Why not match `release-github-tasks.yml` (admin/maintain)?

That workflow keeps the stricter gate **because it is dispatched by the `aspire-repo-bot` GitHub App** (AzDO chained dispatch), which bypasses the human permission check entirely. `extension-release.yml` is **human-dispatched** (a contributor decides to prepare an extension release PR), so it must accept `write`.

## Testing

- Gate logic unit-tested across all permission levels: `write`/`maintain`/`admin` authorized; `read`/`none`/`triage` rejected.
- actionlint clean.
- Follow-up to #15766; this is the change that lets the first real release (and therefore the end-to-end agentic `extension-changelog` run) actually be dispatched.
