### PR TITLE
Fix extension release workflow PR branch authentication

### DIFF
--- a/.github/workflows/extension-release.yml
+++ b/.github/workflows/extension-release.yml
@@ -533,25 +533,31 @@ jobs:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
           NEW_VERSION: ${{ inputs.release_version }}
           REPOSITORY: ${{ github.repository }}
+          SERVER_URL: ${{ github.server_url }}
         run: |
           set -eo pipefail
 
           WORK_DIR="${RUNNER_TEMP}/extension-release/${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
           BRANCH_NAME="extension-release/v${NEW_VERSION}"
 
-          # Configure git author metadata. The GitHub App token is supplied only to
-          # the commands that need it so it is not persisted in .git/config.
+          # GitHub's Git HTTPS endpoint expects token credentials in the URL/credential
+          # flow (the same pattern used by pr-docs-check.md and
+          # release-update-support-mdx.md). Supplying a bearer extraHeader is not enough
+          # for `git push`, which otherwise falls back to prompting for a username.
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
+          export GIT_TERMINAL_PROMPT=0
+          SERVER_URL_STRIPPED="${SERVER_URL#https://}"
+          git remote set-url origin "https://x-access-token:${GH_TOKEN}@${SERVER_URL_STRIPPED}/${REPOSITORY}.git"
 
           # Create branch and commit
           git checkout -B "$BRANCH_NAME"
           git add extension/package.json extension/CHANGELOG.md
           git commit -m "Prepare VS Code extension release v${NEW_VERSION}"
-          if git -c http.extraHeader="AUTHORIZATION: bearer ${GH_TOKEN}" ls-remote --exit-code --heads origin "$BRANCH_NAME" >/dev/null 2>&1; then
-            git -c http.extraHeader="AUTHORIZATION: bearer ${GH_TOKEN}" fetch origin "$BRANCH_NAME:refs/remotes/origin/$BRANCH_NAME"
+          if git ls-remote --exit-code --heads origin "$BRANCH_NAME" >/dev/null 2>&1; then
+            git fetch origin "$BRANCH_NAME:refs/remotes/origin/$BRANCH_NAME"
           fi
-          git -c http.extraHeader="AUTHORIZATION: bearer ${GH_TOKEN}" push --force-with-lease origin "$BRANCH_NAME"
+          git push --force-with-lease origin "$BRANCH_NAME"
 
           # Create or update draft PR. Capture the PR number directly from each
           # path (the update path already resolved it; `gh pr create` prints the


### PR DESCRIPTION
## Description

The Extension Release workflow could pass its permission gate and prepare release files, then fail when pushing the `extension-release/v...` branch because checkout intentionally uses `persist-credentials: false` and the previous bearer `http.extraHeader` approach did not provide Git HTTPS credentials for `git push`.

This configures `origin` with the GitHub App token using the repository's existing `x-access-token` remote URL pattern before `ls-remote`, `fetch`, and `push`, and disables interactive Git prompts so authentication failures fail clearly in CI. The draft release PR still uses the GitHub App token, then removes/re-adds the `vscode-extension-release` label so the downstream extension changelog agentic workflow receives a fresh `pull_request` `labeled` event.

Validation:

- Parsed the workflow YAML and syntax-checked the extracted `Create draft pull request` shell script with `bash -n`.
- Ran `git diff --check`.
- Verified the same `https://x-access-token:<token>@github.com/<repo>.git` credential shape can non-interactively push and delete a temporary branch.
- Confirmed the live agentic workflow is active and wired to `pull_request` `labeled` events gated on the `vscode-extension-release` label for same-repo PRs.

Fixes # (issue)

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [x] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
