### PR TITLE
Flush VS Code debug output before CLI exit

### DIFF
--- a/.agents/skills/vscode-extension/SKILL.md
+++ b/.agents/skills/vscode-extension/SKILL.md
@@ -1,0 +1,154 @@
+---
+name: vscode-extension
+description: "Guide for developing, building, testing, and debugging the Aspire VS Code extension under extension/. Use this when asked to investigate an issue in the VS Code extension, debug the VS Code extension, or work on a VS Code extension issue or feature."
+---
+
+# Aspire VS Code Extension
+
+This skill covers working on the Aspire VS Code extension, which lives entirely under
+[extension/](../../../extension). It is a TypeScript extension built with **yarn** (pinned via
+`packageManager` in `extension/package.json`) and **webpack**, and it communicates with the Aspire
+CLI over RPC.
+
+## Orientation
+
+All commands below are run from the `extension/` directory unless noted.
+
+| Path | What it is |
+|------|------------|
+| `extension/src/extension.ts` | Activation entry point |
+| `extension/src/commands/` | Command implementations |
+| `extension/src/views/` | Tree views, welcome views, panel UI |
+| `extension/src/debugger/` | Debug adapter + per-language debuggers (dotnet, node, python, go) |
+| `extension/src/server/`, `extension/src/mcp/`, `extension/src/dcp/` | RPC server, MCP provider, DCP integration |
+| `extension/src/loc/strings.ts` | Localized strings (TypeScript-side) |
+| `extension/package.nls.json` | Localized strings referenced from `package.json` (`%key%`) |
+| `extension/src/test/` | Mocha unit tests (`*.test.ts`) run via `vscode-test` |
+| `extension/package.json` | Manifest: `contributes`, `activationEvents`, scripts |
+
+## Prerequisites
+
+**Do NOT run the repo-root `./build.sh` or `./restore.sh` when you are only working on the Aspire
+CLI and/or the VS Code extension.** The root scripts build the entire product (all of `src/`, native
+AOT, packages) and are slow and unnecessary for this work. Instead, **build the extension and CLI
+together with the extension build script.** From `extension/`, run `./build.sh` (Linux/macOS) or
+`./build.ps1` (Windows). This script builds the Aspire CLI
+(`dotnet build ../src/Aspire.Cli/Aspire.Cli.csproj`) **and** the extension, and installs extension
+dependencies (seeds Corepack and runs `corepack yarn install`). You do not install Yarn yourself —
+it is pinned via `packageManager`.
+
+If `corepack yarn install` fails with registry 401/404 or `EACCES`, see the Troubleshooting section
+of [extension/CONTRIBUTING.MD](../../../extension/CONTRIBUTING.MD) — these are environment/npm-mirror
+issues, not code issues.
+
+## Extension ↔ CLI compatibility (IMPORTANT)
+
+The extension and the Aspire CLI are tightly coupled: **new features or changes in the extension
+often require corresponding changes in the CLI.** When you add or modify extension behavior, expect
+to also touch `src/Aspire.Cli/` and rebuild both with `extension/build.sh` / `extension/build.ps1`.
+
+When you change a CLI contract or expectation (command output shape, JSON schema, new flags, new
+behavior the extension relies on), **you must remain backwards compatible and keep working with older
+Aspire CLI versions.** A user may have a newer extension paired with an older `aspire` CLI on their
+PATH. Do not assume the CLI supports a capability just because the current build does.
+
+Detect what the installed CLI supports at runtime instead of assuming, by reading capabilities from extension functionality that wraps `aspire config info`.
+
+## Develop / modify the extension
+
+- Prefer **TypeScript** (`.ts`) files; never create `.js` source files for extension code.
+- Use **static imports**, not dynamic imports, unless dynamic import is absolutely necessary.
+- Use the latest TypeScript features consistent with the existing code style.
+- New user-facing commands, views, settings, or debugger config go in the `contributes` section of
+  `extension/package.json`.
+
+### Localization (REQUIRED for any user-facing string)
+
+Every string shown to the user must be localized. There are two surfaces:
+
+- **TypeScript code** → add to `extension/src/loc/strings.ts` using `vscode.l10n.t(...)`. Follow the
+  existing pattern (plain `const` for static strings, an arrow function for strings with
+  placeholders like `{0}`). Import from `loc/strings` rather than inlining literals.
+- **`package.json` manifest** (command titles, view names, setting descriptions, debugger
+  properties) → use a `%key%` reference and define the key in `extension/package.nls.json`.
+
+Do not hand-edit generated localization bundles (the `l10n/` output, `*.xlf`, or
+`*/localize/templatestrings.*.json`); translation is handled by a dedicated workflow. The npm
+scripts `l10n:export` / `l10n:import` (run automatically by `precompile`/`prepackage`/`prewatch`)
+regenerate the l10n bundle from `package.nls.json` and the `vscode.l10n.t` calls.
+
+## Build
+
+From `extension/`:
+
+```bash
+yarn run compile      # one-off webpack build to ./dist
+yarn run watch        # incremental webpack build (use while iterating)
+yarn run package      # production build (minified, hidden source maps)
+```
+
+`watch`, `compile`, and `package` are preceded by `prewatch`/`precompile`/`prepackage`, which run
+`generate-version`, `generate-schema`, and the l10n export/import. The VS Code task
+`yarn: watch extension` (the default build task) runs `yarn run watch`.
+
+To produce a `.vsix`, the full MSBuild path is `extension/Extension.proj` (used by CI/signing); for
+local iteration `yarn run package` plus the launch configs below is usually enough.
+
+## Test
+
+The extension has Mocha unit tests under `extension/src/test/` executed by `@vscode/test-cli`.
+
+```bash
+yarn run compile-tests   # tsc -> ./out (or watch-tests to keep rebuilding)
+yarn run test            # alias for unit-test (vscode-test); runs lint+compile via pretest
+yarn run lint            # eslint src
+```
+
+`pretest` runs `compile-tests`, `compile`, and `lint`, so `yarn run test` is the single command that
+builds and runs everything. When iterating on one area, keep `watch-tests` running and re-run
+`yarn run test`.
+
+Add new tests as `extension/src/test/<area>.test.ts` mirroring nearby tests (e.g.
+`appHostDiscovery.test.ts`, `strings.test.ts`). There is a `strings.test.ts` that guards
+localization conventions — run it after touching `loc/strings.ts` or `package.nls.json`.
+
+## Debug / run locally
+
+1. Open the `extension/` folder in VS Code.
+2. Launch the **Run Extension** launch configuration to start an Extension Development Host, or
+   **Run Extension (cli stop on entry)** to make the CLI wait for a debugger to attach (use this to
+   debug the CLI and the extension together).
+3. To debug against a locally built CLI, set the `Aspire Cli Executable Path` setting to the build
+   output, e.g. `artifacts/bin/Aspire.Cli/Debug/net8.0/aspire` (relative to the repo root). The
+   `Aspire: Extension settings` command opens settings filtered to the extension.
+
+RPC and debugger issues usually live in `src/server/`, `src/debugger/`, or `src/dcp/`.
+
+## Reproducing issues yourself (do this FIRST for root-cause / "can you repro" requests)
+
+When asked to **find the root cause of** or **reproduce** an issue, do not stop at reading source
+code. One of the first things to try is to launch VS Code with the built extension
+(`extension/build.sh` / `extension/build.ps1`) and drive it to trigger the failing behavior:
+
+- **Prefer VS Code Insiders** (`code-insiders` CLI) if installed; otherwise use the stable `code` CLI.
+- Drive the editor UI with the **Playwright CLI** (`playwright` skill / `run_playwright_code`) to
+  open a workspace, run Aspire commands, and trigger the behavior described in the issue.
+- Iterate in a loop: add logging to the **Aspire Extension** output channel, reproduce, read the
+  channel, make changes, and repeat.
+- You can test a **custom build of the CLI** while driving VS Code this way: point the
+  `Aspire Cli Executable Path` setting at your locally built `aspire` (see the
+  `Aspire Cli Executable Path` setting and how the launch configs in `extension/.vscode/launch.json`
+  wire it up to learn the exact mechanism).
+
+If **neither** the Playwright CLI **nor** a VS Code CLI is installed, you cannot do this — fall back
+to source inspection and the Extension Development Host only.
+
+## Gotchas
+
+- Do not modify `package.json` / `yarn.lock` / `package-lock.json` unless explicitly asked; when you
+  must pin a transitive dependency, add it to `resolutions` and regenerate `yarn.lock` with
+  `corepack yarn install` (see CONTRIBUTING).
+- `yarn.lock` must resolve through the internal `dotnet-public-npm` feed; the build rejects public
+  npmjs.org URLs.
+- Generated files (`l10n/` bundle, schema, version) are produced by the pre-scripts — edit the
+  sources (`package.nls.json`, `loc/strings.ts`, schema/version generator scripts), not the output.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -524,6 +524,7 @@ The following specialized skills are available in `.agents/skills/`:
 - **backport-pr**: Triggers the `/backport` bot on a source PR, waits for the bot-created backport PR, and fills in the shiproom template (Customer Impact, Testing, Risk, Regression?). Use when backporting a fix to a release branch.
 - **startup-perf**: Measures Aspire startup profiling with CLI self-profile capture and dashboard export traces
 - **reviewing-aspire-architecture**: Reviews PRs for Aspire-specific architectural patterns across 15 dimensions including API design, resource model, Azure provisioning, pattern conformance, dashboard UX, CLI behavior, and more. Complements the code-review skill with domain knowledge that generic review cannot catch.
+- **vscode-extension**: Guide for developing, building, testing, and debugging the Aspire VS Code extension under `extension/`. Use when investigating an issue in, debugging, or working on a feature for the VS Code extension.
 
 ## Pattern-Based Instructions
 

--- a/src/Aspire.Cli/Commands/BaseCommand.cs
+++ b/src/Aspire.Cli/Commands/BaseCommand.cs
@@ -16,6 +16,7 @@ namespace Aspire.Cli.Commands;
 internal abstract class BaseCommand : Command
 {
     private static readonly int[] s_suppressErrorLogsMessageExitCodes = [CliExitCodes.Cancelled, CliExitCodes.MissingRequiredArgument];
+    private static readonly TimeSpan s_extensionInteractionFlushTimeout = TimeSpan.FromSeconds(10);
 
     protected virtual bool UpdateNotificationsEnabled { get; }
 
@@ -83,6 +84,8 @@ internal abstract class BaseCommand : Command
             if (result.ShouldDisplayHelp)
             {
                 new HelpAction().Invoke(parseResult);
+                await FlushExtensionInteractionServiceAsync(interactionService).ConfigureAwait(false);
+
                 return result.ExitCode;
             }
 
@@ -126,6 +129,8 @@ internal abstract class BaseCommand : Command
                 }
             }
 
+            await FlushExtensionInteractionServiceAsync(interactionService).ConfigureAwait(false);
+
             return result.ExitCode;
         }));
     }
@@ -146,6 +151,28 @@ internal abstract class BaseCommand : Command
         }
 
         return false;
+    }
+
+    private static async Task FlushExtensionInteractionServiceAsync(IInteractionService interactionService)
+    {
+        if (interactionService is not IExtensionInteractionService extensionInteractionService)
+        {
+            return;
+        }
+
+        // Command cancellation has already been translated into CommandResult; using a canceled
+        // token here would skip the final debug-console drain or throw after the command selected
+        // its exit code. Bound the drain separately so a broken extension cannot hang CLI exit.
+        using var flushCancellationTokenSource = new CancellationTokenSource(s_extensionInteractionFlushTimeout);
+        try
+        {
+            await extensionInteractionService.FlushAsync(flushCancellationTokenSource.Token).ConfigureAwait(false);
+        }
+        catch (OperationCanceledException) when (flushCancellationTokenSource.IsCancellationRequested)
+        {
+            // Prefer returning the command's chosen exit code over hanging indefinitely when
+            // VS Code has already gone away or stopped responding to backchannel requests.
+        }
     }
 
     internal static CommandResult HandleProjectLocatorException(ProjectLocatorException ex, IInteractionService interactionService, AspireCliTelemetry telemetry)

--- a/src/Aspire.Cli/Interaction/ExtensionInteractionService.cs
+++ b/src/Aspire.Cli/Interaction/ExtensionInteractionService.cs
@@ -14,6 +14,7 @@ namespace Aspire.Cli.Interaction;
 internal interface IExtensionInteractionService : IInteractionService
 {
     IExtensionBackchannel Backchannel { get; }
+    Task FlushAsync(CancellationToken cancellationToken = default);
     void OpenEditor(string projectPath);
     void LogMessage(LogLevel logLevel, string message);
     Task LaunchAppHostAsync(string projectFile, List<string> arguments, List<EnvVar> environment, bool debug);
@@ -31,15 +32,17 @@ internal class ExtensionInteractionService : IExtensionInteractionService
     private readonly bool _extensionPromptEnabled;
     private readonly CancellationToken _cancellationToken;
     private readonly Channel<Func<Task>> _extensionTaskChannel;
+    private readonly ILogger<ExtensionInteractionService>? _logger;
 
     public IExtensionBackchannel Backchannel { get; }
 
-    public ExtensionInteractionService(ConsoleInteractionService consoleInteractionService, IExtensionBackchannel backchannel, bool extensionPromptEnabled, CancellationToken? cancellationToken = null)
+    public ExtensionInteractionService(ConsoleInteractionService consoleInteractionService, IExtensionBackchannel backchannel, bool extensionPromptEnabled, CancellationToken? cancellationToken = null, ILogger<ExtensionInteractionService>? logger = null)
     {
         _consoleInteractionService = consoleInteractionService;
         Backchannel = backchannel;
         _extensionPromptEnabled = extensionPromptEnabled;
         _cancellationToken = cancellationToken ?? CancellationToken.None;
+        _logger = logger;
         _extensionTaskChannel = Channel.CreateUnbounded<Func<Task>>(new UnboundedChannelOptions
         {
             SingleReader = true,
@@ -57,11 +60,36 @@ internal class ExtensionInteractionService : IExtensionInteractionService
                 }
                 catch (Exception ex) when (ex is not ExtensionOperationCanceledException)
                 {
-                    await Backchannel.DisplayErrorAsync(ex.Message.RemoveSpectreFormatting(), _cancellationToken);
+                    try
+                    {
+                        await Backchannel.DisplayErrorAsync(ex.Message.RemoveSpectreFormatting(), _cancellationToken);
+                    }
+                    catch (Exception displayErrorException)
+                    {
+                        // Keep the single-reader pump alive even when the extension connection is
+                        // already broken; otherwise the final flush sentinel can never be processed.
+                        _logger?.LogDebug(displayErrorException, "Failed to display an extension operation error through the extension backchannel.");
+                    }
+
                     _consoleInteractionService.DisplayError(ex.Message);
                 }
             }
         });
+    }
+
+    public async Task FlushAsync(CancellationToken cancellationToken = default)
+    {
+        var completionSource = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        // Queue a sentinel after all pending extension operations so callers can wait until
+        // debug-console output has reached the extension before the CLI process exits.
+        await _extensionTaskChannel.Writer.WriteAsync(() =>
+        {
+            completionSource.TrySetResult();
+            return Task.CompletedTask;
+        }, cancellationToken).ConfigureAwait(false);
+
+        await completionSource.Task.WaitAsync(cancellationToken).ConfigureAwait(false);
     }
 
     public async Task<T> ShowStatusAsync<T>(string statusText, Func<Task<T>> action, KnownEmoji? emoji = null, bool allowMarkup = false)

--- a/src/Aspire.Cli/Program.cs
+++ b/src/Aspire.Cli/Program.cs
@@ -1013,7 +1013,8 @@ public class Program
                 var consoleInteractionService = new ConsoleInteractionService(consoleEnvironment, executionContext, hostEnvironment, loggerFactory, logBufferCtx);
                 return new ExtensionInteractionService(consoleInteractionService,
                     provider.GetRequiredService<IExtensionBackchannel>(),
-                    extensionPromptEnabled);
+                    extensionPromptEnabled,
+                    logger: provider.GetRequiredService<ILogger<ExtensionInteractionService>>());
             });
         }
         else

--- a/tests/Aspire.Cli.Tests/Commands/RunCommandTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/RunCommandTests.cs
@@ -1935,6 +1935,80 @@ public class RunCommandTests(ITestOutputHelper outputHelper)
     }
 
     [Fact]
+    public async Task RunCommand_WhenExtensionBuildFails_WaitsForBuildOutputToFlush()
+    {
+        var displayLinesStarted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var allowDisplayLinesToComplete = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        DisplayLineState[] displayedLines = [];
+        var buildError = "error CS0103: The name 'MissingSymbol' does not exist in the current context";
+
+        var extensionBackchannel = new TestExtensionBackchannel();
+        extensionBackchannel.HasCapabilityAsyncCallback = (capability, ct) => Task.FromResult(capability == KnownCapabilities.BuildDotnetUsingCli);
+        extensionBackchannel.DisplayLinesAsyncCallback = async lines =>
+        {
+            displayedLines = lines.ToArray();
+            displayLinesStarted.TrySetResult();
+            await allowDisplayLinesToComplete.Task;
+        };
+
+        var runnerFactory = (IServiceProvider sp) =>
+        {
+            var runner = new TestDotNetCliRunner();
+            runner.BuildAsyncCallback = (projectFile, noRestore, options, ct) =>
+            {
+                options.StandardErrorCallback?.Invoke(buildError);
+                return 1;
+            };
+            runner.GetAppHostInformationAsyncCallback = (projectFile, options, ct) => (0, true, VersionHelper.GetDefaultTemplateVersion());
+            return runner;
+        };
+
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper, options =>
+        {
+            options.ProjectLocatorFactory = _ => new TestProjectLocator();
+            options.DotNetCliRunnerFactory = runnerFactory;
+            options.ExtensionBackchannelFactory = _ => extensionBackchannel;
+            options.InteractionServiceFactory = sp =>
+            {
+                var consoleEnvironment = sp.GetRequiredService<ConsoleEnvironment>();
+                var executionContext = sp.GetRequiredService<CliExecutionContext>();
+                var hostEnvironment = sp.GetRequiredService<ICliHostEnvironment>();
+                var loggerFactory = sp.GetRequiredService<ILoggerFactory>();
+                var logBufferContext = sp.GetRequiredService<ConsoleLogBufferContext>();
+                var consoleInteractionService = new ConsoleInteractionService(consoleEnvironment, executionContext, hostEnvironment, loggerFactory, logBufferContext);
+
+                return new ExtensionInteractionService(consoleInteractionService, extensionBackchannel, extensionPromptEnabled: false);
+            };
+            options.ConfigurationCallback += config =>
+            {
+                config["ASPIRE_EXTENSION_DEBUG_SESSION_ID"] = "test-session-id";
+            };
+        });
+
+        using var provider = services.BuildServiceProvider();
+        var command = provider.GetRequiredService<RootCommand>();
+        var result = command.Parse("run");
+
+        var pendingRun = result.InvokeAsync();
+
+        try
+        {
+            await displayLinesStarted.Task.DefaultTimeout();
+            Assert.False(pendingRun.IsCompleted, "The command should not exit before queued extension debug console output is flushed.");
+        }
+        finally
+        {
+            allowDisplayLinesToComplete.TrySetResult();
+        }
+
+        var exitCode = await pendingRun.DefaultTimeout();
+
+        Assert.Equal(CliExitCodes.FailedToBuildArtifacts, exitCode);
+        Assert.Contains(displayedLines, line => line.Stream == "stderr" && line.Line == buildError);
+    }
+
+    [Fact]
     public async Task RunCommand_WhenSingleFileAppHostAndDefaultWatchEnabled_DoesNotUseWatchMode()
     {
         var watchModeUsed = false;

--- a/tests/Aspire.Cli.Tests/Projects/ExtensionGuestLauncherTests.cs
+++ b/tests/Aspire.Cli.Tests/Projects/ExtensionGuestLauncherTests.cs
@@ -138,6 +138,8 @@ public class ExtensionGuestLauncherTests
 
         public IExtensionBackchannel Backchannel => throw new NotImplementedException();
 
+        public Task FlushAsync(CancellationToken cancellationToken = default) => Task.CompletedTask;
+
         public Task LaunchAppHostAsync(string projectFile, List<string> arguments, List<EnvVar> environment, bool debug)
         {
             _onLaunch(projectFile, arguments, environment, debug);

--- a/tests/Aspire.Cli.Tests/TestServices/TestExtensionInteractionService.cs
+++ b/tests/Aspire.Cli.Tests/TestServices/TestExtensionInteractionService.cs
@@ -26,8 +26,16 @@ internal sealed class TestExtensionInteractionService(IServiceProvider servicePr
     public Func<string, bool, bool>? ConfirmCallback { get; set; }
     public Func<string, IReadOnlyList<string>, string>? SelectionCallback { get; set; }
     public Func<IRenderable, Func<Action<IRenderable>, Task>, Task>? DisplayLiveAsyncCallback { get; set; }
+    public List<(OutputLineStream Stream, string Line)> DisplayedLines { get; } = [];
+    public bool FlushAsyncCalled { get; private set; }
 
     public IExtensionBackchannel Backchannel { get; } = serviceProvider.GetRequiredService<IExtensionBackchannel>();
+
+    public Task FlushAsync(CancellationToken cancellationToken = default)
+    {
+        FlushAsyncCalled = true;
+        return Task.CompletedTask;
+    }
 
     public Task<T> ShowStatusAsync<T>(string statusText, Func<Task<T>> action, KnownEmoji? emoji = null, bool allowMarkup = false)
     {
@@ -135,6 +143,7 @@ internal sealed class TestExtensionInteractionService(IServiceProvider servicePr
 
     public void DisplayLines(IEnumerable<(OutputLineStream Stream, string Line)> lines)
     {
+        DisplayedLines.AddRange(lines);
     }
 
     public void DisplayCancellationMessage(ConsoleOutput? consoleOverride = null)


### PR DESCRIPTION
## Description

Fixes #17735.

This drains queued VS Code extension backchannel output before the Aspire CLI command exits, so extension-hosted AppHost build diagnostics reach the debug console before the CLI process terminates. The drain is bounded so a disconnected or unresponsive extension cannot hang CLI exit.

This also includes the repo-local `vscode-extension` skill that was missing from this branch's skill registry context.

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No

Validation:

- `dotnet test --project tests/Aspire.Cli.Tests/Aspire.Cli.Tests.csproj --no-launch-profile -- --filter-class "*.RunCommandTests" --filter-not-trait "quarantined=true" --filter-not-trait "outerloop=true"`
- `./extension/build.sh`
- `npx playwright@1.60.0 --version` plus Playwright-launched VS Code Insiders validation using the built Aspire extension and CLI, confirming AppHost build diagnostics (`CS0103`) are emitted through the Aspire debug session output.
- 3 independent review agents: CLI diff review, async/concurrency review, Aspire architecture review.
