### PR TITLE
Delegate bundled AppHost dotnet run to Aspire CLI

### DIFF
--- a/src/Aspire.Cli/DotNet/DotNetCliRunner.cs
+++ b/src/Aspire.Cli/DotNet/DotNetCliRunner.cs
@@ -628,7 +628,8 @@ internal sealed class DotNetCliRunner(
         var env = new Dictionary<string, string>
         {
             [KnownConfigNames.DotnetCliTelemetryOptOut] = "1",
-            [KnownConfigNames.DotnetCliWorkloadUpdateNotifyDisable] = "1"
+            [KnownConfigNames.DotnetCliWorkloadUpdateNotifyDisable] = "1",
+            [KnownConfigNames.SuppressCliRunHook] = "true"
         };
 
         var existingStandardOutputCallback = options.StandardOutputCallback;
@@ -735,6 +736,7 @@ internal sealed class DotNetCliRunner(
         var finalEnv = CreateRunEnvironment(
             env,
             watch,
+            suppressCliRunHook: !isSingleFile,
             backchannelCompletionSource);
 
         return await ExecuteAsync(
@@ -762,6 +764,7 @@ internal sealed class DotNetCliRunner(
         var finalEnv = CreateRunEnvironment(
             env,
             watch: false,
+            suppressCliRunHook: false,
             backchannelCompletionSource);
 
         return await ExecuteAsync(
@@ -778,6 +781,7 @@ internal sealed class DotNetCliRunner(
     private Dictionary<string, string> CreateRunEnvironment(
         IDictionary<string, string>? env,
         bool watch,
+        bool suppressCliRunHook,
         TaskCompletionSource<IAppHostCliBackchannel>? backchannelCompletionSource)
     {
         // We copy the dictionary here because we don't want to mutate the input.
@@ -801,6 +805,11 @@ internal sealed class DotNetCliRunner(
             {
                 finalEnv["DOTNET_WATCH_SUPPRESS_LAUNCH_BROWSER"] = "true";
             }
+        }
+
+        if (suppressCliRunHook)
+        {
+            finalEnv[KnownConfigNames.SuppressCliRunHook] = "true";
         }
 
         // Set the backchannel socket path when backchannel is configured

--- a/src/Aspire.Cli/DotNet/DotNetCliRunner.cs
+++ b/src/Aspire.Cli/DotNet/DotNetCliRunner.cs
@@ -720,6 +720,7 @@ internal sealed class DotNetCliRunner(
         var noBuildSwitch = noBuild ? "--no-build" : string.Empty;
         var noRestoreSwitch = noRestore && !noBuild ? "--no-restore" : string.Empty; // --no-build implies --no-restore
         var noProfileSwitch = options.NoLaunchProfile ? "--no-launch-profile" : string.Empty;
+        var suppressCliRunHookProperty = $"/p:{KnownConfigNames.SuppressCliRunHook}=true";
         // Add --non-interactive flag when using watch to prevent interactive prompts during automation
         var nonInteractiveSwitch = watch ? "--non-interactive" : string.Empty;
         // Add --verbose flag when using watch and debug is enabled
@@ -728,7 +729,9 @@ internal sealed class DotNetCliRunner(
         string[] cliArgs = isSingleFile switch
         {
             false => [watchOrRunCommand, nonInteractiveSwitch, verboseSwitch, noBuildSwitch, noRestoreSwitch, noProfileSwitch, "--project", projectFile.FullName, "--", .. args],
-            true => ["run", noProfileSwitch, "--file", projectFile.FullName, "--", .. args]
+            // File-based --no-build reuses the previously computed run command, so the suppression
+            // property would not be observed and a CLI-launched AppHost can recursively enter the run hook.
+            true => ["run", noRestoreSwitch, noProfileSwitch, suppressCliRunHookProperty, "--file", projectFile.FullName, "--", .. args]
         };
 
         cliArgs = [.. cliArgs.Where(arg => !string.IsNullOrWhiteSpace(arg))];
@@ -736,7 +739,10 @@ internal sealed class DotNetCliRunner(
         var finalEnv = CreateRunEnvironment(
             env,
             watch,
-            suppressCliRunHook: !isSingleFile,
+            // Aspire CLI launches AppHosts by shelling out to dotnet run. If the AppHost SDK run hook
+            // is enabled, every CLI-launched AppHost must suppress the hook to avoid recursive
+            // dotnet run -> aspire run -> dotnet run loops.
+            suppressCliRunHook: true,
             backchannelCompletionSource);
 
         return await ExecuteAsync(

--- a/src/Aspire.Cli/DotNet/DotNetCliRunner.cs
+++ b/src/Aspire.Cli/DotNet/DotNetCliRunner.cs
@@ -729,10 +729,9 @@ internal sealed class DotNetCliRunner(
         string[] cliArgs = isSingleFile switch
         {
             false => [watchOrRunCommand, nonInteractiveSwitch, verboseSwitch, noBuildSwitch, noRestoreSwitch, noProfileSwitch, "--project", projectFile.FullName, "--", .. args],
-            // File-based dotnet run currently does not account for /p: properties when
-            // reusing the cached run command for --no-build. Omit --no-build for single-file
-            // AppHosts so suppression is observed and a CLI-launched AppHost cannot recursively
-            // enter the run hook.
+            // File-based dotnet run only recomputes RunCommand during build. Omit --no-build
+            // for single-file AppHosts so the suppression property is applied before launch
+            // and a CLI-launched AppHost cannot recursively enter the run hook.
             true => ["run", noRestoreSwitch, noProfileSwitch, suppressCliRunHookProperty, "--file", projectFile.FullName, "--", .. args]
         };
 

--- a/src/Aspire.Cli/DotNet/DotNetCliRunner.cs
+++ b/src/Aspire.Cli/DotNet/DotNetCliRunner.cs
@@ -729,8 +729,10 @@ internal sealed class DotNetCliRunner(
         string[] cliArgs = isSingleFile switch
         {
             false => [watchOrRunCommand, nonInteractiveSwitch, verboseSwitch, noBuildSwitch, noRestoreSwitch, noProfileSwitch, "--project", projectFile.FullName, "--", .. args],
-            // File-based --no-build reuses the previously computed run command, so the suppression
-            // property would not be observed and a CLI-launched AppHost can recursively enter the run hook.
+            // File-based dotnet run currently does not account for /p: properties when
+            // reusing the cached run command for --no-build. Omit --no-build for single-file
+            // AppHosts so suppression is observed and a CLI-launched AppHost cannot recursively
+            // enter the run hook.
             true => ["run", noRestoreSwitch, noProfileSwitch, suppressCliRunHookProperty, "--file", projectFile.FullName, "--", .. args]
         };
 

--- a/src/Aspire.Hosting.AppHost/build/Aspire.Hosting.AppHost.in.targets
+++ b/src/Aspire.Hosting.AppHost/build/Aspire.Hosting.AppHost.in.targets
@@ -213,8 +213,20 @@ namespace Projects%3B
   <Target Name="_AspireComputeRunArguments"
           BeforeTargets="ComputeRunArguments"
           Condition="'$(IsAspireHost)' == 'true' and '$(AspireUseCliBundle)' == 'true' and '$(_AspireSuppressCliRunHook)' != 'true' and '$(ASPIRE_SUPPRESS_CLI_RUN_HOOK)' != 'true'">
+    <ItemGroup Condition="'$(FileBasedProgram)' == 'true'">
+      <_AspireFileBasedAppHostPath Include="%(RuntimeHostConfigurationOption.Value)"
+                                   Condition="'%(RuntimeHostConfigurationOption.Identity)' == 'EntryPointFilePath'" />
+      <_AspireFileBasedAppHostDirectory Include="%(RuntimeHostConfigurationOption.Value)"
+                                        Condition="'%(RuntimeHostConfigurationOption.Identity)' == 'EntryPointFileDirectoryPath'" />
+    </ItemGroup>
+
     <PropertyGroup>
       <_AspireOriginalRunArguments>$(RunArguments)</_AspireOriginalRunArguments>
+      <_AspireRunProject>$(MSBuildProjectFullPath)</_AspireRunProject>
+      <!-- File-based dotnet run uses a synthetic apphost.csproj for MSBuild, but the Aspire CLI needs the original .cs file. -->
+      <_AspireRunProject Condition="'$(FileBasedProgram)' == 'true' and '@(_AspireFileBasedAppHostPath)' != ''">@(_AspireFileBasedAppHostPath)</_AspireRunProject>
+      <_AspireRunWorkingDirectory>$(MSBuildProjectDirectory)</_AspireRunWorkingDirectory>
+      <_AspireRunWorkingDirectory Condition="'$(FileBasedProgram)' == 'true' and '@(_AspireFileBasedAppHostDirectory)' != ''">@(_AspireFileBasedAppHostDirectory)</_AspireRunWorkingDirectory>
       <RunCommand Condition="'$(AspireCliPath)' != ''">$(AspireCliPath)</RunCommand>
       <!-- On Windows, Aspire can be installed as a command shim such as aspire.cmd.
            dotnet run starts RunCommand directly, so use cmd /C for the default PATH
@@ -223,10 +235,10 @@ namespace Projects%3B
       <RunCommand Condition="'$(AspireCliPath)' == '' and '$(OS)' != 'Windows_NT'">aspire</RunCommand>
       <!-- dotnet run appends application arguments after ComputeRunArguments, so the double-dash separator
            must be present even when RunArguments is initially empty. -->
-      <RunArguments>run --project "$(MSBuildProjectFullPath)" --no-build --</RunArguments>
+      <RunArguments>run --project "$(_AspireRunProject)" --no-build --</RunArguments>
       <RunArguments Condition="'$(AspireCliPath)' == '' and '$(OS)' == 'Windows_NT'">/C aspire $(RunArguments)</RunArguments>
       <RunArguments Condition="'$(_AspireOriginalRunArguments)' != ''">$(RunArguments) $(_AspireOriginalRunArguments)</RunArguments>
-      <RunWorkingDirectory>$(MSBuildProjectDirectory)</RunWorkingDirectory>
+      <RunWorkingDirectory>$(_AspireRunWorkingDirectory)</RunWorkingDirectory>
     </PropertyGroup>
   </Target>
 

--- a/src/Aspire.Hosting.AppHost/build/Aspire.Hosting.AppHost.in.targets
+++ b/src/Aspire.Hosting.AppHost/build/Aspire.Hosting.AppHost.in.targets
@@ -210,9 +210,14 @@ namespace Projects%3B
            Text="$(_AspireCliBundleNotFoundError)" />
   </Target>
 
+  <PropertyGroup>
+    <_AspireCliRunHookSuppressed Condition="'$(_AspireSuppressCliRunHook)' == 'true' or '$(_AspireSuppressCliRunHook)' == '1'">true</_AspireCliRunHookSuppressed>
+    <_AspireCliRunHookSuppressed Condition="'$(ASPIRE_SUPPRESS_CLI_RUN_HOOK)' == 'true' or '$(ASPIRE_SUPPRESS_CLI_RUN_HOOK)' == '1'">true</_AspireCliRunHookSuppressed>
+  </PropertyGroup>
+
   <Target Name="_AspireComputeRunArguments"
           BeforeTargets="ComputeRunArguments"
-          Condition="'$(IsAspireHost)' == 'true' and '$(AspireUseCliBundle)' == 'true' and '$(_AspireSuppressCliRunHook)' != 'true' and '$(ASPIRE_SUPPRESS_CLI_RUN_HOOK)' != 'true'">
+          Condition="'$(IsAspireHost)' == 'true' and '$(AspireUseCliBundle)' == 'true' and '$(_AspireCliRunHookSuppressed)' != 'true'">
     <ItemGroup Condition="'$(FileBasedProgram)' == 'true'">
       <_AspireFileBasedAppHostPath Include="%(RuntimeHostConfigurationOption.Value)"
                                    Condition="'%(RuntimeHostConfigurationOption.Identity)' == 'EntryPointFilePath'" />

--- a/src/Aspire.Hosting.AppHost/build/Aspire.Hosting.AppHost.in.targets
+++ b/src/Aspire.Hosting.AppHost/build/Aspire.Hosting.AppHost.in.targets
@@ -210,6 +210,21 @@ namespace Projects%3B
            Text="$(_AspireCliBundleNotFoundError)" />
   </Target>
 
+  <Target Name="_AspireComputeRunArguments"
+          BeforeTargets="ComputeRunArguments"
+          Condition="'$(IsAspireHost)' == 'true' and '$(AspireUseCliBundle)' == 'true' and '$(_AspireSuppressCliRunHook)' != 'true' and '$(ASPIRE_SUPPRESS_CLI_RUN_HOOK)' != 'true'">
+    <PropertyGroup>
+      <_AspireOriginalRunArguments>$(RunArguments)</_AspireOriginalRunArguments>
+      <RunCommand Condition="'$(AspireCliPath)' != ''">$(AspireCliPath)</RunCommand>
+      <RunCommand Condition="'$(AspireCliPath)' == ''">aspire</RunCommand>
+      <!-- dotnet run appends application arguments after ComputeRunArguments, so the double-dash separator
+           must be present even when RunArguments is initially empty. -->
+      <RunArguments>run --project "$(MSBuildProjectFullPath)" --no-build --</RunArguments>
+      <RunArguments Condition="'$(_AspireOriginalRunArguments)' != ''">$(RunArguments) $(_AspireOriginalRunArguments)</RunArguments>
+      <RunWorkingDirectory>$(MSBuildProjectDirectory)</RunWorkingDirectory>
+    </PropertyGroup>
+  </Target>
+
   <!-- This target registers the location of the Aspire orchestration dependencies -->
   <Target Name="SetOrchestrationDiscoveryAttributes" DependsOnTargets="ResolveAspireCliBundlePaths" BeforeTargets="GetAssemblyAttributes" Condition=" '$(DcpDir)' != '' or '$(AspireUseCliBundle)' == 'true' ">
     <PropertyGroup>

--- a/src/Aspire.Hosting.AppHost/build/Aspire.Hosting.AppHost.in.targets
+++ b/src/Aspire.Hosting.AppHost/build/Aspire.Hosting.AppHost.in.targets
@@ -216,10 +216,15 @@ namespace Projects%3B
     <PropertyGroup>
       <_AspireOriginalRunArguments>$(RunArguments)</_AspireOriginalRunArguments>
       <RunCommand Condition="'$(AspireCliPath)' != ''">$(AspireCliPath)</RunCommand>
-      <RunCommand Condition="'$(AspireCliPath)' == ''">aspire</RunCommand>
+      <!-- On Windows, Aspire can be installed as a command shim such as aspire.cmd.
+           dotnet run starts RunCommand directly, so use cmd /C for the default PATH
+           lookup to get the same PATHEXT resolution as an interactive shell. -->
+      <RunCommand Condition="'$(AspireCliPath)' == '' and '$(OS)' == 'Windows_NT'">cmd</RunCommand>
+      <RunCommand Condition="'$(AspireCliPath)' == '' and '$(OS)' != 'Windows_NT'">aspire</RunCommand>
       <!-- dotnet run appends application arguments after ComputeRunArguments, so the double-dash separator
            must be present even when RunArguments is initially empty. -->
       <RunArguments>run --project "$(MSBuildProjectFullPath)" --no-build --</RunArguments>
+      <RunArguments Condition="'$(AspireCliPath)' == '' and '$(OS)' == 'Windows_NT'">/C aspire $(RunArguments)</RunArguments>
       <RunArguments Condition="'$(_AspireOriginalRunArguments)' != ''">$(RunArguments) $(_AspireOriginalRunArguments)</RunArguments>
       <RunWorkingDirectory>$(MSBuildProjectDirectory)</RunWorkingDirectory>
     </PropertyGroup>

--- a/src/Shared/KnownConfigNames.cs
+++ b/src/Shared/KnownConfigNames.cs
@@ -36,6 +36,7 @@ internal static class KnownConfigNames
     public const string CliLogFilePath = "ASPIRE_CLI_LOG_FILE";
     public const string CliRunDetached = "ASPIRE_CLI_RUN_DETACHED";
     public const string CliGenerateHttpsCertificate = "ASPIRE_CLI_GENERATE_HTTPS_CERTIFICATE";
+    public const string SuppressCliRunHook = "ASPIRE_SUPPRESS_CLI_RUN_HOOK";
     public const string IntegrationLibsPath = "ASPIRE_INTEGRATION_LIBS_PATH";
     public const string IntegrationProbeManifestPath = "ASPIRE_INTEGRATION_PROBE_MANIFEST_PATH";
     public const string ForceRichConsole = "ASPIRE_FORCE_RICH_CONSOLE";

--- a/tests/Aspire.Cli.EndToEnd.Tests/BundleSmokeTests.cs
+++ b/tests/Aspire.Cli.EndToEnd.Tests/BundleSmokeTests.cs
@@ -110,4 +110,67 @@ public sealed class BundleSmokeTests(ITestOutputHelper output)
         Assert.True(File.Exists(argsOutputPath), $"Expected AppHost to write forwarded args to: {argsOutputPath}");
         Assert.Equal("--from-dotnet-run", File.ReadAllText(argsOutputPath));
     }
+
+    [CaptureWorkspaceOnFailure]
+    [Fact]
+    public async Task DotNetRunFileBasedAppHostUsesAspireCliBundle()
+    {
+        var repoRoot = CliE2ETestHelpers.GetRepoRoot();
+        var strategy = CliInstallStrategy.Detect(output.WriteLine);
+        var projectName = "DotNetRunFileBundleApp";
+
+        var workspace = TemporaryWorkspace.Create(output);
+
+        using var terminal = CliE2ETestHelpers.CreateDockerTestTerminal(repoRoot, strategy, output, workspace: workspace);
+
+        var counter = new SequenceCounter();
+        var auto = new Hex1bTerminalAutomator(terminal, defaultTimeout: TimeSpan.FromSeconds(500));
+        await using var terminalRun = CliE2ETestHelpers.StartRun(terminal, workspace, auto, counter, output, TestContext.Current.CancellationToken);
+
+        await auto.PrepareDockerEnvironmentAsync(counter, workspace);
+        await auto.InstallAspireCliAsync(strategy, counter);
+
+        await auto.AspireNewCSharpEmptyAppHostAsync(projectName, counter);
+
+        var projectRoot = Path.Combine(workspace.WorkspaceRoot.FullName, projectName);
+        var appHostSourcePath = Path.Combine(projectRoot, "apphost.cs");
+        var argsOutputPath = Path.Combine(projectRoot, "apphost-file-args.txt");
+        var containerArgsOutputPath = CliE2ETestHelpers.ToContainerPath(argsOutputPath, workspace);
+
+        Assert.True(File.Exists(appHostSourcePath), $"Expected AppHost source file to exist at: {appHostSourcePath}");
+
+        var appHostSource = File.ReadAllText(appHostSourcePath);
+        Assert.Contains("#:sdk Aspire.AppHost.Sdk", appHostSource);
+        Assert.Contains("var builder = DistributedApplication.CreateBuilder(args);", appHostSource);
+
+        var firstLineEnd = appHostSource.IndexOf('\n', StringComparison.Ordinal);
+        Assert.True(firstLineEnd >= 0, $"Expected file-based AppHost source to contain a newline: {appHostSourcePath}");
+        appHostSource = appHostSource.Insert(firstLineEnd + 1, "#:property AspireUseCliBundle=true\n");
+
+        File.WriteAllText(
+            appHostSourcePath,
+            appHostSource.Replace(
+                "var builder = DistributedApplication.CreateBuilder(args);",
+                $$"""
+                File.WriteAllText({{JsonSerializer.Serialize(containerArgsOutputPath)}}, string.Join("|", args));
+
+                var builder = DistributedApplication.CreateBuilder(args);
+                """));
+
+        await auto.RunCommandAsync($"cd {AspireCliShellCommandHelpers.QuoteBashArg(projectName)}", counter);
+
+        await auto.TypeAsync("dotnet run --file apphost.cs -- --from-dotnet-run-file");
+        await auto.EnterAsync();
+
+        await auto.WaitUntilAsync(
+            s => s.ContainsText("Press CTRL+C to stop the AppHost and exit."),
+            timeout: TimeSpan.FromMinutes(2),
+            description: "Press CTRL+C message from aspire run");
+
+        await auto.Ctrl().KeyAsync(Hex1bKey.C);
+        await auto.WaitForSuccessPromptAsync(counter);
+
+        Assert.True(File.Exists(argsOutputPath), $"Expected AppHost to write forwarded args to: {argsOutputPath}");
+        Assert.Equal("--from-dotnet-run-file", File.ReadAllText(argsOutputPath));
+    }
 }

--- a/tests/Aspire.Cli.EndToEnd.Tests/BundleSmokeTests.cs
+++ b/tests/Aspire.Cli.EndToEnd.Tests/BundleSmokeTests.cs
@@ -1,9 +1,11 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Text.Json;
 using Aspire.Cli.EndToEnd.Tests.Helpers;
 using Aspire.Cli.Tests.Utils;
 using Hex1b.Automation;
+using Hex1b.Input;
 using Xunit;
 
 namespace Aspire.Cli.EndToEnd.Tests;
@@ -37,5 +39,75 @@ public sealed class BundleSmokeTests(ITestOutputHelper output)
 
         await auto.AspireStartAsync(counter);
         await auto.AspireStopAsync(counter);
+    }
+
+    [CaptureWorkspaceOnFailure]
+    [Fact]
+    public async Task DotNetRunProjectAppHostUsesAspireCliBundle()
+    {
+        var repoRoot = CliE2ETestHelpers.GetRepoRoot();
+        var strategy = CliInstallStrategy.Detect(output.WriteLine);
+        var projectName = "DotNetRunBundleApp";
+
+        var workspace = TemporaryWorkspace.Create(output);
+
+        using var terminal = CliE2ETestHelpers.CreateDockerTestTerminal(repoRoot, strategy, output, workspace: workspace);
+
+        var counter = new SequenceCounter();
+        var auto = new Hex1bTerminalAutomator(terminal, defaultTimeout: TimeSpan.FromSeconds(500));
+        await using var terminalRun = CliE2ETestHelpers.StartRun(terminal, workspace, auto, counter, output, TestContext.Current.CancellationToken);
+
+        await auto.PrepareDockerEnvironmentAsync(counter, workspace);
+        await auto.InstallAspireCliAsync(strategy, counter);
+
+        await auto.AspireNewAsync(projectName, counter, useRedisCache: false);
+
+        var projectRoot = Path.Combine(workspace.WorkspaceRoot.FullName, projectName);
+        var appHostDirectory = Path.Combine(projectRoot, $"{projectName}.AppHost");
+        var appHostProjectPath = Path.Combine(appHostDirectory, $"{projectName}.AppHost.csproj");
+        var appHostSourcePath = Path.Combine(appHostDirectory, "AppHost.cs");
+        var argsOutputPath = Path.Combine(projectRoot, "apphost-args.txt");
+        var containerArgsOutputPath = CliE2ETestHelpers.ToContainerPath(argsOutputPath, workspace);
+
+        Assert.True(File.Exists(appHostProjectPath), $"Expected AppHost project file to exist at: {appHostProjectPath}");
+        Assert.True(File.Exists(appHostSourcePath), $"Expected AppHost source file to exist at: {appHostSourcePath}");
+
+        var appHostProject = File.ReadAllText(appHostProjectPath);
+        Assert.Contains("<Nullable>enable</Nullable>", appHostProject);
+        File.WriteAllText(
+            appHostProjectPath,
+            appHostProject.Replace(
+                "<Nullable>enable</Nullable>",
+                """
+                    <Nullable>enable</Nullable>
+                    <AspireUseCliBundle>true</AspireUseCliBundle>
+                """));
+
+        File.WriteAllText(
+            appHostSourcePath,
+            $$"""
+            File.WriteAllText({{JsonSerializer.Serialize(containerArgsOutputPath)}}, string.Join("|", args));
+
+            var builder = DistributedApplication.CreateBuilder(args);
+
+            builder.Build().Run();
+            """);
+
+        var appHostProjectRelativePath = Path.GetRelativePath(workspace.WorkspaceRoot.FullName, appHostProjectPath);
+        var quotedAppHostProjectPath = AspireCliShellCommandHelpers.QuoteBashArg(appHostProjectRelativePath);
+
+        await auto.TypeAsync($"dotnet run --no-launch-profile --project {quotedAppHostProjectPath} -- --from-dotnet-run");
+        await auto.EnterAsync();
+
+        await auto.WaitUntilAsync(
+            s => s.ContainsText("Press CTRL+C to stop the AppHost and exit."),
+            timeout: TimeSpan.FromMinutes(2),
+            description: "Press CTRL+C message from aspire run");
+
+        await auto.Ctrl().KeyAsync(Hex1bKey.C);
+        await auto.WaitForSuccessPromptAsync(counter);
+
+        Assert.True(File.Exists(argsOutputPath), $"Expected AppHost to write forwarded args to: {argsOutputPath}");
+        Assert.Equal("--from-dotnet-run", File.ReadAllText(argsOutputPath));
     }
 }

--- a/tests/Aspire.Cli.EndToEnd.Tests/BundleSmokeTests.cs
+++ b/tests/Aspire.Cli.EndToEnd.Tests/BundleSmokeTests.cs
@@ -159,7 +159,7 @@ public sealed class BundleSmokeTests(ITestOutputHelper output)
 
         await auto.RunCommandAsync($"cd {AspireCliShellCommandHelpers.QuoteBashArg(projectName)}", counter);
 
-        await auto.TypeAsync("dotnet run --file apphost.cs -- --from-dotnet-run-file");
+        await auto.TypeAsync("dotnet run apphost.cs -- --from-dotnet-run-file");
         await auto.EnterAsync();
 
         await auto.WaitUntilAsync(

--- a/tests/Aspire.Cli.Tests/Commands/RunCommandTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/RunCommandTests.cs
@@ -234,12 +234,9 @@ public class RunCommandTests(ITestOutputHelper outputHelper)
         var command = provider.GetRequiredService<RootCommand>();
         var result = command.Parse("run");
 
-        var stopwatch = Stopwatch.StartNew();
         var exitCode = await result.InvokeAsync().DefaultTimeout();
-        stopwatch.Stop();
 
         Assert.Equal(CliExitCodes.FailedToDotnetRunAppHost, exitCode);
-        Assert.True(stopwatch.Elapsed < TimeSpan.FromSeconds(1), $"Expected startup timeout to use the remaining budget, but the command took {stopwatch.Elapsed}.");
         Assert.Contains(
             string.Format(CultureInfo.CurrentCulture, RunCommandStrings.TimeoutWaitingForAppHost, 2, CliConfigNames.AppHostStartupTimeout),
             interactionService.DisplayedErrors);

--- a/tests/Aspire.Cli.Tests/DotNet/DotNetCliRunnerTests.cs
+++ b/tests/Aspire.Cli.Tests/DotNet/DotNetCliRunnerTests.cs
@@ -1381,6 +1381,80 @@ public class DotNetCliRunnerTests(ITestOutputHelper outputHelper)
     }
 
     [Fact]
+    public async Task RunAsyncSuppressesCliRunHookForProjectAppHost()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        var projectFile = new FileInfo(Path.Combine(workspace.WorkspaceRoot.FullName, "AppHost.csproj"));
+        await File.WriteAllTextAsync(projectFile.FullName, "Not a real project file.");
+
+        var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper);
+        using var provider = services.BuildServiceProvider();
+
+        Dictionary<string, string>? capturedEnv = null;
+        var executionContext = CreateExecutionContext(workspace.WorkspaceRoot);
+        var runner = DotNetCliRunnerTestHelper.Create(
+            provider,
+            executionContext,
+            (_, env, _, _) =>
+            {
+                capturedEnv = env?.ToDictionary();
+            },
+            0);
+
+        var exitCode = await runner.RunAsync(
+            projectFile: projectFile,
+            watch: false,
+            noBuild: false,
+            noRestore: false,
+            args: [],
+            env: new Dictionary<string, string>(),
+            null,
+            new ProcessInvocationOptions(),
+            CancellationToken.None).DefaultTimeout();
+
+        Assert.Equal(0, exitCode);
+        Assert.NotNull(capturedEnv);
+        Assert.Equal("true", capturedEnv[KnownConfigNames.SuppressCliRunHook]);
+    }
+
+    [Fact]
+    public async Task RunAsyncDoesNotSuppressCliRunHookForSingleFileAppHost()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        var appHostFile = new FileInfo(Path.Combine(workspace.WorkspaceRoot.FullName, "apphost.cs"));
+        await File.WriteAllTextAsync(appHostFile.FullName, "// Single-file AppHost");
+
+        var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper);
+        using var provider = services.BuildServiceProvider();
+
+        Dictionary<string, string>? capturedEnv = null;
+        var executionContext = CreateExecutionContext(workspace.WorkspaceRoot);
+        var runner = DotNetCliRunnerTestHelper.Create(
+            provider,
+            executionContext,
+            (_, env, _, _) =>
+            {
+                capturedEnv = env?.ToDictionary();
+            },
+            0);
+
+        var exitCode = await runner.RunAsync(
+            projectFile: appHostFile,
+            watch: false,
+            noBuild: false,
+            noRestore: false,
+            args: [],
+            env: new Dictionary<string, string>(),
+            null,
+            new ProcessInvocationOptions(),
+            CancellationToken.None).DefaultTimeout();
+
+        Assert.Equal(0, exitCode);
+        Assert.NotNull(capturedEnv);
+        Assert.DoesNotContain(KnownConfigNames.SuppressCliRunHook, capturedEnv.Keys);
+    }
+
+    [Fact]
     public async Task RunAsyncFiltersOutEmptyAndWhitespaceArguments()
     {
         using var workspace = TemporaryWorkspace.Create(outputHelper);
@@ -1608,6 +1682,41 @@ public class DotNetCliRunnerTests(ITestOutputHelper outputHelper)
             options,
             CancellationToken.None
         );
+    }
+
+    [Fact]
+    public async Task GetProjectItemsAndPropertiesAsyncSuppressesCliRunHook()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        var projectFile = new FileInfo(Path.Combine(workspace.WorkspaceRoot.FullName, "AppHost.csproj"));
+        await File.WriteAllTextAsync(projectFile.FullName, "Not a real project file.");
+
+        var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper);
+        using var provider = services.BuildServiceProvider();
+
+        Dictionary<string, string>? capturedEnv = null;
+        var executionContext = CreateExecutionContext(workspace.WorkspaceRoot);
+        var runner = DotNetCliRunnerTestHelper.Create(
+            provider,
+            executionContext,
+            (_, env, _, invocationOptions) =>
+            {
+                capturedEnv = env?.ToDictionary();
+                invocationOptions.StandardOutputCallback?.Invoke("{\"Properties\":{\"MSBuildVersion\":\"17.0.0\",\"AspireHostingSDKVersion\":\"9.0.0\"},\"Items\":{\"PackageReference\":[]}}");
+            },
+            0);
+
+        await runner.GetProjectItemsAndPropertiesAsync(
+            projectFile,
+            ["PackageReference"],
+            ["AspireHostingSDKVersion"],
+            targets: [],
+            new ProcessInvocationOptions(),
+            CancellationToken.None
+        );
+
+        Assert.NotNull(capturedEnv);
+        Assert.Equal("true", capturedEnv[KnownConfigNames.SuppressCliRunHook]);
     }
 
     [Fact]

--- a/tests/Aspire.Cli.Tests/DotNet/DotNetCliRunnerTests.cs
+++ b/tests/Aspire.Cli.Tests/DotNet/DotNetCliRunnerTests.cs
@@ -1314,6 +1314,7 @@ public class DotNetCliRunnerTests(ITestOutputHelper outputHelper)
                 Assert.Collection(args,
                     arg => Assert.Equal("run", arg),
                     arg => Assert.Equal("--no-launch-profile", arg),
+                    arg => Assert.Equal($"/p:{KnownConfigNames.SuppressCliRunHook}=true", arg),
                     arg => Assert.Equal("--file", arg),
                     arg => Assert.Equal(appHostFile.FullName, arg),
                     arg => Assert.Equal("--", arg)
@@ -1359,6 +1360,7 @@ public class DotNetCliRunnerTests(ITestOutputHelper outputHelper)
                 // For single-file .cs files, should NOT include --no-launch-profile when false
                 Assert.Collection(args,
                     arg => Assert.Equal("run", arg),
+                    arg => Assert.Equal($"/p:{KnownConfigNames.SuppressCliRunHook}=true", arg),
                     arg => Assert.Equal("--file", arg),
                     arg => Assert.Equal(appHostFile.FullName, arg),
                     arg => Assert.Equal("--", arg)
@@ -1418,7 +1420,7 @@ public class DotNetCliRunnerTests(ITestOutputHelper outputHelper)
     }
 
     [Fact]
-    public async Task RunAsyncDoesNotSuppressCliRunHookForSingleFileAppHost()
+    public async Task RunAsyncSuppressesCliRunHookForSingleFileAppHost()
     {
         using var workspace = TemporaryWorkspace.Create(outputHelper);
         var appHostFile = new FileInfo(Path.Combine(workspace.WorkspaceRoot.FullName, "apphost.cs"));
@@ -1451,7 +1453,48 @@ public class DotNetCliRunnerTests(ITestOutputHelper outputHelper)
 
         Assert.Equal(0, exitCode);
         Assert.NotNull(capturedEnv);
-        Assert.DoesNotContain(KnownConfigNames.SuppressCliRunHook, capturedEnv.Keys);
+        Assert.Equal("true", capturedEnv[KnownConfigNames.SuppressCliRunHook]);
+    }
+
+    [Fact]
+    public async Task RunAsyncDoesNotIncludeNoBuildFlagForSingleFileAppHostWhenNoBuildIsTrue()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        var appHostFile = new FileInfo(Path.Combine(workspace.WorkspaceRoot.FullName, "apphost.cs"));
+        await File.WriteAllTextAsync(appHostFile.FullName, "// Single-file AppHost");
+
+        var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper);
+        using var provider = services.BuildServiceProvider();
+
+        var executionContext = CreateExecutionContext(workspace.WorkspaceRoot);
+        var runner = DotNetCliRunnerTestHelper.Create(
+            provider,
+            executionContext,
+            (args, _, _, _) =>
+            {
+                Assert.Collection(args,
+                    arg => Assert.Equal("run", arg),
+                    arg => Assert.Equal($"/p:{KnownConfigNames.SuppressCliRunHook}=true", arg),
+                    arg => Assert.Equal("--file", arg),
+                    arg => Assert.Equal(appHostFile.FullName, arg),
+                    arg => Assert.Equal("--", arg)
+                );
+                Assert.DoesNotContain("--no-build", args);
+            },
+            0);
+
+        var exitCode = await runner.RunAsync(
+            projectFile: appHostFile,
+            watch: false,
+            noBuild: true,
+            noRestore: false,
+            args: [],
+            env: new Dictionary<string, string>(),
+            null,
+            new ProcessInvocationOptions(),
+            CancellationToken.None).DefaultTimeout();
+
+        Assert.Equal(0, exitCode);
     }
 
     [Fact]
@@ -1529,6 +1572,7 @@ public class DotNetCliRunnerTests(ITestOutputHelper outputHelper)
                 // Ensure the correct arguments are present
                 Assert.Collection(args,
                     arg => Assert.Equal("run", arg),
+                    arg => Assert.Equal($"/p:{KnownConfigNames.SuppressCliRunHook}=true", arg),
                     arg => Assert.Equal("--file", arg),
                     arg => Assert.Equal(appHostFile.FullName, arg),
                     arg => Assert.Equal("--", arg)

--- a/tests/Aspire.Hosting.Sdk.Tests/AppHostSdkTargetsTests.cs
+++ b/tests/Aspire.Hosting.Sdk.Tests/AppHostSdkTargetsTests.cs
@@ -64,8 +64,8 @@ public class AppHostSdkTargetsTests
 
         var properties = await GetComputeRunArgumentsPropertiesAsync(project, ["-p:RunArguments=--custom foo"]);
 
-        Assert.Equal("aspire", properties["RunCommand"]);
-        Assert.Equal($"run --project \"{project.ProjectFile}\" --no-build -- --custom foo", properties["RunArguments"]);
+        Assert.Equal(GetExpectedAspireRunCommand(), properties["RunCommand"]);
+        Assert.Equal(GetExpectedAspireRunArguments(project, "--custom foo"), properties["RunArguments"]);
         Assert.Equal(project.ProjectDirectory, properties["RunWorkingDirectory"]);
     }
 
@@ -90,8 +90,8 @@ public class AppHostSdkTargetsTests
 
         var properties = await GetComputeRunArgumentsPropertiesAsync(project);
 
-        Assert.NotEqual("aspire", properties["RunCommand"]);
-        Assert.NotEqual($"run --project \"{project.ProjectFile}\" --no-build --", properties["RunArguments"]);
+        Assert.NotEqual(GetExpectedAspireRunCommand(), properties["RunCommand"]);
+        Assert.NotEqual(GetExpectedAspireRunArguments(project), properties["RunArguments"]);
     }
 
     [Theory]
@@ -111,8 +111,8 @@ public class AppHostSdkTargetsTests
 
         var properties = await GetComputeRunArgumentsPropertiesAsync(project, extraArguments, environment);
 
-        Assert.NotEqual("aspire", properties["RunCommand"]);
-        Assert.NotEqual($"run --project \"{project.ProjectFile}\" --no-build --", properties["RunArguments"]);
+        Assert.NotEqual(GetExpectedAspireRunCommand(), properties["RunCommand"]);
+        Assert.NotEqual(GetExpectedAspireRunArguments(project), properties["RunArguments"]);
     }
 
     [Fact]
@@ -270,15 +270,12 @@ public class AppHostSdkTargetsTests
         {
             await File.WriteAllTextAsync(Path.Combine(fakeCliDirectory, "aspire.cmd"), """
                 @echo off
-                > "%ASPIRE_TEST_CAPTURE_PATH%" (
+                type nul > "%ASPIRE_TEST_CAPTURE_PATH%"
                 :loop
-                if "%~1"=="" goto done
-                echo %~1
+                if "%~1"=="" exit /b 0
+                >> "%ASPIRE_TEST_CAPTURE_PATH%" echo %~1
                 shift
                 goto loop
-                :done
-                )
-                exit /b 0
                 """);
 
             return;
@@ -326,6 +323,16 @@ public class AppHostSdkTargetsTests
         Assert.True(equalsIndex > prefix.Length, $"Package reference '{packageReference}' did not contain a RID.");
 
         return packageReference[prefix.Length..equalsIndex];
+    }
+
+    private static string GetExpectedAspireRunCommand() => OperatingSystem.IsWindows() ? "cmd" : "aspire";
+
+    private static string GetExpectedAspireRunArguments(RunHookProject project, string? extraArguments = null)
+    {
+        var prefix = OperatingSystem.IsWindows() ? "/C aspire " : string.Empty;
+        var arguments = $"{prefix}run --project \"{project.ProjectFile}\" --no-build --";
+
+        return string.IsNullOrEmpty(extraArguments) ? arguments : $"{arguments} {extraArguments}";
     }
 
     private static string GetPathEnvironmentVariableName() => OperatingSystem.IsWindows() ? "Path" : "PATH";

--- a/tests/Aspire.Hosting.Sdk.Tests/AppHostSdkTargetsTests.cs
+++ b/tests/Aspire.Hosting.Sdk.Tests/AppHostSdkTargetsTests.cs
@@ -130,18 +130,20 @@ public class AppHostSdkTargetsTests
     }
 
     [Theory]
-    [InlineData(SuppressCliRunHookEnvironmentVariable)]
-    [InlineData("_AspireSuppressCliRunHook")]
-    public async Task ComputeRunArgumentsDoesNotUseAspireCliWhenHookIsSuppressed(string suppressionPropertyName)
+    [InlineData(SuppressCliRunHookEnvironmentVariable, "true")]
+    [InlineData(SuppressCliRunHookEnvironmentVariable, "1")]
+    [InlineData("_AspireSuppressCliRunHook", "true")]
+    [InlineData("_AspireSuppressCliRunHook", "1")]
+    public async Task ComputeRunArgumentsDoesNotUseAspireCliWhenHookIsSuppressed(string suppressionPropertyName, string suppressionValue)
     {
         using var tempDirectory = new TestTempDirectory();
         var project = await CreateRunHookProjectAsync(tempDirectory.Path, aspireUseCliBundle: true);
 
         Dictionary<string, string>? environment = suppressionPropertyName == SuppressCliRunHookEnvironmentVariable
-            ? new Dictionary<string, string> { [SuppressCliRunHookEnvironmentVariable] = "true" }
+            ? new Dictionary<string, string> { [SuppressCliRunHookEnvironmentVariable] = suppressionValue }
             : null;
         var extraArguments = suppressionPropertyName == "_AspireSuppressCliRunHook"
-            ? new[] { "-p:_AspireSuppressCliRunHook=true" }
+            ? new[] { $"-p:_AspireSuppressCliRunHook={suppressionValue}" }
             : [];
 
         var properties = await GetComputeRunArgumentsPropertiesAsync(project, extraArguments, environment);

--- a/tests/Aspire.Hosting.Sdk.Tests/AppHostSdkTargetsTests.cs
+++ b/tests/Aspire.Hosting.Sdk.Tests/AppHostSdkTargetsTests.cs
@@ -4,12 +4,15 @@
 using System.Diagnostics;
 using System.Reflection;
 using System.Security;
+using System.Text.Json;
 using Xunit;
 
 namespace Aspire.Hosting.Sdk.Tests;
 
 public class AppHostSdkTargetsTests
 {
+    private const string SuppressCliRunHookEnvironmentVariable = "ASPIRE_SUPPRESS_CLI_RUN_HOOK";
+
     private static readonly string[] s_supportedRids =
     [
         "win-x64",
@@ -51,6 +54,99 @@ public class AppHostSdkTargetsTests
         Assert.Contains("UseSdkPickBestRid=false", packageReferences);
         Assert.Contains("RunRidToolFallback=true", packageReferences);
         AssertDashboardAndOrchestrationReferences(packageReferences);
+    }
+
+    [Fact]
+    public async Task ComputeRunArgumentsUsesAspireCliWhenCliBundleIsEnabled()
+    {
+        using var tempDirectory = new TestTempDirectory();
+        var project = await CreateRunHookProjectAsync(tempDirectory.Path, aspireUseCliBundle: true);
+
+        var properties = await GetComputeRunArgumentsPropertiesAsync(project, ["-p:RunArguments=--custom foo"]);
+
+        Assert.Equal("aspire", properties["RunCommand"]);
+        Assert.Equal($"run --project \"{project.ProjectFile}\" --no-build -- --custom foo", properties["RunArguments"]);
+        Assert.Equal(project.ProjectDirectory, properties["RunWorkingDirectory"]);
+    }
+
+    [Fact]
+    public async Task ComputeRunArgumentsUsesConfiguredAspireCliPathWhenCliBundleIsEnabled()
+    {
+        using var tempDirectory = new TestTempDirectory();
+        var project = await CreateRunHookProjectAsync(tempDirectory.Path, aspireUseCliBundle: true);
+        var aspireCliPath = Path.Combine(tempDirectory.Path, "custom-aspire");
+
+        var properties = await GetComputeRunArgumentsPropertiesAsync(project, [$"-p:AspireCliPath={aspireCliPath}"]);
+
+        Assert.Equal(aspireCliPath, properties["RunCommand"]);
+        Assert.Equal($"run --project \"{project.ProjectFile}\" --no-build --", properties["RunArguments"]);
+    }
+
+    [Fact]
+    public async Task ComputeRunArgumentsDoesNotUseAspireCliWhenCliBundleIsDisabled()
+    {
+        using var tempDirectory = new TestTempDirectory();
+        var project = await CreateRunHookProjectAsync(tempDirectory.Path, aspireUseCliBundle: false);
+
+        var properties = await GetComputeRunArgumentsPropertiesAsync(project);
+
+        Assert.NotEqual("aspire", properties["RunCommand"]);
+        Assert.NotEqual($"run --project \"{project.ProjectFile}\" --no-build --", properties["RunArguments"]);
+    }
+
+    [Theory]
+    [InlineData(SuppressCliRunHookEnvironmentVariable)]
+    [InlineData("_AspireSuppressCliRunHook")]
+    public async Task ComputeRunArgumentsDoesNotUseAspireCliWhenHookIsSuppressed(string suppressionPropertyName)
+    {
+        using var tempDirectory = new TestTempDirectory();
+        var project = await CreateRunHookProjectAsync(tempDirectory.Path, aspireUseCliBundle: true);
+
+        Dictionary<string, string>? environment = suppressionPropertyName == SuppressCliRunHookEnvironmentVariable
+            ? new Dictionary<string, string> { [SuppressCliRunHookEnvironmentVariable] = "true" }
+            : null;
+        var extraArguments = suppressionPropertyName == "_AspireSuppressCliRunHook"
+            ? new[] { "-p:_AspireSuppressCliRunHook=true" }
+            : [];
+
+        var properties = await GetComputeRunArgumentsPropertiesAsync(project, extraArguments, environment);
+
+        Assert.NotEqual("aspire", properties["RunCommand"]);
+        Assert.NotEqual($"run --project \"{project.ProjectFile}\" --no-build --", properties["RunArguments"]);
+    }
+
+    [Fact]
+    public async Task DotNetRunUsesAspireCliWhenCliBundleIsEnabled()
+    {
+        using var tempDirectory = new TestTempDirectory();
+        var project = await CreateRunHookProjectAsync(tempDirectory.Path, aspireUseCliBundle: true);
+        var fakeCliDirectory = Directory.CreateDirectory(Path.Combine(tempDirectory.Path, "fake-cli"));
+        var captureFile = Path.Combine(tempDirectory.Path, "aspire-args.txt");
+        await CreateFakeAspireCliAsync(fakeCliDirectory.FullName);
+
+        var environment = new Dictionary<string, string>
+        {
+            ["ASPIRE_TEST_CAPTURE_PATH"] = captureFile,
+            ["PATH"] = $"{fakeCliDirectory.FullName}{Path.PathSeparator}{Environment.GetEnvironmentVariable("PATH")}"
+        };
+
+        var result = await RunDotNetWithArgumentsAsync(
+            project.ProjectDirectory,
+            ["run", "--project", project.ProjectFile, "--", "--custom", "foo"],
+            environment);
+
+        Assert.True(result.ExitCode == 0, result.Output);
+        Assert.Equal(
+            [
+                "run",
+                "--project",
+                project.ProjectFile,
+                "--no-build",
+                "--",
+                "--custom",
+                "foo"
+            ],
+            await File.ReadAllLinesAsync(captureFile));
     }
 
     private static async Task<string[]> RunAddReferenceToDashboardAndDcpAsync(string? extraProjectXml)
@@ -95,6 +191,104 @@ public class AppHostSdkTargetsTests
         Assert.True(result.ExitCode == 0, result.Output);
 
         return await File.ReadAllLinesAsync(packageReferencesPath);
+    }
+
+    private static async Task<RunHookProject> CreateRunHookProjectAsync(string tempDirectory, bool aspireUseCliBundle)
+    {
+        var repoRoot = GetRepoRoot();
+        var projectDirectory = Path.Combine(tempDirectory, "AppHost");
+        Directory.CreateDirectory(projectDirectory);
+
+        var appHostTargetsPath = SecurityElement.Escape(Path.Combine(repoRoot, "src", "Aspire.Hosting.AppHost", "build", "Aspire.Hosting.AppHost.in.targets"));
+        var projectFile = Path.Combine(projectDirectory, "AppHost.csproj");
+
+        await File.WriteAllTextAsync(projectFile,
+            $$"""
+            <Project Sdk="Microsoft.NET.Sdk">
+
+              <PropertyGroup>
+                <OutputType>Exe</OutputType>
+                <TargetFramework>net8.0</TargetFramework>
+                <IsAspireHost>true</IsAspireHost>
+                <AspireHostingSDKVersion>9.0.0</AspireHostingSDKVersion>
+                <AspireUseCliBundle>{{aspireUseCliBundle.ToString().ToLowerInvariant()}}</AspireUseCliBundle>
+                <AspireDashboardPath>$(MSBuildProjectDirectory)/Aspire.Dashboard.dll</AspireDashboardPath>
+                <DcpDir>$(MSBuildProjectDirectory)</DcpDir>
+                <SkipAspireWorkloadManifest>true</SkipAspireWorkloadManifest>
+                <SkipValidateAspireHostProjectResources>true</SkipValidateAspireHostProjectResources>
+              </PropertyGroup>
+
+              <Import Project="{{appHostTargetsPath}}" />
+
+            </Project>
+            """);
+
+        await File.WriteAllTextAsync(Path.Combine(projectDirectory, "Program.cs"), """
+            System.Console.WriteLine("AppHost should be launched by the Aspire CLI.");
+            """);
+
+        return new RunHookProject(projectDirectory, projectFile);
+    }
+
+    private static async Task<Dictionary<string, string>> GetComputeRunArgumentsPropertiesAsync(
+        RunHookProject project,
+        string[]? extraArguments = null,
+        IDictionary<string, string>? environment = null)
+    {
+        var arguments = new List<string>
+        {
+            "msbuild",
+            "-nologo",
+            "-restore",
+            "-t:ComputeRunArguments",
+            "-getProperty:RunCommand,RunArguments,RunWorkingDirectory",
+            project.ProjectFile
+        };
+
+        if (extraArguments is not null)
+        {
+            arguments.AddRange(extraArguments);
+        }
+
+        var result = await RunDotNetWithArgumentsAsync(project.ProjectDirectory, [.. arguments], environment);
+        Assert.True(result.ExitCode == 0, result.Output);
+
+        var jsonStart = result.StandardOutput.IndexOf('{');
+        var jsonEnd = result.StandardOutput.LastIndexOf('}');
+        Assert.True(jsonStart >= 0 && jsonEnd > jsonStart, result.Output);
+
+        using var document = JsonDocument.Parse(result.StandardOutput[jsonStart..(jsonEnd + 1)]);
+        var properties = document.RootElement.GetProperty("Properties");
+
+        return properties.EnumerateObject().ToDictionary(property => property.Name, property => property.Value.GetString() ?? string.Empty);
+    }
+
+    private static async Task CreateFakeAspireCliAsync(string fakeCliDirectory)
+    {
+        if (OperatingSystem.IsWindows())
+        {
+            await File.WriteAllTextAsync(Path.Combine(fakeCliDirectory, "aspire.cmd"), """
+                @echo off
+                > "%ASPIRE_TEST_CAPTURE_PATH%" (
+                :loop
+                if "%~1"=="" goto done
+                echo %~1
+                shift
+                goto loop
+                :done
+                )
+                exit /b 0
+                """);
+
+            return;
+        }
+
+        var aspirePath = Path.Combine(fakeCliDirectory, "aspire");
+        await File.WriteAllTextAsync(aspirePath, """
+            #!/bin/sh
+            printf '%s\n' "$@" > "$ASPIRE_TEST_CAPTURE_PATH"
+            """);
+        File.SetUnixFileMode(aspirePath, UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.UserExecute);
     }
 
     private static void AssertDashboardAndOrchestrationReferences(string[] packageReferences)
@@ -167,6 +361,54 @@ public class AppHostSdkTargetsTests
         return (process.ExitCode, output + error);
     }
 
+    private static async Task<DotNetResult> RunDotNetWithArgumentsAsync(string workingDirectory, string[] arguments, IDictionary<string, string>? environment = null)
+    {
+        var startInfo = new ProcessStartInfo("dotnet")
+        {
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+            CreateNoWindow = true,
+            WorkingDirectory = workingDirectory
+        };
+
+        startInfo.Environment["MSBUILDTERMINALLOGGER"] = "false";
+
+        foreach (var argument in arguments)
+        {
+            startInfo.ArgumentList.Add(argument);
+        }
+
+        if (environment is not null)
+        {
+            foreach (var (key, value) in environment)
+            {
+                startInfo.Environment[key] = value;
+            }
+        }
+
+        using var process = Process.Start(startInfo);
+
+        Assert.NotNull(process);
+
+        var outputTask = process.StandardOutput.ReadToEndAsync();
+        var errorTask = process.StandardError.ReadToEndAsync();
+
+        using var cts = new CancellationTokenSource(TimeSpan.FromMinutes(3));
+
+        try
+        {
+            await process.WaitForExitAsync(cts.Token);
+        }
+        catch (OperationCanceledException)
+        {
+            process.Kill(entireProcessTree: true);
+            throw new TimeoutException($"dotnet {string.Join(' ', arguments)} timed out after 3 minutes.");
+        }
+
+        return new DotNetResult(process.ExitCode, await outputTask, await errorTask);
+    }
+
     private static string GetRepoRoot()
     {
         var directory = AppContext.BaseDirectory;
@@ -177,5 +419,12 @@ public class AppHostSdkTargetsTests
         }
 
         return directory ?? throw new InvalidOperationException("Could not find repository root.");
+    }
+
+    private sealed record RunHookProject(string ProjectDirectory, string ProjectFile);
+
+    private sealed record DotNetResult(int ExitCode, string StandardOutput, string StandardError)
+    {
+        public string Output => StandardOutput + StandardError;
     }
 }

--- a/tests/Aspire.Hosting.Sdk.Tests/AppHostSdkTargetsTests.cs
+++ b/tests/Aspire.Hosting.Sdk.Tests/AppHostSdkTargetsTests.cs
@@ -124,10 +124,11 @@ public class AppHostSdkTargetsTests
         var captureFile = Path.Combine(tempDirectory.Path, "aspire-args.txt");
         await CreateFakeAspireCliAsync(fakeCliDirectory.FullName);
 
+        var pathEnvironmentVariable = GetPathEnvironmentVariableName();
         var environment = new Dictionary<string, string>
         {
             ["ASPIRE_TEST_CAPTURE_PATH"] = captureFile,
-            ["PATH"] = $"{fakeCliDirectory.FullName}{Path.PathSeparator}{Environment.GetEnvironmentVariable("PATH")}"
+            [pathEnvironmentVariable] = $"{fakeCliDirectory.FullName}{Path.PathSeparator}{Environment.GetEnvironmentVariable(pathEnvironmentVariable)}"
         };
 
         var result = await RunDotNetWithArgumentsAsync(
@@ -326,6 +327,8 @@ public class AppHostSdkTargetsTests
 
         return packageReference[prefix.Length..equalsIndex];
     }
+
+    private static string GetPathEnvironmentVariableName() => OperatingSystem.IsWindows() ? "Path" : "PATH";
 
     private static async Task<(int ExitCode, string Output)> RunDotNetAsync(string workingDirectory, string arguments)
     {

--- a/tests/Aspire.Hosting.Sdk.Tests/AppHostSdkTargetsTests.cs
+++ b/tests/Aspire.Hosting.Sdk.Tests/AppHostSdkTargetsTests.cs
@@ -83,6 +83,41 @@ public class AppHostSdkTargetsTests
     }
 
     [Fact]
+    public async Task ComputeRunArgumentsUsesFileBasedAppHostPathWhenCliBundleIsEnabled()
+    {
+        using var tempDirectory = new TestTempDirectory();
+        var appHostDirectory = Path.Combine(tempDirectory.Path, "FileApp");
+        Directory.CreateDirectory(appHostDirectory);
+        var appHostFile = Path.Combine(appHostDirectory, "apphost.cs");
+        await File.WriteAllTextAsync(appHostFile, """
+            var builder = DistributedApplication.CreateBuilder(args);
+            builder.Build().Run();
+            """);
+
+        var extraProjectXml = $$"""
+              <PropertyGroup>
+                <FileBasedProgram>true</FileBasedProgram>
+              </PropertyGroup>
+
+              <ItemGroup>
+                <RuntimeHostConfigurationOption Include="EntryPointFileDirectoryPath">
+                  <Value>{{SecurityElement.Escape(appHostDirectory)}}</Value>
+                </RuntimeHostConfigurationOption>
+                <RuntimeHostConfigurationOption Include="EntryPointFilePath">
+                  <Value>{{SecurityElement.Escape(appHostFile)}}</Value>
+                </RuntimeHostConfigurationOption>
+              </ItemGroup>
+            """;
+        var project = await CreateRunHookProjectAsync(tempDirectory.Path, aspireUseCliBundle: true, extraProjectXml: extraProjectXml);
+
+        var properties = await GetComputeRunArgumentsPropertiesAsync(project, ["-p:RunArguments=--custom foo"]);
+
+        Assert.Equal(GetExpectedAspireRunCommand(), properties["RunCommand"]);
+        Assert.Equal(GetExpectedAspireRunArguments(appHostFile, "--custom foo"), properties["RunArguments"]);
+        Assert.Equal(appHostDirectory, properties["RunWorkingDirectory"]);
+    }
+
+    [Fact]
     public async Task ComputeRunArgumentsDoesNotUseAspireCliWhenCliBundleIsDisabled()
     {
         using var tempDirectory = new TestTempDirectory();
@@ -194,7 +229,7 @@ public class AppHostSdkTargetsTests
         return await File.ReadAllLinesAsync(packageReferencesPath);
     }
 
-    private static async Task<RunHookProject> CreateRunHookProjectAsync(string tempDirectory, bool aspireUseCliBundle)
+    private static async Task<RunHookProject> CreateRunHookProjectAsync(string tempDirectory, bool aspireUseCliBundle, string? extraProjectXml = null)
     {
         var repoRoot = GetRepoRoot();
         var projectDirectory = Path.Combine(tempDirectory, "AppHost");
@@ -218,6 +253,8 @@ public class AppHostSdkTargetsTests
                 <SkipAspireWorkloadManifest>true</SkipAspireWorkloadManifest>
                 <SkipValidateAspireHostProjectResources>true</SkipValidateAspireHostProjectResources>
               </PropertyGroup>
+
+            {{extraProjectXml}}
 
               <Import Project="{{appHostTargetsPath}}" />
 
@@ -328,9 +365,12 @@ public class AppHostSdkTargetsTests
     private static string GetExpectedAspireRunCommand() => OperatingSystem.IsWindows() ? "cmd" : "aspire";
 
     private static string GetExpectedAspireRunArguments(RunHookProject project, string? extraArguments = null)
+        => GetExpectedAspireRunArguments(project.ProjectFile, extraArguments);
+
+    private static string GetExpectedAspireRunArguments(string projectPath, string? extraArguments = null)
     {
         var prefix = OperatingSystem.IsWindows() ? "/C aspire " : string.Empty;
-        var arguments = $"{prefix}run --project \"{project.ProjectFile}\" --no-build --";
+        var arguments = $"{prefix}run --project \"{projectPath}\" --no-build --";
 
         return string.IsNullOrEmpty(extraArguments) ? arguments : $"{arguments} {extraArguments}";
     }


### PR DESCRIPTION
## Description

~~dotnet run~~

aspire run

`dotnet run` for AppHosts should behave consistently with other Aspire bundle flows when `AspireUseCliBundle` is enabled. This change lets the AppHost SDK take over MSBuild's run command and route the invocation through `aspire run`, so bundled CLI behavior is used while still preserving app arguments.

The full control flow is `dotnet run` -> `aspire run` -> `dotnet run`: the outer user-facing `dotnet run` delegates to the Aspire CLI, and the Aspire CLI then starts the AppHost using `dotnet run` as usual. To avoid recursively re-entering the MSBuild run hook on that inner launch, the CLI sets `ASPIRE_SUPPRESS_CLI_RUN_HOOK` while it probes and runs AppHosts. File-based AppHosts also pass the suppression property to the inner `dotnet run` invocation so cached run arguments cannot bounce back to `aspire run`.

The SDK target computes `RunCommand` and `RunArguments` for `dotnet run` in bundle mode, appending original app arguments after `--`.

### User-facing usage

Project AppHosts with the bundle enabled can run through the Aspire CLI via `dotnet run`:

```bash
dotnet run --project MyApp.AppHost -- --from-dotnet-run
```

Internally this delegates to:

```bash
aspire run --project "MyApp.AppHost.csproj" --no-build -- --from-dotnet-run
```

Validation:

```bash
dotnet test --project tests/Aspire.Hosting.Sdk.Tests/Aspire.Hosting.Sdk.Tests.csproj --no-launch-profile -- --filter-class "*.AppHostSdkTargetsTests" --filter-not-trait "quarantined=true" --filter-not-trait "outerloop=true"
dotnet test --project tests/Aspire.Cli.Tests/Aspire.Cli.Tests.csproj --no-launch-profile -- --filter-class "*.DotNetCliRunnerTests" --filter-not-trait "quarantined=true" --filter-not-trait "outerloop=true"
ASPIRE_E2E_ARCHIVE=/tmp/aspire-e2e-dotnet-run.tar.gz dotnet test --project tests/Aspire.Cli.EndToEnd.Tests/Aspire.Cli.EndToEnd.Tests.csproj --no-build --no-launch-profile -- --filter-method "*.DotNetRunProjectAppHostUsesAspireCliBundle" --filter-not-trait "quarantined=true" --filter-not-trait "outerloop=true"
```

Fixes # (issue)

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
