### PR TITLE
Resolve cross-compute-environment endpoint references for Foundry hosted agents

### DIFF
--- a/src/Aspire.Hosting.Azure.AppContainers/Aspire.Hosting.Azure.AppContainers.csproj
+++ b/src/Aspire.Hosting.Azure.AppContainers/Aspire.Hosting.Azure.AppContainers.csproj
@@ -11,6 +11,7 @@
   <ItemGroup>
     <Compile Include="$(SharedDir)AzurePortalUrls.cs" Link="AzurePortalUrls.cs" />
     <Compile Include="$(SharedDir)BicepFormattingHelpers.cs" LinkBase="Shared\BicepFormattingHelpers.cs" />
+    <Compile Include="$(SharedDir)ComputeEnvironmentEndpointResolver.cs" LinkBase="Shared\ComputeEnvironmentEndpointResolver.cs" />
     <Compile Include="$(SharedDir)ContainerRegistryInfrastructure.cs" LinkBase="Shared\ContainerRegistryInfrastructure.cs" />
     <Compile Include="$(SharedDir)ResourceNameComparer.cs" LinkBase="Shared\ResourceNameComparer.cs" />
   </ItemGroup>

--- a/src/Aspire.Hosting.Azure.AppContainers/BaseContainerAppContext.cs
+++ b/src/Aspire.Hosting.Azure.AppContainers/BaseContainerAppContext.cs
@@ -226,7 +226,7 @@ internal abstract class BaseContainerAppContext(IResource resource, ContainerApp
             // environment (for example a Foundry hosted agent). In that case delegate to the owning
             // compute environment instead of looking it up in this environment's local endpoint map.
             if (ComputeEnvironmentEndpointResolver.TryGetCrossEnvironmentEndpointExpression(
-                ep.Property(EndpointProperty.Url), [_containerAppEnvironmentContext.Environment], out var crossExpr))
+                ep, [_containerAppEnvironmentContext.Environment], out var crossExpr))
             {
                 return ProcessValue(crossExpr, secretType, parent);
             }

--- a/src/Aspire.Hosting.Azure.AppContainers/BaseContainerAppContext.cs
+++ b/src/Aspire.Hosting.Azure.AppContainers/BaseContainerAppContext.cs
@@ -222,6 +222,15 @@ internal abstract class BaseContainerAppContext(IResource resource, ContainerApp
 
         if (value is EndpointReference ep)
         {
+            // The referenced endpoint may belong to a resource deployed to a different compute
+            // environment (for example a Foundry hosted agent). In that case delegate to the owning
+            // compute environment instead of looking it up in this environment's local endpoint map.
+            if (ComputeEnvironmentEndpointResolver.TryGetCrossEnvironmentEndpointExpression(
+                ep.Property(EndpointProperty.Url), out var crossExpr, _containerAppEnvironmentContext.Environment))
+            {
+                return ProcessValue(crossExpr, secretType, parent);
+            }
+
             var context = ep.Resource == resource
                 ? this
                 : _containerAppEnvironmentContext.GetContainerAppContext(ep.Resource);
@@ -274,6 +283,12 @@ internal abstract class BaseContainerAppContext(IResource resource, ContainerApp
 
         if (value is EndpointReferenceExpression epExpr)
         {
+            if (ComputeEnvironmentEndpointResolver.TryGetCrossEnvironmentEndpointExpression(
+                epExpr, out var crossExpr, _containerAppEnvironmentContext.Environment))
+            {
+                return ProcessValue(crossExpr, secretType, parent);
+            }
+
             var context = epExpr.Endpoint.Resource == resource
                 ? this
                 : _containerAppEnvironmentContext.GetContainerAppContext(epExpr.Endpoint.Resource);

--- a/src/Aspire.Hosting.Azure.AppContainers/BaseContainerAppContext.cs
+++ b/src/Aspire.Hosting.Azure.AppContainers/BaseContainerAppContext.cs
@@ -226,7 +226,7 @@ internal abstract class BaseContainerAppContext(IResource resource, ContainerApp
             // environment (for example a Foundry hosted agent). In that case delegate to the owning
             // compute environment instead of looking it up in this environment's local endpoint map.
             if (ComputeEnvironmentEndpointResolver.TryGetCrossEnvironmentEndpointExpression(
-                ep.Property(EndpointProperty.Url), out var crossExpr, _containerAppEnvironmentContext.Environment))
+                ep.Property(EndpointProperty.Url), [_containerAppEnvironmentContext.Environment], out var crossExpr))
             {
                 return ProcessValue(crossExpr, secretType, parent);
             }
@@ -284,7 +284,7 @@ internal abstract class BaseContainerAppContext(IResource resource, ContainerApp
         if (value is EndpointReferenceExpression epExpr)
         {
             if (ComputeEnvironmentEndpointResolver.TryGetCrossEnvironmentEndpointExpression(
-                epExpr, out var crossExpr, _containerAppEnvironmentContext.Environment))
+                epExpr, [_containerAppEnvironmentContext.Environment], out var crossExpr))
             {
                 return ProcessValue(crossExpr, secretType, parent);
             }

--- a/src/Aspire.Hosting.Azure.AppService/Aspire.Hosting.Azure.AppService.csproj
+++ b/src/Aspire.Hosting.Azure.AppService/Aspire.Hosting.Azure.AppService.csproj
@@ -13,6 +13,7 @@
   <ItemGroup>
     <Compile Include="$(SharedDir)AzurePortalUrls.cs" Link="AzurePortalUrls.cs" />
     <Compile Include="$(SharedDir)BicepFormattingHelpers.cs" LinkBase="Shared\BicepFormattingHelpers.cs" />
+    <Compile Include="$(SharedDir)ComputeEnvironmentEndpointResolver.cs" LinkBase="Shared\ComputeEnvironmentEndpointResolver.cs" />
     <Compile Include="$(SharedDir)ContainerRegistryInfrastructure.cs" LinkBase="Shared\ContainerRegistryInfrastructure.cs" />
     <Compile Include="$(SharedDir)DashboardConfigNames.cs" LinkBase="Shared\DashboardConfigNames.cs" />
     <Compile Include="$(SharedDir)KnownConfigNames.cs" LinkBase="Shared\KnownConfigNames.cs" />

--- a/src/Aspire.Hosting.Azure.AppService/AzureAppServiceWebsiteContext.cs
+++ b/src/Aspire.Hosting.Azure.AppService/AzureAppServiceWebsiteContext.cs
@@ -167,6 +167,15 @@ internal sealed class AzureAppServiceWebsiteContext(
 
         if (value is EndpointReference ep)
         {
+            // The referenced endpoint may belong to a resource deployed to a different compute
+            // environment (for example a Foundry hosted agent). In that case delegate to the owning
+            // compute environment instead of looking it up in this environment's local endpoint map.
+            if (ComputeEnvironmentEndpointResolver.TryGetCrossEnvironmentEndpointExpression(
+                ep.Property(EndpointProperty.Url), out var crossExpr, environmentContext.Environment))
+            {
+                return ProcessValue(crossExpr, secretType, parent, isSlot);
+            }
+
             var context = environmentContext.GetAppServiceContext(ep.Resource);
             return isSlot ?
                 (GetEndpointValue(context._slotEndpointMapping[ep.EndpointName], EndpointProperty.Url), secretType) :
@@ -206,6 +215,12 @@ internal sealed class AzureAppServiceWebsiteContext(
 
         if (value is EndpointReferenceExpression epExpr)
         {
+            if (ComputeEnvironmentEndpointResolver.TryGetCrossEnvironmentEndpointExpression(
+                epExpr, out var crossExpr, environmentContext.Environment))
+            {
+                return ProcessValue(crossExpr, secretType, parent, isSlot);
+            }
+
             var context = environmentContext.GetAppServiceContext(epExpr.Endpoint.Resource);
             var mapping = isSlot ? context._slotEndpointMapping[epExpr.Endpoint.EndpointName] : context._endpointMapping[epExpr.Endpoint.EndpointName];
             var val = GetEndpointValue(mapping, epExpr.Property);

--- a/src/Aspire.Hosting.Azure.AppService/AzureAppServiceWebsiteContext.cs
+++ b/src/Aspire.Hosting.Azure.AppService/AzureAppServiceWebsiteContext.cs
@@ -171,7 +171,7 @@ internal sealed class AzureAppServiceWebsiteContext(
             // environment (for example a Foundry hosted agent). In that case delegate to the owning
             // compute environment instead of looking it up in this environment's local endpoint map.
             if (ComputeEnvironmentEndpointResolver.TryGetCrossEnvironmentEndpointExpression(
-                ep.Property(EndpointProperty.Url), out var crossExpr, environmentContext.Environment))
+                ep.Property(EndpointProperty.Url), [environmentContext.Environment], out var crossExpr))
             {
                 return ProcessValue(crossExpr, secretType, parent, isSlot);
             }
@@ -216,7 +216,7 @@ internal sealed class AzureAppServiceWebsiteContext(
         if (value is EndpointReferenceExpression epExpr)
         {
             if (ComputeEnvironmentEndpointResolver.TryGetCrossEnvironmentEndpointExpression(
-                epExpr, out var crossExpr, environmentContext.Environment))
+                epExpr, [environmentContext.Environment], out var crossExpr))
             {
                 return ProcessValue(crossExpr, secretType, parent, isSlot);
             }

--- a/src/Aspire.Hosting.Azure.AppService/AzureAppServiceWebsiteContext.cs
+++ b/src/Aspire.Hosting.Azure.AppService/AzureAppServiceWebsiteContext.cs
@@ -171,7 +171,7 @@ internal sealed class AzureAppServiceWebsiteContext(
             // environment (for example a Foundry hosted agent). In that case delegate to the owning
             // compute environment instead of looking it up in this environment's local endpoint map.
             if (ComputeEnvironmentEndpointResolver.TryGetCrossEnvironmentEndpointExpression(
-                ep.Property(EndpointProperty.Url), [environmentContext.Environment], out var crossExpr))
+                ep, [environmentContext.Environment], out var crossExpr))
             {
                 return ProcessValue(crossExpr, secretType, parent, isSlot);
             }

--- a/src/Aspire.Hosting.Azure.FrontDoor/Aspire.Hosting.Azure.FrontDoor.csproj
+++ b/src/Aspire.Hosting.Azure.FrontDoor/Aspire.Hosting.Azure.FrontDoor.csproj
@@ -16,6 +16,10 @@
   </ItemGroup>
 
   <ItemGroup>
+    <Compile Include="$(SharedDir)ComputeEnvironmentEndpointResolver.cs" LinkBase="Shared\ComputeEnvironmentEndpointResolver.cs" />
+  </ItemGroup>
+
+  <ItemGroup>
     <InternalsVisibleTo Include="Aspire.Hosting.Azure.Tests" />
   </ItemGroup>
 

--- a/src/Aspire.Hosting.Azure.FrontDoor/AzureFrontDoorExtensions.cs
+++ b/src/Aspire.Hosting.Azure.FrontDoor/AzureFrontDoorExtensions.cs
@@ -201,14 +201,9 @@ public static class AzureFrontDoorExtensions
 
     private static IComputeEnvironmentResource GetEffectiveComputeEnvironment(IResource resource)
     {
-        if (resource.GetComputeEnvironment() is { } computeEnvironment)
+        if (ComputeEnvironmentEndpointResolver.TryGetEffectiveComputeEnvironment(resource, out var computeEnvironment))
         {
             return computeEnvironment;
-        }
-
-        if (resource.GetDeploymentTargetAnnotation()?.ComputeEnvironment is { } deploymentComputeEnvironment)
-        {
-            return deploymentComputeEnvironment;
         }
 
         throw new InvalidOperationException(

--- a/src/Aspire.Hosting.Azure/AzureResourcePreparer.cs
+++ b/src/Aspire.Hosting.Azure/AzureResourcePreparer.cs
@@ -133,7 +133,8 @@ internal sealed class AzureResourcePreparer(
             foreach (var resource in resourceSnapshot)
             {
                 var prerequisiteResources = new HashSet<AzureBicepResource>();
-                var azureReferences = await GetAzureReferences(resource, cancellationToken).ConfigureAwait(false);
+                var directDependencies = await resource.GetResourceDependenciesAsync(executionContext, ResourceDependencyDiscoveryMode.DirectOnly, cancellationToken).ConfigureAwait(false);
+                var azureReferences = new HashSet<IAzureResource>(directDependencies.OfType<IAzureResource>());
 
                 var azureReferencesWithRoleAssignments =
                     (resource.TryGetAnnotationsOfType<RoleAssignmentAnnotation>(out var annotations)
@@ -180,6 +181,42 @@ internal sealed class AzureResourcePreparer(
                         foreach (var peAnnotation in peAnnotations)
                         {
                             prerequisiteResources.Add(peAnnotation.PrivateEndpointResource);
+                        }
+                    }
+                }
+
+                // A direct dependency that is not itself an Azure resource can still "front" one
+                // (e.g. a Foundry hosted agent's node app fronts its owning Foundry account). Such a
+                // resource carries ReferenceRoleAssignmentAnnotation(s) declaring that any resource
+                // referencing it should be granted roles on a transitive Azure target the normal
+                // IAzureResource-only reference walk above cannot reach. Fold those implied targets
+                // into the same role-assignment path so the consumer gets an identity + role bicep
+                // exactly as it would for a direct Azure reference.
+                foreach (var dependency in directDependencies)
+                {
+                    if (!dependency.TryGetAnnotationsOfType<ReferenceRoleAssignmentAnnotation>(out var impliedRoleAssignments))
+                    {
+                        continue;
+                    }
+
+                    foreach (var impliedRoleAssignment in impliedRoleAssignments)
+                    {
+                        var target = impliedRoleAssignment.Target;
+                        if (target.IsContainer() || target.IsEmulator())
+                        {
+                            continue;
+                        }
+
+                        if (executionContext.IsRunMode)
+                        {
+                            AppendGlobalRoleAssignments(globalRoleAssignments, target, impliedRoleAssignment.Roles);
+                        }
+                        else
+                        {
+                            // In PublishMode, materialize as an explicit RoleAssignmentAnnotation so
+                            // GetAllRoleAssignments (which groups by target and unions roles) picks it
+                            // up alongside any roles the consumer already declares for the same target.
+                            resource.Annotations.Add(new RoleAssignmentAnnotation(target, impliedRoleAssignment.Roles));
                         }
                     }
                 }
@@ -250,7 +287,12 @@ internal sealed class AzureResourcePreparer(
         {
             foreach (var g in roleAssignments.GroupBy(r => r.Target))
             {
-                result[g.Key] = g.SelectMany(r => r.Roles);
+                // Deduplicate roles per target. A target can accumulate multiple RoleAssignmentAnnotations
+                // (e.g. an implied ReferenceRoleAssignmentAnnotation from two hosted agents on the same
+                // Foundry account, plus a direct reference). Emitting the same RoleDefinition twice would
+                // produce two RoleAssignment bicep resources with the same identifier ("{prefix}_{roleName}")
+                // and fail bicep compilation. This mirrors the RunMode path, which unions into a HashSet.
+                result[g.Key] = g.SelectMany(r => r.Roles).Distinct();
             }
         }
         return result;
@@ -357,19 +399,6 @@ internal sealed class AzureResourcePreparer(
         public BicepValue<string> PrincipalName => getPrincipalName.Value;
 
         public DistributedApplicationExecutionContext ExecutionContext => executionContext;
-    }
-
-    private async Task<HashSet<IAzureResource>> GetAzureReferences(IResource resource, CancellationToken cancellationToken)
-    {
-        var dependencies = await resource.GetResourceDependenciesAsync(executionContext, ResourceDependencyDiscoveryMode.DirectOnly, cancellationToken).ConfigureAwait(false);
-
-        HashSet<IAzureResource> azureReferences = [];
-        foreach (var azureResource in dependencies.OfType<IAzureResource>())
-        {
-            azureReferences.Add(azureResource);
-        }
-
-        return azureReferences;
     }
 
     private static void AppendGlobalRoleAssignments(Dictionary<AzureProvisioningResource, HashSet<RoleDefinition>> globalRoleAssignments, AzureProvisioningResource azureResource, IEnumerable<RoleDefinition> newRoles)

--- a/src/Aspire.Hosting.Azure/ReferenceRoleAssignmentAnnotation.cs
+++ b/src/Aspire.Hosting.Azure/ReferenceRoleAssignmentAnnotation.cs
@@ -1,0 +1,43 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Diagnostics.CodeAnalysis;
+using Aspire.Hosting.ApplicationModel;
+
+namespace Aspire.Hosting.Azure;
+
+/// <summary>
+/// Declares that any compute resource referencing the annotated resource should be granted
+/// <see cref="Roles"/> on the Azure resource <see cref="Target"/>.
+/// </summary>
+/// <param name="target">The Azure resource that referencing resources should be granted roles on.</param>
+/// <param name="roles">The roles that referencing resources should be assigned on <paramref name="target"/>.</param>
+/// <remarks>
+/// <para>
+/// This annotation is applied to a resource that "fronts" an Azure resource without being an
+/// <see cref="IAzureResource"/> itself. For example, a Foundry hosted agent's node app is a plain
+/// compute resource, but invoking the agent requires the caller to hold a role on the owning
+/// Foundry account. The account is only a transitive dependency of a consumer, so
+/// <see cref="AzureResourcePreparer"/>'s normal reference walk — which only acts on direct
+/// <see cref="IAzureResource"/> dependencies — cannot reach it.
+/// </para>
+/// <para>
+/// When a compute resource takes a direct dependency on a resource carrying this annotation,
+/// <see cref="AzureResourcePreparer"/> folds <c>(Target, Roles)</c> into the same role-assignment
+/// path used for direct Azure references, so the consumer gets a managed identity and the
+/// corresponding role assignment on <see cref="Target"/> with no additional wiring.
+/// </para>
+/// </remarks>
+[Experimental("ASPIREAZURE003", UrlFormat = "https://aka.ms/aspire/diagnostics/{0}")]
+public sealed class ReferenceRoleAssignmentAnnotation(AzureProvisioningResource target, IReadOnlySet<RoleDefinition> roles) : IResourceAnnotation
+{
+    /// <summary>
+    /// Gets the Azure resource that resources referencing the annotated resource should be granted roles on.
+    /// </summary>
+    public AzureProvisioningResource Target { get; } = target;
+
+    /// <summary>
+    /// Gets the set of roles that resources referencing the annotated resource should be assigned on <see cref="Target"/>.
+    /// </summary>
+    public IReadOnlySet<RoleDefinition> Roles { get; } = roles;
+}

--- a/src/Aspire.Hosting.Foundry/Aspire.Hosting.Foundry.csproj
+++ b/src/Aspire.Hosting.Foundry/Aspire.Hosting.Foundry.csproj
@@ -23,6 +23,7 @@
   <ItemGroup>
     <Compile Include="$(RepoRoot)src\Shared\AzureRoleAssignmentUtils.cs" />
     <Compile Include="$(RepoRoot)src\Shared\ContainerRegistryInfrastructure.cs" />
+    <Compile Include="$(SharedDir)ComputeEnvironmentEndpointResolver.cs" LinkBase="Shared\ComputeEnvironmentEndpointResolver.cs" />
     <Compile Include="$(RepoRoot)src\Aspire.Hosting\Utils\FormattingHelpers.cs" Link="Utils\FormattingHelpers.cs" />
     <Compile Include="..\Shared\AzureCredentialHelper.cs" Link="AzureCredentialHelper.cs" />
     <Compile Remove="tools\**\*.cs" />

--- a/src/Aspire.Hosting.Foundry/HostedAgent/AzureHostedAgentResource.cs
+++ b/src/Aspire.Hosting.Foundry/HostedAgent/AzureHostedAgentResource.cs
@@ -429,8 +429,7 @@ public class AzureHostedAgentResource : Resource, IResourceWithEnvironment
             throw CreateEndpointResolutionException(hostedAgent, resource, environmentVariableName, endpointReference, $"Endpoint '{endpoint.Name}' is internal. Foundry hosted agents can only reference externally exposed endpoints during publish.");
         }
 
-        var deploymentTarget = endpointReference.Resource.GetDeploymentTargetAnnotation();
-        if (deploymentTarget?.ComputeEnvironment is not { } computeEnvironment)
+        if (!ComputeEnvironmentEndpointResolver.TryGetEffectiveComputeEnvironment(endpointReference.Resource, out var computeEnvironment))
         {
             var reason = $"Resource '{endpointReference.Resource.Name}' does not have a compute environment deployment target.";
             throw CreateEndpointResolutionException(hostedAgent, resource, environmentVariableName, endpointReference, reason);

--- a/src/Aspire.Hosting.Foundry/HostedAgent/AzureHostedAgentResource.cs
+++ b/src/Aspire.Hosting.Foundry/HostedAgent/AzureHostedAgentResource.cs
@@ -25,7 +25,10 @@ namespace Aspire.Hosting.Foundry;
 /// </summary>
 public class AzureHostedAgentResource : Resource, IResourceWithEnvironment
 {
-    private const string AzureAIUserRoleDefinitionId = "53ca6127-db72-4b80-b1b0-d745d6d5456d";
+    // The "Azure AI User" built-in role (data-plane access to Foundry agents/inference). Granted to
+    // the agent's own instance identity below, and to consumers that reference the agent (see
+    // HostedAgentResourceBuilderExtensions.GrantHostedAgentConsumerRoles).
+    internal const string AzureAIUserRoleDefinitionId = "53ca6127-db72-4b80-b1b0-d745d6d5456d";
 
     /// <summary>
     /// Creates a new instance of the <see cref="AzureHostedAgentResource"/> class.

--- a/src/Aspire.Hosting.Foundry/HostedAgent/HostedAgentBuilderExtension.cs
+++ b/src/Aspire.Hosting.Foundry/HostedAgent/HostedAgentBuilderExtension.cs
@@ -4,6 +4,7 @@
 using System.Net.Http.Json;
 using System.Text.Json;
 using Aspire.Hosting.ApplicationModel;
+using Aspire.Hosting.Azure;
 using Aspire.Hosting.Foundry;
 using Microsoft.Extensions.DependencyInjection;
 
@@ -419,6 +420,35 @@ public static class HostedAgentResourceBuilderExtensions
         builder.ApplicationBuilder.AddResource(hostedAgent)
             .WithIconName("Agents")
             .WithReferenceRelationship(target);
+
+        // Referencing a hosted agent (its node app) only injects the agent's service-discovery URL.
+        // Unlike referencing a first-class Azure resource, it does not give the consumer a managed
+        // identity or any RBAC on the Foundry account, so calls to the agent's invocation endpoint
+        // fail with 401/403 at runtime. Stamp a ReferenceRoleAssignmentAnnotation on the agent's
+        // target so AzureResourcePreparer grants the "Azure AI User" role on the owning Foundry
+        // account to every consumer that references this agent, and provisions the identity that
+        // makes ACA inject AZURE_CLIENT_ID.
+        StampHostedAgentConsumerRoleAnnotation(target, projectResource.Parent);
+    }
+
+    private static void StampHostedAgentConsumerRoleAnnotation(IResourceWithEnvironment target, FoundryResource account)
+    {
+        // Grant only the "Azure AI User" role required to invoke the hosted agent. We deliberately do
+        // not union the account's default data-plane roles here:
+        //  - A consumer that also references the account directly still receives those defaults through
+        //    AzureResourcePreparer's normal reference walk (they are preserved when GetAllRoleAssignments
+        //    unions per target).
+        //  - A consumer that declares explicit role assignments on the account intentionally suppresses
+        //    the account defaults; folding them back in here would defeat that suppression.
+        // So the minimal, least-privilege grant for a pure agent consumer is "Azure AI User" alone.
+        var roles = new HashSet<RoleDefinition>
+        {
+            new(AzureHostedAgentResource.AzureAIUserRoleDefinitionId, "Azure AI User")
+        };
+
+#pragma warning disable ASPIREAZURE003 // Type is for evaluation purposes only and is subject to change or removal in future updates.
+        target.Annotations.Add(new ReferenceRoleAssignmentAnnotation(account, roles));
+#pragma warning restore ASPIREAZURE003
     }
 
     private sealed class HostedAgentRunProtocol
@@ -454,3 +484,4 @@ public static class HostedAgentResourceBuilderExtensions
         public required Func<string, HttpContent> CreateRequestContent { get; init; }
     }
 }
+

--- a/src/Aspire.Hosting.Foundry/Project/ProjectResource.cs
+++ b/src/Aspire.Hosting.Foundry/Project/ProjectResource.cs
@@ -212,6 +212,35 @@ public class AzureCognitiveServicesProjectResource :
     /// Get the address for the particular agent's endpoint.
     /// </summary>
     ReferenceExpression IComputeEnvironmentResource.GetHostAddressExpression(EndpointReference endpointReference)
+        => GetAgentAddressExpression(endpointReference);
+
+    /// <summary>
+    /// Produces the endpoint property expression for a hosted agent endpoint owned by this Foundry project.
+    /// </summary>
+    /// <remarks>
+    /// The agent address is already a fully-qualified <c>https</c> URL
+    /// (for example <c>https://{account}.services.ai.azure.com/.../agents/{name}</c>), so it is
+    /// returned directly for URL-shaped properties. The default
+    /// <see cref="IComputeEnvironmentResource.GetEndpointPropertyExpression"/> implementation composes
+    /// <c>{scheme}://{host}</c>, which would produce a malformed double-scheme value
+    /// (for example <c>http://https://...</c>). Only the properties that <c>WithReference</c> emits for a
+    /// hosted agent endpoint are supported.
+    /// </remarks>
+    ReferenceExpression IComputeEnvironmentResource.GetEndpointPropertyExpression(EndpointReferenceExpression endpointReferenceExpression)
+    {
+        ArgumentNullException.ThrowIfNull(endpointReferenceExpression);
+
+        var property = endpointReferenceExpression.Property;
+        return property switch
+        {
+            EndpointProperty.Url => GetAgentAddressExpression(endpointReferenceExpression.Endpoint),
+            EndpointProperty.Scheme => ReferenceExpression.Create($"https"),
+            _ => throw new InvalidOperationException(
+                $"The endpoint property '{property}' is not supported for Foundry hosted agent endpoints. Only 'Url' and 'Scheme' are supported.")
+        };
+    }
+
+    private ReferenceExpression GetAgentAddressExpression(EndpointReference endpointReference)
     {
         var resource = endpointReference.Resource;
         return ReferenceExpression.Create($"{Endpoint}/agents/{resource.Name}");

--- a/src/Aspire.Hosting.Foundry/Project/ProjectResource.cs
+++ b/src/Aspire.Hosting.Foundry/Project/ProjectResource.cs
@@ -243,7 +243,17 @@ public class AzureCognitiveServicesProjectResource :
     private ReferenceExpression GetAgentAddressExpression(EndpointReference endpointReference)
     {
         var resource = endpointReference.Resource;
-        return ReferenceExpression.Create($"{Endpoint}/agents/{resource.Name}");
+
+        // For hosted agents, deployment creates the Foundry agent version using the wrapper
+        // AzureHostedAgentResource.Name (e.g. "agent-ha" for a target named "agent"), not the
+        // target resource name. The published cross-environment URL must point at that deployed
+        // agent name, so prefer the hosted-agent deployment target's name when one exists and fall
+        // back to the resource name for plain (non-hosted) agents.
+        var agentName = resource.GetDeploymentTargetAnnotation(this)?.DeploymentTarget is AzureHostedAgentResource hostedAgent
+            ? hostedAgent.Name
+            : resource.Name;
+
+        return ReferenceExpression.Create($"{Endpoint}/agents/{agentName}");
     }
 
     /// <summary>

--- a/src/Aspire.Hosting.Kubernetes/Aspire.Hosting.Kubernetes.csproj
+++ b/src/Aspire.Hosting.Kubernetes/Aspire.Hosting.Kubernetes.csproj
@@ -14,6 +14,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <Compile Include="$(SharedDir)ComputeEnvironmentEndpointResolver.cs" LinkBase="Shared\ComputeEnvironmentEndpointResolver.cs" />
     <Compile Include="$(SharedDir)PublishingContextUtils.cs" LinkBase="Shared" />
     <Compile Include="$(SharedDir)Yaml\*.cs" LinkBase="Shared\Yaml" />
   </ItemGroup>

--- a/src/Aspire.Hosting.Kubernetes/KubernetesResource.cs
+++ b/src/Aspire.Hosting.Kubernetes/KubernetesResource.cs
@@ -490,7 +490,7 @@ public partial class KubernetesResource(string name, IResource resource, Kuberne
                 // environment (for example a Foundry hosted agent). In that case delegate to the owning
                 // compute environment instead of looking it up in this environment's local endpoint map.
                 if (ComputeEnvironmentEndpointResolver.TryGetCrossEnvironmentEndpointExpression(
-                    ep.Property(EndpointProperty.Url), [kubernetesEnvironmentResource, kubernetesEnvironmentResource.OwningComputeEnvironment], out var crossExpr))
+                    ep, [kubernetesEnvironmentResource, kubernetesEnvironmentResource.OwningComputeEnvironment], out var crossExpr))
                 {
                     value = crossExpr;
                     continue;

--- a/src/Aspire.Hosting.Kubernetes/KubernetesResource.cs
+++ b/src/Aspire.Hosting.Kubernetes/KubernetesResource.cs
@@ -490,7 +490,7 @@ public partial class KubernetesResource(string name, IResource resource, Kuberne
                 // environment (for example a Foundry hosted agent). In that case delegate to the owning
                 // compute environment instead of looking it up in this environment's local endpoint map.
                 if (ComputeEnvironmentEndpointResolver.TryGetCrossEnvironmentEndpointExpression(
-                    ep.Property(EndpointProperty.Url), out var crossExpr, kubernetesEnvironmentResource, kubernetesEnvironmentResource.OwningComputeEnvironment))
+                    ep.Property(EndpointProperty.Url), [kubernetesEnvironmentResource, kubernetesEnvironmentResource.OwningComputeEnvironment], out var crossExpr))
                 {
                     value = crossExpr;
                     continue;
@@ -527,7 +527,7 @@ public partial class KubernetesResource(string name, IResource resource, Kuberne
             if (value is EndpointReferenceExpression epExpr)
             {
                 if (ComputeEnvironmentEndpointResolver.TryGetCrossEnvironmentEndpointExpression(
-                    epExpr, out var crossExpr, kubernetesEnvironmentResource, kubernetesEnvironmentResource.OwningComputeEnvironment))
+                    epExpr, [kubernetesEnvironmentResource, kubernetesEnvironmentResource.OwningComputeEnvironment], out var crossExpr))
                 {
                     value = crossExpr;
                     continue;

--- a/src/Aspire.Hosting.Kubernetes/KubernetesResource.cs
+++ b/src/Aspire.Hosting.Kubernetes/KubernetesResource.cs
@@ -486,6 +486,16 @@ public partial class KubernetesResource(string name, IResource resource, Kuberne
 
             if (value is EndpointReference ep)
             {
+                // The referenced endpoint may belong to a resource deployed to a different compute
+                // environment (for example a Foundry hosted agent). In that case delegate to the owning
+                // compute environment instead of looking it up in this environment's local endpoint map.
+                if (ComputeEnvironmentEndpointResolver.TryGetCrossEnvironmentEndpointExpression(
+                    ep.Property(EndpointProperty.Url), out var crossExpr, kubernetesEnvironmentResource, kubernetesEnvironmentResource.OwningComputeEnvironment))
+                {
+                    value = crossExpr;
+                    continue;
+                }
+
                 var referencedResource = ep.Resource == this
                     ? this
                     : await context.CreateKubernetesResourceAsync(ep.Resource, executionContext, default).ConfigureAwait(false);
@@ -516,6 +526,13 @@ public partial class KubernetesResource(string name, IResource resource, Kuberne
 
             if (value is EndpointReferenceExpression epExpr)
             {
+                if (ComputeEnvironmentEndpointResolver.TryGetCrossEnvironmentEndpointExpression(
+                    epExpr, out var crossExpr, kubernetesEnvironmentResource, kubernetesEnvironmentResource.OwningComputeEnvironment))
+                {
+                    value = crossExpr;
+                    continue;
+                }
+
                 var referencedResource = epExpr.Endpoint.Resource == this
                     ? this
                     : await context.CreateKubernetesResourceAsync(epExpr.Endpoint.Resource, executionContext, default).ConfigureAwait(false);

--- a/src/Shared/ComputeEnvironmentEndpointResolver.cs
+++ b/src/Shared/ComputeEnvironmentEndpointResolver.cs
@@ -1,0 +1,118 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Diagnostics.CodeAnalysis;
+using Aspire.Hosting.ApplicationModel;
+
+namespace Aspire.Hosting;
+
+/// <summary>
+/// Helper for resolving endpoint references that point at a resource deployed to a different
+/// compute environment than the one currently generating deployment artifacts.
+/// </summary>
+/// <remarks>
+/// Compute environment publishers (App Service, Azure Container Apps, Kubernetes) resolve
+/// endpoint references against their own local endpoint map. When a resource references an
+/// endpoint owned by a resource deployed to a different compute environment (for example a
+/// Foundry hosted agent deployed to an <c>AzureCognitiveServicesProjectResource</c>), the
+/// endpoint is not present in the local map and the lookup fails. In that case the owning
+/// compute environment knows how to express the endpoint property, so we delegate to it.
+/// This mirrors the inverse-direction logic used by Foundry hosted agents when they reference
+/// endpoints owned by App Service/ACA/Kubernetes resources.
+/// </remarks>
+internal static class ComputeEnvironmentEndpointResolver
+{
+    /// <summary>
+    /// Attempts to produce a <see cref="ReferenceExpression"/> for an endpoint property by
+    /// delegating to the compute environment that owns the endpoint's resource, when that
+    /// environment is different from the publisher's current compute environment(s).
+    /// </summary>
+    /// <param name="endpointReferenceExpression">The endpoint reference expression to resolve.</param>
+    /// <param name="expression">
+    /// When this method returns <see langword="true"/>, contains the delegated reference expression.
+    /// </param>
+    /// <param name="currentComputeEnvironments">
+    /// The compute environment(s) the current publisher is generating artifacts for. When the
+    /// endpoint's owning resource deploys to one of these, resolution is left to the local
+    /// endpoint map and this method returns <see langword="false"/>.
+    /// </param>
+    /// <returns>
+    /// <see langword="true"/> if the endpoint is owned by a different compute environment and a
+    /// delegated expression was produced; otherwise <see langword="false"/>.
+    /// </returns>
+    public static bool TryGetCrossEnvironmentEndpointExpression(
+        EndpointReferenceExpression endpointReferenceExpression,
+        [NotNullWhen(true)] out ReferenceExpression? expression,
+        params IComputeEnvironmentResource?[] currentComputeEnvironments)
+    {
+        ArgumentNullException.ThrowIfNull(endpointReferenceExpression);
+
+        expression = null;
+
+        var owningResource = endpointReferenceExpression.Endpoint.Resource;
+
+        // If the endpoint's owning resource deploys to one of the current publisher's compute
+        // environments, the endpoint lives in the local endpoint map. Leave resolution to the
+        // existing local lookup so generated artifacts (bicep parameters, helm values, etc.)
+        // are unchanged. GetDeploymentTargetAnnotation(env) accounts for ComputeEnvironmentAnnotation
+        // binding and returns null when the resource does not deploy to that environment. It is also
+        // binding-aware and never throws on multi-target resources, so checking it before resolving
+        // the owning environment preserves existing behavior.
+        foreach (var current in currentComputeEnvironments)
+        {
+            if (current is not null && owningResource.GetDeploymentTargetAnnotation(current) is not null)
+            {
+                return false;
+            }
+        }
+
+        // The owning resource has no compute environment (for example a plain resource that is not
+        // deployed anywhere). There is nothing to delegate to, so let the local lookup handle it.
+        if (!TryGetEffectiveComputeEnvironment(owningResource, out var owningComputeEnvironment))
+        {
+            return false;
+        }
+
+        // Defensive: if the resolved owning environment is itself one of the current publisher's
+        // environments, prefer the local map.
+        foreach (var current in currentComputeEnvironments)
+        {
+            if (ReferenceEquals(current, owningComputeEnvironment))
+            {
+                return false;
+            }
+        }
+
+#pragma warning disable ASPIRECOMPUTE002 // Experimental: compute environment endpoint expression
+        expression = owningComputeEnvironment.GetEndpointPropertyExpression(endpointReferenceExpression);
+#pragma warning restore ASPIRECOMPUTE002
+
+        return true;
+    }
+
+    /// <summary>
+    /// Resolves the compute environment that a resource is deployed to. A resource may be bound to a
+    /// compute environment explicitly (via <see cref="ResourceExtensions.GetComputeEnvironment"/>) or
+    /// implicitly through its deployment target.
+    /// </summary>
+    /// <param name="resource">The resource whose compute environment should be resolved.</param>
+    /// <param name="computeEnvironment">
+    /// When this method returns <see langword="true"/>, contains the owning compute environment.
+    /// </param>
+    /// <returns>
+    /// <see langword="true"/> if a compute environment was resolved; otherwise <see langword="false"/>.
+    /// </returns>
+    public static bool TryGetEffectiveComputeEnvironment(
+        IResource resource,
+        [NotNullWhen(true)] out IComputeEnvironmentResource? computeEnvironment)
+    {
+        ArgumentNullException.ThrowIfNull(resource);
+
+        // Prefer an explicit compute environment binding, then fall back to the deployment target's
+        // compute environment. This matches how endpoint references are resolved elsewhere
+        // (Azure Front Door origins, Foundry hosted agents) so all call sites agree on "where is
+        // this resource deployed".
+        computeEnvironment = resource.GetComputeEnvironment() ?? resource.GetDeploymentTargetAnnotation()?.ComputeEnvironment;
+        return computeEnvironment is not null;
+    }
+}

--- a/src/Shared/ComputeEnvironmentEndpointResolver.cs
+++ b/src/Shared/ComputeEnvironmentEndpointResolver.cs
@@ -51,13 +51,19 @@ internal static class ComputeEnvironmentEndpointResolver
 
         var owningResource = endpointReferenceExpression.Endpoint.Resource;
 
-        // If the endpoint's owning resource deploys to one of the current publisher's compute
-        // environments, the endpoint lives in the local endpoint map. Leave resolution to the
-        // existing local lookup so generated artifacts (bicep parameters, helm values, etc.)
-        // are unchanged. GetDeploymentTargetAnnotation(env) accounts for ComputeEnvironmentAnnotation
-        // binding and returns null when the resource does not deploy to that environment. It is also
-        // binding-aware and never throws on multi-target resources, so checking it before resolving
-        // the owning environment preserves existing behavior.
+        // Fast path: if the endpoint's owning resource deploys to one of the current publisher's
+        // compute environments, the endpoint lives in the local endpoint map. Leave resolution to
+        // the existing local lookup so generated artifacts (bicep parameters, helm values, etc.) are
+        // unchanged. GetDeploymentTargetAnnotation(env) accounts for ComputeEnvironmentAnnotation
+        // binding and returns null when the resource does not deploy to that environment.
+        //
+        // For well-formed inputs this loop is redundant with the TryGetEffectiveComputeEnvironment +
+        // ReferenceEquals backstop below (a resource resolves to the current environment in both
+        // places). It is NOT a guard against the multi-target throw: for an unbound resource with
+        // more than one deployment target, GetDeploymentTargetAnnotation(current) throws exactly like
+        // the parameterless overload TryGetEffectiveComputeEnvironment uses. That malformed
+        // configuration is rejected earlier in the pipeline, so it is not reachable here. The loop is
+        // kept as a harmless explicit fast-path; it can be removed if the backstop is preferred.
         foreach (var current in currentComputeEnvironments)
         {
             if (current is not null && owningResource.GetDeploymentTargetAnnotation(current) is not null)

--- a/src/Shared/ComputeEnvironmentEndpointResolver.cs
+++ b/src/Shared/ComputeEnvironmentEndpointResolver.cs
@@ -28,13 +28,13 @@ internal static class ComputeEnvironmentEndpointResolver
     /// environment is different from the publisher's current compute environment(s).
     /// </summary>
     /// <param name="endpointReferenceExpression">The endpoint reference expression to resolve.</param>
-    /// <param name="expression">
-    /// When this method returns <see langword="true"/>, contains the delegated reference expression.
-    /// </param>
     /// <param name="currentComputeEnvironments">
     /// The compute environment(s) the current publisher is generating artifacts for. When the
     /// endpoint's owning resource deploys to one of these, resolution is left to the local
     /// endpoint map and this method returns <see langword="false"/>.
+    /// </param>
+    /// <param name="expression">
+    /// When this method returns <see langword="true"/>, contains the delegated reference expression.
     /// </param>
     /// <returns>
     /// <see langword="true"/> if the endpoint is owned by a different compute environment and a
@@ -42,10 +42,11 @@ internal static class ComputeEnvironmentEndpointResolver
     /// </returns>
     public static bool TryGetCrossEnvironmentEndpointExpression(
         EndpointReferenceExpression endpointReferenceExpression,
-        [NotNullWhen(true)] out ReferenceExpression? expression,
-        params IComputeEnvironmentResource?[] currentComputeEnvironments)
+        IReadOnlyList<IComputeEnvironmentResource?> currentComputeEnvironments,
+        [NotNullWhen(true)] out ReferenceExpression? expression)
     {
         ArgumentNullException.ThrowIfNull(endpointReferenceExpression);
+        ArgumentNullException.ThrowIfNull(currentComputeEnvironments);
 
         expression = null;
 

--- a/src/Shared/ComputeEnvironmentEndpointResolver.cs
+++ b/src/Shared/ComputeEnvironmentEndpointResolver.cs
@@ -23,6 +23,37 @@ namespace Aspire.Hosting;
 internal static class ComputeEnvironmentEndpointResolver
 {
     /// <summary>
+    /// Attempts to produce a <see cref="ReferenceExpression"/> for an endpoint's URL by
+    /// delegating to the compute environment that owns the endpoint's resource, when that
+    /// environment is different from the publisher's current compute environment(s).
+    /// </summary>
+    /// <param name="endpointReference">The endpoint reference to resolve.</param>
+    /// <param name="currentComputeEnvironments">
+    /// The compute environment(s) the current publisher is generating artifacts for. When the
+    /// endpoint's owning resource deploys to one of these, resolution is left to the local
+    /// endpoint map and this method returns <see langword="false"/>.
+    /// </param>
+    /// <param name="expression">
+    /// When this method returns <see langword="true"/>, contains the delegated reference expression.
+    /// </param>
+    /// <returns>
+    /// <see langword="true"/> if the endpoint is owned by a different compute environment and a
+    /// delegated expression was produced; otherwise <see langword="false"/>.
+    /// </returns>
+    public static bool TryGetCrossEnvironmentEndpointExpression(
+        EndpointReference endpointReference,
+        IReadOnlyList<IComputeEnvironmentResource?> currentComputeEnvironments,
+        [NotNullWhen(true)] out ReferenceExpression? expression)
+    {
+        ArgumentNullException.ThrowIfNull(endpointReference);
+
+        return TryGetCrossEnvironmentEndpointExpression(
+            endpointReference.Property(EndpointProperty.Url),
+            currentComputeEnvironments,
+            out expression);
+    }
+
+    /// <summary>
     /// Attempts to produce a <see cref="ReferenceExpression"/> for an endpoint property by
     /// delegating to the compute environment that owns the endpoint's resource, when that
     /// environment is different from the publisher's current compute environment(s).

--- a/src/Shared/ComputeEnvironmentEndpointResolver.cs
+++ b/src/Shared/ComputeEnvironmentEndpointResolver.cs
@@ -51,36 +51,17 @@ internal static class ComputeEnvironmentEndpointResolver
 
         var owningResource = endpointReferenceExpression.Endpoint.Resource;
 
-        // Fast path: if the endpoint's owning resource deploys to one of the current publisher's
-        // compute environments, the endpoint lives in the local endpoint map. Leave resolution to
-        // the existing local lookup so generated artifacts (bicep parameters, helm values, etc.) are
-        // unchanged. GetDeploymentTargetAnnotation(env) accounts for ComputeEnvironmentAnnotation
-        // binding and returns null when the resource does not deploy to that environment.
-        //
-        // For well-formed inputs this loop is redundant with the TryGetEffectiveComputeEnvironment +
-        // ReferenceEquals backstop below (a resource resolves to the current environment in both
-        // places). It is NOT a guard against the multi-target throw: for an unbound resource with
-        // more than one deployment target, GetDeploymentTargetAnnotation(current) throws exactly like
-        // the parameterless overload TryGetEffectiveComputeEnvironment uses. That malformed
-        // configuration is rejected earlier in the pipeline, so it is not reachable here. The loop is
-        // kept as a harmless explicit fast-path; it can be removed if the backstop is preferred.
-        foreach (var current in currentComputeEnvironments)
-        {
-            if (current is not null && owningResource.GetDeploymentTargetAnnotation(current) is not null)
-            {
-                return false;
-            }
-        }
-
-        // The owning resource has no compute environment (for example a plain resource that is not
-        // deployed anywhere). There is nothing to delegate to, so let the local lookup handle it.
+        // Resolve the compute environment the owning resource deploys to. A plain resource that is
+        // not deployed anywhere has none, so there is nothing to delegate to and the local lookup
+        // handles it.
         if (!TryGetEffectiveComputeEnvironment(owningResource, out var owningComputeEnvironment))
         {
             return false;
         }
 
-        // Defensive: if the resolved owning environment is itself one of the current publisher's
-        // environments, prefer the local map.
+        // If the owning resource deploys to one of the current publisher's compute environments, the
+        // endpoint lives in the local endpoint map. Leave resolution to the existing local lookup so
+        // generated artifacts (bicep parameters, helm values, etc.) are unchanged.
         foreach (var current in currentComputeEnvironments)
         {
             if (ReferenceEquals(current, owningComputeEnvironment))

--- a/tests/Aspire.Hosting.Azure.Kubernetes.Tests/AzureKubernetesFoundryReferenceTests.cs
+++ b/tests/Aspire.Hosting.Azure.Kubernetes.Tests/AzureKubernetesFoundryReferenceTests.cs
@@ -52,15 +52,15 @@ public class AzureKubernetesFoundryReferenceTests
         await app.RunAsync();
 
         // The resolved environment variable values are emitted into the Helm chart's values.yaml.
-        // The agent endpoint must resolve to the Foundry project endpoint composed with the agent
-        // path. Prior to the fix, publishing threw because the agent endpoint was not present in the
-        // Kubernetes environment's local endpoint map.
+        // The agent endpoint must resolve to the Foundry project endpoint composed with the deployed
+        // hosted agent path because hosted-agent deployment creates the Foundry agent version with the
+        // wrapper resource name.
         var valuesPath = Directory.EnumerateFiles(tempDir.Path, "values.yaml", SearchOption.AllDirectories).Single();
         var values = await File.ReadAllTextAsync(valuesPath);
 
-        Assert.Contains("AGENT_HTTP: \"{project.outputs.endpoint}/agents/agent\"", values);
-        Assert.Contains("AGENT_URL: \"{project.outputs.endpoint}/agents/agent\"", values);
-        Assert.Contains("services__agent__http__0: \"{project.outputs.endpoint}/agents/agent\"", values);
+        Assert.Contains("AGENT_HTTP: \"{project.outputs.endpoint}/agents/agent-ha\"", values);
+        Assert.Contains("AGENT_URL: \"{project.outputs.endpoint}/agents/agent-ha\"", values);
+        Assert.Contains("services__agent__http__0: \"{project.outputs.endpoint}/agents/agent-ha\"", values);
     }
 
     private sealed class Project : IProjectMetadata

--- a/tests/Aspire.Hosting.Azure.Kubernetes.Tests/AzureKubernetesFoundryReferenceTests.cs
+++ b/tests/Aspire.Hosting.Azure.Kubernetes.Tests/AzureKubernetesFoundryReferenceTests.cs
@@ -1,0 +1,70 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+#pragma warning disable ASPIREAZURE003
+#pragma warning disable ASPIREPIPELINES003
+
+using Aspire.Hosting.ApplicationModel;
+using Aspire.Hosting.Publishing;
+using Aspire.Hosting.Tests;
+using Aspire.Hosting.Utils;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Aspire.Hosting.Azure.Tests;
+
+public class AzureKubernetesFoundryReferenceTests
+{
+    [Fact]
+    public async Task EndpointReferenceToFoundryHostedAgentIsResolvedAcrossComputeEnvironments()
+    {
+        using var tempDir = new TestTempDirectory();
+        using var builder = TestDistributedApplicationBuilder.Create(
+            DistributedApplicationOperation.Publish,
+            tempDir.Path);
+
+        builder.Services.AddSingleton<IResourceContainerImageManager, MockImageBuilder>();
+
+        var aks = builder.AddAzureKubernetesEnvironment("aks");
+
+        var project = builder.AddFoundry("foundry")
+            .AddProject("project");
+
+        // The agent app is deployed to the Foundry project compute environment via AsHostedAgent.
+        var agent = builder.AddProject<Project>("agent", launchProfileName: null)
+            .WithHttpEndpoint()
+            .WithExternalHttpEndpoints();
+        agent.AsHostedAgent(project);
+
+        // The web app is deployed to Azure Kubernetes and references the Foundry hosted agent.
+        // The Kubernetes publisher must delegate endpoint resolution to the Foundry compute
+        // environment rather than looking the agent up in its own (local) endpoint map, which
+        // does not contain the cross-environment agent. See issue #17749.
+        // WithReference(agent) exercises the bare EndpointReference branch; the explicit
+        // Property(Url) environment variable exercises the EndpointReferenceExpression branch.
+        builder.AddProject<Project>("web", launchProfileName: null)
+            .WithHttpEndpoint()
+            .WithExternalHttpEndpoints()
+            .WithComputeEnvironment(aks)
+            .WithReference(agent)
+            .WithEnvironment("AGENT_URL", agent.GetEndpoint("http").Property(EndpointProperty.Url));
+
+        await using var app = builder.Build();
+        await app.RunAsync();
+
+        // The resolved environment variable values are emitted into the Helm chart's values.yaml.
+        // The agent endpoint must resolve to the Foundry project endpoint composed with the agent
+        // path. Prior to the fix, publishing threw because the agent endpoint was not present in the
+        // Kubernetes environment's local endpoint map.
+        var valuesPath = Directory.EnumerateFiles(tempDir.Path, "values.yaml", SearchOption.AllDirectories).Single();
+        var values = await File.ReadAllTextAsync(valuesPath);
+
+        Assert.Contains("AGENT_HTTP: \"{project.outputs.endpoint}/agents/agent\"", values);
+        Assert.Contains("AGENT_URL: \"{project.outputs.endpoint}/agents/agent\"", values);
+        Assert.Contains("services__agent__http__0: \"{project.outputs.endpoint}/agents/agent\"", values);
+    }
+
+    private sealed class Project : IProjectMetadata
+    {
+        public string ProjectPath => "project";
+    }
+}

--- a/tests/Aspire.Hosting.Azure.Tests/AzureAppServiceTests.cs
+++ b/tests/Aspire.Hosting.Azure.Tests/AzureAppServiceTests.cs
@@ -6,6 +6,7 @@
 
 using System.Text.Json.Nodes;
 using Aspire.Hosting.ApplicationModel;
+using Aspire.Hosting.Foundry;
 using Aspire.Hosting.Pipelines;
 using Aspire.Hosting.Utils;
 using Aspire.TestUtilities;
@@ -223,6 +224,59 @@ public class AzureAppServiceTests(ITestOutputHelper testOutputHelper)
 
         await Verify(manifest.ToString(), "json")
               .AppendContentAsFile(bicep, "bicep");
+    }
+
+    [Fact]
+    public async Task EndpointReferenceToFoundryHostedAgentIsResolvedAcrossComputeEnvironments()
+    {
+        var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish);
+
+        var appServiceEnv = builder.AddAzureAppServiceEnvironment("env");
+
+        var project = builder.AddFoundry("foundry")
+            .AddProject("project");
+
+        // The agent app is deployed to the Foundry project compute environment via AsHostedAgent.
+        var agent = builder.AddProject<Project>("agent", launchProfileName: null)
+            .WithHttpEndpoint()
+            .WithExternalHttpEndpoints();
+        agent.AsHostedAgent(project);
+
+        // The web app is deployed to App Service and references the Foundry hosted agent. The App
+        // Service publisher must delegate endpoint resolution to the Foundry compute environment
+        // rather than looking the agent up in its own (App Service) endpoint map. See issue #17749.
+        // WithReference(agent) exercises the bare EndpointReference branch; the explicit
+        // Property(Url) environment variable exercises the EndpointReferenceExpression branch.
+        var web = builder.AddProject<Project>("web", launchProfileName: null)
+            .WithHttpEndpoint()
+            .WithExternalHttpEndpoints()
+            .WithComputeEnvironment(appServiceEnv)
+            .WithReference(agent)
+            .WithEnvironment("AGENT_URL", agent.GetEndpoint("http").Property(EndpointProperty.Url));
+
+        using var app = builder.Build();
+
+        await ExecuteBeforeStartHooksAsync(app, default);
+
+        SetFoundryProjectOutputs(project.Resource);
+
+        web.Resource.TryGetLastAnnotation<DeploymentTargetAnnotation>(out var target);
+
+        var resource = target?.DeploymentTarget as AzureProvisioningResource;
+
+        Assert.NotNull(resource);
+
+        var (manifest, bicep) = await GetManifestWithBicep(resource);
+
+        await Verify(manifest.ToString(), "json")
+              .AppendContentAsFile(bicep, "bicep");
+    }
+
+    private static void SetFoundryProjectOutputs(AzureCognitiveServicesProjectResource project)
+    {
+        project.Outputs["endpoint"] = "https://account.services.ai.azure.com/api/projects/my-project";
+        project.Outputs["APPLICATION_INSIGHTS_CONNECTION_STRING"] = "";
+        project.ProvisioningTaskCompletionSource?.TrySetResult();
     }
 
     [Fact]

--- a/tests/Aspire.Hosting.Azure.Tests/AzureContainerAppsTests.cs
+++ b/tests/Aspire.Hosting.Azure.Tests/AzureContainerAppsTests.cs
@@ -10,6 +10,7 @@
 using System.Text.Json.Nodes;
 using Aspire.Hosting.ApplicationModel;
 using Aspire.Hosting.Azure.AppContainers;
+using Aspire.Hosting.Foundry;
 using Aspire.Hosting.Pipelines;
 using Aspire.Hosting.Utils;
 using Azure.Provisioning;
@@ -118,6 +119,59 @@ public class AzureContainerAppsTests
 
         await Verify(manifest.ToString(), "json")
               .AppendContentAsFile(bicep, "bicep");
+    }
+
+    [Fact]
+    public async Task EndpointReferenceToFoundryHostedAgentIsResolvedAcrossComputeEnvironments()
+    {
+        var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish);
+
+        var acaEnv = builder.AddAzureContainerAppEnvironment("env");
+
+        var project = builder.AddFoundry("foundry")
+            .AddProject("project");
+
+        // The agent app is deployed to the Foundry project compute environment via AsHostedAgent.
+        var agent = builder.AddProject<Project>("agent", launchProfileName: null)
+            .WithHttpEndpoint()
+            .WithExternalHttpEndpoints();
+        agent.AsHostedAgent(project);
+
+        // The web app is deployed to Azure Container Apps and references the Foundry hosted agent.
+        // The ACA publisher must delegate endpoint resolution to the Foundry compute environment
+        // rather than looking the agent up in its own endpoint map. See issue #17749.
+        // WithReference(agent) exercises the bare EndpointReference branch; the explicit
+        // Property(Url) environment variable exercises the EndpointReferenceExpression branch.
+        var web = builder.AddProject<Project>("web", launchProfileName: null)
+            .WithHttpEndpoint()
+            .WithExternalHttpEndpoints()
+            .WithComputeEnvironment(acaEnv)
+            .WithReference(agent)
+            .WithEnvironment("AGENT_URL", agent.GetEndpoint("http").Property(EndpointProperty.Url));
+
+        using var app = builder.Build();
+
+        await ExecuteBeforeStartHooksAsync(app, default);
+
+        SetFoundryProjectOutputs(project.Resource);
+
+        var target = web.Resource.GetDeploymentTargetAnnotation();
+
+        var resource = target?.DeploymentTarget as AzureProvisioningResource;
+
+        Assert.NotNull(resource);
+
+        var (manifest, bicep) = await GetManifestWithBicep(resource);
+
+        await Verify(manifest.ToString(), "json")
+              .AppendContentAsFile(bicep, "bicep");
+    }
+
+    private static void SetFoundryProjectOutputs(AzureCognitiveServicesProjectResource project)
+    {
+        project.Outputs["endpoint"] = "https://account.services.ai.azure.com/api/projects/my-project";
+        project.Outputs["APPLICATION_INSIGHTS_CONNECTION_STRING"] = "";
+        project.ProvisioningTaskCompletionSource?.TrySetResult();
     }
 
     [Fact]

--- a/tests/Aspire.Hosting.Azure.Tests/AzureResourcePreparerTests.cs
+++ b/tests/Aspire.Hosting.Azure.Tests/AzureResourcePreparerTests.cs
@@ -538,6 +538,204 @@ public class AzureResourcePreparerTests
         Assert.DoesNotContain(model.Resources, r => r.Name == "frontend-identity");
     }
 
+    [Fact]
+    public async Task ReferenceRoleAssignmentAnnotation_PublishMode_GrantsRolesOnImpliedTargetToConsumer()
+    {
+        using var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish);
+        builder.AddAzureContainerAppEnvironment("env");
+
+        var storage = builder.AddAzureStorage("storage");
+
+        // A non-Azure compute resource (the "agent" node app) that fronts the storage account: any
+        // resource referencing it should be granted a role on storage even though storage is only a
+        // transitive dependency that the IAzureResource-only reference walk cannot reach.
+        var agent = builder.AddContainer("agent", "img:latest")
+            .WithHttpEndpoint();
+        agent.Resource.Annotations.Add(new ReferenceRoleAssignmentAnnotation(
+            storage.Resource,
+            new HashSet<RoleDefinition> { new(StorageBuiltInRole.StorageBlobDataReader.ToString(), nameof(StorageBuiltInRole.StorageBlobDataReader)) }));
+
+        var consumer = builder.AddProject<Project>("api", launchProfileName: null)
+            .WithReference(agent.GetEndpoint("http"));
+
+        using var app = builder.Build();
+        await ExecuteBeforeStartHooksAsync(app, default);
+
+        Assert.True(consumer.Resource.TryGetLastAnnotation<RoleAssignmentAnnotation>(out var consumerRoleAssignments));
+        Assert.Equal(storage.Resource, consumerRoleAssignments.Target);
+        Assert.Single(consumerRoleAssignments.Roles, role => role.Id == StorageBuiltInRole.StorageBlobDataReader.ToString());
+    }
+
+    [Fact]
+    public async Task ReferenceRoleAssignmentAnnotation_RunMode_AppliesRolesToGlobalRolesResource()
+    {
+        using var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Run);
+        builder.AddAzureContainerAppEnvironment("env");
+
+        var storage = builder.AddAzureStorage("storage");
+
+        var agent = builder.AddContainer("agent", "img:latest")
+            .WithHttpEndpoint();
+        agent.Resource.Annotations.Add(new ReferenceRoleAssignmentAnnotation(
+            storage.Resource,
+            new HashSet<RoleDefinition> { new(StorageBuiltInRole.StorageBlobDataReader.ToString(), nameof(StorageBuiltInRole.StorageBlobDataReader)) }));
+
+        builder.AddProject<Project>("api", launchProfileName: null)
+            .WithReference(agent.GetEndpoint("http"));
+
+        using var app = builder.Build();
+        var model = app.Services.GetRequiredService<DistributedApplicationModel>();
+        await ExecuteBeforeStartHooksAsync(app, default);
+
+        var storageRoles = Assert.Single(model.Resources.OfType<AzureRoleAssignmentResource>(), r => r.Name == "storage-roles");
+        Assert.Same(storage.Resource, storageRoles.TargetAzureResource);
+    }
+
+    [Fact]
+    public async Task ReferenceRoleAssignmentAnnotation_ConsumerNotReferencingFrontingResource_GetsNoRole()
+    {
+        using var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish);
+        builder.AddAzureContainerAppEnvironment("env");
+
+        var storage = builder.AddAzureStorage("storage");
+
+        var agent = builder.AddContainer("agent", "img:latest")
+            .WithHttpEndpoint();
+        agent.Resource.Annotations.Add(new ReferenceRoleAssignmentAnnotation(
+            storage.Resource,
+            new HashSet<RoleDefinition> { new(StorageBuiltInRole.StorageBlobDataReader.ToString(), nameof(StorageBuiltInRole.StorageBlobDataReader)) }));
+
+        // This compute resource does not reference the fronting agent, so it must not be granted any
+        // role on the implied storage target.
+        var bystander = builder.AddProject<Project>("bystander", launchProfileName: null);
+
+        using var app = builder.Build();
+        await ExecuteBeforeStartHooksAsync(app, default);
+
+        Assert.False(bystander.Resource.TryGetLastAnnotation<RoleAssignmentAnnotation>(out _));
+    }
+
+    [Fact]
+    public async Task ReferenceRoleAssignmentAnnotation_SameTargetFromTwoDependencies_DedupesRoles()
+    {
+        using var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish);
+        builder.AddAzureContainerAppEnvironment("env");
+
+        var storage = builder.AddAzureStorage("storage");
+
+        // Two fronting resources (e.g. two hosted agents on the same Foundry account) each imply the
+        // same role on the same target. A consumer referencing both must end up with a single role
+        // assignment for that role, otherwise two RoleAssignment bicep resources collide on the same
+        // identifier ("{prefix}_{roleName}") and bicep compilation fails.
+        var role = new HashSet<RoleDefinition> { new(StorageBuiltInRole.StorageBlobDataReader.ToString(), nameof(StorageBuiltInRole.StorageBlobDataReader)) };
+
+        var agent1 = builder.AddContainer("agent1", "img:latest").WithHttpEndpoint();
+        agent1.Resource.Annotations.Add(new ReferenceRoleAssignmentAnnotation(storage.Resource, role));
+
+        var agent2 = builder.AddContainer("agent2", "img:latest").WithHttpEndpoint();
+        agent2.Resource.Annotations.Add(new ReferenceRoleAssignmentAnnotation(storage.Resource, role));
+
+        var consumer = builder.AddProject<Project>("api", launchProfileName: null)
+            .WithReference(agent1.GetEndpoint("http"))
+            .WithReference(agent2.GetEndpoint("http"));
+
+        using var app = builder.Build();
+        var model = app.Services.GetRequiredService<DistributedApplicationModel>();
+        await ExecuteBeforeStartHooksAsync(app, default);
+
+        var roleAssignmentResource = Assert.Single(model.Resources.OfType<AzureRoleAssignmentResource>(), r => r.Name == "api-roles-storage");
+        Assert.Same(storage.Resource, roleAssignmentResource.TargetAzureResource);
+        Assert.Same(consumer.Resource, roleAssignmentResource.OwnerResource);
+
+        // The generated bicep must contain exactly one role assignment, not two duplicates of the same role.
+        var manifest = await GetManifestWithBicep(roleAssignmentResource, skipPreparer: true);
+        var roleAssignmentCount = System.Text.RegularExpressions.Regex.Matches(manifest.BicepText, "Microsoft.Authorization/roleAssignments@").Count;
+        Assert.Equal(1, roleAssignmentCount);
+    }
+
+    [Fact]
+    public async Task ReferenceRoleAssignmentAnnotation_ConsumerWithExplicitRoleAssignment_DoesNotReintroduceSuppressedDefaults()
+    {
+        using var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish);
+        builder.AddAzureContainerAppEnvironment("env");
+
+        var storage = builder.AddAzureStorage("storage");
+        var blobs = storage.AddBlobs("blobs");
+
+        // A fronting resource (e.g. a Foundry hosted agent's node app) implies the Reader role on storage.
+        var agent = builder.AddContainer("agent", "img:latest").WithHttpEndpoint();
+        agent.Resource.Annotations.Add(new ReferenceRoleAssignmentAnnotation(
+            storage.Resource,
+            new HashSet<RoleDefinition> { new(StorageBuiltInRole.StorageBlobDataReader.ToString(), nameof(StorageBuiltInRole.StorageBlobDataReader)) }));
+
+        // The consumer references storage directly (so its default role assignments would normally be
+        // applied) but declares an explicit WithRoleAssignments, which intentionally suppresses those
+        // defaults. The implied-reference hook must add only its Reader role and must NOT re-introduce the
+        // suppressed defaults - that was the "pit of failure" the union-of-defaults pattern would have caused.
+        var consumer = builder.AddProject<Project>("api", launchProfileName: null)
+            .WithRoleAssignments(storage, StorageBuiltInRole.StorageBlobDelegator)
+            .WithReference(blobs)
+            .WithReference(agent.GetEndpoint("http"));
+
+        using var app = builder.Build();
+        await ExecuteBeforeStartHooksAsync(app, default);
+
+        var roleIds = consumer.Resource.Annotations.OfType<RoleAssignmentAnnotation>()
+            .Where(a => a.Target == storage.Resource)
+            .SelectMany(a => a.Roles)
+            .Select(r => r.Id)
+            .ToHashSet();
+
+        // Explicit role + implied Reader are present.
+        Assert.Contains(StorageBuiltInRole.StorageBlobDelegator.ToString(), roleIds);
+        Assert.Contains(StorageBuiltInRole.StorageBlobDataReader.ToString(), roleIds);
+
+        // The suppressed defaults must not be re-introduced by the implied-reference hook.
+        Assert.DoesNotContain(StorageBuiltInRole.StorageBlobDataContributor.ToString(), roleIds);
+        Assert.DoesNotContain(StorageBuiltInRole.StorageTableDataContributor.ToString(), roleIds);
+        Assert.DoesNotContain(StorageBuiltInRole.StorageQueueDataContributor.ToString(), roleIds);
+    }
+
+    [Fact]
+    public async Task ReferenceRoleAssignmentAnnotation_ConsumerWithDirectReference_KeepsDefaultsAndAddsImpliedRole()
+    {
+        using var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish);
+        builder.AddAzureContainerAppEnvironment("env");
+
+        var storage = builder.AddAzureStorage("storage");
+        var blobs = storage.AddBlobs("blobs");
+
+        // A fronting resource (e.g. a Foundry hosted agent's node app) implies the Reader role on storage.
+        var agent = builder.AddContainer("agent", "img:latest").WithHttpEndpoint();
+        agent.Resource.Annotations.Add(new ReferenceRoleAssignmentAnnotation(
+            storage.Resource,
+            new HashSet<RoleDefinition> { new(StorageBuiltInRole.StorageBlobDataReader.ToString(), nameof(StorageBuiltInRole.StorageBlobDataReader)) }));
+
+        // The consumer references storage directly without declaring explicit role assignments, so the
+        // account defaults still apply. The implied-reference hook must add its Reader role alongside the
+        // defaults (the caller - the preparer - owns defaults; the hook never replaces or removes them).
+        var consumer = builder.AddProject<Project>("api", launchProfileName: null)
+            .WithReference(blobs)
+            .WithReference(agent.GetEndpoint("http"));
+
+        using var app = builder.Build();
+        await ExecuteBeforeStartHooksAsync(app, default);
+
+        var roleIds = consumer.Resource.Annotations.OfType<RoleAssignmentAnnotation>()
+            .Where(a => a.Target == storage.Resource)
+            .SelectMany(a => a.Roles)
+            .Select(r => r.Id)
+            .ToHashSet();
+
+        // Defaults are preserved by the preparer's normal reference walk.
+        Assert.Contains(StorageBuiltInRole.StorageBlobDataContributor.ToString(), roleIds);
+        Assert.Contains(StorageBuiltInRole.StorageTableDataContributor.ToString(), roleIds);
+        Assert.Contains(StorageBuiltInRole.StorageQueueDataContributor.ToString(), roleIds);
+
+        // The implied Reader role is added on top of the defaults.
+        Assert.Contains(StorageBuiltInRole.StorageBlobDataReader.ToString(), roleIds);
+    }
+
     private sealed class Project : IProjectMetadata
     {
         public string ProjectPath => "project";

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureAppServiceTests.EndpointReferenceToFoundryHostedAgentIsResolvedAcrossComputeEnvironments.verified.bicep
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureAppServiceTests.EndpointReferenceToFoundryHostedAgentIsResolvedAcrossComputeEnvironments.verified.bicep
@@ -62,15 +62,15 @@ resource webapp 'Microsoft.Web/sites@2025-03-01' = {
         }
         {
           name: 'AGENT_HTTP'
-          value: '${project_outputs_endpoint}/agents/agent'
+          value: '${project_outputs_endpoint}/agents/agent-ha'
         }
         {
           name: 'services__agent__http__0'
-          value: '${project_outputs_endpoint}/agents/agent'
+          value: '${project_outputs_endpoint}/agents/agent-ha'
         }
         {
           name: 'AGENT_URL'
-          value: '${project_outputs_endpoint}/agents/agent'
+          value: '${project_outputs_endpoint}/agents/agent-ha'
         }
         {
           name: 'ASPIRE_ENVIRONMENT_NAME'

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureAppServiceTests.EndpointReferenceToFoundryHostedAgentIsResolvedAcrossComputeEnvironments.verified.bicep
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureAppServiceTests.EndpointReferenceToFoundryHostedAgentIsResolvedAcrossComputeEnvironments.verified.bicep
@@ -15,6 +15,10 @@ param web_containerport string
 
 param project_outputs_endpoint string
 
+param web_identity_outputs_id string
+
+param web_identity_outputs_clientid string
+
 param env_outputs_azure_app_service_dashboard_uri string
 
 param env_outputs_azure_website_contributor_managed_identity_id string
@@ -38,6 +42,7 @@ resource webapp 'Microsoft.Web/sites@2025-03-01' = {
   location: location
   properties: {
     serverFarmId: env_outputs_planid
+    keyVaultReferenceIdentity: web_identity_outputs_id
     siteConfig: {
       numberOfWorkers: 30
       linuxFxVersion: 'SITECONTAINERS'
@@ -71,6 +76,14 @@ resource webapp 'Microsoft.Web/sites@2025-03-01' = {
         {
           name: 'AGENT_URL'
           value: '${project_outputs_endpoint}/agents/agent-ha'
+        }
+        {
+          name: 'AZURE_CLIENT_ID'
+          value: web_identity_outputs_clientid
+        }
+        {
+          name: 'AZURE_TOKEN_CREDENTIALS'
+          value: 'ManagedIdentityCredential'
         }
         {
           name: 'ASPIRE_ENVIRONMENT_NAME'
@@ -107,6 +120,7 @@ resource webapp 'Microsoft.Web/sites@2025-03-01' = {
     type: 'UserAssigned'
     userAssignedIdentities: {
       '${env_outputs_azure_container_registry_managed_identity_id}': { }
+      '${web_identity_outputs_id}': { }
     }
   }
 }

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureAppServiceTests.EndpointReferenceToFoundryHostedAgentIsResolvedAcrossComputeEnvironments.verified.bicep
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureAppServiceTests.EndpointReferenceToFoundryHostedAgentIsResolvedAcrossComputeEnvironments.verified.bicep
@@ -1,0 +1,134 @@
+﻿@description('The location for the resource(s) to be deployed.')
+param location string = resourceGroup().location
+
+param env_outputs_azure_container_registry_endpoint string
+
+param env_outputs_planid string
+
+param env_outputs_azure_container_registry_managed_identity_id string
+
+param env_outputs_azure_container_registry_managed_identity_client_id string
+
+param web_containerimage string
+
+param web_containerport string
+
+param project_outputs_endpoint string
+
+param env_outputs_azure_app_service_dashboard_uri string
+
+param env_outputs_azure_website_contributor_managed_identity_id string
+
+param env_outputs_azure_website_contributor_managed_identity_principal_id string
+
+resource mainContainer 'Microsoft.Web/sites/sitecontainers@2025-03-01' = {
+  name: 'main'
+  properties: {
+    authType: 'UserAssigned'
+    image: web_containerimage
+    isMain: true
+    targetPort: web_containerport
+    userManagedIdentityClientId: env_outputs_azure_container_registry_managed_identity_client_id
+  }
+  parent: webapp
+}
+
+resource webapp 'Microsoft.Web/sites@2025-03-01' = {
+  name: take('${toLower('web')}-${uniqueString(resourceGroup().id)}', 60)
+  location: location
+  properties: {
+    serverFarmId: env_outputs_planid
+    siteConfig: {
+      numberOfWorkers: 30
+      linuxFxVersion: 'SITECONTAINERS'
+      acrUseManagedIdentityCreds: true
+      acrUserManagedIdentityID: env_outputs_azure_container_registry_managed_identity_client_id
+      appSettings: [
+        {
+          name: 'WEBSITES_PORT'
+          value: web_containerport
+        }
+        {
+          name: 'OTEL_DOTNET_EXPERIMENTAL_OTLP_RETRY'
+          value: 'in_memory'
+        }
+        {
+          name: 'ASPNETCORE_FORWARDEDHEADERS_ENABLED'
+          value: 'true'
+        }
+        {
+          name: 'HTTP_PORTS'
+          value: web_containerport
+        }
+        {
+          name: 'AGENT_HTTP'
+          value: '${project_outputs_endpoint}/agents/agent'
+        }
+        {
+          name: 'services__agent__http__0'
+          value: '${project_outputs_endpoint}/agents/agent'
+        }
+        {
+          name: 'AGENT_URL'
+          value: '${project_outputs_endpoint}/agents/agent'
+        }
+        {
+          name: 'ASPIRE_ENVIRONMENT_NAME'
+          value: 'env'
+        }
+        {
+          name: 'OTEL_SERVICE_NAME'
+          value: 'web'
+        }
+        {
+          name: 'OTEL_EXPORTER_OTLP_PROTOCOL'
+          value: 'grpc'
+        }
+        {
+          name: 'OTEL_EXPORTER_OTLP_ENDPOINT'
+          value: 'http://localhost:6001'
+        }
+        {
+          name: 'WEBSITE_ENABLE_ASPIRE_OTEL_SIDECAR'
+          value: 'true'
+        }
+        {
+          name: 'OTEL_COLLECTOR_URL'
+          value: env_outputs_azure_app_service_dashboard_uri
+        }
+        {
+          name: 'OTEL_CLIENT_ID'
+          value: env_outputs_azure_container_registry_managed_identity_client_id
+        }
+      ]
+    }
+  }
+  identity: {
+    type: 'UserAssigned'
+    userAssignedIdentities: {
+      '${env_outputs_azure_container_registry_managed_identity_id}': { }
+    }
+  }
+}
+
+resource web_website_ra 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
+  name: guid(webapp.id, env_outputs_azure_website_contributor_managed_identity_id, subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'de139f84-1756-47ae-9be6-808fbbe84772'))
+  properties: {
+    principalId: env_outputs_azure_website_contributor_managed_identity_principal_id
+    roleDefinitionId: subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'de139f84-1756-47ae-9be6-808fbbe84772')
+    principalType: 'ServicePrincipal'
+  }
+  scope: webapp
+}
+
+resource slotConfigNames 'Microsoft.Web/sites/config@2025-03-01' = {
+  name: 'slotConfigNames'
+  properties: {
+    appSettingNames: [
+      'AGENT_HTTP'
+      'services__agent__http__0'
+      'OTEL_SERVICE_NAME'
+    ]
+  }
+  parent: webapp
+}

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureAppServiceTests.EndpointReferenceToFoundryHostedAgentIsResolvedAcrossComputeEnvironments.verified.json
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureAppServiceTests.EndpointReferenceToFoundryHostedAgentIsResolvedAcrossComputeEnvironments.verified.json
@@ -9,6 +9,8 @@
     "web_containerimage": "{web.containerImage}",
     "web_containerport": "{web.containerPort}",
     "project_outputs_endpoint": "{project.outputs.endpoint}",
+    "web_identity_outputs_id": "{web-identity.outputs.id}",
+    "web_identity_outputs_clientid": "{web-identity.outputs.clientId}",
     "env_outputs_azure_app_service_dashboard_uri": "{env.outputs.AZURE_APP_SERVICE_DASHBOARD_URI}",
     "env_outputs_azure_website_contributor_managed_identity_id": "{env.outputs.AZURE_WEBSITE_CONTRIBUTOR_MANAGED_IDENTITY_ID}",
     "env_outputs_azure_website_contributor_managed_identity_principal_id": "{env.outputs.AZURE_WEBSITE_CONTRIBUTOR_MANAGED_IDENTITY_PRINCIPAL_ID}"

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureAppServiceTests.EndpointReferenceToFoundryHostedAgentIsResolvedAcrossComputeEnvironments.verified.json
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureAppServiceTests.EndpointReferenceToFoundryHostedAgentIsResolvedAcrossComputeEnvironments.verified.json
@@ -1,0 +1,16 @@
+﻿{
+  "type": "azure.bicep.v0",
+  "path": "web-website.module.bicep",
+  "params": {
+    "env_outputs_azure_container_registry_endpoint": "{env.outputs.AZURE_CONTAINER_REGISTRY_ENDPOINT}",
+    "env_outputs_planid": "{env.outputs.planId}",
+    "env_outputs_azure_container_registry_managed_identity_id": "{env.outputs.AZURE_CONTAINER_REGISTRY_MANAGED_IDENTITY_ID}",
+    "env_outputs_azure_container_registry_managed_identity_client_id": "{env.outputs.AZURE_CONTAINER_REGISTRY_MANAGED_IDENTITY_CLIENT_ID}",
+    "web_containerimage": "{web.containerImage}",
+    "web_containerport": "{web.containerPort}",
+    "project_outputs_endpoint": "{project.outputs.endpoint}",
+    "env_outputs_azure_app_service_dashboard_uri": "{env.outputs.AZURE_APP_SERVICE_DASHBOARD_URI}",
+    "env_outputs_azure_website_contributor_managed_identity_id": "{env.outputs.AZURE_WEBSITE_CONTRIBUTOR_MANAGED_IDENTITY_ID}",
+    "env_outputs_azure_website_contributor_managed_identity_principal_id": "{env.outputs.AZURE_WEBSITE_CONTRIBUTOR_MANAGED_IDENTITY_PRINCIPAL_ID}"
+  }
+}

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureContainerAppsTests.EndpointReferenceToFoundryHostedAgentIsResolvedAcrossComputeEnvironments.verified.bicep
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureContainerAppsTests.EndpointReferenceToFoundryHostedAgentIsResolvedAcrossComputeEnvironments.verified.bicep
@@ -59,15 +59,15 @@ resource web 'Microsoft.App/containerApps@2025-10-02-preview' = {
             }
             {
               name: 'AGENT_HTTP'
-              value: '${project_outputs_endpoint}/agents/agent'
+              value: '${project_outputs_endpoint}/agents/agent-ha'
             }
             {
               name: 'services__agent__http__0'
-              value: '${project_outputs_endpoint}/agents/agent'
+              value: '${project_outputs_endpoint}/agents/agent-ha'
             }
             {
               name: 'AGENT_URL'
-              value: '${project_outputs_endpoint}/agents/agent'
+              value: '${project_outputs_endpoint}/agents/agent-ha'
             }
           ]
         }

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureContainerAppsTests.EndpointReferenceToFoundryHostedAgentIsResolvedAcrossComputeEnvironments.verified.bicep
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureContainerAppsTests.EndpointReferenceToFoundryHostedAgentIsResolvedAcrossComputeEnvironments.verified.bicep
@@ -1,0 +1,86 @@
+﻿@description('The location for the resource(s) to be deployed.')
+param location string = resourceGroup().location
+
+param env_outputs_azure_container_apps_environment_default_domain string
+
+param env_outputs_azure_container_apps_environment_id string
+
+param env_outputs_azure_container_registry_endpoint string
+
+param env_outputs_azure_container_registry_managed_identity_id string
+
+param web_containerimage string
+
+param web_containerport string
+
+param project_outputs_endpoint string
+
+resource web 'Microsoft.App/containerApps@2025-10-02-preview' = {
+  name: 'web'
+  location: location
+  properties: {
+    configuration: {
+      activeRevisionsMode: 'Single'
+      ingress: {
+        external: true
+        targetPort: int(web_containerport)
+        transport: 'http'
+      }
+      registries: [
+        {
+          server: env_outputs_azure_container_registry_endpoint
+          identity: env_outputs_azure_container_registry_managed_identity_id
+        }
+      ]
+      runtime: {
+        dotnet: {
+          autoConfigureDataProtection: true
+        }
+      }
+    }
+    environmentId: env_outputs_azure_container_apps_environment_id
+    template: {
+      containers: [
+        {
+          image: web_containerimage
+          name: 'web'
+          env: [
+            {
+              name: 'OTEL_DOTNET_EXPERIMENTAL_OTLP_RETRY'
+              value: 'in_memory'
+            }
+            {
+              name: 'ASPNETCORE_FORWARDEDHEADERS_ENABLED'
+              value: 'true'
+            }
+            {
+              name: 'HTTP_PORTS'
+              value: web_containerport
+            }
+            {
+              name: 'AGENT_HTTP'
+              value: '${project_outputs_endpoint}/agents/agent'
+            }
+            {
+              name: 'services__agent__http__0'
+              value: '${project_outputs_endpoint}/agents/agent'
+            }
+            {
+              name: 'AGENT_URL'
+              value: '${project_outputs_endpoint}/agents/agent'
+            }
+          ]
+        }
+      ]
+      scale: {
+        minReplicas: 1
+      }
+    }
+  }
+  identity: {
+    type: 'UserAssigned'
+    userAssignedIdentities: {
+      '${env_outputs_azure_container_registry_managed_identity_id}': { }
+    }
+  }
+}

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureContainerAppsTests.EndpointReferenceToFoundryHostedAgentIsResolvedAcrossComputeEnvironments.verified.bicep
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureContainerAppsTests.EndpointReferenceToFoundryHostedAgentIsResolvedAcrossComputeEnvironments.verified.bicep
@@ -11,9 +11,13 @@ param env_outputs_azure_container_registry_managed_identity_id string
 
 param web_containerimage string
 
+param web_identity_outputs_id string
+
 param web_containerport string
 
 param project_outputs_endpoint string
+
+param web_identity_outputs_clientid string
 
 resource web 'Microsoft.App/containerApps@2025-10-02-preview' = {
   name: 'web'
@@ -69,6 +73,14 @@ resource web 'Microsoft.App/containerApps@2025-10-02-preview' = {
               name: 'AGENT_URL'
               value: '${project_outputs_endpoint}/agents/agent-ha'
             }
+            {
+              name: 'AZURE_CLIENT_ID'
+              value: web_identity_outputs_clientid
+            }
+            {
+              name: 'AZURE_TOKEN_CREDENTIALS'
+              value: 'ManagedIdentityCredential'
+            }
           ]
         }
       ]
@@ -80,6 +92,7 @@ resource web 'Microsoft.App/containerApps@2025-10-02-preview' = {
   identity: {
     type: 'UserAssigned'
     userAssignedIdentities: {
+      '${web_identity_outputs_id}': { }
       '${env_outputs_azure_container_registry_managed_identity_id}': { }
     }
   }

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureContainerAppsTests.EndpointReferenceToFoundryHostedAgentIsResolvedAcrossComputeEnvironments.verified.json
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureContainerAppsTests.EndpointReferenceToFoundryHostedAgentIsResolvedAcrossComputeEnvironments.verified.json
@@ -1,0 +1,13 @@
+﻿{
+  "type": "azure.bicep.v0",
+  "path": "web-containerapp.module.bicep",
+  "params": {
+    "env_outputs_azure_container_apps_environment_default_domain": "{env.outputs.AZURE_CONTAINER_APPS_ENVIRONMENT_DEFAULT_DOMAIN}",
+    "env_outputs_azure_container_apps_environment_id": "{env.outputs.AZURE_CONTAINER_APPS_ENVIRONMENT_ID}",
+    "env_outputs_azure_container_registry_endpoint": "{env.outputs.AZURE_CONTAINER_REGISTRY_ENDPOINT}",
+    "env_outputs_azure_container_registry_managed_identity_id": "{env.outputs.AZURE_CONTAINER_REGISTRY_MANAGED_IDENTITY_ID}",
+    "web_containerimage": "{web.containerImage}",
+    "web_containerport": "{web.containerPort}",
+    "project_outputs_endpoint": "{project.outputs.endpoint}"
+  }
+}

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureContainerAppsTests.EndpointReferenceToFoundryHostedAgentIsResolvedAcrossComputeEnvironments.verified.json
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureContainerAppsTests.EndpointReferenceToFoundryHostedAgentIsResolvedAcrossComputeEnvironments.verified.json
@@ -7,7 +7,9 @@
     "env_outputs_azure_container_registry_endpoint": "{env.outputs.AZURE_CONTAINER_REGISTRY_ENDPOINT}",
     "env_outputs_azure_container_registry_managed_identity_id": "{env.outputs.AZURE_CONTAINER_REGISTRY_MANAGED_IDENTITY_ID}",
     "web_containerimage": "{web.containerImage}",
+    "web_identity_outputs_id": "{web-identity.outputs.id}",
     "web_containerport": "{web.containerPort}",
-    "project_outputs_endpoint": "{project.outputs.endpoint}"
+    "project_outputs_endpoint": "{project.outputs.endpoint}",
+    "web_identity_outputs_clientid": "{web-identity.outputs.clientId}"
   }
 }

--- a/tests/Aspire.Hosting.Foundry.Tests/HostedAgentExtensionTests.cs
+++ b/tests/Aspire.Hosting.Foundry.Tests/HostedAgentExtensionTests.cs
@@ -5,6 +5,7 @@
 
 using System.Runtime.CompilerServices;
 using Aspire.Hosting.ApplicationModel;
+using Aspire.Hosting.Azure;
 using Aspire.Hosting.Tests.Utils;
 using Aspire.Hosting.Utils;
 using Azure.AI.Projects.Agents;
@@ -446,6 +447,88 @@ public class HostedAgentExtensionTests
 
     [UnsafeAccessor(UnsafeAccessorKind.Method, Name = "ExecuteBeforeStartHooksAsync")]
     private static extern Task ExecuteBeforeStartHooksAsync(DistributedApplication app, CancellationToken cancellationToken);
+
+    [Fact]
+    public void AsHostedAgent_StampsReferenceRoleAssignmentAnnotationOnTarget_WithAzureAIUserRole()
+    {
+        using var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish);
+        var project = builder.AddFoundry("account")
+            .AddProject("my-project");
+
+        builder.AddPythonApp("agent", "./app.py", "main:app")
+            .AsHostedAgent(project);
+
+        var hostedAgent = Assert.Single(builder.Resources.OfType<AzureHostedAgentResource>());
+        var account = Assert.Single(builder.Resources.OfType<FoundryResource>());
+
+#pragma warning disable ASPIREAZURE003 // Type is for evaluation purposes only and is subject to change or removal in future updates.
+        var annotation = Assert.Single(hostedAgent.Target.Annotations.OfType<ReferenceRoleAssignmentAnnotation>());
+        Assert.Same(account, annotation.Target);
+        Assert.Contains(annotation.Roles, role =>
+            string.Equals(role.Id, AzureHostedAgentResource.AzureAIUserRoleDefinitionId, StringComparison.OrdinalIgnoreCase));
+#pragma warning restore ASPIREAZURE003
+    }
+
+    [Fact]
+    public void AsHostedAgent_ReferenceRoleAssignmentAnnotation_GrantsOnlyAzureAIUserRole()
+    {
+        using var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish);
+        var project = builder.AddFoundry("account")
+            .AddProject("my-project");
+
+        builder.AddPythonApp("agent", "./app.py", "main:app")
+            .AsHostedAgent(project);
+
+        var hostedAgent = Assert.Single(builder.Resources.OfType<AzureHostedAgentResource>());
+        var account = Assert.Single(builder.Resources.OfType<FoundryResource>());
+        Assert.True(account.TryGetLastAnnotation<DefaultRoleAssignmentsAnnotation>(out var defaults));
+
+#pragma warning disable ASPIREAZURE003 // Type is for evaluation purposes only and is subject to change or removal in future updates.
+        var annotation = Assert.Single(hostedAgent.Target.Annotations.OfType<ReferenceRoleAssignmentAnnotation>());
+
+        // The implied grant is least-privilege: only "Azure AI User" is required to invoke the agent.
+        var role = Assert.Single(annotation.Roles);
+        Assert.Equal(AzureHostedAgentResource.AzureAIUserRoleDefinitionId, role.Id, ignoreCase: true);
+
+        // The account's default data-plane roles must NOT be folded in here. A consumer that references
+        // the account directly still receives them via the preparer's normal walk, and a consumer that
+        // explicitly suppresses them must keep them suppressed.
+        foreach (var defaultRole in defaults.Roles)
+        {
+            Assert.DoesNotContain(annotation.Roles, r => string.Equals(r.Id, defaultRole.Id, StringComparison.OrdinalIgnoreCase));
+        }
+#pragma warning restore ASPIREAZURE003
+    }
+
+    [Fact]
+    public void AsHostedAgent_MultipleHostedAgents_EachTargetCarriesItsOwnReferenceRoleAssignment()
+    {
+        using var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish);
+        var project = builder.AddFoundry("account")
+            .AddProject("my-project");
+        var otherProject = builder.AddFoundry("account2")
+            .AddProject("other-project");
+
+        builder.AddPythonApp("agent", "./app.py", "main:app")
+            .AsHostedAgent(project);
+        builder.AddPythonApp("agent2", "./app.py", "main:app")
+            .AsHostedAgent(otherProject);
+
+        var hostedAgents = builder.Resources.OfType<AzureHostedAgentResource>().ToList();
+        Assert.Equal(2, hostedAgents.Count);
+
+        var account = Assert.Single(builder.Resources.OfType<FoundryResource>(), r => r.Name == "account");
+        var account2 = Assert.Single(builder.Resources.OfType<FoundryResource>(), r => r.Name == "account2");
+
+#pragma warning disable ASPIREAZURE003 // Type is for evaluation purposes only and is subject to change or removal in future updates.
+        var targets = hostedAgents
+            .Select(a => Assert.Single(a.Target.Annotations.OfType<ReferenceRoleAssignmentAnnotation>()).Target)
+            .ToList();
+
+        Assert.Contains(account, targets);
+        Assert.Contains(account2, targets);
+#pragma warning restore ASPIREAZURE003
+    }
 
     private sealed class Project : IProjectMetadata
     {

--- a/tests/Aspire.Hosting.Tests/Aspire.Hosting.Tests.csproj
+++ b/tests/Aspire.Hosting.Tests/Aspire.Hosting.Tests.csproj
@@ -48,6 +48,7 @@
     <Compile Include="$(TestsSharedDir)Logging\*.cs" LinkBase="shared/Logging" />
     <Compile Include="$(TestsSharedDir)ConsoleLogging\*.cs" LinkBase="shared" />
     <Compile Include="$(TestsSharedDir)AsyncTestHelpers.cs" Link="shared/AsyncTestHelpers.cs" />
+    <Compile Include="$(SharedDir)ComputeEnvironmentEndpointResolver.cs" LinkBase="shared/ComputeEnvironmentEndpointResolver.cs" />
     <Compile Include="$(TestsSharedDir)TempDirectory.cs" Link="shared/TempDirectory.cs" />
     <Compile Include="$(TestsSharedDir)TestInteractionService.cs" LinkBase="shared" />
     <Compile Include="$(TestsSharedDir)TestPipelineActivityReporter.cs" Link="shared/TestPipelineActivityReporter.cs" />

--- a/tests/Aspire.Hosting.Tests/ComputeEnvironmentEndpointResolverTests.cs
+++ b/tests/Aspire.Hosting.Tests/ComputeEnvironmentEndpointResolverTests.cs
@@ -30,6 +30,26 @@ public class ComputeEnvironmentEndpointResolverTests
     }
 
     [Fact]
+    public async Task EndpointReferenceOverload_DelegatesToOwningEnvironment()
+    {
+        using var builder = TestDistributedApplicationBuilder.Create();
+
+        var currentEnv = builder.AddResource(new TestComputeEnvironmentResource("current"));
+        var owningEnv = builder.AddResource(new TestComputeEnvironmentResource("owning"));
+        var agent = builder.AddResource(new TestComputeResource("agent"));
+        var endpoint = AddHttpEndpoint(agent.Resource, port: 8080, targetPort: 5000);
+        agent.Resource.Annotations.Add(new DeploymentTargetAnnotation(owningEnv.Resource) { ComputeEnvironment = owningEnv.Resource });
+
+        // The EndpointReference overload uses EndpointProperty.Url internally.
+        var resolved = ComputeEnvironmentEndpointResolver.TryGetCrossEnvironmentEndpointExpression(
+            endpoint, [currentEnv.Resource], out var expression);
+
+        Assert.True(resolved);
+        Assert.NotNull(expression);
+        Assert.Equal("http://agent.example.com:8080", await expression.GetValueAsync(default).DefaultTimeout());
+    }
+
+    [Fact]
     public void OwningResourceDeploysToCurrentEnvironment_ReturnsFalse()
     {
         using var builder = TestDistributedApplicationBuilder.Create();

--- a/tests/Aspire.Hosting.Tests/ComputeEnvironmentEndpointResolverTests.cs
+++ b/tests/Aspire.Hosting.Tests/ComputeEnvironmentEndpointResolverTests.cs
@@ -1,0 +1,149 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Net.Sockets;
+using Aspire.Hosting.Utils;
+using Microsoft.AspNetCore.InternalTesting;
+
+namespace Aspire.Hosting.Tests;
+
+public class ComputeEnvironmentEndpointResolverTests
+{
+    [Fact]
+    public async Task OwningResourceInDifferentEnvironment_DelegatesToOwningEnvironment()
+    {
+        using var builder = TestDistributedApplicationBuilder.Create();
+
+        var currentEnv = builder.AddResource(new TestComputeEnvironmentResource("current"));
+        var owningEnv = builder.AddResource(new TestComputeEnvironmentResource("owning"));
+        var agent = builder.AddResource(new TestComputeResource("agent"));
+        var endpoint = AddHttpEndpoint(agent.Resource, port: 8080, targetPort: 5000);
+        agent.Resource.Annotations.Add(new DeploymentTargetAnnotation(owningEnv.Resource) { ComputeEnvironment = owningEnv.Resource });
+
+        var resolved = ComputeEnvironmentEndpointResolver.TryGetCrossEnvironmentEndpointExpression(
+            endpoint.Property(EndpointProperty.Url), out var expression, currentEnv.Resource);
+
+        Assert.True(resolved);
+        Assert.NotNull(expression);
+        // The owning environment (TestComputeEnvironmentResource) maps the host to "{name}.example.com".
+        Assert.Equal("http://agent.example.com:8080", await expression.GetValueAsync(default).DefaultTimeout());
+    }
+
+    [Fact]
+    public void OwningResourceDeploysToCurrentEnvironment_ReturnsFalse()
+    {
+        using var builder = TestDistributedApplicationBuilder.Create();
+
+        var currentEnv = builder.AddResource(new TestComputeEnvironmentResource("current"));
+        var agent = builder.AddResource(new TestComputeResource("agent"));
+        var endpoint = AddHttpEndpoint(agent.Resource, port: 8080, targetPort: 5000);
+        agent.Resource.Annotations.Add(new DeploymentTargetAnnotation(currentEnv.Resource) { ComputeEnvironment = currentEnv.Resource });
+
+        var resolved = ComputeEnvironmentEndpointResolver.TryGetCrossEnvironmentEndpointExpression(
+            endpoint.Property(EndpointProperty.Url), out var expression, currentEnv.Resource);
+
+        Assert.False(resolved);
+        Assert.Null(expression);
+    }
+
+    [Fact]
+    public void OwningResourceBoundToCurrentEnvironmentWithoutDeploymentTarget_ReturnsFalseViaBackstop()
+    {
+        using var builder = TestDistributedApplicationBuilder.Create();
+
+        var currentEnv = builder.AddResource(new TestComputeEnvironmentResource("current"));
+        // Bind via WithComputeEnvironment only (no DeploymentTargetAnnotation). The fast-path loop
+        // falls through and the ReferenceEquals backstop catches it after the effective environment
+        // resolves to the current environment.
+        var agent = builder.AddResource(new TestComputeResource("agent"))
+            .WithComputeEnvironment(currentEnv);
+        var endpoint = AddHttpEndpoint(agent.Resource, port: 8080, targetPort: 5000);
+
+        var resolved = ComputeEnvironmentEndpointResolver.TryGetCrossEnvironmentEndpointExpression(
+            endpoint.Property(EndpointProperty.Url), out var expression, currentEnv.Resource);
+
+        Assert.False(resolved);
+        Assert.Null(expression);
+    }
+
+    [Fact]
+    public void OwningResourceHasNoComputeEnvironment_ReturnsFalse()
+    {
+        using var builder = TestDistributedApplicationBuilder.Create();
+
+        var currentEnv = builder.AddResource(new TestComputeEnvironmentResource("current"));
+        // No binding and no deployment target: nothing to delegate to.
+        var agent = builder.AddResource(new TestComputeResource("agent"));
+        var endpoint = AddHttpEndpoint(agent.Resource, port: 8080, targetPort: 5000);
+
+        var resolved = ComputeEnvironmentEndpointResolver.TryGetCrossEnvironmentEndpointExpression(
+            endpoint.Property(EndpointProperty.Url), out var expression, currentEnv.Resource);
+
+        Assert.False(resolved);
+        Assert.Null(expression);
+    }
+
+    [Fact]
+    public void OwningResourceBoundToCurrentEnvironmentWithMultipleDeploymentTargets_ReturnsFalseAndDoesNotThrow()
+    {
+        using var builder = TestDistributedApplicationBuilder.Create();
+
+        var currentEnv = builder.AddResource(new TestComputeEnvironmentResource("current"));
+        var otherEnv = builder.AddResource(new TestComputeEnvironmentResource("other"));
+        // Explicit binding to the current environment plus deployment targets for both environments.
+        // The binding makes GetDeploymentTargetAnnotation(current) select the current target without
+        // throwing on the multi-target ambiguity.
+        var agent = builder.AddResource(new TestComputeResource("agent"))
+            .WithComputeEnvironment(currentEnv);
+        agent.Resource.Annotations.Add(new DeploymentTargetAnnotation(currentEnv.Resource) { ComputeEnvironment = currentEnv.Resource });
+        agent.Resource.Annotations.Add(new DeploymentTargetAnnotation(otherEnv.Resource) { ComputeEnvironment = otherEnv.Resource });
+        var endpoint = AddHttpEndpoint(agent.Resource, port: 8080, targetPort: 5000);
+
+        var resolved = ComputeEnvironmentEndpointResolver.TryGetCrossEnvironmentEndpointExpression(
+            endpoint.Property(EndpointProperty.Url), out var expression, currentEnv.Resource);
+
+        Assert.False(resolved);
+        Assert.Null(expression);
+    }
+
+    [Fact]
+    public void OwningResourceUnboundWithMultipleDeploymentTargets_Throws()
+    {
+        using var builder = TestDistributedApplicationBuilder.Create();
+
+        var currentEnv = builder.AddResource(new TestComputeEnvironmentResource("current"));
+        var otherEnv = builder.AddResource(new TestComputeEnvironmentResource("other"));
+        // No binding: an unbound resource with more than one deployment target is ambiguous.
+        // GetDeploymentTargetAnnotation(current) throws, exactly like the parameterless overload used
+        // by TryGetEffectiveComputeEnvironment. This documents that the fast-path loop is NOT a guard
+        // against this throw; the pipeline rejects this configuration earlier in practice.
+        var agent = builder.AddResource(new TestComputeResource("agent"));
+        agent.Resource.Annotations.Add(new DeploymentTargetAnnotation(currentEnv.Resource) { ComputeEnvironment = currentEnv.Resource });
+        agent.Resource.Annotations.Add(new DeploymentTargetAnnotation(otherEnv.Resource) { ComputeEnvironment = otherEnv.Resource });
+        var endpoint = AddHttpEndpoint(agent.Resource, port: 8080, targetPort: 5000);
+
+        Assert.Throws<InvalidOperationException>(() =>
+            ComputeEnvironmentEndpointResolver.TryGetCrossEnvironmentEndpointExpression(
+                endpoint.Property(EndpointProperty.Url), out _, currentEnv.Resource));
+    }
+
+    private static EndpointReference AddHttpEndpoint(TestComputeResource resource, int? port, int? targetPort)
+    {
+        var endpoint = new EndpointAnnotation(ProtocolType.Tcp, uriScheme: "http", name: "http", port: port, targetPort: targetPort);
+        resource.Annotations.Add(endpoint);
+
+        return new EndpointReference(resource, endpoint);
+    }
+
+    private sealed class TestComputeEnvironmentResource(string name) : Resource(name), IComputeEnvironmentResource
+    {
+#pragma warning disable ASPIRECOMPUTE002
+        public ReferenceExpression GetHostAddressExpression(EndpointReference endpointReference) =>
+            ReferenceExpression.Create($"{endpointReference.Resource.Name}.example.com");
+#pragma warning restore ASPIRECOMPUTE002
+    }
+
+    private sealed class TestComputeResource(string name) : Resource(name), IComputeResource, IResourceWithEndpoints
+    {
+    }
+}

--- a/tests/Aspire.Hosting.Tests/ComputeEnvironmentEndpointResolverTests.cs
+++ b/tests/Aspire.Hosting.Tests/ComputeEnvironmentEndpointResolverTests.cs
@@ -52,9 +52,8 @@ public class ComputeEnvironmentEndpointResolverTests
         using var builder = TestDistributedApplicationBuilder.Create();
 
         var currentEnv = builder.AddResource(new TestComputeEnvironmentResource("current"));
-        // Bind via WithComputeEnvironment only (no DeploymentTargetAnnotation). The fast-path loop
-        // falls through and the ReferenceEquals backstop catches it after the effective environment
-        // resolves to the current environment.
+        // Bind via WithComputeEnvironment only (no DeploymentTargetAnnotation). The effective
+        // environment resolves to the current environment and the ReferenceEquals backstop catches it.
         var agent = builder.AddResource(new TestComputeResource("agent"))
             .WithComputeEnvironment(currentEnv);
         var endpoint = AddHttpEndpoint(agent.Resource, port: 8080, targetPort: 5000);
@@ -91,8 +90,8 @@ public class ComputeEnvironmentEndpointResolverTests
         var currentEnv = builder.AddResource(new TestComputeEnvironmentResource("current"));
         var otherEnv = builder.AddResource(new TestComputeEnvironmentResource("other"));
         // Explicit binding to the current environment plus deployment targets for both environments.
-        // The binding makes GetDeploymentTargetAnnotation(current) select the current target without
-        // throwing on the multi-target ambiguity.
+        // The binding lets GetComputeEnvironment() short-circuit to the current environment without
+        // hitting the parameterless deployment-target resolver that throws on multi-target ambiguity.
         var agent = builder.AddResource(new TestComputeResource("agent"))
             .WithComputeEnvironment(currentEnv);
         agent.Resource.Annotations.Add(new DeploymentTargetAnnotation(currentEnv.Resource) { ComputeEnvironment = currentEnv.Resource });
@@ -114,9 +113,9 @@ public class ComputeEnvironmentEndpointResolverTests
         var currentEnv = builder.AddResource(new TestComputeEnvironmentResource("current"));
         var otherEnv = builder.AddResource(new TestComputeEnvironmentResource("other"));
         // No binding: an unbound resource with more than one deployment target is ambiguous.
-        // GetDeploymentTargetAnnotation(current) throws, exactly like the parameterless overload used
-        // by TryGetEffectiveComputeEnvironment. This documents that the fast-path loop is NOT a guard
-        // against this throw; the pipeline rejects this configuration earlier in practice.
+        // TryGetEffectiveComputeEnvironment falls back to the parameterless GetDeploymentTargetAnnotation()
+        // which throws. This documents that the resolver does not swallow that ambiguity; the pipeline
+        // rejects this configuration earlier in practice.
         var agent = builder.AddResource(new TestComputeResource("agent"));
         agent.Resource.Annotations.Add(new DeploymentTargetAnnotation(currentEnv.Resource) { ComputeEnvironment = currentEnv.Resource });
         agent.Resource.Annotations.Add(new DeploymentTargetAnnotation(otherEnv.Resource) { ComputeEnvironment = otherEnv.Resource });

--- a/tests/Aspire.Hosting.Tests/ComputeEnvironmentEndpointResolverTests.cs
+++ b/tests/Aspire.Hosting.Tests/ComputeEnvironmentEndpointResolverTests.cs
@@ -21,7 +21,7 @@ public class ComputeEnvironmentEndpointResolverTests
         agent.Resource.Annotations.Add(new DeploymentTargetAnnotation(owningEnv.Resource) { ComputeEnvironment = owningEnv.Resource });
 
         var resolved = ComputeEnvironmentEndpointResolver.TryGetCrossEnvironmentEndpointExpression(
-            endpoint.Property(EndpointProperty.Url), out var expression, currentEnv.Resource);
+            endpoint.Property(EndpointProperty.Url), [currentEnv.Resource], out var expression);
 
         Assert.True(resolved);
         Assert.NotNull(expression);
@@ -40,7 +40,7 @@ public class ComputeEnvironmentEndpointResolverTests
         agent.Resource.Annotations.Add(new DeploymentTargetAnnotation(currentEnv.Resource) { ComputeEnvironment = currentEnv.Resource });
 
         var resolved = ComputeEnvironmentEndpointResolver.TryGetCrossEnvironmentEndpointExpression(
-            endpoint.Property(EndpointProperty.Url), out var expression, currentEnv.Resource);
+            endpoint.Property(EndpointProperty.Url), [currentEnv.Resource], out var expression);
 
         Assert.False(resolved);
         Assert.Null(expression);
@@ -59,7 +59,7 @@ public class ComputeEnvironmentEndpointResolverTests
         var endpoint = AddHttpEndpoint(agent.Resource, port: 8080, targetPort: 5000);
 
         var resolved = ComputeEnvironmentEndpointResolver.TryGetCrossEnvironmentEndpointExpression(
-            endpoint.Property(EndpointProperty.Url), out var expression, currentEnv.Resource);
+            endpoint.Property(EndpointProperty.Url), [currentEnv.Resource], out var expression);
 
         Assert.False(resolved);
         Assert.Null(expression);
@@ -76,7 +76,7 @@ public class ComputeEnvironmentEndpointResolverTests
         var endpoint = AddHttpEndpoint(agent.Resource, port: 8080, targetPort: 5000);
 
         var resolved = ComputeEnvironmentEndpointResolver.TryGetCrossEnvironmentEndpointExpression(
-            endpoint.Property(EndpointProperty.Url), out var expression, currentEnv.Resource);
+            endpoint.Property(EndpointProperty.Url), [currentEnv.Resource], out var expression);
 
         Assert.False(resolved);
         Assert.Null(expression);
@@ -99,7 +99,7 @@ public class ComputeEnvironmentEndpointResolverTests
         var endpoint = AddHttpEndpoint(agent.Resource, port: 8080, targetPort: 5000);
 
         var resolved = ComputeEnvironmentEndpointResolver.TryGetCrossEnvironmentEndpointExpression(
-            endpoint.Property(EndpointProperty.Url), out var expression, currentEnv.Resource);
+            endpoint.Property(EndpointProperty.Url), [currentEnv.Resource], out var expression);
 
         Assert.False(resolved);
         Assert.Null(expression);
@@ -123,7 +123,7 @@ public class ComputeEnvironmentEndpointResolverTests
 
         Assert.Throws<InvalidOperationException>(() =>
             ComputeEnvironmentEndpointResolver.TryGetCrossEnvironmentEndpointExpression(
-                endpoint.Property(EndpointProperty.Url), out _, currentEnv.Resource));
+                endpoint.Property(EndpointProperty.Url), [currentEnv.Resource], out _));
     }
 
     private static EndpointReference AddHttpEndpoint(TestComputeResource resource, int? port, int? targetPort)


### PR DESCRIPTION
## Description

This PR fixes two related gaps that surface when a Foundry **hosted agent** is referenced from a resource deployed to a *different* compute environment (#17749). Each is independently useful, but together they make the reported scenario deploy and run end-to-end with no manual steps.

### 1. Cross-compute-environment endpoint resolution

`aspire deploy` failed when a resource referenced (via `WithReference()`) an endpoint whose **owning resource was deployed to a different compute environment**. Each publisher resolved endpoint references against its **local** endpoint map, which doesn't contain a resource owned by another environment, so resolution threw a "context not found" error and deployment broke.

This isn't specific to one resource type or one environment. The bug affected cross-environment endpoint references in general — across the **Azure Container Apps (ACA)**, **Azure App Service**, and **Kubernetes (AKS)** publishers — and the referenced resource can be any resource with endpoints (a Foundry hosted agent referenced from a different environment was just the originally reported repro from #17749).

This change teaches the publishers to detect when a referenced endpoint's owning resource lives in a *different* compute environment and to delegate endpoint resolution to that owning environment instead of failing against the local map. Same-environment references are unaffected and continue to resolve locally, so existing generated artifacts (bicep/manifests) stay byte-for-byte unchanged.

The fix is entirely publisher-side: it runs at publish/deploy time against the already-resolved application model, so it applies regardless of how the cross-environment reference was introduced into the model. Resolution is implemented in C#, but because it operates on the resolved model it applies equally to **C# and TypeScript AppHosts** — a TypeScript AppHost that wires the same cross-environment reference benefits from the fix without any TypeScript-side changes.

The shared logic lives in a new internal helper, `ComputeEnvironmentEndpointResolver`, which the ACA, App Service, and Kubernetes publishers now call. The Foundry hosted agent resource and the previously bespoke Azure Front Door cross-environment handling were refactored onto the same helper so there is a single resolution path.

### 2. RBAC auto-wiring for hosted-agent consumers

Even after endpoint resolution succeeded, the deployed consumer could not actually **call** the hosted agent: invoking a Foundry hosted agent requires the caller to authenticate with a managed identity that holds the **Azure AI User** role on the owning Foundry account. Previously the app model emitted neither the identity nor the role assignment for a consumer that only referenced the agent's node app, so the developer had to run two manual `az role assignment create` / identity steps after every deploy.

The blocker is structural: `AzureResourcePreparer` discovers role targets by walking a resource's **direct** dependencies and acting on the ones that are themselves `IAzureResource`. A consumer that references a hosted agent references the agent's **node app** (a plain compute resource), and the owning Foundry account is only a *transitive* dependency behind it — so the preparer's walk never reaches the account and no identity/role is wired.

This PR closes that gap with a small, sanctioned hook rather than bespoke per-resource logic:

- A new **public experimental** annotation, `ReferenceRoleAssignmentAnnotation` (`[Experimental("ASPIREAZURE003")]`), expresses "*this resource implies these roles on that Azure resource*". It is the redirect that the dependency walk cannot derive on its own.
- `AzureResourcePreparer` now honors that annotation as a first-class input alongside the existing `RoleAssignmentAnnotation` path (RunMode → global role assignments; PublishMode → an explicit role-assignment annotation on the consumer), and de-duplicates roles per target so generated bicep contains no duplicate role-assignment identifiers.
- The Foundry hosted-agent integration stamps exactly one **least-privilege** role — **Azure AI User** — on the consumer's reference to the owning account. It deliberately does **not** fold in the account's default role set: defaults remain owned by the preparer's normal reference walk, and a consumer that declares its own `WithRoleAssignments(...)` still suppresses them.

The net effect: referencing a hosted agent now auto-provisions the consumer's managed identity and grants Azure AI User on the Foundry account, eliminating the two manual post-deploy steps.

### User-facing usage

A service deployed to one compute environment (here, Azure Kubernetes) can now reference a hosted agent hosted in another (the Foundry project environment) and both deploy **and invoke** it successfully, with the required identity and role assignment generated automatically. This works for both C# and TypeScript AppHosts.

C# AppHost:

```csharp
var aks = builder.AddAzureKubernetesEnvironment("aks");

var project = builder.AddFoundry("foundry")
                     .AddProject("project");

// The agent app is deployed to the Foundry project compute environment.
var agent = builder.AddProject<Projects.Agent>("agent")
                   .WithHttpEndpoint()
                   .WithExternalHttpEndpoints();
agent.AsHostedAgent(project);

// The web app is deployed to Azure Kubernetes and references the cross-environment agent.
// Endpoint resolution AND the managed identity + Azure AI User role on the Foundry
// account are now wired automatically — no manual `az role assignment create`.
builder.AddProject<Projects.Web>("web")
       .WithHttpEndpoint()
       .WithExternalHttpEndpoints()
       .WithComputeEnvironment(aks)
       .WithReference(agent);
```

TypeScript AppHost:

```typescript
import { createBuilder } from './.aspire/modules/aspire.mjs';

const builder = await createBuilder();

const aks = await builder.addAzureKubernetesEnvironment("aks");

const foundry = await builder.addFoundry("foundry");
const project = await foundry.addProject("project");

// The agent app is deployed to the Foundry project compute environment.
const agent = await builder
    .addProject("agent", "../Agent/Agent.csproj")
    .withHttpEndpoint()
    .withExternalHttpEndpoints();
await agent.asHostedAgent(project);

// The web app is deployed to Azure Kubernetes and references the cross-environment agent.
await builder
    .addProject("web", "../Web/Web.csproj")
    .withHttpEndpoint()
    .withExternalHttpEndpoints()
    .withComputeEnvironment(aks)
    .withReference(agent);

await builder.build().run();
```

Fixes #17749

### Validation

- Added `ComputeEnvironmentEndpointResolverTests` (7 tests) covering each observable branch of the helper: cross-environment delegation (both the `EndpointReference` and `EndpointReferenceExpression` overloads), same-environment via deployment target, binding-backstop, no-environment, bound multi-target (no throw), and unbound multi-target (throws).
- Added publisher regression tests for ACA, App Service, and Kubernetes that reference a resource across compute environments, with Verify snapshots for generated bicep/JSON.
- Added `AzureResourcePreparerTests` coverage for the RBAC hook: that `ReferenceRoleAssignmentAnnotation` produces the implied identity + role assignment in both Run and Publish modes, that roles are de-duplicated per target, and that the hosted-agent consumer is granted **only** Azure AI User (account defaults are not silently folded in, and explicit `WithRoleAssignments` suppression is honored).
- Added Foundry `HostedAgentExtensionTests` asserting the consumer stamps the single least-privilege Azure AI User role.
- All affected publisher projects build; existing same-environment publisher suites continue to pass (cross-env Foundry snapshots were regenerated to include the auto-wired identity/role).
- **Validated end-to-end against a live Azure deploy:** a clean deployment to Azure Container Apps (`agentweb` → `apiservice` → Foundry hosted agent) returns real agent responses with **no** manual role-assignment steps — the consumer's managed identity and Azure AI User grant are emitted by the app model.

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [x] Yes
    - `ReferenceRoleAssignmentAnnotation` in `Aspire.Hosting.Azure`, gated behind `[Experimental("ASPIREAZURE003")]`.
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [x] No — experimental; API review to follow before the diagnostic is stabilized.
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [x] No
  - [ ] No
- Does the change make any security assumptions or guarantees?
  - [x] Yes
    - The RBAC auto-wiring grants the consumer's managed identity the **Azure AI User** role on the referenced Foundry account. This is a deliberate **least-privilege** grant (not Contributor/Owner), is only emitted when a resource explicitly references a hosted agent, and is suppressible via an explicit `WithRoleAssignments(...)`. No other roles or defaults are folded in.
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [x] No