### PR TITLE
Fix extension-changelog 422: skip branch-protection pre-flight to drop administration:read

### DIFF
--- a/.github/workflows/extension-changelog.lock.yml
+++ b/.github/workflows/extension-changelog.lock.yml
@@ -1,4 +1,4 @@
-# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"7fd593750592c75e5e26eaec75ab58ab28e262d2aff0a08568f1e64a10d13daf","compiler_version":"v0.72.1","strict":true,"agent_id":"copilot"}
+# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"d5a7f178cf60b303f479d0e6fa0c911cbbfdf39fd57f0b6abaefae4234b70c11","compiler_version":"v0.72.1","strict":true,"agent_id":"copilot"}
 # gh-aw-manifest: {"version":1,"secrets":["ASPIRE_BOT_APP_ID","ASPIRE_BOT_PRIVATE_KEY","COPILOT_GITHUB_TOKEN","GH_AW_CI_TRIGGER_TOKEN","GH_AW_GITHUB_MCP_SERVER_TOKEN","GH_AW_GITHUB_TOKEN","GITHUB_TOKEN"],"actions":[{"repo":"actions/checkout","sha":"de0fac2e4500dabe0009e67214ff5f5447ce83dd","version":"v6.0.2"},{"repo":"actions/create-github-app-token","sha":"1b10c78c7865c340bc4f6099eb2f838309f1e8c3","version":"v3.1.1"},{"repo":"actions/download-artifact","sha":"3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c","version":"v8.0.1"},{"repo":"actions/github-script","sha":"3a2844b7e9c422d3c10d287c895573f7108da1b3","version":"v9.0.0"},{"repo":"actions/setup-node","sha":"48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e","version":"v6.4.0"},{"repo":"actions/upload-artifact","sha":"043fb46d1a93c77aae656e7c1c64a875d1fc6a0a","version":"v7.0.1"},{"repo":"github/gh-aw-actions/setup","sha":"bc56a0cad2f450c562810785ef38649c04db812a","version":"v0.72.1"}],"containers":[{"image":"ghcr.io/github/gh-aw-firewall/agent:0.25.41"},{"image":"ghcr.io/github/gh-aw-firewall/api-proxy:0.25.41"},{"image":"ghcr.io/github/gh-aw-firewall/squid:0.25.41"},{"image":"ghcr.io/github/gh-aw-mcpg:v0.3.6","digest":"sha256:2bb8eef86006a4c5963c55616a9c51c32f27bfdecb023b8aa6f91f6718d9171c","pinned_image":"ghcr.io/github/gh-aw-mcpg:v0.3.6@sha256:2bb8eef86006a4c5963c55616a9c51c32f27bfdecb023b8aa6f91f6718d9171c"},{"image":"ghcr.io/github/github-mcp-server:v1.0.3","digest":"sha256:2ac27ef03461ef2b877031b838a7d1fd7f12b12d4ace7796d8cad91446d55959","pinned_image":"ghcr.io/github/github-mcp-server:v1.0.3@sha256:2ac27ef03461ef2b877031b838a7d1fd7f12b12d4ace7796d8cad91446d55959"},{"image":"node:lts-alpine","digest":"sha256:d1b3b4da11eefd5941e7f0b9cf17783fc99d9c6fc34884a665f40a06dbdfc94f","pinned_image":"node:lts-alpine@sha256:d1b3b4da11eefd5941e7f0b9cf17783fc99d9c6fc34884a665f40a06dbdfc94f"}]}
 #    ___                   _   _      
 #   / _ \                 | | (_)     
@@ -200,23 +200,23 @@ jobs:
         run: |
           bash "${RUNNER_TEMP}/gh-aw/actions/create_prompt_first.sh"
           {
-          cat << 'GH_AW_PROMPT_a2cec1d80cba25e5_EOF'
+          cat << 'GH_AW_PROMPT_ee3b264e140a9d68_EOF'
           <system>
-          GH_AW_PROMPT_a2cec1d80cba25e5_EOF
+          GH_AW_PROMPT_ee3b264e140a9d68_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/xpia.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/temp_folder_prompt.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/markdown.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/safe_outputs_prompt.md"
-          cat << 'GH_AW_PROMPT_a2cec1d80cba25e5_EOF'
+          cat << 'GH_AW_PROMPT_ee3b264e140a9d68_EOF'
           <safe-output-tools>
           Tools: push_to_pull_request_branch, missing_tool, missing_data, noop
-          GH_AW_PROMPT_a2cec1d80cba25e5_EOF
+          GH_AW_PROMPT_ee3b264e140a9d68_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/safe_outputs_push_to_pr_branch.md"
-          cat << 'GH_AW_PROMPT_a2cec1d80cba25e5_EOF'
+          cat << 'GH_AW_PROMPT_ee3b264e140a9d68_EOF'
           </safe-output-tools>
-          GH_AW_PROMPT_a2cec1d80cba25e5_EOF
+          GH_AW_PROMPT_ee3b264e140a9d68_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/mcp_cli_tools_prompt.md"
-          cat << 'GH_AW_PROMPT_a2cec1d80cba25e5_EOF'
+          cat << 'GH_AW_PROMPT_ee3b264e140a9d68_EOF'
           <github-context>
           The following GitHub context information is available for this workflow:
           {{#if __GH_AW_GITHUB_ACTOR__ }}
@@ -245,12 +245,12 @@ jobs:
           {{/if}}
           </github-context>
           
-          GH_AW_PROMPT_a2cec1d80cba25e5_EOF
+          GH_AW_PROMPT_ee3b264e140a9d68_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/github_mcp_tools_with_safeoutputs_prompt.md"
-          cat << 'GH_AW_PROMPT_a2cec1d80cba25e5_EOF'
+          cat << 'GH_AW_PROMPT_ee3b264e140a9d68_EOF'
           </system>
           {{#runtime-import .github/workflows/extension-changelog.md}}
-          GH_AW_PROMPT_a2cec1d80cba25e5_EOF
+          GH_AW_PROMPT_ee3b264e140a9d68_EOF
           } > "$GH_AW_PROMPT"
       - name: Interpolate variables and render templates
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
@@ -460,9 +460,9 @@ jobs:
           mkdir -p "${RUNNER_TEMP}/gh-aw/safeoutputs"
           mkdir -p /tmp/gh-aw/safeoutputs
           mkdir -p /tmp/gh-aw/mcp-logs/safeoutputs
-          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << 'GH_AW_SAFE_OUTPUTS_CONFIG_370b4d1b20ddbe9d_EOF'
-          {"create_report_incomplete_issue":{},"missing_data":{},"missing_tool":{},"noop":{"max":1,"report-as-issue":"true"},"push_to_pull_request_branch":{"allowed_files":["extension/CHANGELOG.md"],"if_no_changes":"error","max":1,"max_patch_size":1024,"protect_top_level_dot_folders":true,"protected_files":["package.json","bun.lockb","bunfig.toml","deno.json","deno.jsonc","deno.lock","global.json","NuGet.Config","Directory.Packages.props","mix.exs","mix.lock","go.mod","go.sum","stack.yaml","stack.yaml.lock","pom.xml","build.gradle","build.gradle.kts","settings.gradle","settings.gradle.kts","gradle.properties","package-lock.json","yarn.lock","pnpm-lock.yaml","npm-shrinkwrap.json","requirements.txt","Pipfile","Pipfile.lock","pyproject.toml","setup.py","setup.cfg","Gemfile","Gemfile.lock","uv.lock","CODEOWNERS","DESIGN.md","README.md","CONTRIBUTING.md","SECURITY.md","CODE_OF_CONDUCT.md","AGENTS.md","CLAUDE.md","GEMINI.md"]},"report_incomplete":{}}
-          GH_AW_SAFE_OUTPUTS_CONFIG_370b4d1b20ddbe9d_EOF
+          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << 'GH_AW_SAFE_OUTPUTS_CONFIG_07d376b751ed0c6e_EOF'
+          {"create_report_incomplete_issue":{},"missing_data":{},"missing_tool":{},"noop":{"max":1,"report-as-issue":"true"},"push_to_pull_request_branch":{"allowed_files":["extension/CHANGELOG.md"],"check_branch_protection":false,"if_no_changes":"error","max":1,"max_patch_size":1024,"protect_top_level_dot_folders":true,"protected_files":["package.json","bun.lockb","bunfig.toml","deno.json","deno.jsonc","deno.lock","global.json","NuGet.Config","Directory.Packages.props","mix.exs","mix.lock","go.mod","go.sum","stack.yaml","stack.yaml.lock","pom.xml","build.gradle","build.gradle.kts","settings.gradle","settings.gradle.kts","gradle.properties","package-lock.json","yarn.lock","pnpm-lock.yaml","npm-shrinkwrap.json","requirements.txt","Pipfile","Pipfile.lock","pyproject.toml","setup.py","setup.cfg","Gemfile","Gemfile.lock","uv.lock","CODEOWNERS","DESIGN.md","README.md","CONTRIBUTING.md","SECURITY.md","CODE_OF_CONDUCT.md","AGENTS.md","CLAUDE.md","GEMINI.md"]},"report_incomplete":{}}
+          GH_AW_SAFE_OUTPUTS_CONFIG_07d376b751ed0c6e_EOF
       - name: Generate Safe Outputs Tools
         env:
           GH_AW_TOOLS_META_JSON: |
@@ -647,7 +647,7 @@ jobs:
           
           mkdir -p /home/runner/.copilot
           GH_AW_NODE=$(which node 2>/dev/null || command -v node 2>/dev/null || echo node)
-          cat << GH_AW_MCP_CONFIG_472acba20838b74d_EOF | "$GH_AW_NODE" "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.cjs"
+          cat << GH_AW_MCP_CONFIG_e68315ca95523272_EOF | "$GH_AW_NODE" "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.cjs"
           {
             "mcpServers": {
               "github": {
@@ -693,7 +693,7 @@ jobs:
               "payloadDir": "${MCP_GATEWAY_PAYLOAD_DIR}"
             }
           }
-          GH_AW_MCP_CONFIG_472acba20838b74d_EOF
+          GH_AW_MCP_CONFIG_e68315ca95523272_EOF
       - name: Mount MCP servers as CLIs
         id: mount-mcp-clis
         continue-on-error: true
@@ -972,7 +972,6 @@ jobs:
           owner: microsoft
           repositories: aspire
           github-api-url: ${{ github.api_url }}
-          permission-administration: read
           permission-contents: write
           permission-pull-requests: write
       - name: Download agent output artifact
@@ -1397,7 +1396,6 @@ jobs:
           owner: microsoft
           repositories: aspire
           github-api-url: ${{ github.api_url }}
-          permission-administration: read
           permission-contents: write
           permission-pull-requests: write
       - name: Extract base branch from agent output
@@ -1462,7 +1460,7 @@ jobs:
           GH_AW_ALLOWED_DOMAINS: "*.githubusercontent.com,api.business.githubcopilot.com,api.enterprise.githubcopilot.com,api.github.com,api.githubcopilot.com,api.individual.githubcopilot.com,api.snapcraft.io,archive.ubuntu.com,azure.archive.ubuntu.com,codeload.github.com,crl.geotrust.com,crl.globalsign.com,crl.identrust.com,crl.sectigo.com,crl.thawte.com,crl.usertrust.com,crl.verisign.com,crl3.digicert.com,crl4.digicert.com,crls.ssl.com,docs.github.com,github-cloud.githubusercontent.com,github-cloud.s3.amazonaws.com,github.blog,github.com,github.githubassets.com,host.docker.internal,json-schema.org,json.schemastore.org,keyserver.ubuntu.com,lfs.github.com,objects.githubusercontent.com,ocsp.digicert.com,ocsp.geotrust.com,ocsp.globalsign.com,ocsp.identrust.com,ocsp.sectigo.com,ocsp.ssl.com,ocsp.thawte.com,ocsp.usertrust.com,ocsp.verisign.com,packagecloud.io,packages.cloud.google.com,packages.microsoft.com,ppa.launchpad.net,raw.githubusercontent.com,registry.npmjs.org,s.symcb.com,s.symcd.com,security.ubuntu.com,telemetry.enterprise.githubcopilot.com,ts-crl.ws.symantec.com,ts-ocsp.ws.symantec.com,www.googleapis.com"
           GITHUB_SERVER_URL: ${{ github.server_url }}
           GITHUB_API_URL: ${{ github.api_url }}
-          GH_AW_SAFE_OUTPUTS_HANDLER_CONFIG: "{\"create_report_incomplete_issue\":{},\"missing_data\":{},\"missing_tool\":{},\"noop\":{\"max\":1,\"report-as-issue\":\"true\"},\"push_to_pull_request_branch\":{\"allowed_files\":[\"extension/CHANGELOG.md\"],\"if_no_changes\":\"error\",\"max\":1,\"max_patch_size\":1024,\"protect_top_level_dot_folders\":true,\"protected_files\":[\"package.json\",\"bun.lockb\",\"bunfig.toml\",\"deno.json\",\"deno.jsonc\",\"deno.lock\",\"global.json\",\"NuGet.Config\",\"Directory.Packages.props\",\"mix.exs\",\"mix.lock\",\"go.mod\",\"go.sum\",\"stack.yaml\",\"stack.yaml.lock\",\"pom.xml\",\"build.gradle\",\"build.gradle.kts\",\"settings.gradle\",\"settings.gradle.kts\",\"gradle.properties\",\"package-lock.json\",\"yarn.lock\",\"pnpm-lock.yaml\",\"npm-shrinkwrap.json\",\"requirements.txt\",\"Pipfile\",\"Pipfile.lock\",\"pyproject.toml\",\"setup.py\",\"setup.cfg\",\"Gemfile\",\"Gemfile.lock\",\"uv.lock\",\"CODEOWNERS\",\"DESIGN.md\",\"README.md\",\"CONTRIBUTING.md\",\"SECURITY.md\",\"CODE_OF_CONDUCT.md\",\"AGENTS.md\",\"CLAUDE.md\",\"GEMINI.md\"]},\"report_incomplete\":{}}"
+          GH_AW_SAFE_OUTPUTS_HANDLER_CONFIG: "{\"create_report_incomplete_issue\":{},\"missing_data\":{},\"missing_tool\":{},\"noop\":{\"max\":1,\"report-as-issue\":\"true\"},\"push_to_pull_request_branch\":{\"allowed_files\":[\"extension/CHANGELOG.md\"],\"check_branch_protection\":false,\"if_no_changes\":\"error\",\"max\":1,\"max_patch_size\":1024,\"protect_top_level_dot_folders\":true,\"protected_files\":[\"package.json\",\"bun.lockb\",\"bunfig.toml\",\"deno.json\",\"deno.jsonc\",\"deno.lock\",\"global.json\",\"NuGet.Config\",\"Directory.Packages.props\",\"mix.exs\",\"mix.lock\",\"go.mod\",\"go.sum\",\"stack.yaml\",\"stack.yaml.lock\",\"pom.xml\",\"build.gradle\",\"build.gradle.kts\",\"settings.gradle\",\"settings.gradle.kts\",\"gradle.properties\",\"package-lock.json\",\"yarn.lock\",\"pnpm-lock.yaml\",\"npm-shrinkwrap.json\",\"requirements.txt\",\"Pipfile\",\"Pipfile.lock\",\"pyproject.toml\",\"setup.py\",\"setup.cfg\",\"Gemfile\",\"Gemfile.lock\",\"uv.lock\",\"CODEOWNERS\",\"DESIGN.md\",\"README.md\",\"CONTRIBUTING.md\",\"SECURITY.md\",\"CODE_OF_CONDUCT.md\",\"AGENTS.md\",\"CLAUDE.md\",\"GEMINI.md\"]},\"report_incomplete\":{}}"
           GH_AW_CI_TRIGGER_TOKEN: ${{ secrets.GH_AW_CI_TRIGGER_TOKEN }}
           GITHUB_TOKEN: ${{ steps.safe-outputs-app-token.outputs.token }}
         with:

--- a/.github/workflows/extension-changelog.md
+++ b/.github/workflows/extension-changelog.md
@@ -74,6 +74,18 @@ network:
 safe-outputs:
   push-to-pull-request-branch:
     max: 1
+    # Skip gh-aw's branch-protection pre-flight check. By default this safe output
+    # reads branch protection before pushing, which makes gh-aw request
+    # `administration: read` on the minted aspire-repo-bot app token. That scope is
+    # NOT granted to the App installation, so the `Generate GitHub App token` step
+    # fails with a 422 ("The permissions requested are not granted to this
+    # installation") and the changelog is never pushed. The PR head we push to is a
+    # short-lived release branch created moments earlier by extension-release.yml and
+    # is never protected, so the pre-flight check has no value here. Disabling it
+    # drops `administration: read` from the token request, leaving only the already
+    # granted `contents: write` + `pull-requests: write`.
+    # See https://github.com/github/gh-aw push_to_pull_request_branch.go (check-branch-protection).
+    check-branch-protection: false
     # Fail (don't just warn) if the agent emits a push with no diff. Every
     # legitimate run that gets this far edits extension/CHANGELOG.md (even the
     # "no user-facing changes" case rewrites the placeholder), and the benign


### PR DESCRIPTION
## Description

The `extension-changelog` agentic (gh-aw) workflow is failing at the **Generate GitHub App token** step in its `safe_outputs` job, so the generated VS Code extension changelog is never pushed onto the release PR. Example failure: [run 26696770738](https://github.com/microsoft/aspire/actions/runs/26696770738/job/78682826401).

**Root cause:** the `push-to-pull-request-branch` safe output runs a branch-protection pre-flight check by default. gh-aw therefore adds `administration: read` to the `aspire-repo-bot` app token it mints. That scope is **not granted** to the App installation, so `actions/create-github-app-token` fails with:

```text
422 The permissions requested are not granted to this installation.
```

The other two requested scopes (`contents: write`, `pull-requests: write`) are already granted, so `administration: read` is the only blocker.

**Fix:** set `check-branch-protection: false` on the `push-to-pull-request-branch` safe output. Per gh-aw, this "skips the branch protection API pre-flight check ... to avoid needing `administration: read` permission." The PR head this workflow pushes to is a short-lived release branch created moments earlier by `extension-release.yml` and is never protected, so the pre-flight check adds no value here. This avoids granting the bot any new permission.

### Before / after (minted `safe_outputs` token)

```diff
  owner: microsoft
  repositories: aspire
- permission-administration: read
  permission-contents: write
  permission-pull-requests: write
```

### Why `administration: read` is the only missing scope

The fix only works if the App already has `contents: write` + `pull-requests: write` and `administration: read` is the sole ungranted scope. Evidence that this holds:

- `extension-release.yml` mints a token from the **same** `aspire-repo-bot` App (`secrets.ASPIRE_BOT_*`), and in the run that produced this release PR it both **created** the PR via `git push` to a new branch (requires `contents: write`) and **applied** the `vscode-extension-release` label (requires `pull-requests: write`). Both succeeded — so the installation demonstrably grants those two scopes.
- The failing `safe_outputs` step requested exactly those two scopes **plus** `administration: read` and got the 422. Since the first two are granted, `administration: read` is necessarily the missing one.
- A relevant difference: `extension-release.yml` uses `create-github-app-token@v2.0.6` with **no** explicit `permission-*` inputs (it requests all granted scopes and so never 422s on permissions), whereas the gh-aw lock uses v3.1.1 with **explicit** scopes (which 422s if any single one isn't granted). That's why only the gh-aw job hit the error, and why narrowing its explicit request fixes it.

### Blast radius

In the failing run, the `agent` and `detection` jobs already passed; the **only** failure was the token mint in `safe_outputs`, so fixing the mint unblocks the changelog push. `check-branch-protection: false` only skips one read-only pre-flight API call — the push itself still uses `contents: write`, and the target branch is unprotected.

### Validation

Recompiled the lock file with the same compiler version the repo uses (`gh aw compile extension-changelog`, v0.72.1): `0 error(s), 0 warning(s)`. Confirmed the regenerated `extension-changelog.lock.yml` no longer contains any `administration` permission and both app-token-mint steps now request only `contents: write` + `pull-requests: write`. The only functional diff is the added `check_branch_protection:false` and the removed `administration: read` lines (plus gh-aw's deterministic prompt/marker hashes); compiler version is unchanged.

End-to-end confirmation happens on the next run against a labeled release PR; a maintainer can force it by removing and re-adding the `vscode-extension-release` label once this merges.

Fixes # (issue)

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [x] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No

