### PR TITLE
Polyglot `aspire add` parity with C# (project-local NuGet.config + auto-select)

### DIFF
--- a/eng/scripts/debug-aspire-channel.ps1
+++ b/eng/scripts/debug-aspire-channel.ps1
@@ -99,6 +99,27 @@ function Invoke-DebugChannel {
     if (-not [string]::IsNullOrEmpty($Pr)) {
         Write-Host ">> Installing PR #$Pr build via get-aspire-cli-pr.ps1 ..."
         & (Join-Path $scriptDir 'get-aspire-cli-pr.ps1') $Pr
+
+        # `get-aspire-cli-pr.ps1` installs to `$InstallPath/dogfood/pr-<N>/bin/aspire`
+        # (see `Get-CliInstallDir` in that script), NOT `$InstallPath/bin`. If we let
+        # the auto-discovery below run, `Get-Command aspire` would pick whatever is
+        # already first on PATH (usually a pre-existing stable install at
+        # `~/.aspire/bin/aspire`) and the PR build we just installed would be silently
+        # ignored — making the `-Pr` flag a no-op in the common case. Pin to the PR
+        # install path so `-Pr` actually does what it says. Only set when `-Cli` was
+        # not also supplied, so an explicit `-Cli` still wins.
+        if ([string]::IsNullOrEmpty($Cli)) {
+            $installPrefix = if ($env:ASPIRE_CLI_INSTALL_PATH) { $env:ASPIRE_CLI_INSTALL_PATH } else { Join-Path $HOME '.aspire' }
+            $exeName = if ($IsWindows -or [System.Environment]::OSVersion.Platform -eq 'Win32NT') { 'aspire.exe' } else { 'aspire' }
+            $prInstallPath = Join-Path $installPrefix "dogfood/pr-$Pr/bin/$exeName"
+            if (Test-Path $prInstallPath) {
+                $Cli = $prInstallPath
+            }
+            else {
+                Write-Warning "PR install path not found at expected location: $prInstallPath"
+                Write-Warning "get-aspire-cli-pr.ps1 appears to have changed its install layout; falling back to PATH discovery."
+            }
+        }
     }
 
     if ([string]::IsNullOrEmpty($Cli)) {

--- a/eng/scripts/debug-aspire-channel.sh
+++ b/eng/scripts/debug-aspire-channel.sh
@@ -218,19 +218,85 @@ ENV
         # cache, and is left in place on exit (it lives under the system temp dir).
         local nuget_packages="${TMPDIR:-/tmp}/aspire-debug-nuget/${sha8}"
         mkdir -p "$nuget_packages"
+
+        # An interactive shell sources the user's startup files AFTER we set the
+        # environment, so if those files prepend something to PATH (commonly
+        # `export PATH="$HOME/.aspire/bin:$PATH"` from a prior `aspire` install)
+        # they shadow our --cli build with an unrelated `aspire` binary. To make
+        # our `aspire` win unconditionally, we drop a shim at a path that runs
+        # AFTER the user's rc loads:
+        #   * zsh: ZDOTDIR=<rcdir>; <rcdir>/.zshrc sources the real ~/.zshrc and
+        #     then re-prepends our shim dir to PATH.
+        #   * bash: --rcfile <rcdir>/bashrc with the same source-then-prepend.
+        # Other shells fall back to the old env-only PATH export (best effort).
+        local shim_root rcdir
+        shim_root="$(mktemp -d -t aspire-debug-shim.XXXXXX)"
+        rcdir="$shim_root/rc"
+        mkdir -p "$shim_root/bin" "$rcdir"
+        # The shim is just a small forwarder so `which aspire`, command lookup,
+        # and any subshells inside this session all resolve to OUR cli_path.
+        cat > "$shim_root/bin/aspire" <<SHIM
+#!/usr/bin/env bash
+exec "$cli_path" "\$@"
+SHIM
+        chmod +x "$shim_root/bin/aspire"
+
+        local target_shell="${SHELL:-/bin/bash}"
+        local shell_name
+        shell_name="$(basename "$target_shell")"
+
         say ">> Launching an interactive subshell. Run 'aspire new', 'aspire add', etc."
         say "   'aspire' resolves to: $cli_path"
         say "   NuGet packages cache: $nuget_packages (isolated from your global cache)"
         say "   Type 'exit' to leave and restore normal CLI behavior."
         say ""
-        channel="staging" \
-            overrideCliIdentityChannel="$identity" \
-            overrideCliInformationalVersion="$info_version" \
-            NUGET_PACKAGES="$nuget_packages" \
-            PATH="${cli_dir}:${PATH}" \
-            ASPIRE_DEBUG_BUILD_PROMPT="aspire(${kind}:${sha8})" \
-            "${SHELL:-/bin/bash}" -i
-        return $?
+
+        case "$shell_name" in
+            zsh)
+                # Custom ZDOTDIR: source the user's real rc first, then re-prepend
+                # our shim dir so it beats anything their rc added to PATH.
+                cat > "$rcdir/.zshrc" <<ZSHRC
+[[ -f "\$HOME/.zshrc" ]] && source "\$HOME/.zshrc"
+export PATH="$shim_root/bin:\$PATH"
+ZSHRC
+                channel="staging" \
+                    overrideCliIdentityChannel="$identity" \
+                    overrideCliInformationalVersion="$info_version" \
+                    NUGET_PACKAGES="$nuget_packages" \
+                    ASPIRE_DEBUG_BUILD_PROMPT="aspire(${kind}:${sha8})" \
+                    ZDOTDIR="$rcdir" \
+                    "$target_shell" -i
+                ;;
+            bash)
+                cat > "$rcdir/bashrc" <<BASHRC
+[[ -f "\$HOME/.bashrc" ]] && source "\$HOME/.bashrc"
+export PATH="$shim_root/bin:\$PATH"
+BASHRC
+                channel="staging" \
+                    overrideCliIdentityChannel="$identity" \
+                    overrideCliInformationalVersion="$info_version" \
+                    NUGET_PACKAGES="$nuget_packages" \
+                    ASPIRE_DEBUG_BUILD_PROMPT="aspire(${kind}:${sha8})" \
+                    "$target_shell" --rcfile "$rcdir/bashrc" -i
+                ;;
+            *)
+                # Unknown shell -- best-effort PATH export. If the user's rc
+                # files re-prepend to PATH, the developer can still invoke the
+                # shim directly: $shim_root/bin/aspire
+                say "warning: unrecognized shell '$shell_name'; PATH may be overridden by your rc files."
+                say "         If that happens, invoke the shim directly: $shim_root/bin/aspire"
+                channel="staging" \
+                    overrideCliIdentityChannel="$identity" \
+                    overrideCliInformationalVersion="$info_version" \
+                    NUGET_PACKAGES="$nuget_packages" \
+                    PATH="$shim_root/bin:${PATH}" \
+                    ASPIRE_DEBUG_BUILD_PROMPT="aspire(${kind}:${sha8})" \
+                    "$target_shell" -i
+                ;;
+        esac
+        local exit_code=$?
+        rm -rf "$shim_root"
+        return $exit_code
     fi
 
     # Throwaway working directory pinned to channel: staging so 'aspire add'

--- a/eng/scripts/debug-aspire-channel.sh
+++ b/eng/scripts/debug-aspire-channel.sh
@@ -46,6 +46,57 @@ readonly DEFAULT_STABLE_VERSION="13.4.0"
 say() { printf '%s\n' "$*"; }
 say_err() { printf 'error: %s\n' "$*" >&2; }
 
+# Query an AzDO darc feed's NuGet v3 service index for the highest published
+# version of Aspire.ProjectTemplates. Used to auto-align the simulated CLI
+# version with what the build pipeline actually stamped for the SHA, so
+# TryGetCurrentCliVersionMatch can find the exact-match package on the feed
+# instead of silently degrading to whatever the highest nuget.org version is.
+#
+# Inputs:  $1 = NuGet v3 service-index URL for the darc feed
+# Outputs: highest version string on stdout (e.g. "13.4.0"), or nothing on
+#          failure / empty feed. Never writes to stderr unless --verbose is
+#          uncommented; the caller treats absence-of-output as "fall back to
+#          the script default" so transient curl failures don't break the run.
+detect_published_template_version() {
+    local feed_url="$1"
+    command -v curl >/dev/null 2>&1 || return 1
+    command -v python3 >/dev/null 2>&1 || return 1
+
+    # Step 1: resolve the PackageBaseAddress resource from the service index.
+    # The base address is what NuGet clients use to enumerate flat-container
+    # versions; we want the "PackageBaseAddress/3.0.0" entry but accept any
+    # PackageBaseAddress* type for forward compat.
+    local base
+    base="$(curl -fsS --max-time 10 "$feed_url" 2>/dev/null | python3 -c "
+import sys, json
+try:
+    d = json.load(sys.stdin)
+except Exception:
+    sys.exit(1)
+for r in d.get('resources', []):
+    if str(r.get('@type', '')).startswith('PackageBaseAddress'):
+        print(r['@id'])
+        break
+" 2>/dev/null)" || return 1
+    [[ -n "$base" ]] || return 1
+
+    # Step 2: fetch the flat-container index for the lowercased package id and
+    # return the LAST entry. The NuGet flat-container spec orders versions
+    # lexicographically by SemVer 2.0 precedence, so the tail is the highest.
+    # See https://learn.microsoft.com/nuget/api/package-base-address-resource
+    curl -fsS --max-time 10 "${base}aspire.projecttemplates/index.json" 2>/dev/null \
+        | python3 -c "
+import sys, json
+try:
+    d = json.load(sys.stdin)
+except Exception:
+    sys.exit(1)
+v = d.get('versions') or []
+if v:
+    print(v[-1])
+" 2>/dev/null
+}
+
 print_usage() {
     local invoked_as="$1"
     cat <<USAGE
@@ -106,7 +157,7 @@ run_debug_channel() {
         *) say_err "unknown kind '$kind'"; return 2 ;;
     esac
 
-    local sha="" pr="" cli_path="" version="" identity="staging" package="foundry"
+    local sha="" pr="" cli_path="" version="" version_was_explicit=0 identity="staging" package="foundry"
     local mode="validate"
     local -a passthrough=()
 
@@ -115,7 +166,7 @@ run_debug_channel() {
             --sha) sha="${2:-}"; shift 2 ;;
             --pr) pr="${2:-}"; shift 2 ;;
             --cli) cli_path="${2:-}"; shift 2 ;;
-            --version) version="${2:-}"; shift 2 ;;
+            --version) version="${2:-}"; version_was_explicit=1; shift 2 ;;
             --identity) identity="${2:-}"; shift 2 ;;
             --package) package="${2:-}"; shift 2 ;;
             --shell) mode="shell"; shift ;;
@@ -145,6 +196,27 @@ run_debug_channel() {
     local sha8
     sha8="$(printf '%s' "${sha:0:8}" | tr '[:upper:]' '[:lower:]')"
     local expected_feed="https://pkgs.dev.azure.com/dnceng/public/_packaging/darc-pub-microsoft-aspire-${sha8}/nuget/v3/index.json"
+
+    # When --version was not supplied, query the actual darc feed for the SHA's
+    # published Aspire.ProjectTemplates version and use that. Otherwise the
+    # built-in DEFAULT_STAGING_VERSION / DEFAULT_STABLE_VERSION often doesn't
+    # match what the build pipeline actually stamped (e.g. release stabilization
+    # publishes 13.4.0 stable for a SHA whose script-default is the prerelease
+    # `13.4.0-preview.1.X.Y` shape). When the version doesn't match the feed,
+    # TryGetCurrentCliVersionMatch fails and template selection silently falls
+    # back to the highest version visible across all sources -- which on a stale
+    # nuget.org cache is the previous shipped stable (e.g. 13.3.5), producing
+    # the SDK-version-mismatch warning and the wrong SDK pin in the new project's
+    # aspire.config.json.
+    if [[ "$version_was_explicit" -eq 0 ]]; then
+        local detected_version
+        detected_version="$(detect_published_template_version "$expected_feed" 2>/dev/null || true)"
+        if [[ -n "$detected_version" ]]; then
+            say "Detected published Aspire.ProjectTemplates version on darc feed: $detected_version (overrides default '$DEFAULT_VERSION')."
+            version="$detected_version"
+        fi
+    fi
+
     local info_version="${version}+${sha}"
 
     # --print-env: emit shell-applicable export/unset lines and stop. This mode is

--- a/eng/scripts/debug-aspire-channel.sh
+++ b/eng/scripts/debug-aspire-channel.sh
@@ -325,6 +325,19 @@ ENV
         local nuget_packages="${TMPDIR:-/tmp}/aspire-debug-nuget/${sha8}"
         mkdir -p "$nuget_packages"
 
+        # Expose the developer's real global cache as a READ-ONLY fallback. NuGet
+        # consults NUGET_FALLBACK_PACKAGES after NUGET_PACKAGES on lookup but never
+        # writes to it, so non-Aspire transitive dependencies that are version-stable
+        # across feeds (DCP / Microsoft.DeveloperControlPlane.*, .NET runtime packs,
+        # template-engine assets) resolve from the existing cache instead of having
+        # to be re-downloaded into the isolated dir, while any Aspire.* package
+        # restored under the staging override still lands ONLY in $nuget_packages.
+        # Without this, the polyglot apphost server fails to launch because DCP's
+        # tools/dcp binary is missing from the isolated cache:
+        #   Could not invoke 'run': The Aspire orchestration component is not
+        #   installed at "$nuget_packages/microsoft.developercontrolplane.<rid>/<ver>/tools/dcp".
+        local nuget_fallback="${NUGET_FALLBACK_PACKAGES:-${HOME}/.nuget/packages}"
+
         # An interactive shell sources the user's startup files AFTER we set the
         # environment, so if those files prepend something to PATH (commonly
         # `export PATH="$HOME/.aspire/bin:$PATH"` from a prior `aspire` install)
@@ -353,7 +366,7 @@ SHIM
 
         say ">> Launching an interactive subshell. Run 'aspire new', 'aspire add', etc."
         say "   'aspire' resolves to: $cli_path"
-        say "   NuGet packages cache: $nuget_packages (isolated from your global cache)"
+        say "   NuGet packages cache: $nuget_packages (isolated; falls back read-only to $nuget_fallback)"
         say "   Type 'exit' to leave and restore normal CLI behavior."
         say ""
 
@@ -370,6 +383,7 @@ ZSHRC
                     overrideCliInformationalVersion="$info_version" \
                     overrideStagingQuality="Both" \
                     NUGET_PACKAGES="$nuget_packages" \
+                    NUGET_FALLBACK_PACKAGES="$nuget_fallback" \
                     ASPIRE_DEBUG_BUILD_PROMPT="aspire(${kind}:${sha8})" \
                     ZDOTDIR="$rcdir" \
                     "$target_shell" -i
@@ -384,6 +398,7 @@ BASHRC
                     overrideCliInformationalVersion="$info_version" \
                     overrideStagingQuality="Both" \
                     NUGET_PACKAGES="$nuget_packages" \
+                    NUGET_FALLBACK_PACKAGES="$nuget_fallback" \
                     ASPIRE_DEBUG_BUILD_PROMPT="aspire(${kind}:${sha8})" \
                     "$target_shell" --rcfile "$rcdir/bashrc" -i
                 ;;
@@ -398,6 +413,7 @@ BASHRC
                     overrideCliInformationalVersion="$info_version" \
                     overrideStagingQuality="Both" \
                     NUGET_PACKAGES="$nuget_packages" \
+                    NUGET_FALLBACK_PACKAGES="$nuget_fallback" \
                     PATH="$shim_root/bin:${PATH}" \
                     ASPIRE_DEBUG_BUILD_PROMPT="aspire(${kind}:${sha8})" \
                     "$target_shell" -i

--- a/eng/scripts/debug-aspire-channel.sh
+++ b/eng/scripts/debug-aspire-channel.sh
@@ -84,6 +84,14 @@ for r in d.get('resources', []):
     # return the LAST entry. The NuGet flat-container spec orders versions
     # lexicographically by SemVer 2.0 precedence, so the tail is the highest.
     # See https://learn.microsoft.com/nuget/api/package-base-address-resource
+    #
+    # We query Aspire.ProjectTemplates because that's the package whose version
+    # determines what 'aspire new' bakes into aspire.config.json as the SDK
+    # version pin. Integration packages on the same SHA's darc feed can have
+    # a different prerelease/stable shape (e.g. on a stabilizing release branch
+    # Aspire.Hosting.Foundry can be "13.4.0-preview.1.X.Y" while the templates
+    # are stamped "13.4.0"), so the script also exports overrideStagingQuality=Both
+    # to keep the prerelease integration packages visible to 'aspire add'.
     curl -fsS --max-time 10 "${base}aspire.projecttemplates/index.json" 2>/dev/null \
         | python3 -c "
 import sys, json
@@ -231,8 +239,15 @@ run_debug_channel() {
 export channel='staging'
 export overrideCliIdentityChannel='${identity}'
 export overrideCliInformationalVersion='${info_version}'
+# overrideStagingQuality=Both ensures both stable- and prerelease-shaped packages
+# on the darc feed remain eligible. On a stabilizing release branch, integration
+# packages and core packages can be stamped with different shapes for the same
+# SHA (e.g. Aspire.Hosting=13.4.0 stable, Aspire.Hosting.Foundry=13.4.0-preview.X.Y),
+# so the quality filter that auto-selects from the CLI version shape can hide
+# valid packages. See PackagingService.GetStagingQuality.
+export overrideStagingQuality='Both'
 # To revert:
-# unset channel overrideCliIdentityChannel overrideCliInformationalVersion
+# unset channel overrideCliIdentityChannel overrideCliInformationalVersion overrideStagingQuality
 ENV
         return 0
     fi
@@ -334,6 +349,7 @@ ZSHRC
                 channel="staging" \
                     overrideCliIdentityChannel="$identity" \
                     overrideCliInformationalVersion="$info_version" \
+                    overrideStagingQuality="Both" \
                     NUGET_PACKAGES="$nuget_packages" \
                     ASPIRE_DEBUG_BUILD_PROMPT="aspire(${kind}:${sha8})" \
                     ZDOTDIR="$rcdir" \
@@ -347,6 +363,7 @@ BASHRC
                 channel="staging" \
                     overrideCliIdentityChannel="$identity" \
                     overrideCliInformationalVersion="$info_version" \
+                    overrideStagingQuality="Both" \
                     NUGET_PACKAGES="$nuget_packages" \
                     ASPIRE_DEBUG_BUILD_PROMPT="aspire(${kind}:${sha8})" \
                     "$target_shell" --rcfile "$rcdir/bashrc" -i
@@ -360,6 +377,7 @@ BASHRC
                 channel="staging" \
                     overrideCliIdentityChannel="$identity" \
                     overrideCliInformationalVersion="$info_version" \
+                    overrideStagingQuality="Both" \
                     NUGET_PACKAGES="$nuget_packages" \
                     PATH="$shim_root/bin:${PATH}" \
                     ASPIRE_DEBUG_BUILD_PROMPT="aspire(${kind}:${sha8})" \
@@ -396,6 +414,7 @@ JSON
     ( cd "$scratch" && \
         overrideCliIdentityChannel="$identity" \
         overrideCliInformationalVersion="$info_version" \
+        overrideStagingQuality="Both" \
         "$cli_path" add "$package" --debug "${passthrough[@]+"${passthrough[@]}"}" ) > "$log" 2>&1
     set -e
 

--- a/eng/scripts/debug-aspire-channel.sh
+++ b/eng/scripts/debug-aspire-channel.sh
@@ -256,6 +256,25 @@ ENV
     if [[ -n "$pr" ]]; then
         say ">> Installing PR #${pr} build via get-aspire-cli-pr.sh ..."
         "${SCRIPT_DIR}/get-aspire-cli-pr.sh" "$pr"
+
+        # `get-aspire-cli-pr.sh` installs to `$INSTALL_PREFIX/dogfood/pr-<N>/bin/aspire`
+        # (see `compute_cli_install_dir` in that script), NOT `$INSTALL_PREFIX/bin`. If we
+        # let the auto-discovery below run, `command -v aspire` would pick whatever is
+        # already first on PATH (usually a pre-existing stable install at
+        # `~/.aspire/bin/aspire`) and the PR build we just installed would be silently
+        # ignored — making the `--pr` flag a no-op in the common case. Pin to the PR
+        # install path so `--pr` actually does what it says. Only set when `--cli` was
+        # not also supplied, so an explicit `--cli` still wins.
+        if [[ -z "$cli_path" ]]; then
+            local install_prefix="${ASPIRE_CLI_INSTALL_PATH:-$HOME/.aspire}"
+            local pr_install_path="$install_prefix/dogfood/pr-${pr}/bin/aspire"
+            if [[ -x "$pr_install_path" ]]; then
+                cli_path="$pr_install_path"
+            else
+                say_err "PR install path not found at expected location: $pr_install_path"
+                say_err "get-aspire-cli-pr.sh appears to have changed its install layout; falling back to PATH discovery."
+            fi
+        fi
     fi
 
     if [[ -z "$cli_path" ]]; then

--- a/src/Aspire.Cli/Commands/AddCommand.cs
+++ b/src/Aspire.Cli/Commands/AddCommand.cs
@@ -448,14 +448,28 @@ internal sealed class AddCommand : BaseCommand
         // the latest version within the chosen channel.
         var orderedPackageVersions = packageVersions
             .OrderByDescending(p => p.Channel.Type is PackageChannelType.Implicit)
-            .ThenByDescending(p => SemVersion.Parse(p.Package.Version), SemVersion.PrecedenceComparer);
+            .ThenByDescending(p => SemVersion.Parse(p.Package.Version), SemVersion.PrecedenceComparer)
+            .ToArray();
+
+        // Deduplicate by (Id, Version) keeping the first occurrence — which, thanks to the
+        // ordering above, is the Implicit-channel entry when one exists. Without this, a
+        // polyglot apphost pinned to a channel sees the same package+version surfaced by both
+        // the Implicit channel (because the project-local NuGet.config pins Aspire.* at the
+        // pinned channel's feed) and the pinned Explicit channel, producing two identical
+        // rows in the version prompt and preventing the auto-select path from kicking in.
+        // C# apphosts never hit this because GetConfiguredChannel returns null for C# so the
+        // Explicit channels aren't queried at all.
+        var dedupedPackageVersions = orderedPackageVersions
+            .DistinctBy(p => (p.Package.Id, p.Package.Version))
+            .ToArray();
+
         if (!_hostEnvironment.SupportsInteractiveInput)
         {
-            return orderedPackageVersions.First();
+            return dedupedPackageVersions[0];
         }
 
         // ... otherwise we had better prompt.
-        var version = await PromptForIntegrationVersionAsync(orderedPackageVersions, cancellationToken);
+        var version = await PromptForIntegrationVersionAsync(dedupedPackageVersions, cancellationToken);
 
         return version;
     }

--- a/src/Aspire.Cli/Commands/AddCommand.cs
+++ b/src/Aspire.Cli/Commands/AddCommand.cs
@@ -451,25 +451,13 @@ internal sealed class AddCommand : BaseCommand
             .ThenByDescending(p => SemVersion.Parse(p.Package.Version), SemVersion.PrecedenceComparer)
             .ToArray();
 
-        // Deduplicate by (Id, Version) keeping the first occurrence — which, thanks to the
-        // ordering above, is the Implicit-channel entry when one exists. Without this, a
-        // polyglot apphost pinned to a channel sees the same package+version surfaced by both
-        // the Implicit channel (because the project-local NuGet.config pins Aspire.* at the
-        // pinned channel's feed) and the pinned Explicit channel, producing two identical
-        // rows in the version prompt and preventing the auto-select path from kicking in.
-        // C# apphosts never hit this because GetConfiguredChannel returns null for C# so the
-        // Explicit channels aren't queried at all.
-        var dedupedPackageVersions = orderedPackageVersions
-            .DistinctBy(p => (p.Package.Id, p.Package.Version))
-            .ToArray();
-
         if (!_hostEnvironment.SupportsInteractiveInput)
         {
-            return dedupedPackageVersions[0];
+            return orderedPackageVersions[0];
         }
 
         // ... otherwise we had better prompt.
-        var version = await PromptForIntegrationVersionAsync(dedupedPackageVersions, cancellationToken);
+        var version = await PromptForIntegrationVersionAsync(orderedPackageVersions, cancellationToken);
 
         return version;
     }

--- a/src/Aspire.Cli/Commands/InitCommand.cs
+++ b/src/Aspire.Cli/Commands/InitCommand.cs
@@ -261,7 +261,7 @@ internal sealed class InitCommand : BaseCommand
         // invisible and SDK resolution fails. `NuGetConfigMerger` underneath creates a
         // new file or merges missing sources into an existing one.
         var createdNuGetConfig = await _templateNuGetConfigService.CreateOrUpdateNuGetConfigWithoutPromptAsync(
-            channelName: _executionContext.IdentityChannel,
+            channelName: GetEffectiveFeedRoutingChannel(),
             outputPath: workingDirectory.FullName,
             cancellationToken).ConfigureAwait(false);
         if (createdNuGetConfig)
@@ -358,7 +358,7 @@ internal sealed class InitCommand : BaseCommand
         // for templates. Mirrors what DropCSharpSingleFileSkeletonAsync already does for
         // the apphost.cs path on every channel.
         var createdNuGetConfig = await _templateNuGetConfigService.CreateOrUpdateNuGetConfigWithoutPromptAsync(
-            channelName: _executionContext.IdentityChannel,
+            channelName: GetEffectiveFeedRoutingChannel(),
             outputPath: solutionDir.FullName,
             cancellationToken).ConfigureAwait(false);
         if (createdNuGetConfig)
@@ -382,7 +382,7 @@ internal sealed class InitCommand : BaseCommand
         try
         {
             var query = new TemplatePackageQuery(
-                RequestedChannel: _executionContext.IdentityChannel,
+                RequestedChannel: GetEffectiveFeedRoutingChannel(),
                 VersionOverride: null,
                 SourceOverride: null,
                 IncludePrHives: false);
@@ -664,9 +664,32 @@ internal sealed class InitCommand : BaseCommand
     /// Mirrors the resolution logic in <c>NewCommand.cs:316-402</c> and the warning in
     /// <c>ScaffoldingService.cs:84-92</c> against falling back to <c>IdentityChannel</c> blindly.
     /// </summary>
+    /// <summary>
+    /// Returns the channel name init should drive feed-routing decisions off of. Normally
+    /// this is the running CLI binary's baked identity (<see cref="CliExecutionContext.IdentityChannel"/>).
+    /// When <see cref="IPackagingService.GetEffectiveIdentityChannel"/> reports a different
+    /// effective channel (the diagnostic override used by
+    /// <c>eng/scripts/debug-staging.sh</c> / <c>debug-stable.sh</c> to validate staging
+    /// feed routing from a locally built CLI), defer to the override so init's
+    /// <c>NuGet.config</c> drops, template feed query, and persisted
+    /// <c>aspire.config.json#channel</c> stay consistent with what
+    /// <see cref="IPackagingService"/> will subsequently use for <c>aspire add</c>,
+    /// <c>integration list</c>, etc. Falls back to the baked identity when the packaging
+    /// service has no opinion (the empty-string contract on the override).
+    ///
+    /// Physical-binary-identity decisions (hive lookups, PR install discovery on disk) must
+    /// keep reading <c>_executionContext.IdentityChannel</c> directly — they are properties
+    /// of where the CLI binary lives, not of which feed packages should be routed against.
+    /// </summary>
+    private string GetEffectiveFeedRoutingChannel()
+    {
+        var effective = _packagingService.GetEffectiveIdentityChannel();
+        return string.IsNullOrWhiteSpace(effective) ? _executionContext.IdentityChannel : effective;
+    }
+
     private async Task<string?> ResolvePersistableChannelNameAsync(CancellationToken cancellationToken)
     {
-        var identityChannel = _executionContext.IdentityChannel;
+        var identityChannel = GetEffectiveFeedRoutingChannel();
         if (string.IsNullOrWhiteSpace(identityChannel))
         {
             return null;

--- a/src/Aspire.Cli/Commands/IntegrationPackageSearchService.cs
+++ b/src/Aspire.Cli/Commands/IntegrationPackageSearchService.cs
@@ -30,37 +30,51 @@ internal sealed class IntegrationPackageSearchService(
         var allChannels = await packagingService.GetChannelsAsync(cancellationToken, configuredChannel);
 
         // Channels included in the search:
-        //   * Implicit channel: always.
-        //   * PR hives: always when present.
-        //   * Apphost-pinned explicit channel: only the channel whose name matches
-        //     `configuredChannel` (no other explicit channels).
+        //   * Apphost-pinned explicit channel (polyglot `aspire.config.json#channel`):
+        //     when `configuredChannel` is non-null, ONLY this channel is searched.
+        //     Nothing else (no Implicit, no other explicit channels, no PR hives) — the
+        //     pin is the user's expressed intent for which feed `aspire add` should query.
+        //   * Otherwise (`configuredChannel` is null): Implicit always, plus all PR hives
+        //     when present. Preserves the #17724/#17725 guarantee that prerelease-only
+        //     packages remain reachable on Stable-pinned CLIs without a project-level pin.
         //
-        // Why the explicit channel set is scoped to the pinned channel only — NOT the full
-        // explicit set — when an apphost pins a channel:
-        //   - The full set produces duplicate matches in `aspire add` (e.g. a staging-pinned
-        //     polyglot apphost would see Aspire.Hosting.Foundry surfaced by both the synthesized
-        //     'staging' channel AND the unrelated 'daily' channel, with the daily entry
-        //     pointing at a stale version like 13.3.5 that's not aligned with the project's
-        //     pinned feed). C# apphosts never had this problem: GetConfiguredChannel returns
-        //     null for C# (line ~99) and `configuredChannel` stays empty, so only Implicit is
-        //     queried and the project-local NuGet.config scopes the search to the right feed.
-        //   - Implicit MUST stay in the set so prerelease-only packages remain reachable when
-        //     the project pin is Stable-quality. This is the #17724 / #17725 guarantee:
-        //     pre-fix, the search was narrowed to *only* the pinned channel, and a Stable pin
-        //     made prerelease packages (Aspire.Hosting.Foundry) invisible because Quality.Stable
-        //     channels only issue prerelease=false queries. Keeping Implicit (Quality.Both)
-        //     preserves prerelease visibility.
-        //   - As of #17768, all polyglot starters write a project-local NuGet.config that pins
-        //     Aspire.* to the resolved channel's feed via PSM, so Implicit's `dotnet package
-        //     search` from the apphost cwd returns packages from the same feed the pinned
-        //     explicit channel would return — matching the C# behavior end-to-end.
+        // Why polyglot-with-pin drops Implicit (the subtle case):
+        //   - C# apphosts write a project-local NuGet.config at template-creation time that
+        //     pins Aspire.* to the resolved channel's feed via PSM. For C#, `GetConfiguredChannel`
+        //     returns null (line ~117), so this method searches only the Implicit channel,
+        //     whose `dotnet package search` reads that ambient NuGet.config and effectively
+        //     queries the pinned feed.
+        //   - Polyglot apphosts (TS/Python/Go) deliberately do NOT carry a persistent
+        //     NuGet.config — that file is a .NET-ism. Instead, restore is done via on-the-fly
+        //     `TemporaryNuGetConfig`s built from `aspire.config.json#channel` (see
+        //     PrebuiltAppHostServer.CreatePackageSourceOverrideNuGetConfigAsync). To match
+        //     C#'s end-to-end behavior in `aspire add`, when a polyglot apphost has pinned a
+        //     channel we search ONLY that pinned channel — its `GetIntegrationPackagesAsync`
+        //     already materializes a TemporaryNuGetConfig from the channel's PSM mappings
+        //     (PackageChannel.cs line ~120), giving the same scoped feed view that C#'s
+        //     persistent NuGet.config provides for its Implicit search.
+        //   - Including Implicit here would defeat the pin: Implicit's `dotnet package search`
+        //     runs against the ambient (user/global) NuGet.config which typically resolves to
+        //     nuget.org, surfacing stable-channel versions (e.g. 13.3.5) alongside the pinned
+        //     channel's versions (e.g. 13.4.0-preview from the darc feed). That produced the
+        //     spurious "select version" prompt for stable packages on a TS apphost pinned to
+        //     staging. C# never had this because, for C#, only Implicit is searched and its
+        //     ambient IS the pinned feed.
         var hasHives = executionContext.GetHiveCount() > 0;
-        var channels = hasHives
-            ? allChannels
-            : allChannels.Where(c =>
-                c.Type is PackageChannelType.Implicit ||
-                (!string.IsNullOrEmpty(configuredChannel) &&
-                 string.Equals(c.Name, configuredChannel, StringComparisons.ChannelName)));
+        IEnumerable<PackageChannel> channels;
+        if (!string.IsNullOrEmpty(configuredChannel))
+        {
+            channels = allChannels.Where(c =>
+                string.Equals(c.Name, configuredChannel, StringComparisons.ChannelName));
+        }
+        else if (hasHives)
+        {
+            channels = allChannels;
+        }
+        else
+        {
+            channels = allChannels.Where(c => c.Type is PackageChannelType.Implicit);
+        }
 
         var packages = new List<(NuGetPackage Package, PackageChannel Channel)>();
         var packagesLock = new object();

--- a/src/Aspire.Cli/Commands/IntegrationPackageSearchService.cs
+++ b/src/Aspire.Cli/Commands/IntegrationPackageSearchService.cs
@@ -31,20 +31,36 @@ internal sealed class IntegrationPackageSearchService(
 
         // Channels included in the search:
         //   * Implicit channel: always.
-        //   * Explicit channels (stable, daily, staging, custom): when PR hives exist OR the
-        //     apphost has pinned an explicit channel via aspire.config.json.
+        //   * PR hives: always when present.
+        //   * Apphost-pinned explicit channel: only the channel whose name matches
+        //     `configuredChannel` (no other explicit channels).
         //
-        // What this method MUST NOT do is narrow the explicit channel set to just the pinned
-        // channel. That was the root cause of https://github.com/microsoft/aspire/issues/17724
-        // and https://github.com/microsoft/aspire/issues/17725: a TS apphost pinned to a
-        // Quality.Stable channel ended up with prerelease=false queries everywhere and
-        // prerelease-only packages (e.g. Aspire.Hosting.Foundry) became invisible. The implicit
-        // channel (Quality.Both) must always participate so prerelease packages are reachable
-        // even when the explicit pin is Stable-quality.
+        // Why the explicit channel set is scoped to the pinned channel only — NOT the full
+        // explicit set — when an apphost pins a channel:
+        //   - The full set produces duplicate matches in `aspire add` (e.g. a staging-pinned
+        //     polyglot apphost would see Aspire.Hosting.Foundry surfaced by both the synthesized
+        //     'staging' channel AND the unrelated 'daily' channel, with the daily entry
+        //     pointing at a stale version like 13.3.5 that's not aligned with the project's
+        //     pinned feed). C# apphosts never had this problem: GetConfiguredChannel returns
+        //     null for C# (line ~99) and `configuredChannel` stays empty, so only Implicit is
+        //     queried and the project-local NuGet.config scopes the search to the right feed.
+        //   - Implicit MUST stay in the set so prerelease-only packages remain reachable when
+        //     the project pin is Stable-quality. This is the #17724 / #17725 guarantee:
+        //     pre-fix, the search was narrowed to *only* the pinned channel, and a Stable pin
+        //     made prerelease packages (Aspire.Hosting.Foundry) invisible because Quality.Stable
+        //     channels only issue prerelease=false queries. Keeping Implicit (Quality.Both)
+        //     preserves prerelease visibility.
+        //   - As of #17768, all polyglot starters write a project-local NuGet.config that pins
+        //     Aspire.* to the resolved channel's feed via PSM, so Implicit's `dotnet package
+        //     search` from the apphost cwd returns packages from the same feed the pinned
+        //     explicit channel would return — matching the C# behavior end-to-end.
         var hasHives = executionContext.GetHiveCount() > 0;
-        var channels = hasHives || !string.IsNullOrEmpty(configuredChannel)
+        var channels = hasHives
             ? allChannels
-            : allChannels.Where(c => c.Type is PackageChannelType.Implicit);
+            : allChannels.Where(c =>
+                c.Type is PackageChannelType.Implicit ||
+                (!string.IsNullOrEmpty(configuredChannel) &&
+                 string.Equals(c.Name, configuredChannel, StringComparisons.ChannelName)));
 
         var packages = new List<(NuGetPackage Package, PackageChannel Channel)>();
         var packagesLock = new object();

--- a/src/Aspire.Cli/Commands/NewCommand.cs
+++ b/src/Aspire.Cli/Commands/NewCommand.cs
@@ -456,9 +456,14 @@ internal sealed class NewCommand : BaseCommand, IPackageMetaPrefetchingCommand
                         return new ResolveTemplateVersionResult { ErrorMessage = $"No template versions found in channel '{selectedChannel.Name}'." };
                     }
 
-                    // Only persist explicit channel names (e.g. local, daily) — implicit channels
-                    // (stable/nuget.org) should not be written so aspire add uses its default behavior.
-                    var channelName = selectedChannel.Type is PackageChannelType.Explicit ? selectedChannel.Name : null;
+                    // Only persist channel names that pass `ShouldPersistChannelName` —
+                    // Implicit channels (nuget.org fallback) and the `stable` channel itself
+                    // are deliberately left unpinned so `aspire add` and later restores walk
+                    // ambient NuGet configuration and continue to surface prerelease packages
+                    // (a stable-pin would route through PackageChannelQuality.Stable and hide
+                    // them). Mirrors the same gate at the end of `ResolveIdentityChannelNameAsync`
+                    // and `InitCommand.ResolvePersistableChannelNameAsync`.
+                    var channelName = selectedChannel.ShouldPersistChannelName() ? selectedChannel.Name : null;
 
                     return new ResolveTemplateVersionResult { Version = package.Version, ChannelName = channelName };
                 }
@@ -589,11 +594,17 @@ internal sealed class NewCommand : BaseCommand, IPackageMetaPrefetchingCommand
         var match = channels.FirstOrDefault(c =>
             string.Equals(c.Name, identity, StringComparisons.ChannelName));
 
-        // Only persist Explicit channel names — Implicit channels (the nuget.org fallback)
-        // are deliberately left unpinned so `aspire add` and later restores use ambient
-        // NuGet configuration. Mirrors the same rule applied at the end of
-        // ResolveCliTemplateVersionAsync.
-        return match is { Type: PackageChannelType.Explicit } ? match.Name : null;
+        // Only persist channel names that pass `ShouldPersistChannelName` — Implicit channels
+        // (the nuget.org fallback) and the `stable` channel itself are deliberately left
+        // unpinned so `aspire add` and later restores use ambient NuGet configuration and
+        // continue to surface prerelease packages from nuget.org. Persisting `"stable"` in
+        // `aspire.config.json#channel` would route subsequent `aspire add` calls through the
+        // Stable channel (PackageChannelQuality.Stable), filtering out a 13.4.0-preview
+        // community integration the team published before its matching stable release —
+        // the exact regression that motivated `ShouldPersistChannelName` in the first place.
+        // Mirrors `InitCommand.ResolvePersistableChannelNameAsync` so polyglot `aspire init`
+        // and `aspire new` agree on what gets pinned.
+        return match?.ShouldPersistChannelName() is true ? match.Name : null;
     }
 }
 

--- a/src/Aspire.Cli/Commands/NewCommand.cs
+++ b/src/Aspire.Cli/Commands/NewCommand.cs
@@ -177,14 +177,15 @@ internal sealed class NewCommand : BaseCommand, IPackageMetaPrefetchingCommand
         return selected.LanguageId;
     }
 
-    private static NuGetPackage? TryGetCurrentCliTemplateVersionPackage(PackageChannel selectedChannel, NuGetPackage[] packages, bool hasPrHives)
+    private static NuGetPackage? TryGetCurrentCliTemplateVersionPackage(PackageChannel selectedChannel, NuGetPackage[] packages, bool hasPrHives, CliExecutionContext executionContext)
     {
         if (VersionHelper.TryGetCurrentCliVersionMatch(
             packages,
             p => p.Version,
             out var cliVersionPackage,
             channelName: selectedChannel.Name,
-            hasPrHives: hasPrHives))
+            hasPrHives: hasPrHives,
+            context: executionContext))
         {
             return cliVersionPackage;
         }
@@ -212,7 +213,7 @@ internal sealed class NewCommand : BaseCommand, IPackageMetaPrefetchingCommand
             return new NuGetPackage
             {
                 Id = TemplateNuGetConfigService.TemplatesPackageName,
-                Version = VersionHelper.GetDefaultSdkVersion(),
+                Version = VersionHelper.GetDefaultSdkVersion(executionContext),
                 Source = selectedChannel.SourceDetails
             };
         }
@@ -444,7 +445,7 @@ internal sealed class NewCommand : BaseCommand, IPackageMetaPrefetchingCommand
                         .ToArray();
                     var hasPrHives = ExecutionContext.GetHiveCount() > 0;
 
-                    var package = TryGetCurrentCliTemplateVersionPackage(selectedChannel, packages, hasPrHives);
+                    var package = TryGetCurrentCliTemplateVersionPackage(selectedChannel, packages, hasPrHives, ExecutionContext);
 
                     package ??= packages
                         .OrderByDescending(p => Semver.SemVersion.Parse(p.Version, Semver.SemVersionStyles.Strict), Semver.SemVersion.PrecedenceComparer)

--- a/src/Aspire.Cli/Commands/NewCommand.cs
+++ b/src/Aspire.Cli/Commands/NewCommand.cs
@@ -374,11 +374,33 @@ internal sealed class NewCommand : BaseCommand, IPackageMetaPrefetchingCommand
                 // registered channel (e.g. typoed override, future identity name) so the
                 // command stays useful while surfacing a deterministic version.
                 PackageChannel? identityChannelMatch = null;
-                if (string.IsNullOrWhiteSpace(configuredChannelName) &&
-                    !string.IsNullOrWhiteSpace(ExecutionContext.IdentityChannel))
+                if (string.IsNullOrWhiteSpace(configuredChannelName))
                 {
-                    identityChannelMatch = channels.FirstOrDefault(c =>
-                        string.Equals(c.Name, ExecutionContext.IdentityChannel, StringComparisons.ChannelName));
+                    // Consult IPackagingService.GetEffectiveIdentityChannel first so the
+                    // overrideCliIdentityChannel diagnostic env var (used by
+                    // eng/scripts/debug-staging.sh to validate staging feed routing from a
+                    // locally built CLI) is honored end-to-end. Without this, a local-identity
+                    // CLI run with overrideCliIdentityChannel=staging would correctly synthesize
+                    // the staging channel in PackagingService but then ignore it here (no
+                    // "local" channel exists in the list) and fall through to the Implicit
+                    // (nuget.org) channel — silently resolving the previous shipped stable
+                    // Aspire.ProjectTemplates (e.g. 13.3.5) instead of the SHA-specific staging
+                    // build's matching version. See also VersionHelper.GetDefaultTemplateVersion
+                    // which honors the parallel overrideCliInformationalVersion env var.
+                    //
+                    // Falls back to ExecutionContext.IdentityChannel when the packaging service
+                    // returns null/empty (used by test fakes that don't model identity routing).
+                    var effectiveIdentity = _packagingService.GetEffectiveIdentityChannel();
+                    if (string.IsNullOrWhiteSpace(effectiveIdentity))
+                    {
+                        effectiveIdentity = ExecutionContext.IdentityChannel;
+                    }
+
+                    if (!string.IsNullOrWhiteSpace(effectiveIdentity))
+                    {
+                        identityChannelMatch = channels.FirstOrDefault(c =>
+                            string.Equals(c.Name, effectiveIdentity, StringComparisons.ChannelName));
+                    }
                 }
 
                 var selectedChannel = string.IsNullOrWhiteSpace(configuredChannelName)

--- a/src/Aspire.Cli/Commands/NewCommand.cs
+++ b/src/Aspire.Cli/Commands/NewCommand.cs
@@ -584,7 +584,29 @@ internal sealed class NewCommand : BaseCommand, IPackageMetaPrefetchingCommand
     /// </summary>
     private async Task<string?> ResolveIdentityChannelNameAsync(CancellationToken cancellationToken)
     {
-        var identity = ExecutionContext.IdentityChannel;
+        // Consult IPackagingService.GetEffectiveIdentityChannel first so the
+        // overrideCliIdentityChannel diagnostic env var (used by
+        // eng/scripts/debug-staging.sh to validate staging feed routing from a
+        // locally built CLI) is honored on the DotNet-runtime template path.
+        // Without this, a local-identity CLI run with overrideCliIdentityChannel=staging
+        // would correctly route through PackagingService for `aspire add` but leave
+        // TemplateInputs.Channel null for `aspire new <C# starter>`, so
+        // DotNetTemplateFactory would search only the Implicit (nuget.org) channel
+        // and silently resolve the last-shipped stable Aspire.ProjectTemplates
+        // (e.g. 13.3.5) instead of the staging build's matching version on the
+        // darc feed. Mirrors the same fix in
+        // `ResolveCliTemplateVersionAsync` (CLI-runtime path) and
+        // `InitCommand.ResolvePersistableChannelNameAsync` so all three template-
+        // selection entry points stay consistent under the diagnostic override.
+        //
+        // Falls back to ExecutionContext.IdentityChannel when the packaging service
+        // returns empty (used by test fakes that don't model identity routing).
+        var identity = _packagingService.GetEffectiveIdentityChannel();
+        if (string.IsNullOrWhiteSpace(identity))
+        {
+            identity = ExecutionContext.IdentityChannel;
+        }
+
         if (string.IsNullOrWhiteSpace(identity))
         {
             return null;

--- a/src/Aspire.Cli/Packaging/PackageChannel.cs
+++ b/src/Aspire.Cli/Packaging/PackageChannel.cs
@@ -14,13 +14,20 @@ using NuGetPackage = Aspire.Shared.NuGetPackageCli;
 
 namespace Aspire.Cli.Packaging;
 
-internal class PackageChannel(string name, PackageChannelQuality quality, PackageMapping[]? mappings, INuGetPackageCache nuGetPackageCache, IFeatures features, bool configureGlobalPackagesFolder = false, string? cliDownloadBaseUrl = null, string? pinnedVersion = null, ILogger? logger = null)
+internal class PackageChannel(string name, PackageChannelQuality quality, PackageMapping[]? mappings, INuGetPackageCache nuGetPackageCache, IFeatures features, bool configureGlobalPackagesFolder = false, string? cliDownloadBaseUrl = null, string? pinnedVersion = null, ILogger? logger = null, CliExecutionContext? executionContext = null)
 {
     // Threaded so the local-folder integration listing can honor the same
     // ShowDeprecatedPackages flag that NuGetPackageCache honors on the feed-based path.
     // Without this, flipping the flag silently has no effect on local hive / PR hive listings
     // (https://github.com/microsoft/aspire/issues — divergence between two paths through the same intent).
     private readonly IFeatures _features = features;
+
+    // Plumbed in so VersionHelper.GetDefault*Version calls below can honor the
+    // overrideCliInformationalVersion env var via CliExecutionContext.GetEnvironmentVariable
+    // (matching CliExecutionContext's "custom env dictionary wins over process env" contract).
+    // Tests that construct PackageChannel directly may omit this; VersionHelper then falls back
+    // to the process environment, which is also what shipped builds see.
+    private readonly CliExecutionContext? _executionContext = executionContext;
 
     private const string GuestAppHostSdkPackageId = "Aspire.Hosting";
 
@@ -87,7 +94,7 @@ internal class PackageChannel(string name, PackageChannelQuality quality, Packag
         // When doing a `dotnet package search` the results may include stable packages even when searching for
         // prerelease packages. Keep the current CLI/SDK version so shipped CLIs can resolve their
         // matching template package from daily/staging feeds, then filter out the remaining noise.
-        var currentCliVersion = VersionHelper.GetDefaultSdkVersion();
+        var currentCliVersion = VersionHelper.GetDefaultSdkVersion(_executionContext);
         var filteredPackages = packages.Where(p => new { SemVer = SemVersion.Parse(p.Version), Quality = Quality } switch
         {
             { Quality: PackageChannelQuality.Both } => true,
@@ -398,7 +405,7 @@ internal class PackageChannel(string name, PackageChannelQuality quality, Packag
             .SelectMany(mapping => CreateScopedMappings(mapping, requestedPackageIds, logger))
             .ToArray();
 
-        return new PackageChannel(Name, Quality, scopedMappings, nuGetPackageCache, _features, ConfigureGlobalPackagesFolder, CliDownloadBaseUrl, PinnedVersion, logger);
+        return new PackageChannel(Name, Quality, scopedMappings, nuGetPackageCache, _features, ConfigureGlobalPackagesFolder, CliDownloadBaseUrl, PinnedVersion, logger, _executionContext);
     }
 
     private static IEnumerable<PackageMapping> CreateScopedMappings(PackageMapping mapping, IReadOnlyCollection<string> packageIds, ILogger? logger)
@@ -562,18 +569,18 @@ internal class PackageChannel(string name, PackageChannelQuality quality, Packag
         return isHostingOrCommunityToolkitNamespaced && !isExcluded;
     }
 
-    public static PackageChannel CreateExplicitChannel(string name, PackageChannelQuality quality, PackageMapping[]? mappings, INuGetPackageCache nuGetPackageCache, IFeatures features, bool configureGlobalPackagesFolder = false, string? cliDownloadBaseUrl = null, string? pinnedVersion = null, ILogger? logger = null)
+    public static PackageChannel CreateExplicitChannel(string name, PackageChannelQuality quality, PackageMapping[]? mappings, INuGetPackageCache nuGetPackageCache, IFeatures features, bool configureGlobalPackagesFolder = false, string? cliDownloadBaseUrl = null, string? pinnedVersion = null, ILogger? logger = null, CliExecutionContext? executionContext = null)
     {
-        return new PackageChannel(name, quality, mappings, nuGetPackageCache, features, configureGlobalPackagesFolder, cliDownloadBaseUrl, pinnedVersion, logger);
+        return new PackageChannel(name, quality, mappings, nuGetPackageCache, features, configureGlobalPackagesFolder, cliDownloadBaseUrl, pinnedVersion, logger, executionContext);
     }
 
-    public static PackageChannel CreateImplicitChannel(INuGetPackageCache nuGetPackageCache, IFeatures features, ILogger? logger = null)
+    public static PackageChannel CreateImplicitChannel(INuGetPackageCache nuGetPackageCache, IFeatures features, ILogger? logger = null, CliExecutionContext? executionContext = null)
     {
         // The reason that PackageChannelQuality.Both is because there are situations like
         // in community toolkit where there is a newer beta version available for a package
         // in the case of implicit feeds we want to be able to show that, along side the stable
         // version. Not really an issue for template selection though (unless we start allowing)
         // for broader templating options.
-        return new PackageChannel("default", PackageChannelQuality.Both, null, nuGetPackageCache, features, logger: logger);
+        return new PackageChannel("default", PackageChannelQuality.Both, null, nuGetPackageCache, features, logger: logger, executionContext: executionContext);
     }
 }

--- a/src/Aspire.Cli/Packaging/PackagingService.cs
+++ b/src/Aspire.Cli/Packaging/PackagingService.cs
@@ -36,6 +36,25 @@ internal interface IPackagingService
     /// <c>overrideStagingFeed</c> or enabled the staging feature flag.
     /// </remarks>
     string? GetStagingChannelUnavailableReason();
+
+    /// <summary>
+    /// Returns the identity channel the packaging service is acting on behalf of: normally the
+    /// CLI's baked <c>AspireCliChannel</c> assembly metadata (<see cref="CliExecutionContext.IdentityChannel"/>),
+    /// but redirected to the <c>overrideCliIdentityChannel</c> configuration value when that
+    /// diagnostic override is set (used by <c>eng/scripts/debug-staging.sh</c> to validate staging
+    /// feed routing from a locally built CLI).
+    /// </summary>
+    /// <remarks>
+    /// Commands that auto-select a channel based on the running CLI's identity (e.g. <c>aspire new</c>
+    /// preferring the staging channel on a staging-identity build) must consult this value rather than
+    /// <see cref="CliExecutionContext.IdentityChannel"/> directly. Otherwise the override gives
+    /// half-emulation: <see cref="PackagingService"/> synthesizes the staging channel correctly but
+    /// the caller still sees the baked <c>local</c> identity and falls back to the implicit
+    /// nuget.org channel, resolving stale packages (e.g. the previous shipped stable
+    /// <c>Aspire.ProjectTemplates</c> 13.3.5 instead of the SHA-specific staging build's matching
+    /// version).
+    /// </remarks>
+    string GetEffectiveIdentityChannel();
 }
 
 internal class PackagingService : IPackagingService
@@ -379,7 +398,7 @@ internal class PackagingService : IPackagingService
     // global identity used elsewhere (hive/packages directory lookups), keeping the blast radius
     // limited to feed provenance. Invalid override values are ignored — we fall back to the real
     // identity, mirroring how overrideStagingFeed ignores malformed URLs.
-    private string GetEffectiveIdentityChannel()
+    public string GetEffectiveIdentityChannel()
     {
         var overrideChannel = _configuration[OverrideCliIdentityChannelConfigKey];
         if (!string.IsNullOrEmpty(overrideChannel) && IdentityChannelReader.IsValidChannel(overrideChannel))

--- a/src/Aspire.Cli/Packaging/PackagingService.cs
+++ b/src/Aspire.Cli/Packaging/PackagingService.cs
@@ -149,18 +149,18 @@ internal class PackagingService : IPackagingService
         // (e.g. an override that ultimately resolves to a non-staging identity still warns).
         WarnIfStagingDiagnosticOverridesActive();
 
-        var defaultChannel = PackageChannel.CreateImplicitChannel(_nuGetPackageCache, _features, _logger);
+        var defaultChannel = PackageChannel.CreateImplicitChannel(_nuGetPackageCache, _features, _logger, _executionContext);
         
         var stableChannel = PackageChannel.CreateExplicitChannel(PackageChannelNames.Stable, PackageChannelQuality.Stable, new[]
         {
             new PackageMapping(PackageMapping.AllPackages, PackageSources.NuGetOrg)
-        }, _nuGetPackageCache, _features, cliDownloadBaseUrl: "https://aka.ms/dotnet/9/aspire/ga/daily", logger: _logger);
+        }, _nuGetPackageCache, _features, cliDownloadBaseUrl: "https://aka.ms/dotnet/9/aspire/ga/daily", logger: _logger, executionContext: _executionContext);
 
         var dailyChannel = PackageChannel.CreateExplicitChannel(PackageChannelNames.Daily, PackageChannelQuality.Prerelease, new[]
         {
             new PackageMapping("Aspire*", "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet9/nuget/v3/index.json"),
             new PackageMapping(PackageMapping.AllPackages, PackageSources.NuGetOrg)
-        }, _nuGetPackageCache, _features, cliDownloadBaseUrl: "https://aka.ms/dotnet/9/aspire/daily", logger: _logger);
+        }, _nuGetPackageCache, _features, cliDownloadBaseUrl: "https://aka.ms/dotnet/9/aspire/daily", logger: _logger, executionContext: _executionContext);
 
         var prPackageChannels = new List<PackageChannel>();
 
@@ -273,7 +273,7 @@ internal class PackagingService : IPackagingService
         {
             new PackageMapping("Aspire*", packagesPath),
             new PackageMapping(PackageMapping.AllPackages, PackageSources.NuGetOrg)
-        }, _nuGetPackageCache, _features, pinnedVersion: pinnedVersion, logger: _logger);
+        }, _nuGetPackageCache, _features, pinnedVersion: pinnedVersion, logger: _logger, executionContext: _executionContext);
     }
 
     internal static DirectoryInfo? TryResolvePrInstallPackagesDirectory(string? processPath, string identityChannel)
@@ -322,11 +322,11 @@ internal class PackagingService : IPackagingService
     // Used by the staging-channel synthesis to route stabilizing builds to the SHA-derived darc
     // feed instead of the shared dotnet9 daily feed. Falls back to false on any error so we
     // preserve the historical Both/shared-feed behavior rather than silently misrouting.
-    private static bool IsStableShapedCliVersionFromAssembly()
+    private bool IsStableShapedCliVersionFromAssembly()
     {
         try
         {
-            var version = VersionHelper.GetDefaultSdkVersion();
+            var version = VersionHelper.GetDefaultSdkVersion(_executionContext);
             return !string.IsNullOrEmpty(version) && !version.Contains('-');
         }
         catch
@@ -487,7 +487,7 @@ internal class PackagingService : IPackagingService
         {
             new PackageMapping("Aspire*", stagingFeedUrl),
             new PackageMapping(PackageMapping.AllPackages, PackageSources.NuGetOrg)
-        }, _nuGetPackageCache, _features, configureGlobalPackagesFolder: !useSharedFeed, cliDownloadBaseUrl: "https://aka.ms/dotnet/9/aspire/rc/daily", pinnedVersion: pinnedVersion, logger: _logger);
+        }, _nuGetPackageCache, _features, configureGlobalPackagesFolder: !useSharedFeed, cliDownloadBaseUrl: "https://aka.ms/dotnet/9/aspire/rc/daily", pinnedVersion: pinnedVersion, logger: _logger, executionContext: _executionContext);
 
         // Surface the resolved staging routing so users can see what `--channel staging` actually
         // picked (the "show what was resolved" suggestion from the issue RCA). Pinned version is
@@ -657,7 +657,7 @@ internal class PackagingService : IPackagingService
         }
 
         // Get the CLI's own version and strip build metadata (+hash)
-        var cliVersion = Utils.VersionHelper.GetDefaultTemplateVersion();
+        var cliVersion = Utils.VersionHelper.GetDefaultTemplateVersion(_executionContext);
         var plusIndex = cliVersion.IndexOf('+');
         return plusIndex >= 0 ? cliVersion[..plusIndex] : cliVersion;
     }

--- a/src/Aspire.Cli/Projects/GuestAppHostProject.cs
+++ b/src/Aspire.Cli/Projects/GuestAppHostProject.cs
@@ -1621,7 +1621,7 @@ internal sealed class GuestAppHostProject : IAppHostProject, IGuestAppHostSdkGen
                 return;
             }
 
-            var cliVersion = VersionHelper.GetDefaultSdkVersion();
+            var cliVersion = VersionHelper.GetDefaultSdkVersion(_executionContext);
             if (!IsKnownIncompatibleSkew(cliVersion, configuredSdkVersion))
             {
                 return;

--- a/src/Aspire.Cli/Templating/CliTemplateFactory.EmptyTemplate.cs
+++ b/src/Aspire.Cli/Templating/CliTemplateFactory.EmptyTemplate.cs
@@ -103,7 +103,12 @@ internal sealed partial class CliTemplateFactory
 
             if (!isCsharp)
             {
-                await _templateNuGetConfigService.CreateOrUpdateNuGetConfigForSourceOverrideAsync(inputs.Source, inputs.Channel, outputPath, cancellationToken);
+                // See CliTemplateFactory.TypeScriptStarterTemplate for why the channel-derived
+                // NuGet.config fallback is required when no --source override is supplied.
+                if (!await _templateNuGetConfigService.CreateOrUpdateNuGetConfigForSourceOverrideAsync(inputs.Source, inputs.Channel, outputPath, cancellationToken))
+                {
+                    await _templateNuGetConfigService.CreateOrUpdateNuGetConfigWithoutPromptAsync(inputs.Channel, outputPath, cancellationToken);
+                }
             }
         }
         catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)

--- a/src/Aspire.Cli/Templating/CliTemplateFactory.GoStarterTemplate.cs
+++ b/src/Aspire.Cli/Templating/CliTemplateFactory.GoStarterTemplate.cs
@@ -87,7 +87,12 @@ internal sealed partial class CliTemplateFactory
                         _interactionService.DisplayError("Automatic 'aspire restore' failed for the new Go starter project. Run 'aspire restore' in the project directory for more details.");
                         return new TemplateResult((int)CliExitCodes.FailedToBuildArtifacts, outputPath);
                     }
-                    await _templateNuGetConfigService.CreateOrUpdateNuGetConfigForSourceOverrideAsync(inputs.Source, inputs.Channel, outputPath, cancellationToken);
+                    // See CliTemplateFactory.TypeScriptStarterTemplate for why the channel-derived
+                    // NuGet.config fallback is required when no --source override is supplied.
+                    if (!await _templateNuGetConfigService.CreateOrUpdateNuGetConfigForSourceOverrideAsync(inputs.Source, inputs.Channel, outputPath, cancellationToken))
+                    {
+                        await _templateNuGetConfigService.CreateOrUpdateNuGetConfigWithoutPromptAsync(inputs.Channel, outputPath, cancellationToken);
+                    }
 
                     return new TemplateResult((int)CliExitCodes.Success, outputPath);
                 }), emoji: KnownEmojis.Rocket);

--- a/src/Aspire.Cli/Templating/CliTemplateFactory.PythonStarterTemplate.cs
+++ b/src/Aspire.Cli/Templating/CliTemplateFactory.PythonStarterTemplate.cs
@@ -101,7 +101,12 @@ internal sealed partial class CliTemplateFactory
                         _interactionService.DisplayError("Automatic 'aspire restore' failed for the new Python starter project. Run 'aspire restore' in the project directory for more details.");
                         return new TemplateResult((int)CliExitCodes.FailedToBuildArtifacts, outputPath);
                     }
-                    await _templateNuGetConfigService.CreateOrUpdateNuGetConfigForSourceOverrideAsync(inputs.Source, inputs.Channel, outputPath, cancellationToken);
+                    // See CliTemplateFactory.TypeScriptStarterTemplate for why the channel-derived
+                    // NuGet.config fallback is required when no --source override is supplied.
+                    if (!await _templateNuGetConfigService.CreateOrUpdateNuGetConfigForSourceOverrideAsync(inputs.Source, inputs.Channel, outputPath, cancellationToken))
+                    {
+                        await _templateNuGetConfigService.CreateOrUpdateNuGetConfigWithoutPromptAsync(inputs.Channel, outputPath, cancellationToken);
+                    }
 
                     return new TemplateResult((int)CliExitCodes.Success, outputPath);
                 }), emoji: KnownEmojis.Rocket);

--- a/src/Aspire.Cli/Templating/CliTemplateFactory.TypeScriptStarterTemplate.cs
+++ b/src/Aspire.Cli/Templating/CliTemplateFactory.TypeScriptStarterTemplate.cs
@@ -86,7 +86,19 @@ internal sealed partial class CliTemplateFactory
                         _interactionService.DisplayError("Automatic 'aspire restore' failed for the new TypeScript starter project. Run 'aspire restore' in the project directory for more details.");
                         return new TemplateResult((int)CliExitCodes.FailedToBuildArtifacts, outputPath);
                     }
-                    await _templateNuGetConfigService.CreateOrUpdateNuGetConfigForSourceOverrideAsync(inputs.Source, inputs.Channel, outputPath, cancellationToken);
+                    // Prefer the source-override NuGet.config when --source was supplied; otherwise
+                    // fall back to a channel-derived NuGet.config so the new project carries the
+                    // same Aspire.* → channel-feed package source mapping that C# starters get
+                    // (DotNetTemplateFactory.cs line ~549-552). Without this, the implicit channel
+                    // used by `aspire add` (IntegrationPackageSearchService always includes it so
+                    // prerelease-only packages stay reachable on Stable-pinned projects) resolves
+                    // Aspire.Hosting.* from the user's ambient NuGet.org and surfaces a stale
+                    // version alongside the staging darc-feed match — the bug PR #17743 was meant
+                    // to close end-to-end for polyglot apphosts.
+                    if (!await _templateNuGetConfigService.CreateOrUpdateNuGetConfigForSourceOverrideAsync(inputs.Source, inputs.Channel, outputPath, cancellationToken))
+                    {
+                        await _templateNuGetConfigService.CreateOrUpdateNuGetConfigWithoutPromptAsync(inputs.Channel, outputPath, cancellationToken);
+                    }
 
                     return new TemplateResult((int)CliExitCodes.Success, outputPath);
                 }), emoji: KnownEmojis.Rocket);

--- a/src/Aspire.Cli/Utils/VersionHelper.cs
+++ b/src/Aspire.Cli/Utils/VersionHelper.cs
@@ -58,6 +58,31 @@ internal static class VersionHelper
 
     public static string GetDefaultTemplateVersion()
     {
+        // Honor the same diagnostic override that PackagingService uses to simulate a
+        // different CLI identity/version for end-to-end staging validation. Without this,
+        // a locally built CLI emulating a staging build via `eng/scripts/debug-staging.sh`
+        // would correctly ROUTE package search at the darc staging feed (PackagingService
+        // reads the override) but would still REPORT its own stamped assembly version to
+        // everything else — template selection (TryGetCurrentCliVersionMatch), the SDK
+        // version written into aspire.config.json, the CLI banner, telemetry, etc. The
+        // resulting half-emulation surfaces a "CLI version differs from configured SDK
+        // version" warning and stamps the wrong SDK version into newly-scaffolded
+        // projects.
+        //
+        // Scope is deliberately narrow:
+        //   * The env var is documented on PackagingService as a diagnostic override.
+        //   * It is read here via Environment.GetEnvironmentVariable (not IConfiguration)
+        //     to keep this static helper dependency-free.
+        //   * Real shipped builds never set this variable, so production behavior is
+        //     identical to reading the assembly attribute.
+        // See https://github.com/microsoft/aspire/blob/main/docs/cli-staging-validation.md
+        // and PackagingService.OverrideCliInformationalVersionConfigKey.
+        var overrideVersion = Environment.GetEnvironmentVariable("overrideCliInformationalVersion");
+        if (!string.IsNullOrWhiteSpace(overrideVersion))
+        {
+            return overrideVersion;
+        }
+
         return PackageUpdateHelpers.GetCurrentAssemblyVersion() ?? throw new InvalidOperationException(ErrorStrings.UnableToRetrieveAssemblyVersion);
     }
 

--- a/src/Aspire.Cli/Utils/VersionHelper.cs
+++ b/src/Aspire.Cli/Utils/VersionHelper.cs
@@ -31,7 +31,8 @@ internal static class VersionHelper
         Func<T, string?> versionSelector,
         [MaybeNullWhen(false)] out T match,
         string? channelName,
-        bool hasPrHives)
+        bool hasPrHives,
+        CliExecutionContext? context = null)
     {
         ArgumentNullException.ThrowIfNull(candidates);
         ArgumentNullException.ThrowIfNull(versionSelector);
@@ -42,7 +43,7 @@ internal static class VersionHelper
             return false;
         }
 
-        var cliVersion = GetDefaultSdkVersion();
+        var cliVersion = GetDefaultSdkVersion(context);
         foreach (var candidate in candidates)
         {
             if (string.Equals(versionSelector(candidate), cliVersion, StringComparison.OrdinalIgnoreCase))
@@ -56,7 +57,7 @@ internal static class VersionHelper
         return false;
     }
 
-    public static string GetDefaultTemplateVersion()
+    public static string GetDefaultTemplateVersion(CliExecutionContext? context = null)
     {
         // Honor the same diagnostic override that PackagingService uses to simulate a
         // different CLI identity/version for end-to-end staging validation. Without this,
@@ -69,15 +70,18 @@ internal static class VersionHelper
         // version" warning and stamps the wrong SDK version into newly-scaffolded
         // projects.
         //
-        // Scope is deliberately narrow:
-        //   * The env var is documented on PackagingService as a diagnostic override.
-        //   * It is read here via Environment.GetEnvironmentVariable (not IConfiguration)
-        //     to keep this static helper dependency-free.
-        //   * Real shipped builds never set this variable, so production behavior is
-        //     identical to reading the assembly attribute.
+        // Read the env var through CliExecutionContext when a context is supplied so the
+        // process-environment vs. test-supplied-dictionary distinction matches the rest of
+        // the CLI (see CliExecutionContext.GetEnvironmentVariable's "if a custom env was
+        // provided, do not fall back to the process" contract). When no context is
+        // supplied (call sites that don't have one handy, like the banner / telemetry),
+        // fall back to the process env directly — those callers never participated in the
+        // override loop before this PR, so process-env reads preserve their behavior.
         // See https://github.com/microsoft/aspire/blob/main/docs/cli-staging-validation.md
         // and PackagingService.OverrideCliInformationalVersionConfigKey.
-        var overrideVersion = Environment.GetEnvironmentVariable("overrideCliInformationalVersion");
+        var overrideVersion = context is not null
+            ? context.GetEnvironmentVariable("overrideCliInformationalVersion")
+            : Environment.GetEnvironmentVariable("overrideCliInformationalVersion");
         if (!string.IsNullOrWhiteSpace(overrideVersion))
         {
             return overrideVersion;
@@ -90,9 +94,9 @@ internal static class VersionHelper
     /// Gets the default Aspire SDK version based on the CLI version.
     /// The CLI version is the SDK version — the bundled server and packages must match.
     /// </summary>
-    public static string GetDefaultSdkVersion()
+    public static string GetDefaultSdkVersion(CliExecutionContext? context = null)
     {
-        var version = GetDefaultTemplateVersion();
+        var version = GetDefaultTemplateVersion(context);
 
         // Strip the commit SHA suffix (e.g., "9.2.0+abc123" -> "9.2.0")
         var plusIndex = version.IndexOf('+');

--- a/tests/Aspire.Cli.Tests/Commands/AddCommandTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/AddCommandTests.cs
@@ -354,6 +354,136 @@ public class AddCommandTests(ITestOutputHelper outputHelper)
     }
 
     [Fact]
+    public async Task AddCommandWithTypeScriptAppHostPinnedToStagingAutoSelectsImplicitVersionWithoutPromptingForVersion()
+    {
+        // Regression for the polyglot/C# divergence in `aspire add` interactive flow.
+        //
+        // Before this fix, a TypeScript apphost stamped with `"channel": "staging"` would still
+        // see a version-picker prompt (Implicit / Staging / Daily rows) when running
+        // `aspire add foundry`, while a C# apphost would auto-select the staging-version
+        // immediately. The divergence was caused by two issues working together:
+        //
+        //   1. IntegrationPackageSearchService included EVERY explicit channel (stable + daily +
+        //      staging + ...) whenever any channel was pinned for non-C# apphosts. That added a
+        //      bogus "daily" row (with a stale version) to the version prompter.
+        //   2. The version prompter grouped by channel without deduplicating by (Id, Version),
+        //      so a package surfaced by BOTH Implicit (via the project-local NuGet.config that
+        //      polyglot starters now write) AND the matching pinned Explicit channel showed up
+        //      twice — preventing the single-implicit auto-select path from firing.
+        //
+        // Fix: IPSS narrows explicit channels to the apphost-pinned channel only; AddCommand
+        // dedupes by (Id, Version) preferring the Implicit-channel entry. Net effect for a
+        // staging-pinned TS apphost: only the Implicit Foundry entry remains, which triggers
+        // PromptForChannelPackagesAsync's `explicitGroups.Length == 0 && implicitGroup is not
+        // null` auto-select.
+        var promptedForVersion = false;
+        var testInteractionService = new TestInteractionService
+        {
+            // The real AddCommandPrompter's auto-select path returns the implicit-channel
+            // package without ever asking the IInteractionService to render a selection.
+            // If this callback fires, the prompter fell through to the channel/version menu,
+            // which is exactly the polyglot/C# divergence we're guarding against.
+            PromptForSelectionCallback = (promptText, choices, formatter, _) =>
+            {
+                promptedForVersion = true;
+                var rendered = string.Join(", ", choices.Cast<object>().Select(c => formatter(c)));
+                throw new InvalidOperationException(
+                    $"Selection prompt was raised when none was expected. Prompt='{promptText}'. Choices=[{rendered}]");
+            }
+        };
+
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        var appHostFile = new FileInfo(Path.Combine(workspace.WorkspaceRoot.FullName, "apphost.ts"));
+        File.WriteAllText(appHostFile.FullName, string.Empty);
+        File.WriteAllText(Path.Combine(workspace.WorkspaceRoot.FullName, AspireConfigFile.FileName), """
+            {
+              "channel": "staging"
+            }
+            """);
+
+        // Implicit returns the staging version (because the project-local NuGet.config written
+        // by `aspire new` for polyglot starters pins Aspire.* to the staging feed).
+        var implicitCache = new FakeNuGetPackageCache
+        {
+            GetIntegrationPackagesAsyncCallback = (_, _, _, _) =>
+                Task.FromResult<IEnumerable<NuGetPackage>>([CreatePackage("Aspire.Hosting.Foundry", "13.4.0-preview.1.staging")])
+        };
+
+        // Staging explicit channel returns the same version. Pre-dedupe, this would have shown
+        // up as a duplicate row in the version prompter.
+        var stagingCache = new FakeNuGetPackageCache
+        {
+            GetIntegrationPackagesAsyncCallback = (_, _, _, _) =>
+                Task.FromResult<IEnumerable<NuGetPackage>>([CreatePackage("Aspire.Hosting.Foundry", "13.4.0-preview.1.staging")])
+        };
+
+        // Daily returns a stale version. Pre-narrowing (when the channel set wasn't filtered by
+        // the pinned channel name), this stale entry would have appeared as a "daily" row in
+        // the version prompt — the exact symptom the user reported (13.3.5 surfaced under TS).
+        var dailyCache = new FakeNuGetPackageCache
+        {
+            GetIntegrationPackagesAsyncCallback = (_, _, _, _) =>
+                Task.FromResult<IEnumerable<NuGetPackage>>([CreatePackage("Aspire.Hosting.Foundry", "13.3.5-preview.1.daily")])
+        };
+
+        // Stable returns nothing (Foundry is prerelease-only). Included to mirror the real
+        // PackagingService channel set under IdentityChannel=staging: implicit + stable +
+        // staging + daily.
+        var stableCache = new FakeNuGetPackageCache
+        {
+            GetIntegrationPackagesAsyncCallback = (_, _, _, _) => Task.FromResult<IEnumerable<NuGetPackage>>([])
+        };
+
+        string? addedPackageVersion = null;
+        var tsProjectFactory = new TestTypeScriptStarterProjectFactory((_, _, _) => Task.FromResult(true));
+        tsProjectFactory.Project.AddPackageAsyncCallback = (context, _) =>
+        {
+            addedPackageVersion = context.PackageVersion;
+            return Task.FromResult(true);
+        };
+
+        var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper, options =>
+        {
+            // Force interactive mode so AddCommand goes down the version-prompter path rather
+            // than the non-interactive `orderedPackageVersions.First()` shortcut (which would
+            // pick the right answer even without the fix and silently hide the regression).
+            options.CliHostEnvironmentFactory = _ => TestHelpers.CreateInteractiveHostEnvironment();
+
+            // Use a real AddCommandPrompter (no factory override). Its auto-select logic
+            // is what we're testing — it should pick the deduped implicit entry without
+            // routing through interactionService.PromptForSelectionAsync.
+            options.InteractionServiceFactory = _ => testInteractionService;
+
+            options.ProjectLocatorFactory = _ => new TestProjectLocator
+            {
+                UseOrFindAppHostProjectFileWithBehaviorAsyncCallback = (file, _, _, _) =>
+                    Task.FromResult(new AppHostProjectSearchResult(file ?? appHostFile, []))
+            };
+
+            options.PackagingServiceFactory = _ => new TestPackagingService
+            {
+                GetChannelsAsyncCallback = _ => Task.FromResult<IEnumerable<PackageChannel>>([
+                    PackageChannel.CreateImplicitChannel(implicitCache, new TestFeatures()),
+                    PackageChannel.CreateExplicitChannel("stable", PackageChannelQuality.Stable, [new PackageMapping("Aspire*", "stable")], stableCache, new TestFeatures()),
+                    PackageChannel.CreateExplicitChannel("staging", PackageChannelQuality.Both, [new PackageMapping("Aspire*", "staging")], stagingCache, new TestFeatures()),
+                    PackageChannel.CreateExplicitChannel("daily", PackageChannelQuality.Both, [new PackageMapping("Aspire*", "daily")], dailyCache, new TestFeatures())
+                ])
+            };
+        });
+        services.AddSingleton<IAppHostProjectFactory>(tsProjectFactory);
+        using var provider = services.BuildServiceProvider();
+
+        var command = provider.GetRequiredService<RootCommand>();
+        var result = command.Parse($"add foundry --apphost \"{appHostFile.FullName}\"");
+
+        var exitCode = await result.InvokeAsync().DefaultTimeout();
+
+        Assert.Equal(0, exitCode);
+        Assert.False(promptedForVersion, "Version prompt must not be raised when the staging-pinned implicit version is unambiguous.");
+        Assert.Equal("13.4.0-preview.1.staging", addedPackageVersion);
+    }
+
+    [Fact]
     public async Task IntegrationSearchCommandFormatJsonWithTypeScriptAppHostPinnedToChannelAlsoSearchesImplicitChannel()
     {
         // Regression for https://github.com/microsoft/aspire/issues/17724 + https://github.com/microsoft/aspire/issues/17725.
@@ -606,30 +736,26 @@ public class AddCommandTests(ITestOutputHelper outputHelper)
 
     [Theory]
     [InlineData(null, false)]          // No persisted channel — only implicit is searched, the explicit channel is excluded.
-    [InlineData("\"daily\"", true)]    // Persisted daily channel — implicit AND daily are searched.
-    [InlineData("\"staging\"", true)]  // Persisted staging channel — implicit AND staging are searched. Proves the gate is channel-name-opaque,
-                                       // so the post-fix behavior verified for "daily" applies equally to a staging-stamped release where
-                                       // `aspire new` would write `"channel": "staging"` into the polyglot apphost's aspire.config.json.
-                                       // (See IntegrationPackageSearchService.GetIntegrationPackagesWithChannelsAsync: the gate is
-                                       //  `hasHives || !string.IsNullOrEmpty(configuredChannel)` — it never inspects the channel name.)
+    [InlineData("\"daily\"", true)]    // Persisted daily channel matches the registered 'daily' explicit channel — both searched.
+    [InlineData("\"staging\"", false)] // Persisted staging channel does NOT match the registered 'daily' explicit channel — only implicit is searched.
+                                       // The gate IS channel-name-aware (as of the Layer-2 fix that aligns polyglot with C# by
+                                       // narrowing explicit channels to the apphost-pinned one). See
+                                       // IntegrationPackageSearchService.GetIntegrationPackagesWithChannelsAsync.
     public async Task IntegrationSearchCommandTypeScriptAppHostPersistedChannelExpandsDiscoveryWithoutChangingPreferredResult(string? configFileChannelJson, bool expectExplicitChannelHit)
     {
-        // Durable regression guard against re-introducing the Layer-1 narrowing bug.
+        // Durable regression guard against re-introducing the original Layer-1 narrowing bug
+        // (https://github.com/microsoft/aspire/issues/17724) AND the Layer-2 over-broad
+        // explicit-channel inclusion bug (polyglot was searching unrelated channels and
+        // surfacing stale versions in `aspire add`).
         //
-        // Pre-fix: aspire.config.json with `"channel"` set caused IntegrationPackageSearchService to
-        //   narrow the channel set to that single channel, so the with-channel arm would have returned
-        //   ONLY the daily channel's Redis (2.0.0) while the without-channel arm returned Redis 1.0.0.
-        // Post-fix two things hold simultaneously:
-        //   (a) Both arms yield the SAME preferred Redis to the user (1.0.0, the implicit channel
-        //       wins via SelectPreferredIntegrationPackage) — because the pin no longer overrides
-        //       what the user sees as the top-ranked result.
-        //   (b) The with-channel arm ALSO queries the pinned (daily) channel; the without-channel arm
-        //       does not — because the explicit channel set is gated on `hasHives || !empty(configuredChannel)`.
-        //
-        // Both halves matter. (a) alone would pass for an implementation that incorrectly narrowed
-        // to implicit-only when a channel was pinned (a different regression than the original bug
-        // but still wrong — it would mean users who pin to `daily` lose access to packages that only
-        // exist on the daily feed). (b) is the new structural guarantee on top of (a).
+        // Post-fix properties:
+        //   (a) The preferred user-visible result is the implicit channel's package (1.0.0) —
+        //       the apphost pin doesn't override what the user sees as top-ranked.
+        //   (b) The explicit channel registered in the fake PackagingService is searched ONLY
+        //       when the apphost pin's channel name MATCHES the explicit channel's name. An
+        //       apphost pinned to 'staging' will not query the 'daily' channel, even though
+        //       both are explicit. This matches the C# code path (which never queries any
+        //       explicit channel because GetConfiguredChannel returns null for C#).
         var rawJson = string.Empty;
         var testInteractionService = new TestInteractionService
         {

--- a/tests/Aspire.Cli.Tests/Commands/AddCommandTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/AddCommandTests.cs
@@ -356,26 +356,26 @@ public class AddCommandTests(ITestOutputHelper outputHelper)
     [Fact]
     public async Task AddCommandWithTypeScriptAppHostPinnedToStagingAutoSelectsImplicitVersionWithoutPromptingForVersion()
     {
-        // Regression for the polyglot/C# divergence in `aspire add` interactive flow.
+        // Regression for the polyglot/C# divergence in `aspire add` interactive flow that
+        // surfaced in #17743: a TS apphost stamped with `"channel": "staging"` would see a
+        // version-picker prompt (Implicit / Stable / Staging / Daily rows) for `aspire add
+        // foundry`, while the C# equivalent auto-selected the staging version immediately.
         //
-        // Before this fix, a TypeScript apphost stamped with `"channel": "staging"` would still
-        // see a version-picker prompt (Implicit / Staging / Daily rows) when running
-        // `aspire add foundry`, while a C# apphost would auto-select the staging-version
-        // immediately. The divergence was caused by two issues working together:
+        // Root cause: IntegrationPackageSearchService always queried the Implicit channel for
+        // polyglot apphosts, in addition to whatever channel the apphost had pinned. Implicit's
+        // `dotnet package search` runs against the user's ambient NuGet config (typically
+        // nuget.org because polyglot apphosts deliberately don't ship a persistent NuGet.config —
+        // see PrebuiltAppHostServer.CreatePackageSourceOverrideNuGetConfigAsync), so it returned
+        // a stale/wrong-feed version on top of the correct one from the pinned channel. The
+        // resulting multi-row prompt is the symptom the user reported.
         //
-        //   1. IntegrationPackageSearchService included EVERY explicit channel (stable + daily +
-        //      staging + ...) whenever any channel was pinned for non-C# apphosts. That added a
-        //      bogus "daily" row (with a stale version) to the version prompter.
-        //   2. The version prompter grouped by channel without deduplicating by (Id, Version),
-        //      so a package surfaced by BOTH Implicit (via the project-local NuGet.config that
-        //      polyglot starters now write) AND the matching pinned Explicit channel showed up
-        //      twice — preventing the single-implicit auto-select path from firing.
-        //
-        // Fix: IPSS narrows explicit channels to the apphost-pinned channel only; AddCommand
-        // dedupes by (Id, Version) preferring the Implicit-channel entry. Net effect for a
-        // staging-pinned TS apphost: only the Implicit Foundry entry remains, which triggers
-        // PromptForChannelPackagesAsync's `explicitGroups.Length == 0 && implicitGroup is not
-        // null` auto-select.
+        // Fix: IPSS now searches ONLY the pinned channel when a polyglot apphost carries a pin.
+        // The pinned channel builds its own TemporaryNuGetConfig from its PSM mappings, so it's
+        // correctly scoped. This matches C# end-to-end: C#'s GetConfiguredChannel returns null,
+        // so IPSS runs Implicit against the C# template's project-local NuGet.config (which IS
+        // correctly scoped because the C# template writes one). Net effect for a staging-pinned
+        // TS apphost: only the staging channel runs, returns one Foundry entry, AddCommand's
+        // version-prompt path auto-selects without rendering a menu.
         var promptedForVersion = false;
         var testInteractionService = new TestInteractionService
         {
@@ -484,29 +484,21 @@ public class AddCommandTests(ITestOutputHelper outputHelper)
     }
 
     [Fact]
-    public async Task IntegrationSearchCommandFormatJsonWithTypeScriptAppHostPinnedToChannelAlsoSearchesImplicitChannel()
+    public async Task IntegrationSearchCommandFormatJsonWithTypeScriptAppHostPinnedToChannelSearchesOnlyPinnedChannel()
     {
-        // Regression for https://github.com/microsoft/aspire/issues/17724 + https://github.com/microsoft/aspire/issues/17725.
+        // Polyglot apphost with `aspire.config.json#channel` set pins the search to that channel only.
+        // The Implicit channel is excluded — its `dotnet package search` would otherwise hit the user's
+        // ambient (typically nuget.org) and surface stale/wrong-feed versions alongside the pinned-channel
+        // result. C# apphosts avoid this by writing a project-local NuGet.config that scopes Implicit's
+        // ambient to the pinned feed; polyglot apphosts deliberately don't carry a persistent NuGet.config
+        // (it's a .NET-ism — see PrebuiltAppHostServer.CreatePackageSourceOverrideNuGetConfigAsync for the
+        // on-the-fly approach used at restore time). To match C#'s end-to-end behavior, we narrow `aspire
+        // add`'s search to only the pinned channel — whose own GetIntegrationPackagesAsync builds a
+        // TemporaryNuGetConfig from the channel's PSM mappings (PackageChannel.cs line ~120).
         //
-        // Layer 1 (latent bug, born 2026-01-13 in PR #13705): IntegrationPackageSearchService used to
-        //   narrow the channel set to whatever `configuredChannel` resolved to whenever the apphost was
-        //   non-C#. This dropped the implicit channel and any other channels from discovery.
-        // Layer 2 (PR #17452, 2026-05-26): `aspire init` started writing `"channel": "<identity>"` into
-        //   the scaffolded aspire.config.json for polyglot apphosts. This activated the Layer 1 bug for
-        //   every newly-initialized TS apphost in 13.4.
-        //
-        // Fix: IntegrationPackageSearchService no longer narrows. The full channel set (implicit +
-        //   pinned channel + any hives) is searched.
-        //
-        // This test pins the TS apphost to the "daily" channel via aspire.config.json. Pre-fix only the
-        // daily channel was searched and Redis 2.0.0 (daily) was the only result. Post-fix the implicit
-        // channel is ALSO searched, and SelectPreferredIntegrationPackage prefers the implicit channel
-        // when versions collide on Id, so Redis 1.0.0 (implicit) wins the dedupe.
-        //
-        // The structural guarantee asserted below — both `implicitHits` AND `dailyHits` being > 0 — is
-        // what defends against a regression that drops either channel from the search. Asserting only
-        // on the resulting Redis version is insufficient because implicit-only and daily-only searches
-        // both happen to produce a single result.
+        // This test pins to "daily". Pre-fix the Implicit channel was searched too, so Redis 1.0.0
+        // (implicit) won the dedupe over Redis 2.0.0 (daily). Post-fix only daily is searched, so
+        // Redis 2.0.0 wins.
         var rawJson = string.Empty;
         var testInteractionService = new TestInteractionService
         {
@@ -522,8 +514,6 @@ public class AddCommandTests(ITestOutputHelper outputHelper)
             }
             """);
 
-        // Track per-channel invocation. IntegrationPackageSearchService walks channels via
-        // Parallel.ForEachAsync, so callbacks may run concurrently; Interlocked guards that.
         var implicitHits = 0;
         var dailyHits = 0;
         var implicitCache = new FakeNuGetPackageCache
@@ -564,22 +554,23 @@ public class AddCommandTests(ITestOutputHelper outputHelper)
 
         Assert.Equal(CliExitCodes.Success, exitCode);
 
-        // Structural regression signal: BOTH channels must have been searched.
-        Assert.True(implicitHits > 0, "Implicit channel was not queried — discovery is dropping it.");
-        Assert.True(dailyHits > 0, "Daily channel was not queried — pinned channel is being dropped from discovery.");
+        // Structural regression signal: ONLY the pinned channel is searched.
+        Assert.Equal(0, implicitHits);
+        Assert.True(dailyHits > 0, "Pinned (daily) channel must be searched.");
 
-        // Implicit channel result wins the dedupe (SelectPreferredIntegrationPackage prefers implicit).
+        // Pinned-channel result wins because Implicit is excluded.
         var integration = Assert.Single(ReadIntegrationResults(rawJson));
         Assert.Equal("Aspire.Hosting.Redis", integration.Package);
-        Assert.Equal("1.0.0", integration.Version);
+        Assert.Equal("2.0.0", integration.Version);
     }
 
     [Fact]
-    public async Task IntegrationSearchCommandFormatJsonWithTypeScriptAppHostPinnedToStagingChannelAlsoSearchesImplicitChannel()
+    public async Task IntegrationSearchCommandFormatJsonWithTypeScriptAppHostPinnedToStagingChannelSearchesOnlyPinnedChannel()
     {
-        // See companion test above for the full Layer 1 / Layer 2 regression story.
-        // This variant covers the staging-channel pin: a stable-shaped CLI dogfooder whose apphost
-        // was init'd by PR #17452 and now has `"channel": "staging"` written into aspire.config.json.
+        // Staging-pin variant of the polyglot pinned-channel narrowing contract. See companion test
+        // for the rationale (TS apphost doesn't carry a persistent NuGet.config, so we cannot lean
+        // on Implicit's ambient to scope the search; instead we limit the search to the pinned
+        // channel which materializes its own TemporaryNuGetConfig).
         var rawJson = string.Empty;
         var testInteractionService = new TestInteractionService
         {
@@ -636,31 +627,34 @@ public class AddCommandTests(ITestOutputHelper outputHelper)
 
         Assert.Equal(CliExitCodes.Success, exitCode);
 
-        Assert.True(implicitHits > 0, "Implicit channel was not queried — discovery is dropping it.");
-        Assert.True(stagingHits > 0, "Staging channel was not queried — pinned channel is being dropped from discovery.");
+        Assert.Equal(0, implicitHits);
+        Assert.True(stagingHits > 0, "Pinned (staging) channel must be searched.");
 
         var integration = Assert.Single(ReadIntegrationResults(rawJson));
         Assert.Equal("Aspire.Hosting.Redis", integration.Package);
-        Assert.Equal("1.0.0", integration.Version);
+        Assert.Equal("2.0.0", integration.Version);
     }
 
     [Fact]
-    public async Task IntegrationSearchCommandFormatJsonWithTypeScriptAppHostPinnedToStableChannelStillSurfacesPrereleaseOnlyPackages()
+    public async Task IntegrationSearchCommandFormatJsonWithTypeScriptAppHostPinnedToStableChannelHidesPrereleaseOnlyPackagesMatchingCSharpBehavior()
     {
-        // Regression for https://github.com/microsoft/aspire/issues/17725 specifically.
+        // Trade-off documentation, not a happy-path test.
         //
-        // Aspire.Hosting.Foundry has never shipped a stable version — it only exists as prerelease.
-        // Pre-fix, a TS apphost with `"channel": "stable"` in aspire.config.json got narrowed to the
-        // stable channel only. That channel is Quality.Stable, so only `prerelease: false` queries
-        // were issued, and Foundry never appeared in the result set. Users dogfooding the staging CLI
-        // (which writes `"channel": "stable"` for a stable-shaped build) could not discover Foundry.
+        // A polyglot TS apphost pinned to the "stable" channel (Quality.Stable) sees ONLY stable
+        // packages. Prerelease-only integrations (e.g. Aspire.Hosting.Foundry) are NOT discoverable.
         //
-        // Post-fix the implicit channel (Quality.Both) is also searched, which DOES issue
-        // `prerelease: true` queries, and Foundry surfaces.
+        // This matches the C# behavior: a C# apphost pinned to stable writes a project-local
+        // NuGet.config that points Implicit's `dotnet package search` at the stable feed, which
+        // doesn't surface prereleases either. The previous "always include Implicit for polyglot"
+        // workaround (PR for #17725) made polyglot inconsistent with C# in this case, and as a
+        // side-effect produced spurious version prompts on staging/daily pins because Implicit's
+        // unscoped search returned a different (typically nuget.org-resolved) version alongside
+        // the pinned-channel result. The fix in IntegrationPackageSearchService restores C# parity
+        // by narrowing polyglot-with-pin to the pinned channel only. The cost is this test's
+        // assertion: a stable-pinned polyglot apphost cannot reach prerelease-only packages.
         //
-        // The fake here respects the `prerelease` arg passed to GetIntegrationPackagesAsync so the
-        // stable channel sees Redis only, while the implicit channel sees Redis + Foundry. The
-        // existence of Foundry in the result is the regression signal.
+        // Users in a real "I'm on staging CLI but my apphost says channel=stable" situation should
+        // either update the pin (recommended) or pass `--source` for the one-off install.
         var rawJson = string.Empty;
         var testInteractionService = new TestInteractionService
         {
@@ -676,7 +670,6 @@ public class AddCommandTests(ITestOutputHelper outputHelper)
             }
             """);
 
-        // Implicit channel: Quality.Both. Returns Redis when prerelease=false, Redis+Foundry when prerelease=true.
         var implicitHits = 0;
         var implicitCache = new FakeNuGetPackageCache
         {
@@ -689,8 +682,6 @@ public class AddCommandTests(ITestOutputHelper outputHelper)
                         : [CreatePackage("Aspire.Hosting.Redis", "1.0.0")]);
             }
         };
-        // Stable channel: Quality.Stable. PackageChannel only issues prerelease=false queries against it,
-        // so Foundry (prerelease-only) never appears regardless of what the cache could return.
         var stableHits = 0;
         var stableCache = new FakeNuGetPackageCache
         {
@@ -723,39 +714,35 @@ public class AddCommandTests(ITestOutputHelper outputHelper)
 
         Assert.Equal(CliExitCodes.Success, exitCode);
 
-        // Both channels must be queried. The implicit channel is what surfaces Foundry (via
-        // prerelease=true), but the stable channel must also be searched so users who pinned to
-        // it don't lose stable-only packages.
-        Assert.True(implicitHits > 0, "Implicit channel was not queried — Foundry would not be discoverable.");
-        Assert.True(stableHits > 0, "Stable channel was not queried — pinned channel is being dropped from discovery.");
+        // The pin is the only channel searched. Implicit is excluded.
+        Assert.Equal(0, implicitHits);
+        Assert.True(stableHits > 0, "Pinned (stable) channel must be searched.");
 
-        var integration = Assert.Single(ReadIntegrationResults(rawJson));
-        Assert.Equal("Aspire.Hosting.Foundry", integration.Package);
-        Assert.Equal("1.0.0-preview.1", integration.Version);
+        // Foundry is prerelease-only and the stable channel is Quality.Stable, so it is not
+        // discoverable. The result set is empty — matching what a stable-pinned C# apphost would
+        // see in the same configuration.
+        Assert.Empty(ReadIntegrationResults(rawJson));
     }
 
     [Theory]
     [InlineData(null, false)]          // No persisted channel — only implicit is searched, the explicit channel is excluded.
-    [InlineData("\"daily\"", true)]    // Persisted daily channel matches the registered 'daily' explicit channel — both searched.
-    [InlineData("\"staging\"", false)] // Persisted staging channel does NOT match the registered 'daily' explicit channel — only implicit is searched.
-                                       // The gate IS channel-name-aware (as of the Layer-2 fix that aligns polyglot with C# by
-                                       // narrowing explicit channels to the apphost-pinned one). See
-                                       // IntegrationPackageSearchService.GetIntegrationPackagesWithChannelsAsync.
-    public async Task IntegrationSearchCommandTypeScriptAppHostPersistedChannelExpandsDiscoveryWithoutChangingPreferredResult(string? configFileChannelJson, bool expectExplicitChannelHit)
+    [InlineData("\"daily\"", true)]    // Persisted daily channel matches the registered 'daily' explicit channel — ONLY daily searched (Implicit excluded).
+    [InlineData("\"staging\"", false)] // Persisted staging channel does NOT match the registered 'daily' explicit channel — neither searched (no matching channel).
+    public async Task IntegrationSearchCommandTypeScriptAppHostPersistedChannelGatesDiscovery(string? configFileChannelJson, bool expectExplicitChannelHit)
     {
-        // Durable regression guard against re-introducing the original Layer-1 narrowing bug
-        // (https://github.com/microsoft/aspire/issues/17724) AND the Layer-2 over-broad
-        // explicit-channel inclusion bug (polyglot was searching unrelated channels and
-        // surfacing stale versions in `aspire add`).
+        // Polyglot apphost search contract (post-fix for the staging-pin auto-select regression):
         //
-        // Post-fix properties:
-        //   (a) The preferred user-visible result is the implicit channel's package (1.0.0) —
-        //       the apphost pin doesn't override what the user sees as top-ranked.
-        //   (b) The explicit channel registered in the fake PackagingService is searched ONLY
-        //       when the apphost pin's channel name MATCHES the explicit channel's name. An
-        //       apphost pinned to 'staging' will not query the 'daily' channel, even though
-        //       both are explicit. This matches the C# code path (which never queries any
-        //       explicit channel because GetConfiguredChannel returns null for C#).
+        //   (a) No pin   -> Implicit ONLY. (Matches C#, where GetConfiguredChannel returns null and
+        //       Implicit's ambient NuGet.config — written by the C# template — scopes the search.)
+        //   (b) Pin set  -> Pinned channel ONLY (matched by name). Implicit is excluded; other
+        //       explicit channels are also excluded. This matches C# end-to-end: polyglot apphosts
+        //       don't carry a persistent NuGet.config (it's a .NET-ism), so we cannot rely on
+        //       Implicit's ambient to be scoped to the pinned feed. Instead, we restrict the
+        //       search to the pinned channel, which materializes its own TemporaryNuGetConfig.
+        //
+        // Pre-fix behavior was the opposite: Implicit was ALWAYS searched, even with a pin, which
+        // surfaced stale/wrong-feed versions in `aspire add` (the spurious "select version" prompt
+        // on staging-pinned TS apphosts).
         var rawJson = string.Empty;
         var testInteractionService = new TestInteractionService
         {
@@ -814,25 +801,39 @@ public class AddCommandTests(ITestOutputHelper outputHelper)
 
         Assert.Equal(CliExitCodes.Success, exitCode);
 
-        // (a) User-visible result is identical across arms: implicit Redis 1.0.0 wins.
-        var integration = Assert.Single(ReadIntegrationResults(rawJson));
-        Assert.Equal("Aspire.Hosting.Redis", integration.Package);
-        Assert.Equal("1.0.0", integration.Version);
+        var hasPin = configFileChannelJson is not null;
+        if (hasPin)
+        {
+            // (b) With a pin: Implicit is NOT searched.
+            Assert.Equal(0, implicitHits);
+        }
+        else
+        {
+            // (a) No pin: Implicit IS searched.
+            Assert.True(implicitHits > 0, "Implicit channel must be searched when no pin is set.");
+        }
 
-        // (b) Per-channel search invocation differs based on whether a channel was pinned.
-        Assert.True(implicitHits > 0, "Implicit channel must always be searched.");
         if (expectExplicitChannelHit)
         {
-            // The explicit (daily) channel registered in the fake PackagingService gets searched
-            // regardless of what channel NAME the apphost pinned (the gate is channel-name-opaque —
-            // it only checks `!string.IsNullOrEmpty(configuredChannel)`). That's how a real CLI
-            // built with `AspireCliChannel=staging` (writing `"channel": "staging"` into apphosts
-            // via `aspire new`) will exercise the same gate path as a CLI that pinned `"daily"`.
-            Assert.True(dailyHits > 0, $"With-channel arm: explicit channel must also be searched when apphost pin is non-empty (configured: {configFileChannelJson}).");
+            Assert.True(dailyHits > 0, $"Pinned channel name matched the registered 'daily' channel — must be searched (configured: {configFileChannelJson}).");
+            var integration = Assert.Single(ReadIntegrationResults(rawJson));
+            Assert.Equal("Aspire.Hosting.Redis", integration.Package);
+            Assert.Equal("2.0.0", integration.Version);
         }
         else
         {
             Assert.Equal(0, dailyHits);
+            // No-pin arm: implicit Redis 1.0.0. Pin-doesn't-match arm: no channel ran, empty result.
+            if (hasPin)
+            {
+                Assert.Empty(ReadIntegrationResults(rawJson));
+            }
+            else
+            {
+                var integration = Assert.Single(ReadIntegrationResults(rawJson));
+                Assert.Equal("Aspire.Hosting.Redis", integration.Package);
+                Assert.Equal("1.0.0", integration.Version);
+            }
         }
     }
 
@@ -931,32 +932,28 @@ public class AddCommandTests(ITestOutputHelper outputHelper)
     }
 
     [Fact]
-    public async Task IntegrationSearchCommandStagingStampedCliWithPinnedStagingApphostQueriesBothImplicitAndStagingChannelsAndSurfacesPrereleaseOnlyPackages()
+    public async Task IntegrationSearchCommandWithPolyglotApphostPinnedToStagingQueriesOnlyStagingAndSurfacesPrereleaseOnlyPackages()
     {
-        // High-confidence shipping-shape regression guard for #17724 and #17725.
+        // Shipping-shape regression guard for the polyglot scenario from #17743:
         //
-        // This test simulates EXACTLY what a real CLI built and shipped as staging will do when
-        // the user runs `aspire add <name>` against a polyglot apphost that `aspire new` created:
-        //
-        //   * The CLI binary is stamped `AspireCliChannel=staging` -> `IdentityChannel == "staging"`.
-        //     This triggers the real PackagingService.GetChannelsAsync to synthesize a real staging
-        //     channel alongside implicit + stable (no fake TestPackagingService is used here).
-        //   * `aspire new` writes `"channel": "staging"` into aspire.config.json (see
-        //     CliTemplateFactory.TypeScriptStarterTemplate). We mirror that here.
-        //   * There are NO PR hives. This is a real shipped install, not a dogfood/PR build.
-        //
-        // Pre-fix (the regression introduced before 13.4): the gate narrowed the search to ONLY the
-        // pinned staging channel. Implicit was excluded. Prerelease-only integrations (e.g.,
-        // Aspire.Hosting.Foundry) were invisible because the only feed queried was the staging
-        // feed, which doesn't surface them. The `aspire add kubernetes` regression had the same
-        // root cause: kubernetes was reachable via implicit (nuget.org) but invisible under the
-        // narrowed staging-only search.
+        //   * `aspire new` (polyglot starter, staging-stamped CLI) writes
+        //     `"channel": "staging"` into aspire.config.json for the apphost.
+        //   * `aspire add foundry` must surface the prerelease-only Foundry package from the
+        //     pinned staging feed — NOT a stale stable version from the user's ambient nuget.org.
         //
         // Post-fix invariants verified here:
-        //   (i)  BOTH implicit AND the synthesized staging channel are queried (cache call count
-        //        is >= 2). Pre-fix this would have been exactly 1.
-        //   (ii) A prerelease-only package returned by the cache only when prerelease=true (which
-        //        is what Quality.Both channels request) is reachable to the user.
+        //   (i)  ONLY the pinned (staging) channel is queried. Implicit is excluded for
+        //        pinned-polyglot — see IntegrationPackageSearchService for the rationale
+        //        (polyglot apphosts don't carry a persistent NuGet.config to scope Implicit's
+        //        ambient `dotnet package search`). The other explicit channels (stable, daily,
+        //        etc.) are also excluded — they are not the user's expressed intent.
+        //   (ii) A prerelease-only package returned only on prerelease=true (which Quality.Both
+        //        channels request) is reachable to the user.
+        //
+        // This test uses TestPackagingService (a hand-stamped channel set) rather than the real
+        // PackagingService to avoid the staging-channel synthesis path's dependency on a
+        // commit-hash-bearing CLI version. The IPSS gate logic — what this PR fixes — is
+        // identical regardless of whether the staging channel came from synthesis or test stub.
         var rawJson = string.Empty;
         var testInteractionService = new TestInteractionService
         {
@@ -972,16 +969,50 @@ public class AddCommandTests(ITestOutputHelper outputHelper)
             }
             """);
 
-        var totalCacheCalls = 0;
-        var prereleaseRequested = 0;
-        var cache = new FakeNuGetPackageCache
+        var implicitHits = 0;
+        var stableHits = 0;
+        var dailyHits = 0;
+        var stagingTotalCalls = 0;
+        var stagingPrereleaseCalls = 0;
+
+        // Implicit returns a stale stable version. Under the pre-fix behavior (Implicit always
+        // searched), this is what produced the spurious "select version" prompt with the stale
+        // Foundry version. Post-fix this entry must never appear in the result.
+        var implicitCache = new FakeNuGetPackageCache
+        {
+            GetIntegrationPackagesAsyncCallback = (_, _, _, _) =>
+            {
+                Interlocked.Increment(ref implicitHits);
+                return Task.FromResult<IEnumerable<NuGetPackage>>([CreatePackage("Aspire.Hosting.Foundry", "13.3.5")]);
+            }
+        };
+        var stableCache = new FakeNuGetPackageCache
+        {
+            GetIntegrationPackagesAsyncCallback = (_, _, _, _) =>
+            {
+                Interlocked.Increment(ref stableHits);
+                return Task.FromResult<IEnumerable<NuGetPackage>>([]);
+            }
+        };
+        var dailyCache = new FakeNuGetPackageCache
+        {
+            GetIntegrationPackagesAsyncCallback = (_, _, _, _) =>
+            {
+                Interlocked.Increment(ref dailyHits);
+                return Task.FromResult<IEnumerable<NuGetPackage>>([]);
+            }
+        };
+        // Staging is Quality.Both, so PackageChannel.GetIntegrationPackagesAsync issues both a
+        // prerelease=false and a prerelease=true search. Only the prerelease search returns
+        // the Foundry package, modeling prerelease-only packages on the staging feed.
+        var stagingCache = new FakeNuGetPackageCache
         {
             GetIntegrationPackagesAsyncCallback = (_, prerelease, _, _) =>
             {
-                Interlocked.Increment(ref totalCacheCalls);
+                Interlocked.Increment(ref stagingTotalCalls);
                 if (prerelease)
                 {
-                    Interlocked.Increment(ref prereleaseRequested);
+                    Interlocked.Increment(ref stagingPrereleaseCalls);
                     return Task.FromResult<IEnumerable<NuGetPackage>>([CreatePackage("Aspire.Hosting.Foundry", "13.4.0-rc.1")]);
                 }
                 return Task.FromResult<IEnumerable<NuGetPackage>>([]);
@@ -990,13 +1021,16 @@ public class AddCommandTests(ITestOutputHelper outputHelper)
 
         var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper, options =>
         {
-            // Stamp the running CLI as the staging release identity. The real PackagingService
-            // (left un-overridden here) reads this from CliExecutionContext.IdentityChannel and
-            // synthesizes the staging channel automatically (see PackagingService.GetChannelsAsync
-            // -> stagingIdentityChannel branch).
-            options.CliExecutionContextFactory = _ => CreateExecutionContext(workspace, PackageChannelNames.Staging);
             options.InteractionServiceFactory = _ => testInteractionService;
-            options.NuGetPackageCacheFactory = _ => cache;
+            options.PackagingServiceFactory = _ => new TestPackagingService
+            {
+                GetChannelsAsyncCallback = _ => Task.FromResult<IEnumerable<PackageChannel>>([
+                    PackageChannel.CreateImplicitChannel(implicitCache, new TestFeatures()),
+                    PackageChannel.CreateExplicitChannel("stable", PackageChannelQuality.Stable, [new PackageMapping("Aspire*", "stable")], stableCache, new TestFeatures()),
+                    PackageChannel.CreateExplicitChannel("staging", PackageChannelQuality.Both, [new PackageMapping("Aspire*", "staging")], stagingCache, new TestFeatures()),
+                    PackageChannel.CreateExplicitChannel("daily", PackageChannelQuality.Both, [new PackageMapping("Aspire*", "daily")], dailyCache, new TestFeatures())
+                ])
+            };
         });
         services.AddSingleton<IAppHostProjectFactory>(new TestTypeScriptStarterProjectFactory((_, _, _) => Task.FromResult(true)));
         using var provider = services.BuildServiceProvider();
@@ -1008,20 +1042,18 @@ public class AddCommandTests(ITestOutputHelper outputHelper)
 
         Assert.Equal(CliExitCodes.Success, exitCode);
 
-        // (ii) The prerelease-only package is reachable to the user.
+        // (ii) The prerelease-only package from the pinned staging feed is reachable.
         var integration = Assert.Single(ReadIntegrationResults(rawJson));
         Assert.Equal("Aspire.Hosting.Foundry", integration.Package);
         Assert.Equal("13.4.0-rc.1", integration.Version);
 
-        // (i) Both implicit AND staging were queried. Pre-fix narrowing would have produced exactly 1 call.
-        // Real PackagingService.GetChannelsAsync under IdentityChannel=Staging returns at least
-        // [implicit, stable, staging]; the IPSS gate now lets all of them through (hasHives=false,
-        // configuredChannel="staging" -> not empty -> gate evaluates true). At minimum the implicit
-        // and staging channels must have run, so we require >= 2 calls. Using `>= 2` rather than
-        // `== N` keeps the test robust to PackagingService adding additional explicit channels
-        // (e.g., stable) without weakening the regression guard.
-        Assert.True(totalCacheCalls >= 2, $"Expected >= 2 cache calls (both implicit and staging channels), got {totalCacheCalls}. Pre-fix narrowing would have produced 1 call.");
-        Assert.True(prereleaseRequested >= 1, $"Expected at least one channel to request prerelease=true (Quality.Both channels do); got {prereleaseRequested}.");
+        // (i) Only the staging channel ran. No Implicit (key invariant — pre-fix this was > 0
+        // and surfaced the stale 13.3.5 version), no Stable, no Daily.
+        Assert.Equal(0, implicitHits);
+        Assert.Equal(0, stableHits);
+        Assert.Equal(0, dailyHits);
+        Assert.Equal(2, stagingTotalCalls); // Quality.Both => prerelease=false + prerelease=true
+        Assert.Equal(1, stagingPrereleaseCalls);
     }
 
     [Fact]

--- a/tests/Aspire.Cli.Tests/Commands/InitCommandTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/InitCommandTests.cs
@@ -1245,6 +1245,211 @@ public class InitCommandTests(ITestOutputHelper outputHelper)
     }
 
     /// <summary>
+    /// Diagnostic-override contract for <c>aspire init</c>'s C# single-file path. When the
+    /// running CLI's baked identity is <c>local</c> (a developer build or a CI emulation rig
+    /// like <c>eng/scripts/debug-staging.sh</c>) and <see cref="IPackagingService.GetEffectiveIdentityChannel"/>
+    /// reports a different effective channel (here <c>staging</c>), the workspace
+    /// <c>nuget.config</c> dropped by init MUST match what <see cref="IPackagingService"/>
+    /// will subsequently use for feed routing — i.e. the override — NOT the baked identity.
+    /// <para>
+    /// Without this contract, a staging-emulation run scaffolds an <c>apphost.cs</c> with
+    /// <c>#:sdk Aspire.AppHost.Sdk@13.4.0-preview…</c> but drops a <c>local</c>-shaped (or
+    /// stable-shaped) <c>nuget.config</c> that lists only <c>nuget.org</c>, so the
+    /// SDK-directive restore fails to find the staging-feed-only SDK version. The user
+    /// then sees the wrong package versions surfaced by <c>aspire add</c>'s subsequent
+    /// (correctly-routed) calls — the exact symptom that motivated this test.
+    /// </para>
+    /// <para>
+    /// This is the test-coverage gap for the <c>aspire init</c> + C# single-file +
+    /// staging-emulation cell of the full identity/template/command matrix. The polyglot
+    /// and project-mode counterparts are exercised by sibling tests in this class.
+    /// </para>
+    /// </summary>
+    [Fact]
+    public async Task InitCommand_SingleFileMode_OverrideCliIdentityChannel_WiresNuGetConfigToOverrideChannel()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+
+        // Bake identity=local (the typical developer/locally-built CLI shape), but report
+        // an effective identity of `staging` from the packaging service so `aspire init`'s
+        // NuGet.config drop routes through the override, mirroring what `aspire add` would
+        // do for the same invocation.
+        var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper, options =>
+        {
+            options.CliExecutionContextFactory = _ => CreateExecutionContextForChannel(workspace.WorkspaceRoot, "local");
+            options.PackagingServiceFactory = _ =>
+            {
+                var packagingService = CreateMultiChannelPackagingService("local", "staging");
+                packagingService.GetEffectiveIdentityChannelCallback = () => "staging";
+                return packagingService;
+            };
+        });
+
+        var serviceProvider = services.BuildServiceProvider();
+        var initCommand = serviceProvider.GetRequiredService<InitCommand>();
+
+        var parseResult = initCommand.Parse("init");
+        var exitCode = await parseResult.InvokeAsync().DefaultTimeout();
+
+        Assert.Equal(CliExitCodes.Success, exitCode);
+
+        var nugetConfigPath = Path.Combine(workspace.WorkspaceRoot.FullName, "nuget.config");
+        Assert.True(File.Exists(nugetConfigPath), "nuget.config should be created in workspace under the override channel.");
+
+        // Must carry the override channel's feed, NOT the baked identity's feed.
+        AssertNuGetConfigHasChannelShape(nugetConfigPath, "staging");
+    }
+
+    /// <summary>
+    /// Project-mode counterpart of
+    /// <see cref="InitCommand_SingleFileMode_OverrideCliIdentityChannel_WiresNuGetConfigToOverrideChannel"/>.
+    /// The solution-directory <c>nuget.config</c> dropped before <c>dotnet new aspire-apphost</c>
+    /// must match the override channel so the template's <c>restore</c> post-action can
+    /// resolve <c>Aspire.AppHost.Sdk/&lt;staging-version&gt;</c>.
+    /// </summary>
+    [Fact]
+    public async Task InitCommand_ProjectMode_OverrideCliIdentityChannel_WiresNuGetConfigInSolutionDirToOverrideChannel()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+
+        var solutionFile = new FileInfo(Path.Combine(workspace.WorkspaceRoot.FullName, "Test.sln"));
+        File.WriteAllText(solutionFile.FullName, "Fake solution file");
+
+        var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper, options =>
+        {
+            options.CliExecutionContextFactory = _ => CreateExecutionContextForChannel(workspace.WorkspaceRoot, "local");
+            options.PackagingServiceFactory = _ =>
+            {
+                var packagingService = CreateMultiChannelPackagingService("local", "staging");
+                packagingService.GetEffectiveIdentityChannelCallback = () => "staging";
+                return packagingService;
+            };
+
+            options.DotNetCliRunnerFactory = _ =>
+            {
+                var runner = new TestDotNetCliRunner();
+                runner.InstallTemplateAsyncCallback = (_, version, _, _, _, _, _) => (0, version);
+                runner.NewProjectAsyncCallback = (_, _, outputPath, _, _) =>
+                {
+                    Directory.CreateDirectory(outputPath);
+                    return 0;
+                };
+                return runner;
+            };
+        });
+
+        var serviceProvider = services.BuildServiceProvider();
+        var initCommand = serviceProvider.GetRequiredService<InitCommand>();
+
+        var parseResult = initCommand.Parse("init");
+        var exitCode = await parseResult.InvokeAsync().DefaultTimeout();
+
+        Assert.Equal(CliExitCodes.Success, exitCode);
+
+        var nugetConfigPath = Path.Combine(workspace.WorkspaceRoot.FullName, "nuget.config");
+        Assert.True(File.Exists(nugetConfigPath), "nuget.config should be created in solution dir under the override channel.");
+        AssertNuGetConfigHasChannelShape(nugetConfigPath, "staging");
+    }
+
+    /// <summary>
+    /// Sibling-site coverage: the <c>aspire.config.json#channel</c> pin written by
+    /// <c>aspire init</c> (single-file C#) must reflect the override so subsequent
+    /// <c>aspire add</c> calls — which DO consult the override via
+    /// <c>PackagingService.GetEffectiveIdentityChannel</c> — keep resolving against the
+    /// same channel that init scaffolded. A divergence here leaves the project's persisted
+    /// channel referring to a feed that <c>aspire add</c> would never select on a normal
+    /// (non-emulation) machine.
+    /// </summary>
+    [Fact(Skip = "Out of scope for the first-pass staging-emulation fix; tracked for a follow-up. The two in-scope tests are the C# (single-file + project) NuGet.config drops and the polyglot scaffolder hand-off.")]
+    public async Task InitCommand_SingleFileMode_OverrideCliIdentityChannel_WritesOverrideChannelIntoAspireConfig()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+
+        var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper, options =>
+        {
+            options.CliExecutionContextFactory = _ => CreateExecutionContextForChannel(workspace.WorkspaceRoot, "local");
+            options.PackagingServiceFactory = _ =>
+            {
+                var packagingService = CreateMultiChannelPackagingService("local", "staging");
+                packagingService.GetEffectiveIdentityChannelCallback = () => "staging";
+                return packagingService;
+            };
+        });
+
+        var serviceProvider = services.BuildServiceProvider();
+        var initCommand = serviceProvider.GetRequiredService<InitCommand>();
+
+        var parseResult = initCommand.Parse("init");
+        var exitCode = await parseResult.InvokeAsync().DefaultTimeout();
+
+        Assert.Equal(CliExitCodes.Success, exitCode);
+
+        var configPath = Path.Combine(workspace.WorkspaceRoot.FullName, AspireConfigFile.FileName);
+        Assert.True(File.Exists(configPath));
+
+        var config = JsonNode.Parse(File.ReadAllText(configPath))!.AsObject();
+        Assert.Equal("staging", config["channel"]!.GetValue<string>());
+    }
+
+    /// <summary>
+    /// Polyglot equivalent of
+    /// <see cref="InitCommand_SingleFileMode_OverrideCliIdentityChannel_WritesOverrideChannelIntoAspireConfig"/>.
+    /// The polyglot init path goes through <c>ResolvePersistableChannelNameAsync</c> and
+    /// passes the result into <c>ScaffoldContext.Channel</c>, which the scaffolder writes
+    /// into the polyglot <c>aspire.config.json#channel</c>. Under staging emulation the
+    /// effective channel (<c>staging</c>) must reach the scaffolder — not the baked
+    /// <c>local</c> identity, which would resolve to an Explicit channel name a normal CLI
+    /// would never produce.
+    /// </summary>
+    [Fact]
+    public async Task InitCommand_PolyglotMode_OverrideCliIdentityChannel_PassesOverrideChannelToScaffolder()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+
+        ScaffoldContext? capturedContext = null;
+        var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper, options =>
+        {
+            options.CliExecutionContextFactory = _ => CreateExecutionContextForChannel(workspace.WorkspaceRoot, "local");
+            options.PackagingServiceFactory = _ =>
+            {
+                var packagingService = CreateMultiChannelPackagingService("local", "staging");
+                packagingService.GetEffectiveIdentityChannelCallback = () => "staging";
+                return packagingService;
+            };
+            options.LanguageServiceFactory = sp =>
+            {
+                var projectFactory = sp.GetRequiredService<IAppHostProjectFactory>();
+                var tsProject = projectFactory.GetProject(new LanguageInfo(
+                    LanguageId: new LanguageId(KnownLanguageId.TypeScript),
+                    DisplayName: "TypeScript (Node.js)",
+                    PackageName: "@aspire/app-host",
+                    DetectionPatterns: ["apphost.mts", "apphost.ts"],
+                    CodeGenerator: "TypeScript",
+                    AppHostFileName: "apphost.mts"));
+                return new TestLanguageService { DefaultProject = tsProject };
+            };
+            options.ScaffoldingServiceFactory = _ => new TestScaffoldingService
+            {
+                ScaffoldAsyncCallback = (ctx, _) =>
+                {
+                    capturedContext = ctx;
+                    return Task.FromResult(true);
+                }
+            };
+        });
+
+        var serviceProvider = services.BuildServiceProvider();
+        var initCommand = serviceProvider.GetRequiredService<InitCommand>();
+
+        var parseResult = initCommand.Parse("init");
+        var exitCode = await parseResult.InvokeAsync().DefaultTimeout();
+
+        Assert.Equal(CliExitCodes.Success, exitCode);
+        Assert.NotNull(capturedContext);
+        Assert.Equal("staging", capturedContext!.Channel);
+    }
+
+    /// <summary>
     /// Polyglot pre-existing-channel preservation. <c>ScaffoldingService.cs:93-95</c> writes
     /// <c>config.Channel = context.Channel</c> unconditionally when non-empty, so if init
     /// passed the resolved identity channel into <see cref="ScaffoldContext.Channel"/> without

--- a/tests/Aspire.Cli.Tests/Commands/NewCommandChannelResolutionTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/NewCommandChannelResolutionTests.cs
@@ -124,7 +124,9 @@ public class NewCommandChannelResolutionTests(ITestOutputHelper outputHelper)
     /// </summary>
     [Theory]
     [InlineData(PackageChannelNames.Daily, "13.4.0-preview.1.99999.1", null)]
-    [InlineData(PackageChannelNames.Stable, "13.5.0", "13.5.0")]
+    // PackageChannelNames.Stable is intentionally NOT covered here — see
+    // `NewCommand_StableIdentity_NoChannelArg_DoesNotPersistStablePin_Cli` for why the
+    // stable identity must not pin `aspire.config.json#channel`.
     public async Task NewCommand_NoChannelArg_ResolvesTemplateFromIdentityChannel(string identityChannel, string identityChannelVersion, string? expectedVersion)
     {
         var captured = await CaptureTemplateInputsAsync(
@@ -298,7 +300,10 @@ public class NewCommandChannelResolutionTests(ITestOutputHelper outputHelper)
     [InlineData("pr-99999", "13.4.0-pr.99999.gabc123")]
     [InlineData(PackageChannelNames.Daily, "13.4.0-preview.1.99999.1")]
     [InlineData(PackageChannelNames.Staging, "13.4.0-rc.1.99999.1")]
-    [InlineData(PackageChannelNames.Stable, "13.5.0")]
+    // PackageChannelNames.Stable is intentionally NOT covered here — see
+    // `NewCommand_StableIdentity_NoChannelArg_DoesNotPersistStablePin_DotNet` for why the
+    // stable identity must not flow through `inputs.Channel` (which would then be persisted
+    // into `aspire.config.json#channel` by `DotNetTemplateFactory`).
     public async Task NewCommand_DotNetRuntimeTemplate_NoChannelArg_ForwardsIdentityChannelToInputs(string identityChannel, string identityChannelVersion)
     {
         var captured = await CaptureTemplateInputsAsync(
@@ -379,6 +384,63 @@ public class NewCommandChannelResolutionTests(ITestOutputHelper outputHelper)
 
         Assert.Equal("13.4.0-preview.1.99999.1", captured.Version);
         Assert.Equal(PackageChannelNames.Daily, captured.Channel);
+    }
+
+    /// <summary>
+    /// Prerelease-visibility invariant for a shipped (identity=<c>stable</c>) CLI on the
+    /// CLI-runtime template path (TypeScript / Python / Go polyglot starters). Resolving
+    /// identity to the registered <c>stable</c> channel and persisting <c>"stable"</c> as
+    /// <c>aspire.config.json#channel</c> looks symmetric to daily/staging/pr, but
+    /// the <c>stable</c> channel is constructed with <see cref="PackageChannelQuality.Stable"/>.
+    /// A subsequent <c>aspire add</c> pinned to that channel filters out prerelease packages
+    /// on nuget.org — including community-published <c>13.4.0-preview</c> integrations the
+    /// team has not yet shipped as stable. <c>aspire init</c> avoids the trap via
+    /// <c>ShouldPersistChannelName</c> (which excludes <c>"stable"</c>); <c>aspire new</c>
+    /// must agree, leaving <c>inputs.Channel</c> as <see langword="null"/> so the polyglot
+    /// scaffold writes no channel pin and later <c>aspire add</c> walks the Implicit
+    /// (nuget.org, <see cref="PackageChannelQuality.Both"/>) channel.
+    /// <para>
+    /// Red test: today <c>NewCommand.ResolveIdentityChannelNameAsync</c> gates only on
+    /// <see cref="PackageChannelType.Explicit"/> and therefore returns <c>"stable"</c>,
+    /// hiding the matrix cell (stable identity × prerelease package × <c>aspire new</c> × TS).
+    /// </para>
+    /// </summary>
+    [Fact]
+    public async Task NewCommand_StableIdentity_NoChannelArg_DoesNotPersistStablePin_Cli()
+    {
+        var captured = await CaptureTemplateInputsAsync(
+            identityChannel: PackageChannelNames.Stable,
+            channelOptionArg: null,
+            identityChannelVersion: "13.5.0",
+            runtime: TemplateRuntime.Cli);
+
+        Assert.Null(captured.Channel);
+    }
+
+    /// <summary>
+    /// DotNet-runtime mirror of <see cref="NewCommand_StableIdentity_NoChannelArg_DoesNotPersistStablePin_Cli"/>
+    /// for the C# <c>aspire-starter</c> / <c>aspire-starter-csharp-typescript</c> templates.
+    /// <see cref="DotNetTemplateFactory"/> persists <c>aspire.config.json#channel</c>
+    /// whenever the resolved channel is <see cref="PackageChannelType.Explicit"/>, so the
+    /// only place to break the chain is here in <see cref="NewCommand"/>: when the identity
+    /// is <c>stable</c>, <c>inputs.Channel</c> must be <see langword="null"/> so the factory's
+    /// Explicit-gate is never entered and the scaffolded project inherits ambient
+    /// (<see cref="PackageChannelQuality.Both"/>) NuGet behavior — keeping community
+    /// <c>13.4.0-preview</c> integrations visible after a shipped-stable <c>aspire new</c>.
+    /// <para>
+    /// Red test for the matrix cell (stable identity × prerelease package × <c>aspire new</c> × C#).
+    /// </para>
+    /// </summary>
+    [Fact]
+    public async Task NewCommand_StableIdentity_NoChannelArg_DoesNotPersistStablePin_DotNet()
+    {
+        var captured = await CaptureTemplateInputsAsync(
+            identityChannel: PackageChannelNames.Stable,
+            channelOptionArg: null,
+            identityChannelVersion: "13.5.0",
+            runtime: TemplateRuntime.DotNet);
+
+        Assert.Null(captured.Channel);
     }
 
     /// <summary>

--- a/tests/Aspire.Cli.Tests/Commands/NewCommandChannelResolutionTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/NewCommandChannelResolutionTests.cs
@@ -444,6 +444,57 @@ public class NewCommandChannelResolutionTests(ITestOutputHelper outputHelper)
     }
 
     /// <summary>
+    /// Regression test for the DotNet-runtime arm of the staging-emulation bug
+    /// reproduced via <c>eng/scripts/debug-staging.sh</c>: a locally built CLI
+    /// (identity=<c>local</c>) running with <c>overrideCliIdentityChannel=staging</c>
+    /// would route <c>aspire add</c> correctly through <see cref="IPackagingService"/>
+    /// (which already consults <see cref="IPackagingService.GetEffectiveIdentityChannel"/>)
+    /// but <c>aspire new &lt;C# starter&gt;</c> would silently fall back to
+    /// the Implicit (nuget.org) channel. The cause was
+    /// <see cref="NewCommand"/>'s <c>ResolveIdentityChannelNameAsync</c> reading
+    /// <see cref="CliExecutionContext.IdentityChannel"/> directly (returning
+    /// <c>"local"</c>, which never matches any registered Explicit channel), so
+    /// <see cref="TemplateInputs.Channel"/> was set to <see langword="null"/> and
+    /// <c>DotNetTemplateFactory</c> resolved <c>Aspire.ProjectTemplates</c> from
+    /// nuget.org — picking the last-shipped stable (e.g. <c>13.3.5</c>) instead of
+    /// the staging build's matching prerelease on the darc feed.
+    /// </summary>
+    [Fact]
+    public async Task NewCommand_LocalIdentityWithStagingOverride_DotNet_PropagatesEffectiveChannel()
+    {
+        var captured = await CaptureTemplateInputsAsync(
+            identityChannel: PackageChannelNames.Local,
+            channelOptionArg: null,
+            identityChannelVersion: "13.4.0-preview.6.26280.1",
+            runtime: TemplateRuntime.DotNet,
+            effectiveIdentityChannelOverride: PackageChannelNames.Staging);
+
+        Assert.Equal(PackageChannelNames.Staging, captured.Channel);
+    }
+
+    /// <summary>
+    /// CLI-runtime mirror of <see cref="NewCommand_LocalIdentityWithStagingOverride_DotNet_PropagatesEffectiveChannel"/>
+    /// for polyglot starters (TypeScript / Python / Go). The CLI-runtime branch was already
+    /// override-aware via <c>ResolveCliTemplateVersionAsync</c>, so this asserts no regression:
+    /// not only does <c>inputs.Channel</c> become <c>"staging"</c>, but version resolution
+    /// also wins against the staging channel rather than falling through to Implicit, so
+    /// the scaffolded project's <c>aspire.config.json</c> pin and Aspire.ProjectTemplates
+    /// version stay mutually satisfiable on the darc feed.
+    /// </summary>
+    [Fact]
+    public async Task NewCommand_LocalIdentityWithStagingOverride_Cli_PropagatesEffectiveChannel()
+    {
+        var captured = await CaptureTemplateInputsAsync(
+            identityChannel: PackageChannelNames.Local,
+            channelOptionArg: null,
+            identityChannelVersion: "13.4.0-preview.6.26280.1",
+            runtime: TemplateRuntime.Cli,
+            effectiveIdentityChannelOverride: PackageChannelNames.Staging);
+
+        Assert.Equal(PackageChannelNames.Staging, captured.Channel);
+    }
+
+    /// <summary>
     /// Invokes <see cref="NewCommand"/> with a fake template that captures the
     /// <see cref="TemplateInputs"/> handed to it. Its <c>Version</c> reflects which channel
     /// won template-version resolution; its <c>Channel</c> reflects what the template
@@ -464,7 +515,8 @@ public class NewCommandChannelResolutionTests(ITestOutputHelper outputHelper)
         string? identityChannelVersion,
         IEnumerable<string>? identityChannelVersions = null,
         TemplateRuntime runtime = TemplateRuntime.Cli,
-        string? versionOptionArg = null)
+        string? versionOptionArg = null,
+        string? effectiveIdentityChannelOverride = null)
     {
         using var workspace = TemporaryWorkspace.Create(outputHelper);
 
@@ -504,7 +556,7 @@ public class NewCommandChannelResolutionTests(ITestOutputHelper outputHelper)
 
             options.TemplateProviderFactory = _ => new SingleTemplateProvider(fakeTemplate);
 
-            options.PackagingServiceFactory = _ => BuildPackagingService(identityChannel, identityChannelVersion, identityChannelVersions);
+            options.PackagingServiceFactory = _ => BuildPackagingService(identityChannel, identityChannelVersion, identityChannelVersions, effectiveIdentityChannelOverride);
         });
 
         using var serviceProvider = services.BuildServiceProvider();
@@ -528,10 +580,22 @@ public class NewCommandChannelResolutionTests(ITestOutputHelper outputHelper)
     private static IPackagingService BuildPackagingService(
         string identityChannel,
         string? identityChannelVersion,
-        IEnumerable<string>? identityChannelVersions)
+        IEnumerable<string>? identityChannelVersions,
+        string? effectiveIdentityChannelOverride = null)
     {
         var identityVersions = identityChannelVersions?.ToArray()
             ?? (identityChannelVersion is null ? [] : [identityChannelVersion]);
+
+        // The "effective" channel is what PackagingService.GetEffectiveIdentityChannel
+        // returns: the diagnostic-override channel name when active
+        // (overrideCliIdentityChannel under eng/scripts/debug-staging.sh), otherwise
+        // the identity baked into the binary. The non-stable explicit channel registered
+        // below tracks this effective name so a `local`-identity + `staging`-override
+        // test scenario advertises a `staging` channel (matching production
+        // PackagingService synthesis under the same env vars).
+        var effectiveChannel = string.IsNullOrWhiteSpace(effectiveIdentityChannelOverride)
+            ? identityChannel
+            : effectiveIdentityChannelOverride;
 
         // Implicit channel always returns the stable token so a "fell-through to Implicit"
         // outcome is distinguishable from an identity-channel pickup.
@@ -565,8 +629,8 @@ public class NewCommandChannelResolutionTests(ITestOutputHelper outputHelper)
         // scenario calls for it. Deliberately omitted in the "identity not registered"
         // case so fallback to Implicit can be observed.
         var isDailyOrStaging = identityVersions.Length > 0 &&
-            !string.Equals(identityChannel, PackageChannelNames.Stable, StringComparison.OrdinalIgnoreCase) &&
-            !identityChannel.StartsWith("pr-", StringComparison.OrdinalIgnoreCase);
+            !string.Equals(effectiveChannel, PackageChannelNames.Stable, StringComparison.OrdinalIgnoreCase) &&
+            !effectiveChannel.StartsWith("pr-", StringComparison.OrdinalIgnoreCase);
         if (isDailyOrStaging)
         {
             var explicitCache = new FakeNuGetPackageCache
@@ -576,7 +640,7 @@ public class NewCommandChannelResolutionTests(ITestOutputHelper outputHelper)
                         identityVersions.Select(version => new NuGetPackage { Id = "Aspire.ProjectTemplates", Source = "nuget", Version = version }))
             };
             channels.Add(PackageChannel.CreateExplicitChannel(
-                identityChannel,
+                effectiveChannel,
                 PackageChannelQuality.Prerelease,
                 [
                     new PackageMapping("Aspire*", "https://example.invalid/feed/v3/index.json"),
@@ -611,7 +675,10 @@ public class NewCommandChannelResolutionTests(ITestOutputHelper outputHelper)
 
         return new TestPackagingService
         {
-            GetChannelsAsyncCallback = _ => Task.FromResult<IEnumerable<PackageChannel>>(channels)
+            GetChannelsAsyncCallback = _ => Task.FromResult<IEnumerable<PackageChannel>>(channels),
+            GetEffectiveIdentityChannelCallback = string.IsNullOrWhiteSpace(effectiveIdentityChannelOverride)
+                ? null
+                : () => effectiveIdentityChannelOverride,
         };
     }
 

--- a/tests/Aspire.Cli.Tests/Commands/NewCommandTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/NewCommandTests.cs
@@ -2027,6 +2027,81 @@ public class NewCommandTests(ITestOutputHelper outputHelper)
     }
 
     [Fact]
+    public async Task NewCommandWithTypeScriptStarterAndExplicitChannelWritesChannelDerivedNuGetConfig()
+    {
+        // Regression for the symptom that PR #17743 missed for polyglot apphosts: with a
+        // resolved Explicit channel (e.g., staging) and no --source override, the TS starter
+        // must drop a project-local NuGet.config that pins Aspire.* at the channel's feed.
+        // Without it, IntegrationPackageSearchService's always-on Implicit channel resolves
+        // Aspire.Hosting.* from ambient nuget.org during `aspire add` and surfaces a stale
+        // version alongside the staging darc-feed match. C# starters get this via
+        // DotNetTemplateFactory's PromptToCreateOrUpdateNuGetConfigAsync fallback; this test
+        // pins the equivalent fallback for the TS starter.
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        const string channelFeed = "https://pkgs.dev.azure.com/dnceng/public/_packaging/darc-pub-microsoft-aspire-abcdef12/nuget/v3/index.json";
+
+        var services = CreateServiceCollection(workspace, options =>
+        {
+            options.DotNetCliRunnerFactory = _ => new TestDotNetCliRunner
+            {
+                SearchPackagesAsyncCallback = (dir, query, exactMatch, prerelease, take, skip, nugetSource, useCache, runnerOptions, cancellationToken) =>
+                {
+                    var package = new NuGetPackage { Id = "Aspire.ProjectTemplates", Source = "nuget", Version = "13.4.0-preview.1.99999.1" };
+                    return (0, new NuGetPackage[] { package });
+                }
+            };
+
+            options.PackagingServiceFactory = _ => new TestPackagingService
+            {
+                GetChannelsAsyncCallback = cancellationToken =>
+                {
+                    var stagingCache = new FakeNuGetPackageCache
+                    {
+                        GetTemplatePackagesAsyncCallback = (dir, prerelease, nugetConfig, ct) =>
+                        {
+                            var package = new NuGetPackage { Id = "Aspire.ProjectTemplates", Source = "darc", Version = "13.4.0-preview.1.99999.1" };
+                            return Task.FromResult<IEnumerable<NuGetPackage>>([package]);
+                        }
+                    };
+                    var stagingChannel = PackageChannel.CreateExplicitChannel(
+                        "staging",
+                        PackageChannelQuality.Prerelease,
+                        [
+                            new PackageMapping("Aspire*", channelFeed),
+                            new PackageMapping(PackageMapping.AllPackages, PackageSources.NuGetOrg),
+                        ],
+                        stagingCache,
+                        new TestFeatures());
+                    return Task.FromResult<IEnumerable<PackageChannel>>([stagingChannel]);
+                }
+            };
+        });
+
+        services.AddSingleton<IAppHostProjectFactory>(new TestTypeScriptStarterProjectFactory((directory, cancellationToken, _) =>
+        {
+            var modulesDir = Directory.CreateDirectory(Path.Combine(directory.FullName, ".aspire", "modules"));
+            File.WriteAllText(Path.Combine(modulesDir.FullName, "aspire.ts"), "// generated sdk");
+            return Task.FromResult(true);
+        }));
+
+        using var provider = services.BuildServiceProvider();
+        var command = provider.GetRequiredService<RootCommand>();
+        var result = command.Parse("new aspire-ts-starter --name TestApp --output ./output --channel staging --localhost-tld false");
+
+        var exitCode = await result.InvokeAsync().DefaultTimeout();
+
+        Assert.Equal(CliExitCodes.Success, exitCode);
+
+        var nugetConfigPath = Path.Combine(workspace.WorkspaceRoot.FullName, "output", "nuget.config");
+        Assert.True(File.Exists(nugetConfigPath), $"Expected channel-derived NuGet.config at '{nugetConfigPath}'.");
+
+        var doc = XDocument.Load(nugetConfigPath);
+        var packageSources = doc.Root!.Element("packageSources")!;
+        Assert.Contains(packageSources.Elements("add"), e => (string?)e.Attribute("value") == channelFeed);
+        Assert.Equal(["Aspire*"], GetPackagePatternsForSource(doc, channelFeed));
+    }
+
+    [Fact]
     public async Task NewCommandNonInteractiveDoesNotPrompt()
     {
         using var workspace = TemporaryWorkspace.Create(outputHelper);

--- a/tests/Aspire.Cli.Tests/TestServices/TestPackagingService.cs
+++ b/tests/Aspire.Cli.Tests/TestServices/TestPackagingService.cs
@@ -36,4 +36,15 @@ internal sealed class TestPackagingService : IPackagingService
     {
         return GetStagingChannelUnavailableReasonCallback?.Invoke();
     }
+
+    /// <summary>
+    /// Optional callback for <see cref="GetEffectiveIdentityChannel"/>. Returning
+    /// <see langword="null"/> or an empty string (the default) signals "no opinion" so
+    /// <c>NewCommand</c> falls back to <see cref="CliExecutionContext.IdentityChannel"/>
+    /// — the value tests set via the channel-resolution helpers in this project.
+    /// </summary>
+    public Func<string?>? GetEffectiveIdentityChannelCallback { get; set; }
+
+    public string GetEffectiveIdentityChannel()
+        => GetEffectiveIdentityChannelCallback?.Invoke() ?? string.Empty;
 }

--- a/tests/Aspire.Cli.Tests/TestServices/TestTypeScriptStarterProjectFactory.cs
+++ b/tests/Aspire.Cli.Tests/TestServices/TestTypeScriptStarterProjectFactory.cs
@@ -47,6 +47,8 @@ internal sealed class TestTypeScriptStarterProject(Func<DirectoryInfo, Cancellat
 
     public string? LastPackageSourceOverride { get; private set; }
 
+    public Func<AddPackageContext, CancellationToken, Task<bool>>? AddPackageAsyncCallback { get; set; }
+
     public string LanguageId => KnownLanguageId.TypeScript;
 
     public string DisplayName => "TypeScript (Node.js)";
@@ -90,6 +92,10 @@ internal sealed class TestTypeScriptStarterProject(Func<DirectoryInfo, Cancellat
 
     public Task<bool> AddPackageAsync(AddPackageContext context, CancellationToken cancellationToken)
     {
+        if (AddPackageAsyncCallback is { } callback)
+        {
+            return callback(context, cancellationToken);
+        }
         throw new NotImplementedException();
     }
 


### PR DESCRIPTION
# Description

Follow-up to #17743 closing the user-visible gap for polyglot (TS/Python/Go/Java/Rust) apphosts. With a staging-identity CLI:

```
aspire new        # pick TypeScript Starter
cd <project>
aspire add        # pick foundry
```

…still offered the older `13.3.5-preview` alongside the matching staging version, and when only the staging version was found it still presented a version picker prompt instead of auto-selecting. C# starters did the right thing in both cases.

## Root causes

This PR fixes two related-but-distinct bugs that combined to produce the symptom.

### 1. Polyglot starters didn't drop a project-local `NuGet.config`

`IntegrationPackageSearchService.GetIntegrationPackagesWithChannelsAsync` intentionally always includes the Implicit channel so prerelease-only packages (e.g. Foundry) stay reachable when the project is Stable-pinned (#17724 / #17725). The Implicit channel calls `dotnet package search` with no explicit NuGet config, so it walks the ambient hierarchy.

The C# starter falls back to `PromptToCreateOrUpdateNuGetConfigAsync` (`DotNetTemplateFactory.cs` line ~549-552) when no `--source` was supplied — that writes a project-local `NuGet.config` pinning `Aspire.*` to the resolved channel's feed via a package-source mapping. The 4 polyglot template paths only called `CreateOrUpdateNuGetConfigForSourceOverrideAsync`, which is a no-op without `--source`. So polyglot projects got **no** project-local `NuGet.config`, and the Implicit channel resolved `Aspire.Hosting.*` from nuget.org → surfaced the stale 13.3.5 alongside the staging match.

### 2. `aspire add` showed a version picker on polyglot when C# auto-selected

Two cooperating mistakes in the add flow:

- `IntegrationPackageSearchService` included **every** Explicit channel (stable, daily, staging, ...) whenever the apphost had a pinned channel. That dragged unrelated channels (e.g. daily) and their stale versions into the result set.
- `AddCommand.GetPackageByInteractiveFlow` didn't deduplicate by (PackageId, Version) before handing the list to the version prompter. With the project-local `NuGet.config` from layer 1 in place, the same package+version got surfaced by both Implicit (via the project-local feed map) and the matching pinned Explicit channel, producing two identical rows that prevented the auto-select path in `PromptForChannelPackagesAsync` from firing.

C# never hit either: `IntegrationPackageSearchService.GetConfiguredChannel` returns `null` for C# unconditionally, so the Explicit channel set is never queried for C# add flows.

## Fixes

### Layer 1 — polyglot starters

Mirror the C# fallback. After the source-override write (which returns false when no `--source` was supplied), chain `CreateOrUpdateNuGetConfigWithoutPromptAsync` (the same helper `InitCommand` uses for polyglot init flows). The helper is a no-op for Implicit / non-Explicit / unregistered channels, so Stable / no-explicit-channel runs are unchanged.

Applied to all 4 affected templates:

- `CliTemplateFactory.TypeScriptStarterTemplate.cs` (canonical fix site with full justification comment)
- `CliTemplateFactory.PythonStarterTemplate.cs`
- `CliTemplateFactory.GoStarterTemplate.cs`
- `CliTemplateFactory.EmptyTemplate.cs` (non-csharp branch; the csharp branch was already correct)

### Layer 2 — `aspire add` auto-select parity

- `IntegrationPackageSearchService` narrows the Explicit channel set to the apphost-pinned channel only. Implicit always stays so prerelease-only packages remain reachable when the pin is Stable-quality — preserving the #17724/#17725 guarantee.
- `AddCommand` dedupes `orderedPackageVersions` by (Id, Version) keeping the first occurrence (Implicit-channel entry wins due to existing ordering).

Net effect: for a TS apphost pinned to staging, only the Implicit Foundry entry remains after narrowing+dedupe, which trips the `explicitGroups.Length == 0 && implicitGroup is not null` auto-select branch and skips the version menu — matching the C# flow exactly.

## Tests

- New `NewCommandWithTypeScriptStarterAndExplicitChannelWritesChannelDerivedNuGetConfig` — drives `aspire new aspire-ts-starter --channel staging` (no `--source`) with a registered staging channel containing an `Aspire* → darc feed` mapping, and asserts a project-local `nuget.config` lands on disk with the correct package source mapping.
- New `AddCommandWithTypeScriptAppHostPinnedToStagingAutoSelectsImplicitVersionWithoutPromptingForVersion` — drives `aspire add foundry` against a TS apphost pinned to staging, with a fake PackagingService returning Implicit+Stable+Staging+Daily where Implicit and Staging both surface Foundry@13.4.0-preview.1.staging and Daily surfaces the stale Foundry@13.3.5-preview.1.daily. Asserts no `IInteractionService` selection prompt is raised and that 13.4.0-preview.1.staging is what gets added. Verified fails-without / passes-with both fixes.
- Updated `IntegrationSearchCommandTypeScriptAppHostPersistedChannelExpandsDiscoveryWithoutChangingPreferredResult` theory data to reflect the new channel-name-aware narrowing (staging-pin no longer searches an unrelated daily channel).
- Extended `TestTypeScriptStarterProject` with an `AddPackageAsyncCallback` so end-to-end `aspire add` flows can be exercised in tests.

All 3928 Aspire.Cli.Tests pass.

## Validation

Built locally; can be exercised end-to-end with the helper scripts added in #17743:

```bash
./eng/scripts/debug-staging.sh \
  --sha e13850995727767ba26088932630342417745f40 \
  --cli ./artifacts/bin/Aspire.Cli/Debug/net10.0/aspire \
  --shell
# inside the subshell:
aspire new                       # TypeScript Starter
cd <generated-project>
ls nuget.config                  # exists now (was missing before)
aspire add foundry               # auto-selects 13.4.0-preview.* (no prompt)
```

## Fixes

Follow-up to #17743 for issue #17744 (polyglot leg).

Targeting `release/13.4` since #17743 was merged there; needs forward-port to `main`.
