### PR TITLE
Fix Aspire CLI npm signing scope

### DIFF
--- a/eng/Signing.props
+++ b/eng/Signing.props
@@ -69,12 +69,14 @@
 
     <!--
       npm packages are tarballs, but only the Aspire CLI npm tarballs should get
-      detached signatures. Scope both the .tgz rule and the nested JavaScript
-      launcher override to the npm package ItemsToSign collision id so the global
-      .tgz/.js defaults remain unchanged for unrelated artifacts.
+      detached signatures. Scope these rules to the npm package ItemsToSign
+      collision id so the global .tgz/.js/native-executable defaults remain
+      unchanged for unrelated artifacts.
     -->
     <FileExtensionSignInfo Include=".tgz" CertificateName="LinuxSign500180PGP" CollisionPriorityId="AspireCliNpmPackage" />
     <FileSignInfo Include="aspire.js" CertificateName="MicrosoftDotNet500" CollisionPriorityId="AspireCliNpmPackage" />
+    <FileSignInfo Include="aspire.exe" CertificateName="None" CollisionPriorityId="AspireCliNpmPackage" />
+    <FileSignInfo Include="aspire" CertificateName="None" CollisionPriorityId="AspireCliNpmPackage" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/Infrastructure.Tests/Pipelines/NpmCliPackageTests.cs
+++ b/tests/Infrastructure.Tests/Pipelines/NpmCliPackageTests.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Xml.Linq;
 using Xunit;
 
 namespace Infrastructure.Tests;
@@ -201,6 +202,23 @@ public sealed class NpmCliPackageTests
     }
 
     [Fact]
+    public async Task NpmSigningScopeCoversNestedTarballPayloads()
+    {
+        var signingProps = XDocument.Parse(await ReadRepoFileAsync("eng/Signing.props"));
+
+        AssertScopedSigningRule(signingProps, "FileExtensionSignInfo", ".tgz", "LinuxSign500180PGP");
+        AssertScopedSigningRule(signingProps, "FileSignInfo", "aspire.js", "MicrosoftDotNet500");
+
+        // The native npm packages are built from already-signed native archives.
+        // The main Windows build should only produce the detached npm tarball
+        // signature; it must still provide scoped rules for nested native
+        // executables because Arcade resolves nested file certificates inside
+        // the ItemsToSign collision scope.
+        AssertScopedSigningRule(signingProps, "FileSignInfo", "aspire.exe", "None");
+        AssertScopedSigningRule(signingProps, "FileSignInfo", "aspire", "None");
+    }
+
+    [Fact]
     public async Task ReleasePipelinePreflightsScheduledNpmPackagesBeforePublishing()
     {
         var releasePipeline = await ReadRepoFileAsync("eng/pipelines/release-publish-nuget.yml");
@@ -263,6 +281,21 @@ public sealed class NpmCliPackageTests
         }
 
         return count;
+    }
+
+    private static void AssertScopedSigningRule(XDocument document, string elementName, string include, string certificateName)
+    {
+        var matchingRules = document
+            .Descendants(elementName)
+            .Where(element =>
+                (string?)element.Attribute("CollisionPriorityId") == "AspireCliNpmPackage" &&
+                ((string?)element.Attribute("Include") == include || (string?)element.Attribute("Update") == include) &&
+                (string?)element.Attribute("CertificateName") == certificateName)
+            .ToArray();
+
+        Assert.True(
+            matchingRules.Length == 1,
+            $"Expected exactly one {elementName} for '{include}' using '{certificateName}' in the AspireCliNpmPackage signing scope, but found {matchingRules.Length}.");
     }
 
     private static string FindRepoRoot()


### PR DESCRIPTION
## Description

Fixes the internal signed build failure introduced by the Aspire CLI npm package release integration. The failed build staged `microsoft-aspire-cli-win-*.tgz` into the `AspireCliNpmPackage` signing scope, but the nested `aspire.exe` only had an unscoped signing rule. Arcade resolves nested file certificates within the `ItemsToSign` collision scope, so it failed with `Could not determine certificate name for signable file(s): File: aspire.exe`.

This keeps the npm tarball signing behavior scoped to Aspire CLI npm packages: `.tgz` still gets the detached `LinuxSign500180PGP` signature, `aspire.js` still uses `MicrosoftDotNet500`, and the already-signed native `aspire.exe`/`aspire` payloads are explicitly `CertificateName="None"` inside that same scope.

Internal validation build: https://dev.azure.com/dnceng/internal/_build/results?buildId=2988598

Relevant tasks from build 2988598 completed successfully:

- `🟣Build` on Windows, the task that failed on main
- `🟣Validate npm package signatures`
- `🟣Sign VS Code extension`
- `🟣Verify VS Code extension signature`
- All `🟣Verify CLI npm package (...)` tasks for Windows, Linux, and macOS RIDs

Fixes # (issue)

### Security considerations

This change touches signing metadata only. The native executable payloads in the npm RID packages are copied from the already-signed native CLI archives; the main Windows build should produce detached signatures for the npm tarballs rather than re-sign those nested native payloads. The tarballs remain covered by detached PGP signatures.

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [x] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [x] No
  - [ ] No
