### PR TITLE
[do not review] Fix View options expanded state announcement

### DIFF
--- a/src/Aspire.Dashboard/Components/Controls/AspireMenu.razor.cs
+++ b/src/Aspire.Dashboard/Components/Controls/AspireMenu.razor.cs
@@ -105,7 +105,8 @@ public partial class AspireMenu : FluentComponentBase
         {
             await onClick();
         }
-        Open = false;
+
+        await OnOpenChanged(false);
     }
 
     private Task OnOpenChanged(bool open)

--- a/src/Aspire.Dashboard/Components/Controls/AspireMenuButton.razor
+++ b/src/Aspire.Dashboard/Components/Controls/AspireMenuButton.razor
@@ -6,7 +6,7 @@
     var additionalButtonAttributes = new Dictionary<string, object>(AdditionalAttributes ?? ImmutableDictionary<string, object>.Empty)
     {
         { "aria-haspopup", "true" },
-        { "aria-expanded", _visible },
+        { "aria-expanded", _visible ? "true" : "false" },
         { "onkeydown", (KeyboardEventArgs args) => OnKeyDown(args) }
     };
 }

--- a/tests/Aspire.Dashboard.Components.Tests/Controls/AspireMenuButtonTests.cs
+++ b/tests/Aspire.Dashboard.Components.Tests/Controls/AspireMenuButtonTests.cs
@@ -18,16 +18,21 @@ public class AspireMenuButtonTests : DashboardTestContext
         FluentUISetupHelpers.SetupFluentButton(this);
         FluentUISetupHelpers.SetupFluentMenu(this);
 
-        var cut = RenderComponent<AspireMenuButton>(builder =>
+        var cut = Render(builder =>
         {
-            builder.Add(p => p.MenuButtonId, "view-options-button");
-            builder.Add(p => p.Text, "View options");
-            builder.Add(p => p.Items, [
+            builder.OpenComponent<Microsoft.FluentUI.AspNetCore.Components.FluentMenuProvider>(0);
+            builder.CloseComponent();
+            builder.OpenComponent<AspireMenuButton>(1);
+            builder.AddAttribute(2, nameof(AspireMenuButton.MenuButtonId), "view-options-button");
+            builder.AddAttribute(3, nameof(AspireMenuButton.Text), "View options");
+            builder.AddAttribute(4, nameof(AspireMenuButton.Items), new List<MenuButtonItem>
+            {
                 new MenuButtonItem
                 {
                     Text = "Show hidden resources"
                 }
-            ]);
+            });
+            builder.CloseComponent();
         });
 
         var button = cut.Find("#view-options-button");
@@ -38,6 +43,15 @@ public class AspireMenuButtonTests : DashboardTestContext
         cut.WaitForAssertion(() =>
         {
             Assert.Equal("true", cut.Find("#view-options-button").GetAttribute("aria-expanded"));
+        });
+
+        cut.FindComponent<Microsoft.FluentUI.AspNetCore.Components.FluentMenuItem>()
+            .Find("fluent-menu-item")
+            .Click();
+
+        cut.WaitForAssertion(() =>
+        {
+            Assert.Equal("false", cut.Find("#view-options-button").GetAttribute("aria-expanded"));
         });
     }
 }

--- a/tests/Aspire.Dashboard.Components.Tests/Controls/AspireMenuButtonTests.cs
+++ b/tests/Aspire.Dashboard.Components.Tests/Controls/AspireMenuButtonTests.cs
@@ -1,0 +1,43 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Aspire.Dashboard.Components.Tests.Shared;
+using Aspire.Dashboard.Model;
+using Bunit;
+using Xunit;
+
+namespace Aspire.Dashboard.Components.Tests.Controls;
+
+public class AspireMenuButtonTests : DashboardTestContext
+{
+    [Fact]
+    public void ToggleMenu_UpdatesAriaExpandedState()
+    {
+        FluentUISetupHelpers.SetupFluentUIComponents(this);
+        FluentUISetupHelpers.SetupFluentAnchoredRegion(this);
+        FluentUISetupHelpers.SetupFluentButton(this);
+        FluentUISetupHelpers.SetupFluentMenu(this);
+
+        var cut = RenderComponent<AspireMenuButton>(builder =>
+        {
+            builder.Add(p => p.MenuButtonId, "view-options-button");
+            builder.Add(p => p.Text, "View options");
+            builder.Add(p => p.Items, [
+                new MenuButtonItem
+                {
+                    Text = "Show hidden resources"
+                }
+            ]);
+        });
+
+        var button = cut.Find("#view-options-button");
+        Assert.Equal("false", button.GetAttribute("aria-expanded"));
+
+        button.Click();
+
+        cut.WaitForAssertion(() =>
+        {
+            Assert.Equal("true", cut.Find("#view-options-button").GetAttribute("aria-expanded"));
+        });
+    }
+}


### PR DESCRIPTION
## Description

Fixes #17466

The Resources page "View options" menu button now exposes a real expanded/collapsed state to assistive technology. Previously the Blazor bool attribute rendering could leave `aria-expanded` absent while collapsed and empty while expanded, so screen readers did not have a reliable state to announce.

### User-facing usage

Keyboard and screen reader users can now hear the View options menu button state when it is toggled:

```text
Closed: aria-expanded="false"
Open:   aria-expanded="true"
```

After-fix Playwright evidence showed the View options button with `aria-expanded="false"` when closed, `aria-expanded="true"` when open, and the accessibility snapshot reported `button "View options" [expanded]`.

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
