### PR TITLE
[do not review] Restore focus after Resources view option selection

### DIFF
--- a/src/Aspire.Dashboard/Components/Controls/AspireMenu.razor.cs
+++ b/src/Aspire.Dashboard/Components/Controls/AspireMenu.razor.cs
@@ -119,7 +119,7 @@ public partial class AspireMenu : FluentComponentBase
         {
             await onClick();
         }
-        Open = false;
+        await OnOpenChanged(false);
 
         if (RestoreFocusOnItemClick && !string.IsNullOrEmpty(Anchor))
         {

--- a/src/Aspire.Dashboard/Components/Controls/AspireMenu.razor.cs
+++ b/src/Aspire.Dashboard/Components/Controls/AspireMenu.razor.cs
@@ -5,6 +5,7 @@ using Aspire.Dashboard.Model;
 using Microsoft.AspNetCore.Components;
 using Microsoft.FluentUI.AspNetCore.Components;
 using Microsoft.FluentUI.AspNetCore.Components.Utilities;
+using Microsoft.JSInterop;
 
 namespace Aspire.Dashboard.Components;
 
@@ -32,6 +33,19 @@ public partial class AspireMenu : FluentComponentBase
 
     [Parameter]
     public required IReadOnlyList<MenuButtonItem> Items { get; set; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether focus should return to <see cref="Anchor"/> after a menu item is clicked.
+    /// </summary>
+    /// <remarks>
+    /// Use this only for button-anchored menus where <see cref="Anchor"/> identifies the element that opened the menu.
+    /// Do not enable it for cursor-positioned or context menus where <see cref="Anchor"/> is only used for positioning.
+    /// </remarks>
+    [Parameter]
+    public bool RestoreFocusOnItemClick { get; set; }
+
+    [Inject]
+    public required IJSRuntime JS { get; init; }
 
     // Each menu item is approximately 32px tall, plus 16px padding for the menu container.
     private const int EstimatedItemHeight = 32;
@@ -106,6 +120,11 @@ public partial class AspireMenu : FluentComponentBase
             await onClick();
         }
         Open = false;
+
+        if (RestoreFocusOnItemClick && !string.IsNullOrEmpty(Anchor))
+        {
+            await JS.InvokeVoidAsync("focusElement", Anchor);
+        }
     }
 
     private Task OnOpenChanged(bool open)

--- a/src/Aspire.Dashboard/Components/Controls/AspireMenuButton.razor
+++ b/src/Aspire.Dashboard/Components/Controls/AspireMenuButton.razor
@@ -27,4 +27,4 @@
     }
 </FluentButton>
 
-<AspireMenu Anchor="@MenuButtonId" @bind-Open="@_visible" Items="_items" />
+<AspireMenu Anchor="@MenuButtonId" @bind-Open="@_visible" Items="_items" RestoreFocusOnItemClick="@RestoreFocusOnItemClick" />

--- a/src/Aspire.Dashboard/Components/Controls/AspireMenuButton.razor.cs
+++ b/src/Aspire.Dashboard/Components/Controls/AspireMenuButton.razor.cs
@@ -51,6 +51,16 @@ public partial class AspireMenuButton : FluentComponentBase
     [Parameter]
     public bool HideIcon { get; set; }
 
+    /// <summary>
+    /// Gets or sets a value indicating whether focus should return to this menu button after a menu item is clicked.
+    /// </summary>
+    /// <remarks>
+    /// Use this for button-anchored menus because the underlying menu anchor is the element that opened the menu.
+    /// Do not use this behavior for cursor-positioned or context menus where the anchor is only used for positioning.
+    /// </remarks>
+    [Parameter]
+    public bool RestoreFocusOnItemClick { get; set; }
+
     protected override void OnParametersSet()
     {
         _icon = Icon ?? s_defaultIcon;

--- a/src/Aspire.Dashboard/Components/Pages/Resources.razor
+++ b/src/Aspire.Dashboard/Components/Pages/Resources.razor
@@ -45,6 +45,7 @@
                     <AspireMenuButton ButtonAppearance="Appearance.Stealth"
                                       Icon="@(new Icons.Regular.Size20.Options())"
                                       Items="@_resourcesMenuItems"
+                                      RestoreFocusOnItemClick="true"
                                       Title="@Loc[nameof(Dashboard.Resources.Resources.ResourcesChangeViewOptions)]"
                                       slot="end" />
                 }

--- a/tests/Aspire.Dashboard.Components.Tests/Controls/AspireMenuTests.cs
+++ b/tests/Aspire.Dashboard.Components.Tests/Controls/AspireMenuTests.cs
@@ -1,0 +1,111 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Aspire.Dashboard.Components.Tests.Shared;
+using Aspire.Dashboard.Model;
+using Bunit;
+using Microsoft.FluentUI.AspNetCore.Components;
+using Xunit;
+
+namespace Aspire.Dashboard.Components.Tests.Controls;
+
+public class AspireMenuTests : DashboardTestContext
+{
+    [Fact]
+    public void ClickItem_RestoreFocusOnItemClickTrue_FocusesAnchor()
+    {
+        FluentUISetupHelpers.SetupFluentUIComponents(this);
+        FluentUISetupHelpers.SetupFluentMenu(this);
+        FluentUISetupHelpers.SetupFluentAnchoredRegion(this);
+        FluentUISetupHelpers.SetupFluentButton(this);
+
+        var anchor = "view-options-button";
+        var itemClicked = false;
+        var focusElementInvocationHandler = JSInterop.SetupVoid("focusElement", anchor);
+        var focusElementInvocationsDuringOnClick = -1;
+        var items = new List<MenuButtonItem>
+        {
+            new()
+            {
+                Text = "Show hidden resources",
+                OnClick = () =>
+                {
+                    focusElementInvocationsDuringOnClick = focusElementInvocationHandler.Invocations.Count;
+                    Assert.True(
+                        focusElementInvocationsDuringOnClick == 0,
+                        $"Focus should not be restored until item OnClick completes. Actual focusElement invocations during OnClick: {focusElementInvocationsDuringOnClick}.");
+                    itemClicked = true;
+
+                    return Task.CompletedTask;
+                }
+            }
+        };
+
+        var cut = Render(builder =>
+        {
+            builder.OpenComponent<FluentMenuProvider>(0);
+            builder.CloseComponent();
+            builder.OpenComponent<AspireMenuButton>(1);
+            builder.AddAttribute(2, nameof(AspireMenuButton.MenuButtonId), anchor);
+            builder.AddAttribute(3, nameof(AspireMenuButton.Title), "View options");
+            builder.AddAttribute(4, nameof(AspireMenuButton.Items), items);
+            builder.AddAttribute(5, nameof(AspireMenuButton.RestoreFocusOnItemClick), true);
+            builder.CloseComponent();
+        });
+
+        cut.Find($"#{anchor}").Click();
+        cut.WaitForElement("fluent-menu-item").Click();
+
+        Assert.True(itemClicked);
+        Assert.True(
+            focusElementInvocationsDuringOnClick == 0,
+            $"Expected zero focusElement invocations during item OnClick, but captured {focusElementInvocationsDuringOnClick}.");
+        var invocation = Assert.Single(focusElementInvocationHandler.Invocations);
+        Assert.Collection(invocation.Arguments,
+            argument => Assert.Equal(anchor, Assert.IsType<string>(argument)));
+    }
+
+    [Fact]
+    public void ClickItem_RestoreFocusOnItemClickFalse_DoesNotFocusAnchor()
+    {
+        FluentUISetupHelpers.SetupFluentUIComponents(this);
+        FluentUISetupHelpers.SetupFluentMenu(this);
+        FluentUISetupHelpers.SetupFluentAnchoredRegion(this);
+        FluentUISetupHelpers.SetupFluentButton(this);
+
+        var anchor = "view-options-button";
+        var itemClicked = false;
+        var items = new List<MenuButtonItem>
+        {
+            new()
+            {
+                Text = "Show hidden resources",
+                OnClick = () =>
+                {
+                    itemClicked = true;
+                    return Task.CompletedTask;
+                }
+            }
+        };
+
+        var cut = Render(builder =>
+        {
+            builder.OpenComponent<FluentMenuProvider>(0);
+            builder.CloseComponent();
+            builder.OpenComponent<AspireMenuButton>(1);
+            builder.AddAttribute(2, nameof(AspireMenuButton.MenuButtonId), anchor);
+            builder.AddAttribute(3, nameof(AspireMenuButton.Title), "View options");
+            builder.AddAttribute(4, nameof(AspireMenuButton.Items), items);
+            builder.CloseComponent();
+        });
+
+        cut.Find($"#{anchor}").Click();
+        cut.WaitForElement("fluent-menu-item").Click();
+
+        Assert.True(itemClicked);
+        var focusElementInvocations = JSInterop.Invocations
+            .Where(invocation => invocation.Identifier == "focusElement")
+            .ToArray();
+        Assert.Empty(focusElementInvocations);
+    }
+}

--- a/tests/Aspire.Dashboard.Components.Tests/Pages/ResourcesTests.cs
+++ b/tests/Aspire.Dashboard.Components.Tests/Pages/ResourcesTests.cs
@@ -390,7 +390,7 @@ public partial class ResourcesTests : DashboardTestContext
     }
 
     [Fact]
-    public void ViewOptionsMenuIsVisibleWhenHiddenResourcesExist()
+    public void ViewOptionsMenu_WiresFocusRestorationWhenHiddenResourcesExist()
     {
         // Arrange
         var viewport = new ViewportInformation(IsDesktop: true, IsUltraLowHeight: false, IsUltraLowWidth: false);
@@ -411,9 +411,8 @@ public partial class ResourcesTests : DashboardTestContext
             builder.AddCascadingValue(viewport);
         });
 
-        // Assert - the menu button should be present (it contains the "Show hidden resources" option)
         var menuButton = cut.FindComponent<AspireMenuButton>();
-        Assert.NotNull(menuButton);
+        Assert.True(menuButton.Instance.RestoreFocusOnItemClick);
     }
 
     [Fact]


### PR DESCRIPTION
## Description

Fixes #17656

The Resources page View options menu now returns keyboard focus to the View options button after a menu item is selected. Previously selecting an item could leave focus on `<body>`, which made keyboard and screen reader users lose their place after the dynamic menu interaction.

The focus restoration is opt-in on Aspire menu components and is enabled only for the Resources View options menu. Other menus keep their existing behavior so item handlers that intentionally move focus, such as chat model selection or dialogs, are not overridden.

### User-facing usage

After selecting a View options item such as **Collapse child resources**, focus remains on the **View options** button instead of moving out of the page. After-fix Playwright evidence captured:

```json
{
  "selectedItemText": "Collapse child resources",
  "after": {
    "tagName": "FLUENT-BUTTON",
    "ariaLabel": "View options",
    "isBody": false
  }
}
```

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
