### PR TITLE
Default release npm contacts

### DIFF
--- a/eng/pipelines/release-publish-nuget.yml
+++ b/eng/pipelines/release-publish-nuget.yml
@@ -108,7 +108,7 @@ parameters:
   - name: NpmPublishApprovers
     displayName: 'npm ESRP approvers (comma-separated Microsoft aliases or emails; leave unchanged for repo default)'
     type: string
-    default: 'adamratzman'
+    default: 'adamratzman,David.Pine'
 
   - name: NpmRegistryPropagationDelayMinutes
     displayName: 'Minutes to wait between npm RID and pointer package submissions'

--- a/eng/pipelines/release-publish-nuget.yml
+++ b/eng/pipelines/release-publish-nuget.yml
@@ -98,8 +98,8 @@ parameters:
     type: boolean
     default: false
 
-  # Azure DevOps manual string parameters cannot be left blank. Keep these
-  # defaults in sync with NPM_PUBLISH_REQUIRED_* in common-variables.yml.
+  # Azure DevOps manual string parameters cannot be left blank. These defaults
+  # must include the NPM_PUBLISH_REQUIRED_* aliases from common-variables.yml.
   - name: NpmPublishOwners
     displayName: 'npm ESRP owners (comma-separated Microsoft aliases or emails; leave unchanged for repo default)'
     type: string

--- a/eng/pipelines/release-publish-nuget.yml
+++ b/eng/pipelines/release-publish-nuget.yml
@@ -98,15 +98,17 @@ parameters:
     type: boolean
     default: false
 
+  # Azure DevOps manual string parameters cannot be left blank. Keep these
+  # defaults in sync with NPM_PUBLISH_REQUIRED_* in common-variables.yml.
   - name: NpmPublishOwners
-    displayName: 'npm ESRP owners (comma-separated Microsoft aliases or emails; leave blank for repo default)'
+    displayName: 'npm ESRP owners (comma-separated Microsoft aliases or emails; leave unchanged for repo default)'
     type: string
-    default: ''
+    default: 'joperezr,ankj'
 
   - name: NpmPublishApprovers
-    displayName: 'npm ESRP approvers (comma-separated Microsoft aliases or emails; leave blank for repo default)'
+    displayName: 'npm ESRP approvers (comma-separated Microsoft aliases or emails; leave unchanged for repo default)'
     type: string
-    default: ''
+    default: 'adamratzman'
 
   - name: NpmRegistryPropagationDelayMinutes
     displayName: 'Minutes to wait between npm RID and pointer package submissions'

--- a/tests/Infrastructure.Tests/Pipelines/NpmCliPackageTests.cs
+++ b/tests/Infrastructure.Tests/Pipelines/NpmCliPackageTests.cs
@@ -256,7 +256,6 @@ public sealed class NpmCliPackageTests
 
         Assert.Contains("NPM_PUBLISH_REQUIRED_OWNERS", commonVariables);
         Assert.Contains("NPM_PUBLISH_REQUIRED_APPROVERS", commonVariables);
-        Assert.Contains("default: ''", releasePipeline);
         Assert.Contains("NpmPublishOwnersEffective", releasePipeline);
         Assert.Contains("NpmPublishApproversEffective", releasePipeline);
         Assert.Contains("owners: '$(NpmPublishOwnersEffective)'", releasePipeline);

--- a/tests/Infrastructure.Tests/Pipelines/ReleasePublishNugetPipelineTests.cs
+++ b/tests/Infrastructure.Tests/Pipelines/ReleasePublishNugetPipelineTests.cs
@@ -101,12 +101,14 @@ public sealed class ReleasePublishNugetPipelineTests
         Assert.Contains("displayName: 'npm ESRP owners (comma-separated Microsoft aliases or emails; leave unchanged for repo default)'", pipeline);
         Assert.Contains("displayName: 'npm ESRP approvers (comma-separated Microsoft aliases or emails; leave unchanged for repo default)'", pipeline);
         Assert.DoesNotContain("leave blank for repo default", pipeline);
-        Assert.Equal(
+        AssertContainsRequiredAliases(
             FindYamlVariableValue(commonVariables, "NPM_PUBLISH_REQUIRED_OWNERS"),
-            FindYamlParameterDefault(pipeline, "NpmPublishOwners"));
-        Assert.Equal(
+            FindYamlParameterDefault(pipeline, "NpmPublishOwners"),
+            "NpmPublishOwners");
+        AssertContainsRequiredAliases(
             FindYamlVariableValue(commonVariables, "NPM_PUBLISH_REQUIRED_APPROVERS"),
-            FindYamlParameterDefault(pipeline, "NpmPublishApprovers"));
+            FindYamlParameterDefault(pipeline, "NpmPublishApprovers"),
+            "NpmPublishApprovers");
         Assert.Contains("$requiredNpmOwnersValue = \"$(NPM_PUBLISH_REQUIRED_OWNERS)\"", pipeline);
         Assert.Contains("$requiredNpmApproversValue = \"$(NPM_PUBLISH_REQUIRED_APPROVERS)\"", pipeline);
         Assert.Contains("owners: '$(NpmPublishOwnersEffective)'", pipeline);
@@ -404,6 +406,37 @@ public sealed class ReleasePublishNugetPipelineTests
         Assert.True(index >= 0, $"Expected to find '{text}'.");
 
         return index;
+    }
+
+    private static void AssertContainsRequiredAliases(string requiredAliasesValue, string actualAliasesValue, string parameterName)
+    {
+        var actualAliases = ParseNpmReleaseAliasSet(actualAliasesValue);
+        var missingAliases = ParseNpmReleaseAliasSet(requiredAliasesValue)
+            .Where(requiredAlias => !actualAliases.Contains(requiredAlias))
+            .OrderBy(alias => alias)
+            .ToArray();
+
+        Assert.True(
+            missingAliases.Length == 0,
+            $"{parameterName} default must include required ESRP alias(es): {string.Join(", ", missingAliases)}.");
+    }
+
+    private static HashSet<string> ParseNpmReleaseAliasSet(string value)
+    {
+        var aliases = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
+        foreach (var entry in value.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries))
+        {
+            var alias = entry;
+            if (alias.EndsWith("@microsoft.com", StringComparison.OrdinalIgnoreCase))
+            {
+                alias = alias[..^"@microsoft.com".Length];
+            }
+
+            aliases.Add(alias.ToLowerInvariant());
+        }
+
+        return aliases;
     }
 
     private static string FindYamlVariableValue(string contents, string variableName)

--- a/tests/Infrastructure.Tests/Pipelines/ReleasePublishNugetPipelineTests.cs
+++ b/tests/Infrastructure.Tests/Pipelines/ReleasePublishNugetPipelineTests.cs
@@ -98,8 +98,15 @@ public sealed class ReleasePublishNugetPipelineTests
         Assert.Contains("value: joperezr,ankj", commonVariables);
         Assert.Contains("- name: NPM_PUBLISH_REQUIRED_APPROVERS", commonVariables);
         Assert.Contains("value: adamratzman", commonVariables);
-        Assert.Contains("displayName: 'npm ESRP owners (comma-separated Microsoft aliases or emails; leave blank for repo default)'", pipeline);
-        Assert.Contains("displayName: 'npm ESRP approvers (comma-separated Microsoft aliases or emails; leave blank for repo default)'", pipeline);
+        Assert.Contains("displayName: 'npm ESRP owners (comma-separated Microsoft aliases or emails; leave unchanged for repo default)'", pipeline);
+        Assert.Contains("displayName: 'npm ESRP approvers (comma-separated Microsoft aliases or emails; leave unchanged for repo default)'", pipeline);
+        Assert.DoesNotContain("leave blank for repo default", pipeline);
+        Assert.Equal(
+            FindYamlVariableValue(commonVariables, "NPM_PUBLISH_REQUIRED_OWNERS"),
+            FindYamlParameterDefault(pipeline, "NpmPublishOwners"));
+        Assert.Equal(
+            FindYamlVariableValue(commonVariables, "NPM_PUBLISH_REQUIRED_APPROVERS"),
+            FindYamlParameterDefault(pipeline, "NpmPublishApprovers"));
         Assert.Contains("$requiredNpmOwnersValue = \"$(NPM_PUBLISH_REQUIRED_OWNERS)\"", pipeline);
         Assert.Contains("$requiredNpmApproversValue = \"$(NPM_PUBLISH_REQUIRED_APPROVERS)\"", pipeline);
         Assert.Contains("owners: '$(NpmPublishOwnersEffective)'", pipeline);
@@ -397,6 +404,43 @@ public sealed class ReleasePublishNugetPipelineTests
         Assert.True(index >= 0, $"Expected to find '{text}'.");
 
         return index;
+    }
+
+    private static string FindYamlVariableValue(string contents, string variableName)
+        => FindYamlValueAfterMarker(contents, $"- name: {variableName}", "value:");
+
+    private static string FindYamlParameterDefault(string contents, string parameterName)
+        => FindYamlValueAfterMarker(contents, $"- name: {parameterName}", "default:");
+
+    private static string FindYamlValueAfterMarker(string contents, string marker, string valueKey)
+    {
+        var lines = contents.Split('\n');
+        var markerLineIndex = Array.FindIndex(lines, line => line.TrimEnd('\r').Trim() == marker);
+
+        Assert.True(markerLineIndex >= 0, $"Expected to find '{marker}'.");
+
+        for (var i = markerLineIndex + 1; i < lines.Length; i++)
+        {
+            var line = lines[i].TrimEnd('\r').Trim();
+            if (line.StartsWith(valueKey, StringComparison.Ordinal))
+            {
+                return TrimYamlQuotes(line[valueKey.Length..].Trim());
+            }
+        }
+
+        throw new Xunit.Sdk.XunitException($"Expected to find '{valueKey}' after '{marker}'.");
+    }
+
+    private static string TrimYamlQuotes(string value)
+    {
+        if (value.Length >= 2 &&
+            ((value[0] == '\'' && value[^1] == '\'') ||
+             (value[0] == '"' && value[^1] == '"')))
+        {
+            return value[1..^1];
+        }
+
+        return value;
     }
 
     private Task<string> ReadRepoFileAsync(string relativePath)

--- a/tests/Infrastructure.Tests/Pipelines/ReleasePublishNugetPipelineTests.cs
+++ b/tests/Infrastructure.Tests/Pipelines/ReleasePublishNugetPipelineTests.cs
@@ -419,16 +419,40 @@ public sealed class ReleasePublishNugetPipelineTests
 
         Assert.True(markerLineIndex >= 0, $"Expected to find '{marker}'.");
 
+        var markerIndent = CountLeadingWhitespace(lines[markerLineIndex]);
         for (var i = markerLineIndex + 1; i < lines.Length; i++)
         {
-            var line = lines[i].TrimEnd('\r').Trim();
-            if (line.StartsWith(valueKey, StringComparison.Ordinal))
+            var rawLine = lines[i].TrimEnd('\r');
+            var line = rawLine.Trim();
+            if (line.Length == 0)
+            {
+                continue;
+            }
+
+            var indent = CountLeadingWhitespace(rawLine);
+            if (indent == markerIndent && line.StartsWith("- ", StringComparison.Ordinal))
+            {
+                break;
+            }
+
+            if (indent > markerIndent && line.StartsWith(valueKey, StringComparison.Ordinal))
             {
                 return TrimYamlQuotes(line[valueKey.Length..].Trim());
             }
         }
 
         throw new Xunit.Sdk.XunitException($"Expected to find '{valueKey}' after '{marker}'.");
+    }
+
+    private static int CountLeadingWhitespace(string value)
+    {
+        var count = 0;
+        while (count < value.Length && char.IsWhiteSpace(value[count]))
+        {
+            count++;
+        }
+
+        return count;
     }
 
     private static string TrimYamlQuotes(string value)


### PR DESCRIPTION
## Description

Azure DevOps requires values for the release pipeline's npm ESRP owner and approver string parameters, even on runs where npm publishing is skipped. Those fields previously defaulted to blank while saying blank would use the repo default, which made manual release runs fail validation before the existing fallback logic could help.

This sets the pipeline parameter defaults to the repo default owner and approver values from `eng/pipelines/common-variables.yml`, updates the display text to say operators can leave the defaults unchanged, and adds test coverage so the parameter defaults stay in sync with the repo defaults.

Validation: `dotnet run --project tests/Infrastructure.Tests/Infrastructure.Tests.csproj --no-restore --no-launch-profile -- --filter-class "*.ReleasePublishNugetPipelineTests" --filter-not-trait "quarantined=true" --filter-not-trait "outerloop=true"`

Fixes # (issue)

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
