### PR TITLE
[do not review] Use semantic help shortcut descriptions

### DIFF
--- a/src/Aspire.Dashboard/Components/Dialogs/HelpDialog.razor
+++ b/src/Aspire.Dashboard/Components/Dialogs/HelpDialog.razor
@@ -8,19 +8,25 @@
 
 <h5>@Loc[nameof(Dialogs.HelpDialogKeyboardShortcutsTitle)]</h5>
 
+@{
+    var shortcutCategories = GetShortcutsByCategory();
+}
+
 <FluentGrid Spacing="3">
-    @foreach (var shortcutCategory in GetShortcutsByCategory())
+    @for (var categoryIndex = 0; categoryIndex < shortcutCategories.Count; categoryIndex++)
     {
+        var shortcutCategory = shortcutCategories[categoryIndex];
+        var categoryHeadingId = $"help-dialog-shortcut-category-{categoryIndex}";
+
         <FluentGridItem xs="12" sm="6">
             <FluentStack Orientation="Orientation.Vertical" VerticalGap="3" style="border-radius: 0.375rem; border-style: solid; border-width: 1px; border-color: var(--neutral-layer-4); padding: 11px;">
-                <h6 style="margin-bottom: 5px;">@shortcutCategory.Category</h6>
-                <FluentStack Orientation="Orientation.Vertical" VerticalGap="6">
+                <h6 id="@categoryHeadingId" style="margin-bottom: 5px;">@shortcutCategory.Category</h6>
+                <dl aria-labelledby="@categoryHeadingId" style="margin: 0; display: flex; flex-direction: column; gap: 6px;">
                     @foreach (var shortcut in shortcutCategory.Shortcuts)
                     {
-                        <FluentStack Orientation="Orientation.Horizontal" width="100%">
-                            @shortcut.Description
-                            <FluentSpacer/>
-                            <span>
+                        <div style="display: flex; align-items: center; width: 100%; gap: 6px;">
+                            <dt style="font-weight: normal;">@shortcut.Description</dt>
+                            <dd style="margin: 0 0 0 auto;">
                                 @for (var i = 0; i < shortcut.Keys.Length; i++)
                                 {
                                     <kbd style="margin-right: 3px;">@shortcut.Keys[i]</kbd>
@@ -30,10 +36,10 @@
                                         <span style="margin-right: 3px;">+</span>
                                     }
                                 }
-                            </span>
-                        </FluentStack>
+                            </dd>
+                        </div>
                     }
-                </FluentStack>
+                </dl>
             </FluentStack>
         </FluentGridItem>
     }

--- a/tests/Aspire.Dashboard.Components.Tests/Dialogs/HelpDialogTests.cs
+++ b/tests/Aspire.Dashboard.Components.Tests/Dialogs/HelpDialogTests.cs
@@ -1,0 +1,73 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Aspire.Dashboard.Components.Dialogs;
+using Aspire.Dashboard.Components.Tests.Shared;
+using Bunit;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Localization;
+using Xunit;
+using DashboardDialogs = Aspire.Dashboard.Resources.Dialogs;
+
+namespace Aspire.Dashboard.Components.Tests.Dialogs;
+
+public class HelpDialogTests : DashboardTestContext
+{
+    [Fact]
+    public void Render_KeyboardShortcuts_UsesAssociatedDescriptionLists()
+    {
+        SetupHelpDialogServices();
+        var loc = Services.GetRequiredService<IStringLocalizer<DashboardDialogs>>();
+        var expectedCategoryNames = new[]
+        {
+            loc[nameof(DashboardDialogs.HelpDialogCategoryPanels)].Value,
+            loc[nameof(DashboardDialogs.HelpDialogCategoryPageNavigation)].Value,
+            loc[nameof(DashboardDialogs.HelpDialogCategoryNavigation)].Value
+        };
+
+        var cut = RenderComponent<HelpDialog>();
+
+        var shortcutLists = cut.FindAll("dl");
+        Assert.Equal(expectedCategoryNames.Length, shortcutLists.Count);
+
+        for (var listIndex = 0; listIndex < shortcutLists.Count; listIndex++)
+        {
+            var shortcutList = shortcutLists[listIndex];
+            var labelledBy = shortcutList.GetAttribute("aria-labelledby");
+            Assert.False(string.IsNullOrWhiteSpace(labelledBy));
+
+            var heading = cut.Find($"#{labelledBy}");
+            Assert.Equal("h6", heading.TagName.ToLowerInvariant());
+            Assert.Equal(expectedCategoryNames[listIndex], heading.TextContent.Trim());
+
+            var descriptions = shortcutList.QuerySelectorAll("dt");
+            var keyDescriptions = shortcutList.QuerySelectorAll("dd");
+            Assert.NotEmpty(descriptions);
+            Assert.Equal(descriptions.Length, keyDescriptions.Length);
+
+            for (var i = 0; i < descriptions.Length; i++)
+            {
+                Assert.False(string.IsNullOrWhiteSpace(descriptions[i].TextContent));
+
+                var keys = keyDescriptions[i].QuerySelectorAll("kbd");
+                Assert.NotEmpty(keys);
+                Assert.All(keys, key => Assert.False(string.IsNullOrWhiteSpace(key.TextContent)));
+            }
+        }
+
+        var resetPanelSizesText = loc[nameof(DashboardDialogs.HelpDialogResetPanelSize)].Value;
+        var resetPanelSizesTerm = Assert.Single(cut.FindAll("dt"), t => t.TextContent.Trim() == resetPanelSizesText);
+        var resetPanelSizesKeys = resetPanelSizesTerm.NextElementSibling;
+        Assert.NotNull(resetPanelSizesKeys);
+        Assert.Equal("dd", resetPanelSizesKeys.TagName.ToLowerInvariant());
+        Assert.Equal(["shift", "r"], resetPanelSizesKeys.QuerySelectorAll("kbd").Select(k => k.TextContent.Trim()).ToArray());
+        Assert.Contains("+", resetPanelSizesKeys.TextContent);
+    }
+
+    private void SetupHelpDialogServices()
+    {
+        FluentUISetupHelpers.AddCommonDashboardServices(this);
+        FluentUISetupHelpers.SetupFluentUIComponents(this);
+        FluentUISetupHelpers.SetupFluentAnchor(this);
+    }
+}


### PR DESCRIPTION
## Description

Fixes #17650

The Help dialog now renders keyboard shortcuts as semantic description lists, so each shortcut description is programmatically associated with its key sequence. Previously the dialog rendered shortcut rows as plain layout stacks, which allowed screen readers to flatten a whole category into one continuous string.

### User-facing usage

Screen reader users now get separate term/definition pairs for Help dialog shortcuts. Annotated evidence captured the before state as flat text:

```text
Increase panel size + Decrease panel size - Reset panel sizes shift+r ...
```

The after-fix accessibility snapshot exposes separate terms and definitions:

```text
term: Reset panel sizes
definition: shift+r
```

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
