### PR TITLE
[do not review] Add non-color mobile nav selected indicator

### DIFF
--- a/src/Aspire.Dashboard/Components/Layout/MobileNavMenu.razor
+++ b/src/Aspire.Dashboard/Components/Layout/MobileNavMenu.razor
@@ -1,13 +1,21 @@
 ﻿<FluentMenu Class="aspire-menu-container" Open="@IsNavMenuOpen" Anchored="false" Style="grid-area: nav-menu; height: 100vh; margin-top: 2px; overflow-y: auto;">
     @foreach (var item in GetMobileNavMenuEntries())
     {
-        <FluentMenuItem OnClick="@(async () => { CloseNavMenu(); await item.OnClick(); })" Style="height: 40px; width: 100vw; margin-bottom: 6px;" title="@item.Text">
+        var isActive = item.LinkMatchRegex is not null && item.LinkMatchRegex.IsMatch($"/{NavigationManager.ToBaseRelativePath(NavigationManager.Uri)}");
+        var menuItemAttributes = new Dictionary<string, object>
+        {
+            ["title"] = item.Text
+        };
+        if (isActive)
+        {
+            menuItemAttributes["aria-current"] = "page";
+        }
+
+        <FluentMenuItem OnClick="@(async () => { CloseNavMenu(); await item.OnClick(); })" Class="@(isActive ? "mobile-nav-menu-item-active" : null)" Style="height: 40px; width: 100vw; margin-bottom: 6px;" AdditionalAttributes="@menuItemAttributes">
             <span>@item.Text</span>
 
             @if (item.Icon is { } icon)
             {
-                var isActive = item.LinkMatchRegex is not null && item.LinkMatchRegex.IsMatch($"/{NavigationManager.ToBaseRelativePath(NavigationManager.Uri)}");
-
                 <span slot="start">
                     @if (isActive)
                     {
@@ -18,6 +26,11 @@
                         <FluentIcon Class="align-text-bottom" Value="@icon" Slot="start" Color="Color.Neutral" />
                     }
                 </span>
+            }
+
+            @if (isActive)
+            {
+                <span slot="end" class="mobile-nav-menu-selected-indicator" aria-hidden="true">✓</span>
             }
         </FluentMenuItem>
 

--- a/src/Aspire.Dashboard/Components/Layout/MobileNavMenu.razor.cs
+++ b/src/Aspire.Dashboard/Components/Layout/MobileNavMenu.razor.cs
@@ -42,7 +42,7 @@ public partial class MobileNavMenu : ComponentBase
                 Loc[nameof(Resources.Layout.NavMenuResourcesTab)],
                 () => NavigateToAsync(DashboardUrls.ResourcesUrl()),
                 DesktopNavMenu.ResourcesIcon(),
-                LinkMatchRegex: new Regex($"^{DashboardUrls.ResourcesUrl()}(\\?.*)?$")
+                LinkMatchRegex: GetIndexPageRegex(DashboardUrls.ResourcesUrl())
             );
 
             yield return new MobileNavMenuEntry(
@@ -123,7 +123,14 @@ public partial class MobileNavMenu : ComponentBase
     private static Regex GetNonIndexPageRegex(string pageRelativeBasePath)
     {
         pageRelativeBasePath = Regex.Escape(pageRelativeBasePath);
-        return new Regex($"^({pageRelativeBasePath}|{pageRelativeBasePath}/.+)$", RegexOptions.CultureInvariant | RegexOptions.IgnoreCase);
+        return new Regex($"^({pageRelativeBasePath}(\\?.*)?|{pageRelativeBasePath}/.+)$", LinkMatchRegexOptions);
     }
-}
 
+    private static Regex GetIndexPageRegex(string pageRelativeBasePath)
+    {
+        pageRelativeBasePath = Regex.Escape(pageRelativeBasePath);
+        return new Regex($"^{pageRelativeBasePath}(\\?.*)?$", LinkMatchRegexOptions);
+    }
+
+    private const RegexOptions LinkMatchRegexOptions = RegexOptions.CultureInvariant | RegexOptions.IgnoreCase;
+}

--- a/src/Aspire.Dashboard/wwwroot/css/app.css
+++ b/src/Aspire.Dashboard/wwwroot/css/app.css
@@ -937,6 +937,21 @@ fluent-tooltip[anchor="dialog_close"] > div {
     text-overflow: ellipsis;
 }
 
+.aspire-menu-container fluent-menu-item.mobile-nav-menu-item-active {
+    font-weight: 600;
+}
+
+.aspire-menu-container .mobile-nav-menu-selected-indicator {
+    color: var(--accent-foreground-active);
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    font-size: var(--type-ramp-plus-1-font-size);
+    font-weight: 700;
+    line-height: 1;
+    min-inline-size: 1.5rem;
+}
+
 .aspire-menu-container fluent-menu fluent-menu {
     max-width: var(--aspire-menu-max-width);
 }

--- a/tests/Aspire.Dashboard.Components.Tests/Layout/MobileNavMenuTests.cs
+++ b/tests/Aspire.Dashboard.Components.Tests/Layout/MobileNavMenuTests.cs
@@ -1,0 +1,89 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Aspire.Dashboard.Components.Layout;
+using Aspire.Dashboard.Components.Tests.Shared;
+using Aspire.Dashboard.Tests.Shared;
+using Aspire.Dashboard.Utils;
+using Bunit;
+using Microsoft.AspNetCore.Components;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace Aspire.Dashboard.Components.Tests.Layout;
+
+[UseCulture("en-US")]
+public class MobileNavMenuTests : DashboardTestContext
+{
+    [Fact]
+    public void Render_OpenMenu_CurrentPageHasSemanticAndVisualSelectedState()
+    {
+        var cut = RenderMobileNavMenu(DashboardUrls.StructuredLogsUrl());
+
+        AssertMenuItemIsActive(cut, Resources.Layout.NavMenuStructuredLogsTab);
+    }
+
+    [Fact]
+    public void Render_OpenMenu_CurrentPageWithQueryStringHasSemanticAndVisualSelectedState()
+    {
+        var cut = RenderMobileNavMenu(DashboardUrls.StructuredLogsUrl(logLevel: "warning"));
+
+        AssertMenuItemIsActive(cut, Resources.Layout.NavMenuStructuredLogsTab);
+    }
+
+    [Fact]
+    public void Render_OpenMenu_ResourcesPageWithQueryStringHasSemanticAndVisualSelectedState()
+    {
+        var cut = RenderMobileNavMenu(DashboardUrls.ResourcesUrl(resource: "foo"));
+
+        AssertMenuItemIsActive(cut, Resources.Layout.NavMenuResourcesTab);
+    }
+
+    private IRenderedComponent<MobileNavMenu> RenderMobileNavMenu(string currentUrl)
+    {
+        FluentUISetupHelpers.AddCommonDashboardServices(this);
+        Services.AddSingleton<IDashboardClient>(new TestDashboardClient(isEnabled: true));
+        FluentUISetupHelpers.SetupFluentUIComponents(this);
+        FluentUISetupHelpers.SetupFluentMenu(this);
+        FluentUISetupHelpers.SetupFluentDivider(this);
+        FluentUISetupHelpers.SetupFluentAnchoredRegion(this);
+
+        var navigationManager = Services.GetRequiredService<NavigationManager>();
+        navigationManager.NavigateTo(currentUrl);
+
+        return RenderComponent<MobileNavMenu>(builder =>
+        {
+            builder.Add(p => p.IsNavMenuOpen, true);
+            builder.Add(p => p.IsAIEnabled, false);
+            builder.Add(p => p.CloseNavMenu, () => { });
+            builder.Add(p => p.LaunchHelpAsync, () => Task.CompletedTask);
+            builder.Add(p => p.LaunchAIAgentsAsync, () => Task.CompletedTask);
+            builder.Add(p => p.IsAgentHelpEnabled, false);
+            builder.Add(p => p.LaunchAIAssistantAsync, () => Task.CompletedTask);
+            builder.Add(p => p.LaunchNotificationsAsync, () => Task.CompletedTask);
+            builder.Add(p => p.LaunchSettingsAsync, () => Task.CompletedTask);
+        });
+    }
+
+    private static void AssertMenuItemIsActive(IRenderedComponent<MobileNavMenu> cut, string expectedText)
+    {
+        var currentItem = Assert.Single(cut.FindAll("""fluent-menu-item[aria-current="page"]"""));
+
+        Assert.Contains(expectedText, currentItem.TextContent);
+        Assert.True(currentItem.ClassList.Contains("mobile-nav-menu-item-active"));
+
+        var selectedIndicator = Assert.Single(currentItem.QuerySelectorAll(".mobile-nav-menu-selected-indicator"));
+        Assert.Equal("true", selectedIndicator.GetAttribute("aria-hidden"));
+        Assert.Equal("✓", selectedIndicator.TextContent.Trim());
+
+        var inactiveItems = cut.FindAll("fluent-menu-item")
+            .Where(item => item.GetAttribute("aria-current") != "page")
+            .ToList();
+        Assert.NotEmpty(inactiveItems);
+        Assert.All(inactiveItems, item =>
+        {
+            Assert.False(item.ClassList.Contains("mobile-nav-menu-item-active"));
+            Assert.Empty(item.QuerySelectorAll(".mobile-nav-menu-selected-indicator"));
+        });
+    }
+}


### PR DESCRIPTION
## Description

Fixes #17470

The mobile/hamburger navigation now exposes and displays the selected page without relying on color alone. The active mobile nav item gets `aria-current="page"`, a visible checkmark marker, and active text styling. Query-string routes such as filtered Structured logs and resource-specific Resources URLs are also recognized as the current page.

### User-facing usage

At narrow widths, opening the hamburger navigation now shows a non-color selected indicator for the current page:

```text
Structured ✓
```

Annotated Playwright evidence captured the before state with no `aria-current` and no marker. The after state has exactly one active item, `aria-current="page"`, and a checkmark indicator with `aria-hidden="true"`.

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
