### PR TITLE
[do not review] Expose assistant feedback button pressed state

### DIFF
--- a/src/Aspire.Dashboard/Components/Controls/AssistantChat.razor
+++ b/src/Aspire.Dashboard/Components/Controls/AssistantChat.razor
@@ -95,7 +95,8 @@
                                 <FluentButton Appearance="Appearance.Stealth"
                                               OnClick="@(() => LikeChatMessage(chatMessage))"
                                               Title="@Loc[nameof(AIAssistant.LikeMessageButtonText)]"
-                                              aria-label="@Loc[nameof(AIAssistant.LikeMessageButtonText)]">
+                                              aria-label="@Loc[nameof(AIAssistant.LikeMessageButtonText)]"
+                                              aria-pressed="@(chatMessage.IsLiked ? "true" : "false")">
                                     <FluentIcon Value="@(!chatMessage.IsLiked ? (Icon)new Icons.Regular.Size16.ThumbLike() : new Icons.Filled.Size16.ThumbLike())" Color="Color.Neutral" />
                                 </FluentButton>
                             </span>
@@ -103,7 +104,8 @@
                                 <FluentButton Appearance="Appearance.Stealth"
                                               OnClick="@(() => DislikeChatMessage(chatMessage))"
                                               Title="@Loc[nameof(AIAssistant.DislikeMessageButtonText)]"
-                                              aria-label="@Loc[nameof(AIAssistant.DislikeMessageButtonText)]">
+                                              aria-label="@Loc[nameof(AIAssistant.DislikeMessageButtonText)]"
+                                              aria-pressed="@(chatMessage.IsDisliked ? "true" : "false")">
                                     <FluentIcon Value="@(!chatMessage.IsDisliked ? (Icon)new Icons.Regular.Size16.ThumbDislike() : new Icons.Filled.Size16.ThumbDislike())" Color="Color.Neutral" />
                                 </FluentButton>
                             </span>

--- a/tests/Aspire.Dashboard.Components.Tests/Controls/AssistantChatTests.cs
+++ b/tests/Aspire.Dashboard.Components.Tests/Controls/AssistantChatTests.cs
@@ -1,0 +1,153 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Reflection;
+using AngleSharp.Dom;
+using Aspire.Dashboard.Components.Pages;
+using Aspire.Dashboard.Components.Tests.Shared;
+using Aspire.Dashboard.Configuration;
+using Aspire.Dashboard.Model.Assistant;
+using Aspire.Dashboard.Model.Assistant.Prompts;
+using Aspire.Dashboard.Model.BrowserStorage;
+using Aspire.Dashboard.Otlp.Storage;
+using Aspire.Dashboard.Resources;
+using Aspire.Dashboard.Telemetry;
+using Aspire.Dashboard.Tests;
+using Aspire.Dashboard.Tests.Shared;
+using Bunit;
+using Microsoft.AspNetCore.Components;
+using Microsoft.AspNetCore.Components.Web;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Localization;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using Xunit;
+
+namespace Aspire.Dashboard.Components.Tests.Controls;
+
+public class AssistantChatTests : DashboardTestContext
+{
+    [Fact]
+    public async Task FeedbackButtonsExposePressedState()
+    {
+        var chatMessage = new ChatViewModel(isUserMessage: false)
+        {
+            IsComplete = true,
+            PromptText = "Answer"
+        };
+        chatMessage.SetText("Answer");
+
+        var chatState = new AssistantChatState();
+        chatState.VisibleChatMessages.Add(chatMessage);
+
+        var chatViewModel = CreateChatViewModel(chatState);
+
+        var cut = RenderComponent<AssistantChat>(builder =>
+        {
+            builder.Add(p => p.ChatViewModel, chatViewModel);
+            builder.Add(p => p.Class, "chat");
+            builder.Add(p => p.ModelInitialized, EventCallback.Empty);
+        });
+
+        Assert.Equal("false", FindButton(cut, nameof(AIAssistant.LikeMessageButtonText)).GetAttribute("aria-pressed"));
+        Assert.Equal("false", FindButton(cut, nameof(AIAssistant.DislikeMessageButtonText)).GetAttribute("aria-pressed"));
+
+        await FindButton(cut, nameof(AIAssistant.LikeMessageButtonText)).ClickAsync(new MouseEventArgs());
+
+        Assert.Equal("true", FindButton(cut, nameof(AIAssistant.LikeMessageButtonText)).GetAttribute("aria-pressed"));
+        Assert.Equal("false", FindButton(cut, nameof(AIAssistant.DislikeMessageButtonText)).GetAttribute("aria-pressed"));
+
+        await FindButton(cut, nameof(AIAssistant.LikeMessageButtonText)).ClickAsync(new MouseEventArgs());
+
+        Assert.Equal("false", FindButton(cut, nameof(AIAssistant.LikeMessageButtonText)).GetAttribute("aria-pressed"));
+        Assert.Equal("false", FindButton(cut, nameof(AIAssistant.DislikeMessageButtonText)).GetAttribute("aria-pressed"));
+
+        await FindButton(cut, nameof(AIAssistant.DislikeMessageButtonText)).ClickAsync(new MouseEventArgs());
+
+        Assert.Equal("false", FindButton(cut, nameof(AIAssistant.LikeMessageButtonText)).GetAttribute("aria-pressed"));
+        Assert.Equal("true", FindButton(cut, nameof(AIAssistant.DislikeMessageButtonText)).GetAttribute("aria-pressed"));
+    }
+
+    private AssistantChatViewModel CreateChatViewModel(AssistantChatState chatState)
+    {
+        var aiContextProvider = new TestAIContextProvider { Enabled = true };
+        var dashboardOptions = new DashboardOptions();
+        var optionsMonitor = new TestOptionsMonitor<DashboardOptions>(dashboardOptions);
+        var assistantLocalizer = new TestStringLocalizer<AIAssistant>();
+        var controlsLocalizer = new TestStringLocalizer<ControlsStrings>();
+
+        FluentUISetupHelpers.AddCommonDashboardServices(this);
+
+        Services.AddLogging();
+        Services.AddSingleton<IConfiguration>(new ConfigurationManager());
+        Services.AddSingleton<IDashboardClient>(new TestDashboardClient());
+        Services.AddSingleton<IAIContextProvider>(aiContextProvider);
+        Services.AddSingleton<IStringLocalizer<AIAssistant>>(assistantLocalizer);
+        Services.AddSingleton<IStringLocalizer<ControlsStrings>>(controlsLocalizer);
+
+        FluentUISetupHelpers.SetupFluentUIComponents(this);
+        FluentUISetupHelpers.SetupFluentButton(this);
+
+        var assistantChatModule = JSInterop.SetupModule("./Components/Controls/AssistantChat.razor.js");
+        assistantChatModule.SetupVoid("initializeAssistantChat", _ => true);
+
+        var dataContext = new AssistantChatDataContext(
+            Services.GetRequiredService<TelemetryRepository>(),
+            Services.GetRequiredService<IDashboardClient>(),
+            [],
+            assistantLocalizer,
+            optionsMonitor);
+
+        var telemetryService = new DashboardTelemetryService(
+            NullLogger<DashboardTelemetryService>.Instance,
+            Services.GetRequiredService<IDashboardTelemetrySender>());
+
+        var chatViewModel = new AssistantChatViewModel(
+            Services.GetRequiredService<TelemetryRepository>(),
+            Services.GetRequiredService<IConfiguration>(),
+            Services.GetRequiredService<ILocalStorage>(),
+            NullLoggerFactory.Instance,
+            aiContextProvider,
+            new ChatClientFactory(Services.GetRequiredService<IConfiguration>(), NullLoggerFactory.Instance, optionsMonitor),
+            dataContext,
+            Services,
+            assistantLocalizer,
+            controlsLocalizer,
+            telemetryService,
+            new ComponentTelemetryContextProvider(telemetryService),
+            new IceBreakersBuilder(new TestStringLocalizer<AIPrompts>()),
+            optionsMonitor)
+        {
+            DisplayState = AssistantChatDisplayState.Chat
+        };
+
+        // AssistantChatViewModel doesn't expose a way to seed completed assistant responses without
+        // initializing GHCP clients. Keep this test focused on the rendered component state.
+        typeof(AssistantChatViewModel)
+            .GetField("_chatState", BindingFlags.Instance | BindingFlags.NonPublic)!
+            .SetValue(chatViewModel, chatState);
+
+        return chatViewModel;
+    }
+
+    private static IElement FindButton(IRenderedComponent<AssistantChat> cut, string resourceName)
+    {
+        return cut.Find($"fluent-button[aria-label='Localized:{resourceName}']");
+    }
+
+    private sealed class TestOptionsMonitor<T>(T currentValue) : IOptionsMonitor<T>
+    {
+        public T CurrentValue { get; } = currentValue;
+
+        public T Get(string? name)
+        {
+            return CurrentValue;
+        }
+
+        public IDisposable? OnChange(Action<T, string?> listener)
+        {
+            return null;
+        }
+    }
+}

--- a/tests/Shared/TestAIContextProvider.cs
+++ b/tests/Shared/TestAIContextProvider.cs
@@ -12,7 +12,7 @@ public class TestAIContextProvider : IAIContextProvider
 {
     public AssistantChatViewModel? AssistantChatViewModel { get; set; }
     public bool ShowAssistantSidebarDialog { get; set; }
-    public bool Enabled { get; }
+    public bool Enabled { get; init; }
     public AssistantChatState? ChatState { get; set; }
     public IceBreakersBuilder IceBreakersBuilder { get; } = new IceBreakersBuilder(new TestStringLocalizer<AIPrompts>());
 


### PR DESCRIPTION
## Description

Fixes #10299

The assistant feedback buttons now expose their pressed state to assistive technology. Previously the helpful/unhelpful state was conveyed only by swapping between regular and filled thumb icons, so screen readers could announce the button name but not whether it was selected.

### User-facing usage

The helpful and unhelpful buttons now expose `aria-pressed`:

```text
Helpful:   aria-pressed="false" -> "true" -> "false"
Unhelpful: aria-pressed="false" -> "true"
```

The existing labels and visual icon behavior are preserved.

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
