### PR TITLE
Remove duplicated profiles block from empty C# AppHost aspire.config.json

### DIFF
--- a/src/Aspire.Cli/Templating/Templates/empty-apphost/aspire.config.json
+++ b/src/Aspire.Cli/Templating/Templates/empty-apphost/aspire.config.json
@@ -1,26 +1,5 @@
 {
   "appHost": {
     "path": "apphost.cs"
-  },
-  "profiles": {
-    "https": {
-      "applicationUrl": "https://{{hostName}}:{{httpsPort}};http://{{hostName}}:{{httpPort}}",
-      "environmentVariables": {
-        "ASPNETCORE_ENVIRONMENT": "Development",
-        "DOTNET_ENVIRONMENT": "Development",
-        "ASPIRE_DASHBOARD_OTLP_ENDPOINT_URL": "https://{{hostName}}:{{otlpHttpsPort}}",
-        "ASPIRE_RESOURCE_SERVICE_ENDPOINT_URL": "https://{{hostName}}:{{resourceHttpsPort}}"
-      }
-    },
-    "http": {
-      "applicationUrl": "http://{{hostName}}:{{httpPort}}",
-      "environmentVariables": {
-        "ASPNETCORE_ENVIRONMENT": "Development",
-        "DOTNET_ENVIRONMENT": "Development",
-        "ASPIRE_DASHBOARD_OTLP_ENDPOINT_URL": "http://{{hostName}}:{{otlpHttpPort}}",
-        "ASPIRE_RESOURCE_SERVICE_ENDPOINT_URL": "http://{{hostName}}:{{resourceHttpPort}}",
-        "ASPIRE_ALLOW_UNSECURED_TRANSPORT": "true"
-      }
-    }
   }
 }

--- a/tests/Aspire.Cli.Tests/Commands/NewCommandTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/NewCommandTests.cs
@@ -1411,7 +1411,7 @@ public class NewCommandTests(ITestOutputHelper outputHelper)
     }
 
     [Fact]
-    public async Task NewCommandWithCSharpEmptyTemplateAndPlainLocalhostEmitsAppHostRunJsonMatchingAspireConfigJson()
+    public async Task NewCommandWithCSharpEmptyTemplateEmitsAppHostRunJsonAndAspireConfigJsonWithoutDuplicateProfiles()
     {
         using var workspace = TemporaryWorkspace.Create(outputHelper);
 
@@ -1434,10 +1434,14 @@ public class NewCommandTests(ITestOutputHelper outputHelper)
         var aspireConfig = await File.ReadAllTextAsync(aspireConfigPath);
         var appHostRunJson = await File.ReadAllTextAsync(appHostRunJsonPath);
 
+        // Launch profile shape (applicationUrl / commandName / environmentVariables) must live in
+        // apphost.run.json so that `dotnet run apphost.cs` and the C# Dev Kit can pick it up.
         Assert.Contains("://localhost:", appHostRunJson);
         Assert.Contains("\"commandName\": \"Project\"", appHostRunJson);
 
-        AssertHttpsApplicationUrlMatches(aspireConfig, appHostRunJson);
+        // aspire.config.json must NOT carry a duplicated `profiles` block — that content belongs to
+        // apphost.run.json only. See https://github.com/microsoft/aspire/issues/17660.
+        AssertAspireConfigHasNoProfiles(aspireConfig);
     }
 
     [Fact]
@@ -1467,26 +1471,23 @@ public class NewCommandTests(ITestOutputHelper outputHelper)
         Assert.Contains("testapp.dev.localhost", appHostRunJson);
         Assert.DoesNotContain("://localhost", appHostRunJson);
 
-        AssertHttpsApplicationUrlMatches(aspireConfig, appHostRunJson);
+        // aspire.config.json must NOT carry a duplicated `profiles` block — that content belongs to
+        // apphost.run.json only. See https://github.com/microsoft/aspire/issues/17660.
+        AssertAspireConfigHasNoProfiles(aspireConfig);
     }
 
-    private static void AssertHttpsApplicationUrlMatches(string aspireConfigJson, string appHostRunJson)
+    private static void AssertAspireConfigHasNoProfiles(string aspireConfigJson)
     {
         using var aspireDoc = System.Text.Json.JsonDocument.Parse(aspireConfigJson);
-        using var runDoc = System.Text.Json.JsonDocument.Parse(appHostRunJson);
+        Assert.False(
+            aspireDoc.RootElement.TryGetProperty("profiles", out _),
+            "aspire.config.json must not contain a 'profiles' block for the empty C# template; profiles live in apphost.run.json.");
 
-        var aspireHttpsUrl = aspireDoc.RootElement
-            .GetProperty("profiles")
-            .GetProperty("https")
-            .GetProperty("applicationUrl")
-            .GetString();
-        var runHttpsUrl = runDoc.RootElement
-            .GetProperty("profiles")
-            .GetProperty("https")
-            .GetProperty("applicationUrl")
-            .GetString();
-
-        Assert.Equal(aspireHttpsUrl, runHttpsUrl);
+        // Pin the expected minimal shape: aspire.config.json for the C# Empty template should only
+        // identify the AppHost file. See https://github.com/microsoft/aspire/issues/17660.
+        Assert.True(aspireDoc.RootElement.TryGetProperty("appHost", out var appHost), "aspire.config.json is missing the required 'appHost' object.");
+        Assert.True(appHost.TryGetProperty("path", out var path), "aspire.config.json#appHost is missing the 'path' property.");
+        Assert.Equal("apphost.cs", path.GetString());
     }
 
     [Fact]
@@ -1532,11 +1533,20 @@ public class NewCommandTests(ITestOutputHelper outputHelper)
         Assert.Equal(CliExitCodes.Success, exitCode);
         Assert.True(localhostPrompted);
 
-        var runProfilePath = Path.Combine(workspace.WorkspaceRoot.FullName, "output", "aspire.config.json");
-        Assert.True(File.Exists(runProfilePath));
-        var runProfile = await File.ReadAllTextAsync(runProfilePath);
-        Assert.Contains("testapp.dev.localhost", runProfile);
-        Assert.DoesNotContain("://localhost", runProfile);
+        var outputRoot = Path.Combine(workspace.WorkspaceRoot.FullName, "output");
+
+        var aspireConfigPath = Path.Combine(outputRoot, "aspire.config.json");
+        Assert.True(File.Exists(aspireConfigPath));
+        var aspireConfig = await File.ReadAllTextAsync(aspireConfigPath);
+        // aspire.config.json must NOT contain the localhost-TLD URLs — those belong in
+        // apphost.run.json. See https://github.com/microsoft/aspire/issues/17660.
+        Assert.DoesNotContain("testapp.dev.localhost", aspireConfig);
+
+        var appHostRunJsonPath = Path.Combine(outputRoot, "apphost.run.json");
+        Assert.True(File.Exists(appHostRunJsonPath));
+        var appHostRunJson = await File.ReadAllTextAsync(appHostRunJsonPath);
+        Assert.Contains("testapp.dev.localhost", appHostRunJson);
+        Assert.DoesNotContain("://localhost", appHostRunJson);
     }
 
     [Fact]


### PR DESCRIPTION
# Description

Fixes #17660.

The embedded CLI template `src/Aspire.Cli/Templating/Templates/empty-apphost/aspire.config.json` shipped a `profiles` block that duplicated the content already in `apphost.run.json`. The canonical template at `src/Aspire.ProjectTemplates/templates/aspire-apphost-singlefile/aspire.config.json` intentionally has no `profiles` (per @DamianEdwards in the issue): `aspire run` / `dotnet run apphost.cs` / C# Dev Kit honor `apphost.run.json` when present, so `aspire.config.json` for the C# Empty template should only carry:

```json
{ "appHost": { "path": "apphost.cs" } }
```

This was a regression introduced in the 13.4 cycle. In 13.3.5 only `aspire.config.json` was emitted; once `apphost.run.json` was added the embedded template was not trimmed to remove the now-duplicated profiles.

## Changes

- `src/Aspire.Cli/Templating/Templates/empty-apphost/aspire.config.json` — removed the `profiles` block.
- `tests/Aspire.Cli.Tests/Commands/NewCommandTests.cs` — three tests previously asserted the duplicated content:
  - The two `…EmitsAppHostRunJson…` tests now assert `aspire.config.json` has **no** `profiles` block and that it pins `appHost.path = "apphost.cs"`, while `apphost.run.json` carries the launch URLs (plain `localhost` and `dev.localhost` variants).
  - The `…PromptsForLocalhostTld…` test now asserts the dev-localhost URL lives in `apphost.run.json` and is absent from `aspire.config.json`.
  - Removed the obsolete `AssertHttpsApplicationUrlMatches` helper.

## Safety

- `DotNetAppHostProject` reads `apphost.run.json` first and only falls back to `aspire.config.json#profiles` when `apphost.run.json` is missing, so removing profiles from a template that ships `apphost.run.json` is safe at runtime.
- `ApplyLocalhostTldToScaffoldedRunProfileAsync` only runs for non-C# scaffolded templates (TypeScript / Python); the C# path applies tokens via `ApplyAllTokens` to all files including `apphost.run.json`, so the localhost-TLD substitution still lands in the right file.
- E2E coverage already exists: `tests/Aspire.Cli.EndToEnd.Tests/EmptyAppHostTemplateTests.CreateAndRunEmptyAppHostProject` runs `aspire new` (C# Empty) → `aspire start --format json` → curls the dashboard URL for HTTP 200 → `aspire stop`. If the new layout broke startup it would catch it.
- Existing projects on disk are not modified; this only affects newly-scaffolded projects.

## Tested

- All 77 `NewCommandTests` pass locally.
- All 50 `NewCommandTemplateConfigPersistenceTests` + `NewCommandChannelResolutionTests` pass locally.

## Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/aspire/pull/new/mitchdenny/fix-duplicate-config-empty-template)