### PR TITLE
Skip MicroBuild auth for VS Code release job

### DIFF
--- a/eng/pipelines/release-publish-nuget.yml
+++ b/eng/pipelines/release-publish-nuget.yml
@@ -2061,6 +2061,12 @@ extends:
             templateContext:
               type: releaseJob
               isProduction: true
+              # No ESRP publish in this job (vsce publishes directly to the VS Code Marketplace
+              # using a PAT). Skip the auto-injected MicroBuildAuthorizePublishPlugin@0 so it
+              # does not 401 against the devdiv MicroBuildToolset feed.
+              mb:
+                publish:
+                  enabled: false
               inputs:
                 - input: pipelineArtifact
                   artifactName: aspire-vscode-extension

--- a/eng/pipelines/release-publish-nuget.yml
+++ b/eng/pipelines/release-publish-nuget.yml
@@ -2061,8 +2061,8 @@ extends:
             templateContext:
               type: releaseJob
               isProduction: true
-              # No ESRP publish in this job (vsce publishes directly to the VS Code Marketplace
-              # using a PAT). Skip the auto-injected MicroBuildAuthorizePublishPlugin@0 so it
+              # No ESRP publish runs in this job; vsce publishes directly to the VS Code Marketplace
+              # using a PAT. Skip the auto-injected MicroBuildAuthorizePublishPlugin@0 so it
               # does not 401 against the devdiv MicroBuildToolset feed.
               mb:
                 publish:


### PR DESCRIPTION
## Description

The release pipeline was failing before the VS Code Marketplace publish steps because the MicroBuild template injected `MicroBuildAuthorizePublishPlugin@0` into `VSCodeExtensionJob`. That job publishes with `vsce` and `VscePublishToken`, not ESRP/MicroBuild, so the injected auth task was trying to authenticate to the DevDiv MicroBuildToolset feed and failing with a 401.

This matches the existing opt-out pattern used by the other non-ESRP release jobs: set `templateContext.mb.publish.enabled: false` for `VSCodeExtensionJob` so only the real ESRP/MicroBuild publish job keeps the authorization check.

Validation:
- Parsed `eng/pipelines/release-publish-nuget.yml` as YAML.
- Confirmed the failed AzDO log was `Publish Authorization Check` in `Publish VS Code Extension to Marketplace`, failing on the DevDiv MicroBuildToolset feed with 401.
- Ran two independent code-review agents on the scoped diff.

Fixes # (issue)

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [x] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
