### PR TITLE
[do not review] Add Manage Data selection accessible names

### DIFF
--- a/src/Aspire.Dashboard/Components/Dialogs/ManageDataDialog.razor
+++ b/src/Aspire.Dashboard/Components/Dialogs/ManageDataDialog.razor
@@ -22,6 +22,9 @@
         <ChildContent>
             <TemplateColumn Title="@ControlsStringsLoc[nameof(ControlsStrings.NameColumnHeader)]">
                 <HeaderCellItemTemplate>
+                    @{
+                        var headerSelectionLabel = GetHeaderSelectionLabel();
+                    }
                     <div style="display: flex; justify-content: flex-start;">
                         <div style="width: calc(100% - 10px);">
                             <div class="name-title-text">
@@ -29,6 +32,8 @@
                                               IconEnd="@GetHeaderCheckboxIcon()"
                                               OnClick="OnSelectAllClicked"
                                               Disabled="@(_resourceDataRows.Count == 0)"
+                                              Title="@headerSelectionLabel"
+                                              aria-label="@headerSelectionLabel"
                                               style="margin-right: 8px;" />
                                 @ControlsStringsLoc[nameof(ControlsStrings.NameColumnHeader)]
                             </div>
@@ -43,6 +48,9 @@
                     <span class="resources-name-container" style="margin-left: @(indent)px;">
                         @if (context.IsResourceRow && context.ResourceRow is not null)
                         {
+                            var resourceDisplayName = GetResourceDisplayName(context.ResourceRow);
+                            var resourceSelectionLabel = GetResourceSelectionLabel(context.ResourceRow, resourceDisplayName);
+
                             <span @onclick:stopPropagation="true" class="main-grid-expand-container @(IsResourceExpanded(context.ResourceRow.Name) ? "main-grid-expanded" : "main-grid-collapsed")">
                                 @if (context.ResourceRow.TelemetryData.Count > 0)
                                 {
@@ -58,6 +66,8 @@
                                 <FluentButton Appearance="Appearance.Lightweight"
                                               IconEnd="@GetResourceCheckboxIcon(context.ResourceRow)"
                                               OnClick="@(() => OnSelectRowClicked(context.ResourceRow))"
+                                              Title="@resourceSelectionLabel"
+                                              aria-label="@resourceSelectionLabel"
                                               style="margin-right: 8px;" />
                             </span>
                             @if (context.ResourceRow.Resource is not null)
@@ -76,19 +86,25 @@
                                                     CustomColor="@ColorGenerator.Instance.GetColorVariableByKey(context.ResourceRow.Name)"
                                                     Value="@(new Icons.Filled.Size16.Book())" />
                                     }
-                                    <span class="resource-name-text">@GetOtlpResourceName(context.ResourceRow.OtlpResource)</span>
+                                    <span class="resource-name-text">@resourceDisplayName</span>
                                 </span>
                             }
                         }
                         else if (context.IsNestedRow && context.NestedRow is not null && context.ParentResourceName is not null)
                         {
+                            var dataTypeDisplayName = GetDataTypeDisplayName(context.NestedRow.DataType);
+                            var parentResourceDisplayName = GetResourceDisplayName(context.ParentResourceName);
+                            var dataTypeSelectionLabel = GetDataRowSelectionLabel(context.ParentResourceName, context.NestedRow.DataType, dataTypeDisplayName, parentResourceDisplayName);
+
                             <span @onclick:stopPropagation="true">
                                 <FluentButton Appearance="Appearance.Lightweight"
                                               IconEnd="@(IsDataRowSelected(context.ParentResourceName, context.NestedRow.DataType) ? _iconSelectedMultiple : _iconUnselectedMultiple)"
                                               OnClick="@(() => OnSelectDataRowClicked(context.ParentResourceName, context.NestedRow.DataType))"
+                                              Title="@dataTypeSelectionLabel"
+                                              aria-label="@dataTypeSelectionLabel"
                                               style="margin-right: 8px;" />
                             </span>
-                            <span class="cellText">@GetDataTypeDisplayName(context.NestedRow.DataType)</span>
+                            <span class="cellText">@dataTypeDisplayName</span>
                         }
                     </span>
                 </ChildContent>

--- a/src/Aspire.Dashboard/Components/Dialogs/ManageDataDialog.razor.cs
+++ b/src/Aspire.Dashboard/Components/Dialogs/ManageDataDialog.razor.cs
@@ -343,6 +343,37 @@ public partial class ManageDataDialog : IDialogContentComponent, IAsyncDisposabl
 
     private string GetOtlpResourceName(OtlpResource resource) => OtlpHelpers.GetResourceName(resource, TelemetryRepository.GetResources());
 
+    private string GetHeaderSelectionLabel() => AreAllSelected()
+        ? Loc[nameof(Resources.Dialogs.ManageDataDeselectAllButtonLabel)]
+        : Loc[nameof(Resources.Dialogs.ManageDataSelectAllButtonLabel)];
+
+    private string GetResourceDisplayName(ResourceDataRow row)
+    {
+        if (row.Resource is not null)
+        {
+            return GetResourceName(row.Resource);
+        }
+
+        if (row.OtlpResource is not null)
+        {
+            return GetOtlpResourceName(row.OtlpResource);
+        }
+
+        return row.Name;
+    }
+
+    private string GetResourceDisplayName(string resourceName) => _resourceDataRows.TryGetValue(resourceName, out var row) ? GetResourceDisplayName(row) : resourceName;
+
+    private string GetResourceSelectionLabel(ResourceDataRow row, string resourceDisplayName) => GetSelectionLabel(AreAllDataRowsSelected(row), resourceDisplayName);
+
+    private string GetDataRowSelectionLabel(string resourceName, AspireDataType dataType, string dataTypeDisplayName, string parentResourceDisplayName) => IsDataRowSelected(resourceName, dataType)
+        ? Loc[nameof(Resources.Dialogs.ManageDataDeselectDataTypeForResourceButtonLabel), dataTypeDisplayName, parentResourceDisplayName]
+        : Loc[nameof(Resources.Dialogs.ManageDataSelectDataTypeForResourceButtonLabel), dataTypeDisplayName, parentResourceDisplayName];
+
+    private string GetSelectionLabel(bool selected, string displayName) => selected
+        ? Loc[nameof(Resources.Dialogs.ManageDataDeselectItemButtonLabel), displayName]
+        : Loc[nameof(Resources.Dialogs.ManageDataSelectItemButtonLabel), displayName];
+
     private string GetDataTypeDisplayName(AspireDataType dataType) => dataType switch
     {
         AspireDataType.ResourceDetails => Loc[nameof(Resources.Dialogs.ManageDataResource)],

--- a/src/Aspire.Dashboard/Resources/Dialogs.Designer.cs
+++ b/src/Aspire.Dashboard/Resources/Dialogs.Designer.cs
@@ -838,6 +838,33 @@ namespace Aspire.Dashboard.Resources {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Deselect all.
+        /// </summary>
+        public static string ManageDataDeselectAllButtonLabel {
+            get {
+                return ResourceManager.GetString("ManageDataDeselectAllButtonLabel", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Deselect {0}.
+        /// </summary>
+        public static string ManageDataDeselectItemButtonLabel {
+            get {
+                return ResourceManager.GetString("ManageDataDeselectItemButtonLabel", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Deselect {0} for {1}.
+        /// </summary>
+        public static string ManageDataDeselectDataTypeForResourceButtonLabel {
+            get {
+                return ResourceManager.GetString("ManageDataDeselectDataTypeForResourceButtonLabel", resourceCulture);
+            }
+        }
+
+        /// <summary>
         ///   Looks up a localized string similar to Manage logs and telemetry.
         /// </summary>
         public static string ManageDataDialogTitle {
@@ -927,6 +954,33 @@ namespace Aspire.Dashboard.Resources {
             }
         }
         
+        /// <summary>
+        ///   Looks up a localized string similar to Select all.
+        /// </summary>
+        public static string ManageDataSelectAllButtonLabel {
+            get {
+                return ResourceManager.GetString("ManageDataSelectAllButtonLabel", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Select {0}.
+        /// </summary>
+        public static string ManageDataSelectItemButtonLabel {
+            get {
+                return ResourceManager.GetString("ManageDataSelectItemButtonLabel", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Select {0} for {1}.
+        /// </summary>
+        public static string ManageDataSelectDataTypeForResourceButtonLabel {
+            get {
+                return ResourceManager.GetString("ManageDataSelectDataTypeForResourceButtonLabel", resourceCulture);
+            }
+        }
+
         /// <summary>
         ///   Looks up a localized string similar to Structured logs.
         /// </summary>

--- a/src/Aspire.Dashboard/Resources/Dialogs.resx
+++ b/src/Aspire.Dashboard/Resources/Dialogs.resx
@@ -456,6 +456,17 @@
   <data name="ManageDataConsoleLogs" xml:space="preserve">
     <value>Console logs</value>
   </data>
+  <data name="ManageDataDeselectAllButtonLabel" xml:space="preserve">
+    <value>Deselect all</value>
+  </data>
+  <data name="ManageDataDeselectItemButtonLabel" xml:space="preserve">
+    <value>Deselect {0}</value>
+    <comment>{0} is the resource or data type display name.</comment>
+  </data>
+  <data name="ManageDataDeselectDataTypeForResourceButtonLabel" xml:space="preserve">
+    <value>Deselect {0} for {1}</value>
+    <comment>{0} is the data type display name. {1} is the parent resource display name.</comment>
+  </data>
   <data name="ManageDataExportButtonText" xml:space="preserve">
     <value>Export selected</value>
   </data>
@@ -482,6 +493,17 @@
   </data>
   <data name="ManageDataResource" xml:space="preserve">
     <value>Resource</value>
+  </data>
+  <data name="ManageDataSelectAllButtonLabel" xml:space="preserve">
+    <value>Select all</value>
+  </data>
+  <data name="ManageDataSelectItemButtonLabel" xml:space="preserve">
+    <value>Select {0}</value>
+    <comment>{0} is the resource or data type display name.</comment>
+  </data>
+  <data name="ManageDataSelectDataTypeForResourceButtonLabel" xml:space="preserve">
+    <value>Select {0} for {1}</value>
+    <comment>{0} is the data type display name. {1} is the parent resource display name.</comment>
   </data>
   <data name="SettingsDialogTimeFormat" xml:space="preserve">
     <value>Time format</value>

--- a/src/Aspire.Dashboard/Resources/xlf/Dialogs.cs.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Dialogs.cs.xlf
@@ -484,6 +484,21 @@ For more information about using AI agents with the dashboard, including setting
         <target state="translated">OK</target>
         <note />
       </trans-unit>
+      <trans-unit id="ManageDataDeselectAllButtonLabel">
+        <source>Deselect all</source>
+        <target state="new">Deselect all</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ManageDataDeselectDataTypeForResourceButtonLabel">
+        <source>Deselect {0} for {1}</source>
+        <target state="new">Deselect {0} for {1}</target>
+        <note>{0} is the data type display name. {1} is the parent resource display name.</note>
+      </trans-unit>
+      <trans-unit id="ManageDataDeselectItemButtonLabel">
+        <source>Deselect {0}</source>
+        <target state="new">Deselect {0}</target>
+        <note>{0} is the resource or data type display name.</note>
+      </trans-unit>
       <trans-unit id="ManageDataDialogTitle">
         <source>Manage logs and telemetry</source>
         <target state="translated">Správa protokolů a telemetrie</target>
@@ -528,6 +543,21 @@ For more information about using AI agents with the dashboard, including setting
         <source>Resource</source>
         <target state="translated">Prostředek</target>
         <note />
+      </trans-unit>
+      <trans-unit id="ManageDataSelectAllButtonLabel">
+        <source>Select all</source>
+        <target state="new">Select all</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ManageDataSelectDataTypeForResourceButtonLabel">
+        <source>Select {0} for {1}</source>
+        <target state="new">Select {0} for {1}</target>
+        <note>{0} is the data type display name. {1} is the parent resource display name.</note>
+      </trans-unit>
+      <trans-unit id="ManageDataSelectItemButtonLabel">
+        <source>Select {0}</source>
+        <target state="new">Select {0}</target>
+        <note>{0} is the resource or data type display name.</note>
       </trans-unit>
       <trans-unit id="ManageDataStructuredLogs">
         <source>Structured logs</source>

--- a/src/Aspire.Dashboard/Resources/xlf/Dialogs.de.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Dialogs.de.xlf
@@ -484,6 +484,21 @@ For more information about using AI agents with the dashboard, including setting
         <target state="translated">OK</target>
         <note />
       </trans-unit>
+      <trans-unit id="ManageDataDeselectAllButtonLabel">
+        <source>Deselect all</source>
+        <target state="new">Deselect all</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ManageDataDeselectDataTypeForResourceButtonLabel">
+        <source>Deselect {0} for {1}</source>
+        <target state="new">Deselect {0} for {1}</target>
+        <note>{0} is the data type display name. {1} is the parent resource display name.</note>
+      </trans-unit>
+      <trans-unit id="ManageDataDeselectItemButtonLabel">
+        <source>Deselect {0}</source>
+        <target state="new">Deselect {0}</target>
+        <note>{0} is the resource or data type display name.</note>
+      </trans-unit>
       <trans-unit id="ManageDataDialogTitle">
         <source>Manage logs and telemetry</source>
         <target state="translated">Protokolle und Telemetrie verwalten</target>
@@ -528,6 +543,21 @@ For more information about using AI agents with the dashboard, including setting
         <source>Resource</source>
         <target state="translated">Ressource</target>
         <note />
+      </trans-unit>
+      <trans-unit id="ManageDataSelectAllButtonLabel">
+        <source>Select all</source>
+        <target state="new">Select all</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ManageDataSelectDataTypeForResourceButtonLabel">
+        <source>Select {0} for {1}</source>
+        <target state="new">Select {0} for {1}</target>
+        <note>{0} is the data type display name. {1} is the parent resource display name.</note>
+      </trans-unit>
+      <trans-unit id="ManageDataSelectItemButtonLabel">
+        <source>Select {0}</source>
+        <target state="new">Select {0}</target>
+        <note>{0} is the resource or data type display name.</note>
       </trans-unit>
       <trans-unit id="ManageDataStructuredLogs">
         <source>Structured logs</source>

--- a/src/Aspire.Dashboard/Resources/xlf/Dialogs.es.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Dialogs.es.xlf
@@ -484,6 +484,21 @@ For more information about using AI agents with the dashboard, including setting
         <target state="translated">Aceptar</target>
         <note />
       </trans-unit>
+      <trans-unit id="ManageDataDeselectAllButtonLabel">
+        <source>Deselect all</source>
+        <target state="new">Deselect all</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ManageDataDeselectDataTypeForResourceButtonLabel">
+        <source>Deselect {0} for {1}</source>
+        <target state="new">Deselect {0} for {1}</target>
+        <note>{0} is the data type display name. {1} is the parent resource display name.</note>
+      </trans-unit>
+      <trans-unit id="ManageDataDeselectItemButtonLabel">
+        <source>Deselect {0}</source>
+        <target state="new">Deselect {0}</target>
+        <note>{0} is the resource or data type display name.</note>
+      </trans-unit>
       <trans-unit id="ManageDataDialogTitle">
         <source>Manage logs and telemetry</source>
         <target state="translated">Administrar registros y telemetría</target>
@@ -528,6 +543,21 @@ For more information about using AI agents with the dashboard, including setting
         <source>Resource</source>
         <target state="translated">Recurso</target>
         <note />
+      </trans-unit>
+      <trans-unit id="ManageDataSelectAllButtonLabel">
+        <source>Select all</source>
+        <target state="new">Select all</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ManageDataSelectDataTypeForResourceButtonLabel">
+        <source>Select {0} for {1}</source>
+        <target state="new">Select {0} for {1}</target>
+        <note>{0} is the data type display name. {1} is the parent resource display name.</note>
+      </trans-unit>
+      <trans-unit id="ManageDataSelectItemButtonLabel">
+        <source>Select {0}</source>
+        <target state="new">Select {0}</target>
+        <note>{0} is the resource or data type display name.</note>
       </trans-unit>
       <trans-unit id="ManageDataStructuredLogs">
         <source>Structured logs</source>

--- a/src/Aspire.Dashboard/Resources/xlf/Dialogs.fr.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Dialogs.fr.xlf
@@ -484,6 +484,21 @@ For more information about using AI agents with the dashboard, including setting
         <target state="translated">OK</target>
         <note />
       </trans-unit>
+      <trans-unit id="ManageDataDeselectAllButtonLabel">
+        <source>Deselect all</source>
+        <target state="new">Deselect all</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ManageDataDeselectDataTypeForResourceButtonLabel">
+        <source>Deselect {0} for {1}</source>
+        <target state="new">Deselect {0} for {1}</target>
+        <note>{0} is the data type display name. {1} is the parent resource display name.</note>
+      </trans-unit>
+      <trans-unit id="ManageDataDeselectItemButtonLabel">
+        <source>Deselect {0}</source>
+        <target state="new">Deselect {0}</target>
+        <note>{0} is the resource or data type display name.</note>
+      </trans-unit>
       <trans-unit id="ManageDataDialogTitle">
         <source>Manage logs and telemetry</source>
         <target state="translated">Gérer les journaux et la télémétrie</target>
@@ -528,6 +543,21 @@ For more information about using AI agents with the dashboard, including setting
         <source>Resource</source>
         <target state="translated">Ressource</target>
         <note />
+      </trans-unit>
+      <trans-unit id="ManageDataSelectAllButtonLabel">
+        <source>Select all</source>
+        <target state="new">Select all</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ManageDataSelectDataTypeForResourceButtonLabel">
+        <source>Select {0} for {1}</source>
+        <target state="new">Select {0} for {1}</target>
+        <note>{0} is the data type display name. {1} is the parent resource display name.</note>
+      </trans-unit>
+      <trans-unit id="ManageDataSelectItemButtonLabel">
+        <source>Select {0}</source>
+        <target state="new">Select {0}</target>
+        <note>{0} is the resource or data type display name.</note>
       </trans-unit>
       <trans-unit id="ManageDataStructuredLogs">
         <source>Structured logs</source>

--- a/src/Aspire.Dashboard/Resources/xlf/Dialogs.it.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Dialogs.it.xlf
@@ -484,6 +484,21 @@ For more information about using AI agents with the dashboard, including setting
         <target state="translated">OK</target>
         <note />
       </trans-unit>
+      <trans-unit id="ManageDataDeselectAllButtonLabel">
+        <source>Deselect all</source>
+        <target state="new">Deselect all</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ManageDataDeselectDataTypeForResourceButtonLabel">
+        <source>Deselect {0} for {1}</source>
+        <target state="new">Deselect {0} for {1}</target>
+        <note>{0} is the data type display name. {1} is the parent resource display name.</note>
+      </trans-unit>
+      <trans-unit id="ManageDataDeselectItemButtonLabel">
+        <source>Deselect {0}</source>
+        <target state="new">Deselect {0}</target>
+        <note>{0} is the resource or data type display name.</note>
+      </trans-unit>
       <trans-unit id="ManageDataDialogTitle">
         <source>Manage logs and telemetry</source>
         <target state="translated">Gestire log e metriche</target>
@@ -528,6 +543,21 @@ For more information about using AI agents with the dashboard, including setting
         <source>Resource</source>
         <target state="translated">Risorsa</target>
         <note />
+      </trans-unit>
+      <trans-unit id="ManageDataSelectAllButtonLabel">
+        <source>Select all</source>
+        <target state="new">Select all</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ManageDataSelectDataTypeForResourceButtonLabel">
+        <source>Select {0} for {1}</source>
+        <target state="new">Select {0} for {1}</target>
+        <note>{0} is the data type display name. {1} is the parent resource display name.</note>
+      </trans-unit>
+      <trans-unit id="ManageDataSelectItemButtonLabel">
+        <source>Select {0}</source>
+        <target state="new">Select {0}</target>
+        <note>{0} is the resource or data type display name.</note>
       </trans-unit>
       <trans-unit id="ManageDataStructuredLogs">
         <source>Structured logs</source>

--- a/src/Aspire.Dashboard/Resources/xlf/Dialogs.ja.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Dialogs.ja.xlf
@@ -484,6 +484,21 @@ For more information about using AI agents with the dashboard, including setting
         <target state="translated">OK</target>
         <note />
       </trans-unit>
+      <trans-unit id="ManageDataDeselectAllButtonLabel">
+        <source>Deselect all</source>
+        <target state="new">Deselect all</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ManageDataDeselectDataTypeForResourceButtonLabel">
+        <source>Deselect {0} for {1}</source>
+        <target state="new">Deselect {0} for {1}</target>
+        <note>{0} is the data type display name. {1} is the parent resource display name.</note>
+      </trans-unit>
+      <trans-unit id="ManageDataDeselectItemButtonLabel">
+        <source>Deselect {0}</source>
+        <target state="new">Deselect {0}</target>
+        <note>{0} is the resource or data type display name.</note>
+      </trans-unit>
       <trans-unit id="ManageDataDialogTitle">
         <source>Manage logs and telemetry</source>
         <target state="translated">リソース ログとテレメトリ</target>
@@ -528,6 +543,21 @@ For more information about using AI agents with the dashboard, including setting
         <source>Resource</source>
         <target state="translated">リソース</target>
         <note />
+      </trans-unit>
+      <trans-unit id="ManageDataSelectAllButtonLabel">
+        <source>Select all</source>
+        <target state="new">Select all</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ManageDataSelectDataTypeForResourceButtonLabel">
+        <source>Select {0} for {1}</source>
+        <target state="new">Select {0} for {1}</target>
+        <note>{0} is the data type display name. {1} is the parent resource display name.</note>
+      </trans-unit>
+      <trans-unit id="ManageDataSelectItemButtonLabel">
+        <source>Select {0}</source>
+        <target state="new">Select {0}</target>
+        <note>{0} is the resource or data type display name.</note>
       </trans-unit>
       <trans-unit id="ManageDataStructuredLogs">
         <source>Structured logs</source>

--- a/src/Aspire.Dashboard/Resources/xlf/Dialogs.ko.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Dialogs.ko.xlf
@@ -484,6 +484,21 @@ For more information about using AI agents with the dashboard, including setting
         <target state="translated">확인</target>
         <note />
       </trans-unit>
+      <trans-unit id="ManageDataDeselectAllButtonLabel">
+        <source>Deselect all</source>
+        <target state="new">Deselect all</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ManageDataDeselectDataTypeForResourceButtonLabel">
+        <source>Deselect {0} for {1}</source>
+        <target state="new">Deselect {0} for {1}</target>
+        <note>{0} is the data type display name. {1} is the parent resource display name.</note>
+      </trans-unit>
+      <trans-unit id="ManageDataDeselectItemButtonLabel">
+        <source>Deselect {0}</source>
+        <target state="new">Deselect {0}</target>
+        <note>{0} is the resource or data type display name.</note>
+      </trans-unit>
       <trans-unit id="ManageDataDialogTitle">
         <source>Manage logs and telemetry</source>
         <target state="translated">로그 및 원격 분석 관리</target>
@@ -528,6 +543,21 @@ For more information about using AI agents with the dashboard, including setting
         <source>Resource</source>
         <target state="translated">리소스</target>
         <note />
+      </trans-unit>
+      <trans-unit id="ManageDataSelectAllButtonLabel">
+        <source>Select all</source>
+        <target state="new">Select all</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ManageDataSelectDataTypeForResourceButtonLabel">
+        <source>Select {0} for {1}</source>
+        <target state="new">Select {0} for {1}</target>
+        <note>{0} is the data type display name. {1} is the parent resource display name.</note>
+      </trans-unit>
+      <trans-unit id="ManageDataSelectItemButtonLabel">
+        <source>Select {0}</source>
+        <target state="new">Select {0}</target>
+        <note>{0} is the resource or data type display name.</note>
       </trans-unit>
       <trans-unit id="ManageDataStructuredLogs">
         <source>Structured logs</source>

--- a/src/Aspire.Dashboard/Resources/xlf/Dialogs.pl.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Dialogs.pl.xlf
@@ -484,6 +484,21 @@ For more information about using AI agents with the dashboard, including setting
         <target state="translated">OK</target>
         <note />
       </trans-unit>
+      <trans-unit id="ManageDataDeselectAllButtonLabel">
+        <source>Deselect all</source>
+        <target state="new">Deselect all</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ManageDataDeselectDataTypeForResourceButtonLabel">
+        <source>Deselect {0} for {1}</source>
+        <target state="new">Deselect {0} for {1}</target>
+        <note>{0} is the data type display name. {1} is the parent resource display name.</note>
+      </trans-unit>
+      <trans-unit id="ManageDataDeselectItemButtonLabel">
+        <source>Deselect {0}</source>
+        <target state="new">Deselect {0}</target>
+        <note>{0} is the resource or data type display name.</note>
+      </trans-unit>
       <trans-unit id="ManageDataDialogTitle">
         <source>Manage logs and telemetry</source>
         <target state="translated">Zarządzaj dziennikami i danymi telemetrycznymi</target>
@@ -528,6 +543,21 @@ For more information about using AI agents with the dashboard, including setting
         <source>Resource</source>
         <target state="translated">Zasób</target>
         <note />
+      </trans-unit>
+      <trans-unit id="ManageDataSelectAllButtonLabel">
+        <source>Select all</source>
+        <target state="new">Select all</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ManageDataSelectDataTypeForResourceButtonLabel">
+        <source>Select {0} for {1}</source>
+        <target state="new">Select {0} for {1}</target>
+        <note>{0} is the data type display name. {1} is the parent resource display name.</note>
+      </trans-unit>
+      <trans-unit id="ManageDataSelectItemButtonLabel">
+        <source>Select {0}</source>
+        <target state="new">Select {0}</target>
+        <note>{0} is the resource or data type display name.</note>
       </trans-unit>
       <trans-unit id="ManageDataStructuredLogs">
         <source>Structured logs</source>

--- a/src/Aspire.Dashboard/Resources/xlf/Dialogs.pt-BR.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Dialogs.pt-BR.xlf
@@ -484,6 +484,21 @@ For more information about using AI agents with the dashboard, including setting
         <target state="translated">OK</target>
         <note />
       </trans-unit>
+      <trans-unit id="ManageDataDeselectAllButtonLabel">
+        <source>Deselect all</source>
+        <target state="new">Deselect all</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ManageDataDeselectDataTypeForResourceButtonLabel">
+        <source>Deselect {0} for {1}</source>
+        <target state="new">Deselect {0} for {1}</target>
+        <note>{0} is the data type display name. {1} is the parent resource display name.</note>
+      </trans-unit>
+      <trans-unit id="ManageDataDeselectItemButtonLabel">
+        <source>Deselect {0}</source>
+        <target state="new">Deselect {0}</target>
+        <note>{0} is the resource or data type display name.</note>
+      </trans-unit>
       <trans-unit id="ManageDataDialogTitle">
         <source>Manage logs and telemetry</source>
         <target state="translated">Gerenciar logs e telemetria</target>
@@ -528,6 +543,21 @@ For more information about using AI agents with the dashboard, including setting
         <source>Resource</source>
         <target state="translated">Recurso</target>
         <note />
+      </trans-unit>
+      <trans-unit id="ManageDataSelectAllButtonLabel">
+        <source>Select all</source>
+        <target state="new">Select all</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ManageDataSelectDataTypeForResourceButtonLabel">
+        <source>Select {0} for {1}</source>
+        <target state="new">Select {0} for {1}</target>
+        <note>{0} is the data type display name. {1} is the parent resource display name.</note>
+      </trans-unit>
+      <trans-unit id="ManageDataSelectItemButtonLabel">
+        <source>Select {0}</source>
+        <target state="new">Select {0}</target>
+        <note>{0} is the resource or data type display name.</note>
       </trans-unit>
       <trans-unit id="ManageDataStructuredLogs">
         <source>Structured logs</source>

--- a/src/Aspire.Dashboard/Resources/xlf/Dialogs.ru.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Dialogs.ru.xlf
@@ -484,6 +484,21 @@ For more information about using AI agents with the dashboard, including setting
         <target state="translated">ОК</target>
         <note />
       </trans-unit>
+      <trans-unit id="ManageDataDeselectAllButtonLabel">
+        <source>Deselect all</source>
+        <target state="new">Deselect all</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ManageDataDeselectDataTypeForResourceButtonLabel">
+        <source>Deselect {0} for {1}</source>
+        <target state="new">Deselect {0} for {1}</target>
+        <note>{0} is the data type display name. {1} is the parent resource display name.</note>
+      </trans-unit>
+      <trans-unit id="ManageDataDeselectItemButtonLabel">
+        <source>Deselect {0}</source>
+        <target state="new">Deselect {0}</target>
+        <note>{0} is the resource or data type display name.</note>
+      </trans-unit>
       <trans-unit id="ManageDataDialogTitle">
         <source>Manage logs and telemetry</source>
         <target state="translated">Управление журналами и телеметрией</target>
@@ -528,6 +543,21 @@ For more information about using AI agents with the dashboard, including setting
         <source>Resource</source>
         <target state="translated">Ресурс</target>
         <note />
+      </trans-unit>
+      <trans-unit id="ManageDataSelectAllButtonLabel">
+        <source>Select all</source>
+        <target state="new">Select all</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ManageDataSelectDataTypeForResourceButtonLabel">
+        <source>Select {0} for {1}</source>
+        <target state="new">Select {0} for {1}</target>
+        <note>{0} is the data type display name. {1} is the parent resource display name.</note>
+      </trans-unit>
+      <trans-unit id="ManageDataSelectItemButtonLabel">
+        <source>Select {0}</source>
+        <target state="new">Select {0}</target>
+        <note>{0} is the resource or data type display name.</note>
       </trans-unit>
       <trans-unit id="ManageDataStructuredLogs">
         <source>Structured logs</source>

--- a/src/Aspire.Dashboard/Resources/xlf/Dialogs.tr.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Dialogs.tr.xlf
@@ -484,6 +484,21 @@ For more information about using AI agents with the dashboard, including setting
         <target state="translated">Tamam</target>
         <note />
       </trans-unit>
+      <trans-unit id="ManageDataDeselectAllButtonLabel">
+        <source>Deselect all</source>
+        <target state="new">Deselect all</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ManageDataDeselectDataTypeForResourceButtonLabel">
+        <source>Deselect {0} for {1}</source>
+        <target state="new">Deselect {0} for {1}</target>
+        <note>{0} is the data type display name. {1} is the parent resource display name.</note>
+      </trans-unit>
+      <trans-unit id="ManageDataDeselectItemButtonLabel">
+        <source>Deselect {0}</source>
+        <target state="new">Deselect {0}</target>
+        <note>{0} is the resource or data type display name.</note>
+      </trans-unit>
       <trans-unit id="ManageDataDialogTitle">
         <source>Manage logs and telemetry</source>
         <target state="translated">Günlükleri ve telemetriyi yönet</target>
@@ -528,6 +543,21 @@ For more information about using AI agents with the dashboard, including setting
         <source>Resource</source>
         <target state="translated">Kaynak</target>
         <note />
+      </trans-unit>
+      <trans-unit id="ManageDataSelectAllButtonLabel">
+        <source>Select all</source>
+        <target state="new">Select all</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ManageDataSelectDataTypeForResourceButtonLabel">
+        <source>Select {0} for {1}</source>
+        <target state="new">Select {0} for {1}</target>
+        <note>{0} is the data type display name. {1} is the parent resource display name.</note>
+      </trans-unit>
+      <trans-unit id="ManageDataSelectItemButtonLabel">
+        <source>Select {0}</source>
+        <target state="new">Select {0}</target>
+        <note>{0} is the resource or data type display name.</note>
       </trans-unit>
       <trans-unit id="ManageDataStructuredLogs">
         <source>Structured logs</source>

--- a/src/Aspire.Dashboard/Resources/xlf/Dialogs.zh-Hans.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Dialogs.zh-Hans.xlf
@@ -484,6 +484,21 @@ For more information about using AI agents with the dashboard, including setting
         <target state="translated">确定</target>
         <note />
       </trans-unit>
+      <trans-unit id="ManageDataDeselectAllButtonLabel">
+        <source>Deselect all</source>
+        <target state="new">Deselect all</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ManageDataDeselectDataTypeForResourceButtonLabel">
+        <source>Deselect {0} for {1}</source>
+        <target state="new">Deselect {0} for {1}</target>
+        <note>{0} is the data type display name. {1} is the parent resource display name.</note>
+      </trans-unit>
+      <trans-unit id="ManageDataDeselectItemButtonLabel">
+        <source>Deselect {0}</source>
+        <target state="new">Deselect {0}</target>
+        <note>{0} is the resource or data type display name.</note>
+      </trans-unit>
       <trans-unit id="ManageDataDialogTitle">
         <source>Manage logs and telemetry</source>
         <target state="translated">管理日志和遥测</target>
@@ -528,6 +543,21 @@ For more information about using AI agents with the dashboard, including setting
         <source>Resource</source>
         <target state="translated">资源</target>
         <note />
+      </trans-unit>
+      <trans-unit id="ManageDataSelectAllButtonLabel">
+        <source>Select all</source>
+        <target state="new">Select all</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ManageDataSelectDataTypeForResourceButtonLabel">
+        <source>Select {0} for {1}</source>
+        <target state="new">Select {0} for {1}</target>
+        <note>{0} is the data type display name. {1} is the parent resource display name.</note>
+      </trans-unit>
+      <trans-unit id="ManageDataSelectItemButtonLabel">
+        <source>Select {0}</source>
+        <target state="new">Select {0}</target>
+        <note>{0} is the resource or data type display name.</note>
       </trans-unit>
       <trans-unit id="ManageDataStructuredLogs">
         <source>Structured logs</source>

--- a/src/Aspire.Dashboard/Resources/xlf/Dialogs.zh-Hant.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Dialogs.zh-Hant.xlf
@@ -484,6 +484,21 @@ For more information about using AI agents with the dashboard, including setting
         <target state="translated">確定</target>
         <note />
       </trans-unit>
+      <trans-unit id="ManageDataDeselectAllButtonLabel">
+        <source>Deselect all</source>
+        <target state="new">Deselect all</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ManageDataDeselectDataTypeForResourceButtonLabel">
+        <source>Deselect {0} for {1}</source>
+        <target state="new">Deselect {0} for {1}</target>
+        <note>{0} is the data type display name. {1} is the parent resource display name.</note>
+      </trans-unit>
+      <trans-unit id="ManageDataDeselectItemButtonLabel">
+        <source>Deselect {0}</source>
+        <target state="new">Deselect {0}</target>
+        <note>{0} is the resource or data type display name.</note>
+      </trans-unit>
       <trans-unit id="ManageDataDialogTitle">
         <source>Manage logs and telemetry</source>
         <target state="translated">管理記錄與遙測</target>
@@ -528,6 +543,21 @@ For more information about using AI agents with the dashboard, including setting
         <source>Resource</source>
         <target state="translated">資源</target>
         <note />
+      </trans-unit>
+      <trans-unit id="ManageDataSelectAllButtonLabel">
+        <source>Select all</source>
+        <target state="new">Select all</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ManageDataSelectDataTypeForResourceButtonLabel">
+        <source>Select {0} for {1}</source>
+        <target state="new">Select {0} for {1}</target>
+        <note>{0} is the data type display name. {1} is the parent resource display name.</note>
+      </trans-unit>
+      <trans-unit id="ManageDataSelectItemButtonLabel">
+        <source>Select {0}</source>
+        <target state="new">Select {0}</target>
+        <note>{0} is the resource or data type display name.</note>
       </trans-unit>
       <trans-unit id="ManageDataStructuredLogs">
         <source>Structured logs</source>

--- a/tests/Aspire.Dashboard.Components.Tests/Dialogs/ManageDataDialogTests.cs
+++ b/tests/Aspire.Dashboard.Components.Tests/Dialogs/ManageDataDialogTests.cs
@@ -1,0 +1,168 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Threading.Channels;
+using Aspire.Dashboard.Components.Dialogs;
+using Aspire.Dashboard.Components.Tests.Shared;
+using Aspire.Dashboard.Configuration;
+using Aspire.Dashboard.Model;
+using Aspire.Dashboard.Tests.Shared;
+using Aspire.Tests.Shared.DashboardModel;
+using AngleSharp.Dom;
+using Bunit;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+using Xunit;
+
+namespace Aspire.Dashboard.Components.Tests.Dialogs;
+
+[UseCulture("en-US")]
+public sealed class ManageDataDialogTests : DashboardTestContext
+{
+    [Fact]
+    public void Render_SelectionButtons_HaveAccessibleNames()
+    {
+        var basketResource = ModelTestHelpers.CreateResource(
+            resourceName: "basket",
+            displayName: "Basket service",
+            state: KnownResourceState.Running);
+        var catalogResource = ModelTestHelpers.CreateResource(
+            resourceName: "catalog",
+            displayName: "Catalog service",
+            state: KnownResourceState.Running);
+        var resourcesChannel = Channel.CreateUnbounded<IReadOnlyList<ResourceViewModelChange>>();
+        var dashboardClient = new TestDashboardClient(
+            isEnabled: true,
+            initialResources: [basketResource, catalogResource],
+            resourceChannelProvider: () => resourcesChannel);
+
+        SetupManageDataDialogServices(dashboardClient);
+
+        var cut = RenderComponent<ManageDataDialog>();
+
+        cut.WaitForAssertion(() =>
+        {
+            AssertSelectionButtonHasAccessibleName(cut, "Deselect all");
+            AssertNoButtonHasAccessibleName(cut, "Name");
+        });
+
+        ExpandResourceRows(cut, expectedCount: 2);
+
+        cut.WaitForAssertion(() =>
+        {
+            AssertSelectionButtonInRowHasAccessibleName(cut, "Basket service", "Deselect Basket service");
+            AssertSelectionButtonInRowHasAccessibleName(cut, "Catalog service", "Deselect Catalog service");
+            AssertNestedRowSelectionLabels(
+                cut,
+                "Resource",
+                "Deselect Resource for Basket service",
+                "Deselect Resource for Catalog service");
+            AssertNestedRowSelectionLabels(
+                cut,
+                "Console logs",
+                "Deselect Console logs for Basket service",
+                "Deselect Console logs for Catalog service");
+            AssertNoButtonHasAccessibleName(cut, "Deselect Console logs");
+            AssertNoButtonHasAccessibleName(cut, "Name");
+        });
+
+        cut.Find("fluent-button[aria-label='Deselect all']").Click();
+
+        cut.WaitForAssertion(() =>
+        {
+            AssertSelectionButtonHasAccessibleName(cut, "Select all");
+            AssertSelectionButtonInRowHasAccessibleName(cut, "Basket service", "Select Basket service");
+            AssertSelectionButtonInRowHasAccessibleName(cut, "Catalog service", "Select Catalog service");
+            AssertNestedRowSelectionLabels(
+                cut,
+                "Resource",
+                "Select Resource for Basket service",
+                "Select Resource for Catalog service");
+            AssertNestedRowSelectionLabels(
+                cut,
+                "Console logs",
+                "Select Console logs for Basket service",
+                "Select Console logs for Catalog service");
+            AssertNoButtonHasAccessibleName(cut, "Select Console logs");
+            AssertNoButtonHasAccessibleName(cut, "Name");
+        });
+    }
+
+    private void SetupManageDataDialogServices(TestDashboardClient dashboardClient)
+    {
+        FluentUISetupHelpers.AddCommonDashboardServices(this);
+        Services.AddLogging();
+        Services.AddSingleton<ILoggerFactory>(NullLoggerFactory.Instance);
+        Services.AddOptions<DashboardOptions>().Configure(options => options.UI.DisableImport = true);
+        Services.AddSingleton<IDashboardClient>(dashboardClient);
+        Services.AddSingleton<IconResolver>();
+        Services.AddSingleton<ConsoleLogsManager>();
+        Services.AddSingleton<ConsoleLogsFetcher>();
+        Services.AddSingleton<TelemetryExportService>();
+        Services.AddSingleton<TelemetryImportService>();
+
+        FluentUISetupHelpers.SetupFluentUIComponents(this);
+        FluentUISetupHelpers.SetupFluentButton(this);
+        FluentUISetupHelpers.SetupFluentDataGrid(this);
+    }
+
+    private static void ExpandResourceRows(IRenderedComponent<ManageDataDialog> cut, int expectedCount)
+    {
+        for (var i = 0; i < expectedCount; i++)
+        {
+            var toggleButtons = cut.FindAll("fluent-button[aria-label='Toggle nesting']");
+
+            Assert.Equal(expectedCount, toggleButtons.Count);
+
+            toggleButtons[i].Click();
+        }
+    }
+
+    private static void AssertSelectionButtonHasAccessibleName(IRenderedComponent<ManageDataDialog> cut, string accessibleName)
+    {
+        Assert.Contains(cut.FindAll("fluent-button"), button => ButtonHasAccessibleName(button, accessibleName));
+    }
+
+    private static void AssertSelectionButtonInRowHasAccessibleName(IRenderedComponent<ManageDataDialog> cut, string visibleText, string accessibleName)
+    {
+        var row = Assert.Single(cut.FindAll(".fluent-data-grid-row"), row => row.TextContent.Contains(visibleText, StringComparison.Ordinal));
+
+        Assert.Contains(row.QuerySelectorAll("fluent-button"), button => ButtonHasAccessibleName(button, accessibleName));
+    }
+
+    private static void AssertNestedRowSelectionLabels(IRenderedComponent<ManageDataDialog> cut, string visibleText, params string[] expectedAccessibleNames)
+    {
+        var accessibleNames = cut.FindAll(".fluent-data-grid-row")
+            .Where(row => row.TextContent.Contains(visibleText, StringComparison.Ordinal))
+            .Select(GetOnlySelectionButtonAccessibleName)
+            .ToArray();
+
+        Assert.Equal(
+            expectedAccessibleNames.OrderBy(name => name, StringComparer.Ordinal),
+            accessibleNames.OrderBy(name => name, StringComparer.Ordinal));
+        Assert.Equal(accessibleNames.Length, accessibleNames.Distinct(StringComparer.Ordinal).Count());
+    }
+
+    private static void AssertNoButtonHasAccessibleName(IRenderedComponent<ManageDataDialog> cut, string accessibleName) =>
+        Assert.DoesNotContain(
+            cut.FindAll("fluent-button"),
+            button =>
+                string.Equals(button.GetAttribute("title"), accessibleName, StringComparison.Ordinal) ||
+                string.Equals(button.GetAttribute("aria-label"), accessibleName, StringComparison.Ordinal));
+
+    private static bool ButtonHasAccessibleName(IElement button, string accessibleName) =>
+        string.Equals(button.GetAttribute("title"), accessibleName, StringComparison.Ordinal) &&
+        string.Equals(button.GetAttribute("aria-label"), accessibleName, StringComparison.Ordinal);
+
+    private static string GetOnlySelectionButtonAccessibleName(IElement row)
+    {
+        var button = Assert.Single(row.QuerySelectorAll("fluent-button"));
+        var title = button.GetAttribute("title");
+
+        Assert.False(string.IsNullOrEmpty(title));
+        Assert.Equal(title, button.GetAttribute("aria-label"));
+
+        return title;
+    }
+}


### PR DESCRIPTION
## Description

Fixes #17467

The Manage logs and telemetry dialog selection buttons now expose meaningful accessible names. Previously several icon-only selection buttons had no useful accessible name, so screen reader users could not tell which selection control they were operating.

The labels now describe the action and target:

```text
Deselect all
Deselect apigateway
Deselect Console logs for apigateway
```

This stays scoped to accessible names only; checkbox role/state semantics are left for the separate role issue.

### User-facing usage

Screen reader users can distinguish the Manage Data selection controls, including duplicate data types across different resources. Annotated evidence captures the before state with missing nested labels and the after state with action-oriented labels that include the parent resource.

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
