### PR TITLE
[do not review] Expose Manage Data selections as checkboxes

### DIFF
--- a/src/Aspire.Dashboard/Components/Dialogs/ManageDataDialog.razor
+++ b/src/Aspire.Dashboard/Components/Dialogs/ManageDataDialog.razor
@@ -22,6 +22,9 @@
         <ChildContent>
             <TemplateColumn Title="@ControlsStringsLoc[nameof(ControlsStrings.NameColumnHeader)]">
                 <HeaderCellItemTemplate>
+                    @{
+                        var headerSelectionLabel = GetHeaderSelectionLabel();
+                    }
                     <div style="display: flex; justify-content: flex-start;">
                         <div style="width: calc(100% - 10px);">
                             <div class="name-title-text">
@@ -29,6 +32,8 @@
                                               IconEnd="@GetHeaderCheckboxIcon()"
                                               OnClick="OnSelectAllClicked"
                                               Disabled="@(_resourceDataRows.Count == 0)"
+                                              Title="@headerSelectionLabel"
+                                              aria-label="@headerSelectionLabel"
                                               style="margin-right: 8px;" />
                                 @ControlsStringsLoc[nameof(ControlsStrings.NameColumnHeader)]
                             </div>
@@ -43,6 +48,9 @@
                     <span class="resources-name-container" style="margin-left: @(indent)px;">
                         @if (context.IsResourceRow && context.ResourceRow is not null)
                         {
+                            var resourceDisplayName = GetResourceDisplayName(context.ResourceRow);
+                            var resourceSelectionLabel = GetResourceSelectionLabel(context.ResourceRow, resourceDisplayName);
+
                             <span @onclick:stopPropagation="true" class="main-grid-expand-container @(IsResourceExpanded(context.ResourceRow.Name) ? "main-grid-expanded" : "main-grid-collapsed")">
                                 @if (context.ResourceRow.TelemetryData.Count > 0)
                                 {
@@ -58,6 +66,8 @@
                                 <FluentButton Appearance="Appearance.Lightweight"
                                               IconEnd="@GetResourceCheckboxIcon(context.ResourceRow)"
                                               OnClick="@(() => OnSelectRowClicked(context.ResourceRow))"
+                                              Title="@resourceSelectionLabel"
+                                              aria-label="@resourceSelectionLabel"
                                               style="margin-right: 8px;" />
                             </span>
                             @if (context.ResourceRow.Resource is not null)
@@ -76,19 +86,25 @@
                                                     CustomColor="@ColorGenerator.Instance.GetColorVariableByKey(context.ResourceRow.Name)"
                                                     Value="@(new Icons.Filled.Size16.Book())" />
                                     }
-                                    <span class="resource-name-text">@GetOtlpResourceName(context.ResourceRow.OtlpResource)</span>
+                                    <span class="resource-name-text">@resourceDisplayName</span>
                                 </span>
                             }
                         }
                         else if (context.IsNestedRow && context.NestedRow is not null && context.ParentResourceName is not null)
                         {
+                            var dataTypeDisplayName = GetDataTypeDisplayName(context.NestedRow.DataType);
+                            var parentResourceDisplayName = GetResourceDisplayName(context.ParentResourceName);
+                            var dataTypeSelectionLabel = GetDataRowSelectionLabel(context.ParentResourceName, context.NestedRow.DataType, dataTypeDisplayName, parentResourceDisplayName);
+
                             <span @onclick:stopPropagation="true">
                                 <FluentButton Appearance="Appearance.Lightweight"
                                               IconEnd="@(IsDataRowSelected(context.ParentResourceName, context.NestedRow.DataType) ? _iconSelectedMultiple : _iconUnselectedMultiple)"
                                               OnClick="@(() => OnSelectDataRowClicked(context.ParentResourceName, context.NestedRow.DataType))"
+                                              Title="@dataTypeSelectionLabel"
+                                              aria-label="@dataTypeSelectionLabel"
                                               style="margin-right: 8px;" />
                             </span>
-                            <span class="cellText">@GetDataTypeDisplayName(context.NestedRow.DataType)</span>
+                            <span class="cellText">@dataTypeDisplayName</span>
                         }
                     </span>
                 </ChildContent>

--- a/src/Aspire.Dashboard/Components/Dialogs/ManageDataDialog.razor
+++ b/src/Aspire.Dashboard/Components/Dialogs/ManageDataDialog.razor
@@ -34,6 +34,8 @@
                                               Disabled="@(_resourceDataRows.Count == 0)"
                                               Title="@headerSelectionLabel"
                                               aria-label="@headerSelectionLabel"
+                                              role="checkbox"
+                                              aria-checked="@GetHeaderCheckboxAriaChecked()"
                                               style="margin-right: 8px;" />
                                 @ControlsStringsLoc[nameof(ControlsStrings.NameColumnHeader)]
                             </div>
@@ -68,6 +70,8 @@
                                               OnClick="@(() => OnSelectRowClicked(context.ResourceRow))"
                                               Title="@resourceSelectionLabel"
                                               aria-label="@resourceSelectionLabel"
+                                              role="checkbox"
+                                              aria-checked="@GetResourceCheckboxAriaChecked(context.ResourceRow)"
                                               style="margin-right: 8px;" />
                             </span>
                             @if (context.ResourceRow.Resource is not null)
@@ -102,6 +106,8 @@
                                               OnClick="@(() => OnSelectDataRowClicked(context.ParentResourceName, context.NestedRow.DataType))"
                                               Title="@dataTypeSelectionLabel"
                                               aria-label="@dataTypeSelectionLabel"
+                                              role="checkbox"
+                                              aria-checked="@GetDataRowCheckboxAriaChecked(context.ParentResourceName, context.NestedRow.DataType)"
                                               style="margin-right: 8px;" />
                             </span>
                             <span class="cellText">@dataTypeDisplayName</span>

--- a/src/Aspire.Dashboard/Components/Dialogs/ManageDataDialog.razor
+++ b/src/Aspire.Dashboard/Components/Dialogs/ManageDataDialog.razor
@@ -7,7 +7,7 @@
 @using Resources = Aspire.Dashboard.Resources.Resources
 @using Dialogs = Aspire.Dashboard.Resources.Dialogs
 
-<div style="height: 44vh; overflow-y: auto;">
+<div @ref="_dataGridContainer" style="height: 44vh; overflow-y: auto;">
     <FluentDataGrid @ref="_dataGrid"
                     Items="@GetGridItems()"
                     ItemSize="46"
@@ -28,15 +28,19 @@
                     <div style="display: flex; justify-content: flex-start;">
                         <div style="width: calc(100% - 10px);">
                             <div class="name-title-text">
-                                <FluentButton Appearance="Appearance.Lightweight"
-                                              IconEnd="@GetHeaderCheckboxIcon()"
-                                              OnClick="OnSelectAllClicked"
-                                              Disabled="@(_resourceDataRows.Count == 0)"
-                                              Title="@headerSelectionLabel"
-                                              aria-label="@headerSelectionLabel"
-                                              role="checkbox"
-                                              aria-checked="@GetHeaderCheckboxAriaChecked()"
-                                              style="margin-right: 8px;" />
+                                @* FluentButton renders a shadow-DOM button that remains exposed as role=button,
+                                   so the checkbox semantics need to live on this focused element. *@
+                                <span class="manage-data-selection-checkbox"
+                                      tabindex="@GetHeaderSelectionCheckboxTabIndex()"
+                                      role="checkbox"
+                                      aria-checked="@GetHeaderCheckboxAriaChecked()"
+                                      aria-disabled="@GetHeaderSelectionCheckboxAriaDisabled()"
+                                      title="@headerSelectionLabel"
+                                      aria-label="@headerSelectionLabel"
+                                      @onclick="OnSelectAllClicked"
+                                      @onkeydown="OnSelectAllCheckboxKeyDown">
+                                    <FluentIcon Value="@GetHeaderCheckboxIcon()" aria-hidden="true" />
+                                </span>
                                 @ControlsStringsLoc[nameof(ControlsStrings.NameColumnHeader)]
                             </div>
                         </div>
@@ -51,7 +55,7 @@
                         @if (context.IsResourceRow && context.ResourceRow is not null)
                         {
                             var resourceDisplayName = GetResourceDisplayName(context.ResourceRow);
-                            var resourceSelectionLabel = GetResourceSelectionLabel(context.ResourceRow, resourceDisplayName);
+                            var resourceSelectionLabel = resourceDisplayName;
 
                             <span @onclick:stopPropagation="true" class="main-grid-expand-container @(IsResourceExpanded(context.ResourceRow.Name) ? "main-grid-expanded" : "main-grid-collapsed")">
                                 @if (context.ResourceRow.TelemetryData.Count > 0)
@@ -65,14 +69,16 @@
                                 }
                             </span>
                             <span @onclick:stopPropagation="true">
-                                <FluentButton Appearance="Appearance.Lightweight"
-                                              IconEnd="@GetResourceCheckboxIcon(context.ResourceRow)"
-                                              OnClick="@(() => OnSelectRowClicked(context.ResourceRow))"
-                                              Title="@resourceSelectionLabel"
-                                              aria-label="@resourceSelectionLabel"
-                                              role="checkbox"
-                                              aria-checked="@GetResourceCheckboxAriaChecked(context.ResourceRow)"
-                                              style="margin-right: 8px;" />
+                                <span class="manage-data-selection-checkbox"
+                                      tabindex="0"
+                                      role="checkbox"
+                                      aria-checked="@GetResourceCheckboxAriaChecked(context.ResourceRow)"
+                                      title="@resourceSelectionLabel"
+                                      aria-label="@resourceSelectionLabel"
+                                      @onclick="@(() => OnSelectRowClicked(context.ResourceRow))"
+                                      @onkeydown="@((KeyboardEventArgs args) => OnResourceCheckboxKeyDown(args, context.ResourceRow))">
+                                    <FluentIcon Value="@GetResourceCheckboxIcon(context.ResourceRow)" aria-hidden="true" />
+                                </span>
                             </span>
                             @if (context.ResourceRow.Resource is not null)
                             {
@@ -98,17 +104,19 @@
                         {
                             var dataTypeDisplayName = GetDataTypeDisplayName(context.NestedRow.DataType);
                             var parentResourceDisplayName = GetResourceDisplayName(context.ParentResourceName);
-                            var dataTypeSelectionLabel = GetDataRowSelectionLabel(context.ParentResourceName, context.NestedRow.DataType, dataTypeDisplayName, parentResourceDisplayName);
+                            var dataTypeSelectionLabel = GetDataRowSelectionLabel(dataTypeDisplayName, parentResourceDisplayName);
 
                             <span @onclick:stopPropagation="true">
-                                <FluentButton Appearance="Appearance.Lightweight"
-                                              IconEnd="@(IsDataRowSelected(context.ParentResourceName, context.NestedRow.DataType) ? _iconSelectedMultiple : _iconUnselectedMultiple)"
-                                              OnClick="@(() => OnSelectDataRowClicked(context.ParentResourceName, context.NestedRow.DataType))"
-                                              Title="@dataTypeSelectionLabel"
-                                              aria-label="@dataTypeSelectionLabel"
-                                              role="checkbox"
-                                              aria-checked="@GetDataRowCheckboxAriaChecked(context.ParentResourceName, context.NestedRow.DataType)"
-                                              style="margin-right: 8px;" />
+                                <span class="manage-data-selection-checkbox"
+                                      tabindex="0"
+                                      role="checkbox"
+                                      aria-checked="@GetDataRowCheckboxAriaChecked(context.ParentResourceName, context.NestedRow.DataType)"
+                                      title="@dataTypeSelectionLabel"
+                                      aria-label="@dataTypeSelectionLabel"
+                                      @onclick="@(() => OnSelectDataRowClicked(context.ParentResourceName, context.NestedRow.DataType))"
+                                      @onkeydown="@((KeyboardEventArgs args) => OnDataRowCheckboxKeyDown(args, context.ParentResourceName, context.NestedRow.DataType))">
+                                    <FluentIcon Value="@(IsDataRowSelected(context.ParentResourceName, context.NestedRow.DataType) ? _iconSelectedMultiple : _iconUnselectedMultiple)" aria-hidden="true" />
+                                </span>
                             </span>
                             <span class="cellText">@dataTypeDisplayName</span>
                         }

--- a/src/Aspire.Dashboard/Components/Dialogs/ManageDataDialog.razor.cs
+++ b/src/Aspire.Dashboard/Components/Dialogs/ManageDataDialog.razor.cs
@@ -11,6 +11,7 @@ using Aspire.Dashboard.Resources;
 using Aspire.Dashboard.Telemetry;
 using Aspire.Dashboard.Utils;
 using Microsoft.AspNetCore.Components;
+using Microsoft.AspNetCore.Components.Web;
 using Microsoft.Extensions.Localization;
 using Microsoft.FluentUI.AspNetCore.Components;
 using Microsoft.JSInterop;
@@ -64,6 +65,8 @@ public partial class ManageDataDialog : IDialogContentComponent, IAsyncDisposabl
     private readonly Icon _iconUnselectedMultiple = new Icons.Regular.Size20.CheckboxUnchecked().WithColor(Color.FillInverse);
     private readonly Icon _iconSelectedMultiple = new Icons.Filled.Size20.CheckboxChecked();
     private readonly Icon _iconIndeterminate = new Icons.Filled.Size20.CheckboxIndeterminate();
+    private ElementReference _dataGridContainer;
+    private IJSObjectReference? _jsModule;
     private Task? _resourceSubscriptionTask;
     private FluentDataGrid<ManageDataGridItem>? _dataGrid;
     private bool _isExporting;
@@ -85,6 +88,15 @@ public partial class ManageDataDialog : IDialogContentComponent, IAsyncDisposabl
 
         // Initialize telemetry-only resources
         UpdateData();
+    }
+
+    protected override async Task OnAfterRenderAsync(bool firstRender)
+    {
+        if (firstRender)
+        {
+            _jsModule = await JS.InvokeAsync<IJSObjectReference>("import", "./Components/Dialogs/ManageDataDialog.razor.js");
+            await _jsModule.InvokeVoidAsync("initializeSelectionCheckboxKeyboard", _dataGridContainer);
+        }
     }
 
     private async Task OnTelemetryChangedAsync()
@@ -343,9 +355,7 @@ public partial class ManageDataDialog : IDialogContentComponent, IAsyncDisposabl
 
     private string GetOtlpResourceName(OtlpResource resource) => OtlpHelpers.GetResourceName(resource, TelemetryRepository.GetResources());
 
-    private string GetHeaderSelectionLabel() => AreAllSelected()
-        ? Loc[nameof(Resources.Dialogs.ManageDataDeselectAllButtonLabel)]
-        : Loc[nameof(Resources.Dialogs.ManageDataSelectAllButtonLabel)];
+    private string GetHeaderSelectionLabel() => Loc[nameof(Resources.Dialogs.ManageDataAllDataCheckboxLabel)];
 
     private string GetResourceDisplayName(ResourceDataRow row)
     {
@@ -364,15 +374,8 @@ public partial class ManageDataDialog : IDialogContentComponent, IAsyncDisposabl
 
     private string GetResourceDisplayName(string resourceName) => _resourceDataRows.TryGetValue(resourceName, out var row) ? GetResourceDisplayName(row) : resourceName;
 
-    private string GetResourceSelectionLabel(ResourceDataRow row, string resourceDisplayName) => GetSelectionLabel(AreAllDataRowsSelected(row), resourceDisplayName);
-
-    private string GetDataRowSelectionLabel(string resourceName, AspireDataType dataType, string dataTypeDisplayName, string parentResourceDisplayName) => IsDataRowSelected(resourceName, dataType)
-        ? Loc[nameof(Resources.Dialogs.ManageDataDeselectDataTypeForResourceButtonLabel), dataTypeDisplayName, parentResourceDisplayName]
-        : Loc[nameof(Resources.Dialogs.ManageDataSelectDataTypeForResourceButtonLabel), dataTypeDisplayName, parentResourceDisplayName];
-
-    private string GetSelectionLabel(bool selected, string displayName) => selected
-        ? Loc[nameof(Resources.Dialogs.ManageDataDeselectItemButtonLabel), displayName]
-        : Loc[nameof(Resources.Dialogs.ManageDataSelectItemButtonLabel), displayName];
+    private string GetDataRowSelectionLabel(string dataTypeDisplayName, string parentResourceDisplayName) =>
+        Loc[nameof(Resources.Dialogs.ManageDataDataTypeForResourceCheckboxLabel), dataTypeDisplayName, parentResourceDisplayName];
 
     private string GetDataTypeDisplayName(AspireDataType dataType) => dataType switch
     {
@@ -399,6 +402,11 @@ public partial class ManageDataDialog : IDialogContentComponent, IAsyncDisposabl
 
     private void OnSelectAllClicked()
     {
+        if (_resourceDataRows.Count == 0)
+        {
+            return;
+        }
+
         // If any are unselected (including data rows), select all. Otherwise deselect all.
         var shouldSelectAll = !AreAllSelected();
 
@@ -514,6 +522,10 @@ public partial class ManageDataDialog : IDialogContentComponent, IAsyncDisposabl
 
     private string GetHeaderCheckboxAriaChecked() => GetCheckboxAriaChecked(AreAllSelected(), AreNoneSelected());
 
+    private string GetHeaderSelectionCheckboxTabIndex() => _resourceDataRows.Count == 0 ? "-1" : "0";
+
+    private string? GetHeaderSelectionCheckboxAriaDisabled() => _resourceDataRows.Count == 0 ? "true" : null;
+
     private Icon GetResourceCheckboxIcon(ResourceDataRow row)
     {
         if (AreAllDataRowsSelected(row))
@@ -537,6 +549,26 @@ public partial class ManageDataDialog : IDialogContentComponent, IAsyncDisposabl
         (_, true) => "false",
         _ => "mixed"
     };
+
+    private void OnSelectAllCheckboxKeyDown(KeyboardEventArgs args) => OnSelectionCheckboxKeyDown(args, OnSelectAllClicked);
+
+    private void OnResourceCheckboxKeyDown(KeyboardEventArgs args, ResourceDataRow row) =>
+        OnSelectionCheckboxKeyDown(args, () => OnSelectRowClicked(row));
+
+    private void OnDataRowCheckboxKeyDown(KeyboardEventArgs args, string resourceName, AspireDataType dataType) =>
+        OnSelectionCheckboxKeyDown(args, () => OnSelectDataRowClicked(resourceName, dataType));
+
+    private static void OnSelectionCheckboxKeyDown(KeyboardEventArgs args, Action toggle)
+    {
+        if (!args.Repeat && IsSpaceKey(args))
+        {
+            toggle();
+        }
+    }
+
+    private static bool IsSpaceKey(KeyboardEventArgs args) =>
+        args.Key is " " or "Spacebar" ||
+        string.Equals(args.Code, "Space", StringComparison.Ordinal);
 
     private void NavigateToDataPage(TelemetryDataRow dataRow)
     {
@@ -707,6 +739,24 @@ public partial class ManageDataDialog : IDialogContentComponent, IAsyncDisposabl
 
     public async ValueTask DisposeAsync()
     {
+        if (_jsModule is not null)
+        {
+            try
+            {
+                await _jsModule.InvokeVoidAsync("disposeSelectionCheckboxKeyboard", _dataGridContainer);
+            }
+            catch (JSDisconnectedException)
+            {
+                // The browser may already be gone when the dialog is disposed.
+            }
+            catch (OperationCanceledException)
+            {
+                // The browser may already be gone when the dialog is disposed.
+            }
+
+            await JSInteropHelpers.SafeDisposeAsync(_jsModule);
+        }
+
         _resourcesSubscription?.Dispose();
 
         await _cts.CancelAsync();

--- a/src/Aspire.Dashboard/Components/Dialogs/ManageDataDialog.razor.cs
+++ b/src/Aspire.Dashboard/Components/Dialogs/ManageDataDialog.razor.cs
@@ -343,6 +343,37 @@ public partial class ManageDataDialog : IDialogContentComponent, IAsyncDisposabl
 
     private string GetOtlpResourceName(OtlpResource resource) => OtlpHelpers.GetResourceName(resource, TelemetryRepository.GetResources());
 
+    private string GetHeaderSelectionLabel() => AreAllSelected()
+        ? Loc[nameof(Resources.Dialogs.ManageDataDeselectAllButtonLabel)]
+        : Loc[nameof(Resources.Dialogs.ManageDataSelectAllButtonLabel)];
+
+    private string GetResourceDisplayName(ResourceDataRow row)
+    {
+        if (row.Resource is not null)
+        {
+            return GetResourceName(row.Resource);
+        }
+
+        if (row.OtlpResource is not null)
+        {
+            return GetOtlpResourceName(row.OtlpResource);
+        }
+
+        return row.Name;
+    }
+
+    private string GetResourceDisplayName(string resourceName) => _resourceDataRows.TryGetValue(resourceName, out var row) ? GetResourceDisplayName(row) : resourceName;
+
+    private string GetResourceSelectionLabel(ResourceDataRow row, string resourceDisplayName) => GetSelectionLabel(AreAllDataRowsSelected(row), resourceDisplayName);
+
+    private string GetDataRowSelectionLabel(string resourceName, AspireDataType dataType, string dataTypeDisplayName, string parentResourceDisplayName) => IsDataRowSelected(resourceName, dataType)
+        ? Loc[nameof(Resources.Dialogs.ManageDataDeselectDataTypeForResourceButtonLabel), dataTypeDisplayName, parentResourceDisplayName]
+        : Loc[nameof(Resources.Dialogs.ManageDataSelectDataTypeForResourceButtonLabel), dataTypeDisplayName, parentResourceDisplayName];
+
+    private string GetSelectionLabel(bool selected, string displayName) => selected
+        ? Loc[nameof(Resources.Dialogs.ManageDataDeselectItemButtonLabel), displayName]
+        : Loc[nameof(Resources.Dialogs.ManageDataSelectItemButtonLabel), displayName];
+
     private string GetDataTypeDisplayName(AspireDataType dataType) => dataType switch
     {
         AspireDataType.ResourceDetails => Loc[nameof(Resources.Dialogs.ManageDataResource)],

--- a/src/Aspire.Dashboard/Components/Dialogs/ManageDataDialog.razor.cs
+++ b/src/Aspire.Dashboard/Components/Dialogs/ManageDataDialog.razor.cs
@@ -512,6 +512,8 @@ public partial class ManageDataDialog : IDialogContentComponent, IAsyncDisposabl
         return _iconIndeterminate;
     }
 
+    private string GetHeaderCheckboxAriaChecked() => GetCheckboxAriaChecked(AreAllSelected(), AreNoneSelected());
+
     private Icon GetResourceCheckboxIcon(ResourceDataRow row)
     {
         if (AreAllDataRowsSelected(row))
@@ -524,6 +526,17 @@ public partial class ManageDataDialog : IDialogContentComponent, IAsyncDisposabl
         }
         return _iconIndeterminate;
     }
+
+    private string GetResourceCheckboxAriaChecked(ResourceDataRow row) => GetCheckboxAriaChecked(AreAllDataRowsSelected(row), AreNoDataRowsSelected(row));
+
+    private string GetDataRowCheckboxAriaChecked(string resourceName, AspireDataType dataType) => IsDataRowSelected(resourceName, dataType) ? "true" : "false";
+
+    private static string GetCheckboxAriaChecked(bool isChecked, bool isUnchecked) => (isChecked, isUnchecked) switch
+    {
+        (true, _) => "true",
+        (_, true) => "false",
+        _ => "mixed"
+    };
 
     private void NavigateToDataPage(TelemetryDataRow dataRow)
     {

--- a/src/Aspire.Dashboard/Components/Dialogs/ManageDataDialog.razor.css
+++ b/src/Aspire.Dashboard/Components/Dialogs/ManageDataDialog.razor.css
@@ -10,6 +10,36 @@
     align-items: center;
 }
 
+::deep .manage-data-selection-checkbox {
+    align-items: center;
+    border-radius: calc(var(--control-corner-radius) * 1px);
+    cursor: pointer;
+    display: inline-flex;
+    height: 32px;
+    justify-content: center;
+    margin-right: 8px;
+    vertical-align: middle;
+    width: 32px;
+}
+
+::deep .manage-data-selection-checkbox:not([aria-disabled="true"]):hover {
+    background: var(--neutral-fill-stealth-hover);
+}
+
+::deep .manage-data-selection-checkbox:not([aria-disabled="true"]):active {
+    background: var(--neutral-fill-stealth-active);
+}
+
+::deep .manage-data-selection-checkbox:focus-visible {
+    outline: 2px solid var(--accent-fill-rest);
+    outline-offset: 2px;
+}
+
+::deep .manage-data-selection-checkbox[aria-disabled="true"] {
+    cursor: not-allowed;
+    opacity: var(--disabled-opacity);
+}
+
 ::deep .resource-name-container {
     display: inline-flex;
 }

--- a/src/Aspire.Dashboard/Components/Dialogs/ManageDataDialog.razor.js
+++ b/src/Aspire.Dashboard/Components/Dialogs/ManageDataDialog.razor.js
@@ -1,0 +1,51 @@
+const selectionCheckboxSelector = ".manage-data-selection-checkbox";
+
+export function initializeSelectionCheckboxKeyboard(container) {
+    if (!container) {
+        return;
+    }
+
+    disposeSelectionCheckboxKeyboard(container);
+
+    const onKeyDown = event => {
+        if (event.repeat || !isSpaceKey(event)) {
+            return;
+        }
+
+        const target = event.target;
+        if (!(target instanceof Element)) {
+            return;
+        }
+
+        const checkbox = target.closest(selectionCheckboxSelector);
+        if (!checkbox || !container.contains(checkbox) || checkbox.getAttribute("aria-disabled") === "true") {
+            return;
+        }
+
+        // Blazor's preventDefault event modifier applies to every key. Handle Space here
+        // so Tab/Shift+Tab keep their native focus behavior while Space cannot scroll or
+        // bubble to the grid.
+        event.preventDefault();
+        event.stopPropagation();
+        checkbox.click();
+    };
+
+    container.addEventListener("keydown", onKeyDown, true);
+    container.manageDataSelectionCheckboxKeyDown = onKeyDown;
+}
+
+export function disposeSelectionCheckboxKeyboard(container) {
+    const onKeyDown = container?.manageDataSelectionCheckboxKeyDown;
+    if (!onKeyDown) {
+        return;
+    }
+
+    container.removeEventListener("keydown", onKeyDown, true);
+    delete container.manageDataSelectionCheckboxKeyDown;
+}
+
+function isSpaceKey(event) {
+    return event.key === " " ||
+        event.key === "Spacebar" ||
+        event.code === "Space";
+}

--- a/src/Aspire.Dashboard/Resources/Dialogs.Designer.cs
+++ b/src/Aspire.Dashboard/Resources/Dialogs.Designer.cs
@@ -827,6 +827,15 @@ namespace Aspire.Dashboard.Resources {
                 return ResourceManager.GetString("InteractionButtonOk", resourceCulture);
             }
         }
+
+        /// <summary>
+        ///   Looks up a localized string similar to All data.
+        /// </summary>
+        public static string ManageDataAllDataCheckboxLabel {
+            get {
+                return ResourceManager.GetString("ManageDataAllDataCheckboxLabel", resourceCulture);
+            }
+        }
         
         /// <summary>
         ///   Looks up a localized string similar to Console logs.
@@ -836,31 +845,13 @@ namespace Aspire.Dashboard.Resources {
                 return ResourceManager.GetString("ManageDataConsoleLogs", resourceCulture);
             }
         }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Deselect all.
-        /// </summary>
-        public static string ManageDataDeselectAllButtonLabel {
-            get {
-                return ResourceManager.GetString("ManageDataDeselectAllButtonLabel", resourceCulture);
-            }
-        }
 
         /// <summary>
-        ///   Looks up a localized string similar to Deselect {0}.
+        ///   Looks up a localized string similar to {0} for {1}.
         /// </summary>
-        public static string ManageDataDeselectItemButtonLabel {
+        public static string ManageDataDataTypeForResourceCheckboxLabel {
             get {
-                return ResourceManager.GetString("ManageDataDeselectItemButtonLabel", resourceCulture);
-            }
-        }
-
-        /// <summary>
-        ///   Looks up a localized string similar to Deselect {0} for {1}.
-        /// </summary>
-        public static string ManageDataDeselectDataTypeForResourceButtonLabel {
-            get {
-                return ResourceManager.GetString("ManageDataDeselectDataTypeForResourceButtonLabel", resourceCulture);
+                return ResourceManager.GetString("ManageDataDataTypeForResourceCheckboxLabel", resourceCulture);
             }
         }
 
@@ -951,33 +942,6 @@ namespace Aspire.Dashboard.Resources {
         public static string ManageDataResource {
             get {
                 return ResourceManager.GetString("ManageDataResource", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Select all.
-        /// </summary>
-        public static string ManageDataSelectAllButtonLabel {
-            get {
-                return ResourceManager.GetString("ManageDataSelectAllButtonLabel", resourceCulture);
-            }
-        }
-
-        /// <summary>
-        ///   Looks up a localized string similar to Select {0}.
-        /// </summary>
-        public static string ManageDataSelectItemButtonLabel {
-            get {
-                return ResourceManager.GetString("ManageDataSelectItemButtonLabel", resourceCulture);
-            }
-        }
-
-        /// <summary>
-        ///   Looks up a localized string similar to Select {0} for {1}.
-        /// </summary>
-        public static string ManageDataSelectDataTypeForResourceButtonLabel {
-            get {
-                return ResourceManager.GetString("ManageDataSelectDataTypeForResourceButtonLabel", resourceCulture);
             }
         }
 

--- a/src/Aspire.Dashboard/Resources/Dialogs.Designer.cs
+++ b/src/Aspire.Dashboard/Resources/Dialogs.Designer.cs
@@ -838,6 +838,33 @@ namespace Aspire.Dashboard.Resources {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Deselect all.
+        /// </summary>
+        public static string ManageDataDeselectAllButtonLabel {
+            get {
+                return ResourceManager.GetString("ManageDataDeselectAllButtonLabel", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Deselect {0}.
+        /// </summary>
+        public static string ManageDataDeselectItemButtonLabel {
+            get {
+                return ResourceManager.GetString("ManageDataDeselectItemButtonLabel", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Deselect {0} for {1}.
+        /// </summary>
+        public static string ManageDataDeselectDataTypeForResourceButtonLabel {
+            get {
+                return ResourceManager.GetString("ManageDataDeselectDataTypeForResourceButtonLabel", resourceCulture);
+            }
+        }
+
+        /// <summary>
         ///   Looks up a localized string similar to Manage logs and telemetry.
         /// </summary>
         public static string ManageDataDialogTitle {
@@ -927,6 +954,33 @@ namespace Aspire.Dashboard.Resources {
             }
         }
         
+        /// <summary>
+        ///   Looks up a localized string similar to Select all.
+        /// </summary>
+        public static string ManageDataSelectAllButtonLabel {
+            get {
+                return ResourceManager.GetString("ManageDataSelectAllButtonLabel", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Select {0}.
+        /// </summary>
+        public static string ManageDataSelectItemButtonLabel {
+            get {
+                return ResourceManager.GetString("ManageDataSelectItemButtonLabel", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Select {0} for {1}.
+        /// </summary>
+        public static string ManageDataSelectDataTypeForResourceButtonLabel {
+            get {
+                return ResourceManager.GetString("ManageDataSelectDataTypeForResourceButtonLabel", resourceCulture);
+            }
+        }
+
         /// <summary>
         ///   Looks up a localized string similar to Structured logs.
         /// </summary>

--- a/src/Aspire.Dashboard/Resources/Dialogs.resx
+++ b/src/Aspire.Dashboard/Resources/Dialogs.resx
@@ -456,6 +456,17 @@
   <data name="ManageDataConsoleLogs" xml:space="preserve">
     <value>Console logs</value>
   </data>
+  <data name="ManageDataDeselectAllButtonLabel" xml:space="preserve">
+    <value>Deselect all</value>
+  </data>
+  <data name="ManageDataDeselectItemButtonLabel" xml:space="preserve">
+    <value>Deselect {0}</value>
+    <comment>{0} is the resource or data type display name.</comment>
+  </data>
+  <data name="ManageDataDeselectDataTypeForResourceButtonLabel" xml:space="preserve">
+    <value>Deselect {0} for {1}</value>
+    <comment>{0} is the data type display name. {1} is the parent resource display name.</comment>
+  </data>
   <data name="ManageDataExportButtonText" xml:space="preserve">
     <value>Export selected</value>
   </data>
@@ -482,6 +493,17 @@
   </data>
   <data name="ManageDataResource" xml:space="preserve">
     <value>Resource</value>
+  </data>
+  <data name="ManageDataSelectAllButtonLabel" xml:space="preserve">
+    <value>Select all</value>
+  </data>
+  <data name="ManageDataSelectItemButtonLabel" xml:space="preserve">
+    <value>Select {0}</value>
+    <comment>{0} is the resource or data type display name.</comment>
+  </data>
+  <data name="ManageDataSelectDataTypeForResourceButtonLabel" xml:space="preserve">
+    <value>Select {0} for {1}</value>
+    <comment>{0} is the data type display name. {1} is the parent resource display name.</comment>
   </data>
   <data name="SettingsDialogTimeFormat" xml:space="preserve">
     <value>Time format</value>

--- a/src/Aspire.Dashboard/Resources/Dialogs.resx
+++ b/src/Aspire.Dashboard/Resources/Dialogs.resx
@@ -453,18 +453,14 @@
   <data name="ManageDataDialogTitle" xml:space="preserve">
     <value>Manage logs and telemetry</value>
   </data>
+  <data name="ManageDataAllDataCheckboxLabel" xml:space="preserve">
+    <value>All data</value>
+  </data>
   <data name="ManageDataConsoleLogs" xml:space="preserve">
     <value>Console logs</value>
   </data>
-  <data name="ManageDataDeselectAllButtonLabel" xml:space="preserve">
-    <value>Deselect all</value>
-  </data>
-  <data name="ManageDataDeselectItemButtonLabel" xml:space="preserve">
-    <value>Deselect {0}</value>
-    <comment>{0} is the resource or data type display name.</comment>
-  </data>
-  <data name="ManageDataDeselectDataTypeForResourceButtonLabel" xml:space="preserve">
-    <value>Deselect {0} for {1}</value>
+  <data name="ManageDataDataTypeForResourceCheckboxLabel" xml:space="preserve">
+    <value>{0} for {1}</value>
     <comment>{0} is the data type display name. {1} is the parent resource display name.</comment>
   </data>
   <data name="ManageDataExportButtonText" xml:space="preserve">
@@ -493,17 +489,6 @@
   </data>
   <data name="ManageDataResource" xml:space="preserve">
     <value>Resource</value>
-  </data>
-  <data name="ManageDataSelectAllButtonLabel" xml:space="preserve">
-    <value>Select all</value>
-  </data>
-  <data name="ManageDataSelectItemButtonLabel" xml:space="preserve">
-    <value>Select {0}</value>
-    <comment>{0} is the resource or data type display name.</comment>
-  </data>
-  <data name="ManageDataSelectDataTypeForResourceButtonLabel" xml:space="preserve">
-    <value>Select {0} for {1}</value>
-    <comment>{0} is the data type display name. {1} is the parent resource display name.</comment>
   </data>
   <data name="SettingsDialogTimeFormat" xml:space="preserve">
     <value>Time format</value>

--- a/src/Aspire.Dashboard/Resources/xlf/Dialogs.cs.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Dialogs.cs.xlf
@@ -484,6 +484,21 @@ For more information about using AI agents with the dashboard, including setting
         <target state="translated">OK</target>
         <note />
       </trans-unit>
+      <trans-unit id="ManageDataDeselectAllButtonLabel">
+        <source>Deselect all</source>
+        <target state="new">Deselect all</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ManageDataDeselectDataTypeForResourceButtonLabel">
+        <source>Deselect {0} for {1}</source>
+        <target state="new">Deselect {0} for {1}</target>
+        <note>{0} is the data type display name. {1} is the parent resource display name.</note>
+      </trans-unit>
+      <trans-unit id="ManageDataDeselectItemButtonLabel">
+        <source>Deselect {0}</source>
+        <target state="new">Deselect {0}</target>
+        <note>{0} is the resource or data type display name.</note>
+      </trans-unit>
       <trans-unit id="ManageDataDialogTitle">
         <source>Manage logs and telemetry</source>
         <target state="translated">Správa protokolů a telemetrie</target>
@@ -528,6 +543,21 @@ For more information about using AI agents with the dashboard, including setting
         <source>Resource</source>
         <target state="translated">Prostředek</target>
         <note />
+      </trans-unit>
+      <trans-unit id="ManageDataSelectAllButtonLabel">
+        <source>Select all</source>
+        <target state="new">Select all</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ManageDataSelectDataTypeForResourceButtonLabel">
+        <source>Select {0} for {1}</source>
+        <target state="new">Select {0} for {1}</target>
+        <note>{0} is the data type display name. {1} is the parent resource display name.</note>
+      </trans-unit>
+      <trans-unit id="ManageDataSelectItemButtonLabel">
+        <source>Select {0}</source>
+        <target state="new">Select {0}</target>
+        <note>{0} is the resource or data type display name.</note>
       </trans-unit>
       <trans-unit id="ManageDataStructuredLogs">
         <source>Structured logs</source>

--- a/src/Aspire.Dashboard/Resources/xlf/Dialogs.cs.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Dialogs.cs.xlf
@@ -484,20 +484,15 @@ For more information about using AI agents with the dashboard, including setting
         <target state="translated">OK</target>
         <note />
       </trans-unit>
-      <trans-unit id="ManageDataDeselectAllButtonLabel">
-        <source>Deselect all</source>
-        <target state="new">Deselect all</target>
+      <trans-unit id="ManageDataAllDataCheckboxLabel">
+        <source>All data</source>
+        <target state="new">All data</target>
         <note />
       </trans-unit>
-      <trans-unit id="ManageDataDeselectDataTypeForResourceButtonLabel">
-        <source>Deselect {0} for {1}</source>
-        <target state="new">Deselect {0} for {1}</target>
+      <trans-unit id="ManageDataDataTypeForResourceCheckboxLabel">
+        <source>{0} for {1}</source>
+        <target state="new">{0} for {1}</target>
         <note>{0} is the data type display name. {1} is the parent resource display name.</note>
-      </trans-unit>
-      <trans-unit id="ManageDataDeselectItemButtonLabel">
-        <source>Deselect {0}</source>
-        <target state="new">Deselect {0}</target>
-        <note>{0} is the resource or data type display name.</note>
       </trans-unit>
       <trans-unit id="ManageDataDialogTitle">
         <source>Manage logs and telemetry</source>
@@ -543,21 +538,6 @@ For more information about using AI agents with the dashboard, including setting
         <source>Resource</source>
         <target state="translated">Prostředek</target>
         <note />
-      </trans-unit>
-      <trans-unit id="ManageDataSelectAllButtonLabel">
-        <source>Select all</source>
-        <target state="new">Select all</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ManageDataSelectDataTypeForResourceButtonLabel">
-        <source>Select {0} for {1}</source>
-        <target state="new">Select {0} for {1}</target>
-        <note>{0} is the data type display name. {1} is the parent resource display name.</note>
-      </trans-unit>
-      <trans-unit id="ManageDataSelectItemButtonLabel">
-        <source>Select {0}</source>
-        <target state="new">Select {0}</target>
-        <note>{0} is the resource or data type display name.</note>
       </trans-unit>
       <trans-unit id="ManageDataStructuredLogs">
         <source>Structured logs</source>

--- a/src/Aspire.Dashboard/Resources/xlf/Dialogs.de.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Dialogs.de.xlf
@@ -484,20 +484,15 @@ For more information about using AI agents with the dashboard, including setting
         <target state="translated">OK</target>
         <note />
       </trans-unit>
-      <trans-unit id="ManageDataDeselectAllButtonLabel">
-        <source>Deselect all</source>
-        <target state="new">Deselect all</target>
+      <trans-unit id="ManageDataAllDataCheckboxLabel">
+        <source>All data</source>
+        <target state="new">All data</target>
         <note />
       </trans-unit>
-      <trans-unit id="ManageDataDeselectDataTypeForResourceButtonLabel">
-        <source>Deselect {0} for {1}</source>
-        <target state="new">Deselect {0} for {1}</target>
+      <trans-unit id="ManageDataDataTypeForResourceCheckboxLabel">
+        <source>{0} for {1}</source>
+        <target state="new">{0} for {1}</target>
         <note>{0} is the data type display name. {1} is the parent resource display name.</note>
-      </trans-unit>
-      <trans-unit id="ManageDataDeselectItemButtonLabel">
-        <source>Deselect {0}</source>
-        <target state="new">Deselect {0}</target>
-        <note>{0} is the resource or data type display name.</note>
       </trans-unit>
       <trans-unit id="ManageDataDialogTitle">
         <source>Manage logs and telemetry</source>
@@ -543,21 +538,6 @@ For more information about using AI agents with the dashboard, including setting
         <source>Resource</source>
         <target state="translated">Ressource</target>
         <note />
-      </trans-unit>
-      <trans-unit id="ManageDataSelectAllButtonLabel">
-        <source>Select all</source>
-        <target state="new">Select all</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ManageDataSelectDataTypeForResourceButtonLabel">
-        <source>Select {0} for {1}</source>
-        <target state="new">Select {0} for {1}</target>
-        <note>{0} is the data type display name. {1} is the parent resource display name.</note>
-      </trans-unit>
-      <trans-unit id="ManageDataSelectItemButtonLabel">
-        <source>Select {0}</source>
-        <target state="new">Select {0}</target>
-        <note>{0} is the resource or data type display name.</note>
       </trans-unit>
       <trans-unit id="ManageDataStructuredLogs">
         <source>Structured logs</source>

--- a/src/Aspire.Dashboard/Resources/xlf/Dialogs.de.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Dialogs.de.xlf
@@ -484,6 +484,21 @@ For more information about using AI agents with the dashboard, including setting
         <target state="translated">OK</target>
         <note />
       </trans-unit>
+      <trans-unit id="ManageDataDeselectAllButtonLabel">
+        <source>Deselect all</source>
+        <target state="new">Deselect all</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ManageDataDeselectDataTypeForResourceButtonLabel">
+        <source>Deselect {0} for {1}</source>
+        <target state="new">Deselect {0} for {1}</target>
+        <note>{0} is the data type display name. {1} is the parent resource display name.</note>
+      </trans-unit>
+      <trans-unit id="ManageDataDeselectItemButtonLabel">
+        <source>Deselect {0}</source>
+        <target state="new">Deselect {0}</target>
+        <note>{0} is the resource or data type display name.</note>
+      </trans-unit>
       <trans-unit id="ManageDataDialogTitle">
         <source>Manage logs and telemetry</source>
         <target state="translated">Protokolle und Telemetrie verwalten</target>
@@ -528,6 +543,21 @@ For more information about using AI agents with the dashboard, including setting
         <source>Resource</source>
         <target state="translated">Ressource</target>
         <note />
+      </trans-unit>
+      <trans-unit id="ManageDataSelectAllButtonLabel">
+        <source>Select all</source>
+        <target state="new">Select all</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ManageDataSelectDataTypeForResourceButtonLabel">
+        <source>Select {0} for {1}</source>
+        <target state="new">Select {0} for {1}</target>
+        <note>{0} is the data type display name. {1} is the parent resource display name.</note>
+      </trans-unit>
+      <trans-unit id="ManageDataSelectItemButtonLabel">
+        <source>Select {0}</source>
+        <target state="new">Select {0}</target>
+        <note>{0} is the resource or data type display name.</note>
       </trans-unit>
       <trans-unit id="ManageDataStructuredLogs">
         <source>Structured logs</source>

--- a/src/Aspire.Dashboard/Resources/xlf/Dialogs.es.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Dialogs.es.xlf
@@ -484,6 +484,21 @@ For more information about using AI agents with the dashboard, including setting
         <target state="translated">Aceptar</target>
         <note />
       </trans-unit>
+      <trans-unit id="ManageDataDeselectAllButtonLabel">
+        <source>Deselect all</source>
+        <target state="new">Deselect all</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ManageDataDeselectDataTypeForResourceButtonLabel">
+        <source>Deselect {0} for {1}</source>
+        <target state="new">Deselect {0} for {1}</target>
+        <note>{0} is the data type display name. {1} is the parent resource display name.</note>
+      </trans-unit>
+      <trans-unit id="ManageDataDeselectItemButtonLabel">
+        <source>Deselect {0}</source>
+        <target state="new">Deselect {0}</target>
+        <note>{0} is the resource or data type display name.</note>
+      </trans-unit>
       <trans-unit id="ManageDataDialogTitle">
         <source>Manage logs and telemetry</source>
         <target state="translated">Administrar registros y telemetría</target>
@@ -528,6 +543,21 @@ For more information about using AI agents with the dashboard, including setting
         <source>Resource</source>
         <target state="translated">Recurso</target>
         <note />
+      </trans-unit>
+      <trans-unit id="ManageDataSelectAllButtonLabel">
+        <source>Select all</source>
+        <target state="new">Select all</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ManageDataSelectDataTypeForResourceButtonLabel">
+        <source>Select {0} for {1}</source>
+        <target state="new">Select {0} for {1}</target>
+        <note>{0} is the data type display name. {1} is the parent resource display name.</note>
+      </trans-unit>
+      <trans-unit id="ManageDataSelectItemButtonLabel">
+        <source>Select {0}</source>
+        <target state="new">Select {0}</target>
+        <note>{0} is the resource or data type display name.</note>
       </trans-unit>
       <trans-unit id="ManageDataStructuredLogs">
         <source>Structured logs</source>

--- a/src/Aspire.Dashboard/Resources/xlf/Dialogs.es.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Dialogs.es.xlf
@@ -484,20 +484,15 @@ For more information about using AI agents with the dashboard, including setting
         <target state="translated">Aceptar</target>
         <note />
       </trans-unit>
-      <trans-unit id="ManageDataDeselectAllButtonLabel">
-        <source>Deselect all</source>
-        <target state="new">Deselect all</target>
+      <trans-unit id="ManageDataAllDataCheckboxLabel">
+        <source>All data</source>
+        <target state="new">All data</target>
         <note />
       </trans-unit>
-      <trans-unit id="ManageDataDeselectDataTypeForResourceButtonLabel">
-        <source>Deselect {0} for {1}</source>
-        <target state="new">Deselect {0} for {1}</target>
+      <trans-unit id="ManageDataDataTypeForResourceCheckboxLabel">
+        <source>{0} for {1}</source>
+        <target state="new">{0} for {1}</target>
         <note>{0} is the data type display name. {1} is the parent resource display name.</note>
-      </trans-unit>
-      <trans-unit id="ManageDataDeselectItemButtonLabel">
-        <source>Deselect {0}</source>
-        <target state="new">Deselect {0}</target>
-        <note>{0} is the resource or data type display name.</note>
       </trans-unit>
       <trans-unit id="ManageDataDialogTitle">
         <source>Manage logs and telemetry</source>
@@ -543,21 +538,6 @@ For more information about using AI agents with the dashboard, including setting
         <source>Resource</source>
         <target state="translated">Recurso</target>
         <note />
-      </trans-unit>
-      <trans-unit id="ManageDataSelectAllButtonLabel">
-        <source>Select all</source>
-        <target state="new">Select all</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ManageDataSelectDataTypeForResourceButtonLabel">
-        <source>Select {0} for {1}</source>
-        <target state="new">Select {0} for {1}</target>
-        <note>{0} is the data type display name. {1} is the parent resource display name.</note>
-      </trans-unit>
-      <trans-unit id="ManageDataSelectItemButtonLabel">
-        <source>Select {0}</source>
-        <target state="new">Select {0}</target>
-        <note>{0} is the resource or data type display name.</note>
       </trans-unit>
       <trans-unit id="ManageDataStructuredLogs">
         <source>Structured logs</source>

--- a/src/Aspire.Dashboard/Resources/xlf/Dialogs.fr.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Dialogs.fr.xlf
@@ -484,20 +484,15 @@ For more information about using AI agents with the dashboard, including setting
         <target state="translated">OK</target>
         <note />
       </trans-unit>
-      <trans-unit id="ManageDataDeselectAllButtonLabel">
-        <source>Deselect all</source>
-        <target state="new">Deselect all</target>
+      <trans-unit id="ManageDataAllDataCheckboxLabel">
+        <source>All data</source>
+        <target state="new">All data</target>
         <note />
       </trans-unit>
-      <trans-unit id="ManageDataDeselectDataTypeForResourceButtonLabel">
-        <source>Deselect {0} for {1}</source>
-        <target state="new">Deselect {0} for {1}</target>
+      <trans-unit id="ManageDataDataTypeForResourceCheckboxLabel">
+        <source>{0} for {1}</source>
+        <target state="new">{0} for {1}</target>
         <note>{0} is the data type display name. {1} is the parent resource display name.</note>
-      </trans-unit>
-      <trans-unit id="ManageDataDeselectItemButtonLabel">
-        <source>Deselect {0}</source>
-        <target state="new">Deselect {0}</target>
-        <note>{0} is the resource or data type display name.</note>
       </trans-unit>
       <trans-unit id="ManageDataDialogTitle">
         <source>Manage logs and telemetry</source>
@@ -543,21 +538,6 @@ For more information about using AI agents with the dashboard, including setting
         <source>Resource</source>
         <target state="translated">Ressource</target>
         <note />
-      </trans-unit>
-      <trans-unit id="ManageDataSelectAllButtonLabel">
-        <source>Select all</source>
-        <target state="new">Select all</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ManageDataSelectDataTypeForResourceButtonLabel">
-        <source>Select {0} for {1}</source>
-        <target state="new">Select {0} for {1}</target>
-        <note>{0} is the data type display name. {1} is the parent resource display name.</note>
-      </trans-unit>
-      <trans-unit id="ManageDataSelectItemButtonLabel">
-        <source>Select {0}</source>
-        <target state="new">Select {0}</target>
-        <note>{0} is the resource or data type display name.</note>
       </trans-unit>
       <trans-unit id="ManageDataStructuredLogs">
         <source>Structured logs</source>

--- a/src/Aspire.Dashboard/Resources/xlf/Dialogs.fr.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Dialogs.fr.xlf
@@ -484,6 +484,21 @@ For more information about using AI agents with the dashboard, including setting
         <target state="translated">OK</target>
         <note />
       </trans-unit>
+      <trans-unit id="ManageDataDeselectAllButtonLabel">
+        <source>Deselect all</source>
+        <target state="new">Deselect all</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ManageDataDeselectDataTypeForResourceButtonLabel">
+        <source>Deselect {0} for {1}</source>
+        <target state="new">Deselect {0} for {1}</target>
+        <note>{0} is the data type display name. {1} is the parent resource display name.</note>
+      </trans-unit>
+      <trans-unit id="ManageDataDeselectItemButtonLabel">
+        <source>Deselect {0}</source>
+        <target state="new">Deselect {0}</target>
+        <note>{0} is the resource or data type display name.</note>
+      </trans-unit>
       <trans-unit id="ManageDataDialogTitle">
         <source>Manage logs and telemetry</source>
         <target state="translated">Gérer les journaux et la télémétrie</target>
@@ -528,6 +543,21 @@ For more information about using AI agents with the dashboard, including setting
         <source>Resource</source>
         <target state="translated">Ressource</target>
         <note />
+      </trans-unit>
+      <trans-unit id="ManageDataSelectAllButtonLabel">
+        <source>Select all</source>
+        <target state="new">Select all</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ManageDataSelectDataTypeForResourceButtonLabel">
+        <source>Select {0} for {1}</source>
+        <target state="new">Select {0} for {1}</target>
+        <note>{0} is the data type display name. {1} is the parent resource display name.</note>
+      </trans-unit>
+      <trans-unit id="ManageDataSelectItemButtonLabel">
+        <source>Select {0}</source>
+        <target state="new">Select {0}</target>
+        <note>{0} is the resource or data type display name.</note>
       </trans-unit>
       <trans-unit id="ManageDataStructuredLogs">
         <source>Structured logs</source>

--- a/src/Aspire.Dashboard/Resources/xlf/Dialogs.it.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Dialogs.it.xlf
@@ -484,20 +484,15 @@ For more information about using AI agents with the dashboard, including setting
         <target state="translated">OK</target>
         <note />
       </trans-unit>
-      <trans-unit id="ManageDataDeselectAllButtonLabel">
-        <source>Deselect all</source>
-        <target state="new">Deselect all</target>
+      <trans-unit id="ManageDataAllDataCheckboxLabel">
+        <source>All data</source>
+        <target state="new">All data</target>
         <note />
       </trans-unit>
-      <trans-unit id="ManageDataDeselectDataTypeForResourceButtonLabel">
-        <source>Deselect {0} for {1}</source>
-        <target state="new">Deselect {0} for {1}</target>
+      <trans-unit id="ManageDataDataTypeForResourceCheckboxLabel">
+        <source>{0} for {1}</source>
+        <target state="new">{0} for {1}</target>
         <note>{0} is the data type display name. {1} is the parent resource display name.</note>
-      </trans-unit>
-      <trans-unit id="ManageDataDeselectItemButtonLabel">
-        <source>Deselect {0}</source>
-        <target state="new">Deselect {0}</target>
-        <note>{0} is the resource or data type display name.</note>
       </trans-unit>
       <trans-unit id="ManageDataDialogTitle">
         <source>Manage logs and telemetry</source>
@@ -543,21 +538,6 @@ For more information about using AI agents with the dashboard, including setting
         <source>Resource</source>
         <target state="translated">Risorsa</target>
         <note />
-      </trans-unit>
-      <trans-unit id="ManageDataSelectAllButtonLabel">
-        <source>Select all</source>
-        <target state="new">Select all</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ManageDataSelectDataTypeForResourceButtonLabel">
-        <source>Select {0} for {1}</source>
-        <target state="new">Select {0} for {1}</target>
-        <note>{0} is the data type display name. {1} is the parent resource display name.</note>
-      </trans-unit>
-      <trans-unit id="ManageDataSelectItemButtonLabel">
-        <source>Select {0}</source>
-        <target state="new">Select {0}</target>
-        <note>{0} is the resource or data type display name.</note>
       </trans-unit>
       <trans-unit id="ManageDataStructuredLogs">
         <source>Structured logs</source>

--- a/src/Aspire.Dashboard/Resources/xlf/Dialogs.it.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Dialogs.it.xlf
@@ -484,6 +484,21 @@ For more information about using AI agents with the dashboard, including setting
         <target state="translated">OK</target>
         <note />
       </trans-unit>
+      <trans-unit id="ManageDataDeselectAllButtonLabel">
+        <source>Deselect all</source>
+        <target state="new">Deselect all</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ManageDataDeselectDataTypeForResourceButtonLabel">
+        <source>Deselect {0} for {1}</source>
+        <target state="new">Deselect {0} for {1}</target>
+        <note>{0} is the data type display name. {1} is the parent resource display name.</note>
+      </trans-unit>
+      <trans-unit id="ManageDataDeselectItemButtonLabel">
+        <source>Deselect {0}</source>
+        <target state="new">Deselect {0}</target>
+        <note>{0} is the resource or data type display name.</note>
+      </trans-unit>
       <trans-unit id="ManageDataDialogTitle">
         <source>Manage logs and telemetry</source>
         <target state="translated">Gestire log e metriche</target>
@@ -528,6 +543,21 @@ For more information about using AI agents with the dashboard, including setting
         <source>Resource</source>
         <target state="translated">Risorsa</target>
         <note />
+      </trans-unit>
+      <trans-unit id="ManageDataSelectAllButtonLabel">
+        <source>Select all</source>
+        <target state="new">Select all</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ManageDataSelectDataTypeForResourceButtonLabel">
+        <source>Select {0} for {1}</source>
+        <target state="new">Select {0} for {1}</target>
+        <note>{0} is the data type display name. {1} is the parent resource display name.</note>
+      </trans-unit>
+      <trans-unit id="ManageDataSelectItemButtonLabel">
+        <source>Select {0}</source>
+        <target state="new">Select {0}</target>
+        <note>{0} is the resource or data type display name.</note>
       </trans-unit>
       <trans-unit id="ManageDataStructuredLogs">
         <source>Structured logs</source>

--- a/src/Aspire.Dashboard/Resources/xlf/Dialogs.ja.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Dialogs.ja.xlf
@@ -484,6 +484,21 @@ For more information about using AI agents with the dashboard, including setting
         <target state="translated">OK</target>
         <note />
       </trans-unit>
+      <trans-unit id="ManageDataDeselectAllButtonLabel">
+        <source>Deselect all</source>
+        <target state="new">Deselect all</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ManageDataDeselectDataTypeForResourceButtonLabel">
+        <source>Deselect {0} for {1}</source>
+        <target state="new">Deselect {0} for {1}</target>
+        <note>{0} is the data type display name. {1} is the parent resource display name.</note>
+      </trans-unit>
+      <trans-unit id="ManageDataDeselectItemButtonLabel">
+        <source>Deselect {0}</source>
+        <target state="new">Deselect {0}</target>
+        <note>{0} is the resource or data type display name.</note>
+      </trans-unit>
       <trans-unit id="ManageDataDialogTitle">
         <source>Manage logs and telemetry</source>
         <target state="translated">リソース ログとテレメトリ</target>
@@ -528,6 +543,21 @@ For more information about using AI agents with the dashboard, including setting
         <source>Resource</source>
         <target state="translated">リソース</target>
         <note />
+      </trans-unit>
+      <trans-unit id="ManageDataSelectAllButtonLabel">
+        <source>Select all</source>
+        <target state="new">Select all</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ManageDataSelectDataTypeForResourceButtonLabel">
+        <source>Select {0} for {1}</source>
+        <target state="new">Select {0} for {1}</target>
+        <note>{0} is the data type display name. {1} is the parent resource display name.</note>
+      </trans-unit>
+      <trans-unit id="ManageDataSelectItemButtonLabel">
+        <source>Select {0}</source>
+        <target state="new">Select {0}</target>
+        <note>{0} is the resource or data type display name.</note>
       </trans-unit>
       <trans-unit id="ManageDataStructuredLogs">
         <source>Structured logs</source>

--- a/src/Aspire.Dashboard/Resources/xlf/Dialogs.ja.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Dialogs.ja.xlf
@@ -484,20 +484,15 @@ For more information about using AI agents with the dashboard, including setting
         <target state="translated">OK</target>
         <note />
       </trans-unit>
-      <trans-unit id="ManageDataDeselectAllButtonLabel">
-        <source>Deselect all</source>
-        <target state="new">Deselect all</target>
+      <trans-unit id="ManageDataAllDataCheckboxLabel">
+        <source>All data</source>
+        <target state="new">All data</target>
         <note />
       </trans-unit>
-      <trans-unit id="ManageDataDeselectDataTypeForResourceButtonLabel">
-        <source>Deselect {0} for {1}</source>
-        <target state="new">Deselect {0} for {1}</target>
+      <trans-unit id="ManageDataDataTypeForResourceCheckboxLabel">
+        <source>{0} for {1}</source>
+        <target state="new">{0} for {1}</target>
         <note>{0} is the data type display name. {1} is the parent resource display name.</note>
-      </trans-unit>
-      <trans-unit id="ManageDataDeselectItemButtonLabel">
-        <source>Deselect {0}</source>
-        <target state="new">Deselect {0}</target>
-        <note>{0} is the resource or data type display name.</note>
       </trans-unit>
       <trans-unit id="ManageDataDialogTitle">
         <source>Manage logs and telemetry</source>
@@ -543,21 +538,6 @@ For more information about using AI agents with the dashboard, including setting
         <source>Resource</source>
         <target state="translated">リソース</target>
         <note />
-      </trans-unit>
-      <trans-unit id="ManageDataSelectAllButtonLabel">
-        <source>Select all</source>
-        <target state="new">Select all</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ManageDataSelectDataTypeForResourceButtonLabel">
-        <source>Select {0} for {1}</source>
-        <target state="new">Select {0} for {1}</target>
-        <note>{0} is the data type display name. {1} is the parent resource display name.</note>
-      </trans-unit>
-      <trans-unit id="ManageDataSelectItemButtonLabel">
-        <source>Select {0}</source>
-        <target state="new">Select {0}</target>
-        <note>{0} is the resource or data type display name.</note>
       </trans-unit>
       <trans-unit id="ManageDataStructuredLogs">
         <source>Structured logs</source>

--- a/src/Aspire.Dashboard/Resources/xlf/Dialogs.ko.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Dialogs.ko.xlf
@@ -484,20 +484,15 @@ For more information about using AI agents with the dashboard, including setting
         <target state="translated">확인</target>
         <note />
       </trans-unit>
-      <trans-unit id="ManageDataDeselectAllButtonLabel">
-        <source>Deselect all</source>
-        <target state="new">Deselect all</target>
+      <trans-unit id="ManageDataAllDataCheckboxLabel">
+        <source>All data</source>
+        <target state="new">All data</target>
         <note />
       </trans-unit>
-      <trans-unit id="ManageDataDeselectDataTypeForResourceButtonLabel">
-        <source>Deselect {0} for {1}</source>
-        <target state="new">Deselect {0} for {1}</target>
+      <trans-unit id="ManageDataDataTypeForResourceCheckboxLabel">
+        <source>{0} for {1}</source>
+        <target state="new">{0} for {1}</target>
         <note>{0} is the data type display name. {1} is the parent resource display name.</note>
-      </trans-unit>
-      <trans-unit id="ManageDataDeselectItemButtonLabel">
-        <source>Deselect {0}</source>
-        <target state="new">Deselect {0}</target>
-        <note>{0} is the resource or data type display name.</note>
       </trans-unit>
       <trans-unit id="ManageDataDialogTitle">
         <source>Manage logs and telemetry</source>
@@ -543,21 +538,6 @@ For more information about using AI agents with the dashboard, including setting
         <source>Resource</source>
         <target state="translated">리소스</target>
         <note />
-      </trans-unit>
-      <trans-unit id="ManageDataSelectAllButtonLabel">
-        <source>Select all</source>
-        <target state="new">Select all</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ManageDataSelectDataTypeForResourceButtonLabel">
-        <source>Select {0} for {1}</source>
-        <target state="new">Select {0} for {1}</target>
-        <note>{0} is the data type display name. {1} is the parent resource display name.</note>
-      </trans-unit>
-      <trans-unit id="ManageDataSelectItemButtonLabel">
-        <source>Select {0}</source>
-        <target state="new">Select {0}</target>
-        <note>{0} is the resource or data type display name.</note>
       </trans-unit>
       <trans-unit id="ManageDataStructuredLogs">
         <source>Structured logs</source>

--- a/src/Aspire.Dashboard/Resources/xlf/Dialogs.ko.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Dialogs.ko.xlf
@@ -484,6 +484,21 @@ For more information about using AI agents with the dashboard, including setting
         <target state="translated">확인</target>
         <note />
       </trans-unit>
+      <trans-unit id="ManageDataDeselectAllButtonLabel">
+        <source>Deselect all</source>
+        <target state="new">Deselect all</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ManageDataDeselectDataTypeForResourceButtonLabel">
+        <source>Deselect {0} for {1}</source>
+        <target state="new">Deselect {0} for {1}</target>
+        <note>{0} is the data type display name. {1} is the parent resource display name.</note>
+      </trans-unit>
+      <trans-unit id="ManageDataDeselectItemButtonLabel">
+        <source>Deselect {0}</source>
+        <target state="new">Deselect {0}</target>
+        <note>{0} is the resource or data type display name.</note>
+      </trans-unit>
       <trans-unit id="ManageDataDialogTitle">
         <source>Manage logs and telemetry</source>
         <target state="translated">로그 및 원격 분석 관리</target>
@@ -528,6 +543,21 @@ For more information about using AI agents with the dashboard, including setting
         <source>Resource</source>
         <target state="translated">리소스</target>
         <note />
+      </trans-unit>
+      <trans-unit id="ManageDataSelectAllButtonLabel">
+        <source>Select all</source>
+        <target state="new">Select all</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ManageDataSelectDataTypeForResourceButtonLabel">
+        <source>Select {0} for {1}</source>
+        <target state="new">Select {0} for {1}</target>
+        <note>{0} is the data type display name. {1} is the parent resource display name.</note>
+      </trans-unit>
+      <trans-unit id="ManageDataSelectItemButtonLabel">
+        <source>Select {0}</source>
+        <target state="new">Select {0}</target>
+        <note>{0} is the resource or data type display name.</note>
       </trans-unit>
       <trans-unit id="ManageDataStructuredLogs">
         <source>Structured logs</source>

--- a/src/Aspire.Dashboard/Resources/xlf/Dialogs.pl.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Dialogs.pl.xlf
@@ -484,20 +484,15 @@ For more information about using AI agents with the dashboard, including setting
         <target state="translated">OK</target>
         <note />
       </trans-unit>
-      <trans-unit id="ManageDataDeselectAllButtonLabel">
-        <source>Deselect all</source>
-        <target state="new">Deselect all</target>
+      <trans-unit id="ManageDataAllDataCheckboxLabel">
+        <source>All data</source>
+        <target state="new">All data</target>
         <note />
       </trans-unit>
-      <trans-unit id="ManageDataDeselectDataTypeForResourceButtonLabel">
-        <source>Deselect {0} for {1}</source>
-        <target state="new">Deselect {0} for {1}</target>
+      <trans-unit id="ManageDataDataTypeForResourceCheckboxLabel">
+        <source>{0} for {1}</source>
+        <target state="new">{0} for {1}</target>
         <note>{0} is the data type display name. {1} is the parent resource display name.</note>
-      </trans-unit>
-      <trans-unit id="ManageDataDeselectItemButtonLabel">
-        <source>Deselect {0}</source>
-        <target state="new">Deselect {0}</target>
-        <note>{0} is the resource or data type display name.</note>
       </trans-unit>
       <trans-unit id="ManageDataDialogTitle">
         <source>Manage logs and telemetry</source>
@@ -543,21 +538,6 @@ For more information about using AI agents with the dashboard, including setting
         <source>Resource</source>
         <target state="translated">Zasób</target>
         <note />
-      </trans-unit>
-      <trans-unit id="ManageDataSelectAllButtonLabel">
-        <source>Select all</source>
-        <target state="new">Select all</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ManageDataSelectDataTypeForResourceButtonLabel">
-        <source>Select {0} for {1}</source>
-        <target state="new">Select {0} for {1}</target>
-        <note>{0} is the data type display name. {1} is the parent resource display name.</note>
-      </trans-unit>
-      <trans-unit id="ManageDataSelectItemButtonLabel">
-        <source>Select {0}</source>
-        <target state="new">Select {0}</target>
-        <note>{0} is the resource or data type display name.</note>
       </trans-unit>
       <trans-unit id="ManageDataStructuredLogs">
         <source>Structured logs</source>

--- a/src/Aspire.Dashboard/Resources/xlf/Dialogs.pl.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Dialogs.pl.xlf
@@ -484,6 +484,21 @@ For more information about using AI agents with the dashboard, including setting
         <target state="translated">OK</target>
         <note />
       </trans-unit>
+      <trans-unit id="ManageDataDeselectAllButtonLabel">
+        <source>Deselect all</source>
+        <target state="new">Deselect all</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ManageDataDeselectDataTypeForResourceButtonLabel">
+        <source>Deselect {0} for {1}</source>
+        <target state="new">Deselect {0} for {1}</target>
+        <note>{0} is the data type display name. {1} is the parent resource display name.</note>
+      </trans-unit>
+      <trans-unit id="ManageDataDeselectItemButtonLabel">
+        <source>Deselect {0}</source>
+        <target state="new">Deselect {0}</target>
+        <note>{0} is the resource or data type display name.</note>
+      </trans-unit>
       <trans-unit id="ManageDataDialogTitle">
         <source>Manage logs and telemetry</source>
         <target state="translated">Zarządzaj dziennikami i danymi telemetrycznymi</target>
@@ -528,6 +543,21 @@ For more information about using AI agents with the dashboard, including setting
         <source>Resource</source>
         <target state="translated">Zasób</target>
         <note />
+      </trans-unit>
+      <trans-unit id="ManageDataSelectAllButtonLabel">
+        <source>Select all</source>
+        <target state="new">Select all</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ManageDataSelectDataTypeForResourceButtonLabel">
+        <source>Select {0} for {1}</source>
+        <target state="new">Select {0} for {1}</target>
+        <note>{0} is the data type display name. {1} is the parent resource display name.</note>
+      </trans-unit>
+      <trans-unit id="ManageDataSelectItemButtonLabel">
+        <source>Select {0}</source>
+        <target state="new">Select {0}</target>
+        <note>{0} is the resource or data type display name.</note>
       </trans-unit>
       <trans-unit id="ManageDataStructuredLogs">
         <source>Structured logs</source>

--- a/src/Aspire.Dashboard/Resources/xlf/Dialogs.pt-BR.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Dialogs.pt-BR.xlf
@@ -484,20 +484,15 @@ For more information about using AI agents with the dashboard, including setting
         <target state="translated">OK</target>
         <note />
       </trans-unit>
-      <trans-unit id="ManageDataDeselectAllButtonLabel">
-        <source>Deselect all</source>
-        <target state="new">Deselect all</target>
+      <trans-unit id="ManageDataAllDataCheckboxLabel">
+        <source>All data</source>
+        <target state="new">All data</target>
         <note />
       </trans-unit>
-      <trans-unit id="ManageDataDeselectDataTypeForResourceButtonLabel">
-        <source>Deselect {0} for {1}</source>
-        <target state="new">Deselect {0} for {1}</target>
+      <trans-unit id="ManageDataDataTypeForResourceCheckboxLabel">
+        <source>{0} for {1}</source>
+        <target state="new">{0} for {1}</target>
         <note>{0} is the data type display name. {1} is the parent resource display name.</note>
-      </trans-unit>
-      <trans-unit id="ManageDataDeselectItemButtonLabel">
-        <source>Deselect {0}</source>
-        <target state="new">Deselect {0}</target>
-        <note>{0} is the resource or data type display name.</note>
       </trans-unit>
       <trans-unit id="ManageDataDialogTitle">
         <source>Manage logs and telemetry</source>
@@ -543,21 +538,6 @@ For more information about using AI agents with the dashboard, including setting
         <source>Resource</source>
         <target state="translated">Recurso</target>
         <note />
-      </trans-unit>
-      <trans-unit id="ManageDataSelectAllButtonLabel">
-        <source>Select all</source>
-        <target state="new">Select all</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ManageDataSelectDataTypeForResourceButtonLabel">
-        <source>Select {0} for {1}</source>
-        <target state="new">Select {0} for {1}</target>
-        <note>{0} is the data type display name. {1} is the parent resource display name.</note>
-      </trans-unit>
-      <trans-unit id="ManageDataSelectItemButtonLabel">
-        <source>Select {0}</source>
-        <target state="new">Select {0}</target>
-        <note>{0} is the resource or data type display name.</note>
       </trans-unit>
       <trans-unit id="ManageDataStructuredLogs">
         <source>Structured logs</source>

--- a/src/Aspire.Dashboard/Resources/xlf/Dialogs.pt-BR.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Dialogs.pt-BR.xlf
@@ -484,6 +484,21 @@ For more information about using AI agents with the dashboard, including setting
         <target state="translated">OK</target>
         <note />
       </trans-unit>
+      <trans-unit id="ManageDataDeselectAllButtonLabel">
+        <source>Deselect all</source>
+        <target state="new">Deselect all</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ManageDataDeselectDataTypeForResourceButtonLabel">
+        <source>Deselect {0} for {1}</source>
+        <target state="new">Deselect {0} for {1}</target>
+        <note>{0} is the data type display name. {1} is the parent resource display name.</note>
+      </trans-unit>
+      <trans-unit id="ManageDataDeselectItemButtonLabel">
+        <source>Deselect {0}</source>
+        <target state="new">Deselect {0}</target>
+        <note>{0} is the resource or data type display name.</note>
+      </trans-unit>
       <trans-unit id="ManageDataDialogTitle">
         <source>Manage logs and telemetry</source>
         <target state="translated">Gerenciar logs e telemetria</target>
@@ -528,6 +543,21 @@ For more information about using AI agents with the dashboard, including setting
         <source>Resource</source>
         <target state="translated">Recurso</target>
         <note />
+      </trans-unit>
+      <trans-unit id="ManageDataSelectAllButtonLabel">
+        <source>Select all</source>
+        <target state="new">Select all</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ManageDataSelectDataTypeForResourceButtonLabel">
+        <source>Select {0} for {1}</source>
+        <target state="new">Select {0} for {1}</target>
+        <note>{0} is the data type display name. {1} is the parent resource display name.</note>
+      </trans-unit>
+      <trans-unit id="ManageDataSelectItemButtonLabel">
+        <source>Select {0}</source>
+        <target state="new">Select {0}</target>
+        <note>{0} is the resource or data type display name.</note>
       </trans-unit>
       <trans-unit id="ManageDataStructuredLogs">
         <source>Structured logs</source>

--- a/src/Aspire.Dashboard/Resources/xlf/Dialogs.ru.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Dialogs.ru.xlf
@@ -484,6 +484,21 @@ For more information about using AI agents with the dashboard, including setting
         <target state="translated">ОК</target>
         <note />
       </trans-unit>
+      <trans-unit id="ManageDataDeselectAllButtonLabel">
+        <source>Deselect all</source>
+        <target state="new">Deselect all</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ManageDataDeselectDataTypeForResourceButtonLabel">
+        <source>Deselect {0} for {1}</source>
+        <target state="new">Deselect {0} for {1}</target>
+        <note>{0} is the data type display name. {1} is the parent resource display name.</note>
+      </trans-unit>
+      <trans-unit id="ManageDataDeselectItemButtonLabel">
+        <source>Deselect {0}</source>
+        <target state="new">Deselect {0}</target>
+        <note>{0} is the resource or data type display name.</note>
+      </trans-unit>
       <trans-unit id="ManageDataDialogTitle">
         <source>Manage logs and telemetry</source>
         <target state="translated">Управление журналами и телеметрией</target>
@@ -528,6 +543,21 @@ For more information about using AI agents with the dashboard, including setting
         <source>Resource</source>
         <target state="translated">Ресурс</target>
         <note />
+      </trans-unit>
+      <trans-unit id="ManageDataSelectAllButtonLabel">
+        <source>Select all</source>
+        <target state="new">Select all</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ManageDataSelectDataTypeForResourceButtonLabel">
+        <source>Select {0} for {1}</source>
+        <target state="new">Select {0} for {1}</target>
+        <note>{0} is the data type display name. {1} is the parent resource display name.</note>
+      </trans-unit>
+      <trans-unit id="ManageDataSelectItemButtonLabel">
+        <source>Select {0}</source>
+        <target state="new">Select {0}</target>
+        <note>{0} is the resource or data type display name.</note>
       </trans-unit>
       <trans-unit id="ManageDataStructuredLogs">
         <source>Structured logs</source>

--- a/src/Aspire.Dashboard/Resources/xlf/Dialogs.ru.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Dialogs.ru.xlf
@@ -484,20 +484,15 @@ For more information about using AI agents with the dashboard, including setting
         <target state="translated">ОК</target>
         <note />
       </trans-unit>
-      <trans-unit id="ManageDataDeselectAllButtonLabel">
-        <source>Deselect all</source>
-        <target state="new">Deselect all</target>
+      <trans-unit id="ManageDataAllDataCheckboxLabel">
+        <source>All data</source>
+        <target state="new">All data</target>
         <note />
       </trans-unit>
-      <trans-unit id="ManageDataDeselectDataTypeForResourceButtonLabel">
-        <source>Deselect {0} for {1}</source>
-        <target state="new">Deselect {0} for {1}</target>
+      <trans-unit id="ManageDataDataTypeForResourceCheckboxLabel">
+        <source>{0} for {1}</source>
+        <target state="new">{0} for {1}</target>
         <note>{0} is the data type display name. {1} is the parent resource display name.</note>
-      </trans-unit>
-      <trans-unit id="ManageDataDeselectItemButtonLabel">
-        <source>Deselect {0}</source>
-        <target state="new">Deselect {0}</target>
-        <note>{0} is the resource or data type display name.</note>
       </trans-unit>
       <trans-unit id="ManageDataDialogTitle">
         <source>Manage logs and telemetry</source>
@@ -543,21 +538,6 @@ For more information about using AI agents with the dashboard, including setting
         <source>Resource</source>
         <target state="translated">Ресурс</target>
         <note />
-      </trans-unit>
-      <trans-unit id="ManageDataSelectAllButtonLabel">
-        <source>Select all</source>
-        <target state="new">Select all</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ManageDataSelectDataTypeForResourceButtonLabel">
-        <source>Select {0} for {1}</source>
-        <target state="new">Select {0} for {1}</target>
-        <note>{0} is the data type display name. {1} is the parent resource display name.</note>
-      </trans-unit>
-      <trans-unit id="ManageDataSelectItemButtonLabel">
-        <source>Select {0}</source>
-        <target state="new">Select {0}</target>
-        <note>{0} is the resource or data type display name.</note>
       </trans-unit>
       <trans-unit id="ManageDataStructuredLogs">
         <source>Structured logs</source>

--- a/src/Aspire.Dashboard/Resources/xlf/Dialogs.tr.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Dialogs.tr.xlf
@@ -484,6 +484,21 @@ For more information about using AI agents with the dashboard, including setting
         <target state="translated">Tamam</target>
         <note />
       </trans-unit>
+      <trans-unit id="ManageDataDeselectAllButtonLabel">
+        <source>Deselect all</source>
+        <target state="new">Deselect all</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ManageDataDeselectDataTypeForResourceButtonLabel">
+        <source>Deselect {0} for {1}</source>
+        <target state="new">Deselect {0} for {1}</target>
+        <note>{0} is the data type display name. {1} is the parent resource display name.</note>
+      </trans-unit>
+      <trans-unit id="ManageDataDeselectItemButtonLabel">
+        <source>Deselect {0}</source>
+        <target state="new">Deselect {0}</target>
+        <note>{0} is the resource or data type display name.</note>
+      </trans-unit>
       <trans-unit id="ManageDataDialogTitle">
         <source>Manage logs and telemetry</source>
         <target state="translated">Günlükleri ve telemetriyi yönet</target>
@@ -528,6 +543,21 @@ For more information about using AI agents with the dashboard, including setting
         <source>Resource</source>
         <target state="translated">Kaynak</target>
         <note />
+      </trans-unit>
+      <trans-unit id="ManageDataSelectAllButtonLabel">
+        <source>Select all</source>
+        <target state="new">Select all</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ManageDataSelectDataTypeForResourceButtonLabel">
+        <source>Select {0} for {1}</source>
+        <target state="new">Select {0} for {1}</target>
+        <note>{0} is the data type display name. {1} is the parent resource display name.</note>
+      </trans-unit>
+      <trans-unit id="ManageDataSelectItemButtonLabel">
+        <source>Select {0}</source>
+        <target state="new">Select {0}</target>
+        <note>{0} is the resource or data type display name.</note>
       </trans-unit>
       <trans-unit id="ManageDataStructuredLogs">
         <source>Structured logs</source>

--- a/src/Aspire.Dashboard/Resources/xlf/Dialogs.tr.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Dialogs.tr.xlf
@@ -484,20 +484,15 @@ For more information about using AI agents with the dashboard, including setting
         <target state="translated">Tamam</target>
         <note />
       </trans-unit>
-      <trans-unit id="ManageDataDeselectAllButtonLabel">
-        <source>Deselect all</source>
-        <target state="new">Deselect all</target>
+      <trans-unit id="ManageDataAllDataCheckboxLabel">
+        <source>All data</source>
+        <target state="new">All data</target>
         <note />
       </trans-unit>
-      <trans-unit id="ManageDataDeselectDataTypeForResourceButtonLabel">
-        <source>Deselect {0} for {1}</source>
-        <target state="new">Deselect {0} for {1}</target>
+      <trans-unit id="ManageDataDataTypeForResourceCheckboxLabel">
+        <source>{0} for {1}</source>
+        <target state="new">{0} for {1}</target>
         <note>{0} is the data type display name. {1} is the parent resource display name.</note>
-      </trans-unit>
-      <trans-unit id="ManageDataDeselectItemButtonLabel">
-        <source>Deselect {0}</source>
-        <target state="new">Deselect {0}</target>
-        <note>{0} is the resource or data type display name.</note>
       </trans-unit>
       <trans-unit id="ManageDataDialogTitle">
         <source>Manage logs and telemetry</source>
@@ -543,21 +538,6 @@ For more information about using AI agents with the dashboard, including setting
         <source>Resource</source>
         <target state="translated">Kaynak</target>
         <note />
-      </trans-unit>
-      <trans-unit id="ManageDataSelectAllButtonLabel">
-        <source>Select all</source>
-        <target state="new">Select all</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ManageDataSelectDataTypeForResourceButtonLabel">
-        <source>Select {0} for {1}</source>
-        <target state="new">Select {0} for {1}</target>
-        <note>{0} is the data type display name. {1} is the parent resource display name.</note>
-      </trans-unit>
-      <trans-unit id="ManageDataSelectItemButtonLabel">
-        <source>Select {0}</source>
-        <target state="new">Select {0}</target>
-        <note>{0} is the resource or data type display name.</note>
       </trans-unit>
       <trans-unit id="ManageDataStructuredLogs">
         <source>Structured logs</source>

--- a/src/Aspire.Dashboard/Resources/xlf/Dialogs.zh-Hans.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Dialogs.zh-Hans.xlf
@@ -484,6 +484,21 @@ For more information about using AI agents with the dashboard, including setting
         <target state="translated">确定</target>
         <note />
       </trans-unit>
+      <trans-unit id="ManageDataDeselectAllButtonLabel">
+        <source>Deselect all</source>
+        <target state="new">Deselect all</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ManageDataDeselectDataTypeForResourceButtonLabel">
+        <source>Deselect {0} for {1}</source>
+        <target state="new">Deselect {0} for {1}</target>
+        <note>{0} is the data type display name. {1} is the parent resource display name.</note>
+      </trans-unit>
+      <trans-unit id="ManageDataDeselectItemButtonLabel">
+        <source>Deselect {0}</source>
+        <target state="new">Deselect {0}</target>
+        <note>{0} is the resource or data type display name.</note>
+      </trans-unit>
       <trans-unit id="ManageDataDialogTitle">
         <source>Manage logs and telemetry</source>
         <target state="translated">管理日志和遥测</target>
@@ -528,6 +543,21 @@ For more information about using AI agents with the dashboard, including setting
         <source>Resource</source>
         <target state="translated">资源</target>
         <note />
+      </trans-unit>
+      <trans-unit id="ManageDataSelectAllButtonLabel">
+        <source>Select all</source>
+        <target state="new">Select all</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ManageDataSelectDataTypeForResourceButtonLabel">
+        <source>Select {0} for {1}</source>
+        <target state="new">Select {0} for {1}</target>
+        <note>{0} is the data type display name. {1} is the parent resource display name.</note>
+      </trans-unit>
+      <trans-unit id="ManageDataSelectItemButtonLabel">
+        <source>Select {0}</source>
+        <target state="new">Select {0}</target>
+        <note>{0} is the resource or data type display name.</note>
       </trans-unit>
       <trans-unit id="ManageDataStructuredLogs">
         <source>Structured logs</source>

--- a/src/Aspire.Dashboard/Resources/xlf/Dialogs.zh-Hans.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Dialogs.zh-Hans.xlf
@@ -484,20 +484,15 @@ For more information about using AI agents with the dashboard, including setting
         <target state="translated">确定</target>
         <note />
       </trans-unit>
-      <trans-unit id="ManageDataDeselectAllButtonLabel">
-        <source>Deselect all</source>
-        <target state="new">Deselect all</target>
+      <trans-unit id="ManageDataAllDataCheckboxLabel">
+        <source>All data</source>
+        <target state="new">All data</target>
         <note />
       </trans-unit>
-      <trans-unit id="ManageDataDeselectDataTypeForResourceButtonLabel">
-        <source>Deselect {0} for {1}</source>
-        <target state="new">Deselect {0} for {1}</target>
+      <trans-unit id="ManageDataDataTypeForResourceCheckboxLabel">
+        <source>{0} for {1}</source>
+        <target state="new">{0} for {1}</target>
         <note>{0} is the data type display name. {1} is the parent resource display name.</note>
-      </trans-unit>
-      <trans-unit id="ManageDataDeselectItemButtonLabel">
-        <source>Deselect {0}</source>
-        <target state="new">Deselect {0}</target>
-        <note>{0} is the resource or data type display name.</note>
       </trans-unit>
       <trans-unit id="ManageDataDialogTitle">
         <source>Manage logs and telemetry</source>
@@ -543,21 +538,6 @@ For more information about using AI agents with the dashboard, including setting
         <source>Resource</source>
         <target state="translated">资源</target>
         <note />
-      </trans-unit>
-      <trans-unit id="ManageDataSelectAllButtonLabel">
-        <source>Select all</source>
-        <target state="new">Select all</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ManageDataSelectDataTypeForResourceButtonLabel">
-        <source>Select {0} for {1}</source>
-        <target state="new">Select {0} for {1}</target>
-        <note>{0} is the data type display name. {1} is the parent resource display name.</note>
-      </trans-unit>
-      <trans-unit id="ManageDataSelectItemButtonLabel">
-        <source>Select {0}</source>
-        <target state="new">Select {0}</target>
-        <note>{0} is the resource or data type display name.</note>
       </trans-unit>
       <trans-unit id="ManageDataStructuredLogs">
         <source>Structured logs</source>

--- a/src/Aspire.Dashboard/Resources/xlf/Dialogs.zh-Hant.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Dialogs.zh-Hant.xlf
@@ -484,6 +484,21 @@ For more information about using AI agents with the dashboard, including setting
         <target state="translated">確定</target>
         <note />
       </trans-unit>
+      <trans-unit id="ManageDataDeselectAllButtonLabel">
+        <source>Deselect all</source>
+        <target state="new">Deselect all</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ManageDataDeselectDataTypeForResourceButtonLabel">
+        <source>Deselect {0} for {1}</source>
+        <target state="new">Deselect {0} for {1}</target>
+        <note>{0} is the data type display name. {1} is the parent resource display name.</note>
+      </trans-unit>
+      <trans-unit id="ManageDataDeselectItemButtonLabel">
+        <source>Deselect {0}</source>
+        <target state="new">Deselect {0}</target>
+        <note>{0} is the resource or data type display name.</note>
+      </trans-unit>
       <trans-unit id="ManageDataDialogTitle">
         <source>Manage logs and telemetry</source>
         <target state="translated">管理記錄與遙測</target>
@@ -528,6 +543,21 @@ For more information about using AI agents with the dashboard, including setting
         <source>Resource</source>
         <target state="translated">資源</target>
         <note />
+      </trans-unit>
+      <trans-unit id="ManageDataSelectAllButtonLabel">
+        <source>Select all</source>
+        <target state="new">Select all</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ManageDataSelectDataTypeForResourceButtonLabel">
+        <source>Select {0} for {1}</source>
+        <target state="new">Select {0} for {1}</target>
+        <note>{0} is the data type display name. {1} is the parent resource display name.</note>
+      </trans-unit>
+      <trans-unit id="ManageDataSelectItemButtonLabel">
+        <source>Select {0}</source>
+        <target state="new">Select {0}</target>
+        <note>{0} is the resource or data type display name.</note>
       </trans-unit>
       <trans-unit id="ManageDataStructuredLogs">
         <source>Structured logs</source>

--- a/src/Aspire.Dashboard/Resources/xlf/Dialogs.zh-Hant.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Dialogs.zh-Hant.xlf
@@ -484,20 +484,15 @@ For more information about using AI agents with the dashboard, including setting
         <target state="translated">確定</target>
         <note />
       </trans-unit>
-      <trans-unit id="ManageDataDeselectAllButtonLabel">
-        <source>Deselect all</source>
-        <target state="new">Deselect all</target>
+      <trans-unit id="ManageDataAllDataCheckboxLabel">
+        <source>All data</source>
+        <target state="new">All data</target>
         <note />
       </trans-unit>
-      <trans-unit id="ManageDataDeselectDataTypeForResourceButtonLabel">
-        <source>Deselect {0} for {1}</source>
-        <target state="new">Deselect {0} for {1}</target>
+      <trans-unit id="ManageDataDataTypeForResourceCheckboxLabel">
+        <source>{0} for {1}</source>
+        <target state="new">{0} for {1}</target>
         <note>{0} is the data type display name. {1} is the parent resource display name.</note>
-      </trans-unit>
-      <trans-unit id="ManageDataDeselectItemButtonLabel">
-        <source>Deselect {0}</source>
-        <target state="new">Deselect {0}</target>
-        <note>{0} is the resource or data type display name.</note>
       </trans-unit>
       <trans-unit id="ManageDataDialogTitle">
         <source>Manage logs and telemetry</source>
@@ -543,21 +538,6 @@ For more information about using AI agents with the dashboard, including setting
         <source>Resource</source>
         <target state="translated">資源</target>
         <note />
-      </trans-unit>
-      <trans-unit id="ManageDataSelectAllButtonLabel">
-        <source>Select all</source>
-        <target state="new">Select all</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ManageDataSelectDataTypeForResourceButtonLabel">
-        <source>Select {0} for {1}</source>
-        <target state="new">Select {0} for {1}</target>
-        <note>{0} is the data type display name. {1} is the parent resource display name.</note>
-      </trans-unit>
-      <trans-unit id="ManageDataSelectItemButtonLabel">
-        <source>Select {0}</source>
-        <target state="new">Select {0}</target>
-        <note>{0} is the resource or data type display name.</note>
       </trans-unit>
       <trans-unit id="ManageDataStructuredLogs">
         <source>Structured logs</source>

--- a/tests/Aspire.Dashboard.Components.Tests/Dialogs/ManageDataDialogTests.cs
+++ b/tests/Aspire.Dashboard.Components.Tests/Dialogs/ManageDataDialogTests.cs
@@ -2,17 +2,17 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Threading.Channels;
+using AngleSharp.Dom;
 using Aspire.Dashboard.Components.Dialogs;
 using Aspire.Dashboard.Components.Tests.Shared;
 using Aspire.Dashboard.Configuration;
 using Aspire.Dashboard.Model;
+using Aspire.Dashboard.Model.ManageData;
 using Aspire.Dashboard.Tests.Shared;
 using Aspire.Tests.Shared.DashboardModel;
-using AngleSharp.Dom;
 using Bunit;
 using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Logging;
-using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.FluentUI.AspNetCore.Components;
 using Xunit;
 
 namespace Aspire.Dashboard.Components.Tests.Dialogs;
@@ -21,7 +21,7 @@ namespace Aspire.Dashboard.Components.Tests.Dialogs;
 public sealed class ManageDataDialogTests : DashboardTestContext
 {
     [Fact]
-    public void Render_SelectionButtons_HaveAccessibleNames()
+    public void Render_SelectionControlsExposeAccessibleNamesCheckboxRoleAndState()
     {
         var basketResource = ModelTestHelpers.CreateResource(
             resourceName: "basket",
@@ -36,14 +36,16 @@ public sealed class ManageDataDialogTests : DashboardTestContext
             isEnabled: true,
             initialResources: [basketResource, catalogResource],
             resourceChannelProvider: () => resourcesChannel);
-
         SetupManageDataDialogServices(dashboardClient);
 
         var cut = RenderComponent<ManageDataDialog>();
 
         cut.WaitForAssertion(() =>
         {
-            AssertSelectionButtonHasAccessibleName(cut, "Deselect all");
+            AssertSelectionCheckboxCount(cut, 3);
+            AssertSelectionCheckbox(cut, "Deselect all", "true");
+            AssertSelectionCheckbox(cut, "Deselect Basket service", "true");
+            AssertSelectionCheckbox(cut, "Deselect Catalog service", "true");
             AssertNoButtonHasAccessibleName(cut, "Name");
         });
 
@@ -51,39 +53,48 @@ public sealed class ManageDataDialogTests : DashboardTestContext
 
         cut.WaitForAssertion(() =>
         {
-            AssertSelectionButtonInRowHasAccessibleName(cut, "Basket service", "Deselect Basket service");
-            AssertSelectionButtonInRowHasAccessibleName(cut, "Catalog service", "Deselect Catalog service");
-            AssertNestedRowSelectionLabels(
-                cut,
-                "Resource",
-                "Deselect Resource for Basket service",
-                "Deselect Resource for Catalog service");
-            AssertNestedRowSelectionLabels(
-                cut,
-                "Console logs",
-                "Deselect Console logs for Basket service",
-                "Deselect Console logs for Catalog service");
+            AssertAllSelectionControlsSelected(cut);
             AssertNoButtonHasAccessibleName(cut, "Deselect Console logs");
             AssertNoButtonHasAccessibleName(cut, "Name");
         });
 
-        cut.Find("fluent-button[aria-label='Deselect all']").Click();
+        AssertSelectionCheckbox(cut, "Deselect Console logs for Basket service", "true").Click();
 
         cut.WaitForAssertion(() =>
         {
-            AssertSelectionButtonHasAccessibleName(cut, "Select all");
-            AssertSelectionButtonInRowHasAccessibleName(cut, "Basket service", "Select Basket service");
-            AssertSelectionButtonInRowHasAccessibleName(cut, "Catalog service", "Select Catalog service");
-            AssertNestedRowSelectionLabels(
-                cut,
-                "Resource",
-                "Select Resource for Basket service",
-                "Select Resource for Catalog service");
-            AssertNestedRowSelectionLabels(
-                cut,
-                "Console logs",
-                "Select Console logs for Basket service",
-                "Select Console logs for Catalog service");
+            AssertSelectionCheckboxCount(cut, 7);
+            AssertSelectionCheckbox(cut, "Select all", "mixed");
+            AssertSelectionCheckbox(cut, "Select Basket service", "mixed");
+            AssertSelectionCheckbox(cut, "Deselect Catalog service", "true");
+            AssertSelectionCheckbox(cut, "Deselect Resource for Basket service", "true");
+            AssertSelectionCheckbox(cut, "Select Console logs for Basket service", "false");
+            AssertSelectionCheckbox(cut, "Deselect Resource for Catalog service", "true");
+            AssertSelectionCheckbox(cut, "Deselect Console logs for Catalog service", "true");
+            AssertNoButtonHasAccessibleName(cut, "Select Console logs");
+            AssertNoButtonHasAccessibleName(cut, "Name");
+        });
+
+        AssertSelectionCheckbox(cut, "Select all", "mixed").Click();
+
+        cut.WaitForAssertion(() =>
+        {
+            AssertAllSelectionControlsSelected(cut);
+            AssertNoButtonHasAccessibleName(cut, "Deselect Console logs");
+            AssertNoButtonHasAccessibleName(cut, "Name");
+        });
+
+        AssertSelectionCheckbox(cut, "Deselect all", "true").Click();
+
+        cut.WaitForAssertion(() =>
+        {
+            AssertSelectionCheckboxCount(cut, 7);
+            AssertSelectionCheckbox(cut, "Select all", "false");
+            AssertSelectionCheckbox(cut, "Select Basket service", "false");
+            AssertSelectionCheckbox(cut, "Select Catalog service", "false");
+            AssertSelectionCheckbox(cut, "Select Resource for Basket service", "false");
+            AssertSelectionCheckbox(cut, "Select Console logs for Basket service", "false");
+            AssertSelectionCheckbox(cut, "Select Resource for Catalog service", "false");
+            AssertSelectionCheckbox(cut, "Select Console logs for Catalog service", "false");
             AssertNoButtonHasAccessibleName(cut, "Select Console logs");
             AssertNoButtonHasAccessibleName(cut, "Name");
         });
@@ -93,14 +104,13 @@ public sealed class ManageDataDialogTests : DashboardTestContext
     {
         FluentUISetupHelpers.AddCommonDashboardServices(this);
         Services.AddLogging();
-        Services.AddSingleton<ILoggerFactory>(NullLoggerFactory.Instance);
         Services.AddOptions<DashboardOptions>().Configure(options => options.UI.DisableImport = true);
-        Services.AddSingleton<IDashboardClient>(dashboardClient);
         Services.AddSingleton<IconResolver>();
-        Services.AddSingleton<ConsoleLogsManager>();
-        Services.AddSingleton<ConsoleLogsFetcher>();
-        Services.AddSingleton<TelemetryExportService>();
-        Services.AddSingleton<TelemetryImportService>();
+        Services.AddSingleton<IDashboardClient>(dashboardClient);
+        Services.AddScoped<ConsoleLogsManager>();
+        Services.AddScoped<ConsoleLogsFetcher>();
+        Services.AddScoped<TelemetryExportService>();
+        Services.AddScoped<TelemetryImportService>();
 
         FluentUISetupHelpers.SetupFluentUIComponents(this);
         FluentUISetupHelpers.SetupFluentButton(this);
@@ -119,30 +129,30 @@ public sealed class ManageDataDialogTests : DashboardTestContext
         }
     }
 
-    private static void AssertSelectionButtonHasAccessibleName(IRenderedComponent<ManageDataDialog> cut, string accessibleName)
+    private static void AssertAllSelectionControlsSelected(IRenderedComponent<ManageDataDialog> cut)
     {
-        Assert.Contains(cut.FindAll("fluent-button"), button => ButtonHasAccessibleName(button, accessibleName));
+        AssertSelectionCheckboxCount(cut, 7);
+        AssertSelectionCheckbox(cut, "Deselect all", "true");
+        AssertSelectionCheckbox(cut, "Deselect Basket service", "true");
+        AssertSelectionCheckbox(cut, "Deselect Catalog service", "true");
+        AssertSelectionCheckbox(cut, "Deselect Resource for Basket service", "true");
+        AssertSelectionCheckbox(cut, "Deselect Console logs for Basket service", "true");
+        AssertSelectionCheckbox(cut, "Deselect Resource for Catalog service", "true");
+        AssertSelectionCheckbox(cut, "Deselect Console logs for Catalog service", "true");
     }
 
-    private static void AssertSelectionButtonInRowHasAccessibleName(IRenderedComponent<ManageDataDialog> cut, string visibleText, string accessibleName)
+    private static IElement AssertSelectionCheckbox(IRenderedComponent<ManageDataDialog> cut, string accessibleName, string ariaChecked)
     {
-        var row = Assert.Single(cut.FindAll(".fluent-data-grid-row"), row => row.TextContent.Contains(visibleText, StringComparison.Ordinal));
+        var button = Assert.Single(GetSelectionCheckboxes(cut), button => ButtonHasAccessibleName(button, accessibleName));
 
-        Assert.Contains(row.QuerySelectorAll("fluent-button"), button => ButtonHasAccessibleName(button, accessibleName));
+        Assert.Equal("checkbox", button.GetAttribute("role"));
+        Assert.Equal(ariaChecked, button.GetAttribute("aria-checked"));
+
+        return button;
     }
 
-    private static void AssertNestedRowSelectionLabels(IRenderedComponent<ManageDataDialog> cut, string visibleText, params string[] expectedAccessibleNames)
-    {
-        var accessibleNames = cut.FindAll(".fluent-data-grid-row")
-            .Where(row => row.TextContent.Contains(visibleText, StringComparison.Ordinal))
-            .Select(GetOnlySelectionButtonAccessibleName)
-            .ToArray();
-
-        Assert.Equal(
-            expectedAccessibleNames.OrderBy(name => name, StringComparer.Ordinal),
-            accessibleNames.OrderBy(name => name, StringComparer.Ordinal));
-        Assert.Equal(accessibleNames.Length, accessibleNames.Distinct(StringComparer.Ordinal).Count());
-    }
+    private static void AssertSelectionCheckboxCount(IRenderedComponent<ManageDataDialog> cut, int expectedCount) =>
+        Assert.Equal(expectedCount, GetSelectionCheckboxes(cut).Count);
 
     private static void AssertNoButtonHasAccessibleName(IRenderedComponent<ManageDataDialog> cut, string accessibleName) =>
         Assert.DoesNotContain(
@@ -155,14 +165,8 @@ public sealed class ManageDataDialogTests : DashboardTestContext
         string.Equals(button.GetAttribute("title"), accessibleName, StringComparison.Ordinal) &&
         string.Equals(button.GetAttribute("aria-label"), accessibleName, StringComparison.Ordinal);
 
-    private static string GetOnlySelectionButtonAccessibleName(IElement row)
+    private static IReadOnlyList<IElement> GetSelectionCheckboxes(IRenderedComponent<ManageDataDialog> cut)
     {
-        var button = Assert.Single(row.QuerySelectorAll("fluent-button"));
-        var title = button.GetAttribute("title");
-
-        Assert.False(string.IsNullOrEmpty(title));
-        Assert.Equal(title, button.GetAttribute("aria-label"));
-
-        return title;
+        return cut.FindComponent<FluentDataGrid<ManageDataGridItem>>().FindAll("[role='checkbox']");
     }
 }

--- a/tests/Aspire.Dashboard.Components.Tests/Dialogs/ManageDataDialogTests.cs
+++ b/tests/Aspire.Dashboard.Components.Tests/Dialogs/ManageDataDialogTests.cs
@@ -11,7 +11,10 @@ using Aspire.Dashboard.Model.ManageData;
 using Aspire.Dashboard.Tests.Shared;
 using Aspire.Tests.Shared.DashboardModel;
 using Bunit;
+using Microsoft.AspNetCore.Components.Web;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.FluentUI.AspNetCore.Components;
 using Xunit;
 
@@ -43,10 +46,40 @@ public sealed class ManageDataDialogTests : DashboardTestContext
         cut.WaitForAssertion(() =>
         {
             AssertSelectionCheckboxCount(cut, 3);
-            AssertSelectionCheckbox(cut, "Deselect all", "true");
-            AssertSelectionCheckbox(cut, "Deselect Basket service", "true");
-            AssertSelectionCheckbox(cut, "Deselect Catalog service", "true");
+            AssertSelectionCheckbox(cut, "All data", "true");
+            AssertSelectionCheckbox(cut, "Basket service", "true");
+            AssertSelectionCheckbox(cut, "Catalog service", "true");
+            AssertSelectionCheckboxesHaveNoActionLabels(cut);
             AssertNoButtonHasAccessibleName(cut, "Name");
+        });
+
+        PressKey(AssertSelectionCheckbox(cut, "Basket service", "true"), "Tab");
+        AssertSelectionCheckbox(cut, "Basket service", "true");
+
+        PressKey(AssertSelectionCheckbox(cut, "Basket service", "true"), "Tab", shiftKey: true);
+        AssertSelectionCheckbox(cut, "Basket service", "true");
+
+        PressKey(AssertSelectionCheckbox(cut, "Basket service", "true"), "Enter");
+        AssertSelectionCheckbox(cut, "Basket service", "true");
+
+        PressSpace(AssertSelectionCheckbox(cut, "Basket service", "true"));
+
+        cut.WaitForAssertion(() =>
+        {
+            AssertSelectionCheckboxCount(cut, 3);
+            AssertSelectionCheckbox(cut, "All data", "mixed");
+            AssertSelectionCheckbox(cut, "Basket service", "false");
+            AssertSelectionCheckbox(cut, "Catalog service", "true");
+        });
+
+        PressSpace(AssertSelectionCheckbox(cut, "Basket service", "false"));
+
+        cut.WaitForAssertion(() =>
+        {
+            AssertSelectionCheckboxCount(cut, 3);
+            AssertSelectionCheckbox(cut, "All data", "true");
+            AssertSelectionCheckbox(cut, "Basket service", "true");
+            AssertSelectionCheckbox(cut, "Catalog service", "true");
         });
 
         ExpandResourceRows(cut, expectedCount: 2);
@@ -54,48 +87,50 @@ public sealed class ManageDataDialogTests : DashboardTestContext
         cut.WaitForAssertion(() =>
         {
             AssertAllSelectionControlsSelected(cut);
-            AssertNoButtonHasAccessibleName(cut, "Deselect Console logs");
+            AssertNoSelectionCheckboxHasAccessibleName(cut, "Console logs");
             AssertNoButtonHasAccessibleName(cut, "Name");
         });
 
-        AssertSelectionCheckbox(cut, "Deselect Console logs for Basket service", "true").Click();
+        AssertSelectionCheckbox(cut, "Console logs for Basket service", "true").Click();
 
         cut.WaitForAssertion(() =>
         {
             AssertSelectionCheckboxCount(cut, 7);
-            AssertSelectionCheckbox(cut, "Select all", "mixed");
-            AssertSelectionCheckbox(cut, "Select Basket service", "mixed");
-            AssertSelectionCheckbox(cut, "Deselect Catalog service", "true");
-            AssertSelectionCheckbox(cut, "Deselect Resource for Basket service", "true");
-            AssertSelectionCheckbox(cut, "Select Console logs for Basket service", "false");
-            AssertSelectionCheckbox(cut, "Deselect Resource for Catalog service", "true");
-            AssertSelectionCheckbox(cut, "Deselect Console logs for Catalog service", "true");
-            AssertNoButtonHasAccessibleName(cut, "Select Console logs");
+            AssertSelectionCheckbox(cut, "All data", "mixed");
+            AssertSelectionCheckbox(cut, "Basket service", "mixed");
+            AssertSelectionCheckbox(cut, "Catalog service", "true");
+            AssertSelectionCheckbox(cut, "Resource for Basket service", "true");
+            AssertSelectionCheckbox(cut, "Console logs for Basket service", "false");
+            AssertSelectionCheckbox(cut, "Resource for Catalog service", "true");
+            AssertSelectionCheckbox(cut, "Console logs for Catalog service", "true");
+            AssertSelectionCheckboxesHaveNoActionLabels(cut);
+            AssertNoSelectionCheckboxHasAccessibleName(cut, "Console logs");
             AssertNoButtonHasAccessibleName(cut, "Name");
         });
 
-        AssertSelectionCheckbox(cut, "Select all", "mixed").Click();
+        AssertSelectionCheckbox(cut, "All data", "mixed").Click();
 
         cut.WaitForAssertion(() =>
         {
             AssertAllSelectionControlsSelected(cut);
-            AssertNoButtonHasAccessibleName(cut, "Deselect Console logs");
+            AssertNoSelectionCheckboxHasAccessibleName(cut, "Console logs");
             AssertNoButtonHasAccessibleName(cut, "Name");
         });
 
-        AssertSelectionCheckbox(cut, "Deselect all", "true").Click();
+        AssertSelectionCheckbox(cut, "All data", "true").Click();
 
         cut.WaitForAssertion(() =>
         {
             AssertSelectionCheckboxCount(cut, 7);
-            AssertSelectionCheckbox(cut, "Select all", "false");
-            AssertSelectionCheckbox(cut, "Select Basket service", "false");
-            AssertSelectionCheckbox(cut, "Select Catalog service", "false");
-            AssertSelectionCheckbox(cut, "Select Resource for Basket service", "false");
-            AssertSelectionCheckbox(cut, "Select Console logs for Basket service", "false");
-            AssertSelectionCheckbox(cut, "Select Resource for Catalog service", "false");
-            AssertSelectionCheckbox(cut, "Select Console logs for Catalog service", "false");
-            AssertNoButtonHasAccessibleName(cut, "Select Console logs");
+            AssertSelectionCheckbox(cut, "All data", "false");
+            AssertSelectionCheckbox(cut, "Basket service", "false");
+            AssertSelectionCheckbox(cut, "Catalog service", "false");
+            AssertSelectionCheckbox(cut, "Resource for Basket service", "false");
+            AssertSelectionCheckbox(cut, "Console logs for Basket service", "false");
+            AssertSelectionCheckbox(cut, "Resource for Catalog service", "false");
+            AssertSelectionCheckbox(cut, "Console logs for Catalog service", "false");
+            AssertSelectionCheckboxesHaveNoActionLabels(cut);
+            AssertNoSelectionCheckboxHasAccessibleName(cut, "Console logs");
             AssertNoButtonHasAccessibleName(cut, "Name");
         });
     }
@@ -103,18 +138,22 @@ public sealed class ManageDataDialogTests : DashboardTestContext
     private void SetupManageDataDialogServices(TestDashboardClient dashboardClient)
     {
         FluentUISetupHelpers.AddCommonDashboardServices(this);
-        Services.AddLogging();
+        Services.AddSingleton<ILoggerFactory>(NullLoggerFactory.Instance);
         Services.AddOptions<DashboardOptions>().Configure(options => options.UI.DisableImport = true);
-        Services.AddSingleton<IconResolver>();
         Services.AddSingleton<IDashboardClient>(dashboardClient);
-        Services.AddScoped<ConsoleLogsManager>();
-        Services.AddScoped<ConsoleLogsFetcher>();
-        Services.AddScoped<TelemetryExportService>();
-        Services.AddScoped<TelemetryImportService>();
+        Services.AddSingleton<IconResolver>();
+        Services.AddSingleton<ConsoleLogsManager>();
+        Services.AddSingleton<ConsoleLogsFetcher>();
+        Services.AddSingleton<TelemetryExportService>();
+        Services.AddSingleton<TelemetryImportService>();
 
         FluentUISetupHelpers.SetupFluentUIComponents(this);
         FluentUISetupHelpers.SetupFluentButton(this);
         FluentUISetupHelpers.SetupFluentDataGrid(this);
+
+        var module = JSInterop.SetupModule("./Components/Dialogs/ManageDataDialog.razor.js");
+        module.SetupVoid("initializeSelectionCheckboxKeyboard", _ => true);
+        module.SetupVoid("disposeSelectionCheckboxKeyboard", _ => true);
     }
 
     private static void ExpandResourceRows(IRenderedComponent<ManageDataDialog> cut, int expectedCount)
@@ -132,38 +171,66 @@ public sealed class ManageDataDialogTests : DashboardTestContext
     private static void AssertAllSelectionControlsSelected(IRenderedComponent<ManageDataDialog> cut)
     {
         AssertSelectionCheckboxCount(cut, 7);
-        AssertSelectionCheckbox(cut, "Deselect all", "true");
-        AssertSelectionCheckbox(cut, "Deselect Basket service", "true");
-        AssertSelectionCheckbox(cut, "Deselect Catalog service", "true");
-        AssertSelectionCheckbox(cut, "Deselect Resource for Basket service", "true");
-        AssertSelectionCheckbox(cut, "Deselect Console logs for Basket service", "true");
-        AssertSelectionCheckbox(cut, "Deselect Resource for Catalog service", "true");
-        AssertSelectionCheckbox(cut, "Deselect Console logs for Catalog service", "true");
+        AssertSelectionCheckbox(cut, "All data", "true");
+        AssertSelectionCheckbox(cut, "Basket service", "true");
+        AssertSelectionCheckbox(cut, "Catalog service", "true");
+        AssertSelectionCheckbox(cut, "Resource for Basket service", "true");
+        AssertSelectionCheckbox(cut, "Console logs for Basket service", "true");
+        AssertSelectionCheckbox(cut, "Resource for Catalog service", "true");
+        AssertSelectionCheckbox(cut, "Console logs for Catalog service", "true");
+        AssertSelectionCheckboxesHaveNoActionLabels(cut);
     }
 
     private static IElement AssertSelectionCheckbox(IRenderedComponent<ManageDataDialog> cut, string accessibleName, string ariaChecked)
     {
-        var button = Assert.Single(GetSelectionCheckboxes(cut), button => ButtonHasAccessibleName(button, accessibleName));
+        var checkbox = Assert.Single(GetSelectionCheckboxes(cut), checkbox => ElementHasAccessibleName(checkbox, accessibleName));
 
-        Assert.Equal("checkbox", button.GetAttribute("role"));
-        Assert.Equal(ariaChecked, button.GetAttribute("aria-checked"));
+        Assert.Equal("span", checkbox.LocalName);
+        Assert.Equal("checkbox", checkbox.GetAttribute("role"));
+        Assert.Equal(ariaChecked, checkbox.GetAttribute("aria-checked"));
+        Assert.Equal("0", checkbox.GetAttribute("tabindex"));
+        Assert.Empty(checkbox.QuerySelectorAll("fluent-button"));
 
-        return button;
+        return checkbox;
     }
 
-    private static void AssertSelectionCheckboxCount(IRenderedComponent<ManageDataDialog> cut, int expectedCount) =>
+    private static void AssertSelectionCheckboxCount(IRenderedComponent<ManageDataDialog> cut, int expectedCount)
+    {
+        Assert.Empty(cut.FindAll("fluent-button[role='checkbox']"));
         Assert.Equal(expectedCount, GetSelectionCheckboxes(cut).Count);
+    }
+
+    private static void AssertSelectionCheckboxesHaveNoActionLabels(IRenderedComponent<ManageDataDialog> cut)
+    {
+        Assert.DoesNotContain(GetSelectionCheckboxes(cut), button =>
+        {
+            var accessibleName = button.GetAttribute("aria-label");
+
+            return accessibleName is not null &&
+                (accessibleName.StartsWith("Select ", StringComparison.Ordinal) ||
+                 accessibleName.StartsWith("Deselect ", StringComparison.Ordinal));
+        });
+    }
+
+    private static void AssertNoSelectionCheckboxHasAccessibleName(IRenderedComponent<ManageDataDialog> cut, string accessibleName) =>
+        Assert.DoesNotContain(GetSelectionCheckboxes(cut), checkbox => ElementHasAccessibleName(checkbox, accessibleName));
 
     private static void AssertNoButtonHasAccessibleName(IRenderedComponent<ManageDataDialog> cut, string accessibleName) =>
         Assert.DoesNotContain(
             cut.FindAll("fluent-button"),
-            button =>
-                string.Equals(button.GetAttribute("title"), accessibleName, StringComparison.Ordinal) ||
-                string.Equals(button.GetAttribute("aria-label"), accessibleName, StringComparison.Ordinal));
+            element =>
+                string.Equals(element.GetAttribute("title"), accessibleName, StringComparison.Ordinal) ||
+                string.Equals(element.GetAttribute("aria-label"), accessibleName, StringComparison.Ordinal));
 
-    private static bool ButtonHasAccessibleName(IElement button, string accessibleName) =>
-        string.Equals(button.GetAttribute("title"), accessibleName, StringComparison.Ordinal) &&
-        string.Equals(button.GetAttribute("aria-label"), accessibleName, StringComparison.Ordinal);
+    private static bool ElementHasAccessibleName(IElement element, string accessibleName) =>
+        string.Equals(element.GetAttribute("title"), accessibleName, StringComparison.Ordinal) &&
+        string.Equals(element.GetAttribute("aria-label"), accessibleName, StringComparison.Ordinal);
+
+    private static void PressSpace(IElement element) =>
+        PressKey(element, " ", code: "Space");
+
+    private static void PressKey(IElement element, string key, string? code = null, bool shiftKey = false) =>
+        element.TriggerEvent("onkeydown", new KeyboardEventArgs { Key = key, Code = code ?? string.Empty, ShiftKey = shiftKey });
 
     private static IReadOnlyList<IElement> GetSelectionCheckboxes(IRenderedComponent<ManageDataDialog> cut)
     {

--- a/tests/Aspire.Dashboard.Components.Tests/Dialogs/ManageDataDialogTests.cs
+++ b/tests/Aspire.Dashboard.Components.Tests/Dialogs/ManageDataDialogTests.cs
@@ -1,0 +1,168 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Threading.Channels;
+using Aspire.Dashboard.Components.Dialogs;
+using Aspire.Dashboard.Components.Tests.Shared;
+using Aspire.Dashboard.Configuration;
+using Aspire.Dashboard.Model;
+using Aspire.Dashboard.Tests.Shared;
+using Aspire.Tests.Shared.DashboardModel;
+using AngleSharp.Dom;
+using Bunit;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+using Xunit;
+
+namespace Aspire.Dashboard.Components.Tests.Dialogs;
+
+[UseCulture("en-US")]
+public sealed class ManageDataDialogTests : DashboardTestContext
+{
+    [Fact]
+    public void Render_SelectionButtons_HaveAccessibleNames()
+    {
+        var basketResource = ModelTestHelpers.CreateResource(
+            resourceName: "basket",
+            displayName: "Basket service",
+            state: KnownResourceState.Running);
+        var catalogResource = ModelTestHelpers.CreateResource(
+            resourceName: "catalog",
+            displayName: "Catalog service",
+            state: KnownResourceState.Running);
+        var resourcesChannel = Channel.CreateUnbounded<IReadOnlyList<ResourceViewModelChange>>();
+        var dashboardClient = new TestDashboardClient(
+            isEnabled: true,
+            initialResources: [basketResource, catalogResource],
+            resourceChannelProvider: () => resourcesChannel);
+
+        SetupManageDataDialogServices(dashboardClient);
+
+        var cut = RenderComponent<ManageDataDialog>();
+
+        cut.WaitForAssertion(() =>
+        {
+            AssertSelectionButtonHasAccessibleName(cut, "Deselect all");
+            AssertNoButtonHasAccessibleName(cut, "Name");
+        });
+
+        ExpandResourceRows(cut, expectedCount: 2);
+
+        cut.WaitForAssertion(() =>
+        {
+            AssertSelectionButtonInRowHasAccessibleName(cut, "Basket service", "Deselect Basket service");
+            AssertSelectionButtonInRowHasAccessibleName(cut, "Catalog service", "Deselect Catalog service");
+            AssertNestedRowSelectionLabels(
+                cut,
+                "Resource",
+                "Deselect Resource for Basket service",
+                "Deselect Resource for Catalog service");
+            AssertNestedRowSelectionLabels(
+                cut,
+                "Console logs",
+                "Deselect Console logs for Basket service",
+                "Deselect Console logs for Catalog service");
+            AssertNoButtonHasAccessibleName(cut, "Deselect Console logs");
+            AssertNoButtonHasAccessibleName(cut, "Name");
+        });
+
+        cut.Find("fluent-button[aria-label='Deselect all']").Click();
+
+        cut.WaitForAssertion(() =>
+        {
+            AssertSelectionButtonHasAccessibleName(cut, "Select all");
+            AssertSelectionButtonInRowHasAccessibleName(cut, "Basket service", "Select Basket service");
+            AssertSelectionButtonInRowHasAccessibleName(cut, "Catalog service", "Select Catalog service");
+            AssertNestedRowSelectionLabels(
+                cut,
+                "Resource",
+                "Select Resource for Basket service",
+                "Select Resource for Catalog service");
+            AssertNestedRowSelectionLabels(
+                cut,
+                "Console logs",
+                "Select Console logs for Basket service",
+                "Select Console logs for Catalog service");
+            AssertNoButtonHasAccessibleName(cut, "Select Console logs");
+            AssertNoButtonHasAccessibleName(cut, "Name");
+        });
+    }
+
+    private void SetupManageDataDialogServices(TestDashboardClient dashboardClient)
+    {
+        FluentUISetupHelpers.AddCommonDashboardServices(this);
+        Services.AddLogging();
+        Services.AddSingleton<ILoggerFactory>(NullLoggerFactory.Instance);
+        Services.AddOptions<DashboardOptions>().Configure(options => options.UI.DisableImport = true);
+        Services.AddSingleton<IDashboardClient>(dashboardClient);
+        Services.AddSingleton<IconResolver>();
+        Services.AddSingleton<ConsoleLogsManager>();
+        Services.AddSingleton<ConsoleLogsFetcher>();
+        Services.AddSingleton<TelemetryExportService>();
+        Services.AddSingleton<TelemetryImportService>();
+
+        FluentUISetupHelpers.SetupFluentUIComponents(this);
+        FluentUISetupHelpers.SetupFluentButton(this);
+        FluentUISetupHelpers.SetupFluentDataGrid(this);
+    }
+
+    private static void ExpandResourceRows(IRenderedComponent<ManageDataDialog> cut, int expectedCount)
+    {
+        for (var i = 0; i < expectedCount; i++)
+        {
+            var toggleButtons = cut.FindAll("fluent-button[aria-label='Toggle nesting']");
+
+            Assert.Equal(expectedCount, toggleButtons.Count);
+
+            toggleButtons[i].Click();
+        }
+    }
+
+    private static void AssertSelectionButtonHasAccessibleName(IRenderedComponent<ManageDataDialog> cut, string accessibleName)
+    {
+        Assert.Contains(cut.FindAll("fluent-button"), button => ButtonHasAccessibleName(button, accessibleName));
+    }
+
+    private static void AssertSelectionButtonInRowHasAccessibleName(IRenderedComponent<ManageDataDialog> cut, string visibleText, string accessibleName)
+    {
+        var row = Assert.Single(cut.FindAll(".fluent-data-grid-row"), row => row.TextContent.Contains(visibleText, StringComparison.Ordinal));
+
+        Assert.Contains(row.QuerySelectorAll("fluent-button"), button => ButtonHasAccessibleName(button, accessibleName));
+    }
+
+    private static void AssertNestedRowSelectionLabels(IRenderedComponent<ManageDataDialog> cut, string visibleText, params string[] expectedAccessibleNames)
+    {
+        var accessibleNames = cut.FindAll(".fluent-data-grid-row")
+            .Where(row => row.TextContent.Contains(visibleText, StringComparison.Ordinal))
+            .Select(GetOnlySelectionButtonAccessibleName)
+            .ToArray();
+
+        Assert.Equal(
+            expectedAccessibleNames.OrderBy(name => name, StringComparer.Ordinal),
+            accessibleNames.OrderBy(name => name, StringComparer.Ordinal));
+        Assert.Equal(accessibleNames.Length, accessibleNames.Distinct(StringComparer.Ordinal).Count());
+    }
+
+    private static void AssertNoButtonHasAccessibleName(IRenderedComponent<ManageDataDialog> cut, string accessibleName) =>
+        Assert.DoesNotContain(
+            cut.FindAll("fluent-button"),
+            button =>
+                string.Equals(button.GetAttribute("title"), accessibleName, StringComparison.Ordinal) ||
+                string.Equals(button.GetAttribute("aria-label"), accessibleName, StringComparison.Ordinal));
+
+    private static bool ButtonHasAccessibleName(IElement button, string accessibleName) =>
+        string.Equals(button.GetAttribute("title"), accessibleName, StringComparison.Ordinal) &&
+        string.Equals(button.GetAttribute("aria-label"), accessibleName, StringComparison.Ordinal);
+
+    private static string GetOnlySelectionButtonAccessibleName(IElement row)
+    {
+        var button = Assert.Single(row.QuerySelectorAll("fluent-button"));
+        var title = button.GetAttribute("title");
+
+        Assert.False(string.IsNullOrEmpty(title));
+        Assert.Equal(title, button.GetAttribute("aria-label"));
+
+        return title;
+    }
+}


### PR DESCRIPTION
## Description

Fixes #17468

Depends on #17784.

The Manage logs and telemetry dialog selection controls now expose checkbox role and state semantics on the actual focused element. This branch builds on the accessible-name work in #17784 and changes the selection affordances from icon-only buttons to focusable checkbox elements with `aria-checked` values for selected, unselected, and mixed states.

### User-facing usage

Screen reader users can now identify the selection controls as checkboxes with state:

```text
All data, checkbox, checked
Basket service, checkbox, mixed
Console logs for Basket service, checkbox, unchecked
```

Annotated evidence captured the before state with zero checkbox-role selection controls and the after state with focusable `span role="checkbox"` controls and `aria-checked` state.

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
