### PR TITLE
[do not review] Use select for text visualizer format picker

### DIFF
--- a/src/Aspire.Dashboard/Components/Dialogs/TextVisualizerDialog.razor
+++ b/src/Aspire.Dashboard/Components/Dialogs/TextVisualizerDialog.razor
@@ -1,4 +1,5 @@
 ﻿@using Aspire.Dashboard.Extensions
+@using Aspire.Dashboard.Model
 @using Aspire.Dashboard.Resources
 
 @inject IStringLocalizer<Dialogs> Loc
@@ -15,17 +16,18 @@
         @if (!HasFixedFormat)
         {
             <div Style="grid-area: dialog-format;">
-                <FluentMenuButton id="@_openSelectFormatButtonId"
-                                  ButtonAppearance="Appearance.Stealth"
-                                  IconEnd="@(new Icons.Regular.Size24.SlideTextEdit())"
-                                  Text="@(_selectedFormat ?? Loc[nameof(Dialogs.TextVisualizerSelectFormatType)])"
-                                  aria-label="@Loc[nameof(Dialogs.TextVisualizerSelectFormatType)]"
-                                  OnMenuChanged="@OnFormatOptionChanged">
-                    @foreach (var option in _options)
-                    {
-                        <FluentMenuItem Class="overflow-fluent-menu-item" Id="@option.Id" Disabled="@(!EnabledOptions.Contains(option.Id))" Value="@option.Id" title="@option.Name">@option.Name</FluentMenuItem>
-                    }
-                </FluentMenuButton>
+                <FluentSelect TOption="SelectViewModel<string>"
+                              Id="@_selectFormatId"
+                              Items="@_options"
+                              Position="SelectPosition.Below"
+                              OptionText="@(option => option.Name)"
+                              OptionValue="@(option => option.Id)"
+                              OptionDisabled="@(option => !EnabledOptions.Contains(option.Id))"
+                              OptionTitle="@(option => option.Name)"
+                              @bind-SelectedOption="@_selectedFormat"
+                              @bind-SelectedOption:after="OnSelectedFormatChanged"
+                              AriaLabel="@Loc[nameof(Dialogs.TextVisualizerSelectFormatType)]"
+                              Style="min-width: 12rem; width: max-content; max-width: 100%;" />
             </div>
         }
     </div>

--- a/src/Aspire.Dashboard/Components/Dialogs/TextVisualizerDialog.razor.cs
+++ b/src/Aspire.Dashboard/Components/Dialogs/TextVisualizerDialog.razor.cs
@@ -14,12 +14,13 @@ namespace Aspire.Dashboard.Components.Dialogs;
 public partial class TextVisualizerDialog : ComponentBase
 {
     private readonly string _copyButtonId = $"copy-{Guid.NewGuid():N}";
-    private readonly string _openSelectFormatButtonId = $"select-format-{Guid.NewGuid():N}";
+    private readonly string _selectFormatId = $"select-format-{Guid.NewGuid():N}";
 
     private List<SelectViewModel<string>> _options = null!;
-    private string? _selectedFormat;
+    private SelectViewModel<string> _selectedFormat = null!;
     private bool _isLoading = true;
     private MarkdownProcessor? _markdownProcessor;
+    private TextVisualizerDialogViewModel? _previousContent;
     internal TextVisualizerViewModel TextVisualizerViewModel { get; set; } = default!;
 
     public HashSet<string?> EnabledOptions { get; } = [];
@@ -57,16 +58,22 @@ public partial class TextVisualizerDialog : ComponentBase
 
     protected override void OnParametersSet()
     {
-        EnabledOptions.Clear();
-        EnabledOptions.Add(DashboardUIHelpers.PlaintextFormat);
-        EnabledOptions.Add(DashboardUIHelpers.MarkdownFormat);
-
         _options = [
             new SelectViewModel<string> { Id = DashboardUIHelpers.PlaintextFormat, Name = Loc[nameof(Resources.Dialogs.TextVisualizerDialogPlaintextFormat)] },
             new SelectViewModel<string> { Id = DashboardUIHelpers.MarkdownFormat, Name = Loc[nameof(Resources.Dialogs.TextVisualizerDialogMarkdownFormat)] },
             new SelectViewModel<string> { Id = DashboardUIHelpers.JsonFormat, Name = Loc[nameof(Resources.Dialogs.TextVisualizerDialogJsonFormat)] },
             new SelectViewModel<string> { Id = DashboardUIHelpers.XmlFormat, Name = Loc[nameof(Resources.Dialogs.TextVisualizerDialogXmlFormat)] }
         ];
+
+        if (_previousContent == Content)
+        {
+            _selectedFormat = GetSelectedFormatOption(TextVisualizerViewModel.FormatKind);
+            return;
+        }
+
+        EnabledOptions.Clear();
+        EnabledOptions.Add(DashboardUIHelpers.PlaintextFormat);
+        EnabledOptions.Add(DashboardUIHelpers.MarkdownFormat);
 
         // If a fixed format is specified, use it directly without auto-detection.
         if (Content.FixedFormat is not null)
@@ -86,6 +93,9 @@ public partial class TextVisualizerDialog : ComponentBase
                 EnabledOptions.Add(DashboardUIHelpers.XmlFormat);
             }
         }
+
+        _previousContent = Content;
+        _selectedFormat = GetSelectedFormatOption(TextVisualizerViewModel.FormatKind);
     }
 
     private bool IsTextContentDisplayed
@@ -101,13 +111,15 @@ public partial class TextVisualizerDialog : ComponentBase
         }
     }
 
-    private void OnFormatOptionChanged(MenuChangeEventArgs args) => ChangeFormat(args.Id, args.Value);
+    private void OnSelectedFormatChanged() => ChangeFormat(_selectedFormat.Id);
 
-    public void ChangeFormat(string? newFormat, string? text)
+    internal void ChangeFormat(string? newFormat)
     {
-        _selectedFormat = text;
-        TextVisualizerViewModel.UpdateFormat(newFormat ?? DashboardUIHelpers.PlaintextFormat);
+        _selectedFormat = GetSelectedFormatOption(newFormat);
+        TextVisualizerViewModel.UpdateFormat(_selectedFormat.Id ?? DashboardUIHelpers.PlaintextFormat);
     }
+
+    private SelectViewModel<string> GetSelectedFormatOption(string? format) => _options.SingleOrDefault(o => o.Id == format) ?? _options[0];
 
     internal MarkdownProcessor GetMarkdownProcessor()
     {
@@ -146,4 +158,3 @@ public partial class TextVisualizerDialog : ComponentBase
         ShowSecretsWarning = false;
     }
 }
-

--- a/tests/Aspire.Dashboard.Components.Tests/Controls/TextVisualizerDialogTests.cs
+++ b/tests/Aspire.Dashboard.Components.Tests/Controls/TextVisualizerDialogTests.cs
@@ -72,11 +72,49 @@ public class TextVisualizerDialogTests : DashboardTestContext
         Assert.Equal(expectedXml, instance.TextVisualizerViewModel.FormattedText);
         Assert.Equal([DashboardUIHelpers.MarkdownFormat, DashboardUIHelpers.PlaintextFormat, DashboardUIHelpers.XmlFormat], instance.EnabledOptions.ToImmutableSortedSet());
 
-        // changing format works
-        instance.ChangeFormat(DashboardUIHelpers.PlaintextFormat, rawXml);
+        instance.ChangeFormat(DashboardUIHelpers.PlaintextFormat);
 
         Assert.Equal(DashboardUIHelpers.PlaintextFormat, instance.TextVisualizerViewModel.FormatKind);
         Assert.Equal(rawXml, instance.TextVisualizerViewModel.FormattedText);
+    }
+
+    [Fact]
+    public async Task Render_TextVisualizerDialog_FormatPicker_UsesFluentSelectAndPreservesSelectionAfterParentRerenderAsync()
+    {
+        const string rawXml = """<parent><child>text<!-- comment --></child></parent>""";
+
+        var content = new TextVisualizerDialogViewModel(rawXml, string.Empty, false);
+        var cut = SetUpDialog(out var dialogService);
+        await dialogService.ShowDialogAsync<TextVisualizerDialog>(content, []);
+        cut.WaitForAssertion(() => Assert.True(cut.HasComponent<TextVisualizerDialog>()));
+
+        var formatSelect = Assert.Single(cut.FindComponents<FluentSelect<SelectViewModel<string>>>());
+        Assert.NotNull(formatSelect.Find("fluent-select"));
+
+        Assert.Equal(Aspire.Dashboard.Resources.Dialogs.TextVisualizerSelectFormatType, formatSelect.Instance.AriaLabel);
+        Assert.Equal(DashboardUIHelpers.XmlFormat, formatSelect.Instance.SelectedOption?.Id);
+
+        var formatOptions = formatSelect.Instance.Items ?? throw new InvalidOperationException("Expected format options.");
+        var plaintextOption = formatOptions.Single(o => o.Id == DashboardUIHelpers.PlaintextFormat);
+        await formatSelect.InvokeAsync(() => formatSelect.Instance.SelectedOptionChanged.InvokeAsync(plaintextOption));
+
+        cut.WaitForAssertion(() =>
+        {
+            var dialog = cut.FindComponent<TextVisualizerDialog>().Instance;
+            Assert.Equal(DashboardUIHelpers.PlaintextFormat, dialog.TextVisualizerViewModel.FormatKind);
+            Assert.Equal(rawXml, dialog.TextVisualizerViewModel.FormattedText);
+            Assert.Equal(DashboardUIHelpers.PlaintextFormat, cut.FindComponent<FluentSelect<SelectViewModel<string>>>().Instance.SelectedOption?.Id);
+        });
+
+        cut.FindComponent<TextVisualizerDialog>().SetParametersAndRender(parameters => parameters.Add(p => p.Content, content));
+
+        cut.WaitForAssertion(() =>
+        {
+            var dialog = cut.FindComponent<TextVisualizerDialog>().Instance;
+            Assert.Equal(DashboardUIHelpers.PlaintextFormat, dialog.TextVisualizerViewModel.FormatKind);
+            Assert.Equal(rawXml, dialog.TextVisualizerViewModel.FormattedText);
+            Assert.Equal(DashboardUIHelpers.PlaintextFormat, cut.FindComponent<FluentSelect<SelectViewModel<string>>>().Instance.SelectedOption?.Id);
+        });
     }
 
     [Fact]
@@ -222,7 +260,7 @@ public class TextVisualizerDialogTests : DashboardTestContext
         Assert.True(instance.HasFixedFormat);
 
         // Verify the format dropdown is not rendered
-        Assert.Empty(cut.FindAll("#" + instance.GetType().GetField("_openSelectFormatButtonId", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance)?.GetValue(instance)));
+        Assert.Empty(cut.FindComponents<FluentSelect<SelectViewModel<string>>>());
     }
 
     [Fact]
@@ -249,6 +287,8 @@ public class TextVisualizerDialogTests : DashboardTestContext
         module.SetupVoid();
 
         FluentUISetupHelpers.SetupFluentAnchoredRegion(this);
+        FluentUISetupHelpers.SetupFluentInputLabel(this);
+        FluentUISetupHelpers.SetupFluentList(this);
         FluentUISetupHelpers.SetupFluentMenu(this);
 
         var cut = FluentUISetupHelpers.RenderDialogProvider(this);


### PR DESCRIPTION
## Description

Fixes #17498

The Text Visualizer dialog now uses a `FluentSelect` for the format picker instead of a menu-style button. This gives the format picker standard keyboard selection behavior while preserving the available/disabled format options, fixed-format hiding, and user-selected format across parent re-renders.

### User-facing usage

The **Select format** control now renders as a select/listbox control with options:

```text
Unformatted
Markdown
JSON (disabled when unavailable)
XML (disabled when unavailable)
```

Annotated evidence captured the before state as a `Select format` button and the after state as a `fluent-select` with `aria-label="Select format"` and keyboard-accessible options.

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
