### PR TITLE
[do not review] Fix Resources grid keyboard activation

### DIFF
--- a/src/Aspire.Dashboard/Components/Pages/Resources.razor
+++ b/src/Aspire.Dashboard/Components/Pages/Resources.razor
@@ -119,7 +119,7 @@
                                     </FluentTab>
                                 </FluentTabs>
                             }
-                            <div class="resources-grid-container" hidden="@(PageViewModel.SelectedViewKind == ResourceViewKind.Graph)">
+                            <div @ref="_resourcesGridContainer" class="resources-grid-container" hidden="@(PageViewModel.SelectedViewKind == ResourceViewKind.Graph)">
                                 <GridColumnManager @ref="_manager" Columns="@_gridColumns">
                                     <FluentDataGrid @ref="_dataGrid"
                                                     ColumnResizeLabels="@_resizeLabels"

--- a/src/Aspire.Dashboard/Components/Pages/Resources.razor.cs
+++ b/src/Aspire.Dashboard/Components/Pages/Resources.razor.cs
@@ -122,11 +122,14 @@ public partial class Resources : ComponentBase, IComponentWithTelemetry, IAsyncD
     private Task? _resourceSubscriptionTask;
     private string? _elementIdBeforeDetailsViewOpened;
     private FluentDataGrid<ResourceGridViewModel> _dataGrid = null!;
+    private ElementReference _resourcesGridContainer;
     private GridColumnManager _manager = null!;
     private int _maxHighlightedCount;
     private readonly List<MenuButtonItem> _resourcesMenuItems = new();
     private DotNetObjectReference<ResourcesInterop>? _resourcesInteropReference;
     private IJSObjectReference? _jsModule;
+    private IJSObjectReference? _resourcesPageModule;
+    private IJSObjectReference? _resourcesGridKeyboardActivation;
     private bool _graphInitialized;
     private AspirePageContentLayout? _contentLayout;
     private TotalItemsFooter _totalItemsFooter = default!;
@@ -393,6 +396,12 @@ public partial class Resources : ComponentBase, IComponentWithTelemetry, IAsyncD
 
     protected override async Task OnAfterRenderAsync(bool firstRender)
     {
+        if (firstRender)
+        {
+            _resourcesPageModule = await JS.InvokeAsync<IJSObjectReference>("import", "/Components/Pages/Resources.razor.js");
+            _resourcesGridKeyboardActivation = await _resourcesPageModule.InvokeAsync<IJSObjectReference>("initializeResourcesGridKeyboardActivation", _resourcesGridContainer);
+        }
+
         // Check to see whether max item count should be set on every render.
         // This is required because the data grid's virtualize component can be recreated on data change.
         if (_dataGrid != null && FluentDataGridHelper<ResourceGridViewModel>.TrySetMaxItemCount(_dataGrid, 10_000))
@@ -990,9 +999,30 @@ public partial class Resources : ComponentBase, IComponentWithTelemetry, IAsyncD
         _cts.Cancel();
         _logsSubscription?.Dispose();
         TelemetryContext.Dispose();
+        await DisposeResourcesGridKeyboardActivationAsync();
+        await JSInteropHelpers.SafeDisposeAsync(_resourcesPageModule);
         await JSInteropHelpers.SafeDisposeAsync(_jsModule);
 
         await TaskHelpers.WaitIgnoreCancelAsync(_resourceSubscriptionTask);
+    }
+
+    private async Task DisposeResourcesGridKeyboardActivationAsync()
+    {
+        if (_resourcesGridKeyboardActivation is null)
+        {
+            return;
+        }
+
+        try
+        {
+            await _resourcesGridKeyboardActivation.InvokeVoidAsync("dispose");
+        }
+        catch (JSDisconnectedException)
+        {
+            // This can happen when the browser has already disconnected during teardown.
+        }
+
+        await JSInteropHelpers.SafeDisposeAsync(_resourcesGridKeyboardActivation);
     }
 
     private async Task ContextMenuClosed(Microsoft.AspNetCore.Components.Web.MouseEventArgs args)

--- a/src/Aspire.Dashboard/Components/Pages/Resources.razor.js
+++ b/src/Aspire.Dashboard/Components/Pages/Resources.razor.js
@@ -21,10 +21,6 @@ const interactiveSelector = [
 ].join(',');
 
 export function shouldStopResourcesGridRowKeydown(event) {
-    if (event.altKey || event.ctrlKey || event.metaKey || event.shiftKey) {
-        return false;
-    }
-
     return event.key === 'Enter';
 }
 

--- a/src/Aspire.Dashboard/Components/Pages/Resources.razor.js
+++ b/src/Aspire.Dashboard/Components/Pages/Resources.razor.js
@@ -1,0 +1,117 @@
+const interactiveSelector = [
+    'a[href]',
+    'button',
+    'input',
+    'select',
+    'textarea',
+    '[role="button"]',
+    '[role="link"]',
+    '[role="menuitem"]',
+    'fluent-anchor',
+    'fluent-button',
+    'fluent-checkbox',
+    'fluent-combobox',
+    'fluent-menu-item',
+    'fluent-option',
+    'fluent-radio',
+    'fluent-search',
+    'fluent-select',
+    'fluent-switch',
+    'fluent-text-field'
+].join(',');
+
+export function shouldStopResourcesGridRowKeydown(event) {
+    if (event.altKey || event.ctrlKey || event.metaKey || event.shiftKey) {
+        return false;
+    }
+
+    return event.key === 'Enter';
+}
+
+export function initializeResourcesGridKeyboardActivation(grid) {
+    if (!grid) {
+        return {
+            dispose() {
+            }
+        };
+    }
+
+    const registeredElements = new Set();
+
+    const onKeyDown = event => {
+        // The data grid also treats Enter as row activation. Stop only the keys
+        // that activate focused controls so Tab, arrows, Escape, and shortcuts
+        // keep bubbling through the grid.
+        if (shouldStopResourcesGridRowKeydown(event)) {
+            event.stopPropagation();
+        }
+    };
+
+    const registerElement = element => {
+        if (!registeredElements.has(element)) {
+            element.addEventListener('keydown', onKeyDown);
+            registeredElements.add(element);
+        }
+    };
+
+    const unregisterElement = element => {
+        if (registeredElements.delete(element)) {
+            element.removeEventListener('keydown', onKeyDown);
+        }
+    };
+
+    const registerTree = node => {
+        if (node.nodeType !== Node.ELEMENT_NODE) {
+            return;
+        }
+
+        if (node.matches(interactiveSelector)) {
+            registerElement(node);
+        }
+
+        for (const element of node.querySelectorAll(interactiveSelector)) {
+            registerElement(element);
+        }
+    };
+
+    const unregisterTree = node => {
+        if (node.nodeType !== Node.ELEMENT_NODE) {
+            return;
+        }
+
+        if (node.matches(interactiveSelector)) {
+            unregisterElement(node);
+        }
+
+        for (const element of node.querySelectorAll(interactiveSelector)) {
+            unregisterElement(element);
+        }
+    };
+
+    registerTree(grid);
+
+    const observer = new MutationObserver(mutations => {
+        for (const mutation of mutations) {
+            for (const node of mutation.addedNodes) {
+                registerTree(node);
+            }
+
+            for (const node of mutation.removedNodes) {
+                unregisterTree(node);
+            }
+        }
+    });
+    observer.observe(grid, { childList: true, subtree: true });
+
+    return {
+        dispose() {
+            observer.disconnect();
+
+            for (const element of registeredElements) {
+                element.removeEventListener('keydown', onKeyDown);
+            }
+
+            registeredElements.clear();
+        }
+    };
+}

--- a/tests/Aspire.Dashboard.Components.Tests/Pages/ResourcesTests.cs
+++ b/tests/Aspire.Dashboard.Components.Tests/Pages/ResourcesTests.cs
@@ -498,7 +498,7 @@ public partial class ResourcesTests : DashboardTestContext
             assert.equal(resourcesModule.shouldStopResourcesGridRowKeydown(createKeydownEvent('Tab')), false);
             assert.equal(resourcesModule.shouldStopResourcesGridRowKeydown(createKeydownEvent('ArrowDown')), false);
             assert.equal(resourcesModule.shouldStopResourcesGridRowKeydown(createKeydownEvent('Escape')), false);
-            assert.equal(resourcesModule.shouldStopResourcesGridRowKeydown(createKeydownEvent('Enter', { ctrlKey: true })), false);
+            assert.equal(resourcesModule.shouldStopResourcesGridRowKeydown(createKeydownEvent('Enter', { ctrlKey: true })), true);
 
             const grid = new FakeElement('div');
             const button = new FakeElement('button');
@@ -509,6 +509,7 @@ public partial class ResourcesTests : DashboardTestContext
             const registration = resourcesModule.initializeResourcesGridKeyboardActivation(grid);
 
             assert.equal(button.dispatchKeydown('Enter'), true);
+            assert.equal(button.dispatchKeydown('Enter', { ctrlKey: true }), true);
             assert.equal(button.dispatchKeydown(' '), false);
             assert.equal(button.dispatchKeydown('ArrowDown'), false);
             assert.equal(button.dispatchKeydown('Tab'), false);
@@ -545,7 +546,8 @@ public partial class ResourcesTests : DashboardTestContext
             directory = directory.Parent;
         }
 
-        throw new FileNotFoundException("Unable to locate Resources.razor.js from the test output directory.", "Resources.razor.js");
+        Assert.Skip("Resources.razor.js is required to run the Resources grid keyboard activation JavaScript test.");
+        return string.Empty;
     }
 
     private static async Task RunNodeScriptAsync(string script, string scriptPath)

--- a/tests/Aspire.Dashboard.Components.Tests/Pages/ResourcesTests.cs
+++ b/tests/Aspire.Dashboard.Components.Tests/Pages/ResourcesTests.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Collections.Immutable;
+using System.Diagnostics;
 using System.Threading.Channels;
 using Aspire.Dashboard.Components.Resize;
 using Aspire.Dashboard.Components.Tests.Shared;
@@ -352,6 +353,299 @@ public partial class ResourcesTests : DashboardTestContext
         var filteredResources = cut.Instance.GetFilteredResources().ToList();
         Assert.Contains(filteredResources, r => r.Name == "Resource2");
         Assert.Contains(filteredResources, r => r.Name == "Resource3");
+    }
+
+    [Fact]
+    public void ResourcesGrid_InitializesScopedKeyboardActivationHandler()
+    {
+        var viewport = new ViewportInformation(IsDesktop: true, IsUltraLowHeight: false, IsUltraLowWidth: false);
+        var initialResources = new List<ResourceViewModel>
+        {
+            CreateResource("Resource1", "Type1", "Running", null),
+        };
+        var dashboardClient = new TestDashboardClient(isEnabled: true, initialResources: initialResources, resourceChannelProvider: Channel.CreateUnbounded<IReadOnlyList<ResourceViewModelChange>>);
+
+        ResourceSetupHelpers.SetupResourcesPage(this, viewport, dashboardClient);
+
+        var cut = RenderComponent<Components.Pages.Resources>(builder =>
+        {
+            builder.AddCascadingValue(viewport);
+        });
+
+        cut.WaitForAssertion(() => Assert.Contains(JSInterop.Invocations, i => i.Identifier == "initializeResourcesGridKeyboardActivation"));
+
+        var invocation = Assert.Single(JSInterop.Invocations, i => i.Identifier == "initializeResourcesGridKeyboardActivation");
+        Assert.IsType<ElementReference>(invocation.Arguments[0]);
+        Assert.Contains("resources-grid-container", cut.Markup);
+    }
+
+    [Fact]
+    public async Task ResourcesGridKeyboardActivationScript_StopsOnlyInteractiveActivationKeys()
+    {
+        var scriptPath = GetResourcesPageScriptPath();
+        var script = """
+            import { readFileSync } from 'node:fs';
+            import assert from 'node:assert/strict';
+
+            const observers = [];
+
+            globalThis.Node = { ELEMENT_NODE: 1 };
+            globalThis.MutationObserver = class {
+                constructor(callback) {
+                    this.callback = callback;
+                    observers.push(this);
+                }
+
+                observe(target, options) {
+                    this.target = target;
+                    this.options = options;
+                }
+
+                disconnect() {
+                    this.disconnected = true;
+                }
+            };
+
+            const source = readFileSync(process.argv[2], 'utf8');
+            const resourcesModule = await import('data:text/javascript;base64,' + Buffer.from(source).toString('base64'));
+
+            function createKeydownEvent(key, options = {}) {
+                return {
+                    key,
+                    altKey: options.altKey ?? false,
+                    ctrlKey: options.ctrlKey ?? false,
+                    metaKey: options.metaKey ?? false,
+                    shiftKey: options.shiftKey ?? false,
+                    stopped: false,
+                    stopPropagation() {
+                        this.stopped = true;
+                    }
+                };
+            }
+
+            class FakeElement {
+                nodeType = Node.ELEMENT_NODE;
+                children = [];
+                listeners = new Map();
+
+                constructor(tagName, attributes = {}) {
+                    this.tagName = tagName.toUpperCase();
+                    this.attributes = new Map(Object.entries(attributes));
+                }
+
+                appendChild(child) {
+                    this.children.push(child);
+                }
+
+                matches(selector) {
+                    return selector
+                        .split(',')
+                        .some(s => this.matchesSingleSelector(s.trim()));
+                }
+
+                matchesSingleSelector(selector) {
+                    if (selector === 'a[href]') {
+                        return this.tagName === 'A' && this.attributes.has('href');
+                    }
+
+                    const roleMatch = selector.match(/^\[role="(.+)"\]$/);
+                    if (roleMatch) {
+                        return this.attributes.get('role') === roleMatch[1];
+                    }
+
+                    return this.tagName.toLowerCase() === selector;
+                }
+
+                querySelectorAll(selector) {
+                    const matches = [];
+                    const visit = node => {
+                        for (const child of node.children) {
+                            if (child.matches(selector)) {
+                                matches.push(child);
+                            }
+
+                            visit(child);
+                        }
+                    };
+                    visit(this);
+                    return matches;
+                }
+
+                addEventListener(type, listener) {
+                    const listeners = this.listeners.get(type) ?? [];
+                    listeners.push(listener);
+                    this.listeners.set(type, listeners);
+                }
+
+                removeEventListener(type, listener) {
+                    const listeners = this.listeners.get(type) ?? [];
+                    this.listeners.set(type, listeners.filter(l => l !== listener));
+                }
+
+                dispatchKeydown(key, options = {}) {
+                    const event = createKeydownEvent(key, options);
+                    for (const listener of this.listeners.get('keydown') ?? []) {
+                        listener(event);
+                    }
+
+                    return event.stopped;
+                }
+            }
+
+            assert.equal(resourcesModule.shouldStopResourcesGridRowKeydown(createKeydownEvent('Enter')), true);
+            assert.equal(resourcesModule.shouldStopResourcesGridRowKeydown(createKeydownEvent(' ')), false);
+            assert.equal(resourcesModule.shouldStopResourcesGridRowKeydown(createKeydownEvent('Spacebar')), false);
+            assert.equal(resourcesModule.shouldStopResourcesGridRowKeydown(createKeydownEvent('Tab')), false);
+            assert.equal(resourcesModule.shouldStopResourcesGridRowKeydown(createKeydownEvent('ArrowDown')), false);
+            assert.equal(resourcesModule.shouldStopResourcesGridRowKeydown(createKeydownEvent('Escape')), false);
+            assert.equal(resourcesModule.shouldStopResourcesGridRowKeydown(createKeydownEvent('Enter', { ctrlKey: true })), false);
+
+            const grid = new FakeElement('div');
+            const button = new FakeElement('button');
+            const text = new FakeElement('span');
+            grid.appendChild(button);
+            grid.appendChild(text);
+
+            const registration = resourcesModule.initializeResourcesGridKeyboardActivation(grid);
+
+            assert.equal(button.dispatchKeydown('Enter'), true);
+            assert.equal(button.dispatchKeydown(' '), false);
+            assert.equal(button.dispatchKeydown('ArrowDown'), false);
+            assert.equal(button.dispatchKeydown('Tab'), false);
+            assert.equal(text.dispatchKeydown('Enter'), false);
+
+            const anchor = new FakeElement('a', { href: '#' });
+            observers[0].callback([{ addedNodes: [anchor], removedNodes: [] }]);
+            assert.equal(anchor.dispatchKeydown('Enter'), true);
+
+            observers[0].callback([{ addedNodes: [], removedNodes: [anchor] }]);
+            assert.equal(anchor.dispatchKeydown('Enter'), false);
+
+            registration.dispose();
+
+            assert.equal(observers[0].disconnected, true);
+            assert.equal(button.dispatchKeydown('Enter'), false);
+            """;
+
+        await RunNodeScriptAsync(script, scriptPath);
+    }
+
+    private static string GetResourcesPageScriptPath()
+    {
+        var directory = new DirectoryInfo(AppContext.BaseDirectory);
+
+        while (directory is not null)
+        {
+            var scriptPath = Path.Combine(directory.FullName, "src", "Aspire.Dashboard", "Components", "Pages", "Resources.razor.js");
+            if (File.Exists(scriptPath))
+            {
+                return scriptPath;
+            }
+
+            directory = directory.Parent;
+        }
+
+        throw new FileNotFoundException("Unable to locate Resources.razor.js from the test output directory.", "Resources.razor.js");
+    }
+
+    private static async Task RunNodeScriptAsync(string script, string scriptPath)
+    {
+        await SkipIfNodeUnavailableAsync();
+
+        using var process = new Process
+        {
+            StartInfo = new ProcessStartInfo
+            {
+                FileName = "node",
+                RedirectStandardInput = true,
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false
+            }
+        };
+        process.StartInfo.ArgumentList.Add("--input-type=module");
+        process.StartInfo.ArgumentList.Add("-");
+        process.StartInfo.ArgumentList.Add(scriptPath);
+
+        process.Start();
+
+        await process.StandardInput.WriteAsync(script);
+        process.StandardInput.Close();
+
+        var stdoutTask = process.StandardOutput.ReadToEndAsync();
+        var stderrTask = process.StandardError.ReadToEndAsync();
+        var waitTask = process.WaitForExitAsync();
+
+        if (await Task.WhenAny(waitTask, Task.Delay(TimeSpan.FromSeconds(30))) != waitTask)
+        {
+            process.Kill(entireProcessTree: true);
+            throw new TimeoutException("Timed out waiting for the Resources grid keyboard activation JavaScript test to complete.");
+        }
+
+        var stdout = await stdoutTask;
+        var stderr = await stderrTask;
+
+        Assert.True(process.ExitCode == 0, $"""
+            node exited with code {process.ExitCode}.
+
+            stdout:
+            {stdout}
+
+            stderr:
+            {stderr}
+            """);
+    }
+
+    private static async Task SkipIfNodeUnavailableAsync()
+    {
+        using var process = new Process
+        {
+            StartInfo = new ProcessStartInfo
+            {
+                FileName = "node",
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false
+            }
+        };
+        process.StartInfo.ArgumentList.Add("--version");
+
+        try
+        {
+            process.Start();
+        }
+        catch (Exception ex) when (ex is System.ComponentModel.Win32Exception or FileNotFoundException)
+        {
+            Assert.Skip("Node.js is required to run the Resources grid keyboard activation JavaScript test.");
+            return;
+        }
+
+        var stdoutTask = process.StandardOutput.ReadToEndAsync();
+        var stderrTask = process.StandardError.ReadToEndAsync();
+        var waitTask = process.WaitForExitAsync();
+
+        if (await Task.WhenAny(waitTask, Task.Delay(TimeSpan.FromSeconds(10))) != waitTask)
+        {
+            process.Kill(entireProcessTree: true);
+            Assert.Skip("Node.js is required to run the Resources grid keyboard activation JavaScript test, but `node --version` did not complete.");
+            return;
+        }
+
+        var stdout = await stdoutTask;
+        var stderr = await stderrTask;
+
+        if (process.ExitCode != 0)
+        {
+            Assert.Skip($"""
+                Node.js is required to run the Resources grid keyboard activation JavaScript test, but `node --version` exited with code {process.ExitCode}.
+
+                stdout:
+                {stdout}
+
+                stderr:
+                {stderr}
+                """);
+        }
     }
 
     private static ResourceViewModel CreateResource(

--- a/tests/Aspire.Dashboard.Components.Tests/Shared/ResourceSetupHelpers.cs
+++ b/tests/Aspire.Dashboard.Components.Tests/Shared/ResourceSetupHelpers.cs
@@ -64,6 +64,10 @@ internal static class ResourceSetupHelpers
 
         FluentUISetupHelpers.SetupFluentUIComponents(context);
 
+        var resourcesPageModule = context.JSInterop.SetupModule("/Components/Pages/Resources.razor.js");
+        var resourcesGridKeyboardActivation = resourcesPageModule.SetupModule("initializeResourcesGridKeyboardActivation", _ => true);
+        resourcesGridKeyboardActivation.SetupVoid("dispose", _ => true);
+
         var dimensionManager = context.Services.GetRequiredService<DimensionManager>();
         dimensionManager.InvokeOnViewportInformationChanged(viewport);
     }


### PR DESCRIPTION
## Description

Fixes #17651.

Stops the Resources grid row keyboard handler from also opening row details when Enter originates on an interactive control inside the row, such as "Open in text visualizer". The new Resources-page JS module scopes the behavior to the Resources grid, registers current and virtualized interactive descendants, stops only unmodified Enter so Tab/arrows/Escape/shortcuts keep bubbling, and unregisters the listener during disposal.

Evidence: before/after screenshots and videos are linked in the artifact branch: https://github.com/adamint/aspire/tree/a11y-artifacts-20260601042635/17651

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
