### PR TITLE
[do not review] Constrain mobile navigation scrollport

### DIFF
--- a/src/Aspire.Dashboard/Components/Layout/MainLayout.razor.css
+++ b/src/Aspire.Dashboard/Components/Layout/MainLayout.razor.css
@@ -84,11 +84,15 @@
 
 @media (max-width: 768px) {
     ::deep.layout {
+        /* MobileNavMenu uses this same value to keep its scrollport within the
+           visible viewport instead of extending underneath the header at high zoom. */
+        --mobile-header-height: 52px;
+        --mobile-nav-menu-offset: 2px;
         height: 100vh;
         width: 100vw;
         display: grid;
         grid-template-columns: auto 1fr;
-        grid-template-rows: auto auto auto 1fr;
+        grid-template-rows: var(--mobile-header-height) auto auto 1fr;
         grid-template-areas:
             "icon head"
             "nav-menu nav-menu"

--- a/src/Aspire.Dashboard/Components/Layout/MobileNavMenu.razor
+++ b/src/Aspire.Dashboard/Components/Layout/MobileNavMenu.razor
@@ -1,4 +1,4 @@
-﻿<FluentMenu Class="aspire-menu-container" Open="@IsNavMenuOpen" Anchored="false" Style="grid-area: nav-menu; height: 100vh; margin-top: 2px; overflow-y: auto;">
+﻿<FluentMenu Class="aspire-menu-container" Open="@IsNavMenuOpen" Anchored="false" Style="grid-area: nav-menu; max-height: calc(100dvh - var(--mobile-header-height) - var(--mobile-nav-menu-offset)); margin-top: var(--mobile-nav-menu-offset); overflow-y: auto;">
     @foreach (var item in GetMobileNavMenuEntries())
     {
         <FluentMenuItem OnClick="@(async () => { CloseNavMenu(); await item.OnClick(); })" Style="height: 40px; width: 100vw; margin-bottom: 6px;" title="@item.Text">

--- a/tests/Aspire.Dashboard.Components.Tests/Layout/MobileNavMenuTests.cs
+++ b/tests/Aspire.Dashboard.Components.Tests/Layout/MobileNavMenuTests.cs
@@ -1,0 +1,46 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Aspire.Dashboard.Components.Layout;
+using Aspire.Dashboard.Components.Tests.Shared;
+using Aspire.Dashboard.Tests.Shared;
+using Bunit;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace Aspire.Dashboard.Components.Tests.Layout;
+
+[UseCulture("en-US")]
+public class MobileNavMenuTests : DashboardTestContext
+{
+    [Fact]
+    public void MobileNavMenu_ConstrainedToRemainingViewport()
+    {
+        FluentUISetupHelpers.AddCommonDashboardServices(this);
+        Services.AddSingleton<IDashboardClient>(new TestDashboardClient(isEnabled: true));
+        FluentUISetupHelpers.SetupFluentUIComponents(this);
+        FluentUISetupHelpers.SetupFluentDivider(this);
+        FluentUISetupHelpers.SetupFluentAnchoredRegion(this);
+        FluentUISetupHelpers.SetupFluentMenu(this);
+
+        var cut = RenderComponent<MobileNavMenu>(builder =>
+        {
+            builder.Add(p => p.IsNavMenuOpen, true);
+            builder.Add(p => p.IsAIEnabled, false);
+            builder.Add(p => p.IsAgentHelpEnabled, false);
+            builder.Add(p => p.CloseNavMenu, () => { });
+            builder.Add(p => p.LaunchHelpAsync, () => Task.CompletedTask);
+            builder.Add(p => p.LaunchAIAgentsAsync, () => Task.CompletedTask);
+            builder.Add(p => p.LaunchAIAssistantAsync, () => Task.CompletedTask);
+            builder.Add(p => p.LaunchNotificationsAsync, () => Task.CompletedTask);
+            builder.Add(p => p.LaunchSettingsAsync, () => Task.CompletedTask);
+        });
+
+        var style = cut.Find("fluent-menu").GetAttribute("style");
+
+        Assert.Contains("max-height: calc(100dvh - var(--mobile-header-height) - var(--mobile-nav-menu-offset))", style);
+        Assert.DoesNotContain("height: 100vh", style);
+        Assert.Contains("margin-top: var(--mobile-nav-menu-offset)", style);
+        Assert.Contains("overflow-y: auto", style);
+    }
+}


### PR DESCRIPTION
## Description

Fixes #17657.

Constrains the mobile hamburger menu to the visible viewport at high zoom by sharing mobile layout variables for the header height and menu offset. This keeps keyboard focus visible inside the menu scrollport instead of allowing the menu to extend below the viewport.

Evidence: https://github.com/adamint/aspire/tree/a11y-artifacts-20260601042635/17657

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
