### PR TITLE
[do not review] Fix Resources tabs reflow

### DIFF
--- a/src/Aspire.Dashboard/Components/Pages/Resources.razor
+++ b/src/Aspire.Dashboard/Components/Pages/Resources.razor
@@ -100,22 +100,29 @@
                             *@
                             @if (!_hideResourceGraph)
                             {
-                                <FluentTabs Class="resources-tab-header" ActiveTabId="@($"tab-{PageViewModel.SelectedViewKind}")" OnTabChange="@OnTabChangeAsync" Size="null">
+                                <FluentTabs Class="resources-tab-header"
+                                            ActiveTabId="@($"tab-{PageViewModel.SelectedViewKind}")"
+                                            OnTabChange="@OnTabChangeAsync"
+                                            Orientation="@(ViewportInformation.IsUltraLowWidth ? Orientation.Vertical : Orientation.Horizontal)"
+                                            Size="null">
                                     <FluentTab LabelClass="tab-label"
                                                Id="@($"tab-{ResourceViewKind.Table}")"
                                                Label="@ControlsStringsLoc[nameof(ControlsStrings.ChartContainerTableTab)]"
-                                               Icon="@(new Icons.Regular.Size24.Table())">
+                                               Icon="@(new Icons.Regular.Size24.Table())"
+                                               fixed>
                                     </FluentTab>
                                     <FluentTab LabelClass="tab-label"
                                                Id="@($"tab-{ResourceViewKind.Parameters}")"
                                                Label="@ControlsStringsLoc[nameof(ControlsStrings.ChartContainerParametersTab)]"
-                                               Icon="@(new Icons.Regular.Size24.Key())">
+                                               Icon="@(new Icons.Regular.Size24.Key())"
+                                               fixed>
                                     </FluentTab>
                                     <FluentTab LabelClass="tab-label"
                                                Id="@($"tab-{ResourceViewKind.Graph}")"
                                                aria-label="@ControlsStringsLoc[nameof(ControlsStrings.ChartContainerGraphAccessibleLabel)]"
                                                Label="@ControlsStringsLoc[nameof(ControlsStrings.ChartContainerGraphTab)]"
-                                               Icon="@(new Icons.Regular.Size24.ShareAndroid())">
+                                               Icon="@(new Icons.Regular.Size24.ShareAndroid())"
+                                               fixed>
                                     </FluentTab>
                                 </FluentTabs>
                             }

--- a/src/Aspire.Dashboard/Components/Pages/Resources.razor.css
+++ b/src/Aspire.Dashboard/Components/Pages/Resources.razor.css
@@ -83,6 +83,18 @@
     margin-left: calc(var(--design-unit) * 3px);
 }
 
+::deep .resources-tab-header {
+    max-width: 100%;
+    min-width: 0;
+}
+
+/* FluentTabs keeps its horizontal tab list at max-content width. Constrain the host so
+   focus can scroll the selected tab into view when space is limited above ultra-low width. */
+::deep .resources-tab-header[orientation="horizontal"] {
+    overflow-x: auto;
+    overflow-y: hidden;
+}
+
 ::deep .resources-grid-container {
     overflow: auto;
     grid-area: resources-tab-content;

--- a/tests/Aspire.Dashboard.Components.Tests/Pages/ResourcesTests.cs
+++ b/tests/Aspire.Dashboard.Components.Tests/Pages/ResourcesTests.cs
@@ -210,6 +210,38 @@ public partial class ResourcesTests : DashboardTestContext
         Assert.Single(initializeGraphInvocationHandler.Invocations);
     }
 
+    [Theory]
+    [InlineData(false, true, "vertical")]
+    [InlineData(true, true, "vertical")]
+    [InlineData(false, false, "horizontal")]
+    [InlineData(true, false, "horizontal")]
+    public void ResourceTabs_OrientationRespondsToUltraLowWidth(bool isDesktop, bool isUltraLowWidth, string expectedOrientation)
+    {
+        var viewport = new ViewportInformation(IsDesktop: isDesktop, IsUltraLowHeight: false, IsUltraLowWidth: isUltraLowWidth);
+        var initialResources = new List<ResourceViewModel>
+        {
+            CreateResource(
+                "Resource1",
+                "Type1",
+                "Running",
+                ImmutableArray.Create(new HealthReportViewModel("Null", null, "Description1", null))),
+        };
+        var dashboardClient = new TestDashboardClient(isEnabled: true, initialResources: initialResources, resourceChannelProvider: Channel.CreateUnbounded<IReadOnlyList<ResourceViewModelChange>>);
+        ResourceSetupHelpers.SetupResourcesPage(
+            this,
+            viewport,
+            dashboardClient);
+
+        var cut = RenderComponent<Components.Pages.Resources>(builder =>
+        {
+            builder.AddCascadingValue(viewport);
+        });
+
+        var tabs = cut.Find("fluent-tabs.resources-tab-header");
+        Assert.Equal(expectedOrientation, tabs.GetAttribute("orientation"));
+        Assert.All(cut.FindAll("fluent-tab"), tab => Assert.True(tab.HasAttribute("fixed")));
+    }
+
     [Fact]
     public void ResourceFilters_ApplyExistingFiltersOnInitialRender()
     {


### PR DESCRIPTION
## Description

Fixes #17654.

Keeps the Resources page view tabs visible under 320px reflow by switching the tab orientation to vertical at ultra-low width and marking the three tabs as fixed so FluentTabs does not collapse them into overflow. The selected Graph tab remains visible instead of moving behind a `+N` overflow badge.

Evidence: https://github.com/adamint/aspire/tree/a11y-artifacts-20260601042635/17654

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
