### PR TITLE
[do not review] Restore focus after dashboard dialogs close

### DIFF
--- a/src/Aspire.Dashboard/Components/Dialogs/AssistantModalDialog.razor.cs
+++ b/src/Aspire.Dashboard/Components/Dialogs/AssistantModalDialog.razor.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using Aspire.Dashboard.Components.Layout;
 using Aspire.Dashboard.Model.Assistant;
 using Microsoft.AspNetCore.Components;
 using Microsoft.FluentUI.AspNetCore.Components;
@@ -124,7 +125,15 @@ public partial class AssistantModalDialog : IAsyncDisposable
 
     private async Task DisplaySidebarViewAsync()
     {
-        await AIContextProvider.LaunchAssistantSidebarAsync(Content.Chat, Content.ReturnFocusElementId);
+        var returnFocusElementId = GetSidebarReturnFocusElementId(Content.OpenedForMobileView, Content.ReturnFocusElementId);
+        await AIContextProvider.LaunchAssistantSidebarAsync(Content.Chat, returnFocusElementId);
+    }
+
+    public static string? GetSidebarReturnFocusElementId(bool openedForMobileView, string? returnFocusElementId)
+    {
+        return openedForMobileView
+            ? MainLayout.AssistantButtonId
+            : returnFocusElementId;
     }
 
     public async Task StartNewChatAsync()

--- a/src/Aspire.Dashboard/Components/Dialogs/AssistantModalDialog.razor.cs
+++ b/src/Aspire.Dashboard/Components/Dialogs/AssistantModalDialog.razor.cs
@@ -86,7 +86,7 @@ public partial class AssistantModalDialog : IAsyncDisposable
         return ValueTask.CompletedTask;
     }
 
-    public static async Task OpenDialogAsync(IDialogService dialogService, string title, AssistantDialogViewModel viewModel)
+    public static async Task OpenDialogAsync(IDialogService dialogService, IJSRuntime js, string title, AssistantDialogViewModel viewModel, string? returnFocusElementId = null)
     {
         var parameters = new DialogParameters
         {
@@ -95,7 +95,15 @@ public partial class AssistantModalDialog : IAsyncDisposable
             Width = "min(800px, 100vw)",
             TrapFocus = true,
             Modal = true,
-            PreventScroll = true
+            PreventScroll = true,
+            OnDialogClosing = EventCallback.Factory.Create<DialogInstance>(dialogService, async _ =>
+            {
+                if (returnFocusElementId is not null && viewModel.Chat?.DisplayContainer != AssistantChatDisplayContainer.Switching)
+                {
+                    // FluentUI can restore focus to a shadow-DOM proxy instead of the launcher.
+                    await js.InvokeVoidAsync("focusElement", returnFocusElementId);
+                }
+            })
         };
 
         await dialogService.ShowDialogAsync<AssistantModalDialog>(viewModel, parameters);
@@ -116,7 +124,7 @@ public partial class AssistantModalDialog : IAsyncDisposable
 
     private async Task DisplaySidebarViewAsync()
     {
-        await AIContextProvider.LaunchAssistantSidebarAsync(Content.Chat);
+        await AIContextProvider.LaunchAssistantSidebarAsync(Content.Chat, Content.ReturnFocusElementId);
     }
 
     public async Task StartNewChatAsync()

--- a/src/Aspire.Dashboard/Components/Dialogs/AssistantSidebarDialog.razor
+++ b/src/Aspire.Dashboard/Components/Dialogs/AssistantSidebarDialog.razor
@@ -28,7 +28,7 @@
                                     <FluentIcon Value="@(new Icons.Regular.Size16.ArrowExpand())" Width="16px" Color="Color.Neutral" />
                                 </FluentButton>
                             }
-                            <FluentButton Appearance="Appearance.Stealth" OnClick="CloseDialog" aria-label="@DialogsLoc[nameof(Dialogs.DialogCloseButtonText)]" Title="@DialogsLoc[nameof(Dialogs.DialogCloseButtonText)]">
+                            <FluentButton Appearance="Appearance.Stealth" OnClick="CloseDialogAsync" aria-label="@DialogsLoc[nameof(Dialogs.DialogCloseButtonText)]" Title="@DialogsLoc[nameof(Dialogs.DialogCloseButtonText)]">
                                 <FluentIcon Value="@(new Icons.Regular.Size16.Dismiss())" Width="16px" Color="Color.Neutral" />
                             </FluentButton>
                         </div>

--- a/src/Aspire.Dashboard/Components/Dialogs/AssistantSidebarDialog.razor.cs
+++ b/src/Aspire.Dashboard/Components/Dialogs/AssistantSidebarDialog.razor.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using Aspire.Dashboard.Components.CustomIcons;
+using Aspire.Dashboard.Components.Layout;
 using Aspire.Dashboard.Model.Assistant;
 using Microsoft.AspNetCore.Components;
 using Microsoft.FluentUI.AspNetCore.Components;
@@ -63,7 +64,18 @@ public partial class AssistantSidebarDialog : IAsyncDisposable
     {
         Content.Chat.DisplayContainer = AssistantChatDisplayContainer.Switching;
         await AIContextProvider.HideAssistantSidebarAsync(restoreFocus: false);
-        await AIContextProvider.LaunchAssistantModelDialogAsync(Content.Chat, openedForMobileView, Content.ReturnFocusElementId);
+
+        // The viewport switch changes which launcher is visible. Keep focus restoration
+        // pointed at the control users can actually reach after the switch completes.
+        var returnFocusElementId = GetReturnFocusElementId(openedForMobileView, Content.ReturnFocusElementId);
+        await AIContextProvider.LaunchAssistantModelDialogAsync(Content.Chat, openedForMobileView, returnFocusElementId);
+    }
+
+    public static string? GetReturnFocusElementId(bool openedForMobileView, string? returnFocusElementId)
+    {
+        return openedForMobileView
+            ? MainLayout.NavigationButtonId
+            : returnFocusElementId;
     }
 
     public async Task StartNewChatAsync()

--- a/src/Aspire.Dashboard/Components/Dialogs/AssistantSidebarDialog.razor.cs
+++ b/src/Aspire.Dashboard/Components/Dialogs/AssistantSidebarDialog.razor.cs
@@ -5,6 +5,7 @@ using Aspire.Dashboard.Components.CustomIcons;
 using Aspire.Dashboard.Model.Assistant;
 using Microsoft.AspNetCore.Components;
 using Microsoft.FluentUI.AspNetCore.Components;
+using Microsoft.JSInterop;
 
 namespace Aspire.Dashboard.Components.Dialogs;
 
@@ -26,6 +27,9 @@ public partial class AssistantSidebarDialog : IAsyncDisposable
 
     [Inject]
     public required IServiceProvider ServiceProvider { get; init; }
+
+    [Inject]
+    public required IJSRuntime JS { get; init; }
 
     protected override void OnInitialized()
     {
@@ -50,16 +54,16 @@ public partial class AssistantSidebarDialog : IAsyncDisposable
         }
     }
 
-    public void CloseDialog()
+    public async Task CloseDialogAsync()
     {
-        AIContextProvider.HideAssistantSidebarAsync();
+        await AIContextProvider.HideAssistantSidebarAsync();
     }
 
     public async Task ExpandDialogAsync(bool openedForMobileView)
     {
         Content.Chat.DisplayContainer = AssistantChatDisplayContainer.Switching;
-        await AIContextProvider.HideAssistantSidebarAsync();
-        await AIContextProvider.LaunchAssistantModelDialogAsync(Content.Chat, openedForMobileView);
+        await AIContextProvider.HideAssistantSidebarAsync(restoreFocus: false);
+        await AIContextProvider.LaunchAssistantModelDialogAsync(Content.Chat, openedForMobileView, Content.ReturnFocusElementId);
     }
 
     public async Task StartNewChatAsync()

--- a/src/Aspire.Dashboard/Components/Layout/MainLayout.razor
+++ b/src/Aspire.Dashboard/Components/Layout/MainLayout.razor
@@ -29,7 +29,8 @@
                 <FluentIcon Value="@(new AspireIcons.Size24.GitHub())" Color="Color.Neutral"/>
             </FluentAnchor>
             <FluentButton Class="header-button"
-                          Appearance="Appearance.Stealth" OnClick="@LaunchHelpAsync"
+                          Id="@HelpButtonId"
+                          Appearance="Appearance.Stealth" OnClick="@(() => LaunchHelpAsync(HelpButtonId))"
                           Title="@Loc[nameof(Layout.MainLayoutAspireDashboardHelpLink)]" aria-label="@Loc[nameof(Layout.MainLayoutAspireDashboardHelpLink)]">
                 <FluentIcon Value="@(new Icons.Regular.Size24.QuestionCircle())" Color="Color.Neutral"/>
             </FluentButton>
@@ -44,14 +45,16 @@
             @if (AIContextProvider.Enabled)
             {
                 <FluentButton Class="@("header-button" + ((AIContextProvider.AssistantChatViewModel is {} vm && AIContextProvider.ShowAssistantSidebarDialog) ? " header-button-selected" : ""))"
-                              Appearance="Appearance.Stealth" OnClick="@LaunchAssistantAsync"
+                              Id="@AssistantButtonId"
+                              Appearance="Appearance.Stealth" OnClick="@(() => LaunchAssistantAsync(AssistantButtonId))"
                               Title="@AIAssistantLoc[nameof(AIAssistant.AIAssistantLaunchButtonText)]" aria-label="@AIAssistantLoc[nameof(AIAssistant.AIAssistantLaunchButtonText)]">
                     <FluentIcon Value="@(new AspireIcons.Size24.GitHubCopilot())" Color="Color.Neutral" />
                 </FluentButton>
             }
             <NotificationsHeaderButton OnClick="@LaunchNotificationsAsync" />
             <FluentButton Class="header-button"
-                          Appearance="Appearance.Stealth" OnClick="@LaunchSettingsAsync"
+                          Id="@SettingsButtonId"
+                          Appearance="Appearance.Stealth" OnClick="@(() => LaunchSettingsAsync(SettingsButtonId))"
                           Title="@Loc[nameof(Layout.MainLayoutLaunchSettings)]" aria-label="@Loc[nameof(Layout.MainLayoutLaunchSettings)]">
                 <FluentIcon Value="@(new Icons.Regular.Size24.Settings())" Color="Color.Neutral"/>
             </FluentButton>
@@ -60,7 +63,7 @@
 
         @if (AIContextProvider.AssistantChatViewModel is {} vm && AIContextProvider.ShowAssistantSidebarDialog)
         {
-            <Aspire.Dashboard.Components.Dialogs.AssistantSidebarDialog Content="@(new AssistantDialogViewModel { Chat = vm })" />
+            <Aspire.Dashboard.Components.Dialogs.AssistantSidebarDialog Content="@(new AssistantDialogViewModel { Chat = vm, ReturnFocusElementId = _assistantReturnFocusElementId })" />
         }
         <DesktopNavMenu/>
     }
@@ -75,6 +78,7 @@
             <UserProfile/>
             <FluentButton
                 IconEnd="@(_isNavMenuOpen ? new Icons.Regular.Size24.Dismiss() : new Icons.Regular.Size24.Navigation())"
+                Id="@NavigationButtonId"
                 Title="@(DialogsLoc[nameof(Dialogs.HelpDialogCategoryNavigation)])"
                 Appearance="Appearance.Stealth"
                 BackgroundColor="transparent"

--- a/src/Aspire.Dashboard/Components/Layout/MainLayout.razor.cs
+++ b/src/Aspire.Dashboard/Components/Layout/MainLayout.razor.cs
@@ -27,11 +27,19 @@ public partial class MainLayout : IGlobalKeydownListener, IAsyncDisposable
     private DotNetObjectReference<ShortcutManager>? _shortcutManagerReference;
     private DotNetObjectReference<MainLayout>? _layoutReference;
     private IDialogReference? _openPageDialog;
+    private string? _pendingReturnFocusElementId;
+    private string? _assistantReturnFocusElementId;
+    private bool _suppressNextDialogFocusRestore;
+    private bool _assistantSidebarWasVisible;
     private IDisposable? _aiDisplayChangedSubscription;
     private const string SettingsDialogId = "SettingsDialog";
     private const string HelpDialogId = "HelpDialog";
     private const string NotificationsDialogId = "NotificationsDialog";
     private const string AIAgentsDialogId = "AIAgentsDialog";
+    internal const string HelpButtonId = "dashboard-help-button";
+    internal const string AssistantButtonId = "dashboard-assistant-button";
+    internal const string SettingsButtonId = "dashboard-settings-button";
+    internal const string NavigationButtonId = "dashboard-navigation-button";
 
     [Inject]
     public required ThemeManager ThemeManager { get; init; }
@@ -124,7 +132,26 @@ public partial class MainLayout : IGlobalKeydownListener, IAsyncDisposable
 
         await DisplayUnsecuredEndpointsMessageAsync();
 
-        _aiDisplayChangedSubscription = AIContextProvider.OnDisplayChanged(() => InvokeAsync(StateHasChanged));
+        _aiDisplayChangedSubscription = AIContextProvider.OnDisplayChanged(() => InvokeAsync(() =>
+        {
+            if (!AIContextProvider.ShowAssistantSidebarDialog)
+            {
+                if (_assistantSidebarWasVisible && AIContextProvider.RestoreFocusOnAssistantSidebarHidden)
+                {
+                    _pendingReturnFocusElementId = _assistantReturnFocusElementId;
+                }
+
+                _assistantReturnFocusElementId = null;
+                _assistantSidebarWasVisible = false;
+            }
+            else
+            {
+                _assistantReturnFocusElementId = AIContextProvider.AssistantReturnFocusElementId;
+                _assistantSidebarWasVisible = true;
+            }
+
+            StateHasChanged();
+        }));
     }
 
     private async Task DisplayUnsecuredEndpointsMessageAsync()
@@ -202,6 +229,12 @@ public partial class MainLayout : IGlobalKeydownListener, IAsyncDisposable
             _keyboardHandlers = await JS.InvokeAsync<IJSObjectReference>("window.registerGlobalKeydownListener", _shortcutManagerReference);
             ShortcutManager.AddGlobalKeydownListener(this);
         }
+
+        if (_pendingReturnFocusElementId is { } elementId && _openPageDialog is null)
+        {
+            _pendingReturnFocusElementId = null;
+            await JS.InvokeVoidAsync("focusElement", elementId);
+        }
     }
 
     protected override void OnParametersSet()
@@ -213,7 +246,11 @@ public partial class MainLayout : IGlobalKeydownListener, IAsyncDisposable
         }
     }
 
-    private async Task LaunchHelpAsync()
+    private string GetDefaultReturnFocusElementId(string desktopButtonId) => ViewportInformation.IsDesktop ? desktopButtonId : NavigationButtonId;
+
+    private Task LaunchHelpAsync() => LaunchHelpAsync(GetDefaultReturnFocusElementId(HelpButtonId));
+
+    private async Task LaunchHelpAsync(string? returnFocusElementId)
     {
         DialogParameters parameters = new()
         {
@@ -227,25 +264,50 @@ public partial class MainLayout : IGlobalKeydownListener, IAsyncDisposable
             Width = "700px",
             Height = "auto",
             Id = HelpDialogId,
-            OnDialogClosing = EventCallback.Factory.Create<DialogInstance>(this, HandleDialogClose)
+            OnDialogClosing = EventCallback.Factory.Create<DialogInstance>(this, _ => HandleDialogClose(returnFocusElementId))
         };
 
-        if (_openPageDialog is not null)
+        if (!await CloseOpenPageDialogForReplacementAsync(HelpDialogId).ConfigureAwait(true))
         {
-            if (Equals(_openPageDialog.Id, HelpDialogId) && !_openPageDialog.Result.IsCompleted)
-            {
-                return;
-            }
-
-            await _openPageDialog.CloseAsync();
+            return;
         }
 
         _openPageDialog = await DialogService.ShowDialogAsync<HelpDialog>(parameters).ConfigureAwait(true);
     }
 
-    private void HandleDialogClose(DialogInstance dialogResult)
+    private void HandleDialogClose(string? returnFocusElementId = null)
     {
         _openPageDialog = null;
+        if (!_suppressNextDialogFocusRestore)
+        {
+            _pendingReturnFocusElementId = returnFocusElementId;
+        }
+    }
+
+    private async Task<bool> CloseOpenPageDialogForReplacementAsync(string dialogId)
+    {
+        if (_openPageDialog is null)
+        {
+            return true;
+        }
+
+        if (Equals(_openPageDialog.Id, dialogId) && !_openPageDialog.Result.IsCompleted)
+        {
+            return false;
+        }
+
+        _suppressNextDialogFocusRestore = true;
+        try
+        {
+            await _openPageDialog.CloseAsync();
+            _pendingReturnFocusElementId = null;
+        }
+        finally
+        {
+            _suppressNextDialogFocusRestore = false;
+        }
+
+        return true;
     }
 
     public async Task LaunchAIAgentsAsync()
@@ -262,23 +324,20 @@ public partial class MainLayout : IGlobalKeydownListener, IAsyncDisposable
             Width = "700px",
             Height = "auto",
             Id = AIAgentsDialogId,
-            OnDialogClosing = EventCallback.Factory.Create<DialogInstance>(this, HandleDialogClose)
+            OnDialogClosing = EventCallback.Factory.Create<DialogInstance>(this, _ => HandleDialogClose())
         };
 
-        if (_openPageDialog is not null)
+        if (!await CloseOpenPageDialogForReplacementAsync(AIAgentsDialogId).ConfigureAwait(true))
         {
-            if (Equals(_openPageDialog.Id, AIAgentsDialogId) && !_openPageDialog.Result.IsCompleted)
-            {
-                return;
-            }
-
-            await _openPageDialog.CloseAsync();
+            return;
         }
 
         _openPageDialog = await DialogService.ShowDialogAsync<AIAgentsDialog>(parameters).ConfigureAwait(true);
     }
 
-    public async Task LaunchSettingsAsync()
+    public Task LaunchSettingsAsync() => LaunchSettingsAsync(GetDefaultReturnFocusElementId(SettingsButtonId));
+
+    private async Task LaunchSettingsAsync(string? returnFocusElementId)
     {
         var parameters = new DialogParameters
         {
@@ -291,17 +350,12 @@ public partial class MainLayout : IGlobalKeydownListener, IAsyncDisposable
             Width = "300px",
             Height = "auto",
             Id = SettingsDialogId,
-            OnDialogClosing = EventCallback.Factory.Create<DialogInstance>(this, HandleDialogClose)
+            OnDialogClosing = EventCallback.Factory.Create<DialogInstance>(this, _ => HandleDialogClose(returnFocusElementId))
         };
 
-        if (_openPageDialog is not null)
+        if (!await CloseOpenPageDialogForReplacementAsync(SettingsDialogId).ConfigureAwait(true))
         {
-            if (Equals(_openPageDialog.Id, SettingsDialogId) && !_openPageDialog.Result.IsCompleted)
-            {
-                return;
-            }
-
-            await _openPageDialog.CloseAsync();
+            return;
         }
 
         // Ensure the currently set theme is immediately available to display in settings dialog.
@@ -330,17 +384,12 @@ public partial class MainLayout : IGlobalKeydownListener, IAsyncDisposable
             Width = "350px",
             Height = "auto",
             Id = NotificationsDialogId,
-            OnDialogClosing = EventCallback.Factory.Create<DialogInstance>(this, HandleDialogClose)
+            OnDialogClosing = EventCallback.Factory.Create<DialogInstance>(this, _ => HandleDialogClose())
         };
 
-        if (_openPageDialog is not null)
+        if (!await CloseOpenPageDialogForReplacementAsync(NotificationsDialogId).ConfigureAwait(true))
         {
-            if (Equals(_openPageDialog.Id, NotificationsDialogId) && !_openPageDialog.Result.IsCompleted)
-            {
-                return;
-            }
-
-            await _openPageDialog.CloseAsync();
+            return;
         }
 
         if (ViewportInformation.IsDesktop)
@@ -353,7 +402,9 @@ public partial class MainLayout : IGlobalKeydownListener, IAsyncDisposable
         }
     }
 
-    public async Task LaunchAssistantAsync()
+    public Task LaunchAssistantAsync() => LaunchAssistantAsync(GetDefaultReturnFocusElementId(AssistantButtonId));
+
+    private async Task LaunchAssistantAsync(string? returnFocusElementId)
     {
         if (AIContextProvider.AssistantChatViewModel != null && AIContextProvider.ShowAssistantSidebarDialog)
         {
@@ -368,11 +419,13 @@ public partial class MainLayout : IGlobalKeydownListener, IAsyncDisposable
 
             if (ViewportInformation.IsDesktop)
             {
-                await AIContextProvider.LaunchAssistantSidebarAsync(viewModel);
+                _assistantReturnFocusElementId = returnFocusElementId;
+                await AIContextProvider.LaunchAssistantSidebarAsync(viewModel, returnFocusElementId);
             }
             else
             {
-                await AIContextProvider.LaunchAssistantModelDialogAsync(viewModel);
+                _assistantReturnFocusElementId = null;
+                await AIContextProvider.LaunchAssistantModelDialogAsync(viewModel, returnFocusElementId: returnFocusElementId);
             }
 
             await initializeTask;

--- a/src/Aspire.Dashboard/Model/Assistant/AIContextProvider.cs
+++ b/src/Aspire.Dashboard/Model/Assistant/AIContextProvider.cs
@@ -8,6 +8,7 @@ using Aspire.Dashboard.Model.Assistant.Prompts;
 using Aspire.Dashboard.Telemetry;
 using Microsoft.Extensions.Options;
 using Microsoft.FluentUI.AspNetCore.Components;
+using Microsoft.JSInterop;
 
 namespace Aspire.Dashboard.Model.Assistant;
 
@@ -44,6 +45,8 @@ public class AIContextProvider : IAIContextProvider
     public bool Enabled { get; }
     public AssistantChatViewModel? AssistantChatViewModel { get; private set; }
     public bool ShowAssistantSidebarDialog { get; private set; }
+    public string? AssistantReturnFocusElementId { get; private set; }
+    public bool RestoreFocusOnAssistantSidebarHidden { get; private set; } = true;
     public AssistantChatState? ChatState { get; set; }
     public IceBreakersBuilder IceBreakersBuilder { get; }
 
@@ -193,6 +196,8 @@ public class AIContextProvider : IAIContextProvider
 
         AssistantChatViewModel = viewModel;
         ShowAssistantSidebarDialog = true;
+        AssistantReturnFocusElementId = null;
+        RestoreFocusOnAssistantSidebarHidden = false;
 
         await ExecuteSubscriptionsAsync(_displayChangedSubscriptions).ConfigureAwait(false);
         await initializeTask.ConfigureAwait(false);
@@ -240,32 +245,38 @@ public class AIContextProvider : IAIContextProvider
         await ExecuteSubscriptionsAsync(_displayChangedSubscriptions).ConfigureAwait(false);
     }
 
-    public async Task HideAssistantSidebarAsync()
+    public async Task HideAssistantSidebarAsync(bool restoreFocus = true)
     {
         AssistantChatViewModel = null;
         ShowAssistantSidebarDialog = false;
+        RestoreFocusOnAssistantSidebarHidden = restoreFocus;
         await ExecuteSubscriptionsAsync(_displayChangedSubscriptions).ConfigureAwait(false);
     }
 
-    public async Task LaunchAssistantModelDialogAsync(AssistantChatViewModel viewModel, bool openedForMobileView = false)
+    public async Task LaunchAssistantModelDialogAsync(AssistantChatViewModel viewModel, bool openedForMobileView = false, string? returnFocusElementId = null)
     {
         this.EnsureEnabled();
 
         var dialogService = _serviceProvider.GetRequiredService<IDialogService>();
-        await AssistantModalDialog.OpenDialogAsync(dialogService, "Assistant", new AssistantDialogViewModel
+        var js = _serviceProvider.GetRequiredService<IJSRuntime>();
+        AssistantReturnFocusElementId = returnFocusElementId;
+        await AssistantModalDialog.OpenDialogAsync(dialogService, js, "Assistant", new AssistantDialogViewModel
         {
             Chat = viewModel,
-            OpenedForMobileView = openedForMobileView
-        }).ConfigureAwait(false);
+            OpenedForMobileView = openedForMobileView,
+            ReturnFocusElementId = returnFocusElementId
+        }, returnFocusElementId).ConfigureAwait(false);
         await ExecuteSubscriptionsAsync(_displayChangedSubscriptions).ConfigureAwait(false);
     }
 
-    public async Task LaunchAssistantSidebarAsync(AssistantChatViewModel viewModel)
+    public async Task LaunchAssistantSidebarAsync(AssistantChatViewModel viewModel, string? returnFocusElementId = null)
     {
         this.EnsureEnabled();
 
         AssistantChatViewModel = viewModel;
         ShowAssistantSidebarDialog = true;
+        AssistantReturnFocusElementId = returnFocusElementId;
+        RestoreFocusOnAssistantSidebarHidden = true;
         await ExecuteSubscriptionsAsync(_displayChangedSubscriptions).ConfigureAwait(false);
     }
 

--- a/src/Aspire.Dashboard/Model/Assistant/AssistantDialogViewModel.cs
+++ b/src/Aspire.Dashboard/Model/Assistant/AssistantDialogViewModel.cs
@@ -8,4 +8,6 @@ public sealed class AssistantDialogViewModel
     public AssistantChatViewModel Chat { get; set; } = null!;
 
     public bool OpenedForMobileView { get; set; }
+
+    public string? ReturnFocusElementId { get; set; }
 }

--- a/src/Aspire.Dashboard/Model/Assistant/IAIContextProvider.cs
+++ b/src/Aspire.Dashboard/Model/Assistant/IAIContextProvider.cs
@@ -19,12 +19,14 @@ public interface IAIContextProvider
 
     AssistantChatViewModel? AssistantChatViewModel { get; }
     bool ShowAssistantSidebarDialog { get; }
+    string? AssistantReturnFocusElementId { get; }
+    bool RestoreFocusOnAssistantSidebarHidden { get; }
     AssistantChatState? ChatState { get; set; }
 
-    Task LaunchAssistantModelDialogAsync(AssistantChatViewModel viewModel, bool openedForMobileView = false);
+    Task LaunchAssistantModelDialogAsync(AssistantChatViewModel viewModel, bool openedForMobileView = false, string? returnFocusElementId = null);
     Task LaunchAssistantSidebarAsync(Func<InitializePromptContext, Task> sendInitialPrompt);
-    Task LaunchAssistantSidebarAsync(AssistantChatViewModel viewModel);
-    Task HideAssistantSidebarAsync();
+    Task LaunchAssistantSidebarAsync(AssistantChatViewModel viewModel, string? returnFocusElementId = null);
+    Task HideAssistantSidebarAsync(bool restoreFocus = true);
     Task SetAssistantSidebarAsync(AssistantChatViewModel viewModel);
     Task<GhcpInfoResponse> GetInfoAsync(CancellationToken cancellationToken);
 }

--- a/tests/Aspire.Dashboard.Components.Tests/Layout/MainLayoutTests.cs
+++ b/tests/Aspire.Dashboard.Components.Tests/Layout/MainLayoutTests.cs
@@ -19,6 +19,7 @@ using Microsoft.FluentUI.AspNetCore.Components.Components.Tooltip;
 using Microsoft.JSInterop;
 using Xunit;
 using AssistantModalDialog = Aspire.Dashboard.Components.Dialogs.AssistantModalDialog;
+using AssistantSidebarDialog = Aspire.Dashboard.Components.Dialogs.AssistantSidebarDialog;
 
 namespace Aspire.Dashboard.Components.Tests.Layout;
 
@@ -360,6 +361,24 @@ public partial class MainLayoutTests : DashboardTestContext
                 Assert.Equal("focusElement", invocation.Identifier);
                 Assert.Collection(invocation.Arguments, argument => Assert.Equal("dashboard-assistant-button", argument));
             });
+    }
+
+    [Theory]
+    [InlineData(true, "dashboard-assistant-button", "dashboard-navigation-button")]
+    [InlineData(false, "dashboard-assistant-button", "dashboard-assistant-button")]
+    [InlineData(false, null, null)]
+    public void AssistantSidebarSwitchToModal_UsesVisibleLauncherAsReturnFocusTarget(bool openedForMobileView, string? returnFocusElementId, string? expectedReturnFocusElementId)
+    {
+        Assert.Equal(expectedReturnFocusElementId, AssistantSidebarDialog.GetReturnFocusElementId(openedForMobileView, returnFocusElementId));
+    }
+
+    [Theory]
+    [InlineData(true, "dashboard-navigation-button", "dashboard-assistant-button")]
+    [InlineData(false, "dashboard-navigation-button", "dashboard-navigation-button")]
+    [InlineData(false, null, null)]
+    public void AssistantModalSwitchToSidebar_UsesVisibleLauncherAsReturnFocusTarget(bool openedForMobileView, string? returnFocusElementId, string? expectedReturnFocusElementId)
+    {
+        Assert.Equal(expectedReturnFocusElementId, AssistantModalDialog.GetSidebarReturnFocusElementId(openedForMobileView, returnFocusElementId));
     }
 
     private void SetupMainLayoutServices(

--- a/tests/Aspire.Dashboard.Components.Tests/Layout/MainLayoutTests.cs
+++ b/tests/Aspire.Dashboard.Components.Tests/Layout/MainLayoutTests.cs
@@ -6,14 +6,19 @@ using Aspire.Dashboard.Components.Resize;
 using Aspire.Dashboard.Components.Tests.Shared;
 using Aspire.Dashboard.Configuration;
 using Aspire.Dashboard.Model;
+using Aspire.Dashboard.Model.Assistant;
+using Aspire.Dashboard.Tests;
 using Aspire.Dashboard.Tests.Shared;
 using Aspire.Dashboard.Utils;
+using Aspire.Tests.Shared;
 using Bunit;
 using Microsoft.AspNetCore.InternalTesting;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.FluentUI.AspNetCore.Components;
 using Microsoft.FluentUI.AspNetCore.Components.Components.Tooltip;
+using Microsoft.JSInterop;
 using Xunit;
+using AssistantModalDialog = Aspire.Dashboard.Components.Dialogs.AssistantModalDialog;
 
 namespace Aspire.Dashboard.Components.Tests.Layout;
 
@@ -184,9 +189,197 @@ public partial class MainLayoutTests : DashboardTestContext
         }
     }
 
-    private void SetupMainLayoutServices(TestLocalStorage? localStorage = null, MessageService? messageService = null, Action<DashboardOptions>? configureOptions = null)
+    [Theory]
+    [InlineData(true, "dashboard-help-button", "HelpDialog", "dashboard-help-button")]
+    [InlineData(true, "dashboard-settings-button", "SettingsDialog", "dashboard-settings-button")]
+    [InlineData(false, "dashboard-navigation-button", "HelpDialog", "dashboard-navigation-button")]
+    [InlineData(false, "dashboard-navigation-button", "SettingsDialog", "dashboard-navigation-button")]
+    public async Task HeaderDialogClose_RestoresFocusToLaunchButton(bool isDesktop, string launchButtonId, string expectedDialogId, string expectedFocusId)
+    {
+        DialogParameters? capturedParameters = null;
+        TestDialogService? dialogService = null;
+        dialogService = new TestDialogService(onShowDialog: (_, parameters) =>
+        {
+            capturedParameters = parameters;
+            return Task.FromResult<IDialogReference>(new DialogReference(parameters.Id, dialogService!));
+        });
+
+        SetupMainLayoutServices(dialogService: dialogService);
+        JSInterop.SetupVoid("focusElement", _ => true);
+
+        var cut = RenderComponent<MainLayout>(builder =>
+        {
+            builder.Add(p => p.ViewportInformation, new ViewportInformation(IsDesktop: isDesktop, IsUltraLowHeight: false, IsUltraLowWidth: false));
+        });
+
+        if (isDesktop)
+        {
+            await cut.InvokeAsync(() => cut.Find($"#{launchButtonId}").Click());
+        }
+        else
+        {
+            var menuItemName = expectedDialogId == "HelpDialog"
+                ? "Help"
+                : "Settings";
+
+            await cut.InvokeAsync(() => cut.Find("#dashboard-navigation-button").Click());
+            await cut.InvokeAsync(() => cut.FindAll("fluent-menu-item").Single(item => item.TextContent.Contains(menuItemName, StringComparison.OrdinalIgnoreCase)).Click());
+        }
+
+        Assert.NotNull(capturedParameters);
+        Assert.Equal(expectedDialogId, capturedParameters.Id);
+
+        await cut.InvokeAsync(() => capturedParameters.OnDialogClosing.InvokeAsync(null!));
+
+        cut.WaitForAssertion(() =>
+        {
+            Assert.Contains(JSInterop.Invocations, invocation =>
+                invocation.Identifier == "focusElement" &&
+                invocation.Arguments.Count == 1 &&
+                string.Equals((string?)invocation.Arguments[0], expectedFocusId, StringComparison.Ordinal));
+        });
+    }
+
+    [Theory]
+    [InlineData(AspireKeyboardShortcut.Help, "dashboard-help-button", "HelpDialog")]
+    [InlineData(AspireKeyboardShortcut.Settings, "dashboard-settings-button", "SettingsDialog")]
+    public async Task HeaderDialogShortcutClose_RestoresFocusToLaunchButton(AspireKeyboardShortcut shortcut, string launchButtonId, string expectedDialogId)
+    {
+        DialogParameters? capturedParameters = null;
+        TestDialogService? dialogService = null;
+        dialogService = new TestDialogService(onShowDialog: (_, parameters) =>
+        {
+            capturedParameters = parameters;
+            return Task.FromResult<IDialogReference>(new DialogReference(parameters.Id, dialogService!));
+        });
+
+        SetupMainLayoutServices(dialogService: dialogService);
+        JSInterop.SetupVoid("focusElement", _ => true);
+
+        var cut = RenderComponent<MainLayout>(builder =>
+        {
+            builder.Add(p => p.ViewportInformation, new ViewportInformation(IsDesktop: true, IsUltraLowHeight: false, IsUltraLowWidth: false));
+        });
+
+        await cut.InvokeAsync(() => cut.Instance.OnPageKeyDownAsync(shortcut));
+
+        Assert.NotNull(capturedParameters);
+        Assert.Equal(expectedDialogId, capturedParameters.Id);
+
+        await cut.InvokeAsync(() => capturedParameters.OnDialogClosing.InvokeAsync(null!));
+
+        cut.WaitForAssertion(() =>
+        {
+            Assert.Contains(JSInterop.Invocations, invocation =>
+                invocation.Identifier == "focusElement" &&
+                invocation.Arguments.Count == 1 &&
+                string.Equals((string?)invocation.Arguments[0], launchButtonId, StringComparison.Ordinal));
+        });
+    }
+
+    [Fact]
+    public async Task AssistantSidebarHide_RestoresFocusToLaunchButton()
+    {
+        var aiContextProvider = new TestAIContextProvider();
+        SetupMainLayoutServices(aiContextProvider: aiContextProvider);
+        JSInterop.SetupVoid("focusElement", _ => true);
+
+        var cut = RenderComponent<MainLayout>(builder =>
+        {
+            builder.Add(p => p.ViewportInformation, new ViewportInformation(IsDesktop: true, IsUltraLowHeight: false, IsUltraLowWidth: false));
+        });
+
+        typeof(MainLayout)
+            .GetField("_assistantReturnFocusElementId", System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic)!
+            .SetValue(cut.Instance, "dashboard-assistant-button");
+        typeof(MainLayout)
+            .GetField("_assistantSidebarWasVisible", System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic)!
+            .SetValue(cut.Instance, true);
+
+        Func<Task> hideAssistantSidebarAsync = () => aiContextProvider.HideAssistantSidebarAsync();
+        await cut.InvokeAsync(hideAssistantSidebarAsync);
+
+        cut.WaitForAssertion(() =>
+        {
+            Assert.Contains(JSInterop.Invocations, invocation =>
+                invocation.Identifier == "focusElement" &&
+                invocation.Arguments.Count == 1 &&
+                string.Equals((string?)invocation.Arguments[0], "dashboard-assistant-button", StringComparison.Ordinal));
+        });
+    }
+
+    [Fact]
+    public async Task PromptLaunchedAssistantSidebarHide_DoesNotReusePreviousFocusTarget()
+    {
+        var aiContextProvider = new TestAIContextProvider();
+        SetupMainLayoutServices(aiContextProvider: aiContextProvider);
+        JSInterop.SetupVoid("focusElement", _ => true);
+
+        var cut = RenderComponent<MainLayout>(builder =>
+        {
+            builder.Add(p => p.ViewportInformation, new ViewportInformation(IsDesktop: true, IsUltraLowHeight: false, IsUltraLowWidth: false));
+        });
+
+        typeof(MainLayout)
+            .GetField("_assistantReturnFocusElementId", System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic)!
+            .SetValue(cut.Instance, "dashboard-assistant-button");
+        typeof(MainLayout)
+            .GetField("_assistantSidebarWasVisible", System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic)!
+            .SetValue(cut.Instance, true);
+
+        Func<Task> launchPromptSidebarAsync = () => aiContextProvider.LaunchAssistantSidebarAsync(_ => Task.CompletedTask);
+        await cut.InvokeAsync(launchPromptSidebarAsync);
+
+        Func<Task> hideAssistantSidebarAsync = () => aiContextProvider.HideAssistantSidebarAsync();
+        await cut.InvokeAsync(hideAssistantSidebarAsync);
+
+        Assert.DoesNotContain(JSInterop.Invocations, invocation => invocation.Identifier == "focusElement");
+    }
+
+    [Fact]
+    public async Task AssistantModalDialogClose_RestoresFocusToLaunchButton()
+    {
+        DialogParameters? capturedParameters = null;
+        TestDialogService? dialogService = null;
+        dialogService = new TestDialogService(onShowDialog: (_, parameters) =>
+        {
+            capturedParameters = parameters;
+            return Task.FromResult<IDialogReference>(new DialogReference(parameters.Id, dialogService!));
+        });
+        var js = new RecordingJSRuntime();
+
+        await AssistantModalDialog.OpenDialogAsync(dialogService, js, "Assistant", new AssistantDialogViewModel { Chat = null! }, "dashboard-assistant-button");
+
+        Assert.NotNull(capturedParameters);
+
+        await capturedParameters.OnDialogClosing.InvokeAsync(null!);
+
+        Assert.Collection(js.Invocations,
+            invocation =>
+            {
+                Assert.Equal("focusElement", invocation.Identifier);
+                Assert.Collection(invocation.Arguments, argument => Assert.Equal("dashboard-assistant-button", argument));
+            });
+    }
+
+    private void SetupMainLayoutServices(
+        TestLocalStorage? localStorage = null,
+        MessageService? messageService = null,
+        Action<DashboardOptions>? configureOptions = null,
+        IDialogService? dialogService = null,
+        IAIContextProvider? aiContextProvider = null)
     {
         FluentUISetupHelpers.AddCommonDashboardServices(this, localStorage: localStorage, messageService: messageService);
+
+        if (dialogService is not null)
+        {
+            Services.AddSingleton(dialogService);
+        }
+
+        if (aiContextProvider is not null)
+        {
+            Services.AddSingleton(aiContextProvider);
+        }
 
         Services.AddOptions();
         Services.AddSingleton<IThemeResolver, TestThemeResolver>();
@@ -206,6 +399,10 @@ public partial class MainLayoutTests : DashboardTestContext
         FluentUISetupHelpers.SetupFluentDialogProvider(this);
         FluentUISetupHelpers.SetupFluentOverflow(this);
         FluentUISetupHelpers.SetupFluentAnchor(this);
+        FluentUISetupHelpers.SetupFluentButton(this);
+        FluentUISetupHelpers.SetupFluentMenu(this);
+        FluentUISetupHelpers.SetupFluentAnchoredRegion(this);
+        FluentUISetupHelpers.SetupFluentDivider(this);
 
         var themeModule = JSInterop.SetupModule("/js/app-theme.js");
 
@@ -213,5 +410,24 @@ public partial class MainLayoutTests : DashboardTestContext
         JSInterop.SetupModule("window.registerOpenTextVisualizerOnClick", _ => true);
 
         JSInterop.Setup<BrowserInfo>("window.getBrowserInfo").SetResult(new BrowserInfo { TimeZone = "abc", UserAgent = "mozilla" });
+    }
+
+    private sealed class RecordingJSRuntime : IJSRuntime
+    {
+        public List<Invocation> Invocations { get; } = [];
+
+        public ValueTask<TValue> InvokeAsync<TValue>(string identifier, object?[]? args)
+        {
+            Invocations.Add(new Invocation(identifier, args ?? []));
+            return ValueTask.FromResult(default(TValue)!);
+        }
+
+        public ValueTask<TValue> InvokeAsync<TValue>(string identifier, CancellationToken cancellationToken, object?[]? args)
+        {
+            Invocations.Add(new Invocation(identifier, args ?? []));
+            return ValueTask.FromResult(default(TValue)!);
+        }
+
+        public sealed record Invocation(string Identifier, object?[] Arguments);
     }
 }

--- a/tests/Shared/TestAIContextProvider.cs
+++ b/tests/Shared/TestAIContextProvider.cs
@@ -10,10 +10,16 @@ namespace Aspire.Dashboard.Tests;
 
 public class TestAIContextProvider : IAIContextProvider
 {
+    private readonly object _lock = new();
+    private readonly List<Func<Task>> _displayChangedCallbacks = [];
+
     public AssistantChatViewModel? AssistantChatViewModel { get; set; }
     public bool ShowAssistantSidebarDialog { get; set; }
-    public bool Enabled { get; }
+    public string? AssistantReturnFocusElementId { get; private set; }
+    public bool RestoreFocusOnAssistantSidebarHidden { get; private set; } = true;
+    public bool Enabled { get; set; }
     public AssistantChatState? ChatState { get; set; }
+    public string? LastAssistantModelDialogReturnFocusElementId { get; private set; }
     public IceBreakersBuilder IceBreakersBuilder { get; } = new IceBreakersBuilder(new TestStringLocalizer<AIPrompts>());
 
     public AIContext AddNew(string description, Action<AIContext> configure)
@@ -31,24 +37,36 @@ public class TestAIContextProvider : IAIContextProvider
         throw new NotImplementedException();
     }
 
-    public Task HideAssistantSidebarAsync()
+    public async Task HideAssistantSidebarAsync(bool restoreFocus = true)
     {
-        throw new NotImplementedException();
+        AssistantChatViewModel = null;
+        ShowAssistantSidebarDialog = false;
+        RestoreFocusOnAssistantSidebarHidden = restoreFocus;
+        await ExecuteDisplayChangedCallbacksAsync();
     }
 
-    public Task LaunchAssistantModelDialogAsync(AssistantChatViewModel viewModel, bool openedForMobileView = false)
+    public async Task LaunchAssistantModelDialogAsync(AssistantChatViewModel viewModel, bool openedForMobileView = false, string? returnFocusElementId = null)
     {
-        throw new NotImplementedException();
+        AssistantReturnFocusElementId = returnFocusElementId;
+        LastAssistantModelDialogReturnFocusElementId = returnFocusElementId;
+        await ExecuteDisplayChangedCallbacksAsync();
     }
 
-    public Task LaunchAssistantSidebarAsync(AssistantChatViewModel viewModel)
+    public async Task LaunchAssistantSidebarAsync(AssistantChatViewModel viewModel, string? returnFocusElementId = null)
     {
-        throw new NotImplementedException();
+        AssistantChatViewModel = viewModel;
+        ShowAssistantSidebarDialog = true;
+        AssistantReturnFocusElementId = returnFocusElementId;
+        RestoreFocusOnAssistantSidebarHidden = true;
+        await ExecuteDisplayChangedCallbacksAsync();
     }
 
     public Task LaunchAssistantSidebarAsync(Func<InitializePromptContext, Task> sendInitialPrompt)
     {
-        throw new NotImplementedException();
+        ShowAssistantSidebarDialog = true;
+        AssistantReturnFocusElementId = null;
+        RestoreFocusOnAssistantSidebarHidden = false;
+        return ExecuteDisplayChangedCallbacksAsync();
     }
 
     public IDisposable OnContextChanged(Func<Task> callback)
@@ -58,22 +76,55 @@ public class TestAIContextProvider : IAIContextProvider
 
     public IDisposable OnDisplayChanged(Func<Task> callback)
     {
-        return new DisplayChangedSubscription();
+        lock (_lock)
+        {
+            _displayChangedCallbacks.Add(callback);
+        }
+
+        return new DisplayChangedSubscription(this, callback);
     }
 
     public void Remove(AIContext context)
     {
     }
 
-    public Task SetAssistantSidebarAsync(AssistantChatViewModel viewModel)
+    public async Task SetAssistantSidebarAsync(AssistantChatViewModel viewModel)
     {
-        throw new NotImplementedException();
+        AssistantChatViewModel = viewModel;
+        await ExecuteDisplayChangedCallbacksAsync();
+    }
+
+    private async Task ExecuteDisplayChangedCallbacksAsync()
+    {
+        Func<Task>[] callbacks;
+        lock (_lock)
+        {
+            callbacks = [.. _displayChangedCallbacks];
+        }
+
+        foreach (var callback in callbacks)
+        {
+            await callback();
+        }
     }
 
     private sealed class DisplayChangedSubscription : IDisposable
     {
+        private readonly TestAIContextProvider _provider;
+        private readonly Func<Task> _callback;
+
+        public DisplayChangedSubscription(TestAIContextProvider provider, Func<Task> callback)
+        {
+            _provider = provider;
+            _callback = callback;
+        }
+
         public void Dispose()
         {
+            lock (_provider._lock)
+            {
+                _provider._displayChangedCallbacks.Remove(_callback);
+            }
         }
     }
 }

--- a/tests/Shared/TestDialogService.cs
+++ b/tests/Shared/TestDialogService.cs
@@ -53,7 +53,10 @@ public class TestDialogService : IDialogService
         return reference;
     }
 
-    public Task<IDialogReference> ShowDialogAsync<TDialog>(DialogParameters parameters) where TDialog : IDialogContentComponent => throw new NotImplementedException();
+    public async Task<IDialogReference> ShowDialogAsync<TDialog>(DialogParameters parameters) where TDialog : IDialogContentComponent
+    {
+        return await RunShowDialogCallbackAsync(typeof(TDialog), new object(), parameters).ConfigureAwait(false);
+    }
     public Task<IDialogReference> ShowDialogAsync(RenderFragment renderFragment, DialogParameters dialogParameters) => throw new NotImplementedException();
     public Task<IDialogReference> ShowDialogAsync<TDialog, TData>(DialogParameters<TData> parameters) where TDialog : IDialogContentComponent<TData> where TData : class => throw new NotImplementedException();
     public void ShowError(string message, string? title = null, string? primaryText = null) => throw new NotImplementedException();
@@ -74,9 +77,18 @@ public class TestDialogService : IDialogService
     }
     public void ShowPanel<TDialog, TData>(DialogParameters<TData> parameters) where TDialog : IDialogContentComponent<TData> where TData : class => throw new NotImplementedException();
     public void ShowPanel<TData>(Type dialogComponent, DialogParameters<TData> parameters) where TData : class => throw new NotImplementedException();
-    public Task<IDialogReference> ShowPanelAsync<TData>(Type dialogComponent, TData data, DialogParameters parameters) where TData : class => throw new NotImplementedException();
-    public Task<IDialogReference> ShowPanelAsync<TDialog>(object data, DialogParameters parameters) where TDialog : IDialogContentComponent => throw new NotImplementedException();
-    public Task<IDialogReference> ShowPanelAsync<TDialog>(DialogParameters parameters) where TDialog : IDialogContentComponent => throw new NotImplementedException();
+    public async Task<IDialogReference> ShowPanelAsync<TData>(Type dialogComponent, TData data, DialogParameters parameters) where TData : class
+    {
+        return await RunShowDialogCallbackAsync(dialogComponent, data, parameters).ConfigureAwait(false);
+    }
+    public async Task<IDialogReference> ShowPanelAsync<TDialog>(object data, DialogParameters parameters) where TDialog : IDialogContentComponent
+    {
+        return await RunShowDialogCallbackAsync(typeof(TDialog), data, parameters).ConfigureAwait(false);
+    }
+    public async Task<IDialogReference> ShowPanelAsync<TDialog>(DialogParameters parameters) where TDialog : IDialogContentComponent
+    {
+        return await RunShowDialogCallbackAsync(typeof(TDialog), new object(), parameters).ConfigureAwait(false);
+    }
     public Task<IDialogReference> ShowPanelAsync<TDialog, TData>(DialogParameters<TData> parameters) where TDialog : IDialogContentComponent<TData> where TData : class => throw new NotImplementedException();
     public Task<IDialogReference> ShowPanelAsync<TData>(Type dialogComponent, DialogParameters<TData> parameters) where TData : class => throw new NotImplementedException();
     public void ShowSplashScreen(object receiver, Func<DialogResult, Task> callback, DialogParameters<SplashScreenContent> parameters) => throw new NotImplementedException();


### PR DESCRIPTION
## Description

Fixes #10119.

Restores focus to stable launcher controls after closing Help, Settings, and GitHub Copilot surfaces. The change covers desktop header launchers, keyboard shortcuts, mobile navigation launchers, assistant sidebar hides, assistant modal closes, and assistant sidebar/modal transitions.

Evidence: https://github.com/adamint/aspire/tree/a11y-artifacts-20260601042635/10119

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
