### PR TITLE
Add Aspire test run DCP leases

### DIFF
--- a/eng/pipelines/release-publish-nuget.yml
+++ b/eng/pipelines/release-publish-nuget.yml
@@ -2061,6 +2061,12 @@ extends:
             templateContext:
               type: releaseJob
               isProduction: true
+              # No ESRP publish in this job (vsce publishes directly to the VS Code Marketplace
+              # using a PAT). Skip the auto-injected MicroBuildAuthorizePublishPlugin@0 so it
+              # does not 401 against the devdiv MicroBuildToolset feed.
+              mb:
+                publish:
+                  enabled: false
               inputs:
                 - input: pipelineArtifact
                   artifactName: aspire-vscode-extension

--- a/eng/pipelines/release-publish-nuget.yml
+++ b/eng/pipelines/release-publish-nuget.yml
@@ -2061,8 +2061,8 @@ extends:
             templateContext:
               type: releaseJob
               isProduction: true
-              # No ESRP publish in this job (vsce publishes directly to the VS Code Marketplace
-              # using a PAT). Skip the auto-injected MicroBuildAuthorizePublishPlugin@0 so it
+              # No ESRP publish runs in this job; vsce publishes directly to the VS Code Marketplace
+              # using a PAT. Skip the auto-injected MicroBuildAuthorizePublishPlugin@0 so it
               # does not 401 against the devdiv MicroBuildToolset feed.
               mb:
                 publish:

--- a/extension/src/dcp/AspireDcpServer.ts
+++ b/extension/src/dcp/AspireDcpServer.ts
@@ -8,16 +8,28 @@ import { AspireResourceDebugSession, DcpServerConnectionInfo, ErrorDetails, Erro
 import { AspireDebugSession } from '../debugger/AspireDebugSession';
 import { createDebugSessionConfiguration, getResourceDebuggerExtensions } from '../debugger/debuggerExtensions';
 import { cleanupRun } from '../debugger/runCleanupRegistry';
+import { createDebugAdapterTracker } from '../debugger/adapterTracker';
 import { timingSafeEqual } from 'crypto';
 import { getRunSessionInfo, getSupportedCapabilities } from '../capabilities';
 import { authorizationAndDcpHeadersRequired, authorizationHeaderMustStartWithBearer, encounteredErrorStartingResource, invalidOrMissingToken, invalidTokenLength } from '../loc/strings';
+import { AcquiredTestRunSession, TestRunSessionAcquireOptions, TestRunSessionLease, TestRunSessionManager } from './TestRunSessionManager';
+
+type AuthorizedDcpRequest = {
+    dcpId: string;
+    token: string;
+    testRunSessionLease?: TestRunSessionLease;
+};
 
 export default class AspireDcpServer {
     private readonly app: express.Express;
     private server: https.Server;
     private wss: WebSocketServer;
     private wsBySession: Map<string, WebSocket> = new Map();
+    private runsBySession: Map<string, AspireResourceDebugSession[]> = new Map();
+    private testRunSessionLeaseIdByRunId: Map<string, string> = new Map();
+    private debugAdapterTrackerDisposablesByAdapter: Map<string, vscode.Disposable> = new Map();
     private pendingNotificationQueueByDcpId: Map<string, RunSessionNotification[]> = new Map();
+    private testRunSessionManager: TestRunSessionManager;
 
     public readonly connectionInfo: DcpServerConnectionInfo;
 
@@ -26,55 +38,90 @@ export default class AspireDcpServer {
         app: express.Express,
         server: https.Server,
         wss: WebSocketServer,
+        runsBySession: Map<string, AspireResourceDebugSession[]>,
+        testRunSessionLeaseIdByRunId: Map<string, string>,
         wsBySession: Map<string, WebSocket>,
-        pendingNotificationQueueByDcpId: Map<string, RunSessionNotification[]>) {
+        pendingNotificationQueueByDcpId: Map<string, RunSessionNotification[]>,
+        testRunSessionManager: TestRunSessionManager) {
         this.connectionInfo = info;
         this.app = app;
         this.server = server;
         this.wss = wss;
+        this.runsBySession = runsBySession;
+        this.testRunSessionLeaseIdByRunId = testRunSessionLeaseIdByRunId;
         this.wsBySession = wsBySession;
         this.pendingNotificationQueueByDcpId = pendingNotificationQueueByDcpId;
+        this.testRunSessionManager = testRunSessionManager;
     }
 
     static async create(getDebugSession: (debugSessionId: string) => AspireDebugSession | null): Promise<AspireDcpServer> {
         const runsBySession = new Map<string, AspireResourceDebugSession[]>();
         const wsBySession = new Map<string, WebSocket>();
         const pendingNotificationQueueByDcpId = new Map<string, RunSessionNotification[]>();
+        let testRunSessionManager: TestRunSessionManager | undefined;
+        let dcpServerInstance: AspireDcpServer | undefined;
 
         return new Promise(async (resolve, reject) => {
             const token = generateToken();
 
             const app = express();
             app.use(express.json());
+            const testRunSessionLeaseIdByRunId = new Map<string, string>();
 
             function requireHeaders(req: Request, res: Response, next: NextFunction): void {
-                const auth = req.header('Authorization');
-                const dcpId = req.header('microsoft-developer-dcp-instance-id');
-                if (!auth || !dcpId) {
+                const authorization = authorizeDcpRequest(req.header('Authorization'), req.header('microsoft-developer-dcp-instance-id'));
+                if (!authorization) {
                     respondWithError(res, 401, { error: { code: 'MissingHeaders', message: authorizationAndDcpHeadersRequired, details: [] } });
                     return;
                 }
 
-                if (auth.split('Bearer ').length !== 2) {
+                if (authorization === 'invalid-auth-header') {
                     respondWithError(res, 401, { error: { code: 'InvalidAuthHeader', message: authorizationHeaderMustStartWithBearer, details: [] } });
                     return;
                 }
 
-                const bearerTokenBuffer = Buffer.from(auth.split('Bearer ')[1]);
-                const expectedTokenBuffer = Buffer.from(token);
-
-                if (bearerTokenBuffer.length !== expectedTokenBuffer.length) {
+                if (authorization === 'invalid-token-length') {
                     respondWithError(res, 401, { error: { code: 'InvalidToken', message: invalidTokenLength, details: [] } });
                     return;
                 }
 
-                // timingSafeEqual is used to verify that the tokens are equivalent in a way that mitigates timing attacks
-                if (timingSafeEqual(bearerTokenBuffer, expectedTokenBuffer) === false) {
+                if (authorization === 'invalid-token') {
                     respondWithError(res, 401, { error: { code: 'InvalidToken', message: invalidOrMissingToken, details: [] } });
                     return;
                 }
 
+                (req as Request & { aspireDcpAuthorization?: AuthorizedDcpRequest }).aspireDcpAuthorization = authorization;
                 next();
+            }
+
+            function authorizeDcpRequest(auth: string | undefined, dcpId: string | undefined): AuthorizedDcpRequest | 'invalid-auth-header' | 'invalid-token-length' | 'invalid-token' | undefined {
+                if (!auth || !dcpId) {
+                    return undefined;
+                }
+
+                if (!auth.startsWith('Bearer ')) {
+                    return 'invalid-auth-header';
+                }
+
+                const bearerToken = auth.substring('Bearer '.length);
+                const testRunSessionLease = testRunSessionManager?.tryAuthorizeDcpRequest(dcpId, bearerToken);
+                if (testRunSessionLease) {
+                    return { dcpId, token: bearerToken, testRunSessionLease };
+                }
+
+                const bearerTokenBuffer = Buffer.from(bearerToken);
+                const expectedTokenBuffer = Buffer.from(token);
+
+                if (bearerTokenBuffer.length !== expectedTokenBuffer.length) {
+                    return 'invalid-token-length';
+                }
+
+                // timingSafeEqual is used to verify that the tokens are equivalent in a way that mitigates timing attacks
+                if (timingSafeEqual(bearerTokenBuffer, expectedTokenBuffer) === false) {
+                    return 'invalid-token';
+                }
+
+                return { dcpId, token: bearerToken };
             }
 
             app.get("/telemetry/enabled", (req: Request, res: Response) => {
@@ -89,8 +136,9 @@ export default class AspireDcpServer {
             app.put('/run_session', requireHeaders, async (req: Request, res: Response) => {
                 const payload: RunSessionPayload = req.body;
                 const runId = generateRunId();
-                const dcpId = req.header('microsoft-developer-dcp-instance-id') as string;
-                const debugSessionId = getDcpIdPrefix(dcpId);
+                const authorization = (req as Request & { aspireDcpAuthorization: AuthorizedDcpRequest }).aspireDcpAuthorization;
+                const dcpId = authorization.dcpId;
+                const debugSessionId = getDcpIdPrefix(dcpId) ?? authorization.testRunSessionLease?.sessionId;
                 const processes: AspireResourceDebugSession[] = [];
 
                 if (!debugSessionId) {
@@ -123,7 +171,7 @@ export default class AspireDcpServer {
                 }
 
                 const aspireDebugSession = getDebugSession(debugSessionId);
-                if (!aspireDebugSession) {
+                if (!aspireDebugSession && !authorization.testRunSessionLease) {
                     const error: ErrorDetails = {
                         code: 'DebugSessionNotFound',
                         message: `No Aspire debug session found for Debug Session ID ${debugSessionId}`,
@@ -137,20 +185,27 @@ export default class AspireDcpServer {
                 }
 
                 try {
+                    if (authorization.testRunSessionLease) {
+                        testRunSessionLeaseIdByRunId.set(runId, authorization.testRunSessionLease.id);
+                    }
+
                     const config = await createDebugSessionConfiguration(
-                        aspireDebugSession.configuration,
+                        aspireDebugSession?.configuration ?? { type: 'aspire', request: 'launch', name: 'Aspire test run', program: '' },
                         launchConfig,
                         payload.args,
                         payload.env ?? [],
-                        { debug: launchConfig.mode === "Debug", runId, debugSessionId: dcpId, isApphost: false, debugSession: aspireDebugSession },
+                        { debug: launchConfig.mode === "Debug", runId, debugSessionId: dcpId, isApphost: false, debugSession: aspireDebugSession ?? undefined },
                         foundDebuggerExtension
                     );
 
-                    const resourceDebugSession = await aspireDebugSession.startAndGetDebugSession(config);
+                    const resourceDebugSession = aspireDebugSession
+                        ? await aspireDebugSession.startAndGetDebugSession(config)
+                        : await startAndGetDebugSession(config, dcpServerInstance);
 
                     if (!resourceDebugSession) {
                         // Clean up any processes associated with this run (registered by resource-type extensions)
                         cleanupRun(runId);
+                        testRunSessionLeaseIdByRunId.delete(runId);
 
                         const error: ErrorDetails = {
                             code: 'DebugSessionFailed',
@@ -164,10 +219,27 @@ export default class AspireDcpServer {
                         return;
                     }
 
+                    if (authorization.testRunSessionLease && !testRunSessionManager?.isActive(authorization.testRunSessionLease.id)) {
+                        await resourceDebugSession.stopSession();
+                        testRunSessionLeaseIdByRunId.delete(runId);
+
+                        const error: ErrorDetails = {
+                            code: 'TestRunSessionReleased',
+                            message: 'The Aspire test run session was released before the resource debug session started.',
+                            details: []
+                        };
+
+                        extensionLogOutputChannel.error(`Error creating debug session ${runId}: ${error.message}`);
+                        const response: ErrorResponse = { error };
+                        respondWithError(res, 410, response);
+                        return;
+                    }
+
                     processes.push(resourceDebugSession);
                     extensionLogOutputChannel.info(`Debugging session created with ID: ${runId}`);
 
                     runsBySession.set(runId, processes);
+
                     res.status(201).set('Location', `https://${req.get('host')}/run_session/${runId}`).end();
                     extensionLogOutputChannel.info(`New run session created with ID: ${runId}`);
                 } catch (err) {
@@ -175,6 +247,7 @@ export default class AspireDcpServer {
 
                     // Clean up any processes associated with this run (registered by resource-type extensions)
                     cleanupRun(runId);
+                    testRunSessionLeaseIdByRunId.delete(runId);
 
                     // Notify DCP via WebSocket that the session terminated so it can update
                     // resource state, AND respond with HTTP 500 so the original POST /run_session
@@ -207,13 +280,14 @@ export default class AspireDcpServer {
 
             app.delete('/run_session/:id', requireHeaders, async (req: Request, res: Response) => {
                 const runId = req.params.id as string;
+                const authorization = (req as Request & { aspireDcpAuthorization: AuthorizedDcpRequest }).aspireDcpAuthorization;
                 if (runsBySession.has(runId)) {
-                    const baseDebugSessions = runsBySession.get(runId);
-                    for (const debugSession of baseDebugSessions || []) {
-                        debugSession.stopSession();
+                    if (authorization.testRunSessionLease && testRunSessionLeaseIdByRunId.get(runId) !== authorization.testRunSessionLease.id) {
+                        res.status(404).end();
+                        return;
                     }
 
-                    runsBySession.delete(runId);
+                    await dcpServerInstance?.stopRunSession(runId);
                     res.status(200).end();
                 } else {
                     res.status(204).end();
@@ -227,8 +301,14 @@ export default class AspireDcpServer {
 
             server.on('upgrade', (request, socket, head) => {
                 if (request.url?.startsWith('/run_session/notify')) {
+                    const authorization = authorizeDcpRequest(request.headers.authorization, request.headers['microsoft-developer-dcp-instance-id'] as string | undefined);
+                    if (!authorization || typeof authorization === 'string') {
+                        socket.destroy();
+                        return;
+                    }
+
                     wss.handleUpgrade(request, socket, head, (ws) => {
-                        const dcpId = request.headers['microsoft-developer-dcp-instance-id'] as string;
+                        const dcpId = authorization.dcpId;
                         extensionLogOutputChannel.info(`WebSocket connection established for DCP ID: ${dcpId}`);
                         wsBySession.set(dcpId, ws);
 
@@ -268,7 +348,9 @@ export default class AspireDcpServer {
                         token: token,
                         certificate: certBase64
                     };
-                    resolve(new AspireDcpServer(info, app, server, wss, wsBySession, pendingNotificationQueueByDcpId));
+                    testRunSessionManager = new TestRunSessionManager(info);
+                    dcpServerInstance = new AspireDcpServer(info, app, server, wss, runsBySession, testRunSessionLeaseIdByRunId, wsBySession, pendingNotificationQueueByDcpId, testRunSessionManager);
+                    resolve(dcpServerInstance);
                 } else {
                     reject(new Error('Failed to get server address'));
                 }
@@ -276,6 +358,26 @@ export default class AspireDcpServer {
 
             server.on('error', reject);
         });
+    }
+
+    acquireTestRunSession(options: TestRunSessionAcquireOptions): AcquiredTestRunSession {
+        return this.testRunSessionManager.acquire(options);
+    }
+
+    async releaseTestRunSession(id: string): Promise<void> {
+        const lease = this.testRunSessionManager.release(id);
+        const stopSessionPromises: Promise<void>[] = [];
+        for (const [runId, leaseId] of this.testRunSessionLeaseIdByRunId) {
+            if (leaseId === id) {
+                stopSessionPromises.push(this.stopRunSession(runId));
+            }
+        }
+
+        if (lease) {
+            this.closeLeaseNotificationConnections(lease);
+        }
+
+        await Promise.all(stopSessionPromises);
     }
 
     sendNotification(notification: RunSessionNotification) {
@@ -325,7 +427,56 @@ export default class AspireDcpServer {
         }
     }
 
+    private async stopRunSession(runId: string): Promise<void> {
+        const baseDebugSessions = this.runsBySession.get(runId);
+        for (const debugSession of baseDebugSessions || []) {
+            await debugSession.stopSession();
+        }
+
+        this.runsBySession.delete(runId);
+        this.testRunSessionLeaseIdByRunId.delete(runId);
+    }
+
+    ensureDebugAdapterTracker(debugAdapter: string): void {
+        if (this.debugAdapterTrackerDisposablesByAdapter.has(debugAdapter)) {
+            return;
+        }
+
+        this.debugAdapterTrackerDisposablesByAdapter.set(debugAdapter, createDebugAdapterTracker(this, debugAdapter));
+    }
+
+    private closeLeaseNotificationConnections(lease: TestRunSessionLease): void {
+        const prefix = `${lease.sessionId}-`;
+        for (const [dcpId, ws] of this.wsBySession) {
+            if (dcpId.startsWith(prefix)) {
+                if (ws.readyState === WebSocket.OPEN) {
+                    ws.close(1000, 'Test run session released');
+                }
+
+                this.wsBySession.delete(dcpId);
+            }
+        }
+
+        for (const dcpId of this.pendingNotificationQueueByDcpId.keys()) {
+            if (dcpId.startsWith(prefix)) {
+                this.pendingNotificationQueueByDcpId.delete(dcpId);
+            }
+        }
+    }
+
     public dispose(): void {
+        for (const runId of [...this.runsBySession.keys()]) {
+            void this.stopRunSession(runId);
+        }
+
+        this.testRunSessionLeaseIdByRunId.clear();
+        this.pendingNotificationQueueByDcpId.clear();
+        for (const disposable of this.debugAdapterTrackerDisposablesByAdapter.values()) {
+            disposable.dispose();
+        }
+
+        this.debugAdapterTrackerDisposablesByAdapter.clear();
+
         // Send WebSocket close message to all clients before shutting down
         if (this.wss) {
             this.wss.clients.forEach(client => {
@@ -340,6 +491,82 @@ export default class AspireDcpServer {
             this.server.close();
         }
     }
+}
+
+async function startAndGetDebugSession(debugConfig: vscode.DebugConfiguration, dcpServer: AspireDcpServer | undefined): Promise<AspireResourceDebugSession | undefined> {
+    dcpServer?.ensureDebugAdapterTracker(debugConfig.type);
+
+    return new Promise((resolve, reject) => {
+        let completed = false;
+        let timeout: NodeJS.Timeout | undefined;
+        let lateCleanupTimeout: NodeJS.Timeout | undefined;
+        const disposable = vscode.debug.onDidStartDebugSession(session => {
+            if (session.configuration.runId === debugConfig.runId) {
+                if (completed) {
+                    void vscode.debug.stopDebugging(session);
+                    cleanupRun(debugConfig.runId);
+                    disposable.dispose();
+                    if (lateCleanupTimeout) {
+                        clearTimeout(lateCleanupTimeout);
+                    }
+
+                    return;
+                }
+
+                complete({
+                    id: session.id,
+                    session,
+                    stopSession: async () => {
+                        await vscode.debug.stopDebugging(session);
+                        cleanupRun(debugConfig.runId);
+                    }
+                });
+            }
+        });
+
+        function complete(result: AspireResourceDebugSession | undefined): void {
+            if (completed) {
+                return;
+            }
+
+            completed = true;
+            if (timeout) {
+                clearTimeout(timeout);
+            }
+            if (lateCleanupTimeout) {
+                clearTimeout(lateCleanupTimeout);
+            }
+
+            disposable.dispose();
+            resolve(result);
+        }
+
+        timeout = setTimeout(() => {
+            completed = true;
+            resolve(undefined);
+            lateCleanupTimeout = setTimeout(() => {
+                disposable.dispose();
+            }, 60_000);
+        }, 10000);
+
+        vscode.debug.startDebugging(undefined, debugConfig).then(started => {
+            if (!started) {
+                complete(undefined);
+            }
+        }, err => {
+            if (completed) {
+                return;
+            }
+
+            completed = true;
+            if (timeout) {
+                clearTimeout(timeout);
+            }
+
+            disposable.dispose();
+            reject(err);
+        });
+    });
 }
 
 export function generateRunId(): string {

--- a/extension/src/dcp/TestRunSessionManager.ts
+++ b/extension/src/dcp/TestRunSessionManager.ts
@@ -1,0 +1,143 @@
+import { randomBytes, timingSafeEqual } from 'crypto';
+import { getRunSessionInfo, getSupportedCapabilities } from '../capabilities';
+import { generateToken } from '../utils/security';
+import { DcpServerConnectionInfo, RunSessionInfo } from './types';
+
+export interface TestRunSessionAcquireOptions {
+    debug: boolean;
+}
+
+export interface AcquiredTestRunSession {
+    id: string;
+    sessionId: string;
+    env: Record<string, string>;
+}
+
+export interface TestRunSessionLease {
+    id: string;
+    sessionId: string;
+    token: string;
+    expiresAt: number;
+}
+
+export interface TestRunSessionManagerOptions {
+    leaseLifetimeMs?: number;
+    now?: () => number;
+}
+
+export class TestRunSessionManager {
+    private readonly leases = new Map<string, TestRunSessionLease>();
+    private readonly leaseLifetimeMs?: number;
+    private readonly now: () => number;
+
+    constructor(
+        private readonly connectionInfo: Pick<DcpServerConnectionInfo, 'address' | 'certificate'>,
+        private readonly getSupportedLaunchConfigurations: () => string[] = getSupportedCapabilities,
+        options: TestRunSessionManagerOptions = {}) {
+        this.leaseLifetimeMs = options.leaseLifetimeMs;
+        this.now = options.now ?? Date.now;
+    }
+
+    acquire(options: TestRunSessionAcquireOptions): AcquiredTestRunSession {
+        this.removeExpiredLeases();
+
+        const id = generateToken();
+        const sessionId = `aspire-extension-test-run-${randomBytes(16).toString('hex')}`;
+        const token = generateToken();
+        const runSessionInfo: RunSessionInfo = {
+            ...getRunSessionInfo(),
+            supported_launch_configurations: this.getSupportedLaunchConfigurations()
+        };
+
+        this.leases.set(id, { id, sessionId, token, expiresAt: this.getExpiresAt() });
+
+        return {
+            id,
+            sessionId,
+            env: {
+                DEBUG_SESSION_PORT: this.connectionInfo.address,
+                DEBUG_SESSION_TOKEN: token,
+                DEBUG_SESSION_SERVER_CERTIFICATE: this.connectionInfo.certificate,
+                DCP_INSTANCE_ID_PREFIX: `${sessionId}-`,
+                DEBUG_SESSION_RUN_MODE: options.debug ? 'Debug' : 'NoDebug',
+                DEBUG_SESSION_INFO: JSON.stringify(runSessionInfo)
+            }
+        };
+    }
+
+    release(id: string): TestRunSessionLease | undefined {
+        const lease = this.leases.get(id);
+        this.leases.delete(id);
+        return lease;
+    }
+
+    isActive(id: string): boolean {
+        const lease = this.leases.get(id);
+        if (!lease) {
+            return false;
+        }
+
+        if (this.isExpired(lease)) {
+            this.leases.delete(id);
+            return false;
+        }
+
+        return true;
+    }
+
+    tryAuthorizeDcpRequest(dcpId: string, token: string): TestRunSessionLease | undefined {
+        const lease = this.tryGetLeaseForDcpId(dcpId);
+        if (!lease) {
+            return undefined;
+        }
+
+        if (this.isExpired(lease)) {
+            this.leases.delete(lease.id);
+            return undefined;
+        }
+
+        const bearerTokenBuffer = Buffer.from(token);
+        const expectedTokenBuffer = Buffer.from(lease.token);
+        if (bearerTokenBuffer.length !== expectedTokenBuffer.length) {
+            return undefined;
+        }
+
+        if (timingSafeEqual(bearerTokenBuffer, expectedTokenBuffer) === false) {
+            return undefined;
+        }
+
+        return lease;
+    }
+
+    private tryGetLeaseForDcpId(dcpId: string): TestRunSessionLease | undefined {
+        for (const lease of this.leases.values()) {
+            if (dcpId.startsWith(`${lease.sessionId}-`)) {
+                return lease;
+            }
+        }
+
+        return undefined;
+    }
+
+    private removeExpiredLeases(): void {
+        for (const lease of this.leases.values()) {
+            if (this.isExpired(lease)) {
+                this.leases.delete(lease.id);
+            }
+        }
+    }
+
+    private isExpired(lease: TestRunSessionLease): boolean {
+        if (this.leaseLifetimeMs === undefined) {
+            return false;
+        }
+
+        return this.now() >= lease.expiresAt;
+    }
+
+    private getExpiresAt(): number {
+        return this.leaseLifetimeMs === undefined
+            ? Number.POSITIVE_INFINITY
+            : this.now() + this.leaseLifetimeMs;
+    }
+}

--- a/extension/src/dcp/types.ts
+++ b/extension/src/dcp/types.ts
@@ -147,7 +147,7 @@ export interface LaunchOptions {
     runId: string;
     debugSessionId: string;
     isApphost: boolean;
-    debugSession: AspireDebugSession;
+    debugSession?: AspireDebugSession;
 };
 
 export interface StartAppHostOptions {
@@ -157,7 +157,7 @@ export interface StartAppHostOptions {
 export interface AspireResourceDebugSession {
     id: string;
     session: vscode.DebugSession;
-    stopSession(): void;
+    stopSession(): Thenable<void> | void;
 }
 
 export interface AspireResourceExtendedDebugConfiguration extends vscode.DebugConfiguration {

--- a/extension/src/debugger/languages/dotnet.ts
+++ b/extension/src/debugger/languages/dotnet.ts
@@ -30,16 +30,21 @@ interface IDotNetService {
 }
 
 class DotNetService implements IDotNetService {
-    private _debugSession: AspireDebugSession;
+    private _debugSession?: AspireDebugSession;
 
-    constructor(debugSession: AspireDebugSession) {
+    constructor(debugSession?: AspireDebugSession) {
         this._debugSession = debugSession;
     }
 
     execFileAsync = util.promisify(execFile);
 
     writeToDebugConsole(message: string, category: 'stdout' | 'stderr', addNewLine: boolean = false): void {
-        this._debugSession.sendMessage(message, addNewLine, category);
+        if (this._debugSession) {
+            this._debugSession.sendMessage(message, addNewLine, category);
+        }
+        else {
+            extensionLogOutputChannel.appendLine(message);
+        }
     }
 
     async getAndActivateDevKit(): Promise<boolean> {
@@ -253,7 +258,7 @@ function createDotNetRunArguments(projectPath: string, baseProfileArgs: string |
     return dotnetRunArgs;
 }
 
-export function createProjectDebuggerExtension(dotNetServiceProducer: (debugSession: AspireDebugSession) => IDotNetService): ResourceDebuggerExtension {
+export function createProjectDebuggerExtension(dotNetServiceProducer: (debugSession?: AspireDebugSession) => IDotNetService): ResourceDebuggerExtension {
     return {
         resourceType: 'project',
         debugAdapter: 'coreclr',

--- a/extension/src/extension.ts
+++ b/extension/src/extension.ts
@@ -40,10 +40,17 @@ import { createResourceCommandArgumentLoader } from './views/ResourceCommandArgu
 import { ResourceCommandJson } from './views/AppHostDataRepository';
 import { AppHostDiscoveryService } from './utils/appHostDiscovery';
 import { AppHostLaunchService } from './services/AppHostLaunchService';
+import { AcquiredTestRunSession, TestRunSessionAcquireOptions } from './dcp/TestRunSessionManager';
 
 let aspireExtensionContext = new AspireExtensionContext();
 
-export async function activate(context: vscode.ExtensionContext) {
+export interface AspireExtensionApi {
+  rpcServerInfo: RpcServerConnectionInfo;
+  acquireTestRunSession(options: TestRunSessionAcquireOptions): AcquiredTestRunSession;
+  releaseTestRunSession(id: string): Promise<void>;
+}
+
+export async function activate(context: vscode.ExtensionContext): Promise<AspireExtensionApi> {
   const gitCommitSha = readGitCommitSha(context);
   extensionLogOutputChannel.info(`Activating Aspire extension (commit: ${gitCommitSha})`);
   initializeTelemetry(context);
@@ -264,6 +271,8 @@ export async function activate(context: vscode.ExtensionContext) {
   // Return exported API for tests or other extensions
   return {
     rpcServerInfo: rpcServer.connectionInfo,
+    acquireTestRunSession: (options: TestRunSessionAcquireOptions) => dcpServer.acquireTestRunSession(options),
+    releaseTestRunSession: (id: string) => dcpServer.releaseTestRunSession(id),
   };
 }
 

--- a/extension/src/test/aspireDcpServer.test.ts
+++ b/extension/src/test/aspireDcpServer.test.ts
@@ -1,0 +1,333 @@
+import * as assert from 'assert';
+import * as https from 'https';
+import { IncomingHttpHeaders } from 'http';
+import * as sinon from 'sinon';
+import * as vscode from 'vscode';
+import WebSocket from 'ws';
+import AspireDcpServer from '../dcp/AspireDcpServer';
+import waitForExpect from 'wait-for-expect';
+
+suite('Aspire DCP server', () => {
+    let dcpServer: AspireDcpServer;
+    let startDebuggingStub: sinon.SinonStub;
+    let stopDebuggingStub: sinon.SinonStub;
+    let registerDebugAdapterTrackerFactoryStub: sinon.SinonStub;
+    let startListeners: Array<(session: vscode.DebugSession) => unknown>;
+
+    setup(() => {
+        startListeners = [];
+        sinon.stub(vscode.debug, 'onDidStartDebugSession').callsFake(listener => {
+            startListeners.push(listener);
+            return {
+                dispose: () => {
+                    startListeners = startListeners.filter(l => l !== listener);
+                }
+            };
+        });
+        startDebuggingStub = sinon.stub(vscode.debug, 'startDebugging').callsFake(async (_folder, config) => {
+            const debugConfig = config as vscode.DebugConfiguration;
+            setImmediate(() => {
+                for (const listener of startListeners) {
+                    listener({
+                        id: 'resource-debug-session',
+                        type: debugConfig.type,
+                        name: debugConfig.name,
+                        workspaceFolder: undefined,
+                        configuration: debugConfig,
+                        customRequest: sinon.stub(),
+                        getDebugProtocolBreakpoint: sinon.stub()
+                    } as unknown as vscode.DebugSession);
+                }
+            });
+
+            return true;
+        });
+        stopDebuggingStub = sinon.stub(vscode.debug, 'stopDebugging').resolves();
+        registerDebugAdapterTrackerFactoryStub = sinon.stub(vscode.debug, 'registerDebugAdapterTrackerFactory').returns({ dispose: sinon.stub() });
+    });
+
+    teardown(() => {
+        dcpServer?.dispose();
+        sinon.restore();
+    });
+
+    test('lease-backed run session starts resource without Aspire debug session', async () => {
+        dcpServer = await AspireDcpServer.create(() => null);
+        const lease = dcpServer.acquireTestRunSession({ debug: true });
+        const dcpId = `${lease.sessionId}-api`;
+
+        const response = await requestDcpServer(dcpServer, 'PUT', '/run_session', lease.env.DEBUG_SESSION_TOKEN, dcpId, {
+            launch_configurations: [
+                {
+                    type: 'node',
+                    mode: 'Debug',
+                    script_path: '/workspace/app.js'
+                }
+            ],
+            args: [],
+            env: []
+        });
+
+        assert.strictEqual(response.statusCode, 201);
+        assert.strictEqual(startDebuggingStub.calledOnce, true);
+        assert.strictEqual(startDebuggingStub.firstCall.args[2], undefined);
+    });
+
+    test('lease-backed run session rejects wrong token', async () => {
+        dcpServer = await AspireDcpServer.create(() => null);
+        const lease = dcpServer.acquireTestRunSession({ debug: true });
+        const dcpId = `${lease.sessionId}-api`;
+
+        const response = await requestDcpServer(dcpServer, 'PUT', '/run_session', 'wrong-token', dcpId, {
+            launch_configurations: [
+                {
+                    type: 'node',
+                    mode: 'Debug',
+                    script_path: '/workspace/app.js'
+                }
+            ]
+        });
+
+        assert.strictEqual(response.statusCode, 401);
+        assert.strictEqual(startDebuggingStub.called, false);
+    });
+
+    test('release stops lease-backed run sessions and revokes token', async () => {
+        dcpServer = await AspireDcpServer.create(() => null);
+        const lease = dcpServer.acquireTestRunSession({ debug: true });
+        const dcpId = `${lease.sessionId}-api`;
+
+        const response = await requestDcpServer(dcpServer, 'PUT', '/run_session', lease.env.DEBUG_SESSION_TOKEN, dcpId, {
+            launch_configurations: [
+                {
+                    type: 'node',
+                    mode: 'Debug',
+                    script_path: '/workspace/app.js'
+                }
+            ],
+            args: [],
+            env: []
+        });
+
+        assert.strictEqual(response.statusCode, 201);
+
+        await dcpServer.releaseTestRunSession(lease.id);
+
+        const rejectedResponse = await requestDcpServer(dcpServer, 'PUT', '/run_session', lease.env.DEBUG_SESSION_TOKEN, dcpId, {
+            launch_configurations: [
+                {
+                    type: 'node',
+                    mode: 'Debug',
+                    script_path: '/workspace/app.js'
+                }
+            ],
+            args: [],
+            env: []
+        });
+
+        assert.strictEqual(stopDebuggingStub.calledOnce, true);
+        assert.strictEqual(rejectedResponse.statusCode, 401);
+    });
+
+    test('lease-backed run session registers debug adapter tracker', async () => {
+        dcpServer = await AspireDcpServer.create(() => null);
+        const lease = dcpServer.acquireTestRunSession({ debug: true });
+
+        const response = await requestDcpServer(dcpServer, 'PUT', '/run_session', lease.env.DEBUG_SESSION_TOKEN, `${lease.sessionId}-api`, {
+            launch_configurations: [
+                {
+                    type: 'node',
+                    mode: 'Debug',
+                    script_path: '/workspace/app.js'
+                }
+            ],
+            args: [],
+            env: []
+        });
+
+        assert.strictEqual(response.statusCode, 201);
+        assert.strictEqual(registerDebugAdapterTrackerFactoryStub.calledOnceWith('pwa-node'), true);
+    });
+
+    test('lease token cannot delete another lease run session', async () => {
+        dcpServer = await AspireDcpServer.create(() => null);
+        const firstLease = dcpServer.acquireTestRunSession({ debug: true });
+        const secondLease = dcpServer.acquireTestRunSession({ debug: true });
+        const firstDcpId = `${firstLease.sessionId}-api`;
+        const secondDcpId = `${secondLease.sessionId}-api`;
+
+        const response = await requestDcpServer(dcpServer, 'PUT', '/run_session', firstLease.env.DEBUG_SESSION_TOKEN, firstDcpId, {
+            launch_configurations: [
+                {
+                    type: 'node',
+                    mode: 'Debug',
+                    script_path: '/workspace/app.js'
+                }
+            ],
+            args: [],
+            env: []
+        });
+        const runId = getRunIdFromLocation(response.headers.location);
+
+        const deleteResponse = await requestDcpServer(dcpServer, 'DELETE', `/run_session/${runId}`, secondLease.env.DEBUG_SESSION_TOKEN, secondDcpId, {});
+
+        assert.strictEqual(deleteResponse.statusCode, 404);
+        assert.strictEqual(stopDebuggingStub.called, false);
+    });
+
+    test('release during lease-backed startup stops started resource and returns gone', async () => {
+        dcpServer = await AspireDcpServer.create(() => null);
+        const lease = dcpServer.acquireTestRunSession({ debug: true });
+        let debugConfig: vscode.DebugConfiguration | undefined;
+
+        startDebuggingStub.callsFake(async (_folder, config) => {
+            debugConfig = config as vscode.DebugConfiguration;
+            return true;
+        });
+
+        const responsePromise = requestDcpServer(dcpServer, 'PUT', '/run_session', lease.env.DEBUG_SESSION_TOKEN, `${lease.sessionId}-api`, {
+            launch_configurations: [
+                {
+                    type: 'node',
+                    mode: 'Debug',
+                    script_path: '/workspace/app.js'
+                }
+            ],
+            args: [],
+            env: []
+        });
+
+        await waitForExpect(() => assert.ok(debugConfig));
+        await dcpServer.releaseTestRunSession(lease.id);
+        emitStartedDebugSession(startListeners, debugConfig!);
+
+        const response = await responsePromise;
+
+        assert.strictEqual(response.statusCode, 410);
+        assert.strictEqual(stopDebuggingStub.calledOnce, true);
+    });
+
+    test('dispose stops lease-backed run sessions', async () => {
+        dcpServer = await AspireDcpServer.create(() => null);
+        const lease = dcpServer.acquireTestRunSession({ debug: true });
+
+        const response = await requestDcpServer(dcpServer, 'PUT', '/run_session', lease.env.DEBUG_SESSION_TOKEN, `${lease.sessionId}-api`, {
+            launch_configurations: [
+                {
+                    type: 'node',
+                    mode: 'Debug',
+                    script_path: '/workspace/app.js'
+                }
+            ],
+            args: [],
+            env: []
+        });
+
+        assert.strictEqual(response.statusCode, 201);
+
+        dcpServer.dispose();
+
+        assert.strictEqual(stopDebuggingStub.calledOnce, true);
+    });
+
+    test('lease-backed notification websocket rejects wrong token', async () => {
+        dcpServer = await AspireDcpServer.create(() => null);
+        const lease = dcpServer.acquireTestRunSession({ debug: true });
+
+        await assert.rejects(
+            connectNotifyWebSocket(dcpServer, 'wrong-token', `${lease.sessionId}-api`));
+    });
+
+    test('release closes lease-backed notification websocket', async () => {
+        dcpServer = await AspireDcpServer.create(() => null);
+        const lease = dcpServer.acquireTestRunSession({ debug: true });
+        const ws = await connectNotifyWebSocket(dcpServer, lease.env.DEBUG_SESSION_TOKEN, `${lease.sessionId}-api`);
+
+        const closed = new Promise<void>(resolve => ws.once('close', () => resolve()));
+
+        await dcpServer.releaseTestRunSession(lease.id);
+
+        await closed;
+    });
+});
+
+async function requestDcpServer(
+    server: AspireDcpServer,
+    method: string,
+    path: string,
+    token: string,
+    dcpId: string,
+    body: unknown): Promise<{ statusCode?: number; body: string; headers: IncomingHttpHeaders }> {
+    const [, port] = server.connectionInfo.address.split(':');
+    const bodyJson = JSON.stringify(body);
+
+    return new Promise((resolve, reject) => {
+        const req = https.request({
+            hostname: 'localhost',
+            port,
+            path,
+            method,
+            rejectUnauthorized: false,
+            headers: {
+                Authorization: `Bearer ${token}`,
+                'microsoft-developer-dcp-instance-id': dcpId,
+                'Content-Type': 'application/json',
+                'Content-Length': Buffer.byteLength(bodyJson)
+            }
+        }, res => {
+            let responseBody = '';
+            res.on('data', chunk => responseBody += chunk);
+            res.on('end', () => resolve({ statusCode: res.statusCode, body: responseBody, headers: res.headers }));
+        });
+
+        req.on('error', reject);
+        req.write(bodyJson);
+        req.end();
+    });
+}
+
+function emitStartedDebugSession(
+    listeners: Array<(session: vscode.DebugSession) => unknown>,
+    debugConfig: vscode.DebugConfiguration): void {
+    for (const listener of listeners) {
+        listener({
+            id: 'resource-debug-session',
+            type: debugConfig.type,
+            name: debugConfig.name,
+            workspaceFolder: undefined,
+            configuration: debugConfig,
+            customRequest: sinon.stub(),
+            getDebugProtocolBreakpoint: sinon.stub()
+        } as unknown as vscode.DebugSession);
+    }
+}
+
+function getRunIdFromLocation(location: string | string[] | undefined): string {
+    assert.ok(typeof location === 'string');
+
+    const match = /\/run_session\/([^/]+)$/.exec(location);
+    assert.ok(match);
+
+    return match[1];
+}
+
+async function connectNotifyWebSocket(
+    server: AspireDcpServer,
+    token: string,
+    dcpId: string): Promise<WebSocket> {
+    const [, port] = server.connectionInfo.address.split(':');
+
+    return new Promise((resolve, reject) => {
+        const ws = new WebSocket(`wss://localhost:${port}/run_session/notify`, {
+            rejectUnauthorized: false,
+            headers: {
+                Authorization: `Bearer ${token}`,
+                'microsoft-developer-dcp-instance-id': dcpId
+            }
+        });
+
+        ws.once('open', () => resolve(ws));
+        ws.once('error', reject);
+        ws.once('close', () => reject(new Error('WebSocket closed before opening.')));
+    });
+}

--- a/extension/src/test/rpc/e2eServerTests.test.ts
+++ b/extension/src/test/rpc/e2eServerTests.test.ts
@@ -7,6 +7,12 @@ import { createMessageConnection } from 'vscode-jsonrpc';
 import { StreamMessageReader, StreamMessageWriter } from 'vscode-jsonrpc/node';
 import { getAndActivateExtension } from '../common';
 import { RpcServerConnectionInfo } from '../../server/AspireRpcServer';
+import { AcquiredTestRunSession, TestRunSessionAcquireOptions } from '../../dcp/TestRunSessionManager';
+
+interface TestRunSessionApi {
+	acquireTestRunSession(options: TestRunSessionAcquireOptions): AcquiredTestRunSession;
+	releaseTestRunSession(id: string): Promise<void>;
+}
 
 suite('End-to-end RPC server auth tests', () => {
 	vscode.window.showInformationMessage('Starting end-to-end rpc server tests.');
@@ -29,6 +35,25 @@ suite('End-to-end RPC server auth tests', () => {
 
 		// Act & Assert
 		assert.rejects(() => connection.sendRequest('ping', { token: 'invalid-token' }));
+	});
+
+	test('exports test run session API for C# Dev Kit', async () => {
+		const extension = await getAndActivateExtension();
+
+		await waitForExpect(() => {
+			assert.ok(extension.exports.acquireTestRunSession);
+			assert.ok(extension.exports.releaseTestRunSession);
+		}, 2000, 50);
+
+		const api = extension.exports as TestRunSessionApi;
+		const lease = api.acquireTestRunSession({ debug: true });
+
+		assert.ok(lease.id);
+		assert.ok(lease.env.DEBUG_SESSION_TOKEN);
+		assert.ok(lease.env.DEBUG_SESSION_PORT);
+		assert.strictEqual(lease.env.DCP_INSTANCE_ID_PREFIX, `${lease.sessionId}-`);
+
+		await api.releaseTestRunSession(lease.id);
 	});
 
 	async function getRealRpcServer() {

--- a/extension/src/test/testRunSessionManager.test.ts
+++ b/extension/src/test/testRunSessionManager.test.ts
@@ -1,0 +1,92 @@
+import * as assert from 'assert';
+import { TestRunSessionManager } from '../dcp/TestRunSessionManager';
+
+suite('Test run session manager', () => {
+    test('acquire returns DCP environment and release revokes the lease', () => {
+        const manager = new TestRunSessionManager(
+            {
+                address: 'localhost:1234',
+                certificate: 'test-cert'
+            },
+            () => ['project', 'node']);
+
+        const lease = manager.acquire({ debug: true });
+        const dcpId = `${lease.sessionId}-webfrontend`;
+
+        assert.match(lease.sessionId, /^aspire-extension-test-run-[0-9a-f]+$/);
+        assert.strictEqual(lease.env.DEBUG_SESSION_PORT, 'localhost:1234');
+        assert.strictEqual(lease.env.DEBUG_SESSION_SERVER_CERTIFICATE, 'test-cert');
+        assert.strictEqual(lease.env.DCP_INSTANCE_ID_PREFIX, `${lease.sessionId}-`);
+        assert.strictEqual(lease.env.DEBUG_SESSION_RUN_MODE, 'Debug');
+        assert.deepStrictEqual(JSON.parse(lease.env.DEBUG_SESSION_INFO), {
+            protocols_supported: ["2024-03-03", "2024-04-23", "2025-10-01"],
+            supported_launch_configurations: ['project', 'node']
+        });
+
+        assert.strictEqual(manager.tryAuthorizeDcpRequest(dcpId, lease.env.DEBUG_SESSION_TOKEN)?.id, lease.id);
+
+        manager.release(lease.id);
+
+        assert.strictEqual(manager.tryAuthorizeDcpRequest(dcpId, lease.env.DEBUG_SESSION_TOKEN), undefined);
+    });
+
+    test('wrong token does not authorize a matching DCP instance id', () => {
+        const manager = new TestRunSessionManager(
+            {
+                address: 'localhost:1234',
+                certificate: 'test-cert'
+            },
+            () => ['project']);
+
+        const lease = manager.acquire({ debug: false });
+
+        assert.strictEqual(manager.tryAuthorizeDcpRequest(`${lease.sessionId}-api`, 'wrong-token'), undefined);
+    });
+
+    test('expired lease does not authorize matching DCP request', () => {
+        let now = 1_000;
+        const manager = new TestRunSessionManager(
+            {
+                address: 'localhost:1234',
+                certificate: 'test-cert'
+            },
+            () => ['project'],
+            {
+                leaseLifetimeMs: 5_000,
+                now: () => now
+            });
+
+        const lease = manager.acquire({ debug: false });
+        const dcpId = `${lease.sessionId}-api`;
+
+        assert.strictEqual(manager.tryAuthorizeDcpRequest(dcpId, lease.env.DEBUG_SESSION_TOKEN)?.id, lease.id);
+
+        now += 5_001;
+
+        assert.strictEqual(manager.tryAuthorizeDcpRequest(dcpId, lease.env.DEBUG_SESSION_TOKEN), undefined);
+    });
+
+    test('lease remains valid until release by default', () => {
+        let now = 1_000;
+        const manager = new TestRunSessionManager(
+            {
+                address: 'localhost:1234',
+                certificate: 'test-cert'
+            },
+            () => ['project'],
+            {
+                now: () => now
+            });
+
+        const lease = manager.acquire({ debug: false });
+        const dcpId = `${lease.sessionId}-api`;
+
+        now += 60 * 60 * 1000;
+
+        assert.strictEqual(manager.tryAuthorizeDcpRequest(dcpId, lease.env.DEBUG_SESSION_TOKEN)?.id, lease.id);
+
+        manager.release(lease.id);
+
+        assert.strictEqual(manager.tryAuthorizeDcpRequest(dcpId, lease.env.DEBUG_SESSION_TOKEN), undefined);
+    });
+});


### PR DESCRIPTION
## Description

This lets VS Code/C# Dev Kit test runs acquire an Aspire-owned DCP lease before starting the test process, so an in-process AppHost started by the test can still ask the Aspire extension to start/debug resources through DCP.

The extension now exports a small test-run API:

```ts
const lease = api.acquireTestRunSession({ debug: true });
// inject lease.env into the .NET test process
await api.releaseTestRunSession(lease.id);
```

The lease returns only the DCP/debug-session environment needed by Aspire.Hosting:

```text
DEBUG_SESSION_PORT
DEBUG_SESSION_TOKEN
DEBUG_SESSION_SERVER_CERTIFICATE
DCP_INSTANCE_ID_PREFIX
DEBUG_SESSION_RUN_MODE
DEBUG_SESSION_INFO
```

The DCP server accepts lease-backed `/run_session` requests without requiring a parent Aspire debug session, but keeps them scoped with a per-lease token and randomized DCP prefix. Releasing the lease revokes future DCP auth, stops lease-owned resource debug sessions, closes lease notification WebSockets, and awaits VS Code debug cleanup.

### Security considerations

This change adds an authorization path for process launching through the existing local Aspire DCP HTTPS server. The lease uses a per-test-run bearer token bound to a randomized `DCP_INSTANCE_ID_PREFIX`, authenticates both HTTP and `/run_session/notify` WebSocket requests, scopes DELETE requests to the owning lease, and does not return the broader Aspire RPC environment.

I did a security review pass with multiple agents and fixed the high-confidence findings around WebSocket auth, run ownership, release/in-flight cleanup, debug adapter tracker registration, and awaitable cleanup. One important design constraint remains: VS Code `extension.exports` does not authenticate the calling extension, so callers in the same extension host are within the local extension trust boundary.

Fixes # (issue)

## Checklist

- Is this feature complete?
  - [ ] Yes. Ready to ship.
  - [x] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [x] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [x] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [x] No
  - [ ] No
- Does the change make any security assumptions or guarantees?
  - [x] Yes
    - If yes, have you done a threat model and had a security review?
      - [x] Yes
      - [ ] No
  - [ ] No

Validation:

- `yarn run compile-tests`
- `yarn run compile`
- `yarn run lint`
- `vscode-test` full extension suite with short-path local test config: 636 passing
