### PR TITLE
Use catalog signing for template JS files instead of Authenticode

### DIFF
--- a/eng/Signing.props
+++ b/eng/Signing.props
@@ -14,8 +14,16 @@
     <!-- add missing entry for .msi, this can be removed once aspire uses arcade 10.0 -->
     <FileExtensionSignInfo Include=".msi" CertificateName="MicrosoftDotNet500" Condition="!@(FileExtensionSignInfo->AnyHaveMetadataValue('Identity', '.msi'))" />
 
-    <!-- We don't need to code sign .js files because they are not used in Windows Script Host. -->
+    <!--
+      JS files in project templates are customer-modifiable: users edit them after project
+      creation. Authenticode signing would append a // SIG // block that is visible to users
+      and breaks on any edit. Instead, we catalog-sign: a .cat file hashes the JS files and
+      carries the signature, leaving the JS content untouched.
+      See GenerateCatalogFiles target in Aspire.ProjectTemplates.csproj.
+    -->
     <FileExtensionSignInfo Update=".js" CertificateName="None" />
+    <!-- Sign the catalog file that covers the template JS files -->
+    <FileExtensionSignInfo Include=".cat" CertificateName="MicrosoftDotNet500" />
     <!-- Remove .py files from being signed. See https://github.com/microsoft/aspire/issues/13004 -->
     <FileExtensionSignInfo Update=".py" CertificateName="None" />
   </ItemGroup>

--- a/eng/generate-catalog.ps1
+++ b/eng/generate-catalog.ps1
@@ -1,0 +1,167 @@
+<#
+.SYNOPSIS
+    Generates a Catalog Definition File (.cdf) and optionally runs makecat.exe to
+    produce a signed catalog (.cat) file.
+.DESCRIPTION
+    Recursively scans a directory for files matching a filter and produces a .cdf
+    file suitable for makecat.exe. Optionally invokes makecat.exe to generate the
+    .cat file directly.
+
+    Used in component team pipelines (Arcade SDK, MicroBuild, or custom) to
+    catalog-sign customer-modifiable or non-PE files that cannot use direct
+    Authenticode signing.
+
+    If -RunMakecat is specified, the script finds and runs makecat.exe automatically.
+    Otherwise, it prints the commands to run manually.
+.PARAMETER RootPath
+    The directory containing files to include in the catalog.
+.PARAMETER CdfPath
+    The output path for the .cdf file. If not specified and CatOutputPath is set,
+    defaults to the CatOutputPath with a .cdf extension.
+.PARAMETER CatOutputPath
+    The path where makecat.exe will create the .cat file. Defaults to the CDF
+    path with a .cat extension.
+.PARAMETER Filter
+    File filter pattern (e.g., '*.js', '*.xml', '*.ttf'). Default: '*.*' (all files).
+.PARAMETER RunMakecat
+    If specified, finds and runs makecat.exe to produce the .cat file.
+.PARAMETER WindowsSdkDir
+    Optional path to the Windows SDK. Used to locate makecat.exe when -RunMakecat is set.
+.PARAMETER ErrorIfMakecatNotFound
+    If specified with -RunMakecat, throws an error when makecat.exe is not found
+    instead of warning and skipping. Use in CI/official builds.
+.EXAMPLE
+    # Generate CDF only (print manual steps):
+    .\generate-catalog.ps1 -RootPath ".\content" -CdfPath ".\obj\my-files.cdf"
+.EXAMPLE
+    # Generate CDF and run makecat.exe:
+    .\generate-catalog.ps1 -RootPath ".\content" -CatOutputPath ".\obj\my-files.cat" -Filter "*.js" -RunMakecat
+.EXAMPLE
+    # CI usage (error if makecat.exe not found):
+    .\generate-catalog.ps1 -RootPath "$(_ContentRoot)" -CatOutputPath "$(_CatOutputPath)" -Filter "*.js" -RunMakecat -ErrorIfMakecatNotFound
+#>
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory)]
+    [string]$RootPath,
+
+    [string]$CdfPath,
+
+    [string]$CatOutputPath,
+
+    [string]$Filter = '*.*',
+
+    [string]$WindowsSdkDir = '',
+
+    [switch]$RunMakecat,
+
+    [switch]$ErrorIfMakecatNotFound
+)
+
+$ErrorActionPreference = 'Stop'
+
+if (-not (Test-Path $RootPath)) {
+    Write-Error "Root path not found: $RootPath"
+    return
+}
+
+# Resolve paths: need at least one of CdfPath or CatOutputPath
+if (-not $CdfPath -and -not $CatOutputPath) {
+    Write-Error "Specify at least one of -CdfPath or -CatOutputPath."
+    return
+}
+if (-not $CatOutputPath) {
+    $CatOutputPath = [System.IO.Path]::ChangeExtension($CdfPath, '.cat')
+}
+if (-not $CdfPath) {
+    $CdfPath = [System.IO.Path]::ChangeExtension($CatOutputPath, '.cdf')
+}
+
+# Ensure output directories exist
+$cdfDir = Split-Path $CdfPath -Parent
+if ($cdfDir -and -not (Test-Path $cdfDir)) {
+    New-Item -ItemType Directory -Path $cdfDir -Force | Out-Null
+}
+$catDir = Split-Path $CatOutputPath -Parent
+if ($catDir -and -not (Test-Path $catDir)) {
+    New-Item -ItemType Directory -Path $catDir -Force | Out-Null
+}
+
+$files = Get-ChildItem -Path $RootPath -Recurse -Filter $Filter -File
+if ($files.Count -eq 0) {
+    Write-Warning "No files matching '$Filter' found under $RootPath - skipping catalog generation."
+    return
+}
+
+$cdfContent = @()
+$cdfContent += "[CatalogHeader]"
+$cdfContent += "Name=$CatOutputPath"
+$cdfContent += "CatalogVersion=2"
+$cdfContent += "HashAlgorithms=SHA256"
+$cdfContent += ""
+$cdfContent += "[CatalogFiles]"
+
+$i = 0
+foreach ($f in $files) {
+    $ext = $f.Extension.TrimStart('.').ToLower()
+    $label = "${ext}_${i}_" + ($f.Name -replace '[^\w\.-]', '_')
+    $cdfContent += "<hash>$label=`"$($f.FullName)`""
+    $i++
+}
+
+$cdfContent | Set-Content -Path $CdfPath -Encoding ASCII
+
+Write-Host "Generated CDF with $($files.Count) file(s) matching '$Filter' at $CdfPath"
+
+if ($RunMakecat) {
+    # Find makecat.exe — ships with the Windows SDK.
+    # Probe versioned directories directly instead of expensive recursive search.
+    $makecat = $null
+    if ($WindowsSdkDir -and (Test-Path $WindowsSdkDir)) {
+        $binDir = Join-Path $WindowsSdkDir 'bin'
+        if (Test-Path $binDir) {
+            $makecat = Get-ChildItem -Path $binDir -Directory |
+                Where-Object { $_.Name -match '^\d+\.\d+' } |
+                Sort-Object Name -Descending |
+                ForEach-Object { Join-Path $_.FullName 'x64\makecat.exe' } |
+                Where-Object { Test-Path $_ } |
+                Select-Object -First 1 |
+                ForEach-Object { Get-Item $_ }
+        }
+    }
+    if (-not $makecat) { $makecat = Get-Command makecat.exe -ErrorAction SilentlyContinue }
+    if (-not $makecat) {
+        $sdkRoot = "${env:ProgramFiles(x86)}\Windows Kits\10\bin"
+        if (Test-Path $sdkRoot) {
+            $makecat = Get-ChildItem -Path $sdkRoot -Directory |
+                Where-Object { $_.Name -match '^\d+\.\d+' } |
+                Sort-Object Name -Descending |
+                ForEach-Object { Join-Path $_.FullName 'x64\makecat.exe' } |
+                Where-Object { Test-Path $_ } |
+                Select-Object -First 1 |
+                ForEach-Object { Get-Item $_ }
+        }
+    }
+    if (-not $makecat) {
+        if ($ErrorIfMakecatNotFound) {
+            throw "makecat.exe not found. Catalog signing requires the Windows SDK."
+        }
+        Write-Warning "makecat.exe not found - skipping catalog generation. Install Windows SDK for catalog signing."
+        return
+    }
+
+    $makecatPath = if ($makecat -is [System.Management.Automation.CommandInfo]) { $makecat.Source } else { $makecat.FullName }
+    Write-Host "Using makecat.exe at: $makecatPath"
+
+    & $makecatPath $CdfPath
+    if ($LASTEXITCODE -ne 0) {
+        throw "makecat.exe failed with exit code $LASTEXITCODE"
+    }
+
+    Write-Host "Generated catalog file: $CatOutputPath"
+} else {
+    Write-Host ""
+    Write-Host "Next steps:"
+    Write-Host "  1. Run: makecat.exe `"$CdfPath`""
+    Write-Host "  2. Sign: dotnet ddsignfiles.dll -- /file:`"$CatOutputPath`" /certs:Microsoft400"
+}

--- a/src/Aspire.ProjectTemplates/Aspire.ProjectTemplates.csproj
+++ b/src/Aspire.ProjectTemplates/Aspire.ProjectTemplates.csproj
@@ -151,4 +151,31 @@
 
   </Target>
 
+  <!--
+    Generate a catalog (.cat) file covering template JS files for VS signing compliance.
+    Template JS files (Bootstrap, eslint configs) are customer-modifiable — users edit them
+    after project creation. Authenticode signing would append a visible // SIG // block and
+    break on modification. Catalog signing hashes the files into a .cat without modifying them.
+    The .cat is signed by Arcade (FileExtensionSignInfo in eng/Signing.props) and included in
+    the NuGet so it flows through dotnet-project-system -> Aspire.vsix -> VS.
+    Only runs on Windows (makecat.exe requires Windows SDK).
+  -->
+  <Target Name="GenerateCatalogFiles"
+          AfterTargets="CopyTemplatesToIntermediateOutputPath"
+          BeforeTargets="AddTemplatesToPackageAsContent"
+          Condition="$([MSBuild]::IsOSPlatform('Windows'))">
+    <PropertyGroup>
+      <_ContentRoot>$(IntermediateOutputPath)content\templates</_ContentRoot>
+      <_CatOutputPath>$(IntermediateOutputPath)aspire-templates.cat</_CatOutputPath>
+      <_ErrorFlag Condition="'$(ContinuousIntegrationBuild)' == 'true' or '$(OfficialBuild)' == 'true'">-ErrorIfMakecatNotFound</_ErrorFlag>
+    </PropertyGroup>
+
+    <Exec Command="powershell.exe -NoProfile -ExecutionPolicy Bypass -Command &quot;&amp; '$(RepoRoot)eng\generate-catalog.ps1' -RootPath '$(_ContentRoot)' -CatOutputPath '$(_CatOutputPath)' -Filter '*.js' -RunMakecat $(_ErrorFlag)&quot;"
+          StandardOutputImportance="High" />
+
+    <ItemGroup Condition="Exists('$(_CatOutputPath)')">
+      <Content Include="$(_CatOutputPath)" PackagePath="content/templates/" />
+    </ItemGroup>
+  </Target>
+
 </Project>

--- a/src/Aspire.ProjectTemplates/Aspire.ProjectTemplates.csproj
+++ b/src/Aspire.ProjectTemplates/Aspire.ProjectTemplates.csproj
@@ -159,9 +159,13 @@
     The .cat is signed by Arcade (FileExtensionSignInfo in eng/Signing.props) and included in
     the NuGet so it flows through dotnet-project-system -> Aspire.vsix -> VS.
     Only runs on Windows (makecat.exe requires Windows SDK).
+
+    Runs after ReplacePackageVersionOnTemplates (not just after the copy) so the catalog always
+    hashes the final shipped bytes. Version replacement doesn't touch the current .js files, but
+    binding here keeps the hashes correct if a cataloged file ever carries a version token.
   -->
   <Target Name="GenerateCatalogFiles"
-          AfterTargets="CopyTemplatesToIntermediateOutputPath"
+          AfterTargets="ReplacePackageVersionOnTemplates"
           BeforeTargets="AddTemplatesToPackageAsContent"
           Condition="$([MSBuild]::IsOSPlatform('Windows'))">
     <PropertyGroup>


### PR DESCRIPTION
## Summary

Fixes VS signing compliance for 7 unsigned JS files in the `Aspire.ProjectTemplates` NuGet package (payload `mswebtoolsaspire186834245`).

**Replaces the approach in #16606** which used `3PartyScriptsSHA2` Authenticode signing. Authenticode signing is wrong for template files because it appends a `// SIG //` block that is visible to users and breaks on modification.

## Approach: Catalog Signing

Template JS files (6 Bootstrap library + 1 eslint config) are **customer-modifiable**: users edit them after project creation. Catalog signing hashes the files into a `.cat` file and signs the `.cat` with `MicrosoftDotNet500`. The JS files remain untouched.

### Changes

| File | Change |
|------|--------|
| `eng/Signing.props` | Add `FileExtensionSignInfo` for `.cat` with `MicrosoftDotNet500`; update `.js` comment |
| `eng/generate-catalog.ps1` | Script that generates a CDF and runs `makecat.exe` to produce the `.cat` |
| `src/Aspire.ProjectTemplates/Aspire.ProjectTemplates.csproj` | `GenerateCatalogFiles` target runs after `CopyTemplatesToIntermediateOutputPath`, catalogs all `*.js` under the template content, and includes the `.cat` in the NuGet |

### Signing flow

1. `CopyTemplatesToIntermediateOutputPath` copies JS files to `obj/content/templates/`
2. `GenerateCatalogFiles` scans for `*.js`, generates a CDF, runs `makecat.exe` → `aspire-templates.cat`
3. The `.cat` is added as NuGet content at `content/templates/aspire-templates.cat`
4. Arcade signing signs the `.cat` with `MicrosoftDotNet500` (via `FileExtensionSignInfo`)
5. The signed `.cat` flows: NuGet → dotnet-project-system → Aspire.vsix → VS

### Why not Authenticode?

`3PartyScriptsSHA2` (PR #16606) appends a `// SIG // Begin signature block` comment to each JS file. For **template files** this is wrong:
- Users see the signature block in their project files (bootstrap.js, eslint.config.js)
- Any user edit invalidates the signature
- The VS signing compliance scanner then flags the modified file as broken

Catalog signing avoids this: the `.cat` carries the hashes and signature; the JS files are unmodified.