### PR TITLE
Add timestamp search qualifier for telemetry filtering

### DIFF
--- a/src/Aspire.Dashboard/Api/TelemetryApiService.cs
+++ b/src/Aspire.Dashboard/Api/TelemetryApiService.cs
@@ -523,6 +523,7 @@ internal sealed class TelemetryApiService(
         "trace-id" or "traceid" => KnownStructuredLogFields.TraceIdField,
         "span-id" or "spanid" => KnownStructuredLogFields.SpanIdField,
         "event" => KnownStructuredLogFields.EventNameField,
+        "timestamp" => KnownStructuredLogFields.TimestampField,
         _ => null
     };
 
@@ -540,6 +541,7 @@ internal sealed class TelemetryApiService(
         "trace-id" or "traceid" => KnownTraceFields.TraceIdField,
         "span-id" or "spanid" => KnownTraceFields.SpanIdField,
         "duration" => KnownTraceFields.DurationField,
+        "timestamp" => KnownTraceFields.TimestampField,
         _ => null
     };
 

--- a/src/Aspire.Dashboard/Components/Dialogs/FilterDialog.razor
+++ b/src/Aspire.Dashboard/Components/Dialogs/FilterDialog.razor
@@ -1,4 +1,5 @@
 ﻿@using Aspire.Dashboard.Model
+@using Aspire.Dashboard.Model.Otlp
 @using Aspire.Dashboard.Resources
 @implements IDialogContentComponent<FilterDialogViewModel>
 
@@ -45,6 +46,33 @@
                                    ImmediateDelay="@FluentUIExtensions.InputDelay"
                                    Label="@Loc[nameof(Dialogs.FilterDialogTextValuePlaceholder)]" />
                 <ValidationMessage For="() => _formModel.NumericValue" />
+            </div>
+        }
+        else if (_formModel.ValueIsDate)
+        {
+            <div class="filter-input-container input-container">
+                @* Position relative to correctly align the absolute positioned date picker *@
+                <div style="position: relative;">
+                    <FluentTextField @bind-Value="_formModel.Value"
+                                    Style="min-width: 100%"
+                                    Immediate="true"
+                                    ImmediateDelay="@FluentUIExtensions.InputDelay"
+                                    Placeholder="@Loc[nameof(Dialogs.FilterDialogDatePlaceholder)]"
+                                    Label="@Loc[nameof(Dialogs.FilterDialogDateValueLabel)]">
+                        <FluentIcon slot="end"
+                                    Value="@(new Icons.Regular.Size16.Calendar())"
+                                    Title="@Loc[nameof(Dialogs.FilterDialogPickDateButtonTitle)]"
+                                    OnClick="OpenDatePickerAsync"
+                                    Style="cursor: pointer;" />
+                    </FluentTextField>
+                    <input type="datetime-local"
+                        @ref="_datePickerInput"
+                        step="1"
+                        value="@_formModel.DateTimeLocalValue"
+                        @oninput="OnDateTimePickerChanged"
+                        style="position: absolute; right: 0; bottom: 0; height: 0; width: 0; overflow: hidden; border: none; padding: 0; margin: 0; pointer-events: none; opacity: 0;" />
+                </div>
+                <ValidationMessage For="() => _formModel.Value" />
             </div>
         }
         else

--- a/src/Aspire.Dashboard/Components/Dialogs/FilterDialog.razor.cs
+++ b/src/Aspire.Dashboard/Components/Dialogs/FilterDialog.razor.cs
@@ -5,6 +5,7 @@ using System.Globalization;
 using Aspire.Dashboard.Model;
 using Aspire.Dashboard.Model.Otlp;
 using Aspire.Dashboard.Otlp.Storage;
+using Aspire.Dashboard.Utils;
 using Microsoft.AspNetCore.Components;
 using Microsoft.AspNetCore.Components.Forms;
 using Microsoft.FluentUI.AspNetCore.Components;
@@ -12,7 +13,7 @@ using Microsoft.JSInterop;
 
 namespace Aspire.Dashboard.Components.Dialogs;
 
-public partial class FilterDialog
+public partial class FilterDialog : IAsyncDisposable
 {
     private List<SelectViewModel<FilterCondition>> _filterConditions = null!;
     private List<SelectViewModel<FilterCondition>> _stringFilterConditions = null!;
@@ -303,6 +304,11 @@ public partial class FilterDialog
         return dateTime.Ticks % TimeSpan.TicksPerSecond == 0
             ? dateTime.ToString("yyyy-MM-dd'T'HH:mm:ss", CultureInfo.InvariantCulture)
             : dateTime.ToString("yyyy-MM-dd'T'HH:mm:ss.FFFFFFF", CultureInfo.InvariantCulture);
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        await JSInteropHelpers.SafeDisposeAsync(_jsModule);
     }
 
     private sealed class FieldValue

--- a/src/Aspire.Dashboard/Components/Dialogs/FilterDialog.razor.cs
+++ b/src/Aspire.Dashboard/Components/Dialogs/FilterDialog.razor.cs
@@ -8,6 +8,7 @@ using Aspire.Dashboard.Otlp.Storage;
 using Microsoft.AspNetCore.Components;
 using Microsoft.AspNetCore.Components.Forms;
 using Microsoft.FluentUI.AspNetCore.Components;
+using Microsoft.JSInterop;
 
 namespace Aspire.Dashboard.Components.Dialogs;
 
@@ -16,6 +17,7 @@ public partial class FilterDialog
     private List<SelectViewModel<FilterCondition>> _filterConditions = null!;
     private List<SelectViewModel<FilterCondition>> _stringFilterConditions = null!;
     private List<SelectViewModel<FilterCondition>> _numericFilterConditions = null!;
+    private List<SelectViewModel<FilterCondition>> _dateFilterConditions = null!;
 
     private SelectViewModel<FilterCondition> CreateFilterSelectViewModel(FilterCondition condition) =>
         new SelectViewModel<FilterCondition> { Id = condition, Name = FieldTelemetryFilter.ConditionToString(condition, FilterLoc) };
@@ -29,6 +31,11 @@ public partial class FilterDialog
     [Inject]
     public required TelemetryRepository TelemetryRepository { get; init; }
 
+    [Inject]
+    public required IJSRuntime JS { get; init; }
+
+    private IJSObjectReference? _jsModule;
+    private ElementReference _datePickerInput;
     private FilterDialogFormModel _formModel = default!;
     private List<SelectViewModel<string>> _parameters = default!;
     private List<SelectViewModel<FieldValue>> _filteredValues = default!;
@@ -52,6 +59,16 @@ public partial class FilterDialog
             CreateFilterSelectViewModel(FilterCondition.GreaterThan),
             CreateFilterSelectViewModel(FilterCondition.LessThanOrEqual),
             CreateFilterSelectViewModel(FilterCondition.LessThan)
+        ];
+
+        _dateFilterConditions =
+        [
+            CreateFilterSelectViewModel(FilterCondition.GreaterThanOrEqual),
+            CreateFilterSelectViewModel(FilterCondition.GreaterThan),
+            CreateFilterSelectViewModel(FilterCondition.LessThanOrEqual),
+            CreateFilterSelectViewModel(FilterCondition.LessThan),
+            CreateFilterSelectViewModel(FilterCondition.Equals),
+            CreateFilterSelectViewModel(FilterCondition.NotEqual)
         ];
 
         _filterConditions = _stringFilterConditions;
@@ -102,13 +119,20 @@ public partial class FilterDialog
 
     private void UpdateSelectedParameter()
     {
-        _formModel.ValueIsNumeric = _formModel.Parameter?.Id is { } parameterName && FieldTelemetryFilter.IsNumericField(parameterName);
-        _filterConditions = _formModel.ValueIsNumeric ? _numericFilterConditions : _stringFilterConditions;
+        var fieldType = _formModel.Parameter?.Id is { } parameterName ? FieldTelemetryFilter.GetFieldType(parameterName) : FieldType.String;
+        _formModel.ValueIsNumeric = fieldType is FieldType.Numeric;
+        _formModel.ValueIsDate = fieldType is FieldType.Date;
+        _filterConditions = fieldType switch
+        {
+            FieldType.Numeric => _numericFilterConditions,
+            FieldType.Date => _dateFilterConditions,
+            _ => _stringFilterConditions
+        };
     }
 
     private SelectViewModel<FilterCondition> GetDefaultCondition()
     {
-        var condition = _formModel.ValueIsNumeric ? FilterCondition.GreaterThanOrEqual : FilterCondition.Contains;
+        var condition = (_formModel.ValueIsNumeric || _formModel.ValueIsDate) ? FilterCondition.GreaterThanOrEqual : FilterCondition.Contains;
         return _filterConditions.Single(c => c.Id == condition);
     }
 
@@ -130,7 +154,7 @@ public partial class FilterDialog
 
     private void UpdateParameterFieldValues()
     {
-        if (_formModel.ValueIsNumeric)
+        if (_formModel.ValueIsNumeric || _formModel.ValueIsDate)
         {
             _allValues = null;
             _filteredValues = [];
@@ -162,7 +186,7 @@ public partial class FilterDialog
 
         StateHasChanged();
 
-        if (_formModel.ValueIsNumeric)
+        if (_formModel.ValueIsNumeric || _formModel.ValueIsDate)
         {
             return;
         }
@@ -176,7 +200,7 @@ public partial class FilterDialog
 
     private void ValueChanged()
     {
-        if (_formModel.ValueIsNumeric)
+        if (_formModel.ValueIsNumeric || _formModel.ValueIsDate)
         {
             return;
         }
@@ -225,9 +249,15 @@ public partial class FilterDialog
 
     private void Apply()
     {
-        var value = _formModel.ValueIsNumeric
-            ? _formModel.NumericValue!.Value.ToString("R", CultureInfo.InvariantCulture)
-            : _formModel.Value!;
+        string value;
+        if (_formModel.ValueIsNumeric)
+        {
+            value = _formModel.NumericValue!.Value.ToString("R", CultureInfo.InvariantCulture);
+        }
+        else
+        {
+            value = _formModel.Value!;
+        }
 
         if (Content.Filter is { } filter)
         {
@@ -248,6 +278,31 @@ public partial class FilterDialog
 
             Dialog!.CloseAsync(DialogResult.Ok(new FilterDialogResult() { Filter = filter, Add = true }));
         }
+    }
+
+    private async Task OpenDatePickerAsync()
+    {
+        _jsModule ??= await JS.InvokeAsync<IJSObjectReference>("import", "./Components/Dialogs/FilterDialog.razor.js");
+        await _jsModule.InvokeVoidAsync("showPicker", _datePickerInput);
+    }
+
+    private void OnDateTimePickerChanged(ChangeEventArgs e)
+    {
+        // The datetime-local input returns a value in "YYYY-MM-DDThh:mm:ss" format (local time).
+        if (e.Value is string dateStr &&
+            DateTime.TryParse(dateStr, CultureInfo.InvariantCulture, DateTimeStyles.AssumeLocal, out var localDateTime))
+        {
+            _formModel.Value = FormatIsoDate(localDateTime);
+        }
+    }
+
+    private static string FormatIsoDate(DateTime dateTime)
+    {
+        // Format as ISO 8601 without trailing zeros on fractional seconds.
+        // e.g. "2024-01-15T09:30:00" or "2024-01-15T09:30:00.12"
+        return dateTime.Ticks % TimeSpan.TicksPerSecond == 0
+            ? dateTime.ToString("yyyy-MM-dd'T'HH:mm:ss", CultureInfo.InvariantCulture)
+            : dateTime.ToString("yyyy-MM-dd'T'HH:mm:ss.FFFFFFF", CultureInfo.InvariantCulture);
     }
 
     private sealed class FieldValue

--- a/src/Aspire.Dashboard/Components/Dialogs/FilterDialog.razor.js
+++ b/src/Aspire.Dashboard/Components/Dialogs/FilterDialog.razor.js
@@ -1,0 +1,3 @@
+export function showPicker(element) {
+    element.showPicker();
+}

--- a/src/Aspire.Dashboard/Components/Dialogs/FilterDialog.razor.js
+++ b/src/Aspire.Dashboard/Components/Dialogs/FilterDialog.razor.js
@@ -1,4 +1,8 @@
 export function showPicker(element) {
+    if (!element) {
+        return;
+    }
+
     try {
         element.showPicker();
     } catch {

--- a/src/Aspire.Dashboard/Components/Dialogs/FilterDialog.razor.js
+++ b/src/Aspire.Dashboard/Components/Dialogs/FilterDialog.razor.js
@@ -1,3 +1,9 @@
 export function showPicker(element) {
-    element.showPicker();
+    try {
+        element.showPicker();
+    } catch {
+        // showPicker() is not supported in all browsers/element states.
+        // Fall back to focusing the element so the user can interact with it directly.
+        element.focus();
+    }
 }

--- a/src/Aspire.Dashboard/Model/Otlp/FilterDialogFormModel.cs
+++ b/src/Aspire.Dashboard/Model/Otlp/FilterDialogFormModel.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.ComponentModel.DataAnnotations;
+using System.Globalization;
 using Aspire.Dashboard.Resources;
 
 namespace Aspire.Dashboard.Model.Otlp;
@@ -16,7 +17,26 @@ public class FilterDialogFormModel : IValidatableObject
 
     public bool ValueIsNumeric { get; set; }
 
+    public bool ValueIsDate { get; set; }
+
     public double? NumericValue { get; set; }
+
+    /// <summary>
+    /// Gets the current value formatted for an HTML datetime-local input element.
+    /// Parses the ISO 8601 value into "yyyy-MM-ddTHH:mm:ss" format expected by the input.
+    /// </summary>
+    public string? DateTimeLocalValue
+    {
+        get
+        {
+            if (Value is { Length: > 0 } v &&
+                DateTime.TryParse(v, CultureInfo.InvariantCulture, DateTimeStyles.None, out var dateTime))
+            {
+                return dateTime.ToString("yyyy-MM-dd\\THH:mm:ss", CultureInfo.InvariantCulture);
+            }
+            return null;
+        }
+    }
 
     // Set a max length on value because it will be added to the query string.
     // Max length is protection against accidently building a query string that exceeds limits because of a very long value.
@@ -35,6 +55,10 @@ public class FilterDialogFormModel : IValidatableObject
         else if (string.IsNullOrWhiteSpace(Value))
         {
             yield return new ValidationResult(Dialogs.FieldRequired, [nameof(Value)]);
+        }
+        else if (ValueIsDate && !DateTime.TryParse(Value, CultureInfo.InvariantCulture, DateTimeStyles.None, out _))
+        {
+            yield return new ValidationResult(Dialogs.FilterDialogInvalidDate, [nameof(Value)]);
         }
     }
 }

--- a/src/Aspire.Dashboard/Model/Otlp/KnownStructuredLogFields.cs
+++ b/src/Aspire.Dashboard/Model/Otlp/KnownStructuredLogFields.cs
@@ -13,6 +13,7 @@ public static class KnownStructuredLogFields
     public const string LevelField = "log.level";
     public const string OriginalFormatField = "log.originalformat";
     public const string EventNameField = "log.eventname";
+    public const string TimestampField = "log.timestamp";
 
     public static readonly List<string> AllFields = [
         MessageField,
@@ -21,6 +22,7 @@ public static class KnownStructuredLogFields
         TraceIdField,
         SpanIdField,
         OriginalFormatField,
-        EventNameField
+        EventNameField,
+        TimestampField
     ];
 }

--- a/src/Aspire.Dashboard/Model/Otlp/KnownTraceFields.cs
+++ b/src/Aspire.Dashboard/Model/Otlp/KnownTraceFields.cs
@@ -11,6 +11,7 @@ public static class KnownTraceFields
     public const string TraceIdField = "trace.traceid";
     public const string SpanIdField = "trace.spanid";
     public const string DurationField = "trace.duration";
+    public const string TimestampField = "trace.timestamp";
 
     // Not used in search.
     public const string StatusMessageField = "trace.statusmessage";
@@ -25,6 +26,7 @@ public static class KnownTraceFields
         TraceIdField,
         SpanIdField,
         KnownSourceFields.NameField,
-        DurationField
+        DurationField,
+        TimestampField
     ];
 }

--- a/src/Aspire.Dashboard/Model/Otlp/TelemetryFilter.cs
+++ b/src/Aspire.Dashboard/Model/Otlp/TelemetryFilter.cs
@@ -42,12 +42,14 @@ public class FieldTelemetryFilter : TelemetryFilter
             KnownStructuredLogFields.OriginalFormatField => "OriginalFormat",
             KnownStructuredLogFields.CategoryField => "Category",
             KnownStructuredLogFields.EventNameField => "EventName",
+            KnownStructuredLogFields.TimestampField => "Timestamp",
             KnownTraceFields.NameField => "Name",
             KnownTraceFields.SpanIdField => "SpanId",
             KnownTraceFields.TraceIdField => "TraceId",
             KnownTraceFields.KindField => "Kind",
             KnownTraceFields.StatusField => "Status",
             KnownTraceFields.DurationField => "Duration (ms)",
+            KnownTraceFields.TimestampField => "Timestamp",
             KnownSourceFields.NameField => "Source",
             KnownResourceFields.ServiceNameField => "Resource",
             _ => name
@@ -55,6 +57,26 @@ public class FieldTelemetryFilter : TelemetryFilter
     }
 
     public static bool IsNumericField(string name) => name is KnownTraceFields.DurationField;
+
+    /// <summary>
+    /// Returns true when the field represents a timestamp that should be compared as a date.
+    /// Filter values for these fields are parsed as <see cref="DateTime"/> and compared using
+    /// ticks stored in the field value from <see cref="OtlpSpan.GetFieldValue"/> / <see cref="OtlpLogEntry.GetFieldValue"/>.
+    /// </summary>
+    public static bool IsDateField(string name) => name is KnownTraceFields.TimestampField or KnownStructuredLogFields.TimestampField;
+
+    public static FieldType GetFieldType(string name)
+    {
+        if (IsNumericField(name))
+        {
+            return FieldType.Numeric;
+        }
+        if (IsDateField(name))
+        {
+            return FieldType.Date;
+        }
+        return FieldType.String;
+    }
 
     public static string ConditionToString(FilterCondition c, IStringLocalizer<StructuredFiltering>? loc) =>
         c switch
@@ -134,6 +156,32 @@ public class FieldTelemetryFilter : TelemetryFilter
         return func(fieldNumber, filterNumber);
     }
 
+    /// <summary>
+    /// Compares a field value (stored as ticks) against a filter value (a date string).
+    /// The filter value is parsed as a UTC DateTime, then compared by ticks.
+    /// </summary>
+    private static bool TryMatchDate(string fieldTicksValue, string filterDateValue, FilterCondition condition)
+    {
+        if (!long.TryParse(fieldTicksValue, NumberStyles.Integer, CultureInfo.InvariantCulture, out var fieldTicks))
+        {
+            return false;
+        }
+
+        if (!DateTime.TryParse(filterDateValue, CultureInfo.InvariantCulture, DateTimeStyles.AdjustToUniversal | DateTimeStyles.AssumeLocal, out var filterDate))
+        {
+            return false;
+        }
+
+        if (condition is not (FilterCondition.Equals or FilterCondition.GreaterThan or FilterCondition.LessThan or FilterCondition.GreaterThanOrEqual or FilterCondition.LessThanOrEqual or FilterCondition.NotEqual))
+        {
+            return false;
+        }
+
+        var filterTicks = filterDate.ToUniversalTime().Ticks;
+        var func = ConditionToFuncNumber(condition);
+        return func(fieldTicks, filterTicks);
+    }
+
     public bool HasNumericMatch(double fieldValue)
     {
         if (!double.TryParse(Value, NumberStyles.Float, CultureInfo.InvariantCulture, out var filterNumber) ||
@@ -178,26 +226,35 @@ public class FieldTelemetryFilter : TelemetryFilter
                 }
             default:
                 {
-                    var func = ConditionToFuncString(Condition);
-                    return input.Where(x => func(OtlpLogEntry.GetFieldValue(x, Field) ?? string.Empty, Value));
+                    var fieldType = GetFieldType(Field);
+                    return input.Where(x =>
+                    {
+                        var fieldValue = OtlpLogEntry.GetFieldValue(x, Field) ?? string.Empty;
+                        return fieldType switch
+                        {
+                            FieldType.Numeric => TryMatchNumber(fieldValue, Value, Condition),
+                            FieldType.Date => TryMatchDate(fieldValue, Value, Condition),
+                            _ => ConditionToFuncString(Condition)(fieldValue, Value)
+                        };
+                    });
                 }
         }
     }
 
     public override bool Apply(OtlpSpan span)
     {
-        var fieldValue = OtlpSpan.GetFieldValue(span, Field);
+        var fieldValues = OtlpSpan.GetFieldValue(span, Field);
         var isNot = Condition is FilterCondition.NotEqual or FilterCondition.NotContains;
-        var isNumeric = IsNumericField(Field);
+        var fieldType = GetFieldType(Field);
 
         if (!isNot)
         {
             // Or
-            if (fieldValue.Value1 != null && IsMatch(fieldValue.Value1, Value, Condition, isNumeric))
+            if (fieldValues.Value1 != null && IsMatch(fieldValues.Value1, Value, Condition, fieldType))
             {
                 return true;
             }
-            if (fieldValue.Value2 != null && IsMatch(fieldValue.Value2, Value, Condition, isNumeric))
+            if (fieldValues.Value2 != null && IsMatch(fieldValues.Value2, Value, Condition, fieldType))
             {
                 return true;
             }
@@ -206,9 +263,9 @@ public class FieldTelemetryFilter : TelemetryFilter
         {
             // And — both values must satisfy the not-equal/not-contains condition.
             // When Value2 is null (most fields only have one value), Value1 alone is sufficient.
-            if (fieldValue.Value1 != null && IsMatch(fieldValue.Value1, Value, Condition, isNumeric))
+            if (fieldValues.Value1 != null && IsMatch(fieldValues.Value1, Value, Condition, fieldType))
             {
-                if (fieldValue.Value2 is null || IsMatch(fieldValue.Value2, Value, Condition, isNumeric))
+                if (fieldValues.Value2 is null || IsMatch(fieldValues.Value2, Value, Condition, fieldType))
                 {
                     return true;
                 }
@@ -217,15 +274,14 @@ public class FieldTelemetryFilter : TelemetryFilter
 
         return false;
 
-        static bool IsMatch(string fieldValue, string filterValue, FilterCondition condition, bool isNumeric)
+        static bool IsMatch(string fieldValue, string filterValue, FilterCondition condition, FieldType fieldType)
         {
-            if (isNumeric)
+            return fieldType switch
             {
-                return TryMatchNumber(fieldValue, filterValue, condition);
-            }
-
-            var func = ConditionToFuncString(condition);
-            return func(fieldValue, filterValue);
+                FieldType.Numeric => TryMatchNumber(fieldValue, filterValue, condition),
+                FieldType.Date => TryMatchDate(fieldValue, filterValue, condition),
+                _ => ConditionToFuncString(condition)(fieldValue, filterValue)
+            };
         }
     }
 
@@ -254,4 +310,11 @@ public class FieldTelemetryFilter : TelemetryFilter
 
         return true;
     }
+}
+
+public enum FieldType
+{
+    String,
+    Numeric,
+    Date
 }

--- a/src/Aspire.Dashboard/Model/Otlp/TelemetryFilter.cs
+++ b/src/Aspire.Dashboard/Model/Otlp/TelemetryFilter.cs
@@ -65,7 +65,7 @@ public class FieldTelemetryFilter : TelemetryFilter
     /// </summary>
     public static bool IsDateField(string name) => name is KnownTraceFields.TimestampField or KnownStructuredLogFields.TimestampField;
 
-    public static FieldType GetFieldType(string name)
+    internal static FieldType GetFieldType(string name)
     {
         if (IsNumericField(name))
         {
@@ -312,7 +312,7 @@ public class FieldTelemetryFilter : TelemetryFilter
     }
 }
 
-public enum FieldType
+internal enum FieldType
 {
     String,
     Numeric,

--- a/src/Aspire.Dashboard/Model/Otlp/TelemetryFilter.cs
+++ b/src/Aspire.Dashboard/Model/Otlp/TelemetryFilter.cs
@@ -61,7 +61,7 @@ public class FieldTelemetryFilter : TelemetryFilter
     /// <summary>
     /// Returns true when the field represents a timestamp that should be compared as a date.
     /// Filter values for these fields are parsed as <see cref="DateTime"/> and compared using
-    /// ticks stored in the field value from <see cref="OtlpSpan.GetFieldValue"/> / <see cref="OtlpLogEntry.GetFieldValue"/>.
+    /// milliseconds stored in the field value from <see cref="OtlpSpan.GetFieldValue"/> / <see cref="OtlpLogEntry.GetFieldValue"/>.
     /// </summary>
     public static bool IsDateField(string name) => name is KnownTraceFields.TimestampField or KnownStructuredLogFields.TimestampField;
 
@@ -157,12 +157,12 @@ public class FieldTelemetryFilter : TelemetryFilter
     }
 
     /// <summary>
-    /// Compares a field value (stored as ticks) against a filter value (a date string).
-    /// The filter value is parsed as a UTC DateTime, then compared by ticks.
+    /// Compares a field value (stored as milliseconds since DateTime.MinValue) against a filter value (a date string).
+    /// Milliseconds fit within double's exact integer range (max ~3.16×10^14 vs 2^53 ≈ 9×10^15).
     /// </summary>
-    private static bool TryMatchDate(string fieldTicksValue, string filterDateValue, FilterCondition condition)
+    private static bool TryMatchDate(string fieldMillisecondsValue, string filterDateValue, FilterCondition condition)
     {
-        if (!long.TryParse(fieldTicksValue, NumberStyles.Integer, CultureInfo.InvariantCulture, out var fieldTicks))
+        if (!long.TryParse(fieldMillisecondsValue, NumberStyles.Integer, CultureInfo.InvariantCulture, out var fieldMs))
         {
             return false;
         }
@@ -177,9 +177,9 @@ public class FieldTelemetryFilter : TelemetryFilter
             return false;
         }
 
-        var filterTicks = filterDate.ToUniversalTime().Ticks;
+        var filterMs = filterDate.ToUniversalTime().Ticks / TimeSpan.TicksPerMillisecond;
         var func = ConditionToFuncNumber(condition);
-        return func(fieldTicks, filterTicks);
+        return func(fieldMs, filterMs);
     }
 
     public bool HasNumericMatch(double fieldValue)

--- a/src/Aspire.Dashboard/Otlp/Model/OtlpLogEntry.cs
+++ b/src/Aspire.Dashboard/Otlp/Model/OtlpLogEntry.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Diagnostics;
+using System.Globalization;
 using Aspire.Dashboard.Model.Otlp;
 using OpenTelemetry.Proto.Logs.V1;
 using SeverityNumberProto = OpenTelemetry.Proto.Logs.V1.SeverityNumber;
@@ -134,6 +135,7 @@ public class OtlpLogEntry
             KnownStructuredLogFields.CategoryField => log.Scope.Name,
             KnownStructuredLogFields.EventNameField => log.EventName,
             KnownStructuredLogFields.LevelField => log.Severity.ToString(),
+            KnownStructuredLogFields.TimestampField => log.TimeStamp.ToUniversalTime().Ticks.ToString(CultureInfo.InvariantCulture),
             KnownResourceFields.ServiceNameField => log.ResourceView.Resource.ResourceName,
             _ => log.Attributes.GetValue(field)
         };

--- a/src/Aspire.Dashboard/Otlp/Model/OtlpLogEntry.cs
+++ b/src/Aspire.Dashboard/Otlp/Model/OtlpLogEntry.cs
@@ -135,7 +135,7 @@ public class OtlpLogEntry
             KnownStructuredLogFields.CategoryField => log.Scope.Name,
             KnownStructuredLogFields.EventNameField => log.EventName,
             KnownStructuredLogFields.LevelField => log.Severity.ToString(),
-            KnownStructuredLogFields.TimestampField => log.TimeStamp.ToUniversalTime().Ticks.ToString(CultureInfo.InvariantCulture),
+            KnownStructuredLogFields.TimestampField => (log.TimeStamp.ToUniversalTime().Ticks / TimeSpan.TicksPerMillisecond).ToString(CultureInfo.InvariantCulture),
             KnownResourceFields.ServiceNameField => log.ResourceView.Resource.ResourceName,
             _ => log.Attributes.GetValue(field)
         };

--- a/src/Aspire.Dashboard/Otlp/Model/OtlpSpan.cs
+++ b/src/Aspire.Dashboard/Otlp/Model/OtlpSpan.cs
@@ -241,7 +241,7 @@ public class OtlpSpan
             KnownSourceFields.NameField => span.Scope.Name,
             KnownTraceFields.NameField => span.Name,
             KnownTraceFields.DurationField => span.Duration.TotalMilliseconds.ToString("R", CultureInfo.InvariantCulture),
-            KnownTraceFields.TimestampField => span.StartTime.ToUniversalTime().Ticks.ToString(CultureInfo.InvariantCulture),
+            KnownTraceFields.TimestampField => (span.StartTime.ToUniversalTime().Ticks / TimeSpan.TicksPerMillisecond).ToString(CultureInfo.InvariantCulture),
             _ => span.Attributes.GetValue(field)
         };
     }

--- a/src/Aspire.Dashboard/Otlp/Model/OtlpSpan.cs
+++ b/src/Aspire.Dashboard/Otlp/Model/OtlpSpan.cs
@@ -241,6 +241,7 @@ public class OtlpSpan
             KnownSourceFields.NameField => span.Scope.Name,
             KnownTraceFields.NameField => span.Name,
             KnownTraceFields.DurationField => span.Duration.TotalMilliseconds.ToString("R", CultureInfo.InvariantCulture),
+            KnownTraceFields.TimestampField => span.StartTime.ToUniversalTime().Ticks.ToString(CultureInfo.InvariantCulture),
             _ => span.Attributes.GetValue(field)
         };
     }

--- a/src/Aspire.Dashboard/Otlp/Storage/TelemetryRepository.cs
+++ b/src/Aspire.Dashboard/Otlp/Storage/TelemetryRepository.cs
@@ -1132,6 +1132,7 @@ public sealed partial class TelemetryRepository : IDisposable
         {
             if (filter is FieldTelemetryFilter fieldFilter &&
                 !FieldTelemetryFilter.IsNumericField(fieldFilter.Field) &&
+                !FieldTelemetryFilter.IsDateField(fieldFilter.Field) &&
                 IsSupportedCondition(fieldFilter.Condition))
             {
                 stringFilter = new StringFilter(fieldFilter.Field, fieldFilter.Condition, fieldFilter.Value);

--- a/src/Aspire.Dashboard/Resources/Dialogs.Designer.cs
+++ b/src/Aspire.Dashboard/Resources/Dialogs.Designer.cs
@@ -289,6 +289,42 @@ namespace Aspire.Dashboard.Resources {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Date and time.
+        /// </summary>
+        public static string FilterDialogDateValueLabel {
+            get {
+                return ResourceManager.GetString("FilterDialogDateValueLabel", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to e.g. 2024-01-15T09:30:00.
+        /// </summary>
+        public static string FilterDialogDatePlaceholder {
+            get {
+                return ResourceManager.GetString("FilterDialogDatePlaceholder", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Pick date and time.
+        /// </summary>
+        public static string FilterDialogPickDateButtonTitle {
+            get {
+                return ResourceManager.GetString("FilterDialogPickDateButtonTitle", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Invalid date format.
+        /// </summary>
+        public static string FilterDialogInvalidDate {
+            get {
+                return ResourceManager.GetString("FilterDialogInvalidDate", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Details.
         /// </summary>
         public static string GenAIDetailsTabText {

--- a/src/Aspire.Dashboard/Resources/Dialogs.resx
+++ b/src/Aspire.Dashboard/Resources/Dialogs.resx
@@ -123,6 +123,18 @@
   <data name="FilterDialogTextValuePlaceholder" xml:space="preserve">
     <value>Value</value>
   </data>
+  <data name="FilterDialogDateValueLabel" xml:space="preserve">
+    <value>Date and time</value>
+  </data>
+  <data name="FilterDialogDatePlaceholder" xml:space="preserve">
+    <value>e.g. 2024-01-15T09:30:00</value>
+  </data>
+  <data name="FilterDialogPickDateButtonTitle" xml:space="preserve">
+    <value>Pick date and time</value>
+  </data>
+  <data name="FilterDialogInvalidDate" xml:space="preserve">
+    <value>Invalid date format</value>
+  </data>
   <data name="FilterDialogCancelButtonText" xml:space="preserve">
     <value>Cancel</value>
   </data>

--- a/src/Aspire.Dashboard/Resources/xlf/Dialogs.cs.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Dialogs.cs.xlf
@@ -149,6 +149,16 @@ For more information about using AI agents with the dashboard, including setting
         <target state="translated">Podmínka</target>
         <note />
       </trans-unit>
+      <trans-unit id="FilterDialogDatePlaceholder">
+        <source>e.g. 2024-01-15T09:30:00</source>
+        <target state="new">e.g. 2024-01-15T09:30:00</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FilterDialogDateValueLabel">
+        <source>Date and time</source>
+        <target state="new">Date and time</target>
+        <note />
+      </trans-unit>
       <trans-unit id="FilterDialogDisableAll">
         <source>Disable all</source>
         <target state="translated">Zakázat vše</target>
@@ -169,9 +179,19 @@ For more information about using AI agents with the dashboard, including setting
         <target state="translated">Pole</target>
         <note />
       </trans-unit>
+      <trans-unit id="FilterDialogInvalidDate">
+        <source>Invalid date format</source>
+        <target state="new">Invalid date format</target>
+        <note />
+      </trans-unit>
       <trans-unit id="FilterDialogParameterInputLabel">
         <source>Parameter</source>
         <target state="translated">Parametr</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FilterDialogPickDateButtonTitle">
+        <source>Pick date and time</source>
+        <target state="new">Pick date and time</target>
         <note />
       </trans-unit>
       <trans-unit id="FilterDialogRemoveFilterButtonText">

--- a/src/Aspire.Dashboard/Resources/xlf/Dialogs.de.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Dialogs.de.xlf
@@ -149,6 +149,16 @@ For more information about using AI agents with the dashboard, including setting
         <target state="translated">Bedingung</target>
         <note />
       </trans-unit>
+      <trans-unit id="FilterDialogDatePlaceholder">
+        <source>e.g. 2024-01-15T09:30:00</source>
+        <target state="new">e.g. 2024-01-15T09:30:00</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FilterDialogDateValueLabel">
+        <source>Date and time</source>
+        <target state="new">Date and time</target>
+        <note />
+      </trans-unit>
       <trans-unit id="FilterDialogDisableAll">
         <source>Disable all</source>
         <target state="translated">Alle deaktivieren</target>
@@ -169,9 +179,19 @@ For more information about using AI agents with the dashboard, including setting
         <target state="translated">Feld</target>
         <note />
       </trans-unit>
+      <trans-unit id="FilterDialogInvalidDate">
+        <source>Invalid date format</source>
+        <target state="new">Invalid date format</target>
+        <note />
+      </trans-unit>
       <trans-unit id="FilterDialogParameterInputLabel">
         <source>Parameter</source>
         <target state="translated">Parameter</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FilterDialogPickDateButtonTitle">
+        <source>Pick date and time</source>
+        <target state="new">Pick date and time</target>
         <note />
       </trans-unit>
       <trans-unit id="FilterDialogRemoveFilterButtonText">

--- a/src/Aspire.Dashboard/Resources/xlf/Dialogs.es.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Dialogs.es.xlf
@@ -149,6 +149,16 @@ For more information about using AI agents with the dashboard, including setting
         <target state="translated">Condición</target>
         <note />
       </trans-unit>
+      <trans-unit id="FilterDialogDatePlaceholder">
+        <source>e.g. 2024-01-15T09:30:00</source>
+        <target state="new">e.g. 2024-01-15T09:30:00</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FilterDialogDateValueLabel">
+        <source>Date and time</source>
+        <target state="new">Date and time</target>
+        <note />
+      </trans-unit>
       <trans-unit id="FilterDialogDisableAll">
         <source>Disable all</source>
         <target state="translated">Deshabilitar todo</target>
@@ -169,9 +179,19 @@ For more information about using AI agents with the dashboard, including setting
         <target state="translated">Campo</target>
         <note />
       </trans-unit>
+      <trans-unit id="FilterDialogInvalidDate">
+        <source>Invalid date format</source>
+        <target state="new">Invalid date format</target>
+        <note />
+      </trans-unit>
       <trans-unit id="FilterDialogParameterInputLabel">
         <source>Parameter</source>
         <target state="translated">Parámetro</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FilterDialogPickDateButtonTitle">
+        <source>Pick date and time</source>
+        <target state="new">Pick date and time</target>
         <note />
       </trans-unit>
       <trans-unit id="FilterDialogRemoveFilterButtonText">

--- a/src/Aspire.Dashboard/Resources/xlf/Dialogs.fr.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Dialogs.fr.xlf
@@ -149,6 +149,16 @@ For more information about using AI agents with the dashboard, including setting
         <target state="translated">Condition</target>
         <note />
       </trans-unit>
+      <trans-unit id="FilterDialogDatePlaceholder">
+        <source>e.g. 2024-01-15T09:30:00</source>
+        <target state="new">e.g. 2024-01-15T09:30:00</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FilterDialogDateValueLabel">
+        <source>Date and time</source>
+        <target state="new">Date and time</target>
+        <note />
+      </trans-unit>
       <trans-unit id="FilterDialogDisableAll">
         <source>Disable all</source>
         <target state="translated">Désactiver tout</target>
@@ -169,9 +179,19 @@ For more information about using AI agents with the dashboard, including setting
         <target state="translated">Champ</target>
         <note />
       </trans-unit>
+      <trans-unit id="FilterDialogInvalidDate">
+        <source>Invalid date format</source>
+        <target state="new">Invalid date format</target>
+        <note />
+      </trans-unit>
       <trans-unit id="FilterDialogParameterInputLabel">
         <source>Parameter</source>
         <target state="translated">Paramètre</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FilterDialogPickDateButtonTitle">
+        <source>Pick date and time</source>
+        <target state="new">Pick date and time</target>
         <note />
       </trans-unit>
       <trans-unit id="FilterDialogRemoveFilterButtonText">

--- a/src/Aspire.Dashboard/Resources/xlf/Dialogs.it.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Dialogs.it.xlf
@@ -149,6 +149,16 @@ For more information about using AI agents with the dashboard, including setting
         <target state="translated">Condizione</target>
         <note />
       </trans-unit>
+      <trans-unit id="FilterDialogDatePlaceholder">
+        <source>e.g. 2024-01-15T09:30:00</source>
+        <target state="new">e.g. 2024-01-15T09:30:00</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FilterDialogDateValueLabel">
+        <source>Date and time</source>
+        <target state="new">Date and time</target>
+        <note />
+      </trans-unit>
       <trans-unit id="FilterDialogDisableAll">
         <source>Disable all</source>
         <target state="translated">Disabilita tutto</target>
@@ -169,9 +179,19 @@ For more information about using AI agents with the dashboard, including setting
         <target state="translated">Campo</target>
         <note />
       </trans-unit>
+      <trans-unit id="FilterDialogInvalidDate">
+        <source>Invalid date format</source>
+        <target state="new">Invalid date format</target>
+        <note />
+      </trans-unit>
       <trans-unit id="FilterDialogParameterInputLabel">
         <source>Parameter</source>
         <target state="translated">Parametro</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FilterDialogPickDateButtonTitle">
+        <source>Pick date and time</source>
+        <target state="new">Pick date and time</target>
         <note />
       </trans-unit>
       <trans-unit id="FilterDialogRemoveFilterButtonText">

--- a/src/Aspire.Dashboard/Resources/xlf/Dialogs.ja.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Dialogs.ja.xlf
@@ -149,6 +149,16 @@ For more information about using AI agents with the dashboard, including setting
         <target state="translated">条件</target>
         <note />
       </trans-unit>
+      <trans-unit id="FilterDialogDatePlaceholder">
+        <source>e.g. 2024-01-15T09:30:00</source>
+        <target state="new">e.g. 2024-01-15T09:30:00</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FilterDialogDateValueLabel">
+        <source>Date and time</source>
+        <target state="new">Date and time</target>
+        <note />
+      </trans-unit>
       <trans-unit id="FilterDialogDisableAll">
         <source>Disable all</source>
         <target state="translated">すべて無効にする</target>
@@ -169,9 +179,19 @@ For more information about using AI agents with the dashboard, including setting
         <target state="translated">フィールド</target>
         <note />
       </trans-unit>
+      <trans-unit id="FilterDialogInvalidDate">
+        <source>Invalid date format</source>
+        <target state="new">Invalid date format</target>
+        <note />
+      </trans-unit>
       <trans-unit id="FilterDialogParameterInputLabel">
         <source>Parameter</source>
         <target state="translated">パラメーター</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FilterDialogPickDateButtonTitle">
+        <source>Pick date and time</source>
+        <target state="new">Pick date and time</target>
         <note />
       </trans-unit>
       <trans-unit id="FilterDialogRemoveFilterButtonText">

--- a/src/Aspire.Dashboard/Resources/xlf/Dialogs.ko.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Dialogs.ko.xlf
@@ -149,6 +149,16 @@ For more information about using AI agents with the dashboard, including setting
         <target state="translated">조건</target>
         <note />
       </trans-unit>
+      <trans-unit id="FilterDialogDatePlaceholder">
+        <source>e.g. 2024-01-15T09:30:00</source>
+        <target state="new">e.g. 2024-01-15T09:30:00</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FilterDialogDateValueLabel">
+        <source>Date and time</source>
+        <target state="new">Date and time</target>
+        <note />
+      </trans-unit>
       <trans-unit id="FilterDialogDisableAll">
         <source>Disable all</source>
         <target state="translated">모두 사용 안 함</target>
@@ -169,9 +179,19 @@ For more information about using AI agents with the dashboard, including setting
         <target state="translated">필드</target>
         <note />
       </trans-unit>
+      <trans-unit id="FilterDialogInvalidDate">
+        <source>Invalid date format</source>
+        <target state="new">Invalid date format</target>
+        <note />
+      </trans-unit>
       <trans-unit id="FilterDialogParameterInputLabel">
         <source>Parameter</source>
         <target state="translated">매개 변수</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FilterDialogPickDateButtonTitle">
+        <source>Pick date and time</source>
+        <target state="new">Pick date and time</target>
         <note />
       </trans-unit>
       <trans-unit id="FilterDialogRemoveFilterButtonText">

--- a/src/Aspire.Dashboard/Resources/xlf/Dialogs.pl.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Dialogs.pl.xlf
@@ -149,6 +149,16 @@ For more information about using AI agents with the dashboard, including setting
         <target state="translated">Warunek</target>
         <note />
       </trans-unit>
+      <trans-unit id="FilterDialogDatePlaceholder">
+        <source>e.g. 2024-01-15T09:30:00</source>
+        <target state="new">e.g. 2024-01-15T09:30:00</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FilterDialogDateValueLabel">
+        <source>Date and time</source>
+        <target state="new">Date and time</target>
+        <note />
+      </trans-unit>
       <trans-unit id="FilterDialogDisableAll">
         <source>Disable all</source>
         <target state="translated">Wyłącz wszystko</target>
@@ -169,9 +179,19 @@ For more information about using AI agents with the dashboard, including setting
         <target state="translated">Pole</target>
         <note />
       </trans-unit>
+      <trans-unit id="FilterDialogInvalidDate">
+        <source>Invalid date format</source>
+        <target state="new">Invalid date format</target>
+        <note />
+      </trans-unit>
       <trans-unit id="FilterDialogParameterInputLabel">
         <source>Parameter</source>
         <target state="translated">Parametr</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FilterDialogPickDateButtonTitle">
+        <source>Pick date and time</source>
+        <target state="new">Pick date and time</target>
         <note />
       </trans-unit>
       <trans-unit id="FilterDialogRemoveFilterButtonText">

--- a/src/Aspire.Dashboard/Resources/xlf/Dialogs.pt-BR.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Dialogs.pt-BR.xlf
@@ -149,6 +149,16 @@ For more information about using AI agents with the dashboard, including setting
         <target state="translated">Condição</target>
         <note />
       </trans-unit>
+      <trans-unit id="FilterDialogDatePlaceholder">
+        <source>e.g. 2024-01-15T09:30:00</source>
+        <target state="new">e.g. 2024-01-15T09:30:00</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FilterDialogDateValueLabel">
+        <source>Date and time</source>
+        <target state="new">Date and time</target>
+        <note />
+      </trans-unit>
       <trans-unit id="FilterDialogDisableAll">
         <source>Disable all</source>
         <target state="translated">Desabilitar tudo</target>
@@ -169,9 +179,19 @@ For more information about using AI agents with the dashboard, including setting
         <target state="translated">Campo</target>
         <note />
       </trans-unit>
+      <trans-unit id="FilterDialogInvalidDate">
+        <source>Invalid date format</source>
+        <target state="new">Invalid date format</target>
+        <note />
+      </trans-unit>
       <trans-unit id="FilterDialogParameterInputLabel">
         <source>Parameter</source>
         <target state="translated">Parâmetro</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FilterDialogPickDateButtonTitle">
+        <source>Pick date and time</source>
+        <target state="new">Pick date and time</target>
         <note />
       </trans-unit>
       <trans-unit id="FilterDialogRemoveFilterButtonText">

--- a/src/Aspire.Dashboard/Resources/xlf/Dialogs.ru.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Dialogs.ru.xlf
@@ -149,6 +149,16 @@ For more information about using AI agents with the dashboard, including setting
         <target state="translated">Условие</target>
         <note />
       </trans-unit>
+      <trans-unit id="FilterDialogDatePlaceholder">
+        <source>e.g. 2024-01-15T09:30:00</source>
+        <target state="new">e.g. 2024-01-15T09:30:00</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FilterDialogDateValueLabel">
+        <source>Date and time</source>
+        <target state="new">Date and time</target>
+        <note />
+      </trans-unit>
       <trans-unit id="FilterDialogDisableAll">
         <source>Disable all</source>
         <target state="translated">Отключить все</target>
@@ -169,9 +179,19 @@ For more information about using AI agents with the dashboard, including setting
         <target state="translated">Поле</target>
         <note />
       </trans-unit>
+      <trans-unit id="FilterDialogInvalidDate">
+        <source>Invalid date format</source>
+        <target state="new">Invalid date format</target>
+        <note />
+      </trans-unit>
       <trans-unit id="FilterDialogParameterInputLabel">
         <source>Parameter</source>
         <target state="translated">Параметр</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FilterDialogPickDateButtonTitle">
+        <source>Pick date and time</source>
+        <target state="new">Pick date and time</target>
         <note />
       </trans-unit>
       <trans-unit id="FilterDialogRemoveFilterButtonText">

--- a/src/Aspire.Dashboard/Resources/xlf/Dialogs.tr.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Dialogs.tr.xlf
@@ -149,6 +149,16 @@ For more information about using AI agents with the dashboard, including setting
         <target state="translated">Koşul</target>
         <note />
       </trans-unit>
+      <trans-unit id="FilterDialogDatePlaceholder">
+        <source>e.g. 2024-01-15T09:30:00</source>
+        <target state="new">e.g. 2024-01-15T09:30:00</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FilterDialogDateValueLabel">
+        <source>Date and time</source>
+        <target state="new">Date and time</target>
+        <note />
+      </trans-unit>
       <trans-unit id="FilterDialogDisableAll">
         <source>Disable all</source>
         <target state="translated">Tümünü devre dışı bırak</target>
@@ -169,9 +179,19 @@ For more information about using AI agents with the dashboard, including setting
         <target state="translated">Alan</target>
         <note />
       </trans-unit>
+      <trans-unit id="FilterDialogInvalidDate">
+        <source>Invalid date format</source>
+        <target state="new">Invalid date format</target>
+        <note />
+      </trans-unit>
       <trans-unit id="FilterDialogParameterInputLabel">
         <source>Parameter</source>
         <target state="translated">Parametre</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FilterDialogPickDateButtonTitle">
+        <source>Pick date and time</source>
+        <target state="new">Pick date and time</target>
         <note />
       </trans-unit>
       <trans-unit id="FilterDialogRemoveFilterButtonText">

--- a/src/Aspire.Dashboard/Resources/xlf/Dialogs.zh-Hans.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Dialogs.zh-Hans.xlf
@@ -149,6 +149,16 @@ For more information about using AI agents with the dashboard, including setting
         <target state="translated">条件</target>
         <note />
       </trans-unit>
+      <trans-unit id="FilterDialogDatePlaceholder">
+        <source>e.g. 2024-01-15T09:30:00</source>
+        <target state="new">e.g. 2024-01-15T09:30:00</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FilterDialogDateValueLabel">
+        <source>Date and time</source>
+        <target state="new">Date and time</target>
+        <note />
+      </trans-unit>
       <trans-unit id="FilterDialogDisableAll">
         <source>Disable all</source>
         <target state="translated">全部禁用</target>
@@ -169,9 +179,19 @@ For more information about using AI agents with the dashboard, including setting
         <target state="translated">字段</target>
         <note />
       </trans-unit>
+      <trans-unit id="FilterDialogInvalidDate">
+        <source>Invalid date format</source>
+        <target state="new">Invalid date format</target>
+        <note />
+      </trans-unit>
       <trans-unit id="FilterDialogParameterInputLabel">
         <source>Parameter</source>
         <target state="translated">参数</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FilterDialogPickDateButtonTitle">
+        <source>Pick date and time</source>
+        <target state="new">Pick date and time</target>
         <note />
       </trans-unit>
       <trans-unit id="FilterDialogRemoveFilterButtonText">

--- a/src/Aspire.Dashboard/Resources/xlf/Dialogs.zh-Hant.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Dialogs.zh-Hant.xlf
@@ -149,6 +149,16 @@ For more information about using AI agents with the dashboard, including setting
         <target state="translated">條件</target>
         <note />
       </trans-unit>
+      <trans-unit id="FilterDialogDatePlaceholder">
+        <source>e.g. 2024-01-15T09:30:00</source>
+        <target state="new">e.g. 2024-01-15T09:30:00</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FilterDialogDateValueLabel">
+        <source>Date and time</source>
+        <target state="new">Date and time</target>
+        <note />
+      </trans-unit>
       <trans-unit id="FilterDialogDisableAll">
         <source>Disable all</source>
         <target state="translated">全部停用</target>
@@ -169,9 +179,19 @@ For more information about using AI agents with the dashboard, including setting
         <target state="translated">欄位</target>
         <note />
       </trans-unit>
+      <trans-unit id="FilterDialogInvalidDate">
+        <source>Invalid date format</source>
+        <target state="new">Invalid date format</target>
+        <note />
+      </trans-unit>
       <trans-unit id="FilterDialogParameterInputLabel">
         <source>Parameter</source>
         <target state="translated">參數</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FilterDialogPickDateButtonTitle">
+        <source>Pick date and time</source>
+        <target state="new">Pick date and time</target>
         <note />
       </trans-unit>
       <trans-unit id="FilterDialogRemoveFilterButtonText">

--- a/tests/Aspire.Dashboard.Tests/TelemetryApiServiceTests.cs
+++ b/tests/Aspire.Dashboard.Tests/TelemetryApiServiceTests.cs
@@ -540,6 +540,144 @@ public class TelemetryApiServiceTests
         Assert.Equal(1, result.ReturnedCount);
     }
 
+    [Fact]
+    public void GetSpans_WithTimestampGreaterThan_FiltersCorrectly()
+    {
+        var repository = CreateRepository();
+        // Spans at s_testTime+1min, +2min, +3min
+        AddSpans(repository, count: 3);
+
+        var service = CreateService(repository);
+
+        // Filter for spans after s_testTime+1.5min (should return spans at +2min and +3min)
+        var cutoff = s_testTime.AddMinutes(1).AddSeconds(30).ToString("O");
+        var result = service.GetSpans(resourceNames: null, traceId: null, hasError: null, limit: null, search: $"timestamp:>{cutoff}");
+
+        Assert.NotNull(result);
+        Assert.Equal(2, result.ReturnedCount);
+    }
+
+    [Fact]
+    public void GetSpans_WithTimestampLessThan_FiltersCorrectly()
+    {
+        var repository = CreateRepository();
+        // Spans at s_testTime+1min, +2min, +3min
+        AddSpans(repository, count: 3);
+
+        var service = CreateService(repository);
+
+        // Filter for spans before s_testTime+2.5min (should return spans at +1min and +2min)
+        var cutoff = s_testTime.AddMinutes(2).AddSeconds(30).ToString("O");
+        var result = service.GetSpans(resourceNames: null, traceId: null, hasError: null, limit: null, search: $"timestamp:<{cutoff}");
+
+        Assert.NotNull(result);
+        Assert.Equal(2, result.ReturnedCount);
+    }
+
+    [Fact]
+    public void GetSpans_WithTimestampGreaterThanOrEqual_FiltersCorrectly()
+    {
+        var repository = CreateRepository();
+        // Spans at s_testTime+1min, +2min, +3min
+        AddSpans(repository, count: 3);
+
+        var service = CreateService(repository);
+
+        // Filter for spans at or after exactly s_testTime+2min (should return spans at +2min and +3min)
+        var cutoff = s_testTime.AddMinutes(2).ToString("O");
+        var result = service.GetSpans(resourceNames: null, traceId: null, hasError: null, limit: null, search: $"timestamp:>={cutoff}");
+
+        Assert.NotNull(result);
+        Assert.Equal(2, result.ReturnedCount);
+    }
+
+    [Fact]
+    public void GetLogs_WithTimestampGreaterThan_FiltersCorrectly()
+    {
+        var repository = CreateRepository();
+        // Logs at s_testTime, +1min, +2min
+        AddLogs(repository, ["log1", "log2", "log3"]);
+
+        var service = CreateService(repository);
+
+        // Filter for logs after s_testTime+0.5min (should return logs at +1min and +2min)
+        var cutoff = s_testTime.AddSeconds(30).ToString("O");
+        var result = service.GetLogs(resourceNames: null, traceId: null, severity: null, limit: null, search: $"timestamp:>{cutoff}");
+
+        Assert.NotNull(result);
+        Assert.Equal(2, result.ReturnedCount);
+    }
+
+    [Fact]
+    public void GetSpans_WithTimestampInvalidDate_ReturnsNoResults()
+    {
+        var repository = CreateRepository();
+        AddSpans(repository, count: 3);
+
+        var service = CreateService(repository);
+
+        // Invalid date string should not match anything
+        var result = service.GetSpans(resourceNames: null, traceId: null, hasError: null, limit: null, search: "timestamp:>not-a-date");
+
+        Assert.NotNull(result);
+        Assert.Equal(0, result.ReturnedCount);
+    }
+
+    [Fact]
+    public void GetSpans_WithTimestampUtcSuffix_TreatedAsUtc()
+    {
+        var repository = CreateRepository();
+        // Spans at s_testTime+1min, +2min, +3min (s_testTime is 1970-01-01T00:00:00Z)
+        AddSpans(repository, count: 3);
+
+        var service = CreateService(repository);
+
+        // A timestamp ending in Z is UTC and should not be adjusted.
+        // s_testTime+1.5min = 1970-01-01T00:01:30Z — should match spans at +2min and +3min
+        var result = service.GetSpans(resourceNames: null, traceId: null, hasError: null, limit: null, search: "timestamp:>1970-01-01T00:01:30Z");
+
+        Assert.NotNull(result);
+        Assert.Equal(2, result.ReturnedCount);
+    }
+
+    [Fact]
+    public void GetSpans_WithTimestampNoTimezone_TreatedAsLocalTime()
+    {
+        var repository = CreateRepository();
+        // Spans at s_testTime+1min, +2min, +3min (s_testTime is 1970-01-01T00:00:00Z)
+        AddSpans(repository, count: 3);
+
+        var service = CreateService(repository);
+
+        // A timestamp without Z or offset is treated as local time and converted to UTC.
+        // Compute what local time corresponds to s_testTime+1.5min UTC so the filter matches the same spans.
+        var utcCutoff = s_testTime.AddMinutes(1).AddSeconds(30);
+        var localCutoff = utcCutoff.ToLocalTime();
+        var localString = localCutoff.ToString("yyyy-MM-dd'T'HH:mm:ss", System.Globalization.CultureInfo.InvariantCulture);
+
+        var result = service.GetSpans(resourceNames: null, traceId: null, hasError: null, limit: null, search: $"timestamp:>{localString}");
+
+        Assert.NotNull(result);
+        Assert.Equal(2, result.ReturnedCount);
+    }
+
+    [Fact]
+    public void GetSpans_WithTimestampOffset_AdjustedToUtc()
+    {
+        var repository = CreateRepository();
+        // Spans at s_testTime+1min, +2min, +3min (s_testTime is 1970-01-01T00:00:00Z)
+        AddSpans(repository, count: 3);
+
+        var service = CreateService(repository);
+
+        // A timestamp with an explicit offset is adjusted to UTC.
+        // 1970-01-01T01:01:30+01:00 = 1970-01-01T00:01:30Z — should match spans at +2min and +3min
+        var result = service.GetSpans(resourceNames: null, traceId: null, hasError: null, limit: null, search: "timestamp:>1970-01-01T01:01:30+01:00");
+
+        Assert.NotNull(result);
+        Assert.Equal(2, result.ReturnedCount);
+    }
+
     /// <summary>
     /// Adds spans with sequential trace/span IDs to the repository. Each span is added in a separate
     /// AddTraces call so that it gets its own trace entry.

--- a/tests/Aspire.Dashboard.Tests/TelemetryApiServiceTests.cs
+++ b/tests/Aspire.Dashboard.Tests/TelemetryApiServiceTests.cs
@@ -678,6 +678,28 @@ public class TelemetryApiServiceTests
         Assert.Equal(2, result.ReturnedCount);
     }
 
+    [Fact]
+    public void GetSpans_WithTimestampDateOnly_FiltersCorrectly()
+    {
+        var repository = CreateRepository();
+        // Create spans on two different days: 1970-01-01 and 1970-01-02
+        AddSpansToRepository(repository, [
+            CreateSpan(traceId: "trace1", spanId: "span1", startTime: new DateTime(1970, 1, 1, 12, 0, 0, DateTimeKind.Utc), endTime: new DateTime(1970, 1, 1, 12, 1, 0, DateTimeKind.Utc))
+        ]);
+        AddSpansToRepository(repository, [
+            CreateSpan(traceId: "trace2", spanId: "span2", startTime: new DateTime(1970, 1, 2, 12, 0, 0, DateTimeKind.Utc), endTime: new DateTime(1970, 1, 2, 12, 1, 0, DateTimeKind.Utc))
+        ]);
+
+        var service = CreateService(repository);
+
+        // A date-only string (no time component) should be parsed as midnight UTC and filter correctly.
+        // "1970-01-02" = midnight 1970-01-02 UTC — only the span on 1970-01-02 has a start time >= that.
+        var result = service.GetSpans(resourceNames: null, traceId: null, hasError: null, limit: null, search: "timestamp:>=1970-01-02");
+
+        Assert.NotNull(result);
+        Assert.Equal(1, result.ReturnedCount);
+    }
+
     /// <summary>
     /// Adds spans with sequential trace/span IDs to the repository. Each span is added in a separate
     /// AddTraces call so that it gets its own trace entry.


### PR DESCRIPTION
## Description

Add a `timestamp` search qualifier for filtering traces, spans, and structured logs by date/time in the dashboard. Users can filter telemetry using comparison operators with ISO 8601 date strings (e.g., `timestamp:>2024-01-15T09:30:00`, `timestamp:<=2024-06-01T12:00:00Z`).

### UI

<img width="711" height="716" alt="image" src="https://github.com/user-attachments/assets/1ff36795-6a8e-4b8d-9bca-37d7a292d714" />

### User-facing usage

In the search/filter bar on the Traces, Spans, or Logs pages:
```
timestamp:>2024-01-15T09:30:00
timestamp:<=2024-06-01T12:00:00+05:00
timestamp:>=2024-03-01T08:30:00Z
```

Timestamps without a timezone suffix are treated as local time, timestamps with an offset are adjusted to UTC, and timestamps with `Z` are treated as UTC directly.

When using the filter dialog UI, selecting the Timestamp field shows a text input for the ISO date value with a calendar icon that opens the browser's native date/time picker.

### Implementation details

- Added `TimestampField` constants to `KnownTraceFields` and `KnownStructuredLogFields`
- Introduced `FieldType` enum (`String`, `Numeric`, `Date`) replacing the boolean `isNumeric` parameter in filter matching
- Added `TryMatchDate` for ticks-based date comparison in `TelemetryFilter`
- Filter dialog shows a `FluentTextField` with a calendar icon that triggers the native `datetime-local` picker via JS interop
- Date values are validated before the filter is applied

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
  - [x] No
