### PR TITLE
Fix telemetry streaming to wait for resource to appear

### DIFF
--- a/src/Aspire.Dashboard/Api/TelemetryApiService.cs
+++ b/src/Aspire.Dashboard/Api/TelemetryApiService.cs
@@ -47,21 +47,17 @@ internal sealed class TelemetryApiService(
         var searchTextFragments = ParseAndApplySearchFilters(search, spanFilters, AddSpanFiltersFromQualifiers, key => ResolveSpanFieldKey(key) is not null);
 
         // Get spans for all resource keys (empty list means no filter / all resources)
-        var allSpans = new List<OtlpSpan>();
-        foreach (var resourceKey in resourceKeys.Count > 0 ? resourceKeys.Select(k => (ResourceKey?)k) : [null])
+        var result = telemetryRepository.GetSpans(new GetSpansRequest
         {
-            var result = telemetryRepository.GetSpans(new GetSpansRequest
-            {
-                ResourceKey = resourceKey,
-                StartIndex = 0,
-                Count = int.MaxValue,
-                Filters = spanFilters,
-                TraceId = traceId,
-                HasError = hasError,
-                TextFragments = searchTextFragments
-            });
-            allSpans.AddRange(result.PagedResult.Items);
-        }
+            ResourceKeys = resourceKeys,
+            StartIndex = 0,
+            Count = int.MaxValue,
+            Filters = spanFilters,
+            TraceId = traceId,
+            HasError = hasError,
+            TextFragments = searchTextFragments
+        });
+        var allSpans = result.PagedResult.Items;
 
         var totalCount = allSpans.Count;
 
@@ -104,19 +100,15 @@ internal sealed class TelemetryApiService(
         var searchTextFragments = ParseAndApplySearchFilters(search, traceFilters, AddSpanFiltersFromQualifiers, key => ResolveSpanFieldKey(key) is not null);
 
         // Get traces for all resource keys (empty list means no filter / all resources)
-        var allTraces = new List<OtlpTrace>();
-        foreach (var resourceKey in resourceKeys.Count > 0 ? resourceKeys.Select(k => (ResourceKey?)k) : [null])
+        var result = telemetryRepository.GetTraces(new GetTracesRequest
         {
-            var result = telemetryRepository.GetTraces(new GetTracesRequest
-            {
-                ResourceKey = resourceKey,
-                StartIndex = 0,
-                Count = int.MaxValue,
-                Filters = traceFilters,
-                TextFragments = searchTextFragments
-            });
-            allTraces.AddRange(result.PagedResult.Items);
-        }
+            ResourceKeys = resourceKeys,
+            StartIndex = 0,
+            Count = int.MaxValue,
+            Filters = traceFilters,
+            TextFragments = searchTextFragments
+        });
+        var allTraces = result.PagedResult.Items;
 
         var traces = allTraces;
 
@@ -273,7 +265,7 @@ internal sealed class TelemetryApiService(
         // Build the watch request with all filters pushed into the repository
         var watchRequest = new WatchSpansRequest
         {
-            ResourceKey = resourceKeys is [var singleKey] ? singleKey : null,
+            ResourceKeys = resourceKeys,
             Filters = spanFilters,
             TraceId = traceId,
             HasError = hasError,
@@ -283,14 +275,6 @@ internal sealed class TelemetryApiService(
         // Watch spans with filtering done inside the repository
         await foreach (var span in telemetryRepository.WatchSpansAsync(watchRequest, cancellationToken).ConfigureAwait(false))
         {
-            // Multi-resource filtering: repository only supports single ResourceKey,
-            // so for multi-resource queries we filter here.
-            if (resourceKeys is { Count: > 1 } &&
-                !resourceKeys.Any(k => k.EqualsCompositeName(span.Source.ResourceKey.GetCompositeName())))
-            {
-                continue;
-            }
-
             // Use compact JSON for NDJSON streaming (no indentation)
             yield return TelemetryExportService.ConvertSpanToJson(span, _outgoingPeerResolvers, logs: null, indent: false);
         }
@@ -343,7 +327,7 @@ internal sealed class TelemetryApiService(
         // Build the watch request with all filters pushed into the repository
         var watchRequest = new WatchLogsRequest
         {
-            ResourceKey = resourceKeys is [var singleKey] ? singleKey : null,
+            ResourceKeys = resourceKeys,
             Filters = filters,
             TextFragments = searchTextFragments
         };
@@ -351,14 +335,6 @@ internal sealed class TelemetryApiService(
         // Watch logs with filtering done inside the repository
         await foreach (var log in telemetryRepository.WatchLogsAsync(watchRequest, cancellationToken).ConfigureAwait(false))
         {
-            // Multi-resource filtering: repository only supports single ResourceKey,
-            // so for multi-resource queries we filter here.
-            if (resourceKeys is { Count: > 1 } &&
-                !resourceKeys.Any(k => k.EqualsCompositeName(log.ResourceView.ResourceKey.GetCompositeName())))
-            {
-                continue;
-            }
-
             var otlpData = TelemetryExportService.ConvertLogsToOtlpJson([log]);
             yield return JsonSerializer.Serialize(otlpData, OtlpJsonSerializerContext.DefaultOptions);
         }

--- a/src/Aspire.Dashboard/Api/TelemetryApiService.cs
+++ b/src/Aspire.Dashboard/Api/TelemetryApiService.cs
@@ -3,6 +3,7 @@
 
 using System.Runtime.CompilerServices;
 using System.Text.Json;
+using System.Threading.Channels;
 using Aspire.Dashboard.Model;
 using Aspire.Dashboard.Model.Assistant;
 using Aspire.Dashboard.Model.Otlp;
@@ -266,18 +267,9 @@ internal sealed class TelemetryApiService(
         string? search,
         [EnumeratorCancellation] CancellationToken cancellationToken = default)
     {
-        // Resolve resource keys
-        var resources = telemetryRepository.GetResources();
-        var resourceKeys = ResolveResourceKeys(resources, resourceNames);
-
-        // For streaming, if resources were specified but can't be resolved, filter everything out
-        var hasResourceFilter = resourceNames is { Length: > 0 };
-        var invalidResourceFilter = hasResourceFilter && resourceKeys is null;
-
-        if (invalidResourceFilter)
-        {
-            yield break;
-        }
+        // Resolve resource keys, waiting for the resource to appear if it doesn't exist yet.
+        // Throws OperationCanceledException if the client disconnects before the resource appears.
+        var resourceKeys = await WaitForResourceKeysAsync(resourceNames, cancellationToken).ConfigureAwait(false);
 
         // Convert structured search qualifiers into TelemetryFilter objects for per-span filtering
         List<TelemetryFilter> spanFilters = [];
@@ -320,18 +312,9 @@ internal sealed class TelemetryApiService(
         string? search,
         [EnumeratorCancellation] CancellationToken cancellationToken)
     {
-        // Resolve resource keys
-        var resources = telemetryRepository.GetResources();
-        var resourceKeys = ResolveResourceKeys(resources, resourceNames);
-
-        // For streaming, if resources were specified but can't be resolved, filter everything out
-        var hasResourceFilter = resourceNames is { Length: > 0 };
-        var invalidResourceFilter = hasResourceFilter && resourceKeys is null;
-
-        if (invalidResourceFilter)
-        {
-            yield break;
-        }
+        // Resolve resource keys, waiting for the resource to appear if it doesn't exist yet.
+        // Throws OperationCanceledException if the client disconnects before the resource appears.
+        var resourceKeys = await WaitForResourceKeysAsync(resourceNames, cancellationToken).ConfigureAwait(false);
 
         // Build filters
         var filters = new List<TelemetryFilter>();
@@ -561,6 +544,35 @@ internal sealed class TelemetryApiService(
         (ComparisonOperator.LessThanOrEqual, true) => FilterCondition.GreaterThan,
         _ => FilterCondition.Contains
     };
+
+    /// <summary>
+    /// Resolves resource names to ResourceKeys, waiting for the resources to appear if they
+    /// don't exist yet. This enables streaming subscriptions started before telemetry arrives
+    /// to pick up data once the resource is first seen.
+    /// Throws OperationCanceledException if cancellation is triggered before the resources appear.
+    /// </summary>
+    private async Task<List<ResourceKey?>> WaitForResourceKeysAsync(string[]? resourceNames, CancellationToken cancellationToken)
+    {
+        // Subscribe before the first check so no notification can be missed between
+        // GetResources() and the subscription registration.
+        var signal = Channel.CreateBounded<bool>(new BoundedChannelOptions(1) { FullMode = BoundedChannelFullMode.DropOldest });
+        using var subscription = telemetryRepository.OnNewResources(() =>
+        {
+            signal.Writer.TryWrite(true);
+            return Task.CompletedTask;
+        });
+
+        while (true)
+        {
+            var resources = telemetryRepository.GetResources();
+            if (ResolveResourceKeys(resources, resourceNames) is { } result)
+            {
+                return result;
+            }
+
+            await signal.Reader.ReadAsync(cancellationToken).ConfigureAwait(false);
+        }
+    }
 
     /// <summary>
     /// Resolves resource names to ResourceKeys.

--- a/src/Aspire.Dashboard/Api/TelemetryApiService.cs
+++ b/src/Aspire.Dashboard/Api/TelemetryApiService.cs
@@ -46,9 +46,9 @@ internal sealed class TelemetryApiService(
         var spanFilters = new List<TelemetryFilter>();
         var searchTextFragments = ParseAndApplySearchFilters(search, spanFilters, AddSpanFiltersFromQualifiers, key => ResolveSpanFieldKey(key) is not null);
 
-        // Get spans for all resource keys
+        // Get spans for all resource keys (empty list means no filter / all resources)
         var allSpans = new List<OtlpSpan>();
-        foreach (var resourceKey in resourceKeys)
+        foreach (var resourceKey in resourceKeys.Count > 0 ? resourceKeys.Select(k => (ResourceKey?)k) : [null])
         {
             var result = telemetryRepository.GetSpans(new GetSpansRequest
             {
@@ -103,9 +103,9 @@ internal sealed class TelemetryApiService(
         var traceFilters = new List<TelemetryFilter>();
         var searchTextFragments = ParseAndApplySearchFilters(search, traceFilters, AddSpanFiltersFromQualifiers, key => ResolveSpanFieldKey(key) is not null);
 
-        // Get traces for all resource keys
+        // Get traces for all resource keys (empty list means no filter / all resources)
         var allTraces = new List<OtlpTrace>();
-        foreach (var resourceKey in resourceKeys)
+        foreach (var resourceKey in resourceKeys.Count > 0 ? resourceKeys.Select(k => (ResourceKey?)k) : [null])
         {
             var result = telemetryRepository.GetTraces(new GetTracesRequest
             {
@@ -221,22 +221,17 @@ internal sealed class TelemetryApiService(
 
         var searchTextFragments = ParseAndApplySearchFilters(search, filters, AddLogFiltersFromQualifiers, key => ResolveLogFieldKey(key) is not null);
 
-        // Get logs for all resource keys
-        var allLogs = new List<OtlpLogEntry>();
-        foreach (var resourceKey in resourceKeys)
+        // Get logs for all resource keys (empty list means no filter / all resources)
+        var result = telemetryRepository.GetLogs(new GetLogsContext
         {
-            var result = telemetryRepository.GetLogs(new GetLogsContext
-            {
-                ResourceKey = resourceKey,
-                StartIndex = 0,
-                Count = int.MaxValue,
-                Filters = filters,
-                TextFragments = searchTextFragments
-            });
-            allLogs.AddRange(result.Items);
-        }
+            ResourceKeys = resourceKeys,
+            StartIndex = 0,
+            Count = int.MaxValue,
+            Filters = filters,
+            TextFragments = searchTextFragments
+        });
 
-        var logs = allLogs;
+        var logs = result.Items;
 
         var totalCount = logs.Count;
 
@@ -278,7 +273,7 @@ internal sealed class TelemetryApiService(
         // Build the watch request with all filters pushed into the repository
         var watchRequest = new WatchSpansRequest
         {
-            ResourceKey = resourceKeys is { Count: 1 } ? resourceKeys[0] : null,
+            ResourceKey = resourceKeys is [var singleKey] ? singleKey : null,
             Filters = spanFilters,
             TraceId = traceId,
             HasError = hasError,
@@ -291,7 +286,7 @@ internal sealed class TelemetryApiService(
             // Multi-resource filtering: repository only supports single ResourceKey,
             // so for multi-resource queries we filter here.
             if (resourceKeys is { Count: > 1 } &&
-                !resourceKeys.Any(k => k?.EqualsCompositeName(span.Source.ResourceKey.GetCompositeName()) == true))
+                !resourceKeys.Any(k => k.EqualsCompositeName(span.Source.ResourceKey.GetCompositeName())))
             {
                 continue;
             }
@@ -348,7 +343,7 @@ internal sealed class TelemetryApiService(
         // Build the watch request with all filters pushed into the repository
         var watchRequest = new WatchLogsRequest
         {
-            ResourceKey = resourceKeys is { Count: 1 } ? resourceKeys[0] : null,
+            ResourceKey = resourceKeys is [var singleKey] ? singleKey : null,
             Filters = filters,
             TextFragments = searchTextFragments
         };
@@ -359,7 +354,7 @@ internal sealed class TelemetryApiService(
             // Multi-resource filtering: repository only supports single ResourceKey,
             // so for multi-resource queries we filter here.
             if (resourceKeys is { Count: > 1 } &&
-                !resourceKeys.Any(k => k?.EqualsCompositeName(log.ResourceView.ResourceKey.GetCompositeName()) == true))
+                !resourceKeys.Any(k => k.EqualsCompositeName(log.ResourceView.ResourceKey.GetCompositeName())))
             {
                 continue;
             }
@@ -551,8 +546,14 @@ internal sealed class TelemetryApiService(
     /// to pick up data once the resource is first seen.
     /// Throws OperationCanceledException if cancellation is triggered before the resources appear.
     /// </summary>
-    private async Task<List<ResourceKey?>> WaitForResourceKeysAsync(string[]? resourceNames, CancellationToken cancellationToken)
+    private async Task<List<ResourceKey>> WaitForResourceKeysAsync(string[]? resourceNames, CancellationToken cancellationToken)
     {
+        if (resourceNames is null || resourceNames.Length == 0)
+        {
+            // No filter - return immediately without allocating a channel or subscription.
+            return [];
+        }
+
         // Subscribe before the first check so no notification can be missed between
         // GetResources() and the subscription registration.
         var signal = Channel.CreateBounded<bool>(new BoundedChannelOptions(1) { FullMode = BoundedChannelFullMode.DropOldest });
@@ -577,24 +578,26 @@ internal sealed class TelemetryApiService(
     /// <summary>
     /// Resolves resource names to ResourceKeys.
     /// Returns null if any specified resource is not found.
-    /// If no resources are specified, returns a list with a single null key (no filter).
+    /// Returns an empty list when no resource filter is specified (meaning all resources).
     /// </summary>
-    private static List<ResourceKey?>? ResolveResourceKeys(IReadOnlyList<OtlpResource> resources, string[]? resourceNames)
+    private static List<ResourceKey>? ResolveResourceKeys(IReadOnlyList<OtlpResource> resources, string[]? resourceNames)
     {
         if (resourceNames is null || resourceNames.Length == 0)
         {
-            // No filter - return a list with null to indicate "all resources"
-            return [null];
+            return [];
         }
 
-        var keys = new List<ResourceKey?>();
+        var keys = new List<ResourceKey>();
         foreach (var resourceName in resourceNames)
         {
             if (!AIHelpers.TryResolveResourceForTelemetry(resources, resourceName, out _, out var resourceKey))
             {
                 return null;
             }
-            keys.Add(resourceKey);
+            if (resourceKey is { } key)
+            {
+                keys.Add(key);
+            }
         }
         return keys;
     }

--- a/src/Aspire.Dashboard/Model/Assistant/AssistantChatDataContext.cs
+++ b/src/Aspire.Dashboard/Model/Assistant/AssistantChatDataContext.cs
@@ -170,7 +170,7 @@ public sealed class AssistantChatDataContext
 
         var traces = TelemetryRepository.GetTraces(new GetTracesRequest
         {
-            ResourceKey = resourceKey,
+            ResourceKeys = resourceKey is { } rk ? [rk] : [],
             StartIndex = 0,
             Count = int.MaxValue,
             Filters = []

--- a/src/Aspire.Dashboard/Model/Assistant/AssistantChatDataContext.cs
+++ b/src/Aspire.Dashboard/Model/Assistant/AssistantChatDataContext.cs
@@ -126,7 +126,7 @@ public sealed class AssistantChatDataContext
         // If support is added for ordering logs by timestamp then improve this.
         var logs = TelemetryRepository.GetLogs(new GetLogsContext
         {
-            ResourceKey = resourceKey,
+            ResourceKeys = resourceKey is { } rk ? [rk] : [],
             StartIndex = 0,
             Count = int.MaxValue,
             Filters = []
@@ -207,7 +207,7 @@ public sealed class AssistantChatDataContext
 
         var logs = TelemetryRepository.GetLogs(new GetLogsContext
         {
-            ResourceKey = null,
+            ResourceKeys = [],
             Count = int.MaxValue,
             StartIndex = 0,
             Filters = [traceIdFilter]

--- a/src/Aspire.Dashboard/Model/GenAI/GenAIVisualizerDialogViewModel.cs
+++ b/src/Aspire.Dashboard/Model/GenAI/GenAIVisualizerDialogViewModel.cs
@@ -596,7 +596,7 @@ public sealed class GenAIVisualizerDialogViewModel
     {
         var logsContext = new GetLogsContext
         {
-            ResourceKey = null,
+            ResourceKeys = [],
             Count = int.MaxValue,
             StartIndex = 0,
             Filters = [

--- a/src/Aspire.Dashboard/Model/StructuredLogsViewModel.cs
+++ b/src/Aspire.Dashboard/Model/StructuredLogsViewModel.cs
@@ -115,7 +115,7 @@ public class StructuredLogsViewModel
 
             logs = _telemetryRepository.GetLogs(new GetLogsContext
             {
-                ResourceKey = ResourceKey,
+                ResourceKeys = ResourceKey is { } key ? [key] : [],
                 StartIndex = StartIndex,
                 Count = Count,
                 Filters = filters
@@ -154,7 +154,7 @@ public class StructuredLogsViewModel
 
         var errorLogs = _telemetryRepository.GetLogs(new GetLogsContext
         {
-            ResourceKey = ResourceKey,
+            ResourceKeys = ResourceKey is { } key ? [key] : [],
             StartIndex = 0,
             Count = count,
             Filters = filters

--- a/src/Aspire.Dashboard/Model/TracesViewModel.cs
+++ b/src/Aspire.Dashboard/Model/TracesViewModel.cs
@@ -84,7 +84,7 @@ public class TracesViewModel
 
             var result = _telemetryRepository.GetTraces(new GetTracesRequest
             {
-                ResourceKey = ResourceKey,
+                ResourceKeys = ResourceKey is { } key ? [key] : [],
                 StartIndex = StartIndex,
                 Count = Count,
                 Filters = filters,
@@ -116,7 +116,7 @@ public class TracesViewModel
 
         var errorTraces = _telemetryRepository.GetTraces(new GetTracesRequest
         {
-            ResourceKey = ResourceKey,
+            ResourceKeys = ResourceKey is { } key ? [key] : [],
             StartIndex = 0,
             Count = count,
             Filters = filters,

--- a/src/Aspire.Dashboard/Otlp/Storage/GetLogsContext.cs
+++ b/src/Aspire.Dashboard/Otlp/Storage/GetLogsContext.cs
@@ -7,7 +7,7 @@ namespace Aspire.Dashboard.Otlp.Storage;
 
 public sealed class GetLogsContext
 {
-    public required ResourceKey? ResourceKey { get; init; }
+    public required IReadOnlyList<ResourceKey> ResourceKeys { get; init; }
     public required int StartIndex { get; init; }
     public required int Count { get; init; }
     public required List<TelemetryFilter> Filters { get; init; }
@@ -15,7 +15,7 @@ public sealed class GetLogsContext
 
     public static GetLogsContext ForResourceKey(ResourceKey resourceKey) => new()
     {
-        ResourceKey = resourceKey,
+        ResourceKeys = [resourceKey],
         StartIndex = 0,
         Count = int.MaxValue,
         Filters = []

--- a/src/Aspire.Dashboard/Otlp/Storage/GetSpansRequest.cs
+++ b/src/Aspire.Dashboard/Otlp/Storage/GetSpansRequest.cs
@@ -7,7 +7,7 @@ namespace Aspire.Dashboard.Otlp.Storage;
 
 public sealed class GetSpansRequest
 {
-    public required ResourceKey? ResourceKey { get; init; }
+    public required IReadOnlyList<ResourceKey> ResourceKeys { get; init; }
     public required int StartIndex { get; init; }
     public required int Count { get; init; }
     public required List<TelemetryFilter> Filters { get; init; }

--- a/src/Aspire.Dashboard/Otlp/Storage/GetTracesRequest.cs
+++ b/src/Aspire.Dashboard/Otlp/Storage/GetTracesRequest.cs
@@ -7,7 +7,7 @@ namespace Aspire.Dashboard.Otlp.Storage;
 
 public sealed class GetTracesRequest
 {
-    public required ResourceKey? ResourceKey { get; init; }
+    public required IReadOnlyList<ResourceKey> ResourceKeys { get; init; }
     public required int StartIndex { get; init; }
     public required int Count { get; init; }
     public required List<TelemetryFilter> Filters { get; init; }
@@ -16,7 +16,7 @@ public sealed class GetTracesRequest
 
     public static GetTracesRequest ForResourceKey(ResourceKey resourceKey) => new()
     {
-        ResourceKey = resourceKey,
+        ResourceKeys = [resourceKey],
         StartIndex = 0,
         Count = int.MaxValue,
         Filters = []

--- a/src/Aspire.Dashboard/Otlp/Storage/TelemetryRepository.Watchers.cs
+++ b/src/Aspire.Dashboard/Otlp/Storage/TelemetryRepository.Watchers.cs
@@ -57,7 +57,7 @@ public sealed partial class TelemetryRepository
             // (resource, traceId, hasError, telemetry filters, text fragments) at the query level.
             var existingSpans = GetSpans(new GetSpansRequest
             {
-                ResourceKey = request.ResourceKey,
+                ResourceKeys = request.ResourceKeys,
                 StartIndex = 0,
                 Count = MaxWatcherSnapshotCount,
                 Filters = request.Filters,
@@ -148,7 +148,7 @@ public sealed partial class TelemetryRepository
             // Get existing logs snapshot (capped to prevent OOM)
             var existingLogs = GetLogs(new GetLogsContext
             {
-                ResourceKeys = request.ResourceKey is { } key ? [key] : [],
+                ResourceKeys = request.ResourceKeys,
                 StartIndex = 0,
                 Count = MaxWatcherSnapshotCount,
                 Filters = request.Filters,
@@ -224,7 +224,7 @@ public sealed partial class TelemetryRepository
                 var request = watcher.Request;
 
                 // Check if watcher is filtering by resource
-                if (request.ResourceKey is { } key && !key.Equals(resourceKey))
+                if (request.ResourceKeys is { Count: > 0 } keys && !keys.Contains(resourceKey))
                 {
                     continue;
                 }
@@ -269,7 +269,7 @@ public sealed partial class TelemetryRepository
                 var request = watcher.Request;
 
                 // Check if watcher is filtering by resource
-                if (request.ResourceKey is { } key && !key.Equals(resourceKey))
+                if (request.ResourceKeys is { Count: > 0 } keys && !keys.Contains(resourceKey))
                 {
                     continue;
                 }

--- a/src/Aspire.Dashboard/Otlp/Storage/TelemetryRepository.Watchers.cs
+++ b/src/Aspire.Dashboard/Otlp/Storage/TelemetryRepository.Watchers.cs
@@ -148,7 +148,7 @@ public sealed partial class TelemetryRepository
             // Get existing logs snapshot (capped to prevent OOM)
             var existingLogs = GetLogs(new GetLogsContext
             {
-                ResourceKey = request.ResourceKey,
+                ResourceKeys = request.ResourceKey is { } key ? [key] : [],
                 StartIndex = 0,
                 Count = MaxWatcherSnapshotCount,
                 Filters = request.Filters,

--- a/src/Aspire.Dashboard/Otlp/Storage/TelemetryRepository.cs
+++ b/src/Aspire.Dashboard/Otlp/Storage/TelemetryRepository.cs
@@ -620,9 +620,13 @@ public sealed partial class TelemetryRepository : IDisposable
     public GetTracesResponse GetTraces(GetTracesRequest context)
     {
         List<OtlpResource>? resources = null;
-        if (context.ResourceKey is { } key)
+        if (context.ResourceKeys is { Count: > 0 } keys)
         {
-            resources = GetResources(key, includeUninstrumentedPeers: true);
+            resources = [];
+            foreach (var key in keys)
+            {
+                resources.AddRange(GetResources(key, includeUninstrumentedPeers: true));
+            }
 
             if (resources.Count == 0)
             {
@@ -712,9 +716,13 @@ public sealed partial class TelemetryRepository : IDisposable
     public GetSpansResponse GetSpans(GetSpansRequest context)
     {
         List<OtlpResource>? resources = null;
-        if (context.ResourceKey is { } key)
+        if (context.ResourceKeys is { Count: > 0 } keys)
         {
-            resources = GetResources(key, includeUninstrumentedPeers: true);
+            resources = [];
+            foreach (var key in keys)
+            {
+                resources.AddRange(GetResources(key, includeUninstrumentedPeers: true));
+            }
 
             if (resources.Count == 0)
             {

--- a/src/Aspire.Dashboard/Otlp/Storage/TelemetryRepository.cs
+++ b/src/Aspire.Dashboard/Otlp/Storage/TelemetryRepository.cs
@@ -442,9 +442,13 @@ public sealed partial class TelemetryRepository : IDisposable
     public PagedResult<OtlpLogEntry> GetLogs(GetLogsContext context)
     {
         List<OtlpResource>? resources = null;
-        if (context.ResourceKey is { } key)
+        if (context.ResourceKeys is { Count: > 0 } keys)
         {
-            resources = GetResources(key);
+            resources = [];
+            foreach (var key in keys)
+            {
+                resources.AddRange(GetResources(key));
+            }
 
             if (resources.Count == 0)
             {
@@ -512,7 +516,7 @@ public sealed partial class TelemetryRepository : IDisposable
     {
         var logsContext = new GetLogsContext
         {
-            ResourceKey = null,
+            ResourceKeys = [],
             Count = int.MaxValue,
             StartIndex = 0,
             Filters =
@@ -543,7 +547,7 @@ public sealed partial class TelemetryRepository : IDisposable
     {
         var logsContext = new GetLogsContext
         {
-            ResourceKey = null,
+            ResourceKeys = [],
             Count = int.MaxValue,
             StartIndex = 0,
             Filters =

--- a/src/Aspire.Dashboard/Otlp/Storage/WatchLogsRequest.cs
+++ b/src/Aspire.Dashboard/Otlp/Storage/WatchLogsRequest.cs
@@ -7,7 +7,7 @@ namespace Aspire.Dashboard.Otlp.Storage;
 
 public sealed class WatchLogsRequest
 {
-    public required ResourceKey? ResourceKey { get; init; }
+    public required IReadOnlyList<ResourceKey> ResourceKeys { get; init; }
     public required List<TelemetryFilter> Filters { get; init; }
     public string[]? TextFragments { get; init; }
 }

--- a/src/Aspire.Dashboard/Otlp/Storage/WatchSpansRequest.cs
+++ b/src/Aspire.Dashboard/Otlp/Storage/WatchSpansRequest.cs
@@ -7,7 +7,7 @@ namespace Aspire.Dashboard.Otlp.Storage;
 
 public sealed class WatchSpansRequest
 {
-    public required ResourceKey? ResourceKey { get; init; }
+    public required IReadOnlyList<ResourceKey> ResourceKeys { get; init; }
     public required List<TelemetryFilter> Filters { get; init; }
     public string? TraceId { get; init; }
     public bool? HasError { get; init; }

--- a/tests/Aspire.Dashboard.Components.Tests/Controls/GenAIVisualizerDialogTests.cs
+++ b/tests/Aspire.Dashboard.Components.Tests/Controls/GenAIVisualizerDialogTests.cs
@@ -148,7 +148,7 @@ public class GenAIVisualizerDialogTests : DashboardTestContext
         var resource = resources[0];
         var tracesResult = repository.GetTraces(new GetTracesRequest
         {
-            ResourceKey = resource.ResourceKey,
+            ResourceKeys = [resource.ResourceKey],
             StartIndex = 0,
             Count = 10,
             Filters = []
@@ -231,7 +231,7 @@ public class GenAIVisualizerDialogTests : DashboardTestContext
         var resource = resources[0];
         var tracesResult = repository.GetTraces(new GetTracesRequest
         {
-            ResourceKey = resource.ResourceKey,
+            ResourceKeys = [resource.ResourceKey],
             StartIndex = 0,
             Count = 10,
             Filters = []
@@ -244,7 +244,7 @@ public class GenAIVisualizerDialogTests : DashboardTestContext
         {
             var currentTrace = repository.GetTraces(new GetTracesRequest
             {
-                ResourceKey = resource.ResourceKey,
+                ResourceKeys = [resource.ResourceKey],
                 StartIndex = 0,
                 Count = 10,
                 Filters = []

--- a/tests/Aspire.Dashboard.Tests/Integration/OtlpHttpJsonTests.cs
+++ b/tests/Aspire.Dashboard.Tests/Integration/OtlpHttpJsonTests.cs
@@ -586,7 +586,7 @@ public class OtlpHttpJsonTests
 
         var logs = telemetryRepository.GetLogs(new GetLogsContext
         {
-            ResourceKey = resource.ResourceKey,
+            ResourceKeys = [resource.ResourceKey],
             StartIndex = 0,
             Count = 10,
             Filters = []
@@ -663,7 +663,7 @@ public class OtlpHttpJsonTests
 
         var logs = telemetryRepository.GetLogs(new GetLogsContext
         {
-            ResourceKey = resource.ResourceKey,
+            ResourceKeys = [resource.ResourceKey],
             StartIndex = 0,
             Count = 10,
             Filters = []

--- a/tests/Aspire.Dashboard.Tests/Integration/OtlpHttpJsonTests.cs
+++ b/tests/Aspire.Dashboard.Tests/Integration/OtlpHttpJsonTests.cs
@@ -526,7 +526,7 @@ public class OtlpHttpJsonTests
 
         var traces = telemetryRepository.GetTraces(new GetTracesRequest
         {
-            ResourceKey = resource.ResourceKey,
+            ResourceKeys = [resource.ResourceKey],
             StartIndex = 0,
             Count = 10,
             Filters = []

--- a/tests/Aspire.Dashboard.Tests/Model/TelemetryExportServiceTests.cs
+++ b/tests/Aspire.Dashboard.Tests/Model/TelemetryExportServiceTests.cs
@@ -286,7 +286,7 @@ public sealed class TelemetryExportServiceTests
         var resource = resources[0];
         var traces = repository.GetTraces(new GetTracesRequest
         {
-            ResourceKey = resource.ResourceKey,
+            ResourceKeys = [resource.ResourceKey],
             StartIndex = 0,
             Count = int.MaxValue,
             Filters = []

--- a/tests/Aspire.Dashboard.Tests/Model/TelemetryExportServiceTests.cs
+++ b/tests/Aspire.Dashboard.Tests/Model/TelemetryExportServiceTests.cs
@@ -53,7 +53,7 @@ public sealed class TelemetryExportServiceTests
         var resource = resources[0];
         var logs = repository.GetLogs(new GetLogsContext
         {
-            ResourceKey = resource.ResourceKey,
+            ResourceKeys = [resource.ResourceKey],
             StartIndex = 0,
             Count = int.MaxValue,
             Filters = []

--- a/tests/Aspire.Dashboard.Tests/TelemetryApiServiceTests.cs
+++ b/tests/Aspire.Dashboard.Tests/TelemetryApiServiceTests.cs
@@ -8,6 +8,7 @@ using Aspire.Dashboard.Otlp.Model;
 using Aspire.Dashboard.Otlp.Storage;
 using Aspire.Otlp.Serialization;
 using Google.Protobuf.Collections;
+using Microsoft.AspNetCore.InternalTesting;
 using OpenTelemetry.Proto.Logs.V1;
 using OpenTelemetry.Proto.Trace.V1;
 using Xunit;
@@ -26,10 +27,9 @@ public class TelemetryApiServiceTests
         AddSpans(repository, count: 5);
 
         var service = CreateService(repository);
-        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
 
         var receivedItems = new List<string>();
-        await foreach (var item in service.FollowSpansAsync(null, null, null, null, cancellationToken: cts.Token))
+        await foreach (var item in service.FollowSpansAsync(null, null, null, null).DefaultTimeout())
         {
             receivedItems.Add(item);
             if (receivedItems.Count >= 5)
@@ -48,10 +48,9 @@ public class TelemetryApiServiceTests
         AddLogs(repository, ["log1", "log2", "log3", "log4", "log5"]);
 
         var service = CreateService(repository);
-        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
 
         var receivedItems = new List<string>();
-        await foreach (var item in service.FollowLogsAsync(null, null, null, null, cts.Token))
+        await foreach (var item in service.FollowLogsAsync(null, null, null, null, default).DefaultTimeout())
         {
             receivedItems.Add(item);
             if (receivedItems.Count >= 5)
@@ -87,17 +86,16 @@ public class TelemetryApiServiceTests
         AddSpans(repository, count: 1);
 
         var service = CreateService(repository);
-        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(2));
 
         var receivedItems = new List<string>();
         try
         {
-            await foreach (var item in service.FollowSpansAsync(["nonexistent-service"], null, null, null, cancellationToken: cts.Token))
+            await foreach (var item in service.FollowSpansAsync(["nonexistent-service"], null, null, null).DefaultTimeout())
             {
                 receivedItems.Add(item);
             }
         }
-        catch (OperationCanceledException)
+        catch (TimeoutException)
         {
         }
 
@@ -111,17 +109,16 @@ public class TelemetryApiServiceTests
         AddLogs(repository, ["log1"]);
 
         var service = CreateService(repository);
-        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(2));
 
         var receivedItems = new List<string>();
         try
         {
-            await foreach (var item in service.FollowLogsAsync(["nonexistent-service"], null, null, null, cts.Token))
+            await foreach (var item in service.FollowLogsAsync(["nonexistent-service"], null, null, null, default).DefaultTimeout())
             {
                 receivedItems.Add(item);
             }
         }
-        catch (OperationCanceledException)
+        catch (TimeoutException)
         {
         }
 
@@ -169,10 +166,9 @@ public class TelemetryApiServiceTests
         ]);
 
         var service = CreateService(repository);
-        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
 
         var receivedItems = new List<string>();
-        await foreach (var streamedItem in service.FollowSpansAsync(null, "7472616", null, null, cancellationToken: cts.Token))
+        await foreach (var streamedItem in service.FollowSpansAsync(null, "7472616", null, null).DefaultTimeout())
         {
             receivedItems.Add(streamedItem);
             break;
@@ -650,10 +646,9 @@ public class TelemetryApiServiceTests
     {
         var repository = CreateRepository(subscriptionMinExecuteInterval: TimeSpan.Zero);
         var service = CreateService(repository);
-        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
 
         // Start enumerating - MoveNextAsync will block until data arrives.
-        var enumerator = service.FollowSpansAsync(["service1"], null, null, null, cancellationToken: cts.Token).GetAsyncEnumerator(cts.Token);
+        var enumerator = service.FollowSpansAsync(["service1"], null, null, null).GetAsyncEnumerator();
         var moveNextTask = enumerator.MoveNextAsync();
 
         // The task should not complete yet because the resource doesn't exist.
@@ -662,7 +657,7 @@ public class TelemetryApiServiceTests
         // Now add spans for the resource - this should unblock the stream.
         AddSpans(repository, count: 1);
 
-        Assert.True(await moveNextTask);
+        Assert.True(await moveNextTask.DefaultTimeout());
         Assert.NotNull(enumerator.Current);
 
         await enumerator.DisposeAsync();
@@ -673,10 +668,9 @@ public class TelemetryApiServiceTests
     {
         var repository = CreateRepository(subscriptionMinExecuteInterval: TimeSpan.Zero);
         var service = CreateService(repository);
-        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
 
         // Start enumerating - MoveNextAsync will block until data arrives.
-        var enumerator = service.FollowLogsAsync(["service1"], null, null, null, cts.Token).GetAsyncEnumerator(cts.Token);
+        var enumerator = service.FollowLogsAsync(["service1"], null, null, null, default).GetAsyncEnumerator();
         var moveNextTask = enumerator.MoveNextAsync();
 
         // The task should not complete yet because the resource doesn't exist.
@@ -685,7 +679,7 @@ public class TelemetryApiServiceTests
         // Now add logs for the resource - this should unblock the stream.
         AddLogs(repository, ["hello"]);
 
-        Assert.True(await moveNextTask);
+        Assert.True(await moveNextTask.DefaultTimeout());
         Assert.NotNull(enumerator.Current);
 
         await enumerator.DisposeAsync();

--- a/tests/Aspire.Dashboard.Tests/TelemetryApiServiceTests.cs
+++ b/tests/Aspire.Dashboard.Tests/TelemetryApiServiceTests.cs
@@ -645,6 +645,72 @@ public class TelemetryApiServiceTests
             .ToList() ?? [];
     }
 
+    [Fact]
+    public async Task FollowSpansAsync_WaitsForResourceToAppear_ThenStreams()
+    {
+        var repository = CreateRepository(subscriptionMinExecuteInterval: TimeSpan.Zero);
+        var service = CreateService(repository);
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+
+        var receivedItems = new List<string>();
+
+        // Start streaming for a resource that doesn't exist yet.
+        var streamTask = Task.Run(async () =>
+        {
+            await foreach (var item in service.FollowSpansAsync(["service1"], null, null, null, cancellationToken: cts.Token))
+            {
+                receivedItems.Add(item);
+                if (receivedItems.Count >= 1)
+                {
+                    break;
+                }
+            }
+        }, cts.Token);
+
+        // Give the streaming task time to start waiting for the resource.
+        await Task.Delay(100, cts.Token);
+
+        // Now add spans for the resource - this should unblock the stream.
+        AddSpans(repository, count: 1);
+
+        await streamTask;
+
+        Assert.Single(receivedItems);
+    }
+
+    [Fact]
+    public async Task FollowLogsAsync_WaitsForResourceToAppear_ThenStreams()
+    {
+        var repository = CreateRepository(subscriptionMinExecuteInterval: TimeSpan.Zero);
+        var service = CreateService(repository);
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+
+        var receivedItems = new List<string>();
+
+        // Start streaming for a resource that doesn't exist yet.
+        var streamTask = Task.Run(async () =>
+        {
+            await foreach (var item in service.FollowLogsAsync(["service1"], null, null, null, cts.Token))
+            {
+                receivedItems.Add(item);
+                if (receivedItems.Count >= 1)
+                {
+                    break;
+                }
+            }
+        }, cts.Token);
+
+        // Give the streaming task time to start waiting for the resource.
+        await Task.Delay(100, cts.Token);
+
+        // Now add logs for the resource - this should unblock the stream.
+        AddLogs(repository, ["hello"]);
+
+        await streamTask;
+
+        Assert.Single(receivedItems);
+    }
+
     // SpanId is serialized as lowercase hex per the OTLP/JSON spec
     // (see https://opentelemetry.io/docs/specs/otlp/#json-protobuf-encoding), and our
     // CreateSpan test helper stores the friendly identifier as the raw UTF-8 bytes of

--- a/tests/Aspire.Dashboard.Tests/TelemetryApiServiceTests.cs
+++ b/tests/Aspire.Dashboard.Tests/TelemetryApiServiceTests.cs
@@ -652,30 +652,20 @@ public class TelemetryApiServiceTests
         var service = CreateService(repository);
         using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
 
-        var receivedItems = new List<string>();
+        // Start enumerating - MoveNextAsync will block until data arrives.
+        var enumerator = service.FollowSpansAsync(["service1"], null, null, null, cancellationToken: cts.Token).GetAsyncEnumerator(cts.Token);
+        var moveNextTask = enumerator.MoveNextAsync();
 
-        // Start streaming for a resource that doesn't exist yet.
-        var streamTask = Task.Run(async () =>
-        {
-            await foreach (var item in service.FollowSpansAsync(["service1"], null, null, null, cancellationToken: cts.Token))
-            {
-                receivedItems.Add(item);
-                if (receivedItems.Count >= 1)
-                {
-                    break;
-                }
-            }
-        }, cts.Token);
-
-        // Give the streaming task time to start waiting for the resource.
-        await Task.Delay(100, cts.Token);
+        // The task should not complete yet because the resource doesn't exist.
+        Assert.False(moveNextTask.IsCompleted);
 
         // Now add spans for the resource - this should unblock the stream.
         AddSpans(repository, count: 1);
 
-        await streamTask;
+        Assert.True(await moveNextTask);
+        Assert.NotNull(enumerator.Current);
 
-        Assert.Single(receivedItems);
+        await enumerator.DisposeAsync();
     }
 
     [Fact]
@@ -685,30 +675,20 @@ public class TelemetryApiServiceTests
         var service = CreateService(repository);
         using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
 
-        var receivedItems = new List<string>();
+        // Start enumerating - MoveNextAsync will block until data arrives.
+        var enumerator = service.FollowLogsAsync(["service1"], null, null, null, cts.Token).GetAsyncEnumerator(cts.Token);
+        var moveNextTask = enumerator.MoveNextAsync();
 
-        // Start streaming for a resource that doesn't exist yet.
-        var streamTask = Task.Run(async () =>
-        {
-            await foreach (var item in service.FollowLogsAsync(["service1"], null, null, null, cts.Token))
-            {
-                receivedItems.Add(item);
-                if (receivedItems.Count >= 1)
-                {
-                    break;
-                }
-            }
-        }, cts.Token);
-
-        // Give the streaming task time to start waiting for the resource.
-        await Task.Delay(100, cts.Token);
+        // The task should not complete yet because the resource doesn't exist.
+        Assert.False(moveNextTask.IsCompleted);
 
         // Now add logs for the resource - this should unblock the stream.
         AddLogs(repository, ["hello"]);
 
-        await streamTask;
+        Assert.True(await moveNextTask);
+        Assert.NotNull(enumerator.Current);
 
-        Assert.Single(receivedItems);
+        await enumerator.DisposeAsync();
     }
 
     // SpanId is serialized as lowercase hex per the OTLP/JSON spec

--- a/tests/Aspire.Dashboard.Tests/TelemetryRepositoryTests/LogTests.cs
+++ b/tests/Aspire.Dashboard.Tests/TelemetryRepositoryTests/LogTests.cs
@@ -64,7 +64,7 @@ public class LogTests
 
         var logs = repository.GetLogs(new GetLogsContext
         {
-            ResourceKey = resources[0].ResourceKey,
+            ResourceKeys = [resources[0].ResourceKey],
             StartIndex = 0,
             Count = 10,
             Filters = []
@@ -119,7 +119,7 @@ public class LogTests
 
         var logs = repository.GetLogs(new GetLogsContext
         {
-            ResourceKey = null,
+            ResourceKeys = [],
             StartIndex = 0,
             Count = 10,
             Filters = []
@@ -171,7 +171,7 @@ public class LogTests
 
         var logs = repository.GetLogs(new GetLogsContext
         {
-            ResourceKey = null,
+            ResourceKeys = [],
             StartIndex = 0,
             Count = 10,
             Filters = []
@@ -419,7 +419,7 @@ public class LogTests
         // Act
         var logs = repository.GetLogs(new GetLogsContext
         {
-            ResourceKey = new ResourceKey("TestService", "UnknownResource"),
+            ResourceKeys = [new ResourceKey("TestService", "UnknownResource")],
             StartIndex = 0,
             Count = 10,
             Filters = []
@@ -517,7 +517,7 @@ public class LogTests
 
         var logs = repository.GetLogs(new GetLogsContext
         {
-            ResourceKey = resources[0].ResourceKey,
+            ResourceKeys = [resources[0].ResourceKey],
             StartIndex = 0,
             Count = 1,
             Filters = []
@@ -659,7 +659,7 @@ public class LogTests
 
         var logs = repository.GetLogs(new GetLogsContext
         {
-            ResourceKey = resources[0].ResourceKey,
+            ResourceKeys = [resources[0].ResourceKey],
             StartIndex = 0,
             Count = 10,
             Filters = []
@@ -807,7 +807,7 @@ public class LogTests
         // Assert
         Assert.Empty(repository.GetLogs(new GetLogsContext
         {
-            ResourceKey = resourceKey,
+            ResourceKeys = [resourceKey],
             StartIndex = 0,
             Count = 1,
             Filters = [new FieldTelemetryFilter { Condition = FilterCondition.Contains, Field = nameof(OtlpLogEntry.Message), Value = "does_not_contain" }]
@@ -815,7 +815,7 @@ public class LogTests
 
         Assert.Single(repository.GetLogs(new GetLogsContext
         {
-            ResourceKey = resourceKey,
+            ResourceKeys = [resourceKey],
             StartIndex = 0,
             Count = 1,
             Filters = [new FieldTelemetryFilter { Condition = FilterCondition.Contains, Field = nameof(OtlpLogEntry.Message), Value = "message" }]
@@ -854,7 +854,7 @@ public class LogTests
         // Assert
         Assert.Empty(repository.GetLogs(new GetLogsContext
         {
-            ResourceKey = resourceKey,
+            ResourceKeys = [resourceKey],
             StartIndex = 0,
             Count = 1,
             Filters = [new FieldTelemetryFilter { Condition = FilterCondition.Contains, Field = KnownStructuredLogFields.EventNameField, Value = "does_not_contain" }]
@@ -862,7 +862,7 @@ public class LogTests
 
         Assert.Single(repository.GetLogs(new GetLogsContext
         {
-            ResourceKey = resourceKey,
+            ResourceKeys = [resourceKey],
             StartIndex = 0,
             Count = 1,
             Filters = [new FieldTelemetryFilter { Condition = FilterCondition.Contains, Field = KnownStructuredLogFields.EventNameField, Value = "MyEvent" }]
@@ -923,7 +923,7 @@ public class LogTests
 
         var logs1 = repository.GetLogs(new GetLogsContext
         {
-            ResourceKey = resources[0].ResourceKey,
+            ResourceKeys = [resources[0].ResourceKey],
             StartIndex = 0,
             Count = 10,
             Filters = []
@@ -946,7 +946,7 @@ public class LogTests
 
         var logs2 = repository.GetLogs(new GetLogsContext
         {
-            ResourceKey = resources[1].ResourceKey,
+            ResourceKeys = [resources[1].ResourceKey],
             StartIndex = 0,
             Count = 10,
             Filters = []
@@ -1022,7 +1022,7 @@ public class LogTests
         var resourceKey = new ResourceKey("resource1", InstanceId: null);
         var logs = repository.GetLogs(new GetLogsContext
         {
-            ResourceKey = resourceKey,
+            ResourceKeys = [resourceKey],
             StartIndex = 0,
             Count = 10,
             Filters = []
@@ -1112,7 +1112,7 @@ public class LogTests
 
         var logs = repository.GetLogs(new GetLogsContext
         {
-            ResourceKey = null,
+            ResourceKeys = [],
             StartIndex = 0,
             Count = 10,
             Filters = []
@@ -1177,7 +1177,7 @@ public class LogTests
 
         var logs = repository.GetLogs(new GetLogsContext
         {
-            ResourceKey = null,
+            ResourceKeys = [],
             StartIndex = 0,
             Count = 10,
             Filters = []
@@ -1251,7 +1251,7 @@ public class LogTests
 
         var logs = repository.GetLogs(new GetLogsContext
         {
-            ResourceKey = null,
+            ResourceKeys = [],
             StartIndex = 0,
             Count = 10,
             Filters = []
@@ -1291,7 +1291,7 @@ public class LogTests
 
         var logs = repository.GetLogs(new GetLogsContext
         {
-            ResourceKey = null,
+            ResourceKeys = [],
             StartIndex = 0,
             Count = 10,
             Filters = []
@@ -1332,7 +1332,7 @@ public class LogTests
 
         var logs = repository.GetLogs(new GetLogsContext
         {
-            ResourceKey = null,
+            ResourceKeys = [],
             StartIndex = 0,
             Count = 10,
             Filters = []
@@ -1373,7 +1373,7 @@ public class LogTests
 
         var logs = repository.GetLogs(new GetLogsContext
         {
-            ResourceKey = null,
+            ResourceKeys = [],
             StartIndex = 0,
             Count = 10,
             Filters = []
@@ -1416,7 +1416,7 @@ public class LogTests
 
         var logs = repository.GetLogs(new GetLogsContext
         {
-            ResourceKey = null,
+            ResourceKeys = [],
             StartIndex = 0,
             Count = 10,
             Filters = []
@@ -1458,7 +1458,7 @@ public class LogTests
 
         var logs = repository.GetLogs(new GetLogsContext
         {
-            ResourceKey = null,
+            ResourceKeys = [],
             StartIndex = 0,
             Count = 10,
             Filters = []
@@ -1516,7 +1516,7 @@ public class LogTests
 
         var logs = repository.GetLogs(new GetLogsContext
         {
-            ResourceKey = null,
+            ResourceKeys = [],
             StartIndex = 0,
             Count = 10,
             Filters = filters

--- a/tests/Aspire.Dashboard.Tests/TelemetryRepositoryTests/TelemetryRepositoryTests.cs
+++ b/tests/Aspire.Dashboard.Tests/TelemetryRepositoryTests/TelemetryRepositoryTests.cs
@@ -38,7 +38,7 @@ public class TelemetryRepositoryTests
         AddTrace();
 
         var resourceKey = new ResourceKey("resource", "resource");
-        Assert.Empty(repository.GetLogs(new GetLogsContext { ResourceKey = resourceKey, Count = 100, Filters = [], StartIndex = 0 }).Items);
+        Assert.Empty(repository.GetLogs(new GetLogsContext { ResourceKeys = [resourceKey], Count = 100, Filters = [], StartIndex = 0 }).Items);
         Assert.Null(repository.GetResource(resourceKey));
         Assert.Empty(repository.GetTraces(new GetTracesRequest { ResourceKey = resourceKey, Count = 100, Filters = [], StartIndex = 0 }).PagedResult.Items);
 
@@ -49,7 +49,7 @@ public class TelemetryRepositoryTests
         AddLog();
         AddMetric();
         AddTrace();
-        Assert.Single(repository.GetLogs(new GetLogsContext { ResourceKey = resourceKey, Count = 100, Filters = [], StartIndex = 0 }).Items);
+        Assert.Single(repository.GetLogs(new GetLogsContext { ResourceKeys = [resourceKey], Count = 100, Filters = [], StartIndex = 0 }).Items);
         var resource = repository.GetResource(resourceKey);
         Assert.NotNull(resource);
         Assert.NotEmpty(resource.GetInstrumentsSummary());
@@ -230,7 +230,7 @@ public class TelemetryRepositoryTests
         Assert.Equal(1, errorCount2);
 
         // Assert - resource1 logs cleared, but traces and metrics remain
-        var logs = repository.GetLogs(new GetLogsContext { ResourceKey = null, StartIndex = 0, Count = 10, Filters = [] });
+        var logs = repository.GetLogs(new GetLogsContext { ResourceKeys = [], StartIndex = 0, Count = 10, Filters = [] });
         Assert.Single(logs.Items);
         Assert.Equal("log-resource2-456", logs.Items[0].Message);
 
@@ -242,7 +242,7 @@ public class TelemetryRepositoryTests
 
         // Assert - resource2 data is unaffected
         var resource2Key = new ResourceKey("resource2", "456");
-        var resource2Logs = repository.GetLogs(new GetLogsContext { ResourceKey = resource2Key, StartIndex = 0, Count = 10, Filters = [] });
+        var resource2Logs = repository.GetLogs(new GetLogsContext { ResourceKeys = [resource2Key], StartIndex = 0, Count = 10, Filters = [] });
         Assert.Single(resource2Logs.Items);
         Assert.Equal("log-resource2-456", resource2Logs.Items[0].Message);
 
@@ -271,7 +271,7 @@ public class TelemetryRepositoryTests
         repository.ClearSelectedSignals(selectedResources);
 
         // Assert - resource1 and resource3 data is unaffected
-        var logs = repository.GetLogs(new GetLogsContext { ResourceKey = null, StartIndex = 0, Count = 10, Filters = [] });
+        var logs = repository.GetLogs(new GetLogsContext { ResourceKeys = [], StartIndex = 0, Count = 10, Filters = [] });
         Assert.Equal(2, logs.TotalItemCount);
         Assert.Contains(logs.Items, l => l.Message == "log-resource1-111");
         Assert.Contains(logs.Items, l => l.Message == "log-resource3-333");
@@ -315,7 +315,7 @@ public class TelemetryRepositoryTests
         Assert.Null(resourceAfter);
 
         // Assert - All telemetry data is cleared
-        var logs = repository.GetLogs(new GetLogsContext { ResourceKey = null, StartIndex = 0, Count = 10, Filters = [] });
+        var logs = repository.GetLogs(new GetLogsContext { ResourceKeys = [], StartIndex = 0, Count = 10, Filters = [] });
         Assert.Empty(logs.Items);
 
         var traces = repository.GetTraces(new GetTracesRequest { ResourceKey = null, StartIndex = 0, Count = 10, Filters = [] });
@@ -346,7 +346,7 @@ public class TelemetryRepositoryTests
         Assert.NotNull(resourceAfter);
 
         // Assert - Logs and traces are cleared, but metrics remain
-        var logs = repository.GetLogs(new GetLogsContext { ResourceKey = null, StartIndex = 0, Count = 10, Filters = [] });
+        var logs = repository.GetLogs(new GetLogsContext { ResourceKeys = [], StartIndex = 0, Count = 10, Filters = [] });
         Assert.Empty(logs.Items);
 
         var traces = repository.GetTraces(new GetTracesRequest { ResourceKey = null, StartIndex = 0, Count = 10, Filters = [] });

--- a/tests/Aspire.Dashboard.Tests/TelemetryRepositoryTests/TelemetryRepositoryTests.cs
+++ b/tests/Aspire.Dashboard.Tests/TelemetryRepositoryTests/TelemetryRepositoryTests.cs
@@ -40,7 +40,7 @@ public class TelemetryRepositoryTests
         var resourceKey = new ResourceKey("resource", "resource");
         Assert.Empty(repository.GetLogs(new GetLogsContext { ResourceKeys = [resourceKey], Count = 100, Filters = [], StartIndex = 0 }).Items);
         Assert.Null(repository.GetResource(resourceKey));
-        Assert.Empty(repository.GetTraces(new GetTracesRequest { ResourceKey = resourceKey, Count = 100, Filters = [], StartIndex = 0 }).PagedResult.Items);
+        Assert.Empty(repository.GetTraces(new GetTracesRequest { ResourceKeys = [resourceKey], Count = 100, Filters = [], StartIndex = 0 }).PagedResult.Items);
 
         pauseManager.SetStructuredLogsPaused(false);
         pauseManager.SetMetricsPaused(false);
@@ -53,7 +53,7 @@ public class TelemetryRepositoryTests
         var resource = repository.GetResource(resourceKey);
         Assert.NotNull(resource);
         Assert.NotEmpty(resource.GetInstrumentsSummary());
-        Assert.Single(repository.GetTraces(new GetTracesRequest { ResourceKey = resourceKey, Count = 100, Filters = [], StartIndex = 0 }).PagedResult.Items);
+        Assert.Single(repository.GetTraces(new GetTracesRequest { ResourceKeys = [resourceKey], Count = 100, Filters = [], StartIndex = 0 }).PagedResult.Items);
 
         void AddLog()
         {
@@ -234,7 +234,7 @@ public class TelemetryRepositoryTests
         Assert.Single(logs.Items);
         Assert.Equal("log-resource2-456", logs.Items[0].Message);
 
-        var traces = repository.GetTraces(new GetTracesRequest { ResourceKey = null, StartIndex = 0, Count = 10, Filters = [] });
+        var traces = repository.GetTraces(new GetTracesRequest { ResourceKeys = [], StartIndex = 0, Count = 10, Filters = [] });
         Assert.Equal(2, traces.PagedResult.TotalItemCount);
 
         var resource1Metrics = repository.GetInstrumentsSummaries(new ResourceKey("resource1", "123"));
@@ -246,7 +246,7 @@ public class TelemetryRepositoryTests
         Assert.Single(resource2Logs.Items);
         Assert.Equal("log-resource2-456", resource2Logs.Items[0].Message);
 
-        var resource2Traces = repository.GetTraces(new GetTracesRequest { ResourceKey = resource2Key, StartIndex = 0, Count = 10, Filters = [] });
+        var resource2Traces = repository.GetTraces(new GetTracesRequest { ResourceKeys = [resource2Key], StartIndex = 0, Count = 10, Filters = [] });
         Assert.Single(resource2Traces.PagedResult.Items);
 
         var resource2Metrics = repository.GetInstrumentsSummaries(new ResourceKey("resource2", "456"));
@@ -277,7 +277,7 @@ public class TelemetryRepositoryTests
         Assert.Contains(logs.Items, l => l.Message == "log-resource3-333");
         Assert.DoesNotContain(logs.Items, l => l.Message == "log-resource2-222");
 
-        var traces = repository.GetTraces(new GetTracesRequest { ResourceKey = null, StartIndex = 0, Count = 10, Filters = [] });
+        var traces = repository.GetTraces(new GetTracesRequest { ResourceKeys = [], StartIndex = 0, Count = 10, Filters = [] });
         Assert.Equal(2, traces.PagedResult.TotalItemCount);
 
         var resource1Metrics = repository.GetInstrumentsSummaries(new ResourceKey("resource1", "111"));
@@ -318,7 +318,7 @@ public class TelemetryRepositoryTests
         var logs = repository.GetLogs(new GetLogsContext { ResourceKeys = [], StartIndex = 0, Count = 10, Filters = [] });
         Assert.Empty(logs.Items);
 
-        var traces = repository.GetTraces(new GetTracesRequest { ResourceKey = null, StartIndex = 0, Count = 10, Filters = [] });
+        var traces = repository.GetTraces(new GetTracesRequest { ResourceKeys = [], StartIndex = 0, Count = 10, Filters = [] });
         Assert.Empty(traces.PagedResult.Items);
 
         // Assert - Resources list is empty
@@ -349,7 +349,7 @@ public class TelemetryRepositoryTests
         var logs = repository.GetLogs(new GetLogsContext { ResourceKeys = [], StartIndex = 0, Count = 10, Filters = [] });
         Assert.Empty(logs.Items);
 
-        var traces = repository.GetTraces(new GetTracesRequest { ResourceKey = null, StartIndex = 0, Count = 10, Filters = [] });
+        var traces = repository.GetTraces(new GetTracesRequest { ResourceKeys = [], StartIndex = 0, Count = 10, Filters = [] });
         Assert.Empty(traces.PagedResult.Items);
 
         var metrics = repository.GetInstrumentsSummaries(new ResourceKey("resource1", "123"));
@@ -391,7 +391,7 @@ public class TelemetryRepositoryTests
         // Act
         var watchTask = Task.Run(async () =>
         {
-            await foreach (var span in repository.WatchSpansAsync(new WatchSpansRequest { ResourceKey = null, Filters = [] }, cts.Token))
+            await foreach (var span in repository.WatchSpansAsync(new WatchSpansRequest { ResourceKeys = [], Filters = [] }, cts.Token))
             {
                 receivedSpans.Add(span);
                 if (receivedSpans.Count == 1)
@@ -453,7 +453,7 @@ public class TelemetryRepositoryTests
             watchStarted.TrySetResult();
             try
             {
-                await foreach (var span in repository.WatchSpansAsync(new WatchSpansRequest { ResourceKey = null, Filters = [] }, cts.Token))
+                await foreach (var span in repository.WatchSpansAsync(new WatchSpansRequest { ResourceKeys = [], Filters = [] }, cts.Token))
                 {
                     count++;
                 }
@@ -509,7 +509,7 @@ public class TelemetryRepositoryTests
         // Act
         var watchTask = Task.Run(async () =>
         {
-            await foreach (var log in repository.WatchLogsAsync(new WatchLogsRequest { ResourceKey = null, Filters = [] }, cts.Token))
+            await foreach (var log in repository.WatchLogsAsync(new WatchLogsRequest { ResourceKeys = [], Filters = [] }, cts.Token))
             {
                 receivedLogs.Add(log);
                 if (receivedLogs.Count == 1)
@@ -570,7 +570,7 @@ public class TelemetryRepositoryTests
             watchStarted.TrySetResult();
             try
             {
-                await foreach (var log in repository.WatchLogsAsync(new WatchLogsRequest { ResourceKey = null, Filters = [] }, cts.Token))
+                await foreach (var log in repository.WatchLogsAsync(new WatchLogsRequest { ResourceKeys = [], Filters = [] }, cts.Token))
                 {
                     count++;
                 }
@@ -662,7 +662,7 @@ public class TelemetryRepositoryTests
         // Act
         try
         {
-            await foreach (var span in repository.WatchSpansAsync(new WatchSpansRequest { ResourceKey = null, Filters = [] }, linkedCts.Token))
+            await foreach (var span in repository.WatchSpansAsync(new WatchSpansRequest { ResourceKeys = [], Filters = [] }, linkedCts.Token))
             {
                 receivedSpans.Add(span);
                 if (receivedSpans.Count == expectedSpans)
@@ -740,7 +740,7 @@ public class TelemetryRepositoryTests
         // Act
         try
         {
-            await foreach (var span in repository.WatchSpansAsync(new WatchSpansRequest { ResourceKey = null, Filters = [] }, linkedCts.Token))
+            await foreach (var span in repository.WatchSpansAsync(new WatchSpansRequest { ResourceKeys = [], Filters = [] }, linkedCts.Token))
             {
                 receivedSpans.Add(span);
                 if (receivedSpans.Count == expectedSpans)
@@ -809,7 +809,7 @@ public class TelemetryRepositoryTests
         // Act - Watch only service1
         try
         {
-            await foreach (var span in repository.WatchSpansAsync(new WatchSpansRequest { ResourceKey = new ResourceKey("service1", "inst1"), Filters = [] }, cts.Token))
+            await foreach (var span in repository.WatchSpansAsync(new WatchSpansRequest { ResourceKeys = [new ResourceKey("service1", "inst1")], Filters = [] }, cts.Token))
             {
                 receivedSpans.Add(span);
             }
@@ -868,7 +868,7 @@ public class TelemetryRepositoryTests
         // Start watching with filter
         var watchTask = Task.Run(async () =>
         {
-            await foreach (var log in repository.WatchLogsAsync(new WatchLogsRequest { ResourceKey = null, Filters = filters }, cts.Token))
+            await foreach (var log in repository.WatchLogsAsync(new WatchLogsRequest { ResourceKeys = [], Filters = filters }, cts.Token))
             {
                 receivedLogs.Add(log);
                 if (receivedLogs.Count == 1)
@@ -959,7 +959,7 @@ public class TelemetryRepositoryTests
         // Start watching with severity filter
         var watchTask = Task.Run(async () =>
         {
-            await foreach (var log in repository.WatchLogsAsync(new WatchLogsRequest { ResourceKey = null, Filters = filters }, cts.Token))
+            await foreach (var log in repository.WatchLogsAsync(new WatchLogsRequest { ResourceKeys = [], Filters = filters }, cts.Token))
             {
                 receivedLogs.Add(log);
                 if (receivedLogs.Count == 1)
@@ -1044,7 +1044,7 @@ public class TelemetryRepositoryTests
         {
             await foreach (var log in repository.WatchLogsAsync(new WatchLogsRequest
             {
-                ResourceKey = null,
+                ResourceKeys = [],
                 Filters = [],
                 TextFragments = ["timeout", "error"]
             }, cts.Token))
@@ -1144,7 +1144,7 @@ public class TelemetryRepositoryTests
 
         var watchTask = Task.Run(async () =>
         {
-            await foreach (var log in repository.WatchLogsAsync(new WatchLogsRequest { ResourceKey = null, Filters = filters }, cts.Token))
+            await foreach (var log in repository.WatchLogsAsync(new WatchLogsRequest { ResourceKeys = [], Filters = filters }, cts.Token))
             {
                 receivedLogs.Add(log);
                 if (receivedLogs.Count == 1)
@@ -1241,7 +1241,7 @@ public class TelemetryRepositoryTests
 
         var watchTask = Task.Run(async () =>
         {
-            await foreach (var span in repository.WatchSpansAsync(new WatchSpansRequest { ResourceKey = null, Filters = filters }, cts.Token))
+            await foreach (var span in repository.WatchSpansAsync(new WatchSpansRequest { ResourceKeys = [], Filters = filters }, cts.Token))
             {
                 receivedSpans.Add(span);
                 if (receivedSpans.Count == 1)

--- a/tests/Aspire.Dashboard.Tests/TelemetryRepositoryTests/TelemetryRepositoryTests.cs
+++ b/tests/Aspire.Dashboard.Tests/TelemetryRepositoryTests/TelemetryRepositoryTests.cs
@@ -825,6 +825,113 @@ public class TelemetryRepositoryTests
     }
 
     [Fact]
+    public void GetTraces_MultipleResourceKeys_ReturnsMatchingTracesOnly()
+    {
+        var repository = CreateRepository();
+
+        AddTestData(repository, "resource1", "inst1");
+        AddTestData(repository, "resource2", "inst2");
+        AddTestData(repository, "resource3", "inst3");
+
+        var key1 = new ResourceKey("resource1", "inst1");
+        var key2 = new ResourceKey("resource2", "inst2");
+
+        // Act - query with two resource keys
+        var traces = repository.GetTraces(new GetTracesRequest { ResourceKeys = [key1, key2], StartIndex = 0, Count = 10, Filters = [] });
+
+        // Assert - should return traces from both resource1 and resource2, but not resource3
+        Assert.Collection(traces.PagedResult.Items,
+            t => AssertId("resource2-inst2", t.TraceId),
+            t => AssertId("resource1-inst1", t.TraceId));
+    }
+
+    [Fact]
+    public void GetSpans_MultipleResourceKeys_ReturnsMatchingSpansOnly()
+    {
+        var repository = CreateRepository();
+
+        AddTestData(repository, "service1", "inst1");
+        AddTestData(repository, "service2", "inst2");
+        AddTestData(repository, "service3", "inst3");
+
+        // Act - query spans for service1 and service2 only
+        var result = repository.GetSpans(new GetSpansRequest
+        {
+            ResourceKeys = [new ResourceKey("service1", "inst1"), new ResourceKey("service2", "inst2")],
+            StartIndex = 0,
+            Count = 10,
+            Filters = []
+        });
+
+        // Assert - should return spans from service1 and service2, not service3
+        Assert.Collection(result.PagedResult.Items,
+            s => Assert.Equal("Test span. Id: service2-inst2-1", s.Name),
+            s => Assert.Equal("Test span. Id: service1-inst1-1", s.Name));
+    }
+
+    [Fact]
+    public async Task WatchSpansAsync_MultipleResourceKeys_FiltersCorrectly()
+    {
+        var repository = CreateRepository();
+
+        AddTestData(repository, "service1", "inst1");
+        AddTestData(repository, "service2", "inst2");
+        AddTestData(repository, "service3", "inst3");
+
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(2));
+        var receivedSpans = new List<OtlpSpan>();
+
+        // Act - Watch service1 and service2 (not service3)
+        try
+        {
+            await foreach (var span in repository.WatchSpansAsync(new WatchSpansRequest { ResourceKeys = [new ResourceKey("service1", "inst1"), new ResourceKey("service2", "inst2")], Filters = [] }, cts.Token))
+            {
+                receivedSpans.Add(span);
+            }
+        }
+        catch (OperationCanceledException)
+        {
+            // Expected
+        }
+
+        // Assert - should receive spans from service1 and service2, not service3
+        Assert.Collection(receivedSpans,
+            s => Assert.Equal("Test span. Id: service2-inst2-1", s.Name),
+            s => Assert.Equal("Test span. Id: service1-inst1-1", s.Name));
+    }
+
+    [Fact]
+    public async Task WatchLogsAsync_MultipleResourceKeys_FiltersCorrectly()
+    {
+        var repository = CreateRepository();
+
+        AddTestData(repository, "service1", "inst1");
+        AddTestData(repository, "service2", "inst2");
+        AddTestData(repository, "service3", "inst3");
+
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(2));
+        var receivedLogs = new List<OtlpLogEntry>();
+
+        // Act - Watch service1 and service2 (not service3)
+        try
+        {
+            await foreach (var log in repository.WatchLogsAsync(new WatchLogsRequest { ResourceKeys = [new ResourceKey("service1", "inst1"), new ResourceKey("service2", "inst2")], Filters = [] }, cts.Token))
+            {
+                receivedLogs.Add(log);
+            }
+        }
+        catch (OperationCanceledException)
+        {
+            // Expected
+        }
+
+        // Assert - should receive logs from service1 and service2, not service3
+        Assert.Collection(receivedLogs,
+            l => Assert.Equal("log-service2-inst2", l.Message),
+            l => Assert.Equal("log-service1-inst1", l.Message));
+    }
+
+    [Fact]
     public async Task WatchLogsAsync_FiltersAppliedWhenPushing()
     {
         // Arrange

--- a/tests/Aspire.Dashboard.Tests/TelemetryRepositoryTests/TraceTests.cs
+++ b/tests/Aspire.Dashboard.Tests/TelemetryRepositoryTests/TraceTests.cs
@@ -78,7 +78,7 @@ public class TraceTests
 
         var traces = repository.GetTraces(new GetTracesRequest
         {
-            ResourceKey = resources[0].ResourceKey,
+            ResourceKeys = [resources[0].ResourceKey],
             StartIndex = 0,
             Count = 10,
             Filters = []
@@ -136,7 +136,7 @@ public class TraceTests
 
         var traces = repository.GetTraces(new GetTracesRequest
         {
-            ResourceKey = resources[0].ResourceKey,
+            ResourceKeys = [resources[0].ResourceKey],
             StartIndex = 0,
             Count = 10,
             Filters = []
@@ -190,7 +190,7 @@ public class TraceTests
 
         var traces = repository.GetTraces(new GetTracesRequest
         {
-            ResourceKey = resources[0].ResourceKey,
+            ResourceKeys = [resources[0].ResourceKey],
             StartIndex = 0,
             Count = 10,
             Filters = []
@@ -244,7 +244,7 @@ public class TraceTests
 
         var traces = repository.GetTraces(new GetTracesRequest
         {
-            ResourceKey = resources[0].ResourceKey,
+            ResourceKeys = [resources[0].ResourceKey],
             StartIndex = 0,
             Count = 10,
             Filters = []
@@ -314,7 +314,7 @@ public class TraceTests
 
         var traces = repository.GetTraces(new GetTracesRequest
         {
-            ResourceKey = resources[0].ResourceKey,
+            ResourceKeys = [resources[0].ResourceKey],
             StartIndex = 0,
             Count = 10,
             Filters = []
@@ -390,7 +390,7 @@ public class TraceTests
 
         var traces1 = repository.GetTraces(new GetTracesRequest
         {
-            ResourceKey = resources[0].ResourceKey,
+            ResourceKeys = [resources[0].ResourceKey],
             StartIndex = 0,
             Count = 10,
             Filters = []
@@ -431,7 +431,7 @@ public class TraceTests
 
         var traces2 = repository.GetTraces(new GetTracesRequest
         {
-            ResourceKey = resources[0].ResourceKey,
+            ResourceKeys = [resources[0].ResourceKey],
             StartIndex = 0,
             Count = 10,
             Filters = []
@@ -485,7 +485,7 @@ public class TraceTests
 
         var traces = repository.GetTraces(new GetTracesRequest
         {
-            ResourceKey = null,
+            ResourceKeys = [],
             StartIndex = 0,
             Count = 10,
             Filters = []
@@ -553,7 +553,7 @@ public class TraceTests
 
         var traces = repository.GetTraces(new GetTracesRequest
         {
-            ResourceKey = null,
+            ResourceKeys = [],
             StartIndex = 0,
             Count = 10,
             Filters = []
@@ -629,7 +629,7 @@ public class TraceTests
 
         var traces = repository.GetTraces(new GetTracesRequest
         {
-            ResourceKey = null,
+            ResourceKeys = [],
             StartIndex = 0,
             Count = 10,
             Filters = []
@@ -718,7 +718,7 @@ public class TraceTests
 
         var traces1 = repository.GetTraces(new GetTracesRequest
         {
-            ResourceKey = null,
+            ResourceKeys = [],
             StartIndex = 0,
             Count = 10,
             Filters = []
@@ -733,7 +733,7 @@ public class TraceTests
 
         var traces2 = repository.GetTraces(new GetTracesRequest
         {
-            ResourceKey = null,
+            ResourceKeys = [],
             StartIndex = 0,
             Count = 10,
             Filters = []
@@ -800,7 +800,7 @@ public class TraceTests
 
         var traces = repository.GetTraces(new GetTracesRequest
         {
-            ResourceKey = resources[0].ResourceKey,
+            ResourceKeys = [resources[0].ResourceKey],
             StartIndex = 0,
             Count = 10,
             Filters = []
@@ -851,7 +851,7 @@ public class TraceTests
         AddTrace(repository, "1", s_testTime);
         var traces = repository.GetTraces(new GetTracesRequest
         {
-            ResourceKey = null,
+            ResourceKeys = [],
             StartIndex = 0,
             Count = 10,
             Filters = []
@@ -922,7 +922,7 @@ public class TraceTests
 
         var traces = repository.GetTraces(new GetTracesRequest
         {
-            ResourceKey = resources[0].ResourceKey,
+            ResourceKeys = [resources[0].ResourceKey],
             StartIndex = 0,
             Count = 10,
             Filters = []
@@ -1028,7 +1028,7 @@ public class TraceTests
 
         var traces = repository.GetTraces(new GetTracesRequest
         {
-            ResourceKey = null,
+            ResourceKeys = [],
             StartIndex = 0,
             Count = 10,
             Filters = []
@@ -1097,7 +1097,7 @@ public class TraceTests
         var resourceKey = new ResourceKey("resource1", InstanceId: null);
         var traces = repository.GetTraces(new GetTracesRequest
         {
-            ResourceKey = resourceKey,
+            ResourceKeys = [resourceKey],
             StartIndex = 0,
             Count = 10,
             Filters = []
@@ -1160,7 +1160,7 @@ public class TraceTests
         // Act 1
         var traces = repository.GetTraces(new GetTracesRequest
         {
-            ResourceKey = resourceKey,
+            ResourceKeys = [resourceKey],
             StartIndex = 0,
             Count = 10,
             Filters = [
@@ -1178,7 +1178,7 @@ public class TraceTests
         // Act 2
         traces = repository.GetTraces(new GetTracesRequest
         {
-            ResourceKey = resourceKey,
+            ResourceKeys = [resourceKey],
             StartIndex = 0,
             Count = 10,
             Filters = [
@@ -1196,7 +1196,7 @@ public class TraceTests
         // Act 3
         traces = repository.GetTraces(new GetTracesRequest
         {
-            ResourceKey = resourceKey,
+            ResourceKeys = [resourceKey],
             StartIndex = 0,
             Count = 10,
             Filters = [
@@ -1248,7 +1248,7 @@ public class TraceTests
         // Act 1
         var traces = repository.GetTraces(new GetTracesRequest
         {
-            ResourceKey = resourceKey,
+            ResourceKeys = [resourceKey],
             StartIndex = 0,
             Count = 10,
             Filters = [
@@ -1263,7 +1263,7 @@ public class TraceTests
         // Act 2
         traces = repository.GetTraces(new GetTracesRequest
         {
-            ResourceKey = resourceKey,
+            ResourceKeys = [resourceKey],
             StartIndex = 0,
             Count = 10,
             Filters = [
@@ -1317,7 +1317,7 @@ public class TraceTests
         // intentionally comes from all matching traces, not just the returned page.
         var traces = repository.GetTraces(new GetTracesRequest
         {
-            ResourceKey = new ResourceKey("resource1", InstanceId: null),
+            ResourceKeys = [new ResourceKey("resource1", InstanceId: null)],
             StartIndex = 1,
             Count = 1,
             Filters =
@@ -1376,7 +1376,7 @@ public class TraceTests
         // Duration filter "> 50ms" should match because trace duration is 100ms.
         var traces = repository.GetTraces(new GetTracesRequest
         {
-            ResourceKey = resourceKey,
+            ResourceKeys = [resourceKey],
             StartIndex = 0,
             Count = 10,
             Filters = [new FieldTelemetryFilter { Field = KnownTraceFields.DurationField, Condition = FilterCondition.GreaterThan, Value = "50" }]
@@ -1388,7 +1388,7 @@ public class TraceTests
         // even though the child span is only 5ms.
         traces = repository.GetTraces(new GetTracesRequest
         {
-            ResourceKey = resourceKey,
+            ResourceKeys = [resourceKey],
             StartIndex = 0,
             Count = 10,
             Filters = [new FieldTelemetryFilter { Field = KnownTraceFields.DurationField, Condition = FilterCondition.LessThan, Value = "10" }]
@@ -1425,7 +1425,7 @@ public class TraceTests
         // Act - filter for key1 != "other_value" should return the trace since key1 is "value1"
         var traces = repository.GetTraces(new GetTracesRequest
         {
-            ResourceKey = new ResourceKey("resource1", InstanceId: null),
+            ResourceKeys = [new ResourceKey("resource1", InstanceId: null)],
             StartIndex = 0,
             Count = 10,
             Filters = [
@@ -1448,7 +1448,7 @@ public class TraceTests
         var repository = CreateRepository();
         var request = new GetTracesRequest
         {
-            ResourceKey = new ResourceKey("TestService", "TestId"),
+            ResourceKeys = [new ResourceKey("TestService", "TestId")],
             StartIndex = 0,
             Count = 10,
             Filters = []
@@ -1650,7 +1650,7 @@ public class TraceTests
 
         var traces = repository.GetTraces(new GetTracesRequest
         {
-            ResourceKey = resource.ResourceKey,
+            ResourceKeys = [resource.ResourceKey],
             StartIndex = 0,
             Count = 10,
             Filters = []
@@ -1767,7 +1767,7 @@ public class TraceTests
 
         var traces = repository.GetTraces(new GetTracesRequest
         {
-            ResourceKey = null,
+            ResourceKeys = [],
             StartIndex = 0,
             Count = 10,
             Filters = []
@@ -1845,7 +1845,7 @@ public class TraceTests
 
         var traces = repository.GetTraces(new GetTracesRequest
         {
-            ResourceKey = null,
+            ResourceKeys = [],
             StartIndex = 0,
             Count = 10,
             Filters = []
@@ -1950,7 +1950,7 @@ public class TraceTests
 
         var traces = repository.GetTraces(new GetTracesRequest
         {
-            ResourceKey = null,
+            ResourceKeys = [],
             StartIndex = 0,
             Count = 10,
             Filters = []
@@ -2041,7 +2041,7 @@ public class TraceTests
 
         var traces = repository.GetTraces(new GetTracesRequest
         {
-            ResourceKey = null,
+            ResourceKeys = [],
             StartIndex = 0,
             Count = 10,
             Filters = []
@@ -2113,7 +2113,7 @@ public class TraceTests
 
         var traces = repository.GetTraces(new GetTracesRequest
         {
-            ResourceKey = uninstrumentedPeerApp.ResourceKey,
+            ResourceKeys = [uninstrumentedPeerApp.ResourceKey],
             StartIndex = 0,
             Count = 10,
             Filters = []
@@ -2191,7 +2191,7 @@ public class TraceTests
 
         var traces = repository.GetTraces(new GetTracesRequest
         {
-            ResourceKey = resources[0].ResourceKey,
+            ResourceKeys = [resources[0].ResourceKey],
             StartIndex = 0,
             Count = 10,
             Filters = []
@@ -2232,7 +2232,7 @@ public class TraceTests
 
         traces = repository.GetTraces(new GetTracesRequest
         {
-            ResourceKey = uninstrumentedPeerApp.ResourceKey,
+            ResourceKeys = [uninstrumentedPeerApp.ResourceKey],
             StartIndex = 0,
             Count = 10,
             Filters = []
@@ -2327,7 +2327,7 @@ public class TraceTests
         // Act
         var result = repository.GetSpans(new GetSpansRequest
         {
-            ResourceKey = null,
+            ResourceKeys = [],
             StartIndex = 0,
             Count = int.MaxValue,
             Filters = []
@@ -2368,7 +2368,7 @@ public class TraceTests
         // Act
         var result = repository.GetSpans(new GetSpansRequest
         {
-            ResourceKey = null,
+            ResourceKeys = [],
             StartIndex = 0,
             Count = int.MaxValue,
             Filters = [],
@@ -2409,7 +2409,7 @@ public class TraceTests
         // Act
         var result = repository.GetSpans(new GetSpansRequest
         {
-            ResourceKey = null,
+            ResourceKeys = [],
             StartIndex = 0,
             Count = int.MaxValue,
             Filters = [],
@@ -2450,7 +2450,7 @@ public class TraceTests
         // Act
         var result = repository.GetSpans(new GetSpansRequest
         {
-            ResourceKey = null,
+            ResourceKeys = [],
             StartIndex = 0,
             Count = int.MaxValue,
             Filters = [],
@@ -2508,7 +2508,7 @@ public class TraceTests
         // Act
         var result = repository.GetSpans(new GetSpansRequest
         {
-            ResourceKey = serviceA.ResourceKey,
+            ResourceKeys = [serviceA.ResourceKey],
             StartIndex = 0,
             Count = int.MaxValue,
             Filters = []
@@ -2550,7 +2550,7 @@ public class TraceTests
         // Act - filter for spans with duration >= 100000ms (100s)
         var result = repository.GetSpans(new GetSpansRequest
         {
-            ResourceKey = null,
+            ResourceKeys = [],
             StartIndex = 0,
             Count = int.MaxValue,
             Filters =
@@ -2598,7 +2598,7 @@ public class TraceTests
         // Act
         var result = repository.GetSpans(new GetSpansRequest
         {
-            ResourceKey = null,
+            ResourceKeys = [],
             StartIndex = 0,
             Count = int.MaxValue,
             Filters = [],
@@ -2640,7 +2640,7 @@ public class TraceTests
         // Act - get second page (skip 1, take 1)
         var result = repository.GetSpans(new GetSpansRequest
         {
-            ResourceKey = null,
+            ResourceKeys = [],
             StartIndex = 1,
             Count = 1,
             Filters = []
@@ -2682,7 +2682,7 @@ public class TraceTests
         // Act - filter for error spans with "example.com" text
         var result = repository.GetSpans(new GetSpansRequest
         {
-            ResourceKey = null,
+            ResourceKeys = [],
             StartIndex = 0,
             Count = int.MaxValue,
             Filters = [],
@@ -2704,7 +2704,7 @@ public class TraceTests
         // Act
         var result = repository.GetSpans(new GetSpansRequest
         {
-            ResourceKey = null,
+            ResourceKeys = [],
             StartIndex = 0,
             Count = int.MaxValue,
             Filters = []
@@ -2743,7 +2743,7 @@ public class TraceTests
         // Act
         var result = repository.GetSpans(new GetSpansRequest
         {
-            ResourceKey = ResourceKey.Create("nonexistent", "unknown"),
+            ResourceKeys = [ResourceKey.Create("nonexistent", "unknown")],
             StartIndex = 0,
             Count = int.MaxValue,
             Filters = []
@@ -2789,7 +2789,7 @@ public class TraceTests
         // Act
         var result = repository.GetSpans(new GetSpansRequest
         {
-            ResourceKey = null,
+            ResourceKeys = [],
             StartIndex = 0,
             Count = int.MaxValue,
             Filters = [],
@@ -2828,7 +2828,7 @@ public class TraceTests
         // Enabled filter matches span name containing "span1", disabled filter would exclude everything
         var result = repository.GetSpans(new GetSpansRequest
         {
-            ResourceKey = null,
+            ResourceKeys = [],
             StartIndex = 0,
             Count = int.MaxValue,
             Filters =


### PR DESCRIPTION
## Summary

Fixes #17802

When streaming spans/logs with a resource filter via `follow=true`, if the resource hasn't sent any telemetry yet, the stream would immediately return empty (HTTP 200 with closed NDJSON stream). This is a problem because the dashboard starts streaming before the resource has had a chance to emit telemetry.

## Changes

**`src/Aspire.Dashboard/Api/TelemetryApiService.cs`**
- Added `WaitForResourceKeysAsync` method that subscribes to `OnNewResources` notifications and waits for the requested resource(s) to appear before starting the span/log watcher
- Uses a bounded channel (capacity 1, `DropOldest`) as the signaling mechanism to avoid race conditions between notifications and state checks
- Both `FollowSpansAsync` and `FollowLogsAsync` now call this instead of immediately yielding break on unknown resources

**`tests/Aspire.Dashboard.Tests/TelemetryApiServiceTests.cs`**
- Added `FollowSpansAsync_WaitsForResourceToAppear_ThenStreams` - verifies that streaming waits for a resource and yields data once it appears
- Added `FollowLogsAsync_WaitsForResourceToAppear_ThenStreams` - same for logs

## Design

The subscribe-before-check pattern ensures no notification is lost:

1. Subscribe to `OnNewResources` channel signal first
2. Check if resources are already available (fast path)
3. If not, loop: await channel read → re-check state → return or continue waiting
4. `OperationCanceledException` propagates naturally when the client disconnects

The bounded channel with `DropOldest` collapses multiple rapid resource notifications into a single "wake up and re-check" signal, which is simpler and more robust than a TCS-reset approach.